### PR TITLE
fix: suppress auth expired banner on recovered mid-conversation 401 (#1312)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1015,7 +1015,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     return grouped;
   });
 
-  const renderMessage = (message: AgentMessage) => {
+  const renderMessage = (message: AgentMessage, isLastMessage = false) => {
     switch (message.type) {
       case "user":
         return (
@@ -1072,7 +1072,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         return (
           <article class="group/msg relative px-5 py-4 border-b border-surface-2 [contain:layout]">
             <Show
-              when={isLikelyAuthError(message.content)}
+              when={isLastMessage && isLikelyAuthError(message.content)}
               fallback={
                 <div
                   class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
@@ -1492,7 +1492,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             </Show>
 
             <For each={groupConsecutiveToolCalls()}>
-              {(item) => {
+              {(item, index) => {
+                const isLast = () =>
+                  index() === groupConsecutiveToolCalls().length - 1;
                 if (item.type === "tool_group") {
                   return (
                     <ToolCallGroup
@@ -1501,7 +1503,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                     />
                   );
                 }
-                return renderMessage(item.message);
+                return renderMessage(item.message, isLast());
               }}
             </For>
 


### PR DESCRIPTION
## Summary
- Only show the "Authentication expired" banner on the **last** message in the conversation
- If subsequent messages exist after an auth-related assistant message, the token refresh succeeded and the banner is suppressed
- Adds `isLastMessage` parameter to `renderMessage()`, passed from the `For` loop index

Closes #1312

## Test plan
- [x] All 224 unit tests pass
- [x] Biome checks pass
- [ ] Manual: trigger a transient 401 mid-conversation — verify banner does NOT appear on recovered messages
- [ ] Manual: trigger a real auth expiry (last message) — verify banner still appears correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
