### PR TITLE
fix: enable network and macOS temp dirs in WorkspaceWrite sandbox

### DIFF
--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -934,17 +934,17 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                       {
                         value: "read-only",
                         label: "Read Only",
-                        desc: "Read workspace files only",
+                        desc: "Read files only, no writes or network",
                       },
                       {
                         value: "workspace-write",
                         label: "Workspace Write",
-                        desc: "Read + write workspace, run commands",
+                        desc: "Write workspace, network, secrets blocked",
                       },
                       {
                         value: "full-access",
                         label: "Full Access",
-                        desc: "No restrictions",
+                        desc: "No restrictions at all",
                       },
                     ] as const
                   }


### PR DESCRIPTION
## Summary

- Enables network access in WorkspaceWrite sandbox mode (was fully blocked, making git/npm/pip unusable)
- Adds /var/folders to writable paths for macOS per-user temp/cache directories (fixes confstr() failures)
- Updates Settings UI descriptions to accurately reflect what each sandbox mode allows

## Problem

The Codex agent was completely non-functional under the default WorkspaceWrite sandbox. Every command wrapped with sandbox-exec hit Seatbelt denials:

- **Network blocked** - git can't resolve github.com, npm/pip/cargo can't fetch packages
- **confstr() fails** - DARWIN_USER_TEMP_DIR and DARWIN_USER_CACHE_DIR resolve to /var/folders which wasn't writable
- **pyenv/rbenv blocked** - shim writes to ~/.pyenv/shims denied
- **xcodebuild/xcrun broken** - can't create cache files

## What changed in sandbox.rs

| Permission | Before | After |
|------------|--------|-------|
| Network | Denied for WorkspaceWrite | Allowed (same as FullAccess) |
| /var/folders writes | Denied | Allowed (macOS user temp/cache) |
| Secrets (.ssh, .aws, Keychains) | Blocked | Still blocked |
| Workspace writes | Allowed | Allowed (unchanged) |

## Security posture

WorkspaceWrite still enforces:
- Sensitive path reads blocked (~/.ssh, ~/.aws, ~/.config/gcloud, ~/Library/Keychains)
- GPG private keys blocked (~/.gnupg/private-keys-v1.d)
- File writes limited to workspace, /tmp, /var/folders, and ~/.gnupg
- All 9 sandbox unit tests pass

Closes #593

## Test plan

- [ ] Verify all 9 sandbox tests pass (confirmed locally)
- [ ] Spawn Codex agent with default WorkspaceWrite mode
- [ ] Verify git fetch/pull works (network access)
- [ ] Verify no confstr() warnings in agent stderr
- [ ] Verify pyenv/rbenv shim writes succeed
- [ ] Verify agent can still NOT read ~/.ssh or ~/.aws

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
