### PR TITLE
fix(agent): report peak-per-turn context, not averaged (#1611)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -15,6 +15,7 @@ import {
   normalizeEffort,
   DEFAULT_CLAUDE_EFFORT,
 } from "./effort.mjs";
+import { updatePeakInputTokens } from "./usage.mjs";
 
 /**
  * Resolve the full path to the `claude` binary.
@@ -704,12 +705,13 @@ function buildClaudeArgs({
   return args;
 }
 
-function buildPromptMeta(result) {
+function buildPromptMeta(result, peakInputTokens) {
   const usage = result?.usage ?? {};
-  // result.usage reports CUMULATIVE tokens across all iterations (tool
-  // call round-trips) in this prompt. For autocompact we need the
-  // approximate context window fill — the input for a single API call.
-  // Divide cumulative total by num_turns to approximate per-turn usage.
+  // Prefer per-turn peak tracked from assistant message usage events — the
+  // authoritative per-API-call input size. The final turn in a multi-turn
+  // prompt (many tool calls) is typically the largest; the averaged value
+  // that result.usage implies hides that peak and lets the gauge read
+  // comfortably while the next turn overflows. See #1611.
   const rawInput =
     typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
   const cacheCreation =
@@ -725,8 +727,15 @@ function buildPromptMeta(result) {
     typeof result?.num_turns === "number" && result.num_turns > 0
       ? result.num_turns
       : 1;
-  const inputTokens =
+  // Fallback to the old averaged math if the runtime never observed a
+  // per-turn usage event (e.g. Anthropic stops emitting usage in assistant
+  // payloads). Never regress below current behavior.
+  const averagedInput =
     cumulativeInput > 0 ? Math.round(cumulativeInput / numTurns) : undefined;
+  const inputTokens =
+    typeof peakInputTokens === "number" && peakInputTokens > 0
+      ? peakInputTokens
+      : averagedInput;
   const outputTokens =
     typeof usage.output_tokens === "number" ? usage.output_tokens : undefined;
 
@@ -1109,6 +1118,13 @@ function handleAssistantMessage(emit, session, payload) {
   const sawStreamedAssistant =
     session.currentPrompt != null && session.currentPromptHasChunks === true;
 
+  // Track the largest per-turn input across tool-call iterations. message.usage
+  // is the authoritative per-API-call count from Anthropic — see #1611.
+  session.peakInputTokens = updatePeakInputTokens(
+    session.peakInputTokens,
+    message.usage,
+  );
+
   if (typeof payload.session_id === "string") {
     session.agentSessionId = payload.session_id;
   }
@@ -1213,11 +1229,14 @@ function handleStreamEvent(emit, session, payload) {
 function handleResult(emit, session, payload) {
   session.status = "ready";
 
+  const peakInputTokens = session.peakInputTokens ?? 0;
   emit("provider://prompt-complete", {
     sessionId: session.id,
     stopReason: payload?.stop_reason ?? (payload?.is_error ? "error" : "end_turn"),
-    ...buildPromptMeta(payload),
+    ...buildPromptMeta(payload, peakInputTokens),
   });
+  // Reset for the next prompt. Peak is prompt-scoped, not session-scoped.
+  session.peakInputTokens = 0;
   emit("provider://session-status", buildSessionStatus(session, "ready"));
 
   if (payload?.is_error) {
@@ -1403,6 +1422,9 @@ export function createClaudeRuntime({ emit }) {
       spawnEnv,
       reasoningEffort:
         normalizeEffort(reasoningEffort) ?? DEFAULT_CLAUDE_EFFORT,
+      // Peak per-turn input tokens across the current prompt's tool-call
+      // iterations. Reset at handleResult. See #1611.
+      peakInputTokens: 0,
     };
   }
 

--- a/bin/browser-local/usage.mjs
+++ b/bin/browser-local/usage.mjs
@@ -1,0 +1,31 @@
+// ABOUTME: Pure helpers for Claude Code per-turn token usage tracking.
+// ABOUTME: Lets the runtime report peak-per-turn context instead of the misleading average.
+
+function nonNegativeNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : 0;
+}
+
+/**
+ * Total input tokens processed by the model in a single API turn.
+ * Includes non-cached, cache-creation, and cache-read tokens, because all three
+ * count toward the model's context window — only billing differs.
+ */
+export function perTurnInputTokens(usage) {
+  if (!usage || typeof usage !== "object") return 0;
+  return (
+    nonNegativeNumber(usage.input_tokens) +
+    nonNegativeNumber(usage.cache_creation_input_tokens) +
+    nonNegativeNumber(usage.cache_read_input_tokens)
+  );
+}
+
+/**
+ * Returns the greater of a prior peak and the per-turn input for a new message.
+ */
+export function updatePeakInputTokens(prevPeak, usage) {
+  const current = perTurnInputTokens(usage);
+  const prior = nonNegativeNumber(prevPeak);
+  return current > prior ? current : prior;
+}

--- a/tests/unit/claude-per-turn-usage.test.ts
+++ b/tests/unit/claude-per-turn-usage.test.ts
@@ -1,0 +1,64 @@
+// ABOUTME: Critical tests for #1611 — peak-per-turn input token tracking.
+// ABOUTME: Guards the context gauge + auto-compact threshold against averaged undercounts.
+
+import { describe, expect, it } from "vitest";
+
+const usageModulePath = new URL(
+  "../../bin/browser-local/usage.mjs",
+  import.meta.url,
+).href;
+const { perTurnInputTokens, updatePeakInputTokens } = await import(
+  /* @vite-ignore */ usageModulePath
+);
+
+describe("perTurnInputTokens", () => {
+  it("sums input + cache_creation + cache_read because all three count toward the context window", () => {
+    expect(
+      perTurnInputTokens({
+        input_tokens: 100,
+        cache_creation_input_tokens: 2000,
+        cache_read_input_tokens: 95000,
+        output_tokens: 500,
+      }),
+    ).toBe(97100);
+  });
+
+  it.each([
+    { value: null, note: "null" },
+    { value: undefined, note: "missing" },
+    { value: "garbage", note: "non-object" },
+    { value: {}, note: "empty object" },
+    { value: { input_tokens: -5 }, note: "negative value" },
+    { value: { input_tokens: "100" }, note: "string value" },
+    { value: { input_tokens: NaN }, note: "NaN" },
+  ])("returns 0 for $note (fail-closed)", ({ value }) => {
+    expect(perTurnInputTokens(value as unknown as Record<string, number>)).toBe(
+      0,
+    );
+  });
+});
+
+describe("updatePeakInputTokens", () => {
+  it("retains the peak when later turns are smaller — the whole point of #1611", () => {
+    // Simulate a prompt with 3 tool-call turns: early turn large, later turns
+    // smaller. Averaging would hide turn 2; peak tracking must keep it.
+    let peak = 0;
+    peak = updatePeakInputTokens(peak, { input_tokens: 50_000 });
+    peak = updatePeakInputTokens(peak, { input_tokens: 180_000 });
+    peak = updatePeakInputTokens(peak, { input_tokens: 40_000 });
+    expect(peak).toBe(180_000);
+  });
+
+  it("handles missing usage without dropping the prior peak", () => {
+    expect(updatePeakInputTokens(95_000, null)).toBe(95_000);
+    expect(updatePeakInputTokens(95_000, undefined)).toBe(95_000);
+  });
+
+  it("treats a non-numeric prior peak as zero (defensive)", () => {
+    expect(
+      updatePeakInputTokens(undefined as unknown as number, {
+        input_tokens: 1000,
+      }),
+    ).toBe(1000);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1611 — the context gauge and auto-compact threshold both read a per-turn *average* of input tokens instead of the peak. On prompts with many tool-call round-trips, the last turn is the largest; the averaged value hid that peak, so the gauge showed comfortable headroom (e.g., 48%) while the next user turn overflowed Anthropic's 200K context limit with "Prompt is too long".

## What changed

- **`bin/browser-local/usage.mjs`** (new): pure helpers `perTurnInputTokens(usage)` and `updatePeakInputTokens(prev, usage)`.
- **`bin/browser-local/claude-runtime.mjs`**: track `session.peakInputTokens` in `handleAssistantMessage` using Anthropic's authoritative `message.usage` (which includes `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`). Reset to 0 in `handleResult` so each prompt is scoped independently.
- **`buildPromptMeta(result, peakInputTokens)`**: uses peak when > 0, falls back to the old averaged math otherwise — no regression if Anthropic stops emitting per-turn usage.
- **`tests/unit/claude-per-turn-usage.test.ts`** (new): 11 critical-only tests — sum math, fail-closed on invalid inputs, peak retention across decreasing turns.

## Why this fixes both the gauge and auto-compact in one change

Both consumers read `meta.usage.input_tokens`:
- `src/stores/agent.store.ts:3302-3309` — gauge display
- `src/stores/agent.store.ts:3352-3369` — auto-compact threshold check

Changing the runtime's emitted value fixes both at once. No UI changes required.

## Test plan

- [x] `pnpm test` — 366/366 pass (11 new + 355 existing).
- [x] `pnpm check` — no new errors/warnings; 6 errors / 42 warnings match pre-existing baseline.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- [x] `pnpm tauri dev` — to verify end-to-end.

## Out of scope (follow-ups if needed)

- Mid-prompt "approaching 85%" warning UX.
- Exposing both peak and average in the gauge tooltip.
- Changing the default `autoCompactThreshold` from 85%.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
