### PR TITLE
feat: persist thinking block expansion preference

### DIFF
--- a/src/components/chat/ThinkingBlock.tsx
+++ b/src/components/chat/ThinkingBlock.tsx
@@ -2,7 +2,8 @@
 // ABOUTME: Shows the AI's chain of thought when enabled in settings.
 
 import type { Component } from "solid-js";
-import { createSignal, Show } from "solid-js";
+import { createEffect, createSignal, Show } from "solid-js";
+import { settingsStore } from "@/stores/settings.store";
 
 interface ThinkingBlockProps {
   thinking: string;
@@ -10,14 +11,32 @@ interface ThinkingBlockProps {
 }
 
 export const ThinkingBlock: Component<ThinkingBlockProps> = (props) => {
-  const [isExpanded, setIsExpanded] = createSignal(props.isStreaming ?? false);
+  const initialPreference = settingsStore.get("chatThinkingExpanded");
+  const [isExpanded, setIsExpanded] = createSignal(
+    props.isStreaming ? true : initialPreference,
+  );
+  let lastStoredPreference = initialPreference;
+
+  createEffect(() => {
+    const storedPreference = settingsStore.get("chatThinkingExpanded");
+    if (storedPreference !== lastStoredPreference) {
+      lastStoredPreference = storedPreference;
+      setIsExpanded(storedPreference);
+    }
+  });
+
+  const handleToggle = () => {
+    const next = !isExpanded();
+    setIsExpanded(next);
+    settingsStore.set("chatThinkingExpanded", next);
+  };
 
   return (
     <div class="mb-3 border border-[#30363d] rounded-lg overflow-hidden bg-[#161b22]">
       <button
         type="button"
         class="w-full flex items-center gap-2 px-3 py-2 bg-[#21262d] text-[#8b949e] text-xs font-medium cursor-pointer hover:bg-[#30363d] transition-colors border-none text-left"
-        onClick={() => setIsExpanded(!isExpanded())}
+        onClick={handleToggle}
       >
         <svg
           class={`w-3 h-3 transition-transform ${isExpanded() ? "rotate-90" : ""}`}

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -34,6 +34,11 @@ export interface Settings {
   chatEnterToSend: boolean;
   chatShowThinking: boolean;
   /**
+   * Whether thinking blocks should default to the expanded state.
+   * Controlled by the in-UI chevron toggle so the preference persists.
+   */
+  chatThinkingExpanded: boolean;
+  /**
    * Maximum tool call iterations per message.
    * Controls how many times the AI can use tools in a single response.
    * Higher values allow more complex multi-step tasks but use more credits.
@@ -101,6 +106,7 @@ const DEFAULT_SETTINGS: Settings = {
   chatMaxHistoryMessages: 50,
   chatEnterToSend: true,
   chatShowThinking: false,
+  chatThinkingExpanded: false,
   chatMaxToolIterations: 10,
   // Auto-compact
   autoCompactEnabled: true,


### PR DESCRIPTION
## Summary
- add a `chatThinkingExpanded` preference alongside other chat settings so we can remember whether the user left Thinking opened or closed
- have `ThinkingBlock` read/write that preference so expanding/collapsing the chevron now updates the stored value and new messages inherit it (both chat + agent + streaming blocks)
- keep the existing "Show Thinking" switch as the guard for rendering the block; this change only controls the default expansion state

## Testing
- pnpm biome lint src/components/chat/ThinkingBlock.tsx src/stores/settings.store.ts
- pnpm lint *(fails: existing Biome diagnostics across unrelated files in `src-tauri/...` and wallet UI components; same failures reproduced on `main`)*

Closes #325.
