### PR TITLE
fix(updater): skip production update check on dev builds (#1599)

### DIFF
--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -38,11 +38,32 @@ let initialized = false;
 
 const UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 
+/** True when we must not hit the production update channel.
+ *
+ * Why: `pnpm tauri dev` builds the binary with whatever version is in
+ * `src-tauri/tauri.conf.json` (currently a placeholder). The release workflow
+ * rewrites that file from the git tag before packaging, so the shipped binary
+ * always carries the real semver, but dev builds don't. If the updater runs
+ * in dev it compares the placeholder against a real latest.json on R2 and
+ * surfaces a spurious "Update available" banner every 15 minutes. Worse,
+ * clicking Install would download + apply a production artifact on top of an
+ * in-progress dev checkout.
+ */
+function isDevRuntime(): boolean {
+  return import.meta.env.DEV === true;
+}
+
 async function initUpdater(): Promise<void> {
   if (initialized) return;
   initialized = true;
 
   if (!isTauriRuntime()) {
+    setState({ status: "unsupported" });
+    return;
+  }
+
+  if (isDevRuntime()) {
+    console.log("[Updater] Dev build — skipping update check");
     setState({ status: "unsupported" });
     return;
   }


### PR DESCRIPTION
## Summary
Closes [#1599](https://github.com/serenorg/seren-desktop/issues/1599). Gates `updaterStore.initUpdater()` on `import.meta.env.DEV` so `pnpm tauri dev` no longer hits the production R2 updater channel.

**My original issue diagnosis was wrong** ([correction comment](https://github.com/serenorg/seren-desktop/issues/1599#issuecomment-4276794830)): v3.14.1 is a legitimate tag, the R2 `latest.json` is well-formed with real signed artifacts for all four platforms, and the release workflow correctly rewrites `tauri.conf.json` version from the git tag at build time. The real bug is purely dev-side — the committed `"1.3.52"` placeholder in `tauri.conf.json` doesn't get substituted in `pnpm tauri dev`, so the dev binary genuinely is at 1.3.52, the updater correctly reports "Update available: 3.14.1", and the dev user sees noise every 15 minutes.

## Why gate at `initUpdater` rather than `checkForUpdates`
- `initUpdater` is the only caller that runs automatically (App boot + 15-min interval).
- `checkForUpdates` is also used manually from AboutDialog's "Check for updates" button. That button is already disabled when `status === "unsupported"`, which we now set in dev, so the UI stays consistent without a second gate.
- Leaving the exported `checkForUpdates` un-gated means someone can still call it explicitly to exercise the updater path locally (useful for QA testing the install flow against a staging R2 endpoint), without shotgunning a second layer of dev-guards into every entry point.

## Behavior change
- **Dev (`pnpm tauri dev`)**: status goes straight to `"unsupported"`; no `check()` call, no banner, no 15-minute recheck, no titlebar pill, AboutDialog update button disabled.
- **Production (packaged release)**: unchanged — `import.meta.env.DEV` is false, `initUpdater` runs the full flow.

## Test plan
- [x] `pnpm biome check src/stores/updater.store.ts` — clean.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm test` — 336/336 vitest pass.
- [ ] Manual: `pnpm tauri dev` → confirm no "Update available" banner, AboutDialog shows update button disabled.
- [ ] Manual (later, against a real release build): confirm update check still fires in production.

## Scope notes
- No test added. Gate is a single `import.meta.env.DEV` branch. Unit-testing it would require mocking the Vite env, which CLAUDE.md forbids ("NEVER test mocked behavior"). Existing 336 vitest tests verify no regression in surrounding code.
- Did NOT bump the `tauri.conf.json` placeholder to 3.14.1. Bumping it would help a hypothetical "someone packages the app locally outside CI" scenario, but it adds a per-release maintenance burden (we'd have to bump it every release or it goes stale again). The dev-gate alone covers the actual reported symptom.
- Did NOT add a tag-vs-tauri.conf.json CI guard as originally proposed in the issue. That guard was predicated on the phantom-tag hypothesis, which turned out to be wrong — tags are fine.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
