### PR TITLE
fix: show Gemini sparkles icon in sidebar thread list

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -1069,7 +1069,9 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                             <span class="text-xs">
                               {thread.agentType === "codex"
                                 ? "\u26A1"
-                                : "\u{1F916}"}
+                                : thread.agentType === "gemini"
+                                  ? "\u2728"
+                                  : "\u{1F916}"}
                             </span>
                           </Show>
                         </div>


### PR DESCRIPTION
Fixes #1484

Gemini agent threads showed the generic robot emoji (🤖) in the sidebar because the ternary at `ThreadSidebar.tsx:1070` was never updated when Gemini was added — it matched only `codex` and fell through to 🤖 for everything else.

Match the `ThreadTabBar` pattern: codex → ⚡, gemini → ✨, claude → 🤖.

3 lines changed. 322 tests pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com