### PR TITLE
Fix balance warning and add Switch to Free Model button

### DIFF
--- a/src/stores/provider.store.ts
+++ b/src/stores/provider.store.ts
@@ -162,7 +162,7 @@ const DEFAULT_MODELS: Record<ProviderId, ProviderModel[]> = {
 
 const DEFAULT_STATE: ProviderState = {
   activeProvider: "seren",
-  activeModel: "anthropic/claude-sonnet-4",
+  activeModel: "google/gemini-2.5-flash",
   configuredProviders: ["seren"],
   oauthProviders: [],
   providerModels: { ...DEFAULT_MODELS },


### PR DESCRIPTION
## Summary

- **Fix x402 JSON parsing**: The parseBalanceError function was looking for balance info at the wrong path. The x402 payment response has the extra data nested in accepts[0].extra, not extra at the top level.
- **Handle string amounts**: Added parseAmount helper to convert string values like 0.061300 to numbers
- **Add Switch to Free Model button**: Users with insufficient balance can now click a green button to switch to Gemini 2.5 Flash and automatically retry their request
- **Default to free model**: Changed the default startup model to Gemini 2.5 Flash so new users avoid immediate balance errors

Closes #182

## Test plan

- [ ] Trigger a 402 balance error and verify the friendly warning shows (not raw JSON)
- [ ] Verify balance info displays correctly (current balance, required amount, deficit)
- [ ] Click Switch to Free Model and verify it switches to Gemini Flash and retries
- [ ] Click Top Up Wallet and verify checkout flow works
- [ ] Verify new users start with Gemini 2.5 Flash selected

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com