### PR TITLE
feat(chat): add image attachment support (#235)

### DIFF
--- a/src-tauri/src/files.rs
+++ b/src-tauri/src/files.rs
@@ -1,6 +1,7 @@
 // ABOUTME: File system operations for the editor.
 // ABOUTME: Provides commands for reading, writing, and listing files/directories.
 
+use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
@@ -16,6 +17,13 @@ pub struct FileEntry {
 #[tauri::command]
 pub fn read_file(path: String) -> Result<String, String> {
     fs::read_to_string(&path).map_err(|e| format!("Failed to read file: {}", e))
+}
+
+/// Read a file and return its contents as base64.
+#[tauri::command]
+pub fn read_file_base64(path: String) -> Result<String, String> {
+    let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+    Ok(STANDARD.encode(&bytes))
 }
 
 /// Write content to a file.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -462,6 +462,7 @@ pub fn run() {
             clear_provider_key,
             get_configured_providers,
             files::read_file,
+            files::read_file_base64,
             files::write_file,
             files::list_directory,
             files::path_exists,


### PR DESCRIPTION
## Summary

- Add image attachment support to both chat and agent input panels
- Users can pick images via file dialog (PNG, JPG, JPEG, GIF, WebP, max 20MB)
- Images display as thumbnails in the input area with remove buttons
- Attached images render in message history with click-to-expand overlay
- Multimodal content blocks (OpenAI-compatible format) sent to vision-capable AI models
- New `read_file_base64` Rust command for binary file reading via Tauri IPC

## Changes

- **`src-tauri/src/files.rs`** — Added `read_file_base64` command for binary file reads
- **`src-tauri/src/lib.rs`** — Registered new command
- **`src/lib/providers/types.ts`** — Added `ContentBlock`, `ImageAttachment` types; `ChatMessage.content` supports `string | ContentBlock[]`
- **`src/lib/images/attachments.ts`** (NEW) — File dialog integration, base64 conversion via IPC, validation
- **`src/components/chat/ImageAttachmentBar.tsx`** (NEW) — Shared attach button + thumbnail strip component
- **`src/components/chat/MessageImages.tsx`** (NEW) — Image display in message bubbles with expand overlay
- **`src/services/chat.ts`** — `Message.images` field, `buildUserContent()` helper, `streamMessageWithTools()` accepts images
- **`src/components/chat/ChatContent.tsx`** — Integrated attachment UI and image display in chat panel
- **`src/components/chat/AgentChat.tsx`** — Integrated attachment UI in agent panel (images passed as context)

Closes #235

## Test plan

- [ ] Click Attach button in chat panel — file dialog opens with image filter
- [ ] Select image — thumbnail appears in input area
- [ ] Click X on thumbnail — image removed
- [ ] Send message with image — image appears in message bubble, AI analyzes it
- [ ] Click image in message — expands to full size overlay
- [ ] Test same workflow in agent panel
- [ ] Verify multiple images can be attached simultaneously

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com