### PR TITLE
fix: keep permission dialogs visible during agent streaming

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -589,32 +589,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           >
             <For each={acpStore.messages}>{renderMessage}</For>
 
-            {/* Diff proposal dialogs (scoped to active session) */}
-            <For
-              each={acpStore.pendingDiffProposals.filter(
-                (p) => p.sessionId === acpStore.activeSessionId,
-              )}
-            >
-              {(proposal) => (
-                <div class="px-5 py-2">
-                  <DiffProposalDialog proposal={proposal} />
-                </div>
-              )}
-            </For>
-
-            {/* Permission request dialogs (scoped to active session) */}
-            <For
-              each={acpStore.pendingPermissions.filter(
-                (p) => p.sessionId === acpStore.activeSessionId,
-              )}
-            >
-              {(perm) => (
-                <div class="px-5 py-2">
-                  <AcpPermissionDialog permission={perm} />
-                </div>
-              )}
-            </For>
-
             {/* Loading placeholder while waiting for first chunk */}
             <Show
               when={
@@ -650,6 +624,44 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           </Show>
         </Show>
       </div>
+
+      {/* Permission and diff proposal dialogs — rendered outside the scroll
+          container so they stay visible while the agent streams content. */}
+      <Show
+        when={
+          acpStore.pendingDiffProposals.some(
+            (p) => p.sessionId === acpStore.activeSessionId,
+          ) ||
+          acpStore.pendingPermissions.some(
+            (p) => p.sessionId === acpStore.activeSessionId,
+          )
+        }
+      >
+        <div class="border-t border-[#30363d] bg-[#0d1117] max-h-[40vh] overflow-y-auto">
+          <For
+            each={acpStore.pendingDiffProposals.filter(
+              (p) => p.sessionId === acpStore.activeSessionId,
+            )}
+          >
+            {(proposal) => (
+              <div class="px-5 py-2">
+                <DiffProposalDialog proposal={proposal} />
+              </div>
+            )}
+          </For>
+          <For
+            each={acpStore.pendingPermissions.filter(
+              (p) => p.sessionId === acpStore.activeSessionId,
+            )}
+          >
+            {(perm) => (
+              <div class="px-5 py-2">
+                <AcpPermissionDialog permission={perm} />
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
 
       {/* Error Display */}
       <Show when={sessionError()}>


### PR DESCRIPTION
## Summary

- Moves AcpPermissionDialog and DiffProposalDialog from inside the scrolling messages container to a fixed section below it
- Wraps dialogs in a Show that only renders when there are pending permissions or diff proposals for the active session
- Container has max-h-[40vh] with overflow-y-auto so multiple dialogs do not overwhelm the viewport

## Problem

When the agent streams content, scrollToBottom() scrolls past the inline permission dialogs, forcing users to scroll up to find and respond to them. This is disruptive and easy to miss.

## Fix

Render the dialogs outside the scrolling message list, in a separate section between the messages and the input area. They now stay visible regardless of scroll position.

Closes #442

## Test plan

- [ ] Start an agent session that triggers tool use requiring permission
- [ ] Verify the permission dialog stays visible at the bottom while content streams
- [ ] Verify diff proposal dialogs also stay visible
- [ ] Verify dialogs disappear after approving/denying
- [ ] Verify multiple pending dialogs scroll within their container (max 40vh)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com