### PR TITLE
fix: use shared SQLite connection pool to prevent database locked errors (#994)

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1,11 +1,11 @@
 // ABOUTME: Tauri commands for chat persistence and conversation management.
 // ABOUTME: Handles CRUD operations for conversations and messages in SQLite.
 
-use crate::services::database::init_db;
+use crate::services::database::{DbPool, init_db};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 const MAX_MESSAGES_PER_CONVERSATION: i32 = 1000;
 
@@ -573,14 +573,20 @@ pub async fn clear_all_history(app: AppHandle) -> Result<(), String> {
 
 async fn run_db<T>(
     app: AppHandle,
-    task: impl FnOnce(Connection) -> rusqlite::Result<T> + Send + 'static,
+    task: impl FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
 ) -> Result<T, String>
 where
     T: Send + 'static,
 {
     tauri::async_runtime::spawn_blocking(move || {
-        let conn = init_db(&app).map_err(|err| err.to_string())?;
-        task(conn).map_err(|err| err.to_string())
+        // Use the shared connection pool if available (normal runtime),
+        // fall back to opening a fresh connection (tests / early startup).
+        if let Some(pool) = app.try_state::<DbPool>() {
+            pool.with_connection(|conn| task(conn))
+        } else {
+            let conn = init_db(&app).map_err(|err| err.to_string())?;
+            task(&conn).map_err(|err| err.to_string())
+        }
     })
     .await
     .map_err(|err| err.to_string())?

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -629,6 +629,13 @@ pub fn run() {
                 });
             }
 
+            // Initialize shared SQLite connection pool to prevent "database is locked" errors.
+            {
+                let pool = services::database::DbPool::new(&app.handle())
+                    .expect("failed to initialize database pool");
+                app.manage(pool);
+            }
+
             // Initialize memory state for cloud + local cache operations.
             // Token is read fresh from the auth store on each request.
             {

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -1,11 +1,34 @@
-// ABOUTME: SQLite database initialization for chat persistence.
+// ABOUTME: SQLite database initialization and shared connection pool for chat persistence.
 // ABOUTME: Creates conversations and messages tables with migration support.
 
 use rusqlite::{Connection, Result};
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Mutex;
 use std::time::Duration;
 use tauri::{AppHandle, Manager};
+
+/// Shared SQLite connection pool managed as Tauri state.
+/// Serializes all DB operations through a single connection to prevent
+/// "database is locked" errors from concurrent connection opens.
+pub struct DbPool(Mutex<Connection>);
+
+impl DbPool {
+    /// Create a new pool by opening and configuring the database connection.
+    pub fn new(app: &AppHandle) -> std::result::Result<Self, String> {
+        let conn = init_db(app).map_err(|e| e.to_string())?;
+        Ok(Self(Mutex::new(conn)))
+    }
+
+    /// Run a closure with exclusive access to the shared connection.
+    pub fn with_connection<T, F>(&self, f: F) -> std::result::Result<T, String>
+    where
+        F: FnOnce(&Connection) -> Result<T>,
+    {
+        let conn = self.0.lock().map_err(|e| format!("DB mutex poisoned: {}", e))?;
+        f(&conn).map_err(|e| e.to_string())
+    }
+}
 
 pub fn get_db_path(app: &AppHandle) -> PathBuf {
     app.path()


### PR DESCRIPTION
## Summary

- Adds `DbPool` struct (`Mutex<Connection>`) to `database.rs`
- Registers it as Tauri managed state at app startup in `lib.rs`
- Changes `run_db` in `commands/chat.rs` to use the shared pool instead of opening a new connection per call
- Falls back to a fresh connection when pool is unavailable (tests, early startup)

## Root Cause

Every `run_db` call opened a new `Connection::open()` inside a `spawn_blocking` task. When rapid agent events fired concurrent `save_message` calls (3+ in quick succession), each task opened its own connection. SQLite only allows one writer at a time, even with WAL mode, so the contending connections produced `database is locked` errors despite the 5-second busy timeout.

## How the fix works

One connection is opened at startup and wrapped in a `Mutex`. All 17 `run_db` callers now acquire the mutex, use the shared connection, and release. This serializes writes through a single connection — no contention, no lock errors.

Closes #994

## Test plan

- [ ] Start an agent session, trigger rapid tool calls — no more 'database is locked' console errors
- [ ] Verify messages persist correctly (check conversation history after restart)
- [ ] Verify concurrent reads (loading conversations while agent is writing) work without errors
- [ ] Run `cargo test` on the Rust crate (tests use fallback path, no pool needed)

## Follow-up

`skills.rs` and `orchestrator/service.rs` also call `init_db` directly. They are lower frequency and can be migrated to the shared pool in a follow-up PR.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com