### PR TITLE
feat(agent): Add multiple agent session tabs

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -7,6 +7,7 @@ import type { DiffEvent } from "@/services/acp";
 import { type AgentMessage, acpStore } from "@/stores/acp.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { AgentSelector } from "./AgentSelector";
+import { AgentTabBar } from "./AgentTabBar";
 import { DiffCard } from "./DiffCard";
 import { PlanHeader } from "./PlanHeader";
 import { ThinkingBlock } from "./ThinkingBlock";
@@ -140,6 +141,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
   return (
     <div class="flex-1 flex flex-col min-h-0">
+      {/* Agent Tab Bar */}
+      <Show when={hasSession()}>
+        <AgentTabBar onNewSession={startSession} />
+      </Show>
+
       {/* Plan Header */}
       <PlanHeader />
 
@@ -194,7 +200,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                           />
                         </svg>
                         <span>
-                          <strong>Claude Code Required:</strong> Make sure Claude Code CLI is installed on your computer.
+                          <strong>Claude Code Required:</strong> Make sure
+                          Claude Code CLI is installed on your computer.
                         </span>
                       </div>
                     </div>
@@ -232,7 +239,13 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             <For each={acpStore.messages}>{renderMessage}</For>
 
             {/* Loading placeholder while waiting for first chunk */}
-            <Show when={isPrompting() && !acpStore.streamingContent && !acpStore.streamingThinking}>
+            <Show
+              when={
+                isPrompting() &&
+                !acpStore.streamingContent &&
+                !acpStore.streamingThinking
+              }
+            >
               <article class="px-5 py-4 border-b border-[#21262d]">
                 <div class="flex items-center gap-2 text-sm text-[#8b949e]">
                   <span class="inline-block w-2 h-2 rounded-full bg-[#58a6ff] animate-pulse" />
@@ -244,7 +257,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             {/* Streaming Thinking */}
             <Show when={acpStore.streamingThinking}>
               <article class="px-5 py-3 border-b border-[#21262d]">
-                <ThinkingBlock thinking={acpStore.streamingThinking} isStreaming={true} />
+                <ThinkingBlock
+                  thinking={acpStore.streamingThinking}
+                  isStreaming={true}
+                />
               </article>
             </Show>
 

--- a/src/components/chat/AgentTabBar.tsx
+++ b/src/components/chat/AgentTabBar.tsx
@@ -1,0 +1,68 @@
+// ABOUTME: Tab bar for managing multiple agent sessions.
+// ABOUTME: Displays session tabs with close buttons and a new session button.
+
+import { type Component, For, Show } from "solid-js";
+import { acpStore } from "@/stores/acp.store";
+
+interface AgentTabBarProps {
+  onNewSession: () => void;
+}
+
+export const AgentTabBar: Component<AgentTabBarProps> = (props) => {
+  const sessionIds = () => Object.keys(acpStore.sessions);
+
+  const handleTabClick = (id: string) => {
+    acpStore.setActiveSession(id);
+  };
+
+  const handleCloseTab = async (e: MouseEvent, id: string) => {
+    e.stopPropagation();
+    await acpStore.terminateSession(id);
+  };
+
+  const sessionLabel = (id: string, index: number) => {
+    const session = acpStore.sessions[id];
+    const agentType = session?.info?.agentType ?? "Agent";
+    const label = agentType === "claude-code" ? "Claude" : agentType;
+    return `${label} #${index + 1}`;
+  };
+
+  return (
+    <div class="flex items-center gap-1 px-3 py-2 bg-[#161b22] border-b border-[#21262d] min-h-[40px]">
+      <div class="flex items-center gap-1 flex-1 overflow-x-auto scrollbar-none [&::-webkit-scrollbar]:hidden">
+        <For each={sessionIds()}>
+          {(id: string, index) => (
+            <button
+              type="button"
+              class={`group flex items-center gap-1.5 px-2.5 py-1.5 bg-transparent border border-transparent rounded-md text-[13px] text-[#8b949e] cursor-pointer whitespace-nowrap max-w-[180px] transition-all hover:bg-[rgba(139,148,158,0.1)] hover:text-[#e6edf3] ${id === acpStore.activeSessionId ? "bg-[rgba(88,166,255,0.1)] border-[rgba(88,166,255,0.3)] text-[#58a6ff]" : ""}`}
+              onClick={() => handleTabClick(id)}
+              title={sessionLabel(id, index())}
+            >
+              <span class="overflow-hidden text-ellipsis max-w-[140px]">
+                {sessionLabel(id, index())}
+              </span>
+              <Show when={sessionIds().length > 1}>
+                <button
+                  type="button"
+                  class="flex items-center justify-center w-4 h-4 p-0 bg-transparent border-none rounded-sm text-sm leading-none text-[#8b949e] cursor-pointer opacity-0 transition-all group-hover:opacity-100 hover:bg-[rgba(248,81,73,0.2)] hover:text-[#f85149]"
+                  onClick={(e) => handleCloseTab(e, id)}
+                  title="Close session"
+                >
+                  ×
+                </button>
+              </Show>
+            </button>
+          )}
+        </For>
+      </div>
+      <button
+        type="button"
+        class="flex items-center justify-center w-7 h-7 p-0 bg-transparent border border-[#30363d] rounded-md text-lg leading-none text-[#8b949e] cursor-pointer shrink-0 transition-all hover:bg-[#21262d] hover:border-[#484f58] hover:text-[#e6edf3]"
+        onClick={props.onNewSession}
+        title="New Agent Session"
+      >
+        +
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Add `AgentTabBar` component for managing multiple concurrent agent sessions
- Tab bar appears when an agent session is active, with "+" to spawn additional sessions
- Click tabs to switch between sessions; close button terminates a session
- Leverages existing multi-session support in `acpStore` (no store changes needed)

## Test plan
- [ ] Start an agent session — tab bar appears with one tab
- [ ] Click "+" to spawn a second agent session — new tab appears
- [ ] Click between tabs — messages, streaming, and plan switch correctly
- [ ] Close a tab — session terminates, switches to remaining tab
- [ ] Close last tab — returns to "Start Agent" splash screen

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com