### PR TITLE
feat(wallet): display USDC balance from Base mainnet

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -2055,12 +2055,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -2073,6 +2082,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2711,6 +2726,22 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -3408,6 +3439,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3789,6 +3837,50 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4635,10 +4727,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4649,6 +4743,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -4880,6 +4975,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4970,6 +5074,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5176,6 +5303,7 @@ dependencies = [
  "lazy_static",
  "notify",
  "rand 0.8.5",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -6133,6 +6261,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,3 +36,4 @@ alloy = { version = "1.0", default-features = false, features = ["signers", "sig
 hex = "0.4"
 rand = "0.8"
 base64 = "0.22"
+reqwest = { version = "0.12", features = ["json"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -165,6 +165,7 @@ pub fn run() {
             wallet::commands::get_crypto_wallet_address,
             wallet::commands::clear_crypto_wallet,
             wallet::commands::sign_x402_payment,
+            wallet::commands::get_crypto_usdc_balance,
             embedded_runtime::get_embedded_runtime_info,
         ])
         .run(tauri::generate_context!())

--- a/src/components/settings/SettingsPanel.css
+++ b/src/components/settings/SettingsPanel.css
@@ -588,6 +588,61 @@ button.danger-outline:hover {
   border-color: #ef4444;
 }
 
+/* Crypto balance display */
+.crypto-balance-display {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.balance-value {
+  padding: 10px 16px;
+  background: var(--surface-elevated, rgba(30, 30, 30, 0.6));
+  border: 1px solid var(--border-muted, rgba(148, 163, 184, 0.2));
+  border-radius: 6px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary, #f8fafc);
+  font-family: monospace;
+  min-width: 140px;
+}
+
+.balance-loading {
+  padding: 10px 16px;
+  background: var(--surface-elevated, rgba(30, 30, 30, 0.6));
+  border: 1px solid var(--border-muted, rgba(148, 163, 184, 0.2));
+  border-radius: 6px;
+  font-size: 0.9rem;
+  color: var(--text-muted, #64748b);
+  min-width: 140px;
+}
+
+.refresh-balance-btn {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-elevated, rgba(30, 30, 30, 0.6));
+  border: 1px solid var(--border-muted, rgba(148, 163, 184, 0.2));
+  border-radius: 6px;
+  font-size: 1.2rem;
+  color: var(--text-secondary, #94a3b8);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.refresh-balance-btn:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.1);
+  border-color: rgba(148, 163, 184, 0.4);
+  color: var(--text-primary, #f8fafc);
+}
+
+.refresh-balance-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .settings-sidebar {

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -484,6 +484,34 @@ export const SettingsPanel: Component = () => {
                     </button>
                   </div>
                 </div>
+
+                <div class="settings-group">
+                  <label class="settings-label">
+                    <span class="label-text">USDC Balance (Base)</span>
+                    <span class="label-hint">Your current USDC balance on Base mainnet</span>
+                  </label>
+                  <div class="crypto-balance-display">
+                    <Show
+                      when={!cryptoWalletStore.state().balanceLoading}
+                      fallback={<span class="balance-loading">Loading balance...</span>}
+                    >
+                      <span class="balance-value">
+                        {cryptoWalletStore.state().usdcBalance !== null
+                          ? `${cryptoWalletStore.state().usdcBalance} USDC`
+                          : "—"}
+                      </span>
+                    </Show>
+                    <button
+                      type="button"
+                      class="refresh-balance-btn"
+                      onClick={() => cryptoWalletStore.fetchBalance()}
+                      disabled={cryptoWalletStore.state().balanceLoading}
+                      title="Refresh balance"
+                    >
+                      ↻
+                    </button>
+                  </div>
+                </div>
               </div>
             </Show>
           </section>

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -339,3 +339,30 @@ export async function signX402Payment(requirementsJson: string): Promise<SignX40
   }
   return result.data!;
 }
+
+/**
+ * Response from USDC balance query.
+ */
+export interface UsdcBalanceResponse {
+  balance: string;
+  balanceRaw: string;
+  network: string;
+}
+
+/**
+ * Get the USDC balance for the stored crypto wallet on Base mainnet.
+ *
+ * @returns The USDC balance with human-readable amount and raw value
+ * @throws Error if wallet is not configured or query fails
+ */
+export async function getCryptoUsdcBalance(): Promise<UsdcBalanceResponse> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("USDC balance query requires Tauri runtime");
+  }
+  const result = await invoke<WalletCommandResult<UsdcBalanceResponse>>("get_crypto_usdc_balance");
+  if (!result.success) {
+    throw new Error(result.error || "Failed to get USDC balance");
+  }
+  return result.data!;
+}


### PR DESCRIPTION
## Summary

- Add real-time USDC balance display for configured crypto wallets
- Query balance from Base mainnet via eth_call to USDC contract
- Show balance in Settings > Wallet with refresh button

## Changes

**Rust Backend:**
- Add `get_crypto_usdc_balance` command that queries Base RPC
- Uses eth_call to USDC contract (0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913)
- Returns human-readable balance (6 decimals)

**TypeScript:**
- Add `getCryptoUsdcBalance()` bridge function
- Add balance state to crypto-wallet store
- Auto-fetch balance on wallet load and key save

**UI:**
- Display USDC balance below wallet address in Settings
- Loading state while fetching
- Refresh button for manual updates

## Test plan

- [ ] Configure a crypto wallet with a private key
- [ ] Verify balance displays after saving key
- [ ] Click refresh button and verify balance updates
- [ ] Clear wallet and verify balance resets

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com