### PR TITLE
fix: improve microphone error messages with platform-specific guidance

### DIFF
--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -25,5 +25,9 @@
     <!-- Disable library validation (for bundled Node.js) -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+
+    <!-- Allow microphone access for voice input (required on macOS 15+) -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
**Root Cause Found**: On macOS 15 (Sequoia), WebView requires explicit device entitlements for microphone access, even when app sandbox is disabled. Without the `com.apple.security.device.audio-input` entitlement, the permission prompt never appears and Seren doesn't show up in System Settings > Microphone.

### Changes
1. **Add audio-input entitlement** to `entitlements.plist` - this is the critical fix
2. Replace misleading "browser settings" error with platform-specific guidance
3. Add debug logging for permission errors
4. Handle `NotFoundError` when no microphone is connected

### Reference
- [tauri-apps/tauri#11951 - comment with solution](https://github.com/tauri-apps/tauri/issues/11951#issuecomment-2698797263)

## Test plan
After merging and rebuilding:
- [ ] Seren should appear in System Settings > Privacy & Security > Microphone
- [ ] Permission prompt should appear when clicking microphone button for the first time
- [ ] Voice input should work after granting permission

Fixes #357

---
Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com