### PR TITLE
feat: derive agent tab titles from first user prompt

### DIFF
--- a/src/components/chat/AgentTabBar.tsx
+++ b/src/components/chat/AgentTabBar.tsx
@@ -32,6 +32,7 @@ export const AgentTabBar: Component<AgentTabBarProps> = (props) => {
 
   const sessionLabel = (id: string, index: number) => {
     const session = acpStore.sessions[id];
+    if (session?.title) return session.title;
     const agentType = session?.info?.agentType ?? "Agent";
     const label =
       agentType === "claude-code"

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -77,6 +77,8 @@ export interface ActiveSession {
   availableModes?: AgentModeInfo[];
   /** Session-specific error message */
   error?: string | null;
+  /** Title derived from the first user prompt */
+  title?: string;
 }
 
 interface AcpState {
@@ -527,6 +529,21 @@ export const acpStore = {
     ]);
     setState("sessions", sessionId, "streamingContent", "");
     setState("sessions", sessionId, "streamingThinking", "");
+
+    // Derive tab title from the first user prompt
+    if (!state.sessions[sessionId]?.title) {
+      const maxLen = 30;
+      const trimmed = prompt.trim().replace(/\s+/g, " ");
+      const title =
+        trimmed.length <= maxLen
+          ? trimmed
+          : (() => {
+              const t = trimmed.slice(0, maxLen);
+              const sp = t.lastIndexOf(" ");
+              return `${sp > 10 ? t.slice(0, sp) : t}\u2026`;
+            })();
+      setState("sessions", sessionId, "title", title);
+    }
 
     console.log("[AcpStore] Calling acpService.sendPrompt...");
     try {


### PR DESCRIPTION
## Summary
- Derive a concise title from the first user prompt in each agent session
- Display it as the tab label in AgentTabBar, matching the chat conversation title pattern (truncate at 30 chars on word boundary)
- Falls back to the existing "Claude #N" / "Codex #N" format until the first prompt is sent

Closes #514

## Changes
| File | Change |
|------|--------|
| src/stores/acp.store.ts | Add title field to ActiveSession, generate title on first sendPrompt |
| src/components/chat/AgentTabBar.tsx | Prefer session.title in sessionLabel, fall back to agent type |

## Test plan
- [ ] Open a new agent session — tab shows "Claude #1" or "Codex #1"
- [ ] Send a short prompt (e.g. "Fix the login bug") — tab updates to "Fix the login bug"
- [ ] Send a long prompt (40+ chars) — tab shows truncated title with ellipsis at word boundary
- [ ] Open multiple sessions — each tab shows its own title after first prompt
- [ ] Switch between tabs — titles persist correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com