### PR TITLE
fix: surface Claude Code OAuth errors and improve auth UX

### DIFF
--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -22,12 +22,11 @@ const AUTH_ERROR_PATTERNS = [
 ];
 
 /**
- * Max length of a genuine auth error message. CLI tools sometimes wrap the
- * underlying error in JSON (e.g. Claude Code's "Failed to authenticate. API
- * Error: 401 {...}") which can exceed 500 chars. 2000 is still well below a
- * typical assistant response, so false-positives remain unlikely.
+ * Max length of a genuine auth error message. Real auth errors from CLI tools
+ * are short (< 500 chars). Longer messages are normal assistant responses that
+ * happen to contain auth-related phrases in tool output or code discussion.
  */
-const AUTH_ERROR_MAX_LENGTH = 2000;
+const AUTH_ERROR_MAX_LENGTH = 500;
 
 /**
  * Check if an error message indicates an authentication/session failure.

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -377,6 +377,18 @@ export const acpStore = {
   },
 
   /**
+   * Get the active session for a specific conversation ID.
+   * Returns null if no session is running for that conversation.
+   */
+  getSessionForConversation(conversationId: string): ActiveSession | null {
+    return (
+      Object.values(state.sessions).find(
+        (s) => s.conversationId === conversationId,
+      ) ?? null
+    );
+  },
+
+  /**
    * Get plan entries for the active session.
    */
   get plan(): PlanEntry[] {


### PR DESCRIPTION
## Summary

- **Codex thread shows Claude controls** (BUG): Added `threadSession` memo in AgentChat that resolves the session for the currently-viewed thread instead of using the global `activeSessionId`. `hasSession`, `isReady`, `isPrompting`, `sessionError`, and `lockedAgentType` all now derive from `threadSession`. A running Claude session can no longer bleed into the Codex thread's controls, ready-state, or send behaviour. Also added `getSessionForConversation()` to acp.store.

- **`/login` clarity**: Changed slash command description from 'Sign in to your account' to 'Sign in to Seren' so users know it opens the Seren login flow, not Claude Code re-authentication.

- **'Session already exists' fix**: Added a pre-emptive `terminateSession(conversationId)` in `resumeAgentConversation` before spawning. When a session errored without being cleanly terminated, the backend retained the session under the conversation id, blocking re-spawn.

## Test plan
- [ ] Start a Claude Agent session, then switch to a Codex Agent thread — confirm controls show 'Codex' and 'Start Session' appears (not 'Agent Ready' for Claude)
- [ ] Type `/login` in agent panel and confirm autocomplete shows 'Sign in to Seren'
- [ ] Resume a conversation whose session errored without termination and confirm no 'Session already exists' error
- [ ] CI tests pass

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com