### PR TITLE
fix: configure git auth for private seren-memory-sdk in CI test-rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+      - name: Configure git for private dependencies
+        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
       - uses: pnpm/action-setup@v4
         with:
           version: 9


### PR DESCRIPTION
## Summary

- `test-rust` CI job fails because `cargo test` cannot authenticate to clone the private `seren-memory-sdk` dependency
- The default `GITHUB_TOKEN` only has access to the current repo, not cross-repo private deps
- Fix: configure git URL rewriting to use `GH_PAT` (same secret the release workflow already uses)

Fixes #1175 / Fixes #1174

## Test plan

- CI should pass on this PR (test-rust will clone seren-memory-sdk successfully)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com