### PR TITLE
revert: undo MCP header env var resolve (#1394)

### DIFF
--- a/bin/browser-local/mcp-config.mjs
+++ b/bin/browser-local/mcp-config.mjs
@@ -89,7 +89,7 @@ function encodeTomlValue(value) {
   return '""';
 }
 
-function buildClaudeMcpConfig(servers, childEnv) {
+function buildClaudeMcpConfig(servers) {
   if (servers.length === 0) {
     return null;
   }
@@ -97,20 +97,10 @@ function buildClaudeMcpConfig(servers, childEnv) {
   const mcpServers = {};
   for (const server of servers) {
     if (server.type === "http") {
-      // Resolve env var placeholders in headers to actual values.
-      // Claude CLI may not expand ${VAR} in MCP config headers on all
-      // platforms. Use the real value from childEnv to guarantee it works.
-      const resolvedHeaders = {};
-      for (const [key, value] of Object.entries(server.headers ?? {})) {
-        resolvedHeaders[key] =
-          typeof value === "string"
-            ? value.replace(/\$\{(\w+)\}/g, (_, varName) => childEnv[varName] ?? process.env[varName] ?? "")
-            : value;
-      }
       mcpServers[server.name] = {
         type: "http",
         url: server.url,
-        headers: resolvedHeaders,
+        headers: server.headers ?? {},
       };
       continue;
     }
@@ -161,14 +151,12 @@ export function buildProviderMcpConfig({ apiKey, mcpServers } = {}) {
       .filter(Boolean)),
   ].filter(Boolean));
 
-  const childEnv =
-    trimToNull(apiKey) == null
-      ? {}
-      : { [SEREN_MCP_API_KEY_ENV]: trimToNull(apiKey) };
-
   return {
-    childEnv,
-    claudeMcpConfigJson: buildClaudeMcpConfig(normalizedServers, childEnv),
+    childEnv:
+      trimToNull(apiKey) == null
+        ? {}
+        : { [SEREN_MCP_API_KEY_ENV]: trimToNull(apiKey) },
+    claudeMcpConfigJson: buildClaudeMcpConfig(normalizedServers),
     codexMcpConfigOverride: buildCodexMcpOverride(normalizedServers),
   };
 }


### PR DESCRIPTION
Wrong diagnosis — the bug was in Seren Agent chat (orchestrator), not Claude Agent (provider-runtime). Reverting the MCP config change.