### PR TITLE
fix: surface Seren Notes response errors in agent chat download

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -359,9 +359,13 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       }
 
       const result = await response.json();
-      const noteId = result?.data?.id;
+      console.log("[AgentChat] Seren Notes response:", JSON.stringify(result));
+      const noteId = result?.data?.id ?? result?.id;
       if (noteId) {
         openExternalLink(`https://notes.serendb.com/_authed/notes/${noteId}`);
+      } else {
+        console.error("[AgentChat] No noteId in response:", result);
+        alert("Note saved but could not open it. Check console for details.");
       }
     } catch (error) {
       console.error("[AgentChat] Failed to save to Seren Notes:", error);


### PR DESCRIPTION
## Summary

- Adds `console.log` of the full Seren Notes API response to diagnose why `noteId` is missing after a successful request (the \"nothing happens\" bug)
- Adds `?? result?.id` fallback in case the Gateway proxy strips the `data` wrapper from the Seren Notes response
- Alerts the user instead of silently doing nothing when `noteId` is falsy after a 200/201 response

## Test plan

- [ ] Click the download button in Agent Chat after warmup
- [ ] Check console for `[AgentChat] Seren Notes response:` log — use the shape to confirm correct ID path
- [ ] Confirm note opens in browser OR a meaningful alert appears (not silence)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com