### PR TITLE
fix: make new thread launcher dropdown scrollable

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -384,7 +384,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
         </button>
 
         <Show when={showLauncher()}>
-          <div class="absolute top-[calc(100%+4px)] left-3 right-3 bg-surface-2 border border-border rounded-lg z-20 shadow-lg animate-[slideDown_150ms_ease] overflow-hidden py-1">
+          <div class="absolute top-[calc(100%+4px)] left-3 right-3 max-h-[60vh] overflow-y-auto bg-surface-2 border border-border rounded-lg z-20 shadow-lg animate-[slideDown_150ms_ease] py-1">
             {/* Primary Seren chat path */}
             <Show when={allowsSerenPublicModels(authStore.privateChatPolicy)}>
               <button


### PR DESCRIPTION
Fixes #1493

The '+ New' launcher used `overflow-hidden`, clipping Codex and Gemini agent buttons when the list was taller than available vertical space. Raising z-index would just trade one context-menu occlusion for another.

**Fix**: `max-h-[60vh] overflow-y-auto` so the launcher scrolls internally. Skills section below stays clickable.

1 line changed. 323 tests pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com