### PR TITLE
fix: derive installed skill slug from metadata instead of directory name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ coverage/
 test-results/
 
 # Installed skills (runtime data, not committed)
-skills/
+/skills/
 
 # Tauri
 src-tauri/WixTools/

--- a/src/lib/skills/parser.ts
+++ b/src/lib/skills/parser.ts
@@ -147,6 +147,9 @@ function parseYamlFrontmatter(yaml: string): SkillMetadata {
         case "name":
           metadata.name = cleanValue;
           break;
+        case "slug":
+          metadata.slug = cleanValue;
+          break;
         case "description":
           metadata.description = cleanValue;
           break;
@@ -216,6 +219,38 @@ export function resolveSkillDisplayName(
   }
 
   return "Unnamed Skill";
+}
+
+/**
+ * Derive a URL-friendly slug from a display name.
+ * "Polymarket Bot" → "polymarket-bot"
+ * Returns null if the name can't produce a valid slug.
+ */
+export function slugFromName(name: string): string | null {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return SKILL_SLUG_PATTERN.test(slug) ? slug : null;
+}
+
+/**
+ * Resolve the canonical slug for an installed skill.
+ * Priority: explicit slug field > name-derived slug > directory name.
+ */
+export function resolveSkillSlug(parsed: ParsedSkill, dirName: string): string {
+  if (parsed.metadata.slug && SKILL_SLUG_PATTERN.test(parsed.metadata.slug)) {
+    return parsed.metadata.slug;
+  }
+
+  const nameSlug = parsed.metadata.name
+    ? slugFromName(parsed.metadata.name)
+    : null;
+  if (nameSlug && nameSlug !== dirName) {
+    return nameSlug;
+  }
+
+  return dirName;
 }
 
 /**

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -19,6 +19,7 @@ export type SkillSource =
 export interface SkillMetadata {
   name: string;
   description: string;
+  slug?: string;
   version?: string;
   author?: string;
   tags?: string[];
@@ -64,6 +65,8 @@ export interface InstalledSkill extends Skill {
   scope: SkillScope;
   /** Root skills directory for this installation scope */
   skillsDir: string;
+  /** Filesystem directory name (may differ from slug after a rename) */
+  dirName: string;
   /** Full path to the SKILL.md file */
   path: string;
   /** Timestamp when the skill was installed */


### PR DESCRIPTION
## Summary
- Installed skill slugs were tied to the filesystem directory name, so renaming a skill upstream (e.g., polymarket-trader to polymarket-bot) left the old slug in use
- Added resolveSkillSlug() that derives the canonical slug from SKILL.md metadata: explicit slug field > name-derived > directory name fallback
- Added dirName field to InstalledSkill to decouple filesystem operations from invocation slug
- Fixed gitignore skills/ pattern to be root-relative (/skills/) so src/lib/skills/ source files are not accidentally ignored

## How it works
For a skill with name: Polymarket Bot installed in directory polymarket-trader/:
- Before: slug = polymarket-trader (directory name), click inserts /polymarket-trader
- After: slug = polymarket-bot (derived from name), click inserts /polymarket-bot
- File operations still use dirName (polymarket-trader) to find the SKILL.md on disk

## Test plan
- [ ] Click Polymarket Bot in sidebar - should insert /polymarket-bot (not /polymarket-trader)
- [ ] Skill content still loads correctly for execution
- [ ] Uninstall still works (removes correct directory)
- [ ] Newly installed skills work normally (dirName = slug)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com