### PR TITLE
fix: pin core Seren gateway tools so BM25 never drops them (#1397)

### DIFF
--- a/src-tauri/src/orchestrator/tool_relevance.rs
+++ b/src-tauri/src/orchestrator/tool_relevance.rs
@@ -42,6 +42,16 @@ const PINNED_TOOL_NAMES: &[&str] = &[
     "create_directory",
     "seren_web_fetch",
     "execute_command",
+    // Core Seren publisher and database tools — without these, skills that
+    // use SerenDB (run_sql, create_project, etc.) or publishers (call_publisher)
+    // silently fail because BM25 drops them for non-technical prompts.
+    "gateway__call_publisher",
+    "gateway__run_sql",
+    "gateway__run_sql_transaction",
+    "gateway__list_projects",
+    "gateway__create_project",
+    "gateway__list_databases",
+    "gateway__create_database",
 ];
 
 /// Model-aware tool cap: returns (max_tools, token_budget) for the given model.
@@ -760,14 +770,23 @@ mod tests {
             "Execute a shell command on the user machine",
         ));
 
-        // Fill with 131 gateway tools so total exceeds budget
-        for i in 0..65 {
+        // Add pinned gateway tools so they appear in the output
+        tools.push(make_tool("gateway__call_publisher", "Call a Seren publisher"));
+        tools.push(make_tool("gateway__run_sql", "Execute SQL on SerenDB"));
+        tools.push(make_tool("gateway__run_sql_transaction", "Execute SQL transaction on SerenDB"));
+        tools.push(make_tool("gateway__list_projects", "List Seren projects"));
+        tools.push(make_tool("gateway__create_project", "Create a Seren project"));
+        tools.push(make_tool("gateway__list_databases", "List Seren databases"));
+        tools.push(make_tool("gateway__create_database", "Create a Seren database"));
+
+        // Fill with gateway tools so total exceeds budget
+        for i in 0..62 {
             tools.push(make_tool(
                 &format!("gateway__polymarket-data__action_{i}"),
                 "Polymarket prediction market data",
             ));
         }
-        for i in 0..66 {
+        for i in 0..62 {
             tools.push(make_tool(
                 &format!("gateway__firecrawl-serenai__scrape_{i}"),
                 "Web scraping and crawling",


### PR DESCRIPTION
Skills using SerenDB failed because BM25 dropped run_sql/call_publisher for non-technical prompts. Pin 7 core Seren gateway tools as always-included. 19 Rust tests pass. Closes #1397