### PR TITLE
fix: add Seren product identity to chat system prompt

### DIFF
--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -404,6 +404,16 @@ export async function* streamMessageWithTools(
       serenPublishersContext;
   }
 
+  // Add Seren product identity context
+  systemContent +=
+    "\n\nIMPORTANT — Seren Product Identity:\n" +
+    '"Seren" refers to the Seren platform at https://www.serendb.com — a serverless Postgres database platform with AI agents, ' +
+    "MCP tool integration, and a publisher marketplace. It is NOT seren.xyz or any other project. " +
+    "When users ask about Seren, always answer in the context of SerenDB (https://www.serendb.com). " +
+    "Key Seren concepts: SerenBucks (billing credits), Publishers (third-party data services), " +
+    "Skills (installable prompt-based capabilities from the seren-skills repo), " +
+    "Gateway API (AI model access), MCP servers (tool integration), and Seren Desktop (this application).";
+
   // Add user-provided context if available
   if (context) {
     if (context.file) {


### PR DESCRIPTION
## Summary
- Adds a Seren product identity block to the chat system prompt so the AI always associates "Seren" with https://www.serendb.com
- Covers key concepts: SerenBucks, Publishers, Skills, Gateway API, MCP servers, and Seren Desktop
- Prevents the model from confusing Seren with seren.xyz or other projects

Closes #794

## Test plan
- [ ] Open Seren Desktop and ask the chat "What is Seren?"
- [ ] Verify the response references serendb.com, not seren.xyz
- [ ] Ask about specific Seren concepts (SerenBucks, Publishers, Skills) and confirm accurate answers

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com