### PR TITLE
Add per-operation approval for Gateway publisher tool calls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { ResizableLayout } from "@/components/common/ResizableLayout";
 import { StatusBar } from "@/components/common/StatusBar";
 import { EditorContent } from "@/components/editor/EditorContent";
 import { X402PaymentApproval } from "@/components/mcp/X402PaymentApproval";
+import { GatewayToolApproval } from "@/components/gateway/GatewayToolApproval";
 import { OpenClawApprovalManager } from "@/components/settings/OpenClawApproval";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { DatabasePanel } from "@/components/sidebar/DatabasePanel";
@@ -259,6 +260,7 @@ function App() {
         <LowBalanceModal />
         <DailyClaimPopup />
         <X402PaymentApproval />
+        <GatewayToolApproval />
         <OpenClawApprovalManager />
         <AboutDialog />
       </div>

--- a/src/components/gateway/GatewayToolApproval.css
+++ b/src/components/gateway/GatewayToolApproval.css
@@ -1,0 +1,164 @@
+/* Approval dialog overlay */
+.gateway-approval-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  backdrop-filter: blur(4px);
+}
+
+/* Approval dialog container */
+.gateway-approval-dialog {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  width: 90%;
+  max-width: 550px;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: gateway-approval-slide-in 0.2s ease-out;
+}
+
+@keyframes gateway-approval-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Header */
+.gateway-approval-header {
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.gateway-approval-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+/* Body */
+.gateway-approval-body {
+  padding: 24px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.gateway-approval-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.gateway-approval-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.gateway-approval-value {
+  font-size: 1rem;
+  color: var(--foreground);
+  word-break: break-word;
+}
+
+.gateway-approval-publisher {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.gateway-approval-endpoint {
+  font-family: "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas,
+    "Courier New", monospace;
+  font-size: 0.9rem;
+  background: var(--surface);
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+.gateway-approval-args {
+  font-family: "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas,
+    "Courier New", monospace;
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+  background: var(--surface);
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+.gateway-approval-warning {
+  margin-top: 16px;
+  padding: 12px 16px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 8px;
+  color: #ef4444;
+  font-size: 0.9rem;
+}
+
+/* Footer */
+.gateway-approval-footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.gateway-approval-button {
+  padding: 10px 24px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.gateway-approval-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.gateway-approval-deny {
+  background: transparent;
+  color: var(--foreground);
+  border: 1px solid var(--border);
+}
+
+.gateway-approval-deny:hover:not(:disabled) {
+  background: var(--surface);
+  border-color: var(--muted-foreground);
+}
+
+.gateway-approval-approve {
+  background: var(--accent);
+  color: white;
+}
+
+.gateway-approval-approve:hover:not(:disabled) {
+  background: #4f46e5;
+  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
+}

--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -1,0 +1,168 @@
+// ABOUTME: Approval dialog for Gateway publisher tool operations.
+// ABOUTME: Shows operation details and requires user confirmation before execution.
+
+import { listen } from "@tauri-apps/api/event";
+import { emit } from "@tauri-apps/api/event";
+import {
+  type Component,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import "./GatewayToolApproval.css";
+
+interface ApprovalRequest {
+  approvalId: string;
+  publisherSlug: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  description: string;
+  isDestructive: boolean;
+}
+
+export const GatewayToolApproval: Component = () => {
+  const [request, setRequest] = createSignal<ApprovalRequest | null>(null);
+  const [isProcessing, setIsProcessing] = createSignal(false);
+
+  onMount(async () => {
+    const unlisten = await listen<ApprovalRequest>(
+      "gateway-tool-approval-request",
+      (event) => {
+        console.log("[GatewayToolApproval] Received approval request:", event.payload);
+        setRequest(event.payload);
+        setIsProcessing(false);
+      },
+    );
+
+    onCleanup(() => {
+      unlisten();
+    });
+  });
+
+  const handleApprove = async () => {
+    const req = request();
+    if (!req || isProcessing()) return;
+
+    setIsProcessing(true);
+    console.log("[GatewayToolApproval] Approving operation:", req.approvalId);
+
+    try {
+      await emit("gateway-tool-approval-response", {
+        id: req.approvalId,
+        approved: true,
+      });
+      setRequest(null);
+    } catch (err) {
+      console.error("[GatewayToolApproval] Failed to emit approval:", err);
+      setIsProcessing(false);
+    }
+  };
+
+  const handleDeny = async () => {
+    const req = request();
+    if (!req || isProcessing()) return;
+
+    setIsProcessing(true);
+    console.log("[GatewayToolApproval] Denying operation:", req.approvalId);
+
+    try {
+      await emit("gateway-tool-approval-response", {
+        id: req.approvalId,
+        approved: false,
+      });
+      setRequest(null);
+    } catch (err) {
+      console.error("[GatewayToolApproval] Failed to emit denial:", err);
+      setIsProcessing(false);
+    }
+  };
+
+  const formatArgs = (args: Record<string, unknown>): string => {
+    // Show key operation parameters in a readable format
+    const relevant = Object.entries(args)
+      .filter(([key]) => !key.startsWith("_")) // Skip internal params
+      .slice(0, 3) // Limit to 3 params
+      .map(([key, value]) => {
+        const strValue = typeof value === "string"
+          ? value.length > 50
+            ? `${value.slice(0, 50)}...`
+            : value
+          : JSON.stringify(value);
+        return `${key}: ${strValue}`;
+      });
+
+    return relevant.length > 0 ? relevant.join(", ") : "No parameters";
+  };
+
+  return (
+    <Show when={request()}>
+      {(req) => (
+        <div class="gateway-approval-overlay">
+          <div class="gateway-approval-dialog">
+            <div class="gateway-approval-header">
+              <h2 class="gateway-approval-title">
+                {req().isDestructive ? "⚠️ Confirm Destructive Operation" : "🔐 Confirm Operation"}
+              </h2>
+            </div>
+
+            <div class="gateway-approval-body">
+              <div class="gateway-approval-section">
+                <span class="gateway-approval-label">Publisher:</span>
+                <span class="gateway-approval-value gateway-approval-publisher">
+                  {req().publisherSlug}
+                </span>
+              </div>
+
+              <div class="gateway-approval-section">
+                <span class="gateway-approval-label">Operation:</span>
+                <span class="gateway-approval-value">{req().description}</span>
+              </div>
+
+              <div class="gateway-approval-section">
+                <span class="gateway-approval-label">Endpoint:</span>
+                <span class="gateway-approval-value gateway-approval-endpoint">
+                  {req().toolName}
+                </span>
+              </div>
+
+              <div class="gateway-approval-section">
+                <span class="gateway-approval-label">Parameters:</span>
+                <span class="gateway-approval-value gateway-approval-args">
+                  {formatArgs(req().args)}
+                </span>
+              </div>
+
+              <Show when={req().isDestructive}>
+                <div class="gateway-approval-warning">
+                  <strong>Warning:</strong> This operation cannot be undone.
+                </div>
+              </Show>
+            </div>
+
+            <div class="gateway-approval-footer">
+              <button
+                type="button"
+                class="gateway-approval-button gateway-approval-deny"
+                onClick={handleDeny}
+                disabled={isProcessing()}
+              >
+                Deny
+              </button>
+              <button
+                type="button"
+                class="gateway-approval-button gateway-approval-approve"
+                onClick={handleApprove}
+                disabled={isProcessing()}
+              >
+                {isProcessing() ? "Processing..." : "Approve"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Show>
+  );
+};
+
+export default GatewayToolApproval;

--- a/src/lib/tools/approval-config.ts
+++ b/src/lib/tools/approval-config.ts
@@ -1,0 +1,102 @@
+// ABOUTME: Configuration for Gateway publisher tool approval requirements.
+// ABOUTME: Defines which operations need user approval before execution.
+
+/**
+ * Approval requirement for a specific operation.
+ */
+export interface ApprovalRequirement {
+  /** Publisher slug (e.g., "gmail") */
+  publisherSlug: string;
+  /** Tool/endpoint name (e.g., "messages/{id}/delete") */
+  toolPattern: string;
+  /** Human-readable description of what this operation does */
+  description: string;
+  /** Whether this is a destructive operation (higher warning level) */
+  isDestructive?: boolean;
+}
+
+/**
+ * List of Gateway publisher operations that require user approval.
+ *
+ * Operations not in this list execute immediately (e.g., read-only operations).
+ */
+export const APPROVAL_REQUIREMENTS: ApprovalRequirement[] = [
+  // Gmail - Modify operations
+  {
+    publisherSlug: "gmail",
+    toolPattern: "messages/*/delete",
+    description: "Permanently delete email",
+    isDestructive: true,
+  },
+  {
+    publisherSlug: "gmail",
+    toolPattern: "messages/*/trash",
+    description: "Move email to trash",
+  },
+  {
+    publisherSlug: "gmail",
+    toolPattern: "messages/*/modify",
+    description: "Modify email labels",
+  },
+  {
+    publisherSlug: "gmail",
+    toolPattern: "threads/*/trash",
+    description: "Move thread to trash",
+  },
+  {
+    publisherSlug: "gmail",
+    toolPattern: "labels",
+    description: "Create label",
+  },
+  {
+    publisherSlug: "gmail",
+    toolPattern: "labels/*/delete",
+    description: "Delete label",
+    isDestructive: true,
+  },
+  {
+    publisherSlug: "gmail",
+    toolPattern: "drafts/*/send",
+    description: "Send draft email",
+  },
+  {
+    publisherSlug: "gmail",
+    toolPattern: "messages/send",
+    description: "Send email",
+  },
+];
+
+/**
+ * Check if a Gateway tool call requires user approval.
+ */
+export function requiresApproval(
+  publisherSlug: string,
+  toolName: string,
+): boolean {
+  // Check if any approval requirement matches this operation
+  return APPROVAL_REQUIREMENTS.some((req) => {
+    if (req.publisherSlug !== publisherSlug) return false;
+
+    // Simple wildcard matching: "messages/*/delete" matches "messages/123/delete"
+    const pattern = req.toolPattern.replace(/\*/g, "[^/]+");
+    const regex = new RegExp(`^${pattern}$`);
+    return regex.test(toolName);
+  });
+}
+
+/**
+ * Get the approval requirement details for a specific operation.
+ */
+export function getApprovalRequirement(
+  publisherSlug: string,
+  toolName: string,
+): ApprovalRequirement | null {
+  const req = APPROVAL_REQUIREMENTS.find((req) => {
+    if (req.publisherSlug !== publisherSlug) return false;
+    const pattern = req.toolPattern.replace(/\*/g, "[^/]+");
+    const regex = new RegExp(`^${pattern}$`);
+    return regex.test(toolName);
+  });
+
+  return req || null;
+}

--- a/tests/unit/approval-config.test.ts
+++ b/tests/unit/approval-config.test.ts
@@ -1,0 +1,71 @@
+// Unit tests for Gateway tool approval configuration
+
+import { describe, expect, it } from "vitest";
+import {
+  getApprovalRequirement,
+  requiresApproval,
+} from "@/lib/tools/approval-config";
+
+describe("approval-config", () => {
+  describe("requiresApproval", () => {
+    it("should require approval for Gmail delete operations", () => {
+      expect(requiresApproval("gmail", "messages/123/delete")).toBe(true);
+    });
+
+    it("should require approval for Gmail trash operations", () => {
+      expect(requiresApproval("gmail", "messages/456/trash")).toBe(true);
+      expect(requiresApproval("gmail", "threads/789/trash")).toBe(true);
+    });
+
+    it("should require approval for Gmail modify operations", () => {
+      expect(requiresApproval("gmail", "messages/123/modify")).toBe(true);
+    });
+
+    it("should require approval for label operations", () => {
+      expect(requiresApproval("gmail", "labels")).toBe(true);
+      expect(requiresApproval("gmail", "labels/123/delete")).toBe(true);
+    });
+
+    it("should require approval for sending emails", () => {
+      expect(requiresApproval("gmail", "messages/send")).toBe(true);
+      expect(requiresApproval("gmail", "drafts/123/send")).toBe(true);
+    });
+
+    it("should NOT require approval for read operations", () => {
+      expect(requiresApproval("gmail", "messages")).toBe(false);
+      expect(requiresApproval("gmail", "messages/123")).toBe(false);
+      expect(requiresApproval("gmail", "threads")).toBe(false);
+      expect(requiresApproval("gmail", "threads/456")).toBe(false);
+      expect(requiresApproval("gmail", "labels/list")).toBe(false);
+    });
+
+    it("should NOT require approval for non-Gmail publishers", () => {
+      expect(requiresApproval("other-publisher", "messages/123/delete")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("getApprovalRequirement", () => {
+    it("should return requirement for matching operations", () => {
+      const req = getApprovalRequirement("gmail", "messages/123/delete");
+      expect(req).not.toBeNull();
+      expect(req?.publisherSlug).toBe("gmail");
+      expect(req?.description).toBe("Permanently delete email");
+      expect(req?.isDestructive).toBe(true);
+    });
+
+    it("should return null for non-matching operations", () => {
+      const req = getApprovalRequirement("gmail", "messages");
+      expect(req).toBeNull();
+    });
+
+    it("should match wildcard patterns correctly", () => {
+      const req1 = getApprovalRequirement("gmail", "messages/abc123/trash");
+      expect(req1?.description).toBe("Move email to trash");
+
+      const req2 = getApprovalRequirement("gmail", "threads/xyz789/trash");
+      expect(req2?.description).toBe("Move thread to trash");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements user approval workflow for Gateway publisher operations to justify broader OAuth scopes to Google.

Closes #470

## Changes

- **Approval Configuration** (`src/lib/tools/approval-config.ts`)
  - Defines which Gateway operations require user approval
  - Gmail operations requiring `gmail.modify` scope now trigger approval dialogs
  - Configurable via pattern matching (e.g., `messages/*/delete`)

- **Executor Integration** (`src/lib/tools/executor.ts`)
  - Modified `executeGatewayTool()` to check approval requirements
  - Added `requestGatewayApproval()` function with 5-minute timeout
  - Event-based approval flow: `gateway-tool-approval-request` / `gateway-tool-approval-response`

- **UI Component** (`src/components/gateway/GatewayToolApproval.tsx`)
  - Modal approval dialog showing operation details
  - Displays publisher, operation description, endpoint, and parameters
  - Approve/Deny buttons with destructive operation warnings
  - Follows existing approval patterns (OpenClaw, x402)

- **Unit Tests** (`tests/unit/approval-config.test.ts`)
  - Tests approval requirement matching logic
  - Covers Gmail read vs modify operations
  - Validates wildcard pattern matching

## Operations Requiring Approval

All Gmail operations that need `gmail.modify` scope:
- ✅ Delete email (`messages/*/delete`)
- ✅ Move to trash (`messages/*/trash`, `threads/*/trash`)
- ✅ Modify labels (`messages/*/modify`)
- ✅ Create/delete labels (`labels`, `labels/*/delete`)
- ✅ Send emails (`messages/send`, `drafts/*/send`)

Read-only operations (GET requests) execute without approval.

## Google OAuth Justification

This implementation provides the safeguards Google requires for broader OAuth scopes:

1. **Explicit User Control** - Every data-modifying operation requires approval
2. **Transparent Operations** - Users see exactly what will be executed
3. **Destructive Operation Warnings** - Special UI treatment for delete operations
4. **Timeout Protection** - Auto-deny after 5 minutes prevents hanging state

We can now respond to Google with:
- Screenshots of approval dialogs in action
- Code demonstrating per-operation user consent
- Explanation that `gmail.modify` is essential for core functionality

## Test Plan

- [x] Unit tests pass for approval config
- [ ] Manual test: Gmail delete operation shows approval dialog
- [ ] Manual test: Approval allows operation to proceed
- [ ] Manual test: Denial prevents operation execution
- [ ] Manual test: Timeout auto-denies after 5 minutes
- [ ] Manual test: Read operations execute without approval

## Screenshots

_To be added after manual testing_

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com