### PR TITLE
fix: Use opener plugin for OAuth URL opening

### DIFF
--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Publisher OAuth service for gateway-managed OAuth flows.
 // ABOUTME: Handles connecting/disconnecting OAuth providers for MCP publishers.
 
-import { open } from "@tauri-apps/plugin-shell";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   listConnections,
   revokeConnection,
@@ -23,7 +23,7 @@ export async function connectPublisher(providerSlug: string): Promise<void> {
   const authUrl = `${apiBase}/api/oauth/${providerSlug}/authorize?redirect_uri=${encodeURIComponent(redirectUri)}`;
 
   console.log(`[PublisherOAuth] Opening authorization URL: ${authUrl}`);
-  await open(authUrl);
+  await openUrl(authUrl);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Publisher OAuth "Connect" button failed with "Failed to start OAuth flow" for all providers
- Root cause: `publisher-oauth.ts` imported `open` from `@tauri-apps/plugin-shell`, but Tauri capabilities only grant `opener:default` (not `shell:allow-open`)
- Fix: Switch to `openUrl` from `@tauri-apps/plugin-opener` which matches the granted capability

## Test plan
- [ ] Click "Connect" on GitHub provider in Settings > Logins
- [ ] Verify browser opens to GitHub OAuth authorization page
- [ ] Complete OAuth flow and verify callback returns to app

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com