### PR TITLE
feat: periodically re-check daily SerenBucks claim eligibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import {
   checkDailyClaim,
   resetWalletState,
   startAutoRefresh,
+  startDailyClaimPolling,
   stopAutoRefresh,
 } from "@/stores/wallet.store";
 import "./styles.css";
@@ -176,6 +177,7 @@ function App() {
         // Store cleanup to prevent effect accumulation
         cleanupAutoTopUp = initAutoTopUp();
         checkDailyClaim();
+        startDailyClaimPolling();
         // Push any locally-cached memories that failed to reach cloud (e.g. cold start)
         void syncMemories();
       });

--- a/src/stores/wallet.store.ts
+++ b/src/stores/wallet.store.ts
@@ -37,6 +37,8 @@ interface WalletState {
   dailyClaimDismissed: boolean;
   /** Whether daily claim check is in progress */
   dailyClaimLoading: boolean;
+  /** Timer for periodic daily claim eligibility re-checks */
+  dailyClaimTimerId: ReturnType<typeof setInterval> | null;
 }
 
 /**
@@ -55,12 +57,16 @@ const initialState: WalletState = {
   dailyClaim: null,
   dailyClaimDismissed: false,
   dailyClaimLoading: false,
+  dailyClaimTimerId: null,
 };
 
 const [walletState, setWalletState] = createStore<WalletState>(initialState);
 
 // Refresh interval in milliseconds (60 seconds)
 const REFRESH_INTERVAL = 60_000;
+
+// Daily claim re-check interval (30 minutes)
+const DAILY_CLAIM_POLL_INTERVAL = 30 * 60 * 1_000;
 
 // Lock to prevent duplicate top-ups
 let topUpInProgress = false;
@@ -264,10 +270,46 @@ function dismissDailyClaim(): void {
 }
 
 /**
+ * Start periodic re-checking of daily claim eligibility.
+ * Surfaces the claim popup for long-running sessions that span midnight UTC.
+ */
+function startDailyClaimPolling(): void {
+  if (walletState.dailyClaimTimerId) return;
+
+  const timerId = setInterval(async () => {
+    const wasPreviouslyEligible = walletState.dailyClaim?.can_claim ?? false;
+    try {
+      const eligibility = await fetchDailyEligibility();
+      setWalletState("dailyClaim", eligibility);
+      // New eligibility appeared — reset dismiss so popup re-surfaces
+      if (!wasPreviouslyEligible && eligibility.can_claim) {
+        setWalletState("dailyClaimDismissed", false);
+      }
+    } catch {
+      // Silently ignore — don't clear existing state on transient errors
+    }
+  }, DAILY_CLAIM_POLL_INTERVAL);
+
+  setWalletState("dailyClaimTimerId", timerId);
+}
+
+/**
+ * Stop periodic daily claim eligibility re-checks.
+ */
+function stopDailyClaimPolling(): void {
+  const timerId = walletState.dailyClaimTimerId;
+  if (timerId) {
+    clearInterval(timerId);
+  }
+  setWalletState("dailyClaimTimerId", null);
+}
+
+/**
  * Reset wallet state (e.g., on logout).
  */
 function resetWalletState(): void {
   stopAutoRefresh();
+  stopDailyClaimPolling();
   setWalletState(initialState);
   topUpInProgress = false;
   consecutiveFailures = 0;
@@ -353,5 +395,7 @@ export {
   checkDailyClaim,
   claimDaily,
   dismissDailyClaim,
+  startDailyClaimPolling,
+  stopDailyClaimPolling,
   updateBalanceFromError,
 };


### PR DESCRIPTION
## Summary

- Adds a 30-minute polling interval to re-check daily claim eligibility from the API
- Long-running sessions that span midnight UTC now surface the claim popup without requiring an app restart
- When eligibility transitions from false to true, the dismissed state resets so the popup re-appears
- Timer cleaned up on logout via resetWalletState()

Fixes #1133

## Test plan

- Keep app open past midnight UTC (or mock the API to return can_claim: true after 30 min)
- Verify the DailyClaimPopup re-appears without restarting the app
- Verify dismissing the popup works, and it re-surfaces on the next eligibility transition
- Verify logout cleans up the timer (no console errors after logout)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com