### PR TITLE
feat: add Polymarket position syncing to polymarket-trader skill

### DIFF
--- a/skills/polymarket-trader/agent.py
+++ b/skills/polymarket-trader/agent.py
@@ -71,6 +71,19 @@ class TradingAgent:
         print(f"  Max positions: {self.max_positions}")
         print()
 
+        # Sync positions on startup
+        print("Syncing positions with Polymarket...")
+        try:
+            sync_result = self.positions.sync_with_polymarket(self.polymarket)
+            print(f"✓ Position sync complete:")
+            print(f"  Added: {sync_result['added']}")
+            print(f"  Updated: {sync_result['updated']}")
+            print(f"  Removed: {sync_result['removed']}")
+            print(f"  Total positions: {len(self.positions.get_all_positions())}")
+        except Exception as e:
+            print(f"⚠️  Position sync failed: {e}")
+        print()
+
     def check_balances(self) -> Dict[str, float]:
         """
         Check SerenBucks and Polymarket balances
@@ -341,6 +354,18 @@ class TradingAgent:
         print(f"Balances:")
         print(f"  SerenBucks: ${balances['serenbucks']:.2f}")
         print(f"  Polymarket: ${balances['polymarket']:.2f}")
+        print()
+
+        # Sync positions with Polymarket API
+        print("Syncing positions...")
+        try:
+            sync_result = self.positions.sync_with_polymarket(self.polymarket)
+            if sync_result['added'] > 0 or sync_result['removed'] > 0 or sync_result['updated'] > 0:
+                print(f"  Added: {sync_result['added']}, Updated: {sync_result['updated']}, Removed: {sync_result['removed']}")
+            else:
+                print(f"  All positions in sync ({len(self.positions.get_all_positions())} open)")
+        except Exception as e:
+            print(f"  ⚠️  Sync failed: {e}")
         print()
 
         # Check for low balances

--- a/skills/polymarket-trader/test_syntax.py
+++ b/skills/polymarket-trader/test_syntax.py
@@ -48,6 +48,10 @@ try:
     assert hasattr(PolymarketClient, 'get_positions'), "PolymarketClient missing get_positions"
     print("  ✅ PolymarketClient has all required methods")
 
+    # Check PositionTracker methods
+    assert hasattr(PositionTracker, 'sync_with_polymarket'), "PositionTracker missing sync_with_polymarket"
+    print("  ✅ PositionTracker has sync_with_polymarket method")
+
 except AssertionError as e:
     print(f"  ❌ {e}")
     sys.exit(1)


### PR DESCRIPTION
## Summary

Adds automatic position synchronization with Polymarket API to keep local position tracking in sync with actual on-chain positions.

## Changes

**position_tracker.py:**
- Added sync_with_polymarket() method that calls Polymarket API via MCP server
- Syncs positions from API and merges with local tracking
- Adds new positions found in API that aren't tracked locally
- Removes positions that no longer exist in API (closed/resolved markets)
- Updates prices for existing positions during sync
- Returns dict with added/removed/updated counts

**agent.py:**
- Call position sync on agent startup (after initialization)
- Call position sync at start of each scan cycle (after balance check)
- Display sync results to user (added/removed/updated counts)

**test_syntax.py:**
- Added verification that sync_with_polymarket method exists

## Implementation Details

- Uses existing polymarket_client.get_positions() method
- Leverages Polymarket MCP server (no custom API code)
- Handles different API response formats adaptively
- Graceful error handling with fallback
- Positions keyed by market_id for efficient lookups

## Testing

- ✅ Syntax validation passes
- ✅ Module imports successfully
- ✅ Method signature verified

## Fixes

Closes #672