### PR TITLE
fix(oauth): deep link redirect on macOS/Linux and fix compile error

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,23 +70,19 @@ async fn get_oauth_redirect_url(url: String, bearer_token: String) -> Result<Str
     }
 
     let status = response.status();
+    let body_text = response.text().await.unwrap_or_default();
 
     // If not a redirect, try to parse JSON with authorize_url
     if status.is_success() {
-        let body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| format!("Failed to parse response: {}", e))?;
-
-        if let Some(url) = body.get("authorize_url").or(body.get("url")) {
-            if let Some(url_str) = url.as_str() {
-                return Ok(url_str.to_string());
+        if let Ok(body) = serde_json::from_str::<serde_json::Value>(&body_text) {
+            if let Some(url) = body.get("authorize_url").or(body.get("url")) {
+                if let Some(url_str) = url.as_str() {
+                    return Ok(url_str.to_string());
+                }
             }
         }
     }
 
-    // Log the response body for error responses to aid debugging
-    let body_text = response.text().await.unwrap_or_default();
     log::error!("[OAuth] {} response from Gateway: {}", status, body_text);
     Err(format!("Unexpected response status: {} - {}", status, body_text))
 }

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -25,10 +25,13 @@ export async function connectPublisher(providerSlug: string): Promise<void> {
     throw new Error("Not authenticated. Please log in first.");
   }
 
-  // Use localhost callback server — works on all platforms including Windows
-  // where deep links (seren://) are unavailable due to WiX bundler issues.
-  // Gateway whitelists http://localhost:8787 (serenorg/serencore#46).
-  const redirectUri = "http://localhost:8787/oauth/callback";
+  // Use deep links on macOS/Linux where seren:// URL scheme is registered.
+  // Fall back to localhost callback server on Windows where deep links are
+  // unavailable due to WiX bundler issues (tauri-apps/tauri#10453).
+  const isWindows = navigator.userAgent.includes("Windows");
+  const redirectUri = isWindows
+    ? "http://localhost:8787/oauth/callback"
+    : "seren://oauth/callback";
 
   const authUrl = `${apiBase}/oauth/${providerSlug}/authorize?redirect_uri=${encodeURIComponent(redirectUri)}`;
 


### PR DESCRIPTION
## Summary
- Switch publisher OAuth to use `seren://oauth/callback` deep links on macOS/Linux where the URL scheme is registered
- Fall back to `http://localhost:8787/oauth/callback` on Windows where deep links are broken (tauri-apps/tauri#10453)
- Fix Rust compile error (`use of moved value: response`) where `response.text()` was called after `response.json()` consumed the value — reads body text first, then parses JSON from the string

Fixes CI failure from https://github.com/serenorg/seren-desktop/actions/runs/21539260309

**Note:** Deep link OAuth requires Gateway to have `seren://oauth` in `OAUTH_ALLOWED_REDIRECT_ORIGINS` (serenorg/serencore#53).

## Test plan
- [ ] `cargo check` passes (no compile errors)
- [ ] OAuth login on macOS uses `seren://oauth/callback` redirect
- [ ] OAuth deep link handler emits `oauth-callback` event to frontend
- [ ] Verify CI passes

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com