### PR TITLE
fix: use acceptEdits mode to prevent seatbelt sandbox from blocking bash approval

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1160,13 +1160,12 @@ export function createClaudeRuntime({ emit }) {
     switch (approvalPolicy) {
       case "on-request":
       case "untrusted":
-        return "default";
       case "on-failure":
         return "acceptEdits";
       case "never":
         return "bypassPermissions";
       default:
-        return "default";
+        return "acceptEdits";
     }
   }
 


### PR DESCRIPTION
## Summary

- set_permission_mode default activates Claude Code macOS seatbelt sandbox internally, intercepting bash before control_request is sent to parent — so the approval dialog never fires
- Maps all approval-requiring policies (on-request, untrusted, on-failure) to acceptEdits instead of default
- In acceptEdits mode, the CLI sends control_request for non-edit tools (e.g. Bash) without engaging the seatbelt, so the approval dialog shows correctly

Fixes #1116 (regression from #1112)

## Test plan

- Set approval policy to on-request (default)
- Run an agent that invokes a Bash command
- Verify the approval dialog appears inline in chat
- Verify approving/denying works as expected
- Verify compound bash commands show the approval dialog instead of sandbox blocking message

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com