### PR TITLE
feat: add copy and download buttons for chat history

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -692,9 +692,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
       }
     } catch (error) {
       console.error("Failed to save to Seren Notes:", error);
-      alert(
-        "Failed to save to Seren Notes. Downloading locally instead...",
-      );
+      alert("Failed to save to Seren Notes. Downloading locally instead...");
 
       // Fallback: download as local markdown file
       const blob = new Blob([markdown], { type: "text/markdown" });
@@ -793,7 +791,10 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
+                  role="img"
+                  aria-label="Copy"
                 >
+                  <title>Copy chat history</title>
                   <path
                     stroke-linecap="round"
                     stroke-linejoin="round"
@@ -813,7 +814,10 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
+                  role="img"
+                  aria-label="Download"
                 >
+                  <title>Download chat history</title>
                   <path
                     stroke-linecap="round"
                     stroke-linejoin="round"


### PR DESCRIPTION
Adds Copy All and Download buttons to the chat header for easy export of conversation history.

## Features

**Copy Button** (📋 icon)
- Copies entire chat history as markdown to clipboard
- Formats messages with clear user/assistant labels

**Download Button** (⬇️ icon)
- Saves chat history to **Seren Notes** publisher
- Falls back to local markdown download if save fails
- Requires authentication
- Uses Seren Notes API at `https://api.serendb.com/publishers/seren-notes/notes`
- Billing: $0.0005 per save (x402 per request)

## UI Placement
Both buttons positioned in chat header (right side) next to existing Compact/Clear controls. Only appear when chat history exists.

## Implementation
- `POST /notes` endpoint with title, content, and format
- Markdown formatting of chat messages
- Graceful fallback to local download on errors

Addresses #607