### PR TITLE
fix: exclude restored history from auto-compaction threshold

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -1353,9 +1353,16 @@ Summary:`;
         return;
       }
 
-      // Store compacted summary and preserved messages on the new session
+      // Store compacted summary and preserved messages on the new session.
+      // Mark them as restored so the message-count threshold ignores them.
       setState("sessions", newSessionId, "compactedSummary", compactedSummary);
       setState("sessions", newSessionId, "messages", toPreserve);
+      setState(
+        "sessions",
+        newSessionId,
+        "restoredMessageCount",
+        toPreserve.length,
+      );
 
       // Seed the new agent with the summary so it has context
       console.info(
@@ -1586,9 +1593,16 @@ Summary:`;
           localSessionId: session.conversationId,
         });
         if (newSessionId) {
-          // Restore conversation history to the new session
+          // Restore conversation history to the new session.
+          // Mark as restored so the message-count threshold ignores them.
           if (existingMessages.length > 0) {
             setState("sessions", newSessionId, "messages", existingMessages);
+            setState(
+              "sessions",
+              newSessionId,
+              "restoredMessageCount",
+              existingMessages.length,
+            );
           }
 
           // Show recovery indicator so the user knows what happened
@@ -2075,8 +2089,10 @@ Summary:`;
               // Only count messages added since session start — restored
               // display-only history from SQLite should not re-trigger
               // compaction on every app restart.
-              const activeCount =
-                sess.messages.length - (sess.restoredMessageCount ?? 0);
+              const activeCount = Math.max(
+                0,
+                sess.messages.length - (sess.restoredMessageCount ?? 0),
+              );
               if (activeCount > MESSAGE_COUNT_COMPACT_THRESHOLD) {
                 console.info(
                   `[AcpStore] ${activeCount} active messages (${sess.messages.length} total) without token usage data — triggering auto-compaction`,


### PR DESCRIPTION
## Summary
- Adds `restoredMessageCount` field to `ActiveSession` to track how many messages came from SQLite on session restore
- The message-count auto-compaction check now subtracts `restoredMessageCount`, so display-only history does not re-trigger compaction on every app restart
- Fixes an infinite loop where users with 1000+ message conversations had compaction fire on every restart, sending a useless summary to a fresh agent session, which would then time out

## Root Cause
On restart, up to 1000 messages are loaded from SQLite and set on `session.messages`. The auto-compaction check (`sess.messages.length > 850`) counted all messages including this display history, triggering compaction immediately after the first prompt. The compaction was pointless since the agent backend had a fresh session with no context from those messages.

Reported by user Selen who was stuck in this loop for 3+ days with every prompt returning "API Error: Request timed out."

Closes #912

## Test plan
- [ ] Resume a conversation with 1000+ persisted messages
- [ ] Send a message — verify auto-compaction does NOT trigger
- [ ] Send 850+ new messages — verify auto-compaction triggers correctly based on active message count
- [ ] Verify token-based compaction still works normally when the agent reports usage data

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com