### PR TITLE
fix: preserve all-project thread list when switching Explorer folders

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -538,7 +538,7 @@ export const acpStore = {
     try {
       const [page, localRows] = await Promise.all([
         acpService.listRemoteSessions(resolvedAgentType, cwd),
-        getAgentConversations(200, cwd),
+        getAgentConversations(200),
       ]);
 
       setState("recentAgentConversations", localRows);


### PR DESCRIPTION
## Summary

- When the user switches folder in Explorer, `refreshRemoteSessions` was calling `getAgentConversations(200, cwd)`, which filtered conversations to the new folder only and replaced the entire `recentAgentConversations` array
- This caused the thread sidebar to lose all agents and chats from every other project folder
- Fix: remove the `cwd` filter from the local-rows fetch so `recentAgentConversations` always holds all projects; remote sessions stay correctly scoped to the selected folder

## Test plan
- Open app with agents in two different project folders (e.g. `seren-skillforge` and `Seren`)
- Confirm both folder groups are visible in the thread sidebar
- Switch Explorer folder — confirm agents from the other folder remain visible in the sidebar

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com