### PR TITLE
fix: route gateway API requests through Rust bridge (#1229)

### DIFF
--- a/src-tauri/src/commands/gateway_http.rs
+++ b/src-tauri/src/commands/gateway_http.rs
@@ -1,0 +1,309 @@
+// ABOUTME: Rust-backed HTTP bridge for Seren Gateway API requests from the webview.
+// ABOUTME: Streams reqwest response bytes back to the frontend to avoid webview CORS limits.
+
+use std::collections::HashMap;
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+use futures::StreamExt;
+use reqwest::{
+    Method,
+    header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue},
+};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::sync::{Mutex, oneshot};
+use url::Url;
+
+const GATEWAY_HTTP_EVENT: &str = "gateway-http://event";
+const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
+
+#[derive(Default)]
+pub struct GatewayHttpState {
+    active: Mutex<HashMap<String, oneshot::Sender<()>>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GatewayHttpRequest {
+    pub request_id: String,
+    pub url: String,
+    pub method: String,
+    pub headers: HashMap<String, String>,
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GatewayHttpResponseMeta {
+    pub status: u16,
+    pub status_text: String,
+    pub headers: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GatewayHttpEvent {
+    request_id: String,
+    event_type: String,
+    chunk_base64: Option<String>,
+    error: Option<String>,
+}
+
+fn validate_gateway_url(raw_url: &str) -> Result<Url, String> {
+    let url = Url::parse(raw_url).map_err(|e| format!("Invalid gateway URL: {}", e))?;
+    let allowed_origin =
+        Url::parse(GATEWAY_BASE_URL).map_err(|e| format!("Invalid gateway base URL: {}", e))?;
+
+    if url.scheme() != allowed_origin.scheme()
+        || url.host_str() != allowed_origin.host_str()
+        || url.port_or_known_default() != allowed_origin.port_or_known_default()
+    {
+        return Err(format!(
+            "Gateway bridge only allows {} requests",
+            allowed_origin.origin().ascii_serialization()
+        ));
+    }
+
+    Ok(url)
+}
+
+fn normalize_path(path: &str) -> String {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn should_skip_stored_auth(path: &str) -> bool {
+    matches!(
+        normalize_path(path).as_str(),
+        "/auth/login" | "/auth/refresh" | "/auth/signup"
+    )
+}
+
+fn should_use_stored_auth(url: &Url, headers: &HeaderMap) -> bool {
+    !headers.contains_key(AUTHORIZATION) && !should_skip_stored_auth(url.path())
+}
+
+fn build_header_map(raw_headers: &HashMap<String, String>) -> Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+
+    for (name, value) in raw_headers {
+        let lower = name.to_ascii_lowercase();
+        if matches!(lower.as_str(), "host" | "origin" | "content-length" | "connection") {
+            continue;
+        }
+
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|e| format!("Invalid request header name '{}': {}", name, e))?;
+        let header_value = HeaderValue::from_str(value)
+            .map_err(|e| format!("Invalid request header '{}' value: {}", name, e))?;
+        headers.insert(header_name, header_value);
+    }
+
+    Ok(headers)
+}
+
+fn apply_headers(
+    mut builder: reqwest::RequestBuilder,
+    headers: &HeaderMap,
+) -> reqwest::RequestBuilder {
+    for (name, value) in headers {
+        builder = builder.header(name, value.clone());
+    }
+    builder
+}
+
+fn build_request(
+    client: &reqwest::Client,
+    method: &Method,
+    url: &Url,
+    headers: &HeaderMap,
+    body: Option<&str>,
+    token: Option<&str>,
+) -> reqwest::RequestBuilder {
+    let mut builder = client.request(method.clone(), url.clone());
+    builder = apply_headers(builder, headers);
+
+    if let Some(token) = token {
+        builder = builder.header(AUTHORIZATION, format!("Bearer {}", token));
+    }
+
+    if let Some(body) = body {
+        builder = builder.body(body.to_owned());
+    }
+
+    builder
+}
+
+fn response_headers_to_map(headers: &HeaderMap) -> HashMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|v| (name.as_str().to_string(), v.to_string()))
+        })
+        .collect()
+}
+
+fn emit_gateway_event(app: &AppHandle, payload: GatewayHttpEvent) {
+    if let Err(err) = app.emit(GATEWAY_HTTP_EVENT, payload) {
+        log::warn!("[gateway-http] Failed to emit gateway event: {}", err);
+    }
+}
+
+#[tauri::command]
+pub async fn gateway_http_start(
+    app: AppHandle,
+    state: State<'_, GatewayHttpState>,
+    request: GatewayHttpRequest,
+) -> Result<GatewayHttpResponseMeta, String> {
+    if request.request_id.trim().is_empty() {
+        return Err("requestId is required".to_string());
+    }
+
+    let url = validate_gateway_url(&request.url)?;
+    let method = request
+        .method
+        .parse::<Method>()
+        .map_err(|e| format!("Invalid HTTP method '{}': {}", request.method, e))?;
+    let headers = build_header_map(&request.headers)?;
+    let body = request.body.clone();
+
+    let client = reqwest::Client::builder()
+        .build()
+        .map_err(|e| format!("Failed to create gateway HTTP client: {}", e))?;
+
+    let response = if should_use_stored_auth(&url, &headers) {
+        crate::auth::authenticated_request(&app, &client, |client, token| {
+            build_request(client, &method, &url, &headers, body.as_deref(), Some(token))
+        })
+        .await?
+    } else {
+        build_request(&client, &method, &url, &headers, body.as_deref(), None)
+            .send()
+            .await
+            .map_err(|e| format!("Gateway request failed: {}", e))?
+    };
+
+    let meta = GatewayHttpResponseMeta {
+        status: response.status().as_u16(),
+        status_text: response
+            .status()
+            .canonical_reason()
+            .unwrap_or_default()
+            .to_string(),
+        headers: response_headers_to_map(response.headers()),
+    };
+
+    let request_id = request.request_id;
+    let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+    state.active.lock().await.insert(request_id.clone(), cancel_tx);
+
+    let app_for_stream = app.clone();
+    let app_for_cleanup = app.clone();
+
+    tokio::spawn(async move {
+        let mut stream = response.bytes_stream();
+        let mut saw_error = false;
+
+        loop {
+            tokio::select! {
+                _ = &mut cancel_rx => {
+                    break;
+                }
+                chunk = stream.next() => {
+                    match chunk {
+                        Some(Ok(bytes)) => {
+                            emit_gateway_event(
+                                &app_for_stream,
+                                GatewayHttpEvent {
+                                    request_id: request_id.clone(),
+                                    event_type: "chunk".to_string(),
+                                    chunk_base64: Some(STANDARD.encode(bytes)),
+                                    error: None,
+                                },
+                            );
+                        }
+                        Some(Err(err)) => {
+                            saw_error = true;
+                            emit_gateway_event(
+                                &app_for_stream,
+                                GatewayHttpEvent {
+                                    request_id: request_id.clone(),
+                                    event_type: "error".to_string(),
+                                    chunk_base64: None,
+                                    error: Some(err.to_string()),
+                                },
+                            );
+                            break;
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+
+        {
+            let state = app_for_cleanup.state::<GatewayHttpState>();
+            let mut active = state.active.lock().await;
+            active.remove(&request_id);
+        }
+
+        if !saw_error {
+            emit_gateway_event(
+                &app_for_cleanup,
+                GatewayHttpEvent {
+                    request_id,
+                    event_type: "end".to_string(),
+                    chunk_base64: None,
+                    error: None,
+                },
+            );
+        }
+    });
+
+    Ok(meta)
+}
+
+#[tauri::command]
+pub async fn gateway_http_cancel(
+    state: State<'_, GatewayHttpState>,
+    request_id: String,
+) -> Result<(), String> {
+    let cancel = state.active.lock().await.remove(&request_id);
+    if let Some(cancel) = cancel {
+        let _ = cancel.send(());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_gateway_url_allows_api_origin_only() {
+        assert!(validate_gateway_url("https://api.serendb.com/projects").is_ok());
+        assert!(validate_gateway_url("https://mcp.serendb.com/mcp").is_err());
+        assert!(validate_gateway_url("http://api.serendb.com/projects").is_err());
+    }
+
+    #[test]
+    fn stored_auth_skips_login_refresh_and_signup() {
+        let no_auth_headers = HeaderMap::new();
+
+        let projects = Url::parse("https://api.serendb.com/projects").unwrap();
+        assert!(should_use_stored_auth(&projects, &no_auth_headers));
+
+        let login = Url::parse("https://api.serendb.com/auth/login").unwrap();
+        assert!(!should_use_stored_auth(&login, &no_auth_headers));
+
+        let refresh = Url::parse("https://api.serendb.com/auth/refresh").unwrap();
+        assert!(!should_use_stored_auth(&refresh, &no_auth_headers));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ use tauri_plugin_store::StoreExt;
 pub mod commands {
     pub mod chat;
     pub mod cli_installer;
+    pub mod gateway_http;
     pub mod indexing;
     pub mod memory;
     pub mod orchestrator;
@@ -629,6 +630,9 @@ pub fn run() {
                 app.manage(pool);
             }
 
+            // Track Rust-bridged Gateway HTTP requests so the frontend can abort streams.
+            app.manage(commands::gateway_http::GatewayHttpState::default());
+
             // Initialize memory state for cloud + local cache operations.
             // Token is read fresh from the auth store on each request.
             {
@@ -677,6 +681,9 @@ pub fn run() {
             shell::diagnose_shell_network,
             // Web fetch command
             commands::web::web_fetch,
+            // Rust-backed Gateway API bridge
+            commands::gateway_http::gateway_http_start,
+            commands::gateway_http::gateway_http_cancel,
             // Conversation commands
             commands::chat::create_conversation,
             commands::chat::get_conversations,

--- a/src/api/setup-auth.ts
+++ b/src/api/setup-auth.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Adds bearer token to every outbound request.
 
 import { getToken } from "@/lib/tauri-bridge";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 
 type ClientWithRequestInterceptor = {
   interceptors?: {
@@ -21,6 +22,10 @@ export function attachAuthInterceptor(
     return;
   }
   client.interceptors.request.use(async (request: Request) => {
+    if (shouldUseRustGatewayAuth(request)) {
+      return request;
+    }
+
     const token = await getToken();
     if (token) {
       request.headers.set("Authorization", `Bearer ${token}`);

--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -3,6 +3,7 @@
 
 import { apiBase } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 import { updateBalanceFromError } from "@/stores/wallet.store";
 import type {
@@ -152,12 +153,25 @@ const DEFAULT_MODELS: ProviderModel[] = [
   },
 ];
 
-async function requireToken(): Promise<string> {
-  const token = await getToken();
-  if (!token) {
-    throw new Error("Not authenticated with Seren");
+async function getGatewayHeaders(
+  url: string,
+  includeJsonContentType = false,
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {};
+
+  if (includeJsonContentType) {
+    headers["Content-Type"] = "application/json";
   }
-  return token;
+
+  if (!shouldUseRustGatewayAuth(url)) {
+    const token = await getToken();
+    if (!token) {
+      throw new Error("Not authenticated with Seren");
+    }
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
 }
 
 function extractContent(data: unknown): string {
@@ -309,8 +323,8 @@ export const serenProvider: ProviderAdapter = {
     request: ChatRequest,
     _auth: string | AuthOptions,
   ): Promise<string> {
-    const token = await requireToken();
     const model = normalizeModelId(request.model);
+    const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/chat/completions`;
 
     const payload: ChatCompletionRequest = {
       model,
@@ -320,17 +334,11 @@ export const serenProvider: ProviderAdapter = {
       tool_choice: request.tool_choice,
     };
 
-    const response = await appFetch(
-      `${apiBase}/publishers/${PUBLISHER_SLUG}/chat/completions`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(payload),
-      },
-    );
+    const response = await appFetch(url, {
+      method: "POST",
+      headers: await getGatewayHeaders(url, true),
+      body: JSON.stringify(payload),
+    });
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => "");
@@ -371,8 +379,8 @@ export const serenProvider: ProviderAdapter = {
     request: ChatRequest,
     _auth: string | AuthOptions,
   ): AsyncGenerator<string, void, unknown> {
-    const token = await requireToken();
     const model = normalizeModelId(request.model);
+    const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/chat/completions`;
 
     const payload: ChatCompletionRequest = {
       model,
@@ -380,17 +388,11 @@ export const serenProvider: ProviderAdapter = {
       stream: true,
     };
 
-    const response = await appFetch(
-      `${apiBase}/publishers/${PUBLISHER_SLUG}/chat/completions`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(payload),
-      },
-    );
+    const response = await appFetch(url, {
+      method: "POST",
+      headers: await getGatewayHeaders(url, true),
+      body: JSON.stringify(payload),
+    });
 
     if (!response.ok || !response.body) {
       const errorText = await response.text().catch(() => "");
@@ -452,18 +454,12 @@ export const serenProvider: ProviderAdapter = {
   async getModels(_apiKey: string): Promise<ProviderModel[]> {
     // Try to fetch from Seren's models endpoint
     try {
-      const token = await getToken();
-      if (!token) return DEFAULT_MODELS;
+      const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/models`;
 
-      const response = await appFetch(
-        `${apiBase}/publishers/${PUBLISHER_SLUG}/models`,
-        {
-          method: "GET",
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        },
-      );
+      const response = await appFetch(url, {
+        method: "GET",
+        headers: await getGatewayHeaders(url),
+      });
 
       if (!response.ok) {
         return DEFAULT_MODELS;
@@ -508,8 +504,8 @@ export async function sendMessageWithTools(
   tools?: ToolDefinition[],
   toolChoice?: ToolChoice,
 ): Promise<ChatResponse> {
-  const token = await requireToken();
   const normalizedModel = normalizeModelId(model);
+  const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/chat/completions`;
 
   const payload: ChatCompletionRequest = {
     model: normalizedModel,
@@ -519,17 +515,11 @@ export async function sendMessageWithTools(
     tool_choice: toolChoice,
   };
 
-  const response = await appFetch(
-    `${apiBase}/publishers/${PUBLISHER_SLUG}/chat/completions`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(payload),
-    },
-  );
+  const response = await appFetch(url, {
+    method: "POST",
+    headers: await getGatewayHeaders(url, true),
+    body: JSON.stringify(payload),
+  });
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => "");

--- a/src/lib/save-to-notes.ts
+++ b/src/lib/save-to-notes.ts
@@ -4,6 +4,7 @@
 import { API_BASE } from "@/lib/config";
 import { openExternalLink } from "@/lib/external-link";
 import { appFetch } from "@/lib/fetch";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 
 const RETRY_DELAYS_MS = [10_000, 20_000];
@@ -12,21 +13,22 @@ export async function saveToSerenNotes(
   title: string,
   content: string,
 ): Promise<void> {
-  const token = await getToken();
-  if (!token) throw new Error("Not authenticated");
+  const url = `${API_BASE}/publishers/seren-notes/notes`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!shouldUseRustGatewayAuth(url)) {
+    const token = await getToken();
+    if (!token) throw new Error("Not authenticated");
+    headers.Authorization = `Bearer ${token}`;
+  }
 
   for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
-    const response = await appFetch(
-      `${API_BASE}/publishers/seren-notes/notes`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ title, content, format: "markdown" }),
-      },
-    );
+    const response = await appFetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ title, content, format: "markdown" }),
+    });
 
     if (response.status === 408) {
       if (attempt < RETRY_DELAYS_MS.length) {

--- a/src/lib/tauri-fetch.ts
+++ b/src/lib/tauri-fetch.ts
@@ -1,15 +1,220 @@
-// ABOUTME: Shared Tauri HTTP plugin fetch resolution.
-// ABOUTME: Used by both appFetch (direct calls) and hey-api client config.
+// ABOUTME: Shared fetch resolution for Tauri and browser runtimes.
+// ABOUTME: Routes Seren Gateway API traffic through Rust in Tauri to avoid webview CORS.
 
+import { API_BASE } from "./config";
 import { isTauriRuntime } from "./tauri-bridge";
 
 type TauriFetch = typeof globalThis.fetch;
+type UnlistenFn = () => void;
+
+interface GatewayHttpRequest {
+  requestId: string;
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+}
+
+interface GatewayHttpResponseMeta {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+}
+
+interface GatewayHttpEvent {
+  requestId: string;
+  eventType: "chunk" | "end" | "error";
+  chunkBase64?: string | null;
+  error?: string | null;
+}
 
 let cached: TauriFetch | null = null;
+const GATEWAY_API_ORIGIN = new URL(API_BASE).origin;
+const GATEWAY_HTTP_EVENT = "gateway-http://event";
+
+function createAbortError(): Error {
+  try {
+    return new DOMException("The operation was aborted.", "AbortError");
+  } catch {
+    return new Error("The operation was aborted.");
+  }
+}
+
+function decodeBase64Chunk(base64: string): Uint8Array {
+  if (typeof atob === "function") {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  // Vitest/Node fallback
+  return Uint8Array.from(Buffer.from(base64, "base64"));
+}
+
+function buildGatewayRequestId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `gateway-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function isGatewayApiRequest(input: RequestInfo | URL): boolean {
+  const raw =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+
+  try {
+    return new URL(raw, API_BASE).origin === GATEWAY_API_ORIGIN;
+  } catch {
+    return false;
+  }
+}
+
+export function shouldUseRustGatewayBridge(input: RequestInfo | URL): boolean {
+  return isTauriRuntime() && isGatewayApiRequest(input);
+}
+
+export function shouldUseRustGatewayAuth(input: RequestInfo | URL): boolean {
+  return shouldUseRustGatewayBridge(input) && !shouldSkipRefresh(input);
+}
+
+async function cancelGatewayHttpRequest(requestId: string): Promise<void> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  await invoke("gateway_http_cancel", { requestId });
+}
+
+async function serializeGatewayRequest(
+  request: Request,
+  requestId: string,
+): Promise<GatewayHttpRequest> {
+  const headers: Record<string, string> = {};
+
+  for (const [name, value] of request.headers.entries()) {
+    if (name.toLowerCase() === "authorization") {
+      continue;
+    }
+    headers[name] = value;
+  }
+
+  const rawBody =
+    request.method === "GET" || request.method === "HEAD"
+      ? null
+      : await request.clone().text();
+
+  return {
+    requestId,
+    url: request.url,
+    method: request.method,
+    headers,
+    body: rawBody && rawBody.length > 0 ? rawBody : null,
+  };
+}
+
+async function gatewayFetch(request: Request): Promise<Response> {
+  const requestId = buildGatewayRequestId();
+  const abortError = createAbortError();
+  const payload = await serializeGatewayRequest(request, requestId);
+  const { invoke } = await import("@tauri-apps/api/core");
+  const { listen } = await import("@tauri-apps/api/event");
+
+  let cleanedUp = false;
+  let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null;
+  let rejectResponse: ((reason?: unknown) => void) | null = null;
+
+  const unlistenPromise = listen<GatewayHttpEvent>(GATEWAY_HTTP_EVENT, (event) => {
+    const payload = event.payload;
+    if (payload.requestId !== requestId || !controllerRef) {
+      return;
+    }
+
+    if (payload.eventType === "chunk" && payload.chunkBase64) {
+      controllerRef.enqueue(decodeBase64Chunk(payload.chunkBase64));
+      return;
+    }
+
+    if (payload.eventType === "error") {
+      const error = new Error(payload.error || "Gateway request failed");
+      cleanup();
+      controllerRef.error(error);
+      return;
+    }
+
+    if (payload.eventType === "end") {
+      cleanup();
+      controllerRef.close();
+    }
+  });
+
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    void unlistenPromise
+      .then((unlisten: UnlistenFn) => unlisten())
+      .catch(() => {});
+    request.signal?.removeEventListener("abort", onAbort);
+  };
+
+  const onAbort = () => {
+    void cancelGatewayHttpRequest(requestId).catch(() => {});
+    cleanup();
+    if (controllerRef) {
+      try {
+        controllerRef.error(abortError);
+      } catch {
+        // Stream already closed
+      }
+    } else if (rejectResponse) {
+      rejectResponse(abortError);
+    }
+  };
+
+  if (request.signal?.aborted) {
+    throw abortError;
+  }
+
+  request.signal?.addEventListener("abort", onAbort, { once: true });
+
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllerRef = controller;
+    },
+    cancel() {
+      cleanup();
+      void cancelGatewayHttpRequest(requestId).catch(() => {});
+    },
+  });
+
+  const responseMeta = await new Promise<GatewayHttpResponseMeta>(
+    (resolve, reject) => {
+      rejectResponse = reject;
+      void invoke<GatewayHttpResponseMeta>("gateway_http_start", { request: payload })
+        .then(resolve)
+        .catch((error) => {
+          cleanup();
+          reject(error);
+        });
+    },
+  );
+  rejectResponse = null;
+
+  return new Response(body, {
+    status: responseMeta.status,
+    statusText: responseMeta.statusText,
+    headers: responseMeta.headers,
+  });
+}
 
 /**
  * Get the appropriate fetch function for the current environment.
- * Uses Tauri HTTP plugin in Tauri runtime, browser fetch otherwise.
+ * Uses the Rust Gateway bridge for api.serendb.com requests in Tauri,
+ * Tauri HTTP plugin for other network requests, and browser fetch otherwise.
  * Caches the result after first resolution.
  */
 export async function getTauriFetch(): Promise<TauriFetch> {
@@ -21,13 +226,25 @@ export async function getTauriFetch(): Promise<TauriFetch> {
     return cached;
   }
 
+  let fallbackFetch: TauriFetch = globalThis.fetch;
+
   try {
     const mod = await import("@tauri-apps/plugin-http");
-    cached = mod.fetch as TauriFetch;
-    return cached;
+    fallbackFetch = mod.fetch as TauriFetch;
   } catch {
-    return globalThis.fetch;
+    // Keep the Rust bridge active for Gateway requests even when the HTTP
+    // plugin is unavailable. Only non-Gateway traffic falls back to window.fetch.
   }
+
+  cached = (async (input, init) => {
+    const request = new Request(input, init);
+    if (shouldUseRustGatewayBridge(request)) {
+      return gatewayFetch(request);
+    }
+    return fallbackFetch(request);
+  }) as TauriFetch;
+
+  return cached;
 }
 
 /**

--- a/src/services/agent-tasks.ts
+++ b/src/services/agent-tasks.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Provides API calls for task lifecycle and SSE streaming.
 
 import { API_BASE } from "@/lib/config";
-import { getTauriFetch } from "@/lib/tauri-fetch";
+import { getTauriFetch, shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -49,14 +49,16 @@ export interface AgentTaskEvent {
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 async function authHeaders(
+  url: string,
   includeJsonContentType = false,
 ): Promise<HeadersInit> {
-  const token = await getToken();
-  if (!token) throw new Error("Not authenticated");
+  const headers: Record<string, string> = {};
 
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
-  };
+  if (!shouldUseRustGatewayAuth(url)) {
+    const token = await getToken();
+    if (!token) throw new Error("Not authenticated");
+    headers.Authorization = `Bearer ${token}`;
+  }
 
   if (includeJsonContentType) {
     headers["Content-Type"] = "application/json";
@@ -67,8 +69,9 @@ async function authHeaders(
 
 async function apiGet<T>(path: string): Promise<T> {
   const fetchFn = await getTauriFetch();
-  const resp = await fetchFn(`${API_BASE}${path}`, {
-    headers: await authHeaders(),
+  const url = `${API_BASE}${path}`;
+  const resp = await fetchFn(url, {
+    headers: await authHeaders(url),
   });
   if (!resp.ok) {
     const body = await resp.text().catch(() => "");
@@ -83,9 +86,10 @@ async function apiPost<T>(
   body?: unknown,
 ): Promise<{ data: T; status: number }> {
   const fetchFn = await getTauriFetch();
-  const resp = await fetchFn(`${API_BASE}${path}`, {
+  const url = `${API_BASE}${path}`;
+  const resp = await fetchFn(url, {
     method: "POST",
-    headers: await authHeaders(true),
+    headers: await authHeaders(url, true),
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!resp.ok && resp.status !== 202) {
@@ -198,7 +202,7 @@ export function streamTask(
 
   (async () => {
     try {
-      const headers = await authHeaders();
+      const headers = await authHeaders(url);
       const fetchFn = await getTauriFetch();
       const resp = await fetchFn(url, {
         headers: { ...headers, Accept: "text/event-stream" },

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -4,6 +4,7 @@
 import { getCurrentUser } from "@/api";
 import { apiBase } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import {
   clearDefaultOrganizationId,
   clearRefreshToken,
@@ -233,17 +234,21 @@ interface ApiKeyCreateResponse {
  * @throws Error if not authenticated or request fails
  */
 export async function createApiKey(): Promise<string> {
-  const token = await getToken();
-  if (!token) {
-    throw new Error("Not authenticated");
+  const url = `${apiBase}/organizations/default/api-keys`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!shouldUseRustGatewayAuth(url)) {
+    const token = await getToken();
+    if (!token) {
+      throw new Error("Not authenticated");
+    }
+    headers.Authorization = `Bearer ${token}`;
   }
 
-  const response = await appFetch(`${apiBase}/organizations/default/api-keys`, {
+  const response = await appFetch(url, {
     method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
+    headers,
     body: JSON.stringify({ name: DESKTOP_API_KEY_NAME }),
   });
 

--- a/src/services/docreader.ts
+++ b/src/services/docreader.ts
@@ -3,6 +3,7 @@
 
 import { apiBase } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import type { Attachment } from "@/lib/providers/types";
 import { getToken } from "@/services/auth";
 import { updateBalanceFromError } from "@/stores/wallet.store";
@@ -69,23 +70,25 @@ export async function readDocument(attachment: Attachment): Promise<string> {
     "KB base64",
   );
 
-  const token = await getToken();
-  if (!token) {
-    console.error("[DocReader] No auth token available");
-    throw new Error(
-      "Document processing requires a Seren account. Sign in to continue.",
-    );
-  }
-
   const url = `${apiBase}/publishers/seren-docreader/process`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!shouldUseRustGatewayAuth(url)) {
+    const token = await getToken();
+    if (!token) {
+      console.error("[DocReader] No auth token available");
+      throw new Error(
+        "Document processing requires a Seren account. Sign in to continue.",
+      );
+    }
+    headers.Authorization = `Bearer ${token}`;
+  }
   console.log("[DocReader] POST", url);
 
   const response = await appFetch(url, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
+    headers,
     body: JSON.stringify({ file: attachment.base64 }),
   });
 

--- a/src/services/seren-embed.ts
+++ b/src/services/seren-embed.ts
@@ -3,6 +3,7 @@
 
 import { apiBase } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 
 const PUBLISHER_SLUG = "seren-embed";
@@ -61,28 +62,28 @@ export async function embedTexts(
   texts: string[],
   model?: string,
 ): Promise<EmbeddingResponse> {
-  const token = await getToken();
-  if (!token) {
-    throw new Error("Not authenticated - please log in");
-  }
-
   const payload: EmbeddingRequest = {
     input: texts,
     model: model || DEFAULT_MODEL,
   };
+  const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/embeddings`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!shouldUseRustGatewayAuth(url)) {
+    const token = await getToken();
+    if (!token) {
+      throw new Error("Not authenticated - please log in");
+    }
+    headers.Authorization = `Bearer ${token}`;
+  }
 
   // Use unified /publishers endpoint
-  const response = await appFetch(
-    `${apiBase}/publishers/${PUBLISHER_SLUG}/embeddings`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(payload),
-    },
-  );
+  const response = await appFetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
 
   if (!response.ok) {
     const errorText = await response.text();

--- a/src/services/seren-whisper.ts
+++ b/src/services/seren-whisper.ts
@@ -3,6 +3,7 @@
 
 import { apiBase } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 
 const PUBLISHER_SLUG = "seren-whisper";
@@ -50,11 +51,6 @@ export async function transcribeAudio(
   audioBlob: Blob,
   mimeType = "audio/webm",
 ): Promise<string> {
-  const token = await getToken();
-  if (!token) {
-    throw new Error("Not authenticated - please log in");
-  }
-
   const base64Audio = await blobToBase64(audioBlob);
 
   // Use unified /publishers endpoint with multipart body structure
@@ -69,18 +65,23 @@ export async function transcribeAudio(
       },
     ],
   };
+  const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/audio/transcriptions`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!shouldUseRustGatewayAuth(url)) {
+    const token = await getToken();
+    if (!token) {
+      throw new Error("Not authenticated - please log in");
+    }
+    headers.Authorization = `Bearer ${token}`;
+  }
 
-  const response = await appFetch(
-    `${apiBase}/publishers/${PUBLISHER_SLUG}/audio/transcriptions`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(payload),
-    },
-  );
+  const response = await appFetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
 
   if (!response.ok) {
     const errorText = await response.text();

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -5,6 +5,7 @@ import { API_BASE } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
 import { getErrorKey, RateLimiter } from "@/lib/rate-limiter";
 import { scrubSensitive } from "@/lib/scrub-sensitive";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/lib/tauri-bridge";
 
 export interface ErrorReport {
@@ -125,12 +126,15 @@ class TelemetryService {
     const batch = this.errorQueue.splice(0, this.config.maxBatchSize);
 
     try {
-      const token = await getToken();
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
       };
-      if (token) {
-        headers.Authorization = `Bearer ${token}`;
+
+      if (!shouldUseRustGatewayAuth(`${API_BASE}/diagnostics/errors`)) {
+        const token = await getToken();
+        if (token) {
+          headers.Authorization = `Bearer ${token}`;
+        }
       }
 
       await appFetch(`${API_BASE}/diagnostics/errors`, {

--- a/tests/unit/tauri-fetch-gateway.test.ts
+++ b/tests/unit/tauri-fetch-gateway.test.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Unit tests for Seren Gateway bridge routing in tauri-fetch.
+// ABOUTME: Verifies when requests should bypass webview CORS via the Rust bridge.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const isTauriRuntimeMock = vi.fn<() => boolean>();
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: isTauriRuntimeMock,
+}));
+
+describe("tauri-fetch gateway helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    isTauriRuntimeMock.mockReset();
+  });
+
+  it("detects Seren Gateway requests by origin", async () => {
+    const { isGatewayApiRequest } = await import("@/lib/tauri-fetch");
+
+    expect(isGatewayApiRequest("https://api.serendb.com/projects")).toBe(true);
+    expect(isGatewayApiRequest("/organizations/default/api-keys")).toBe(true);
+    expect(isGatewayApiRequest("https://mcp.serendb.com/mcp")).toBe(false);
+  });
+
+  it("uses the Rust bridge only for gateway requests in Tauri", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const { shouldUseRustGatewayBridge } = await import("@/lib/tauri-fetch");
+
+    expect(
+      shouldUseRustGatewayBridge("https://api.serendb.com/projects"),
+    ).toBe(true);
+    expect(
+      shouldUseRustGatewayBridge("https://mcp.serendb.com/mcp"),
+    ).toBe(false);
+  });
+
+  it("keeps auth/login and auth/refresh on the caller-managed path", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const { shouldUseRustGatewayAuth } = await import("@/lib/tauri-fetch");
+
+    expect(
+      shouldUseRustGatewayAuth("https://api.serendb.com/organizations/default"),
+    ).toBe(true);
+    expect(shouldUseRustGatewayAuth("https://api.serendb.com/auth/login")).toBe(
+      false,
+    );
+    expect(
+      shouldUseRustGatewayAuth("https://api.serendb.com/auth/refresh"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Rust-backed Gateway HTTP bridge for `api.serendb.com` requests in Tauri and stream response chunks back to the webview
- route gateway auth-bearing frontend callers through the bridge while keeping login/refresh/signup on the existing caller-managed path
- add focused gateway bridge unit coverage in both TypeScript and Rust

## Testing
- pnpm exec vitest run tests/unit/tauri-fetch.test.ts tests/unit/tauri-fetch-gateway.test.ts tests/unit/fetch-retry.test.ts
- pnpm build
- pnpm prepare:mcp-servers
- cargo test --manifest-path src-tauri/Cargo.toml gateway_http

Closes #1229