### PR TITLE
fix: agent chat file clicks, image attachments, and slash commands

### DIFF
--- a/src/components/chat/ImageAttachmentBar.tsx
+++ b/src/components/chat/ImageAttachmentBar.tsx
@@ -10,6 +10,7 @@ interface ImageAttachmentBarProps {
   images: Attachment[];
   onAttach: () => void;
   onRemove: (index: number) => void;
+  isLoading?: boolean;
 }
 
 export const ImageAttachmentBar: Component<ImageAttachmentBarProps> = (
@@ -19,7 +20,8 @@ export const ImageAttachmentBar: Component<ImageAttachmentBarProps> = (
   console.log(
     "[ImageAttachmentBar] Rendering with",
     props.images.length,
-    "images",
+    "images, isLoading:",
+    props.isLoading,
   );
 
   return (
@@ -27,28 +29,51 @@ export const ImageAttachmentBar: Component<ImageAttachmentBarProps> = (
       {/* Attach button */}
       <button
         type="button"
-        class="flex items-center gap-1 px-2 py-1 bg-transparent border border-[#30363d] text-[#8b949e] rounded text-xs cursor-pointer transition-colors hover:bg-[#21262d] hover:text-[#e6edf3]"
+        class={`flex items-center gap-1 px-2 py-1 bg-transparent border border-[#30363d] text-[#8b949e] rounded text-xs cursor-pointer transition-colors hover:bg-[#21262d] hover:text-[#e6edf3] ${props.isLoading ? "opacity-50 cursor-wait" : ""}`}
         onClick={() => {
-          console.log("[ImageAttachmentBar] Attach button clicked");
-          props.onAttach();
+          console.log("[ImageAttachmentBar] Attach button clicked, isLoading:", props.isLoading);
+          if (!props.isLoading) {
+            props.onAttach();
+          }
         }}
-        title="Attach files"
+        disabled={props.isLoading}
+        title={props.isLoading ? "Opening file picker..." : "Attach files"}
       >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          role="img"
-          aria-label="Attach"
+        <Show
+          when={!props.isLoading}
+          fallback={
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              class="animate-spin"
+              role="img"
+              aria-label="Loading"
+            >
+              <circle cx="12" cy="12" r="10" stroke-opacity="0.25" />
+              <path d="M12 2a10 10 0 0 1 10 10" />
+            </svg>
+          }
         >
-          <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
-        </svg>
-        Attach
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            role="img"
+            aria-label="Attach"
+          >
+            <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+          </svg>
+        </Show>
+        {props.isLoading ? "Opening..." : "Attach"}
       </button>
 
       {/* Attachment thumbnails */}

--- a/src/components/chat/SlashCommandPopup.css
+++ b/src/components/chat/SlashCommandPopup.css
@@ -6,13 +6,13 @@
   bottom: 100%;
   left: 0;
   right: 0;
-  margin-bottom: 4px;
-  background: var(--popover);
-  border: 1px solid var(--border);
+  margin-bottom: 8px;
+  background: var(--popover, #252526);
+  border: 1px solid var(--border, #333333);
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.05);
   overflow: hidden;
-  z-index: 50;
+  z-index: 999;
   max-height: 300px;
   overflow-y: auto;
 }

--- a/src/components/chat/SlashCommandPopup.tsx
+++ b/src/components/chat/SlashCommandPopup.tsx
@@ -15,7 +15,14 @@ interface SlashCommandPopupProps {
 }
 
 export function SlashCommandPopup(props: SlashCommandPopupProps) {
-  const matches = () => getCompletions(props.input, props.panel);
+  const matches = () => {
+    const result = getCompletions(props.input, props.panel);
+    // Debug logging to trace slash command matching
+    if (props.input.startsWith("/")) {
+      console.log("[SlashCommandPopup] Input:", props.input, "Panel:", props.panel, "Matches:", result.length, result.map(c => c.name));
+    }
+    return result;
+  };
 
   return (
     <Show when={matches().length > 0}>

--- a/src/components/sidebar/FileExplorer.tsx
+++ b/src/components/sidebar/FileExplorer.tsx
@@ -49,6 +49,10 @@ export const FileExplorer: Component = () => {
   const handleFileSelect = async (path: string) => {
     try {
       await openFileInTab(path);
+      // Switch to editor panel to show the opened file
+      window.dispatchEvent(
+        new CustomEvent("seren:open-panel", { detail: "editor" }),
+      );
     } catch (error) {
       console.error("Failed to open file:", error);
     }

--- a/src/lib/images/attachments.ts
+++ b/src/lib/images/attachments.ts
@@ -206,7 +206,15 @@ function resizeImage(
  */
 export async function pickFiles(): Promise<string[]> {
   console.log("[attachments] pickFiles called, opening dialog...");
+  console.log("[attachments] Supported extensions:", ALL_EXTENSIONS.join(", "));
   try {
+    // Ensure the dialog module is available
+    if (typeof open !== "function") {
+      console.error("[attachments] Dialog 'open' function not available");
+      throw new Error("File dialog not available - dialog plugin may not be initialized");
+    }
+
+    console.log("[attachments] Calling open() with filters...");
     const selected = await open({
       multiple: true,
       title: "Attach Files",
@@ -230,12 +238,23 @@ export async function pickFiles(): Promise<string[]> {
       ],
     });
 
-    console.log("[attachments] pickFiles dialog result:", selected);
-    if (!selected) return [];
-    if (typeof selected === "string") return [selected];
+    console.log("[attachments] pickFiles dialog returned:", selected);
+    if (!selected) {
+      console.log("[attachments] No files selected (dialog cancelled or empty selection)");
+      return [];
+    }
+    if (typeof selected === "string") {
+      console.log("[attachments] Single file selected:", selected);
+      return [selected];
+    }
+    console.log("[attachments] Multiple files selected:", selected.length);
     return selected;
   } catch (error) {
     console.error("[attachments] pickFiles error:", error);
+    // Re-throw with more context
+    if (error instanceof Error) {
+      throw new Error(`Failed to open file picker: ${error.message}`);
+    }
     throw error;
   }
 }


### PR DESCRIPTION
## Summary

Fixes three related issues affecting user interaction in the Agent Chat panel (#450):

- **File clicks now open Editor**: Clicking files in the explorer while in Agent Chat mode now properly switches to the Editor panel
- **Image attachment improvements**: Added loading state, better error handling, and visual feedback when attaching files
- **Slash command popup fixes**: Increased z-index and added CSS improvements for reliable visibility

## Changes

### FileExplorer.tsx
- Dispatch `seren:open-panel` event with "editor" after opening file in tab

### AgentChat.tsx
- Added `isAttaching` state to prevent concurrent attach operations
- Show error message to user when attachment fails

### ImageAttachmentBar.tsx
- Accept `isLoading` prop to show loading state
- Display spinner and "Opening..." text during file picker operation
- Disable button while loading

### SlashCommandPopup.css
- Increased z-index from 50 to 999
- Added CSS variable fallbacks (`var(--popover, #252526)`)
- Enhanced box-shadow for better visibility

### SlashCommandPopup.tsx
- Added debug logging to trace command matching

### attachments.ts
- Enhanced logging throughout file picker flow
- Better error messages with context

## Test plan

- [ ] Open Agent Chat and click a file in the explorer - should switch to Editor panel
- [ ] Click Attach button - should show loading state and open file picker
- [ ] Type "/" in Agent Chat input - should show slash command popup
- [ ] Verify console logs appear when interacting with these features

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com