### PR TITLE
debug: add logging to trace editor file loading flow

### DIFF
--- a/src/components/editor/EditorPanel.tsx
+++ b/src/components/editor/EditorPanel.tsx
@@ -138,13 +138,23 @@ export const EditorPanel: Component = () => {
   createEffect(() => {
     const activeId = tabsState.activeTabId;
     const activeTab = tabsState.tabs.find((tab) => tab.id === activeId);
+    console.log("[EditorPanel] Sync effect triggered:", {
+      activeId,
+      activeTab: activeTab ? {
+        id: activeTab.id,
+        filePath: activeTab.filePath,
+        contentLength: activeTab.content.length
+      } : null
+    });
     if (activeTab) {
       setActiveFilePath(activeTab.filePath);
       setEditorContent(activeTab.content);
       setSelectedPath(activeTab.filePath);
+      console.log("[EditorPanel] Editor content set, first 100 chars:", activeTab.content.substring(0, 100));
     } else {
       setActiveFilePath(null);
       setEditorContent("");
+      console.log("[EditorPanel] No active tab, cleared editor");
     }
   });
 
@@ -160,10 +170,12 @@ export const EditorPanel: Component = () => {
   }
 
   async function handleFileSelect(path: string) {
+    console.log("[EditorPanel] handleFileSelect called with:", path);
     try {
       await openFileInTab(path);
+      console.log("[EditorPanel] File opened successfully");
     } catch (error) {
-      console.error("Failed to open file:", error);
+      console.error("[EditorPanel] Failed to open file:", error);
     }
   }
 

--- a/src/lib/files/service.ts
+++ b/src/lib/files/service.ts
@@ -132,8 +132,11 @@ function entriesToNodes(entries: FileEntry[]): FileNode[] {
  * Open a file in a tab.
  */
 export async function openFileInTab(path: string): Promise<void> {
+  console.log("[openFileInTab] Opening file:", path);
   const content = await readFile(path);
-  openTab(path, content);
+  console.log("[openFileInTab] Read content length:", content.length);
+  const tabId = openTab(path, content);
+  console.log("[openFileInTab] Opened tab:", tabId);
 }
 
 /**

--- a/src/stores/tabs.ts
+++ b/src/stores/tabs.ts
@@ -22,8 +22,10 @@ const [tabsState, setTabsState] = createStore<TabsState>({
  * Open a file in a new tab or focus existing tab.
  */
 export function openTab(filePath: string, content: string = ""): string {
+  console.log("[openTab] Called with:", { filePath, contentLength: content.length });
   const existing = tabsState.tabs.find((t) => t.filePath === filePath);
   if (existing) {
+    console.log("[openTab] Tab already exists, focusing:", existing.id);
     setTabsState("activeTabId", existing.id);
     return existing.id;
   }
@@ -36,6 +38,7 @@ export function openTab(filePath: string, content: string = ""): string {
     { id, filePath, fileName, isDirty: false, content },
   ]);
   setTabsState("activeTabId", id);
+  console.log("[openTab] Created new tab:", { id, fileName, contentLength: content.length });
 
   return id;
 }


### PR DESCRIPTION
## Summary
- Added comprehensive `[EditorPanel]`, `[openFileInTab]`, and `[openTab]` console logging to trace the file loading pipeline
- Logs cover: file selection, content read, tab creation/focus, and editor content sync
- Helps diagnose issues where files fail to load or display in the editor

## Test plan
- [ ] Open a file in the editor and verify `[EditorPanel]` / `[openFileInTab]` / `[openTab]` logs appear in console
- [ ] Verify file content loads correctly in the editor
- [ ] Open an already-open file and verify "Tab already exists, focusing" log appears

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com