### PR TITLE
fix: detect Codex authentication errors and trigger login flow

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -52,6 +52,11 @@ fn is_auth_error(msg: &str) -> bool {
         || lower.contains("please obtain a new token")
         || lower.contains("refresh your existing token")
         || lower.contains("401")
+        // Codex-specific: "Invalid request" usually means missing/invalid OpenAI credentials
+        || (lower.contains("codex") && lower.contains("invalid request"))
+        || (lower.contains("codex") && lower.contains("-32600"))
+        || lower.contains("openai api key")
+        || lower.contains("codex connection error")
 }
 
 /// Return a user-friendly auth error message for the given agent type


### PR DESCRIPTION
## Summary
- Fixes critical bug where Codex agent fails with "Invalid request" error and no authentication option
- Added detection for Codex-specific error patterns in `is_auth_error()`
- **Replaced OpenClaw-based login with native Codex CLI** (`codex login`)

## Problem
When users attempt to start the Codex agent without authentication, they receive:
```
Failed to create agent session: Error { code: -32603: Internal error, message: "Failed to start Codex thread: Codex connection error: Codex error -32600: Invalid request", data: None }
```

This error was not recognized as an authentication issue, and the previous login flow incorrectly used OpenClaw instead of the native Codex CLI.

## Solution
1. Extended `is_auth_error()` to detect Codex-specific patterns:
   - `codex` + `invalid request`
   - `codex` + `-32600`
   - `openai api key`
   - `codex connection error`

2. Replaced `launch_codex_login()` to use native Codex CLI:
   - Now runs `codex login` directly (like `claude login` for Claude)
   - Removed OpenClaw dependency from Codex authentication
   - Works with user's installed Codex CLI

## Test plan
- [ ] Have Codex CLI installed but not authenticated
- [ ] Attempt to start Codex agent in Seren Desktop
- [ ] Verify a terminal opens with `codex login`
- [ ] Complete authentication
- [ ] Retry starting Codex agent
- [ ] Verify agent connects successfully

Fixes #426

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com