### PR TITLE
feat(ci): inject publisher plugin from pre-built R2 sidecars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,64 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm install
 
+      # ---- Inject publisher plugin (if sidecar binaries were pre-built to R2) ----
+      - name: Check for publisher sidecar binaries
+        id: check_sidecars
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          TARGET="${{ matrix.target }}"
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            EXT=".exe"
+          else
+            EXT=""
+          fi
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "${{ secrets.R2_PUBLIC_URL }}/sidecars/${TAG}/${TARGET}/desktop-mcp-coinbase-trading${EXT}")
+          if [ "$STATUS" = "200" ]; then
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "Publisher sidecars found for ${TAG}/${TARGET}"
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+            echo "No publisher sidecars for ${TAG}/${TARGET} — building OSS-only"
+          fi
+
+      - name: Clone seren-desktop-publishers
+        if: steps.check_sidecars.outputs.found == 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: serenorg/seren-desktop-publishers
+          token: ${{ secrets.GH_PAT }}
+          path: seren-desktop-publishers
+
+      - name: Download sidecar binaries from R2
+        if: steps.check_sidecars.outputs.found == 'true'
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          TARGET="${{ matrix.target }}"
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            EXT=".exe"
+          else
+            EXT=""
+          fi
+          mkdir -p seren-desktop-mcp/target/release
+          for bin in desktop-mcp-coinbase-trading desktop-mcp-kraken-trading desktop-mcp-polymarket-trading; do
+            curl -fSL -o "seren-desktop-mcp/target/release/${bin}${EXT}" \
+              "${{ secrets.R2_PUBLIC_URL }}/sidecars/${TAG}/${TARGET}/${bin}${EXT}"
+            chmod +x "seren-desktop-mcp/target/release/${bin}${EXT}" 2>/dev/null || true
+            echo "Downloaded: ${bin}${EXT}"
+          done
+
+      - name: Inject publisher plugin
+        if: steps.check_sidecars.outputs.found == 'true'
+        shell: bash
+        run: |
+          bash seren-desktop-publishers/ci/inject-plugin.sh \
+            . \
+            seren-desktop-publishers \
+            seren-desktop-mcp
+
       - name: Prepare embedded runtime (macOS arm64)
         if: matrix.target == 'aarch64-apple-darwin'
         run: pnpm prepare:runtime:darwin-arm64


### PR DESCRIPTION
## Summary

- Adds conditional publisher injection to the release workflow
- Checks R2 for pre-built MCP sidecar binaries matching the release tag
- If found: clones `seren-desktop-publishers`, downloads sidecars, runs `inject-plugin.sh`
- If not found: builds OSS-only release (backward compatible)

## Architecture

```
Private CI (publishers)          Public CI (this repo)
Build 3 sidecars x 4 platforms  Download sidecars from R2
Upload to R2 (~230 min)         Inject plugin + full Tauri build (FREE)
```

## New secret required

- `GH_PAT` — already added, used to clone private `seren-desktop-publishers` repo

## Test plan

- [ ] Build sidecars via private workflow first
- [ ] Push test tag, verify injection steps run
- [ ] Verify built app includes publisher settings
- [ ] Verify OSS-only fallback when no sidecars on R2

Closes #852
Refs: serenorg/seren-core#93