### PR TITLE
fix: inject accumulated cost in non-streaming handlers and make thumbs prominent

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -451,7 +451,23 @@ impl ChatModelWorker {
                                     accumulated_thinking.push_str(text);
                                 }
                                 WorkerEvent::Complete { .. } => {
+                                    // Intercept to inject accumulated cost (same as streaming path)
                                     got_complete = true;
+                                    let thinking = if accumulated_thinking.is_empty() {
+                                        None
+                                    } else {
+                                        Some(accumulated_thinking.clone())
+                                    };
+                                    let cost = if accumulated_cost > 0.0 { Some(accumulated_cost) } else { None };
+                                    event_tx
+                                        .send(WorkerEvent::Complete {
+                                            final_content: accumulated_content.clone(),
+                                            thinking,
+                                            cost,
+                                        })
+                                        .await
+                                        .map_err(|e| format!("Failed to send Complete event: {}", e))?;
+                                    continue;
                                 }
                                 _ => {}
                             }
@@ -475,7 +491,23 @@ impl ChatModelWorker {
                                     accumulated_content.push_str(text);
                                 }
                                 WorkerEvent::Complete { .. } => {
+                                    // Intercept to inject accumulated cost (same as streaming path)
                                     got_complete = true;
+                                    let thinking = if accumulated_thinking.is_empty() {
+                                        None
+                                    } else {
+                                        Some(accumulated_thinking.clone())
+                                    };
+                                    let cost = if accumulated_cost > 0.0 { Some(accumulated_cost) } else { None };
+                                    event_tx
+                                        .send(WorkerEvent::Complete {
+                                            final_content: accumulated_content.clone(),
+                                            thinking,
+                                            cost,
+                                        })
+                                        .await
+                                        .map_err(|e| format!("Failed to send Complete event: {}", e))?;
+                                    continue;
                                 }
                                 _ => {}
                             }

--- a/src/components/chat/SatisfactionSignal.tsx
+++ b/src/components/chat/SatisfactionSignal.tsx
@@ -38,21 +38,21 @@ export const SatisfactionSignal: Component<SatisfactionSignalProps> = (
   };
 
   return (
-    <div class="inline-flex items-center gap-1 opacity-0 group-hover/msg:opacity-100 transition-opacity duration-150">
+    <div class="inline-flex items-center gap-2">
       <Show when={signal() === null || signal() === 1}>
         <button
           type="button"
-          class={`bg-transparent border-none cursor-pointer p-0.5 rounded transition-colors ${
+          class={`bg-transparent border border-[#30363d] cursor-pointer px-2 py-1 rounded-md transition-all ${
             signal() === 1
-              ? "text-[#3fb950]"
-              : "text-[#484f58] hover:text-[#3fb950]"
+              ? "text-[#3fb950] border-[#238636] bg-[rgba(35,134,54,0.1)]"
+              : "text-[#8b949e] hover:text-[#3fb950] hover:border-[#238636] hover:bg-[rgba(35,134,54,0.05)]"
           }`}
           onClick={() => submit(1)}
-          title="Helpful"
+          title="This response was helpful — your feedback helps Seren route to the best models for you"
         >
           <svg
-            width="14"
-            height="14"
+            width="18"
+            height="18"
             viewBox="0 0 24 24"
             fill="currentColor"
             aria-hidden="true"
@@ -64,17 +64,17 @@ export const SatisfactionSignal: Component<SatisfactionSignalProps> = (
       <Show when={signal() === null || signal() === 0}>
         <button
           type="button"
-          class={`bg-transparent border-none cursor-pointer p-0.5 rounded transition-colors ${
+          class={`bg-transparent border border-[#30363d] cursor-pointer px-2 py-1 rounded-md transition-all ${
             signal() === 0
-              ? "text-[#f85149]"
-              : "text-[#484f58] hover:text-[#f85149]"
+              ? "text-[#f85149] border-[#da3633] bg-[rgba(218,54,51,0.1)]"
+              : "text-[#8b949e] hover:text-[#f85149] hover:border-[#da3633] hover:bg-[rgba(218,54,51,0.05)]"
           }`}
           onClick={() => submit(0)}
-          title="Not helpful"
+          title="This response was not helpful — your feedback helps Seren avoid poor models"
         >
           <svg
-            width="14"
-            height="14"
+            width="18"
+            height="18"
             viewBox="0 0 24 24"
             fill="currentColor"
             aria-hidden="true"


### PR DESCRIPTION
## Summary

Fixes #522

- **Non-streaming cost injection**: The Gateway non-streaming wrapper handlers (string body and JSON body) now intercept `Complete` events and inject the accumulated cost, matching the streaming handler behavior. Previously, `Complete` events from `parse_sse_data` were forwarded with `cost: None`, and the final Complete (with accumulated cost) was skipped because `got_complete` was already `true`.
- **Prominent thumbs up/down**: `SatisfactionSignal` buttons are now always visible (removed hover-only opacity), larger (18px icons with border/padding), and have descriptive tooltips explaining that feedback helps Seren route to the best models.

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/orchestrator/chat_model_worker.rs` | Intercept Complete in both non-streaming wrapper handlers to inject accumulated cost |
| `src/components/chat/SatisfactionSignal.tsx` | Always visible, larger icons, borders, descriptive tooltips |

## Test plan

- [x] All 24 `chat_model_worker` Rust tests pass
- [x] `cargo check` clean (only pre-existing warnings)
- [x] Biome check passes on changed TypeScript
- [ ] Manual: verify cost displays after duration in Chat mode
- [ ] Manual: verify thumbs up/down are visible and clickable without hover
- [ ] Manual: verify tooltip text appears on hover over thumbs buttons

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com