### PR TITLE
fix: restore ResizableTextarea to chat input box

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -14,6 +14,7 @@ import {
 } from "solid-js";
 import { SignIn } from "@/components/auth/SignIn";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
+import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { isAuthError } from "@/lib/auth-errors";
 import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
@@ -888,7 +889,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                   setCommandPopupIndex(0);
                 }}
               />
-              <textarea
+              <ResizableTextarea
                 ref={(el) => {
                   inputRef = el;
                   console.log(
@@ -904,7 +905,9 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                     ? "Type to queue message..."
                     : "Ask Seren anything… (type / for commands)"
                 }
-                class="w-full min-h-[72px] max-h-[50vh] resize-y bg-[#0d1117] border border-[#30363d] rounded-xl text-[#e6edf3] px-3.5 py-3 font-inherit text-[14px] leading-normal transition-all focus:outline-none focus:border-[#58a6ff] focus:shadow-[0_0_0_3px_rgba(88,166,255,0.15)] placeholder:text-[#484f58]"
+                class="w-full bg-[#0d1117] border border-[#30363d] rounded-xl text-[#e6edf3] px-3.5 py-3 font-inherit text-[14px] leading-normal transition-all focus:outline-none focus:border-[#58a6ff] focus:shadow-[0_0_0_3px_rgba(88,166,255,0.15)] placeholder:text-[#484f58]"
+                minHeight={72}
+                maxHeight={window.innerHeight * 0.5}
                 onInput={(event) => {
                   setInput(event.currentTarget.value);
                   setCommandPopupIndex(0);


### PR DESCRIPTION
## Summary

- The chat input lost its `ResizableTextarea` drag handle when `ChatPanel.tsx` was replaced by `ChatContent.tsx` during the orchestrator migration (`082ab14`)
- Swaps the plain `<textarea>` in `ChatContent.tsx` back to `ResizableTextarea`, matching the agent input box behavior
- Both chat and agent input boxes now have the same visible drag-to-resize handle

## Root Cause

In commit `dbdff4e`, `ResizableTextarea` was applied to both `ChatPanel.tsx` and `AgentChat.tsx`. When `ChatPanel.tsx` was deleted and superseded by `ChatContent.tsx` in `082ab14`, the new component used a plain `<textarea>` instead of `ResizableTextarea` — a regression.

## Test plan

- [ ] Open Chat mode — verify the resize drag handle (chevron icon) appears above the input
- [ ] Drag the handle to resize the chat input vertically
- [ ] Switch to Agent mode — confirm both input boxes have identical resize behavior
- [ ] Verify slash command popup still works in chat input
- [ ] Verify Up/Down arrow history navigation still works

Closes #487

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com