### PR TITLE
feat: agent permission mode selector for Codex sessions

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -1536,6 +1536,20 @@ async fn run_session_worker(
         })
     });
 
+    // Extract mode state from session response (if agent supports mode selection)
+    let modes_json = new_session_response.modes.as_ref().map(|m| {
+        serde_json::json!({
+            "currentModeId": &*m.current_mode_id.0,
+            "availableModes": m.available_modes.iter().map(|mode| {
+                serde_json::json!({
+                    "modeId": &*mode.id.0,
+                    "name": &mode.name,
+                    "description": &mode.description,
+                })
+            }).collect::<Vec<_>>()
+        })
+    });
+
     let emit_result = app.emit(
         events::SESSION_STATUS,
         serde_json::json!({
@@ -1545,10 +1559,42 @@ async fn run_session_worker(
                 "name": agent_info.map(|i| i.name.as_str()).unwrap_or("Unknown"),
                 "version": agent_info.map(|i| i.version.as_str()).unwrap_or("Unknown")
             },
-            "models": models_json
+            "models": models_json,
+            "modes": modes_json
         }),
     );
     log::debug!("[ACP] Emit result: {:?}", emit_result);
+
+    // Auto-set the user's preferred permission mode if the agent advertises modes.
+    // Map Seren sandbox mode names to agent mode IDs by matching name patterns.
+    if let Some(mode_state) = &new_session_response.modes {
+        let preferred = match sandbox_mode {
+            crate::sandbox::SandboxMode::ReadOnly => "read",
+            crate::sandbox::SandboxMode::WorkspaceWrite => "default",
+            crate::sandbox::SandboxMode::FullAccess => "full",
+        };
+
+        let target_mode = mode_state
+            .available_modes
+            .iter()
+            .find(|m| m.name.to_lowercase().contains(preferred))
+            .map(|m| m.id.clone());
+
+        if let Some(mode_id) = target_mode {
+            if mode_id != mode_state.current_mode_id {
+                log::info!(
+                    "[ACP] Auto-setting mode to {:?} (user preference: {:?})",
+                    &*mode_id.0,
+                    preferred
+                );
+                let request = SetSessionModeRequest::new(agent_session_id.clone(), mode_id);
+                match connection.set_session_mode(request).await {
+                    Ok(_) => log::info!("[ACP] Mode set successfully"),
+                    Err(e) => log::warn!("[ACP] Failed to auto-set mode: {:?}", e),
+                }
+            }
+        }
+    }
 
     // Command processing loop
     while let Some(cmd) = command_rx.recv().await {

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -29,6 +29,7 @@ import { type AgentMessage, acpStore } from "@/stores/acp.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { settingsStore } from "@/stores/settings.store";
 import { AgentModelSelector } from "./AgentModelSelector";
+import { AgentModeSelector } from "./AgentModeSelector";
 import { AgentSelector } from "./AgentSelector";
 import { AgentTabBar } from "./AgentTabBar";
 import { DiffCard } from "./DiffCard";
@@ -851,6 +852,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               <div class="flex items-center gap-3">
                 <AgentSelector />
                 <AgentModelSelector />
+                <AgentModeSelector />
                 <Show when={isPrompting()}>
                   <ThinkingStatus />
                 </Show>

--- a/src/components/chat/AgentModeSelector.tsx
+++ b/src/components/chat/AgentModeSelector.tsx
@@ -1,0 +1,132 @@
+// ABOUTME: Dropdown component for selecting the permission mode in an agent session.
+// ABOUTME: Shows available modes reported by the ACP agent and sends set_mode commands.
+
+import type { Component } from "solid-js";
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { acpStore } from "@/stores/acp.store";
+
+export const AgentModeSelector: Component = () => {
+  const [isOpen, setIsOpen] = createSignal(false);
+  let dropdownRef: HTMLDivElement | undefined;
+
+  const availableModes = () => acpStore.activeSession?.availableModes ?? [];
+  const currentModeId = () => acpStore.activeSession?.currentModeId;
+
+  const currentModeName = () => {
+    const id = currentModeId();
+    if (!id) return null;
+    const mode = availableModes().find((m) => m.modeId === id);
+    return mode?.name ?? id;
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (dropdownRef && !dropdownRef.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
+  onMount(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener("mousedown", handleClickOutside);
+  });
+
+  const selectMode = (modeId: string) => {
+    acpStore.setPermissionMode(modeId);
+    setIsOpen(false);
+  };
+
+  return (
+    <Show when={availableModes().length > 0}>
+      <div class="relative" ref={dropdownRef}>
+        <button
+          type="button"
+          class="flex items-center gap-1.5 px-2 py-1 bg-[#21262d] border border-[#30363d] rounded-md text-xs text-[#e6edf3] cursor-pointer hover:bg-[#30363d] transition-colors"
+          onClick={() => setIsOpen(!isOpen())}
+          title="Change permission mode"
+        >
+          <svg
+            class="w-3 h-3 text-[#8b949e]"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            role="img"
+            aria-label="Mode"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+            />
+          </svg>
+          <span class="font-medium max-w-[120px] truncate">
+            {currentModeName() ?? "Mode"}
+          </span>
+          <svg
+            class={`w-3 h-3 text-[#8b949e] transition-transform ${isOpen() ? "rotate-180" : ""}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            role="img"
+            aria-label="Toggle dropdown"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+
+        <Show when={isOpen()}>
+          <div class="absolute bottom-full left-0 mb-1 w-72 bg-[#161b22] border border-[#30363d] rounded-lg shadow-lg z-50 overflow-hidden">
+            <div class="px-3 py-2 border-b border-[#21262d] text-[10px] uppercase tracking-wider text-[#8b949e] font-medium">
+              Permission Mode
+            </div>
+            <For each={availableModes()}>
+              {(mode) => (
+                <button
+                  type="button"
+                  class={`w-full text-left px-3 py-2 border-b border-[#21262d] last:border-b-0 transition-colors cursor-pointer hover:bg-[#21262d] ${
+                    mode.modeId === currentModeId() ? "bg-[#21262d]" : ""
+                  }`}
+                  onClick={() => selectMode(mode.modeId)}
+                >
+                  <div class="flex items-center justify-between">
+                    <div class="flex flex-col gap-0.5">
+                      <span class="text-sm text-[#e6edf3]">{mode.name}</span>
+                      <Show when={mode.description}>
+                        <span class="text-[11px] text-[#8b949e]">
+                          {mode.description}
+                        </span>
+                      </Show>
+                    </div>
+                    <Show when={mode.modeId === currentModeId()}>
+                      <svg
+                        class="w-4 h-4 text-green-500 flex-shrink-0 ml-2"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                        role="img"
+                        aria-label="Selected"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clip-rule="evenodd"
+                        />
+                      </svg>
+                    </Show>
+                  </div>
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </Show>
+  );
+};

--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -107,6 +107,14 @@ export interface SessionStatusEvent {
     currentModelId: string;
     availableModels: Array<{ modelId: string; name: string }>;
   };
+  modes?: {
+    currentModeId: string;
+    availableModes: Array<{
+      modeId: string;
+      name: string;
+      description?: string;
+    }>;
+  };
 }
 
 export interface DiffProposalEvent {


### PR DESCRIPTION
## Summary
- Reads `NewSessionResponse.modes` from ACP protocol (previously ignored entirely)
- Auto-sets preferred mode on session creation based on Seren sandbox setting (Read Only → read, Workspace Write → default, Full Access → full)
- Adds per-session `AgentModeSelector` dropdown in chat input toolbar (lock icon, mode names + descriptions, green checkmark for current)
- Updates `acp.store.ts` with `currentModeId` / `availableModes` reactive state

Closes #504

## Changes
| File | Change |
|------|--------|
| `src-tauri/src/acp.rs` | Extract modes from `NewSessionResponse`, emit in ready event, auto-set preferred mode via `SetSessionModeRequest` |
| `src/services/acp.ts` | Add `modes` field to `SessionStatusEvent` interface |
| `src/stores/acp.store.ts` | Add `AgentModeInfo`, track `currentModeId`/`availableModes`, update on mode change |
| `src/components/chat/AgentModeSelector.tsx` | New dropdown component (follows `AgentModelSelector` pattern) |
| `src/components/chat/AgentChat.tsx` | Import and render `AgentModeSelector` in input toolbar |

## Test plan
- [ ] Start a Codex agent session — verify mode selector appears next to model selector
- [ ] Verify current mode shows with green checkmark in dropdown
- [ ] Switch between Read Only, Default, Full Access — verify mode changes
- [ ] Verify Seren Settings sandbox mode auto-applies on new session creation
- [ ] Verify selector only appears when agent reports available modes

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com