### PR TITLE
fix(skills): run full installed-skill sync on sidebar refresh and match backfill by dirName (#1558)

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -587,11 +587,11 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
               </span>
             </Show>
           </div>
-          {/* Refresh skills catalog */}
+          {/* Refresh skills catalog and sync installed skills */}
           <button
             type="button"
             class="shrink-0 p-1 rounded hover:bg-surface-3 text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-100"
-            title="Refresh skills catalog"
+            title="Refresh skills"
             onClick={(e) => {
               e.stopPropagation();
               void skillsStore.clearCacheAndRefresh();

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1515,9 +1515,15 @@ export const skills = {
       // Skip skills that already have sync state
       if (skill.syncState) continue;
 
-      // Try matching to upstream repo first, then publisher catalog
-      const repoMatch = repoSkillsBySlug.get(skill.slug);
-      const publisherMatch = publisherSkillsBySlug.get(skill.slug);
+      // Try matching by slug first, then fall back to dirName (which always
+      // equals the marketplace slug even when resolveSkillSlug() derives a
+      // different slug from SKILL.md frontmatter name).
+      const repoMatch =
+        repoSkillsBySlug.get(skill.slug) ??
+        repoSkillsBySlug.get(skill.dirName);
+      const publisherMatch =
+        publisherSkillsBySlug.get(skill.slug) ??
+        publisherSkillsBySlug.get(skill.dirName);
       const match = repoMatch ?? publisherMatch;
       if (!match?.sourceUrl) {
         // Also detect publisher skills by SKILL.md metadata (publisher_slug)

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -712,7 +712,7 @@ export const skillsStore = {
         !s.syncState &&
         state.available.some(
           (a) =>
-            a.slug === s.slug &&
+            (a.slug === s.slug || a.slug === s.dirName) &&
             (a.source === "serenorg" || a.source === "seren"),
         ),
     );
@@ -941,11 +941,11 @@ export const skillsStore = {
   },
 
   /**
-   * Clear the skills index cache and refresh.
+   * Clear the skills index cache and run a full refresh (catalog + installed sync).
    */
   async clearCacheAndRefresh(): Promise<void> {
     skills.clearCache();
-    await this.refreshAvailable();
+    await this.refresh(true);
   },
 
   hideSkill(slug: string): void {

--- a/tests/unit/skills-auto-sync.test.ts
+++ b/tests/unit/skills-auto-sync.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Test that refresh() auto-refreshes stale upstream-managed skills.
-// ABOUTME: Verifies concurrency guard (#1289), summary tracking, and the fix for #1155.
+// ABOUTME: Verifies concurrency guard (#1289), summary tracking, #1155, and #1558.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,6 +12,7 @@ const mockSkillsService = vi.hoisted(() => ({
   isUpstreamManagedSkill: vi.fn().mockReturnValue(false),
   isPublisherManagedSkill: vi.fn().mockReturnValue(false),
   renameSkillDir: vi.fn().mockResolvedValue("/skills/renamed/SKILL.md"),
+  clearCache: vi.fn(),
 }));
 
 vi.mock("solid-js/store", () => ({
@@ -43,6 +44,7 @@ vi.mock("@/services/skills", () => ({
     inspectSyncStatus: mockSkillsService.inspectSyncStatus,
     refreshInstalledSkill: mockSkillsService.refreshInstalledSkill,
     renameSkillDir: mockSkillsService.renameSkillDir,
+    clearCache: mockSkillsService.clearCache,
   },
   isUpstreamManagedSkill: mockSkillsService.isUpstreamManagedSkill,
   isPublisherManagedSkill: mockSkillsService.isPublisherManagedSkill,
@@ -199,5 +201,55 @@ describe("refresh() concurrency guard and summary (#1289)", () => {
 
     // Two sequential calls should each execute
     expect(mockSkillsService.fetchAllSkills).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("clearCacheAndRefresh runs full sync (#1558)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("runs installed-skill sync, not just catalog refresh", async () => {
+    mockSkillsService.fetchAllSkills.mockResolvedValue([]);
+    mockSkillsService.listAllInstalled.mockResolvedValue([]);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.clearCacheAndRefresh();
+
+    expect(mockSkillsService.clearCache).toHaveBeenCalled();
+    expect(mockSkillsService.listAllInstalled).toHaveBeenCalled();
+  });
+});
+
+describe("backfill triggers for slug/dirName mismatch (#1558)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("triggers backfill when installed slug differs from marketplace slug but dirName matches", async () => {
+    const installedSkill = {
+      slug: "saas-short-trader",
+      dirName: "alpaca-saas-short-trader",
+      scope: "seren" as const,
+      source: "serenorg",
+      path: "/skills/alpaca-saas-short-trader/SKILL.md",
+      syncState: undefined,
+    };
+    const catalogEntry = {
+      slug: "alpaca-saas-short-trader",
+      source: "serenorg",
+      sourceUrl: "https://raw.githubusercontent.com/serenorg/seren-skills/main/alpaca/saas-short-trader/SKILL.md",
+    };
+
+    mockSkillsService.fetchAllSkills.mockResolvedValue([catalogEntry]);
+    mockSkillsService.listAllInstalled.mockResolvedValue([installedSkill]);
+    mockSkillsService.backfillSyncState.mockResolvedValue(1);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refresh();
+
+    expect(mockSkillsService.backfillSyncState).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause 1:** Thread sidebar refresh button called `clearCacheAndRefresh()` which only ran `refreshAvailable()` — catalog only. Changed it to call `refresh(true)` which runs the full pipeline: catalog fetch, installed-skill scan, backfill, and auto-refresh of stale upstream skills.
- **Root cause 2:** `backfillSyncState()` matched installed skills to marketplace entries by `skill.slug` only. When `resolveSkillSlug()` derives a different slug from SKILL.md frontmatter `name` (e.g. `saas-short-trader`) than the marketplace slug (`alpaca-saas-short-trader`), the lookup failed silently. Added fallback to `skill.dirName` which always matches the marketplace slug.
- Same `dirName` fallback added to the `needsBackfill` guard in `_refreshInner()`.

Closes #1558

## Test plan

- [x] All 345 existing tests pass (including skills-auto-sync suite)
- [x] New test: `clearCacheAndRefresh` calls `listAllInstalled` (proves full sync runs)
- [x] New test: backfill triggers when `slug !== catalog slug` but `dirName === catalog slug`
- [ ] Functional: click sidebar refresh, verify installed skill files update on disk

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com