### PR TITLE
feat: expand Settings Panel with full configuration options

### DIFF
--- a/src/components/settings/SettingsPanel.css
+++ b/src/components/settings/SettingsPanel.css
@@ -162,6 +162,32 @@
   border-color: var(--accent, #6366f1);
 }
 
+.settings-group select {
+  min-width: 180px;
+  padding: 8px 12px;
+  background: var(--input-bg, rgba(30, 30, 30, 0.8));
+  border: 1px solid var(--border-muted, rgba(148, 163, 184, 0.3));
+  border-radius: 6px;
+  color: var(--text-primary, #f8fafc);
+  font-size: 0.9rem;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2394a3b8' d='M2 4l4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 32px;
+}
+
+.settings-group select:focus {
+  outline: none;
+  border-color: var(--accent, #6366f1);
+}
+
+.settings-group select option {
+  background: var(--surface, #1e1e1e);
+  color: var(--text-primary, #f8fafc);
+}
+
 /* Checkbox styling */
 .settings-checkbox {
   display: flex;

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -12,10 +12,17 @@ import {
 } from "@/stores/settings.store";
 import "./SettingsPanel.css";
 
-type SettingsSection = "editor" | "wallet" | "appearance" | "mcp";
+type SettingsSection = "chat" | "editor" | "wallet" | "appearance" | "general" | "mcp";
+
+// Available AI models for chat and completion
+const AI_MODELS = [
+  { id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4" },
+  { id: "claude-opus-4-20250514", name: "Claude Opus 4" },
+  { id: "claude-haiku-3-20240307", name: "Claude Haiku 3" },
+] as const;
 
 export const SettingsPanel: Component = () => {
-  const [activeSection, setActiveSection] = createSignal<SettingsSection>("editor");
+  const [activeSection, setActiveSection] = createSignal<SettingsSection>("chat");
   const [showResetConfirm, setShowResetConfirm] = createSignal(false);
 
   const handleNumberChange = (key: keyof Settings, value: string) => {
@@ -35,6 +42,10 @@ export const SettingsPanel: Component = () => {
     }
   };
 
+  const handleStringChange = (key: keyof Settings, value: string) => {
+    settingsStore.set(key, value as Settings[typeof key]);
+  };
+
   const handleResetAll = () => {
     settingsStore.reset();
     setShowResetConfirm(false);
@@ -52,9 +63,11 @@ export const SettingsPanel: Component = () => {
   };
 
   const sections: { id: SettingsSection; label: string; icon: string }[] = [
+    { id: "chat", label: "Chat", icon: "💬" },
     { id: "editor", label: "Editor", icon: "📝" },
     { id: "wallet", label: "Wallet", icon: "💳" },
     { id: "appearance", label: "Appearance", icon: "🎨" },
+    { id: "general", label: "General", icon: "⚙️" },
     { id: "mcp", label: "MCP Servers", icon: "🔌" },
   ];
 
@@ -88,6 +101,47 @@ export const SettingsPanel: Component = () => {
       </aside>
 
       <main class="settings-content">
+        <Show when={activeSection() === "chat"}>
+          <section class="settings-section">
+            <h3>Chat Settings</h3>
+            <p class="settings-description">
+              Configure AI chat behavior and conversation history.
+            </p>
+
+            <div class="settings-group">
+              <label class="settings-label">
+                <span class="label-text">Default Model</span>
+                <span class="label-hint">AI model for chat conversations</span>
+              </label>
+              <select
+                value={settingsState.app.chatDefaultModel}
+                onChange={(e) => handleStringChange("chatDefaultModel", e.currentTarget.value)}
+              >
+                <For each={AI_MODELS}>
+                  {(model) => (
+                    <option value={model.id}>{model.name}</option>
+                  )}
+                </For>
+              </select>
+            </div>
+
+            <div class="settings-group">
+              <label class="settings-label">
+                <span class="label-text">History Limit</span>
+                <span class="label-hint">Maximum messages to keep in conversation context</span>
+              </label>
+              <input
+                type="number"
+                min="10"
+                max="200"
+                step="10"
+                value={settingsState.app.chatMaxHistoryMessages}
+                onInput={(e) => handleNumberChange("chatMaxHistoryMessages", e.currentTarget.value)}
+              />
+            </div>
+          </section>
+        </Show>
+
         <Show when={activeSection() === "editor"}>
           <section class="settings-section">
             <h3>Editor Settings</h3>
@@ -165,6 +219,37 @@ export const SettingsPanel: Component = () => {
                 step="100"
                 value={settingsState.app.completionDelay}
                 onInput={(e) => handleNumberChange("completionDelay", e.currentTarget.value)}
+              />
+            </div>
+
+            <div class="settings-group">
+              <label class="settings-label">
+                <span class="label-text">Completion Model</span>
+                <span class="label-hint">AI model for code completions</span>
+              </label>
+              <select
+                value={settingsState.app.completionModelId}
+                onChange={(e) => handleStringChange("completionModelId", e.currentTarget.value)}
+              >
+                <For each={AI_MODELS}>
+                  {(model) => (
+                    <option value={model.id}>{model.name}</option>
+                  )}
+                </For>
+              </select>
+            </div>
+
+            <div class="settings-group">
+              <label class="settings-label">
+                <span class="label-text">Max Suggestion Lines</span>
+                <span class="label-hint">Maximum lines in code completion suggestions</span>
+              </label>
+              <input
+                type="number"
+                min="1"
+                max="20"
+                value={settingsState.app.completionMaxSuggestionLines}
+                onInput={(e) => handleNumberChange("completionMaxSuggestionLines", e.currentTarget.value)}
               />
             </div>
           </section>
@@ -283,6 +368,29 @@ export const SettingsPanel: Component = () => {
                   )}
                 </For>
               </div>
+            </div>
+          </section>
+        </Show>
+
+        <Show when={activeSection() === "general"}>
+          <section class="settings-section">
+            <h3>General Settings</h3>
+            <p class="settings-description">
+              Configure application behavior and privacy options.
+            </p>
+
+            <div class="settings-group checkbox">
+              <label class="settings-checkbox">
+                <input
+                  type="checkbox"
+                  checked={settingsState.app.telemetryEnabled}
+                  onChange={(e) => handleBooleanChange("telemetryEnabled", e.currentTarget.checked)}
+                />
+                <span class="checkbox-label">
+                  <span class="label-text">Enable Telemetry</span>
+                  <span class="label-hint">Help improve Seren by sharing anonymous usage data</span>
+                </span>
+              </label>
             </div>
           </section>
         </Show>

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -13,6 +13,10 @@ const APP_SETTINGS_KEY = "app";
  * Application settings.
  */
 export interface Settings {
+  // Chat settings
+  chatDefaultModel: string;
+  chatMaxHistoryMessages: number;
+
   // Editor settings
   editorFontSize: number;
   editorTabSize: number;
@@ -21,6 +25,8 @@ export interface Settings {
   // Completion settings
   completionEnabled: boolean;
   completionDelay: number;
+  completionMaxSuggestionLines: number;
+  completionModelId: string;
   completionDisabledLanguages: string[];
 
   // Wallet settings
@@ -34,24 +40,39 @@ export interface Settings {
 
   // Theme settings
   theme: "dark" | "light" | "system";
+
+  // General settings
+  telemetryEnabled: boolean;
 }
 
 /**
  * Default settings values.
  */
 const DEFAULT_SETTINGS: Settings = {
+  // Chat
+  chatDefaultModel: "claude-sonnet-4-20250514",
+  chatMaxHistoryMessages: 50,
+  // Editor
   editorFontSize: 14,
   editorTabSize: 2,
   editorWordWrap: true,
+  // Completion
   completionEnabled: true,
   completionDelay: 300,
+  completionMaxSuggestionLines: 6,
+  completionModelId: "claude-sonnet-4-20250514",
   completionDisabledLanguages: ["markdown", "plaintext"],
+  // Wallet
   showBalance: true,
   lowBalanceThreshold: 1.0,
+  // Auto top-up
   autoTopUpEnabled: false,
   autoTopUpThreshold: 5.0,
   autoTopUpAmount: 25.0,
+  // Theme
   theme: "dark",
+  // General
+  telemetryEnabled: true,
 };
 
 const defaultMcpSettings: McpSettings = {


### PR DESCRIPTION
## Summary
- Adds **Chat section** with default AI model selector and conversation history limit controls
- Enhances **Editor section** with completion model selector and max suggestion lines control
- Adds **General section** with telemetry opt-out toggle for privacy-conscious users
- Implements 5 new settings fields with proper defaults and persistence

## Changes
| File | Changes |
|------|---------|
| `settings.store.ts` | Added chatDefaultModel, chatMaxHistoryMessages, completionMaxSuggestionLines, completionModelId, telemetryEnabled |
| `SettingsPanel.tsx` | Added Chat, enhanced Editor, and General sections with dropdown and input controls |
| `SettingsPanel.css` | Added select element styling to match existing form controls |

## Screenshots
The settings panel now has 6 sections: Chat, Editor, Wallet, Appearance, General, and MCP Servers.

## Test plan
- [ ] Verify Chat section displays with model dropdown and history limit input
- [ ] Verify Editor section shows completion model and max suggestion lines
- [ ] Verify General section shows telemetry toggle
- [ ] Verify all new settings persist after app restart
- [ ] Verify reset all settings resets new fields to defaults

Closes #94

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com