### PR TITLE
fix: convert manualChunks to function form for Vite 8 / Rolldown

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -92,12 +92,15 @@ export default defineConfig(async () => ({
     include: ["monaco-editor", "qrcode"],
   },
 
-  // Build configuration for Monaco workers
+  // Build configuration for Monaco workers.
+  // Vite 8 uses Rolldown which only supports the function form of manualChunks.
   build: {
     rollupOptions: {
       output: {
-        manualChunks: {
-          "monaco-editor": ["monaco-editor"],
+        manualChunks(id: string) {
+          if (id.includes("monaco-editor")) {
+            return "monaco-editor";
+          }
         },
       },
     },


### PR DESCRIPTION
## Summary
- Converts `manualChunks` from object form to function form in `vite.config.ts`
- Rolldown (Vite 8 bundler) only supports the function form; the object shorthand crashes with `TypeError: manualChunks is not a function`
- Regression introduced by #1319 (Vite 7.3.1 to 8.0.3 upgrade)

Closes #1347

## Test plan
- [x] `npx vite build` succeeds locally (was crashing before)
- [x] Monaco editor chunk correctly isolated (4.2MB)
- [x] 267 unit tests pass
- [x] Biome lint clean
- [ ] CI E2E production bundle test should pass

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com