### PR TITLE
fix: parse orchestrator tool call arguments for display in UI

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -393,7 +393,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
   type GroupedMessage =
     | { type: "single"; message: AgentMessage }
-    | { type: "tool_group"; messages: AgentMessage[]; toolCalls: ToolCallEvent[] };
+    | {
+        type: "tool_group";
+        messages: AgentMessage[];
+        toolCalls: ToolCallEvent[];
+      };
 
   /** Group consecutive tool messages into collapsed groups */
   const groupConsecutiveToolCalls = createMemo(() => {
@@ -680,7 +684,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             <For each={groupConsecutiveToolCalls()}>
               {(item) => {
                 if (item.type === "tool_group") {
-                  return <ToolCallGroup toolCalls={item.toolCalls} isComplete={true} />;
+                  return (
+                    <ToolCallGroup
+                      toolCalls={item.toolCalls}
+                      isComplete={true}
+                    />
+                  );
                 }
                 return renderMessage(item.message);
               }}

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -62,8 +62,9 @@ import "highlight.js/styles/github-dark.css";
 
 /** Map orchestrator ToolCallData to the ToolCallEvent shape ToolCallCard expects. */
 function toToolCallEvent(data: ToolCallData): ToolCallEvent {
-  let params: Record<string, unknown> | undefined;
-  if (data.arguments) {
+  // Use pre-parsed parameters if available, otherwise parse arguments (backward compat)
+  let params: Record<string, unknown> | undefined = data.parameters;
+  if (!params && data.arguments) {
     try {
       params = JSON.parse(data.arguments);
     } catch {
@@ -728,7 +729,12 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
               {(item) => {
                 // Render grouped tool calls
                 if (item.type === "tool_group") {
-                  return <ToolCallGroup toolCalls={item.toolCalls} isComplete={true} />;
+                  return (
+                    <ToolCallGroup
+                      toolCalls={item.toolCalls}
+                      isComplete={true}
+                    />
+                  );
                 }
 
                 // Render single message

--- a/src/components/chat/ToolCallGroup.tsx
+++ b/src/components/chat/ToolCallGroup.tsx
@@ -26,13 +26,22 @@ function categorizeToolCalls(toolCalls: ToolCallEvent[]) {
     const kind = tool.kind.toLowerCase();
     const title = tool.title.toLowerCase();
 
-    if (kind === "read" || kind.includes("file") || kind === "glob" || kind === "grep") {
+    if (
+      kind === "read" ||
+      kind.includes("file") ||
+      kind === "glob" ||
+      kind === "grep"
+    ) {
       categories.filesSearched++;
     } else if (kind === "edit") {
       categories.filesEdited++;
     } else if (kind === "write" || kind === "notebookedit") {
       categories.filesWritten++;
-    } else if (kind.includes("bash") || kind.includes("command") || kind === "execute") {
+    } else if (
+      kind.includes("bash") ||
+      kind.includes("command") ||
+      kind === "execute"
+    ) {
       categories.commandsRun++;
     } else if (title.includes("todo") || kind === "todowrite") {
       categories.tasksCreated++;
@@ -45,26 +54,38 @@ function categorizeToolCalls(toolCalls: ToolCallEvent[]) {
 }
 
 /** Build plain language summary from categories */
-function buildSummary(categories: ReturnType<typeof categorizeToolCalls>): string {
+function buildSummary(
+  categories: ReturnType<typeof categorizeToolCalls>,
+): string {
   const parts: string[] = [];
 
   if (categories.filesSearched > 0) {
-    parts.push(`searched ${categories.filesSearched} file${categories.filesSearched > 1 ? "s" : ""}`);
+    parts.push(
+      `searched ${categories.filesSearched} file${categories.filesSearched > 1 ? "s" : ""}`,
+    );
   }
   if (categories.filesEdited > 0) {
-    parts.push(`edited ${categories.filesEdited} file${categories.filesEdited > 1 ? "s" : ""}`);
+    parts.push(
+      `edited ${categories.filesEdited} file${categories.filesEdited > 1 ? "s" : ""}`,
+    );
   }
   if (categories.filesWritten > 0) {
-    parts.push(`created ${categories.filesWritten} file${categories.filesWritten > 1 ? "s" : ""}`);
+    parts.push(
+      `created ${categories.filesWritten} file${categories.filesWritten > 1 ? "s" : ""}`,
+    );
   }
   if (categories.commandsRun > 0) {
-    parts.push(`ran ${categories.commandsRun} command${categories.commandsRun > 1 ? "s" : ""}`);
+    parts.push(
+      `ran ${categories.commandsRun} command${categories.commandsRun > 1 ? "s" : ""}`,
+    );
   }
   if (categories.tasksCreated > 0) {
     parts.push("updated task list");
   }
   if (categories.other > 0 && parts.length === 0) {
-    parts.push(`${categories.other} operation${categories.other > 1 ? "s" : ""}`);
+    parts.push(
+      `${categories.other} operation${categories.other > 1 ? "s" : ""}`,
+    );
   }
 
   if (parts.length === 0) return "No operations";
@@ -81,7 +102,8 @@ export const ToolCallGroup: Component<ToolCallGroupProps> = (props) => {
 
   const categories = () => categorizeToolCalls(props.toolCalls);
   const summary = () => buildSummary(categories());
-  const hasRunning = () => props.toolCalls.some((t) => t.status.toLowerCase().includes("running"));
+  const hasRunning = () =>
+    props.toolCalls.some((t) => t.status.toLowerCase().includes("running"));
 
   return (
     <div class="my-2 mx-5 bg-[#161b22] border border-[#30363d] rounded-lg overflow-hidden">

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -37,7 +37,7 @@ function formatBytes(bytes: number): string {
   const k = 1024;
   const sizes = ["B", "KB", "MB", "GB"];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+  return `${(bytes / k ** i).toFixed(1)} ${sizes[i]}`;
 }
 
 export const Titlebar: Component<TitlebarProps> = (props) => {
@@ -138,7 +138,9 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
         {/* Installing state */}
         <Show when={updaterStore.state.status === "installing"}>
           <div class="flex flex-col gap-0.5 min-w-[140px]">
-            <div class="text-[10px] text-foreground/70">Installing update...</div>
+            <div class="text-[10px] text-foreground/70">
+              Installing update...
+            </div>
             <div class="w-full h-[4px] bg-white/10 rounded-full overflow-hidden">
               <div class="updater-bar-installing w-full h-full rounded-full" />
             </div>

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -288,6 +288,19 @@ function handleToolCall(event: {
   // Flush any pending streaming content into the assistant message
   flushStreamingToMessage();
 
+  // Parse arguments JSON for display in ToolCallCard
+  let parameters: Record<string, unknown> | undefined;
+  try {
+    if (event.arguments) {
+      parameters = JSON.parse(event.arguments);
+    }
+  } catch (error) {
+    console.warn(
+      `[orchestrator] Failed to parse tool arguments for ${event.name}:`,
+      error,
+    );
+  }
+
   const toolMessage: UnifiedMessage = {
     id: crypto.randomUUID(),
     type: "tool_call",
@@ -304,6 +317,7 @@ function handleToolCall(event: {
       status: "running",
       name: event.name,
       arguments: event.arguments,
+      parameters,
     },
   };
 

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -66,6 +66,7 @@ export interface ToolCallData {
   status: string;
   name?: string;
   arguments?: string;
+  parameters?: Record<string, unknown>;
   result?: string;
   isError?: boolean;
 }


### PR DESCRIPTION
Fixes orchestrator tool calls showing 'No parameters' in UI.

## Problem
When the orchestrator executes tools, ToolCallCard shows 'No parameters' because arguments are JSON strings but UI expects parsed objects.

## Solution
- Add parameters field to ToolCallData interface
- Parse arguments JSON in orchestrator handleToolCall()
- Update ChatContent toToolCallEvent() to prefer pre-parsed parameters

## Testing
- Biome formatting checks pass
- Manual testing needed

Fixes #633