### PR TITLE
fix: deduplicate cancel alerts, clear Running status, flush queue on cancel

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -270,6 +270,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   });
 
   const handleCancel = async () => {
+    // Clear queued messages so they don't auto-send after cancellation
+    setMessageQueue([]);
     await acpStore.cancelPrompt();
   };
 


### PR DESCRIPTION
## Summary

Fixes #495 — Agent cancel shows duplicate error banners and tool cards stuck on Running.

Three-part fix for agent cancellation UX bugs:

- **Error event handler**: call `finalizeStreamingContent()` and `markPendingToolCallsComplete()` on error events so tool cards stop spinning. For user-initiated cancellation ("Task cancelled"), record in chat history but skip the persistent error banner since cancellation is not a real error.
- **sendPrompt catch**: skip `addErrorMessage` for "Task cancelled" since the error event already recorded it — prevents duplicate inline banners.
- **AgentChat handleCancel**: clear the message queue immediately so queued messages don't auto-send after cancellation triggers a "ready" status transition.

## Test plan

- [ ] Start agent session, send a prompt that triggers tool calls, cancel while running — verify ONE cancellation message appears (not 3+)
- [ ] Verify tool cards show "Completed" (not "Running") after cancel
- [ ] Queue a message while agent is running, then cancel — verify queued message does NOT auto-send
- [ ] Verify non-cancel errors (e.g. auth errors) still show persistent error banner with Dismiss button
- [ ] Verify normal prompt completion still works correctly (tool cards complete, streaming finalizes)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
