### PR TITLE
Fix Windows WiX bundler failure with multiple binaries

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["SerenAI <hello@serendb.com>"]
 edition = "2024"
 default-run = "Seren"
 
+# Note: default-run tells Tauri's bundler which binary is the main application.
+# This prevents WiX from trying to bundle acp_agent (which isn't built on Windows).
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,6 +3,7 @@
   "productName": "SerenDesktop",
   "version": "0.1.0",
   "identifier": "com.serendb.desktop",
+  "mainBinaryName": "Seren",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Problem

Issue #200: Windows MSI builds were failing during the WiX packaging phase with:
```
failed to bundle project `failed to run C:\Users\runneradmin\AppData\Local\tauri\WixTools314\light.exe`
```

This started after the ACP integration merge when we introduced a second binary (`acp_agent`) in Cargo.toml.

## Root Cause

Tauri's WiX bundler scans `Cargo.toml` for all `[[bin]]` entries and attempts to bundle them, even if they have `required-features` and aren't built.

Our configuration:
- `Seren` (main binary) - ✓ built on all platforms
- `acp_agent` (requires `acp` feature) - ✗ NOT built on Windows (due to `--no-default-features`)

WiX failed because it couldn't find `acp_agent.exe` to bundle, even though we never intended to bundle it on Windows.

## Solution

Added `mainBinaryName: "Seren"` to `tauri.conf.json` to explicitly tell Tauri which binary is the main application.

### Why this works:
- `default-run` in `Cargo.toml` is NOT sufficient for Tauri's bundler
- `mainBinaryName` is Tauri 2.x's configuration for specifying the main binary
- This tells WiX to ignore other binaries and only bundle `Seren.exe`

## Changes

1. **src-tauri/tauri.conf.json**: Added `mainBinaryName: "Seren"`
2. **src-tauri/Cargo.toml**: Added comment explaining `default-run` purpose

## References

- Related Tauri issue: [#4807 - Build fail when more than one `[[bin]]` in Cargo.toml](https://github.com/tauri-apps/tauri/issues/4807)
- Tauri documentation: [Configuration Reference - mainBinaryName](https://v2.tauri.app/reference/config/)

## Testing

This fix should allow Windows builds to complete successfully by preventing WiX from looking for the `acp_agent` binary that isn't built on Windows.

Fixes #200