### PR TITLE
fix: resolve sessionReadyPromises entry when ready event fires before entry is created

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -924,6 +924,14 @@ export const acpStore = {
             "status",
             "ready" as SessionStatus,
           );
+          // The ready event may have fired before sessionReadyPromises was
+          // created (buffered in pendingSessionEvents and drained before the
+          // entry existed). Resolve it now so sendPrompt doesn't hang forever.
+          const pendingReadyEntry = sessionReadyPromises.get(info.id);
+          if (pendingReadyEntry) {
+            pendingReadyEntry.resolve();
+            sessionReadyPromises.delete(info.id);
+          }
         }
       } catch (raceError) {
         const message =


### PR DESCRIPTION
Closes #1011

## Root Cause

`spawnSession` uses two separate promises:
1. A **local** `readyPromise` — resolved by `tempUnsubscribe` when any session emits "ready"
2. A `sessionReadyPromises` entry — what `sendPrompt` awaits

When the "ready" event arrives early (buffered in `pendingSessionEvents` before the session is in state), it is drained via `handleSessionEvent` → `handleStatusChange`. At that point the `sessionReadyPromises` entry doesn't exist yet (it's created after draining, so  does nothing with it.

The local  was already resolved by , so  returns immediately and  exits normally. But the  entry is now permanently unresolved — no future ready event will fire for it.

Every  call finds the stale entry and waits forever. Confirmed by backend logs: zero prompts reached the agent for 3+ hours after compaction.

## Fix

After the race resolves with the correct session ID, explicitly resolve and delete the  entry if it still exists.

## Test plan

- [ ] Trigger compaction and immediately send a prompt — verify the prompt goes through
- [ ] Verify the session responds after compaction completes

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
EOF
)