### PR TITLE
fix: restore resumeAgentSessionId in fallback and add Claude exit diagnostics

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1227,10 +1227,18 @@ function handleLine(emit, session, line) {
 function attachProcessListeners(emit, sessions, session, exitPromises) {
   session.output.on("line", (line) => handleLine(emit, session, line));
 
+  // Buffer the last stderr lines so exit diagnostics include the reason.
+  const stderrLines = [];
+  const MAX_STDERR_LINES = 20;
+
   session.process.stderr.on("data", (chunk) => {
     const message = String(chunk).trim();
     if (message.length > 0) {
       console.log(`[browser-local][claude] ${message}`);
+      stderrLines.push(message);
+      if (stderrLines.length > MAX_STDERR_LINES) {
+        stderrLines.shift();
+      }
     }
   });
 
@@ -1239,8 +1247,23 @@ function attachProcessListeners(emit, sessions, session, exitPromises) {
   let resolveExit;
   exitPromises.set(session.id, new Promise((r) => { resolveExit = r; }));
 
-  session.process.on("exit", () => {
+  session.process.on("exit", (code, signal) => {
     const wasTracked = sessions.delete(session.id);
+
+    const stderrTail = stderrLines.join("\n").slice(-500);
+    const exitDetail = signal
+      ? `signal=${signal}`
+      : `code=${code ?? "unknown"}`;
+
+    if (stderrTail) {
+      console.error(
+        `[browser-local][claude] Process exited (${exitDetail}) stderr:\n${stderrTail}`,
+      );
+    } else {
+      console.warn(
+        `[browser-local][claude] Process exited (${exitDetail}) with no stderr`,
+      );
+    }
 
     // Resolve the exit promise AFTER cleanup so waiters know it's safe
     // to reuse this session ID.
@@ -1254,19 +1277,24 @@ function attachProcessListeners(emit, sessions, session, exitPromises) {
       return;
     }
 
+    const diagnosticSuffix = stderrTail
+      ? ` (${exitDetail}): ${stderrTail.split("\n").pop()}`
+      : ` (${exitDetail})`;
+
     rejectPendingControlRequests(
       session,
-      new Error("Claude Code stopped before request completed."),
+      new Error(`Claude Code stopped before request completed${diagnosticSuffix}`),
     );
 
     if (session.currentPrompt) {
+      const promptError = `Claude Code stopped while prompt was active${diagnosticSuffix}`;
       rejectCurrentPrompt(
         session,
-        new Error("Claude Code stopped while prompt was active."),
+        new Error(promptError),
       );
       emit("provider://error", {
         sessionId: session.id,
-        error: "Claude Code stopped while prompt was active.",
+        error: promptError,
       });
     }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1623,6 +1623,7 @@ export const agentStore = {
           agentType,
           {
             localSessionId: conversationId,
+            resumeAgentSessionId: remoteSessionId,
             conversationTitle: convo.title,
             restoredMessages,
             bootstrapPromptContext: pendingBootstrapPromptContext,


### PR DESCRIPTION
Updates #1380

**Reverts** the premature removal of `resumeAgentSessionId` from `resumeAgentConversation` fallback. Dropping the resume ID silently loses conversation history on any failure, even transient ones. The cascade detector (3 failures / 30s) already protects against infinite loops.

**Adds** diagnostic logging to `claude-runtime.mjs` exit handler:
- Buffers last 20 stderr lines from the Claude CLI process
- Logs exit code + signal on process exit
- Appends the last stderr line to error messages so the actual cause propagates to the console and UI

Before: `Claude Code stopped before request completed.`
After: `Claude Code stopped before request completed (code=1): Error: session abc123 not found`

Next time this happens, the console will show exactly why. No more guessing.

263 tests pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com