### PR TITLE
fix(chat): block first message on gateway readiness + tone rules (#1464)

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -40,6 +40,19 @@ const REQUEST_TIMEOUT_SECS: u64 = 600;
 /// via `WorkerEvent::ToolResult`.
 const MAX_TOOL_RESULT_CONTEXT_BYTES: usize = 30_000;
 
+/// Tone and behavior rules injected into every chat system prompt.
+///
+/// Kept here as a single source of truth for the Rust orchestrator path.
+/// The JS direct-provider path (src/services/chat.ts TONE_INSTRUCTIONS)
+/// carries a matching copy — update both when changing this block.
+pub(crate) const TONE_INSTRUCTIONS: &str = "Tone and behavior:\n\
+    - Be concise. Lead with the answer, not preamble.\n\
+    - Never open with \"Great question,\" \"Excellent,\" \"Perfect,\" or \"You're absolutely right.\"\n\
+    - Do not use emojis unless the user uses them first.\n\
+    - Push back honestly on bad ideas. The user wants candor, not validation.\n\
+    - Never claim a tool or capability is unavailable without first checking your actual tool list. \
+    If the tool list is empty or still loading, say so — do not assert the capability does not exist.";
+
 // =============================================================================
 // Live Repo Context
 // =============================================================================
@@ -346,6 +359,10 @@ impl ChatModelWorker {
         if !skill_content.is_empty() {
             system_parts.push(skill_content.to_string());
         }
+        // Tone and behavior rules — must match JS path TONE_INSTRUCTIONS in
+        // src/services/chat.ts. Appended last so the model reads them after
+        // the tool inventory it is allowed to use.
+        system_parts.push(TONE_INSTRUCTIONS.to_string());
         let system_content = system_parts.join("\n\n");
 
         messages.push(serde_json::json!({
@@ -1582,6 +1599,48 @@ mod tests {
         assert_eq!(messages[0]["role"], "system");
         assert_eq!(messages[1]["content"], "previous message");
         assert_eq!(messages[2]["content"], "Hello world");
+    }
+
+    #[test]
+    fn injects_tone_instructions_into_system_prompt() {
+        // Critical: every chat system prompt must carry the tone block so the
+        // model is bound by the same anti-sycophancy / verify-before-denying
+        // rules regardless of skills, tools, or repo context. Regression
+        // guard for serenorg/seren-desktop#1464.
+        let worker = ChatModelWorker::new();
+        let routing = RoutingDecision {
+            worker_type: super::super::types::WorkerType::ChatModel,
+            model_id: "anthropic/claude-sonnet-4".to_string(),
+            delegation: super::super::types::DelegationType::InLoop,
+            reason: "General chat".to_string(),
+            selected_skills: vec![],
+            publisher_slug: None,
+            reasoning_effort: None,
+            project_root: None,
+        };
+
+        let body =
+            worker.build_request_body("hi", &[], &routing, "", &[], &[], None);
+        let system_msg = body["messages"][0]["content"].as_str().unwrap();
+
+        assert!(
+            system_msg.contains("Tone and behavior:"),
+            "system prompt must contain the tone header"
+        );
+        assert!(
+            system_msg.contains("Be concise. Lead with the answer"),
+            "tone block must enforce concise/lead-with-answer rule"
+        );
+        assert!(
+            system_msg.contains("Never open with"),
+            "tone block must forbid sycophantic openers"
+        );
+        assert!(
+            system_msg.contains(
+                "Never claim a tool or capability is unavailable without first checking"
+            ),
+            "tone block must require verification before denying capabilities"
+        );
     }
 
     #[test]

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -22,6 +22,9 @@ import { executeTools, getAllTools } from "@/lib/tools";
 import {
   getCallablePublisherSlugs,
   getGatewayTools,
+  isGatewayInitInFlight,
+  isGatewayInitialized,
+  waitForGatewayReady,
 } from "@/services/mcp-gateway";
 import { storeAssistantResponse } from "@/services/memory";
 import { authStore } from "@/stores/auth.store";
@@ -70,6 +73,29 @@ export interface Message {
 export const CHAT_MAX_RETRIES = 3;
 const INITIAL_DELAY = 1000;
 const TRANSIENT_STATUS_CODES = ["408", "429", "500", "502", "503", "504"];
+
+/**
+ * Maximum time to wait for the MCP gateway to finish initializing before
+ * assembling the first system prompt. Short enough that the user does not
+ * perceive a hang, long enough for a warm login to complete.
+ */
+export const GATEWAY_READY_TIMEOUT_MS = 5000;
+
+/**
+ * Tone and behavior rules injected into every chat system prompt.
+ *
+ * Kept here as a single source of truth for the JS direct-provider path.
+ * The Rust orchestrator path (src-tauri/src/orchestrator/chat_model_worker.rs)
+ * carries a matching copy — update both when changing this block.
+ */
+export const TONE_INSTRUCTIONS =
+  "\n\nTone and behavior:\n" +
+  "- Be concise. Lead with the answer, not preamble.\n" +
+  '- Never open with "Great question," "Excellent," "Perfect," or "You\'re absolutely right."\n' +
+  "- Do not use emojis unless the user uses them first.\n" +
+  "- Push back honestly on bad ideas. The user wants candor, not validation.\n" +
+  "- Never claim a tool or capability is unavailable without first checking your actual tool list. " +
+  "If the tool list is empty or still loading, say so — do not assert the capability does not exist.";
 
 /**
  * Check if an error is transient and should be retried.
@@ -350,6 +376,15 @@ export async function* streamMessageWithTools(
   // Build initial messages array
   const messages: ChatMessageWithTools[] = [];
 
+  // Wait for the MCP gateway to finish initializing before reading the
+  // publisher cache. Without this, the first message after login races the
+  // background initializeGateway() call and lands while the cache is empty,
+  // producing a system prompt that falsely claims no Seren tools are
+  // available. waitForGatewayReady is a no-op once the cache is hot.
+  if (authStore.isAuthenticated && !isGatewayInitialized()) {
+    await waitForGatewayReady(GATEWAY_READY_TIMEOUT_MS);
+  }
+
   // Build Seren MCP publishers context dynamically based on active toolset.
   // Uses the canonical publisher inventory (all callable publishers) as the
   // source of truth, not just publishers that expose first-class MCP tools.
@@ -374,6 +409,20 @@ export async function* streamMessageWithTools(
       : allSlugs;
 
     if (publishers.length === 0) {
+      // Honest fallback: distinguish "still loading / unreachable" from
+      // "user has actually disabled all publishers". The former must NOT
+      // make the model deny access — it should tell the user to retry.
+      if (
+        authStore.isAuthenticated &&
+        (isGatewayInitInFlight() || !isGatewayInitialized())
+      ) {
+        return (
+          "\n\nIMPORTANT — Seren MCP Gateway Status:\n" +
+          "The Seren MCP gateway is still initializing or temporarily unreachable. " +
+          "Do NOT claim that Seren publishers or tools are unavailable. " +
+          "Tell the user the tools are still loading and to retry their request in a moment."
+        );
+      }
       return "";
     }
 
@@ -426,6 +475,10 @@ export async function* streamMessageWithTools(
     "Key Seren concepts: SerenBucks (billing credits), Publishers (third-party data services), " +
     "Skills (installable prompt-based capabilities from the seren-skills repo), " +
     "Gateway API (AI model access), MCP servers (tool integration), and Seren Desktop (this application).";
+
+  // Tone and behavior instructions — must match Rust orchestrator copy at
+  // src-tauri/src/orchestrator/chat_model_worker.rs TONE_INSTRUCTIONS.
+  systemContent += TONE_INSTRUCTIONS;
 
   // Add user-provided context if available
   if (context) {

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -414,6 +414,47 @@ export function isGatewayInitialized(): boolean {
 }
 
 /**
+ * True when an initializeGateway() call is in flight (started but not resolved).
+ * Used by callers that need to distinguish "still loading" from "never started".
+ */
+export function isGatewayInitInFlight(): boolean {
+  return loadingPromise !== null;
+}
+
+/**
+ * Wait for the gateway to become ready, with a bounded timeout.
+ *
+ * Resolves `true` once the gateway reports initialized (publishers and tools
+ * cached). Resolves `false` on timeout or if initialization throws — callers
+ * should degrade gracefully rather than falsely claim tools are unavailable.
+ *
+ * Safe to call before, during, or after initializeGateway() — it piggy-backs
+ * on the shared loadingPromise so concurrent callers do not trigger redundant
+ * MCP connections.
+ */
+export async function waitForGatewayReady(timeoutMs: number): Promise<boolean> {
+  if (isGatewayInitialized()) return true;
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<false>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve(false), timeoutMs);
+  });
+
+  try {
+    const initPromise = initializeGateway()
+      .then(() => isGatewayInitialized())
+      .catch((error) => {
+        console.warn("[MCP Gateway] waitForGatewayReady init failed:", error);
+        return false;
+      });
+
+    return await Promise.race([initPromise, timeoutPromise]);
+  } finally {
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+  }
+}
+
+/**
  * Reset gateway state (for logout).
  * Disconnects from MCP server. API key is cleared separately in auth flow.
  */

--- a/tests/unit/chat-tone-and-gateway.test.ts
+++ b/tests/unit/chat-tone-and-gateway.test.ts
@@ -1,0 +1,96 @@
+// ABOUTME: Regression guards for serenorg/seren-desktop#1464 — chat assistant
+// ABOUTME: must inject tone rules and must not race the MCP gateway init.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const chatSource = readFileSync(resolve("src/services/chat.ts"), "utf-8");
+const gatewaySource = readFileSync(
+  resolve("src/services/mcp-gateway.ts"),
+  "utf-8",
+);
+const rustSource = readFileSync(
+  resolve("src-tauri/src/orchestrator/chat_model_worker.rs"),
+  "utf-8",
+);
+
+describe("tone instructions (#1464)", () => {
+  it("JS path exports a TONE_INSTRUCTIONS constant", () => {
+    // Single source of truth for the JS direct-provider system prompt.
+    expect(chatSource).toMatch(/export const TONE_INSTRUCTIONS\s*=/);
+  });
+
+  it("JS tone block forbids sycophantic openers and emoji", () => {
+    expect(chatSource).toContain("Be concise. Lead with the answer");
+    expect(chatSource).toContain("Never open with");
+    expect(chatSource).toContain("Do not use emojis");
+    expect(chatSource).toContain(
+      "Never claim a tool or capability is unavailable without first checking",
+    );
+  });
+
+  it("JS path appends TONE_INSTRUCTIONS to systemContent", () => {
+    // The constant must actually be injected into the prompt, not merely
+    // declared. Catches the case where someone removes the append.
+    expect(chatSource).toMatch(/systemContent\s*\+=\s*TONE_INSTRUCTIONS/);
+  });
+
+  it("Rust path defines a matching TONE_INSTRUCTIONS constant", () => {
+    expect(rustSource).toContain("const TONE_INSTRUCTIONS");
+    expect(rustSource).toContain("Be concise. Lead with the answer");
+    expect(rustSource).toContain("Never open with");
+    expect(rustSource).toContain("Do not use emojis");
+    expect(rustSource).toContain(
+      "Never claim a tool or capability is unavailable without first checking",
+    );
+  });
+
+  it("Rust path pushes TONE_INSTRUCTIONS into system_parts", () => {
+    expect(rustSource).toContain("system_parts.push(TONE_INSTRUCTIONS");
+  });
+});
+
+describe("MCP gateway readiness wait (#1464)", () => {
+  it("mcp-gateway exports waitForGatewayReady with a bounded timeout", () => {
+    expect(gatewaySource).toMatch(
+      /export async function waitForGatewayReady\(\s*timeoutMs:\s*number/,
+    );
+  });
+
+  it("mcp-gateway exports isGatewayInitInFlight introspection helper", () => {
+    expect(gatewaySource).toMatch(
+      /export function isGatewayInitInFlight\(\)/,
+    );
+  });
+
+  it("waitForGatewayReady races initializeGateway against the timeout", () => {
+    // Must not block the chat indefinitely — Promise.race or equivalent.
+    expect(gatewaySource).toContain("Promise.race");
+    expect(gatewaySource).toContain("initializeGateway()");
+  });
+
+  it("chat.ts awaits gateway readiness before building publisher context", () => {
+    // The await must come BEFORE buildPublishersContext is called, otherwise
+    // the cache is read while still empty on the first message after login.
+    const idxAwait = chatSource.indexOf("await waitForGatewayReady(");
+    const idxBuild = chatSource.indexOf("const buildPublishersContext");
+    expect(idxAwait).toBeGreaterThan(-1);
+    expect(idxBuild).toBeGreaterThan(-1);
+    expect(idxAwait).toBeLessThan(idxBuild);
+  });
+});
+
+describe("honest fallback when gateway not ready (#1464)", () => {
+  it("buildPublishersContext returns 'still initializing' message instead of empty string when init in flight", () => {
+    // This is the belt-and-suspenders branch: if waitForGatewayReady times
+    // out or the user sends a message before init even starts, the system
+    // prompt must NOT be silent about Seren tools — it must explicitly tell
+    // the model to say tools are loading rather than denying access.
+    expect(chatSource).toContain("isGatewayInitInFlight");
+    expect(chatSource).toContain(
+      "Do NOT claim that Seren publishers or tools are unavailable",
+    );
+    expect(chatSource).toMatch(/still initializing or temporarily unreachable/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1464. Eliminates two related failure modes in the shipped chat assistant that produced the incident described in the linked issue (four straight false denials of SerenDB access, leading to a user pasting a live API key into chat).

**Fix 1 + Fix 2 — gateway race + honest fallback.** `streamMessageWithTools` now calls a new bounded `waitForGatewayReady(5000)` before assembling the system prompt, so the publisher/tool cache is populated before `buildPublishersContext()` reads from it. If the 5s timeout fires or the gateway fails outright, `buildPublishersContext()` returns an honest "still initializing or temporarily unreachable — do NOT claim publishers are unavailable, tell the user to retry" message instead of silently producing an empty string.

**Fix 3 — tone rules.** Both the Rust orchestrator path ([src-tauri/src/orchestrator/chat_model_worker.rs](../blob/main/src-tauri/src/orchestrator/chat_model_worker.rs)) and the JS direct-provider path ([src/services/chat.ts](../blob/main/src/services/chat.ts)) now inject a `TONE_INSTRUCTIONS` block into every system prompt:

- Be concise. Lead with the answer, not preamble.
- Never open with "Great question," "Excellent," "Perfect," or "You're absolutely right."
- Do not use emojis unless the user uses them first.
- Push back honestly on bad ideas. The user wants candor, not validation.
- Never claim a tool or capability is unavailable without first checking your actual tool list.

The two copies live as language-native constants with cross-reference comments so they can't drift silently.

## New public surface

- `waitForGatewayReady(timeoutMs)` — races `initializeGateway()` against a `setTimeout`, resolves `true` on success, `false` on timeout or init failure. Piggy-backs on the existing `loadingPromise` so concurrent callers don't trigger redundant MCP connections.
- `isGatewayInitInFlight()` — lets callers distinguish "still loading" from "never started," which is what makes the honest fallback trustworthy.

## Test plan

- [x] `pnpm test` — 281/281 passing
- [x] `cargo test --lib orchestrator::chat_model_worker` — 40/40 passing, including new `injects_tone_instructions_into_system_prompt`
- [x] New `tests/unit/chat-tone-and-gateway.test.ts` — 9 assertions covering: `TONE_INSTRUCTIONS` export, every rule bullet, append-to-systemContent, Rust constant, Rust push, `waitForGatewayReady` signature, `isGatewayInitInFlight` signature, `Promise.race` usage, await-before-build ordering, honest fallback text
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean (3 pre-existing dead_code warnings)
- [x] `npx vite build` — clean production build
- [x] `pnpm tauri dev` — app compiles and boots, frontend serves on :1420

## Manual verification (post-merge, on a signed build)

- Fresh login → immediately send "do you have access to my SerenDB?" → assistant confirms access (no race)
- Throttle network / block MCP gateway → first message should hit the 5s timeout → assistant says tools are still loading, not "unavailable"
- Send a generic greeting → response does not start with "Great question" or contain emojis
- Ask for something genuinely out of scope → assistant pushes back honestly rather than sycophantically hedging

## Non-goals

- User-customizable system prompt via Settings panel (follow-up)
- Per-model tone tuning
- Refactoring the MCP gateway caching layer

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
