### PR TITLE
fix: auto-execute skills when clicked in thread sidebar (#694)

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -609,7 +609,10 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                         if (skillSlug) {
                           window.dispatchEvent(
                             new CustomEvent("seren:set-chat-input", {
-                              detail: `/${skillSlug} `,
+                              detail: {
+                                text: `/${skillSlug} `,
+                                autoSend: true,
+                              },
                             }),
                           );
                         }


### PR DESCRIPTION
## Summary
Fixes #694 - Skills clicked in the thread sidebar now automatically execute instead of just inserting the command and leaving users confused.

## Problem
When users click an active skill in the thread sidebar, the skill command is inserted into the chat input (e.g., "/skill-creator ") but nothing happens. Users are left confused, not realizing they need to manually press Send/Enter to actually start the skill.

![Current UX issue](~/Desktop/skill-help.png)

## Root Cause
The skill click handler in ThreadSidebar.tsx dispatched a `seren:set-chat-input` custom event with just the command text. The event handlers in ChatContent.tsx and AgentChat.tsx only:
- Set the input value
- Focus the input field

They did NOT auto-send the message, requiring users to manually press Send/Enter.

## Solution

### 1. Enhanced the `seren:set-chat-input` event format
The event now supports two formats:
- **Legacy (string)**: `detail: "/skill-creator "` - backward compatible
- **New (object)**: `detail: { text: "/skill-creator ", autoSend: true }` - with auto-send flag

### 2. Updated event handlers
Modified `handleSetChatInput` in both ChatContent.tsx and AgentChat.tsx to:
- Detect event detail format (string vs object)
- Support legacy string format (set input only)
- Support new object format with optional autoSend flag
- Call `sendMessage()` when `autoSend: true`
- Use `setTimeout` to ensure input is set before sending

### 3. Updated skill click dispatcher
Modified ThreadSidebar.tsx skill click handler to dispatch with:
```typescript
window.dispatchEvent(
  new CustomEvent("seren:set-chat-input", {
    detail: {
      text: `/${skillSlug} `,
      autoSend: true,
    },
  }),
);
```

## Behavior After Fix

| Action | Before | After |
|--------|--------|-------|
| Click active skill in sidebar | Inserts command, no execution | Inserts command + auto-executes ✅ |
| Click "Create new skill" button | Inserts prompt text | Same (allows editing before send) ✅ |
| Other event dispatchers | Work normally | Still work (backward compatible) ✅ |

## Technical Details

### Files Changed
- **src/components/chat/ChatContent.tsx** - Updated `handleSetChatInput` event handler
- **src/components/chat/AgentChat.tsx** - Updated `onSetChatInput` event handler
- **src/components/layout/ThreadSidebar.tsx** - Updated skill click dispatcher

### Type Safety
```typescript
const customEvent = event as CustomEvent<
  string | { text: string; autoSend?: boolean }
>;
```

### Backward Compatibility
All existing event dispatchers using string format continue to work:
- SkillsSelector.tsx line 116 - "Create new skill" prompt
- ThreadSidebar.tsx line 567 - "Create new skill" button

These intentionally do NOT auto-send, allowing users to edit the prompt first.

## Testing
- ✅ All Biome checks pass
- ✅ Type-safe with proper CustomEvent typing
- ✅ Legacy string format still supported
- ✅ No breaking changes to existing functionality

## Related
- Closes #694

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com