### PR TITLE
fix(messaging): fix Telegram shutdown hang and clean unused imports

### DIFF
--- a/src-tauri/src/messaging/telegram.rs
+++ b/src-tauri/src/messaging/telegram.rs
@@ -8,7 +8,6 @@ use tokio::sync::Mutex;
 
 use teloxide::prelude::*;
 use teloxide::respond;
-use teloxide::types::{InlineKeyboardButton, InlineKeyboardMarkup, ParseMode};
 
 use crate::messaging::adapter::{AdapterConfig, MessagingAdapter};
 
@@ -57,7 +56,7 @@ impl MessagingAdapter for TelegramAdapter {
             }
         }
 
-        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         *self.shutdown_tx.lock().await = Some(shutdown_tx);
         self.running.store(true, Ordering::SeqCst);
 
@@ -109,15 +108,15 @@ impl MessagingAdapter for TelegramAdapter {
                 .enable_ctrlc_handler()
                 .build();
 
-            let token = dispatcher.shutdown_token();
+            let shutdown_token = dispatcher.shutdown_token();
 
-            tokio::select! {
-                _ = dispatcher.dispatch() => {},
-                _ = &mut shutdown_rx => {
-                    log::info!("[Telegram] Shutdown signal received");
-                    token.shutdown().expect("Failed to signal teloxide shutdown");
-                }
-            }
+            tokio::spawn(async move {
+                let _ = shutdown_rx.await;
+                log::info!("[Telegram] Shutdown signal received");
+                let _ = shutdown_token.shutdown();
+            });
+
+            dispatcher.dispatch().await;
 
             running_flag.store(false, Ordering::SeqCst);
             log::info!("[Telegram] Bot stopped");


### PR DESCRIPTION
## Summary

- Fix Telegram adapter shutdown hang: use a separate spawned task to receive the shutdown signal and call `shutdown_token.shutdown()`, instead of `tokio::select!` which raced with the long-polling cycle
- Remove unused imports (`InlineKeyboardButton`, `InlineKeyboardMarkup`, `ParseMode`) and unnecessary `mut`
- Found during functional testing with real bot token (`@serenainews_bot` connected successfully, but `stop()` hung indefinitely waiting for the long-poll timeout)

## Test plan

- [x] Verified bot connects to Telegram API: `[Test] Connected as @serenainews_bot`
- [x] `cargo check --features telegram` compiles clean (zero warnings)
- [x] All 345 existing tests pass

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
