### PR TITLE
fix: preserve agent input when switching between chat and agent modes

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -85,6 +85,20 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   });
   onCleanup(() => {
     window.removeEventListener("seren:pick-images", onPickImages);
+    // Save agent input when component unmounts (e.g., when switching to chat mode)
+    const currentInput = input();
+    if (currentInput) {
+      acpStore.setPendingAgentInput(currentInput);
+    }
+  });
+
+  // Restore pending agent input when component mounts (e.g., when switching back to agent mode)
+  createEffect(() => {
+    const pending = acpStore.pendingAgentInput;
+    if (pending) {
+      setInput(pending);
+      acpStore.setPendingAgentInput(null);
+    }
   });
 
   const hasSession = () => acpStore.activeSession !== null;

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -86,6 +86,8 @@ interface AcpState {
   pendingPermissions: import("@/services/acp").PermissionRequestEvent[];
   /** Pending diff proposals awaiting user accept/reject */
   pendingDiffProposals: DiffProposalEvent[];
+  /** Pending agent input to restore when switching back to agent mode */
+  pendingAgentInput: string | null;
 }
 
 const [state, setState] = createStore<AcpState>({
@@ -99,6 +101,7 @@ const [state, setState] = createStore<AcpState>({
   installStatus: null,
   pendingPermissions: [],
   pendingDiffProposals: [],
+  pendingAgentInput: null,
 });
 
 let globalUnsubscribe: UnlistenFn | null = null;
@@ -157,6 +160,10 @@ export const acpStore = {
 
   get pendingDiffProposals() {
     return state.pendingDiffProposals;
+  },
+
+  get pendingAgentInput() {
+    return state.pendingAgentInput;
   },
 
   /**
@@ -737,6 +744,13 @@ export const acpStore = {
    */
   setSelectedAgentType(agentType: AgentType) {
     setState("selectedAgentType", agentType);
+  },
+
+  /**
+   * Set pending agent input to restore when switching back to agent mode.
+   */
+  setPendingAgentInput(input: string | null) {
+    setState("pendingAgentInput", input);
   },
 
   /**


### PR DESCRIPTION
## Summary
- Adds `pendingAgentInput` field to the ACP store to persist input text across mode switches
- Saves agent input when AgentChat component unmounts (via `onCleanup`)
- Restores agent input when AgentChat component mounts (via `createEffect`)

Fixes #438

## Root Cause
The `Show` component in `ChatContent.tsx` unmounts `AgentChat` when switching to Chat mode. Since `AgentChat` manages its input with a local SolidJS signal, the state was destroyed on unmount and not preserved.

## Test plan
- [ ] Open the app and switch to Agent mode
- [ ] Type some text in the agent input box (e.g., "test message")
- [ ] Click to switch to Chat mode
- [ ] Switch back to Agent mode
- [ ] Verify the text you typed ("test message") is still present in the input box

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com