### PR TITLE
fix: pre-release audit bug fixes

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -238,6 +238,7 @@ export const acpStore = {
           await acpService.ensureClaudeCli();
         } catch (error) {
           progressUnsub();
+          tempUnsubscribe();
           const message =
             error instanceof Error
               ? error.message


### PR DESCRIPTION
## Summary

Fixes 7 bugs found during pre-release audit of the agent startup flow and OpenClaw integration (#272).

### Critical fixes
- **OpenClaw path resolution**: `find_openclaw_mjs()` now checks platform subdirectories (`darwin-x64`, etc.) matching the embedded runtime layout
- **ACP event listener leak**: `tempUnsubscribe()` now called when `ensureClaudeCli()` fails
- **OpenClaw WebSocket silent failure**: Emits `openclaw://error` event to frontend when max retries exhausted

### High priority fixes
- **OpenClaw monitor race**: Monitor exits on restart failure to prevent duplicate monitors
- **OpenClaw config write race**: Uses nanosecond timestamp + thread ID for unique temp file names
- **ACP worker error state**: Updates `AcpSession.status` to `Error` when worker fails
- **OpenClaw approval timeout leak**: Guards against race between `listen()` resolving and timeout firing

### Refactoring
- Extracted `platform_subdir()` helper in `embedded_runtime.rs` for reuse across modules

## Test plan
- [ ] `cargo check` passes
- [ ] Start agent session — verify CLI installs and session reaches "ready"
- [ ] Cancel CLI install mid-flight — verify no leaked listeners
- [ ] Start OpenClaw — verify WebSocket connects and channels load
- [ ] Kill OpenClaw process — verify monitor restarts it once, then exits

Closes #272

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
