### PR TITLE
fix: search installed skills in slash command autocomplete

### DIFF
--- a/src/components/chat/SlashCommandPopup.tsx
+++ b/src/components/chat/SlashCommandPopup.tsx
@@ -50,6 +50,11 @@ export function SlashCommandPopup(props: SlashCommandPopupProps) {
               <span class="font-semibold text-primary shrink-0 font-mono">
                 /{cmd.name}
               </span>
+              {cmd.isSkill && (
+                <span class="text-[10px] font-medium text-accent-foreground bg-accent px-1.5 py-0.5 rounded shrink-0">
+                  skill
+                </span>
+              )}
               <span class="text-muted-foreground flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
                 {cmd.description}
               </span>

--- a/src/lib/commands/parser.ts
+++ b/src/lib/commands/parser.ts
@@ -1,8 +1,9 @@
 // ABOUTME: Parses slash command input and matches against the registry.
-// ABOUTME: Returns parsed command or null if input is not a command.
+// ABOUTME: Also searches installed skills so they appear in slash command autocomplete.
 
+import { skillsStore } from "@/stores/skills.store";
 import { registry } from "./registry";
-import type { ParsedCommand } from "./types";
+import type { ParsedCommand, SlashCommand } from "./types";
 
 /**
  * Parse input text to see if it starts with a slash command.
@@ -31,11 +32,12 @@ export function parseCommand(
 /**
  * Get commands matching a partial input for autocomplete.
  * Input should start with "/" but the slash is stripped for matching.
+ * Searches built-in commands first, then installed skills as fallback.
  */
 export function getCompletions(
   input: string,
   panel: "chat" | "agent",
-): import("./types").SlashCommand[] {
+): SlashCommand[] {
   const trimmed = input.trim();
   if (!trimmed.startsWith("/")) return [];
 
@@ -43,5 +45,41 @@ export function getCompletions(
   if (trimmed.includes(" ")) return [];
 
   const partial = trimmed.slice(1).toLowerCase();
-  return registry.search(partial, panel);
+  const builtins = registry.search(partial, panel);
+  const skillResults = searchInstalledSkills(partial);
+
+  // Deduplicate: built-in commands win over skills with the same name
+  const builtinNames = new Set(builtins.map((c) => c.name));
+  const uniqueSkills = skillResults.filter((s) => !builtinNames.has(s.name));
+
+  return [...builtins, ...uniqueSkills];
+}
+
+/**
+ * Search installed skills whose slug or display name match a partial input.
+ * Returns SlashCommand entries for the autocomplete popup.
+ */
+function searchInstalledSkills(partial: string): SlashCommand[] {
+  const installed = skillsStore.installed;
+  if (installed.length === 0) return [];
+
+  const results: SlashCommand[] = [];
+  for (const skill of installed) {
+    if (!skill.enabled) continue;
+
+    const slugMatch = skill.slug.toLowerCase().startsWith(partial);
+    const nameMatch = skill.name.toLowerCase().startsWith(partial);
+    if (!slugMatch && !nameMatch) continue;
+
+    results.push({
+      name: skill.slug,
+      description: skill.name !== skill.slug ? skill.name : skill.description,
+      argHint: "<prompt>",
+      panels: ["chat", "agent"],
+      isSkill: true,
+      execute: () => false, // Skills are sent as regular messages, not intercepted
+    });
+  }
+
+  return results.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/lib/commands/types.ts
+++ b/src/lib/commands/types.ts
@@ -10,6 +10,8 @@ export interface SlashCommand {
   panels: ("chat" | "agent")[];
   /** Execute the command. Returns true if handled (suppress send). */
   execute: (ctx: CommandContext) => boolean | Promise<boolean>;
+  /** True when this entry represents an installed skill rather than a built-in command. */
+  isSkill?: boolean;
 }
 
 export interface CommandContext {


### PR DESCRIPTION
## Summary
- Extends `getCompletions()` in `parser.ts` to also search installed skills by slug and display name
- Skills appear in the slash command popup alongside built-in commands with a "skill" badge
- Built-in commands take precedence over skills with the same name
- Works in both chat and agent panels

Closes #920

## How It Works
1. User types `/poly` in chat input
2. `getCompletions()` searches the built-in command registry (as before)
3. **New**: also searches `skillsStore.installed` for enabled skills whose slug or name starts with the partial input
4. Matching skills are converted to `SlashCommand` entries with `argHint: "<prompt>"` and `isSkill: true`
5. Popup shows combined results — built-in commands first, then skills with a visual "skill" badge
6. Tab/Enter expands to `/{slug} ` so the user can type their prompt
7. The message is sent normally — skill content is already in the system prompt

## Files Changed
- `src/lib/commands/types.ts` — Added optional `isSkill` flag to `SlashCommand`
- `src/lib/commands/parser.ts` — Added `searchInstalledSkills()`, extended `getCompletions()`
- `src/components/chat/SlashCommandPopup.tsx` — Added "skill" badge for skill entries

## Test plan
- [ ] Type `/poly` in chat — verify installed skill with slug starting with "poly" appears
- [ ] Type `/model` — verify built-in command still appears (no regression)
- [ ] Type `/` alone — verify all commands + all enabled skills appear
- [ ] Select a skill with Tab — verify input becomes `/{slug} `
- [ ] Send a skill slash command — verify it's sent as a regular message (not intercepted)
- [ ] Verify agent panel also shows skills in popup
- [ ] Verify disabled skills don't appear in popup

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com