### PR TITLE
fix: await auth before loading threads to ensure agents get publisher tools

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,7 +72,7 @@ function App() {
     }
 
     await initAuthRuntimeBindings();
-    checkAuth();
+    await checkAuth();
 
     if (runtime.capabilities.updater) {
       const { updaterStore } = await import("@/stores/updater.store");

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1028,8 +1028,17 @@ export const agentStore = {
         setState("installStatus", null);
       }
 
-      // Get Seren API key to enable MCP tools for the agent
-      const apiKey = await getSerenApiKey();
+      // Get Seren API key to enable MCP tools for the agent.
+      // If null, auth may still be initializing — wait briefly and retry
+      // so the agent gets publisher access on cold start.
+      let apiKey = await getSerenApiKey();
+      if (!apiKey) {
+        await new Promise((r) => setTimeout(r, 3000));
+        apiKey = await getSerenApiKey();
+        if (apiKey) {
+          console.info("[AgentStore] API key became available after waiting for auth");
+        }
+      }
       const enabledMcpServers = getEnabledMcpServers();
 
       // No inactivity timeout — agent sessions wait indefinitely.


### PR DESCRIPTION
## Summary

- `checkAuth()` was called without `await` in App.tsx, causing agent sessions to spawn before the API key was stored
- Agents spawned without the Seren MCP server configured — no publisher tools (Gmail, Firecrawl, etc.)
- Claude Code CLI crashed on cold start ('request failed') without proper auth
- Now awaits `checkAuth()` before `threadStore.refresh()` loads
- Defensive retry in `spawnSession` waits 3s if API key is null on first attempt

Fixes #1225

## Three symptoms resolved

1. 'No Seren publishers or agents are currently available' — agents now get API key before spawn
2. 'Claude Code request failed' on cold start — CLI gets proper auth
3. Gmail and other publisher tools inaccessible in agent threads — Seren MCP server now configured

## Test plan

- Cold start the app with last-active thread being an agent thread
- Verify console shows API key retrieved before session spawn
- Send 'Summarize my emails in Gmail' in an agent thread
- Verify the agent can access Seren publisher tools (no 'No publishers available' error)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com