### PR TITLE
fix: nudge model to complete task after empty tool-call response

### DIFF
--- a/src/components/chat/ToolStreamingMessage.tsx
+++ b/src/components/chat/ToolStreamingMessage.tsx
@@ -137,7 +137,8 @@ export const ToolStreamingMessage: Component<ToolStreamingMessageProps> = (
         const executions = toolExecutions();
 
         // When text content is empty but tool operations occurred,
-        // generate a summary so the message isn't invisible after streaming ends
+        // generate a summary so the message isn't invisible after streaming ends.
+        // The message makes clear the AI may not have completed the user's request.
         if (!finalContent.trim() && executions.length > 0) {
           console.warn(
             "[ToolStreamingMessage] Empty content with",
@@ -153,7 +154,15 @@ export const ToolStreamingMessage: Component<ToolStreamingMessageProps> = (
             }
             return `- ${icon} **${name}**${detail}`;
           });
-          finalContent = `*Tool operations completed:*\n\n${lines.join("\n")}`;
+
+          const hasErrors = executions.some((e) => e.status === "error");
+          const header = hasErrors
+            ? "*Some tool operations failed:*"
+            : "*Tool operations completed:*";
+          const footer =
+            "\n\n*The AI did not provide a response. " +
+            "Your request may not have been fully completed — please try again if needed.*";
+          finalContent = `${header}\n\n${lines.join("\n")}${footer}`;
         }
 
         props.onComplete(finalContent, fullThinking || undefined);


### PR DESCRIPTION
## Summary

Fixes #444

- When a model calls discovery/meta tools but returns an empty response without completing the task, the chat now automatically sends a one-time follow-up prompt ("nudge") asking the model to finish or explain
- Improves the fallback message in ToolStreamingMessage to make clear the AI may not have completed the request, instead of the misleading "Tool operations completed" that implied success

## Root Cause

In Chat mode, some models (observed with Gemini 3 Flash) call discovery tools (`list_agent_publishers`, `list_mcp_tools`) but then return an empty response with no further tool calls — never executing the actual action tool (e.g., `create_issue`). The UI showed "Tool operations completed" with success checkmarks, giving the false impression the task was done.

## Changes

- **`src/services/chat.ts`**: Added nudge mechanism in both `streamMessageWithTools` and `continueToolIteration` — when the model returns empty content and no tool_calls after having executed tools, a follow-up message is injected once to prompt task completion
- **`src/components/chat/ToolStreamingMessage.tsx`**: Updated fallback summary to append a note that the AI did not respond and the request may not have been completed

## Test plan

- [ ] In Chat mode with Gemini, ask the AI to perform a tool action (e.g., create a GitHub issue)
- [ ] Verify the model gets a nudge if it stops after discovery tools without completing the task
- [ ] Verify the fallback message shows the warning note when the AI provides no text response
- [ ] Verify normal tool-use flows (where model completes the task) are not affected
- [ ] Verify the nudge only fires once (no infinite loops)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com