### PR TITLE
fix: detect Python, Rust, Go code islands in agent markdown

### DIFF
--- a/src/lib/render-markdown.ts
+++ b/src/lib/render-markdown.ts
@@ -60,8 +60,9 @@ marked.setOptions({
 });
 
 /**
- * Returns true when a line (already trimmed) looks like TypeScript/JavaScript
- * code rather than prose. Used by wrapCodeIslands to detect unfenced code.
+ * Returns true when a line (already trimmed) looks like code rather than
+ * prose. Used by wrapCodeIslands to detect unfenced code from agents.
+ * Covers TypeScript/JS, Python, Rust, Go, and Shell patterns.
  */
 export function isCodeLine(trimmed: string, inCComment: boolean): boolean {
   if (!trimmed) return false;
@@ -72,7 +73,10 @@ export function isCodeLine(trimmed: string, inCComment: boolean): boolean {
   // C-style comment closers and continuations – only inside an open comment
   if (inCComment && /^(\*\/|\*\s)/.test(trimmed)) return true;
 
-  // TypeScript/JS typed declarations
+  // Shebangs
+  if (/^#!\//.test(trimmed)) return true;
+
+  // TypeScript/JS declarations
   if (/^(export\s+)?(type|interface)\s+\w/.test(trimmed)) return true;
   if (/^(export\s+)?(abstract\s+)?class\s+\w/.test(trimmed)) return true;
   if (/^(export\s+)?(async\s+)?function\s+\w/.test(trimmed)) return true;
@@ -80,13 +84,42 @@ export function isCodeLine(trimmed: string, inCComment: boolean): boolean {
   if (/^(export\s+)?enum\s+\w/.test(trimmed)) return true;
   if (/^import\s+(type\s+)?(\{|\*|[\w_$])/.test(trimmed)) return true;
 
+  // Python declarations and keywords
+  if (/^(async\s+)?def\s+\w/.test(trimmed)) return true;
+  if (/^class\s+\w+[:(]/.test(trimmed)) return true;
+  if (/^from\s+\S+\s+import\s/.test(trimmed)) return true;
+  if (/^(assert|raise|yield|return|pass)\b/.test(trimmed)) return true;
+  // Python control flow — unambiguous keywords
+  if (/^(for|while|with|try|except)\s.*:\s*$/.test(trimmed)) return true;
+  if (/^(elif|else|except|finally):\s*$/.test(trimmed)) return true;
+  if (/^elif\s.*:\s*$/.test(trimmed)) return true;
+  // Python if — require at least two tokens after `if` to avoid
+  // false-positiving on prose like "if condition:"
+  if (/^if\s+\S+\s+\S.*:\s*$/.test(trimmed)) return true;
+  if (/^@\w/.test(trimmed)) return true; // decorators
+
+  // Rust declarations
+  if (
+    /^(pub(\(.+?\))?\s+)?(fn|struct|enum|trait|impl|mod|use|type)\s/.test(
+      trimmed,
+    )
+  )
+    return true;
+  if (/^let\s+(mut\s+)?\w/.test(trimmed)) return true;
+
+  // Go declarations
+  if (/^func\s+[\w(]/.test(trimmed)) return true;
+  if (/^package\s+\w/.test(trimmed)) return true;
+
   // Lines ending with ; — strong code signal. Exclude obvious prose sentences
   // (capital letter followed by a lowercase word, e.g. "This returns a value;")
   if (/;\s*$/.test(trimmed) && !/^[A-Z][a-z]+\s+[a-z]/.test(trimmed))
     return true;
 
-  // Closing brace/bracket lines common in TypeScript
+  // Closing brace/bracket/paren lines
   if (/^\}[;,]?\s*$/.test(trimmed)) return true;
+  if (/^\)[;,]?\s*$/.test(trimmed)) return true;
+  if (/^\]\s*$/.test(trimmed)) return true;
 
   // HTTP/OpenAPI status-code type entries: `404: unknown;`
   if (/^\d{3,4}:\s+\w/.test(trimmed)) return true;
@@ -95,10 +128,10 @@ export function isCodeLine(trimmed: string, inCComment: boolean): boolean {
 }
 
 /**
- * Wrap consecutive "code island" lines outside existing fences in a
- * ```typescript fence. Codex frequently outputs TypeScript type definitions
- * and JSDoc comments as plain text without code fences, causing * lines to
- * render as markdown bullets and declarations to appear as unstyled paragraphs.
+ * Wrap consecutive "code island" lines outside existing fences in a bare
+ * ``` fence (hljs auto-detects the language). Agents frequently output code
+ * as plain text without fences, causing declarations to appear as unstyled
+ * paragraphs.
  *
  * A run of 2+ consecutive code-like lines is wrapped. Single isolated lines
  * are left alone to avoid false positives.
@@ -118,7 +151,7 @@ export function wrapCodeIslands(text: string): string {
         blankBuf.unshift(codeBuf.pop() as string);
       }
       if (codeBuf.length >= 2) {
-        out.push("```typescript", ...codeBuf, "```");
+        out.push("```", ...codeBuf, "```");
         codeBuf.length = 0;
         return;
       }
@@ -180,9 +213,9 @@ export function wrapCodeIslands(text: string): string {
  * in-progress paragraph at these block-level elements when no blank line
  * separates them — common in Codex/agent output that omits blank lines.
  *
- * Also detects unfenced TypeScript/JSDoc "code islands" and wraps them in
- * fenced code blocks so they render with syntax highlighting rather than
- * as markdown bullets and plain paragraphs.
+ * Also detects unfenced code islands (TypeScript, Python, Rust, Go, etc.)
+ * and wraps them in fenced code blocks so they render with syntax
+ * highlighting rather than as markdown bullets and plain paragraphs.
  */
 function normalizeAgentMarkdown(markdown: string): string {
   let result = markdown.replace(/([^\n])\n(#{1,6} )/g, "$1\n\n$2");

--- a/tests/unit/render-markdown.test.ts
+++ b/tests/unit/render-markdown.test.ts
@@ -71,6 +71,67 @@ describe("isCodeLine", () => {
     expect(isCodeLine("* Handle error cases", false)).toBe(false);
     expect(isCodeLine("* This is a bullet", false)).toBe(false);
   });
+
+  it("recognises Python declarations", () => {
+    expect(isCodeLine("def test_happy_path() -> None:", false)).toBe(true);
+    expect(isCodeLine("async def fetch_data():", false)).toBe(true);
+    expect(isCodeLine("class MyTestCase(unittest.TestCase):", false)).toBe(
+      true,
+    );
+    expect(isCodeLine('from future import annotations', false)).toBe(true);
+    expect(isCodeLine("from pathlib import Path", false)).toBe(true);
+    expect(isCodeLine("import json", false)).toBe(true);
+    expect(isCodeLine("import subprocess", false)).toBe(true);
+  });
+
+  it("recognises Python keywords", () => {
+    expect(isCodeLine('assert payload["status"] == "ok"', false)).toBe(true);
+    expect(isCodeLine("return json.load(f)", false)).toBe(true);
+    expect(isCodeLine("raise ValueError('bad')", false)).toBe(true);
+    expect(isCodeLine("yield item", false)).toBe(true);
+    expect(isCodeLine("pass", false)).toBe(true);
+    expect(isCodeLine("if condition:", false)).toBe(false); // no trailing content+colon
+  });
+
+  it("recognises Python control flow with trailing colon", () => {
+    expect(isCodeLine("if x > 0:", false)).toBe(true);
+    expect(isCodeLine("for item in items:", false)).toBe(true);
+    expect(isCodeLine("while True:", false)).toBe(true);
+    expect(isCodeLine("with open(f) as fh:", false)).toBe(true);
+    expect(isCodeLine("except ValueError:", false)).toBe(true);
+    expect(isCodeLine("else:", false)).toBe(true);
+    expect(isCodeLine("elif x:", false)).toBe(true);
+  });
+
+  it("recognises Python decorators", () => {
+    expect(isCodeLine("@pytest.fixture", false)).toBe(true);
+    expect(isCodeLine("@staticmethod", false)).toBe(true);
+  });
+
+  it("recognises Rust declarations", () => {
+    expect(isCodeLine("fn main() {", false)).toBe(true);
+    expect(isCodeLine("pub fn new() -> Self {", false)).toBe(true);
+    expect(isCodeLine("struct Config {", false)).toBe(true);
+    expect(isCodeLine("let mut count = 0;", false)).toBe(true);
+    expect(isCodeLine("use std::io;", false)).toBe(true);
+  });
+
+  it("recognises Go declarations", () => {
+    expect(isCodeLine("func main() {", false)).toBe(true);
+    expect(isCodeLine("func (s *Server) Start() error {", false)).toBe(true);
+    expect(isCodeLine("package main", false)).toBe(true);
+  });
+
+  it("recognises closing paren and bracket lines", () => {
+    expect(isCodeLine(")", false)).toBe(true);
+    expect(isCodeLine("),", false)).toBe(true);
+    expect(isCodeLine("]", false)).toBe(true);
+  });
+
+  it("recognises shebangs", () => {
+    expect(isCodeLine("#!/usr/bin/env python3", false)).toBe(true);
+    expect(isCodeLine("#!/bin/bash", false)).toBe(true);
+  });
 });
 
 describe("wrapCodeIslands", () => {
@@ -85,7 +146,7 @@ describe("wrapCodeIslands", () => {
     ].join("\n");
 
     const result = wrapCodeIslands(input);
-    expect(result).toContain("```typescript");
+    expect(result).toContain("```");
     expect(result).toContain("/**");
     expect(result).toContain("branch_id: string;");
     expect(result).toContain("```");
@@ -118,7 +179,7 @@ describe("wrapCodeIslands", () => {
 
     const result = wrapCodeIslands(input);
     // Code section must be in a fence
-    expect(result).toContain("```typescript");
+    expect(result).toContain("```");
     // Prose must be outside the fence
     const lastFence = result.lastIndexOf("```");
     expect(result.indexOf("I have enough")).toBeGreaterThan(lastFence);
@@ -129,11 +190,11 @@ describe("wrapCodeIslands", () => {
     const input = "export type Foo = string;\n\nSome prose here.";
     const result = wrapCodeIslands(input);
     // Single code line — should NOT be wrapped
-    expect(result).not.toContain("```typescript");
+    expect(result).not.toContain("```");
   });
 
   it("leaves existing fenced blocks untouched", () => {
-    const input = "```typescript\nconst x = 1;\n```\nSome prose.";
+    const input = "```\nconst x = 1;\n```\nSome prose.";
     const result = wrapCodeIslands(input);
     // Should still have exactly one fence pair — no extra wrapping
     const fenceCount = (result.match(/```/g) ?? []).length;
@@ -158,12 +219,35 @@ describe("wrapCodeIslands", () => {
     ].join("\n");
 
     const result = wrapCodeIslands(input);
-    expect(result).toContain("```typescript");
+    expect(result).toContain("```");
     expect(result).toContain("This is prose after a blank line.");
     // Blank line should appear after the closing fence
     const closingFence = result.lastIndexOf("```");
     const proseIdx = result.indexOf("This is prose");
     expect(proseIdx).toBeGreaterThan(closingFence);
+  });
+
+  it("wraps unfenced Python code in a code fence", () => {
+    const input = [
+      "from future import annotations",
+      "import json",
+      "import os",
+      "",
+      "def test_happy_path() -> None:",
+      '    payload = read_fixture("happy_path.json")',
+      '    assert payload["status"] == "ok"',
+      "",
+      "Here is the explanation.",
+    ].join("\n");
+
+    const result = wrapCodeIslands(input);
+    expect(result).toContain("```");
+    expect(result).toContain("import json");
+    // Prose should be outside the fence
+    const lastFence = result.lastIndexOf("```");
+    expect(result.indexOf("Here is the explanation")).toBeGreaterThan(
+      lastFence,
+    );
   });
 
   it("does not wrap real markdown bullet lists as code", () => {
@@ -176,6 +260,6 @@ describe("wrapCodeIslands", () => {
     ].join("\n");
 
     const result = wrapCodeIslands(input);
-    expect(result).not.toContain("```typescript");
+    expect(result).not.toContain("```");
   });
 });


### PR DESCRIPTION
## Summary

- Extend isCodeLine to detect Python (def, class, from/import, assert, decorators, control flow with colon), Rust (pub fn, struct, let mut, use), and Go (func, package)
- Detect closing parens/brackets and shebangs
- Use bare fences in wrapCodeIslands so hljs auto-detects language instead of hardcoding typescript
- Add comprehensive tests for all new language patterns (25 tests, all passing)

## Root Cause

isCodeLine only recognized TypeScript/JS patterns. Python code from agents (def, assert, from X import Y, decorators) passed through unfenced and rendered as raw unstyled paragraphs.

## Test plan

- [ ] Verify Python code blocks render with syntax highlighting
- [ ] Verify TypeScript/JS code blocks still render correctly (no regression)
- [ ] Verify Rust and Go code blocks render with highlighting
- [ ] Verify prose text is NOT wrapped in code fences
- [ ] Verify existing fenced blocks are not double-wrapped

Fixes #987

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
