### PR TITLE
feat: auto-configure Claude Code environment on pnpm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Open source AI-powered desktop IDE with integrated chat, code completion, and MCP integration",
   "type": "module",
   "scripts": {
+    "postinstall": "./scripts/setup-claude-env.sh || true",
     "start": "vite",
     "dev": "vite",
     "build": "vite build",

--- a/scripts/setup-claude-env.sh
+++ b/scripts/setup-claude-env.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# ABOUTME: Configures Claude Code environment for seren-desktop development.
+# ABOUTME: Adds cargo/rustup to PATH in user's Claude Code settings.
+
+CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+CARGO_BIN="$HOME/.cargo/bin"
+
+# Skip if cargo not installed (not a Rust developer)
+if [ ! -d "$CARGO_BIN" ]; then
+    exit 0
+fi
+
+# Skip if Claude Code not installed
+if [ ! -d "$HOME/.claude" ]; then
+    exit 0
+fi
+
+# Skip if cargo already in Claude Code PATH
+if [ -f "$CLAUDE_SETTINGS" ] && grep -q ".cargo/bin" "$CLAUDE_SETTINGS" 2>/dev/null; then
+    exit 0
+fi
+
+echo "[seren-desktop] Configuring Claude Code environment..."
+
+# Create settings if doesn't exist
+if [ ! -f "$CLAUDE_SETTINGS" ]; then
+    cat > "$CLAUDE_SETTINGS" << EOF
+{
+  "env": {
+    "PATH": "$CARGO_BIN:/usr/local/bin:/usr/bin:/bin"
+  }
+}
+EOF
+    echo "[seren-desktop] ✓ Claude Code configured with cargo in PATH"
+    echo "[seren-desktop]   Restart Claude Code for changes to take effect"
+    exit 0
+fi
+
+# Backup and update existing settings
+cp "$CLAUDE_SETTINGS" "$CLAUDE_SETTINGS.backup"
+
+# Check if env section exists
+if grep -q '"env"' "$CLAUDE_SETTINGS"; then
+    echo "[seren-desktop] Claude Code settings already has 'env' section"
+    echo "[seren-desktop] Please manually add to your PATH: $CARGO_BIN"
+    exit 0
+fi
+
+# Add env section after opening brace
+sed -i.tmp 's/^{$/{\
+  "env": {\
+    "PATH": "'"$CARGO_BIN"':\/usr\/local\/bin:\/usr\/bin:\/bin"\
+  },/' "$CLAUDE_SETTINGS"
+rm -f "$CLAUDE_SETTINGS.tmp"
+
+echo "[seren-desktop] ✓ Claude Code configured with cargo in PATH"
+echo "[seren-desktop]   Restart Claude Code for changes to take effect"


### PR DESCRIPTION
## Summary

Automatically configures Claude Code environment when users run `pnpm install`. Zero manual setup required.

## Changes

- **scripts/setup-claude-env.sh** - Script that configures Claude Code settings
- **package.json** - Added `postinstall` hook to run the script

## How It Works

1. User runs `pnpm install`
2. Postinstall script runs automatically
3. Script checks if cargo and Claude Code are installed
4. If both exist and not already configured, updates `~/.claude/settings.json`
5. Adds cargo to PATH in Claude Code environment

## Safety

- Skips silently if cargo not installed (not a Rust developer)
- Skips silently if Claude Code not installed
- Skips if already configured
- Backs up existing settings before modifying
- Uses `|| true` so failures don't break install

## Test Plan

- [ ] Run `pnpm install` on fresh clone
- [ ] Verify `~/.claude/settings.json` is updated
- [ ] Restart Claude Code
- [ ] Run `which cargo` - should return path

Fixes #421

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com