### PR TITLE
feat(files): show dotfiles and dotfolders in file tree

### DIFF
--- a/src-tauri/src/files.rs
+++ b/src-tauri/src/files.rs
@@ -40,11 +40,6 @@ pub fn list_directory(path: String) -> Result<Vec<FileEntry>, String> {
             let path = entry.path();
             let name = entry.file_name().to_string_lossy().to_string();
 
-            // Skip hidden files (starting with .)
-            if name.starts_with('.') {
-                return None;
-            }
-
             Some(FileEntry {
                 name,
                 path: path.to_string_lossy().to_string(),


### PR DESCRIPTION
## Summary
- Removed filter that hid files/folders starting with '.'
- Dotfiles (.gitignore, .env.example) and dotfolders (.github, .vscode) now visible
- Matches Cursor's file explorer behavior

## Test plan
- [ ] Open a folder containing dotfiles in Seren Desktop
- [ ] Verify .gitignore, .github/, .vscode/ etc. are visible
- [ ] Verify sorting still works (directories first, then alphabetical)

Fixes #116

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com