### PR TITLE
fix: always send set_permission_mode to Claude CLI including bypassPermissions

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1253,20 +1253,20 @@ export function createClaudeRuntime({ emit }) {
         ) ??
         session.currentModelId;
 
-      // Sync the permission mode with Claude CLI so it sends control_request
-      // messages for tool approval instead of auto-approving everything.
-      if (resolvedMode !== "bypassPermissions") {
-        await sendControlRequest(
-          session,
-          { subtype: "set_permission_mode", mode: resolvedMode },
-          10_000,
-        ).catch((err) => {
-          console.warn(
-            `[browser-local][claude] Failed to set permission mode "${resolvedMode}":`,
-            err.message,
-          );
-        });
-      }
+      // Sync the permission mode with Claude CLI. This must be sent for ALL
+      // modes including bypassPermissions — without it Claude CLI stays in
+      // default mode with its seatbelt active, which blocks writes outside cwd
+      // and never sends control_request, so our permission dialog never fires.
+      await sendControlRequest(
+        session,
+        { subtype: "set_permission_mode", mode: resolvedMode },
+        10_000,
+      ).catch((err) => {
+        console.warn(
+          `[browser-local][claude] Failed to set permission mode "${resolvedMode}":`,
+          err.message,
+        );
+      });
 
       if (resumeAgentSessionId) {
         await replayClaudeHistoryBestEffort(


### PR DESCRIPTION
## Summary

- Removes the `if (resolvedMode !== "bypassPermissions")` guard around the `set_permission_mode` control request after session init
- Now `set_permission_mode` is always sent to Claude CLI, for every mode including `bypassPermissions`

## Root Cause

Claude CLI starts in **default mode with seatbelt active** regardless of what our app wants. Without sending `set_permission_mode`, the seatbelt:
- Blocks writes outside the cwd (e.g. `/tmp/`) — Claude CLI outputs "you haven't granted it yet" in response text and never sends `control_request` to our app
- Means `handlePermissionRequest` is never called → no `permission-request` event → no dialog

PR #1113 fixed this for non-bypass modes but explicitly skipped `bypassPermissions`, assuming Claude CLI would auto-approve by default. It doesn't — it sandboxes.

## Test plan

- [ ] Set Bypass Permissions in agent footer, run a skill that writes to `/tmp/` — verify it succeeds without "you haven't granted it yet"
- [ ] Set On Request mode, run a Bash command — verify the inline permission dialog appears
- [ ] Approve the dialog and verify the command runs
- [ ] Deny the dialog and verify the command is rejected

Closes #1127

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
