### PR TITLE
fix: send agent image attachments as ACP image content blocks

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -21,7 +21,7 @@ import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { openExternalLink } from "@/lib/external-link";
 import { formatDurationWithVerb } from "@/lib/format-duration";
-import { pickAndReadAttachments, toDataUrl } from "@/lib/images/attachments";
+import { pickAndReadAttachments } from "@/lib/images/attachments";
 import type { Attachment } from "@/lib/providers/types";
 import {
   getModelDisplayName,
@@ -256,11 +256,13 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       return;
     }
 
-    // Build context with images as data URLs
-    const context: Array<{ text?: string }> | undefined =
+    // Build context with images as ACP image content blocks
+    const context: Array<Record<string, string>> | undefined =
       images.length > 0
         ? images.map((img) => ({
-            text: `[Attached image: ${img.name}]\n${toDataUrl(img)}`,
+            type: "image",
+            data: img.base64,
+            mimeType: img.mimeType,
           }))
         : undefined;
 

--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -250,7 +250,7 @@ export async function spawnAgent(
 export async function sendPrompt(
   sessionId: string,
   prompt: string,
-  context?: Array<{ text?: string }>,
+  context?: Array<Record<string, string>>,
 ): Promise<void> {
   return invoke("acp_prompt", { sessionId, prompt, context });
 }

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -842,7 +842,7 @@ export const acpStore = {
    * Send a prompt to the active session.
    * Auto-recovers from dead sessions by restarting and retrying.
    */
-  async sendPrompt(prompt: string, context?: Array<{ text?: string }>) {
+  async sendPrompt(prompt: string, context?: Array<Record<string, string>>) {
     const sessionId = state.activeSessionId;
     console.log("[AcpStore] sendPrompt called:", {
       sessionId,


### PR DESCRIPTION
## Summary
- Images in Agent view were sent as base64 text strings inside `ContentBlock::Text`, causing "Prompt is too long" for any image attachment (~1.1MB image = ~1.5MB of text tokens)
- Now sends images as `ContentBlock::Image(ImageContent)` which the ACP protocol already supports
- Updated TypeScript context type signatures to pass structured image objects instead of data URL text

## Changes
- **`src-tauri/src/acp.rs`**: Import `ImageContent`, parse context items by `type` field — create `ContentBlock::Image` for images, `ContentBlock::Text` for text
- **`src/components/chat/AgentChat.tsx`**: Send images as `{type: "image", data: base64, mimeType}` instead of `{text: "data:..."}`
- **`src/services/acp.ts`** + **`src/stores/acp.store.ts`**: Widen context type to `Record<string, string>`

## Test plan
- [ ] Attach a 1MB+ image in Agent view and send a prompt — should get a real response, not "Prompt is too long"
- [ ] Attach a small image (<100KB) in Agent view — should work as before
- [ ] Send a text-only prompt in Agent view — should work unchanged
- [ ] Verify Chat view image attachments still work (different code path, unchanged)

Closes #553

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com