### PR TITLE
fix(windows): resolve Win32 error 193 when spawning agent

### DIFF
--- a/scripts/build-sidecar.ts
+++ b/scripts/build-sidecar.ts
@@ -298,7 +298,10 @@ function buildSidecar(
 
     srcBin = path.join(installRoot, "bin", `${binName}${ext}`);
 
-    if (!forceInstall && existsSync(srcBin)) {
+    // Branch pins track a moving target — always rebuild to pick up upstream changes.
+    // Only rev and tag pins are safe to cache (they're immutable).
+    const isMutablePin = source.type === "git" && source.branch;
+    if (!forceInstall && !isMutablePin && existsSync(srcBin)) {
       console.log(`  Using cached install at ${srcBin}`);
     } else {
       mkdirSync(installRoot, { recursive: true });
@@ -314,7 +317,7 @@ function buildSidecar(
       baseArgs.push("--bin", binName, "--root", installRoot);
       if (profile === "debug") baseArgs.push("--debug");
       if (targetTriple !== hostTriple) baseArgs.push("--target", targetTriple);
-      if (forceInstall) baseArgs.push("--force");
+      if (forceInstall || isMutablePin) baseArgs.push("--force");
       // For git repos with workspaces, the crate/package name is a positional argument at the end
       if (source.package) baseArgs.push(source.package);
 

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -3414,14 +3414,17 @@ pub async fn acp_ensure_claude_cli(app: AppHandle) -> Result<String, String> {
             }
 
             // Fallback: return the expected installation location
-            if cfg!(target_os = "windows") {
-                let home = std::env::var("USERPROFILE")
-                    .unwrap_or_else(|_| String::from("C:\\Users\\Default"));
-                Ok(format!("{}/.local/bin", home))
+            let home = if cfg!(target_os = "windows") {
+                std::env::var("USERPROFILE")
+                    .unwrap_or_else(|_| String::from("C:\\Users\\Default"))
             } else {
-                let home = std::env::var("HOME").unwrap_or_else(|_| String::from("/root"));
-                Ok(format!("{}/.local/bin", home))
-            }
+                std::env::var("HOME").unwrap_or_else(|_| String::from("/root"))
+            };
+            Ok(std::path::PathBuf::from(home)
+                .join(".local")
+                .join("bin")
+                .to_string_lossy()
+                .to_string())
         }
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
## Summary
- Branch-pinned sidecars (`"branch": "main"`) were cached by branch name only in `build-sidecar.ts`, so the stale binary never rebuilt when upstream main advanced. This meant the SDK fix that wraps `.cmd` files with `cmd.exe /C` was never picked up by CI.
- Always force-rebuild branch-pinned sidecars (immutable rev/tag pins still cache normally)
- Use `PathBuf::join()` for Windows CLI fallback path instead of `format!()` with forward slashes

## Test plan
- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Trigger a release build and confirm the sidecar is rebuilt (not cached)
- [ ] Install on Windows and confirm agent session starts without error 193

Closes #855

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com