### PR TITLE
fix: add configurable agent timeouts with heartbeat and skill exemptions

### DIFF
--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -25,6 +25,8 @@ export interface AcpSessionInfo {
   createdAt: string;
   /** Remote ACP session id (e.g., Codex thread id). Populated after ready. */
   agentSessionId?: string;
+  /** Prompt timeout in seconds. Undefined means unlimited (no timeout). */
+  timeoutSecs?: number;
 }
 
 export interface AgentInfo {
@@ -222,6 +224,7 @@ export type AcpEvent =
  * @param approvalPolicy - Optional approval policy for command execution
  * @param searchEnabled - Optional flag to enable web search
  * @param networkEnabled - Optional flag to enable direct network access (uses full-access sandbox)
+ * @param timeoutSecs - Optional timeout in seconds for prompts. Undefined means unlimited.
  */
 export async function spawnAgent(
   agentType: AgentType,
@@ -233,6 +236,7 @@ export async function spawnAgent(
   networkEnabled?: boolean,
   localSessionId?: string,
   resumeAgentSessionId?: string,
+  timeoutSecs?: number,
 ): Promise<AcpSessionInfo> {
   return invoke<AcpSessionInfo>("acp_spawn", {
     agentType,
@@ -244,6 +248,7 @@ export async function spawnAgent(
     approvalPolicy: approvalPolicy ?? null,
     searchEnabled: searchEnabled ?? null,
     networkEnabled: networkEnabled ?? null,
+    timeoutSecs: timeoutSecs ?? null,
   });
 }
 

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -627,6 +627,16 @@ export const acpStore = {
 
       // Get Seren API key to enable MCP tools for the agent
       const apiKey = await getSerenApiKey();
+
+      // Determine timeout based on enabled skills:
+      // - Long-running skills (polymarket-trader, polymarket-data) get unlimited timeout
+      // - Other sessions get default 300s timeout
+      const longRunningSkills = ["polymarket-trader", "polymarket-data"];
+      const hasLongRunningSkill = skillsStore.installed.some(
+        (skill) => skill.enabled && longRunningSkills.includes(skill.slug),
+      );
+      const timeoutSecs = hasLongRunningSkill ? undefined : 300;
+
       const info = await acpService.spawnAgent(
         resolvedAgentType,
         cwd,
@@ -637,6 +647,7 @@ export const acpStore = {
         settingsStore.settings.agentNetworkEnabled,
         localSessionId,
         resumeAgentSessionId,
+        timeoutSecs,
       );
       console.log("[AcpStore] Spawn result:", info);
 


### PR DESCRIPTION
## Problem

Trading agents and other long-running skills timeout after 300 seconds (5 minutes) of inactivity, killing the session even when the agent is actively working.

Closes #671

## Solution

Implements all three approaches:

### 1. Configurable Timeout Per Agent Type
- Added `timeout_secs` field to spawn request
- Sessions can specify custom timeout (`None` = unlimited)
- Default: 300s for interactive, unlimited for skill-based agents

### 2. Heartbeat Mechanism
- Agents can send "heartbeat" extension notifications
- Resets inactivity timer without producing visible output
- Allows long-running operations to stay alive

### 3. Skill-Based Timeout Exemptions
- Checks if session has long-running skills enabled
- Polymarket-trader and polymarket-data get unlimited timeout
- Interactive sessions maintain 5-minute timeout for hung agents

## Changes

- **src-tauri/src/acp.rs**: Add timeout configuration and heartbeat handling
- **src/services/acp.ts**: Update AcpSessionInfo interface
- **src/stores/acp.store.ts**: Set appropriate timeout based on enabled skills

## Testing

- ✅ Trading bots can run indefinitely without timeout
- ✅ Interactive sessions still timeout after 5 minutes of inactivity
- ✅ Heartbeat notifications keep sessions alive during long operations

## Impact

- Trading bots can run for hours without interruption
- Other long-running automation tasks won't get killed
- Interactive sessions maintain safety timeout for hung agents

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com