### PR TITLE
fix: classify skill invocations to prevent runaway tool loops

### DIFF
--- a/src-tauri/src/orchestrator/classifier.rs
+++ b/src-tauri/src/orchestrator/classifier.rs
@@ -226,6 +226,21 @@ pub fn classify(prompt: &str, skills: &[SkillRef]) -> TaskClassification {
 
     let relevant_skills = select_relevant_skills(prompt, skills);
 
+    // Rule 0: Skill invocation — the frontend wraps invoked skills in
+    // <skill-invocation> tags with the full SKILL.md content inlined.
+    // This MUST be checked before any keyword rules because the SKILL.md
+    // body contains code keywords, numbered lists, and other patterns
+    // that would cause misclassification and unwanted decomposition.
+    if prompt.contains("<skill-invocation") {
+        return TaskClassification {
+            task_type: "skill_execution".to_string(),
+            requires_tools: true,
+            requires_file_system: false,
+            complexity: TaskComplexity::Simple,
+            relevant_skills,
+        };
+    }
+
     // Rule 1: Code generation
     if contains_code_fence(prompt)
         || CODE_KEYWORDS
@@ -598,6 +613,39 @@ mod tests {
     fn latest_does_not_match_in_code_context() {
         // Code keywords take priority over research keywords
         let result = classify("Get the latest version of the function from git", &[]);
+        assert_eq!(result.task_type, "code_generation");
+    }
+
+    // =========================================================================
+    // Skill Invocation Classification
+    // =========================================================================
+
+    #[test]
+    fn skill_invocation_overrides_code_keywords() {
+        // The SKILL.md body contains "python", "script", code fences, etc.
+        // Skill invocation must win over code_generation.
+        let prompt = r#"<skill-invocation name="polymarket-bot">
+The user has invoked the /polymarket-bot skill. Execute it by following the skill instructions below.
+
+## Scanning for Opportunities
+```bash
+cd ~/.config/seren/skills/polymarket-bot && python3 scripts/agent.py --config config.json --dry-run
+```
+
+1. Check prerequisites
+2. Run the scan
+3. Report results
+</skill-invocation>"#;
+        let result = classify(prompt, &[]);
+        assert_eq!(result.task_type, "skill_execution");
+        assert_eq!(result.complexity, TaskComplexity::Simple);
+        assert!(result.requires_tools);
+        assert!(!result.requires_file_system);
+    }
+
+    #[test]
+    fn non_skill_prompt_with_code_keywords_still_classifies_as_code() {
+        let result = classify("Write a python function to sort a list", &[]);
         assert_eq!(result.task_type, "code_generation");
     }
 }

--- a/src-tauri/src/orchestrator/decomposer.rs
+++ b/src-tauri/src/orchestrator/decomposer.rs
@@ -25,6 +25,17 @@ pub fn decompose(
     classification: &TaskClassification,
     skills: &[SkillRef],
 ) -> Vec<SubTask> {
+    // Skill invocations are always a single task — the SKILL.md body contains
+    // numbered lists and code keywords that would cause spurious decomposition.
+    if classification.task_type == "skill_execution" {
+        return vec![SubTask {
+            id: Uuid::new_v4().to_string(),
+            prompt: prompt.to_string(),
+            classification: classification.clone(),
+            depends_on: vec![],
+        }];
+    }
+
     // Try numbered list first
     if let Some(subtasks) = try_numbered_list(prompt, skills) {
         if subtasks.len() > 1 {
@@ -733,5 +744,29 @@ mod tests {
         assert_eq!(result.len(), 2);
         // Second task should depend on first (sequential, not parallel)
         assert_eq!(result[1].depends_on, vec![result[0].id.clone()]);
+    }
+
+    // =========================================================================
+    // Skill Invocation — No Decomposition
+    // =========================================================================
+
+    #[test]
+    fn skill_execution_never_decomposes() {
+        let classification = TaskClassification {
+            task_type: "skill_execution".to_string(),
+            requires_tools: true,
+            requires_file_system: false,
+            complexity: TaskComplexity::Simple,
+            relevant_skills: vec!["polymarket-bot".to_string()],
+        };
+        // Prompt has numbered list + code keywords — must still be 1 task
+        let prompt = r#"<skill-invocation name="polymarket-bot">
+1. Check prerequisites
+2. Run python3 scripts/agent.py
+3. Report results
+</skill-invocation>"#;
+        let result = decompose(prompt, &classification, &[]);
+        assert_eq!(result.len(), 1, "skill_execution must never be decomposed");
+        assert_eq!(result[0].classification.task_type, "skill_execution");
     }
 }


### PR DESCRIPTION
## Summary
- When skills are invoked, the frontend inlines the entire SKILL.md (1000+ lines) into the prompt
- The classifier saw code keywords in SKILL.md content and returned `code_generation/Moderate`
- The decomposer found numbered lists in SKILL.md and created 57 sequential subtasks
- This caused a runaway tool loop where the model modified skill runtime files, breaking them
- **Fix**: Add Rule 0 in classifier — if prompt contains `<skill-invocation`, return `skill_execution/Simple` before any keyword checks
- **Fix**: Add guard in decomposer — `skill_execution` always produces a single task, no decomposition

## Test plan
- [x] `skill_invocation_overrides_code_keywords` — SKILL.md with python, code fences, numbered lists classifies as `skill_execution`
- [x] `non_skill_prompt_with_code_keywords_still_classifies_as_code` — non-skill prompts unaffected
- [x] `skill_execution_never_decomposes` — numbered lists inside skill invocation produce 1 task
- [x] All 30 classifier tests pass
- [x] All 22 decomposer tests pass

Closes #1272

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com