### PR TITLE
fix(oauth): localhost callback and listener guards

### DIFF
--- a/src-tauri/src/oauth_callback_server.rs
+++ b/src-tauri/src/oauth_callback_server.rs
@@ -1,94 +1,91 @@
-// ABOUTME: OAuth callback HTTP server for dev mode only
-// ABOUTME: Provides localhost redirect for OAuth flows without deep links
+// ABOUTME: OAuth callback HTTP server for localhost OAuth redirects.
+// ABOUTME: Runs on all builds to support Windows (no deep links) and dev mode.
 
 use std::thread;
 use tauri::{AppHandle, Emitter};
 use tiny_http::{Response, Server};
 
-/// Start the OAuth callback server in dev mode
+/// Start the OAuth callback server.
 /// Listens on http://localhost:8787/oauth/callback
-/// Emits oauth-callback events to the frontend
+/// Emits oauth-callback events to the frontend.
 pub fn start_oauth_callback_server(app_handle: AppHandle) {
-    #[cfg(debug_assertions)]
-    {
-        thread::spawn(move || {
-            let server = match Server::http("127.0.0.1:8787") {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("[OAuth Server] Failed to start: {}", e);
-                    return;
-                }
-            };
-
-            println!("[OAuth Server] Listening on http://localhost:8787/oauth/callback");
-
-            for request in server.incoming_requests() {
-                let url = request.url();
-
-                // Only handle /oauth/callback path
-                if url.starts_with("/oauth/callback") {
-                    println!("[OAuth Server] Received callback: {}", url);
-
-                    // Build full callback URL (localhost:8787 + path + query)
-                    let callback_url = format!("http://localhost:8787{}", url);
-
-                    // Emit oauth-callback event to frontend
-                    if let Err(e) = app_handle.emit("oauth-callback", callback_url.clone()) {
-                        eprintln!("[OAuth Server] Failed to emit event: {}", e);
-                    }
-
-                    // Send success response to browser
-                    let html = r#"
-                        <!DOCTYPE html>
-                        <html>
-                        <head>
-                            <title>OAuth Success</title>
-                            <style>
-                                body {
-                                    font-family: system-ui, -apple-system, sans-serif;
-                                    display: flex;
-                                    align-items: center;
-                                    justify-content: center;
-                                    height: 100vh;
-                                    margin: 0;
-                                    background: #f5f5f5;
-                                }
-                                .container {
-                                    text-align: center;
-                                    background: white;
-                                    padding: 2rem;
-                                    border-radius: 8px;
-                                    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-                                }
-                                h1 { color: #22c55e; margin: 0 0 0.5rem; }
-                                p { color: #666; margin: 0; }
-                            </style>
-                        </head>
-                        <body>
-                            <div class="container">
-                                <h1>✓ Authorization Successful</h1>
-                                <p>You can close this window and return to Seren Desktop.</p>
-                            </div>
-                            <script>
-                                // Auto-close after 2 seconds
-                                setTimeout(() => window.close(), 2000);
-                            </script>
-                        </body>
-                        </html>
-                    "#;
-
-                    let response = Response::from_string(html)
-                        .with_header(tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..]).unwrap());
-
-                    if let Err(e) = request.respond(response) {
-                        eprintln!("[OAuth Server] Failed to send response: {}", e);
-                    }
-                } else {
-                    // Return 404 for other paths
-                    let response = Response::from_string("Not Found").with_status_code(404);
-                    let _ = request.respond(response);
-                }
+    thread::spawn(move || {
+        let server = match Server::http("127.0.0.1:8787") {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[OAuth Server] Failed to start: {}", e);
+                return;
             }
-        });
-    }
+        };
+
+        println!("[OAuth Server] Listening on http://localhost:8787/oauth/callback");
+
+        for request in server.incoming_requests() {
+            let url = request.url();
+
+            // Only handle /oauth/callback path
+            if url.starts_with("/oauth/callback") {
+                println!("[OAuth Server] Received callback: {}", url);
+
+                // Build full callback URL (localhost:8787 + path + query)
+                let callback_url = format!("http://localhost:8787{}", url);
+
+                // Emit oauth-callback event to frontend
+                if let Err(e) = app_handle.emit("oauth-callback", callback_url.clone()) {
+                    eprintln!("[OAuth Server] Failed to emit event: {}", e);
+                }
+
+                // Send success response to browser
+                let html = r#"
+                    <!DOCTYPE html>
+                    <html>
+                    <head>
+                        <title>OAuth Success</title>
+                        <style>
+                            body {
+                                font-family: system-ui, -apple-system, sans-serif;
+                                display: flex;
+                                align-items: center;
+                                justify-content: center;
+                                height: 100vh;
+                                margin: 0;
+                                background: #f5f5f5;
+                            }
+                            .container {
+                                text-align: center;
+                                background: white;
+                                padding: 2rem;
+                                border-radius: 8px;
+                                box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+                            }
+                            h1 { color: #22c55e; margin: 0 0 0.5rem; }
+                            p { color: #666; margin: 0; }
+                        </style>
+                    </head>
+                    <body>
+                        <div class="container">
+                            <h1>Authorization Successful</h1>
+                            <p>You can close this window and return to Seren Desktop.</p>
+                        </div>
+                        <script>
+                            // Auto-close after 2 seconds
+                            setTimeout(() => window.close(), 2000);
+                        </script>
+                    </body>
+                    </html>
+                "#;
+
+                let response = Response::from_string(html)
+                    .with_header(tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..]).unwrap());
+
+                if let Err(e) = request.respond(response) {
+                    eprintln!("[OAuth Server] Failed to send response: {}", e);
+                }
+            } else {
+                // Return 404 for other paths
+                let response = Response::from_string("Not Found").with_status_code(404);
+                let _ = request.respond(response);
+            }
+        }
+    });
 }

--- a/src/components/settings/OAuthLogins.tsx
+++ b/src/components/settings/OAuthLogins.tsx
@@ -88,6 +88,9 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
   onMount(async () => {
     console.log("[OAuthLogins] Setting up OAuth callback listener");
     const unlisten = await listenForOAuthCallback(async (url) => {
+      // Only process if we initiated a publisher OAuth flow
+      if (!connectingProvider()) return;
+
       console.log("[OAuthLogins] Received OAuth callback URL:", url);
       try {
         const urlObj = new URL(url);

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -25,11 +25,10 @@ export async function connectPublisher(providerSlug: string): Promise<void> {
     throw new Error("Not authenticated. Please log in first.");
   }
 
-  // TEMPORARY: Using deep link for testing until backend supports localhost
-  // TODO: Revert to localhost in dev after backend whitelists http://localhost:8787
-  const redirectUri = "seren://oauth/callback";
-
-  console.log(`[PublisherOAuth] Using redirect URI: ${redirectUri}`);
+  // Use localhost callback server — works on all platforms including Windows
+  // where deep links (seren://) are unavailable due to WiX bundler issues.
+  // Gateway whitelists http://localhost:8787 (serenorg/serencore#46).
+  const redirectUri = "http://localhost:8787/oauth/callback";
 
   const authUrl = `${apiBase}/oauth/${providerSlug}/authorize?redirect_uri=${encodeURIComponent(redirectUri)}`;
 


### PR DESCRIPTION
## Summary
- Remove `debug_assertions` gate from OAuth callback server so it runs on all builds (fixes Windows OAuth)
- Switch publisher OAuth redirect URI from `seren://oauth/callback` to `http://localhost:8787/oauth/callback` (already whitelisted by Gateway per serenorg/serencore#46)
- Add early-return guard in OAuthLogins listener to prevent conflicts with ProviderSettings listener

## Test plan
- [ ] Verify OAuth callback server starts on production builds (check logs for `[OAuth Server] Listening`)
- [ ] Test GitHub OAuth flow — browser should redirect to localhost:8787, app should receive callback
- [ ] Test Google OAuth flow — same localhost redirect behavior
- [ ] Verify ProviderSettings OAuth (OpenAI/Gemini) still works independently
- [ ] Test on Windows if possible — OAuth should now complete via localhost

Closes #274, closes #275.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com