### PR TITLE
fix: auth token refresh fallback and wallet refresh loop (#484, #485)

### DIFF
--- a/src/services/wallet.ts
+++ b/src/services/wallet.ts
@@ -37,7 +37,13 @@ export async function fetchBalance() {
 
   if (error) {
     console.error("[Wallet] Error fetching balance:", error);
-    throw new Error("Failed to fetch balance");
+    const detail =
+      typeof error === "object" && error !== null
+        ? (error as Record<string, unknown>).message ||
+          (error as Record<string, unknown>).statusText ||
+          JSON.stringify(error)
+        : String(error);
+    throw new Error(`Failed to fetch balance: ${detail}`);
   }
 
   if (!data?.data) {


### PR DESCRIPTION
## Summary

- **Orchestrator auth fix (#484)**: When the access token is missing from the store (cleared after failed refresh), `authenticated_request()` now attempts `refresh_access_token()` before giving up. Previously it would fail immediately with "No access token in store" even when a refresh token was still available.

- **Wallet refresh loop fix (#485)**: The wallet service now propagates actual error details (status, message) instead of wrapping everything in a generic "Failed to fetch balance". The wallet store adds `"Unauthorized"` to the auth-error keyword list and stops auto-refresh after 5 consecutive failures as a safety net.

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/auth.rs` | `authenticated_request()` falls back to refresh when no access token |
| `src/services/wallet.ts` | `fetchBalance()` includes error details in thrown message |
| `src/stores/wallet.store.ts` | Consecutive failure counter + "Unauthorized" keyword match |

## Test plan

- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Verify `cargo test -- chat_model_worker` passes (24/24 confirmed locally)
- [ ] Verify `biome check` passes on changed files (confirmed locally)
- [ ] Manual test: log in, let token expire, confirm orchestrator recovers via refresh
- [ ] Manual test: disconnect network, confirm wallet stops retrying after 5 failures

Closes #484, closes #485

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com