### PR TITLE
fix: prevent background agent spawns from stealing active session focus

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1104,7 +1104,15 @@ export const agentStore = {
       };
 
       setState("sessions", info.id, session);
-      setState("activeSessionId", info.id);
+
+      // Only take focus if no session is currently active. Background spawns
+      // (e.g. compaction of an inactive thread) must not steal focus from
+      // the user's current thread. The caller (threadStore.selectThread,
+      // resumeAgentConversation, etc.) is responsible for setting focus
+      // after spawn when the user explicitly navigates to the thread.
+      if (!state.activeSessionId) {
+        setState("activeSessionId", info.id);
+      }
 
       const pendingEvents = pendingSessionEvents.get(info.id);
       if (pendingEvents?.length) {


### PR DESCRIPTION
## Summary

- `spawnSession` unconditionally set `activeSessionId` to the new session, even for background spawns
- When compaction or recovery spawned a session for a background thread (e.g. Codex running tool calls while user views Claude Code), it stole focus
- This triggered reactive thread switches and wasted orchestrator API calls (double-fire + cancel)
- Now `spawnSession` only sets `activeSessionId` when no session is currently active
- The caller (`selectThread`, `resumeAgentConversation`, etc.) sets focus when the user explicitly navigates

Fixes #1213

## Test plan

- Open two agent threads (e.g. Claude Code and Codex)
- Start a task on Codex, then switch to the Claude Code thread
- Verify the UI stays on Claude Code while Codex works in the background
- Verify no `setActiveSession` calls switch to the Codex session in the console
- Verify creating a new agent thread still takes focus correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com