### PR TITLE
fix: correct skill context detection and fix file link editor opening

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1247,6 +1247,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         ref={messagesRef}
         onScroll={handleMessagesScroll}
         class="flex-1 min-h-0 overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-surface-3 [&::-webkit-scrollbar-thumb]:rounded"
+        onContextMenu={(e) => {
+          if ((e.target as HTMLElement).closest(".external-link")) {
+            e.preventDefault();
+          }
+        }}
         onClick={(e) => {
           const target = e.target as HTMLElement;
           const link = target.closest(".external-link") as HTMLAnchorElement;

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -263,6 +263,14 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     }
   });
 
+  // Suppress the native browser context menu on file links so "Open Link"
+  // doesn't navigate the WebView. The JS click handler opens the editor instead.
+  const handleContextMenu = (event: MouseEvent) => {
+    if ((event.target as HTMLElement).closest(".external-link")) {
+      event.preventDefault();
+    }
+  };
+
   // Click handler for copy buttons and external links (event delegation)
   const handleCopyClick = (event: MouseEvent) => {
     const target = event.target as HTMLElement;
@@ -287,9 +295,15 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
               : root
                 ? `${root.replace(/\/$/, "")}/${url}`
                 : url;
-          openFileInTab(resolved).catch((err) =>
-            console.warn("[ChatContent] Failed to open file:", resolved, err),
-          );
+          openFileInTab(resolved)
+            .then(() => {
+              window.dispatchEvent(
+                new CustomEvent("seren:open-panel", { detail: "editor" }),
+              );
+            })
+            .catch((err) =>
+              console.warn("[ChatContent] Failed to open file:", resolved, err),
+            );
         } else {
           openExternalLink(url);
         }
@@ -345,6 +359,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     // Register copy button handler on document for better reliability
     // Using document-level delegation ensures copy buttons work even if messagesRef timing is off
     document.addEventListener("click", handleCopyClick);
+    document.addEventListener("contextmenu", handleContextMenu);
 
     // Listen for slash command events
     window.addEventListener("seren:pick-images", handlePickImages);
@@ -389,6 +404,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
 
   onCleanup(() => {
     document.removeEventListener("click", handleCopyClick);
+    document.removeEventListener("contextmenu", handleContextMenu);
     window.removeEventListener(
       "seren:pick-images",
       handlePickImages as EventListener,

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3350,7 +3350,7 @@ Summary:`;
       // echoed back by the provider as an assistant message during session
       // replay. Discard these — they are system prompts, not conversation
       // content, and should never appear as visible chat messages.
-      if (session.streamingContent.trimStart().startsWith("## Skill:")) {
+      if (session.streamingContent.trimStart().startsWith("# Active Skills")) {
         setState("sessions", sessionId, "streamingContent", "");
         setState("sessions", sessionId, "streamingContentTimestamp", undefined);
         setState("sessions", sessionId, "promptStartTime", undefined);


### PR DESCRIPTION
## Summary

- Fixes #1103: Skill context filter used wrong header (## Skill: vs actual # Active Skills), so skill content continued appearing as visible chat messages after session replay
- Fixes #1104: ChatContent.tsx was missing seren:open-panel dispatch after opening a file tab, and both components lacked onContextMenu suppression on file links

## Changes

**src/stores/agent.store.ts** — Change detection from startsWith('## Skill:') to startsWith('# Active Skills')

**src/components/chat/ChatContent.tsx** — Add seren:open-panel dispatch after openFileInTab() + contextmenu suppression on .external-link elements

**src/components/chat/AgentChat.tsx** — Add onContextMenu suppression on the messages div for .external-link elements

## Test plan

- [ ] Start Codex session with a skill active, restart app — skill context should NOT appear as a visible message
- [ ] In standard chat, click a file link — editor panel should open
- [ ] Right-click a file link — native context menu should NOT appear

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com