### PR TITLE
fix: preserve draft text during Up/Down arrow history navigation

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -762,6 +762,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         const newIndex = Math.min(historyIndex() + 1, history.length - 1);
         setHistoryIndex(newIndex);
         setInput(history[newIndex]);
+        queueMicrotask(() => {
+          textarea.setSelectionRange(
+            textarea.value.length,
+            textarea.value.length,
+          );
+        });
       }
     }
 
@@ -778,6 +784,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         } else {
           setInput(history[newIndex]);
         }
+        queueMicrotask(() => {
+          textarea.setSelectionRange(
+            textarea.value.length,
+            textarea.value.length,
+          );
+        });
       }
     }
 

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -1347,7 +1347,6 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                   setCommandPopupIndex(0);
                   if (historyIndex() !== -1) {
                     setHistoryIndex(-1);
-                    setSavedInput("");
                   }
                 }}
                 onKeyDown={(event) => {
@@ -1413,6 +1412,12 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                       );
                       setHistoryIndex(newIndex);
                       setInput(history[newIndex]);
+                      queueMicrotask(() => {
+                        textarea.setSelectionRange(
+                          textarea.value.length,
+                          textarea.value.length,
+                        );
+                      });
                     }
                   }
 
@@ -1431,6 +1436,12 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                       } else {
                         setInput(history[newIndex]);
                       }
+                      queueMicrotask(() => {
+                        textarea.setSelectionRange(
+                          textarea.value.length,
+                          textarea.value.length,
+                        );
+                      });
                     }
                   }
 


### PR DESCRIPTION
## Summary

- **ChatContent.tsx**: Removed `setSavedInput("")` from the `onInput` handler so the user's draft survives accidental keystrokes while browsing history
- **Both panels**: Added `queueMicrotask` cursor positioning after programmatic `setInput()` in Up/Down handlers so the Down arrow guard (`selectionStart === value.length`) reliably succeeds

## Root cause

1. ChatContent's `onInput` handler cleared both `historyIndex` and `savedInput` when the user typed while browsing history — permanently destroying the draft
2. After `setInput(history[n])`, cursor position was browser-dependent. If not at end, the Down arrow condition failed silently, leaving the user stuck

## Test plan

- [ ] Type a message in the chat input, press Up arrow to browse history, press Down to return — draft text is preserved
- [ ] Same test in agent chat panel
- [ ] Browse multiple history items with Up, then Down back through all — draft restored at the end
- [ ] Type while browsing history, then press Up again — exits history mode without losing original draft
- [ ] Run `pnpm check` — Biome passes

Closes #936

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com