### PR TITLE
fix: enable orchestrator rerouting with Auto model selector

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -6,6 +6,7 @@ use futures::StreamExt;
 use log;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 
 use super::types::{ImageAttachment, RoutingDecision, WorkerEvent};
@@ -24,7 +25,10 @@ pub struct ChatModelWorker {
 impl ChatModelWorker {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(30))
+                .build()
+                .unwrap_or_default(),
             cancelled: Arc::new(Mutex::new(false)),
         }
     }

--- a/src-tauri/src/orchestrator/mcp_publisher_worker.rs
+++ b/src-tauri/src/orchestrator/mcp_publisher_worker.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use log;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 
 use super::types::{ImageAttachment, RoutingDecision, WorkerEvent};
@@ -21,7 +22,10 @@ pub struct McpPublisherWorker {
 impl McpPublisherWorker {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(30))
+                .build()
+                .unwrap_or_default(),
             cancelled: Arc::new(Mutex::new(false)),
         }
     }

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/lib/providers";
 import { type Model, modelsService } from "@/services/models";
 import { chatStore } from "@/stores/chat.store";
-import { providerStore } from "@/stores/provider.store";
+import { AUTO_MODEL_ID, providerStore } from "@/stores/provider.store";
 
 export const ModelSelector: Component = () => {
   const [isOpen, setIsOpen] = createSignal(false);
@@ -79,8 +79,12 @@ export const ModelSelector: Component = () => {
   });
 
   const currentModel = () => {
-    const models = defaultModels();
     const activeModel = providerStore.activeModel;
+    if (activeModel === AUTO_MODEL_ID) {
+      return { id: AUTO_MODEL_ID, name: "Auto", contextWindow: 0 };
+    }
+
+    const models = defaultModels();
     // First check defaults, then check full OpenRouter list for Seren
     const found = models.find((model) => model.id === activeModel);
     if (found) return found;
@@ -164,10 +168,19 @@ export const ModelSelector: Component = () => {
           }
         }}
       >
-        <span class="inline-flex items-center justify-center w-[18px] h-[18px] bg-accent text-white rounded text-[11px] font-semibold">
-          {getProviderIcon(currentProvider())}
-        </span>
-        <span class="text-foreground">
+        <Show
+          when={providerStore.isAutoModel}
+          fallback={
+            <span class="inline-flex items-center justify-center w-[18px] h-[18px] bg-accent text-white rounded text-[11px] font-semibold">
+              {getProviderIcon(currentProvider())}
+            </span>
+          }
+        >
+          <span class="inline-flex items-center justify-center w-[18px] h-[18px] bg-[#238636] text-white rounded text-[11px] font-semibold">
+            A
+          </span>
+        </Show>
+        <span class={providerStore.isAutoModel ? "text-[#7ee787]" : "text-foreground"}>
           {currentModel()?.name || "Select model"}
         </span>
         <span class="text-[10px] text-muted-foreground">
@@ -235,6 +248,26 @@ export const ModelSelector: Component = () => {
 
           {/* Models for selected provider */}
           <div class="max-h-[300px] overflow-y-auto py-1 bg-[#1e1e1e]">
+            {/* Auto option — only when not searching */}
+            <Show when={!searchQuery()}>
+              <button
+                type="button"
+                class={`w-full flex items-center justify-between gap-2 px-3 py-2 bg-transparent border-none text-left text-[13px] cursor-pointer transition-colors hover:bg-[rgba(148,163,184,0.1)] border-b border-b-[#3c3c3c] ${providerStore.isAutoModel ? "bg-[rgba(34,134,54,0.15)]" : ""}`}
+                onClick={() => selectModel(AUTO_MODEL_ID)}
+              >
+                <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                  <span class="text-[#7ee787] font-medium">Auto</span>
+                  <span class="text-[11px] text-muted-foreground">
+                    Best model for each task
+                  </span>
+                </div>
+                <Show when={providerStore.isAutoModel}>
+                  <span class="text-[#7ee787] text-sm font-semibold">
+                    &#10003;
+                  </span>
+                </Show>
+              </button>
+            </Show>
             <Show
               when={filteredModels().length > 0}
               fallback={

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -7,7 +7,7 @@ import type { Attachment } from "@/lib/providers/types";
 import { getAllTools } from "@/lib/tools";
 import { acpStore } from "@/stores/acp.store";
 import { conversationStore } from "@/stores/conversation.store";
-import { providerStore } from "@/stores/provider.store";
+import { AUTO_MODEL_ID, providerStore } from "@/stores/provider.store";
 import { skillsStore } from "@/stores/skills.store";
 import type { UnifiedMessage } from "@/types/conversation";
 
@@ -519,7 +519,7 @@ function buildCapabilities(): UserCapabilities {
   return {
     has_acp_agent: acpStore.availableAgents.length > 0,
     agent_type: acpStore.selectedAgentType ?? null,
-    selected_model: providerStore.activeModel,
+    selected_model: providerStore.activeModel === AUTO_MODEL_ID ? null : providerStore.activeModel,
     available_models: activeModels.map((m) => m.id),
     available_tools: tools.map((t) => t.function.name),
     installed_skills: enabledSkills.map((s) => ({

--- a/src/stores/provider.store.ts
+++ b/src/stores/provider.store.ts
@@ -17,6 +17,9 @@ import {
   storeProviderKey,
 } from "@/lib/tauri-bridge";
 
+/** Sentinel value for automatic model selection by the orchestrator. */
+export const AUTO_MODEL_ID = "auto";
+
 const PROVIDER_SETTINGS_STORE = "provider-settings.json";
 const PROVIDER_SETTINGS_KEY = "provider-settings";
 const BROWSER_PROVIDER_SETTINGS_KEY = "seren_provider_settings";
@@ -162,7 +165,7 @@ const DEFAULT_MODELS: Record<ProviderId, ProviderModel[]> = {
 
 const DEFAULT_STATE: ProviderState = {
   activeProvider: "seren",
-  activeModel: "google/gemini-3-flash-preview",
+  activeModel: AUTO_MODEL_ID,
   configuredProviders: ["seren"],
   oauthProviders: [],
   providerModels: { ...DEFAULT_MODELS },
@@ -516,6 +519,9 @@ export const providerStore = {
   },
   get isLoading() {
     return state.isLoading;
+  },
+  get isAutoModel() {
+    return state.activeModel === AUTO_MODEL_ID;
   },
 
   // Functions


### PR DESCRIPTION
## Summary
- Add **Auto model option** to the model selector — sends selected_model: null so the orchestrator uses Thompson sampling to pick the best model per task
- **Fix dead reroute logic** — user_explicitly_selected was always true because providerStore.activeModel was always a non-empty string, blocking all 408/429/5xx rerouting
- **Allow rerouting even with pinned models** — transient server errors should fallback rather than show an error message
- **Add 30s connect timeout** to ChatModelWorker and McpPublisherWorker reqwest clients (previously no timeout at all)

Closes #508

## Changes
| File | Change |
|------|--------|
| provider.store.ts | Export AUTO_MODEL_ID, default to auto, add isAutoModel getter |
| ModelSelector.tsx | Add green Auto entry at top of dropdown with distinct styling |
| orchestrator.ts | Send selected_model: null when Auto is active |
| service.rs | Remove user_explicitly_selected reroute guard |
| chat_model_worker.rs | Add 30s connect timeout |
| mcp_publisher_worker.rs | Add 30s connect timeout |

## Test plan
- [ ] Verify Auto appears at top of model selector with green styling
- [ ] Select Auto — verify orchestrator picks model based on task classification
- [ ] Pin a specific model — verify it is used for requests
- [ ] Trigger a 408 timeout — verify reroute to fallback model (both Auto and pinned)
- [ ] Verify reroute announcement message appears in chat
- [ ] Verify cargo check passes, pnpm test passes (115 tests)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com