### PR TITLE
fix: always show toolset indicator in chat panel

### DIFF
--- a/src/components/chat/ToolsetSelector.tsx
+++ b/src/components/chat/ToolsetSelector.tsx
@@ -40,10 +40,8 @@ export const ToolsetSelector: Component = () => {
     document.removeEventListener("click", handleDocumentClick);
   });
 
-  // Don't render if no toolsets exist
-  if (toolsets().length === 0) {
-    return null;
-  }
+  // Always show the selector - even with no custom toolsets, users need to see
+  // "All Publishers" as visual confirmation that tools are available and active
 
   return (
     <div class="relative" ref={containerRef}>


### PR DESCRIPTION
## Summary
- Removes early return that hid ToolsetSelector when no custom toolsets exist
- Now always shows the selector displaying "All Publishers" as the default
- Provides visual confirmation that tools are available and active

## Root Cause
The ToolsetSelector component returned `null` when `toolsets().length === 0`, hiding the entire indicator when no custom toolsets were configured.

## Test Plan
- [ ] Open Seren Desktop chat panel with no custom toolsets configured
- [ ] Verify "All Publishers" indicator is now visible next to the model selector
- [ ] Click the indicator to confirm dropdown opens with "All Publishers" option
- [ ] Create a custom toolset and verify it appears in the dropdown

Fixes #370