### PR TITLE
Show unclaimed SerenBucks amount in claim banner

### DIFF
--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -14,10 +14,7 @@ import {
   settingsStore,
   toggleMcpServer,
 } from "@/stores/settings.store";
-import {
-  claimDaily,
-  walletState,
-} from "@/stores/wallet.store";
+import { claimDaily, walletState } from "@/stores/wallet.store";
 import { OAuthLogins } from "./OAuthLogins";
 import { ProviderSettings } from "./ProviderSettings";
 import { SearchableModelSelect } from "./SearchableModelSelect";
@@ -950,7 +947,8 @@ export const SettingsPanel: Component = () => {
               Semantic Code Indexing
             </h3>
             <p class="m-0 mb-6 text-muted-foreground leading-normal">
-              Enable semantic search across your codebase. Powered by SerenEmbed.
+              Enable semantic search across your codebase. Powered by
+              SerenEmbed.
             </p>
 
             <div class="flex items-start justify-start gap-4 py-3 border-b border-[rgba(148,163,184,0.1)]">
@@ -971,7 +969,9 @@ export const SettingsPanel: Component = () => {
                     Enable Semantic Indexing
                   </span>
                   <span class="text-[0.8rem] text-muted-foreground">
-                    Index your codebase for AI-powered semantic code search. Embeddings are generated via SerenEmbed (paid via SerenBucks) and stored locally for instant retrieval.
+                    Index your codebase for AI-powered semantic code search.
+                    Embeddings are generated via SerenEmbed (paid via
+                    SerenBucks) and stored locally for instant retrieval.
                   </span>
                 </span>
               </label>
@@ -983,9 +983,16 @@ export const SettingsPanel: Component = () => {
               </h4>
               <ul class="m-0 pl-4 text-[0.8rem] text-muted-foreground space-y-2">
                 <li>Your code is chunked at function/class boundaries</li>
-                <li>SerenEmbed generates embeddings (charged via SerenBucks)</li>
-                <li>Embeddings are stored locally in sqlite-vec for instant search</li>
-                <li>AI automatically retrieves relevant code when you ask questions</li>
+                <li>
+                  SerenEmbed generates embeddings (charged via SerenBucks)
+                </li>
+                <li>
+                  Embeddings are stored locally in sqlite-vec for instant search
+                </li>
+                <li>
+                  AI automatically retrieves relevant code when you ask
+                  questions
+                </li>
               </ul>
             </div>
 
@@ -994,7 +1001,10 @@ export const SettingsPanel: Component = () => {
                 Cost Estimate
               </h4>
               <p class="m-0 text-[0.8rem] text-muted-foreground">
-                Indexing cost depends on your codebase size. A typical project with 100 files (~50k lines) costs approximately 100-200k tokens. Use the "Start Indexing" button in the editor sidebar to see the exact estimate before proceeding.
+                Indexing cost depends on your codebase size. A typical project
+                with 100 files (~50k lines) costs approximately 100-200k tokens.
+                Use the "Start Indexing" button in the editor sidebar to see the
+                exact estimate before proceeding.
               </p>
             </div>
           </section>
@@ -1224,10 +1234,14 @@ const DailyClaimBanner: Component = () => {
       <div class="flex items-center justify-between gap-4 py-3 px-4 mb-4 rounded-lg border border-[rgba(99,102,241,0.3)] bg-[rgba(99,102,241,0.08)]">
         <div class="flex flex-col gap-0.5">
           <span class="text-[0.95rem] font-medium text-foreground">
-            Daily SerenBucks Available
+            {walletState.dailyClaim?.claim_amount_usd
+              ? `${walletState.dailyClaim.claim_amount_usd} SerenBucks Available`
+              : "Daily SerenBucks Available"}
           </span>
           <span class="text-[0.8rem] text-muted-foreground">
-            Claim your free daily credits
+            {walletState.dailyClaim?.claim_amount_usd
+              ? `Claim your ${walletState.dailyClaim.claim_amount_usd} of SerenBucks`
+              : "Claim your free daily credits"}
           </span>
           <Show when={error()}>
             <span class="text-[0.75rem] text-[#ef4444]">{error()}</span>

--- a/src/components/wallet/DailyClaimPopup.tsx
+++ b/src/components/wallet/DailyClaimPopup.tsx
@@ -2,12 +2,12 @@
 // ABOUTME: Shows eligibility, handles claim action, and supports dismissal.
 
 import { type Component, createSignal, Show } from "solid-js";
+import type { DailyClaimResponse } from "@/services/dailyClaim";
 import {
   claimDaily,
   dismissDailyClaim,
   walletState,
 } from "@/stores/wallet.store";
-import type { DailyClaimResponse } from "@/services/dailyClaim";
 import "./DailyClaimPopup.css";
 
 /**
@@ -16,8 +16,9 @@ import "./DailyClaimPopup.css";
  */
 export const DailyClaimPopup: Component = () => {
   const [claiming, setClaiming] = createSignal(false);
-  const [claimResult, setClaimResult] =
-    createSignal<DailyClaimResponse | null>(null);
+  const [claimResult, setClaimResult] = createSignal<DailyClaimResponse | null>(
+    null,
+  );
   const [error, setError] = createSignal<string | null>(null);
 
   const shouldShow = () => {
@@ -106,8 +107,9 @@ export const DailyClaimPopup: Component = () => {
 
             <div class="daily-claim-body">
               <p class="daily-claim-message">
-                You have unclaimed SerenBucks today! Claim your free daily
-                credits to use with AI models and publisher tools.
+                {walletState.dailyClaim?.claim_amount_usd
+                  ? `You have ${walletState.dailyClaim.claim_amount_usd} unclaimed SerenBucks today! Claim your ${walletState.dailyClaim.claim_amount_usd} of SerenBucks to use with AI models and publisher tools.`
+                  : "You have unclaimed SerenBucks today! Claim your free daily credits to use with AI models and publisher tools."}
               </p>
               <Show when={walletState.dailyClaim}>
                 <p class="daily-claim-remaining">

--- a/src/services/dailyClaim.ts
+++ b/src/services/dailyClaim.ts
@@ -7,12 +7,21 @@ import type {
   DailyClaimResponse,
 } from "@/api/generated/types.gen";
 
-export type { DailyClaimEligibilityResponse, DailyClaimResponse };
+export type { DailyClaimResponse };
+
+/**
+ * Extended eligibility response that includes optional claim amount.
+ * The claim_amount_usd field is added by the backend when available (see issue #226).
+ * Falls back gracefully when the field is absent.
+ */
+export type DailyClaimEligibility = DailyClaimEligibilityResponse & {
+  claim_amount_usd?: string | null;
+};
 
 /**
  * Check if the current user is eligible to claim daily credits.
  */
-export async function fetchDailyEligibility(): Promise<DailyClaimEligibilityResponse> {
+export async function fetchDailyEligibility(): Promise<DailyClaimEligibility> {
   const { data, error } = await checkDailyEligibility({
     throwOnError: false,
   });

--- a/src/stores/wallet.store.ts
+++ b/src/stores/wallet.store.ts
@@ -4,9 +4,9 @@
 import { createStore } from "solid-js/store";
 import {
   claimDailyCredits,
-  fetchDailyEligibility,
-  type DailyClaimEligibilityResponse,
+  type DailyClaimEligibility,
   type DailyClaimResponse,
+  fetchDailyEligibility,
 } from "@/services/dailyClaim";
 import { fetchBalance, type WalletBalance } from "@/services/wallet";
 
@@ -30,7 +30,7 @@ interface WalletState {
   /** Track if auto-refresh is active (HMR-resistant) */
   autoRefreshActive: boolean;
   /** Daily claim eligibility data */
-  dailyClaim: DailyClaimEligibilityResponse | null;
+  dailyClaim: DailyClaimEligibility | null;
   /** Whether user dismissed the daily claim popup this session */
   dailyClaimDismissed: boolean;
   /** Whether daily claim check is in progress */


### PR DESCRIPTION
## Summary

- Display specific dollar amount in daily claim popup and settings banner when `claim_amount_usd` is available from the eligibility API
- Falls back gracefully to generic message when field is absent
- Extended `DailyClaimEligibility` type with optional `claim_amount_usd` field

## Backend Dependency

Requires backend issue serenorg/seren#100 to add `claim_amount_usd` to the eligibility response. Until then, the fallback message displays.

Closes serenorg/seren-desktop#224

## Test plan

- [ ] Verify banner shows generic message when `claim_amount_usd` is not in API response
- [ ] Verify banner shows specific amount when field is present
- [ ] Verify settings panel banner also shows amount
- [ ] Verify claim flow still works correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com