### PR TITLE
fix: bump seren-memory-sdk to fix SSE response parsing in remember/recall

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1829,7 +1829,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2104,7 +2104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3071,7 +3071,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3382,7 +3382,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4895,7 +4895,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5500,7 +5500,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5558,7 +5558,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6018,7 +6018,7 @@ dependencies = [
 [[package]]
 name = "seren-memory-sdk"
 version = "0.1.0"
-source = "git+https://github.com/serenorg/seren-memory-sdk.git?branch=main#4813594c88f9482de3acaf195510a75a92d370ec"
+source = "git+https://github.com/serenorg/seren-memory-sdk.git?branch=main#18945417d2fcdf9b777fc5aa9d7373849849c646"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -6966,7 +6966,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7936,7 +7936,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #1254

Updates seren-memory-sdk to 1894541 (serenorg/seren-memory-sdk#3) which handles text/event-stream responses from the memory server MCP endpoint.

**Root cause**: The SDK sends Accept: application/json, text/event-stream (required to avoid 406), but the server responds with SSE format (data: {...}). resp.json() cannot parse SSE, so every cloud remember/recall call fails with error decoding response body.

**Fix**: The SDK now detects SSE content-type and extracts JSON from data: lines before parsing. Plain JSON responses still work.

## Test plan

- [x] 32/32 SDK tests pass (including 3 new SSE tests)
- [ ] Manual: verify cloud remember warning no longer appears in console

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com