### PR TITLE
DEBUG: Single skill click bug investigation (#723)

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -173,7 +173,16 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
     const skillPath = installedSkill.path;
 
     const activeSkills = skillsStore.getThreadSkills(cwd, thread.id);
-    return activeSkills.some((s) => s.path === skillPath);
+    const isActive = activeSkills.some((s) => s.path === skillPath);
+
+    console.log("[ThreadSidebar] isSkillActiveInThread:", {
+      skillName: skill.name,
+      skillPath,
+      activeSkillsCount: activeSkills.length,
+      isActive,
+    });
+
+    return isActive;
   };
 
   const filteredSkills = () => {
@@ -603,9 +612,19 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                     const isSearching = launcherQuery().trim().length > 0;
 
                     const handleClick = () => {
+                      console.log("[ThreadSidebar] handleClick:", {
+                        skillName: skill.name,
+                        isActive,
+                        isSearching,
+                      });
+
                       if (isActive) {
                         // Active skill (in thread) = Invoke the skill
                         const skillSlug = "slug" in skill ? skill.slug : "";
+                        console.log(
+                          "[ThreadSidebar] Invoking skill:",
+                          skillSlug,
+                        );
                         if (skillSlug) {
                           window.dispatchEvent(
                             new CustomEvent("seren:set-chat-input", {
@@ -618,6 +637,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                         }
                       } else {
                         // Inactive skill (not in thread) = Add to thread
+                        console.log("[ThreadSidebar] Adding skill to thread");
                         handleSkillThread(skill);
                       }
                     };
@@ -691,6 +711,10 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                             type="button"
                             class="absolute top-2 right-2 w-5 h-5 flex items-center justify-center rounded bg-muted text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity hover:bg-muted-foreground/20"
                             onClick={(e) => {
+                              console.log(
+                                "[ThreadSidebar] X button clicked:",
+                                skill.name,
+                              );
                               e.stopPropagation();
                               handleSkillThread(skill);
                             }}


### PR DESCRIPTION
## Summary  
Debug PR to investigate why clicking a single active skill removes it instead of invoking it.

## Issue
#723 - When there's only ONE active skill, clicking removes it. With TWO+ skills, clicking correctly invokes.

## Debugging Added
Added console logging to:
1. `isSkillActiveInThread()` - Shows if skill is correctly detected as active
2. `handleClick()` - Shows which code path executes (invoke vs add)
3. X button `onClick` - Confirms if X button is accidentally clicked

## Testing Instructions
1. Open DevTools Console
2. Add one skill (e.g., "Web Search")
3. Click the skill card
4. Check console logs:
   - Does `isActive` show true or false?
   - Does it say "Invoking skill" or "Adding skill to thread"?
   - Does "X button clicked" appear?

## Expected Console Output (Should Invoke)
```
[ThreadSidebar] isSkillActiveInThread: {skillName: 'Web', activeSkillsCount: 1, isActive: true}
[ThreadSidebar] handleClick: {skillName: 'Web', isActive: true, isSearching: false}
[ThreadSidebar] Invoking skill: web
```

## Actual Output (Bug)  
TBD - Taariq will test and share console logs

## Next Steps
Once we see the console logs, we'll know:
- If `isActive` is wrong (reactivity bug)
- If X button is being clicked (UI overlap)
- If another code path is executing

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com