### PR TITLE
fix(backend): resolve resource leaks and add safety timeouts

### DIFF
--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -265,6 +265,16 @@ impl TerminalManager {
         self.terminals.remove(terminal_id);
         Ok(())
     }
+
+    /// Release all terminals, freeing all resources.
+    /// Called when a session terminates to prevent orphaned processes.
+    pub fn release_all(&mut self) {
+        let count = self.terminals.len();
+        self.terminals.clear();
+        if count > 0 {
+            log::info!("[TerminalManager] Released {} terminal(s) on session cleanup", count);
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add 30s timeout on ACP agent initialization to prevent infinite hang (#295)
- Auto-remove sessions from map on worker exit to prevent ghost sessions (#296)
- Store and cancel WS listener + process monitor task handles on OpenClaw stop/restart (#297)
- Release all terminal processes when ACP session terminates (#298)
- Forward agent stderr to frontend via `acp://agent-stderr` events (#299)
- Use `Stdio::null` for OpenClaw stdout/stderr to prevent pipe buffer blocking (#300)

Closes #295 #296 #297 #298 #299 #300

## Test plan
- [ ] Start an ACP session and verify it initializes within 30s (or errors on timeout)
- [ ] Kill agent binary mid-session — verify session is cleaned up from list
- [ ] Restart OpenClaw — verify no orphaned WS listener tasks (check logs for cancel messages)
- [ ] Terminate ACP session with running terminals — verify terminals are released
- [ ] Check Rust logs for agent stderr output at WARN level
- [ ] Start/stop OpenClaw repeatedly — verify no resource accumulation

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com