### PR TITLE
fix: persist orchestrator messages to database for satisfaction signals

### DIFF
--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -234,6 +234,7 @@ function handleTransition(event: TransitionEvent): void {
   };
 
   conversationStore.addMessage(transitionMessage);
+  conversationStore.persistMessage(transitionMessage);
 }
 
 function handleWorkerEvent(event: OrchestratorEvent): void {
@@ -322,6 +323,7 @@ function handleToolCall(event: {
   };
 
   conversationStore.addMessage(toolMessage);
+  conversationStore.persistMessage(toolMessage);
 }
 
 function handleToolResult(event: {
@@ -368,6 +370,7 @@ function handleToolResult(event: {
   };
 
   conversationStore.addMessage(resultMessage);
+  conversationStore.persistMessage(resultMessage);
 }
 
 function handleDiff(event: {
@@ -394,6 +397,7 @@ function handleDiff(event: {
   };
 
   conversationStore.addMessage(diffMessage);
+  conversationStore.persistMessage(diffMessage);
 }
 
 function handleComplete(
@@ -525,6 +529,7 @@ function handleReroute(event: {
   };
 
   conversationStore.addMessage(rerouteMessage);
+  conversationStore.persistMessage(rerouteMessage);
 }
 
 // =============================================================================
@@ -553,6 +558,7 @@ function flushStreamingToMessage(): void {
       workerType: "orchestrator",
     };
     conversationStore.addMessage(flushedMessage);
+    conversationStore.persistMessage(flushedMessage);
     conversationStore.finalizeStreaming();
 
     // Generate a new ID for the next streaming segment


### PR DESCRIPTION
Fixes satisfaction signal errors when clicking thumbs up/down on orchestrator messages by persisting tool call, tool result, diff, reroute, transition, and flushed streaming messages to SQLite database. This ensures memory ingestion via seren embeds triggers correctly for all message types.