### PR TITLE
fix: debounce skills refresh and show user feedback (#1289)

### DIFF
--- a/src/components/sidebar/SkillsExplorer.tsx
+++ b/src/components/sidebar/SkillsExplorer.tsx
@@ -26,7 +26,7 @@ import {
   skills as skillsService,
 } from "@/services/skills";
 import { agentStore } from "@/stores/agent.store";
-import { skillsStore } from "@/stores/skills.store";
+import { type RefreshSummary, skillsStore } from "@/stores/skills.store";
 import { threadStore } from "@/stores/thread.store";
 
 interface SkillsExplorerProps {
@@ -65,6 +65,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
   const [actionInProgress, setActionInProgress] = createSignal<string | null>(
     null,
   );
+  const [refreshStatus, setRefreshStatus] = createSignal<string | null>(null);
   const [overflowMenuId, setOverflowMenuId] = createSignal<string | null>(null);
   const [installWarning, setInstallWarning] = createSignal<{
     slug: string;
@@ -333,9 +334,23 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
   };
 
   const handleRefreshAll = async () => {
-    await skillsStore.refresh(true);
+    const summary = await skillsStore.refresh(true);
     await refreshAllSyncStatuses();
+    showRefreshStatus(summary);
   };
+
+  function showRefreshStatus(summary: RefreshSummary) {
+    let message: string;
+    if (summary.updated > 0) {
+      message = `${summary.updated} skill${summary.updated === 1 ? "" : "s"} updated`;
+    } else if (summary.failed > 0) {
+      message = `Refresh failed for ${summary.failed} skill${summary.failed === 1 ? "" : "s"}`;
+    } else {
+      message = "All skills up to date";
+    }
+    setRefreshStatus(message);
+    setTimeout(() => setRefreshStatus(null), 4000);
+  }
 
   const handleRefreshInstalledSkill = async (skill: InstalledSkill) => {
     const cachedStatus = syncStatusFor(skill);
@@ -625,6 +640,13 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
           </button>
         </div>
       </div>
+
+      {/* Refresh status feedback */}
+      <Show when={refreshStatus()}>
+        <div class="px-3 py-1.5 text-xs text-muted-foreground bg-surface-2/50 border-b border-border animate-[fadeIn_0.15s_ease-out]">
+          {refreshStatus()}
+        </div>
+      </Show>
 
       {/* Create dialog */}
       <Show when={showCreateDialog()}>

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -22,6 +22,18 @@ const ENABLED_SKILLS_KEY = "seren:enabled_skills";
 const HIDDEN_SKILLS_KEY = "seren:hidden_skills";
 
 /**
+ * Summary returned by refresh() so callers can display user feedback.
+ */
+export interface RefreshSummary {
+  updated: number;
+  alreadyCurrent: number;
+  failed: number;
+}
+
+/** Concurrency guard: in-flight refresh promise so concurrent calls coalesce. */
+let activeRefreshPromise: Promise<RefreshSummary> | null = null;
+
+/**
  * Load enabled skills state from localStorage.
  */
 function loadEnabledState(): Record<string, boolean> {
@@ -626,8 +638,31 @@ export const skillsStore = {
   /**
    * Refresh all skills (available and installed).
    * Pass skipCache=true for user-triggered refreshes that should bypass cache.
+   * Concurrent calls coalesce — the second caller gets the first caller's result.
    */
-  async refresh(skipCache = false): Promise<void> {
+  async refresh(skipCache = false): Promise<RefreshSummary> {
+    if (activeRefreshPromise) {
+      log.info("[SkillsStore] Refresh already in progress, coalescing");
+      return activeRefreshPromise;
+    }
+
+    const promise = this._refreshInner(skipCache);
+    activeRefreshPromise = promise;
+    try {
+      return await promise;
+    } finally {
+      activeRefreshPromise = null;
+    }
+  },
+
+  /** @internal — the actual refresh logic, called only by refresh(). */
+  async _refreshInner(skipCache: boolean): Promise<RefreshSummary> {
+    const summary: RefreshSummary = {
+      updated: 0,
+      alreadyCurrent: 0,
+      failed: 0,
+    };
+
     await Promise.all([
       this.refreshAvailable(skipCache),
       this.refreshInstalled(),
@@ -668,7 +703,10 @@ export const skillsStore = {
         if (status.updateAvailable || status.state === "bootstrap-required") {
           await skills.refreshInstalledSkill(skill);
           autoRefreshed++;
+          summary.updated++;
           log.info("[SkillsStore] Auto-refreshed stale skill:", skill.slug);
+        } else {
+          summary.alreadyCurrent++;
         }
       } catch (err) {
         const is404 = err instanceof Error && err.message.includes(": 404");
@@ -685,6 +723,7 @@ export const skillsStore = {
             skill.slug,
           );
         } else {
+          summary.failed++;
           log.warn(
             "[SkillsStore] Failed to check/refresh skill:",
             skill.slug,
@@ -771,6 +810,8 @@ export const skillsStore = {
     if (renamedDirs > 0) {
       await this.refreshInstalled();
     }
+
+    return summary;
   },
 
   /**

--- a/tests/unit/skills-auto-sync.test.ts
+++ b/tests/unit/skills-auto-sync.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Test that refresh() auto-refreshes stale upstream-managed skills.
-// ABOUTME: Verifies the fix for #1155 — skills must not stay stale after startup/periodic refresh.
+// ABOUTME: Verifies concurrency guard (#1289), summary tracking, and the fix for #1155.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -126,5 +126,81 @@ describe("skills auto-sync on refresh (#1155)", () => {
 
     expect(mockSkillsService.inspectSyncStatus).toHaveBeenCalledWith(editedSkill);
     expect(mockSkillsService.refreshInstalledSkill).not.toHaveBeenCalled();
+  });
+});
+
+describe("refresh() concurrency guard and summary (#1289)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("concurrent refresh() calls coalesce into a single execution", async () => {
+    mockSkillsService.fetchAllSkills.mockResolvedValue([]);
+    mockSkillsService.listAllInstalled.mockResolvedValue([]);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+
+    const [r1, r2, r3] = await Promise.all([
+      skillsStore.refresh(true),
+      skillsStore.refresh(true),
+      skillsStore.refresh(true),
+    ]);
+
+    // All three callers get a result
+    expect(r1).toBeDefined();
+    expect(r2).toBeDefined();
+    expect(r3).toBeDefined();
+
+    // But the underlying fetch only ran once
+    expect(mockSkillsService.fetchAllSkills).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns accurate summary counts", async () => {
+    const updatedSkill = {
+      slug: "skill-a",
+      scope: "serenorg" as const,
+      path: "/skills/skill-a",
+      syncState: { upstreamSource: "serenorg/seren-skills", syncedRevision: "aaa", syncedAt: 1, managedFiles: {} },
+    };
+    const currentSkill = {
+      slug: "skill-b",
+      scope: "serenorg" as const,
+      path: "/skills/skill-b",
+      syncState: { upstreamSource: "serenorg/seren-skills", syncedRevision: "bbb", syncedAt: 1, managedFiles: {} },
+    };
+    const failingSkill = {
+      slug: "skill-c",
+      scope: "serenorg" as const,
+      path: "/skills/skill-c",
+      syncState: { upstreamSource: "serenorg/seren-skills", syncedRevision: "ccc", syncedAt: 1, managedFiles: {} },
+    };
+
+    mockSkillsService.fetchAllSkills.mockResolvedValue([]);
+    mockSkillsService.listAllInstalled.mockResolvedValue([updatedSkill, currentSkill, failingSkill]);
+    mockSkillsService.isUpstreamManagedSkill.mockReturnValue(true);
+    mockSkillsService.inspectSyncStatus
+      .mockResolvedValueOnce({ updateAvailable: true, hasLocalChanges: false })
+      .mockResolvedValueOnce({ updateAvailable: false, hasLocalChanges: false, state: "current" })
+      .mockRejectedValueOnce(new Error("Failed to fetch remote revision: 403"));
+    mockSkillsService.refreshInstalledSkill.mockResolvedValue({ installed: updatedSkill, syncStatus: null });
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    const summary = await skillsStore.refresh();
+
+    expect(summary).toEqual({ updated: 1, alreadyCurrent: 1, failed: 1 });
+  });
+
+  it("allows a new refresh after the previous one completes", async () => {
+    mockSkillsService.fetchAllSkills.mockResolvedValue([]);
+    mockSkillsService.listAllInstalled.mockResolvedValue([]);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+
+    await skillsStore.refresh(true);
+    await skillsStore.refresh(true);
+
+    // Two sequential calls should each execute
+    expect(mockSkillsService.fetchAllSkills).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- Add concurrency guard to `skillsStore.refresh()` — concurrent calls coalesce into a single execution instead of racing and doubling GitHub API usage
- Return a `RefreshSummary` from `refresh()` with `{ updated, alreadyCurrent, failed }` counts
- Show inline status feedback in SkillsExplorer toolbar after refresh completes (auto-dismisses after 4s)

Closes #1289

## Test plan
- [x] Concurrent `refresh()` calls coalesce (second call returns same promise, `fetchAllSkills` only called once)
- [x] Sequential `refresh()` calls each execute independently
- [x] Summary correctly counts updated/current/failed skills
- [x] All 222 existing tests pass
- [x] Biome checks pass

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
