### PR TITLE
fix: use per-turn token average and model context window for autocompact

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -612,10 +612,10 @@ function buildClaudeArgs({
 
 function buildPromptMeta(result) {
   const usage = result?.usage ?? {};
-  // input_tokens only counts non-cached tokens. The actual context
-  // consumption includes cache_creation_input_tokens (newly cached) and
-  // cache_read_input_tokens (previously cached). Sum all three to get
-  // the real context window usage for autocompact decisions.
+  // result.usage reports CUMULATIVE tokens across all iterations (tool
+  // call round-trips) in this prompt. For autocompact we need the
+  // approximate context window fill — the input for a single API call.
+  // Divide cumulative total by num_turns to approximate per-turn usage.
   const rawInput =
     typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
   const cacheCreation =
@@ -626,12 +626,23 @@ function buildPromptMeta(result) {
     typeof usage.cache_read_input_tokens === "number"
       ? usage.cache_read_input_tokens
       : 0;
+  const cumulativeInput = rawInput + cacheCreation + cacheRead;
+  const numTurns =
+    typeof result?.num_turns === "number" && result.num_turns > 0
+      ? result.num_turns
+      : 1;
   const inputTokens =
-    rawInput + cacheCreation + cacheRead > 0
-      ? rawInput + cacheCreation + cacheRead
-      : undefined;
+    cumulativeInput > 0 ? Math.round(cumulativeInput / numTurns) : undefined;
   const outputTokens =
     typeof usage.output_tokens === "number" ? usage.output_tokens : undefined;
+
+  // Extract context window size from modelUsage if available.
+  const modelUsage = result?.modelUsage ?? {};
+  const firstModel = Object.values(modelUsage)[0];
+  const contextWindow =
+    typeof firstModel?.contextWindow === "number"
+      ? firstModel.contextWindow
+      : undefined;
 
   return {
     meta: {
@@ -643,6 +654,7 @@ function buildPromptMeta(result) {
             },
           }
         : {}),
+      ...(contextWindow != null ? { contextWindow } : {}),
       ...(typeof result?.num_turns === "number" ? { numTurns: result.num_turns } : {}),
     },
   };

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2715,11 +2715,26 @@ Summary:`;
         // Track agent usage metadata for compaction decisions
         if (!isHistoryReplay && event.data.meta) {
           const inputTokens = event.data.meta.usage?.input_tokens;
+          // Update context window size from model metadata when available
+          const reportedContextWindow = event.data.meta.contextWindow;
+          if (
+            typeof reportedContextWindow === "number" &&
+            reportedContextWindow > 0
+          ) {
+            setState(
+              "sessions",
+              sessionId,
+              "contextWindowSize",
+              reportedContextWindow,
+            );
+          }
           if (inputTokens != null) {
             setState("sessions", sessionId, "lastInputTokens", inputTokens);
+            const ctxSize =
+              state.sessions[sessionId]?.contextWindowSize ?? 200_000;
             console.log(
               `[AgentStore] Agent usage: ${inputTokens} input tokens`,
-              `(${Math.round((inputTokens / (state.sessions[sessionId]?.contextWindowSize ?? 200_000)) * 100)}% of context)`,
+              `(${Math.round((inputTokens / ctxSize) * 100)}% of ${ctxSize.toLocaleString()} context)`,
             );
           }
         }


### PR DESCRIPTION
## Summary

- `result.usage` reports cumulative tokens across all tool call iterations, not context fill
- A 3-turn prompt showed 67K cumulative but ~22K actual context fill
- With many tool calls, cumulative totals hit 3.3M (1689% of 200K window), triggering compaction every prompt
- Compaction then failed with 504 Gateway Timeout repeatedly
- Fix: divide cumulative input by `num_turns` for per-turn average, and use `modelUsage.contextWindow` (1M for Opus) instead of hardcoded 200K

Before: `3,378,895 tokens (1689% of 200K context)` — compaction every prompt
After: `22,569 tokens (2.3% of 1M context)` — compaction only at 85%

Fixes #1179

## Test plan

- Run an agent session with multiple tool calls per prompt
- Verify console shows realistic percentages (single-digit % for short sessions)
- Verify autocompact does NOT trigger prematurely
- Verify autocompact DOES trigger when context genuinely approaches 85%

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com