### PR TITLE
fix: fail loudly when skill tree API fetch fails instead of using stale cache

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -449,7 +449,9 @@ export function isPublisherManagedSkill(
 
 /**
  * Fetch all payload files (excluding SKILL.md) from a skill's GitHub directory.
- * Uses the cached repo tree to discover files, then fetches their raw content.
+ * Fetches a fresh repo tree (cache-busted) to discover files, then fetches
+ * their raw content.  If the tree fetch fails, the error propagates so callers
+ * never silently install from a stale tree.
  */
 async function fetchRepoSkillPayloadFiles(
   sourceUrl: string,
@@ -457,25 +459,28 @@ async function fetchRepoSkillPayloadFiles(
   const dirPrefix = deriveRepoDirPrefix(sourceUrl);
   if (!dirPrefix) return [];
 
-  // Always fetch a fresh tree for install/refresh operations so we pick up
-  // newly added files and don't serve stale content from a cached tree that
-  // was fetched at app startup (before the upstream merge landed).
-  try {
-    const response = await appFetch(SKILLS_INDEX_URL, {
-      headers: githubApiHeaders(),
-    });
-    if (response.ok) {
-      const payload = (await response.json()) as GitHubTreeResponse;
-      cachedRepoTree = payload.tree ?? [];
-    }
-  } catch {
-    log.warn("[Skills] Failed to fetch repo tree for payload files");
+  // Fetch a fresh tree with cache-bust to avoid GitHub API CDN staleness.
+  // On failure this throws — callers must not fall back to a stale tree
+  // because recording a new syncedRevision with old file content would mask
+  // an incomplete sync and prevent future retries.
+  const cacheBustedTreeUrl = `${SKILLS_INDEX_URL}&t=${Date.now()}`;
+  const response = await appFetch(cacheBustedTreeUrl, {
+    headers: githubApiHeaders(),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch repo tree for payload files: ${response.status}`,
+    );
   }
+  const payload = (await response.json()) as GitHubTreeResponse;
+  const freshTree = payload.tree ?? [];
+  // Also update the global cache so subsequent operations benefit
+  cachedRepoTree = freshTree;
 
-  if (!cachedRepoTree) return [];
+  if (freshTree.length === 0) return [];
 
   // Find all blob files under the skill directory (excluding SKILL.md itself)
-  const siblingFiles = cachedRepoTree.filter(
+  const siblingFiles = freshTree.filter(
     (node) =>
       node.type === "blob" &&
       typeof node.path === "string" &&

--- a/tests/unit/skills-payload-fetch.test.ts
+++ b/tests/unit/skills-payload-fetch.test.ts
@@ -1,0 +1,128 @@
+// ABOUTME: Tests that skill payload file fetching fails loudly on network errors.
+// ABOUTME: Prevents silent fallback to stale tree cache during install/refresh (#1215).
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAppFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/fetch", () => ({
+  appFetch: mockAppFetch,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@/services/catalog", () => ({
+  catalog: {},
+}));
+
+describe("fetchRepoSkillPayloadFiles stale cache prevention (#1215)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("throws when tree API fetch fails instead of using stale cache", async () => {
+    // First call: SKILL.md fetch succeeds
+    // Second call: tree API fetch fails (network error)
+    // Third call: revision fetch succeeds
+    mockAppFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => "---\nname: Test Skill\n---\nContent",
+      })
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ sha: "abc123" }],
+      });
+
+    const { skills } = await import("@/services/skills");
+
+    // refreshInstalledSkill calls fetchUpstreamSkillBundle which calls
+    // fetchRepoSkillPayloadFiles. If the tree fetch fails, the whole
+    // refresh must fail — not silently succeed with stale files.
+    await expect(
+      skills.refreshInstalledSkill({
+        slug: "test-skill",
+        name: "Test Skill",
+        description: "desc",
+        id: "local:test-skill",
+        source: "local",
+        tags: [],
+        scope: "seren",
+        skillsDir: "/skills",
+        dirName: "test-skill",
+        path: "/skills/test-skill/SKILL.md",
+        installedAt: 1,
+        enabled: true,
+        contentHash: "hash",
+        upstreamSource: "serenorg",
+        upstreamSourceUrl:
+          "https://raw.githubusercontent.com/serenorg/seren-skills/main/test/skill/SKILL.md",
+        syncState: {
+          version: 1,
+          upstreamSource: "serenorg",
+          upstreamSourceUrl:
+            "https://raw.githubusercontent.com/serenorg/seren-skills/main/test/skill/SKILL.md",
+          syncedRevision: "old-sha",
+          syncedAt: 1,
+          managedFiles: { "SKILL.md": "oldhash" },
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws when tree API returns non-OK status", async () => {
+    mockAppFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => "---\nname: Test Skill\n---\nContent",
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ sha: "abc123" }],
+      });
+
+    const { skills } = await import("@/services/skills");
+
+    await expect(
+      skills.refreshInstalledSkill({
+        slug: "test-skill",
+        name: "Test Skill",
+        description: "desc",
+        id: "local:test-skill",
+        source: "local",
+        tags: [],
+        scope: "seren",
+        skillsDir: "/skills",
+        dirName: "test-skill",
+        path: "/skills/test-skill/SKILL.md",
+        installedAt: 1,
+        enabled: true,
+        contentHash: "hash",
+        upstreamSource: "serenorg",
+        upstreamSourceUrl:
+          "https://raw.githubusercontent.com/serenorg/seren-skills/main/test/skill/SKILL.md",
+        syncState: {
+          version: 1,
+          upstreamSource: "serenorg",
+          upstreamSourceUrl:
+            "https://raw.githubusercontent.com/serenorg/seren-skills/main/test/skill/SKILL.md",
+          syncedRevision: "old-sha",
+          syncedAt: 1,
+          managedFiles: { "SKILL.md": "oldhash" },
+        },
+      }),
+    ).rejects.toThrow(/Failed to fetch repo tree/);
+  });
+});


### PR DESCRIPTION
## Summary
- `fetchRepoSkillPayloadFiles()` was silently falling back to stale `cachedRepoTree` when GitHub tree API failed
- This caused `refreshInstalledSkill()` to write old files while recording a new `syncedRevision`, masking the incomplete sync
- Cache-bust the tree API URL (`&t=Date.now()`)
- Throw on failure instead of falling through to stale cache
- Use a local `freshTree` variable to avoid confusion with the global cache

## Test plan
- [x] New test: tree API network error throws instead of silent fallback
- [x] New test: tree API non-OK status (403) throws with descriptive message
- [x] Full suite: 208 tests pass (19 files)
- [x] Biome check passes
- [x] Verified locally that skill runtime IS now synced (safety guards present)

Fixes #1215