### PR TITLE
fix: reset stale session status on cancel 'not found'

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -1766,7 +1766,15 @@ Summary:`;
       await acpService.cancelPrompt(sessionId);
       console.info("[AcpStore] cancelPrompt: backend acknowledged cancel");
     } catch (error) {
-      console.error("[AcpStore] cancelPrompt failed:", error);
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes("not found")) {
+        console.warn(
+          "[AcpStore] cancelPrompt: stale session, resetting status",
+        );
+        setState("sessions", sessionId, "info", "status", "ready");
+      } else {
+        console.error("[AcpStore] cancelPrompt failed:", error);
+      }
     }
   },
 


### PR DESCRIPTION
## Summary

- When `cancelPrompt` gets a "Session not found" error from the Rust backend, reset the session status to `ready` instead of leaving it stuck in `prompting`
- This handles the case where the user switches to a thread from a previous app run — the session exists in the frontend store but the backend process is gone

## Root cause

`selectThread` finds the session in `acpStore.sessions` and sets it active, but the Rust backend only tracks sessions for the current app lifecycle. Hitting Cancel sends a cancel for a session ID the backend has never seen, and the error was silently swallowed while the UI stayed stuck.

## Test plan

- [ ] Start an agent session, let it run, restart the app
- [ ] Switch to the thread with the stale session
- [ ] Hit Cancel — session resets to ready (no error, UI unblocks)
- [ ] Verify fresh sessions still cancel normally
- [ ] Run `pnpm check` — Biome passes

Closes #938

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com