### PR TITLE
fix: stop hardcoding seren fallback in parsePublisherFromToolName

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -85,28 +85,30 @@ function isCacheValid(): boolean {
 
 /**
  * Parse publisher slug from MCP tool name.
- * Seren MCP tools are named like "mcp__publisher-slug__tool-name"
+ * Publisher tools are named like "mcp__publisher-slug__tool-name".
+ * Returns null for built-in gateway tools (no mcp__ prefix).
  */
 function parsePublisherFromToolName(toolName: string): {
   publisher: string;
   originalName: string;
-} {
+} | null {
   const match = toolName.match(/^mcp__([^_]+)__(.+)$/);
   if (match) {
     return { publisher: match[1], originalName: match[2] };
   }
-  // Fallback for tools without publisher prefix
-  return { publisher: "seren", originalName: toolName };
+  return null;
 }
 
 /**
  * Convert MCP tool to GatewayTool format.
+ * Returns null for built-in gateway tools (no publisher prefix).
  */
-function convertToGatewayTool(tool: McpTool): GatewayTool {
-  const { publisher } = parsePublisherFromToolName(tool.name);
+function convertToGatewayTool(tool: McpTool): GatewayTool | null {
+  const parsed = parsePublisherFromToolName(tool.name);
+  if (!parsed) return null;
   return {
-    publisher,
-    publisherName: publisher, // We don't have the display name from MCP
+    publisher: parsed.publisher,
+    publisherName: parsed.publisher,
     tool: {
       name: tool.name,
       description: tool.description,
@@ -270,8 +272,10 @@ export async function initializeGateway(): Promise<void> {
         throw new Error("Connection not found after connecting");
       }
 
-      // Convert static MCP tools to GatewayTool format
-      cachedTools = connection.tools.map(convertToGatewayTool);
+      // Convert publisher MCP tools to GatewayTool format (skip built-in tools)
+      cachedTools = connection.tools
+        .map(convertToGatewayTool)
+        .filter((t): t is GatewayTool => t !== null);
 
       // Discover dynamic publisher tools (Gmail, Google Calendar, etc.)
       // that aren't in the static list_tools() response.
@@ -279,9 +283,7 @@ export async function initializeGateway(): Promise<void> {
         const publisherTools = await discoverPublisherTools();
         if (publisherTools.length > 0) {
           // Merge, deduplicating by tool name
-          const existingNames = new Set(
-            cachedTools.map((t) => t.tool.name),
-          );
+          const existingNames = new Set(cachedTools.map((t) => t.tool.name));
           const newTools = publisherTools.filter(
             (t) => !existingNames.has(t.tool.name),
           );

--- a/tests/services/mcp-gateway.test.ts
+++ b/tests/services/mcp-gateway.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/services/mcp-oauth", () => ({
   clearStoredTokens: vi.fn().mockResolvedValue(undefined),
 }));
 
-// Mock MCP client
+// Mock MCP client — includes a publisher tool AND a built-in tool (no mcp__ prefix)
 vi.mock("@/lib/mcp/client", () => ({
   mcpClient: {
     connectHttp: vi.fn().mockResolvedValue(undefined),
@@ -26,7 +26,17 @@ vi.mock("@/lib/mcp/client", () => ({
       tools: [
         {
           name: "mcp__test__test-tool",
-          description: "Test tool",
+          description: "Test publisher tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+        {
+          name: "list_mcp_tools",
+          description: "Built-in gateway management tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+        {
+          name: "call_publisher",
+          description: "Another built-in tool",
           inputSchema: { type: "object", properties: {} },
         },
       ],
@@ -43,27 +53,6 @@ vi.mock("@/services/mcp-oauth", () => ({
   getValidAccessToken: vi.fn().mockResolvedValue("mock-mcp-token"),
   isMcpAuthenticated: vi.fn().mockResolvedValue(true),
   clearStoredTokens: vi.fn().mockResolvedValue(undefined),
-}));
-
-// Mock MCP client
-vi.mock("@/lib/mcp/client", () => ({
-  mcpClient: {
-    connectHttp: vi.fn().mockResolvedValue(undefined),
-    disconnectHttp: vi.fn().mockResolvedValue(undefined),
-    getConnection: vi.fn().mockReturnValue({
-      tools: [
-        {
-          name: "mcp__test__test-tool",
-          description: "Test tool",
-          inputSchema: { type: "object", properties: {} },
-        },
-      ],
-    }),
-    callToolHttp: vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: "result" }],
-      isError: false,
-    }),
-  },
 }));
 
 describe("MCP Gateway Caching", () => {
@@ -125,5 +114,24 @@ describe("MCP Gateway Caching", () => {
     await resetGateway();
     expect(getGatewayTools()).toHaveLength(0);
     expect(isGatewayInitialized()).toBe(false);
+  });
+
+  it("should exclude built-in tools without mcp__ prefix (#1210)", async () => {
+    const { initializeGateway, getGatewayTools } = await import(
+      "@/services/mcp-gateway"
+    );
+
+    await initializeGateway();
+    const tools = getGatewayTools();
+
+    // Only the mcp__test__test-tool should survive; list_mcp_tools and
+    // call_publisher are built-in gateway tools and must not be converted
+    expect(tools).toHaveLength(1);
+    expect(tools[0].publisher).toBe("test");
+    expect(tools[0].tool.name).toBe("mcp__test__test-tool");
+
+    // Verify no tool has the fallback "seren" publisher
+    const serenTools = tools.filter((t) => t.publisher === "seren");
+    expect(serenTools).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- `parsePublisherFromToolName()` was hardcoding `publisher: "seren"` as fallback for tools without `mcp__` prefix
- Built-in gateway tools (list_mcp_tools, call_publisher, etc.) hit this fallback
- Orchestrator then routed to non-existent `seren` publisher → HTTP 404
- Fix: return `null` for non-publisher tools, filter them out in `convertToGatewayTool()`
- Also fixes pre-existing biome formatting issue in the same file

## Test plan
- [x] New test: built-in tools without `mcp__` prefix are excluded from gateway tools
- [x] All 4 mcp-gateway tests pass
- [x] Full test suite: 206 tests pass (18 files)
- [x] Biome check passes

Fixes #1210