### PR TITLE
fix(claude-memory): increase cold-start database readiness budget from 60s to 180s (#1524)

### DIFF
--- a/src/services/claudeMemory.ts
+++ b/src/services/claudeMemory.ts
@@ -51,10 +51,18 @@ CREATE TABLE IF NOT EXISTS claude_agent_preference_audit (
 
 /**
  * How many times to poll a freshly-created database for readiness before
- * giving up. With a 2-second delay between attempts this gives ~60 seconds
+ * giving up. With a 2-second delay between attempts this gives ~3 minutes
  * total for the database's Postgres backend to finish provisioning.
+ *
+ * The original budget was 30 attempts / 60s, which was insufficient for
+ * first-run cold-start provisioning on Windows (reported in #1524): a
+ * user who upgrades to a version with auto-memory for the first time
+ * triggers project + database + Postgres backend creation in one shot,
+ * and the backend can take 60-120s to become queryable. 90 attempts
+ * (180s) gives a generous margin without changing the 2s poll interval
+ * (warm databases still return on the first or second attempt).
  */
-const DATABASE_READY_MAX_ATTEMPTS = 30;
+const DATABASE_READY_MAX_ATTEMPTS = 90;
 const DATABASE_READY_DELAY_MS = 2000;
 
 /**
@@ -113,16 +121,15 @@ export async function waitForDatabaseReady(
     } catch (err) {
       if (!isDatabaseNotReadyError(err)) {
         // Not a cold-start error — surface it immediately instead of
-        // burning the whole 60-second budget on a permanent failure.
+        // burning the whole budget on a permanent failure.
         throw err;
       }
       if (attempt === maxAttempts) {
+        const totalSeconds = (maxAttempts * delayMs) / 1000;
         throw new Error(
-          `SerenDB database "${databaseName}" did not become ready after ${maxAttempts} attempts (${
-            (maxAttempts * delayMs) / 1000
-          }s total). Last error: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
+          `SerenDB database "${databaseName}" did not become ready after ${maxAttempts} attempts (${totalSeconds}s total). ` +
+            `This can happen on first run when the database backend is still provisioning. ` +
+            `Last error: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
       console.debug(


### PR DESCRIPTION
## Summary
Resolves #1524.

A Windows user upgrading to a version with auto-memory for the first time reported a modal error dialog: "SerenDB database 'claude_agent_prefs' did not become ready after 30 attempts (60s total)... Internal error: Failed to connect to target database."

This is a first-run cold-start scenario: the user never had the auto-memory feature before, so `ensureClaudeMemoryProvisioned` creates the `claude-agent-prefs` project AND the `claude_agent_prefs` database AND waits for the underlying Postgres backend to become queryable -- all in one shot. The Postgres provisioning for a brand-new database can take 60-120s, and the previous budget of 30 attempts x 2s = 60s was cutting it too close.

## Fix

- Increase `DATABASE_READY_MAX_ATTEMPTS` from **30 to 90** (180 seconds total with the unchanged 2s polling interval). Warm databases still return on the first or second `SELECT 1` probe -- only the cold-start ceiling moves.
- Improve the timeout error message to mention that this can happen on first run when the database backend is still provisioning, so the user understands it is transient rather than permanent.

**Net diff**: 1 file, +15 / -8 lines in [claudeMemory.ts](src/services/claudeMemory.ts).

## Tests
- [x] `pnpm biome check src/services/claudeMemory.ts` -- clean
- [x] `pnpm test tests/services/claudeMemory.test.ts` -- **10 passed** (tests use custom maxAttempts/delayMs, independent of the constant)
- [x] `pnpm test` -- **343 passed** across 39 files, no regressions

## Related
- #1492 -- the original auto-memory feature spec
- #1514 -- databases.runSql via Tauri command (the query path this poll uses)
- #1511 -- the waitForDatabaseReady function that this PR adjusts

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
