### PR TITLE
Set MiniMax M2.5 as Default Seren Agent Model

### DIFF
--- a/src/services/models.ts
+++ b/src/services/models.ts
@@ -104,6 +104,7 @@ function extractProvider(modelId: string): string {
     perplexity: "Perplexity",
     deepseek: "DeepSeek",
     qwen: "Qwen",
+    minimax: "MiniMax",
     "x-ai": "xAI",
     microsoft: "Microsoft",
     nvidia: "NVIDIA",
@@ -130,6 +131,12 @@ function capitalize(str: string): string {
 
 function getDefaultModels(): Model[] {
   return [
+    {
+      id: "minimax/minimax-m2.5",
+      name: "MiniMax M2.5",
+      provider: "MiniMax",
+      contextWindow: 128000,
+    },
     {
       id: "anthropic/claude-sonnet-4",
       name: "Claude Sonnet 4",


### PR DESCRIPTION
## Summary

Sets MiniMax M2.5 as the default Seren Agent Model, replacing Claude Sonnet 4.

## Why MiniMax M2.5?

**Performance:**
- 80.2% on SWE-Bench Verified (vs Sonnet 4's 77.2%)
- Nearly matches Opus 4.6 (80.8%) at 17x lower cost
- 8.17% hallucination rate (vs Gemini 3 Flash's 91%)

**Cost:**
- Input: $0.30 per 1M tokens
- Output: $1.20 per 1M tokens
- 5-10x cheaper than Claude Sonnet 4
- 17x cheaper than Opus 4.6

**Capabilities:**
- Strong agentic workflow support
- 128K context window
- Excellent coding performance

## Changes

- Added MiniMax M2.5 as first entry in default models list
- Added minimax provider mapping for proper display
- Context window: 128K tokens

## Testing

- [x] Model appears in dropdown
- [ ] Model selection persists
- [ ] API calls route correctly through OpenRouter

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com