### PR TITLE
fix: prevent conversation switching during streaming

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -175,16 +175,24 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
   const handleKeyDown = (event: KeyboardEvent) => {
     const isMod = event.metaKey || event.ctrlKey;
 
-    // Ctrl/Cmd+T: New tab
+    // Ctrl/Cmd+T: New tab (blocked during streaming)
     if (isMod && event.key === "t") {
       event.preventDefault();
+      if (chatStore.isLoading) {
+        console.log("[ChatContent] Blocked new tab during streaming");
+        return;
+      }
       chatStore.createConversation();
       return;
     }
 
-    // Ctrl/Cmd+W: Close current tab
+    // Ctrl/Cmd+W: Close current tab (blocked during streaming)
     if (isMod && event.key === "w") {
       event.preventDefault();
+      if (chatStore.isLoading) {
+        console.log("[ChatContent] Blocked tab close during streaming");
+        return;
+      }
       const activeId = chatStore.activeConversationId;
       if (activeId) {
         chatStore.archiveConversation(activeId);
@@ -192,9 +200,13 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
       return;
     }
 
-    // Ctrl+Tab / Ctrl+Shift+Tab: Switch tabs
+    // Ctrl+Tab / Ctrl+Shift+Tab: Switch tabs (blocked during streaming)
     if (event.ctrlKey && event.key === "Tab") {
       event.preventDefault();
+      if (chatStore.isLoading) {
+        console.log("[ChatContent] Blocked tab switch during streaming");
+        return;
+      }
       const conversations = chatStore.conversations.filter(
         (c) => !c.isArchived,
       );

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -182,16 +182,24 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
 
     const isMod = event.metaKey || event.ctrlKey;
 
-    // Ctrl/Cmd+T: New tab
+    // Ctrl/Cmd+T: New tab (blocked during streaming)
     if (isMod && event.key === "t") {
       event.preventDefault();
+      if (chatStore.isLoading) {
+        console.log("[ChatPanel] Blocked new tab during streaming");
+        return;
+      }
       chatStore.createConversation();
       return;
     }
 
-    // Ctrl/Cmd+W: Close current tab
+    // Ctrl/Cmd+W: Close current tab (blocked during streaming)
     if (isMod && event.key === "w") {
       event.preventDefault();
+      if (chatStore.isLoading) {
+        console.log("[ChatPanel] Blocked tab close during streaming");
+        return;
+      }
       const activeId = chatStore.activeConversationId;
       if (activeId) {
         chatStore.archiveConversation(activeId);
@@ -199,9 +207,13 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
       return;
     }
 
-    // Ctrl+Tab / Ctrl+Shift+Tab: Switch tabs
+    // Ctrl+Tab / Ctrl+Shift+Tab: Switch tabs (blocked during streaming)
     if (event.ctrlKey && event.key === "Tab") {
       event.preventDefault();
+      if (chatStore.isLoading) {
+        console.log("[ChatPanel] Blocked tab switch during streaming");
+        return;
+      }
       const conversations = chatStore.conversations.filter(
         (c) => !c.isArchived,
       );


### PR DESCRIPTION
## Summary
- **Root Cause**: Users could switch tabs (via click or keyboard) while Claude was processing. This made the UI show a different conversation's messages, appearing as if chat history was lost.
- Blocks tab switching during streaming via click and keyboard shortcuts (Ctrl+Tab, Ctrl+W, Ctrl+T)
- Adds visual feedback: inactive tabs appear disabled with `cursor-not-allowed` and reduced opacity
- Shows helpful tooltip explaining why tabs are blocked

## Test plan
- [ ] Start a chat and send a message
- [ ] While Claude is responding, try to click another tab - should be blocked
- [ ] Try Ctrl+Tab to switch tabs - should be blocked
- [ ] Try Ctrl+T to create new tab - should be blocked
- [ ] Try Ctrl+W to close tab - should be blocked
- [ ] Verify tabs show visual disabled state during streaming
- [ ] After response completes, verify all tab operations work normally

Fixes #337

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com