### PR TITLE
fix: dispatch skill slash commands with execution directive to agent

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -21,7 +21,11 @@ import { CompactedMessage } from "@/components/chat/CompactedMessage";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { isAuthError } from "@/lib/auth-errors";
-import { getCompletions, parseCommand } from "@/lib/commands/parser";
+import {
+  getCompletions,
+  matchSkillCommand,
+  parseCommand,
+} from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { escapeHtml } from "@/lib/escape-html";
 import { openExternalLink } from "@/lib/external-link";
@@ -45,6 +49,7 @@ import {
   type ToolCallEvent,
 } from "@/services/acp";
 import { readDocument } from "@/services/docreader";
+import { skills } from "@/services/skills";
 import {
   type AgentCompactedSummary,
   type AgentMessage,
@@ -518,6 +523,42 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     // Check for slash commands first
     if (trimmed.startsWith("/") && images.length === 0) {
       if (executeSlashCommand(trimmed)) return;
+
+      // Check if the slash command matches an installed skill
+      const skillMatch = matchSkillCommand(trimmed);
+      if (skillMatch) {
+        const { skill, args } = skillMatch;
+        console.log("[AgentChat] Skill invocation:", skill.slug, "args:", args);
+
+        setInput("");
+        setHistoryIndex(-1);
+        setSavedInput("");
+        userHasScrolledUp = false;
+
+        let skillContent: string | null = null;
+        try {
+          skillContent = await skills.readContent(skill);
+        } catch (err) {
+          console.warn("[AgentChat] Failed to load skill content:", err);
+        }
+
+        const directive = skillContent
+          ? [
+              `<skill-invocation name="${skill.slug}">`,
+              `The user has invoked the /${skill.slug} skill. Execute it by following the skill instructions below.`,
+              args ? `\nUser request: ${args}` : "",
+              `\n${skillContent}`,
+              `</skill-invocation>`,
+            ].join("\n")
+          : args
+            ? `/${skill.slug} ${args}`
+            : `/${skill.slug}`;
+
+        await acpStore.sendPrompt(directive, undefined, {
+          displayContent: trimmed,
+        });
+        return;
+      }
     }
 
     // If agent is prompting, queue the message instead

--- a/src/lib/commands/parser.ts
+++ b/src/lib/commands/parser.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Parses slash command input and matches against the registry.
-// ABOUTME: Also searches installed skills so they appear in slash command autocomplete.
+// ABOUTME: Also searches installed skills for autocomplete and skill invocation dispatch.
 
+import type { InstalledSkill } from "@/lib/skills";
 import { skillsStore } from "@/stores/skills.store";
 import { registry } from "./registry";
 import type { ParsedCommand, SlashCommand } from "./types";
@@ -53,6 +54,35 @@ export function getCompletions(
   const uniqueSkills = skillResults.filter((s) => !builtinNames.has(s.name));
 
   return [...builtins, ...uniqueSkills];
+}
+
+/**
+ * Match a slash command input against installed skills.
+ * Returns the matched skill and any trailing args, or null.
+ */
+export function matchSkillCommand(
+  input: string,
+): { skill: InstalledSkill; args: string } | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("/")) return null;
+
+  const spaceIdx = trimmed.indexOf(" ");
+  const name = spaceIdx === -1 ? trimmed.slice(1) : trimmed.slice(1, spaceIdx);
+  const args = spaceIdx === -1 ? "" : trimmed.slice(spaceIdx + 1).trim();
+
+  if (!name) return null;
+
+  const lower = name.toLowerCase();
+  const installed = skillsStore.installed;
+
+  for (const skill of installed) {
+    if (!skill.enabled) continue;
+    if (skill.slug.toLowerCase() === lower) {
+      return { skill, args };
+    }
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- When a user types `/skill-slug` in agent chat, the prompt is now wrapped in a `<skill-invocation>` directive containing the full SKILL.md content, so the agent receives explicit instructions to execute the skill
- Added `matchSkillCommand()` to parser.ts that matches slash input against installed+enabled skill slugs and returns the skill + any trailing args
- Chat UI still displays the original `/skill-slug` text via `displayContent`

## Root Cause

Skill slash commands were sent as raw text (e.g., `/money-mode-router`) with skills only injected as passive documentation in context. The agent had no explicit signal to execute the skill, so it would explore the filesystem instead.

## Test plan

- [ ] Type `/money-mode-router` in agent chat — agent should follow SKILL.md instructions instead of exploring filesystem
- [ ] Type `/money-mode-router what should I do?` — agent receives the args in the directive
- [ ] Type `/clear` (built-in command) — still handled by executeSlashCommand, not affected
- [ ] Type `/nonexistent` — falls through to regular sendPrompt as before
- [ ] Click skill in thread sidebar — triggers autoSend which goes through same path
- [ ] Biome lint passes clean

Closes #925

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
