### PR TITLE
fix: use hoisted node-linker when installing provider-runtime deps

### DIFF
--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -93,7 +93,10 @@ function main(): void {
     "utf8",
   );
 
-  run("pnpm", ["install", "--prod", "--ignore-scripts"], destDir);
+  // Use --node-linker=hoisted to create real files instead of pnpm symlinks.
+  // Symlinks don't survive Tauri bundling or macOS notarization, so without
+  // this the ws package is missing from the app bundle at runtime.
+  run("pnpm", ["install", "--prod", "--ignore-scripts", "--node-linker=hoisted"], destDir);
 
   writeFileSync(
     markerPath,


### PR DESCRIPTION
## Summary

- `pnpm install` without `--node-linker=hoisted` creates symlinks into the pnpm global store
- Those symlinks do not survive Tauri resource bundling or macOS notarization
- At runtime Node.js cannot find the `ws` package and the provider-runtime crashes with `ERR_MODULE_NOT_FOUND`, preventing Codex Agent from starting
- Fix mirrors the same approach already used in `prepare-mcp-servers.ts`

## Test plan

- [ ] Run `pnpm build:provider-runtime` and confirm `embedded-runtime/provider-runtime/node_modules/ws` contains real files (not symlinks)
- [ ] Build the app and verify Codex Agent starts without `ERR_MODULE_NOT_FOUND`
- [ ] CI passes on all platforms (macOS, Windows, Linux)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com