### PR TITLE
fix: add R2 URL to Tauri HTTP capability scope (#1390)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -30,7 +30,8 @@
         { "url": "https://generativelanguage.googleapis.com/**" },
         { "url": "https://oauth2.googleapis.com/**" },
         { "url": "https://api.github.com/**" },
-        { "url": "https://raw.githubusercontent.com/**" }
+        { "url": "https://raw.githubusercontent.com/**" },
+        { "url": "https://pub-714fe894394345a0a8a102fbac2b208f.r2.dev/**" }
       ]
     }
   ]


### PR DESCRIPTION
CSP fix (#1386) only covered browser CSP. Tauri v2 HTTP plugin has a separate capability scope in capabilities/default.json. R2 skills index was blocked on all platforms. One-line fix. Closes #1390