### PR TITLE
feat(chat): rotating thinking status indicator

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -10,6 +10,7 @@ import { AgentSelector } from "./AgentSelector";
 import { DiffCard } from "./DiffCard";
 import { PlanHeader } from "./PlanHeader";
 import { ThinkingBlock } from "./ThinkingBlock";
+import { ThinkingStatus } from "./ThinkingStatus";
 import { ToolCallCard } from "./ToolCallCard";
 
 interface AgentChatProps {
@@ -234,10 +235,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             {/* Loading placeholder while waiting for first chunk */}
             <Show when={isPrompting() && !acpStore.streamingContent && !acpStore.streamingThinking}>
               <article class="px-5 py-4 border-b border-[#21262d]">
-                <div class="flex items-center gap-2 text-sm text-[#8b949e]">
-                  <span class="inline-block w-2 h-2 rounded-full bg-[#58a6ff] animate-pulse" />
-                  <span>Waiting for agent response…</span>
-                </div>
+                <ThinkingStatus />
               </article>
             </Show>
 
@@ -298,9 +296,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               <div class="flex items-center gap-3">
                 <AgentSelector />
                 <Show when={isPrompting()}>
-                  <span class="text-xs text-[#8b949e]">
-                    Agent is working...
-                  </span>
+                  <ThinkingStatus />
                 </Show>
               </div>
               <div class="flex gap-2">

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -34,6 +34,7 @@ import { providerStore } from "@/stores/provider.store";
 import { settingsStore } from "@/stores/settings.store";
 import { AgentChat } from "./AgentChat";
 import { AgentModeToggle } from "./AgentModeToggle";
+import { ThinkingStatus } from "./ThinkingStatus";
 import { ChatTabBar } from "./ChatTabBar";
 import { CompactedMessage } from "./CompactedMessage";
 import { ModelSelector } from "./ModelSelector";
@@ -684,6 +685,12 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                       </article>
                     )}
                   </For>
+                </Show>
+
+                <Show when={chatStore.isLoading && !streamingSession()}>
+                  <article class="px-5 py-4 border-b border-[#21262d]">
+                    <ThinkingStatus />
+                  </article>
                 </Show>
 
                 <Show when={streamingSession()}>

--- a/src/components/chat/ThinkingStatus.tsx
+++ b/src/components/chat/ThinkingStatus.tsx
@@ -1,0 +1,42 @@
+// ABOUTME: Rotating thinking status indicator with varied words.
+// ABOUTME: Shows pulsing dot + cycling status text like Claude Code's thinking animation.
+
+import { createSignal, onCleanup, onMount } from "solid-js";
+
+const THINKING_WORDS = [
+  "Thinking",
+  "Reasoning",
+  "Pondering",
+  "Analyzing",
+  "Considering",
+  "Processing",
+  "Reflecting",
+  "Evaluating",
+  "Working",
+  "Deliberating",
+];
+
+const ROTATION_INTERVAL_MS = 3000;
+
+export function ThinkingStatus() {
+  const [index, setIndex] = createSignal(
+    Math.floor(Math.random() * THINKING_WORDS.length),
+  );
+
+  let timer: ReturnType<typeof setInterval>;
+
+  onMount(() => {
+    timer = setInterval(() => {
+      setIndex((prev) => (prev + 1) % THINKING_WORDS.length);
+    }, ROTATION_INTERVAL_MS);
+  });
+
+  onCleanup(() => clearInterval(timer));
+
+  return (
+    <span class="inline-flex items-center gap-2 text-sm text-[#8b949e]">
+      <span class="inline-block w-2 h-2 rounded-full bg-[#58a6ff] animate-pulse" />
+      <span>{THINKING_WORDS[index()]}…</span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds shared `ThinkingStatus` component with rotating status words (Thinking, Reasoning, Pondering, Analyzing, etc.) and pulsing blue dot
- Replaces static "Waiting for agent response" and "Agent is working" text in AgentChat
- Adds thinking indicator to ChatContent during the gap between send and first streaming token

Closes #233

## Test plan
- [ ] Open agent panel, send a message, verify rotating status words appear while waiting
- [ ] Verify status words rotate every 3 seconds with varied text
- [ ] Open chat panel, send a message, verify thinking indicator shows before streaming starts
- [ ] Verify indicator disappears once streaming content arrives

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com