### PR TITLE
fix: prevent isInstalled() from falsely matching stale skills

### DIFF
--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -182,12 +182,22 @@ export const skillsStore = {
 
   /**
    * Check if a skill is installed.
+   * A slug match alone is not sufficient when the installed skill's dirName
+   * differs from its slug and has no sync state — that indicates a stale
+   * skill whose name-derived slug happens to collide with the repo skill.
    */
   isInstalled(skillId: string): boolean {
-    // Check by slug since installed skills have different IDs
     const skill = state.available.find((s) => s.id === skillId);
     if (!skill) return false;
-    return state.installed.some((s) => s.slug === skill.slug);
+    return state.installed.some((s) => {
+      if (s.slug !== skill.slug) return false;
+      // dirName matches slug — genuine install
+      if (s.dirName === s.slug) return true;
+      // dirName differs but has upstream sync state linking to this source — genuine install
+      if (s.syncState && s.upstreamSourceUrl) return true;
+      // dirName differs, no sync state — stale skill with coincidental slug collision
+      return false;
+    });
   },
 
   /**


### PR DESCRIPTION
## Summary

- `isInstalled()` only compared slugs, causing false positives when a stale local skill's name-derived slug collided with a new repo skill's slug
- Example: old directory `polymarket-trader/` with `name: Polymarket Bot` resolved to slug `polymarket-bot`, blocking install of the new `polymarket/bot` repo skill
- Now requires either dirName == slug (genuine flat install) or sync state with upstream URL (genuine repo install) to count as installed
- A slug match with mismatched dirName and no sync state is treated as a stale collision, allowing the new skill to be installed

Fixes #1151

## Test plan

- Have a stale skill directory (e.g. `polymarket-trader/`) with a SKILL.md name that derives a different slug (`polymarket-bot`)
- Open Skills Browser — the repo skill `polymarket/bot` should show as NOT installed (Install button visible)
- Install the new skill — creates `polymarket-bot/` directory correctly
- Skills with matching dirName/slug should still show as installed

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com