### PR TITLE
fix: abort skill sync when any payload file fails to fetch

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -524,32 +524,38 @@ async function fetchRawFilesFromTree(
   if (nodes.length === 0) return [];
 
   const results = await Promise.allSettled(
-    nodes.map(async ({ repoPath, relativePath }): Promise<ExtraFile | null> => {
+    nodes.map(async ({ repoPath, relativePath }): Promise<ExtraFile> => {
       const segments = repoPath.split("/").map((s) => encodeURIComponent(s));
       const rawUrl = `${SKILLS_RAW_URL}/${segments.join("/")}?t=${Date.now()}`;
 
-      try {
-        const resp = await appFetch(rawUrl);
-        if (!resp.ok) {
-          log.warn(
-            "[Skills] Failed to fetch payload file",
-            rawUrl,
-            resp.status,
-          );
-          return null;
-        }
-        const content = await resp.text();
-        return { path: relativePath, content };
-      } catch (error) {
-        log.warn("[Skills] Error fetching payload file", rawUrl, error);
-        return null;
+      const resp = await appFetch(rawUrl);
+      if (!resp.ok) {
+        throw new Error(
+          `Failed to fetch payload file ${relativePath}: HTTP ${resp.status}`,
+        );
       }
+      const content = await resp.text();
+      return { path: relativePath, content };
     }),
   );
 
-  return results
-    .map((r) => (r.status === "fulfilled" ? r.value : null))
-    .filter((f): f is ExtraFile => f !== null);
+  const files: ExtraFile[] = [];
+  const failures: string[] = [];
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      files.push(result.value);
+    } else {
+      failures.push(result.reason?.message ?? String(result.reason));
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Failed to fetch ${failures.length}/${nodes.length} payload files: ${failures.join("; ")}`,
+    );
+  }
+
+  return files;
 }
 
 /**

--- a/tests/unit/skills-payload-fetch.test.ts
+++ b/tests/unit/skills-payload-fetch.test.ts
@@ -78,6 +78,76 @@ describe("fetchRepoSkillPayloadFiles stale cache prevention (#1215)", () => {
     ).rejects.toThrow();
   });
 
+  it("throws when any individual payload file fails to fetch (#1293)", async () => {
+    // Simulates the serendb_storage.py bug: tree has 3 files, but one
+    // returns HTTP 500. The sync must abort — not silently proceed with
+    // 2/3 files and wipe the missing one from the runtime directory.
+    const treeWithFiles = [
+      { path: "test/skill/agent.py", type: "blob" },
+      { path: "test/skill/config.json", type: "blob" },
+      { path: "test/skill/serendb_storage.py", type: "blob" },
+    ];
+
+    mockAppFetch.mockImplementation(async (url: string) => {
+      // SKILL.md content
+      if (url.includes("/SKILL.md")) {
+        return { ok: true, text: async () => "---\nname: Test Skill\n---\nContent" };
+      }
+      // Tree API
+      if (url.includes("git/trees/")) {
+        return { ok: true, json: async () => ({ tree: treeWithFiles }) };
+      }
+      // Commits list API
+      if (url.includes("/commits?")) {
+        return { ok: true, json: async () => [{ sha: "abc123" }] };
+      }
+      // Commit detail API
+      if (url.includes("/commits/abc123")) {
+        return {
+          ok: true,
+          json: async () => ({ commit: { committer: { date: "2026-01-01" }, message: "test" } }),
+        };
+      }
+      // Raw file fetches — fail serendb_storage.py
+      if (url.includes("serendb_storage.py")) {
+        return { ok: false, status: 500 };
+      }
+      return { ok: true, text: async () => "file content" };
+    });
+
+    const { skills } = await import("@/services/skills");
+
+    await expect(
+      skills.refreshInstalledSkill({
+        slug: "test-skill",
+        name: "Test Skill",
+        description: "desc",
+        id: "local:test-skill",
+        source: "local",
+        tags: [],
+        scope: "seren",
+        skillsDir: "/skills",
+        dirName: "test-skill",
+        path: "/skills/test-skill/SKILL.md",
+        installedAt: 1,
+        enabled: true,
+        contentHash: "hash",
+        upstreamSource: "serenorg",
+        upstreamSourceUrl:
+          "https://raw.githubusercontent.com/serenorg/seren-skills/main/test/skill/SKILL.md",
+        syncState: {
+          version: 1,
+          upstreamSource: "serenorg",
+          upstreamSourceUrl:
+            "https://raw.githubusercontent.com/serenorg/seren-skills/main/test/skill/SKILL.md",
+          syncedRevision: "old-sha",
+          syncedAt: 1,
+          managedFiles: { "SKILL.md": "oldhash" },
+        },
+      }),
+    ).rejects.toThrow(/Failed to fetch.*payload files/);
+  });
+
   it("throws when tree API returns non-OK status", async () => {
     mockAppFetch
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Closes #1293

- `fetchRawFilesFromTree` now throws if any payload file fails to fetch, instead of silently dropping it
- Prevents partial syncs from proceeding to the atomic directory replacement, which permanently deletes unfetched files from the runtime directory
- Added test verifying that a single file fetch failure (e.g., `serendb_storage.py` returning HTTP 500) aborts the entire sync

## Root Cause

`fetchRawFilesFromTree` used `Promise.allSettled` and filtered out `null` results (failed fetches). When one file out of 23 hit a transient GitHub API error (rate limit, CDN staleness, network timeout), the sync proceeded with 22/23 files. The atomic `fs::rename` in the Rust `install_skill` command then replaced the entire runtime directory with the incomplete set, permanently deleting the 23rd file.

## Test plan

- [ ] Verify new test passes: `pnpm test -- --run tests/unit/skills-payload-fetch.test.ts`
- [ ] Verify all existing tests still pass: `pnpm test`
- [ ] Manual: install polymarket-bot skill, verify all files including `serendb_storage.py` are present after sync

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
