### PR TITLE
fix: make "No skills found" clickable to create new skill

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -74,8 +74,16 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   );
 
   const onPickImages = () => handleAttachImages();
+  const onSetChatInput = (event: Event) => {
+    const customEvent = event as CustomEvent<string>;
+    if (customEvent.detail) {
+      setInput(customEvent.detail);
+      inputRef?.focus();
+    }
+  };
   onMount(() => {
     window.addEventListener("seren:pick-images", onPickImages);
+    window.addEventListener("seren:set-chat-input", onSetChatInput);
     if (fileTreeState.rootPath) {
       void acpStore.refreshRemoteSessions(
         fileTreeState.rootPath,
@@ -85,6 +93,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   });
   onCleanup(() => {
     window.removeEventListener("seren:pick-images", onPickImages);
+    window.removeEventListener("seren:set-chat-input", onSetChatInput);
   });
 
   const hasSession = () => acpStore.activeSession !== null;


### PR DESCRIPTION
## Summary

Fixes #654 - Makes the "No skills installed" empty state clickable to guide users into skill creation.

## Problem

When clicking the Skills selector dropdown and no skills are installed, users see a static message:
```
No skills installed
```

This provides no path forward for users to get started with skills.

## Solution

Replaced the static message with an interactive button that:

1. **Text**: "No skills found. Click to create a new skill"
2. **Behavior on click**:
   - Ensures the Skill Creator skill is installed (auto-installs if needed)
   - Sets the chat input to: "What skill do you want to create today?"
   - Focuses the chat input
   - Closes the skills dropdown

This provides a smooth, guided onboarding experience for new users.

## Changes

### SkillsSelector.tsx
- Added imports for `Skill` type and `skillsService`
- Added `SKILL_CREATOR_SLUG` and `SKILL_CREATOR_SOURCE_URL` constants
- Added `handleCreateNewSkill()` function:
  - Checks if Skill Creator is installed
  - Auto-installs Skill Creator if not present
  - Dispatches `seren:set-chat-input` custom event
- Replaced static `<div>` with clickable `<button>` in empty state fallback

### AgentChat.tsx
- Added `onSetChatInput` event handler
- Listens for `seren:set-chat-input` custom event
- Sets input value from event detail
- Focuses the textarea
- Registered/unregistered event listener in mount/cleanup

## Testing Checklist

- [ ] Empty state shows clickable button when no skills installed
- [ ] Clicking button installs Skill Creator (if not already installed)
- [ ] Chat input is populated with "What skill do you want to create today?"
- [ ] Chat input receives focus after click
- [ ] Skills dropdown closes after click
- [ ] Works with existing skills (button doesn't show)

## Screenshots

Before:
```
[Static gray text: "No skills installed"]
```

After:
```
[Blue clickable button: "No skills found. Click to create a new skill"]
```

---

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com