### PR TITLE
fix: retry Claude initialize timeout during session spawn (#1118)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -511,7 +511,11 @@ function isRetryableClaudeInitError(message: string): boolean {
   return (
     lower.includes("server shut down unexpectedly") ||
     lower.includes("signal: 9") ||
-    lower.includes("sigkill")
+    lower.includes("sigkill") ||
+    // Claude MCP initialize handshake can time out under load (another session
+    // active, slow startup, machine pressure). This is transient — retrying
+    // with backoff succeeds without any user intervention needed.
+    lower.includes("timed out waiting for claude control request initialize")
   );
 }
 
@@ -3376,8 +3380,9 @@ Summary:`;
       // calls: the first chunk starts with '# Active Skills' (caught here), but
       // subsequent chunks of the same block start mid-content. The
       // isSkippingSkillContext flag ensures those continuations are also dropped.
-      const isSkillContextStart =
-        session.streamingContent.trimStart().startsWith("# Active Skills");
+      const isSkillContextStart = session.streamingContent
+        .trimStart()
+        .startsWith("# Active Skills");
       if (isSkillContextStart || session.isSkippingSkillContext) {
         if (isSkillContextStart) {
           setState("sessions", sessionId, "isSkippingSkillContext", true);


### PR DESCRIPTION
## Summary

- Add `"timed out waiting for claude control request initialize"` to `isRetryableClaudeInitError` so `spawnSession` retries with backoff instead of failing immediately
- Pre-existing Biome formatter fix on adjacent line

The Claude MCP initialize handshake times out when a second session is spawned while another is active, or under machine load. Previously this hit none of the retry patterns in `isRetryableClaudeInitError`, so `spawnSession` threw immediately. `resumeAgentConversation` then fell back to a fresh session — which also timed out — forcing the user to retry manually a third time before the session finally started.

With this fix, `spawnSession` retries up to `MAX_CLAUDE_INIT_RETRIES` (3×) with increasing backoff, exactly as it already does for SIGKILL/crash scenarios.

## Test plan

- [ ] Open a thread that causes a Claude session to spawn while another thread is actively prompting
- [ ] Confirm no error banner appears — session starts silently after a brief delay
- [ ] Confirm single-session spawns are unaffected

Fixes #1118

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
