### PR TITLE
feat: Auto-install Claude Code CLI for Agent mode

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -431,6 +431,8 @@ pub fn run() {
             acp::acp_get_available_agents,
             #[cfg(feature = "acp")]
             acp::acp_check_agent_available,
+            #[cfg(feature = "acp")]
+            acp::acp_ensure_claude_cli,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -205,7 +205,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                     onClick={startSession}
                     disabled={acpStore.isLoading}
                   >
-                    {acpStore.isLoading ? "Starting..." : "Start Agent"}
+                    {acpStore.isLoading
+                      ? (acpStore.installStatus ?? "Starting...")
+                      : "Start Agent"}
                   </button>
                 </div>
               </div>

--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -177,6 +177,14 @@ export async function getAvailableAgents(): Promise<AgentInfo[]> {
 }
 
 /**
+ * Ensure Claude Code CLI is installed, auto-installing via npm if needed.
+ * Returns the bin directory path containing the claude binary.
+ */
+export async function ensureClaudeCli(): Promise<string> {
+  return invoke<string>("acp_ensure_claude_cli");
+}
+
+/**
  * Check if a specific agent binary is available in PATH.
  */
 export async function checkAgentAvailable(


### PR DESCRIPTION
## Summary

- Auto-installs `@anthropic-ai/claude-code` via npm when a user clicks "Start Agent" and the CLI is missing
- Uses the already-bundled Node.js runtime to run `npm install --prefix <app_data>/cli-tools`
- Shows install progress in the Start Agent button ("Installing Claude Code CLI...")
- Prepends cli-tools bin dir to PATH so `acp_agent` can find the `claude` binary
- Fixes `acp_get_available_agents` to check actual binary availability instead of hardcoding `true`

Closes #212

## Test plan

- [ ] On a machine without Claude Code CLI, click Agent → Start Agent → verify auto-install occurs
- [ ] On second launch, verify it skips install (binary already present)
- [ ] Verify Agent mode still works on macOS/Linux where CLI may already be installed
- [ ] Verify `cargo check` passes
- [ ] Verify `pnpm test` passes

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com