### PR TITLE
test: add Playwright phase3 e2e suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ pnpm install
 pnpm tauri dev
 ```
 
+### Testing
+
+```bash
+# Unit tests (Vitest)
+pnpm test
+
+# Playwright E2E (headless)
+pnpm test:e2e
+
+# Debug helpers
+pnpm test:e2e:ui
+pnpm test:e2e:headed
+```
+
 ### Build
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "license": "MIT",
   "dependencies": {
@@ -22,13 +25,14 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-opener": "^2",
-    "monaco-editor": "^0.55.1",
     "highlight.js": "^11.11.1",
     "marked": "^17.0.1",
+    "monaco-editor": "^0.55.1",
     "solid-js": "^1.9.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@playwright/test": "^1.58.0",
     "@tauri-apps/cli": "^2",
     "@types/node": "^25.0.10",
     "@typescript-eslint/eslint-plugin": "^8.53.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 1420;
+const HOST = process.env.PLAYWRIGHT_WEB_HOST ?? "localhost";
+const WEB_COMMAND = process.env.PLAYWRIGHT_WEB_COMMAND ?? "pnpm tauri dev";
+const WEB_TIMEOUT = Number(process.env.PLAYWRIGHT_WEB_TIMEOUT ?? 360_000);
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  timeout: 60_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: `http://${HOST}:${PORT}`,
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+    browserName: "chromium",
+    viewport: { width: 1280, height: 800 },
+  },
+  webServer: {
+    command: WEB_COMMAND,
+    url: `http://${HOST}:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: WEB_TIMEOUT,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
+      '@playwright/test':
+        specifier: ^1.58.0
+        version: 1.58.0
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.9.6
@@ -387,6 +390,11 @@ packages:
 
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
+
+  '@playwright/test@1.58.0':
+    resolution: {integrity: sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.56.0':
     resolution: {integrity: sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==}
@@ -938,6 +946,11 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1141,6 +1154,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.58.0:
+    resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.0:
+    resolution: {integrity: sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -1655,6 +1678,10 @@ snapshots:
   '@monaco-editor/loader@1.7.0':
     dependencies:
       state-local: 1.0.7
+
+  '@playwright/test@1.58.0':
+    dependencies:
+      playwright: 1.58.0
 
   '@rollup/rollup-android-arm-eabi@4.56.0':
     optional: true
@@ -2210,6 +2237,9 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2366,6 +2396,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.58.0: {}
+
+  playwright@1.58.0:
+    dependencies:
+      playwright-core: 1.58.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.6:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Sidebar, Panel } from "@/components/common/Sidebar";
 import { StatusBar } from "@/components/common/StatusBar";
 import { SignIn } from "@/components/auth/SignIn";
 import { ChatPanel } from "@/components/chat/ChatPanel";
+import { Phase3Playground } from "@/playground/Phase3Playground";
 import {
   authStore,
   checkAuth,
@@ -16,6 +17,10 @@ import {
 import "./App.css";
 
 function App() {
+  if (shouldRenderPhase3Playground()) {
+    return <Phase3Playground />;
+  }
+
   const [activePanel, setActivePanel] = createSignal<Panel>("chat");
 
   onMount(() => {
@@ -70,3 +75,10 @@ function App() {
 }
 
 export default App;
+
+function shouldRenderPhase3Playground(): boolean {
+  if (!import.meta.env.DEV) return false;
+  if (typeof window === "undefined") return false;
+  const params = new URLSearchParams(window.location.search);
+  return params.get("test") === "phase3";
+}

--- a/src/components/editor/FileTabs.tsx
+++ b/src/components/editor/FileTabs.tsx
@@ -59,6 +59,8 @@ export const FileTabs: Component<FileTabsProps> = (props) => {
               aria-controls={`panel-${tab.id}`}
               tabIndex={tab.id === tabsState.activeTabId ? 0 : -1}
               title={tab.filePath}
+              data-testid="file-tab"
+              data-file-path={tab.filePath}
             >
               <Show when={tab.isDirty}>
                 <span class="file-tab-dirty-indicator" aria-label="Unsaved changes">●</span>
@@ -69,6 +71,7 @@ export const FileTabs: Component<FileTabsProps> = (props) => {
                 onClick={(e) => handleTabClose(e, tab)}
                 aria-label={`Close ${tab.fileName}`}
                 tabIndex={-1}
+                data-testid="file-tab-close"
               >
                 ×
               </button>

--- a/src/components/sidebar/FileTree.tsx
+++ b/src/components/sidebar/FileTree.tsx
@@ -15,7 +15,12 @@ interface FileTreeProps {
 
 export const FileTree: Component<FileTreeProps> = (props) => {
   return (
-    <div class="file-tree" role="tree" aria-label="File explorer">
+    <div
+      class="file-tree"
+      role="tree"
+      aria-label="File explorer"
+      data-testid="file-tree"
+    >
       <Show
         when={fileTreeState.nodes.length > 0}
         fallback={<div class="file-tree-empty">No folder open</div>}
@@ -88,6 +93,9 @@ const FileTreeNode: Component<FileTreeNodeProps> = (props) => {
         aria-expanded={props.node.isDirectory ? expanded() : undefined}
         aria-selected={isSelected()}
         tabIndex={0}
+        data-testid="file-tree-item"
+        data-file-path={props.node.path}
+        data-file-type={props.node.isDirectory ? "directory" : "file"}
       >
         <span class="file-tree-icon">{icon()}</span>
         <span class="file-tree-name">{props.node.name}</span>

--- a/src/playground/Phase3Playground.css
+++ b/src/playground/Phase3Playground.css
@@ -1,0 +1,62 @@
+.phase3-playground {
+  display: flex;
+  height: 100vh;
+  background: radial-gradient(circle at top, #111827, #020617 70%);
+  color: #fff;
+}
+
+.phase3-sidebar {
+  width: 280px;
+  padding: 16px;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(2, 6, 23, 0.85);
+}
+
+.phase3-sidebar h2 {
+  margin-top: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.phase3-editor {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: rgba(15, 23, 42, 0.8);
+}
+
+.phase3-tabs {
+  padding: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.phase3-editor-surface {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 0 12px 12px 12px;
+}
+
+.phase3-editor-header {
+  font-size: 0.9rem;
+  color: #94a3b8;
+  margin: 12px 0;
+}
+
+.phase3-editor-container {
+  flex: 1;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  overflow: hidden;
+  background: #0f172a;
+}
+
+.phase3-editor-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #94a3b8;
+}

--- a/src/playground/Phase3Playground.tsx
+++ b/src/playground/Phase3Playground.tsx
@@ -1,0 +1,236 @@
+import { Show, createEffect, createSignal, onCleanup, onMount } from "solid-js";
+import { FileTree } from "@/components/sidebar/FileTree";
+import { FileTabs } from "@/components/editor/FileTabs";
+import { MonacoEditor } from "@/components/editor/MonacoEditor";
+import {
+  setRootPath,
+  setNodes,
+  setSelectedPath,
+  type FileNode,
+} from "@/stores/fileTree";
+import {
+  openTab,
+  tabsState,
+  updateTabContent,
+  setTabDirty,
+  getActiveTab,
+  closeAllTabs,
+} from "@/stores/tabs";
+import {
+  initCompletionService,
+  setApiHandler,
+  registerInlineCompletionProvider,
+} from "@/lib/completions";
+import { initMonaco } from "@/lib/editor";
+import type { CompletionContext, CompletionResult } from "@/lib/completions";
+import "./Phase3Playground.css";
+
+const SAMPLE_FILES: Record<string, string> = {
+  "/workspace/src/App.tsx": `import type { Component } from "solid-js";
+
+export const PlaygroundApp: Component = () => {
+  const greeting = "Hello from Seren";
+  console.log(greeting);
+  return <div class="playground-app">{greeting}</div>;
+};
+`,
+  "/workspace/src/components/Hello.tsx": `export function Hello() {
+  return <p>Phase 3 playground</p>;
+}
+`,
+  "/workspace/src/utils/math.ts": `export function add(a: number, b: number) {
+  return a + b;
+}
+`,
+  "/workspace/README.md": `# Seren Playground\n\nThis is a fake project used for Playwright e2e tests.`,
+};
+
+const SAMPLE_TREE: FileNode[] = [
+  {
+    name: "src",
+    path: "/workspace/src",
+    isDirectory: true,
+    children: [
+      {
+        name: "App.tsx",
+        path: "/workspace/src/App.tsx",
+        isDirectory: false,
+      },
+      {
+        name: "components",
+        path: "/workspace/src/components",
+        isDirectory: true,
+        children: [
+          {
+            name: "Hello.tsx",
+            path: "/workspace/src/components/Hello.tsx",
+            isDirectory: false,
+          },
+        ],
+      },
+      {
+        name: "utils",
+        path: "/workspace/src/utils",
+        isDirectory: true,
+        children: [
+          {
+            name: "math.ts",
+            path: "/workspace/src/utils/math.ts",
+            isDirectory: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "README.md",
+    path: "/workspace/README.md",
+    isDirectory: false,
+  },
+];
+
+let completionsRegistered = false;
+
+async function ensureCompletionProvider(): Promise<void> {
+  if (completionsRegistered) return;
+  await initMonaco();
+  initCompletionService();
+  registerInlineCompletionProvider();
+  setApiHandler(async (context) => mockCompletions(context));
+  completionsRegistered = true;
+}
+
+function mockCompletions(context: CompletionContext): CompletionResult[] {
+  const { lineNumber, column, prefix } = context;
+  if (prefix.endsWith("console.")) {
+    return [
+      {
+        text: "log('Seren inline completion')",
+        range: {
+          startLineNumber: lineNumber,
+          startColumn: column,
+          endLineNumber: lineNumber,
+          endColumn: column,
+        },
+      },
+    ];
+  }
+
+  if (prefix.trim().endsWith("return")) {
+    return [
+      {
+        text: " add(a, b);",
+        range: {
+          startLineNumber: lineNumber,
+          startColumn: column,
+          endLineNumber: lineNumber,
+          endColumn: column,
+        },
+      },
+    ];
+  }
+
+  return [];
+}
+
+export const Phase3Playground = () => {
+  const [editorContent, setEditorContent] = createSignal("");
+  const [activeFilePath, setActiveFilePath] = createSignal<string | null>(null);
+
+  onMount(() => {
+    setRootPath("/workspace");
+    setNodes(cloneTree(SAMPLE_TREE));
+    setSelectedPath(null);
+    closeAllTabs();
+    ensureCompletionProvider();
+    openInitialFile();
+
+    // expose minimal test API for Playwright helpers
+    if (typeof window !== "undefined") {
+      (window as typeof window & { __phase3TestAPI?: unknown }).__phase3TestAPI = {
+        openFile: handleFileSelect,
+        getActiveFile: () => getActiveTab()?.filePath ?? null,
+        getDirtyTabs: () => tabsState.tabs.filter((tab) => tab.isDirty).map((tab) => tab.filePath),
+      };
+    }
+  });
+
+  onCleanup(() => {
+    if (typeof window !== "undefined" && (window as typeof window & { __phase3TestAPI?: unknown }).__phase3TestAPI) {
+      delete (window as typeof window & { __phase3TestAPI?: unknown }).__phase3TestAPI;
+    }
+  });
+
+  createEffect(() => {
+    const activeId = tabsState.activeTabId;
+    const activeTab = tabsState.tabs.find((tab) => tab.id === activeId);
+    if (activeTab) {
+      setActiveFilePath(activeTab.filePath);
+      setEditorContent(activeTab.content);
+      setSelectedPath(activeTab.filePath);
+    } else {
+      setActiveFilePath(null);
+      setEditorContent("Select a file to begin editing");
+    }
+  });
+
+  function openInitialFile(): void {
+    handleFileSelect("/workspace/src/App.tsx");
+  }
+
+  function handleFileSelect(path: string): void {
+    const content = SAMPLE_FILES[path] ?? "// Sample file";
+    setSelectedPath(path);
+    openTab(path, content);
+  }
+
+  function handleEditorChange(value: string): void {
+    const activeTab = getActiveTab();
+    if (!activeTab) return;
+    updateTabContent(activeTab.id, value);
+    const baseline = SAMPLE_FILES[activeTab.filePath] ?? "";
+    setTabDirty(activeTab.id, value !== baseline);
+    setEditorContent(value);
+  }
+
+  return (
+    <div class="phase3-playground" data-testid="phase3-playground">
+      <aside class="phase3-sidebar">
+        <h2>File Tree</h2>
+        <FileTree onFileSelect={handleFileSelect} />
+      </aside>
+      <section class="phase3-editor">
+        <div class="phase3-tabs">
+          <FileTabs />
+        </div>
+        <div class="phase3-editor-surface" data-testid="phase3-editor-pane">
+          <Show
+            when={activeFilePath()}
+            fallback={<div class="phase3-editor-empty">Select a file from the tree</div>}
+          >
+            <div class="phase3-editor-header">
+              <span data-testid="active-file-path">{activeFilePath()}</span>
+            </div>
+            <div data-testid="monaco-editor" class="phase3-editor-container">
+              <MonacoEditor
+                filePath={activeFilePath() ?? undefined}
+                value={editorContent()}
+                onChange={handleEditorChange}
+                language={activeFilePath()?.endsWith(".md") ? "markdown" : undefined}
+              />
+            </div>
+          </Show>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default Phase3Playground;
+
+function cloneTree(nodes: FileNode[]): FileNode[] {
+  return nodes.map((node) => ({
+    ...node,
+    children: node.children ? cloneTree(node.children) : undefined,
+  }));
+}

--- a/tests/e2e/completions.spec.ts
+++ b/tests/e2e/completions.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+import { gotoPhase3Playground, clickFileTreeItem } from "./utils";
+
+const SRC_DIR = "/workspace/src";
+
+test.beforeEach(async ({ page }) => {
+  await gotoPhase3Playground(page);
+  await clickFileTreeItem(page, SRC_DIR);
+});
+
+test("typing triggers inline completions that can be accepted", async ({ page }) => {
+  const editorView = page.locator(".monaco-editor .view-lines");
+  await page.getByTestId("monaco-editor").click();
+  await editorView.click({ position: { x: 200, y: 140 } });
+  await page.keyboard.type("\nconsole.");
+  await page.waitForTimeout(500);
+  await page.keyboard.press("Tab");
+  await expect(editorView).toContainText("console.log('Seren inline completion')");
+});

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import { gotoPhase3Playground, clickFileTreeItem } from "./utils";
+
+const SRC_DIR = "/workspace/src";
+
+test.beforeEach(async ({ page }) => {
+  await gotoPhase3Playground(page);
+  // expand src directory for subsequent tests
+  await clickFileTreeItem(page, SRC_DIR);
+});
+
+test("editor renders and accepts input", async ({ page }) => {
+  await page.getByTestId("monaco-editor").click();
+  await page.keyboard.type("\nconst testValue = 99;");
+  await expect(page.locator(".monaco-editor .view-lines")).toContainText("testValue");
+});
+
+test("selecting a file opens it in the editor", async ({ page }) => {
+  await clickFileTreeItem(page, `${SRC_DIR}/components`);
+  await clickFileTreeItem(page, `${SRC_DIR}/components/Hello.tsx`);
+  await expect(page.getByTestId("active-file-path")).toHaveText(
+    `${SRC_DIR}/components/Hello.tsx`
+  );
+  await expect(
+    page.locator(`[data-testid="file-tab"][data-file-path="${SRC_DIR}/components/Hello.tsx"]`)
+  ).toHaveClass(/active/);
+});
+
+test("typing marks tab dirty and shows indicator", async ({ page }) => {
+  await page.getByTestId("monaco-editor").click();
+  await page.keyboard.type("\n// dirty flag test");
+  await expect(
+    page.locator(`[data-testid="file-tab"][data-file-path="${SRC_DIR}/App.tsx"]`)
+  ).toHaveClass(/dirty/);
+});
+
+test("typescript syntax highlighting tokens are rendered", async ({ page }) => {
+  const view = page.locator(".monaco-editor .view-lines");
+  await expect(view).toContainText("export");
+});

--- a/tests/e2e/file-tree.spec.ts
+++ b/tests/e2e/file-tree.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "@playwright/test";
+import { gotoPhase3Playground, clickFileTreeItem } from "./utils";
+
+const SRC_DIR = "/workspace/src";
+
+test.beforeEach(async ({ page }) => {
+  await gotoPhase3Playground(page);
+});
+
+test("file tree renders directories", async ({ page }) => {
+  const directories = page.locator('[data-testid="file-tree-item"][data-file-type="directory"]');
+  await expect(directories).toContainText(["src"]);
+});
+
+test("directories expand and collapse", async ({ page }) => {
+  const childSelector = `[data-testid="file-tree-item"][data-file-path="${SRC_DIR}/App.tsx"]`;
+  await expect(page.locator(childSelector)).toHaveCount(0);
+  await clickFileTreeItem(page, SRC_DIR);
+  await expect(page.locator(childSelector)).toHaveCount(1);
+  await clickFileTreeItem(page, SRC_DIR);
+  await expect(page.locator(childSelector)).toHaveCount(0);
+});
+
+test("selecting a file opens a tab", async ({ page }) => {
+  await clickFileTreeItem(page, SRC_DIR);
+  await clickFileTreeItem(page, `${SRC_DIR}/components`);
+  await clickFileTreeItem(page, `${SRC_DIR}/components/Hello.tsx`);
+  await expect(
+    page.locator(`[data-testid=\"file-tab\"][data-file-path=\"${SRC_DIR}/components/Hello.tsx\"]`)
+  ).toHaveCount(1);
+});

--- a/tests/e2e/tabs.spec.ts
+++ b/tests/e2e/tabs.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+import { gotoPhase3Playground, clickFileTreeItem } from "./utils";
+
+const SRC_DIR = "/workspace/src";
+
+test.beforeEach(async ({ page }) => {
+  await gotoPhase3Playground(page);
+  await clickFileTreeItem(page, SRC_DIR);
+});
+
+test("opening files creates tabs and highlights active tab", async ({ page }) => {
+  await clickFileTreeItem(page, `${SRC_DIR}/components`);
+  await clickFileTreeItem(page, `${SRC_DIR}/components/Hello.tsx`);
+  const tabs = page.locator('[data-testid="file-tab"]');
+  await expect(tabs).toHaveCount(2);
+  await expect(
+    page.locator(`[data-testid="file-tab"][data-file-path="${SRC_DIR}/components/Hello.tsx"]`)
+  ).toHaveClass(/active/);
+});
+
+test("dirty indicator shows for unsaved files", async ({ page }) => {
+  await page.getByTestId("monaco-editor").click();
+  await page.keyboard.type("\n// unsaved change");
+  const dirtyIndicator = page
+    .locator(`[data-testid="file-tab"][data-file-path="${SRC_DIR}/App.tsx"]`)
+    .locator(".file-tab-dirty-indicator");
+  await expect(dirtyIndicator).toBeVisible();
+});
+
+test("tab closes when clicking the close button", async ({ page }) => {
+  await clickFileTreeItem(page, `${SRC_DIR}/components`);
+  await clickFileTreeItem(page, `${SRC_DIR}/components/Hello.tsx`);
+  const tabLocator = page.locator(
+    `[data-testid=\"file-tab\"][data-file-path=\"${SRC_DIR}/components/Hello.tsx\"]`
+  );
+  await tabLocator.locator('[data-testid="file-tab-close"]').click();
+  await expect(tabLocator).toHaveCount(0);
+});

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -1,0 +1,12 @@
+import { expect, Page } from "@playwright/test";
+
+export const PHASE3_URL = "/?test=phase3";
+
+export async function gotoPhase3Playground(page: Page): Promise<void> {
+  await page.goto(PHASE3_URL);
+  await expect(page.getByTestId("phase3-playground")).toBeVisible();
+}
+
+export async function clickFileTreeItem(page: Page, filePath: string): Promise<void> {
+  await page.locator(`[data-testid="file-tree-item"][data-file-path="${filePath}"]`).first().click();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- Add a dev-only Phase 3 playground (`/?test=phase3`) and deterministic selectors so Monaco, file tree, tabs, and completions can be exercised in E2E runs
- Configure Playwright (Chromium) to launch the Vite/Tauri dev server, include npm scripts/docs, and expose env overrides for CI/local tweaks
- Cover editor, file tree, tabs, and inline completion flows via new specs in `tests/e2e`

## Testing
```bash
pnpm lint
pnpm test
PLAYWRIGHT_WEB_COMMAND='pnpm dev' pnpm exec playwright test --config=playwright.config.ts --workers=1
```
