### PR TITLE
fix: detect API Error 400 form of prompt-too-long in agent failover

### DIFF
--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -42,14 +42,36 @@ const PROMPT_TOO_LONG_PATTERNS = [
   "content too large",
   "exceeds the model",
   "ran out of room",
+  "too many tokens",
+  "exceeds the maximum",
+  "number of input tokens",
+  "reduce your prompt",
+  "reduce the number of messages",
 ];
 
 /**
  * Check whether a message indicates the agent's context window is full.
+ *
+ * Also catches the CLI's raw API error form:
+ *   `API Error: 400 {"type":"error","error":{"type":"invalid_request_error",...}}`
+ * which wraps the Anthropic error without always including recognizable keywords.
  */
 export function isPromptTooLongError(message: string): boolean {
   const lower = message.toLowerCase();
-  return PROMPT_TOO_LONG_PATTERNS.some((pattern) => lower.includes(pattern));
+  if (PROMPT_TOO_LONG_PATTERNS.some((pattern) => lower.includes(pattern))) {
+    return true;
+  }
+  // The Claude CLI sometimes returns the raw API error as assistant content.
+  // A 400 invalid_request_error during an active agent session is almost always
+  // a context-length issue — other 400 causes (bad params, missing fields) don't
+  // happen mid-session.
+  if (
+    lower.includes("api error: 400") &&
+    lower.includes("invalid_request_error")
+  ) {
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/tests/unit/rate-limit-fallback.test.ts
+++ b/tests/unit/rate-limit-fallback.test.ts
@@ -1,0 +1,121 @@
+// ABOUTME: Tests for rate-limit and prompt-too-long error detection functions.
+// ABOUTME: Verifies pattern matching catches all known API error forms.
+
+import { describe, expect, it } from "vitest";
+import {
+  isPromptTooLongError,
+  isRateLimitError,
+} from "@/lib/rate-limit-fallback";
+
+describe("isPromptTooLongError", () => {
+  it("detects bare 'Prompt is too long' from CLI", () => {
+    expect(isPromptTooLongError("Prompt is too long")).toBe(true);
+  });
+
+  it("detects case-insensitive variants", () => {
+    expect(isPromptTooLongError("PROMPT IS TOO LONG")).toBe(true);
+    expect(isPromptTooLongError("prompt too long")).toBe(true);
+  });
+
+  it("detects Anthropic API error wrapped by CLI", () => {
+    const apiError =
+      'API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 250000 tokens > 200000 maximum"}}';
+    expect(isPromptTooLongError(apiError)).toBe(true);
+  });
+
+  it("detects API Error 400 + invalid_request_error without recognizable message", () => {
+    // When the inner message doesn't match any keyword patterns,
+    // the compound check (api error: 400 + invalid_request_error) should still catch it
+    const apiError =
+      'API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"something unexpected"}}';
+    expect(isPromptTooLongError(apiError)).toBe(true);
+  });
+
+  it("detects 'too many tokens' phrasing", () => {
+    expect(
+      isPromptTooLongError(
+        "Number of input tokens 250000 exceeds the maximum of 200000 for this model. Too many tokens.",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects 'exceeds the maximum' phrasing", () => {
+    expect(
+      isPromptTooLongError(
+        "Number of input tokens exceeds the maximum for this model",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects 'reduce your prompt' phrasing", () => {
+    expect(
+      isPromptTooLongError(
+        "Please reduce your prompt and try again.",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects 'reduce the number of messages' phrasing", () => {
+    expect(
+      isPromptTooLongError(
+        "Please reduce the number of messages or the length of your system prompt.",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects context_length_exceeded", () => {
+    expect(isPromptTooLongError("context_length_exceeded")).toBe(true);
+  });
+
+  it("detects 'maximum context length' phrasing", () => {
+    expect(
+      isPromptTooLongError(
+        "This model's maximum context length is 200000 tokens",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not false-positive on normal assistant content", () => {
+    expect(
+      isPromptTooLongError(
+        "I can help you write that function. Here's an implementation:",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not false-positive on unrelated 400 errors", () => {
+    expect(
+      isPromptTooLongError(
+        'API Error: 400 {"type":"error","error":{"type":"authentication_error","message":"invalid api key"}}',
+      ),
+    ).toBe(false);
+  });
+
+  it("does not false-positive on 400 without invalid_request_error", () => {
+    expect(
+      isPromptTooLongError(
+        "API Error: 400 Bad Request",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isRateLimitError", () => {
+  it("detects 429 status", () => {
+    expect(isRateLimitError("429 Too Many Requests")).toBe(true);
+  });
+
+  it("detects rate limit phrasing", () => {
+    expect(isRateLimitError("You have hit your rate limit")).toBe(true);
+  });
+
+  it("detects overloaded", () => {
+    expect(isRateLimitError("API is overloaded")).toBe(true);
+  });
+
+  it("does not false-positive on unrelated errors", () => {
+    expect(
+      isRateLimitError("Invalid JSON in request body"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Agent-to-chat failover only triggered on bare `Prompt is too long` from the CLI
- The first 1-2 failures arrive as `API Error: 400 {"type":"error","error":{"type":"invalid_request_error",...}}` which got displayed to the user as assistant content
- Added 5 missing patterns to `PROMPT_TOO_LONG_PATTERNS`: `too many tokens`, `exceeds the maximum`, `number of input tokens`, `reduce your prompt`, `reduce the number of messages`
- Added compound check: `api error: 400` + `invalid_request_error` catches the raw JSON wrapper form regardless of inner message wording
- Added 17 unit tests for `isPromptTooLongError` and `isRateLimitError`

## Test plan
- [x] All 166 unit tests pass (including 17 new detection tests)
- [ ] In a long agent session that exhausts context, failover should trigger on the FIRST error, not after 2-3 retries

Closes #954

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com