### PR TITLE
fix(agent-store): restore Codex/Gemini conversation history from SQLite on thread reopen (#1533)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1688,13 +1688,28 @@ export const agentStore = {
         ? (convo.agent_type as AgentType)
         : state.selectedAgentType;
     const convoMetadata = parseAgentConversationMetadata(convo.agent_metadata);
-    const pendingBootstrapPromptContext =
+    let pendingBootstrapPromptContext =
       convoMetadata.pendingBootstrapPromptContext;
-    const restoredMessages = Array.isArray(
-      convoMetadata.pendingBootstrapMessages,
-    )
+    let restoredMessages = Array.isArray(convoMetadata.pendingBootstrapMessages)
       ? convoMetadata.pendingBootstrapMessages
       : [];
+
+    // Metadata messages are only populated when bootstrapPromptContext is
+    // truthy (see spawnSession line ~1322). For Codex and Gemini sessions
+    // that never went through the Claude Code resume-fallback path, metadata
+    // messages are always empty even though the messages WERE persisted to
+    // SQLite via persistAgentMessage during the session. Fall back to the
+    // SQLite store so users see their conversation history when reopening a
+    // thread after a crash, kill, or compaction failure. Resolves #1533.
+    if (restoredMessages.length === 0) {
+      const persisted = await loadPersistedAgentHistory(conversationId);
+      if (persisted.messages.length > 0) {
+        restoredMessages = persisted.messages;
+        if (!pendingBootstrapPromptContext && persisted.context) {
+          pendingBootstrapPromptContext = persisted.context;
+        }
+      }
+    }
 
     const remoteSessionId = convo.agent_session_id?.trim();
     if (!remoteSessionId) {


### PR DESCRIPTION
## Summary
Resolves #1533.

When a Codex or Gemini agent session crashes (e.g. OpenAI compaction 401, force-kill, or any unrecoverable error), reopening the thread showed blank content or the active Skill's system prompt instead of the actual conversation messages. Users lost all visible work even though messages were persisted to SQLite via `persistAgentMessage` during the session.

## Root cause

`resumeAgentConversation` loads messages from **conversation metadata** (`convoMetadata.pendingBootstrapMessages`), not from SQLite. For Codex and Gemini sessions, metadata messages are always empty because `spawnSession` only populates `pendingBootstrapMessages` when `bootstrapPromptContext` is truthy -- and normal Codex/Gemini sessions don't have a bootstrap context.

The Claude Code path has a dedicated fallback that calls `loadPersistedAgentHistory` to read from SQLite, but it's guarded by `agentType === "claude-code"` and doesn't run for other agent types.

## Fix

After loading metadata messages in `resumeAgentConversation`, if the array is empty, fall back to `loadPersistedAgentHistory` (SQLite) for ALL agent types. This runs before the remote-session-id check, so it covers both the fresh-spawn path and the resume path.

```typescript
if (restoredMessages.length === 0) {
  const persisted = await loadPersistedAgentHistory(conversationId);
  if (persisted.messages.length > 0) {
    restoredMessages = persisted.messages;
    if (!pendingBootstrapPromptContext && persisted.context) {
      pendingBootstrapPromptContext = persisted.context;
    }
  }
}
```

The persisted messages are passed as `restoredMessages` to `spawnSession`, which sets `skipHistoryReplay` so the provider's replay events are filtered and the user sees their actual conversation history.

**Net diff**: 1 file, +19 / -4 lines in [agent.store.ts](src/stores/agent.store.ts).

## Tests
- [x] `pnpm biome check src/stores/agent.store.ts` -- clean (0 errors, 1 pre-existing warning)
- [x] `pnpm test` -- **343 passed** across 39 files, no regressions

## Related
- #1533 -- the issue being resolved
- The original incident: a Codex session hit OpenAI's compaction 401 (`Missing scopes: api.responses.write`) at 258K/258K context, the session froze, the user force-killed it, and reopening the thread showed the Skill Creator system prompt instead of their work

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
