### PR TITLE
fix: allow WebSocket and HTTP connections to local provider runtime in CSP

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc://localhost http://ipc.localhost https://api.serendb.com https://api.github.com https://raw.githubusercontent.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai https://*.thirdweb.com https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org https://*.base.org; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' asset: https: data:; font-src 'self' https://fonts.gstatic.com; frame-src http://127.0.0.1:* http://localhost:*",
+      "csp": "default-src 'self'; connect-src 'self' ipc://localhost http://ipc.localhost ws://127.0.0.1:* http://127.0.0.1:* https://api.serendb.com https://api.github.com https://raw.githubusercontent.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai https://*.thirdweb.com https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org https://*.base.org; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' asset: https: data:; font-src 'self' https://fonts.gstatic.com; frame-src http://127.0.0.1:* http://localhost:*",
       "assetProtocol": {
         "enable": true,
         "scope": [


### PR DESCRIPTION
## Summary

- Adds `ws://127.0.0.1:*` and `http://127.0.0.1:*` to `connect-src` in `tauri.conf.json`
- The provider runtime binds to a dynamic localhost port; without these the frontend silently fails to connect

## Error (v2.0.1)

```
Refused to connect to ws://127.0.0.1:56481/ because it does not appear in the connect-src directive of the Content Security Policy.
Failed to connect to local provider runtime: SecurityError: The operation is insecure.
```

Fixes #1068

## Test plan

- [ ] Start app with local provider runtime enabled
- [ ] Verify no CSP errors in console for ws://127.0.0.1:* connections
- [ ] Verify provider runtime connects successfully

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com