### PR TITLE
fix: skip resources/list for MCP servers without resources capability

### DIFF
--- a/src/lib/mcp/client.ts
+++ b/src/lib/mcp/client.ts
@@ -88,11 +88,11 @@ function createMcpClient() {
         env: env || null,
       });
 
-      // Fetch tools and resources
-      const [tools, resources] = await Promise.all([
-        listTools(serverName),
-        listResources(serverName),
-      ]);
+      // Fetch tools (always) and resources (only if server announced capability)
+      const tools = await listTools(serverName);
+      const resources = result.capabilities?.resources
+        ? await listResources(serverName)
+        : [];
 
       // Update connection state
       setConnections((prev) => {


### PR DESCRIPTION
## Summary

- MCP client called `resources/list` on all servers via `Promise.all`, regardless of announced capabilities
- Servers like playwright-stealth that only announce `tools` capability returned `-32601: Method not found`
- `Promise.all` rejected, discarding the successful `tools/list` result and marking the connection as errored with 0 tools
- Now checks `result.capabilities.resources` from the initialize response before calling `listResources`

## Test plan

- [ ] `pnpm tauri dev` -- playwright MCP should show green with 13 tools (MCP: 3/3)
- [ ] Seren MCP (gateway) still shows 94 tools
- [ ] Servers that DO announce resources capability still fetch resources correctly

Closes #865

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com