### PR TITLE
fix: surface API error details in catalog and add frontend log bridge

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,73 @@
+// ABOUTME: Frontend logging bridge that writes to the Tauri log file.
+// ABOUTME: Falls back to console when running outside Tauri (browser dev).
+
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+
+type LogFn = (message: string) => Promise<void>;
+
+let tauriError: LogFn | null = null;
+let tauriWarn: LogFn | null = null;
+let tauriInfo: LogFn | null = null;
+let tauriDebug: LogFn | null = null;
+let initialized = false;
+
+async function init(): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+
+  if (!isTauriRuntime()) return;
+
+  try {
+    const mod = await import("@tauri-apps/plugin-log");
+    tauriError = mod.error;
+    tauriWarn = mod.warn;
+    tauriInfo = mod.info;
+    tauriDebug = mod.debug;
+  } catch {
+    // Plugin not available, stay with console fallback
+  }
+}
+
+function stringify(args: unknown[]): string {
+  return args
+    .map((a) => {
+      if (typeof a === "string") return a;
+      if (a instanceof Error) return `${a.message}\n${a.stack ?? ""}`;
+      try {
+        return JSON.stringify(a);
+      } catch {
+        return String(a);
+      }
+    })
+    .join(" ");
+}
+
+export const log = {
+  async error(...args: unknown[]): Promise<void> {
+    const msg = stringify(args);
+    console.error(...args);
+    await init();
+    if (tauriError) await tauriError(msg).catch(() => {});
+  },
+
+  async warn(...args: unknown[]): Promise<void> {
+    const msg = stringify(args);
+    console.warn(...args);
+    await init();
+    if (tauriWarn) await tauriWarn(msg).catch(() => {});
+  },
+
+  async info(...args: unknown[]): Promise<void> {
+    const msg = stringify(args);
+    console.info(...args);
+    await init();
+    if (tauriInfo) await tauriInfo(msg).catch(() => {});
+  },
+
+  async debug(...args: unknown[]): Promise<void> {
+    const msg = stringify(args);
+    console.debug(...args);
+    await init();
+    if (tauriDebug) await tauriDebug(msg).catch(() => {});
+  },
+};

--- a/src/services/catalog.ts
+++ b/src/services/catalog.ts
@@ -8,6 +8,7 @@ import {
   suggestPublishers,
 } from "@/api";
 import { apiBase } from "@/lib/config";
+import { log } from "@/lib/logger";
 
 /**
  * Publisher type (database, api, mcp, compute).
@@ -218,17 +219,17 @@ export const catalog = {
    * List all active publishers.
    */
   async list(): Promise<Publisher[]> {
-    console.log("[Catalog] Fetching publishers");
+    log.info("[Catalog] Fetching publishers");
     const { data, error } = await listStorePublishers({
       query: { limit: 100 },
       throwOnError: false,
     });
     if (error) {
-      console.error("[Catalog] Error fetching publishers:", error);
+      log.error("[Catalog] Error fetching publishers:", error);
       throw new Error(`Failed to list publishers: ${formatApiError(error, "unknown error")}`);
     }
     const rawPublishers = data?.data || [];
-    console.log("[Catalog] Found", rawPublishers.length, "publishers");
+    log.info("[Catalog] Found", rawPublishers.length, "publishers");
     return rawPublishers.map(transformPublisher);
   },
 
@@ -241,7 +242,7 @@ export const catalog = {
       throwOnError: false,
     });
     if (error || !data?.data) {
-      console.error("[Catalog] Error fetching publisher:", error);
+      log.error("[Catalog] Error fetching publisher:", error);
       throw new Error(`Failed to get publisher: ${formatApiError(error, "not found")}`);
     }
     return transformPublisher(data.data);
@@ -260,7 +261,7 @@ export const catalog = {
       throwOnError: false,
     });
     if (error) {
-      console.error("[Catalog] Error searching publishers:", error);
+      log.error("[Catalog] Error searching publishers:", error);
       throw new Error(`Failed to search publishers: ${formatApiError(error, "unknown error")}`);
     }
     const rawPublishers = data?.data || [];
@@ -319,7 +320,7 @@ export const catalog = {
       throwOnError: false,
     });
     if (error) {
-      console.error("[Catalog] Error listing by category:", error);
+      log.error("[Catalog] Error listing by category:", error);
       throw new Error(`Failed to list publishers by category: ${formatApiError(error, "unknown error")}`);
     }
     const rawPublishers = data?.data || [];


### PR DESCRIPTION
## Summary
- Adds `src/lib/logger.ts` — frontend logging bridge that writes to the Tauri log file via `@tauri-apps/plugin-log` (already installed but never used on frontend). Falls back to console outside Tauri.
- Updates `src/services/catalog.ts` to use the log bridge, so catalog API errors appear in `~/Library/Logs/com.serendb.desktop/SerenDesktop.log` where AI assistants and support can read them
- Adds `formatApiError()` helper to extract real error details (HTTP status, message, detail) from SDK error responses instead of showing generic 'Failed to list publishers'

Closes #320

## Test plan
- [ ] Open Catalog page — publishers load, log shows `[Catalog] Fetching publishers` and `[Catalog] Found N publishers` in SerenDesktop.log
- [ ] Trigger API error (e.g. disconnect network) — error detail appears in both UI and log file
- [ ] pnpm check passes

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com