### PR TITLE
fix: increase Seren Chat max tool rounds from 35 to 100 (#996)

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -20,8 +20,8 @@ const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
 const PUBLISHER_SLUG: &str = "seren-models";
 
 /// Maximum number of tool execution rounds before forcing completion.
-/// At ~$0.15/round (Opus), this allows up to ~$5.25 of tool execution.
-const MAX_TOOL_ROUNDS: usize = 35;
+/// Context window limits and cost naturally cap long sessions.
+const MAX_TOOL_ROUNDS: usize = 100;
 
 /// Connect timeout for the HTTP client (seconds).
 const CONNECT_TIMEOUT_SECS: u64 = 30;


### PR DESCRIPTION
## Summary

Bumps `MAX_TOOL_ROUNDS` from 35 to 100 in `chat_model_worker.rs`.

## Why

Complex tasks (multi-file generation, iterative code writing) legitimately exhaust 35 rounds. Context window limits and cost naturally cap long sessions — the artificial round limit was unnecessarily restrictive. Agent sessions (ACP) have no such cap.

Closes #996

## Test plan

- [ ] Run a complex Seren Chat task that previously hit the 35-round limit — should continue past 35 rounds
- [ ] Verify the model still stops naturally when the task is complete

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com