### PR TITLE
fix: clear terminatedSessionIds before spawn so Claude retry gets config events

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1136,11 +1136,14 @@ export const agentStore = {
 
         // Register spawn context so the global event logger can identify
         // early events that arrive before the session is in state.sessions.
+        // Also clear the terminated flag — this session ID is being reborn;
+        // events from the new process must NOT be dropped by the stale filter.
         if (localSessionId) {
           spawnContextMap.set(localSessionId, {
             agentType: resolvedAgentType,
             conversationId: localSessionId,
           });
+          terminatedSessionIds.delete(localSessionId);
         }
 
         console.log("[AgentStore] Spawning agent process...");


### PR DESCRIPTION
Claude model/mode/effort buttons missing after retry. First spawn fails, adds ID to terminatedSessionIds. Retry uses same ID but config events are dropped. Clear the flag when registering spawn context.