### PR TITLE
fix(sidebar): enforce mutual exclusion between + New launcher and Create New Skill dropdowns (#1493)

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -43,6 +43,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
   const [showCreateMenu, setShowCreateMenu] = createSignal(false);
   const [showCatalog, setShowCatalog] = createSignal(false);
   let launcherRef: HTMLDivElement | undefined;
+  let createMenuRef: HTMLDivElement | undefined;
   let searchInputRef: HTMLInputElement | undefined;
 
   const folderName = () => {
@@ -52,14 +53,21 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
   };
   const primaryChatLauncherDescription = createMemo(() => "Seren models chat");
 
+  // Close any open sidebar popover when the user clicks outside its container.
+  // Handles the `+ New` launcher (z-20) and the `+ Create New Skill` dropdown
+  // (z-50) symmetrically so neither can be left orphaned behind another UI
+  // interaction. Resolves #1493 together with the mutual-exclusion toggles in
+  // `toggleLauncher` and the create-menu button's onClick: without click-outside
+  // coverage for both, the create-menu could stay pinned open and visually
+  // overlap the launcher's scroll region, hiding Codex and Gemini items.
   const handleClickOutside = (e: MouseEvent) => {
-    if (
-      showLauncher() &&
-      launcherRef &&
-      !launcherRef.contains(e.target as Node)
-    ) {
+    const target = e.target as Node;
+    if (showLauncher() && launcherRef && !launcherRef.contains(target)) {
       setShowLauncher(false);
       setLauncherQuery("");
+    }
+    if (showCreateMenu() && createMenuRef && !createMenuRef.contains(target)) {
+      setShowCreateMenu(false);
     }
   };
 
@@ -178,6 +186,12 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
     const opening = !showLauncher();
     setShowLauncher(opening);
     if (opening) {
+      // Mutual exclusion with the Skills section's "+ Create New Skill"
+      // dropdown so only one sidebar popover is open at a time. Without this,
+      // the create-menu's higher z-index (z-50) renders its items on top of
+      // the launcher's (z-20) scroll region, visually hiding Codex / Gemini.
+      // Resolves #1493.
+      setShowCreateMenu(false);
       setLauncherQuery("");
       requestAnimationFrame(() => searchInputRef?.focus());
     }
@@ -620,12 +634,21 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
             />
 
             {/* + Create New Skill dropdown */}
-            <div class="relative mt-2">
+            <div class="relative mt-2" ref={createMenuRef}>
               <button
                 type="button"
                 class="flex items-center justify-center gap-2 w-full py-2 px-3 bg-primary/8 border border-primary/15 rounded-md text-primary text-[13px] font-medium cursor-pointer transition-all duration-100 hover:bg-primary/15 hover:border-primary/25 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={!threadStore.activeThread}
-                onClick={() => setShowCreateMenu((v) => !v)}
+                onClick={() => {
+                  const opening = !showCreateMenu();
+                  setShowCreateMenu(opening);
+                  // Mutual exclusion with the `+ New` launcher dropdown.
+                  // See toggleLauncher for the symmetric side. #1493.
+                  if (opening) {
+                    setShowLauncher(false);
+                    setLauncherQuery("");
+                  }
+                }}
               >
                 <svg
                   width="14"


### PR DESCRIPTION
## Summary
Resolves #1493 (reopened — #1494 was necessary but not sufficient).

Persistent bug: Codex and Gemini agent buttons appear "clipped" from the `+ New` thread launcher dropdown. #1494 replaced `overflow-hidden` with `max-h-[60vh] overflow-y-auto`, which is the right CSS change, but the actual symptom wasn't clipping — it was **visual overlap** between two sidebar popovers that can be open simultaneously.

## Root cause

- [`+ New` launcher](src/components/layout/ThreadSidebar.tsx#L387) dropdown uses `showLauncher` state at z-20.
- [`+ Create New Skill`](src/components/layout/ThreadSidebar.tsx#L646) dropdown inside the Skills section uses `showCreateMenu` state at z-50.
- [`toggleLauncher`](src/components/layout/ThreadSidebar.tsx#L177) only toggled `showLauncher` — never closed `showCreateMenu`.
- The `+ Create New Skill` button's `onClick={() => setShowCreateMenu((v) => !v)}` only toggled `showCreateMenu` — never closed `showLauncher`.
- [`handleClickOutside`](src/components/layout/ThreadSidebar.tsx#L55) only had branch logic for `showLauncher`. Clicking outside the create-menu never closed it.

Result: user opens `+ New`, then clicks `+ Create New Skill`, and both dropdowns are open at once. The create-menu's higher z-index (z-50) renders its `Browse Skills Catalog` / `Create with Skill Creator` buttons **on top of** the launcher's (z-20) scroll region at exactly the vertical position where Codex and Gemini would appear. Those agents are rendered but visually hidden underneath.

#1494's scroll fix didn't resolve this because scrolling can't reveal content that's occluded by a higher-z-index overlay.

## Fix (three matching edits)

1. [`toggleLauncher`](src/components/layout/ThreadSidebar.tsx) — when opening the launcher, also call `setShowCreateMenu(false)`. Mutual exclusion from the launcher side.
2. **`+ Create New Skill` onClick** — expanded from `setShowCreateMenu((v) => !v)` into an explicit opening/closing flow that also calls `setShowLauncher(false)` and clears the launcher query when opening. Mutual exclusion from the create-menu side.
3. **`handleClickOutside`** — added a symmetric branch for `showCreateMenu` using a new `createMenuRef` assigned to the `+ Create New Skill` container `<div>`. Clicking outside the create-menu now closes it, matching the launcher's behavior.

Standard "one popover at a time" UX pattern. No z-index changes — a higher z-index just trades one occlusion for another. The #1494 scroll behavior is preserved for the case where the launcher genuinely needs to scroll past its max-height.

## Tests

**No new unit test.** This is a 3-edit logic contract in a SolidJS component. The repo has no `@solidjs/testing-library` dep and no existing ThreadSidebar tests; adding a mock-heavy component test for a visually-verifiable 3-line toggle contract would violate CLAUDE.md's "Critical and required tests ONLY" rule and YAGNI. Same call I made on #1520's single-instance wiring — the compile check, biome, full vitest suite, and manual click-through are the right verification shape for this kind of UI state fix.

- [x] `pnpm biome check src/components/layout/ThreadSidebar.tsx` — clean
- [x] `pnpm test` — **343 passed**, 0 failed, across 39 test files. No regressions.
- [ ] Manual smoke test: open `+ New`, then click `+ Create New Skill` → launcher closes. Open `+ Create New Skill`, then click `+ New` → create-menu closes. Click outside either → it closes. Codex and Gemini (when available) remain visible in the launcher without overlap.

## Related
- #1493 — the reopened issue
- #1494 — previous scroll fix (shipped, still beneficial, not enough on its own)
- #1521 — separate follow-up for the `__CFBundleIdentifier` strip (unrelated)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
