### PR TITLE
fix: suppress DOS console window popups on Windows

### DIFF
--- a/src-tauri/src/commands/cli_installer.rs
+++ b/src-tauri/src/commands/cli_installer.rs
@@ -21,7 +21,14 @@ pub async fn check_cli_installed(tool: CliTool) -> Result<bool, String> {
 
     // Try to run --version command
     let result = if cfg!(target_os = "windows") {
-        Command::new("where").arg(bin_name).output()
+        let mut c = Command::new("where");
+        c.arg(bin_name);
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            c.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        }
+        c.output()
     } else {
         Command::new("which").arg(bin_name).output()
     };
@@ -127,10 +134,14 @@ fn get_codex_install_script() -> String {
 
 /// Install on Windows using PowerShell
 fn install_windows(script: &str) -> Result<bool, String> {
-    let output = Command::new("powershell")
-        .arg("-NoProfile")
-        .arg("-Command")
-        .arg(script)
+    let mut cmd = Command::new("powershell");
+    cmd.arg("-NoProfile").arg("-Command").arg(script);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+    let output = cmd
         .output()
         .map_err(|e| format!("Failed to execute PowerShell: {}", e))?;
 

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -405,6 +405,12 @@ pub fn mcp_connect(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
     // Inject the embedded runtime PATH so child processes can find bundled node/git
     let embedded_path = embedded_runtime::get_embedded_path();
     if !embedded_path.is_empty() {

--- a/src-tauri/src/openclaw.rs
+++ b/src-tauri/src/openclaw.rs
@@ -317,6 +317,12 @@ pub async fn openclaw_start(app: AppHandle, state: State<'_, OpenClawState>) -> 
         .stderr(std::process::Stdio::null());
     cmd.kill_on_drop(true);
 
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
     // Add embedded runtime to PATH
     let embedded_path = crate::embedded_runtime::get_embedded_path();
     if !embedded_path.is_empty() {
@@ -800,6 +806,12 @@ async fn query_channels() -> Result<Vec<ChannelInfo>, String> {
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
 
     if !embedded_path.is_empty() {
         let sep = if cfg!(target_os = "windows") {
@@ -1362,6 +1374,12 @@ pub async fn openclaw_disconnect_channel(
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
 
     if !embedded_path.is_empty() {
         let sep = if cfg!(target_os = "windows") {

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -93,6 +93,12 @@ impl ProviderRuntimeState {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            command.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        }
+
         let embedded_path = crate::embedded_runtime::get_embedded_path();
         if !embedded_path.is_empty() {
             command.env("PATH", embedded_path);

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -41,6 +41,12 @@ pub async fn execute_shell_command(
         c
     };
 
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
     // Prepend embedded runtime to PATH so shell commands can find bundled Node/Git
     // while preserving access to system-installed tools.
     let embedded_path = crate::embedded_runtime::get_embedded_path();


### PR DESCRIPTION
## Summary

Closes #1295

- Add `CREATE_NO_WINDOW` (0x08000000) creation flag to all 8 subprocess spawn points on Windows
- Uses `#[cfg(windows)]` conditional compilation -- compiles to nothing on macOS/Linux
- Prevents DOS console window popups when spawning Node.js, cmd.exe, PowerShell, and where.exe

## Root Cause

On Windows, `Command::new()` creates a visible console window by default for every spawned subprocess. The embedded Node.js runtime, MCP servers, OpenClaw, shell commands, and CLI installer checks all spawn processes without the `CREATE_NO_WINDOW` flag, causing repeated DOS window popups during normal app usage.

## Test plan

- [ ] Windows: verify no console window popups during normal app usage (agent chat, MCP connections, skill runs)
- [ ] macOS/Linux: verify no regressions (the `#[cfg(windows)]` blocks compile to nothing)
- [ ] Verify provider runtime, MCP servers, and OpenClaw still function correctly after the change

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
