### PR TITLE
fix(settings): default Enable Web Search to ON (#1482)

### DIFF
--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -183,7 +183,7 @@ const DEFAULT_SETTINGS: Settings = {
   // Agent
   agentSandboxMode: "workspace-write",
   agentApprovalPolicy: "on-request",
-  agentSearchEnabled: false,
+  agentSearchEnabled: true,
   agentNetworkEnabled: true,
   agentAutoApproveReads: true,
   // Voice

--- a/tests/unit/settings-defaults.test.ts
+++ b/tests/unit/settings-defaults.test.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Regression guard for #1482 — Enable Web Search must default to ON.
+// ABOUTME: Fresh installs shipped with web-search disabled, silently degrading every new session.
+
+import { describe, expect, it, vi } from "vitest";
+
+// Mock Tauri bridge before importing the store so settings init runs in browser fallback mode.
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: () => false,
+}));
+
+import { settingsStore } from "@/stores/settings.store";
+
+describe("settings defaults — #1482 web-search regression guard", () => {
+  it("agentSearchEnabled defaults to true so fresh installs can browse the web", () => {
+    // If this flips back to false, every new install ships with the agent
+    // unable to use the web-search tool until the user manually finds the
+    // toggle under Settings → Agent. That is the bug #1482 fixed.
+    expect(settingsStore.getDefault("agentSearchEnabled")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1482. `Settings → Agent → Enable Web Search` shipped unchecked in `DEFAULT_SETTINGS`, so every fresh install started the agent with the web-search tool disabled. Users had to discover the toggle manually or the LLM would never browse the web — a silent capability degradation on every new session.

## Root cause

[src/stores/settings.store.ts:186](src/stores/settings.store.ts#L186) set `agentSearchEnabled: false` in `DEFAULT_SETTINGS`. That value flows through [src/stores/agent.store.ts:1273](src/stores/agent.store.ts#L1273) into `providerService.spawnAgent`, which starts every session with web-search off.

## Fix

One-character change: flip the default to `true`. The UI toggle under [src/components/settings/SettingsPanel.tsx:1119-1141](src/components/settings/SettingsPanel.tsx#L1119-L1141) still works, so users can disable it if they want. Only the default changes.

## Why just the default (no migration)

Existing users who have already persisted `agentSearchEnabled: false` keep their stored value — no retroactive migration. If dogfood sessions still hit the old default after upgrade, a follow-up ticket can add a one-shot migration. Smallest reasonable change for this PR.

## Tests

New [tests/unit/settings-defaults.test.ts](tests/unit/settings-defaults.test.ts) — **1 load-bearing** regression guard. Imports the real `settingsStore` (Tauri bridge mocked into browser-fallback mode so the store initializes without a live runtime) and asserts `settingsStore.getDefault("agentSearchEnabled") === true`.

No source-text tautologies, no type-system duplicates of `tsc`. The single assertion exercises the actual runtime default-lookup path and targets the exact footgun: a future "cleanup" PR flipping the default back to `false`.

## Verification

| Check | Result |
|---|---|
| `pnpm test` | 322/322 pass (was 321, +1 new) |
| `npx tsc --noEmit` | 0 errors |
| `npx vite build` | clean |

Cargo skipped — no Rust changes.

## Manual verification (post-merge)

`pnpm tauri dev` on a fresh settings store → `Settings → Agent` → `Enable Web Search` should be **checked** by default. Start a new agent session → LLM should be able to use the web-search tool without toggling anything.

## Non-goals

- One-shot migration for existing users with persisted `false` — separate ticket if needed
- Removing the user-facing toggle — users should still be able to disable
- Reworking how `agentSearchEnabled` propagates through `spawnAgent`

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
