### PR TITLE
fix: restore deferred config restore and surface provider runtime startup errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,14 @@ function App() {
       runtime.capabilities.agents &&
       (runtime.mode === "browser-local" || runtime.mode === "desktop-native")
     ) {
-      await connectLocalProviderRuntime();
+      try {
+        await connectLocalProviderRuntime();
+      } catch (error) {
+        console.error(
+          "[App] Failed to connect to local provider runtime:",
+          error,
+        );
+      }
     }
 
     await initAuthRuntimeBindings();

--- a/src/api/setup-auth.ts
+++ b/src/api/setup-auth.ts
@@ -11,9 +11,13 @@ type ClientWithRequestInterceptor = {
   };
 };
 
-export function attachAuthInterceptor(client: ClientWithRequestInterceptor): void {
+export function attachAuthInterceptor(
+  client: ClientWithRequestInterceptor,
+): void {
   if (!client.interceptors?.request?.use) {
-    console.warn("[API] Client missing request interceptors — auth will not be attached");
+    console.warn(
+      "[API] Client missing request interceptors — auth will not be attached",
+    );
     return;
   }
   client.interceptors.request.use(async (request: Request) => {

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/rate-limit-fallback";
 import { escapeHtmlWithLinks } from "@/lib/render-markdown";
 import { saveToSerenNotes } from "@/lib/save-to-notes";
+import { readDocument } from "@/services/docreader";
 import {
   type AgentType,
   type DiffEvent,
@@ -52,7 +53,6 @@ import {
   supportsConversationFork,
   type ToolCallEvent,
 } from "@/services/providers";
-import { readDocument } from "@/services/docreader";
 import { skills } from "@/services/skills";
 import {
   type AgentCompactedSummary,

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -35,7 +35,6 @@ import { isPaymentError } from "@/lib/payment-errors";
 import type { Attachment } from "@/lib/providers/types";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
 import { saveToSerenNotes } from "@/lib/save-to-notes";
-import type { ToolCallEvent } from "@/services/providers";
 import { catalog, type Publisher } from "@/services/catalog";
 import {
   CHAT_MAX_RETRIES,
@@ -47,6 +46,7 @@ import {
   orchestrate,
   retryOrchestration,
 } from "@/services/orchestrator";
+import type { ToolCallEvent } from "@/services/providers";
 import { skills } from "@/services/skills";
 import { authStore, checkAuth } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";

--- a/src/components/common/StatusBar.tsx
+++ b/src/components/common/StatusBar.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Application status bar at the bottom.
 // ABOUTME: Displays status messages, MCP state, autocomplete status, and connection state.
 
-import { createMemo, type Component } from "solid-js";
+import { type Component, createMemo } from "solid-js";
 import { agentStore } from "@/stores/agent.store";
 import { autocompleteStore } from "@/stores/autocomplete.store";
 import { AutocompleteStatus } from "./AutocompleteStatus";

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -342,7 +342,9 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
               />
             </svg>
           </Show>
-          {spawning() ? (agentStore.installStatus ?? "Starting...") : "New Agent"}
+          {spawning()
+            ? (agentStore.installStatus ?? "Starting...")
+            : "New Agent"}
         </button>
 
         <Show when={showLauncher()}>

--- a/src/lib/browser-local-runtime.ts
+++ b/src/lib/browser-local-runtime.ts
@@ -111,7 +111,9 @@ async function fetchRuntimeHealth(apiBaseUrl: string): Promise<RuntimeHealth> {
 
 async function loadDesktopRuntimeConfig(): Promise<LocalRuntimeConnectionConfig> {
   const { invoke } = await import("@tauri-apps/api/core");
-  const config = await invoke<DesktopRuntimeConfig>("provider_runtime_get_config");
+  const config = await invoke<DesktopRuntimeConfig>(
+    "provider_runtime_get_config",
+  );
   return {
     mode: "desktop-native",
     apiBaseUrl: config.apiBaseUrl,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,6 +5,6 @@ export * as auth from "./auth";
 export * as autoTopUp from "./autoTopUp";
 export * as catalog from "./catalog";
 export * as chat from "./chat";
-export * as providers from "./providers";
 export * as projects from "./projects";
+export * as providers from "./providers";
 export * as wallet from "./wallet";

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -304,7 +304,9 @@ export async function callGatewayTool(
     };
   } catch (error) {
     const executionTime = Date.now() - startTime;
-    console.error(`[MCP Gateway] Tool call failed: ${error instanceof Error ? error.message : String(error)}`);
+    console.error(
+      `[MCP Gateway] Tool call failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
 
     return {
       result: error instanceof Error ? error.message : String(error),

--- a/src/services/projects.ts
+++ b/src/services/projects.ts
@@ -3,13 +3,13 @@
 
 import {
   type CreateProjectRequest,
+  type Project,
   serenDbCreateProject,
   serenDbDeleteProject,
   serenDbGetProject,
   serenDbListProjects,
-  type Project,
-  type UpdateProjectRequest,
   serenDbUpdateProject,
+  type UpdateProjectRequest,
 } from "@/api/seren-db";
 
 // Re-export types for backwards compatibility

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -247,15 +247,17 @@ async function fetchRepoSkillPayloadFiles(
     siblingFiles.map(async (node): Promise<ExtraFile | null> => {
       const filePath = node.path ?? "";
       const relativePath = filePath.slice(dirPrefix.length);
-      const segments = filePath
-        .split("/")
-        .map((s) => encodeURIComponent(s));
+      const segments = filePath.split("/").map((s) => encodeURIComponent(s));
       const rawUrl = `${SKILLS_RAW_URL}/${segments.join("/")}`;
 
       try {
         const resp = await appFetch(rawUrl);
         if (!resp.ok) {
-          log.warn("[Skills] Failed to fetch payload file", rawUrl, resp.status);
+          log.warn(
+            "[Skills] Failed to fetch payload file",
+            rawUrl,
+            resp.status,
+          );
           return null;
         }
         const content = await resp.text();
@@ -340,10 +342,18 @@ export const skills = {
         const { timestamp, data } = JSON.parse(cached);
         const ageMs = Date.now() - timestamp;
         if (ageMs < MAX_STALE_CACHE_AGE) {
-          log.warn("[Skills] Serving stale index cache, age:", Math.round(ageMs / 1000), "s");
+          log.warn(
+            "[Skills] Serving stale index cache, age:",
+            Math.round(ageMs / 1000),
+            "s",
+          );
           return (data as SkillIndexEntry[]).map(indexEntryToSkill);
         }
-        log.error("[Skills] Stale cache too old to serve:", Math.round(ageMs / 1000), "s");
+        log.error(
+          "[Skills] Stale cache too old to serve:",
+          Math.round(ageMs / 1000),
+          "s",
+        );
       }
       return [];
     }
@@ -393,10 +403,18 @@ export const skills = {
         const { timestamp, data } = JSON.parse(cached);
         const ageMs = Date.now() - timestamp;
         if (ageMs < MAX_STALE_CACHE_AGE) {
-          log.warn("[Skills] Serving stale publisher skills cache, age:", Math.round(ageMs / 1000), "s");
+          log.warn(
+            "[Skills] Serving stale publisher skills cache, age:",
+            Math.round(ageMs / 1000),
+            "s",
+          );
           return data as Skill[];
         }
-        log.error("[Skills] Stale publisher skills cache too old to serve:", Math.round(ageMs / 1000), "s");
+        log.error(
+          "[Skills] Stale publisher skills cache too old to serve:",
+          Math.round(ageMs / 1000),
+          "s",
+        );
       }
       return [];
     }
@@ -764,10 +782,7 @@ export const skills = {
    * Validate an installed skill's payload files.
    * Returns a list of file paths referenced in SKILL.md but missing from disk.
    */
-  async validatePayload(
-    skillsDir: string,
-    slug: string,
-  ): Promise<string[]> {
+  async validatePayload(skillsDir: string, slug: string): Promise<string[]> {
     if (!isTauriRuntime()) return [];
     try {
       return await invoke<string[]>("validate_skill_payload", {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -8,10 +8,7 @@ import {
   onRuntimeEvent,
 } from "@/lib/browser-local-runtime";
 import { runtimeHasCapability } from "@/lib/runtime";
-import {
-  getEnabledMcpServers,
-  settingsStore,
-} from "@/stores/settings.store";
+import { getEnabledMcpServers, settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
 
 /** Per-session ready promises — resolved when backend emits "ready" status */
@@ -34,20 +31,21 @@ import {
   getAgentConversation,
   getAgentConversations,
   getSerenApiKey,
-    setAgentConversationModelId as setAgentConversationModelIdDb,
   setAgentConversationMetadata as setAgentConversationMetadataDb,
-    setAgentConversationSessionId as setAgentConversationSessionIdDb,
-    setAgentConversationTitle as setAgentConversationTitleDb,
+  setAgentConversationModelId as setAgentConversationModelIdDb,
+  setAgentConversationSessionId as setAgentConversationSessionIdDb,
+  setAgentConversationTitle as setAgentConversationTitleDb,
 } from "@/lib/tauri-bridge";
+import { sendMessage } from "@/services/chat";
 import type {
   AgentEvent,
-  AgentSessionInfo,
   AgentInfo,
+  AgentSessionInfo,
   AgentType,
   DiffEvent,
   DiffProposalEvent,
-  PlanEntry,
   PermissionRequestEvent,
+  PlanEntry,
   RemoteSessionInfo,
   SessionConfigOption,
   SessionStatus,
@@ -55,7 +53,6 @@ import type {
   ToolCallEvent,
 } from "@/services/providers";
 import * as providerService from "@/services/providers";
-import { sendMessage } from "@/services/chat";
 
 // ============================================================================
 // Types
@@ -167,6 +164,10 @@ export interface ActiveSession {
   /** Set when the user explicitly requested a cancel — suppresses auto-retry
    *  in the unresponsive-agent recovery path. */
   cancelRequested?: boolean;
+  /** Config option values queued for restoration after the next configOptionsUpdate
+   *  event from the new session. Prevents the agent's initial announcement from
+   *  overwriting values restored during compaction or recovery. */
+  pendingConfigRestore?: Record<string, string>;
 }
 
 // ============================================================================
@@ -272,13 +273,19 @@ function serializeAgentConversationMetadata(
  * We keep only in-memory session messages plus narrow bootstrap metadata for
  * exact local forks that have not materialized provider history yet.
  */
-function persistAgentMessage(_conversationId: string, _msg: AgentMessage): void {
+function persistAgentMessage(
+  _conversationId: string,
+  _msg: AgentMessage,
+): void {
   // Intentionally no-op.
 }
 
 function clearLegacyAgentTranscript(conversationId: string): void {
   clearConversationHistory(conversationId).catch((error) =>
-    console.warn("[AgentStore] Failed to clear legacy provider transcript:", error),
+    console.warn(
+      "[AgentStore] Failed to clear legacy provider transcript:",
+      error,
+    ),
   );
 }
 
@@ -396,9 +403,11 @@ function disposeAgentStoreRuntimeBindings(): void {
 }
 
 const agentStoreHot =
-  (import.meta as ImportMeta & {
-    hot?: { dispose: (callback: () => void) => void };
-  }).hot ?? null;
+  (
+    import.meta as ImportMeta & {
+      hot?: { dispose: (callback: () => void) => void };
+    }
+  ).hot ?? null;
 
 if (agentStoreHot) {
   const globalScope = globalThis as typeof globalThis & {
@@ -867,34 +876,36 @@ export const agentStore = {
     // Subscribe once to all agent runtime events before spawning, so early replay events
     // from load_session are buffered instead of dropped.
     if (!globalUnsubscribe) {
-      globalUnsubscribe = await providerService.subscribeToAllEvents((event) => {
-        const eventSessionId = event.data.sessionId;
-        if (!eventSessionId) return;
-        // Skip logging high-frequency messageChunk events to avoid flooding
-        // DevTools. Other event types (sessionStatus, toolCall, etc.) are
-        // still logged for debugging.
-        if (event.type !== "messageChunk") {
-          console.log(
-            "[AgentRuntime] Event received - type:",
-            event.type,
-            "sessionId:",
-            eventSessionId,
-            "conversationId:",
-            state.sessions[eventSessionId]?.conversationId,
-          );
-        }
-        if (state.sessions[eventSessionId]) {
-          this.handleSessionEvent(eventSessionId, event);
-          return;
-        }
+      globalUnsubscribe = await providerService.subscribeToAllEvents(
+        (event) => {
+          const eventSessionId = event.data.sessionId;
+          if (!eventSessionId) return;
+          // Skip logging high-frequency messageChunk events to avoid flooding
+          // DevTools. Other event types (sessionStatus, toolCall, etc.) are
+          // still logged for debugging.
+          if (event.type !== "messageChunk") {
+            console.log(
+              "[AgentRuntime] Event received - type:",
+              event.type,
+              "sessionId:",
+              eventSessionId,
+              "conversationId:",
+              state.sessions[eventSessionId]?.conversationId,
+            );
+          }
+          if (state.sessions[eventSessionId]) {
+            this.handleSessionEvent(eventSessionId, event);
+            return;
+          }
 
-        const pending = pendingSessionEvents.get(eventSessionId) ?? [];
-        pending.push(event);
-        if (pending.length > PENDING_SESSION_EVENT_LIMIT) {
-          pending.shift();
-        }
-        pendingSessionEvents.set(eventSessionId, pending);
-      });
+          const pending = pendingSessionEvents.get(eventSessionId) ?? [];
+          pending.push(event);
+          if (pending.length > PENDING_SESSION_EVENT_LIMIT) {
+            pending.shift();
+          }
+          pendingSessionEvents.set(eventSessionId, pending);
+        },
+      );
     }
 
     try {
@@ -1099,7 +1110,10 @@ export const agentStore = {
           initRetryAttempt < MAX_CLAUDE_INIT_RETRIES &&
           isRetryableClaudeInitError(initFailure)
         ) {
-          console.warn("[AgentStore] Claude init failed, retrying:", initFailure);
+          console.warn(
+            "[AgentStore] Claude init failed, retrying:",
+            initFailure,
+          );
           await this.terminateSession(info.id);
           sessionReadyPromises.delete(info.id);
           pendingSessionEvents.delete(info.id);
@@ -1456,10 +1470,16 @@ export const agentStore = {
         session.conversationId,
       );
       if (skillsContent) {
-        mergedContext = [{ type: "text", text: skillsContent }, ...mergedContext];
+        mergedContext = [
+          { type: "text", text: skillsContent },
+          ...mergedContext,
+        ];
       }
     } catch (error) {
-      console.warn("[AgentStore] Failed to load skills for agent prompt:", error);
+      console.warn(
+        "[AgentStore] Failed to load skills for agent prompt:",
+        error,
+      );
     }
 
     return mergedContext.length > 0 ? mergedContext : undefined;
@@ -1509,16 +1529,23 @@ export const agentStore = {
     targetSessionId: string,
   ) {
     if (sourceSession.currentModeId) {
-      await this.setPermissionMode(sourceSession.currentModeId, targetSessionId);
+      await this.setPermissionMode(
+        sourceSession.currentModeId,
+        targetSessionId,
+      );
     }
     if (sourceSession.currentModelId) {
       await this.setModel(sourceSession.currentModelId, targetSessionId);
     }
     if (sourceSession.configOptions) {
+      const restore: Record<string, string> = {};
       for (const opt of sourceSession.configOptions) {
         if (opt.type === "select" && opt.currentValue) {
-          await this.setConfigOption(opt.id, opt.currentValue, targetSessionId);
+          restore[opt.id] = opt.currentValue;
         }
+      }
+      if (Object.keys(restore).length > 0) {
+        setState("sessions", targetSessionId, "pendingConfigRestore", restore);
       }
     }
   },
@@ -1696,7 +1723,10 @@ Summary:`;
 
       await providerService.sendPrompt(newSessionId, seedPrompt);
     } catch (error) {
-      console.error("[AgentStore] Failed to compact agent conversation:", error);
+      console.error(
+        "[AgentStore] Failed to compact agent conversation:",
+        error,
+      );
       // If the original session still exists, clear compacting flag
       if (state.sessions[sessionId]) {
         setState("sessions", sessionId, "isCompacting", false);
@@ -1959,11 +1989,7 @@ Summary:`;
     console.log("[AgentStore] Calling providerService.sendPrompt...");
     try {
       const mergedContext = await this.buildPromptContext(sessionId, context);
-      await providerService.sendPrompt(
-        sessionId,
-        prompt,
-        mergedContext,
-      );
+      await providerService.sendPrompt(sessionId, prompt, mergedContext);
       this.clearBootstrapPromptContext(sessionId);
       console.log("[AgentStore] sendPrompt completed successfully");
     } catch (error) {
@@ -2624,14 +2650,25 @@ Summary:`;
         break;
       }
 
-      case "configOptionsUpdate":
-        setState(
-          "sessions",
-          sessionId,
-          "configOptions",
-          event.data.configOptions,
-        );
+      case "configOptionsUpdate": {
+        const restore = state.sessions[sessionId]?.pendingConfigRestore;
+        const incoming = event.data.configOptions;
+        const merged = restore
+          ? incoming.map((opt) =>
+              opt.type === "select" && restore[opt.id]
+                ? { ...opt, currentValue: restore[opt.id] }
+                : opt,
+            )
+          : incoming;
+        setState("sessions", sessionId, "configOptions", merged);
+        if (restore) {
+          setState("sessions", sessionId, "pendingConfigRestore", undefined);
+          for (const [id, value] of Object.entries(restore)) {
+            void this.setConfigOption(id, value, sessionId);
+          }
+        }
         break;
+      }
       case "sessionStatus":
         this.handleStatusChange(sessionId, event.data.status, event.data);
         break;
@@ -3290,7 +3327,9 @@ Summary:`;
       // If the agent's response is a prompt-too-long error (context window full),
       // try compaction + retry before falling back to Chat mode.
       if (isPromptTooLongError(session.streamingContent)) {
-        console.info("[AgentStore] Prompt too long detected in streamed content");
+        console.info(
+          "[AgentStore] Prompt too long detected in streamed content",
+        );
         void this.compactAndRetry(sessionId).then((retried) => {
           if (!retried) {
             console.info(
@@ -3350,19 +3389,20 @@ Summary:`;
     const forkedMessages = allMessages.slice(0, forkIndex + 1);
     const isHeadFork = forkIndex === allMessages.length - 1;
     const useNativeFork =
-      providerService.supportsNativeProviderFork(agentType) &&
-      isHeadFork;
+      providerService.supportsNativeProviderFork(agentType) && isHeadFork;
 
     let newAgentSessionId: string | undefined;
     let bootstrapPromptContext: string | undefined;
 
     if (useNativeFork) {
       try {
-        newAgentSessionId = await providerService.nativeForkSession(
-          conversationId,
-        );
+        newAgentSessionId =
+          await providerService.nativeForkSession(conversationId);
       } catch (err) {
-        console.error("[AgentStore] forkConversation: native fork failed:", err);
+        console.error(
+          "[AgentStore] forkConversation: native fork failed:",
+          err,
+        );
         this.addErrorMessage(
           conversationId,
           `Fork failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -567,7 +567,10 @@ export const skillsStore = {
    * Pass skipCache=true for user-triggered refreshes that should bypass cache.
    */
   async refresh(skipCache = false): Promise<void> {
-    await Promise.all([this.refreshAvailable(skipCache), this.refreshInstalled()]);
+    await Promise.all([
+      this.refreshAvailable(skipCache),
+      this.refreshInstalled(),
+    ]);
   },
 
   /**


### PR DESCRIPTION
## Summary

- Restores the pendingConfigRestore deferred pattern in restoreSessionSettings (closes #1018). The refactor replaced this with direct setConfigOption calls, re-introducing the race where the agent's initial configOptionsUpdate event overwrites restored config values after compaction or recovery. Fix: queue config options in pendingConfigRestore and apply them inside the configOptionsUpdate handler, same as PR #1010.
- Wraps connectLocalProviderRuntime in try/catch in App.tsx (closes #1017). If the provider runtime fails to start, the uncaught error was aborting the entire onMount, killing auth, wallet, and settings initialization. Fix: catch and log the error so the rest of startup proceeds.
- Fixes pre-existing Biome formatting errors in the branch (were causing pnpm check to fail).

## Test plan

- [ ] After auto-compaction, Permission Mode and Reasoning Effort retain their pre-compaction values
- [ ] If provider runtime fails to start, auth and wallet still initialize correctly
- [ ] pnpm check passes with no errors

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com