### PR TITLE
fix: verify frontend build against current commit (#1227)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,20 +176,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: pnpm tauri build --bundles deb,appimage --config src-tauri/tauri.ci.json
       - name: Verify frontend dist is current
-        shell: bash
-        run: |
-          if [ ! -d "dist" ] || [ -z "$(ls -A dist/)" ]; then
-            echo "FATAL: dist/ directory is missing or empty"
-            exit 1
-          fi
-          MARKERS=("AgentStore" "SkillsStore" "sendPrompt" "MCP Gateway")
-          for marker in "${MARKERS[@]}"; do
-            if ! grep -rq "$marker" dist/; then
-              echo "FATAL: Frontend marker '$marker' missing from dist/ — stale build"
-              exit 1
-            fi
-          done
-          echo "Frontend markers verified in dist/."
+        run: pnpm verify:frontend-build
       - uses: actions/upload-artifact@v7
         with:
           name: seren-desktop-${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,34 +306,8 @@ jobs:
 
       # Verify dist/ contains current frontend code.
       # Catches stale dist/ bundles that bypass beforeBuildCommand.
-      # Note: Tauri compresses embedded assets, so we check dist/ not the binary.
       - name: Verify frontend dist is current
-        shell: bash
-        run: |
-          echo "Checking that dist/ contains current frontend code..."
-
-          if [ ! -d "dist" ] || [ -z "$(ls -A dist/)" ]; then
-            echo "FATAL: dist/ directory is missing or empty"
-            exit 1
-          fi
-
-          MARKERS=("AgentStore" "SkillsStore" "sendPrompt" "MCP Gateway")
-          MISSING=0
-          for marker in "${MARKERS[@]}"; do
-            if ! grep -rq "$marker" dist/; then
-              echo "ERROR: Frontend marker '$marker' not found in dist/ — frontend may be stale"
-              MISSING=$((MISSING + 1))
-            fi
-          done
-
-          if [ "$MISSING" -gt 0 ]; then
-            echo ""
-            echo "FATAL: $MISSING frontend markers missing from dist/."
-            echo "The frontend build may have failed or produced stale output."
-            exit 1
-          fi
-
-          echo "All frontend markers verified in dist/."
+        run: pnpm verify:frontend-build
 
       # Upload macOS DMG immediately (before notarization so we always have an artifact)
       - name: Upload macOS DMG (pre-notarization)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "vite",
     "dev": "vite",
     "build": "vite build",
+    "verify:frontend-build": "node ./scripts/verify-frontend-build.mjs",
     "browser:local": "node ./bin/seren-desktop.mjs",
     "serve": "vite preview",
     "tauri": "tauri",

--- a/scripts/verify-frontend-build.mjs
+++ b/scripts/verify-frontend-build.mjs
@@ -1,0 +1,94 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { extname, join, relative, resolve } from "node:path";
+
+const DIST_DIR = resolve(process.env.SEREN_BUILD_DIST_DIR ?? "dist");
+const MANIFEST_PATH = join(DIST_DIR, "build-manifest.json");
+const SEARCHABLE_EXTENSIONS = new Set([".html", ".js"]);
+
+function fail(message) {
+  console.error(`FATAL: ${message}`);
+  process.exit(1);
+}
+
+function resolveExpectedCommit() {
+  const envCommit =
+    process.env.SEREN_BUILD_EXPECTED_COMMIT?.trim() ||
+    process.env.GITHUB_SHA?.trim();
+  if (envCommit) {
+    return envCommit;
+  }
+
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function collectCommitHits(dirPath, expectedCommit, matches = []) {
+  for (const entry of readdirSync(dirPath)) {
+    const entryPath = join(dirPath, entry);
+    const entryStat = statSync(entryPath);
+    if (entryStat.isDirectory()) {
+      collectCommitHits(entryPath, expectedCommit, matches);
+      continue;
+    }
+
+    if (!SEARCHABLE_EXTENSIONS.has(extname(entryPath))) {
+      continue;
+    }
+
+    const content = readFileSync(entryPath, "utf8");
+    if (content.includes(expectedCommit)) {
+      matches.push(relative(DIST_DIR, entryPath));
+    }
+  }
+
+  return matches;
+}
+
+const expectedCommit = resolveExpectedCommit();
+if (!expectedCommit) {
+  fail("could not determine expected git commit for this build");
+}
+
+if (!existsSync(DIST_DIR)) {
+  fail(`dist directory is missing at ${DIST_DIR}`);
+}
+
+if (!existsSync(MANIFEST_PATH)) {
+  fail(`build manifest missing at ${MANIFEST_PATH}`);
+}
+
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+} catch (error) {
+  fail(
+    `build manifest is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+  );
+}
+
+if (manifest.commit !== expectedCommit) {
+  fail(
+    `build manifest commit ${JSON.stringify(manifest.commit)} does not match HEAD ${expectedCommit}`,
+  );
+}
+
+if (typeof manifest.builtAt !== "string" || manifest.builtAt.trim() === "") {
+  fail("build manifest is missing a non-empty builtAt timestamp");
+}
+
+const commitHits = collectCommitHits(DIST_DIR, expectedCommit);
+if (commitHits.length === 0) {
+  fail(
+    `no built frontend asset embeds commit ${expectedCommit}; dist may be stale or partially rebuilt`,
+  );
+}
+
+console.log(
+  `Verified frontend build for ${expectedCommit} in ${commitHits.length} asset(s): ${commitHits.join(", ")}`,
+);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,9 @@ import { installExternalLinkInterceptor } from "@/lib/external-link";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 import App from "./App";
 
+document.documentElement.dataset.buildCommit = __SEREN_BUILD_COMMIT__;
+document.documentElement.dataset.buildTimestamp = __SEREN_BUILD_TIMESTAMP__;
+
 // Bridge browser console output to the Rust log backend.
 // In production, this persists console.log/error/warn to log files.
 if (isTauriRuntime()) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __SEREN_BUILD_COMMIT__: string;
+declare const __SEREN_BUILD_TIMESTAMP__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,82 @@
+import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
+import { defineConfig, type PluginOption } from "vite";
 import solid from "vite-plugin-solid";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+const BUILD_TIMESTAMP = new Date().toISOString();
+const BUILD_COMMIT = resolveBuildCommit();
+
+function resolveBuildCommit(): string {
+  const envCommit =
+    process.env.VITE_BUILD_COMMIT?.trim() || process.env.GITHUB_SHA?.trim();
+  if (envCommit) {
+    return envCommit;
+  }
+
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function buildMetadataPlugin(): PluginOption {
+  const manifest = `${JSON.stringify(
+    {
+      commit: BUILD_COMMIT,
+      builtAt: BUILD_TIMESTAMP,
+    },
+    null,
+    2,
+  )}\n`;
+
+  return {
+    name: "seren-build-metadata",
+    apply: "build",
+    transformIndexHtml() {
+      return {
+        tags: [
+          {
+            tag: "meta",
+            attrs: {
+              name: "seren-build-commit",
+              content: BUILD_COMMIT,
+            },
+            injectTo: "head",
+          },
+          {
+            tag: "meta",
+            attrs: {
+              name: "seren-build-timestamp",
+              content: BUILD_TIMESTAMP,
+            },
+            injectTo: "head",
+          },
+        ],
+      };
+    },
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "build-manifest.json",
+        source: manifest,
+      });
+    },
+  };
+}
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
-  plugins: [tailwindcss(), solid()],
+  plugins: [tailwindcss(), solid(), buildMetadataPlugin()],
+  define: {
+    __SEREN_BUILD_COMMIT__: JSON.stringify(BUILD_COMMIT),
+    __SEREN_BUILD_TIMESTAMP__: JSON.stringify(BUILD_TIMESTAMP),
+  },
 
   // Path aliases
   resolve: {


### PR DESCRIPTION
## Summary
- emit commit-specific frontend build metadata during `vite build`
- embed the current commit into shipped frontend assets and verify it via a shared script in CI/release
- replace the generic marker-based guard that allowed stale `dist/` output to pass

## Verification
- `pnpm build`
- `pnpm verify:frontend-build`
- `SEREN_BUILD_EXPECTED_COMMIT=deadbeef pnpm verify:frontend-build` (expected failure)

Closes #1227