### PR TITLE
fix: resolve claude binary path and handle spawn ENOENT gracefully

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1,13 +1,60 @@
 // ABOUTME: Browser-local Claude Code runtime backed by the local claude CLI.
 // ABOUTME: Manages long-lived stream-json sessions, permissions, and session listing without ACP.
 
-import { spawn, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
+
+/**
+ * Resolve the full path to the `claude` binary.
+ * GUI apps don't inherit shell profile PATH additions, so `which claude`
+ * and bare `spawn("claude")` may fail even when Claude Code is installed.
+ * Check well-known install locations before falling back to bare command name.
+ */
+function resolveClaudeBinary() {
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA ?? "";
+    if (appData) {
+      const candidate = path.join(appData, "Claude", "claude.exe");
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+    return "claude";
+  }
+
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, ".claude", "bin", "claude"),
+    path.join(home, ".local", "bin", "claude"),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Try PATH lookup (works when Rust side has extended PATH correctly)
+  try {
+    const resolved = execFileSync("which", ["claude"], {
+      encoding: "utf8",
+      timeout: 5_000,
+    }).trim();
+    if (resolved) {
+      return resolved;
+    }
+  } catch {
+    // which failed — fall through to bare command name
+  }
+
+  return "claude";
+}
 
 function isAuthError(message) {
   const lower = String(message).toLowerCase();
@@ -1122,8 +1169,9 @@ export function createClaudeRuntime({ emit }) {
     const sessionId = localSessionId ?? randomUUID();
     const remoteSessionId = resumeAgentSessionId ?? randomUUID();
     const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
+    const claudeBin = resolveClaudeBinary();
     const processHandle = spawn(
-      "claude",
+      claudeBin,
       buildClaudeArgs({
         sessionId: remoteSessionId,
         resumeSessionId: resumeAgentSessionId ?? null,
@@ -1141,6 +1189,22 @@ export function createClaudeRuntime({ emit }) {
         shell: process.platform === "win32",
       },
     );
+
+    // Catch spawn errors (e.g. ENOENT) to prevent crashing the provider runtime.
+    processHandle.on("error", (spawnError) => {
+      console.error(`[browser-local][claude] Spawn error: ${spawnError.message}`);
+      sessions.delete(sessionId);
+      emit("provider://error", {
+        sessionId,
+        error: spawnError.code === "ENOENT"
+          ? `Claude Code CLI not found at "${claudeBin}". Install it from https://claude.ai/download`
+          : `Failed to start Claude Code: ${spawnError.message}`,
+      });
+      emit("provider://session-status", {
+        sessionId,
+        status: "terminated",
+      });
+    });
 
     const session = createSessionRecord({
       sessionId,
@@ -1437,8 +1501,9 @@ export function createClaudeRuntime({ emit }) {
 
     const forkedAgentSessionId = randomUUID();
     const tempLocalSessionId = randomUUID();
+    const claudeBin = resolveClaudeBinary();
     const processHandle = spawn(
-      "claude",
+      claudeBin,
       buildClaudeArgs({
         sessionId: forkedAgentSessionId,
         resumeSessionId: sourceAgentSessionId,
@@ -1456,6 +1521,11 @@ export function createClaudeRuntime({ emit }) {
         shell: process.platform === "win32",
       },
     );
+
+    // Catch spawn errors to prevent crashing the provider runtime.
+    processHandle.on("error", (spawnError) => {
+      console.error(`[browser-local][claude] Fork spawn error: ${spawnError.message}`);
+    });
 
     const tempSession = createSessionRecord({
       sessionId: tempLocalSessionId,

--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -234,24 +234,44 @@ fn extend_path_with_common_bins(current_path: &str, path_separator: &str) -> Str
 
         let mut seen: HashSet<String> = entries.iter().cloned().collect();
 
+        // Build common bins list including user-local tool directories.
+        // GUI apps don't source shell profiles so ~/.claude/bin and ~/.local/bin
+        // (where native installers place CLIs) are typically missing from PATH.
+        let home = std::env::var("HOME").unwrap_or_default();
+        let mut common_bins: Vec<String> = Vec::new();
+
+        if !home.is_empty() {
+            common_bins.push(format!("{}/.claude/bin", home));
+            common_bins.push(format!("{}/.local/bin", home));
+        }
+
         #[cfg(target_os = "macos")]
-        let common_bins: [&str; 6] = [
-            "/usr/local/bin",
-            "/opt/homebrew/bin",
-            "/usr/bin",
-            "/bin",
-            "/usr/sbin",
-            "/sbin",
-        ];
+        {
+            common_bins.extend([
+                "/usr/local/bin".to_string(),
+                "/opt/homebrew/bin".to_string(),
+                "/usr/bin".to_string(),
+                "/bin".to_string(),
+                "/usr/sbin".to_string(),
+                "/sbin".to_string(),
+            ]);
+        }
 
         #[cfg(target_os = "linux")]
-        let common_bins: [&str; 5] = ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+        {
+            common_bins.extend([
+                "/usr/local/bin".to_string(),
+                "/usr/bin".to_string(),
+                "/bin".to_string(),
+                "/usr/sbin".to_string(),
+                "/sbin".to_string(),
+            ]);
+        }
 
         for bin in common_bins {
-            if !seen.contains(bin) {
-                let bin = bin.to_string();
-                entries.push(bin.clone());
-                seen.insert(bin);
+            if !seen.contains(&bin) {
+                seen.insert(bin.clone());
+                entries.push(bin);
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #1094

- Add ~/.claude/bin and ~/.local/bin to the embedded runtime PATH in Rust. GUI apps do not source shell profiles, so these directories (where native installers place CLIs) were missing
- Add resolveClaudeBinary() in claude-runtime.mjs to check well-known install locations before falling back to bare claude command
- Add error event handlers on spawned claude processes to prevent unhandled ENOENT from crashing the entire provider runtime (which kills ALL active sessions including Codex)

## Test plan

- [ ] Launch Claude Agent on macOS - should find ~/.claude/bin/claude and spawn successfully
- [ ] If claude is not installed, should show a helpful error message instead of crashing the runtime
- [ ] Active Codex session should not be disconnected by a failed Claude Agent spawn
- [ ] Verify Windows path resolution works
- [ ] Verify Linux ~/.local/bin/claude resolution works

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com