### PR TITLE
fix: compact agent conversation even when lastUserPrompt is unavailable

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1821,15 +1821,11 @@ Summary:`;
       return false;
     }
 
-    const lastPrompt = session.lastUserPrompt;
-    if (!lastPrompt) {
-      console.warn("[AgentStore] compactAndRetry: no lastUserPrompt to retry");
-      return false;
-    }
-
     setState("sessions", sessionId, "compactRetryAttempted", true);
+
+    const lastPrompt = session.lastUserPrompt;
     console.info(
-      "[AgentStore] Prompt too long — attempting compaction before falling back to Chat",
+      `[AgentStore] Prompt too long — attempting compaction${lastPrompt ? " + retry" : " (no prompt to retry)"}`,
     );
 
     try {
@@ -1863,17 +1859,23 @@ Summary:`;
         return false;
       }
 
-      console.info(
-        `[AgentStore] Compaction complete, retrying prompt on session ${newSessionId}`,
-      );
-
       // compactAgentConversation sends the seed prompt before returning, so the
       // session may still be in 'prompting' state. Wait for it to go idle before
       // sending the user's original prompt to avoid a concurrent-prompt race.
       await waitForSessionIdle(newSessionId);
 
-      // Retry the original prompt
-      await providerService.sendPrompt(newSessionId, lastPrompt);
+      // Retry the original prompt if available; otherwise leave the
+      // compacted session ready for the user's next input.
+      if (lastPrompt) {
+        console.info(
+          `[AgentStore] Compaction complete, retrying prompt on session ${newSessionId}`,
+        );
+        await providerService.sendPrompt(newSessionId, lastPrompt);
+      } else {
+        console.info(
+          `[AgentStore] Compaction complete on session ${newSessionId} — no prompt to retry, session ready`,
+        );
+      }
       return true;
     } catch (error) {
       console.error(


### PR DESCRIPTION
## Summary

- `compactAndRetry` bailed out entirely when `lastUserPrompt` was null, skipping compaction and falling back to chat mode
- Common on resumed sessions where prompt state wasn't preserved
- Now always attempts compaction when context is full
- If `lastUserPrompt` exists, retries after compaction; if not, leaves the compacted session ready for the user's next input

Fixes #1163

## Test plan

- Resume an agent session from a previous app session (lastUserPrompt will be null)
- Fill the context until 'Prompt is too long'
- Verify compaction runs and the session stays in agent mode (no chat fallback)
- Verify the session is ready for the next prompt after compaction

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com