### PR TITLE
fix(ui): format tool results as human-readable JSON

### DIFF
--- a/src/components/chat/ToolStreamingMessage.tsx
+++ b/src/components/chat/ToolStreamingMessage.tsx
@@ -4,6 +4,7 @@
 
 import type { Component } from "solid-js";
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { formatToolResultText } from "@/lib/format-tool-result";
 import type { ToolCall, ToolResult } from "@/lib/providers/types";
 import { renderMarkdown } from "@/lib/render-markdown";
 import type { ToolIterationState, ToolStreamEvent } from "@/services/chat";
@@ -182,7 +183,7 @@ export const ToolStreamingMessage: Component<ToolStreamingMessageProps> = (
                       Result
                     </summary>
                     <pre class="mt-1.5 mb-0 p-2 bg-[rgba(0,0,0,0.3)] rounded text-[11px] overflow-x-auto max-h-[200px] whitespace-pre-wrap break-words">
-                      {exec.result?.content}
+                      {formatToolResultText(exec.result?.content ?? "")}
                     </pre>
                   </details>
                 </Show>

--- a/src/components/mcp/McpToolCallApproval.tsx
+++ b/src/components/mcp/McpToolCallApproval.tsx
@@ -9,6 +9,7 @@ import {
   onCleanup,
   Show,
 } from "solid-js";
+import { formatToolResultText } from "@/lib/format-tool-result";
 import { isRecoverableError } from "@/lib/mcp";
 import { mcpClient } from "@/lib/mcp/client";
 import { getRiskLabel, getToolRiskLevel } from "@/lib/mcp/risk";
@@ -187,7 +188,9 @@ export const McpToolCallApproval: Component<McpToolCallApprovalProps> = (
     return res.content
       .map((c) => {
         if (c.type === "text") {
-          return (c as { type: "text"; text: string }).text;
+          return formatToolResultText(
+            (c as { type: "text"; text: string }).text,
+          );
         }
         return JSON.stringify(c, null, 2);
       })

--- a/src/components/mcp/McpToolsPanel.tsx
+++ b/src/components/mcp/McpToolsPanel.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Shows available tools across all connected servers with execution UI.
 
 import { type Component, createSignal, For, Show } from "solid-js";
+import { formatToolResultText } from "@/lib/format-tool-result";
 import { mcpClient } from "@/lib/mcp/client";
 import type { McpTool, McpToolResult } from "@/lib/mcp/types";
 
@@ -116,7 +117,9 @@ export const McpToolsPanel: Component = () => {
     return result.content
       .map((c) => {
         if (c.type === "text") {
-          return (c as { type: "text"; text: string }).text;
+          return formatToolResultText(
+            (c as { type: "text"; text: string }).text,
+          );
         }
         return JSON.stringify(c, null, 2);
       })

--- a/src/lib/format-tool-result.ts
+++ b/src/lib/format-tool-result.ts
@@ -1,0 +1,24 @@
+// ABOUTME: Formats tool result content for human-readable display.
+// ABOUTME: Parses JSON strings and pretty-prints them with proper indentation.
+
+/**
+ * Takes a string that may contain JSON and returns a formatted version.
+ * If the string is valid JSON, it's pretty-printed. Otherwise returned as-is
+ * with common escape sequences unescaped.
+ */
+export function formatToolResultText(text: string): string {
+  const trimmed = text.trim();
+  if (
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"))
+  ) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      // Not valid JSON, fall through
+    }
+  }
+  // Unescape common escape sequences from stringified JSON
+  return text.replace(/\\n/g, "\n").replace(/\\t/g, "\t").replace(/\\"/g, '"');
+}


### PR DESCRIPTION
## Summary
- Add shared `formatToolResultText` utility that parses JSON strings and pretty-prints them, or unescapes `\n`/`\t`/`\"` for non-JSON text
- Apply formatting to all 3 tool result display surfaces: chat streaming, MCP approval dialog, and MCP tools panel

Closes #289

## Test plan
- [ ] Trigger a tool call in chat (e.g. list_mcp_tools) and expand the result — verify JSON is indented
- [ ] Approve an MCP tool call and verify the result shows formatted JSON
- [ ] Execute a tool from the MCP Tools panel and verify formatted output
- [ ] Verify non-JSON results still display correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com