### PR TITLE
fix: steer model toward publisher tools over seren_web_fetch

### DIFF
--- a/src/lib/tools/definitions.ts
+++ b/src/lib/tools/definitions.ts
@@ -364,7 +364,11 @@ export const FILE_TOOLS: ToolDefinition[] = [
       name: "seren_web_fetch",
       description:
         "Fetch content from any public URL. Returns page content as markdown. " +
-        "Use this tool proactively when users ask about web content, news, documentation, or current events. " +
+        "IMPORTANT: Before using this tool, check if a specialized publisher tool " +
+        "(e.g. gateway__github__, gateway__jira__, etc.) is available for the target domain. " +
+        "Publisher tools return structured, smaller data and should always be preferred. " +
+        "Use seren_web_fetch only when no publisher tool covers the URL, or for general " +
+        "web searches via DuckDuckGo/Google. " +
         "To SEARCH the web, construct a search engine URL: " +
         "'https://html.duckduckgo.com/html/?q=your+search+terms' or " +
         "'https://www.google.com/search?q=your+search+terms'. " +


### PR DESCRIPTION
## Summary

- Updates seren_web_fetch tool description to instruct the model to prefer specialized publisher tools (GitHub, Jira, etc.) over raw web fetching
- Removes the "use this tool proactively" language that was steering the model toward seren_web_fetch for all URLs

## Context

When a user asks the model to review a GitHub PR, the model reaches for seren_web_fetch instead of using a structured GitHub publisher tool from the Gateway. Raw HTML-to-markdown conversion returns noisy 50-200KB pages, contributing to the 408 timeout issue in #584.

This is a complementary fix to #588 (context truncation). Together they address 408 timeouts from two angles:
- #588 bounds context size as a safety net
- This PR steers the model toward tools that produce smaller, better-structured results in the first place

Closes #589

## Test plan

- [ ] Verify model prefers gateway publisher tools for GitHub/Jira URLs when available
- [ ] Verify seren_web_fetch still works for general URLs and web searches
- [ ] Verify no regressions in tool selection for non-publisher URLs

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
