### PR TITLE
fix(agent): compaction no longer overwrites queued user messages

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2220,6 +2220,15 @@ export const agentStore = {
   async compactAgentConversation(
     sessionId: string,
     preserveCount: number,
+    /**
+     * Optional prompt to retry on the new session after compaction. Callers
+     * pass this when a send failed mid-flight (e.g. `compactAndRetry`). The
+     * auto-compact-from-promptComplete path passes `undefined` because the
+     * previous prompt already completed successfully — retrying it would
+     * duplicate. Queued prompts are handled separately via the pendingPrompts
+     * transfer below — see #1623.
+     */
+    pendingUserPrompt?: string,
   ): Promise<CompactionOutcome> {
     const session = state.sessions[sessionId];
     if (!session || session.isCompacting) {
@@ -2303,10 +2312,13 @@ Structured summary:`;
       const cwd = session.cwd;
       const agentType = session.info.agentType;
       const conversationId = session.conversationId;
-      // Preserve the last user prompt so we can retry it after compaction.
-      // Without this, the user's message is lost when the old session is
-      // terminated and the new session starts with lastUserPrompt = undefined.
-      const pendingUserPrompt = session.lastUserPrompt;
+      // Transfer the queue of user-typed-but-not-yet-sent prompts to the new
+      // session. In the race where the user types while the agent is mid-turn
+      // and the in-flight turn triggers compaction, those prompts must survive
+      // — previously they were overwritten by compaction's stale `toPreserve`
+      // snapshot (#1623). Seeding + promptComplete on the new session will
+      // drain this queue naturally.
+      const queuedPrompts = session.pendingPrompts ?? [];
       // Terminate the old agent session
       await this.terminateSession(sessionId);
 
@@ -2346,6 +2358,10 @@ Structured summary:`;
         "restoredMessageCount",
         toPreserve.length + 1, // +1 for the compaction notice
       );
+      // Hand the queue to the new session so promptComplete will drain it.
+      if (queuedPrompts.length > 0) {
+        setState("sessions", newSessionId, "pendingPrompts", queuedPrompts);
+      }
 
       // Seed the new agent with the summary so it has context
       console.info(
@@ -2424,9 +2440,12 @@ Structured summary:`;
     );
 
     try {
+      // Retry the last prompt that failed — this entry point is called from
+      // sendPrompt's error handler when the CLI rejected for context overflow.
       const outcome = await this.compactAgentConversation(
         sessionId,
         settingsStore.settings.autoCompactPreserveMessages,
+        lastPrompt,
       );
 
       // Propagate non-success outcomes directly. "skipped" means the message
@@ -2534,6 +2553,21 @@ Structured summary:`;
     }
 
     const session = state.sessions[sessionId];
+
+    // Defensive: if a caller races compaction (e.g. a stray setTimeout the
+    // drain block scheduled before the auto-compact block set isCompacting),
+    // re-enqueue rather than send. The session is about to be terminated
+    // and re-spawned; compaction will transfer the queue to the new session
+    // and its first promptComplete will drain it (#1623).
+    if (session?.isCompacting) {
+      console.info(
+        "[AgentStore] sendPrompt: session is compacting, re-enqueuing",
+        { sessionId, prompt: prompt.slice(0, 50) },
+      );
+      this.enqueuePrompt(sessionId, prompt);
+      return;
+    }
+
     if (!session || session.info.status === "error") {
       // Set session-specific error if session exists
       if (session) {
@@ -3353,31 +3387,15 @@ Structured summary:`;
           "ready" as SessionStatus,
         );
 
-        // Drain the prompt queue for this session. This runs in the store
-        // regardless of which thread the UI is showing, so background threads
-        // don't stall. Guard against compaction — the session will be
-        // terminated and re-spawned, so sendPrompt would fail.
-        if (!isHistoryReplay && !state.sessions[sessionId]?.isCompacting) {
-          const queue = state.sessions[sessionId]?.pendingPrompts ?? [];
-          if (queue.length > 0) {
-            const [nextPrompt, ...remaining] = queue;
-            setState("sessions", sessionId, "pendingPrompts", remaining);
-            console.log(
-              "[AgentStore] Draining queued prompt for session",
-              sessionId,
-              "remaining:",
-              remaining.length,
-            );
-            // Dispatch asynchronously so the promptComplete handler finishes
-            // before the next sendPrompt begins.
-            setTimeout(() => {
-              void this.sendPrompt(nextPrompt, undefined, undefined, sessionId);
-            }, 100);
-          }
-        }
-
-        // Auto-compact check: trigger compaction at 85% of context window,
-        // or at 200 messages for agents that don't report token usage at all.
+        // Auto-compact check runs BEFORE drain (#1623). The drain block below
+        // schedules a setTimeout to send the next queued prompt — if we drained
+        // first and compaction then kicked in, the queued sendPrompt would
+        // race the session teardown, add a user message to the old session's
+        // messages array, and then be overwritten by compaction's stale
+        // `toPreserve` snapshot. Triggering compaction first sets isCompacting
+        // synchronously (before the first await in compactAgentConversation),
+        // so the drain block's existing guard will skip. The queue is then
+        // transferred to the new session inside compactAgentConversation.
         if (!isHistoryReplay && !state.sessions[sessionId]?.isCompacting) {
           const sess = state.sessions[sessionId];
           if (settingsStore.settings.autoCompactEnabled && sess) {
@@ -3410,13 +3428,44 @@ Structured summary:`;
             }
 
             if (shouldCompact) {
+              // Explicit undefined for pendingUserPrompt: the prompt that
+              // just produced this promptComplete already succeeded, so we
+              // do NOT retry it — retrying would duplicate the turn. Queued
+              // prompts handled via pendingPrompts transfer inside compaction.
               this.compactAgentConversation(
                 sessionId,
                 settingsStore.settings.autoCompactPreserveMessages,
+                undefined,
               );
             }
           }
         }
+
+        // Drain the prompt queue for this session. This runs in the store
+        // regardless of which thread the UI is showing, so background threads
+        // don't stall. Guard against compaction — if the auto-compact block
+        // above fired, `isCompacting` is already true, the session will be
+        // terminated and re-spawned, and the queue will be transferred to
+        // the new session by compactAgentConversation (#1623).
+        if (!isHistoryReplay && !state.sessions[sessionId]?.isCompacting) {
+          const queue = state.sessions[sessionId]?.pendingPrompts ?? [];
+          if (queue.length > 0) {
+            const [nextPrompt, ...remaining] = queue;
+            setState("sessions", sessionId, "pendingPrompts", remaining);
+            console.log(
+              "[AgentStore] Draining queued prompt for session",
+              sessionId,
+              "remaining:",
+              remaining.length,
+            );
+            // Dispatch asynchronously so the promptComplete handler finishes
+            // before the next sendPrompt begins.
+            setTimeout(() => {
+              void this.sendPrompt(nextPrompt, undefined, undefined, sessionId);
+            }, 100);
+          }
+        }
+
         break;
       }
 

--- a/tests/unit/compaction-queue-race.test.ts
+++ b/tests/unit/compaction-queue-race.test.ts
@@ -1,0 +1,94 @@
+// ABOUTME: Regression tests for #1623 — queued user messages must survive
+// ABOUTME: auto-compaction (no silent data loss in chat).
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1623 — auto-compact runs BEFORE drain in promptComplete handler", () => {
+  it("auto-compact comment anchor appears before the drain comment anchor", () => {
+    // The bug was: drain ran first, scheduled a setTimeout(sendPrompt, 100),
+    // then auto-compact triggered. The setTimeout fired during compaction and
+    // added a user message to the old session's messages array, which was
+    // then overwritten by compaction's stale toPreserve snapshot. Reordering
+    // the two blocks causes isCompacting to be set synchronously before the
+    // drain block's guard runs, so the drain is skipped.
+    const autoCompactAnchor = "Auto-compact check runs BEFORE drain (#1623)";
+    const drainAnchor = "Drain the prompt queue for this session";
+    const autoCompactIdx = agentStoreSource.indexOf(autoCompactAnchor);
+    const drainIdx = agentStoreSource.indexOf(drainAnchor);
+
+    expect(autoCompactIdx, "auto-compact anchor must exist").toBeGreaterThan(0);
+    expect(drainIdx, "drain anchor must exist").toBeGreaterThan(0);
+    expect(
+      autoCompactIdx,
+      "auto-compact must be positioned BEFORE drain in promptComplete handler",
+    ).toBeLessThan(drainIdx);
+  });
+});
+
+describe("#1623 — compactAgentConversation transfers pendingPrompts to new session", () => {
+  it("captures queuedPrompts from the old session before termination", () => {
+    // Without this capture, compaction's setState overwrites any
+    // mid-compaction drains and the user's typed message is silently lost.
+    expect(agentStoreSource).toContain(
+      "const queuedPrompts = session.pendingPrompts ?? [];",
+    );
+  });
+
+  it("assigns queuedPrompts to the new session's pendingPrompts", () => {
+    expect(agentStoreSource).toContain(
+      'setState("sessions", newSessionId, "pendingPrompts", queuedPrompts)',
+    );
+  });
+
+  it("takes an explicit pendingUserPrompt parameter (not session.lastUserPrompt)", () => {
+    // The old code read session.lastUserPrompt inline, which retried
+    // whatever the last sendPrompt set — in the auto-compact path that was
+    // the just-completed prompt, causing a duplicate turn. An explicit param
+    // lets callers distinguish "failed in-flight prompt" (compactAndRetry)
+    // from "prompt completed successfully" (auto-compact from promptComplete).
+    expect(agentStoreSource).toContain("pendingUserPrompt?: string,");
+    // The inline read must be gone.
+    expect(agentStoreSource).not.toContain(
+      "const pendingUserPrompt = session.lastUserPrompt;",
+    );
+  });
+
+  it("auto-compact-from-promptComplete passes undefined for pendingUserPrompt", () => {
+    // The prompt that produced this promptComplete already succeeded — we
+    // MUST NOT retry it or the user sees a duplicate turn.
+    expect(agentStoreSource).toContain(
+      "settingsStore.settings.autoCompactPreserveMessages,\n                undefined,",
+    );
+  });
+
+  it("compactAndRetry passes lastPrompt for pendingUserPrompt", () => {
+    // The failed-prompt retry path must still work — it IS a real retry.
+    expect(agentStoreSource).toContain(
+      "settingsStore.settings.autoCompactPreserveMessages,\n        lastPrompt,",
+    );
+  });
+});
+
+describe("#1623 — sendPrompt defensive guard against compaction race", () => {
+  it("enqueues the prompt instead of sending when session.isCompacting", () => {
+    const sendPromptStart = agentStoreSource.indexOf(
+      "async sendPrompt(\n    prompt: string",
+    );
+    expect(sendPromptStart, "sendPrompt must exist").toBeGreaterThan(0);
+    // The guard must live BEFORE the session.info.status === "error" branch
+    // because a compacting session still has an otherwise-valid status.
+    const sendPromptWindow = agentStoreSource.slice(
+      sendPromptStart,
+      sendPromptStart + 2000,
+    );
+    expect(sendPromptWindow).toContain("session?.isCompacting");
+    expect(sendPromptWindow).toContain("this.enqueuePrompt(sessionId, prompt)");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1623. **High-severity silent data loss**: when a user typed while the agent was mid-prompt AND the in-flight prompt ended at a context threshold that triggered auto-compaction, the queued message was silently overwritten out of the chat UI. The agent still answered it (via `lastUserPrompt` retry) but the user saw only the response — no record of the question.

## Root cause — race between two blocks in promptComplete handler

Pre-fix ordering in [agent.store.ts](src/stores/agent.store.ts):

1. **Drain block** scheduled `setTimeout(sendPrompt, 100)` for the queued prompt. Its guard `!isCompacting` evaluated TRUE (compaction hadn't started yet).
2. **Auto-compact block** then triggered `compactAgentConversation`, which synchronously set `isCompacting=true` and captured a stale `messages` snapshot.
3. 100ms later the setTimeout fired. `sendPrompt` added the queued user message to the old session's messages array, then the provider call errored with `Session terminated`.
4. Compaction finished, `setState` overwrote the messages array with `[compactionNotice, ...toPreserve_stale]` — user's typed message gone.
5. `lastUserPrompt` (updated by the failed `sendPrompt`) was retried on the new session → the agent replied to a question no longer visible to the user.

## Fix

- **Reorder `promptComplete`**: auto-compact check runs BEFORE drain. `compactAgentConversation` sets `isCompacting` synchronously (before its first `await`), so the drain block's existing guard skips.
- **Transfer the queue**: `compactAgentConversation` captures `session.pendingPrompts` before termination and assigns it to the new session after spawn + `setState`. On the new session's first `promptComplete` (from the seed) the drain naturally picks up the queue.
- **Distinguish retry sources**: new `pendingUserPrompt?: string` parameter on `compactAgentConversation`.
  - `compactAndRetry` passes `lastUserPrompt` (failed-prompt retry — preserved).
  - Auto-compact-from-promptComplete passes `undefined` (the prompt that produced this completion already succeeded — retrying would duplicate).
- **Defensive**: `sendPrompt` guards `session.isCompacting` at the top and re-enqueues via `enqueuePrompt` rather than sending. Stray setTimeouts can no longer add a user message to a torn-down session.

## Test

`tests/unit/compaction-queue-race.test.ts` — source-level assertions for structural invariants:
1. Auto-compact anchor appears before drain anchor in `promptComplete` handler.
2. `queuedPrompts` captured from old session before termination.
3. `queuedPrompts` assigned to new session's `pendingPrompts`.
4. `pendingUserPrompt?: string` parameter exists; inline `session.lastUserPrompt` read removed.
5. Auto-compact call passes `undefined`.
6. `compactAndRetry` call passes `lastPrompt`.
7. `sendPrompt` has an `isCompacting` guard that calls `enqueuePrompt`.

**Verified**: reverting the fix fails all 7 tests; restoring passes all 381 (7 new).

## Verification

- `pnpm tauri dev`, open agent session with ~70% context, send a long prompt, immediately queue another ("can you also do X"), watch auto-compact trigger on the first response → the queued prompt arrives on the new session with its user message visible.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
