### PR TITLE
fix: preserve conversation history in non-tool chat path

### DIFF
--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -48,11 +48,11 @@ import {
 import { ChatTabBar } from "./ChatTabBar";
 import { ModelSelector } from "./ModelSelector";
 import { PublisherSuggestions } from "./PublisherSuggestions";
-import { ToolsetSelector } from "./ToolsetSelector";
 import { StreamingMessage } from "./StreamingMessage";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { ThinkingToggle } from "./ThinkingToggle";
 import { ToolStreamingMessage } from "./ToolStreamingMessage";
+import { ToolsetSelector } from "./ToolsetSelector";
 import "highlight.js/styles/github-dark.css";
 
 // Keywords that trigger publisher suggestions
@@ -456,7 +456,12 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
           prompt: trimmed,
           model: chatStore.selectedModel,
           context,
-          stream: streamMessage(trimmed, chatStore.selectedModel, context),
+          stream: streamMessage(
+            trimmed,
+            chatStore.selectedModel,
+            context,
+            chatStore.messages,
+          ),
           toolsEnabled: false,
         };
 

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -192,7 +192,7 @@ export async function* streamMessage(
 }
 
 /**
- * Build a chat request from content and optional context.
+ * Build a chat request from content, optional context, and conversation history.
  * This is a helper to construct the request object.
  */
 export function buildChatRequest(
@@ -203,6 +203,7 @@ export function buildChatRequest(
     file?: string | null;
     range?: { startLine: number; endLine: number } | null;
   },
+  history?: Array<{ role: "user" | "assistant" | "system"; content: string }>,
 ): ChatRequest {
   const messages: ChatMessage[] = [];
 
@@ -227,7 +228,16 @@ export function buildChatRequest(
     });
   }
 
-  // Add user message
+  // Add conversation history (user and assistant messages only)
+  if (history && history.length > 0) {
+    for (const msg of history) {
+      if (msg.role === "user" || msg.role === "assistant") {
+        messages.push({ role: msg.role, content: msg.content });
+      }
+    }
+  }
+
+  // Add current user message
   messages.push({ role: "user", content });
 
   return {

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -114,8 +114,9 @@ export async function sendMessage(
   content: string,
   model: string,
   context?: ChatContext,
+  history?: Message[],
 ): Promise<string> {
-  const request = buildChatRequest(content, model, context);
+  const request = buildChatRequest(content, model, context, history);
   const providerId = providerStore.activeProvider;
 
   return sendProviderMessage(providerId, request);
@@ -123,13 +124,15 @@ export async function sendMessage(
 
 /**
  * Stream a message using the active provider.
+ * Includes conversation history for multi-turn context.
  */
 export async function* streamMessage(
   content: string,
   model: string,
   context?: ChatContext,
+  history?: Message[],
 ): AsyncGenerator<string> {
-  const request = buildChatRequest(content, model, context);
+  const request = buildChatRequest(content, model, context, history);
   request.stream = true;
   const providerId = providerStore.activeProvider;
 
@@ -144,12 +147,13 @@ export async function sendMessageWithRetry(
   model: string,
   context: ChatContext | undefined,
   onRetry?: (attempt: number) => void,
+  history?: Message[],
 ): Promise<string> {
   let lastError: Error | null = null;
 
   for (let attempt = 1; attempt <= CHAT_MAX_RETRIES; attempt++) {
     try {
-      return await sendMessage(content, model, context);
+      return await sendMessage(content, model, context, history);
     } catch (error) {
       lastError = error as Error;
 


### PR DESCRIPTION
## Summary

- Fixes critical bug where LLM loses all conversation context mid-chat
- Root cause: `buildChatRequest()` only sent current message, discarding history
- When tools become unavailable (MCP disconnect, etc.), the non-tool path was used which had no history support

## Changes

- Add `history` parameter to `buildChatRequest()` in providers/index.ts
- Update `streamMessage()` and `sendMessage()` to accept and pass history
- Update `sendMessageWithRetry()` to forward history parameter  
- Pass `chatStore.messages` to `streamMessage` in ChatPanel non-tool path

## Test plan

- [ ] Start a multi-turn conversation in Chat tab
- [ ] Verify context is maintained across messages
- [ ] Disconnect MCP / disable tools and continue conversation
- [ ] Verify LLM still has access to previous conversation history

Closes #372

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com