### PR TITLE
fix: match all in-progress plan status variants on completion

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -2220,13 +2220,15 @@ Summary:`;
           // Plan entry status is set by planUpdate events from the backend,
           // but a final planUpdate may not arrive after the last tool finishes.
           const plan = state.sessions[sessionId]?.plan;
-          if (plan?.some((e) => e.status === "in_progress")) {
+          const isInProgress = (s: string) =>
+            s === "in_progress" || s === "inprogress" || s === "inProgress";
+          if (plan?.some((e) => isInProgress(e.status))) {
             setState(
               "sessions",
               sessionId,
               "plan",
               plan.map((e) =>
-                e.status === "in_progress" ? { ...e, status: "completed" } : e,
+                isInProgress(e.status) ? { ...e, status: "completed" } : e,
               ),
             );
           }


### PR DESCRIPTION
## Summary
- The previous fix (#963) only matched `in_progress` when transitioning plan entries to completed on `promptComplete`
- The backend can also send `inprogress` or `inProgress`, which `PlanHeader` already renders as yellow spinners
- This left plan entries stuck with the spinning indicator after the agent finished
- Now all three variants are matched during cleanup

## Test plan
- [ ] Run agent task that produces a plan
- [ ] Wait for agent to complete
- [ ] Verify all plan entries show green checkmarks, not yellow spinners

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com