### PR TITLE
chore(gitignore): ignore Claude Code scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ yarn.lock
 
 # Claude Code local settings (per-developer)
 .claude/settings.local.json
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
Adds .claude/scheduled_tasks.lock to .gitignore. Follow-up from #1600 cleanup — the lockfile is per-session runtime state written by Claude Code to serialize scheduled tasks; it was showing up as untracked noise in every status.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com