### PR TITLE
fix: update UI when automatic model fallback occurs (#691)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -333,7 +333,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   };
 
   const clearHistory = async () => {
-    const confirmClear = window.confirm("Clear all agent chat history for this session?");
+    const confirmClear = window.confirm(
+      "Clear all agent chat history for this session?",
+    );
     if (!confirmClear) return;
 
     const session = acpStore.activeSession;
@@ -724,7 +726,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           <button
             type="button"
             class="bg-transparent border border-border text-muted-foreground px-2 py-1 rounded text-xs cursor-pointer transition-all hover:bg-surface-2 hover:text-foreground"
-            onClick={() => compactConversation(settingsStore.get("autoCompactPreserveMessages"))}
+            onClick={() =>
+              compactConversation(
+                settingsStore.get("autoCompactPreserveMessages"),
+              )
+            }
             title="Compact older messages"
           >
             Compact

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -1298,7 +1298,12 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                 <Show when={conversationStore.isLoading}>
                   <ThinkingStatus />
                 </Show>
-                <Show when={!conversationStore.isLoading && conversationStore.messages.length > 0}>
+                <Show
+                  when={
+                    !conversationStore.isLoading &&
+                    conversationStore.messages.length > 0
+                  }
+                >
                   <span class="text-[10px] text-muted-foreground">
                     {settingsStore.get("chatEnterToSend")
                       ? "Enter to send"

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -8,6 +8,7 @@ import { getAllTools } from "@/lib/tools";
 import { executeTool } from "@/lib/tools/executor";
 import { storeAssistantResponse } from "@/services/memory";
 import { acpStore } from "@/stores/acp.store";
+import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { AUTO_MODEL_ID, providerStore } from "@/stores/provider.store";
@@ -516,6 +517,10 @@ function handleReroute(event: {
   // Reset streaming state for the new model attempt
   activeMessageId = crypto.randomUUID();
   streamStartTime = Date.now();
+
+  // Update UI to reflect the actual model being used after automatic fallback
+  providerStore.setActiveModel(event.to_model);
+  chatStore.setModel(event.to_model);
 
   // Add a reroute announcement message to the conversation
   const rerouteMessage: UnifiedMessage = {


### PR DESCRIPTION
## Summary

Fixes #691 - When a model times out and the backend automatically falls back to a faster model (Opus → Sonnet → Haiku), the frontend now updates the model selector to reflect which model is actually being used.

## Problem

The automatic reroute logic in the Rust backend would switch models on timeout, but the frontend UI (model selector dropdown) wasn't updated to reflect this change. This created confusion:

1. User selects Opus, request times out
2. Backend automatically falls back to Sonnet (then Haiku)
3. UI still shows "Opus" selected
4. User manually changes to "Sonnet" thinking they're changing models
5. Clicks Retry with Sonnet
6. Same timeout behavior occurs, appears like retry didn't respect new selection

## Solution

Update `handleReroute()` in `orchestrator.ts` to call:
- `providerStore.setActiveModel(event.to_model)`
- `chatStore.setModel(event.to_model)`

This syncs the UI with the backend's automatic model changes, providing transparency about which model is actually being used.

## Changes

- Add chatStore import to orchestrator.ts
- Update model stores in handleReroute() when automatic fallback occurs
- Biome formatting fixes applied

## Test Plan

1. Select a model that will timeout (e.g., Claude Opus 4.6)
2. Send a request that triggers timeout
3. Verify model selector updates to show fallback model (Sonnet, then Haiku)
4. Manually select a different model
5. Click Retry
6. Verify the newly selected model is used

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com