### PR TITLE
fix(ci): add libfuse2 for Linux AppImage bundling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libfuse2
 
       - name: Install frontend dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary
- Adds `libfuse2` to the Ubuntu apt-get install step in the release workflow
- Ubuntu 24.04 (`ubuntu-latest`) only ships with FUSE 3; `linuxdeploy` requires `libfuse2` for AppImage creation
- This fixes the release v0.1.0-alpha.78 Linux build failure: `failed to bundle project: failed to run linuxdeploy`

## Test plan
- [ ] Merge and re-tag v0.1.0-alpha.78 (or push v0.1.0-alpha.79) to trigger a new release build
- [ ] Verify the Linux AppImage bundle completes successfully
- [ ] Verify the publish-release job runs and uploads all platform artifacts

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com