### PR TITLE
fix: add auth context to system prompt so LLM never asks for API keys

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -264,7 +264,14 @@ impl ChatModelWorker {
         // The tool inventory ensures the model knows about ALL connected services,
         // not just the skills matched by the classifier.
         let tool_inventory = Self::build_tool_inventory(tools);
-        let mut system_parts = vec!["You are a helpful AI assistant.".to_string()];
+        let mut system_parts = vec![
+            "You are a helpful AI assistant running inside Seren Desktop. \
+             The user is already authenticated and all tool calls are pre-authenticated \
+             through the Seren Gateway — you do not need API keys, tokens, or environment \
+             variables to use any of your tools. Never ask the user to configure credentials \
+             or look for keys like SEREN_API_KEY. Just call the tools directly."
+                .to_string(),
+        ];
         if !tool_inventory.is_empty() {
             system_parts.push(tool_inventory);
         }
@@ -2029,5 +2036,31 @@ mod tests {
         assert!(system_msg.contains("gmail"), "tool inventory must be present");
         assert!(system_msg.contains("Active Skills"), "skill content must be present");
         assert!(system_msg.contains("Google Docs"), "skill details must be present");
+    }
+
+    #[test]
+    fn system_prompt_includes_auth_context() {
+        let worker = ChatModelWorker::new();
+        let routing = RoutingDecision {
+            worker_type: super::super::types::WorkerType::ChatModel,
+            model_id: "anthropic/claude-sonnet-4".to_string(),
+            delegation: super::super::types::DelegationType::InLoop,
+            reason: "General chat".to_string(),
+            selected_skills: vec![],
+            publisher_slug: None,
+            reasoning_effort: None,
+        };
+
+        let body = worker.build_request_body("Hi", &[], &routing, "", &[], &[]);
+        let system_msg = body["messages"][0]["content"].as_str().unwrap();
+
+        assert!(
+            system_msg.contains("pre-authenticated"),
+            "system prompt must tell model that tools are pre-authenticated"
+        );
+        assert!(
+            system_msg.contains("SEREN_API_KEY"),
+            "system prompt must explicitly mention SEREN_API_KEY so model never asks for it"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #1406
- The system prompt now tells the LLM that all tool calls are pre-authenticated through the Seren Gateway
- The model will no longer try to read SEREN_API_KEY from the environment or ask users to configure credentials
- Added regression test system_prompt_includes_auth_context

## Root Cause

build_request_body() set the system prompt to "You are a helpful AI assistant" with no mention of authentication. When the LLM saw Seren-prefixed tools, it assumed credentials were needed, called execute_command to read $SEREN_API_KEY, found nothing, and told the user it could not access Seren services.

## Test plan

- [x] All 39 chat_model_worker::tests pass
- [x] New test verifies pre-authenticated and SEREN_API_KEY appear in system prompt
- [ ] Manual: start a conversation using a skill - model should use tools directly without mentioning API keys

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com