### PR TITLE
fix(build): Replace externalBin sidecar with resource bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ src-tauri/binaries/
 
 # Embedded runtime binaries (downloaded, not committed)
 # Keep .gitkeep placeholder for CI
+src-tauri/embedded-runtime/bin/
 src-tauri/embedded-runtime/darwin-*/
 src-tauri/embedded-runtime/win32-*/
 src-tauri/embedded-runtime/linux-*/

--- a/scripts/build-sidecar.ts
+++ b/scripts/build-sidecar.ts
@@ -139,9 +139,6 @@ function main(): void {
   if (profile === "release") cargoArgs.push("--release");
   if (targetTriple !== hostTriple) cargoArgs.push("--target", targetTriple);
 
-  // Set SKIP_TAURI_BUILD to prevent build.rs from running tauri_build::build(),
-  // which validates that the sidecar binary exists — creating a circular dependency.
-  process.env.SKIP_TAURI_BUILD = "1";
   run("cargo", cargoArgs, srcTauriDir);
 
   const cargoTargetDir =
@@ -154,10 +151,10 @@ function main(): void {
     throw new Error(`Built binary not found at: ${srcBin}`);
   }
 
-  const binDir = path.join(srcTauriDir, "binaries");
+  const binDir = path.join(srcTauriDir, "embedded-runtime", "bin");
   mkdirSync(binDir, { recursive: true });
 
-  const destBin = path.join(binDir, `acp_agent-${targetTriple}${ext}`);
+  const destBin = path.join(binDir, `acp_agent${ext}`);
   copyFileSync(srcBin, destBin);
 
   try {

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -5,13 +5,5 @@ fn main() {
         std::env::var("TARGET").unwrap()
     );
 
-    // Skip Tauri build validation when SKIP_TAURI_BUILD is set.
-    // The sidecar build script sets this to avoid a circular dependency: tauri_build::build()
-    // validates that externalBin sidecar files exist, but when building the sidecar itself,
-    // those files don't exist yet.
-    if std::env::var("SKIP_TAURI_BUILD").is_ok() {
-        return;
-    }
-
     tauri_build::build()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,7 +46,6 @@
   "bundle": {
     "active": true,
     "targets": ["nsis", "dmg", "deb", "appimage"],
-    "externalBin": ["binaries/acp_agent"],
     "icon": [
       "icons/icon.png",
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
- Moves ACP agent binary from Tauri `externalBin` to `embedded-runtime/bin/` resource bundling
- Eliminates WiX MSI bundler failure on Windows (root cause of alpha.20 Windows build break)
- Removes circular build dependency (`tauri_build::build()` no longer validates sidecar existence)
- Removes `SKIP_TAURI_BUILD` workaround from `build.rs` and `build-sidecar.ts`
- Checks system PATH for existing `claude` CLI before attempting npm install (#222)

## Changes
- **tauri.conf.json**: Removed `externalBin` config
- **build.rs**: Removed `SKIP_TAURI_BUILD` env var workaround
- **build-sidecar.ts**: Output to `embedded-runtime/bin/` instead of `binaries/`, no target-triple suffix
- **acp.rs**: Updated binary discovery to check resource dir; added system PATH check for claude CLI; removed unused `get_target_triple()`
- **.gitignore**: Added `embedded-runtime/bin/` ignore entry

## Test plan
- [ ] `cargo check` passes (verified locally, zero warnings)
- [ ] `pnpm build:sidecar` outputs to `embedded-runtime/bin/acp_agent` (verified locally)
- [ ] CI release build passes on all platforms (especially Windows)
- [ ] Users with globally installed claude CLI are detected via PATH

Closes #221
Closes #222

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com