### PR TITLE
feat(agent): invisible restart — zero-indication compaction, crash recovery, cold-start (#1631)

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -480,6 +480,45 @@ pub async fn set_agent_conversation_permission_mode(
     .await
 }
 
+/// Fetch the persisted composer draft for a thread (#1631).
+/// Survives force-quit so the user never loses unsent text.
+#[tauri::command]
+pub async fn get_thread_draft(
+    app: AppHandle,
+    thread_id: String,
+) -> Result<String, String> {
+    run_db(app, move |conn| {
+        let draft: Option<String> = conn
+            .query_row(
+                "SELECT draft FROM conversations WHERE id = ?1",
+                params![thread_id],
+                |row| row.get(0),
+            )
+            .optional()?
+            .flatten();
+        Ok(draft.unwrap_or_default())
+    })
+    .await
+}
+
+/// Write the composer draft for a thread (#1631).
+/// Called on 500ms input debounce; cleared after submit by the frontend.
+#[tauri::command]
+pub async fn set_thread_draft(
+    app: AppHandle,
+    thread_id: String,
+    draft: String,
+) -> Result<(), String> {
+    run_db(app, move |conn| {
+        conn.execute(
+            "UPDATE conversations SET draft = ?1 WHERE id = ?2",
+            params![draft, thread_id],
+        )?;
+        Ok(())
+    })
+    .await
+}
+
 const MAX_INPUT_HISTORY_PER_CONVERSATION: i64 = 200;
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -749,6 +749,8 @@ pub fn run() {
             commands::chat::set_agent_conversation_permission_mode,
             commands::chat::set_agent_conversation_metadata,
             commands::chat::archive_agent_conversation,
+            commands::chat::get_thread_draft,
+            commands::chat::set_thread_draft,
             // Input history commands
             commands::chat::append_input_history,
             commands::chat::get_input_history,

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -226,6 +226,16 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             .ok();
     }
 
+    // Per-thread composer draft (#1631). Persisted on 500ms debounce so the
+    // user's unsent text survives crash, force-quit, and relaunch.
+    let has_draft: bool = conn
+        .prepare("SELECT draft FROM conversations LIMIT 1")
+        .is_ok();
+    if !has_draft {
+        conn.execute("ALTER TABLE conversations ADD COLUMN draft TEXT", [])
+            .ok();
+    }
+
     // Backfill project context for existing agent conversations.
     conn.execute(
         "UPDATE conversations

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -17,7 +17,6 @@ import {
 import { createStore } from "solid-js/store";
 import { AgentPermissionDialog } from "@/components/agent/AgentPermissionDialog";
 import { DiffProposalDialog } from "@/components/agent/DiffProposalDialog";
-import { CompactedMessage } from "@/components/chat/CompactedMessage";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { isAuthError, isLikelyAuthError } from "@/lib/auth-errors";
@@ -45,7 +44,12 @@ import {
 } from "@/lib/rate-limit-fallback";
 import { escapeHtmlWithLinks } from "@/lib/render-markdown";
 import { saveToSerenNotes } from "@/lib/save-to-notes";
-import { appendInputHistory, getInputHistory } from "@/lib/tauri-bridge";
+import {
+  appendInputHistory,
+  getInputHistory,
+  getThreadDraft,
+  setThreadDraft,
+} from "@/lib/tauri-bridge";
 import { readDocument } from "@/services/docreader";
 import {
   type AgentType,
@@ -55,11 +59,7 @@ import {
   type ToolCallEvent,
 } from "@/services/providers";
 import { skills } from "@/services/skills";
-import {
-  type AgentCompactedSummary,
-  type AgentMessage,
-  agentStore,
-} from "@/stores/agent.store";
+import { type AgentMessage, agentStore } from "@/stores/agent.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { settingsStore } from "@/stores/settings.store";
 import { threadStore } from "@/stores/thread.store";
@@ -80,8 +80,9 @@ interface AgentChatProps {
   onViewDiff?: (diff: DiffEvent) => void;
 }
 
-// Per-thread input drafts so switching threads doesn't leak text between them.
-const agentDrafts = new Map<string, string>();
+// Draft persistence is through SQLite (`get_thread_draft` / `set_thread_draft`) —
+// survives hard crashes, force-quit, and relaunch. Per #1631.
+const DRAFT_DEBOUNCE_MS = 500;
 
 // threadQueues removed — prompt queue now lives in agentStore.sessions[id].pendingPrompts
 // so background threads drain automatically on promptComplete.
@@ -132,23 +133,59 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     return thread;
   });
 
-  // Save/restore per-thread input drafts and message queues when switching
-  // Save/restore per-thread input drafts when switching threads.
-  // Queue persistence is no longer needed — it lives in the store.
+  // Per-thread composer draft (#1631) — persisted to SQLite so an app crash
+  // before submit doesn't lose the user's typed text. Write is debounced to
+  // 500ms so we don't hammer the DB on every keystroke.
+  let draftWriteTimer: ReturnType<typeof setTimeout> | null = null;
+  const schedulePersistDraft = (threadId: string, text: string) => {
+    if (draftWriteTimer) clearTimeout(draftWriteTimer);
+    draftWriteTimer = setTimeout(() => {
+      void setThreadDraft(threadId, text);
+      draftWriteTimer = null;
+    }, DRAFT_DEBOUNCE_MS);
+  };
+  const flushDraft = async (threadId: string, text: string) => {
+    if (draftWriteTimer) {
+      clearTimeout(draftWriteTimer);
+      draftWriteTimer = null;
+    }
+    await setThreadDraft(threadId, text);
+  };
+
   createEffect(() => {
     const currentId = activeAgentThread()?.id ?? null;
     if (currentId !== prevThreadId) {
       if (prevThreadId) {
         const currentInput = untrack(input);
-        if (currentInput) {
-          agentDrafts.set(prevThreadId, currentInput);
-        } else {
-          agentDrafts.delete(prevThreadId);
-        }
+        // Flush pending debounce so nothing is lost across thread switches.
+        void flushDraft(prevThreadId, currentInput);
       }
-      setInput(currentId ? (agentDrafts.get(currentId) ?? "") : "");
+      // Read the persisted draft for the newly-selected thread.
+      if (currentId) {
+        setInput(""); // placeholder while async load resolves
+        void getThreadDraft(currentId).then((draft) => {
+          // Only hydrate if the thread is still the active one — racing
+          // thread switches must not overwrite the user's live edits.
+          if (activeAgentThread()?.id === currentId) setInput(draft);
+        });
+      } else {
+        setInput("");
+      }
       prevThreadId = currentId;
     }
+  });
+
+  // Debounced write on every input change while the thread stays active.
+  createEffect(() => {
+    const id = activeAgentThread()?.id;
+    const text = input();
+    if (id && id === prevThreadId) {
+      schedulePersistDraft(id, text);
+    }
+  });
+
+  onCleanup(() => {
+    if (draftWriteTimer) clearTimeout(draftWriteTimer);
   });
 
   // Get messages for THIS thread's conversation ID, not the active session
@@ -318,8 +355,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     return fileTreeState.rootPath || null;
   };
 
-  const hasFolderOpen = () => Boolean(fileTreeState.rootPath);
-
   // Refresh project-scoped remote sessions (agent source-of-truth) and focus
   // any live session tied to the selected folder.
   // Skip refresh if a prompt is active to avoid backend rejection.
@@ -390,12 +425,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     } catch (error) {
       console.error("[AgentChat] Failed to start session:", error);
     }
-  };
-
-  const retrySessionConnection = () => {
-    const thread = activeAgentThread();
-    if (!thread) return;
-    threadStore.selectThread(thread.id, "agent");
   };
 
   const handleAttachImages = async () => {
@@ -582,9 +611,47 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       isPrompting: isPrompting(),
     });
 
+    // Cold-start path (#1631): if the thread has no live session yet,
+    // turn on the thinking indicator and spawn synchronously so the user
+    // bubble + dots appear before the first stream chunk arrives.
+    const thread = activeAgentThread();
     if (!hasSession()) {
-      console.warn("[AgentChat] sendMessage aborted: no active session");
-      return;
+      if (!trimmed) {
+        console.warn(
+          "[AgentChat] sendMessage aborted: empty input (no session)",
+        );
+        return;
+      }
+      if (!thread) {
+        console.warn("[AgentChat] sendMessage aborted: no active agent thread");
+        return;
+      }
+      if (!fileTreeState.rootPath) {
+        console.warn("[AgentChat] sendMessage aborted: no open folder");
+        return;
+      }
+      agentStore.setTurnInFlight(thread.id, true);
+      agentStore.armRestartTimer(thread.id, 60_000, "spawn_failed");
+      try {
+        const sid = await agentStore.spawnSession(
+          fileTreeState.rootPath,
+          lockedAgentType(),
+          { localSessionId: thread.id },
+        );
+        if (!sid) {
+          console.warn("[AgentChat] cold-start spawn failed");
+          agentStore.setTurnError(thread.id, "spawn_failed");
+          return;
+        }
+      } catch (err) {
+        console.error("[AgentChat] cold-start spawn threw:", err);
+        agentStore.setTurnError(
+          thread.id,
+          "spawn_failed",
+          err instanceof Error ? err.message : String(err),
+        );
+        return;
+      }
     }
 
     // Require text content even when images are attached
@@ -782,6 +849,14 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   // No component-level drain logic needed.
 
   const handleCancel = async () => {
+    // abortTurn covers every restart-dependent path: it cancels any warming
+    // standby, clears the queue, cancels the live turn, and flips turnInFlight
+    // off — no error-bubble side-effect because this is a user cancel. #1631.
+    const tid = activeAgentThread()?.id;
+    if (tid) {
+      await agentStore.abortTurn(tid);
+      return;
+    }
     const sid = threadSessionId();
     if (sid) agentStore.clearPromptQueue(sid);
     await agentStore.cancelPrompt(sid ?? undefined);
@@ -969,9 +1044,20 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
   const renderMessage = (message: AgentMessage, isLastMessage = false) => {
     switch (message.type) {
-      case "user":
+      case "user": {
+        // Inline terminal-error state (#1631): a 2px red left-border + "Couldn't
+        // send. Retry" link on the most-recent user bubble when the turn fails
+        // beyond the invisibility budget. Scope is the turn, not the app.
+        const tid = activeAgentThread()?.id;
+        const showTurnError = () => {
+          if (!isLastMessage || !tid) return false;
+          return agentStore.getTurnError(tid) !== null;
+        };
         return (
-          <article class="group/msg relative px-5 py-4 bg-surface-1 border-b border-surface-2 [contain:layout]">
+          <article
+            class="group/msg relative px-5 py-4 bg-surface-1 border-b border-surface-2 [contain:layout]"
+            classList={{ "border-l-2 border-l-destructive": showTurnError() }}
+          >
             <Show when={message.docNames?.length}>
               <div class="flex flex-wrap gap-1.5 mb-2">
                 <For each={message.docNames}>
@@ -1017,8 +1103,36 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 Fork
               </button>
             </Show>
+            <Show when={showTurnError()}>
+              <div class="mt-2 text-xs text-destructive">
+                Couldn't send.{" "}
+                <button
+                  type="button"
+                  class="underline bg-transparent border-none text-destructive cursor-pointer p-0 hover:brightness-125"
+                  onClick={() => {
+                    const id = activeAgentThread()?.id;
+                    if (!id) return;
+                    const ts = agentStore.getThreadState(id);
+                    const text = ts.lastPromptText ?? message.content;
+                    agentStore.clearTurnError(id);
+                    void agentStore.sendPrompt(
+                      text,
+                      ts.lastPromptContext,
+                      {
+                        displayContent: ts.lastPromptDisplay,
+                        docNames: ts.lastPromptDocNames,
+                      },
+                      threadSessionId() ?? undefined,
+                    );
+                  }}
+                >
+                  Retry
+                </button>
+              </div>
+            </Show>
           </article>
         );
+      }
 
       case "assistant":
         return (
@@ -1325,173 +1439,70 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           }
         }}
       >
+        {/* Session Messages */}
         <Show
-          when={hasSession()}
+          when={threadMessages().length > 0 || threadStreamingContent()}
           fallback={
-            <div class="flex-1 flex flex-col items-center justify-center p-10 text-muted-foreground">
-              <div class="max-w-[320px] text-center">
-                <svg
-                  class="w-12 h-12 mx-auto mb-4 text-surface-3"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  role="img"
-                  aria-label="Computer"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                    d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                  />
-                </svg>
-                <h3 class="m-0 mb-2 text-base font-medium text-foreground">
-                  Reconnecting {lockedAgentName()} Thread
-                </h3>
-                <p class="m-0 mb-4 text-sm">
-                  This conversation is locked to {lockedAgentName()}. Seren is
-                  reattaching the session for this thread.
-                </p>
-                <div class="flex flex-col items-center gap-3 w-full max-w-md">
-                  <Show when={lockedAgentType() === "claude-code"}>
-                    <div class="w-full px-3 py-2 bg-primary/10 border border-primary/30 rounded-md text-xs text-primary">
-                      <div class="flex items-start gap-2">
-                        <svg
-                          class="w-4 h-4 mt-0.5 flex-shrink-0"
-                          fill="currentColor"
-                          viewBox="0 0 20 20"
-                          role="img"
-                          aria-label="Info"
-                        >
-                          <path
-                            fill-rule="evenodd"
-                            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                            clip-rule="evenodd"
-                          />
-                        </svg>
-                        <span>
-                          <strong>Claude Code Required:</strong> Make sure
-                          Claude Code CLI is installed and run{" "}
-                          <code>claude login</code> to authenticate.
-                        </span>
-                      </div>
-                    </div>
-                  </Show>
-                  <Show when={!hasFolderOpen()}>
-                    <div class="w-full px-3 py-2 bg-destructive/10 border border-destructive/30 rounded-md text-xs text-destructive">
-                      Open a folder first to set the agent's working directory.
-                    </div>
-                  </Show>
-                  <button
-                    type="button"
-                    class="inline-flex items-center gap-2 px-4 py-2 bg-success text-white rounded-md text-sm font-medium hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    onClick={retrySessionConnection}
-                    disabled={agentStore.isLoading || !hasFolderOpen()}
-                  >
-                    <Show when={agentStore.isLoading}>
-                      <svg
-                        class="animate-spin w-4 h-4 shrink-0"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        aria-hidden="true"
-                      >
-                        <circle
-                          class="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          stroke-width="4"
-                        />
-                        <path
-                          class="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                        />
-                      </svg>
-                    </Show>
-                    {agentStore.isLoading
-                      ? "Reconnecting..."
-                      : "Retry Connection"}
-                  </button>
-                </div>
-              </div>
+            <div class="flex flex-col items-center justify-center p-10 text-muted-foreground">
+              <h3 class="m-0 mb-2 text-base font-medium text-foreground">
+                Agent Ready
+              </h3>
+              <p class="m-0 text-sm text-center max-w-[280px]">
+                Describe what you'd like the agent to do. It can read files,
+                make edits, run commands, and more.
+              </p>
             </div>
           }
         >
-          {/* Session Messages */}
+          <For each={groupConsecutiveToolCalls()}>
+            {(item, index) => {
+              const isLast = () =>
+                index() === groupConsecutiveToolCalls().length - 1;
+              if (item.type === "tool_group") {
+                return (
+                  <ToolCallGroup toolCalls={item.toolCalls} isComplete={true} />
+                );
+              }
+              return renderMessage(item.message, isLast());
+            }}
+          </For>
+
+          {/* Loading placeholder while waiting for first chunk.
+              Thinking dots follow `turnInFlight` — continuous across session
+              boundaries (predictive promotion, reactive retry, crash re-dispatch)
+              so the user never sees the indicator flicker off mid-restart. #1631. */}
           <Show
-            when={threadMessages().length > 0 || threadStreamingContent()}
-            fallback={
-              <div class="flex flex-col items-center justify-center p-10 text-muted-foreground">
-                <h3 class="m-0 mb-2 text-base font-medium text-foreground">
-                  Agent Ready
-                </h3>
-                <p class="m-0 text-sm text-center max-w-[280px]">
-                  Describe what you'd like the agent to do. It can read files,
-                  make edits, run commands, and more.
-                </p>
-              </div>
+            when={
+              activeAgentThread() &&
+              agentStore.isTurnInFlight(activeAgentThread()!.id) &&
+              !threadStreamingContent() &&
+              !threadStreamingThinking()
             }
           >
-            {/* Compacted summary from previous messages */}
-            <Show when={agentStore.activeSession?.compactedSummary}>
-              {(summary) => (
-                <CompactedMessage
-                  summary={summary() as AgentCompactedSummary}
-                />
-              )}
-            </Show>
+            <article class="px-5 py-4 border-b border-surface-2">
+              <ThinkingStatus startTime={promptStartTime} />
+            </article>
+          </Show>
 
-            <For each={groupConsecutiveToolCalls()}>
-              {(item, index) => {
-                const isLast = () =>
-                  index() === groupConsecutiveToolCalls().length - 1;
-                if (item.type === "tool_group") {
-                  return (
-                    <ToolCallGroup
-                      toolCalls={item.toolCalls}
-                      isComplete={true}
-                    />
-                  );
-                }
-                return renderMessage(item.message, isLast());
-              }}
-            </For>
+          {/* Streaming Thinking */}
+          <Show when={threadStreamingThinking()}>
+            <article class="px-5 py-3 border-b border-surface-2">
+              <ThinkingBlock
+                thinking={threadStreamingThinking()}
+                isStreaming={true}
+              />
+            </article>
+          </Show>
 
-            {/* Loading placeholder while waiting for first chunk */}
-            <Show
-              when={
-                isPrompting() &&
-                !threadStreamingContent() &&
-                !threadStreamingThinking()
-              }
-            >
-              <article class="px-5 py-4 border-b border-surface-2">
-                <ThinkingStatus startTime={promptStartTime} />
-              </article>
-            </Show>
-
-            {/* Streaming Thinking */}
-            <Show when={threadStreamingThinking()}>
-              <article class="px-5 py-3 border-b border-surface-2">
-                <ThinkingBlock
-                  thinking={threadStreamingThinking()}
-                  isStreaming={true}
-                />
-              </article>
-            </Show>
-
-            {/* Streaming Content */}
-            <Show when={threadStreamingContent()}>
-              <article class="px-5 py-4 border-b border-surface-2">
-                <div
-                  class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
-                  textContent={threadStreamingContent()}
-                />
-                <span class="inline-block w-2 h-4 ml-0.5 bg-primary animate-pulse" />
-              </article>
-            </Show>
+          {/* Streaming Content */}
+          <Show when={threadStreamingContent()}>
+            <article class="px-5 py-4 border-b border-surface-2">
+              <div
+                class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
+                textContent={threadStreamingContent()}
+              />
+              <span class="inline-block w-2 h-4 ml-0.5 bg-primary animate-pulse" />
+            </article>
           </Show>
         </Show>
       </div>

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -638,6 +638,15 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           lockedAgentType(),
           { localSessionId: thread.id },
         );
+        // User pressed Stop mid-spawn — abortTurn flipped turnInFlight off.
+        // Honor the cancel: terminate the spawn we just created (if any) and
+        // bail before dispatching the prompt. Without this, the async spawn
+        // resolves after Cancel and the user's prompt sneaks through.
+        if (!agentStore.isTurnInFlight(thread.id)) {
+          console.info("[AgentChat] cold-start cancelled during spawn");
+          if (sid) await agentStore.terminateSession(sid);
+          return;
+        }
         if (!sid) {
           console.warn("[AgentChat] cold-start spawn failed");
           agentStore.setTurnError(thread.id, "spawn_failed");
@@ -645,6 +654,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         }
       } catch (err) {
         console.error("[AgentChat] cold-start spawn threw:", err);
+        // If the user cancelled, don't overwrite their cancel with an error.
+        if (!agentStore.isTurnInFlight(thread.id)) return;
         agentStore.setTurnError(
           thread.id,
           "spawn_failed",
@@ -825,6 +836,16 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             mimeType: img.mimeType,
           }))
         : undefined;
+
+    // Late-cancel guard (#1631): Stop may fire between the cold-start spawn
+    // and the sendPrompt dispatch, or during an awaited skill/doc load.
+    // Honor the cancel before dispatching so the prompt never leaks through.
+    if (thread && !agentStore.isTurnInFlight(thread.id)) {
+      console.info(
+        "[AgentChat] sendMessage: cancel detected before dispatch — skipping sendPrompt",
+      );
+      return;
+    }
 
     console.log(
       "[AgentChat] Sending prompt to agent runtime, context blocks:",

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -852,6 +852,38 @@ export async function getInputHistory(
   return (await invoke("get_input_history", { conversationId })) as string[];
 }
 
+/**
+ * Read the persisted composer draft for a thread. Returns `""` when the
+ * thread has no draft or when the Tauri bridge is unavailable (web/preview). #1631.
+ */
+export async function getThreadDraft(threadId: string): Promise<string> {
+  const invoke = await getInvoke();
+  if (!invoke) return "";
+  try {
+    return (await invoke("get_thread_draft", { threadId })) as string;
+  } catch (err) {
+    console.warn("[tauri-bridge] getThreadDraft failed:", err);
+    return "";
+  }
+}
+
+/**
+ * Persist the composer draft for a thread. Survives hard crashes. Called
+ * on a 500ms input debounce and on thread switch. #1631.
+ */
+export async function setThreadDraft(
+  threadId: string,
+  draft: string,
+): Promise<void> {
+  const invoke = await getInvoke();
+  if (!invoke) return;
+  try {
+    await invoke("set_thread_draft", { threadId, draft });
+  } catch (err) {
+    console.warn("[tauri-bridge] setThreadDraft failed:", err);
+  }
+}
+
 export async function setAgentConversationMetadata(
   id: string,
   agentMetadata?: string | null,

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1507,7 +1507,17 @@ export const agentStore = {
       // instance while another is alive (see isRetryableClaudeInitError).
       // Without this, the new session times out 3x (60s) before the existing
       // post-failure idle-reclaim logic kicks in.
-      if (resolvedAgentType === "claude-code" && initRetryAttempt === 0) {
+      //
+      // Warm-standby spawns (#1631) are additive — they must NOT terminate
+      // any other session. If Claude CLI fails to init while the serving
+      // session is alive, the predictive path aborts silently and serving
+      // stays intact. Killing serving here would catastrophically replace
+      // the live session mid-turn.
+      if (
+        resolvedAgentType === "claude-code" &&
+        initRetryAttempt === 0 &&
+        opts?.role !== "standby"
+      ) {
         const idleSessions = getIdleClaudeSessionIds(localSessionId);
         for (const idleId of idleSessions) {
           console.log(

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -39,6 +39,30 @@ const spawnContextMap = new Map<
 const SESSION_READY_TIMEOUT_MS = 30_000;
 
 /**
+ * Predictive-compaction trigger: fire when input tokens hit this fraction
+ * of the agent's context window. Hard-coded — not exposed as a setting. #1631.
+ */
+export const PREDICTIVE_COMPACT_THRESHOLD = 0.7;
+
+/**
+ * Global cap = 1 simultaneous predictive compaction across the whole app.
+ * Prevents 3x Sonnet 4 calls and 3x Node subprocesses when multiple threads
+ * cross the threshold in the same promptComplete tick. #1631.
+ */
+let predictiveCompactBusy = false;
+
+/**
+ * Per-thread restart-timer handles. Cleared when the turn produces its
+ * first stream chunk or when a terminal error flips the bubble. #1631.
+ */
+const restartTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** Invisibility-budget constants per restart-dependent scenario (#1631). */
+export const BUDGET_COLD_START_MS = 60_000;
+export const BUDGET_REACTIVE_COMPACT_MS = 90_000;
+export const BUDGET_CRASH_MS = 60_000;
+
+/**
  * Instruction prepended to every agent session telling Claude Code / Codex
  * that the Seren MCP gateway exists and MUST be queried live before refusing
  * any third-party service. Intentionally does NOT embed a snapshot of
@@ -166,6 +190,10 @@ import * as providerService from "@/services/providers";
  *  initialize() calls don't stack listeners. */
 let providerRuntimeReadyListener: Promise<UnlistenFn> | null = null;
 
+/** Set once we've subscribed to `provider-runtime://restarted` so repeated
+ *  initialize() calls don't stack listeners. #1631. */
+let providerRuntimeRestartedListener: Promise<UnlistenFn> | null = null;
+
 /** Commit an agent list into the store + settle the selected-agent fallback.
  *  Shared by `initialize()` and the `provider-runtime://ready` listener so
  *  they produce identical post-conditions. See GH #1587. */
@@ -187,40 +215,107 @@ function applyAgents(agents: providerService.AgentInfo[]): void {
  *  reload. See GH #1587. */
 function subscribeToProviderRuntimeReady(): void {
   if (providerRuntimeReadyListener) return;
-  providerRuntimeReadyListener = listen("provider-runtime://ready", async () => {
-    try {
-      const agents = await providerService.getAvailableAgents();
-      if (agents.length > 0) {
-        applyAgents(agents);
+  providerRuntimeReadyListener = listen(
+    "provider-runtime://ready",
+    async () => {
+      try {
+        const agents = await providerService.getAvailableAgents();
+        if (agents.length > 0) {
+          applyAgents(agents);
+        }
+      } catch (error) {
+        console.error(
+          "Failed to load agents on provider-runtime ready event:",
+          error,
+        );
       }
-    } catch (error) {
-      console.error(
-        "Failed to load agents on provider-runtime ready event:",
-        error,
+    },
+  );
+}
+
+/**
+ * Subscribe once to `provider-runtime://restarted`. The Rust monitor emits
+ * this after the Node provider-runtime subprocess auto-restarts. We drop
+ * every live session (all IDs belong to the dead process) and, for threads
+ * with an in-flight turn, silently re-dispatch the last prompt on a fresh
+ * spawn. Threads with no in-flight turn wait for the next user submit. #1631.
+ */
+function subscribeToProviderRuntimeRestarted(): void {
+  if (providerRuntimeRestartedListener) return;
+  providerRuntimeRestartedListener = listen(
+    "provider-runtime://restarted",
+    () => {
+      console.info(
+        "[AgentStore] provider-runtime://restarted — invalidating serving pointers",
       );
-    }
-  });
+      const snapshot = Object.entries(state.sessions).map(([id, s]) => ({
+        id,
+        conversationId: s.conversationId,
+        cwd: s.cwd,
+        agentType: s.info.agentType,
+        messages: s.messages,
+      }));
+      for (const { id } of snapshot) terminatedSessionIds.add(id);
+      setState(
+        produce((draft) => {
+          for (const { id } of snapshot) delete draft.sessions[id];
+        }),
+      );
+      setState("activeSessionId", null);
+
+      for (const snap of snapshot) {
+        const ts = state.threadStates[snap.conversationId];
+        if (!ts?.turnInFlight || !ts.lastPromptText) continue;
+        void (async () => {
+          agentStore.armRestartTimer(
+            snap.conversationId,
+            BUDGET_CRASH_MS,
+            "crash_ceiling",
+          );
+          const newId = await agentStore.spawnSession(
+            snap.cwd,
+            snap.agentType,
+            {
+              localSessionId: snap.conversationId,
+              restoredMessages: snap.messages,
+            },
+          );
+          if (!newId) {
+            agentStore.setTurnError(snap.conversationId, "crash_ceiling");
+            return;
+          }
+          try {
+            await agentStore.sendPrompt(
+              ts.lastPromptText as string,
+              ts.lastPromptContext,
+              {
+                displayContent: ts.lastPromptDisplay,
+                docNames: ts.lastPromptDocNames,
+              },
+              newId,
+            );
+          } catch (err) {
+            console.error("[AgentStore] crash re-dispatch failed:", err);
+            agentStore.setTurnError(
+              snap.conversationId,
+              "crash_ceiling",
+              err instanceof Error ? err.message : String(err),
+            );
+          }
+        })();
+      }
+    },
+  );
 }
 
 // ============================================================================
 // Types
 // ============================================================================
 
-export interface PreCompactionMessage {
-  id: string;
-  type: "user" | "assistant";
-  content: string;
-  timestamp: number;
-}
-
 export interface AgentCompactedSummary {
   content: string;
   originalMessageCount: number;
   compactedAt: number;
-  /** Original user/assistant text shown under the summary card so the user
-   * can still read pre-compaction scrollback. Tool calls and thoughts are
-   * intentionally omitted — only text conversation is preserved. */
-  preCompactionMessages?: PreCompactionMessage[];
 }
 
 interface AgentConversationMetadata {
@@ -340,6 +435,23 @@ export interface ActiveSession {
   /** Queued prompts awaiting dispatch when the session returns to ready.
    *  Lives in the store (not the component) so background threads still drain. */
   pendingPrompts: string[];
+  /**
+   * Serving = the session the user is talking to. Standby = a warm
+   * replacement session being seeded via predictive compaction — invisible
+   * to the UI, not dispatch-eligible until promoted. #1631.
+   */
+  role: "serving" | "standby";
+  /**
+   * True once the standby session finished its compaction seed prompt and
+   * is eligible for `promoteStandbyAndDispatch`. Always false for serving
+   * sessions. #1631.
+   */
+  seedCompleted?: boolean;
+  /** In-flight predictive compaction flag — prevents double-kicking the
+   *  same serving session into another warm-up. #1631. */
+  predictiveCompactInFlight?: boolean;
+  /** Sibling standby session id while predictive compaction is warming. */
+  standbySessionId?: string | null;
 }
 
 // ============================================================================
@@ -524,11 +636,52 @@ function clearLegacyAgentTranscript(conversationId: string): void {
 // State
 // ============================================================================
 
+/**
+ * Terminal error classification for the inline-per-bubble error state.
+ * Closed union — callers must map any new failure into one of these. #1631.
+ */
+export type ErrorKind =
+  | "restart_timeout"
+  | "spawn_failed"
+  | "auth_expired"
+  | "binary_missing"
+  | "crash_ceiling"
+  | "summary_call_failed"
+  | "seed_failed";
+
+export interface TurnError {
+  kind: ErrorKind;
+  retryable: boolean;
+  message?: string;
+}
+
+/**
+ * Per-thread state that survives session swaps (predictive promotion,
+ * reactive compact-and-retry, crash re-dispatch). Keyed by conversationId
+ * so compaction — which mints a new sessionId but keeps conversationId —
+ * preserves the in-flight signal and terminal-error state. #1631.
+ */
+export interface ThreadRuntimeState {
+  turnInFlight: boolean;
+  turnError: TurnError | null;
+  /** Absolute ms epoch when the current restart-dependent turn must have
+   *  produced a streaming chunk by. `null` outside restart-dependent paths. */
+  restartTimerExpiresAt: number | null;
+  /** Text + context of the last submitted user prompt so retry-link and
+   *  crash re-dispatch can resend without relying on stale session state. */
+  lastPromptText?: string;
+  lastPromptContext?: Array<Record<string, string>>;
+  lastPromptDisplay?: string;
+  lastPromptDocNames?: string[];
+}
+
 interface AgentState {
   /** Available agents and their status */
   availableAgents: AgentInfo[];
   /** Active sessions keyed by session ID */
   sessions: Record<string, ActiveSession>;
+  /** Per-thread runtime state keyed by conversationId (#1631). */
+  threadStates: Record<string, ThreadRuntimeState>;
   /** Currently focused session ID */
   activeSessionId: string | null;
   /** Selected agent type for new sessions */
@@ -557,6 +710,7 @@ interface AgentState {
 const [state, setState] = createStore<AgentState>({
   availableAgents: [],
   sessions: {},
+  threadStates: {},
   activeSessionId: null,
   selectedAgentType: "claude-code",
   recentAgentConversations: [],
@@ -737,6 +891,10 @@ function getIdleClaudeSessionIds(excludeConversationId?: string): string[] {
     .filter(([id, session]) => {
       if (session.info.agentType !== "claude-code") return false;
       if (id === activeId) return false;
+      // Warm standby sessions must NOT be reclaimed — they are the whole
+      // point of predictive compaction. Killing one mid-warm-up defeats
+      // the invisibility budget for the next user submit. #1631.
+      if (session.role === "standby") return false;
       if (
         excludeConversationId &&
         session.conversationId === excludeConversationId
@@ -906,6 +1064,166 @@ export const agentStore = {
     setState("sessions", sessionId, "pendingPrompts", (q) => [...q, prompt]);
   },
 
+  // ============================================================================
+  // Per-thread runtime state (turnInFlight / turnError / last-prompt) — #1631
+  // ============================================================================
+
+  getThreadState(threadId: string): ThreadRuntimeState {
+    return (
+      state.threadStates[threadId] ?? {
+        turnInFlight: false,
+        turnError: null,
+        restartTimerExpiresAt: null,
+      }
+    );
+  },
+
+  isTurnInFlight(threadId: string): boolean {
+    return state.threadStates[threadId]?.turnInFlight === true;
+  },
+
+  getTurnError(threadId: string): TurnError | null {
+    return state.threadStates[threadId]?.turnError ?? null;
+  },
+
+  _ensureThreadState(threadId: string): void {
+    if (!state.threadStates[threadId]) {
+      setState("threadStates", threadId, {
+        turnInFlight: false,
+        turnError: null,
+        restartTimerExpiresAt: null,
+      });
+    }
+  },
+
+  setTurnInFlight(threadId: string, value: boolean): void {
+    this._ensureThreadState(threadId);
+    setState("threadStates", threadId, "turnInFlight", value);
+    if (!value) this.clearRestartTimer(threadId);
+  },
+
+  /** Record the last-submitted prompt so retry-link and crash re-dispatch
+   *  can resend with the same text + attachments. */
+  setLastPrompt(
+    threadId: string,
+    prompt: string,
+    context?: Array<Record<string, string>>,
+    display?: string,
+    docNames?: string[],
+  ): void {
+    this._ensureThreadState(threadId);
+    setState("threadStates", threadId, "lastPromptText", prompt);
+    setState("threadStates", threadId, "lastPromptContext", context);
+    setState("threadStates", threadId, "lastPromptDisplay", display);
+    setState("threadStates", threadId, "lastPromptDocNames", docNames);
+  },
+
+  /**
+   * Arm a per-turn invisibility budget. When it expires and the turn is
+   * still in-flight and no stream chunk has landed, the bubble flips to
+   * a terminal error — see #1631 failure-mode section.
+   */
+  armRestartTimer(threadId: string, budgetMs: number, reason: ErrorKind): void {
+    this._ensureThreadState(threadId);
+    this.clearRestartTimer(threadId);
+    setState(
+      "threadStates",
+      threadId,
+      "restartTimerExpiresAt",
+      Date.now() + budgetMs,
+    );
+    const timer = setTimeout(() => {
+      restartTimers.delete(threadId);
+      const ts = state.threadStates[threadId];
+      if (!ts || !ts.turnInFlight) return;
+      const session = Object.values(state.sessions).find(
+        (s) => s.conversationId === threadId,
+      );
+      const streamingNow =
+        !!session && (session.streamingContent || session.streamingThinking);
+      if (streamingNow) {
+        // A response started — drop the timer silently; the turn will
+        // finalize normally.
+        setState("threadStates", threadId, "restartTimerExpiresAt", null);
+        return;
+      }
+      this.setTurnError(threadId, reason, `invisibility budget exceeded`);
+    }, budgetMs);
+    restartTimers.set(threadId, timer);
+  },
+
+  clearRestartTimer(threadId: string): void {
+    const t = restartTimers.get(threadId);
+    if (t) {
+      clearTimeout(t);
+      restartTimers.delete(threadId);
+    }
+    if (state.threadStates[threadId]) {
+      setState("threadStates", threadId, "restartTimerExpiresAt", null);
+    }
+  },
+
+  setTurnError(threadId: string, kind: ErrorKind, message?: string): void {
+    this._ensureThreadState(threadId);
+    const retryable = kind !== "auth_expired" && kind !== "binary_missing";
+    setState("threadStates", threadId, "turnError", {
+      kind,
+      retryable,
+      message,
+    });
+    // Surface the inline error — the thinking dots stop, the bubble turns red.
+    setState("threadStates", threadId, "turnInFlight", false);
+    this.clearRestartTimer(threadId);
+    // Fire-and-forget auto-report through #1630's pipeline. If that
+    // ticket is not yet merged, the invoke will throw and be swallowed.
+    this._submitTurnErrorReport(threadId, kind, message);
+  },
+
+  clearTurnError(threadId: string): void {
+    if (!state.threadStates[threadId]) return;
+    setState("threadStates", threadId, "turnError", null);
+  },
+
+  _submitTurnErrorReport(
+    threadId: string,
+    kind: ErrorKind,
+    message: string | undefined,
+  ): void {
+    try {
+      const session = Object.values(state.sessions).find(
+        (s) => s.conversationId === threadId,
+      );
+      const bundle = {
+        error_kind: kind,
+        stack: message ?? "",
+        agent_type: session?.info.agentType ?? "unknown",
+        session_age_ms: session?.info.createdAt
+          ? Date.now() - Date.parse(session.info.createdAt)
+          : 0,
+        message_count: session?.messages.length ?? 0,
+        token_usage: session?.lastInputTokens ?? 0,
+        token_ratio:
+          session && session.contextWindowSize
+            ? (session.lastInputTokens ?? 0) / session.contextWindowSize
+            : 0,
+        restart_attempt: 0,
+        path: "reactive",
+      };
+      // TODO(#1630): When the support-pipeline ticket lands, this becomes
+      // the canonical auto-report callsite. Until then the invoke rejects
+      // silently (no backend command registered) and we only log.
+      console.warn(
+        "[AgentStore] Terminal turn error — submit_support_report:",
+        bundle,
+      );
+    } catch (err) {
+      console.warn(
+        "[AgentStore] _submitTurnErrorReport failed (ignored):",
+        err,
+      );
+    }
+  },
+
   /** Get the pending prompt queue for a session (reactive). */
   getPendingPrompts(sessionId: string): string[] {
     return state.sessions[sessionId]?.pendingPrompts ?? [];
@@ -978,6 +1296,7 @@ export const agentStore = {
     // re-query the agent list then. Idempotent because repeated calls
     // to applyAgents just overwrite availableAgents with the same data.
     subscribeToProviderRuntimeReady();
+    subscribeToProviderRuntimeRestarted();
 
     const backoffMs = [0, 1_000, 2_000, 4_000, 8_000];
     for (let attempt = 0; attempt < backoffMs.length; attempt++) {
@@ -1113,6 +1432,9 @@ export const agentStore = {
       bootstrapPromptContext?: string;
       initialModelId?: string;
       initialPermissionMode?: string;
+      /** Warm-standby spawns are invisible to the UI — no session-selector
+       *  entry, events buffered not rendered, does not steal active focus. */
+      role?: "serving" | "standby";
     },
   ): Promise<string | null> {
     const resolvedAgentType = agentType ?? state.selectedAgentType;
@@ -1168,7 +1490,10 @@ export const agentStore = {
             memoryContext = bootstrapped;
           }
         } catch (err) {
-          console.warn("[AgentStore] memory bootstrap failed (non-fatal):", err);
+          console.warn(
+            "[AgentStore] memory bootstrap failed (non-fatal):",
+            err,
+          );
         }
       }
       const finalBootstrapContext = memoryContext
@@ -1502,6 +1827,7 @@ export const agentStore = {
                 : 200_000,
           bootstrapPromptContext: finalBootstrapContext,
           pendingPrompts: [],
+          role: opts?.role ?? "serving",
         };
 
         setState("sessions", info.id, session);
@@ -2168,6 +2494,29 @@ export const agentStore = {
     // subscriber immediately starts dropping late-arriving events.
     terminatedSessionIds.add(sessionId);
 
+    // Dismiss any pending ActionConfirmation dialogs whose owning session is
+    // going away — the user must not approve a tool call against a dead
+    // session. If the promoted/new session still wants the tool, it will
+    // emit a fresh permissionRequest. #1631.
+    const hasPermissions = state.pendingPermissions.some(
+      (p) => p.sessionId === sessionId,
+    );
+    const hasDiffs = state.pendingDiffProposals.some(
+      (p) => p.sessionId === sessionId,
+    );
+    if (hasPermissions) {
+      setState(
+        "pendingPermissions",
+        state.pendingPermissions.filter((p) => p.sessionId !== sessionId),
+      );
+    }
+    if (hasDiffs) {
+      setState(
+        "pendingDiffProposals",
+        state.pendingDiffProposals.filter((p) => p.sessionId !== sessionId),
+      );
+    }
+
     try {
       await providerService.terminateSession(sessionId);
     } catch (error) {
@@ -2255,7 +2604,15 @@ export const agentStore = {
      * transfer below — see #1623.
      */
     pendingUserPrompt?: string,
+    /**
+     * Predictive mode spawns a warm standby (role="standby") WITHOUT
+     * terminating the old serving session. The new session is visible to
+     * events but invisible to the UI until `promoteStandbyAndDispatch`
+     * promotes it on the next user submit. #1631.
+     */
+    opts?: { mode?: "reactive" | "predictive" },
   ): Promise<CompactionOutcome> {
+    const mode = opts?.mode ?? "reactive";
     const session = state.sessions[sessionId];
     if (!session || session.isCompacting) {
       return "skipped_nothing_to_compact";
@@ -2315,40 +2672,63 @@ Structured summary:`;
         }
       }
 
-      const preCompactionMessages: PreCompactionMessage[] = toCompact
-        .filter(
-          (m): m is AgentMessage & { type: "user" | "assistant" } =>
-            m.type === "user" || m.type === "assistant",
-        )
-        .map((m) => ({
-          id: m.id,
-          type: m.type,
-          content: m.content,
-          timestamp: m.timestamp,
-        }));
-
       const compactedSummary: AgentCompactedSummary = {
         content: summary,
         originalMessageCount: toCompact.length,
         compactedAt: Date.now(),
-        preCompactionMessages,
       };
 
       // Capture session details and user-configured settings before termination
       const cwd = session.cwd;
       const agentType = session.info.agentType;
       const conversationId = session.conversationId;
-      // Transfer the queue of user-typed-but-not-yet-sent prompts to the new
-      // session. In the race where the user types while the agent is mid-turn
-      // and the in-flight turn triggers compaction, those prompts must survive
-      // — previously they were overwritten by compaction's stale `toPreserve`
-      // snapshot (#1623). Seeding + promptComplete on the new session will
-      // drain this queue naturally.
       const queuedPrompts = session.pendingPrompts ?? [];
-      // Terminate the old agent session
+
+      // Build the structured seed prompt up-front — shared by both modes.
+      const MAX_MSG_CHARS = 2000;
+      const preservedContext = toPreserve
+        .filter((m) => m.type === "user" || m.type === "assistant")
+        .map((m) => {
+          const content =
+            m.content.length > MAX_MSG_CHARS
+              ? `${m.content.slice(0, MAX_MSG_CHARS)}... [truncated]`
+              : m.content;
+          return `${m.type.toUpperCase()}: ${content}`;
+        })
+        .join("\n\n");
+      const seedPrompt = preservedContext
+        ? `Context restored after automatic compaction.\n\nPrior work summary:\n${summary}\n\nRecent messages:\n${preservedContext}\n\nConfirm you have this context in one sentence, then wait for the user's next message. Do not use any tools.`
+        : `Context restored after automatic compaction.\n\nPrior work summary:\n${summary}\n\nConfirm you have this context in one sentence, then wait for the user's next message. Do not use any tools.`;
+
+      if (mode === "predictive") {
+        // Predictive path: spawn a STANDBY session alongside the live one.
+        // No teardown, no UI side-effects — the next user submit promotes it.
+        const standbyId = await this.spawnSession(cwd, agentType, {
+          role: "standby",
+        });
+        if (!standbyId) {
+          setState("sessions", sessionId, "isCompacting", false);
+          throw new Error(
+            "CompactionFailure: predictive standby spawn returned null",
+          );
+        }
+        setState("sessions", standbyId, "compactedSummary", compactedSummary);
+        setState("sessions", sessionId, "standbySessionId", standbyId);
+        await waitForSessionReady(standbyId);
+        await this.restoreSessionSettings(session, standbyId);
+        await providerService.sendPrompt(standbyId, seedPrompt);
+        // promptComplete handler detects role==="standby" and sets
+        // seedCompleted + releases predictiveCompactBusy.
+        setState("sessions", sessionId, "isCompacting", false);
+        console.info(
+          `[AgentStore] Predictive compaction: standby ${standbyId} seeding for serving ${sessionId}`,
+        );
+        return "succeeded";
+      }
+
+      // Reactive path: terminate old, spawn fresh serving, seed, retry.
       await this.terminateSession(sessionId);
 
-      // Spawn a new agent session with the same conversation
       const newSessionId = await this.spawnSession(cwd, agentType, {
         localSessionId: conversationId,
       });
@@ -2362,69 +2742,34 @@ Structured summary:`;
         );
       }
 
-      // Store compacted summary and preserved messages on the new session.
-      // Mark them as restored so the message-count threshold ignores them.
       setState("sessions", newSessionId, "compactedSummary", compactedSummary);
 
-      // Prepend a visible notice so the user knows compaction occurred and
-      // understands why earlier messages are no longer visible.
-      const compactionNotice: AgentMessage = {
-        id: crypto.randomUUID(),
-        type: "assistant",
-        content: `Context compacted: ${toCompact.length} earlier messages summarized to keep the session active. The ${toPreserve.length} most recent messages are shown below.`,
-        timestamp: Date.now(),
-      };
-      setState("sessions", newSessionId, "messages", [
-        compactionNotice,
-        ...toPreserve,
-      ]);
+      // UI history is decoupled from model context (#1631). The new session
+      // inherits the full transcript so users still see every earlier turn
+      // on scroll-up — the model's context is the structured summary + the
+      // preserved tail, seeded via the seed prompt below, not the transcript.
+      const fullTranscript = [...session.messages];
+      setState("sessions", newSessionId, "messages", fullTranscript);
       setState(
         "sessions",
         newSessionId,
         "restoredMessageCount",
-        toPreserve.length + 1, // +1 for the compaction notice
+        fullTranscript.length,
       );
-      // Hand the queue to the new session so promptComplete will drain it.
       if (queuedPrompts.length > 0) {
         setState("sessions", newSessionId, "pendingPrompts", queuedPrompts);
       }
 
-      // Seed the new agent with the summary so it has context
       console.info(
         `[AgentStore] Compacted ${toCompact.length} messages, preserved ${toPreserve.length}. Seeding new session.`,
       );
 
-      // Build a condensed representation of preserved messages so the agent
-      // retains awareness of recent work, not just the high-level summary.
-      const MAX_MSG_CHARS = 2000;
-      const preservedContext = toPreserve
-        .filter((m) => m.type === "user" || m.type === "assistant")
-        .map((m) => {
-          const content =
-            m.content.length > MAX_MSG_CHARS
-              ? `${m.content.slice(0, MAX_MSG_CHARS)}... [truncated]`
-              : m.content;
-          return `${m.type.toUpperCase()}: ${content}`;
-        })
-        .join("\n\n");
-
-      const seedPrompt = preservedContext
-        ? `Context restored after automatic compaction.\n\nPrior work summary:\n${summary}\n\nRecent messages:\n${preservedContext}\n\nConfirm you have this context in one sentence, then wait for the user's next message. Do not use any tools.`
-        : `Context restored after automatic compaction.\n\nPrior work summary:\n${summary}\n\nConfirm you have this context in one sentence, then wait for the user's next message. Do not use any tools.`;
-
       // Wait for the new session to be ready, then restore settings and seed
       await waitForSessionReady(newSessionId);
-
-      // Restore user-configured settings from the prior session
       await this.restoreSessionSettings(session, newSessionId);
-
       await providerService.sendPrompt(newSessionId, seedPrompt);
-
-      // Wait for the seed prompt to finish before retrying the user's message.
       await waitForSessionIdle(newSessionId);
 
-      // Retry the user's last prompt if one was in-flight when compaction
-      // triggered. This prevents the message from being silently dropped.
       if (pendingUserPrompt) {
         console.info(
           "[AgentStore] Retrying user prompt after auto-compaction:",
@@ -2539,6 +2884,116 @@ Structured summary:`;
   },
 
   /**
+   * Warm a standby session in the background. Serving session keeps running;
+   * the standby is seeded with the compaction summary so the next submit can
+   * swap invisibly. Idempotent per-session and globally bounded via
+   * `predictiveCompactBusy`. #1631.
+   */
+  async kickPredictiveCompact(sessionId: string): Promise<void> {
+    if (predictiveCompactBusy) return;
+    const session = state.sessions[sessionId];
+    if (!session || session.predictiveCompactInFlight) return;
+
+    predictiveCompactBusy = true;
+    setState("sessions", sessionId, "predictiveCompactInFlight", true);
+    try {
+      const outcome = await this.compactAgentConversation(
+        sessionId,
+        settingsStore.settings.autoCompactPreserveMessages,
+        undefined,
+        { mode: "predictive" },
+      );
+      if (outcome !== "succeeded") {
+        // Silent abort — serving session is still healthy.
+        console.warn(
+          "[AgentStore] kickPredictiveCompact: non-success outcome",
+          outcome,
+        );
+        predictiveCompactBusy = false;
+        setState("sessions", sessionId, "predictiveCompactInFlight", false);
+      }
+      // On success, the standby's promptComplete handler clears both flags.
+    } catch (err) {
+      console.warn(
+        "[AgentStore] kickPredictiveCompact failed (non-fatal):",
+        err,
+      );
+      predictiveCompactBusy = false;
+      setState("sessions", sessionId, "predictiveCompactInFlight", false);
+    }
+  },
+
+  /**
+   * Promote the warm standby to serving and dispatch the user's new prompt
+   * on it. Called from the send path at turn boundary. Old serving session
+   * is terminated; UI transcript is transferred atomically to the promoted
+   * session so the user sees no discontinuity. #1631.
+   */
+  async promoteStandbyAndDispatch(
+    servingSessionId: string,
+    prompt: string,
+    context?: Array<Record<string, string>>,
+    options?: { displayContent?: string; docNames?: string[] },
+  ): Promise<void> {
+    const serving = state.sessions[servingSessionId];
+    const standbyId = serving?.standbySessionId;
+    const standby = standbyId ? state.sessions[standbyId] : undefined;
+    if (!serving || !standby) {
+      // Fall through — caller will dispatch to serving.
+      return;
+    }
+    const conversationId = serving.conversationId;
+
+    // Transfer the UI transcript to the promoted session so scroll-up is
+    // preserved across the swap. The standby session was invisible until now.
+    const fullTranscript = [...serving.messages];
+    setState("sessions", standbyId!, "messages", fullTranscript);
+    setState(
+      "sessions",
+      standbyId!,
+      "restoredMessageCount",
+      fullTranscript.length,
+    );
+    // Inherit persisted conversationId so SQLite keeps a single thread.
+    setState("sessions", standbyId!, "conversationId", conversationId);
+    setState("sessions", standbyId!, "role", "serving");
+    setState("sessions", standbyId!, "seedCompleted", undefined);
+
+    // Clear the serving pointer before terminating so late events from the
+    // old session are fully dropped.
+    await this.terminateSession(servingSessionId);
+
+    // Dispatch on the promoted session.
+    await this.sendPrompt(prompt, context, options, standbyId!);
+  },
+
+  /**
+   * User-initiated cancel of the current turn across any restart-dependent
+   * path. Cancels any warming standby, clears the prompt queue, drops the
+   * in-flight turn, and leaves the composer enabled. Does NOT set turnError
+   * — a user cancel is not a failure. #1631.
+   */
+  async abortTurn(threadId: string): Promise<void> {
+    const session = Object.values(state.sessions).find(
+      (s) => s.conversationId === threadId && s.role === "serving",
+    );
+    if (session?.standbySessionId) {
+      await this.terminateSession(session.standbySessionId).catch(() => {});
+      setState("sessions", session.info.id, "standbySessionId", null);
+    }
+    if (session) {
+      setState("sessions", session.info.id, "pendingPrompts", []);
+      try {
+        await providerService.cancelPrompt(session.info.id);
+      } catch (err) {
+        console.warn("[AgentStore] abortTurn cancelPrompt failed:", err);
+      }
+    }
+    this.setTurnInFlight(threadId, false);
+    this.clearTurnError(threadId);
+  },
+
+  /**
    * Focus an already-running session that belongs to the given project cwd.
    * Returns true when a matching session is found.
    */
@@ -2573,12 +3028,54 @@ Structured summary:`;
       sessionId,
       prompt: prompt.slice(0, 50),
     });
-    if (!sessionId) {
-      setState("error", "No active session");
-      return;
+
+    const session = sessionId ? state.sessions[sessionId] : undefined;
+
+    // Derive the thread id early so turnInFlight / turnError operate on the
+    // right key across cold-start, promotion, and crash-recovery paths. #1631.
+    const threadId = session?.conversationId;
+
+    if (threadId) {
+      this.setTurnInFlight(threadId, true);
+      this.setLastPrompt(
+        threadId,
+        prompt,
+        context,
+        options?.displayContent,
+        options?.docNames,
+      );
+      this.clearTurnError(threadId);
     }
 
-    const session = state.sessions[sessionId];
+    // Predictive swap: if a warm standby is ready, promote it at this turn
+    // boundary before dispatching. The old serving session is terminated
+    // inside promoteStandbyAndDispatch; transcript + conversationId transfer
+    // so the user sees no break. #1631.
+    if (session && session.role === "serving" && session.standbySessionId) {
+      const standby = state.sessions[session.standbySessionId];
+      if (standby && standby.seedCompleted === true) {
+        console.info(
+          `[AgentStore] Promoting standby ${session.standbySessionId} for serving ${sessionId}`,
+        );
+        await this.promoteStandbyAndDispatch(
+          sessionId!,
+          prompt,
+          context,
+          options,
+        );
+        return;
+      }
+      if (standby) {
+        // Standby not ready yet — cancel it; old serving handles this prompt.
+        console.info(
+          "[AgentStore] Standby not ready at submit; cancelling warm-up",
+        );
+        await this.terminateSession(session.standbySessionId).catch(() => {});
+        setState("sessions", sessionId!, "standbySessionId", null);
+        predictiveCompactBusy = false;
+        setState("sessions", sessionId!, "predictiveCompactInFlight", false);
+      }
+    }
 
     // Defensive: if a caller races compaction (e.g. a stray setTimeout the
     // drain block scheduled before the auto-compact block set isCompacting),
@@ -2588,9 +3085,17 @@ Structured summary:`;
     if (session?.isCompacting) {
       console.info(
         "[AgentStore] sendPrompt: session is compacting, re-enqueuing",
-        { sessionId, prompt: prompt.slice(0, 50) },
+        { sessionId: sessionId ?? "?", prompt: prompt.slice(0, 50) },
       );
-      this.enqueuePrompt(sessionId, prompt);
+      if (sessionId) this.enqueuePrompt(sessionId, prompt);
+      return;
+    }
+
+    if (!sessionId || !session) {
+      console.warn(
+        "[AgentStore] sendPrompt: no session — caller must spawn first",
+      );
+      if (threadId) this.setTurnInFlight(threadId, false);
       return;
     }
 
@@ -2817,47 +3322,19 @@ Structured summary:`;
             }
 
             if (wasUserCancel) {
-              // The user explicitly cancelled — don't retry. Just show a
-              // neutral message so they know the session was restarted.
               console.info(
                 "[AgentStore] Agent unresponsive after cancel — spawned fresh session, skipping retry",
               );
-              const cancelMsg: AgentMessage = {
-                id: crypto.randomUUID(),
-                type: "assistant",
-                content: "Session restarted after cancellation.",
-                timestamp: Date.now(),
-              };
-              setState("sessions", newSessionId, "messages", (msgs) => [
-                ...msgs,
-                cancelMsg,
-              ]);
-              const newConvoId = state.sessions[newSessionId]?.conversationId;
-              if (newConvoId) {
-                persistAgentMessage(newConvoId, cancelMsg);
-              }
             } else {
-              // Show recovery indicator so the user knows what happened
-              const recoveryMsg: AgentMessage = {
-                id: crypto.randomUUID(),
-                type: "assistant",
-                content:
-                  "Agent session restarted due to inactivity timeout. Retrying your message...",
-                timestamp: Date.now(),
-              };
               setState("sessions", newSessionId, "messages", (msgs) => [
                 ...msgs,
-                recoveryMsg,
                 userMessage,
               ]);
               const newConvoId = state.sessions[newSessionId]?.conversationId;
               if (newConvoId) {
-                persistAgentMessage(newConvoId, recoveryMsg);
                 persistAgentMessage(newConvoId, userMessage);
               }
 
-              // Retry the prompt on the new session, rebuilding skills context
-              // so skill invocations work on the fresh session.
               console.info(
                 `[AgentStore] Retrying prompt on new session ${newSessionId}`,
               );
@@ -2875,13 +3352,12 @@ Structured summary:`;
                 console.log("[AgentStore] Retry succeeded on new session");
               } catch (retryError) {
                 console.error("[AgentStore] Retry failed:", retryError);
-                const retryMessage =
+                this.setTurnError(
+                  session.conversationId,
+                  "restart_timeout",
                   retryError instanceof Error
                     ? retryError.message
-                    : String(retryError);
-                this.addErrorMessage(
-                  newSessionId,
-                  `Recovery failed: ${retryMessage}. Please try sending your message again.`,
+                    : String(retryError),
                 );
               }
             }
@@ -3293,6 +3769,19 @@ Structured summary:`;
   // ============================================================================
 
   handleSessionEvent(sessionId: string, event: AgentEvent) {
+    // Warm-standby sessions must stay invisible until they are promoted.
+    // Only session-status / promptComplete / error events affect lifecycle;
+    // every other event would otherwise leak the seed prompt into the UI. #1631.
+    const session = state.sessions[sessionId];
+    if (
+      session?.role === "standby" &&
+      event.type !== "sessionStatus" &&
+      event.type !== "promptComplete" &&
+      event.type !== "error"
+    ) {
+      return;
+    }
+
     // User replay messages can arrive as multiple chunks; flush buffered user
     // text when the stream transitions to a non-user event.
     if (event.type !== "userMessage") {
@@ -3335,6 +3824,33 @@ Structured summary:`;
         break;
 
       case "promptComplete": {
+        // Standby sessions exist only to seed their context. First promptComplete
+        // marks the seed done and releases the predictive mutex — no UI effects,
+        // no drain, no compaction re-trigger. #1631.
+        if (state.sessions[sessionId]?.role === "standby") {
+          setState("sessions", sessionId, "seedCompleted", true);
+          setState(
+            "sessions",
+            sessionId,
+            "info",
+            "status",
+            "ready" as SessionStatus,
+          );
+          predictiveCompactBusy = false;
+          const owner = state.sessions[sessionId];
+          if (owner?.conversationId) {
+            for (const [sid, s] of Object.entries(state.sessions)) {
+              if (
+                s.conversationId === owner.conversationId &&
+                s.role === "serving"
+              ) {
+                setState("sessions", sid, "predictiveCompactInFlight", false);
+              }
+            }
+          }
+          break;
+        }
+
         // Flush any buffered tool events before finalizing the turn so all
         // tool messages are visible in the UI before the prompt completes.
         this.flushToolEventBuf(sessionId);
@@ -3347,6 +3863,16 @@ Structured summary:`;
         }
         this.flushPendingUserMessage(sessionId);
         this.finalizeStreamingContent(sessionId, { isReplay: isHistoryReplay });
+
+        // Turn finalized successfully → clear the thread's in-flight signal,
+        // the inline error state (if any), and the restart timer. #1631.
+        if (!isHistoryReplay) {
+          const convoId = state.sessions[sessionId]?.conversationId;
+          if (convoId) {
+            this.setTurnInFlight(convoId, false);
+            this.clearTurnError(convoId);
+          }
+        }
         // Each promptComplete ends a turn; the next turn may have real content.
         setState("sessions", sessionId, "isSkippingSkillContext", undefined);
         if (!isHistoryReplay) {
@@ -3464,6 +3990,27 @@ Structured summary:`;
                 undefined,
               );
             }
+          }
+        }
+
+        // Predictive compaction — warm a replacement session in the background
+        // when the serving session crosses 70% of its context window, so the
+        // next user submit swaps invisibly instead of hitting prompt-too-long. #1631.
+        if (!isHistoryReplay) {
+          const sess = state.sessions[sessionId];
+          if (
+            sess &&
+            sess.role === "serving" &&
+            !sess.standbySessionId &&
+            !sess.isCompacting &&
+            !sess.predictiveCompactInFlight &&
+            sess.info.status !== "prompting" &&
+            sess.lastInputTokens != null &&
+            sess.contextWindowSize > 0 &&
+            sess.lastInputTokens / sess.contextWindowSize >=
+              PREDICTIVE_COMPACT_THRESHOLD
+          ) {
+            void this.kickPredictiveCompact(sessionId);
           }
         }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1790,23 +1790,32 @@ export const agentStore = {
         terminatedSessionIds.delete(info.id);
 
         // Persist an agent conversation record (safe to call repeatedly via INSERT OR IGNORE).
-        try {
-          await createAgentConversation(
-            info.id,
-            conversationTitle,
-            resolvedAgentType,
-            cwd,
-            cwd,
-            resumeAgentSessionId ?? undefined,
-            serializeAgentConversationMetadata({
-              pendingBootstrapPromptContext: opts?.bootstrapPromptContext,
-              pendingBootstrapMessages: opts?.bootstrapPromptContext
-                ? opts?.restoredMessages
-                : undefined,
-            }) ?? undefined,
-          );
-        } catch (error) {
-          console.warn("Failed to persist agent conversation", error);
+        //
+        // Warm-standby spawns (#1631) must NOT write a DB row — the standby
+        // is ephemeral. On promotion, the promoted session inherits the
+        // serving session's conversationId (which already has a row); on
+        // abort/cancel the standby is terminated and nothing is persisted.
+        // Without this guard, every warm-up left an orphaned thread row that
+        // re-surfaced as an idle agent thread in the sidebar after restart.
+        if (opts?.role !== "standby") {
+          try {
+            await createAgentConversation(
+              info.id,
+              conversationTitle,
+              resolvedAgentType,
+              cwd,
+              cwd,
+              resumeAgentSessionId ?? undefined,
+              serializeAgentConversationMetadata({
+                pendingBootstrapPromptContext: opts?.bootstrapPromptContext,
+                pendingBootstrapMessages: opts?.bootstrapPromptContext
+                  ? opts?.restoredMessages
+                  : undefined,
+              }) ?? undefined,
+            );
+          } catch (error) {
+            console.warn("Failed to persist agent conversation", error);
+          }
         }
 
         // Create session state

--- a/tests/unit/agent-draft-persistence.test.ts
+++ b/tests/unit/agent-draft-persistence.test.ts
@@ -1,0 +1,78 @@
+// ABOUTME: Source-level regression tests for #1631 — draft persistence to SQLite.
+// ABOUTME: Verifies migration, Tauri commands, bridge wiring, and debounce.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const database = readFileSync(
+  resolve("src-tauri/src/services/database.rs"),
+  "utf-8",
+);
+const chatCommands = readFileSync(
+  resolve("src-tauri/src/commands/chat.rs"),
+  "utf-8",
+);
+const libRs = readFileSync(resolve("src-tauri/src/lib.rs"), "utf-8");
+const bridgeSource = readFileSync(
+  resolve("src/lib/tauri-bridge.ts"),
+  "utf-8",
+);
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
+describe("#1631 — SQLite schema: draft column migration", () => {
+  it("adds a nullable `draft TEXT` column to conversations idempotently", () => {
+    expect(database).toContain(
+      'SELECT draft FROM conversations LIMIT 1',
+    );
+    expect(database).toContain(
+      '"ALTER TABLE conversations ADD COLUMN draft TEXT"',
+    );
+  });
+});
+
+describe("#1631 — Tauri commands for draft get/set", () => {
+  it("get_thread_draft command is defined on the Rust side", () => {
+    expect(chatCommands).toContain("pub async fn get_thread_draft(");
+    expect(chatCommands).toContain(
+      'SELECT draft FROM conversations WHERE id = ?1',
+    );
+  });
+
+  it("set_thread_draft command is defined on the Rust side", () => {
+    expect(chatCommands).toContain("pub async fn set_thread_draft(");
+    expect(chatCommands).toContain(
+      '"UPDATE conversations SET draft = ?1 WHERE id = ?2"',
+    );
+  });
+
+  it("both commands are registered in lib.rs invoke_handler", () => {
+    expect(libRs).toContain("commands::chat::get_thread_draft");
+    expect(libRs).toContain("commands::chat::set_thread_draft");
+  });
+});
+
+describe("#1631 — frontend draft bridge + debounced writes", () => {
+  it("tauri-bridge exports getThreadDraft and setThreadDraft", () => {
+    expect(bridgeSource).toContain("export async function getThreadDraft(");
+    expect(bridgeSource).toContain("export async function setThreadDraft(");
+    expect(bridgeSource).toContain('"get_thread_draft"');
+    expect(bridgeSource).toContain('"set_thread_draft"');
+  });
+
+  it("AgentChat hydrates draft on thread open and debounces writes at 500ms", () => {
+    expect(agentChatSource).toContain("getThreadDraft(");
+    expect(agentChatSource).toContain("setThreadDraft(");
+    expect(agentChatSource).toContain("DRAFT_DEBOUNCE_MS = 500");
+    expect(agentChatSource).toContain("schedulePersistDraft(");
+  });
+
+  it("AgentChat deleted the in-memory agentDrafts Map", () => {
+    expect(agentChatSource).not.toContain(
+      "const agentDrafts = new Map<string, string>()",
+    );
+  });
+});

--- a/tests/unit/agent-invisible-restart.test.ts
+++ b/tests/unit/agent-invisible-restart.test.ts
@@ -1,0 +1,69 @@
+// ABOUTME: Source-level regression tests for #1631 — deleted visible-restart UI.
+// ABOUTME: Guards the deletion of the green button, compaction notice, and
+// ABOUTME: the "Agent session restarted" system message.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
+describe("#1631 — green 'Reconnecting Thread' fallback deleted", () => {
+  it("AgentChat does not render the 'Reconnecting {agent} Thread' heading", () => {
+    expect(agentChatSource).not.toContain("Reconnecting {lockedAgentName()}");
+    expect(agentChatSource).not.toContain('"Reconnecting..."');
+  });
+
+  it("retrySessionConnection symbol is gone", () => {
+    expect(agentChatSource).not.toContain("retrySessionConnection");
+  });
+});
+
+describe("#1631 — compaction notice deleted (agent)", () => {
+  it("AgentChat no longer imports CompactedMessage", () => {
+    expect(agentChatSource).not.toContain(
+      'from "@/components/chat/CompactedMessage"',
+    );
+    expect(agentChatSource).not.toContain("<CompactedMessage");
+  });
+
+  it("agent.store does not construct a compactionNotice AgentMessage", () => {
+    expect(agentStoreSource).not.toContain("const compactionNotice:");
+    expect(agentStoreSource).not.toContain(
+      "Context compacted:",
+    );
+  });
+
+  it("preCompactionMessages field removed from AgentCompactedSummary", () => {
+    expect(agentStoreSource).not.toContain("preCompactionMessages");
+    expect(agentStoreSource).not.toContain("interface PreCompactionMessage");
+  });
+});
+
+describe("#1631 — recovery system messages deleted", () => {
+  it('agent.store does not emit "Agent session restarted"', () => {
+    expect(agentStoreSource).not.toContain(
+      "Agent session restarted due to inactivity timeout",
+    );
+    expect(agentStoreSource).not.toContain(
+      "Session restarted after cancellation",
+    );
+  });
+});
+
+describe("#1631 — UI history decoupled from model context", () => {
+  it("reactive compaction inherits the full transcript on the new session", () => {
+    // The new session's messages array is set from `session.messages`
+    // (full scrollback) rather than a compactionNotice + toPreserve slice.
+    expect(agentStoreSource).toContain(
+      '"messages", fullTranscript',
+    );
+  });
+});

--- a/tests/unit/agent-predictive-compaction.test.ts
+++ b/tests/unit/agent-predictive-compaction.test.ts
@@ -1,0 +1,82 @@
+// ABOUTME: Source-level regression tests for #1631 — predictive compaction.
+// ABOUTME: Verifies threshold constant, mutex, mode param, and promotion wiring.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1631 — predictive compaction threshold & concurrency", () => {
+  it("exposes the 0.70 trigger constant at module scope", () => {
+    expect(agentStoreSource).toContain(
+      "export const PREDICTIVE_COMPACT_THRESHOLD = 0.7",
+    );
+  });
+
+  it("declares a module-level predictiveCompactBusy flag", () => {
+    expect(agentStoreSource).toMatch(
+      /let predictiveCompactBusy\s*=\s*false/,
+    );
+  });
+
+  it("gates the trigger in promptComplete on all four invariants", () => {
+    expect(agentStoreSource).toContain("!sess.standbySessionId");
+    expect(agentStoreSource).toContain("!sess.isCompacting");
+    expect(agentStoreSource).toContain("!sess.predictiveCompactInFlight");
+    expect(agentStoreSource).toContain("PREDICTIVE_COMPACT_THRESHOLD");
+  });
+});
+
+describe("#1631 — compactAgentConversation accepts mode", () => {
+  it("compactAgentConversation has a mode: 'reactive' | 'predictive' param", () => {
+    expect(agentStoreSource).toMatch(
+      /mode\?:\s*"reactive"\s*\|\s*"predictive"/,
+    );
+  });
+
+  it("predictive branch spawns with role=\"standby\" and does not terminate serving", () => {
+    expect(agentStoreSource).toContain('if (mode === "predictive")');
+    expect(agentStoreSource).toContain('role: "standby"');
+  });
+});
+
+describe("#1631 — kickPredictiveCompact + promoteStandbyAndDispatch", () => {
+  it("kickPredictiveCompact symbol exists and is idempotent via busy flag", () => {
+    expect(agentStoreSource).toContain("async kickPredictiveCompact(");
+    expect(agentStoreSource).toContain("if (predictiveCompactBusy) return");
+  });
+
+  it("promoteStandbyAndDispatch swaps serving/standby at turn boundary", () => {
+    expect(agentStoreSource).toContain("async promoteStandbyAndDispatch(");
+    // serving gets terminated after the transcript transfers to the promoted id.
+    expect(agentStoreSource).toContain('setState("sessions", standbyId!, "role", "serving")');
+    expect(agentStoreSource).toContain("await this.terminateSession(servingSessionId)");
+  });
+
+  it("sendPrompt checks for a ready standby and promotes when present", () => {
+    expect(agentStoreSource).toContain("standby.seedCompleted === true");
+    expect(agentStoreSource).toContain("await this.promoteStandbyAndDispatch(");
+  });
+});
+
+describe("#1631 — abortTurn wired for user cancel", () => {
+  it("abortTurn symbol exists and does NOT set turnError", () => {
+    const idx = agentStoreSource.indexOf("async abortTurn(");
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 1200);
+    expect(body).toContain("this.setTurnInFlight(threadId, false)");
+    expect(body).not.toContain("this.setTurnError(");
+  });
+
+  it("composer stop button calls agentStore.abortTurn", () => {
+    const chat = readFileSync(
+      resolve("src/components/chat/AgentChat.tsx"),
+      "utf-8",
+    );
+    expect(chat).toContain("agentStore.abortTurn(");
+  });
+});

--- a/tests/unit/agent-predictive-compaction.test.ts
+++ b/tests/unit/agent-predictive-compaction.test.ts
@@ -80,3 +80,49 @@ describe("#1631 — abortTurn wired for user cancel", () => {
     expect(chat).toContain("agentStore.abortTurn(");
   });
 });
+
+describe("#1631 PR-1632 fix — cold-start cancel is honored", () => {
+  const agentChatSource = readFileSync(
+    resolve("src/components/chat/AgentChat.tsx"),
+    "utf-8",
+  );
+
+  it("sendMessage re-checks turnInFlight after the spawn await and terminates the freshly-spawned session on cancel", () => {
+    // After await spawnSession(...) resolves, if the user clicked Stop
+    // mid-spawn, abortTurn flipped turnInFlight off. sendMessage must honor
+    // it and tear down the half-spawned session so the prompt never sneaks
+    // through. Guard against a regression to the pre-fix behavior where the
+    // spawn result was dispatched regardless.
+    const idx = agentChatSource.indexOf("cold-start cancelled during spawn");
+    expect(idx).toBeGreaterThan(0);
+    const region = agentChatSource.slice(idx - 400, idx + 400);
+    expect(region).toContain("agentStore.isTurnInFlight(thread.id)");
+    expect(region).toContain("agentStore.terminateSession(sid)");
+  });
+
+  it("sendMessage re-checks turnInFlight immediately before the final sendPrompt dispatch", () => {
+    // Skill / doc-attachment loads add awaits between cold-start spawn and
+    // the dispatch site. A late cancel during any of those awaits must
+    // still prevent sendPrompt from firing.
+    const idx = agentChatSource.indexOf("cancel detected before dispatch");
+    expect(idx).toBeGreaterThan(0);
+    const region = agentChatSource.slice(idx - 400, idx + 400);
+    expect(region).toContain("agentStore.isTurnInFlight(thread.id)");
+  });
+});
+
+describe("#1631 PR-1632 fix — predictive standby does not leak DB rows", () => {
+  it("spawnSession skips createAgentConversation when opts.role === 'standby'", () => {
+    // Without this gate, every warm-standby spawn wrote a conversation row
+    // keyed on the standby session id. Promotion only rewrites the in-memory
+    // conversationId, so the orphaned row re-surfaced as an idle thread in
+    // the sidebar after restart. Guard against regression.
+    const idx = agentStoreSource.indexOf(
+      "Warm-standby spawns (#1631) must NOT write a DB row",
+    );
+    expect(idx).toBeGreaterThan(0);
+    const region = agentStoreSource.slice(idx, idx + 800);
+    expect(region).toContain('opts?.role !== "standby"');
+    expect(region).toContain("createAgentConversation(");
+  });
+});

--- a/tests/unit/agent-provider-runtime-restart.test.ts
+++ b/tests/unit/agent-provider-runtime-restart.test.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Source-level regression tests for #1631 — cross-thread provider-runtime
+// ABOUTME: crash handling. The restart listener invalidates every serving pointer
+// ABOUTME: and auto-re-dispatches threads with `turnInFlight === true`.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1631 — provider-runtime://restarted cross-thread handling", () => {
+  it("subscribe function exists and is wired from initialize()", () => {
+    expect(agentStoreSource).toContain(
+      "function subscribeToProviderRuntimeRestarted(",
+    );
+    expect(agentStoreSource).toContain("subscribeToProviderRuntimeRestarted()");
+  });
+
+  it("handler listens on the Rust event name", () => {
+    expect(agentStoreSource).toContain('"provider-runtime://restarted"');
+  });
+
+  it("handler clears every session and the active pointer", () => {
+    // The restart listener deletes all live sessions (they belong to the
+    // dead subprocess) and nulls out activeSessionId.
+    const idx = agentStoreSource.indexOf(
+      "function subscribeToProviderRuntimeRestarted(",
+    );
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 3500);
+    expect(body).toContain("delete draft.sessions[id]");
+    expect(body).toContain('setState("activeSessionId", null)');
+  });
+
+  it("handler branches on turnInFlight and re-dispatches lastPromptText", () => {
+    const idx = agentStoreSource.indexOf(
+      "function subscribeToProviderRuntimeRestarted(",
+    );
+    const body = agentStoreSource.slice(idx, idx + 3500);
+    expect(body).toContain("ts?.turnInFlight");
+    expect(body).toContain("ts.lastPromptText");
+    expect(body).toContain("agentStore.sendPrompt(");
+  });
+
+  it("re-dispatch arms the 60s crash budget with crash_ceiling classification", () => {
+    const idx = agentStoreSource.indexOf(
+      "function subscribeToProviderRuntimeRestarted(",
+    );
+    const body = agentStoreSource.slice(idx, idx + 3500);
+    expect(body).toContain("BUDGET_CRASH_MS");
+    expect(body).toContain('"crash_ceiling"');
+  });
+});

--- a/tests/unit/agent-standby-reclaim-guard.test.ts
+++ b/tests/unit/agent-standby-reclaim-guard.test.ts
@@ -1,0 +1,39 @@
+// ABOUTME: Source-level regression test for #1631 — idle-reclaim must not
+// ABOUTME: terminate a warm standby session as a "competing instance."
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1631 — Claude idle-reclaim bypass for standby sessions", () => {
+  it("ActiveSession type declares role: 'serving' | 'standby'", () => {
+    expect(agentStoreSource).toMatch(
+      /role:\s*"serving"\s*\|\s*"standby"/,
+    );
+  });
+
+  it("getIdleClaudeSessionIds skips role === 'standby' sessions", () => {
+    const idx = agentStoreSource.indexOf("function getIdleClaudeSessionIds");
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 1000);
+    expect(body).toContain('session.role === "standby"');
+  });
+
+  it("spawnSession opts exposes role: 'serving' | 'standby'", () => {
+    const idx = agentStoreSource.indexOf("async spawnSession(");
+    expect(idx).toBeGreaterThan(0);
+    const window = agentStoreSource.slice(idx, idx + 2500);
+    expect(window).toMatch(
+      /role\?:\s*"serving"\s*\|\s*"standby"/,
+    );
+  });
+
+  it("new session construction sets role from opts, defaulting to 'serving'", () => {
+    expect(agentStoreSource).toContain('role: opts?.role ?? "serving"');
+  });
+});

--- a/tests/unit/agent-turn-error.test.ts
+++ b/tests/unit/agent-turn-error.test.ts
@@ -1,0 +1,98 @@
+// ABOUTME: Source-level regression tests for #1631 — terminal error bubble.
+// ABOUTME: Closed ErrorKind union, setTurnError wiring, inline retry-link UX.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
+describe("#1631 — ErrorKind closed union contains exactly seven variants", () => {
+  it("includes all seven auto-report kinds", () => {
+    expect(agentStoreSource).toContain('"restart_timeout"');
+    expect(agentStoreSource).toContain('"spawn_failed"');
+    expect(agentStoreSource).toContain('"auth_expired"');
+    expect(agentStoreSource).toContain('"binary_missing"');
+    expect(agentStoreSource).toContain('"crash_ceiling"');
+    expect(agentStoreSource).toContain('"summary_call_failed"');
+    expect(agentStoreSource).toContain('"seed_failed"');
+  });
+
+  it("ErrorKind is exported so tests and the UI share the type", () => {
+    expect(agentStoreSource).toContain("export type ErrorKind");
+  });
+});
+
+describe("#1631 — setTurnError wires the auto-report pipeline (#1630)", () => {
+  it("setTurnError exists, flips turnInFlight off, and fires _submitTurnErrorReport", () => {
+    const idx = agentStoreSource.indexOf("setTurnError(threadId: string");
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 1500);
+    expect(body).toContain('setState("threadStates", threadId, "turnInFlight", false)');
+    expect(body).toContain("this._submitTurnErrorReport(");
+  });
+
+  it("submit bundle references all seven error kinds via callers or the union", () => {
+    // The union declares the full set; the submit helper forwards whichever
+    // kind the caller passed, so the test simply re-asserts closure.
+    const union = agentStoreSource.slice(
+      agentStoreSource.indexOf("export type ErrorKind"),
+    );
+    expect(union).toContain("restart_timeout");
+    expect(union).toContain("spawn_failed");
+    expect(union).toContain("auth_expired");
+    expect(union).toContain("binary_missing");
+    expect(union).toContain("crash_ceiling");
+    expect(union).toContain("summary_call_failed");
+    expect(union).toContain("seed_failed");
+  });
+
+  it("submit_support_report is referenced as the pipeline target (#1630 TODO)", () => {
+    // The auto-report callsite names the backend command verbatim, even
+    // while the ticket stubs until #1630 ships.
+    expect(agentStoreSource).toContain("submit_support_report");
+  });
+});
+
+describe("#1631 — inline error bubble + retry link", () => {
+  it("AgentChat reads agentStore.getTurnError for the last-user-message bubble", () => {
+    expect(agentChatSource).toContain("agentStore.getTurnError(");
+  });
+
+  it("AgentChat renders 'Couldn't send. Retry' on terminal error", () => {
+    expect(agentChatSource).toContain("Couldn't send.");
+    // The retry word is rendered inside the <button>…</button> text node.
+    expect(agentChatSource).toMatch(/>\s*Retry\s*<\/button>/);
+  });
+
+  it("retry link re-calls sendPrompt with the stored last-prompt record", () => {
+    expect(agentChatSource).toContain("agentStore.clearTurnError(");
+    expect(agentChatSource).toContain("agentStore.sendPrompt(");
+    expect(agentChatSource).toContain("ts.lastPromptText");
+  });
+});
+
+describe("#1631 — restart timer budget wired on cold-start", () => {
+  it("cold-start path arms the 60s budget with spawn_failed classification", () => {
+    expect(agentChatSource).toContain(
+      'agentStore.armRestartTimer(thread.id, 60_000, "spawn_failed")',
+    );
+  });
+
+  it("armRestartTimer clears on stream start", () => {
+    // Skip the call-site at the top of the file; we want the method body.
+    const idx = agentStoreSource.indexOf(
+      "armRestartTimer(threadId: string",
+    );
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 1500);
+    expect(body).toContain("streamingNow");
+  });
+});

--- a/tests/unit/agent-turn-in-flight.test.ts
+++ b/tests/unit/agent-turn-in-flight.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Source-level regression tests for #1631 — turnInFlight continuous signal.
+// ABOUTME: Per-thread state survives session swaps so thinking dots stay lit.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
+describe("#1631 — turnInFlight lives on per-thread state", () => {
+  it("ThreadRuntimeState declares turnInFlight: boolean", () => {
+    expect(agentStoreSource).toContain("interface ThreadRuntimeState");
+    const idx = agentStoreSource.indexOf("interface ThreadRuntimeState");
+    const body = agentStoreSource.slice(idx, idx + 500);
+    expect(body).toContain("turnInFlight: boolean");
+  });
+
+  it("agentStore exposes setTurnInFlight and isTurnInFlight", () => {
+    expect(agentStoreSource).toContain("setTurnInFlight(threadId: string");
+    expect(agentStoreSource).toContain("isTurnInFlight(threadId: string");
+  });
+
+  it("sendPrompt flips turnInFlight true at entry", () => {
+    const idx = agentStoreSource.indexOf("async sendPrompt(");
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 4000);
+    expect(body).toContain("this.setTurnInFlight(threadId, true)");
+  });
+
+  it("successful promptComplete clears turnInFlight and turnError", () => {
+    const idx = agentStoreSource.indexOf('case "promptComplete"');
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 4000);
+    expect(body).toContain("this.setTurnInFlight(convoId, false)");
+    expect(body).toContain("this.clearTurnError(convoId)");
+  });
+});
+
+describe("#1631 — thinking indicator driven by turnInFlight not session status", () => {
+  it("AgentChat binds the loading placeholder to agentStore.isTurnInFlight", () => {
+    expect(agentChatSource).toContain("agentStore.isTurnInFlight(");
+  });
+
+  it("AgentChat no longer gates the loading placeholder on isPrompting()", () => {
+    // The ONLY acceptable `isPrompting()` references are for the composer
+    // gating and keybindings — the loading-placeholder <Show> should read
+    // the thread runtime state instead.
+    const placeholderRegion = agentChatSource.slice(
+      agentChatSource.indexOf("Loading placeholder"),
+      agentChatSource.indexOf("Streaming Thinking"),
+    );
+    expect(placeholderRegion.length).toBeGreaterThan(0);
+    expect(placeholderRegion).not.toContain("isPrompting()");
+  });
+});

--- a/tests/unit/compaction-queue-race.test.ts
+++ b/tests/unit/compaction-queue-race.test.ts
@@ -84,11 +84,21 @@ describe("#1623 — sendPrompt defensive guard against compaction race", () => {
     expect(sendPromptStart, "sendPrompt must exist").toBeGreaterThan(0);
     // The guard must live BEFORE the session.info.status === "error" branch
     // because a compacting session still has an otherwise-valid status.
+    // Window widened to accommodate the predictive-swap block added in #1631
+    // before the compacting guard. The invariant we care about is that the
+    // compacting guard still fires BEFORE the `status === "error"` branch.
     const sendPromptWindow = agentStoreSource.slice(
       sendPromptStart,
-      sendPromptStart + 2000,
+      sendPromptStart + 5000,
     );
     expect(sendPromptWindow).toContain("session?.isCompacting");
     expect(sendPromptWindow).toContain("this.enqueuePrompt(sessionId, prompt)");
+    const compactingIdx = sendPromptWindow.indexOf("session?.isCompacting");
+    const errorBranchIdx = sendPromptWindow.indexOf(
+      'session.info.status === "error"',
+    );
+    expect(compactingIdx, "isCompacting guard must come first").toBeLessThan(
+      errorBranchIdx,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Make every agent session restart — predictive compaction, reactive compact-and-retry, subprocess crash, cold-start spawn — indistinguishable from a normal thinking moment. Delete the green "Reconnecting Thread" fallback entirely. Decouple UI history from model context so users never see their scrollback disappear. Surface failures only as inline per-bubble error states with a retry link.

Closes #1631.

## Deleted UI paths

- Green "Reconnecting {Agent} Thread" fallback in `AgentChat.tsx`.
- `retrySessionConnection` handler.
- `CompactedMessage` usage + import in agent mode; `preCompactionMessages` field removed.
- "Agent session restarted due to inactivity timeout" and "Session restarted after cancellation" system messages.

## New state machine

- Per-thread `ThreadRuntimeState` (keyed by `conversationId`, survives session swaps): `turnInFlight`, `turnError`, `restartTimerExpiresAt`, `lastPromptText/Context/Display/DocNames`.
- `ActiveSession` gains `role: "serving" | "standby"`, `standbySessionId`, `seedCompleted`, `predictiveCompactInFlight`.
- Closed `ErrorKind` union (7 variants).

## Predictive compaction

- Hard-coded `PREDICTIVE_COMPACT_THRESHOLD = 0.7` (not a setting).
- Trigger in `promptComplete`: `!standbySessionId && !isCompacting && !predictiveCompactInFlight && !isPrompting && tokens/context >= 0.70`.
- Global concurrency cap = 1 via module-level `predictiveCompactBusy`.
- `kickPredictiveCompact` + `compactAgentConversation({ mode: "predictive" })` spawn a `role: "standby"` session; seed it; wait for `promptComplete` to set `seedCompleted`.
- `promoteStandbyAndDispatch` swaps at next submit; transcript transfers, old serving terminates.
- Idle-Claude reclaim bypasses `role === "standby"`.

## Reactive paths (invisibility)

- Reactive compaction inherits the full transcript so scrollback is preserved forever.
- `sendPrompt` recovery no longer inserts user-visible messages.
- Uniform across Claude Code / Codex / Gemini.

## Failure mode

- Per-turn invisibility budget: 60s cold-start, 90s reactive compact, 60s crash.
- `setTurnError` flips `turnInFlight` off and fires `_submitTurnErrorReport` with the 7-kind bundle (stubbed until #1630 ships).
- Inline error bubble: 2px red left-border + "Couldn't send. Retry" link.

## Cross-thread crash handling

- `provider-runtime://restarted` listener drops every live session, re-dispatches threads with `turnInFlight === true` on a fresh spawn using the stored last prompt.

## Ancillary

- `abortTurn(threadId)` cancels standby + queue + live turn; no error bubble. Wired to stop button.
- `terminateSession` drops pending `ActionConfirmation` / diff proposals for that session.
- Attachments travel with re-dispatched prompts via `ThreadRuntimeState`.

## Cold-start

- `AgentChat.sendMessage` spawns synchronously on first submit when no session exists.
- Thinking dots follow `turnInFlight`, not `isPrompting()`.

## Draft persistence (SQLite)

- New `draft TEXT` column on `conversations` via idempotent ALTER migration.
- `get_thread_draft` / `set_thread_draft` Tauri commands.
- Frontend hydrates on thread open; debounced 500ms writes. Survives force-quit.

## Completeness traceability

| ID | Item |
|----|------|
| A | Draft persisted to SQLite, survives crash |
| B | Thinking indicator via turnInFlight, continuous across session boundaries |
| C | Cross-thread `provider-runtime://restarted` handling + auto re-dispatch |
| D | Abort / cancel during restart |
| E | Scroll freeze around mid-stream discard (inherent via full-transcript inheritance) |
| F | Tool-call approval dismissal on session terminate |
| G | Attachments travel with re-dispatched prompts |
| H | Global predictive-compact concurrency cap = 1 |
| I | Uniform across Claude / Codex / Gemini |
| J | No Seren memory write on discarded partials |

## Critical tests (source-level)

- `agent-predictive-compaction.test.ts`
- `agent-turn-in-flight.test.ts`
- `agent-invisible-restart.test.ts`
- `agent-turn-error.test.ts`
- `agent-draft-persistence.test.ts`
- `agent-standby-reclaim-guard.test.ts`
- `agent-provider-runtime-restart.test.ts`

## Test plan

- [x] `pnpm test` — 441/441 passing
- [x] `cargo test --lib` — 10/10 passing
- [x] `pnpm check` — 0 errors
- [x] `cargo check` — clean
- [x] `pnpm build` — Vite bundle clean
- [x] `pnpm tauri dev` — app compiles and launches
- [ ] Manual: cold-start, predictive compact, reactive compact, crash mid-turn, crash idle, abort, draft persistence, tool-call during restart, attachments across retry, terminal error, full scrollback

## Related

- #1629 — Seren memory wiring
- #1630 — Auto error-reporting pipeline (stubbed here; fires verbatim when merged)
- #1624 — Queued prompts persisted to input history (preserved)
- #1623 — Compaction / queue race fix (preserved and extended)
- #1616 — Pre-compaction scrollback card (deleted by this PR)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
