### PR TITLE
ci: decouple publisher sidecar builds from desktop release cycle

### DIFF
--- a/.github/workflows/build-publisher-sidecars.yml
+++ b/.github/workflows/build-publisher-sidecars.yml
@@ -1,0 +1,136 @@
+# ABOUTME: Builds publisher MCP sidecars and uploads to R2 for release injection.
+# ABOUTME: Run manually when publisher code changes — decouples from desktop release cycle.
+
+name: Build Publisher Sidecars
+
+on:
+  workflow_dispatch:
+    inputs:
+      publisher_version:
+        description: 'Publisher version tag (e.g., v1.0.0). Must match publisherVersion in package.json.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-publisher-sidecars-${{ github.event.inputs.publisher_version }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            name: macOS-arm64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            name: macOS-x64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            name: Windows-x64
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            name: Linux-x64
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Validate version format
+        shell: bash
+        run: |
+          VERSION="${{ github.event.inputs.publisher_version }}"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: publisher_version must match vX.Y.Z format (got: $VERSION)"
+            exit 1
+          fi
+
+      - name: Clone seren-desktop-mcp
+        uses: actions/checkout@v6
+        with:
+          repository: serenorg/seren-desktop-mcp
+          token: ${{ secrets.GH_PAT }}
+          path: seren-desktop-mcp
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: publisher-${{ matrix.target }}
+          workspaces: 'seren-desktop-mcp'
+
+      - name: Install dependencies (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config
+
+      - name: Build publisher sidecars
+        shell: bash
+        run: |
+          cd seren-desktop-mcp
+          cargo build --release --target ${{ matrix.target }}
+
+      - name: Upload to R2
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET_NAME }}
+        run: |
+          VERSION="${{ github.event.inputs.publisher_version }}"
+          TARGET="${{ matrix.target }}"
+
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            EXT=".exe"
+          else
+            EXT=""
+          fi
+
+          for bin in desktop-mcp-coinbase-trading desktop-mcp-kraken-trading desktop-mcp-polymarket-trading; do
+            SRC="seren-desktop-mcp/target/${TARGET}/release/${bin}${EXT}"
+            DEST="s3://${R2_BUCKET}/sidecars/publishers/${VERSION}/${TARGET}/${bin}${EXT}"
+
+            if [ ! -f "$SRC" ]; then
+              echo "WARNING: ${bin}${EXT} not found at ${SRC}, skipping"
+              continue
+            fi
+
+            aws s3 cp "$SRC" "$DEST" --endpoint-url="${AWS_ENDPOINT_URL}"
+            echo "Uploaded: sidecars/publishers/${VERSION}/${TARGET}/${bin}${EXT}"
+          done
+
+      - name: Verify uploads
+        shell: bash
+        env:
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+        run: |
+          VERSION="${{ github.event.inputs.publisher_version }}"
+          TARGET="${{ matrix.target }}"
+
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            EXT=".exe"
+          else
+            EXT=""
+          fi
+
+          echo "Verifying uploads for ${VERSION}/${TARGET}..."
+          for bin in desktop-mcp-coinbase-trading desktop-mcp-kraken-trading desktop-mcp-polymarket-trading; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              "${R2_PUBLIC_URL}/sidecars/publishers/${VERSION}/${TARGET}/${bin}${EXT}")
+            if [ "$STATUS" = "200" ]; then
+              echo "  OK: ${bin}${EXT}"
+            else
+              echo "  FAIL: ${bin}${EXT} (HTTP ${STATUS})"
+              exit 1
+            fi
+          done
+          echo "All uploads verified for ${TARGET}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,11 +162,31 @@ jobs:
         run: pnpm install
 
       # ---- Inject publisher plugin (if sidecar binaries were pre-built to R2) ----
-      - name: Check for publisher sidecar binaries
-        id: check_sidecars
+      # Publisher sidecars are keyed by publisherVersion from package.json,
+      # NOT by the desktop release tag. This decouples publisher builds from
+      # the desktop release cycle — only rebuild when publisher code changes.
+      - name: Read publisher version from package.json
+        id: publisher_version
         shell: bash
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          PUB_VERSION=$(node -e "
+            const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
+            console.log(pkg.publisherVersion || '');
+          ")
+          if [ -z "$PUB_VERSION" ]; then
+            echo "No publisherVersion in package.json — skipping publisher injection"
+            echo "version=" >> $GITHUB_OUTPUT
+          else
+            echo "Publisher version: $PUB_VERSION"
+            echo "version=$PUB_VERSION" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for publisher sidecar binaries
+        id: check_sidecars
+        if: steps.publisher_version.outputs.version != ''
+        shell: bash
+        run: |
+          PUB_VERSION="${{ steps.publisher_version.outputs.version }}"
           TARGET="${{ matrix.target }}"
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             EXT=".exe"
@@ -174,13 +194,13 @@ jobs:
             EXT=""
           fi
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            "${{ secrets.R2_PUBLIC_URL }}/sidecars/${TAG}/${TARGET}/desktop-mcp-coinbase-trading${EXT}")
+            "${{ secrets.R2_PUBLIC_URL }}/sidecars/publishers/${PUB_VERSION}/${TARGET}/desktop-mcp-coinbase-trading${EXT}")
           if [ "$STATUS" = "200" ]; then
             echo "found=true" >> $GITHUB_OUTPUT
-            echo "Publisher sidecars found for ${TAG}/${TARGET}"
+            echo "Publisher sidecars found for publishers/${PUB_VERSION}/${TARGET}"
           else
             echo "found=false" >> $GITHUB_OUTPUT
-            echo "No publisher sidecars for ${TAG}/${TARGET} — building OSS-only"
+            echo "No publisher sidecars for publishers/${PUB_VERSION}/${TARGET} — building OSS-only"
           fi
 
       - name: Clone seren-desktop-publishers
@@ -195,7 +215,7 @@ jobs:
         if: steps.check_sidecars.outputs.found == 'true'
         shell: bash
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          PUB_VERSION="${{ steps.publisher_version.outputs.version }}"
           TARGET="${{ matrix.target }}"
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             EXT=".exe"
@@ -205,7 +225,7 @@ jobs:
           mkdir -p seren-desktop-mcp/target/release
           for bin in desktop-mcp-coinbase-trading desktop-mcp-kraken-trading desktop-mcp-polymarket-trading; do
             curl -fSL -o "seren-desktop-mcp/target/release/${bin}${EXT}" \
-              "${{ secrets.R2_PUBLIC_URL }}/sidecars/${TAG}/${TARGET}/${bin}${EXT}"
+              "${{ secrets.R2_PUBLIC_URL }}/sidecars/publishers/${PUB_VERSION}/${TARGET}/${bin}${EXT}"
             chmod +x "seren-desktop-mcp/target/release/${bin}${EXT}" 2>/dev/null || true
             echo "Downloaded: ${bin}${EXT}"
           done

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "vite-plugin-solid": "^2.11.0",
     "vitest": "^4.0.18"
   },
+  "publisherVersion": "v1.0.0",
   "sidecars": {
     "seren-acp-claude": {
       "name": "Claude Code",


### PR DESCRIPTION
## Summary

- Publisher sidecars were keyed by **desktop release tag** in R2, requiring a rebuild in private CI for every desktop release even when publisher code was unchanged
- New build-publisher-sidecars.yml workflow (manual workflow_dispatch) builds publisher MCPs for all 4 platforms and uploads to R2 keyed by **publisher version**
- release.yml reads publisherVersion from package.json for R2 lookups instead of using the desktop tag
- Tagged seren-desktop-mcp and seren-desktop-publishers repos with v1.0.0

## R2 path change

```
Before: sidecars/{DESKTOP_TAG}/{TARGET}/{binary}
After:  sidecars/publishers/{PUBLISHER_VERSION}/{TARGET}/{binary}
```

## Usage

1. When publisher code changes: bump version, run build-publisher-sidecars.yml with the new version
2. Update publisherVersion in package.json to match
3. All subsequent desktop releases download from that version -- no rebuild needed

## Test plan

- [ ] Trigger build-publisher-sidecars.yml with publisher_version=v1.0.0
- [ ] Verify binaries appear at sidecars/publishers/v1.0.0/{target}/ on R2
- [ ] Tag a test desktop release -- verify it reads publisherVersion and downloads from versioned path
- [ ] Verify graceful fallback: if publisherVersion is absent or binaries do not exist, release continues OSS-only

Closes #863

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com