### PR TITLE
feat(acp): inline diff view with accept/reject for file edits

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -645,6 +645,8 @@ pub fn run() {
             acp::acp_check_agent_available,
             #[cfg(feature = "acp")]
             acp::acp_ensure_claude_cli,
+            #[cfg(feature = "acp")]
+            acp::acp_respond_to_diff_proposal,
             // OpenClaw commands (conditionally included when openclaw feature is enabled)
             #[cfg(feature = "openclaw")]
             openclaw::openclaw_start,

--- a/src/components/acp/DiffProposalDialog.css
+++ b/src/components/acp/DiffProposalDialog.css
@@ -1,0 +1,94 @@
+/* ABOUTME: Styles for the diff proposal review dialog. */
+/* ABOUTME: Inline card shown in agent chat when a file edit needs user approval. */
+
+.diff-proposal-dialog {
+  border: 1px solid var(--border-color, #333);
+  border-radius: 8px;
+  margin: 8px 0;
+  background: var(--surface-secondary, #1a1a2e);
+  overflow: hidden;
+}
+
+.diff-proposal-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border-color, #333);
+}
+
+.diff-proposal-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.diff-proposal-title {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.diff-proposal-path {
+  margin-left: auto;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--text-secondary, #aaa);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 50%;
+}
+
+.diff-proposal-editor {
+  height: 300px;
+  min-height: 150px;
+  max-height: 60vh;
+  resize: vertical;
+  overflow: hidden;
+}
+
+.diff-proposal-actions {
+  display: flex;
+  gap: 8px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border-color, #333);
+  align-items: center;
+}
+
+.diff-proposal-stats {
+  font-size: 11px;
+  color: var(--text-secondary, #aaa);
+  margin-right: auto;
+}
+
+.diff-proposal-stats-added {
+  color: #3fb950;
+}
+
+.diff-proposal-stats-removed {
+  color: #f85149;
+}
+
+.diff-proposal-btn {
+  padding: 6px 16px;
+  border-radius: 6px;
+  border: none;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.diff-proposal-btn:hover {
+  opacity: 0.85;
+}
+
+.diff-proposal-btn--accept {
+  background: #238636;
+  color: white;
+}
+
+.diff-proposal-btn--reject {
+  background: var(--surface-tertiary, #333);
+  color: var(--text-secondary, #aaa);
+}

--- a/src/components/acp/DiffProposalDialog.tsx
+++ b/src/components/acp/DiffProposalDialog.tsx
@@ -1,0 +1,149 @@
+// ABOUTME: Diff proposal review dialog for agent file edits.
+// ABOUTME: Shows Monaco diff editor with accept/reject buttons before writing to disk.
+
+import type { Component } from "solid-js";
+import { createSignal, onCleanup, onMount } from "solid-js";
+import type * as Monaco from "monaco-editor";
+import { getMonaco } from "@/lib/editor";
+import type { DiffProposalEvent } from "@/stores/acp.store";
+import { acpStore } from "@/stores/acp.store";
+import "./DiffProposalDialog.css";
+
+export interface DiffProposalDialogProps {
+  proposal: DiffProposalEvent;
+}
+
+function countDiffLines(oldText: string, newText: string): { added: number; removed: number } {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+  const oldSet = new Set(oldLines);
+  const newSet = new Set(newLines);
+  let added = 0;
+  let removed = 0;
+  for (const line of newLines) {
+    if (!oldSet.has(line)) added++;
+  }
+  for (const line of oldLines) {
+    if (!newSet.has(line)) removed++;
+  }
+  return { added, removed };
+}
+
+function guessLanguage(filePath: string): string {
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  const map: Record<string, string> = {
+    ts: "typescript",
+    tsx: "typescript",
+    js: "javascript",
+    jsx: "javascript",
+    rs: "rust",
+    py: "python",
+    json: "json",
+    css: "css",
+    html: "html",
+    md: "markdown",
+    toml: "toml",
+    yaml: "yaml",
+    yml: "yaml",
+    sh: "shell",
+    bash: "shell",
+  };
+  return map[ext] ?? "plaintext";
+}
+
+export const DiffProposalDialog: Component<DiffProposalDialogProps> = (props) => {
+  let containerRef: HTMLDivElement | undefined;
+  let diffEditor: Monaco.editor.IStandaloneDiffEditor | undefined;
+  const [ready, setReady] = createSignal(false);
+
+  const stats = () => countDiffLines(props.proposal.oldText, props.proposal.newText);
+  const fileName = () => {
+    const parts = props.proposal.path.split("/");
+    return parts[parts.length - 1];
+  };
+
+  onMount(() => {
+    if (!containerRef) return;
+    try {
+      const monaco = getMonaco();
+      const language = guessLanguage(props.proposal.path);
+
+      const originalModel = monaco.editor.createModel(props.proposal.oldText, language);
+      const modifiedModel = monaco.editor.createModel(props.proposal.newText, language);
+
+      diffEditor = monaco.editor.createDiffEditor(containerRef, {
+        readOnly: true,
+        renderSideBySide: true,
+        automaticLayout: true,
+        minimap: { enabled: false },
+        scrollBeyondLastLine: false,
+        lineNumbers: "on",
+        glyphMargin: false,
+        folding: false,
+        renderOverviewRuler: false,
+        theme: "vs-dark",
+        fontSize: 12,
+      });
+
+      diffEditor.setModel({
+        original: originalModel,
+        modified: modifiedModel,
+      });
+
+      setReady(true);
+    } catch (err) {
+      console.error("[DiffProposalDialog] Failed to create diff editor:", err);
+    }
+  });
+
+  onCleanup(() => {
+    if (diffEditor) {
+      const model = diffEditor.getModel();
+      diffEditor.dispose();
+      model?.original?.dispose();
+      model?.modified?.dispose();
+    }
+  });
+
+  function handleAccept() {
+    acpStore.respondToDiffProposal(props.proposal.proposalId, true);
+  }
+
+  function handleReject() {
+    acpStore.respondToDiffProposal(props.proposal.proposalId, false);
+  }
+
+  return (
+    <div class="diff-proposal-dialog">
+      <div class="diff-proposal-header">
+        <span class="diff-proposal-icon">{"\u270F"}</span>
+        <span class="diff-proposal-title">Review Edit</span>
+        <span class="diff-proposal-path" title={props.proposal.path}>
+          {fileName()}
+        </span>
+      </div>
+
+      <div class="diff-proposal-editor" ref={containerRef} />
+
+      <div class="diff-proposal-actions">
+        <span class="diff-proposal-stats">
+          <span class="diff-proposal-stats-added">+{stats().added}</span>
+          {" / "}
+          <span class="diff-proposal-stats-removed">-{stats().removed}</span>
+        </span>
+        <button
+          class="diff-proposal-btn diff-proposal-btn--reject"
+          onClick={handleReject}
+        >
+          Reject
+        </button>
+        <button
+          class="diff-proposal-btn diff-proposal-btn--accept"
+          onClick={handleAccept}
+        >
+          Accept
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -12,6 +12,7 @@ import {
   Show,
 } from "solid-js";
 import { AcpPermissionDialog } from "@/components/acp/AcpPermissionDialog";
+import { DiffProposalDialog } from "@/components/acp/DiffProposalDialog";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
@@ -407,6 +408,15 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             }
           >
             <For each={acpStore.messages}>{renderMessage}</For>
+
+            {/* Diff proposal dialogs */}
+            <For each={acpStore.pendingDiffProposals}>
+              {(proposal) => (
+                <div class="px-5 py-2">
+                  <DiffProposalDialog proposal={proposal} />
+                </div>
+              )}
+            </For>
 
             {/* Permission request dialogs */}
             <For each={acpStore.pendingPermissions}>


### PR DESCRIPTION
## Summary
- Intercepts `write_text_file` in the Rust ACP backend to emit a diff proposal event instead of writing immediately
- Shows a Monaco side-by-side diff editor inline in AgentChat with Accept/Reject buttons
- On Accept, writes to disk; on Reject, returns error to agent ("User rejected the edit")

## Files Changed
- `src-tauri/src/acp.rs` — Diff proposal emission, oneshot channel waiting, response command
- `src-tauri/src/lib.rs` — Register `acp_respond_to_diff_proposal` command
- `src/services/acp.ts` — `DiffProposalEvent` type, event channel, response function
- `src/stores/acp.store.ts` — `pendingDiffProposals` state, event handler, response method
- `src/components/acp/DiffProposalDialog.tsx` — Monaco diff editor component (new)
- `src/components/acp/DiffProposalDialog.css` — Styles (new)
- `src/components/chat/AgentChat.tsx` — Render diff proposals inline

## Test plan
- [ ] Run `pnpm tauri dev` and enable agent mode
- [ ] Ask agent to edit a file (e.g., "Add a comment to src/App.tsx")
- [ ] Verify diff dialog appears with side-by-side Monaco diff editor
- [ ] Click Accept → file is written to disk
- [ ] Repeat and click Reject → file is NOT written, agent sees rejection
- [ ] Verify regular permission dialogs still work for non-file tools

Closes #261

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com