### PR TITLE
refactor: treat SerenDB tools as first-class like file tools (#1422)

### DIFF
--- a/src-tauri/src/orchestrator/tool_relevance.rs
+++ b/src-tauri/src/orchestrator/tool_relevance.rs
@@ -42,17 +42,16 @@ const PINNED_TOOL_NAMES: &[&str] = &[
     "create_directory",
     "seren_web_fetch",
     "execute_command",
-    // Core Seren publisher and database tools — without these, skills that
-    // use SerenDB (run_sql, create_project, etc.) or publishers (call_publisher)
-    // silently fail because BM25 drops them for non-technical prompts.
-    // Tool names use the format gateway__{publisher}__{toolName}.
-    "gateway__seren-mcp__call_publisher",
-    "gateway__seren-mcp__run_sql",
-    "gateway__seren-mcp__run_sql_transaction",
-    "gateway__seren-mcp__list_projects",
-    "gateway__seren-mcp__create_project",
-    "gateway__seren-mcp__list_databases",
-    "gateway__seren-mcp__create_database",
+    // Built-in Seren tools use seren__ prefix (not gateway__) and bypass BM25
+    // entirely — they're always included like file tools. Pin them here as a
+    // safety net in case the tool set grows beyond the model budget.
+    "seren__call_publisher",
+    "seren__run_sql",
+    "seren__run_sql_transaction",
+    "seren__list_projects",
+    "seren__create_project",
+    "seren__list_databases",
+    "seren__create_database",
 ];
 
 /// Model-aware tool cap: returns (max_tools, token_budget) for the given model.
@@ -772,13 +771,14 @@ mod tests {
         ));
 
         // Add pinned gateway tools (must match gateway__{publisher}__{tool} format)
-        tools.push(make_tool("gateway__seren-mcp__call_publisher", "Call a Seren publisher"));
-        tools.push(make_tool("gateway__seren-mcp__run_sql", "Execute SQL on SerenDB"));
-        tools.push(make_tool("gateway__seren-mcp__run_sql_transaction", "Execute SQL transaction on SerenDB"));
-        tools.push(make_tool("gateway__seren-mcp__list_projects", "List Seren projects"));
-        tools.push(make_tool("gateway__seren-mcp__create_project", "Create a Seren project"));
-        tools.push(make_tool("gateway__seren-mcp__list_databases", "List Seren databases"));
-        tools.push(make_tool("gateway__seren-mcp__create_database", "Create a Seren database"));
+        // Built-in Seren tools use seren__ prefix (first-class, like file tools)
+        tools.push(make_tool("seren__call_publisher", "Call a Seren publisher"));
+        tools.push(make_tool("seren__run_sql", "Execute SQL on SerenDB"));
+        tools.push(make_tool("seren__run_sql_transaction", "Execute SQL transaction on SerenDB"));
+        tools.push(make_tool("seren__list_projects", "List Seren projects"));
+        tools.push(make_tool("seren__create_project", "Create a Seren project"));
+        tools.push(make_tool("seren__list_databases", "List Seren databases"));
+        tools.push(make_tool("seren__create_database", "Create a Seren database"));
 
         // Fill with gateway tools so total exceeds budget
         for i in 0..62 {

--- a/src/lib/tools/definitions.ts
+++ b/src/lib/tools/definitions.ts
@@ -7,7 +7,11 @@ import type {
   ToolDefinition,
   ToolParameterSchema,
 } from "@/lib/providers/types";
-import { type GatewayTool, getGatewayTools } from "@/services/mcp-gateway";
+import {
+  type GatewayTool,
+  getBuiltinToolSchemas,
+  getGatewayTools,
+} from "@/services/mcp-gateway";
 import { getActiveToolsetPublishers } from "@/stores/settings.store";
 
 /**
@@ -356,8 +360,28 @@ export function getAllTools(modelId?: string): ToolDefinition[] {
   const tools: ToolDefinition[] = [...FILE_TOOLS];
   const seenNames = new Set<string>(FILE_TOOLS.map((t) => t.function.name));
 
+  // Add built-in Seren tools (run_sql, list_projects, etc.) — always included,
+  // like file tools. These bypass BM25 and publisher dispatch entirely.
+  for (const schema of getBuiltinToolSchemas()) {
+    const name = `seren__${schema.name}`;
+    if (seenNames.has(name)) continue;
+    tools.push({
+      type: "function",
+      function: {
+        name,
+        description: schema.description || `Seren built-in: ${schema.name}`,
+        parameters: {
+          type: "object",
+          properties: schema.inputSchema?.properties ?? {},
+          required: schema.inputSchema?.required,
+        },
+      },
+    });
+    seenNames.add(name);
+  }
+
   // Add tools from connected local MCP servers (user-added) - high priority
-  // IMPORTANT: Exclude "seren-gateway" server as those tools are handled by getGatewayTools()
+  // IMPORTANT: Exclude "seren-gateway" server as those tools are handled separately
   const mcpTools = mcpClient.getAllTools();
   for (const { serverName, tool } of mcpTools) {
     // Skip seren-gateway tools - they're added via getGatewayTools() below

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -6,7 +6,11 @@ import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { mcpClient } from "@/lib/mcp/client";
 import type { ToolCall, ToolResult } from "@/lib/providers/types";
 import { type PaymentRequirements, parsePaymentRequirements } from "@/lib/x402";
-import { callGatewayTool, type PaymentProxyInfo } from "@/services/mcp-gateway";
+import {
+  callGatewayTool,
+  callSerenTool,
+  type PaymentProxyInfo,
+} from "@/services/mcp-gateway";
 import { x402Service } from "@/services/x402";
 import { getApprovalRequirement, requiresApproval } from "./approval-config";
 import { parseGatewayToolName, parseMcpToolName } from "./definitions";
@@ -260,6 +264,21 @@ export async function executeTool(toolCall: ToolCall): Promise<ToolResult> {
       string,
       unknown
     >;
+
+    // Check if this is a built-in Seren tool (seren__toolName)
+    if (name.startsWith("seren__")) {
+      const serenToolName = name.slice("seren__".length);
+      const response = await callSerenTool(serenToolName, args);
+      const content =
+        typeof response.result === "string"
+          ? response.result
+          : JSON.stringify(response.result);
+      return {
+        tool_call_id: toolCall.id,
+        content,
+        is_error: response.is_error,
+      };
+    }
 
     // Check if this is a Seren Gateway tool call (gateway__publisher__toolName)
     const gatewayInfo = parseGatewayToolName(name);

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -113,24 +113,12 @@ function parsePublisherFromToolName(toolName: string): {
  * Convert MCP tool to GatewayTool format.
  * Stores the bare tool name (without mcp__publisher__ prefix) so that
  * callGatewayTool() can dispatch through call_publisher correctly.
- * Built-in gateway tools (no mcp__ prefix) are included under "seren-mcp".
+ * Returns null for built-in gateway tools — those are handled separately
+ * as first-class SEREN_TOOLS in definitions.ts.
  */
 function convertToGatewayTool(tool: McpTool): GatewayTool | null {
   const parsed = parsePublisherFromToolName(tool.name);
-  if (!parsed) {
-    // Built-in gateway tool (e.g. call_publisher, run_sql, list_projects).
-    // These don't have the mcp__publisher__ prefix but are core SerenDB
-    // capabilities that must be available to the model.
-    return {
-      publisher: "seren-mcp",
-      publisherName: "Seren",
-      tool: {
-        name: tool.name,
-        description: tool.description,
-        inputSchema: tool.inputSchema as McpToolInfo["inputSchema"],
-      },
-    };
-  }
+  if (!parsed) return null;
   return {
     publisher: parsed.publisher,
     publisherName: parsed.publisher,
@@ -314,12 +302,9 @@ export async function initializeGateway(): Promise<void> {
             `${parsed.publisher}:${parsed.originalName}`,
             tool.name,
           );
-        } else {
-          // Built-in gateway tools (no mcp__ prefix) — index under seren-mcp
-          // so callGatewayTool("seren-mcp", "list_projects", {}) dispatches
-          // directly via MCP protocol instead of through call_publisher.
-          nativeMcpTools.set(`seren-mcp:${tool.name}`, tool.name);
         }
+        // Built-in tools (no mcp__ prefix) are handled by SEREN_TOOLS
+        // in definitions.ts with their own execution path.
       }
 
       // Convert publisher MCP tools to GatewayTool format (skip built-in tools)
@@ -364,11 +349,52 @@ export async function initializeGateway(): Promise<void> {
 }
 
 /**
- * Get all cached gateway tools.
+ * Get all cached gateway tools (publisher tools only, not built-in).
  * Returns empty array if not initialized.
  */
 export function getGatewayTools(): GatewayTool[] {
   return cachedTools;
+}
+
+/**
+ * Get tool schemas for built-in gateway tools (run_sql, list_projects, etc.).
+ * These are first-class Seren tools, not publisher tools.
+ */
+export function getBuiltinToolSchemas(): McpToolInfo[] {
+  const connection = mcpClient.getConnection(SEREN_MCP_SERVER_NAME);
+  if (!connection) return [];
+  return connection.tools
+    .filter((t) => !parsePublisherFromToolName(t.name))
+    .map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: (t.inputSchema ?? { type: "object", properties: {} }) as McpToolInfo["inputSchema"],
+    }));
+}
+
+/**
+ * Call a built-in Seren gateway tool directly via MCP protocol.
+ * No publisher dispatch — these are first-class tools on the gateway.
+ */
+export async function callSerenTool(
+  toolName: string,
+  args: Record<string, unknown>,
+) {
+  if (!isConnected) {
+    throw new McpGatewayError("MCP Gateway not connected", 503, MCP_GATEWAY_URL);
+  }
+  const startTime = Date.now();
+  const result = await mcpClient.callToolHttp(SEREN_MCP_SERVER_NAME, {
+    name: toolName,
+    arguments: args,
+  });
+  const executionTime = Date.now() - startTime;
+  return {
+    result: result.content,
+    is_error: result.isError ?? false,
+    execution_time_ms: executionTime,
+    response_bytes: JSON.stringify(result).length,
+  };
 }
 
 /**

--- a/tests/services/mcp-gateway.test.ts
+++ b/tests/services/mcp-gateway.test.ts
@@ -72,7 +72,7 @@ describe("MCP Gateway Caching", () => {
     // First init - should connect
     await initializeGateway();
     expect(connectMock).toHaveBeenCalledTimes(1);
-    expect(getGatewayTools()).toHaveLength(3);
+    expect(getGatewayTools()).toHaveLength(1);
     expect(isGatewayInitialized()).toBe(true);
 
     // Second init within TTL - should use cache
@@ -109,14 +109,14 @@ describe("MCP Gateway Caching", () => {
     } = await import("@/services/mcp-gateway");
 
     await initializeGateway();
-    expect(getGatewayTools()).toHaveLength(3);
+    expect(getGatewayTools()).toHaveLength(1);
 
     await resetGateway();
     expect(getGatewayTools()).toHaveLength(0);
     expect(isGatewayInitialized()).toBe(false);
   });
 
-  it("should include built-in tools under seren-mcp publisher (#1210, #1417)", async () => {
+  it("should exclude built-in tools from gateway pipeline (#1210, #1422)", async () => {
     const { initializeGateway, getGatewayTools } = await import(
       "@/services/mcp-gateway"
     );
@@ -124,18 +124,16 @@ describe("MCP Gateway Caching", () => {
     await initializeGateway();
     const tools = getGatewayTools();
 
-    // All 3 tools survive: prefixed publisher tool + 2 built-in under seren-mcp
-    expect(tools).toHaveLength(3);
+    // Only the mcp__test__test-tool should be in gateway tools.
+    // Built-in tools (list_mcp_tools, call_publisher) are now first-class
+    // SEREN_TOOLS handled by definitions.ts, not the gateway pipeline.
+    expect(tools).toHaveLength(1);
+    expect(tools[0].publisher).toBe("test");
+    expect(tools[0].tool.name).toBe("test-tool");
 
-    const prefixedTool = tools.find((t) => t.publisher === "test");
-    expect(prefixedTool).toBeDefined();
-    expect(prefixedTool!.tool.name).toBe("test-tool");
-
+    // No seren-mcp tools in gateway pipeline
     const serenTools = tools.filter((t) => t.publisher === "seren-mcp");
-    expect(serenTools).toHaveLength(2);
-    expect(serenTools.map((t) => t.tool.name).sort()).toEqual(
-      ["call_publisher", "list_mcp_tools"],
-    );
+    expect(serenTools).toHaveLength(0);
   });
 
   it("should discover publisher tools regardless of publisher_type (#1217)", async () => {

--- a/tests/unit/builtin-gateway-tools.test.ts
+++ b/tests/unit/builtin-gateway-tools.test.ts
@@ -1,23 +1,46 @@
-// ABOUTME: Tests that built-in gateway tools are included, not silently dropped.
-// ABOUTME: Prevents regression where tools without mcp__ prefix were filtered out.
+// ABOUTME: Tests that built-in Seren tools are first-class, separate from gateway publisher pipeline.
+// ABOUTME: Prevents regression where SerenDB tools were mixed into the publisher tool pipeline.
 
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-describe("built-in gateway tools inclusion", () => {
+describe("first-class Seren tools (#1422)", () => {
   const gatewaySource = readFileSync(
     resolve("src/services/mcp-gateway.ts"),
     "utf-8",
   );
+  const definitionsSource = readFileSync(
+    resolve("src/lib/tools/definitions.ts"),
+    "utf-8",
+  );
+  const executorSource = readFileSync(
+    resolve("src/lib/tools/executor.ts"),
+    "utf-8",
+  );
 
-  it("convertToGatewayTool includes unprefixed tools under seren-mcp", () => {
-    // Built-in tools like call_publisher, run_sql don't have mcp__ prefix.
-    // convertToGatewayTool must NOT return null for them.
-    expect(gatewaySource).not.toContain(
-      "if (!parsed) return null",
+  it("mcp-gateway excludes built-in tools from GatewayTool pipeline", () => {
+    // convertToGatewayTool must return null for unprefixed tools
+    expect(gatewaySource).toContain("if (!parsed) return null");
+  });
+
+  it("mcp-gateway exports getBuiltinToolSchemas for definitions.ts", () => {
+    expect(gatewaySource).toContain(
+      "export function getBuiltinToolSchemas",
     );
-    // Instead, they should be assigned to seren-mcp publisher
-    expect(gatewaySource).toContain('publisher: "seren-mcp"');
+  });
+
+  it("mcp-gateway exports callSerenTool for direct MCP dispatch", () => {
+    expect(gatewaySource).toContain("export async function callSerenTool");
+  });
+
+  it("definitions.ts includes built-in Seren tools with seren__ prefix", () => {
+    expect(definitionsSource).toContain("getBuiltinToolSchemas");
+    expect(definitionsSource).toContain('`seren__${schema.name}`');
+  });
+
+  it("executor.ts dispatches seren__ tools via callSerenTool", () => {
+    expect(executorSource).toContain("callSerenTool");
+    expect(executorSource).toContain('name.startsWith("seren__")');
   });
 });


### PR DESCRIPTION
Extract built-in SerenDB tools from the publisher pipeline into their own first-class pipeline (like FILE_TOOLS). seren__ prefix, direct MCP dispatch, always included, no BM25. Reverts #1418/#1421 publisher-pipeline approach. 14 JS + 19 Rust tests pass. Closes #1422