### PR TITLE
feat(about): Add detailed About Seren dialog with build info

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -5,5 +5,38 @@ fn main() {
         std::env::var("TARGET").unwrap()
     );
 
+    // Embed git commit hash at compile time
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+    {
+        let commit = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        println!("cargo:rustc-env=BUILT_COMMIT={commit}");
+    } else {
+        println!("cargo:rustc-env=BUILT_COMMIT=unknown");
+    }
+
+    // Embed build date at compile time (ISO 8601)
+    if let Ok(output) = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+    {
+        let date = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        println!("cargo:rustc-env=BUILT_DATE={date}");
+    } else {
+        println!("cargo:rustc-env=BUILT_DATE=unknown");
+    }
+
+    // Embed Rust version at compile time
+    if let Ok(output) = std::process::Command::new("rustc")
+        .args(["--version"])
+        .output()
+    {
+        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        println!("cargo:rustc-env=BUILT_RUST_VERSION={version}");
+    } else {
+        println!("cargo:rustc-env=BUILT_RUST_VERSION=unknown");
+    }
+
     tauri_build::build()
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { ResizableLayout } from "@/components/common/ResizableLayout";
 import { StatusBar } from "@/components/common/StatusBar";
 import { EditorContent } from "@/components/editor/EditorContent";
 // MCP OAuth dialog removed - now using API key auth flow
+import { AboutDialog } from "@/components/common/AboutDialog";
 import { X402PaymentApproval } from "@/components/mcp/X402PaymentApproval";
 import { DailyClaimPopup } from "@/components/wallet/DailyClaimPopup";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
@@ -232,6 +233,7 @@ function App() {
         <LowBalanceModal />
         <DailyClaimPopup />
         <X402PaymentApproval />
+        <AboutDialog />
       </div>
     </Show>
   );

--- a/src/components/common/AboutDialog.css
+++ b/src/components/common/AboutDialog.css
@@ -1,0 +1,99 @@
+/* ABOUTME: Styles for the About Seren dialog. */
+/* ABOUTME: Matches existing modal patterns with build info layout. */
+
+.about-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.15s ease-out;
+}
+
+.about-dialog {
+  background: var(--popover);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  width: 420px;
+  max-width: 90vw;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  animation: slideUp 0.2s ease-out;
+  overflow: hidden;
+}
+
+.about-header {
+  padding: 24px 24px 16px;
+  text-align: center;
+}
+
+.about-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.about-content {
+  padding: 0 24px 16px;
+}
+
+.about-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 0;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.about-label {
+  color: var(--muted-foreground);
+  flex-shrink: 0;
+  margin-right: 16px;
+}
+
+.about-value {
+  color: var(--foreground);
+  text-align: right;
+  word-break: break-all;
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.about-footer {
+  display: flex;
+  gap: 12px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+  justify-content: flex-end;
+}
+
+.about-footer button {
+  padding: 8px 20px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  transition: background 0.15s;
+}
+
+.about-btn-ok {
+  background: var(--card);
+  color: var(--foreground);
+}
+
+.about-btn-ok:hover {
+  background: var(--accent);
+}
+
+.about-btn-copy {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.about-btn-copy:hover {
+  opacity: 0.9;
+}

--- a/src/components/common/AboutDialog.tsx
+++ b/src/components/common/AboutDialog.tsx
@@ -1,0 +1,113 @@
+// ABOUTME: About Seren dialog showing detailed build information.
+// ABOUTME: Triggered by the native "About Seren" menu item via Tauri event.
+
+import { createSignal, onCleanup, onMount, Show } from "solid-js";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import "./AboutDialog.css";
+
+interface BuildInfo {
+  app_version: string;
+  commit: string;
+  build_date: string;
+  build_type: string;
+  tauri_version: string;
+  webview: string;
+  rust_version: string;
+  os: string;
+}
+
+export function AboutDialog() {
+  const [isOpen, setIsOpen] = createSignal(false);
+  const [info, setInfo] = createSignal<BuildInfo | null>(null);
+  const [copied, setCopied] = createSignal(false);
+
+  onMount(() => {
+    const unlisten = listen("open-about", async () => {
+      try {
+        const buildInfo = await invoke<BuildInfo>("get_build_info");
+        setInfo(buildInfo);
+      } catch (e) {
+        console.error("[AboutDialog] Failed to get build info:", e);
+      }
+      setIsOpen(true);
+    });
+
+    onCleanup(() => {
+      unlisten.then((fn) => fn());
+    });
+  });
+
+  function close() {
+    setIsOpen(false);
+    setCopied(false);
+  }
+
+  function handleBackdropClick(e: MouseEvent) {
+    if (e.target === e.currentTarget) close();
+  }
+
+  function copyInfo() {
+    const data = info();
+    if (!data) return;
+
+    const text = [
+      `Version: ${data.app_version}`,
+      `Commit: ${data.commit}`,
+      `Date: ${data.build_date}`,
+      `Build Type: ${data.build_type}`,
+      `Tauri: ${data.tauri_version}`,
+      `WebView: ${data.webview}`,
+      `Rust: ${data.rust_version}`,
+      `OS: ${data.os}`,
+    ].join("\n");
+
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <Show when={isOpen()}>
+      <div class="about-overlay" onClick={handleBackdropClick}>
+        <div class="about-dialog">
+          <div class="about-header">
+            <h2>Seren</h2>
+          </div>
+          <Show when={info()}>
+            {(data) => (
+              <div class="about-content">
+                <Row label="Version" value={data().app_version} />
+                <Row label="Commit" value={data().commit} />
+                <Row label="Date" value={data().build_date} />
+                <Row label="Build Type" value={data().build_type} />
+                <Row label="Tauri" value={data().tauri_version} />
+                <Row label="WebView" value={data().webview} />
+                <Row label="Rust" value={data().rust_version} />
+                <Row label="OS" value={data().os} />
+              </div>
+            )}
+          </Show>
+          <div class="about-footer">
+            <button class="about-btn-ok" onClick={close}>
+              OK
+            </button>
+            <button class="about-btn-copy" onClick={copyInfo}>
+              {copied() ? "Copied!" : "Copy"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}
+
+function Row(props: { label: string; value: string }) {
+  return (
+    <div class="about-row">
+      <span class="about-label">{props.label}</span>
+      <span class="about-value">{props.value}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Custom About dialog triggered from native macOS Seren menu
- Shows: Version, Commit, Build Date, Build Type, Tauri, WebView, Rust, OS
- Copy button for easy bug reporting (matches Cursor's About dialog UX)
- Build script embeds git commit hash, build date, and Rust version at compile time

## Test plan
- [ ] Run `pnpm tauri dev` and click Seren > About Seren in macOS menu bar
- [ ] Verify all build info fields display correctly
- [ ] Click Copy and paste into text editor to verify output
- [ ] Click OK to close dialog
- [ ] Click backdrop to close dialog

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com