### PR TITLE
feat(agent): wire agent sessions into Seren memory

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -141,6 +141,10 @@ import {
   setAgentConversationTitle as setAgentConversationTitleDb,
 } from "@/lib/tauri-bridge";
 import { refreshAccessToken } from "@/services/auth";
+import {
+  bootstrapMemoryContext,
+  storeAssistantResponse,
+} from "@/services/memory";
 import type {
   AgentEvent,
   AgentInfo,
@@ -1151,6 +1155,28 @@ export const agentStore = {
         resumeAgentSessionId,
       });
 
+      // Bootstrap Seren memory context so the agent starts with relevant
+      // recall from past sessions — agent transcripts (written via
+      // storeAssistantResponse below) accumulate into memory, and this
+      // pulls them back on every fresh spawn including post-compaction
+      // spawns. Best-effort; a failure here must not block the spawn (#1625).
+      let memoryContext: string | undefined;
+      if (settingsStore.settings.memoryEnabled) {
+        try {
+          const bootstrapped = await bootstrapMemoryContext();
+          if (bootstrapped && bootstrapped.trim().length > 0) {
+            memoryContext = bootstrapped;
+          }
+        } catch (err) {
+          console.warn("[AgentStore] memory bootstrap failed (non-fatal):", err);
+        }
+      }
+      const finalBootstrapContext = memoryContext
+        ? opts?.bootstrapPromptContext
+          ? `${memoryContext}\n\n${opts.bootstrapPromptContext}`
+          : memoryContext
+        : opts?.bootstrapPromptContext;
+
       // Preemptively terminate idle Claude sessions for other conversations
       // before spawning. Claude CLI cannot reliably initialize a second
       // instance while another is alive (see isRetryableClaudeInitError).
@@ -1474,7 +1500,7 @@ export const agentStore = {
               : resolvedAgentType === "gemini"
                 ? 1_000_000
                 : 200_000,
-          bootstrapPromptContext: opts?.bootstrapPromptContext,
+          bootstrapPromptContext: finalBootstrapContext,
           pendingPrompts: [],
         };
 
@@ -3320,7 +3346,7 @@ Structured summary:`;
           setState("sessions", sessionId, "skipHistoryReplay", undefined);
         }
         this.flushPendingUserMessage(sessionId);
-        this.finalizeStreamingContent(sessionId);
+        this.finalizeStreamingContent(sessionId, { isReplay: isHistoryReplay });
         // Each promptComplete ends a turn; the next turn may have real content.
         setState("sessions", sessionId, "isSkippingSkillContext", undefined);
         if (!isHistoryReplay) {
@@ -4198,7 +4224,8 @@ Structured summary:`;
     }
   },
 
-  finalizeStreamingContent(sessionId: string) {
+  finalizeStreamingContent(sessionId: string, opts?: { isReplay?: boolean }) {
+    const isReplay = opts?.isReplay ?? false;
     // Flush any buffered chunks before reading store state
     flushChunkBuf(sessionId);
 
@@ -4270,6 +4297,24 @@ Structured summary:`;
       setState("sessions", sessionId, "messages", (msgs) => [...msgs, message]);
       if (session.conversationId)
         persistAgentMessage(session.conversationId, message);
+
+      // Persist the assistant turn to Seren memory so future sessions (agent
+      // or chat) can recall this conversation via memory_bootstrap. Gated by
+      // memoryEnabled setting, guarded against empty / replay / error turns,
+      // and best-effort — a failure must not affect the session (#1625).
+      if (
+        !isReplay &&
+        settingsStore.settings.memoryEnabled &&
+        session.streamingContent.trim().length > 0 &&
+        !isLikelyAuthError(session.streamingContent)
+      ) {
+        storeAssistantResponse(session.streamingContent, {
+          model: `agent:${session.info.agentType}`,
+          userQuery: session.lastUserPrompt,
+        }).catch((err) => {
+          console.warn("[AgentStore] storeAssistantResponse failed:", err);
+        });
+      }
 
       // If the agent streamed a short auth error as text, surface it as a session error
       // so the error banner with the Login button appears. Long messages are skipped

--- a/tests/unit/agent-history-persistence.test.ts
+++ b/tests/unit/agent-history-persistence.test.ts
@@ -47,7 +47,7 @@ describe("agent message persistence guards", () => {
 
   it("finalizeStreamingContent DOES persist assistant messages", () => {
     const finalizeHandler = agentStoreSource.slice(
-      agentStoreSource.indexOf("finalizeStreamingContent(sessionId: string)"),
+      agentStoreSource.indexOf("finalizeStreamingContent(sessionId: string"),
     );
     const finalizeBody = finalizeHandler.slice(
       0,

--- a/tests/unit/agent-seren-memory-wiring.test.ts
+++ b/tests/unit/agent-seren-memory-wiring.test.ts
@@ -1,0 +1,105 @@
+// ABOUTME: Regression tests for #1625 — agent sessions must read from and
+// ABOUTME: write to Seren memory (same path as chat). Covers spawn bootstrap,
+// ABOUTME: per-turn storeAssistantResponse, and post-compaction re-bootstrap.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1625 — agent spawnSession bootstraps Seren memory context", () => {
+  it("imports bootstrapMemoryContext + storeAssistantResponse from @/services/memory", () => {
+    expect(agentStoreSource).toContain(
+      'from "@/services/memory"',
+    );
+    expect(agentStoreSource).toContain("bootstrapMemoryContext");
+    expect(agentStoreSource).toContain("storeAssistantResponse");
+  });
+
+  it("spawnSession calls bootstrapMemoryContext when memoryEnabled is true", () => {
+    const spawnSessionStart = agentStoreSource.indexOf("async spawnSession(");
+    expect(spawnSessionStart, "spawnSession must exist").toBeGreaterThan(0);
+    // Bound the window to the first 5000 chars of spawnSession so we don't
+    // false-match against unrelated occurrences elsewhere in the file.
+    const spawnWindow = agentStoreSource.slice(
+      spawnSessionStart,
+      spawnSessionStart + 5000,
+    );
+    expect(spawnWindow).toContain("settingsStore.settings.memoryEnabled");
+    expect(spawnWindow).toContain("bootstrapMemoryContext()");
+  });
+
+  it("spawnSession merges memory context with any caller-supplied bootstrap", () => {
+    // Compaction passes no bootstrapPromptContext — without merging, memory
+    // would be skipped after compaction spawn. Inverse: resumeAgentConversation
+    // DOES pass bootstrapPromptContext — without merging, memory would shadow
+    // the caller's replay context.
+    expect(agentStoreSource).toContain("finalBootstrapContext");
+    // The final context must be what gets attached to the session state.
+    expect(agentStoreSource).toContain(
+      "bootstrapPromptContext: finalBootstrapContext,",
+    );
+  });
+
+  it("spawnSession memory bootstrap is best-effort (catches error)", () => {
+    // A memory service outage must not block spawn.
+    const spawnSessionStart = agentStoreSource.indexOf("async spawnSession(");
+    const spawnWindow = agentStoreSource.slice(
+      spawnSessionStart,
+      spawnSessionStart + 5000,
+    );
+    expect(spawnWindow).toContain("memory bootstrap failed (non-fatal)");
+  });
+});
+
+describe("#1625 — finalizeStreamingContent writes assistant turns to memory", () => {
+  it("finalizeStreamingContent accepts an isReplay option", () => {
+    // Replay emissions must NOT re-write to memory; only live turns write.
+    expect(agentStoreSource).toContain(
+      "finalizeStreamingContent(sessionId: string, opts?: { isReplay?: boolean })",
+    );
+    expect(agentStoreSource).toContain("const isReplay = opts?.isReplay");
+  });
+
+  it("non-replay path calls storeAssistantResponse with the agent tag", () => {
+    // The ONLY acceptable call of storeAssistantResponse in this file is the
+    // one gated on !isReplay + memoryEnabled + non-empty + !auth-error.
+    expect(agentStoreSource).toContain("!isReplay &&");
+    expect(agentStoreSource).toContain("storeAssistantResponse(");
+    expect(agentStoreSource).toContain("agent:${session.info.agentType}");
+  });
+
+  it("caller passes isHistoryReplay flag into finalizeStreamingContent", () => {
+    // The promptComplete handler knows whether this is a replay; the helper
+    // does not, so the caller must propagate the flag — otherwise every
+    // replayed session flood-writes duplicates to cloud memory.
+    expect(agentStoreSource).toContain(
+      "this.finalizeStreamingContent(sessionId, { isReplay: isHistoryReplay })",
+    );
+  });
+});
+
+describe("#1625 — post-compaction re-bootstrap (via spawnSession)", () => {
+  it("compactAgentConversation reuses spawnSession, so memory re-bootstraps automatically", () => {
+    // compactAgentConversation calls this.spawnSession(...) to create the
+    // new session after compaction. Because memory bootstrap now lives
+    // inside spawnSession, the new post-compaction session automatically
+    // pulls fresh memory — no separate wiring needed. Guard against a
+    // regression that moves the bootstrap into a caller-specific path.
+    const compactFnStart = agentStoreSource.indexOf(
+      "async compactAgentConversation(",
+    );
+    expect(compactFnStart, "compactAgentConversation must exist").toBeGreaterThan(
+      0,
+    );
+    const compactBody = agentStoreSource.slice(
+      compactFnStart,
+      compactFnStart + 8000,
+    );
+    expect(compactBody).toContain("await this.spawnSession(");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1625.

Agent sessions (Claude Code, Codex, Gemini) were disconnected from Seren memory: **no writes on assistant turns, no bootstrap recall on spawn.** A session that helped on doc X on Monday could not answer *"do you remember working on doc X"* on Tuesday because nothing from Monday was ever written. Grep at start of work: `agent.store.ts` had zero calls to `storeAssistantResponse`, `storeConversationTurn`, `rememberMemory`, or `memory_bootstrap`.

## Changes

Two hooks added, both gated on `settingsStore.settings.memoryEnabled`:

**1. Spawn-time bootstrap** — `spawnSession` ([agent.store.ts:1154-1176](src/stores/agent.store.ts#L1154-L1176))
- `bootstrapMemoryContext()` is awaited early in `spawnSession`.
- Any non-empty result is merged (prepended) with the caller-supplied `bootstrapPromptContext` into `finalBootstrapContext`, which is assigned to the new session state.
- **Post-compaction is handled automatically**: `compactAgentConversation` re-spawns via `this.spawnSession(...)` with no caller-supplied bootstrap, so the new CLI process gets a fresh memory pull without any separate wiring.
- Best-effort: memory-service outage logs a warning and proceeds with the caller's bootstrap (or nothing).

**2. Per-turn write** — `finalizeStreamingContent` ([agent.store.ts:4300-4317](src/stores/agent.store.ts#L4300-L4317))
- After the assistant message is appended to `session.messages` and persisted locally, `storeAssistantResponse` is called with `streamingContent`, `model: "agent:<agentType>"`, and `userQuery: session.lastUserPrompt`.
- Guards: non-empty content and `!isLikelyAuthError` so auth-error banners don't pollute cloud memory.
- New `opts.isReplay` parameter lets the `promptComplete` caller skip writes during session history replay — without this, every replay would flood duplicates to cloud memory.

## Tests

`tests/unit/agent-seren-memory-wiring.test.ts` — 8 source-level assertions:
- Memory service imports exist.
- `spawnSession` awaits `bootstrapMemoryContext()` under `memoryEnabled`.
- `finalBootstrapContext` merges memory + caller bootstrap.
- Bootstrap error path is non-fatal (catch + warn).
- `finalizeStreamingContent` accepts `isReplay`.
- `!isReplay` gate exists on the storeAssistantResponse call.
- `promptComplete` caller propagates `isHistoryReplay`.
- `compactAgentConversation` still calls `this.spawnSession` (post-compaction re-bootstrap invariant).

Existing `agent-history-persistence` test updated to match the new `finalizeStreamingContent` signature.

**392 tests pass (8 new).** TSC clean. Reverting the fix fails the new assertions.

## Verification

- `pnpm tauri dev`:
  1. Enable memory (Settings → Memory → on).
  2. Open an agent session, have a turn where the agent mentions a distinctive detail (e.g. a doc URL).
  3. Close the session. Open a NEW agent session.
  4. Ask about the distinctive detail → the agent recalls it via bootstrap.
- Post-compaction: trigger auto-compact in an agent session; after the new session spawns, confirm `memory_bootstrap` was called in logs + the agent still recalls prior context.

## Related

- #1619 — the feedback/correction UI will naturally surface these agent memories once wired end-to-end.
- #1620 — workflow/tool-use memory is the next memory class on top of this transcript wiring.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
