### PR TITLE
fix: prevent duplicate skill invocation from dual set-chat-input listeners

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -202,6 +202,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
   const onPickImages = () => handleAttachImages();
   const onSetChatInput = (event: Event) => {
+    // Skip if another handler already processed this event (prevents
+    // duplicate sends when both AgentChat and ChatContent are mounted).
+    if ((event as CustomEvent & { _handled?: boolean })._handled) return;
+
     const customEvent = event as CustomEvent<
       string | { text: string; autoSend?: boolean }
     >;
@@ -217,6 +221,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
       // Auto-send if requested (e.g., from skill click)
       if (detail.autoSend) {
+        (event as CustomEvent & { _handled?: boolean })._handled = true;
         // Use setTimeout to ensure input is set before sending
         setTimeout(() => {
           sendMessage();

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -542,6 +542,10 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
 
   // Event handler for setting chat input (e.g., from skill invocation)
   const handleSetChatInput = (event: Event) => {
+    // Skip if another handler already processed this event (prevents
+    // duplicate sends when both AgentChat and ChatContent are mounted).
+    if ((event as CustomEvent & { _handled?: boolean })._handled) return;
+
     const customEvent = event as CustomEvent<
       | string
       | {
@@ -563,6 +567,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
 
       // Auto-send if requested (e.g., from skill click)
       if (detail.autoSend) {
+        (event as CustomEvent & { _handled?: boolean })._handled = true;
         // Use setTimeout to ensure input is set before sending
         setTimeout(() => {
           sendMessage({


### PR DESCRIPTION
## Summary

- Both AgentChat and ChatContent register listeners for `seren:set-chat-input`
- Sidebar skill click dispatches `autoSend: true` → both fire `sendPrompt` → second errors with "Another prompt is already active"
- Added `_handled` flag on the event — first handler to process `autoSend` marks it, second skips

Fixes #1157

## Test plan

- Click a skill in the sidebar on an active agent thread
- Verify the skill invocation fires only once (no error banner)
- Verify skill invocations from ChatContent (non-agent) still work
- Verify manual text input (non-autoSend) is unaffected in both panels

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com