### PR TITLE
fix: cancel in-flight workers when stop is clicked during multi-task orchestration

### DIFF
--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -834,6 +834,7 @@ async fn execute_multi_task(
         );
 
         let mut handles = Vec::new();
+        let mut active_workers: Vec<Arc<dyn Worker>> = Vec::new();
 
         for subtask in layer {
             // Compute rankings for this subtask's task_type
@@ -899,8 +900,9 @@ async fn execute_multi_task(
             app.emit("orchestrator://transition", &transition)
                 .map_err(|e| format!("Failed to emit transition: {}", e))?;
 
-            // Spawn worker
+            // Spawn worker — keep Arc clone for cancellation
             let worker = create_worker(&routing, app, capabilities)?;
+            active_workers.push(Arc::clone(&worker));
             let subtask_prompt = subtask.prompt.clone();
             let subtask_id = subtask.id.clone();
             let worker_routing = routing.clone();
@@ -947,34 +949,53 @@ async fn execute_multi_task(
         let mut layer_fatal_error: Option<String> = None;
         let cancel_check = cancel_watch_rx.clone();
         for handle in handles {
-            // If already cancelled, abort this handle immediately
+            // If already cancelled, signal workers to stop and abort handles
             if *cancel_check.borrow() {
+                for w in &active_workers {
+                    let _ = w.cancel().await;
+                }
                 handle.abort();
                 continue;
             }
-            match handle.await {
-                Ok(Ok(Ok(()))) => {
-                    layer_had_success = true;
-                }
-                Ok(Ok(Err(e))) => {
-                    log::error!("[Orchestrator] Worker error in layer {}: {}", layer_idx, e);
-                    // Check for fatal errors that should abort the entire plan
-                    if e.contains("402 Payment Required")
-                        || e.contains("Insufficient prepaid balance")
-                    {
-                        layer_fatal_error = Some(e);
+            let mut cancel_for_handle = cancel_check.clone();
+            let cancelled_during_await = tokio::select! {
+                result = handle => {
+                    match result {
+                        Ok(Ok(Ok(()))) => {
+                            layer_had_success = true;
+                        }
+                        Ok(Ok(Err(e))) => {
+                            log::error!("[Orchestrator] Worker error in layer {}: {}", layer_idx, e);
+                            // Check for fatal errors that should abort the entire plan
+                            if e.contains("402 Payment Required")
+                                || e.contains("Insufficient prepaid balance")
+                            {
+                                layer_fatal_error = Some(e);
+                            }
+                        }
+                        Ok(Err(e)) => {
+                            log::error!(
+                                "[Orchestrator] Worker panicked in layer {}: {}",
+                                layer_idx,
+                                e
+                            );
+                        }
+                        Err(e) => {
+                            log::error!("[Orchestrator] Join error in layer {}: {}", layer_idx, e);
+                        }
                     }
+                    false
                 }
-                Ok(Err(e)) => {
-                    log::error!(
-                        "[Orchestrator] Worker panicked in layer {}: {}",
-                        layer_idx,
-                        e
-                    );
+                _ = cancel_for_handle.wait_for(|v| *v) => {
+                    log::info!("[Orchestrator] Cancel arrived during layer {} handle await", layer_idx);
+                    true
                 }
-                Err(e) => {
-                    log::error!("[Orchestrator] Join error in layer {}: {}", layer_idx, e);
+            };
+            if cancelled_during_await {
+                for w in &active_workers {
+                    let _ = w.cancel().await;
                 }
+                break;
             }
         }
 


### PR DESCRIPTION
## Summary

- Fixes #1411
- Multi-task orchestration now cancels in-flight workers when the user clicks Stop
- Each layer keeps `Arc<dyn Worker>` clones for cancellation
- Uses `tokio::select!` to race handle completion against the cancel signal
- Workers exit at their next `self.cancelled` check in the tool loop

## Root Cause

The `worker` was moved into `tokio::spawn` without keeping a reference. The cancel signal removed the session from the orchestrator map and broke the event forwarding loop, but the worker's `self.cancelled` flag was never set to `true`. Workers kept executing tools and making API calls after the user clicked Stop.

The single-task path correctly called `worker.cancel()` — the multi-task path did not.

## Test plan

- [x] 12 orchestrator::service::tests pass
- [x] 39 chat_model_worker::tests pass
- [x] `pnpm tauri dev` compiles and launches cleanly
- [ ] Manual: start a multi-subtask conversation, click Stop mid-stream, verify tool execution halts

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com