### PR TITLE
fix: improve Copy button reliability in chat

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -227,8 +227,9 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
 
     document.addEventListener("keydown", handleKeyDown);
 
-    // Register copy button handler (event delegation)
-    messagesRef?.addEventListener("click", handleCopyClick);
+    // Register copy button handler on document for better reliability
+    // Using document-level delegation ensures copy buttons work even if messagesRef timing is off
+    document.addEventListener("click", handleCopyClick);
 
     // Listen for slash command events
     window.addEventListener("seren:pick-images", handlePickImages);
@@ -269,7 +270,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
 
   onCleanup(() => {
     document.removeEventListener("keydown", handleKeyDown);
-    messagesRef?.removeEventListener("click", handleCopyClick);
+    document.removeEventListener("click", handleCopyClick);
     window.removeEventListener(
       "seren:pick-images",
       handlePickImages as EventListener,

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -224,8 +224,9 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
     // Register keyboard shortcuts
     document.addEventListener("keydown", handleKeyDown);
 
-    // Register copy button handler (event delegation)
-    messagesRef?.addEventListener("click", handleCopyClick);
+    // Register copy button handler on document for better reliability
+    // Using document-level delegation ensures copy buttons work even if messagesRef timing is off
+    document.addEventListener("click", handleCopyClick);
 
     try {
       await chatStore.loadHistory();
@@ -245,7 +246,7 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
 
   onCleanup(() => {
     document.removeEventListener("keydown", handleKeyDown);
-    messagesRef?.removeEventListener("click", handleCopyClick);
+    document.removeEventListener("click", handleCopyClick);
     if (suggestionDebounceTimer) {
       clearTimeout(suggestionDebounceTimer);
     }


### PR DESCRIPTION
## Summary

Fixes #347 - Copy button in chat messages doesn't work reliably.

**Root cause:** The click event handler was attached to messagesRef in onMount, but the ref may not be available at that point, causing the event listener to silently fail to attach.

**Fix:** Changed to document-level event delegation which ensures the click handler works regardless of when the DOM elements are rendered.

## Changes

- ChatContent.tsx: Changed from messagesRef?.addEventListener to document.addEventListener
- ChatPanel.tsx: Same change for consistency

## Test plan

- [ ] Open a chat conversation with code blocks
- [ ] Click the Copy button on a code block
- [ ] Verify the code is copied to clipboard
- [ ] Verify Copied! feedback appears

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com