### PR TITLE
fix(acp): detect prompt-too-long errors and offer Chat fallback

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -796,8 +796,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         </div>
       </Show>
 
-      {/* Rate Limit Fallback Banner */}
-      <Show when={acpStore.rateLimitHit}>
+      {/* Agent Fallback Banner (rate limit or context window full) */}
+      <Show when={acpStore.agentFallbackNeeded}>
         {(() => {
           const agentType =
             acpStore.activeSession?.info.agentType ?? "claude-code";
@@ -805,6 +805,15 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           const chatModelId = mapAgentModelToChat(agentModelId, agentType);
           const modelName = getModelDisplayName(chatModelId);
           const agentName = agentType === "codex" ? "Codex" : "Claude Code";
+          const reason = acpStore.agentFallbackReason;
+          const title =
+            reason === "prompt_too_long"
+              ? `${agentName}'s context window is full`
+              : `${agentName} hit its rate limit`;
+          const description =
+            reason === "prompt_too_long"
+              ? `The conversation is too long for the agent to continue. You can pick up in Chat mode with ${modelName} via Seren.`
+              : `Your conversation history will be preserved. You can continue in Chat mode with ${modelName} via Seren.`;
           return (
             <div class="mx-4 mb-2 px-3 py-3 border rounded-md text-sm bg-[rgba(88,166,255,0.1)] border-[rgba(88,166,255,0.4)] text-[#58a6ff]">
               <div class="flex items-start gap-3">
@@ -822,13 +831,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                   />
                 </svg>
                 <div class="flex-1">
-                  <p class="m-0 mb-2 font-medium text-[#e6edf3]">
-                    {agentName} hit its rate limit
-                  </p>
-                  <p class="m-0 mb-3 text-xs text-[#8b949e]">
-                    Your conversation history will be preserved. You can
-                    continue in Chat mode with {modelName} via Seren.
-                  </p>
+                  <p class="m-0 mb-2 font-medium text-[#e6edf3]">{title}</p>
+                  <p class="m-0 mb-3 text-xs text-[#8b949e]">{description}</p>
                   <div class="flex items-center gap-2">
                     <button
                       type="button"

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -521,7 +521,9 @@ function buildCapabilities(): UserCapabilities {
   return {
     has_acp_agent: acpStore.availableAgents.length > 0,
     agent_type: acpStore.selectedAgentType ?? null,
-    active_acp_session_id: acpStore.activeSessionId ?? null,
+    active_acp_session_id: acpStore.agentModeEnabled
+      ? (acpStore.activeSessionId ?? null)
+      : null,
     selected_model:
       providerStore.activeModel === AUTO_MODEL_ID
         ? null


### PR DESCRIPTION
## Summary
- Detects "prompt is too long" / context-window-full errors from ACP agents (both as error events and streamed content)
- Shows a fallback banner offering to continue in Chat mode with an equivalent SerenModels LLM
- Generalizes the existing rate-limit fallback to handle both rate-limit and prompt-too-long conditions
- Prevents Chat mode from routing through the broken ACP worker after the user switches away from Agent mode

## Files changed
- `src/lib/rate-limit-fallback.ts` — Added prompt-too-long detection patterns, `isPromptTooLongError()`, `isAgentFallbackError()`, and generalized `performAgentFallback()`
- `src/stores/acp.store.ts` — Added `promptTooLong` flag, `agentFallbackNeeded`/`agentFallbackReason` getters, detection in error and streaming handlers
- `src/components/chat/AgentChat.tsx` — Updated fallback banner to show context-appropriate title/description
- `src/services/orchestrator.ts` — Only pass `active_acp_session_id` when Agent mode is enabled

## Test plan
- [ ] Start an Agent session and exhaust the context window — verify the fallback banner appears
- [ ] Click "Continue in Chat" — verify conversation history is preserved and Chat mode uses correct model
- [ ] Dismiss the banner — verify it disappears and session flags are cleared
- [ ] Verify rate-limit fallback still works as before
- [ ] Verify Chat mode messages route through ChatModelWorker (not ACP) after fallback

Closes #552

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com