### PR TITLE
feat(agent): wire Claude Code --effort to AgentEffortSelector

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -9,6 +9,12 @@ import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
+import {
+  buildEffortArgs,
+  buildEffortConfigOption,
+  normalizeEffort,
+  DEFAULT_CLAUDE_EFFORT,
+} from "./effort.mjs";
 
 /**
  * Resolve the full path to the `claude` binary.
@@ -364,6 +370,7 @@ function buildSessionStatus(session, status = session.status) {
         }
       : {}),
     modes: buildModeState(session.currentModeId),
+    configOptions: [buildEffortConfigOption(session.reasoningEffort)],
   };
 }
 
@@ -645,6 +652,7 @@ function buildClaudeArgs({
   forkSession,
   preferredModel,
   mcpConfigJson,
+  effort,
 }) {
   const args = [
     "--output-format",
@@ -660,6 +668,7 @@ function buildClaudeArgs({
     "stdio",
     // Allow switching into bypassPermissions later from the UI footer.
     "--allow-dangerously-skip-permissions",
+    ...buildEffortArgs(effort),
   ];
 
   if (mcpConfigJson) {
@@ -1367,6 +1376,7 @@ export function createClaudeRuntime({ emit }) {
     currentModeId = "default",
     mcpConfigJson = null,
     spawnEnv = {},
+    reasoningEffort = DEFAULT_CLAUDE_EFFORT,
   }) {
     return {
       id: sessionId,
@@ -1391,6 +1401,8 @@ export function createClaudeRuntime({ emit }) {
       currentModeId,
       mcpConfigJson,
       spawnEnv,
+      reasoningEffort:
+        normalizeEffort(reasoningEffort) ?? DEFAULT_CLAUDE_EFFORT,
     };
   }
 
@@ -1416,6 +1428,7 @@ export function createClaudeRuntime({ emit }) {
       mcpServers,
       approvalPolicy,
       timeoutSecs,
+      reasoningEffort,
     } = params;
 
     const sessionId = localSessionId ?? randomUUID();
@@ -1432,6 +1445,8 @@ export function createClaudeRuntime({ emit }) {
     const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
     const claudeBin = resolveClaudeBinary();
     const extendedPath = buildExtendedPath();
+    const effectiveEffort =
+      normalizeEffort(reasoningEffort) ?? DEFAULT_CLAUDE_EFFORT;
     const claudeArgs = buildClaudeArgs({
       sessionId: remoteSessionId,
       resumeSessionId: resumeAgentSessionId ?? null,
@@ -1442,6 +1457,7 @@ export function createClaudeRuntime({ emit }) {
       // Users can switch via the picker; resumed sessions use session.currentModelId.
       preferredModel: "claude-opus-4-5",
       mcpConfigJson: mcpConfig.claudeMcpConfigJson,
+      effort: effectiveEffort,
     });
     const processHandle = spawn(
       claudeBin,
@@ -1492,6 +1508,7 @@ export function createClaudeRuntime({ emit }) {
       currentModeId: "default",
       mcpConfigJson: mcpConfig.claudeMcpConfigJson,
       spawnEnv: mcpConfig.childEnv,
+      reasoningEffort: effectiveEffort,
     });
 
     sessions.set(sessionId, session);
@@ -1765,7 +1782,23 @@ export function createClaudeRuntime({ emit }) {
     emit("provider://session-status", buildSessionStatus(session));
   }
 
-  async function setConfigOption() {
+  async function setConfigOption({ sessionId, configId, valueId }) {
+    if (configId !== "reasoning_effort") {
+      return null;
+    }
+    const session = sessions.get(sessionId);
+    if (!session) {
+      return null;
+    }
+    const normalized = normalizeEffort(valueId);
+    if (!normalized) {
+      throw new Error(`Unsupported reasoning effort: ${valueId}`);
+    }
+    session.reasoningEffort = normalized;
+    // Re-emit session status so AgentEffortSelector reflects the new value.
+    // The --effort flag is spawn-time; this change applies to the NEXT session
+    // spawn (resume or fork), not the current CLI process.
+    emit("provider://session-status", buildSessionStatus(session));
     return null;
   }
 
@@ -1794,6 +1827,7 @@ export function createClaudeRuntime({ emit }) {
       forkSession: true,
       preferredModel: session.currentModelId,
       mcpConfigJson: session.mcpConfigJson,
+      effort: session.reasoningEffort,
     });
     const processHandle = spawn(
       claudeBin,
@@ -1833,6 +1867,7 @@ export function createClaudeRuntime({ emit }) {
       currentModeId: session.currentModeId,
       mcpConfigJson: session.mcpConfigJson,
       spawnEnv: session.spawnEnv,
+      reasoningEffort: session.reasoningEffort,
     });
     const tempSessions = new Map([[tempSession.id, tempSession]]);
     attachProcessListeners(silentEmit, tempSessions, tempSession, new Map());

--- a/bin/browser-local/effort.mjs
+++ b/bin/browser-local/effort.mjs
@@ -1,0 +1,33 @@
+// ABOUTME: Pure helpers for Claude Code reasoning effort.
+// ABOUTME: Extracted so buildClaudeArgs mapping can be unit-tested without spawning a process.
+
+export const CLAUDE_EFFORT_VALUES = ["low", "medium", "high", "xhigh"];
+export const DEFAULT_CLAUDE_EFFORT = "medium";
+
+export function normalizeEffort(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  return CLAUDE_EFFORT_VALUES.includes(trimmed) ? trimmed : null;
+}
+
+export function buildEffortArgs(effort) {
+  const normalized = normalizeEffort(effort);
+  return normalized ? ["--effort", normalized] : [];
+}
+
+export function buildEffortConfigOption(currentValue) {
+  const current = normalizeEffort(currentValue) ?? DEFAULT_CLAUDE_EFFORT;
+  return {
+    id: "reasoning_effort",
+    name: "Reasoning Effort",
+    description:
+      "Controls how much extended thinking Claude Code does. Applies to the next session.",
+    type: "select",
+    currentValue: current,
+    options: CLAUDE_EFFORT_VALUES.map((value) => ({
+      value,
+      name: value,
+      description: null,
+    })),
+  };
+}

--- a/src/components/chat/AgentEffortSelector.tsx
+++ b/src/components/chat/AgentEffortSelector.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Dropdown component for selecting agent reasoning effort.
-// ABOUTME: Currently targets Codex's `reasoning_effort` session config option when available.
+// ABOUTME: Renders whenever the active session exposes a reasoning_effort select config option (Codex, Claude Code).
 
 import type { Component } from "solid-js";
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -294,6 +294,7 @@ export async function spawnAgent(
   resumeAgentSessionId?: string,
   timeoutSecs?: number,
   mcpServers?: McpServerConfig[],
+  reasoningEffort?: string,
 ): Promise<AgentSessionInfo> {
   return invokeProvider<AgentSessionInfo>(
     "provider_spawn",
@@ -309,6 +310,7 @@ export async function spawnAgent(
       networkEnabled: networkEnabled ?? null,
       timeoutSecs: timeoutSecs ?? null,
       mcpServers: mcpServers ?? null,
+      reasoningEffort: reasoningEffort ?? null,
     },
     { timeoutMs: 120_000 },
   );

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1369,6 +1369,11 @@ export const agentStore = {
           terminatedSessionIds.delete(localSessionId);
         }
 
+        const reasoningEffort =
+          resolvedAgentType === "claude-code"
+            ? settingsStore.settings.claudeReasoningEffort
+            : undefined;
+
         console.log("[AgentStore] Spawning agent process...");
         const info = await providerService.spawnAgent(
           resolvedAgentType,
@@ -1382,6 +1387,7 @@ export const agentStore = {
           resumeAgentSessionId,
           timeoutSecs,
           enabledMcpServers,
+          reasoningEffort,
         );
         console.log("[AgentStore] Spawn result:", info);
 
@@ -2959,6 +2965,13 @@ Structured summary:`;
           return o;
         });
       });
+      // Persist Claude Code reasoning effort so the next spawn uses the new
+      // value. Claude Code's --effort flag is spawn-time; mid-session changes
+      // don't affect the running CLI, only the next session that starts.
+      const agentType = state.sessions[sessionId]?.info.agentType;
+      if (agentType === "claude-code" && configId === "reasoning_effort") {
+        settingsStore.set("claudeReasoningEffort", valueId);
+      }
     } catch (error) {
       console.error("[AgentStore] Failed to set config option:", error);
     }

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -132,6 +132,12 @@ export interface Settings {
   agentSearchEnabled: boolean;
   agentNetworkEnabled: boolean;
   agentAutoApproveReads: boolean;
+  /**
+   * Reasoning effort passed to the Claude Code CLI via --effort on next spawn.
+   * Values: "low" | "medium" | "high" | "xhigh". Changes do not affect
+   * running sessions; they apply when the next session starts.
+   */
+  claudeReasoningEffort: string;
 
   // Voice settings
   voiceAutoSubmit: boolean;
@@ -227,6 +233,7 @@ const DEFAULT_SETTINGS: Settings = {
   agentSearchEnabled: true,
   agentNetworkEnabled: true,
   agentAutoApproveReads: true,
+  claudeReasoningEffort: "medium",
   // Voice
   voiceAutoSubmit: true,
   // General

--- a/tests/unit/claude-effort.test.ts
+++ b/tests/unit/claude-effort.test.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Critical tests for Claude Code reasoning effort → --effort CLI arg mapping.
+// ABOUTME: Guards against invalid values reaching the spawn and keeps the dropdown options honest.
+
+import { describe, expect, it } from "vitest";
+
+const effortModulePath = new URL(
+  "../../bin/browser-local/effort.mjs",
+  import.meta.url,
+).href;
+const mod = await import(/* @vite-ignore */ effortModulePath);
+
+const {
+  CLAUDE_EFFORT_VALUES,
+  DEFAULT_CLAUDE_EFFORT,
+  normalizeEffort,
+  buildEffortArgs,
+  buildEffortConfigOption,
+} = mod;
+
+describe("normalizeEffort", () => {
+  it.each(["low", "medium", "high", "xhigh"] as const)(
+    "accepts %s",
+    (value) => {
+      expect(normalizeEffort(value)).toBe(value);
+    },
+  );
+
+  it("lowercases + trims valid values", () => {
+    expect(normalizeEffort("  HIGH  ")).toBe("high");
+  });
+
+  const invalidCases: Array<{ value: unknown; note: string }> = [
+    { value: "minimal", note: "rejected to avoid a confusing translation to low" },
+    { value: "max", note: "not in seren's selector set" },
+    { value: "", note: "empty string" },
+    { value: "garbage", note: "unknown" },
+    { value: null, note: "non-string" },
+    { value: undefined, note: "non-string" },
+    { value: 42, note: "non-string" },
+  ];
+  it.each(invalidCases)("rejects $value ($note)", ({ value }) => {
+    expect(normalizeEffort(value as string)).toBeNull();
+  });
+});
+
+describe("buildEffortArgs", () => {
+  it("returns --effort <value> for valid values", () => {
+    expect(buildEffortArgs("high")).toEqual(["--effort", "high"]);
+  });
+
+  it("returns empty array for invalid values — never leaks a bad --effort to the CLI", () => {
+    expect(buildEffortArgs("minimal")).toEqual([]);
+    expect(buildEffortArgs("")).toEqual([]);
+    expect(buildEffortArgs(null as unknown as string)).toEqual([]);
+    expect(buildEffortArgs(undefined as unknown as string)).toEqual([]);
+  });
+});
+
+describe("buildEffortConfigOption", () => {
+  it("exposes exactly the four values seren supports for Claude Code", () => {
+    const opt = buildEffortConfigOption("medium");
+    expect(opt.options.map((o: { value: string }) => o.value)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
+  it("falls back to the default when currentValue is invalid", () => {
+    expect(buildEffortConfigOption("minimal").currentValue).toBe(
+      DEFAULT_CLAUDE_EFFORT,
+    );
+  });
+
+  it("has id 'reasoning_effort' and type 'select' so AgentEffortSelector picks it up", () => {
+    const opt = buildEffortConfigOption("medium");
+    expect(opt.id).toBe("reasoning_effort");
+    expect(opt.type).toBe("select");
+  });
+
+  it("default matches the setting default", () => {
+    expect(DEFAULT_CLAUDE_EFFORT).toBe("medium");
+  });
+
+  it("value set matches what the CLI accepts (lock against drift)", () => {
+    expect(CLAUDE_EFFORT_VALUES).toEqual(["low", "medium", "high", "xhigh"]);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes [#1597](https://github.com/serenorg/seren-desktop/issues/1597) — three interlocking persistence bugs in agent threads (Seren/Claude/Codex):

- **Permission Mode + Agent Model** now persist per-conversation in SQLite and re-apply on spawn/resume/compaction (new `agent_permission_mode` column + forward migration; `setPermissionMode` mirrors `setModel`'s persistence; `resumeAgentConversation` + `spawnSession` thread `initialModelId` / `initialPermissionMode` end-to-end).
- **Chat input history** now lives in a dedicated `input_history` table (capped 200 per conversation) decoupled from `session.messages`. Up-arrow recall survives thread switches, compaction (which drops compacted user messages), and app restarts — works identically in `ChatContent.tsx` and `AgentChat.tsx`.
- **Compaction failover** no longer silently falls back to Seren Chat on non-catastrophic outcomes. `compactAgentConversation` returns a typed `CompactionOutcome` and the two auto-fallback call sites only fire `acceptRateLimitFallback` on `failed_catastrophic`. `skipped_nothing_to_compact` (a single oversized prompt) now surfaces a clear error to the user instead of bouncing them to Chat. The catastrophic safety net is preserved intact.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib services::database::tests` — 10/10 pass, including two new tests covering the `agent_permission_mode` column round-trip and the ALTER TABLE migration against a pre-existing DB.
- [x] `pnpm test` — 336/336 vitest tests pass.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm lint` — no new errors introduced (pre-existing warnings unchanged).
- [x] `pnpm tauri dev` — compiles and launches locally (Vite ready, cargo Finished, Seren binary running).
- [ ] Manual macOS smoke test: set permission mode + model on a Claude thread, switch threads and back, restart app — values persist.
- [ ] Manual macOS smoke test: send messages, switch threads, press up-arrow — history recalled. Trigger compaction — history survives.
- [ ] Manual macOS smoke test: simulate prompt-too-long with `messages <= preserveCount` — confirms error message shown instead of Chat fallback.
- [ ] Windows functional test via SSH to `Administrator@98.82.19.35` (pending confirmation).

## Scope notes
- Bundled three bugs in one issue + PR because they share an implementation surface (state-hydration path through `spawnSession`).
- Rate-limit auto-fallback path intentionally left untouched — compaction cannot help with rate limits, so always-fallback is correct there.
- Test coverage stays minimal per CLAUDE.md ("critical functionality only"): schema/migration tests for the data-layer invariants; no UI or mocked-behavior tests.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
