### PR TITLE
fix: move threadValidationRun after threadSession to prevent TDZ (#1358)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -175,12 +175,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     return agentStore.getStreamingContentForConversation(thread.id);
   });
 
-  // Active validation run for this thread's session
-  const threadValidationRun = createMemo(() => {
-    const session = threadSession();
-    if (!session) return undefined;
-    return validationStore.getActiveRun(session.info.id);
-  });
 
   // Enqueue finalized assistant messages to the render worker.
   // The worker returns HTML via onmessage → setHtmlCache → reactive DOM update.
@@ -263,6 +257,15 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     return agentStore.getSessionForConversation(thread.id);
   });
   const threadSessionId = createMemo(() => threadSession()?.info.id ?? null);
+
+  // Active validation run for this thread's session.
+  // MUST be declared after threadSession to avoid TDZ — SolidJS may eagerly
+  // evaluate memos during reactive batches triggered by selectThread.
+  const threadValidationRun = createMemo(() => {
+    const session = threadSession();
+    if (!session) return undefined;
+    return validationStore.getActiveRun(session.info.id);
+  });
 
   createEffect(() => {
     const sessionId = threadSessionId();

--- a/tests/unit/agent-chat-memo-order.test.ts
+++ b/tests/unit/agent-chat-memo-order.test.ts
@@ -1,0 +1,35 @@
+// ABOUTME: Verifies no forward references to threadSession before its declaration in AgentChat.
+// ABOUTME: Prevents TDZ crash when SolidJS eagerly evaluates memos during selectThread.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("AgentChat memo declaration order", () => {
+  const source = readFileSync(
+    resolve("src/components/chat/AgentChat.tsx"),
+    "utf-8",
+  );
+
+  it("threadValidationRun is declared after threadSession", () => {
+    const sessionDeclPos = source.indexOf("const threadSession = createMemo");
+    const validationDeclPos = source.indexOf(
+      "const threadValidationRun = createMemo",
+    );
+
+    expect(sessionDeclPos).toBeGreaterThan(-1);
+    expect(validationDeclPos).toBeGreaterThan(-1);
+    expect(validationDeclPos).toBeGreaterThan(sessionDeclPos);
+  });
+
+  it("no createMemo calls threadSession() before its declaration", () => {
+    const sessionDeclPos = source.indexOf("const threadSession = createMemo");
+    const beforeDecl = source.slice(0, sessionDeclPos);
+    // Check that no createMemo in the region before threadSession's
+    // declaration contains a call to threadSession()
+    const memoBlocks = beforeDecl.match(/createMemo\(\(\) => \{[^}]*\}/g) ?? [];
+    for (const block of memoBlocks) {
+      expect(block).not.toContain("threadSession()");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Move `threadValidationRun` memo declaration after `threadSession` in AgentChat.tsx
- `threadValidationRun` (line 179) called `threadSession()` (line 260) — forward reference to a `const` that hadn't been assigned yet
- SolidJS eagerly evaluates memos during reactive batches from `selectThread`, hitting the TDZ
- Add unit test verifying declaration order

Closes #1358