### PR TITLE
hotfix(agent): warm-path sends were aborted by the late-cancel guard (#1631)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -754,6 +754,15 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       return;
     }
 
+    // Mark the turn in-flight now so the late-cancel guard below distinguishes
+    // "user actively submitting" from "user pressed Stop mid-awaits." Cold-start
+    // already set this true inside the !hasSession() block; this is a no-op
+    // there but ensures the warm path also flips it. Without this, the guard
+    // aborted every warm-path send because turnInFlight stayed false. #1631 hotfix.
+    if (thread) {
+      agentStore.setTurnInFlight(thread.id, true);
+    }
+
     // Split attachments: images go as agent context blocks; docreader files get extracted to text
     const imageAttachments = images.filter((a) => !isDocreaderMime(a.mimeType));
     const docAttachments = images.filter((a) => isDocreaderMime(a.mimeType));

--- a/tests/unit/agent-predictive-compaction.test.ts
+++ b/tests/unit/agent-predictive-compaction.test.ts
@@ -111,6 +111,30 @@ describe("#1631 PR-1632 fix — cold-start cancel is honored", () => {
   });
 });
 
+describe("#1631 hotfix — warm-path submit sets turnInFlight before late-cancel guard", () => {
+  const agentChatSource = readFileSync(
+    resolve("src/components/chat/AgentChat.tsx"),
+    "utf-8",
+  );
+
+  it("sendMessage flips turnInFlight true on the warm path before the late-cancel guard runs", () => {
+    // Regression guard for the prod bug where the late-cancel guard fired
+    // on every warm-path send — turnInFlight was never set to true before
+    // the guard (sendPrompt sets it AFTER). The fix sets it true after the
+    // isPrompting queue check and before any async awaits.
+    const flipIdx = agentChatSource.indexOf(
+      "ensures the warm path also flips it",
+    );
+    expect(flipIdx, "setTurnInFlight warm-path guard must exist").toBeGreaterThan(0);
+    const guardIdx = agentChatSource.indexOf(
+      "cancel detected before dispatch",
+    );
+    expect(guardIdx, "late-cancel guard must still exist").toBeGreaterThan(0);
+    // The flip must appear BEFORE the late-cancel guard in source order.
+    expect(flipIdx).toBeLessThan(guardIdx);
+  });
+});
+
 describe("#1631 PR-1632 fix — predictive standby does not leak DB rows", () => {
   it("spawnSession skips createAgentConversation when opts.role === 'standby'", () => {
     // Without this gate, every warm-standby spawn wrote a conversation row


### PR DESCRIPTION
## Summary

Production hotfix — users cannot send messages to Claude Code or Codex agents on any thread that already has a live session. Every warm-path submit logs `[AgentChat] sendMessage: cancel detected before dispatch — skipping sendPrompt` and silently drops.

## Root cause

Regression introduced by the P1.1 fix in PR #1632 (commit `6754590`). The late-cancel guard added before `agentStore.sendPrompt(...)` checks `agentStore.isTurnInFlight(thread.id)` and bails if false:

```ts
if (thread && !agentStore.isTurnInFlight(thread.id)) {
  console.info("[AgentChat] sendMessage: cancel detected before dispatch — skipping sendPrompt");
  return;
}
```

This assumed `turnInFlight` was already true by the time we reach the guard. It IS true on the cold-start path (set inside the `!hasSession()` block at the top of `sendMessage`). But on the **warm path** (session already exists), nothing flips it to true before the guard runs — `agentStore.sendPrompt` sets it, but AFTER the guard. So `isTurnInFlight` returns `false` on every warm send and the guard misreads "never set" as "user cancelled."

## Fix

Set `turnInFlight = true` at the top of the dispatch section, right after the `isPrompting` queue check and before any async awaits. Idempotent for cold-start (already true there); first write for the warm path. The late-cancel guard now correctly distinguishes "actively submitting" from "user pressed Stop mid-await."

## Test plan

- [x] `pnpm test` — 445/445 passing (new regression test: `agent-predictive-compaction.test.ts › #1631 hotfix — warm-path submit sets turnInFlight before late-cancel guard`)
- [x] `tsc --noEmit` — clean
- [x] Regression test asserts the flip appears BEFORE the late-cancel guard in source order

## Related

- PR #1632 — original invisible-restart feature (introduced the regression)
- Issue #1631 — design ticket

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
