### PR TITLE
fix: stop button hidden when chat component remounts during active tool loop

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -305,12 +305,6 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
       conversationStore.isLoading,
     );
 
-    // Reset orphaned loading state from HMR interruption
-    if (conversationStore.isLoading) {
-      console.log("[ChatContent] Resetting orphaned loading state from HMR");
-      conversationStore.setLoading(false);
-    }
-
     // Register copy button handler on document for better reliability
     // Using document-level delegation ensures copy buttons work even if messagesRef timing is off
     document.addEventListener("click", handleCopyClick);
@@ -362,12 +356,6 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
       "seren:set-chat-input",
       handleSetChatInput as EventListener,
     );
-
-    // Reset loading state if still active when unmounting (e.g., HMR)
-    if (conversationStore.isLoading) {
-      console.log("[ChatContent] Cleaning up loading state on unmount");
-      conversationStore.setLoading(false);
-    }
 
     if (suggestionDebounceTimer) {
       clearTimeout(suggestionDebounceTimer);


### PR DESCRIPTION
## Summary

- Removes `onMount` block that reset `isLoading` to `false` on every component mount (disguised as an HMR fix but ran in production)
- Removes `onCleanup` block that reset `isLoading` to `false` on unmount

Both caused the Stop button to disappear if the user navigated away from a conversation and back while the backend tool loop was still running, forcing a full app kill to cancel.

Fixes #1063

## Test plan

- [ ] Start a long agentic task
- [ ] Switch to a different conversation and back — Stop button should still be visible
- [ ] Click Stop — orchestration should cancel cleanly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com