### PR TITLE
docs: add Rust/cargo PATH configuration instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,17 +36,13 @@ It connects to Seren's proprietary Gateway API for AI chat, billing, and MCP act
 
 **Required:** Rust toolchain (cargo, rustc) must be in PATH for `pnpm tauri dev` to work.
 
-If cargo is not available in Claude Code shell commands, add to your `~/.claude/settings.json`:
+If cargo is not available in Claude Code shell commands, run the setup script:
 
-```json
-{
-  "env": {
-    "PATH": "/Users/YOUR_USERNAME/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
-  }
-}
+```bash
+./scripts/setup-claude-env.sh
 ```
 
-Replace `YOUR_USERNAME` with your actual username. This is needed because Claude Code may not source your shell profile where `~/.cargo/env` is typically loaded.
+This automatically configures your Claude Code environment to include cargo in PATH. Restart Claude Code after running.
 
 ### API Endpoints
 

--- a/scripts/setup-claude-env.sh
+++ b/scripts/setup-claude-env.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# ABOUTME: Configures Claude Code environment for seren-desktop development.
+# ABOUTME: Adds cargo/rustup to PATH in user's Claude Code settings.
+
+set -e
+
+CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+CARGO_BIN="$HOME/.cargo/bin"
+
+echo "Setting up Claude Code environment for seren-desktop..."
+
+# Check if cargo is installed
+if [ ! -d "$CARGO_BIN" ]; then
+    echo "Error: Cargo not found at $CARGO_BIN"
+    echo "Please install Rust first: https://rustup.rs"
+    exit 1
+fi
+
+# Create .claude directory if it doesn't exist
+mkdir -p "$HOME/.claude"
+
+# Check if settings.json exists
+if [ -f "$CLAUDE_SETTINGS" ]; then
+    echo "Found existing Claude Code settings at $CLAUDE_SETTINGS"
+
+    # Check if PATH is already configured
+    if grep -q ".cargo/bin" "$CLAUDE_SETTINGS" 2>/dev/null; then
+        echo "✓ Cargo is already in Claude Code PATH"
+        exit 0
+    fi
+
+    # Backup existing settings
+    cp "$CLAUDE_SETTINGS" "$CLAUDE_SETTINGS.backup"
+    echo "Backed up existing settings to $CLAUDE_SETTINGS.backup"
+
+    # Add env section with PATH if it doesn't exist
+    # Using node/jq to safely modify JSON would be better, but keeping it simple
+    if grep -q '"env"' "$CLAUDE_SETTINGS"; then
+        echo "Warning: settings.json already has an 'env' section."
+        echo "Please manually add this to your env.PATH:"
+        echo "  $CARGO_BIN"
+        exit 1
+    fi
+
+    # Insert env section after the opening brace
+    # This is a simple approach - for complex settings, use jq
+    sed -i.tmp 's/^{$/{\n  "env": {\n    "PATH": "'"$CARGO_BIN"':\/usr\/local\/bin:\/usr\/bin:\/bin"\n  },/' "$CLAUDE_SETTINGS"
+    rm -f "$CLAUDE_SETTINGS.tmp"
+else
+    # Create new settings file
+    cat > "$CLAUDE_SETTINGS" << EOF
+{
+  "env": {
+    "PATH": "$CARGO_BIN:/usr/local/bin:/usr/bin:/bin"
+  }
+}
+EOF
+fi
+
+echo "✓ Claude Code environment configured!"
+echo "  Added $CARGO_BIN to PATH"
+echo ""
+echo "Restart Claude Code for changes to take effect."


### PR DESCRIPTION
## Summary

Updates the cargo PATH fix from PR #417. The previous approach used `.claude/settings.json` with `$HOME` variables, but Claude Code's `env` section does NOT expand environment variables.

## Changes

- **Removes** the broken `.claude/settings.json` (merged in #417)
- **Adds** documentation to CLAUDE.md explaining how to configure cargo PATH
- Users must configure their **user-level** `~/.claude/settings.json` with their actual username

## Why This Approach

Claude Code's `settings.json` `env` section sets environment variables literally - it does NOT expand `$HOME` or `$PATH`. Variable expansion only works in `.mcp.json` files using `${VAR}` syntax.

Therefore, users need to configure their own path in their user settings with their actual home directory path.

## Test Plan

- [ ] Verify cargo is available after configuring `~/.claude/settings.json`
- [ ] Run `pnpm tauri dev` successfully

Related to #414

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com