### PR TITLE
fix: use native Tauri dialog for clear/compact confirmations

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -1,6 +1,7 @@
 // ABOUTME: Chat content panel without file tree for resizable layout.
 // ABOUTME: Shows chat messages, input, and model selector.
 
+import { confirm } from "@tauri-apps/plugin-dialog";
 /* eslint-disable solid/no-innerhtml */
 import type { Component } from "solid-js";
 import {
@@ -651,7 +652,10 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
   };
 
   const clearHistory = async () => {
-    const confirmClear = window.confirm("Clear all chat history?");
+    const confirmClear = await confirm("Clear all chat history?", {
+      title: "Clear Chat",
+      kind: "warning",
+    });
     if (!confirmClear) return;
     await conversationStore.clearHistory();
   };


### PR DESCRIPTION
## Summary

- `window.confirm()` is unreliable in Tauri v2 WebView on macOS — it can return `true` regardless of which button the user presses, so hitting Cancel still clears the chat
- Replaced with the async `confirm()` from `@tauri-apps/plugin-dialog` which uses native OS dialogs and properly returns the user's choice
- Fixed in: `clearHistory` (ChatContent.tsx + AgentChat.tsx) and `compactConversation` (AgentChat.tsx)

## Note

There are ~10 other uses of `window.confirm()` in the codebase (file delete, MCP server remove, provider disconnect, etc). This PR fixes the reported bug only — the remaining uses can be migrated in a follow-up.

## Test plan

- [ ] Click Clear button in chat, press Cancel — chat should NOT clear
- [ ] Click Clear button in chat, press OK — chat should clear
- [ ] Same for agent chat Clear and Compact buttons

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com