### PR TITLE
fix: model selector requires sidecar v0.2.1+

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -2083,12 +2083,27 @@ export const acpStore = {
         currentModelId: string;
         availableModels: AgentModelInfo[];
       };
+      console.log(
+        "[ACP] Setting models for session:",
+        sessionId,
+        "currentModel:",
+        models.currentModelId,
+        "available:",
+        models.availableModels,
+      );
       setState("sessions", sessionId, "currentModelId", models.currentModelId);
       setState(
         "sessions",
         sessionId,
         "availableModels",
         models.availableModels,
+      );
+    } else {
+      console.log(
+        "[ACP] No models in status event for session:",
+        sessionId,
+        "data:",
+        data,
       );
     }
 


### PR DESCRIPTION
## ✅ Root Cause Found

**Issue**: Model selector not appearing for Codex/Claude agents

**Root Cause**: The desktop was using `seren-acp-claude v0.1.2`, which predates the model selector feature. Model extraction and reporting was added in `v0.2.0`.

## Solution

Released **seren-acp-claude v0.2.1** with:
- Model extraction from Claude CLI server info
- Model state reporting in `NewSessionResponse`, `LoadSessionResponse`, `ResumeSessionResponse`, and `ForkSessionResponse`
- Support for `set_session_model` ACP command
- Comprehensive parsing for various Claude CLI output formats

## Changes in This PR

Added debug logging to trace model handling (can be removed after verification).

## Testing

1. Rebuild sidecars: `pnpm run prepare:sidecars`
2. Start dev server: `pnpm tauri dev`
3. Create Codex or Claude agent session
4. Verify model selector appears in UI
5. Test changing models

## Sidecar Version Requirements

- **Minimum**: seren-acp-claude >= v0.2.0
- **Recommended**: v0.2.1 (includes image support improvements)

Related to serenorg/seren-desktop-issues#8

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com