### PR TITLE
fix: route MCP-native publisher tools directly via MCP protocol (#1329)

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -75,6 +75,11 @@ let lastFetchedAt: number | null = null;
 let loadingPromise: Promise<void> | null = null;
 let isConnected = false;
 
+// Track first-class MCP tools from the gateway's list_tools() response.
+// These tools can be called directly via MCP protocol, bypassing call_publisher.
+// Key: "publisher:toolName", Value: original MCP tool name (e.g., "mcp__mcp-time__get_current_time").
+const nativeMcpTools: Map<string, string> = new Map();
+
 /**
  * Check if the cache is still valid (not expired).
  */
@@ -209,6 +214,17 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
 }
 
 /**
+ * Check if a tool is a first-class MCP tool on the gateway.
+ * Native tools are called directly via MCP protocol instead of call_publisher.
+ */
+export function isNativeMcpTool(
+  publisherSlug: string,
+  toolName: string,
+): boolean {
+  return nativeMcpTools.has(`${publisherSlug}:${toolName}`);
+}
+
+/**
  * Check if MCP authentication is available.
  * With API key auth, this just checks if we have an API key stored.
  * Returns true if user needs to authenticate (no API key).
@@ -264,6 +280,19 @@ export async function initializeGateway(): Promise<void> {
       const connection = mcpClient.getConnection(SEREN_MCP_SERVER_NAME);
       if (!connection) {
         throw new Error("Connection not found after connecting");
+      }
+
+      // Index first-class MCP tools from the gateway's tool list.
+      // These can be called directly via MCP protocol without call_publisher.
+      nativeMcpTools.clear();
+      for (const tool of connection.tools) {
+        const parsed = parsePublisherFromToolName(tool.name);
+        if (parsed) {
+          nativeMcpTools.set(
+            `${parsed.publisher}:${parsed.originalName}`,
+            tool.name,
+          );
+        }
       }
 
       // Convert publisher MCP tools to GatewayTool format (skip built-in tools)
@@ -338,6 +367,7 @@ export async function resetGateway(): Promise<void> {
   lastFetchedAt = null;
   loadingPromise = null;
   isConnected = false;
+  nativeMcpTools.clear();
 }
 
 /**
@@ -373,10 +403,11 @@ function parsePaymentProxyError(content: unknown): PaymentProxyInfo | null {
 }
 
 /**
- * Call a tool via the MCP Gateway using the call_publisher dispatch mechanism.
+ * Call a tool via the MCP Gateway.
  *
- * Publisher tools are not first-class MCP tools on the gateway — they must be
- * invoked through the `call_publisher` meta-tool with `tool` + `tool_args`.
+ * Native MCP tools (from the gateway's list_tools response) are called directly
+ * via MCP protocol. REST-proxied publisher tools are dispatched through the
+ * `call_publisher` meta-tool with `tool` + `tool_args`.
  */
 export async function callGatewayTool(
   publisherSlug: string,
@@ -396,19 +427,35 @@ export async function callGatewayTool(
   try {
     // Separate x402 payment from tool args (call_publisher accepts it at top level)
     const { _x402_payment, ...toolArgs } = args;
-    const dispatchArgs: Record<string, unknown> = {
-      publisher: publisherSlug,
-      tool: toolName,
-      tool_args: toolArgs,
-    };
-    if (_x402_payment !== undefined) {
-      dispatchArgs._x402_payment = _x402_payment;
-    }
 
-    const result: McpToolResult = await mcpClient.callToolHttp(
-      SEREN_MCP_SERVER_NAME,
-      { name: "call_publisher", arguments: dispatchArgs },
-    );
+    // Check if this is a first-class MCP tool on the gateway.
+    // Native tools (from the gateway's list_tools response) are called directly
+    // via MCP protocol, bypassing the call_publisher dispatch mechanism.
+    // This is required for MCP-native publishers (e.g., mcp-time) whose tools
+    // are not routable through the REST-oriented call_publisher meta-tool.
+    const nativeName = nativeMcpTools.get(`${publisherSlug}:${toolName}`);
+
+    let result: McpToolResult;
+    if (nativeName) {
+      result = await mcpClient.callToolHttp(SEREN_MCP_SERVER_NAME, {
+        name: nativeName,
+        arguments: toolArgs,
+      });
+    } else {
+      const dispatchArgs: Record<string, unknown> = {
+        publisher: publisherSlug,
+        tool: toolName,
+        tool_args: toolArgs,
+      };
+      if (_x402_payment !== undefined) {
+        dispatchArgs._x402_payment = _x402_payment;
+      }
+
+      result = await mcpClient.callToolHttp(SEREN_MCP_SERVER_NAME, {
+        name: "call_publisher",
+        arguments: dispatchArgs,
+      });
+    }
 
     const executionTime = Date.now() - startTime;
 

--- a/tests/services/mcp-gateway.test.ts
+++ b/tests/services/mcp-gateway.test.ts
@@ -208,3 +208,159 @@ describe("MCP Gateway Caching", () => {
     expect(gmailTools[1].tool.name).toBe("post_messages_send");
   });
 });
+
+describe("MCP Gateway Native Tool Routing (#1329)", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it("should call native MCP tools directly instead of through call_publisher", async () => {
+    const { mcpClient } = await import("@/lib/mcp/client");
+    const callToolMock = vi.mocked(mcpClient.callToolHttp);
+
+    const { initializeGateway, callGatewayTool } = await import(
+      "@/services/mcp-gateway"
+    );
+
+    await initializeGateway();
+
+    // Reset mock call history after init (which calls connectHttp, callToolHttp, etc.)
+    callToolMock.mockClear();
+    callToolMock.mockResolvedValue({
+      content: [{ type: "text", text: '{"time":"2026-03-31T12:00:00Z"}' }],
+      isError: false,
+    });
+
+    // Call the native MCP tool (test publisher is in connection.tools as mcp__test__test-tool)
+    const result = await callGatewayTool("test", "test-tool", {});
+
+    // Should call directly with the original MCP name, NOT through call_publisher
+    expect(callToolMock).toHaveBeenCalledWith("seren-gateway", {
+      name: "mcp__test__test-tool",
+      arguments: {},
+    });
+    expect(result.is_error).toBe(false);
+  });
+
+  it("should use call_publisher for non-native REST publisher tools", async () => {
+    const { mcpClient } = await import("@/lib/mcp/client");
+    const callToolMock = vi.mocked(mcpClient.callToolHttp);
+
+    // Add a dynamically-discovered publisher tool (not in connection.tools)
+    callToolMock.mockImplementation(async (_server, request) => {
+      if (request.name === "list_agent_publishers") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                publishers: [{ slug: "kraken", name: "Kraken" }],
+              }),
+            },
+          ],
+          isError: false,
+        };
+      }
+      if (
+        request.name === "list_mcp_tools" &&
+        request.arguments?.publisher === "kraken"
+      ) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                tools: [
+                  {
+                    name: "get_balance",
+                    description: "Get account balance",
+                    inputSchema: { type: "object", properties: {} },
+                  },
+                ],
+              }),
+            },
+          ],
+          isError: false,
+        };
+      }
+      return { content: [], isError: true };
+    });
+
+    const { initializeGateway, callGatewayTool } = await import(
+      "@/services/mcp-gateway"
+    );
+
+    await initializeGateway();
+
+    // Reset and set up for the actual tool call
+    callToolMock.mockClear();
+    callToolMock.mockResolvedValue({
+      content: [{ type: "text", text: '{"balance":"100.00"}' }],
+      isError: false,
+    });
+
+    // kraken/get_balance is NOT in connection.tools, only discovered dynamically
+    const result = await callGatewayTool("kraken", "get_balance", {
+      currency: "USD",
+    });
+
+    // Should dispatch through call_publisher, not direct MCP call
+    expect(callToolMock).toHaveBeenCalledWith("seren-gateway", {
+      name: "call_publisher",
+      arguments: {
+        publisher: "kraken",
+        tool: "get_balance",
+        tool_args: { currency: "USD" },
+      },
+    });
+    expect(result.is_error).toBe(false);
+  });
+
+  it("should track native tools and clear them on reset", async () => {
+    const { initializeGateway, isNativeMcpTool, resetGateway } = await import(
+      "@/services/mcp-gateway"
+    );
+
+    await initializeGateway();
+
+    // "test" publisher's "test-tool" should be detected as native
+    // (it's in mock connection.tools as mcp__test__test-tool)
+    expect(isNativeMcpTool("test", "test-tool")).toBe(true);
+
+    // Non-existent tool should not be native
+    expect(isNativeMcpTool("kraken", "get_balance")).toBe(false);
+
+    // Reset should clear native tool tracking
+    await resetGateway();
+    expect(isNativeMcpTool("test", "test-tool")).toBe(false);
+  });
+
+  it("should strip _x402_payment from args for native MCP tool calls", async () => {
+    const { mcpClient } = await import("@/lib/mcp/client");
+    const callToolMock = vi.mocked(mcpClient.callToolHttp);
+
+    const { initializeGateway, callGatewayTool } = await import(
+      "@/services/mcp-gateway"
+    );
+
+    await initializeGateway();
+    callToolMock.mockClear();
+    callToolMock.mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    });
+
+    await callGatewayTool("test", "test-tool", {
+      some_arg: "value",
+      _x402_payment: "payment-header",
+    });
+
+    // Native call should NOT include _x402_payment in arguments
+    expect(callToolMock).toHaveBeenCalledWith("seren-gateway", {
+      name: "mcp__test__test-tool",
+      arguments: { some_arg: "value" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause**: callGatewayTool() always dispatched through the call_publisher meta-tool, which only handles REST-proxied publishers. MCP-native publishers (e.g., mcp-time) register their tools as first-class MCP tools on the gateway and are not routable through call_publisher.
- **Fix**: Track native MCP tools from the gateway list_tools() response in a nativeMcpTools map. In callGatewayTool(), check if the tool is native -- if so, call it directly via MCP protocol with its original name (e.g., mcp__mcp-time__get_current_time). Non-native tools continue using call_publisher.
- Clears native tool tracking on gateway reset.

Closes #1329

## Test plan
- [x] Native MCP tools are called directly with original MCP name, not through call_publisher
- [x] Non-native REST publisher tools still dispatch through call_publisher
- [x] Native tool index is populated during initialization and cleared on reset
- [x] _x402_payment is stripped from args for native MCP tool calls
- [x] All 251 tests pass, no lint errors in changed files

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com