### PR TITLE
feat: implement functional Catalog Panel with publisher browser

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { ChatPanel } from "@/components/chat/ChatPanel";
 import { EditorPanel } from "@/components/editor/EditorPanel";
 import { FileExplorerPanel } from "@/components/sidebar/FileExplorerPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
+import { CatalogPanel } from "@/components/catalog";
 import { LowBalanceModal } from "@/components/common/LowBalanceWarning";
 import { Phase3Playground } from "@/playground/Phase3Playground";
 import {
@@ -160,7 +161,7 @@ function App() {
                 <EditorPanel />
               </Match>
               <Match when={activePanel() === "catalog"}>
-                <div class="panel-placeholder">Catalog Panel (Coming Soon)</div>
+                <CatalogPanel onSignInClick={handleSignInClick} />
               </Match>
               <Match when={activePanel() === "settings"}>
                 <SettingsPanel />

--- a/src/components/catalog/CatalogPanel.css
+++ b/src/components/catalog/CatalogPanel.css
@@ -1,0 +1,491 @@
+/* ABOUTME: Styles for the publisher catalog panel. */
+/* ABOUTME: Grid layout for publisher cards with detail sidebar. */
+
+.catalog-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--surface, #1e1e1e);
+  color: var(--text-primary, #f8fafc);
+}
+
+/* Sign-in prompt */
+.catalog-signin-prompt {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--surface, #1e1e1e);
+}
+
+.catalog-signin-prompt .signin-prompt-content {
+  text-align: center;
+  max-width: 320px;
+}
+
+.catalog-signin-prompt .signin-prompt-icon {
+  font-size: 3rem;
+  display: block;
+  margin-bottom: 16px;
+  opacity: 0.6;
+}
+
+.catalog-signin-prompt h2 {
+  margin: 0 0 8px;
+  font-size: 1.3rem;
+  font-weight: 500;
+  color: var(--text-primary, #f8fafc);
+}
+
+.catalog-signin-prompt p {
+  margin: 0 0 20px;
+  color: var(--text-secondary, #94a3b8);
+  line-height: 1.5;
+}
+
+.catalog-signin-prompt .signin-prompt-button {
+  background: var(--accent, #6366f1);
+  color: white;
+  border: none;
+  padding: 10px 24px;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.catalog-signin-prompt .signin-prompt-button:hover {
+  background: #4f46e5;
+}
+
+/* Header */
+.catalog-header {
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border-muted, rgba(148, 163, 184, 0.15));
+}
+
+.catalog-header h1 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.catalog-subtitle {
+  margin: 4px 0 0;
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.9rem;
+}
+
+/* Toolbar with search and filters */
+.catalog-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--border-muted, rgba(148, 163, 184, 0.1));
+}
+
+.catalog-search {
+  flex: 1;
+  max-width: 320px;
+}
+
+.catalog-search input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--input-bg, rgba(30, 30, 30, 0.8));
+  border: 1px solid var(--border-muted, rgba(148, 163, 184, 0.3));
+  border-radius: 6px;
+  color: var(--text-primary, #f8fafc);
+  font-size: 0.9rem;
+}
+
+.catalog-search input:focus {
+  outline: none;
+  border-color: var(--accent, #6366f1);
+}
+
+.catalog-search input::placeholder {
+  color: var(--text-muted, #64748b);
+}
+
+.catalog-categories {
+  display: flex;
+  gap: 8px;
+}
+
+.category-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: transparent;
+  border: 1px solid var(--border-muted, rgba(148, 163, 184, 0.25));
+  border-radius: 20px;
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.category-btn:hover {
+  background: rgba(148, 163, 184, 0.1);
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.category-btn.active {
+  background: var(--accent, #6366f1);
+  border-color: var(--accent, #6366f1);
+  color: white;
+}
+
+.category-icon {
+  font-size: 1rem;
+}
+
+/* Loading and error states */
+.catalog-loading,
+.catalog-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.catalog-loading .loading-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border-muted, rgba(148, 163, 184, 0.2));
+  border-top-color: var(--accent, #6366f1);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.catalog-error p {
+  margin: 0 0 12px;
+  color: #ef4444;
+}
+
+.catalog-error button {
+  padding: 6px 16px;
+  background: var(--accent, #6366f1);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  cursor: pointer;
+}
+
+/* Content area with grid and detail panel */
+.catalog-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.catalog-grid {
+  flex: 1;
+  padding: 20px 24px;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  align-content: start;
+}
+
+/* Empty state */
+.catalog-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.catalog-empty .empty-icon {
+  font-size: 2.5rem;
+  display: block;
+  margin-bottom: 12px;
+  opacity: 0.6;
+}
+
+.catalog-empty p {
+  margin: 0;
+}
+
+.catalog-empty .empty-hint {
+  font-size: 0.85rem;
+  color: var(--text-muted, #64748b);
+  margin-top: 8px;
+}
+
+/* Publisher cards */
+.publisher-card {
+  background: var(--surface-elevated, rgba(30, 30, 30, 0.6));
+  border: 1px solid var(--border-muted, rgba(148, 163, 184, 0.2));
+  border-radius: 12px;
+  padding: 16px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.publisher-card:hover {
+  border-color: rgba(148, 163, 184, 0.4);
+  transform: translateY(-2px);
+}
+
+.publisher-card.selected {
+  border-color: var(--accent, #6366f1);
+  background: rgba(99, 102, 241, 0.1);
+}
+
+.publisher-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.publisher-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.publisher-logo-placeholder {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: white;
+}
+
+.publisher-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.publisher-title h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.verified-badge {
+  color: #22c55e;
+  font-size: 0.9rem;
+}
+
+.publisher-description {
+  margin: 0 0 12px;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #94a3b8);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.publisher-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.publisher-category {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 4px;
+  color: var(--text-secondary, #94a3b8);
+  text-transform: capitalize;
+}
+
+.publisher-price {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--accent, #6366f1);
+}
+
+.publisher-capabilities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.capability-tag {
+  font-size: 0.7rem;
+  padding: 2px 6px;
+  background: rgba(99, 102, 241, 0.15);
+  border-radius: 4px;
+  color: var(--accent-light, #a5b4fc);
+}
+
+.capability-more {
+  font-size: 0.7rem;
+  color: var(--text-muted, #64748b);
+}
+
+/* Publisher detail sidebar */
+.publisher-detail {
+  width: 320px;
+  min-width: 280px;
+  border-left: 1px solid var(--border-muted, rgba(148, 163, 184, 0.15));
+  background: var(--surface-elevated, rgba(15, 18, 32, 0.95));
+  overflow-y: auto;
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-muted, rgba(148, 163, 184, 0.15));
+}
+
+.detail-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.detail-close {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  font-size: 1.2rem;
+  color: var(--text-muted, #64748b);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.detail-close:hover {
+  background: rgba(148, 163, 184, 0.1);
+  color: var(--text-primary, #f8fafc);
+}
+
+.detail-content {
+  padding: 20px;
+}
+
+.detail-logo {
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+  margin-bottom: 16px;
+}
+
+.detail-description {
+  margin: 0 0 20px;
+  font-size: 0.9rem;
+  color: var(--text-secondary, #94a3b8);
+  line-height: 1.5;
+}
+
+.detail-section {
+  margin-bottom: 20px;
+}
+
+.detail-section h4 {
+  margin: 0 0 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary, #94a3b8);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.detail-pricing {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pricing-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: rgba(148, 163, 184, 0.1);
+  border-radius: 6px;
+}
+
+.pricing-label {
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.85rem;
+}
+
+.pricing-value {
+  font-weight: 500;
+  color: var(--text-primary, #f8fafc);
+}
+
+.detail-capabilities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.detail-slug code {
+  display: inline-block;
+  padding: 4px 8px;
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: var(--text-primary, #f8fafc);
+}
+
+/* Responsive adjustments */
+@media (max-width: 900px) {
+  .publisher-detail {
+    position: fixed;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 100;
+    box-shadow: -4px 0 24px rgba(0, 0, 0, 0.3);
+  }
+}
+
+@media (max-width: 600px) {
+  .catalog-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .catalog-search {
+    max-width: none;
+  }
+
+  .catalog-categories {
+    flex-wrap: wrap;
+  }
+
+  .catalog-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .publisher-detail {
+    width: 100%;
+  }
+}

--- a/src/components/catalog/CatalogPanel.tsx
+++ b/src/components/catalog/CatalogPanel.tsx
@@ -1,0 +1,299 @@
+// ABOUTME: Publisher catalog panel for browsing available API and database publishers.
+// ABOUTME: Shows searchable list of publishers with pricing and capabilities.
+
+import { createSignal, createEffect, For, Show, type Component } from "solid-js";
+import { catalog, type Publisher } from "@/services/catalog";
+import { authStore } from "@/stores/auth.store";
+import "./CatalogPanel.css";
+
+interface CatalogPanelProps {
+  onSignInClick?: () => void;
+}
+
+export const CatalogPanel: Component<CatalogPanelProps> = (props) => {
+  const [publishers, setPublishers] = createSignal<Publisher[]>([]);
+  const [filteredPublishers, setFilteredPublishers] = createSignal<Publisher[]>([]);
+  const [searchQuery, setSearchQuery] = createSignal("");
+  const [selectedCategory, setSelectedCategory] = createSignal<string | null>(null);
+  const [isLoading, setIsLoading] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+  const [selectedPublisher, setSelectedPublisher] = createSignal<Publisher | null>(null);
+
+  const categories = [
+    { id: "database", label: "Databases", icon: "🗄️" },
+    { id: "integration", label: "APIs", icon: "🔌" },
+    { id: "compute", label: "AI & Compute", icon: "🤖" },
+  ];
+
+  // Load publishers when authenticated
+  createEffect(() => {
+    if (authStore.isAuthenticated) {
+      loadPublishers();
+    }
+  });
+
+  // Filter publishers based on search and category
+  createEffect(() => {
+    const query = searchQuery().toLowerCase();
+    const category = selectedCategory();
+
+    let filtered = publishers();
+
+    if (category) {
+      filtered = filtered.filter(p => p.category === category);
+    }
+
+    if (query) {
+      filtered = filtered.filter(p =>
+        p.name.toLowerCase().includes(query) ||
+        p.description.toLowerCase().includes(query) ||
+        p.capabilities.some(c => c.toLowerCase().includes(query))
+      );
+    }
+
+    setFilteredPublishers(filtered);
+  });
+
+  async function loadPublishers() {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await catalog.list();
+      setPublishers(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function formatPrice(pricing: Publisher["pricing"]): string {
+    if (pricing.price_per_call) {
+      const price = parseFloat(pricing.price_per_call);
+      if (price === 0) return "Free";
+      if (price < 0.01) return `$${(price * 1000).toFixed(2)}/1K calls`;
+      return `$${price.toFixed(4)}/call`;
+    }
+    if (pricing.price_per_query) {
+      const price = parseFloat(pricing.price_per_query);
+      if (price === 0) return "Free";
+      return `$${price.toFixed(4)}/query`;
+    }
+    return "Contact for pricing";
+  }
+
+  function handleCategoryClick(categoryId: string) {
+    setSelectedCategory(prev => prev === categoryId ? null : categoryId);
+  }
+
+  return (
+    <Show
+      when={authStore.isAuthenticated}
+      fallback={
+        <div class="catalog-signin-prompt">
+          <div class="signin-prompt-content">
+            <span class="signin-prompt-icon">📚</span>
+            <h2>Sign in to explore the catalog</h2>
+            <p>Browse APIs, databases, and AI services available through Seren.</p>
+            <button type="button" class="signin-prompt-button" onClick={() => props.onSignInClick?.()}>
+              Sign In
+            </button>
+          </div>
+        </div>
+      }
+    >
+      <div class="catalog-panel">
+        <header class="catalog-header">
+          <div class="catalog-header-content">
+            <h1>Publisher Catalog</h1>
+            <p class="catalog-subtitle">
+              Discover APIs, databases, and AI services to power your workflows.
+            </p>
+          </div>
+        </header>
+
+        <div class="catalog-toolbar">
+          <div class="catalog-search">
+            <input
+              type="text"
+              placeholder="Search publishers..."
+              value={searchQuery()}
+              onInput={(e) => setSearchQuery(e.currentTarget.value)}
+            />
+          </div>
+          <div class="catalog-categories">
+            <For each={categories}>
+              {(cat) => (
+                <button
+                  type="button"
+                  class={`category-btn ${selectedCategory() === cat.id ? "active" : ""}`}
+                  onClick={() => handleCategoryClick(cat.id)}
+                >
+                  <span class="category-icon">{cat.icon}</span>
+                  {cat.label}
+                </button>
+              )}
+            </For>
+          </div>
+        </div>
+
+        <Show when={error()}>
+          <div class="catalog-error">
+            <p>{error()}</p>
+            <button type="button" onClick={loadPublishers}>Retry</button>
+          </div>
+        </Show>
+
+        <Show when={isLoading()}>
+          <div class="catalog-loading">
+            <div class="loading-spinner" />
+            <p>Loading publishers...</p>
+          </div>
+        </Show>
+
+        <Show when={!isLoading() && !error()}>
+          <div class="catalog-content">
+            <div class="catalog-grid">
+              <Show
+                when={filteredPublishers().length > 0}
+                fallback={
+                  <div class="catalog-empty">
+                    <span class="empty-icon">🔍</span>
+                    <p>No publishers found</p>
+                    <p class="empty-hint">
+                      {searchQuery() || selectedCategory()
+                        ? "Try adjusting your search or filters"
+                        : "Publishers will appear here once available"}
+                    </p>
+                  </div>
+                }
+              >
+                <For each={filteredPublishers()}>
+                  {(publisher) => (
+                    <article
+                      class={`publisher-card ${selectedPublisher()?.id === publisher.id ? "selected" : ""}`}
+                      onClick={() => setSelectedPublisher(publisher)}
+                    >
+                      <div class="publisher-header">
+                        <Show
+                          when={publisher.logo_url}
+                          fallback={
+                            <div class="publisher-logo-placeholder">
+                              {publisher.name.charAt(0).toUpperCase()}
+                            </div>
+                          }
+                        >
+                          <img
+                            src={publisher.logo_url!}
+                            alt={publisher.name}
+                            class="publisher-logo"
+                          />
+                        </Show>
+                        <div class="publisher-title">
+                          <h3>{publisher.name}</h3>
+                          <Show when={publisher.is_verified}>
+                            <span class="verified-badge" title="Verified publisher">✓</span>
+                          </Show>
+                        </div>
+                      </div>
+                      <p class="publisher-description">{publisher.description}</p>
+                      <div class="publisher-meta">
+                        <span class="publisher-category">{publisher.category}</span>
+                        <span class="publisher-price">{formatPrice(publisher.pricing)}</span>
+                      </div>
+                      <Show when={publisher.capabilities.length > 0}>
+                        <div class="publisher-capabilities">
+                          <For each={publisher.capabilities.slice(0, 3)}>
+                            {(cap) => <span class="capability-tag">{cap}</span>}
+                          </For>
+                          <Show when={publisher.capabilities.length > 3}>
+                            <span class="capability-more">
+                              +{publisher.capabilities.length - 3} more
+                            </span>
+                          </Show>
+                        </div>
+                      </Show>
+                    </article>
+                  )}
+                </For>
+              </Show>
+            </div>
+
+            <Show when={selectedPublisher()}>
+              <aside class="publisher-detail">
+                <div class="detail-header">
+                  <h2>{selectedPublisher()!.name}</h2>
+                  <button
+                    type="button"
+                    class="detail-close"
+                    onClick={() => setSelectedPublisher(null)}
+                  >
+                    ×
+                  </button>
+                </div>
+                <div class="detail-content">
+                  <Show when={selectedPublisher()!.logo_url}>
+                    <img
+                      src={selectedPublisher()!.logo_url!}
+                      alt={selectedPublisher()!.name}
+                      class="detail-logo"
+                    />
+                  </Show>
+                  <p class="detail-description">{selectedPublisher()!.description}</p>
+
+                  <div class="detail-section">
+                    <h4>Pricing</h4>
+                    <div class="detail-pricing">
+                      <div class="pricing-item">
+                        <span class="pricing-label">Per Call</span>
+                        <span class="pricing-value">
+                          {formatPrice(selectedPublisher()!.pricing)}
+                        </span>
+                      </div>
+                      <Show when={selectedPublisher()!.pricing.min_charge}>
+                        <div class="pricing-item">
+                          <span class="pricing-label">Min Charge</span>
+                          <span class="pricing-value">
+                            ${selectedPublisher()!.pricing.min_charge}
+                          </span>
+                        </div>
+                      </Show>
+                      <Show when={selectedPublisher()!.pricing.max_charge}>
+                        <div class="pricing-item">
+                          <span class="pricing-label">Max Charge</span>
+                          <span class="pricing-value">
+                            ${selectedPublisher()!.pricing.max_charge}
+                          </span>
+                        </div>
+                      </Show>
+                    </div>
+                  </div>
+
+                  <Show when={selectedPublisher()!.capabilities.length > 0}>
+                    <div class="detail-section">
+                      <h4>Capabilities</h4>
+                      <div class="detail-capabilities">
+                        <For each={selectedPublisher()!.capabilities}>
+                          {(cap) => <span class="capability-tag">{cap}</span>}
+                        </For>
+                      </div>
+                    </div>
+                  </Show>
+
+                  <div class="detail-section">
+                    <h4>Integration</h4>
+                    <p class="detail-slug">
+                      Slug: <code>{selectedPublisher()!.slug}</code>
+                    </p>
+                  </div>
+                </div>
+              </aside>
+            </Show>
+          </div>
+        </Show>
+      </div>
+    </Show>
+  );
+};
+
+export default CatalogPanel;

--- a/src/components/catalog/index.ts
+++ b/src/components/catalog/index.ts
@@ -1,0 +1,1 @@
+export { CatalogPanel } from "./CatalogPanel";


### PR DESCRIPTION
## Summary
- Add CatalogPanel component with searchable publisher grid
- Category filter buttons (Databases, APIs, AI & Compute)
- Publisher cards showing name, description, pricing, and capabilities
- Detail sidebar with full publisher information when selected
- Sign-in prompt for unauthenticated users
- Loading spinner and error states with retry button

Replaces the "Catalog Panel (Coming Soon)" placeholder.

## Test plan
- [ ] Navigate to Catalog panel via sidebar
- [ ] Verify sign-in prompt shows when not authenticated
- [ ] Sign in and verify publishers load
- [ ] Search for a publisher by name
- [ ] Click category filter buttons to filter results
- [ ] Click a publisher card to open detail sidebar
- [ ] Verify pricing and capabilities display correctly
- [ ] Close detail sidebar with X button
- [ ] Test loading state (temporarily throttle network)
- [ ] Test error state and retry button

Closes #104

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com