### PR TITLE
feat(chat): Add Chain of Thought toggle for AI responses

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -38,6 +38,8 @@ import { ChatTabBar } from "./ChatTabBar";
 import { ModelSelector } from "./ModelSelector";
 import { PublisherSuggestions } from "./PublisherSuggestions";
 import { StreamingMessage } from "./StreamingMessage";
+import { ThinkingBlock } from "./ThinkingBlock";
+import { ThinkingToggle } from "./ThinkingToggle";
 import { ToolStreamingMessage } from "./ToolStreamingMessage";
 import "highlight.js/styles/github-dark.css";
 
@@ -413,11 +415,13 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
   const handleStreamingComplete = async (
     session: ActiveStreamingSession,
     content: string,
+    thinking?: string,
   ) => {
     const assistantMessage: Message = {
       id: session.id,
       role: "assistant",
       content,
+      thinking,
       timestamp: Date.now(),
       model: session.model,
       status: "complete",
@@ -558,6 +562,7 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
               {/* Model selector in input area, tab bar above */}
             </div>
             <div class="flex gap-2 items-center">
+              <ThinkingToggle />
               <button
                 type="button"
                 class="bg-transparent border border-[#30363d] text-[#8b949e] px-3 py-1 rounded-md text-xs cursor-pointer transition-all hover:bg-[#21262d] hover:text-[#e6edf3] hover:border-[#484f58]"
@@ -591,6 +596,15 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
                   <article
                     class={`px-5 py-4 border-b border-[#21262d] last:border-b-0 ${message.role === "user" ? "bg-[#161b22]" : "bg-transparent"}`}
                   >
+                    <Show
+                      when={
+                        message.role === "assistant" &&
+                        message.thinking &&
+                        settingsStore.get("chatShowThinking")
+                      }
+                    >
+                      <ThinkingBlock thinking={message.thinking ?? ""} />
+                    </Show>
                     <div
                       class="text-sm leading-relaxed text-[#e6edf3] break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_code]:bg-[#21262d] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-[#161b22] [&_pre]:border [&_pre]:border-[#30363d] [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-[#30363d] [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-[#8b949e] [&_a]:text-[#58a6ff] [&_a]:no-underline [&_a:hover]:underline"
                       innerHTML={
@@ -650,8 +664,8 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
                   >
                     <ToolStreamingMessage
                       stream={(session as ToolStreamingSession).stream}
-                      onComplete={(content) =>
-                        handleStreamingComplete(session, content)
+                      onComplete={(content, thinking) =>
+                        handleStreamingComplete(session, content, thinking)
                       }
                       onError={(error) => handleStreamingError(session, error)}
                       onContentUpdate={scrollToBottom}

--- a/src/components/chat/ThinkingBlock.tsx
+++ b/src/components/chat/ThinkingBlock.tsx
@@ -1,0 +1,45 @@
+// ABOUTME: Collapsible thinking/reasoning block for AI responses.
+// ABOUTME: Shows the AI's chain of thought when enabled in settings.
+
+import type { Component } from "solid-js";
+import { createSignal, Show } from "solid-js";
+
+interface ThinkingBlockProps {
+  thinking: string;
+  isStreaming?: boolean;
+}
+
+export const ThinkingBlock: Component<ThinkingBlockProps> = (props) => {
+  const [isExpanded, setIsExpanded] = createSignal(false);
+
+  return (
+    <div class="mb-3 border border-[#30363d] rounded-lg overflow-hidden bg-[#161b22]">
+      <button
+        type="button"
+        class="w-full flex items-center gap-2 px-3 py-2 bg-[#21262d] text-[#8b949e] text-xs font-medium cursor-pointer hover:bg-[#30363d] transition-colors border-none text-left"
+        onClick={() => setIsExpanded(!isExpanded())}
+      >
+        <svg
+          class={`w-3 h-3 transition-transform ${isExpanded() ? "rotate-90" : ""}`}
+          fill="currentColor"
+          viewBox="0 0 16 16"
+          aria-hidden="true"
+        >
+          <path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z" />
+        </svg>
+        <span>Thinking</span>
+        <Show when={props.isStreaming}>
+          <span class="inline-block w-1.5 h-1.5 bg-[#58a6ff] rounded-full animate-pulse" />
+        </Show>
+      </button>
+      <Show when={isExpanded()}>
+        <div class="px-3 py-2 text-xs text-[#8b949e] leading-relaxed whitespace-pre-wrap max-h-[300px] overflow-y-auto">
+          {props.thinking}
+          <Show when={props.isStreaming}>
+            <span class="inline-block w-0.5 h-[1em] bg-[#58a6ff] ml-0.5 align-text-bottom animate-[blink_1s_step-end_infinite]" />
+          </Show>
+        </div>
+      </Show>
+    </div>
+  );
+};

--- a/src/components/chat/ThinkingToggle.tsx
+++ b/src/components/chat/ThinkingToggle.tsx
@@ -1,0 +1,42 @@
+// ABOUTME: Toggle switch for enabling/disabling Chain of Thought display.
+// ABOUTME: Persists user preference via settings store.
+
+import type { Component } from "solid-js";
+import { settingsStore } from "@/stores/settings.store";
+
+export const ThinkingToggle: Component = () => {
+  const isEnabled = () => settingsStore.get("chatShowThinking");
+
+  const toggle = () => {
+    settingsStore.set("chatShowThinking", !isEnabled());
+  };
+
+  return (
+    <button
+      type="button"
+      class={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors border ${
+        isEnabled()
+          ? "bg-[#238636]/20 border-[#238636] text-[#3fb950]"
+          : "bg-transparent border-[#30363d] text-[#8b949e] hover:border-[#484f58] hover:text-[#e6edf3]"
+      }`}
+      onClick={toggle}
+      title={isEnabled() ? "Hide AI thinking" : "Show AI thinking"}
+    >
+      <svg
+        class="w-3.5 h-3.5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+        />
+      </svg>
+      <span>Thinking</span>
+    </button>
+  );
+};

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -33,6 +33,7 @@ export interface Message {
   id: string;
   role: ChatRole;
   content: string;
+  thinking?: string;
   model?: string;
   timestamp: number;
   status?: "pending" | "streaming" | "complete" | "error";
@@ -139,9 +140,10 @@ const MAX_TOOL_ITERATIONS = 10;
  */
 export type ToolStreamEvent =
   | { type: "content"; content: string }
+  | { type: "thinking"; thinking: string }
   | { type: "tool_calls"; toolCalls: ToolCall[] }
   | { type: "tool_results"; results: ToolResult[] }
-  | { type: "complete"; finalContent: string };
+  | { type: "complete"; finalContent: string; finalThinking?: string };
 
 /**
  * Send a message with tool support enabled.
@@ -214,7 +216,10 @@ export async function* streamMessageWithTools(
 
     // Yield content if present
     if (response.content) {
-      console.log("[streamMessageWithTools] Yielding content:", response.content.substring(0, 100));
+      console.log(
+        "[streamMessageWithTools] Yielding content:",
+        response.content.substring(0, 100),
+      );
       fullContent += response.content;
       yield { type: "content", content: response.content };
     } else {
@@ -224,7 +229,10 @@ export async function* streamMessageWithTools(
     // Check if model wants to call tools
     if (!response.tool_calls || response.tool_calls.length === 0) {
       // No tool calls, we're done
-      console.log("[streamMessageWithTools] No tool_calls, completing with content length:", fullContent.length);
+      console.log(
+        "[streamMessageWithTools] No tool_calls, completing with content length:",
+        fullContent.length,
+      );
       yield { type: "complete", finalContent: fullContent };
       return;
     }

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -32,6 +32,7 @@ export interface Settings {
   chatDefaultModel: string;
   chatMaxHistoryMessages: number;
   chatEnterToSend: boolean;
+  chatShowThinking: boolean;
 
   // Editor settings
   editorFontSize: number;
@@ -76,6 +77,7 @@ const DEFAULT_SETTINGS: Settings = {
   chatDefaultModel: "anthropic/claude-sonnet-4",
   chatMaxHistoryMessages: 50,
   chatEnterToSend: true,
+  chatShowThinking: false,
   // Editor
   editorFontSize: 14,
   editorTabSize: 2,


### PR DESCRIPTION
## Summary
- Add a toggle that allows users to show/hide AI thinking (Chain of Thought) in chat messages
- Similar to Cursor's Thinking toggle for Claude Code

## Changes
- Add chatShowThinking setting to persist user preference
- Add thinking field to Message type for storing reasoning content
- Create ThinkingBlock component - collapsible display of AI reasoning
- Create ThinkingToggle component - toggle button in chat header
- Update ToolStreamEvent to support thinking stream events
- Integrate thinking display into ChatPanel and ToolStreamingMessage

## Test plan
- [ ] Toggle appears in chat header
- [ ] Toggle state persists across sessions
- [ ] Thinking blocks display when toggle is enabled
- [ ] Thinking blocks are hidden when toggle is disabled
- [ ] Collapsing/expanding thinking blocks works correctly

Closes #167

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com