### PR TITLE
fix: remove 300s agent inactivity timeout that kills live sessions

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -806,14 +806,10 @@ export const acpStore = {
       // Get Seren API key to enable MCP tools for the agent
       const apiKey = await getSerenApiKey();
 
-      // Determine timeout based on enabled skills:
-      // - Long-running skills (trading bots) get unlimited timeout
-      // - Other sessions get default 300s timeout
-      const longRunningSkills = ["polymarket-bot", "kraken-grid-trader"];
-      const hasLongRunningSkill = skillsStore.installed.some(
-        (skill) => skill.enabled && longRunningSkills.includes(skill.slug),
-      );
-      const timeoutSecs = hasLongRunningSkill ? undefined : 300;
+      // No inactivity timeout — agent sessions wait indefinitely.
+      // The agent may be waiting for tool approval, thinking, or the user
+      // may have stepped away. Killing the session is never the right call.
+      const timeoutSecs = undefined;
 
       // Codex defaults to "on-failure" (auto-approve safe ops) regardless of
       // the global agentApprovalPolicy setting, which applies to Claude Code.


### PR DESCRIPTION
## Summary

- Removes the hardcoded 300s inactivity timeout that was killing agent sessions
- Agent sessions now wait indefinitely, matching Claude Code in Cursor behavior
- The agent may be waiting for tool approval, in a long thinking phase, or the user may have stepped away — killing the session is never correct

Closes #966

## Test plan

- [ ] Start an agent session, send a prompt, and leave it idle for 5+ minutes — session stays alive
- [ ] Agent waiting for tool approval does not get killed
- [ ] Long-running agent tasks complete without timeout interruption

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com