### PR TITLE
fix: restore code formatting during Codex streaming

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -27,11 +27,7 @@ import {
   getModelDisplayName,
   mapAgentModelToChat,
 } from "@/lib/rate-limit-fallback";
-import {
-  escapeHtmlWithLinks,
-  renderMarkdown,
-  renderMarkdownStreaming,
-} from "@/lib/render-markdown";
+import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
 import { saveToSerenNotes } from "@/lib/save-to-notes";
 import { type AgentType, type DiffEvent, launchLogin } from "@/services/acp";
 import { type AgentMessage, acpStore } from "@/stores/acp.store";
@@ -104,7 +100,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
     streamingThrottle = setTimeout(() => {
       streamingThrottle = null;
-      setStreamingMarkdown(renderMarkdownStreaming(content));
+      setStreamingMarkdown(renderMarkdown(content));
     }, 80);
     onCleanup(() => {
       if (streamingThrottle !== null) {

--- a/src/lib/render-markdown.ts
+++ b/src/lib/render-markdown.ts
@@ -195,20 +195,6 @@ export function renderMarkdown(markdown: string): string {
   return typeof result === "string" ? result : "";
 }
 
-// Fast path for streaming: skip wrapCodeIslands (expensive O(n) scan per chunk).
-// Called on every throttle tick during active streaming; wrapCodeIslands runs
-// once when the final message is committed to threadMessages.
-function normalizeStreaming(markdown: string): string {
-  let result = markdown.replace(/([^\n])\n(#{1,6} )/g, "$1\n\n$2");
-  result = result.replace(/([^\n])\n(`{3,}|~{3,})/g, "$1\n\n$2");
-  return result;
-}
-
-export function renderMarkdownStreaming(markdown: string): string {
-  const result = marked.parse(normalizeStreaming(markdown));
-  return typeof result === "string" ? result : "";
-}
-
 const URL_REGEX = /https?:\/\/[^\s<>"'`)\]]+/g;
 
 /**


### PR DESCRIPTION
## Summary
- PR #776 skipped wrapCodeIslands during streaming for performance, but the 80ms throttle alone is sufficient to prevent UI freeze
- This caused a regression: Codex TypeScript/JSDoc output rendered as plain text during active streaming (the fix from PR #775 only applied after message commit)
- Now uses renderMarkdown (with wrapCodeIslands) in the throttled streaming signal
- Removes dead renderMarkdownStreaming/normalizeStreaming functions

## Test plan
- [ ] Start a Codex session that outputs TypeScript code without fences
- [ ] Verify code blocks render correctly DURING streaming (not just after)
- [ ] Verify UI remains responsive during long streaming (throttle still active)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
