### PR TITLE
fix: allow data: URIs in CSP and execute no-arg slash commands on click

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc://localhost https://api.serendb.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https:; frame-src http://127.0.0.1:* http://localhost:*",
+      "csp": "default-src 'self'; connect-src 'self' ipc://localhost https://api.serendb.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https: data:; frame-src http://127.0.0.1:* http://localhost:*",
       "assetProtocol": {
         "enable": true,
         "scope": ["**"]

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -819,8 +819,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 panel="agent"
                 selectedIndex={commandPopupIndex()}
                 onSelect={(cmd) => {
-                  setInput(`/${cmd.name} `);
-                  inputRef?.focus();
+                  if (cmd.argHint) {
+                    setInput(`/${cmd.name} `);
+                    inputRef?.focus();
+                  } else {
+                    executeSlashCommand(`/${cmd.name}`);
+                  }
                   setCommandPopupIndex(0);
                 }}
               />

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -919,8 +919,12 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                 panel="chat"
                 selectedIndex={commandPopupIndex()}
                 onSelect={(cmd) => {
-                  setInput(`/${cmd.name} `);
-                  inputRef?.focus();
+                  if (cmd.argHint) {
+                    setInput(`/${cmd.name} `);
+                    inputRef?.focus();
+                  } else {
+                    executeSlashCommand(`/${cmd.name}`);
+                  }
                   setCommandPopupIndex(0);
                 }}
               />


### PR DESCRIPTION
## Summary

Fixes #527

- **CSP img-src**: Added `data:` to the Content Security Policy `img-src` directive. The image resizing code (commit 5dab081) creates `data:` URIs to load images into canvas for resizing, and `toDataUrl()` renders thumbnails — both were blocked by CSP.
- **Slash command popup**: Commands without arguments (like `/attach`, `/clear`, `/balance`) now execute immediately when clicked in the popup, instead of requiring an extra Enter press. Commands with arguments (like `/model`) still fill the input for the user to complete.

## Files Changed
- `src-tauri/tauri.conf.json` — add `data:` to `img-src` CSP directive
- `src/components/chat/ChatContent.tsx` — execute no-arg commands on popup click
- `src/components/chat/AgentChat.tsx` — same fix for agent panel

## Test plan
- [ ] Attach an image in chat — should resize and display thumbnail
- [ ] Attach an image in agent — same behavior
- [ ] Click "/attach" in slash command popup (both panels) — should open file picker immediately
- [ ] Click "/model" in popup — should fill input with `/model ` for user to type model name
- [ ] Verify image thumbnails display in message bubbles after sending

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com