### PR TITLE
chore: upgrade rmcp from 0.17 to 1.2.0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5348,9 +5348,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.17.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0ce46f9101dc911f07e1468084c057839d15b08040d110820c5513312ef56a"
+checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5375,9 +5375,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.17.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abad6f5f46e220e3bda2fc90fd1ad64c1c2a2bd716d52c845eb5c9c64cda7542"
+checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,7 +57,7 @@ base64 = "0.22"
 libc = "0.2"
 reqwest = { version = "0.13", features = ["json", "stream"] }
 seren-memory-sdk = "0.1"
-rmcp = { version = "0.17", features = [
+rmcp = { version = "1.2", features = [
     "client",
     "transport-io",                           # stdio for local MCP servers
     "transport-child-process",                # spawn local MCP processes

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -773,12 +773,10 @@ pub async fn mcp_call_tool_http(
         .ok_or_else(|| format!("Server '{}' not connected", server_name))?;
 
     let result = client
-        .call_tool(rmcp::model::CallToolRequestParams {
-            name: tool_name.into(),
-            arguments: Some(serde_json::from_value(arguments).unwrap_or_default()),
-            meta: None,
-            task: None,
-        })
+        .call_tool(
+            rmcp::model::CallToolRequestParams::new(tool_name)
+                .with_arguments(serde_json::from_value(arguments).unwrap_or_default()),
+        )
         .await
         .map_err(|e| format!("Failed to call tool: {}", e))?;
 


### PR DESCRIPTION
## Summary

- Upgrade rmcp (MCP Rust SDK) from 0.17.0 to 1.2.0 (first stable release)
- Only code change: CallToolRequestParams is now #[non_exhaustive], switched to builder API
- cargo check passes cleanly

Supersedes dependabot PR #1139
Fixes #1147

## Benefits from 1.2.0

- Handle ping requests before initialize handshake
- Deserialize notifications without params field
- OAuth refresh token scope improvements
- Transparent session re-init on HTTP 404
- Missing constructors for non-exhaustive model types

## Test plan

- cargo check passes with zero errors
- All pre-existing warnings are unchanged
- Verify MCP gateway connection works (mcp.serendb.com)
- Verify local MCP server connections work (stdio transport unchanged)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com