### PR TITLE
fix: stop reinstalling CLI in refreshRemoteSessions

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -440,13 +440,6 @@ export const acpStore = {
     setState("remoteSessionsLoading", true);
     setState("remoteSessionsError", null);
     try {
-      // Ensure the underlying CLI is available before listing remote sessions.
-      const ensureFn =
-        resolvedAgentType === "claude-code"
-          ? acpService.ensureClaudeCli
-          : acpService.ensureCodexCli;
-      await ensureFn();
-
       const [page, localRows] = await Promise.all([
         acpService.listRemoteSessions(resolvedAgentType, cwd),
         getAgentConversations(200, cwd),


### PR DESCRIPTION
## Summary

- refreshRemoteSessions was calling ensureClaudeCli/ensureCodexCli on every session list refresh
- If the CLI was not found on PATH, this triggered the native installer mid-session
- The installer replaced the claude binary on disk, breaking the stdin pipe to the already-running seren-acp-claude subprocess
- Next prompt to that session failed with: Transport error: Failed to write to stdin: Broken pipe (os error 32)

CLI installation belongs in startAgent only. Session listing should fail gracefully if the CLI is absent, not reinstall it.

## Test plan

- [ ] Start a Claude Code session, switch away to trigger refreshRemoteSessions, send another prompt — no broken pipe
- [ ] If Claude CLI is missing, refreshRemoteSessions fails gracefully without installing

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com