### PR TITLE
feat(skills): support multi-directory skill bundles via includes field

### DIFF
--- a/src/lib/skills/parser.ts
+++ b/src/lib/skills/parser.ts
@@ -103,6 +103,9 @@ function parseYamlFrontmatter(yaml: string): SkillMetadata {
       if (currentKey === "alwaysAllow") {
         metadata.alwaysAllow = [...(metadata.alwaysAllow ?? []), value];
       }
+      if (currentKey === "includes") {
+        metadata.includes = [...(metadata.includes ?? []), value];
+      }
       continue;
     }
 
@@ -120,6 +123,7 @@ function parseYamlFrontmatter(yaml: string): SkillMetadata {
         if (key === "requires") metadata.requires = [];
         if (key === "globs") metadata.globs = [];
         if (key === "alwaysAllow") metadata.alwaysAllow = [];
+        if (key === "includes") metadata.includes = [];
         continue;
       }
 
@@ -137,6 +141,7 @@ function parseYamlFrontmatter(yaml: string): SkillMetadata {
         if (key === "requires") metadata.requires = items;
         if (key === "globs") metadata.globs = items;
         if (key === "alwaysAllow") metadata.alwaysAllow = items;
+        if (key === "includes") metadata.includes = items;
         continue;
       }
 

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -26,6 +26,8 @@ export interface SkillMetadata {
   requires?: string[];
   globs?: string[];
   alwaysAllow?: string[];
+  /** Repo-relative paths to bundle as shared dependencies under _deps/ */
+  includes?: string[];
 }
 
 /**

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -320,18 +320,26 @@ async function fetchUpstreamSkillBundle(skill: {
 }): Promise<UpstreamSkillBundle | null> {
   if (!skill.sourceUrl) return null;
 
-  // Cache-bust raw.githubusercontent.com CDN to ensure we get latest content
+  // Phase 1: Fetch SKILL.md, repo tree, and revision in parallel
   const cacheBustedUrl = `${skill.sourceUrl}${skill.sourceUrl.includes("?") ? "&" : "?"}t=${Date.now()}`;
-  const [skillMd, payloadFiles, remoteRevision] = await Promise.all([
+  const [skillMd, freshTree, remoteRevision] = await Promise.all([
     appFetch(cacheBustedUrl).then(async (response) => {
       if (!response.ok) {
         throw new Error(`Failed to fetch skill content: ${response.status}`);
       }
       return response.text();
     }),
-    fetchRepoSkillPayloadFiles(skill.sourceUrl),
+    fetchFreshRepoTree(skill.sourceUrl),
     fetchRemoteSkillRevision(skill.sourceUrl),
   ]);
+
+  // Phase 2: Parse SKILL.md for includes, then fetch payload + includes files
+  const parsed = parseSkillMd(skillMd);
+  const payloadFiles = await fetchPayloadAndIncludes(
+    skill.sourceUrl,
+    freshTree,
+    parsed.metadata.includes,
+  );
 
   return { skillMd, payloadFiles, remoteRevision };
 }
@@ -448,21 +456,14 @@ export function isPublisherManagedSkill(
 }
 
 /**
- * Fetch all payload files (excluding SKILL.md) from a skill's GitHub directory.
- * Fetches a fresh repo tree (cache-busted) to discover files, then fetches
- * their raw content.  If the tree fetch fails, the error propagates so callers
- * never silently install from a stale tree.
+ * Fetch a fresh repo tree with cache-bust to avoid GitHub API CDN staleness.
+ * On failure this throws — callers must not fall back to a stale tree
+ * because recording a new syncedRevision with old file content would mask
+ * an incomplete sync and prevent future retries.
  */
-async function fetchRepoSkillPayloadFiles(
-  sourceUrl: string,
-): Promise<ExtraFile[]> {
-  const dirPrefix = deriveRepoDirPrefix(sourceUrl);
-  if (!dirPrefix) return [];
-
-  // Fetch a fresh tree with cache-bust to avoid GitHub API CDN staleness.
-  // On failure this throws — callers must not fall back to a stale tree
-  // because recording a new syncedRevision with old file content would mask
-  // an incomplete sync and prevent future retries.
+async function fetchFreshRepoTree(
+  _sourceUrl: string,
+): Promise<GitHubTreeNode[]> {
   const cacheBustedTreeUrl = `${SKILLS_INDEX_URL}&t=${Date.now()}`;
   const response = await appFetch(cacheBustedTreeUrl, {
     headers: githubApiHeaders(),
@@ -474,35 +475,57 @@ async function fetchRepoSkillPayloadFiles(
   }
   const payload = (await response.json()) as GitHubTreeResponse;
   const freshTree = payload.tree ?? [];
-  // Also update the global cache so subsequent operations benefit
   cachedRepoTree = freshTree;
+  return freshTree;
+}
 
-  if (freshTree.length === 0) return [];
+/**
+ * Validate an includes path for safety.
+ * Must be relative, no traversal, no absolute paths.
+ */
+function isValidIncludesPath(path: string): boolean {
+  if (!path || path.startsWith("/") || path.startsWith("\\")) return false;
+  if (path.includes("..")) return false;
+  if (path.startsWith(".") && !path.startsWith("./")) return false;
+  return true;
+}
 
-  // Find all blob files under the skill directory (excluding SKILL.md itself)
-  const siblingFiles = freshTree.filter(
-    (node) =>
-      node.type === "blob" &&
-      typeof node.path === "string" &&
-      node.path.startsWith(dirPrefix) &&
-      !node.path.endsWith("/SKILL.md"),
-  );
+/**
+ * Collect blob file nodes from a tree matching a directory prefix.
+ * Returns objects mapping each file's repo path to its install-relative path.
+ */
+function collectTreeFiles(
+  tree: GitHubTreeNode[],
+  dirPrefix: string,
+  relativePrefix: string,
+  excludeSkillMd: boolean,
+): Array<{ repoPath: string; relativePath: string }> {
+  return tree
+    .filter(
+      (node) =>
+        node.type === "blob" &&
+        typeof node.path === "string" &&
+        node.path.startsWith(dirPrefix) &&
+        (!excludeSkillMd || !node.path.endsWith("/SKILL.md")),
+    )
+    .map((node) => ({
+      repoPath: node.path as string,
+      relativePath:
+        relativePrefix + (node.path as string).slice(dirPrefix.length),
+    }));
+}
 
-  if (siblingFiles.length === 0) return [];
-
-  log.info(
-    "[Skills] Fetching",
-    siblingFiles.length,
-    "payload files for",
-    dirPrefix,
-  );
+/**
+ * Fetch raw file contents from GitHub for a list of file nodes.
+ */
+async function fetchRawFilesFromTree(
+  nodes: Array<{ repoPath: string; relativePath: string }>,
+): Promise<ExtraFile[]> {
+  if (nodes.length === 0) return [];
 
   const results = await Promise.allSettled(
-    siblingFiles.map(async (node): Promise<ExtraFile | null> => {
-      const filePath = node.path ?? "";
-      const relativePath = filePath.slice(dirPrefix.length);
-      const segments = filePath.split("/").map((s) => encodeURIComponent(s));
-      // Cache-bust raw.githubusercontent.com CDN (caches up to 300s)
+    nodes.map(async ({ repoPath, relativePath }): Promise<ExtraFile | null> => {
+      const segments = repoPath.split("/").map((s) => encodeURIComponent(s));
       const rawUrl = `${SKILLS_RAW_URL}/${segments.join("/")}?t=${Date.now()}`;
 
       try {
@@ -527,6 +550,64 @@ async function fetchRepoSkillPayloadFiles(
   return results
     .map((r) => (r.status === "fulfilled" ? r.value : null))
     .filter((f): f is ExtraFile => f !== null);
+}
+
+/**
+ * Fetch payload files from a skill's directory plus any declared includes paths.
+ * Includes files are installed under `_deps/{repo-path}/` to keep them
+ * safely within the skill directory while preserving the upstream structure.
+ */
+async function fetchPayloadAndIncludes(
+  sourceUrl: string,
+  tree: GitHubTreeNode[],
+  includes?: string[],
+): Promise<ExtraFile[]> {
+  const dirPrefix = deriveRepoDirPrefix(sourceUrl);
+  if (!dirPrefix || tree.length === 0) return [];
+
+  // Collect files from the skill's own directory (excluding SKILL.md)
+  const fileNodes = collectTreeFiles(tree, dirPrefix, "", true);
+
+  // Collect files from declared includes paths (installed under _deps/)
+  if (includes && includes.length > 0) {
+    for (const includePath of includes) {
+      if (!isValidIncludesPath(includePath)) {
+        log.warn("[Skills] Skipping invalid includes path:", includePath);
+        continue;
+      }
+      const normalizedPath = includePath.endsWith("/")
+        ? includePath
+        : `${includePath}/`;
+      const includeNodes = collectTreeFiles(
+        tree,
+        normalizedPath,
+        `_deps/${normalizedPath}`,
+        false,
+      );
+      if (includeNodes.length === 0) {
+        log.warn("[Skills] No files found for includes path:", includePath);
+      }
+      fileNodes.push(...includeNodes);
+    }
+    if (fileNodes.some((n) => n.relativePath.startsWith("_deps/"))) {
+      log.info(
+        "[Skills] Including shared dependencies from",
+        includes.length,
+        "declared paths",
+      );
+    }
+  }
+
+  if (fileNodes.length === 0) return [];
+
+  log.info(
+    "[Skills] Fetching",
+    fileNodes.length,
+    "payload files for",
+    dirPrefix,
+  );
+
+  return fetchRawFilesFromTree(fileNodes);
 }
 
 /**
@@ -1342,7 +1423,12 @@ export const skills = {
       if (content) {
         const parsed = parseSkillMd(content);
         const runtimeDir = `${skill.skillsDir}/${skill.dirName}`;
-        const runtimeNote = `> **Skill runtime directory:** \`${runtimeDir}\`\n> Use this absolute path to reference skill files. Do not create local copies or fallback scaffolds.\n\n`;
+        const hasIncludes =
+          parsed.metadata.includes && parsed.metadata.includes.length > 0;
+        const depsNote = hasIncludes
+          ? `\n> **Shared dependencies:** \`${runtimeDir}/_deps/\` contains shared files from declared \`includes\` paths.\n`
+          : "";
+        const runtimeNote = `> **Skill runtime directory:** \`${runtimeDir}\`\n> Use this absolute path to reference skill files. Do not create local copies or fallback scaffolds.${depsNote}\n\n`;
         contents.push(
           `## Skill: ${skill.name}\n\n${runtimeNote}${parsed.content}`,
         );

--- a/tests/unit/skill-includes.test.ts
+++ b/tests/unit/skill-includes.test.ts
@@ -1,0 +1,205 @@
+// ABOUTME: Tests for SKILL.md includes field parsing and shared dependency bundling.
+// ABOUTME: Validates that declared includes paths are fetched and installed under _deps/.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { parseSkillMd } from "@/lib/skills/parser";
+
+// --- Parser tests (no mocks needed) ---
+
+describe("parseSkillMd includes field", () => {
+  it("parses inline array includes", () => {
+    const raw = `---
+name: My Skill
+description: A skill
+includes: [polymarket/_shared, common/utils]
+---
+# My Skill`;
+    const parsed = parseSkillMd(raw);
+    expect(parsed.metadata.includes).toEqual([
+      "polymarket/_shared",
+      "common/utils",
+    ]);
+  });
+
+  it("parses multiline array includes", () => {
+    const raw = `---
+name: My Skill
+description: A skill
+includes:
+- polymarket/_shared
+- common/utils
+---
+# My Skill`;
+    const parsed = parseSkillMd(raw);
+    expect(parsed.metadata.includes).toEqual([
+      "polymarket/_shared",
+      "common/utils",
+    ]);
+  });
+
+  it("returns undefined includes when not declared", () => {
+    const raw = `---
+name: My Skill
+description: A skill
+---
+# My Skill`;
+    const parsed = parseSkillMd(raw);
+    expect(parsed.metadata.includes).toBeUndefined();
+  });
+
+  it("parses empty includes array", () => {
+    const raw = `---
+name: My Skill
+description: A skill
+includes: []
+---
+# My Skill`;
+    const parsed = parseSkillMd(raw);
+    expect(parsed.metadata.includes).toEqual([]);
+  });
+});
+
+// --- Fetch integration tests ---
+
+const mockAppFetch = vi.hoisted(() => vi.fn());
+const mockInvoke = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/fetch", () => ({
+  appFetch: mockAppFetch,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
+vi.mock("@/services/catalog", () => ({
+  catalog: {},
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: () => true,
+}));
+
+describe("fetchUpstreamSkillBundle with includes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches includes files under _deps/ prefix alongside skill payload", async () => {
+    const skillMdContent = `---
+name: Maker Bot
+description: A bot
+includes: [polymarket/_shared]
+---
+# Maker Bot`;
+
+    mockAppFetch
+      // SKILL.md
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => skillMdContent,
+      })
+      // Tree API
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tree: [
+            {
+              path: "polymarket/polymarket-maker-bot/SKILL.md",
+              type: "blob",
+            },
+            {
+              path: "polymarket/polymarket-maker-bot/scripts/run.py",
+              type: "blob",
+            },
+            { path: "polymarket/_shared/utils.py", type: "blob" },
+            { path: "polymarket/_shared/config.json", type: "blob" },
+          ],
+        }),
+      })
+      // Revision list
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ sha: "abc123" }],
+      })
+      // Revision detail
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sha: "abc123",
+          commit: { message: "update", committer: { date: "2026-01-01" } },
+          files: [],
+        }),
+      })
+      // Payload file: scripts/run.py
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => "print('run')",
+      })
+      // Includes file: _shared/utils.py
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => "def helper(): pass",
+      })
+      // Includes file: _shared/config.json
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => '{"key": "value"}',
+      });
+
+    // Mock invoke for get_seren_skills_dir + install_skill + validate_skill_payload
+    mockInvoke
+      .mockResolvedValueOnce("/skills") // get_seren_skills_dir
+      .mockResolvedValueOnce("/skills/polymarket-maker-bot/SKILL.md") // install_skill
+      .mockResolvedValueOnce([]); // validate_skill_payload
+
+    const { skills } = await import("@/services/skills");
+
+    const skill = {
+      id: "serenorg:polymarket-maker-bot",
+      slug: "polymarket-maker-bot",
+      name: "Maker Bot",
+      description: "A bot",
+      source: "serenorg" as const,
+      sourceUrl:
+        "https://raw.githubusercontent.com/serenorg/seren-skills/main/polymarket/polymarket-maker-bot/SKILL.md",
+      tags: [],
+    };
+
+    await skills.install(skill, skillMdContent, "seren", null);
+
+    // Find the install_skill call
+    const installCall = mockInvoke.mock.calls.find(
+      (call: unknown[]) => call[0] === "install_skill",
+    );
+    expect(installCall).toBeDefined();
+
+    const args = installCall![1] as Record<string, unknown>;
+    const extraFilesJson = args.extraFiles as string;
+    expect(extraFilesJson).toBeDefined();
+
+    const extraFiles = JSON.parse(extraFilesJson) as Array<{
+      path: string;
+      content: string;
+    }>;
+
+    // Should have the skill's own payload file
+    expect(extraFiles.some((f) => f.path === "scripts/run.py")).toBe(true);
+
+    // Should have includes files under _deps/
+    expect(
+      extraFiles.some(
+        (f) => f.path === "_deps/polymarket/_shared/utils.py",
+      ),
+    ).toBe(true);
+    expect(
+      extraFiles.some(
+        (f) => f.path === "_deps/polymarket/_shared/config.json",
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `includes` field to SKILL.md frontmatter for declaring shared dependency paths
- Shared files are fetched from the repo tree and installed under `_deps/{repo-path}/` within the skill directory
- Restructures `fetchUpstreamSkillBundle` into phased fetch for correct includes resolution
- Validates includes paths for safety (no traversal, no absolute)
- Injects `_deps` runtime note into agent system prompt for skills with includes

Closes #1208

## Test plan
- [x] Parser correctly handles inline, multiline, empty, and missing `includes` arrays (4 tests)
- [x] Install flow fetches includes files and installs them under `_deps/` prefix (1 integration test)
- [x] All 219 existing tests pass unchanged
- [x] Biome lint clean on changed files

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com