### PR TITLE
fix: auto-recover agent session after cancel force-stop timeout

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -496,7 +496,8 @@ export const acpStore = {
       if (
         message.includes("Worker thread dropped") ||
         message.includes("not found") ||
-        message.includes("Session not initialized")
+        message.includes("Session not initialized") ||
+        message.includes("agent did not stop in time")
       ) {
         console.info(
           "[AcpStore] Session appears dead, attempting auto-recovery...",


### PR DESCRIPTION
## Summary
- Add "agent did not stop in time" to auto-recovery conditions in `acp.store.ts` so zombie sessions are terminated and respawned automatically
- Format ACP errors as human-readable strings via `format_acp_error()` helper in `acp.rs` instead of raw JSON-RPC debug format (`Error { code: -32603, ... }`)

Closes #381

## Root Cause
After a cancel force-stop timeout (5s), the agent binary remains alive in an inconsistent state. The `connection.prompt()` future is abandoned but the underlying connection is stalled — all subsequent prompts hang indefinitely. The frontend did not recognize this specific error as recoverable, so no auto-recovery was triggered.

## Changes
- **`src-tauri/src/acp.rs`**: Added `format_acp_error()` that extracts the `data` string from ACP errors (falls back to `message`). Used for prompt error events and responses instead of `format!("{:?}", e)`.
- **`src/stores/acp.store.ts`**: Added `"agent did not stop in time"` to the auto-recovery condition alongside existing checks for "Worker thread dropped", "not found", and "Session not initialized".

## Test plan
- [ ] Start agent conversation, send prompt, cancel while processing
- [ ] If cancel times out (5s), verify session auto-recovers instead of becoming zombie
- [ ] Verify error messages show readable text, not raw JSON-RPC debug format
- [ ] Verify normal cancel (within 5s) still works as before

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com