### PR TITLE
fix: prevent false claims about MCP tool access

### DIFF
--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -254,6 +254,7 @@ export async function executeTool(toolCall: ToolCall): Promise<ToolResult> {
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    console.error(`[Tool Executor] Tool "${name}" failed:`, message);
     return {
       tool_call_id: toolCall.id,
       content: `Error: ${message}`,
@@ -372,6 +373,7 @@ async function executeOpenClawTool(
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    console.error(`[Tool Executor] OpenClaw tool "${toolName}" failed:`, message);
     return {
       tool_call_id: toolCallId,
       content: `OpenClaw tool error: ${message}`,
@@ -414,6 +416,7 @@ async function executeMcpTool(
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    console.error(`[Tool Executor] MCP tool "${serverName}/${toolName}" failed:`, message);
     return {
       tool_call_id: toolCallId,
       content: `MCP tool error: ${message}`,
@@ -565,6 +568,7 @@ async function executeGatewayTool(
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    console.error(`[Tool Executor] Gateway tool "${publisherSlug}/${toolName}" failed:`, message);
     return {
       tool_call_id: toolCallId,
       content: `Gateway tool error: ${message}`,


### PR DESCRIPTION
## Summary
Fixes Claude making contradictory claims about having/not having access to MCP publisher tools.

**Root Cause**: The system prompt unconditionally claimed tool access without verifying tools were actually available. `areToolsAvailable()` only checked provider type.

**Changes**:
1. `areToolsAvailable()` now verifies actual tools exist (calls `getAllTools()`)
2. Added `getAvailableToolCount()` helper for conditional prompts
3. System prompt is now conditional:
   - **With tools**: States specific tool count (e.g., "access to 47 tools")
   - **Without tools**: Explicitly notes tools are unavailable
4. Added `console.error` logging for all tool failure paths:
   - File tools
   - MCP tools (local stdio servers)
   - Gateway tools (Seren publishers)
   - OpenClaw tools

## Test plan
- [ ] Start chat with Seren provider - verify system prompt mentions tool count
- [ ] Start chat with non-Seren provider - verify system prompt says tools unavailable
- [ ] Trigger a tool failure - verify error is logged to console
- [ ] No more contradictory claims about tool access

Fixes #336

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com