### PR TITLE
fix: resolve Claude Code CLI path on Windows (#1297)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -3,6 +3,7 @@
 
 import { execFile, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 function launchLoginCommand(command) {
@@ -178,6 +179,42 @@ async function ensureClaudeCodeViaNativeInstaller(emit) {
     message: "Claude Code CLI installed successfully",
   });
 
+  // Re-resolve the binary path after install. The installer adds the binary
+  // to a well-known location that the current process PATH may not include.
+  return resolveInstalledClaudeBinary();
+}
+
+/**
+ * Resolve the installed Claude Code binary path.
+ * GUI apps don't inherit shell PATH updates made by installers, so check
+ * well-known install locations before falling back to bare command name.
+ */
+function resolveInstalledClaudeBinary() {
+  if (process.platform === "win32") {
+    const home = os.homedir();
+    const appData = process.env.APPDATA ?? "";
+    const candidates = [
+      path.join(home, ".claude", "bin", "claude.exe"),
+      ...(appData ? [path.join(appData, "Claude", "claude.exe")] : []),
+      ...(appData ? [path.join(appData, "npm", "claude.cmd")] : []),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  } else {
+    const home = os.homedir();
+    const candidates = [
+      path.join(home, ".claude", "bin", "claude"),
+      path.join(home, ".local", "bin", "claude"),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
   return "claude";
 }
 

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -18,13 +18,36 @@ import { buildProviderMcpConfig } from "./mcp-config.mjs";
  */
 function resolveClaudeBinary() {
   if (process.platform === "win32") {
+    const home = os.homedir();
     const appData = process.env.APPDATA ?? "";
-    if (appData) {
-      const candidate = path.join(appData, "Claude", "claude.exe");
+    const candidates = [
+      // Native installer (install.ps1) places binary here
+      path.join(home, ".claude", "bin", "claude.exe"),
+      // Legacy/alternate location
+      ...(appData ? [path.join(appData, "Claude", "claude.exe")] : []),
+      // npm global install creates a .cmd wrapper here
+      ...(appData ? [path.join(appData, "npm", "claude.cmd")] : []),
+    ];
+
+    for (const candidate of candidates) {
       if (existsSync(candidate)) {
         return candidate;
       }
     }
+
+    // Try PATH lookup via `where`
+    try {
+      const resolved = execFileSync("where", ["claude"], {
+        encoding: "utf8",
+        timeout: 5_000,
+      }).trim().split(/\r?\n/)[0];
+      if (resolved) {
+        return resolved;
+      }
+    } catch {
+      // where failed — fall through to bare command name
+    }
+
     return "claude";
   }
 
@@ -57,15 +80,29 @@ function resolveClaudeBinary() {
 }
 
 /**
- * Build a PATH string that includes well-known Node.js install locations.
- * macOS GUI apps don't inherit the user's shell profile, so node/npm from
- * nvm, fnm, Homebrew, or Volta aren't on PATH. Without this, Claude Code
- * hooks that shell out to `node` fail with "command not found".
+ * Build a PATH string that includes well-known CLI install locations.
+ * GUI apps don't inherit the user's shell profile, so tools installed via
+ * native installers or npm global aren't on PATH. Without this, spawned
+ * processes fail with "command not found" / "not recognized".
  */
 function buildExtendedPath() {
   const sep = process.platform === "win32" ? ";" : ":";
   const base = process.env.PATH ?? "";
-  if (process.platform === "win32") return base;
+
+  if (process.platform === "win32") {
+    const home = os.homedir();
+    const appData = process.env.APPDATA ?? "";
+    const winExtra = [
+      // Claude Code native installer (install.ps1)
+      path.join(home, ".claude", "bin"),
+      // npm global bin directory
+      ...(appData ? [path.join(appData, "npm")] : []),
+    ];
+    const winAdditions = winExtra.filter((p) => p && !base.includes(p));
+    return winAdditions.length > 0
+      ? `${winAdditions.join(sep)}${sep}${base}`
+      : base;
+  }
 
   const home = os.homedir();
   const extra = [

--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -228,21 +228,21 @@ fn extend_path_with_common_bins(current_path: &str, path_separator: &str) -> Str
         .collect();
 
     // Keep the user's order, but append missing common locations.
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    // GUI apps don't source shell profiles so CLI install directories
+    // (e.g., ~/.claude/bin, %APPDATA%\npm) are typically missing from PATH.
     {
         use std::collections::HashSet;
 
         let mut seen: HashSet<String> = entries.iter().cloned().collect();
-
-        // Build common bins list including user-local tool directories.
-        // GUI apps don't source shell profiles so ~/.claude/bin and ~/.local/bin
-        // (where native installers place CLIs) are typically missing from PATH.
-        let home = std::env::var("HOME").unwrap_or_default();
         let mut common_bins: Vec<String> = Vec::new();
 
-        if !home.is_empty() {
-            common_bins.push(format!("{}/.claude/bin", home));
-            common_bins.push(format!("{}/.local/bin", home));
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        {
+            let home = std::env::var("HOME").unwrap_or_default();
+            if !home.is_empty() {
+                common_bins.push(format!("{}/.claude/bin", home));
+                common_bins.push(format!("{}/.local/bin", home));
+            }
         }
 
         #[cfg(target_os = "macos")]
@@ -266,6 +266,20 @@ fn extend_path_with_common_bins(current_path: &str, path_separator: &str) -> Str
                 "/usr/sbin".to_string(),
                 "/sbin".to_string(),
             ]);
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            // Claude Code native installer (install.ps1) puts binary here
+            let userprofile = std::env::var("USERPROFILE").unwrap_or_default();
+            if !userprofile.is_empty() {
+                common_bins.push(format!("{}\\.claude\\bin", userprofile));
+            }
+            // npm global installs land here
+            let appdata = std::env::var("APPDATA").unwrap_or_default();
+            if !appdata.is_empty() {
+                common_bins.push(format!("{}\\npm", appdata));
+            }
         }
 
         for bin in common_bins {


### PR DESCRIPTION
## Summary
- Add correct Windows install paths for Claude Code CLI (`%USERPROFILE%\.claude\bin\claude.exe`, `%APPDATA%\npm\claude.cmd`) to `resolveClaudeBinary()`
- Extend `buildExtendedPath()` on Windows to include Claude and npm directories (was early-returning with bare PATH)
- Add `%USERPROFILE%\.claude\bin` and `%APPDATA%\npm` to Rust `extend_path_with_common_bins` on Windows (was skipped entirely via `#[cfg]` guard)
- Re-resolve binary path after `ensureClaudeCodeViaNativeInstaller` instead of returning bare "claude"

Closes #1297

## Test plan
- [x] All 223 unit tests pass
- [x] Biome checks pass (no new errors)
- [ ] Manual: verify on Windows that Claude Code CLI is found after install.ps1
- [ ] Manual: verify `where claude` works from embedded runtime context

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
