### PR TITLE
fix(ui): remove duplicate balance display from status bar

### DIFF
--- a/src/components/common/StatusBar.tsx
+++ b/src/components/common/StatusBar.tsx
@@ -1,10 +1,9 @@
 // ABOUTME: Application status bar at the bottom.
-// ABOUTME: Displays status messages, wallet balance, MCP state, autocomplete status, and connection state.
+// ABOUTME: Displays status messages, MCP state, autocomplete status, and connection state.
 
 import { Component } from "solid-js";
 import { McpStatusIndicator } from "./McpStatusIndicator";
 import { UpdateIndicator } from "./UpdateIndicator";
-import { WalletStatus } from "./WalletStatus";
 import { AutocompleteStatus } from "./AutocompleteStatus";
 import { autocompleteStore } from "@/stores/autocomplete.store";
 import "./StatusBar.css";
@@ -24,7 +23,6 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
           onToggle={autocompleteStore.toggle}
         />
         <UpdateIndicator />
-        <WalletStatus />
         <McpStatusIndicator />
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- Remove duplicate SerenBucks balance from status bar
- Balance is already properly displayed in header via BalanceDisplay component
- Reduces UI clutter and aligns with user expectations

## Details
The BalanceDisplay component in the header already provides:
- Balance display in top right corner
- Loading/error states
- Low balance warning with color coding
- Click to open deposit modal
- Respects showBalance setting

The WalletStatus in the status bar was redundant.

## Test plan
- [ ] Verify balance appears in header (top right) when logged in
- [ ] Verify balance does NOT appear in status bar
- [ ] Verify clicking balance opens deposit modal
- [ ] Verify low balance warning styling still works
- [ ] Verify showBalance setting respected

Closes #110

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com