### PR TITLE
fix: prevent send button from getting stuck disabled when input signal is undefined

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -212,7 +212,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       setInput(detail);
       inputRef?.focus();
     } else if (detail && typeof detail === "object") {
-      setInput(detail.text);
+      setInput(detail.text ?? "");
       inputRef?.focus();
 
       // Auto-send if requested (e.g., from skill click)
@@ -871,7 +871,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         }
         const newIndex = Math.min(historyIndex() + 1, history.length - 1);
         setHistoryIndex(newIndex);
-        setInput(history[newIndex]);
+        setInput(history[newIndex] ?? "");
         queueMicrotask(() => {
           textarea.setSelectionRange(
             textarea.value.length,
@@ -892,7 +892,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           setInput(savedInput());
           setSavedInput("");
         } else {
-          setInput(history[newIndex]);
+          setInput(history[newIndex] ?? "");
         }
         queueMicrotask(() => {
           textarea.setSelectionRange(
@@ -1741,7 +1741,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             />
             <div class="relative">
               <SlashCommandPopup
-                input={input()}
+                input={input() ?? ""}
                 panel="agent"
                 selectedIndex={commandPopupIndex()}
                 onSelect={(cmd) => {
@@ -1756,7 +1756,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               />
               <ResizableTextarea
                 ref={(el) => (inputRef = el)}
-                value={input()}
+                value={input() ?? ""}
                 placeholder={
                   isPrompting()
                     ? "Type to queue message..."
@@ -1822,7 +1822,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                       type="submit"
                       class="px-4 py-1.5 bg-success text-white rounded-md text-[13px] font-medium hover:bg-emerald-700 transition-colors disabled:bg-surface-2 disabled:text-muted-foreground disabled:cursor-not-allowed"
                       disabled={
-                        !hasSession() || !input().trim() || isProcessingDocs()
+                        !hasSession() ||
+                        !(input() ?? "").trim() ||
+                        isProcessingDocs()
                       }
                     >
                       Send

--- a/src/components/chat/SlashCommandPopup.tsx
+++ b/src/components/chat/SlashCommandPopup.tsx
@@ -17,7 +17,7 @@ export function SlashCommandPopup(props: SlashCommandPopupProps) {
   const matches = () => {
     const result = getCompletions(props.input, props.panel);
     // Debug logging to trace slash command matching
-    if (props.input.startsWith("/")) {
+    if (props.input?.startsWith("/")) {
       console.log(
         "[SlashCommandPopup] Input:",
         props.input,


### PR DESCRIPTION
## Summary

- Adds `?? ""` fallbacks at all reactive access points where `input()` signal could be `undefined` in `AgentChat.tsx`
- Fixes `setInput` callers that pass `undefined` via ArrowUp/ArrowDown history navigation and `seren:set-chat-input` event
- Adds optional chaining in `SlashCommandPopup.tsx` to guard `props.input?.startsWith("/")`

## Root Cause

`input()` signal (`createSignal<string>("")`) could be set to `undefined` when:
1. `history[newIndex]` is out of bounds during keyboard navigation
2. `detail.text` is `undefined` in the `seren:set-chat-input` event handler

When a SolidJS reactive computation throws a `TypeError` (e.g. `undefined is not an object (evaluating 'n.trim')`), SolidJS removes it from the reactive graph permanently — leaving `disabled` stuck at `true` for the rest of the session.

## Test plan

- [ ] Open agent chat, use ArrowUp/ArrowDown to navigate input history, verify send button remains enabled
- [ ] Send a message and confirm send button is not stuck after receiving response
- [ ] Type "/" and verify slash command popup appears without errors in console

Closes #1125

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
