### PR TITLE
fix: log warning when embedded runtime directory is missing

### DIFF
--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -75,6 +75,11 @@ pub fn discover_embedded_runtime(app: &AppHandle) -> EmbeddedRuntimePaths {
     let runtime_dir = match get_embedded_runtime_dir(app) {
         Some(dir) => dir,
         None => {
+            log::warn!(
+                "[EmbeddedRuntime] No runtime directory found for {}. \
+                 Child processes may fail to locate node/git.",
+                platform_subdir()
+            );
             return EmbeddedRuntimePaths {
                 node_dir: None,
                 git_dir: None,


### PR DESCRIPTION
## Summary
- Adds a log::warn! when discover_embedded_runtime() cannot find the runtime directory
- Includes the platform subdirectory name in the message for easier diagnosis
- Previously returned empty paths silently, leading to cryptic command not found errors

Closes #602

## Test plan
- [ ] Build without embedded runtime present - verify warning appears in logs
- [ ] Build with embedded runtime present - no warning logged

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com