### PR TITLE
fix(oauth): use localhost redirect in dev mode and focus window on callback

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@
 // ABOUTME: Contains Tauri commands and the application run function.
 
 use log::info;
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_store::StoreExt;
 
@@ -544,6 +544,11 @@ pub fn run() {
                                 log::error!("[Deep Link] Failed to emit oauth-callback event: {}", e);
                             } else {
                                 log::info!("[Deep Link] Successfully emitted oauth-callback event");
+                            }
+                            // Focus the main window so user returns to the app
+                            if let Some(window) = handle.get_webview_window("main") {
+                                let _ = window.set_focus();
+                                log::info!("[Deep Link] Focused main window after OAuth callback");
                             }
                         } else {
                             log::debug!("[Deep Link] No match - scheme: {}, path: {}", url.scheme(), url.path());

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -41,13 +41,19 @@ async function generateCodeChallenge(verifier: string): Promise<string> {
 
 /**
  * Get the OAuth redirect URI for this app.
+ * In dev mode, use localhost callback server to avoid launching the production app.
+ * In production, use the seren:// deep link scheme.
  */
 function getRedirectUri(): string {
   if (isTauriRuntime()) {
-    // Tauri deep link
+    if (import.meta.env.DEV) {
+      // Dev mode: use localhost callback server (avoids launching production app)
+      return "http://localhost:8787/oauth/callback";
+    }
+    // Production: use deep link scheme
     return "seren://oauth/callback";
   }
-  // Browser fallback (for development)
+  // Browser fallback
   return `${window.location.origin}/oauth/callback`;
 }
 


### PR DESCRIPTION
## Summary
- **Dev mode**: Use `http://localhost:8787/oauth/callback` instead of `seren://` deep link, preventing macOS from launching the production app bundle
- **Production**: Focus the main window after processing the deep link OAuth callback, so user returns to the app automatically

## Test plan
- [ ] Dev mode: Click OAuth connect — browser should redirect to localhost, NOT launch production app
- [ ] Production: Click OAuth connect — after completing in browser, Seren window should come to front
- [ ] Verify OAuth token exchange completes successfully in both modes

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com