### PR TITLE
Fix AI not knowing it can save files to disk

### DIFF
--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -185,7 +185,10 @@ export async function* streamMessageWithTools(
 
   // Build system message
   let systemContent =
-    "You are a helpful coding assistant with access to the user's local files.";
+    "You are a helpful coding assistant running inside a desktop application with full access to the user's local filesystem. " +
+    "You can read, write, and create files and directories on the user's computer using the available tools. " +
+    "When the user asks you to save, export, or write content to a file, use the write_file tool to save it to their filesystem. " +
+    "Always ask for the desired file path if the user doesn't specify one.";
 
   // Add user-provided context if available
   if (context) {
@@ -198,9 +201,6 @@ export async function* streamMessageWithTools(
     } else {
       systemContent += `\n\nThe user has selected this code:\n\n\`\`\`\n${context.content}\n\`\`\``;
     }
-  } else {
-    systemContent +=
-      " Use the available tools to read, list, and write files when needed to help the user.";
   }
 
   // Retrieve and inject semantic code context if available


### PR DESCRIPTION
## Summary
- The AI chat assistant was telling users "I'm not able to save files to your desktop" when asked to save content
- Root cause: the system prompt vaguely said "helpful coding assistant with access to the user's local files" without explicitly mentioning write/save capabilities
- Updated the system prompt to clearly state the assistant runs in a desktop app with full filesystem access and should use `write_file` when asked to save content

## Test plan
- [ ] Open Seren Desktop, ask the AI to "save this to a file on my desktop"
- [ ] Verify the AI uses the `write_file` tool instead of refusing
- [ ] Verify file operations still require user approval via ActionConfirmation

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com