### PR TITLE
fix(models): correct invalid model IDs for GLM and Kimi (#1536 follow-up)

### DIFF
--- a/src-tauri/src/orchestrator/router.rs
+++ b/src-tauri/src/orchestrator/router.rs
@@ -17,8 +17,8 @@ const SIMPLE_PREFERRED_MODELS: &[&str] = &[
     "google/gemini-3-flash-preview",
     "google/gemini-2.5-flash",
     "anthropic/claude-haiku-4.5",
-    "moonshot/kimi-k2.5",
-    "thudm/glm-4.7",
+    "moonshotai/kimi-k2.5",
+    "z-ai/glm-5.1",
     "anthropic/claude-sonnet-4",
 ];
 
@@ -355,9 +355,8 @@ fn humanize_model_id(model_id: &str) -> &str {
         "google/gemini-2.5-pro" => "Gemini Pro",
         "google/gemini-2.5-flash" => "Gemini Flash",
         "google/gemini-3-flash-preview" => "Gemini 3 Flash",
-        "moonshot/kimi-k2.5" => "Kimi K2.5",
-        "thudm/glm-4.7" => "GLM-4.7",
-        "thudm/glm-4" => "GLM-4",
+        "moonshotai/kimi-k2.5" => "Kimi K2.5",
+        "z-ai/glm-5.1" => "GLM 5.1",
         "organization/private-model" => "Private Models",
         _ => model_id,
     }
@@ -1343,9 +1342,9 @@ mod tests {
         .unwrap();
 
         let classification = make_classification("general_chat", false, false);
-        let tried = vec!["moonshot/kimi-k2.5".to_string()];
+        let tried = vec!["moonshotai/kimi-k2.5".to_string()];
         let available = vec![
-            "moonshot/kimi-k2.5".to_string(),
+            "moonshotai/kimi-k2.5".to_string(),
             "anthropic/claude-haiku-4.5".to_string(),
             "anthropic/claude-sonnet-4".to_string(),
         ];

--- a/src-tauri/src/orchestrator/types.rs
+++ b/src-tauri/src/orchestrator/types.rs
@@ -330,13 +330,13 @@ mod tests {
         assert_eq!(json["message"], "oops");
 
         let reroute = WorkerEvent::Reroute {
-            from_model: "moonshot/kimi-k2.5".to_string(),
+            from_model: "moonshotai/kimi-k2.5".to_string(),
             to_model: "anthropic/claude-sonnet-4".to_string(),
             reason: "Rerouted to Claude Sonnet (rated helpful for research)".to_string(),
         };
         let json = serde_json::to_value(&reroute).unwrap();
         assert_eq!(json["type"], "reroute");
-        assert_eq!(json["from_model"], "moonshot/kimi-k2.5");
+        assert_eq!(json["from_model"], "moonshotai/kimi-k2.5");
         assert_eq!(json["to_model"], "anthropic/claude-sonnet-4");
         assert!(json["reason"].as_str().unwrap().contains("Claude Sonnet"));
     }

--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -100,7 +100,7 @@ interface GatewayResponse<T> {
  */
 const DEFAULT_MODELS: ProviderModel[] = [
   // OpenAI
-  { id: "openai/gpt-5.4", name: "OpenAI GPT 5.4", contextWindow: 128000 },
+  { id: "openai/gpt-5.4", name: "OpenAI GPT 5.4", contextWindow: 1050000 },
   // Anthropic
   {
     id: "anthropic/claude-opus-4.6",
@@ -115,17 +115,17 @@ const DEFAULT_MODELS: ProviderModel[] = [
   {
     id: "anthropic/claude-sonnet-4.6",
     name: "Claude Sonnet 4.6",
-    contextWindow: 200000,
+    contextWindow: 1000000,
   },
-  // THUDM
-  { id: "thudm/glm-5.4", name: "GLM 5.4", contextWindow: 128000 },
-  // Moonshot
-  { id: "moonshot/kimi-k2.5", name: "Kimi K2.5", contextWindow: 128000 },
+  // Z.ai (formerly THUDM)
+  { id: "z-ai/glm-5.1", name: "GLM 5.1", contextWindow: 202752 },
+  // MoonshotAI
+  { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5", contextWindow: 262144 },
   // Arcee AI
   {
     id: "arcee-ai/trinity-large-thinking",
     name: "Arcee-AI Trinity Large Thinking",
-    contextWindow: 128000,
+    contextWindow: 262144,
   },
 ];
 

--- a/src/stores/provider.store.ts
+++ b/src/stores/provider.store.ts
@@ -78,7 +78,7 @@ interface ProviderState {
 const DEFAULT_MODELS: Record<ProviderId, ProviderModel[]> = {
   seren: [
     // OpenAI
-    { id: "openai/gpt-5.4", name: "OpenAI GPT 5.4", contextWindow: 128000 },
+    { id: "openai/gpt-5.4", name: "OpenAI GPT 5.4", contextWindow: 1050000 },
     // Anthropic
     {
       id: "anthropic/claude-opus-4.6",
@@ -93,17 +93,17 @@ const DEFAULT_MODELS: Record<ProviderId, ProviderModel[]> = {
     {
       id: "anthropic/claude-sonnet-4.6",
       name: "Claude Sonnet 4.6",
-      contextWindow: 200000,
+      contextWindow: 1000000,
     },
-    // THUDM
-    { id: "thudm/glm-5.4", name: "GLM 5.4", contextWindow: 128000 },
-    // Moonshot
-    { id: "moonshot/kimi-k2.5", name: "Kimi K2.5", contextWindow: 128000 },
+    // Z.ai (formerly THUDM)
+    { id: "z-ai/glm-5.1", name: "GLM 5.1", contextWindow: 202752 },
+    // MoonshotAI
+    { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5", contextWindow: 262144 },
     // Arcee AI
     {
       id: "arcee-ai/trinity-large-thinking",
       name: "Arcee-AI Trinity Large Thinking",
-      contextWindow: 128000,
+      contextWindow: 262144,
     },
   ],
   "seren-private": [],


### PR DESCRIPTION
## Summary
Follow-up to #1536 / #1537. Fixes invalid model IDs that returned HTTP 400.

**Broken IDs:**
- `moonshot/kimi-k2.5` -> HTTP 400 (correct: `moonshotai/kimi-k2.5`)
- `thudm/glm-5.4` -> HTTP 400 (correct: `z-ai/glm-5.1`; GLM 5.4 does not exist)

All 7 model IDs validated against the live OpenRouter catalog API. Context windows also corrected to match actual values (GPT 5.4 is 1.05M not 128K, Sonnet 4.6 is 1M not 200K, etc).

**4 files, +22 / -23 lines.** Updated in seren.ts, provider.store.ts, router.rs, types.rs.

## Tests
- pnpm biome check: clean
- pnpm test: 343 passed
- cargo test: 320 passed

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com