### PR TITLE
feat: add manual update check to About Seren dialog

### DIFF
--- a/src/components/common/AboutDialog.css
+++ b/src/components/common/AboutDialog.css
@@ -97,3 +97,44 @@
 .about-btn-copy:hover {
   opacity: 0.9;
 }
+
+.about-btn-check-updates {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.about-btn-check-updates:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.about-btn-check-updates:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.about-btn-install-update {
+  background: #238636;
+  color: white;
+  border-color: #238636;
+}
+
+.about-btn-install-update:hover {
+  background: #2ea043;
+}
+
+.about-dialog-small {
+  width: 360px;
+}
+
+.about-content-centered {
+  padding: 0 24px 16px;
+  text-align: center;
+}
+
+.about-content-centered p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--muted-foreground);
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Summary
Adds a "Check for Updates" button to the About Seren dialog that allows users to manually trigger update checks.

## Changes
- Added "Check for Updates" button in About Seren dialog footer
- Integrates with existing `updaterStore.checkForUpdates()` functionality
- Shows "Checking..." state during update check
- Displays "All Up to Date!" dialog when no update is available
- Shows "Install Update" button when an update is detected
- Added CSS styling for new buttons and success dialog

## Testing
1. Open Seren Desktop
2. Click Help → About Seren (or use native About menu item)
3. Click "Check for Updates" button
4. **If on latest version**: Verify "All Up to Date!" dialog appears
5. **If update available**: Verify "Install Update X.X.X" button appears

## Screenshots
Before: Only OK and Copy buttons
After: Includes "Check for Updates" button

## Closes
Closes #505

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com