### PR TITLE
fix: suppress messageChunk noise from global ACP event log (#941)

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -739,14 +739,19 @@ export const acpStore = {
       globalUnsubscribe = await acpService.subscribeToAllEvents((event) => {
         const eventSessionId = event.data.sessionId;
         if (!eventSessionId) return;
-        console.log(
-          "[ACP] Event received - type:",
-          event.type,
-          "sessionId:",
-          eventSessionId,
-          "conversationId:",
-          state.sessions[eventSessionId]?.conversationId,
-        );
+        // Skip logging high-frequency messageChunk events to avoid flooding
+        // DevTools. Other event types (sessionStatus, toolCall, etc.) are
+        // still logged for debugging.
+        if (event.type !== "messageChunk") {
+          console.log(
+            "[ACP] Event received - type:",
+            event.type,
+            "sessionId:",
+            eventSessionId,
+            "conversationId:",
+            state.sessions[eventSessionId]?.conversationId,
+          );
+        }
         if (state.sessions[eventSessionId]) {
           this.handleSessionEvent(eventSessionId, event);
           return;


### PR DESCRIPTION
## Summary
- Skips logging for `messageChunk` events in the global ACP event subscriber, which fire dozens/hundreds of times per agent response and flood DevTools
- All other event types (`sessionStatus`, `toolCall`, `toolResult`, `promptComplete`, `error`, `permissionRequest`) remain logged for debugging

## Test plan
- [x] All 149 unit tests pass
- [x] Biome lint/format clean
- [ ] Run an agent session, verify DevTools no longer shows messageChunk spam
- [ ] Verify other event types still appear in console

Closes #941

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com