### PR TITLE
fix: prevent SQLite lock contention dropping agent messages

### DIFF
--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -4,6 +4,7 @@
 use rusqlite::{Connection, Result};
 use std::fs;
 use std::path::PathBuf;
+use std::time::Duration;
 use tauri::{AppHandle, Manager};
 
 pub fn get_db_path(app: &AppHandle) -> PathBuf {
@@ -20,6 +21,8 @@ pub fn init_db(app: &AppHandle) -> Result<Connection> {
     }
 
     let conn = Connection::open(path)?;
+    conn.busy_timeout(Duration::from_millis(5000))?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")?;
     setup_schema(&conn)?;
     Ok(conn)
 }


### PR DESCRIPTION
## Summary

- Enable WAL journal mode on every SQLite connection opened by `init_db`
- Set a 5-second busy timeout so concurrent writers wait instead of immediately failing
- Fixes #834

## Root Cause

`run_db` opens a fresh `Connection` for each operation. During active agent sessions, rapid concurrent events (tool calls, message chunks) each trigger `save_message`, opening multiple parallel connections. With default SQLite settings (no WAL, no busy timeout), any connection blocked on the write lock immediately errors with `SQLITE_BUSY`, silently dropping messages.

## Changes

**`src-tauri/src/services/database.rs`** — 3 lines in `init_db`:
```rust
conn.busy_timeout(Duration::from_millis(5000))?;
conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")?;
```

WAL allows concurrent reads alongside a single writer. The busy timeout causes blocked writes to retry for up to 5s before giving up, which covers any real-world burst of concurrent saves.

## Test plan

- [x] All existing `database` unit tests pass (`cargo test -- database`)
- [x] `cargo check` clean

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com