### PR TITLE
feat: support PDF, text, and code file attachments

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -19,8 +19,8 @@ import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { openExternalLink } from "@/lib/external-link";
 import { formatDurationWithVerb } from "@/lib/format-duration";
-import { pickAndReadImages, toDataUrl } from "@/lib/images/attachments";
-import type { ImageAttachment } from "@/lib/providers/types";
+import { pickAndReadAttachments, toDataUrl } from "@/lib/images/attachments";
+import type { Attachment } from "@/lib/providers/types";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
 import { type AgentType, type DiffEvent, launchLogin } from "@/services/acp";
 import { type AgentMessage, acpStore } from "@/stores/acp.store";
@@ -62,9 +62,7 @@ interface AgentChatProps {
 export const AgentChat: Component<AgentChatProps> = (props) => {
   const [input, setInput] = createSignal("");
   const [messageQueue, setMessageQueue] = createSignal<string[]>([]);
-  const [attachedImages, setAttachedImages] = createSignal<ImageAttachment[]>(
-    [],
-  );
+  const [attachedImages, setAttachedImages] = createSignal<Attachment[]>([]);
   const [commandStatus, setCommandStatus] = createSignal<string | null>(null);
   const [commandPopupIndex, setCommandPopupIndex] = createSignal(0);
   let inputRef: HTMLTextAreaElement | undefined;
@@ -141,9 +139,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   };
 
   const handleAttachImages = async () => {
-    const images = await pickAndReadImages();
-    if (images.length > 0) {
-      setAttachedImages((prev) => [...prev, ...images]);
+    const files = await pickAndReadAttachments();
+    if (files.length > 0) {
+      setAttachedImages((prev) => [...prev, ...files]);
     }
   };
 

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -18,8 +18,8 @@ import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { openExternalLink } from "@/lib/external-link";
 import { formatDurationWithVerb } from "@/lib/format-duration";
-import { pickAndReadImages } from "@/lib/images/attachments";
-import type { ImageAttachment } from "@/lib/providers/types";
+import { pickAndReadAttachments } from "@/lib/images/attachments";
+import type { Attachment } from "@/lib/providers/types";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
 import { catalog, type Publisher } from "@/services/catalog";
 import {
@@ -115,9 +115,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
   // Message queue for sending messages while streaming
   const [messageQueue, setMessageQueue] = createSignal<string[]>([]);
   const [showSignInPrompt, setShowSignInPrompt] = createSignal(false);
-  const [attachedImages, setAttachedImages] = createSignal<ImageAttachment[]>(
-    [],
-  );
+  const [attachedImages, setAttachedImages] = createSignal<Attachment[]>([]);
   let inputRef: HTMLTextAreaElement | undefined;
   let messagesRef: HTMLDivElement | undefined;
   let suggestionDebounceTimer: ReturnType<typeof setTimeout> | undefined;
@@ -395,9 +393,9 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
   };
 
   const handleAttachImages = async () => {
-    const images = await pickAndReadImages();
-    if (images.length > 0) {
-      setAttachedImages((prev) => [...prev, ...images]);
+    const files = await pickAndReadAttachments();
+    if (files.length > 0) {
+      setAttachedImages((prev) => [...prev, ...files]);
     }
   };
 
@@ -474,7 +472,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
 
   const sendMessageImmediate = async (
     messageContent: string,
-    images?: ImageAttachment[],
+    images?: Attachment[],
   ) => {
     const userMessage: Message = {
       id: crypto.randomUUID(),

--- a/src/components/chat/ImageAttachmentBar.tsx
+++ b/src/components/chat/ImageAttachmentBar.tsx
@@ -1,13 +1,13 @@
-// ABOUTME: Shared image attachment UI for chat and agent input areas.
-// ABOUTME: Shows attach button, image thumbnails, and remove controls.
+// ABOUTME: Shared file attachment UI for chat and agent input areas.
+// ABOUTME: Shows attach button, thumbnails for images, and file icons for other types.
 
 import type { Component } from "solid-js";
 import { For, Show } from "solid-js";
-import { toDataUrl } from "@/lib/images/attachments";
-import type { ImageAttachment } from "@/lib/providers/types";
+import { isImageMime, toDataUrl } from "@/lib/images/attachments";
+import type { Attachment } from "@/lib/providers/types";
 
 interface ImageAttachmentBarProps {
-  images: ImageAttachment[];
+  images: Attachment[];
   onAttach: () => void;
   onRemove: (index: number) => void;
 }
@@ -22,7 +22,7 @@ export const ImageAttachmentBar: Component<ImageAttachmentBarProps> = (
         type="button"
         class="flex items-center gap-1 px-2 py-1 bg-transparent border border-[#30363d] text-[#8b949e] rounded text-xs cursor-pointer transition-colors hover:bg-[#21262d] hover:text-[#e6edf3]"
         onClick={props.onAttach}
-        title="Attach images"
+        title="Attach files"
       >
         <svg
           width="14"
@@ -41,27 +41,50 @@ export const ImageAttachmentBar: Component<ImageAttachmentBarProps> = (
         Attach
       </button>
 
-      {/* Image thumbnails */}
+      {/* Attachment thumbnails */}
       <Show when={props.images.length > 0}>
         <div class="flex items-center gap-1.5 overflow-x-auto">
           <For each={props.images}>
-            {(image, index) => (
+            {(file, index) => (
               <div class="relative group flex-shrink-0">
-                <img
-                  src={toDataUrl(image)}
-                  alt={image.name}
-                  class="w-10 h-10 object-cover rounded border border-[#30363d]"
-                />
+                <Show
+                  when={isImageMime(file.mimeType)}
+                  fallback={
+                    <div class="w-10 h-10 flex items-center justify-center rounded border border-[#30363d] bg-[#21262d] text-[#8b949e]">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        role="img"
+                        aria-label="File"
+                      >
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                        <polyline points="14 2 14 8 20 8" />
+                      </svg>
+                    </div>
+                  }
+                >
+                  <img
+                    src={toDataUrl(file)}
+                    alt={file.name}
+                    class="w-10 h-10 object-cover rounded border border-[#30363d]"
+                  />
+                </Show>
                 <button
                   type="button"
                   class="absolute -top-1 -right-1 w-4 h-4 bg-[#f85149] text-white rounded-full text-[10px] leading-none flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer border-none"
                   onClick={() => props.onRemove(index())}
-                  title={`Remove ${image.name}`}
+                  title={`Remove ${file.name}`}
                 >
                   ×
                 </button>
                 <div class="absolute bottom-0 left-0 right-0 bg-black/60 text-[8px] text-white text-center truncate px-0.5 rounded-b">
-                  {image.name}
+                  {file.name}
                 </div>
               </div>
             )}

--- a/src/components/chat/MessageImages.tsx
+++ b/src/components/chat/MessageImages.tsx
@@ -1,13 +1,13 @@
-// ABOUTME: Renders image attachments within chat message bubbles.
-// ABOUTME: Displays base64 images as thumbnails with click-to-expand behavior.
+// ABOUTME: Renders file attachments within chat message bubbles.
+// ABOUTME: Displays image thumbnails with click-to-expand, and file icons for non-image types.
 
 import type { Component } from "solid-js";
 import { createSignal, For, Show } from "solid-js";
-import { toDataUrl } from "@/lib/images/attachments";
-import type { ImageAttachment } from "@/lib/providers/types";
+import { isImageMime, toDataUrl } from "@/lib/images/attachments";
+import type { Attachment } from "@/lib/providers/types";
 
 interface MessageImagesProps {
-  images: ImageAttachment[];
+  images: Attachment[];
 }
 
 export const MessageImages: Component<MessageImagesProps> = (props) => {
@@ -16,36 +16,63 @@ export const MessageImages: Component<MessageImagesProps> = (props) => {
   return (
     <div class="flex flex-wrap gap-2 my-2">
       <For each={props.images}>
-        {(image, index) => (
+        {(file, index) => (
           <>
-            <button
-              type="button"
-              class="border border-[#30363d] rounded-lg overflow-hidden cursor-pointer bg-transparent p-0 hover:border-[#58a6ff] transition-colors"
-              onClick={() => setExpandedIndex(index())}
-              title={image.name}
+            <Show
+              when={isImageMime(file.mimeType)}
+              fallback={
+                <div
+                  class="flex items-center gap-2 px-3 py-2 border border-[#30363d] rounded-lg bg-[#161b22] text-[#8b949e] text-xs"
+                  title={file.name}
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    role="img"
+                    aria-label="File"
+                  >
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                  </svg>
+                  <span class="max-w-[160px] truncate">{file.name}</span>
+                </div>
+              }
             >
-              <img
-                src={toDataUrl(image)}
-                alt={image.name}
-                class="max-w-[200px] max-h-[150px] object-contain"
-              />
-            </button>
-
-            {/* Expanded overlay */}
-            <Show when={expandedIndex() === index()}>
-              <div
-                class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 cursor-pointer"
-                onClick={() => setExpandedIndex(null)}
-                onKeyDown={(e) => {
-                  if (e.key === "Escape") setExpandedIndex(null);
-                }}
+              <button
+                type="button"
+                class="border border-[#30363d] rounded-lg overflow-hidden cursor-pointer bg-transparent p-0 hover:border-[#58a6ff] transition-colors"
+                onClick={() => setExpandedIndex(index())}
+                title={file.name}
               >
                 <img
-                  src={toDataUrl(image)}
-                  alt={image.name}
-                  class="max-w-[90vw] max-h-[90vh] object-contain rounded-lg"
+                  src={toDataUrl(file)}
+                  alt={file.name}
+                  class="max-w-[200px] max-h-[150px] object-contain"
                 />
-              </div>
+              </button>
+
+              {/* Expanded overlay */}
+              <Show when={expandedIndex() === index()}>
+                <div
+                  class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 cursor-pointer"
+                  onClick={() => setExpandedIndex(null)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") setExpandedIndex(null);
+                  }}
+                >
+                  <img
+                    src={toDataUrl(file)}
+                    alt={file.name}
+                    class="max-w-[90vw] max-h-[90vh] object-contain rounded-lg"
+                  />
+                </div>
+              </Show>
             </Show>
           </>
         )}

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -105,13 +105,17 @@ export interface ImageContentBlock {
 export type ContentBlock = TextContentBlock | ImageContentBlock;
 
 /**
- * Image attachment metadata stored with messages.
+ * File attachment metadata stored with messages.
+ * Supports images, PDFs, and text/code files.
  */
-export interface ImageAttachment {
+export interface Attachment {
   name: string;
   mimeType: string;
   base64: string; // raw base64 without data URL prefix
 }
+
+/** @deprecated Use Attachment instead */
+export type ImageAttachment = Attachment;
 
 /**
  * Message format for chat requests.


### PR DESCRIPTION
## Summary
- Expands attachment support from images-only to 60+ file types: PDFs, text/markup (md, csv, json, xml, yaml), and programming languages (py, rs, go, ts, js, java, c, cpp, etc.)
- Text/code files are base64-decoded and inlined as markdown code blocks in the user message; images and PDFs are sent as multimodal content blocks
- UI shows file icons for non-image attachments and image thumbnails for images, in both Chat and Agent input modes

## Changes
- `src/lib/providers/types.ts` — Add generic `Attachment` type, deprecate `ImageAttachment` as alias
- `src/lib/images/attachments.ts` — Expand file picker with 3 categories, add MIME type map, image resizing, `isImageMime`/`isTextMime` helpers
- `src/services/chat.ts` — Rewrite `buildUserContent()` to route text files as inlined code blocks and media as content blocks
- `src/components/chat/ImageAttachmentBar.tsx` — Show file icon for non-image types
- `src/components/chat/MessageImages.tsx` — Show file name badge for non-image types in message history
- `src/components/chat/ChatContent.tsx` — Use `pickAndReadAttachments` and `Attachment` type
- `src/components/chat/AgentChat.tsx` — Same updates for agent input mode

## Test plan
- [ ] Attach a PNG image — verify thumbnail preview and image content block sent to API
- [ ] Attach a PDF — verify file icon shown in bar, sent as content block
- [ ] Attach a .py or .ts file — verify file icon shown, content inlined as code block in message
- [ ] Attach multiple mixed types simultaneously
- [ ] Verify agent mode attach button works identically
- [ ] Verify message history renders file badges for non-image attachments

Closes #405

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com