### PR TITLE
fix: route gateway publisher tools through call_publisher dispatch

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -101,6 +101,8 @@ function parsePublisherFromToolName(toolName: string): {
 
 /**
  * Convert MCP tool to GatewayTool format.
+ * Stores the bare tool name (without mcp__publisher__ prefix) so that
+ * callGatewayTool() can dispatch through call_publisher correctly.
  * Returns null for built-in gateway tools (no publisher prefix).
  */
 function convertToGatewayTool(tool: McpTool): GatewayTool | null {
@@ -110,7 +112,7 @@ function convertToGatewayTool(tool: McpTool): GatewayTool | null {
     publisher: parsed.publisher,
     publisherName: parsed.publisher,
     tool: {
-      name: tool.name,
+      name: parsed.originalName,
       description: tool.description,
       inputSchema: tool.inputSchema as McpToolInfo["inputSchema"],
     },
@@ -186,7 +188,7 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
         publisher: slug,
         publisherName: slug,
         tool: {
-          name: `mcp__${slug}__${tool.name}`,
+          name: tool.name,
           description: tool.description ?? `${tool.name} from ${slug}`,
           inputSchema: tool.inputSchema ?? {
             type: "object" as const,
@@ -371,10 +373,13 @@ function parsePaymentProxyError(content: unknown): PaymentProxyInfo | null {
 }
 
 /**
- * Call a tool via the MCP Gateway.
+ * Call a tool via the MCP Gateway using the call_publisher dispatch mechanism.
+ *
+ * Publisher tools are not first-class MCP tools on the gateway — they must be
+ * invoked through the `call_publisher` meta-tool with `tool` + `tool_args`.
  */
 export async function callGatewayTool(
-  _publisherSlug: string,
+  publisherSlug: string,
   toolName: string,
   args: Record<string, unknown>,
 ): Promise<McpToolCallResponse> {
@@ -389,9 +394,20 @@ export async function callGatewayTool(
   const startTime = Date.now();
 
   try {
+    // Separate x402 payment from tool args (call_publisher accepts it at top level)
+    const { _x402_payment, ...toolArgs } = args;
+    const dispatchArgs: Record<string, unknown> = {
+      publisher: publisherSlug,
+      tool: toolName,
+      tool_args: toolArgs,
+    };
+    if (_x402_payment !== undefined) {
+      dispatchArgs._x402_payment = _x402_payment;
+    }
+
     const result: McpToolResult = await mcpClient.callToolHttp(
       SEREN_MCP_SERVER_NAME,
-      { name: toolName, arguments: args },
+      { name: "call_publisher", arguments: dispatchArgs },
     );
 
     const executionTime = Date.now() - startTime;


### PR DESCRIPTION
## Summary

Closes #1251

All 108 gateway publisher tool calls fail with `-32602: tool not found` because:

1. **Double-prefixed names**: `discoverPublisherTools()` added `mcp__publisher__` to bare tool names, then `convertGatewayToolToDefinition()` added `gateway__publisher__` on top, producing `gateway__gmail__mcp__gmail__get_messages`
2. **Wrong dispatch**: `callGatewayTool()` called tools directly on the MCP server, but publisher tools are not first-class MCP tools -- they must go through the `call_publisher` meta-tool

### Changes

- **`convertToGatewayTool()`**: Store bare tool name (`get_messages`) instead of full MCP name (`mcp__gmail__get_messages`)
- **`discoverPublisherTools()`**: Store bare tool name from gateway response (remove `mcp__slug__` prefix)
- **`callGatewayTool()`**: Dispatch through `call_publisher` with `publisher`, `tool`, and `tool_args` parameters. The previously unused `_publisherSlug` parameter now drives routing as originally intended
- x402 payment header correctly separated from tool_args and passed at `call_publisher` top level

### Result

- Model sees: `gateway__gmail__get_messages` (clean single prefix)
- Gateway receives: `call_publisher(publisher: "gmail", tool: "get_messages", tool_args: {...})`
- Deduplication between static and dynamic tools works correctly (both use bare names)

## Test plan

- [x] Biome lint passes
- [x] No new TypeScript errors (pre-existing only)
- [ ] Manual: verify Gmail, Polymarket, and other publisher tool calls succeed in-app

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com