### PR TITLE
fix: update polymarket skill slug from trader to bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ npm-debug.log*
 coverage/
 test-results/
 
+# Installed skills (runtime data, not committed)
+skills/
+
 # Tauri
 src-tauri/WixTools/
 src-tauri/gen/schemas/

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -755,9 +755,9 @@ export const acpStore = {
       const apiKey = await getSerenApiKey();
 
       // Determine timeout based on enabled skills:
-      // - Long-running skills (polymarket-trader) get unlimited timeout
+      // - Long-running skills (trading bots) get unlimited timeout
       // - Other sessions get default 300s timeout
-      const longRunningSkills = ["polymarket-trader"];
+      const longRunningSkills = ["polymarket-bot", "kraken-grid-trader"];
       const hasLongRunningSkill = skillsStore.installed.some(
         (skill) => skill.enabled && longRunningSkills.includes(skill.slug),
       );


### PR DESCRIPTION
## Summary

- Updated hardcoded `"polymarket-trader"` to `"polymarket-bot"` in the long-running skills timeout list to match the renamed skill in seren-skills repo
- Added `"kraken-grid-trader"` to the long-running skills list (also a trading bot that needs unlimited timeout)
- Added `skills/` to `.gitignore` — contains runtime data (installed skills, logs) not source code
- Removed stale `skills/polymarket-trader/` directory (empty, only had logs)

Closes #824

## Test plan

- [x] 149 frontend tests pass
- [x] Biome lint clean
- [ ] Manual: click Polymarket Bot skill — should trigger `/polymarket-bot`

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com