### PR TITLE
feat: Make URLs in chat messages clickable hyperlinks

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -16,10 +16,10 @@ import { SignIn } from "@/components/auth/SignIn";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
-import { escapeHtml } from "@/lib/escape-html";
+import { openExternalLink } from "@/lib/external-link";
 import { pickAndReadImages } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
-import { renderMarkdown } from "@/lib/render-markdown";
+import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
 import { catalog, type Publisher } from "@/services/catalog";
 import {
   areToolsAvailable,
@@ -117,9 +117,21 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
   let suggestionDebounceTimer: ReturnType<typeof setTimeout> | undefined;
   const handlePickImages = () => handleAttachImages();
 
-  // Copy button click handler (event delegation)
+  // Click handler for copy buttons and external links (event delegation)
   const handleCopyClick = (event: MouseEvent) => {
     const target = event.target as HTMLElement;
+
+    // Handle external link clicks
+    const externalLink = target.closest(".external-link") as HTMLAnchorElement;
+    if (externalLink) {
+      event.preventDefault();
+      const url = externalLink.dataset.externalUrl;
+      if (url) {
+        openExternalLink(url);
+      }
+      return;
+    }
+
     const copyBtn = target.closest(".code-copy-btn") as HTMLButtonElement;
 
     if (copyBtn) {
@@ -746,7 +758,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                           innerHTML={
                             message.role === "assistant"
                               ? renderMarkdown(message.content)
-                              : escapeHtml(message.content)
+                              : escapeHtmlWithLinks(message.content)
                           }
                         />
                         <Show when={message.status === "error"}>

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -12,13 +12,13 @@ import {
 import { SignIn } from "@/components/auth/SignIn";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { FileTree } from "@/components/sidebar/FileTree";
-import { escapeHtml } from "@/lib/escape-html";
+import { openExternalLink } from "@/lib/external-link";
 import {
   loadDirectoryChildren,
   openFileInTab,
   openFolder,
 } from "@/lib/files/service";
-import { renderMarkdown } from "@/lib/render-markdown";
+import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
 import { catalog, type Publisher } from "@/services/catalog";
 import {
   areToolsAvailable,
@@ -117,9 +117,21 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
   let messagesRef: HTMLDivElement | undefined;
   let suggestionDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 
-  // Copy button click handler (event delegation)
+  // Click handler for copy buttons and external links (event delegation)
   const handleCopyClick = (event: MouseEvent) => {
     const target = event.target as HTMLElement;
+
+    // Handle external link clicks
+    const externalLink = target.closest(".external-link") as HTMLAnchorElement;
+    if (externalLink) {
+      event.preventDefault();
+      const url = externalLink.dataset.externalUrl;
+      if (url) {
+        openExternalLink(url);
+      }
+      return;
+    }
+
     const copyBtn = target.closest(".code-copy-btn") as HTMLButtonElement;
 
     if (copyBtn) {
@@ -659,7 +671,7 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
                             innerHTML={
                               message.role === "assistant"
                                 ? renderMarkdown(message.content)
-                                : escapeHtml(message.content)
+                                : escapeHtmlWithLinks(message.content)
                             }
                           />
                           <Show when={message.status === "error"}>

--- a/src/lib/render-markdown.css
+++ b/src/lib/render-markdown.css
@@ -76,3 +76,14 @@
   font-size: 13px;
   line-height: 1.6;
 }
+
+/* External links in chat messages */
+.external-link {
+  color: #58a6ff;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.external-link:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- Adds custom `renderer.link` to marked so markdown links use `data-external-url` attribute for event delegation
- Plain URLs in user messages (which use `escapeHtml`, not markdown) are detected and linkified via new `escapeHtmlWithLinks()`
- Click delegation in ChatContent and ChatPanel intercepts `.external-link` clicks and opens via `openExternalLink()` (Tauri opener plugin)
- Rejects `javascript:`, `data:`, and `vbscript:` schemes to prevent XSS
- Links styled with `#58a6ff` color and underline on hover
- **OAuth:** Switches publisher OAuth to use `seren://oauth/callback` deep links on macOS/Linux, with localhost:8787 fallback on Windows only

Closes #285

## Test plan
- [ ] Send a user message containing a URL like `https://example.com` — verify it renders as a clickable blue link
- [ ] Ask the AI to respond with a markdown link — verify it opens in OS browser on click
- [ ] Verify plain text URLs in AI responses (auto-linked by GFM) open correctly
- [ ] Verify `javascript:alert(1)` in markdown link is sanitized (renders as plain text)
- [ ] Test OAuth login on macOS — verify deep link callback works
- [ ] Test on macOS, verify OS default browser opens

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com