### PR TITLE
fix: cap error banner height and clear stale errors on session ready

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1103,13 +1103,13 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               : "bg-destructive/10 border-destructive/40 text-destructive"
           }`}
         >
-          <div class="flex items-center justify-between">
-            <span class="flex-1">
+          <div class="flex items-start justify-between gap-2">
+            <span class="flex-1 max-h-28 overflow-y-auto break-words">
               {isAuthError(sessionError())
                 ? "Authentication expired. Please log in again to continue."
                 : sessionError()}
             </span>
-            <div class="flex items-center gap-2 ml-2">
+            <div class="flex items-center gap-2 shrink-0">
               <Show when={isAuthError(sessionError())}>
                 <button
                   type="button"

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -2193,6 +2193,9 @@ export const acpStore = {
     }
 
     if (status === "ready") {
+      // Clear stale error banner when session recovers — a ready session has
+      // no persistent error to surface. Error messages in chat history remain.
+      setState("sessions", sessionId, "error", null);
       const entry = sessionReadyPromises.get(sessionId);
       if (entry) {
         entry.resolve();


### PR DESCRIPTION
## Summary

Two related bugs that made the Codex (and Claude Code) agent window unusable when the agent produced a large error:

**Bug 1: Input box disappears when error is large**

`addErrorMessage()` sets `session.error`, which renders as a persistent banner **outside** the scroll container in a `flex-col` layout. The banner had no height constraint — for a large error (e.g. shell stderr mixed with file contents), it grew to hundreds/thousands of pixels, overflowing the container and pushing the `shrink-0` input below the visible viewport.

Fix: cap the error text to `max-h-28 overflow-y-auto`. Action buttons get `shrink-0` so they remain visible. Changed `items-center` → `items-start` so alignment is correct when text scrolls.

**Bug 2: Stale error banner persists after session recovery**

`session.error` was never cleared. An error from a previous session crash would persist as a banner even after the session became `ready` again.

Fix: clear `session.error` in `handleStatusChange` when `status === "ready"`. Chat message history (the red messages in the scroll area) is unaffected.

## Files changed
- `src/components/chat/AgentChat.tsx` — error banner height cap + button anchoring
- `src/stores/acp.store.ts` — clear session error on ready

## Test plan
- [ ] Trigger a large agent error; verify input box remains visible at bottom
- [ ] Verify error banner is scrollable when content is long
- [ ] Verify action buttons (Dismiss, Restart Session) are always visible
- [ ] Verify error banner clears when session recovers to ready state

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com