### PR TITLE
fix: truncate status bar text to prevent content overflow

### DIFF
--- a/src/components/common/StatusBar.tsx
+++ b/src/components/common/StatusBar.tsx
@@ -29,7 +29,7 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
 
   return (
     <footer class="h-6 px-3 bg-surface-0 border-t border-border flex items-center justify-between">
-      <span class="text-xs text-muted-foreground">
+      <span class="text-xs text-muted-foreground truncate min-w-0">
         {agentStatusText() ?? props.message ?? "Ready"}
       </span>
       <div class="flex items-center gap-2 [&_.status-label]:text-muted-foreground">


### PR DESCRIPTION
## Summary
- Adds `truncate min-w-0` CSS classes to the status bar text span in `StatusBar.tsx`
- Prevents raw `toolCall.title` content (e.g. full bash commands with embedded Python scripts) from bleeding across the bottom of the app when Codex runs long shell commands

Closes #892

## Test plan
- [ ] Open a Codex agent session
- [ ] Have Codex run a long shell command (e.g. Python script via heredoc)
- [ ] Verify the status bar text is truncated with ellipsis and stays within the bar bounds
- [ ] Verify short status text (e.g. "Ready", "Working...") still displays normally

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com