### PR TITLE
fix: pass resumeAgentSessionId on Claude retry so history replays (#1373)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1623,6 +1623,7 @@ export const agentStore = {
           agentType,
           {
             localSessionId: conversationId,
+            resumeAgentSessionId: remoteSessionId,
             conversationTitle: convo.title,
             restoredMessages,
             bootstrapPromptContext: pendingBootstrapPromptContext,


### PR DESCRIPTION
One-line fix: the fallback retry omitted resumeAgentSessionId, so Claude CLI had no remote session to replay. All conversation history was lost. Closes #1373