### PR TITLE
fix: clear webview cache before updater relaunch

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:webview:allow-create-webview-window",
+    "core:webview:allow-clear-all-browsing-data",
     "core:window:default",
     "dialog:default",
     "updater:default",

--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -1,3 +1,4 @@
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type DownloadEvent } from "@tauri-apps/plugin-updater";
 import { createStore } from "solid-js/store";
@@ -98,6 +99,24 @@ async function checkForUpdates(_manual = false): Promise<void> {
   }
 }
 
+async function clearBrowsingDataBeforeRestart(): Promise<void> {
+  try {
+    console.log("[Updater] Clearing webview browsing data before restart...");
+    await getCurrentWebview().clearAllBrowsingData();
+    console.log("[Updater] Webview browsing data cleared");
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.warn(
+      "[Updater] Failed to clear webview browsing data before restart:",
+      err.message,
+    );
+    telemetry.captureError(err, {
+      type: "updater",
+      phase: "clear_browsing_data",
+    });
+  }
+}
+
 async function installAvailableUpdate(): Promise<void> {
   if (!isTauriRuntime()) {
     console.warn("[Updater] Install skipped: not Tauri runtime");
@@ -146,7 +165,9 @@ async function installAvailableUpdate(): Promise<void> {
       console.log("[Updater] Download finished, installing...");
       setState({ status: "installing", progressPercent: 100 });
     });
-    console.log("[Updater] Install complete, relaunching...");
+    console.log("[Updater] Install complete");
+    await clearBrowsingDataBeforeRestart();
+    console.log("[Updater] Relaunching after install...");
     await relaunch();
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));

--- a/tests/unit/updater-store.test.ts
+++ b/tests/unit/updater-store.test.ts
@@ -1,0 +1,113 @@
+// ABOUTME: Tests the updater install sequence around browsing-data clearing.
+// ABOUTME: Verifies updates clear the current webview cache before restart without blocking relaunch.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockStoreState,
+  isTauriRuntimeMock,
+  checkMock,
+  relaunchMock,
+  clearAllBrowsingDataMock,
+  captureErrorMock,
+} = vi.hoisted(() => ({
+  mockStoreState: {} as Record<string, unknown>,
+  isTauriRuntimeMock: vi.fn<() => boolean>(),
+  checkMock: vi.fn(),
+  relaunchMock: vi.fn(),
+  clearAllBrowsingDataMock: vi.fn(),
+  captureErrorMock: vi.fn(),
+}));
+
+vi.mock("solid-js/store", () => ({
+  createStore: <T extends Record<string, unknown>>(initial: T) => {
+    Object.assign(mockStoreState, initial);
+    const setState = (update: Partial<T>) => {
+      Object.assign(mockStoreState, update);
+    };
+    return [mockStoreState, setState];
+  },
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: isTauriRuntimeMock,
+}));
+
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: checkMock,
+}));
+
+vi.mock("@tauri-apps/plugin-process", () => ({
+  relaunch: relaunchMock,
+}));
+
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    clearAllBrowsingData: clearAllBrowsingDataMock,
+  }),
+}));
+
+vi.mock("@/services/telemetry", () => ({
+  telemetry: {
+    captureError: captureErrorMock,
+  },
+}));
+
+describe("updaterStore install flow", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    Object.keys(mockStoreState).forEach((key) => delete mockStoreState[key]);
+    isTauriRuntimeMock.mockReset();
+    checkMock.mockReset();
+    relaunchMock.mockReset();
+    clearAllBrowsingDataMock.mockReset();
+    captureErrorMock.mockReset();
+  });
+
+  it("clears browsing data before relaunching an installed update", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const downloadAndInstallMock = vi.fn(async () => {});
+    checkMock.mockResolvedValue({
+      version: "1.3.53",
+      downloadAndInstall: downloadAndInstallMock,
+    });
+    clearAllBrowsingDataMock.mockResolvedValue(undefined);
+    relaunchMock.mockResolvedValue(undefined);
+
+    const { updaterStore } = await import("@/stores/updater.store");
+
+    await updaterStore.checkForUpdates();
+    await updaterStore.installAvailableUpdate();
+
+    expect(downloadAndInstallMock).toHaveBeenCalledOnce();
+    expect(clearAllBrowsingDataMock).toHaveBeenCalledOnce();
+    expect(relaunchMock).toHaveBeenCalledOnce();
+    expect(clearAllBrowsingDataMock.mock.invocationCallOrder[0]).toBeLessThan(
+      relaunchMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("still relaunches if browsing-data clearing fails", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const downloadAndInstallMock = vi.fn(async () => {});
+    checkMock.mockResolvedValue({
+      version: "1.3.53",
+      downloadAndInstall: downloadAndInstallMock,
+    });
+    clearAllBrowsingDataMock.mockRejectedValue(new Error("cache denied"));
+    relaunchMock.mockResolvedValue(undefined);
+
+    const { updaterStore } = await import("@/stores/updater.store");
+
+    await updaterStore.checkForUpdates();
+    await updaterStore.installAvailableUpdate();
+
+    expect(downloadAndInstallMock).toHaveBeenCalledOnce();
+    expect(clearAllBrowsingDataMock).toHaveBeenCalledOnce();
+    expect(captureErrorMock).toHaveBeenCalledWith(expect.any(Error), {
+      type: "updater",
+      phase: "clear_browsing_data",
+    });
+    expect(relaunchMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- clear the current Tauri webview browsing data after `downloadAndInstall()` and before restart
- keep restart non-blocking even if cache clearing fails, while capturing telemetry for the failure
- grant the webview clear-browsing-data permission and add focused unit coverage for the install flow

## Testing
- pnpm exec vitest run tests/unit/updater-store.test.ts
- pnpm exec biome check src/stores/updater.store.ts tests/unit/updater-store.test.ts
- python3 -m json.tool src-tauri/capabilities/default.json >/dev/null

Closes #1224