### PR TITLE
feat: auto-compact context management for long conversations

### DIFF
--- a/src/components/chat/CompactedMessage.tsx
+++ b/src/components/chat/CompactedMessage.tsx
@@ -1,0 +1,74 @@
+// ABOUTME: Displays a compacted conversation summary at the top of the chat.
+// ABOUTME: Shows collapsed older messages with expand option for full summary.
+
+import type { Component } from "solid-js";
+import { createSignal, Show } from "solid-js";
+import type { CompactedSummary } from "@/stores/chat.store";
+
+interface CompactedMessageProps {
+  summary: CompactedSummary;
+  onClear?: () => void;
+}
+
+export const CompactedMessage: Component<CompactedMessageProps> = (props) => {
+  const [isExpanded, setIsExpanded] = createSignal(false);
+
+  const formatDate = (timestamp: number): string => {
+    return new Date(timestamp).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  return (
+    <article class="mx-3 my-2 bg-[#1c2128] border border-[#30363d] rounded-lg overflow-hidden">
+      <button
+        type="button"
+        class="w-full flex items-center justify-between px-3 py-2 bg-[#21262d] text-xs text-[#8b949e] cursor-pointer border-none hover:bg-[#30363d] transition-colors"
+        onClick={() => setIsExpanded(!isExpanded())}
+      >
+        <div class="flex items-center gap-2">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            aria-hidden="true"
+            class={`transition-transform ${isExpanded() ? "rotate-90" : ""}`}
+          >
+            <path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z" />
+          </svg>
+          <span class="font-medium text-[#58a6ff]">
+            {props.summary.originalMessageCount} messages compacted
+          </span>
+          <span class="text-[#484f58]">
+            {formatDate(props.summary.compactedAt)}
+          </span>
+        </div>
+        <Show when={props.onClear}>
+          <button
+            type="button"
+            class="bg-transparent border border-[#30363d] text-[#8b949e] px-2 py-0.5 rounded text-xs cursor-pointer hover:bg-[#30363d] hover:text-[#e6edf3] transition-colors"
+            onClick={(e) => {
+              e.stopPropagation();
+              props.onClear?.();
+            }}
+          >
+            Clear
+          </button>
+        </Show>
+      </button>
+
+      <Show when={isExpanded()}>
+        <div class="px-3 py-2 text-sm text-[#e6edf3] leading-relaxed border-t border-[#30363d]">
+          <div class="text-[10px] text-[#484f58] uppercase tracking-wide mb-2">
+            Summary of previous conversation
+          </div>
+          <div class="whitespace-pre-wrap">{props.summary.content}</div>
+        </div>
+      </Show>
+    </article>
+  );
+};

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -217,6 +217,93 @@ export const SettingsPanel: Component = () => {
                 </span>
               </label>
             </div>
+
+            <h4 class="mt-6 mb-3 text-base font-semibold text-muted-foreground border-t border-[rgba(148,163,184,0.15)] pt-5">
+              Auto-Compact
+            </h4>
+            <p class="m-0 mb-4 text-[0.85rem] text-muted-foreground leading-relaxed">
+              Automatically summarize older messages when approaching context
+              limits.
+            </p>
+
+            <div class="flex items-start justify-start gap-4 py-3 border-b border-[rgba(148,163,184,0.1)]">
+              <label class="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={settingsState.app.autoCompactEnabled}
+                  onChange={(e) =>
+                    handleBooleanChange(
+                      "autoCompactEnabled",
+                      e.currentTarget.checked,
+                    )
+                  }
+                  class="w-[18px] h-[18px] mt-0.5 accent-accent cursor-pointer"
+                />
+                <span class="flex flex-col gap-0.5">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Enable Auto-Compact
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Automatically summarize older messages to manage context
+                  </span>
+                </span>
+              </label>
+            </div>
+
+            <Show when={settingsState.app.autoCompactEnabled}>
+              <div class="flex items-start justify-between gap-4 py-3 border-b border-[rgba(148,163,184,0.1)]">
+                <label class="flex flex-col gap-0.5 flex-1">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Compact Threshold
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Trigger compaction when context usage reaches this % of
+                    limit
+                  </span>
+                </label>
+                <input
+                  type="number"
+                  min="50"
+                  max="95"
+                  step="5"
+                  aria-label="Compact threshold percentage"
+                  value={settingsState.app.autoCompactThreshold}
+                  onInput={(e) =>
+                    handleNumberChange(
+                      "autoCompactThreshold",
+                      e.currentTarget.value,
+                    )
+                  }
+                  class="w-[100px] px-3 py-2 bg-[rgba(30,30,30,0.8)] border border-[rgba(148,163,184,0.3)] rounded-md text-foreground text-[0.9rem] text-right focus:outline-none focus:border-accent"
+                />
+              </div>
+
+              <div class="flex items-start justify-between gap-4 py-3 border-b border-[rgba(148,163,184,0.1)]">
+                <label class="flex flex-col gap-0.5 flex-1">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Preserve Messages
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Number of recent messages to keep (not compacted)
+                  </span>
+                </label>
+                <input
+                  type="number"
+                  min="2"
+                  max="50"
+                  step="1"
+                  aria-label="Number of messages to preserve"
+                  value={settingsState.app.autoCompactPreserveMessages}
+                  onInput={(e) =>
+                    handleNumberChange(
+                      "autoCompactPreserveMessages",
+                      e.currentTarget.value,
+                    )
+                  }
+                  class="w-[100px] px-3 py-2 bg-[rgba(30,30,30,0.8)] border border-[rgba(148,163,184,0.3)] rounded-md text-foreground text-[0.9rem] text-right focus:outline-none focus:border-accent"
+                />
+              </div>
+            </Show>
           </section>
         </Show>
 
@@ -884,7 +971,11 @@ export const SettingsPanel: Component = () => {
                           <span class="font-medium text-foreground">
                             {server.name}
                           </span>
-                          <Show when={server.autoConnect && server.name !== "Seren MCP"}>
+                          <Show
+                            when={
+                              server.autoConnect && server.name !== "Seren MCP"
+                            }
+                          >
                             <span class="px-1.5 py-0.5 bg-[rgba(99,102,241,0.2)] rounded text-[0.7rem] text-accent">
                               Auto-connect
                             </span>

--- a/src/lib/token-counter.ts
+++ b/src/lib/token-counter.ts
@@ -1,0 +1,86 @@
+// ABOUTME: Token counting utility for estimating context window usage.
+// ABOUTME: Uses character-based heuristic (4 chars ≈ 1 token) for efficiency.
+
+import type { Message } from "@/services/chat";
+
+/**
+ * Model context limits in tokens.
+ * These are approximate limits for common models.
+ */
+export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  // Claude models
+  "anthropic/claude-sonnet-4": 200000,
+  "anthropic/claude-opus-4": 200000,
+  "anthropic/claude-3-5-sonnet": 200000,
+  "anthropic/claude-3-opus": 200000,
+  "anthropic/claude-3-haiku": 200000,
+  // OpenAI models
+  "openai/gpt-4-turbo": 128000,
+  "openai/gpt-4o": 128000,
+  "openai/gpt-4": 8192,
+  "openai/gpt-3.5-turbo": 16385,
+  // Gemini models
+  "google/gemini-pro": 32760,
+  "google/gemini-1.5-pro": 1000000,
+  // Default for unknown models
+  default: 100000,
+};
+
+/**
+ * Estimate token count for a string.
+ * Uses a simple heuristic: ~4 characters per token on average.
+ * This is a reasonable approximation for English text and code.
+ */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  // Average of ~4 characters per token for English/code
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Estimate token count for a single message.
+ * Includes overhead for message structure (role, formatting).
+ */
+export function estimateMessageTokens(message: Message): number {
+  // Base overhead for message structure (~4 tokens)
+  const overhead = 4;
+  return overhead + estimateTokens(message.content);
+}
+
+/**
+ * Estimate total token count for an array of messages.
+ */
+export function estimateConversationTokens(messages: Message[]): number {
+  return messages.reduce((sum, msg) => sum + estimateMessageTokens(msg), 0);
+}
+
+/**
+ * Get the context limit for a given model.
+ */
+export function getModelContextLimit(model: string): number {
+  return MODEL_CONTEXT_LIMITS[model] ?? MODEL_CONTEXT_LIMITS.default;
+}
+
+/**
+ * Calculate the percentage of context used.
+ */
+export function calculateContextUsage(
+  messages: Message[],
+  model: string,
+): number {
+  const tokens = estimateConversationTokens(messages);
+  const limit = getModelContextLimit(model);
+  return Math.min(100, Math.round((tokens / limit) * 100));
+}
+
+/**
+ * Check if compaction should be triggered based on threshold.
+ */
+export function shouldTriggerCompaction(
+  messages: Message[],
+  model: string,
+  thresholdPercent: number,
+): boolean {
+  const usage = calculateContextUsage(messages, model);
+  return usage >= thresholdPercent;
+}

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -34,6 +34,11 @@ export interface Settings {
   chatEnterToSend: boolean;
   chatShowThinking: boolean;
 
+  // Auto-compact settings
+  autoCompactEnabled: boolean;
+  autoCompactThreshold: number;
+  autoCompactPreserveMessages: number;
+
   // Editor settings
   editorFontSize: number;
   editorTabSize: number;
@@ -78,6 +83,10 @@ const DEFAULT_SETTINGS: Settings = {
   chatMaxHistoryMessages: 50,
   chatEnterToSend: true,
   chatShowThinking: false,
+  // Auto-compact
+  autoCompactEnabled: true,
+  autoCompactThreshold: 80,
+  autoCompactPreserveMessages: 10,
   // Editor
   editorFontSize: 14,
   editorTabSize: 2,


### PR DESCRIPTION
## Summary
- Adds automatic conversation compaction when approaching context limits
- Token counting utility estimates usage with model-specific limits (Claude 200k, GPT-4 128k, etc.)
- Configurable threshold (50-95%) and preserve count (2-50 messages)
- Context usage indicator with color-coded progress bar in chat header
- Manual "Compact" button for on-demand compaction
- CompactedMessage component displays summarized older messages

## Test plan
- [ ] Enable auto-compact in Settings > Chat Settings
- [ ] Send many messages until context usage reaches threshold
- [ ] Verify compaction triggers automatically and shows summary
- [ ] Test manual "Compact" button
- [ ] Verify expand/collapse on CompactedMessage works
- [ ] Verify "Clear" button removes the compacted summary

Closes #169

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com