### PR TITLE
fix: add CSS layout containment to message articles to prevent flex layout recursion

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -938,7 +938,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     switch (message.type) {
       case "user":
         return (
-          <article class="group/msg relative px-5 py-4 bg-surface-1 border-b border-surface-2">
+          <article class="group/msg relative px-5 py-4 bg-surface-1 border-b border-surface-2 [contain:layout]">
             <Show when={message.docNames?.length}>
               <div class="flex flex-wrap gap-1.5 mb-2">
                 <For each={message.docNames}>
@@ -989,7 +989,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
       case "assistant":
         return (
-          <article class="group/msg relative px-5 py-4 border-b border-surface-2">
+          <article class="group/msg relative px-5 py-4 border-b border-surface-2 [contain:layout]">
             <Show
               when={isLikelyAuthError(message.content)}
               fallback={

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -1122,7 +1122,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                     }
                   >
                     <article
-                      class={`group/msg px-5 py-4 border-b border-surface-2 last:border-b-0 ${message.role === "user" ? "bg-surface-1" : "bg-transparent"}`}
+                      class={`group/msg px-5 py-4 border-b border-surface-2 last:border-b-0 [contain:layout] ${message.role === "user" ? "bg-surface-1" : "bg-transparent"}`}
                     >
                       <Show when={message.images && message.images.length > 0}>
                         <MessageImages images={message.images ?? []} />


### PR DESCRIPTION
Closes #1079

## Root Cause

On macOS 26.x (WebKit 21623), opening a thread with many messages freezes the app. The sampler shows 4034/4034 samples stuck in RenderFlexibleBox::performFlexLayout, triggered by setActivityState (window focus).

With no layout containment, WebKit traverses every flex container in the document during a layout pass — O(messages × code_blocks) flex layout operations. Each message's code blocks contain nested flex containers (code-block-header > code-copy-btn). On macOS 26.x, the new constructFlexLayoutItem function recurses through these, making the cost grow with thread length.

## Fix

Add [contain:layout] to each message article in ChatContent and AgentChat.

CSS layout containment (contain: layout) tells WebKit that a subtree's layout is isolated: changes inside one message cannot cause siblings or ancestors to relayout. This turns the O(n) cross-message traversal into independent per-message passes that can be skipped if the message is clean.

## Test plan
- Open a thread with many messages (20+) on macOS — app should remain responsive
- Window focus/blur should not cause a freeze
- Message rendering should be visually unchanged

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com