### PR TITLE
fix: auto-scroll to permission dialogs when they appear

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -95,14 +95,18 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
   };
 
-  // Auto-scroll when messages change
+  // Auto-scroll when messages change or permission dialogs appear
   createEffect(() => {
     const messages = acpStore.messages;
     const streaming = acpStore.streamingContent;
+    const permissions = acpStore.pendingPermissions;
+    const diffProposals = acpStore.pendingDiffProposals;
     console.log("[AgentChat] Effect triggered:", {
       messagesCount: messages.length,
       streamingLength: streaming.length,
       streamingPreview: streaming.slice(0, 100),
+      pendingPermissions: permissions.length,
+      pendingDiffProposals: diffProposals.length,
     });
     requestAnimationFrame(scrollToBottom);
   });


### PR DESCRIPTION
## Summary
- Fixed permission confirmation box not being visible when it appears
- The chat now auto-scrolls to show permission dialogs and diff proposals

## Problem
The scroll effect in AgentChat only tracked `messages` and `streamingContent`, but not `pendingPermissions` or `pendingDiffProposals`. When a permission dialog appeared, the chat would not scroll, making the dialog invisible or off-screen.

## Solution
Added `pendingPermissions` and `pendingDiffProposals` to the createEffect dependencies so the chat auto-scrolls when these appear.

## Test plan
- [ ] Start an agent session
- [ ] Trigger an action that requires permission (e.g., bash command)
- [ ] Verify the permission dialog scrolls into view automatically

Fixes #364

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com