### PR TITLE
fix(playwright-stealth): disable chrome.app evasion removed by macOS notarization

### DIFF
--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import {
+  createSafeStealthPlugin,
   detectDefaultBrowser,
   isChromiumBased,
   listInstalledBrowsers,
@@ -154,6 +155,23 @@ describe("resolveBrowserName", () => {
 
   it("defaults unknown names to 'chromium'", () => {
     expect(resolveBrowserName("msedge-canary")).toBe("chromium");
+  });
+});
+
+describe("createSafeStealthPlugin", () => {
+  it("excludes chrome.app evasion for macOS notarization compatibility", () => {
+    const plugin = createSafeStealthPlugin();
+    expect(plugin.enabledEvasions.has("chrome.app")).toBe(false);
+  });
+
+  it("keeps other stealth evasions enabled", () => {
+    const plugin = createSafeStealthPlugin();
+    // These core evasions must remain active for bot detection bypass
+    expect(plugin.enabledEvasions.has("chrome.csi")).toBe(true);
+    expect(plugin.enabledEvasions.has("chrome.loadTimes")).toBe(true);
+    expect(plugin.enabledEvasions.has("chrome.runtime")).toBe(true);
+    expect(plugin.enabledEvasions.has("navigator.webdriver")).toBe(true);
+    expect(plugin.enabledEvasions.size).toBeGreaterThan(5);
   });
 });
 

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -245,6 +245,21 @@ export async function setBrowser(
   };
 }
 
+/**
+ * Creates a StealthPlugin with evasions safe for packaged macOS apps.
+ * The `chrome.app` evasion module lives in a directory named "chrome.app".
+ * macOS notarization rejects unsigned .app bundles, so our signing script
+ * (scripts/sign-embedded-runtime.ts) removes all fake .app directories
+ * inside node_modules.  Disabling this single evasion avoids the missing
+ * dependency error at runtime while keeping all other stealth evasions
+ * intact.  See: https://github.com/serenorg/seren-desktop/issues/1276
+ */
+export function createSafeStealthPlugin(): ReturnType<typeof StealthPlugin> {
+  const stealth = StealthPlugin();
+  stealth.enabledEvasions.delete("chrome.app");
+  return stealth;
+}
+
 export async function getBrowser(): Promise<Browser> {
   if (!browser) {
     const engine = resolveBrowserName(activeBrowserName);
@@ -252,7 +267,7 @@ export async function getBrowser(): Promise<Browser> {
 
     if (isChromiumBased(engine) && !stealthApplied) {
       (chromium as BrowserType & { use(plugin: unknown): void }).use(
-        StealthPlugin(),
+        createSafeStealthPlugin(),
       );
       stealthApplied = true;
     }


### PR DESCRIPTION
## Summary

- Disable `chrome.app` stealth evasion that gets removed by the macOS notarization signing script (`scripts/sign-embedded-runtime.ts`), causing a `Plugin dependency not found` error at runtime
- Extract `createSafeStealthPlugin()` for testability — deletes `chrome.app` from enabled evasions while keeping all others active
- Add 2 unit tests verifying the evasion exclusion and that core evasions remain enabled

Closes #1276

## Test plan

- [x] `npm test` passes in `mcp-servers/playwright-stealth` (38/38 tests)
- [ ] Manual: build packaged macOS app, verify playwright_navigate works with system Chrome

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com