### PR TITLE
feat(build): configure code signing for production distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,259 @@
+# ABOUTME: Release workflow for building and signing production binaries.
+# ABOUTME: Triggers on version tags, signs for macOS/Windows, and notarizes for Apple.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+  TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create_release.outputs.id }}
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Seren Desktop ${{ github.ref_name }}
+          draft: true
+          prerelease: false
+
+  build:
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            name: macOS-arm64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            name: macOS-x64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            name: Windows-x64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            name: Linux-x64
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: 'src-tauri'
+
+      - name: Install dependencies (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install frontend dependencies
+        run: pnpm install
+
+      - name: Prepare embedded runtime
+        run: pnpm prepare:runtime
+
+      # macOS: Import certificates and setup keychain
+      - name: Import macOS certificates
+        if: matrix.os == 'macos-latest'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # Create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          # Import certificate from secrets
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode > $CERTIFICATE_PATH
+
+          # Create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # Import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+      # Windows: Setup certificate for signing
+      - name: Setup Windows signing
+        if: matrix.os == 'windows-latest' && secrets.WINDOWS_CERTIFICATE != ''
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        shell: powershell
+        run: |
+          $certificatePath = "$env:RUNNER_TEMP\certificate.pfx"
+          [System.Convert]::FromBase64String($env:WINDOWS_CERTIFICATE) | Set-Content -Path $certificatePath -AsByteStream
+          Import-PfxCertificate -FilePath $certificatePath -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText)
+
+      # Build the app
+      - name: Build Tauri app
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: pnpm tauri build --target ${{ matrix.target }}
+
+      # macOS: Notarize the app
+      - name: Notarize macOS app
+        if: matrix.os == 'macos-latest'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          # Find the DMG file
+          DMG_PATH=$(find src-tauri/target/${{ matrix.target }}/release/bundle/dmg -name "*.dmg" | head -1)
+
+          if [ -n "$DMG_PATH" ]; then
+            echo "Notarizing $DMG_PATH"
+            xcrun notarytool submit "$DMG_PATH" \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --wait
+
+            # Staple the notarization ticket
+            xcrun stapler staple "$DMG_PATH"
+          fi
+
+      # Upload artifacts
+      - name: Upload macOS DMG
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Seren-Desktop-${{ matrix.name }}.dmg
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+
+      - name: Upload Windows MSI
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Seren-Desktop-${{ matrix.name }}.msi
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
+
+      - name: Upload Windows NSIS
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Seren-Desktop-${{ matrix.name }}.exe
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
+
+      - name: Upload Linux DEB
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Seren-Desktop-${{ matrix.name }}.deb
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
+
+      - name: Upload Linux AppImage
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Seren-Desktop-${{ matrix.name }}.AppImage
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+
+      # Clean up macOS keychain
+      - name: Cleanup macOS keychain
+        if: matrix.os == 'macos-latest' && always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
+
+  publish-release:
+    needs: [create-release, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Display structure of downloaded files
+        run: ls -R artifacts
+
+      - name: Publish release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const releaseId = '${{ needs.create-release.outputs.release_id }}';
+            const artifactsDir = 'artifacts';
+
+            // Upload all artifact files
+            const uploadAsset = async (filePath, fileName) => {
+              const content = fs.readFileSync(filePath);
+              await github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: releaseId,
+                name: fileName,
+                data: content
+              });
+            };
+
+            // Walk through artifacts directory
+            const walkDir = (dir) => {
+              const files = fs.readdirSync(dir);
+              for (const file of files) {
+                const filePath = path.join(dir, file);
+                const stat = fs.statSync(filePath);
+                if (stat.isDirectory()) {
+                  walkDir(filePath);
+                } else {
+                  console.log(`Uploading: ${filePath}`);
+                  uploadAsset(filePath, file);
+                }
+              }
+            };
+
+            walkDir(artifactsDir);
+
+            // Undraft the release
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: releaseId,
+              draft: false
+            });

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -1,0 +1,171 @@
+# Code Signing Setup for Seren Desktop
+
+This document explains how to set up code signing for production releases of Seren Desktop.
+
+## Overview
+
+Code signing is required for:
+- **macOS**: Gatekeeper blocks unsigned apps
+- **Windows**: SmartScreen warns on unsigned apps
+- **Auto-updater**: Verifies update authenticity
+
+## GitHub Secrets Required
+
+Add these secrets to the repository settings (Settings → Secrets → Actions):
+
+### Update Signing (Required)
+
+| Secret | Description |
+|--------|-------------|
+| `TAURI_SIGNING_PRIVATE_KEY` | Ed25519 private key (base64) for signing updates |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for the private key |
+
+### macOS Signing
+
+| Secret | Description |
+|--------|-------------|
+| `APPLE_CERTIFICATE` | Developer ID Application certificate (.p12, base64 encoded) |
+| `APPLE_CERTIFICATE_PASSWORD` | Password for the .p12 file |
+| `APPLE_SIGNING_IDENTITY` | Full signing identity, e.g., "Developer ID Application: SerenAI (TEAMID)" |
+| `APPLE_TEAM_ID` | Apple Developer Team ID (10 characters) |
+| `APPLE_ID` | Apple ID email for notarization |
+| `APPLE_PASSWORD` | App-specific password for notarization |
+| `KEYCHAIN_PASSWORD` | Temporary password for CI keychain (any secure random string) |
+
+### Windows Signing
+
+| Secret | Description |
+|--------|-------------|
+| `WINDOWS_CERTIFICATE` | Code signing certificate (.pfx, base64 encoded) |
+| `WINDOWS_CERTIFICATE_PASSWORD` | Password for the .pfx file |
+
+## Certificate Setup
+
+### Step 1: Generate Update Signing Keys
+
+```bash
+# Generate Ed25519 keypair
+openssl genpkey -algorithm ed25519 -out update-private.pem
+openssl pkey -in update-private.pem -pubout -out update-public.pem
+
+# Convert private key to base64 for secrets
+base64 -i update-private.pem
+
+# The public key goes in tauri.conf.json
+cat update-public.pem
+```
+
+Update `src-tauri/tauri.conf.json` with the public key:
+```json
+{
+  "plugins": {
+    "updater": {
+      "pubkey": "YOUR_PUBLIC_KEY_HERE"
+    }
+  }
+}
+```
+
+### Step 2: macOS Developer Certificate
+
+1. **Join Apple Developer Program** ($99/year)
+   - https://developer.apple.com/programs/
+
+2. **Create Developer ID Application Certificate**
+   - Open Keychain Access on Mac
+   - Keychain Access → Certificate Assistant → Request a Certificate From a Certificate Authority
+   - Enter email, leave CA email blank, select "Saved to disk"
+   - Go to https://developer.apple.com/account/resources/certificates
+   - Click "+" → Developer ID Application
+   - Upload the CSR file, download certificate, double-click to install
+
+3. **Export as .p12**
+   ```bash
+   # In Keychain Access:
+   # - Find "Developer ID Application: Your Name"
+   # - Right-click → Export → Save as .p12
+
+   # Convert to base64
+   base64 -i certificate.p12
+   ```
+
+4. **Get Team ID**
+   - https://developer.apple.com/account → Membership → Team ID
+
+5. **Create App-Specific Password**
+   - https://appleid.apple.com → Sign In & Security → App-Specific Passwords
+   - Generate password for "Seren Desktop Notarization"
+
+### Step 3: Windows Code Signing Certificate
+
+**Option A: DigiCert (Recommended)**
+1. https://www.digicert.com/signing/code-signing-certificates
+2. Choose Standard or EV Code Signing
+3. Complete verification (1-3 days for EV)
+4. Download .pfx file
+
+**Option B: Other Providers**
+- Sectigo: https://sectigo.com/code-signing-certificates
+- GlobalSign: https://www.globalsign.com/code-signing
+
+Convert to base64:
+```bash
+base64 -i certificate.pfx
+```
+
+## Testing Locally
+
+### macOS
+```bash
+# Check if certificate is installed
+security find-identity -v -p codesigning
+
+# Build with signing
+APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)" pnpm tauri build
+```
+
+### Windows
+```powershell
+# List installed certificates
+Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert
+
+# Build with signing (certificate must be in store)
+pnpm tauri build
+```
+
+## Release Process
+
+1. Create and push a version tag:
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+2. The release workflow will:
+   - Build for all platforms
+   - Sign macOS and Windows binaries
+   - Notarize macOS app with Apple
+   - Create a GitHub release with all artifacts
+
+3. The release is created as a draft initially. Review and publish when ready.
+
+## Troubleshooting
+
+### macOS: "The signature is invalid"
+- Ensure the certificate is a "Developer ID Application" (not Mac Developer)
+- Check that entitlements.plist exists in src-tauri/
+
+### macOS: Notarization fails
+- Verify APPLE_ID and APPLE_PASSWORD are correct
+- Check that app-specific password is used (not account password)
+- Ensure APPLE_TEAM_ID matches the certificate
+
+### Windows: SmartScreen warning
+- EV certificates get immediate reputation
+- Standard certificates need to build reputation over time
+- Consider using EV for production releases
+
+### Update signature missing
+- Check TAURI_SIGNING_PRIVATE_KEY is set correctly
+- Verify the key is base64 encoded
+- Ensure password matches the key

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Disable app sandbox for full system access -->
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+
+    <!-- Allow JIT compilation (required for some JS engines) -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+
+    <!-- Allow unsigned executable memory (required for Tauri) -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+
+    <!-- Allow outbound network connections -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+
+    <!-- Allow dyld environment variables (for embedded runtime) -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+
+    <!-- Disable library validation (for bundled Node.js) -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,6 +51,14 @@
     ],
     "resources": {
       "embedded-runtime/": "embedded-runtime/"
+    },
+    "macOS": {
+      "entitlements": "entitlements.plist",
+      "minimumSystemVersion": "10.13"
+    },
+    "windows": {
+      "certificateThumbprint": null,
+      "timestampUrl": "http://timestamp.digicert.com"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add macOS entitlements.plist for hardened runtime
- Update tauri.conf.json with macOS and Windows signing configuration
- Create release.yml workflow with signing and notarization
- Add comprehensive code-signing.md documentation

Closes #82

## Changes

| File | Description |
|------|-------------|
| `src-tauri/entitlements.plist` | macOS entitlements for hardened runtime |
| `src-tauri/tauri.conf.json` | Bundle config with signing settings |
| `.github/workflows/release.yml` | Release workflow with signing/notarization |
| `docs/code-signing.md` | Setup instructions for certificates |

## GitHub Secrets Required

After merge, add these secrets to enable signing:

| Secret | Required For |
|--------|--------------|
| `TAURI_SIGNING_PRIVATE_KEY` | Update signatures |
| `APPLE_CERTIFICATE` | macOS code signing |
| `APPLE_ID` / `APPLE_PASSWORD` | macOS notarization |
| `WINDOWS_CERTIFICATE` | Windows code signing |

See `docs/code-signing.md` for complete setup instructions.

## Test plan

- [ ] Workflow syntax is valid (GitHub validates on push)
- [ ] Local build works with entitlements: `pnpm tauri build`
- [ ] After adding secrets, tag a release to test full workflow

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com