### PR TITLE
feat: add unified skills directory with symlink support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ yarn.lock
 
 # Claude Code local settings (per-developer)
 .claude/settings.local.json
+
+# Skills directory - ignore user-installed skills but track the symlink
+# The skill-creator skill ships with seren-desktop and should be committed
+skills/*
+!skills/skill-creator/

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: skill-creator
+description: Guides users through creating new skills following the AgentSkills.io standard. Use when the user wants to create a custom skill.
+---
+
+# Skill Creator
+
+Guides users through creating new skills that work with Claude Code, OpenAI Codex, and other compatible LLMs.
+
+## When to Use This Skill
+
+Use this skill when:
+- User asks to create a new skill
+- User wants to customize agent behavior for a specific task
+- User mentions "create a skill", "make a skill", or "custom command"
+
+## Skill Creation Workflow
+
+When creating a skill, follow these steps:
+
+### 1. Gather Requirements
+
+Ask the user:
+- **Skill name**: A short, kebab-case identifier (e.g., `code-reviewer`, `api-tester`)
+- **Purpose**: What task should this skill help with?
+- **When to use**: What triggers or context should activate this skill?
+- **Workflow**: What are the key steps the agent should follow?
+
+### 2. Choose Scope
+
+Skills can be installed in three scopes:
+- **Project** (`skills/`): Available only in this project
+- **Claude** (`~/.claude/skills/`): Available globally in Claude Code
+- **Seren** (app data): Available globally in Seren Desktop
+
+For most cases, recommend **Project scope**.
+
+### 3. Generate SKILL.md
+
+Create a `SKILL.md` file following the AgentSkills.io format:
+
+```markdown
+---
+name: skill-name
+description: Brief description of what this skill does and when to use it
+author: Author Name (optional)
+version: 1.0.0 (optional)
+tags: [tag1, tag2] (optional)
+---
+
+# Skill Name
+
+## Overview
+
+Describe the skill's purpose and capabilities.
+
+## When to Use
+
+Explain when and why an agent should use this skill.
+
+## Workflow
+
+1. First step
+2. Second step
+3. Third step
+
+## Examples
+
+### Example 1: Use Case Name
+
+```
+User: "trigger phrase"
+Agent: [expected behavior]
+```
+
+## Best Practices
+
+- Guideline 1
+- Guideline 2
+
+## Common Pitfalls
+
+- What to avoid
+- Edge cases to handle
+```
+
+### 4. Create the Skill Directory
+
+Use the file system to create:
+- `skills/{skill-name}/SKILL.md` - The main skill file
+- `skills/{skill-name}/examples/` - (Optional) Example outputs
+- `skills/{skill-name}/scripts/` - (Optional) Helper scripts
+
+### 5. Test the Skill
+
+After creating:
+1. Verify the skill appears in the Skills sidebar
+2. Test activation with a relevant prompt
+3. Iterate based on results
+
+## Skill Best Practices
+
+### Writing Effective Skills
+
+- **Be specific**: Clear triggers and workflows produce better results
+- **Use examples**: Show concrete input/output examples
+- **Keep it focused**: One skill = one responsibility
+- **Test iteratively**: Create, test, refine
+
+### Skill Metadata
+
+The YAML frontmatter should include:
+- `name`: Kebab-case identifier (required)
+- `description`: When to use this skill (required)
+- `author`: Creator name (optional)
+- `version`: Semantic version (optional)
+- `tags`: Categories for filtering (optional)
+
+### Progressive Disclosure
+
+For complex skills:
+1. Start with a clear overview
+2. Provide step-by-step workflows
+3. Include detailed examples
+4. Add optional advanced sections
+
+## Example Skills
+
+### Example: Code Reviewer
+
+```markdown
+---
+name: code-reviewer
+description: Performs thorough code reviews following best practices
+tags: [code-quality, review, best-practices]
+---
+
+# Code Reviewer
+
+Reviews code changes for quality, security, and best practices.
+
+## Workflow
+
+1. Read the code changes
+2. Check for common issues:
+   - Security vulnerabilities
+   - Performance problems
+   - Code style violations
+   - Missing error handling
+3. Provide constructive feedback
+4. Suggest improvements with examples
+```
+
+### Example: API Tester
+
+```markdown
+---
+name: api-tester
+description: Tests API endpoints and validates responses
+tags: [testing, api, validation]
+---
+
+# API Tester
+
+Tests API endpoints systematically.
+
+## Workflow
+
+1. Identify API endpoint
+2. Send test requests (GET, POST, etc.)
+3. Validate response codes
+4. Check response structure
+5. Report findings
+```
+
+## Tips for Success
+
+1. **Start simple**: Create basic skills first, add complexity later
+2. **Use clear language**: Write for both humans and LLMs
+3. **Test thoroughly**: Verify skills work as expected
+4. **Iterate**: Refine based on real usage
+5. **Share**: Contribute useful skills to the community
+
+## AgentSkills.io Standard
+
+This skill follows the [AgentSkills.io](https://agentskills.io) open standard, ensuring compatibility across:
+- Claude Code
+- OpenAI Codex
+- Google Gemini
+- Any compatible LLM tool
+
+Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
+Email: hello@serendb.com

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -813,6 +813,7 @@ pub fn run() {
             skills::get_seren_skills_dir,
             skills::get_claude_skills_dir,
             skills::get_project_skills_dir,
+            skills::create_skills_symlink,
             skills::list_skill_dirs,
             skills::install_skill,
             skills::remove_skill,

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -245,7 +245,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     // Require text content even when images are attached
     if (!trimmed) {
       if (images.length > 0) {
-        setCommandStatus("Please add text to your message. Image-only messages are not supported.");
+        setCommandStatus(
+          "Please add text to your message. Image-only messages are not supported.",
+        );
         setTimeout(() => setCommandStatus(null), 4000);
       }
       return;

--- a/src/lib/files/service.ts
+++ b/src/lib/files/service.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
+import { createSkillsSymlink } from "@/lib/skills/paths";
 import { type FileNode, setNodes, setRootPath } from "@/stores/fileTree";
 import { openTab, setTabDirty } from "@/stores/tabs";
 
@@ -98,9 +99,19 @@ export async function openFolder(): Promise<string | null> {
 
 /**
  * Load a folder into the file tree.
+ * Also ensures the skills directory and symlink are set up for unified skills support.
  */
 export async function loadFolder(path: string): Promise<void> {
   setRootPath(path);
+
+  // Ensure skills symlink is created for Claude Code compatibility
+  try {
+    await createSkillsSymlink(path);
+  } catch (error) {
+    console.warn("Failed to create skills symlink:", error);
+    // Don't block folder loading if symlink creation fails
+  }
+
   const entries = await listDirectory(path);
   const nodes = entriesToNodes(entries);
   setNodes(nodes);

--- a/src/lib/skills/paths.ts
+++ b/src/lib/skills/paths.ts
@@ -47,7 +47,9 @@ export async function getClaudeSkillsDir(): Promise<string> {
 }
 
 /**
- * Get the project-scope skills directory (.claude/skills/).
+ * Get the project-scope skills directory (skills/).
+ * This is the canonical location following the AgentSkills.io standard.
+ * A symlink at .claude/skills → ../skills provides Claude Code compatibility.
  * Returns null if no project is currently open.
  */
 export async function getProjectSkillsDir(): Promise<string | null> {
@@ -77,6 +79,23 @@ export function getSkillPath(skillsDir: string, slug: string): string {
 export function getSkillDir(skillsDir: string, slug: string): string {
   const separator = skillsDir.includes("\\") ? "\\" : "/";
   return `${skillsDir}${separator}${slug}`;
+}
+
+/**
+ * Create symlink from .claude/skills to ../skills for Claude Code compatibility.
+ * This enables both Claude Code and OpenAI Codex to use the same skills directory.
+ */
+export async function createSkillsSymlink(projectRoot: string): Promise<void> {
+  if (!isTauriRuntime()) {
+    return;
+  }
+
+  try {
+    await invoke("create_skills_symlink", { projectRoot });
+  } catch (error) {
+    console.error("Failed to create skills symlink:", error);
+    throw error;
+  }
 }
 
 /**

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -18,7 +18,6 @@ import {
   performAgentFallback,
 } from "@/lib/rate-limit-fallback";
 import {
-  archiveAgentConversation,
   createAgentConversation,
   type AgentConversation as DbAgentConversation,
   getAgentConversation,


### PR DESCRIPTION
Closes #617

## Summary

Implements unified skills directory architecture following the [AgentSkills.io](https://agentskills.io) open standard. This enables both Claude Code and OpenAI Codex (and other compatible LLMs) to use the same skills directory.

## Changes

### Backend (Rust/Tauri)
- ✅ Updated `get_project_skills_dir()` to return `skills/` instead of `.claude/skills/` as the canonical location
- ✅ Added `create_skills_symlink()` command to create `.claude/skills` → `../skills` symlink
- ✅ Registered new command in Tauri handler

### Frontend (TypeScript)
- ✅ Updated `paths.ts` with new canonical path and symlink creation function
- ✅ Modified `loadFolder()` in `files/service.ts` to automatically create symlink when folders are opened
- ✅ Updated comments to reflect the new architecture

### Skills
- ✅ Added default `skill-creator` skill that ships with seren-desktop
- ✅ Updated `.gitignore` to track `skill-creator` but ignore user-installed skills

### Code Quality
- ✅ Applied biome linter fixes for consistent formatting

## Architecture

The new unified structure:

```
seren-desktop/
├── skills/                          # Canonical skills directory (AgentSkills.io standard)
│   ├── skill-creator/               # Ships by default
│   │   └── SKILL.md
│   └── [user-installed]/            # Ignored by git
├── .claude/
│   ├── settings.json
│   └── skills -> ../skills          # Symlink for Claude Code compatibility
```

## How It Works

| System | Access Method |
|--------|---------------|
| Claude Code | Via symlink `.claude/skills` → `skills/` |
| OpenAI Codex | Directly from `skills/` |
| Gemini/Others | Directly from `skills/` |

## Testing

- ✅ TypeScript compilation passes (`pnpm run check`)
- ✅ Biome linting passes
- ✅ Default `skill-creator` skill is tracked in git
- ✅ Symlink creation logic implemented in folder loading

## Compatibility

This implementation follows the AgentSkills.io open standard for skills, ensuring compatibility across multiple LLM platforms while maintaining backward compatibility with Claude Code's expectations.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
