### PR TITLE
fix: include cached tokens in context usage for accurate autocompact

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -612,8 +612,24 @@ function buildClaudeArgs({
 
 function buildPromptMeta(result) {
   const usage = result?.usage ?? {};
+  // input_tokens only counts non-cached tokens. The actual context
+  // consumption includes cache_creation_input_tokens (newly cached) and
+  // cache_read_input_tokens (previously cached). Sum all three to get
+  // the real context window usage for autocompact decisions.
+  const rawInput =
+    typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
+  const cacheCreation =
+    typeof usage.cache_creation_input_tokens === "number"
+      ? usage.cache_creation_input_tokens
+      : 0;
+  const cacheRead =
+    typeof usage.cache_read_input_tokens === "number"
+      ? usage.cache_read_input_tokens
+      : 0;
   const inputTokens =
-    typeof usage.input_tokens === "number" ? usage.input_tokens : undefined;
+    rawInput + cacheCreation + cacheRead > 0
+      ? rawInput + cacheCreation + cacheRead
+      : undefined;
   const outputTokens =
     typeof usage.output_tokens === "number" ? usage.output_tokens : undefined;
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -205,9 +205,6 @@ export interface ActiveSession {
   lastUserPrompt?: string;
   /** Set after a compact-and-retry attempt so we only try once per prompt. */
   compactRetryAttempted?: boolean;
-  /** Number of prompt exchanges (promptComplete events) in this session.
-   *  Used as a heuristic for context growth when token usage is unreliable. */
-  promptExchangeCount?: number;
   /** In-flight compactAndRetry promise — awaited by sendPrompt catch block
    *  so compaction completes before the error handler gives up. */
   compactRetryPromise?: Promise<boolean>;
@@ -2710,16 +2707,6 @@ Summary:`;
           }
         }
 
-        // Track prompt exchange count for heuristic compaction decisions
-        if (!isHistoryReplay) {
-          setState(
-            "sessions",
-            sessionId,
-            "promptExchangeCount",
-            (state.sessions[sessionId]?.promptExchangeCount ?? 0) + 1,
-          );
-        }
-
         // Transition status back to "ready" so queued messages can be processed
         setState(
           "sessions",
@@ -2730,23 +2717,13 @@ Summary:`;
         );
 
         // Auto-compact check: trigger compaction at 85% of context window,
-        // or by message/prompt count when token data is unreliable.
+        // or at 200 messages for agents that don't report token usage at all.
         if (!isHistoryReplay && !state.sessions[sessionId]?.isCompacting) {
           const sess = state.sessions[sessionId];
           if (settingsStore.settings.autoCompactEnabled && sess) {
             let shouldCompact = false;
 
-            // Treat token usage below 1% as unreliable — Claude Code
-            // sometimes reports near-zero tokens even when context is full.
-            // Fall through to heuristic checks in that case.
-            const MIN_RELIABLE_TOKENS = Math.max(
-              100,
-              sess.contextWindowSize * 0.01,
-            );
-            if (
-              sess.lastInputTokens &&
-              sess.lastInputTokens >= MIN_RELIABLE_TOKENS
-            ) {
+            if (sess.lastInputTokens && sess.lastInputTokens > 0) {
               const usagePercent =
                 sess.lastInputTokens / sess.contextWindowSize;
               const threshold =
@@ -2758,26 +2735,15 @@ Summary:`;
                 shouldCompact = true;
               }
             } else {
-              // Token usage is unreliable. Use two heuristics:
-              // 1. Active message count (user + assistant messages in store)
-              // 2. Prompt exchange count (how many promptComplete events
-              //    this session has handled — each exchange adds user msg,
-              //    assistant reply, and potentially many tool calls to the
-              //    CLI's internal context even though we only see the final
-              //    assistant message in our store).
+              // No token usage data at all — fall back to message count.
+              // Only count messages added since session start.
               const activeCount = Math.max(
                 0,
                 sess.messages.length - (sess.restoredMessageCount ?? 0),
               );
-              const promptExchanges = sess.promptExchangeCount ?? 0;
-
-              // With unreliable tokens, compact aggressively:
-              // - 50 active messages, OR
-              // - 15 prompt exchanges (each exchange includes tool calls
-              //   that consume context invisibly to us)
-              if (activeCount > 50 || promptExchanges > 15) {
+              if (activeCount > 200) {
                 console.info(
-                  `[AgentStore] Unreliable token data — ${activeCount} active messages, ${promptExchanges} prompt exchanges — triggering auto-compaction`,
+                  `[AgentStore] ${activeCount} active messages without token usage data — triggering auto-compaction`,
                 );
                 shouldCompact = true;
               }


### PR DESCRIPTION
## Summary

Root cause fix for all the autocompact failures.

- `buildPromptMeta` in `claude-runtime.mjs` read only `usage.input_tokens` which excludes cached tokens
- A session consuming 20K tokens of context reported `input_tokens: 3` because 13K were `cache_creation_input_tokens` and 6K were `cache_read_input_tokens`
- Autocompact threshold (85%) never triggered because usage appeared to be 0%
- Fix: sum all three fields to get actual context window usage
- Reverts the prompt exchange counter and lowered message threshold from #1166 — those were workarounds for broken data, not needed with accurate reporting

Fixes #1165

## Evidence

Claude Code CLI `result` payload:
```json
{
  "usage": {
    "input_tokens": 3,
    "cache_creation_input_tokens": 13605,
    "cache_read_input_tokens": 6468
  }
}
```
We were reading only `input_tokens: 3`. Actual usage: 20,076 tokens.

## Test plan

- Start an agent session and send a few prompts
- Check console for `Agent usage: XXXXX input tokens (XX% of context)` — should now show realistic percentages instead of 0%
- Verify autocompact triggers at 85% threshold
- Verify no more surprise Prompt is too long errors

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com