### PR TITLE
fix: backfill sync state for skills installed before upstream sync feature

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -799,6 +799,7 @@ pub fn run() {
             skills::read_skill_content,
             skills::read_skill_file,
             skills::read_skill_sync_state,
+            skills::write_skill_sync_state,
             skills::resolve_skill_path,
             skills::create_skill_folder,
             // Orchestrator commands

--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -956,8 +956,8 @@ pub fn read_skill_sync_state(skills_dir: String, slug: String) -> Result<Option<
 }
 
 /// Persist sync state metadata for a skill.
-#[cfg(test)]
-fn write_skill_sync_state(
+#[tauri::command]
+pub fn write_skill_sync_state(
     skills_dir: String,
     slug: String,
     state_json: String,

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1352,4 +1352,67 @@ export const skills = {
     }
     return Array.from(tagSet).sort();
   },
+
+  /**
+   * Backfill sync state for installed skills that were installed before the
+   * sync feature existed (pre-v2.3.16). Matches installed skills missing
+   * sync state to available repo skills by slug, then writes a minimal
+   * .seren-sync.json so the upstream refresh flow can detect updates.
+   */
+  async backfillSyncState(
+    installed: InstalledSkill[],
+    available: Skill[],
+  ): Promise<number> {
+    if (!isTauriRuntime()) return 0;
+
+    const repoSkillsBySlug = new Map<string, Skill>();
+    for (const skill of available) {
+      if (skill.source === "serenorg" && skill.sourceUrl) {
+        repoSkillsBySlug.set(skill.slug, skill);
+      }
+    }
+
+    let backfilled = 0;
+
+    for (const skill of installed) {
+      // Skip skills that already have sync state
+      if (skill.syncState) continue;
+
+      const repoMatch = repoSkillsBySlug.get(skill.slug);
+      if (!repoMatch?.sourceUrl) continue;
+
+      // Read current content to compute managed file hash
+      const content = await this.readContent(skill);
+      if (!content) continue;
+
+      const contentHash = await computeContentHash(content);
+      const syncState: SkillSyncState = {
+        version: 1,
+        upstreamSource: "serenorg" as SkillSource,
+        upstreamSourceUrl: repoMatch.sourceUrl,
+        syncedRevision: null,
+        syncedAt: Date.now(),
+        managedFiles: { "SKILL.md": contentHash },
+      };
+
+      try {
+        await invoke("write_skill_sync_state", {
+          skillsDir: skill.skillsDir,
+          slug: skill.dirName,
+          stateJson: JSON.stringify(syncState),
+        });
+        backfilled++;
+        log.info(
+          "[Skills] Backfilled sync state for",
+          skill.slug,
+          "→",
+          repoMatch.sourceUrl,
+        );
+      } catch (err) {
+        log.warn("[Skills] Failed to backfill sync state for", skill.slug, err);
+      }
+    }
+
+    return backfilled;
+  },
 };

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -581,6 +581,19 @@ export const skillsStore = {
       this.refreshAvailable(skipCache),
       this.refreshInstalled(),
     ]);
+
+    // Backfill sync state for skills installed before the sync feature
+    // existed (pre-v2.3.16). Non-blocking — failures are logged and skipped.
+    const needsBackfill = state.installed.some(
+      (s) => !s.syncState && state.available.some((a) => a.slug === s.slug && a.source === "serenorg"),
+    );
+    if (needsBackfill) {
+      const count = await skills.backfillSyncState(state.installed, state.available);
+      if (count > 0) {
+        log.info("[SkillsStore] Backfilled sync state for", count, "skills");
+        await this.refreshInstalled();
+      }
+    }
   },
 
   /**


### PR DESCRIPTION
## Summary

- Skills installed via the Skills Browser before v2.3.16 have no `.seren-sync.json` — the sync feature didn't exist at install time
- These skills are stuck on stale content (e.g. referencing dead publishers like `polymarket-trading-serenai`) with no path to auto-update
- Promoted `write_skill_sync_state` from test-only to a Tauri command
- Added `backfillSyncState()` in the skills service — matches installed skills missing sync state to available repo skills by slug, writes minimal `.seren-sync.json`
- The store calls this after `refresh()` completes, then re-loads installed skills so the upstream sync flow can detect and apply updates

Fixes #1153

## Test plan

- Have pre-existing installed skills with no `.seren-sync.json` (e.g. `polymarket-trader`, `polymarket-data`)
- Start the app — console should show `[Skills] Backfilled sync state for <slug>` messages
- Verify `.seren-sync.json` files are created in the skill directories
- Verify the Skills Explorer now shows upstream sync status for these skills
- Verify the upstream refresh flow can now detect and apply updates

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com