### PR TITLE
fix: prevent old worker cleanup from clobbering recovery session

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -1632,7 +1632,10 @@ pub async fn acp_spawn(
                 }
             }
 
-            // Clean up session from map when worker exits (prevents ghost sessions)
+            // Clean up session from map when worker exits (prevents ghost sessions).
+            // Only remove if the map still holds THIS worker's session Arc — a recovery
+            // spawn may have already replaced the entry with a new session under the
+            // same key, and we must not clobber it.
             let cleanup_session_id = session_id_clone.clone();
             let state = app_handle.state::<AcpState>();
 
@@ -1653,8 +1656,19 @@ pub async fn acp_spawn(
             }
 
             let mut sessions = state.sessions.write().await;
-            sessions.remove(&cleanup_session_id);
-            log::info!("[ACP] Session {} removed from map after worker exit", cleanup_session_id);
+            let should_remove = sessions
+                .get(&cleanup_session_id)
+                .map(|current| Arc::ptr_eq(current, &session_arc_for_worker))
+                .unwrap_or(false);
+            if should_remove {
+                sessions.remove(&cleanup_session_id);
+                log::info!("[ACP] Session {} removed from map after worker exit", cleanup_session_id);
+            } else {
+                log::info!(
+                    "[ACP] Session {} was replaced by recovery spawn — skipping removal",
+                    cleanup_session_id
+                );
+            }
         });
     });
 


### PR DESCRIPTION
## Summary
- After a cancel timeout, the old worker's cleanup unconditionally removed the session from the map by key (`sessions.remove(&session_id)`)
- If a recovery spawn had already inserted a new session under the same key, the cleanup clobbered it
- The frontend retry then failed with `Session 'a29099ba' not found`
- Fix: use `Arc::ptr_eq` to verify the map entry is still this worker's session before removing. If a recovery spawn replaced it, cleanup skips removal.

## Test plan
- [ ] Start an agent session, cancel mid-prompt, wait for cancel timeout (5s), verify recovery succeeds on first attempt
- [ ] Normal session teardown (no recovery) still cleans up the map entry
- [ ] Multiple rapid cancel/retry cycles don't leave ghost sessions

Closes #957

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com