### PR TITLE
fix: truncate large tool results and raise chat history limit

### DIFF
--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -23,7 +23,7 @@ import type { Message } from "@/services/chat";
 import { sendMessage } from "@/services/chat";
 
 const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
-const MAX_MESSAGES_PER_CONVERSATION = 100;
+const MAX_MESSAGES_PER_CONVERSATION = 1000;
 
 /**
  * A compacted summary of older messages.
@@ -418,7 +418,8 @@ export const chatStore = {
         message.timestamp,
       );
     } catch (error) {
-      console.warn("Unable to persist message", error);
+      console.error("[chatStore] Failed to persist message:", error);
+      setState("error", "Failed to save message. Chat history may be incomplete.");
     }
   },
 


### PR DESCRIPTION
## Summary
- Adds `truncateToolResult()` helper that caps tool results at 50KB, intelligently extracting key summary fields (subject, sender, date, etc.) from large JSON arrays like email listings — shows first 25 items with a count note
- Raises `MAX_MESSAGES_PER_CONVERSATION` from 100 to 1000 in both Rust backend and TypeScript frontend
- Changes pruning from unconditional (every save) to conditional (only when over limit)
- Removes the `get_messages` limit capping so the frontend controls pagination
- Surfaces persistence errors to the user instead of silently swallowing with `console.warn`

Closes #317

## Test plan
- [ ] Connect Gmail MCP, request "read my emails" — should see truncated summary (25 items max), not full payload
- [ ] Verify chat history is preserved after large tool results
- [ ] Verify persistence error shows in UI if database write fails
- [ ] `cargo check` passes
- [ ] `pnpm check` passes
- [ ] `pnpm test` passes (35/35)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com