### PR TITLE
feat: change default chat model to arcee-ai/trinity-large-thinking

### DIFF
--- a/src-tauri/src/orchestrator/router.rs
+++ b/src-tauri/src/orchestrator/router.rs
@@ -278,7 +278,7 @@ fn select_model(classification: &TaskClassification, capabilities: &UserCapabili
         .available_models
         .first()
         .cloned()
-        .unwrap_or_else(|| "anthropic/claude-sonnet-4".to_string())
+        .unwrap_or_else(|| "arcee-ai/trinity-large-thinking".to_string())
 }
 
 /// Resolve skill slugs from the classification to full SkillRef objects.

--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -106,11 +106,6 @@ const DEFAULT_MODELS: ProviderModel[] = [
     contextWindow: 1000000,
   },
   {
-    id: "anthropic/claude-opus-4.5",
-    name: "Claude Opus 4.5",
-    contextWindow: 200000,
-  },
-  {
     id: "anthropic/claude-sonnet-4",
     name: "Claude Sonnet 4",
     contextWindow: 200000,
@@ -121,34 +116,17 @@ const DEFAULT_MODELS: ProviderModel[] = [
     contextWindow: 200000,
   },
   // OpenAI
-  { id: "openai/gpt-5", name: "GPT-5", contextWindow: 128000 },
-  { id: "openai/gpt-4o", name: "GPT-4o", contextWindow: 128000 },
-  { id: "openai/gpt-4o-mini", name: "GPT-4o Mini", contextWindow: 128000 },
+  { id: "openai/gpt-5.4", name: "GPT-5.4", contextWindow: 128000 },
   // Google Gemini
   {
     id: "google/gemini-3.1-pro-preview",
     name: "Gemini 3.1 Pro",
     contextWindow: 1048576,
   },
+  // Arcee AI
   {
-    id: "google/gemini-3-flash-preview",
-    name: "Gemini 3 Flash",
-    contextWindow: 1048576,
-  },
-  {
-    id: "google/gemini-2.5-pro",
-    name: "Gemini 2.5 Pro",
-    contextWindow: 1000000,
-  },
-  {
-    id: "google/gemini-2.5-flash",
-    name: "Gemini 2.5 Flash",
-    contextWindow: 1000000,
-  },
-  // Zhipu AI
-  {
-    id: "thudm/glm-4",
-    name: "GLM-4",
+    id: "arcee-ai/trinity-large-thinking",
+    name: "Trinity Large Thinking",
     contextWindow: 128000,
   },
 ];

--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -145,8 +145,8 @@ const AGENT_TO_SEREN_MODEL: Array<[pattern: string, serenId: string]> = [
 
 /** Default Seren model per agent type when no match is found. */
 const DEFAULT_SEREN_MODELS: Record<AgentType, string> = {
-  "claude-code": "anthropic/claude-sonnet-4",
-  codex: "openai/gpt-4o",
+  "claude-code": "arcee-ai/trinity-large-thinking",
+  codex: "arcee-ai/trinity-large-thinking",
 };
 
 /**
@@ -165,7 +165,7 @@ export function mapAgentModelToChat(
       }
     }
   }
-  return DEFAULT_SEREN_MODELS[agentType] ?? "anthropic/claude-sonnet-4";
+  return DEFAULT_SEREN_MODELS[agentType] ?? "arcee-ai/trinity-large-thinking";
 }
 
 /**

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -22,7 +22,7 @@ import {
 import type { Message } from "@/services/chat";
 import { sendMessage } from "@/services/chat";
 
-const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
+const DEFAULT_MODEL = "arcee-ai/trinity-large-thinking";
 const MAX_MESSAGES_PER_CONVERSATION = 1000;
 
 /**

--- a/src/stores/conversation.store.ts
+++ b/src/stores/conversation.store.ts
@@ -17,7 +17,7 @@ import {
 import type { UnifiedMessage } from "@/types/conversation";
 import { deserializeMetadata, serializeMetadata } from "@/types/conversation";
 
-const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
+const DEFAULT_MODEL = "arcee-ai/trinity-large-thinking";
 const MAX_MESSAGES_PER_CONVERSATION = 1000;
 
 export interface Conversation {

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -142,7 +142,7 @@ export interface ToolsetSettings {
  */
 const DEFAULT_SETTINGS: Settings = {
   // Chat
-  chatDefaultModel: "anthropic/claude-sonnet-4",
+  chatDefaultModel: "arcee-ai/trinity-large-thinking",
   chatMaxHistoryMessages: 50,
   chatEnterToSend: true,
   chatShowThinking: false,
@@ -160,7 +160,7 @@ const DEFAULT_SETTINGS: Settings = {
   completionEnabled: true,
   completionDelay: 300,
   completionMaxSuggestionLines: 6,
-  completionModelId: "anthropic/claude-sonnet-4",
+  completionModelId: "arcee-ai/trinity-large-thinking",
   completionDisabledLanguages: ["markdown", "plaintext"],
   // Wallet
   showBalance: true,

--- a/tests/unit/conversation-store.test.ts
+++ b/tests/unit/conversation-store.test.ts
@@ -55,7 +55,7 @@ describe("conversationStore", () => {
       expect(convo.id).toBe("test-uuid-1");
       expect(convo.title).toBe("Test");
       expect(convo.isArchived).toBe(false);
-      expect(convo.selectedModel).toBe("anthropic/claude-sonnet-4");
+      expect(convo.selectedModel).toBe("arcee-ai/trinity-large-thinking");
     });
 
     it("sets new conversation as active", async () => {
@@ -79,7 +79,7 @@ describe("conversationStore", () => {
       expect(createConversation).toHaveBeenCalledWith(
         convo.id,
         "With Project",
-        "anthropic/claude-sonnet-4",
+        "arcee-ai/trinity-large-thinking",
         undefined,
         "/Users/dev/my-project",
       );

--- a/tests/unit/thread-store.test.ts
+++ b/tests/unit/thread-store.test.ts
@@ -82,7 +82,7 @@ vi.mock("@/stores/conversation.store", () => ({
         id: `chat-${mockConversations.conversations.length + 1}`,
         title,
         createdAt: Date.now(),
-        selectedModel: "anthropic/claude-sonnet-4",
+        selectedModel: "arcee-ai/trinity-large-thinking",
         selectedProvider: null,
         projectRoot: _projectRoot ?? null,
         isArchived: false,


### PR DESCRIPTION
## Summary
- Change default chat model from `anthropic/claude-sonnet-4` to `arcee-ai/trinity-large-thinking` across all layers
- Curate DEFAULT_MODELS list to 6 models: Claude Opus 4.6, Claude Sonnet 4, Claude Haiku 4.5, GPT-5.4, Gemini 3.1 Pro, Trinity Large Thinking
- Remove deprecated/redundant models: claude-opus-4.5, gpt-5, gpt-4o, gpt-4o-mini, gemini-3-flash, gemini-2.5-pro, gemini-2.5-flash, glm-4

Closes #1436

## Test plan
- [x] All 271 unit tests pass
- [x] Model verified in seren-models publisher catalog
- [ ] Manual: open app, confirm Trinity Large Thinking is default in model selector

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com