### PR TITLE
fix: reset scroll position when switching agent threads

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -246,6 +246,15 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     userHasScrolledUp = scrollHeight - scrollTop - clientHeight > 80;
   };
 
+  // Reset scroll position when switching threads so the latest message is visible
+  createEffect(() => {
+    activeAgentThread();
+    userHasScrolledUp = false;
+    requestAnimationFrame(() => {
+      if (messagesRef) messagesRef.scrollTop = messagesRef.scrollHeight;
+    });
+  });
+
   // Auto-scroll when messages change or permission dialogs appear
   createEffect(() => {
     threadMessages();


### PR DESCRIPTION
Closes #850

## Summary
- `userHasScrolledUp` flag was a plain JS variable that persisted across thread switches, causing `scrollToBottom()` to be suppressed when switching to a new agent
- Added a `createEffect` on `activeAgentThread()` that resets `userHasScrolledUp = false` and forces an unconditional scroll to bottom whenever the active thread changes

## Test plan
- [ ] Open an agent thread with enough messages to scroll
- [ ] Scroll up in the message history
- [ ] Switch to a different agent thread — scroll position should be at the bottom
- [ ] Restart an agent and reload — scroll position should be at the bottom

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com