### PR TITLE
feat(chat): add image attachment support (#235)

### DIFF
--- a/src/components/chat/ImageAttachmentBar.tsx
+++ b/src/components/chat/ImageAttachmentBar.tsx
@@ -1,0 +1,73 @@
+// ABOUTME: Shared image attachment UI for chat and agent input areas.
+// ABOUTME: Shows attach button, image thumbnails, and remove controls.
+
+import type { Component } from "solid-js";
+import { For, Show } from "solid-js";
+import { toDataUrl } from "@/lib/images/attachments";
+import type { ImageAttachment } from "@/lib/providers/types";
+
+interface ImageAttachmentBarProps {
+  images: ImageAttachment[];
+  onAttach: () => void;
+  onRemove: (index: number) => void;
+}
+
+export const ImageAttachmentBar: Component<ImageAttachmentBarProps> = (
+  props,
+) => {
+  return (
+    <div class="flex items-center gap-2">
+      {/* Attach button */}
+      <button
+        type="button"
+        class="flex items-center gap-1 px-2 py-1 bg-transparent border border-[#30363d] text-[#8b949e] rounded text-xs cursor-pointer transition-colors hover:bg-[#21262d] hover:text-[#e6edf3]"
+        onClick={props.onAttach}
+        title="Attach images"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          role="img"
+          aria-label="Attach"
+        >
+          <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+        </svg>
+        Attach
+      </button>
+
+      {/* Image thumbnails */}
+      <Show when={props.images.length > 0}>
+        <div class="flex items-center gap-1.5 overflow-x-auto">
+          <For each={props.images}>
+            {(image, index) => (
+              <div class="relative group flex-shrink-0">
+                <img
+                  src={toDataUrl(image)}
+                  alt={image.name}
+                  class="w-10 h-10 object-cover rounded border border-[#30363d]"
+                />
+                <button
+                  type="button"
+                  class="absolute -top-1 -right-1 w-4 h-4 bg-[#f85149] text-white rounded-full text-[10px] leading-none flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer border-none"
+                  onClick={() => props.onRemove(index())}
+                  title={`Remove ${image.name}`}
+                >
+                  ×
+                </button>
+                <div class="absolute bottom-0 left-0 right-0 bg-black/60 text-[8px] text-white text-center truncate px-0.5 rounded-b">
+                  {image.name}
+                </div>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+};

--- a/src/components/chat/MessageImages.tsx
+++ b/src/components/chat/MessageImages.tsx
@@ -1,0 +1,55 @@
+// ABOUTME: Renders image attachments within chat message bubbles.
+// ABOUTME: Displays base64 images as thumbnails with click-to-expand behavior.
+
+import type { Component } from "solid-js";
+import { createSignal, For, Show } from "solid-js";
+import { toDataUrl } from "@/lib/images/attachments";
+import type { ImageAttachment } from "@/lib/providers/types";
+
+interface MessageImagesProps {
+  images: ImageAttachment[];
+}
+
+export const MessageImages: Component<MessageImagesProps> = (props) => {
+  const [expandedIndex, setExpandedIndex] = createSignal<number | null>(null);
+
+  return (
+    <div class="flex flex-wrap gap-2 my-2">
+      <For each={props.images}>
+        {(image, index) => (
+          <>
+            <button
+              type="button"
+              class="border border-[#30363d] rounded-lg overflow-hidden cursor-pointer bg-transparent p-0 hover:border-[#58a6ff] transition-colors"
+              onClick={() => setExpandedIndex(index())}
+              title={image.name}
+            >
+              <img
+                src={toDataUrl(image)}
+                alt={image.name}
+                class="max-w-[200px] max-h-[150px] object-contain"
+              />
+            </button>
+
+            {/* Expanded overlay */}
+            <Show when={expandedIndex() === index()}>
+              <div
+                class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 cursor-pointer"
+                onClick={() => setExpandedIndex(null)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") setExpandedIndex(null);
+                }}
+              >
+                <img
+                  src={toDataUrl(image)}
+                  alt={image.name}
+                  class="max-w-[90vw] max-h-[90vh] object-contain rounded-lg"
+                />
+              </div>
+            </Show>
+          </>
+        )}
+      </For>
+    </div>
+  );
+};

--- a/src/lib/images/attachments.ts
+++ b/src/lib/images/attachments.ts
@@ -1,0 +1,108 @@
+// ABOUTME: Image attachment utilities for picking, reading, and validating images.
+// ABOUTME: Provides file dialog integration and base64 conversion for chat image attachments.
+
+import { open } from "@tauri-apps/plugin-dialog";
+import { readFile } from "@tauri-apps/plugin-fs";
+import type { ImageAttachment } from "@/lib/providers/types";
+
+const SUPPORTED_EXTENSIONS = ["png", "jpg", "jpeg", "gif", "webp"];
+const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
+
+const MIME_TYPES: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+};
+
+function getExtension(path: string): string {
+  const parts = path.split(".");
+  return parts.length > 1 ? parts[parts.length - 1].toLowerCase() : "";
+}
+
+function getFileName(path: string): string {
+  const parts = path.split("/");
+  const winParts = parts[parts.length - 1].split("\\");
+  return winParts[winParts.length - 1];
+}
+
+/**
+ * Open a file dialog to pick one or more images.
+ * Returns file paths selected by the user.
+ */
+export async function pickImageFiles(): Promise<string[]> {
+  const selected = await open({
+    multiple: true,
+    title: "Attach Images",
+    filters: [
+      {
+        name: "Images",
+        extensions: SUPPORTED_EXTENSIONS,
+      },
+    ],
+  });
+
+  if (!selected) return [];
+  if (typeof selected === "string") return [selected];
+  return selected;
+}
+
+/**
+ * Read an image file and convert it to an ImageAttachment.
+ */
+export async function readImageAttachment(
+  path: string,
+): Promise<ImageAttachment> {
+  const ext = getExtension(path);
+  const mimeType = MIME_TYPES[ext];
+  if (!mimeType) {
+    throw new Error(`Unsupported image format: .${ext}`);
+  }
+
+  const bytes = await readFile(path);
+  if (bytes.length > MAX_FILE_SIZE) {
+    throw new Error(
+      `Image too large: ${(bytes.length / 1024 / 1024).toFixed(1)}MB (max 20MB)`,
+    );
+  }
+
+  // Convert Uint8Array to base64
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  const base64 = btoa(binary);
+
+  return {
+    name: getFileName(path),
+    mimeType,
+    base64,
+  };
+}
+
+/**
+ * Pick images via file dialog and return them as attachments.
+ */
+export async function pickAndReadImages(): Promise<ImageAttachment[]> {
+  const paths = await pickImageFiles();
+  const attachments: ImageAttachment[] = [];
+
+  for (const path of paths) {
+    try {
+      const attachment = await readImageAttachment(path);
+      attachments.push(attachment);
+    } catch (error) {
+      console.warn(`[attachments] Failed to read image ${path}:`, error);
+    }
+  }
+
+  return attachments;
+}
+
+/**
+ * Build a data URL from an ImageAttachment.
+ */
+export function toDataUrl(attachment: ImageAttachment): string {
+  return `data:${attachment.mimeType};base64,${attachment.base64}`;
+}

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -82,11 +82,43 @@ export interface OAuthCredentials {
 export type ProviderCredentials = ApiKeyCredentials | OAuthCredentials;
 
 /**
+ * Text content block for multimodal messages.
+ */
+export interface TextContentBlock {
+  type: "text";
+  text: string;
+}
+
+/**
+ * Image content block for multimodal messages (OpenAI-compatible format).
+ */
+export interface ImageContentBlock {
+  type: "image_url";
+  image_url: {
+    url: string; // data:image/png;base64,... or https://...
+  };
+}
+
+/**
+ * Content block for multimodal messages.
+ */
+export type ContentBlock = TextContentBlock | ImageContentBlock;
+
+/**
+ * Image attachment metadata stored with messages.
+ */
+export interface ImageAttachment {
+  name: string;
+  mimeType: string;
+  base64: string; // raw base64 without data URL prefix
+}
+
+/**
  * Message format for chat requests.
  */
 export interface ChatMessage {
   role: "user" | "assistant" | "system";
-  content: string;
+  content: string | ContentBlock[];
 }
 
 /**
@@ -160,7 +192,7 @@ export interface ToolCall {
  */
 export interface ChatMessageWithTools {
   role: "user" | "assistant" | "system" | "tool";
-  content: string | null;
+  content: string | ContentBlock[] | null;
   tool_calls?: ToolCall[];
   tool_call_id?: string; // Required when role is "tool"
 }


### PR DESCRIPTION
## Summary

- Add image attachment support to both chat and agent input panels
- Users can pick images via file dialog (PNG, JPG, JPEG, GIF, WebP, max 20MB)
- Images display as thumbnails in the input area with remove buttons
- Attached images render in message history with click-to-expand overlay
- Multimodal content blocks (OpenAI-compatible format) sent to vision-capable AI models

## Changes

- **`src/lib/providers/types.ts`** — Added `ContentBlock`, `ImageAttachment` types; made `ChatMessage.content` support `string | ContentBlock[]`
- **`src/lib/images/attachments.ts`** (NEW) — File dialog integration, base64 conversion, validation
- **`src/components/chat/ImageAttachmentBar.tsx`** (NEW) — Shared attach button + thumbnail strip component
- **`src/components/chat/MessageImages.tsx`** (NEW) — Image display in message bubbles with expand overlay
- **`src/services/chat.ts`** — `Message.images` field, `buildUserContent()` helper, `streamMessageWithTools()` accepts images
- **`src/components/chat/ChatContent.tsx`** — Integrated attachment UI and image display in chat panel
- **`src/components/chat/AgentChat.tsx`** — Integrated attachment UI in agent panel (images passed as context)

Closes #235

## Test plan

- [ ] Click "Attach" button in chat panel — file dialog opens with image filter
- [ ] Select image — thumbnail appears in input area
- [ ] Click X on thumbnail — image removed
- [ ] Send message with image — image appears in message bubble, AI analyzes it
- [ ] Click image in message — expands to full size overlay
- [ ] Test same workflow in agent panel
- [ ] Verify multiple images can be attached simultaneously

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com