### PR TITLE
perf(agent-store): batch toolCall/toolResult events and skip skills refresh during prompting (#1531)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,9 +118,16 @@ function App() {
 
   // Periodically refresh available skills so newly published skills appear without restart.
   // Base interval: 5 min + up to 30s jitter. R2 serves the index with zero rate limits.
+  // Skip the refresh when any agent session is actively prompting — the 4+ network
+  // requests and large setState batch compound the already-saturated event stream
+  // from high-velocity tool-call chains, making the UI feel unresponsive. #1531.
   const SKILLS_REFRESH_BASE = 5 * 60 * 1000;
   const skillsRefreshTimer = setInterval(
-    () => void skillsStore.refresh(),
+    () => {
+      const session = agentStore.activeSession;
+      if (session?.info.status === "prompting") return;
+      void skillsStore.refresh();
+    },
     SKILLS_REFRESH_BASE + Math.random() * 30 * 1000,
   );
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -492,6 +492,19 @@ const CHUNK_FLUSH_MS = 50;
 const chunkBufs = new Map<string, { content: string; thinking: string }>();
 const chunkFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+// Tool event accumulation buffers — plain JS, not reactive.
+// During high-velocity tool-call chains (e.g. Codex doing 20+ sequential
+// tool calls), each toolCall/toolResult event triggers multiple setState
+// calls (message append, status update, persistence). Batching these on
+// the same CHUNK_FLUSH_MS interval as streaming chunks coalesces a burst
+// of N tool events into a single SolidJS reconciliation pass. #1531.
+interface PendingToolEvent {
+  type: "toolCall" | "toolResult";
+  data: unknown;
+}
+const toolEventBufs = new Map<string, PendingToolEvent[]>();
+const toolEventFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
 function flushChunkBuf(sessionId: string): void {
   const timer = chunkFlushTimers.get(sessionId);
   if (timer !== undefined) {
@@ -524,6 +537,15 @@ function clearChunkBuf(sessionId: string): void {
   chunkBufs.delete(sessionId);
 }
 
+function clearToolEventBuf(sessionId: string): void {
+  const timer = toolEventFlushTimers.get(sessionId);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    toolEventFlushTimers.delete(sessionId);
+  }
+  toolEventBufs.delete(sessionId);
+}
+
 function disposeAgentStoreRuntimeBindings(): void {
   if (globalUnsubscribe) {
     globalUnsubscribe();
@@ -539,6 +561,11 @@ function disposeAgentStoreRuntimeBindings(): void {
   }
   chunkFlushTimers.clear();
   chunkBufs.clear();
+  for (const timer of toolEventFlushTimers.values()) {
+    clearTimeout(timer);
+  }
+  toolEventFlushTimers.clear();
+  toolEventBufs.clear();
 }
 
 const agentStoreHot =
@@ -2684,6 +2711,9 @@ Structured summary:`;
     );
 
     setState("sessions", sessionId, "cancelRequested", true);
+    // Drop any already-buffered tool events — no point flushing them
+    // when the user has requested cancel. #1531.
+    clearToolEventBuf(sessionId);
 
     try {
       await providerService.cancelPrompt(sessionId);
@@ -3019,17 +3049,11 @@ Structured summary:`;
         break;
 
       case "toolCall":
-        this.handleToolCall(sessionId, event.data);
-        break;
-
       case "toolResult":
-        this.handleToolResult(
-          sessionId,
-          event.data.toolCallId,
-          event.data.status,
-          event.data.result,
-          event.data.error,
-        );
+        // Buffer tool events and flush on the same interval as streaming
+        // chunks so a burst of N tool calls produces one SolidJS
+        // reconciliation pass instead of N. See #1531.
+        this.enqueueToolEvent(sessionId, event.type, event.data);
         break;
 
       case "diff":
@@ -3050,6 +3074,9 @@ Structured summary:`;
         break;
 
       case "promptComplete": {
+        // Flush any buffered tool events before finalizing the turn so all
+        // tool messages are visible in the UI before the prompt completes.
+        this.flushToolEventBuf(sessionId);
         const isHistoryReplay =
           event.data.historyReplay === true ||
           event.data.stopReason === "HistoryReplay";
@@ -3553,6 +3580,72 @@ Structured summary:`;
           flushChunkBuf(sessionId);
         }, CHUNK_FLUSH_MS),
       );
+    }
+  },
+
+  enqueueToolEvent(
+    sessionId: string,
+    type: "toolCall" | "toolResult",
+    data: unknown,
+  ) {
+    // Drop tool events for sessions where cancel has been requested.
+    // The agent process may still be finishing a tool chain after cancel
+    // was sent — processing those events just wastes render cycles and
+    // makes the UI feel unresponsive while the user is waiting for the
+    // cancel to take effect. #1531.
+    const session = state.sessions[sessionId];
+    if (session?.cancelRequested) return;
+
+    let buf = toolEventBufs.get(sessionId);
+    if (!buf) {
+      buf = [];
+      toolEventBufs.set(sessionId, buf);
+    }
+    buf.push({ type, data });
+
+    // Schedule a flush if one isn't already pending.
+    if (!toolEventFlushTimers.has(sessionId)) {
+      toolEventFlushTimers.set(
+        sessionId,
+        setTimeout(() => {
+          toolEventFlushTimers.delete(sessionId);
+          this.flushToolEventBuf(sessionId);
+        }, CHUNK_FLUSH_MS),
+      );
+    }
+  },
+
+  flushToolEventBuf(sessionId: string) {
+    const timer = toolEventFlushTimers.get(sessionId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      toolEventFlushTimers.delete(sessionId);
+    }
+    const buf = toolEventBufs.get(sessionId);
+    if (!buf || buf.length === 0) return;
+    toolEventBufs.delete(sessionId);
+
+    // Process all buffered events in order. This triggers setState calls,
+    // but SolidJS batches synchronous updates within the same microtask,
+    // so the entire flush produces a single reconciliation pass.
+    for (const event of buf) {
+      if (event.type === "toolCall") {
+        this.handleToolCall(sessionId, event.data as ToolCallEvent);
+      } else {
+        const d = event.data as {
+          toolCallId: string;
+          status: string;
+          result?: string;
+          error?: string;
+        };
+        this.handleToolResult(
+          sessionId,
+          d.toolCallId,
+          d.status,
+          d.result,
+          d.error,
+        );
+      }
     }
   },
 


### PR DESCRIPTION
## Summary
Resolves #1531.

The UI becomes sluggish during high-velocity agent tool use (observed with Codex at 65% context / 258K tokens doing 20+ sequential tool calls). Three compounding causes, all addressed.

## Fix 1: Batch discrete tool events (agent.store.ts)

The existing `CHUNK_FLUSH_MS = 50` buffer only batched streaming content (`content` + `thinking` chunks). Discrete `toolCall` and `toolResult` events bypassed the buffer entirely, each calling `setState` immediately and triggering a full SolidJS reactive cycle + DOM reconciliation.

New `toolEventBufs` / `toolEventFlushTimers` accumulation buffers mirror the existing chunk buffer pattern:
- `enqueueToolEvent()` buffers incoming tool events and schedules a flush on the same 50ms interval
- `flushToolEventBuf()` processes all buffered events in order -- SolidJS batches synchronous `setState` calls within the same microtask, so the entire flush produces **one reconciliation pass** instead of N
- `promptComplete` flushes the tool buffer before finalizing the turn
- `dispose` clears buffers and timers

## Fix 2: Skip skills refresh during active prompting (App.tsx)

The periodic skills refresh (5 min + 30s jitter) fires regardless of agent activity. Each cycle issues 4+ network requests and writes a large `setState` batch. When this fires during an active tool chain, it compounds the saturated event stream.

Now checks `agentStore.activeSession?.info.status === "prompting"` and skips the refresh. Runs on the next interval tick after the prompt completes.

## Fix 3: Drop tool events after cancel (agent.store.ts)

After `cancelPrompt`, the agent process may still finish its current tool chain. Each trailing `toolCall`/`toolResult` event caused unnecessary re-renders while the user waits for cancel to take effect.

`enqueueToolEvent` now checks `session.cancelRequested` and drops the event. `cancelPrompt` also calls `clearToolEventBuf()` to drop already-buffered events.

## Diff
2 files changed, **+111 / -11 lines**.

## Tests
- [x] `pnpm biome check src/stores/agent.store.ts src/App.tsx` -- clean (0 errors, 1 pre-existing warning)
- [x] `pnpm test` -- **343 passed** across 39 files, no regressions

No new unit tests: the batching is a performance optimization that doesn't change observable behavior (tool messages still appear in the same order, coalesced into fewer render cycles). The cancel-drop uses the existing `cancelRequested` flag. Per CLAUDE.md "critical tests ONLY."

## Related
- #1531 -- the issue being resolved
- The existing `CHUNK_FLUSH_MS` buffer pattern (lines ~491-516 before this PR) that this extends

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
