### PR TITLE
fix: unblock sendPrompt after session termination (#959)

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -2846,6 +2846,18 @@ Summary:`;
         sessionReadyPromises.delete(sessionId);
       }
     }
+
+    // When a session is terminated (force-stopped, permission timeout, etc.),
+    // resolve any pending ready promise so sendPrompt unblocks instead of
+    // hanging forever. sendPrompt will then detect the dead session and
+    // trigger recovery.
+    if (status === "terminated") {
+      const entry = sessionReadyPromises.get(sessionId);
+      if (entry) {
+        entry.resolve();
+        sessionReadyPromises.delete(sessionId);
+      }
+    }
   },
 
   finalizeStreamingContent(sessionId: string) {


### PR DESCRIPTION
## Summary
- Resolve `sessionReadyPromises` entry when session status becomes "terminated"
- Previously, `sendPrompt` hung forever at `await readyEntry.promise` because the promise was only resolved on "ready" status, never on "terminated"
- User's input was silently swallowed after permission timeout recovery failure

## Root Cause
When a permission request times out and the session is force-stopped, the backend marks the session as "terminated". The "ready" status handler resolves the promise, but "terminated" had no handler — the promise stayed pending forever, blocking all subsequent `sendPrompt` calls.

## Test plan
- [ ] Let a permission request time out (wait 5+ minutes)
- [ ] After recovery failure message, send a new message — should trigger recovery instead of hanging
- [ ] Normal sessions unaffected

Fixes #959

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
