### PR TITLE
feat(tools): expose read_file_base64 to chat orchestrator

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -1026,6 +1026,7 @@ impl ChatModelWorker {
         matches!(
             name,
             "read_file"
+                | "read_file_base64"
                 | "write_file"
                 | "list_directory"
                 | "path_exists"
@@ -1064,6 +1065,16 @@ impl ChatModelWorker {
                     return ("Missing required parameter: path".to_string(), true);
                 }
                 match crate::files::read_file(path) {
+                    Ok(content) => (content, false),
+                    Err(e) => (e, true),
+                }
+            }
+            "read_file_base64" => {
+                let path = args["path"].as_str().unwrap_or("").to_string();
+                if path.is_empty() {
+                    return ("Missing required parameter: path".to_string(), true);
+                }
+                match crate::files::read_file_base64(path) {
                     Ok(content) => (content, false),
                     Err(e) => (e, true),
                 }
@@ -2179,6 +2190,40 @@ mod tests {
         let (content, is_error) = ChatModelWorker::execute_tool("read_file", "{}").await;
         assert!(is_error);
         assert!(content.contains("Missing required parameter"));
+    }
+
+    #[tokio::test]
+    async fn execute_tool_read_file_base64_round_trips_bytes() {
+        // Critical regression guard: the read_file_base64 dispatcher arm must
+        // hand off to crate::files::read_file_base64 and return real base64.
+        // Without this wiring, agents have no typed path to upload binary
+        // files (PDF, images) to API publishers like seren-docreader.
+        use base64::{Engine, engine::general_purpose::STANDARD};
+        use std::io::Write;
+
+        // Use a binary payload that includes a NUL byte so a string-based
+        // read_file would either fail or corrupt the content — proves the
+        // base64 path is reading raw bytes, not UTF-8.
+        let payload: &[u8] = &[0x25, 0x50, 0x44, 0x46, 0x00, 0xFF, 0xC0, 0xA9];
+        let mut tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+        tmp.write_all(payload).expect("write payload");
+        let path = tmp.path().to_string_lossy().to_string();
+
+        let args = serde_json::json!({ "path": path }).to_string();
+        let (content, is_error) =
+            ChatModelWorker::execute_tool("read_file_base64", &args).await;
+
+        assert!(!is_error, "read_file_base64 returned error: {}", content);
+        let decoded = STANDARD
+            .decode(content.as_bytes())
+            .expect("dispatcher must return valid base64");
+        assert_eq!(decoded, payload, "round-tripped bytes must match input");
+
+        // Empty path is a user error, not a panic.
+        let (err_content, err_flag) =
+            ChatModelWorker::execute_tool("read_file_base64", "{}").await;
+        assert!(err_flag);
+        assert!(err_content.contains("Missing required parameter"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/orchestrator/tool_relevance.rs
+++ b/src-tauri/src/orchestrator/tool_relevance.rs
@@ -36,6 +36,7 @@ const RECENCY_BOOST: f32 = 2.0;
 /// without them it cannot read/write files or execute commands.
 const PINNED_TOOL_NAMES: &[&str] = &[
     "read_file",
+    "read_file_base64",
     "write_file",
     "list_directory",
     "path_exists",
@@ -745,14 +746,18 @@ mod tests {
 
     #[test]
     fn pinned_local_tools_always_included() {
-        // Simulate 138 tools: 7 local + 131 gateway tools.
+        // Simulate 139 tools: 8 local + 131 gateway tools.
         // Query is domain-specific with zero overlap with local tool names.
         let mut tools: Vec<serde_json::Value> = Vec::new();
 
-        // Add all 7 pinned local tools
+        // Add all pinned local tools
         tools.push(make_tool(
             "read_file",
             "Read file contents from the filesystem",
+        ));
+        tools.push(make_tool(
+            "read_file_base64",
+            "Read a file and return its bytes as base64",
         ));
         tools.push(make_tool("write_file", "Write content to a file on disk"));
         tools.push(make_tool("list_directory", "List entries in a directory"));
@@ -802,7 +807,7 @@ mod tests {
             &tools,
         );
 
-        // All 7 pinned tools must be present
+        // All pinned tools must be present
         for pinned_name in PINNED_TOOL_NAMES {
             let found = result
                 .iter()

--- a/src/lib/tools/definitions.ts
+++ b/src/lib/tools/definitions.ts
@@ -209,6 +209,29 @@ export const FILE_TOOLS: ToolDefinition[] = [
   {
     type: "function",
     function: {
+      name: "read_file_base64",
+      description:
+        "Read a file from the local filesystem and return its bytes as a base64-encoded string. " +
+        "Use this for binary files (PDF, images, audio, video, Office documents) when you need to " +
+        "upload them to a publisher API that accepts base64 input — for example, sending a PDF to " +
+        'the seren-docreader publisher\'s /process endpoint via seren__call_publisher with {"file": "<base64-string>"}. ' +
+        "Prefer read_file for plain text. Files up to 50 MB are supported.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description:
+              "The absolute or relative path to the binary file to read and base64-encode",
+          },
+        },
+        required: ["path"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
       name: "list_directory",
       description:
         "List all files and subdirectories in a directory. Returns name, path, and whether each entry is a directory.",


### PR DESCRIPTION
## Summary
- The Tauri command `read_file_base64` already exists in [src-tauri/src/files.rs:34-47](src-tauri/src/files.rs#L34-L47) but was never wired into the chat orchestrator's local tool surface.
- Result: agents had no typed path to encode binary files for upload to API publishers (e.g. `seren-docreader`'s `/process` endpoint expects `{file: <base64>}`). They fell back to `execute_command` shell pipelines and frequently abandoned.
- This PR is the four-line wiring fix: allowlist + dispatcher arm + pinned + frontend tool definition.

## Changes
- [src-tauri/src/orchestrator/chat_model_worker.rs:1025-1037](src-tauri/src/orchestrator/chat_model_worker.rs#L1025-L1037) — add `"read_file_base64"` to `is_local_tool()` allowlist.
- [src-tauri/src/orchestrator/chat_model_worker.rs:1061-1080](src-tauri/src/orchestrator/chat_model_worker.rs#L1061-L1080) — add the dispatcher arm calling the existing `crate::files::read_file_base64(path)`.
- [src-tauri/src/orchestrator/tool_relevance.rs:37-56](src-tauri/src/orchestrator/tool_relevance.rs#L37-L56) — add `"read_file_base64"` to `PINNED_TOOL_NAMES` so BM25 ranking always includes it.
- [src/lib/tools/definitions.ts:190-230](src/lib/tools/definitions.ts#L190-L230) — add the OpenAI function schema in `FILE_TOOLS` with a description that explicitly tells the model when to prefer it over `read_file` (binary uploads to publishers).
- Updated the existing `pinned_local_tools_always_included` test fixture to include the new tool so the existing loop still passes.

## Critical regression test
A single new Rust test in [chat_model_worker.rs](src-tauri/src/orchestrator/chat_model_worker.rs) — `execute_tool_read_file_base64_round_trips_bytes`:
- Writes a binary payload with a NUL byte and high-bit bytes (`[0x25, 0x50, 0x44, 0x46, 0x00, 0xFF, 0xC0, 0xA9]`) to a tempfile.
- Calls `ChatModelWorker::execute_tool("read_file_base64", ...)`.
- Decodes the result and asserts the bytes match the input — proves the dispatcher reads raw bytes (not UTF-8) and returns valid base64.
- Also asserts that empty path returns the same `Missing required parameter` error as the other file tools (UX consistency).

This guards against the wiring being dropped in a future refactor — the binary payload would fail any text-based read_file path.

## Why now (tracking the wider fix)

This is the desktop half of the docs-reader unblocker. The gateway side is tracked in [serenorg/seren-core#126](https://github.com/serenorg/seren-core/issues/126) — auto-synthesizing MCP tool wrappers for the **46 of 50 invisible API publishers** in the catalog (`seren-docreader`, `polymarket-data`, `coingecko-serenai`, `openai-embeddings`, `seren-cron`, `alpaca`, `perplexity`, `firecrawl`, `apollo`, `exa`, etc.). When that lands, agents will see e.g. `mcp__seren-docreader__process` in their inventory automatically.

But this PR is **independently useful even before that lands**: any agent that needs to base64-encode a local file for vision model image inputs, audio transcription, or document upload to ANY API endpoint can now do it with one tool call instead of a brittle `base64 < file.pdf` shell pipeline.

## Test plan
- [x] `cargo test --lib orchestrator::` — 236/236 passing.
- [x] `cargo test --lib execute_tool_read_file_base64_round_trips_bytes` — new test passes.
- [x] `pnpm vitest run` — 33 files / 312/312 passing.
- [x] `tsc --noEmit` — clean.
- [x] No new compiler warnings introduced.

Closes #1475
