### PR TITLE
fix: silent auto-retry on 408 for Seren Notes, prevent duplicate saves

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -19,9 +19,7 @@ import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { isAuthError } from "@/lib/auth-errors";
 import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
-import { API_BASE } from "@/lib/config";
 import { openExternalLink } from "@/lib/external-link";
-import { appFetch } from "@/lib/fetch";
 import { formatDurationWithVerb } from "@/lib/format-duration";
 import { pickAndReadAttachments } from "@/lib/images/attachments";
 import type { Attachment } from "@/lib/providers/types";
@@ -30,8 +28,8 @@ import {
   mapAgentModelToChat,
 } from "@/lib/rate-limit-fallback";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
+import { saveToSerenNotes } from "@/lib/save-to-notes";
 import { type AgentType, type DiffEvent, launchLogin } from "@/services/acp";
-import { getToken } from "@/services/auth";
 import { type AgentMessage, acpStore } from "@/stores/acp.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { settingsStore } from "@/stores/settings.store";
@@ -317,7 +315,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
   };
 
+  const [isSaving, setIsSaving] = createSignal(false);
+
   const downloadChatHistory = async () => {
+    if (isSaving()) return;
     const messages = threadMessages();
     if (messages.length === 0) return;
 
@@ -334,40 +335,14 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       }
     }
 
+    setIsSaving(true);
     try {
-      const token = await getToken();
-      if (!token) throw new Error("Not authenticated");
-
-      const response = await appFetch(
-        `${API_BASE}/publishers/seren-notes/notes`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            title,
-            content: markdown,
-            format: "markdown",
-          }),
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error(`Notes API returned ${response.status}`);
-      }
-
-      const result = await response.json();
-      const noteId = result?.body?.data?.id ?? result?.data?.id;
-      if (noteId) {
-        openExternalLink(`https://notes.serendb.com/notes/${noteId}`);
-      } else {
-        throw new Error("Note created but ID missing from response");
-      }
+      await saveToSerenNotes(title, markdown);
     } catch (error) {
       console.error("[AgentChat] Failed to save to Seren Notes:", error);
       alert("Failed to save to Seren Notes. Are you logged in?");
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -799,8 +774,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           </button>
           <button
             type="button"
-            class="bg-transparent border border-border text-muted-foreground p-1.5 rounded text-xs cursor-pointer transition-all hover:bg-surface-2 hover:text-foreground"
+            class="bg-transparent border border-border text-muted-foreground p-1.5 rounded text-xs cursor-pointer transition-all hover:bg-surface-2 hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={downloadChatHistory}
+            disabled={isSaving()}
             title="Download chat history"
           >
             <svg

--- a/src/lib/save-to-notes.ts
+++ b/src/lib/save-to-notes.ts
@@ -1,0 +1,50 @@
+// ABOUTME: Saves markdown content to Seren Notes via the Gateway publisher proxy.
+// ABOUTME: Retries silently on 408 (scale-to-zero DB cold start) before giving up.
+
+import { API_BASE } from "@/lib/config";
+import { openExternalLink } from "@/lib/external-link";
+import { appFetch } from "@/lib/fetch";
+import { getToken } from "@/services/auth";
+
+const RETRY_DELAYS_MS = [10_000, 20_000];
+
+export async function saveToSerenNotes(
+  title: string,
+  content: string,
+): Promise<void> {
+  const token = await getToken();
+  if (!token) throw new Error("Not authenticated");
+
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    const response = await appFetch(
+      `${API_BASE}/publishers/seren-notes/notes`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ title, content, format: "markdown" }),
+      },
+    );
+
+    if (response.status === 408) {
+      if (attempt < RETRY_DELAYS_MS.length) {
+        await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]));
+        continue;
+      }
+      throw new Error("Seren Notes timed out");
+    }
+
+    if (!response.ok) {
+      throw new Error(`Notes API returned ${response.status}`);
+    }
+
+    const result = await response.json();
+    const noteId = result?.body?.data?.id ?? result?.data?.id;
+    if (!noteId) throw new Error("Note created but ID missing from response");
+
+    openExternalLink(`https://notes.serendb.com/notes/${noteId}`);
+    return;
+  }
+}


### PR DESCRIPTION
## Summary
- Extract notes POST logic into `src/lib/save-to-notes.ts` — single source of truth for both AgentChat and ChatContent
- Automatically retry on HTTP 408 (Seren Notes scale-to-zero cold start) with 10s then 20s delays before giving up
- Add `isSaving` signal to both components to disable the download button while a save is in flight, preventing duplicate notes

## Test plan
- [ ] Click download button once — note saves and opens in browser
- [ ] Click download button while save is in progress — button is disabled, no duplicate note created
- [ ] Test with cold Seren Notes DB — first request returns 408, retry kicks in silently, note eventually saves

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com