### PR TITLE
fix: rename skill directories when slug diverges from dirName

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -795,6 +795,7 @@ pub fn run() {
             skills::list_skill_dirs,
             skills::install_skill,
             skills::validate_skill_payload,
+            skills::rename_skill_dir,
             skills::remove_skill,
             skills::read_skill_content,
             skills::read_skill_file,

--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -780,6 +780,39 @@ pub fn validate_skill_payload(skills_dir: String, slug: String) -> Result<Vec<St
     Ok(missing)
 }
 
+/// Rename a skill directory when the resolved slug no longer matches the
+/// filesystem directory name (e.g. after an upstream SKILL.md name change).
+/// Returns the new SKILL.md path on success.
+#[tauri::command]
+pub fn rename_skill_dir(
+    skills_dir: String,
+    old_dir_name: String,
+    new_dir_name: String,
+) -> Result<String, String> {
+    let base = PathBuf::from(&skills_dir);
+    let old_path = base.join(&old_dir_name);
+    let new_path = base.join(&new_dir_name);
+
+    if !old_path.is_dir() {
+        return Err(format!(
+            "Source directory does not exist: {}",
+            old_path.display()
+        ));
+    }
+    if new_path.exists() {
+        return Err(format!(
+            "Target directory already exists: {}",
+            new_path.display()
+        ));
+    }
+
+    fs::rename(&old_path, &new_path)
+        .map_err(|e| format!("Failed to rename skill directory: {}", e))?;
+
+    let skill_md = new_path.join("SKILL.md");
+    Ok(skill_md.to_string_lossy().to_string())
+}
+
 #[derive(serde::Deserialize)]
 struct ExtraFile {
     path: String,

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1114,6 +1114,21 @@ export const skills = {
   },
 
   /**
+   * Rename a skill directory when the resolved slug no longer matches the
+   * filesystem directory name. Returns the new SKILL.md path.
+   */
+  async renameSkillDir(
+    skill: InstalledSkill,
+    newDirName: string,
+  ): Promise<string> {
+    return invoke<string>("rename_skill_dir", {
+      skillsDir: skill.skillsDir,
+      oldDirName: skill.dirName,
+      newDirName,
+    });
+  },
+
+  /**
    * Read a relative file from an installed skill directory.
    */
   async readFile(

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -699,6 +699,38 @@ export const skillsStore = {
         "stale publisher skill(s)",
       );
     }
+
+    // Rename skill directories where the resolved slug (from SKILL.md name)
+    // no longer matches the filesystem directory name. This happens when a
+    // skill is renamed upstream — the content syncs but the directory retains
+    // the old name, causing the agent to not find the skill by its new slug.
+    let renamedDirs = 0;
+    for (const skill of [...state.installed]) {
+      if (skill.dirName === skill.slug) continue;
+      if (!skill.syncState) continue;
+      try {
+        await skills.renameSkillDir(skill, skill.slug);
+        renamedDirs++;
+        log.info(
+          "[SkillsStore] Renamed skill dir:",
+          skill.dirName,
+          "→",
+          skill.slug,
+        );
+      } catch (err) {
+        // Target may already exist or rename failed — not fatal
+        log.debug(
+          "[SkillsStore] Could not rename skill dir:",
+          skill.dirName,
+          "→",
+          skill.slug,
+          err,
+        );
+      }
+    }
+    if (renamedDirs > 0) {
+      await this.refreshInstalled();
+    }
   },
 
   /**


### PR DESCRIPTION
## Summary
- Adds `rename_skill_dir` Tauri command to rename a skill's filesystem directory
- Adds `renameSkillDir` to the skills service as the frontend wrapper
- During `refresh()`, detects installed skills where `dirName !== slug` (indicating an upstream rename) and auto-renames the directory to match

## Problem
When a skill is renamed upstream (e.g. `polymarket/trader` → `polymarket/bot`), the SKILL.md content syncs correctly but the filesystem directory retains the old name (`polymarket-trader/`). The panel shows it as installed under the new name, but the agent cannot find it by the new slug — silently falling back to a different skill.

## Test plan
- [ ] Verify `polymarket-trader/` is renamed to `polymarket-bot/` on next app startup
- [ ] Verify the skill loads correctly after rename
- [ ] Verify skills with matching dirName/slug are not affected
- [ ] Run `pnpm test` — all existing tests pass

Closes #1204

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com