### PR TITLE
feat(claude-memory): intercept Claude Code auto-memory writes to SerenDB

### DIFF
--- a/src-tauri/src/claude_memory.rs
+++ b/src-tauri/src/claude_memory.rs
@@ -1,0 +1,848 @@
+// ABOUTME: Intercepts Claude Code auto-memory writes and persists them to SerenDB.
+// ABOUTME: Watches ~/.claude/projects/*/memory/ and awaits a real cloud write per file.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+
+use seren_memory_sdk::client::MemoryClient;
+
+use crate::commands::memory::MemoryState;
+
+const AUTH_STORE: &str = "auth.json";
+const AUTH_TOKEN_KEY: &str = "token";
+const RENDERED_INDEX_FILENAME: &str = "MEMORY.md";
+const PROJECT_ID_FILENAME: &str = "project_id";
+const DEFAULT_MEMORY_TYPE: &str = "claude_preference";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Parsed frontmatter block from a Claude memory `.md` file.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryFrontmatter {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub memory_type: Option<String>,
+}
+
+/// Result of parsing a memory file: the frontmatter plus the body text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedMemoryFile {
+    pub frontmatter: MemoryFrontmatter,
+    pub body: String,
+}
+
+/// Stable identity for a project directory (git remote or persisted UUID).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectIdentity {
+    pub identifier: String,
+    pub source: ProjectIdentitySource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectIdentitySource {
+    GitRemote,
+    PersistedUuid,
+    GeneratedUuid,
+}
+
+/// Event emitted to the frontend after a successful SerenDB write.
+#[derive(Debug, Clone, Serialize)]
+pub struct InterceptSuccessEvent {
+    pub path: String,
+    pub name: Option<String>,
+    pub memory_type: String,
+    pub serendb_response: String,
+}
+
+/// Event emitted when the cloud write fails; the file is left on disk so the
+/// watcher can retry on the next event (or after an app restart).
+#[derive(Debug, Clone, Serialize)]
+pub struct InterceptFailureEvent {
+    pub path: String,
+    pub memory_type: String,
+    pub error: String,
+}
+
+/// Global watcher handle so we can start / stop / inspect from Tauri commands.
+struct WatcherSlot {
+    watcher: Option<RecommendedWatcher>,
+    stop_tx: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<()>>,
+    running: bool,
+    project_id: Option<Uuid>,
+}
+
+impl Default for WatcherSlot {
+    fn default() -> Self {
+        Self {
+            watcher: None,
+            stop_tx: None,
+            task: None,
+            running: false,
+            project_id: None,
+        }
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref WATCHER_SLOT: Arc<Mutex<WatcherSlot>> =
+        Arc::new(Mutex::new(WatcherSlot::default()));
+}
+
+// ---------------------------------------------------------------------------
+// Path / filesystem helpers
+// ---------------------------------------------------------------------------
+
+/// Return `~/.claude/projects`, creating it on demand.
+pub fn claude_projects_root() -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or_else(|| "Could not resolve home directory".to_string())?;
+    Ok(home.join(".claude").join("projects"))
+}
+
+/// Encode an absolute project directory the same way Claude Code does:
+/// `/Users/a/b` → `-Users-a-b`.
+pub fn encode_project_dir(cwd: &Path) -> String {
+    let resolved = cwd
+        .canonicalize()
+        .unwrap_or_else(|_| cwd.to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/");
+    let sanitized = resolved.trim_start_matches('/').replace(':', "");
+    format!("-{}", sanitized.replace('/', "-"))
+}
+
+/// True when `path` is a `.md` file inside a Claude project's `memory/` subdir
+/// **and** is not the rendered `MEMORY.md` index file.
+pub fn should_intercept_path(path: &Path) -> bool {
+    if path.extension().and_then(|e| e.to_str()) != Some("md") {
+        return false;
+    }
+    let file_name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(n) => n,
+        None => return false,
+    };
+    if file_name.eq_ignore_ascii_case(RENDERED_INDEX_FILENAME) {
+        return false;
+    }
+    path.parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .map(|n| n == "memory")
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Project identity
+// ---------------------------------------------------------------------------
+
+/// Resolve a stable identifier for a project directory:
+///   1. git remote URL (same repo → same identity across machines)
+///   2. UUID persisted at `<cwd>/.claude/project_id`
+///   3. A freshly generated UUID written to the same path
+pub fn resolve_project_identity(cwd: &Path) -> Result<ProjectIdentity, String> {
+    if let Some(remote) = read_git_remote_url(cwd) {
+        return Ok(ProjectIdentity {
+            identifier: normalize_git_remote(&remote),
+            source: ProjectIdentitySource::GitRemote,
+        });
+    }
+
+    let dot_claude = cwd.join(".claude");
+    let id_path = dot_claude.join(PROJECT_ID_FILENAME);
+
+    if let Ok(existing) = fs::read_to_string(&id_path) {
+        let trimmed = existing.trim().to_string();
+        if !trimmed.is_empty() {
+            return Ok(ProjectIdentity {
+                identifier: trimmed,
+                source: ProjectIdentitySource::PersistedUuid,
+            });
+        }
+    }
+
+    fs::create_dir_all(&dot_claude)
+        .map_err(|e| format!("failed to create .claude directory: {e}"))?;
+    let fresh = Uuid::new_v4().to_string();
+    fs::write(&id_path, &fresh).map_err(|e| format!("failed to persist project_id: {e}"))?;
+
+    Ok(ProjectIdentity {
+        identifier: fresh,
+        source: ProjectIdentitySource::GeneratedUuid,
+    })
+}
+
+fn read_git_remote_url(cwd: &Path) -> Option<String> {
+    let config = cwd.join(".git").join("config");
+    let text = fs::read_to_string(&config).ok()?;
+    let mut in_origin = false;
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.starts_with('[') {
+            in_origin = line == "[remote \"origin\"]";
+            continue;
+        }
+        if in_origin {
+            if let Some(rest) = line.strip_prefix("url") {
+                let value = rest.trim_start().trim_start_matches('=').trim();
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Normalize a git remote URL into a stable identifier (scheme-independent,
+/// trailing `.git` stripped, host lowercased).
+pub fn normalize_git_remote(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    let without_git = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+
+    if let Some(rest) = without_git.strip_prefix("git@") {
+        if let Some((host, path)) = rest.split_once(':') {
+            return format!("{}/{}", host.to_lowercase(), path.trim_start_matches('/'));
+        }
+    }
+
+    let after_scheme = match without_git.find("://") {
+        Some(idx) => &without_git[idx + 3..],
+        None => without_git,
+    };
+    let after_userinfo = after_scheme.rsplit_once('@').map_or(after_scheme, |t| t.1);
+
+    match after_userinfo.split_once('/') {
+        Some((host, path)) => format!("{}/{}", host.to_lowercase(), path),
+        None => after_userinfo.to_lowercase(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter parser (no YAML dep)
+// ---------------------------------------------------------------------------
+
+/// Parse a Claude memory `.md` file:
+///
+/// ```text
+/// ---
+/// name: foo
+/// description: short blurb
+/// type: feedback
+/// ---
+/// body...
+/// ```
+///
+/// Frontmatter is optional. Unterminated frontmatter falls through to body.
+pub fn parse_memory_file(contents: &str) -> ParsedMemoryFile {
+    let normalized = contents.replace("\r\n", "\n");
+    let trimmed_start = normalized.trim_start_matches('\n');
+
+    if !trimmed_start.starts_with("---") {
+        return ParsedMemoryFile {
+            frontmatter: MemoryFrontmatter::default(),
+            body: normalized.trim().to_string(),
+        };
+    }
+
+    let after_open = match trimmed_start.find('\n') {
+        Some(idx) => &trimmed_start[idx + 1..],
+        None => "",
+    };
+
+    let close_marker = "\n---";
+    let (front_text, body) = match after_open.find(close_marker) {
+        Some(idx) => {
+            let after_close = &after_open[idx + close_marker.len()..];
+            let body = match after_close.find('\n') {
+                Some(nl) => &after_close[nl + 1..],
+                None => "",
+            };
+            (&after_open[..idx], body)
+        }
+        None => {
+            return ParsedMemoryFile {
+                frontmatter: MemoryFrontmatter::default(),
+                body: normalized.trim().to_string(),
+            };
+        }
+    };
+
+    let mut map: HashMap<String, String> = HashMap::new();
+    for line in front_text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once(':') {
+            let key = key.trim().to_lowercase();
+            let value = value.trim().trim_matches('"').trim_matches('\'').to_string();
+            if !value.is_empty() {
+                map.insert(key, value);
+            }
+        }
+    }
+
+    ParsedMemoryFile {
+        frontmatter: MemoryFrontmatter {
+            name: map.remove("name"),
+            description: map.remove("description"),
+            memory_type: map.remove("type"),
+        },
+        body: body.trim().to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MEMORY.md rendering
+// ---------------------------------------------------------------------------
+
+/// Atomically write a rendered `MEMORY.md` (write tmp, then rename).
+pub fn write_rendered_memory_md(
+    claude_project_dir: &Path,
+    rendered: &str,
+) -> Result<PathBuf, String> {
+    fs::create_dir_all(claude_project_dir)
+        .map_err(|e| format!("failed to create claude project dir: {e}"))?;
+
+    let final_path = claude_project_dir.join(RENDERED_INDEX_FILENAME);
+    let tmp_path = claude_project_dir.join(format!("{RENDERED_INDEX_FILENAME}.tmp"));
+
+    fs::write(&tmp_path, rendered).map_err(|e| format!("failed to write temp MEMORY.md: {e}"))?;
+    fs::rename(&tmp_path, &final_path)
+        .map_err(|e| format!("failed to finalize MEMORY.md: {e}"))?;
+    Ok(final_path)
+}
+
+// ---------------------------------------------------------------------------
+// Core interception logic (testable without Tauri)
+// ---------------------------------------------------------------------------
+
+/// Read a single memory file, push it to SerenDB via the supplied
+/// authenticated [`MemoryClient`], and delete the file **only** on cloud
+/// success. On failure the file is left on disk so the watcher can retry.
+///
+/// This is the single unit of work for the interceptor — the tokio event
+/// loop calls it, the startup migration calls it, and the SerenDB
+/// round-trip integration test calls it. It does NOT touch the local
+/// `seren-memory-sdk` cache or any other memory stack.
+pub async fn process_memory_file(
+    path: &Path,
+    client: &MemoryClient,
+    project_id: Option<Uuid>,
+) -> Result<ProcessOutcome, String> {
+    if !path.exists() {
+        return Ok(ProcessOutcome::Skipped);
+    }
+
+    let contents = fs::read_to_string(path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    if contents.trim().is_empty() {
+        return Ok(ProcessOutcome::Skipped);
+    }
+
+    let parsed = parse_memory_file(&contents);
+    let memory_type = parsed
+        .frontmatter
+        .memory_type
+        .clone()
+        .unwrap_or_else(|| DEFAULT_MEMORY_TYPE.to_string());
+
+    // Await the REAL cloud write. On Err we return without deleting the file.
+    let serendb_response = client
+        .remember(&contents, &memory_type, project_id, None)
+        .await
+        .map_err(|e| format!("serendb remember failed: {e}"))?;
+
+    // Cloud write succeeded — now remove the plaintext file.
+    fs::remove_file(path).map_err(|e| format!("failed to delete {}: {e}", path.display()))?;
+
+    Ok(ProcessOutcome::Persisted {
+        name: parsed.frontmatter.name,
+        memory_type,
+        serendb_response,
+    })
+}
+
+/// Outcome of a single [`process_memory_file`] call.
+#[derive(Debug, Clone)]
+pub enum ProcessOutcome {
+    Skipped,
+    Persisted {
+        name: Option<String>,
+        memory_type: String,
+        serendb_response: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Tauri-facing auth + client bootstrap
+// ---------------------------------------------------------------------------
+
+fn read_auth_token(app: &AppHandle) -> Result<String, String> {
+    use tauri_plugin_store::StoreExt;
+    let token = app
+        .store(AUTH_STORE)
+        .map_err(|e| e.to_string())?
+        .get(AUTH_TOKEN_KEY)
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .unwrap_or_default();
+    if token.is_empty() {
+        return Err("unauthorized".to_string());
+    }
+    Ok(token)
+}
+
+fn build_client(app: &AppHandle) -> Result<MemoryClient, String> {
+    let token = read_auth_token(app)?;
+    let base_url = app.state::<MemoryState>().base_url().to_string();
+    Ok(MemoryClient::new(base_url, token))
+}
+
+// ---------------------------------------------------------------------------
+// Watcher lifecycle
+// ---------------------------------------------------------------------------
+
+/// Start watching `~/.claude/projects` recursively. Any `.md` write inside a
+/// `memory/` subdirectory will be intercepted, pushed to SerenDB, and deleted.
+///
+/// `project_id` is the user's active SerenDB project UUID — this is the same
+/// project the rest of the app uses for memory operations.
+pub fn start_watcher(app: AppHandle, project_id: Option<Uuid>) -> Result<PathBuf, String> {
+    // Validate credentials up-front so the user sees the error in the UI
+    // instead of discovering it via a silent watcher failure later.
+    let _ = build_client(&app)?;
+
+    let root = claude_projects_root()?;
+    fs::create_dir_all(&root).map_err(|e| format!("failed to create claude projects root: {e}"))?;
+
+    let mut slot = WATCHER_SLOT
+        .lock()
+        .map_err(|e| format!("watcher lock poisoned: {e}"))?;
+
+    // Idempotent: tear down any existing watcher first.
+    tear_down_locked(&mut slot);
+
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<PathBuf>();
+    let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+
+    let tx_for_callback = event_tx.clone();
+    let mut watcher = RecommendedWatcher::new(
+        move |res: Result<Event, notify::Error>| {
+            let Ok(event) = res else { return };
+            if !is_interesting_event(&event.kind) {
+                return;
+            }
+            for path in event.paths {
+                if should_intercept_path(&path) {
+                    // Unbounded tokio channel; send() is sync and non-blocking,
+                    // so this is safe on the notify thread.
+                    let _ = tx_for_callback.send(path);
+                }
+            }
+        },
+        Config::default(),
+    )
+    .map_err(|e| format!("failed to create watcher: {e}"))?;
+
+    watcher
+        .watch(&root, RecursiveMode::Recursive)
+        .map_err(|e| format!("failed to watch {}: {e}", root.display()))?;
+
+    // Spawn the async consumer. The channel is drained and each path is
+    // processed with a fresh MemoryClient (so token rotations are picked up).
+    let app_for_task = app.clone();
+    let task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                maybe_path = event_rx.recv() => {
+                    match maybe_path {
+                        Some(path) => {
+                            handle_event(&app_for_task, path, project_id).await;
+                        }
+                        None => break,
+                    }
+                }
+                _ = &mut stop_rx => {
+                    log::debug!("[ClaudeMemory] stop signal received; draining and exiting");
+                    break;
+                }
+            }
+        }
+    });
+
+    slot.watcher = Some(watcher);
+    slot.stop_tx = Some(stop_tx);
+    slot.task = Some(task);
+    slot.running = true;
+    slot.project_id = project_id;
+    drop(slot);
+
+    log::info!(
+        "[ClaudeMemory] watcher started on {} (project_id={:?})",
+        root.display(),
+        project_id
+    );
+    Ok(root)
+}
+
+/// Stop the watcher if running. Safe to call repeatedly.
+pub fn stop_watcher() -> Result<(), String> {
+    let mut slot = WATCHER_SLOT
+        .lock()
+        .map_err(|e| format!("watcher lock poisoned: {e}"))?;
+    tear_down_locked(&mut slot);
+    log::info!("[ClaudeMemory] watcher stopped");
+    Ok(())
+}
+
+fn tear_down_locked(slot: &mut WatcherSlot) {
+    if let Some(tx) = slot.stop_tx.take() {
+        let _ = tx.send(());
+    }
+    if let Some(task) = slot.task.take() {
+        task.abort();
+    }
+    slot.watcher = None;
+    slot.running = false;
+    slot.project_id = None;
+}
+
+/// Is the watcher currently running?
+pub fn is_watcher_running() -> bool {
+    WATCHER_SLOT.lock().map(|s| s.running).unwrap_or(false)
+}
+
+fn is_interesting_event(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Any
+    )
+}
+
+async fn handle_event(app: &AppHandle, path: PathBuf, project_id: Option<Uuid>) {
+    let memory_type_fallback = DEFAULT_MEMORY_TYPE.to_string();
+
+    let client = match build_client(app) {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!(
+                "[ClaudeMemory] skipping {}: cannot build SerenDB client: {e}",
+                path.display()
+            );
+            let _ = app.emit(
+                "claude-memory-intercept-failed",
+                InterceptFailureEvent {
+                    path: path.to_string_lossy().to_string(),
+                    memory_type: memory_type_fallback,
+                    error: e,
+                },
+            );
+            return;
+        }
+    };
+
+    match process_memory_file(&path, &client, project_id).await {
+        Ok(ProcessOutcome::Persisted {
+            name,
+            memory_type,
+            serendb_response,
+        }) => {
+            log::info!(
+                "[ClaudeMemory] persisted {} to SerenDB and removed plaintext file",
+                path.display()
+            );
+            let _ = app.emit(
+                "claude-memory-intercepted",
+                InterceptSuccessEvent {
+                    path: path.to_string_lossy().to_string(),
+                    name,
+                    memory_type,
+                    serendb_response,
+                },
+            );
+        }
+        Ok(ProcessOutcome::Skipped) => {}
+        Err(e) => {
+            log::warn!(
+                "[ClaudeMemory] {} left on disk — cloud write failed: {e}",
+                path.display()
+            );
+            let _ = app.emit(
+                "claude-memory-intercept-failed",
+                InterceptFailureEvent {
+                    path: path.to_string_lossy().to_string(),
+                    memory_type: memory_type_fallback,
+                    error: e,
+                },
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Startup migration
+// ---------------------------------------------------------------------------
+
+/// Walk every `~/.claude/projects/*/memory/` directory and push any pre-existing
+/// `.md` files to SerenDB. Returns the number successfully persisted. Files
+/// whose cloud write fails are left on disk and counted in `failures`.
+pub async fn migrate_existing_files(
+    app: &AppHandle,
+    project_id: Option<Uuid>,
+) -> Result<MigrationReport, String> {
+    let client = build_client(app)?;
+    let root = claude_projects_root()?;
+    if !root.exists() {
+        return Ok(MigrationReport::default());
+    }
+
+    let mut report = MigrationReport::default();
+    let project_dirs = fs::read_dir(&root)
+        .map_err(|e| format!("failed to read claude projects root: {e}"))?;
+
+    for entry in project_dirs.flatten() {
+        let memory_dir = entry.path().join("memory");
+        if !memory_dir.is_dir() {
+            continue;
+        }
+        let files = match fs::read_dir(&memory_dir) {
+            Ok(f) => f,
+            Err(_) => continue,
+        };
+        for file in files.flatten() {
+            let path = file.path();
+            if !should_intercept_path(&path) {
+                continue;
+            }
+            match process_memory_file(&path, &client, project_id).await {
+                Ok(ProcessOutcome::Persisted { .. }) => report.persisted += 1,
+                Ok(ProcessOutcome::Skipped) => {}
+                Err(e) => {
+                    log::warn!(
+                        "[ClaudeMemory] migration failed for {}: {e}",
+                        path.display()
+                    );
+                    report.failures += 1;
+                }
+            }
+        }
+    }
+
+    log::info!(
+        "[ClaudeMemory] migration finished: persisted={} failures={}",
+        report.persisted,
+        report.failures
+    );
+    Ok(report)
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct MigrationReport {
+    pub persisted: usize,
+    pub failures: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function tests (no network, no SDK internals)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn parse_memory_file_extracts_frontmatter_and_body() {
+        let input = "---\nname: foo\ndescription: hello world\ntype: feedback\n---\nbody line one\nbody line two\n";
+        let parsed = parse_memory_file(input);
+        assert_eq!(parsed.frontmatter.name.as_deref(), Some("foo"));
+        assert_eq!(
+            parsed.frontmatter.description.as_deref(),
+            Some("hello world")
+        );
+        assert_eq!(parsed.frontmatter.memory_type.as_deref(), Some("feedback"));
+        assert_eq!(parsed.body, "body line one\nbody line two");
+    }
+
+    #[test]
+    fn parse_memory_file_handles_missing_frontmatter() {
+        let parsed = parse_memory_file("just a body with no frontmatter\n");
+        assert_eq!(parsed.frontmatter, MemoryFrontmatter::default());
+        assert_eq!(parsed.body, "just a body with no frontmatter");
+    }
+
+    #[test]
+    fn parse_memory_file_handles_unterminated_frontmatter() {
+        let parsed = parse_memory_file("---\nname: foo\ndescription: still going");
+        assert_eq!(parsed.frontmatter, MemoryFrontmatter::default());
+        assert!(parsed.body.contains("still going"));
+    }
+
+    #[test]
+    fn normalize_git_remote_handles_scp_and_https() {
+        assert_eq!(
+            normalize_git_remote("git@github.com:serenorg/seren-desktop.git"),
+            "github.com/serenorg/seren-desktop"
+        );
+        assert_eq!(
+            normalize_git_remote("https://github.com/serenorg/seren-desktop.git"),
+            "github.com/serenorg/seren-desktop"
+        );
+        assert_eq!(
+            normalize_git_remote("https://user:token@GitHub.com/serenorg/seren-desktop/"),
+            "github.com/serenorg/seren-desktop"
+        );
+    }
+
+    #[test]
+    fn resolve_project_identity_prefers_git_remote() {
+        let tmp = TempDir::new().expect("tempdir");
+        let git_dir = tmp.path().join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(
+            git_dir.join("config"),
+            "[remote \"origin\"]\n\turl = git@github.com:serenorg/seren-desktop.git\n",
+        )
+        .unwrap();
+
+        let identity = resolve_project_identity(tmp.path()).expect("identity");
+        assert_eq!(identity.source, ProjectIdentitySource::GitRemote);
+        assert_eq!(identity.identifier, "github.com/serenorg/seren-desktop");
+    }
+
+    #[test]
+    fn resolve_project_identity_persists_uuid_fallback() {
+        let tmp = TempDir::new().expect("tempdir");
+        let first = resolve_project_identity(tmp.path()).expect("first identity");
+        assert_eq!(first.source, ProjectIdentitySource::GeneratedUuid);
+        let second = resolve_project_identity(tmp.path()).expect("second identity");
+        assert_eq!(second.source, ProjectIdentitySource::PersistedUuid);
+        assert_eq!(first.identifier, second.identifier);
+    }
+
+    #[test]
+    fn should_intercept_path_rules() {
+        let memory_dir = Path::new("/home/a/.claude/projects/-proj/memory");
+        assert!(should_intercept_path(&memory_dir.join("feedback.md")));
+        assert!(!should_intercept_path(&memory_dir.join("MEMORY.md")));
+        assert!(!should_intercept_path(&memory_dir.join("memory.txt")));
+        assert!(!should_intercept_path(Path::new(
+            "/home/a/.claude/projects/-proj/foo.md"
+        )));
+    }
+
+    #[test]
+    fn write_rendered_memory_md_is_atomic_overwrite() {
+        let tmp = TempDir::new().expect("tempdir");
+        let dir = tmp.path().join("-proj");
+        let first = write_rendered_memory_md(&dir, "first render").expect("first");
+        assert_eq!(fs::read_to_string(&first).unwrap(), "first render");
+        let second = write_rendered_memory_md(&dir, "second render").expect("second");
+        assert_eq!(fs::read_to_string(&second).unwrap(), "second render");
+        assert!(!dir.join("MEMORY.md.tmp").exists());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SerenDB round-trip integration test (ignored by default)
+//
+// This is the ONLY test that talks to the network. It proves the spec:
+// a file intercepted by our code ends up in SerenDB and comes back out via
+// `MemoryClient::recall()`. Run with:
+//
+//   SEREN_CLAUDE_MEMORY_TEST_TOKEN=<token> \
+//   SEREN_CLAUDE_MEMORY_TEST_PROJECT=<project-uuid> \
+//   cargo test --lib claude_memory -- --ignored --nocapture \
+//     serendb_roundtrip_persists_and_recalls
+//
+// Optional env vars:
+//   SEREN_CLAUDE_MEMORY_TEST_BASE_URL (default: https://memory.serendb.com)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod integration {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn require_env(name: &str) -> String {
+        match std::env::var(name) {
+            Ok(v) if !v.trim().is_empty() => v,
+            _ => panic!(
+                "{name} is not set — SerenDB roundtrip test requires a live token and project UUID"
+            ),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires live SerenDB credentials; see module docs"]
+    async fn serendb_roundtrip_persists_and_recalls() {
+        let token = require_env("SEREN_CLAUDE_MEMORY_TEST_TOKEN");
+        let project_raw = require_env("SEREN_CLAUDE_MEMORY_TEST_PROJECT");
+        let project_id = Uuid::parse_str(&project_raw).expect("project id must be a UUID");
+        let base_url = std::env::var("SEREN_CLAUDE_MEMORY_TEST_BASE_URL")
+            .unwrap_or_else(|_| "https://memory.serendb.com".to_string());
+
+        // Build the SAME client the production code would build.
+        let client = MemoryClient::new(base_url, token);
+
+        // Write a memory file into a temp Claude-style memory directory so we
+        // exercise the full parse + persist + delete path our production
+        // watcher uses, not a shortcut that calls client.remember directly.
+        let tmp = TempDir::new().expect("tempdir");
+        let memory_dir = tmp.path().join("-test-proj").join("memory");
+        fs::create_dir_all(&memory_dir).unwrap();
+
+        // Unique marker so we can find this row on recall even if the project
+        // has many other memories. Embedded in both the body and the frontmatter.
+        let marker = format!("claude-memory-roundtrip-{}", Uuid::new_v4());
+        let file_path = memory_dir.join("feedback_roundtrip.md");
+        let contents = format!(
+            "---\nname: roundtrip_{marker}\ndescription: integration test marker\ntype: feedback\n---\nMARKER={marker}\nclaude-memory-interceptor roundtrip test — safe to delete.\n"
+        );
+        fs::write(&file_path, &contents).unwrap();
+
+        // Exercise OUR code under test.
+        let outcome = process_memory_file(&file_path, &client, Some(project_id))
+            .await
+            .expect("process_memory_file must succeed against live SerenDB");
+
+        match outcome {
+            ProcessOutcome::Persisted { memory_type, .. } => {
+                assert_eq!(memory_type, "feedback", "memory_type comes from frontmatter");
+            }
+            other => panic!("expected Persisted, got {other:?}"),
+        }
+
+        // The plaintext file must be gone once the cloud write succeeded.
+        assert!(
+            !file_path.exists(),
+            "file must be deleted after successful SerenDB write"
+        );
+
+        // Round-trip: recall by unique marker and assert the content came back.
+        let results = client
+            .recall(&marker, Some(project_id), Some(10))
+            .await
+            .expect("recall against SerenDB must succeed");
+
+        let hit = results.iter().find(|r| r.content.contains(&marker));
+        assert!(
+            hit.is_some(),
+            "expected to recall a memory containing MARKER={marker}; got {} results: {:?}",
+            results.len(),
+            results.iter().map(|r| &r.content).collect::<Vec<_>>()
+        );
+    }
+}

--- a/src-tauri/src/commands/claude_memory.rs
+++ b/src-tauri/src/commands/claude_memory.rs
@@ -1,0 +1,135 @@
+// ABOUTME: Tauri commands for the Claude Code auto-memory interceptor.
+// ABOUTME: Exposes start/stop/status, startup migration, render, and identity lookup.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use tauri::{AppHandle, State};
+use uuid::Uuid;
+
+use crate::claude_memory;
+use crate::commands::memory::MemoryState;
+
+/// Public status snapshot for the frontend.
+#[derive(Debug, Serialize)]
+pub struct ClaudeMemoryStatus {
+    pub running: bool,
+    pub watching_root: Option<String>,
+}
+
+/// Public project identity payload for the frontend.
+#[derive(Debug, Serialize)]
+pub struct ClaudeMemoryProjectIdentity {
+    pub identifier: String,
+    pub source: String,
+}
+
+fn parse_project_id(project_id: Option<String>) -> Result<Option<Uuid>, String> {
+    match project_id.as_deref() {
+        Some(s) if !s.is_empty() => Uuid::parse_str(s)
+            .map(Some)
+            .map_err(|e| format!("invalid project_id UUID: {e}")),
+        _ => Ok(None),
+    }
+}
+
+/// Start watching `~/.claude/projects/*/memory/` for Claude Code memory writes.
+/// Requires the user to be authenticated and to pass the SerenDB project UUID
+/// that intercepted memories should be written to.
+#[tauri::command]
+pub fn claude_memory_start(
+    app: AppHandle,
+    project_id: Option<String>,
+) -> Result<ClaudeMemoryStatus, String> {
+    let project_uuid = parse_project_id(project_id)?;
+    let root = claude_memory::start_watcher(app, project_uuid)?;
+    Ok(ClaudeMemoryStatus {
+        running: true,
+        watching_root: Some(root.to_string_lossy().to_string()),
+    })
+}
+
+/// Stop the watcher if running.
+#[tauri::command]
+pub fn claude_memory_stop() -> Result<ClaudeMemoryStatus, String> {
+    claude_memory::stop_watcher()?;
+    Ok(ClaudeMemoryStatus {
+        running: false,
+        watching_root: None,
+    })
+}
+
+/// Return the current watcher status without mutating it.
+#[tauri::command]
+pub fn claude_memory_status() -> Result<ClaudeMemoryStatus, String> {
+    let running = claude_memory::is_watcher_running();
+    let watching_root = if running {
+        claude_memory::claude_projects_root()
+            .ok()
+            .map(|p| p.to_string_lossy().to_string())
+    } else {
+        None
+    };
+    Ok(ClaudeMemoryStatus {
+        running,
+        watching_root,
+    })
+}
+
+/// Walk every existing Claude memory directory and push any files already on
+/// disk to SerenDB. Returns persisted + failures.
+#[tauri::command]
+pub async fn claude_memory_migrate_existing(
+    app: AppHandle,
+    project_id: Option<String>,
+) -> Result<claude_memory::MigrationReport, String> {
+    let project_uuid = parse_project_id(project_id)?;
+    claude_memory::migrate_existing_files(&app, project_uuid).await
+}
+
+/// Resolve a stable project identifier for `project_cwd` (git remote or UUID).
+#[tauri::command]
+pub fn claude_memory_get_project_identity(
+    project_cwd: String,
+) -> Result<ClaudeMemoryProjectIdentity, String> {
+    let identity = claude_memory::resolve_project_identity(Path::new(&project_cwd))?;
+    let source = match identity.source {
+        claude_memory::ProjectIdentitySource::GitRemote => "git_remote",
+        claude_memory::ProjectIdentitySource::PersistedUuid => "persisted_uuid",
+        claude_memory::ProjectIdentitySource::GeneratedUuid => "generated_uuid",
+    }
+    .to_string();
+    Ok(ClaudeMemoryProjectIdentity {
+        identifier: identity.identifier,
+        source,
+    })
+}
+
+/// Render `~/.claude/projects/<encoded(project_cwd)>/MEMORY.md` from the
+/// authenticated user's SerenDB memory bootstrap. The frontend calls this
+/// when a project is opened so Claude Code reads fresh content next session.
+#[tauri::command]
+pub async fn claude_memory_render_memory_md(
+    app: AppHandle,
+    state: State<'_, MemoryState>,
+    project_cwd: String,
+    project_id: Option<String>,
+) -> Result<String, String> {
+    let root = claude_memory::claude_projects_root()?;
+    let encoded = claude_memory::encode_project_dir(Path::new(&project_cwd));
+    let claude_project_dir: PathBuf = root.join(&encoded);
+
+    let rendered = match super::memory::memory_bootstrap(app, state, project_id).await {
+        Ok(Some(prompt)) if !prompt.trim().is_empty() => prompt,
+        Ok(_) => "# Claude Memory\n\n_No preferences stored yet._\n".to_string(),
+        Err(e) => {
+            log::warn!("[ClaudeMemory] memory_bootstrap failed during render: {e}");
+            format!(
+                "# Claude Memory\n\n> Preferences are rehydrating from SerenDB. This message will be replaced on the next successful sync.\n\n_Last error: {e}_\n"
+            )
+        }
+    };
+
+    let final_path = claude_memory::write_rendered_memory_md(&claude_project_dir, &rendered)?;
+    Ok(final_path.to_string_lossy().to_string())
+}

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -32,6 +32,13 @@ impl MemoryState {
         }
     }
 
+    /// Read-only accessor for the memory service base URL so other modules
+    /// (e.g. the Claude Code memory interceptor) can build their own clients
+    /// against the same endpoint without duplicating the constant.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
     /// Create a MemoryClient using the current token from the Tauri store.
     fn client(&self, app: &tauri::AppHandle) -> Result<MemoryClient, String> {
         use tauri_plugin_store::StoreExt;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use tauri_plugin_store::StoreExt;
 
 pub mod commands {
     pub mod chat;
+    pub mod claude_memory;
     pub mod cli_installer;
     pub mod gateway_http;
     pub mod indexing;
@@ -25,6 +26,7 @@ pub mod services {
 }
 
 mod auth;
+mod claude_memory;
 mod claude_setup;
 mod embedded_runtime;
 mod files;
@@ -791,6 +793,13 @@ pub fn run() {
             commands::memory::memory_remember,
             commands::memory::memory_recall,
             commands::memory::memory_sync,
+            // Claude Code auto-memory interceptor commands
+            commands::claude_memory::claude_memory_start,
+            commands::claude_memory::claude_memory_stop,
+            commands::claude_memory::claude_memory_status,
+            commands::claude_memory::claude_memory_migrate_existing,
+            commands::claude_memory::claude_memory_get_project_identity,
+            commands::claude_memory::claude_memory_render_memory_md,
             // Runtime session commands
             commands::session::create_runtime_session,
             commands::session::get_runtime_session,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,6 +107,66 @@ function App() {
     // Load skills and threads after auth check completes
     await skillsStore.refresh();
     await threadStore.refresh();
+
+    // Claude Code auto-memory interceptor — opt-in. If the user enabled it
+    // but a precondition is missing (no SerenDB login, no active project) or
+    // the start call fails, we surface an actionable error dialog so the
+    // user knows what to fix. No silent failures.
+    try {
+      const { settingsStore } = await import("@/stores/settings.store");
+      if (settingsStore.get("claudeMemoryInterceptEnabled")) {
+        const { projectStore } = await import("@/stores/project.store");
+        const { message: showMessageDialog } = await import(
+          "@tauri-apps/plugin-dialog"
+        );
+        const reportError = async (msg: string) => {
+          console.error(`[ClaudeMemory] ${msg}`);
+          try {
+            await showMessageDialog(msg, {
+              title: "Claude Memory Interceptor",
+              kind: "error",
+            });
+          } catch {
+            // Dialog plugin unavailable (e.g. browser runtime) — the
+            // console.error above is the fallback.
+          }
+        };
+        if (!authStore.isAuthenticated) {
+          await reportError(
+            "Claude Code auto-memory interceptor is enabled but you are not logged in to SerenDB. Log in to start the interceptor, or turn it off in Settings → Code Indexing → Claude Code Auto-Memory.",
+          );
+        } else if (!projectStore.activeProject?.id) {
+          await reportError(
+            "Claude Code auto-memory interceptor is enabled but no active SerenDB project is selected. Select a project to start the interceptor, or turn it off in Settings → Code Indexing → Claude Code Auto-Memory.",
+          );
+        } else {
+          const { startClaudeMemoryInterceptor, migrateExistingClaudeMemory } =
+            await import("@/services/claudeMemory");
+          try {
+            await startClaudeMemoryInterceptor();
+            if (settingsStore.get("claudeMemoryMigrateOnStartup")) {
+              const report = await migrateExistingClaudeMemory();
+              console.info(
+                `[ClaudeMemory] startup migration: persisted=${report.persisted} failures=${report.failures}`,
+              );
+              if (report.failures > 0) {
+                await reportError(
+                  `Claude memory interceptor: ${report.failures} file${
+                    report.failures === 1 ? "" : "s"
+                  } could not be pushed to SerenDB on startup and were left on disk. Check your SerenDB connection and retry from Settings → Code Indexing → Claude Code Auto-Memory → Migrate Existing Files.`,
+                );
+              }
+            }
+          } catch (err) {
+            await reportError(
+              `Failed to start Claude memory interceptor: ${err}. Check your SerenDB login and project selection, then toggle the interceptor off and on again in Settings.`,
+            );
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`[ClaudeMemory] boot hook crashed: ${error}`);
+    }
   });
 
   // Periodically refresh available skills so newly published skills appear without restart.

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -10,6 +10,12 @@ import {
   Show,
 } from "solid-js";
 import { isBuiltinServer, isLocalServer } from "@/lib/mcp/types";
+import {
+  getClaudeMemoryStatus,
+  migrateExistingClaudeMemory,
+  startClaudeMemoryInterceptor,
+  stopClaudeMemoryInterceptor,
+} from "@/services/claudeMemory";
 import { allowsSerenPublicModels } from "@/services/organization-policy";
 import { authStore } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
@@ -52,6 +58,77 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
     createSignal<SettingsSection>("chat");
   const [showResetConfirm, setShowResetConfirm] = createSignal(false);
   const [showClearConfirm, setShowClearConfirm] = createSignal(false);
+
+  // Claude Code auto-memory interceptor state. The watcher lives in Rust;
+  // the panel only reflects its current status and exposes the controls.
+  const [claudeMemoryRunning, setClaudeMemoryRunning] = createSignal(false);
+  const [claudeMemoryWatchingRoot, setClaudeMemoryWatchingRoot] = createSignal<
+    string | null
+  >(null);
+  const [claudeMemoryBusy, setClaudeMemoryBusy] = createSignal(false);
+  const [claudeMemoryMessage, setClaudeMemoryMessage] = createSignal<
+    string | null
+  >(null);
+
+  const refreshClaudeMemoryStatus = async () => {
+    try {
+      const status = await getClaudeMemoryStatus();
+      setClaudeMemoryRunning(status.running);
+      setClaudeMemoryWatchingRoot(status.watching_root);
+    } catch (err) {
+      console.warn("[ClaudeMemory] status read failed", err);
+    }
+  };
+
+  const handleClaudeMemoryToggle = async (enabled: boolean) => {
+    handleBooleanChange("claudeMemoryInterceptEnabled", enabled);
+    setClaudeMemoryBusy(true);
+    setClaudeMemoryMessage(null);
+    try {
+      const status = enabled
+        ? await startClaudeMemoryInterceptor()
+        : await stopClaudeMemoryInterceptor();
+      setClaudeMemoryRunning(status.running);
+      setClaudeMemoryWatchingRoot(status.watching_root);
+      if (enabled && !status.running) {
+        setClaudeMemoryMessage(
+          "Could not start the interceptor. Make sure you are logged in to SerenDB and have an active project selected.",
+        );
+      }
+    } catch (err) {
+      setClaudeMemoryMessage(
+        `Failed to ${enabled ? "start" : "stop"} interceptor: ${err}`,
+      );
+      console.error("[ClaudeMemory] toggle failed", err);
+    } finally {
+      setClaudeMemoryBusy(false);
+    }
+  };
+
+  const handleClaudeMemoryMigrate = async () => {
+    setClaudeMemoryBusy(true);
+    setClaudeMemoryMessage(null);
+    try {
+      const report = await migrateExistingClaudeMemory();
+      const { persisted, failures } = report;
+      if (persisted === 0 && failures === 0) {
+        setClaudeMemoryMessage("No plaintext memory files found.");
+      } else if (failures === 0) {
+        setClaudeMemoryMessage(
+          `Pushed ${persisted} file${persisted === 1 ? "" : "s"} to SerenDB.`,
+        );
+      } else {
+        setClaudeMemoryMessage(
+          `Pushed ${persisted}, left ${failures} on disk (cloud write failed — will retry).`,
+        );
+      }
+    } catch (err) {
+      setClaudeMemoryMessage(`Migration failed: ${err}`);
+      console.error("[ClaudeMemory] migration failed", err);
+    } finally {
+      setClaudeMemoryBusy(false);
+    }
+  };
 
   const handleNumberChange = (key: keyof Settings, value: string) => {
     const num = Number.parseFloat(value);
@@ -151,6 +228,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
       "seren:open-settings-section",
       handleOpenSection as EventListener,
     );
+    void refreshClaudeMemoryStatus();
   });
 
   onCleanup(() => {
@@ -1339,6 +1417,99 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                 </span>
               </label>
             </div>
+
+            <h4 class="mt-6 mb-3 text-base font-semibold text-muted-foreground border-t border-border-medium pt-5">
+              Claude Code Auto-Memory Interceptor
+            </h4>
+            <p class="m-0 mb-4 text-[0.85rem] text-muted-foreground leading-relaxed">
+              Claude Code's built-in auto-memory writes plain markdown files to{" "}
+              <code class="px-1 py-0.5 rounded bg-border/40 text-[0.78rem]">
+                ~/.claude/projects/*/memory/
+              </code>
+              . When enabled, Seren Desktop intercepts every write, persists it
+              to SerenDB via your authenticated memory project, and deletes the
+              plaintext file only after the cloud write succeeds. If the cloud
+              write fails the file is left on disk and the watcher retries on
+              the next event — no data loss.
+            </p>
+
+            <div class="flex items-start justify-start gap-4 py-3 border-b border-border">
+              <label class="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={settingsState.app.claudeMemoryInterceptEnabled}
+                  disabled={claudeMemoryBusy()}
+                  onChange={(e) =>
+                    handleClaudeMemoryToggle(e.currentTarget.checked)
+                  }
+                  class="w-[18px] h-[18px] mt-0.5 accent-accent cursor-pointer"
+                />
+                <span class="flex flex-col gap-0.5">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Secure Claude Memory Storage
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Watch Claude Code memory directories, persist writes to
+                    SerenDB through the existing authenticated memory stack, and
+                    remove the plaintext files from disk only on cloud success.
+                    Requires a SerenDB login and an active project.
+                  </span>
+                </span>
+              </label>
+            </div>
+
+            <div class="flex items-start justify-start gap-4 py-3 border-b border-border">
+              <label class="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={settingsState.app.claudeMemoryMigrateOnStartup}
+                  onChange={(e) =>
+                    handleBooleanChange(
+                      "claudeMemoryMigrateOnStartup",
+                      e.currentTarget.checked,
+                    )
+                  }
+                  class="w-[18px] h-[18px] mt-0.5 accent-accent cursor-pointer"
+                />
+                <span class="flex flex-col gap-0.5">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Migrate Existing Files On Startup
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    On app launch, scan every Claude memory directory and push
+                    any pre-existing <code>.md</code> files to SerenDB using the
+                    same delete-on-cloud-success rule.
+                  </span>
+                </span>
+              </label>
+            </div>
+
+            <div class="flex items-center justify-between py-3 border-b border-border">
+              <div class="flex flex-col gap-0.5">
+                <span class="text-[0.85rem] font-medium text-foreground">
+                  Interceptor Status
+                </span>
+                <span class="text-[0.78rem] text-muted-foreground">
+                  {claudeMemoryRunning()
+                    ? `Watching ${claudeMemoryWatchingRoot() ?? "Claude projects directory"}`
+                    : "Watcher is stopped."}
+                </span>
+              </div>
+              <button
+                type="button"
+                disabled={claudeMemoryBusy()}
+                class="px-3 py-1.5 text-[0.8rem] rounded-md border border-border-strong bg-transparent hover:bg-border text-foreground cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={handleClaudeMemoryMigrate}
+              >
+                {claudeMemoryBusy() ? "Working…" : "Migrate Existing Files"}
+              </button>
+            </div>
+
+            <Show when={claudeMemoryMessage()}>
+              <p class="m-0 mt-2 text-[0.78rem] text-muted-foreground">
+                {claudeMemoryMessage()}
+              </p>
+            </Show>
           </section>
         </Show>
 

--- a/src/services/claudeMemory.ts
+++ b/src/services/claudeMemory.ts
@@ -1,0 +1,122 @@
+// ABOUTME: Frontend service for the Claude Code auto-memory interceptor.
+// ABOUTME: Starts/stops the Rust watcher that persists intercepted files to SerenDB.
+
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+import { projectStore } from "@/stores/project.store";
+
+export interface ClaudeMemoryStatus {
+  running: boolean;
+  watching_root: string | null;
+}
+
+export interface ClaudeMemoryMigrationReport {
+  persisted: number;
+  failures: number;
+}
+
+export interface ClaudeMemoryProjectIdentity {
+  identifier: string;
+  source: "git_remote" | "persisted_uuid" | "generated_uuid";
+}
+
+export interface InterceptSuccessEvent {
+  path: string;
+  name: string | null;
+  memory_type: string;
+  serendb_response: string;
+}
+
+export interface InterceptFailureEvent {
+  path: string;
+  memory_type: string;
+  error: string;
+}
+
+function getActiveProjectId(): string | null {
+  return projectStore.activeProject?.id ?? null;
+}
+
+/**
+ * Start the filesystem watcher. The Rust side intercepts every `.md` write
+ * in `~/.claude/projects/*\/memory/`, awaits a real SerenDB write for each
+ * file, and only deletes the plaintext file once the cloud write succeeds.
+ *
+ * Requires an authenticated SerenDB session and an active project UUID.
+ */
+export async function startClaudeMemoryInterceptor(): Promise<ClaudeMemoryStatus> {
+  if (!isTauriRuntime()) {
+    return { running: false, watching_root: null };
+  }
+  const projectId = getActiveProjectId();
+  return invoke<ClaudeMemoryStatus>("claude_memory_start", { projectId });
+}
+
+/**
+ * Stop the watcher. Safe to call when it is not running.
+ */
+export async function stopClaudeMemoryInterceptor(): Promise<ClaudeMemoryStatus> {
+  if (!isTauriRuntime()) {
+    return { running: false, watching_root: null };
+  }
+  return invoke<ClaudeMemoryStatus>("claude_memory_stop");
+}
+
+/**
+ * Snapshot the watcher's current running state without mutating it.
+ */
+export async function getClaudeMemoryStatus(): Promise<ClaudeMemoryStatus> {
+  if (!isTauriRuntime()) {
+    return { running: false, watching_root: null };
+  }
+  return invoke<ClaudeMemoryStatus>("claude_memory_status");
+}
+
+/**
+ * Walk every existing Claude memory directory and push any pre-existing `.md`
+ * files to SerenDB. Returns persisted + failures counts. Files whose cloud
+ * write fails are left on disk so the live watcher can retry later.
+ */
+export async function migrateExistingClaudeMemory(): Promise<ClaudeMemoryMigrationReport> {
+  if (!isTauriRuntime()) {
+    return { persisted: 0, failures: 0 };
+  }
+  const projectId = getActiveProjectId();
+  return invoke<ClaudeMemoryMigrationReport>("claude_memory_migrate_existing", {
+    projectId,
+  });
+}
+
+/**
+ * Resolve a stable identifier for a project directory — git remote URL or a
+ * persisted UUID at `<cwd>/.claude/project_id`.
+ */
+export async function getClaudeProjectIdentity(
+  projectCwd: string,
+): Promise<ClaudeMemoryProjectIdentity | null> {
+  if (!isTauriRuntime()) {
+    return null;
+  }
+  return invoke<ClaudeMemoryProjectIdentity>(
+    "claude_memory_get_project_identity",
+    { projectCwd },
+  );
+}
+
+/**
+ * Render `~/.claude/projects/<encoded(projectCwd)>/MEMORY.md` from the user's
+ * authenticated SerenDB memory bootstrap, so Claude Code reads fresh content
+ * at the start of its next session.
+ */
+export async function renderClaudeMemoryMd(
+  projectCwd: string,
+): Promise<string | null> {
+  if (!isTauriRuntime()) {
+    return null;
+  }
+  const projectId = getActiveProjectId();
+  return invoke<string>("claude_memory_render_memory_md", {
+    projectCwd,
+    projectId,
+  });
+}

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -93,6 +93,21 @@ export interface Settings {
 
   // Memory settings
   memoryEnabled: boolean;
+  /**
+   * Intercept Claude Code auto-memory writes at
+   * ~/.claude/projects/*\/memory/*.md, persist each file to SerenDB through
+   * the authenticated user's memory project, and delete the plaintext file
+   * only after the cloud write succeeds. When disabled, Claude Code's
+   * default behavior is preserved and nothing is touched on disk.
+   */
+  claudeMemoryInterceptEnabled: boolean;
+  /**
+   * On app launch, scan every Claude memory directory and push any files
+   * already on disk to SerenDB (same rules as the live watcher: delete only
+   * after a successful cloud write). Files whose cloud write fails are left
+   * on disk.
+   */
+  claudeMemoryMigrateOnStartup: boolean;
 
   // Agent settings
   agentSandboxMode: "read-only" | "workspace-write" | "full-access";
@@ -180,6 +195,10 @@ const DEFAULT_SETTINGS: Settings = {
   semanticIndexingEnabled: false,
   // Memory
   memoryEnabled: false,
+  // Claude Code auto-memory interceptor (off by default — opt-in so users
+  // who haven't logged into SerenDB aren't surprised by file deletions).
+  claudeMemoryInterceptEnabled: false,
+  claudeMemoryMigrateOnStartup: false,
   // Agent
   agentSandboxMode: "workspace-write",
   agentApprovalPolicy: "on-request",

--- a/tests/services/claudeMemory.test.ts
+++ b/tests/services/claudeMemory.test.ts
@@ -1,0 +1,91 @@
+// ABOUTME: Critical tests for the Claude Code auto-memory interceptor service.
+// ABOUTME: Verifies the frontend wrapper dispatches to the correct Tauri commands.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invokeMock, projectStoreMock, isTauriMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  projectStoreMock: {
+    activeProject: { id: "project-1" } as { id: string } | null,
+  },
+  isTauriMock: vi.fn(() => true),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: isTauriMock,
+}));
+
+vi.mock("@/stores/project.store", () => ({
+  projectStore: projectStoreMock,
+}));
+
+import {
+  getClaudeMemoryStatus,
+  migrateExistingClaudeMemory,
+  renderClaudeMemoryMd,
+  startClaudeMemoryInterceptor,
+  stopClaudeMemoryInterceptor,
+} from "@/services/claudeMemory";
+
+describe("claudeMemory service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isTauriMock.mockReturnValue(true);
+    projectStoreMock.activeProject = { id: "project-1" };
+  });
+
+  it("start passes the active SerenDB project id to Rust", async () => {
+    invokeMock.mockResolvedValue({
+      running: true,
+      watching_root: "/home/a/.claude/projects",
+    });
+    const status = await startClaudeMemoryInterceptor();
+    expect(status.running).toBe(true);
+    expect(invokeMock).toHaveBeenCalledWith("claude_memory_start", {
+      projectId: "project-1",
+    });
+  });
+
+  it("stop and status call the correct commands without project context", async () => {
+    invokeMock.mockResolvedValueOnce({ running: false, watching_root: null });
+    invokeMock.mockResolvedValueOnce({ running: false, watching_root: null });
+    await stopClaudeMemoryInterceptor();
+    await getClaudeMemoryStatus();
+    expect(invokeMock).toHaveBeenNthCalledWith(1, "claude_memory_stop");
+    expect(invokeMock).toHaveBeenNthCalledWith(2, "claude_memory_status");
+  });
+
+  it("migrate returns the persisted+failures report", async () => {
+    invokeMock.mockResolvedValue({ persisted: 7, failures: 2 });
+    const report = await migrateExistingClaudeMemory();
+    expect(report).toEqual({ persisted: 7, failures: 2 });
+    expect(invokeMock).toHaveBeenCalledWith(
+      "claude_memory_migrate_existing",
+      { projectId: "project-1" },
+    );
+  });
+
+  it("render forwards projectCwd and projectId", async () => {
+    invokeMock.mockResolvedValue("/home/a/.claude/projects/-proj/MEMORY.md");
+    await renderClaudeMemoryMd("/home/a/Projects/proj");
+    expect(invokeMock).toHaveBeenCalledWith(
+      "claude_memory_render_memory_md",
+      { projectCwd: "/home/a/Projects/proj", projectId: "project-1" },
+    );
+  });
+
+  it("no-ops in non-Tauri runtime (never calls invoke)", async () => {
+    isTauriMock.mockReturnValue(false);
+    const started = await startClaudeMemoryInterceptor();
+    const status = await getClaudeMemoryStatus();
+    const migrated = await migrateExistingClaudeMemory();
+    expect(started).toEqual({ running: false, watching_root: null });
+    expect(status).toEqual({ running: false, watching_root: null });
+    expect(migrated).toEqual({ persisted: 0, failures: 0 });
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Implements #1492 — the real version this time. Redo of the reverted #1495 with the actual spec: intercepted files go to **SerenDB**, not to a local SQLite blob.

Claude Code's built-in auto-memory stores user preferences as plaintext markdown at `~/.claude/projects/*/memory/`. This adds a Rust filesystem watcher that intercepts every write, **awaits a real `MemoryClient::remember()` call against SerenDB**, and deletes the plaintext file **only** after the cloud write succeeds. If the cloud write fails the file is left on disk and the watcher retries on the next event. No silent local queue, no destructive "migration" that moves plaintext into a local blob.

### What's different from the reverted #1495
| #1495 (reverted) | This PR |
| --- | --- |
| `persist_memory_local` into seren-memory-sdk's local SQLite cache with `synced=0` | `client.remember()` awaited directly — real SerenDB cloud write per file |
| File deleted even when nothing reached the cloud | File deleted **only** on `Ok(_)` from `client.remember()`; retained on `Err(_)` |
| "Verified" by peeking at `cached_memories` via `sqlite3` | Verified by a real `memory_recall` round-trip through `MemoryClient` — no sqlite3, no SDK internals |
| `claudeMemoryInterceptEnabled` defaulted **on** | Defaults **off** — opt-in; start dialog surfaces an error if auth or project is missing |
| Silent console warnings on failure | Native error dialog via `@tauri-apps/plugin-dialog` telling the user exactly what to fix |

### Architecture
- [src-tauri/src/claude_memory.rs](src-tauri/src/claude_memory.rs): pure-function helpers (frontmatter parser, project identity resolver, git remote normalizer, atomic `MEMORY.md` renderer, path rules) + the sync→async bridge (`notify` callback → `tokio::sync::mpsc::unbounded_channel` → tokio task that awaits the real `MemoryClient::remember()` and deletes the file only on success) + startup migration using the same code path
- [src-tauri/src/commands/claude_memory.rs](src-tauri/src/commands/claude_memory.rs): Tauri commands `claude_memory_start` / `claude_memory_stop` / `claude_memory_status` / `claude_memory_migrate_existing` / `claude_memory_get_project_identity` / `claude_memory_render_memory_md`
- [src-tauri/src/commands/memory.rs](src-tauri/src/commands/memory.rs): **minimal** change — one new read-only `base_url()` accessor on `MemoryState` so the interceptor can build its own `MemoryClient` against the same endpoint. Zero behavior changes to `memory_remember`, `memory_bootstrap`, `memory_recall`, or `memory_sync`. The existing Persistent Memory feature is **untouched**.
- [src/services/claudeMemory.ts](src/services/claudeMemory.ts): frontend wrapper with `isTauriRuntime` guards
- [src/components/settings/SettingsPanel.tsx](src/components/settings/SettingsPanel.tsx): new controls **under the existing Persistent Memory section** (toggle, startup-migration toggle, live status, manual "Migrate Existing Files" button with persisted/failures summary)
- [src/stores/settings.store.ts](src/stores/settings.store.ts): `claudeMemoryInterceptEnabled` and `claudeMemoryMigrateOnStartup` — both default **off**
- [src/App.tsx](src/App.tsx): boot hook that auto-starts the watcher **only** when the user opted in AND is authenticated AND has an active SerenDB project. If any precondition is missing, or if the start call itself fails, the user sees a native `@tauri-apps/plugin-dialog` error dialog explaining what to fix — never a silent failure.

### Spec blockers
All three blockers from the #1492 discussion are addressed the same way:
1. **Portability** — project identity is a normalized git remote URL with a persisted UUID fallback at `<cwd>/.claude/project_id`
2. **Cold-start correctness** — cloud write is awaited synchronously per file; on failure the file stays on disk so the watcher retries on the next event, and the startup migration reports `failures > 0` to the user via the error dialog
3. **No split-brain** — reuses the existing user token, the existing `MemoryClient`, the existing `MemoryState` base URL, and the existing Memory settings panel. No parallel `/auth/agent` identity, no new table, no second auth flow, no modifications to the existing `memory_remember` / `memory_bootstrap` path

## Tests
### Unit tests — Rust (8 passing, pure functions only, no network, no SDK internals)
- `parse_memory_file_extracts_frontmatter_and_body`
- `parse_memory_file_handles_missing_frontmatter`
- `parse_memory_file_handles_unterminated_frontmatter` (no crash on malformed input)
- `normalize_git_remote_handles_scp_and_https`
- `resolve_project_identity_prefers_git_remote`
- `resolve_project_identity_persists_uuid_fallback`
- `should_intercept_path_rules` (skips `MEMORY.md`, non-`.md`, and non-`memory/` paths)
- `write_rendered_memory_md_is_atomic_overwrite`

### Integration test — Rust (`#[ignore]` by default — requires live SerenDB)
`serendb_roundtrip_persists_and_recalls` exercises the **full interception path** against **real SerenDB**:
1. Writes a `.md` file with a unique marker into a temp Claude-style memory dir
2. Calls our real `process_memory_file(path, &client, Some(project_id))`
3. Asserts the file was deleted on disk
4. Calls `client.recall(marker, ...)` and asserts the marker content comes back from SerenDB

Run with:
```
SEREN_CLAUDE_MEMORY_TEST_TOKEN=<token> \
SEREN_CLAUDE_MEMORY_TEST_PROJECT=<project-uuid> \
cargo test --lib claude_memory -- --ignored --nocapture serendb_roundtrip_persists_and_recalls
```

### Unit tests — Vitest (5 passing)
`tests/services/claudeMemory.test.ts` verifies the frontend wrapper dispatches the correct Tauri commands with `projectId` context, returns `{ running: false }` in non-Tauri runtime, and never calls `invoke` in that case.

## Test plan
- [x] `cargo check` clean
- [x] `cargo test` — 301 passed, 1 ignored (the SerenDB roundtrip). My 8 unit tests are in the 301.
- [x] `pnpm test` — 328 passed (38 files). Includes the 5 new vitest tests.
- [x] `pnpm biome check` on all changed files — clean
- [ ] Manual smoke test with `pnpm tauri dev` on main **after merge**: start interceptor, write a marker `.md` file, run `memory_recall` via the UI with the marker query, verify the content comes back from SerenDB. **Verification is strictly via the SerenDB `memory_recall` round-trip — no `sqlite3`, no cache peeks, no SDK internals.**

Resolves #1492.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
