### PR TITLE
fix(updater): add GitHub release latest.json as fallback endpoint (#1573)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -938,6 +938,108 @@ jobs:
             --content-type "application/json"
           echo "Uploaded latest.json to R2"
 
+      # Generate a GitHub-variant latest.json whose artifact URLs point at the
+      # GitHub release assets rather than R2. This is the fallback served when
+      # R2 is unreachable (e.g. ISP-level blocking of pub-*.r2.dev in Turkey).
+      # Signatures are content-based and identical to the R2 manifest.
+      - name: Generate latest.json for updater (GitHub)
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const tag = '${{ github.ref_name }}';
+            const version = tag.replace(/^v/, '');
+            const baseUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/${tag}`;
+
+            const platforms = [
+              'darwin-aarch64',
+              'darwin-x86_64',
+              'windows-x86_64',
+              'linux-x86_64',
+              'linux-aarch64'
+            ];
+
+            const manifest = {
+              version,
+              notes: `Release ${tag}`,
+              pub_date: new Date().toISOString(),
+              platforms: {}
+            };
+
+            for (const platform of platforms) {
+              const dir = path.join('artifacts', `update-${platform}`);
+              if (!fs.existsSync(dir)) {
+                console.log(`No update artifact for ${platform}, skipping`);
+                continue;
+              }
+
+              const files = fs.readdirSync(dir);
+              const sigFile = files.find((f) => f.endsWith('.sig'));
+              const bundleFile = files.find((f) => !f.endsWith('.sig'));
+
+              if (!sigFile || !bundleFile) {
+                console.log(`Missing sig or bundle for ${platform}: sig=${sigFile}, bundle=${bundleFile}`);
+                continue;
+              }
+
+              const signature = fs.readFileSync(path.join(dir, sigFile), 'utf8').trim();
+
+              manifest.platforms[platform] = {
+                signature,
+                url: `${baseUrl}/${bundleFile}`
+              };
+
+              console.log(`Added platform ${platform}: ${bundleFile}`);
+            }
+
+            fs.writeFileSync('artifacts/latest-github.json', JSON.stringify(manifest, null, 2));
+            console.log('Generated latest-github.json:', JSON.stringify(manifest, null, 2));
+
+      - name: Upload latest.json to GitHub release
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tagName = '${{ github.ref_name }}';
+
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner,
+              repo,
+              tag: tagName
+            });
+
+            const existingAssets = await github.rest.repos.listReleaseAssets({
+              owner,
+              repo,
+              release_id: release.id
+            });
+
+            const stale = existingAssets.data.find((a) => a.name === 'latest.json');
+            if (stale) {
+              console.log(`Deleting stale latest.json asset ${stale.id} on release ${release.id}`);
+              await github.rest.repos.deleteReleaseAsset({
+                owner,
+                repo,
+                asset_id: stale.id
+              });
+            }
+
+            const content = fs.readFileSync('artifacts/latest-github.json');
+            await github.rest.repos.uploadReleaseAsset({
+              owner,
+              repo,
+              release_id: release.id,
+              name: 'latest.json',
+              data: content
+            });
+
+            console.log(`Uploaded latest.json to GitHub release ${release.id} for tag ${tagName}`);
+
       - name: Upload installer files to R2
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,7 +36,8 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://pub-714fe894394345a0a8a102fbac2b208f.r2.dev/latest.json"
+        "https://pub-714fe894394345a0a8a102fbac2b208f.r2.dev/latest.json",
+        "https://github.com/serenorg/seren-desktop/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdGQTYwRTZBOEE0Mzg5QTcKUldTbmlVT0thZzZtZjhBS3d6L0dqY2lOVWlHSXRJNkFuRWlwSTVTM2hQSkdhVjBHRnh6UWw5a2gK",
       "dialog": false


### PR DESCRIPTION
## Summary

- Adds `https://github.com/serenorg/seren-desktop/releases/latest/download/latest.json` as a second Tauri updater endpoint in `tauri.conf.json`. R2 stays primary; GitHub acts as automatic fallback when R2 is unreachable.
- Extends `.github/workflows/release.yml` to generate a GitHub-variant `latest.json` (artifact URLs pointing at GitHub release downloads for the current tag) and upload it to the release as an asset named `latest.json`. Signatures are identical to the R2 manifest since they are content-based.

Closes #1573.

## Why

A user in Turkey reported "Update failed - Retry" persisting across restarts. Diagnostic browser test confirmed ISP-level TLS MITM of `pub-*.r2.dev`:

```
SSL_ERROR_RX_RECORD_TOO_LONG
An error occurred during a connection to pub-714fe894394345a0a8a102fbac2b208f.r2.dev.
```

This is targeted network-layer blocking (plain HTTP injected where TLS handshake should be), not latency or throttling. Cloudflare R2 custom domain is not a viable fix because `serendb.com` is on AWS Route 53 and Cloudflare Free/Pro won't accept subdomain-only zones (requires Business plan at $200/mo). Moving `serendb.com` to Cloudflare DNS would affect email/API/web and is out of scope.

GitHub's CDN (Fastly-backed) routes differently from Cloudflare and is unblocked in Turkey in practice.

## Scope notes

- Only affects users who install v3.13.1+. Existing users have the R2-only endpoint baked into their binary.
- The Turkey user needs a one-time manual install of v3.13.1 from the GitHub release page to pick up the new endpoint list. Future updates will then fall back automatically.
- Per CLAUDE.md, no new tests added — this is a config + CI workflow change, not business logic. Adding tests would just exercise JSON parsing / GitHub Actions execution (framework guarantees).

## Test plan

- [x] `python3 -m json.tool src-tauri/tauri.conf.json` — JSON valid
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — YAML valid
- [ ] Tag v3.13.1, watch CI — confirm `latest.json` appears as a release asset with GitHub URLs
- [ ] After merge, `pnpm tauri dev` on main — confirm app still starts and updater check still runs

## Follow-up (separate tickets)

- If GitHub fallback still fails in Turkey, migrate updater path off Cloudflare entirely (Bunny CDN / AWS CloudFront → S3).
- "Update failed - Retry" button re-runs `checkForUpdates()` rather than `installAvailableUpdate()`. Correct for the current case (check failures) but may confuse users on install failures.
