### PR TITLE
feat(skills): add Skills Browser with dual directory support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5860,6 +5860,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "dirs",
  "futures",
  "hex",
  "html2md",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,6 +66,7 @@ tiny_http = "0.12"
 log = "0.4"
 tauri-plugin-log = "2"
 anyhow = "1"
+dirs = "6"
 
 
 # ACP (Agent Client Protocol) support

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ mod oauth_callback_server;
 #[cfg(feature = "openclaw")]
 mod openclaw;
 mod sandbox;
+mod skills;
 mod sync;
 mod terminal;
 mod wallet;
@@ -708,6 +709,14 @@ pub fn run() {
             openclaw::openclaw_set_trust,
             #[cfg(feature = "openclaw")]
             openclaw::openclaw_grant_approval,
+            // Skills commands
+            skills::get_seren_skills_dir,
+            skills::get_claude_skills_dir,
+            skills::get_project_skills_dir,
+            skills::list_skill_dirs,
+            skills::install_skill,
+            skills::remove_skill,
+            skills::read_skill_content,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -1,0 +1,139 @@
+// ABOUTME: Tauri commands for skills directory management.
+// ABOUTME: Provides commands to get seren, claude, and project skills directories.
+
+use std::fs;
+use std::path::PathBuf;
+use tauri::AppHandle;
+use tauri::Manager;
+
+/// Get the Seren-scope skills directory ({app_data_dir}/skills/).
+/// Creates the directory if it doesn't exist.
+#[tauri::command]
+pub fn get_seren_skills_dir(app: AppHandle) -> Result<String, String> {
+    let app_data = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Could not determine app data directory: {}", e))?;
+    let skills_dir = app_data.join("skills");
+
+    if !skills_dir.exists() {
+        fs::create_dir_all(&skills_dir)
+            .map_err(|e| format!("Failed to create skills directory: {}", e))?;
+    }
+
+    Ok(skills_dir.to_string_lossy().to_string())
+}
+
+/// Get the Claude Code skills directory (~/.claude/skills/).
+/// Creates the directory if it doesn't exist.
+#[tauri::command]
+pub fn get_claude_skills_dir() -> Result<String, String> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    let skills_dir = home.join(".claude").join("skills");
+
+    if !skills_dir.exists() {
+        fs::create_dir_all(&skills_dir)
+            .map_err(|e| format!("Failed to create skills directory: {}", e))?;
+    }
+
+    Ok(skills_dir.to_string_lossy().to_string())
+}
+
+/// Get the project-scope skills directory (.claude/skills/).
+/// Returns the path if a project root is provided, otherwise returns None.
+/// The project root is determined by the frontend based on the open folder.
+#[tauri::command]
+pub fn get_project_skills_dir(project_root: Option<String>) -> Result<Option<String>, String> {
+    match project_root {
+        Some(root) => {
+            let root_path = PathBuf::from(&root);
+            if !root_path.is_dir() {
+                return Ok(None);
+            }
+
+            let skills_dir = root_path.join(".claude").join("skills");
+            Ok(Some(skills_dir.to_string_lossy().to_string()))
+        }
+        None => Ok(None),
+    }
+}
+
+/// List all skill directories in a given skills directory.
+/// Returns a list of skill slugs (directory names).
+#[tauri::command]
+pub fn list_skill_dirs(skills_dir: String) -> Result<Vec<String>, String> {
+    let dir_path = PathBuf::from(&skills_dir);
+
+    if !dir_path.exists() {
+        return Ok(vec![]);
+    }
+
+    let entries = fs::read_dir(&dir_path)
+        .map_err(|e| format!("Failed to read skills directory: {}", e))?;
+
+    let mut slugs = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Check if SKILL.md exists in this directory
+            let skill_file = path.join("SKILL.md");
+            if skill_file.exists() {
+                if let Some(name) = path.file_name() {
+                    slugs.push(name.to_string_lossy().to_string());
+                }
+            }
+        }
+    }
+
+    Ok(slugs)
+}
+
+/// Create a skill directory and write SKILL.md content.
+#[tauri::command]
+pub fn install_skill(skills_dir: String, slug: String, content: String) -> Result<String, String> {
+    let dir_path = PathBuf::from(&skills_dir);
+    let skill_dir = dir_path.join(&slug);
+    let skill_file = skill_dir.join("SKILL.md");
+
+    // Create skill directory
+    fs::create_dir_all(&skill_dir)
+        .map_err(|e| format!("Failed to create skill directory: {}", e))?;
+
+    // Write SKILL.md content
+    fs::write(&skill_file, content)
+        .map_err(|e| format!("Failed to write SKILL.md: {}", e))?;
+
+    Ok(skill_file.to_string_lossy().to_string())
+}
+
+/// Remove a skill directory.
+#[tauri::command]
+pub fn remove_skill(skills_dir: String, slug: String) -> Result<(), String> {
+    let dir_path = PathBuf::from(&skills_dir);
+    let skill_dir = dir_path.join(&slug);
+
+    if !skill_dir.exists() {
+        return Ok(());
+    }
+
+    fs::remove_dir_all(&skill_dir)
+        .map_err(|e| format!("Failed to remove skill directory: {}", e))?;
+
+    Ok(())
+}
+
+/// Read a skill's SKILL.md content.
+#[tauri::command]
+pub fn read_skill_content(skills_dir: String, slug: String) -> Result<Option<String>, String> {
+    let dir_path = PathBuf::from(&skills_dir);
+    let skill_file = dir_path.join(&slug).join("SKILL.md");
+
+    if !skill_file.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&skill_file)
+        .map_err(|e| format!("Failed to read SKILL.md: {}", e))?;
+
+    Ok(Some(content))
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { X402PaymentApproval } from "@/components/mcp/X402PaymentApproval";
 import { OpenClawApprovalManager } from "@/components/settings/OpenClawApproval";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { DatabasePanel } from "@/components/sidebar/DatabasePanel";
+import { SkillsPanel } from "@/components/skills";
 import { FileExplorer } from "@/components/sidebar/FileExplorer";
 import { DailyClaimPopup } from "@/components/wallet/DailyClaimPopup";
 import { shortcuts } from "@/lib/shortcuts";
@@ -191,7 +192,7 @@ function App() {
       setShowEditor(true);
       setOverlayPanel(null);
     } else {
-      // Settings, catalog, database, account are overlays
+      // Settings, catalog, database, skills, account are overlays
       setOverlayPanel(panel);
     }
   };
@@ -248,6 +249,9 @@ function App() {
                 </Match>
                 <Match when={overlayPanel() === "database"}>
                   <DatabasePanel />
+                </Match>
+                <Match when={overlayPanel() === "skills"}>
+                  <SkillsPanel />
                 </Match>
                 <Match when={overlayPanel() === "settings"}>
                   <SettingsPanel onSignInClick={handleSignInClick} />

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -10,6 +10,7 @@ export type Panel =
   | "editor"
   | "catalog"
   | "database"
+  | "skills"
   | "settings"
   | "account";
 
@@ -25,6 +26,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: "editor", label: "Editor", icon: "📝" },
   { id: "catalog", label: "Catalog", icon: "📚" },
   { id: "database", label: "Database", icon: "🗄️" },
+  { id: "skills", label: "Skills", icon: "🧩" },
   { id: "settings", label: "Settings", icon: "⚙️" },
 ];
 

--- a/src/components/skills/SkillCard.tsx
+++ b/src/components/skills/SkillCard.tsx
@@ -1,0 +1,106 @@
+// ABOUTME: Card component for displaying a skill in the browse/installed lists.
+// ABOUTME: Shows skill name, description, tags, and source badge.
+
+import { type Component, For, Show } from "solid-js";
+import type { InstalledSkill, Skill, SkillSource } from "@/lib/skills";
+
+interface SkillCardProps {
+  skill: Skill | InstalledSkill;
+  isSelected: boolean;
+  isInstalled: boolean;
+  onClick: () => void;
+}
+
+const SOURCE_COLORS: Record<SkillSource, string> = {
+  seren: "bg-[rgba(99,102,241,0.2)] text-[#818cf8]",
+  anthropic: "bg-[rgba(234,179,8,0.2)] text-[#fbbf24]",
+  openai: "bg-[rgba(34,197,94,0.2)] text-[#22c55e]",
+  community: "bg-[rgba(148,163,184,0.2)] text-[#94a3b8]",
+  local: "bg-[rgba(59,130,246,0.2)] text-[#3b82f6]",
+};
+
+const SOURCE_LABELS: Record<SkillSource, string> = {
+  seren: "Seren",
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  community: "Community",
+  local: "Local",
+};
+
+export const SkillCard: Component<SkillCardProps> = (props) => {
+  const isInstalledSkill = () => "scope" in props.skill;
+
+  return (
+    <article
+      class={`flex flex-col p-4 bg-[rgba(30,41,59,0.5)] border rounded-xl cursor-pointer transition-all hover:bg-[rgba(30,41,59,0.8)] hover:border-[rgba(148,163,184,0.3)] ${
+        props.isSelected
+          ? "border-[#6366f1] bg-[rgba(99,102,241,0.1)]"
+          : "border-[rgba(148,163,184,0.15)]"
+      }`}
+      onClick={props.onClick}
+    >
+      <div class="flex items-start justify-between gap-3 mb-2">
+        <div class="flex items-center gap-2 min-w-0">
+          <span class="text-[18px]">📄</span>
+          <h3 class="text-[14px] font-semibold text-white m-0 truncate">
+            {props.skill.name}
+          </h3>
+        </div>
+        <div class="flex items-center gap-2 shrink-0">
+          <Show when={props.isInstalled}>
+            <span
+              class="flex items-center justify-center w-5 h-5 bg-[#22c55e] rounded-full text-[10px] text-white"
+              title="Installed"
+            >
+              ✓
+            </span>
+          </Show>
+          <span
+            class={`px-2 py-0.5 rounded text-[10px] font-medium ${SOURCE_COLORS[props.skill.source]}`}
+          >
+            {SOURCE_LABELS[props.skill.source]}
+          </span>
+        </div>
+      </div>
+
+      <Show when={props.skill.author}>
+        <p class="text-[11px] text-[#64748b] -mt-1 mb-2 m-0">
+          by {props.skill.author}
+        </p>
+      </Show>
+
+      <p class="text-[12px] text-[#94a3b8] leading-relaxed mb-3 m-0 line-clamp-2">
+        {props.skill.description}
+      </p>
+
+      <Show when={props.skill.tags.length > 0}>
+        <div class="flex flex-wrap gap-1.5 mt-auto">
+          <For each={props.skill.tags.slice(0, 3)}>
+            {(tag) => (
+              <span class="px-2 py-0.5 bg-[rgba(148,163,184,0.1)] rounded text-[10px] text-[#94a3b8]">
+                {tag}
+              </span>
+            )}
+          </For>
+          <Show when={props.skill.tags.length > 3}>
+            <span class="px-2 py-0.5 text-[10px] text-[#64748b]">
+              +{props.skill.tags.length - 3}
+            </span>
+          </Show>
+        </div>
+      </Show>
+
+      <Show when={isInstalledSkill()}>
+        <div class="flex items-center gap-2 mt-3 pt-3 border-t border-[rgba(148,163,184,0.1)]">
+          <span class="text-[11px] text-[#64748b]">
+            {(props.skill as InstalledSkill).scope === "seren"
+              ? "Seren"
+              : (props.skill as InstalledSkill).scope === "claude"
+                ? "Claude Code"
+                : "Project"}
+          </span>
+        </div>
+      </Show>
+    </article>
+  );
+};

--- a/src/components/skills/SkillPreview.tsx
+++ b/src/components/skills/SkillPreview.tsx
@@ -1,0 +1,332 @@
+// ABOUTME: Preview pane for displaying full skill content and install actions.
+// ABOUTME: Shows skill metadata, raw content, and install/remove buttons.
+
+import {
+  type Component,
+  createResource,
+  createSignal,
+  For,
+  Show,
+} from "solid-js";
+import type {
+  InstalledSkill,
+  Skill,
+  SkillScope,
+  SkillSource,
+} from "@/lib/skills";
+import { skills } from "@/services/skills";
+import { skillsStore } from "@/stores/skills.store";
+
+interface SkillPreviewProps {
+  skill: Skill | InstalledSkill;
+  onClose: () => void;
+}
+
+const SOURCE_LABELS: Record<SkillSource, string> = {
+  seren: "Seren",
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  community: "Community",
+  local: "Local",
+};
+
+const SCOPE_LABELS: Record<SkillScope, string> = {
+  seren: "Seren",
+  claude: "Claude Code",
+  project: "Project",
+};
+
+export const SkillPreview: Component<SkillPreviewProps> = (props) => {
+  const [installing, setInstalling] = createSignal(false);
+  const [showScopeMenu, setShowScopeMenu] = createSignal(false);
+  const [showRemoveMenu, setShowRemoveMenu] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const isInstalledSkill = () => "scope" in props.skill;
+  const isInstalled = () =>
+    isInstalledSkill() || skillsStore.isInstalled(props.skill.id);
+
+  /** All installations of this skill across scopes. */
+  const installedInstances = () =>
+    skillsStore.installed.filter((s) => s.slug === props.skill.slug);
+
+  // Fetch content for preview
+  const [content] = createResource(
+    () => props.skill,
+    async (skill) => {
+      if ("path" in skill) {
+        // Already installed - read from disk
+        return skills.readContent(skill as InstalledSkill);
+      }
+      // Not installed - fetch from source
+      return skills.fetchContent(skill);
+    },
+  );
+
+  async function handleInstall(scope: SkillScope) {
+    setShowScopeMenu(false);
+    setInstalling(true);
+    setError(null);
+
+    try {
+      const skillContent = content();
+      if (!skillContent) {
+        throw new Error("No content available to install");
+      }
+
+      await skillsStore.install(props.skill, skillContent, scope);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to install skill");
+    } finally {
+      setInstalling(false);
+    }
+  }
+
+  async function handleRemove(instance: InstalledSkill) {
+    setShowRemoveMenu(false);
+    setError(null);
+    try {
+      await skillsStore.remove(instance);
+      // Close preview if no installations remain
+      if (installedInstances().length === 0) {
+        props.onClose();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove skill");
+    }
+  }
+
+  function handleToggleEnabled() {
+    if (!isInstalledSkill()) return;
+    skillsStore.toggleEnabled(props.skill.id);
+  }
+
+  return (
+    <aside class="w-[400px] border-l border-[rgba(148,163,184,0.1)] bg-[rgba(15,23,42,0.5)] flex flex-col overflow-hidden">
+      <div class="flex items-center justify-between p-4 border-b border-[rgba(148,163,184,0.1)]">
+        <h2 class="text-[16px] font-semibold text-white m-0 truncate">
+          {props.skill.name}
+        </h2>
+        <button
+          type="button"
+          class="w-7 h-7 flex items-center justify-center bg-transparent border-none rounded text-[20px] text-[#64748b] cursor-pointer hover:bg-[rgba(148,163,184,0.1)] hover:text-white"
+          onClick={props.onClose}
+        >
+          ×
+        </button>
+      </div>
+
+      <div class="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
+        {/* Metadata */}
+        <div class="flex flex-col gap-2">
+          <Show when={props.skill.author}>
+            <p class="text-[13px] text-[#64748b] m-0">
+              by {props.skill.author}
+            </p>
+          </Show>
+
+          <p class="text-[14px] text-[#94a3b8] leading-relaxed m-0">
+            {props.skill.description}
+          </p>
+        </div>
+
+        {/* Tags */}
+        <Show when={props.skill.tags.length > 0}>
+          <div class="flex flex-col gap-2">
+            <h4 class="text-[12px] font-semibold text-[#64748b] uppercase tracking-wide m-0">
+              Tags
+            </h4>
+            <div class="flex flex-wrap gap-1.5">
+              <For each={props.skill.tags}>
+                {(tag) => (
+                  <span class="px-2 py-0.5 bg-[rgba(148,163,184,0.1)] rounded text-[12px] text-[#94a3b8]">
+                    {tag}
+                  </span>
+                )}
+              </For>
+            </div>
+          </div>
+        </Show>
+
+        {/* Source info */}
+        <div class="flex flex-col gap-2">
+          <h4 class="text-[12px] font-semibold text-[#64748b] uppercase tracking-wide m-0">
+            Source
+          </h4>
+          <p class="text-[13px] text-[#94a3b8] m-0">
+            {SOURCE_LABELS[props.skill.source]}
+          </p>
+          <p class="text-[13px] text-[#94a3b8] m-0">
+            Slug:{" "}
+            <code class="px-1.5 py-0.5 bg-[rgba(15,23,42,0.8)] rounded text-[12px] text-[#818cf8] font-mono">
+              {props.skill.slug}
+            </code>
+          </p>
+        </div>
+
+        {/* Installed info */}
+        <Show when={isInstalledSkill()}>
+          <div class="flex flex-col gap-2">
+            <h4 class="text-[12px] font-semibold text-[#64748b] uppercase tracking-wide m-0">
+              Installation
+            </h4>
+            <p class="text-[13px] text-[#94a3b8] m-0">
+              Scope: {SCOPE_LABELS[(props.skill as InstalledSkill).scope]}
+            </p>
+            <p class="text-[13px] text-[#94a3b8] m-0 break-all">
+              Path: {(props.skill as InstalledSkill).path}
+            </p>
+          </div>
+        </Show>
+
+        {/* Content preview */}
+        <div class="flex flex-col gap-2">
+          <h4 class="text-[12px] font-semibold text-[#64748b] uppercase tracking-wide m-0">
+            Content
+          </h4>
+          <Show
+            when={!content.loading}
+            fallback={
+              <div class="flex items-center gap-2 p-4 bg-[rgba(30,41,59,0.5)] rounded-lg">
+                <div class="loading-spinner-sm" />
+                <span class="text-[13px] text-[#64748b]">
+                  Loading content...
+                </span>
+              </div>
+            }
+          >
+            <Show
+              when={content()}
+              fallback={
+                <p class="text-[13px] text-[#64748b] m-0">
+                  Content not available
+                </p>
+              }
+            >
+              <pre class="p-3 bg-[rgba(15,23,42,0.8)] rounded-lg text-[12px] text-[#94a3b8] font-mono overflow-x-auto whitespace-pre-wrap m-0 max-h-[300px] overflow-y-auto">
+                {content()}
+              </pre>
+            </Show>
+          </Show>
+        </div>
+
+        {/* Error display */}
+        <Show when={error()}>
+          <div class="p-3 bg-[rgba(239,68,68,0.1)] border border-[rgba(239,68,68,0.3)] rounded-lg">
+            <p class="text-[13px] text-[#f87171] m-0">{error()}</p>
+          </div>
+        </Show>
+      </div>
+
+      {/* Action buttons */}
+      <div class="p-4 border-t border-[rgba(148,163,184,0.1)] flex flex-col gap-2">
+        <Show
+          when={isInstalledSkill()}
+          fallback={
+            <Show when={!isInstalled()}>
+              <div class="relative">
+                <button
+                  type="button"
+                  class="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-[#6366f1] border-none rounded-lg text-[14px] font-medium text-white cursor-pointer transition-all hover:bg-[#5558e3] disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={() => setShowScopeMenu(!showScopeMenu())}
+                  disabled={installing() || !content()}
+                >
+                  <Show when={installing()} fallback={<>Install ▼</>}>
+                    <div class="loading-spinner-sm" />
+                    Installing...
+                  </Show>
+                </button>
+
+                <Show when={showScopeMenu()}>
+                  <div class="absolute bottom-full left-0 right-0 mb-1 bg-[rgba(30,41,59,0.95)] border border-[rgba(148,163,184,0.2)] rounded-lg overflow-hidden shadow-lg">
+                    <button
+                      type="button"
+                      class="w-full px-4 py-2.5 text-left text-[13px] text-white bg-transparent border-none cursor-pointer hover:bg-[rgba(148,163,184,0.1)]"
+                      onClick={() => handleInstall("seren")}
+                    >
+                      <span class="block font-medium">Seren (default)</span>
+                      <span class="text-[11px] text-[#64748b]">
+                        Only in Seren Desktop
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      class="w-full px-4 py-2.5 text-left text-[13px] text-white bg-transparent border-none cursor-pointer hover:bg-[rgba(148,163,184,0.1)]"
+                      onClick={() => handleInstall("claude")}
+                    >
+                      <span class="block font-medium">Claude Code (shared)</span>
+                      <span class="text-[11px] text-[#64748b]">
+                        Available in Claude Code CLI too (~/.claude/skills/)
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      class="w-full px-4 py-2.5 text-left text-[13px] text-white bg-transparent border-none cursor-pointer hover:bg-[rgba(148,163,184,0.1)]"
+                      onClick={() => handleInstall("project")}
+                    >
+                      <span class="block font-medium">Project</span>
+                      <span class="text-[11px] text-[#64748b]">
+                        Only in current project (.claude/skills/)
+                      </span>
+                    </button>
+                  </div>
+                </Show>
+              </div>
+            </Show>
+          }
+        >
+          <div class="flex gap-2">
+            <button
+              type="button"
+              class={`flex-1 flex items-center justify-center gap-2 px-4 py-2.5 border rounded-lg text-[14px] font-medium cursor-pointer transition-all ${
+                skillsStore.isEnabled(props.skill.id)
+                  ? "bg-[rgba(34,197,94,0.1)] border-[rgba(34,197,94,0.3)] text-[#22c55e] hover:bg-[rgba(34,197,94,0.2)]"
+                  : "bg-[rgba(148,163,184,0.1)] border-[rgba(148,163,184,0.2)] text-[#94a3b8] hover:bg-[rgba(148,163,184,0.2)]"
+              }`}
+              onClick={handleToggleEnabled}
+            >
+              {skillsStore.isEnabled(props.skill.id) ? "Enabled ✓" : "Disabled"}
+            </button>
+            <div class="relative">
+              <button
+                type="button"
+                class="px-4 py-2.5 bg-[rgba(239,68,68,0.1)] border border-[rgba(239,68,68,0.3)] rounded-lg text-[14px] font-medium text-[#f87171] cursor-pointer transition-all hover:bg-[rgba(239,68,68,0.2)]"
+                onClick={() => {
+                  const instances = installedInstances();
+                  if (instances.length <= 1) {
+                    handleRemove(props.skill as InstalledSkill);
+                  } else {
+                    setShowRemoveMenu(!showRemoveMenu());
+                  }
+                }}
+              >
+                Remove{installedInstances().length > 1 ? " \u25BC" : ""}
+              </button>
+
+              <Show when={showRemoveMenu()}>
+                <div class="absolute bottom-full right-0 mb-1 min-w-[220px] bg-[rgba(30,41,59,0.95)] border border-[rgba(148,163,184,0.2)] rounded-lg overflow-hidden shadow-lg">
+                  <For each={installedInstances()}>
+                    {(instance) => (
+                      <button
+                        type="button"
+                        class="w-full px-4 py-2.5 text-left text-[13px] text-white bg-transparent border-none cursor-pointer hover:bg-[rgba(239,68,68,0.1)]"
+                        onClick={() => handleRemove(instance)}
+                      >
+                        <span class="block font-medium">
+                          {SCOPE_LABELS[instance.scope]}
+                        </span>
+                        <span class="text-[11px] text-[#64748b] block truncate">
+                          {instance.path}
+                        </span>
+                      </button>
+                    )}
+                  </For>
+                </div>
+              </Show>
+            </div>
+          </div>
+        </Show>
+      </div>
+    </aside>
+  );
+};

--- a/src/components/skills/SkillsBrowser.tsx
+++ b/src/components/skills/SkillsBrowser.tsx
@@ -1,0 +1,176 @@
+// ABOUTME: Browse tab for discovering and installing skills.
+// ABOUTME: Shows searchable grid of available skills with filtering.
+
+import {
+  type Component,
+  createEffect,
+  createSignal,
+  For,
+  Show,
+} from "solid-js";
+import type { Skill, SkillSource } from "@/lib/skills";
+import { skills } from "@/services/skills";
+import { skillsStore } from "@/stores/skills.store";
+import { SkillCard } from "./SkillCard";
+
+interface SkillsBrowserProps {
+  onSelectSkill: (skill: Skill) => void;
+  selectedId: string | null;
+}
+
+const SOURCES: { id: SkillSource | null; label: string }[] = [
+  { id: null, label: "All" },
+  { id: "seren", label: "Seren" },
+  { id: "anthropic", label: "Anthropic" },
+  { id: "openai", label: "OpenAI" },
+  { id: "community", label: "Community" },
+];
+
+export const SkillsBrowser: Component<SkillsBrowserProps> = (props) => {
+  const [searchQuery, setSearchQuery] = createSignal("");
+  const [selectedSource, setSelectedSource] = createSignal<SkillSource | null>(
+    null,
+  );
+  const [selectedTag, setSelectedTag] = createSignal<string | null>(null);
+  const [filteredSkills, setFilteredSkills] = createSignal<Skill[]>([]);
+
+  // Get all unique tags from available skills
+  const allTags = () => skills.getAllTags(skillsStore.available);
+
+  // Filter skills based on search, source, and tag
+  createEffect(() => {
+    let filtered = skillsStore.available;
+
+    // Filter by source
+    filtered = skills.filterBySource(filtered, selectedSource());
+
+    // Filter by tag
+    filtered = skills.filterByTag(filtered, selectedTag());
+
+    // Filter by search query
+    filtered = skills.search(filtered, searchQuery());
+
+    setFilteredSkills(filtered);
+  });
+
+  function handleSourceClick(source: SkillSource | null) {
+    setSelectedSource(source);
+  }
+
+  function handleTagClick(tag: string) {
+    setSelectedTag((prev) => (prev === tag ? null : tag));
+  }
+
+  return (
+    <div class="flex flex-col h-full">
+      {/* Search and filters */}
+      <div class="flex items-center gap-4 p-4 border-b border-[rgba(148,163,184,0.1)] flex-wrap">
+        <div class="min-w-[200px] max-w-[350px]">
+          <input
+            type="text"
+            placeholder="Search skills..."
+            value={searchQuery()}
+            onInput={(e) => setSearchQuery(e.currentTarget.value)}
+            class="w-full px-4 py-2.5 bg-[rgba(15,23,42,0.6)] border border-[rgba(148,163,184,0.2)] rounded-lg text-[14px] text-white placeholder:text-[#64748b] outline-none transition-colors focus:border-[#6366f1]"
+          />
+        </div>
+        <div class="flex gap-2 flex-wrap">
+          <For each={SOURCES}>
+            {(source) => (
+              <button
+                type="button"
+                class={`px-3 py-2 rounded-lg text-[13px] font-medium transition-all cursor-pointer border ${
+                  selectedSource() === source.id
+                    ? "bg-[#6366f1] border-[#6366f1] text-white"
+                    : "bg-[rgba(30,41,59,0.5)] border-[rgba(148,163,184,0.15)] text-[#94a3b8] hover:bg-[rgba(30,41,59,0.8)] hover:text-white"
+                }`}
+                onClick={() => handleSourceClick(source.id)}
+              >
+                {source.label}
+              </button>
+            )}
+          </For>
+        </div>
+      </div>
+
+      {/* Tag filters */}
+      <Show when={allTags().length > 0}>
+        <div class="flex items-center gap-2 px-4 py-2 border-b border-[rgba(148,163,184,0.1)] overflow-x-auto">
+          <span class="text-[12px] text-[#64748b] shrink-0">Tags:</span>
+          <div class="flex gap-1.5">
+            <For each={allTags().slice(0, 10)}>
+              {(tag) => (
+                <button
+                  type="button"
+                  class={`px-2 py-1 rounded text-[11px] transition-all cursor-pointer border ${
+                    selectedTag() === tag
+                      ? "bg-[rgba(99,102,241,0.2)] border-[rgba(99,102,241,0.4)] text-[#818cf8]"
+                      : "bg-transparent border-[rgba(148,163,184,0.15)] text-[#94a3b8] hover:bg-[rgba(148,163,184,0.1)]"
+                  }`}
+                  onClick={() => handleTagClick(tag)}
+                >
+                  {tag}
+                </button>
+              )}
+            </For>
+          </div>
+        </div>
+      </Show>
+
+      {/* Loading state */}
+      <Show when={skillsStore.isLoading}>
+        <div class="flex flex-col items-center justify-center gap-4 p-12">
+          <div class="loading-spinner" />
+          <p class="text-[#94a3b8] m-0">Loading skills...</p>
+        </div>
+      </Show>
+
+      {/* Error state */}
+      <Show when={skillsStore.error}>
+        <div class="m-6 p-4 bg-[rgba(239,68,68,0.1)] border border-[rgba(239,68,68,0.3)] rounded-lg flex items-center justify-between">
+          <p class="text-[#f87171] m-0">{skillsStore.error}</p>
+          <button
+            type="button"
+            onClick={() => skillsStore.refreshAvailable()}
+            class="px-3 py-1.5 bg-[rgba(239,68,68,0.2)] border-none rounded text-[#f87171] cursor-pointer hover:bg-[rgba(239,68,68,0.3)]"
+          >
+            Retry
+          </button>
+        </div>
+      </Show>
+
+      {/* Skills grid */}
+      <Show when={!skillsStore.isLoading && !skillsStore.error}>
+        <div class="flex-1 overflow-y-auto p-4">
+          <Show
+            when={filteredSkills().length > 0}
+            fallback={
+              <div class="flex flex-col items-center justify-center gap-3 p-12 text-center">
+                <span class="text-[48px]">📚</span>
+                <p class="text-white text-[16px] m-0">No skills found</p>
+                <p class="text-[#64748b] text-[14px] m-0">
+                  {searchQuery() || selectedSource() || selectedTag()
+                    ? "Try adjusting your search or filters"
+                    : "Skills will appear here once the index is loaded"}
+                </p>
+              </div>
+            }
+          >
+            <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
+              <For each={filteredSkills()}>
+                {(skill) => (
+                  <SkillCard
+                    skill={skill}
+                    isSelected={props.selectedId === skill.id}
+                    isInstalled={skillsStore.isInstalled(skill.id)}
+                    onClick={() => props.onSelectSkill(skill)}
+                  />
+                )}
+              </For>
+            </div>
+          </Show>
+        </div>
+      </Show>
+    </div>
+  );
+};

--- a/src/components/skills/SkillsInstalled.tsx
+++ b/src/components/skills/SkillsInstalled.tsx
@@ -1,0 +1,152 @@
+// ABOUTME: Installed tab for managing installed skills.
+// ABOUTME: Shows list of installed skills with enable/disable and remove options.
+
+import { type Component, createSignal, For, Show } from "solid-js";
+import type { InstalledSkill } from "@/lib/skills";
+import { skillsStore } from "@/stores/skills.store";
+import { SkillCard } from "./SkillCard";
+
+interface SkillsInstalledProps {
+  onSelectSkill: (skill: InstalledSkill) => void;
+  selectedId: string | null;
+}
+
+export const SkillsInstalled: Component<SkillsInstalledProps> = (props) => {
+  const [filterScope, setFilterScope] = createSignal<
+    "all" | "seren" | "claude" | "project"
+  >("all");
+
+  const filteredSkills = () => {
+    const scope = filterScope();
+    if (scope === "all") return skillsStore.installed;
+    return skillsStore.installed.filter((s) => s.scope === scope);
+  };
+
+  const serenCount = () =>
+    skillsStore.installed.filter((s) => s.scope === "seren").length;
+  const claudeCount = () =>
+    skillsStore.installed.filter((s) => s.scope === "claude").length;
+  const projectCount = () =>
+    skillsStore.installed.filter((s) => s.scope === "project").length;
+
+  return (
+    <div class="flex flex-col h-full">
+      {/* Scope filter */}
+      <div class="flex items-center gap-4 p-4 border-b border-[rgba(148,163,184,0.1)]">
+        <div class="flex gap-2">
+          <button
+            type="button"
+            class={`px-3 py-2 rounded-lg text-[13px] font-medium transition-all cursor-pointer border ${
+              filterScope() === "all"
+                ? "bg-[#6366f1] border-[#6366f1] text-white"
+                : "bg-[rgba(30,41,59,0.5)] border-[rgba(148,163,184,0.15)] text-[#94a3b8] hover:bg-[rgba(30,41,59,0.8)] hover:text-white"
+            }`}
+            onClick={() => setFilterScope("all")}
+          >
+            All ({skillsStore.installed.length})
+          </button>
+          <button
+            type="button"
+            class={`px-3 py-2 rounded-lg text-[13px] font-medium transition-all cursor-pointer border ${
+              filterScope() === "seren"
+                ? "bg-[#6366f1] border-[#6366f1] text-white"
+                : "bg-[rgba(30,41,59,0.5)] border-[rgba(148,163,184,0.15)] text-[#94a3b8] hover:bg-[rgba(30,41,59,0.8)] hover:text-white"
+            }`}
+            onClick={() => setFilterScope("seren")}
+          >
+            Seren ({serenCount()})
+          </button>
+          <button
+            type="button"
+            class={`px-3 py-2 rounded-lg text-[13px] font-medium transition-all cursor-pointer border ${
+              filterScope() === "claude"
+                ? "bg-[#6366f1] border-[#6366f1] text-white"
+                : "bg-[rgba(30,41,59,0.5)] border-[rgba(148,163,184,0.15)] text-[#94a3b8] hover:bg-[rgba(30,41,59,0.8)] hover:text-white"
+            }`}
+            onClick={() => setFilterScope("claude")}
+          >
+            Claude ({claudeCount()})
+          </button>
+          <button
+            type="button"
+            class={`px-3 py-2 rounded-lg text-[13px] font-medium transition-all cursor-pointer border ${
+              filterScope() === "project"
+                ? "bg-[#6366f1] border-[#6366f1] text-white"
+                : "bg-[rgba(30,41,59,0.5)] border-[rgba(148,163,184,0.15)] text-[#94a3b8] hover:bg-[rgba(30,41,59,0.8)] hover:text-white"
+            }`}
+            onClick={() => setFilterScope("project")}
+          >
+            Project ({projectCount()})
+          </button>
+        </div>
+
+        <div class="ml-auto text-[13px] text-[#64748b]">
+          {skillsStore.enabledSkills.length} enabled
+        </div>
+      </div>
+
+      {/* Loading state */}
+      <Show when={skillsStore.isLoading}>
+        <div class="flex flex-col items-center justify-center gap-4 p-12">
+          <div class="loading-spinner" />
+          <p class="text-[#94a3b8] m-0">Loading installed skills...</p>
+        </div>
+      </Show>
+
+      {/* Skills list */}
+      <Show when={!skillsStore.isLoading}>
+        <div class="flex-1 overflow-y-auto p-4">
+          <Show
+            when={filteredSkills().length > 0}
+            fallback={
+              <div class="flex flex-col items-center justify-center gap-3 p-12 text-center">
+                <span class="text-[48px]">📦</span>
+                <p class="text-white text-[16px] m-0">No skills installed</p>
+                <p class="text-[#64748b] text-[14px] m-0">
+                  {filterScope() !== "all"
+                    ? `No ${filterScope()} scope skills installed`
+                    : "Browse the catalog to discover and install skills"}
+                </p>
+              </div>
+            }
+          >
+            <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
+              <For each={filteredSkills()}>
+                {(skill) => (
+                  <div class="relative">
+                    <SkillCard
+                      skill={skill}
+                      isSelected={props.selectedId === skill.id}
+                      isInstalled={true}
+                      onClick={() => props.onSelectSkill(skill)}
+                    />
+                    {/* Quick enable/disable toggle */}
+                    <button
+                      type="button"
+                      class={`absolute top-3 right-3 w-6 h-6 flex items-center justify-center rounded-full transition-all cursor-pointer border ${
+                        skillsStore.isEnabled(skill.id)
+                          ? "bg-[#22c55e] border-[#22c55e] text-white"
+                          : "bg-[rgba(148,163,184,0.2)] border-[rgba(148,163,184,0.3)] text-[#64748b]"
+                      }`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        skillsStore.toggleEnabled(skill.id);
+                      }}
+                      title={
+                        skillsStore.isEnabled(skill.id)
+                          ? "Click to disable"
+                          : "Click to enable"
+                      }
+                    >
+                      {skillsStore.isEnabled(skill.id) ? "✓" : "○"}
+                    </button>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+        </div>
+      </Show>
+    </div>
+  );
+};

--- a/src/components/skills/SkillsPanel.tsx
+++ b/src/components/skills/SkillsPanel.tsx
@@ -1,0 +1,116 @@
+// ABOUTME: Main skills panel with tabbed interface for browse and installed views.
+// ABOUTME: Provides skill discovery, installation, and management functionality.
+
+import { type Component, createSignal, onMount, Show } from "solid-js";
+import type { InstalledSkill, Skill } from "@/lib/skills";
+import { skillsStore } from "@/stores/skills.store";
+import { SkillPreview } from "./SkillPreview";
+import { SkillsBrowser } from "./SkillsBrowser";
+import { SkillsInstalled } from "./SkillsInstalled";
+
+type Tab = "browse" | "installed";
+
+export const SkillsPanel: Component = () => {
+  const [activeTab, setActiveTab] = createSignal<Tab>("browse");
+  const [selectedSkill, setSelectedSkill] = createSignal<
+    Skill | InstalledSkill | null
+  >(null);
+
+  // Load skills on mount
+  onMount(() => {
+    skillsStore.refresh();
+  });
+
+  function handleSelectSkill(skill: Skill | InstalledSkill) {
+    setSelectedSkill(skill);
+    skillsStore.setSelected(skill.id);
+  }
+
+  function handleClosePreview() {
+    setSelectedSkill(null);
+    skillsStore.setSelected(null);
+  }
+
+  function handleRefresh() {
+    skillsStore.clearCacheAndRefresh();
+  }
+
+  return (
+    <div class="flex flex-col h-full bg-transparent">
+      {/* Header */}
+      <header class="p-6 pb-4 border-b border-[rgba(148,163,184,0.1)]">
+        <div class="flex items-center justify-between">
+          <div>
+            <h1 class="text-2xl font-semibold text-white m-0">Skills</h1>
+            <p class="text-[14px] text-[#94a3b8] mt-1 m-0">
+              Discover and manage SKILL.md-based capabilities for your AI
+              assistant.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="px-3 py-2 bg-[rgba(30,41,59,0.5)] border border-[rgba(148,163,184,0.15)] rounded-lg text-[13px] font-medium text-[#94a3b8] cursor-pointer transition-all hover:bg-[rgba(30,41,59,0.8)] hover:text-white"
+            onClick={handleRefresh}
+            title="Refresh skills index"
+          >
+            ↻ Refresh
+          </button>
+        </div>
+      </header>
+
+      {/* Tabs */}
+      <div class="flex border-b border-[rgba(148,163,184,0.1)]">
+        <button
+          type="button"
+          class={`px-6 py-3 text-[14px] font-medium cursor-pointer transition-all border-b-2 ${
+            activeTab() === "browse"
+              ? "text-white border-[#6366f1] bg-transparent"
+              : "text-[#94a3b8] border-transparent hover:text-white bg-transparent"
+          }`}
+          onClick={() => setActiveTab("browse")}
+        >
+          Browse
+        </button>
+        <button
+          type="button"
+          class={`px-6 py-3 text-[14px] font-medium cursor-pointer transition-all border-b-2 ${
+            activeTab() === "installed"
+              ? "text-white border-[#6366f1] bg-transparent"
+              : "text-[#94a3b8] border-transparent hover:text-white bg-transparent"
+          }`}
+          onClick={() => setActiveTab("installed")}
+        >
+          Installed ({skillsStore.installed.length})
+        </button>
+      </div>
+
+      {/* Content area with preview */}
+      <div class="flex flex-1 overflow-hidden">
+        {/* Main content */}
+        <div class="flex-1 overflow-hidden">
+          <Show when={activeTab() === "browse"}>
+            <SkillsBrowser
+              onSelectSkill={handleSelectSkill}
+              selectedId={selectedSkill()?.id ?? null}
+            />
+          </Show>
+          <Show when={activeTab() === "installed"}>
+            <SkillsInstalled
+              onSelectSkill={handleSelectSkill}
+              selectedId={selectedSkill()?.id ?? null}
+            />
+          </Show>
+        </div>
+
+        {/* Preview pane */}
+        <Show when={selectedSkill()}>
+          {(skill) => (
+            <SkillPreview skill={skill()} onClose={handleClosePreview} />
+          )}
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default SkillsPanel;

--- a/src/components/skills/index.ts
+++ b/src/components/skills/index.ts
@@ -1,0 +1,8 @@
+// ABOUTME: Skills components exports.
+// ABOUTME: Provides SkillsPanel and related components.
+
+export { SkillCard } from "./SkillCard";
+export { SkillPreview } from "./SkillPreview";
+export { SkillsBrowser } from "./SkillsBrowser";
+export { SkillsInstalled } from "./SkillsInstalled";
+export { SkillsPanel } from "./SkillsPanel";

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -1,0 +1,6 @@
+// ABOUTME: Skills library exports.
+// ABOUTME: Provides types, parser, and path utilities for skill management.
+
+export * from "./parser";
+export * from "./paths";
+export * from "./types";

--- a/src/lib/skills/parser.ts
+++ b/src/lib/skills/parser.ts
@@ -1,0 +1,218 @@
+// ABOUTME: Parser for SKILL.md files with YAML frontmatter.
+// ABOUTME: Extracts metadata and content from skill definition files.
+
+import type { SkillMetadata } from "./types";
+
+/**
+ * Result of parsing a SKILL.md file.
+ */
+export interface ParsedSkill {
+  metadata: SkillMetadata;
+  content: string;
+  rawContent: string;
+}
+
+/**
+ * Parse YAML frontmatter from a SKILL.md file.
+ * Frontmatter is delimited by --- at the start of the file.
+ */
+export function parseSkillMd(rawContent: string): ParsedSkill {
+  const trimmed = rawContent.trim();
+
+  // Check for frontmatter delimiter
+  if (!trimmed.startsWith("---")) {
+    // No frontmatter, treat entire content as the skill description
+    return {
+      metadata: extractMetadataFromContent(trimmed),
+      content: trimmed,
+      rawContent,
+    };
+  }
+
+  // Find the closing delimiter
+  const endIndex = trimmed.indexOf("---", 3);
+  if (endIndex === -1) {
+    // No closing delimiter, treat as no frontmatter
+    return {
+      metadata: extractMetadataFromContent(trimmed),
+      content: trimmed,
+      rawContent,
+    };
+  }
+
+  const frontmatter = trimmed.slice(3, endIndex).trim();
+  const content = trimmed.slice(endIndex + 3).trim();
+
+  const metadata = parseYamlFrontmatter(frontmatter);
+
+  // If no name in frontmatter, try to extract from content heading
+  if (!metadata.name) {
+    const nameFromContent = extractNameFromContent(content);
+    if (nameFromContent) {
+      metadata.name = nameFromContent;
+    }
+  }
+
+  return {
+    metadata,
+    content,
+    rawContent,
+  };
+}
+
+/**
+ * Parse YAML-like frontmatter into metadata.
+ * Simple parser that handles common YAML patterns.
+ */
+function parseYamlFrontmatter(yaml: string): SkillMetadata {
+  const metadata: SkillMetadata = {
+    name: "",
+    description: "",
+    tags: [],
+  };
+
+  const lines = yaml.split("\n");
+  let currentKey: string | null = null;
+  let inArray = false;
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+
+    // Skip empty lines and comments
+    if (!trimmedLine || trimmedLine.startsWith("#")) {
+      continue;
+    }
+
+    // Check for array item
+    if (trimmedLine.startsWith("- ") && currentKey && inArray) {
+      const value = trimmedLine
+        .slice(2)
+        .trim()
+        .replace(/^["']|["']$/g, "");
+      if (
+        currentKey === "tags" ||
+        currentKey === "globs" ||
+        currentKey === "alwaysAllow"
+      ) {
+        (metadata[currentKey] as string[]).push(value);
+      }
+      continue;
+    }
+
+    // Check for key-value pair
+    const colonIndex = trimmedLine.indexOf(":");
+    if (colonIndex > 0) {
+      const key = trimmedLine.slice(0, colonIndex).trim();
+      const value = trimmedLine.slice(colonIndex + 1).trim();
+
+      currentKey = key;
+
+      // Check if this is the start of an array (empty value or explicit array)
+      if (!value || value === "[]") {
+        inArray = true;
+        if (key === "tags") metadata.tags = [];
+        if (key === "globs") metadata.globs = [];
+        if (key === "alwaysAllow") metadata.alwaysAllow = [];
+        continue;
+      }
+
+      inArray = false;
+
+      // Handle inline arrays [item1, item2]
+      if (value.startsWith("[") && value.endsWith("]")) {
+        const items = value
+          .slice(1, -1)
+          .split(",")
+          .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+          .filter(Boolean);
+
+        if (key === "tags") metadata.tags = items;
+        if (key === "globs") metadata.globs = items;
+        if (key === "alwaysAllow") metadata.alwaysAllow = items;
+        continue;
+      }
+
+      // Handle scalar values
+      const cleanValue = value.replace(/^["']|["']$/g, "");
+
+      switch (key) {
+        case "name":
+          metadata.name = cleanValue;
+          break;
+        case "description":
+          metadata.description = cleanValue;
+          break;
+        case "version":
+          metadata.version = cleanValue;
+          break;
+        case "author":
+          metadata.author = cleanValue;
+          break;
+      }
+    }
+  }
+
+  return metadata;
+}
+
+/**
+ * Extract metadata from content when no frontmatter is present.
+ * Uses the first heading as name and first paragraph as description.
+ */
+function extractMetadataFromContent(content: string): SkillMetadata {
+  const name = extractNameFromContent(content) || "Unnamed Skill";
+  const description = extractDescriptionFromContent(content) || "";
+
+  return {
+    name,
+    description,
+    tags: [],
+  };
+}
+
+/**
+ * Extract the skill name from the first markdown heading.
+ */
+function extractNameFromContent(content: string): string | null {
+  const headingMatch = content.match(/^#\s+(.+)$/m);
+  return headingMatch ? headingMatch[1].trim() : null;
+}
+
+/**
+ * Extract description from the first non-heading paragraph.
+ */
+function extractDescriptionFromContent(content: string): string | null {
+  const lines = content.split("\n");
+  let foundHeading = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines
+    if (!trimmed) continue;
+
+    // Skip headings
+    if (trimmed.startsWith("#")) {
+      foundHeading = true;
+      continue;
+    }
+
+    // Return first non-heading, non-empty line after a heading
+    if (foundHeading && trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Compute SHA-256 hash of content for change detection.
+ */
+export async function computeContentHash(content: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(content);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}

--- a/src/lib/skills/paths.ts
+++ b/src/lib/skills/paths.ts
@@ -1,0 +1,88 @@
+// ABOUTME: Path utilities for skills directories.
+// ABOUTME: Provides functions to get seren, claude, and project skill paths.
+
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+
+/** Cached Seren skills directory */
+let cachedSerenSkillsDir: string | null = null;
+
+/** Cached Claude Code skills directory */
+let cachedClaudeSkillsDir: string | null = null;
+
+/**
+ * Get the Seren-scope skills directory ({app_data_dir}/skills/).
+ * Creates the directory if it doesn't exist.
+ */
+export async function getSerenSkillsDir(): Promise<string> {
+  if (cachedSerenSkillsDir) {
+    return cachedSerenSkillsDir;
+  }
+
+  if (!isTauriRuntime()) {
+    return "{app_data}/skills";
+  }
+
+  const dir = await invoke<string>("get_seren_skills_dir");
+  cachedSerenSkillsDir = dir;
+  return dir;
+}
+
+/**
+ * Get the Claude Code skills directory (~/.claude/skills/).
+ * Creates the directory if it doesn't exist.
+ */
+export async function getClaudeSkillsDir(): Promise<string> {
+  if (cachedClaudeSkillsDir) {
+    return cachedClaudeSkillsDir;
+  }
+
+  if (!isTauriRuntime()) {
+    return "~/.claude/skills";
+  }
+
+  const dir = await invoke<string>("get_claude_skills_dir");
+  cachedClaudeSkillsDir = dir;
+  return dir;
+}
+
+/**
+ * Get the project-scope skills directory (.claude/skills/).
+ * Returns null if no project is currently open.
+ */
+export async function getProjectSkillsDir(): Promise<string | null> {
+  if (!isTauriRuntime()) {
+    return null;
+  }
+
+  try {
+    return invoke<string | null>("get_project_skills_dir");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the full path for a skill file.
+ */
+export function getSkillPath(skillsDir: string, slug: string): string {
+  // Normalize path separators for the platform
+  const separator = skillsDir.includes("\\") ? "\\" : "/";
+  return `${skillsDir}${separator}${slug}${separator}SKILL.md`;
+}
+
+/**
+ * Get the directory path for a skill.
+ */
+export function getSkillDir(skillsDir: string, slug: string): string {
+  const separator = skillsDir.includes("\\") ? "\\" : "/";
+  return `${skillsDir}${separator}${slug}`;
+}
+
+/**
+ * Clear cached paths (useful when project changes).
+ */
+export function clearPathCache(): void {
+  cachedSerenSkillsDir = null;
+  cachedClaudeSkillsDir = null;
+}

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -1,0 +1,109 @@
+// ABOUTME: Type definitions for the Skills Browser feature.
+// ABOUTME: Defines Skill, InstalledSkill, and SkillSource types.
+
+/**
+ * Source of a skill - where it comes from.
+ */
+export type SkillSource =
+  | "seren"
+  | "anthropic"
+  | "openai"
+  | "community"
+  | "local";
+
+/**
+ * Skill metadata parsed from SKILL.md frontmatter.
+ */
+export interface SkillMetadata {
+  name: string;
+  description: string;
+  version?: string;
+  author?: string;
+  tags: string[];
+  globs?: string[];
+  alwaysAllow?: string[];
+}
+
+/**
+ * A skill available for installation.
+ */
+export interface Skill {
+  /** Unique identifier: "source:slug" */
+  id: string;
+  /** URL-friendly slug (e.g., "commit-message") */
+  slug: string;
+  /** Display name */
+  name: string;
+  /** Short description */
+  description: string;
+  /** Where this skill comes from */
+  source: SkillSource;
+  /** URL to fetch full SKILL.md content */
+  sourceUrl?: string;
+  /** Tags for categorization and filtering */
+  tags: string[];
+  /** Author name or organization */
+  author?: string;
+  /** Version string */
+  version?: string;
+}
+
+/**
+ * Scope where a skill is installed.
+ */
+export type SkillScope = "seren" | "claude" | "project";
+
+/**
+ * An installed skill with additional metadata.
+ */
+export interface InstalledSkill extends Skill {
+  /** Where the skill is installed (user or project scope) */
+  scope: SkillScope;
+  /** Full path to the SKILL.md file */
+  path: string;
+  /** Timestamp when the skill was installed */
+  installedAt: number;
+  /** Whether the skill is currently enabled */
+  enabled: boolean;
+  /** SHA-256 hash of content for update detection */
+  contentHash: string;
+}
+
+/**
+ * Index entry from the aggregated skills index.
+ */
+export interface SkillIndexEntry {
+  slug: string;
+  name: string;
+  description: string;
+  source: SkillSource;
+  sourceUrl: string;
+  tags: string[];
+  author?: string;
+  version?: string;
+}
+
+/**
+ * Aggregated skills index response from skills.serendb.com.
+ */
+export interface SkillsIndex {
+  version: string;
+  updatedAt: string;
+  skills: SkillIndexEntry[];
+}
+
+/**
+ * State for the skills store.
+ */
+export interface SkillsState {
+  /** All available skills from the index */
+  available: Skill[];
+  /** All installed skills */
+  installed: InstalledSkill[];
+  /** Currently selected skill for preview */
+  selectedId: string | null;
+  /** Loading state */
+  isLoading: boolean;
+  /** Error message if any */
+  error: string | null;
+}

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -25,6 +25,7 @@ import {
   getActiveToolsetPublishers,
   settingsStore,
 } from "@/stores/settings.store";
+import { skillsStore } from "@/stores/skills.store";
 
 export type ChatRole = "user" | "assistant" | "system";
 
@@ -343,6 +344,16 @@ export async function* streamMessageWithTools(
   } catch (error) {
     // Silently fail - semantic context is optional
     console.warn("[Chat] Failed to retrieve semantic context:", error);
+  }
+
+  // Inject enabled skills content
+  try {
+    const skillsContent = await skillsStore.getEnabledContent();
+    if (skillsContent) {
+      systemContent += skillsContent;
+    }
+  } catch (error) {
+    console.warn("[Chat] Failed to retrieve skills content:", error);
   }
 
   // Add system message to messages array

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1,0 +1,493 @@
+// ABOUTME: Skills service for managing skill discovery, installation, and content.
+// ABOUTME: Handles fetching from index, local skills, and Seren publishers.
+
+import { invoke } from "@tauri-apps/api/core";
+import { apiBase } from "@/lib/config";
+import { appFetch } from "@/lib/fetch";
+import { log } from "@/lib/logger";
+import {
+  computeContentHash,
+  getSkillPath,
+  type InstalledSkill,
+  parseSkillMd,
+  type Skill,
+  type SkillIndexEntry,
+  type SkillScope,
+  type SkillSource,
+  type SkillsIndex,
+} from "@/lib/skills";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+import { catalog, type Publisher } from "./catalog";
+
+const SKILLS_INDEX_URL = "https://skills.serendb.com/index.json";
+const INDEX_CACHE_KEY = "seren:skills_index";
+const PUBLISHER_SKILLS_CACHE_KEY = "seren:publisher_skills";
+const INDEX_CACHE_DURATION = 1000 * 60 * 60; // 1 hour
+
+/**
+ * Transform an index entry to a Skill.
+ */
+function indexEntryToSkill(entry: SkillIndexEntry): Skill {
+  return {
+    id: `${entry.source}:${entry.slug}`,
+    slug: entry.slug,
+    name: entry.name,
+    description: entry.description,
+    source: entry.source,
+    sourceUrl: entry.sourceUrl,
+    tags: entry.tags,
+    author: entry.author,
+    version: entry.version,
+  };
+}
+
+/**
+ * Convert a Seren publisher to a Skill.
+ */
+function publisherToSkill(publisher: Publisher): Skill {
+  // Map publisher type to tags
+  const typeTags: string[] = [];
+  if (publisher.publisher_type === "database") typeTags.push("database");
+  if (publisher.publisher_type === "api") typeTags.push("api");
+  if (publisher.publisher_type === "mcp") typeTags.push("mcp");
+
+  // Combine with publisher categories
+  const tags = [...new Set([...typeTags, ...publisher.categories])];
+
+  return {
+    id: `seren:${publisher.slug}`,
+    slug: publisher.slug,
+    name: publisher.resource_name || publisher.name,
+    description: publisher.description,
+    source: "seren" as SkillSource,
+    sourceUrl: `${apiBase}/publishers/${publisher.slug}/skill.md`,
+    tags,
+    author: publisher.name,
+  };
+}
+
+/**
+ * Skills service for Seren Desktop.
+ */
+export const skills = {
+  /**
+   * Fetch the skills index from the aggregated endpoint.
+   * Uses caching to reduce network requests.
+   */
+  async fetchIndex(): Promise<Skill[]> {
+    try {
+      // Check cache first
+      const cached = localStorage.getItem(INDEX_CACHE_KEY);
+      if (cached) {
+        const { timestamp, data } = JSON.parse(cached);
+        if (Date.now() - timestamp < INDEX_CACHE_DURATION) {
+          log.info("[Skills] Using cached index");
+          return (data as SkillIndexEntry[]).map(indexEntryToSkill);
+        }
+      }
+
+      log.info("[Skills] Fetching skills index from", SKILLS_INDEX_URL);
+      const response = await appFetch(SKILLS_INDEX_URL);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch skills index: ${response.status}`);
+      }
+
+      const index: SkillsIndex = await response.json();
+
+      // Cache the result
+      localStorage.setItem(
+        INDEX_CACHE_KEY,
+        JSON.stringify({
+          timestamp: Date.now(),
+          data: index.skills,
+        }),
+      );
+
+      log.info("[Skills] Fetched", index.skills.length, "skills from index");
+      return index.skills.map(indexEntryToSkill);
+    } catch (error) {
+      log.error("[Skills] Error fetching index:", error);
+      // Return cached data if available, even if expired
+      const cached = localStorage.getItem(INDEX_CACHE_KEY);
+      if (cached) {
+        const { data } = JSON.parse(cached);
+        return (data as SkillIndexEntry[]).map(indexEntryToSkill);
+      }
+      return [];
+    }
+  },
+
+  /**
+   * Fetch skills from Seren publishers.
+   * Each publisher has a skill.md available at /publishers/{slug}/skill.md
+   */
+  async fetchPublisherSkills(): Promise<Skill[]> {
+    try {
+      // Check cache first
+      const cached = localStorage.getItem(PUBLISHER_SKILLS_CACHE_KEY);
+      if (cached) {
+        const { timestamp, data } = JSON.parse(cached);
+        if (Date.now() - timestamp < INDEX_CACHE_DURATION) {
+          log.info("[Skills] Using cached publisher skills");
+          return data as Skill[];
+        }
+      }
+
+      log.info("[Skills] Fetching publisher skills from catalog");
+      const publishers = await catalog.list();
+
+      // Convert publishers to skills
+      const skills = publishers
+        .filter((p) => p.is_active)
+        .map(publisherToSkill);
+
+      // Cache the result
+      localStorage.setItem(
+        PUBLISHER_SKILLS_CACHE_KEY,
+        JSON.stringify({
+          timestamp: Date.now(),
+          data: skills,
+        }),
+      );
+
+      log.info("[Skills] Fetched", skills.length, "publisher skills");
+      return skills;
+    } catch (error) {
+      log.error("[Skills] Error fetching publisher skills:", error);
+      // Return cached data if available, even if expired
+      const cached = localStorage.getItem(PUBLISHER_SKILLS_CACHE_KEY);
+      if (cached) {
+        const { data } = JSON.parse(cached);
+        return data as Skill[];
+      }
+      return [];
+    }
+  },
+
+  /**
+   * Fetch all available skills (from index + publishers).
+   */
+  async fetchAllSkills(): Promise<Skill[]> {
+    const [indexSkills, publisherSkills] = await Promise.all([
+      this.fetchIndex(),
+      this.fetchPublisherSkills(),
+    ]);
+
+    // Merge skills, with publisher skills taking precedence for duplicates
+    const skillMap = new Map<string, Skill>();
+
+    // Add index skills first
+    for (const skill of indexSkills) {
+      skillMap.set(skill.slug, skill);
+    }
+
+    // Publisher skills override index skills (they're more up-to-date)
+    for (const skill of publisherSkills) {
+      skillMap.set(skill.slug, skill);
+    }
+
+    return Array.from(skillMap.values());
+  },
+
+  /**
+   * Get the Seren-scope skills directory ({app_data_dir}/skills/).
+   */
+  async getSerenSkillsDir(): Promise<string> {
+    if (!isTauriRuntime()) {
+      return "{app_data}/skills";
+    }
+    return invoke<string>("get_seren_skills_dir");
+  },
+
+  /**
+   * Get the Claude Code skills directory (~/.claude/skills/).
+   */
+  async getClaudeSkillsDir(): Promise<string> {
+    if (!isTauriRuntime()) {
+      return "~/.claude/skills";
+    }
+    return invoke<string>("get_claude_skills_dir");
+  },
+
+  /**
+   * Get the project skills directory.
+   */
+  async getProjectSkillsDir(
+    projectRoot: string | null,
+  ): Promise<string | null> {
+    if (!isTauriRuntime() || !projectRoot) {
+      return null;
+    }
+    return invoke<string | null>("get_project_skills_dir", { projectRoot });
+  },
+
+  /**
+   * List installed skills from a skills directory.
+   */
+  async listInstalled(
+    skillsDir: string,
+    scope: SkillScope,
+  ): Promise<InstalledSkill[]> {
+    if (!isTauriRuntime()) {
+      return [];
+    }
+
+    try {
+      const slugs = await invoke<string[]>("list_skill_dirs", { skillsDir });
+      const installed: InstalledSkill[] = [];
+
+      for (const slug of slugs) {
+        const content = await invoke<string | null>("read_skill_content", {
+          skillsDir,
+          slug,
+        });
+
+        if (content) {
+          const parsed = parseSkillMd(content);
+          const hash = await computeContentHash(content);
+
+          installed.push({
+            id: `local:${slug}`,
+            slug,
+            name: parsed.metadata.name || slug,
+            description: parsed.metadata.description || "",
+            source: "local" as SkillSource,
+            tags: parsed.metadata.tags || [],
+            author: parsed.metadata.author,
+            version: parsed.metadata.version,
+            scope,
+            path: getSkillPath(skillsDir, slug),
+            installedAt: Date.now(), // We don't track this yet
+            enabled: true, // All installed skills are enabled by default
+            contentHash: hash,
+          });
+        }
+      }
+
+      return installed;
+    } catch (error) {
+      log.error("[Skills] Error listing installed skills:", error);
+      return [];
+    }
+  },
+
+  /**
+   * List all installed skills (seren, claude, and project scopes).
+   */
+  async listAllInstalled(
+    projectRoot: string | null,
+  ): Promise<InstalledSkill[]> {
+    const serenDir = await this.getSerenSkillsDir();
+    const claudeDir = await this.getClaudeSkillsDir();
+    const projectDir = await this.getProjectSkillsDir(projectRoot);
+
+    const serenSkills = await this.listInstalled(serenDir, "seren");
+    const claudeSkills = await this.listInstalled(claudeDir, "claude");
+    const projectSkills = projectDir
+      ? await this.listInstalled(projectDir, "project")
+      : [];
+
+    return [...serenSkills, ...claudeSkills, ...projectSkills];
+  },
+
+  /**
+   * Fetch the full content of a skill from its source URL.
+   */
+  async fetchContent(skill: Skill): Promise<string | null> {
+    if (!skill.sourceUrl) {
+      log.warn("[Skills] No source URL for skill:", skill.id);
+      return null;
+    }
+
+    try {
+      log.info("[Skills] Fetching content from", skill.sourceUrl);
+      const response = await appFetch(skill.sourceUrl);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch skill content: ${response.status}`);
+      }
+
+      return await response.text();
+    } catch (error) {
+      log.error("[Skills] Error fetching content:", error);
+      return null;
+    }
+  },
+
+  /**
+   * Install a skill to the specified scope.
+   */
+  async install(
+    skill: Skill,
+    content: string,
+    scope: SkillScope,
+    projectRoot: string | null,
+  ): Promise<InstalledSkill> {
+    if (!isTauriRuntime()) {
+      throw new Error("Skills can only be installed in the desktop app");
+    }
+
+    let skillsDir: string | null;
+    if (scope === "seren") {
+      skillsDir = await this.getSerenSkillsDir();
+    } else if (scope === "claude") {
+      skillsDir = await this.getClaudeSkillsDir();
+    } else {
+      skillsDir = await this.getProjectSkillsDir(projectRoot);
+    }
+
+    if (!skillsDir) {
+      throw new Error("No skills directory available for project scope");
+    }
+
+    const path = await invoke<string>("install_skill", {
+      skillsDir,
+      slug: skill.slug,
+      content,
+    });
+
+    const hash = await computeContentHash(content);
+    const parsed = parseSkillMd(content);
+
+    log.info("[Skills] Installed skill:", skill.slug, "to", scope, "scope");
+
+    return {
+      ...skill,
+      id: `local:${skill.slug}`,
+      source: "local",
+      scope,
+      path,
+      installedAt: Date.now(),
+      enabled: true,
+      contentHash: hash,
+      // Override with parsed metadata in case it differs
+      name: parsed.metadata.name || skill.name,
+      description: parsed.metadata.description || skill.description,
+      tags: parsed.metadata.tags || skill.tags,
+      author: parsed.metadata.author || skill.author,
+      version: parsed.metadata.version || skill.version,
+    };
+  },
+
+  /**
+   * Remove an installed skill.
+   */
+  async remove(skill: InstalledSkill): Promise<void> {
+    if (!isTauriRuntime()) {
+      throw new Error("Skills can only be removed in the desktop app");
+    }
+
+    // skill.path = ".../skills/my-skill/SKILL.md"
+    // Strip "/my-skill/SKILL.md" to get the skills directory
+    const skillsDir = skill.path.replace(/[/\\][^/\\]+[/\\]SKILL\.md$/, "");
+
+    await invoke("remove_skill", {
+      skillsDir,
+      slug: skill.slug,
+    });
+
+    log.info("[Skills] Removed skill:", skill.slug);
+  },
+
+  /**
+   * Read the content of an installed skill.
+   */
+  async readContent(skill: InstalledSkill): Promise<string | null> {
+    if (!isTauriRuntime()) {
+      return null;
+    }
+
+    const parentDir = skill.path.replace(/[/\\][^/\\]+[/\\]SKILL\.md$/, "");
+
+    return invoke<string | null>("read_skill_content", {
+      skillsDir: parentDir,
+      slug: skill.slug,
+    });
+  },
+
+  /**
+   * Get content for enabled skills to inject into agent system prompt.
+   */
+  async getEnabledSkillsContent(
+    installedSkills: InstalledSkill[],
+  ): Promise<string> {
+    const enabled = installedSkills.filter((s) => s.enabled);
+
+    if (enabled.length === 0) {
+      return "";
+    }
+
+    const contents: string[] = [];
+
+    for (const skill of enabled) {
+      const content = await this.readContent(skill);
+      if (content) {
+        const parsed = parseSkillMd(content);
+        contents.push(`## Skill: ${skill.name}\n\n${parsed.content}`);
+      }
+    }
+
+    if (contents.length === 0) {
+      return "";
+    }
+
+    return `\n\n# Active Skills\n\n${contents.join("\n\n---\n\n")}`;
+  },
+
+  /**
+   * Clear the skills index cache.
+   */
+  clearCache(): void {
+    localStorage.removeItem(INDEX_CACHE_KEY);
+    localStorage.removeItem(PUBLISHER_SKILLS_CACHE_KEY);
+    log.info("[Skills] Cache cleared");
+  },
+
+  /**
+   * Search skills by query.
+   */
+  search(skills: Skill[], query: string): Skill[] {
+    const q = query.toLowerCase().trim();
+    if (!q) return skills;
+
+    return skills.filter(
+      (skill) =>
+        skill.name.toLowerCase().includes(q) ||
+        skill.description.toLowerCase().includes(q) ||
+        skill.tags.some((tag) => tag.toLowerCase().includes(q)) ||
+        skill.author?.toLowerCase().includes(q),
+    );
+  },
+
+  /**
+   * Filter skills by source.
+   */
+  filterBySource(skills: Skill[], source: SkillSource | null): Skill[] {
+    if (!source) return skills;
+    return skills.filter((skill) => skill.source === source);
+  },
+
+  /**
+   * Filter skills by tag.
+   */
+  filterByTag(skills: Skill[], tag: string | null): Skill[] {
+    if (!tag) return skills;
+    return skills.filter((skill) =>
+      skill.tags.some((t) => t.toLowerCase() === tag.toLowerCase()),
+    );
+  },
+
+  /**
+   * Get all unique tags from a list of skills.
+   */
+  getAllTags(skills: Skill[]): string[] {
+    const tagSet = new Set<string>();
+    for (const skill of skills) {
+      for (const tag of skill.tags) {
+        tagSet.add(tag.toLowerCase());
+      }
+    }
+    return Array.from(tagSet).sort();
+  },
+};

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -1,0 +1,293 @@
+// ABOUTME: Skills store for managing skills state in the UI.
+// ABOUTME: Handles available skills, installed skills, and selection state.
+
+import { createStore } from "solid-js/store";
+import { log } from "@/lib/logger";
+import type {
+  InstalledSkill,
+  Skill,
+  SkillScope,
+  SkillsState,
+} from "@/lib/skills";
+import { skills } from "@/services/skills";
+import { getFileTreeState } from "@/stores/fileTree";
+
+const ENABLED_SKILLS_KEY = "seren:enabled_skills";
+
+/**
+ * Load enabled skills state from localStorage.
+ */
+function loadEnabledState(): Record<string, boolean> {
+  try {
+    const stored = localStorage.getItem(ENABLED_SKILLS_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return {};
+}
+
+/**
+ * Save enabled skills state to localStorage.
+ */
+function saveEnabledState(state: Record<string, boolean>): void {
+  try {
+    localStorage.setItem(ENABLED_SKILLS_KEY, JSON.stringify(state));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+const [state, setState] = createStore<SkillsState>({
+  available: [],
+  installed: [],
+  selectedId: null,
+  isLoading: false,
+  error: null,
+});
+
+/**
+ * Track enabled state separately (not part of the skill data).
+ */
+const enabledState: Record<string, boolean> = loadEnabledState();
+
+/**
+ * Skills store with reactive state and actions.
+ */
+export const skillsStore = {
+  /**
+   * Get all available skills.
+   */
+  get available(): Skill[] {
+    return state.available;
+  },
+
+  /**
+   * Get all installed skills.
+   */
+  get installed(): InstalledSkill[] {
+    return state.installed;
+  },
+
+  /**
+   * Get the currently selected skill ID.
+   */
+  get selectedId(): string | null {
+    return state.selectedId;
+  },
+
+  /**
+   * Get the currently selected skill.
+   */
+  get selected(): Skill | InstalledSkill | null {
+    if (!state.selectedId) return null;
+
+    // First check installed skills
+    const installed = state.installed.find((s) => s.id === state.selectedId);
+    if (installed) return installed;
+
+    // Then check available skills
+    return state.available.find((s) => s.id === state.selectedId) || null;
+  },
+
+  /**
+   * Get loading state.
+   */
+  get isLoading(): boolean {
+    return state.isLoading;
+  },
+
+  /**
+   * Get error message.
+   */
+  get error(): string | null {
+    return state.error;
+  },
+
+  /**
+   * Check if a skill is installed.
+   */
+  isInstalled(skillId: string): boolean {
+    // Check by slug since installed skills have different IDs
+    const skill = state.available.find((s) => s.id === skillId);
+    if (!skill) return false;
+    return state.installed.some((s) => s.slug === skill.slug);
+  },
+
+  /**
+   * Check if a skill is enabled.
+   */
+  isEnabled(skillId: string): boolean {
+    const skill = state.installed.find((s) => s.id === skillId);
+    if (!skill) return false;
+    return enabledState[skill.path] !== false; // Default to enabled
+  },
+
+  /**
+   * Get enabled skills.
+   */
+  get enabledSkills(): InstalledSkill[] {
+    return state.installed.filter((s) => enabledState[s.path] !== false);
+  },
+
+  /**
+   * Set the selected skill.
+   */
+  setSelected(id: string | null): void {
+    setState("selectedId", id);
+  },
+
+  /**
+   * Toggle a skill's enabled state.
+   */
+  toggleEnabled(skillId: string): void {
+    const skill = state.installed.find((s) => s.id === skillId);
+    if (!skill) return;
+
+    const currentlyEnabled = enabledState[skill.path] !== false;
+    enabledState[skill.path] = !currentlyEnabled;
+    saveEnabledState(enabledState);
+
+    // Update the installed skill's enabled state
+    setState(
+      "installed",
+      (s) => s.id === skillId,
+      "enabled",
+      !currentlyEnabled,
+    );
+
+    log.info(
+      "[SkillsStore] Toggled skill",
+      skill.slug,
+      "to",
+      !currentlyEnabled ? "enabled" : "disabled",
+    );
+  },
+
+  /**
+   * Refresh available skills from the index and publishers.
+   */
+  async refreshAvailable(): Promise<void> {
+    setState("isLoading", true);
+    setState("error", null);
+
+    try {
+      const available = await skills.fetchAllSkills();
+      setState("available", available);
+      log.info("[SkillsStore] Loaded", available.length, "available skills");
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to load skills";
+      setState("error", message);
+      log.error("[SkillsStore] Error loading available skills:", err);
+    } finally {
+      setState("isLoading", false);
+    }
+  },
+
+  /**
+   * Refresh installed skills from the file system.
+   */
+  async refreshInstalled(): Promise<void> {
+    setState("isLoading", true);
+    setState("error", null);
+
+    try {
+      const fileTree = getFileTreeState();
+      const projectRoot = fileTree.rootPath;
+
+      const installed = await skills.listAllInstalled(projectRoot);
+
+      // Apply enabled state from localStorage
+      for (const skill of installed) {
+        skill.enabled = enabledState[skill.path] !== false;
+      }
+
+      setState("installed", installed);
+      log.info("[SkillsStore] Loaded", installed.length, "installed skills");
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to load installed skills";
+      setState("error", message);
+      log.error("[SkillsStore] Error loading installed skills:", err);
+    } finally {
+      setState("isLoading", false);
+    }
+  },
+
+  /**
+   * Refresh all skills (available and installed).
+   */
+  async refresh(): Promise<void> {
+    await Promise.all([this.refreshAvailable(), this.refreshInstalled()]);
+  },
+
+  /**
+   * Install a skill.
+   */
+  async install(
+    skill: Skill,
+    content: string,
+    scope: SkillScope,
+  ): Promise<InstalledSkill> {
+    const fileTree = getFileTreeState();
+    const projectRoot = fileTree.rootPath;
+
+    const installed = await skills.install(skill, content, scope, projectRoot);
+
+    // Add to installed list
+    setState("installed", [...state.installed, installed]);
+
+    // Set as enabled by default
+    enabledState[installed.path] = true;
+    saveEnabledState(enabledState);
+
+    log.info("[SkillsStore] Installed skill:", skill.slug);
+    return installed;
+  },
+
+  /**
+   * Remove an installed skill.
+   */
+  async remove(skill: InstalledSkill): Promise<void> {
+    await skills.remove(skill);
+
+    // Remove from installed list (filter by path, not id, since the same
+    // slug can be installed in multiple scopes sharing the same id)
+    setState(
+      "installed",
+      state.installed.filter((s) => s.path !== skill.path),
+    );
+
+    // Remove enabled state
+    delete enabledState[skill.path];
+    saveEnabledState(enabledState);
+
+    // Clear selection if this skill was selected and no other installation remains
+    if (
+      state.selectedId === skill.id &&
+      !state.installed.some((s) => s.id === skill.id)
+    ) {
+      setState("selectedId", null);
+    }
+
+    log.info("[SkillsStore] Removed skill:", skill.slug);
+  },
+
+  /**
+   * Get content for enabled skills to inject into agent system prompt.
+   */
+  async getEnabledContent(): Promise<string> {
+    return skills.getEnabledSkillsContent(this.enabledSkills);
+  },
+
+  /**
+   * Clear the skills index cache and refresh.
+   */
+  async clearCacheAndRefresh(): Promise<void> {
+    skills.clearCache();
+    await this.refreshAvailable();
+  },
+};


### PR DESCRIPTION
## Summary

- Adds a full Skills Browser feature for discovering, installing, and managing skills from the Seren skills index and publisher catalog
- Skills can be installed to three scopes: **Seren** (app data dir, default), **Claude Code** (~/.claude/skills/, shared with CLI), or **Project** (.claude/skills/)
- Install and remove actions both present a scope dropdown when multiple options exist
- Includes browsable catalog with search/filter, scope-aware install/remove, enable/disable toggles, content preview, and system prompt injection for enabled skills

## Key changes

| File | Change |
|------|--------|
| `src-tauri/src/skills.rs` | Rust commands: `get_seren_skills_dir` (app data), `get_claude_skills_dir` (~/.claude), `get_project_skills_dir`, install/remove/list/read |
| `src-tauri/src/lib.rs` | Register skills module and commands |
| `src/lib/skills/` | Types (`SkillScope = "seren" \| "claude" \| "project"`), SKILL.md parser, path utilities |
| `src/services/skills.ts` | Service layer: index fetching, 3-scope install/remove routing, content hashing |
| `src/stores/skills.store.ts` | SolidJS store with path-based removal (handles same slug in multiple scopes) |
| `src/components/skills/` | SkillsPanel, SkillsBrowser, SkillsInstalled (3 filter tabs), SkillPreview (scope dropdowns), SkillCard |
| `src/services/chat.ts` | Inject enabled skills content into agent system prompt |
| `src/App.tsx`, `Header.tsx` | Skills nav item and panel routing |

## Test plan

- [ ] Open Skills panel → Browse tab shows skills from index and publishers
- [ ] Install a skill choosing "Seren" → verify file at `%APPDATA%\com.serendb.desktop\skills\{slug}\SKILL.md`
- [ ] Install same skill choosing "Claude Code" → verify file at `~\.claude\skills\{slug}\SKILL.md`
- [ ] Install a skill choosing "Project" → verify file at `{project}\.claude\skills\{slug}\SKILL.md`
- [ ] Switch to Installed tab → verify all show with correct scope labels
- [ ] Filter by scope (Seren/Claude/Project) → verify counts and filtering
- [ ] Remove via dropdown when installed in multiple scopes → only removes selected scope
- [ ] Enable/disable toggle → verify system prompt only includes enabled skills
- [ ] Search and tag filtering work in browse tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)