### PR TITLE
fix: drop resumeAgentSessionId from fallback spawn to prevent crash loop

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1623,7 +1623,6 @@ export const agentStore = {
           agentType,
           {
             localSessionId: conversationId,
-            resumeAgentSessionId: remoteSessionId,
             conversationTitle: convo.title,
             restoredMessages,
             bootstrapPromptContext: pendingBootstrapPromptContext,


### PR DESCRIPTION
Fixes #1380

When resuming a Claude agent thread with a stale remote session ID, the first `spawnSession` fails (Claude CLI exits immediately). The fallback was passing the same broken `resumeAgentSessionId`, causing `claude --resume <dead-id>` to fail again in an infinite loop.

**Fix**: Remove `resumeAgentSessionId` from the fallback call (1 line deleted). The fresh session starts without `--resume`, succeeding on the first attempt.

263 tests pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com