### PR TITLE
fix: strip v prefix before semver sort in R2 prune

### DIFF
--- a/.github/workflows/prune-r2-releases.yml
+++ b/.github/workflows/prune-r2-releases.yml
@@ -42,7 +42,7 @@ jobs:
           # List version directories, sort by semver descending
           VERSIONS=$(aws s3 ls "s3://${R2_BUCKET}/" --endpoint-url="${AWS_ENDPOINT_URL}" \
             | grep 'PRE v' | awk '{print $2}' | sed 's|/$||' \
-            | sort -t. -k1,1rn -k2,2rn -k3,3rn)
+            | sed 's/^v//' | sort -t. -k1,1rn -k2,2rn -k3,3rn | sed 's/^/v/')
 
           TOTAL=$(echo "$VERSIONS" | wc -l | tr -d ' ')
           echo ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1051,7 +1051,7 @@ jobs:
           # List all version directories (v*), sort by semver descending, skip first 5
           VERSIONS=$(aws s3 ls "s3://${R2_BUCKET}/" --endpoint-url="${AWS_ENDPOINT_URL}" \
             | grep 'PRE v' | awk '{print $2}' | sed 's|/$||' \
-            | sort -t. -k1,1rn -k2,2rn -k3,3rn)
+            | sed 's/^v//' | sort -t. -k1,1rn -k2,2rn -k3,3rn | sed 's/^/v/')
 
           KEEP=5
           COUNT=0


### PR DESCRIPTION
Sort broke on v prefix — kept v2.x, marked v3.x for pruning. No data lost (dry run only).