### PR TITLE
fix: move nsis config inside bundle.windows

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -70,10 +70,10 @@
     },
     "windows": {
       "certificateThumbprint": null,
-      "timestampUrl": "https://timestamp.digicert.com"
-    },
-    "nsis": {
-      "installerHooks": "nsis/installer-hooks.nsh"
+      "timestampUrl": "https://timestamp.digicert.com",
+      "nsis": {
+        "installerHooks": "nsis/installer-hooks.nsh"
+      }
     }
   }
 }


### PR DESCRIPTION
tauri-build 2.5.5 rejects nsis as a top-level bundle field. Moves bundle.nsis into bundle.windows.nsis where the schema expects it. Broke test-rust CI on both main and PRs after #765 merged.