### PR TITLE
fix(provider-runtime): strip __CFBundleIdentifier + __CF_USER_TEXT_ENCODING (#1521 Phase 1)

### DIFF
--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -306,25 +306,51 @@ pub fn get_embedded_path() -> &'static str {
     EMBEDDED_PATH.get().map(|s| s.as_str()).unwrap_or("")
 }
 
-/// Environment variables that VSCode, Cursor, and the Claude Code extension
-/// inject into the extension host process and every subprocess spawned from
-/// the VSCode integrated terminal. When these leak into an embedded Node.js
-/// subprocess, Node tries to bootstrap as a VSCode extension host and hangs
-/// in ESM module resolution (looking for
-/// `vs/workbench/api/node/extensionHostProcess` which only exists inside the
-/// VSCode app bundle, not in our embedded-runtime tree).
+/// Environment variables injected by Electron-based parent processes
+/// (VSCode, Cursor, ToDesktop-wrapped apps, the Claude Code extension) that
+/// leak into every subprocess spawned from their integrated terminals.
 ///
-/// Strip them from every `Command` that spawns the embedded node binary or a
-/// node-based child (provider runtime, local MCP servers, etc.) BEFORE calling
-/// `.spawn()`. This is a no-op outside of VSCode/Cursor integrated terminals
-/// and fixes the "Timed out waiting for provider runtime readiness" kill-loop
-/// documented in serenorg/seren-desktop#1516.
-const VSCODE_POLLUTING_ENV_VARS: &[&str] = &[
-    // The two that actually trigger the hang — Node interprets
-    // ELECTRON_RUN_AS_NODE + VSCODE_ESM_ENTRYPOINT as "boot as an
-    // extension host" and tries to load a nonexistent entry point.
+/// Two classes of variables are stripped here:
+///
+/// 1. **Node.js / Electron runtime hijacks** (`ELECTRON_RUN_AS_NODE`,
+///    `VSCODE_ESM_ENTRYPOINT`, and the surrounding `VSCODE_*` family): when
+///    these leak into an embedded Node.js subprocess, Node tries to
+///    bootstrap as a VSCode extension host and hangs in ESM module
+///    resolution looking for `vs/workbench/api/node/extensionHostProcess`,
+///    which only exists inside the VSCode app bundle — not in our
+///    embedded-runtime tree. Documented in serenorg/seren-desktop#1516 /
+///    fixed in #1518.
+///
+/// 2. **CoreFoundation bundle-identity hijacks** (`__CFBundleIdentifier`,
+///    `__CF_USER_TEXT_ENCODING`): ToDesktop / Electron / Cursor inject
+///    these to tell macOS CoreFoundation which app bundle the process is
+///    part of. When a CoreFoundation-linked binary inherits them, CF tries
+///    to resolve the parent's bundle via LaunchServices from inside a
+///    foreign subprocess context. That lookup hangs or pulls in unrelated
+///    framework state (Metal, RenderBox) *before* our provider runtime's
+///    `server.listen()` is ever reached. The embedded Node.js binary
+///    statically links `CoreFoundation.framework`, so it's directly
+///    affected. Documented in serenorg/seren-desktop#1521.
+///
+/// Strip them from every `Command` that spawns the embedded node binary or
+/// a node-based child (provider runtime, local MCP servers, etc.) BEFORE
+/// calling `.spawn()`. This is a no-op outside of Electron-host terminals
+/// and fixes the "Timed out waiting for provider runtime readiness" loop
+/// documented in #1516.
+const POLLUTING_PARENT_ENV_VARS: &[&str] = &[
+    // The two Node.js / Electron vars that actually trigger the ESM
+    // bootstrap hijack — Node interprets ELECTRON_RUN_AS_NODE +
+    // VSCODE_ESM_ENTRYPOINT as "boot as an extension host" and tries to
+    // load a nonexistent entry point.
     "ELECTRON_RUN_AS_NODE",
     "VSCODE_ESM_ENTRYPOINT",
+    // The two CoreFoundation-private vars that trigger the bundle-lookup
+    // hang on macOS (#1521). `__CFBundleIdentifier` is the load-bearing
+    // one; `__CF_USER_TEXT_ENCODING` is stripped together because it's
+    // set by the same parent and has no reason to be inherited by an
+    // embedded subprocess.
+    "__CFBundleIdentifier",
+    "__CF_USER_TEXT_ENCODING",
     // Additional VSCode/Cursor vars that are noise at best and may
     // confuse downstream tooling — stripping them is cheap and keeps
     // the embedded node env clean.
@@ -360,15 +386,16 @@ impl CommandEnvSanitize for tokio::process::Command {
     }
 }
 
-/// Remove VSCode / Cursor / Electron-extension-host environment variables
-/// from a `Command` before spawning. Call this on every spawn of the embedded
-/// Node.js binary (and any other subprocess that might load it transitively).
+/// Remove environment variables injected by Electron-based parent processes
+/// (VSCode, Cursor, ToDesktop, Claude Code extension) from a `Command` before
+/// spawning. Call this on every spawn of the embedded Node.js binary (and any
+/// other subprocess that might load it transitively).
 ///
-/// See [`VSCODE_POLLUTING_ENV_VARS`] and serenorg/seren-desktop#1516 for the
-/// full motivation. Safe to call from any context — it's a pure env-scrub and
-/// does nothing when the variables aren't present.
+/// See [`POLLUTING_PARENT_ENV_VARS`] and serenorg/seren-desktop#1516 / #1521
+/// for the full motivation. Safe to call from any context — it's a pure
+/// env-scrub and does nothing when the variables aren't present.
 pub fn sanitize_spawn_env<C: CommandEnvSanitize>(command: &mut C) -> &mut C {
-    for var in VSCODE_POLLUTING_ENV_VARS {
+    for var in POLLUTING_PARENT_ENV_VARS {
         command.env_remove_str(var);
     }
     command
@@ -378,21 +405,29 @@ pub fn sanitize_spawn_env<C: CommandEnvSanitize>(command: &mut C) -> &mut C {
 mod tests {
     use super::*;
 
-    /// Critical test for serenorg/seren-desktop#1516.
+    /// Critical test for serenorg/seren-desktop#1516 and #1521.
     ///
-    /// Verifies that `sanitize_spawn_env` actually removes the two VSCode
-    /// variables that cause the embedded Node.js subprocess hang
-    /// (`ELECTRON_RUN_AS_NODE` + `VSCODE_ESM_ENTRYPOINT`), even when the
-    /// parent process has them set in its own environment. Without this
-    /// test, a future refactor that accidentally drops the `env_remove`
-    /// calls would re-introduce the "no chat window" regression without
-    /// any unit-level signal.
+    /// Verifies that `sanitize_spawn_env` actually removes the load-bearing
+    /// variables that cause the embedded Node.js subprocess hang when
+    /// spawned from a VSCode / Cursor / ToDesktop extension host process
+    /// tree. Without this test, a future refactor that accidentally drops
+    /// any of the `env_remove` calls would re-introduce the "no chat
+    /// window" regression without any unit-level signal.
+    ///
+    /// Four load-bearing variables in total:
+    ///   - `ELECTRON_RUN_AS_NODE` + `VSCODE_ESM_ENTRYPOINT` → Node tries to
+    ///     boot as a VSCode extension host and hangs in ESM resolution
+    ///     (#1516 / #1518).
+    ///   - `__CFBundleIdentifier` + `__CF_USER_TEXT_ENCODING` →
+    ///     CoreFoundation tries to resolve the parent's bundle identity
+    ///     via LaunchServices from inside the subprocess and hangs before
+    ///     `server.listen()` (#1521).
     ///
     /// We assert via `get_envs()` inspection because `tokio::process::Command`
     /// stores env overrides as explicit (key, None) entries when removed,
     /// which is exactly the shape we need to verify the scrub happened.
     #[test]
-    fn sanitize_spawn_env_removes_vscode_extension_host_vars() {
+    fn sanitize_spawn_env_removes_extension_host_and_corefoundation_vars() {
         let mut cmd = tokio::process::Command::new("/bin/true");
 
         sanitize_spawn_env(&mut cmd);
@@ -410,11 +445,16 @@ mod tests {
             })
             .collect();
 
-        // The two load-bearing variables MUST be explicitly removed.
-        // If either is missing from the override list (or present with
-        // a non-None value), the embedded node subprocess will inherit
-        // the parent's VSCode env and hang during ESM bootstrap.
-        let critical_vars = ["ELECTRON_RUN_AS_NODE", "VSCODE_ESM_ENTRYPOINT"];
+        // All four load-bearing variables MUST be explicitly removed.
+        // If any is missing from the override list (or present with a
+        // non-None value), the embedded node subprocess will inherit the
+        // parent's Electron-host env and hang during init.
+        let critical_vars = [
+            "ELECTRON_RUN_AS_NODE",
+            "VSCODE_ESM_ENTRYPOINT",
+            "__CFBundleIdentifier",
+            "__CF_USER_TEXT_ENCODING",
+        ];
         for var in critical_vars {
             let entry = overrides
                 .iter()
@@ -422,8 +462,9 @@ mod tests {
                 .unwrap_or_else(|| {
                     panic!(
                         "sanitize_spawn_env must env_remove \"{var}\" — without this the \
-                         provider runtime node subprocess hangs in ESM bootstrap when spawned \
-                         from a VSCode/Cursor integrated terminal (serenorg/seren-desktop#1516)"
+                         provider runtime node subprocess hangs when spawned from a \
+                         VSCode/Cursor/ToDesktop extension host process tree \
+                         (serenorg/seren-desktop#1516 / #1521)"
                     )
                 });
             assert!(
@@ -449,15 +490,15 @@ mod tests {
             .get_envs()
             .filter(|(k, v)| {
                 v.is_none()
-                    && VSCODE_POLLUTING_ENV_VARS
+                    && POLLUTING_PARENT_ENV_VARS
                         .iter()
                         .any(|p| *p == k.to_string_lossy())
             })
             .count();
         assert_eq!(
             removed_count,
-            VSCODE_POLLUTING_ENV_VARS.len(),
-            "every VSCODE_POLLUTING_ENV_VARS entry must appear exactly once as a removal"
+            POLLUTING_PARENT_ENV_VARS.len(),
+            "every POLLUTING_PARENT_ENV_VARS entry must appear exactly once as a removal"
         );
     }
 }


### PR DESCRIPTION
## Summary
Resolves #1521. Phase 1 of the three-phase plan documented in the issue.

#1518 introduced `sanitize_spawn_env` and stripped the Electron / VSCode ESM-bootstrap hijack variables (`ELECTRON_RUN_AS_NODE`, `VSCODE_ESM_ENTRYPOINT`, and the surrounding `VSCODE_*` family). That fixed the ESM-resolution hang for devs running `pnpm tauri dev` from a plain VSCode integrated terminal, but did NOT fix it for devs running from **Cursor's integrated terminal** or from the **Claude Code Bash tool**.

## Root cause (for the remaining hang)

`ps -Eww` on a stuck provider runtime subprocess spawned from a Cursor-rooted process tree shows:

```
__CFBundleIdentifier=com.todesktop.230313mzl4w4u92
__CF_USER_TEXT_ENCODING=0x1F6:0x0:0x0
```

These are CoreFoundation private env vars that Electron / ToDesktop-wrapped apps (Cursor, VSCode) inject into child processes to propagate their bundle identity. When a CoreFoundation-linked binary inherits them, CoreFoundation uses the bundle identifier to look up the parent's `Info.plist`, preferences domain, and Mach-O resources via LaunchServices from inside the foreign subprocess context.

The embedded Node.js at `embedded-runtime/darwin-x64/node/bin/node` statically links `CoreFoundation.framework` (verified via `otool -L`). When it inherits `__CFBundleIdentifier=com.todesktop.230313mzl4w4u92`, CoreFoundation tries to resolve Cursor's bundle via LaunchServices from inside our foreign subprocess. That lookup hangs (or pulls in unrelated framework state — `lsof` on hung processes showed Metal framework files loaded into the plain Node.js binary, which only makes sense if CoreFoundation pulled in the render pipeline during bundle resolution).

The subprocess stays alive but never prints to stdout and never binds the TCP port it was given, confirming the hang happens before `server.listen()` in `provider-runtime.mjs` is ever reached.

## Fix

### [src-tauri/src/embedded_runtime.rs](src-tauri/src/embedded_runtime.rs)
- Add `__CFBundleIdentifier` and `__CF_USER_TEXT_ENCODING` to the scrub list.
- Rename `VSCODE_POLLUTING_ENV_VARS` → `POLLUTING_PARENT_ENV_VARS` since the list is no longer VSCode-only — it now covers both ESM-hijack vars AND CoreFoundation bundle-identity vars.
- Update the doc comment to document both classes of variables and cross-reference #1521.
- Rename the critical unit test from `sanitize_spawn_env_removes_vscode_extension_host_vars` → `sanitize_spawn_env_removes_extension_host_and_corefoundation_vars` and extend its `critical_vars` assertion from 2 → 4 load-bearing variables (`ELECTRON_RUN_AS_NODE`, `VSCODE_ESM_ENTRYPOINT`, `__CFBundleIdentifier`, `__CF_USER_TEXT_ENCODING`).
- Update the idempotency test to reference the new constant name.

**No other call-site changes needed** — `sanitize_spawn_env` is already wired into `provider_runtime::ensure_started` and `mcp::connect_stdio_server` from #1518, so extending the scrub list automatically covers both spawn sites.

## Why only Phase 1

Scope deliberately narrow. This is Phase 1 of the #1521 three-phase plan:

- **Phase 1 (this PR)**: strip CoreFoundation env vars.
- **Phase 2 (deferred)**: capture subprocess stderr tail on `wait_for_provider_runtime` error to surface kernel rejection reasons in the error message. Pattern already exists in `mcp.rs::spawn_stderr_drain`.
- **Phase 3 (contingency)**: `setsid()` via `CommandExt::pre_exec` to sever the child from the parent's session/mach-port namespace. Only ships if Phases 1+2 are insufficient.

Phase 1 should be sufficient for the observed hang. Deferring Phases 2/3 keeps the diff small and lets us validate the hypothesis before adding more plumbing.

## Tests

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib --tests` — **317 passed**, 0 failed, 1 ignored (live-SerenDB integration). Unchanged from main; no regressions.
- [x] The critical test `sanitize_spawn_env_removes_extension_host_and_corefoundation_vars` now guards against a future refactor accidentally dropping any of the 4 load-bearing `env_remove` calls with a clear panic message citing #1516 / #1521.
- [ ] Manual smoke test on `pnpm tauri dev` launched from a Cursor integrated terminal or Claude Code Bash tool — provider runtime should boot cleanly (`[ProviderRuntime stdout]` JSON log line appears within ~2s of spawn) and the chat window should render.

## Impact

- **Dev-only**: does not affect shipped releases (end users don't have these variables in their parent env).
- Fixes `pnpm tauri dev` launches from Cursor integrated terminals and the Claude Code Bash tool on macOS.
- No-op when the scrubbed variables aren't present (normal Terminal.app / iTerm2 launches continue to work exactly as before).
- No API or behavior changes to the non-hanging case.

## Related
- #1516 — original provider runtime hang investigation
- #1518 — shipped `sanitize_spawn_env` with the VSCode-specific strip list (this PR extends it)
- #1520 — single-instance plugin (shipped, orthogonal)
- #1522 — sidebar dropdown mutual exclusion (shipped, orthogonal)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
