### PR TITLE
feat(messaging): swap WhatsApp Business API for QR code pairing via whatsapp-rust (#1566)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash 0.5.1",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,7 +514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
 dependencies = [
  "android_log-sys",
- "env_filter",
+ "env_filter 0.1.4",
  "log",
 ]
 
@@ -718,6 +753,12 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -1025,6 +1066,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1393,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1410,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "combine"
@@ -1472,6 +1547,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
+ "indexmap 2.13.0",
  "log",
  "publicsuffix",
  "serde",
@@ -1530,6 +1606,12 @@ dependencies = [
  "core-foundation 0.10.1",
  "libc",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
 name = "cpufeatures"
@@ -1617,6 +1699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1740,51 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.114",
 ]
@@ -1851,7 +1987,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -2134,6 +2270,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "env_filter 1.0.1",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,6 +2415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +2460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2473,7 @@ checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2687,6 +2855,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.1",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,6 +3129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,6 +3236,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3359,6 +3564,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -3844,6 +4059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3922,6 +4143,12 @@ dependencies = [
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "native-tls"
@@ -4263,6 +4490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4475,6 +4708,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4488,6 +4731,17 @@ checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
 dependencies = [
  "memchr",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -4521,6 +4775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4538,6 +4801,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4568,6 +4841,16 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4620,6 +4903,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
 ]
@@ -4721,6 +5013,29 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -4910,6 +5225,55 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -5677,6 +6041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6015,6 +6380,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-untagged"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6213,6 +6587,8 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "wacore",
+ "whatsapp-rust",
 ]
 
 [[package]]
@@ -7560,6 +7936,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-websockets"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "httparse",
+ "rand 0.10.1",
+ "ring",
+ "rustls-pki-types",
+ "simdutf8",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7799,6 +8196,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7917,10 +8334,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.1",
+ "ctutils",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store 0.22.0",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -7964,6 +8432,12 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -8034,6 +8508,148 @@ dependencies = [
 ]
 
 [[package]]
+name = "wacore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5292fb723da7505e90cfd7a828dd397802b98e0f819a2bc058a6b3a9f2345306"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "anyhow",
+ "async-channel",
+ "async-lock",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "ctr",
+ "event-listener",
+ "flate2",
+ "futures",
+ "hex",
+ "hkdf",
+ "hmac",
+ "log",
+ "md5",
+ "once_cell",
+ "pbkdf2",
+ "prost",
+ "rand 0.10.1",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "thiserror 2.0.18",
+ "typed-builder",
+ "wacore-appstate",
+ "wacore-binary",
+ "wacore-derive",
+ "wacore-libsignal",
+ "wacore-noise",
+ "waproto",
+]
+
+[[package]]
+name = "wacore-appstate"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab29b1c5198e16e2619868cc3e48c32f0bcecec936fd20d09460a8f7e374604d"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "hex",
+ "hkdf",
+ "log",
+ "prost",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "wacore-binary",
+ "wacore-libsignal",
+ "waproto",
+]
+
+[[package]]
+name = "wacore-binary"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "127a3a6e7554ce002092f1711aa927b0efa3d3fb1ee83506525565c626e68834"
+dependencies = [
+ "flate2",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "wacore-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9546a14730f112eca3bc2e4cbd815df88046fa78530f110c3665492604e770"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "wacore-libsignal"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89676f7e09708d6b3a58e02bfea42000e3d7bffbc1bf67d0c8bf58ddbdf6373"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "arrayref",
+ "async-trait",
+ "cbc",
+ "chrono",
+ "ctr",
+ "curve25519-dalek",
+ "derive_more 2.1.1",
+ "displaydoc",
+ "ghash 0.6.0",
+ "hex",
+ "hkdf",
+ "hmac",
+ "log",
+ "prost",
+ "rand 0.10.1",
+ "serde",
+ "sha1",
+ "sha2",
+ "subtle",
+ "thiserror 2.0.18",
+ "uuid",
+ "waproto",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "wacore-noise"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1c5a0ef2ddaf0f7c5a227649c09de5f354571d95feea4dbac55f2b31c2da53"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "bytes",
+ "hkdf",
+ "log",
+ "prost",
+ "rand 0.10.1",
+ "sha2",
+ "thiserror 2.0.18",
+ "wacore-binary",
+ "wacore-libsignal",
+ "waproto",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8059,6 +8675,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "waproto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fb5d942027d97e5ca1e542a9915388742cc5efab4802910ecc2fd1f430cefe"
+dependencies = [
+ "prost",
+ "prost-build",
+ "serde",
 ]
 
 [[package]]
@@ -8335,6 +8962,72 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "whatsapp-rust"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b79e16847fe6e7ea8d103b4b575b1a1b77bd57cb4c292f7c50616b72a74374"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "async-lock",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "env_logger",
+ "event-listener",
+ "futures",
+ "hex",
+ "log",
+ "prost",
+ "rand 0.10.1",
+ "scopeguard",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "wacore",
+ "wacore-binary",
+ "waproto",
+ "whatsapp-rust-tokio-transport",
+ "whatsapp-rust-ureq-http-client",
+]
+
+[[package]]
+name = "whatsapp-rust-tokio-transport"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aca6e068f01d56f7d360a04aeb16d34a3edb623e7d43e7cd857682a186c0130"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "log",
+ "rustls 0.23.36",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-websockets",
+ "wacore",
+ "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "whatsapp-rust-ureq-http-client"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ae9349f172ab8e50031ef5c429bb56ffdd677fbfeb22ed09fff3ce3b62c135"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "tokio",
+ "ureq",
+ "wacore",
 ]
 
 [[package]]
@@ -9031,6 +9724,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9240,6 +9945,12 @@ dependencies = [
  "indexmap 2.13.0",
  "memchr",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,6 +78,8 @@ tokio-tungstenite = { version = "0.28" }
 # Messaging transport adapters (opt-in via cargo features)
 teloxide = { version = "0.14", features = ["macros"], optional = true }
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "model", "rustls_backend"], optional = true }
+whatsapp-rust = { version = "0.5", default-features = false, features = ["tokio-transport", "tokio-runtime", "ureq-client", "signal"], optional = true }
+wacore = { version = "0.5", default-features = false, optional = true }
 
 
 # Platform-specific dependencies
@@ -98,7 +100,7 @@ default = []
 messaging = []
 telegram = ["messaging", "dep:teloxide"]
 discord = ["messaging", "dep:serenity"]
-whatsapp = ["messaging"]
+whatsapp = ["messaging", "dep:whatsapp-rust", "dep:wacore"]
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -836,6 +836,7 @@ pub fn run() {
             messaging::commands::messaging_stop,
             messaging::commands::messaging_status,
             messaging::commands::messaging_status_all,
+            messaging::commands::messaging_whatsapp_qr,
             // Orchestrator commands
             commands::orchestrator::orchestrate,
             commands::orchestrator::cancel_orchestration,

--- a/src-tauri/src/messaging/adapter.rs
+++ b/src-tauri/src/messaging/adapter.rs
@@ -3,6 +3,7 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::any::Any;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolApprovalRequest {
@@ -22,6 +23,8 @@ pub trait MessagingAdapter: Send + Sync {
     fn is_running(&self) -> bool;
 
     fn bot_username(&self) -> Option<String>;
+
+    fn as_any(&self) -> &dyn Any;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/messaging/commands.rs
+++ b/src-tauri/src/messaging/commands.rs
@@ -89,3 +89,28 @@ pub async fn messaging_status_all(
 ) -> Result<Vec<PlatformStatus>, String> {
     Ok(state.status_all().await)
 }
+
+#[cfg(feature = "whatsapp")]
+#[tauri::command]
+pub async fn messaging_whatsapp_qr(
+    state: State<'_, MessagingState>,
+) -> Result<Option<String>, String> {
+    let adapter = state
+        .get("whatsapp")
+        .await
+        .ok_or("WhatsApp adapter not started")?;
+
+    let wa = adapter
+        .as_any()
+        .downcast_ref::<crate::messaging::whatsapp::WhatsAppAdapter>()
+        .ok_or("Failed to downcast WhatsApp adapter")?;
+
+    let rx = wa.subscribe_qr();
+    Ok(rx.borrow().clone())
+}
+
+#[cfg(not(feature = "whatsapp"))]
+#[tauri::command]
+pub async fn messaging_whatsapp_qr() -> Result<Option<String>, String> {
+    Err("WhatsApp feature not enabled".into())
+}

--- a/src-tauri/src/messaging/discord.rs
+++ b/src-tauri/src/messaging/discord.rs
@@ -174,4 +174,8 @@ impl MessagingAdapter for DiscordAdapter {
     fn bot_username(&self) -> Option<String> {
         self.bot_username.try_lock().ok()?.clone()
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/src-tauri/src/messaging/telegram.rs
+++ b/src-tauri/src/messaging/telegram.rs
@@ -148,4 +148,8 @@ impl MessagingAdapter for TelegramAdapter {
     fn bot_username(&self) -> Option<String> {
         self.bot_username.try_lock().ok()?.clone()
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/src-tauri/src/messaging/whatsapp.rs
+++ b/src-tauri/src/messaging/whatsapp.rs
@@ -1,78 +1,41 @@
-// ABOUTME: WhatsApp Business API adapter using reqwest for HTTP calls.
-// ABOUTME: Receives messages via webhook; sends responses via Cloud API.
+// ABOUTME: WhatsApp adapter using whatsapp-rust for QR code pairing via WhatsApp Web protocol.
+// ABOUTME: Scan a QR code from your phone to link — no Meta Business account needed.
 
 use async_trait::async_trait;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use crate::messaging::adapter::{AdapterConfig, MessagingAdapter};
+use wacore::store::in_memory::InMemoryBackend;
+use wacore::types::events::Event;
+use whatsapp_rust::bot::Bot;
+use whatsapp_rust::transport::{TokioWebSocketTransportFactory, UreqHttpClient};
+use whatsapp_rust::TokioRuntime;
 
-const WHATSAPP_API_BASE: &str = "https://graph.facebook.com/v21.0";
+use crate::messaging::adapter::{AdapterConfig, MessagingAdapter};
 
 pub struct WhatsAppAdapter {
     running: Arc<AtomicBool>,
-    phone_number_id: Mutex<Option<String>>,
-    access_token: Mutex<Option<String>>,
+    phone_display: Arc<Mutex<Option<String>>>,
     shutdown_tx: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
-    webhook_port: u16,
-    allowed_phone: Mutex<Option<String>>,
+    qr_tx: Arc<Mutex<Option<tokio::sync::watch::Sender<Option<String>>>>>,
+    qr_rx: tokio::sync::watch::Receiver<Option<String>>,
 }
 
 impl WhatsAppAdapter {
     pub fn new() -> Self {
+        let (qr_tx, qr_rx) = tokio::sync::watch::channel(None);
         Self {
             running: Arc::new(AtomicBool::new(false)),
-            phone_number_id: Mutex::new(None),
-            access_token: Mutex::new(None),
+            phone_display: Arc::new(Mutex::new(None)),
             shutdown_tx: Mutex::new(None),
-            webhook_port: 8788,
-            allowed_phone: Mutex::new(None),
+            qr_tx: Arc::new(Mutex::new(Some(qr_tx))),
+            qr_rx,
         }
     }
 
-    async fn send_text_message(
-        &self,
-        to: &str,
-        text: &str,
-    ) -> Result<(), String> {
-        let token = self
-            .access_token
-            .lock()
-            .await
-            .clone()
-            .ok_or("WhatsApp access token not set")?;
-        let phone_id = self
-            .phone_number_id
-            .lock()
-            .await
-            .clone()
-            .ok_or("WhatsApp phone number ID not set")?;
-
-        let url = format!("{WHATSAPP_API_BASE}/{phone_id}/messages");
-        let body = serde_json::json!({
-            "messaging_product": "whatsapp",
-            "to": to,
-            "type": "text",
-            "text": { "body": text }
-        });
-
-        let client = reqwest::Client::new();
-        let resp = client
-            .post(&url)
-            .bearer_auth(&token)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| format!("WhatsApp send failed: {e}"))?;
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            return Err(format!("WhatsApp API error {status}: {text}"));
-        }
-
-        Ok(())
+    pub fn subscribe_qr(&self) -> tokio::sync::watch::Receiver<Option<String>> {
+        self.qr_rx.clone()
     }
 }
 
@@ -87,56 +50,79 @@ impl MessagingAdapter for WhatsAppAdapter {
             return Err("WhatsApp adapter is already running".into());
         }
 
-        let phone_id = config
-            .phone_number_id
-            .ok_or("WhatsApp requires phone_number_id")?;
+        // In-memory backend: sessions don't persist across restarts.
+        // TODO: implement Backend trait with rusqlite for persistence (#1566)
+        let backend = Arc::new(InMemoryBackend::new());
 
-        *self.access_token.lock().await = Some(config.token.clone());
-        *self.phone_number_id.lock().await = Some(phone_id);
-        *self.allowed_phone.lock().await = config.allowed_user_id;
+        let qr_sender = self.qr_tx.clone();
+        let running_flag = self.running.clone();
+        let phone_display = self.phone_display.clone();
 
-        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         *self.shutdown_tx.lock().await = Some(shutdown_tx);
         self.running.store(true, Ordering::SeqCst);
 
-        let port = self.webhook_port;
-        let running_flag = self.running.clone();
-        let verify_token = config.token[..16.min(config.token.len())].to_string();
-
         tokio::spawn(async move {
-            let server = Arc::new(
-                tiny_http::Server::http(format!("0.0.0.0:{port}"))
-                    .expect("Failed to start WhatsApp webhook server"),
-            );
+            let qr_sender_event = qr_sender.clone();
 
-            log::info!("[WhatsApp] Webhook server listening on port {port}");
-
-            loop {
-                tokio::select! {
-                    _ = &mut shutdown_rx => {
-                        log::info!("[WhatsApp] Shutdown signal received");
-                        break;
-                    }
-                    _ = tokio::task::spawn_blocking({
-                        let server = Arc::clone(&server);
-                        move || {
-                            if let Ok(request) = server.recv_timeout(std::time::Duration::from_millis(500)) {
-                                if let Some(req) = request {
-                                    let response = tiny_http::Response::from_string("OK");
-                                    let _ = req.respond(response);
+            let bot_result = Bot::builder()
+                .with_backend(backend)
+                .with_transport_factory(TokioWebSocketTransportFactory::new())
+                .with_http_client(UreqHttpClient::new())
+                .with_runtime(TokioRuntime)
+                .on_event(move |event, _client| {
+                    let qr_tx = qr_sender_event.clone();
+                    let phone = phone_display.clone();
+                    async move {
+                        match event {
+                            Event::PairingQrCode { code, .. } => {
+                                log::info!("[WhatsApp] QR code received, waiting for scan...");
+                                if let Some(tx) = qr_tx.lock().await.as_ref() {
+                                    let _ = tx.send(Some(code));
                                 }
                             }
+                            Event::Connected(_) => {
+                                log::info!("[WhatsApp] Connected and authenticated");
+                                if let Some(tx) = qr_tx.lock().await.as_ref() {
+                                    let _ = tx.send(None);
+                                }
+                            }
+                            Event::Message(msg, info) => {
+                                let sender = format!("{}", info.source.sender);
+                                log::info!("[WhatsApp] Message from {sender}");
+                            }
+                            _ => {}
                         }
-                    }) => {}
-                }
+                    }
+                })
+                .build()
+                .await;
 
-                if !running_flag.load(Ordering::SeqCst) {
-                    break;
+            let mut bot = match bot_result {
+                Ok(b) => b,
+                Err(e) => {
+                    log::error!("[WhatsApp] Failed to build bot: {e}");
+                    running_flag.store(false, Ordering::SeqCst);
+                    return;
                 }
-            }
+            };
 
-            running_flag.store(false, Ordering::SeqCst);
-            log::info!("[WhatsApp] Adapter stopped");
+            let handle = match bot.run().await {
+                Ok(h) => h,
+                Err(e) => {
+                    log::error!("[WhatsApp] Failed to start bot: {e}");
+                    running_flag.store(false, Ordering::SeqCst);
+                    return;
+                }
+            };
+
+            log::info!("[WhatsApp] Bot running, waiting for QR scan or existing session...");
+
+            tokio::spawn(async move {
+                let _ = shutdown_rx.await;
+                log::info!("[WhatsApp] Shutdown signal received");
+                drop(handle);
+            });
         });
 
         log::info!("[WhatsApp] Adapter started");
@@ -153,8 +139,12 @@ impl MessagingAdapter for WhatsAppAdapter {
         }
 
         self.running.store(false, Ordering::SeqCst);
-        *self.access_token.lock().await = None;
-        *self.phone_number_id.lock().await = None;
+        *self.phone_display.lock().await = None;
+
+        if let Some(tx) = self.qr_tx.lock().await.as_ref() {
+            let _ = tx.send(None);
+        }
+
         log::info!("[WhatsApp] Adapter stop requested");
         Ok(())
     }
@@ -164,6 +154,10 @@ impl MessagingAdapter for WhatsAppAdapter {
     }
 
     fn bot_username(&self) -> Option<String> {
-        self.phone_number_id.try_lock().ok()?.clone()
+        self.phone_display.try_lock().ok()?.clone()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }

--- a/src/components/settings/MessagingSettings.tsx
+++ b/src/components/settings/MessagingSettings.tsx
@@ -1,7 +1,14 @@
 // ABOUTME: Settings panel for Telegram, Discord, and WhatsApp messaging transports.
-// ABOUTME: Each platform card has token input, start/stop toggle, and status display.
+// ABOUTME: Token input for Telegram/Discord; QR code pairing for WhatsApp.
 
-import { type Component, createSignal, For, onMount } from "solid-js";
+import {
+  type Component,
+  createSignal,
+  For,
+  Show,
+  onCleanup,
+  onMount,
+} from "solid-js";
 import { invoke } from "@tauri-apps/api/core";
 
 interface PlatformStatus {
@@ -17,7 +24,7 @@ interface PlatformConfig {
   placeholder: string;
   helpUrl: string;
   helpText: string;
-  hasPhoneField: boolean;
+  useQrPairing: boolean;
 }
 
 const PLATFORMS: PlatformConfig[] = [
@@ -28,7 +35,7 @@ const PLATFORMS: PlatformConfig[] = [
     placeholder: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
     helpUrl: "https://t.me/BotFather",
     helpText: "Get a token from @BotFather",
-    hasPhoneField: false,
+    useQrPairing: false,
   },
   {
     id: "discord",
@@ -37,16 +44,16 @@ const PLATFORMS: PlatformConfig[] = [
     placeholder: "MTI3ODk5Nzk...",
     helpUrl: "https://discord.com/developers/applications",
     helpText: "Create a bot at discord.dev",
-    hasPhoneField: false,
+    useQrPairing: false,
   },
   {
     id: "whatsapp",
     label: "WhatsApp",
-    tokenLabel: "Access Token",
-    placeholder: "EAAG...",
-    helpUrl: "https://developers.facebook.com/docs/whatsapp/cloud-api/get-started",
-    helpText: "Set up WhatsApp Business API",
-    hasPhoneField: true,
+    tokenLabel: "",
+    placeholder: "",
+    helpUrl: "",
+    helpText: "",
+    useQrPairing: true,
   },
 ];
 
@@ -55,9 +62,10 @@ export const MessagingSettings: Component = () => {
     {},
   );
   const [tokens, setTokens] = createSignal<Record<string, string>>({});
-  const [phoneIds, setPhoneIds] = createSignal<Record<string, string>>({});
   const [loading, setLoading] = createSignal<Record<string, boolean>>({});
   const [errors, setErrors] = createSignal<Record<string, string>>({});
+  const [whatsappQr, setWhatsappQr] = createSignal<string | null>(null);
+  let qrPollInterval: ReturnType<typeof setInterval> | undefined;
 
   const refreshStatuses = async () => {
     try {
@@ -72,25 +80,66 @@ export const MessagingSettings: Component = () => {
     }
   };
 
+  const pollWhatsAppQr = async () => {
+    try {
+      const qr: string | null = await invoke("messaging_whatsapp_qr");
+      setWhatsappQr(qr);
+      if (!qr && statuses().whatsapp?.running) {
+        stopQrPolling();
+      }
+    } catch {
+      // Not available or not started
+    }
+  };
+
+  const startQrPolling = () => {
+    stopQrPolling();
+    qrPollInterval = setInterval(() => void pollWhatsAppQr(), 2000);
+  };
+
+  const stopQrPolling = () => {
+    if (qrPollInterval) {
+      clearInterval(qrPollInterval);
+      qrPollInterval = undefined;
+    }
+  };
+
   onMount(() => {
     void refreshStatuses();
+  });
+
+  onCleanup(() => {
+    stopQrPolling();
   });
 
   const handleStart = async (platformId: string) => {
     setLoading((prev) => ({ ...prev, [platformId]: true }));
     setErrors((prev) => ({ ...prev, [platformId]: "" }));
     try {
-      const token = tokens()[platformId] || "";
-      if (!token.trim()) {
-        setErrors((prev) => ({ ...prev, [platformId]: "Token is required" }));
-        return;
+      if (platformId === "whatsapp") {
+        await invoke("messaging_start", {
+          platform: "whatsapp",
+          token: "qr-pairing",
+          allowedUserId: null,
+          phoneNumberId: null,
+        });
+        startQrPolling();
+      } else {
+        const token = tokens()[platformId] || "";
+        if (!token.trim()) {
+          setErrors((prev) => ({
+            ...prev,
+            [platformId]: "Token is required",
+          }));
+          return;
+        }
+        await invoke("messaging_start", {
+          platform: platformId,
+          token: token.trim(),
+          allowedUserId: null,
+          phoneNumberId: null,
+        });
       }
-      await invoke("messaging_start", {
-        platform: platformId,
-        token: token.trim(),
-        allowedUserId: null,
-        phoneNumberId: phoneIds()[platformId] || null,
-      });
       await refreshStatuses();
     } catch (err) {
       setErrors((prev) => ({
@@ -106,6 +155,10 @@ export const MessagingSettings: Component = () => {
     setLoading((prev) => ({ ...prev, [platformId]: true }));
     try {
       await invoke("messaging_stop", { platform: platformId });
+      if (platformId === "whatsapp") {
+        stopQrPolling();
+        setWhatsappQr(null);
+      }
       await refreshStatuses();
     } catch (err) {
       setErrors((prev) => ({
@@ -116,6 +169,9 @@ export const MessagingSettings: Component = () => {
       setLoading((prev) => ({ ...prev, [platformId]: false }));
     }
   };
+
+  const qrCodeUrl = (qrString: string) =>
+    `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(qrString)}`;
 
   return (
     <section>
@@ -137,19 +193,26 @@ export const MessagingSettings: Component = () => {
               <div class="rounded-lg border border-border bg-surface-2 p-4">
                 <div class="flex items-center justify-between mb-3">
                   <div class="flex items-center gap-2">
-                    <span class="font-medium text-sm">{platform.label}</span>
+                    <span class="font-medium text-sm">
+                      {platform.label}
+                      {platform.useQrPairing && (
+                        <span class="ml-1.5 text-[10px] px-1.5 py-0.5 rounded bg-yellow-600/20 text-yellow-400 font-normal">
+                          Beta
+                        </span>
+                      )}
+                    </span>
                     <span
                       class={`inline-block w-2 h-2 rounded-full ${
                         isRunning() ? "bg-green-500" : "bg-muted-foreground/30"
                       }`}
                     />
-                    {isRunning() && status()?.bot_username && (
+                    <Show when={isRunning() && status()?.bot_username}>
                       <span class="text-xs text-muted-foreground">
                         {platform.id === "whatsapp"
                           ? status()!.bot_username
                           : `@${status()!.bot_username}`}
                       </span>
-                    )}
+                    </Show>
                   </div>
                   <button
                     type="button"
@@ -169,11 +232,13 @@ export const MessagingSettings: Component = () => {
                       ? "..."
                       : isRunning()
                         ? "Stop"
-                        : "Start"}
+                        : platform.useQrPairing
+                          ? "Link Account"
+                          : "Start"}
                   </button>
                 </div>
 
-                {!isRunning() && (
+                <Show when={!isRunning() && !platform.useQrPairing}>
                   <div class="flex flex-col gap-2">
                     <label class="text-xs text-muted-foreground">
                       {platform.tokenLabel}
@@ -190,27 +255,6 @@ export const MessagingSettings: Component = () => {
                       }
                       class="w-full px-3 py-2 text-sm rounded-md border border-border bg-surface-1 text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-accent"
                     />
-
-                    {platform.hasPhoneField && (
-                      <>
-                        <label class="text-xs text-muted-foreground">
-                          Phone Number ID
-                        </label>
-                        <input
-                          type="text"
-                          placeholder="123456789012345"
-                          value={phoneIds()[platform.id] ?? ""}
-                          onInput={(e) =>
-                            setPhoneIds((prev) => ({
-                              ...prev,
-                              [platform.id]: e.currentTarget.value,
-                            }))
-                          }
-                          class="w-full px-3 py-2 text-sm rounded-md border border-border bg-surface-1 text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-accent"
-                        />
-                      </>
-                    )}
-
                     <a
                       href={platform.helpUrl}
                       target="_blank"
@@ -220,11 +264,41 @@ export const MessagingSettings: Component = () => {
                       {platform.helpText}
                     </a>
                   </div>
-                )}
+                </Show>
 
-                {error() && (
+                <Show when={!isRunning() && platform.useQrPairing}>
+                  <div class="flex flex-col gap-2 items-center">
+                    <Show
+                      when={whatsappQr()}
+                      fallback={
+                        <p class="text-xs text-muted-foreground text-center py-2">
+                          Click "Link Account" to generate a QR code.
+                          <br />
+                          Open WhatsApp on your phone &gt; Linked Devices &gt;
+                          Link a Device.
+                        </p>
+                      }
+                    >
+                      <p class="text-xs text-muted-foreground text-center">
+                        Scan this QR code with WhatsApp on your phone
+                      </p>
+                      <img
+                        src={qrCodeUrl(whatsappQr()!)}
+                        alt="WhatsApp QR Code"
+                        width={200}
+                        height={200}
+                        class="rounded-lg border border-border"
+                      />
+                      <p class="text-[10px] text-muted-foreground/60 text-center">
+                        QR code refreshes automatically
+                      </p>
+                    </Show>
+                  </div>
+                </Show>
+
+                <Show when={error()}>
                   <p class="mt-2 text-xs text-red-400">{error()}</p>
-                )}
+                </Show>
               </div>
             );
           }}


### PR DESCRIPTION
## Summary

- Replaces the WhatsApp Business Cloud API adapter (reqwest + webhook + Meta account) with QR code pairing via the `whatsapp-rust` crate (WhatsApp Web multi-device protocol)
- User clicks "Link Account" in Settings > Messaging > WhatsApp, scans a QR code with their phone, done. No Meta Business account, no webhook URL, no access token
- Uses `InMemoryBackend` from `wacore` for session storage (sessions don't persist across restarts yet; SQLite persistence tracked as follow-up in #1566)
- Frontend polls for QR code string via `messaging_whatsapp_qr` command, renders via QR code API
- WhatsApp card labeled "Beta" in the UI (unofficial protocol)
- Adds `as_any()` to `MessagingAdapter` trait for platform-specific downcasting (needed for QR subscription)

Closes #1566

## Test plan

- [x] `cargo check --no-default-features` compiles clean
- [x] `cargo check --features whatsapp` compiles clean (no nightly required)
- [x] All 348 existing tests pass
- [ ] Functional: enable WhatsApp, QR code renders, scan with phone, connection established

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
