### PR TITLE
fix: create tool cards from ToolCallUpdate when no prior ToolCall exists

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -868,6 +868,21 @@ fn handle_session_notification(
             }
         }
         SessionUpdate::ToolCallUpdate(update) => {
+            // Defensive: if the update has a title, also emit a TOOL_CALL event
+            // so the frontend creates a card even if no prior ToolCall was sent.
+            if let Some(ref title) = update.fields.title {
+                let _ = app.emit(
+                    events::TOOL_CALL,
+                    serde_json::json!({
+                        "sessionId": session_id,
+                        "toolCallId": update.tool_call_id.to_string(),
+                        "title": title,
+                        "kind": format!("{:?}", update.fields.kind.unwrap_or_default()),
+                        "status": format!("{:?}", update.fields.status.unwrap_or_default())
+                    }),
+                );
+            }
+
             // Check for diffs in content
             if let Some(ref content) = update.fields.content {
                 for block in content {

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -925,6 +925,11 @@ export const acpStore = {
       setState("sessions", sessionId, "streamingContent", "");
     }
 
+    // Skip duplicate if a message with this toolCallId already exists
+    if (session.messages.some((m) => m.toolCallId === toolCall.toolCallId)) {
+      return;
+    }
+
     // Store pending tool call
     session.pendingToolCalls.set(toolCall.toolCallId, toolCall);
 


### PR DESCRIPTION
## Summary
- Some ACP agents (like seren-acp-claude) send `ToolCallUpdate` without a prior `ToolCall`, causing tool activity cards to never appear in Agent mode
- Added defensive fallback in Rust: when `ToolCallUpdate` includes a `title` field, also emit a `TOOL_CALL` event to create the card
- Made `handleToolCall` in the store idempotent to prevent duplicate cards

## Context

The ACP protocol has two notification types:
- `ToolCall` — creates a new tool card (seren-desktop's `handleToolCall`)
- `ToolCallUpdate` — updates an existing card (seren-desktop's `handleToolResult`)

The root cause fix is in serenorg/seren-acp-claude#6 which changes the agent to send the correct event type. This PR adds a defensive fallback so tool cards work regardless of agent implementation.

## Test plan
- [ ] Start an agent session and trigger tool usage
- [ ] Verify tool activity cards appear in the chat stream
- [ ] Verify no duplicate cards when both ToolCall and ToolCallUpdate arrive
- [ ] Verify cards transition from InProgress to Completed/Failed correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com