### PR TITLE
feat: add Codex CLI minimum version check

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -721,6 +721,8 @@ pub fn run() {
             #[cfg(feature = "acp")]
             acp::acp_ensure_claude_cli,
             #[cfg(feature = "acp")]
+            acp::acp_ensure_codex_cli,
+            #[cfg(feature = "acp")]
             acp::acp_respond_to_diff_proposal,
             // OpenClaw commands (conditionally included when openclaw feature is enabled)
             #[cfg(feature = "openclaw")]

--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -254,6 +254,15 @@ export async function ensureClaudeCli(): Promise<string> {
 }
 
 /**
+ * Ensure Codex CLI (`@openai/codex`) is installed and meets the minimum version.
+ * Installs or upgrades via npm if needed.
+ * Returns the bin directory path containing the codex binary.
+ */
+export async function ensureCodexCli(): Promise<string> {
+  return invoke<string>("acp_ensure_codex_cli");
+}
+
+/**
  * Check if a specific agent binary is available in PATH.
  */
 export async function checkAgentAvailable(


### PR DESCRIPTION
## Summary

- Adds `acp_ensure_codex_cli` Tauri command that checks for `@openai/codex` CLI, validates its version against `MIN_CODEX_CLI_VERSION` (0.98.0), and auto-installs/upgrades via npm if missing or outdated
- Mirrors the existing `acp_ensure_claude_cli` pattern used for Claude Code CLI
- Frontend store now gates **both** Claude and Codex agent spawns through their respective CLI ensure functions

## Context

We discovered that running Codex CLI 0.46.0 against the current `codex app-server` protocol produces cryptic `-32600 "Invalid request"` errors on `thread/start`. Upgrading to 0.98.0 resolved the issue immediately. This is the same class of problem we previously hit with Claude CLI versions, so the same solution applies: check and auto-upgrade at spawn time.

Closes #462

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/acp.rs` | Added `acp_ensure_codex_cli` command + `upgrade_codex_cli_sync` helper |
| `src-tauri/src/lib.rs` | Registered `acp_ensure_codex_cli` in invoke_handler |
| `src/services/acp.ts` | Added `ensureCodexCli()` service function |
| `src/stores/acp.store.ts` | Generalized pre-spawn CLI check to cover both agent types |

## Test plan

- [ ] Start a Codex agent session with no `codex` CLI installed — should auto-install and succeed
- [ ] Start a Codex agent session with outdated `codex` CLI — should auto-upgrade and succeed
- [ ] Start a Codex agent session with up-to-date `codex` CLI — should pass through immediately
- [ ] Start a Claude Code agent session — existing behavior unchanged
- [ ] Verify `cargo check` passes
- [ ] Verify `biome check` passes on changed TS files

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com