### PR TITLE
fix: restore Codex approval mode selector in status bar (#1086)

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -82,10 +82,21 @@ function codexApprovalPolicy(modeId) {
   return modeId === "ask" ? "on-request" : "never";
 }
 
-function codexModes() {
+function codexModes(session) {
   return {
-    currentModeId: "auto",
-    availableModes: [],
+    currentModeId: session?.currentModeId ?? "auto",
+    availableModes: [
+      {
+        modeId: "auto",
+        name: "Auto",
+        description: "Automatically approve safe operations",
+      },
+      {
+        modeId: "ask",
+        name: "Suggest",
+        description: "Ask for approval on each action",
+      },
+    ],
   };
 }
 
@@ -250,7 +261,7 @@ function buildSessionStatus(session, status = session.status) {
       currentModelId: session.currentModelId,
       availableModels: buildAvailableModels(session),
     },
-    modes: codexModes(),
+    modes: codexModes(session),
     configOptions: buildConfigOptions(session),
   };
 }


### PR DESCRIPTION
## Summary
- Populate `codexModes()` with "Auto" and "Suggest" modes instead of returning an empty array
- Pass session to `codexModes(session)` so it reflects `session.currentModeId` instead of always hardcoding "auto"
- Fixes the `AgentModeSelector` dropdown being hidden via `<Show when={availableModes().length > 0}>`

Closes #1086

## Note on SerenModels Chat
The `AgentModeSelector` only applies to agent sessions (Codex, Claude Code). SerenModels "Seren Chat" uses `ChatContent.tsx` which is a non-agent chat completion flow -- it does not have an agent runtime or modes. Claude Code already has modes working via `buildModeState()` in `claude-runtime.mjs`.

## Test plan
- [ ] Open a Codex agent session -- verify the "Auto" approval mode selector appears in the status bar
- [ ] Switch mode to "Suggest" -- verify it persists and shows in the dropdown
- [ ] Verify Claude Code sessions still show their mode selector (Default, Accept Edits, Plan Mode, Bypass Permissions)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
