### PR TITLE
feat(agent): allow choosing agent type when adding new tabs

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -20,7 +20,7 @@ import { openExternalLink } from "@/lib/external-link";
 import { pickAndReadImages, toDataUrl } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
-import type { DiffEvent } from "@/services/acp";
+import type { AgentType, DiffEvent } from "@/services/acp";
 import { type AgentMessage, acpStore } from "@/stores/acp.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { settingsStore } from "@/stores/settings.store";
@@ -100,7 +100,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     ),
   );
 
-  const startSession = async () => {
+  const startSession = async (agentType?: AgentType) => {
     const cwd = getCwd();
     if (!cwd) {
       console.warn("[AgentChat] No folder open, cannot start session");
@@ -108,7 +108,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
     console.log("[AgentChat] Starting session with cwd:", cwd);
     try {
-      const sessionId = await acpStore.spawnSession(cwd);
+      const sessionId = await acpStore.spawnSession(cwd, agentType);
       console.log("[AgentChat] Session started:", sessionId);
     } catch (error) {
       console.error("[AgentChat] Failed to start session:", error);

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -196,12 +196,16 @@ export const acpStore = {
   /**
    * Spawn a new agent session.
    */
-  async spawnSession(cwd: string): Promise<string | null> {
+  async spawnSession(
+    cwd: string,
+    agentType?: AgentType,
+  ): Promise<string | null> {
+    const resolvedAgentType = agentType ?? state.selectedAgentType;
     setState("isLoading", true);
     setState("error", null);
 
     console.log("[AcpStore] Spawning session:", {
-      agentType: state.selectedAgentType,
+      agentType: resolvedAgentType,
       cwd,
     });
 
@@ -225,7 +229,7 @@ export const acpStore = {
 
     try {
       // Ensure Claude CLI is installed before spawning
-      if (state.selectedAgentType === "claude-code") {
+      if (resolvedAgentType === "claude-code") {
         const { listen } = await import("@tauri-apps/api/event");
         const progressUnsub = await listen<{ stage: string; message: string }>(
           "acp://cli-install-progress",
@@ -254,7 +258,7 @@ export const acpStore = {
       }
 
       const info = await acpService.spawnAgent(
-        state.selectedAgentType,
+        resolvedAgentType,
         cwd,
         settingsStore.settings.agentSandboxMode,
       );


### PR DESCRIPTION
## Summary
- Add optional `agentType` parameter to `spawnSession` for explicit type selection
- Show agent type picker dropdown on "+" tab bar button when multiple agents are available
- Skip picker and spawn directly when only one agent type exists
- Thread `agentType` through `startSession` in AgentChat
- Capitalize "Codex" in tab labels

Closes #302

## Test plan
- [ ] Start Claude session, click "+" — should show dropdown with available agents
- [ ] Select Codex from picker — new tab should show "Codex #2"
- [ ] With only one agent available, click "+" — should spawn directly without picker
- [ ] Click outside picker dropdown — should dismiss

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com