### PR TITLE
fix(orchestrator): bogus parallel split, Windows exec paths, date drift, auth bypass

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -355,7 +355,20 @@ impl ChatModelWorker {
         // The tool inventory ensures the model knows about ALL connected services,
         // not just the skills matched by the classifier.
         let tool_inventory = Self::build_tool_inventory(tools);
+        // Pin the current UTC date as the very first line of the system prompt
+        // so document-generation tasks (invoices, reports) stamp a correct date
+        // even when history has been trimmed by RLM. The system prompt itself
+        // is never trimmed, so this context cannot be dropped.
+        let today_utc = seren_memory_sdk::chrono::Utc::now()
+            .format("%Y-%m-%d")
+            .to_string();
         let mut system_parts = vec![
+            format!(
+                "Current date (UTC): {}. Use this date for any timestamp, \
+                 invoice date, report date, or other dated artifact unless \
+                 the user explicitly supplies a different date.",
+                today_utc
+            ),
             "You are a helpful AI assistant running inside Seren Desktop. \
              The user is already authenticated and all tool calls are pre-authenticated \
              through the Seren Gateway — you do not need API keys, tokens, or environment \
@@ -2396,6 +2409,41 @@ mod tests {
         assert!(
             system_msg.contains("SEREN_API_KEY"),
             "system prompt must explicitly mention SEREN_API_KEY so model never asks for it"
+        );
+    }
+
+    #[test]
+    fn system_prompt_pins_current_utc_date() {
+        // Regression for #1579: document-generation tasks (invoices, reports)
+        // must stamp the real current date even when RLM has trimmed history.
+        // The system prompt is never trimmed, so we pin a formatted UTC date
+        // at the top. We assert the format and today's year are present —
+        // enough to catch accidental removal without being flaky at day rollover.
+        let worker = ChatModelWorker::new();
+        let routing = RoutingDecision {
+            worker_type: super::super::types::WorkerType::ChatModel,
+            model_id: "anthropic/claude-sonnet-4".to_string(),
+            delegation: super::super::types::DelegationType::InLoop,
+            reason: "General chat".to_string(),
+            selected_skills: vec![],
+            publisher_slug: None,
+            reasoning_effort: None,
+            project_root: None,
+        };
+
+        let body = worker.build_request_body("Hi", &[], &routing, "", &[], &[], None);
+        let system_msg = body["messages"][0]["content"].as_str().unwrap();
+
+        let current_year = seren_memory_sdk::chrono::Utc::now()
+            .format("%Y")
+            .to_string();
+        assert!(
+            system_msg.contains("Current date (UTC):"),
+            "system prompt must pin a current-date line"
+        );
+        assert!(
+            system_msg.contains(&current_year),
+            "system prompt must include the current year so stamped dates are fresh"
         );
     }
 }

--- a/src-tauri/src/orchestrator/decomposer.rs
+++ b/src-tauri/src/orchestrator/decomposer.rs
@@ -199,18 +199,22 @@ fn try_sequential_conjunction(prompt: &str, skills: &[SkillRef]) -> Option<Vec<S
 
 /// Detect parallel conjunctions: "Scrape A and also scrape B", "Do X and do Y".
 ///
-/// Only triggers when:
-/// - "and also" appears
-/// - "and" appears between what look like independent clauses (both sides have verbs)
+/// Both "and also" and bare "and" require the second side to look like an
+/// independent clause (starts with a clause-starter verb). Without that gate,
+/// parenthetical "and also refer to..." style continuations inside a single
+/// instruction get incorrectly split into two parallel workers, which
+/// duplicates side effects (file writes, folder creation) and doubles cost.
 fn try_parallel_conjunction(prompt: &str, skills: &[SkillRef]) -> Option<Vec<SubTask>> {
     let lower = prompt.to_lowercase();
 
-    // "and also" is a strong parallel signal
+    // "and also" is a strong parallel signal, but still require the second
+    // side to look like an imperative clause — otherwise "refer to X",
+    // "include Y", "note that Z" style continuations get wrongly split.
     if let Some(pos) = lower.find(" and also ") {
         let first = prompt[..pos].trim();
         let second = prompt[pos + " and also ".len()..].trim();
 
-        if !first.is_empty() && !second.is_empty() {
+        if !first.is_empty() && !second.is_empty() && looks_like_clause(second) {
             return Some(vec![
                 SubTask {
                     id: Uuid::new_v4().to_string(),
@@ -594,6 +598,24 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].prompt, "Research AI and ML trends");
+    }
+
+    #[test]
+    fn and_also_without_clause_does_not_split() {
+        // Regression for #1579: a single document-generation prompt containing
+        // a descriptive "and also <non-imperative>" continuation must stay one
+        // subtask. The original bug duplicated file writes and doubled cost.
+        let classification = make_classification();
+        let prompt = "Create an invoice report for my first sale. \
+                      Here are details below, and also refer to my attached Contract \
+                      for further details.";
+        let result = decompose(prompt, &classification, &[]);
+
+        assert_eq!(
+            result.len(),
+            1,
+            "prompt with descriptive 'and also refer to...' must not split"
+        );
     }
 
     // =========================================================================

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -9,6 +9,16 @@ const MAX_OUTPUT_BYTES: usize = 50_000;
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const MAX_TIMEOUT_SECS: u64 = 300;
 
+/// Wrap a shell command string in outer double quotes so that `cmd.exe /S /C`
+/// strips them verbatim. This keeps any inner quotes (e.g. around absolute
+/// paths with spaces) intact instead of letting cmd.exe's default /C quote
+/// rule mis-parse them as cwd-relative — the classic
+/// `python: can't open file 'C:\cwd\"C:\abs\path.py"'` failure on Windows.
+#[cfg(any(target_os = "windows", test))]
+fn wrap_for_cmd_slash_s(command: &str) -> String {
+    format!("\"{}\"", command)
+}
+
 #[derive(Debug, Serialize)]
 pub struct CommandResult {
     pub stdout: String,
@@ -31,20 +41,30 @@ pub async fn execute_shell_command(
         .min(MAX_TIMEOUT_SECS);
     let timeout = Duration::from_secs(secs);
 
-    let mut cmd = if cfg!(target_os = "windows") {
-        let mut c = Command::new("cmd");
-        c.args(["/c", &command]);
-        c
+    let mut cmd = Command::new(if cfg!(target_os = "windows") {
+        "cmd"
     } else {
-        let mut c = Command::new("/bin/sh");
-        c.args(["-c", &command]);
-        c
-    };
+        "/bin/sh"
+    });
 
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;
+        // /D disables AutoRun, /S forces cmd.exe to strip exactly one pair
+        // of outer quotes from the /C string (overriding its complex default
+        // rule). We then wrap the command in those outer quotes ourselves
+        // via raw_arg so any inner quotes around absolute paths survive.
+        cmd.as_std_mut()
+            .raw_arg("/D")
+            .raw_arg("/S")
+            .raw_arg("/C")
+            .raw_arg(wrap_for_cmd_slash_s(&command));
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        cmd.args(["-c", &command]);
     }
 
     // Prepend embedded runtime to PATH so shell commands can find bundled Node/Git
@@ -182,5 +202,24 @@ fn truncate_output(s: String) -> String {
             &s[..MAX_OUTPUT_BYTES],
             s.len()
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_for_cmd_slash_s_preserves_inner_quotes() {
+        // Regression for #1579: wrapping the command in an extra outer pair
+        // of quotes is what lets `cmd.exe /D /S /C` strip exactly that pair,
+        // so any inner quotes around absolute paths survive untouched. The
+        // function itself is platform-independent; we exercise it on every
+        // target so CI catches breakage without needing Windows.
+        let cmd = r#"python "C:\Users\test\script.py""#;
+        let wrapped = wrap_for_cmd_slash_s(cmd);
+        assert!(wrapped.starts_with('"'));
+        assert!(wrapped.ends_with('"'));
+        assert!(wrapped.contains(r#""C:\Users\test\script.py""#));
     }
 }

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -729,6 +729,20 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     const conversationId = conversationStore.activeConversationId;
     if (!conversationId) return;
 
+    // Defensive auth gate: matches sendMessage()'s gate but also covers the
+    // skill-invocation branch and queue-drain path that bypass it. Without
+    // this, a session-expired state can still start an orchestrator turn
+    // with no access token and no publishers, producing silent "no file
+    // found" failures while the user believes the turn is running normally.
+    if (
+      (providerStore.activeProvider === "seren" ||
+        providerStore.activeProvider === "seren-private") &&
+      !authStore.isAuthenticated
+    ) {
+      setShowSignInPrompt(true);
+      return;
+    }
+
     const userMessage: UnifiedMessage = {
       id: crypto.randomUUID(),
       type: "user",


### PR DESCRIPTION
## Summary

Fixes #1579. Four tight defects surfaced by a single real user invoice-generation failure:

- **D1 — decomposer false-positive split.** `" and also "` now requires the second side to look like an imperative clause, so a single document-generation prompt with a descriptive continuation (`"...and also refer to my attached Contract..."`) stays one subtask. No more duplicate directory/file creation, no more ~2x cost from parallel workers racing on the same artifact.
- **D2 — Windows `execute_command` malformed paths.** Switch `cmd.exe` invocation to `/D /S /C` with the command pre-wrapped in a raw outer quote pair (via `raw_arg`). `cmd.exe /S` always strips exactly that pair, so inner quotes around absolute paths survive untouched. Ends the `python: can't open file 'C:\cwd\"C:\abs\path.py"'` failures on Windows.
- **D3 — current-date drift after RLM trim.** Pin the current UTC date as the very first line of the system prompt. The system prompt is never trimmed by RLM, so document-generation tasks (invoices, reports) now always have a real date to stamp, even when long history forces trimming.
- **D4 — auth gate bypass.** `sendMessageImmediate` now also runs the seren-provider auth gate. The existing gate in `sendMessage` was skipped by the skill-invocation branch and by queue drains, letting orchestrator turns start with no access token, no publishers, and silent "no file found" failures.

## Test plan

- [x] `cargo test --lib` — 325 passed, 0 failed (including three new regression tests: `and_also_without_clause_does_not_split`, `wrap_for_cmd_slash_s_preserves_inner_quotes`, `system_prompt_pins_current_utc_date`)
- [x] `pnpm test` — 336 passed, 0 failed
- [x] `pnpm check src/components/chat/ChatContent.tsx` — clean
- [ ] Manual functional: run the invoice prompt that triggered #1579 and verify (a) single `Decomposed into 1 subtask(s)`, (b) correct date on the generated PDF, (c) no stray `check_deps.py`, (d) no duplicate `create_directory` calls

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com