### PR TITLE
Fix: Agent type display not syncing between sidebar and chat

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -154,7 +154,13 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       ([newPath, agentType]) => {
         if (newPath && !isPrompting()) {
           void acpStore.refreshRemoteSessions(newPath, agentType);
-          acpStore.focusProjectSession(newPath);
+          // Only auto-focus a project session if there's no active session
+          // or if the active session belongs to a different project.
+          // This prevents overriding explicit user thread selections.
+          const activeSession = acpStore.activeSession;
+          if (!activeSession || activeSession.cwd !== newPath) {
+            acpStore.focusProjectSession(newPath);
+          }
         }
       },
       { defer: true },


### PR DESCRIPTION
## Summary
- Fixes Codex/Claude agent type mismatch in UI
- Messages sent to correct agent session now
- Agent label in chat input displays correct agent type

## Problem
When selecting a Codex Agent session from the sidebar, the chat input continued showing Claude Code and messages were sent to the wrong (Claude) session instead.

## Root Cause
The createEffect in AgentChat.tsx called focusProjectSession whenever fileTreeState.rootPath changed. When selectThread updated the project root, this triggered the effect which auto-focused the FIRST session matching that project (the Claude session), overriding the user's explicit Codex selection.

## Solution  
Added a guard condition: only call focusProjectSession if:
- There's no active session, OR
- The active session belongs to a different project

This preserves explicit user thread selections while still auto-focusing when genuinely switching projects.

## Testing
✅ Code compiles successfully
✅ Ready for manual testing with Codex/Claude agent switching

Fixes serenorg/seren-desktop-issues#7

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com