### PR TITLE
feat: add model selector for agent sessions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -675,6 +675,8 @@ pub fn run() {
             #[cfg(feature = "acp")]
             acp::acp_set_permission_mode,
             #[cfg(feature = "acp")]
+            acp::acp_set_model,
+            #[cfg(feature = "acp")]
             acp::acp_respond_to_permission,
             #[cfg(feature = "acp")]
             acp::acp_get_available_agents,

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -18,14 +18,15 @@ import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { openExternalLink } from "@/lib/external-link";
+import { formatDurationWithVerb } from "@/lib/format-duration";
 import { pickAndReadImages, toDataUrl } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
-import { formatDurationWithVerb } from "@/lib/format-duration";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
 import { type AgentType, type DiffEvent, launchLogin } from "@/services/acp";
 import { type AgentMessage, acpStore } from "@/stores/acp.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { settingsStore } from "@/stores/settings.store";
+import { AgentModelSelector } from "./AgentModelSelector";
 import { AgentSelector } from "./AgentSelector";
 import { AgentTabBar } from "./AgentTabBar";
 import { DiffCard } from "./DiffCard";
@@ -697,6 +698,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             <div class="flex justify-between items-center">
               <div class="flex items-center gap-3">
                 <AgentSelector />
+                <AgentModelSelector />
                 <Show when={isPrompting()}>
                   <ThinkingStatus />
                 </Show>

--- a/src/components/chat/AgentModelSelector.tsx
+++ b/src/components/chat/AgentModelSelector.tsx
@@ -1,0 +1,125 @@
+// ABOUTME: Dropdown component for selecting the AI model in an agent session.
+// ABOUTME: Shows available models reported by the ACP agent and sends set_model commands.
+
+import type { Component } from "solid-js";
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { acpStore } from "@/stores/acp.store";
+
+export const AgentModelSelector: Component = () => {
+  const [isOpen, setIsOpen] = createSignal(false);
+  let dropdownRef: HTMLDivElement | undefined;
+
+  const availableModels = () => acpStore.activeSession?.availableModels ?? [];
+  const currentModelId = () => acpStore.activeSession?.currentModelId;
+
+  const currentModelName = () => {
+    const id = currentModelId();
+    if (!id) return null;
+    const model = availableModels().find((m) => m.modelId === id);
+    return model?.name ?? id;
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (dropdownRef && !dropdownRef.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
+  onMount(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener("mousedown", handleClickOutside);
+  });
+
+  const selectModel = (modelId: string) => {
+    acpStore.setModel(modelId);
+    setIsOpen(false);
+  };
+
+  return (
+    <Show when={availableModels().length > 0}>
+      <div class="relative" ref={dropdownRef}>
+        <button
+          type="button"
+          class="flex items-center gap-1.5 px-2 py-1 bg-[#21262d] border border-[#30363d] rounded-md text-xs text-[#e6edf3] cursor-pointer hover:bg-[#30363d] transition-colors"
+          onClick={() => setIsOpen(!isOpen())}
+          title="Change model"
+        >
+          <svg
+            class="w-3 h-3 text-[#8b949e]"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            role="img"
+            aria-label="Model"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+            />
+          </svg>
+          <span class="font-medium max-w-[120px] truncate">
+            {currentModelName() ?? "Model"}
+          </span>
+          <svg
+            class={`w-3 h-3 text-[#8b949e] transition-transform ${isOpen() ? "rotate-180" : ""}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            role="img"
+            aria-label="Toggle dropdown"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+
+        <Show when={isOpen()}>
+          <div class="absolute bottom-full left-0 mb-1 w-64 bg-[#161b22] border border-[#30363d] rounded-lg shadow-lg z-50 overflow-hidden">
+            <div class="px-3 py-2 border-b border-[#21262d] text-[10px] uppercase tracking-wider text-[#8b949e] font-medium">
+              Agent Model
+            </div>
+            <For each={availableModels()}>
+              {(model) => (
+                <button
+                  type="button"
+                  class={`w-full text-left px-3 py-2 border-b border-[#21262d] last:border-b-0 transition-colors cursor-pointer hover:bg-[#21262d] ${
+                    model.modelId === currentModelId() ? "bg-[#21262d]" : ""
+                  }`}
+                  onClick={() => selectModel(model.modelId)}
+                >
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm text-[#e6edf3]">{model.name}</span>
+                    <Show when={model.modelId === currentModelId()}>
+                      <svg
+                        class="w-4 h-4 text-green-500"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                        role="img"
+                        aria-label="Selected"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clip-rule="evenodd"
+                        />
+                      </svg>
+                    </Show>
+                  </div>
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </Show>
+  );
+};

--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -98,6 +98,10 @@ export interface SessionStatusEvent {
     name: string;
     version: string;
   };
+  models?: {
+    currentModelId: string;
+    availableModels: Array<{ modelId: string; name: string }>;
+  };
 }
 
 export interface DiffProposalEvent {
@@ -182,6 +186,16 @@ export async function terminateSession(sessionId: string): Promise<void> {
  */
 export async function listSessions(): Promise<AcpSessionInfo[]> {
   return invoke<AcpSessionInfo[]>("acp_list_sessions");
+}
+
+/**
+ * Set the AI model for an ACP session.
+ */
+export async function setModel(
+  sessionId: string,
+  modelId: string,
+): Promise<void> {
+  return invoke("acp_set_model", { sessionId, modelId });
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #385

- **Rust backend**: Added SetModel command variant and acp_set_model Tauri command. Extracts model state from NewSessionResponse.models on session ready and includes it in the session-status event payload.
- **Frontend service**: Added setModel() function and extended SessionStatusEvent with optional models field.
- **Store**: Added currentModelId and availableModels to ActiveSession, handleStatusChange now parses model data, new setModel() action calls backend and updates local state.
- **UI**: New AgentModelSelector dropdown component placed next to AgentSelector in the agent chat bottom bar. Only appears when the agent reports available models.

Uses the ACP session/set_model method (behind unstable_session_model feature flag, already enabled).

## Test plan

- [ ] Start an agent session and verify the model selector appears if agent reports available models
- [ ] Select a different model and verify the dropdown updates
- [ ] Verify agent continues to function after model change
- [ ] Verify the selector is hidden when no models are reported
- [ ] Run cargo check - passes
- [ ] Run pnpm check - no new lint errors

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com