### PR TITLE
feat: show thinking duration like Claude Code

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -20,6 +20,7 @@ import type { CommandContext } from "@/lib/commands/types";
 import { openExternalLink } from "@/lib/external-link";
 import { pickAndReadImages, toDataUrl } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
+import { formatDuration } from "@/lib/format-duration";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
 import { type AgentType, type DiffEvent, launchLogin } from "@/services/acp";
 import { type AgentMessage, acpStore } from "@/stores/acp.store";
@@ -290,6 +291,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               class="text-sm leading-relaxed text-[#e6edf3] break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_code]:bg-[#21262d] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-[#161b22] [&_pre]:border [&_pre]:border-[#30363d] [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-[#30363d] [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-[#8b949e] [&_a]:text-[#58a6ff] [&_a]:no-underline [&_a:hover]:underline"
               innerHTML={renderMarkdown(message.content)}
             />
+            <Show when={message.duration}>
+              <div class="mt-2 text-xs text-[#8b949e]">
+                ✻ Brewed for {formatDuration(message.duration!)}
+              </div>
+            </Show>
           </article>
         );
 

--- a/src/lib/format-duration.ts
+++ b/src/lib/format-duration.ts
@@ -1,0 +1,17 @@
+// ABOUTME: Utility for formatting thinking duration in human-readable format.
+// ABOUTME: Formats milliseconds into "Xm Ys" or "Xs" style strings.
+
+/**
+ * Format a duration in milliseconds to a human-readable string.
+ * Examples: "1m 18s", "45s", "2m 5s"
+ */
+export function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -46,6 +46,8 @@ export interface Message {
   status?: "pending" | "streaming" | "complete" | "error";
   error?: string | null;
   attemptCount?: number;
+  /** Duration in milliseconds for how long the response took */
+  duration?: number;
   request?: {
     prompt: string;
     context?: ChatContext;


### PR DESCRIPTION
## Summary
- Add duration tracking to chat and agent panels
- Display "✻ Brewed for Xm Ys" after assistant messages complete
- Create shared formatDuration utility for consistent formatting

## Changes
- `src/lib/format-duration.ts` - New utility for formatting milliseconds
- `src/services/chat.ts` - Add `duration` field to Message interface
- `src/stores/acp.store.ts` - Track promptStartTime and add duration to AgentMessage
- `src/components/chat/ChatContent.tsx` - Track startTime in streaming sessions, display duration
- `src/components/chat/AgentChat.tsx` - Display duration on assistant messages

## Test plan
- [ ] Send a message in Chat panel, verify duration shows after response
- [ ] Send a prompt in Agent panel, verify duration shows after response
- [ ] Verify format shows "Xs" for short durations, "Xm Ys" for longer ones

Closes #359

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com