### PR TITLE
feat: add custom resizable textarea for chat input

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -14,13 +14,14 @@ import {
 import { AcpPermissionDialog } from "@/components/acp/AcpPermissionDialog";
 import { DiffProposalDialog } from "@/components/acp/DiffProposalDialog";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
+import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { openExternalLink } from "@/lib/external-link";
 import { pickAndReadImages, toDataUrl } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
-import { launchLogin, type AgentType, type DiffEvent } from "@/services/acp";
+import { type AgentType, type DiffEvent, launchLogin } from "@/services/acp";
 import { type AgentMessage, acpStore } from "@/stores/acp.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { settingsStore } from "@/stores/settings.store";
@@ -328,12 +329,15 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 fallback={<span>{message.content}</span>}
               >
                 <div class="flex items-center justify-between gap-2">
-                  <span>Authentication expired. Please log in to continue.</span>
+                  <span>
+                    Authentication expired. Please log in to continue.
+                  </span>
                   <button
                     type="button"
                     class="px-2 py-1 text-xs font-medium bg-[#d2992a] text-[#0d1117] rounded hover:bg-[#e5ac3d] flex-shrink-0"
                     onClick={() => {
-                      const agentType = acpStore.activeSession?.info.agentType ?? "claude-code";
+                      const agentType =
+                        acpStore.activeSession?.info.agentType ?? "claude-code";
                       launchLogin(agentType);
                     }}
                   >
@@ -543,14 +547,19 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           }`}
         >
           <div class="flex items-center justify-between">
-            <span class="flex-1">{isAuthError(sessionError()) ? "Authentication expired. Please log in again to continue." : sessionError()}</span>
+            <span class="flex-1">
+              {isAuthError(sessionError())
+                ? "Authentication expired. Please log in again to continue."
+                : sessionError()}
+            </span>
             <div class="flex items-center gap-2 ml-2">
               <Show when={isAuthError(sessionError())}>
                 <button
                   type="button"
                   class="px-2 py-1 text-xs font-medium bg-[#d2992a] text-[#0d1117] rounded hover:bg-[#e5ac3d]"
                   onClick={() => {
-                    const agentType = acpStore.activeSession?.info.agentType ?? "claude-code";
+                    const agentType =
+                      acpStore.activeSession?.info.agentType ?? "claude-code";
                     launchLogin(agentType);
                   }}
                 >
@@ -584,7 +593,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           </div>
           <Show when={isAuthError(sessionError())}>
             <p class="mt-1 text-xs opacity-80">
-              Click "Login" to authenticate with {acpStore.activeSession?.info.agentType === "codex" ? "OpenAI" : "Anthropic"}, then restart the session.
+              Click "Login" to authenticate with{" "}
+              {acpStore.activeSession?.info.agentType === "codex"
+                ? "OpenAI"
+                : "Anthropic"}
+              , then restart the session.
             </p>
           </Show>
         </div>
@@ -640,15 +653,17 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                   setCommandPopupIndex(0);
                 }}
               />
-              <textarea
-                ref={inputRef}
+              <ResizableTextarea
+                ref={(el) => (inputRef = el)}
                 value={input()}
                 placeholder={
                   isPrompting()
                     ? "Type to queue message..."
                     : "Tell the agent what to do… (type / for commands)"
                 }
-                class="w-full min-h-[80px] max-h-[50vh] resize-y bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-3 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58] disabled:opacity-60 disabled:cursor-not-allowed"
+                class="w-full bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-3 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58] disabled:opacity-60 disabled:cursor-not-allowed"
+                minHeight={80}
+                maxHeight={window.innerHeight * 0.5}
                 onInput={(e) => {
                   setInput(e.currentTarget.value);
                   setCommandPopupIndex(0);

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "solid-js";
 import { SignIn } from "@/components/auth/SignIn";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
+import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { FileTree } from "@/components/sidebar/FileTree";
 import { openExternalLink } from "@/lib/external-link";
 import {
@@ -795,11 +796,13 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
                       onSelect={handlePublisherSelect}
                       onDismiss={dismissSuggestions}
                     />
-                    <textarea
-                      ref={inputRef}
+                    <ResizableTextarea
+                      ref={(el) => (inputRef = el)}
                       value={input()}
                       placeholder="Ask Seren anything…"
-                      class="w-full min-h-[80px] max-h-[50vh] resize-y bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-3 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58] disabled:opacity-60 disabled:cursor-not-allowed"
+                      class="w-full bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] p-3 font-inherit text-sm leading-normal transition-colors focus:outline-none focus:border-[#58a6ff] placeholder:text-[#484f58] disabled:opacity-60 disabled:cursor-not-allowed"
+                      minHeight={80}
+                      maxHeight={window.innerHeight * 0.5}
                       onInput={(event) => {
                         setInput(event.currentTarget.value);
                         // Reset history browsing when user types manually

--- a/src/components/common/ResizableTextarea.tsx
+++ b/src/components/common/ResizableTextarea.tsx
@@ -1,0 +1,92 @@
+// ABOUTME: Resizable textarea component with a visible drag handle at the top.
+// ABOUTME: Provides better UX than native resize-y for chat/agent input boxes.
+
+import type { Component, JSX } from "solid-js";
+import { createSignal, onCleanup, onMount } from "solid-js";
+
+interface ResizableTextareaProps {
+  ref?: (el: HTMLTextAreaElement) => void;
+  value: string;
+  placeholder?: string;
+  class?: string;
+  onInput?: JSX.EventHandler<HTMLTextAreaElement, InputEvent>;
+  onKeyDown?: JSX.EventHandler<HTMLTextAreaElement, KeyboardEvent>;
+  disabled?: boolean;
+  minHeight?: number;
+  maxHeight?: number;
+}
+
+export const ResizableTextarea: Component<ResizableTextareaProps> = (props) => {
+  let containerRef: HTMLDivElement | undefined;
+  const [height, setHeight] = createSignal(props.minHeight ?? 80);
+  const [isDragging, setIsDragging] = createSignal(false);
+
+  const minHeight = props.minHeight ?? 80;
+  const maxHeight = props.maxHeight ?? window.innerHeight * 0.5;
+
+  const handleMouseDown = (e: MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+    document.body.style.cursor = "ns-resize";
+    document.body.style.userSelect = "none";
+  };
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (!isDragging() || !containerRef) return;
+
+    const containerRect = containerRef.getBoundingClientRect();
+    // Calculate new height based on mouse position relative to container bottom
+    // Dragging UP (lower Y) = bigger textarea
+    const newHeight = containerRect.bottom - e.clientY;
+    const clampedHeight = Math.max(minHeight, Math.min(maxHeight, newHeight));
+    setHeight(clampedHeight);
+  };
+
+  const handleMouseUp = () => {
+    if (isDragging()) {
+      setIsDragging(false);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    }
+  };
+
+  onMount(() => {
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener("mousemove", handleMouseMove);
+    document.removeEventListener("mouseup", handleMouseUp);
+  });
+
+  return (
+    <div ref={containerRef} class="relative">
+      {/* Resize handle at top */}
+      <div
+        class="absolute top-0 left-0 right-0 h-2 cursor-ns-resize flex items-center justify-center group z-10 -translate-y-1"
+        onMouseDown={handleMouseDown}
+      >
+        <div
+          class={`w-12 h-1 rounded-full transition-colors ${
+            isDragging()
+              ? "bg-[#58a6ff]"
+              : "bg-[#30363d] group-hover:bg-[#484f58]"
+          }`}
+        />
+      </div>
+      <textarea
+        ref={(el) => {
+          props.ref?.(el);
+        }}
+        value={props.value}
+        placeholder={props.placeholder}
+        class={props.class}
+        style={{ height: `${height()}px`, resize: "none" }}
+        onInput={props.onInput}
+        onKeyDown={props.onKeyDown}
+        disabled={props.disabled}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Add ResizableTextarea component with visible drag handle at top
- Replace native CSS resize-y (doesn't work in Tauri WebView) with custom mouse-drag implementation
- Update ChatPanel.tsx and AgentChat.tsx to use the new component

## User Story
As a user who inputs paragraphs of text, I want to vertically resize the input box to see all my content.

## Technical Notes
- Drag handle positioned at top of textarea
- Height controlled via SolidJS signal
- Respects min/max height constraints (80px - 50vh)
- Visual feedback on hover and during drag

## Test plan
- [ ] Verify drag handle is visible above input box
- [ ] Verify dragging up increases textarea height
- [ ] Verify dragging down decreases textarea height
- [ ] Verify height respects min/max constraints
- [ ] Test in both Chat and Agent panels

Closes #330

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com