### PR TITLE
fix: prevent duplicate browser opens when clicking external links

### DIFF
--- a/src/lib/external-link.ts
+++ b/src/lib/external-link.ts
@@ -48,6 +48,9 @@ export async function openExternalLink(url: string): Promise<void> {
  */
 export function installExternalLinkInterceptor(): void {
   document.addEventListener("click", (e) => {
+    // Skip if another handler already processed this click (e.g., AgentChat, ChatPanel)
+    if (e.defaultPrevented) return;
+
     const anchor = (e.target as HTMLElement).closest("a[href]");
     if (!anchor) return;
     const href = (anchor as HTMLAnchorElement).href;


### PR DESCRIPTION
## Summary

- Add `defaultPrevented` check to the global link interceptor
- Skips links already handled by component-level click handlers

This fixes #424 where clicking an external link in Agent chat opens the browser multiple times.

## Root Cause

There are two layers of click handlers for external links:
1. Component handlers (AgentChat, ChatContent, ChatPanel) call `openExternalLink()` and `event.preventDefault()`
2. Global interceptor in `installExternalLinkInterceptor()` catches the bubbled event and calls `openExternalLink()` again

The global interceptor was not checking `event.defaultPrevented`, so it opened the link even when already handled.

## Fix

Add `if (e.defaultPrevented) return;` at the start of the global interceptor to respect the standard DOM API for signaling that an event was already handled.

## Test Plan

- [ ] Open Seren Desktop
- [ ] Start an agent session
- [ ] Get the agent to output a URL
- [ ] Click the URL link
- [ ] Verify browser opens only once

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com