### PR TITLE
fix(chat): prevent input disabled after HMR during streaming

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -179,6 +179,13 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
 
   onMount(async () => {
     console.log("[ChatContent] Mounting, chatStore.isLoading:", chatStore.isLoading);
+
+    // Reset orphaned loading state from HMR interruption
+    if (chatStore.isLoading && !streamingSession()) {
+      console.log("[ChatContent] Resetting orphaned loading state from HMR");
+      chatStore.setLoading(false);
+    }
+
     document.addEventListener("keydown", handleKeyDown);
 
     // Register copy button handler (event delegation)
@@ -206,6 +213,13 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
   onCleanup(() => {
     document.removeEventListener("keydown", handleKeyDown);
     messagesRef?.removeEventListener("click", handleCopyClick);
+
+    // Reset loading state if still active when unmounting (e.g., HMR)
+    if (chatStore.isLoading) {
+      console.log("[ChatContent] Cleaning up loading state on unmount");
+      chatStore.setLoading(false);
+    }
+
     if (suggestionDebounceTimer) {
       clearTimeout(suggestionDebounceTimer);
     }


### PR DESCRIPTION
## Problem

When HMR triggers during an active streaming session, the chat input becomes permanently disabled. This happens because:

1. Streaming starts → `chatStore.isLoading` set to `true` → textarea `disabled={true}`
2. HMR hot reload → component unmounts and remounts
3. Streaming completion handlers never execute (orphaned state)
4. Component remounts with `chatStore.isLoading` still `true`
5. Result: textarea remains disabled permanently

## Solution

Implemented dual protection against orphaned loading state:

### Approach 1: Cleanup on Unmount
Reset loading state when component unmounts (triggered by HMR):
```typescript
onCleanup(() => {
  if (chatStore.isLoading) {
    chatStore.setLoading(false);
  }
});
```

### Approach 2: Recovery on Mount
Detect and fix orphaned state when mounting:
```typescript
onMount(() => {
  if (chatStore.isLoading && !streamingSession()) {
    chatStore.setLoading(false);
  }
});
```

## Testing

1. Start a streaming message
2. Trigger HMR by saving a file
3. Verify textarea remains enabled after HMR completes
4. Verify normal streaming still works correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com