### PR TITLE
fix(skills): recover backfilled upstream skill refreshes

### DIFF
--- a/src/components/sidebar/SkillsExplorer.tsx
+++ b/src/components/sidebar/SkillsExplorer.tsx
@@ -131,9 +131,10 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
   };
 
   const updateCount = () =>
-    skillsStore.installed.filter(
-      (skill) => syncStatusFor(skill)?.updateAvailable,
-    ).length;
+    skillsStore.installed.filter((skill) => {
+      const status = syncStatusFor(skill);
+      return status?.updateAvailable || status?.state === "bootstrap-required";
+    }).length;
 
   const localChangesCount = () =>
     skillsStore.installed.filter(
@@ -171,6 +172,8 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
     switch (status.state) {
       case "current":
         return "Current";
+      case "bootstrap-required":
+        return "Sync required";
       case "update-available":
         return "Update available";
       case "local-changes":
@@ -190,6 +193,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
     switch (status.state) {
       case "current":
         return "bg-success/10 text-success";
+      case "bootstrap-required":
       case "update-available":
         return "bg-warning/10 text-warning";
       case "local-changes":

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -77,7 +77,12 @@ export interface RemoteSkillRevision {
 }
 
 export interface SkillSyncStatus {
-  state: "current" | "update-available" | "local-changes" | "error";
+  state:
+    | "current"
+    | "bootstrap-required"
+    | "update-available"
+    | "local-changes"
+    | "error";
   updateAvailable: boolean;
   hasLocalChanges: boolean;
   syncedRevision: string | null;

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1154,13 +1154,21 @@ export const skills = {
       );
       const hasLocalChanges =
         changedLocalFiles.length > 0 || missingManagedFiles.length > 0;
+      const bootstrapRequired = Boolean(
+        remoteRevision?.sha &&
+          syncedRevision === null &&
+          !hasLocalChanges &&
+          managedPaths.length > 0,
+      );
 
       return {
         state: hasLocalChanges
           ? "local-changes"
-          : updateAvailable
-            ? "update-available"
-            : "current",
+          : bootstrapRequired
+            ? "bootstrap-required"
+            : updateAvailable
+              ? "update-available"
+              : "current",
         updateAvailable,
         hasLocalChanges,
         syncedRevision,

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -10,8 +10,8 @@ import type {
   SkillsState,
 } from "@/lib/skills";
 import {
-  type ProjectSkillsConfig,
   isUpstreamManagedSkill,
+  type ProjectSkillsConfig,
   skills,
 } from "@/services/skills";
 import { getFileTreeState } from "@/stores/fileTree";
@@ -465,10 +465,17 @@ export const skillsStore = {
         if (status.updateAvailable) {
           await skills.refreshInstalledSkill(installed);
           await this.refreshInstalled();
-          log.info("[SkillsStore] Refreshed stale skill on toggle-on:", installed.slug);
+          log.info(
+            "[SkillsStore] Refreshed stale skill on toggle-on:",
+            installed.slug,
+          );
         }
       } catch (err) {
-        log.warn("[SkillsStore] Upstream check failed on toggle-on:", installed.slug, err);
+        log.warn(
+          "[SkillsStore] Upstream check failed on toggle-on:",
+          installed.slug,
+          err,
+        );
       }
     }
 
@@ -604,10 +611,17 @@ export const skillsStore = {
     // Backfill sync state for skills installed before the sync feature
     // existed (pre-v2.3.16). Non-blocking — failures are logged and skipped.
     const needsBackfill = state.installed.some(
-      (s) => !s.syncState && state.available.some((a) => a.slug === s.slug && a.source === "serenorg"),
+      (s) =>
+        !s.syncState &&
+        state.available.some(
+          (a) => a.slug === s.slug && a.source === "serenorg",
+        ),
     );
     if (needsBackfill) {
-      const count = await skills.backfillSyncState(state.installed, state.available);
+      const count = await skills.backfillSyncState(
+        state.installed,
+        state.available,
+      );
       if (count > 0) {
         log.info("[SkillsStore] Backfilled sync state for", count, "skills");
         await this.refreshInstalled();
@@ -621,13 +635,18 @@ export const skillsStore = {
       if (!isUpstreamManagedSkill(skill)) continue;
       try {
         const status = await skills.inspectSyncStatus(skill);
-        if (status.updateAvailable) {
+        if (!status || status.hasLocalChanges) continue;
+        if (status.updateAvailable || status.state === "bootstrap-required") {
           await skills.refreshInstalledSkill(skill);
           autoRefreshed++;
           log.info("[SkillsStore] Auto-refreshed stale skill:", skill.slug);
         }
       } catch (err) {
-        log.warn("[SkillsStore] Failed to check/refresh skill:", skill.slug, err);
+        log.warn(
+          "[SkillsStore] Failed to check/refresh skill:",
+          skill.slug,
+          err,
+        );
       }
     }
     if (autoRefreshed > 0) {

--- a/tests/unit/skills-auto-sync.test.ts
+++ b/tests/unit/skills-auto-sync.test.ts
@@ -72,4 +72,55 @@ describe("skills auto-sync on refresh (#1155)", () => {
     expect(mockSkillsService.inspectSyncStatus).toHaveBeenCalledWith(staleSkill);
     expect(mockSkillsService.refreshInstalledSkill).toHaveBeenCalledWith(staleSkill);
   });
+
+  it("calls refreshInstalledSkill when an upstream-managed skill needs bootstrap refresh", async () => {
+    const backfilledSkill = {
+      slug: "polymarket-maker-rebate-bot",
+      scope: "serenorg" as const,
+      path: "/skills/polymarket-maker-rebate-bot",
+      syncState: { upstreamSource: "serenorg/seren-skills", syncedRevision: null, syncedAt: 1, managedFiles: { "SKILL.md": "hash" } },
+    };
+
+    mockSkillsService.fetchAllSkills.mockResolvedValue([]);
+    mockSkillsService.listAllInstalled.mockResolvedValue([backfilledSkill]);
+    mockSkillsService.isUpstreamManagedSkill.mockReturnValue(true);
+    mockSkillsService.inspectSyncStatus.mockResolvedValue({
+      state: "bootstrap-required",
+      updateAvailable: false,
+      hasLocalChanges: false,
+      syncedRevision: null,
+    });
+    mockSkillsService.refreshInstalledSkill.mockResolvedValue({ installed: backfilledSkill, syncStatus: null });
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refresh();
+
+    expect(mockSkillsService.inspectSyncStatus).toHaveBeenCalledWith(backfilledSkill);
+    expect(mockSkillsService.refreshInstalledSkill).toHaveBeenCalledWith(backfilledSkill);
+  });
+
+  it("does not auto-refresh when local managed files have changed", async () => {
+    const editedSkill = {
+      slug: "polymarket-maker-rebate-bot",
+      scope: "serenorg" as const,
+      path: "/skills/polymarket-maker-rebate-bot",
+      syncState: { upstreamSource: "serenorg/seren-skills", syncedRevision: "abc123", syncedAt: 1, managedFiles: { "SKILL.md": "hash" } },
+    };
+
+    mockSkillsService.fetchAllSkills.mockResolvedValue([]);
+    mockSkillsService.listAllInstalled.mockResolvedValue([editedSkill]);
+    mockSkillsService.isUpstreamManagedSkill.mockReturnValue(true);
+    mockSkillsService.inspectSyncStatus.mockResolvedValue({
+      state: "local-changes",
+      updateAvailable: true,
+      hasLocalChanges: true,
+      syncedRevision: "abc123",
+    });
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refresh();
+
+    expect(mockSkillsService.inspectSyncStatus).toHaveBeenCalledWith(editedSkill);
+    expect(mockSkillsService.refreshInstalledSkill).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/skills-sync-status.test.ts
+++ b/tests/unit/skills-sync-status.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAppFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/fetch", () => ({
+  appFetch: mockAppFetch,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@/services/catalog", () => ({
+  catalog: {},
+}));
+
+describe("skills.inspectSyncStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks backfilled upstream skills as bootstrap-required when no local drift exists", async () => {
+    const commitSha = "1234567890abcdef1234567890abcdef12345678";
+    mockAppFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ sha: commitSha }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          html_url: "https://github.com/serenorg/seren-skills/commit/1234567",
+          commit: {
+            message: "Add missing runtime files",
+            committer: { date: "2026-03-18T00:00:00Z" },
+          },
+          files: [{ filename: "polymarket-maker-rebate-bot/SKILL.md" }],
+        }),
+      });
+
+    const { skills } = await import("@/services/skills");
+    vi.spyOn(skills, "readContent").mockResolvedValue("skill body");
+
+    const status = await skills.inspectSyncStatus({
+      slug: "polymarket-maker-rebate-bot",
+      name: "Polymarket Maker Rebate Bot",
+      description: "desc",
+      id: "local:polymarket-maker-rebate-bot",
+      source: "local",
+      tags: [],
+      scope: "seren",
+      skillsDir: "/skills",
+      dirName: "polymarket-maker-rebate-bot",
+      path: "/skills/polymarket-maker-rebate-bot/SKILL.md",
+      installedAt: 1,
+      enabled: true,
+      contentHash: "hash",
+      upstreamSource: "serenorg",
+      upstreamSourceUrl:
+        "https://raw.githubusercontent.com/serenorg/seren-skills/main/polymarket-maker-rebate-bot/SKILL.md",
+      syncState: {
+        version: 1,
+        upstreamSource: "serenorg",
+        upstreamSourceUrl:
+          "https://raw.githubusercontent.com/serenorg/seren-skills/main/polymarket-maker-rebate-bot/SKILL.md",
+        syncedRevision: null,
+        syncedAt: 1,
+        managedFiles: { "SKILL.md": "1f42523adcc9a31dd7b8ab3b36f098c6a87e7fc7e0760fb3ea7be7cb93420d0d" },
+      },
+    });
+
+    expect(status).toMatchObject({
+      state: "bootstrap-required",
+      updateAvailable: false,
+      hasLocalChanges: false,
+      syncedRevision: null,
+      remoteRevision: {
+        sha: commitSha,
+        shortSha: commitSha.slice(0, 7),
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- mark backfilled upstream-managed installs with null synced revisions as requiring an initial bootstrap refresh
- auto-refresh bootstrap-required skills during store refresh while skipping any skill with local managed-file edits
- surface the bootstrap sync state in the skills explorer and cover the regression with focused unit tests

## Testing
- 
> seren-desktop@0.1.0 test /Users/taariqlewis/Projects/Seren_Projects/seren-desktop/.worktrees/issue-1181-backfill-refresh
> vitest run tests/unit/skills-auto-sync.test.ts tests/unit/skills-sync-status.test.ts


 RUN  v4.0.18 /Users/taariqlewis/Projects/Seren_Projects/seren-desktop/.worktrees/issue-1181-backfill-refresh

 ✓ tests/unit/skills-auto-sync.test.ts (3 tests) 78ms
 ✓ tests/unit/skills-sync-status.test.ts (1 test) 155ms

 Test Files  2 passed (2)
      Tests  4 passed (4)
   Start at  00:03:58
   Duration  506ms (transform 287ms, setup 0ms, import 140ms, tests 233ms, environment 0ms)
- Checked 4 files in 33ms. No fixes applied.

Fixes #1181