### PR TITLE
fix: eliminate agent chat UI freeze during long streaming responses

### DIFF
--- a/src/lib/render-markdown.ts
+++ b/src/lib/render-markdown.ts
@@ -195,6 +195,20 @@ export function renderMarkdown(markdown: string): string {
   return typeof result === "string" ? result : "";
 }
 
+// Fast path for streaming: skip wrapCodeIslands (expensive O(n) scan per chunk).
+// Called on every throttle tick during active streaming; wrapCodeIslands runs
+// once when the final message is committed to threadMessages.
+function normalizeStreaming(markdown: string): string {
+  let result = markdown.replace(/([^\n])\n(#{1,6} )/g, "$1\n\n$2");
+  result = result.replace(/([^\n])\n(`{3,}|~{3,})/g, "$1\n\n$2");
+  return result;
+}
+
+export function renderMarkdownStreaming(markdown: string): string {
+  const result = marked.parse(normalizeStreaming(markdown));
+  return typeof result === "string" ? result : "";
+}
+
 const URL_REGEX = /https?:\/\/[^\s<>"'`)\]]+/g;
 
 /**

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -1941,12 +1941,6 @@ export const acpStore = {
     isThought?: boolean,
     timestamp?: number,
   ) {
-    console.log("[AcpStore] handleMessageChunk:", {
-      sessionId,
-      text: `${text.slice(0, 50)}...`,
-      isThought,
-    });
-
     const session = state.sessions[sessionId];
     if (!session) return;
 


### PR DESCRIPTION
## Summary
- Remove debug `console.log` calls from `handleMessageChunk` and auto-scroll `createEffect` — both fired on every streaming chunk, serializing I/O on the main thread
- Add `renderMarkdownStreaming` that skips the O(n) `wrapCodeIslands` scan — used during active streaming only
- Throttle streaming render to at most once every 80 ms (trailing call) — eliminates O(n²) main-thread saturation during long Codex "Reflecting…" phases
- `wrapCodeIslands` still runs once when the message is committed to `threadMessages`, so final output is fully formatted

## Test plan
- [ ] Start a Codex agent session with a complex task that triggers deep thinking
- [ ] Verify the UI remains responsive during streaming (cursor works, buttons clickable)
- [ ] Verify final rendered messages still show code blocks with syntax highlighting
- [ ] Verify the streaming cursor/pulse is still visible during active streaming

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com