### PR TITLE
fix: resize image attachments and prevent message duplication

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -486,6 +486,10 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
       status: "complete",
     };
 
+    // Snapshot history BEFORE adding the current message to avoid duplication
+    // (streamMessageWithTools adds the current message separately)
+    const history = [...chatStore.messages];
+
     chatStore.addMessage(userMessage);
     await chatStore.persistMessage(userMessage);
 
@@ -506,7 +510,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
             chatStore.selectedModel,
             context,
             true,
-            chatStore.messages,
+            history,
             images,
           ),
           toolsEnabled: true,


### PR DESCRIPTION
## Summary
Closes #399

- **Image resizing**: Added canvas-based `resizeImage()` in `attachments.ts` that downscales images exceeding 1024px on either dimension before sending to the API. Reduces a typical 3MB photo from ~4MB base64 (~1M tokens) to ~100KB base64 (~25K tokens). Preserves PNG transparency, converts others to JPEG at 0.85 quality, skips GIF (may be animated).
- **Message duplication fix**: Snapshot `chatStore.messages` *before* calling `addMessage()` in `ChatContent.tsx`, then pass the snapshot as history to `streamMessageWithTools()`. Previously the current message was added to the store first, causing it to appear twice in the API payload (once from history, once as the current message), doubling effective token usage.

## Test plan
- [ ] Attach a large image (>1024px) and verify the thumbnail looks correct
- [ ] Send a message with an image attachment — should not get "Prompt is too long" error
- [ ] Send multiple messages in a row — verify no message duplication in API payload
- [ ] Attach a GIF and verify it is not resized (preserves animation)
- [ ] Attach a PNG with transparency and verify transparency is preserved after resize

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com