### PR TITLE
fix: remove tool iteration limit so agent completes multi-step tasks

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -26,10 +26,12 @@ import {
   areToolsAvailable,
   CHAT_MAX_RETRIES,
   type ChatContext,
+  continueToolIteration,
   type Message,
   sendMessageWithRetry,
   streamMessage,
   streamMessageWithTools,
+  type ToolIterationState,
   type ToolStreamEvent,
 } from "@/services/chat";
 import { acpStore } from "@/stores/acp.store";
@@ -533,6 +535,18 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     setSavedInput("");
   };
 
+  const handleIterationLimit = (
+    state: ToolIterationState,
+    iteration: number,
+  ): AsyncGenerator<ToolStreamEvent> => {
+    console.log(
+      "[ChatContent] Tool iteration limit reached at iteration",
+      iteration,
+      "— auto-continuing",
+    );
+    return continueToolIteration(state);
+  };
+
   const handleStreamingComplete = async (
     session: ActiveStreamingSession,
     content: string,
@@ -890,6 +904,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                             handleStreamingError(session, error)
                           }
                           onContentUpdate={scrollToBottom}
+                          onIterationLimit={handleIterationLimit}
                         />
                       </Show>
                     );

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -138,7 +138,7 @@ const DEFAULT_SETTINGS: Settings = {
   chatEnterToSend: true,
   chatShowThinking: false,
   chatThinkingExpanded: false,
-  chatMaxToolIterations: 10,
+  chatMaxToolIterations: 0,
   // Auto-compact
   autoCompactEnabled: true,
   autoCompactThreshold: 80,


### PR DESCRIPTION
## Summary
- Default `chatMaxToolIterations` changed from 10 to 0 (unlimited) so the agent does not silently stop mid-work
- `ToolStreamingMessage` now supports auto-continuation: when `onIterationLimit` returns a continuation generator, it seamlessly keeps consuming events in the same message
- `ChatContent` wires up `onIterationLimit` to call `continueToolIteration`, which was previously dead code
- Users who set a custom iteration limit in Settings will now auto-continue instead of silently stopping

Closes #396

## Test plan
- [ ] Start a multi-step agent task (e.g. explore directories, update issues) and verify it runs to completion beyond 10 tool calls
- [ ] Verify the streaming message stays as a single message (no split into multiple messages)
- [ ] Set a custom `chatMaxToolIterations` (e.g. 5) in Settings, verify it auto-continues past the limit
- [ ] Verify the Stop button works to cancel mid-stream
- [ ] Verify normal chat (non-tool) still works as before

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com