### PR TITLE
fix: suppress timeout assistant content

### DIFF
--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -68,6 +68,19 @@ const TIMEOUT_PATTERNS = [
   "operation timeout",
 ];
 
+/** Tighter patterns for assistant content that should be treated as timeout errors. */
+const TIMEOUT_ASSISTANT_PATTERNS = [
+  /api error:\s*request timed out/i,
+  /request timed out/i,
+  /request timeout/i,
+  /408 request timeout/i,
+  /deadline exceeded/i,
+  /operation timeout/i,
+  /connection timed out/i,
+  /network timeout/i,
+  /timed out\.\s*check your internet/i,
+];
+
 /**
  * Check whether an error message indicates a request timeout.
  * These errors are often spurious race conditions where the error event
@@ -76,6 +89,14 @@ const TIMEOUT_PATTERNS = [
 export function isTimeoutError(message: string): boolean {
   const lower = message.toLowerCase();
   return TIMEOUT_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
+/**
+ * Stricter timeout detection for assistant content to avoid suppressing
+ * normal responses that mention timeouts in passing.
+ */
+export function isTimeoutAssistantContent(message: string): boolean {
+  return TIMEOUT_ASSISTANT_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 /**

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -16,9 +16,11 @@ import { isLikelyAuthError } from "@/lib/auth-errors";
 import {
   isPromptTooLongError,
   isRateLimitError,
+  isTimeoutAssistantContent,
   isTimeoutError,
   performAgentFallback,
 } from "@/lib/rate-limit-fallback";
+import { telemetry } from "@/services/telemetry";
 import {
   createAgentConversation,
   type AgentConversation as DbAgentConversation,
@@ -2161,13 +2163,21 @@ export const acpStore = {
 
     // Finalize assistant content if any
     if (session.streamingContent) {
-      if (isTimeoutError(session.streamingContent)) {
+      if (isTimeoutAssistantContent(session.streamingContent)) {
         // Some agents emit a timeout string as assistant content even when the
         // prompt completes successfully. Surface this as a session error banner
         // instead of adding a misleading assistant message.
         console.info(
           "[AcpStore] Suppressing timeout assistant message — surfacing banner instead",
         );
+        telemetry.captureError(new Error("ACP assistant timeout content"), {
+          type: "acp_timeout_assistant_content",
+          agentType: session.info.agentType,
+          sessionId,
+          agentSessionId: session.agentSessionId,
+          conversationId: session.conversationId,
+          timeoutSecs: session.info.timeoutSecs,
+        });
         setState("sessions", sessionId, "error", session.streamingContent);
         setState("sessions", sessionId, "streamingContent", "");
         setState("sessions", sessionId, "streamingContentTimestamp", undefined);


### PR DESCRIPTION
## Summary
- suppress timeout assistant text when it is emitted as assistant content
- surface the timeout as a session error banner instead

## Testing
- not run (UI change)

Fixes #682