### PR TITLE
fix: show clean slash command in chat instead of raw skill-invocation XML (#1303)

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -717,7 +717,8 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
             ? `/${skill.slug} ${args}`
             : `/${skill.slug}`;
 
-        await sendMessageImmediate(directive, undefined);
+        const displayText = args ? `/${skill.slug} ${args}` : `/${skill.slug}`;
+        await sendMessageImmediate(directive, undefined, displayText);
         return;
       }
     }
@@ -753,6 +754,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
   const sendMessageImmediate = async (
     messageContent: string,
     images?: Attachment[],
+    displayContent?: string,
   ) => {
     const conversationId = conversationStore.activeConversationId;
     if (!conversationId) return;
@@ -761,7 +763,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
       id: crypto.randomUUID(),
       type: "user",
       role: "user",
-      content: messageContent,
+      content: displayContent ?? messageContent,
       images,
       timestamp: Date.now(),
       modelId: chatStore.selectedModel,


### PR DESCRIPTION
## Summary
- Add optional `displayContent` parameter to `sendMessageImmediate()` in ChatContent.tsx
- Skill invocations now show the clean slash command (e.g. `/knowledge`) in the chat UI while sending the full `<skill-invocation>` directive to the orchestrator
- Mirrors the pattern already used in AgentChat.tsx (line 621: `displayContent: trimmed`)

Closes #1303

## Test plan
- [x] All 223 unit tests pass
- [x] Biome checks pass
- [ ] Manual: invoke a skill via slash command in orchestrator chat — verify user sees `/knowledge` not raw XML
- [ ] Manual: verify the orchestrator still receives the full skill directive and executes the skill

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
