### PR TITLE
fix(chat): persist queued prompts to input history for up-arrow recall

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -657,7 +657,21 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       if (sid) {
         agentStore.enqueuePrompt(sid, trimmed);
       }
+      // Persist to input history even on the queued path — the user typed and
+      // submitted this, so up-arrow recall must see it (#1624).
+      const convId = activeAgentThread()?.id ?? null;
+      if (convId) {
+        setPersistedInputs((prev) => {
+          const next = [...prev, trimmed];
+          return next.length > 200 ? next.slice(-200) : next;
+        });
+        void appendInputHistory(convId, trimmed).catch((err) => {
+          console.warn("[AgentChat] Failed to persist input history:", err);
+        });
+      }
       setInput("");
+      setHistoryIndex(-1);
+      setSavedInput("");
       console.log("[AgentChat] Message queued:", trimmed);
       return;
     }

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -736,6 +736,18 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     // If currently streaming, queue the message instead
     if (conversationStore.isLoading) {
       setMessageQueue((queue) => [...queue, trimmed]);
+      // Persist to input history even on the queued path — the user typed and
+      // submitted this, so up-arrow recall must see it (#1624).
+      const convId = conversationStore.activeConversationId;
+      if (convId) {
+        setPersistedInputs((prev) => {
+          const next = [...prev, trimmed];
+          return next.length > 200 ? next.slice(-200) : next;
+        });
+        void appendInputHistory(convId, trimmed).catch((err) => {
+          console.warn("[ChatContent] Failed to persist input history:", err);
+        });
+      }
       setInput("");
       setHistoryIndex(-1);
       setSavedInput("");

--- a/tests/unit/queued-input-history.test.ts
+++ b/tests/unit/queued-input-history.test.ts
@@ -1,0 +1,70 @@
+// ABOUTME: Regression test for #1624 — queued prompts must be persisted to
+// ABOUTME: input history so up-arrow recall works.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+const chatContentSource = readFileSync(
+  resolve("src/components/chat/ChatContent.tsx"),
+  "utf-8",
+);
+
+/**
+ * Return the queued-message branch of a sendMessage handler — the block that
+ * runs when the user submits while the agent is still mid-turn (AgentChat) or
+ * the conversation is still streaming (ChatContent). Bounded to 40 lines so
+ * we don't accidentally match the direct-send path below it.
+ */
+function extractQueueBranch(source: string, anchor: string): string {
+  const start = source.indexOf(anchor);
+  if (start < 0) return "";
+  const lines = source.slice(start).split("\n").slice(0, 40);
+  return lines.join("\n");
+}
+
+describe("#1624 — queued prompts appear in up-arrow input history", () => {
+  it("AgentChat queue branch calls appendInputHistory", () => {
+    const branch = extractQueueBranch(
+      agentChatSource,
+      "if (isPrompting()) {",
+    );
+    expect(branch, "agent queued branch must exist").toContain(
+      "agentStore.enqueuePrompt",
+    );
+    // The fix: persist to input history even when the prompt is queued.
+    expect(branch).toContain("appendInputHistory");
+    expect(branch).toContain("setPersistedInputs");
+  });
+
+  it("ChatContent queue branch calls appendInputHistory", () => {
+    const branch = extractQueueBranch(
+      chatContentSource,
+      "if (conversationStore.isLoading) {",
+    );
+    expect(branch, "chat queued branch must exist").toContain(
+      "setMessageQueue",
+    );
+    expect(branch).toContain("appendInputHistory");
+    expect(branch).toContain("setPersistedInputs");
+  });
+
+  it("both queued branches cap history at 200 entries like the direct path", () => {
+    // Prevents the queued path from growing history unbounded while the direct
+    // path caps — silent divergence in behavior would be a regression.
+    const agentBranch = extractQueueBranch(
+      agentChatSource,
+      "if (isPrompting()) {",
+    );
+    const chatBranch = extractQueueBranch(
+      chatContentSource,
+      "if (conversationStore.isLoading) {",
+    );
+    expect(agentBranch).toContain("next.length > 200");
+    expect(chatBranch).toContain("next.length > 200");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1624. Both `AgentChat` and `ChatContent` submit handlers had two branches: a direct-send branch that wrote to input history (`appendInputHistory` + `setPersistedInputs`), and a queued branch that did neither. When the user typed while the agent was mid-turn (AgentChat) or while the chat conversation was still streaming (ChatContent), the message was queued for dispatch but never recorded in history. Pressing up-arrow couldn't recall it.

## Fix

- [AgentChat.tsx:655-673](src/components/chat/AgentChat.tsx#L655-L673): queued branch now writes to `setPersistedInputs` (capped at 200) and calls `appendInputHistory` with the same wiring as the direct path. Resets `historyIndex` and `savedInput` so the next up-arrow starts fresh.
- [ChatContent.tsx:737-754](src/components/chat/ChatContent.tsx#L737-L754): same fix for the chat-queue path.

## Test

`tests/unit/queued-input-history.test.ts` — source-level assertions:
1. `AgentChat` queued branch calls `appendInputHistory` + `setPersistedInputs`.
2. `ChatContent` queued branch calls `appendInputHistory` + `setPersistedInputs`.
3. Both queued branches cap history at 200 entries (parity with direct path).

384 tests pass (3 new). TSC clean. Reverting the fix fails all 3.

## Verification

- `pnpm tauri dev`: open an agent session mid-turn, type and send "foo", type and send "bar" (both queued). Click empty input, press ↑ → "bar". Press ↑ again → "foo". ✓

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
