### PR TITLE
fix: add isPublisherManagedSkill to skills-auto-sync test mock

### DIFF
--- a/tests/unit/skills-auto-sync.test.ts
+++ b/tests/unit/skills-auto-sync.test.ts
@@ -13,6 +13,7 @@ const mockSkillsService = vi.hoisted(() => ({
   inspectSyncStatus: vi.fn().mockResolvedValue({ updateAvailable: false }),
   refreshInstalledSkill: vi.fn().mockResolvedValue({ installed: {}, syncStatus: null }),
   isUpstreamManagedSkill: vi.fn().mockReturnValue(false),
+  isPublisherManagedSkill: vi.fn().mockReturnValue(false),
 }));
 
 vi.mock("solid-js/store", () => ({
@@ -45,6 +46,7 @@ vi.mock("@/services/skills", () => ({
     refreshInstalledSkill: mockSkillsService.refreshInstalledSkill,
   },
   isUpstreamManagedSkill: mockSkillsService.isUpstreamManagedSkill,
+  isPublisherManagedSkill: mockSkillsService.isPublisherManagedSkill,
 }));
 
 describe("skills auto-sync on refresh (#1155)", () => {


### PR DESCRIPTION
## Summary
- Adds missing `isPublisherManagedSkill` export to the `@/services/skills` mock in `skills-auto-sync.test.ts`

## Test plan
- [x] All 3 skills-auto-sync tests pass locally

Fixes #1202

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com