### PR TITLE
feat: highlight active setting in Settings sidebar nav

### DIFF
--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -156,10 +156,10 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
             {(section) => (
               <button
                 type="button"
-                class={`flex items-center gap-2.5 px-3 py-2.5 bg-transparent border-none rounded-md cursor-pointer text-[0.9rem] text-left transition-all duration-150 ${
+                class={`flex items-center gap-2.5 px-3 py-2.5 border-none rounded-md cursor-pointer text-[0.9rem] text-left transition-all duration-150 ${
                   activeSection() === section.id
                     ? "bg-accent text-white"
-                    : "text-muted-foreground hover:bg-border hover:text-foreground"
+                    : "bg-transparent text-muted-foreground hover:bg-border hover:text-foreground"
                 }`}
                 onClick={() => setActiveSection(section.id)}
               >


### PR DESCRIPTION
## Summary

- Nav buttons had bg-transparent as a permanent base class alongside the conditional bg-accent, causing Tailwind CSS ordering to override the active background color
- Moved bg-transparent into the inactive branch of the conditional so only one background class applies at a time
- Active items now correctly render with bg-accent (blue highlight + white text)

Fixes #1129

## Test plan

- Open Settings
- Click each nav item (Window, Agent, AI Providers, etc.)
- Verify the clicked item shows a blue highlight and white text
- Verify switching between items correctly moves the highlight

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com