### PR TITLE
fix: prevent agent auto-restart after user cancellation

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -523,11 +523,12 @@ export const acpStore = {
       const message = error instanceof Error ? error.message : String(error);
 
       // Auto-recover from dead/zombie sessions
+      // NOTE: "agent did not stop in time" is excluded because it's from
+      // user-initiated cancellation, not a dead session
       if (
         message.includes("Worker thread dropped") ||
         message.includes("not found") ||
-        message.includes("Session not initialized") ||
-        message.includes("agent did not stop in time")
+        message.includes("Session not initialized")
       ) {
         console.info(
           "[AcpStore] Session appears dead, attempting auto-recovery...",


### PR DESCRIPTION
## Summary

Fixes #453

When user clicks the Cancel button during an Agent session, if the agent doesn't stop within 5 seconds, the backend returns . This was incorrectly triggering auto-recovery logic which would:

1. Terminate the session (causing chat to blank)
2. Spawn a new session
3. Retry the prompt (restarting the agent)

## Root Cause

The error "agent did not stop in time" was included in the auto-recovery conditions at [acp.store.ts:530](https://github.com/serenorg/seren-desktop/blob/main/src/stores/acp.store.ts#L530). This is wrong because:
- Cancellation is intentional user action, not a dead/zombie session
- The error ONLY occurs when the user explicitly hits Cancel
- Auto-recovery retries the prompt, defeating the purpose of cancellation

## Changes

- Removed `message.includes("agent did not stop in time")` from auto-recovery conditions
- Added comment explaining why it's excluded
- Now cancellation errors are shown as error messages without triggering session restart

## Testing

**Before:**
1. Start Agent session
2. Click Cancel while agent is processing
3. Chat blanks out
4. Agent restarts with the same prompt

**After:**
1. Start Agent session
2. Click Cancel while agent is processing
3. Chat stays visible
4. Error message shown, agent stops (or error displayed if it doesn't stop in time)
5. Agent does NOT restart

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com