### PR TITLE
fix(provider-runtime): start_kill() instead of kill().await so retry loop advances (#1589)

### DIFF
--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -157,7 +157,24 @@ impl ProviderRuntimeState {
                             "giving up"
                         },
                     );
-                    let _ = child.kill().await;
+                    // Non-blocking kill: `Child::kill().await` is *not*
+                    // just a signal send — it sends SIGKILL *and then
+                    // awaits* the child's wait status. On a hung node
+                    // subprocess (the exact case this retry loop exists
+                    // for) that await never returns, which traps the
+                    // loop before attempt 2 can spawn.
+                    //
+                    // Observed after #1588 landed: attempt 1 timed out,
+                    // warn logged, then the process silently hung — the
+                    // "Attempt 2/3 — spawned" log line never appeared
+                    // even though STARTUP_ATTEMPT_BUDGETS has three
+                    // entries. Codex/Gemini never showed up.
+                    //
+                    // `start_kill()` sends SIGKILL synchronously without
+                    // waiting. `kill_on_drop(true)` (set at spawn) takes
+                    // care of reaping when `child` drops at end-of-scope.
+                    let _ = child.start_kill();
+                    drop(child);
                     attempt_errors.push(format!("attempt {}: {}", attempt_num, attempt_err));
                 }
             }
@@ -604,7 +621,36 @@ mod tests {
         .expect_err("must err on timeout");
         assert!(err.contains("Timed out"), "unexpected err: {err}");
         assert!(err.contains("0s") || err.contains("after"), "err should mention budget: {err}");
-        let _ = child.kill().await;
+        // Use start_kill here too — see test below for why.
+        let _ = child.start_kill();
+        drop(child);
+    }
+
+    /// Regression guard (GH #1587 post-merge field-observed hang):
+    /// `Child::kill().await` sends SIGKILL *and awaits the child's wait
+    /// status*. On a hung subprocess that await never returns, which in
+    /// the retry loop blocks attempt 2 from ever spawning.
+    ///
+    /// `start_kill()` is the non-blocking variant and is what the retry
+    /// loop uses. This test proves it completes in <100ms even on a
+    /// long-running child so the loop can advance deterministically.
+    #[tokio::test]
+    async fn start_kill_does_not_block_on_long_running_child() {
+        let mut child = spawn_hanging_child().await;
+        let t0 = std::time::Instant::now();
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            async { child.start_kill() },
+        )
+        .await
+        .expect("start_kill must not block")
+        .expect("start_kill returned err");
+        drop(child);
+        assert!(
+            t0.elapsed() < Duration::from_millis(100),
+            "start_kill should be near-instant, took {:?}",
+            t0.elapsed()
+        );
     }
 
     /// GH #1587: the attempt-budget table has three entries so the retry


### PR DESCRIPTION
## Summary

Hotfix for a regression observed immediately after #1588 merged. The retry loop hangs between attempts because `tokio::process::Child::kill().await` awaits the child's wait status, which never returns on the hung subprocess the loop was built to retry past.

Switch to `Child::start_kill()` (non-blocking signal send); rely on `kill_on_drop(true)` to reap. Child drops naturally at end-of-scope.

Closes #1589. Refs #1587, #1588.

## Test plan

- [x] New test `provider_runtime::tests::start_kill_does_not_block_on_long_running_child` — proves 100ms timeout for the non-blocking path
- [x] Updated existing timeout test to use the same pattern so it can't be bitten by the same bug
- [x] `cargo test --lib` — **337 passed, 0 failed** (up from 336)
- [x] `cargo check` clean
- [ ] Manual: boot tauri dev → attempt 1 fails → attempt 2/3 visible in log within ~1s → agent store eventually populates Codex/Gemini
