### PR TITLE
fix: add skills.serendb.com to CSP connect-src

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc://localhost https://api.serendb.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https: data:; frame-src http://127.0.0.1:* http://localhost:*",
+      "csp": "default-src 'self'; connect-src 'self' ipc://localhost https://api.serendb.com https://skills.serendb.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https: data:; frame-src http://127.0.0.1:* http://localhost:*",
       "assetProtocol": {
         "enable": true,
         "scope": ["**"]


### PR DESCRIPTION
## Summary

Fixes #652 - Adds `https://skills.serendb.com` to the Tauri CSP `connect-src` directive to allow the unified skills index to load.

## Problem

The skills service attempts to fetch the unified skills index from `https://skills.serendb.com/index.json` on startup, but the request is blocked by the Tauri Content Security Policy with:

```
url not allowed on the configured scope: https://skills.serendb.com/index.json
```

The app currently falls back to publisher skills (which works correctly), but users don't get access to the full aggregated skills index from the community.

## Root Cause

The CSP configuration in `src-tauri/tauri.conf.json` did not include `https://skills.serendb.com` in the `connect-src` directive.

## Changes

Modified `src-tauri/tauri.conf.json`:
- Added `https://skills.serendb.com` to the CSP `connect-src` list

**Before:**
```
connect-src 'self' ipc://localhost https://api.serendb.com https://api.openai.com ...
```

**After:**
```
connect-src 'self' ipc://localhost https://api.serendb.com https://skills.serendb.com https://api.openai.com ...
```

## Testing Checklist

- [ ] App starts without CSP errors
- [ ] Skills index fetches successfully from skills.serendb.com
- [ ] Skills browser shows community skills
- [ ] Fallback to publisher skills still works
- [ ] No other CSP violations introduced

## Impact

Low impact fix - resolves a non-critical warning and enables the full unified skills index feature.

---

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com