### PR TITLE
fix(scripts): atomically swap mcp-servers bundle to avoid tauri_build race

### DIFF
--- a/scripts/prepare-mcp-servers.ts
+++ b/scripts/prepare-mcp-servers.ts
@@ -9,6 +9,8 @@ const ROOT = path.resolve(import.meta.dirname, "..");
 const SOURCE = path.join(ROOT, "mcp-servers", "playwright-stealth");
 const DEST_PARENT = path.join(ROOT, "src-tauri", "mcp-servers");
 const DEST = path.join(DEST_PARENT, "playwright-stealth");
+const DEST_NEW = path.join(DEST_PARENT, "playwright-stealth.new");
+const DEST_OLD = path.join(DEST_PARENT, "playwright-stealth.old");
 const RM_RETRY_OPTS = { recursive: true, force: true, maxRetries: 10, retryDelay: 100 } as const;
 
 // Main
@@ -30,14 +32,37 @@ execSync("pnpm install --node-linker=hoisted", { cwd: SOURCE, stdio: "inherit" }
 console.log("Building...");
 execSync("pnpm build", { cwd: SOURCE, stdio: "inherit" });
 
-// 3. Clean destination
-if (fs.existsSync(DEST_PARENT)) {
-	console.log("Cleaning destination...");
-	fs.rmSync(DEST_PARENT, RM_RETRY_OPTS);
+// 3. Atomic swap: copy to sibling, then rename into place.
+//
+// The previous implementation wiped DEST_PARENT then cpSync'd the source back,
+// leaving a ~1-3s window where src-tauri/mcp-servers/playwright-stealth/ did not
+// exist. Tauri's build script walks that tree on fresh builds to emit
+// `rerun-if-changed` entries for bundle resources and aborts with
+// "resource path doesn't exist" if a file vanishes mid-walk. Running both
+// concurrently via `beforeDevCommand` reliably raced on cold builds (#1505).
+//
+// Two renameSync calls on the same filesystem shrink that window to a few
+// microseconds, narrow enough that the walker will not observe a missing dest.
+fs.mkdirSync(DEST_PARENT, { recursive: true });
+
+if (fs.existsSync(DEST_NEW)) {
+	fs.rmSync(DEST_NEW, RM_RETRY_OPTS);
+}
+console.log("Staging new bundle at playwright-stealth.new...");
+fs.cpSync(SOURCE, DEST_NEW, { recursive: true });
+
+if (fs.existsSync(DEST_OLD)) {
+	fs.rmSync(DEST_OLD, RM_RETRY_OPTS);
 }
 
-// 4. Simple copy - no symlink handling needed since hoisted mode creates real files
-console.log("Copying to bundle location...");
-fs.cpSync(SOURCE, DEST, { recursive: true });
+console.log("Swapping into place...");
+if (fs.existsSync(DEST)) {
+	fs.renameSync(DEST, DEST_OLD);
+}
+fs.renameSync(DEST_NEW, DEST);
+
+if (fs.existsSync(DEST_OLD)) {
+	fs.rmSync(DEST_OLD, RM_RETRY_OPTS);
+}
 
 console.log("MCP servers prepared successfully.");


### PR DESCRIPTION
## Summary

Fixes a race between `scripts/prepare-mcp-servers.ts` and `tauri_build::build()` that reliably breaks cold `pnpm tauri dev` runs with `resource path ... doesn't exist`. The previous flow wiped `src-tauri/mcp-servers/` then re-copied it from source, leaving a 1–3 second window where the bundle tree was missing. Tauri's build script walks that tree on every fresh build to emit `rerun-if-changed` entries, and since `beforeDevCommand` runs concurrently with `devCommand`, cargo's walker regularly hit that window.

The fix stages the copy in a sibling `playwright-stealth.new/` directory and swaps it into place with two same-filesystem `renameSync` calls, shrinking the window from seconds to microseconds.

- `scripts/prepare-mcp-servers.ts`: build to `playwright-stealth.new/`, rename current `playwright-stealth/` → `.old/`, rename `.new/` → `playwright-stealth/`, then cleanup `.old/`.
- No stale-file leakage — the new tree is fully built before the swap.
- Idempotent — verified by running the script twice; no orphan `.new` or `.old` directories remain after either run.

Closes #1505. Closes #1504.

## About #1504

#1504 was the "provider runtime hangs, app stuck on Reconnecting" bug filed during the prior debugging session. Root cause today: a corrupted copy of the embedded node binary under `src-tauri/target/debug/embedded-runtime/darwin-x64/node/bin/node` — stuck in kernel state `UE` (uninterruptible exit), never produced output, never bound an HTTP server. The fix was `rm -rf src-tauri/target/debug/embedded-runtime/` so Tauri's build would re-copy a fresh binary from the healthy source tree. That recovery path previously tripped #1505 on the next `pnpm tauri dev` (surfacing a different, misleading error about missing resource paths), which is why the two bugs were tangled. This PR makes the recovery a single clean step.

Verified end-to-end: after wiping `target/debug/embedded-runtime/` and running `pnpm tauri dev`, the provider runtime now starts, prints `{"ok":true,"mode":"desktop-native","host":"127.0.0.1","port":50402,...}`, and the app launches with chats loaded and 28 installed + 170 available skills.

## Test plan
- [x] Fresh run of `pnpm prepare:mcp-servers` produces a clean `src-tauri/mcp-servers/playwright-stealth/` with a populated `dist/`
- [x] Second run is idempotent — no orphan `.new`/`.old` directories
- [x] `pnpm tauri dev` on a wiped `target/debug/embedded-runtime/` completes the build and launches the app (provider runtime ready, chats live, skills loaded)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
