### PR TITLE
fix: show local Linear logo instead of broken remote URL

### DIFF
--- a/src/components/settings/OAuthLogins.tsx
+++ b/src/components/settings/OAuthLogins.tsx
@@ -377,12 +377,13 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
                   class={`flex items-center justify-between px-4 py-4 bg-[rgba(30,30,30,0.6)] border rounded-lg transition-all duration-150 ${cardClasses()}`}
                 >
                   <div class="flex items-center gap-4 flex-1 min-w-0">
-                    {/* Publisher Logo */}
+                    {/* Publisher Logo — prefer local bundled logos, then
+                         publisher store, then API, with initial-letter fallback */}
                     <Show
                       when={
-                        provider.logo_url ||
+                        LOCAL_PROVIDER_LOGOS[provider.slug] ||
                         publisherLogos()?.[provider.id] ||
-                        LOCAL_PROVIDER_LOGOS[provider.slug]
+                        provider.logo_url
                       }
                       fallback={
                         <div class="w-10 h-10 flex items-center justify-center bg-[rgba(148,163,184,0.1)] rounded-lg text-base font-semibold text-muted-foreground">
@@ -395,6 +396,16 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
                           src={logoUrl()}
                           alt={provider.name}
                           class="w-10 h-10 rounded-lg object-contain"
+                          onError={(e) => {
+                            const fallback =
+                              LOCAL_PROVIDER_LOGOS[provider.slug];
+                            if (
+                              fallback &&
+                              e.currentTarget.src !== fallback
+                            ) {
+                              e.currentTarget.src = fallback;
+                            }
+                          }}
                         />
                       )}
                     </Show>


### PR DESCRIPTION
## Summary

- Reorders OAuth provider logo source priority: local bundled SVGs first, then publisher store logos, then API logo_url
- Adds onError fallback on the img element to swap to local logo if remote fails to load

## Problem

The Linear logo was showing as a broken image because the API-returned logo_url was prioritized over the bundled local SVG. When the remote URL is inaccessible or broken, the local fallback was never reached since the truthy logo_url short-circuited the Show condition.

## Test plan

- [ ] Verify Linear logo displays correctly in Settings > Connected Accounts
- [ ] Verify GitHub, Google, and Attio logos also display correctly
- [ ] Verify providers without local logos still fall back to the initial-letter placeholder

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
