### PR TITLE
fix: increase update poll frequency from 1 hour to 15 minutes

### DIFF
--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -35,7 +35,7 @@ const [state, setState] = createStore<UpdaterState>({
 
 let initialized = false;
 
-const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 
 async function initUpdater(): Promise<void> {
   if (initialized) return;
@@ -48,7 +48,7 @@ async function initUpdater(): Promise<void> {
 
   await checkForUpdates();
 
-  // Re-check hourly so the badge appears without requiring a restart
+  // Re-check every 15 minutes so the badge appears without requiring a restart
   setInterval(() => {
     if (state.status !== "downloading" && state.status !== "installing") {
       checkForUpdates();


### PR DESCRIPTION
## Summary

- Changed update check interval from 60 minutes to 15 minutes
- Users shipping 3-4 versions/day need faster update discovery

Fixes #1189

## Test plan

- Verify console shows `[Updater] Checking for updates...` every 15 minutes
- Verify update badge appears promptly when a new version is available

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com