### PR TITLE
fix(claude-agent): default to Opus 4.5, add Opus 4.5/4.6 options in model picker (#1577)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -385,6 +385,36 @@ function normalizeModelRecords(result) {
     .filter((record) => typeof record.modelId === "string");
 }
 
+// Anthropic still accepts older Opus tiers on the API, but Claude Code's
+// curated model list drops them when a new Opus ships. We expose them here
+// so users who want the lower-cost Opus tiers can pick them from the picker.
+// Each entry is prepended only if the CLI hasn't already reported the same
+// modelId, so this is a no-op the day Claude Code adds them back natively.
+const LEGACY_OPUS_RECORDS = [
+  {
+    modelId: "claude-opus-4-5",
+    name: "Opus 4.5",
+    description: "Previous Opus generation — lower cost than 4.7",
+    supportsEffort: false,
+    supportedEffortLevels: [],
+    isDefault: false,
+  },
+  {
+    modelId: "claude-opus-4-6",
+    name: "Opus 4.6",
+    description: "Opus 4.6 — mid-tier Opus",
+    supportsEffort: false,
+    supportedEffortLevels: [],
+    isDefault: false,
+  },
+];
+
+function augmentWithLegacyOpus(records) {
+  const existingIds = new Set(records.map((r) => r.modelId));
+  const extras = LEGACY_OPUS_RECORDS.filter((r) => !existingIds.has(r.modelId));
+  return [...extras, ...records];
+}
+
 function inferCurrentModelId(currentModel, records) {
   if (!currentModel || records.length === 0) {
     return records[0]?.modelId ?? null;
@@ -1406,7 +1436,11 @@ export function createClaudeRuntime({ emit }) {
       sessionId: remoteSessionId,
       resumeSessionId: resumeAgentSessionId ?? null,
       forkSession: false,
-      preferredModel: null,
+      // Default new sessions to Opus 4.5 — lowest-cost Opus tier still on the
+      // Anthropic API. Claude Code's own "Default (recommended)" rolls forward
+      // to the newest Opus (currently 4.7) which is the most expensive option.
+      // Users can switch via the picker; resumed sessions use session.currentModelId.
+      preferredModel: "claude-opus-4-5",
       mcpConfigJson: mcpConfig.claudeMcpConfigJson,
     });
     const processHandle = spawn(
@@ -1473,7 +1507,9 @@ export function createClaudeRuntime({ emit }) {
         20_000,
       );
 
-      session.availableModelRecords = normalizeModelRecords(initResult);
+      session.availableModelRecords = augmentWithLegacyOpus(
+        normalizeModelRecords(initResult),
+      );
       session.currentModelId =
         inferCurrentModelId(
           initResult?.model ?? null,
@@ -1811,7 +1847,9 @@ export function createClaudeRuntime({ emit }) {
         20_000,
       );
 
-      tempSession.availableModelRecords = normalizeModelRecords(initResult);
+      tempSession.availableModelRecords = augmentWithLegacyOpus(
+        normalizeModelRecords(initResult),
+      );
       tempSession.currentModelId =
         inferCurrentModelId(
           initResult?.model ?? null,


### PR DESCRIPTION
## Summary

- Defaults new Claude Code agent spawns to `claude-opus-4-5` (the lowest-cost Opus tier still on the Anthropic API) instead of the CLI's auto-rolling "Default (recommended)" — which currently points at Opus 4.7 with 1M context, the most expensive option.
- Injects **Opus 4.5** and **Opus 4.6** entries into `availableModelRecords` so they show up in the picker and pass `set_model` validation. Existing CLI options (Opus 4.7, Sonnet 4.6, Sonnet 4.6 1M, Haiku 4.5) stay visible and selectable.

Closes #1577.

## Dropdown after change

- **Opus 4.5** *(default, selected on new sessions)*
- **Opus 4.6**
- Default (recommended) — Opus 4.7 with 1M context
- Sonnet — Sonnet 4.6
- Sonnet (1M context) — Sonnet 4.6 · Billed as extra
- Haiku — Haiku 4.5

## Verification (pre-PR)

Model IDs accepted by the Claude Code CLI:
```
$ echo "say OK" | claude --print --model claude-opus-4-5   → OK
$ echo "say OK" | claude --print --model claude-opus-4-6   → OK
$ echo "say OK" | claude --print --model claude-sonnet-4-6 → OK
```

Code health:
- `node --check bin/browser-local/claude-runtime.mjs` — syntax OK
- `pnpm build:provider-runtime` — bundle built, contains new code (6 ref matches)
- Inline test of `augmentWithLegacyOpus`: no-dup, partial-dup, and full-dup cases all correct
- `pnpm test` — 336 passed, 0 failed, no regressions

## Test plan

- [x] Pre-PR verifications above
- [ ] CI: lint, test-frontend, test-rust, E2E, 3 platform builds all pass
- [ ] After merge, `pnpm tauri dev` on main — new Claude Code session shows Opus 4.5 selected, Opus 4.6 in list, all existing options still present and selectable

## Scope / non-goals

- **Additive only.** Existing sessions with a saved `currentModelId` keep their model. Only new Claude Code spawns pick up the new default.
- **No new vitest added.** Per CLAUDE.md, TDD is reserved for security/billing/core logic. The augmentation helper is a pure prepend-if-absent verified inline. A vitest on it would duplicate that check without exercising the real CLI integration surface, which `tauri dev` verifies end-to-end.

## Risk

Opus 4.5/4.6 are not in the CLI's curated list. If Anthropic deprecates them on the API side, `set_model` succeeds locally (we validate against our list) but the next API call fails cleanly. Accepted per the brief: "users get Opus lower versions because they need it and will be able to head to 4.7 or Sonnet when your bosses remove those options via support."
