### PR TITLE
fix: detect stale sessions on thread switch and auto-resume

### DIFF
--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -4,7 +4,11 @@
 import { createStore } from "solid-js/store";
 import { type InstalledSkill, parseSkillMd } from "@/lib/skills";
 import { archiveAgentConversation } from "@/lib/tauri-bridge";
-import type { AgentType, SessionStatus } from "@/services/acp";
+import {
+  type AgentType,
+  listSessions,
+  type SessionStatus,
+} from "@/services/acp";
 import { skills as skillsService } from "@/services/skills";
 import { acpStore } from "@/stores/acp.store";
 import { conversationStore } from "@/stores/conversation.store";
@@ -308,7 +312,28 @@ export const threadStore = {
         liveSession?.info.id,
       );
       if (liveSession) {
-        acpStore.setActiveSession(liveSession.info.id);
+        // Verify the session actually exists in the Rust backend.
+        // After an app restart the JS store may hold stale sessions
+        // whose backend process is gone.
+        void listSessions().then((backendSessions) => {
+          const alive = backendSessions.some(
+            (s) => s.id === liveSession.info.id,
+          );
+          if (alive) {
+            acpStore.setActiveSession(liveSession.info.id);
+          } else {
+            console.warn(
+              "[Thread] Session",
+              liveSession.info.id,
+              "exists in store but not in backend — resuming",
+            );
+            acpStore.terminateSession(liveSession.info.id);
+            const cwd = thread?.projectRoot || fileTreeState.rootPath;
+            if (cwd) {
+              void acpStore.resumeAgentConversation(id, cwd);
+            }
+          }
+        });
       } else {
         // No live session — clear active and auto-resume the agent conversation.
         // The spawn lock in the Rust backend prevents SIGKILL collisions.

--- a/tests/unit/thread-store.test.ts
+++ b/tests/unit/thread-store.test.ts
@@ -75,6 +75,12 @@ vi.mock("@/stores/conversation.store", () => ({
   },
 }));
 
+// Mock ACP service (listSessions)
+const mockBackendSessions: Array<{ id: string }> = [];
+vi.mock("@/services/acp", () => ({
+  listSessions: vi.fn(async () => mockBackendSessions),
+}));
+
 // Mock ACP store
 const mockSessions: Record<
   string,
@@ -108,6 +114,7 @@ vi.mock("@/stores/acp.store", () => ({
     setActiveSession: vi.fn(),
     setSelectedAgentType: vi.fn(),
     resumeAgentConversation: vi.fn(),
+    terminateSession: vi.fn(),
     spawnSession: vi.fn(),
     refreshRecentAgentConversations: vi.fn(),
   },
@@ -127,6 +134,7 @@ describe("threadStore", () => {
     mockFileTreeState.rootPath = "/Users/dev/project-a";
     Object.keys(mockSessions).forEach((k) => delete mockSessions[k]);
     mockAgentConversations.length = 0;
+    mockBackendSessions.length = 0;
 
     // Reset thread store internal state
     threadStore.clear();
@@ -284,7 +292,7 @@ describe("threadStore", () => {
       );
     });
 
-    it("selects an agent thread with live session", () => {
+    it("selects an agent thread with live session", async () => {
       mockAgentConversations.push({
         id: "agent-1",
         title: "Agent",
@@ -301,11 +309,48 @@ describe("threadStore", () => {
         conversationId: "agent-1",
         info: { id: "sess-1", status: "ready", agentType: "claude-code" },
       };
+      // Backend confirms session is alive
+      mockBackendSessions.push({ id: "sess-1" });
 
       threadStore.selectThread("agent-1", "agent");
+      // Wait for async listSessions check
+      await vi.waitFor(() => {
+        expect(acpStore.setActiveSession).toHaveBeenCalledWith("sess-1");
+      });
 
       expect(threadStore.activeThreadKind).toBe("agent");
-      expect(acpStore.setActiveSession).toHaveBeenCalledWith("sess-1");
+    });
+
+    it("resumes stale session not present in backend", async () => {
+      mockAgentConversations.push({
+        id: "agent-1",
+        title: "Agent",
+        created_at: 1000,
+        agent_type: "claude-code",
+        agent_session_id: "sess-1",
+        agent_cwd: "/dev",
+        agent_model_id: null,
+        project_id: null,
+        project_root: "/Users/dev/project-a",
+        is_archived: false,
+      });
+      mockSessions["sess-1"] = {
+        conversationId: "agent-1",
+        info: { id: "sess-1", status: "ready", agentType: "claude-code" },
+      };
+      // Backend does NOT have this session (stale after restart)
+      // mockBackendSessions is empty
+
+      threadStore.selectThread("agent-1", "agent");
+      // Wait for async listSessions check to trigger resume
+      await vi.waitFor(() => {
+        expect(acpStore.terminateSession).toHaveBeenCalledWith("sess-1");
+      });
+
+      expect(acpStore.resumeAgentConversation).toHaveBeenCalledWith(
+        "agent-1",
+        "/Users/dev/project-a",
+      );
     });
 
     it("auto-resumes agent thread without live session", () => {


### PR DESCRIPTION
## Summary
- Fixes #971: session frozen when switching to thread with persisted but dead backend session
- `selectThread` now calls `listSessions()` to verify the Rust backend actually has the session alive
- If the backend has no matching process (e.g. after app restart), the stale JS-side session is terminated and `resumeAgentConversation` is triggered
- Adds new test for stale session detection, updates existing live session test to handle async verification

## Test plan
- [x] 186 tests pass (14 thread-store tests including new stale session test)
- [ ] Restart app, switch to a previous agent thread — should auto-resume instead of freezing
- [ ] Switch between live agent threads — should work normally without re-spawning

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com