### PR TITLE
fix: add R2 to CSP + increase skills refresh to 5 min (#1385)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc://localhost http://ipc.localhost ws://127.0.0.1:* http://127.0.0.1:* https://api.serendb.com https://api.github.com https://raw.githubusercontent.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai https://*.thirdweb.com https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org https://*.base.org; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' asset: https: data:; font-src 'self' https://fonts.gstatic.com; frame-src http://127.0.0.1:* http://localhost:*",
+      "csp": "default-src 'self'; connect-src 'self' ipc://localhost http://ipc.localhost ws://127.0.0.1:* http://127.0.0.1:* https://api.serendb.com https://api.github.com https://raw.githubusercontent.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai https://*.thirdweb.com https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org https://*.base.org https://pub-714fe894394345a0a8a102fbac2b208f.r2.dev; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' asset: https: data:; font-src 'self' https://fonts.gstatic.com; frame-src http://127.0.0.1:* http://localhost:*",
       "assetProtocol": {
         "enable": true,
         "scope": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,11 +109,11 @@ function App() {
   });
 
   // Periodically refresh available skills so newly published skills appear without restart.
-  // Base interval: 60 min + up to 5 min jitter to avoid thundering herd across instances.
-  const SKILLS_REFRESH_BASE = 60 * 60 * 1000;
+  // Base interval: 5 min + up to 30s jitter. R2 serves the index with zero rate limits.
+  const SKILLS_REFRESH_BASE = 5 * 60 * 1000;
   const skillsRefreshTimer = setInterval(
     () => void skillsStore.refresh(),
-    SKILLS_REFRESH_BASE + Math.random() * 5 * 60 * 1000,
+    SKILLS_REFRESH_BASE + Math.random() * 30 * 1000,
   );
 
   onCleanup(() => {


### PR DESCRIPTION
- Add R2 public URL to Tauri CSP connect-src so skills index fetch works
- Increase skills refresh interval from 60min to 5min (R2 has no rate limits)
Closes #1385