### PR TITLE
fix: Connect memory service to memory.serendb.com REST API

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -644,7 +644,7 @@ pub fn run() {
                     .unwrap_or_default();
 
                 app.manage(commands::memory::MemoryState::new(
-                    "https://api.serendb.com".to_string(),
+                    "https://memory.serendb.com".to_string(),
                     api_key,
                     cache_path,
                 ));


### PR DESCRIPTION
## Summary

Fixes memory integration by connecting to the correct seren-memory service endpoint.

## Changes

- Update memory service base URL from  to 
- Fixes 404 errors when calling memory operations (remember, recall, bootstrap)

## Problem

The client was trying to call memory endpoints at  which don't exist. The seren-memory publisher is hosted at  with REST endpoints at .

## Testing

Tested the new REST endpoints:
- ✅ POST /api/remember - Store memories
- ✅ POST /api/recall - Search/retrieve memories
- ✅ POST /api/bootstrap - Get session context
- ✅ GET /api/memories - List memories

All endpoints working correctly with authentication.

## Related Issues

- Closes serenorg/seren-memory#1

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com