### PR TITLE
feat: add Update button in Header when new version available

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -3,6 +3,7 @@
 
 import { type Component, For, Show } from "solid-js";
 import { BalanceDisplay } from "./BalanceDisplay";
+import { updaterStore } from "@/stores/updater.store";
 
 export type Panel =
   | "chat"
@@ -80,6 +81,18 @@ export const Header: Component<HeaderProps> = (props) => {
             </button>
           }
         >
+          <Show when={updaterStore.state.status === "available"}>
+            <button
+              type="button"
+              class="flex items-center gap-1.5 py-1 px-2.5 text-[12px] font-medium text-white bg-[#238636] border-none rounded cursor-pointer transition-all duration-100 hover:bg-[#2ea043] animate-pulse"
+              onClick={() => updaterStore.installAvailableUpdate()}
+            >
+              <span class="leading-none">⬆</span>
+              <span class="leading-none">
+                Update {updaterStore.state.availableVersion}
+              </span>
+            </button>
+          </Show>
           <BalanceDisplay />
           {props.onLogout && (
             <button


### PR DESCRIPTION
## Summary
- Adds green "Update vX.X.X" button in Header when app update is available
- Button appears next to Balance display (before Logout)
- Clicking triggers download, install, and automatic relaunch

## Implementation
- Uses existing `updaterStore` infrastructure (no new dependencies)
- Shows only when `updaterStore.state.status === "available"`
- Green button with pulse animation to draw attention

## Test plan
- [ ] Run `pnpm tauri dev`
- [ ] In devtools, set `updaterStore.state.status = "available"` to test UI
- [ ] Verify button appears with green styling and pulse animation
- [ ] Verify clicking triggers install flow

Fixes #367

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com