### PR TITLE
fix(playwright-stealth): retry installed browsers on launch failure

### DIFF
--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -6,6 +6,7 @@ import {
   createSafeStealthPlugin,
   detectDefaultBrowser,
   isChromiumBased,
+  launchBrowserWithFallback,
   listInstalledBrowsers,
   parseBrowserType,
   resolveBrowserName,
@@ -172,6 +173,113 @@ describe("createSafeStealthPlugin", () => {
     expect(plugin.enabledEvasions.has("chrome.runtime")).toBe(true);
     expect(plugin.enabledEvasions.has("navigator.webdriver")).toBe(true);
     expect(plugin.enabledEvasions.size).toBeGreaterThan(5);
+  });
+});
+
+describe("launchBrowserWithFallback", () => {
+  it("retries the next installed browser in preference order after a launch failure", async () => {
+    const launchedBrowser = { close: vi.fn() } as never;
+    const launchBrowser = vi
+      .fn<
+        (
+          browserName: string,
+          engine: string,
+          launchOptions: Record<string, unknown>,
+        ) => Promise<unknown>
+      >()
+      .mockRejectedValueOnce(new Error("chrome failed"))
+      .mockResolvedValueOnce(launchedBrowser);
+
+    const result = await launchBrowserWithFallback(
+      "chrome",
+      [
+        {
+          name: "chrome",
+          browserName: "chromium",
+          executablePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+          isChromiumBased: true,
+          stealthSupported: true,
+        },
+        {
+          name: "moz-firefox",
+          browserName: "firefox",
+          executablePath: "/Applications/Firefox.app/Contents/MacOS/firefox",
+          isChromiumBased: false,
+          stealthSupported: false,
+        },
+      ],
+      launchBrowser as never,
+    );
+
+    expect(result).toEqual({
+      browser: launchedBrowser,
+      browserName: "moz-firefox",
+    });
+    expect(launchBrowser).toHaveBeenNthCalledWith(
+      1,
+      "chrome",
+      "chromium",
+      expect.objectContaining({
+        executablePath:
+          "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      }),
+    );
+    expect(launchBrowser).toHaveBeenNthCalledWith(
+      2,
+      "moz-firefox",
+      "firefox",
+      expect.objectContaining({
+        executablePath: "/Applications/Firefox.app/Contents/MacOS/firefox",
+      }),
+    );
+  });
+
+  it("surfaces a combined error when every launch candidate fails", async () => {
+    const launchBrowser = vi
+      .fn<
+        (
+          browserName: string,
+          engine: string,
+          launchOptions: Record<string, unknown>,
+        ) => Promise<unknown>
+      >()
+      .mockRejectedValueOnce(new Error("chrome failed"))
+      .mockRejectedValueOnce(new Error("edge failed"))
+      .mockRejectedValueOnce(new Error("firefox failed"));
+
+    await expect(
+      launchBrowserWithFallback(
+        "chrome",
+        [
+          {
+            name: "chrome",
+            browserName: "chromium",
+            executablePath:
+              "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            isChromiumBased: true,
+            stealthSupported: true,
+          },
+          {
+            name: "msedge",
+            browserName: "chromium",
+            executablePath:
+              "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+            isChromiumBased: true,
+            stealthSupported: true,
+          },
+          {
+            name: "moz-firefox",
+            browserName: "firefox",
+            executablePath: "/Applications/Firefox.app/Contents/MacOS/firefox",
+            isChromiumBased: false,
+            stealthSupported: false,
+          },
+        ],
+        launchBrowser as never,
+      ),
+    ).rejects.toThrow(
+      "Failed to launch any supported browser. Tried 3 candidate(s): chrome: chrome failed; msedge: edge failed; moz-firefox: firefox failed.",
+    );
   });
 });
 

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -203,6 +203,86 @@ function getLauncher(
   return chromium as BrowserType & { use(plugin: unknown): void };
 }
 
+function getLaunchCandidateNames(
+  preferredName: string,
+  installed: InstalledBrowser[],
+): string[] {
+  const installedNames = new Set(installed.map((b) => b.name));
+  const candidates = [preferredName];
+
+  for (const name of SYSTEM_BROWSER_PREFERENCE) {
+    if (name === preferredName) continue;
+    if (installedNames.has(name)) candidates.push(name);
+  }
+
+  for (const browser of installed) {
+    if (!candidates.includes(browser.name)) candidates.push(browser.name);
+  }
+
+  return candidates;
+}
+
+function buildLaunchOptions(
+  browserName: string,
+  engine: BrowserEngine,
+  installed: InstalledBrowser[],
+): Record<string, unknown> {
+  const launchOptions: Record<string, unknown> = {
+    headless: true,
+  };
+
+  if (isChromiumBased(engine)) {
+    launchOptions.args = [
+      "--disable-blink-features=AutomationControlled",
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+    ];
+  }
+
+  const match = installed.find((b) => b.name === browserName);
+  if (match) {
+    launchOptions.executablePath = match.executablePath;
+  } else if (browserName !== engine) {
+    launchOptions.channel = browserName;
+  }
+
+  return launchOptions;
+}
+
+export async function launchBrowserWithFallback(
+  preferredName: string,
+  installed: InstalledBrowser[],
+  launchBrowser: (
+    browserName: string,
+    engine: BrowserEngine,
+    launchOptions: Record<string, unknown>,
+  ) => Promise<Browser>,
+): Promise<{ browser: Browser; browserName: string }> {
+  const candidates = getLaunchCandidateNames(preferredName, installed);
+  const failures: string[] = [];
+
+  for (const browserName of candidates) {
+    const engine = resolveBrowserName(browserName);
+    const launchOptions = buildLaunchOptions(browserName, engine, installed);
+
+    try {
+      const launchedBrowser = await launchBrowser(
+        browserName,
+        engine,
+        launchOptions,
+      );
+      return { browser: launchedBrowser, browserName };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      failures.push(`${browserName}: ${msg}`);
+    }
+  }
+
+  throw new Error(
+    `Failed to launch any supported browser. Tried ${failures.length} candidate(s): ${failures.join("; ")}.`,
+  );
+}
+
 // ── State ──────────────────────────────────────────────────────────────────────
 
 let activeBrowserName: string = parseBrowserType(process.env.BROWSER_TYPE);
@@ -262,47 +342,30 @@ export function createSafeStealthPlugin(): ReturnType<typeof StealthPlugin> {
 
 export async function getBrowser(): Promise<Browser> {
   if (!browser) {
-    const engine = resolveBrowserName(activeBrowserName);
-    const launcher = getLauncher(engine);
-
-    if (isChromiumBased(engine) && !stealthApplied) {
-      (chromium as BrowserType & { use(plugin: unknown): void }).use(
-        createSafeStealthPlugin(),
-      );
-      stealthApplied = true;
-    }
-
-    const launchOptions: Record<string, unknown> = {
-      headless: true,
-    };
-
-    if (isChromiumBased(engine)) {
-      launchOptions.args = [
-        "--disable-blink-features=AutomationControlled",
-        "--no-sandbox",
-        "--disable-setuid-sandbox",
-      ];
-    }
-
-    // Use executablePath from the registry instead of channel.
-    // channel requires Playwright's internal browser plugin binaries;
-    // executablePath launches the system binary directly — no plugins needed.
     const installed = listInstalledBrowsers();
-    const match = installed.find((b) => b.name === activeBrowserName);
-    if (match) {
-      launchOptions.executablePath = match.executablePath;
-    } else if (activeBrowserName !== engine) {
-      // Fallback to channel if somehow the browser isn't in the registry
-      launchOptions.channel = activeBrowserName;
-    }
 
     try {
-      browser = await launcher.launch(launchOptions);
+      const launched = await launchBrowserWithFallback(
+        activeBrowserName,
+        installed,
+        async (browserName, engine, launchOptions) => {
+          if (isChromiumBased(engine) && !stealthApplied) {
+            (chromium as BrowserType & { use(plugin: unknown): void }).use(
+              createSafeStealthPlugin(),
+            );
+            stealthApplied = true;
+          }
+
+          const launcher = getLauncher(engine);
+          return launcher.launch(launchOptions);
+        },
+      );
+      browser = launched.browser;
+      activeBrowserName = launched.browserName;
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       throw new Error(
-        `Failed to launch ${activeBrowserName}: ${msg}. ` +
-          `Ensure ${activeBrowserName} is installed on this system.`,
+        `${msg} Ensure at least one supported system browser is installed and launchable.`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- retry alternate installed system browsers when the preferred browser fails to launch
- update the active browser to the successful fallback so context/page creation stays consistent
- add focused tests for fallback success and aggregated fallback failure

Closes #1278.

## Testing
- `npm test`
- `npm run build`
