### PR TITLE
fix: scroll to bottom after worker renders chat history HTML

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -375,10 +375,14 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     }
   });
 
-  // Auto-scroll to bottom when messages change, streaming starts, or switching channels
+  // Auto-scroll to bottom when messages change, streaming starts, or switching channels.
+  // Also track htmlCache size: the worker renders HTML asynchronously, so the DOM
+  // grows after messages first load. Without tracking htmlCache, the scroll fires
+  // once on empty content and never again as worker responses fill in the HTML.
   createEffect(() => {
     void conversationStore.messages;
     void conversationStore.streamingContent;
+    void Object.keys(htmlCache).length;
     requestAnimationFrame(scrollToBottom);
   });
 


### PR DESCRIPTION
## Problem

When loading a thread with chat history, the scrollbar stayed at the top instead of scrolling to the latest messages.

The auto-scroll createEffect fired when conversationStore.messages loaded, but at that point all message innerHTML was still empty — the markdown worker had not responded yet. The DOM was tiny, so scrollTop = scrollHeight appeared to reach the bottom of an empty message list. As worker responses arrived and filled in the HTML, the DOM grew, but htmlCache changes were not tracked by the scroll effect — leaving the scrollbar stuck at the top.

## Fix

Track Object.keys(htmlCache).length in the scroll effect. Each time the worker completes rendering a message and updates htmlCache, the effect re-fires and scrolls to the new bottom.

## Test plan
- Open a thread with many messages — scrollbar should reach the bottom after history loads
- New messages during streaming should still auto-scroll

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com