### PR TITLE
fix: queued messages now send after Claude completes response

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -759,6 +759,14 @@ export const acpStore = {
 
       case "promptComplete":
         this.finalizeStreamingContent(sessionId);
+        // Transition status back to "ready" so queued messages can be processed
+        setState(
+          "sessions",
+          sessionId,
+          "info",
+          "status",
+          "ready" as SessionStatus,
+        );
         break;
 
       case "sessionStatus":


### PR DESCRIPTION
## Summary
- Set session status to 'ready' when promptComplete event is received
- This allows the queue processing effect to detect the status change and send queued messages

## Root Cause
When `sendPrompt` is called, it sets the session status to `'prompting'`. When the prompt completes, the `promptComplete` event only finalized streaming content but did not transition the status back to `'ready'`. This left the status stuck at `'prompting'` indefinitely, so the queue processing effect (which checks `isReady()`) never triggered.

## Test plan
- [ ] Start an agent session
- [ ] Send a prompt and wait for Claude to start processing
- [ ] While processing, type another message and press Enter (should show 'queued')
- [ ] Wait for Claude to complete
- [ ] Verify the queued message automatically sends

Closes #332

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com