### PR TITLE
fix: show tool execution summary for empty chat responses

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -530,6 +530,21 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     content: string,
   ) => {
     const duration = Date.now() - session.startTime;
+
+    if (!content.trim()) {
+      console.warn("[ChatContent] Empty content in completed message", {
+        duration,
+        model: session.model,
+        toolsEnabled: session.toolsEnabled,
+      });
+    } else {
+      console.log("[ChatContent] Streaming complete", {
+        contentLength: content.length,
+        duration,
+        model: session.model,
+      });
+    }
+
     const assistantMessage: Message = {
       id: session.id,
       role: "assistant",


### PR DESCRIPTION
## Summary

- When the LLM uses tools and returns no text content, the stored message was empty — only a timing badge (e.g., "✻ Assembled for 2m 8s") appeared with no visible text
- `ToolStreamingMessage` now generates a markdown summary of tool operations as fallback content when text content is empty
- Added diagnostic logging to `ChatContent.handleStreamingComplete`, `streamMessageWithTools`, and `ToolStreamingMessage.consume` for future debugging

## Root Cause

The API returns `content: null` for tool-call-only responses (standard OpenAI format). In `streamMessageWithTools`, the truthy check `if (response.content)` skips null, so `fullContent` stays empty across all iterations. The message gets stored with `content: ""` but valid `duration`, producing a timing badge over nothing.

## Test plan

- [ ] Send a chat message with "All Publishers" toolset that triggers tool calls
- [ ] Verify tool operations are visible both during streaming AND after message is finalized
- [ ] Verify messages with text content still render normally (no change)
- [ ] Check browser console for new `[ChatContent]` and `[streamMessageWithTools]` log entries

Closes #382

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com