### PR TITLE
feat(chat): Add slash command system with 17 commands

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,18 +14,18 @@ import {
 import { SignIn } from "@/components/auth/SignIn";
 import { CatalogPanel } from "@/components/catalog";
 import { ChatContent } from "@/components/chat/ChatContent";
+// MCP OAuth dialog removed - now using API key auth flow
+import { AboutDialog } from "@/components/common/AboutDialog";
 import { Header, type Panel } from "@/components/common/Header";
 import { LowBalanceModal } from "@/components/common/LowBalanceWarning";
 import { ResizableLayout } from "@/components/common/ResizableLayout";
 import { StatusBar } from "@/components/common/StatusBar";
 import { EditorContent } from "@/components/editor/EditorContent";
-// MCP OAuth dialog removed - now using API key auth flow
-import { AboutDialog } from "@/components/common/AboutDialog";
 import { X402PaymentApproval } from "@/components/mcp/X402PaymentApproval";
-import { DailyClaimPopup } from "@/components/wallet/DailyClaimPopup";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { DatabasePanel } from "@/components/sidebar/DatabasePanel";
 import { FileExplorer } from "@/components/sidebar/FileExplorer";
+import { DailyClaimPopup } from "@/components/wallet/DailyClaimPopup";
 import { shortcuts } from "@/lib/shortcuts";
 import { Phase3Playground } from "@/playground/Phase3Playground";
 import { initAutoTopUp } from "@/services/autoTopUp";
@@ -95,6 +95,18 @@ function App() {
       // Escape closes overlay panels
       setOverlayPanel(null);
     });
+
+    // Listen for slash command panel navigation
+    const onOpenPanel = ((e: CustomEvent) => {
+      const p = e.detail as string;
+      if (p === "editor") {
+        setShowEditor(true);
+        setOverlayPanel(null);
+      } else {
+        handlePanelChange(p as Panel);
+      }
+    }) as EventListener;
+    window.addEventListener("seren:open-panel", onOpenPanel);
   });
 
   onCleanup(() => {

--- a/src/components/chat/SlashCommandPopup.css
+++ b/src/components/chat/SlashCommandPopup.css
@@ -1,0 +1,61 @@
+/* ABOUTME: Styles for the slash command autocomplete popup. */
+/* ABOUTME: Positioned above the chat input area. */
+
+.slash-popup {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 4px;
+  background: var(--popover);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+  z-index: 50;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.slash-popup-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 13px;
+  color: var(--foreground);
+  transition: background 0.1s;
+}
+
+.slash-popup-item:hover,
+.slash-popup-item--active {
+  background: var(--accent);
+}
+
+.slash-popup-name {
+  font-weight: 600;
+  color: var(--primary);
+  flex-shrink: 0;
+  font-family: monospace;
+}
+
+.slash-popup-desc {
+  color: var(--muted-foreground);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.slash-popup-hint {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-style: italic;
+  opacity: 0.7;
+  flex-shrink: 0;
+}

--- a/src/components/chat/SlashCommandPopup.tsx
+++ b/src/components/chat/SlashCommandPopup.tsx
@@ -1,0 +1,47 @@
+// ABOUTME: Autocomplete popup for slash commands in chat/agent input.
+// ABOUTME: Shows matching commands as user types "/" prefix.
+
+import { For, Show } from "solid-js";
+import { getCompletions } from "@/lib/commands/parser";
+import type { SlashCommand } from "@/lib/commands/types";
+import "./SlashCommandPopup.css";
+
+interface SlashCommandPopupProps {
+  input: string;
+  panel: "chat" | "agent";
+  onSelect: (command: SlashCommand) => void;
+  /** Index of the currently highlighted item (controlled by parent for keyboard nav) */
+  selectedIndex: number;
+}
+
+export function SlashCommandPopup(props: SlashCommandPopupProps) {
+  const matches = () => getCompletions(props.input, props.panel);
+
+  return (
+    <Show when={matches().length > 0}>
+      <div class="slash-popup">
+        <For each={matches()}>
+          {(cmd, i) => (
+            <button
+              type="button"
+              class="slash-popup-item"
+              classList={{
+                "slash-popup-item--active": i() === props.selectedIndex,
+              }}
+              onMouseDown={(e) => {
+                e.preventDefault(); // Prevent input blur
+                props.onSelect(cmd);
+              }}
+            >
+              <span class="slash-popup-name">/{cmd.name}</span>
+              <span class="slash-popup-desc">{cmd.description}</span>
+              {cmd.argHint && (
+                <span class="slash-popup-hint">{cmd.argHint}</span>
+              )}
+            </button>
+          )}
+        </For>
+      </div>
+    </Show>
+  );
+}

--- a/src/lib/commands/index.ts
+++ b/src/lib/commands/index.ts
@@ -1,0 +1,6 @@
+// ABOUTME: Barrel export for the slash commands module.
+// ABOUTME: Ensures registry is initialized when any command API is imported.
+
+export { getCompletions, parseCommand } from "./parser";
+export { registry } from "./registry";
+export type { CommandContext, ParsedCommand, SlashCommand } from "./types";

--- a/src/lib/commands/parser.ts
+++ b/src/lib/commands/parser.ts
@@ -1,0 +1,47 @@
+// ABOUTME: Parses slash command input and matches against the registry.
+// ABOUTME: Returns parsed command or null if input is not a command.
+
+import { registry } from "./registry";
+import type { ParsedCommand } from "./types";
+
+/**
+ * Parse input text to see if it starts with a slash command.
+ * Returns the matched command and remaining args, or null.
+ */
+export function parseCommand(
+  input: string,
+  panel: "chat" | "agent",
+): ParsedCommand | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("/")) return null;
+
+  // Extract command name (everything up to first space)
+  const spaceIdx = trimmed.indexOf(" ");
+  const name = spaceIdx === -1 ? trimmed.slice(1) : trimmed.slice(1, spaceIdx);
+  const args = spaceIdx === -1 ? "" : trimmed.slice(spaceIdx + 1).trim();
+
+  if (!name) return null;
+
+  const command = registry.get(name, panel);
+  if (!command) return null;
+
+  return { command, args };
+}
+
+/**
+ * Get commands matching a partial input for autocomplete.
+ * Input should start with "/" but the slash is stripped for matching.
+ */
+export function getCompletions(
+  input: string,
+  panel: "chat" | "agent",
+): import("./types").SlashCommand[] {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("/")) return [];
+
+  // Only complete if still typing the command name (no space yet)
+  if (trimmed.includes(" ")) return [];
+
+  const partial = trimmed.slice(1).toLowerCase();
+  return registry.search(partial, panel);
+}

--- a/src/lib/commands/registry.ts
+++ b/src/lib/commands/registry.ts
@@ -1,0 +1,285 @@
+// ABOUTME: Central registry of all slash commands with their handlers.
+// ABOUTME: Commands are organized by tier and registered at module load.
+
+import { acpStore } from "@/stores/acp.store";
+import { chatStore } from "@/stores/chat.store";
+import { providerStore } from "@/stores/provider.store";
+import { settingsStore } from "@/stores/settings.store";
+import { walletStore } from "@/stores/wallet.store";
+import type { SlashCommand } from "./types";
+
+class CommandRegistry {
+  private commands = new Map<string, SlashCommand>();
+
+  register(cmd: SlashCommand) {
+    this.commands.set(cmd.name, cmd);
+  }
+
+  get(name: string, panel: "chat" | "agent"): SlashCommand | undefined {
+    const cmd = this.commands.get(name);
+    if (!cmd) return undefined;
+    if (!cmd.panels.includes(panel)) return undefined;
+    return cmd;
+  }
+
+  search(partial: string, panel: "chat" | "agent"): SlashCommand[] {
+    const results: SlashCommand[] = [];
+    for (const cmd of this.commands.values()) {
+      if (!cmd.panels.includes(panel)) continue;
+      if (cmd.name.startsWith(partial)) {
+        results.push(cmd);
+      }
+    }
+    return results.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  all(panel: "chat" | "agent"): SlashCommand[] {
+    return Array.from(this.commands.values())
+      .filter((cmd) => cmd.panels.includes(panel))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+}
+
+export const registry = new CommandRegistry();
+
+// ---------------------------------------------------------------------------
+// Tier 1: Essential Commands
+// ---------------------------------------------------------------------------
+
+registry.register({
+  name: "model",
+  description: "Switch AI model",
+  argHint: "<model-name>",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    if (!ctx.args) {
+      const models = providerStore
+        .getModels(providerStore.activeProvider)
+        .map((m) => m.name)
+        .join(", ");
+      ctx.showStatus(`Usage: /model <name>. Available: ${models}`);
+      return true;
+    }
+
+    const allModels = providerStore.getModels(providerStore.activeProvider);
+    const match = allModels.find(
+      (m) =>
+        m.id.toLowerCase().includes(ctx.args.toLowerCase()) ||
+        m.name.toLowerCase().includes(ctx.args.toLowerCase()),
+    );
+
+    if (match) {
+      providerStore.setActiveModel(match.id);
+      chatStore.setModel(match.id);
+      ctx.showStatus(`Switched to ${match.name}`);
+    } else {
+      ctx.showStatus(`Model "${ctx.args}" not found.`);
+    }
+    ctx.clearInput();
+    return true;
+  },
+});
+
+registry.register({
+  name: "clear",
+  description: "Clear chat messages",
+  panels: ["chat"],
+  execute: (ctx) => {
+    chatStore.clearMessages();
+    ctx.clearInput();
+    ctx.showStatus("Chat cleared.");
+    return true;
+  },
+});
+
+registry.register({
+  name: "new",
+  description: "Start new conversation",
+  panels: ["chat"],
+  execute: async (ctx) => {
+    await chatStore.createConversation();
+    ctx.clearInput();
+    ctx.showStatus("New conversation started.");
+    return true;
+  },
+});
+
+registry.register({
+  name: "attach",
+  description: "Attach an image",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    window.dispatchEvent(new CustomEvent("seren:pick-images"));
+    ctx.clearInput();
+    return true;
+  },
+});
+
+registry.register({
+  name: "copy",
+  description: "Copy last response",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    const messages = chatStore.messages;
+    const lastAssistant = [...messages]
+      .reverse()
+      .find((m) => m.role === "assistant");
+    if (lastAssistant?.content) {
+      navigator.clipboard.writeText(lastAssistant.content);
+      ctx.showStatus("Response copied to clipboard.");
+    } else {
+      ctx.showStatus("No response to copy.");
+    }
+    ctx.clearInput();
+    return true;
+  },
+});
+
+registry.register({
+  name: "topup",
+  description: "Top up SerenBucks",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    window.dispatchEvent(new CustomEvent("seren:open-deposit"));
+    ctx.clearInput();
+    ctx.showStatus("Opening deposit...");
+    return true;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2: Navigation Commands
+// ---------------------------------------------------------------------------
+
+registry.register({
+  name: "settings",
+  description: "Open settings panel",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    ctx.openPanel("settings");
+    ctx.clearInput();
+    return true;
+  },
+});
+
+registry.register({
+  name: "catalog",
+  description: "Open publisher catalog",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    ctx.openPanel("catalog");
+    ctx.clearInput();
+    return true;
+  },
+});
+
+registry.register({
+  name: "editor",
+  description: "Open code editor",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    ctx.openPanel("editor");
+    ctx.clearInput();
+    return true;
+  },
+});
+
+registry.register({
+  name: "agent",
+  description: "Switch to agent mode",
+  panels: ["chat"],
+  execute: (ctx) => {
+    acpStore.setAgentModeEnabled(true);
+    ctx.clearInput();
+    ctx.showStatus("Switched to agent mode.");
+    return true;
+  },
+});
+
+registry.register({
+  name: "chat",
+  description: "Switch to chat mode",
+  panels: ["agent"],
+  execute: (ctx) => {
+    acpStore.setAgentModeEnabled(false);
+    ctx.clearInput();
+    ctx.showStatus("Switched to chat mode.");
+    return true;
+  },
+});
+
+registry.register({
+  name: "database",
+  description: "Open database panel",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    ctx.openPanel("database");
+    ctx.clearInput();
+    return true;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Tier 3: Power User Commands
+// ---------------------------------------------------------------------------
+
+registry.register({
+  name: "balance",
+  description: "Show SerenBucks balance",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    ctx.showStatus(`Balance: ${walletStore.formattedBalance}`);
+    ctx.clearInput();
+    return true;
+  },
+});
+
+registry.register({
+  name: "about",
+  description: "Show About Seren dialog",
+  panels: ["chat", "agent"],
+  execute: async (ctx) => {
+    const { emit } = await import("@tauri-apps/api/event");
+    await emit("open-about");
+    ctx.clearInput();
+    return true;
+  },
+});
+
+registry.register({
+  name: "tools",
+  description: "List available MCP tools",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    window.dispatchEvent(new CustomEvent("seren:list-tools"));
+    ctx.clearInput();
+    ctx.showStatus("Listing available tools...");
+    return true;
+  },
+});
+
+registry.register({
+  name: "thinking",
+  description: "Toggle thinking display",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    const current = settingsStore.get("chatShowThinking");
+    settingsStore.set("chatShowThinking", !current);
+    ctx.showStatus(`Thinking display ${!current ? "enabled" : "disabled"}.`);
+    ctx.clearInput();
+    return true;
+  },
+});
+
+registry.register({
+  name: "help",
+  description: "Show available commands",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    const commands = registry.all(ctx.panel);
+    const lines = commands.map((c) => `/${c.name} — ${c.description}`);
+    ctx.showStatus(lines.join("\n"));
+    ctx.clearInput();
+    return true;
+  },
+});

--- a/src/lib/commands/types.ts
+++ b/src/lib/commands/types.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Type definitions for the slash command system.
+// ABOUTME: Shared between registry, parser, and UI components.
+
+export interface SlashCommand {
+  name: string;
+  description: string;
+  /** Optional argument hint shown in autocomplete, e.g. "<model-name>" */
+  argHint?: string;
+  /** Which panels support this command */
+  panels: ("chat" | "agent")[];
+  /** Execute the command. Returns true if handled (suppress send). */
+  execute: (ctx: CommandContext) => boolean | Promise<boolean>;
+}
+
+export interface CommandContext {
+  /** The full raw input string */
+  rawInput: string;
+  /** Arguments after the command name */
+  args: string;
+  /** Which panel invoked the command */
+  panel: "chat" | "agent";
+  /** Clear the input field */
+  clearInput: () => void;
+  /** Navigate to an overlay panel */
+  openPanel: (panel: string) => void;
+  /** Show a transient status message in chat */
+  showStatus: (message: string) => void;
+}
+
+export interface ParsedCommand {
+  command: SlashCommand;
+  args: string;
+}


### PR DESCRIPTION
## Summary
- Adds a `/` slash command system to both Chat and Agent panels with autocomplete popup and keyboard navigation (arrow keys, Tab, Escape)
- Implements 17 commands across three tiers: essential (`/model`, `/clear`, `/new`, `/attach`, `/copy`, `/topup`), navigation (`/settings`, `/catalog`, `/editor`, `/agent`, `/chat`, `/database`), and power user (`/balance`, `/about`, `/tools`, `/thinking`, `/help`)
- Extensible registry-based architecture in `src/lib/commands/` for easy addition of future commands

Closes #241

## Test plan
- [ ] Type `/` in chat input — autocomplete popup appears with all available commands
- [ ] Arrow up/down navigates popup, Tab/Enter selects, Escape dismisses
- [ ] `/model sonnet` switches model and shows status message
- [ ] `/clear` clears chat messages
- [ ] `/new` creates a new conversation
- [ ] `/settings`, `/catalog`, `/database` open their respective panels
- [ ] `/agent` switches to agent mode from chat; `/chat` switches back
- [ ] `/help` lists all available commands
- [ ] `/thinking` toggles thinking display
- [ ] `/copy` copies last assistant response to clipboard
- [ ] `/topup` opens deposit modal
- [ ] `/about` opens About Seren dialog
- [ ] `/attach` opens image picker
- [ ] `/balance` shows SerenBucks balance
- [ ] Commands work in both Chat and Agent panels (where applicable)
- [ ] Non-command messages starting with `/` (e.g., file paths) still send normally

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com