### PR TITLE
feat: Add daily SerenBucks claim popup on login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { StatusBar } from "@/components/common/StatusBar";
 import { EditorContent } from "@/components/editor/EditorContent";
 // MCP OAuth dialog removed - now using API key auth flow
 import { X402PaymentApproval } from "@/components/mcp/X402PaymentApproval";
+import { DailyClaimPopup } from "@/components/wallet/DailyClaimPopup";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { DatabasePanel } from "@/components/sidebar/DatabasePanel";
 import { FileExplorer } from "@/components/sidebar/FileExplorer";
@@ -40,6 +41,7 @@ import { providerStore } from "@/stores/provider.store";
 import { loadAllSettings } from "@/stores/settings.store";
 import { updaterStore } from "@/stores/updater.store";
 import {
+  checkDailyClaim,
   resetWalletState,
   startAutoRefresh,
   stopAutoRefresh,
@@ -117,6 +119,7 @@ function App() {
         autocompleteStore.enable();
         // Store cleanup to prevent effect accumulation
         cleanupAutoTopUp = initAutoTopUp();
+        checkDailyClaim();
       });
     } else {
       console.log("[App] User logged out, stopping services...");
@@ -227,6 +230,7 @@ function App() {
         </main>
         <StatusBar />
         <LowBalanceModal />
+        <DailyClaimPopup />
         <X402PaymentApproval />
       </div>
     </Show>

--- a/src/components/wallet/DailyClaimPopup.css
+++ b/src/components/wallet/DailyClaimPopup.css
@@ -1,0 +1,134 @@
+/* ABOUTME: Styles for the daily SerenBucks claim popup modal. */
+/* ABOUTME: Uses same animation and theme patterns as LowBalanceWarning. */
+
+.daily-claim-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.daily-claim-dialog {
+  background: var(--color-card, #1e293b);
+  border: 1px solid var(--color-border, rgba(148, 163, 184, 0.15));
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  animation: slideUp 0.2s ease-out;
+}
+
+.daily-claim-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 16px;
+}
+
+.daily-claim-icon {
+  font-size: 1.5rem;
+}
+
+.daily-claim-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-foreground, #fff);
+  margin: 0;
+}
+
+.daily-claim-body {
+  margin-bottom: 20px;
+}
+
+.daily-claim-message {
+  font-size: 0.875rem;
+  color: var(--color-muted-foreground, #94a3b8);
+  line-height: 1.5;
+  margin: 0 0 8px;
+}
+
+.daily-claim-remaining {
+  font-size: 0.8rem;
+  color: var(--color-muted-foreground, #64748b);
+  margin: 0;
+}
+
+.daily-claim-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+  padding: 12px 0;
+}
+
+.daily-claim-success-icon {
+  font-size: 2rem;
+  color: #22c55e;
+}
+
+.daily-claim-success-amount {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-foreground, #fff);
+}
+
+.daily-claim-success-balance {
+  font-size: 0.8rem;
+  color: var(--color-muted-foreground, #94a3b8);
+}
+
+.daily-claim-error {
+  font-size: 0.8rem;
+  color: var(--color-destructive, #ef4444);
+  background: rgba(239, 68, 68, 0.1);
+  padding: 8px;
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+.daily-claim-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.daily-claim-btn {
+  padding: 6px 14px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: none;
+}
+
+.daily-claim-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.daily-claim-btn-dismiss {
+  background: transparent;
+  color: var(--color-muted-foreground, #94a3b8);
+  border: 1px solid var(--color-border, rgba(148, 163, 184, 0.2));
+}
+
+.daily-claim-btn-dismiss:hover:not(:disabled) {
+  background: var(--color-secondary, rgba(148, 163, 184, 0.1));
+  color: var(--color-foreground, #fff);
+}
+
+.daily-claim-btn-claim {
+  background: var(--color-primary, #6366f1);
+  color: var(--color-primary-foreground, #fff);
+}
+
+.daily-claim-btn-claim:hover:not(:disabled) {
+  opacity: 0.9;
+}

--- a/src/components/wallet/DailyClaimPopup.tsx
+++ b/src/components/wallet/DailyClaimPopup.tsx
@@ -1,0 +1,145 @@
+// ABOUTME: Modal popup for claiming daily SerenBucks credits after login.
+// ABOUTME: Shows eligibility, handles claim action, and supports dismissal.
+
+import { type Component, createSignal, Show } from "solid-js";
+import {
+  claimDaily,
+  dismissDailyClaim,
+  walletState,
+} from "@/stores/wallet.store";
+import type { DailyClaimResponse } from "@/services/dailyClaim";
+import "./DailyClaimPopup.css";
+
+/**
+ * Daily SerenBucks claim popup modal.
+ * Appears after login when user is eligible to claim.
+ */
+export const DailyClaimPopup: Component = () => {
+  const [claiming, setClaiming] = createSignal(false);
+  const [claimResult, setClaimResult] =
+    createSignal<DailyClaimResponse | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const shouldShow = () => {
+    const claim = walletState.dailyClaim;
+    return (
+      claim !== null &&
+      claim.can_claim &&
+      !walletState.dailyClaimDismissed &&
+      !claimResult()
+    );
+  };
+
+  const showSuccess = () => claimResult() !== null;
+
+  const handleClaim = async () => {
+    setClaiming(true);
+    setError(null);
+    try {
+      const result = await claimDaily();
+      setClaimResult(result);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to claim daily credits",
+      );
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    dismissDailyClaim();
+  };
+
+  const handleCloseSuccess = () => {
+    setClaimResult(null);
+  };
+
+  const handleBackdropClick = () => {
+    if (showSuccess()) {
+      handleCloseSuccess();
+    } else {
+      handleDismiss();
+    }
+  };
+
+  return (
+    <Show when={shouldShow() || showSuccess()}>
+      <div class="daily-claim-overlay" onClick={handleBackdropClick}>
+        <div
+          class="daily-claim-dialog"
+          onClick={(e) => e.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="daily-claim-title"
+        >
+          <Show
+            when={!showSuccess()}
+            fallback={
+              <div class="daily-claim-success">
+                <span class="daily-claim-success-icon">&#10003;</span>
+                <span class="daily-claim-success-amount">
+                  +{claimResult()!.amount_usd}
+                </span>
+                <span class="daily-claim-success-balance">
+                  New balance: {claimResult()!.balance_usd}
+                </span>
+                <span class="daily-claim-remaining">
+                  {claimResult()!.claims_remaining_this_month} claims remaining
+                  this month
+                </span>
+                <button
+                  class="daily-claim-btn daily-claim-btn-claim"
+                  onClick={handleCloseSuccess}
+                >
+                  Done
+                </button>
+              </div>
+            }
+          >
+            <div class="daily-claim-header">
+              <span class="daily-claim-icon">&#128176;</span>
+              <h2 id="daily-claim-title" class="daily-claim-title">
+                Daily SerenBucks
+              </h2>
+            </div>
+
+            <div class="daily-claim-body">
+              <p class="daily-claim-message">
+                You have unclaimed SerenBucks today! Claim your free daily
+                credits to use with AI models and publisher tools.
+              </p>
+              <Show when={walletState.dailyClaim}>
+                <p class="daily-claim-remaining">
+                  {walletState.dailyClaim!.claims_remaining_this_month} claims
+                  remaining this month
+                </p>
+              </Show>
+            </div>
+
+            <Show when={error()}>
+              <div class="daily-claim-error">{error()}</div>
+            </Show>
+
+            <div class="daily-claim-footer">
+              <button
+                class="daily-claim-btn daily-claim-btn-dismiss"
+                onClick={handleDismiss}
+                disabled={claiming()}
+              >
+                Dismiss
+              </button>
+              <button
+                class="daily-claim-btn daily-claim-btn-claim"
+                onClick={handleClaim}
+                disabled={claiming()}
+              >
+                {claiming() ? "Claiming..." : "Claim Now"}
+              </button>
+            </div>
+          </Show>
+        </div>
+      </div>
+    </Show>
+  );
+};

--- a/src/services/dailyClaim.ts
+++ b/src/services/dailyClaim.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Service for checking and claiming daily SerenBucks credits.
+// ABOUTME: Wraps generated SDK calls with error handling.
+
+import { checkDailyEligibility, claimDaily } from "@/api";
+import type {
+  DailyClaimEligibilityResponse,
+  DailyClaimResponse,
+} from "@/api/generated/types.gen";
+
+export type { DailyClaimEligibilityResponse, DailyClaimResponse };
+
+/**
+ * Check if the current user is eligible to claim daily credits.
+ */
+export async function fetchDailyEligibility(): Promise<DailyClaimEligibilityResponse> {
+  const { data, error } = await checkDailyEligibility({
+    throwOnError: false,
+  });
+
+  if (error) {
+    throw new Error("Failed to check daily claim eligibility");
+  }
+
+  if (!data?.data) {
+    throw new Error("No eligibility data returned");
+  }
+
+  return data.data;
+}
+
+/**
+ * Claim daily free credits.
+ */
+export async function claimDailyCredits(): Promise<DailyClaimResponse> {
+  const { data, error } = await claimDaily({ throwOnError: false });
+
+  if (error) {
+    throw new Error("Failed to claim daily credits");
+  }
+
+  if (!data?.data) {
+    throw new Error("No claim data returned");
+  }
+
+  return data.data;
+}


### PR DESCRIPTION
## Summary
- Show a modal popup after login when user is eligible to claim daily SerenBucks credits
- User can claim immediately or dismiss; dismissing reveals a claim banner in Settings > Wallet
- Uses existing checkDailyEligibility and claimDaily SDK endpoints
- Claiming updates wallet balance inline from the API response

## Test plan
- [ ] Login with an account that has not claimed today -- popup should appear
- [ ] Click Claim Now -- verify success state shows amount and updated balance
- [ ] Login again -- popup should NOT appear (already claimed)
- [ ] Click Dismiss -- verify popup closes, navigate to Settings > Wallet and see claim banner
- [ ] pnpm test passes (35/35)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com