### PR TITLE
feat: animate Reconnecting button with spinner during thread reattach

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1364,13 +1364,33 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                   </Show>
                   <button
                     type="button"
-                    class="px-4 py-2 bg-success text-white rounded-md text-sm font-medium hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="inline-flex items-center gap-2 px-4 py-2 bg-success text-white rounded-md text-sm font-medium hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     onClick={retrySessionConnection}
                     disabled={agentStore.isLoading || !hasFolderOpen()}
                   >
-                    {agentStore.isLoading
-                      ? "Reconnecting..."
-                      : "Retry Connection"}
+                    <Show when={agentStore.isLoading}>
+                      <svg
+                        class="animate-spin w-4 h-4 shrink-0"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        aria-hidden="true"
+                      >
+                        <circle
+                          class="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          stroke-width="4"
+                        />
+                        <path
+                          class="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                        />
+                      </svg>
+                    </Show>
+                    {agentStore.isLoading ? "Reconnecting..." : "Retry Connection"}
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Closes #1107. When the app is reconnecting to a previously active agent thread, the button now shows a spinning indicator alongside 'Reconnecting...' so users can see the app is actively working and not frozen.

## Changes

**AgentChat.tsx** — Add a conditionally rendered SVG spinner (animate-spin) inside the Reconnecting button when agentStore.isLoading is true. Button layout switched to inline-flex to align spinner and text.

## Test plan

- [ ] Open a Codex thread, close and reopen the app — verify the Reconnecting button shows a spinner while reattaching
- [ ] After reconnection completes, button should revert to 'Retry Connection' (no spinner)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com