### PR TITLE
fix: clear stale auth error banner on successful prompt completion

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2751,6 +2751,13 @@ Summary:`;
           }
         }
 
+        // A successful prompt completion proves the session is healthy.
+        // Clear any stale error (e.g. auth-expired banner after re-login).
+        if (!isHistoryReplay && state.sessions[sessionId]?.error) {
+          setState("sessions", sessionId, "error", null);
+          setState("error", null);
+        }
+
         // Transition status back to "ready" so queued messages can be processed
         setState(
           "sessions",


### PR DESCRIPTION
## Summary
- Clears session error on successful promptComplete (non-replay), so the auth-expired banner auto-dismisses after re-login
- 7 lines added to the promptComplete handler in agent store

Closes #1286

## Test plan
- [x] All 219 existing tests pass
- [x] Biome clean on changed lines (pre-existing format issues in file are unrelated)
- [ ] Manual: trigger OAuth expiry, re-auth, send message - banner should dismiss

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com