### PR TITLE
fix: warn when unknown architecture falls back to x64 in embedded runtime

### DIFF
--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -33,6 +33,7 @@ pub fn platform_subdir() -> String {
     } else if cfg!(target_arch = "aarch64") {
         "arm64"
     } else {
+        log::warn!("[EmbeddedRuntime] Unknown target architecture, falling back to x64");
         "x64"
     };
 


### PR DESCRIPTION
## Summary

- Add warn-level log when platform_subdir() falls back to x64 for an unknown architecture
- Prevents silent failures on unusual build targets

Closes #1048

## Test plan

- [ ] Build on a non-x86_64/non-aarch64 target and verify the warning appears in logs

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com