### PR TITLE
fix: add /login slash command and detect access auth errors

### DIFF
--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -18,6 +18,8 @@ const AUTH_ERROR_PATTERNS = [
   /please obtain a new token/i,
   /refresh your existing token/i,
   /please sign in/i,
+  /does not have access/i,
+  /please login again/i,
 ];
 
 /**

--- a/src/lib/commands/registry.ts
+++ b/src/lib/commands/registry.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Commands are organized by tier and registered at module load.
 
 import { acpStore } from "@/stores/acp.store";
+import { promptLogin } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
 import { providerStore } from "@/stores/provider.store";
@@ -152,6 +153,18 @@ registry.register({
     window.dispatchEvent(new CustomEvent("seren:open-deposit"));
     ctx.clearInput();
     ctx.showStatus("Opening deposit...");
+    return true;
+  },
+});
+
+registry.register({
+  name: "login",
+  description: "Sign in to your account",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    promptLogin();
+    ctx.clearInput();
+    ctx.showStatus("Opening sign in...");
     return true;
   },
 });

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -23,7 +23,9 @@ function isAuthError(msg: string): boolean {
     /please obtain a new token/i.test(msg) ||
     /refresh your existing token/i.test(msg) ||
     /login required/i.test(msg) ||
-    /not logged in/i.test(msg)
+    /not logged in/i.test(msg) ||
+    /does not have access/i.test(msg) ||
+    /please login again/i.test(msg)
   );
 }
 

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -166,11 +166,19 @@ export async function logout(): Promise<void> {
   });
 }
 
+/**
+ * Show the sign-in prompt by clearing authentication state.
+ * Used by the /login slash command and session-expired events.
+ */
+export function promptLogin(): void {
+  setState({ isAuthenticated: false, user: null });
+}
+
 // Listen for session-expired events from Rust backend (e.g. both tokens dead).
 // Sets isAuthenticated = false so the UI shows the sign-in prompt.
 listen("auth:session-expired", () => {
   console.warn("[Auth Store] Session expired event from backend");
-  setState({ isAuthenticated: false, user: null });
+  promptLogin();
 });
 
 export const authStore = state;


### PR DESCRIPTION
## Summary
- Adds `/login` slash command to the command registry (available in both chat and agent panels) so users can re-authenticate from the chat input
- Adds `promptLogin()` export to auth store, reused by both the slash command and the existing session-expired listener
- Adds two missing auth error patterns (`does not have access`, `please login again`) to both `auth-errors.ts` and `acp.store.ts` so the Login button UI appears automatically when the agent returns these errors

Closes #489

## Test plan
- [ ] Type `/login` in chat input — should appear in autocomplete and trigger sign-in screen
- [ ] Type `/login` in agent input — same behavior
- [ ] Simulate an error containing 'does not have access to Claude' — Login button should appear
- [ ] Simulate an error containing 'please login again' — Login button should appear
- [ ] Verify `/help` lists the new `/login` command

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com