### PR TITLE
fix: use permissive default tool limit for unknown/auto model

### DIFF
--- a/src/lib/tools/definitions.ts
+++ b/src/lib/tools/definitions.ts
@@ -27,8 +27,9 @@ export const MODEL_TOOL_LIMITS: Record<string, number> = {
   // Google models
   gemini: 256,
 
-  // Default for unknown models - be conservative
-  default: 128,
+  // Default for unknown/auto models - use permissive limit since the
+  // backend orchestrator applies its own model-specific tool filtering.
+  default: 4096,
 };
 
 /**
@@ -580,7 +581,7 @@ export function getAllTools(modelId?: string): ToolDefinition[] {
     FILE_TOOLS.length + mcpToolsFiltered + gatewayTools.length;
   if (tools.length < totalAvailable) {
     console.warn(
-      `[Tools] Limited to ${limit} tools for model "${modelId ?? "unknown"}" (had ${totalAvailable} available)`,
+      `[Tools] Limited to ${limit} tools for model "${modelId || "unspecified"}" (had ${totalAvailable} available)`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Changes default tool limit from 128 to 4096 for unknown/auto model IDs
- The backend orchestrator already applies model-specific tool filtering via tool_relevance, so the frontend limit was unnecessarily dropping 11 gateway publisher tools on Claude-routed requests
- Fixes warning message to show "unspecified" instead of "unknown"

## Test plan
- [ ] Verify no more "Limited to 128 tools" warnings in console
- [ ] Confirm all gateway publisher tools are available when using Claude models
- [ ] Verify OpenAI models still get their 128 limit when explicitly selected

Closes #1170

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com