### PR TITLE
fix: inject publisher inventory into agent prompt context

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -101,6 +101,7 @@ import {
   setAgentConversationTitle as setAgentConversationTitleDb,
 } from "@/lib/tauri-bridge";
 import { refreshAccessToken } from "@/services/auth";
+import { getCallablePublisherSlugs } from "@/services/mcp-gateway";
 import type {
   AgentEvent,
   AgentInfo,
@@ -1812,6 +1813,27 @@ export const agentStore = {
         "[AgentStore] Failed to load skills for agent prompt:",
         error,
       );
+    }
+
+    // Inject publisher inventory so the agent knows which services are
+    // available via call_publisher / list_agent_publishers. Without this,
+    // the agent checks MCP resources (empty) and concludes services like
+    // GitHub are unavailable.
+    const publisherSlugs = getCallablePublisherSlugs();
+    if (publisherSlugs.length > 0) {
+      const publisherList = publisherSlugs.sort().join(", ");
+      mergedContext = [
+        {
+          type: "text",
+          text:
+            "Available Seren MCP Publishers (callable via your seren-mcp tools): " +
+            publisherList +
+            ". Use list_agent_publishers to discover tools for a specific publisher, " +
+            "then call_publisher to invoke them. Do NOT say a service is unavailable " +
+            "without first checking this list.",
+        },
+        ...mergedContext,
+      ];
     }
 
     return mergedContext.length > 0 ? mergedContext : undefined;


### PR DESCRIPTION
Fixes #1458

Codex/Claude agents checked `list_mcp_resources` (empty) and concluded GitHub was unavailable. The agent has `call_publisher` and `list_agent_publishers` tools but didn't know which publishers exist without explicitly calling list first.

**Fix**: Inject the callable publisher slug list (~400 tokens) into `buildPromptContext()` as a context block. Same mechanism used for skills. The agent now sees the full publisher inventory on every prompt.

**Cost**: ~400 tokens per prompt (100 slugs x ~15 chars each). Negligible vs skill content blocks already injected (2,000+ tokens).

**What the agent sees**:
```
Available Seren MCP Publishers (callable via your seren-mcp tools):
attio, firecrawl, github-repos, gmail, google-calendar, ...
Use list_agent_publishers to discover tools for a specific publisher,
then call_publisher to invoke them.
```

271 tests pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com