### PR TITLE
fix: remove Browse Remote Sessions from empty state

### DIFF
--- a/src/components/layout/AppShell.css
+++ b/src/components/layout/AppShell.css
@@ -188,7 +188,7 @@
   line-height: 1.5;
 }
 
-/* Browse remote sessions button */
+/* Open folder button in empty state */
 .thread-content__browse-btn {
   margin-top: 8px;
   padding: 6px 14px;
@@ -212,102 +212,4 @@
 .thread-content__browse-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-/* Remote sessions panel */
-.thread-content__remote {
-  width: 100%;
-  max-width: 400px;
-  margin-top: 16px;
-}
-
-.thread-content__remote-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 8px;
-}
-
-.thread-content__remote-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--foreground);
-  opacity: 0.8;
-  margin: 0;
-}
-
-.thread-content__remote-refresh {
-  font-size: 11px;
-  color: var(--primary);
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 2px 6px;
-  border-radius: 4px;
-  transition: background var(--transition-fast, 100ms ease);
-}
-
-.thread-content__remote-refresh:hover {
-  background: var(--primary-muted, rgba(56, 189, 248, 0.1));
-}
-
-.thread-content__remote-refresh:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.thread-content__remote-error {
-  font-size: 12px;
-  color: var(--destructive);
-  margin: 4px 0;
-}
-
-.thread-content__remote-empty {
-  font-size: 12px;
-  color: var(--muted-foreground);
-  opacity: 0.6;
-  margin: 8px 0;
-  text-align: center;
-}
-
-.thread-content__remote-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  max-height: 240px;
-  overflow-y: auto;
-}
-
-.thread-content__remote-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 10px;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--foreground);
-  cursor: pointer;
-  text-align: left;
-  font-size: 12px;
-  transition: background var(--transition-fast, 100ms ease);
-}
-
-.thread-content__remote-item:hover {
-  background: var(--surface-2, rgba(255, 255, 255, 0.06));
-}
-
-.thread-content__remote-item-title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-  min-width: 0;
-}
-
-.thread-content__remote-item-meta {
-  font-size: 11px;
-  color: var(--muted-foreground);
-  flex-shrink: 0;
-  margin-left: 8px;
 }

--- a/src/components/layout/ThreadContent.tsx
+++ b/src/components/layout/ThreadContent.tsx
@@ -1,19 +1,11 @@
 // ABOUTME: Routes to the correct content view based on the active thread type.
-// ABOUTME: Shows ChatContent for chat threads, AgentChat for agent threads, or empty state with remote sessions.
+// ABOUTME: Shows ChatContent for chat threads, AgentChat for agent threads, or empty state.
 
 import { open } from "@tauri-apps/plugin-dialog";
-import {
-  type Component,
-  createSignal,
-  For,
-  Match,
-  Show,
-  Switch,
-} from "solid-js";
+import { type Component, Match, Show, Switch } from "solid-js";
 import { AgentChat } from "@/components/chat/AgentChat";
 import { ChatContent } from "@/components/chat/ChatContent";
 import { ThreadTabBar } from "@/components/layout/ThreadTabBar";
-import { acpStore } from "@/stores/acp.store";
 import { fileTreeState, setRootPath } from "@/stores/fileTree";
 import { threadStore } from "@/stores/thread.store";
 
@@ -40,53 +32,11 @@ export const ThreadContent: Component<ThreadContentProps> = (props) => {
 };
 
 function EmptyState() {
-  const [showRemote, setShowRemote] = createSignal(false);
-
   const handleOpenFolder = async () => {
     const selected = await open({ directory: true, multiple: false });
     if (selected && typeof selected === "string") {
       setRootPath(selected);
     }
-  };
-
-  const handleBrowse = async () => {
-    setShowRemote(true);
-    const cwd = fileTreeState.rootPath;
-    if (cwd) {
-      await acpStore.refreshRemoteSessions(cwd, acpStore.selectedAgentType);
-    }
-  };
-
-  const handleResume = async (session: { sessionId: string; cwd: string }) => {
-    const cwd = session.cwd || fileTreeState.rootPath;
-    if (!cwd) return;
-    await acpStore.resumeRemoteSession(
-      session,
-      cwd,
-      acpStore.selectedAgentType,
-    );
-  };
-
-  const handleLoadMore = async () => {
-    const cwd = fileTreeState.rootPath;
-    if (cwd) {
-      await acpStore.loadMoreRemoteSessions(cwd, acpStore.selectedAgentType);
-    }
-  };
-
-  const formatTime = (dateStr?: string | null) => {
-    if (!dateStr) return "";
-    const date = new Date(dateStr);
-    const diff = Date.now() - date.getTime();
-    const mins = Math.floor(diff / 60000);
-    if (mins < 1) return "just now";
-    if (mins < 60) return `${mins}m ago`;
-    const hours = Math.floor(mins / 60);
-    if (hours < 24) return `${hours}h ago`;
-    return date.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    });
   };
 
   return (
@@ -133,84 +83,6 @@ function EmptyState() {
         >
           Open Folder
         </button>
-      </Show>
-
-      {/* Remote session browser */}
-      <Show
-        when={showRemote()}
-        fallback={
-          <Show when={fileTreeState.rootPath}>
-            <button
-              type="button"
-              class="thread-content__browse-btn"
-              onClick={handleBrowse}
-            >
-              Browse Remote Sessions
-            </button>
-          </Show>
-        }
-      >
-        <div class="thread-content__remote">
-          <div class="thread-content__remote-header">
-            <h3 class="thread-content__remote-title">Remote Sessions</h3>
-            <button
-              type="button"
-              class="thread-content__remote-refresh"
-              onClick={handleBrowse}
-              disabled={acpStore.remoteSessionsLoading}
-            >
-              {acpStore.remoteSessionsLoading ? "Loading..." : "Refresh"}
-            </button>
-          </div>
-
-          <Show when={acpStore.remoteSessionsError}>
-            <p class="thread-content__remote-error">
-              {acpStore.remoteSessionsError}
-            </p>
-          </Show>
-
-          <Show
-            when={acpStore.remoteSessions.length > 0}
-            fallback={
-              <Show when={!acpStore.remoteSessionsLoading}>
-                <p class="thread-content__remote-empty">
-                  No remote sessions found.
-                </p>
-              </Show>
-            }
-          >
-            <div class="thread-content__remote-list">
-              <For each={acpStore.remoteSessions}>
-                {(session) => (
-                  <button
-                    type="button"
-                    class="thread-content__remote-item"
-                    onClick={() => handleResume(session)}
-                  >
-                    <span class="thread-content__remote-item-title">
-                      {session.title ||
-                        `Session ${session.sessionId.slice(0, 8)}`}
-                    </span>
-                    <span class="thread-content__remote-item-meta">
-                      {formatTime(session.updatedAt)}
-                    </span>
-                  </button>
-                )}
-              </For>
-            </div>
-          </Show>
-
-          <Show when={acpStore.remoteSessionsNextCursor}>
-            <button
-              type="button"
-              class="thread-content__browse-btn"
-              onClick={handleLoadMore}
-              disabled={acpStore.remoteSessionsLoading}
-            >
-              Load More
-            </button>
-          </Show>
-        </div>
       </Show>
     </div>
   );


### PR DESCRIPTION
## Summary
- Removed the "Browse Remote Sessions" panel from the empty state — it showed stale agent sessions that confused non-technical users
- Stripped ~130 lines of remote session browsing code from ThreadContent.tsx (handlers, formatTime, session list JSX, unused imports)
- Cleaned up ~100 lines of orphaned `.thread-content__remote*` CSS from AppShell.css
- The empty state now shows only the clean "No skill selected" message with an "Open Folder" button

Closes #608

## Test plan
- [ ] Launch app with no active thread — empty state shows "No skill selected" with Open Folder button
- [ ] No remote sessions panel or Browse button visible
- [ ] Click Open Folder — file dialog opens, selecting a folder sets the root path
- [ ] Create a new chat or agent thread — content area switches correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com