### PR TITLE
fix(agents): scope model/mode/effort selectors to active thread session

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1319,9 +1319,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 <span class="px-2 py-1 bg-surface-2 border border-surface-3 rounded-md text-xs text-foreground font-medium">
                   {lockedAgentName()}
                 </span>
-                <AgentModelSelector />
-                <AgentModeSelector />
-                <AgentEffortSelector />
+                <AgentModelSelector session={threadSession()} />
+                <AgentModeSelector session={threadSession()} />
+                <AgentEffortSelector session={threadSession()} />
                 <Show when={isPrompting()}>
                   <ThinkingStatus />
                 </Show>

--- a/src/components/chat/AgentEffortSelector.tsx
+++ b/src/components/chat/AgentEffortSelector.tsx
@@ -3,14 +3,18 @@
 
 import type { Component } from "solid-js";
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
-import { acpStore } from "@/stores/acp.store";
+import { type ActiveSession, acpStore } from "@/stores/acp.store";
 
-export const AgentEffortSelector: Component = () => {
+interface Props {
+  session: ActiveSession | null;
+}
+
+export const AgentEffortSelector: Component<Props> = (props) => {
   const [isOpen, setIsOpen] = createSignal(false);
   let dropdownRef: HTMLDivElement | undefined;
 
   const option = () =>
-    acpStore.activeSession?.configOptions?.find(
+    props.session?.configOptions?.find(
       (o) => o.id === "reasoning_effort" && o.type === "select",
     ) ?? null;
 
@@ -36,7 +40,11 @@ export const AgentEffortSelector: Component = () => {
   });
 
   const selectValue = (valueId: string) => {
-    acpStore.setConfigOption("reasoning_effort", valueId);
+    acpStore.setConfigOption(
+      "reasoning_effort",
+      valueId,
+      props.session?.info.id,
+    );
     setIsOpen(false);
   };
 

--- a/src/components/chat/AgentModeSelector.tsx
+++ b/src/components/chat/AgentModeSelector.tsx
@@ -3,14 +3,18 @@
 
 import type { Component } from "solid-js";
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
-import { acpStore } from "@/stores/acp.store";
+import { type ActiveSession, acpStore } from "@/stores/acp.store";
 
-export const AgentModeSelector: Component = () => {
+interface Props {
+  session: ActiveSession | null;
+}
+
+export const AgentModeSelector: Component<Props> = (props) => {
   const [isOpen, setIsOpen] = createSignal(false);
   let dropdownRef: HTMLDivElement | undefined;
 
-  const availableModes = () => acpStore.activeSession?.availableModes ?? [];
-  const currentModeId = () => acpStore.activeSession?.currentModeId;
+  const availableModes = () => props.session?.availableModes ?? [];
+  const currentModeId = () => props.session?.currentModeId;
 
   const currentModeName = () => {
     const id = currentModeId();
@@ -34,7 +38,7 @@ export const AgentModeSelector: Component = () => {
   });
 
   const selectMode = (modeId: string) => {
-    acpStore.setPermissionMode(modeId);
+    acpStore.setPermissionMode(modeId, props.session?.info.id);
     setIsOpen(false);
   };
 

--- a/src/components/chat/AgentModelSelector.tsx
+++ b/src/components/chat/AgentModelSelector.tsx
@@ -3,14 +3,18 @@
 
 import type { Component } from "solid-js";
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
-import { acpStore } from "@/stores/acp.store";
+import { type ActiveSession, acpStore } from "@/stores/acp.store";
 
-export const AgentModelSelector: Component = () => {
+interface Props {
+  session: ActiveSession | null;
+}
+
+export const AgentModelSelector: Component<Props> = (props) => {
   const [isOpen, setIsOpen] = createSignal(false);
   let dropdownRef: HTMLDivElement | undefined;
 
-  const availableModels = () => acpStore.activeSession?.availableModels ?? [];
-  const currentModelId = () => acpStore.activeSession?.currentModelId;
+  const availableModels = () => props.session?.availableModels ?? [];
+  const currentModelId = () => props.session?.currentModelId;
 
   const currentModelName = () => {
     const id = currentModelId();
@@ -34,7 +38,7 @@ export const AgentModelSelector: Component = () => {
   });
 
   const selectModel = (modelId: string) => {
-    acpStore.setModel(modelId);
+    acpStore.setModel(modelId, props.session?.info.id);
     setIsOpen(false);
   };
 

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -1527,8 +1527,8 @@ export const acpStore = {
   /**
    * Set permission mode for the active session.
    */
-  async setPermissionMode(modeId: string) {
-    const sessionId = state.activeSessionId;
+  async setPermissionMode(modeId: string, forSessionId?: string) {
+    const sessionId = forSessionId ?? state.activeSessionId;
     if (!sessionId) return;
 
     try {
@@ -1547,8 +1547,8 @@ export const acpStore = {
   /**
    * Set the AI model for the active session.
    */
-  async setModel(modelId: string) {
-    const sessionId = state.activeSessionId;
+  async setModel(modelId: string, forSessionId?: string) {
+    const sessionId = forSessionId ?? state.activeSessionId;
     if (!sessionId) return;
 
     try {
@@ -1571,8 +1571,12 @@ export const acpStore = {
   /**
    * Set a session configuration option (e.g., reasoning effort).
    */
-  async setConfigOption(configId: string, valueId: string) {
-    const sessionId = state.activeSessionId;
+  async setConfigOption(
+    configId: string,
+    valueId: string,
+    forSessionId?: string,
+  ) {
+    const sessionId = forSessionId ?? state.activeSessionId;
     if (!sessionId) return;
 
     try {


### PR DESCRIPTION
## Summary

- AgentModelSelector, AgentModeSelector, and AgentEffortSelector all read acpStore.activeSession globally, causing a Claude Code session models/modes/effort options to appear in a Codex thread (regression of #792)
- Each selector now accepts a session prop and reads from it instead of the global active session
- setModel, setPermissionMode, and setConfigOption in acp.store.ts accept an optional forSessionId parameter so mutations target the correct session
- AgentChat.tsx passes threadSession() (introduced in #792) to all three selectors

## Root cause

PR #792 scoped hasSession, isReady, isPrompting, sessionError, and lockedAgentType in AgentChat.tsx via the threadSession memo, but the three sub-components it renders were untouched and still read from the global store.

## Test plan

- [ ] Open two threads (one Claude Code, one Codex) with both sessions active
- [ ] Switch between them and verify model/mode/effort controls reflect the selected thread
- [ ] Confirm CI passes

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com