### PR TITLE
feat: add execute_command shell tool with approval dialog

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ mod oauth_callback_server;
 #[cfg(feature = "openclaw")]
 mod openclaw;
 mod sandbox;
+mod shell;
 mod skills;
 mod sync;
 mod terminal;
@@ -629,6 +630,8 @@ pub fn run() {
             files::delete_path,
             files::rename_path,
             files::reveal_in_file_manager,
+            // Shell command execution (requires frontend approval)
+            shell::execute_shell_command,
             // Web fetch command
             commands::web::web_fetch,
             // Conversation commands

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -1,0 +1,83 @@
+// ABOUTME: Shell command execution for AI tool calls.
+// ABOUTME: Runs commands with timeout and output capture, invoked via Tauri IPC.
+
+use serde::Serialize;
+use std::time::Duration;
+use tokio::process::Command;
+
+const MAX_OUTPUT_BYTES: usize = 50_000;
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+const MAX_TIMEOUT_SECS: u64 = 300;
+
+#[derive(Debug, Serialize)]
+pub struct CommandResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: Option<i32>,
+    pub timed_out: bool,
+}
+
+#[tauri::command]
+pub async fn execute_shell_command(
+    command: String,
+    timeout_secs: Option<u64>,
+) -> Result<CommandResult, String> {
+    if command.trim().is_empty() {
+        return Err("Command must not be empty".to_string());
+    }
+
+    let secs = timeout_secs
+        .unwrap_or(DEFAULT_TIMEOUT_SECS)
+        .min(MAX_TIMEOUT_SECS);
+    let timeout = Duration::from_secs(secs);
+
+    let mut cmd = if cfg!(target_os = "windows") {
+        let mut c = Command::new("cmd");
+        c.args(["/c", &command]);
+        c
+    } else {
+        let mut c = Command::new("/bin/sh");
+        c.args(["-c", &command]);
+        c
+    };
+
+    cmd.stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    let child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to spawn command: {}", e))?;
+
+    match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(output)) => {
+            let stdout = truncate_output(String::from_utf8_lossy(&output.stdout).to_string());
+            let stderr = truncate_output(String::from_utf8_lossy(&output.stderr).to_string());
+            Ok(CommandResult {
+                stdout,
+                stderr,
+                exit_code: output.status.code(),
+                timed_out: false,
+            })
+        }
+        Ok(Err(e)) => Err(format!("Command execution failed: {}", e)),
+        Err(_) => Ok(CommandResult {
+            stdout: String::new(),
+            stderr: format!("Command timed out after {} seconds", secs),
+            exit_code: None,
+            timed_out: true,
+        }),
+    }
+}
+
+fn truncate_output(s: String) -> String {
+    if s.len() <= MAX_OUTPUT_BYTES {
+        s
+    } else {
+        format!(
+            "{}\n\n[Truncated: output was {} bytes]",
+            &s[..MAX_OUTPUT_BYTES],
+            s.len()
+        )
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,10 +20,11 @@ import { LowBalanceModal } from "@/components/common/LowBalanceWarning";
 import { ResizableLayout } from "@/components/common/ResizableLayout";
 import { StatusBar } from "@/components/common/StatusBar";
 import { EditorContent } from "@/components/editor/EditorContent";
-import { X402PaymentApproval } from "@/components/mcp/X402PaymentApproval";
 import { GatewayToolApproval } from "@/components/gateway/GatewayToolApproval";
+import { X402PaymentApproval } from "@/components/mcp/X402PaymentApproval";
 import { OpenClawApprovalManager } from "@/components/settings/OpenClawApproval";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
+import { ShellApproval } from "@/components/shell/ShellApproval";
 import { DatabasePanel } from "@/components/sidebar/DatabasePanel";
 import { FileExplorer } from "@/components/sidebar/FileExplorer";
 import { DailyClaimPopup } from "@/components/wallet/DailyClaimPopup";
@@ -261,6 +262,7 @@ function App() {
         <DailyClaimPopup />
         <X402PaymentApproval />
         <GatewayToolApproval />
+        <ShellApproval />
         <OpenClawApprovalManager />
         <AboutDialog />
       </div>

--- a/src/components/shell/ShellApproval.css
+++ b/src/components/shell/ShellApproval.css
@@ -1,0 +1,153 @@
+/* Shell command approval dialog overlay */
+.shell-approval-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  backdrop-filter: blur(4px);
+}
+
+/* Shell approval dialog container */
+.shell-approval-dialog {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  width: 90%;
+  max-width: 550px;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: shell-approval-slide-in 0.2s ease-out;
+}
+
+@keyframes shell-approval-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Header */
+.shell-approval-header {
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.shell-approval-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+/* Body */
+.shell-approval-body {
+  padding: 24px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.shell-approval-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.shell-approval-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.shell-approval-value {
+  font-size: 1rem;
+  color: var(--foreground);
+}
+
+.shell-approval-command {
+  font-family:
+    "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New",
+    monospace;
+  font-size: 0.9rem;
+  background: var(--surface);
+  padding: 12px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  color: var(--foreground);
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+  overflow-x: auto;
+}
+
+.shell-approval-warning {
+  margin-top: 16px;
+  padding: 12px 16px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 8px;
+  color: #ef4444;
+  font-size: 0.9rem;
+}
+
+/* Footer */
+.shell-approval-footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.shell-approval-button {
+  padding: 10px 24px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.shell-approval-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.shell-approval-deny {
+  background: transparent;
+  color: var(--foreground);
+  border: 1px solid var(--border);
+}
+
+.shell-approval-deny:hover:not(:disabled) {
+  background: var(--surface);
+  border-color: var(--muted-foreground);
+}
+
+.shell-approval-approve {
+  background: var(--accent);
+  color: white;
+}
+
+.shell-approval-approve:hover:not(:disabled) {
+  background: #4f46e5;
+  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
+}

--- a/src/components/shell/ShellApproval.tsx
+++ b/src/components/shell/ShellApproval.tsx
@@ -1,0 +1,131 @@
+// ABOUTME: Approval dialog for shell command execution.
+// ABOUTME: Shows the command and requires user confirmation before execution.
+
+import { emit, listen } from "@tauri-apps/api/event";
+import {
+  type Component,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import "./ShellApproval.css";
+
+interface ShellApprovalRequest {
+  approvalId: string;
+  command: string;
+  timeoutSecs: number;
+}
+
+export const ShellApproval: Component = () => {
+  const [request, setRequest] = createSignal<ShellApprovalRequest | null>(null);
+  const [isProcessing, setIsProcessing] = createSignal(false);
+
+  onMount(async () => {
+    const unlisten = await listen<ShellApprovalRequest>(
+      "shell-command-approval-request",
+      (event) => {
+        console.log(
+          "[ShellApproval] Received approval request:",
+          event.payload,
+        );
+        setRequest(event.payload);
+        setIsProcessing(false);
+      },
+    );
+
+    onCleanup(() => {
+      unlisten();
+    });
+  });
+
+  const handleApprove = async () => {
+    const req = request();
+    if (!req || isProcessing()) return;
+
+    setIsProcessing(true);
+    console.log("[ShellApproval] Approving command:", req.approvalId);
+
+    try {
+      await emit("shell-command-approval-response", {
+        id: req.approvalId,
+        approved: true,
+      });
+      setRequest(null);
+    } catch (err) {
+      console.error("[ShellApproval] Failed to emit approval:", err);
+      setIsProcessing(false);
+    }
+  };
+
+  const handleDeny = async () => {
+    const req = request();
+    if (!req || isProcessing()) return;
+
+    setIsProcessing(true);
+    console.log("[ShellApproval] Denying command:", req.approvalId);
+
+    try {
+      await emit("shell-command-approval-response", {
+        id: req.approvalId,
+        approved: false,
+      });
+      setRequest(null);
+    } catch (err) {
+      console.error("[ShellApproval] Failed to emit denial:", err);
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <Show when={request()}>
+      {(req) => (
+        <div class="shell-approval-overlay">
+          <div class="shell-approval-dialog">
+            <div class="shell-approval-header">
+              <h2 class="shell-approval-title">Confirm Shell Command</h2>
+            </div>
+
+            <div class="shell-approval-body">
+              <div class="shell-approval-section">
+                <span class="shell-approval-label">Command:</span>
+                <pre class="shell-approval-command">{req().command}</pre>
+              </div>
+
+              <div class="shell-approval-section">
+                <span class="shell-approval-label">Timeout:</span>
+                <span class="shell-approval-value">{req().timeoutSecs}s</span>
+              </div>
+
+              <div class="shell-approval-warning">
+                <strong>Warning:</strong> This command will execute on your
+                machine. Review it carefully before approving.
+              </div>
+            </div>
+
+            <div class="shell-approval-footer">
+              <button
+                type="button"
+                class="shell-approval-button shell-approval-deny"
+                onClick={handleDeny}
+                disabled={isProcessing()}
+              >
+                Deny
+              </button>
+              <button
+                type="button"
+                class="shell-approval-button shell-approval-approve"
+                onClick={handleApprove}
+                disabled={isProcessing()}
+              >
+                {isProcessing() ? "Processing..." : "Approve"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Show>
+  );
+};
+
+export default ShellApproval;

--- a/src/lib/tools/definitions.ts
+++ b/src/lib/tools/definitions.ts
@@ -384,6 +384,35 @@ export const FILE_TOOLS: ToolDefinition[] = [
       },
     },
   },
+  {
+    type: "function",
+    function: {
+      name: "execute_command",
+      description:
+        "Execute a shell command on the user's machine. " +
+        "Use this to run system commands like killing processes, checking system status, " +
+        "running scripts, installing packages, or any terminal operation. " +
+        "The command runs in a shell (/bin/sh on Unix, cmd on Windows). " +
+        "Always requires user approval before execution. " +
+        "Returns stdout, stderr, and exit code.",
+      parameters: {
+        type: "object",
+        properties: {
+          command: {
+            type: "string",
+            description:
+              "The shell command to execute (e.g., 'pkill -f \"npm run dev\"')",
+          },
+          timeout_secs: {
+            type: "number",
+            description:
+              "Timeout in seconds (default: 30, max: 300). Use longer timeouts for commands like npm install.",
+          },
+        },
+        required: ["command"],
+      },
+    },
+  },
 ];
 
 /** Check if OpenClaw is set up and running so we can expose its tools. */


### PR DESCRIPTION
## Summary

- Adds execute_command tool to ChatModelWorker so AI models can run shell commands on the users machine
- Every command requires explicit user approval via a modal dialog -- no bypass
- Rust backend with timeout (30s default, 300s max) and kill_on_drop safety
- Follows the existing GatewayToolApproval pattern for the approval flow

Closes #474
Related: #473

## Changes

| File | Change |
|------|--------|
| src-tauri/src/shell.rs | New Rust command: execute_shell_command |
| src-tauri/src/lib.rs | Register shell module and command |
| src/lib/tools/definitions.ts | Add execute_command to FILE_TOOLS |
| src/lib/tools/executor.ts | Add execution handler + requestShellApproval() |
| src/components/shell/ShellApproval.tsx | Approval dialog component |
| src/components/shell/ShellApproval.css | Approval dialog styles |
| src/App.tsx | Register ShellApproval component |

## Test plan

- [ ] cargo check passes (verified)
- [ ] pnpm biome check passes on modified files (verified)
- [ ] pnpm tauri dev -- send kill npm run dev in chat, verify approval dialog appears
- [ ] Approve command -- verify process is killed and stdout/stderr returned
- [ ] Deny command -- verify model receives Command was not approved by user error
- [ ] Timeout test -- send a long-running command, verify 30s timeout triggers
- [ ] Verify approval dialog shows correct command text and warning

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com