### PR TITLE
fix: detect OAuth token expiry and show login button for agent auth errors

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -29,11 +29,18 @@ fn is_auth_error(msg: &str) -> bool {
     let lower = msg.to_lowercase();
     lower.contains("invalid api key")
         || lower.contains("authentication required")
+        || lower.contains("authentication_error")
         || lower.contains("auth required")
         || lower.contains("please run /login")
         || lower.contains("authrequired")
         || lower.contains("not logged in")
         || lower.contains("login required")
+        || lower.contains("oauth token has expired")
+        || lower.contains("token has expired")
+        || lower.contains("token expired")
+        || lower.contains("please obtain a new token")
+        || lower.contains("refresh your existing token")
+        || lower.contains("401")
 }
 
 /// Return a user-friendly auth error message for the given agent type
@@ -1543,6 +1550,19 @@ pub async fn acp_check_agent_available(agent_type: AgentType) -> Result<bool, St
     match agent_type.command() {
         Ok(path) => Ok(path.exists()),
         Err(_) => Ok(false),
+    }
+}
+
+/// Launch the authentication flow for an agent.
+/// For Claude, this opens a terminal running `claude login`.
+#[tauri::command]
+pub fn acp_launch_login(agent_type: AgentType) {
+    match agent_type {
+        AgentType::ClaudeCode => launch_claude_login(),
+        AgentType::Codex => {
+            // Codex uses OpenAI API keys, no OAuth login flow
+            log::info!("[ACP] Codex uses API keys, no login flow available");
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -666,6 +666,8 @@ pub fn run() {
             #[cfg(feature = "acp")]
             acp::acp_check_agent_available,
             #[cfg(feature = "acp")]
+            acp::acp_launch_login,
+            #[cfg(feature = "acp")]
             acp::acp_ensure_claude_cli,
             #[cfg(feature = "acp")]
             acp::acp_respond_to_diff_proposal,

--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -243,6 +243,14 @@ export async function checkAgentAvailable(
   });
 }
 
+/**
+ * Launch the authentication flow for an agent.
+ * For Claude, this opens a terminal running `claude login`.
+ */
+export async function launchLogin(agentType: AgentType): Promise<void> {
+  return invoke("acp_launch_login", { agentType });
+}
+
 // ============================================================================
 // Event Subscription
 // ============================================================================


### PR DESCRIPTION
## Summary
- Extends is_auth_error() to detect OAuth token expiry and related patterns (401, authentication_error, etc.)
- Adds acp_launch_login Tauri command to trigger claude login from the frontend
- Adds a Login button in AgentChat that opens terminal with claude login when auth errors occur
- Shows user-friendly error message for auth errors with clear next steps

## Problem
When the agent OAuth token expired, users saw a raw 401 error with no way to re-authenticate. The error was not being detected as an auth issue, so the existing login flow was not triggered.

## Solution
Now when users encounter an OAuth expiration error:
1. The error is displayed with amber styling (auth error, not generic error)
2. A clear message explains what happened
3. A Login button triggers claude login in a terminal (same flow as the backend)
4. After authenticating, users can click Restart Session to continue

## Test plan
- [ ] Start an agent session with an expired OAuth token
- [ ] Verify the error shows with amber styling and Login button
- [ ] Click Login and verify terminal opens with claude login
- [ ] Complete authentication and restart session
- [ ] Verify new prompts work correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com