### PR TITLE
fix: execute no-arg slash commands on keyboard Enter

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -324,7 +324,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           event.preventDefault();
           const selected = matches[commandPopupIndex()];
           if (selected) {
-            setInput(`/${selected.name} `);
+            if (event.key === "Tab" || selected.argHint) {
+              setInput(`/${selected.name} `);
+            } else {
+              executeSlashCommand(`/${selected.name}`);
+            }
             setCommandPopupIndex(0);
           }
           return;

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -983,7 +983,11 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                         event.preventDefault();
                         const selected = matches[commandPopupIndex()];
                         if (selected) {
-                          setInput(`/${selected.name} `);
+                          if (event.key === "Tab" || selected.argHint) {
+                            setInput(`/${selected.name} `);
+                          } else {
+                            executeSlashCommand(`/${selected.name}`);
+                          }
                           setCommandPopupIndex(0);
                         }
                         return;


### PR DESCRIPTION
## Summary
- Keyboard Enter on no-arg slash commands (e.g., `/attach`, `/clear`, `/copy`) now executes directly instead of requiring a second Enter press
- Tab still autocompletes for discoverability; commands with args (e.g., `/model`) still autocomplete on Enter
- Fixes the same bug in both AgentChat and ChatContent for consistency

Closes #550

## Root Cause
Commit #529 fixed the **click** handler (`onSelect`) to execute no-arg commands directly, but the **keyboard Enter** handler was missed — it always just autocompleted the command name, requiring a double-Enter to actually execute.

## Test plan
- [ ] Type `/attach` in Agent view, press Enter → file picker opens immediately (no double Enter)
- [ ] Type `/clear` in Chat view, press Enter → chat clears immediately
- [ ] Type `/model` in either view, press Enter → autocompletes to `/model ` (waits for arg)
- [ ] Type `/att` and press Tab → autocompletes to `/attach ` (Tab always autocompletes)
- [ ] Click a no-arg command in the popup → still executes directly (no regression)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com