### PR TITLE
fix(skills): humanize slug-style names from catalog index

### DIFF
--- a/src/components/chat/SkillsSelector.tsx
+++ b/src/components/chat/SkillsSelector.tsx
@@ -279,7 +279,7 @@ export const SkillsSelector: Component = () => {
 
                     <div class="flex flex-col gap-0.5 min-w-0 flex-1">
                       <span class="text-foreground font-medium truncate">
-                        {skill.name}
+                        {skill.displayName ?? skill.name}
                       </span>
                       <Show when={skill.description}>
                         <span class="text-[11px] text-muted-foreground line-clamp-1">

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -887,7 +887,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
 
                             <div class="flex-1 min-w-0">
                               <div class="text-[13px] font-medium text-foreground">
-                                {skill.name}
+                                {skill.displayName ?? skill.name}
                                 {isActive() && isSearching && (
                                   <span class="ml-1.5 text-[10px] text-primary font-semibold">
                                     ●

--- a/src/components/sidebar/SkillsExplorer.tsx
+++ b/src/components/sidebar/SkillsExplorer.tsx
@@ -85,6 +85,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
     if (!q) return skillsStore.installed;
     return skillsStore.installed.filter(
       (s) =>
+        (s.displayName ?? s.name).toLowerCase().includes(q) ||
         s.name.toLowerCase().includes(q) ||
         (s.description ?? "").toLowerCase().includes(q) ||
         s.tags.some((t) => t.toLowerCase().includes(q)),
@@ -882,7 +883,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                       <div class="flex-1 min-w-0">
                         <div class="flex items-center gap-2">
                           <span class="text-[13px] font-medium text-foreground truncate">
-                            {skill.name}
+                            {skill.displayName ?? skill.name}
                           </span>
                           <span
                             class="shrink-0 px-1 py-0 text-[10px] font-semibold rounded bg-surface-3 text-muted-foreground"
@@ -1241,7 +1242,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                         {/* Info */}
                         <div class="flex-1 min-w-0">
                           <span class="text-[13px] font-medium text-foreground truncate block">
-                            {skill.name}
+                            {skill.displayName ?? skill.name}
                           </span>
                           <Show when={skill.description}>
                             <p class="m-0 mt-0.5 text-[12px] text-muted-foreground truncate">

--- a/src/lib/skills/parser.ts
+++ b/src/lib/skills/parser.ts
@@ -203,6 +203,26 @@ function humanizeSlug(value: string): string {
 }
 
 /**
+ * Humanize a skill name from a catalog index entry.
+ * Returns the name as-is if it already has spaces or capitalization,
+ * humanizes it if it looks like a slug, and falls back to the slug
+ * if the name is empty.
+ *
+ * Used by the catalog ingestion path where the index `name` field
+ * is often the directory basename (e.g. "backtester", "grid-trader").
+ */
+export function humanizeSkillName(name: string, fallbackSlug?: string): string {
+  const trimmed = name?.trim() ?? "";
+  if (trimmed) {
+    return SKILL_SLUG_PATTERN.test(trimmed) ? humanizeSlug(trimmed) : trimmed;
+  }
+  if (fallbackSlug) {
+    return humanizeSlug(fallbackSlug);
+  }
+  return "Unnamed Skill";
+}
+
+/**
  * Resolve a human-friendly skill name.
  * Prefers Markdown H1, then metadata name, then fallback slug.
  */

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -8,6 +8,7 @@ import { log } from "@/lib/logger";
 import {
   computeContentHash,
   getSkillPath,
+  humanizeSkillName,
   type InstalledSkill,
   parseSkillMd,
   type RemoteSkillRevision,
@@ -94,12 +95,18 @@ function githubApiHeaders(): HeadersInit {
 
 /**
  * Transform an index entry to a Skill.
+ *
+ * The catalog index `name` is often a slug-style directory basename
+ * (e.g. `backtester`, `grid-trader`) when the upstream SKILL.md does
+ * not provide a `display-name` in its frontmatter. Humanize the name
+ * here so the UI never renders raw slugs even when the catalog or a
+ * specific SKILL.md is missing display metadata.
  */
 function indexEntryToSkill(entry: SkillIndexEntry): Skill {
   return {
     id: `${entry.source}:${entry.slug}`,
     slug: entry.slug,
-    name: entry.name,
+    name: humanizeSkillName(entry.name, entry.slug),
     displayName: entry.displayName,
     description: entry.description,
     source: entry.source,

--- a/tests/unit/humanize-skill-name.test.ts
+++ b/tests/unit/humanize-skill-name.test.ts
@@ -1,0 +1,34 @@
+// ABOUTME: Critical regression test for catalog name humanization.
+// ABOUTME: Guards against slug-style names rendering raw in the SkillsExplorer.
+
+import { describe, expect, it } from "vitest";
+import { humanizeSkillName } from "@/lib/skills/parser";
+
+describe("humanizeSkillName", () => {
+  it("humanizes a slug-style name with hyphens", () => {
+    // Real catalog example: plausibleai-backtester has name="backtester"
+    expect(humanizeSkillName("backtester")).toBe("Backtester");
+    expect(humanizeSkillName("bot-rasta-coach")).toBe("Bot Rasta Coach");
+    expect(humanizeSkillName("polymarket-maker-rebate-bot")).toBe(
+      "Polymarket Maker Rebate Bot",
+    );
+  });
+
+  it("returns names that already have spaces or capitalization unchanged", () => {
+    // Catalog skills with proper display-name in frontmatter
+    expect(humanizeSkillName("Kraken 1099-DA Tax")).toBe("Kraken 1099-DA Tax");
+    expect(humanizeSkillName("AI Governance Assessment")).toBe(
+      "AI Governance Assessment",
+    );
+  });
+
+  it("falls back to humanizing the slug when name is empty", () => {
+    expect(humanizeSkillName("", "egeria-cmintro-loan")).toBe(
+      "Egeria Cmintro Loan",
+    );
+  });
+
+  it("returns 'Unnamed Skill' when both name and fallback slug are empty", () => {
+    expect(humanizeSkillName("")).toBe("Unnamed Skill");
+  });
+});


### PR DESCRIPTION
## Summary
- 19 of 74 skills in the R2 catalog index lack a `displayName` and carry a slug-style `name` field (e.g. `backtester`, `grid-trader`). The desktop client passed `entry.name` through unchanged so the Skills sidebar rendered raw slugs.
- The fix from #1405 was only applied to `ThreadSidebar.tsx` — `SkillsExplorer.tsx` and `SkillsSelector.tsx` still rendered `skill.name` directly. And even with `displayName ?? name` in place, names from the catalog stayed as slugs because `indexEntryToSkill` never humanized them.
- Added `humanizeSkillName` helper, use it in `indexEntryToSkill`, and switched the remaining render sites to `displayName ?? name`.

## Changes
- `src/lib/skills/parser.ts` — export new `humanizeSkillName(name, fallbackSlug)` helper.
- `src/services/skills.ts` — humanize the `name` field at catalog ingestion in `indexEntryToSkill`.
- `src/components/sidebar/SkillsExplorer.tsx` — render `displayName ?? name` in both Installed and Browse tabs and in the search filter.
- `src/components/chat/SkillsSelector.tsx` — render `displayName ?? name` in the picker.
- `src/components/layout/ThreadSidebar.tsx` — render `displayName ?? name` in the agent thread skill picker (the file already had this fix in one place; this catches the second site).
- `tests/unit/humanize-skill-name.test.ts` — critical regression test (4 cases).

## Test plan
- [x] `pnpm test` — full unit suite (32 files / 285 tests) passes.
- [x] `tsc --noEmit` — no new type errors.
- [x] Manual reasoning: with the catalog containing `name: "backtester"` and no `displayName`, the sidebar now renders "Backtester".

Closes #1469
