### PR TITLE
fix: interpolate error into MCP gateway log string

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -304,7 +304,7 @@ export async function callGatewayTool(
     };
   } catch (error) {
     const executionTime = Date.now() - startTime;
-    console.error("[MCP Gateway] Tool call failed:", error);
+    console.error(`[MCP Gateway] Tool call failed: ${error instanceof Error ? error.message : String(error)}`);
 
     return {
       result: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary

- `console.error("[MCP Gateway] Tool call failed:", error)` — the Rust logger only captures the first string argument, silently dropping the error object
- Tool call failures logged as `[MCP Gateway] Tool call failed:` with no details
- Changed to template literal so the error message is always captured

## Changes

- `src/services/mcp-gateway.ts` line 307: interpolate error into the log string

## Test plan
- [ ] Tool call failures now show full error message in logs

Closes #782

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com