### PR TITLE
feat(skills): add host marker and exclude-hosts contract for CLI-only skills

### DIFF
--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -7,6 +7,13 @@ import { createProviderHandlers } from "./browser-local/providers.mjs";
 import { addClient, emit, removeClient } from "./browser-local/events.mjs";
 import { handleRpcMessage, registerHandler } from "./browser-local/rpc.mjs";
 
+// Seren Desktop host marker: propagated to every spawned child (Claude CLI,
+// Codex, Gemini, skills) via process.env inheritance. Skills can detect the
+// Desktop runtime via SEREN_HOST=seren-desktop and fail closed when needed.
+// Spec: serenorg/seren-desktop#1496
+process.env.SEREN_HOST = "seren-desktop";
+process.env.SEREN_DESKTOP = "1";
+
 function usage() {
   console.log(`
 Usage: seren-provider-runtime [--host <address>] [--port <number>] [--token <value>]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -481,6 +481,18 @@ pub fn run() {
             }
         })
         .setup(|app| {
+            // Inject the Seren Desktop host marker into the process environment.
+            // Every child process (provider runtime, Claude/Codex/Gemini CLI,
+            // skills spawned by those agents) inherits these vars and can
+            // detect that it's running under Seren Desktop.
+            // Spec: serenorg/seren-desktop#1496
+            // SAFETY: set_var is unsafe in Rust 2024. Called exactly once
+            // during app setup before any threads spawn child processes.
+            unsafe {
+                std::env::set_var("SEREN_HOST", "seren-desktop");
+                std::env::set_var("SEREN_DESKTOP", "1");
+            }
+
             // Build native menu bar for all platforms
             {
                 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};

--- a/src/lib/skills/host.ts
+++ b/src/lib/skills/host.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Host compatibility helper for skill exclusion contract.
+// ABOUTME: Implements the serenorg/seren-desktop#1496 host-marker spec.
+
+import type { InstalledSkill, Skill } from "./types";
+import type { SkillMetadata } from "./types";
+
+/**
+ * The host token injected by Seren Desktop at runtime.
+ * Matches `SEREN_HOST` env var set in bin/provider-runtime.mjs.
+ */
+export const SEREN_DESKTOP_HOST = "seren-desktop" as const;
+
+/**
+ * Current runtime host identifier. Hardcoded because this code only ever
+ * runs inside Seren Desktop — the env marker is for child processes.
+ */
+export const CURRENT_HOST = SEREN_DESKTOP_HOST;
+
+/**
+ * Check if a skill is compatible with the current host.
+ * A skill is incompatible when its `excludeHosts` metadata contains the
+ * current host token.
+ */
+export function isSkillCompatibleWithHost(
+  metadata: Pick<SkillMetadata, "excludeHosts"> | undefined | null,
+  host: string = CURRENT_HOST,
+): boolean {
+  if (!metadata?.excludeHosts || metadata.excludeHosts.length === 0) {
+    return true;
+  }
+  return !metadata.excludeHosts.includes(host);
+}
+
+/**
+ * Filter a list of installed skills to only those compatible with the
+ * current host. Excluded skills are removed from discovery/search results.
+ */
+export function filterHostCompatibleSkills<T extends InstalledSkill>(
+  skills: T[],
+  hostMetadata: Map<string, SkillMetadata | undefined>,
+  host: string = CURRENT_HOST,
+): T[] {
+  return skills.filter((skill) =>
+    isSkillCompatibleWithHost(hostMetadata.get(skill.slug), host),
+  );
+}
+
+/**
+ * Filter available (catalog) skills by the `excludeHosts` field on index
+ * entries. Used at catalog ingestion time to drop CLI-only skills.
+ */
+export function filterHostCompatibleCatalog<
+  T extends Skill & { excludeHosts?: string[] },
+>(catalog: T[], host: string = CURRENT_HOST): T[] {
+  return catalog.filter(
+    (entry) =>
+      !entry.excludeHosts || !entry.excludeHosts.includes(host),
+  );
+}

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Skills library exports.
-// ABOUTME: Provides types, parser, and path utilities for skill management.
+// ABOUTME: Provides types, parser, path utilities, and host compatibility for skill management.
 
+export * from "./host";
 export * from "./parser";
 export * from "./paths";
 export * from "./types";

--- a/src/lib/skills/parser.ts
+++ b/src/lib/skills/parser.ts
@@ -106,6 +106,9 @@ function parseYamlFrontmatter(yaml: string): SkillMetadata {
       if (currentKey === "includes") {
         metadata.includes = [...(metadata.includes ?? []), value];
       }
+      if (currentKey === "exclude-hosts" || currentKey === "excludeHosts") {
+        metadata.excludeHosts = [...(metadata.excludeHosts ?? []), value];
+      }
       continue;
     }
 
@@ -124,6 +127,8 @@ function parseYamlFrontmatter(yaml: string): SkillMetadata {
         if (key === "globs") metadata.globs = [];
         if (key === "alwaysAllow") metadata.alwaysAllow = [];
         if (key === "includes") metadata.includes = [];
+        if (key === "exclude-hosts" || key === "excludeHosts")
+          metadata.excludeHosts = [];
         continue;
       }
 
@@ -142,6 +147,8 @@ function parseYamlFrontmatter(yaml: string): SkillMetadata {
         if (key === "globs") metadata.globs = items;
         if (key === "alwaysAllow") metadata.alwaysAllow = items;
         if (key === "includes") metadata.includes = items;
+        if (key === "exclude-hosts" || key === "excludeHosts")
+          metadata.excludeHosts = items;
         continue;
       }
 

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -30,6 +30,13 @@ export interface SkillMetadata {
   alwaysAllow?: string[];
   /** Repo-relative paths to bundle as shared dependencies under _deps/ */
   includes?: string[];
+  /**
+   * Hosts this skill is NOT compatible with. When the current host matches
+   * one of these values, the skill is filtered from discovery and blocked
+   * from invocation. Supported host tokens: "seren-desktop".
+   * Spec: serenorg/seren-desktop#1496
+   */
+  excludeHosts?: string[];
 }
 
 /**
@@ -63,6 +70,12 @@ export interface Skill {
    * the GitHub API call entirely. (#1476)
    */
   lastModified?: string;
+  /**
+   * Hosts this skill is NOT compatible with. Propagated from SKILL.md
+   * frontmatter. Used to filter Desktop-incompatible skills from catalog
+   * discovery. Spec: serenorg/seren-desktop#1496
+   */
+  excludeHosts?: string[];
 }
 
 export interface SkillSyncState {
@@ -159,6 +172,12 @@ export interface SkillIndexEntry {
    * older indexes — desktop falls back to GitHub API when missing. (#1476)
    */
   lastModified?: string;
+  /**
+   * Hosts this skill is NOT compatible with. Present in R2 index entries
+   * that declare host exclusion. Used to filter CLI-only skills from
+   * Desktop discovery. Spec: serenorg/seren-desktop#1496
+   */
+  excludeHosts?: string[];
 }
 
 /**

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1069,7 +1069,7 @@ export const skills = {
             description: parsed.metadata.description || "",
             source: "local" as SkillSource,
             tags: [],
-
+            excludeHosts: parsed.metadata.excludeHosts,
             scope,
             skillsDir,
             dirName,

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -4,11 +4,13 @@
 import { invoke } from "@tauri-apps/api/core";
 import { createStore } from "solid-js/store";
 import { log } from "@/lib/logger";
-import type {
-  InstalledSkill,
-  Skill,
-  SkillScope,
-  SkillsState,
+import {
+  filterHostCompatibleCatalog,
+  type InstalledSkill,
+  isSkillCompatibleWithHost,
+  type Skill,
+  type SkillScope,
+  type SkillsState,
 } from "@/lib/skills";
 import {
   isPublisherManagedSkill,
@@ -449,14 +451,22 @@ export const skillsStore = {
     const refs = threadSkillsState[key];
 
     // Explicit thread override (including empty [] = "no skills")
+    // Fail-closed on host exclusion: a skill that declares excludeHosts
+    // including "seren-desktop" is never resolved, even if a stale
+    // project config or cached ref still points at it.
+    // Spec: serenorg/seren-desktop#1496
     if (Array.isArray(refs)) {
-      return this.resolveRefs(refs);
+      return this.resolveRefs(refs).filter((skill) =>
+        isSkillCompatibleWithHost(skill),
+      );
     }
 
     // No override yet — fall back to project/global defaults so existing
     // threads don't lose their skills on upgrade. New threads get an
     // explicit empty override when the user first toggles a skill.
-    return this.getProjectSkills(projectRoot);
+    return this.getProjectSkills(projectRoot).filter((skill) =>
+      isSkillCompatibleWithHost(skill),
+    );
   },
 
   /**
@@ -594,9 +604,19 @@ export const skillsStore = {
     setState("error", null);
 
     try {
-      const available = await skills.fetchAllSkills(skipCache);
+      const all = await skills.fetchAllSkills(skipCache);
+      // Filter out skills that exclude the Seren Desktop host. These are
+      // CLI-only skills and should never appear in Desktop discovery.
+      // Spec: serenorg/seren-desktop#1496
+      const available = filterHostCompatibleCatalog(all);
+      const excluded = all.length - available.length;
       setState("available", available);
-      log.info("[SkillsStore] Loaded", available.length, "available skills");
+      log.info(
+        "[SkillsStore] Loaded",
+        available.length,
+        "available skills",
+        excluded > 0 ? `(${excluded} host-excluded)` : "",
+      );
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to load skills";
@@ -618,7 +638,21 @@ export const skillsStore = {
       const fileTree = getFileTreeState();
       const projectRoot = fileTree.rootPath;
 
-      const installed = await skills.listAllInstalled(projectRoot);
+      const all = await skills.listAllInstalled(projectRoot);
+
+      // Drop host-excluded skills (CLI-only skills installed by mistake
+      // from the claude/ scope). They never show up in the UI and cannot
+      // be resolved via getThreadSkills.
+      // Spec: serenorg/seren-desktop#1496
+      const installed = all.filter((skill) => isSkillCompatibleWithHost(skill));
+      const excluded = all.length - installed.length;
+      if (excluded > 0) {
+        log.info(
+          "[SkillsStore]",
+          excluded,
+          "installed skill(s) host-excluded from Desktop",
+        );
+      }
 
       // Apply enabled state from localStorage
       for (const skill of installed) {

--- a/tests/unit/skill-host-exclusion.test.ts
+++ b/tests/unit/skill-host-exclusion.test.ts
@@ -1,0 +1,141 @@
+// ABOUTME: Tests for skill host exclusion contract (#1496).
+// ABOUTME: Covers parser, host check, catalog/installed filtering, and fail-closed gating.
+
+import { describe, expect, it } from "vitest";
+import {
+  filterHostCompatibleCatalog,
+  isSkillCompatibleWithHost,
+  parseSkillMd,
+  SEREN_DESKTOP_HOST,
+} from "@/lib/skills";
+
+// ============================================================================
+// Parser: excludeHosts frontmatter reading
+// ============================================================================
+
+describe("parseSkillMd excludeHosts", () => {
+  it("parses inline array form", () => {
+    const md = `---
+name: cli-only
+description: Claude CLI only skill
+exclude-hosts: ["seren-desktop"]
+---
+
+# CLI Only
+`;
+    const parsed = parseSkillMd(md);
+    expect(parsed.metadata.excludeHosts).toEqual(["seren-desktop"]);
+  });
+
+  it("parses block array form (unindented per parser spec)", () => {
+    // The existing YAML-lite parser treats indented lines as sub-keys and
+    // skips them. Block arrays must use unindented '- item' lines.
+    const md = `---
+name: cli-only
+description: Claude CLI only skill
+exclude-hosts:
+- seren-desktop
+- other-host
+---
+
+# CLI Only
+`;
+    const parsed = parseSkillMd(md);
+    expect(parsed.metadata.excludeHosts).toEqual([
+      "seren-desktop",
+      "other-host",
+    ]);
+  });
+
+  it("accepts excludeHosts camelCase key as alias", () => {
+    const md = `---
+name: cli-only
+description: Claude CLI only skill
+excludeHosts: ["seren-desktop"]
+---
+
+# CLI Only
+`;
+    const parsed = parseSkillMd(md);
+    expect(parsed.metadata.excludeHosts).toEqual(["seren-desktop"]);
+  });
+
+  it("leaves excludeHosts undefined when not present", () => {
+    const md = `---
+name: normal
+description: Desktop-compatible skill
+---
+
+# Normal
+`;
+    const parsed = parseSkillMd(md);
+    expect(parsed.metadata.excludeHosts).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// isSkillCompatibleWithHost: core gate logic
+// ============================================================================
+
+describe("isSkillCompatibleWithHost", () => {
+  it("allows skill with no excludeHosts", () => {
+    expect(isSkillCompatibleWithHost({})).toBe(true);
+    expect(isSkillCompatibleWithHost({ excludeHosts: [] })).toBe(true);
+    expect(isSkillCompatibleWithHost(null)).toBe(true);
+    expect(isSkillCompatibleWithHost(undefined)).toBe(true);
+  });
+
+  it("blocks skill that explicitly excludes seren-desktop", () => {
+    expect(
+      isSkillCompatibleWithHost({ excludeHosts: [SEREN_DESKTOP_HOST] }),
+    ).toBe(false);
+  });
+
+  it("allows skill that excludes a different host", () => {
+    expect(
+      isSkillCompatibleWithHost({ excludeHosts: ["some-other-host"] }),
+    ).toBe(true);
+  });
+});
+
+// ============================================================================
+// filterHostCompatibleCatalog: discovery filtering
+// ============================================================================
+
+describe("filterHostCompatibleCatalog", () => {
+  const normalSkill = {
+    id: "s:a",
+    slug: "a",
+    name: "Normal",
+    description: "",
+    source: "seren" as const,
+    tags: [],
+  };
+  const excludedSkill = {
+    id: "s:b",
+    slug: "b",
+    name: "CLI Only",
+    description: "",
+    source: "claude" as const,
+    tags: [],
+    excludeHosts: ["seren-desktop"],
+  };
+
+  it("drops Desktop-excluded entries from catalog", () => {
+    const filtered = filterHostCompatibleCatalog([normalSkill, excludedSkill]);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].slug).toBe("a");
+  });
+
+  it("keeps all entries when none exclude Desktop", () => {
+    const filtered = filterHostCompatibleCatalog([normalSkill]);
+    expect(filtered).toHaveLength(1);
+  });
+
+  it("fail-closed: an installed skill that manages to declare exclusion cannot be resolved", () => {
+    // Regression guard: even if a stale cached ref points at an excluded skill,
+    // it must not flow through the catalog filter.
+    const allExcluded = filterHostCompatibleCatalog([excludedSkill]);
+    expect(allExcluded).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Injects `SEREN_HOST=seren-desktop` and `SEREN_DESKTOP=1` at both the Rust backend startup (`src-tauri/src/lib.rs`) and the Node provider runtime entry (`bin/provider-runtime.mjs`) so every spawned CLI (Claude, Codex, Gemini) and every skill beneath them inherits the host marker.
- Adds an `exclude-hosts` frontmatter contract: the YAML-lite parser now reads both `exclude-hosts` and `excludeHosts` (inline and unindented block arrays), and the new `src/lib/skills/host.ts` helper fail-closed filters excluded entries at catalog ingestion, installed listing, and thread resolution — so stale cached refs cannot resolve an excluded skill.
- Skill authors can mark a SKILL.md as CLI-only with `exclude-hosts: ["seren-desktop"]` and Desktop will drop it from discovery and invocation.

Closes #1496.

## Test plan
- [x] `pnpm test` — 337 passing (14 new in `tests/unit/skill-host-exclusion.test.ts` covering parser, host gate, catalog filter, and fail-closed regression)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com