### PR TITLE
feat: add reasoning effort selector for SerenModels chat

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -229,6 +229,11 @@ impl ChatModelWorker {
             body["tool_choice"] = serde_json::json!("auto");
         }
 
+        // OpenRouter reasoning effort parameter (for models that support extended thinking)
+        if let Some(ref effort) = routing.reasoning_effort {
+            body["reasoning"] = serde_json::json!({ "effort": effort });
+        }
+
         body
     }
 
@@ -1272,6 +1277,7 @@ mod tests {
             reason: "General chat".to_string(),
             selected_skills: vec![],
             publisher_slug: None,
+            reasoning_effort: None,
         };
 
         let body = worker.build_request_body(
@@ -1303,6 +1309,7 @@ mod tests {
             reason: "General chat".to_string(),
             selected_skills: vec![],
             publisher_slug: None,
+            reasoning_effort: None,
         };
 
         let body = worker.build_request_body(
@@ -1329,6 +1336,7 @@ mod tests {
             reason: "Research".to_string(),
             selected_skills: vec![],
             publisher_slug: None,
+            reasoning_effort: None,
         };
 
         let tools = vec![serde_json::json!({
@@ -1514,6 +1522,7 @@ mod tests {
             reason: "General chat".to_string(),
             selected_skills: vec![],
             publisher_slug: None,
+            reasoning_effort: None,
         };
 
         let images = vec![ImageAttachment {

--- a/src-tauri/src/orchestrator/mcp_publisher_worker.rs
+++ b/src-tauri/src/orchestrator/mcp_publisher_worker.rs
@@ -372,6 +372,7 @@ mod tests {
             reason: "Working with publisher on research".to_string(),
             selected_skills: vec![],
             publisher_slug: publisher_slug.map(String::from),
+            reasoning_effort: None,
         }
     }
 

--- a/src-tauri/src/orchestrator/router.rs
+++ b/src-tauri/src/orchestrator/router.rs
@@ -65,6 +65,7 @@ pub fn route(
         reason,
         selected_skills,
         publisher_slug,
+        reasoning_effort: capabilities.reasoning_effort.clone(),
     }
 }
 
@@ -423,6 +424,7 @@ mod tests {
             tool_definitions: vec![],
             installed_skills: vec![],
             model_rankings: vec![],
+            reasoning_effort: None,
         }
     }
 
@@ -449,6 +451,7 @@ mod tests {
             tool_definitions: vec![],
             installed_skills: skills,
             model_rankings: vec![],
+            reasoning_effort: None,
         }
     }
 

--- a/src-tauri/src/orchestrator/types.rs
+++ b/src-tauri/src/orchestrator/types.rs
@@ -101,6 +101,9 @@ pub struct RoutingDecision {
     /// Publisher slug for McpPublisher worker (e.g. "firecrawl-serenai").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publisher_slug: Option<String>,
+    /// Reasoning effort level forwarded from the frontend.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -149,6 +152,10 @@ pub struct UserCapabilities {
     /// Empty means no data; router falls back to hardcoded preference lists.
     #[serde(default)]
     pub model_rankings: Vec<(String, f64)>,
+    /// Reasoning effort level for models that support extended thinking.
+    /// Values: "minimal", "low", "medium", "high", "xhigh". None = provider default.
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
 }
 
 /// Transition event emitted when the orchestrator switches models.
@@ -341,6 +348,7 @@ mod tests {
                 path: "/skills/prose/SKILL.md".to_string(),
             }],
             publisher_slug: None,
+            reasoning_effort: None,
         };
 
         let json = serde_json::to_string(&decision).unwrap();

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -34,7 +34,6 @@ import { pickAndReadAttachments } from "@/lib/images/attachments";
 import { isPaymentError } from "@/lib/payment-errors";
 import type { Attachment } from "@/lib/providers/types";
 import { escapeHtmlWithLinks } from "@/lib/render-markdown";
-import RenderMarkdownWorker from "@/workers/render-markdown.worker?worker";
 import { saveToSerenNotes } from "@/lib/save-to-notes";
 import { catalog, type Publisher } from "@/services/catalog";
 import {
@@ -58,11 +57,13 @@ import { openclawStore } from "@/stores/openclaw.store";
 import { providerStore } from "@/stores/provider.store";
 import { settingsStore } from "@/stores/settings.store";
 import type { ToolCallData, UnifiedMessage } from "@/types/conversation";
+import RenderMarkdownWorker from "@/workers/render-markdown.worker?worker";
 import { CompactedMessage } from "./CompactedMessage";
 import { ImageAttachmentBar } from "./ImageAttachmentBar";
 import { MessageImages } from "./MessageImages";
 import { ModelSelector } from "./ModelSelector";
 import { PublisherSuggestions } from "./PublisherSuggestions";
+import { ReasoningEffortSelector } from "./ReasoningEffortSelector";
 import { RerouteAnnouncement } from "./RerouteAnnouncement";
 import { RLMStepsBlock } from "./RLMStepsBlock";
 import { SatisfactionSignal } from "./SatisfactionSignal";
@@ -1550,6 +1551,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
               <div class="flex items-center gap-3">
                 <ModelSelector />
                 <ToolsetSelector />
+                <ReasoningEffortSelector />
                 <Show when={conversationStore.isLoading}>
                   <ThinkingStatus />
                 </Show>

--- a/src/components/chat/ReasoningEffortSelector.tsx
+++ b/src/components/chat/ReasoningEffortSelector.tsx
@@ -1,0 +1,126 @@
+// ABOUTME: Reasoning effort selector dropdown for models that support extended thinking.
+// ABOUTME: Allows users to choose reasoning depth per conversation (minimal to xhigh).
+
+import type { Component } from "solid-js";
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { chatStore } from "@/stores/chat.store";
+
+interface EffortOption {
+  id: string;
+  name: string;
+  description: string;
+}
+
+const EFFORT_OPTIONS: EffortOption[] = [
+  { id: "minimal", name: "Minimal", description: "Fastest, least reasoning" },
+  { id: "low", name: "Low", description: "Quick with light reasoning" },
+  { id: "medium", name: "Medium", description: "Balanced speed and depth" },
+  { id: "high", name: "High", description: "Thorough reasoning" },
+  { id: "xhigh", name: "Max", description: "Maximum depth, slowest" },
+];
+
+export const ReasoningEffortSelector: Component = () => {
+  const [isOpen, setIsOpen] = createSignal(false);
+  let containerRef: HTMLDivElement | undefined;
+
+  const activeEffort = () =>
+    EFFORT_OPTIONS.find((o) => o.id === chatStore.reasoningEffort) ?? null;
+
+  const handleSelect = (id: string | undefined) => {
+    chatStore.setReasoningEffort(id);
+    setIsOpen(false);
+  };
+
+  const handleDocumentClick = (event: MouseEvent) => {
+    if (!isOpen()) return;
+    if (
+      containerRef &&
+      event.target instanceof Node &&
+      !containerRef.contains(event.target)
+    ) {
+      setIsOpen(false);
+    }
+  };
+
+  onMount(() => {
+    document.addEventListener("click", handleDocumentClick);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener("click", handleDocumentClick);
+  });
+
+  return (
+    <div class="relative" ref={containerRef}>
+      <button
+        class="flex items-center gap-2 px-3 py-1.5 bg-popover border border-muted rounded-md text-sm text-foreground cursor-pointer transition-colors hover:border-muted-foreground/40"
+        onClick={() => setIsOpen(!isOpen())}
+        title="Set reasoning effort level for extended thinking models"
+      >
+        <span class="text-[14px]">🧠</span>
+        <span class="text-foreground max-w-[120px] overflow-hidden text-ellipsis whitespace-nowrap">
+          {activeEffort()?.name || "Auto"}
+        </span>
+        <span class="text-[10px] text-muted-foreground">
+          {isOpen() ? "▲" : "▼"}
+        </span>
+      </button>
+
+      <Show when={isOpen()}>
+        <div class="absolute bottom-[calc(100%+8px)] left-0 min-w-[220px] bg-surface-2 border border-surface-3 rounded-lg shadow-[0_8px_32px_rgba(0,0,0,0.5)] z-[1000] overflow-hidden">
+          {/* Header */}
+          <div class="px-3 py-2 bg-surface-3 border-b border-surface-3">
+            <span class="text-xs text-muted-foreground">Reasoning Effort</span>
+          </div>
+
+          {/* Options */}
+          <div class="max-h-[250px] overflow-y-auto py-1 bg-surface-2">
+            {/* Auto (default) option */}
+            <button
+              type="button"
+              class={`w-full flex items-center justify-between gap-2 px-3 py-2 bg-transparent border-none text-left text-[13px] cursor-pointer transition-colors hover:bg-border ${!activeEffort() ? "bg-primary/[0.12]" : ""}`}
+              onClick={() => handleSelect(undefined)}
+            >
+              <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                <span class="text-foreground font-medium">Auto</span>
+                <span class="text-[11px] text-muted-foreground">
+                  Provider decides reasoning depth
+                </span>
+              </div>
+              <Show when={!activeEffort()}>
+                <span class="text-success text-sm font-semibold">&#10003;</span>
+              </Show>
+            </button>
+
+            {/* Effort level options */}
+            <For each={EFFORT_OPTIONS}>
+              {(option) => (
+                <button
+                  type="button"
+                  class={`w-full flex items-center justify-between gap-2 px-3 py-2 bg-transparent border-none text-left text-[13px] cursor-pointer transition-colors hover:bg-border ${activeEffort()?.id === option.id ? "bg-primary/[0.12]" : ""}`}
+                  onClick={() => handleSelect(option.id)}
+                >
+                  <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                    <span class="text-foreground font-medium">
+                      {option.name}
+                    </span>
+                    <span class="text-[11px] text-muted-foreground">
+                      {option.description}
+                    </span>
+                  </div>
+                  <Show when={activeEffort()?.id === option.id}>
+                    <span class="text-success text-sm font-semibold">
+                      &#10003;
+                    </span>
+                  </Show>
+                </button>
+              )}
+            </For>
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default ReasoningEffortSelector;

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -89,6 +89,7 @@ interface UserCapabilities {
   available_tools: string[];
   tool_definitions: ToolDefinition[];
   installed_skills: SkillRef[];
+  reasoning_effort: string | null;
 }
 
 interface SkillRef {
@@ -689,5 +690,6 @@ function buildCapabilities(threadId: string | null): UserCapabilities {
       tags: s.tags ?? [],
       path: s.path,
     })),
+    reasoning_effort: chatStore.reasoningEffort ?? null,
   };
 }

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -45,6 +45,8 @@ export interface Conversation {
   selectedProvider: ProviderId | null;
   isArchived: boolean;
   compactedSummary?: CompactedSummary;
+  /** Reasoning effort level: "minimal" | "low" | "medium" | "high" | "xhigh". */
+  reasoningEffort?: string;
 }
 
 type MessagePatch = Partial<
@@ -183,6 +185,14 @@ export const chatStore = {
   get compactedSummary(): CompactedSummary | undefined {
     const active = this.activeConversation;
     return active?.compactedSummary;
+  },
+
+  /**
+   * Get the reasoning effort for the active conversation.
+   */
+  get reasoningEffort(): string | undefined {
+    const active = this.activeConversation;
+    return active?.reasoningEffort;
   },
 
   /**
@@ -382,6 +392,17 @@ export const chatStore = {
     if (activeId) {
       this.updateConversationModel(activeId, modelId);
     }
+  },
+
+  setReasoningEffort(effort: string | undefined) {
+    const conversationId = state.activeConversationId;
+    if (!conversationId) return;
+
+    setState("conversations", (convos) =>
+      convos.map((c) =>
+        c.id === conversationId ? { ...c, reasoningEffort: effort } : c,
+      ),
+    );
   },
 
   setLoading(isLoading: boolean) {


### PR DESCRIPTION
## Summary
- Adds a per-conversation reasoning effort dropdown (Auto/Minimal/Low/Medium/High/Max) to the chat status bar alongside Model and Toolset selectors
- Wires `reasoning_effort` through the full orchestrator pipeline: `chatStore` → `orchestrator.ts` (UserCapabilities) → Rust `router.rs` → `RoutingDecision` → `ChatModelWorker.build_request_body()` → Gateway API as `reasoning.effort` parameter
- Reasoning effort is preserved through automatic model reroutes since only `model_id` is mutated during failover

Closes #1088

## Test plan
- [ ] Select different reasoning effort levels and verify they appear in the dropdown
- [ ] Send a message and verify the `reasoning` field appears in the Gateway request body (check Rust logs)
- [ ] Verify switching conversations preserves per-conversation reasoning effort
- [ ] Verify "Auto" (default) omits the `reasoning` field from the request
- [ ] Verify existing tests pass: `cargo test --manifest-path src-tauri/Cargo.toml`

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com