### PR TITLE
fix: kill orphaned node.exe during Windows install and handle runtime restarts (#1297, #1299)

### DIFF
--- a/src-tauri/nsis/installer-hooks.nsh
+++ b/src-tauri/nsis/installer-hooks.nsh
@@ -1,10 +1,19 @@
 ; ABOUTME: NSIS installer hooks for Seren Desktop.
-; ABOUTME: Kills running Seren process before files are copied to prevent file-lock errors.
+; ABOUTME: Kills running Seren and orphaned embedded-runtime processes to prevent file-lock errors.
 
 !macro NSIS_HOOK_PREINSTALL
-  ; Kill any running Seren instance so installer can overwrite locked files
+  ; Kill Seren main process and its child process tree
   nsExec::ExecToStack 'taskkill /F /IM "Seren.exe" /T'
   Pop $0
   Pop $1
+  ; Brief pause for child processes to exit
   Sleep 1000
+  ; Kill orphaned node.exe from the embedded runtime. The /T flag above misses
+  ; node.exe processes that were detached or orphaned by a provider-runtime crash.
+  ; Target only Seren's embedded node — not the user's own Node.js processes.
+  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "Get-Process node -EA 0 | ? { $_.Path -and $_.Path -match ''SerenDesktop'' } | Stop-Process -Force -EA 0"'
+  Pop $0
+  Pop $1
+  ; Allow OS to release file handles after process termination
+  Sleep 2000
 !macroend

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { DailyClaimPopup } from "@/components/wallet/DailyClaimPopup";
 import {
   connectLocalProviderRuntime,
   disconnectLocalProviderRuntime,
+  listenForRuntimeRestart,
 } from "@/lib/browser-local-runtime";
 import { getRuntimeConfig } from "@/lib/runtime";
 import { shortcuts } from "@/lib/shortcuts";
@@ -67,6 +68,7 @@ function App() {
     ) {
       try {
         await connectLocalProviderRuntime();
+        void listenForRuntimeRestart();
       } catch (error) {
         console.error(
           "[App] Failed to connect to local provider runtime:",

--- a/src/lib/browser-local-runtime.ts
+++ b/src/lib/browser-local-runtime.ts
@@ -312,6 +312,26 @@ export function disconnectLocalProviderRuntime(): void {
   rejectPendingRpc(new Error("Local provider runtime disconnected."));
 }
 
+/**
+ * Listen for provider-runtime restarts from the Rust backend.
+ * When the runtime crashes and restarts on a new port, the cached config
+ * (host/port/token) is stale. Disconnect so the next call re-fetches config.
+ */
+export async function listenForRuntimeRestart(): Promise<void> {
+  if (!isDesktopNativeRuntime()) return;
+  try {
+    const { listen } = await import("@tauri-apps/api/event");
+    await listen("provider-runtime://restarted", () => {
+      console.info(
+        "[local-provider-runtime] Runtime restarted, invalidating cached config",
+      );
+      disconnectLocalProviderRuntime();
+    });
+  } catch {
+    // Not in Tauri environment
+  }
+}
+
 export async function runtimeInvoke<T>(
   method: string,
   params?: Record<string, unknown>,


### PR DESCRIPTION
## Summary
- NSIS installer now kills orphaned `node.exe` processes from the embedded runtime via PowerShell path-match, not just `Seren.exe` — fixes "Error opening file for writing" during Windows updates
- Increased post-kill wait from 1s to 3s total (1s after Seren kill + 2s after node kill) to let OS release file handles
- Frontend now listens for `provider-runtime://restarted` Tauri event and invalidates cached WebSocket config, fixing stale port connections after runtime crashes

Closes #1299
Updates #1297

## Test plan
- [x] All 223 unit tests pass
- [x] Biome checks pass
- [ ] Manual: Windows update install no longer shows node.exe file lock error
- [ ] Manual: After provider runtime crash/restart, next agent spawn reconnects on correct port

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
