### PR TITLE
fix(playwright-stealth): use executablePath to launch system browsers

### DIFF
--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -210,4 +210,15 @@ describe("listInstalledBrowsers", () => {
       expect(b.isChromiumBased).toBe(b.browserName === "chromium");
     }
   });
+
+  it("default browser has a valid executablePath in the registry", () => {
+    const browsers = listInstalledBrowsers();
+    const defaultName = detectDefaultBrowser();
+    const match = browsers.find((b) => b.name === defaultName);
+    // The default browser must exist in the registry with a real path —
+    // getBrowser() uses this path to launch directly via executablePath
+    // instead of channel, which avoids Playwright plugin dependencies.
+    expect(match).toBeDefined();
+    expect(match!.executablePath).toBeTruthy();
+  });
 });

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -269,8 +269,15 @@ export async function getBrowser(): Promise<Browser> {
       ];
     }
 
-    // Channel browsers (chrome, msedge, etc.) need the channel option
-    if (activeBrowserName !== engine) {
+    // Use executablePath from the registry instead of channel.
+    // channel requires Playwright's internal browser plugin binaries;
+    // executablePath launches the system binary directly — no plugins needed.
+    const installed = listInstalledBrowsers();
+    const match = installed.find((b) => b.name === activeBrowserName);
+    if (match) {
+      launchOptions.executablePath = match.executablePath;
+    } else if (activeBrowserName !== engine) {
+      // Fallback to channel if somehow the browser isn't in the registry
       launchOptions.channel = activeBrowserName;
     }
 
@@ -278,11 +285,10 @@ export async function getBrowser(): Promise<Browser> {
       browser = await launcher.launch(launchOptions);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      const isChannel = activeBrowserName !== engine;
-      const hint = isChannel
-        ? `Ensure ${activeBrowserName} is installed on this system.`
-        : `Run 'npx playwright install ${activeBrowserName}' to install it.`;
-      throw new Error(`Failed to launch ${activeBrowserName}: ${msg}. ${hint}`);
+      throw new Error(
+        `Failed to launch ${activeBrowserName}: ${msg}. ` +
+          `Ensure ${activeBrowserName} is installed on this system.`,
+      );
     }
   }
   return browser;


### PR DESCRIPTION
## Summary

Closes #1274

- Replace channel with executablePath when launching system browsers (Chrome, Edge, Firefox)
- channel requires Playwright internal browser plugin binaries; executablePath launches the system binary directly
- The executable path is already known from the registry query in listInstalledBrowsers()
- Add test verifying the default browser has a valid executablePath in the registry

## Root Cause

getBrowser() used launchOptions.channel = activeBrowserName (e.g. channel: chrome), which tells Playwright to resolve the browser path through its own internal registry. That registry requires plugin binaries to be installed even for system Chrome. When those plugins are missing (normal case for Seren Desktop since we use system browsers), launch fails with Plugin dependency not found.

## Why Now

Latent since multi-browser support was added in #897. Surfaces when users have system Chrome installed but no Playwright browser binaries (the normal case for desktop app users).

## Test plan

- [x] All 36 existing browser.test.ts tests pass
- [x] New test validates default browser has valid executablePath in registry
- [ ] Manual: launch Seren Desktop, verify playwright_navigate works with system Chrome

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com