### PR TITLE
fix: add updater bundle target to enable auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         env:
           NO_STRIP: "true"
-        run: pnpm tauri build --verbose --target ${{ matrix.target }} --bundles deb,appimage
+        run: pnpm tauri build --verbose --target ${{ matrix.target }} --bundles deb,appimage,updater
       - name: Build Tauri app (unsigned, other)
         if: matrix.os != 'macos-latest' && !startsWith(matrix.os, 'ubuntu')
         run: pnpm tauri build --target ${{ matrix.target }}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis", "dmg", "deb", "appimage"],
+    "targets": ["nsis", "dmg", "deb", "appimage", "updater"],
     "icon": [
       "icons/icon.png",
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
Closes #403

The auto-updater never detected available updates because the `"updater"` bundle target was missing from `tauri.conf.json`. In Tauri v2, updater bundles (`.app.tar.gz` + `.sig` for macOS, `.nsis.zip` + `.sig` for Windows, `.AppImage.tar.gz` + `.sig` for Linux) must be explicitly listed as a bundle target.

Without it, the CI builds generated DMGs/EXEs/DEBs but no updater artifacts, causing `latest.json` to have `"platforms": {}` (empty). The Tauri updater plugin found no platform entries and never showed an update alert.

**Changes:**
- Add `"updater"` to `bundle.targets` in `src-tauri/tauri.conf.json`
- Add `updater` to the Linux `--bundles` override in `.github/workflows/release.yml`

## Test plan
- [ ] Merge and tag a new release
- [ ] Verify CI generates updater artifacts (`update-darwin-aarch64`, `update-darwin-x86_64`, `update-windows-x86_64`, `update-linux-x86_64`)
- [ ] Verify `latest.json` has populated `platforms` object with signatures and URLs
- [ ] Verify app on older version detects the update and shows the green Update button

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com