### PR TITLE
feat: set MiniMax M2.5 as default model for general chat (#695)

### DIFF
--- a/src-tauri/src/orchestrator/router.rs
+++ b/src-tauri/src/orchestrator/router.rs
@@ -11,6 +11,7 @@ const CODE_PREFERRED_MODELS: &[&str] = &["anthropic/claude-opus-4-6", "openai/gp
 
 /// Preferred models for simple Q&A (ordered by speed/cost).
 const SIMPLE_PREFERRED_MODELS: &[&str] = &[
+    "minimax/minimax-m2.5",
     "google/gemini-3-flash-preview",
     "google/gemini-2.5-flash",
     "anthropic/claude-haiku-4.5",


### PR DESCRIPTION
## Summary

Fixes #695 - Sets MiniMax M2.5 as the first choice for general chat in auto mode, reducing costs for users while maintaining quality.

## Changes

Updated `SIMPLE_PREFERRED_MODELS` in [router.rs](src-tauri/src/orchestrator/router.rs#L13-L21) to prioritize MiniMax M2.5:

**Before:**
1. Gemini 3 Flash Preview
2. Gemini 2.5 Flash
3. Haiku 4.5
4. ...

**After:**
1. **MiniMax M2.5** (most cost-effective)
2. Gemini 3 Flash Preview
3. Gemini 2.5 Flash
4. Haiku 4.5
5. ...

## Impact

- **Cost Reduction**: MiniMax M2.5 is cheaper than Gemini 3 Flash
- **Quality Maintained**: Still automatically upgrades to more capable models for complex tasks
- **Backward Compatible**: Existing explicit model selections are unaffected
- **Smart Fallback**: If MiniMax unavailable, falls back to Gemini/Haiku chain

## Testing

- ✅ Rust compilation passes
- Model selection logic unchanged, only preference order updated
- Automatic routing and Thompson sampling still work as before

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com