### PR TITLE
fix: remove duplicate spawn guard from resumeAgentConversation (#1360)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1478,18 +1478,6 @@ export const agentStore = {
       return conversationId;
     }
 
-    // If a spawn is already in progress for this conversation, skip.
-    // selectThread can fire multiple times reactively before the first
-    // spawn completes and registers the session in state.
-    if (spawningConversations.has(conversationId)) {
-      console.log(
-        "[AgentStore] Spawn already in progress for",
-        conversationId,
-        "— skipping duplicate",
-      );
-      return null;
-    }
-
     // Prevent infinite spawn-crash-respawn cascades: if this conversation
     // has failed too many times in a short window, stop retrying.
     if (isSpawnCascading(conversationId)) {
@@ -1505,9 +1493,8 @@ export const agentStore = {
     }
 
     setState("error", null);
-    spawningConversations.add(conversationId);
-    try {
-      // Pre-emptively clean up any stale backend session with this conversation id.
+
+    // Pre-emptively clean up any stale backend session with this conversation id.
       // If the frontend lost track of a session (e.g. after a crash or auth error),
       // the backend may still hold it, causing "Session already exists" on re-spawn.
       try {
@@ -1639,9 +1626,6 @@ export const agentStore = {
         recordSpawnFailure(conversationId);
       }
       return sessionId;
-    } finally {
-      spawningConversations.delete(conversationId);
-    }
   },
   /**
    * Resume a remote agent session from the provider's stored session list.

--- a/tests/unit/agent-spawn-guard.test.ts
+++ b/tests/unit/agent-spawn-guard.test.ts
@@ -11,14 +11,25 @@ describe("agent spawn double-spawn guard", () => {
     "utf-8",
   );
 
-  it("tracks spawning conversations to prevent double-spawn", () => {
+  it("spawnSession guards against double-spawn with cleanup", () => {
     expect(agentStoreSource).toContain("spawningConversations");
-    // Must add before spawn
-    expect(agentStoreSource).toContain("spawningConversations.add(conversationId)");
-    // Must check before proceeding
-    expect(agentStoreSource).toContain("spawningConversations.has(conversationId)");
-    // Must clean up in finally
-    expect(agentStoreSource).toContain("spawningConversations.delete(conversationId)");
+    // Must add before spawn in spawnSession
+    expect(agentStoreSource).toContain("spawningConversations.add(spawnKey)");
+    // Must check before proceeding in spawnSession
+    expect(agentStoreSource).toContain("spawningConversations.has(spawnKey)");
+    // Must clean up in finally in spawnSession
+    expect(agentStoreSource).toContain("spawningConversations.delete(spawnKey)");
+  });
+
+  it("resumeAgentConversation does NOT hold spawn guard (avoids blocking retries)", () => {
+    // The guard must only live in spawnSession. If resumeAgentConversation
+    // also holds it, its own retry fallback gets blocked.
+    const resumeFn = agentStoreSource.slice(
+      agentStoreSource.indexOf("async resumeAgentConversation("),
+      agentStoreSource.indexOf("async resumeRemoteSession("),
+    );
+    expect(resumeFn).not.toContain("spawningConversations.add(conversationId)");
+    expect(resumeFn).not.toContain("spawningConversations.delete(conversationId)");
   });
 });
 


### PR DESCRIPTION
## Summary
Remove the `spawningConversations` guard from `resumeAgentConversation`. It duplicates the guard in `spawnSession` and uses the same key, causing a deadlock: when the first spawn fails, the retry calls `spawnSession` which sees the lock still held by `resumeAgentConversation` and returns null.

`spawnSession` already has its own guard with proper `try/finally` cleanup.

Closes #1360