### PR TITLE
fix: auto-restart session on auth error Login click

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -441,10 +441,16 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                   <button
                     type="button"
                     class="px-2 py-1 text-xs font-medium bg-[#d2992a] text-[#0d1117] rounded hover:bg-[#e5ac3d] flex-shrink-0"
-                    onClick={() => {
+                    onClick={async () => {
                       const agentType =
                         acpStore.activeSession?.info.agentType ?? "claude-code";
                       launchLogin(agentType);
+                      const sid = acpStore.activeSessionId;
+                      if (sid) {
+                        await acpStore.terminateSession(sid);
+                      }
+                      acpStore.clearError();
+                      startSession(agentType);
                     }}
                   >
                     Login
@@ -671,16 +677,27 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 <button
                   type="button"
                   class="px-2 py-1 text-xs font-medium bg-[#d2992a] text-[#0d1117] rounded hover:bg-[#e5ac3d]"
-                  onClick={() => {
+                  onClick={async () => {
                     const agentType =
                       acpStore.activeSession?.info.agentType ?? "claude-code";
                     launchLogin(agentType);
+                    const sid = acpStore.activeSessionId;
+                    if (sid) {
+                      await acpStore.terminateSession(sid);
+                    }
+                    acpStore.clearError();
+                    startSession(agentType);
                   }}
                 >
                   Login
                 </button>
               </Show>
-              <Show when={acpStore.activeSession?.info.status === "error"}>
+              <Show
+                when={
+                  !isAuthError(sessionError()) &&
+                  acpStore.activeSession?.info.status === "error"
+                }
+              >
                 <button
                   type="button"
                   class="text-xs underline hover:no-underline"
@@ -711,7 +728,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               {acpStore.activeSession?.info.agentType === "codex"
                 ? "OpenAI"
                 : "Anthropic"}
-              , then restart the session.
+              . A new session will start automatically.
             </p>
           </Show>
         </div>


### PR DESCRIPTION
## Summary
- **Login button on auth error banners now also restarts the session** — previously it only opened a terminal for `codex login` / `claude login`, leaving the session in a dead ERROR state
- For auth errors, the redundant "Restart Session" link is hidden since Login now handles both actions
- Updated helper text from "then restart the session" to "A new session will start automatically"

Closes #443

## Test plan
- [ ] Trigger an auth error with Codex agent (expired OAuth token)
- [ ] Click "Login" on the inline error message — verify terminal opens AND session restarts
- [ ] Click "Login" on the bottom error banner — verify same behavior
- [ ] Verify non-auth errors still show "Restart Session" link
- [ ] Verify "Dismiss" button still works on all error types

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com