### PR TITLE
fix: hide broken OAuth provider logos when no local fallback exists

### DIFF
--- a/src/components/settings/OAuthLogins.tsx
+++ b/src/components/settings/OAuthLogins.tsx
@@ -404,6 +404,9 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
                               e.currentTarget.src !== fallback
                             ) {
                               e.currentTarget.src = fallback;
+                            } else {
+                              // No local fallback — hide broken image
+                              e.currentTarget.style.display = "none";
                             }
                           }}
                         />


### PR DESCRIPTION
## Summary
Extends the Linear logo fallback handling to also fix icon.png 404 errors from broken publisher logo URLs.

## Problem
When OAuth provider logos fail to load and there's no local SVG fallback (e.g., dynamic publisher logos from the API), the browser shows a broken image icon, resulting in console 404 errors like:
```
GET https://api.serendb.com/.../icon.png 404
```

## Solution
Updated the `onError` handler in OAuthLogins.tsx to hide the image element (`display: none`) when there's no local fallback available, preventing the broken image icon from displaying.

## Test Plan
- [x] `pnpm check` passes
- [x] Verified broken publisher logos are hidden instead of showing broken image icon

## Related
- Builds on #592 (Linear logo priority fix)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com