### PR TITLE
fix: enable native menu bar on Windows and Linux

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -456,32 +456,39 @@ pub fn run() {
             }
         })
         .setup(|app| {
-            // Build custom menu with About item that emits to frontend
-            #[cfg(target_os = "macos")]
+            // Build native menu bar for all platforms
             {
                 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
 
                 let about = MenuItem::with_id(app, "about", "About Seren", true, None::<&str>)?;
                 let separator = PredefinedMenuItem::separator(app)?;
                 let quit = PredefinedMenuItem::quit(app, Some("Quit Seren"))?;
-                let hide = PredefinedMenuItem::hide(app, Some("Hide Seren"))?;
-                let hide_others = PredefinedMenuItem::hide_others(app, None)?;
-                let show_all = PredefinedMenuItem::show_all(app, None)?;
 
-                let app_menu = Submenu::with_items(
-                    app,
-                    "Seren",
-                    true,
-                    &[
-                        &about,
-                        &separator,
-                        &hide,
-                        &hide_others,
-                        &show_all,
-                        &separator,
-                        &quit,
-                    ],
-                )?;
+                // macOS app menu includes Hide/Show items; Windows/Linux just About + Quit
+                #[cfg(target_os = "macos")]
+                let app_menu = {
+                    let hide = PredefinedMenuItem::hide(app, Some("Hide Seren"))?;
+                    let hide_others = PredefinedMenuItem::hide_others(app, None)?;
+                    let show_all = PredefinedMenuItem::show_all(app, None)?;
+                    Submenu::with_items(
+                        app,
+                        "Seren",
+                        true,
+                        &[
+                            &about,
+                            &separator,
+                            &hide,
+                            &hide_others,
+                            &show_all,
+                            &separator,
+                            &quit,
+                        ],
+                    )?
+                };
+
+                #[cfg(not(target_os = "macos"))]
+                let app_menu =
+                    Submenu::with_items(app, "Seren", true, &[&about, &separator, &quit])?;
 
                 let edit_menu = {
                     let undo = PredefinedMenuItem::undo(app, None)?;


### PR DESCRIPTION
## Summary
- Removes the `#[cfg(target_os = "macos")]` gate that prevented menu construction on Windows and Linux
- Moves the platform guard to only the macOS-specific items (Hide, Hide Others, Show All)
- Windows/Linux now get: **Seren** (About, Quit), **Edit** (Undo, Redo, Cut, Copy, Paste, Select All), **Window** (Minimize, Zoom, Fullscreen, Close)

Closes #518

## Test plan
- [ ] Build and run on Windows — verify Seren, Edit, and Window menus appear in the menu bar
- [ ] Verify About Seren opens the about dialog on Windows
- [ ] Verify Edit menu keyboard shortcuts (Ctrl+C, Ctrl+V, etc.) work
- [ ] Verify Window menu actions (Minimize, Close) work
- [ ] Build and run on macOS — verify existing menus still work including Hide/Show items
- [ ] Build on Linux — verify menus appear

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com