### PR TITLE
fix: reset session to ready on prompt-too-long and rate-limit errors

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -1821,6 +1821,19 @@ Summary:`;
       ) {
         this.addErrorMessage(sessionId, message);
       }
+
+      // Ensure the session is not stuck in "prompting" after any error.
+      // The promptComplete event never fires when sendPrompt rejects, so
+      // without this the input stays locked forever.
+      if (state.sessions[sessionId]?.info.status === "prompting") {
+        setState(
+          "sessions",
+          sessionId,
+          "info",
+          "status",
+          "ready" as SessionStatus,
+        );
+      }
     }
   },
 
@@ -2411,6 +2424,17 @@ Summary:`;
           setState("sessions", sessionId, "promptTooLong", true);
           this.addErrorMessage(sessionId, event.data.error);
 
+          // Reset to "ready" so the UI unfreezes — promptComplete never
+          // fires after this error so the session would stay stuck in
+          // "prompting" forever without this.
+          setState(
+            "sessions",
+            sessionId,
+            "info",
+            "status",
+            "ready" as SessionStatus,
+          );
+
           // Automatically trigger failover without user interaction
           this.acceptRateLimitFallback().catch((err) => {
             console.error("[AcpStore] Auto-failover failed:", err);
@@ -2422,6 +2446,15 @@ Summary:`;
           );
           setState("sessions", sessionId, "rateLimitHit", true);
           this.addErrorMessage(sessionId, event.data.error);
+
+          // Reset to "ready" so the UI unfreezes (same reason as above).
+          setState(
+            "sessions",
+            sessionId,
+            "info",
+            "status",
+            "ready" as SessionStatus,
+          );
 
           // Automatically trigger failover without user interaction
           this.acceptRateLimitFallback().catch((err) => {


### PR DESCRIPTION
## Summary

- Reset session status to "ready" when prompt-too-long or rate-limit errors arrive via the error event handler
- Reset session status to "ready" in the sendPrompt catch block when any error leaves the session stuck in "prompting"
- Matches the existing pattern used by the cancellation error handler (line ~2344)

## Root Cause

When the Codex CLI returns a context-window-exceeded error, the Rust backend emits an ERROR event AND rejects the sendPrompt promise. Neither handler was resetting session status to "ready". The session stayed stuck in "prompting" forever — input disabled, Send button gone, app unresponsive.

Observed in production: session 019cbf40 exhausted 400K context in 28 prompts. User retried 3x in 16 seconds with no recovery.

## Test plan

- [ ] Start a Codex agent session and use it until context window fills
- [ ] Verify the error message appears but input remains functional
- [ ] Verify auto-failover to chat mode triggers
- [ ] If failover fails, verify user can still type and interact
- [ ] Verify rate-limit errors also recover correctly

Fixes #984

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
