### PR TITLE
feat(telemetry): add error telemetry service with rate limiting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,11 @@ import {
   logout,
   setAuthenticated,
 } from "@/stores/auth.store";
+import { telemetry } from "@/services/telemetry";
 import "./App.css";
+
+// Initialize telemetry early to capture startup errors
+telemetry.init();
 
 function App() {
   if (shouldRenderPhase3Playground()) {

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -1,0 +1,121 @@
+// ABOUTME: Rate limiter utility to prevent flooding telemetry endpoints.
+// ABOUTME: Deduplicates identical errors and limits reports per time window.
+
+interface ErrorEntry {
+  count: number;
+  firstSeen: number;
+  lastSeen: number;
+}
+
+interface RateLimiterConfig {
+  /** Maximum errors per time window */
+  maxErrors: number;
+  /** Time window in milliseconds */
+  windowMs: number;
+}
+
+const DEFAULT_CONFIG: RateLimiterConfig = {
+  maxErrors: 10,
+  windowMs: 60_000, // 1 minute
+};
+
+/**
+ * Rate limiter for error telemetry.
+ * Prevents flooding by limiting errors per time window and deduplicating identical errors.
+ */
+export class RateLimiter {
+  private errors: Map<string, ErrorEntry> = new Map();
+  private windowStart: number = Date.now();
+  private totalInWindow: number = 0;
+  private config: RateLimiterConfig;
+
+  constructor(config: Partial<RateLimiterConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Check if an error should be reported.
+   * @param errorKey - Unique identifier for the error (e.g., message + stack hash)
+   * @returns true if the error should be reported, false if rate limited
+   */
+  shouldReport(errorKey: string): boolean {
+    this.maybeResetWindow();
+
+    // Check global rate limit
+    if (this.totalInWindow >= this.config.maxErrors) {
+      return false;
+    }
+
+    const entry = this.errors.get(errorKey);
+    const now = Date.now();
+
+    if (entry) {
+      // Duplicate error - update count but don't report
+      entry.count++;
+      entry.lastSeen = now;
+      return false;
+    }
+
+    // New error - track and allow reporting
+    this.errors.set(errorKey, {
+      count: 1,
+      firstSeen: now,
+      lastSeen: now,
+    });
+    this.totalInWindow++;
+    return true;
+  }
+
+  /**
+   * Get the count of occurrences for an error key.
+   */
+  getCount(errorKey: string): number {
+    return this.errors.get(errorKey)?.count ?? 0;
+  }
+
+  /**
+   * Get all error entries with their counts for batch reporting.
+   * Useful for sending aggregated counts at end of window.
+   */
+  getErrorSummary(): Map<string, ErrorEntry> {
+    return new Map(this.errors);
+  }
+
+  /**
+   * Get total unique errors in current window.
+   */
+  getTotalInWindow(): number {
+    return this.totalInWindow;
+  }
+
+  /**
+   * Reset the rate limiter state.
+   */
+  reset(): void {
+    this.errors.clear();
+    this.windowStart = Date.now();
+    this.totalInWindow = 0;
+  }
+
+  /**
+   * Check if window has expired and reset if needed.
+   */
+  private maybeResetWindow(): void {
+    const now = Date.now();
+    if (now - this.windowStart >= this.config.windowMs) {
+      this.reset();
+    }
+  }
+}
+
+/**
+ * Generate a unique key for an error based on message and stack.
+ */
+export function getErrorKey(error: Error): string {
+  const message = error.message || "Unknown error";
+  const stackFirstLine = error.stack?.split("\n")[1]?.trim() || "";
+  return `${message}|${stackFirstLine}`;
+}
+
+// Default singleton instance
+export const errorRateLimiter = new RateLimiter();

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -1,0 +1,203 @@
+// ABOUTME: Error telemetry service for reporting errors to Seren Gateway.
+// ABOUTME: Captures unhandled errors, scrubs PII, rate limits, and batches reports.
+
+import { API_BASE } from "@/lib/config";
+import { scrubSensitive } from "@/lib/scrub-sensitive";
+import { RateLimiter, getErrorKey } from "@/lib/rate-limiter";
+import { getToken } from "@/lib/tauri-bridge";
+
+export interface ErrorReport {
+  message: string;
+  stack?: string;
+  timestamp: string;
+  appVersion: string;
+  platform: string;
+  context?: Record<string, unknown>;
+  occurrences?: number;
+}
+
+interface TelemetryConfig {
+  /** Whether telemetry is enabled */
+  enabled: boolean;
+  /** Batch interval in milliseconds */
+  batchIntervalMs: number;
+  /** Maximum errors per batch */
+  maxBatchSize: number;
+}
+
+const DEFAULT_CONFIG: TelemetryConfig = {
+  enabled: true,
+  batchIntervalMs: 30_000, // 30 seconds
+  maxBatchSize: 20,
+};
+
+class TelemetryService {
+  private config: TelemetryConfig;
+  private rateLimiter: RateLimiter;
+  private errorQueue: ErrorReport[] = [];
+  private batchTimer: ReturnType<typeof setInterval> | null = null;
+  private initialized = false;
+
+  constructor(config: Partial<TelemetryConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.rateLimiter = new RateLimiter();
+  }
+
+  /**
+   * Initialize telemetry service and attach global error handlers.
+   */
+  init(): void {
+    if (this.initialized || !this.config.enabled) return;
+
+    // Global error handler
+    window.addEventListener("error", (event) => {
+      this.captureError(event.error || new Error(event.message), {
+        type: "uncaught",
+        filename: event.filename,
+        lineno: event.lineno,
+        colno: event.colno,
+      });
+    });
+
+    // Unhandled promise rejection handler
+    window.addEventListener("unhandledrejection", (event) => {
+      const error =
+        event.reason instanceof Error
+          ? event.reason
+          : new Error(String(event.reason));
+      this.captureError(error, { type: "unhandledrejection" });
+    });
+
+    // Start batch processing
+    this.startBatchTimer();
+    this.initialized = true;
+  }
+
+  /**
+   * Capture an error for telemetry.
+   */
+  captureError(error: Error, context?: Record<string, unknown>): void {
+    if (!this.config.enabled) return;
+
+    const errorKey = getErrorKey(error);
+
+    // Check rate limit
+    if (!this.rateLimiter.shouldReport(errorKey)) {
+      return;
+    }
+
+    const report: ErrorReport = {
+      message: scrubSensitive(error.message || "Unknown error"),
+      stack: error.stack ? scrubSensitive(error.stack) : undefined,
+      timestamp: new Date().toISOString(),
+      appVersion: this.getAppVersion(),
+      platform: this.getPlatform(),
+      context,
+    };
+
+    this.errorQueue.push(report);
+
+    // Flush immediately if queue is full
+    if (this.errorQueue.length >= this.config.maxBatchSize) {
+      this.flush();
+    }
+  }
+
+  /**
+   * Manually report an error (for try/catch scenarios).
+   */
+  reportError(error: Error, context?: Record<string, unknown>): void {
+    this.captureError(error, context);
+  }
+
+  /**
+   * Send queued errors to the server.
+   */
+  async flush(): Promise<void> {
+    if (this.errorQueue.length === 0) return;
+
+    const batch = this.errorQueue.splice(0, this.config.maxBatchSize);
+
+    try {
+      const token = await getToken();
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+      }
+
+      await fetch(`${API_BASE}/diagnostics/errors`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ errors: batch }),
+      });
+    } catch {
+      // Silently fail - don't want telemetry errors to cause more errors
+      // Put errors back in queue for retry (up to max size)
+      const remaining = this.config.maxBatchSize - this.errorQueue.length;
+      if (remaining > 0) {
+        this.errorQueue.unshift(...batch.slice(0, remaining));
+      }
+    }
+  }
+
+  /**
+   * Enable or disable telemetry.
+   */
+  setEnabled(enabled: boolean): void {
+    this.config.enabled = enabled;
+    if (!enabled) {
+      this.stopBatchTimer();
+      this.errorQueue = [];
+    } else if (this.initialized) {
+      this.startBatchTimer();
+    }
+  }
+
+  /**
+   * Check if telemetry is enabled.
+   */
+  isEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  /**
+   * Shutdown telemetry service.
+   */
+  shutdown(): void {
+    this.stopBatchTimer();
+    this.flush();
+    this.initialized = false;
+  }
+
+  private startBatchTimer(): void {
+    if (this.batchTimer) return;
+    this.batchTimer = setInterval(() => {
+      this.flush();
+    }, this.config.batchIntervalMs);
+  }
+
+  private stopBatchTimer(): void {
+    if (this.batchTimer) {
+      clearInterval(this.batchTimer);
+      this.batchTimer = null;
+    }
+  }
+
+  private getAppVersion(): string {
+    // Could be injected at build time via Vite
+    return import.meta.env.VITE_APP_VERSION || "0.0.0";
+  }
+
+  private getPlatform(): string {
+    const ua = navigator.userAgent;
+    if (ua.includes("Mac")) return "macos";
+    if (ua.includes("Windows")) return "windows";
+    if (ua.includes("Linux")) return "linux";
+    return "unknown";
+  }
+}
+
+// Default singleton instance
+export const telemetry = new TelemetryService();

--- a/tests/unit/rate-limiter.test.ts
+++ b/tests/unit/rate-limiter.test.ts
@@ -1,0 +1,142 @@
+// ABOUTME: Unit tests for the RateLimiter utility.
+// ABOUTME: Ensures rate limiting and deduplication work correctly for telemetry.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { RateLimiter, getErrorKey } from "@/lib/rate-limiter";
+
+describe("RateLimiter", () => {
+  let limiter: RateLimiter;
+
+  beforeEach(() => {
+    limiter = new RateLimiter({ maxErrors: 5, windowMs: 60_000 });
+  });
+
+  describe("shouldReport", () => {
+    it("allows first occurrence of an error", () => {
+      expect(limiter.shouldReport("error-1")).toBe(true);
+    });
+
+    it("blocks duplicate errors", () => {
+      limiter.shouldReport("error-1");
+      expect(limiter.shouldReport("error-1")).toBe(false);
+    });
+
+    it("allows different errors", () => {
+      expect(limiter.shouldReport("error-1")).toBe(true);
+      expect(limiter.shouldReport("error-2")).toBe(true);
+    });
+
+    it("respects max errors per window", () => {
+      for (let i = 0; i < 5; i++) {
+        expect(limiter.shouldReport(`error-${i}`)).toBe(true);
+      }
+      // 6th error should be blocked
+      expect(limiter.shouldReport("error-5")).toBe(false);
+    });
+
+    it("resets after window expires", () => {
+      vi.useFakeTimers();
+
+      limiter.shouldReport("error-1");
+      expect(limiter.shouldReport("error-1")).toBe(false);
+
+      // Advance time past window
+      vi.advanceTimersByTime(60_001);
+
+      // Same error should be allowed again
+      expect(limiter.shouldReport("error-1")).toBe(true);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("getCount", () => {
+    it("returns 0 for unknown errors", () => {
+      expect(limiter.getCount("unknown")).toBe(0);
+    });
+
+    it("tracks occurrence count", () => {
+      limiter.shouldReport("error-1");
+      expect(limiter.getCount("error-1")).toBe(1);
+
+      limiter.shouldReport("error-1");
+      expect(limiter.getCount("error-1")).toBe(2);
+
+      limiter.shouldReport("error-1");
+      expect(limiter.getCount("error-1")).toBe(3);
+    });
+  });
+
+  describe("getTotalInWindow", () => {
+    it("tracks unique errors in window", () => {
+      expect(limiter.getTotalInWindow()).toBe(0);
+
+      limiter.shouldReport("error-1");
+      expect(limiter.getTotalInWindow()).toBe(1);
+
+      // Duplicate doesn't increase total
+      limiter.shouldReport("error-1");
+      expect(limiter.getTotalInWindow()).toBe(1);
+
+      // New error increases total
+      limiter.shouldReport("error-2");
+      expect(limiter.getTotalInWindow()).toBe(2);
+    });
+  });
+
+  describe("reset", () => {
+    it("clears all state", () => {
+      limiter.shouldReport("error-1");
+      limiter.shouldReport("error-1");
+      expect(limiter.getCount("error-1")).toBe(2);
+      expect(limiter.getTotalInWindow()).toBe(1);
+
+      limiter.reset();
+
+      expect(limiter.getCount("error-1")).toBe(0);
+      expect(limiter.getTotalInWindow()).toBe(0);
+      expect(limiter.shouldReport("error-1")).toBe(true);
+    });
+  });
+
+  describe("getErrorSummary", () => {
+    it("returns all error entries", () => {
+      limiter.shouldReport("error-1");
+      limiter.shouldReport("error-1");
+      limiter.shouldReport("error-2");
+
+      const summary = limiter.getErrorSummary();
+
+      expect(summary.size).toBe(2);
+      expect(summary.get("error-1")?.count).toBe(2);
+      expect(summary.get("error-2")?.count).toBe(1);
+    });
+  });
+});
+
+describe("getErrorKey", () => {
+  it("generates key from error message and stack", () => {
+    const error = new Error("Test error");
+    const key = getErrorKey(error);
+    expect(key).toContain("Test error");
+  });
+
+  it("handles errors without stack", () => {
+    const error = new Error("No stack");
+    error.stack = undefined;
+    const key = getErrorKey(error);
+    expect(key).toBe("No stack|");
+  });
+
+  it("handles errors without message", () => {
+    const error = new Error();
+    const key = getErrorKey(error);
+    expect(key).toContain("Unknown error");
+  });
+
+  it("generates different keys for different errors", () => {
+    const error1 = new Error("Error 1");
+    const error2 = new Error("Error 2");
+    expect(getErrorKey(error1)).not.toBe(getErrorKey(error2));
+  });
+});


### PR DESCRIPTION
## Summary
Implements error telemetry for issues #75 and #76:

- **Rate Limiter** (`src/lib/rate-limiter.ts`): Prevents flooding telemetry endpoint
  - Configurable max errors per time window (default: 10/minute)
  - Deduplicates identical errors based on message + stack
  - Tracks occurrence counts for batch reporting

- **Telemetry Service** (`src/services/telemetry.ts`): Centralized error reporting
  - Captures unhandled errors and promise rejections
  - Scrubs PII using existing `scrubSensitive()` utility
  - Batches errors every 30 seconds for efficient network usage
  - Includes context: app version, platform, timestamp
  - Can be disabled via `telemetry.setEnabled(false)`

- **App Integration**: Telemetry initializes on app startup

## Test plan
- [x] Rate limiter has 14 unit tests covering:
  - First occurrence allowed, duplicates blocked
  - Max errors per window enforced
  - Window reset after expiry
  - Error counting and summary
- [ ] Manual testing: verify errors are captured and batched

Closes #75, closes #76

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com