### PR TITLE
fix: validate health response ok field before marking provider runtime ready

### DIFF
--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -264,7 +264,12 @@ async fn wait_for_provider_runtime(
 
         if let Ok(response) = client.get(&health_url).send().await {
             if response.status().is_success() {
-                return Ok(());
+                // Also check that the runtime reports itself as ready
+                if let Ok(body) = response.json::<serde_json::Value>().await {
+                    if body.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+                        return Ok(());
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Parse the health endpoint response body and require ok: true before considering the runtime ready
- Previously any HTTP 200 was accepted, including partial initialization states
- The runtime now must self-report as ready, matching the frontend browser-local-runtime.ts behavior

Closes #1047

## Test plan

- [ ] Normal startup — verify health check still passes and runtime becomes ready
- [ ] Verify runtime that returns HTTP 200 with ok: false is not treated as ready

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com