### PR TITLE
feat(chat): Configurable tool iteration limit with Continue option

### DIFF
--- a/src/components/chat/ToolStreamingMessage.tsx
+++ b/src/components/chat/ToolStreamingMessage.tsx
@@ -6,7 +6,7 @@ import type { Component } from "solid-js";
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import type { ToolCall, ToolResult } from "@/lib/providers/types";
 import { renderMarkdown } from "@/lib/render-markdown";
-import type { ToolStreamEvent } from "@/services/chat";
+import type { ToolIterationState, ToolStreamEvent } from "@/services/chat";
 import { settingsStore } from "@/stores/settings.store";
 import { ThinkingBlock } from "./ThinkingBlock";
 
@@ -15,6 +15,7 @@ interface ToolStreamingMessageProps {
   onComplete: (fullContent: string, thinking?: string) => void;
   onError?: (error: Error) => void;
   onContentUpdate?: () => void;
+  onIterationLimit?: (state: ToolIterationState, iteration: number) => void;
 }
 
 interface ToolExecution {
@@ -94,6 +95,16 @@ export const ToolStreamingMessage: Component<ToolStreamingMessageProps> = (
               setThinking(fullThinking);
             }
             break;
+
+          case "iteration_limit":
+            // Notify parent about the limit being reached
+            props.onIterationLimit?.(
+              event.continueState,
+              event.currentIteration,
+            );
+            // Don't call onComplete - let parent handle continuation
+            setIsStreaming(false);
+            return;
         }
       }
     } catch (error) {

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -194,6 +194,33 @@ export const SettingsPanel: Component = () => {
               />
             </div>
 
+            <div class="flex items-start justify-between gap-4 py-3 border-b border-[rgba(148,163,184,0.1)]">
+              <label class="flex flex-col gap-0.5 flex-1">
+                <span class="text-[0.95rem] font-medium text-foreground">
+                  Max Tool Iterations
+                </span>
+                <span class="text-[0.8rem] text-muted-foreground">
+                  How many times the AI can use tools per message. Higher values
+                  allow more complex tasks but use more credits. Set to 0 for
+                  unlimited (use with caution).
+                </span>
+              </label>
+              <input
+                type="number"
+                min="0"
+                max="50"
+                step="5"
+                value={settingsState.app.chatMaxToolIterations}
+                onInput={(e) =>
+                  handleNumberChange(
+                    "chatMaxToolIterations",
+                    e.currentTarget.value,
+                  )
+                }
+                class="w-[100px] px-3 py-2 bg-[rgba(30,30,30,0.8)] border border-[rgba(148,163,184,0.3)] rounded-md text-foreground text-[0.9rem] text-right focus:outline-none focus:border-accent"
+              />
+            </div>
+
             <div class="flex items-start justify-start gap-4 py-3 border-b border-[rgba(148,163,184,0.1)]">
               <label class="flex items-start gap-3 cursor-pointer">
                 <input

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -33,6 +33,14 @@ export interface Settings {
   chatMaxHistoryMessages: number;
   chatEnterToSend: boolean;
   chatShowThinking: boolean;
+  /**
+   * Maximum tool call iterations per message.
+   * Controls how many times the AI can use tools in a single response.
+   * Higher values allow more complex multi-step tasks but use more credits.
+   * Set to 0 for unlimited (use with caution - may run up costs).
+   * Default: 10. Range: 0-50.
+   */
+  chatMaxToolIterations: number;
 
   // Auto-compact settings
   autoCompactEnabled: boolean;
@@ -83,6 +91,7 @@ const DEFAULT_SETTINGS: Settings = {
   chatMaxHistoryMessages: 50,
   chatEnterToSend: true,
   chatShowThinking: false,
+  chatMaxToolIterations: 10,
   // Auto-compact
   autoCompactEnabled: true,
   autoCompactThreshold: 80,


### PR DESCRIPTION
## Summary
- Replace hardcoded `MAX_TOOL_ITERATIONS = 10` with user-configurable setting
- Add `chatMaxToolIterations` setting in Settings → Chat with explanation
- Show friendly warning UI when iteration limit is reached (instead of just appending terse text)
- Add Continue button to resume the task and Stop Here button to finalize

## Changes
- **settings.store.ts**: Add `chatMaxToolIterations` setting with JSDoc explanation
- **chat.ts**: Add `iteration_limit` event type, `ToolIterationState` interface, and `continueToolIteration()` function
- **ToolStreamingMessage.tsx**: Handle new `iteration_limit` event
- **ChatPanel.tsx**: Show iteration limit warning with Continue/Stop buttons
- **SettingsPanel.tsx**: Add Max Tool Iterations input with explanation

## Test plan
- [ ] Trigger tool iteration limit by running a complex multi-tool task
- [ ] Verify friendly warning appears with Continue and Stop buttons
- [ ] Test Continue button resumes the task
- [ ] Test Stop Here button finalizes with current content
- [ ] Verify setting can be changed in Settings → Chat
- [ ] Test with setting = 0 (unlimited) still works

Closes #174

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com