### PR TITLE
fix(compaction): keep pre-compaction scrollback under the summary card

### DIFF
--- a/src/components/chat/CompactedMessage.tsx
+++ b/src/components/chat/CompactedMessage.tsx
@@ -1,8 +1,8 @@
 // ABOUTME: Displays a compacted conversation summary at the top of the chat.
-// ABOUTME: Shows collapsed older messages with expand option for full summary.
+// ABOUTME: Shows collapsed older messages with expand option for full summary + original scrollback.
 
 import type { Component } from "solid-js";
-import { createSignal, Show } from "solid-js";
+import { createSignal, For, Show } from "solid-js";
 import type { CompactedSummary } from "@/stores/chat.store";
 
 interface CompactedMessageProps {
@@ -12,6 +12,7 @@ interface CompactedMessageProps {
 
 export const CompactedMessage: Component<CompactedMessageProps> = (props) => {
   const [isExpanded, setIsExpanded] = createSignal(false);
+  const [showScrollback, setShowScrollback] = createSignal(false);
 
   const formatDate = (timestamp: number): string => {
     return new Date(timestamp).toLocaleDateString(undefined, {
@@ -21,6 +22,14 @@ export const CompactedMessage: Component<CompactedMessageProps> = (props) => {
       minute: "2-digit",
     });
   };
+
+  const formatTime = (timestamp: number): string =>
+    new Date(timestamp).toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+  const scrollback = () => props.summary.preCompactionMessages ?? [];
 
   return (
     <article class="mx-3 my-2 bg-surface-1 border border-surface-3 rounded-lg overflow-hidden">
@@ -67,6 +76,58 @@ export const CompactedMessage: Component<CompactedMessageProps> = (props) => {
             Summary of previous conversation
           </div>
           <div class="whitespace-pre-wrap">{props.summary.content}</div>
+
+          <Show when={scrollback().length > 0}>
+            <button
+              type="button"
+              class="mt-3 flex items-center gap-1.5 bg-transparent border border-surface-3 text-muted-foreground px-2 py-1 rounded text-xs cursor-pointer hover:bg-surface-3 hover:text-foreground transition-colors"
+              onClick={() => setShowScrollback(!showScrollback())}
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+                class={`transition-transform ${
+                  showScrollback() ? "rotate-90" : ""
+                }`}
+              >
+                <path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z" />
+              </svg>
+              {showScrollback() ? "Hide" : "Show"} {scrollback().length}{" "}
+              original
+              {scrollback().length === 1 ? " message" : " messages"}
+            </button>
+
+            <Show when={showScrollback()}>
+              <div class="mt-3 flex flex-col gap-3 border-t border-surface-3 pt-3">
+                <For each={scrollback()}>
+                  {(msg) => (
+                    <div class="flex flex-col gap-0.5">
+                      <div class="text-[10px] uppercase tracking-wide text-muted-foreground/70 flex items-center gap-2">
+                        <span
+                          class={
+                            msg.type === "user"
+                              ? "text-primary"
+                              : "text-foreground"
+                          }
+                        >
+                          {msg.type === "user" ? "You" : "Assistant"}
+                        </span>
+                        <span class="text-muted-foreground/50">
+                          {formatTime(msg.timestamp)}
+                        </span>
+                      </div>
+                      <div class="whitespace-pre-wrap text-foreground/90 text-sm">
+                        {msg.content}
+                      </div>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
+          </Show>
         </div>
       </Show>
     </article>

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -183,10 +183,21 @@ function subscribeToProviderRuntimeReady(): void {
 // Types
 // ============================================================================
 
+export interface PreCompactionMessage {
+  id: string;
+  type: "user" | "assistant";
+  content: string;
+  timestamp: number;
+}
+
 export interface AgentCompactedSummary {
   content: string;
   originalMessageCount: number;
   compactedAt: number;
+  /** Original user/assistant text shown under the summary card so the user
+   * can still read pre-compaction scrollback. Tool calls and thoughts are
+   * intentionally omitted — only text conversation is preserved. */
+  preCompactionMessages?: PreCompactionMessage[];
 }
 
 interface AgentConversationMetadata {
@@ -2266,10 +2277,23 @@ Structured summary:`;
         }
       }
 
+      const preCompactionMessages: PreCompactionMessage[] = toCompact
+        .filter(
+          (m): m is AgentMessage & { type: "user" | "assistant" } =>
+            m.type === "user" || m.type === "assistant",
+        )
+        .map((m) => ({
+          id: m.id,
+          type: m.type,
+          content: m.content,
+          timestamp: m.timestamp,
+        }));
+
       const compactedSummary: AgentCompactedSummary = {
         content: summary,
         originalMessageCount: toCompact.length,
         compactedAt: Date.now(),
+        preCompactionMessages,
       };
 
       // Capture session details and user-configured settings before termination

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -26,12 +26,25 @@ const DEFAULT_MODEL = "arcee-ai/trinity-large-thinking";
 const MAX_MESSAGES_PER_CONVERSATION = 1000;
 
 /**
+ * A pre-compaction user/assistant message preserved under the summary card so
+ * the user retains read access to their scrollback after compaction.
+ */
+export interface PreCompactionMessage {
+  id: string;
+  type: "user" | "assistant";
+  content: string;
+  timestamp: number;
+}
+
+/**
  * A compacted summary of older messages.
  */
 export interface CompactedSummary {
   content: string;
   originalMessageCount: number;
   compactedAt: number;
+  /** Original user/assistant text preserved for the expand-scrollback UI. */
+  preCompactionMessages?: PreCompactionMessage[];
 }
 
 /**
@@ -586,11 +599,21 @@ Structured summary:`;
         undefined,
       );
 
+      const preCompactionMessages: PreCompactionMessage[] = toCompact
+        .filter((m) => m.role === "user" || m.role === "assistant")
+        .map((m) => ({
+          id: m.id,
+          type: m.role as "user" | "assistant",
+          content: m.content,
+          timestamp: m.timestamp,
+        }));
+
       // Create the compacted summary
       const compactedSummary: CompactedSummary = {
         content: summary,
         originalMessageCount: toCompact.length,
         compactedAt: Date.now(),
+        preCompactionMessages,
       };
 
       // Update conversation with compacted summary

--- a/tests/unit/compaction-scrollback.test.ts
+++ b/tests/unit/compaction-scrollback.test.ts
@@ -1,0 +1,135 @@
+// ABOUTME: Regression test for #1616 — compaction must preserve pre-compaction
+// ABOUTME: user/assistant scrollback on the CompactedSummary so the UI can expand it.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendMessageMock } = vi.hoisted(() => ({
+  sendMessageMock: vi.fn(async () => "GOAL: test\nKEY_POINTS: -\n"),
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  createConversation: vi.fn(async () => {}),
+  getConversations: vi.fn(async () => []),
+  getMessages: vi.fn(async () => []),
+  saveMessage: vi.fn(async () => {}),
+  updateConversation: vi.fn(async () => {}),
+  archiveConversation: vi.fn(async () => {}),
+  clearConversationHistory: vi.fn(async () => {}),
+  clearAllHistory: vi.fn(async () => {}),
+}));
+
+vi.mock("@/services/chat", async () => {
+  const actual = await vi.importActual<typeof import("@/services/chat")>(
+    "@/services/chat",
+  );
+  return {
+    ...actual,
+    sendMessage: sendMessageMock,
+  };
+});
+
+import { chatStore } from "@/stores/chat.store";
+import type { Message } from "@/services/chat";
+
+function makeMessage(
+  id: string,
+  role: "user" | "assistant" | "system",
+  content: string,
+  ts: number,
+): Message {
+  return {
+    id,
+    role,
+    content,
+    timestamp: ts,
+    status: "complete",
+  };
+}
+
+describe("chat.store compaction #1616 — preCompactionMessages are preserved", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores pre-compaction user+assistant messages on the summary", async () => {
+    const convo = await chatStore.createConversation("Compaction test");
+    const base = 1_700_000_000_000;
+    const msgs: Message[] = [
+      makeMessage("u1", "user", "How do I deploy?", base),
+      makeMessage("a1", "assistant", "Use the release workflow.", base + 1),
+      makeMessage("s1", "system", "system note", base + 2),
+      makeMessage("u2", "user", "What about rollbacks?", base + 3),
+      makeMessage("a2", "assistant", "Cherry-pick the fix.", base + 4),
+      makeMessage("u3", "user", "Latest?", base + 5),
+      makeMessage("a3", "assistant", "On main.", base + 6),
+    ];
+    chatStore.setMessages(convo.id, msgs);
+
+    // Preserve 2 most recent — compact the other 5 (3 user, 2 assistant, 1 system).
+    await chatStore.compactConversation(2);
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+
+    const summary = chatStore.activeConversation?.compactedSummary;
+    expect(summary).toBeDefined();
+    expect(summary?.originalMessageCount).toBe(5);
+
+    // Pre-compaction scrollback contains every user+assistant message that was
+    // compacted, in original order, with content intact. The system message is
+    // intentionally filtered out — we only preserve conversational text.
+    const preserved = summary?.preCompactionMessages ?? [];
+    expect(preserved.map((m) => m.id)).toEqual(["u1", "a1", "u2", "a2"]);
+    expect(preserved.map((m) => m.type)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    expect(preserved[0].content).toBe("How do I deploy?");
+    expect(preserved[3].content).toBe("Cherry-pick the fix.");
+
+    // The 2 preserved messages remain on the conversation.
+    expect(chatStore.messages).toHaveLength(2);
+    expect(chatStore.messages[0].id).toBe("u3");
+    expect(chatStore.messages[1].id).toBe("a3");
+  });
+
+  it("a second compaction replaces the prior preCompactionMessages (bounded memory)", async () => {
+    const convo = await chatStore.createConversation("Second compaction");
+    const base = 1_700_000_000_000;
+
+    // Round 1 — 4 messages, preserve 1.
+    chatStore.setMessages(convo.id, [
+      makeMessage("u1", "user", "old q", base),
+      makeMessage("a1", "assistant", "old a", base + 1),
+      makeMessage("u2", "user", "old q2", base + 2),
+      makeMessage("a2", "assistant", "old a2", base + 3),
+    ]);
+    await chatStore.compactConversation(1);
+
+    const firstRound = chatStore.activeConversation?.compactedSummary;
+    expect(firstRound?.preCompactionMessages?.map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "u2",
+    ]);
+
+    // Round 2 — append 3 more, compact again preserving 1.
+    chatStore.setMessages(convo.id, [
+      ...(chatStore.messages ?? []),
+      makeMessage("u3", "user", "mid q", base + 10),
+      makeMessage("a3", "assistant", "mid a", base + 11),
+      makeMessage("u4", "user", "new q", base + 12),
+    ]);
+    await chatStore.compactConversation(1);
+
+    const secondRound = chatStore.activeConversation?.compactedSummary;
+    // Prior compactedSummary is overwritten — only the most-recent batch is
+    // retained, so memory does not accumulate across compactions.
+    const ids = secondRound?.preCompactionMessages?.map((m) => m.id) ?? [];
+    expect(ids).not.toContain("u1");
+    expect(ids).not.toContain("a1");
+    expect(ids).toContain("u3");
+    expect(ids).toContain("a3");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1616.

Compaction discarded the pre-compaction message list from the UI even though the data cost nothing to keep. After auto-compaction, users saw the summary card + the last N preserved messages and nothing else — every earlier turn was gone from the scrollback with no way to reach it.

Root cause: both compaction paths explicitly replaced the message list with just the summary notice + preserved tail — see `src/stores/agent.store.ts:2312-2315` and `src/stores/chat.store.ts:604`. `toCompact` (the old messages) was read once for the summary prompt, counted, and then dropped on the floor.

This was a pure UI discard — the CLI-restart architecture (stream-json stdio for Claude Code, IPC for Codex) was unrelated. Whether we show the old scrollback or not has zero effect on the new CLI process.

## Changes

- `src/stores/agent.store.ts` and `src/stores/chat.store.ts` — extend `AgentCompactedSummary` and `CompactedSummary` with an optional `preCompactionMessages: PreCompactionMessage[]`. Both compaction paths now populate the field from `toCompact`, filtered to user + assistant text.
- `src/components/chat/CompactedMessage.tsx` — when the summary is expanded and `preCompactionMessages` is non-empty, show a nested "Show N original messages" button that renders the messages with role, timestamp, and content. Zero visible change when the summary lacks the new field (pre-fix persisted summaries still render normally).
- `tests/unit/compaction-scrollback.test.ts` — critical regression: after chat compaction, `preCompactionMessages` contains exactly the user+assistant entries from `toCompact` in order; a second compaction replaces (not appends) the prior batch so memory stays bounded.

Tool calls, thoughts, diffs, and system messages are intentionally NOT preserved here — only text scrollback. Keeps the field small and focused on what users actually want to read back.

## Verification

- `pnpm test`: 371 passed (2 new).
- Flipped the fix off locally — both new tests fail with the expected "undefined" on `preCompactionMessages`. Fix restored.
- `tsc --noEmit`: clean.
- Biome: no new issues in touched files (existing repo-wide Biome noise is pre-existing and lands on `main` today).
- `pnpm tauri dev` functional test: triggered compaction on a long chat — summary card shows "X messages compacted", expanding it reveals the summary text plus a "Show N original messages" button, clicking reveals the original turns with role + timestamp. Confirmed by @taariq.

## Test plan

- [x] After agent compaction, expand the summary → see the original user+assistant messages
- [x] After chat compaction, same behavior
- [x] A second compaction replaces the prior `preCompactionMessages` batch (no unbounded accumulation)
- [x] Summaries without `preCompactionMessages` (pre-fix persisted rows) render the summary text with no errors

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
