### PR TITLE
fix: prevent agent spawn-crash-respawn cascade (#928)

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -3725,6 +3725,35 @@ fn get_cli_tools_bin_dir(app: &AppHandle) -> Option<std::path::PathBuf> {
 }
 
 /// Check if a CLI version meets the minimum requirement.
+/// Run a CLI binary and capture its output.
+/// On Windows, `.cmd` files are batch wrappers that need `cmd.exe /c` to execute.
+fn run_cli_command(
+    bin: &std::path::Path,
+    args: &[&str],
+    env_path: &str,
+) -> std::io::Result<std::process::Output> {
+    if cfg!(target_os = "windows")
+        && bin
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd"))
+    {
+        let mut cmd = std::process::Command::new("cmd.exe");
+        cmd.arg("/c").arg(bin);
+        for arg in args {
+            cmd.arg(arg);
+        }
+        cmd.env("PATH", env_path);
+        cmd.output()
+    } else {
+        let mut cmd = std::process::Command::new(bin);
+        for arg in args {
+            cmd.arg(arg);
+        }
+        cmd.env("PATH", env_path);
+        cmd.output()
+    }
+}
+
 fn is_version_sufficient(version: &str, min_version: &str) -> bool {
     let parse = |v: &str| -> Option<(u32, u32, u32)> {
         let parts: Vec<&str> = v.trim_start_matches('v').split('.').collect();
@@ -3772,11 +3801,7 @@ pub async fn acp_ensure_codex_cli(app: AppHandle) -> Result<String, String> {
     // Already installed locally? Check version and upgrade if needed.
     if codex_bin.exists() {
         let embedded_path = crate::embedded_runtime::get_embedded_path();
-        if let Ok(output) = std::process::Command::new(&codex_bin)
-            .arg("--version")
-            .env("PATH", embedded_path)
-            .output()
-        {
+        if let Ok(output) = run_cli_command(&codex_bin, &["--version"], &embedded_path) {
             // `codex --version` outputs "codex-cli X.Y.Z"
             let version_str = String::from_utf8_lossy(&output.stdout);
             let version = version_str
@@ -3833,10 +3858,8 @@ pub async fn acp_ensure_codex_cli(app: AppHandle) -> Result<String, String> {
             if let Some(parent) = std::path::Path::new(&path).parent() {
                 // Check version of system-installed codex
                 let embedded_path = crate::embedded_runtime::get_embedded_path();
-                if let Ok(ver_output) = std::process::Command::new(&path)
-                    .arg("--version")
-                    .env("PATH", &embedded_path)
-                    .output()
+                if let Ok(ver_output) =
+                    run_cli_command(std::path::Path::new(&path), &["--version"], &embedded_path)
                 {
                     let version_str = String::from_utf8_lossy(&ver_output.stdout);
                     let version = version_str

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -314,6 +314,33 @@ const PENDING_SESSION_EVENT_LIMIT = 500;
 const CLAUDE_INIT_RETRY_DELAY_MS = 350;
 const MAX_CLAUDE_INIT_RETRIES = 3;
 
+/** Spawn cascade guard: track recent failures per conversation to prevent infinite loops. */
+const SPAWN_CASCADE_WINDOW_MS = 30_000;
+const SPAWN_CASCADE_MAX_FAILURES = 3;
+const spawnFailureTimestamps = new Map<string, number[]>();
+
+function recordSpawnFailure(conversationId: string): void {
+  const now = Date.now();
+  const timestamps = spawnFailureTimestamps.get(conversationId) ?? [];
+  timestamps.push(now);
+  // Keep only failures within the window
+  const cutoff = now - SPAWN_CASCADE_WINDOW_MS;
+  const recent = timestamps.filter((t) => t >= cutoff);
+  spawnFailureTimestamps.set(conversationId, recent);
+}
+
+function isSpawnCascading(conversationId: string): boolean {
+  const now = Date.now();
+  const timestamps = spawnFailureTimestamps.get(conversationId) ?? [];
+  const cutoff = now - SPAWN_CASCADE_WINDOW_MS;
+  const recent = timestamps.filter((t) => t >= cutoff);
+  return recent.length >= SPAWN_CASCADE_MAX_FAILURES;
+}
+
+function clearSpawnFailures(conversationId: string): void {
+  spawnFailureTimestamps.delete(conversationId);
+}
+
 function isRetryableClaudeInitError(message: string): boolean {
   const lower = message.toLowerCase();
   return (
@@ -1067,6 +1094,20 @@ export const acpStore = {
       return conversationId;
     }
 
+    // Prevent infinite spawn-crash-respawn cascades: if this conversation
+    // has failed too many times in a short window, stop retrying.
+    if (isSpawnCascading(conversationId)) {
+      console.error(
+        `[AcpStore] Spawn cascade detected for ${conversationId} — ${SPAWN_CASCADE_MAX_FAILURES} failures in ${SPAWN_CASCADE_WINDOW_MS / 1000}s. Stopping auto-resume.`,
+      );
+      setState(
+        "error",
+        "Agent failed to start after multiple attempts. Please try again or check Settings.",
+      );
+      setState("isLoading", false);
+      return null;
+    }
+
     setState("error", null);
 
     // Pre-emptively clean up any stale backend session with this conversation id.
@@ -1130,7 +1171,10 @@ export const acpStore = {
         restoredMessages,
       });
       if (freshSessionId) {
+        clearSpawnFailures(conversationId);
         void this.refreshRecentAgentConversations(200).catch(() => {});
+      } else {
+        recordSpawnFailure(conversationId);
       }
       return freshSessionId;
     }
@@ -1178,13 +1222,19 @@ export const acpStore = {
         restoredMessages,
       });
       if (fallbackSessionId) {
+        clearSpawnFailures(conversationId);
         void this.refreshRecentAgentConversations(200).catch(() => {});
+      } else {
+        recordSpawnFailure(conversationId);
       }
       return fallbackSessionId;
     }
 
     if (sessionId) {
+      clearSpawnFailures(conversationId);
       void this.refreshRecentAgentConversations(200).catch(() => {});
+    } else {
+      recordSpawnFailure(conversationId);
     }
     return sessionId;
   },
@@ -2162,6 +2212,12 @@ Summary:`;
         break;
 
       case "error":
+        // Log full error content for diagnostics (helps debug cascade crashes)
+        console.error(
+          `[AcpStore] Error event for session ${sessionId}:`,
+          event.data.error,
+        );
+
         // Clean up any in-flight streaming and tool cards
         this.flushPendingUserMessage(sessionId);
         this.finalizeStreamingContent(sessionId);


### PR DESCRIPTION
## Summary

- **Windows .cmd version detection**: Added `run_cli_command()` helper in `acp.rs` that wraps `.cmd` batch files with `cmd.exe /c`. On Windows, CLI tools in `node_modules/.bin/` are `.cmd` batch wrappers that produce empty stdout when spawned directly via `Command::new()`. This caused Codex version checks to always return empty, triggering perpetual upgrade attempts on every spawn.

- **Spawn cascade guard**: Added failure tracking per conversation in `acp.store.ts` with a 3-failure/30-second threshold. When `resumeAgentConversation` detects repeated immediate failures, it stops auto-resuming and surfaces an actionable error message instead of looping infinitely. Failures are cleared on successful spawn.

- **Error event logging**: Added `console.error` logging of full error event content at the top of the `handleSessionEvent` error case, enabling post-mortem diagnosis of crash loops from browser devtools.

Closes #928

## Test plan

- [ ] On Windows: verify Codex version detection returns correct version (not empty)
- [ ] Simulate agent crash loop: after 3 rapid failures, auto-resume should stop with error message
- [ ] Verify successful spawn clears failure history (subsequent resume works normally)
- [ ] Check browser devtools for `[AcpStore] Error event for session` log lines on agent errors

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com