### PR TITLE
fix: prevent MCP server stderr blocking by redirecting to null

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -184,7 +184,7 @@ pub fn mcp_connect(
     cmd.args(&args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .stderr(Stdio::null()); // Discard stderr to prevent blocking
 
     // Inject the embedded runtime PATH so child processes can find bundled node/git
     let embedded_path = embedded_runtime::get_embedded_path();


### PR DESCRIPTION
## Summary
Fixes Playwright MCP server initialization failure by preventing stderr pipe blocking.

## Problem  
Playwright MCP server (and potentially other MCP servers) fail with error:
```
Failed to parse response: EOF while parsing a value at line 1 column 0
```

UI shows:
- Server name: playwright
- Status: 🔴 (error)
- Tools: 0 tools

## Root Cause
Classic pipe deadlock issue in src-tauri/src/mcp.rs:

1. Line 187: .stderr(Stdio::piped()) creates a pipe for stderr
2. MCP server writes debug/warning messages to stderr
3. Pipe buffer fills up (~64KB)
4. Process blocks waiting for stderr to be read
5. Blocked process cannot write to stdout
6. read_line() returns empty string
7. JSON parser gets EOF

## Solution
Change: Redirect stderr to /dev/null instead of piping it

```rust
// Before (line 187):
.stderr(Stdio::piped())

// After:
.stderr(Stdio::null()) // Discard stderr to prevent blocking
```

Rationale:
- MCP protocol uses only stdout/stdin for JSON-RPC communication
- stderr is for debugging/warnings only (not part of protocol)
- We were not reading stderr anyway, so piping it caused deadlock
- Discarding stderr prevents blocking with no functional loss

## Testing
Verified Playwright MCP server works correctly via command line:

1. Initialize - Returns protocolVersion, capabilities, serverInfo
2. notifications/initialized - Notification sent (no response expected)
3. tools/list - Returns 22 Playwright browser automation tools

## Impact
- Fixes #745 - Playwright MCP server initialization
- Prevents deadlock for any MCP server that writes to stderr
- No functional change (stderr was not being consumed anyway)
- Loses stderr debugging output (acceptable trade-off for stability)

## Alternative Considered
Could spawn a background thread to consume stderr, but:
- More complex implementation
- stderr is not needed for MCP protocol operation  
- Simpler solution (null redirect) is more maintainable

## Files Changed
File: src-tauri/src/mcp.rs
- Line 187: Changed .stderr(Stdio::piped()) to .stderr(Stdio::null())

Fixes #745

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
