### PR TITLE
fix: remove sessionStore import from thread.store.ts to prevent TDZ crash

### DIFF
--- a/src/components/layout/ThreadContent.tsx
+++ b/src/components/layout/ThreadContent.tsx
@@ -1,10 +1,9 @@
 // ABOUTME: Routes to the correct content view based on the active thread type.
-// ABOUTME: Shows ChatContent for chat, AgentChat for agents, SessionContent for sessions.
+// ABOUTME: Shows ChatContent for chat threads, AgentChat for agent threads, or empty state.
 
 import { type Component, Match, Show, Switch } from "solid-js";
 import { AgentChat } from "@/components/chat/AgentChat";
 import { ChatContent } from "@/components/chat/ChatContent";
-import { SessionContent } from "@/components/session/SessionContent";
 import { openFolder } from "@/lib/files/service";
 import { fileTreeState } from "@/stores/fileTree";
 import { threadStore } from "@/stores/thread.store";
@@ -23,9 +22,6 @@ export const ThreadContent: Component<ThreadContentProps> = (props) => {
           </Match>
           <Match when={threadStore.activeThreadKind === "agent"}>
             <AgentChat />
-          </Match>
-          <Match when={threadStore.activeThreadKind === "session"}>
-            <SessionContent />
           </Match>
         </Switch>
       </div>

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -23,7 +23,6 @@ import { skills as skillsService } from "@/services/skills";
 import { agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
 import { fileTreeState } from "@/stores/fileTree";
-import { sessionStore } from "@/stores/session.store";
 import { skillsStore } from "@/stores/skills.store";
 import { type Thread, threadStore } from "@/stores/thread.store";
 
@@ -1153,11 +1152,6 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
             />
           </svg>
           Sessions
-          <Show when={sessionStore.activeSessions.length > 0}>
-            <span class="ml-auto text-[10px] px-1.5 py-0.5 rounded-full bg-primary/15 text-primary font-medium">
-              {sessionStore.activeSessions.length}
-            </span>
-          </Show>
         </button>
 
         <Show when={threadStore.runningCount > 0}>

--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -16,15 +16,11 @@ import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
 import { fileTreeState, setRootPath } from "@/stores/fileTree";
 import { AUTO_MODEL_ID, providerStore } from "@/stores/provider.store";
-import { sessionStore } from "@/stores/session.store";
 import { skillsStore } from "@/stores/skills.store";
 
 const LAST_ACTIVE_THREAD_KEY = "seren:lastActiveThread";
 
-function persistLastActiveThread(
-  id: string,
-  kind: "chat" | "agent" | "session",
-): void {
+function persistLastActiveThread(id: string, kind: "chat" | "agent"): void {
   try {
     localStorage.setItem(LAST_ACTIVE_THREAD_KEY, JSON.stringify({ id, kind }));
   } catch {
@@ -34,7 +30,7 @@ function persistLastActiveThread(
 
 function loadLastActiveThread(): {
   id: string;
-  kind: "chat" | "agent" | "session";
+  kind: "chat" | "agent";
 } | null {
   try {
     const raw = localStorage.getItem(LAST_ACTIVE_THREAD_KEY);
@@ -42,11 +38,9 @@ function loadLastActiveThread(): {
     const parsed = JSON.parse(raw);
     if (
       typeof parsed?.id === "string" &&
-      (parsed?.kind === "chat" ||
-        parsed?.kind === "agent" ||
-        parsed?.kind === "session")
+      (parsed?.kind === "chat" || parsed?.kind === "agent")
     ) {
-      return parsed as { id: string; kind: "chat" | "agent" | "session" };
+      return parsed as { id: string; kind: "chat" | "agent" };
     }
   } catch {
     // Ignore
@@ -63,15 +57,13 @@ export type ThreadStatus = "idle" | "running" | "waiting-input" | "error";
 export interface Thread {
   id: string;
   title: string;
-  kind: "chat" | "agent" | "session";
+  kind: "chat" | "agent";
   agentType?: AgentType;
   status: ThreadStatus;
   projectRoot: string | null;
   timestamp: number;
   /** Whether this thread has an active in-memory agent runtime session. */
   isLive: boolean;
-  /** For session threads, the runtime session ID. */
-  sessionId?: string;
 }
 
 export interface ThreadGroup {
@@ -82,7 +74,7 @@ export interface ThreadGroup {
 
 interface ThreadState {
   activeThreadId: string | null;
-  activeThreadKind: "chat" | "agent" | "session" | null;
+  activeThreadKind: "chat" | "agent" | null;
   /** When true, new threads prefer Seren Chat over any available agent. */
   preferChat: boolean;
 }
@@ -236,26 +228,8 @@ export const threadStore = {
         };
       });
 
-    // Runtime sessions → Thread
-    const sessionThreads: Thread[] = sessionStore.sessions.map((s) => ({
-      id: `session:${s.id}`,
-      title: s.title,
-      kind: "session" as const,
-      status: (s.status === "running"
-        ? "running"
-        : s.status === "waiting_approval"
-          ? "waiting-input"
-          : s.status === "error"
-            ? "error"
-            : "idle") as ThreadStatus,
-      projectRoot: s.project_root,
-      timestamp: s.updated_at,
-      isLive: s.status === "running" || s.status === "waiting_approval",
-      sessionId: s.id,
-    }));
-
     // Merge and sort by recency
-    const all = [...chatThreads, ...agentThreads, ...sessionThreads];
+    const all = [...chatThreads, ...agentThreads];
 
     return all.sort((a, b) => b.timestamp - a.timestamp);
   },
@@ -341,7 +315,7 @@ export const threadStore = {
    * Select a thread by ID. Updates the underlying store (conversation or agent)
    * to match.
    */
-  selectThread(id: string, kind: "chat" | "agent" | "session") {
+  selectThread(id: string, kind: "chat" | "agent") {
     setState({ activeThreadId: id, activeThreadKind: kind });
     persistLastActiveThread(id, kind);
 
@@ -365,15 +339,6 @@ export const threadStore = {
         );
         chatStore.setModel(conversation.selectedModel || AUTO_MODEL_ID);
       }
-    } else if (kind === "session") {
-      // For session threads, activate the runtime session.
-      const realSessionId = thread?.sessionId ?? id.replace("session:", "");
-      sessionStore.setActiveSession(realSessionId);
-      void sessionStore.loadEvents(realSessionId);
-      // Open the sessions panel so the user sees the session detail.
-      window.dispatchEvent(
-        new CustomEvent("seren:open-panel", { detail: "sessions" }),
-      );
     } else {
       if (
         thread?.agentType &&
@@ -577,12 +542,9 @@ export const threadStore = {
   /**
    * Archive a thread.
    */
-  async archiveThread(id: string, kind: "chat" | "agent" | "session") {
+  async archiveThread(id: string, kind: "chat" | "agent") {
     if (kind === "chat") {
       await conversationStore.archiveConversation(id);
-    } else if (kind === "session") {
-      const realSessionId = id.replace("session:", "");
-      await sessionStore.deleteSession(realSessionId);
     } else {
       await archiveAgentConversation(id);
       await agentStore.refreshRecentAgentConversations(200);
@@ -621,7 +583,6 @@ export const threadStore = {
   async refresh() {
     await conversationStore.loadHistory();
     await agentStore.refreshRecentAgentConversations(200);
-    await sessionStore.loadSessions();
 
     // Only restore if no thread is already active (e.g. deep-linked navigation).
     if (state.activeThreadId) return;
@@ -645,7 +606,6 @@ export const threadStore = {
       activeThreadKind: null,
       preferChat: false,
     });
-    sessionStore.clear();
     try {
       localStorage.removeItem(LAST_ACTIVE_THREAD_KEY);
     } catch {

--- a/tests/unit/thread-store.test.ts
+++ b/tests/unit/thread-store.test.ts
@@ -565,4 +565,16 @@ describe("threadStore", () => {
       expect(threadStore.runningCount).toBe(1);
     });
   });
+
+  describe("module isolation", () => {
+    it("thread.store.ts does not import session.store (TDZ guard)", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const filePath = path.resolve("src/stores/thread.store.ts");
+      const source = fs.readFileSync(filePath, "utf-8");
+
+      expect(source).not.toContain("session.store");
+      expect(source).not.toContain("sessionStore");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1334

PR #1333 introduced a sessionStore import in thread.store.ts that causes a ReferenceError in production bundles. The bundler evaluates thread.store.ts before session.store.ts, so the const sessionStore hits the Temporal Dead Zone when the reactive threads getter runs.

### Changes
- Remove sessionStore import and all 7 references from thread.store.ts
- Revert Thread.kind to chat | agent only
- Remove SessionContent route from ThreadContent.tsx
- Remove sessionStore import from ThreadSidebar.tsx
- Add regression test: thread.store.ts must not contain session.store or sessionStore

### Verified
- 263 unit tests pass (including new TDZ guard)
- Production vite build succeeds
- cargo check succeeds

## Test plan
- [ ] Click any thread in sidebar - no ReferenceError
- [ ] Agent threads spawn and resume normally
- [ ] Sessions panel opens from sidebar button
- [ ] Run pnpm test - 263 pass including TDZ guard

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com