### PR TITLE
fix: auto-failover to Chat when agent streams 'prompt is too long'

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -1743,10 +1743,13 @@ Summary:`;
         return;
       }
 
-      // Skip addErrorMessage for cancellation — the error event handler
-      // already recorded it in chat history. Adding it again here would
-      // create a duplicate banner.
-      if (!message.includes("Task cancelled")) {
+      // Skip addErrorMessage for cancellation and prompt-too-long — the error
+      // event handler already recorded them and triggers the appropriate
+      // recovery flow. Adding them again here would create duplicates.
+      if (
+        !message.includes("Task cancelled") &&
+        !isPromptTooLongError(message)
+      ) {
         this.addErrorMessage(sessionId, message);
       }
     }
@@ -2840,12 +2843,18 @@ Summary:`;
       }
 
       // If the agent's response is a prompt-too-long error (context window full),
-      // flag the session so the UI shows the "Continue in Chat" fallback banner.
+      // automatically switch to Chat mode with history preserved.
       if (isPromptTooLongError(session.streamingContent)) {
         console.info(
-          "[AcpStore] Prompt too long detected in streamed content, flagging session for chat fallback",
+          "[AcpStore] Prompt too long detected in streamed content, switching to Chat mode",
         );
         setState("sessions", sessionId, "promptTooLong", true);
+        this.acceptRateLimitFallback().catch((err) => {
+          console.error(
+            "[AcpStore] Auto-failover from streamed content failed:",
+            err,
+          );
+        });
       }
 
       setState("sessions", sessionId, "streamingContent", "");


### PR DESCRIPTION
The streamed content path only set the promptTooLong flag but never called acceptRateLimitFallback(), leaving the user stuck on the agent screen with no way to continue. Now both paths (error event and streamed content) trigger the auto-switch to Chat mode.

Also skip duplicate addErrorMessage in sendPrompt catch for prompt-too-long errors since the event handler already handles them.

Fixes #944

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com Email: hello@serendb.com

## Description

What does this PR do?

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] No secrets or credentials in code

## Screenshots

If UI changes, add before/after screenshots.
