### PR TITLE
fix(voice): add macOS microphone permission

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Seren uses your microphone to transcribe voice input for AI chat.</string>
+</dict>
+</plist>

--- a/src/lib/audio/useVoiceInput.ts
+++ b/src/lib/audio/useVoiceInput.ts
@@ -27,6 +27,13 @@ export function useVoiceInput(onTranscript: (text: string) => void) {
     let stream: MediaStream | null = null;
     try {
       setError(null);
+
+      if (!navigator.mediaDevices?.getUserMedia) {
+        throw new Error(
+          "Microphone access is not available. Please ensure the app has microphone permission in System Settings > Privacy & Security > Microphone.",
+        );
+      }
+
       activeMimeType = getSupportedMimeType();
       const options: MediaRecorderOptions = activeMimeType
         ? { mimeType: activeMimeType }


### PR DESCRIPTION
## Summary
- Adds NSMicrophoneUsageDescription to src-tauri/Info.plist so macOS WKWebView exposes navigator.mediaDevices
- Adds defensive guard in useVoiceInput.ts with a clear error message when mediaDevices is unavailable

## Root Cause
Tauri WKWebView on macOS does not expose navigator.mediaDevices.getUserMedia unless the app declares NSMicrophoneUsageDescription in its Info.plist. Without it, clicking the mic button throws undefined is not an object.

## Test plan
- [ ] pnpm tauri dev - click mic button, macOS should prompt for microphone permission
- [ ] Grant permission - recording indicator should appear
- [ ] Deny permission - error tooltip should show Microphone access denied

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com