### PR TITLE
fix: prevent queued messages lost during auto-compaction

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -737,6 +737,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     const drainSessionId = threadSessionId();
     if (!drainThreadId || !drainSessionId || !isReady()) return;
 
+    // Don't process queued messages while compaction is in progress —
+    // the session will be terminated and re-spawned, so any sendPrompt
+    // call would fail with "Session terminated" and the message would be
+    // lost. The isReady effect will re-trigger once the new session is up.
+    if (threadSession()?.isCompacting) return;
+
     // Read from the thread-specific Map, NOT the reactive messageQueue()
     // signal. During a thread switch the isReady effect can fire before the
     // thread-switch effect clears messageQueue(), making the signal stale.
@@ -764,7 +770,26 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         drainSessionId,
       );
     } catch (error) {
-      console.error("[AgentChat] Queued message failed:", error);
+      // If the session was terminated (e.g. by compaction), re-queue the
+      // message at the front so it survives the session transition and
+      // gets delivered once the new session is ready.
+      const msg = error instanceof Error ? error.message : String(error);
+      if (
+        msg.includes("Session terminated") ||
+        msg.includes("not found") ||
+        msg.includes("Worker thread dropped")
+      ) {
+        console.warn(
+          "[AgentChat] Re-queuing message after session termination:",
+          nextMessage,
+        );
+        const currentQueue = threadQueues.get(drainThreadId) ?? [];
+        const restored = [nextMessage, ...currentQueue];
+        threadQueues.set(drainThreadId, restored);
+        setMessageQueue(restored);
+      } else {
+        console.error("[AgentChat] Queued message failed:", error);
+      }
     }
 
     queueDraining = false;
@@ -781,12 +806,20 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   // Check threadQueues Map (not the reactive signal) to avoid reading stale
   // messageQueue() values during a thread switch — the root cause of
   // cross-thread message pollution.
+  // Also guard against compaction: the session briefly reports "ready" during
+  // the compaction flow before being terminated — processing queued messages
+  // in that window causes "Session terminated" errors and message loss.
   createEffect(
     on(
       isReady,
       (ready) => {
         const threadId = activeAgentThread()?.id;
-        if (ready && threadId && (threadQueues.get(threadId)?.length ?? 0) > 0) {
+        if (
+          ready &&
+          threadId &&
+          !threadSession()?.isCompacting &&
+          (threadQueues.get(threadId)?.length ?? 0) > 0
+        ) {
           processNextQueuedMessage();
         }
       },

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1831,8 +1831,8 @@ Summary:`;
         .join("\n\n");
 
       const seedPrompt = preservedContext
-        ? `Here is a summary of our prior conversation:\n\n${summary}\n\nHere are the most recent messages:\n\n${preservedContext}\n\nContinue from where we left off. The user may send a new message shortly.`
-        : `Here is a summary of our prior conversation:\n\n${summary}\n\nContinue from where we left off. The user may send a new message shortly.`;
+        ? `Here is a summary of our prior conversation:\n\n${summary}\n\nHere are the most recent messages:\n\n${preservedContext}\n\nThis context was restored after automatic compaction. Do NOT take any action or make any changes. Wait for the user to send their next message before proceeding.`
+        : `Here is a summary of our prior conversation:\n\n${summary}\n\nThis context was restored after automatic compaction. Do NOT take any action or make any changes. Wait for the user to send their next message before proceeding.`;
 
       // Wait for the new session to be ready, then restore settings and seed
       await waitForSessionReady(newSessionId);


### PR DESCRIPTION
## Summary

Closes #1288

- Guard queue processing with `isCompacting` check — prevents dequeuing messages when the session is about to be terminated by compaction
- Re-queue messages at front of thread queue when `sendPrompt` fails with session termination errors during compaction
- Change compaction seed prompt from "Continue from where we left off" to "Wait for the user to send their next message" — prevents agent from taking autonomous action with only summary context

## Root Cause

Race condition: auto-compaction fires from `promptComplete` handler while `isReady` effect simultaneously drains the message queue. The queued message is dequeued, `sendPrompt` is called, but compaction terminates the session underneath it. The message is consumed from the queue but never delivered. The new post-compaction session then gets a seed prompt saying "Continue from where we left off" which causes the agent to take initiative without user intent.

## Test plan

- [ ] Reproduce: fill context to ~80%, queue a follow-up message while agent is responding, observe compaction triggers
- [ ] Verify queued message survives compaction and is delivered to the new session
- [ ] Verify agent does not take autonomous action after compaction — waits for user input
- [ ] Verify normal (non-compaction) queue processing is unaffected

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com