### PR TITLE
fix: preserve array items in tool schema and surface gateway errors

### DIFF
--- a/src/lib/tools/definitions.ts
+++ b/src/lib/tools/definitions.ts
@@ -203,6 +203,7 @@ function convertMcpToolToDefinition(
         type: schema.type,
         description: schema.description,
         enum: schema.enum,
+        items: schema.items,
       };
     }
   }
@@ -238,6 +239,7 @@ function convertGatewayToolToDefinition(
         type: schema.type,
         description: schema.description,
         enum: schema.enum,
+        items: schema.items,
       };
     }
   }


### PR DESCRIPTION
## Summary

Fixes #533 — GPT-4o chat shows no response when gateway tools have array properties.

- **Tool schema**: `convertGatewayToolToDefinition()` and `convertMcpToolToDefinition()` now preserve the `items` property on array-typed parameters. Azure/OpenAI requires `items` on arrays, and the missing field caused a 400 rejection for `create_org_oauth_provider`'s `scopes` parameter.
- **Error handling**: The non-streaming wrapper handler in `ChatModelWorker` now checks the wrapper's `status` field for errors before processing the body. Previously, when Gateway returned `{"status":400,...}` inside an HTTP 200, the error was silently swallowed and the user saw nothing.

## Test plan

- [x] All 24 `chat_model_worker` Rust tests pass
- [x] Biome check passes on modified file
- [ ] Manual: send a prompt in Chat mode with GPT-4o selected — should get a response (or a visible error if the model rejects for other reasons)
- [ ] Manual: verify other models (Gemini, Claude) still work correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com