### PR TITLE
fix: add devtools feature to enable browser console

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset"] }
+tauri = { version = "2", features = ["protocol-asset", "devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"


### PR DESCRIPTION
## Summary
Fixes the disabled browser console/DevTools in Seren Desktop.

**Root Cause**: In Tauri 2.0, DevTools requires BOTH:
1. `"devtools": true` in tauri.conf.json ✅ (was already present)
2. `devtools` feature in Cargo.toml ❌ (was missing)

**Fix**: Added `devtools` to the tauri features in Cargo.toml:
```toml
tauri = { version = "2", features = ["protocol-asset", "devtools"] }
```

## Test plan
- [ ] Build the app: `pnpm tauri dev`
- [ ] Right-click in the webview → "Inspect Element" should work
- [ ] DevTools console should be accessible

Fixes #329

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com