### PR TITLE
feat: implement conversation fork with agent context seeding

### DIFF
--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -3235,7 +3235,46 @@ Summary:`;
       `[AcpStore] Forked conversation ${conversationId} -> ${newConversationId} (agent session: ${newAgentSessionId})`,
     );
 
+    // Seed the forked agent with a summary of the forked conversation so it
+    // has context of the prior work. Same pattern as compaction seeding.
+    void this.seedForkedSession(newSessionId, forkedMessages);
+
     return newConversationId;
+  },
+
+  async seedForkedSession(
+    sessionId: string,
+    messages: AgentMessage[],
+  ): Promise<void> {
+    const summaryPrompt = `Please provide a concise summary of the following AI coding agent conversation. Focus on: what tasks were requested, what files were modified, key decisions made, and current state of the work. Keep the summary under 500 words.
+
+Conversation to summarize:
+${messages
+  .filter((m) => m.type === "user" || m.type === "assistant")
+  .map((m) => `${m.type.toUpperCase()}: ${m.content}`)
+  .join("\n\n")}
+
+Summary:`;
+
+    try {
+      const summary = await sendMessage(
+        summaryPrompt,
+        "anthropic/claude-sonnet-4",
+      );
+
+      const readyEntry = sessionReadyPromises.get(sessionId);
+      if (readyEntry) {
+        await readyEntry.promise;
+      }
+
+      const seedPrompt = `Here is a summary of the conversation up to the fork point:\n\n${summary}\n\nContinue from where we left off. The user may send a new message shortly.`;
+      await acpService.sendPrompt(sessionId, seedPrompt);
+      console.info(
+        "[AcpStore] Forked session seeded with conversation summary",
+      );
+    } catch (error) {
+      console.warn("[AcpStore] Failed to seed forked session:", error);
+    }
   },
 
   addErrorMessage(sessionId: string, error: string) {


### PR DESCRIPTION
Closes #1013

Requires serenorg/seren-acp-codex#8 to be merged and deployed first.

## Changes

**seren-acp-codex** (separate PR): implements `fork_session` by starting a new Codex thread and returning its ID.

**seren-desktop** (this PR): after the fork spawns a new session, seeds the agent with a Gateway API summary of the forked messages — same pattern already used by compaction.

## How fork works end-to-end

1. User clicks fork at message N
2. Frontend calls `acpService.forkSession` → Tauri → ACP `fork_session` → seren-acp-codex starts new Codex thread, returns new thread ID
3. Frontend creates new SQLite conversation with messages up to N, spawns session resuming the new thread
4. Frontend generates a summary of the forked messages via Gateway API and seeds the new agent — agent now has context of the prior work
5. User continues from the fork point

## Test plan

- [ ] Fork a conversation at an arbitrary message
- [ ] Verify forked session opens with correct history displayed
- [ ] Verify the agent responds with awareness of the prior conversation context
- [ ] Verify original session is unaffected

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com