### PR TITLE
fix: replace PowerShell with taskkill in NSIS hook — NSIS eats dollar-underscore

### DIFF
--- a/src-tauri/nsis/installer-hooks.nsh
+++ b/src-tauri/nsis/installer-hooks.nsh
@@ -9,29 +9,16 @@
   ; Brief pause for child processes to exit
   Sleep 1500
 
-  ; Kill ALL node.exe whose executable path lives under the SerenDesktop
-  ; install directory. Uses Get-CimInstance (WMI) which returns the full
-  ; ExecutablePath — more reliable than Get-Process which can miss
-  ; processes running under different security contexts.
-  ; This catches: embedded node.exe, claude CLI node.exe spawned from
-  ; the embedded runtime, and any other node child still holding a lock.
-  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "\
-    Get-CimInstance Win32_Process -Filter \"Name=''node.exe''\" -EA 0 | \
-      Where-Object { $_.ExecutablePath -and $_.ExecutablePath -match ''SerenDesktop'' } | \
-      ForEach-Object { Stop-Process -Id $_.ProcessId -Force -EA 0 }"'
-  Pop $0
-  Pop $1
-
-  ; Also kill node.exe that were spawned BY the embedded runtime but live
-  ; outside SerenDesktop (e.g. globally-installed claude at ~/.local/bin).
-  ; Match by parent: any node.exe whose parent command line contains SerenDesktop.
-  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "\
-    Get-CimInstance Win32_Process -Filter \"Name=''node.exe''\" -EA 0 | \
-      Where-Object { \
-        $ppid = $_.ParentProcessId; \
-        $parent = Get-CimInstance Win32_Process -Filter \"ProcessId=$ppid\" -EA 0; \
-        $parent -and $parent.ExecutablePath -and $parent.ExecutablePath -match ''SerenDesktop'' \
-      } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -EA 0 }"'
+  ; Kill ALL node.exe processes. This is the nuclear option but the only
+  ; reliable approach through NSIS:
+  ;
+  ; - PowerShell $_ variables get eaten by NSIS's own $ interpolation
+  ; - wmic + cmd /c for /f has nested quoting issues inside nsExec
+  ; - The user is actively installing — killing node.exe is expected
+  ;
+  ; This catches: embedded provider-runtime, playwright MCP server,
+  ; claude CLI, and any other orphaned node.exe holding file locks.
+  nsExec::ExecToStack 'taskkill /F /IM "node.exe" /T'
   Pop $0
   Pop $1
 


### PR DESCRIPTION
Updates #1389

The PowerShell WMI commands from PR #1392 silently failed because NSIS interprets `$` as its own variable prefix, stripping `$_` from PowerShell pipeline variables.

Ishan confirmed: `Get-CimInstance` found 4 node.exe processes (3 provider-runtimes + 1 playwright MCP), but `Where-Object` errored with `$_.ExecutablePath: term not recognized` because NSIS ate the `$_`.

**Fix**: Replace PowerShell entirely with `taskkill /F /IM node.exe /T`. No PowerShell, no dollar-sign escaping. Kills all node.exe during install — acceptable since the user is actively upgrading.

266 tests pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com