### PR TITLE
feat(acp): add structured logging to permission request flow

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -469,7 +469,16 @@ export const acpStore = {
     const permission = state.pendingPermissions.find(
       (p) => p.requestId === requestId,
     );
-    if (!permission) return;
+    if (!permission) {
+      console.warn(
+        `[AcpStore] respondToPermission: request ${requestId} not found in pending list`,
+      );
+      return;
+    }
+
+    console.info(
+      `[AcpStore] Responding to permission ${requestId}: session=${permission.sessionId}, option=${optionId}`,
+    );
 
     try {
       await acpService.respondToPermission(
@@ -477,8 +486,14 @@ export const acpStore = {
         requestId,
         optionId,
       );
+      console.info(
+        `[AcpStore] Permission ${requestId} response delivered to backend`,
+      );
     } catch (error) {
-      console.error("Failed to respond to permission:", error);
+      console.error(
+        `[AcpStore] Failed to respond to permission ${requestId}:`,
+        error,
+      );
     }
 
     setState(
@@ -492,6 +507,9 @@ export const acpStore = {
       (p) => p.requestId === requestId,
     );
     if (permission) {
+      console.info(
+        `[AcpStore] Dismissing permission ${requestId}: session=${permission.sessionId}`,
+      );
       try {
         await acpService.respondToPermission(
           permission.sessionId,
@@ -499,8 +517,15 @@ export const acpStore = {
           "deny",
         );
       } catch (error) {
-        console.error("Failed to send deny response:", error);
+        console.error(
+          `[AcpStore] Failed to send deny for permission ${requestId}:`,
+          error,
+        );
       }
+    } else {
+      console.warn(
+        `[AcpStore] dismissPermission: request ${requestId} not found in pending list`,
+      );
     }
     setState(
       "pendingPermissions",
@@ -627,6 +652,9 @@ export const acpStore = {
       case "permissionRequest": {
         const permEvent =
           event.data as import("@/services/acp").PermissionRequestEvent;
+        console.info(
+          `[AcpStore] Permission request received: requestId=${permEvent.requestId}, session=${permEvent.sessionId}, tool=${JSON.stringify((permEvent.toolCall as Record<string, unknown>)?.name ?? "unknown")}`,
+        );
         setState("pendingPermissions", [
           ...state.pendingPermissions,
           permEvent,


### PR DESCRIPTION
## Summary
- Add detailed logging across the full ACP permission lifecycle (Rust backend + frontend store)
- Log permission request creation, frontend delivery, user response, backend acknowledgment
- Detect and warn when worker exits with orphaned pending permissions
- Helps diagnose ZodError failures in tool call approvals (#310)

## Test plan
- [ ] Start ACP agent session and trigger a tool call requiring permission
- [ ] Approve the permission and verify logs show full lifecycle
- [ ] Deny a permission and verify deny path is logged
- [ ] Check Rust logs (Console.app or terminal) for `[ACP] Permission` entries
- [ ] Check browser devtools console for `[AcpStore]` entries

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com