### PR TITLE
feat: collapse directory listing output in chat panels

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -27,6 +27,7 @@ import {
   parseCommand,
 } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
+import { collapseDirectoryListings } from "@/lib/directory-listing";
 import { escapeHtml } from "@/lib/escape-html";
 import { openExternalLink } from "@/lib/external-link";
 import { openFileInTab } from "@/lib/files/service";
@@ -887,10 +888,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           <article class="px-5 py-4 border-b border-surface-2">
             <div
               class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
-              innerHTML={
+              innerHTML={collapseDirectoryListings(
                 htmlCache[message.id] ??
-                escapeHtml(message.content).replace(/\n/g, "<br>")
-              }
+                  escapeHtml(message.content).replace(/\n/g, "<br>"),
+              )}
             />
             <Show when={message.duration}>
               {(() => {

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -24,6 +24,7 @@ import {
   parseCommand,
 } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
+import { collapseDirectoryListings } from "@/lib/directory-listing";
 import { openExternalLink } from "@/lib/external-link";
 import { openFileInTab } from "@/lib/files/service";
 import { formatDurationWithVerb } from "@/lib/format-duration";
@@ -1071,7 +1072,9 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                         class="chat-message-content text-[14px] leading-[1.7] text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-[1.3em] [&_h1]:font-semibold [&_h1]:mt-5 [&_h1]:mb-3 [&_h1]:text-foreground [&_h1]:border-b [&_h1]:border-surface-2 [&_h1]:pb-2 [&_h2]:text-[1.15em] [&_h2]:font-semibold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-foreground [&_h3]:text-[1.05em] [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-2 [&_h3]:text-foreground [&_code]:bg-surface-1 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_li]:leading-[1.6] [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline [&_strong]:text-foreground [&_strong]:font-semibold"
                         innerHTML={
                           message.role === "assistant"
-                            ? renderMarkdown(message.content)
+                            ? collapseDirectoryListings(
+                                renderMarkdown(message.content),
+                              )
                             : escapeHtmlWithLinks(message.content)
                         }
                       />

--- a/src/components/chat/ToolCallCard.tsx
+++ b/src/components/chat/ToolCallCard.tsx
@@ -3,6 +3,10 @@
 
 import type { Component } from "solid-js";
 import { createSignal, Show } from "solid-js";
+import {
+  isDirectoryListing,
+  summarizeDirectoryListing,
+} from "@/lib/directory-listing";
 import type { ToolCallEvent } from "@/services/acp";
 
 interface ToolCallCardProps {
@@ -107,6 +111,17 @@ function extractSummary(toolCall: ToolCallEvent): string {
 
 export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
   const [isExpanded, setIsExpanded] = createSignal(false);
+  const [isResultExpanded, setIsResultExpanded] = createSignal(false);
+
+  const resultIsListing = () => {
+    const result = props.toolCall.result;
+    return result ? isDirectoryListing(result) : false;
+  };
+
+  const resultSummary = () => {
+    const result = props.toolCall.result;
+    return result ? summarizeDirectoryListing(result) : "";
+  };
 
   const summary = () => extractSummary(props.toolCall);
 
@@ -415,9 +430,32 @@ export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
               <div class="text-muted-foreground/70 font-medium mb-1">
                 Result:
               </div>
-              <div class="bg-background border border-success/70 rounded p-2 text-success max-h-48 overflow-auto">
-                {props.toolCall.result}
-              </div>
+              <Show
+                when={resultIsListing()}
+                fallback={
+                  <div class="bg-background border border-success/70 rounded p-2 text-success max-h-48 overflow-auto">
+                    {props.toolCall.result}
+                  </div>
+                }
+              >
+                <div class="bg-background border border-success/70 rounded p-2 text-success">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm">{resultSummary()}</span>
+                    <button
+                      type="button"
+                      class="text-xs text-muted-foreground hover:text-foreground shrink-0 ml-2"
+                      onClick={() => setIsResultExpanded(!isResultExpanded())}
+                    >
+                      {isResultExpanded() ? "Hide" : "Show"}
+                    </button>
+                  </div>
+                  <Show when={isResultExpanded()}>
+                    <pre class="mt-2 text-xs whitespace-pre-wrap max-h-48 overflow-auto border-t border-surface-2 pt-2">
+                      {props.toolCall.result}
+                    </pre>
+                  </Show>
+                </div>
+              </Show>
             </div>
           </Show>
 

--- a/src/lib/directory-listing.ts
+++ b/src/lib/directory-listing.ts
@@ -1,0 +1,97 @@
+// ABOUTME: Detects Unix directory listing output and provides collapse utilities.
+// ABOUTME: Used to suppress verbose ls output in chat and agent chat panels.
+
+/** Unix ls -l permission format: drwxr-xr-x, -rw-r--r--, etc. */
+const LS_LINE = /^[dlcbps-][rwxsStT-]{9}\s/;
+
+/** Total line header from ls -l output */
+const TOTAL_LINE = /^total \d+$/;
+
+/** Minimum consecutive matching lines to trigger detection */
+const MIN_CONSECUTIVE = 5;
+
+/**
+ * Returns true if the text is predominantly a Unix directory listing.
+ * Detects `ls -l` style output with permission bits.
+ */
+export function isDirectoryListing(text: string): boolean {
+  const lines = text.split("\n");
+  let consecutive = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (LS_LINE.test(trimmed) || TOTAL_LINE.test(trimmed)) {
+      consecutive++;
+      if (consecutive >= MIN_CONSECUTIVE) return true;
+    } else {
+      consecutive = 0;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns a one-line summary of a directory listing.
+ * Counts lines matching ls -l format.
+ */
+export function summarizeDirectoryListing(text: string): string {
+  const lines = text.split("\n");
+  let count = 0;
+  for (const line of lines) {
+    if (LS_LINE.test(line.trim())) count++;
+  }
+  return `Directory listing (${count} ${count === 1 ? "entry" : "entries"})`;
+}
+
+/** Decode basic HTML entities for detection in rendered HTML. */
+function decodeBasicHtmlEntities(html: string): string {
+  return html
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+/**
+ * Post-processes rendered HTML to collapse directory listing blocks.
+ * Wraps detected blocks in native <details><summary> elements.
+ */
+export function collapseDirectoryListings(html: string): string {
+  // Handle directory listings inside <pre><code> blocks (markdown-rendered path)
+  const modified = html.replace(
+    /(<pre[^>]*><code[^>]*>)([\s\S]*?)(<\/code><\/pre>)/g,
+    (match, _open: string, content: string, _close: string) => {
+      const decoded = decodeBasicHtmlEntities(content);
+      if (isDirectoryListing(decoded)) {
+        const summary = summarizeDirectoryListing(decoded);
+        return `<details class="dir-listing-collapse"><summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>${match}</details>`;
+      }
+      return match;
+    },
+  );
+
+  // If we already handled a <pre> block, return
+  if (modified !== html) return modified;
+
+  // Handle <br>-separated content (fallback/escaped HTML path)
+  if (!/<pre[\s>]/.test(html)) {
+    const segments = html.split(/<br\s*\/?>/i);
+    if (segments.length >= MIN_CONSECUTIVE) {
+      const plainText = segments
+        .map((s) => decodeBasicHtmlEntities(s))
+        .join("\n");
+      if (isDirectoryListing(plainText)) {
+        const summary = summarizeDirectoryListing(plainText);
+        return [
+          '<details class="dir-listing-collapse">',
+          `<summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>`,
+          `<pre style="white-space:pre-wrap;margin:0.5em 0;font-size:12px;color:inherit">${html}</pre>`,
+          "</details>",
+        ].join("");
+      }
+    }
+  }
+
+  return html;
+}


### PR DESCRIPTION
## Summary

- Auto-detects Unix `ls -l` directory listing output (5+ consecutive lines with permission-string format)
- Collapses detected listings into a one-line summary with expand/collapse toggle
- Applies to three surfaces:
  - **ToolCallCard**: tool call results show "Directory listing (N entries)" with Show/Hide button
  - **AgentChat**: assistant message HTML post-processed via `<details><summary>` elements
  - **ChatContent**: same treatment for regular chat panel

## New file

- `src/lib/directory-listing.ts` — Detection utility (`isDirectoryListing`, `summarizeDirectoryListing`, `collapseDirectoryListings`)

## Test plan

- [ ] Open agent chat, run a prompt that triggers `ls -la` on a large directory
- [ ] Verify tool call result shows collapsed "Directory listing (N entries)" instead of full output
- [ ] Click "Show" toggle — full listing appears; click "Hide" — collapses again
- [ ] Verify assistant messages containing directory listings show a `<details>` collapse
- [ ] Open regular chat, verify same collapse behavior
- [ ] Verify non-directory-listing tool results display normally
- [ ] Run `pnpm check` — Biome lint passes

Closes #929

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com