### PR TITLE
fix: remove publisher_type filter that blocked all publisher tool discovery

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -120,13 +120,9 @@ function convertToGatewayTool(tool: McpTool): GatewayTool | null {
 /**
  * Discover dynamic publisher tools via the gateway.
  *
- * `list_mcp_tools` requires a `publisher` parameter (one publisher at a time).
- * We first identify publishers already known from the static tool list, then
- * call `list_mcp_tools` for each to discover any additional tools not already
- * in the static `list_tools()` response (e.g. Gmail, Google Calendar).
- *
- * Uses `list_agent_publishers` to discover publishers, then queries each
- * MCP-type publisher for its tools.
+ * Queries `list_agent_publishers` for all active publishers, then calls
+ * `list_mcp_tools` for each to discover tools (Gmail, Google Calendar, etc.).
+ * Publishers that don't expose tools return empty/error and are skipped.
  */
 async function discoverPublisherTools(): Promise<GatewayTool[]> {
   // Get all available publishers from the gateway
@@ -148,10 +144,6 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
       const parsed = JSON.parse(textContent);
       const pubs = parsed.publishers ?? parsed.data ?? parsed ?? [];
       publisherSlugs = pubs
-        .filter(
-          (p: { publisher_type?: string }) =>
-            p.publisher_type === "mcp" || p.publisher_type === "api",
-        )
         .map((p: { slug?: string; name?: string }) => p.slug ?? p.name)
         .filter(Boolean);
     }

--- a/tests/services/mcp-gateway.test.ts
+++ b/tests/services/mcp-gateway.test.ts
@@ -134,4 +134,75 @@ describe("MCP Gateway Caching", () => {
     const serenTools = tools.filter((t) => t.publisher === "seren");
     expect(serenTools).toHaveLength(0);
   });
+
+  it("should discover publisher tools regardless of publisher_type (#1217)", async () => {
+    const { mcpClient } = await import("@/lib/mcp/client");
+    const callToolMock = vi.mocked(mcpClient.callToolHttp);
+
+    // Mock list_agent_publishers → returns publisher with type "individual"
+    // Mock list_mcp_tools for gmail → returns gmail tools
+    callToolMock.mockImplementation(async (_server, request) => {
+      if (request.name === "list_agent_publishers") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                publishers: [
+                  {
+                    slug: "gmail",
+                    name: "GMail",
+                    publisher_type: "individual",
+                    integration_type: "api",
+                  },
+                ],
+              }),
+            },
+          ],
+          isError: false,
+        };
+      }
+      if (
+        request.name === "list_mcp_tools" &&
+        request.arguments?.publisher === "gmail"
+      ) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                tools: [
+                  {
+                    name: "get_messages",
+                    description: "List messages in mailbox",
+                    inputSchema: { type: "object", properties: {} },
+                  },
+                  {
+                    name: "post_messages_send",
+                    description: "Send a new email",
+                    inputSchema: { type: "object", properties: {} },
+                  },
+                ],
+              }),
+            },
+          ],
+          isError: false,
+        };
+      }
+      return { content: [], isError: true };
+    });
+
+    const { initializeGateway, getGatewayTools } = await import(
+      "@/services/mcp-gateway"
+    );
+
+    await initializeGateway();
+    const tools = getGatewayTools();
+
+    // Should have: 1 static tool (mcp__test__test-tool) + 2 gmail tools
+    const gmailTools = tools.filter((t) => t.publisher === "gmail");
+    expect(gmailTools).toHaveLength(2);
+    expect(gmailTools[0].tool.name).toBe("mcp__gmail__get_messages");
+    expect(gmailTools[1].tool.name).toBe("mcp__gmail__post_messages_send");
+  });
 });


### PR DESCRIPTION
## Summary
- discoverPublisherTools() filtered on publisher_type === mcp or api but every publisher has publisher_type: individual - zero matched
- This meant Gmail, Google Calendar, Google Drive, and all other publisher tools were never discovered
- Removed the filter entirely - all active publishers are queried, list_mcp_tools returns empty for those without tools

## Root cause analysis
- All 50 publishers in the catalog have publisher_type: individual
- The field that distinguishes API publishers is integration_type: api (a different field)
- Rather than switching to filter on integration_type, removed the filter since Promise.allSettled already handles publishers that dont expose tools

## Test plan
- [x] New test: publishers with publisher_type individual are discovered (Gmail mock with 2 tools)
- [x] All 5 gateway tests pass
- [x] Full suite: 209 tests pass (19 files)
- [x] Biome clean

Fixes #1217

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com