### PR TITLE
fix(memory): use SerenDB API key instead of OAuth token for cloud memory sync (#1540)

### DIFF
--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -14,7 +14,11 @@ use seren_memory_sdk::models::CachedMemory;
 use seren_memory_sdk::sync::SyncEngine;
 
 const AUTH_STORE: &str = "auth.json";
-const TOKEN_KEY: &str = "token";
+// The memory service at memory.serendb.com authenticates via SerenDB API key,
+// NOT the OAuth bearer token. Using "token" (the OAuth token) caused every
+// cloud call to return HTTP 401, silently falling back to local-only cache.
+// Same credential used by claude_memory.rs (fixed in #1511). Resolves #1540.
+const TOKEN_KEY: &str = "seren_api_key";
 
 /// Managed state for memory operations.
 pub struct MemoryState {


### PR DESCRIPTION
## Summary
Resolves #1540.

The user memory feature was silently failing on every cloud call with HTTP 401. `MemoryState::client()` read `auth.json.token` (OAuth bearer token) but `memory.serendb.com` authenticates via the SerenDB API key (`auth.json.seren_api_key`).

Local cache fallback masked the failure — memories saved locally but never synced to cloud.

## Fix

```rust
// Before
const TOKEN_KEY: &str = "token";

// After
const TOKEN_KEY: &str = "seren_api_key";
```

Same credential the `claude_memory.rs` module uses (fixed in #1511).

**1 file, +5 / -1 lines.**

## Tests
- cargo check: clean
- cargo test: 320 passed, 0 failed

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com