### PR TITLE
fix: show Login button when auth errors stream as text

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -400,6 +400,36 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         );
 
       case "assistant":
+        if (isAuthError(message.content)) {
+          return (
+            <article class="px-5 py-3 border-b border-[#21262d]">
+              <div class="px-3 py-2 border rounded-md text-sm bg-[rgba(210,153,34,0.1)] border-[rgba(210,153,34,0.4)] text-[#d2992a]">
+                <div class="flex items-center justify-between gap-2">
+                  <span>
+                    Authentication expired. Please log in to continue.
+                  </span>
+                  <button
+                    type="button"
+                    class="px-2 py-1 text-xs font-medium bg-[#d2992a] text-[#0d1117] rounded hover:bg-[#e5ac3d] flex-shrink-0"
+                    onClick={async () => {
+                      const agentType =
+                        acpStore.activeSession?.info.agentType ?? "claude-code";
+                      launchLogin(agentType);
+                      const sid = acpStore.activeSessionId;
+                      if (sid) {
+                        await acpStore.terminateSession(sid);
+                      }
+                      acpStore.clearError();
+                      setAwaitingLogin(agentType);
+                    }}
+                  >
+                    Login
+                  </button>
+                </div>
+              </div>
+            </article>
+          );
+        }
         return (
           <article class="px-5 py-4 border-b border-[#21262d]">
             <div


### PR DESCRIPTION
## Summary

- Detects auth errors (expired OAuth tokens, 401s) in assistant message content and renders the gold-styled Login card instead of raw JSON
- Sets session error state when streaming content contains auth patterns, surfacing the error banner with Login/Dismiss buttons

## Problem

When Claude OAuth token expires mid-session, the agent streams the raw API error as text. This arrived as a messageChunk, finalized as type "assistant" message, and rendered as plain markdown. The existing auth error UI (gold Login button) only triggered for type "error" messages from acp://error events.

## Changes

| File | Change |
|------|--------|
| src/components/chat/AgentChat.tsx | Added isAuthError() check in case "assistant" rendering - shows Login card when auth error detected |
| src/stores/acp.store.ts | Added isAuthError() helper; detect auth errors in finalizeStreamingContent() and set session.error so the banner appears |

Fixes #464

## Test plan

- [ ] Trigger an expired OAuth token error in a Claude Code session - should show gold Login card, not raw JSON
- [ ] Click Login button - should open terminal with claude login and terminate the old session
- [ ] Non-auth errors still show as normal red error messages
- [ ] Regular assistant messages render as markdown (no false positives)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
