### PR TITLE
fix: remove stale threadValidationRun test after validation revert

### DIFF
--- a/tests/unit/agent-chat-memo-order.test.ts
+++ b/tests/unit/agent-chat-memo-order.test.ts
@@ -11,17 +11,6 @@ describe("AgentChat memo declaration order", () => {
     "utf-8",
   );
 
-  it("threadValidationRun is declared after threadSession", () => {
-    const sessionDeclPos = source.indexOf("const threadSession = createMemo");
-    const validationDeclPos = source.indexOf(
-      "const threadValidationRun = createMemo",
-    );
-
-    expect(sessionDeclPos).toBeGreaterThan(-1);
-    expect(validationDeclPos).toBeGreaterThan(-1);
-    expect(validationDeclPos).toBeGreaterThan(sessionDeclPos);
-  });
-
   it("no createMemo calls threadSession() before its declaration", () => {
     const sessionDeclPos = source.indexOf("const threadSession = createMemo");
     const beforeDecl = source.slice(0, sessionDeclPos);


### PR DESCRIPTION
Test checked for threadValidationRun which was removed with the validation revert. CI fails.