### PR TITLE
fix(ui): open URLs in OS browser and scroll to bottom on channel switch

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -259,10 +259,11 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     }
   });
 
-  // Auto-scroll to bottom when messages change or streaming starts
+  // Auto-scroll to bottom when messages change, streaming starts, or switching channels
   createEffect(() => {
     void chatStore.messages;
     void streamingSession();
+    void acpStore.agentModeEnabled;
     requestAnimationFrame(scrollToBottom);
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,14 @@
 /* @refresh reload */
-import { render } from "solid-js/web";
 import { attachConsole } from "@tauri-apps/plugin-log";
+import { render } from "solid-js/web";
+import { installExternalLinkInterceptor } from "@/lib/external-link";
 import App from "./App";
 
 // Bridge browser console output to the Rust log backend.
 // In production, this persists console.log/error/warn to log files.
 attachConsole();
+
+// Prevent external URLs from navigating the webview
+installExternalLinkInterceptor();
 
 render(() => <App />, document.getElementById("root") as HTMLElement);


### PR DESCRIPTION
## Summary
- Prevent external URLs from navigating the Tauri webview by removing the `window.open` fallback when in Tauri context and adding a global click interceptor for all `<a>` tags with http(s) hrefs
- Fix chat not scrolling to bottom when switching between agent and chat channels by tracking `agentModeEnabled` in the scroll effect

Closes #291
Closes #292

## Test plan
- [ ] Click a URL in a chat message — should open in OS browser, not in the app
- [ ] After clicking a link, verify the app window stays on the chat view
- [ ] Switch from chat to agent mode and back — verify messages scroll to bottom
- [ ] Switch between chat tabs — verify scroll to bottom still works
- [ ] Verify streaming messages still auto-scroll

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com