### PR TITLE
fix(acp): enforce cancel deadline and fix release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           release_name: Seren Desktop ${{ github.ref_name }}
           body_path: release_notes.md
           draft: true
-          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}
+          prerelease: false
 
       - name: Set release ID output
         id: set_release_id

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -442,12 +442,21 @@ export const acpStore = {
    */
   async cancelPrompt() {
     const sessionId = state.activeSessionId;
-    if (!sessionId) return;
+    if (!sessionId) {
+      console.warn("[AcpStore] cancelPrompt: no active session");
+      return;
+    }
+
+    const session = state.sessions[sessionId];
+    console.info(
+      `[AcpStore] cancelPrompt: session=${sessionId}, status=${session?.info.status}`,
+    );
 
     try {
       await acpService.cancelPrompt(sessionId);
+      console.info("[AcpStore] cancelPrompt: backend acknowledged cancel");
     } catch (error) {
-      console.error("Failed to cancel prompt:", error);
+      console.error("[AcpStore] cancelPrompt failed:", error);
     }
   },
 


### PR DESCRIPTION
## Summary
- Fix non-functional Cancel button: enforce 5-second deadline after CancelNotification so UI returns to ready state even if agent ignores cancel
- Add cancel logging to frontend store for debugging
- Stop release workflow from marking alpha builds as pre-releases (fixes GitHub showing wrong latest release)

## Test plan
- [ ] Start agent session, send a prompt, click Cancel
- [ ] Verify UI returns to ready state within 5 seconds
- [ ] Verify Escape key also triggers cancel
- [ ] Check console for cancel logging messages
- [ ] Verify GitHub releases page shows correct latest release

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com