### PR TITLE
fix(agent): kill stale publisher snapshot; force live list_agent_publishers query

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -38,6 +38,26 @@ const spawnContextMap = new Map<
 /** Max time to wait for a session to become ready before giving up */
 const SESSION_READY_TIMEOUT_MS = 30_000;
 
+/**
+ * Instruction prepended to every agent session telling Claude Code / Codex
+ * that the Seren MCP gateway exists and MUST be queried live before refusing
+ * any third-party service. Intentionally does NOT embed a snapshot of
+ * publisher slugs — snapshots go stale at cold-start when the gateway's
+ * discovery is still in-flight, and the agent then confidently refuses real
+ * publishers while telling itself it's following instructions (#1622).
+ */
+export const PUBLISHER_LIVE_QUERY_INSTRUCTION =
+  "You have access to a Seren MCP gateway with callable publishers via " +
+  "your seren-mcp tools (list_agent_publishers, call_publisher). Before " +
+  "stating that any third-party service (Google Docs, Gmail, GitHub, " +
+  "Slack, Notion, Linear, Figma, and many others) is unavailable, you " +
+  "MUST call list_agent_publishers with NO arguments to get the current " +
+  "live publisher list — publishers are added frequently and any list " +
+  "you may have seen is stale. After confirming a publisher exists, " +
+  'call list_agent_publishers with slug: "<name>" to enumerate its ' +
+  "tools, then call_publisher to invoke. This live-query rule " +
+  "overrides any prior belief about what tools you have.";
+
 /** Await a session ready promise with a timeout to prevent infinite hangs */
 function waitForSessionReady(sessionId: string): Promise<void> {
   // Note: this only resolves the initial ready promise set up in spawnSession.
@@ -121,7 +141,6 @@ import {
   setAgentConversationTitle as setAgentConversationTitleDb,
 } from "@/lib/tauri-bridge";
 import { refreshAccessToken } from "@/services/auth";
-import { getCallablePublisherSlugs } from "@/services/mcp-gateway";
 import type {
   AgentEvent,
   AgentInfo,
@@ -2039,26 +2058,10 @@ export const agentStore = {
       );
     }
 
-    // Inject publisher inventory so the agent knows which services are
-    // available via call_publisher / list_agent_publishers. Without this,
-    // the agent checks MCP resources (empty) and concludes services like
-    // GitHub are unavailable.
-    const publisherSlugs = getCallablePublisherSlugs();
-    if (publisherSlugs.length > 0) {
-      const publisherList = publisherSlugs.sort().join(", ");
-      mergedContext = [
-        {
-          type: "text",
-          text:
-            "Available Seren MCP Publishers (callable via your seren-mcp tools): " +
-            publisherList +
-            ". Use list_agent_publishers to discover tools for a specific publisher, " +
-            "then call_publisher to invoke them. Do NOT say a service is unavailable " +
-            "without first checking this list.",
-        },
-        ...mergedContext,
-      ];
-    }
+    mergedContext = [
+      { type: "text", text: PUBLISHER_LIVE_QUERY_INSTRUCTION },
+      ...mergedContext,
+    ];
 
     return mergedContext.length > 0 ? mergedContext : undefined;
   },

--- a/tests/unit/publisher-live-query-instruction.test.ts
+++ b/tests/unit/publisher-live-query-instruction.test.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Regression test for #1622 — the agent system-prompt instruction
+// ABOUTME: must force a live list_agent_publishers query, never embed a stale snapshot.
+
+import { describe, expect, it } from "vitest";
+import { PUBLISHER_LIVE_QUERY_INSTRUCTION } from "@/stores/agent.store";
+
+describe("#1622 — PUBLISHER_LIVE_QUERY_INSTRUCTION", () => {
+  it("does not embed any publisher slug or comma-separated list", () => {
+    // The bug was: agent.store.ts inlined `cachedPublisherSlugs.sort().join(", ")`.
+    // If a contributor regresses by reintroducing that pattern, the instruction
+    // will contain comma-separated slug-looking tokens. Guard against any slug
+    // we know is common in Seren's catalog appearing alongside its siblings.
+    const txt = PUBLISHER_LIVE_QUERY_INSTRUCTION;
+
+    // These slug patterns must NEVER appear as a comma-joined list in the
+    // instruction body — they are enumerated examples only in prose form.
+    // A regression would look like "google-docs, google-drive, gmail, ..."
+    // (the exact shape of the old snapshot). We reject any dash-slug that is
+    // immediately followed by ", " and another dash-slug.
+    const slugListPattern = /[a-z]+-[a-z]+,\s[a-z]+-[a-z]+/;
+    expect(
+      txt,
+      "Instruction must not contain a comma-joined dash-slug list (stale snapshot signature)",
+    ).not.toMatch(slugListPattern);
+  });
+
+  it("forces the agent to call list_agent_publishers live before refusing", () => {
+    const txt = PUBLISHER_LIVE_QUERY_INSTRUCTION;
+    // Must mention the tool name — that's how the agent knows what to call.
+    expect(txt).toContain("list_agent_publishers");
+    // Must state the rule as a MUST, not a suggestion, and must call out
+    // the staleness of any prior belief — without these the model has
+    // discretion and will revert to "I don't have that tool" on low confidence.
+    expect(txt).toContain("MUST call");
+    expect(txt.toLowerCase()).toContain("stale");
+  });
+
+  it("mentions call_publisher so the agent can invoke after discovery", () => {
+    expect(PUBLISHER_LIVE_QUERY_INSTRUCTION).toContain("call_publisher");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1622.

Every Claude Code / Codex session had a snapshot of `cachedPublisherSlugs` inlined into its system prompt at spawn time ([agent.store.ts:2046-2061](src/stores/agent.store.ts#L2046-L2061)). On cold-start the snapshot could be empty or partial — the gateway's `discoverPublisherTools()` had not yet populated the cache — and the frozen text then lived on the agent forever. The instruction said *"Do NOT say a service is unavailable without first checking this list"* where *"this list"* was the stale snapshot. The agent would confidently refuse real publishers (e.g. google-docs) while telling itself it was following instructions. On push-back the agent would call `list_agent_publishers` live, find the publisher, and apologize — proving the snapshot was the bug.

## Fix

- Remove the inline list entirely. Replace with `PUBLISHER_LIVE_QUERY_INSTRUCTION` constant that names `list_agent_publishers` + `call_publisher` as the live-query tools and states the rule as a **MUST**.
- Drop the now-unused `getCallablePublisherSlugs` import from `agent.store.ts` (still used by `chat.ts`, which has its own separate path).
- Cost: one extra MCP tool call per session on the first refusal-candidate question. Benefit: no stale snapshot can ever mislead the agent, regardless of cold-start timing.

## Test

`tests/unit/publisher-live-query-instruction.test.ts` — critical regression guard:
- Instruction must NOT contain a comma-joined dash-slug list (the exact shape of the old bug).
- Instruction MUST contain `list_agent_publishers`, `MUST call`, `call_publisher`, and the word `stale`.

374 tests pass (3 new). `tsc --noEmit` clean.

## Verification

- `pnpm tauri dev`, new agent session, first turn asks for Google Docs → agent calls `list_agent_publishers` live, finds google-docs, proceeds. No false refusal.

## Test plan

- [x] Unit test covers all the invariants above
- [x] TypeScript clean
- [x] Functional: fresh agent session + immediate Google Docs request → no publisher-refusal response

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
