### PR TITLE
fix(compaction): auth gate, login prompt, transcript recovery (#1639)

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -15,6 +15,7 @@ import {
   storeToken,
 } from "@/lib/tauri-bridge";
 import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
+import { promptLogin } from "@/stores/auth.store";
 
 export interface LoginResponse {
   data: {
@@ -137,6 +138,7 @@ export async function logout(): Promise<void> {
 export async function refreshAccessToken(): Promise<boolean> {
   const refreshToken = await getRefreshToken();
   if (!refreshToken) {
+    promptLogin();
     return false;
   }
 
@@ -155,6 +157,7 @@ export async function refreshAccessToken(): Promise<boolean> {
       if (response.status === 401) {
         await clearToken();
         await clearRefreshToken();
+        promptLogin();
       }
       return false;
     }
@@ -167,7 +170,7 @@ export async function refreshAccessToken(): Promise<boolean> {
     }
     return true;
   } catch {
-    // Network error - don't clear tokens
+    // Network error - don't clear tokens, don't prompt login
     return false;
   }
 }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -142,6 +142,7 @@ async function waitForSessionIdle(
 }
 
 import { isLikelyAuthError } from "@/lib/auth-errors";
+import { authStore, promptLogin } from "@/stores/auth.store";
 import { buildChatRequest, sendProviderMessage } from "@/lib/providers";
 import {
   isPromptTooLongError,
@@ -2647,6 +2648,13 @@ export const agentStore = {
 
     setState("sessions", sessionId, "isCompacting", true);
 
+    // Hoisted for catch-handler access — the reactive path terminates the
+    // old session, so recovery needs these if anything downstream throws. #1639.
+    const fullTranscript = [...session.messages];
+    const cwd = session.cwd;
+    const agentType = session.info.agentType;
+    const conversationId = session.conversationId;
+
     try {
       // Split messages into those to summarize and those to keep
       const toCompact = messages.slice(0, messages.length - preserveCount);
@@ -2697,10 +2705,6 @@ Structured summary:`;
         compactedAt: Date.now(),
       };
 
-      // Capture session details and user-configured settings before termination
-      const cwd = session.cwd;
-      const agentType = session.info.agentType;
-      const conversationId = session.conversationId;
       const queuedPrompts = session.pendingPrompts ?? [];
 
       // Build the structured seed prompt up-front — shared by both modes.
@@ -2767,7 +2771,6 @@ Structured summary:`;
       // inherits the full transcript so users still see every earlier turn
       // on scroll-up — the model's context is the structured summary + the
       // preserved tail, seeded via the seed prompt below, not the transcript.
-      const fullTranscript = [...session.messages];
       setState("sessions", newSessionId, "messages", fullTranscript);
       setState(
         "sessions",
@@ -2804,9 +2807,34 @@ Structured summary:`;
         "[AgentStore] Failed to compact agent conversation (catastrophic):",
         error,
       );
-      // If the original session still exists, clear compacting flag
       if (state.sessions[sessionId]) {
         setState("sessions", sessionId, "isCompacting", false);
+      } else if (fullTranscript && fullTranscript.length > 0) {
+        // The old session was terminated but the new one failed. Respawn a
+        // recovery session with the saved transcript so the user doesn't
+        // lose their conversation. #1639.
+        console.warn(
+          `[AgentStore] Attempting recovery — restoring ${fullTranscript.length} messages to new session`,
+        );
+        try {
+          const recoveryId = await this.spawnSession(cwd, agentType, {
+            localSessionId: conversationId,
+          });
+          if (recoveryId) {
+            setState("sessions", recoveryId, "messages", fullTranscript);
+            setState(
+              "sessions",
+              recoveryId,
+              "restoredMessageCount",
+              fullTranscript.length,
+            );
+          }
+        } catch (recoveryErr) {
+          console.error(
+            "[AgentStore] Recovery spawn also failed:",
+            recoveryErr,
+          );
+        }
       }
       return "failed_catastrophic";
     }
@@ -3999,15 +4027,22 @@ Structured summary:`;
             }
 
             if (shouldCompact) {
-              // Explicit undefined for pendingUserPrompt: the prompt that
-              // just produced this promptComplete already succeeded, so we
-              // do NOT retry it — retrying would duplicate the turn. Queued
-              // prompts handled via pendingPrompts transfer inside compaction.
-              this.compactAgentConversation(
-                sessionId,
-                settingsStore.settings.autoCompactPreserveMessages,
-                undefined,
-              );
+              if (!authStore.isAuthenticated) {
+                console.warn(
+                  "[AgentStore] Skipping auto-compaction — user is not authenticated",
+                );
+                promptLogin();
+              } else {
+                // Explicit undefined for pendingUserPrompt: the prompt that
+                // just produced this promptComplete already succeeded, so we
+                // do NOT retry it — retrying would duplicate the turn. Queued
+                // prompts handled via pendingPrompts transfer inside compaction.
+                this.compactAgentConversation(
+                  sessionId,
+                  settingsStore.settings.autoCompactPreserveMessages,
+                  undefined,
+                );
+              }
             }
           }
         }
@@ -4015,7 +4050,7 @@ Structured summary:`;
         // Predictive compaction — warm a replacement session in the background
         // when the serving session crosses 70% of its context window, so the
         // next user submit swaps invisibly instead of hitting prompt-too-long. #1631.
-        if (!isHistoryReplay) {
+        if (!isHistoryReplay && authStore.isAuthenticated) {
           const sess = state.sessions[sessionId];
           if (
             sess &&

--- a/tests/unit/compaction-auth-gate.test.ts
+++ b/tests/unit/compaction-auth-gate.test.ts
@@ -1,0 +1,158 @@
+// ABOUTME: Regression tests for #1639 — compaction must not fire without auth.
+// ABOUTME: Verifies auth gates on auto-compact and predictive-compact triggers.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+const authServiceSource = readFileSync(
+  resolve("src/services/auth.ts"),
+  "utf-8",
+);
+
+describe("#1639 — auto-compact auth gate", () => {
+  it("imports authStore and promptLogin from auth.store", () => {
+    expect(agentStoreSource).toContain(
+      'import { authStore, promptLogin } from "@/stores/auth.store"',
+    );
+  });
+
+  it("checks authStore.isAuthenticated before calling compactAgentConversation", () => {
+    const authCheck = "if (!authStore.isAuthenticated)";
+    const compactCall = "this.compactAgentConversation(";
+    const authCheckIdx = agentStoreSource.indexOf(authCheck);
+    expect(authCheckIdx, "auth check must exist").toBeGreaterThan(0);
+
+    // The auth check must appear before the compact call in the auto-compact block
+    const autoCompactAnchor = "Auto-compact check runs BEFORE drain (#1623)";
+    const autoCompactIdx = agentStoreSource.indexOf(autoCompactAnchor);
+    const authCheckAfterAnchor = agentStoreSource.indexOf(
+      authCheck,
+      autoCompactIdx,
+    );
+    const compactCallAfterAnchor = agentStoreSource.indexOf(
+      compactCall,
+      autoCompactIdx,
+    );
+    expect(
+      authCheckAfterAnchor,
+      "auth check must appear after auto-compact anchor",
+    ).toBeGreaterThan(autoCompactIdx);
+    expect(
+      authCheckAfterAnchor,
+      "auth check must appear before compactAgentConversation call",
+    ).toBeLessThan(compactCallAfterAnchor);
+  });
+
+  it("calls promptLogin() when auth check fails in auto-compact path", () => {
+    const autoCompactAnchor = "Auto-compact check runs BEFORE drain (#1623)";
+    const drainAnchor = "Drain the prompt queue for this session";
+    const autoCompactIdx = agentStoreSource.indexOf(autoCompactAnchor);
+    const drainIdx = agentStoreSource.indexOf(drainAnchor);
+
+    const authBlock = agentStoreSource.slice(autoCompactIdx, drainIdx);
+    expect(authBlock).toContain("promptLogin()");
+  });
+
+  it("logs a warning when skipping compaction due to auth", () => {
+    expect(agentStoreSource).toContain(
+      "Skipping auto-compaction — user is not authenticated",
+    );
+  });
+});
+
+describe("#1639 — predictive-compact auth gate", () => {
+  it("gates predictive compaction on authStore.isAuthenticated", () => {
+    // The promptComplete handler's predictive-compact block must check auth
+    const predictiveAnchor =
+      "Predictive compaction — warm a replacement session";
+    const predictiveIdx = agentStoreSource.indexOf(predictiveAnchor);
+    expect(predictiveIdx).toBeGreaterThan(0);
+
+    // The if-condition immediately following the anchor must include auth
+    const nextIf = agentStoreSource.indexOf("if (", predictiveIdx);
+    const ifBlock = agentStoreSource.slice(nextIf, nextIf + 100);
+    expect(ifBlock).toContain("authStore.isAuthenticated");
+  });
+});
+
+describe("#1639 — refreshAccessToken calls promptLogin on terminal failure", () => {
+  it("imports promptLogin from auth.store", () => {
+    expect(authServiceSource).toContain(
+      'import { promptLogin } from "@/stores/auth.store"',
+    );
+  });
+
+  it("calls promptLogin when no refresh token is available", () => {
+    // Find the "if (!refreshToken)" block and verify promptLogin is called
+    const noTokenIdx = authServiceSource.indexOf("if (!refreshToken)");
+    expect(noTokenIdx).toBeGreaterThan(0);
+    const blockAfter = authServiceSource.slice(noTokenIdx, noTokenIdx + 100);
+    expect(blockAfter).toContain("promptLogin()");
+  });
+
+  it("calls promptLogin on 401 from refresh endpoint", () => {
+    // Find the 401 handling block inside refreshAccessToken
+    const refreshFnIdx = authServiceSource.indexOf(
+      "async function refreshAccessToken",
+    );
+    const fnBody = authServiceSource.slice(refreshFnIdx, refreshFnIdx + 1200);
+    const clear401Block = fnBody.indexOf("response.status === 401");
+    expect(clear401Block).toBeGreaterThan(0);
+    const afterClear = fnBody.slice(clear401Block, clear401Block + 200);
+    expect(afterClear).toContain("promptLogin()");
+  });
+
+  it("does NOT call promptLogin on network errors (user may be offline)", () => {
+    const refreshFnIdx = authServiceSource.indexOf(
+      "async function refreshAccessToken",
+    );
+    const fnBody = authServiceSource.slice(refreshFnIdx, refreshFnIdx + 1200);
+    const catchBlock = fnBody.indexOf("} catch {");
+    expect(catchBlock).toBeGreaterThan(0);
+    const afterCatch = fnBody.slice(catchBlock, catchBlock + 150);
+    expect(afterCatch).not.toContain("promptLogin");
+  });
+});
+
+describe("#1639 — compaction failure preserves transcript", () => {
+  it("snapshots fullTranscript before the try block", () => {
+    const hoistAnchor = "Hoisted for catch-handler access";
+    const hoistIdx = agentStoreSource.indexOf(hoistAnchor);
+    expect(hoistIdx, "hoist comment must exist").toBeGreaterThan(0);
+
+    const tryIdx = agentStoreSource.indexOf("try {", hoistIdx);
+    const transcriptDecl = agentStoreSource.indexOf(
+      "const fullTranscript = [...session.messages]",
+      hoistIdx,
+    );
+    expect(
+      transcriptDecl,
+      "fullTranscript must be declared before the try block",
+    ).toBeLessThan(tryIdx);
+  });
+
+  it("hoists cwd, agentType, and conversationId before the try block", () => {
+    const hoistIdx = agentStoreSource.indexOf("Hoisted for catch-handler");
+    const tryIdx = agentStoreSource.indexOf("try {", hoistIdx);
+    const block = agentStoreSource.slice(hoistIdx, tryIdx);
+
+    expect(block).toContain("const cwd = session.cwd");
+    expect(block).toContain("const agentType = session.info.agentType");
+    expect(block).toContain("const conversationId = session.conversationId");
+  });
+
+  it("catch handler attempts recovery spawn when original session is gone", () => {
+    expect(agentStoreSource).toContain(
+      "Attempting recovery — restoring",
+    );
+    expect(agentStoreSource).toContain(
+      'localSessionId: conversationId,\n          });',
+    );
+  });
+});

--- a/tests/unit/compaction-queue-race.test.ts
+++ b/tests/unit/compaction-queue-race.test.ts
@@ -64,7 +64,7 @@ describe("#1623 — compactAgentConversation transfers pendingPrompts to new ses
     // The prompt that produced this promptComplete already succeeded — we
     // MUST NOT retry it or the user sees a duplicate turn.
     expect(agentStoreSource).toContain(
-      "settingsStore.settings.autoCompactPreserveMessages,\n                undefined,",
+      "settingsStore.settings.autoCompactPreserveMessages,\n                  undefined,",
     );
   });
 


### PR DESCRIPTION
## Summary
- **Auth gate on compaction triggers**: Both auto-compact and predictive-compact now check `authStore.isAuthenticated` before firing. If unauthenticated, compaction is skipped and `promptLogin()` shows the sign-in prompt.
- **Frontend refresh parity with Rust**: `refreshAccessToken()` now calls `promptLogin()` when the refresh token is missing or the refresh endpoint returns 401, matching the Rust-side behavior that emits `auth:session-expired`.
- **Transcript recovery on compaction failure**: `fullTranscript`, `cwd`, `agentType`, and `conversationId` are hoisted before the try block. If the reactive path terminates the old session but the new session fails to spawn/seed, the catch handler respawns a recovery session with the saved transcript.

Closes #1639

## Test plan
- [x] All 462 existing tests pass (56 test files)
- [x] New `compaction-auth-gate.test.ts` with 12 regression tests covering auth gate, promptLogin wiring, and transcript snapshot hoisting
- [x] Updated `compaction-queue-race.test.ts` for new indentation after auth gate nesting
- [ ] Manual: `pnpm tauri dev` — log in, build context, clear tokens, verify compaction skips and login prompt appears
- [ ] Manual: Verify predictive compaction does not fire when unauthenticated

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com