### PR TITLE
fix: resolve updater failures from macOS artifact collision (#493)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -490,6 +490,37 @@ jobs:
           name: Seren-Desktop-${{ matrix.name }}.AppImage
           path: src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
 
+      # Rename macOS updater artifacts to include architecture so both can coexist
+      # in the same GitHub release (both aarch64 and x86_64 generate "SerenDesktop.app.tar.gz")
+      - name: Rename macOS updater artifacts per architecture
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          BUNDLE_DIR="src-tauri/target/${{ matrix.target }}/release/bundle/macos"
+          if [ ! -d "$BUNDLE_DIR" ]; then
+            echo "No macos bundle directory found"
+            exit 0
+          fi
+
+          case "${{ matrix.target }}" in
+            aarch64-apple-darwin) ARCH="aarch64" ;;
+            x86_64-apple-darwin) ARCH="x64" ;;
+            *) echo "Unknown macOS target: ${{ matrix.target }}"; exit 1 ;;
+          esac
+
+          if [ -f "$BUNDLE_DIR/SerenDesktop.app.tar.gz" ]; then
+            mv "$BUNDLE_DIR/SerenDesktop.app.tar.gz" "$BUNDLE_DIR/SerenDesktop_${ARCH}.app.tar.gz"
+            echo "Renamed: SerenDesktop.app.tar.gz -> SerenDesktop_${ARCH}.app.tar.gz"
+          fi
+
+          if [ -f "$BUNDLE_DIR/SerenDesktop.app.tar.gz.sig" ]; then
+            mv "$BUNDLE_DIR/SerenDesktop.app.tar.gz.sig" "$BUNDLE_DIR/SerenDesktop_${ARCH}.app.tar.gz.sig"
+            echo "Renamed: SerenDesktop.app.tar.gz.sig -> SerenDesktop_${ARCH}.app.tar.gz.sig"
+          fi
+
+          echo "Files in $BUNDLE_DIR:"
+          ls -la "$BUNDLE_DIR/" || true
+
       # Upload updater artifacts (tar.gz/zip bundles + signatures)
       - name: Upload macOS updater bundle
         if: matrix.os == 'macos-latest'
@@ -619,7 +650,7 @@ jobs:
             });
             const existingNames = new Set(existingAssets.data.map(a => a.name));
 
-            // Upload all artifact files
+            // Upload all artifact files (track names to prevent duplicates within this run)
             const uploadAsset = async (filePath, fileName) => {
               if (existingNames.has(fileName)) {
                 console.log(`Skipping ${fileName} - already exists`);
@@ -633,6 +664,7 @@ jobs:
                 name: fileName,
                 data: content
               });
+              existingNames.add(fileName);
             };
 
             // Walk through artifacts directory

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5898,6 +5898,7 @@ dependencies = [
  "tauri-plugin-http",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-store",
  "tauri-plugin-updater",
@@ -6692,6 +6693,16 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 tauri-plugin-http = "2"
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:window:default",
     "dialog:default",
     "updater:default",
+    "process:default",
     "log:default",
     {
       "identifier": "opener:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -422,6 +422,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_shell::init());
 


### PR DESCRIPTION
## Summary

Fixes #493 — Auto-updater detects new versions but fails to install on all platforms.

- **macOS architecture collision**: Both `darwin-aarch64` and `darwin-x86_64` generate the same updater filename (`SerenDesktop.app.tar.gz`). The publish step crashed on the duplicate upload, preventing ALL subsequent platform artifacts (including Windows and Linux) from being uploaded. Now renamed per-architecture (`SerenDesktop_aarch64.app.tar.gz` / `SerenDesktop_x64.app.tar.gz`).

- **Missing `tauri-plugin-process`**: `relaunch()` imported from `@tauri-apps/plugin-process` but the Rust crate was never added. Added `tauri-plugin-process = "2"` to Cargo.toml, registered plugin in lib.rs, and added `process:default` capability.

- **Duplicate asset tracking**: The publish script only checked pre-existing release assets, not assets uploaded during the current run. Now tracks uploaded names to skip duplicates gracefully.

## Test plan

- [ ] Tag a new release and verify CI completes without `already_exists` error
- [ ] Verify `latest.json` has unique URLs for `darwin-aarch64` and `darwin-x86_64`
- [ ] Verify Windows (`.nsis.zip`) and Linux (`.AppImage.tar.gz`) updater artifacts appear in release
- [ ] Click "Update" button on macOS x86_64 — should download, install, and relaunch
- [ ] Click "Update" button on macOS aarch64 — same
- [ ] Verify `relaunch()` works after install (process plugin registered)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com