### PR TITLE
fix: increase ACP agent timeout from 120s to 300s

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -194,9 +194,10 @@ fn auth_error_message(agent_type: AgentType) -> String {
     }
 }
 
-/// Maximum time to wait for an agent prompt to produce any response (2 minutes).
+/// Maximum time to wait for an agent prompt to produce any response (5 minutes).
 /// If the agent process is hung or the API is unreachable, this prevents infinite waits.
-const PROMPT_TIMEOUT_SECS: u64 = 120;
+/// Increased from 120s to allow complex operations like deep reasoning, refactoring, and multi-step tool execution.
+const PROMPT_TIMEOUT_SECS: u64 = 300;
 
 /// Debounce window: suppress duplicate login launches within this many seconds.
 const LOGIN_DEBOUNCE_SECS: i64 = 15;


### PR DESCRIPTION
## Summary

Fixes #647 

Increases the ACP agent inactivity timeout from 120 seconds (2 minutes) to 300 seconds (5 minutes) to prevent false-positive timeouts during legitimate long-running operations.

## Problem

The previous 120-second timeout was too aggressive for complex agent operations:
- Deep reasoning/thinking
- Large-scale refactorings
- Complex multi-step tool execution
- File operations on large codebases

This caused legitimate operations to fail with "Agent unresponsive" errors, forcing users to restart sessions.

## Solution

Increased `PROMPT_TIMEOUT_SECS` from 120 to 300 seconds:
- Gives agents sufficient time for complex operations
- Still protects against truly hung processes (5min is a reasonable failsafe)
- Timeout resets on any agent activity (inactivity-based, not total duration)

## Changes

- `src-tauri/src/acp.rs`: Update `PROMPT_TIMEOUT_SECS` from 120 to 300
- Updated comment to document reasoning

## Impact

- ✅ Reduces false-positive timeouts during legitimate work
- ✅ Improves UX for complex agent tasks
- ✅ Still catches truly hung agents within reasonable time
- ✅ No breaking changes - purely an increase in timeout threshold

## Testing

- [x] Code compiles
- [ ] Manual testing: Complex refactoring operations no longer timeout
- [ ] Manual testing: Truly hung agents still timeout after 5 minutes

## Related

- Issue: #647