### PR TITLE
fix: log warning when file watcher event channel is closed

### DIFF
--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -83,7 +83,9 @@ pub fn start_watching(app: AppHandle, path: String) -> Result<(), String> {
     // Create watcher
     let watcher = RecommendedWatcher::new(
         move |res| {
-            let _ = event_tx.send(res);
+            if let Err(e) = event_tx.send(res) {
+                log::warn!("[Sync] Event channel closed, file change dropped: {}", e);
+            }
         },
         Config::default(),
     )


### PR DESCRIPTION
## Summary
- Replace `let _ = event_tx.send(res)` with `log::warn!` so closed-channel errors surface instead of being silently swallowed
- If the receiver thread panics, file change events are now logged rather than lost with zero feedback

## Test plan
- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Confirm file watcher still emits events normally when channel is healthy

Closes #598

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com