### PR TITLE
fix: use getToken from auth service instead of authStore

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -36,6 +36,7 @@ import {
   orchestrate,
   retryOrchestration,
 } from "@/services/orchestrator";
+import { getToken } from "@/services/auth";
 import { authStore, checkAuth } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
@@ -686,7 +687,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     try {
       // Save to Seren Notes
       const title = `Chat History - ${new Date().toLocaleDateString()}`;
-      const apiKey = await authStore.getToken();
+      const apiKey = await getToken();
       const response = await fetch(
         "https://api.serendb.com/publishers/seren-notes/notes",
         {


### PR DESCRIPTION
Fixes #688

## Problem
Seren Notes save feature was calling `authStore.getToken()` but that method doesn't exist on the auth store, causing a TypeError.

## Solution
- Import `getToken` from `@/services/auth`  
- Replace `authStore.getToken()` with `getToken()` at [ChatContent.tsx:690](https://github.com/serenorg/seren-desktop/blob/fix/688-seren-notes-getToken/src/components/chat/ChatContent.tsx#L690)

## Testing
- Save chat history to Seren Notes should now work without errors

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com