### PR TITLE
fix: scope permission dialogs to active agent session

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -531,8 +531,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           >
             <For each={acpStore.messages}>{renderMessage}</For>
 
-            {/* Diff proposal dialogs */}
-            <For each={acpStore.pendingDiffProposals}>
+            {/* Diff proposal dialogs (scoped to active session) */}
+            <For
+              each={acpStore.pendingDiffProposals.filter(
+                (p) => p.sessionId === acpStore.activeSessionId,
+              )}
+            >
               {(proposal) => (
                 <div class="px-5 py-2">
                   <DiffProposalDialog proposal={proposal} />
@@ -540,8 +544,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               )}
             </For>
 
-            {/* Permission request dialogs */}
-            <For each={acpStore.pendingPermissions}>
+            {/* Permission request dialogs (scoped to active session) */}
+            <For
+              each={acpStore.pendingPermissions.filter(
+                (p) => p.sessionId === acpStore.activeSessionId,
+              )}
+            >
               {(perm) => (
                 <div class="px-5 py-2">
                   <AcpPermissionDialog permission={perm} />


### PR DESCRIPTION
## Summary
- Filter `pendingPermissions` and `pendingDiffProposals` by `activeSessionId` so permission and diff dialogs only render in the agent tab that owns them
- Both event types already carry a `sessionId` field — the rendering just wasn't filtering on it

## Test plan
- [ ] Open two agent tabs (e.g., Claude #1 and Claude #2)
- [ ] Trigger a permission request in one session
- [ ] Switch to the other tab — verify the permission dialog does NOT appear there
- [ ] Switch back — verify it still appears in the correct tab
- [ ] Same test with diff proposals

Closes #427

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com