### PR TITLE
fix: permission mode selector has no effect - always stays DEFAULT

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -1076,8 +1076,25 @@ fn handle_session_notification(
             );
             log::debug!("[ACP] THOUGHT_CHUNK emit result: {:?}", emit_result);
         }
+        SessionUpdate::CurrentModeUpdate(update) => {
+            log::info!(
+                "[ACP] Mode changed: session={}, currentModeId={}",
+                session_id,
+                &*update.current_mode_id.0
+            );
+            let _ = app.emit(
+                events::SESSION_STATUS,
+                serde_json::json!({
+                    "sessionId": session_id,
+                    "status": "ready",
+                    "modes": {
+                        "currentModeId": &*update.current_mode_id.0
+                    }
+                }),
+            );
+        }
         _ => {
-            // Handle other notification types as needed
+            log::debug!("[ACP] Unhandled session update: {:?}", notification.update);
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Handle `CurrentModeUpdate` notification** in the Rust backend (`handle_session_notification`) — the agent sends this notification when a mode change is confirmed, but it was silently dropped in the catch-all `_ => {}` arm. Now it emits a `SESSION_STATUS` event with the updated `currentModeId` to the frontend.
- **Make `availableModes` update conditional** in the frontend store's `handleStatusChange` — partial mode updates (like `CurrentModeUpdate`, which only carries `currentModeId`) no longer clobber the existing available modes list.
- **Improve error logging** in `setPermissionMode` for diagnosability.

Closes #534

## Test plan

- [ ] Start a Claude Code agent session, wait for Ready state
- [ ] Open permission mode dropdown, select "Bypass Permissions"
- [ ] Verify the dropdown button updates to show "Bypass Permissions"
- [ ] Send a prompt and verify the agent operates in bypass mode (auto-approves tools)
- [ ] Switch back to "Default" and verify it sticks
- [ ] Verify Codex agent permission modes still work (if Codex agent advertises modes)
- [ ] Verify initial auto-set of permission mode on session creation still works

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com