### PR TITLE
Add stop/cancel button for chat and agent streaming

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -194,6 +194,21 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     await acpStore.cancelPrompt();
   };
 
+  const handleGlobalKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape" && isPrompting()) {
+      event.preventDefault();
+      handleCancel();
+    }
+  };
+
+  onMount(() => {
+    document.addEventListener("keydown", handleGlobalKeyDown);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener("keydown", handleGlobalKeyDown);
+  });
+
   const handleKeyDown = (event: KeyboardEvent) => {
     // Slash command popup keyboard navigation
     const isSlashInput = input().startsWith("/") && !input().includes(" ");


### PR DESCRIPTION
## Summary
- Adds a **Stop button** in chat mode that replaces the Send button while streaming is active
- Adds **Escape key** support to cancel streaming in both chat mode and agent mode
- Cancellation cleanly stops the stream via existing `onCleanup` hooks in streaming components

## Test plan
- [ ] Send a chat message, verify Stop button appears during streaming
- [ ] Click Stop — streaming stops, UI resets to Send button
- [ ] Send a chat message, press Escape — same cancellation behavior
- [ ] In agent mode, start a prompt, press Escape — agent cancels
- [ ] Verify no error messages appear after cancellation

Closes #262

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com