### PR TITLE
fix: add build guard to prevent shipping stale frontend dist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,28 @@ jobs:
       - name: Build (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: pnpm tauri build --bundles deb,appimage --config src-tauri/tauri.ci.json
+      - name: Verify frontend is embedded in binary
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+            BINARY=$(find src-tauri/target/release -name "Seren" -not -path "*/bundle/*" -type f | head -1)
+          elif [ "${{ matrix.os }}" == "windows-latest" ]; then
+            BINARY="src-tauri/target/release/Seren.exe"
+          else
+            BINARY="src-tauri/target/release/seren"
+          fi
+          if [ ! -f "$BINARY" ]; then
+            echo "ERROR: Binary not found at $BINARY"
+            exit 1
+          fi
+          MARKERS=("AgentStore" "SkillsStore" "sendPrompt" "MCP Gateway")
+          for marker in "${MARKERS[@]}"; do
+            if ! strings "$BINARY" | grep -q "$marker"; then
+              echo "FATAL: Frontend marker '$marker' missing from binary — stale dist/"
+              exit 1
+            fi
+          done
+          echo "Frontend markers verified."
       - uses: actions/upload-artifact@v7
         with:
           name: seren-desktop-${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,52 @@ jobs:
         if: matrix.os == 'macos-latest' && env.HAS_APPLE_SIGNING != 'true'
         run: pnpm tauri build --target ${{ matrix.target }}
 
+      # Verify the built binary contains current frontend code.
+      # Catches stale dist/ bundles that bypass beforeBuildCommand.
+      - name: Verify frontend is embedded in binary
+        shell: bash
+        run: |
+          echo "Checking that built binary contains current frontend code..."
+
+          # Find the built binary
+          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+            BINARY=$(find src-tauri/target/${{ matrix.target }}/release/bundle -name "Seren" -type f | head -1)
+            if [ -z "$BINARY" ]; then
+              BINARY="src-tauri/target/${{ matrix.target }}/release/Seren"
+            fi
+          elif [[ "${{ matrix.os }}" == *"windows"* ]]; then
+            BINARY="src-tauri/target/${{ matrix.target }}/release/Seren.exe"
+          else
+            BINARY="src-tauri/target/${{ matrix.target }}/release/seren"
+          fi
+
+          if [ ! -f "$BINARY" ]; then
+            echo "ERROR: Built binary not found at $BINARY"
+            exit 1
+          fi
+
+          # Check for key frontend identifiers that must be in every build.
+          # These are stable function/variable names from the TypeScript source
+          # that survive minification because they're used as string literals
+          # in console.log/info statements.
+          MARKERS=("AgentStore" "SkillsStore" "sendPrompt" "MCP Gateway")
+          MISSING=0
+          for marker in "${MARKERS[@]}"; do
+            if ! strings "$BINARY" | grep -q "$marker"; then
+              echo "ERROR: Frontend marker '$marker' not found in binary — dist/ may be stale"
+              MISSING=$((MISSING + 1))
+            fi
+          done
+
+          if [ "$MISSING" -gt 0 ]; then
+            echo ""
+            echo "FATAL: $MISSING frontend markers missing from binary."
+            echo "The embedded frontend is likely stale. Run 'pnpm build' before 'pnpm tauri build'."
+            exit 1
+          fi
+
+          echo "All frontend markers verified in binary."
+
       # Upload macOS DMG immediately (before notarization so we always have an artifact)
       - name: Upload macOS DMG (pre-notarization)
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
## Summary

v2.3.24 shipped with a stale Feb 15 frontend — the backfill/auto-refresh code from #1182 never reached users despite being in the source at that tag.

Adds a post-build verification step to both CI and release workflows:
- After `pnpm tauri build`, runs `strings` on the compiled binary
- Checks for key frontend markers: `AgentStore`, `SkillsStore`, `sendPrompt`, `MCP Gateway`
- If any marker is missing, the build fails before artifacts are uploaded
- Covers all platforms (macOS, Linux, Windows)

Fixes #1192

## Test plan

- CI build jobs should pass the new verification step (markers present in freshly built binaries)
- If `pnpm build` is skipped and an old `dist/` is used, the step should fail

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com