### PR TITLE
fix: improve skills discovery — slug search, stale cache guard, background refresh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,16 @@ function App() {
     await threadStore.refresh();
   });
 
+  // Periodically refresh available skills so newly published skills appear without restart.
+  // Base interval: 10 min + up to 2 min jitter to avoid thundering herd across instances.
+  const SKILLS_REFRESH_BASE = 10 * 60 * 1000;
+  const skillsRefreshTimer = setInterval(
+    () => void skillsStore.refresh(),
+    SKILLS_REFRESH_BASE + Math.random() * 2 * 60 * 1000,
+  );
+
   onCleanup(() => {
+    clearInterval(skillsRefreshTimer);
     shortcuts.destroy();
     stopOpenClawAgent();
     openclawStore.destroy();

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -195,6 +195,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
     return allSkills.filter(
       (s) =>
         s.name.toLowerCase().includes(q) ||
+        s.slug.toLowerCase().includes(q) ||
         (s.description ?? "").toLowerCase().includes(q) ||
         s.tags.some((t) => t.toLowerCase().includes(q)),
     );


### PR DESCRIPTION
## Summary

Three targeted fixes for #841:

- **Slug search parity** — `ThreadSidebar` filter now includes `s.slug`, so searching `customer-support-intake` (or any slug) returns the skill alongside name/description/tags matches
- **Stale cache guard** — on fetch error, skills cache is now only served if ≤1 hour old; older cache is discarded and logged explicitly with its age rather than silently served forever
- **Background refresh** — `App.tsx` runs `skillsStore.refresh()` every ~10 min (+ up to 2 min random jitter) so freshly merged skills appear without restart

## Test plan

- [ ] Search by exact skill slug in thread sidebar — skill appears
- [ ] Merge a new skill to `seren-skills/main` — appears in desktop within ~10 min without restart
- [ ] Force a fetch error (network off) — logs stale cache age warning; if cache >1h old, returns empty instead of serving ancient data
- [ ] Manual refresh still bypasses cache and updates immediately

Closes #841

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com