### PR TITLE
feat: show active Codex tool in status bar

### DIFF
--- a/src/components/common/StatusBar.tsx
+++ b/src/components/common/StatusBar.tsx
@@ -1,7 +1,8 @@
 // ABOUTME: Application status bar at the bottom.
 // ABOUTME: Displays status messages, MCP state, autocomplete status, and connection state.
 
-import type { Component } from "solid-js";
+import { createMemo, type Component } from "solid-js";
+import { acpStore } from "@/stores/acp.store";
 import { autocompleteStore } from "@/stores/autocomplete.store";
 import { AutocompleteStatus } from "./AutocompleteStatus";
 import { McpStatusIndicator } from "./McpStatusIndicator";
@@ -11,10 +12,25 @@ interface StatusBarProps {
 }
 
 export const StatusBar: Component<StatusBarProps> = (props) => {
+  const agentStatusText = createMemo(() => {
+    const session = acpStore.activeSession;
+    if (!session || session.info.status !== "prompting") return null;
+    const running = session.messages
+      .filter(
+        (m) =>
+          m.type === "tool" &&
+          ["running", "pending", "in_progress"].includes(
+            m.toolCall?.status ?? "",
+          ),
+      )
+      .at(-1);
+    return running ? `Codex: ${running.content}` : "Working...";
+  });
+
   return (
     <footer class="h-6 px-3 bg-surface-0 border-t border-border flex items-center justify-between">
       <span class="text-xs text-muted-foreground">
-        {props.message || "Ready"}
+        {agentStatusText() ?? props.message ?? "Ready"}
       </span>
       <div class="flex items-center gap-2 [&_.status-label]:text-muted-foreground">
         {/* MCP indicator moved to left side to avoid accidental clicks near Send button */}


### PR DESCRIPTION
## Summary
- Status bar left side now shows the current running tool when Codex is active (e.g. `Codex: Reflecting ~/Desktop/alive.png`)
- Falls back to `Working...` when prompting but no tool has fired yet
- Reverts to `Ready` when idle
- No prop changes — `StatusBar` reads `acpStore` directly via a reactive memo

## Test plan
- [ ] Start a Codex agent session and send a prompt
- [ ] Confirm status bar shows `Working...` before first tool fires
- [ ] Confirm status bar updates to `Codex: <tool name>` as tools execute
- [ ] Confirm status bar reverts to `Ready` when the prompt completes
- [ ] Confirm status bar shows `Ready` when no session is active

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com