### PR TITLE
feat(tools): add gateway MCP publisher tool integration

### DIFF
--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -1,10 +1,11 @@
-// ABOUTME: Tool executor that routes tool calls to file operations or MCP servers.
+// ABOUTME: Tool executor that routes tool calls to file operations, local MCP, or gateway MCP.
 // ABOUTME: Handles tool call parsing, execution, and result formatting.
 
 import { invoke } from "@tauri-apps/api/core";
 import { mcpClient } from "@/lib/mcp/client";
 import type { ToolCall, ToolResult } from "@/lib/providers/types";
 import { parseMcpToolName } from "./definitions";
+import { gatewayMcpClient, parseGatewayMcpToolName } from "./gateway-mcp";
 
 /**
  * File entry returned by list_directory.
@@ -17,7 +18,7 @@ interface FileEntry {
 
 /**
  * Execute a single tool call and return the result.
- * Routes to MCP server if tool name is prefixed, otherwise uses local file tools.
+ * Routes to local MCP, gateway MCP, or file tools based on prefix.
  */
 export async function executeTool(toolCall: ToolCall): Promise<ToolResult> {
   const { name, arguments: argsJson } = toolCall.function;
@@ -25,7 +26,18 @@ export async function executeTool(toolCall: ToolCall): Promise<ToolResult> {
   try {
     const args = JSON.parse(argsJson) as Record<string, unknown>;
 
-    // Check if this is an MCP tool call
+    // Check if this is a gateway MCP tool call (from publishers)
+    const gatewayInfo = parseGatewayMcpToolName(name);
+    if (gatewayInfo) {
+      return await executeGatewayMcpTool(
+        toolCall.id,
+        gatewayInfo.publisherSlug,
+        gatewayInfo.toolName,
+        args,
+      );
+    }
+
+    // Check if this is a local MCP tool call
     const mcpInfo = parseMcpToolName(name);
     if (mcpInfo) {
       return await executeMcpTool(toolCall.id, mcpInfo.serverName, mcpInfo.toolName, args);
@@ -134,6 +146,33 @@ async function executeMcpTool(
     return {
       tool_call_id: toolCallId,
       content: `MCP tool error: ${message}`,
+      is_error: true,
+    };
+  }
+}
+
+/**
+ * Execute a gateway MCP tool call via the Seren Gateway API.
+ */
+async function executeGatewayMcpTool(
+  toolCallId: string,
+  publisherSlug: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  try {
+    const result = await gatewayMcpClient.callTool(publisherSlug, toolName, args);
+
+    return {
+      tool_call_id: toolCallId,
+      content: result.content,
+      is_error: result.isError,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      tool_call_id: toolCallId,
+      content: `Gateway MCP tool error: ${message}`,
       is_error: true,
     };
   }

--- a/src/lib/tools/gateway-mcp.ts
+++ b/src/lib/tools/gateway-mcp.ts
@@ -1,0 +1,244 @@
+// ABOUTME: Gateway MCP tool integration for builtin MCP servers.
+// ABOUTME: Fetches and caches tools from MCP publishers via Seren Gateway API.
+
+import { callMcpTool, listMcpTools, listStorePublishers } from "@/api";
+import type { McpToolInfo } from "@/api/generated";
+import { createSignal } from "solid-js";
+
+/**
+ * Prefix for gateway MCP tools to distinguish from local MCP tools.
+ * Format: gwmcp__{publisherSlug}__{toolName}
+ */
+export const GATEWAY_MCP_TOOL_PREFIX = "gwmcp__";
+
+/**
+ * Gateway MCP tool with publisher info.
+ */
+export interface GatewayMcpTool {
+  publisherSlug: string;
+  publisherName: string;
+  tool: McpToolInfo;
+}
+
+/**
+ * Parse a gateway MCP tool name to extract publisher slug and tool name.
+ * Returns null if the name is not a gateway MCP tool.
+ */
+export function parseGatewayMcpToolName(
+  name: string,
+): { publisherSlug: string; toolName: string } | null {
+  if (!name.startsWith(GATEWAY_MCP_TOOL_PREFIX)) {
+    return null;
+  }
+  const rest = name.slice(GATEWAY_MCP_TOOL_PREFIX.length);
+  const separatorIndex = rest.indexOf("__");
+  if (separatorIndex === -1) {
+    return null;
+  }
+  return {
+    publisherSlug: rest.slice(0, separatorIndex),
+    toolName: rest.slice(separatorIndex + 2),
+  };
+}
+
+/**
+ * Gateway MCP tools cache using SolidJS signals.
+ */
+function createGatewayMcpClient() {
+  const [tools, setTools] = createSignal<GatewayMcpTool[]>([]);
+  const [isLoading, setIsLoading] = createSignal(false);
+  const [lastError, setLastError] = createSignal<string | null>(null);
+  const [lastFetchTime, setLastFetchTime] = createSignal<number>(0);
+
+  // Cache validity period (5 minutes)
+  const CACHE_TTL_MS = 5 * 60 * 1000;
+
+  /**
+   * Check if cache is still valid.
+   */
+  function isCacheValid(): boolean {
+    const lastFetch = lastFetchTime();
+    if (lastFetch === 0) return false;
+    return Date.now() - lastFetch < CACHE_TTL_MS;
+  }
+
+  /**
+   * Fetch tools from all MCP publishers.
+   * Caches results for subsequent synchronous access.
+   */
+  async function fetchAllTools(): Promise<void> {
+    // Skip if already loading or cache is valid
+    if (isLoading() || isCacheValid()) {
+      return;
+    }
+
+    setIsLoading(true);
+    setLastError(null);
+
+    try {
+      // First, get all MCP publishers
+      const { data: publishersData, error: publishersError } =
+        await listStorePublishers({
+          query: { search: "mcp" },
+          throwOnError: false,
+        });
+
+      if (publishersError || !publishersData?.data) {
+        throw new Error("Failed to fetch MCP publishers");
+      }
+
+      // Filter to only MCP integration type publishers
+      const mcpPublishers = publishersData.data.filter(
+        (p) => p.integration_type === "mcp",
+      );
+
+      console.log(
+        "[GatewayMCP] Found",
+        mcpPublishers.length,
+        "MCP publishers:",
+        mcpPublishers.map((p) => p.slug),
+      );
+
+      // Fetch tools from each publisher in parallel
+      const allTools: GatewayMcpTool[] = [];
+      const fetchResults = await Promise.allSettled(
+        mcpPublishers.map(async (publisher) => {
+          const { data, error } = await listMcpTools({
+            body: { publisher: publisher.slug },
+            throwOnError: false,
+          });
+
+          if (error || !data) {
+            console.warn(
+              `[GatewayMCP] Failed to fetch tools from ${publisher.slug}:`,
+              error,
+            );
+            return [];
+          }
+
+          // Extract tools from response
+          const tools = data.tools || [];
+          return tools.map((tool) => ({
+            publisherSlug: publisher.slug,
+            publisherName: publisher.name,
+            tool,
+          }));
+        }),
+      );
+
+      // Collect successful results
+      for (const result of fetchResults) {
+        if (result.status === "fulfilled") {
+          allTools.push(...result.value);
+        }
+      }
+
+      console.log("[GatewayMCP] Cached", allTools.length, "gateway MCP tools");
+      setTools(allTools);
+      setLastFetchTime(Date.now());
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("[GatewayMCP] Error fetching tools:", message);
+      setLastError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  /**
+   * Get all cached gateway MCP tools synchronously.
+   * Returns empty array if not yet fetched.
+   */
+  function getAllTools(): GatewayMcpTool[] {
+    return tools();
+  }
+
+  /**
+   * Call a gateway MCP tool via the Seren API.
+   */
+  async function callTool(
+    publisherSlug: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<{ content: string; isError: boolean }> {
+    const { data, error } = await callMcpTool({
+      body: {
+        publisher: publisherSlug,
+        tool_name: toolName,
+        arguments: args,
+      },
+      throwOnError: false,
+    });
+
+    if (error) {
+      const errorMessage =
+        typeof error === "object" && error !== null && "message" in error
+          ? String(error.message)
+          : String(error);
+      return {
+        content: `Gateway MCP error: ${errorMessage}`,
+        isError: true,
+      };
+    }
+
+    // Extract content from MCP response
+    // The result is the raw MCP response which may contain content array
+    let content = "";
+    const result = data?.result as {
+      content?: Array<{ type: string; text?: string }>;
+    } | undefined;
+
+    if (result?.content && Array.isArray(result.content)) {
+      for (const item of result.content) {
+        if (item.type === "text" && item.text) {
+          content += item.text;
+        }
+      }
+    } else if (typeof data?.result === "string") {
+      content = data.result;
+    } else if (data?.result) {
+      content = JSON.stringify(data.result, null, 2);
+    }
+
+    return {
+      content: content || "Tool executed successfully",
+      isError: data?.is_error ?? false,
+    };
+  }
+
+  /**
+   * Clear the tools cache.
+   */
+  function clearCache(): void {
+    setTools([]);
+    setLastFetchTime(0);
+    setLastError(null);
+  }
+
+  /**
+   * Get loading state.
+   */
+  function getIsLoading(): boolean {
+    return isLoading();
+  }
+
+  /**
+   * Get last error.
+   */
+  function getLastError(): string | null {
+    return lastError();
+  }
+
+  return {
+    fetchAllTools,
+    getAllTools,
+    callTool,
+    clearCache,
+    getIsLoading,
+    getLastError,
+    isCacheValid,
+  };
+}
+
+// Export singleton instance
+export const gatewayMcpClient = createGatewayMcpClient();

--- a/src/lib/tools/index.ts
+++ b/src/lib/tools/index.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Barrel export for tools module.
-// ABOUTME: Re-exports tool definitions and executor functions.
+// ABOUTME: Re-exports tool definitions, executor, and gateway MCP functions.
 
 export {
   FILE_TOOLS,
@@ -9,3 +9,9 @@ export {
   parseMcpToolName,
 } from "./definitions";
 export { executeTool, executeTools } from "./executor";
+export {
+  gatewayMcpClient,
+  GATEWAY_MCP_TOOL_PREFIX,
+  parseGatewayMcpToolName,
+  type GatewayMcpTool,
+} from "./gateway-mcp";

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -3,6 +3,7 @@
 
 import { createStore } from "solid-js/store";
 import { addSerenDbServer, removeSerenDbServer } from "@/lib/mcp/serendb";
+import { gatewayMcpClient } from "@/lib/tools";
 import { logout as authLogout, isLoggedIn } from "@/services/auth";
 
 export interface User {
@@ -37,6 +38,10 @@ export async function checkAuth(): Promise<void> {
     if (authenticated) {
       try {
         await addSerenDbServer();
+        // Fetch gateway MCP tools in background (don't block auth)
+        gatewayMcpClient.fetchAllTools().catch((error) => {
+          console.warn("Failed to fetch gateway MCP tools:", error);
+        });
       } catch (error) {
         console.error("Failed to add SerenDB MCP server:", error);
       }
@@ -60,6 +65,10 @@ export async function setAuthenticated(user: User): Promise<void> {
   // Add SerenDB as default MCP server on sign-in
   try {
     await addSerenDbServer();
+    // Fetch gateway MCP tools in background (don't block login)
+    gatewayMcpClient.fetchAllTools().catch((error) => {
+      console.warn("Failed to fetch gateway MCP tools:", error);
+    });
   } catch (error) {
     console.error("Failed to add SerenDB MCP server:", error);
   }
@@ -73,6 +82,8 @@ export async function logout(): Promise<void> {
   // Remove SerenDB MCP server on sign-out
   try {
     await removeSerenDbServer();
+    // Clear gateway MCP tools cache
+    gatewayMcpClient.clearCache();
   } catch (error) {
     console.error("Failed to remove SerenDB MCP server:", error);
   }


### PR DESCRIPTION
## Summary
- Adds support for gateway MCP publishers (mcp-git, mcp-memory, etc.) in addition to local MCP servers
- Fetches and caches tools from all MCP publishers via the Seren Gateway API
- Routes gateway MCP tool calls through the API for execution

## Changes
- **src/lib/tools/gateway-mcp.ts**: New module for gateway MCP tool management
  - Fetches tools from MCP publishers (integration_type: "mcp")
  - Caches tools with 5-minute TTL for synchronous access
  - Provides callTool function for gateway MCP execution
- **src/lib/tools/definitions.ts**: Include gateway MCP tools in `getAllTools()`
- **src/lib/tools/executor.ts**: Route gateway MCP tools through gateway API
- **src/stores/auth.store.ts**: Fetch gateway MCP tools on sign-in, clear on sign-out

## How It Works
1. On sign-in, gateway MCP tools are fetched from all MCP publishers in background
2. Tools are prefixed with `gwmcp__{publisherSlug}__{toolName}` for routing
3. `getAllTools()` includes both local MCP and gateway MCP tools
4. Gateway MCP tool calls are routed through the Seren Gateway API

This extends #153 to support MCP publishers exposed through the Seren marketplace, not just locally-connected MCP servers.

## Test plan
- [ ] Sign in and verify gateway MCP tools are fetched (check console logs)
- [ ] Start a chat and verify gateway MCP tools appear in tool list
- [ ] Ask the AI to use a gateway MCP tool (e.g., "what time is it?")
- [ ] Verify the tool executes via gateway and results are shown

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com