### PR TITLE
feat: show agent tool activity in chat stream

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -882,6 +882,35 @@ export const acpStore = {
     const session = state.sessions[sessionId];
     if (!session) return;
 
+    // Flush accumulated streaming content so tool cards appear in correct
+    // chronological order relative to assistant text.
+    if (session.streamingThinking) {
+      const thinkingMsg: AgentMessage = {
+        id: crypto.randomUUID(),
+        type: "thought",
+        content: session.streamingThinking,
+        timestamp: Date.now(),
+      };
+      setState("sessions", sessionId, "messages", (msgs) => [
+        ...msgs,
+        thinkingMsg,
+      ]);
+      setState("sessions", sessionId, "streamingThinking", "");
+    }
+    if (session.streamingContent) {
+      const contentMsg: AgentMessage = {
+        id: crypto.randomUUID(),
+        type: "assistant",
+        content: session.streamingContent,
+        timestamp: Date.now(),
+      };
+      setState("sessions", sessionId, "messages", (msgs) => [
+        ...msgs,
+        contentMsg,
+      ]);
+      setState("sessions", sessionId, "streamingContent", "");
+    }
+
     // Store pending tool call
     session.pendingToolCalls.set(toolCall.toolCallId, toolCall);
 


### PR DESCRIPTION
## Summary
- Emit `acp://tool-call` and `acp://tool-result` events from ClientDelegate methods (`read_text_file`, `create_terminal`, `wait_for_terminal_exit`, `release_terminal`) so the existing ToolCallCard UI renders agent activity
- Flush accumulated streaming content before tool call messages in the store to maintain correct chronological ordering of text and tool cards
- Track terminal-to-tool-call mapping for proper status updates on terminal exit

## Context

The ACP agent does not currently send `SessionUpdate::ToolCall` notifications for its internal tool usage (file reads, terminal commands, etc.). The frontend already has complete UI components (ToolCallCard, DiffCard) and event handling to render these, but no data was flowing. By emitting events from the client-side delegate methods where we know what operations the agent is requesting, we give users visibility into agent activity similar to the Claude Code extension in Cursor.

## Test Plan

- [ ] Start an agent session and send a prompt that triggers tool usage
- [ ] Verify ToolCallCard appears for file reads with correct filename
- [ ] Verify ToolCallCard appears for terminal commands with correct command
- [ ] Verify cards show Running spinner then transition to Completed or Failed
- [ ] Verify text and tool cards are interleaved in correct chronological order
- [ ] Verify existing diff proposal and permission dialog functionality is unaffected

Closes #432