### PR TITLE
fix: build publisher context from catalog inventory, not just gateway tools (#1387)

### DIFF
--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -19,7 +19,10 @@ import type {
   ToolResult,
 } from "@/lib/providers/types";
 import { executeTools, getAllTools } from "@/lib/tools";
-import { getGatewayTools } from "@/services/mcp-gateway";
+import {
+  getCallablePublisherSlugs,
+  getGatewayTools,
+} from "@/services/mcp-gateway";
 import { storeAssistantResponse } from "@/services/memory";
 import { authStore } from "@/stores/auth.store";
 import { conversationStore } from "@/stores/conversation.store";
@@ -347,29 +350,39 @@ export async function* streamMessageWithTools(
   // Build initial messages array
   const messages: ChatMessageWithTools[] = [];
 
-  // Build Seren MCP publishers context dynamically based on active toolset
-  // This ensures the LLM only knows about publishers that are actually available
+  // Build Seren MCP publishers context dynamically based on active toolset.
+  // Uses the canonical publisher inventory (all callable publishers) as the
+  // source of truth, not just publishers that expose first-class MCP tools.
+  // This prevents false "not available" responses for publishers like Gmail
+  // that are callable via call_publisher but don't appear in gateway tools.
   const buildPublishersContext = (): string => {
-    const allGatewayTools = getGatewayTools();
+    // Canonical source: all publishers from list_agent_publishers
+    const allPublisherSlugs = getCallablePublisherSlugs();
+
+    // Also include publishers derived from gateway tools (belt and suspenders)
+    const toolPublishers = [
+      ...new Set(getGatewayTools().map((t) => t.publisher)),
+    ];
+
+    // Merge both sources, deduplicate
+    const allSlugs = [...new Set([...allPublisherSlugs, ...toolPublishers])];
+
+    // Filter by active toolset if one is selected
     const activePublishers = getActiveToolsetPublishers();
-
-    // Filter tools by active toolset (same logic as definitions.ts)
-    const availableTools = activePublishers
-      ? allGatewayTools.filter((t) => activePublishers.includes(t.publisher))
-      : allGatewayTools;
-
-    // Get unique publisher slugs from available tools
-    const publishers = [...new Set(availableTools.map((t) => t.publisher))];
+    const publishers = activePublishers
+      ? allSlugs.filter((slug) => activePublishers.includes(slug))
+      : allSlugs;
 
     if (publishers.length === 0) {
-      return ""; // No publishers available, don't add context
+      return "";
     }
 
-    const publisherList = publishers.join(", ");
+    const publisherList = publishers.sort().join(", ");
     return (
       "\n\nIMPORTANT - Available Seren MCP Publishers:\n" +
       "This application connects to Seren MCP publishers - third-party data services. " +
       `You have access to the following publishers: ${publisherList}. ` +
+      "These publishers are callable via the call_publisher tool. " +
       "ONLY use tools from these publishers. Do NOT suggest or attempt to use publishers that are not in this list. " +
       "When users mention publisher names, interpret them in the Seren MCP context unless they explicitly ask about the technology/framework itself."
     );

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -75,6 +75,11 @@ let lastFetchedAt: number | null = null;
 let loadingPromise: Promise<void> | null = null;
 let isConnected = false;
 
+// All publisher slugs from the last list_agent_publishers call.
+// This is the canonical source of callable publishers — includes publishers
+// that are reachable via call_publisher but don't expose first-class MCP tools.
+let cachedPublisherSlugs: string[] = [];
+
 // Track first-class MCP tools from the gateway's list_tools() response.
 // These tools can be called directly via MCP protocol, bypassing call_publisher.
 // Key: "publisher:toolName", Value: original MCP tool name (e.g., "mcp__mcp-time__get_current_time").
@@ -159,6 +164,10 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
   }
 
   if (publisherSlugs.length === 0) return [];
+
+  // Cache the full publisher list — this is the canonical source of callable
+  // publishers, regardless of whether they expose first-class MCP tools.
+  cachedPublisherSlugs = publisherSlugs;
 
   // For each MCP publisher, query its tools
   const allTools: GatewayTool[] = [];
@@ -342,6 +351,15 @@ export async function initializeGateway(): Promise<void> {
  */
 export function getGatewayTools(): GatewayTool[] {
   return cachedTools;
+}
+
+/**
+ * Get all callable publisher slugs from the last discovery.
+ * This is the canonical source of publisher availability — includes publishers
+ * reachable via call_publisher even if they expose no first-class MCP tools.
+ */
+export function getCallablePublisherSlugs(): string[] {
+  return cachedPublisherSlugs;
 }
 
 /**

--- a/tests/unit/publisher-context.test.ts
+++ b/tests/unit/publisher-context.test.ts
@@ -1,0 +1,34 @@
+// ABOUTME: Tests that publisher availability context includes all callable publishers.
+// ABOUTME: Prevents regression where publishers without MCP tools were omitted from context.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("publisher context construction", () => {
+  const chatSource = readFileSync(resolve("src/services/chat.ts"), "utf-8");
+  const gatewaySource = readFileSync(
+    resolve("src/services/mcp-gateway.ts"),
+    "utf-8",
+  );
+
+  it("builds publisher list from callable slugs, not just gateway tools", () => {
+    // buildPublishersContext must use getCallablePublisherSlugs as the
+    // canonical source — not derive publishers solely from getGatewayTools()
+    expect(chatSource).toContain("getCallablePublisherSlugs");
+  });
+
+  it("mcp-gateway caches publisher slugs from list_agent_publishers", () => {
+    // The full publisher slug list must be stored, not discarded after
+    // tool discovery. Publishers callable via call_publisher but without
+    // first-class MCP tools must still appear in the cached list.
+    expect(gatewaySource).toContain("cachedPublisherSlugs");
+    expect(gatewaySource).toContain("cachedPublisherSlugs = publisherSlugs");
+  });
+
+  it("exposes callable publisher slugs via getter", () => {
+    expect(gatewaySource).toContain(
+      "export function getCallablePublisherSlugs",
+    );
+  });
+});


### PR DESCRIPTION
Publishers like Gmail callable via call_publisher but without first-class MCP tools were omitted from model context, causing false not-available responses. Cache all slugs from list_agent_publishers, expose getCallablePublisherSlugs(), merge into buildPublishersContext. Closes #1387