### PR TITLE
fix: handle terminated session status during agent spawn (#1344)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -918,6 +918,7 @@ export const agentStore = {
       }
     }
 
+    console.log("[AgentStore] Checking agent availability...");
     const agentAvailable =
       await providerService.checkAgentAvailable(resolvedAgentType);
     if (!agentAvailable) {
@@ -955,6 +956,13 @@ export const agentStore = {
             const sessionError =
               state.sessions[data.sessionId]?.error ??
               "Agent session failed during initialization.";
+            rejectReady(new Error(sessionError));
+          } else if (data.status === "terminated" && rejectReady) {
+            // Claude process exited before reaching "ready" — typically an
+            // auth failure or binary-not-found on Windows.
+            const sessionError =
+              state.sessions[data.sessionId]?.error ??
+              "Agent session terminated before initialization completed. Check that Claude Code is installed and authenticated.";
             rejectReady(new Error(sessionError));
           }
         },
@@ -1008,6 +1016,7 @@ export const agentStore = {
             : null;
 
       if (ensureFn) {
+        console.log("[AgentStore] Ensuring CLI is installed...");
         let progressUnsub: UnlistenFn = () => {};
 
         if (!isLocalProviderRuntime()) {
@@ -1073,6 +1082,7 @@ export const agentStore = {
           ? "on-failure"
           : settingsStore.settings.agentApprovalPolicy;
 
+      console.log("[AgentStore] Spawning agent process...");
       const info = await providerService.spawnAgent(
         resolvedAgentType,
         cwd,
@@ -1199,14 +1209,34 @@ export const agentStore = {
         const message =
           raceError instanceof Error ? raceError.message : String(raceError);
         if (message.toLowerCase().includes("timed out")) {
-          console.warn(
-            "[AgentStore] Timeout waiting for ready, proceeding anyway",
-          );
-          // Resolve the ready promise so sendPrompt doesn't block forever
-          const entry = sessionReadyPromises.get(info.id);
-          if (entry) {
-            entry.resolve();
-            sessionReadyPromises.delete(info.id);
+          // Check if the session has an error or was terminated — if so, this
+          // is a real failure (e.g. unauthenticated Claude on Windows), not a
+          // benign slow start that we can proceed past.
+          const sessionState = state.sessions[info.id];
+          const sessionDead =
+            !sessionState ||
+            sessionState.error ||
+            sessionState.info.status === "error" ||
+            sessionState.info.status === "terminated";
+
+          if (sessionDead) {
+            console.error(
+              "[AgentStore] Session terminated or errored during init wait:",
+              sessionState?.error ?? sessionState?.info.status,
+            );
+            initFailure =
+              sessionState?.error ??
+              "Agent session terminated before initialization completed. Check that Claude Code is installed and authenticated.";
+          } else {
+            console.warn(
+              "[AgentStore] Timeout waiting for ready, proceeding anyway",
+            );
+            // Resolve the ready promise so sendPrompt doesn't block forever
+            const entry = sessionReadyPromises.get(info.id);
+            if (entry) {
+              entry.resolve();
+              sessionReadyPromises.delete(info.id);
+            }
           }
         } else {
           initFailure = message;

--- a/tests/e2e/agent-spawn.spec.ts
+++ b/tests/e2e/agent-spawn.spec.ts
@@ -1,0 +1,100 @@
+// ABOUTME: E2E tests for agent spawn lifecycle and error surfacing.
+// ABOUTME: Verifies that spawn failures produce actionable UI feedback instead of silent hangs.
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Agent Spawn Feedback", () => {
+  test("spawn failure surfaces an error in the UI within 30 seconds", async ({
+    page,
+  }) => {
+    const consoleLogs: string[] = [];
+    page.on("console", (msg) => consoleLogs.push(msg.text()));
+
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(2_000);
+
+    // Try to create a new agent thread — this will attempt to spawn Claude
+    const newBtn = page.getByTestId("new-thread-button");
+    if (!(await newBtn.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    await newBtn.click();
+
+    // Look for the Claude Agent option in the launcher
+    const claudeOption = page.getByTestId("new-claude-agent");
+    if (!(await claudeOption.isVisible({ timeout: 3_000 }).catch(() => false))) {
+      // Might be auto-selected or different UI — try Seren Agent
+      const serenAgent = page.getByTestId("new-seren-agent");
+      if (
+        !(await serenAgent.isVisible({ timeout: 2_000 }).catch(() => false))
+      ) {
+        test.skip();
+        return;
+      }
+      await serenAgent.click();
+    } else {
+      await claudeOption.click();
+    }
+
+    // Wait up to 30 seconds for either:
+    // 1. The agent to become ready (authenticated) — session shows "ready" status
+    // 2. An error message to appear in the UI (unauthenticated / not installed)
+    //
+    // The key assertion: we MUST NOT wait indefinitely with no feedback.
+    const errorOrReady = await Promise.race([
+      // Success: agent chat area becomes interactive
+      page
+        .locator("[data-testid='agent-chat-input'], [data-testid='chat-textarea']")
+        .waitFor({ state: "visible", timeout: 30_000 })
+        .then(() => "ready" as const)
+        .catch(() => null),
+
+      // Failure: an error banner or message appears
+      page
+        .locator("[data-testid='agent-error'], .agent-error, [role='alert']")
+        .first()
+        .waitFor({ state: "visible", timeout: 30_000 })
+        .then(() => "error" as const)
+        .catch(() => null),
+
+      // Timeout fallback
+      page
+        .waitForTimeout(30_000)
+        .then(() => "timeout" as const),
+    ]);
+
+    // Verify diagnostic logging exists — the spawn path must not be a black hole
+    const spawnLogs = consoleLogs.filter(
+      (l) =>
+        l.includes("[AgentStore] Spawning session") ||
+        l.includes("[AgentStore] Checking agent availability") ||
+        l.includes("[AgentStore] Ensuring CLI") ||
+        l.includes("[AgentStore] Spawning agent process") ||
+        l.includes("[AgentStore] Spawn result") ||
+        l.includes("[AgentStore] Session ready") ||
+        l.includes("[AgentStore] Spawn error") ||
+        l.includes("[AgentStore] Session terminated"),
+    );
+
+    // At minimum, the spawn attempt should produce diagnostic output
+    expect(spawnLogs.length).toBeGreaterThan(0);
+
+    // The UI must not silently hang — either ready or error must appear
+    expect(errorOrReady).not.toBe("timeout");
+
+    // No JS crashes during the spawn flow
+    const crashErrors = errors.filter(
+      (e) =>
+        e.includes("ReferenceError") ||
+        e.includes("Cannot access") ||
+        e.includes("before initialization"),
+    );
+    expect(crashErrors).toEqual([]);
+  });
+});

--- a/tests/unit/agent-spawn-status.test.ts
+++ b/tests/unit/agent-spawn-status.test.ts
@@ -1,0 +1,47 @@
+// ABOUTME: Tests that agent spawn correctly handles terminated/error session status events.
+// ABOUTME: Prevents regression where terminated status was ignored, causing silent hangs.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("agent.store spawn session status handling", () => {
+  const agentStoreSource = readFileSync(
+    resolve("src/stores/agent.store.ts"),
+    "utf-8",
+  );
+
+  it("handles terminated status in the temp sessionStatus listener", () => {
+    // The temp listener (subscribeToEvent<SessionStatusEvent>) must reject
+    // readyPromise on "terminated" status — not just "ready" and "error".
+    // Without this, a terminated session (e.g. unauthenticated Claude on
+    // Windows) leaves the readyPromise unresolved for 30+ seconds.
+    expect(agentStoreSource).toContain(
+      'data.status === "terminated"',
+    );
+    expect(agentStoreSource).toContain(
+      "rejectReady",
+    );
+  });
+
+  it("checks session state before blindly proceeding on timeout", () => {
+    // When the readyPromise race times out, the handler must check if the
+    // session is dead (terminated/errored) before "proceeding anyway".
+    // A dead session should be treated as a real failure.
+    expect(agentStoreSource).toContain("sessionDead");
+  });
+
+  it("logs diagnostic messages at each IPC boundary during spawn", () => {
+    // Between "Spawning session" and the next success/error log, there were
+    // zero console.log calls — making Windows spawn failures undiagnosable.
+    expect(agentStoreSource).toContain(
+      "[AgentStore] Checking agent availability",
+    );
+    expect(agentStoreSource).toContain(
+      "[AgentStore] Ensuring CLI is installed",
+    );
+    expect(agentStoreSource).toContain(
+      "[AgentStore] Spawning agent process",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Handle `"terminated"` session status in the temp sessionStatus listener during agent spawn — rejects `readyPromise` immediately instead of letting it hang for 30+ seconds
- Check session state on timeout: if the session is dead (terminated/errored), fail with actionable error instead of blindly proceeding
- Add diagnostic `console.log` at each IPC boundary (checkAgentAvailable, ensureCli, spawnAgent) so Windows spawn failures are diagnosable
- Add unit test verifying the fix guards exist in source
- Add e2e test spec for agent spawn feedback (error or ready within 30s, no silent hang)

## Test plan
- [x] Unit test: `tests/unit/agent-spawn-status.test.ts` — 3 tests verifying terminated handling, timeout session-dead check, and diagnostic logging
- [x] Regression: `tests/unit/thread-store.test.ts` — all 16 existing tests pass
- [x] E2E spec: `tests/e2e/agent-spawn.spec.ts` — validates spawn produces UI feedback within 30 seconds
- [ ] Manual: Windows user confirms spawn failure now shows error instead of silent hang

Closes #1344

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com