### PR TITLE
fix: add error handling to markdown worker fallback (#916)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -92,9 +92,17 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const markdownWorker = new RenderMarkdownWorker();
   const [htmlCache, setHtmlCache] = createStore<Record<string, string>>({});
   markdownWorker.onmessage = (
-    e: MessageEvent<{ id: string; html: string }>,
+    e: MessageEvent<{ id: string; html: string; error?: boolean }>,
   ) => {
+    if (e.data.error) {
+      console.warn(
+        `[AgentChat] Worker markdown render failed for message ${e.data.id}, using fallback`,
+      );
+    }
     setHtmlCache(e.data.id, e.data.html);
+  };
+  markdownWorker.onerror = (err) => {
+    console.error("[AgentChat] Markdown worker error:", err.message);
   };
   onCleanup(() => markdownWorker.terminate());
 
@@ -838,7 +846,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           <article class="px-5 py-4 border-b border-surface-2">
             <div
               class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
-              innerHTML={htmlCache[message.id] ?? escapeHtml(message.content)}
+              innerHTML={
+                htmlCache[message.id] ??
+                escapeHtml(message.content).replace(/\n/g, "<br>")
+              }
             />
             <Show when={message.duration}>
               {(() => {

--- a/src/workers/render-markdown.worker.ts
+++ b/src/workers/render-markdown.worker.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Processes renderMarkdown calls without blocking the main thread.
 /// <reference lib="webworker" />
 
+import { escapeHtml } from "@/lib/escape-html";
 import { renderMarkdown } from "@/lib/render-markdown";
 
 interface RenderRequest {
@@ -12,11 +13,22 @@ interface RenderRequest {
 interface RenderResponse {
   id: string;
   html: string;
+  error?: boolean;
 }
 
 self.onmessage = (e: MessageEvent<RenderRequest>) => {
   const { id, markdown } = e.data;
-  const html = renderMarkdown(markdown);
-  const response: RenderResponse = { id, html };
-  self.postMessage(response);
+  try {
+    const html = renderMarkdown(markdown);
+    self.postMessage({ id, html } satisfies RenderResponse);
+  } catch (err) {
+    console.error("[render-markdown.worker] renderMarkdown failed:", err);
+    // Return escaped text with newlines preserved so the message is readable.
+    const fallback = escapeHtml(markdown).replace(/\n/g, "<br>");
+    self.postMessage({
+      id,
+      html: fallback,
+      error: true,
+    } satisfies RenderResponse);
+  }
 };


### PR DESCRIPTION
## Summary
- Adds try-catch to the markdown web worker so a `renderMarkdown()` failure sends escaped text with `<br>` newlines instead of silently dropping the response
- Adds `onerror` handler on the worker instance and logs a warning when the worker returns an error response
- Converts `\n` to `<br>` in the synchronous `escapeHtml()` fallback path so messages remain readable before the worker responds (previously collapsed into a wall of text)

## Test plan
- [x] All 149 unit tests pass
- [x] Biome lint/format clean
- [ ] Manually trigger a renderMarkdown failure (e.g., inject a throw) and verify the message is still readable with preserved line breaks
- [ ] Verify normal markdown rendering is unaffected

Closes #916

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com