### PR TITLE
feat: Highlight tabs when LLM requires permissions

### DIFF
--- a/src/components/chat/AgentTabBar.tsx
+++ b/src/components/chat/AgentTabBar.tsx
@@ -1,7 +1,14 @@
 // ABOUTME: Tab bar for managing multiple agent sessions.
-// ABOUTME: Displays session tabs with close buttons and a new session button with agent type picker.
+// ABOUTME: Displays session tabs with permission indicators, close buttons, and agent type picker.
 
-import { type Component, createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import {
+  type Component,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
 import type { AgentType } from "@/services/acp";
 import { acpStore } from "@/stores/acp.store";
 
@@ -26,12 +33,22 @@ export const AgentTabBar: Component<AgentTabBarProps> = (props) => {
   const sessionLabel = (id: string, index: number) => {
     const session = acpStore.sessions[id];
     const agentType = session?.info?.agentType ?? "Agent";
-    const label = agentType === "claude-code" ? "Claude" : agentType === "codex" ? "Codex" : agentType;
+    const label =
+      agentType === "claude-code"
+        ? "Claude"
+        : agentType === "codex"
+          ? "Codex"
+          : agentType;
     return `${label} #${index + 1}`;
   };
 
   const availableAgents = () =>
     acpStore.availableAgents.filter((a) => a.available);
+
+  // Check if a session has pending permission requests
+  const sessionHasPendingPermissions = (sessionId: string) =>
+    acpStore.pendingPermissions.some((p) => p.sessionId === sessionId) ||
+    acpStore.pendingDiffProposals.some((p) => p.sessionId === sessionId);
 
   const handleNewClick = () => {
     const agents = availableAgents();
@@ -72,6 +89,12 @@ export const AgentTabBar: Component<AgentTabBarProps> = (props) => {
               onClick={() => handleTabClick(id)}
               title={sessionLabel(id, index())}
             >
+              <Show when={sessionHasPendingPermissions(id)}>
+                <span
+                  class="permission-indicator"
+                  title="Permission required"
+                />
+              </Show>
               <span class="overflow-hidden text-ellipsis max-w-[140px]">
                 {sessionLabel(id, index())}
               </span>

--- a/src/components/chat/ChatTabBar.tsx
+++ b/src/components/chat/ChatTabBar.tsx
@@ -1,8 +1,9 @@
 // ABOUTME: Tab bar for managing multiple chat conversations.
-// ABOUTME: Displays tabs with close buttons and a new chat button.
+// ABOUTME: Displays tabs with close buttons, permission indicators, and a new chat button.
 
 import { type Component, For, Show } from "solid-js";
 import { type Conversation, chatStore } from "@/stores/chat.store";
+import { hasPendingApprovals } from "@/stores/mcp-chat.store";
 
 export const ChatTabBar: Component = () => {
   const handleNewChat = async () => {
@@ -58,6 +59,17 @@ export const ChatTabBar: Component = () => {
                   : conversation.title
               }
             >
+              <Show
+                when={
+                  conversation.id === chatStore.activeConversationId &&
+                  hasPendingApprovals()
+                }
+              >
+                <span
+                  class="permission-indicator"
+                  title="Permission required"
+                />
+              </Show>
               <span class="overflow-hidden text-ellipsis max-w-[140px]">
                 {conversation.title}
               </span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -227,7 +227,9 @@ code {
 
 /* Thinking dots bounce animation */
 @keyframes bounce-dot {
-  0%, 80%, 100% {
+  0%,
+  80%,
+  100% {
     transform: translateY(0);
     opacity: 0.4;
   }
@@ -241,9 +243,15 @@ code {
   animation: bounce-dot 1.4s infinite ease-in-out;
 }
 
-.thinking-dot-1 { animation-delay: 0s; }
-.thinking-dot-2 { animation-delay: 0.2s; }
-.thinking-dot-3 { animation-delay: 0.4s; }
+.thinking-dot-1 {
+  animation-delay: 0s;
+}
+.thinking-dot-2 {
+  animation-delay: 0.2s;
+}
+.thinking-dot-3 {
+  animation-delay: 0.4s;
+}
 
 /* Tool execution pulse */
 @keyframes pulse {
@@ -254,4 +262,23 @@ code {
   50% {
     opacity: 0.5;
   }
+}
+
+/* Permission required indicator - pulsing orange dot */
+@keyframes permission-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(251, 146, 60, 0.7);
+  }
+  50% {
+    transform: scale(1.1);
+    box-shadow: 0 0 0 4px rgba(251, 146, 60, 0);
+  }
+}
+
+.permission-indicator {
+  @apply w-2 h-2 rounded-full shrink-0;
+  background-color: #fb923c;
+  animation: permission-pulse 1.5s ease-in-out infinite;
 }


### PR DESCRIPTION
## Summary
- Add visual indicator (pulsing orange dot) to chat and agent tabs when there are pending permission requests
- Helps users notice when action is required, especially when multiple tabs are open
- Similar to Claude Code extension behavior in Cursor

## Changes
- **ChatTabBar**: Shows indicator on active tab when MCP tool approvals are pending
- **AgentTabBar**: Shows indicator per-session when ACP permissions or diff proposals are pending
- **CSS**: Add `permission-pulse` keyframe animation and `.permission-indicator` class

## Test plan
- [ ] Open multiple chat tabs and trigger an MCP tool call requiring approval
- [ ] Verify the pulsing orange indicator appears on the active chat tab
- [ ] Approve/deny the permission and verify the indicator disappears
- [ ] Open agent sessions and trigger a permission request
- [ ] Verify the indicator appears on the correct agent tab
- [ ] Switch tabs while permission is pending to verify visual persistence

Closes #408

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com