### PR TITLE
feat: enable network access for Codex agents

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -1355,14 +1355,20 @@ pub async fn acp_spawn(
     api_key: Option<String>,
     approval_policy: Option<String>,
     search_enabled: Option<bool>,
+    network_enabled: Option<bool>,
 ) -> Result<AcpSessionInfo, String> {
     let cwd = normalize_cwd(&cwd)?;
-    let parsed_sandbox_mode = sandbox_mode
+    let mut parsed_sandbox_mode = sandbox_mode
         .as_deref()
         .map(|s| s.parse::<crate::sandbox::SandboxMode>())
         .transpose()
         .map_err(|e| e)?
         .unwrap_or_default();
+
+    // Override to full-access mode if network access is explicitly enabled
+    if network_enabled.unwrap_or(false) {
+        parsed_sandbox_mode = crate::sandbox::SandboxMode::FullAccess;
+    }
     let session_id = local_session_id
         .as_deref()
         .map(str::trim)

--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -221,6 +221,7 @@ export type AcpEvent =
  * @param apiKey - Optional API key to enable Seren MCP tools for the agent
  * @param approvalPolicy - Optional approval policy for command execution
  * @param searchEnabled - Optional flag to enable web search
+ * @param networkEnabled - Optional flag to enable direct network access (uses full-access sandbox)
  */
 export async function spawnAgent(
   agentType: AgentType,
@@ -229,6 +230,7 @@ export async function spawnAgent(
   apiKey?: string,
   approvalPolicy?: string,
   searchEnabled?: boolean,
+  networkEnabled?: boolean,
   localSessionId?: string,
   resumeAgentSessionId?: string,
 ): Promise<AcpSessionInfo> {
@@ -241,6 +243,7 @@ export async function spawnAgent(
     apiKey: apiKey ?? null,
     approvalPolicy: approvalPolicy ?? null,
     searchEnabled: searchEnabled ?? null,
+    networkEnabled: networkEnabled ?? null,
   });
 }
 

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -634,6 +634,7 @@ export const acpStore = {
         apiKey ?? undefined,
         settingsStore.settings.agentApprovalPolicy,
         settingsStore.settings.agentSearchEnabled,
+        settingsStore.settings.agentNetworkEnabled,
         localSessionId,
         resumeAgentSessionId,
       );

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -95,6 +95,7 @@ export interface Settings {
   agentSandboxMode: "read-only" | "workspace-write" | "full-access";
   agentApprovalPolicy: "untrusted" | "on-failure" | "on-request" | "never";
   agentSearchEnabled: boolean;
+  agentNetworkEnabled: boolean;
   agentAutoApproveReads: boolean;
 
   // Voice settings
@@ -180,6 +181,7 @@ const DEFAULT_SETTINGS: Settings = {
   agentSandboxMode: "workspace-write",
   agentApprovalPolicy: "on-request",
   agentSearchEnabled: false,
+  agentNetworkEnabled: true,
   agentAutoApproveReads: true,
   // Voice
   voiceAutoSubmit: true,


### PR DESCRIPTION
## Summary

Enables direct network access (curl, urllib, DNS resolution) for Codex/Claude agents by adding a new `agentNetworkEnabled` setting that uses full-access sandbox mode.

## Changes

- **Settings**: Add `agentNetworkEnabled: boolean` (default: `true`)
- **Backend**: Override sandbox mode to `FullAccess` when network is enabled
- **Frontend**: Pass network setting through service → store → Tauri command

## Behavior

- **When enabled** (default): Agents can make direct network calls, resolve DNS, use curl/urllib
- **When disabled**: Agents use MCP tools for API access (current behavior)

## Testing

1. Create a Codex agent session
2. Try `curl https://api.serendb.com` - should succeed with network enabled
3. Disable network in Settings → Agent → Network Access
4. Try again - should fail with DNS resolution error

## Related

- Fixes serenorg/seren-desktop-issues#9
- Default: enabled for immediate customer relief
- Users can disable in settings if they prefer MCP-only approach

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com