### PR TITLE
fix: navigate to fallback chat thread so AgentChat unmounts after prompt-too-long

### DIFF
--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -275,6 +275,7 @@ export async function performAgentFallback(
   const { conversationStore } = await import("@/stores/conversation.store");
   const { acpStore } = await import("@/stores/acp.store");
   const { providerStore } = await import("@/stores/provider.store");
+  const { threadStore } = await import("@/stores/thread.store");
 
   const chatModelId = mapAgentModelToChat(agentModelId, agentType);
   const modelDisplayName = getModelDisplayName(chatModelId);
@@ -316,7 +317,10 @@ export async function performAgentFallback(
     providerStore.setActiveProvider("seren");
     providerStore.setActiveModel(chatModelId);
 
-    // Switch UI from Agent → Chat
+    // Switch UI from Agent → Chat: navigate to the new chat thread so
+    // AgentChat unmounts and subsequent messages go to the chat orchestrator,
+    // not the already-full ACP session.
+    threadStore.selectThread(conversation.id, "chat");
     acpStore.setAgentModeEnabled(false);
 
     console.info(


### PR DESCRIPTION
## Root cause

ThreadContent routes on `threadStore.activeThreadKind`. After a prompt-too-long fallback, `performAgentFallback` called `acpStore.setAgentModeEnabled(false)` but never changed the thread kind — AgentChat stayed mounted. Every subsequent `sendMessage` went back to the same overloaded ACP session, which immediately returned "Prompt is too long" again, creating a new chat conversation on every message in an infinite loop.

## Fix

One line: call `threadStore.selectThread(conversation.id, "chat")` after creating the fallback conversation. This navigates the UI to the new chat thread, unmounting AgentChat, so further messages go to the chat orchestrator.

## Test plan
- [ ] Fill context window in Claude agent (invoke a large skill like polymarket-data)
- [ ] Observe fallback to chat — UI should switch to the new chat thread
- [ ] Send a follow-up message — should go to chat, not trigger another fallback

Closes #981

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com