### PR TITLE
fix(playwright-stealth): normalize browser aliases in parseBrowserType

### DIFF
--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -52,16 +52,35 @@ describe("parseBrowserType", () => {
     expect(parseBrowserType("edge")).toBe("msedge");
   });
 
+  it("maps 'firefox' alias to 'moz-firefox'", () => {
+    expect(parseBrowserType("firefox")).toBe("moz-firefox");
+  });
+
+  it("maps 'firefox-beta' alias to 'moz-firefox-beta'", () => {
+    expect(parseBrowserType("firefox-beta")).toBe("moz-firefox-beta");
+  });
+
+  it("maps 'firefox-nightly' alias to 'moz-firefox-nightly'", () => {
+    expect(parseBrowserType("firefox-nightly")).toBe("moz-firefox-nightly");
+  });
+
+  it("maps 'chromium' alias to 'chrome'", () => {
+    expect(parseBrowserType("chromium")).toBe("chrome");
+  });
+
   it("is case-insensitive", () => {
     expect(parseBrowserType("Chrome")).toBe("chrome");
     expect(parseBrowserType("MSEDGE")).toBe("msedge");
     expect(parseBrowserType("EDGE")).toBe("msedge");
     expect(parseBrowserType("MOZ-FIREFOX")).toBe("moz-firefox");
+    expect(parseBrowserType("Firefox")).toBe("moz-firefox");
+    expect(parseBrowserType("CHROMIUM")).toBe("chrome");
   });
 
   it("trims whitespace", () => {
     expect(parseBrowserType("  chrome  ")).toBe("chrome");
     expect(parseBrowserType("  edge  ")).toBe("msedge");
+    expect(parseBrowserType("  firefox  ")).toBe("moz-firefox");
   });
 
   it("falls back with stderr warning for unknown value", () => {
@@ -70,16 +89,6 @@ describe("parseBrowserType", () => {
     expect(result).toBe(detectDefaultBrowser());
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining('Unknown or unsupported BROWSER_TYPE "safari"'),
-    );
-    spy.mockRestore();
-  });
-
-  it("rejects Playwright-bundled browsers with fallback", () => {
-    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const result = parseBrowserType("chromium");
-    expect(result).toBe(detectDefaultBrowser());
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining('Unknown or unsupported BROWSER_TYPE "chromium"'),
     );
     spy.mockRestore();
   });

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -164,6 +164,15 @@ export function resolveBrowserName(name: string): BrowserEngine {
   return "chromium";
 }
 
+/** Common aliases → system channel names. */
+const BROWSER_ALIASES: Record<string, string> = {
+  edge: "msedge",
+  firefox: "moz-firefox",
+  "firefox-beta": "moz-firefox-beta",
+  "firefox-nightly": "moz-firefox-nightly",
+  chromium: "chrome",
+};
+
 /** Validate and normalize a browser type string. Auto-detects if not set. */
 export function parseBrowserType(value: string | undefined): string {
   if (!value) return detectDefaultBrowser();
@@ -171,8 +180,8 @@ export function parseBrowserType(value: string | undefined): string {
   const normalized = value.toLowerCase().trim();
   if (!normalized) return detectDefaultBrowser();
 
-  // Accept "edge" as alias for "msedge"
-  if (normalized === "edge") return "msedge";
+  const aliased = BROWSER_ALIASES[normalized];
+  if (aliased) return aliased;
 
   if (SYSTEM_BROWSERS.has(normalized)) return normalized;
 

--- a/mcp-servers/playwright-stealth/src/index.ts
+++ b/mcp-servers/playwright-stealth/src/index.ts
@@ -214,7 +214,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             browser: {
               type: "string",
               description:
-                "Browser name from playwright_list_browsers (e.g. 'chromium', 'firefox', 'chrome', 'msedge', 'webkit')",
+                "System browser channel name (e.g. 'chrome', 'msedge', 'moz-firefox'). " +
+                "Also accepts aliases: 'firefox' → 'moz-firefox', 'chromium' → 'chrome', 'edge' → 'msedge'.",
             },
           },
           required: ["browser"],
@@ -288,9 +289,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "playwright_list_browsers":
         result = tools.listBrowsers();
         break;
-      case "playwright_set_browser":
-        result = await tools.switchBrowser(args.browser as string);
+      case "playwright_set_browser": {
+        const browserArg =
+          (args.browser as string | undefined) ??
+          (args.browserName as string | undefined) ??
+          (args.name as string | undefined);
+        if (!browserArg) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Error: Missing required argument 'browser'. Use playwright_list_browsers to see available options.",
+              },
+            ],
+            isError: true,
+          };
+        }
+        result = await tools.switchBrowser(browserArg);
         break;
+      }
       default:
         throw new Error(`Unknown tool: ${name}`);
     }


### PR DESCRIPTION
## Summary
- Adds `BROWSER_ALIASES` map so `parseBrowserType` accepts common names: `firefox` → `moz-firefox`, `firefox-beta` → `moz-firefox-beta`, `firefox-nightly` → `moz-firefox-nightly`, `chromium` → `chrome` (existing `edge` → `msedge` moved into the map)
- Hardens `playwright_set_browser` handler to resolve browser arg from `args.browser`, `args.browserName`, or `args.name`; returns `isError: true` if all are missing
- Updates tool schema description to document actual accepted values and aliases

Closes #914

## Test plan
- [x] `parseBrowserType('firefox')` returns `'moz-firefox'`
- [x] `parseBrowserType('firefox-beta')` returns `'moz-firefox-beta'`
- [x] `parseBrowserType('firefox-nightly')` returns `'moz-firefox-nightly'`
- [x] `parseBrowserType('chromium')` returns `'chrome'`
- [x] Case-insensitive: `Firefox`, `CHROMIUM` resolve correctly
- [x] Whitespace-trimmed: `'  firefox  '` resolves correctly
- [x] Unknown values still fall back with stderr warning
- [x] All 32 tests pass, lint clean

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com