### PR TITLE
Fix: Include parameters in ACP tool call events

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -1092,16 +1092,17 @@ fn handle_session_notification(
                     .and_then(|s| serde_json::to_value(s).ok())
                     .and_then(|v| v.as_str().map(String::from))
                     .unwrap_or_else(|| "pending".to_string());
-                let _ = app.emit(
-                    events::TOOL_CALL,
-                    serde_json::json!({
-                        "sessionId": session_id,
-                        "toolCallId": update.tool_call_id.to_string(),
-                        "title": title,
-                        "kind": kind_str,
-                        "status": status_str
-                    }),
-                );
+                let mut payload = serde_json::json!({
+                    "sessionId": session_id,
+                    "toolCallId": update.tool_call_id.to_string(),
+                    "title": title,
+                    "kind": kind_str,
+                    "status": status_str
+                });
+                if let Some(ref raw_input) = update.fields.raw_input {
+                    payload["parameters"] = raw_input.clone();
+                }
+                let _ = app.emit(events::TOOL_CALL, payload);
             }
 
             // Check for diffs in content


### PR DESCRIPTION
## Summary
- Fixes tool call parameters not displaying in ACP agent UI
- Tool calls now show actual command/arguments instead of "No parameters"

## Changes
Modified `src-tauri/src/acp.rs` to include `raw_input` parameters when emitting defensive TOOL_CALL events from `SessionUpdate::ToolCallUpdate` handler.

## Problem
When the ACP agent made tool calls (Bash, Glob, Write, etc.), the UI showed "No parameters" because the `ToolCallUpdate` handler was emitting TOOL_CALL events without the parameters field.

## Solution
Applied the same pattern used in the `SessionUpdate::ToolCall` handler:
- Check for `update.fields.raw_input`
- Add it to the emitted payload as `parameters`

## Testing
- ✅ Code compiles successfully
- Ready for manual testing with ACP agent

Fixes serenorg/seren-desktop-issues#5

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com