### PR TITLE
fix: mark upstream-deleted skills as orphaned to stop 404 retry spam

### DIFF
--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -65,6 +65,8 @@ export interface SkillSyncState {
   syncedAt: number;
   /** SHA-256 hashes for upstream-managed files, keyed by relative path */
   managedFiles: Record<string, string>;
+  /** True when the upstream source returned 404 (skill deleted from repo) */
+  upstreamDeleted?: boolean;
 }
 
 export interface RemoteSkillRevision {

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Skills store for managing skills state in the UI.
 // ABOUTME: Handles available skills, installed skills, and thread/project/global resolution.
 
+import { invoke } from "@tauri-apps/api/core";
 import { createStore } from "solid-js/store";
 import { log } from "@/lib/logger";
 import type {
@@ -660,6 +661,7 @@ export const skillsStore = {
     let autoRefreshed = 0;
     for (const skill of state.installed) {
       if (!isUpstreamManagedSkill(skill)) continue;
+      if (skill.syncState?.upstreamDeleted) continue;
       try {
         const status = await skills.inspectSyncStatus(skill);
         if (!status || status.hasLocalChanges) continue;
@@ -669,11 +671,26 @@ export const skillsStore = {
           log.info("[SkillsStore] Auto-refreshed stale skill:", skill.slug);
         }
       } catch (err) {
-        log.warn(
-          "[SkillsStore] Failed to check/refresh skill:",
-          skill.slug,
-          err,
-        );
+        const is404 = err instanceof Error && err.message.includes(": 404");
+        if (is404 && skill.syncState) {
+          // Upstream skill was deleted — mark as orphaned so we stop retrying.
+          skill.syncState.upstreamDeleted = true;
+          await invoke("write_skill_sync_state", {
+            skillsDir: skill.skillsDir,
+            slug: skill.dirName,
+            stateJson: JSON.stringify(skill.syncState),
+          });
+          log.info(
+            "[SkillsStore] Upstream skill deleted, marked orphaned:",
+            skill.slug,
+          );
+        } else {
+          log.warn(
+            "[SkillsStore] Failed to check/refresh skill:",
+            skill.slug,
+            err,
+          );
+        }
       }
     }
     if (autoRefreshed > 0) {


### PR DESCRIPTION
## Summary
- When auto-sync refresh gets a 404 for an upstream skill, mark it as orphaned via syncState.upstreamDeleted
- Skip orphaned skills in future refresh cycles
- Add upstreamDeleted field to SkillSyncState type
- Skill remains usable locally but stops retrying against a dead URL

## Test plan
- [x] Biome check passes
- [x] Logic verified: 404 error sets upstreamDeleted, subsequent refreshes skip the skill

Fixes #1238

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com