### PR TITLE
fix: configure auto-updater with signing keys and GitHub endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,20 +119,39 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             name: macOS-arm64
+            updater_platform: darwin-aarch64
           - os: macos-latest
             target: x86_64-apple-darwin
             name: macOS-x64
+            updater_platform: darwin-x86_64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             name: Windows-x64
+            updater_platform: windows-x86_64
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             name: Linux-x64
+            updater_platform: linux-x86_64
 
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set version from tag
+        shell: bash
+        run: |
+          # Extract version from git tag (strip 'v' prefix)
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Setting version to $VERSION"
+          # Update tauri.conf.json with the tag version
+          node -e "
+            const fs = require('fs');
+            const conf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
+            conf.version = '$VERSION';
+            fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(conf, null, 2) + '\n');
+          "
+          echo "Updated tauri.conf.json version to $VERSION"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -216,7 +235,7 @@ jobs:
       # Build the app (unsigned for macOS without certificates, or other platforms)
       - name: Build Tauri app (unsigned, Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: pnpm tauri build --target ${{ matrix.target }} --bundles deb
+        run: pnpm tauri build --target ${{ matrix.target }} --bundles deb,appimage
       - name: Build Tauri app (unsigned, other)
         if: matrix.os != 'macos-latest' && matrix.os != 'ubuntu-latest'
         run: pnpm tauri build --target ${{ matrix.target }}
@@ -432,6 +451,37 @@ jobs:
           name: Seren-Desktop-${{ matrix.name }}.deb
           path: src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
 
+      # Upload updater artifacts (tar.gz/zip bundles + signatures)
+      - name: Upload macOS updater bundle
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: update-${{ matrix.updater_platform }}
+          path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.tar.gz
+            src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.tar.gz.sig
+          if-no-files-found: warn
+
+      - name: Upload Windows updater bundle
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: update-${{ matrix.updater_platform }}
+          path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.nsis.zip
+            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.nsis.zip.sig
+          if-no-files-found: warn
+
+      - name: Upload Linux updater bundle
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: update-${{ matrix.updater_platform }}
+          path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.tar.gz
+            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.tar.gz.sig
+          if-no-files-found: warn
+
       # Clean up macOS keychain (only if we created one)
       - name: Cleanup macOS keychain
         if: matrix.os == 'macos-latest' && env.HAS_APPLE_SIGNING == 'true' && always()
@@ -449,6 +499,62 @@ jobs:
 
       - name: Display structure of downloaded files
         run: ls -R artifacts
+
+      - name: Generate latest.json for updater
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const tag = '${{ github.ref_name }}';
+            const version = tag.replace(/^v/, '');
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
+            const baseUrl = `https://github.com/${repo}/releases/download/${tag}`;
+
+            // Platform mapping: artifact dir name -> Tauri updater platform key
+            const platforms = [
+              'darwin-aarch64',
+              'darwin-x86_64',
+              'windows-x86_64',
+              'linux-x86_64'
+            ];
+
+            const manifest = {
+              version,
+              notes: `Release ${tag}`,
+              pub_date: new Date().toISOString(),
+              platforms: {}
+            };
+
+            for (const platform of platforms) {
+              const dir = path.join('artifacts', `update-${platform}`);
+              if (!fs.existsSync(dir)) {
+                console.log(`No update artifact for ${platform}, skipping`);
+                continue;
+              }
+
+              const files = fs.readdirSync(dir);
+              const sigFile = files.find(f => f.endsWith('.sig'));
+              const bundleFile = files.find(f => !f.endsWith('.sig'));
+
+              if (!sigFile || !bundleFile) {
+                console.log(`Missing sig or bundle for ${platform}: sig=${sigFile}, bundle=${bundleFile}`);
+                continue;
+              }
+
+              const signature = fs.readFileSync(path.join(dir, sigFile), 'utf8').trim();
+
+              manifest.platforms[platform] = {
+                signature,
+                url: `${baseUrl}/${bundleFile}`
+              };
+
+              console.log(`Added platform ${platform}: ${bundleFile}`);
+            }
+
+            fs.writeFileSync('artifacts/latest.json', JSON.stringify(manifest, null, 2));
+            console.log('Generated latest.json:', JSON.stringify(manifest, null, 2));
 
       - name: Publish release
         uses: actions/github-script@v7

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,9 +34,9 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://releases.serendb.com/{{target}}/{{arch}}/{{current_version}}"
+        "https://github.com/serenorg/seren-desktop/releases/latest/download/latest.json"
       ],
-      "pubkey": "SEREN_RELEASES_PUBLIC_KEY_PLACEHOLDER",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEZGMkY1NTNENUNFNkZGNkEKUldScS8rWmNQVlV2LzRZeHFmbEIrRS9wVEp3Rms4YXJkMHJYVGlONEZwaEhoQzJvYk50UGx5YWwK",
       "dialog": false
     },
     "shell": {


### PR DESCRIPTION
## Summary

Fixes the non-functional auto-updater. Three root causes:

1. **Placeholder public key** - `SEREN_RELEASES_PUBLIC_KEY_PLACEHOLDER` could never validate signatures
2. **Non-existent endpoint** - `releases.serendb.com` was never set up to serve update manifests
3. **Static version** - `tauri.conf.json` hardcoded `0.1.0`, which SemVer ranks higher than `0.1.0-alpha.x`, so updates were never detected

### Changes

**`src-tauri/tauri.conf.json`**:
- Real ed25519 public key (generated with `tauri signer generate`)
- Endpoint points to GitHub releases: `/releases/latest/download/latest.json`

**`.github/workflows/release.yml`**:
- **Version injection**: Extracts version from git tag (`v0.1.0-alpha.78` -> `0.1.0-alpha.78`) and updates `tauri.conf.json` before building
- **Update bundles**: Uploads `.app.tar.gz` (macOS), `.nsis.zip` (Windows), `.AppImage.tar.gz` (Linux) + `.sig` files
- **`latest.json` manifest**: Generated in publish-release step with platform signatures and download URLs
- **Linux AppImage**: Now builds `deb,appimage` instead of just `deb`
- **`updater_platform` matrix**: Maps build targets to Tauri updater platform keys

### Required: GitHub Secret Setup

After merging, add this secret to the repo:

- **Name**: `TAURI_SIGNING_PRIVATE_KEY`
- **Value**: The private key from `/tmp/seren-updater.key` (already generated locally)

The `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secret is already referenced but can be left empty (key was generated without a password).

### How it works after merge

1. Tag a release (`v0.1.0-alpha.78`)
2. CI injects version into `tauri.conf.json` -> builds with correct version
3. Tauri generates signed update bundles (`.tar.gz` + `.sig`)
4. CI generates `latest.json` with signatures and URLs
5. All artifacts + `latest.json` uploaded to GitHub release
6. Running app checks `/releases/latest/download/latest.json` -> detects newer version
7. Update button appears in Header -> user clicks -> download + install + restart

## Test plan

- [ ] Verify YAML is valid (no syntax errors)
- [ ] Add `TAURI_SIGNING_PRIVATE_KEY` secret to repo
- [ ] Tag a test release and verify CI completes
- [ ] Check that `latest.json` appears as a release asset with correct format
- [ ] Check that `.tar.gz`/`.nsis.zip` + `.sig` files appear as release assets
- [ ] Install previous version, verify Update button appears

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com