### PR TITLE
fix: move MCP indicator to prevent accidental clicks near Send button

### DIFF
--- a/src/components/common/StatusBar.tsx
+++ b/src/components/common/StatusBar.tsx
@@ -18,13 +18,15 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
         {props.message || "Ready"}
       </span>
       <div class="flex items-center gap-2 [&_.mcp-status-indicator]:text-primary-foreground [&_.status-label]:text-primary-foreground/85 [&_.update-indicator]:text-primary-foreground/90">
+        {/* MCP indicator moved to left side to avoid accidental clicks near Send button */}
+        <McpStatusIndicator />
+        <span class="w-px h-3.5 bg-primary-foreground/20" />
         <AutocompleteStatus
           state={autocompleteStore.state}
           errorMessage={autocompleteStore.errorMessage ?? undefined}
           onToggle={autocompleteStore.toggle}
         />
         <UpdateIndicator />
-        <McpStatusIndicator />
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- Move MCP status indicator from rightmost position to leftmost in the status bar right section
- Add a visual separator between MCP indicator and other status items
- This prevents users from accidentally clicking MCP when aiming for Send button above

## Problem
Users were accidentally clicking the MCP indicator in the status bar when trying to click the Send button in the input area above, because both were positioned in the bottom-right area of the screen.

## Solution
Reposition the MCP indicator to the left side of the status bar's right section, and add a visual divider to make the separation clear.

## Test plan
- [ ] Verify MCP indicator appears on the left side of the status bar right section
- [ ] Verify visual separator is visible between MCP and other indicators
- [ ] Verify Send button is no longer directly above MCP indicator
- [ ] Test clicking Send button does not accidentally trigger MCP popup

Closes #333

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com