### PR TITLE
fix: reset session status to ready after agent cancellation

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -2082,6 +2082,18 @@ Summary:`;
           ]);
           const cancelConvoId = state.sessions[sessionId]?.conversationId;
           if (cancelConvoId) persistAgentMessage(cancelConvoId, cancelMsg);
+
+          // Transition back to "ready" so the UI unfreezes and the send
+          // button reappears.  Without this the session stays stuck in
+          // "prompting" forever (the promptComplete event never fires
+          // after a cancellation).
+          setState(
+            "sessions",
+            sessionId,
+            "info",
+            "status",
+            "ready" as SessionStatus,
+          );
         } else if (String(event.data.error).includes("unresponsive")) {
           // "Agent unresponsive" errors are handled by the sendPrompt catch
           // block which spawns a fresh session and retries. Adding the error


### PR DESCRIPTION
## Summary
- The error handler for "Task cancelled" in `acp.store.ts` added the cancel message to chat but never transitioned session status from `"prompting"` → `"ready"`
- This left the UI frozen — Cancel/Send button unresponsive, `messageChunk` events continued flooding (4330+ observed in Codex session)
- Added the same `setState(..., "ready")` call that the `promptComplete` handler already uses

## Test plan
- [ ] Start a Codex agent session, send a prompt, click Cancel while "Reasoning..." — UI should unfreeze and show Send button
- [ ] Start a Claude agent session, send a prompt, click Cancel — same behavior, no regression
- [ ] Verify cancel message appears in chat history after cancellation

Closes #886

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com