### PR TITLE
fix: extract noteId from Gateway envelope in Seren Notes response

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -359,13 +359,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       }
 
       const result = await response.json();
-      console.log("[AgentChat] Seren Notes response:", JSON.stringify(result));
-      const noteId = result?.data?.id ?? result?.id;
+      const noteId = result?.body?.data?.id ?? result?.data?.id;
       if (noteId) {
         openExternalLink(`https://notes.serendb.com/_authed/notes/${noteId}`);
       } else {
-        console.error("[AgentChat] No noteId in response:", result);
-        alert("Note saved but could not open it. Check console for details.");
+        throw new Error("Note created but ID missing from response");
       }
     } catch (error) {
       console.error("[AgentChat] Failed to save to Seren Notes:", error);


### PR DESCRIPTION
## Summary

The Gateway wraps Seren Notes upstream responses as:
\`\`\`json
{ "status": 201, "body": { "data": { "id": "..." } } }
\`\`\`

Both `AgentChat` and `ChatContent` were reading `result.data.id` which is always `undefined` — causing silent failure (the download button appeared to do nothing after a successful note creation).

The fix reads `result.body.data.id` with `result.data.id` as a fallback.

Also removes the diagnostic `console.log` added in #770 since the response shape is now confirmed.

## Test plan

- [ ] Click download in Agent Chat (after DB warmup)
- [ ] Note opens in browser at `notes.serendb.com`
- [ ] Same test in main Chat panel via Chat download button

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com