### PR TITLE
fix(acp): guard dead sessions and surface real backend errors

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -495,13 +495,31 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       <Show when={sessionError()}>
         <div class="mx-4 mb-2 px-3 py-2 bg-[rgba(248,81,73,0.1)] border border-[rgba(248,81,73,0.4)] rounded-md text-sm text-[#f85149] flex items-center justify-between">
           <span>{sessionError()}</span>
-          <button
-            type="button"
-            class="text-xs underline hover:no-underline"
-            onClick={() => acpStore.clearError()}
-          >
-            Dismiss
-          </button>
+          <div class="flex items-center gap-2">
+            <Show when={acpStore.activeSession?.info.status === "error"}>
+              <button
+                type="button"
+                class="text-xs underline hover:no-underline"
+                onClick={async () => {
+                  const sid = acpStore.activeSessionId;
+                  if (sid) {
+                    await acpStore.terminateSession(sid);
+                  }
+                  acpStore.clearError();
+                  startSession();
+                }}
+              >
+                Restart Session
+              </button>
+            </Show>
+            <button
+              type="button"
+              class="text-xs underline hover:no-underline"
+              onClick={() => acpStore.clearError()}
+            >
+              Dismiss
+            </button>
+          </div>
         </div>
       </Show>
 

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -323,7 +323,7 @@ export const acpStore = {
       console.error("[AcpStore] Spawn error:", error);
       tempUnsubscribe();
       const message =
-        error instanceof Error ? error.message : "Failed to spawn agent";
+        error instanceof Error ? error.message : String(error);
       setState("error", message);
       setState("isLoading", false);
       return null;
@@ -390,6 +390,12 @@ export const acpStore = {
       return;
     }
 
+    const session = state.sessions[sessionId];
+    if (!session || session.info.status === "error") {
+      setState("error", "Session has ended. Please start a new session.");
+      return;
+    }
+
     // Optimistically mark as prompting so the UI can show a loading state
     // immediately, even before backend events arrive.
     setState(
@@ -422,7 +428,7 @@ export const acpStore = {
     } catch (error) {
       console.error("[AcpStore] sendPrompt error:", error);
       const message =
-        error instanceof Error ? error.message : "Failed to send prompt";
+        error instanceof Error ? error.message : String(error);
       this.addErrorMessage(sessionId, message);
     }
   },


### PR DESCRIPTION
## Summary
- Guard `sendPrompt` against calling backend when session is in error state
- Show "Restart Session" button in error banner when session has died
- Fix error message swallowing: Tauri invoke rejections are strings, not `Error` objects, so `error instanceof Error` was false and real backend errors (e.g. "Another prompt is already active") were replaced with generic "Failed to send prompt"

Closes #305

## Test plan
- [ ] Start agent session, kill agent process, try sending prompt — should see actual error with restart button
- [ ] Send two prompts rapidly — should see "Another prompt is already active" instead of generic error
- [ ] Verify restart button terminates dead session and starts a new one

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com