### PR TITLE
fix: make agent timeout activity-aware and fix auto-restart recovery

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -553,8 +553,15 @@ export const acpStore = {
           "[AcpStore] Session appears dead, attempting auto-recovery...",
         );
 
-        // Preserve conversation history and cwd before cleanup
-        const existingMessages = [...session.messages];
+        // Preserve conversation history and cwd before cleanup.
+        // Filter out any "unresponsive" error messages that the event handler
+        // may have added before this catch block ran — restoring them would
+        // create duplicate banners in the new session.
+        const existingMessages = [...session.messages].filter(
+          (m) =>
+            m.id !== userMessage.id &&
+            !(m.type === "error" && m.content.includes("unresponsive")),
+        );
         const cwd = session.cwd;
         const agentType = session.info.agentType;
 
@@ -564,25 +571,30 @@ export const acpStore = {
         // Spawn a fresh session
         const newSessionId = await this.spawnSession(cwd, agentType);
         if (newSessionId) {
-          // Restore conversation history to the new session (excluding the
-          // user message we just added, since we'll retry the prompt)
-          const historyToRestore = existingMessages.filter(
-            (m) => m.id !== userMessage.id,
-          );
-          if (historyToRestore.length > 0) {
-            setState("sessions", newSessionId, "messages", historyToRestore);
+          // Restore conversation history to the new session
+          if (existingMessages.length > 0) {
+            setState("sessions", newSessionId, "messages", existingMessages);
           }
+
+          // Show recovery indicator so the user knows what happened
+          const recoveryMsg: AgentMessage = {
+            id: crypto.randomUUID(),
+            type: "assistant",
+            content:
+              "Agent session restarted due to inactivity timeout. Retrying your message...",
+            timestamp: Date.now(),
+          };
+          setState("sessions", newSessionId, "messages", (msgs) => [
+            ...msgs,
+            recoveryMsg,
+            userMessage,
+          ]);
 
           // Retry the prompt on the new session
           console.info(
             `[AcpStore] Retrying prompt on new session ${newSessionId}`,
           );
           try {
-            // Add the user message to the new session
-            setState("sessions", newSessionId, "messages", (msgs) => [
-              ...msgs,
-              userMessage,
-            ]);
             await acpService.sendPrompt(newSessionId, prompt, context);
             console.log("[AcpStore] Retry succeeded on new session");
             return;
@@ -592,7 +604,10 @@ export const acpStore = {
               retryError instanceof Error
                 ? retryError.message
                 : String(retryError);
-            this.addErrorMessage(newSessionId, retryMessage);
+            this.addErrorMessage(
+              newSessionId,
+              `Recovery failed: ${retryMessage}. Please try sending your message again.`,
+            );
             return;
           }
         }
@@ -875,6 +890,14 @@ export const acpStore = {
             ...msgs,
             cancelMsg,
           ]);
+        } else if (String(event.data.error).includes("unresponsive")) {
+          // "Agent unresponsive" errors are handled by the sendPrompt catch
+          // block which spawns a fresh session and retries. Adding the error
+          // here would create duplicate banners when the recovery code
+          // restores message history to the new session.
+          console.info(
+            "[AcpStore] Skipping error message for unresponsive agent — sendPrompt handles recovery",
+          );
         } else {
           this.addErrorMessage(sessionId, event.data.error);
         }


### PR DESCRIPTION
## Summary

Fixes #513 — Agent auto-restart fails after timeout, leaving the session stuck with an error banner.

**Three root causes fixed:**

- **Fixed 120s total timeout killed active agents** — The `PROMPT_TIMEOUT_SECS` was a one-shot timer that fired regardless of streaming activity. Console logs showed tool calls/results arriving right before the timeout. Now the timeout resets on every `session_notification` callback (message chunks, tool calls, tool results, diffs, etc.), only firing after 120s of true inactivity.

- **Duplicate error banners** — The `acp://error` event handler added an "Agent unresponsive" error message *before* the `sendPrompt` catch block ran. The catch block then captured `existingMessages` (including the error), restored them to the new session, and the retry failure added a second error. Now the event handler skips "unresponsive" errors (the `sendPrompt` catch handles recovery), and stale errors are filtered from restored history.

- **Recovery was invisible** — No indicator that recovery was happening. User saw "will restart automatically" but no progress feedback. Now a recovery indicator message is shown: "Agent session restarted due to inactivity timeout. Retrying your message..."

## Test plan

- [ ] Start an agent session and send a complex prompt that triggers many tool calls (>2 minutes of work) — verify the session stays alive as long as the agent is actively streaming
- [ ] Simulate an unresponsive agent (e.g., kill the agent process) — verify the session auto-restarts with a recovery message and no duplicate error banners
- [ ] Verify cancel still works during an active prompt (5s deadline unchanged)
- [ ] Verify multiple tabs (Claude #1, #2, #3) don't interfere with each other during recovery

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
