### PR TITLE
fix: tilde paths, PDF orphans, dev-watch cascade (#1583, #1584, #1585)

### DIFF
--- a/src-tauri/src/files.rs
+++ b/src-tauri/src/files.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
+use crate::path_util::expand_tilde;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FileEntry {
     pub name: String,
@@ -16,52 +18,53 @@ pub struct FileEntry {
 /// Read the contents of a file.
 #[tauri::command]
 pub fn read_file(path: String) -> Result<String, String> {
-    let file_path = Path::new(&path);
+    let resolved = expand_tilde(&path)?;
 
     // Check if path is a directory before attempting to read
-    if file_path.is_dir() {
+    if resolved.is_dir() {
         return Err(format!(
             "Cannot read directory '{}'. Directories cannot be read as files. Use the list_directory tool instead to see the contents of this directory.",
             path
         ));
     }
 
-    fs::read_to_string(&path).map_err(|e| format!("Failed to read file: {}", e))
+    fs::read_to_string(&resolved).map_err(|e| format!("Failed to read file: {}", e))
 }
 
 /// Read a file and return its contents as base64.
 #[tauri::command]
 pub fn read_file_base64(path: String) -> Result<String, String> {
-    let file_path = Path::new(&path);
+    let resolved = expand_tilde(&path)?;
 
-    // Check if path is a directory before attempting to read
-    if file_path.is_dir() {
+    if resolved.is_dir() {
         return Err(format!(
             "Cannot read directory '{}'. Directories cannot be read as files. Use the list_directory tool instead.",
             path
         ));
     }
 
-    let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let bytes = fs::read(&resolved).map_err(|e| format!("Failed to read file: {}", e))?;
     Ok(STANDARD.encode(&bytes))
 }
 
 /// Write content to a file.
 #[tauri::command]
 pub fn write_file(path: String, content: String) -> Result<(), String> {
-    fs::write(&path, content).map_err(|e| format!("Failed to write file: {}", e))
+    let resolved = expand_tilde(&path)?;
+    reject_literal_tilde_segment(&resolved)?;
+    fs::write(&resolved, content).map_err(|e| format!("Failed to write file: {}", e))
 }
 
 /// List entries in a directory.
 #[tauri::command]
 pub fn list_directory(path: String) -> Result<Vec<FileEntry>, String> {
-    let dir_path = Path::new(&path);
+    let resolved = expand_tilde(&path)?;
 
-    if !dir_path.is_dir() {
+    if !resolved.is_dir() {
         return Err(format!("Path is not a directory: {}", path));
     }
 
-    let mut entries: Vec<FileEntry> = fs::read_dir(dir_path)
+    let mut entries: Vec<FileEntry> = fs::read_dir(&resolved)
         .map_err(|e| format!("Failed to read directory: {}", e))?
         .filter_map(|entry| {
             let entry = entry.ok()?;
@@ -89,58 +92,150 @@ pub fn list_directory(path: String) -> Result<Vec<FileEntry>, String> {
 /// Check if a path exists.
 #[tauri::command]
 pub fn path_exists(path: String) -> bool {
-    Path::new(&path).exists()
+    expand_tilde(&path).map(|p| p.exists()).unwrap_or(false)
 }
 
 /// Check if a path is a directory.
 #[tauri::command]
 pub fn is_directory(path: String) -> bool {
-    Path::new(&path).is_dir()
+    expand_tilde(&path).map(|p| p.is_dir()).unwrap_or(false)
 }
 
 /// Create a new file with optional content.
 #[tauri::command]
 pub fn create_file(path: String, content: Option<String>) -> Result<(), String> {
-    let file_path = Path::new(&path);
+    let resolved = expand_tilde(&path)?;
+    reject_literal_tilde_segment(&resolved)?;
 
     // Create parent directories if they don't exist
-    if let Some(parent) = file_path.parent() {
+    if let Some(parent) = resolved.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("Failed to create directories: {}", e))?;
     }
 
     let content = content.unwrap_or_default();
-    fs::write(&path, content).map_err(|e| format!("Failed to create file: {}", e))
+    fs::write(&resolved, content).map_err(|e| format!("Failed to create file: {}", e))
 }
 
 /// Create a new directory.
 #[tauri::command]
 pub fn create_directory(path: String) -> Result<(), String> {
-    fs::create_dir_all(&path).map_err(|e| format!("Failed to create directory: {}", e))
+    let resolved = expand_tilde(&path)?;
+    reject_literal_tilde_segment(&resolved)?;
+    fs::create_dir_all(&resolved).map_err(|e| format!("Failed to create directory: {}", e))
 }
 
 /// Delete a file or empty directory.
 #[tauri::command]
 pub fn delete_path(path: String) -> Result<(), String> {
-    let file_path = Path::new(&path);
+    let resolved = expand_tilde(&path)?;
 
-    if file_path.is_dir() {
-        fs::remove_dir(&path).map_err(|e| format!("Failed to delete directory: {}", e))
+    if resolved.is_dir() {
+        fs::remove_dir(&resolved).map_err(|e| format!("Failed to delete directory: {}", e))
     } else {
-        fs::remove_file(&path).map_err(|e| format!("Failed to delete file: {}", e))
+        fs::remove_file(&resolved).map_err(|e| format!("Failed to delete file: {}", e))
     }
 }
 
 /// Rename/move a file or directory.
 #[tauri::command]
 pub fn rename_path(old_path: String, new_path: String) -> Result<(), String> {
-    fs::rename(&old_path, &new_path).map_err(|e| format!("Failed to rename: {}", e))
+    let resolved_old = expand_tilde(&old_path)?;
+    let resolved_new = expand_tilde(&new_path)?;
+    reject_literal_tilde_segment(&resolved_new)?;
+    fs::rename(&resolved_old, &resolved_new).map_err(|e| format!("Failed to rename: {}", e))
 }
 
 /// Reveal a file or directory in the system file manager (Finder on macOS).
 #[tauri::command]
 pub fn reveal_in_file_manager(app: tauri::AppHandle, path: String) -> Result<(), String> {
     use tauri_plugin_opener::OpenerExt;
+    let resolved = expand_tilde(&path)?;
     app.opener()
-        .reveal_item_in_dir(std::path::Path::new(&path))
+        .reveal_item_in_dir(&resolved)
         .map_err(|e| format!("Failed to reveal in file manager: {}", e))
+}
+
+/// Defence-in-depth guard (GH #1584): reject writes whose resolved path
+/// still contains a literal `~` segment. Before GH #1583 landed, an
+/// unexpanded `~/foo` would fall back to `Path::new("~/foo")` and resolve
+/// relative to the dev-command cwd (`src-tauri/`), producing a
+/// `src-tauri/~/...` tree that tripped Tauri dev's file watcher mid-task.
+/// Even with tilde expansion in place, this catches any future regression
+/// before it can silently restart the dev process during a user task.
+///
+/// Only active in debug/dev builds: in production the resolved path cannot
+/// land inside a Rust source tree on the user's machine, and this guard
+/// would be a false positive on any legitimate file that happens to contain
+/// a `~` component in its path.
+#[cfg(debug_assertions)]
+fn reject_literal_tilde_segment(path: &Path) -> Result<(), String> {
+    if path.components().any(|c| c.as_os_str() == "~") {
+        return Err(format!(
+            "Refusing write to '{}': path contains a literal '~' segment. \
+             This means tilde expansion was skipped upstream. Use an absolute \
+             path or a path starting with '~/' (which will be expanded to your \
+             home directory).",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(debug_assertions))]
+fn reject_literal_tilde_segment(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    /// End-to-end guarantee (GH #1583): `write_file("~/…")` must land under
+    /// `$HOME/…`, NOT under `<cwd>/~/…`. This is the exact failure mode that
+    /// hit the Ishan invoice prompt.
+    #[test]
+    fn write_file_expands_tilde_to_home() {
+        let home = dirs::home_dir().expect("home dir required for test");
+        let unique = format!(".serendesktop-test-{}", Uuid::new_v4());
+        let dir_rel = format!("~/{}", unique);
+        let file_rel = format!("~/{}/hello.txt", unique);
+
+        create_directory(dir_rel.clone()).expect("create_directory");
+        write_file(file_rel.clone(), "hi".to_string()).expect("write_file");
+
+        let expected = home.join(&unique).join("hello.txt");
+        assert!(
+            expected.exists(),
+            "file should exist at {}",
+            expected.display()
+        );
+        assert_eq!(std::fs::read_to_string(&expected).unwrap(), "hi");
+
+        // Must NOT have leaked into <cwd>/~/<unique>/hello.txt (the old bug).
+        let cwd = std::env::current_dir().expect("cwd");
+        let broken = cwd.join("~").join(&unique).join("hello.txt");
+        assert!(
+            !broken.exists(),
+            "file leaked into cwd/~/ at {}",
+            broken.display()
+        );
+
+        let _ = std::fs::remove_dir_all(home.join(&unique));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn reject_literal_tilde_segment_catches_unexpanded_paths() {
+        // In debug builds, any unexpanded `~` segment in the resolved path
+        // must be rejected before IO (GH #1584 defence-in-depth).
+        let sneaky = Path::new("~").join("Downloads").join("bar.txt");
+        assert!(reject_literal_tilde_segment(&sneaky).is_err());
+
+        // Normal absolute paths pass through fine.
+        assert!(reject_literal_tilde_segment(Path::new("/tmp/fine.txt")).is_ok());
+
+        // Tilde embedded inside a filename (no standalone `~` component) is fine.
+        assert!(reject_literal_tilde_segment(Path::new("/tmp/~foo.txt")).is_ok());
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,8 @@ pub mod messaging;
 mod oauth;
 mod oauth_callback_server;
 mod orchestrator;
+mod path_util;
+mod pdf;
 mod polymarket;
 mod provider_runtime;
 mod shell;

--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -269,8 +269,60 @@ impl ChatModelWorker {
             cancelled: Arc::new(Mutex::new(false)),
             publisher_slug: publisher_slug
                 .unwrap_or_else(|| DEFAULT_PUBLISHER_SLUG.to_string()),
-            tool_definitions: tools,
+            tool_definitions: Self::inject_local_tool_definitions(tools),
         }
+    }
+
+    /// Prepend tool definitions for local builtins that the frontend catalog
+    /// does not ship. Today that's just `write_pdf_from_html` (GH #1585) —
+    /// a native atomic HTML→PDF renderer that replaces the previous
+    /// "write HTML intermediate, then shell-out to convert" pattern and its
+    /// orphan-file failure mode.
+    ///
+    /// Definitions are pushed to the front so they are visible to tool-
+    /// relevance ranking even when the gateway catalog is full.
+    fn inject_local_tool_definitions(
+        existing: Vec<serde_json::Value>,
+    ) -> Vec<serde_json::Value> {
+        let write_pdf = serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "write_pdf_from_html",
+                "description": "Render the given HTML as a PDF and write it atomically to `path`. \
+Prefer this tool over `write_file` + a separate conversion step whenever the \
+user asks for PDF output — it uses one tool round, leaves no HTML intermediate \
+on disk, and fails cleanly if conversion is not possible. `path` may start \
+with `~/` to refer to the user's home directory. Parent directories are \
+created if missing.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Absolute or ~/-relative output path ending in .pdf, e.g. '~/Downloads/invoice.pdf'."
+                        },
+                        "html": {
+                            "type": "string",
+                            "description": "Complete, self-contained HTML document (should begin with <!DOCTYPE html>). Inline all CSS; external assets are not fetched."
+                        }
+                    },
+                    "required": ["path", "html"]
+                }
+            }
+        });
+        let mut out = Vec::with_capacity(existing.len() + 1);
+        // Only inject if the catalog doesn't already define it (avoid dup).
+        let already_present = existing.iter().any(|t| {
+            t.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                == Some("write_pdf_from_html")
+        });
+        if !already_present {
+            out.push(write_pdf);
+        }
+        out.extend(existing);
+        out
     }
 
     /// Build a tool publisher inventory from the actual tools being sent.
@@ -374,6 +426,21 @@ impl ChatModelWorker {
              through the Seren Gateway — you do not need API keys, tokens, or environment \
              variables to use any of your tools. Never ask the user to configure credentials \
              or look for keys like SEREN_API_KEY. Just call the tools directly."
+                .to_string(),
+            // File output rules (GH #1583, #1585) — tell the model how to
+            // hit the user's requested path and format in one tool round.
+            "File output rules:\n\
+             • Paths starting with '~/' are expanded to the user's home directory. \
+             Pass them through as-is — do not rewrite to an absolute path.\n\
+             • When the user asks for a PDF, use the `write_pdf_from_html` tool \
+             to produce the file in one step. Do NOT write an HTML file first \
+             and then convert it — that leaves an orphan intermediate on disk \
+             and costs extra rounds. Build a complete self-contained HTML \
+             document (with inline CSS) and pass it to `write_pdf_from_html` \
+             with the exact path the user asked for.\n\
+             • Respect the exact filename and extension the user asked for. \
+             If they asked for '~/Downloads/X/Y.pdf', write to that path — not \
+             to 'invoice.pdf' or a similar auto-named file."
                 .to_string(),
         ];
         // Inject live repo context (git branch, status, recent commits)
@@ -1041,6 +1108,7 @@ impl ChatModelWorker {
             "read_file"
                 | "read_file_base64"
                 | "write_file"
+                | "write_pdf_from_html"
                 | "list_directory"
                 | "path_exists"
                 | "create_directory"
@@ -1100,6 +1168,20 @@ impl ChatModelWorker {
                 }
                 match crate::files::write_file(path.clone(), content) {
                     Ok(()) => (format!("Successfully wrote file: {}", path), false),
+                    Err(e) => (e, true),
+                }
+            }
+            "write_pdf_from_html" => {
+                let path = args["path"].as_str().unwrap_or("").to_string();
+                let html = args["html"].as_str().unwrap_or("").to_string();
+                if path.is_empty() {
+                    return ("Missing required parameter: path".to_string(), true);
+                }
+                if html.is_empty() {
+                    return ("Missing required parameter: html".to_string(), true);
+                }
+                match crate::pdf::write_pdf_from_html(&path, &html).await {
+                    Ok(msg) => (msg, false),
                     Err(e) => (e, true),
                 }
             }
@@ -2281,8 +2363,30 @@ mod tests {
             }
         })];
         let worker = ChatModelWorker::with_tools(tools.clone(), None);
-        assert_eq!(worker.tool_definitions.len(), 1);
-        assert_eq!(worker.tool_definitions[0]["function"]["name"], "read_file");
+        // `with_tools` injects `write_pdf_from_html` (GH #1585) at the front
+        // of the list, so the caller's tools follow. Assert both are present
+        // and read_file is preserved.
+        assert_eq!(worker.tool_definitions.len(), 2);
+        let names: Vec<&str> = worker
+            .tool_definitions
+            .iter()
+            .map(|t| t["function"]["name"].as_str().unwrap_or(""))
+            .collect();
+        assert!(names.contains(&"write_pdf_from_html"));
+        assert!(names.contains(&"read_file"));
+    }
+
+    #[test]
+    fn inject_local_tool_definitions_is_idempotent() {
+        // If the frontend catalog ever ships `write_pdf_from_html`, we must
+        // not duplicate it. (GH #1585)
+        let existing = vec![serde_json::json!({
+            "type": "function",
+            "function": {"name": "write_pdf_from_html"}
+        })];
+        let result = ChatModelWorker::inject_local_tool_definitions(existing);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["function"]["name"], "write_pdf_from_html");
     }
 
     fn make_tool(name: &str) -> serde_json::Value {

--- a/src-tauri/src/orchestrator/tool_relevance.rs
+++ b/src-tauri/src/orchestrator/tool_relevance.rs
@@ -38,6 +38,7 @@ const PINNED_TOOL_NAMES: &[&str] = &[
     "read_file",
     "read_file_base64",
     "write_file",
+    "write_pdf_from_html",
     "list_directory",
     "path_exists",
     "create_directory",
@@ -760,6 +761,10 @@ mod tests {
             "Read a file and return its bytes as base64",
         ));
         tools.push(make_tool("write_file", "Write content to a file on disk"));
+        tools.push(make_tool(
+            "write_pdf_from_html",
+            "Render HTML as a PDF and write it atomically",
+        ));
         tools.push(make_tool("list_directory", "List entries in a directory"));
         tools.push(make_tool(
             "path_exists",

--- a/src-tauri/src/path_util.rs
+++ b/src-tauri/src/path_util.rs
@@ -1,0 +1,82 @@
+// ABOUTME: Path-argument normalisation shared by file tools and Tauri commands.
+// ABOUTME: Expands a leading `~` to the user's home so model-supplied paths land where users expect.
+
+use std::path::PathBuf;
+
+/// Expand a leading `~` or `~/` in `path` to the user's home directory.
+///
+/// Rules (see GH #1583):
+/// - `~` alone -> `$HOME`
+/// - `~/foo` -> `$HOME/foo`
+/// - Anything else (`/abs`, `relative/x`, `~user/x`) is returned unchanged.
+///   `~user` is intentionally NOT expanded: resolving other users' homes is
+///   not portable across platforms and is not something the model should ask
+///   for.
+///
+/// Returns an error on empty input or when the home directory cannot be
+/// resolved (e.g. `$HOME` unset on unix). The error message is phrased so
+/// callers can surface it directly to the LLM as a tool-result error.
+pub fn expand_tilde(path: &str) -> Result<PathBuf, String> {
+    if path.is_empty() {
+        return Err("Path is empty".to_string());
+    }
+    if path == "~" || path.starts_with("~/") {
+        let home = dirs::home_dir().ok_or_else(|| {
+            "Cannot expand '~': unable to resolve home directory".to_string()
+        })?;
+        if path == "~" {
+            return Ok(home);
+        }
+        // `~/foo` -> join `foo`; strip exactly one `~/` prefix.
+        let rest = &path[2..];
+        return Ok(home.join(rest));
+    }
+    Ok(PathBuf::from(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_tilde_table() {
+        let home = dirs::home_dir().expect("home dir required for test");
+
+        // `~` alone -> $HOME
+        assert_eq!(expand_tilde("~").unwrap(), home);
+
+        // `~/foo` -> $HOME/foo
+        assert_eq!(expand_tilde("~/foo").unwrap(), home.join("foo"));
+
+        // `~/deep/path/file.txt` -> $HOME/deep/path/file.txt
+        assert_eq!(
+            expand_tilde("~/Downloads/Ishan/OhHello.pdf").unwrap(),
+            home.join("Downloads/Ishan/OhHello.pdf")
+        );
+
+        // Absolute path -> untouched
+        assert_eq!(
+            expand_tilde("/abs/path").unwrap(),
+            PathBuf::from("/abs/path")
+        );
+
+        // Relative path (no tilde) -> untouched (caller's cwd responsibility)
+        assert_eq!(
+            expand_tilde("relative/path").unwrap(),
+            PathBuf::from("relative/path")
+        );
+
+        // `~user/...` is NOT expanded (other-user homes not portable)
+        assert_eq!(
+            expand_tilde("~alice/foo").unwrap(),
+            PathBuf::from("~alice/foo")
+        );
+
+        // `~.bashrc` is NOT expanded — it's a literal filename that starts with `~`
+        // (no slash after the tilde).
+        assert_eq!(expand_tilde("~.bashrc").unwrap(), PathBuf::from("~.bashrc"));
+
+        // Empty -> error
+        assert!(expand_tilde("").is_err());
+    }
+}

--- a/src-tauri/src/pdf.rs
+++ b/src-tauri/src/pdf.rs
@@ -1,0 +1,324 @@
+// ABOUTME: Native PDF rendering for model tool calls — no HTML intermediate on disk.
+// ABOUTME: Shells out to headless Chrome/Chromium or wkhtmltopdf under one atomic tool.
+
+//! Implements the `write_pdf_from_html` local tool (GH #1585).
+//!
+//! The previous HTML→convert pattern produced a two-round workflow with an
+//! orphan HTML intermediate file whenever the conversion step was skipped
+//! (interrupted, Stop clicked, network error). This module bundles
+//! "write HTML + convert to PDF + remove intermediate" into a single atomic
+//! operation so the model uses one tool round and the user always sees either
+//! a PDF at the requested path or a clean error.
+//!
+//! The HTML intermediate is written into the system temp directory
+//! (`std::env::temp_dir()`), NEVER alongside the output PDF — this keeps
+//! generated HTML out of the Tauri dev file-watcher's scope (GH #1584) and
+//! out of the user's output folder.
+//!
+//! Converter discovery order is deliberate:
+//!  1. `google-chrome` / `chromium` on `$PATH` (most deterministic).
+//!  2. macOS `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`
+//!     (the default install location on Mac — no $PATH entry required).
+//!  3. `wkhtmltopdf` (legacy, still common on Linux).
+//! If none are present, we surface a clear error pointing the user at the
+//! cheapest install. We deliberately do NOT fall back to `print` dialogs or
+//! anything that needs UI.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tokio::process::Command;
+
+use crate::path_util::expand_tilde;
+
+const CONVERSION_TIMEOUT_SECS: u64 = 60;
+
+/// Write `html` as a PDF at `path` in a single atomic step.
+///
+/// `path` may start with `~/` — it's expanded via `expand_tilde`. Parent
+/// directories are created if missing. The HTML intermediate is written to
+/// the system temp dir and removed after conversion (even on failure). On
+/// success, returns the absolute resolved path as a display string for the
+/// tool result.
+pub async fn write_pdf_from_html(path: &str, html: &str) -> Result<String, String> {
+    if html.is_empty() {
+        return Err("Missing required parameter: html".to_string());
+    }
+    let resolved = expand_tilde(path)?;
+
+    // Ensure parent directory exists.
+    if let Some(parent) = resolved.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                format!(
+                    "Failed to create parent directory '{}': {}",
+                    parent.display(),
+                    e
+                )
+            })?;
+        }
+    }
+
+    // Write HTML to system temp (NOT alongside output). Unique filename
+    // prevents concurrent calls from clobbering each other.
+    let tmp_html = std::env::temp_dir().join(format!(
+        "seren-pdf-{}.html",
+        uuid::Uuid::new_v4().simple()
+    ));
+    std::fs::write(&tmp_html, html)
+        .map_err(|e| format!("Failed to write HTML intermediate: {}", e))?;
+
+    // Always clean up the intermediate, even on conversion failure.
+    let conversion_result = run_converter(&tmp_html, &resolved).await;
+    let _ = std::fs::remove_file(&tmp_html);
+    conversion_result?;
+
+    // Sanity-check: file exists and looks like a PDF.
+    let bytes = std::fs::metadata(&resolved)
+        .map_err(|e| format!("PDF was not created at '{}': {}", resolved.display(), e))?
+        .len();
+    if bytes < 4 {
+        return Err(format!(
+            "Converter produced an empty file at '{}' ({}B)",
+            resolved.display(),
+            bytes
+        ));
+    }
+    let mut header = [0u8; 4];
+    use std::io::Read;
+    if let Ok(mut f) = std::fs::File::open(&resolved) {
+        let _ = f.read(&mut header);
+    }
+    if &header != b"%PDF" {
+        return Err(format!(
+            "Converter produced a file at '{}' but it is not a valid PDF (header: {:?})",
+            resolved.display(),
+            header
+        ));
+    }
+
+    Ok(format!(
+        "Successfully wrote PDF: {} ({} bytes)",
+        resolved.display(),
+        bytes
+    ))
+}
+
+async fn run_converter(html_path: &Path, pdf_path: &Path) -> Result<(), String> {
+    let mut errors: Vec<String> = Vec::new();
+
+    for converter in converter_candidates() {
+        match converter.run(html_path, pdf_path).await {
+            Ok(()) => return Ok(()),
+            Err(ConverterError::NotFound) => {
+                // Try the next one silently.
+            }
+            Err(ConverterError::Failed(msg)) => {
+                errors.push(format!("{}: {}", converter.name(), msg));
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Err("No PDF converter found. Install Google Chrome, Chromium, or wkhtmltopdf and retry.".to_string())
+    } else {
+        Err(format!(
+            "PDF converters were present but failed:\n  - {}",
+            errors.join("\n  - ")
+        ))
+    }
+}
+
+enum ConverterError {
+    /// The converter binary was not found on this system.
+    NotFound,
+    /// The converter was found but exited non-zero or timed out.
+    Failed(String),
+}
+
+struct Converter {
+    name_: &'static str,
+    binary: PathBuf,
+    kind: ConverterKind,
+}
+
+#[derive(Clone, Copy)]
+enum ConverterKind {
+    /// Headless Chrome family: `<binary> --headless --disable-gpu --no-sandbox --print-to-pdf=<pdf> file://<html>`
+    Chromium,
+    /// wkhtmltopdf: `wkhtmltopdf [opts] <html> <pdf>`
+    Wkhtmltopdf,
+}
+
+impl Converter {
+    fn name(&self) -> &'static str {
+        self.name_
+    }
+
+    async fn run(&self, html: &Path, pdf: &Path) -> Result<(), ConverterError> {
+        if !self.binary.exists() {
+            return Err(ConverterError::NotFound);
+        }
+        let mut cmd = Command::new(&self.binary);
+        match self.kind {
+            ConverterKind::Chromium => {
+                cmd.arg("--headless=new")
+                    .arg("--disable-gpu")
+                    .arg("--no-sandbox")
+                    // Chrome prints to the cwd by default; force absolute.
+                    .arg(format!("--print-to-pdf={}", pdf.display()))
+                    .arg(format!("file://{}", html.display()));
+            }
+            ConverterKind::Wkhtmltopdf => {
+                cmd.arg("--quiet").arg(html).arg(pdf);
+            }
+        }
+        cmd.stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+
+        let child = cmd
+            .spawn()
+            .map_err(|e| ConverterError::Failed(format!("spawn failed: {}", e)))?;
+        let output = tokio::time::timeout(
+            Duration::from_secs(CONVERSION_TIMEOUT_SECS),
+            child.wait_with_output(),
+        )
+        .await
+        .map_err(|_| ConverterError::Failed("conversion timed out".to_string()))?
+        .map_err(|e| ConverterError::Failed(format!("wait failed: {}", e)))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(ConverterError::Failed(format!(
+                "exit {:?}: {}",
+                output.status.code(),
+                stderr.trim()
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn converter_candidates() -> Vec<Converter> {
+    let mut out = Vec::new();
+
+    // 1. Chromium-family binaries on $PATH (name-order matters: prefer
+    //    `google-chrome` and then `chromium` for consistency across distros).
+    for name in ["google-chrome", "google-chrome-stable", "chromium", "chromium-browser"] {
+        if let Some(p) = which_on_path(name) {
+            out.push(Converter {
+                name_: "chromium",
+                binary: p,
+                kind: ConverterKind::Chromium,
+            });
+        }
+    }
+
+    // 2. macOS default install paths for Chrome. Order: Chrome > Chromium > Edge.
+    #[cfg(target_os = "macos")]
+    {
+        for hard in [
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        ] {
+            let p = PathBuf::from(hard);
+            if p.exists() {
+                out.push(Converter {
+                    name_: "chromium",
+                    binary: p,
+                    kind: ConverterKind::Chromium,
+                });
+            }
+        }
+    }
+
+    // 3. wkhtmltopdf — legacy fallback, still widely packaged.
+    if let Some(p) = which_on_path("wkhtmltopdf") {
+        out.push(Converter {
+            name_: "wkhtmltopdf",
+            binary: p,
+            kind: ConverterKind::Wkhtmltopdf,
+        });
+    }
+
+    out
+}
+
+/// Minimal `which`: scan `$PATH` for a binary by name. Avoids pulling in a
+/// new crate. Returns the first hit.
+fn which_on_path(name: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for entry in std::env::split_paths(&path_var) {
+        let candidate = entry.join(name);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable_file(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    p.is_file()
+        && std::fs::metadata(p)
+            .map(|m| m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(p: &Path) -> bool {
+    p.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// End-to-end smoke: when a Chromium-family converter is present on the
+    /// test machine, `write_pdf_from_html` produces a valid PDF (first four
+    /// bytes are `%PDF`) at a `~/…` path without leaking an HTML intermediate
+    /// into cwd. Skipped if no converter is available (e.g. stripped CI).
+    #[tokio::test]
+    async fn write_pdf_from_html_produces_valid_pdf_header() {
+        if converter_candidates().is_empty() {
+            eprintln!("skipping: no PDF converter on this machine");
+            return;
+        }
+        let home = dirs::home_dir().expect("home dir");
+        let unique = format!(".serendesktop-pdf-test-{}", uuid::Uuid::new_v4().simple());
+        let rel = format!("~/{}/out.pdf", unique);
+
+        let html = "<!DOCTYPE html><html><body><h1>hello</h1></body></html>";
+        let msg = write_pdf_from_html(&rel, html)
+            .await
+            .expect("write_pdf_from_html ok");
+        assert!(msg.contains(".pdf"));
+
+        let expected = home.join(&unique).join("out.pdf");
+        assert!(expected.exists(), "expected PDF at {}", expected.display());
+
+        // Header check: PDF files start with "%PDF-".
+        let mut buf = [0u8; 4];
+        use std::io::Read;
+        let mut f = std::fs::File::open(&expected).expect("open pdf");
+        f.read_exact(&mut buf).expect("read header");
+        assert_eq!(&buf, b"%PDF", "not a PDF at {}", expected.display());
+
+        // No HTML intermediate leaked into the output directory.
+        let siblings: Vec<String> = std::fs::read_dir(home.join(&unique))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            !siblings.iter().any(|n| n.ends_with(".html")),
+            "html intermediate leaked next to PDF: {:?}",
+            siblings
+        );
+
+        let _ = std::fs::remove_dir_all(home.join(&unique));
+    }
+}


### PR DESCRIPTION
## Summary

Three interacting bugs exposed by the Ishan invoice prompt, fixed together because the fixes share a path-handling helper:

- **#1583** (critical): `write_file` and siblings don't expand `~` → silent data loss. Model-supplied `~/Downloads/x/y.pdf` landed at `src-tauri/~/Downloads/x/y.pdf` relative to the dev cwd.
- **#1584** (medium): `tauri dev`'s broad file watcher rebuilt the app whenever a stray write landed inside `src-tauri/`, killing orchestrations mid-task. Fixed as fallout from #1583 + a debug-build guard that rejects any path containing a literal `~` segment.
- **#1585** (high): no native PDF tool → HTML intermediate orphan on interrupt. New `write_pdf_from_html` Rust tool renders atomically via headless Chrome/Chromium/wkhtmltopdf, temp file in the system temp dir, validated `%PDF` output.

Closes #1583, #1584, #1585.

## Test plan

- [x] `cargo test --lib` — **333 passed, 0 failed** (up from 330 before)
- [x] Critical tests all green:
  - `path_util::tests::expand_tilde_table`
  - `files::tests::write_file_expands_tilde_to_home` (exact Ishan repro)
  - `files::tests::reject_literal_tilde_segment_catches_unexpanded_paths`
  - `pdf::tests::write_pdf_from_html_produces_valid_pdf_header` (end-to-end real Chrome render)
  - `chat_model_worker::tests::inject_local_tool_definitions_is_idempotent`
- [x] Regression tests updated: `with_tools_stores_definitions`, `pinned_local_tools_always_included`
- [x] `cargo check` clean
- [ ] Manual: replay the Ishan prompt in `pnpm tauri dev` → PDF lands at `~/Downloads/Ishan/OhHello.pdf` in one tool round, no HTML orphan
