### PR TITLE
feat: add production-bundle Playwright e2e tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,44 @@ jobs:
           workspaces: src-tauri
       - run: cargo test --manifest-path src-tauri/Cargo.toml
 
+  test-e2e:
+    name: E2E tests (production bundle)
+    needs: [lint, test-frontend]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 9
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Build production bundle
+        run: npx vite build
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run e2e tests against production bundle
+        run: pnpm test:e2e
+        env:
+          PLAYWRIGHT_WEB_COMMAND: 'npx vite preview --port 1420'
+          PLAYWRIGHT_WEB_TIMEOUT: '30000'
+          PLAYWRIGHT_PORT: '1420'
+          CI: 'true'
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 14
+
   file-issue-on-failure:
     name: File issue on CI failure
-    needs: [lint, test-frontend, test-rust]
+    needs: [lint, test-frontend, test-rust, test-e2e]
     if: |
       failure() &&
       github.event_name == 'push' &&
@@ -95,10 +130,11 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const failedJobs = ['lint', 'test-frontend', 'test-rust']
+            const failedJobs = ['lint', 'test-frontend', 'test-rust', 'test-e2e']
               .filter(job => '${{ needs.lint.result }}' === 'failure' && job === 'lint' ||
                              '${{ needs.test-frontend.result }}' === 'failure' && job === 'test-frontend' ||
-                             '${{ needs.test-rust.result }}' === 'failure' && job === 'test-rust');
+                             '${{ needs.test-rust.result }}' === 'failure' && job === 'test-rust' ||
+                             '${{ needs.test-e2e.result }}' === 'failure' && job === 'test-e2e');
 
             for (const job of failedJobs) {
               const title = `CI failure: ${job} on main`;
@@ -135,7 +171,7 @@ jobs:
             }
 
   build:
-    needs: [lint, test-frontend, test-rust]
+    needs: [lint, test-frontend, test-rust, test-e2e]
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
     strategy:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,12 @@
+// ABOUTME: Playwright e2e test configuration for Seren Desktop.
+// ABOUTME: Supports dev server (pnpm tauri dev) and production bundle (vite preview) modes.
+
 import { defineConfig, devices } from "@playwright/test";
 
-const PORT = 1420;
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? 1420);
 const HOST = process.env.PLAYWRIGHT_WEB_HOST ?? "localhost";
-const WEB_COMMAND = process.env.PLAYWRIGHT_WEB_COMMAND ?? "pnpm tauri dev";
+const WEB_COMMAND =
+  process.env.PLAYWRIGHT_WEB_COMMAND ?? "pnpm tauri dev";
 const WEB_TIMEOUT = Number(process.env.PLAYWRIGHT_WEB_TIMEOUT ?? 360_000);
 
 export default defineConfig({

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -286,6 +286,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
 
   return (
     <aside
+      data-testid="thread-sidebar"
       class="flex flex-col bg-card border-r border-border overflow-hidden transition-all duration-200"
       classList={{
         "w-[var(--sidebar-width)] min-w-[var(--sidebar-width)]":
@@ -351,6 +352,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
       <div class="px-3 py-2 shrink-0 relative" ref={launcherRef}>
         <button
           type="button"
+          data-testid="new-thread-button"
           class="flex items-center gap-2 w-full py-2 px-3 bg-primary/8 border border-primary/15 rounded-lg text-primary text-[13px] font-medium cursor-pointer transition-all duration-150 hover:bg-primary/15 hover:border-primary/25 hover:shadow-[0_0_12px_rgba(56,189,248,0.1)] active:scale-[0.98] disabled:opacity-60 disabled:cursor-wait disabled:hover:bg-primary/8"
           onClick={toggleLauncher}
           disabled={spawning()}
@@ -386,6 +388,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
             <Show when={allowsSerenAgent(authStore.privateChatPolicy)}>
               <button
                 type="button"
+                data-testid="new-seren-chat"
                 class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
                 onClick={handleNewChat}
               >
@@ -1016,6 +1019,9 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                   <For each={group.threads}>
                     {(thread) => (
                       <div
+                        data-testid="thread-item"
+                        data-thread-id={thread.id}
+                        data-thread-kind={thread.kind}
                         class="group flex items-center gap-2 w-full py-2 px-2.5 bg-transparent border-none border-l-2 border-l-transparent rounded-lg cursor-pointer mb-0.5 text-left transition-all duration-150 hover:bg-surface-2/60"
                         classList={{
                           "!bg-surface-2/80 border-l-2 !border-l-primary !pl-2":
@@ -1120,6 +1126,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
       <div class="border-t border-border shrink-0 bg-surface-0/50">
         <button
           type="button"
+          data-testid="sessions-button"
           class="w-full px-3 py-2 text-left text-[12px] text-muted-foreground hover:text-foreground hover:bg-surface-1/50 transition-colors flex items-center gap-2"
           onClick={() =>
             window.dispatchEvent(

--- a/tests/e2e/production-bundle.spec.ts
+++ b/tests/e2e/production-bundle.spec.ts
@@ -1,0 +1,121 @@
+// ABOUTME: Production bundle smoke tests to catch module ordering and TDZ errors.
+// ABOUTME: These tests verify the built app loads without JavaScript initialization errors.
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Production Bundle Integrity", () => {
+  test("no ReferenceError or initialization errors on load", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Wait for app to fully initialize
+    await page.waitForTimeout(2_000);
+
+    const initErrors = errors.filter(
+      (e) =>
+        e.includes("ReferenceError") ||
+        e.includes("Cannot access") ||
+        e.includes("before initialization") ||
+        e.includes("is not defined") ||
+        e.includes("SyntaxError"),
+    );
+
+    expect(initErrors).toEqual([]);
+  });
+
+  test("all store modules initialize without circular dependency errors", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Interact with UI to trigger reactive store evaluations
+    const sidebar = page.getByTestId("thread-sidebar");
+    if (await sidebar.isVisible()) {
+      // Click new thread to force thread store reactive evaluation
+      const newBtn = page.getByTestId("new-thread-button");
+      if (await newBtn.isVisible()) {
+        await newBtn.click();
+        await page.waitForTimeout(500);
+      }
+
+      // Open sessions panel to force session store evaluation
+      const sessionsBtn = page.getByTestId("sessions-button");
+      if (await sessionsBtn.isVisible()) {
+        await sessionsBtn.click();
+        await page.waitForTimeout(500);
+      }
+    }
+
+    const storeErrors = errors.filter(
+      (e) =>
+        e.includes("Cannot access") ||
+        e.includes("before initialization") ||
+        e.includes("is not a function"),
+    );
+
+    expect(storeErrors).toEqual([]);
+  });
+
+  test("navigating between views does not crash", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Create a thread, then interact with multiple panels
+    const newBtn = page.getByTestId("new-thread-button");
+    if (await newBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await newBtn.click();
+
+      // Click Seren Agent if the launcher shows
+      const serenChat = page.getByTestId("new-seren-chat");
+      if (
+        await serenChat.isVisible({ timeout: 2_000 }).catch(() => false)
+      ) {
+        await serenChat.click();
+        await page.waitForTimeout(1_000);
+      }
+
+      // Open sessions panel
+      const sessionsBtn = page.getByTestId("sessions-button");
+      if (await sessionsBtn.isVisible()) {
+        await sessionsBtn.click();
+        await page.waitForTimeout(500);
+      }
+
+      // Close panel with Escape
+      await page.keyboard.press("Escape");
+      await page.waitForTimeout(500);
+
+      // Click thread again to trigger selectThread
+      const threadItem = page.getByTestId("thread-item").first();
+      if (
+        await threadItem.isVisible({ timeout: 2_000 }).catch(() => false)
+      ) {
+        await threadItem.click();
+        await page.waitForTimeout(500);
+      }
+    }
+
+    const crashErrors = errors.filter(
+      (e) =>
+        e.includes("Cannot access") ||
+        e.includes("before initialization") ||
+        e.includes("ReferenceError") ||
+        e.includes("TypeError") ||
+        e.includes("is not a function"),
+    );
+
+    expect(crashErrors).toEqual([]);
+  });
+});

--- a/tests/e2e/session-panel.spec.ts
+++ b/tests/e2e/session-panel.spec.ts
@@ -1,0 +1,53 @@
+// ABOUTME: E2e tests for the Sessions panel slide-out.
+// ABOUTME: Verifies session panel opens without TDZ crash and renders correctly.
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Session Panel", () => {
+  test.beforeEach(async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    (page as any).__capturedErrors = errors;
+  });
+
+  test("sessions button is visible in sidebar", async ({ page }) => {
+    const sessionsBtn = page.getByTestId("sessions-button");
+    await expect(sessionsBtn).toBeVisible({ timeout: 10_000 });
+    await expect(sessionsBtn).toContainText("Sessions");
+  });
+
+  test("clicking sessions button opens panel without errors", async ({
+    page,
+  }) => {
+    const errors = (page as any).__capturedErrors as string[];
+
+    await page.getByTestId("sessions-button").click();
+
+    // The sessions panel should appear with "Sessions" heading
+    const heading = page.locator("h2", { hasText: "Sessions" });
+    await expect(heading).toBeVisible({ timeout: 5_000 });
+
+    // No TDZ errors
+    const tdzErrors = errors.filter(
+      (e) =>
+        e.includes("Cannot access") || e.includes("before initialization"),
+    );
+    expect(tdzErrors).toEqual([]);
+  });
+
+  test("sessions panel shows new button and empty state", async ({ page }) => {
+    await page.getByTestId("sessions-button").click();
+
+    // "+ New" button should be visible
+    const newBtn = page.locator("button", { hasText: "+ New" });
+    await expect(newBtn).toBeVisible({ timeout: 5_000 });
+
+    // Empty state should show
+    const emptyText = page.locator("text=No sessions yet");
+    await expect(emptyText).toBeVisible();
+  });
+});

--- a/tests/e2e/thread-lifecycle.spec.ts
+++ b/tests/e2e/thread-lifecycle.spec.ts
@@ -1,0 +1,127 @@
+// ABOUTME: E2e tests for thread creation, selection, and lifecycle.
+// ABOUTME: Guards against TDZ crashes (#1334) and selectThread regressions.
+
+import { test, expect } from "@playwright/test";
+
+// Errors expected in browser-only mode (no Tauri IPC backend)
+const EXPECTED_ERROR_PATTERNS = [
+  "refresh token",
+  "No access token",
+  "Session expired",
+  "401",
+  "publishers",
+  "Tauri runtime",
+  "Conversation operations",
+  "Message operations",
+  "Failed to persist",
+  "Unable to load",
+  "Failed to save",
+  "__TAURI",
+];
+
+function isExpectedError(msg: string): boolean {
+  return EXPECTED_ERROR_PATTERNS.some((p) => msg.includes(p));
+}
+
+test.describe("Thread Lifecycle", () => {
+  test.beforeEach(async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    (page as any).__capturedErrors = errors;
+  });
+
+  test("app loads without module initialization errors", async ({ page }) => {
+    const errors = (page as any).__capturedErrors as string[];
+
+    // Only fail on TDZ / module initialization errors, not expected browser-mode errors
+    const initErrors = errors.filter(
+      (e) =>
+        (e.includes("Cannot access") && e.includes("before initialization")) ||
+        e.includes("SyntaxError"),
+    );
+
+    expect(initErrors).toEqual([]);
+  });
+
+  test("sidebar renders without TDZ crash", async ({ page }) => {
+    const sidebar = page.getByTestId("thread-sidebar");
+    await expect(sidebar).toBeVisible({ timeout: 10_000 });
+
+    const newButton = page.getByTestId("new-thread-button");
+    await expect(newButton).toBeVisible();
+    await expect(newButton).toBeEnabled();
+  });
+
+  test("clicking new thread button opens launcher", async ({ page }) => {
+    const newButton = page.getByTestId("new-thread-button");
+    await expect(newButton).toBeVisible({ timeout: 10_000 });
+    await newButton.click();
+
+    const launcher = page.getByTestId("new-seren-chat");
+    await expect(launcher).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("creating a chat thread adds it to the sidebar", async ({ page }) => {
+    const threadsBefore = await page.getByTestId("thread-item").count();
+
+    await page.getByTestId("new-thread-button").click();
+    await page.getByTestId("new-seren-chat").click();
+
+    await expect(page.getByTestId("thread-item")).toHaveCount(
+      threadsBefore + 1,
+      { timeout: 10_000 },
+    );
+  });
+
+  test("selecting a thread does not throw ReferenceError", async ({
+    page,
+  }) => {
+    const errors = (page as any).__capturedErrors as string[];
+
+    // Create a thread
+    await page.getByTestId("new-thread-button").click();
+    await page.getByTestId("new-seren-chat").click();
+    await expect(page.getByTestId("thread-item").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Click the thread item
+    await page.getByTestId("thread-item").first().click();
+    await page.waitForTimeout(500);
+
+    // No TDZ / ReferenceError should have occurred
+    const tdzErrors = errors.filter(
+      (e) =>
+        e.includes("Cannot access") && e.includes("before initialization"),
+    );
+    expect(tdzErrors).toEqual([]);
+  });
+
+  test("clicking thread items repeatedly does not crash", async ({ page }) => {
+    const errors = (page as any).__capturedErrors as string[];
+
+    // Create a thread
+    await page.getByTestId("new-thread-button").click();
+    await page.getByTestId("new-seren-chat").click();
+    await expect(page.getByTestId("thread-item").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Click the thread item multiple times (simulates rapid re-selection)
+    const threadItem = page.getByTestId("thread-item").first();
+    for (let i = 0; i < 3; i++) {
+      await threadItem.click();
+      await page.waitForTimeout(200);
+    }
+
+    const tdzErrors = errors.filter(
+      (e) =>
+        e.includes("Cannot access") && e.includes("before initialization"),
+    );
+    expect(tdzErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1336

Adds a `test-e2e` CI job that builds the production bundle (`vite build`), serves it (`vite preview`), and runs Playwright against the real Rollup-bundled output. This catches TDZ/module-ordering bugs like #1334 that only manifest in production bundles, not in dev mode.

### New CI pipeline

```
lint ──┐
       ├── test-e2e ──┐
test-frontend ──┘      ├── build
test-rust ─────────────┘
```

### Tests added (12 total)

| File | Tests | What it guards |
|------|-------|----------------|
| production-bundle.spec.ts | 3 | Module init errors, store circular deps, view navigation TDZ |
| thread-lifecycle.spec.ts | 6 | Sidebar render, thread create/select, repeated clicking, no ReferenceError |
| session-panel.spec.ts | 3 | Sessions button, panel open, empty state render |

### Infrastructure
- `playwright.config.ts`: supports `PLAYWRIGHT_WEB_COMMAND` env for vite preview mode
- `data-testid` on: sidebar, new-thread button, thread items, seren-chat launcher, sessions button
- Failure artifacts: traces + screenshots + videos uploaded (14-day retention)
- Auto-files GitHub issues on main branch failures

### Verified locally
- 12 e2e tests pass against production bundle
- 263 unit tests pass
- 0 biome errors

## Test plan
- [ ] CI `test-e2e` job runs and passes on this PR
- [ ] Build job gates on test-e2e passing
- [ ] Failure artifacts upload correctly (force a failure to test)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com