### PR TITLE
feat(models): update Seren chat model selector with curated model set (#1536)

### DIFF
--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -99,6 +99,8 @@ interface GatewayResponse<T> {
  * Default models available through Seren Gateway.
  */
 const DEFAULT_MODELS: ProviderModel[] = [
+  // OpenAI
+  { id: "openai/gpt-5.4", name: "OpenAI GPT 5.4", contextWindow: 128000 },
   // Anthropic
   {
     id: "anthropic/claude-opus-4.6",
@@ -106,27 +108,23 @@ const DEFAULT_MODELS: ProviderModel[] = [
     contextWindow: 1000000,
   },
   {
-    id: "anthropic/claude-sonnet-4",
-    name: "Claude Sonnet 4",
+    id: "anthropic/claude-opus-4.5",
+    name: "Claude Opus 4.5",
     contextWindow: 200000,
   },
   {
-    id: "anthropic/claude-haiku-4.5",
-    name: "Claude Haiku 4.5",
+    id: "anthropic/claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6",
     contextWindow: 200000,
   },
-  // OpenAI
-  { id: "openai/gpt-5.4", name: "GPT-5.4", contextWindow: 128000 },
-  // Google Gemini
-  {
-    id: "google/gemini-3.1-pro-preview",
-    name: "Gemini 3.1 Pro",
-    contextWindow: 1048576,
-  },
+  // THUDM
+  { id: "thudm/glm-5.4", name: "GLM 5.4", contextWindow: 128000 },
+  // Moonshot
+  { id: "moonshot/kimi-k2.5", name: "Kimi K2.5", contextWindow: 128000 },
   // Arcee AI
   {
     id: "arcee-ai/trinity-large-thinking",
-    name: "Trinity Large Thinking",
+    name: "Arcee-AI Trinity Large Thinking",
     contextWindow: 128000,
   },
 ];

--- a/src/stores/provider.store.ts
+++ b/src/stores/provider.store.ts
@@ -77,41 +77,33 @@ interface ProviderState {
  */
 const DEFAULT_MODELS: Record<ProviderId, ProviderModel[]> = {
   seren: [
+    // OpenAI
+    { id: "openai/gpt-5.4", name: "OpenAI GPT 5.4", contextWindow: 128000 },
     // Anthropic
+    {
+      id: "anthropic/claude-opus-4.6",
+      name: "Claude Opus 4.6",
+      contextWindow: 1000000,
+    },
     {
       id: "anthropic/claude-opus-4.5",
       name: "Claude Opus 4.5",
       contextWindow: 200000,
     },
     {
-      id: "anthropic/claude-sonnet-4",
-      name: "Claude Sonnet 4",
+      id: "anthropic/claude-sonnet-4.6",
+      name: "Claude Sonnet 4.6",
       contextWindow: 200000,
     },
+    // THUDM
+    { id: "thudm/glm-5.4", name: "GLM 5.4", contextWindow: 128000 },
+    // Moonshot
+    { id: "moonshot/kimi-k2.5", name: "Kimi K2.5", contextWindow: 128000 },
+    // Arcee AI
     {
-      id: "anthropic/claude-haiku-4.5",
-      name: "Claude Haiku 4.5",
-      contextWindow: 200000,
-    },
-    // OpenAI
-    { id: "openai/gpt-5", name: "GPT-5", contextWindow: 128000 },
-    { id: "openai/gpt-4o", name: "GPT-4o", contextWindow: 128000 },
-    { id: "openai/gpt-4o-mini", name: "GPT-4o Mini", contextWindow: 128000 },
-    // Google Gemini
-    {
-      id: "google/gemini-2.5-pro",
-      name: "Gemini 2.5 Pro",
-      contextWindow: 1000000,
-    },
-    {
-      id: "google/gemini-2.5-flash",
-      name: "Gemini 2.5 Flash",
-      contextWindow: 1000000,
-    },
-    {
-      id: "google/gemini-3-flash-preview",
-      name: "Gemini 3 Flash",
-      contextWindow: 1000000,
+      id: "arcee-ai/trinity-large-thinking",
+      name: "Arcee-AI Trinity Large Thinking",
+      contextWindow: 128000,
     },
   ],
   "seren-private": [],


### PR DESCRIPTION
## Summary
Resolves #1536.

Updates the Seren chat model selector dropdown with a curated set of 7 models:

| # | Model | ID |
|---|-------|-----|
| 1 | OpenAI GPT 5.4 | `openai/gpt-5.4` |
| 2 | Claude Opus 4.6 | `anthropic/claude-opus-4.6` |
| 3 | Claude Opus 4.5 | `anthropic/claude-opus-4.5` |
| 4 | Claude Sonnet 4.6 | `anthropic/claude-sonnet-4.6` |
| 5 | GLM 5.4 | `thudm/glm-5.4` |
| 6 | Kimi K2.5 | `moonshot/kimi-k2.5` |
| 7 | Arcee-AI Trinity Large Thinking | `arcee-ai/trinity-large-thinking` |

Updated in both default model sources:
- [seren.ts](src/lib/providers/seren.ts) -- primary source for the dropdown
- [provider.store.ts](src/stores/provider.store.ts) -- UI-layer fallback

The "Auto" option stays at the top (rendered by ModelSelector component). Users can still search for any other model via the search box (OpenRouter catalog search is already wired up).

**Net diff**: 2 files, +28 / -38 lines (smaller list, cleaner).

## Tests
- [x] `pnpm biome check` -- clean
- [x] `pnpm test` -- **343 passed**, no regressions

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
