### PR TITLE
fix: skill search misses new repo skills

### DIFF
--- a/src/components/sidebar/SkillsExplorer.tsx
+++ b/src/components/sidebar/SkillsExplorer.tsx
@@ -368,8 +368,8 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
           <button
             type="button"
             class="flex items-center justify-center w-7 h-7 bg-transparent border-none rounded-md text-muted-foreground cursor-pointer transition-colors hover:bg-surface-2 hover:text-foreground"
-            onClick={() => skillsStore.refresh()}
-            title="Refresh skills"
+            onClick={() => skillsStore.refresh(true)}
+            title="Refresh skills (bypass cache)"
           >
             <svg
               width="14"

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -512,13 +512,14 @@ export const skillsStore = {
 
   /**
    * Refresh available skills from the index and publishers.
+   * Pass skipCache=true to bypass the localStorage cache (e.g. user-triggered refresh).
    */
-  async refreshAvailable(): Promise<void> {
+  async refreshAvailable(skipCache = false): Promise<void> {
     setState("isLoading", true);
     setState("error", null);
 
     try {
-      const available = await skills.fetchAllSkills();
+      const available = await skills.fetchAllSkills(skipCache);
       setState("available", available);
       log.info("[SkillsStore] Loaded", available.length, "available skills");
     } catch (err) {
@@ -563,9 +564,10 @@ export const skillsStore = {
 
   /**
    * Refresh all skills (available and installed).
+   * Pass skipCache=true for user-triggered refreshes that should bypass cache.
    */
-  async refresh(): Promise<void> {
-    await Promise.all([this.refreshAvailable(), this.refreshInstalled()]);
+  async refresh(skipCache = false): Promise<void> {
+    await Promise.all([this.refreshAvailable(skipCache), this.refreshInstalled()]);
   },
 
   /**


### PR DESCRIPTION
## Summary
- **Refresh button now bypasses cache**: Clicking the refresh icon in Skills Explorer forces a fresh fetch from GitHub, no longer serving stale localStorage data
- **Repo skill tags/author/version preserved**: `fetchSkillFromRepo` was hardcoding `tags: []` instead of using parsed frontmatter metadata — now passes through `tags`, `author`, and `version`
- **Search includes slug field**: Skills whose display name differs from their directory slug (e.g. display name "EIP-712 Typed Data Signing" but slug contains "ledger") can now be found by slug keywords

Root cause: after a new skill was merged to seren-skills, the app served cached index data. Even clicking refresh had no effect because the cache TTL had not expired. When it did expire, incomplete results (e.g. CDN miss for a new SKILL.md) would get cached with a fresh timestamp, perpetuating stale data.

## Test plan
- [ ] Add a new skill to serenorg/seren-skills, wait for merge
- [ ] Open Seren Desktop Skills Explorer, search for the new skill by name — may not appear initially
- [ ] Click the refresh button — skill should now appear
- [ ] Search by slug keyword (e.g. "ledger") — should match even if display name differs
- [ ] Verify tags from SKILL.md frontmatter appear on repo skills in Browse tab

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com