### PR TITLE
feat(claude-memory): enable interceptor and startup migration by default

### DIFF
--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -195,10 +195,13 @@ const DEFAULT_SETTINGS: Settings = {
   semanticIndexingEnabled: false,
   // Memory
   memoryEnabled: false,
-  // Claude Code auto-memory interceptor (off by default — opt-in so users
-  // who haven't logged into SerenDB aren't surprised by file deletions).
-  claudeMemoryInterceptEnabled: false,
-  claudeMemoryMigrateOnStartup: false,
+  // Claude Code auto-memory interceptor — on by default so every Seren
+  // Desktop user gets secure SerenDB-backed preference storage out of the
+  // box. If the user is not logged in to SerenDB or has no active project,
+  // the App.tsx boot hook surfaces an actionable error dialog instead of
+  // failing silently.
+  claudeMemoryInterceptEnabled: true,
+  claudeMemoryMigrateOnStartup: true,
   // Agent
   agentSandboxMode: "workspace-write",
   agentApprovalPolicy: "on-request",


### PR DESCRIPTION
## Summary
Flips `claudeMemoryInterceptEnabled` and `claudeMemoryMigrateOnStartup` to `true` in `DEFAULT_SETTINGS` so every Seren Desktop user gets secure SerenDB-backed preference storage on first launch — no opt-in step needed.

## Why this is safe now (and wasn't before)
The reverted [#1495](https://github.com/serenorg/seren-desktop/pull/1495) shipped defaults ON but had broken destination logic: it deleted plaintext files into a local-only SQLite cache that never reached SerenDB. [#1498](https://github.com/serenorg/seren-desktop/pull/1498) already enforces the two guarantees that make defaults-on safe:

1. **Delete only on cloud success** — [`process_memory_file`](src-tauri/src/claude_memory.rs) awaits a real `MemoryClient::remember()` against SerenDB and removes the plaintext file only after `Ok(_)`. If the cloud write fails, the plaintext file stays on disk and the watcher retries on the next event.
2. **No silent failure on bad preconditions** — the [App.tsx boot hook](src/App.tsx) raises a native `@tauri-apps/plugin-dialog` error dialog if the user enabled the interceptor but isn't logged in to SerenDB, has no active project selected, or the start call itself fails. The dialog tells them exactly what to fix and how to turn it off.

Together these mean: if something goes wrong, the user sees an actionable error instead of losing data.

## Test plan
- [x] `pnpm biome check src/stores/settings.store.ts` — clean
- [x] One-line flip, no logic change — existing #1498 tests (301 Rust + 328 vitest) still cover the behavior
- [ ] Manual smoke test on `pnpm tauri dev` after merge: launch the app with defaults, verify the watcher auto-starts, write a marker `.md` file into a Claude memory dir, and confirm it comes back via `memory_recall` from SerenDB. Verification is strictly via the SerenDB `memory_recall` round-trip.

Relates #1492.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
