### PR TITLE
fix: show Top Up UI instead of red error banners on HTTP 402

### DIFF
--- a/src/lib/payment-errors.ts
+++ b/src/lib/payment-errors.ts
@@ -1,0 +1,22 @@
+// ABOUTME: Shared payment error detection for UI components.
+// ABOUTME: Identifies insufficient balance / 402 errors from error messages.
+
+/** Patterns that indicate a payment or insufficient balance error. */
+const PAYMENT_ERROR_PATTERNS = [
+  /\b402\b/,
+  /payment required/i,
+  /insufficient.*balance/i,
+  /insufficient.*credit/i,
+  /insufficient.*fund/i,
+  /not enough.*credit/i,
+  /SerenBucks.*insufficient/i,
+];
+
+/**
+ * Check if an error message indicates a payment/insufficient balance failure.
+ * Use for messages already known to be errors (error events, API errors).
+ */
+export function isPaymentError(msg: string | null | undefined): boolean {
+  if (!msg) return false;
+  return PAYMENT_ERROR_PATTERNS.some((pattern) => pattern.test(msg));
+}

--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -21,10 +21,10 @@ const PUBLISHER_SLUG = "seren-models";
 
 /**
  * User-friendly error message for credits/payment issues.
- * Hides technical OpenRouter details from end users.
+ * Contains "Insufficient" keyword so isPaymentError() detects it.
  */
 const CREDITS_ERROR_MESSAGE =
-  "SerenModels is not available currently. Please contact the Seren team at hello@serendb.com with this alert.";
+  "Insufficient SerenBucks balance. Please add funds to continue.";
 
 /**
  * Check if an error status indicates a credits/payment issue.


### PR DESCRIPTION
## Summary
- When Gateway returns HTTP 402 (insufficient SerenBucks), the chat now shows an **amber warning banner** instead of a red error banner
- Banner displays "Insufficient SerenBucks balance" with a **Top Up** button (opens DepositModal) and a **Retry** button
- Auth errors and other errors remain unchanged (red destructive banners)

## Changes
- **New:** `src/lib/payment-errors.ts` — `isPaymentError()` detector (matches `402`, `payment required`, `insufficient balance`, etc.)
- **Modified:** `src/components/chat/ChatContent.tsx` — Added payment error branch before the existing auth/generic error rendering
- **Modified:** `src/lib/providers/seren.ts` — Updated `CREDITS_ERROR_MESSAGE` from "contact support" to "Insufficient SerenBucks balance"

## Test plan
- [ ] Trigger 402 by using app with near-zero SerenBucks balance
- [ ] Verify error banner is amber/warning styled, not red
- [ ] Verify banner shows "Insufficient SerenBucks balance" + "Top Up" + "Retry"
- [ ] Click "Top Up" → DepositModal opens
- [ ] After adding funds and closing modal, click "Retry" → request succeeds
- [ ] Verify auth errors still show "Session expired" + "Sign In" (no regression)
- [ ] Verify other errors still show red banner + Retry (no regression)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com