### PR TITLE
fix(agent-store): stop persisting intermediate streaming flushes that pollute Codex history on restart

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3701,8 +3701,11 @@ Structured summary:`;
         ...msgs,
         contentMsg,
       ]);
-      if (session.conversationId)
-        persistAgentMessage(session.conversationId, contentMsg);
+      // Do NOT persist this intermediate flush — it captures partial streaming
+      // text (often raw file contents from tool results) that would pollute
+      // the restored conversation history on restart. Only
+      // finalizeStreamingContent (called at promptComplete) should persist
+      // assistant messages.
       setState("sessions", sessionId, "streamingContent", "");
       setState("sessions", sessionId, "streamingContentTimestamp", undefined);
     }

--- a/tests/unit/agent-history-persistence.test.ts
+++ b/tests/unit/agent-history-persistence.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Tests that only finalized assistant messages are persisted to SQLite.
+// ABOUTME: Prevents regression where intermediate tool-call flushes pollute restored history.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("agent message persistence guards", () => {
+  it("persistAgentMessage only stores user and assistant types", () => {
+    const fnStart = agentStoreSource.indexOf(
+      "function persistAgentMessage(",
+    );
+    const fnBody = agentStoreSource.slice(fnStart, fnStart + 300);
+    expect(fnBody).toContain(
+      'if (msg.type !== "user" && msg.type !== "assistant") return',
+    );
+  });
+
+  it("handleToolCall does NOT persist intermediate streaming flush", () => {
+    // The handleToolCall method flushes streamingContent into an assistant
+    // message for UI ordering, but must NOT persist it — these intermediate
+    // messages capture partial text (often file contents) that would pollute
+    // the restored conversation history on restart.
+    const toolCallHandler = agentStoreSource.slice(
+      agentStoreSource.indexOf("handleToolCall(sessionId: string, toolCall:"),
+    );
+    const handlerBody = toolCallHandler.slice(
+      0,
+      toolCallHandler.indexOf("handleToolResult("),
+    );
+
+    // Find the streaming content flush block within handleToolCall
+    const flushBlock = handlerBody.slice(
+      handlerBody.indexOf("if (session.streamingContent)"),
+      handlerBody.indexOf("// Skip duplicate if a message"),
+    );
+    expect(flushBlock.length).toBeGreaterThan(0);
+
+    // The flush block must NOT contain a persistAgentMessage call
+    expect(flushBlock).not.toContain("persistAgentMessage(");
+  });
+
+  it("finalizeStreamingContent DOES persist assistant messages", () => {
+    const finalizeHandler = agentStoreSource.slice(
+      agentStoreSource.indexOf("finalizeStreamingContent(sessionId: string)"),
+    );
+    const finalizeBody = finalizeHandler.slice(
+      0,
+      finalizeHandler.indexOf("handleToolCall(") > 0
+        ? finalizeHandler.indexOf("handleToolCall(")
+        : 2000,
+    );
+
+    // finalizeStreamingContent should persist — this is the real finalization
+    expect(finalizeBody).toContain("persistAgentMessage(");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1561

- Remove `persistAgentMessage` call from the intermediate streaming flush in `handleToolCall`. This flush captures partial assistant text (often raw file contents from tool results) that would pollute the restored conversation history on restart. Only `finalizeStreamingContent` (called at promptComplete) should persist assistant messages.

### Root cause

When a tool call arrived, `handleToolCall` flushed any buffered `streamingContent` as a `type: "assistant"` message and persisted it to SQLite. These intermediate messages were indistinguishable from real finalized responses in the DB. On restart, `loadPersistedAgentHistory` loaded all of them, and the user saw file dumps instead of their actual conversation.

## Test plan

- [x] New regression test `agent-history-persistence.test.ts` verifies the intermediate flush block does NOT contain `persistAgentMessage`
- [x] Test confirmed to FAIL against the unfixed source and PASS against the fix
- [x] Existing `agent-session-events` assertions verified against the fixed source
- [ ] Manual: open a Codex thread, have the agent read a file, close the app, reopen -- history should show conversational messages only

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
