### PR TITLE
fix: expose threadSkills in skillsStore to enable skill creation

### DIFF
--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -206,6 +206,13 @@ export const skillsStore = {
     return state.installed.filter((s) => s.enabled !== false);
   },
 
+  /**
+   * Get thread skills state map.
+   */
+  get threadSkills(): Record<string, string[] | null | undefined> {
+    return threadSkillsState;
+  },
+
   // --------------------------------------------------------------------------
   // Config loading
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The \"+ Create New Skill\" button in Codex/Claude agent chats throws an error and does nothing:

```
TypeError: undefined is not an object (evaluating 'Be.threadSkills.get')
```

## Root Cause

- `ThreadSidebar.tsx:127` tries to access `skillsStore.threadSkills.get()`
- `threadSkillsState` exists internally in skills.store.ts but was not exposed in the skillsStore export
- The getter was missing, making threadSkills undefined

## Solution

Added a getter to expose `threadSkillsState` as `threadSkills` in the skillsStore object:

```typescript
get threadSkills(): Record<string, string[] | null | undefined> {
  return threadSkillsState;
}
```

## Testing

1. Open a Codex or Claude agent chat
2. Click the \"+ Create New Skill\" button
3. Verify the skill creation flow works without errors
4. Check browser console for no errors

## Related

- Fixes serenorg/seren-desktop-issues#10

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com