### PR TITLE
fix: inject compacted summary into model/agent context (#918)

### DIFF
--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -137,6 +137,19 @@ export async function orchestrate(
   const messages = conversationStore.getMessagesFor(conversationId);
   let history = serializeHistory(messages);
 
+  // Inject compacted conversation summary so the model retains context
+  // from messages that were compacted away.
+  const compactedSummary = chatStore.compactedSummary;
+  if (compactedSummary) {
+    history = [
+      {
+        role: "system",
+        content: `Here is a summary of the earlier part of this conversation:\n\n${compactedSummary.content}`,
+      },
+      ...history,
+    ];
+  }
+
   // Inject memory context for the default orchestrator path.
   if (settingsStore.get("memoryEnabled") && authStore.isAuthenticated) {
     try {

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -1369,7 +1369,23 @@ Summary:`;
         `[AcpStore] Compacted ${toCompact.length} messages, preserved ${toPreserve.length}. Seeding new session.`,
       );
 
-      const seedPrompt = `Here is a summary of our prior conversation:\n\n${summary}\n\nContinue from where we left off. The user may send a new message shortly.`;
+      // Build a condensed representation of preserved messages so the agent
+      // retains awareness of recent work, not just the high-level summary.
+      const MAX_MSG_CHARS = 2000;
+      const preservedContext = toPreserve
+        .filter((m) => m.type === "user" || m.type === "assistant")
+        .map((m) => {
+          const content =
+            m.content.length > MAX_MSG_CHARS
+              ? `${m.content.slice(0, MAX_MSG_CHARS)}... [truncated]`
+              : m.content;
+          return `${m.type.toUpperCase()}: ${content}`;
+        })
+        .join("\n\n");
+
+      const seedPrompt = preservedContext
+        ? `Here is a summary of our prior conversation:\n\n${summary}\n\nHere are the most recent messages:\n\n${preservedContext}\n\nContinue from where we left off. The user may send a new message shortly.`
+        : `Here is a summary of our prior conversation:\n\n${summary}\n\nContinue from where we left off. The user may send a new message shortly.`;
 
       // Wait for the new session to be ready, then restore settings and seed
       const readyEntry = sessionReadyPromises.get(newSessionId);


### PR DESCRIPTION
## Summary
- **Seren Chat**: Injects `compactedSummary` as a system message at the front of conversation history in `orchestrate()`, so the model sees prior context on every turn after compaction
- **ACP Agent**: Enriches the seed prompt with filtered/truncated preserved messages (user + assistant only, max 2000 chars each) alongside the summary, so the agent retains awareness of recent files, code, and tasks
- Previously, both paths generated and stored the summary for UI display only — it was never sent to the model/agent

## Test plan
- [x] All 149 unit tests pass
- [x] Biome lint/format clean
- [ ] Start an ACP agent session, compact, verify the agent responds with awareness of prior context
- [ ] Start a Seren Chat conversation, compact, verify the model references compacted history

Closes #918

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com