### PR TITLE
fix: expand directory listing detection to catch find and path output

### DIFF
--- a/src/lib/directory-listing.ts
+++ b/src/lib/directory-listing.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Detects Unix directory listing output and provides collapse utilities.
-// ABOUTME: Used to suppress verbose ls output in chat and agent chat panels.
+// ABOUTME: Detects verbose file-listing output and provides collapse utilities.
+// ABOUTME: Catches ls -l, find, path listings, and traversal errors in chat panels.
 
 /** Unix ls -l permission format: drwxr-xr-x, -rw-r--r--, etc. */
 const LS_LINE = /^[dlcbps-][rwxsStT-]{9}\s/;
@@ -7,12 +7,41 @@ const LS_LINE = /^[dlcbps-][rwxsStT-]{9}\s/;
 /** Total line header from ls -l output */
 const TOTAL_LINE = /^total \d+$/;
 
+/** Absolute Unix path: starts with / followed by at least one path segment */
+const UNIX_PATH = /^\/[\w.@~+-]/;
+
+/** Absolute Windows path: C:\ or similar */
+const WIN_PATH = /^[A-Za-z]:[/\\]/;
+
+/** Path followed by an error: /path/to/dir: Operation not permitted (os error 1) */
+const PATH_ERROR =
+  /^\/[\w.@~+-].*:\s+(Operation not permitted|Permission denied|No such file|Is a directory|Not a directory)/;
+
+/** find-style error: find: '/path': Permission denied */
+const FIND_ERROR = /^(find|ls|stat):\s/;
+
+/** tree-style lines: ├── file.txt, └── dir/, │ */
+const TREE_LINE = /^[│├└─\s]{2,}/;
+
 /** Minimum consecutive matching lines to trigger detection */
 const MIN_CONSECUTIVE = 5;
 
+/** Returns true if a line looks like file-listing output. */
+function isListingLine(trimmed: string): boolean {
+  return (
+    LS_LINE.test(trimmed) ||
+    TOTAL_LINE.test(trimmed) ||
+    PATH_ERROR.test(trimmed) ||
+    FIND_ERROR.test(trimmed) ||
+    TREE_LINE.test(trimmed) ||
+    UNIX_PATH.test(trimmed) ||
+    WIN_PATH.test(trimmed)
+  );
+}
+
 /**
- * Returns true if the text is predominantly a Unix directory listing.
- * Detects `ls -l` style output with permission bits.
+ * Returns true if the text is predominantly a file listing.
+ * Detects `ls -l`, `find`, bare path listings, and traversal errors.
  */
 export function isDirectoryListing(text: string): boolean {
   const lines = text.split("\n");
@@ -20,7 +49,7 @@ export function isDirectoryListing(text: string): boolean {
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    if (LS_LINE.test(trimmed) || TOTAL_LINE.test(trimmed)) {
+    if (isListingLine(trimmed)) {
       consecutive++;
       if (consecutive >= MIN_CONSECUTIVE) return true;
     } else {
@@ -31,16 +60,29 @@ export function isDirectoryListing(text: string): boolean {
 }
 
 /**
- * Returns a one-line summary of a directory listing.
- * Counts lines matching ls -l format.
+ * Returns a one-line summary of a file listing.
+ * Counts lines matching any listing pattern.
  */
 export function summarizeDirectoryListing(text: string): string {
   const lines = text.split("\n");
   let count = 0;
+  let hasErrors = false;
   for (const line of lines) {
-    if (LS_LINE.test(line.trim())) count++;
+    const trimmed = line.trim();
+    if (isListingLine(trimmed)) {
+      count++;
+      if (
+        !hasErrors &&
+        (PATH_ERROR.test(trimmed) || FIND_ERROR.test(trimmed))
+      ) {
+        hasErrors = true;
+      }
+    }
   }
-  return `Directory listing (${count} ${count === 1 ? "entry" : "entries"})`;
+  if (hasErrors) {
+    return `File listing with errors (${count} ${count === 1 ? "line" : "lines"})`;
+  }
+  return `File listing (${count} ${count === 1 ? "entry" : "entries"})`;
 }
 
 /** Decode basic HTML entities for detection in rendered HTML. */
@@ -54,7 +96,7 @@ function decodeBasicHtmlEntities(html: string): string {
 }
 
 /**
- * Post-processes rendered HTML to collapse directory listing blocks.
+ * Post-processes rendered HTML to collapse file listing blocks.
  * Wraps detected blocks in native <details><summary> elements.
  */
 export function collapseDirectoryListings(html: string): string {

--- a/tests/unit/directory-listing.test.ts
+++ b/tests/unit/directory-listing.test.ts
@@ -1,0 +1,210 @@
+// ABOUTME: Tests for directory listing detection and collapse utilities.
+// ABOUTME: Covers ls -l, find output, bare path listings, traversal errors, and tree output.
+
+import { describe, expect, it } from "vitest";
+import {
+  isDirectoryListing,
+  summarizeDirectoryListing,
+  collapseDirectoryListings,
+} from "@/lib/directory-listing";
+
+describe("isDirectoryListing", () => {
+  it("detects ls -l output", () => {
+    const text = [
+      "total 48",
+      "drwxr-xr-x  10 user  staff   320 Mar  1 12:00 .",
+      "drwxr-xr-x   5 user  staff   160 Mar  1 12:00 ..",
+      "-rw-r--r--   1 user  staff  1024 Mar  1 12:00 file1.ts",
+      "-rw-r--r--   1 user  staff  2048 Mar  1 12:00 file2.ts",
+      "-rw-r--r--   1 user  staff   512 Mar  1 12:00 file3.ts",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(true);
+  });
+
+  it("detects bare Unix path listings from find", () => {
+    const text = [
+      "/Users/alice/Projects/app/src/index.ts",
+      "/Users/alice/Projects/app/src/main.ts",
+      "/Users/alice/Projects/app/src/utils.ts",
+      "/Users/alice/Projects/app/src/config.ts",
+      "/Users/alice/Projects/app/src/routes.ts",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(true);
+  });
+
+  it("detects Windows path listings", () => {
+    const text = [
+      "C:\\Users\\ishan\\Projects\\app\\src\\index.ts",
+      "C:\\Users\\ishan\\Projects\\app\\src\\main.ts",
+      "C:\\Users\\ishan\\Projects\\app\\src\\utils.ts",
+      "C:\\Users\\ishan\\Projects\\app\\src\\config.ts",
+      "C:\\Users\\ishan\\Projects\\app\\src\\routes.ts",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(true);
+  });
+
+  it("detects macOS permission error output", () => {
+    const text = [
+      "/Users/alice/Library/AppleMediaServices: Operation not permitted (os error 1)",
+      "/Users/alice/Library/Calendars: Operation not permitted (os error 1)",
+      "/Users/alice/Library/Photos: Operation not permitted (os error 1)",
+      "/Users/alice/Library/Mail: Operation not permitted (os error 1)",
+      "/Users/alice/Library/Safari: Operation not permitted (os error 1)",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(true);
+  });
+
+  it("detects find error output", () => {
+    const text = [
+      "find: '/root/.ssh': Permission denied",
+      "find: '/root/.gnupg': Permission denied",
+      "find: '/root/.cache': Permission denied",
+      "find: '/root/.config': Permission denied",
+      "find: '/root/.local': Permission denied",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(true);
+  });
+
+  it("detects tree command output", () => {
+    const text = [
+      "├── src",
+      "│   ├── index.ts",
+      "│   ├── utils.ts",
+      "│   └── config.ts",
+      "├── package.json",
+      "└── tsconfig.json",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(true);
+  });
+
+  it("detects mixed paths and errors", () => {
+    const text = [
+      "/Users/alice/Library/Caches/com.apple.Safari",
+      "/Users/alice/Library/Mail: Operation not permitted (os error 1)",
+      "/Users/alice/Library/Containers/com.apple.Photos",
+      "/Users/alice/Library/Group Containers: Permission denied",
+      "/Users/alice/Library/Preferences/com.apple.finder.plist",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(true);
+  });
+
+  it("returns false for normal text", () => {
+    const text = [
+      "Here is some explanation of the code.",
+      "The function takes two parameters.",
+      "It returns a boolean value.",
+      "This is used in the chat panel.",
+      "Let me know if you have questions.",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(false);
+  });
+
+  it("returns false for code blocks", () => {
+    const text = [
+      "function hello() {",
+      '  console.log("hello");',
+      "  return true;",
+      "}",
+      "",
+      "hello();",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(false);
+  });
+
+  it("requires MIN_CONSECUTIVE lines to trigger", () => {
+    const text = [
+      "/Users/alice/file1.ts",
+      "/Users/alice/file2.ts",
+      "/Users/alice/file3.ts",
+      "/Users/alice/file4.ts",
+      "some normal text here",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(false);
+  });
+
+  it("resets consecutive count on non-matching lines", () => {
+    const text = [
+      "/Users/alice/file1.ts",
+      "/Users/alice/file2.ts",
+      "--- some separator ---",
+      "/Users/alice/file3.ts",
+      "/Users/alice/file4.ts",
+    ].join("\n");
+    expect(isDirectoryListing(text)).toBe(false);
+  });
+});
+
+describe("summarizeDirectoryListing", () => {
+  it("summarizes path listings with entry count", () => {
+    const text = [
+      "/Users/alice/Projects/app/src/index.ts",
+      "/Users/alice/Projects/app/src/main.ts",
+      "/Users/alice/Projects/app/src/utils.ts",
+    ].join("\n");
+    expect(summarizeDirectoryListing(text)).toBe("File listing (3 entries)");
+  });
+
+  it("summarizes error output with error label", () => {
+    const text = [
+      "/Users/alice/Library/Mail: Operation not permitted (os error 1)",
+      "/Users/alice/Library/Safari: Operation not permitted (os error 1)",
+    ].join("\n");
+    expect(summarizeDirectoryListing(text)).toBe(
+      "File listing with errors (2 lines)",
+    );
+  });
+
+  it("summarizes find errors with error label", () => {
+    const text = [
+      "find: '/root/.ssh': Permission denied",
+      "find: '/root/.cache': Permission denied",
+    ].join("\n");
+    expect(summarizeDirectoryListing(text)).toBe(
+      "File listing with errors (2 lines)",
+    );
+  });
+
+  it("uses singular for single entry", () => {
+    const text = "/Users/alice/file.ts";
+    expect(summarizeDirectoryListing(text)).toBe("File listing (1 entry)");
+  });
+});
+
+describe("collapseDirectoryListings", () => {
+  it("wraps path listing in pre/code blocks with details", () => {
+    const paths = Array.from(
+      { length: 6 },
+      (_, i) => `/Users/alice/file${i}.ts`,
+    ).join("\n");
+    const html = `<pre><code>${paths}</code></pre>`;
+    const result = collapseDirectoryListings(html);
+    expect(result).toContain("<details");
+    expect(result).toContain("File listing (6 entries)");
+    expect(result).toContain("</details>");
+  });
+
+  it("wraps br-separated path listing with details", () => {
+    const paths = Array.from(
+      { length: 6 },
+      (_, i) => `/Users/alice/file${i}.ts`,
+    ).join("<br>");
+    const result = collapseDirectoryListings(paths);
+    expect(result).toContain("<details");
+    expect(result).toContain("File listing (6 entries)");
+  });
+
+  it("does not collapse normal text", () => {
+    const html = "This is a normal message about file handling.";
+    expect(collapseDirectoryListings(html)).toBe(html);
+  });
+
+  it("handles HTML-encoded paths in pre blocks", () => {
+    const paths = Array.from(
+      { length: 6 },
+      (_, i) => `/Users/alice/project&amp;app/file${i}.ts`,
+    ).join("\n");
+    const html = `<pre><code>${paths}</code></pre>`;
+    const result = collapseDirectoryListings(html);
+    expect(result).toContain("<details");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #964: directory listing detection only matched `ls -l` format (permission bits)
- Now detects bare file paths (from `find`, `ls`), Windows paths (`C:\...`), macOS permission errors ("Operation not permitted"), `find`/`ls`/`stat` error prefixes, and `tree` output
- Adds `isListingLine()` helper that checks all patterns in priority order (specific errors first, then general paths)
- Summary distinguishes error output ("File listing with errors") from clean listings ("File listing")
- 19 unit tests covering all pattern types, edge cases, and false-positive guards

## Test plan
- [x] 185 tests pass (19 new directory-listing tests)
- [ ] Verify bare path listings from `find` are collapsed in agent chat
- [ ] Verify macOS permission error output is collapsed
- [ ] Verify normal text and code blocks are NOT collapsed
- [ ] Verify ToolCallCard result detection also benefits from expanded patterns

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com