### PR TITLE
feat: first-class computer-use runtime and session UI

### DIFF
--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -196,7 +196,8 @@ describe("launchBrowserWithFallback", () => {
         {
           name: "chrome",
           browserName: "chromium",
-          executablePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+          executablePath:
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
           isChromiumBased: true,
           stealthSupported: true,
         },

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,0 +1,379 @@
+// ABOUTME: Tauri commands for computer-use runtime session persistence.
+// ABOUTME: Handles CRUD for runtime sessions and session events in SQLite.
+
+use crate::services::database::{DbPool, init_db};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+// ============================================================================
+// Types
+// ============================================================================
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RuntimeSession {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub environment: String,
+    pub context: Option<String>,
+    pub policy: Option<String>,
+    pub thread_id: Option<String>,
+    pub project_root: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub resumed_at: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SessionEvent {
+    pub id: String,
+    pub session_id: String,
+    pub event_type: String,
+    pub title: String,
+    pub content: Option<String>,
+    pub metadata: Option<String>,
+    pub status: String,
+    pub created_at: i64,
+}
+
+// ============================================================================
+// Session Commands
+// ============================================================================
+
+#[tauri::command]
+pub async fn create_runtime_session(
+    app: AppHandle,
+    id: String,
+    title: String,
+    environment: String,
+    thread_id: Option<String>,
+    project_root: Option<String>,
+    policy: Option<String>,
+) -> Result<RuntimeSession, String> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    let session = RuntimeSession {
+        id: id.clone(),
+        title: title.clone(),
+        status: "idle".to_string(),
+        environment: environment.clone(),
+        context: None,
+        policy: policy.clone(),
+        thread_id: thread_id.clone(),
+        project_root: project_root.clone(),
+        created_at: now,
+        updated_at: now,
+        resumed_at: None,
+    };
+
+    run_db(app, move |conn| {
+        conn.execute(
+            "INSERT INTO runtime_sessions (id, title, status, environment, context, policy, thread_id, project_root, created_at, updated_at, resumed_at)
+             VALUES (?1, ?2, 'idle', ?3, NULL, ?4, ?5, ?6, ?7, ?7, NULL)",
+            params![id, title, environment, policy, thread_id, project_root, now],
+        )?;
+        Ok(())
+    })
+    .await?;
+
+    Ok(session)
+}
+
+#[tauri::command]
+pub async fn get_runtime_session(
+    app: AppHandle,
+    id: String,
+) -> Result<Option<RuntimeSession>, String> {
+    run_db(app, move |conn| {
+        let mut stmt = conn.prepare(
+            "SELECT id, title, status, environment, context, policy, thread_id, project_root, created_at, updated_at, resumed_at
+             FROM runtime_sessions WHERE id = ?1",
+        )?;
+
+        let result = stmt
+            .query_row(params![id], |row| {
+                Ok(RuntimeSession {
+                    id: row.get(0)?,
+                    title: row.get(1)?,
+                    status: row.get(2)?,
+                    environment: row.get(3)?,
+                    context: row.get(4)?,
+                    policy: row.get(5)?,
+                    thread_id: row.get(6)?,
+                    project_root: row.get(7)?,
+                    created_at: row.get(8)?,
+                    updated_at: row.get(9)?,
+                    resumed_at: row.get(10)?,
+                })
+            })
+            .optional()?;
+
+        Ok(result)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn list_runtime_sessions(
+    app: AppHandle,
+    limit: Option<i32>,
+    thread_id: Option<String>,
+) -> Result<Vec<RuntimeSession>, String> {
+    run_db(app, move |conn| {
+        let limit = limit.unwrap_or(50);
+
+        let rows = if let Some(ref tid) = thread_id {
+            let mut stmt = conn.prepare(
+                "SELECT id, title, status, environment, context, policy, thread_id, project_root, created_at, updated_at, resumed_at
+                 FROM runtime_sessions WHERE thread_id = ?1 ORDER BY updated_at DESC LIMIT ?2",
+            )?;
+            stmt.query_map(params![tid, limit], |row| {
+                Ok(RuntimeSession {
+                    id: row.get(0)?,
+                    title: row.get(1)?,
+                    status: row.get(2)?,
+                    environment: row.get(3)?,
+                    context: row.get(4)?,
+                    policy: row.get(5)?,
+                    thread_id: row.get(6)?,
+                    project_root: row.get(7)?,
+                    created_at: row.get(8)?,
+                    updated_at: row.get(9)?,
+                    resumed_at: row.get(10)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+        } else {
+            let mut stmt = conn.prepare(
+                "SELECT id, title, status, environment, context, policy, thread_id, project_root, created_at, updated_at, resumed_at
+                 FROM runtime_sessions ORDER BY updated_at DESC LIMIT ?1",
+            )?;
+            stmt.query_map(params![limit], |row| {
+                Ok(RuntimeSession {
+                    id: row.get(0)?,
+                    title: row.get(1)?,
+                    status: row.get(2)?,
+                    environment: row.get(3)?,
+                    context: row.get(4)?,
+                    policy: row.get(5)?,
+                    thread_id: row.get(6)?,
+                    project_root: row.get(7)?,
+                    created_at: row.get(8)?,
+                    updated_at: row.get(9)?,
+                    resumed_at: row.get(10)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+        };
+
+        Ok(rows)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn update_runtime_session(
+    app: AppHandle,
+    id: String,
+    title: Option<String>,
+    status: Option<String>,
+    context: Option<String>,
+    policy: Option<String>,
+    thread_id: Option<String>,
+) -> Result<(), String> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    run_db(app, move |conn| {
+        if let Some(t) = title {
+            conn.execute(
+                "UPDATE runtime_sessions SET title = ?1, updated_at = ?2 WHERE id = ?3",
+                params![t, now, id],
+            )?;
+        }
+        if let Some(s) = status {
+            conn.execute(
+                "UPDATE runtime_sessions SET status = ?1, updated_at = ?2 WHERE id = ?3",
+                params![s, now, id],
+            )?;
+        }
+        if let Some(c) = context {
+            conn.execute(
+                "UPDATE runtime_sessions SET context = ?1, updated_at = ?2 WHERE id = ?3",
+                params![c, now, id],
+            )?;
+        }
+        if let Some(p) = policy {
+            conn.execute(
+                "UPDATE runtime_sessions SET policy = ?1, updated_at = ?2 WHERE id = ?3",
+                params![p, now, id],
+            )?;
+        }
+        if let Some(tid) = thread_id {
+            conn.execute(
+                "UPDATE runtime_sessions SET thread_id = ?1, updated_at = ?2 WHERE id = ?3",
+                params![tid, now, id],
+            )?;
+        }
+        Ok(())
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn resume_runtime_session(app: AppHandle, id: String) -> Result<(), String> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    run_db(app, move |conn| {
+        conn.execute(
+            "UPDATE runtime_sessions SET status = 'running', resumed_at = ?1, updated_at = ?1 WHERE id = ?2",
+            params![now, id],
+        )?;
+        Ok(())
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn delete_runtime_session(app: AppHandle, id: String) -> Result<(), String> {
+    run_db(app, move |conn| {
+        conn.execute("DELETE FROM session_events WHERE session_id = ?1", params![id])?;
+        conn.execute("DELETE FROM runtime_sessions WHERE id = ?1", params![id])?;
+        Ok(())
+    })
+    .await
+}
+
+// ============================================================================
+// Session Event Commands
+// ============================================================================
+
+#[tauri::command]
+pub async fn add_session_event(
+    app: AppHandle,
+    id: String,
+    session_id: String,
+    event_type: String,
+    title: String,
+    content: Option<String>,
+    metadata: Option<String>,
+    status: Option<String>,
+) -> Result<SessionEvent, String> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    let event_status = status.unwrap_or_else(|| "completed".to_string());
+
+    let event = SessionEvent {
+        id: id.clone(),
+        session_id: session_id.clone(),
+        event_type: event_type.clone(),
+        title: title.clone(),
+        content: content.clone(),
+        metadata: metadata.clone(),
+        status: event_status.clone(),
+        created_at: now,
+    };
+
+    run_db(app, move |conn| {
+        conn.execute(
+            "INSERT INTO session_events (id, session_id, event_type, title, content, metadata, status, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![id, session_id, event_type, title, content, metadata, event_status, now],
+        )?;
+
+        // Touch the parent session's updated_at
+        conn.execute(
+            "UPDATE runtime_sessions SET updated_at = ?1 WHERE id = ?2",
+            params![now, session_id],
+        )?;
+
+        Ok(())
+    })
+    .await?;
+
+    Ok(event)
+}
+
+#[tauri::command]
+pub async fn get_session_events(
+    app: AppHandle,
+    session_id: String,
+    limit: Option<i32>,
+) -> Result<Vec<SessionEvent>, String> {
+    run_db(app, move |conn| {
+        let limit = limit.unwrap_or(500);
+        let mut stmt = conn.prepare(
+            "SELECT id, session_id, event_type, title, content, metadata, status, created_at
+             FROM session_events WHERE session_id = ?1 ORDER BY created_at ASC LIMIT ?2",
+        )?;
+
+        let rows = stmt
+            .query_map(params![session_id, limit], |row| {
+                Ok(SessionEvent {
+                    id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    event_type: row.get(2)?,
+                    title: row.get(3)?,
+                    content: row.get(4)?,
+                    metadata: row.get(5)?,
+                    status: row.get(6)?,
+                    created_at: row.get(7)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(rows)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn update_session_event_status(
+    app: AppHandle,
+    id: String,
+    status: String,
+) -> Result<(), String> {
+    run_db(app, move |conn| {
+        conn.execute(
+            "UPDATE session_events SET status = ?1 WHERE id = ?2",
+            params![status, id],
+        )?;
+        Ok(())
+    })
+    .await
+}
+
+// ============================================================================
+// Helper
+// ============================================================================
+
+async fn run_db<T>(
+    app: AppHandle,
+    task: impl FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
+) -> Result<T, String>
+where
+    T: Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(move || {
+        if let Some(pool) = app.try_state::<DbPool>() {
+            pool.with_connection(|conn| task(conn))
+        } else {
+            let conn = init_db(&app).map_err(|err| err.to_string())?;
+            task(&conn).map_err(|err| err.to_string())
+        }
+    })
+    .await
+    .map_err(|e| format!("Join error: {}", e))?
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod commands {
     pub mod indexing;
     pub mod memory;
     pub mod orchestrator;
+    pub mod session;
     pub mod web;
 }
 
@@ -790,6 +791,16 @@ pub fn run() {
             commands::memory::memory_remember,
             commands::memory::memory_recall,
             commands::memory::memory_sync,
+            // Runtime session commands
+            commands::session::create_runtime_session,
+            commands::session::get_runtime_session,
+            commands::session::list_runtime_sessions,
+            commands::session::update_runtime_session,
+            commands::session::resume_runtime_session,
+            commands::session::delete_runtime_session,
+            commands::session::add_session_event,
+            commands::session::get_session_events,
+            commands::session::update_session_event_status,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -349,6 +349,61 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
         [],
     )?;
 
+    // Runtime sessions table for computer-use sessions
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS runtime_sessions (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'idle',
+            environment TEXT NOT NULL DEFAULT 'browser',
+            context TEXT,
+            policy TEXT,
+            thread_id TEXT,
+            project_root TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            resumed_at INTEGER
+        )",
+        [],
+    )?;
+
+    // Session events table for the audit timeline
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS session_events (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT,
+            metadata TEXT,
+            status TEXT NOT NULL DEFAULT 'completed',
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY (session_id) REFERENCES runtime_sessions(id)
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_session_events_session_id
+         ON session_events(session_id, created_at ASC)",
+        [],
+    )
+    .ok();
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_runtime_sessions_thread_id
+         ON runtime_sessions(thread_id)",
+        [],
+    )
+    .ok();
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_runtime_sessions_status
+         ON runtime_sessions(status, updated_at DESC)",
+        [],
+    )
+    .ok();
+
     // Migration: Create default conversation for orphan messages
     migrate_orphan_messages(conn)?;
 
@@ -577,5 +632,119 @@ mod tests {
             )
             .unwrap();
         assert_eq!(depends_on, Some("[\"s1\"]".to_string()));
+    }
+
+    #[test]
+    fn schema_creates_runtime_sessions_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+
+        // Insert a session
+        conn.execute(
+            "INSERT INTO runtime_sessions (id, title, status, environment, context, policy, thread_id, project_root, created_at, updated_at)
+             VALUES ('s1', 'Test Session', 'idle', 'browser', '{\"url\":\"https://example.com\"}', NULL, 't1', '/home/user', 1000, 1000)",
+            [],
+        )
+        .unwrap();
+
+        // Read it back
+        let title: String = conn
+            .query_row(
+                "SELECT title FROM runtime_sessions WHERE id = 's1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(title, "Test Session");
+
+        let context: Option<String> = conn
+            .query_row(
+                "SELECT context FROM runtime_sessions WHERE id = 's1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(context.unwrap().contains("example.com"));
+    }
+
+    #[test]
+    fn schema_creates_session_events_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+
+        // Insert a session first (FK constraint)
+        conn.execute(
+            "INSERT INTO runtime_sessions (id, title, status, environment, created_at, updated_at)
+             VALUES ('s1', 'Test', 'idle', 'browser', 1000, 1000)",
+            [],
+        )
+        .unwrap();
+
+        // Insert events
+        conn.execute(
+            "INSERT INTO session_events (id, session_id, event_type, title, content, metadata, status, created_at)
+             VALUES ('e1', 's1', 'navigation', 'Navigate to page', 'Page loaded', '{\"url\":\"https://example.com\"}', 'completed', 1001)",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO session_events (id, session_id, event_type, title, content, metadata, status, created_at)
+             VALUES ('e2', 's1', 'action', 'Click button', NULL, '{\"tool_name\":\"click\"}', 'completed', 1002)",
+            [],
+        )
+        .unwrap();
+
+        // Verify order
+        let events: Vec<(String, String)> = {
+            let mut stmt = conn
+                .prepare("SELECT id, event_type FROM session_events WHERE session_id = 's1' ORDER BY created_at ASC")
+                .unwrap();
+            stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].0, "e1");
+        assert_eq!(events[0].1, "navigation");
+        assert_eq!(events[1].0, "e2");
+        assert_eq!(events[1].1, "action");
+    }
+
+    #[test]
+    fn session_events_cascade_with_session_delete() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+
+        conn.execute(
+            "INSERT INTO runtime_sessions (id, title, status, environment, created_at, updated_at)
+             VALUES ('s1', 'Test', 'idle', 'browser', 1000, 1000)",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO session_events (id, session_id, event_type, title, status, created_at)
+             VALUES ('e1', 's1', 'action', 'Test', 'completed', 1001)",
+            [],
+        )
+        .unwrap();
+
+        // Manually delete events then session (mimicking app behavior)
+        conn.execute("DELETE FROM session_events WHERE session_id = 's1'", [])
+            .unwrap();
+        conn.execute("DELETE FROM runtime_sessions WHERE id = 's1'", [])
+            .unwrap();
+
+        let count: i32 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_events WHERE session_id = 's1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
     }
 }

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -46,6 +46,10 @@ import {
   orchestrate,
   retryOrchestration,
 } from "@/services/orchestrator";
+import {
+  allowsSerenAgent,
+  allowsSerenPrivateAgent,
+} from "@/services/organization-policy";
 import type { ToolCallEvent } from "@/services/providers";
 import { skills } from "@/services/skills";
 import { authStore, checkAuth } from "@/stores/auth.store";
@@ -55,10 +59,6 @@ import { editorStore } from "@/stores/editor.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { providerStore } from "@/stores/provider.store";
 import { settingsStore } from "@/stores/settings.store";
-import {
-  allowsSerenAgent,
-  allowsSerenPrivateAgent,
-} from "@/services/organization-policy";
 import type { ToolCallData, UnifiedMessage } from "@/types/conversation";
 import RenderMarkdownWorker from "@/workers/render-markdown.worker?worker";
 import { CompactedMessage } from "./CompactedMessage";

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -15,8 +15,8 @@ import {
 import {
   getProviderIcon,
   PROVIDER_CONFIGS,
-  type ProviderModel,
   type ProviderId,
+  type ProviderModel,
 } from "@/lib/providers";
 import { type Model, modelsService } from "@/services/models";
 import { privateModelsService } from "@/services/private-models";
@@ -309,8 +309,10 @@ export const ModelSelector: Component = () => {
                   <Show
                     when={
                       providerId !== "seren-private" &&
-                      !(providerId === "seren" &&
-                        authStore.privateChatPolicy?.disable_seren_models) &&
+                      !(
+                        providerId === "seren" &&
+                        authStore.privateChatPolicy?.disable_seren_models
+                      ) &&
                       !(
                         providerId !== "seren" &&
                         authStore.privateChatPolicy
@@ -318,24 +320,24 @@ export const ModelSelector: Component = () => {
                       )
                     }
                   >
-                  <button
-                    type="button"
-                    class={`flex items-center gap-1 px-2.5 py-1.5 bg-transparent border border-transparent rounded text-xs text-muted-foreground cursor-pointer transition-all no-underline hover:bg-border hover:text-foreground ${providerId === currentProvider() ? "bg-primary/15 border-primary/40 text-accent" : ""}`}
-                    onClick={() => {
-                      selectProvider(providerId);
-                      setSearchQuery("");
-                    }}
-                    title={PROVIDER_CONFIGS[providerId].name}
-                  >
-                    <span
-                      class={`w-4 h-4 inline-flex items-center justify-center bg-surface-3 rounded-sm text-[10px] font-semibold ${providerId === currentProvider() ? "bg-accent text-white" : ""}`}
+                    <button
+                      type="button"
+                      class={`flex items-center gap-1 px-2.5 py-1.5 bg-transparent border border-transparent rounded text-xs text-muted-foreground cursor-pointer transition-all no-underline hover:bg-border hover:text-foreground ${providerId === currentProvider() ? "bg-primary/15 border-primary/40 text-accent" : ""}`}
+                      onClick={() => {
+                        selectProvider(providerId);
+                        setSearchQuery("");
+                      }}
+                      title={PROVIDER_CONFIGS[providerId].name}
                     >
-                      {getProviderIcon(providerId)}
-                    </span>
-                    <span class="max-w-[80px] overflow-hidden text-ellipsis whitespace-nowrap">
-                      {PROVIDER_CONFIGS[providerId].name}
-                    </span>
-                  </button>
+                      <span
+                        class={`w-4 h-4 inline-flex items-center justify-center bg-surface-3 rounded-sm text-[10px] font-semibold ${providerId === currentProvider() ? "bg-accent text-white" : ""}`}
+                      >
+                        {getProviderIcon(providerId)}
+                      </span>
+                      <span class="max-w-[80px] overflow-hidden text-ellipsis whitespace-nowrap">
+                        {PROVIDER_CONFIGS[providerId].name}
+                      </span>
+                    </button>
                   </Show>
                 )}
               </For>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -13,6 +13,7 @@ import { SignIn } from "@/components/auth/SignIn";
 import { StatusBar } from "@/components/common/StatusBar";
 import { EditorContent } from "@/components/editor/EditorContent";
 import { ThreadSidebar } from "@/components/layout/ThreadSidebar";
+import { SessionPanel } from "@/components/session/SessionPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { DatabasePanel } from "@/components/sidebar/DatabasePanel";
 import { AgentTasksPanel } from "@/components/tasks/AgentTasksPanel";
@@ -27,6 +28,7 @@ export type SlidePanelView =
   | "editor"
   | "account"
   | "tasks"
+  | "sessions"
   | null;
 
 interface AppShellProps {
@@ -68,6 +70,8 @@ export const AppShell: Component<AppShellProps> = (props) => {
       setSlidePanel("database");
     } else if (p === "tasks") {
       setSlidePanel("tasks");
+    } else if (p === "sessions") {
+      setSlidePanel("sessions");
     }
   }) as EventListener;
 
@@ -147,6 +151,9 @@ export const AppShell: Component<AppShellProps> = (props) => {
             </Match>
             <Match when={slidePanel() === "tasks"}>
               <AgentTasksPanel onClose={handleCloseSlidePanel} />
+            </Match>
+            <Match when={slidePanel() === "sessions"}>
+              <SessionPanel onClose={handleCloseSlidePanel} />
             </Match>
             <Match when={slidePanel() === "account"}>
               <SignIn onSuccess={handleLoginSuccess} />

--- a/src/components/layout/ThreadContent.tsx
+++ b/src/components/layout/ThreadContent.tsx
@@ -1,9 +1,10 @@
 // ABOUTME: Routes to the correct content view based on the active thread type.
-// ABOUTME: Shows ChatContent for chat threads, AgentChat for agent threads, or empty state.
+// ABOUTME: Shows ChatContent for chat, AgentChat for agents, SessionContent for sessions.
 
 import { type Component, Match, Show, Switch } from "solid-js";
 import { AgentChat } from "@/components/chat/AgentChat";
 import { ChatContent } from "@/components/chat/ChatContent";
+import { SessionContent } from "@/components/session/SessionContent";
 import { openFolder } from "@/lib/files/service";
 import { fileTreeState } from "@/stores/fileTree";
 import { threadStore } from "@/stores/thread.store";
@@ -22,6 +23,9 @@ export const ThreadContent: Component<ThreadContentProps> = (props) => {
           </Match>
           <Match when={threadStore.activeThreadKind === "agent"}>
             <AgentChat />
+          </Match>
+          <Match when={threadStore.activeThreadKind === "session"}>
+            <SessionContent />
           </Match>
         </Switch>
       </div>

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -23,6 +23,7 @@ import { skills as skillsService } from "@/services/skills";
 import { agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
 import { fileTreeState } from "@/stores/fileTree";
+import { sessionStore } from "@/stores/session.store";
 import { skillsStore } from "@/stores/skills.store";
 import { type Thread, threadStore } from "@/stores/thread.store";
 
@@ -377,9 +378,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
               />
             </svg>
           </Show>
-          {spawning()
-            ? (agentStore.installStatus ?? "Starting...")
-            : "New"}
+          {spawning() ? (agentStore.installStatus ?? "Starting...") : "New"}
         </button>
 
         <Show when={showLauncher()}>
@@ -1118,16 +1117,59 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
         </Show>
       </div>
 
-      {/* Running agents footer */}
-      <Show when={threadStore.runningCount > 0}>
-        <div class="px-3 py-2 border-t border-border shrink-0 bg-surface-0/50">
-          <span class="text-[11px] text-status-running flex items-center gap-1.5">
-            <span class="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
-            {threadStore.runningCount} agent
-            {threadStore.runningCount > 1 ? "s" : ""} running
-          </span>
-        </div>
-      </Show>
+      {/* Session & running agents footer */}
+      <div class="border-t border-border shrink-0 bg-surface-0/50">
+        <button
+          type="button"
+          class="w-full px-3 py-2 text-left text-[12px] text-muted-foreground hover:text-foreground hover:bg-surface-1/50 transition-colors flex items-center gap-2"
+          onClick={() =>
+            window.dispatchEvent(
+              new CustomEvent("seren:open-panel", { detail: "sessions" }),
+            )
+          }
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            fill="none"
+            role="img"
+            aria-label="Sessions"
+          >
+            <rect
+              x="2"
+              y="3"
+              width="12"
+              height="10"
+              rx="2"
+              stroke="currentColor"
+              stroke-width="1.2"
+            />
+            <path
+              d="M5 7h6M5 9.5h4"
+              stroke="currentColor"
+              stroke-width="1.2"
+              stroke-linecap="round"
+            />
+          </svg>
+          Sessions
+          <Show when={sessionStore.activeSessions.length > 0}>
+            <span class="ml-auto text-[10px] px-1.5 py-0.5 rounded-full bg-primary/15 text-primary font-medium">
+              {sessionStore.activeSessions.length}
+            </span>
+          </Show>
+        </button>
+
+        <Show when={threadStore.runningCount > 0}>
+          <div class="px-3 py-2 border-t border-border/30">
+            <span class="text-[11px] text-status-running flex items-center gap-1.5">
+              <span class="w-1.5 h-1.5 rounded-full bg-status-running animate-pulse" />
+              {threadStore.runningCount} agent
+              {threadStore.runningCount > 1 ? "s" : ""} running
+            </span>
+          </div>
+        </Show>
+      </div>
     </aside>
   );
 };

--- a/src/components/layout/ThreadTabBar.tsx
+++ b/src/components/layout/ThreadTabBar.tsx
@@ -9,16 +9,16 @@ import {
   onMount,
   Show,
 } from "solid-js";
-import { agentStore } from "@/stores/agent.store";
-import { authStore } from "@/stores/auth.store";
-import { fileTreeState } from "@/stores/fileTree";
-import { type Thread, threadStore } from "@/stores/thread.store";
 import {
   allowsClaudeAgent,
   allowsCodexAgent,
   allowsSerenAgent,
   allowsSerenPrivateAgent,
 } from "@/services/organization-policy";
+import { agentStore } from "@/stores/agent.store";
+import { authStore } from "@/stores/auth.store";
+import { fileTreeState } from "@/stores/fileTree";
+import { type Thread, threadStore } from "@/stores/thread.store";
 
 export const ThreadTabBar: Component = () => {
   const [showNewMenu, setShowNewMenu] = createSignal(false);
@@ -58,7 +58,8 @@ export const ThreadTabBar: Component = () => {
   const handleNewPrivateChat = async () => {
     setShowNewMenu(false);
     const privateModel =
-      authStore.privateChatPolicy?.model_id?.trim() || "organization/private-model";
+      authStore.privateChatPolicy?.model_id?.trim() ||
+      "organization/private-model";
     await threadStore.createChatThreadWithOptions("New Private Chat", {
       provider: "seren-private",
       model: privateModel,

--- a/src/components/session/SessionContent.tsx
+++ b/src/components/session/SessionContent.tsx
@@ -1,0 +1,156 @@
+// ABOUTME: Main content area for session threads.
+// ABOUTME: Shows session state, context, timeline, and controls inline.
+
+import { type Component, createEffect, Show } from "solid-js";
+import { sessionStore } from "@/stores/session.store";
+import { threadStore } from "@/stores/thread.store";
+import { SessionStatusBadge } from "./SessionStatusBadge";
+import { SessionTimeline } from "./SessionTimeline";
+
+export const SessionContent: Component = () => {
+  const sessionId = () => {
+    const thread = threadStore.activeThread;
+    if (!thread) return null;
+    return thread.sessionId ?? thread.id.replace("session:", "");
+  };
+
+  createEffect(() => {
+    const id = sessionId();
+    if (id) {
+      sessionStore.setActiveSession(id);
+      void sessionStore.loadEvents(id);
+    }
+  });
+
+  const session = () => sessionStore.activeSession;
+  const events = () => sessionStore.activeSessionEvents;
+
+  const handleResume = async () => {
+    const id = sessionId();
+    if (id) await sessionStore.resumeSession(id);
+  };
+
+  const handlePause = async () => {
+    const id = sessionId();
+    if (id) await sessionStore.pauseSession(id);
+  };
+
+  const handleComplete = async () => {
+    const id = sessionId();
+    if (id) await sessionStore.completeSession(id);
+  };
+
+  return (
+    <div class="flex flex-col h-full overflow-hidden">
+      <Show
+        when={session()}
+        fallback={
+          <div class="flex items-center justify-center h-full text-muted-foreground text-[13px]">
+            Session not found
+          </div>
+        }
+      >
+        {/* Session header */}
+        <div class="px-5 py-4 border-b border-border/40 bg-surface-0/30">
+          <div class="flex items-center justify-between">
+            <div>
+              <h2 class="text-[16px] font-semibold text-foreground m-0">
+                {session()!.title}
+              </h2>
+              <div class="flex items-center gap-2 mt-1.5">
+                <SessionStatusBadge status={session()!.status} />
+                <span class="text-[12px] text-muted-foreground capitalize">
+                  {session()!.environment} runtime
+                </span>
+                <Show when={session()!.context?.url}>
+                  <span class="text-[12px] text-primary/60 truncate max-w-[300px]">
+                    {session()!.context!.url}
+                  </span>
+                </Show>
+              </div>
+            </div>
+
+            {/* Action buttons */}
+            <div class="flex items-center gap-1.5">
+              <Show
+                when={
+                  session()!.status === "paused" || session()!.status === "idle"
+                }
+              >
+                <button
+                  type="button"
+                  class="px-3 py-1.5 text-[12px] font-medium text-primary-foreground bg-primary rounded hover:bg-primary-hover transition-colors"
+                  onClick={handleResume}
+                >
+                  Resume
+                </button>
+              </Show>
+              <Show when={session()!.status === "running"}>
+                <button
+                  type="button"
+                  class="px-3 py-1.5 text-[12px] font-medium text-violet-400 bg-violet-500/10 border border-violet-500/20 rounded hover:bg-violet-500/[0.18] transition-colors"
+                  onClick={handlePause}
+                >
+                  Pause
+                </button>
+              </Show>
+              <Show
+                when={
+                  session()!.status !== "completed" &&
+                  session()!.status !== "error"
+                }
+              >
+                <button
+                  type="button"
+                  class="px-3 py-1.5 text-[12px] font-medium text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 rounded hover:bg-emerald-500/[0.18] transition-colors"
+                  onClick={handleComplete}
+                >
+                  Complete
+                </button>
+              </Show>
+            </div>
+          </div>
+
+          {/* Active tools / context */}
+          <Show
+            when={
+              session()!.context?.active_tools &&
+              session()!.context!.active_tools!.length > 0
+            }
+          >
+            <div class="flex items-center gap-1.5 mt-2 flex-wrap">
+              <span class="text-[11px] text-muted-foreground">Tools:</span>
+              {session()!.context!.active_tools!.map((tool) => (
+                <span class="text-[11px] px-1.5 py-0.5 rounded bg-surface-2 text-muted-foreground">
+                  {tool}
+                </span>
+              ))}
+            </div>
+          </Show>
+        </div>
+
+        {/* Timeline area */}
+        <div class="flex-1 overflow-auto px-5 py-3">
+          <div class="max-w-[700px] mx-auto">
+            <div class="text-[11px] text-muted-foreground uppercase tracking-wider font-medium mb-2">
+              Activity Timeline
+            </div>
+            <SessionTimeline events={events()} />
+          </div>
+        </div>
+
+        {/* Footer with session info */}
+        <div class="px-5 py-2 border-t border-border/30 bg-surface-0/20">
+          <div class="flex items-center justify-between text-[11px] text-muted-foreground">
+            <span>
+              Created {new Date(session()!.created_at).toLocaleString()}
+            </span>
+            <span>
+              {events().length} event{events().length !== 1 ? "s" : ""}
+            </span>
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+};

--- a/src/components/session/SessionPanel.tsx
+++ b/src/components/session/SessionPanel.tsx
@@ -1,0 +1,348 @@
+// ABOUTME: Main session panel showing runtime session details, controls, and timeline.
+// ABOUTME: Provides session lifecycle management (create, pause, resume, complete, delete).
+
+import {
+  type Component,
+  createEffect,
+  createSignal,
+  Match,
+  Show,
+  Switch,
+} from "solid-js";
+import { sessionStore } from "@/stores/session.store";
+import type { SessionEnvironment } from "@/types/session";
+import { SessionStatusBadge } from "./SessionStatusBadge";
+import { SessionTimeline } from "./SessionTimeline";
+
+interface SessionPanelProps {
+  onClose?: () => void;
+}
+
+export const SessionPanel: Component<SessionPanelProps> = (props) => {
+  const [showCreate, setShowCreate] = createSignal(false);
+  const [newTitle, setNewTitle] = createSignal("");
+  const [newEnv, setNewEnv] = createSignal<SessionEnvironment>("browser");
+  const [isCreating, setIsCreating] = createSignal(false);
+
+  createEffect(() => {
+    void sessionStore.loadSessions();
+  });
+
+  createEffect(() => {
+    const id = sessionStore.activeSessionId;
+    if (id) {
+      void sessionStore.loadEvents(id);
+    }
+  });
+
+  const handleCreate = async () => {
+    const title = newTitle().trim() || "New Session";
+    setIsCreating(true);
+    try {
+      const session = await sessionStore.createSession(title, newEnv());
+      sessionStore.setActiveSession(session.id);
+      setShowCreate(false);
+      setNewTitle("");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleResume = async () => {
+    const id = sessionStore.activeSessionId;
+    if (id) await sessionStore.resumeSession(id);
+  };
+
+  const handlePause = async () => {
+    const id = sessionStore.activeSessionId;
+    if (id) await sessionStore.pauseSession(id);
+  };
+
+  const handleComplete = async () => {
+    const id = sessionStore.activeSessionId;
+    if (id) await sessionStore.completeSession(id);
+  };
+
+  const handleDelete = async () => {
+    const id = sessionStore.activeSessionId;
+    if (id) await sessionStore.deleteSession(id);
+  };
+
+  return (
+    <div class="flex flex-col h-full">
+      {/* Header */}
+      <div class="flex items-center justify-between px-4 py-3 border-b border-border/50">
+        <div class="flex items-center gap-2">
+          <h2 class="text-[15px] font-semibold text-foreground m-0">
+            Sessions
+          </h2>
+          <Show when={sessionStore.activeSessions.length > 0}>
+            <span class="text-[11px] px-1.5 py-0.5 rounded-full bg-primary/15 text-primary font-medium">
+              {sessionStore.activeSessions.length}
+            </span>
+          </Show>
+        </div>
+        <div class="flex items-center gap-1.5">
+          <button
+            type="button"
+            class="px-2.5 py-1 text-[12px] font-medium text-primary bg-primary/10 rounded hover:bg-primary/[0.18] transition-colors"
+            onClick={() => setShowCreate(!showCreate())}
+          >
+            {showCreate() ? "Cancel" : "+ New"}
+          </button>
+          <Show when={props.onClose}>
+            <button
+              type="button"
+              class="p-1 text-muted-foreground hover:text-foreground transition-colors rounded"
+              onClick={props.onClose}
+              title="Close panel"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                role="img"
+                aria-label="Close"
+              >
+                <path
+                  d="M4 4l8 8M12 4l-8 8"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          </Show>
+        </div>
+      </div>
+
+      {/* Create form */}
+      <Show when={showCreate()}>
+        <div class="px-4 py-3 border-b border-border/50 bg-surface-0/50">
+          <div class="flex flex-col gap-2">
+            <input
+              type="text"
+              placeholder="Session title..."
+              value={newTitle()}
+              onInput={(e) => setNewTitle(e.currentTarget.value)}
+              class="w-full px-2.5 py-1.5 text-[13px] bg-surface-1 border border-border/50 rounded text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-primary/50"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleCreate();
+              }}
+            />
+            <div class="flex items-center gap-2">
+              <select
+                value={newEnv()}
+                onChange={(e) =>
+                  setNewEnv(e.currentTarget.value as SessionEnvironment)
+                }
+                class="flex-1 px-2.5 py-1.5 text-[13px] bg-surface-1 border border-border/50 rounded text-foreground focus:outline-none focus:border-primary/50"
+              >
+                <option value="browser">Browser</option>
+                <option value="desktop">Desktop</option>
+                <option value="file">File</option>
+              </select>
+              <button
+                type="button"
+                class="px-3 py-1.5 text-[12px] font-medium text-primary-foreground bg-primary rounded hover:bg-primary-hover transition-colors disabled:opacity-50"
+                onClick={handleCreate}
+                disabled={isCreating()}
+              >
+                {isCreating() ? "Creating..." : "Create"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </Show>
+
+      {/* Content: session list or active session detail */}
+      <div class="flex-1 overflow-auto">
+        <Switch
+          fallback={
+            <SessionListView
+              sessions={sessionStore.sessions}
+              onSelect={(id) => {
+                sessionStore.setActiveSession(id);
+              }}
+            />
+          }
+        >
+          <Match when={sessionStore.activeSession}>
+            <div class="flex flex-col h-full">
+              {/* Active session header */}
+              <div class="px-4 py-3 border-b border-border/30">
+                <div class="flex items-center gap-2 mb-1">
+                  <button
+                    type="button"
+                    class="text-[12px] text-muted-foreground hover:text-foreground transition-colors"
+                    onClick={() => sessionStore.setActiveSession(null)}
+                  >
+                    &larr; All sessions
+                  </button>
+                </div>
+                <div class="flex items-center justify-between">
+                  <div>
+                    <h3 class="text-[14px] font-medium text-foreground m-0">
+                      {sessionStore.activeSession!.title}
+                    </h3>
+                    <div class="flex items-center gap-2 mt-1">
+                      <SessionStatusBadge
+                        status={sessionStore.activeSession!.status}
+                      />
+                      <span class="text-[11px] text-muted-foreground capitalize">
+                        {sessionStore.activeSession!.environment}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Context info */}
+                <Show when={sessionStore.activeSession!.context?.url}>
+                  <div class="mt-2 text-[12px] text-primary/70 truncate">
+                    {sessionStore.activeSession!.context!.url}
+                  </div>
+                </Show>
+
+                {/* Action buttons */}
+                <div class="flex items-center gap-1.5 mt-3">
+                  <Show
+                    when={
+                      sessionStore.activeSession!.status === "paused" ||
+                      sessionStore.activeSession!.status === "idle"
+                    }
+                  >
+                    <button
+                      type="button"
+                      class="px-2.5 py-1 text-[12px] font-medium text-primary bg-primary/10 rounded hover:bg-primary/[0.18] transition-colors"
+                      onClick={handleResume}
+                    >
+                      Resume
+                    </button>
+                  </Show>
+                  <Show when={sessionStore.activeSession!.status === "running"}>
+                    <button
+                      type="button"
+                      class="px-2.5 py-1 text-[12px] font-medium text-violet-400 bg-violet-500/10 rounded hover:bg-violet-500/[0.18] transition-colors"
+                      onClick={handlePause}
+                    >
+                      Pause
+                    </button>
+                  </Show>
+                  <Show
+                    when={
+                      sessionStore.activeSession!.status !== "completed" &&
+                      sessionStore.activeSession!.status !== "error"
+                    }
+                  >
+                    <button
+                      type="button"
+                      class="px-2.5 py-1 text-[12px] font-medium text-emerald-400 bg-emerald-500/10 rounded hover:bg-emerald-500/[0.18] transition-colors"
+                      onClick={handleComplete}
+                    >
+                      Complete
+                    </button>
+                  </Show>
+                  <button
+                    type="button"
+                    class="px-2.5 py-1 text-[12px] font-medium text-red-400 bg-red-500/10 rounded hover:bg-red-500/[0.18] transition-colors ml-auto"
+                    onClick={handleDelete}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+
+              {/* Timeline */}
+              <div class="flex-1 overflow-auto px-3 py-2">
+                <div class="text-[11px] text-muted-foreground uppercase tracking-wider font-medium px-1 py-2">
+                  Timeline
+                </div>
+                <SessionTimeline events={sessionStore.activeSessionEvents} />
+              </div>
+            </div>
+          </Match>
+        </Switch>
+      </div>
+
+      {/* Background session indicator */}
+      <Show when={sessionStore.backgroundSessions.length > 0}>
+        <div class="px-4 py-2 border-t border-border/50 bg-surface-0/50">
+          <div class="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
+            {sessionStore.backgroundSessions.length} session
+            {sessionStore.backgroundSessions.length > 1 ? "s" : ""} running in
+            background
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+// ============================================================================
+// Session List View
+// ============================================================================
+
+const SessionListView: Component<{
+  sessions: import("@/types/session").RuntimeSession[];
+  onSelect: (id: string) => void;
+}> = (props) => {
+  return (
+    <Show
+      when={props.sessions.length > 0}
+      fallback={
+        <div class="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <div class="text-[32px] opacity-30 mb-3">&#9684;</div>
+          <p class="text-[13px] font-medium opacity-70 m-0">No sessions yet</p>
+          <p class="text-[12px] opacity-50 m-0 mt-1">
+            Create a session to start a computer-use runtime
+          </p>
+        </div>
+      }
+    >
+      <div class="flex flex-col">
+        {/* biome-ignore lint/a11y/useSemanticElements: session list items are interactive */}
+        <For each={props.sessions}>
+          {(session) => (
+            <button
+              type="button"
+              class="flex items-center gap-3 px-4 py-3 border-b border-border/20 hover:bg-surface-1/50 transition-colors cursor-pointer text-left w-full bg-transparent border-none"
+              onClick={() => props.onSelect(session.id)}
+            >
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2">
+                  <span class="text-[13px] font-medium text-foreground truncate">
+                    {session.title}
+                  </span>
+                  <SessionStatusBadge status={session.status} />
+                </div>
+                <div class="flex items-center gap-2 mt-0.5">
+                  <span class="text-[11px] text-muted-foreground capitalize">
+                    {session.environment}
+                  </span>
+                  <Show when={session.context?.url}>
+                    <span class="text-[11px] text-primary/50 truncate max-w-[180px]">
+                      {session.context!.url}
+                    </span>
+                  </Show>
+                </div>
+              </div>
+              <span class="text-[11px] text-muted-foreground flex-shrink-0">
+                {formatRelativeTime(session.updated_at)}
+              </span>
+            </button>
+          )}
+        </For>
+      </div>
+    </Show>
+  );
+};
+
+function formatRelativeTime(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
+}

--- a/src/components/session/SessionStatusBadge.tsx
+++ b/src/components/session/SessionStatusBadge.tsx
@@ -1,0 +1,69 @@
+// ABOUTME: Displays a compact status badge for a runtime session.
+// ABOUTME: Color-coded pill showing current session state.
+
+import type { Component } from "solid-js";
+import type { SessionStatus } from "@/types/session";
+
+interface SessionStatusBadgeProps {
+  status: SessionStatus;
+  class?: string;
+}
+
+const STATUS_CONFIG: Record<
+  SessionStatus,
+  { label: string; bg: string; text: string; dot: string }
+> = {
+  idle: {
+    label: "Idle",
+    bg: "bg-surface-2",
+    text: "text-muted-foreground",
+    dot: "bg-muted-foreground",
+  },
+  running: {
+    label: "Running",
+    bg: "bg-primary/15",
+    text: "text-primary",
+    dot: "bg-primary",
+  },
+  waiting_approval: {
+    label: "Awaiting Approval",
+    bg: "bg-amber-500/15",
+    text: "text-amber-400",
+    dot: "bg-amber-400",
+  },
+  completed: {
+    label: "Completed",
+    bg: "bg-emerald-500/15",
+    text: "text-emerald-400",
+    dot: "bg-emerald-400",
+  },
+  error: {
+    label: "Error",
+    bg: "bg-red-500/15",
+    text: "text-red-400",
+    dot: "bg-red-400",
+  },
+  paused: {
+    label: "Paused",
+    bg: "bg-violet-500/15",
+    text: "text-violet-400",
+    dot: "bg-violet-400",
+  },
+};
+
+export const SessionStatusBadge: Component<SessionStatusBadgeProps> = (
+  props,
+) => {
+  const config = () => STATUS_CONFIG[props.status] ?? STATUS_CONFIG.idle;
+
+  return (
+    <span
+      class={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-medium ${config().bg} ${config().text} ${props.class ?? ""}`}
+    >
+      <span
+        class={`w-1.5 h-1.5 rounded-full ${config().dot} ${props.status === "running" ? "animate-pulse" : ""}`}
+      />
+      {config().label}
+    </span>
+  );
+};

--- a/src/components/session/SessionTimeline.tsx
+++ b/src/components/session/SessionTimeline.tsx
@@ -1,0 +1,148 @@
+// ABOUTME: Audit timeline showing all events in a runtime session.
+// ABOUTME: Renders actions, screenshots, approvals, and errors chronologically.
+
+import { type Component, For, Show } from "solid-js";
+import type { SessionEvent, SessionEventType } from "@/types/session";
+
+interface SessionTimelineProps {
+  events: SessionEvent[];
+}
+
+const EVENT_ICONS: Record<SessionEventType, string> = {
+  navigation: "\u2192",
+  action: "\u26A1",
+  screenshot: "\uD83D\uDCF7",
+  approval: "\u2714",
+  content: "\uD83D\uDCC4",
+  command: "\u003E_",
+  error: "\u26A0",
+  status_change: "\u25CF",
+};
+
+const EVENT_COLORS: Record<SessionEventType, string> = {
+  navigation: "border-primary/40 bg-primary/8",
+  action: "border-sky-400/40 bg-sky-400/8",
+  screenshot: "border-violet-400/40 bg-violet-400/8",
+  approval: "border-amber-400/40 bg-amber-400/8",
+  content: "border-emerald-400/40 bg-emerald-400/8",
+  command: "border-slate-400/40 bg-slate-400/8",
+  error: "border-red-400/40 bg-red-400/8",
+  status_change: "border-muted-foreground/40 bg-muted-foreground/8",
+};
+
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.floor(ms / 60000)}m ${Math.round((ms % 60000) / 1000)}s`;
+}
+
+export const SessionTimeline: Component<SessionTimelineProps> = (props) => {
+  return (
+    <div class="flex flex-col gap-0 relative">
+      <Show
+        when={props.events.length > 0}
+        fallback={
+          <div class="flex items-center justify-center py-12 text-muted-foreground text-[13px] opacity-60">
+            No events recorded yet
+          </div>
+        }
+      >
+        {/* Vertical connector line */}
+        <div class="absolute left-[19px] top-4 bottom-4 w-px bg-border/40" />
+
+        <For each={props.events}>
+          {(event) => <TimelineEvent event={event} />}
+        </For>
+      </Show>
+    </div>
+  );
+};
+
+const TimelineEvent: Component<{ event: SessionEvent }> = (props) => {
+  const icon = () => EVENT_ICONS[props.event.event_type] ?? "\u25CB";
+  const colorClass = () =>
+    EVENT_COLORS[props.event.event_type] ?? EVENT_COLORS.status_change;
+  const metadata = () => props.event.metadata;
+
+  return (
+    <div class="flex gap-3 py-2 px-1 group relative">
+      {/* Icon node */}
+      <div
+        class={`flex-shrink-0 w-[26px] h-[26px] rounded-full border flex items-center justify-center text-[12px] z-10 ${colorClass()}`}
+        title={props.event.event_type}
+      >
+        {icon()}
+      </div>
+
+      {/* Content */}
+      <div class="flex-1 min-w-0 pt-0.5">
+        <div class="flex items-baseline gap-2">
+          <span class="text-[13px] font-medium text-foreground truncate">
+            {props.event.title}
+          </span>
+          <span class="text-[11px] text-muted-foreground flex-shrink-0">
+            {formatTime(props.event.created_at)}
+          </span>
+        </div>
+
+        <Show when={props.event.content}>
+          <p class="text-[12px] text-muted-foreground mt-0.5 line-clamp-3 leading-relaxed">
+            {props.event.content}
+          </p>
+        </Show>
+
+        {/* Metadata details */}
+        <div class="flex items-center gap-2 mt-1 flex-wrap">
+          <Show when={metadata()?.url}>
+            <span class="text-[11px] text-primary/70 truncate max-w-[240px]">
+              {metadata()?.url}
+            </span>
+          </Show>
+          <Show when={metadata()?.tool_name}>
+            <span class="text-[11px] px-1.5 py-0.5 rounded bg-surface-2 text-muted-foreground">
+              {metadata()?.tool_name}
+            </span>
+          </Show>
+          <Show when={metadata()?.duration_ms}>
+            <span class="text-[11px] text-muted-foreground">
+              {formatDuration(metadata()!.duration_ms!)}
+            </span>
+          </Show>
+          <Show
+            when={
+              props.event.status !== "completed" &&
+              props.event.event_type === "approval"
+            }
+          >
+            <span
+              class={`text-[11px] px-1.5 py-0.5 rounded font-medium ${
+                props.event.status === "pending"
+                  ? "bg-amber-500/15 text-amber-400"
+                  : props.event.status === "rejected"
+                    ? "bg-red-500/15 text-red-400"
+                    : "bg-emerald-500/15 text-emerald-400"
+              }`}
+            >
+              {props.event.status}
+            </span>
+          </Show>
+        </div>
+
+        <Show when={metadata()?.error_message}>
+          <div class="mt-1 text-[12px] text-red-400 bg-red-500/8 rounded px-2 py-1 border border-red-500/20">
+            {metadata()?.error_message}
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
+};

--- a/src/components/tasks/AgentTasksPanel.tsx
+++ b/src/components/tasks/AgentTasksPanel.tsx
@@ -12,11 +12,8 @@ import {
   Show,
 } from "solid-js";
 import { getDefaultOrganizationId } from "@/lib/tauri-bridge";
-import {
-  getCloudAgentPublisherForProvider,
-} from "@/services/agent-tasks";
+import { getCloudAgentPublisherForProvider } from "@/services/agent-tasks";
 import { allowsCloudAgentLaunch } from "@/services/organization-policy";
-import { authStore } from "@/stores/auth.store";
 import {
   agentTasksState,
   cancelTask,
@@ -26,6 +23,7 @@ import {
   runAgent,
   stopFollowing,
 } from "@/stores/agent-tasks.store";
+import { authStore } from "@/stores/auth.store";
 import { providerStore } from "@/stores/provider.store";
 import { threadStore } from "@/stores/thread.store";
 import { AgentTaskItem } from "./AgentTaskItem";

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -924,3 +924,169 @@ export async function clearAllHistory(): Promise<void> {
   }
   await invoke("clear_all_history");
 }
+
+// ============================================================================
+// Runtime Session Operations
+// ============================================================================
+
+export interface RawRuntimeSessionRow {
+  id: string;
+  title: string;
+  status: string;
+  environment: string;
+  context: string | null;
+  policy: string | null;
+  thread_id: string | null;
+  project_root: string | null;
+  created_at: number;
+  updated_at: number;
+  resumed_at: number | null;
+}
+
+export interface RawSessionEventRow {
+  id: string;
+  session_id: string;
+  event_type: string;
+  title: string;
+  content: string | null;
+  metadata: string | null;
+  status: string;
+  created_at: number;
+}
+
+export async function createRuntimeSession(
+  id: string,
+  title: string,
+  environment: string,
+  threadId?: string,
+  projectRoot?: string,
+  policy?: string,
+): Promise<RawRuntimeSessionRow> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Session operations require Tauri runtime");
+  }
+  return await invoke<RawRuntimeSessionRow>("create_runtime_session", {
+    id,
+    title,
+    environment,
+    threadId: threadId ?? null,
+    projectRoot: projectRoot ?? null,
+    policy: policy ?? null,
+  });
+}
+
+export async function getRuntimeSession(
+  id: string,
+): Promise<RawRuntimeSessionRow | null> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Session operations require Tauri runtime");
+  }
+  return await invoke<RawRuntimeSessionRow | null>("get_runtime_session", {
+    id,
+  });
+}
+
+export async function listRuntimeSessions(
+  limit?: number,
+  threadId?: string,
+): Promise<RawRuntimeSessionRow[]> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Session operations require Tauri runtime");
+  }
+  return await invoke<RawRuntimeSessionRow[]>("list_runtime_sessions", {
+    limit: limit ?? null,
+    threadId: threadId ?? null,
+  });
+}
+
+export async function updateRuntimeSession(
+  id: string,
+  updates: {
+    title?: string;
+    status?: string;
+    context?: string;
+    policy?: string;
+    threadId?: string;
+  },
+): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Session operations require Tauri runtime");
+  }
+  await invoke("update_runtime_session", {
+    id,
+    title: updates.title ?? null,
+    status: updates.status ?? null,
+    context: updates.context ?? null,
+    policy: updates.policy ?? null,
+    threadId: updates.threadId ?? null,
+  });
+}
+
+export async function resumeRuntimeSession(id: string): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Session operations require Tauri runtime");
+  }
+  await invoke("resume_runtime_session", { id });
+}
+
+export async function deleteRuntimeSession(id: string): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Session operations require Tauri runtime");
+  }
+  await invoke("delete_runtime_session", { id });
+}
+
+export async function addSessionEvent(
+  id: string,
+  sessionId: string,
+  eventType: string,
+  title: string,
+  content?: string,
+  metadata?: string,
+  status?: string,
+): Promise<RawSessionEventRow> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Session operations require Tauri runtime");
+  }
+  return await invoke<RawSessionEventRow>("add_session_event", {
+    id,
+    sessionId,
+    eventType,
+    title,
+    content: content ?? null,
+    metadata: metadata ?? null,
+    status: status ?? null,
+  });
+}
+
+export async function getSessionEvents(
+  sessionId: string,
+  limit?: number,
+): Promise<RawSessionEventRow[]> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Session operations require Tauri runtime");
+  }
+  return await invoke<RawSessionEventRow[]>("get_session_events", {
+    sessionId,
+    limit: limit ?? null,
+  });
+}
+
+export async function updateSessionEventStatus(
+  id: string,
+  status: string,
+): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Session operations require Tauri runtime");
+  }
+  await invoke("update_session_event_status", { id, status });
+}

--- a/src/lib/tauri-fetch.ts
+++ b/src/lib/tauri-fetch.ts
@@ -55,7 +55,10 @@ function decodeBase64Chunk(base64: string): Uint8Array {
 }
 
 function buildGatewayRequestId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
     return crypto.randomUUID();
   }
 
@@ -128,29 +131,32 @@ async function gatewayFetch(request: Request): Promise<Response> {
   let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null;
   let rejectResponse: ((reason?: unknown) => void) | null = null;
 
-  const unlistenPromise = listen<GatewayHttpEvent>(GATEWAY_HTTP_EVENT, (event) => {
-    const payload = event.payload;
-    if (payload.requestId !== requestId || !controllerRef) {
-      return;
-    }
+  const unlistenPromise = listen<GatewayHttpEvent>(
+    GATEWAY_HTTP_EVENT,
+    (event) => {
+      const payload = event.payload;
+      if (payload.requestId !== requestId || !controllerRef) {
+        return;
+      }
 
-    if (payload.eventType === "chunk" && payload.chunkBase64) {
-      controllerRef.enqueue(decodeBase64Chunk(payload.chunkBase64));
-      return;
-    }
+      if (payload.eventType === "chunk" && payload.chunkBase64) {
+        controllerRef.enqueue(decodeBase64Chunk(payload.chunkBase64));
+        return;
+      }
 
-    if (payload.eventType === "error") {
-      const error = new Error(payload.error || "Gateway request failed");
-      cleanup();
-      controllerRef.error(error);
-      return;
-    }
+      if (payload.eventType === "error") {
+        const error = new Error(payload.error || "Gateway request failed");
+        cleanup();
+        controllerRef.error(error);
+        return;
+      }
 
-    if (payload.eventType === "end") {
-      cleanup();
-      controllerRef.close();
-    }
-  });
+      if (payload.eventType === "end") {
+        cleanup();
+        controllerRef.close();
+      }
+    },
+  );
 
   const cleanup = () => {
     if (cleanedUp) return;
@@ -194,7 +200,9 @@ async function gatewayFetch(request: Request): Promise<Response> {
   const responseMeta = await new Promise<GatewayHttpResponseMeta>(
     (resolve, reject) => {
       rejectResponse = reject;
-      void invoke<GatewayHttpResponseMeta>("gateway_http_start", { request: payload })
+      void invoke<GatewayHttpResponseMeta>("gateway_http_start", {
+        request: payload,
+      })
         .then(resolve)
         .catch((error) => {
           cleanup();

--- a/src/services/agent-tasks.ts
+++ b/src/services/agent-tasks.ts
@@ -2,13 +2,12 @@
 // ABOUTME: Provides API calls for task lifecycle and SSE streaming.
 
 import { API_BASE } from "@/lib/config";
-import { getTauriFetch, shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import type { ProviderId } from "@/lib/providers/types";
+import { getTauriFetch, shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 
 export const SEREN_CLOUD_AGENT_PUBLISHER_SLUG = "seren-models";
-export const SEREN_PRIVATE_CLOUD_AGENT_PUBLISHER_SLUG =
-  "seren-private-models";
+export const SEREN_PRIVATE_CLOUD_AGENT_PUBLISHER_SLUG = "seren-private-models";
 
 export function getCloudAgentPublisherForProvider(
   providerId: ProviderId | null | undefined,

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -4,7 +4,6 @@
 import { getCurrentUser } from "@/api";
 import { apiBase } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
-import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import {
   clearDefaultOrganizationId,
   clearRefreshToken,
@@ -15,6 +14,7 @@ import {
   storeRefreshToken,
   storeToken,
 } from "@/lib/tauri-bridge";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 
 export interface LoginResponse {
   data: {

--- a/src/services/docreader.ts
+++ b/src/services/docreader.ts
@@ -3,8 +3,8 @@
 
 import { apiBase } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
-import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import type { Attachment } from "@/lib/providers/types";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 import { updateBalanceFromError } from "@/stores/wallet.store";
 

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -699,18 +699,21 @@ function buildCapabilities(threadId: string | null): UserCapabilities {
     active_agent_session_id: agentStore.agentModeEnabled
       ? (agentStore.activeSessionId ?? null)
       : null,
-    selected_model:
-      forcePrivateChat
-        ? (() => {
-            const selected = chatStore.selectedModel?.trim();
-            if (!selected || selected === AUTO_MODEL_ID || selected.includes("/")) {
-              return privateChatPolicy?.model_id ?? null;
-            }
-            return selected;
-          })()
-        : providerStore.activeModel === AUTO_MODEL_ID
-          ? null
-          : providerStore.activeModel,
+    selected_model: forcePrivateChat
+      ? (() => {
+          const selected = chatStore.selectedModel?.trim();
+          if (
+            !selected ||
+            selected === AUTO_MODEL_ID ||
+            selected.includes("/")
+          ) {
+            return privateChatPolicy?.model_id ?? null;
+          }
+          return selected;
+        })()
+      : providerStore.activeModel === AUTO_MODEL_ID
+        ? null
+        : providerStore.activeModel,
     force_private_chat: forcePrivateChat,
     private_chat_deployment_id: privateChatPolicy?.deployment_id ?? null,
     available_models: forcePrivateChat ? [] : activeModels.map((m) => m.id),

--- a/src/services/organization-policy.ts
+++ b/src/services/organization-policy.ts
@@ -4,9 +4,7 @@ import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 
 export type OrganizationPrivateChatMode = "standard" | "private_org_agent";
-export type ManagedAgentSessionDatabaseEngine =
-  | "postgres"
-  | "aurora_postgres";
+export type ManagedAgentSessionDatabaseEngine = "postgres" | "aurora_postgres";
 export type ManagedAgentSessionDatabaseProvider =
   | "direct_url"
   | "seren_organization_database";

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -5,8 +5,8 @@ import { API_BASE } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
 import { getErrorKey, RateLimiter } from "@/lib/rate-limiter";
 import { scrubSensitive } from "@/lib/scrub-sensitive";
-import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/lib/tauri-bridge";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 
 export interface ErrorReport {
   message: string;

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -8,9 +8,9 @@ import {
   onRuntimeEvent,
 } from "@/lib/browser-local-runtime";
 import { runtimeHasCapability } from "@/lib/runtime";
+import { runValidationLoop } from "@/services/validation";
 import { getEnabledMcpServers, settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
-import { runValidationLoop } from "@/services/validation";
 import { validationStore } from "@/stores/validation.store";
 
 /** Per-session ready promises — resolved when backend emits "ready" status */
@@ -2857,7 +2857,12 @@ Summary:`;
                   "Please review the failures below and fix the issues:\n",
                   failureSummary,
                 ].join("\n");
-                await this.sendPrompt(repairPrompt, undefined, undefined, sessionId);
+                await this.sendPrompt(
+                  repairPrompt,
+                  undefined,
+                  undefined,
+                  sessionId,
+                );
               },
             );
           }

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -17,8 +17,8 @@ import {
 } from "@/services/auth";
 import { initializeGateway, resetGateway } from "@/services/mcp-gateway";
 import {
-  type OrganizationPrivateChatPolicy,
   getDefaultOrganizationPrivateChatPolicy,
+  type OrganizationPrivateChatPolicy,
 } from "@/services/organization-policy";
 
 export interface User {

--- a/src/stores/session.store.ts
+++ b/src/stores/session.store.ts
@@ -1,0 +1,332 @@
+// ABOUTME: Reactive store for computer-use runtime sessions.
+// ABOUTME: Manages session lifecycle, events, persistence, and background execution state.
+
+import { createStore } from "solid-js/store";
+import {
+  addSessionEvent as addSessionEventDb,
+  createRuntimeSession as createRuntimeSessionDb,
+  deleteRuntimeSession as deleteRuntimeSessionDb,
+  getSessionEvents as getSessionEventsDb,
+  listRuntimeSessions as listRuntimeSessionsDb,
+  resumeRuntimeSession as resumeRuntimeSessionDb,
+  updateRuntimeSession as updateRuntimeSessionDb,
+  updateSessionEventStatus as updateSessionEventStatusDb,
+} from "@/lib/tauri-bridge";
+import type {
+  RawRuntimeSession,
+  RawSessionEvent,
+  RuntimeSession,
+  SessionContext,
+  SessionEnvironment,
+  SessionEvent,
+  SessionEventMetadata,
+  SessionEventStatus,
+  SessionEventType,
+  SessionPolicy,
+  SessionStatus,
+} from "@/types/session";
+import { parseRuntimeSession, parseSessionEvent } from "@/types/session";
+
+// ============================================================================
+// State
+// ============================================================================
+
+interface SessionState {
+  sessions: RuntimeSession[];
+  activeSessionId: string | null;
+  events: Record<string, SessionEvent[]>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const [state, setState] = createStore<SessionState>({
+  sessions: [],
+  activeSessionId: null,
+  events: {},
+  isLoading: false,
+  error: null,
+});
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export const sessionStore = {
+  // === Getters ===
+
+  get sessions(): RuntimeSession[] {
+    return state.sessions;
+  },
+
+  get activeSessionId(): string | null {
+    return state.activeSessionId;
+  },
+
+  get activeSession(): RuntimeSession | null {
+    if (!state.activeSessionId) return null;
+    return state.sessions.find((s) => s.id === state.activeSessionId) ?? null;
+  },
+
+  get activeSessionEvents(): SessionEvent[] {
+    if (!state.activeSessionId) return [];
+    return state.events[state.activeSessionId] ?? [];
+  },
+
+  get isLoading(): boolean {
+    return state.isLoading;
+  },
+
+  get error(): string | null {
+    return state.error;
+  },
+
+  /** Count of sessions not in completed/error state. */
+  get activeSessions(): RuntimeSession[] {
+    return state.sessions.filter(
+      (s) => s.status !== "completed" && s.status !== "error",
+    );
+  },
+
+  /** Sessions that are running in the background. */
+  get backgroundSessions(): RuntimeSession[] {
+    return state.sessions.filter(
+      (s) =>
+        (s.status === "running" || s.status === "waiting_approval") &&
+        s.id !== state.activeSessionId,
+    );
+  },
+
+  getEventsFor(sessionId: string): SessionEvent[] {
+    return state.events[sessionId] ?? [];
+  },
+
+  getSessionForThread(threadId: string): RuntimeSession | null {
+    return state.sessions.find((s) => s.thread_id === threadId) ?? null;
+  },
+
+  // === Actions ===
+
+  async createSession(
+    title: string,
+    environment: SessionEnvironment,
+    options?: {
+      threadId?: string;
+      projectRoot?: string;
+      policy?: SessionPolicy;
+    },
+  ): Promise<RuntimeSession> {
+    const id = crypto.randomUUID();
+    const policyJson = options?.policy
+      ? JSON.stringify(options.policy)
+      : undefined;
+
+    try {
+      const raw = await createRuntimeSessionDb(
+        id,
+        title,
+        environment,
+        options?.threadId,
+        options?.projectRoot,
+        policyJson,
+      );
+
+      const session = parseRuntimeSession(raw as unknown as RawRuntimeSession);
+      setState("sessions", (prev) => [session, ...prev]);
+      setState("events", id, []);
+      return session;
+    } catch (error) {
+      const msg =
+        error instanceof Error ? error.message : "Failed to create session";
+      setState("error", msg);
+      throw error;
+    }
+  },
+
+  setActiveSession(id: string | null) {
+    setState("activeSessionId", id);
+  },
+
+  async loadSessions(threadId?: string): Promise<void> {
+    setState("isLoading", true);
+    try {
+      const raw = await listRuntimeSessionsDb(50, threadId);
+      const sessions = raw.map((r) =>
+        parseRuntimeSession(r as unknown as RawRuntimeSession),
+      );
+      setState("sessions", sessions);
+    } catch (error) {
+      console.warn("[SessionStore] Failed to load sessions:", error);
+    } finally {
+      setState("isLoading", false);
+    }
+  },
+
+  async loadEvents(sessionId: string): Promise<void> {
+    try {
+      const raw = await getSessionEventsDb(sessionId);
+      const events = raw.map((r) =>
+        parseSessionEvent(r as unknown as RawSessionEvent),
+      );
+      setState("events", sessionId, events);
+    } catch (error) {
+      console.warn("[SessionStore] Failed to load events:", error);
+    }
+  },
+
+  async updateSession(
+    id: string,
+    updates: {
+      title?: string;
+      status?: SessionStatus;
+      context?: SessionContext;
+      policy?: SessionPolicy;
+      threadId?: string;
+    },
+  ): Promise<void> {
+    try {
+      await updateRuntimeSessionDb(id, {
+        title: updates.title,
+        status: updates.status,
+        context: updates.context ? JSON.stringify(updates.context) : undefined,
+        policy: updates.policy ? JSON.stringify(updates.policy) : undefined,
+        threadId: updates.threadId,
+      });
+
+      setState("sessions", (prev) =>
+        prev.map((s) => {
+          if (s.id !== id) return s;
+          return {
+            ...s,
+            ...(updates.title !== undefined && { title: updates.title }),
+            ...(updates.status !== undefined && { status: updates.status }),
+            ...(updates.context !== undefined && { context: updates.context }),
+            ...(updates.policy !== undefined && { policy: updates.policy }),
+            ...(updates.threadId !== undefined && {
+              thread_id: updates.threadId,
+            }),
+            updated_at: Date.now(),
+          };
+        }),
+      );
+    } catch (error) {
+      console.error("[SessionStore] Failed to update session:", error);
+    }
+  },
+
+  async resumeSession(id: string): Promise<void> {
+    try {
+      await resumeRuntimeSessionDb(id);
+
+      setState("sessions", (prev) =>
+        prev.map((s) =>
+          s.id === id
+            ? {
+                ...s,
+                status: "running" as SessionStatus,
+                resumed_at: Date.now(),
+                updated_at: Date.now(),
+              }
+            : s,
+        ),
+      );
+
+      await this.addEvent(id, "status_change", "Session resumed", {
+        metadata: { old_status: "paused", new_status: "running" },
+      });
+    } catch (error) {
+      console.error("[SessionStore] Failed to resume session:", error);
+    }
+  },
+
+  async pauseSession(id: string): Promise<void> {
+    await this.updateSession(id, { status: "paused" });
+    await this.addEvent(id, "status_change", "Session paused", {
+      metadata: { old_status: "running", new_status: "paused" },
+    });
+  },
+
+  async completeSession(id: string): Promise<void> {
+    await this.updateSession(id, { status: "completed" });
+    await this.addEvent(id, "status_change", "Session completed", {
+      metadata: { old_status: "running", new_status: "completed" },
+    });
+  },
+
+  async deleteSession(id: string): Promise<void> {
+    try {
+      await deleteRuntimeSessionDb(id);
+      setState("sessions", (prev) => prev.filter((s) => s.id !== id));
+
+      if (state.activeSessionId === id) {
+        setState("activeSessionId", null);
+      }
+
+      // Clean up events from memory
+      setState("events", id, undefined as unknown as SessionEvent[]);
+    } catch (error) {
+      console.error("[SessionStore] Failed to delete session:", error);
+    }
+  },
+
+  async addEvent(
+    sessionId: string,
+    eventType: SessionEventType,
+    title: string,
+    options?: {
+      content?: string;
+      metadata?: SessionEventMetadata;
+      status?: SessionEventStatus;
+    },
+  ): Promise<SessionEvent | null> {
+    const eventId = crypto.randomUUID();
+    const metadataJson = options?.metadata
+      ? JSON.stringify(options.metadata)
+      : undefined;
+
+    try {
+      const raw = await addSessionEventDb(
+        eventId,
+        sessionId,
+        eventType,
+        title,
+        options?.content,
+        metadataJson,
+        options?.status,
+      );
+
+      const event = parseSessionEvent(raw as unknown as RawSessionEvent);
+      setState("events", sessionId, (prev = []) => [...prev, event]);
+      return event;
+    } catch (error) {
+      console.warn("[SessionStore] Failed to add event:", error);
+      return null;
+    }
+  },
+
+  async updateEventStatus(
+    eventId: string,
+    sessionId: string,
+    status: SessionEventStatus,
+  ): Promise<void> {
+    try {
+      await updateSessionEventStatusDb(eventId, status);
+
+      setState("events", sessionId, (prev = []) =>
+        prev.map((e) => (e.id === eventId ? { ...e, status } : e)),
+      );
+    } catch (error) {
+      console.warn("[SessionStore] Failed to update event status:", error);
+    }
+  },
+
+  /** Clear all state (e.g., on logout). */
+  clear() {
+    setState({
+      sessions: [],
+      activeSessionId: null,
+      events: {},
+      isLoading: false,
+      error: null,
+    });
+  },
+};

--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -2,9 +2,9 @@
 // ABOUTME: Presents chats and agent sessions as a single sorted thread list filtered by project.
 
 import { createStore } from "solid-js/store";
+import type { ProviderId } from "@/lib/providers/types";
 import { type InstalledSkill, parseSkillMd } from "@/lib/skills";
 import { archiveAgentConversation } from "@/lib/tauri-bridge";
-import type { ProviderId } from "@/lib/providers/types";
 import {
   type AgentType,
   listSessions,
@@ -16,11 +16,15 @@ import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
 import { fileTreeState, setRootPath } from "@/stores/fileTree";
 import { AUTO_MODEL_ID, providerStore } from "@/stores/provider.store";
+import { sessionStore } from "@/stores/session.store";
 import { skillsStore } from "@/stores/skills.store";
 
 const LAST_ACTIVE_THREAD_KEY = "seren:lastActiveThread";
 
-function persistLastActiveThread(id: string, kind: "chat" | "agent"): void {
+function persistLastActiveThread(
+  id: string,
+  kind: "chat" | "agent" | "session",
+): void {
   try {
     localStorage.setItem(LAST_ACTIVE_THREAD_KEY, JSON.stringify({ id, kind }));
   } catch {
@@ -28,16 +32,21 @@ function persistLastActiveThread(id: string, kind: "chat" | "agent"): void {
   }
 }
 
-function loadLastActiveThread(): { id: string; kind: "chat" | "agent" } | null {
+function loadLastActiveThread(): {
+  id: string;
+  kind: "chat" | "agent" | "session";
+} | null {
   try {
     const raw = localStorage.getItem(LAST_ACTIVE_THREAD_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw);
     if (
       typeof parsed?.id === "string" &&
-      (parsed?.kind === "chat" || parsed?.kind === "agent")
+      (parsed?.kind === "chat" ||
+        parsed?.kind === "agent" ||
+        parsed?.kind === "session")
     ) {
-      return parsed as { id: string; kind: "chat" | "agent" };
+      return parsed as { id: string; kind: "chat" | "agent" | "session" };
     }
   } catch {
     // Ignore
@@ -54,13 +63,15 @@ export type ThreadStatus = "idle" | "running" | "waiting-input" | "error";
 export interface Thread {
   id: string;
   title: string;
-  kind: "chat" | "agent";
+  kind: "chat" | "agent" | "session";
   agentType?: AgentType;
   status: ThreadStatus;
   projectRoot: string | null;
   timestamp: number;
   /** Whether this thread has an active in-memory agent runtime session. */
   isLive: boolean;
+  /** For session threads, the runtime session ID. */
+  sessionId?: string;
 }
 
 export interface ThreadGroup {
@@ -71,7 +82,7 @@ export interface ThreadGroup {
 
 interface ThreadState {
   activeThreadId: string | null;
-  activeThreadKind: "chat" | "agent" | null;
+  activeThreadKind: "chat" | "agent" | "session" | null;
   /** When true, new threads prefer Seren Chat over any available agent. */
   preferChat: boolean;
 }
@@ -225,8 +236,26 @@ export const threadStore = {
         };
       });
 
+    // Runtime sessions → Thread
+    const sessionThreads: Thread[] = sessionStore.sessions.map((s) => ({
+      id: `session:${s.id}`,
+      title: s.title,
+      kind: "session" as const,
+      status: (s.status === "running"
+        ? "running"
+        : s.status === "waiting_approval"
+          ? "waiting-input"
+          : s.status === "error"
+            ? "error"
+            : "idle") as ThreadStatus,
+      projectRoot: s.project_root,
+      timestamp: s.updated_at,
+      isLive: s.status === "running" || s.status === "waiting_approval",
+      sessionId: s.id,
+    }));
+
     // Merge and sort by recency
-    const all = [...chatThreads, ...agentThreads];
+    const all = [...chatThreads, ...agentThreads, ...sessionThreads];
 
     return all.sort((a, b) => b.timestamp - a.timestamp);
   },
@@ -312,7 +341,7 @@ export const threadStore = {
    * Select a thread by ID. Updates the underlying store (conversation or agent)
    * to match.
    */
-  selectThread(id: string, kind: "chat" | "agent") {
+  selectThread(id: string, kind: "chat" | "agent" | "session") {
     setState({ activeThreadId: id, activeThreadKind: kind });
     persistLastActiveThread(id, kind);
 
@@ -324,14 +353,27 @@ export const threadStore = {
 
     if (kind === "chat") {
       conversationStore.setActiveConversation(id);
-      const conversation = conversationStore.conversations.find((c) => c.id === id);
+      const conversation = conversationStore.conversations.find(
+        (c) => c.id === id,
+      );
       if (conversation) {
         providerStore.setActiveProvider(
           conversation.selectedProvider ?? "seren",
         );
-        providerStore.setActiveModel(conversation.selectedModel || AUTO_MODEL_ID);
+        providerStore.setActiveModel(
+          conversation.selectedModel || AUTO_MODEL_ID,
+        );
         chatStore.setModel(conversation.selectedModel || AUTO_MODEL_ID);
       }
+    } else if (kind === "session") {
+      // For session threads, activate the runtime session.
+      const realSessionId = thread?.sessionId ?? id.replace("session:", "");
+      sessionStore.setActiveSession(realSessionId);
+      void sessionStore.loadEvents(realSessionId);
+      // Open the sessions panel so the user sees the session detail.
+      window.dispatchEvent(
+        new CustomEvent("seren:open-panel", { detail: "sessions" }),
+      );
     } else {
       if (
         thread?.agentType &&
@@ -372,7 +414,10 @@ export const threadStore = {
             );
             agentStore.setActiveSession(null);
             await agentStore.terminateSession(liveSession.info.id);
-            if (state.activeThreadId !== id || state.activeThreadKind !== kind) {
+            if (
+              state.activeThreadId !== id ||
+              state.activeThreadKind !== kind
+            ) {
               return;
             }
             const cwd = thread?.projectRoot || fileTreeState.rootPath;
@@ -532,9 +577,12 @@ export const threadStore = {
   /**
    * Archive a thread.
    */
-  async archiveThread(id: string, kind: "chat" | "agent") {
+  async archiveThread(id: string, kind: "chat" | "agent" | "session") {
     if (kind === "chat") {
       await conversationStore.archiveConversation(id);
+    } else if (kind === "session") {
+      const realSessionId = id.replace("session:", "");
+      await sessionStore.deleteSession(realSessionId);
     } else {
       await archiveAgentConversation(id);
       await agentStore.refreshRecentAgentConversations(200);
@@ -573,6 +621,7 @@ export const threadStore = {
   async refresh() {
     await conversationStore.loadHistory();
     await agentStore.refreshRecentAgentConversations(200);
+    await sessionStore.loadSessions();
 
     // Only restore if no thread is already active (e.g. deep-linked navigation).
     if (state.activeThreadId) return;
@@ -596,6 +645,7 @@ export const threadStore = {
       activeThreadKind: null,
       preferChat: false,
     });
+    sessionStore.clear();
     try {
       localStorage.removeItem(LAST_ACTIVE_THREAD_KEY);
     } catch {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -1,0 +1,167 @@
+// ABOUTME: Type definitions for computer-use runtime sessions.
+// ABOUTME: Defines session state, events, and environment models.
+
+export type SessionStatus =
+  | "idle"
+  | "running"
+  | "waiting_approval"
+  | "completed"
+  | "error"
+  | "paused";
+
+export type SessionEnvironment = "browser" | "desktop" | "file";
+
+export type SessionEventType =
+  | "navigation"
+  | "action"
+  | "screenshot"
+  | "approval"
+  | "content"
+  | "command"
+  | "error"
+  | "status_change";
+
+export type SessionEventStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "completed"
+  | "error";
+
+export interface RuntimeSession {
+  id: string;
+  title: string;
+  status: SessionStatus;
+  environment: SessionEnvironment;
+  context: SessionContext | null;
+  policy: SessionPolicy | null;
+  thread_id: string | null;
+  project_root: string | null;
+  created_at: number;
+  updated_at: number;
+  resumed_at: number | null;
+}
+
+export interface SessionContext {
+  url?: string;
+  page_title?: string;
+  app_name?: string;
+  file_paths?: string[];
+  viewport?: { width: number; height: number };
+  cookies_count?: number;
+  active_tools?: string[];
+}
+
+export interface SessionPolicy {
+  auto_approve?: string[];
+  require_approval?: string[];
+  blocked?: string[];
+  max_actions_per_minute?: number;
+}
+
+export interface SessionEvent {
+  id: string;
+  session_id: string;
+  event_type: SessionEventType;
+  title: string;
+  content: string | null;
+  metadata: SessionEventMetadata | null;
+  status: SessionEventStatus;
+  created_at: number;
+}
+
+export interface SessionEventMetadata {
+  tool_name?: string;
+  url?: string;
+  screenshot_path?: string;
+  duration_ms?: number;
+  error_message?: string;
+  approval_id?: string;
+  old_status?: SessionStatus;
+  new_status?: SessionStatus;
+}
+
+/** Raw session row from the database (context/policy are JSON strings). */
+export interface RawRuntimeSession {
+  id: string;
+  title: string;
+  status: string;
+  environment: string;
+  context: string | null;
+  policy: string | null;
+  thread_id: string | null;
+  project_root: string | null;
+  created_at: number;
+  updated_at: number;
+  resumed_at: number | null;
+}
+
+/** Raw event row from the database (metadata is a JSON string). */
+export interface RawSessionEvent {
+  id: string;
+  session_id: string;
+  event_type: string;
+  title: string;
+  content: string | null;
+  metadata: string | null;
+  status: string;
+  created_at: number;
+}
+
+/** Parse raw DB session into typed RuntimeSession. */
+export function parseRuntimeSession(raw: RawRuntimeSession): RuntimeSession {
+  let context: SessionContext | null = null;
+  if (raw.context) {
+    try {
+      context = JSON.parse(raw.context) as SessionContext;
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  let policy: SessionPolicy | null = null;
+  if (raw.policy) {
+    try {
+      policy = JSON.parse(raw.policy) as SessionPolicy;
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  return {
+    id: raw.id,
+    title: raw.title,
+    status: raw.status as SessionStatus,
+    environment: raw.environment as SessionEnvironment,
+    context,
+    policy,
+    thread_id: raw.thread_id,
+    project_root: raw.project_root,
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+    resumed_at: raw.resumed_at,
+  };
+}
+
+/** Parse raw DB event into typed SessionEvent. */
+export function parseSessionEvent(raw: RawSessionEvent): SessionEvent {
+  let metadata: SessionEventMetadata | null = null;
+  if (raw.metadata) {
+    try {
+      metadata = JSON.parse(raw.metadata) as SessionEventMetadata;
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  return {
+    id: raw.id,
+    session_id: raw.session_id,
+    event_type: raw.event_type as SessionEventType,
+    title: raw.title,
+    content: raw.content,
+    metadata,
+    status: raw.status as SessionEventStatus,
+    created_at: raw.created_at,
+  };
+}

--- a/tests/unit/session-types.test.ts
+++ b/tests/unit/session-types.test.ts
@@ -1,0 +1,289 @@
+// ABOUTME: Tests for session type parsing and serialization.
+// ABOUTME: Verifies parseRuntimeSession and parseSessionEvent handle all edge cases.
+
+import { describe, expect, it } from "vitest";
+import {
+  parseRuntimeSession,
+  parseSessionEvent,
+  type RawRuntimeSession,
+  type RawSessionEvent,
+} from "@/types/session";
+
+describe("parseRuntimeSession", () => {
+  it("parses a complete session with context and policy", () => {
+    const raw: RawRuntimeSession = {
+      id: "sess-1",
+      title: "Test Session",
+      status: "running",
+      environment: "browser",
+      context: JSON.stringify({
+        url: "https://example.com",
+        page_title: "Example",
+        active_tools: ["navigate", "click"],
+      }),
+      policy: JSON.stringify({
+        auto_approve: ["navigate"],
+        require_approval: ["click"],
+        max_actions_per_minute: 10,
+      }),
+      thread_id: "thread-1",
+      project_root: "/home/user/project",
+      created_at: 1711900000000,
+      updated_at: 1711900060000,
+      resumed_at: 1711900030000,
+    };
+
+    const session = parseRuntimeSession(raw);
+
+    expect(session.id).toBe("sess-1");
+    expect(session.title).toBe("Test Session");
+    expect(session.status).toBe("running");
+    expect(session.environment).toBe("browser");
+    expect(session.context).toEqual({
+      url: "https://example.com",
+      page_title: "Example",
+      active_tools: ["navigate", "click"],
+    });
+    expect(session.policy).toEqual({
+      auto_approve: ["navigate"],
+      require_approval: ["click"],
+      max_actions_per_minute: 10,
+    });
+    expect(session.thread_id).toBe("thread-1");
+    expect(session.project_root).toBe("/home/user/project");
+    expect(session.resumed_at).toBe(1711900030000);
+  });
+
+  it("parses a session with null context and policy", () => {
+    const raw: RawRuntimeSession = {
+      id: "sess-2",
+      title: "Minimal Session",
+      status: "idle",
+      environment: "file",
+      context: null,
+      policy: null,
+      thread_id: null,
+      project_root: null,
+      created_at: 1711900000000,
+      updated_at: 1711900000000,
+      resumed_at: null,
+    };
+
+    const session = parseRuntimeSession(raw);
+
+    expect(session.context).toBeNull();
+    expect(session.policy).toBeNull();
+    expect(session.thread_id).toBeNull();
+    expect(session.resumed_at).toBeNull();
+  });
+
+  it("handles invalid JSON in context gracefully", () => {
+    const raw: RawRuntimeSession = {
+      id: "sess-3",
+      title: "Bad Context",
+      status: "error",
+      environment: "desktop",
+      context: "not valid json{",
+      policy: null,
+      thread_id: null,
+      project_root: null,
+      created_at: 1711900000000,
+      updated_at: 1711900000000,
+      resumed_at: null,
+    };
+
+    const session = parseRuntimeSession(raw);
+
+    expect(session.context).toBeNull();
+    expect(session.status).toBe("error");
+  });
+
+  it("handles invalid JSON in policy gracefully", () => {
+    const raw: RawRuntimeSession = {
+      id: "sess-4",
+      title: "Bad Policy",
+      status: "idle",
+      environment: "browser",
+      context: null,
+      policy: "{broken",
+      thread_id: null,
+      project_root: null,
+      created_at: 1711900000000,
+      updated_at: 1711900000000,
+      resumed_at: null,
+    };
+
+    const session = parseRuntimeSession(raw);
+
+    expect(session.policy).toBeNull();
+  });
+
+  it("preserves all session status values", () => {
+    const statuses = [
+      "idle",
+      "running",
+      "waiting_approval",
+      "completed",
+      "error",
+      "paused",
+    ] as const;
+
+    for (const status of statuses) {
+      const raw: RawRuntimeSession = {
+        id: `sess-${status}`,
+        title: status,
+        status,
+        environment: "browser",
+        context: null,
+        policy: null,
+        thread_id: null,
+        project_root: null,
+        created_at: 1711900000000,
+        updated_at: 1711900000000,
+        resumed_at: null,
+      };
+
+      expect(parseRuntimeSession(raw).status).toBe(status);
+    }
+  });
+});
+
+describe("parseSessionEvent", () => {
+  it("parses a complete event with metadata", () => {
+    const raw: RawSessionEvent = {
+      id: "evt-1",
+      session_id: "sess-1",
+      event_type: "navigation",
+      title: "Navigated to Example",
+      content: "Page loaded successfully",
+      metadata: JSON.stringify({
+        url: "https://example.com",
+        duration_ms: 350,
+      }),
+      status: "completed",
+      created_at: 1711900010000,
+    };
+
+    const event = parseSessionEvent(raw);
+
+    expect(event.id).toBe("evt-1");
+    expect(event.session_id).toBe("sess-1");
+    expect(event.event_type).toBe("navigation");
+    expect(event.title).toBe("Navigated to Example");
+    expect(event.content).toBe("Page loaded successfully");
+    expect(event.metadata).toEqual({
+      url: "https://example.com",
+      duration_ms: 350,
+    });
+    expect(event.status).toBe("completed");
+  });
+
+  it("parses an approval event with pending status", () => {
+    const raw: RawSessionEvent = {
+      id: "evt-2",
+      session_id: "sess-1",
+      event_type: "approval",
+      title: "Click button",
+      content: null,
+      metadata: JSON.stringify({
+        tool_name: "click",
+        approval_id: "approval-123",
+      }),
+      status: "pending",
+      created_at: 1711900020000,
+    };
+
+    const event = parseSessionEvent(raw);
+
+    expect(event.event_type).toBe("approval");
+    expect(event.status).toBe("pending");
+    expect(event.metadata?.tool_name).toBe("click");
+    expect(event.metadata?.approval_id).toBe("approval-123");
+    expect(event.content).toBeNull();
+  });
+
+  it("parses an error event", () => {
+    const raw: RawSessionEvent = {
+      id: "evt-3",
+      session_id: "sess-1",
+      event_type: "error",
+      title: "Navigation failed",
+      content: null,
+      metadata: JSON.stringify({
+        error_message: "Page not found",
+        url: "https://example.com/404",
+      }),
+      status: "error",
+      created_at: 1711900030000,
+    };
+
+    const event = parseSessionEvent(raw);
+
+    expect(event.event_type).toBe("error");
+    expect(event.status).toBe("error");
+    expect(event.metadata?.error_message).toBe("Page not found");
+  });
+
+  it("handles null metadata", () => {
+    const raw: RawSessionEvent = {
+      id: "evt-4",
+      session_id: "sess-1",
+      event_type: "status_change",
+      title: "Session started",
+      content: null,
+      metadata: null,
+      status: "completed",
+      created_at: 1711900040000,
+    };
+
+    const event = parseSessionEvent(raw);
+
+    expect(event.metadata).toBeNull();
+  });
+
+  it("handles invalid metadata JSON gracefully", () => {
+    const raw: RawSessionEvent = {
+      id: "evt-5",
+      session_id: "sess-1",
+      event_type: "action",
+      title: "Some action",
+      content: null,
+      metadata: "broken{json",
+      status: "completed",
+      created_at: 1711900050000,
+    };
+
+    const event = parseSessionEvent(raw);
+
+    expect(event.metadata).toBeNull();
+    expect(event.title).toBe("Some action");
+  });
+
+  it("preserves all event types", () => {
+    const types = [
+      "navigation",
+      "action",
+      "screenshot",
+      "approval",
+      "content",
+      "command",
+      "error",
+      "status_change",
+    ] as const;
+
+    for (const eventType of types) {
+      const raw: RawSessionEvent = {
+        id: `evt-${eventType}`,
+        session_id: "sess-1",
+        event_type: eventType,
+        title: eventType,
+        content: null,
+        metadata: null,
+        status: "completed",
+        created_at: 1711900000000,
+      };
+
+      expect(parseSessionEvent(raw).event_type).toBe(eventType);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1327

- **Session abstraction**: Durable `RuntimeSession` model with SQLite persistence, supporting browser/desktop/file environments with context, policy, and thread association.
- **Audit timeline**: `SessionEvent` table captures every action (navigation, clicks, screenshots, approvals, errors, commands) with metadata and chronological ordering.
- **Session UI**: Dedicated slide panel with session list, detail view with lifecycle controls (create/resume/pause/complete/delete), and inline session content view for session threads.
- **Thread integration**: Sessions appear as a new `"session"` thread kind in the sidebar, selectable and archivable like chat/agent threads.
- **Background execution**: Session status indicators show background running sessions; sessions survive navigation away.

### Architecture

| Layer | Component |
|-------|-----------|
| Rust | `commands/session.rs` - 9 Tauri commands, `database.rs` - 2 tables + 3 indexes |
| Bridge | `tauri-bridge.ts` - typed wrappers for all session IPC |
| Store | `session.store.ts` - reactive lifecycle, events, persistence |
| Types | `types/session.ts` - session/event models with JSON parse helpers |
| UI | `SessionPanel`, `SessionContent`, `SessionTimeline`, `SessionStatusBadge` |
| Integration | Thread store, AppShell, ThreadContent, ThreadSidebar |

### Tests

- **Rust**: Schema creation, session events table, cascade delete (3 tests)
- **TypeScript**: Session/event type parsing, all status/event types, malformed JSON resilience (12 tests)
- Full test suite: 258 frontend tests + 288 Rust tests pass

## Test plan

- [ ] Create a new session from the Sessions panel (sidebar button or slide panel)
- [ ] Verify session appears in thread sidebar as a session thread
- [ ] Select session thread — SessionContent renders with status/controls
- [ ] Resume/pause/complete a session — status badge updates in real-time
- [ ] Add events to timeline — verify chronological ordering and metadata display
- [ ] Navigate away from session, verify it continues in background (badge shows)
- [ ] Return to session, verify state persisted and events intact
- [ ] Delete a session — verify events cascade-deleted
- [ ] Restart app — verify sessions rehydrated from SQLite on startup
- [ ] Run `pnpm test` and `cargo test` — all green

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com