### PR TITLE
fix(about): Add release tag to About dialog

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -27,6 +27,21 @@ fn main() {
         println!("cargo:rustc-env=BUILT_DATE=unknown");
     }
 
+    // Embed release tag at compile time (e.g. v0.1.0-alpha.24)
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["describe", "--tags", "--abbrev=0"])
+        .output()
+    {
+        let tag = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !tag.is_empty() {
+            println!("cargo:rustc-env=BUILT_RELEASE_TAG={tag}");
+        } else {
+            println!("cargo:rustc-env=BUILT_RELEASE_TAG=dev");
+        }
+    } else {
+        println!("cargo:rustc-env=BUILT_RELEASE_TAG=dev");
+    }
+
     // Embed Rust version at compile time
     if let Ok(output) = std::process::Command::new("rustc")
         .args(["--version"])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -274,6 +274,7 @@ fn get_oauth_callback_port() -> Result<u16, String> {
 #[derive(serde::Serialize)]
 struct BuildInfo {
     app_version: String,
+    release_tag: String,
     commit: String,
     build_date: String,
     build_type: String,
@@ -304,6 +305,7 @@ fn get_build_info(app: tauri::AppHandle) -> BuildInfo {
 
     BuildInfo {
         app_version: version,
+        release_tag: env!("BUILT_RELEASE_TAG").to_string(),
         commit: env!("BUILT_COMMIT").to_string(),
         build_date: env!("BUILT_DATE").to_string(),
         build_type: "Alpha".to_string(),

--- a/src/components/common/AboutDialog.tsx
+++ b/src/components/common/AboutDialog.tsx
@@ -8,6 +8,7 @@ import "./AboutDialog.css";
 
 interface BuildInfo {
   app_version: string;
+  release_tag: string;
   commit: string;
   build_date: string;
   build_type: string;
@@ -53,6 +54,7 @@ export function AboutDialog() {
 
     const text = [
       `Version: ${data.app_version}`,
+      `Release: ${data.release_tag}`,
       `Commit: ${data.commit}`,
       `Date: ${data.build_date}`,
       `Build Type: ${data.build_type}`,
@@ -79,6 +81,7 @@ export function AboutDialog() {
             {(data) => (
               <div class="about-content">
                 <Row label="Version" value={data().app_version} />
+                <Row label="Release" value={data().release_tag} />
                 <Row label="Commit" value={data().commit} />
                 <Row label="Date" value={data().build_date} />
                 <Row label="Build Type" value={data().build_type} />


### PR DESCRIPTION
## Summary
- About dialog now shows the release tag (e.g. v0.1.0-alpha.24) so users know which release they're running
- Embeds nearest git tag at compile time via build.rs

## Test plan
- [ ] Click Seren > About Seren
- [ ] Verify Release row shows tag like v0.1.0-alpha.24

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com