### PR TITLE
fix: thread/resume timeout falls back to thread/start

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -532,7 +532,8 @@ function isRecoverableResumeError(message) {
     lower.includes("missing thread") ||
     lower.includes("unknown thread") ||
     lower.includes("does not exist") ||
-    lower.includes("no rollout")
+    lower.includes("no rollout") ||
+    lower.includes("timed out")
   );
 }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1141,7 +1141,7 @@ export const agentStore = {
       } catch (raceError) {
         const message =
           raceError instanceof Error ? raceError.message : String(raceError);
-        if (message.includes("timed out")) {
+        if (message.toLowerCase().includes("timed out")) {
           console.warn(
             "[AgentStore] Timeout waiting for ready, proceeding anyway",
           );


### PR DESCRIPTION
## Summary

- Add `lower.includes("timed out")` to `isRecoverableResumeError` in `bin/browser-local/providers.mjs` so a timed-out `thread/resume` call falls back to `thread/start` instead of throwing and failing the entire spawn
- Fix case-sensitive `message.includes("timed out")` check in `spawnSession` readyPromise catch to use `toLowerCase()` so capital-T timeout messages are treated as "proceed anyway" rather than initFailure

## Test plan

- [ ] Resume a Codex conversation while machine is under load; session should start (possibly as a fresh thread) instead of failing with "Timed out waiting for thread/resume."
- [ ] Verify Claude resume flow is unaffected

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
