### PR TITLE
fix: bump min Codex CLI to 0.104.0 to resolve DNS sandbox issues

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -3517,7 +3517,7 @@ pub async fn acp_ensure_codex_cli(app: AppHandle) -> Result<String, String> {
     };
 
     // Minimum required Codex CLI version for app-server protocol compatibility
-    const MIN_CODEX_CLI_VERSION: &str = "0.98.0";
+    const MIN_CODEX_CLI_VERSION: &str = "0.104.0";
 
     // Already installed locally? Check version and upgrade if needed.
     if codex_bin.exists() {


### PR DESCRIPTION
## Summary

- v0.98.0 did not reliably disable sandbox-exec for shell subprocesses even in danger-full-access mode, causing DNS resolution failures
- Bump MIN_CODEX_CLI_VERSION from 0.98.0 to 0.104.0, triggering auto-upgrade via npm install @openai/codex@latest on next launch
- Companion fix: serenorg/seren-acp-codex#3 (pass sandbox mode on session resume)

## Test plan

- [ ] Launch Seren Desktop with bundled codex v0.98.0 — app auto-upgrades to v0.104.0
- [ ] Start new Codex session, run curl command — DNS resolves
- [ ] Resume existing Codex session, run curl — DNS resolves

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com