### PR TITLE
fix: delete stale source dir when rename target already exists

### DIFF
--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -800,10 +800,18 @@ pub fn rename_skill_dir(
         ));
     }
     if new_path.exists() {
-        return Err(format!(
-            "Target directory already exists: {}",
-            new_path.display()
-        ));
+        // Target already has the correct content (synced under the new name).
+        // Remove the stale source directory instead of failing.
+        fs::remove_dir_all(&old_path).map_err(|e| {
+            format!(
+                "Target {} exists but failed to remove stale source {}: {}",
+                new_path.display(),
+                old_path.display(),
+                e
+            )
+        })?;
+        let skill_md = new_path.join("SKILL.md");
+        return Ok(skill_md.to_string_lossy().to_string());
     }
 
     fs::rename(&old_path, &new_path)


### PR DESCRIPTION
## Summary
- When rename_skill_dir target already exists, delete the old source directory instead of erroring
- Eliminates repeated log spam on every refresh cycle for skills like curve-gauges, email-checker, seren-skill-creator

## Test plan
- [x] Cargo check passes
- [x] Verified logic: if new_path exists, remove old_path and return Ok

Fixes #1235

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com