### PR TITLE
fix: build guard uses find to locate binary regardless of platform name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,17 +178,15 @@ jobs:
       - name: Verify frontend is embedded in binary
         shell: bash
         run: |
-          if [ "${{ matrix.os }}" == "macos-latest" ]; then
-            BINARY=$(find src-tauri/target/release -name "Seren" -not -path "*/bundle/*" -type f | head -1)
-          elif [ "${{ matrix.os }}" == "windows-latest" ]; then
-            BINARY="src-tauri/target/release/Seren.exe"
-          else
-            BINARY="src-tauri/target/release/seren"
-          fi
-          if [ ! -f "$BINARY" ]; then
-            echo "ERROR: Binary not found at $BINARY"
+          # Find the main binary — name varies by platform (Seren, SerenDesktop, seren-desktop)
+          BINARY=$(find src-tauri/target/release -maxdepth 1 \( -name "Seren" -o -name "Seren.exe" -o -name "seren-desktop" -o -name "SerenDesktop" -o -name "SerenDesktop.exe" -o -name "seren_desktop" \) -type f | head -1)
+          if [ -z "$BINARY" ]; then
+            echo "Available files in release dir:"
+            ls -la src-tauri/target/release/ | grep -v "\.d$" | head -20
+            echo "ERROR: Could not find built binary"
             exit 1
           fi
+          echo "Found binary: $BINARY"
           MARKERS=("AgentStore" "SkillsStore" "sendPrompt" "MCP Gateway")
           for marker in "${MARKERS[@]}"; do
             if ! strings "$BINARY" | grep -q "$marker"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,27 +311,18 @@ jobs:
         run: |
           echo "Checking that built binary contains current frontend code..."
 
-          # Find the built binary
-          if [ "${{ matrix.os }}" == "macos-latest" ]; then
-            BINARY=$(find src-tauri/target/${{ matrix.target }}/release/bundle -name "Seren" -type f | head -1)
-            if [ -z "$BINARY" ]; then
-              BINARY="src-tauri/target/${{ matrix.target }}/release/Seren"
-            fi
-          elif [[ "${{ matrix.os }}" == *"windows"* ]]; then
-            BINARY="src-tauri/target/${{ matrix.target }}/release/Seren.exe"
-          else
-            BINARY="src-tauri/target/${{ matrix.target }}/release/seren"
-          fi
-
-          if [ ! -f "$BINARY" ]; then
-            echo "ERROR: Built binary not found at $BINARY"
+          # Find the built binary — name varies by platform
+          BINARY=$(find src-tauri/target/${{ matrix.target }}/release -maxdepth 1 \( -name "Seren" -o -name "Seren.exe" -o -name "seren-desktop" -o -name "SerenDesktop" -o -name "SerenDesktop.exe" -o -name "seren_desktop" \) -type f | head -1)
+          if [ -z "$BINARY" ]; then
+            echo "Available files in release dir:"
+            ls -la src-tauri/target/${{ matrix.target }}/release/ | grep -v "\.d$" | head -20
+            echo "ERROR: Could not find built binary"
             exit 1
           fi
 
+          echo "Found binary: $BINARY"
+
           # Check for key frontend identifiers that must be in every build.
-          # These are stable function/variable names from the TypeScript source
-          # that survive minification because they're used as string literals
-          # in console.log/info statements.
           MARKERS=("AgentStore" "SkillsStore" "sendPrompt" "MCP Gateway")
           MISSING=0
           for marker in "${MARKERS[@]}"; do


### PR DESCRIPTION
## Summary

The build guard from #1193 failed on Linux because the binary is named `seren-desktop`, not `seren`. Now uses `find` with all known name variants instead of hardcoded paths. Also lists directory contents on failure for debugging.

## Test plan

- CI build jobs should pass on all platforms (ubuntu, macos, windows)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com