### PR TITLE
fix: persist prompt cost and duration in message metadata

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -331,6 +331,7 @@ impl ChatModelWorker {
                             Some(accumulated_thinking.clone())
                         };
                         let cost = if accumulated_cost > 0.0 { Some(accumulated_cost) } else { None };
+                        log::debug!("[ChatModelWorker] Stream complete — accumulated_cost={}, sending cost={:?}", accumulated_cost, cost);
                         event_tx
                             .send(WorkerEvent::Complete {
                                 final_content: accumulated_content.clone(),
@@ -492,6 +493,7 @@ impl ChatModelWorker {
                 Some(accumulated_thinking)
             };
             let cost = if accumulated_cost > 0.0 { Some(accumulated_cost) } else { None };
+            log::debug!("[ChatModelWorker] Final complete — accumulated_cost={}, sending cost={:?}", accumulated_cost, cost);
             event_tx
                 .send(WorkerEvent::Complete {
                     final_content: accumulated_content,

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -364,6 +364,12 @@ function handleComplete(
 
   const duration = Date.now() - streamStartTime;
 
+  console.debug(
+    "[orchestrator] complete — duration=%dms, cost=%s",
+    duration,
+    cost != null ? `$${cost}` : "none",
+  );
+
   // Use accumulated streaming content or fall back to final_content
   const content = conversationStore.streamingContent || finalContent;
   const thinkingContent =

--- a/src/stores/conversation.store.ts
+++ b/src/stores/conversation.store.ts
@@ -308,6 +308,8 @@ export const conversationStore = {
               workerType: metaFields.workerType ?? "chat_model",
               modelId: metaFields.modelId ?? m.model ?? undefined,
               taskType: metaFields.taskType,
+              duration: metaFields.duration,
+              cost: metaFields.cost,
               toolCall: metaFields.toolCall,
               diff: metaFields.diff,
             };

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -88,6 +88,8 @@ export interface MessageMetadata {
   worker_type?: WorkerType | null;
   model_id?: string | null;
   task_type?: string | null;
+  duration?: number | null;
+  cost?: number | null;
   tool_call?: {
     id: string;
     name: string;
@@ -107,7 +109,9 @@ export function serializeMetadata(msg: UnifiedMessage): string | null {
     !msg.modelId &&
     !msg.taskType &&
     !msg.toolCall &&
-    !msg.diff
+    !msg.diff &&
+    !msg.duration &&
+    !msg.cost
   ) {
     return null;
   }
@@ -116,6 +120,8 @@ export function serializeMetadata(msg: UnifiedMessage): string | null {
     worker_type: msg.workerType ?? null,
     model_id: msg.modelId ?? null,
     task_type: msg.taskType ?? null,
+    duration: msg.duration ?? null,
+    cost: msg.cost ?? null,
     tool_call: msg.toolCall
       ? {
           id: msg.toolCall.toolCallId,
@@ -150,6 +156,9 @@ export function deserializeMetadata(
     if (meta.worker_type) result.workerType = meta.worker_type as WorkerType;
     if (meta.model_id) result.modelId = meta.model_id as string;
     if (meta.task_type) result.taskType = meta.task_type as string;
+    if (typeof meta.duration === "number" && meta.duration > 0)
+      result.duration = meta.duration;
+    if (typeof meta.cost === "number" && meta.cost > 0) result.cost = meta.cost;
     if (meta.tool_call && typeof meta.tool_call === "object") {
       const tc = meta.tool_call as Record<string, string>;
       result.toolCall = {


### PR DESCRIPTION
## Summary

Closes #479

- Add `cost` and `duration` fields to `MessageMetadata` serialization/deserialization so prompt costs survive page reloads and conversation switches
- Restore `cost` and `duration` in `loadHistory()` when reconstructing messages from the database
- Add debug logging in both Rust (`ChatModelWorker`) and TypeScript (`orchestrator.ts`) to trace whether the Gateway is delivering cost data — this will help diagnose whether live-session cost display issues are a Gateway-side or client-side problem

## Test plan

- [x] All 105 frontend tests pass (including 4 new cost/duration metadata round-trip tests)
- [x] All 213 Rust tests pass
- [x] Biome lint/format clean (no new warnings)
- [ ] Manual: send a prompt, verify cost appears next to duration (e.g. "Reasoned for 2s at $0.003")
- [ ] Manual: reload the page, verify cost still displays on historical messages
- [ ] Manual: check browser console for `[orchestrator] complete` debug log showing cost value
- [ ] Manual: check Rust logs for `[ChatModelWorker] Stream complete` with accumulated cost

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com