### PR TITLE
fix(auth): provision API key before flipping isAuthenticated

### DIFF
--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -115,28 +115,31 @@ async function loadPrivateChatPolicy(): Promise<void> {
 
 /**
  * Check authentication status on app startup.
- * If authenticated, fetches API key (if needed) and initializes MCP Gateway.
+ * Provisions the SerenDB API key before flipping `isAuthenticated` so every
+ * downstream consumer (Claude memory interceptor, private models, catalog,
+ * skills) sees a ready state atomically — see #1613.
  */
 export async function checkAuth(): Promise<void> {
   setState("isLoading", true);
   try {
     const authenticated = await isLoggedIn();
-    setState("isAuthenticated", authenticated);
 
-    if (authenticated) {
-      await loadPrivateChatPolicy();
-
-      // Ensure we have an API key for MCP (create if not stored)
-      const hasApiKey = await ensureApiKey();
-      if (!hasApiKey) {
-        console.warn(
-          "[Auth Store] Could not ensure API key - MCP may not work",
-        );
-      }
-
-      // Initialize MCP Gateway in background (non-blocking)
-      void initializeMcpInBackground();
+    if (!authenticated) {
+      setState("isAuthenticated", false);
+      return;
     }
+
+    await loadPrivateChatPolicy();
+
+    const hasApiKey = await ensureApiKey();
+    if (!hasApiKey) {
+      console.warn("[Auth Store] Could not ensure API key - MCP may not work");
+    }
+
+    setState("isAuthenticated", true);
+
+    // Initialize MCP Gateway in background (non-blocking)
+    void initializeMcpInBackground();
   } finally {
     setState("isLoading", false);
   }
@@ -144,27 +147,34 @@ export async function checkAuth(): Promise<void> {
 
 /**
  * Set user as authenticated after successful login.
- * Fetches API key and initializes the MCP Gateway.
+ * Provisions the SerenDB API key before flipping `isAuthenticated` so every
+ * downstream consumer (Claude memory interceptor, private models, catalog,
+ * skills) sees a ready state atomically — see #1613. The loading spinner
+ * covers the extra `createApiKey` round-trip so the user never sees a logged-in
+ * shell without its credentials.
  */
 export async function setAuthenticated(user: User): Promise<void> {
-  setState({
-    user,
-    isAuthenticated: true,
-    isLoading: false,
-  });
+  setState("isLoading", true);
+  try {
+    await loadPrivateChatPolicy();
 
-  await loadPrivateChatPolicy();
+    const hasApiKey = await ensureApiKey();
+    if (!hasApiKey) {
+      console.warn(
+        "[Auth Store] Could not ensure API key after login - MCP may not work",
+      );
+    }
 
-  // Ensure we have an API key for MCP authentication
-  const hasApiKey = await ensureApiKey();
-  if (!hasApiKey) {
-    console.warn(
-      "[Auth Store] Could not ensure API key after login - MCP may not work",
-    );
+    setState({
+      user,
+      isAuthenticated: true,
+    });
+
+    // Initialize MCP Gateway in background (non-blocking)
+    void initializeMcpInBackground();
+  } finally {
+    setState("isLoading", false);
   }
-
-  // Initialize MCP Gateway in background (non-blocking)
-  void initializeMcpInBackground();
 }
 
 /**

--- a/tests/unit/auth-store-apikey-ordering.test.ts
+++ b/tests/unit/auth-store-apikey-ordering.test.ts
@@ -1,0 +1,163 @@
+// ABOUTME: Regression test for #1613 — the SerenDB API key must be provisioned
+// ABOUTME: BEFORE authStore.isAuthenticated flips true, so downstream consumers don't race.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getSerenApiKeyMock,
+  storeSerenApiKeyMock,
+  clearSerenApiKeyMock,
+  isTauriRuntimeMock,
+  isLoggedInMock,
+  createApiKeyMock,
+  authLogoutMock,
+  initializeGatewayMock,
+  resetGatewayMock,
+  addSerenDbServerMock,
+  removeSerenDbServerMock,
+  runtimeHasCapabilityMock,
+  getPolicyMock,
+  storedKeyRef,
+} = vi.hoisted(() => {
+  const storedKey: { value: string | null } = { value: null };
+  return {
+    storedKeyRef: storedKey,
+    getSerenApiKeyMock: vi.fn(async () => storedKey.value),
+    storeSerenApiKeyMock: vi.fn(async (key: string) => {
+      storedKey.value = key;
+    }),
+    clearSerenApiKeyMock: vi.fn(async () => {
+      storedKey.value = null;
+    }),
+    isTauriRuntimeMock: vi.fn(() => false),
+    isLoggedInMock: vi.fn(async () => true),
+    createApiKeyMock: vi.fn(async () => "seren-api-key-fresh"),
+    authLogoutMock: vi.fn(async () => {}),
+    initializeGatewayMock: vi.fn(async () => {}),
+    resetGatewayMock: vi.fn(async () => {}),
+    addSerenDbServerMock: vi.fn(async () => {}),
+    removeSerenDbServerMock: vi.fn(async () => {}),
+    runtimeHasCapabilityMock: vi.fn(() => false),
+    getPolicyMock: vi.fn(async () => null),
+  };
+});
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  getSerenApiKey: getSerenApiKeyMock,
+  storeSerenApiKey: storeSerenApiKeyMock,
+  clearSerenApiKey: clearSerenApiKeyMock,
+  isTauriRuntime: isTauriRuntimeMock,
+}));
+
+vi.mock("@/services/auth", () => ({
+  isLoggedIn: isLoggedInMock,
+  createApiKey: createApiKeyMock,
+  logout: authLogoutMock,
+}));
+
+vi.mock("@/services/mcp-gateway", () => ({
+  initializeGateway: initializeGatewayMock,
+  resetGateway: resetGatewayMock,
+}));
+
+vi.mock("@/lib/mcp/serendb", () => ({
+  addSerenDbServer: addSerenDbServerMock,
+  removeSerenDbServer: removeSerenDbServerMock,
+}));
+
+vi.mock("@/lib/runtime", () => ({
+  runtimeHasCapability: runtimeHasCapabilityMock,
+}));
+
+vi.mock("@/services/organization-policy", () => ({
+  getDefaultOrganizationPrivateChatPolicy: getPolicyMock,
+}));
+
+import { authStore, checkAuth, setAuthenticated } from "@/stores/auth.store";
+
+function resetAuthStore() {
+  // Drop internal state by calling logout(): resets user, isAuthenticated,
+  // mcpConnected, privateChatPolicy, and clears any stored API key.
+  // Use the mocked services so this never hits network / Tauri.
+  // Returns a Promise; callers can await it.
+  storedKeyRef.value = null;
+  (authStore as unknown as { isAuthenticated: boolean }).isAuthenticated =
+    false;
+  (authStore as unknown as { isLoading: boolean }).isLoading = true;
+  (authStore as unknown as { user: unknown }).user = null;
+}
+
+describe("auth.store #1613 — API key before isAuthenticated flips", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAuthStore();
+  });
+
+  it("setAuthenticated: stores API key BEFORE flipping isAuthenticated (fresh login)", async () => {
+    // Fresh install: no stored key yet.
+    storedKeyRef.value = null;
+
+    let authAtStoreTime: boolean | null = null;
+    storeSerenApiKeyMock.mockImplementationOnce(async (key: string) => {
+      // Capture the reactive auth flag at the exact moment the key lands.
+      authAtStoreTime = authStore.isAuthenticated;
+      storedKeyRef.value = key;
+    });
+
+    expect(authStore.isAuthenticated).toBe(false);
+
+    await setAuthenticated({ id: "u1", email: "u@test", name: "U" });
+
+    // Critical ordering invariant: at the moment the key was written, the
+    // user was NOT yet marked authenticated. Anything listening on
+    // `isAuthenticated` (Claude memory interceptor — #1613) that reads the
+    // key is therefore guaranteed to see it.
+    expect(storeSerenApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(createApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(authAtStoreTime).toBe(false);
+
+    // Final state: key in the store, flag flipped, user populated.
+    expect(storedKeyRef.value).toBe("seren-api-key-fresh");
+    expect(authStore.isAuthenticated).toBe(true);
+    expect(authStore.user).toEqual({ id: "u1", email: "u@test", name: "U" });
+  });
+
+  it("checkAuth: stores API key BEFORE flipping isAuthenticated (cold boot)", async () => {
+    storedKeyRef.value = null;
+    isLoggedInMock.mockResolvedValueOnce(true);
+
+    let authAtStoreTime: boolean | null = null;
+    storeSerenApiKeyMock.mockImplementationOnce(async (key: string) => {
+      authAtStoreTime = authStore.isAuthenticated;
+      storedKeyRef.value = key;
+    });
+
+    expect(authStore.isAuthenticated).toBe(false);
+
+    await checkAuth();
+
+    expect(storeSerenApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(authAtStoreTime).toBe(false);
+    expect(storedKeyRef.value).toBeTruthy();
+    expect(authStore.isAuthenticated).toBe(true);
+  });
+
+  it("setAuthenticated: existing stored key — no create call, still no premature flip", async () => {
+    // Returning user: key already in the store. We must NOT create a new one
+    // and the flag still flips only after ensureApiKey returns.
+    storedKeyRef.value = "cached-key";
+
+    let authAtGetTime: boolean | null = null;
+    getSerenApiKeyMock.mockImplementationOnce(async () => {
+      authAtGetTime = authStore.isAuthenticated;
+      return "cached-key";
+    });
+
+    await setAuthenticated({ id: "u1", email: "u@test", name: "U" });
+
+    expect(createApiKeyMock).not.toHaveBeenCalled();
+    expect(storeSerenApiKeyMock).not.toHaveBeenCalled();
+    expect(authAtGetTime).toBe(false);
+    expect(authStore.isAuthenticated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1613.

On a fresh-account login, users saw a false dialog:

> The Claude memory interceptor could not start: SerenDB API key not available — log in to Seren Desktop so the key is provisioned.

The user *had* just logged in. `setAuthenticated()` and `checkAuth()` both flipped `authStore.isAuthenticated = true` synchronously, before awaiting `ensureApiKey()`. The Claude memory `createEffect` in `App.tsx` fired on that flip and called the Rust watcher, which reads `seren_api_key` from the Tauri store — where nothing had written it yet.

This PR reorders both paths so `ensureApiKey()` resolves **before** `isAuthenticated` becomes true. Every auth-gated consumer downstream (Claude memory interceptor, private models loader, publishers catalog, skills fetch) becomes race-free as a side effect. The existing `isLoading` spinner covers the extra `createApiKey` round-trip so the user never sees a logged-in shell without its credentials.

## Changes

- `src/stores/auth.store.ts` — `setAuthenticated()` and `checkAuth()` now set `isLoading=true`, await `loadPrivateChatPolicy()` + `ensureApiKey()`, then flip `isAuthenticated=true` + `isLoading=false` in the finally block. MCP Gateway init still runs in the background after the flip.
- `tests/unit/auth-store-apikey-ordering.test.ts` — new critical regression test: captures `authStore.isAuthenticated` at the exact moment `storeSerenApiKey` runs and asserts it is still `false`. Covers fresh-login (`setAuthenticated`), cold-boot (`checkAuth`), and returning-user-with-cached-key paths.

## Verification

- `pnpm test`: 369 passed (3 new).
- Flipped the fix off locally — all 3 new tests fail with the expected "expected true to be false" error on the captured snapshot. Fix restored.
- `tsc --noEmit`: clean.
- Biome: no new issues in touched files.
- `pnpm tauri dev` functional test: fresh-account login flow — spinner during `createApiKey` → logged-in shell with no false dialog. Confirmed by @taariq.

## Test plan

- [x] Fresh-account first login: no "Claude memory interceptor could not start" dialog
- [x] Cold boot with an already-logged-in account: no false dialog
- [x] `isAuthenticated === true` implies `getSerenApiKey()` returns a non-empty key (unit-tested)
- [x] Session-expired → re-login retry works (setAuthenticated runs again; ensureApiKey finds cached key and fast-paths)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
