### PR TITLE
fix: timeout relaunch() after update and show manual restart prompt

### DIFF
--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -181,6 +181,14 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
           </div>
         </Show>
 
+        {/* Needs manual restart after update */}
+        <Show when={updaterStore.state.status === "needs_restart"}>
+          <div class="text-[10px] text-foreground/70 flex items-center gap-1.5">
+            <span>✓</span>
+            <span>Update installed — please restart</span>
+          </div>
+        </Show>
+
         {/* Error state with retry */}
         <Show when={updaterStore.state.status === "error"}>
           <button

--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -13,6 +13,7 @@ export type UpdateStatus =
   | "deferred"
   | "downloading"
   | "installing"
+  | "needs_restart"
   | "error";
 
 interface UpdaterState {
@@ -147,9 +148,17 @@ async function installAvailableUpdate(): Promise<void> {
       setState({ status: "installing", progressPercent: 100 });
     });
     console.log("[Updater] Install complete, relaunching...");
-    await relaunch();
+    const relaunchTimeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("relaunch_timeout")), 10_000),
+    );
+    await Promise.race([relaunch(), relaunchTimeout]);
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
+    if (err.message === "relaunch_timeout") {
+      console.warn("[Updater] Relaunch timed out — update is installed, manual restart required");
+      setState({ status: "needs_restart" });
+      return;
+    }
     console.error("[Updater] Install failed:", err.message);
     telemetry.captureError(err, { type: "updater", phase: "install" });
     setState({ status: "error", error: err.message });


### PR DESCRIPTION
## Summary

- Adds a 10s timeout to `relaunch()` after a successful in-app update
- If relaunch hangs (macOS Gatekeeper re-verifying the new binary), sets status to `needs_restart` instead of freezing
- Shows "Update installed — please restart" in the titlebar so users know they can manually quit and reopen

## Root Cause

After `downloadAndInstall()` completes, `await relaunch()` blocks indefinitely on macOS when Gatekeeper re-verifies the new binary. The app shows "Installing update..." forever with no escape.

## Fix

`Promise.race([relaunch(), 10s timeout])` — on timeout, shows a clear "please restart" message instead of leaving the user frozen.

Fixes #1066

## Test plan

- [ ] Trigger an in-app update and verify it relaunches normally
- [ ] Simulate relaunch hang: verify "Update installed — please restart" appears after ~10s

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com