### PR TITLE
fix: move agent prompt queue to store so background threads drain

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -82,13 +82,11 @@ interface AgentChatProps {
 // Per-thread input drafts so switching threads doesn't leak text between them.
 const agentDrafts = new Map<string, string>();
 
-// Per-thread message queues so canceling in one thread doesn't lose queued
-// messages in another thread.
-const threadQueues = new Map<string, string[]>();
+// threadQueues removed — prompt queue now lives in agentStore.sessions[id].pendingPrompts
+// so background threads drain automatically on promptComplete.
 
 export const AgentChat: Component<AgentChatProps> = (props) => {
   const [input, setInput] = createSignal("");
-  const [messageQueue, setMessageQueue] = createSignal<string[]>([]);
   const [attachedImages, setAttachedImages] = createSignal<Attachment[]>([]);
   const { isDragging } = createDragDrop((files) =>
     setAttachedImages((prev) => [...prev, ...files]),
@@ -134,6 +132,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   });
 
   // Save/restore per-thread input drafts and message queues when switching
+  // Save/restore per-thread input drafts when switching threads.
+  // Queue persistence is no longer needed — it lives in the store.
   createEffect(() => {
     const currentId = activeAgentThread()?.id ?? null;
     if (currentId !== prevThreadId) {
@@ -144,16 +144,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         } else {
           agentDrafts.delete(prevThreadId);
         }
-        // Persist the outgoing thread's queue
-        const currentQueue = untrack(messageQueue);
-        if (currentQueue.length > 0) {
-          threadQueues.set(prevThreadId, currentQueue);
-        } else {
-          threadQueues.delete(prevThreadId);
-        }
       }
       setInput(currentId ? (agentDrafts.get(currentId) ?? "") : "");
-      setMessageQueue(currentId ? (threadQueues.get(currentId) ?? []) : []);
       prevThreadId = currentId;
     }
   });
@@ -270,6 +262,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const hasSession = () => threadSession() !== null;
   const isReady = () => threadSession()?.info.status === "ready";
   const isPrompting = () => threadSession()?.info.status === "prompting";
+  const messageQueue = () =>
+    threadSessionId() ? agentStore.getPendingPrompts(threadSessionId()!) : [];
   const promptStartTime = () => threadSession()?.promptStartTime;
   const sessionError = () => threadSession()?.error ?? agentStore.error;
   const lockedAgentType = createMemo<AgentType>(() => {
@@ -626,12 +620,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       }
     }
 
-    // If agent is prompting, queue the message instead
+    // If agent is prompting, queue the message in the store
     if (isPrompting()) {
-      const updated = [...messageQueue(), trimmed];
-      setMessageQueue(updated);
-      const threadId = activeAgentThread()?.id;
-      if (threadId) threadQueues.set(threadId, updated);
+      const sid = threadSessionId();
+      if (sid) {
+        agentStore.enqueuePrompt(sid, trimmed);
+      }
       setInput("");
       console.log("[AgentChat] Message queued:", trimmed);
       return;
@@ -727,112 +721,14 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   };
 
   // Guard flag prevents concurrent queue processing
-  let queueDraining = false;
 
-  const processNextQueuedMessage = async () => {
-    if (queueDraining) return;
-
-    // Capture thread identity synchronously before any async gap.
-    const drainThreadId = activeAgentThread()?.id;
-    const drainSessionId = threadSessionId();
-    if (!drainThreadId || !drainSessionId || !isReady()) return;
-
-    // Don't process queued messages while compaction is in progress —
-    // the session will be terminated and re-spawned, so any sendPrompt
-    // call would fail with "Session terminated" and the message would be
-    // lost. The isReady effect will re-trigger once the new session is up.
-    if (threadSession()?.isCompacting) return;
-
-    // Read from the thread-specific Map, NOT the reactive messageQueue()
-    // signal. During a thread switch the isReady effect can fire before the
-    // thread-switch effect clears messageQueue(), making the signal stale.
-    // threadQueues is a plain JS Map keyed by thread ID — it is always
-    // accurate for the target thread and immune to SolidJS batch ordering.
-    const threadQueue = threadQueues.get(drainThreadId);
-    if (!threadQueue || threadQueue.length === 0) return;
-
-    queueDraining = true;
-    const [nextMessage, ...remaining] = threadQueue;
-    // Keep the Map and signal in sync.
-    if (remaining.length > 0) {
-      threadQueues.set(drainThreadId, remaining);
-    } else {
-      threadQueues.delete(drainThreadId);
-    }
-    setMessageQueue(remaining);
-    console.log("[AgentChat] Processing queued message:", nextMessage);
-
-    try {
-      await agentStore.sendPrompt(
-        nextMessage,
-        undefined,
-        undefined,
-        drainSessionId,
-      );
-    } catch (error) {
-      // If the session was terminated (e.g. by compaction), re-queue the
-      // message at the front so it survives the session transition and
-      // gets delivered once the new session is ready.
-      const msg = error instanceof Error ? error.message : String(error);
-      if (
-        msg.includes("Session terminated") ||
-        msg.includes("not found") ||
-        msg.includes("Worker thread dropped")
-      ) {
-        console.warn(
-          "[AgentChat] Re-queuing message after session termination:",
-          nextMessage,
-        );
-        const currentQueue = threadQueues.get(drainThreadId) ?? [];
-        const restored = [nextMessage, ...currentQueue];
-        threadQueues.set(drainThreadId, restored);
-        setMessageQueue(restored);
-      } else {
-        console.error("[AgentChat] Queued message failed:", error);
-      }
-    }
-
-    queueDraining = false;
-    // After the prompt completes, promptComplete has already set status
-    // back to "ready" — only continue draining if still on the same thread.
-    // If the user switched threads during the await, let the isReady effect
-    // for that thread handle its own queue instead of spilling over here.
-    if (activeAgentThread()?.id === drainThreadId) {
-      processNextQueuedMessage();
-    }
-  };
-
-  // Trigger queue drain when agent becomes ready.
-  // Check threadQueues Map (not the reactive signal) to avoid reading stale
-  // messageQueue() values during a thread switch — the root cause of
-  // cross-thread message pollution.
-  // Also guard against compaction: the session briefly reports "ready" during
-  // the compaction flow before being terminated — processing queued messages
-  // in that window causes "Session terminated" errors and message loss.
-  createEffect(
-    on(
-      isReady,
-      (ready) => {
-        const threadId = activeAgentThread()?.id;
-        if (
-          ready &&
-          threadId &&
-          !threadSession()?.isCompacting &&
-          (threadQueues.get(threadId)?.length ?? 0) > 0
-        ) {
-          processNextQueuedMessage();
-        }
-      },
-      { defer: true },
-    ),
-  );
+  // Queue drain is handled by the store's promptComplete handler.
+  // No component-level drain logic needed.
 
   const handleCancel = async () => {
-    // Clear only THIS thread's queued messages
-    setMessageQueue([]);
-    const threadId = activeAgentThread()?.id;
-    if (threadId) threadQueues.delete(threadId);
-    await agentStore.cancelPrompt(threadSessionId() ?? undefined);
+    const sid = threadSessionId();
+    if (sid) agentStore.clearPromptQueue(sid);
+    await agentStore.cancelPrompt(sid ?? undefined);
   };
 
   const [forking, setForking] = createSignal(false);
@@ -1841,7 +1737,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                     <button
                       type="button"
                       class="text-destructive hover:underline"
-                      onClick={() => setMessageQueue([])}
+                      onClick={() => {
+                        const sid = threadSessionId();
+                        if (sid) agentStore.clearPromptQueue(sid);
+                      }}
                     >
                       Clear
                     </button>

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -768,14 +768,23 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
       settingsStore.get("autoCompactPreserveMessages"),
     );
 
-    // Process message queue if there are queued messages
+    // Process message queue if there are queued messages.
+    // Capture the conversation ID to ensure the drain targets the same
+    // conversation even if the user switched threads during orchestration.
+    const drainConversationId = conversationId;
     const queue = messageQueue();
     if (queue.length > 0) {
       const [nextMessage, ...remainingQueue] = queue;
       setMessageQueue(remainingQueue);
       console.log("[ChatContent] Processing queued message:", nextMessage);
       setTimeout(() => {
-        sendMessageImmediate(nextMessage);
+        if (conversationStore.activeConversationId === drainConversationId) {
+          sendMessageImmediate(nextMessage);
+        } else {
+          console.warn(
+            "[ChatContent] Skipping queued message — conversation changed",
+          );
+        }
       }, 100);
     }
   };

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -240,6 +240,9 @@ export interface ActiveSession {
    *  that subsequent chunks of the same skill block — which arrive without the
    *  '# Active Skills' header — are also suppressed. */
   isSkippingSkillContext?: boolean;
+  /** Queued prompts awaiting dispatch when the session returns to ready.
+   *  Lives in the store (not the component) so background threads still drain. */
+  pendingPrompts: string[];
 }
 
 // ============================================================================
@@ -721,6 +724,23 @@ export const agentStore = {
       state.pendingPermissions.some((p) => p.sessionId === sid) ||
       state.pendingDiffProposals.some((p) => p.sessionId === sid)
     );
+  },
+
+  /** Enqueue a prompt for a session. Dispatched automatically on promptComplete. */
+  enqueuePrompt(sessionId: string, prompt: string): void {
+    if (!state.sessions[sessionId]) return;
+    setState("sessions", sessionId, "pendingPrompts", (q) => [...q, prompt]);
+  },
+
+  /** Get the pending prompt queue for a session (reactive). */
+  getPendingPrompts(sessionId: string): string[] {
+    return state.sessions[sessionId]?.pendingPrompts ?? [];
+  },
+
+  /** Clear the prompt queue for a session (e.g. on cancel). */
+  clearPromptQueue(sessionId: string): void {
+    if (!state.sessions[sessionId]) return;
+    setState("sessions", sessionId, "pendingPrompts", []);
   },
 
   /**
@@ -1211,6 +1231,7 @@ export const agentStore = {
             : undefined,
           contextWindowSize: resolvedAgentType === "codex" ? 400_000 : 200_000,
           bootstrapPromptContext: opts?.bootstrapPromptContext,
+          pendingPrompts: [],
         };
 
         setState("sessions", info.id, session);
@@ -1521,141 +1542,135 @@ export const agentStore = {
     try {
       await providerService.terminateSession(conversationId);
     } catch {
-        // Ignore — session likely doesn't exist in the backend
-      }
+      // Ignore — session likely doesn't exist in the backend
+    }
 
-      let convo: DbAgentConversation | null = null;
-      try {
-        convo = await getAgentConversation(conversationId);
-      } catch (error) {
-        console.error("Failed to read agent conversation:", error);
-      }
-      if (!convo) {
-        setState("error", "Agent conversation not found");
-        return null;
-      }
-      const agentType: AgentType =
-        convo.agent_type === "codex" || convo.agent_type === "claude-code"
-          ? (convo.agent_type as AgentType)
-          : state.selectedAgentType;
-      const convoMetadata = parseAgentConversationMetadata(
-        convo.agent_metadata,
+    let convo: DbAgentConversation | null = null;
+    try {
+      convo = await getAgentConversation(conversationId);
+    } catch (error) {
+      console.error("Failed to read agent conversation:", error);
+    }
+    if (!convo) {
+      setState("error", "Agent conversation not found");
+      return null;
+    }
+    const agentType: AgentType =
+      convo.agent_type === "codex" || convo.agent_type === "claude-code"
+        ? (convo.agent_type as AgentType)
+        : state.selectedAgentType;
+    const convoMetadata = parseAgentConversationMetadata(convo.agent_metadata);
+    const pendingBootstrapPromptContext =
+      convoMetadata.pendingBootstrapPromptContext;
+    const restoredMessages = Array.isArray(
+      convoMetadata.pendingBootstrapMessages,
+    )
+      ? convoMetadata.pendingBootstrapMessages
+      : [];
+
+    const remoteSessionId = convo.agent_session_id?.trim();
+    if (!remoteSessionId) {
+      console.warn(
+        "[AgentStore] Conversation has no stored remote session id; creating a fresh session.",
+        conversationId,
       );
-      const pendingBootstrapPromptContext =
-        convoMetadata.pendingBootstrapPromptContext;
-      const restoredMessages = Array.isArray(
-        convoMetadata.pendingBootstrapMessages,
-      )
-        ? convoMetadata.pendingBootstrapMessages
-        : [];
-
-      const remoteSessionId = convo.agent_session_id?.trim();
-      if (!remoteSessionId) {
-        console.warn(
-          "[AgentStore] Conversation has no stored remote session id; creating a fresh session.",
-          conversationId,
-        );
-        const convoCwd =
-          convo.project_root?.trim() || convo.agent_cwd?.trim() || undefined;
-        const freshCwd = convoCwd || cwd;
-        if (!freshCwd) {
-          setState(
-            "error",
-            "Unable to determine project path for this conversation.",
-          );
-          return null;
-        }
-        const freshSessionId = await this.spawnSession(freshCwd, agentType, {
-          localSessionId: conversationId,
-          conversationTitle: convo.title,
-          restoredMessages,
-          bootstrapPromptContext: pendingBootstrapPromptContext,
-        });
-        if (freshSessionId) {
-          clearSpawnFailures(conversationId);
-          void this.refreshRecentAgentConversations(200).catch(() => {});
-        } else {
-          recordSpawnFailure(conversationId);
-        }
-        return freshSessionId;
-      }
-      if (
-        agentType === "claude-code" &&
-        LEGACY_CLAUDE_LOCAL_SESSION_ID_RE.test(remoteSessionId)
-      ) {
-        setState(
-          "error",
-          "This conversation references a legacy local Claude id. Use Browse Claude Sessions and resume the real remote session.",
-        );
-        return null;
-      }
-
       const convoCwd =
         convo.project_root?.trim() || convo.agent_cwd?.trim() || undefined;
-      const resumeCwd = convoCwd || cwd;
-      if (!resumeCwd) {
+      const freshCwd = convoCwd || cwd;
+      if (!freshCwd) {
         setState(
           "error",
           "Unable to determine project path for this conversation.",
         );
         return null;
       }
+      const freshSessionId = await this.spawnSession(freshCwd, agentType, {
+        localSessionId: conversationId,
+        conversationTitle: convo.title,
+        restoredMessages,
+        bootstrapPromptContext: pendingBootstrapPromptContext,
+      });
+      if (freshSessionId) {
+        clearSpawnFailures(conversationId);
+        void this.refreshRecentAgentConversations(200).catch(() => {});
+      } else {
+        recordSpawnFailure(conversationId);
+      }
+      return freshSessionId;
+    }
+    if (
+      agentType === "claude-code" &&
+      LEGACY_CLAUDE_LOCAL_SESSION_ID_RE.test(remoteSessionId)
+    ) {
+      setState(
+        "error",
+        "This conversation references a legacy local Claude id. Use Browse Claude Sessions and resume the real remote session.",
+      );
+      return null;
+    }
 
-      const sessionId = await this.spawnSession(resumeCwd, agentType, {
+    const convoCwd =
+      convo.project_root?.trim() || convo.agent_cwd?.trim() || undefined;
+    const resumeCwd = convoCwd || cwd;
+    if (!resumeCwd) {
+      setState(
+        "error",
+        "Unable to determine project path for this conversation.",
+      );
+      return null;
+    }
+
+    const sessionId = await this.spawnSession(resumeCwd, agentType, {
+      localSessionId: conversationId,
+      resumeAgentSessionId: remoteSessionId,
+      conversationTitle: convo.title,
+      restoredMessages,
+      bootstrapPromptContext: pendingBootstrapPromptContext,
+    });
+
+    // Legacy Claude conversations can reference session IDs that no longer
+    // exist on disk. In that case, fall back to a fresh session for the same
+    // persisted conversation instead of failing hard.
+    if (!sessionId && agentType === "claude-code") {
+      console.warn(
+        "[AgentStore] Claude resume failed, starting a fresh session for conversation",
+        conversationId,
+        state.error,
+      );
+      const fallbackSessionId = await this.spawnSession(resumeCwd, agentType, {
         localSessionId: conversationId,
         resumeAgentSessionId: remoteSessionId,
         conversationTitle: convo.title,
         restoredMessages,
         bootstrapPromptContext: pendingBootstrapPromptContext,
       });
-
-      // Legacy Claude conversations can reference session IDs that no longer
-      // exist on disk. In that case, fall back to a fresh session for the same
-      // persisted conversation instead of failing hard.
-      if (!sessionId && agentType === "claude-code") {
-        console.warn(
-          "[AgentStore] Claude resume failed, starting a fresh session for conversation",
-          conversationId,
-          state.error,
+      if (fallbackSessionId) {
+        // Clear error state and remove stale error messages left by the
+        // failed first spawn. Without this, "Claude Code request failed"
+        // banners persist even though the retry session is healthy.
+        setState("error", null);
+        setState("sessions", fallbackSessionId, "error", undefined);
+        setState("sessions", fallbackSessionId, "messages", (msgs) =>
+          msgs.filter((m) => m.type !== "error"),
         );
-        const fallbackSessionId = await this.spawnSession(
-          resumeCwd,
-          agentType,
-          {
-            localSessionId: conversationId,
-            resumeAgentSessionId: remoteSessionId,
-            conversationTitle: convo.title,
-            restoredMessages,
-            bootstrapPromptContext: pendingBootstrapPromptContext,
-          },
-        );
-        if (fallbackSessionId) {
-          // Clear error state and remove stale error messages left by the
-          // failed first spawn. Without this, "Claude Code request failed"
-          // banners persist even though the retry session is healthy.
-          setState("error", null);
-          setState("sessions", fallbackSessionId, "error", undefined);
-          setState("sessions", fallbackSessionId, "messages", (msgs) =>
-            msgs.filter((m) => m.type !== "error"),
-          );
-          clearSpawnFailures(conversationId);
-          void this.refreshRecentAgentConversations(200).catch(() => {});
-        } else {
-          recordSpawnFailure(conversationId);
-        }
-        return fallbackSessionId;
-      }
-
-      if (sessionId) {
-        if (!pendingBootstrapPromptContext) {
-          clearLegacyAgentTranscript(conversationId);
-        }
         clearSpawnFailures(conversationId);
         void this.refreshRecentAgentConversations(200).catch(() => {});
       } else {
         recordSpawnFailure(conversationId);
       }
-      return sessionId;
+      return fallbackSessionId;
+    }
+
+    if (sessionId) {
+      if (!pendingBootstrapPromptContext) {
+        clearLegacyAgentTranscript(conversationId);
+      }
+      clearSpawnFailures(conversationId);
+      void this.refreshRecentAgentConversations(200).catch(() => {});
+    } else {
+      recordSpawnFailure(conversationId);
+    }
+    return sessionId;
   },
   /**
    * Resume a remote agent session from the provider's stored session list.
@@ -2952,6 +2967,29 @@ Summary:`;
           "ready" as SessionStatus,
         );
 
+        // Drain the prompt queue for this session. This runs in the store
+        // regardless of which thread the UI is showing, so background threads
+        // don't stall. Guard against compaction — the session will be
+        // terminated and re-spawned, so sendPrompt would fail.
+        if (!isHistoryReplay && !state.sessions[sessionId]?.isCompacting) {
+          const queue = state.sessions[sessionId]?.pendingPrompts ?? [];
+          if (queue.length > 0) {
+            const [nextPrompt, ...remaining] = queue;
+            setState("sessions", sessionId, "pendingPrompts", remaining);
+            console.log(
+              "[AgentStore] Draining queued prompt for session",
+              sessionId,
+              "remaining:",
+              remaining.length,
+            );
+            // Dispatch asynchronously so the promptComplete handler finishes
+            // before the next sendPrompt begins.
+            setTimeout(() => {
+              void this.sendPrompt(nextPrompt, undefined, undefined, sessionId);
+            }, 100);
+          }
+        }
+
         // Auto-compact check: trigger compaction at 85% of context window,
         // or at 200 messages for agents that don't report token usage at all.
         if (!isHistoryReplay && !state.sessions[sessionId]?.isCompacting) {
@@ -3907,10 +3945,10 @@ Summary:`;
 };
 
 export type {
-  AgentType,
-  SessionStatus,
-  AgentSessionInfo,
   AgentInfo,
+  AgentSessionInfo,
+  AgentType,
   DiffEvent,
   DiffProposalEvent,
+  SessionStatus,
 };


### PR DESCRIPTION
Fixes #1383

Queued messages stalled when their thread was out of focus. The drain trigger was a SolidJS `createEffect` inside `AgentChat` — unmounting the component froze the queue indefinitely.

### What changed

| Before | After |
|--------|-------|
| Queue in component-level `threadQueues` Map | Queue in `ActiveSession.pendingPrompts[]` in the store |
| Drain via `createEffect(on(isReady, ...))` — only fires when component renders | Drain via `promptComplete` handler in agent store — fires for ALL sessions |
| 141 lines of component queue logic | 3 store methods: `enqueuePrompt`, `getPendingPrompts`, `clearPromptQueue` |

### Queue drain flow (5 queued messages, thread out of focus)

```
promptComplete → ready → drain #1 → prompting →
promptComplete → ready → drain #2 → prompting →
... (continues until queue empty)
```

Each `promptComplete` pops the next message from `pendingPrompts` and dispatches via `sendPrompt`. Works regardless of which thread the UI shows.

### Files

- `agent.store.ts` — `pendingPrompts` field + drain in `promptComplete` + 3 queue methods
- `AgentChat.tsx` — removed `threadQueues`, `queueDraining`, `processNextQueuedMessage`, `createEffect(on(isReady))`. Enqueue/display now reads from store.
- `ChatContent.tsx` — drain guards against conversation switch mid-flight

263 tests pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com