### PR TITLE
fix: run only production-bundle-safe e2e tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Run e2e tests against production bundle
-        run: pnpm test:e2e
+        run: npx playwright test tests/e2e/production-bundle.spec.ts tests/e2e/thread-lifecycle.spec.ts tests/e2e/session-panel.spec.ts
         env:
           PLAYWRIGHT_WEB_COMMAND: 'npx vite preview --port 1420'
           PLAYWRIGHT_WEB_TIMEOUT: '30000'


### PR DESCRIPTION
Fixes #1338

The test-e2e CI job ran all e2e tests including auth, editor, file-tree, tabs, and validation specs that require Tauri IPC. These fail against vite preview (no Tauri backend).

Scopes the CI step to only the 3 production-bundle test files designed for browser-only mode.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com