### PR TITLE
fix: index built-in gateway tools in nativeMcpTools for direct MCP dispatch (#1417)

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -314,6 +314,11 @@ export async function initializeGateway(): Promise<void> {
             `${parsed.publisher}:${parsed.originalName}`,
             tool.name,
           );
+        } else {
+          // Built-in gateway tools (no mcp__ prefix) — index under seren-mcp
+          // so callGatewayTool("seren-mcp", "list_projects", {}) dispatches
+          // directly via MCP protocol instead of through call_publisher.
+          nativeMcpTools.set(`seren-mcp:${tool.name}`, tool.name);
         }
       }
 


### PR DESCRIPTION
Built-in tools were in the tool set (#1418) but callGatewayTool routed them through call_publisher (failed: seren-mcp not a real publisher). Index unprefixed tools in nativeMcpTools so they dispatch directly via MCP.