### PR TITLE
fix: launch terminal for WhatsApp channel login

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -763,6 +763,8 @@ pub fn run() {
             openclaw::openclaw_set_trust,
             #[cfg(feature = "openclaw")]
             openclaw::openclaw_grant_approval,
+            #[cfg(feature = "openclaw")]
+            openclaw::openclaw_launch_channel_login,
             // Skills commands
             skills::get_seren_skills_dir,
             skills::get_claude_skills_dir,

--- a/src/stores/openclaw.store.ts
+++ b/src/stores/openclaw.store.ts
@@ -350,6 +350,10 @@ export const openclawStore = {
     return invoke<string>("openclaw_get_qr", { platform });
   },
 
+  async launchChannelLogin(platform: string) {
+    return invoke("openclaw_launch_channel_login", { platform });
+  },
+
   async disconnectChannel(channelId: string) {
     await invoke("openclaw_disconnect_channel", { channelId });
     // Remove from local state


### PR DESCRIPTION
## Summary
- WhatsApp QR-based login requires an interactive terminal session, but the GUI QR flow always failed with an error
- Added `openclaw_launch_channel_login` Tauri command that opens a native terminal running `openclaw channels login --channel <platform>`
- Updated the QR flow UI to show a "Launch Terminal Login" button instead of the broken QR fetch
- UI polls for channel connection and auto-detects when WhatsApp connects after terminal auth

## Changes
- **src-tauri/src/openclaw.rs** — Added `launch_channel_login()` function and `openclaw_launch_channel_login` Tauri command following the ACP `launch_claude_login` pattern
- **src-tauri/src/lib.rs** — Registered new command
- **src/stores/openclaw.store.ts** — Added `launchChannelLogin()` store method
- **src/components/settings/OpenClawChannelConnect.tsx** — Replaced broken QR fetch with terminal launch flow

Closes #528

## Test plan
- [ ] Open Settings > OpenClaw > Connect Channel > WhatsApp
- [ ] Click "Launch Terminal Login" — verify Terminal.app opens with the openclaw login command
- [ ] Scan QR code in terminal — verify Seren UI auto-detects the connected channel
- [ ] Verify "Relaunch Terminal Login" button works for retry
- [ ] Verify error state displays correctly if terminal fails to launch

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com