### PR TITLE
fix: switch seren-memory-sdk to git dep for Accept header fix

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,7 +56,7 @@ sha2 = "0.10"
 base64 = "0.22"
 libc = "0.2"
 reqwest = { version = "0.13", features = ["json", "stream"] }
-seren-memory-sdk = "0.1"
+seren-memory-sdk = { git = "https://github.com/serenorg/seren-memory-sdk.git", branch = "main" }
 rmcp = { version = "1.2", features = [
     "client",
     "transport-io",                           # stdio for local MCP servers


### PR DESCRIPTION
## Summary
- Switches `seren-memory-sdk` from crates.io v0.1.0 to git dependency pointing at the repo that already has the Accept header fix
- The published v0.1.0 is missing the `Accept: application/json, text/event-stream` header required by the MCP endpoint, causing 406 errors on cloud memory sync

## Test plan
- [ ] Verify cloud memory sync no longer returns 406
- [ ] Confirm local memory caching still works as fallback

Closes #1168

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com