### PR TITLE
feat: publisher skill lifecycle with stale detection

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -426,6 +426,26 @@ export function isUpstreamManagedSkill(
 }
 
 /**
+ * Check if an installed skill is managed by a Seren publisher (has sync state
+ * with source "seren"). Used to detect stale publisher skills whose publisher
+ * has been deleted.
+ */
+export function isPublisherManagedSkill(
+  skill: InstalledSkill,
+): skill is InstalledSkill & {
+  syncState: SkillSyncState;
+  upstreamSource: "seren";
+  upstreamSourceUrl: string;
+} {
+  return (
+    !!skill.syncState &&
+    skill.upstreamSource === "seren" &&
+    typeof skill.upstreamSourceUrl === "string" &&
+    skill.upstreamSourceUrl.length > 0
+  );
+}
+
+/**
  * Fetch all payload files (excluding SKILL.md) from a skill's GitHub directory.
  * Uses the cached repo tree to discover files, then fetches their raw content.
  */
@@ -974,6 +994,16 @@ export const skills = {
         installContent,
         extraFiles,
       );
+    } else if (skill.source === "seren" && skill.sourceUrl) {
+      // Publisher-installed skills also get sync state so they can be
+      // detected and cleaned up when the publisher is deleted.
+      syncState = await computeUpstreamSyncState(
+        skill.source,
+        skill.sourceUrl,
+        null,
+        installContent,
+        [],
+      );
     }
 
     const path = await invoke<string>("install_skill", {
@@ -1374,9 +1404,12 @@ export const skills = {
     if (!isTauriRuntime()) return 0;
 
     const repoSkillsBySlug = new Map<string, Skill>();
+    const publisherSkillsBySlug = new Map<string, Skill>();
     for (const skill of available) {
       if (skill.source === "serenorg" && skill.sourceUrl) {
         repoSkillsBySlug.set(skill.slug, skill);
+      } else if (skill.source === "seren" && skill.sourceUrl) {
+        publisherSkillsBySlug.set(skill.slug, skill);
       }
     }
 
@@ -1386,8 +1419,51 @@ export const skills = {
       // Skip skills that already have sync state
       if (skill.syncState) continue;
 
+      // Try matching to upstream repo first, then publisher catalog
       const repoMatch = repoSkillsBySlug.get(skill.slug);
-      if (!repoMatch?.sourceUrl) continue;
+      const publisherMatch = publisherSkillsBySlug.get(skill.slug);
+      const match = repoMatch ?? publisherMatch;
+      if (!match?.sourceUrl) {
+        // Also detect publisher skills by SKILL.md metadata (publisher_slug)
+        const content = await this.readContent(skill);
+        if (!content) continue;
+        const slugMatch = content.match(/"publisher_slug"\s*:\s*"([^"]+)"/);
+        if (slugMatch) {
+          const publisherSlug = slugMatch[1];
+          const contentHash = await computeContentHash(content);
+          const syncState: SkillSyncState = {
+            version: 1,
+            upstreamSource: "seren" as SkillSource,
+            upstreamSourceUrl: `${apiBase}/publishers/${publisherSlug}/skill.md`,
+            syncedRevision: null,
+            syncedAt: Date.now(),
+            managedFiles: { "SKILL.md": contentHash },
+          };
+          try {
+            await invoke("write_skill_sync_state", {
+              skillsDir: skill.skillsDir,
+              slug: skill.dirName,
+              stateJson: JSON.stringify(syncState),
+            });
+            backfilled++;
+            log.info(
+              "[Skills] Backfilled publisher sync state for",
+              skill.slug,
+              "→ publisher:",
+              publisherSlug,
+            );
+          } catch (err) {
+            log.warn(
+              "[Skills] Failed to backfill publisher sync state for",
+              skill.slug,
+              err,
+            );
+          }
+        }
+        continue;
+      }
+
+      const source: SkillSource = repoMatch ? "serenorg" : "seren";
 
       // Read current content to compute managed file hash
       const content = await this.readContent(skill);
@@ -1396,8 +1472,8 @@ export const skills = {
       const contentHash = await computeContentHash(content);
       const syncState: SkillSyncState = {
         version: 1,
-        upstreamSource: "serenorg" as SkillSource,
-        upstreamSourceUrl: repoMatch.sourceUrl,
+        upstreamSource: source,
+        upstreamSourceUrl: match.sourceUrl,
         syncedRevision: null,
         syncedAt: Date.now(),
         managedFiles: { "SKILL.md": contentHash },
@@ -1414,7 +1490,7 @@ export const skills = {
           "[Skills] Backfilled sync state for",
           skill.slug,
           "→",
-          repoMatch.sourceUrl,
+          match.sourceUrl,
         );
       } catch (err) {
         log.warn("[Skills] Failed to backfill sync state for", skill.slug, err);

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -10,6 +10,7 @@ import type {
   SkillsState,
 } from "@/lib/skills";
 import {
+  isPublisherManagedSkill,
   isUpstreamManagedSkill,
   type ProjectSkillsConfig,
   skills,
@@ -609,12 +610,15 @@ export const skillsStore = {
     ]);
 
     // Backfill sync state for skills installed before the sync feature
-    // existed (pre-v2.3.16). Non-blocking — failures are logged and skipped.
+    // existed (pre-v2.3.16). Covers both upstream repo skills and publisher
+    // skills. Non-blocking — failures are logged and skipped.
     const needsBackfill = state.installed.some(
       (s) =>
         !s.syncState &&
         state.available.some(
-          (a) => a.slug === s.slug && a.source === "serenorg",
+          (a) =>
+            a.slug === s.slug &&
+            (a.source === "serenorg" || a.source === "seren"),
         ),
     );
     if (needsBackfill) {
@@ -651,6 +655,49 @@ export const skillsStore = {
     }
     if (autoRefreshed > 0) {
       await this.refreshInstalled();
+    }
+
+    // Detect and remove installed publisher skills whose publisher no longer
+    // exists in the catalog (deleted publishers return 404 from the Gateway).
+    const catalogSlugs = new Set(
+      state.available.filter((s) => s.source === "seren").map((s) => s.slug),
+    );
+    let removedStale = 0;
+    for (const skill of [...state.installed]) {
+      if (!isPublisherManagedSkill(skill)) continue;
+      // Extract publisher slug from the sourceUrl
+      // Format: https://api.serendb.com/publishers/{slug}/skill.md
+      const urlMatch = skill.upstreamSourceUrl.match(
+        /\/publishers\/([^/]+)\/skill\.md$/,
+      );
+      if (!urlMatch) continue;
+      const publisherSlug = urlMatch[1];
+      if (catalogSlugs.has(publisherSlug)) continue;
+
+      // Publisher not in catalog — remove the stale skill
+      try {
+        await this.remove(skill);
+        removedStale++;
+        log.info(
+          "[SkillsStore] Removed stale publisher skill:",
+          skill.slug,
+          "(publisher deleted:",
+          `${publisherSlug})`,
+        );
+      } catch (err) {
+        log.warn(
+          "[SkillsStore] Failed to remove stale publisher skill:",
+          skill.slug,
+          err,
+        );
+      }
+    }
+    if (removedStale > 0) {
+      log.info(
+        "[SkillsStore] Cleaned up",
+        removedStale,
+        "stale publisher skill(s)",
+      );
     }
   },
 

--- a/tests/unit/publisher-skill-lifecycle.test.ts
+++ b/tests/unit/publisher-skill-lifecycle.test.ts
@@ -1,0 +1,110 @@
+// ABOUTME: Test publisher skill lifecycle management.
+// ABOUTME: Verifies isPublisherManagedSkill guard and stale publisher detection.
+
+import { describe, expect, it } from "vitest";
+import type { InstalledSkill, SkillSyncState } from "@/lib/skills/types";
+
+/**
+ * Inline copy of isPublisherManagedSkill for testing without Tauri deps.
+ * Must match the implementation in src/services/skills.ts.
+ */
+function isPublisherManagedSkill(
+  skill: InstalledSkill,
+): boolean {
+  return (
+    !!skill.syncState &&
+    skill.upstreamSource === "seren" &&
+    typeof skill.upstreamSourceUrl === "string" &&
+    skill.upstreamSourceUrl.length > 0
+  );
+}
+
+function makeSkill(overrides: Partial<InstalledSkill> = {}): InstalledSkill {
+  return {
+    id: "local:test-skill",
+    slug: "test-skill",
+    name: "Test Skill",
+    description: "A test skill",
+    source: "local",
+    tags: [],
+    scope: "seren",
+    skillsDir: "/test/skills",
+    dirName: "test-skill",
+    path: "/test/skills/test-skill/SKILL.md",
+    installedAt: Date.now(),
+    enabled: true,
+    contentHash: "abc123",
+    ...overrides,
+  };
+}
+
+const publisherSyncState: SkillSyncState = {
+  version: 1,
+  upstreamSource: "seren",
+  upstreamSourceUrl:
+    "https://api.serendb.com/publishers/polymarket-trading-serenai/skill.md",
+  syncedRevision: null,
+  syncedAt: Date.now(),
+  managedFiles: { "SKILL.md": "abc123" },
+};
+
+const repoSyncState: SkillSyncState = {
+  version: 1,
+  upstreamSource: "serenorg",
+  upstreamSourceUrl:
+    "https://raw.githubusercontent.com/serenorg/seren-skills/main/polymarket/bot/SKILL.md",
+  syncedRevision: "abc123",
+  syncedAt: Date.now(),
+  managedFiles: { "SKILL.md": "abc123" },
+};
+
+describe("isPublisherManagedSkill", () => {
+  it("returns true for a skill with seren publisher sync state", () => {
+    const skill = makeSkill({
+      syncState: publisherSyncState,
+      upstreamSource: "seren",
+      upstreamSourceUrl: publisherSyncState.upstreamSourceUrl,
+    });
+    expect(isPublisherManagedSkill(skill)).toBe(true);
+  });
+
+  it("returns false for a skill with serenorg upstream sync state", () => {
+    const skill = makeSkill({
+      syncState: repoSyncState,
+      upstreamSource: "serenorg",
+      upstreamSourceUrl: repoSyncState.upstreamSourceUrl,
+    });
+    expect(isPublisherManagedSkill(skill)).toBe(false);
+  });
+
+  it("returns false for a skill with no sync state", () => {
+    const skill = makeSkill({ syncState: null });
+    expect(isPublisherManagedSkill(skill)).toBe(false);
+  });
+
+  it("returns false for a skill with empty upstreamSourceUrl", () => {
+    const skill = makeSkill({
+      syncState: { ...publisherSyncState },
+      upstreamSource: "seren",
+      upstreamSourceUrl: "",
+    });
+    expect(isPublisherManagedSkill(skill)).toBe(false);
+  });
+});
+
+describe("publisher slug extraction from upstreamSourceUrl", () => {
+  it("extracts publisher slug from standard sourceUrl format", () => {
+    const url =
+      "https://api.serendb.com/publishers/polymarket-trading-serenai/skill.md";
+    const match = url.match(/\/publishers\/([^/]+)\/skill\.md$/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("polymarket-trading-serenai");
+  });
+
+  it("returns null for non-publisher URLs", () => {
+    const url =
+      "https://raw.githubusercontent.com/serenorg/seren-skills/main/polymarket/SKILL.md";
+    const match = url.match(/\/publishers\/([^/]+)\/skill\.md$/);
+    expect(match).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Publisher-installed skills now get `.seren-sync.json` at install time with `source: "seren"`
- New `isPublisherManagedSkill()` type guard identifies publisher-managed skills
- `refresh()` now detects installed publisher skills whose publisher is no longer in the catalog and auto-removes them
- `backfillSyncState()` extended to detect legacy publisher skills by parsing `publisher_slug` from SKILL.md metadata
- Stale `target/{debug,release}/skills/` build artifacts verified unused and deleted

## Test plan
- [ ] Install a publisher skill, verify `.seren-sync.json` is created with `upstreamSource: "seren"`
- [ ] Existing `polymarket-trading-serenai` skill should be backfilled and auto-removed on next refresh (publisher deleted)
- [ ] Verify upstream repo skills continue to sync normally
- [ ] Run `pnpm test` — 6 new tests pass

Closes #1199

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com