### PR TITLE
fix: add 10-minute request timeout to orchestrator HTTP client

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -25,6 +25,10 @@ const MAX_TOOL_ROUNDS: usize = 35;
 /// Connect timeout for the HTTP client (seconds).
 const CONNECT_TIMEOUT_SECS: u64 = 30;
 
+/// Overall request timeout for Gateway API calls (10 minutes).
+/// Allows for long-running agent requests with multiple tool execution rounds.
+const REQUEST_TIMEOUT_SECS: u64 = 600;
+
 /// Timeout for waiting on frontend tool execution (5 minutes).
 const TOOL_EXECUTION_TIMEOUT_SECS: u64 = 300;
 
@@ -104,6 +108,7 @@ impl ChatModelWorker {
         Self {
             client: reqwest::Client::builder()
                 .connect_timeout(Duration::from_secs(30))
+                .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
                 .build()
                 .unwrap_or_default(),
             cancelled: Arc::new(Mutex::new(false)),
@@ -115,6 +120,7 @@ impl ChatModelWorker {
     pub fn with_tools(tools: Vec<serde_json::Value>) -> Self {
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new());
         Self {


### PR DESCRIPTION
## Summary

Fixes #664 - Adds explicit 10-minute request timeout to the orchestrator HTTP client to prevent premature 3-minute timeouts during long-running agent requests.

## Problem

Users were experiencing consistent 3-minute timeouts when using the orchestrator to send chat requests:

```
API Error: Request timed out. Check your internet connection and proxy settings
✻ Worked for 3m 10s
```

The `reqwest::Client` in `chat_model_worker.rs` only had a `connect_timeout` (30s) but no overall `timeout()`, causing it to fall back to the default 3-minute timeout.

## Solution

Added explicit `REQUEST_TIMEOUT_SECS` constant (600s = 10 minutes) and applied it to both HTTP client builders:

```rust
.connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
.timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
```

This allows for:
- Multiple tool execution rounds (up to 35 rounds per MAX_TOOL_ROUNDS)
- Skills with complex workflows
- Long-running agent operations

## Changes

- **src-tauri/src/orchestrator/chat_model_worker.rs**
  - Added `REQUEST_TIMEOUT_SECS` constant (600s)
  - Updated `new()` test builder with timeout
  - Updated `with_tools()` builder with timeout

## Testing

- [x] Code compiles (cargo check)
- [ ] Manual test with long-running agent request (>3 minutes)
- [ ] Verify timeout at 10 minutes if request exceeds limit

---

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com