### PR TITLE
fix: collapse verbose build output in agent and chat panels (#952)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -21,6 +21,7 @@ import { CompactedMessage } from "@/components/chat/CompactedMessage";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { isAuthError } from "@/lib/auth-errors";
+import { collapseBuildOutput } from "@/lib/build-output";
 import {
   getCompletions,
   matchSkillCommand,
@@ -900,9 +901,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           <article class="px-5 py-4 border-b border-surface-2">
             <div
               class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
-              innerHTML={collapseDirectoryListings(
-                htmlCache[message.id] ??
-                  escapeHtml(message.content).replace(/\n/g, "<br>"),
+              innerHTML={collapseBuildOutput(
+                collapseDirectoryListings(
+                  htmlCache[message.id] ??
+                    escapeHtml(message.content).replace(/\n/g, "<br>"),
+                ),
               )}
             />
             <Show when={message.duration}>

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -18,6 +18,7 @@ import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { DepositModal } from "@/components/wallet/DepositModal";
 import { isAuthError } from "@/lib/auth-errors";
+import { collapseBuildOutput } from "@/lib/build-output";
 import {
   getCompletions,
   matchSkillCommand,
@@ -1072,8 +1073,10 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                         class="chat-message-content text-[14px] leading-[1.7] text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-[1.3em] [&_h1]:font-semibold [&_h1]:mt-5 [&_h1]:mb-3 [&_h1]:text-foreground [&_h1]:border-b [&_h1]:border-surface-2 [&_h1]:pb-2 [&_h2]:text-[1.15em] [&_h2]:font-semibold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-foreground [&_h3]:text-[1.05em] [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-2 [&_h3]:text-foreground [&_code]:bg-surface-1 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_li]:leading-[1.6] [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline [&_strong]:text-foreground [&_strong]:font-semibold"
                         innerHTML={
                           message.role === "assistant"
-                            ? collapseDirectoryListings(
-                                renderMarkdown(message.content),
+                            ? collapseBuildOutput(
+                                collapseDirectoryListings(
+                                  renderMarkdown(message.content),
+                                ),
                               )
                             : escapeHtmlWithLinks(message.content)
                         }

--- a/src/lib/build-output.ts
+++ b/src/lib/build-output.ts
@@ -1,0 +1,115 @@
+// ABOUTME: Detects verbose build/compile output and provides collapse utilities.
+// ABOUTME: Used to suppress noisy cargo/npm/pip output in chat and agent chat panels.
+
+/**
+ * Patterns that match a single line of verbose build output.
+ * Each regex should match common package-manager progress lines.
+ */
+const BUILD_LINE_PATTERNS = [
+  // Cargo (Rust)
+  /^\s*(Compiling|Downloading|Downloaded|Locking|Updating|Fetching|Unpacking|Fresh)\s+\S+/,
+  // npm / pnpm / yarn
+  /^\s*(added|removed|updated|npm warn|npm info|packages in)\s/i,
+  // pip (Python)
+  /^\s*(Collecting|Downloading|Installing|Using cached|Requirement already satisfied)\s/i,
+  // Go
+  /^\s*go: (downloading|extracting|finding)\s/,
+];
+
+/** Minimum consecutive matching lines to trigger detection */
+const MIN_CONSECUTIVE = 5;
+
+/**
+ * Returns true if the text is predominantly verbose build output.
+ */
+export function isBuildOutput(text: string): boolean {
+  const lines = text.split("\n");
+  let consecutive = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (BUILD_LINE_PATTERNS.some((p) => p.test(trimmed))) {
+      consecutive++;
+      if (consecutive >= MIN_CONSECUTIVE) return true;
+    } else {
+      consecutive = 0;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns a one-line summary of build output.
+ * Counts matching lines and identifies the build tool.
+ */
+export function summarizeBuildOutput(text: string): string {
+  const lines = text.split("\n");
+  let count = 0;
+  let tool = "Build";
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (BUILD_LINE_PATTERNS.some((p) => p.test(trimmed))) {
+      count++;
+      if (/^\s*Compiling\s/.test(trimmed)) tool = "Cargo build";
+      else if (/^\s*Downloading\s/.test(trimmed) && tool === "Build")
+        tool = "Download";
+      else if (/^\s*(added|npm)\s/i.test(trimmed)) tool = "npm install";
+      else if (/^\s*(Collecting|pip)\s/i.test(trimmed)) tool = "pip install";
+      else if (/^\s*go:\s/.test(trimmed)) tool = "Go build";
+    }
+  }
+  return `${tool} output (${count} ${count === 1 ? "line" : "lines"})`;
+}
+
+/** Decode basic HTML entities for detection in rendered HTML. */
+function decodeBasicHtmlEntities(html: string): string {
+  return html
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+/**
+ * Post-processes rendered HTML to collapse verbose build output blocks.
+ * Wraps detected blocks in native <details><summary> elements.
+ */
+export function collapseBuildOutput(html: string): string {
+  // Handle build output inside <pre><code> blocks (markdown-rendered path)
+  const modified = html.replace(
+    /(<pre[^>]*><code[^>]*>)([\s\S]*?)(<\/code><\/pre>)/g,
+    (match, _open: string, content: string, _close: string) => {
+      const decoded = decodeBasicHtmlEntities(content);
+      if (isBuildOutput(decoded)) {
+        const summary = summarizeBuildOutput(decoded);
+        return `<details class="build-output-collapse"><summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>${match}</details>`;
+      }
+      return match;
+    },
+  );
+
+  // If we already handled a <pre> block, return
+  if (modified !== html) return modified;
+
+  // Handle <br>-separated content (fallback/escaped HTML path)
+  if (!/<pre[\s>]/.test(html)) {
+    const segments = html.split(/<br\s*\/?>/i);
+    if (segments.length >= MIN_CONSECUTIVE) {
+      const plainText = segments
+        .map((s) => decodeBasicHtmlEntities(s))
+        .join("\n");
+      if (isBuildOutput(plainText)) {
+        const summary = summarizeBuildOutput(plainText);
+        return [
+          '<details class="build-output-collapse">',
+          `<summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>`,
+          `<pre style="white-space:pre-wrap;margin:0.5em 0;font-size:12px;color:inherit">${html}</pre>`,
+          "</details>",
+        ].join("");
+      }
+    }
+  }
+
+  return html;
+}


### PR DESCRIPTION
## Summary
- Add `build-output.ts` detection module that identifies verbose build output (Cargo, npm, pip, Go)
- Wrap detected blocks in collapsible `<details><summary>` showing a one-line summary like "Cargo build output (47 lines)"
- Chain with existing `collapseDirectoryListings` in both AgentChat.tsx and ChatContent.tsx

## Test plan
- [ ] Run a `cargo build` in an agent session — compile lines should collapse
- [ ] Run `npm install` — install lines should collapse
- [ ] Normal assistant messages unaffected
- [ ] `pnpm check` passes

Fixes #952

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
