### PR TITLE
feat: Resizable chat input textarea

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -287,7 +287,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               ref={inputRef}
               value={input()}
               placeholder="Tell the agent what to do..."
-              class="w-full min-h-[80px] max-h-[200px] resize-none bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-3 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58] disabled:opacity-60 disabled:cursor-not-allowed"
+              class="w-full min-h-[80px] max-h-[50vh] resize-y bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-3 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58] disabled:opacity-60 disabled:cursor-not-allowed"
               onInput={(e) => setInput(e.currentTarget.value)}
               onKeyDown={handleKeyDown}
               disabled={!isReady()}

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -778,7 +778,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                         ? "Type to queue message..."
                         : "Ask Seren anything…"
                     }
-                    class="w-full min-h-[60px] max-h-[150px] resize-none bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-2 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58]"
+                    class="w-full min-h-[60px] max-h-[50vh] resize-y bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-2 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58]"
                     onInput={(event) => {
                       setInput(event.currentTarget.value);
                       if (historyIndex() !== -1) {

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -770,7 +770,7 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
                       ref={inputRef}
                       value={input()}
                       placeholder="Ask Seren anything…"
-                      class="w-full min-h-[80px] max-h-[200px] resize-none bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-3 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58] disabled:opacity-60 disabled:cursor-not-allowed"
+                      class="w-full min-h-[80px] max-h-[50vh] resize-y bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-3 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58] disabled:opacity-60 disabled:cursor-not-allowed"
                       onInput={(event) => {
                         setInput(event.currentTarget.value);
                         // Reset history browsing when user types manually


### PR DESCRIPTION
## Summary
- Enable vertical resize on all chat input textareas (ChatPanel, ChatContent, AgentChat)
- Change `resize-none` to `resize-y` so users can drag the native browser resize handle
- Increase `max-h` from 150-200px to `50vh` to allow meaningful expansion

Closes #213

## Test plan
- [ ] Open chat, verify resize handle appears at bottom-right of textarea
- [ ] Drag handle up/down -- textarea resizes vertically within min-h and 50vh bounds
- [ ] Type and send a message -- input works normally after resizing
- [ ] pnpm test passes (35/35)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com