### PR TITLE
feat(claude-memory): intercept Claude Code auto-memory writes to SerenDB

### DIFF
--- a/src-tauri/src/claude_memory.rs
+++ b/src-tauri/src/claude_memory.rs
@@ -1,0 +1,713 @@
+// ABOUTME: Intercepts Claude Code auto-memory writes and redirects them to SerenDB.
+// ABOUTME: Watches ~/.claude/projects/*/memory/ and persists via the existing memory stack.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{Receiver, Sender, channel};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::commands::memory::{MemoryState, persist_memory_local};
+
+/// Memory type tag persisted alongside Claude preference memories so they can be
+/// filtered from ordinary conversational memories in the future.
+pub const CLAUDE_PREFERENCE_MEMORY_TYPE: &str = "claude_preference";
+
+/// Filename Claude Code itself reads at session start. We never persist user data
+/// into this file directly — it is always rendered from the DB on demand.
+const RENDERED_INDEX_FILENAME: &str = "MEMORY.md";
+
+/// File we persist a stable project identifier to when no git remote is available.
+/// Lives under the project's `.claude/` directory so it travels with the project.
+const PROJECT_ID_FILENAME: &str = "project_id";
+
+/// Parsed frontmatter extracted from a Claude memory markdown file.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryFrontmatter {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub memory_type: Option<String>,
+}
+
+/// Result of parsing a Claude memory `.md` file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedMemoryFile {
+    pub frontmatter: MemoryFrontmatter,
+    pub body: String,
+}
+
+/// Stable identity for a project directory. Survives clones and different machines
+/// as long as the project has a git remote or a persisted UUID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectIdentity {
+    pub identifier: String,
+    pub source: ProjectIdentitySource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectIdentitySource {
+    GitRemote,
+    PersistedUuid,
+    GeneratedUuid,
+}
+
+/// Event emitted to the frontend whenever the watcher intercepts a memory file.
+#[derive(Debug, Clone, Serialize)]
+pub struct InterceptEvent {
+    pub path: String,
+    pub name: Option<String>,
+    pub memory_type: String,
+    pub persisted_id: String,
+    pub deleted: bool,
+}
+
+/// Global watcher state, modeled after `sync.rs` for consistency.
+struct WatcherState {
+    watcher: Option<RecommendedWatcher>,
+    stop_sender: Option<Sender<()>>,
+    roots: Vec<PathBuf>,
+    running: bool,
+}
+
+impl Default for WatcherState {
+    fn default() -> Self {
+        Self {
+            watcher: None,
+            stop_sender: None,
+            roots: Vec::new(),
+            running: false,
+        }
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref CLAUDE_WATCHER_STATE: Arc<Mutex<WatcherState>> =
+        Arc::new(Mutex::new(WatcherState::default()));
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/// Return the `~/.claude/projects` directory, creating it if necessary.
+pub fn claude_projects_root() -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or_else(|| "Could not resolve home directory".to_string())?;
+    Ok(home.join(".claude").join("projects"))
+}
+
+/// Encode an absolute project directory the same way Claude Code does:
+/// `/Users/a/b` -> `-Users-a-b`. Used by callers that want to locate the matching
+/// `~/.claude/projects/<encoded>/` directory.
+pub fn encode_project_dir(cwd: &Path) -> String {
+    let resolved = cwd
+        .canonicalize()
+        .unwrap_or_else(|_| cwd.to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/");
+    let sanitized = resolved.trim_start_matches('/').replace(':', "");
+    format!("-{}", sanitized.replace('/', "-"))
+}
+
+/// Resolve a stable identity for a project directory.
+///
+/// Priority order:
+///   1. Normalized git remote URL (same repo → same identity on any machine).
+///   2. UUID already persisted at `<cwd>/.claude/project_id`.
+///   3. A freshly generated UUID, persisted to the same path for future calls.
+pub fn resolve_project_identity(cwd: &Path) -> Result<ProjectIdentity, String> {
+    if let Some(remote) = read_git_remote_url(cwd) {
+        return Ok(ProjectIdentity {
+            identifier: normalize_git_remote(&remote),
+            source: ProjectIdentitySource::GitRemote,
+        });
+    }
+
+    let dot_claude = cwd.join(".claude");
+    let id_path = dot_claude.join(PROJECT_ID_FILENAME);
+
+    if let Ok(existing) = fs::read_to_string(&id_path) {
+        let trimmed = existing.trim().to_string();
+        if !trimmed.is_empty() {
+            return Ok(ProjectIdentity {
+                identifier: trimmed,
+                source: ProjectIdentitySource::PersistedUuid,
+            });
+        }
+    }
+
+    fs::create_dir_all(&dot_claude)
+        .map_err(|e| format!("failed to create .claude directory: {e}"))?;
+    let fresh = uuid::Uuid::new_v4().to_string();
+    fs::write(&id_path, &fresh).map_err(|e| format!("failed to persist project_id: {e}"))?;
+
+    Ok(ProjectIdentity {
+        identifier: fresh,
+        source: ProjectIdentitySource::GeneratedUuid,
+    })
+}
+
+/// Read the origin remote URL from a project's `.git/config` without shelling out.
+fn read_git_remote_url(cwd: &Path) -> Option<String> {
+    let config = cwd.join(".git").join("config");
+    let text = fs::read_to_string(&config).ok()?;
+    let mut in_origin = false;
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.starts_with('[') {
+            in_origin = line == "[remote \"origin\"]";
+            continue;
+        }
+        if in_origin {
+            if let Some(rest) = line.strip_prefix("url") {
+                let value = rest.trim_start().trim_start_matches('=').trim();
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Normalize a git remote URL into a stable identifier (scheme-independent,
+/// trailing `.git` stripped, lowercased host).
+///
+/// Examples:
+///   git@github.com:serenorg/seren-desktop.git -> github.com/serenorg/seren-desktop
+///   https://github.com/serenorg/seren-desktop -> github.com/serenorg/seren-desktop
+pub fn normalize_git_remote(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    let without_git = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+
+    // SCP-style: git@host:path
+    if let Some(rest) = without_git.strip_prefix("git@") {
+        if let Some((host, path)) = rest.split_once(':') {
+            return format!("{}/{}", host.to_lowercase(), path.trim_start_matches('/'));
+        }
+    }
+
+    // URL-style: strip scheme and optional userinfo.
+    let after_scheme = match without_git.find("://") {
+        Some(idx) => &without_git[idx + 3..],
+        None => without_git,
+    };
+    let after_userinfo = after_scheme.rsplit_once('@').map_or(after_scheme, |t| t.1);
+
+    // Lowercase only the host portion.
+    match after_userinfo.split_once('/') {
+        Some((host, path)) => format!("{}/{}", host.to_lowercase(), path),
+        None => after_userinfo.to_lowercase(),
+    }
+}
+
+/// Parse a Claude memory markdown file. The file format is:
+///
+/// ```text
+/// ---
+/// name: ...
+/// description: ...
+/// type: feedback
+/// ---
+/// body
+/// ```
+///
+/// Frontmatter is optional. Unknown keys are ignored. No YAML dependency.
+pub fn parse_memory_file(contents: &str) -> ParsedMemoryFile {
+    let normalized = contents.replace("\r\n", "\n");
+    let trimmed_start = normalized.trim_start_matches('\n');
+
+    if !trimmed_start.starts_with("---") {
+        return ParsedMemoryFile {
+            frontmatter: MemoryFrontmatter::default(),
+            body: normalized.trim().to_string(),
+        };
+    }
+
+    // Skip the opening `---` line.
+    let after_open = match trimmed_start.find('\n') {
+        Some(idx) => &trimmed_start[idx + 1..],
+        None => "",
+    };
+
+    // Locate the closing `---` line.
+    let close_marker = "\n---";
+    let (front_text, body) = match after_open.find(close_marker) {
+        Some(idx) => {
+            let after_close = &after_open[idx + close_marker.len()..];
+            let body = match after_close.find('\n') {
+                Some(nl) => &after_close[nl + 1..],
+                None => "",
+            };
+            (&after_open[..idx], body)
+        }
+        None => {
+            // Unterminated frontmatter — treat everything as body for safety.
+            return ParsedMemoryFile {
+                frontmatter: MemoryFrontmatter::default(),
+                body: normalized.trim().to_string(),
+            };
+        }
+    };
+
+    let mut map: HashMap<String, String> = HashMap::new();
+    for line in front_text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once(':') {
+            let key = key.trim().to_lowercase();
+            let value = value.trim().trim_matches('"').trim_matches('\'').to_string();
+            if !value.is_empty() {
+                map.insert(key, value);
+            }
+        }
+    }
+
+    ParsedMemoryFile {
+        frontmatter: MemoryFrontmatter {
+            name: map.remove("name"),
+            description: map.remove("description"),
+            memory_type: map.remove("type"),
+        },
+        body: body.trim().to_string(),
+    }
+}
+
+/// Render a MEMORY.md file from an assembled memory prompt using an atomic write.
+///
+/// Claude Code reads `MEMORY.md` at session start. We guarantee the file on disk
+/// is always a rendered view of the remote database — never user data straight
+/// from the filesystem.
+pub fn write_rendered_memory_md(
+    claude_project_dir: &Path,
+    rendered: &str,
+) -> Result<PathBuf, String> {
+    fs::create_dir_all(claude_project_dir)
+        .map_err(|e| format!("failed to create claude project dir: {e}"))?;
+
+    let final_path = claude_project_dir.join(RENDERED_INDEX_FILENAME);
+    let tmp_path = claude_project_dir.join(format!("{}.tmp", RENDERED_INDEX_FILENAME));
+
+    fs::write(&tmp_path, rendered).map_err(|e| format!("failed to write temp MEMORY.md: {e}"))?;
+    fs::rename(&tmp_path, &final_path)
+        .map_err(|e| format!("failed to finalize MEMORY.md: {e}"))?;
+    Ok(final_path)
+}
+
+// ---------------------------------------------------------------------------
+// Watcher lifecycle
+// ---------------------------------------------------------------------------
+
+/// Start the watcher. Idempotent: stops any existing watcher first.
+///
+/// The watcher is recursive on `~/.claude/projects`, which means it automatically
+/// picks up newly-created project directories without any re-registration.
+pub fn start_watcher(app: AppHandle) -> Result<PathBuf, String> {
+    let root = claude_projects_root()?;
+    fs::create_dir_all(&root).map_err(|e| format!("failed to create claude projects root: {e}"))?;
+
+    let mut state = CLAUDE_WATCHER_STATE
+        .lock()
+        .map_err(|e| format!("watcher state lock poisoned: {e}"))?;
+
+    // Stop any existing watcher first.
+    if state.running {
+        if let Some(sender) = state.stop_sender.take() {
+            let _ = sender.send(());
+        }
+        state.watcher = None;
+        state.running = false;
+    }
+
+    let (stop_tx, stop_rx) = channel::<()>();
+    let (event_tx, event_rx) = channel::<Result<Event, notify::Error>>();
+
+    let mut watcher = RecommendedWatcher::new(
+        move |res| {
+            if let Err(e) = event_tx.send(res) {
+                log::warn!("[ClaudeMemory] event channel closed: {e}");
+            }
+        },
+        Config::default(),
+    )
+    .map_err(|e| format!("failed to create claude memory watcher: {e}"))?;
+
+    watcher
+        .watch(&root, RecursiveMode::Recursive)
+        .map_err(|e| format!("failed to watch {}: {e}", root.display()))?;
+
+    state.watcher = Some(watcher);
+    state.stop_sender = Some(stop_tx);
+    state.roots = vec![root.clone()];
+    state.running = true;
+    drop(state);
+
+    let app_clone = app.clone();
+    thread::spawn(move || {
+        run_event_loop(app_clone, event_rx, stop_rx);
+    });
+
+    log::info!(
+        "[ClaudeMemory] watcher started on {} (recursive)",
+        root.display()
+    );
+
+    Ok(root)
+}
+
+/// Stop the watcher if running. Safe to call multiple times.
+pub fn stop_watcher() -> Result<(), String> {
+    let mut state = CLAUDE_WATCHER_STATE
+        .lock()
+        .map_err(|e| format!("watcher state lock poisoned: {e}"))?;
+
+    if let Some(sender) = state.stop_sender.take() {
+        let _ = sender.send(());
+    }
+    state.watcher = None;
+    state.roots.clear();
+    state.running = false;
+    log::info!("[ClaudeMemory] watcher stopped");
+    Ok(())
+}
+
+/// Is the watcher currently running?
+pub fn is_watcher_running() -> bool {
+    CLAUDE_WATCHER_STATE
+        .lock()
+        .map(|s| s.running)
+        .unwrap_or(false)
+}
+
+fn run_event_loop(
+    app: AppHandle,
+    event_rx: Receiver<Result<Event, notify::Error>>,
+    stop_rx: Receiver<()>,
+) {
+    // Lightweight debounce — the same file often gets multiple events in a burst
+    // when editors save. We require a 250ms quiet period before processing.
+    let debounce_window = Duration::from_millis(250);
+    let mut pending: HashMap<PathBuf, Instant> = HashMap::new();
+
+    loop {
+        if stop_rx.try_recv().is_ok() {
+            log::debug!("[ClaudeMemory] received stop signal, exiting event loop");
+            break;
+        }
+
+        match event_rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(Ok(event)) => {
+                if !is_interesting_event(&event.kind) {
+                    continue;
+                }
+                for path in event.paths {
+                    if should_intercept_path(&path) {
+                        pending.insert(path, Instant::now());
+                    }
+                }
+            }
+            Ok(Err(e)) => {
+                log::warn!("[ClaudeMemory] watch error: {e}");
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                log::debug!("[ClaudeMemory] event channel disconnected, exiting");
+                break;
+            }
+        }
+
+        // Flush any paths whose quiet window has elapsed.
+        let now = Instant::now();
+        let ready: Vec<PathBuf> = pending
+            .iter()
+            .filter_map(|(path, seen)| {
+                if now.duration_since(*seen) >= debounce_window {
+                    Some(path.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for path in ready {
+            pending.remove(&path);
+            if let Err(e) = process_memory_file(&app, &path) {
+                log::warn!(
+                    "[ClaudeMemory] failed to process {}: {e}",
+                    path.display()
+                );
+            }
+        }
+    }
+}
+
+fn is_interesting_event(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Any
+    )
+}
+
+/// Should this path be intercepted? True when it sits inside a `memory/` directory
+/// under a Claude project root and is a `.md` file that is NOT `MEMORY.md`.
+pub fn should_intercept_path(path: &Path) -> bool {
+    if path.extension().and_then(|e| e.to_str()) != Some("md") {
+        return false;
+    }
+    let file_name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(n) => n,
+        None => return false,
+    };
+    if file_name.eq_ignore_ascii_case(RENDERED_INDEX_FILENAME) {
+        return false;
+    }
+    // Require a parent component named `memory`.
+    path.parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .map(|n| n == "memory")
+        .unwrap_or(false)
+}
+
+/// Process a single memory file: read, parse, persist to the local memory cache
+/// (which the existing sync engine will push to SerenDB), then delete the file.
+fn process_memory_file(app: &AppHandle, path: &Path) -> Result<(), String> {
+    // The path may have been removed between the event and now.
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let contents = fs::read_to_string(path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    if contents.trim().is_empty() {
+        return Ok(());
+    }
+
+    let parsed = parse_memory_file(&contents);
+
+    let memory_type = parsed
+        .frontmatter
+        .memory_type
+        .clone()
+        .unwrap_or_else(|| CLAUDE_PREFERENCE_MEMORY_TYPE.to_string());
+
+    // Identify the owning project (the directory Claude Code was invoked from).
+    // For now we use the best-effort encoded dir name as the project_identity hint
+    // in metadata — we do NOT rely on it for DB row keys (integration with the
+    // existing memory stack handles that via the user's SerenDB project UUID).
+    let project_hint = path
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .map(String::from)
+        .unwrap_or_default();
+
+    let source_file = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(String::from)
+        .unwrap_or_default();
+
+    let metadata = serde_json::json!({
+        "source": "claude_memory_interceptor",
+        "source_file": source_file,
+        "claude_project_dir": project_hint,
+        "frontmatter": {
+            "name": parsed.frontmatter.name,
+            "description": parsed.frontmatter.description,
+            "type": parsed.frontmatter.memory_type,
+        },
+    });
+
+    let state = app.state::<MemoryState>();
+    let persisted_id = persist_memory_local(&state, contents, memory_type.clone(), metadata)?;
+
+    // Delete the on-disk copy: the data now lives in the encrypted local cache
+    // (not plaintext) and will be synced to SerenDB on the next sync pass.
+    let deleted = fs::remove_file(path).is_ok();
+
+    let _ = app.emit(
+        "claude-memory-intercepted",
+        InterceptEvent {
+            path: path.to_string_lossy().to_string(),
+            name: parsed.frontmatter.name,
+            memory_type,
+            persisted_id,
+            deleted,
+        },
+    );
+
+    log::info!(
+        "[ClaudeMemory] intercepted {} (deleted={})",
+        path.display(),
+        deleted
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Startup migration
+// ---------------------------------------------------------------------------
+
+/// Walk every `~/.claude/projects/*/memory/` directory and intercept any `.md`
+/// files already on disk. Called once on startup to migrate pre-existing files.
+pub fn migrate_existing_files(app: &AppHandle) -> Result<usize, String> {
+    let root = claude_projects_root()?;
+    if !root.exists() {
+        return Ok(0);
+    }
+
+    let mut migrated = 0usize;
+    let project_dirs = match fs::read_dir(&root) {
+        Ok(d) => d,
+        Err(e) => return Err(format!("failed to read claude projects root: {e}")),
+    };
+
+    for entry in project_dirs.flatten() {
+        let memory_dir = entry.path().join("memory");
+        if !memory_dir.is_dir() {
+            continue;
+        }
+        let files = match fs::read_dir(&memory_dir) {
+            Ok(f) => f,
+            Err(_) => continue,
+        };
+        for file in files.flatten() {
+            let path = file.path();
+            if !should_intercept_path(&path) {
+                continue;
+            }
+            match process_memory_file(app, &path) {
+                Ok(()) => migrated += 1,
+                Err(e) => log::warn!(
+                    "[ClaudeMemory] migration skipped {}: {e}",
+                    path.display()
+                ),
+            }
+        }
+    }
+
+    log::info!("[ClaudeMemory] startup migration processed {} files", migrated);
+    Ok(migrated)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn parse_memory_file_extracts_frontmatter_and_body() {
+        let input = "---\nname: foo\ndescription: hello world\ntype: feedback\n---\nbody line one\nbody line two\n";
+        let parsed = parse_memory_file(input);
+        assert_eq!(parsed.frontmatter.name.as_deref(), Some("foo"));
+        assert_eq!(
+            parsed.frontmatter.description.as_deref(),
+            Some("hello world")
+        );
+        assert_eq!(parsed.frontmatter.memory_type.as_deref(), Some("feedback"));
+        assert_eq!(parsed.body, "body line one\nbody line two");
+    }
+
+    #[test]
+    fn parse_memory_file_handles_missing_frontmatter() {
+        let input = "just a body with no frontmatter\n";
+        let parsed = parse_memory_file(input);
+        assert_eq!(parsed.frontmatter, MemoryFrontmatter::default());
+        assert_eq!(parsed.body, "just a body with no frontmatter");
+    }
+
+    #[test]
+    fn parse_memory_file_handles_unterminated_frontmatter() {
+        // No closing `---` — must NOT crash, must fall through to body.
+        let input = "---\nname: foo\ndescription: still going";
+        let parsed = parse_memory_file(input);
+        assert_eq!(parsed.frontmatter, MemoryFrontmatter::default());
+        assert!(parsed.body.contains("still going"));
+    }
+
+    #[test]
+    fn normalize_git_remote_handles_scp_and_https() {
+        assert_eq!(
+            normalize_git_remote("git@github.com:serenorg/seren-desktop.git"),
+            "github.com/serenorg/seren-desktop"
+        );
+        assert_eq!(
+            normalize_git_remote("https://github.com/serenorg/seren-desktop.git"),
+            "github.com/serenorg/seren-desktop"
+        );
+        assert_eq!(
+            normalize_git_remote("https://user:token@github.com/serenorg/seren-desktop"),
+            "github.com/serenorg/seren-desktop"
+        );
+        assert_eq!(
+            normalize_git_remote("https://GitHub.com/serenorg/seren-desktop/"),
+            "github.com/serenorg/seren-desktop"
+        );
+    }
+
+    #[test]
+    fn resolve_project_identity_prefers_git_remote() {
+        let tmp = TempDir::new().expect("tempdir");
+        let git_dir = tmp.path().join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"]\n\turl = git@github.com:serenorg/seren-desktop.git\n",
+        )
+        .unwrap();
+
+        let identity = resolve_project_identity(tmp.path()).expect("identity");
+        assert_eq!(identity.source, ProjectIdentitySource::GitRemote);
+        assert_eq!(identity.identifier, "github.com/serenorg/seren-desktop");
+    }
+
+    #[test]
+    fn resolve_project_identity_persists_uuid_fallback() {
+        let tmp = TempDir::new().expect("tempdir");
+        let first = resolve_project_identity(tmp.path()).expect("first identity");
+        assert_eq!(first.source, ProjectIdentitySource::GeneratedUuid);
+        // UUID must survive on disk for subsequent calls.
+        let second = resolve_project_identity(tmp.path()).expect("second identity");
+        assert_eq!(second.source, ProjectIdentitySource::PersistedUuid);
+        assert_eq!(first.identifier, second.identifier);
+    }
+
+    #[test]
+    fn should_intercept_path_rules() {
+        let memory_dir = Path::new("/home/a/.claude/projects/-proj/memory");
+        assert!(should_intercept_path(&memory_dir.join("feedback.md")));
+        assert!(!should_intercept_path(&memory_dir.join("MEMORY.md")));
+        assert!(!should_intercept_path(&memory_dir.join("memory.txt")));
+        // Not inside a `memory/` dir.
+        assert!(!should_intercept_path(Path::new(
+            "/home/a/.claude/projects/-proj/foo.md"
+        )));
+    }
+
+    #[test]
+    fn write_rendered_memory_md_is_atomic_overwrite() {
+        let tmp = TempDir::new().expect("tempdir");
+        let dir = tmp.path().join("-proj");
+        let first = write_rendered_memory_md(&dir, "first render").expect("first");
+        assert_eq!(fs::read_to_string(&first).unwrap(), "first render");
+        let second = write_rendered_memory_md(&dir, "second render").expect("second");
+        assert_eq!(fs::read_to_string(&second).unwrap(), "second render");
+        // Temp file must not linger.
+        assert!(!dir.join("MEMORY.md.tmp").exists());
+    }
+}

--- a/src-tauri/src/commands/claude_memory.rs
+++ b/src-tauri/src/commands/claude_memory.rs
@@ -1,0 +1,126 @@
+// ABOUTME: Tauri commands for the Claude Code auto-memory interceptor.
+// ABOUTME: Exposes start/stop/status, startup migration, render, and identity lookup.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use tauri::{AppHandle, State};
+
+use crate::claude_memory;
+use crate::commands::memory::MemoryState;
+
+/// Public status snapshot for the frontend.
+#[derive(Debug, Serialize)]
+pub struct ClaudeMemoryStatus {
+    pub running: bool,
+    pub watching_root: Option<String>,
+}
+
+/// Public project identity payload for the frontend.
+#[derive(Debug, Serialize)]
+pub struct ClaudeMemoryProjectIdentity {
+    pub identifier: String,
+    pub source: String,
+}
+
+/// Start watching `~/.claude/projects/*/memory/` for Claude Code memory writes.
+#[tauri::command]
+pub fn claude_memory_start(app: AppHandle) -> Result<ClaudeMemoryStatus, String> {
+    let root = claude_memory::start_watcher(app)?;
+    Ok(ClaudeMemoryStatus {
+        running: true,
+        watching_root: Some(root.to_string_lossy().to_string()),
+    })
+}
+
+/// Stop the watcher if running.
+#[tauri::command]
+pub fn claude_memory_stop() -> Result<ClaudeMemoryStatus, String> {
+    claude_memory::stop_watcher()?;
+    Ok(ClaudeMemoryStatus {
+        running: false,
+        watching_root: None,
+    })
+}
+
+/// Return the current watcher status without mutating it.
+#[tauri::command]
+pub fn claude_memory_status() -> Result<ClaudeMemoryStatus, String> {
+    let running = claude_memory::is_watcher_running();
+    let watching_root = if running {
+        claude_memory::claude_projects_root()
+            .ok()
+            .map(|p| p.to_string_lossy().to_string())
+    } else {
+        None
+    };
+    Ok(ClaudeMemoryStatus {
+        running,
+        watching_root,
+    })
+}
+
+/// Walk every existing Claude memory directory and intercept any files already
+/// on disk. Returns the number migrated.
+#[tauri::command]
+pub fn claude_memory_migrate_existing(app: AppHandle) -> Result<usize, String> {
+    claude_memory::migrate_existing_files(&app)
+}
+
+/// Resolve a stable project identifier for `project_cwd` (git remote or UUID).
+#[tauri::command]
+pub fn claude_memory_get_project_identity(
+    project_cwd: String,
+) -> Result<ClaudeMemoryProjectIdentity, String> {
+    let identity = claude_memory::resolve_project_identity(Path::new(&project_cwd))?;
+    let source = match identity.source {
+        claude_memory::ProjectIdentitySource::GitRemote => "git_remote",
+        claude_memory::ProjectIdentitySource::PersistedUuid => "persisted_uuid",
+        claude_memory::ProjectIdentitySource::GeneratedUuid => "generated_uuid",
+    }
+    .to_string();
+    Ok(ClaudeMemoryProjectIdentity {
+        identifier: identity.identifier,
+        source,
+    })
+}
+
+/// Render `~/.claude/projects/<encoded(project_cwd)>/MEMORY.md` from the
+/// authenticated user's SerenDB memory bootstrap. Used by the frontend when a
+/// project is opened so Claude Code reads fresh content on the next session.
+#[tauri::command]
+pub async fn claude_memory_render_memory_md(
+    app: AppHandle,
+    state: State<'_, MemoryState>,
+    project_cwd: String,
+    project_id: Option<String>,
+) -> Result<String, String> {
+    // Ensure the Claude project dir exists (Claude Code creates it lazily; if the
+    // user hasn't run a session yet we still want a rendered MEMORY.md ready).
+    let root = claude_memory::claude_projects_root()?;
+    let encoded = claude_memory::encode_project_dir(Path::new(&project_cwd));
+    let claude_project_dir: PathBuf = root.join(&encoded);
+
+    // Fetch the assembled memory prompt. Failures render a fallback header so
+    // Claude Code never sees stale plaintext — it sees a clear "DB unavailable"
+    // marker that tells the user preferences are being rehydrated in background.
+    let rendered = match super::memory::memory_bootstrap(
+        app.clone(),
+        state,
+        project_id,
+    )
+    .await
+    {
+        Ok(Some(prompt)) if !prompt.trim().is_empty() => prompt,
+        Ok(_) => "# Claude Memory\n\n_No preferences stored yet._\n".to_string(),
+        Err(e) => {
+            log::warn!("[ClaudeMemory] memory_bootstrap failed during render: {e}");
+            format!(
+                "# Claude Memory\n\n> Preferences are rehydrating from SerenDB. This message will be replaced on the next successful sync.\n\n_Last error: {e}_\n"
+            )
+        }
+    };
+
+    let final_path = claude_memory::write_rendered_memory_md(&claude_project_dir, &rendered)?;
+    Ok(final_path.to_string_lossy().to_string())
+}

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -19,7 +19,7 @@ const TOKEN_KEY: &str = "token";
 /// Managed state for memory operations.
 pub struct MemoryState {
     base_url: String,
-    cache_path: PathBuf,
+    pub(crate) cache_path: PathBuf,
     cache: Mutex<Option<LocalCache>>,
 }
 
@@ -61,6 +61,42 @@ impl MemoryState {
         }
         Ok(())
     }
+}
+
+/// Write a memory directly to the local encrypted cache without requiring an
+/// authenticated cloud call. Used by the Claude memory interceptor which runs
+/// on a synchronous file-watcher thread — the existing `memory_sync` engine
+/// will push these entries to SerenDB on the next sync pass.
+///
+/// Returns the local UUID of the cached entry.
+pub fn persist_memory_local(
+    state: &MemoryState,
+    content: String,
+    memory_type: String,
+    metadata: serde_json::Value,
+) -> Result<String, String> {
+    state.ensure_cache()?;
+    let local_id = uuid::Uuid::new_v4();
+    let cached = CachedMemory {
+        id: local_id,
+        content,
+        memory_type,
+        metadata,
+        embedding: vec![0.0; 1536],
+        relevance_score: 1.0,
+        created_at: seren_memory_sdk::chrono::Utc::now(),
+        synced: false,
+        cloud_id: None,
+    };
+    let guard = state.cache.lock().map_err(|e| e.to_string())?;
+    if let Some(cache) = guard.as_ref() {
+        cache
+            .insert_memory(&cached)
+            .map_err(|e| format!("failed to insert cached memory: {e}"))?;
+    } else {
+        return Err("memory cache unavailable".to_string());
+    }
+    Ok(local_id.to_string())
 }
 
 /// Output type for bootstrap (serializable to frontend).
@@ -144,25 +180,12 @@ pub async fn memory_remember(
 
     // Write to local cache first (synced=false) so memory survives cloud failures
     // such as scale-to-zero cold starts. The sync engine will push pending entries later.
-    let local_id = uuid::Uuid::new_v4();
-    state.ensure_cache()?;
-    let cached = CachedMemory {
-        id: local_id,
-        content: content.clone(),
-        memory_type: memory_type.clone(),
-        metadata: serde_json::json!({}),
-        embedding: vec![0.0; 1536],
-        relevance_score: 1.0,
-        created_at: seren_memory_sdk::chrono::Utc::now(),
-        synced: false,
-        cloud_id: None,
-    };
-    {
-        let guard = state.cache.lock().map_err(|e| e.to_string())?;
-        if let Some(cache) = guard.as_ref() {
-            cache.insert_memory(&cached).ok();
-        }
-    }
+    let local_id = persist_memory_local(
+        &state,
+        content.clone(),
+        memory_type.clone(),
+        serde_json::json!({}),
+    )?;
 
     // Attempt cloud sync (best-effort; service may be warming up from scale-to-zero).
     match client
@@ -172,7 +195,7 @@ pub async fn memory_remember(
         Ok(result) => Ok(result),
         Err(e) => {
             log::warn!("Cloud remember failed (local cache saved, will sync later): {e}");
-            Ok(local_id.to_string())
+            Ok(local_id)
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use tauri_plugin_store::StoreExt;
 
 pub mod commands {
     pub mod chat;
+    pub mod claude_memory;
     pub mod cli_installer;
     pub mod gateway_http;
     pub mod indexing;
@@ -25,6 +26,7 @@ pub mod services {
 }
 
 mod auth;
+mod claude_memory;
 mod claude_setup;
 mod embedded_runtime;
 mod files;
@@ -791,6 +793,13 @@ pub fn run() {
             commands::memory::memory_remember,
             commands::memory::memory_recall,
             commands::memory::memory_sync,
+            // Claude Code auto-memory interceptor commands
+            commands::claude_memory::claude_memory_start,
+            commands::claude_memory::claude_memory_stop,
+            commands::claude_memory::claude_memory_status,
+            commands::claude_memory::claude_memory_migrate_existing,
+            commands::claude_memory::claude_memory_get_project_identity,
+            commands::claude_memory::claude_memory_render_memory_md,
             // Runtime session commands
             commands::session::create_runtime_session,
             commands::session::get_runtime_session,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,10 @@ import { getRuntimeConfig } from "@/lib/runtime";
 import { shortcuts } from "@/lib/shortcuts";
 import { Phase3Playground } from "@/playground/Phase3Playground";
 import { initAutoTopUp } from "@/services/autoTopUp";
+import {
+  migrateExistingClaudeMemory,
+  startClaudeMemoryInterceptor,
+} from "@/services/claudeMemory";
 import { syncMemories } from "@/services/memory";
 import { telemetry } from "@/services/telemetry";
 import { agentStore } from "@/stores/agent.store";
@@ -82,6 +86,30 @@ function App() {
 
     // Load all settings including app settings (chatDefaultModel, etc.) and MCP settings
     await loadAllSettings();
+
+    // Start the Claude Code auto-memory interceptor if enabled. This watches
+    // ~/.claude/projects/*\/memory/ for plaintext memory writes and redirects
+    // them into SerenDB through the existing memory stack. Failures are
+    // non-fatal — the app still works, we just log a warning.
+    const { settingsStore } = await import("@/stores/settings.store");
+    if (settingsStore.get("claudeMemoryInterceptEnabled")) {
+      try {
+        await startClaudeMemoryInterceptor();
+        if (settingsStore.get("claudeMemoryMigrateOnStartup")) {
+          const migrated = await migrateExistingClaudeMemory();
+          if (migrated > 0) {
+            console.info(
+              `[ClaudeMemory] Migrated ${migrated} plaintext memory file(s) to SerenDB on startup.`,
+            );
+          }
+        }
+      } catch (error) {
+        console.warn(
+          "[ClaudeMemory] Failed to start auto-memory interceptor:",
+          error,
+        );
+      }
+    }
 
     // Load provider settings - this restores the last used model from previous session
     await providerStore.loadSettings();

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -10,6 +10,12 @@ import {
   Show,
 } from "solid-js";
 import { isBuiltinServer, isLocalServer } from "@/lib/mcp/types";
+import {
+  getClaudeMemoryStatus,
+  migrateExistingClaudeMemory,
+  startClaudeMemoryInterceptor,
+  stopClaudeMemoryInterceptor,
+} from "@/services/claudeMemory";
 import { allowsSerenPublicModels } from "@/services/organization-policy";
 import { authStore } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
@@ -52,6 +58,64 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
     createSignal<SettingsSection>("chat");
   const [showResetConfirm, setShowResetConfirm] = createSignal(false);
   const [showClearConfirm, setShowClearConfirm] = createSignal(false);
+
+  // Claude Code auto-memory interceptor state.
+  const [claudeMemoryRunning, setClaudeMemoryRunning] = createSignal(false);
+  const [claudeMemoryWatchingRoot, setClaudeMemoryWatchingRoot] = createSignal<
+    string | null
+  >(null);
+  const [claudeMemoryBusy, setClaudeMemoryBusy] = createSignal(false);
+  const [claudeMemoryMessage, setClaudeMemoryMessage] = createSignal<
+    string | null
+  >(null);
+
+  const refreshClaudeMemoryStatus = async () => {
+    try {
+      const status = await getClaudeMemoryStatus();
+      setClaudeMemoryRunning(status.running);
+      setClaudeMemoryWatchingRoot(status.watching_root);
+    } catch (err) {
+      console.warn("[ClaudeMemory] failed to read status", err);
+    }
+  };
+
+  const handleClaudeMemoryToggle = async (enabled: boolean) => {
+    handleBooleanChange("claudeMemoryInterceptEnabled", enabled);
+    setClaudeMemoryBusy(true);
+    setClaudeMemoryMessage(null);
+    try {
+      const status = enabled
+        ? await startClaudeMemoryInterceptor()
+        : await stopClaudeMemoryInterceptor();
+      setClaudeMemoryRunning(status.running);
+      setClaudeMemoryWatchingRoot(status.watching_root);
+    } catch (err) {
+      setClaudeMemoryMessage(
+        `Failed to ${enabled ? "start" : "stop"} interceptor: ${err}`,
+      );
+      console.error("[ClaudeMemory] toggle failed", err);
+    } finally {
+      setClaudeMemoryBusy(false);
+    }
+  };
+
+  const handleClaudeMemoryMigrate = async () => {
+    setClaudeMemoryBusy(true);
+    setClaudeMemoryMessage(null);
+    try {
+      const migrated = await migrateExistingClaudeMemory();
+      setClaudeMemoryMessage(
+        migrated === 0
+          ? "No plaintext memory files found."
+          : `Migrated ${migrated} file${migrated === 1 ? "" : "s"} to SerenDB.`,
+      );
+    } catch (err) {
+      setClaudeMemoryMessage(`Migration failed: ${err}`);
+      console.error("[ClaudeMemory] migration failed", err);
+    } finally {
+      setClaudeMemoryBusy(false);
+    }
+  };
 
   const handleNumberChange = (key: keyof Settings, value: string) => {
     const num = Number.parseFloat(value);
@@ -151,6 +215,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
       "seren:open-settings-section",
       handleOpenSection as EventListener,
     );
+    refreshClaudeMemoryStatus();
   });
 
   onCleanup(() => {
@@ -1339,6 +1404,98 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                 </span>
               </label>
             </div>
+
+            <h4 class="mt-6 mb-3 text-base font-semibold text-muted-foreground border-t border-border-medium pt-5">
+              Claude Code Auto-Memory Interceptor
+            </h4>
+            <p class="m-0 mb-4 text-[0.85rem] text-muted-foreground leading-relaxed">
+              Claude Code's built-in auto-memory writes plain markdown files to{" "}
+              <code class="px-1 py-0.5 rounded bg-border/40 text-[0.78rem]">
+                ~/.claude/projects/*/memory/
+              </code>
+              . When enabled, Seren Desktop intercepts those writes and
+              redirects them to SerenDB through the existing Persistent Memory
+              stack. Files never stay on disk as plaintext.
+            </p>
+
+            <div class="flex items-start justify-start gap-4 py-3 border-b border-border">
+              <label class="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={settingsState.app.claudeMemoryInterceptEnabled}
+                  disabled={claudeMemoryBusy()}
+                  onChange={(e) =>
+                    handleClaudeMemoryToggle(e.currentTarget.checked)
+                  }
+                  class="w-[18px] h-[18px] mt-0.5 accent-accent cursor-pointer"
+                />
+                <span class="flex flex-col gap-0.5">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Secure Claude Memory Storage
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Watch Claude Code memory directories, persist writes to
+                    SerenDB via the existing authenticated memory stack, and
+                    remove the plaintext files from disk. Uses the same project
+                    and user identity as Persistent Memory above — requires
+                    Enable Memory to be on and a SerenDB login.
+                  </span>
+                </span>
+              </label>
+            </div>
+
+            <div class="flex items-start justify-start gap-4 py-3 border-b border-border">
+              <label class="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={settingsState.app.claudeMemoryMigrateOnStartup}
+                  onChange={(e) =>
+                    handleBooleanChange(
+                      "claudeMemoryMigrateOnStartup",
+                      e.currentTarget.checked,
+                    )
+                  }
+                  class="w-[18px] h-[18px] mt-0.5 accent-accent cursor-pointer"
+                />
+                <span class="flex flex-col gap-0.5">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Migrate Existing Files On Startup
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    On app launch, scan every Claude memory directory and
+                    migrate any pre-existing <code>.md</code> files into
+                    SerenDB, then delete them from disk.
+                  </span>
+                </span>
+              </label>
+            </div>
+
+            <div class="flex items-center justify-between py-3 border-b border-border">
+              <div class="flex flex-col gap-0.5">
+                <span class="text-[0.85rem] font-medium text-foreground">
+                  Interceptor Status
+                </span>
+                <span class="text-[0.78rem] text-muted-foreground">
+                  {claudeMemoryRunning()
+                    ? `Watching ${claudeMemoryWatchingRoot() ?? "Claude projects directory"}`
+                    : "Watcher is stopped."}
+                </span>
+              </div>
+              <button
+                type="button"
+                disabled={claudeMemoryBusy()}
+                class="px-3 py-1.5 text-[0.8rem] rounded-md border border-border-strong bg-transparent hover:bg-border text-foreground cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={handleClaudeMemoryMigrate}
+              >
+                {claudeMemoryBusy() ? "Working…" : "Migrate Existing Files"}
+              </button>
+            </div>
+
+            <Show when={claudeMemoryMessage()}>
+              <p class="m-0 mt-2 text-[0.78rem] text-muted-foreground">
+                {claudeMemoryMessage()}
+              </p>
+            </Show>
           </section>
         </Show>
 

--- a/src/services/claudeMemory.ts
+++ b/src/services/claudeMemory.ts
@@ -1,0 +1,101 @@
+// ABOUTME: Frontend service for the Claude Code auto-memory interceptor.
+// ABOUTME: Starts/stops the Rust watcher and renders MEMORY.md from SerenDB on demand.
+
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+import { projectStore } from "@/stores/project.store";
+
+export interface ClaudeMemoryStatus {
+  running: boolean;
+  watching_root: string | null;
+}
+
+export interface ClaudeMemoryProjectIdentity {
+  identifier: string;
+  source: "git_remote" | "persisted_uuid" | "generated_uuid";
+}
+
+export interface InterceptEvent {
+  path: string;
+  name: string | null;
+  memory_type: string;
+  persisted_id: string;
+  deleted: boolean;
+}
+
+/**
+ * Start the filesystem watcher that intercepts Claude Code memory writes.
+ */
+export async function startClaudeMemoryInterceptor(): Promise<ClaudeMemoryStatus> {
+  if (!isTauriRuntime()) {
+    return { running: false, watching_root: null };
+  }
+  return invoke<ClaudeMemoryStatus>("claude_memory_start");
+}
+
+/**
+ * Stop the watcher. Safe to call even if it is not running.
+ */
+export async function stopClaudeMemoryInterceptor(): Promise<ClaudeMemoryStatus> {
+  if (!isTauriRuntime()) {
+    return { running: false, watching_root: null };
+  }
+  return invoke<ClaudeMemoryStatus>("claude_memory_stop");
+}
+
+/**
+ * Read the current watcher status without mutating it.
+ */
+export async function getClaudeMemoryStatus(): Promise<ClaudeMemoryStatus> {
+  if (!isTauriRuntime()) {
+    return { running: false, watching_root: null };
+  }
+  return invoke<ClaudeMemoryStatus>("claude_memory_status");
+}
+
+/**
+ * Walk every existing Claude memory directory and migrate any plaintext files
+ * already on disk. Returns the number migrated.
+ */
+export async function migrateExistingClaudeMemory(): Promise<number> {
+  if (!isTauriRuntime()) {
+    return 0;
+  }
+  return invoke<number>("claude_memory_migrate_existing");
+}
+
+/**
+ * Resolve a stable identifier for a project directory. Uses the git remote URL
+ * when available, otherwise a persisted UUID at `<cwd>/.claude/project_id`.
+ */
+export async function getClaudeProjectIdentity(
+  projectCwd: string,
+): Promise<ClaudeMemoryProjectIdentity | null> {
+  if (!isTauriRuntime()) {
+    return null;
+  }
+  return invoke<ClaudeMemoryProjectIdentity>(
+    "claude_memory_get_project_identity",
+    {
+      projectCwd,
+    },
+  );
+}
+
+/**
+ * Render `~/.claude/projects/<encoded(projectCwd)>/MEMORY.md` from the user's
+ * SerenDB memory bootstrap. Should be called when the user opens a project so
+ * that Claude Code reads fresh content on its next session start.
+ */
+export async function renderClaudeMemoryMd(
+  projectCwd: string,
+): Promise<string | null> {
+  if (!isTauriRuntime()) {
+    return null;
+  }
+  const projectId = projectStore.activeProject?.id ?? null;
+  return invoke<string>("claude_memory_render_memory_md", {
+    projectCwd,
+    projectId,
+  });
+}

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -93,6 +93,17 @@ export interface Settings {
 
   // Memory settings
   memoryEnabled: boolean;
+  /**
+   * Intercept Claude Code auto-memory writes (~/.claude/projects/*\/memory/*.md)
+   * and redirect them to SerenDB through the existing memory stack. When off,
+   * Claude Code's plaintext memory files are left untouched on disk.
+   */
+  claudeMemoryInterceptEnabled: boolean;
+  /**
+   * Migrate any pre-existing plaintext memory files to SerenDB on app startup.
+   * Only applies when the interceptor is enabled.
+   */
+  claudeMemoryMigrateOnStartup: boolean;
 
   // Agent settings
   agentSandboxMode: "read-only" | "workspace-write" | "full-access";
@@ -180,6 +191,8 @@ const DEFAULT_SETTINGS: Settings = {
   semanticIndexingEnabled: false,
   // Memory
   memoryEnabled: false,
+  claudeMemoryInterceptEnabled: true,
+  claudeMemoryMigrateOnStartup: true,
   // Agent
   agentSandboxMode: "workspace-write",
   agentApprovalPolicy: "on-request",

--- a/tests/services/claudeMemory.test.ts
+++ b/tests/services/claudeMemory.test.ts
@@ -1,0 +1,94 @@
+// ABOUTME: Critical tests for the Claude Code auto-memory interceptor service.
+// ABOUTME: Verifies the frontend wrapper dispatches to the correct Tauri commands.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invokeMock, projectStoreMock, isTauriMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  projectStoreMock: {
+    activeProject: { id: "project-1" } as { id: string } | null,
+  },
+  isTauriMock: vi.fn(() => true),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: isTauriMock,
+}));
+
+vi.mock("@/stores/project.store", () => ({
+  projectStore: projectStoreMock,
+}));
+
+import {
+  getClaudeMemoryStatus,
+  migrateExistingClaudeMemory,
+  renderClaudeMemoryMd,
+  startClaudeMemoryInterceptor,
+  stopClaudeMemoryInterceptor,
+} from "@/services/claudeMemory";
+
+describe("claudeMemory service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isTauriMock.mockReturnValue(true);
+    projectStoreMock.activeProject = { id: "project-1" };
+  });
+
+  it("dispatches start/stop/status to the correct Tauri commands", async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "claude_memory_start") {
+        return { running: true, watching_root: "/home/a/.claude/projects" };
+      }
+      if (command === "claude_memory_stop") {
+        return { running: false, watching_root: null };
+      }
+      if (command === "claude_memory_status") {
+        return { running: true, watching_root: "/home/a/.claude/projects" };
+      }
+      throw new Error(`unexpected command: ${command}`);
+    });
+
+    const started = await startClaudeMemoryInterceptor();
+    const status = await getClaudeMemoryStatus();
+    const stopped = await stopClaudeMemoryInterceptor();
+
+    expect(started.running).toBe(true);
+    expect(started.watching_root).toBe("/home/a/.claude/projects");
+    expect(status.running).toBe(true);
+    expect(stopped.running).toBe(false);
+    expect(invokeMock).toHaveBeenCalledWith("claude_memory_start");
+    expect(invokeMock).toHaveBeenCalledWith("claude_memory_status");
+    expect(invokeMock).toHaveBeenCalledWith("claude_memory_stop");
+  });
+
+  it("returns the migrated count from migrate_existing", async () => {
+    invokeMock.mockResolvedValue(7);
+    const count = await migrateExistingClaudeMemory();
+    expect(count).toBe(7);
+    expect(invokeMock).toHaveBeenCalledWith("claude_memory_migrate_existing");
+  });
+
+  it("passes the active SerenDB project id when rendering MEMORY.md", async () => {
+    invokeMock.mockResolvedValue("/home/a/.claude/projects/-proj/MEMORY.md");
+    await renderClaudeMemoryMd("/home/a/Projects/proj");
+    expect(invokeMock).toHaveBeenCalledWith("claude_memory_render_memory_md", {
+      projectCwd: "/home/a/Projects/proj",
+      projectId: "project-1",
+    });
+  });
+
+  it("no-ops in non-Tauri runtime", async () => {
+    isTauriMock.mockReturnValue(false);
+    const started = await startClaudeMemoryInterceptor();
+    const status = await getClaudeMemoryStatus();
+    const migrated = await migrateExistingClaudeMemory();
+    expect(started).toEqual({ running: false, watching_root: null });
+    expect(status).toEqual({ running: false, watching_root: null });
+    expect(migrated).toBe(0);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Implements #1492. Claude Code's built-in auto-memory system persists user preferences as **plaintext markdown** at `~/.claude/projects/*/memory/`. This adds a Rust filesystem watcher in the Seren Desktop sidecar that intercepts those writes, routes them through the existing authenticated memory stack (encrypted local cache → SerenDB sync), and deletes the plaintext file from disk.

Integrates with the existing `memory_remember` / `memory_bootstrap` pipeline and user auth token — does **not** create a parallel `/auth/agent` identity or a new table, resolving the split-brain blocker raised in the #1492 discussion.

- Rust: new [src-tauri/src/claude_memory.rs](src-tauri/src/claude_memory.rs) with a debounced `notify` watcher, frontmatter parser, project-identity resolver (git remote → persisted UUID → generated UUID), and atomic `MEMORY.md` renderer
- Rust: [src-tauri/src/commands/claude_memory.rs](src-tauri/src/commands/claude_memory.rs) exposes `claude_memory_start` / `claude_memory_stop` / `claude_memory_status` / `claude_memory_migrate_existing` / `claude_memory_get_project_identity` / `claude_memory_render_memory_md`
- Rust: extracted `persist_memory_local` in [src-tauri/src/commands/memory.rs](src-tauri/src/commands/memory.rs) so the synchronous watcher thread can write to the encrypted cache without going through the async command dispatcher. `memory_remember` now shares the same helper.
- Frontend: [src/services/claudeMemory.ts](src/services/claudeMemory.ts) wrapper with `isTauriRuntime` guards
- UI: new controls under the existing **Persistent Memory** section in [src/components/settings/SettingsPanel.tsx](src/components/settings/SettingsPanel.tsx) — toggle, startup-migration toggle, live status, and manual "Migrate Existing Files" button
- Settings: `claudeMemoryInterceptEnabled` and `claudeMemoryMigrateOnStartup` (both default **on**)
- Boot hook: [src/App.tsx](src/App.tsx) auto-starts the watcher after `loadAllSettings()`

### Why the original design changed
The three blockers raised in the #1492 comments are all addressed:

1. **Portability** — project identity is now the normalized git remote URL (with a persisted UUID fallback at `<cwd>/.claude/project_id`), not an absolute-path key
2. **Cold-start correctness** — the existing `memory_remember` path writes the local encrypted SQLite cache **first**, so the watcher gets correct-by-construction cold-start handling for free; cloud sync drains later via the existing `memory_sync` engine
3. **No split-brain** — reuses the existing user token, `memory_remember`, `memory_bootstrap`, and the existing Memory settings panel; no parallel `/auth/agent` identity, no new `claude_agent_preferences` table

## Test plan
- [x] `cargo test --lib claude_memory` — 8 new Rust unit tests (frontmatter parse, git remote normalization, project identity resolution, path interception rules, atomic MEMORY.md render)
- [x] `cargo test` — full Rust test suite, 301 passed
- [x] `pnpm test tests/services/claudeMemory.test.ts` — 4 new vitest tests for the frontend wrapper
- [x] `pnpm test` — full vitest suite, 327 passed (38 files)
- [x] `cargo check` — clean
- [x] `pnpm biome check` — no new warnings from changed files (pre-existing drift untouched)
- [ ] Manual smoke test on `pnpm tauri dev` (main branch) — verify start/stop, interception, and `MEMORY.md` render end-to-end

Resolves #1492.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
