### PR TITLE
fix: retry explicitly-selected models on transient 408/5xx errors

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -6,6 +6,7 @@ use futures::StreamExt;
 use log;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{Mutex, mpsc};
 
 use super::types::{ImageAttachment, RoutingDecision, WorkerEvent};
@@ -21,10 +22,17 @@ pub struct ChatModelWorker {
     cancelled: Arc<Mutex<bool>>,
 }
 
+/// Connect timeout for the HTTP client (seconds).
+const CONNECT_TIMEOUT_SECS: u64 = 30;
+
 impl ChatModelWorker {
     pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         Self {
-            client: reqwest::Client::new(),
+            client,
             cancelled: Arc::new(Mutex::new(false)),
         }
     }

--- a/src-tauri/src/orchestrator/mcp_publisher_worker.rs
+++ b/src-tauri/src/orchestrator/mcp_publisher_worker.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use log;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{Mutex, mpsc};
 
 use super::types::{ImageAttachment, RoutingDecision, WorkerEvent};
@@ -18,10 +19,17 @@ pub struct McpPublisherWorker {
     cancelled: Arc<Mutex<bool>>,
 }
 
+/// Connect timeout for the HTTP client (seconds).
+const CONNECT_TIMEOUT_SECS: u64 = 30;
+
 impl McpPublisherWorker {
     pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         Self {
-            client: reqwest::Client::new(),
+            client,
             cancelled: Arc::new(Mutex::new(false)),
         }
     }


### PR DESCRIPTION
## Summary

Fixes #576

- **Add same-model retry for explicitly-selected models** — When a user picks a specific model (e.g. GPT-5) and hits a transient 408/429/5xx, the orchestrator now retries the same model once (2s backoff) before giving up. Previously, the retry/reroute logic was completely skipped for explicitly-selected models.
- **Add 30s connect timeout to ChatModelWorker and McpPublisherWorker** — Both workers created `reqwest::Client::new()` with zero timeout configuration. Now uses `ClientBuilder` with `.connect_timeout(30s)` to prevent indefinite TCP-level hangs.

## Test plan

- [ ] Select GPT-5 explicitly, send "hello?" — should retry once on 408 instead of showing error immediately
- [ ] Verify reroute still works for auto-selected models on transient errors
- [ ] Verify non-transient errors (401, 403, 402) are NOT retried
- [ ] Run `cargo test -- orchestrator` — all existing tests pass
- [ ] Run `cargo check` — compiles clean

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com