### PR TITLE
fix: discard skill context messages from agent chat display

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3346,6 +3346,17 @@ Summary:`;
 
     // Finalize assistant content if any
     if (session.streamingContent) {
+      // Skill context is injected into every prompt as additional context and
+      // echoed back by the provider as an assistant message during session
+      // replay. Discard these — they are system prompts, not conversation
+      // content, and should never appear as visible chat messages.
+      if (session.streamingContent.trimStart().startsWith("## Skill:")) {
+        setState("sessions", sessionId, "streamingContent", "");
+        setState("sessions", sessionId, "streamingContentTimestamp", undefined);
+        setState("sessions", sessionId, "promptStartTime", undefined);
+        return;
+      }
+
       // Calculate duration if we have a start time
       const duration = session.promptStartTime
         ? Date.now() - session.promptStartTime


### PR DESCRIPTION
Fixes #1100. References #1101.

**Problem:** Skill system prompts are injected as context on every agent turn and the Codex provider echoes them back as assistant messages during session replay. These stored and displayed as visible chat messages, making the bottom of the chat look like corrupted garbage (a full skill catalog dump followed by the user's last message).

**Fix:** In `finalizeStreamingContent`, discard any streamed content that starts with `## Skill:` — the standard header for all injected skill context — rather than storing it as a visible message.

**Note:** #1101 (skill context injected per-turn instead of once as system prompt) is the root cause that bloats session history. That requires a separate investigation into the provider layer and is tracked separately.

## Test plan
- [ ] Enable a skill on a Codex agent thread, send messages — skill content should NOT appear as a visible chat message
- [ ] Resume a session that previously had skill context stored — skill messages should not appear on replay
- [ ] Verify legitimate agent responses that happen to discuss skills still render correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com