### PR TITLE
fix: add .local/bin to Windows Claude binary search paths

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -287,7 +287,9 @@ function resolveInstalledClaudeBinary() {
     const appData = process.env.APPDATA ?? "";
     const nodeDir = path.dirname(process.execPath);
     const candidates = [
-      // Native installer location
+      // Native installer location (install.ps1 puts it here)
+      path.join(home, ".local", "bin", "claude.exe"),
+      // Older native installer location
       path.join(home, ".claude", "bin", "claude.exe"),
       // Legacy / alternate location
       ...(appData ? [path.join(appData, "Claude", "claude.exe")] : []),


### PR DESCRIPTION
## Summary

- Fixes #1409
- Adds `%USERPROFILE%\.local\bin\claude.exe` as the first candidate in the Windows binary resolver
- This is where the official native installer (`install.ps1`) places the binary
- The macOS/Linux branch already checked `~/.local/bin` — this aligns Windows to match

## Root Cause

`resolveInstalledClaudeBinary()` checked `~/.claude/bin`, `%APPDATA%/Claude`, `%APPDATA%/npm`, and the embedded node dir — but not `~/.local/bin` on Windows. The native installer succeeded, the resolver missed the binary, and agent sessions failed to spawn.

## Test plan

- [ ] Manual: on Windows, install Claude Code via native installer, verify Seren Desktop finds the binary
- [ ] Verify macOS/Linux paths unchanged

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com