### PR TITLE
fix: collapse verbose output including relative paths and large data dumps

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -22,6 +22,7 @@ import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { isAuthError } from "@/lib/auth-errors";
 import { collapseBuildOutput } from "@/lib/build-output";
+import { collapseVerboseOutput } from "@/lib/verbose-output";
 import {
   getCompletions,
   matchSkillCommand,
@@ -935,10 +936,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           <article class="group/msg relative px-5 py-4 border-b border-surface-2">
             <div
               class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
-              innerHTML={collapseBuildOutput(
-                collapseDirectoryListings(
-                  htmlCache[message.id] ??
-                    escapeHtml(message.content).replace(/\n/g, "<br>"),
+              innerHTML={collapseVerboseOutput(
+                collapseBuildOutput(
+                  collapseDirectoryListings(
+                    htmlCache[message.id] ??
+                      escapeHtml(message.content).replace(/\n/g, "<br>"),
+                  ),
                 ),
               )}
             />

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -19,6 +19,7 @@ import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { DepositModal } from "@/components/wallet/DepositModal";
 import { isAuthError } from "@/lib/auth-errors";
 import { collapseBuildOutput } from "@/lib/build-output";
+import { collapseVerboseOutput } from "@/lib/verbose-output";
 import {
   getCompletions,
   matchSkillCommand,
@@ -1073,9 +1074,11 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                         class="chat-message-content text-[14px] leading-[1.7] text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-[1.3em] [&_h1]:font-semibold [&_h1]:mt-5 [&_h1]:mb-3 [&_h1]:text-foreground [&_h1]:border-b [&_h1]:border-surface-2 [&_h1]:pb-2 [&_h2]:text-[1.15em] [&_h2]:font-semibold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-foreground [&_h3]:text-[1.05em] [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-2 [&_h3]:text-foreground [&_code]:bg-surface-1 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_li]:leading-[1.6] [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline [&_strong]:text-foreground [&_strong]:font-semibold"
                         innerHTML={
                           message.role === "assistant"
-                            ? collapseBuildOutput(
-                                collapseDirectoryListings(
-                                  renderMarkdown(message.content),
+                            ? collapseVerboseOutput(
+                                collapseBuildOutput(
+                                  collapseDirectoryListings(
+                                    renderMarkdown(message.content),
+                                  ),
                                 ),
                               )
                             : escapeHtmlWithLinks(message.content)

--- a/src/lib/directory-listing.ts
+++ b/src/lib/directory-listing.ts
@@ -13,6 +13,9 @@ const UNIX_PATH = /^\/[\w.@~+-]/;
 /** Absolute Windows path: C:\ or similar */
 const WIN_PATH = /^[A-Za-z]:[/\\]/;
 
+/** Relative path with at least two segments: src/lib/file.ts, artifacts/bot/script.py */
+const RELATIVE_PATH = /^[\w.@~+-][\w.@~+-]*\/[\w.@~+-]/;
+
 /** Path followed by an error: /path/to/dir: Operation not permitted (os error 1) */
 const PATH_ERROR =
   /^\/[\w.@~+-].*:\s+(Operation not permitted|Permission denied|No such file|Is a directory|Not a directory)/;
@@ -35,7 +38,8 @@ function isListingLine(trimmed: string): boolean {
     FIND_ERROR.test(trimmed) ||
     TREE_LINE.test(trimmed) ||
     UNIX_PATH.test(trimmed) ||
-    WIN_PATH.test(trimmed)
+    WIN_PATH.test(trimmed) ||
+    RELATIVE_PATH.test(trimmed)
   );
 }
 

--- a/src/lib/verbose-output.ts
+++ b/src/lib/verbose-output.ts
@@ -1,0 +1,82 @@
+// ABOUTME: Catch-all collapser for large output blocks not caught by specific detectors.
+// ABOUTME: Collapses any block exceeding line/character thresholds into a details element.
+
+/** Minimum number of lines to trigger collapse */
+const MIN_LINES = 20;
+
+/** Minimum character count to trigger collapse */
+const MIN_CHARS = 2000;
+
+/** Decode basic HTML entities for measurement. */
+function decodeBasicHtmlEntities(html: string): string {
+  return html
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+/**
+ * Generates a summary label for a large output block.
+ */
+function summarizeLargeOutput(text: string): string {
+  const lineCount = text.split("\n").filter((l) => l.trim()).length;
+  return `Large output (${lineCount} lines)`;
+}
+
+/**
+ * Post-processes rendered HTML to collapse large output blocks that weren't
+ * already collapsed by the directory-listing or build-output detectors.
+ *
+ * This is a catch-all — it should be called LAST in the collapse chain.
+ */
+export function collapseVerboseOutput(html: string): string {
+  // Skip if already collapsed by a specific detector
+  if (
+    html.includes("dir-listing-collapse") ||
+    html.includes("build-output-collapse")
+  ) {
+    return html;
+  }
+
+  // Handle large content inside <pre><code> blocks
+  const modified = html.replace(
+    /(<pre[^>]*><code[^>]*>)([\s\S]*?)(<\/code><\/pre>)/g,
+    (match, _open: string, content: string, _close: string) => {
+      const decoded = decodeBasicHtmlEntities(content);
+      const lines = decoded.split("\n").filter((l) => l.trim());
+      if (lines.length >= MIN_LINES || decoded.length >= MIN_CHARS) {
+        const summary = summarizeLargeOutput(decoded);
+        return `<details class="verbose-output-collapse"><summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>${match}</details>`;
+      }
+      return match;
+    },
+  );
+
+  if (modified !== html) return modified;
+
+  // Handle <br>-separated content
+  if (!/<pre[\s>]/.test(html)) {
+    const segments = html.split(/<br\s*\/?>/i);
+    const plainText = segments
+      .map((s) => decodeBasicHtmlEntities(s))
+      .join("\n");
+    const nonEmptyLines = plainText.split("\n").filter((l) => l.trim());
+
+    if (
+      nonEmptyLines.length >= MIN_LINES ||
+      plainText.length >= MIN_CHARS
+    ) {
+      const summary = summarizeLargeOutput(plainText);
+      return [
+        '<details class="verbose-output-collapse">',
+        `<summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>`,
+        `<pre style="white-space:pre-wrap;margin:0.5em 0;font-size:12px;color:inherit">${html}</pre>`,
+        "</details>",
+      ].join("");
+    }
+  }
+
+  return html;
+}


### PR DESCRIPTION
## Summary

- Expand `directory-listing.ts` to detect **relative file paths** (e.g., `artifacts/bot/script.py`, `src/lib/file.ts`)
- Add `verbose-output.ts` as a **catch-all collapser** for any block >20 lines or >2000 chars
- Wire catch-all as the outermost collapser in both AgentChat and ChatContent

## Problem

Three categories of verbose output were not being collapsed:
1. Relative file path listings (only absolute paths `/...` and `C:\...` were detected)
2. Raw JSON/API schema dumps
3. Configuration/feature flag data dumps

## How it works

Collapse chain runs inside-out:
```
collapseVerboseOutput(         ← catch-all (NEW)
  collapseBuildOutput(         ← cargo/npm/pip
    collapseDirectoryListings( ← ls/find/paths
      renderedHtml
    )
  )
)
```

The catch-all skips if a specific detector already collapsed the block (checks for existing collapse CSS classes).

## Test plan

- [ ] Send a message that triggers large JSON/schema output — verify collapsed
- [ ] File path listing with relative paths (`artifacts/...`) — verify collapsed
- [ ] Normal short assistant messages — verify NOT collapsed
- [ ] Build output (Compiling...) — verify still collapsed by build-output detector (not catch-all)

Closes #976
