### PR TITLE
fix: scope permission dialogs to thread session, add approval indicator

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1211,21 +1211,23 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       </div>
 
       {/* Permission and diff proposal dialogs — rendered outside the scroll
-          container so they stay visible while the agent streams content. */}
+          container so they stay visible while the agent streams content.
+          Filter by the thread-specific session, not the global activeSessionId,
+          to prevent permissions from one session bleeding into another thread. */}
       <Show
         when={
           acpStore.pendingDiffProposals.some(
-            (p) => p.sessionId === acpStore.activeSessionId,
+            (p) => p.sessionId === threadSession()?.info.id,
           ) ||
           acpStore.pendingPermissions.some(
-            (p) => p.sessionId === acpStore.activeSessionId,
+            (p) => p.sessionId === threadSession()?.info.id,
           )
         }
       >
         <div class="border-t border-border bg-background max-h-[40vh] overflow-y-auto">
           <For
             each={acpStore.pendingDiffProposals.filter(
-              (p) => p.sessionId === acpStore.activeSessionId,
+              (p) => p.sessionId === threadSession()?.info.id,
             )}
           >
             {(proposal) => (
@@ -1236,7 +1238,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           </For>
           <For
             each={acpStore.pendingPermissions.filter(
-              (p) => p.sessionId === acpStore.activeSessionId,
+              (p) => p.sessionId === threadSession()?.info.id,
             )}
           >
             {(perm) => (

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -821,14 +821,36 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                           {formatTime(thread.timestamp)}
                         </span>
 
-                        <Show when={thread.status === "running"}>
-                          <span class="w-2 h-2 rounded-full shrink-0 bg-status-running shadow-[0_0_6px_var(--status-running)] animate-pulse" />
+                        <Show
+                          when={
+                            thread.kind === "agent" &&
+                            thread.id !== threadStore.activeThreadId &&
+                            acpStore.hasPendingApprovals(thread.id)
+                          }
+                        >
+                          <span
+                            class="permission-indicator"
+                            title="Permission required"
+                          />
                         </Show>
-                        <Show when={thread.status === "waiting-input"}>
-                          <span class="w-2 h-2 rounded-full shrink-0 bg-status-waiting shadow-[0_0_6px_var(--status-waiting)] animate-pulse" />
-                        </Show>
-                        <Show when={thread.status === "error"}>
-                          <span class="w-2 h-2 rounded-full shrink-0 bg-status-error" />
+                        <Show
+                          when={
+                            !(
+                              thread.kind === "agent" &&
+                              thread.id !== threadStore.activeThreadId &&
+                              acpStore.hasPendingApprovals(thread.id)
+                            )
+                          }
+                        >
+                          <Show when={thread.status === "running"}>
+                            <span class="w-2 h-2 rounded-full shrink-0 bg-status-running shadow-[0_0_6px_var(--status-running)] animate-pulse" />
+                          </Show>
+                          <Show when={thread.status === "waiting-input"}>
+                            <span class="w-2 h-2 rounded-full shrink-0 bg-status-waiting shadow-[0_0_6px_var(--status-waiting)] animate-pulse" />
+                          </Show>
+                          <Show when={thread.status === "error"}>
+                            <span class="w-2 h-2 rounded-full shrink-0 bg-status-error" />
+                          </Show>
                         </Show>
 
                         {/* Close button */}

--- a/src/components/layout/ThreadTabBar.tsx
+++ b/src/components/layout/ThreadTabBar.tsx
@@ -9,6 +9,7 @@ import {
   onMount,
   Show,
 } from "solid-js";
+import { acpStore } from "@/stores/acp.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { type Thread, threadStore } from "@/stores/thread.store";
 
@@ -81,14 +82,36 @@ export const ThreadTabBar: Component = () => {
               <span class="overflow-hidden text-ellipsis min-w-0">
                 {thread.title}
               </span>
-              <Show when={thread.status === "running"}>
-                <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-success shadow-[0_0_4px_var(--color-success)] animate-[tabPulse_2s_ease-in-out_infinite]" />
+              <Show
+                when={
+                  thread.kind === "agent" &&
+                  thread.id !== threadStore.activeThreadId &&
+                  acpStore.hasPendingApprovals(thread.id)
+                }
+              >
+                <span
+                  class="permission-indicator !w-1.5 !h-1.5"
+                  title="Permission required"
+                />
               </Show>
-              <Show when={thread.status === "waiting-input"}>
-                <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-warning shadow-[0_0_4px_var(--color-warning)] animate-[tabPulse_1.5s_ease-in-out_infinite]" />
-              </Show>
-              <Show when={thread.status === "error"}>
-                <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-destructive" />
+              <Show
+                when={
+                  !(
+                    thread.kind === "agent" &&
+                    thread.id !== threadStore.activeThreadId &&
+                    acpStore.hasPendingApprovals(thread.id)
+                  )
+                }
+              >
+                <Show when={thread.status === "running"}>
+                  <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-success shadow-[0_0_4px_var(--color-success)] animate-[tabPulse_2s_ease-in-out_infinite]" />
+                </Show>
+                <Show when={thread.status === "waiting-input"}>
+                  <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-warning shadow-[0_0_4px_var(--color-warning)] animate-[tabPulse_1.5s_ease-in-out_infinite]" />
+                </Show>
+                <Show when={thread.status === "error"}>
+                  <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-destructive" />
+                </Show>
               </Show>
               <span
                 role="button"

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -466,6 +466,20 @@ export const acpStore = {
   },
 
   /**
+   * Check if a conversation has pending permission requests or diff proposals.
+   * Used by sidebar/tab indicators to show a blinking approval dot.
+   */
+  hasPendingApprovals(conversationId: string): boolean {
+    const session = this.getSessionForConversation(conversationId);
+    if (!session) return false;
+    const sid = session.info.id;
+    return (
+      state.pendingPermissions.some((p) => p.sessionId === sid) ||
+      state.pendingDiffProposals.some((p) => p.sessionId === sid)
+    );
+  },
+
+  /**
    * Get plan entries for the active session.
    */
   get plan(): PlanEntry[] {


### PR DESCRIPTION
## Summary

- **Bug fix:** Permission and diff proposal dialogs in `AgentChat.tsx` filtered by the global `acpStore.activeSessionId` instead of the thread-specific `threadSession().info.id`, causing prompts from one Codex agent to bleed into other chat windows (including empty "Agent Ready" screens). All four filter sites are now scoped to the thread's own session.
- **Feature:** Added a pulsing orange `permission-indicator` dot on sidebar and tab bar thread items when a non-active thread has pending permissions or diff proposals awaiting user approval — similar to how Claude Code Extension in Cursor shows pending approvals.
- **Store:** Added `hasPendingApprovals(conversationId)` helper to `acp.store.ts` for checking if a conversation's session has pending permissions or diff proposals.

Closes #888

## Files Changed

| File | Change |
|------|--------|
| `src/components/chat/AgentChat.tsx` | Replace `acpStore.activeSessionId` → `threadSession()?.info.id` in 4 permission filter sites |
| `src/stores/acp.store.ts` | Add `hasPendingApprovals()` method |
| `src/components/layout/ThreadSidebar.tsx` | Add orange pulsing dot for threads with pending approvals |
| `src/components/layout/ThreadTabBar.tsx` | Same indicator in tab bar |

## Test plan

- [ ] Start two Codex agent sessions in different projects
- [ ] Trigger a permission request in one session (e.g., run a shell command)
- [ ] Switch to the other (empty) Codex chat — verify NO permission prompts bleed through
- [ ] Verify the sidebar shows a pulsing orange dot on the thread that needs approval
- [ ] Verify the tab bar shows the same pulsing orange dot
- [ ] Click the thread with the indicator — verify the permission dialog appears correctly
- [ ] Approve/reject the permission — verify the indicator disappears from sidebar/tab bar

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com