### PR TITLE
fix(sandbox): add missing seatbelt permissions for DNS resolution

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -669,6 +669,7 @@ pub fn run() {
             files::reveal_in_file_manager,
             // Shell command execution (requires frontend approval)
             shell::execute_shell_command,
+            shell::diagnose_shell_network,
             // Web fetch command
             commands::web::web_fetch,
             // Conversation commands

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -88,6 +88,79 @@ pub async fn execute_shell_command(
     }
 }
 
+/// Run DNS + HTTP connectivity checks from a shell process and report results.
+///
+/// This diagnostic helps debug split-network issues where MCP (HTTP client)
+/// has network access but shell subprocesses do not.
+#[tauri::command]
+pub async fn diagnose_shell_network() -> Result<serde_json::Value, String> {
+    let mut results = serde_json::Map::new();
+
+    // Check 1: DNS resolution via getent/host/nslookup
+    let dns_check = run_diagnostic_command(
+        "python3 -c \"import socket; print(socket.getaddrinfo('api.serendb.com', 443)[0][4][0])\"",
+        5,
+    )
+    .await;
+    results.insert("dns_resolve".into(), diagnostic_to_json(&dns_check));
+
+    // Check 2: HTTP connectivity
+    let http_check = run_diagnostic_command(
+        "curl -sS -o /dev/null -w '%{http_code}' --max-time 5 https://api.serendb.com/health",
+        10,
+    )
+    .await;
+    results.insert("http_connect".into(), diagnostic_to_json(&http_check));
+
+    // Check 3: PATH contents
+    let path_check = run_diagnostic_command("echo $PATH", 2).await;
+    results.insert("shell_path".into(), diagnostic_to_json(&path_check));
+
+    // Check 4: resolv.conf (Linux) or scutil --dns (macOS)
+    let resolver_check = if cfg!(target_os = "macos") {
+        run_diagnostic_command("scutil --dns 2>&1 | head -20", 5).await
+    } else {
+        run_diagnostic_command("cat /etc/resolv.conf 2>&1", 2).await
+    };
+    results.insert("resolver_config".into(), diagnostic_to_json(&resolver_check));
+
+    // Check 5: Raw IP connectivity (bypasses DNS)
+    let ip_check = run_diagnostic_command("ping -c 1 -W 3 1.1.1.1 2>&1 | tail -2", 5).await;
+    results.insert("ip_reachable".into(), diagnostic_to_json(&ip_check));
+
+    // Overall pass/fail
+    let dns_ok = dns_check.exit_code == Some(0);
+    let http_ok = http_check.exit_code == Some(0);
+    let ip_ok = ip_check.exit_code == Some(0);
+    results.insert("overall_pass".into(), serde_json::Value::Bool(dns_ok && http_ok));
+    results.insert("dns_ok".into(), serde_json::Value::Bool(dns_ok));
+    results.insert("http_ok".into(), serde_json::Value::Bool(http_ok));
+    results.insert("ip_ok".into(), serde_json::Value::Bool(ip_ok));
+
+    Ok(serde_json::Value::Object(results))
+}
+
+async fn run_diagnostic_command(command: &str, timeout_secs: u64) -> CommandResult {
+    match execute_shell_command(command.to_string(), Some(timeout_secs)).await {
+        Ok(result) => result,
+        Err(e) => CommandResult {
+            stdout: String::new(),
+            stderr: e,
+            exit_code: None,
+            timed_out: false,
+        },
+    }
+}
+
+fn diagnostic_to_json(result: &CommandResult) -> serde_json::Value {
+    serde_json::json!({
+        "stdout": result.stdout.trim(),
+        "stderr": result.stderr.trim(),
+        "exit_code": result.exit_code,
+        "timed_out": result.timed_out,
+    })
+}
+
 fn truncate_output(s: String) -> String {
     if s.len() <= MAX_OUTPUT_BYTES {
         s


### PR DESCRIPTION
## Summary
- **sandbox.rs**: Add `system-socket`, `ipc-posix-shm*`, and `user-preference-read` to the macOS seatbelt profile — required by mDNSResponder for DNS resolution in sandboxed processes
- **terminal.rs**: Prevent agent-supplied env vars from overriding the computed PATH (embedded runtime + system dirs); add debug logging for sandbox mode and network policy
- **shell.rs**: Add `diagnose_shell_network` Tauri command that runs DNS, HTTP, IP connectivity, PATH, and resolver config checks from a shell process

## Root Cause
The seatbelt profile uses `(deny default)` and explicitly allows `mach-lookup` and `network*`, but macOS DNS resolution via mDNSResponder also needs `system-socket` (resolver socket creation), `ipc-posix-shm*` (resolver cache via POSIX shared memory), and `user-preference-read` (network/proxy configuration). Without these, `getaddrinfo()` fails with `nodename nor servname provided`.

Additionally, the terminal process PATH could be overridden by agent-supplied env vars, potentially losing system directories needed to find `curl`, `python3`, etc.

## Test plan
- [x] All 256 Rust unit tests pass
- [x] `cargo check` clean (no new warnings)
- [ ] Manual: Start Codex agent session, run `curl -I https://api.serendb.com` — should succeed
- [ ] Manual: Run `python3 -c "import urllib.request; print(urllib.request.urlopen('https://api.serendb.com', timeout=10).status)"` — should print 200
- [ ] Manual: Call `diagnose_shell_network` from devtools — all checks should pass
- [ ] Manual: Verify MCP calls still work in the same session

Closes #789

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com