### PR TITLE
feat: add proper PDF support via document content blocks

### DIFF
--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -100,9 +100,26 @@ export interface ImageContentBlock {
 }
 
 /**
- * Content block for multimodal messages.
+ * Document content block for PDFs (Anthropic-native format).
+ * Used when sending PDFs through content blocks to Anthropic API.
  */
-export type ContentBlock = TextContentBlock | ImageContentBlock;
+export interface DocumentContentBlock {
+  type: "document";
+  source: {
+    type: "base64";
+    media_type: "application/pdf";
+    data: string; // raw base64 without data URL prefix
+  };
+}
+
+/**
+ * Content block for multimodal messages.
+ * Supports text, images (OpenAI format), and documents (Anthropic format).
+ */
+export type ContentBlock =
+  | TextContentBlock
+  | ImageContentBlock
+  | DocumentContentBlock;
 
 /**
  * File attachment metadata stored with messages.


### PR DESCRIPTION
## Summary
Adds proper PDF support using Anthropic-native document content blocks.

## Problem
PR #656 incorrectly marked PDFs as "unsupported" because they don't work with `image_url` content blocks. However, PDFs ARE supported by Anthropic - they just need to use the `document` content block format.

## Solution
- Added `DocumentContentBlock` type for PDF handling
- Updated `ContentBlock` union to include document type
- Modified `buildUserContent()` to create document blocks for PDFs

## Content Block Formats
```typescript
// PDFs (Anthropic format)
{
  type: "document",
  source: {
    type: "base64",
    media_type: "application/pdf",
    data: "base64-encoded-pdf"
  }
}

// Images (OpenAI format)  
{
  type: "image_url",
  image_url: {
    url: "data:image/png;base64,..."
  }
}
```

## File Type Handling
1. **Text files** (.md, .txt, .js, etc.) → Inlined as code blocks
2. **Vision images** (.jpg, .png, .gif, .webp) → image_url content blocks
3. **PDFs** → document content blocks ✅ NEW
4. **Other formats** (SVG, etc.) → Noted as unsupported

## Testing
Ready for testing with PDF attachments.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
