### PR TITLE
fix: return false from compactAndRetry when compaction was skipped

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -1518,6 +1518,17 @@ Summary:`;
       }
 
       const [newSessionId] = newEntry;
+
+      // If compaction was skipped (e.g. not enough messages to compact),
+      // the search returns the original session — retrying on the same
+      // full session would fail again and falsely signal success.
+      if (newSessionId === sessionId) {
+        console.warn(
+          "[AcpStore] compactAndRetry: compaction was skipped, cannot retry",
+        );
+        return false;
+      }
+
       console.info(
         `[AcpStore] Compaction complete, retrying prompt on session ${newSessionId}`,
       );


### PR DESCRIPTION
## Summary

- `compactAgentConversation` returns early (no-op) when `messages.length <= preserveCount`
- `compactAndRetry` then finds the *original* session (same `conversationId`), sends the prompt to it (already at context limit), and returns `true` — falsely signalling success
- User stays stuck in agent mode; the Chat fallback (`acceptRateLimitFallback`) is never called

**Fix:** After resolving the "new" session, check `newSessionId === sessionId`. If they match, compaction was skipped — return `false` immediately so the caller falls back to Chat correctly.

## Test plan

- [ ] Trigger a prompt-too-long error with a conversation that is too short to compact (`messages.length <= preserveCount`)
- [ ] Verify the app falls back to Seren Chat instead of looping in agent mode
- [ ] Verify normal compaction (sufficient messages) still retries correctly on the new session

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com