### PR TITLE
fix: group all store modules into single chunk to prevent TDZ crash (#1356)

### DIFF
--- a/tests/e2e/production-bundle.spec.ts
+++ b/tests/e2e/production-bundle.spec.ts
@@ -65,6 +65,75 @@ test.describe("Production Bundle Integrity", () => {
     expect(storeErrors).toEqual([]);
   });
 
+  test("no TDZ crash when restoring a persisted last-active thread", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    // Seed localStorage with a last-active thread BEFORE the app loads.
+    // This triggers the threadStore.refresh() → selectThread() code path
+    // that caused TDZ crashes when store chunks evaluated out of order.
+    await page.goto("/");
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "seren:lastActiveThread",
+        JSON.stringify({ id: "fake-thread-id", kind: "chat" }),
+      );
+    });
+
+    // Reload so the app picks up the persisted thread on init
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(2_000);
+
+    const tdzErrors = errors.filter(
+      (e) =>
+        e.includes("Cannot access") ||
+        e.includes("before initialization") ||
+        e.includes("ReferenceError"),
+    );
+
+    expect(tdzErrors).toEqual([]);
+
+    // Clean up
+    await page.evaluate(() => {
+      localStorage.removeItem("seren:lastActiveThread");
+    });
+  });
+
+  test("no TDZ crash when restoring a persisted last-active agent thread", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/");
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "seren:lastActiveThread",
+        JSON.stringify({ id: "fake-agent-thread-id", kind: "agent" }),
+      );
+    });
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(2_000);
+
+    const tdzErrors = errors.filter(
+      (e) =>
+        e.includes("Cannot access") ||
+        e.includes("before initialization") ||
+        e.includes("ReferenceError"),
+    );
+
+    expect(tdzErrors).toEqual([]);
+
+    await page.evaluate(() => {
+      localStorage.removeItem("seren:lastActiveThread");
+    });
+  });
+
   test("navigating between views does not crash", async ({ page }) => {
     const errors: string[] = [];
     page.on("pageerror", (err) => errors.push(err.message));

--- a/tests/unit/store-chunk-colocation.test.ts
+++ b/tests/unit/store-chunk-colocation.test.ts
@@ -1,0 +1,28 @@
+// ABOUTME: Verifies vite.config manualChunks groups all store modules into a single chunk.
+// ABOUTME: Prevents TDZ crashes from cross-chunk store access in production bundles.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("store chunk co-location", () => {
+  const viteConfig = readFileSync(resolve("vite.config.ts"), "utf-8");
+
+  it("manualChunks assigns all src/stores/ modules to a 'stores' chunk", () => {
+    // All store modules must be in the same chunk to prevent TDZ crashes
+    // when one store accesses another during initialization.
+    expect(viteConfig).toContain('id.includes("/src/stores/")');
+    expect(viteConfig).toContain('return "stores"');
+  });
+
+  it("thread.store.ts does not import session.store (TDZ guard)", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const source = fs.readFileSync(
+      path.resolve("src/stores/thread.store.ts"),
+      "utf-8",
+    );
+    expect(source).not.toContain("session.store");
+    expect(source).not.toContain("sessionStore");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -92,14 +92,20 @@ export default defineConfig(async () => ({
     include: ["monaco-editor", "qrcode"],
   },
 
-  // Build configuration for Monaco workers.
+  // Build configuration for Monaco workers and store co-location.
   // Vite 8 uses Rolldown which only supports the function form of manualChunks.
+  // All store modules MUST live in a single chunk — Rolldown may split them
+  // into separate chunks whose evaluation order causes TDZ crashes when one
+  // store accesses another before its chunk has been evaluated.
   build: {
     rollupOptions: {
       output: {
         manualChunks(id: string) {
           if (id.includes("monaco-editor")) {
             return "monaco-editor";
+          }
+          if (id.includes("/src/stores/")) {
+            return "stores";
           }
         },
       },


### PR DESCRIPTION
## Summary
- Add `manualChunks` rule: all `src/stores/` modules → single `stores` chunk, eliminating cross-chunk TDZ
- Add 2 e2e tests that seed `localStorage` with persisted last-active thread (chat + agent) before reload — the exact code path CI was missing
- Add unit test verifying the manualChunks config exists

## Root cause
The `manualChunks` function-form migration (`8c64faf2`) only handled Monaco. Rolldown split stores across chunks whose evaluation order broke when `selectThread` accessed an unevaluated store during `threadStore.refresh()`.

## Test plan
- [x] Unit: `store-chunk-colocation.test.ts` passes
- [x] E2E: `production-bundle.spec.ts` now covers persisted thread restore path

Closes #1356

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com