### PR TITLE
fix: add shutdown mechanism to OAuth callback server

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -578,7 +578,9 @@ pub fn run() {
 
             // Start OAuth callback server in dev mode
             // Provides localhost:8787 redirect for OAuth without deep links
-            oauth_callback_server::start_oauth_callback_server(app.handle().clone());
+            if let Some(handle) = oauth_callback_server::start_oauth_callback_server(app.handle().clone()) {
+                app.manage(handle);
+            }
 
             // Register deep link handler for OAuth callbacks (production)
             // Note: Disabled on Windows due to WiX bundler ICE03 registry errors


### PR DESCRIPTION
## Summary
- Wraps `tiny_http::Server` in `Arc` and returns an `OAuthServerHandle` that calls `Server::unblock()` on drop
- Handle is stored in Tauri managed state so the listener thread exits cleanly on app shutdown
- No behavioral change to OAuth flow — just clean resource cleanup

Closes #605

## Test plan
- [ ] OAuth login flow still works (localhost:8787 callback received)
- [ ] App exits cleanly without orphaned threads/port bindings

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com