### PR TITLE
fix: replace node bin symlinks with shell wrappers to survive Tauri bundling

### DIFF
--- a/build/darwin/prepare-embedded-runtime.ts
+++ b/build/darwin/prepare-embedded-runtime.ts
@@ -96,6 +96,20 @@ async function prepareNodejs(options: DownloadOptions): Promise<string> {
 	fs.rmSync(tempDir, { recursive: true, force: true });
 	fs.unlinkSync(tarPath);
 
+	// Replace bin/npm and bin/npx symlinks with shell wrappers.
+	// Tauri resolves symlinks into regular files when bundling the .app, which
+	// breaks `require('../lib/cli.js')` because the path resolves relative to
+	// bin/ rather than lib/node_modules/npm/bin/ where the symlink target lives.
+	// A shell wrapper computes its own directory at runtime and stays correct
+	// whether or not Tauri has dereferenced it.
+	const npmWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npm-cli.js" "$@"\n`;
+	const npxWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npx-cli.js" "$@"\n`;
+	const corepackWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/corepack/dist/corepack.js" "$@"\n`;
+	fs.writeFileSync(path.join(nodeDir, 'bin', 'npm'), npmWrapper, { mode: 0o755 });
+	fs.writeFileSync(path.join(nodeDir, 'bin', 'npx'), npxWrapper, { mode: 0o755 });
+	fs.writeFileSync(path.join(nodeDir, 'bin', 'corepack'), corepackWrapper, { mode: 0o755 });
+	console.log('Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.');
+
 	console.log(`Node.js prepared at ${nodeDir}`);
 	return nodeDir;
 }


### PR DESCRIPTION
## Root Cause

Tauri resolves symlinks into regular files when packaging the macOS .app.

Node.js 22.12.0's bin/npm is a symlink to ../lib/node_modules/npm/bin/npm-cli.js, which contains require('../lib/cli.js')(process). After Tauri dereferences the symlink, this file lands at node/bin/npm. Now require('../lib/cli.js') resolves to node/lib/cli.js (missing) instead of node/lib/node_modules/npm/lib/cli.js (correct), crashing with MODULE_NOT_FOUND.

This was hidden before v2.1.0 because the CSP bug blocked WebSocket connections to the provider runtime, so the agent startup flow (which calls npm install) never ran. The v2.1.0 CSP fix unmasked this.

## Fix

Replace the bin/npm, bin/npx, and bin/corepack symlinks with self-contained sh wrappers in prepare-embedded-runtime.ts (darwin only — Linux/Windows Tauri packaging preserves symlinks). The wrappers compute the bin directory at runtime via $(dirname "$0") and explicitly invoke node with the correct npm-cli.js path.

## Test plan
- Run pnpm prepare:runtime:darwin-arm64 and pnpm prepare:runtime:darwin-x64, confirm bin/npm is a shell script not a symlink
- Build the app and verify npm install succeeds when spawning a claude-code agent session
- Confirm the new release resolves the Cannot find module '../lib/cli.js' error

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com