### PR TITLE
fix: dispatch skill slash commands in chat panel with execution directive

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -18,7 +18,11 @@ import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { DepositModal } from "@/components/wallet/DepositModal";
 import { isAuthError } from "@/lib/auth-errors";
-import { getCompletions, parseCommand } from "@/lib/commands/parser";
+import {
+  getCompletions,
+  matchSkillCommand,
+  parseCommand,
+} from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { openExternalLink } from "@/lib/external-link";
 import { openFileInTab } from "@/lib/files/service";
@@ -40,6 +44,7 @@ import {
   orchestrate,
   retryOrchestration,
 } from "@/services/orchestrator";
+import { skills } from "@/services/skills";
 import { authStore, checkAuth } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
@@ -595,6 +600,44 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     // Check for slash commands first
     if (trimmed.startsWith("/") && images.length === 0) {
       if (executeSlashCommand(trimmed)) return;
+
+      // Check if the slash command matches an installed skill
+      const skillMatch = matchSkillCommand(trimmed);
+      if (skillMatch) {
+        const { skill, args } = skillMatch;
+        console.log(
+          "[ChatContent] Skill invocation:",
+          skill.slug,
+          "args:",
+          args,
+        );
+
+        setInput("");
+        setHistoryIndex(-1);
+        setSavedInput("");
+
+        let skillContent: string | null = null;
+        try {
+          skillContent = await skills.readContent(skill);
+        } catch (err) {
+          console.warn("[ChatContent] Failed to load skill content:", err);
+        }
+
+        const directive = skillContent
+          ? [
+              `<skill-invocation name="${skill.slug}">`,
+              `The user has invoked the /${skill.slug} skill. Execute it by following the skill instructions below.`,
+              args ? `\nUser request: ${args}` : "",
+              `\n${skillContent}`,
+              `</skill-invocation>`,
+            ].join("\n")
+          : args
+            ? `/${skill.slug} ${args}`
+            : `/${skill.slug}`;
+
+        await sendMessageImmediate(directive, undefined);
+        return;
+      }
     }
 
     // If using Seren provider and not authenticated, prompt sign-in


### PR DESCRIPTION
## Summary

- Applies the same skill dispatch fix from #926 to the chat panel (`ChatContent.tsx`)
- When a user types `/skill-slug` in chat mode, the prompt is now wrapped in a `<skill-invocation>` directive with the full SKILL.md content
- The Gateway model receives explicit instructions to follow the skill, rather than seeing raw `/skill-slug` text

## Context

PR #926 fixed skill dispatch for the agent panel (`AgentChat.tsx`) but the chat panel (`ChatContent.tsx`) has the exact same bug — skills appear in autocomplete but typing them sends raw text to the Gateway API.

## Test plan

- [ ] Type `/money-mode-router` in **chat** panel — model should follow skill instructions
- [ ] Type `/money-mode-router what should I do?` in chat — model receives args
- [ ] Built-in commands like `/clear` still work normally
- [ ] `/nonexistent` falls through to regular chat send
- [ ] Biome lint passes clean

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
