### PR TITLE
fix: detect Codex context overflow and set correct 400K window

### DIFF
--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -41,6 +41,7 @@ const PROMPT_TOO_LONG_PATTERNS = [
   "request too large",
   "content too large",
   "exceeds the model",
+  "ran out of room",
 ];
 
 /**

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -829,7 +829,7 @@ export const acpStore = {
         // pollution (the backend replays the full context including injected
         // skill text as user messages).
         skipHistoryReplay: hasRestoredMessages ? true : undefined,
-        contextWindowSize: resolvedAgentType === "codex" ? 200_000 : 200_000,
+        contextWindowSize: resolvedAgentType === "codex" ? 400_000 : 200_000,
       };
 
       setState("sessions", info.id, session);


### PR DESCRIPTION
## Summary
- Add `ran out of room` to `PROMPT_TOO_LONG_PATTERNS` so Codex context exhaustion triggers auto-failover to chat mode
- Set Codex `contextWindowSize` to 400K (GPT-5.3) instead of the incorrect 200K hardcode

Closes #890

## Test plan
- [ ] Start Codex session, fill context until it errors with 'ran out of room'
- [ ] Verify auto-failover to chat mode triggers (same as Claude prompt-too-long behavior)
- [ ] Verify new sessions use 400K for Codex, 200K for Claude

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com