### PR TITLE
fix: prevent sendPrompt race with auto-recovery and restore skills context

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -1526,6 +1526,29 @@ Summary:`;
       return;
     }
 
+    // If auto-recovery is in-flight (triggered by another sendPrompt call),
+    // wait for it to complete. Recovery already retries the original prompt,
+    // so proceeding would race and cause "Another prompt is already active".
+    if (recoveryInFlight) {
+      console.info(
+        "[AcpStore] sendPrompt: recovery in-flight, waiting before proceeding...",
+      );
+      await recoveryInFlight;
+      const refreshed = state.sessions[sessionId];
+      if (!refreshed) {
+        console.info(
+          "[AcpStore] sendPrompt: session gone after recovery, aborting",
+        );
+        return;
+      }
+      if (refreshed.info.status === "prompting") {
+        console.info(
+          "[AcpStore] sendPrompt: session already prompting after recovery, aborting duplicate",
+        );
+        return;
+      }
+    }
+
     // Wait for session to be ready before sending prompt
     const readyEntry = sessionReadyPromises.get(sessionId);
     if (readyEntry) {
@@ -1534,6 +1557,21 @@ Summary:`;
       );
       await readyEntry.promise;
       console.info("[AcpStore] sendPrompt: session is now ready");
+    }
+
+    // Re-check after async waits — recovery may have started while we waited.
+    if (recoveryInFlight) {
+      console.info(
+        "[AcpStore] sendPrompt: recovery started during ready-wait, deferring...",
+      );
+      await recoveryInFlight;
+      const refreshed = state.sessions[sessionId];
+      if (!refreshed || refreshed.info.status === "prompting") {
+        console.info(
+          "[AcpStore] sendPrompt: session busy after recovery, aborting duplicate",
+        );
+        return;
+      }
     }
 
     // Optimistically mark as prompting so the UI can show a loading state
@@ -1705,12 +1743,38 @@ Summary:`;
               persistAgentMessage(newConvoId, userMessage);
             }
 
-            // Retry the prompt on the new session
+            // Retry the prompt on the new session, rebuilding skills context
+            // so skill invocations work on the fresh session.
             console.info(
               `[AcpStore] Retrying prompt on new session ${newSessionId}`,
             );
             try {
-              await acpService.sendPrompt(newSessionId, prompt, context);
+              let retryContext: Array<Record<string, string>> = context
+                ? [...context]
+                : [];
+              try {
+                const newSession = state.sessions[newSessionId];
+                const skillsContent = await skillsStore.getThreadSkillsContent(
+                  newSession?.cwd ?? cwd,
+                  newSession?.conversationId ?? newSessionId,
+                );
+                if (skillsContent) {
+                  retryContext = [
+                    { type: "text", text: skillsContent },
+                    ...retryContext,
+                  ];
+                }
+              } catch (skillsError) {
+                console.warn(
+                  "[AcpStore] Failed to load skills for recovery retry:",
+                  skillsError,
+                );
+              }
+              await acpService.sendPrompt(
+                newSessionId,
+                prompt,
+                retryContext.length > 0 ? retryContext : undefined,
+              );
               console.log("[AcpStore] Retry succeeded on new session");
             } catch (retryError) {
               console.error("[AcpStore] Retry failed:", retryError);


### PR DESCRIPTION
## Summary

- **Race condition fix**: When auto-recovery spawns a new session after cancel/force-stop, the session-ready promise resolves and any pending `sendPrompt` call (e.g. from a skill invocation) proceeds concurrently with recovery's own retry, causing `"Another prompt is already active"` errors. Fixed by checking `recoveryInFlight` both before and after the ready-promise wait — if recovery is in-flight and the session is already prompting, the duplicate call aborts.

- **Skills context fix**: The recovery retry used the bare `context` parameter (undefined for skill invocations from AgentChat) instead of the merged context with skills content. The fresh session received the `<skill-invocation>` directive but lacked the skills system prompt, so the agent reported "skill isn't registered as invocable". Fixed by rebuilding skills context via `getThreadSkillsContent` before the recovery retry.

Closes #940

## Test plan

- [ ] Invoke a skill (`/skill-name`) in agent chat
- [ ] Cancel the running prompt, wait for force-stop and auto-recovery
- [ ] Verify: no `"Another prompt is already active"` console errors
- [ ] Verify: recovery retries the skill invocation successfully (agent understands the skill)
- [ ] Verify: normal skill invocations without recovery still work as before

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com