### PR TITLE
fix: auto-refresh stale upstream-managed skills on startup and toggle-on

### DIFF
--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -9,7 +9,11 @@ import type {
   SkillScope,
   SkillsState,
 } from "@/lib/skills";
-import { type ProjectSkillsConfig, skills } from "@/services/skills";
+import {
+  type ProjectSkillsConfig,
+  isUpstreamManagedSkill,
+  skills,
+} from "@/services/skills";
 import { getFileTreeState } from "@/stores/fileTree";
 
 const ENABLED_SKILLS_KEY = "seren:enabled_skills";
@@ -449,9 +453,24 @@ export const skillsStore = {
       ? [...current]
       : this.getProjectSkills(projectRoot).map((s) => skillRef(s));
 
-    const next = base.includes(target)
-      ? base.filter((r) => r !== target)
-      : [...base, target];
+    const isAdding = !base.includes(target);
+    const next = isAdding
+      ? [...base, target]
+      : base.filter((r) => r !== target);
+
+    // Auto-refresh stale upstream-managed skill when activating on a thread.
+    if (isAdding && isUpstreamManagedSkill(installed)) {
+      try {
+        const status = await skills.inspectSyncStatus(installed);
+        if (status.updateAvailable) {
+          await skills.refreshInstalledSkill(installed);
+          await this.refreshInstalled();
+          log.info("[SkillsStore] Refreshed stale skill on toggle-on:", installed.slug);
+        }
+      } catch (err) {
+        log.warn("[SkillsStore] Upstream check failed on toggle-on:", installed.slug, err);
+      }
+    }
 
     const normalized = normalizeRefs(next);
     await skills.setThreadSkills(projectRoot, threadId, normalized);
@@ -593,6 +612,26 @@ export const skillsStore = {
         log.info("[SkillsStore] Backfilled sync state for", count, "skills");
         await this.refreshInstalled();
       }
+    }
+
+    // Auto-refresh stale upstream-managed skills so users always get the
+    // latest runtime files without needing the explicit Refresh button.
+    let autoRefreshed = 0;
+    for (const skill of state.installed) {
+      if (!isUpstreamManagedSkill(skill)) continue;
+      try {
+        const status = await skills.inspectSyncStatus(skill);
+        if (status.updateAvailable) {
+          await skills.refreshInstalledSkill(skill);
+          autoRefreshed++;
+          log.info("[SkillsStore] Auto-refreshed stale skill:", skill.slug);
+        }
+      } catch (err) {
+        log.warn("[SkillsStore] Failed to check/refresh skill:", skill.slug, err);
+      }
+    }
+    if (autoRefreshed > 0) {
+      await this.refreshInstalled();
     }
   },
 

--- a/tests/unit/skills-auto-sync.test.ts
+++ b/tests/unit/skills-auto-sync.test.ts
@@ -1,0 +1,75 @@
+// ABOUTME: Test that refresh() auto-refreshes stale upstream-managed skills.
+// ABOUTME: Verifies the fix for #1155 — skills must not stay stale after startup/periodic refresh.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockInstalled = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+const mockAvailable = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
+const mockSkillsService = vi.hoisted(() => ({
+  fetchAllSkills: vi.fn().mockResolvedValue([]),
+  listAllInstalled: vi.fn().mockResolvedValue([]),
+  backfillSyncState: vi.fn().mockResolvedValue(0),
+  inspectSyncStatus: vi.fn().mockResolvedValue({ updateAvailable: false }),
+  refreshInstalledSkill: vi.fn().mockResolvedValue({ installed: {}, syncStatus: null }),
+  isUpstreamManagedSkill: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("solid-js/store", () => ({
+  createStore: <T extends Record<string, unknown>>(initial: T) => {
+    const state = { ...initial } as Record<string, unknown>;
+    const setState = (key: string, value: unknown) => {
+      state[key] = value;
+    };
+    return [state, setState];
+  },
+}));
+
+vi.mock("@/stores/fileTree", () => ({
+  getFileTreeState: () => ({ rootPath: "/test/project" }),
+  get fileTreeState() {
+    return { rootPath: "/test/project" };
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/services/skills", () => ({
+  skills: {
+    fetchAllSkills: mockSkillsService.fetchAllSkills,
+    listAllInstalled: mockSkillsService.listAllInstalled,
+    backfillSyncState: mockSkillsService.backfillSyncState,
+    inspectSyncStatus: mockSkillsService.inspectSyncStatus,
+    refreshInstalledSkill: mockSkillsService.refreshInstalledSkill,
+  },
+  isUpstreamManagedSkill: mockSkillsService.isUpstreamManagedSkill,
+}));
+
+describe("skills auto-sync on refresh (#1155)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls refreshInstalledSkill when an upstream-managed skill has updateAvailable", async () => {
+    const staleSkill = {
+      slug: "polymarket-maker-rebate-bot",
+      scope: "serenorg" as const,
+      path: "/skills/polymarket-maker-rebate-bot",
+      syncState: { upstreamSource: "serenorg/seren-skills", syncedRevision: "abc123", syncedAt: 1, managedFiles: {} },
+    };
+
+    mockSkillsService.fetchAllSkills.mockResolvedValue([]);
+    mockSkillsService.listAllInstalled.mockResolvedValue([staleSkill]);
+    mockSkillsService.isUpstreamManagedSkill.mockReturnValue(true);
+    mockSkillsService.inspectSyncStatus.mockResolvedValue({ updateAvailable: true, syncedRevision: "abc123" });
+    mockSkillsService.refreshInstalledSkill.mockResolvedValue({ installed: staleSkill, syncStatus: null });
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refresh();
+
+    expect(mockSkillsService.inspectSyncStatus).toHaveBeenCalledWith(staleSkill);
+    expect(mockSkillsService.refreshInstalledSkill).toHaveBeenCalledWith(staleSkill);
+  });
+});


### PR DESCRIPTION
## Summary
- `refresh()` now auto-refreshes stale upstream-managed skills at startup and on the 60-min periodic timer
- `toggleThreadSkill()` checks upstream freshness when activating a skill (toggle ON), so remove+re-add delivers latest content
- One unit test verifying `refreshInstalledSkill` is called when `updateAvailable` is true

## Test plan
- [ ] Verify polymarket-maker-rebate-bot gets refreshed on toggle-on after upstream fix lands
- [ ] Verify startup refresh logs auto-refresh for stale skills
- [ ] `npm run test` passes with new test

Closes #1155

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com