### PR TITLE
fix: remove excessive per-chunk console logging

### DIFF
--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -442,9 +442,7 @@ export async function subscribeToEvent<T extends { sessionId: string }>(
   callback: (data: T) => void,
 ): Promise<UnlistenFn> {
   const channel = EVENT_CHANNELS[eventType];
-  console.log(`[AcpService] Subscribing to ${channel}`);
   return listen<T>(channel, (event) => {
-    console.log(`[AcpService] Received event on ${channel}:`, event.payload);
     callback(event.payload);
   });
 }
@@ -457,9 +455,6 @@ export async function subscribeToSession(
   sessionId: string,
   callback: (event: AcpEvent) => void,
 ): Promise<UnlistenFn> {
-  console.log(
-    `[AcpService] subscribeToSession called for sessionId: ${sessionId}`,
-  );
   const unlisteners: UnlistenFn[] = [];
 
   // Helper to filter events by sessionId and create properly typed events
@@ -467,9 +462,6 @@ export async function subscribeToSession(
     type: E["type"],
   ): (data: E["data"]) => void {
     return (data) => {
-      console.log(
-        `[AcpService] createHandler received ${type}: sessionId=${data.sessionId}, expected=${sessionId}, match=${data.sessionId === sessionId}`,
-      );
       if (data.sessionId === sessionId) {
         callback({ type, data } as E);
       }

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -418,14 +418,6 @@ export const acpStore = {
    */
   get messages(): AgentMessage[] {
     const session = this.activeSession;
-    console.log(
-      "[ACP] messages getter - activeSessionId:",
-      state.activeSessionId,
-      "session:",
-      session?.info.id,
-      "messageCount:",
-      session?.messages.length ?? 0,
-    );
     return session?.messages ?? [];
   },
 
@@ -437,14 +429,6 @@ export const acpStore = {
   getMessagesForConversation(conversationId: string): AgentMessage[] {
     const session = Object.values(state.sessions).find(
       (s) => s.conversationId === conversationId,
-    );
-    console.log(
-      "[ACP] getMessagesForConversation - conversationId:",
-      conversationId,
-      "found session:",
-      session?.info.id,
-      "messageCount:",
-      session?.messages.length ?? 0,
     );
     return session?.messages ?? [];
   },
@@ -1946,8 +1930,6 @@ Summary:`;
   // ============================================================================
 
   handleSessionEvent(sessionId: string, event: AcpEvent) {
-    console.log("[AcpStore] handleSessionEvent:", event.type, sessionId);
-
     // User replay messages can arrive as multiple chunks; flush buffered user
     // text when the stream transitions to a non-user event.
     if (event.type !== "userMessage") {


### PR DESCRIPTION
## Summary
- Remove 5 high-frequency log sites that produced 4000+ console messages per session
- `subscribeToEvent` and `createHandler` in `acp.ts` logged every event on every channel
- `messages` getter and `getMessagesForConversation` in `acp.store.ts` logged on every reactive read
- `handleSessionEvent` logged every dispatched event

Session-level logs (spawn, ready, error, compaction) are preserved.

Closes #884

## Test plan
- [ ] Launch app, open devtools console
- [ ] Send a few messages to the agent
- [ ] Verify console is no longer flooded with per-chunk logs
- [ ] Verify session lifecycle logs still appear (spawn, ready, error)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com