### PR TITLE
fix: add visual feedback and logging to updater button

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -86,6 +86,23 @@ export const Header: Component<HeaderProps> = (props) => {
               </span>
             </button>
           </Show>
+          <Show when={updaterStore.state.status === "installing"}>
+            <span class="flex items-center gap-1.5 py-1 px-2.5 text-[12px] font-medium text-blue-400">
+              <span class="leading-none animate-spin inline-block">⟳</span>
+              <span class="leading-none">Updating...</span>
+            </span>
+          </Show>
+          <Show when={updaterStore.state.status === "error"}>
+            <button
+              type="button"
+              class="flex items-center gap-1.5 py-1 px-2.5 text-[12px] font-medium text-white bg-red-700 border-none rounded cursor-pointer transition-all duration-100 hover:bg-red-600"
+              onClick={() => updaterStore.checkForUpdates(true)}
+              title={updaterStore.state.error ?? "Update failed"}
+            >
+              <span class="leading-none">⚠</span>
+              <span class="leading-none">Update failed — retry</span>
+            </button>
+          </Show>
           <BalanceDisplay />
           {props.onLogout && (
             <button


### PR DESCRIPTION
## Summary
- The update button in the header silently swallowed errors — `downloadAndInstall()` failures reset status back to `"available"` with no UI indication, making it appear as if nothing happened on click
- Added "Updating..." spinner during install, red "Update failed — retry" button for error state (with error tooltip), and console logging throughout the updater lifecycle
- Error state now surfaces properly instead of being hidden behind the same green button

## Test plan
- [ ] Click the update button and verify "Updating..." spinner appears
- [ ] If install fails, verify red "Update failed — retry" button appears with error in tooltip
- [ ] Check browser console for `[Updater]` log messages showing download progress
- [ ] Verify retry button triggers a fresh update check

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com