### PR TITLE
feat: Browser-based OAuth for MCP Gateway authentication

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -450,7 +450,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45ceac797eb8a56bdf5ab1fab353072c17d472eab87645ca847afe720db3246d"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -1195,8 +1195,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -1508,8 +1510,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1528,12 +1540,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.114",
 ]
@@ -2153,12 +2189,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -2226,6 +2278,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -3510,6 +3563,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,6 +4113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,6 +4482,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1395947e69c07400ef4d43db0051d6f773c21f647ad8b97382fc01f0204c60"
+dependencies = [
+ "futures",
+ "indexmap 2.13.0",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4862,6 +4947,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a621b37a548ff6ab6292d57841eb25785a7f146d89391a19c9f199414bd13da"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "http",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "reqwest",
+ "rmcp-macros",
+ "schemars 1.2.0",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b79ed92303f9262db79575aa8c3652581668e9d136be6fd0b9ededa78954c95"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5047,7 +5172,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -5072,8 +5197,10 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.0",
  "serde",
  "serde_json",
 ]
@@ -5083,6 +5210,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5333,7 +5472,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -5359,7 +5498,9 @@ dependencies = [
  "lazy_static",
  "notify",
  "rand 0.9.2",
+ "regex",
  "reqwest",
+ "rmcp",
  "rusqlite",
  "serde",
  "serde_json",
@@ -5374,6 +5515,7 @@ dependencies = [
  "tauri-plugin-updater",
  "thiserror 2.0.18",
  "tokio",
+ "urlencoding",
  "uuid",
 ]
 
@@ -5600,6 +5742,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5781,7 +5936,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5870,7 +6025,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6056,7 +6211,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -6151,7 +6306,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6177,7 +6332,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -6412,6 +6567,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -6754,6 +6920,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7035,7 +7207,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -7059,7 +7231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -7115,11 +7287,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -7129,6 +7313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7165,7 +7358,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -7210,6 +7414,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7370,6 +7584,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7598,7 +7821,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,3 +43,11 @@ hex = "0.4"
 rand = "0.9"
 base64 = "0.22"
 reqwest = { version = "0.12", features = ["json"] }
+rmcp = { version = "0.14", features = [
+    "client",
+    "transport-io",                           # stdio for local MCP servers
+    "transport-child-process",                # spawn local MCP processes
+    "transport-streamable-http-client-reqwest" # SSE for mcp.serendb.com
+] }
+urlencoding = "2"
+regex = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,9 +2,11 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
+  "windows": ["main", "mcp-oauth"],
   "permissions": [
     "core:default",
+    "core:webview:allow-create-webview-window",
+    "core:window:default",
     "dialog:default",
     "updater:default",
     {
@@ -18,7 +20,8 @@
     {
       "identifier": "http:default",
       "allow": [
-        { "url": "https://api.serendb.com/**" }
+        { "url": "https://api.serendb.com/**" },
+        { "url": "https://mcp.serendb.com/**" }
       ]
     }
   ]

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1,0 +1,415 @@
+// ABOUTME: OAuth loopback server for browser-based authentication.
+// ABOUTME: Starts a local HTTP server to receive OAuth callbacks from the browser.
+
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// Result of the OAuth callback
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthCallbackResult {
+    pub code: String,
+    pub state: String,
+}
+
+/// Error from the OAuth callback
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthError {
+    pub error: String,
+    pub error_description: Option<String>,
+}
+
+/// Start OAuth flow result
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthFlowResult {
+    /// The port the callback server is listening on
+    pub port: u16,
+    /// The full redirect URI to use
+    pub redirect_uri: String,
+}
+
+/// HTML page shown after successful OAuth
+const SUCCESS_HTML: &str = r#"<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Authorization Complete</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+            color: #e2e8f0;
+        }
+        .container {
+            text-align: center;
+            padding: 2rem;
+        }
+        .icon {
+            font-size: 4rem;
+            margin-bottom: 1rem;
+            color: #10b981;
+        }
+        h1 {
+            margin-bottom: 0.5rem;
+        }
+        p {
+            color: #94a3b8;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="icon">&#10003;</div>
+        <h1>Authorization Successful</h1>
+        <p>You can close this window and return to Seren Desktop.</p>
+    </div>
+</body>
+</html>"#;
+
+/// HTML page shown after OAuth error
+const ERROR_HTML: &str = r#"<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Authorization Failed</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+            color: #e2e8f0;
+        }
+        .container {
+            text-align: center;
+            padding: 2rem;
+        }
+        .icon {
+            font-size: 4rem;
+            margin-bottom: 1rem;
+            color: #f87171;
+        }
+        h1 {
+            margin-bottom: 0.5rem;
+        }
+        p {
+            color: #94a3b8;
+        }
+        .error {
+            background: rgba(239, 68, 68, 0.1);
+            border: 1px solid rgba(239, 68, 68, 0.3);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-top: 1rem;
+            color: #f87171;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="icon">&#10007;</div>
+        <h1>Authorization Failed</h1>
+        <p>Please close this window and try again in Seren Desktop.</p>
+        <div class="error">{{ERROR}}</div>
+    </div>
+</body>
+</html>"#;
+
+/// Start a loopback server and wait for the OAuth callback.
+/// Returns the authorization code and state, or an error.
+pub fn wait_for_oauth_callback(
+    timeout_secs: u64,
+) -> Result<Result<OAuthCallbackResult, OAuthError>, String> {
+    // Bind to a random available port on localhost
+    let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| format!("Failed to bind: {}", e))?;
+
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("Failed to get local addr: {}", e))?
+        .port();
+
+    println!("[OAuth] Callback server listening on port {}", port);
+
+    // Set a timeout on the listener
+    listener
+        .set_nonblocking(false)
+        .map_err(|e| format!("Failed to set blocking: {}", e))?;
+
+    // Use a channel to receive the result with timeout
+    let (tx, rx) = mpsc::channel();
+
+    // Accept one connection
+    std::thread::spawn(move || {
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                let mut buffer = [0; 4096];
+                let bytes_read = stream.read(&mut buffer).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+
+                // Parse the HTTP request to extract the path
+                let first_line = request.lines().next().unwrap_or("");
+                let path = first_line.split_whitespace().nth(1).unwrap_or("/");
+
+                // Parse query parameters
+                let result = if let Some(query_start) = path.find('?') {
+                    let query = &path[query_start + 1..];
+                    parse_oauth_callback(query)
+                } else {
+                    Err(OAuthError {
+                        error: "invalid_request".to_string(),
+                        error_description: Some("No query parameters in callback".to_string()),
+                    })
+                };
+
+                // Send appropriate response
+                let (status, body) = match &result {
+                    Ok(_) => ("200 OK", SUCCESS_HTML.to_string()),
+                    Err(e) => {
+                        let error_msg = if let Some(desc) = &e.error_description {
+                            format!("{}: {}", e.error, desc)
+                        } else {
+                            e.error.clone()
+                        };
+                        (
+                            "400 Bad Request",
+                            ERROR_HTML.replace("{{ERROR}}", &error_msg),
+                        )
+                    }
+                };
+
+                let response = format!(
+                    "HTTP/1.1 {}\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    status,
+                    body.len(),
+                    body
+                );
+
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+
+                let _ = tx.send(result);
+            }
+            Err(e) => {
+                let _ = tx.send(Err(OAuthError {
+                    error: "server_error".to_string(),
+                    error_description: Some(format!("Failed to accept connection: {}", e)),
+                }));
+            }
+        }
+    });
+
+    // Wait for result with timeout
+    match rx.recv_timeout(Duration::from_secs(timeout_secs)) {
+        Ok(result) => Ok(result),
+        Err(mpsc::RecvTimeoutError::Timeout) => Err("OAuth callback timed out".to_string()),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err("OAuth callback server disconnected".to_string())
+        }
+    }
+}
+
+/// Parse OAuth callback query parameters
+fn parse_oauth_callback(query: &str) -> Result<OAuthCallbackResult, OAuthError> {
+    let params: std::collections::HashMap<&str, &str> = query
+        .split('&')
+        .filter_map(|param| {
+            let mut parts = param.splitn(2, '=');
+            Some((parts.next()?, parts.next()?))
+        })
+        .collect();
+
+    // Check for error response
+    if let Some(error) = params.get("error") {
+        return Err(OAuthError {
+            error: urlencoding_decode(error),
+            error_description: params.get("error_description").map(|s| urlencoding_decode(s)),
+        });
+    }
+
+    // Extract code and state
+    let code = params
+        .get("code")
+        .ok_or_else(|| OAuthError {
+            error: "missing_code".to_string(),
+            error_description: Some("Authorization code not found in callback".to_string()),
+        })?
+        .to_string();
+
+    let state = params
+        .get("state")
+        .ok_or_else(|| OAuthError {
+            error: "missing_state".to_string(),
+            error_description: Some("State parameter not found in callback".to_string()),
+        })?
+        .to_string();
+
+    Ok(OAuthCallbackResult {
+        code: urlencoding_decode(&code),
+        state: urlencoding_decode(&state),
+    })
+}
+
+/// Simple URL decoding
+fn urlencoding_decode(s: &str) -> String {
+    let mut result = String::new();
+    let mut chars = s.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '%' {
+            let hex: String = chars.by_ref().take(2).collect();
+            if let Ok(byte) = u8::from_str_radix(&hex, 16) {
+                result.push(byte as char);
+            } else {
+                result.push('%');
+                result.push_str(&hex);
+            }
+        } else if c == '+' {
+            result.push(' ');
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}
+
+/// Get a random available port for the OAuth callback server
+pub fn get_available_port() -> Result<u16, String> {
+    let listener =
+        TcpListener::bind("127.0.0.1:0").map_err(|e| format!("Failed to bind: {}", e))?;
+    listener
+        .local_addr()
+        .map(|addr| addr.port())
+        .map_err(|e| format!("Failed to get port: {}", e))
+}
+
+/// Start a loopback server on a specific port and wait for the OAuth callback.
+/// This is used when the port was already determined during client registration.
+pub fn wait_for_oauth_callback_on_port(
+    port: u16,
+    timeout_secs: u64,
+) -> Result<Result<OAuthCallbackResult, OAuthError>, String> {
+    // Bind to the specific port
+    let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
+        .map_err(|e| format!("Failed to bind to port {}: {}", port, e))?;
+
+    println!("[OAuth] Callback server listening on port {}", port);
+
+    // Set blocking mode
+    listener
+        .set_nonblocking(false)
+        .map_err(|e| format!("Failed to set blocking: {}", e))?;
+
+    // Use a channel to receive the result with timeout
+    let (tx, rx) = mpsc::channel();
+
+    // Accept one connection
+    std::thread::spawn(move || {
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                let mut buffer = [0; 4096];
+                let bytes_read = stream.read(&mut buffer).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+
+                // Parse the HTTP request to extract the path
+                let first_line = request.lines().next().unwrap_or("");
+                let path = first_line.split_whitespace().nth(1).unwrap_or("/");
+
+                // Parse query parameters
+                let result = if let Some(query_start) = path.find('?') {
+                    let query = &path[query_start + 1..];
+                    parse_oauth_callback(query)
+                } else {
+                    Err(OAuthError {
+                        error: "invalid_request".to_string(),
+                        error_description: Some("No query parameters in callback".to_string()),
+                    })
+                };
+
+                // Send appropriate response
+                let (status, body) = match &result {
+                    Ok(_) => ("200 OK", SUCCESS_HTML.to_string()),
+                    Err(e) => {
+                        let error_msg = if let Some(desc) = &e.error_description {
+                            format!("{}: {}", e.error, desc)
+                        } else {
+                            e.error.clone()
+                        };
+                        (
+                            "400 Bad Request",
+                            ERROR_HTML.replace("{{ERROR}}", &error_msg),
+                        )
+                    }
+                };
+
+                let response = format!(
+                    "HTTP/1.1 {}\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    status,
+                    body.len(),
+                    body
+                );
+
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+
+                let _ = tx.send(result);
+            }
+            Err(e) => {
+                let _ = tx.send(Err(OAuthError {
+                    error: "server_error".to_string(),
+                    error_description: Some(format!("Failed to accept connection: {}", e)),
+                }));
+            }
+        }
+    });
+
+    // Wait for result with timeout
+    match rx.recv_timeout(Duration::from_secs(timeout_secs)) {
+        Ok(result) => Ok(result),
+        Err(mpsc::RecvTimeoutError::Timeout) => Err("OAuth callback timed out".to_string()),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err("OAuth callback server disconnected".to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_oauth_callback_success() {
+        let query = "code=abc123&state=xyz789";
+        let result = parse_oauth_callback(query).unwrap();
+        assert_eq!(result.code, "abc123");
+        assert_eq!(result.state, "xyz789");
+    }
+
+    #[test]
+    fn test_parse_oauth_callback_error() {
+        let query = "error=access_denied&error_description=User%20denied%20access";
+        let result = parse_oauth_callback(query).unwrap_err();
+        assert_eq!(result.error, "access_denied");
+        assert_eq!(
+            result.error_description,
+            Some("User denied access".to_string())
+        );
+    }
+
+    #[test]
+    fn test_urlencoding_decode() {
+        assert_eq!(urlencoding_decode("hello%20world"), "hello world");
+        assert_eq!(urlencoding_decode("hello+world"), "hello world");
+        assert_eq!(urlencoding_decode("abc%3D123"), "abc=123");
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { LowBalanceModal } from "@/components/common/LowBalanceWarning";
 import { ResizableLayout } from "@/components/common/ResizableLayout";
 import { StatusBar } from "@/components/common/StatusBar";
 import { EditorContent } from "@/components/editor/EditorContent";
+import { McpOAuthDialog } from "@/components/mcp/McpOAuthDialog";
 import { X402PaymentApproval } from "@/components/mcp/X402PaymentApproval";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { DatabasePanel } from "@/components/sidebar/DatabasePanel";
@@ -30,7 +31,9 @@ import { telemetry } from "@/services/telemetry";
 import {
   authStore,
   checkAuth,
+  dismissMcpOAuth,
   logout,
+  onMcpOAuthComplete,
   setAuthenticated,
 } from "@/stores/auth.store";
 import { autocompleteStore } from "@/stores/autocomplete.store";
@@ -227,6 +230,16 @@ function App() {
         <StatusBar />
         <LowBalanceModal />
         <X402PaymentApproval />
+        {/* MCP OAuth dialog for returning users who need to (re)authenticate */}
+        <McpOAuthDialog
+          isOpen={authStore.isAuthenticated && authStore.needsMcpOAuth}
+          onClose={dismissMcpOAuth}
+          onSuccess={onMcpOAuthComplete}
+          onError={(error) => {
+            console.error("[App] MCP OAuth error:", error);
+            dismissMcpOAuth();
+          }}
+        />
       </div>
     </Show>
   );

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -35,6 +35,7 @@ import { CompactedMessage } from "./CompactedMessage";
 import { ModelSelector } from "./ModelSelector";
 import { PublisherSuggestions } from "./PublisherSuggestions";
 import { StreamingMessage } from "./StreamingMessage";
+import { ThinkingToggle } from "./ThinkingToggle";
 import { ToolStreamingMessage } from "./ToolStreamingMessage";
 import "highlight.js/styles/github-dark.css";
 
@@ -558,6 +559,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
             </Show>
           </div>
           <div class="flex items-center gap-2">
+            <ThinkingToggle />
             <Show
               when={
                 chatStore.messages.length >

--- a/src/components/mcp/McpOAuthDialog.css
+++ b/src/components/mcp/McpOAuthDialog.css
@@ -1,0 +1,159 @@
+/* ABOUTME: Styles for MCP OAuth dialog component. */
+/* ABOUTME: Modal overlay with status indicators for OAuth flow. */
+
+.mcp-oauth-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.mcp-oauth-dialog {
+  background: var(--bg-primary, #1a1a1a);
+  border: 1px solid var(--border-color, #333);
+  border-radius: 12px;
+  width: 400px;
+  max-width: 90vw;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.mcp-oauth-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-color, #333);
+}
+
+.mcp-oauth-dialog-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary, #fff);
+}
+
+.mcp-oauth-dialog-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary, #888);
+  font-size: 24px;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  transition: color 0.2s;
+}
+
+.mcp-oauth-dialog-close:hover {
+  color: var(--text-primary, #fff);
+}
+
+.mcp-oauth-dialog-content {
+  padding: 32px 20px;
+  min-height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mcp-oauth-status {
+  text-align: center;
+}
+
+.mcp-oauth-status p {
+  margin: 8px 0;
+  color: var(--text-primary, #fff);
+}
+
+.mcp-oauth-hint {
+  font-size: 14px;
+  color: var(--text-secondary, #888) !important;
+}
+
+.mcp-oauth-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--border-color, #333);
+  border-top-color: var(--accent-color, #3b82f6);
+  border-radius: 50%;
+  animation: mcp-oauth-spin 0.8s linear infinite;
+  margin: 0 auto 16px;
+}
+
+@keyframes mcp-oauth-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.mcp-oauth-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  margin: 0 auto 16px;
+}
+
+.mcp-oauth-success .mcp-oauth-icon {
+  background: var(--success-bg, #22c55e20);
+  color: var(--success-color, #22c55e);
+}
+
+.mcp-oauth-error .mcp-oauth-icon {
+  background: var(--error-bg, #ef444420);
+  color: var(--error-color, #ef4444);
+}
+
+.mcp-oauth-error-message {
+  font-size: 14px;
+  color: var(--error-color, #ef4444) !important;
+  max-width: 300px;
+  word-break: break-word;
+}
+
+.mcp-oauth-retry {
+  margin-top: 16px;
+  padding: 8px 16px;
+  background: var(--accent-color, #3b82f6);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.2s;
+}
+
+.mcp-oauth-retry:hover {
+  background: var(--accent-hover, #2563eb);
+}
+
+.mcp-oauth-dialog-footer {
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-color, #333);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.mcp-oauth-cancel {
+  padding: 8px 16px;
+  background: transparent;
+  color: var(--text-secondary, #888);
+  border: 1px solid var(--border-color, #333);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.mcp-oauth-cancel:hover {
+  color: var(--text-primary, #fff);
+  border-color: var(--text-secondary, #888);
+}

--- a/src/components/mcp/McpOAuthDialog.tsx
+++ b/src/components/mcp/McpOAuthDialog.tsx
@@ -1,0 +1,148 @@
+// ABOUTME: MCP OAuth dialog component for authenticating with mcp.serendb.com.
+// ABOUTME: Uses browser-based OAuth with loopback server for reliable authentication flow.
+
+import { createEffect, createSignal, Show } from "solid-js";
+import { clearOAuthState, startOAuthBrowserFlow } from "@/services/mcp-oauth";
+import "./McpOAuthDialog.css";
+
+interface McpOAuthDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  onError: (error: Error) => void;
+}
+
+export function McpOAuthDialog(props: McpOAuthDialogProps) {
+  const [status, setStatus] = createSignal<
+    "idle" | "loading" | "authorizing" | "exchanging" | "success" | "error"
+  >("idle");
+  const [errorMessage, setErrorMessage] = createSignal<string | null>(null);
+  let abortController: AbortController | null = null;
+
+  const startAuth = async () => {
+    setStatus("loading");
+    setErrorMessage(null);
+    abortController = new AbortController();
+
+    try {
+      setStatus("authorizing");
+      console.log("[McpOAuthDialog] Starting browser-based OAuth flow...");
+
+      // This opens the browser and waits for the callback
+      await startOAuthBrowserFlow();
+
+      setStatus("success");
+      props.onSuccess();
+    } catch (error) {
+      // Don't show error if cancelled
+      if (abortController?.signal.aborted) {
+        return;
+      }
+
+      console.error("[McpOAuthDialog] OAuth flow failed:", error);
+      setStatus("error");
+      setErrorMessage(
+        error instanceof Error ? error.message : "Authentication failed",
+      );
+      props.onError(
+        error instanceof Error ? error : new Error("Authentication failed"),
+      );
+    }
+  };
+
+  const handleCancel = () => {
+    abortController?.abort();
+    clearOAuthState();
+    setStatus("idle");
+    props.onClose();
+  };
+
+  // Auto-start when dialog opens
+  createEffect(() => {
+    if (props.isOpen && status() === "idle") {
+      startAuth();
+    }
+    if (!props.isOpen && status() !== "idle") {
+      abortController?.abort();
+      setStatus("idle");
+    }
+  });
+
+  return (
+    <Show when={props.isOpen}>
+      <div class="mcp-oauth-dialog-overlay">
+        <div class="mcp-oauth-dialog">
+          <div class="mcp-oauth-dialog-header">
+            <h2>Connect to Seren MCP</h2>
+            <button
+              type="button"
+              class="mcp-oauth-dialog-close"
+              onClick={handleCancel}
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </div>
+
+          <div class="mcp-oauth-dialog-content">
+            <Show when={status() === "loading"}>
+              <div class="mcp-oauth-status">
+                <div class="mcp-oauth-spinner" />
+                <p>Preparing authorization...</p>
+              </div>
+            </Show>
+
+            <Show when={status() === "authorizing"}>
+              <div class="mcp-oauth-status">
+                <div class="mcp-oauth-icon mcp-oauth-icon-info">→</div>
+                <p>Complete authorization in your browser</p>
+                <p class="mcp-oauth-hint">
+                  Your default browser has opened. Sign in there to continue.
+                </p>
+              </div>
+            </Show>
+
+            <Show when={status() === "exchanging"}>
+              <div class="mcp-oauth-status">
+                <div class="mcp-oauth-spinner" />
+                <p>Completing authorization...</p>
+              </div>
+            </Show>
+
+            <Show when={status() === "success"}>
+              <div class="mcp-oauth-status mcp-oauth-success">
+                <div class="mcp-oauth-icon">✓</div>
+                <p>Connected to Seren MCP!</p>
+              </div>
+            </Show>
+
+            <Show when={status() === "error"}>
+              <div class="mcp-oauth-status mcp-oauth-error">
+                <div class="mcp-oauth-icon">!</div>
+                <p>Authorization failed</p>
+                <p class="mcp-oauth-error-message">{errorMessage()}</p>
+                <button
+                  type="button"
+                  class="mcp-oauth-retry"
+                  onClick={startAuth}
+                >
+                  Try Again
+                </button>
+              </div>
+            </Show>
+          </div>
+
+          <div class="mcp-oauth-dialog-footer">
+            <button
+              type="button"
+              class="mcp-oauth-cancel"
+              onClick={handleCancel}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -478,7 +478,10 @@ export async function sendMessageWithTools(
   }
 
   const data = await response.json();
-  console.log("[sendMessageWithTools] Raw API response:", JSON.stringify(data, null, 2));
+  console.log(
+    "[sendMessageWithTools] Raw API response:",
+    JSON.stringify(data, null, 2),
+  );
 
   // Check for wrapped error responses (HTTP 200 but error in body)
   if (data.status && data.status >= 400 && data.body?.error) {

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -1,20 +1,27 @@
-// ABOUTME: MCP Gateway service for fetching tools from Seren publishers via REST API.
-// ABOUTME: Replaces the Node.js bridge with direct HTTP calls to api.serendb.com.
+// ABOUTME: MCP Gateway service for connecting to Seren MCP gateway via MCP protocol.
+// ABOUTME: Uses rmcp HTTP streaming transport to connect to mcp.serendb.com/mcp.
 
-import { appFetch } from "@/lib/fetch";
-import { getApiKey } from "./auth";
+import { mcpClient } from "@/lib/mcp/client";
+import type { McpTool, McpToolResult } from "@/lib/mcp/types";
+import {
+  clearStoredTokens,
+  getValidAccessToken,
+  isMcpAuthenticated,
+} from "./mcp-oauth";
 
-const API_BASE = "https://api.serendb.com";
+const MCP_GATEWAY_URL = "https://mcp.serendb.com/mcp";
+const SEREN_MCP_SERVER_NAME = "seren-gateway";
 
 // Cache configuration
 const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
-// Concurrency limit to avoid overwhelming the backend
-// Set to 3 - loads in background so doesn't block user, but still gentle on backend
-// TODO: Increase when backend is fixed (see serenorg/seren#95)
-const MAX_CONCURRENT_REQUESTS = 3;
+// Types for gateway tools (with publisher info parsed from tool name)
+export interface GatewayTool {
+  publisher: string;
+  publisherName: string;
+  tool: McpToolInfo;
+}
 
-// Types matching the backend API responses
 export interface McpToolInfo {
   name: string;
   description: string;
@@ -33,11 +40,6 @@ export interface McpPropertySchema {
   default?: unknown;
 }
 
-export interface McpToolsResponse {
-  tools: McpToolInfo[];
-  execution_time_ms: number;
-}
-
 export interface McpToolCallResponse {
   result: unknown;
   is_error: boolean;
@@ -54,72 +56,6 @@ export interface Publisher {
   mcp_endpoint?: string;
 }
 
-export interface GatewayTool {
-  publisher: string;
-  publisherName: string;
-  tool: McpToolInfo;
-}
-
-/**
- * Process items with limited concurrency to avoid overwhelming the backend.
- * Uses a simple chunking approach - process N items at a time.
- */
-async function processInBatches<T, R>(
-  items: T[],
-  fn: (item: T) => Promise<R>,
-  batchSize: number,
-): Promise<PromiseSettledResult<R>[]> {
-  const results: PromiseSettledResult<R>[] = [];
-
-  for (let i = 0; i < items.length; i += batchSize) {
-    const batch = items.slice(i, i + batchSize);
-    const batchResults = await Promise.allSettled(batch.map(fn));
-    results.push(...batchResults);
-  }
-
-  return results;
-}
-
-/**
- * Retry wrapper with exponential backoff.
- */
-async function withRetry<T>(
-  fn: () => Promise<T>,
-  options: { maxRetries?: number; initialDelayMs?: number } = {},
-): Promise<T> {
-  const maxRetries = options.maxRetries ?? 3;
-  const initialDelay = options.initialDelayMs ?? 1000;
-  let lastError: Error | null = null;
-  let delay = initialDelay;
-
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-
-      // Don't retry on 4xx errors (client errors)
-      if (
-        error instanceof McpGatewayError &&
-        error.status >= 400 &&
-        error.status < 500
-      ) {
-        throw error;
-      }
-
-      if (attempt < maxRetries) {
-        console.log(
-          `[MCP Gateway] Attempt ${attempt} failed, retrying in ${delay}ms...`,
-        );
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        delay *= 2;
-      }
-    }
-  }
-
-  throw lastError ?? new Error("Request failed after retries");
-}
-
 /**
  * Custom error for MCP Gateway failures.
  */
@@ -134,198 +70,12 @@ export class McpGatewayError extends Error {
   }
 }
 
-/**
- * Make an authenticated request to the MCP Gateway API.
- * Accepts an optional pre-fetched apiKey to avoid redundant auth calls during batch operations.
- */
-async function gatewayFetch<T>(
-  endpoint: string,
-  options: RequestInit = {},
-  apiKey?: string,
-): Promise<T> {
-  const key = apiKey ?? (await getApiKey());
-  if (!key) {
-    throw new McpGatewayError("Not authenticated", 401, endpoint);
-  }
-
-  const url = `${API_BASE}${endpoint}`;
-  const response = await appFetch(url, {
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${key}`,
-      ...options.headers,
-    },
-  });
-
-  if (!response.ok) {
-    const errorBody = await response.text().catch(() => "");
-    throw new McpGatewayError(
-      `Gateway request failed: ${response.status} ${errorBody}`,
-      response.status,
-      endpoint,
-    );
-  }
-
-  return response.json();
-}
-
-/**
- * Response shape from /agent/publishers (paginated).
- */
-interface PaginatedPublishersResponse {
-  data: Publisher[];
-  pagination: { offset: number; limit: number; total: number };
-}
-
-/**
- * Fetch all active publishers from the gateway (handles pagination).
- * Accepts optional apiKey to avoid redundant auth calls during batch operations.
- */
-export async function fetchGatewayPublishers(
-  apiKey?: string,
-): Promise<Publisher[]> {
-  return withRetry(async () => {
-    const allPublishers: Publisher[] = [];
-    let offset = 0;
-    const limit = 100; // Fetch in batches of 100
-
-    while (true) {
-      const response = await gatewayFetch<PaginatedPublishersResponse>(
-        `/agent/publishers?offset=${offset}&limit=${limit}`,
-        {},
-        apiKey,
-      );
-      allPublishers.push(...response.data);
-
-      // Check if we've fetched all publishers
-      if (
-        response.data.length < limit ||
-        allPublishers.length >= response.pagination.total
-      ) {
-        break;
-      }
-      offset += limit;
-    }
-
-    // Return all active publishers - backend handles routing to databases, APIs, services, and MCP servers
-    return allPublishers.filter((p) => p.is_active);
-  });
-}
-
-/**
- * Fetch tools for a specific publisher.
- * Accepts optional apiKey to avoid redundant auth calls during batch operations.
- */
-export async function fetchPublisherTools(
-  publisherSlug: string,
-  apiKey?: string,
-): Promise<McpToolInfo[]> {
-  return withRetry(async () => {
-    const response = await gatewayFetch<McpToolsResponse>(
-      "/agent/mcp/tools",
-      { method: "POST", body: JSON.stringify({ publisher: publisherSlug }) },
-      apiKey,
-    );
-    return response.tools;
-  });
-}
-
-/**
- * Fetch all tools from all active publishers.
- * Returns tools tagged with their publisher for routing during execution.
- * Fetches the API key once and reuses it for all publisher requests.
- */
-export async function fetchAllGatewayTools(): Promise<GatewayTool[]> {
-  try {
-    // Fetch API key once and reuse for all requests
-    const apiKey = await getApiKey();
-    if (!apiKey) {
-      console.error("[MCP Gateway] Not authenticated - cannot fetch tools");
-      return [];
-    }
-
-    const publishers = await fetchGatewayPublishers(apiKey);
-    console.log(`[MCP Gateway] Found ${publishers.length} active publishers`);
-
-    const allTools: GatewayTool[] = [];
-    const errors: { publisher: string; status: number; message: string }[] = [];
-
-    // Fetch tools in batches to avoid overwhelming the backend
-    const results = await processInBatches(
-      publishers,
-      async (publisher) => {
-        const tools = await fetchPublisherTools(publisher.slug, apiKey);
-        return tools.map((tool) => ({
-          publisher: publisher.slug,
-          publisherName: publisher.name,
-          tool,
-        }));
-      },
-      MAX_CONCURRENT_REQUESTS,
-    );
-
-    for (let i = 0; i < results.length; i++) {
-      const result = results[i];
-      const publisher = publishers[i];
-      if (result.status === "fulfilled") {
-        allTools.push(...result.value);
-      } else {
-        const error = result.reason;
-        if (error instanceof McpGatewayError) {
-          errors.push({
-            publisher: publisher.slug,
-            status: error.status,
-            message: error.message,
-          });
-        } else {
-          errors.push({
-            publisher: publisher.slug,
-            status: 0,
-            message: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
-    }
-
-    // Log error summary for debugging
-    if (errors.length > 0) {
-      console.warn(`[MCP Gateway] ${errors.length} publishers failed`);
-    }
-
-    console.log(`[MCP Gateway] Loaded ${allTools.length} tools total`);
-    return allTools;
-  } catch (error) {
-    console.error("[MCP Gateway] Failed to fetch gateway tools:", error);
-    return [];
-  }
-}
-
-/**
- * Call a tool on a specific publisher.
- */
-export async function callGatewayTool(
-  publisherSlug: string,
-  toolName: string,
-  args: Record<string, unknown>,
-): Promise<McpToolCallResponse> {
-  return withRetry(async () => {
-    return gatewayFetch<McpToolCallResponse>("/api/agent/mcp/call", {
-      method: "POST",
-      body: JSON.stringify({
-        publisher: publisherSlug,
-        tool_name: toolName,
-        arguments: args,
-      }),
-    });
-  });
-}
-
 // Singleton state for caching tools
 let cachedTools: GatewayTool[] = [];
 let cachedPublishers: Publisher[] = [];
 let lastFetchedAt: number | null = null;
 let loadingPromise: Promise<void> | null = null;
+let isConnected = false;
 
 /**
  * Check if the cache is still valid (not expired).
@@ -336,13 +86,53 @@ function isCacheValid(): boolean {
 }
 
 /**
- * Initialize the gateway by loading all tools.
+ * Parse publisher slug from MCP tool name.
+ * Seren MCP tools are named like "mcp__publisher-slug__tool-name"
+ */
+function parsePublisherFromToolName(toolName: string): {
+  publisher: string;
+  originalName: string;
+} {
+  const match = toolName.match(/^mcp__([^_]+)__(.+)$/);
+  if (match) {
+    return { publisher: match[1], originalName: match[2] };
+  }
+  // Fallback for tools without publisher prefix
+  return { publisher: "seren", originalName: toolName };
+}
+
+/**
+ * Convert MCP tool to GatewayTool format.
+ */
+function convertToGatewayTool(tool: McpTool): GatewayTool {
+  const { publisher } = parsePublisherFromToolName(tool.name);
+  return {
+    publisher,
+    publisherName: publisher, // We don't have the display name from MCP
+    tool: {
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema as McpToolInfo["inputSchema"],
+    },
+  };
+}
+
+/**
+ * Check if MCP OAuth authentication is required.
+ * Returns true if user needs to complete OAuth flow.
+ */
+export async function needsMcpAuth(): Promise<boolean> {
+  return !(await isMcpAuthenticated());
+}
+
+/**
+ * Initialize the gateway by connecting to mcp.serendb.com/mcp.
  * Safe to call multiple times - uses cached data if still valid.
- * Fetches the API key once and reuses it for all publisher requests.
+ * Requires MCP OAuth token - call needsMcpAuth() first to check.
  */
 export async function initializeGateway(): Promise<void> {
   // Return cached data if still valid
-  if (isCacheValid()) {
+  if (isCacheValid() && isConnected) {
     console.log("[MCP Gateway] Using cached tools (still valid)");
     return;
   }
@@ -350,87 +140,50 @@ export async function initializeGateway(): Promise<void> {
   if (loadingPromise) return loadingPromise;
 
   loadingPromise = (async () => {
-    console.log("[MCP Gateway] Initializing...");
+    console.log("[MCP Gateway] Initializing via MCP protocol...");
 
-    // Fetch API key once and reuse for all requests
-    const apiKey = await getApiKey();
-    if (!apiKey) {
-      console.error("[MCP Gateway] Not authenticated - cannot initialize");
-      return;
-    }
-    console.log("[MCP Gateway] API key cached for batch requests");
-
-    cachedPublishers = await fetchGatewayPublishers(apiKey);
-    console.log(
-      `[MCP Gateway] Found ${cachedPublishers.length} active publishers`,
-    );
-
-    const allTools: GatewayTool[] = [];
-    const errors: { publisher: string; status: number; message: string }[] = [];
-
-    // Fetch tools in batches to avoid overwhelming the backend
-    const results = await processInBatches(
-      cachedPublishers,
-      async (publisher) => {
-        const tools = await fetchPublisherTools(publisher.slug, apiKey);
-        return tools.map((tool) => ({
-          publisher: publisher.slug,
-          publisherName: publisher.name,
-          tool,
-        }));
-      },
-      MAX_CONCURRENT_REQUESTS,
-    );
-
-    for (let i = 0; i < results.length; i++) {
-      const result = results[i];
-      const publisher = cachedPublishers[i];
-      if (result.status === "fulfilled") {
-        allTools.push(...result.value);
-      } else {
-        const error = result.reason;
-        if (error instanceof McpGatewayError) {
-          errors.push({
-            publisher: publisher.slug,
-            status: error.status,
-            message: error.message,
-          });
-        } else {
-          errors.push({
-            publisher: publisher.slug,
-            status: 0,
-            message: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
-    }
-
-    // Log error summary for debugging
-    if (errors.length > 0) {
-      const byStatus = errors.reduce(
-        (acc, e) => {
-          acc[e.status] = (acc[e.status] || 0) + 1;
-          return acc;
-        },
-        {} as Record<number, number>,
+    // Get MCP OAuth token (not the SerenDB API key)
+    const mcpToken = await getValidAccessToken();
+    if (!mcpToken) {
+      console.error(
+        "[MCP Gateway] No MCP OAuth token - user needs to authenticate",
       );
-      console.warn(
-        `[MCP Gateway] ${errors.length} publishers failed:`,
-        Object.entries(byStatus)
-          .map(([status, count]) => `${status}: ${count}`)
-          .join(", "),
+      throw new McpGatewayError(
+        "MCP authentication required",
+        401,
+        MCP_GATEWAY_URL,
       );
-      errors.slice(0, 3).forEach((e) => {
-        console.warn(`  - ${e.publisher}: ${e.status} ${e.message}`);
-      });
-      if (errors.length > 3) {
-        console.warn(`  ... and ${errors.length - 3} more`);
-      }
     }
 
-    cachedTools = allTools;
-    lastFetchedAt = Date.now();
-    console.log("[MCP Gateway] Initialized with", cachedTools.length, "tools");
+    try {
+      // Connect to Seren MCP Gateway via HTTP streaming transport
+      console.log(`[MCP Gateway] Connecting to ${MCP_GATEWAY_URL}...`);
+      await mcpClient.connectHttp(
+        SEREN_MCP_SERVER_NAME,
+        MCP_GATEWAY_URL,
+        mcpToken,
+      );
+      isConnected = true;
+      console.log("[MCP Gateway] Connected successfully");
+
+      // Get the connection and its tools
+      const connection = mcpClient.getConnection(SEREN_MCP_SERVER_NAME);
+      if (!connection) {
+        throw new Error("Connection not found after connecting");
+      }
+
+      // Convert MCP tools to GatewayTool format
+      cachedTools = connection.tools.map(convertToGatewayTool);
+      lastFetchedAt = Date.now();
+
+      console.log(
+        `[MCP Gateway] Initialized with ${cachedTools.length} tools via MCP protocol`,
+      );
+    } catch (error) {
+      console.error("[MCP Gateway] Failed to connect:", error);
+      isConnected = false;
+      throw error;
+    }
   })();
 
   await loadingPromise;
@@ -449,17 +202,29 @@ export function getGatewayTools(): GatewayTool[] {
  * Check if gateway is initialized with valid cache.
  */
 export function isGatewayInitialized(): boolean {
-  return isCacheValid();
+  return isCacheValid() && isConnected;
 }
 
 /**
  * Reset gateway state (for logout).
+ * Clears MCP OAuth tokens and disconnects.
  */
-export function resetGateway(): void {
+export async function resetGateway(): Promise<void> {
+  // Disconnect from MCP server if connected
+  if (isConnected) {
+    mcpClient.disconnectHttp(SEREN_MCP_SERVER_NAME).catch((error) => {
+      console.error("[MCP Gateway] Error disconnecting:", error);
+    });
+  }
+
+  // Clear MCP OAuth tokens
+  await clearStoredTokens();
+
   cachedTools = [];
   cachedPublishers = [];
   lastFetchedAt = null;
   loadingPromise = null;
+  isConnected = false;
 }
 
 /**
@@ -467,12 +232,14 @@ export function resetGateway(): void {
  */
 export async function refreshGatewayTools(): Promise<GatewayTool[]> {
   lastFetchedAt = null; // Invalidate cache
+  isConnected = false; // Force reconnect
   await initializeGateway();
   return cachedTools;
 }
 
 /**
  * Get cached publishers (available after initialization).
+ * Note: With MCP protocol, publishers are inferred from tool names.
  */
 export function getGatewayPublishers(): Publisher[] {
   return cachedPublishers;
@@ -483,4 +250,61 @@ export function getGatewayPublishers(): Publisher[] {
  */
 export function getCacheAge(): number | null {
   return lastFetchedAt ? Date.now() - lastFetchedAt : null;
+}
+
+/**
+ * Call a tool via the MCP Gateway.
+ */
+export async function callGatewayTool(
+  _publisherSlug: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<McpToolCallResponse> {
+  if (!isConnected) {
+    throw new McpGatewayError(
+      "MCP Gateway not connected",
+      503,
+      MCP_GATEWAY_URL,
+    );
+  }
+
+  const startTime = Date.now();
+
+  try {
+    const result: McpToolResult = await mcpClient.callToolHttp(
+      SEREN_MCP_SERVER_NAME,
+      { name: toolName, arguments: args },
+    );
+
+    const executionTime = Date.now() - startTime;
+
+    return {
+      result: result.content,
+      is_error: result.isError ?? false,
+      execution_time_ms: executionTime,
+      response_bytes: JSON.stringify(result).length,
+    };
+  } catch (error) {
+    const executionTime = Date.now() - startTime;
+    console.error("[MCP Gateway] Tool call failed:", error);
+
+    return {
+      result: error instanceof Error ? error.message : String(error),
+      is_error: true,
+      execution_time_ms: executionTime,
+      response_bytes: 0,
+    };
+  }
+}
+
+// Legacy exports for backward compatibility
+export async function fetchGatewayPublishers(): Promise<Publisher[]> {
+  // With MCP protocol, we don't fetch publishers separately
+  // Publishers are inferred from tool names
+  return cachedPublishers;
+}
+
+export async function fetchAllGatewayTools(): Promise<GatewayTool[]> {
+  await initializeGateway();
+  return cachedTools;
 }

--- a/src/services/mcp-oauth.ts
+++ b/src/services/mcp-oauth.ts
@@ -1,0 +1,655 @@
+// ABOUTME: MCP OAuth2 service for authenticating with mcp.serendb.com.
+// ABOUTME: Implements Dynamic Client Registration and Authorization Code flow with PKCE (S256).
+
+import { invoke } from "@tauri-apps/api/core";
+
+const MCP_OAUTH_BASE = "https://mcp.serendb.com";
+// MCP server uses dynamic client registration
+const MCP_CLIENT_NAME = "Seren Desktop";
+// Use loopback redirect - webviews can intercept HTTP navigations but not custom schemes
+// The MCP server allows any loopback address (127.0.0.1, localhost, [::1])
+const REDIRECT_URI = "http://127.0.0.1/oauth/callback";
+
+// Token storage keys
+const MCP_TOKEN_STORE = "mcp-oauth.json";
+const ACCESS_TOKEN_KEY = "mcp_access_token";
+const REFRESH_TOKEN_KEY = "mcp_refresh_token";
+const TOKEN_EXPIRY_KEY = "mcp_token_expiry";
+const CLIENT_ID_KEY = "mcp_client_id";
+
+/**
+ * OAuth state for tracking authorization flow.
+ */
+interface OAuthState {
+  codeVerifier: string;
+  state: string;
+  nonce: string;
+}
+
+/**
+ * Token response from MCP OAuth server.
+ */
+interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token?: string;
+  scope?: string;
+}
+
+/**
+ * Client registration response from MCP OAuth server.
+ */
+interface ClientRegistrationResponse {
+  client_id: string;
+  client_name: string;
+  redirect_uris: string[];
+  grant_types: string[];
+  response_types: string[];
+  token_endpoint_auth_method: string;
+}
+
+/**
+ * OAuth discovery metadata.
+ */
+interface OAuthMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint?: string;
+  scopes_supported?: string[];
+  response_types_supported?: string[];
+  code_challenge_methods_supported?: string[];
+}
+
+// Current OAuth state (in-memory during flow)
+let currentOAuthState: OAuthState | null = null;
+
+// Cached client ID (loaded from storage on first use)
+let cachedClientId: string | null = null;
+
+/**
+ * Generate a cryptographically secure random string.
+ */
+function generateRandomString(length: number): string {
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+/**
+ * Generate PKCE code verifier (43-128 characters, URL-safe).
+ */
+function generateCodeVerifier(): string {
+  // 32 bytes = 64 hex chars, within the 43-128 range
+  return generateRandomString(32);
+}
+
+/**
+ * Generate PKCE code challenge from verifier using S256.
+ */
+async function generateCodeChallenge(verifier: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+
+  // Base64url encode (no padding)
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(hash)));
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Get or register the OAuth client with the MCP server.
+ * Uses dynamic client registration per RFC 7591.
+ */
+async function getOrRegisterClient(): Promise<string> {
+  // Check cache first
+  if (cachedClientId) {
+    return cachedClientId;
+  }
+
+  // Check stored client ID
+  const storedClientId = await getStoredClientId();
+  if (storedClientId) {
+    cachedClientId = storedClientId;
+    return storedClientId;
+  }
+
+  // Register new client
+  console.log("[MCP OAuth] Registering new OAuth client...");
+  const response = await fetch(`${MCP_OAUTH_BASE}/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      client_name: MCP_CLIENT_NAME,
+      redirect_uris: [REDIRECT_URI],
+      response_types: ["code"],
+      grant_types: ["authorization_code", "refresh_token"],
+      scope: "api",
+      token_endpoint_auth_method: "none",
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Client registration failed: ${response.status} ${error}`);
+  }
+
+  const registration: ClientRegistrationResponse = await response.json();
+  console.log("[MCP OAuth] Client registered:", registration.client_id);
+
+  // Store client ID
+  await storeClientId(registration.client_id);
+  cachedClientId = registration.client_id;
+
+  return registration.client_id;
+}
+
+/**
+ * Fetch OAuth server metadata from well-known endpoint.
+ */
+export async function fetchOAuthMetadata(): Promise<OAuthMetadata> {
+  const response = await fetch(
+    `${MCP_OAUTH_BASE}/.well-known/oauth-authorization-server`,
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to fetch OAuth metadata: ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Start the OAuth authorization flow.
+ * Returns the authorization URL to open in the popup webview.
+ */
+export async function startOAuthFlow(): Promise<{
+  authUrl: string;
+  state: OAuthState;
+}> {
+  // Clear any stale client registration that might have old redirect_uri
+  // This ensures we always use a client registered with the current REDIRECT_URI
+  const storedClientId = await getStoredClientId();
+  if (storedClientId) {
+    console.log(
+      "[MCP OAuth] Clearing stored client_id to ensure fresh registration with current redirect_uri",
+    );
+    cachedClientId = null;
+    await invoke("set_setting", {
+      store: MCP_TOKEN_STORE,
+      key: CLIENT_ID_KEY,
+      value: "",
+    });
+  }
+
+  // Get or register client first
+  const clientId = await getOrRegisterClient();
+
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+  const state = generateRandomString(16);
+  const nonce = generateRandomString(16);
+
+  // Store state for callback verification
+  currentOAuthState = { codeVerifier, state, nonce };
+
+  // Build authorization URL
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId,
+    redirect_uri: REDIRECT_URI,
+    scope: "api",
+    state,
+    nonce,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+  });
+
+  const authUrl = `${MCP_OAUTH_BASE}/authorize?${params.toString()}`;
+
+  return { authUrl, state: currentOAuthState };
+}
+
+/**
+ * Handle OAuth callback from webview navigation.
+ * Extracts code from URL and exchanges for tokens.
+ */
+export async function handleOAuthCallback(
+  callbackUrl: string,
+): Promise<TokenResponse> {
+  const url = new URL(callbackUrl);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+
+  if (error) {
+    const errorDescription = url.searchParams.get("error_description");
+    throw new Error(`OAuth error: ${error} - ${errorDescription || ""}`);
+  }
+
+  if (!code) {
+    throw new Error("No authorization code in callback");
+  }
+
+  if (!currentOAuthState) {
+    throw new Error("No OAuth state - flow not started");
+  }
+
+  if (state !== currentOAuthState.state) {
+    throw new Error("State mismatch - possible CSRF attack");
+  }
+
+  // Exchange code for tokens
+  const tokens = await exchangeCodeForTokens(
+    code,
+    currentOAuthState.codeVerifier,
+  );
+
+  // Store tokens
+  await storeTokens(tokens);
+
+  // Clear OAuth state
+  currentOAuthState = null;
+
+  return tokens;
+}
+
+/**
+ * Exchange authorization code for access token.
+ */
+async function exchangeCodeForTokens(
+  code: string,
+  codeVerifier: string,
+): Promise<TokenResponse> {
+  const clientId = await getOrRegisterClient();
+
+  const response = await fetch(`${MCP_OAUTH_BASE}/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      client_id: clientId,
+      code,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: codeVerifier,
+    }).toString(),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Token exchange failed: ${response.status} ${error}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Refresh access token using refresh token.
+ */
+export async function refreshAccessToken(): Promise<TokenResponse | null> {
+  const refreshToken = await getStoredRefreshToken();
+  if (!refreshToken) {
+    return null;
+  }
+
+  const clientId = await getOrRegisterClient();
+
+  try {
+    const response = await fetch(`${MCP_OAUTH_BASE}/token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: clientId,
+        refresh_token: refreshToken,
+      }).toString(),
+    });
+
+    if (!response.ok) {
+      // Refresh failed - clear tokens and require re-auth
+      await clearStoredTokens();
+      return null;
+    }
+
+    const tokens: TokenResponse = await response.json();
+    await storeTokens(tokens);
+    return tokens;
+  } catch {
+    await clearStoredTokens();
+    return null;
+  }
+}
+
+/**
+ * Get valid access token, refreshing if needed.
+ */
+export async function getValidAccessToken(): Promise<string | null> {
+  const accessToken = await getStoredAccessToken();
+  const expiry = await getStoredTokenExpiry();
+
+  if (!accessToken) {
+    return null;
+  }
+
+  // Check if token is expired (with 60 second buffer)
+  if (expiry && Date.now() >= expiry - 60000) {
+    console.log("[MCP OAuth] Token expired, refreshing...");
+    const refreshed = await refreshAccessToken();
+    return refreshed?.access_token || null;
+  }
+
+  return accessToken;
+}
+
+/**
+ * Check if user is authenticated with MCP.
+ */
+export async function isMcpAuthenticated(): Promise<boolean> {
+  const token = await getValidAccessToken();
+  return token !== null;
+}
+
+// Token storage functions using Tauri store
+
+async function storeTokens(tokens: TokenResponse): Promise<void> {
+  const expiry = Date.now() + tokens.expires_in * 1000;
+
+  await invoke("set_setting", {
+    store: MCP_TOKEN_STORE,
+    key: ACCESS_TOKEN_KEY,
+    value: tokens.access_token,
+  });
+
+  await invoke("set_setting", {
+    store: MCP_TOKEN_STORE,
+    key: TOKEN_EXPIRY_KEY,
+    value: expiry.toString(),
+  });
+
+  if (tokens.refresh_token) {
+    await invoke("set_setting", {
+      store: MCP_TOKEN_STORE,
+      key: REFRESH_TOKEN_KEY,
+      value: tokens.refresh_token,
+    });
+  }
+}
+
+async function storeClientId(clientId: string): Promise<void> {
+  await invoke("set_setting", {
+    store: MCP_TOKEN_STORE,
+    key: CLIENT_ID_KEY,
+    value: clientId,
+  });
+}
+
+async function getStoredClientId(): Promise<string | null> {
+  try {
+    const result = await invoke<string | null>("get_setting", {
+      store: MCP_TOKEN_STORE,
+      key: CLIENT_ID_KEY,
+    });
+    return result && result.length > 0 ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getStoredAccessToken(): Promise<string | null> {
+  try {
+    const result = await invoke<string | null>("get_setting", {
+      store: MCP_TOKEN_STORE,
+      key: ACCESS_TOKEN_KEY,
+    });
+    return result && result.length > 0 ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getStoredRefreshToken(): Promise<string | null> {
+  try {
+    const result = await invoke<string | null>("get_setting", {
+      store: MCP_TOKEN_STORE,
+      key: REFRESH_TOKEN_KEY,
+    });
+    return result && result.length > 0 ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getStoredTokenExpiry(): Promise<number | null> {
+  try {
+    const result = await invoke<string | null>("get_setting", {
+      store: MCP_TOKEN_STORE,
+      key: TOKEN_EXPIRY_KEY,
+    });
+    return result ? Number.parseInt(result, 10) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearStoredTokens(): Promise<void> {
+  try {
+    await invoke("set_setting", {
+      store: MCP_TOKEN_STORE,
+      key: ACCESS_TOKEN_KEY,
+      value: "",
+    });
+    await invoke("set_setting", {
+      store: MCP_TOKEN_STORE,
+      key: REFRESH_TOKEN_KEY,
+      value: "",
+    });
+    await invoke("set_setting", {
+      store: MCP_TOKEN_STORE,
+      key: TOKEN_EXPIRY_KEY,
+      value: "",
+    });
+  } catch (error) {
+    console.error("[MCP OAuth] Failed to clear tokens:", error);
+  }
+}
+
+/**
+ * Clear all stored OAuth data including client registration.
+ * Use this when redirect URI changes or for complete reset.
+ */
+export async function clearAllOAuthData(): Promise<void> {
+  // Clear in-memory cache
+  cachedClientId = null;
+  currentOAuthState = null;
+
+  try {
+    await invoke("set_setting", {
+      store: MCP_TOKEN_STORE,
+      key: CLIENT_ID_KEY,
+      value: "",
+    });
+    await clearStoredTokens();
+    console.log("[MCP OAuth] All OAuth data cleared");
+  } catch (error) {
+    console.error("[MCP OAuth] Failed to clear OAuth data:", error);
+  }
+}
+
+/**
+ * Check if a URL is the OAuth callback URL.
+ * Matches loopback addresses (127.0.0.1, localhost, [::1]) on any port with /oauth/callback path.
+ */
+export function isOAuthCallback(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const isLoopback =
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "localhost" ||
+      parsed.hostname === "[::1]";
+    const isCallbackPath = parsed.pathname === "/oauth/callback";
+    return isLoopback && isCallbackPath;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the current OAuth state (for verification).
+ */
+export function getCurrentOAuthState(): OAuthState | null {
+  return currentOAuthState;
+}
+
+/**
+ * Clear current OAuth state (e.g., on cancel).
+ */
+export function clearOAuthState(): void {
+  currentOAuthState = null;
+}
+
+/**
+ * Result from the Rust OAuth browser flow.
+ */
+interface OAuthCallbackResult {
+  code: string;
+  state: string;
+}
+
+/**
+ * Start OAuth flow using the default browser with a loopback server.
+ * This is more reliable than webview-based OAuth as it handles all navigation properly.
+ *
+ * The Rust backend:
+ * 1. Starts a local HTTP server on a random port
+ * 2. Opens the OAuth URL in the default browser
+ * 3. Waits for the callback
+ * 4. Returns the authorization code and state
+ */
+export async function startOAuthBrowserFlow(): Promise<TokenResponse> {
+  // Clear any stale client registration
+  const storedClientId = await getStoredClientId();
+  if (storedClientId) {
+    console.log("[MCP OAuth] Clearing stored client_id for fresh registration");
+    cachedClientId = null;
+    await invoke("set_setting", {
+      store: MCP_TOKEN_STORE,
+      key: CLIENT_ID_KEY,
+      value: "",
+    });
+  }
+
+  // Get a port from the Rust backend first so we know the redirect URI
+  const port = await invoke<number>("get_oauth_callback_port");
+  const redirectUri = `http://127.0.0.1:${port}/oauth/callback`;
+
+  console.log("[MCP OAuth] Browser flow - redirect URI:", redirectUri);
+
+  // Register client with the actual redirect URI we'll use
+  console.log("[MCP OAuth] Registering OAuth client...");
+  const registerResponse = await fetch(`${MCP_OAUTH_BASE}/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      client_name: MCP_CLIENT_NAME,
+      redirect_uris: [redirectUri],
+      response_types: ["code"],
+      grant_types: ["authorization_code", "refresh_token"],
+      scope: "api",
+      token_endpoint_auth_method: "none",
+    }),
+  });
+
+  if (!registerResponse.ok) {
+    const error = await registerResponse.text();
+    throw new Error(
+      `Client registration failed: ${registerResponse.status} ${error}`,
+    );
+  }
+
+  const registration: ClientRegistrationResponse =
+    await registerResponse.json();
+  console.log("[MCP OAuth] Client registered:", registration.client_id);
+
+  // Generate PKCE values
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+  const state = generateRandomString(16);
+  const nonce = generateRandomString(16);
+
+  // Store state for verification
+  currentOAuthState = { codeVerifier, state, nonce };
+
+  // Build authorization URL (without redirect_uri - Rust will add it)
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: registration.client_id,
+    redirect_uri: redirectUri,
+    scope: "api",
+    state,
+    nonce,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+  });
+
+  const authUrl = `${MCP_OAUTH_BASE}/authorize?${params.toString()}`;
+  console.log("[MCP OAuth] Starting browser flow...");
+
+  // Call Rust backend to open browser and wait for callback
+  const callbackResult = await invoke<OAuthCallbackResult>(
+    "start_oauth_browser_flow",
+    {
+      authUrl,
+      timeoutSecs: 300, // 5 minute timeout
+    },
+  );
+
+  console.log("[MCP OAuth] Callback received, state:", callbackResult.state);
+
+  // Verify state
+  if (callbackResult.state !== state) {
+    throw new Error("State mismatch - possible CSRF attack");
+  }
+
+  // Exchange code for tokens
+  console.log("[MCP OAuth] Exchanging code for tokens...");
+  const tokenResponse = await fetch(`${MCP_OAUTH_BASE}/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      client_id: registration.client_id,
+      code: callbackResult.code,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+    }).toString(),
+  });
+
+  if (!tokenResponse.ok) {
+    const error = await tokenResponse.text();
+    throw new Error(`Token exchange failed: ${tokenResponse.status} ${error}`);
+  }
+
+  const tokens: TokenResponse = await tokenResponse.json();
+  console.log("[MCP OAuth] Tokens received successfully");
+
+  // Store tokens and client ID
+  await storeTokens(tokens);
+  await storeClientId(registration.client_id);
+  cachedClientId = registration.client_id;
+
+  // Clear OAuth state
+  currentOAuthState = null;
+
+  return tokens;
+}

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -1,10 +1,14 @@
 // ABOUTME: Reactive store for authentication state management.
-// ABOUTME: Tracks user session and provides login/logout actions.
+// ABOUTME: Tracks user session, MCP OAuth state, and provides login/logout actions.
 
 import { createStore } from "solid-js/store";
 import { addSerenDbServer, removeSerenDbServer } from "@/lib/mcp/serendb";
 import { logout as authLogout, isLoggedIn } from "@/services/auth";
-import { initializeGateway, resetGateway } from "@/services/mcp-gateway";
+import {
+  initializeGateway,
+  needsMcpAuth,
+  resetGateway,
+} from "@/services/mcp-gateway";
 
 export interface User {
   id: string;
@@ -16,17 +20,23 @@ interface AuthState {
   user: User | null;
   isLoading: boolean;
   isAuthenticated: boolean;
+  /** Whether MCP OAuth is needed (user logged in but no MCP token) */
+  needsMcpOAuth: boolean;
+  /** Whether MCP Gateway is connected */
+  mcpConnected: boolean;
 }
 
 const [state, setState] = createStore<AuthState>({
   user: null,
   isLoading: true,
   isAuthenticated: false,
+  needsMcpOAuth: false,
+  mcpConnected: false,
 });
 
 /**
  * Check authentication status on app startup.
- * If authenticated, initializes the MCP Gateway.
+ * If authenticated, checks MCP OAuth status and initializes the MCP Gateway.
  */
 export async function checkAuth(): Promise<void> {
   setState("isLoading", true);
@@ -34,8 +44,20 @@ export async function checkAuth(): Promise<void> {
     const authenticated = await isLoggedIn();
     setState("isAuthenticated", authenticated);
 
-    // Initialize MCP Gateway for authenticated users (non-blocking)
+    // Check MCP OAuth status for authenticated users
     if (authenticated) {
+      const mcpAuthNeeded = await needsMcpAuth();
+      setState("needsMcpOAuth", mcpAuthNeeded);
+
+      if (mcpAuthNeeded) {
+        console.log(
+          "[Auth Store] MCP OAuth required - user needs to authorize",
+        );
+        // Don't initialize gateway yet - wait for OAuth
+        return;
+      }
+
+      // Initialize MCP Gateway for authenticated users with MCP token (non-blocking)
       // Fire and forget - don't block login while tools load
       (async () => {
         try {
@@ -43,9 +65,18 @@ export async function checkAuth(): Promise<void> {
           await addSerenDbServer();
 
           console.log("[Auth Store] Initializing MCP Gateway (background)...");
-          initializeGateway().then(() => {
-            console.log("[Auth Store] MCP Gateway initialized successfully");
-          });
+          initializeGateway()
+            .then(() => {
+              console.log("[Auth Store] MCP Gateway initialized successfully");
+              setState("mcpConnected", true);
+            })
+            .catch((error) => {
+              console.error("[Auth Store] MCP Gateway failed:", error);
+              // If gateway init fails due to auth, mark as needing OAuth
+              if (error?.status === 401) {
+                setState("needsMcpOAuth", true);
+              }
+            });
 
           // Trigger auto-connect for local MCP servers
           const { initMcpAutoConnect } = await import("@/lib/mcp/auto-connect");
@@ -66,14 +97,26 @@ export async function checkAuth(): Promise<void> {
 
 /**
  * Set user as authenticated after successful login.
- * Initializes the MCP Gateway.
+ * Checks MCP OAuth status and initializes the MCP Gateway if authorized.
  */
 export async function setAuthenticated(user: User): Promise<void> {
+  // Check MCP OAuth status
+  const mcpAuthNeeded = await needsMcpAuth();
+
   setState({
     user,
     isAuthenticated: true,
     isLoading: false,
+    needsMcpOAuth: mcpAuthNeeded,
   });
+
+  if (mcpAuthNeeded) {
+    console.log(
+      "[Auth Store] setAuthenticated: MCP OAuth required - user needs to authorize",
+    );
+    // Don't initialize gateway yet - wait for OAuth
+    return;
+  }
 
   // Initialize MCP Gateway on sign-in (non-blocking)
   // Fire and forget - don't block UI while tools load
@@ -87,11 +130,23 @@ export async function setAuthenticated(user: User): Promise<void> {
       console.log(
         "[Auth Store] setAuthenticated: Initializing MCP Gateway (background)...",
       );
-      initializeGateway().then(() => {
-        console.log(
-          "[Auth Store] setAuthenticated: MCP Gateway initialized successfully",
-        );
-      });
+      initializeGateway()
+        .then(() => {
+          console.log(
+            "[Auth Store] setAuthenticated: MCP Gateway initialized successfully",
+          );
+          setState("mcpConnected", true);
+        })
+        .catch((error) => {
+          console.error(
+            "[Auth Store] setAuthenticated: MCP Gateway failed:",
+            error,
+          );
+          // If gateway init fails due to auth, mark as needing OAuth
+          if (error?.status === 401) {
+            setState("needsMcpOAuth", true);
+          }
+        });
 
       // Trigger auto-connect for local MCP servers
       const { initMcpAutoConnect } = await import("@/lib/mcp/auto-connect");
@@ -113,12 +168,48 @@ export async function setAuthenticated(user: User): Promise<void> {
 }
 
 /**
+ * Called when MCP OAuth flow completes successfully.
+ * Initializes the MCP Gateway with the new OAuth token.
+ */
+export async function onMcpOAuthComplete(): Promise<void> {
+  console.log("[Auth Store] MCP OAuth completed, initializing gateway...");
+  setState("needsMcpOAuth", false);
+
+  // Now initialize the MCP Gateway
+  try {
+    await addSerenDbServer();
+
+    await initializeGateway();
+    console.log("[Auth Store] MCP Gateway initialized after OAuth");
+    setState("mcpConnected", true);
+
+    // Trigger auto-connect for local MCP servers
+    const { initMcpAutoConnect } = await import("@/lib/mcp/auto-connect");
+    const results = await initMcpAutoConnect();
+    console.log("[Auth Store] MCP auto-connect results:", results);
+  } catch (error) {
+    console.error("[Auth Store] Failed to initialize MCP after OAuth:", error);
+    // Re-enable OAuth prompt if initialization fails
+    if ((error as { status?: number })?.status === 401) {
+      setState("needsMcpOAuth", true);
+    }
+  }
+}
+
+/**
+ * Dismiss the MCP OAuth prompt (user chose not to connect).
+ */
+export function dismissMcpOAuth(): void {
+  setState("needsMcpOAuth", false);
+}
+
+/**
  * Log out and clear authentication state.
- * Cleans up MCP Gateway state.
+ * Cleans up MCP Gateway state and OAuth tokens.
  */
 export async function logout(): Promise<void> {
-  // Reset MCP Gateway state
-  resetGateway();
+  // Reset MCP Gateway state (clears OAuth tokens)
+  await resetGateway();
 
   // Remove Seren MCP server config
   try {
@@ -132,6 +223,8 @@ export async function logout(): Promise<void> {
     user: null,
     isAuthenticated: false,
     isLoading: false,
+    needsMcpOAuth: false,
+    mcpConnected: false,
   });
 }
 


### PR DESCRIPTION
## Summary
- Implements browser-based OAuth2 with PKCE for mcp.serendb.com authentication
- Replaces previous webview-based approach that had navigation event issues
- Adds ThinkingToggle to ChatContent header (was missing)
- Adds rmcp dependency with SSE transport for future MCP server support

## Changes
- **Rust OAuth loopback server** (`oauth.rs`) - Receives OAuth callbacks on localhost
- **Tauri commands** - `start_oauth_browser_flow`, `get_oauth_callback_port`
- **MCP OAuth service** (`mcp-oauth.ts`) - PKCE, dynamic client registration, token management
- **McpOAuthDialog** - Authentication UI component
- **SignIn integration** - Auto-authenticates MCP after Seren login
- **HTTP MCP state** - Gateway connection management

## OAuth Flow
1. Frontend registers dynamic client with mcp.serendb.com
2. Frontend gets available port from Rust backend
3. Rust opens default browser with auth URL
4. User authorizes in browser
5. Rust loopback server receives callback
6. Frontend exchanges code for tokens

## Test plan
- [ ] Login to Seren account
- [ ] Verify browser opens for MCP OAuth
- [ ] Verify "Authorization Successful" page shows in browser
- [ ] Verify MCP Gateway connects with 70+ tools
- [ ] Verify Claude can use file tools (read_file, list_directory)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com