### PR TITLE
fix: clear stale error banners when Claude retry succeeds (#1371)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1629,6 +1629,14 @@ export const agentStore = {
           },
         );
         if (fallbackSessionId) {
+          // Clear error state and remove stale error messages left by the
+          // failed first spawn. Without this, "Claude Code request failed"
+          // banners persist even though the retry session is healthy.
+          setState("error", null);
+          setState("sessions", fallbackSessionId, "error", undefined);
+          setState("sessions", fallbackSessionId, "messages", (msgs) =>
+            msgs.filter((m) => m.type !== "error"),
+          );
           clearSpawnFailures(conversationId);
           void this.refreshRecentAgentConversations(200).catch(() => {});
         } else {


### PR DESCRIPTION
Clear error state and filter error-type messages from session when the retry fallback spawns successfully. Prevents stale 'Claude Code request failed' banners from persisting in a working session. Closes #1371