### PR TITLE
fix: update displayed balance immediately on 402 insufficient funds error

### DIFF
--- a/src/stores/wallet.store.ts
+++ b/src/stores/wallet.store.ts
@@ -267,6 +267,28 @@ function resetWalletState(): void {
 }
 
 /**
+ * Update wallet balance from a 402 error response.
+ * This ensures the displayed balance matches reality when an insufficient funds error occurs.
+ * @param availableBalanceAtomic The actual balance in atomic units (from 402 error response)
+ */
+function updateBalanceFromError(availableBalanceAtomic: number): void {
+  const balanceUsd = `$${(availableBalanceAtomic / 1_000_000).toFixed(2)}`;
+  console.log(
+    "[Wallet Store] Updating balance from 402 error:",
+    availableBalanceAtomic,
+    "->",
+    balanceUsd
+  );
+  setWalletState({
+    balance: availableBalanceAtomic / 1_000_000,
+    balance_atomic: availableBalanceAtomic,
+    balance_usd: balanceUsd,
+    lastUpdated: new Date().toISOString(),
+    error: null,
+  });
+}
+
+/**
  * Wallet store with reactive state and actions.
  */
 export const walletStore = {
@@ -330,4 +352,5 @@ export {
   checkDailyClaim,
   claimDaily,
   dismissDailyClaim,
+  updateBalanceFromError,
 };


### PR DESCRIPTION
## Summary

- Fixes the bug where the header balance shows a stale value (e.g., $3.92) while the actual prepaid balance is much lower (e.g., $0.83)
- When a 402 Insufficient prepaid balance error occurs, the response contains availableBalanceAtomic which represents the actual balance
- Now we parse this value and immediately update the wallet store, so the header reflects reality

## Changes

1. **wallet.store.ts**: Added updateBalanceFromError() function to update balance from 402 error response
2. **seren.ts**: Added handleInsufficientBalanceError() helper and call it in all three API error paths:
   - sendMessage()
   - streamMessage()
   - sendMessageWithTools()

## Test plan

- [ ] Trigger an Insufficient prepaid balance 402 error
- [ ] Verify the header balance updates immediately to match the error availableBalanceAtomic
- [ ] Verify normal balance refresh still works (every 60 seconds)

Fixes #373

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com