### PR TITLE
fix(agent-store): protect active session from idle-reclaim during compaction (#1575)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -638,9 +638,11 @@ function isRetryableClaudeInitError(message: string): boolean {
 }
 
 function getIdleClaudeSessionIds(excludeConversationId?: string): string[] {
+  const activeId = state.activeSessionId;
   return Object.entries(state.sessions)
-    .filter(([, session]) => {
+    .filter(([id, session]) => {
       if (session.info.agentType !== "claude-code") return false;
+      if (id === activeId) return false;
       if (
         excludeConversationId &&
         session.conversationId === excludeConversationId


### PR DESCRIPTION
## Summary

- Adds a one-line guard to `getIdleClaudeSessionIds()` that excludes `state.activeSessionId` from the reclaimable set. The session the user is currently viewing is never killed during compaction, regardless of prompt status.

Closes #1575.

## Why

When two Claude Code sessions run concurrently and one triggers auto-compaction, `spawnSession` calls `getIdleClaudeSessionIds()` to find sessions to kill. The function excluded only the session being spawned — not the session the user was actively viewing. A session in `"ready"` status (between prompts) was treated as "idle" and SIGTERM'd, destroying the user's active conversation.

Observed: user chatting in session A. Background session B compacts, kills session A. User's chat disappears. `selectThread` finds no session for their thread. Fresh spawn — "Seren Swarm skill loaded" — blank slate. All context lost.

## Test plan

- [x] `pnpm biome check src/stores/agent.store.ts` — clean (0 errors, 1 pre-existing warning)
- [x] `pnpm test` — 336 passed across 39 files, no regressions
- [ ] `pnpm tauri dev` — app starts, verify concurrent sessions don't kill each other
