### PR TITLE
fix: kill orphaned child processes on app exit (#1082)

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -520,7 +520,8 @@ function isRecoverableResumeError(message) {
     lower.includes("not found") ||
     lower.includes("missing thread") ||
     lower.includes("unknown thread") ||
-    lower.includes("does not exist")
+    lower.includes("does not exist") ||
+    lower.includes("no rollout")
   );
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@
 // ABOUTME: Contains Tauri commands and the application run function.
 
 use log::info;
-use tauri::{Emitter, Manager};
+use tauri::{Emitter, Manager, RunEvent};
 use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_store::StoreExt;
 
@@ -810,6 +810,19 @@ pub fn run() {
             commands::memory::memory_recall,
             commands::memory::memory_sync,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            if let RunEvent::Exit = event {
+                log::info!("[App] Exit event — cleaning up child processes");
+                // Kill all MCP stdio server processes to prevent orphaned zombies
+                if let Some(mcp_state) = app.try_state::<mcp::McpState>() {
+                    mcp_state.kill_all();
+                }
+                // Stop the provider runtime node process
+                if let Some(rt_state) = app.try_state::<provider_runtime::ProviderRuntimeState>() {
+                    rt_state.kill_sync();
+                }
+            }
+        });
 }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -26,6 +26,17 @@ impl McpState {
             processes: Mutex::new(HashMap::new()),
         }
     }
+
+    /// Kill all connected MCP server processes. Called on app exit to prevent
+    /// orphaned child processes from accumulating across restarts.
+    pub fn kill_all(&self) {
+        if let Ok(mut processes) = self.processes.lock() {
+            for (name, mut process) in processes.drain() {
+                log::info!("[MCP] Killing process on exit: {}", name);
+                let _ = process.child.kill();
+            }
+        }
+    }
 }
 
 impl Default for McpState {

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -138,11 +138,40 @@ impl ProviderRuntimeState {
         });
         drop(guard);
 
-        // Start crash monitor
+        // Abort any previous crash monitor before starting a new one
+        if let Some(old_handle) = self.monitor_handle.lock().await.take() {
+            old_handle.abort();
+        }
         let monitor = spawn_process_monitor(app.clone());
         *self.monitor_handle.lock().await = Some(monitor);
 
         Ok(config)
+    }
+}
+
+impl ProviderRuntimeState {
+    /// Synchronously kill the provider runtime process. Called from the app
+    /// exit handler where the async runtime may be shutting down.
+    pub fn kill_sync(&self) {
+        // Abort the monitor task if reachable via try_lock
+        if let Ok(mut guard) = self.monitor_handle.try_lock() {
+            if let Some(handle) = guard.take() {
+                handle.abort();
+            }
+        }
+
+        if let Ok(mut guard) = self.process.try_lock() {
+            if let Some(ref process) = *guard {
+                if let Some(pid) = process.child.id() {
+                    log::info!("[ProviderRuntime] Killing process on exit: pid={}", pid);
+                    #[cfg(unix)]
+                    unsafe {
+                        libc::kill(pid as i32, libc::SIGKILL);
+                    }
+                }
+            }
+            *guard = None;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Kill all MCP stdio server processes and provider-runtime on app exit via `RunEvent::Exit` handler, preventing zombie process accumulation across restarts (~2.9 GB leaked in a single day)
- Add "no rollout" to Codex `isRecoverableResumeError()` so failed thread resumes fall back to `thread/start` instead of throwing and triggering retry cascades that spawn 69+ orphaned processes
- Abort old provider-runtime monitor task before spawning a new one on crash-restart, preventing ghost tokio tasks

Closes #1082

## Test plan
- [ ] Launch app, open a Codex session, quit app, verify no orphaned `provider-runtime` or `codex app-server` processes remain (`ps aux | grep seren`)
- [ ] Launch app, create Codex session, quit, relaunch, switch to old Codex thread -- verify it gracefully starts a new thread instead of erroring with "no rollout found"
- [ ] Verify MCP servers (playwright-stealth) are killed on app exit
- [ ] Run `cargo check` to confirm no compilation errors

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
