### PR TITLE
fix: eliminate main-thread saturation during agent streaming

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -92,28 +92,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     return acpStore.getStreamingContentForConversation(thread.id);
   });
 
-  // Throttled streaming markdown: renders at most every 80 ms to avoid
-  // saturating the main thread with O(n) marked.parse calls on every chunk.
-  const [streamingMarkdown, setStreamingMarkdown] = createSignal("");
-  let streamingThrottle: ReturnType<typeof setTimeout> | null = null;
-  createEffect(() => {
-    const content = threadStreamingContent();
-    if (streamingThrottle !== null) clearTimeout(streamingThrottle);
-    if (!content) {
-      setStreamingMarkdown("");
-      return;
-    }
-    streamingThrottle = setTimeout(() => {
-      streamingThrottle = null;
-      setStreamingMarkdown(renderMarkdown(content));
-    }, 80);
-    onCleanup(() => {
-      if (streamingThrottle !== null) {
-        clearTimeout(streamingThrottle);
-        streamingThrottle = null;
-      }
-    });
-  });
 
   // Get streaming thinking for THIS thread's conversation ID
   const threadStreamingThinking = createMemo(() => {
@@ -995,7 +973,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               <article class="px-5 py-4 border-b border-surface-2">
                 <div
                   class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
-                  innerHTML={streamingMarkdown()}
+                  textContent={threadStreamingContent()}
                 />
                 <span class="inline-block w-2 h-4 ml-0.5 bg-primary animate-pulse" />
               </article>

--- a/src/components/common/AboutDialog.tsx
+++ b/src/components/common/AboutDialog.tsx
@@ -27,13 +27,13 @@ export function AboutDialog() {
 
   onMount(() => {
     const unlisten = listen("open-about", async () => {
+      setIsOpen(true);
       try {
         const buildInfo = await invoke<BuildInfo>("get_build_info");
         setInfo(buildInfo);
       } catch (e) {
         console.error("[AboutDialog] Failed to get build info:", e);
       }
-      setIsOpen(true);
     });
 
     onCleanup(() => {


### PR DESCRIPTION
## Summary

- **Root cause**: `renderMarkdown()` (marked.parse + wrapCodeIslands + hljs) was called synchronously in an 80ms throttle on the full accumulated streaming content. For large Codex xhigh-effort responses, this O(n) pipeline blocked the JS event loop completely, freezing the UI.
- **Fix**: Replace `innerHTML={streamingMarkdown()}` with `textContent={threadStreamingContent()}` during streaming. Remove the throttled `createEffect` and `streamingMarkdown` signal entirely. Streaming content renders as plain text; full markdown applies to finalized messages (unchanged).
- **Also**: Fix `AboutDialog` to call `setIsOpen(true)` before `await invoke("get_build_info")` so it opens instantly rather than waiting on the invoke — which was itself blocked when the main thread was saturated.

## Test plan

- [ ] Trigger a Codex xhigh-effort response and verify the UI remains responsive during streaming
- [ ] Confirm streaming text appears (plain text with cursor) and transitions to rendered markdown when complete
- [ ] Verify About Seren Desktop dialog opens immediately from the menu
- [ ] Confirm copy button and Check for Updates still work in the About dialog

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com