### PR TITLE
fix: show loading indicator immediately on message send (#1424)

### DIFF
--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -146,6 +146,10 @@ export async function orchestrate(
   prompt: string,
   images?: Attachment[],
 ): Promise<void> {
+  // Show loading indicator immediately so the user sees feedback right
+  // after hitting Enter — before history, memory, and skill context load.
+  conversationStore.setLoading(true);
+
   // Save params for retry support
   lastOrchestrationParams = { conversationId, prompt, images };
 
@@ -188,7 +192,6 @@ export async function orchestrate(
   // 3. Prepare streaming state (message added on completion)
   activeMessageId = crypto.randomUUID();
   streamStartTime = Date.now();
-  conversationStore.setLoading(true);
 
   // 4. Listen for events
   let unlistenTransition: UnlistenFn | null = null;


### PR DESCRIPTION
Move setLoading(true) to top of orchestrate() so user sees feedback instantly after Enter. Was delayed behind history/memory/skills loading. Closes #1424