### PR TITLE
fix: poll for updates hourly and close About dialog on install

### DIFF
--- a/src/components/common/AboutDialog.tsx
+++ b/src/components/common/AboutDialog.tsx
@@ -89,6 +89,7 @@ export function AboutDialog() {
   }
 
   function installUpdate() {
+    close();
     updaterStore.installAvailableUpdate();
   }
 

--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -35,6 +35,8 @@ const [state, setState] = createStore<UpdaterState>({
 
 let initialized = false;
 
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
 async function initUpdater(): Promise<void> {
   if (initialized) return;
   initialized = true;
@@ -45,6 +47,13 @@ async function initUpdater(): Promise<void> {
   }
 
   await checkForUpdates();
+
+  // Re-check hourly so the badge appears without requiring a restart
+  setInterval(() => {
+    if (state.status !== "downloading" && state.status !== "installing") {
+      checkForUpdates();
+    }
+  }, UPDATE_CHECK_INTERVAL_MS);
 }
 
 // Store the update object for later installation


### PR DESCRIPTION
## Summary

Two bugs in the update flow fixed in a single commit.

**Bug 1 — Green badge never appears without restart**
`initUpdater()` checked for updates exactly once at startup, guarded by an `initialized` flag. If a new version was released while the app was running, the badge stayed hidden until the next restart. Added a 1-hour `setInterval` in `initUpdater()` that re-checks any time the updater is not already downloading or installing.

**Bug 2 — "Install Update" click does nothing visible**
`installUpdate()` in `AboutDialog` was fire-and-forget — it called `installAvailableUpdate()` without closing the dialog. The download progress bar lives in the Titlebar, which was fully obscured by the open modal. Added `close()` before starting the install so the progress bar is immediately visible.

## Changes

- `src/stores/updater.store.ts` — `initUpdater()` now sets a 1-hour polling interval after the startup check
- `src/components/common/AboutDialog.tsx` — `installUpdate()` now calls `close()` before `installAvailableUpdate()`

## Test Plan

- [ ] Open app, wait >1 hour (or mock interval), confirm badge appears when a new version is available
- [ ] Open About dialog, click "Check for Updates", find update, click "Install Update X.X.X" — dialog closes and progress bar shows in Titlebar

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com