### PR TITLE
fix: remove 5-minute timeout on permission requests and diff proposals (#992)

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -726,36 +726,28 @@ impl Client for ClientDelegate {
             );
         }
 
-        // Wait for user response (5-minute timeout)
+        // Wait for user response (no timeout — user may need time to review)
         log::debug!("[ACP] Waiting for permission response {} ...", request_id);
-        let option_id_str =
-            match tokio::time::timeout(std::time::Duration::from_secs(300), response_rx).await {
-                Ok(Ok(id)) => {
-                    log::info!(
-                        "[ACP] Permission {} responded with option: {}",
-                        request_id,
-                        id
-                    );
+        let option_id_str = match response_rx.await {
+            Ok(id) => {
+                log::info!(
+                    "[ACP] Permission {} responded with option: {}",
+                    request_id,
                     id
-                }
-                Ok(Err(_)) => {
-                    log::warn!(
-                        "[ACP] Permission {} channel dropped (session may have been cleaned up)",
-                        request_id
-                    );
-                    self.pending_permissions.lock().await.remove(&request_id);
-                    return Err(agent_client_protocol::Error::internal_error().data(
-                        serde_json::Value::String("Permission request cancelled".into()),
-                    ));
-                }
-                Err(_) => {
-                    log::warn!("[ACP] Permission {} timed out after 5 minutes", request_id);
-                    self.pending_permissions.lock().await.remove(&request_id);
-                    return Err(agent_client_protocol::Error::internal_error().data(
-                        serde_json::Value::String("Permission request timed out".into()),
-                    ));
-                }
-            };
+                );
+                id
+            }
+            Err(_) => {
+                log::warn!(
+                    "[ACP] Permission {} channel dropped (session may have been cleaned up)",
+                    request_id
+                );
+                self.pending_permissions.lock().await.remove(&request_id);
+                return Err(agent_client_protocol::Error::internal_error().data(
+                    serde_json::Value::String("Permission request cancelled".into()),
+                ));
+            }
+        };
 
         self.pending_permissions.lock().await.remove(&request_id);
 
@@ -798,27 +790,18 @@ impl Client for ClientDelegate {
             }),
         );
 
-        // Wait for user response (5-minute timeout)
-        let accepted =
-            match tokio::time::timeout(std::time::Duration::from_secs(300), response_rx).await {
-                Ok(Ok(accepted)) => accepted,
-                Ok(Err(_)) => {
-                    self.pending_diff_proposals
-                        .lock()
-                        .await
-                        .remove(&proposal_id);
-                    return Err(agent_client_protocol::Error::internal_error()
-                        .data(serde_json::Value::String("Diff proposal dismissed".into())));
-                }
-                Err(_) => {
-                    self.pending_diff_proposals
-                        .lock()
-                        .await
-                        .remove(&proposal_id);
-                    return Err(agent_client_protocol::Error::internal_error()
-                        .data(serde_json::Value::String("Diff proposal timed out".into())));
-                }
-            };
+        // Wait for user response (no timeout — user may need time to review)
+        let accepted = match response_rx.await {
+            Ok(accepted) => accepted,
+            Err(_) => {
+                self.pending_diff_proposals
+                    .lock()
+                    .await
+                    .remove(&proposal_id);
+                return Err(agent_client_protocol::Error::internal_error()
+                    .data(serde_json::Value::String("Diff proposal dismissed".into())));
+            }
+        };
 
         self.pending_diff_proposals
             .lock()

--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -30,9 +30,6 @@ const CONNECT_TIMEOUT_SECS: u64 = 30;
 /// Allows for long-running agent requests with multiple tool execution rounds.
 const REQUEST_TIMEOUT_SECS: u64 = 600;
 
-/// Timeout for waiting on frontend tool execution (5 minutes).
-const TOOL_EXECUTION_TIMEOUT_SECS: u64 = 300;
-
 /// Maximum size (in bytes) of a single tool result when appended to the LLM
 /// conversation context.  Results larger than this are truncated to prevent the
 /// accumulated messages payload from growing large enough to cause upstream
@@ -973,7 +970,7 @@ impl ChatModelWorker {
     /// Route a non-local tool call to the frontend for execution via the tool bridge.
     ///
     /// Emits an `orchestrator://tool-request` event, then waits for the frontend to
-    /// call `submit_tool_result` with the result. Times out after 5 minutes.
+    /// call `submit_tool_result` with the result.
     async fn execute_frontend_tool(
         app: &tauri::AppHandle,
         tool_call_id: &str,
@@ -1009,13 +1006,12 @@ impl ChatModelWorker {
             return (format!("Failed to request tool execution: {}", e), true);
         }
         log::debug!(
-            "[ChatModelWorker] Tool request emitted, waiting for frontend result (timeout: {}s)",
-            TOOL_EXECUTION_TIMEOUT_SECS
+            "[ChatModelWorker] Tool request emitted, waiting for frontend result (no timeout)"
         );
 
-        // Wait for the frontend to submit the result
-        match tokio::time::timeout(Duration::from_secs(TOOL_EXECUTION_TIMEOUT_SECS), rx).await {
-            Ok(Ok(result)) => {
+        // Wait for the frontend to submit the result (no timeout — user may need time to review)
+        match rx.await {
+            Ok(result) => {
                 log::info!(
                     "[ChatModelWorker] Frontend tool completed: {} (is_error={}, result_len={})",
                     name,
@@ -1024,28 +1020,13 @@ impl ChatModelWorker {
                 );
                 (result.content, result.is_error)
             }
-            Ok(Err(_)) => {
+            Err(_) => {
                 // Sender was dropped (bridge cleaned up or cancelled)
                 log::warn!(
                     "[ChatModelWorker] Tool result channel closed for {} — bridge cleaned up or cancelled",
                     name
                 );
                 ("Tool execution was cancelled".to_string(), true)
-            }
-            Err(_) => {
-                log::error!(
-                    "[ChatModelWorker] TIMEOUT ({}/{}s) waiting for frontend tool execution: {}",
-                    TOOL_EXECUTION_TIMEOUT_SECS,
-                    TOOL_EXECUTION_TIMEOUT_SECS,
-                    name
-                );
-                (
-                    format!(
-                        "Tool '{}' timed out waiting for execution ({}s)",
-                        name, TOOL_EXECUTION_TIMEOUT_SECS
-                    ),
-                    true,
-                )
             }
         }
     }


### PR DESCRIPTION
## Summary

- Removes hardcoded 300-second `tokio::time::timeout` from permission request handling in `acp.rs`
- Removes same from diff proposal handling in `acp.rs`
- Removes same from frontend tool execution in `chat_model_worker.rs`
- Deletes unused `TOOL_EXECUTION_TIMEOUT_SECS` constant

## Root Cause

Three places in the Rust backend wrapped channel awaits with 5-minute timeouts. Commit c31cb535 only improved frontend handling of the timeout error (dismissing stale dialogs) but never removed the backend timeouts.

The channel already handles cleanup correctly: when a session terminates, the sender drops and the receiver unblocks with Err. No artificial timeout is needed.

Closes #992

## Test plan

- [ ] Trigger a permission request, wait >5 minutes without responding, verify it stays open
- [ ] Approve the permission after waiting — should succeed normally
- [ ] Verify session termination still cleans up pending permission requests
- [ ] Test diff proposal approval flow with no timeout

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com