### PR TITLE
fix: mark in-progress plan entries as completed on promptComplete

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -2210,6 +2210,21 @@ Summary:`;
         this.finalizeStreamingContent(sessionId);
         if (!isHistoryReplay) {
           this.markPendingToolCallsComplete(sessionId);
+
+          // Mark any remaining in-progress plan entries as completed.
+          // Plan entry status is set by planUpdate events from the backend,
+          // but a final planUpdate may not arrive after the last tool finishes.
+          const plan = state.sessions[sessionId]?.plan;
+          if (plan?.some((e) => e.status === "in_progress")) {
+            setState(
+              "sessions",
+              sessionId,
+              "plan",
+              plan.map((e) =>
+                e.status === "in_progress" ? { ...e, status: "completed" } : e,
+              ),
+            );
+          }
         }
 
         // Track agent usage metadata for compaction decisions


### PR DESCRIPTION
## Summary
- Fixes #962: Plan indicator (yellow pulsing circle) stays active after agent prompt completes
- Plan entry status is set by `planUpdate` events from the backend, but a final `planUpdate` may not arrive after the last tool finishes — leaving entries stuck in `in_progress`
- On `promptComplete`, any remaining `in_progress` plan entries are now marked `completed`, which clears the pulsing indicator

## Test plan
- [ ] Start an agent chat that generates a multi-step plan
- [ ] Wait for prompt to complete
- [ ] Verify the plan indicator shows all steps as completed (green checkmarks, no yellow pulsing)
- [ ] Verify normal plan progression still works during active prompts

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com