### PR TITLE
fix: add agent type to AgentRuntime event logs

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -953,13 +953,16 @@ export const agentStore = {
           // DevTools. Other event types (sessionStatus, toolCall, etc.) are
           // still logged for debugging.
           if (event.type !== "messageChunk") {
+            const session = state.sessions[eventSessionId];
             console.log(
               "[AgentRuntime] Event received - type:",
               event.type,
+              "agent:",
+              session?.info?.agentType ?? "unknown",
               "sessionId:",
               eventSessionId,
               "conversationId:",
-              state.sessions[eventSessionId]?.conversationId,
+              session?.conversationId,
             );
           }
           if (state.sessions[eventSessionId]) {


### PR DESCRIPTION
## Summary
- Adds `agent: claude-code|codex|unknown` to AgentRuntime event log lines
- Extracts session lookup into a local variable to avoid duplicate state access

Before: `[AgentRuntime] Event received - type: toolCall sessionId: abc916a4...`
After: `[AgentRuntime] Event received - type: toolCall agent: claude-code sessionId: abc916a4...`

## Test plan
- [ ] Open console, send a message, verify agent type appears in event logs
- [ ] Verify events from unknown/pending sessions show "unknown"

Closes #1197

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com