### PR TITLE
feat(ui): add three-column resizable layout

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -1,0 +1,657 @@
+// ABOUTME: Chat content panel without file tree for resizable layout.
+// ABOUTME: Shows chat messages, input, and model selector.
+
+/* eslint-disable solid/no-innerhtml */
+import type { Component } from "solid-js";
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import { SignIn } from "@/components/auth/SignIn";
+import { escapeHtml } from "@/lib/escape-html";
+import { renderMarkdown } from "@/lib/render-markdown";
+import { catalog, type Publisher } from "@/services/catalog";
+import {
+  areToolsAvailable,
+  CHAT_MAX_RETRIES,
+  type ChatContext,
+  type Message,
+  sendMessageWithRetry,
+  streamMessage,
+  streamMessageWithTools,
+  type ToolStreamEvent,
+} from "@/services/chat";
+import { authStore, checkAuth } from "@/stores/auth.store";
+import { chatStore } from "@/stores/chat.store";
+import { editorStore } from "@/stores/editor.store";
+import { settingsStore } from "@/stores/settings.store";
+import { ChatTabBar } from "./ChatTabBar";
+import { ModelSelector } from "./ModelSelector";
+import { PublisherSuggestions } from "./PublisherSuggestions";
+import { StreamingMessage } from "./StreamingMessage";
+import { ToolStreamingMessage } from "./ToolStreamingMessage";
+import "highlight.js/styles/github-dark.css";
+
+// Keywords that trigger publisher suggestions
+const SUGGESTION_KEYWORDS = [
+  "scrape",
+  "crawl",
+  "fetch",
+  "search",
+  "query",
+  "database",
+  "api",
+  "web",
+  "data",
+  "analyze",
+  "extract",
+  "research",
+];
+
+interface StreamingSession {
+  id: string;
+  userMessageId: string;
+  prompt: string;
+  model: string;
+  context?: ChatContext;
+  stream: AsyncGenerator<string>;
+  toolsEnabled: false;
+}
+
+interface ToolStreamingSession {
+  id: string;
+  userMessageId: string;
+  prompt: string;
+  model: string;
+  context?: ChatContext;
+  stream: AsyncGenerator<ToolStreamEvent>;
+  toolsEnabled: true;
+}
+
+type ActiveStreamingSession = StreamingSession | ToolStreamingSession;
+
+interface ChatContentProps {
+  onSignInClick?: () => void;
+}
+
+export const ChatContent: Component<ChatContentProps> = (_props) => {
+  const [input, setInput] = createSignal("");
+  const [streamingSession, setStreamingSession] =
+    createSignal<ActiveStreamingSession | null>(null);
+  const [suggestions, setSuggestions] = createSignal<Publisher[]>([]);
+  const [suggestionsLoading, setSuggestionsLoading] = createSignal(false);
+  const [suggestionsDismissed, setSuggestionsDismissed] = createSignal(false);
+  // Input history navigation (terminal-style up/down arrow)
+  const [historyIndex, setHistoryIndex] = createSignal(-1);
+  const [savedInput, setSavedInput] = createSignal("");
+  let inputRef: HTMLTextAreaElement | undefined;
+  let messagesRef: HTMLDivElement | undefined;
+  let suggestionDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const scrollToBottom = () => {
+    if (messagesRef) {
+      messagesRef.scrollTop = messagesRef.scrollHeight;
+    }
+  };
+
+  // Keyboard shortcuts for tab management
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const isMod = event.metaKey || event.ctrlKey;
+
+    // Ctrl/Cmd+T: New tab
+    if (isMod && event.key === "t") {
+      event.preventDefault();
+      chatStore.createConversation();
+      return;
+    }
+
+    // Ctrl/Cmd+W: Close current tab
+    if (isMod && event.key === "w") {
+      event.preventDefault();
+      const activeId = chatStore.activeConversationId;
+      if (activeId) {
+        chatStore.archiveConversation(activeId);
+      }
+      return;
+    }
+
+    // Ctrl+Tab / Ctrl+Shift+Tab: Switch tabs
+    if (event.ctrlKey && event.key === "Tab") {
+      event.preventDefault();
+      const conversations = chatStore.conversations.filter(
+        (c) => !c.isArchived,
+      );
+      if (conversations.length < 2) return;
+
+      const currentIndex = conversations.findIndex(
+        (c) => c.id === chatStore.activeConversationId,
+      );
+      if (currentIndex === -1) return;
+
+      const nextIndex = event.shiftKey
+        ? (currentIndex - 1 + conversations.length) % conversations.length
+        : (currentIndex + 1) % conversations.length;
+
+      chatStore.setActiveConversation(conversations[nextIndex].id);
+    }
+  };
+
+  onMount(async () => {
+    document.addEventListener("keydown", handleKeyDown);
+
+    try {
+      await chatStore.loadHistory();
+    } catch (error) {
+      chatStore.setError((error as Error).message);
+    }
+  });
+
+  // Auto-scroll to bottom when messages change or streaming starts
+  createEffect(() => {
+    void chatStore.messages;
+    void streamingSession();
+    requestAnimationFrame(scrollToBottom);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener("keydown", handleKeyDown);
+    if (suggestionDebounceTimer) {
+      clearTimeout(suggestionDebounceTimer);
+    }
+  });
+
+  // Check if input contains suggestion-triggering keywords
+  const shouldShowSuggestions = (text: string): boolean => {
+    const lowerText = text.toLowerCase();
+    return SUGGESTION_KEYWORDS.some((keyword) => lowerText.includes(keyword));
+  };
+
+  // Debounced fetch for publisher suggestions
+  const fetchSuggestions = async (query: string) => {
+    if (!authStore.isAuthenticated || suggestionsDismissed()) return;
+
+    if (!shouldShowSuggestions(query)) {
+      setSuggestions([]);
+      return;
+    }
+
+    setSuggestionsLoading(true);
+    try {
+      const results = await catalog.suggest(query);
+      setSuggestions(results.slice(0, 3));
+    } catch {
+      setSuggestions([]);
+    } finally {
+      setSuggestionsLoading(false);
+    }
+  };
+
+  // Watch input changes for suggestions
+  createEffect(() => {
+    const text = input();
+    if (suggestionDebounceTimer) {
+      clearTimeout(suggestionDebounceTimer);
+    }
+
+    if (text.length < 10) {
+      setSuggestions([]);
+      return;
+    }
+
+    suggestionDebounceTimer = setTimeout(() => {
+      fetchSuggestions(text);
+    }, 500);
+  });
+
+  const handlePublisherSelect = (publisher: Publisher) => {
+    const currentInput = input();
+    const mention = `@${publisher.slug} `;
+    setInput(currentInput + (currentInput.endsWith(" ") ? "" : " ") + mention);
+    setSuggestions([]);
+    inputRef?.focus();
+  };
+
+  const dismissSuggestions = () => {
+    setSuggestions([]);
+    setSuggestionsDismissed(true);
+  };
+
+  // Reset dismissed state when input is cleared
+  createEffect(() => {
+    if (input().length === 0) {
+      setSuggestionsDismissed(false);
+    }
+  });
+
+  const contextPreview = createMemo(() => {
+    if (!editorStore.selectedText) return null;
+    return {
+      text: editorStore.selectedText,
+      file: editorStore.selectedFile,
+      range: editorStore.selectedRange,
+    };
+  });
+
+  // User message history for up/down arrow navigation
+  const userMessageHistory = createMemo(() =>
+    chatStore.messages
+      .filter((m) => m.role === "user")
+      .map((m) => m.content)
+      .reverse(),
+  );
+
+  const buildContext = (): ChatContext | undefined => {
+    if (!editorStore.selectedText) return undefined;
+    return {
+      content: editorStore.selectedText,
+      file: editorStore.selectedFile,
+      range: editorStore.selectedRange ?? undefined,
+    };
+  };
+
+  const sendMessage = async () => {
+    const trimmed = input().trim();
+    if (!trimmed) return;
+
+    const userMessage: Message = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: trimmed,
+      timestamp: Date.now(),
+      model: chatStore.selectedModel,
+      status: "complete",
+    };
+
+    chatStore.addMessage(userMessage);
+    await chatStore.persistMessage(userMessage);
+
+    const context = buildContext();
+    const assistantId = crypto.randomUUID();
+
+    const useTools = areToolsAvailable();
+    const session: ActiveStreamingSession = useTools
+      ? {
+          id: assistantId,
+          userMessageId: userMessage.id,
+          prompt: trimmed,
+          model: chatStore.selectedModel,
+          context,
+          stream: streamMessageWithTools(
+            trimmed,
+            chatStore.selectedModel,
+            context,
+            true,
+            chatStore.messages,
+          ),
+          toolsEnabled: true,
+        }
+      : {
+          id: assistantId,
+          userMessageId: userMessage.id,
+          prompt: trimmed,
+          model: chatStore.selectedModel,
+          context,
+          stream: streamMessage(trimmed, chatStore.selectedModel, context),
+          toolsEnabled: false,
+        };
+
+    chatStore.setLoading(true);
+    setStreamingSession(session);
+    chatStore.setError(null);
+    setInput("");
+    setHistoryIndex(-1);
+    setSavedInput("");
+  };
+
+  const handleStreamingComplete = async (
+    session: ActiveStreamingSession,
+    content: string,
+  ) => {
+    const assistantMessage: Message = {
+      id: session.id,
+      role: "assistant",
+      content,
+      timestamp: Date.now(),
+      model: session.model,
+      status: "complete",
+      request: { prompt: session.prompt, context: session.context },
+    };
+
+    chatStore.addMessage(assistantMessage);
+    await chatStore.persistMessage(assistantMessage);
+    setStreamingSession(null);
+    chatStore.setLoading(false);
+  };
+
+  const handleStreamingError = async (
+    session: ActiveStreamingSession,
+    error: Error,
+  ) => {
+    setStreamingSession(null);
+    chatStore.setLoading(false);
+    chatStore.setError(error.message);
+
+    const failedMessage: Message = {
+      id: session.id,
+      role: "assistant",
+      content: "",
+      timestamp: Date.now(),
+      model: session.model,
+      status: "error",
+      error: error.message,
+      request: { prompt: session.prompt, context: session.context },
+    };
+
+    chatStore.addMessage(failedMessage);
+    await attemptRetry(failedMessage, false);
+  };
+
+  const attemptRetry = async (message: Message, isManual: boolean) => {
+    if (!message.request) return;
+
+    chatStore.setRetrying(message.id);
+    chatStore.updateMessage(message.id, {
+      status: "pending",
+      attemptCount: message.attemptCount ?? 1,
+    });
+
+    try {
+      const content = await sendMessageWithRetry(
+        message.request.prompt,
+        message.model ?? chatStore.selectedModel,
+        message.request.context,
+        (attempt) => {
+          chatStore.updateMessage(message.id, {
+            status: "pending",
+            attemptCount: attempt + 1,
+          });
+        },
+      );
+
+      const updated = {
+        ...message,
+        content,
+        status: "complete" as const,
+        error: null,
+        timestamp: Date.now(),
+      };
+
+      chatStore.updateMessage(message.id, updated);
+      await chatStore.persistMessage(updated);
+    } catch (error) {
+      const messageError = (error as Error).message;
+      chatStore.updateMessage(message.id, {
+        status: "error",
+        error: messageError,
+      });
+      if (isManual) {
+        chatStore.setError(messageError);
+      }
+    } finally {
+      chatStore.setRetrying(null);
+    }
+  };
+
+  const handleManualRetry = async (message: Message) => {
+    await attemptRetry(message, true);
+  };
+
+  const clearHistory = async () => {
+    const confirmClear = window.confirm("Clear all chat history?");
+    if (!confirmClear) return;
+    await chatStore.clearHistory();
+  };
+
+  return (
+    <section class="flex flex-col h-full bg-[#0d1117] text-[#e6edf3] border-l border-[#21262d]">
+      <Show
+        when={authStore.isAuthenticated}
+        fallback={
+          <div class="flex-1 flex flex-col items-center justify-center gap-6 p-6">
+            <div class="text-center max-w-[280px]">
+              <h2 class="m-0 mb-2 text-lg font-semibold text-[#e6edf3]">
+                Sign in to chat
+              </h2>
+              <p class="m-0 text-sm text-[#8b949e] leading-normal">
+                Connect with Seren to access AI-powered conversations.
+              </p>
+            </div>
+            <SignIn onSuccess={() => checkAuth()} />
+          </div>
+        }
+      >
+        <ChatTabBar />
+        <header class="shrink-0 flex justify-between items-center px-3 py-2 border-b border-[#21262d] bg-[#161b22]">
+          <span class="text-xs font-medium text-[#8b949e]">Chat</span>
+          <button
+            type="button"
+            class="bg-transparent border border-[#30363d] text-[#8b949e] px-2 py-1 rounded text-xs cursor-pointer transition-all hover:bg-[#21262d] hover:text-[#e6edf3]"
+            onClick={clearHistory}
+          >
+            Clear
+          </button>
+        </header>
+
+        <div
+          class="flex-1 min-h-0 overflow-y-auto pb-4 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-[#30363d] [&::-webkit-scrollbar-thumb]:rounded"
+          ref={messagesRef}
+        >
+          <Show
+            when={chatStore.messages.length > 0}
+            fallback={
+              <div class="flex-1 flex flex-col items-center justify-center p-6 text-[#8b949e]">
+                <h3 class="m-0 mb-2 text-base font-medium text-[#e6edf3]">
+                  Start a conversation
+                </h3>
+                <p class="m-0 text-sm text-center max-w-[240px]">
+                  Ask questions about code or request help with tasks.
+                </p>
+              </div>
+            }
+          >
+            <For each={chatStore.messages}>
+              {(message) => (
+                <article
+                  class={`px-4 py-3 border-b border-[#21262d] last:border-b-0 ${message.role === "user" ? "bg-[#161b22]" : "bg-transparent"}`}
+                >
+                  <div
+                    class="text-sm leading-relaxed text-[#e6edf3] break-words [&_p]:m-0 [&_p]:mb-2 [&_p:last-child]:mb-0 [&_code]:bg-[#21262d] [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-[#161b22] [&_pre]:border [&_pre]:border-[#30363d] [&_pre]:rounded-lg [&_pre]:p-2 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_a]:text-[#58a6ff]"
+                    innerHTML={
+                      message.role === "assistant"
+                        ? renderMarkdown(message.content)
+                        : escapeHtml(message.content)
+                    }
+                  />
+                  <Show when={message.status === "error"}>
+                    <div class="mt-2 px-2 py-1.5 bg-[rgba(248,81,73,0.1)] border border-[rgba(248,81,73,0.4)] rounded flex items-center gap-2 text-xs text-[#f85149]">
+                      <span>{message.error ?? "Message failed"}</span>
+                      <Show when={chatStore.retryingMessageId === message.id}>
+                        <span>
+                          Retrying (
+                          {Math.min(message.attemptCount ?? 1, CHAT_MAX_RETRIES)}
+                          /{CHAT_MAX_RETRIES})…
+                        </span>
+                      </Show>
+                      <Show when={message.request}>
+                        <button
+                          type="button"
+                          class="bg-transparent border border-[rgba(248,81,73,0.4)] text-[#f85149] px-2 py-0.5 rounded text-xs cursor-pointer hover:bg-[rgba(248,81,73,0.15)]"
+                          onClick={() => handleManualRetry(message)}
+                        >
+                          Retry
+                        </button>
+                      </Show>
+                    </div>
+                  </Show>
+                </article>
+              )}
+            </For>
+          </Show>
+
+          <Show when={streamingSession()}>
+            {(sessionAccessor) => {
+              const session = sessionAccessor();
+              return (
+                <Show
+                  when={session.toolsEnabled}
+                  fallback={
+                    <StreamingMessage
+                      stream={(session as StreamingSession).stream}
+                      onComplete={(content) =>
+                        handleStreamingComplete(session, content)
+                      }
+                      onError={(error) => handleStreamingError(session, error)}
+                      onContentUpdate={scrollToBottom}
+                    />
+                  }
+                >
+                  <ToolStreamingMessage
+                    stream={(session as ToolStreamingSession).stream}
+                    onComplete={(content) =>
+                      handleStreamingComplete(session, content)
+                    }
+                    onError={(error) => handleStreamingError(session, error)}
+                    onContentUpdate={scrollToBottom}
+                  />
+                </Show>
+              );
+            }}
+          </Show>
+        </div>
+
+        <Show when={contextPreview()}>
+          {(ctx) => (
+            <div class="mx-3 my-2 bg-[#161b22] border border-[#30363d] rounded-lg overflow-hidden">
+              <div class="flex justify-between items-center px-2 py-1.5 bg-[#21262d] text-xs text-[#8b949e]">
+                <span>
+                  Context from {ctx().file ?? "selection"}
+                  {ctx().range &&
+                    ` (${ctx().range?.startLine}-${ctx().range?.endLine})`}
+                </span>
+                <button
+                  type="button"
+                  class="bg-transparent border-none text-[#8b949e] cursor-pointer px-1 py-0.5 text-sm leading-none hover:text-[#e6edf3]"
+                  onClick={() => editorStore.clearSelection()}
+                >
+                  ×
+                </button>
+              </div>
+              <pre class="m-0 p-2 max-h-[80px] overflow-y-auto text-xs leading-normal bg-transparent">
+                {ctx().text}
+              </pre>
+            </div>
+          )}
+        </Show>
+
+        <div class="shrink-0 p-3 border-t border-[#21262d] bg-[#161b22]">
+          <form
+            class="flex flex-col gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              sendMessage();
+            }}
+          >
+            <PublisherSuggestions
+              suggestions={suggestions()}
+              isLoading={suggestionsLoading()}
+              onSelect={handlePublisherSelect}
+              onDismiss={dismissSuggestions}
+            />
+            <textarea
+              ref={inputRef}
+              value={input()}
+              placeholder="Ask Seren anything…"
+              class="w-full min-h-[60px] max-h-[150px] resize-none bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-2 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58] disabled:opacity-60"
+              onInput={(event) => {
+                setInput(event.currentTarget.value);
+                if (historyIndex() !== -1) {
+                  setHistoryIndex(-1);
+                  setSavedInput("");
+                }
+              }}
+              onKeyDown={(event) => {
+                const history = userMessageHistory();
+
+                // Up arrow: navigate to older message
+                if (event.key === "ArrowUp" && history.length > 0) {
+                  const textarea = event.currentTarget;
+                  if (textarea.selectionStart === 0 || input() === "") {
+                    event.preventDefault();
+
+                    if (historyIndex() === -1) {
+                      setSavedInput(input());
+                    }
+
+                    const newIndex = Math.min(
+                      historyIndex() + 1,
+                      history.length - 1,
+                    );
+                    setHistoryIndex(newIndex);
+                    setInput(history[newIndex]);
+                  }
+                }
+
+                // Down arrow: navigate to newer message
+                if (event.key === "ArrowDown" && historyIndex() >= 0) {
+                  const textarea = event.currentTarget;
+                  if (textarea.selectionStart === textarea.value.length) {
+                    event.preventDefault();
+
+                    const newIndex = historyIndex() - 1;
+                    setHistoryIndex(newIndex);
+
+                    if (newIndex < 0) {
+                      setInput(savedInput());
+                      setSavedInput("");
+                    } else {
+                      setInput(history[newIndex]);
+                    }
+                  }
+                }
+
+                // Enter key handling
+                if (event.key === "Enter") {
+                  const enterToSend = settingsStore.get("chatEnterToSend");
+                  if (enterToSend) {
+                    if (!event.shiftKey) {
+                      event.preventDefault();
+                      sendMessage();
+                    }
+                  } else {
+                    if (event.metaKey || event.ctrlKey) {
+                      event.preventDefault();
+                      sendMessage();
+                    }
+                  }
+                }
+              }}
+              disabled={chatStore.isLoading}
+            />
+            <div class="flex justify-between items-center">
+              <div class="flex items-center gap-2">
+                <ModelSelector />
+                <span class="text-[10px] text-[#484f58]">
+                  {settingsStore.get("chatEnterToSend")
+                    ? "Enter to send"
+                    : "Ctrl+Enter"}
+                </span>
+              </div>
+              <button
+                type="submit"
+                class="bg-[#238636] text-white border-none px-3 py-1 rounded text-xs font-medium cursor-pointer transition-colors hover:bg-[#2ea043] disabled:bg-[#21262d] disabled:text-[#484f58]"
+                disabled={chatStore.isLoading}
+              >
+                Send
+              </button>
+            </div>
+          </form>
+        </div>
+      </Show>
+    </section>
+  );
+};

--- a/src/components/common/ResizableLayout.css
+++ b/src/components/common/ResizableLayout.css
@@ -1,0 +1,88 @@
+/* ABOUTME: Styles for the three-column resizable layout component. */
+/* ABOUTME: Handles separator appearance, cursor states, and drag feedback. */
+
+.resizable-layout {
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+.resizable-layout--dragging {
+  cursor: col-resize;
+  user-select: none;
+}
+
+.resizable-layout__left {
+  flex-shrink: 0;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.resizable-layout__center {
+  flex: 1;
+  min-width: 200px;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.resizable-layout__right {
+  flex-shrink: 0;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.resizable-layout__separator {
+  width: 4px;
+  flex-shrink: 0;
+  cursor: col-resize;
+  background-color: transparent;
+  transition: background-color 0.15s ease;
+  position: relative;
+}
+
+/* Larger hit area for easier grabbing */
+.resizable-layout__separator::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -4px;
+  right: -4px;
+  z-index: 1;
+}
+
+.resizable-layout__separator:hover {
+  background-color: var(--accent, #6366f1);
+}
+
+.resizable-layout__separator--active {
+  background-color: var(--accent, #6366f1);
+}
+
+/* Visual indicator line in the center of the separator */
+.resizable-layout__separator::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 2px;
+  height: 24px;
+  background-color: var(--muted-foreground, #8b949e);
+  border-radius: 1px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.resizable-layout__separator:hover::after,
+.resizable-layout__separator--active::after {
+  opacity: 1;
+}

--- a/src/components/common/ResizableLayout.tsx
+++ b/src/components/common/ResizableLayout.tsx
@@ -1,0 +1,155 @@
+// ABOUTME: Three-column resizable layout with draggable separators.
+// ABOUTME: Provides Cursor-style layout: FileTree | Editor | Chat.
+
+import { createSignal, onCleanup, onMount, type ParentComponent } from "solid-js";
+
+export interface ResizableLayoutProps {
+  /** Initial width of the left panel in pixels */
+  leftWidth?: number;
+  /** Initial width of the right panel in pixels */
+  rightWidth?: number;
+  /** Minimum width of the left panel */
+  leftMinWidth?: number;
+  /** Maximum width of the left panel */
+  leftMaxWidth?: number;
+  /** Minimum width of the right panel */
+  rightMinWidth?: number;
+  /** Maximum width of the right panel */
+  rightMaxWidth?: number;
+  /** Content for the left panel (FileTree) */
+  left: import("solid-js").JSX.Element;
+  /** Content for the center panel (Editor) */
+  center: import("solid-js").JSX.Element;
+  /** Content for the right panel (Chat) */
+  right: import("solid-js").JSX.Element;
+}
+
+const STORAGE_KEY = "resizable-layout-widths";
+
+interface StoredWidths {
+  left: number;
+  right: number;
+}
+
+function loadStoredWidths(): StoredWidths | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored) as StoredWidths;
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return null;
+}
+
+function saveWidths(widths: StoredWidths): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(widths));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export const ResizableLayout: ParentComponent<ResizableLayoutProps> = (props) => {
+  const stored = loadStoredWidths();
+  const [leftWidth, setLeftWidth] = createSignal(stored?.left ?? props.leftWidth ?? 240);
+  const [rightWidth, setRightWidth] = createSignal(stored?.right ?? props.rightWidth ?? 400);
+  const [isDraggingLeft, setIsDraggingLeft] = createSignal(false);
+  const [isDraggingRight, setIsDraggingRight] = createSignal(false);
+
+  const leftMinWidth = props.leftMinWidth ?? 180;
+  const leftMaxWidth = props.leftMaxWidth ?? 500;
+  const rightMinWidth = props.rightMinWidth ?? 280;
+  const rightMaxWidth = props.rightMaxWidth ?? 800;
+
+  let containerRef: HTMLDivElement | undefined;
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (!containerRef) return;
+
+    const rect = containerRef.getBoundingClientRect();
+
+    if (isDraggingLeft()) {
+      const newWidth = e.clientX - rect.left;
+      const clamped = Math.max(leftMinWidth, Math.min(leftMaxWidth, newWidth));
+      setLeftWidth(clamped);
+    }
+
+    if (isDraggingRight()) {
+      const newWidth = rect.right - e.clientX;
+      const clamped = Math.max(rightMinWidth, Math.min(rightMaxWidth, newWidth));
+      setRightWidth(clamped);
+    }
+  };
+
+  const handleMouseUp = () => {
+    if (isDraggingLeft() || isDraggingRight()) {
+      // Save widths when drag ends
+      saveWidths({ left: leftWidth(), right: rightWidth() });
+    }
+    setIsDraggingLeft(false);
+    setIsDraggingRight(false);
+  };
+
+  onMount(() => {
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener("mousemove", handleMouseMove);
+    document.removeEventListener("mouseup", handleMouseUp);
+  });
+
+  return (
+    <div
+      ref={containerRef}
+      class="resizable-layout"
+      classList={{
+        "resizable-layout--dragging": isDraggingLeft() || isDraggingRight(),
+      }}
+    >
+      {/* Left Panel (FileTree) */}
+      <div
+        class="resizable-layout__left"
+        style={{ width: `${leftWidth()}px` }}
+      >
+        {props.left}
+      </div>
+
+      {/* Left Separator */}
+      <div
+        class="resizable-layout__separator"
+        classList={{ "resizable-layout__separator--active": isDraggingLeft() }}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          setIsDraggingLeft(true);
+        }}
+      />
+
+      {/* Center Panel (Editor) */}
+      <div class="resizable-layout__center">
+        {props.center}
+      </div>
+
+      {/* Right Separator */}
+      <div
+        class="resizable-layout__separator"
+        classList={{ "resizable-layout__separator--active": isDraggingRight() }}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          setIsDraggingRight(true);
+        }}
+      />
+
+      {/* Right Panel (Chat) */}
+      <div
+        class="resizable-layout__right"
+        style={{ width: `${rightWidth()}px` }}
+      >
+        {props.right}
+      </div>
+    </div>
+  );
+};

--- a/src/components/editor/EditorContent.tsx
+++ b/src/components/editor/EditorContent.tsx
@@ -1,0 +1,168 @@
+// ABOUTME: Editor content panel without file tree for resizable layout.
+// ABOUTME: Shows file tabs, Monaco editor, and file viewers.
+
+import {
+  type Component,
+  createEffect,
+  createMemo,
+  createSignal,
+  Show,
+} from "solid-js";
+import { setSelectedPath } from "@/stores/fileTree";
+import {
+  getActiveTab,
+  setTabDirty,
+  tabsState,
+  updateTabContent,
+} from "@/stores/tabs";
+import { saveTab } from "@/lib/files/service";
+import { FileTabs } from "./FileTabs";
+import { ImageViewer } from "./ImageViewer";
+import { MarkdownPreview } from "./MarkdownPreview";
+import { MonacoEditor } from "./MonacoEditor";
+import { PdfViewer } from "./PdfViewer";
+
+export const EditorContent: Component = () => {
+  const [editorContent, setEditorContent] = createSignal("");
+  const [activeFilePath, setActiveFilePath] = createSignal<string | null>(null);
+  const [showPreview, setShowPreview] = createSignal(false);
+
+  // Check if current file is markdown
+  const isMarkdownFile = createMemo(() => {
+    const path = activeFilePath();
+    if (!path) return false;
+    return (
+      path.toLowerCase().endsWith(".md") ||
+      path.toLowerCase().endsWith(".markdown")
+    );
+  });
+
+  // Check if current file is an image
+  const isImageFile = createMemo(() => {
+    const path = activeFilePath();
+    if (!path) return false;
+    const ext = path.toLowerCase().split(".").pop();
+    return ["png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "ico"].includes(
+      ext || "",
+    );
+  });
+
+  // Check if current file is a PDF
+  const isPdfFile = createMemo(() => {
+    const path = activeFilePath();
+    if (!path) return false;
+    return path.toLowerCase().endsWith(".pdf");
+  });
+
+  // Sync editor content with active tab
+  createEffect(() => {
+    const activeId = tabsState.activeTabId;
+    const activeTab = tabsState.tabs.find((tab) => tab.id === activeId);
+    if (activeTab) {
+      setActiveFilePath(activeTab.filePath);
+      setEditorContent(activeTab.content);
+      setSelectedPath(activeTab.filePath);
+    } else {
+      setActiveFilePath(null);
+      setEditorContent("");
+    }
+  });
+
+  function handleEditorChange(value: string) {
+    const activeTab = getActiveTab();
+    if (!activeTab) return;
+    updateTabContent(activeTab.id, value);
+    setEditorContent(value);
+  }
+
+  async function handleEditorDirtyChange(isDirty: boolean) {
+    const activeTab = getActiveTab();
+    if (activeTab) {
+      setTabDirty(activeTab.id, isDirty);
+    }
+  }
+
+  async function handleSave() {
+    const activeTab = getActiveTab();
+    if (!activeTab) return;
+    try {
+      await saveTab(activeTab.id, activeTab.filePath, activeTab.content);
+    } catch (error) {
+      console.error("Failed to save file:", error);
+    }
+  }
+
+  // Handle Cmd/Ctrl+S to save
+  function handleKeyDown(e: KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+      e.preventDefault();
+      handleSave();
+    }
+  }
+
+  return (
+    <div class="flex flex-col h-full bg-card text-foreground" onKeyDown={handleKeyDown}>
+      <div class="shrink-0 border-b border-[rgba(148,163,184,0.15)]">
+        <FileTabs
+          isMarkdown={isMarkdownFile()}
+          showPreview={showPreview()}
+          onTogglePreview={() => setShowPreview((prev) => !prev)}
+        />
+      </div>
+      <div
+        class={`flex-1 min-h-0 relative flex ${showPreview() && isMarkdownFile() ? "flex-row" : ""}`}
+      >
+        <Show
+          when={activeFilePath()}
+          fallback={
+            <div class="h-full flex items-center justify-center p-6">
+              <div class="text-center max-w-[320px]">
+                <span class="text-5xl block mb-4 opacity-60">📝</span>
+                <h2 class="m-0 mb-2 text-xl font-medium text-foreground">
+                  No file open
+                </h2>
+                <p class="m-0 mb-5 text-muted-foreground leading-normal">
+                  Select a file from the explorer, or use{" "}
+                  <kbd class="bg-[rgba(148,163,184,0.2)] px-1.5 py-0.5 rounded font-inherit text-[0.9em]">
+                    {navigator.platform.includes("Mac") ? "⌘" : "Ctrl"}+O
+                  </kbd>{" "}
+                  to open a file.
+                </p>
+              </div>
+            </div>
+          }
+        >
+          {(filePath) => (
+            <Show
+              when={isImageFile()}
+              fallback={
+                <Show
+                  when={isPdfFile()}
+                  fallback={
+                    <>
+                      <div class="flex-1 min-w-0 h-full">
+                        <MonacoEditor
+                          filePath={filePath()}
+                          value={editorContent()}
+                          onChange={handleEditorChange}
+                          onDirtyChange={handleEditorDirtyChange}
+                        />
+                      </div>
+                      <Show when={showPreview() && isMarkdownFile()}>
+                        <MarkdownPreview content={editorContent()} />
+                      </Show>
+                    </>
+                  }
+                >
+                  <PdfViewer filePath={filePath()} />
+                </Show>
+              }
+            >
+              <ImageViewer filePath={filePath()} />
+            </Show>
+          )}
+        </Show>
+      </div>
+    </div>
+  );
+};

--- a/src/components/sidebar/FileExplorer.tsx
+++ b/src/components/sidebar/FileExplorer.tsx
@@ -1,0 +1,95 @@
+// ABOUTME: Shared file explorer sidebar for the resizable layout.
+// ABOUTME: Provides folder opening and file tree navigation.
+
+import { type Component, createSignal } from "solid-js";
+import {
+  loadDirectoryChildren,
+  openFileInTab,
+  openFolder,
+} from "@/lib/files/service";
+import { fileTreeState, setNodes } from "@/stores/fileTree";
+import { FileTree } from "./FileTree";
+
+/**
+ * Recursively update children for a node in the tree.
+ */
+function updateNodeChildren(
+  nodes: typeof fileTreeState.nodes,
+  path: string,
+  children: typeof fileTreeState.nodes,
+): typeof fileTreeState.nodes {
+  return nodes.map((node) => {
+    if (node.path === path) {
+      return { ...node, children };
+    }
+    if (node.children) {
+      return {
+        ...node,
+        children: updateNodeChildren(node.children, path, children),
+      };
+    }
+    return node;
+  });
+}
+
+export const FileExplorer: Component = () => {
+  const [isLoading, setIsLoading] = createSignal(false);
+
+  const handleOpenFolder = async () => {
+    setIsLoading(true);
+    try {
+      await openFolder();
+    } catch (error) {
+      console.error("Failed to open folder:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleFileSelect = async (path: string) => {
+    try {
+      await openFileInTab(path);
+    } catch (error) {
+      console.error("Failed to open file:", error);
+    }
+  };
+
+  const handleDirectoryToggle = async (path: string, expanded: boolean) => {
+    if (expanded) {
+      try {
+        const children = await loadDirectoryChildren(path);
+        const updatedNodes = updateNodeChildren(
+          fileTreeState.nodes,
+          path,
+          children,
+        );
+        setNodes(updatedNodes);
+      } catch (error) {
+        console.error("Failed to load directory:", error);
+      }
+    }
+  };
+
+  return (
+    <aside class="flex flex-col h-full bg-[#161b22] border-r border-[#21262d]">
+      <div class="flex justify-between items-center px-3 py-2.5 border-b border-[#21262d] text-[11px] font-semibold uppercase tracking-wide text-[#8b949e]">
+        <span>Explorer</span>
+        <button
+          type="button"
+          onClick={handleOpenFolder}
+          disabled={isLoading()}
+          title="Open Folder"
+          class="bg-transparent border-none text-[#8b949e] cursor-pointer px-1 py-0.5 text-sm leading-none transition-colors hover:text-[#e6edf3] disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isLoading() ? "..." : "+"}
+        </button>
+      </div>
+      <div class="flex-1 overflow-y-auto py-1">
+        <FileTree
+          onFileSelect={handleFileSelect}
+          onDirectoryToggle={handleDirectoryToggle}
+        />
+      </div>
+    </aside>
+  );
+};


### PR DESCRIPTION
## Summary
- Implements Cursor-style three-column layout: FileTree | Editor | Chat
- All panels are always visible with draggable resizable separators
- Panel widths persist across sessions via localStorage

## Issues Closed
- Closes #155 - Chat panel is now always visible as the right column
- Closes #156 - Files open in center editor, visible alongside chat
- Closes #157 - Draggable vertical separators between all three columns

## Changes
- **ResizableLayout** - New component with draggable separators and width persistence
- **FileExplorer** - Shared file tree component for left column
- **EditorContent** - Editor panel without built-in file tree
- **ChatContent** - Chat panel without built-in file tree
- **App.tsx** - Updated to use three-column layout with overlay panels for settings/catalog/database/account

## Test plan
- [ ] Verify three-column layout renders on startup
- [ ] Verify left separator resizes FileTree and Editor
- [ ] Verify right separator resizes Editor and Chat
- [ ] Verify panel widths persist after app restart
- [ ] Verify overlay panels (Settings, Catalog, Database, Account) open correctly
- [ ] Verify files open in center editor when clicked in FileTree
- [ ] Verify chat functionality works in right panel

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com