### PR TITLE
fix: restore agent approval modal by syncing permission mode with Claude CLI

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1156,6 +1156,20 @@ export function createClaudeRuntime({ emit }) {
     };
   }
 
+  function claudeModeFromApprovalPolicy(approvalPolicy) {
+    switch (approvalPolicy) {
+      case "on-request":
+      case "untrusted":
+        return "default";
+      case "on-failure":
+        return "acceptEdits";
+      case "never":
+        return "bypassPermissions";
+      default:
+        return "default";
+    }
+  }
+
   async function spawnSession(params) {
     const {
       cwd,
@@ -1163,6 +1177,7 @@ export function createClaudeRuntime({ emit }) {
       resumeAgentSessionId,
       apiKey,
       mcpServers,
+      approvalPolicy,
       timeoutSecs,
     } = params;
 
@@ -1206,12 +1221,14 @@ export function createClaudeRuntime({ emit }) {
       });
     });
 
+    const resolvedMode = claudeModeFromApprovalPolicy(approvalPolicy);
     const session = createSessionRecord({
       sessionId,
       cwd,
       processHandle,
       timeoutSecs,
       agentSessionId: remoteSessionId,
+      currentModeId: resolvedMode,
       mcpConfigJson: mcpConfig.claudeMcpConfigJson,
       spawnEnv: mcpConfig.childEnv,
     });
@@ -1236,6 +1253,21 @@ export function createClaudeRuntime({ emit }) {
           session.availableModelRecords,
         ) ??
         session.currentModelId;
+
+      // Sync the permission mode with Claude CLI so it sends control_request
+      // messages for tool approval instead of auto-approving everything.
+      if (resolvedMode !== "bypassPermissions") {
+        await sendControlRequest(
+          session,
+          { subtype: "set_permission_mode", mode: resolvedMode },
+          10_000,
+        ).catch((err) => {
+          console.warn(
+            `[browser-local][claude] Failed to set permission mode "${resolvedMode}":`,
+            err.message,
+          );
+        });
+      }
 
       if (resumeAgentSessionId) {
         await replayClaudeHistoryBestEffort(


### PR DESCRIPTION
## Summary
- Destructure `approvalPolicy` from spawn params in `claude-runtime.mjs`
- Map settings values (`on-request`/`untrusted` -> `default`, `on-failure` -> `acceptEdits`, `never` -> `bypassPermissions`)
- Send `set_permission_mode` control request after initialization so Claude CLI asks for approval via `control_request` messages instead of auto-approving

Without this, Claude CLI in `stream-json` mode never sends permission requests and tools execute without user approval.

Closes #1112

## Test plan
- [ ] Set agent approval policy to "On Request" in Settings
- [ ] Send a prompt that triggers tool use (e.g. bash command)
- [ ] Verify approval dialog appears with Allow once / Allow session / Deny buttons
- [ ] Set policy to "Never" and verify tools auto-execute without dialog

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com