### PR TITLE
feat: drag and drop file attachment support

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -22,7 +22,6 @@ import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { isAuthError } from "@/lib/auth-errors";
 import { collapseBuildOutput } from "@/lib/build-output";
-import { collapseVerboseOutput } from "@/lib/verbose-output";
 import {
   getCompletions,
   matchSkillCommand,
@@ -30,6 +29,7 @@ import {
 } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { collapseDirectoryListings } from "@/lib/directory-listing";
+import { createDragDrop } from "@/lib/drag-drop";
 import { escapeHtml } from "@/lib/escape-html";
 import { openExternalLink } from "@/lib/external-link";
 import { openFileInTab } from "@/lib/files/service";
@@ -45,6 +45,7 @@ import {
 } from "@/lib/rate-limit-fallback";
 import { escapeHtmlWithLinks } from "@/lib/render-markdown";
 import { saveToSerenNotes } from "@/lib/save-to-notes";
+import { collapseVerboseOutput } from "@/lib/verbose-output";
 import {
   type AgentType,
   type DiffEvent,
@@ -82,6 +83,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const [input, setInput] = createSignal("");
   const [messageQueue, setMessageQueue] = createSignal<string[]>([]);
   const [attachedImages, setAttachedImages] = createSignal<Attachment[]>([]);
+  const { isDragging } = createDragDrop((files) =>
+    setAttachedImages((prev) => [...prev, ...files]),
+  );
   const [commandStatus, setCommandStatus] = createSignal<string | null>(null);
   const [commandPopupIndex, setCommandPopupIndex] = createSignal(0);
   const [historyIndex, setHistoryIndex] = createSignal(-1);
@@ -1050,7 +1054,14 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   };
 
   return (
-    <div class="flex-1 flex flex-col min-h-0">
+    <div class="relative flex-1 flex flex-col min-h-0">
+      <Show when={isDragging()}>
+        <div class="absolute inset-0 bg-primary/10 border-2 border-dashed border-primary/50 rounded-sm z-50 pointer-events-none flex items-center justify-center">
+          <span class="text-primary text-sm font-medium bg-background/90 px-3 py-1.5 rounded-md shadow-sm">
+            Drop files to attach
+          </span>
+        </div>
+      </Show>
       {/* Plan Header */}
       <PlanHeader />
 

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -19,7 +19,6 @@ import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { DepositModal } from "@/components/wallet/DepositModal";
 import { isAuthError } from "@/lib/auth-errors";
 import { collapseBuildOutput } from "@/lib/build-output";
-import { collapseVerboseOutput } from "@/lib/verbose-output";
 import {
   getCompletions,
   matchSkillCommand,
@@ -27,6 +26,7 @@ import {
 } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { collapseDirectoryListings } from "@/lib/directory-listing";
+import { createDragDrop } from "@/lib/drag-drop";
 import { openExternalLink } from "@/lib/external-link";
 import { openFileInTab } from "@/lib/files/service";
 import { formatDurationWithVerb } from "@/lib/format-duration";
@@ -35,6 +35,7 @@ import { isPaymentError } from "@/lib/payment-errors";
 import type { Attachment } from "@/lib/providers/types";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
 import { saveToSerenNotes } from "@/lib/save-to-notes";
+import { collapseVerboseOutput } from "@/lib/verbose-output";
 import type { ToolCallEvent } from "@/services/acp";
 import { catalog, type Publisher } from "@/services/catalog";
 import {
@@ -196,6 +197,9 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
   const [showDepositFromError, setShowDepositFromError] = createSignal(false);
   const [attachedImages, setAttachedImages] = createSignal<Attachment[]>([]);
   const [isAttaching, setIsAttaching] = createSignal(false);
+  const { isDragging } = createDragDrop((files) =>
+    setAttachedImages((prev) => [...prev, ...files]),
+  );
   let inputRef: HTMLTextAreaElement | undefined;
   let messagesRef: HTMLDivElement | undefined;
   let suggestionDebounceTimer: ReturnType<typeof setTimeout> | undefined;
@@ -857,7 +861,14 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
   };
 
   return (
-    <section class="flex flex-col h-full bg-background text-foreground border-l border-surface-2">
+    <section class="relative flex flex-col h-full bg-background text-foreground border-l border-surface-2">
+      <Show when={isDragging()}>
+        <div class="absolute inset-0 bg-primary/10 border-2 border-dashed border-primary/50 rounded-sm z-50 pointer-events-none flex items-center justify-center">
+          <span class="text-primary text-sm font-medium bg-background/90 px-3 py-1.5 rounded-md shadow-sm">
+            Drop files to attach
+          </span>
+        </div>
+      </Show>
       <Show when={showSignInPrompt()}>
         <div class="flex-1 flex flex-col items-center justify-center gap-6 p-6">
           <div class="text-center max-w-[280px]">

--- a/src/lib/drag-drop.ts
+++ b/src/lib/drag-drop.ts
@@ -1,0 +1,59 @@
+// ABOUTME: SolidJS hook for Tauri window-level file drag-and-drop attachment.
+// ABOUTME: Returns isDragging signal and processes dropped files into Attachment objects.
+
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { createSignal, onCleanup } from "solid-js";
+import { ALL_EXTENSIONS, readAttachment } from "@/lib/images/attachments";
+import type { Attachment } from "@/lib/providers/types";
+
+function getExtension(path: string): string {
+  const parts = path.split(".");
+  return parts.length > 1 ? parts[parts.length - 1].toLowerCase() : "";
+}
+
+/**
+ * Register a Tauri drag-and-drop handler for the current webview.
+ * Call inside a SolidJS component — cleans up the listener automatically.
+ *
+ * @param onFiles Called with successfully read attachments when files are dropped.
+ * @returns isDragging signal — true while files are being dragged over the window.
+ */
+export function createDragDrop(onFiles: (attachments: Attachment[]) => void): {
+  isDragging: () => boolean;
+} {
+  const [isDragging, setIsDragging] = createSignal(false);
+
+  const unlistenPromise = getCurrentWebview().onDragDropEvent(async (event) => {
+    const { type } = event.payload;
+
+    if (type === "enter") {
+      setIsDragging(true);
+    } else if (type === "leave") {
+      setIsDragging(false);
+    } else if (type === "drop") {
+      setIsDragging(false);
+      const paths = event.payload.paths.filter((p) =>
+        ALL_EXTENSIONS.includes(getExtension(p)),
+      );
+      if (paths.length === 0) return;
+
+      const attachments: Attachment[] = [];
+      for (const path of paths) {
+        try {
+          attachments.push(await readAttachment(path));
+        } catch (error) {
+          console.warn("[DragDrop] Failed to read file:", path, error);
+        }
+      }
+      if (attachments.length > 0) {
+        onFiles(attachments);
+      }
+    }
+  });
+
+  onCleanup(() => {
+    unlistenPromise.then((unlisten) => unlisten());
+  });
+
+  return { isDragging };
+}

--- a/src/lib/images/attachments.ts
+++ b/src/lib/images/attachments.ts
@@ -65,7 +65,7 @@ const TEXT_EXTENSIONS = [
   "proto",
 ];
 
-const ALL_EXTENSIONS = [
+export const ALL_EXTENSIONS = [
   ...IMAGE_EXTENSIONS,
   ...DOCUMENT_EXTENSIONS,
   ...DOCREADER_EXTENSIONS,


### PR DESCRIPTION
## Summary

- Drag any supported file from Finder/Explorer onto the chat or agent panel to attach it
- A semi-transparent overlay with "Drop files to attach" appears during drag-over
- Dropped files are processed identically to picker-selected files: images resized, text read as-is, PDFs/Office via docreader
- Works in both regular chat (ChatContent) and agent chat (AgentChat)

## Implementation

- New `src/lib/drag-drop.ts`: `createDragDrop(onFiles)` hook wraps Tauri `getCurrentWebview().onDragDropEvent()`, cleans up on unmount, filters to supported extensions, reads files via existing `readAttachment(path)`
- `ALL_EXTENSIONS` exported from `attachments.ts` so the hook can filter unsupported file types on drop
- Both chat panels get `relative` positioning on root and a `Show when isDragging` overlay as first child

## Test plan
- [ ] Drag an image onto chat panel — appears as attachment thumbnail
- [ ] Drag a CSV onto chat panel — appears as file attachment
- [ ] Drag an unsupported file type (e.g. .exe) — silently ignored
- [ ] Drag onto agent panel — same behavior
- [ ] Drag enters window, overlay appears; drag leaves, overlay disappears
- [ ] Normal attach button still works

Closes #979

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com