### PR TITLE
fix: switch to editor panel when opening file links from agent chat (#932)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1087,13 +1087,21 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                     : cwd
                       ? `${cwd.replace(/\/$/, "")}/${url}`
                       : url;
-                openFileInTab(resolved).catch((err) =>
-                  console.warn(
-                    "[AgentChat] Failed to open file:",
-                    resolved,
-                    err,
-                  ),
-                );
+                openFileInTab(resolved)
+                  .then(() => {
+                    window.dispatchEvent(
+                      new CustomEvent("seren:open-panel", {
+                        detail: "editor",
+                      }),
+                    );
+                  })
+                  .catch((err) =>
+                    console.warn(
+                      "[AgentChat] Failed to open file:",
+                      resolved,
+                      err,
+                    ),
+                  );
               } else {
                 openExternalLink(url);
               }


### PR DESCRIPTION
## Summary

- Clicking a file link in agent chat created a tab but never switched to the editor panel, so the file appeared invisible to the user
- Root cause: AgentChat.tsx called openFileInTab() without dispatching the seren:open-panel event that AppShell listens for to slide open the editor
- Both FileExplorer.tsx and SkillsExplorer.tsx already dispatch this event correctly -- this aligns AgentChat with the same pattern

Closes #932

## Test plan

- [ ] Open an agent session, have the agent reference a file path
- [ ] Click the file link in the agent response
- [ ] Verify the editor panel slides open and displays the file content
- [ ] Verify File Explorer file clicks still work as before

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com