### PR TITLE
feat(orchestrator): auto-reroute to satisfaction-ranked model on 408/timeout

### DIFF
--- a/src-tauri/src/orchestrator/types.rs
+++ b/src-tauri/src/orchestrator/types.rs
@@ -69,6 +69,12 @@ pub enum WorkerEvent {
     Error {
         message: String,
     },
+    /// Emitted when a request is rerouted to a different model after a transient error.
+    Reroute {
+        from_model: String,
+        to_model: String,
+        reason: String,
+    },
 }
 
 /// Routing decision made by the orchestrator.
@@ -261,6 +267,17 @@ mod tests {
         let json = serde_json::to_value(&error).unwrap();
         assert_eq!(json["type"], "error");
         assert_eq!(json["message"], "oops");
+
+        let reroute = WorkerEvent::Reroute {
+            from_model: "moonshot/kimi-k2.5".to_string(),
+            to_model: "anthropic/claude-sonnet-4".to_string(),
+            reason: "Rerouted to Claude Sonnet (rated helpful for research)".to_string(),
+        };
+        let json = serde_json::to_value(&reroute).unwrap();
+        assert_eq!(json["type"], "reroute");
+        assert_eq!(json["from_model"], "moonshot/kimi-k2.5");
+        assert_eq!(json["to_model"], "anthropic/claude-sonnet-4");
+        assert!(json["reason"].as_str().unwrap().contains("Claude Sonnet"));
     }
 
     #[test]

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -47,6 +47,7 @@ import { ImageAttachmentBar } from "./ImageAttachmentBar";
 import { MessageImages } from "./MessageImages";
 import { ModelSelector } from "./ModelSelector";
 import { PublisherSuggestions } from "./PublisherSuggestions";
+import { RerouteAnnouncement } from "./RerouteAnnouncement";
 import { SatisfactionSignal } from "./SatisfactionSignal";
 import { SlashCommandPopup } from "./SlashCommandPopup";
 import { ThinkingStatus } from "./ThinkingStatus";
@@ -673,8 +674,16 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
             <For each={conversationStore.messages}>
               {(message) => (
                 <Show
-                  when={message.type !== "transition"}
-                  fallback={<TransitionAnnouncement message={message} />}
+                  when={
+                    message.type !== "transition" && message.type !== "reroute"
+                  }
+                  fallback={
+                    message.type === "reroute" ? (
+                      <RerouteAnnouncement message={message} />
+                    ) : (
+                      <TransitionAnnouncement message={message} />
+                    )
+                  }
                 >
                   <article
                     class={`group/msg px-5 py-4 border-b border-[#21262d] last:border-b-0 ${message.role === "user" ? "bg-[#161b22]" : "bg-transparent"}`}

--- a/src/components/chat/RerouteAnnouncement.css
+++ b/src/components/chat/RerouteAnnouncement.css
@@ -1,0 +1,34 @@
+/* ABOUTME: Styles for the reroute announcement inline message. */
+/* ABOUTME: Amber indicator when the orchestrator reroutes to a different model. */
+
+.reroute-announcement {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-left: 2px solid #d29922;
+  color: #d29922;
+  font-size: 12px;
+  line-height: 1.4;
+  animation: reroute-fade-in 0.3s ease-in;
+}
+
+.reroute-announcement__label {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.reroute-announcement__reason {
+  color: #8b949e;
+}
+
+@keyframes reroute-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/components/chat/RerouteAnnouncement.tsx
+++ b/src/components/chat/RerouteAnnouncement.tsx
@@ -1,0 +1,21 @@
+// ABOUTME: Inline announcement when the orchestrator reroutes to a different model.
+// ABOUTME: Renders a UnifiedMessage of type "reroute" with amber styling.
+
+import type { Component } from "solid-js";
+import type { UnifiedMessage } from "@/types/conversation";
+import "./RerouteAnnouncement.css";
+
+interface RerouteAnnouncementProps {
+  message: UnifiedMessage;
+}
+
+export const RerouteAnnouncement: Component<RerouteAnnouncementProps> = (
+  props,
+) => {
+  return (
+    <div class="reroute-announcement">
+      <span class="reroute-announcement__label">Rerouted</span>
+      <span class="reroute-announcement__reason">{props.message.content}</span>
+    </div>
+  );
+};

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -56,7 +56,13 @@ type WorkerEvent =
       thinking: string | null;
       cost?: number;
     }
-  | { type: "error"; message: string };
+  | { type: "error"; message: string }
+  | {
+      type: "reroute";
+      from_model: string;
+      to_model: string;
+      reason: string;
+    };
 
 /** Capabilities payload sent to the Rust orchestrator. */
 interface UserCapabilities {
@@ -241,6 +247,9 @@ function handleWorkerEvent(event: OrchestratorEvent): void {
     case "error":
       handleError(workerEvent.message);
       break;
+    case "reroute":
+      handleReroute(workerEvent);
+      break;
   }
 }
 
@@ -406,6 +415,34 @@ function handleError(message: string): void {
   }
 }
 
+function handleReroute(event: {
+  from_model: string;
+  to_model: string;
+  reason: string;
+}): void {
+  // Flush any partial streaming content from the failed model
+  flushStreamingToMessage();
+
+  // Reset streaming state for the new model attempt
+  activeMessageId = crypto.randomUUID();
+  streamStartTime = Date.now();
+
+  // Add a reroute announcement message to the conversation
+  const rerouteMessage: UnifiedMessage = {
+    id: crypto.randomUUID(),
+    type: "reroute",
+    role: "system",
+    content: event.reason,
+    timestamp: Date.now(),
+    status: "complete",
+    workerType: "orchestrator",
+    modelId: event.to_model,
+    error: event.from_model,
+  };
+
+  conversationStore.addMessage(rerouteMessage);
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -451,6 +488,7 @@ function serializeHistory(
       (m) =>
         (m.role === "user" || m.role === "assistant") &&
         m.type !== "transition" &&
+        m.type !== "reroute" &&
         m.type !== "tool_call" &&
         m.type !== "tool_result" &&
         m.type !== "diff" &&

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -19,6 +19,7 @@ export type MessageType =
   | "diff"
   | "thought"
   | "transition"
+  | "reroute"
   | "error";
 
 export type MessageStatus = "pending" | "streaming" | "complete" | "error";
@@ -182,7 +183,11 @@ export function isToolMessage(msg: UnifiedMessage): boolean {
 
 /** Type guard: is this message from the orchestrator itself? */
 export function isOrchestratorMessage(msg: UnifiedMessage): boolean {
-  return msg.type === "transition" || msg.workerType === "orchestrator";
+  return (
+    msg.type === "transition" ||
+    msg.type === "reroute" ||
+    msg.workerType === "orchestrator"
+  );
 }
 
 /** Temporary adapter: convert legacy Message to UnifiedMessage during migration. */


### PR DESCRIPTION
## Summary

- When a model returns HTTP 408/429/5xx during orchestration, automatically reroute to a different model ranked by user satisfaction signals
- Query `eval_signals` table for models with positive feedback for the current task type, falling back to hardcoded preference lists
- Display amber-styled **RerouteAnnouncement** inline in chat so users see exactly when and why a model switch happened
- Respect user explicit model selection (no reroute when user picked a specific model)
- Max 2 reroute attempts before showing the final error

## Changes

### Rust Backend
- **types.rs**: Add `WorkerEvent::Reroute { from_model, to_model, reason }` variant
- **router.rs**: Add `is_reroutable_error()`, `reroute_on_failure()`, and `query_satisfaction_ranked_models()` - queries eval_signals for satisfaction-ranked fallback models
- **service.rs**: Wrap `execute_single_task` in a reroute loop that catches transient errors and retries with a different model

### Frontend
- **orchestrator.ts**: Handle `reroute` WorkerEvent, flush partial streaming content, reset streaming state for new model
- **conversation.ts**: Add `reroute` to `MessageType` union
- **RerouteAnnouncement.tsx/.css**: New component with amber border-left styling (distinct from blue transition announcements)
- **ChatContent.tsx**: Render reroute messages inline alongside transitions

## Test plan

- [x] All 156 Rust orchestrator tests pass (including 7 new reroute tests)
- [x] Biome lint/format clean on all changed files
- [ ] Manual test: trigger a 408 on a model and verify reroute announcement appears
- [ ] Manual test: explicitly select a model, trigger 408, verify NO reroute (same-model retry)
- [ ] Manual test: verify satisfaction signals influence fallback order after thumbs-up feedback

Closes #480

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
