### PR TITLE
fix: persist agent thread titles to DB so they survive app restarts

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -421,6 +421,22 @@ pub async fn set_agent_conversation_session_id(
 }
 
 #[tauri::command]
+pub async fn set_agent_conversation_title(
+    app: AppHandle,
+    id: String,
+    title: String,
+) -> Result<(), String> {
+    run_db(app, move |conn| {
+        conn.execute(
+            "UPDATE conversations SET title = ?1 WHERE id = ?2 AND kind = 'agent'",
+            params![title, id],
+        )?;
+        Ok(())
+    })
+    .await
+}
+
+#[tauri::command]
 pub async fn set_agent_conversation_model_id(
     app: AppHandle,
     id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -689,6 +689,7 @@ pub fn run() {
             commands::chat::get_agent_conversations,
             commands::chat::get_agent_conversation,
             commands::chat::set_agent_conversation_session_id,
+            commands::chat::set_agent_conversation_title,
             commands::chat::set_agent_conversation_model_id,
             commands::chat::archive_agent_conversation,
             // Message commands

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -708,6 +708,20 @@ export async function setAgentConversationSessionId(
 }
 
 /**
+ * Update the title of a persisted agent conversation.
+ */
+export async function setAgentConversationTitle(
+  id: string,
+  title: string,
+): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Conversation operations require Tauri runtime");
+  }
+  await invoke("set_agent_conversation_title", { id, title });
+}
+
+/**
  * Update the selected model id for a persisted agent conversation.
  */
 export async function setAgentConversationModelId(

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -31,6 +31,7 @@ import {
   saveMessage,
   setAgentConversationModelId as setAgentConversationModelIdDb,
   setAgentConversationSessionId as setAgentConversationSessionIdDb,
+  setAgentConversationTitle as setAgentConversationTitleDb,
 } from "@/lib/tauri-bridge";
 import type {
   AcpEvent,
@@ -1634,6 +1635,14 @@ Summary:`;
               return `${sp > 10 ? t.slice(0, sp) : t}\u2026`;
             })();
       setState("sessions", sessionId, "title", title);
+
+      // Persist derived title to DB so it survives app restarts
+      const convoId = state.sessions[sessionId]?.conversationId;
+      if (convoId) {
+        setAgentConversationTitleDb(convoId, title).catch((err) => {
+          console.warn("[AcpStore] Failed to persist title:", err);
+        });
+      }
     }
 
     console.log("[AcpStore] Calling acpService.sendPrompt...");


### PR DESCRIPTION
## Summary

- Add `set_agent_conversation_title` Rust command (same pattern as `set_agent_conversation_session_id`)
- Add `setAgentConversationTitle` TypeScript bridge function
- Call it from `sendPrompt` when deriving the title from the first user prompt

## Problem

When the first user message is sent, `sendPrompt` derives a title from the prompt text but only stores it in in-memory SolidJS state via `setState()`. The DB row is created earlier in `spawnSession` with the default "Claude Agent" / "Codex Agent". On app restart/upgrade, in-memory state is gone and the sidebar reads from DB — showing generic defaults for every thread.

## Test plan

- [ ] Create a new agent session, send a message — verify title updates in sidebar
- [ ] Restart the app — verify title persists (not "Claude Agent")
- [ ] Check SQLite DB directly: `SELECT id, title FROM conversations WHERE kind='agent'` — verify titles match

Closes #970
