### PR TITLE
feat: add Codex startup config settings

### DIFF
--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -981,6 +981,147 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
             </div>
 
             <div class="flex items-start justify-between gap-4 py-3 border-b border-[rgba(148,163,184,0.1)]">
+              <label class="flex flex-col gap-0.5 flex-1">
+                <span class="text-[0.95rem] font-medium text-foreground">
+                  Approval Policy
+                </span>
+                <span class="text-[0.8rem] text-muted-foreground">
+                  When the agent requires human approval before executing
+                  commands
+                </span>
+              </label>
+              <div class="flex gap-3">
+                <For
+                  each={
+                    [
+                      {
+                        value: "untrusted",
+                        label: "Untrusted",
+                        desc: "Approve all untrusted commands",
+                      },
+                      {
+                        value: "on-failure",
+                        label: "On Failure",
+                        desc: "Approve only when commands fail",
+                      },
+                      {
+                        value: "on-request",
+                        label: "On Request",
+                        desc: "Model decides when to ask",
+                      },
+                      {
+                        value: "never",
+                        label: "Never",
+                        desc: "Fully autonomous, no approval",
+                      },
+                    ] as const
+                  }
+                >
+                  {(mode) => (
+                    <button
+                      type="button"
+                      title={
+                        mode.value === "untrusted"
+                          ? "Only run trusted commands (ls, cat, sed) without approval. Escalates for untrusted commands."
+                          : mode.value === "on-failure"
+                            ? "Run all commands without approval. Only asks if a command fails to execute."
+                            : mode.value === "on-request"
+                              ? "The model decides when to ask the user for approval."
+                              : "Never ask for approval. Execution failures are returned directly to the model."
+                      }
+                      class={`flex flex-col items-center gap-2 px-4 py-3 bg-[rgba(30,30,30,0.6)] border-2 rounded-lg cursor-pointer transition-all duration-150 ${
+                        settingsState.app.agentApprovalPolicy === mode.value
+                          ? "border-accent bg-[rgba(99,102,241,0.1)]"
+                          : "border-[rgba(148,163,184,0.2)] hover:border-[rgba(148,163,184,0.4)]"
+                      }`}
+                      onClick={() =>
+                        handleStringChange("agentApprovalPolicy", mode.value)
+                      }
+                    >
+                      <span
+                        class={`text-[0.85rem] ${settingsState.app.agentApprovalPolicy === mode.value ? "text-foreground" : "text-muted-foreground"}`}
+                      >
+                        {mode.label}
+                      </span>
+                      <span class="text-[0.7rem] text-muted-foreground text-center">
+                        {mode.desc}
+                      </span>
+                    </button>
+                  )}
+                </For>
+              </div>
+            </div>
+
+            <div class="flex items-start justify-between gap-4 py-3 border-b border-[rgba(148,163,184,0.1)]">
+              <label class="flex flex-col gap-0.5 flex-1">
+                <span class="text-[0.95rem] font-medium text-foreground">
+                  Quick Presets
+                </span>
+                <span class="text-[0.8rem] text-muted-foreground">
+                  Apply common sandbox + approval combinations
+                </span>
+              </label>
+              <div class="flex gap-3">
+                <button
+                  type="button"
+                  title="Convenience preset: workspace-write sandbox + on-request approval"
+                  class={`px-4 py-2 text-[0.85rem] rounded-lg border-2 cursor-pointer transition-all duration-150 ${
+                    settingsState.app.agentSandboxMode === "workspace-write" &&
+                    settingsState.app.agentApprovalPolicy === "on-request"
+                      ? "border-accent bg-[rgba(99,102,241,0.1)] text-foreground"
+                      : "border-[rgba(148,163,184,0.2)] bg-[rgba(30,30,30,0.6)] text-muted-foreground hover:border-[rgba(148,163,184,0.4)]"
+                  }`}
+                  onClick={() => {
+                    handleStringChange("agentSandboxMode", "workspace-write");
+                    handleStringChange("agentApprovalPolicy", "on-request");
+                  }}
+                >
+                  Recommended
+                </button>
+                <button
+                  type="button"
+                  title="DANGEROUS: Removes all sandbox restrictions and approval requirements"
+                  class={`px-4 py-2 text-[0.85rem] rounded-lg border-2 cursor-pointer transition-all duration-150 ${
+                    settingsState.app.agentSandboxMode === "full-access" &&
+                    settingsState.app.agentApprovalPolicy === "never"
+                      ? "border-red-500 bg-[rgba(239,68,68,0.1)] text-red-400"
+                      : "border-red-500/30 bg-[rgba(30,30,30,0.6)] text-red-400/70 hover:border-red-500/60"
+                  }`}
+                  onClick={() => {
+                    handleStringChange("agentSandboxMode", "full-access");
+                    handleStringChange("agentApprovalPolicy", "never");
+                  }}
+                >
+                  Bypass All Safety
+                </button>
+              </div>
+            </div>
+
+            <div class="flex items-start justify-between gap-4 py-3 border-b border-[rgba(148,163,184,0.1)]">
+              <label class="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={settingsState.app.agentSearchEnabled}
+                  onChange={(e) =>
+                    handleBooleanChange(
+                      "agentSearchEnabled",
+                      e.currentTarget.checked,
+                    )
+                  }
+                  class="mt-1 w-4 h-4 accent-[var(--color-primary,#6366f1)]"
+                />
+                <div class="flex flex-col gap-0.5">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Enable Web Search
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Allow the agent to search the web during sessions
+                  </span>
+                </div>
+              </label>
+            </div>
+
+            <div class="flex items-start justify-between gap-4 py-3 border-b border-[rgba(148,163,184,0.1)]">
               <label class="flex items-start gap-3 cursor-pointer">
                 <input
                   type="checkbox"

--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -154,18 +154,24 @@ export type AcpEvent =
  * @param cwd - Working directory for the agent session
  * @param sandboxMode - Optional sandbox mode for restricting agent capabilities
  * @param apiKey - Optional API key to enable Seren MCP tools for the agent
+ * @param approvalPolicy - Optional approval policy for command execution
+ * @param searchEnabled - Optional flag to enable web search
  */
 export async function spawnAgent(
   agentType: AgentType,
   cwd: string,
   sandboxMode?: string,
   apiKey?: string,
+  approvalPolicy?: string,
+  searchEnabled?: boolean,
 ): Promise<AcpSessionInfo> {
   return invoke<AcpSessionInfo>("acp_spawn", {
     agentType,
     cwd,
     sandboxMode: sandboxMode ?? null,
     apiKey: apiKey ?? null,
+    approvalPolicy: approvalPolicy ?? null,
+    searchEnabled: searchEnabled ?? null,
   });
 }
 

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -325,6 +325,8 @@ export const acpStore = {
         cwd,
         settingsStore.settings.agentSandboxMode,
         apiKey ?? undefined,
+        settingsStore.settings.agentApprovalPolicy,
+        settingsStore.settings.agentSearchEnabled,
       );
       console.log("[AcpStore] Spawn result:", info);
 

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -93,6 +93,8 @@ export interface Settings {
 
   // Agent settings
   agentSandboxMode: "read-only" | "workspace-write" | "full-access";
+  agentApprovalPolicy: "untrusted" | "on-failure" | "on-request" | "never";
+  agentSearchEnabled: boolean;
   agentAutoApproveReads: boolean;
 
   // Voice settings
@@ -176,6 +178,8 @@ const DEFAULT_SETTINGS: Settings = {
   memoryEnabled: false,
   // Agent
   agentSandboxMode: "workspace-write",
+  agentApprovalPolicy: "on-request",
+  agentSearchEnabled: false,
   agentAutoApproveReads: true,
   // Voice
   voiceAutoSubmit: true,


### PR DESCRIPTION
## Summary
- Add approval policy setting (`-a` flag) with untrusted, on-failure, on-request, and never options
- Add web search toggle (`--search` flag) for Codex agent sessions
- Add quick presets: "Recommended" (workspace-write + on-request) and "Bypass All Safety" (full-access + never)
- Build Codex CLI args dynamically in Rust backend based on user settings

## Test plan
- [ ] Verify approval policy selector renders and persists selection
- [ ] Verify web search checkbox toggles and persists
- [ ] Verify quick presets update both sandbox mode and approval policy
- [ ] Spawn a Codex session and confirm CLI args include `-s`, `-a`, and `--search` as configured
- [ ] Verify settings have no effect when spawning a Claude Code session

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com