### PR TITLE
fix: include built-in gateway tools (run_sql, call_publisher) in tool set (#1417)

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -113,11 +113,24 @@ function parsePublisherFromToolName(toolName: string): {
  * Convert MCP tool to GatewayTool format.
  * Stores the bare tool name (without mcp__publisher__ prefix) so that
  * callGatewayTool() can dispatch through call_publisher correctly.
- * Returns null for built-in gateway tools (no publisher prefix).
+ * Built-in gateway tools (no mcp__ prefix) are included under "seren-mcp".
  */
 function convertToGatewayTool(tool: McpTool): GatewayTool | null {
   const parsed = parsePublisherFromToolName(tool.name);
-  if (!parsed) return null;
+  if (!parsed) {
+    // Built-in gateway tool (e.g. call_publisher, run_sql, list_projects).
+    // These don't have the mcp__publisher__ prefix but are core SerenDB
+    // capabilities that must be available to the model.
+    return {
+      publisher: "seren-mcp",
+      publisherName: "Seren",
+      tool: {
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema as McpToolInfo["inputSchema"],
+      },
+    };
+  }
   return {
     publisher: parsed.publisher,
     publisherName: parsed.publisher,

--- a/tests/unit/builtin-gateway-tools.test.ts
+++ b/tests/unit/builtin-gateway-tools.test.ts
@@ -1,0 +1,23 @@
+// ABOUTME: Tests that built-in gateway tools are included, not silently dropped.
+// ABOUTME: Prevents regression where tools without mcp__ prefix were filtered out.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("built-in gateway tools inclusion", () => {
+  const gatewaySource = readFileSync(
+    resolve("src/services/mcp-gateway.ts"),
+    "utf-8",
+  );
+
+  it("convertToGatewayTool includes unprefixed tools under seren-mcp", () => {
+    // Built-in tools like call_publisher, run_sql don't have mcp__ prefix.
+    // convertToGatewayTool must NOT return null for them.
+    expect(gatewaySource).not.toContain(
+      "if (!parsed) return null",
+    );
+    // Instead, they should be assigned to seren-mcp publisher
+    expect(gatewaySource).toContain('publisher: "seren-mcp"');
+  });
+});


### PR DESCRIPTION
Built-in gateway tools had no mcp__ prefix, were silently dropped by convertToGatewayTool. Model never saw SerenDB tools. Include under seren-mcp publisher. Closes #1417