### PR TITLE
fix: preserve conversation history when retrying failed messages (#4)

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -564,6 +564,16 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     });
 
     try {
+      // Include conversation history up to (but not including) the failed message
+      // so the AI can continue from where it left off instead of starting over
+      const messageIndex = conversationStore.messages.findIndex(
+        (m) => m.id === message.id,
+      );
+      const historyBeforeRetry =
+        messageIndex > 0
+          ? conversationStore.messages.slice(0, messageIndex)
+          : undefined;
+
       const content = await sendMessageWithRetry(
         message.request.prompt,
         message.model ?? chatStore.selectedModel,
@@ -574,6 +584,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
             attemptCount: attempt + 1,
           });
         },
+        historyBeforeRetry,
       );
 
       const updated = {


### PR DESCRIPTION
Fixes https://github.com/serenorg/seren-desktop-issues/issues/4

## Problem
When a message fails with a 408 timeout or other error and the user clicks retry, the system was resending only the original prompt without any conversation history. This caused the AI to start over from scratch, wasting time and money by re-doing research and work it had already completed.

## Solution
Modified `attemptRetry` in ChatContent.tsx to include the conversation history up to (but not including) the failed message when retrying. Now when the user clicks retry:

1. The system finds all messages before the failed one
2. Passes that history to `sendMessageWithRetry`
3. The AI sees all previous context and continues from where it left off

## Testing
- User should be able to get a timeout error during a long research task
- Click retry
- AI should acknowledge previous work and continue, not start over

## Impact
- Saves user money by not re-executing expensive research/tool calls
- Faster results since AI doesn't repeat completed work
- Better user experience