### PR TITLE
fix(agent): persist per-thread settings + input history; only fallback on catastrophic compaction (#1597)

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -46,6 +46,7 @@ pub struct AgentConversation {
     pub agent_session_id: Option<String>,
     pub agent_cwd: Option<String>,
     pub agent_model_id: Option<String>,
+    pub agent_permission_mode: Option<String>,
     pub agent_metadata: Option<String>,
     pub project_id: Option<String>,
     pub project_root: Option<String>,
@@ -281,6 +282,7 @@ pub async fn create_agent_conversation(
         agent_session_id: agent_session_id.clone(),
         agent_cwd: agent_cwd.clone(),
         agent_model_id: None,
+        agent_permission_mode: None,
         agent_metadata: agent_metadata.clone(),
         project_id: project_id.clone(),
         project_root: normalized_project_root.clone(),
@@ -340,7 +342,7 @@ pub async fn get_agent_conversations(
 
     run_db(app, move |conn| {
         let mut stmt = conn.prepare(
-            "SELECT id, title, created_at, agent_type, agent_session_id, agent_cwd, agent_model_id, agent_metadata, project_id, project_root, is_archived
+            "SELECT id, title, created_at, agent_type, agent_session_id, agent_cwd, agent_model_id, agent_permission_mode, agent_metadata, project_id, project_root, is_archived
              FROM conversations
              WHERE kind = 'agent' AND is_archived = 0
                AND ((?1 IS NULL AND ?2 IS NULL)
@@ -364,10 +366,11 @@ pub async fn get_agent_conversations(
                     agent_session_id: row.get(4)?,
                     agent_cwd: row.get(5)?,
                     agent_model_id: row.get(6)?,
-                    agent_metadata: row.get(7)?,
-                    project_id: row.get(8)?,
-                    project_root: row.get(9)?,
-                    is_archived: row.get::<_, i32>(10)? != 0,
+                    agent_permission_mode: row.get(7)?,
+                    agent_metadata: row.get(8)?,
+                    project_id: row.get(9)?,
+                    project_root: row.get(10)?,
+                    is_archived: row.get::<_, i32>(11)? != 0,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -384,7 +387,7 @@ pub async fn get_agent_conversation(
 ) -> Result<Option<AgentConversation>, String> {
     run_db(app, move |conn| {
         let mut stmt = conn.prepare(
-            "SELECT id, title, created_at, agent_type, agent_session_id, agent_cwd, agent_model_id, agent_metadata, project_id, project_root, is_archived
+            "SELECT id, title, created_at, agent_type, agent_session_id, agent_cwd, agent_model_id, agent_permission_mode, agent_metadata, project_id, project_root, is_archived
              FROM conversations
              WHERE id = ?1 AND kind = 'agent'",
         )?;
@@ -399,10 +402,11 @@ pub async fn get_agent_conversation(
                     agent_session_id: row.get(4)?,
                     agent_cwd: row.get(5)?,
                     agent_model_id: row.get(6)?,
-                    agent_metadata: row.get(7)?,
-                    project_id: row.get(8)?,
-                    project_root: row.get(9)?,
-                    is_archived: row.get::<_, i32>(10)? != 0,
+                    agent_permission_mode: row.get(7)?,
+                    agent_metadata: row.get(8)?,
+                    project_id: row.get(9)?,
+                    project_root: row.get(10)?,
+                    is_archived: row.get::<_, i32>(11)? != 0,
                 })
             })
             .optional()?;
@@ -456,6 +460,79 @@ pub async fn set_agent_conversation_model_id(
             params![agent_model_id, id],
         )?;
         Ok(())
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn set_agent_conversation_permission_mode(
+    app: AppHandle,
+    id: String,
+    agent_permission_mode: String,
+) -> Result<(), String> {
+    run_db(app, move |conn| {
+        conn.execute(
+            "UPDATE conversations SET agent_permission_mode = ?1 WHERE id = ?2 AND kind = 'agent'",
+            params![agent_permission_mode, id],
+        )?;
+        Ok(())
+    })
+    .await
+}
+
+const MAX_INPUT_HISTORY_PER_CONVERSATION: i64 = 200;
+
+#[tauri::command]
+pub async fn append_input_history(
+    app: AppHandle,
+    conversation_id: String,
+    content: String,
+) -> Result<(), String> {
+    let trimmed = content.trim().to_string();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    run_db(app, move |conn| {
+        conn.execute(
+            "INSERT INTO input_history (conversation_id, timestamp, content) VALUES (?1, ?2, ?3)",
+            params![conversation_id, timestamp, trimmed],
+        )?;
+        conn.execute(
+            "DELETE FROM input_history
+             WHERE conversation_id = ?1
+               AND rowid NOT IN (
+                 SELECT rowid FROM input_history
+                 WHERE conversation_id = ?1
+                 ORDER BY timestamp DESC
+                 LIMIT ?2
+               )",
+            params![conversation_id, MAX_INPUT_HISTORY_PER_CONVERSATION],
+        )?;
+        Ok(())
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn get_input_history(
+    app: AppHandle,
+    conversation_id: String,
+) -> Result<Vec<String>, String> {
+    run_db(app, move |conn| {
+        let mut stmt = conn.prepare(
+            "SELECT content FROM input_history
+             WHERE conversation_id = ?1
+             ORDER BY timestamp ASC",
+        )?;
+        let rows = stmt
+            .query_map(params![conversation_id], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
     })
     .await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -746,8 +746,12 @@ pub fn run() {
             commands::chat::set_agent_conversation_session_id,
             commands::chat::set_agent_conversation_title,
             commands::chat::set_agent_conversation_model_id,
+            commands::chat::set_agent_conversation_permission_mode,
             commands::chat::set_agent_conversation_metadata,
             commands::chat::archive_agent_conversation,
+            // Input history commands
+            commands::chat::append_input_history,
+            commands::chat::get_input_history,
             // Message commands
             commands::chat::save_message,
             commands::chat::get_messages,

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -70,10 +70,28 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             agent_session_id TEXT,
             agent_cwd TEXT,
             agent_model_id TEXT,
+            agent_permission_mode TEXT,
             agent_metadata TEXT,
             project_id TEXT,
             project_root TEXT
         )",
+        [],
+    )?;
+
+    // Per-conversation input history buffer: persists the user's own prompts
+    // independently of session/message state so up-arrow recall survives
+    // thread switches, compaction, and app restarts.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS input_history (
+            conversation_id TEXT NOT NULL,
+            timestamp INTEGER NOT NULL,
+            content TEXT NOT NULL
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_input_history_convo_ts
+         ON input_history(conversation_id, timestamp DESC)",
         [],
     )?;
 
@@ -165,6 +183,17 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
     if !has_agent_model_id {
         conn.execute(
             "ALTER TABLE conversations ADD COLUMN agent_model_id TEXT",
+            [],
+        )
+        .ok();
+    }
+
+    let has_agent_permission_mode: bool = conn
+        .prepare("SELECT agent_permission_mode FROM conversations LIMIT 1")
+        .is_ok();
+    if !has_agent_permission_mode {
+        conn.execute(
+            "ALTER TABLE conversations ADD COLUMN agent_permission_mode TEXT",
             [],
         )
         .ok();
@@ -711,6 +740,104 @@ mod tests {
         assert_eq!(events[0].1, "navigation");
         assert_eq!(events[1].0, "e2");
         assert_eq!(events[1].1, "action");
+    }
+
+    #[test]
+    fn schema_creates_agent_permission_mode_and_input_history() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+
+        // agent_permission_mode column must round-trip
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind, agent_type, agent_permission_mode)
+             VALUES ('c1', 'Agent', 1000, 'agent', 'claude-code', 'acceptEdits')",
+            [],
+        )
+        .unwrap();
+        let mode: Option<String> = conn
+            .query_row(
+                "SELECT agent_permission_mode FROM conversations WHERE id = 'c1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(mode, Some("acceptEdits".to_string()));
+
+        // input_history table exists and stores per-conversation prompts
+        conn.execute(
+            "INSERT INTO input_history (conversation_id, timestamp, content)
+             VALUES ('c1', 1000, 'first'), ('c1', 1001, 'second')",
+            [],
+        )
+        .unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT content FROM input_history WHERE conversation_id = 'c1' ORDER BY timestamp ASC",
+            )
+            .unwrap();
+        let rows: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(rows, vec!["first".to_string(), "second".to_string()]);
+    }
+
+    #[test]
+    fn migration_adds_agent_permission_mode_to_pre_existing_db() {
+        // Simulate a DB created before the new column landed.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE conversations (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                selected_model TEXT,
+                selected_provider TEXT,
+                is_archived INTEGER DEFAULT 0,
+                kind TEXT NOT NULL DEFAULT 'chat',
+                agent_type TEXT,
+                agent_session_id TEXT,
+                agent_cwd TEXT,
+                agent_model_id TEXT,
+                agent_metadata TEXT,
+                project_id TEXT,
+                project_root TEXT
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                model TEXT,
+                timestamp INTEGER NOT NULL
+            )",
+            [],
+        )
+        .unwrap();
+
+        // Running setup_schema should migrate the missing column.
+        setup_schema(&conn).unwrap();
+
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind, agent_type, agent_permission_mode)
+             VALUES ('a1', 'Agent', 1000, 'agent', 'claude-code', 'plan')",
+            [],
+        )
+        .unwrap();
+
+        let mode: Option<String> = conn
+            .query_row(
+                "SELECT agent_permission_mode FROM conversations WHERE id = 'a1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(mode, Some("plan".to_string()));
     }
 
     #[test]

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/rate-limit-fallback";
 import { escapeHtmlWithLinks } from "@/lib/render-markdown";
 import { saveToSerenNotes } from "@/lib/save-to-notes";
+import { appendInputHistory, getInputHistory } from "@/lib/tauri-bridge";
 import { readDocument } from "@/services/docreader";
 import {
   type AgentType,
@@ -184,13 +185,28 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     return agentStore.getStreamingThinkingForConversation(thread.id);
   });
 
-  // Build reversed list of user prompts for Up/Down arrow navigation
-  const userMessageHistory = createMemo(() =>
-    threadMessages()
-      .filter((m) => m.type === "user")
-      .map((m) => m.content)
-      .reverse(),
-  );
+  // Persisted per-conversation input history (oldest first, capped at 200).
+  // Survives thread switches, compaction, and app restarts — decoupled from
+  // session.messages which compaction drops.
+  const [persistedInputs, setPersistedInputs] = createSignal<string[]>([]);
+
+  createEffect(() => {
+    const convId = activeAgentThread()?.id ?? null;
+    if (!convId) {
+      setPersistedInputs([]);
+      return;
+    }
+    getInputHistory(convId)
+      .then(setPersistedInputs)
+      .catch((err) => {
+        console.warn("[AgentChat] Failed to load input history:", err);
+        setPersistedInputs([]);
+      });
+  });
+
+  // Build reversed list of user prompts for Up/Down arrow navigation.
+  // Reads from persisted history so entries survive compaction + restart.
+  const userMessageHistory = createMemo(() => [...persistedInputs()].reverse());
 
   const onPickImages = () => handleAttachImages();
   const onSetChatInput = (event: Event) => {
@@ -701,6 +717,17 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         "[AgentChat] DocReader complete, prompt length:",
         promptWithDocs.length,
       );
+    }
+
+    const convId = activeAgentThread()?.id ?? null;
+    if (convId) {
+      setPersistedInputs((prev) => {
+        const next = [...prev, trimmed];
+        return next.length > 200 ? next.slice(-200) : next;
+      });
+      void appendInputHistory(convId, trimmed).catch((err) => {
+        console.warn("[AgentChat] Failed to persist input history:", err);
+      });
     }
 
     setInput("");

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -35,6 +35,7 @@ import { isPaymentError } from "@/lib/payment-errors";
 import type { Attachment } from "@/lib/providers/types";
 import { escapeHtmlWithLinks } from "@/lib/render-markdown";
 import { saveToSerenNotes } from "@/lib/save-to-notes";
+import { appendInputHistory, getInputHistory } from "@/lib/tauri-bridge";
 import { catalog, type Publisher } from "@/services/catalog";
 import {
   CHAT_MAX_RETRIES,
@@ -497,13 +498,27 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     };
   });
 
-  // User message history for up/down arrow navigation
-  const userMessageHistory = createMemo(() =>
-    conversationStore.messages
-      .filter((m) => m.role === "user")
-      .map((m) => m.content)
-      .reverse(),
-  );
+  // Persisted per-conversation input history (oldest first, capped at 200).
+  // Survives thread switches, compaction, and app restarts — decoupled from
+  // conversationStore.messages which may be empty or not yet hydrated.
+  const [persistedInputs, setPersistedInputs] = createSignal<string[]>([]);
+
+  createEffect(() => {
+    const convId = conversationStore.activeConversationId;
+    if (!convId) {
+      setPersistedInputs([]);
+      return;
+    }
+    getInputHistory(convId)
+      .then(setPersistedInputs)
+      .catch((err) => {
+        console.warn("[ChatContent] Failed to load input history:", err);
+        setPersistedInputs([]);
+      });
+  });
+
+  // User message history for up/down arrow navigation (newest first).
+  const userMessageHistory = createMemo(() => [...persistedInputs()].reverse());
 
   const buildContext = (): ChatContext | undefined => {
     if (!editorStore.selectedText) return undefined;
@@ -629,6 +644,19 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     const trimmed = input().trim();
     const images = attachedImages();
     if (!trimmed && images.length === 0) return;
+
+    // Record the prompt in the persisted input-history buffer so up-arrow
+    // recall survives thread switches, compaction, and app restarts.
+    const convId = conversationStore.activeConversationId;
+    if (trimmed && convId) {
+      setPersistedInputs((prev) => {
+        const next = [...prev, trimmed];
+        return next.length > 200 ? next.slice(-200) : next;
+      });
+      void appendInputHistory(convId, trimmed).catch((err) => {
+        console.warn("[ChatContent] Failed to persist input history:", err);
+      });
+    }
 
     // Check for slash commands first
     if (trimmed.startsWith("/") && images.length === 0) {

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -618,6 +618,7 @@ export interface AgentConversation {
   agent_session_id: string | null;
   agent_cwd: string | null;
   agent_model_id: string | null;
+  agent_permission_mode: string | null;
   agent_metadata: string | null;
   project_id: string | null;
   project_root: string | null;
@@ -808,6 +809,47 @@ export async function setAgentConversationModelId(
     throw new Error("Conversation operations require Tauri runtime");
   }
   await invoke("set_agent_conversation_model_id", { id, agentModelId });
+}
+
+/**
+ * Update the permission mode for a persisted agent conversation.
+ */
+export async function setAgentConversationPermissionMode(
+  id: string,
+  agentPermissionMode: string,
+): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) {
+    throw new Error("Conversation operations require Tauri runtime");
+  }
+  await invoke("set_agent_conversation_permission_mode", {
+    id,
+    agentPermissionMode,
+  });
+}
+
+/**
+ * Append a user-entered prompt to the conversation's input-history buffer.
+ * Buffer is capped at the last 200 entries per conversation.
+ */
+export async function appendInputHistory(
+  conversationId: string,
+  content: string,
+): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) return;
+  await invoke("append_input_history", { conversationId, content });
+}
+
+/**
+ * Load the persisted input-history buffer for a conversation, oldest first.
+ */
+export async function getInputHistory(
+  conversationId: string,
+): Promise<string[]> {
+  const invoke = await getInvoke();
+  if (!invoke) return [];
+  return (await invoke("get_input_history", { conversationId })) as string[];
 }
 
 export async function setAgentConversationMetadata(

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -60,6 +60,25 @@ function waitForSessionReady(sessionId: string): Promise<void> {
   ]);
 }
 
+/**
+ * Outcome of an auto-compaction attempt. Callers use this to decide whether
+ * to fall back to Seren Chat. Only `failed_catastrophic` fires the fallback;
+ * transient or "no-op" outcomes keep the user inside the agent session.
+ *
+ * - `retried`: compaction succeeded AND the user's last prompt was re-sent.
+ * - `succeeded`: compaction succeeded, no prompt to retry.
+ * - `skipped_nothing_to_compact`: message count is below `preserveCount`;
+ *   the session was already too small to compact. Usually means a single
+ *   message is gigantic — Chat fallback would not help.
+ * - `failed_catastrophic`: unrecoverable failure (spawn failed, summary API
+ *   threw after refresh, agent runtime broken). Chat fallback is correct.
+ */
+export type CompactionOutcome =
+  | "retried"
+  | "succeeded"
+  | "skipped_nothing_to_compact"
+  | "failed_catastrophic";
+
 /** Wait for a session to return to 'ready' (not 'prompting') with a timeout.
  * Used after sending the compaction seed prompt to avoid racing with the retry. */
 async function waitForSessionIdle(
@@ -97,6 +116,7 @@ import {
   saveMessage,
   setAgentConversationMetadata as setAgentConversationMetadataDb,
   setAgentConversationModelId as setAgentConversationModelIdDb,
+  setAgentConversationPermissionMode as setAgentConversationPermissionModeDb,
   setAgentConversationSessionId as setAgentConversationSessionIdDb,
   setAgentConversationTitle as setAgentConversationTitleDb,
 } from "@/lib/tauri-bridge";
@@ -268,7 +288,7 @@ export interface ActiveSession {
   compactRetryAttempted?: boolean;
   /** In-flight compactAndRetry promise — awaited by sendPrompt catch block
    *  so compaction completes before the error handler gives up. */
-  compactRetryPromise?: Promise<boolean>;
+  compactRetryPromise?: Promise<CompactionOutcome>;
   /** Transcript bootstrap injected into the first real prompt of a forked branch. */
   bootstrapPromptContext?: string;
   /** Set when the user explicitly requested a cancel — suppresses auto-retry
@@ -1057,6 +1077,8 @@ export const agentStore = {
       reclaimedIdleClaude?: boolean;
       restoredMessages?: AgentMessage[];
       bootstrapPromptContext?: string;
+      initialModelId?: string;
+      initialPermissionMode?: string;
     },
   ): Promise<string | null> {
     const resolvedAgentType = agentType ?? state.selectedAgentType;
@@ -1663,6 +1685,29 @@ export const agentStore = {
         setState("isLoading", false);
         tempUnsubscribe();
 
+        // Re-apply the user's persisted model + permission-mode choices so
+        // that resume/compaction/app-restart preserve them across threads.
+        if (opts?.initialModelId) {
+          try {
+            await this.setModel(opts.initialModelId, info.id);
+          } catch (err) {
+            console.warn(
+              "[AgentStore] Failed to re-apply persisted model on spawn:",
+              err,
+            );
+          }
+        }
+        if (opts?.initialPermissionMode) {
+          try {
+            await this.setPermissionMode(opts.initialPermissionMode, info.id);
+          } catch (err) {
+            console.warn(
+              "[AgentStore] Failed to re-apply persisted permission mode on spawn:",
+              err,
+            );
+          }
+        }
+
         return info.id;
       } catch (error) {
         console.error(
@@ -1792,6 +1837,8 @@ export const agentStore = {
         conversationTitle: convo.title,
         restoredMessages,
         bootstrapPromptContext: pendingBootstrapPromptContext,
+        initialModelId: convo.agent_model_id ?? undefined,
+        initialPermissionMode: convo.agent_permission_mode ?? undefined,
       });
       if (freshSessionId) {
         clearSpawnFailures(conversationId);
@@ -1829,6 +1876,8 @@ export const agentStore = {
       conversationTitle: convo.title,
       restoredMessages,
       bootstrapPromptContext: pendingBootstrapPromptContext,
+      initialModelId: convo.agent_model_id ?? undefined,
+      initialPermissionMode: convo.agent_permission_mode ?? undefined,
     });
 
     // Legacy Claude conversations can reference session IDs that no longer
@@ -1848,6 +1897,8 @@ export const agentStore = {
         conversationTitle: convo.title,
         restoredMessages,
         bootstrapPromptContext: pendingBootstrapPromptContext,
+        initialModelId: convo.agent_model_id ?? undefined,
+        initialPermissionMode: convo.agent_permission_mode ?? undefined,
       });
 
       // If resume-based fallback also failed, the session file is likely
@@ -1866,6 +1917,8 @@ export const agentStore = {
           restoredMessages:
             persisted.messages.length > 0 ? persisted.messages : undefined,
           bootstrapPromptContext: persisted.context || undefined,
+          initialModelId: convo.agent_model_id ?? undefined,
+          initialPermissionMode: convo.agent_permission_mode ?? undefined,
         });
       }
 
@@ -2147,14 +2200,18 @@ export const agentStore = {
   async compactAgentConversation(
     sessionId: string,
     preserveCount: number,
-  ): Promise<void> {
+  ): Promise<CompactionOutcome> {
     const session = state.sessions[sessionId];
-    if (!session || session.isCompacting) return;
+    if (!session || session.isCompacting) {
+      return "skipped_nothing_to_compact";
+    }
 
     const messages = session.messages;
     if (messages.length <= preserveCount) {
-      console.info("[AgentStore] Not enough messages to compact");
-      return;
+      console.info(
+        "[AgentStore] Not enough messages to compact (message count below preserve threshold)",
+      );
+      return "skipped_nothing_to_compact";
     }
 
     setState("sessions", sessionId, "isCompacting", true);
@@ -2227,9 +2284,11 @@ Structured summary:`;
 
       if (!newSessionId) {
         console.error(
-          "[AgentStore] Failed to spawn new session after compaction",
+          "[AgentStore] Failed to spawn new session after compaction — catastrophic",
         );
-        return;
+        throw new Error(
+          "CompactionFailure: new session spawn returned null after compaction",
+        );
       }
 
       // Store compacted summary and preserved messages on the new session.
@@ -2298,16 +2357,19 @@ Structured summary:`;
         );
         setState("sessions", newSessionId, "lastUserPrompt", pendingUserPrompt);
         await providerService.sendPrompt(newSessionId, pendingUserPrompt);
+        return "retried";
       }
+      return "succeeded";
     } catch (error) {
       console.error(
-        "[AgentStore] Failed to compact agent conversation:",
+        "[AgentStore] Failed to compact agent conversation (catastrophic):",
         error,
       );
       // If the original session still exists, clear compacting flag
       if (state.sessions[sessionId]) {
         setState("sessions", sessionId, "isCompacting", false);
       }
+      return "failed_catastrophic";
     }
   },
 
@@ -2315,10 +2377,10 @@ Structured summary:`;
    * Compact the conversation and retry the last user prompt.
    * Returns true if compaction + retry succeeded, false if we should fall back.
    */
-  async compactAndRetry(sessionId: string): Promise<boolean> {
+  async compactAndRetry(sessionId: string): Promise<CompactionOutcome> {
     const session = state.sessions[sessionId];
     if (!session || session.compactRetryAttempted || session.isCompacting) {
-      return false;
+      return "skipped_nothing_to_compact";
     }
 
     setState("sessions", sessionId, "compactRetryAttempted", true);
@@ -2329,10 +2391,22 @@ Structured summary:`;
     );
 
     try {
-      await this.compactAgentConversation(
+      const outcome = await this.compactAgentConversation(
         sessionId,
         settingsStore.settings.autoCompactPreserveMessages,
       );
+
+      // Propagate non-success outcomes directly. "skipped" means the message
+      // count was already under the preserve threshold (nothing to compact);
+      // "failed_catastrophic" means spawn or summary threw. Chat fallback is
+      // only correct for the latter; the former means a single prompt is too
+      // large and Chat would fail identically — show an error instead.
+      if (outcome === "skipped_nothing_to_compact") {
+        return outcome;
+      }
+      if (outcome === "failed_catastrophic") {
+        return outcome;
+      }
 
       // After compaction, the old session is terminated and a new one exists.
       // Find the new session by conversation ID.
@@ -2342,21 +2416,21 @@ Structured summary:`;
       );
       if (!newEntry) {
         console.warn(
-          "[AgentStore] compactAndRetry: new session not found after compaction",
+          "[AgentStore] compactAndRetry: new session not found after compaction — treating as catastrophic",
         );
-        return false;
+        return "failed_catastrophic";
       }
 
       const [newSessionId] = newEntry;
 
-      // If compaction was skipped (e.g. not enough messages to compact),
-      // the search returns the original session — retrying on the same
-      // full session would fail again and falsely signal success.
+      // If the search returned the original session, compaction never
+      // swapped it out — treat as catastrophic so the user isn't silently
+      // stuck on a full session.
       if (newSessionId === sessionId) {
         console.warn(
-          "[AgentStore] compactAndRetry: compaction was skipped, cannot retry",
+          "[AgentStore] compactAndRetry: new session matches old session id — compaction did not swap",
         );
-        return false;
+        return "failed_catastrophic";
       }
 
       // compactAgentConversation sends the seed prompt before returning, so the
@@ -2371,18 +2445,18 @@ Structured summary:`;
           `[AgentStore] Compaction complete, retrying prompt on session ${newSessionId}`,
         );
         await providerService.sendPrompt(newSessionId, lastPrompt);
-      } else {
-        console.info(
-          `[AgentStore] Compaction complete on session ${newSessionId} — no prompt to retry, session ready`,
-        );
+        return "retried";
       }
-      return true;
+      console.info(
+        `[AgentStore] Compaction complete on session ${newSessionId} — no prompt to retry, session ready`,
+      );
+      return "succeeded";
     } catch (error) {
       console.error(
-        "[AgentStore] compactAndRetry failed, falling back to Chat:",
+        "[AgentStore] compactAndRetry threw — treating as catastrophic:",
         error,
       );
-      return false;
+      return "failed_catastrophic";
     }
   },
 
@@ -2818,6 +2892,18 @@ Structured summary:`;
       // Optimistic update — the authoritative update arrives via
       // CurrentModeUpdate notification handled in handleStatusChange.
       setState("sessions", sessionId, "currentModeId", modeId);
+      const session = state.sessions[sessionId];
+      if (session) {
+        void setAgentConversationPermissionModeDb(
+          session.conversationId,
+          modeId,
+        ).catch((error) => {
+          console.warn(
+            "Failed to persist agent permission-mode selection",
+            error,
+          );
+        });
+      }
     } catch (error) {
       console.error(
         `[AgentStore] Failed to set permission mode to "${modeId}":`,
@@ -3428,21 +3514,30 @@ Structured summary:`;
             "ready" as SessionStatus,
           );
 
-          // Try compact-and-retry first; fall back to Chat only if it fails.
-          // Store the promise so sendPrompt catch block can await it.
+          // Try compact-and-retry first. Fall back to Chat only on
+          // catastrophic failure — "skipped" means the user's single prompt
+          // is too large for the context, and Chat would fail the same way.
           const compactPromise = this.compactAndRetry(sessionId).then(
-            (retried) => {
-              if (!retried) {
-                console.info(
-                  "[AgentStore] Compact-and-retry not possible, falling back to Chat mode",
+            (outcome) => {
+              if (outcome === "failed_catastrophic") {
+                console.error(
+                  "[AgentStore] Compaction failed catastrophically — falling back to Chat",
                 );
                 setState("sessions", sessionId, "promptTooLong", true);
                 this.addErrorMessage(sessionId, event.data.error);
                 this.acceptRateLimitFallback().catch((err) => {
                   console.error("[AgentStore] Auto-failover failed:", err);
                 });
+              } else if (outcome === "skipped_nothing_to_compact") {
+                console.warn(
+                  "[AgentStore] Compaction skipped (nothing to compact). Likely a single oversized prompt — surfacing error to user without Chat fallback.",
+                );
+                this.addErrorMessage(
+                  sessionId,
+                  "Your last message is too large for this agent's context window. Try shortening it, attaching files instead of pasting content, or starting a new thread.",
+                );
               }
-              return retried;
+              return outcome;
             },
           );
           setState(
@@ -4107,10 +4202,10 @@ Structured summary:`;
         );
         setState("sessions", sessionId, "promptTooLongHandled", true);
         const compactPromise = this.compactAndRetry(sessionId).then(
-          (retried) => {
-            if (!retried) {
-              console.info(
-                "[AgentStore] Compact-and-retry not possible, falling back to Chat mode",
+          (outcome) => {
+            if (outcome === "failed_catastrophic") {
+              console.error(
+                "[AgentStore] Compaction failed catastrophically from streamed content — falling back to Chat",
               );
               setState("sessions", sessionId, "promptTooLong", true);
               this.acceptRateLimitFallback().catch((err) => {
@@ -4119,8 +4214,16 @@ Structured summary:`;
                   err,
                 );
               });
+            } else if (outcome === "skipped_nothing_to_compact") {
+              console.warn(
+                "[AgentStore] Compaction skipped for streamed content — single prompt too large",
+              );
+              this.addErrorMessage(
+                sessionId,
+                "Your last message is too large for this agent's context window. Try shortening it, attaching files instead of pasting content, or starting a new thread.",
+              );
             }
-            return retried;
+            return outcome;
           },
         );
         setState("sessions", sessionId, "compactRetryPromise", compactPromise);


### PR DESCRIPTION
## Summary
Fixes [#1597](https://github.com/serenorg/seren-desktop/issues/1597) — three interlocking persistence bugs in agent threads (Seren/Claude/Codex):

- **Permission Mode + Agent Model** now persist per-conversation in SQLite and re-apply on spawn/resume/compaction (new `agent_permission_mode` column + forward migration; `setPermissionMode` mirrors `setModel`'s persistence; `resumeAgentConversation` + `spawnSession` thread `initialModelId` / `initialPermissionMode` end-to-end).
- **Chat input history** now lives in a dedicated `input_history` table (capped 200 per conversation) decoupled from `session.messages`. Up-arrow recall survives thread switches, compaction (which drops compacted user messages), and app restarts — works identically in `ChatContent.tsx` and `AgentChat.tsx`.
- **Compaction failover** no longer silently falls back to Seren Chat on non-catastrophic outcomes. `compactAgentConversation` returns a typed `CompactionOutcome` and the two auto-fallback call sites only fire `acceptRateLimitFallback` on `failed_catastrophic`. `skipped_nothing_to_compact` (a single oversized prompt) now surfaces a clear error to the user instead of bouncing them to Chat. The catastrophic safety net is preserved intact.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib services::database::tests` — 10/10 pass, including two new tests covering the `agent_permission_mode` column round-trip and the ALTER TABLE migration against a pre-existing DB.
- [x] `pnpm test` — 336/336 vitest tests pass.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm lint` — no new errors introduced (pre-existing warnings unchanged).
- [x] `pnpm tauri dev` — compiles and launches locally (Vite ready, cargo Finished, Seren binary running).
- [ ] Manual macOS smoke test: set permission mode + model on a Claude thread, switch threads and back, restart app — values persist.
- [ ] Manual macOS smoke test: send messages, switch threads, press up-arrow — history recalled. Trigger compaction — history survives.
- [ ] Manual macOS smoke test: simulate prompt-too-long with `messages <= preserveCount` — confirms error message shown instead of Chat fallback.
- [ ] Windows functional test via SSH to `Administrator@98.82.19.35` (pending confirmation).

## Scope notes
- Bundled three bugs in one issue + PR because they share an implementation surface (state-hydration path through `spawnSession`).
- Rate-limit auto-fallback path intentionally left untouched — compaction cannot help with rate limits, so always-fallback is correct there.
- Test coverage stays minimal per CLAUDE.md ("critical functionality only"): schema/migration tests for the data-layer invariants; no UI or mocked-behavior tests.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
