### PR TITLE
fix: recognize missing-token errors as auth errors to show sign-in prompt

### DIFF
--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -17,6 +17,8 @@ const AUTH_ERROR_PATTERNS = [
   /not authenticated/i,
   /please obtain a new token/i,
   /refresh your existing token/i,
+  /no refresh token/i,
+  /no access token/i,
   /please sign in/i,
   /does not have access/i,
   /please login again/i,

--- a/tests/unit/auth-errors.test.ts
+++ b/tests/unit/auth-errors.test.ts
@@ -19,6 +19,13 @@ describe("isAuthError", () => {
     ).toBe(true);
   });
 
+  it("detects missing token errors from orchestrator (#1341)", () => {
+    expect(isAuthError("No refresh token available")).toBe(true);
+    expect(isAuthError("No access token in store")).toBe(true);
+    expect(isAuthError("No refresh token")).toBe(true);
+    expect(isAuthError("no access token")).toBe(true);
+  });
+
   it("returns false for null/undefined/empty", () => {
     expect(isAuthError(null)).toBe(false);
     expect(isAuthError(undefined)).toBe(false);


### PR DESCRIPTION
Fixes #1341

When auth tokens expire, the orchestrator returns `No refresh token available`. This was not matched by `AUTH_ERROR_PATTERNS`, so the chat showed a generic red error instead of the 'Session expired — Sign In' prompt. Users were stuck with silently failing skills and no way to know they needed to re-authenticate.

**Fix**: Add `/no refresh token/i` and `/no access token/i` to the auth error patterns. Now the existing sign-in prompt UI activates correctly.

**2 files, +9 lines:**
- `src/lib/auth-errors.ts` — 2 new patterns
- `tests/unit/auth-errors.test.ts` — 4 new assertions

264 tests pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com