### PR TITLE
fix: match installed skill by dirName and demote missing-file warning

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -107,9 +107,14 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
         await skillsStore.install(marketplaceSkill, content, "seren");
         await skillsStore.refreshInstalled();
 
-        // Find the newly installed skill
+        // Find the newly installed skill. Match by slug first, then fall back to
+        // dirName because resolveSkillSlug() may derive a different slug from the
+        // SKILL.md name metadata than the marketplace slug (e.g. "skill-creator"
+        // vs "seren-skill-creator"). dirName always equals the marketplace slug.
         const found = skillsStore.installed.find(
-          (s) => s.slug === marketplaceSkill.slug,
+          (s) =>
+            s.slug === marketplaceSkill.slug ||
+            s.dirName === marketplaceSkill.slug,
         );
         if (!found) {
           console.error("[ThreadSidebar] Skill installed but not found");

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -747,10 +747,13 @@ export const skills = {
         slug: skill.slug,
       });
       if (missingFiles.length > 0) {
-        log.warn(
+        // These are user-provisioned files (requirements.txt, config.json, etc.)
+        // referenced in the SKILL.md but not included in the marketplace payload.
+        // Demote to debug — absence is expected and not an install failure.
+        log.debug(
           "[Skills] Skill",
           skill.slug,
-          "is missing referenced files:",
+          "references files not present in payload (user must provision):",
           missingFiles,
         );
       }


### PR DESCRIPTION
## Summary

- Fix 'Skill installed but not found' error: ThreadSidebar now also matches by `dirName` when `slug` doesn't match. The skill's dirName always equals the marketplace slug, but `resolveSkillSlug()` may derive a different slug from the SKILL.md name metadata (#1070)
- Demote `validate_skill_payload` missing-file warning to debug. Files like `requirements.txt`, `package.json`, and `config.json` are user-provisioned and intentionally absent from marketplace payload installs (#1071)

Closes #1070, #1071

## Test plan

- [ ] Install seren-skill-creator from marketplace via thread sidebar — verify no 'Skill installed but not found' error and skill is toggled correctly
- [ ] Verify no warn-level log about missing referenced files after install
- [ ] Verify skill still installs and works correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com