### PR TITLE
fix: prevent double-spawn race and Codex thread/start timeout (#1350)

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -967,6 +967,18 @@ export function createProviderHandlers({ emit }) {
         modelListResult = await sendRequest(session, "model/list", {}, 10_000);
       } catch (error) {
         console.warn("[browser-local] Codex model/list failed:", error);
+        // If the process was terminated during model/list, don't continue
+        // to thread/start on a dead process — it will just time out.
+        const errMsg = error instanceof Error ? error.message : String(error);
+        if (errMsg.includes("terminated") || errMsg.includes("stopped")) {
+          throw error;
+        }
+      }
+
+      // Verify the session is still tracked before proceeding to thread/start.
+      // A terminated session would cause a 20s timeout on a dead stdin pipe.
+      if (!sessions.has(sessionId)) {
+        throw new Error("Codex session was terminated during initialization.");
       }
 
       session.availableModelRecords = normalizeModelRecords(modelListResult);

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -19,6 +19,10 @@ const sessionReadyPromises = new Map<
   { promise: Promise<void>; resolve: () => void }
 >();
 
+/** Conversations with a spawn currently in progress. Prevents double-spawn
+ *  when selectThread fires twice before the first spawn registers the session. */
+const spawningConversations = new Set<string>();
+
 /** Max time to wait for a session to become ready before giving up */
 const SESSION_READY_TIMEOUT_MS = 30_000;
 
@@ -1409,6 +1413,18 @@ export const agentStore = {
       return conversationId;
     }
 
+    // If a spawn is already in progress for this conversation, skip.
+    // selectThread can fire multiple times reactively before the first
+    // spawn completes and registers the session in state.
+    if (spawningConversations.has(conversationId)) {
+      console.log(
+        "[AgentStore] Spawn already in progress for",
+        conversationId,
+        "— skipping duplicate",
+      );
+      return null;
+    }
+
     // Prevent infinite spawn-crash-respawn cascades: if this conversation
     // has failed too many times in a short window, stop retrying.
     if (isSpawnCascading(conversationId)) {
@@ -1424,133 +1440,143 @@ export const agentStore = {
     }
 
     setState("error", null);
-
-    // Pre-emptively clean up any stale backend session with this conversation id.
-    // If the frontend lost track of a session (e.g. after a crash or auth error),
-    // the backend may still hold it, causing "Session already exists" on re-spawn.
+    spawningConversations.add(conversationId);
     try {
-      await providerService.terminateSession(conversationId);
-    } catch {
-      // Ignore — session likely doesn't exist in the backend
-    }
+      // Pre-emptively clean up any stale backend session with this conversation id.
+      // If the frontend lost track of a session (e.g. after a crash or auth error),
+      // the backend may still hold it, causing "Session already exists" on re-spawn.
+      try {
+        await providerService.terminateSession(conversationId);
+      } catch {
+        // Ignore — session likely doesn't exist in the backend
+      }
 
-    let convo: DbAgentConversation | null = null;
-    try {
-      convo = await getAgentConversation(conversationId);
-    } catch (error) {
-      console.error("Failed to read agent conversation:", error);
-    }
-    if (!convo) {
-      setState("error", "Agent conversation not found");
-      return null;
-    }
-    const agentType: AgentType =
-      convo.agent_type === "codex" || convo.agent_type === "claude-code"
-        ? (convo.agent_type as AgentType)
-        : state.selectedAgentType;
-    const convoMetadata = parseAgentConversationMetadata(convo.agent_metadata);
-    const pendingBootstrapPromptContext =
-      convoMetadata.pendingBootstrapPromptContext;
-    const restoredMessages = Array.isArray(
-      convoMetadata.pendingBootstrapMessages,
-    )
-      ? convoMetadata.pendingBootstrapMessages
-      : [];
-
-    const remoteSessionId = convo.agent_session_id?.trim();
-    if (!remoteSessionId) {
-      console.warn(
-        "[AgentStore] Conversation has no stored remote session id; creating a fresh session.",
-        conversationId,
+      let convo: DbAgentConversation | null = null;
+      try {
+        convo = await getAgentConversation(conversationId);
+      } catch (error) {
+        console.error("Failed to read agent conversation:", error);
+      }
+      if (!convo) {
+        setState("error", "Agent conversation not found");
+        return null;
+      }
+      const agentType: AgentType =
+        convo.agent_type === "codex" || convo.agent_type === "claude-code"
+          ? (convo.agent_type as AgentType)
+          : state.selectedAgentType;
+      const convoMetadata = parseAgentConversationMetadata(
+        convo.agent_metadata,
       );
+      const pendingBootstrapPromptContext =
+        convoMetadata.pendingBootstrapPromptContext;
+      const restoredMessages = Array.isArray(
+        convoMetadata.pendingBootstrapMessages,
+      )
+        ? convoMetadata.pendingBootstrapMessages
+        : [];
+
+      const remoteSessionId = convo.agent_session_id?.trim();
+      if (!remoteSessionId) {
+        console.warn(
+          "[AgentStore] Conversation has no stored remote session id; creating a fresh session.",
+          conversationId,
+        );
+        const convoCwd =
+          convo.project_root?.trim() || convo.agent_cwd?.trim() || undefined;
+        const freshCwd = convoCwd || cwd;
+        if (!freshCwd) {
+          setState(
+            "error",
+            "Unable to determine project path for this conversation.",
+          );
+          return null;
+        }
+        const freshSessionId = await this.spawnSession(freshCwd, agentType, {
+          localSessionId: conversationId,
+          conversationTitle: convo.title,
+          restoredMessages,
+          bootstrapPromptContext: pendingBootstrapPromptContext,
+        });
+        if (freshSessionId) {
+          clearSpawnFailures(conversationId);
+          void this.refreshRecentAgentConversations(200).catch(() => {});
+        } else {
+          recordSpawnFailure(conversationId);
+        }
+        return freshSessionId;
+      }
+      if (
+        agentType === "claude-code" &&
+        LEGACY_CLAUDE_LOCAL_SESSION_ID_RE.test(remoteSessionId)
+      ) {
+        setState(
+          "error",
+          "This conversation references a legacy local Claude id. Use Browse Claude Sessions and resume the real remote session.",
+        );
+        return null;
+      }
+
       const convoCwd =
         convo.project_root?.trim() || convo.agent_cwd?.trim() || undefined;
-      const freshCwd = convoCwd || cwd;
-      if (!freshCwd) {
+      const resumeCwd = convoCwd || cwd;
+      if (!resumeCwd) {
         setState(
           "error",
           "Unable to determine project path for this conversation.",
         );
         return null;
       }
-      const freshSessionId = await this.spawnSession(freshCwd, agentType, {
+
+      const sessionId = await this.spawnSession(resumeCwd, agentType, {
         localSessionId: conversationId,
+        resumeAgentSessionId: remoteSessionId,
         conversationTitle: convo.title,
         restoredMessages,
         bootstrapPromptContext: pendingBootstrapPromptContext,
       });
-      if (freshSessionId) {
+
+      // Legacy Claude conversations can reference session IDs that no longer
+      // exist on disk. In that case, fall back to a fresh session for the same
+      // persisted conversation instead of failing hard.
+      if (!sessionId && agentType === "claude-code") {
+        console.warn(
+          "[AgentStore] Claude resume failed, starting a fresh session for conversation",
+          conversationId,
+          state.error,
+        );
+        const fallbackSessionId = await this.spawnSession(
+          resumeCwd,
+          agentType,
+          {
+            localSessionId: conversationId,
+            conversationTitle: convo.title,
+            restoredMessages,
+            bootstrapPromptContext: pendingBootstrapPromptContext,
+          },
+        );
+        if (fallbackSessionId) {
+          clearSpawnFailures(conversationId);
+          void this.refreshRecentAgentConversations(200).catch(() => {});
+        } else {
+          recordSpawnFailure(conversationId);
+        }
+        return fallbackSessionId;
+      }
+
+      if (sessionId) {
+        if (!pendingBootstrapPromptContext) {
+          clearLegacyAgentTranscript(conversationId);
+        }
         clearSpawnFailures(conversationId);
         void this.refreshRecentAgentConversations(200).catch(() => {});
       } else {
         recordSpawnFailure(conversationId);
       }
-      return freshSessionId;
+      return sessionId;
+    } finally {
+      spawningConversations.delete(conversationId);
     }
-    if (
-      agentType === "claude-code" &&
-      LEGACY_CLAUDE_LOCAL_SESSION_ID_RE.test(remoteSessionId)
-    ) {
-      setState(
-        "error",
-        "This conversation references a legacy local Claude id. Use Browse Claude Sessions and resume the real remote session.",
-      );
-      return null;
-    }
-
-    const convoCwd =
-      convo.project_root?.trim() || convo.agent_cwd?.trim() || undefined;
-    const resumeCwd = convoCwd || cwd;
-    if (!resumeCwd) {
-      setState(
-        "error",
-        "Unable to determine project path for this conversation.",
-      );
-      return null;
-    }
-
-    const sessionId = await this.spawnSession(resumeCwd, agentType, {
-      localSessionId: conversationId,
-      resumeAgentSessionId: remoteSessionId,
-      conversationTitle: convo.title,
-      restoredMessages,
-      bootstrapPromptContext: pendingBootstrapPromptContext,
-    });
-
-    // Legacy Claude conversations can reference session IDs that no longer
-    // exist on disk. In that case, fall back to a fresh session for the same
-    // persisted conversation instead of failing hard.
-    if (!sessionId && agentType === "claude-code") {
-      console.warn(
-        "[AgentStore] Claude resume failed, starting a fresh session for conversation",
-        conversationId,
-        state.error,
-      );
-      const fallbackSessionId = await this.spawnSession(resumeCwd, agentType, {
-        localSessionId: conversationId,
-        conversationTitle: convo.title,
-        restoredMessages,
-        bootstrapPromptContext: pendingBootstrapPromptContext,
-      });
-      if (fallbackSessionId) {
-        clearSpawnFailures(conversationId);
-        void this.refreshRecentAgentConversations(200).catch(() => {});
-      } else {
-        recordSpawnFailure(conversationId);
-      }
-      return fallbackSessionId;
-    }
-
-    if (sessionId) {
-      if (!pendingBootstrapPromptContext) {
-        clearLegacyAgentTranscript(conversationId);
-      }
-      clearSpawnFailures(conversationId);
-      void this.refreshRecentAgentConversations(200).catch(() => {});
-    } else {
-      recordSpawnFailure(conversationId);
-    }
-    return sessionId;
   },
   /**
    * Resume a remote agent session from the provider's stored session list.

--- a/tests/unit/agent-spawn-guard.test.ts
+++ b/tests/unit/agent-spawn-guard.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Tests that agent spawn has a double-spawn guard and Codex aborts on dead process.
+// ABOUTME: Prevents regression where selectThread firing twice caused a race condition.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("agent spawn double-spawn guard", () => {
+  const agentStoreSource = readFileSync(
+    resolve("src/stores/agent.store.ts"),
+    "utf-8",
+  );
+
+  it("tracks spawning conversations to prevent double-spawn", () => {
+    expect(agentStoreSource).toContain("spawningConversations");
+    // Must add before spawn
+    expect(agentStoreSource).toContain("spawningConversations.add(conversationId)");
+    // Must check before proceeding
+    expect(agentStoreSource).toContain("spawningConversations.has(conversationId)");
+    // Must clean up in finally
+    expect(agentStoreSource).toContain("spawningConversations.delete(conversationId)");
+  });
+});
+
+describe("Codex spawnSession dead-process guard", () => {
+  const providersSource = readFileSync(
+    resolve("bin/browser-local/providers.mjs"),
+    "utf-8",
+  );
+
+  it("aborts before thread/start if model/list fails with termination error", () => {
+    // After model/list fails with "terminated" or "stopped", the code
+    // must throw instead of continuing to thread/start on a dead process.
+    expect(providersSource).toContain('errMsg.includes("terminated")');
+    expect(providersSource).toContain('errMsg.includes("stopped")');
+  });
+
+  it("checks session is still tracked before thread/start", () => {
+    expect(providersSource).toContain("sessions.has(sessionId)");
+    expect(providersSource).toContain(
+      "Codex session was terminated during initialization",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `spawningConversations` guard in `resumeAgentConversation` — when `selectThread` fires twice reactively, the second call is skipped instead of terminating the first session mid-init
- In Codex `spawnSession` (`providers.mjs`): if `model/list` fails with termination/stopped error, abort immediately instead of continuing to `thread/start` on a dead process
- Add `sessions.has(sessionId)` check before `thread/start` as a safety net

## Test plan
- [x] Unit test: `tests/unit/agent-spawn-guard.test.ts` — 3 tests verifying guard exists and Codex dead-process abort
- [x] Regression: `tests/unit/agent-spawn-status.test.ts` — all 3 prior tests still pass

Closes #1350

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com