### PR TITLE
fix: cancel worker and abort in-flight requests on cancel

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -1072,13 +1072,22 @@ impl Worker for ChatModelWorker {
             if !response.status().is_success() {
                 let status = response.status();
                 let body_text = response.text().await.unwrap_or_default();
+                // Check cancellation before logging — a 504 after cancel is expected
+                if *self.cancelled.lock().await {
+                    log::debug!("[ChatModelWorker] HTTP {} after cancellation (expected)", status);
+                    return Ok(());
+                }
                 log::error!("[ChatModelWorker] HTTP {} from Gateway", status);
-                event_tx
+                if let Err(e) = event_tx
                     .send(WorkerEvent::Error {
                         message: format!("Gateway returned HTTP {}", status),
                     })
                     .await
-                    .map_err(|e| format!("Failed to send error event: {}", e))?;
+                {
+                    // Channel closed — likely cancelled while sending
+                    log::debug!("[ChatModelWorker] Channel closed, cannot send error: {}", e);
+                    return Ok(());
+                }
                 return Err(format!(
                     "Gateway returned HTTP {}: {}",
                     status,
@@ -1111,7 +1120,7 @@ impl Worker for ChatModelWorker {
                         final_content.len(),
                         total
                     );
-                    event_tx
+                    if let Err(e) = event_tx
                         .send(WorkerEvent::Complete {
                             final_content,
                             thinking,
@@ -1119,7 +1128,10 @@ impl Worker for ChatModelWorker {
                             rlm_steps: None,
                         })
                         .await
-                        .map_err(|e| format!("Failed to send Complete event: {}", e))?;
+                    {
+                        log::debug!("[ChatModelWorker] Channel closed, cannot send Complete: {}", e);
+                        return Ok(());
+                    }
                     log::info!("[ChatModelWorker] Execution complete, breaking from tool loop");
                     break;
                 }

--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -291,6 +291,7 @@ async fn execute_single_task(
         // Create channel and spawn worker
         let (event_tx, mut event_rx) = mpsc::channel::<WorkerEvent>(256);
         let worker = create_worker(&routing, app, &capabilities);
+        let worker_for_cancel = Arc::clone(&worker);
         let worker_prompt = subtask.prompt.clone();
         let worker_routing = routing.clone();
         let worker_app = app.clone();
@@ -315,11 +316,13 @@ async fn execute_single_task(
         let app_for_events = app.clone();
         let cancel_rx_clone = cancel_rx.clone();
 
-        // Collect all events, intercepting errors for reroute analysis
+        // Collect all events, intercepting errors for reroute analysis.
+        // Returns (was_cancelled, captured_error).
         let mut reroutable_error: Option<String> = None;
         let forward_handle = tokio::spawn(async move {
             let mut taken_rx = cancel_rx_clone.lock().await.take();
             let mut captured_error: Option<String> = None;
+            let mut cancelled = false;
             loop {
                 if let Some(ref mut rx) = taken_rx {
                     tokio::select! {
@@ -345,6 +348,7 @@ async fn execute_single_task(
                         }
                         _ = rx => {
                             log::info!("[Orchestrator] Cancellation received for conversation {}", conv_id);
+                            cancelled = true;
                             break;
                         }
                     }
@@ -371,12 +375,22 @@ async fn execute_single_task(
                     }
                 }
             }
-            captured_error
+            (cancelled, captured_error)
         });
 
         let forward_result = forward_handle.await;
-        if let Ok(Some(error_msg)) = &forward_result {
+        let was_cancelled = forward_result.as_ref().map(|(c, _)| *c).unwrap_or(false);
+        if let Ok((_, Some(ref error_msg))) = forward_result {
             reroutable_error = Some(error_msg.clone());
+        }
+
+        // If the forward loop exited due to cancellation, signal the worker
+        // to stop and abort its task so in-flight HTTP requests don't linger.
+        if was_cancelled {
+            log::info!("[Orchestrator] Cancelling worker for conversation {}", conversation_id);
+            let _ = worker_for_cancel.cancel().await;
+            worker_handle.abort();
+            break;
         }
 
         match worker_handle.await {


### PR DESCRIPTION
## Summary
- Clones worker Arc before spawning so `cancel()` can be called after the forward loop breaks
- Calls `worker.cancel()` and `worker_handle.abort()` when cancellation is detected, preventing orphaned HTTP requests (up to 600s timeout)
- Downgrades channel-closed and post-cancel HTTP errors to debug-level logs

## Test plan
- [ ] Cancel an in-progress orchestration and verify no error logs about channel closed
- [ ] Verify cancelled requests don't linger (check no 504 errors logged after cancel)
- [ ] Verify normal (non-cancelled) orchestration still completes correctly

Closes #1169

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com