### PR TITLE
fix: bump seren-acp-codex to v0.1.2 for jsonrpc 2.0 compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "seren-acp-codex": {
       "name": "Codex",
       "git": "https://github.com/serenorg/seren-acp-codex",
-      "tag": "v0.1.1",
+      "tag": "v0.1.2",
       "bin": "seren-acp-codex",
       "dest": "seren-acp-codex"
     },


### PR DESCRIPTION
## Summary
- Bumps seren-acp-codex sidecar from v0.1.1 to v0.1.2
- v0.1.2 adds the required jsonrpc 2.0 field to all JSON-RPC messages
- Without this field, Codex app-server rejects all requests with -32600 Invalid request
- This was the root cause of the Codex agent Authentication expired error

## Test plan
- [ ] Build sidecar: pnpm build:sidecar seren-acp-codex
- [ ] Run pnpm tauri dev
- [ ] Login to Codex agent
- [ ] Send a message — agent should respond successfully

Closes #460

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com