### PR TITLE
feat: support display-name frontmatter in skills (#1404)

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -734,7 +734,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                         <div class="flex items-center gap-2 px-2.5 py-2 mb-1 rounded-md hover:bg-surface-2 transition-colors">
                           <div class="flex-1 min-w-0">
                             <div class="text-[13px] font-medium text-foreground truncate">
-                              {skill.name}
+                              {skill.displayName ?? skill.name}
                             </div>
                             <Show when={skill.description}>
                               <div class="text-[11px] text-muted-foreground mt-0.5 line-clamp-1">

--- a/src/lib/skills/parser.ts
+++ b/src/lib/skills/parser.ts
@@ -155,6 +155,9 @@ function parseYamlFrontmatter(yaml: string): SkillMetadata {
         case "slug":
           metadata.slug = cleanValue;
           break;
+        case "display-name":
+          metadata.displayName = cleanValue;
+          break;
         case "description":
           metadata.description = cleanValue;
           break;

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -18,6 +18,8 @@ export type SkillSource =
  */
 export interface SkillMetadata {
   name: string;
+  /** Human-readable display name from frontmatter. */
+  displayName?: string;
   description: string;
   slug?: string;
   version?: string;
@@ -38,8 +40,10 @@ export interface Skill {
   id: string;
   /** URL-friendly slug (e.g., "commit-message") */
   slug: string;
-  /** Display name */
+  /** Slug-based name (used for lookups) */
   name: string;
+  /** Human-readable display name from frontmatter */
+  displayName?: string;
   /** Short description */
   description: string;
   /** Where this skill comes from */
@@ -134,6 +138,8 @@ export interface InstalledSkill extends Skill {
 export interface SkillIndexEntry {
   slug: string;
   name: string;
+  /** Human-readable display name from SKILL.md frontmatter. */
+  displayName?: string;
   description: string;
   source: SkillSource;
   sourceUrl: string;

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -100,6 +100,7 @@ function indexEntryToSkill(entry: SkillIndexEntry): Skill {
     id: `${entry.source}:${entry.slug}`,
     slug: entry.slug,
     name: entry.name,
+    displayName: entry.displayName,
     description: entry.description,
     source: entry.source,
     sourceUrl: entry.sourceUrl,
@@ -116,6 +117,7 @@ function skillToIndexEntry(skill: Skill): SkillIndexEntry {
   return {
     slug: skill.slug,
     name: skill.name,
+    displayName: skill.displayName,
     description: skill.description,
     source: skill.source,
     sourceUrl: skill.sourceUrl ?? "",
@@ -163,6 +165,7 @@ async function fetchSkillFromRepo(path: string): Promise<Skill | null> {
     id: `serenorg:${slug}`,
     slug,
     name: resolveSkillDisplayName(parsed, slug),
+    displayName: parsed.metadata.displayName,
     description: parsed.metadata.description || "Install this skill to add it.",
     source: "serenorg" as SkillSource,
     sourceUrl,


### PR DESCRIPTION
Add displayName to types, parser, index conversion, and sidebar rendering. Shows human-readable names instead of slugs. Closes #1404