### PR TITLE
fix(release): sweep stale drafts before creating new one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,37 @@ jobs:
           echo "Generated release notes:"
           cat release_notes.md
 
+      - name: Sweep stale drafts for this tag
+        uses: actions/github-script@v9
+        continue-on-error: true
+        with:
+          script: |
+            const tagName = context.ref.replace('refs/tags/', '');
+            const expectedName = `Seren Desktop ${tagName}`;
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+            const stale = releases.filter(r =>
+              r.draft && (r.tag_name === tagName || r.name === expectedName)
+            );
+            for (const r of stale) {
+              console.log(`Deleting stale draft id=${r.id} name=${r.name} tag=${r.tag_name}`);
+              try {
+                await github.rest.repos.deleteRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: r.id
+                });
+              } catch (e) {
+                console.log(`  failed: ${e.message}`);
+              }
+            }
+            if (stale.length === 0) {
+              console.log(`No stale drafts found for tag ${tagName}`);
+            }
+
       - name: Create or Update Release
         id: create_release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Summary

- Stop the release workflow from leaving orphan draft releases on failed or re-dispatched runs.
- Adds an idempotent "sweep" step to `create-release` that deletes any existing draft for the current tag before `softprops/action-gh-release` creates a new one.
- No effect on successful-first-try releases — the sweep finds nothing and no-ops.

Closes #1615. See the issue for full root-cause analysis and forensic evidence.

## Why this path, not an `if: failure()` cleanup

A post-failure cleanup job was considered and rejected:

- It doesn't handle tag re-push (the new run's `create-release` would still create a fresh draft, leaving the prior orphan behind).
- `if: failure()` steps don't run on workflow cancellation — a common retry trigger.
- The sweep approach handles all three cases (failed run, cancelled run, re-pushed tag) with a single idempotent step.

`continue-on-error: true` on the sweep means a sweep glitch never blocks a real release.

## Test plan

- [ ] After merge, push a throwaway tag and confirm `create-release` logs `No stale drafts found for tag <tag>` when no orphans exist.
- [ ] Simulate an orphan: manually create a draft with name `Seren Desktop vX.Y.Z-test`, then push tag `vX.Y.Z-test`. Confirm the sweep step logs `Deleting stale draft id=<id>` and the final release is a fresh draft, not the orphan.
- [ ] Confirm `publish-release` still un-drafts correctly (unchanged path).
- [ ] Delete the test tag + release when done.
