### PR TITLE
fix: isolate chat input drafts per thread on switch (#990)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -78,6 +78,9 @@ interface AgentChatProps {
   onViewDiff?: (diff: DiffEvent) => void;
 }
 
+// Per-thread input drafts so switching threads doesn't leak text between them.
+const agentDrafts = new Map<string, string>();
+
 export const AgentChat: Component<AgentChatProps> = (props) => {
   const [input, setInput] = createSignal("");
   const [messageQueue, setMessageQueue] = createSignal<string[]>([]);
@@ -97,6 +100,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   let inputRef: HTMLTextAreaElement | undefined;
   let messagesRef: HTMLDivElement | undefined;
   let userHasScrolledUp = false;
+  let prevThreadId: string | null = null;
 
   // Off-thread markdown rendering: finalized assistant messages are sent to a
   // Web Worker so renderMarkdown (marked + hljs) never blocks the main thread.
@@ -122,6 +126,23 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     const thread = threadStore.activeThread;
     if (!thread || thread.kind !== "agent") return null;
     return thread;
+  });
+
+  // Save/restore per-thread input drafts when switching agent threads
+  createEffect(() => {
+    const currentId = activeAgentThread()?.id ?? null;
+    if (currentId !== prevThreadId) {
+      if (prevThreadId) {
+        const currentInput = untrack(input);
+        if (currentInput) {
+          agentDrafts.set(prevThreadId, currentInput);
+        } else {
+          agentDrafts.delete(prevThreadId);
+        }
+      }
+      setInput(currentId ? (agentDrafts.get(currentId) ?? "") : "");
+      prevThreadId = currentId;
+    }
   });
 
   // Get messages for THIS thread's conversation ID, not the active session

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -180,6 +180,9 @@ interface ChatContentProps {
   onSignInClick?: () => void;
 }
 
+// Per-thread input drafts so switching threads doesn't leak text between them.
+const chatDrafts = new Map<string, string>();
+
 export const ChatContent: Component<ChatContentProps> = (_props) => {
   const [input, setInput] = createSignal("");
   const [suggestions, setSuggestions] = createSignal<Publisher[]>([]);
@@ -202,6 +205,26 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
   let inputRef: HTMLTextAreaElement | undefined;
   let messagesRef: HTMLDivElement | undefined;
   let suggestionDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+  let prevConversationId: string | null = null;
+
+  // Save/restore per-thread input drafts when switching conversations
+  createEffect(() => {
+    const currentId = conversationStore.activeConversationId;
+    if (currentId !== prevConversationId) {
+      // Save draft for the thread we're leaving
+      if (prevConversationId) {
+        const currentInput = input();
+        if (currentInput) {
+          chatDrafts.set(prevConversationId, currentInput);
+        } else {
+          chatDrafts.delete(prevConversationId);
+        }
+      }
+      // Restore draft for the thread we're entering (or clear)
+      setInput(currentId ? (chatDrafts.get(currentId) ?? "") : "");
+      prevConversationId = currentId;
+    }
+  });
 
   // Click handler for copy buttons and external links (event delegation)
   const handleCopyClick = (event: MouseEvent) => {


### PR DESCRIPTION
## Summary

- Adds per-thread draft Maps in both ChatContent and AgentChat (module-level, survives re-renders)
- Adds a createEffect in each component that watches the active thread/conversation ID
- On thread switch: saves current input as draft for the old thread, restores draft for the new thread (or empty string)

## Root Cause

Both components use a local `createSignal('')` for input. SolidJS reuses the component instance when switching between threads of the same kind (via Switch/Match in ThreadContent), so the signal value leaks across threads.

Closes #990

## Test plan

- [ ] Type text in thread A, switch to thread B — input should be empty
- [ ] Switch back to thread A — typed text should be restored
- [ ] Verify this works for both chat threads and agent threads
- [ ] Verify sending a message still clears the input normally

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com