### PR TITLE
fix(skills): fetch full payload for serenorg skills, validate after install

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6054,6 +6054,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-store",
  "tauri-plugin-updater",
+ "tempfile",
  "thiserror 2.0.18",
  "tiny_http",
  "tokio",
@@ -7030,9 +7031,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,3 +89,6 @@ tauri-plugin-deep-link = "2"
 default = ["acp", "openclaw"]
 acp = ["agent-client-protocol"]
 openclaw = ["tokio-tungstenite"]
+
+[dev-dependencies]
+tempfile = "3.25.0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -818,6 +818,7 @@ pub fn run() {
             skills::clear_thread_skills,
             skills::list_skill_dirs,
             skills::install_skill,
+            skills::validate_skill_payload,
             skills::remove_skill,
             skills::read_skill_content,
             skills::resolve_skill_path,


### PR DESCRIPTION
## Summary
- Fix marketplace skills installing as manifest-only (SKILL.md) without runtime payload files
- For serenorg skills, fetch all sibling files from the GitHub repo tree during install (scripts, configs, requirements.txt, etc.)
- Add validate_skill_payload Rust command that checks referenced files in SKILL.md actually exist on disk
- Show dismissible warning banner in Skills Explorer when install is missing referenced files
- Add tempfile dev dependency for Rust tests

## Root Cause
The install_skill command only wrote SKILL.md content. For skills from seren-skills repo that include runtime files (scripts, Python agents, configs), those sibling files were never fetched or written to disk.

## What Changed

### Rust (src-tauri/src/skills.rs)
- install_skill now accepts optional extra_files JSON parameter for writing payload files alongside SKILL.md
- New validate_skill_payload command extracts file references from SKILL.md (markdown links + backtick code refs) and reports missing files
- New extract_referenced_files parser for detecting file paths in markdown content
- Path traversal protection (rejects .. in extra file paths)
- 9 regression tests covering install, validation, deduplication, and security

### Frontend (src/services/skills.ts)
- Cache GitHub repo tree from index fetch for reuse during install
- New fetchRepoSkillPayloadFiles() fetches all non-SKILL.md files from a skill GitHub directory
- install() method fetches payload files for serenorg source skills before calling Rust backend
- Post-install validation logs warnings for missing referenced files
- New validatePayload() public method for on-demand validation

### UI (src/components/sidebar/SkillsExplorer.tsx)
- handleInstall validates payload after install and captures missing files
- Warning banner shows skill slug and list of missing files (max 5 shown, with overflow count)

## Test plan
- [x] 9 Rust unit tests pass (cargo test -- skills::tests)
- [ ] Manual test: install curve-curve-gauge-yield-trader from marketplace, verify payload files are present
- [ ] Manual test: install a skill with no extra files (e.g. prompt-only skill), verify no warnings
- [ ] Manual test: install from URL, verify no regression
- [ ] Verify path traversal is blocked (tested in Rust unit tests)

Closes #814

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com