### PR TITLE
fix: implement archive for agent thread close buttons

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -436,6 +436,18 @@ pub async fn set_agent_conversation_model_id(
     .await
 }
 
+#[tauri::command]
+pub async fn archive_agent_conversation(app: AppHandle, id: String) -> Result<(), String> {
+    run_db(app, move |conn| {
+        conn.execute(
+            "UPDATE conversations SET is_archived = 1 WHERE id = ?1 AND kind = 'agent'",
+            params![id],
+        )?;
+        Ok(())
+    })
+    .await
+}
+
 // ============================================================================
 // Message Commands
 // ============================================================================

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -693,6 +693,7 @@ pub fn run() {
             commands::chat::get_agent_conversation,
             commands::chat::set_agent_conversation_session_id,
             commands::chat::set_agent_conversation_model_id,
+            commands::chat::archive_agent_conversation,
             // Message commands
             commands::chat::save_message,
             commands::chat::get_messages,

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -874,6 +874,17 @@ export async function setAgentConversationModelId(
 }
 
 /**
+ * Archive an agent conversation (hides from tabs but preserves data).
+ */
+export async function archiveAgentConversation(id: string): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Conversation operations require Tauri runtime");
+  }
+  await invoke("archive_agent_conversation", { id });
+}
+
+/**
  * Archive a conversation (hides from tabs but preserves data).
  */
 export async function archiveConversation(id: string): Promise<void> {

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -18,6 +18,7 @@ import {
   performAgentFallback,
 } from "@/lib/rate-limit-fallback";
 import {
+  archiveAgentConversation,
   createAgentConversation,
   type AgentConversation as DbAgentConversation,
   getAgentConversation,

--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Presents chats and agent sessions as a single sorted thread list filtered by project.
 
 import { createStore } from "solid-js/store";
+import { archiveAgentConversation } from "@/lib/tauri-bridge";
 import type { AgentType, SessionStatus } from "@/services/acp";
 import { acpStore } from "@/stores/acp.store";
 import { conversationStore } from "@/stores/conversation.store";
@@ -277,8 +278,10 @@ export const threadStore = {
   async archiveThread(id: string, kind: "chat" | "agent") {
     if (kind === "chat") {
       await conversationStore.archiveConversation(id);
+    } else {
+      await archiveAgentConversation(id);
+      await acpStore.refreshRecentAgentConversations(200);
     }
-    // Agent conversations don't have archive yet — could add later
 
     // Clear selection if this was active
     if (state.activeThreadId === id) {


### PR DESCRIPTION
## Summary
- Fixed the X button on agent thread tabs (Claude Agent, Codex Agent) — previously clicking X did nothing
- Implemented the full archive chain from Rust backend through to frontend store
- Agent threads now close and are hidden from the tab bar when X is clicked, matching chat thread behavior

## Changes
- **Rust**: Added `archive_agent_conversation` command in `src-tauri/src/commands/chat.rs` (sets `is_archived=1` in DB)
- **Tauri**: Registered `archive_agent_conversation` in `src-tauri/src/lib.rs` invoke_handler
- **Bridge**: Added `archiveAgentConversation` TypeScript function in `src/lib/tauri-bridge.ts`
- **Store**: Updated `thread.store.ts archiveThread()` to call `archiveAgentConversation` for agent threads and refresh the agent conversations list

Closes #610

## Test plan
- [ ] Launch app, create a Claude Agent thread — tab appears in tab bar
- [ ] Click X on the Claude Agent tab — tab closes and disappears from tab bar
- [ ] Create a Codex Agent thread — tab appears
- [ ] Click X on the Codex Agent tab — tab closes and disappears
- [ ] Create a chat thread, click X — still works (regression test)
- [ ] Restart app — archived agent threads don't reappear (persistence test)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com