### PR TITLE
fix: guard against stale turn/completed race and show elapsed time (#1090)

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -755,6 +755,19 @@ function handleNotification(emit, session, payload) {
 
     case "turn/completed": {
       const turn = params.turn ?? {};
+      const completedTurnId = turn.id ?? params.turnId;
+
+      // Ignore stale turn/completed from a previously cancelled turn.
+      // After cancellation, a delayed completion can race with a new prompt
+      // and resolve/reject the wrong currentPrompt.
+      if (
+        typeof completedTurnId === "string" &&
+        typeof session.activeTurnId === "string" &&
+        completedTurnId !== session.activeTurnId
+      ) {
+        return;
+      }
+
       session.status = turn.status === "failed" ? "error" : "ready";
       session.activeTurnId = null;
 
@@ -1134,21 +1147,24 @@ export function createProviderHandlers({ emit }) {
     if (!session) {
       return claudeRuntime.cancelPrompt({ sessionId });
     }
-    if (!session.activeTurnId) {
-      return;
-    }
+    if (session.activeTurnId) {
+      // Capture and clear activeTurnId before sending interrupt so a stale
+      // turn/completed from this turn cannot match a subsequently started turn.
+      const interruptTurnId = session.activeTurnId;
+      session.activeTurnId = null;
 
-    await sendRequest(
-      session,
-      "turn/interrupt",
-      {
-        threadId: session.agentSessionId,
-        turnId: session.activeTurnId,
-      },
-      10_000,
-    ).catch(() => {
-      // Best-effort interrupt only.
-    });
+      await sendRequest(
+        session,
+        "turn/interrupt",
+        {
+          threadId: session.agentSessionId,
+          turnId: interruptTurnId,
+        },
+        10_000,
+      ).catch(() => {
+        // Best-effort interrupt only.
+      });
+    }
 
     session.status = "ready";
     emit("provider://error", {

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -265,6 +265,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const hasSession = () => threadSession() !== null;
   const isReady = () => threadSession()?.info.status === "ready";
   const isPrompting = () => threadSession()?.info.status === "prompting";
+  const promptStartTime = () => threadSession()?.promptStartTime;
   const sessionError = () => threadSession()?.error ?? agentStore.error;
   const lockedAgentType = createMemo<AgentType>(() => {
     // Thread's declared agent type takes priority so the controls always
@@ -1423,7 +1424,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               }
             >
               <article class="px-5 py-4 border-b border-surface-2">
-                <ThinkingStatus />
+                <ThinkingStatus startTime={promptStartTime} />
               </article>
             </Show>
 
@@ -1739,7 +1740,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 <AgentModeSelector session={threadSession()} />
                 <AgentEffortSelector session={threadSession()} />
                 <Show when={isPrompting()}>
-                  <ThinkingStatus />
+                  <ThinkingStatus startTime={promptStartTime} />
                 </Show>
                 <Show when={messageQueue().length > 0}>
                   <span class="flex items-center gap-2 px-2 py-1 bg-surface-2 border border-border rounded text-xs text-muted-foreground">

--- a/src/components/chat/ThinkingStatus.tsx
+++ b/src/components/chat/ThinkingStatus.tsx
@@ -1,7 +1,13 @@
-// ABOUTME: Rotating thinking status indicator with varied words.
-// ABOUTME: Shows pulsing dot + cycling status text like Claude Code's thinking animation.
+// ABOUTME: Rotating thinking status indicator with elapsed time counter.
+// ABOUTME: Shows pulsing dots, cycling status text, and seconds elapsed since prompt started.
 
-import { createSignal, onCleanup, onMount } from "solid-js";
+import {
+  type Accessor,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
 
 const THINKING_WORDS = [
   "Thinking",
@@ -18,20 +24,42 @@ const THINKING_WORDS = [
 
 const ROTATION_INTERVAL_MS = 3000;
 
-export function ThinkingStatus() {
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes > 0) {
+    return `${minutes}:${String(seconds).padStart(2, "0")}`;
+  }
+  return `${seconds}s`;
+}
+
+export function ThinkingStatus(props: {
+  startTime?: Accessor<number | undefined>;
+}) {
   const [index, setIndex] = createSignal(
     Math.floor(Math.random() * THINKING_WORDS.length),
   );
+  const [elapsed, setElapsed] = createSignal(0);
 
-  let timer: ReturnType<typeof setInterval>;
+  let wordTimer: ReturnType<typeof setInterval>;
+  let tickTimer: ReturnType<typeof setInterval>;
 
   onMount(() => {
-    timer = setInterval(() => {
+    wordTimer = setInterval(() => {
       setIndex((prev) => (prev + 1) % THINKING_WORDS.length);
     }, ROTATION_INTERVAL_MS);
+
+    tickTimer = setInterval(() => {
+      const start = props.startTime?.();
+      setElapsed(start ? Date.now() - start : 0);
+    }, 1000);
   });
 
-  onCleanup(() => clearInterval(timer));
+  onCleanup(() => {
+    clearInterval(wordTimer);
+    clearInterval(tickTimer);
+  });
 
   return (
     <span class="inline-flex items-center gap-2 text-sm text-foreground">
@@ -41,6 +69,9 @@ export function ThinkingStatus() {
         <span class="inline-block w-[6px] h-[6px] rounded-full bg-primary thinking-dot thinking-dot-3" />
       </span>
       <span>{THINKING_WORDS[index()]}…</span>
+      <Show when={elapsed() >= 5000}>
+        <span class="text-muted-foreground">{formatElapsed(elapsed())}</span>
+      </Show>
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- Guard against stale `turn/completed` from cancelled Codex turns resolving/rejecting the wrong prompt by validating turn ID
- Clear `activeTurnId` in `cancelPrompt` before sending interrupt so stale completions cannot match a new turn
- Always emit cancel events even when `activeTurnId` is not yet set (cancel during `turn/start` window)
- Add elapsed time counter to `ThinkingStatus` so users see seconds ticking when the agent is processing but silent

## Test plan
- [ ] Cancel a Codex prompt mid-turn, then immediately send a new prompt — verify the new prompt completes correctly
- [ ] Cancel a Codex prompt before any tool calls appear, then re-prompt — verify cancel emits properly
- [ ] Observe the thinking indicator shows elapsed time after 5 seconds of waiting
- [ ] Verify SerenModels chat thinking indicator still works (no startTime passed, no timer shown)

Closes #1090

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com