### PR TITLE
feat: implement ACP agent context compaction

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -2309,12 +2309,18 @@ async fn run_session_worker(
                                 response.stop_reason
                             );
                         }
+                        let mut payload = serde_json::json!({
+                            "sessionId": session_id,
+                            "stopReason": format!("{:?}", response.stop_reason)
+                        });
+                        if let Some(meta) = &response.meta {
+                            if let Ok(meta_val) = serde_json::to_value(meta) {
+                                payload["meta"] = meta_val;
+                            }
+                        }
                         let _ = app.emit(
                             events::PROMPT_COMPLETE,
-                            serde_json::json!({
-                                "sessionId": session_id,
-                                "stopReason": format!("{:?}", response.stop_reason)
-                            }),
+                            payload,
                         );
                         let _ = response_tx.send(Ok(()));
                     }

--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -126,6 +126,11 @@ export interface PromptCompleteEvent {
   stopReason: string;
   /** Synthetic completion emitted after load_session history replay. */
   historyReplay?: boolean;
+  /** Agent-forwarded metadata (usage stats, turn count). */
+  meta?: {
+    usage?: { input_tokens?: number; output_tokens?: number };
+    numTurns?: number;
+  };
 }
 
 export interface PermissionOption {

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -150,7 +150,7 @@ const DEFAULT_SETTINGS: Settings = {
   chatMaxToolIterations: 0,
   // Auto-compact
   autoCompactEnabled: true,
-  autoCompactThreshold: 80,
+  autoCompactThreshold: 85,
   autoCompactPreserveMessages: 10,
   // Editor
   editorFontSize: 14,


### PR DESCRIPTION
## Summary

- Forward agent usage metadata (`input_tokens`, `numTurns`) via `PromptResponse._meta` through the `PROMPT_COMPLETE` event to the frontend
- Implement `compactAgentConversation()` in `acp.store.ts`: generates a summary via Gateway API, terminates the old session, spawns a fresh one seeded with the summary
- Wire up the Compact button in AgentChat (was a stub)
- Auto-compact when context usage hits 85% of the agent context window (configurable via `autoCompactThreshold` setting)
- Show `CompactedMessage` banner at the top of compacted conversations
- Update default `autoCompactThreshold` from 80% to 85%

### Companion PRs (sidecar repos)
- **seren-acp-claude**: `feat/forward-usage-meta` -- extracts `ResultMessage.usage` and `num_turns`, attaches to `PromptResponse._meta`
- **seren-acp-codex**: `feat/forward-usage-meta` -- tracks `prompt_count` per session, attaches as `numTurns` in `PromptResponse._meta`

### How it works
1. Agent sidecar completes a prompt and attaches usage/turn data to `_meta`
2. Rust backend forwards `_meta` in the `PROMPT_COMPLETE` event payload
3. Frontend reads `meta.usage.input_tokens`, stores on session
4. If `input_tokens / contextWindowSize >= 0.85` then triggers compaction:
   - Splits messages into older (to summarize) and recent (to preserve)
   - Generates summary via Gateway API (not the agent -- its context is overloaded)
   - Terminates old agent session, spawns new one with same conversation
   - Seeds new session with summary prompt
   - User stays in the same conversation seamlessly

### Root cause
User Selen agent became unresponsive after 1005+ messages. Console logs showed every prompt completing with "Suppressing timeout assistant message" -- the agent API calls were timing out because its internal context was too large. The Compact button was a stub.

## Test plan
- [ ] Start a Claude Code agent session, send several prompts
- [ ] Verify `meta.usage.input_tokens` appears in console logs on promptComplete
- [ ] Click the Compact button, confirm dialog, compaction runs (summary generated, session restarted, messages preserved)
- [ ] Verify CompactedMessage banner appears at top of chat after compaction
- [ ] Verify auto-compact fires when input_tokens >= 85% of context window
- [ ] Repeat with Codex agent (uses numTurns count-based fallback)
- [ ] Verify `pnpm check` and `pnpm test` pass

Closes #868

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
