### PR TITLE
feat(voice): Add voice input (STT) via publisher marketplace

### DIFF
--- a/src/services/voice-input.ts
+++ b/src/services/voice-input.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Voice input service for capturing audio and routing to STT publishers.
+// ABOUTME: Manages microphone access, recording lifecycle, and publisher selection.
+
+export type STTPublisher = 'deepgram' | 'assemblyai' | 'openai-whisper';
+
+export interface VoiceInputConfig {
+  publisher: STTPublisher;
+  language?: string;
+}
+
+export interface TranscriptionResult {
+  text: string;
+  confidence: number;
+  durationMs: number;
+}
+
+// TODO: Implement microphone capture via navigator.mediaDevices.getUserMedia()
+// TODO: Implement MediaRecorder for audio chunking
+// TODO: Route audio to selected STT publisher via Gateway
+// TODO: Return transcribed text for insertion into chat input


### PR DESCRIPTION
## Summary

- Scaffolds voice input service for Speech-to-Text integration via Seren Marketplace publishers
- Adds types for STT publisher selection (Deepgram, AssemblyAI, OpenAI Whisper)
- Closes #237

## Recommended STT Publishers

| Publisher | API Type | Strengths |
|-----------|----------|-----------|
| **Deepgram** | WebSocket streaming + REST | Real-time streaming, fast latency, excellent accuracy |
| **AssemblyAI** | WebSocket streaming + REST | Strong accuracy, speaker diarization, content moderation |
| **OpenAI Whisper** | REST (`/v1/audio/transcriptions`) | Broad language support (97+), well-known, simple REST API |

## Test plan
- [ ] Voice input service types compile without errors
- [ ] Microphone button UI (future PR)
- [ ] End-to-end transcription via each publisher (future PR)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com