### PR TITLE
fix: reroute context-overflow errors to 1M-context models

### DIFF
--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -100,6 +100,11 @@ interface GatewayResponse<T> {
 const DEFAULT_MODELS: ProviderModel[] = [
   // Anthropic
   {
+    id: "anthropic/claude-opus-4.6",
+    name: "Claude Opus 4.6",
+    contextWindow: 1000000,
+  },
+  {
     id: "anthropic/claude-opus-4.5",
     name: "Claude Opus 4.5",
     contextWindow: 200000,
@@ -120,6 +125,16 @@ const DEFAULT_MODELS: ProviderModel[] = [
   { id: "openai/gpt-4o-mini", name: "GPT-4o Mini", contextWindow: 128000 },
   // Google Gemini
   {
+    id: "google/gemini-3.1-pro-preview",
+    name: "Gemini 3.1 Pro",
+    contextWindow: 1048576,
+  },
+  {
+    id: "google/gemini-3-flash-preview",
+    name: "Gemini 3 Flash",
+    contextWindow: 1048576,
+  },
+  {
     id: "google/gemini-2.5-pro",
     name: "Gemini 2.5 Pro",
     contextWindow: 1000000,
@@ -127,11 +142,6 @@ const DEFAULT_MODELS: ProviderModel[] = [
   {
     id: "google/gemini-2.5-flash",
     name: "Gemini 2.5 Flash",
-    contextWindow: 1000000,
-  },
-  {
-    id: "google/gemini-3-flash-preview",
-    name: "Gemini 3 Flash",
     contextWindow: 1000000,
   },
   // Zhipu AI


### PR DESCRIPTION
## Summary

Closes #854

When a conversation exceeds a model context window (e.g. Claude 4.5 at 200K tokens), the orchestrator now automatically falls back to large-context models instead of failing with a 400 error.

**Fallback chain for context overflow:**
1. google/gemini-3.1-pro-preview (1M tokens)
2. google/gemini-3-flash-preview (1M tokens)
3. anthropic/claude-opus-4.6 (1M tokens)

### Changes

- **chat_model_worker.rs**: Include raw provider error in WorkerEvent so orchestrator can detect context overflow
- **router.rs**: Add LARGE_CONTEXT_FALLBACK_MODELS, is_context_overflow_error(), get_large_context_fallback(). Make context-overflow 400s reroutable
- **service.rs**: Detect context overflow before timeout/speed fallback chain. Routes to large-context models regardless of user model selection
- **seren.ts**: Add Gemini 3.1 Pro (1M) and Claude Opus 4.6 (1M) to DEFAULT_MODELS

## Test plan

- [x] cargo check passes
- [x] All 38 router tests pass (including 5 new tests)
- [x] pnpm check -- no new Biome errors
- [ ] Manual: long conversation with many tool calls exceeding 200K tokens reroutes to Gemini 3.1 Pro
- [ ] Manual: reroute event shows Switched to larger context model in UI

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com