### PR TITLE
fix: inline text/code attachments as image_url and fix Claude CLI path on Windows

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -2,6 +2,7 @@
 // ABOUTME: Streams SSE responses with tool execution loop for function calling.
 
 use async_trait::async_trait;
+use base64::{Engine, engine::general_purpose::STANDARD};
 use futures::StreamExt;
 use log;
 use serde::{Deserialize, Serialize};
@@ -181,12 +182,46 @@ impl ChatModelWorker {
                 "text": prompt
             }));
             for image in images {
-                content_parts.push(serde_json::json!({
-                    "type": "image_url",
-                    "image_url": {
-                        "url": format!("data:{};base64,{}", image.mime_type, image.base64)
+                if image.mime_type.starts_with("image/") {
+                    // Vision-compatible image — send as image_url
+                    content_parts.push(serde_json::json!({
+                        "type": "image_url",
+                        "image_url": {
+                            "url": format!("data:{};base64,{}", image.mime_type, image.base64)
+                        }
+                    }));
+                } else if image.mime_type.starts_with("text/")
+                    || image.mime_type == "application/json"
+                    || image.mime_type == "application/xml"
+                {
+                    // Text/code file — decode base64 and inline as text
+                    let decoded = STANDARD
+                        .decode(&image.base64)
+                        .ok()
+                        .and_then(|bytes| String::from_utf8(bytes).ok());
+                    if let Some(text_content) = decoded {
+                        let ext = image
+                            .name
+                            .rsplit('.')
+                            .next()
+                            .unwrap_or("");
+                        content_parts.push(serde_json::json!({
+                            "type": "text",
+                            "text": format!("```{} ({})\n{}\n```", ext, image.name, text_content)
+                        }));
+                    } else {
+                        content_parts.push(serde_json::json!({
+                            "type": "text",
+                            "text": format!("[Could not decode attachment: {}]", image.name)
+                        }));
                     }
-                }));
+                } else {
+                    // Unsupported binary format — note it for the model
+                    content_parts.push(serde_json::json!({
+                        "type": "text",
+                        "text": format!("[Unsupported attachment format: {} ({})]", image.name, image.mime_type)
+                    }));
+                }
             }
             messages.push(serde_json::json!({
                 "role": "user",


### PR DESCRIPTION
## Summary

### 1. Non-image attachments sent as image_url (Closes #946)
- `ChatModelWorker::build_request_body` sent ALL attachments as `image_url` content blocks regardless of MIME type
- When a user attached a non-image file (e.g. `.html`, `.txt`, `.py`), the API provider (OpenAI/Azure) rejected it with HTTP 400: `unsupported MIME type 'text/html'`
- Now checks MIME type per attachment:
  - `image/*` -> `image_url` content block (unchanged)
  - `text/*`, `application/json`, `application/xml` -> base64-decode and inline as fenced code block
  - Other binary formats -> skip with a note to the model

### 2. Claude CLI not found on Windows (Closes #948)
- `find_claude_cli` checked for `claude` without `.exe` extension, so the native install at `~/.local/bin/claude.exe` was never found on Windows
- The spawn code only set `CLAUDE_CLI_PATH` for legacy npm installs (`cli_tools_bin`), never for native installs — GUI apps on Windows don't inherit `~/.local/bin` in PATH
- Fixed both `find_claude_cli` (uses `.exe`/`.cmd` on Windows) and both spawn paths (`run_session_worker` + `load_session`) to check native install and set `CLAUDE_CLI_PATH`

## Test plan

- [ ] Attach an HTML file in Chat panel and send a message — should succeed, file inlined as text
- [ ] Attach a `.py` or `.ts` file — should succeed, inlined as code block
- [ ] Attach a PNG image — should still work as image_url (no regression)
- [ ] On Windows: verify Agent mode finds Claude CLI at `~/.local/bin/claude.exe`
- [ ] On Windows: verify `CLAUDE_CLI_PATH` is set in agent process logs

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com