### PR TITLE
fix: kill full process tree on Windows to prevent node.exe file locks

### DIFF
--- a/src-tauri/nsis/installer-hooks.nsh
+++ b/src-tauri/nsis/installer-hooks.nsh
@@ -7,13 +7,35 @@
   Pop $0
   Pop $1
   ; Brief pause for child processes to exit
-  Sleep 1000
-  ; Kill orphaned node.exe from the embedded runtime. The /T flag above misses
-  ; node.exe processes that were detached or orphaned by a provider-runtime crash.
-  ; Target only Seren's embedded node — not the user's own Node.js processes.
-  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "Get-Process node -EA 0 | ? { $_.Path -and $_.Path -match ''SerenDesktop'' } | Stop-Process -Force -EA 0"'
+  Sleep 1500
+
+  ; Kill ALL node.exe whose executable path lives under the SerenDesktop
+  ; install directory. Uses Get-CimInstance (WMI) which returns the full
+  ; ExecutablePath — more reliable than Get-Process which can miss
+  ; processes running under different security contexts.
+  ; This catches: embedded node.exe, claude CLI node.exe spawned from
+  ; the embedded runtime, and any other node child still holding a lock.
+  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "\
+    Get-CimInstance Win32_Process -Filter \"Name=''node.exe''\" -EA 0 | \
+      Where-Object { $_.ExecutablePath -and $_.ExecutablePath -match ''SerenDesktop'' } | \
+      ForEach-Object { Stop-Process -Id $_.ProcessId -Force -EA 0 }"'
   Pop $0
   Pop $1
-  ; Allow OS to release file handles after process termination
-  Sleep 2000
+
+  ; Also kill node.exe that were spawned BY the embedded runtime but live
+  ; outside SerenDesktop (e.g. globally-installed claude at ~/.local/bin).
+  ; Match by parent: any node.exe whose parent command line contains SerenDesktop.
+  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "\
+    Get-CimInstance Win32_Process -Filter \"Name=''node.exe''\" -EA 0 | \
+      Where-Object { \
+        $ppid = $_.ParentProcessId; \
+        $parent = Get-CimInstance Win32_Process -Filter \"ProcessId=$ppid\" -EA 0; \
+        $parent -and $parent.ExecutablePath -and $parent.ExecutablePath -match ''SerenDesktop'' \
+      } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -EA 0 }"'
+  Pop $0
+  Pop $1
+
+  ; Allow OS to release file handles after process termination.
+  ; 3 seconds — Windows can take longer than Linux to release locks.
+  Sleep 3000
 !macroend

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -177,6 +177,18 @@ impl ProviderRuntimeState {
                     unsafe {
                         libc::kill(pid as i32, libc::SIGKILL);
                     }
+                    #[cfg(windows)]
+                    {
+                        // Use taskkill /T to kill the entire process tree.
+                        // kill_on_drop only terminates the immediate child, leaving
+                        // grandchild node.exe processes (claude CLI) orphaned and
+                        // holding file locks that block the next NSIS install.
+                        use std::os::windows::process::CommandExt;
+                        let _ = std::process::Command::new("taskkill")
+                            .args(["/F", "/T", "/PID", &pid.to_string()])
+                            .creation_flags(0x08000000) // CREATE_NO_WINDOW
+                            .status();
+                    }
                 }
             }
             *guard = None;


### PR DESCRIPTION
Fixes #1389

NSIS installer fails with 'Error opening file for writing' on the embedded node.exe because orphaned grandchild processes hold file locks.

### Two fixes

**1. Rust `kill_sync()`** — `provider_runtime.rs`

Uses `taskkill /F /T /PID` on Windows to kill the entire process tree. Previously, `kill_on_drop` only terminated the immediate child (provider-runtime node.exe), leaving grandchild node.exe processes (claude CLI) orphaned with file locks.

**2. NSIS installer hook** — `installer-hooks.nsh`

- Replaced `Get-Process node` with `Get-CimInstance Win32_Process` (WMI) — reliably returns full `ExecutablePath` across security contexts
- Added parent-process matching: kills node.exe whose *parent* path matches `SerenDesktop` (catches claude CLI spawned by the embedded runtime but living at `~/.local/bin`)
- Added `-ExecutionPolicy Bypass` to PowerShell calls
- Increased handle release sleep from 2s to 3s

### Verified
- 266 frontend tests pass
- Rust `cargo check` passes (Windows block is `#[cfg(windows)]`)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com