### PR TITLE
fix: write MCP config to temp file on Windows to avoid cmd.exe quote stripping

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -3,7 +3,7 @@
 
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, writeFileSync, unlinkSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -633,7 +633,17 @@ function buildClaudeArgs({
   ];
 
   if (mcpConfigJson) {
-    args.push("--mcp-config", mcpConfigJson, "--strict-mcp-config");
+    if (process.platform === "win32") {
+      // Windows spawns claude via cmd.exe (shell: true) which strips double
+      // quotes from arguments, mangling inline JSON. Write to a temp file
+      // and pass the path instead.
+      const tempPath = path.join(os.tmpdir(), `seren-mcp-${sessionId}.json`);
+      writeFileSync(tempPath, mcpConfigJson, "utf-8");
+      args.push("--mcp-config", tempPath, "--strict-mcp-config");
+      args._mcpTempFile = tempPath;
+    } else {
+      args.push("--mcp-config", mcpConfigJson, "--strict-mcp-config");
+    }
   }
 
   if (resumeSessionId) {
@@ -1392,15 +1402,16 @@ export function createClaudeRuntime({ emit }) {
     const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
     const claudeBin = resolveClaudeBinary();
     const extendedPath = buildExtendedPath();
+    const claudeArgs = buildClaudeArgs({
+      sessionId: remoteSessionId,
+      resumeSessionId: resumeAgentSessionId ?? null,
+      forkSession: false,
+      preferredModel: null,
+      mcpConfigJson: mcpConfig.claudeMcpConfigJson,
+    });
     const processHandle = spawn(
       claudeBin,
-      buildClaudeArgs({
-        sessionId: remoteSessionId,
-        resumeSessionId: resumeAgentSessionId ?? null,
-        forkSession: false,
-        preferredModel: null,
-        mcpConfigJson: mcpConfig.claudeMcpConfigJson,
-      }),
+      claudeArgs,
       {
         cwd,
         env: {
@@ -1412,6 +1423,14 @@ export function createClaudeRuntime({ emit }) {
         shell: process.platform === "win32",
       },
     );
+
+    // Clean up MCP config temp file when the process exits
+    if (claudeArgs._mcpTempFile) {
+      const tempFile = claudeArgs._mcpTempFile;
+      processHandle.on("exit", () => {
+        try { unlinkSync(tempFile); } catch {}
+      });
+    }
 
     // Catch spawn errors (e.g. ENOENT) to prevent crashing the provider runtime.
     processHandle.on("error", (spawnError) => {
@@ -1733,15 +1752,16 @@ export function createClaudeRuntime({ emit }) {
     const forkedAgentSessionId = randomUUID();
     const tempLocalSessionId = randomUUID();
     const claudeBin = resolveClaudeBinary();
+    const forkArgs = buildClaudeArgs({
+      sessionId: forkedAgentSessionId,
+      resumeSessionId: sourceAgentSessionId,
+      forkSession: true,
+      preferredModel: session.currentModelId,
+      mcpConfigJson: session.mcpConfigJson,
+    });
     const processHandle = spawn(
       claudeBin,
-      buildClaudeArgs({
-        sessionId: forkedAgentSessionId,
-        resumeSessionId: sourceAgentSessionId,
-        forkSession: true,
-        preferredModel: session.currentModelId,
-        mcpConfigJson: session.mcpConfigJson,
-      }),
+      forkArgs,
       {
         cwd: session.cwd,
         env: {
@@ -1753,6 +1773,14 @@ export function createClaudeRuntime({ emit }) {
         shell: process.platform === "win32",
       },
     );
+
+    // Clean up MCP config temp file when the process exits
+    if (forkArgs._mcpTempFile) {
+      const tempFile = forkArgs._mcpTempFile;
+      processHandle.on("exit", () => {
+        try { unlinkSync(tempFile); } catch {}
+      });
+    }
 
     // Catch spawn errors to prevent crashing the provider runtime.
     processHandle.on("error", (spawnError) => {


### PR DESCRIPTION
## Summary

- Fixes #1414
- On Windows, MCP config JSON is written to a temp file and the file path is passed to `--mcp-config` instead of inline JSON
- Temp file cleaned up on Claude process exit
- macOS/Linux behavior unchanged (still passes inline JSON)

## Root Cause

`spawn()` uses `shell: true` on Windows so `.cmd` wrappers work. But `cmd.exe` strips double quotes from arguments, turning valid JSON `{"mcpServers":...}` into `{mcpServers:...}`. Claude Code cannot parse this and treats it as a file path, crashing with code 1.

## Changes

- `buildClaudeArgs()`: on Windows, writes JSON to `os.tmpdir()/seren-mcp-<sessionId>.json` and passes the path
- Both spawn sites (normal + fork): register process exit handler to clean up temp file

## Test plan

- [ ] Manual: on Windows, start a Claude agent session — should connect with MCP servers
- [x] macOS/Linux: no behavior change (inline JSON still used)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com