### PR TITLE
feat: add Fork Conversation feature for agent sessions

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -5,8 +5,9 @@ use agent_client_protocol::{Agent, Client, ClientSideConnection, Result as AcpRe
 use agent_client_protocol::{
     AuthMethod, AuthenticateRequest, CancelNotification, ClientCapabilities, ContentBlock,
     CreateTerminalRequest, CreateTerminalResponse, EnvVariable, ExtNotification, ExtRequest,
-    ExtResponse, ImageContent, Implementation, InitializeRequest, KillTerminalCommandRequest,
-    KillTerminalCommandResponse, ListSessionsRequest, LoadSessionRequest, McpServer,
+    ExtResponse, ForkSessionRequest, ImageContent, Implementation, InitializeRequest,
+    KillTerminalCommandRequest, KillTerminalCommandResponse, ListSessionsRequest,
+    LoadSessionRequest, McpServer,
     McpServerStdio, ModelId, NewSessionRequest, PromptRequest, ProtocolVersion,
     ReadTextFileRequest, ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
     RequestPermissionRequest, RequestPermissionResponse, SessionModeId, SessionNotification,
@@ -484,6 +485,11 @@ pub(crate) enum AcpCommand {
         cwd: String,
         cursor: Option<String>,
         response_tx: oneshot::Sender<Result<AcpRemoteSessionsPage, String>>,
+    },
+    /// Fork the current agent session, creating a new session with the same
+    /// conversation history.  Returns the new agent session ID.
+    Fork {
+        response_tx: oneshot::Sender<Result<String, String>>,
     },
     Terminate,
 }
@@ -2406,6 +2412,9 @@ async fn run_session_worker(
                                     Some(AcpCommand::ListRemoteSessions { response_tx: tx, .. }) => {
                                         let _ = tx.send(Err("Cannot list sessions while cancellation is pending".to_string()));
                                     }
+                                    Some(AcpCommand::Fork { response_tx: tx }) => {
+                                        let _ = tx.send(Err("Cannot fork while cancellation is pending".to_string()));
+                                    }
                                     None => {
                                         let _ = response_tx.send(Err("Command channel closed".to_string()));
                                         return Ok(());
@@ -2495,6 +2504,9 @@ async fn run_session_worker(
                                     }
                                     Some(AcpCommand::ListRemoteSessions { response_tx: tx, .. }) => {
                                         let _ = tx.send(Err("Cannot list sessions while prompt is active".to_string()));
+                                    }
+                                    Some(AcpCommand::Fork { response_tx: tx }) => {
+                                        let _ = tx.send(Err("Cannot fork while prompt is active".to_string()));
                                     }
                                     Some(other) => {
                                         log::info!("[ACP] Rejecting command while prompt is active");
@@ -2753,6 +2765,26 @@ async fn run_session_worker(
                     .map_err(|e| format!("Failed to list sessions: {}", format_acp_error(&e)));
                 let _ = response_tx.send(result);
             }
+            AcpCommand::Fork { response_tx } => {
+                let mcp_servers = build_mcp_servers(&app, api_key.as_deref());
+                let fork_req = ForkSessionRequest::new(agent_session_id.clone(), &cwd)
+                    .mcp_servers(mcp_servers);
+                match connection.fork_session(fork_req).await {
+                    Ok(resp) => {
+                        let new_id = resp.session_id.0.to_string();
+                        log::info!(
+                            "[ACP] Forked session {} -> {}",
+                            agent_session_id,
+                            new_id
+                        );
+                        let _ = response_tx.send(Ok(new_id));
+                    }
+                    Err(e) => {
+                        log::error!("[ACP] Fork session failed: {:?}", e);
+                        let _ = response_tx.send(Err(format_acp_error(&e)));
+                    }
+                }
+            }
             AcpCommand::Terminate => {
                 break;
             }
@@ -2867,6 +2899,37 @@ pub async fn acp_terminate(state: State<'_, AcpState>, session_id: String) -> Re
     }
 
     Ok(())
+}
+
+/// Fork the agent session, creating a new CLI session with the same conversation
+/// history.  Returns the new remote agent session ID.
+#[tauri::command]
+pub async fn acp_fork_session(
+    state: State<'_, AcpState>,
+    session_id: String,
+) -> Result<String, String> {
+    let command_tx = {
+        let sessions = state.sessions.read().await;
+        let session_arc = sessions
+            .get(&session_id)
+            .ok_or_else(|| format!("Session '{}' not found", session_id))?;
+        let session = session_arc.lock().await;
+        session
+            .command_tx
+            .clone()
+            .ok_or_else(|| "Session not initialized".to_string())?
+    };
+
+    let (response_tx, response_rx) = oneshot::channel();
+
+    command_tx
+        .send(AcpCommand::Fork { response_tx })
+        .await
+        .map_err(|_| "Failed to send fork command".to_string())?;
+
+    response_rx
+        .await
+        .map_err(|_| "Worker thread dropped".to_string())?
 }
 
 /// List all ACP sessions

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -761,6 +761,8 @@ pub fn run() {
             #[cfg(feature = "acp")]
             acp::acp_terminate,
             #[cfg(feature = "acp")]
+            acp::acp_fork_session,
+            #[cfg(feature = "acp")]
             acp::acp_list_sessions,
             #[cfg(feature = "acp")]
             acp::acp_list_remote_sessions,

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -699,6 +699,22 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     await acpStore.cancelPrompt();
   };
 
+  const [forking, setForking] = createSignal(false);
+
+  const handleForkFromMessage = async (messageId: string) => {
+    const session = acpStore.activeSession;
+    if (!session || forking()) return;
+
+    setForking(true);
+    try {
+      await threadStore.forkAgentThread(session.conversationId, messageId);
+    } catch (e) {
+      console.error("[AgentChat] Fork failed:", e);
+    } finally {
+      setForking(false);
+    }
+  };
+
   const handleGlobalKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Escape" && isPrompting()) {
       event.preventDefault();
@@ -867,7 +883,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     switch (message.type) {
       case "user":
         return (
-          <article class="px-5 py-4 bg-surface-1 border-b border-surface-2">
+          <article class="group/msg relative px-5 py-4 bg-surface-1 border-b border-surface-2">
             <Show when={message.docNames?.length}>
               <div class="flex flex-wrap gap-1.5 mb-2">
                 <For each={message.docNames}>
@@ -893,12 +909,30 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               class="text-sm leading-relaxed text-foreground whitespace-pre-wrap"
               innerHTML={escapeHtmlWithLinks(message.content)}
             />
+            <button
+              type="button"
+              class="absolute top-2 right-2 hidden group-hover/msg:inline-flex items-center gap-1 px-2 py-1 rounded text-xs bg-surface-2 border border-border text-muted-foreground cursor-pointer transition-all hover:bg-surface-3 hover:text-foreground"
+              onClick={() => handleForkFromMessage(message.id)}
+              title="Fork conversation from here"
+            >
+              <svg
+                aria-hidden="true"
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                class="shrink-0"
+              >
+                <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM5 12.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm7-7.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM2.75 3.25a1.5 1.5 0 0 0 2.75.8v4.9a1.5 1.5 0 1 0-1.5 0v-4.9a1.5 1.5 0 0 0-1.25-.8Zm8.5 0a1.5 1.5 0 0 1-1.25.8v2.7a.75.75 0 0 1-1.5 0v-2.7a1.5 1.5 0 1 1 2.75-.8Z" />
+              </svg>
+              Fork
+            </button>
           </article>
         );
 
       case "assistant":
         return (
-          <article class="px-5 py-4 border-b border-surface-2">
+          <article class="group/msg relative px-5 py-4 border-b border-surface-2">
             <div
               class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
               innerHTML={collapseBuildOutput(
@@ -922,6 +956,24 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 );
               })()}
             </Show>
+            <button
+              type="button"
+              class="absolute top-2 right-2 hidden group-hover/msg:inline-flex items-center gap-1 px-2 py-1 rounded text-xs bg-surface-2 border border-border text-muted-foreground cursor-pointer transition-all hover:bg-surface-3 hover:text-foreground"
+              onClick={() => handleForkFromMessage(message.id)}
+              title="Fork conversation from here"
+            >
+              <svg
+                aria-hidden="true"
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                class="shrink-0"
+              >
+                <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM5 12.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm7-7.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM2.75 3.25a1.5 1.5 0 0 0 2.75.8v4.9a1.5 1.5 0 1 0-1.5 0v-4.9a1.5 1.5 0 0 0-1.25-.8Zm8.5 0a1.5 1.5 0 0 1-1.25.8v2.7a.75.75 0 0 1-1.5 0v-2.7a1.5 1.5 0 1 1 2.75-.8Z" />
+              </svg>
+              Fork
+            </button>
           </article>
         );
 

--- a/src/services/acp.ts
+++ b/src/services/acp.ts
@@ -287,6 +287,14 @@ export async function terminateSession(sessionId: string): Promise<void> {
 }
 
 /**
+ * Fork an ACP agent session, creating a new CLI session with the same
+ * conversation history.  Returns the new remote agent session ID.
+ */
+export async function forkSession(sessionId: string): Promise<string> {
+  return invoke<string>("acp_fork_session", { sessionId });
+}
+
+/**
  * List all active ACP sessions.
  */
 export async function listSessions(): Promise<AcpSessionInfo[]> {

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -2928,6 +2928,94 @@ Summary:`;
     }
   },
 
+  // ============================================================================
+  // Fork
+  // ============================================================================
+
+  /**
+   * Fork the current agent conversation from a specific message.
+   *
+   * Creates a new agent session with the same conversation history (via the ACP
+   * fork_session capability) and a new local conversation containing messages up
+   * to `fromMessageId`.  Returns the new local conversation ID.
+   */
+  async forkConversation(
+    conversationId: string,
+    fromMessageId: string,
+  ): Promise<string | null> {
+    const session = state.sessions[conversationId];
+    if (!session) {
+      console.error("[AcpStore] forkConversation: session not found");
+      return null;
+    }
+
+    const agentType = session.info.agentType;
+    const cwd = session.cwd;
+
+    // 1. Ask the sidecar to fork the CLI session.
+    let newAgentSessionId: string;
+    try {
+      newAgentSessionId = await acpService.forkSession(conversationId);
+    } catch (err) {
+      console.error("[AcpStore] forkConversation: fork failed:", err);
+      this.addErrorMessage(
+        conversationId,
+        `Fork failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+
+    // 2. Collect messages up to the fork point.
+    const allMessages = session.messages;
+    const forkIndex = allMessages.findIndex((m) => m.id === fromMessageId);
+    if (forkIndex === -1) {
+      console.error("[AcpStore] forkConversation: message not found");
+      return null;
+    }
+    const forkedMessages = allMessages.slice(0, forkIndex + 1);
+
+    // 3. Create a new local conversation in SQLite.
+    const newConversationId = crypto.randomUUID();
+    const forkTitle = `Fork of ${session.title ?? "Agent"}`;
+    try {
+      await createAgentConversation(
+        newConversationId,
+        forkTitle,
+        agentType,
+        cwd,
+        null,
+        newAgentSessionId,
+      );
+
+      // Persist forked messages to the new conversation.
+      for (const msg of forkedMessages) {
+        persistAgentMessage(newConversationId, msg);
+      }
+    } catch (err) {
+      console.error("[AcpStore] forkConversation: DB error:", err);
+      return null;
+    }
+
+    // 4. Spawn a new sidecar session that resumes the forked CLI session.
+    const newSessionId = await this.spawnSession(cwd, agentType, {
+      localSessionId: newConversationId,
+      resumeAgentSessionId: newAgentSessionId,
+      conversationTitle: forkTitle,
+      restoredMessages: forkedMessages,
+    });
+
+    if (!newSessionId) {
+      console.error("[AcpStore] forkConversation: spawn failed");
+      return null;
+    }
+
+    console.info(
+      `[AcpStore] Forked conversation ${conversationId} -> ${newConversationId} (agent session: ${newAgentSessionId})`,
+    );
+
+    return newConversationId;
+  },
+
   addErrorMessage(sessionId: string, error: string) {
     const message: AgentMessage = {
       id: crypto.randomUUID(),

--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -453,6 +453,25 @@ export const threadStore = {
   },
 
   /**
+   * Fork an agent thread from a specific message.
+   * Creates a new conversation with the forked CLI session and switches to it.
+   */
+  async forkAgentThread(
+    fromConversationId: string,
+    fromMessageId: string,
+  ): Promise<string | null> {
+    const newConversationId = await acpStore.forkConversation(
+      fromConversationId,
+      fromMessageId,
+    );
+    if (!newConversationId) return null;
+
+    await acpStore.refreshRecentAgentConversations(200);
+    this.selectThread(newConversationId, "agent");
+    return newConversationId;
+  },
+
+  /**
    * Sync thread state from underlying stores. Call after auth or on mount.
    */
   async refresh() {


### PR DESCRIPTION
## Summary

- Wires ACP `fork_session` through the full stack (Rust backend, TypeScript service, stores, UI)
- Users can hover over any user or assistant message and click "Fork" to create a new agent session that inherits the full conversation history up to that point
- Enables recovery from unrecoverable agent errors (e.g., API 400 "thinking blocks cannot be modified") by branching from the last good message

Closes #956

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/acp.rs` | `AcpCommand::Fork` variant, handler calling `connection.fork_session()`, `acp_fork_session` Tauri command |
| `src-tauri/src/lib.rs` | Register `acp_fork_session` in invoke_handler |
| `src/services/acp.ts` | `forkSession()` function |
| `src/stores/acp.store.ts` | `forkConversation()` — copies messages, forks CLI session, spawns new sidecar |
| `src/stores/thread.store.ts` | `forkAgentThread()` — creates and selects the forked thread |
| `src/components/chat/AgentChat.tsx` | Hover-visible "Fork" button on user and assistant messages |

## Test plan

- [ ] Start an agent conversation and send a few messages
- [ ] Hover over a user or assistant message — "Fork" button appears
- [ ] Click Fork — new thread appears in sidebar with messages up to that point
- [ ] Send a message in the forked conversation — agent responds with context of prior messages
- [ ] Original conversation remains accessible and unchanged
- [ ] Fork while agent is prompting is rejected gracefully

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com