### PR TITLE
feat(cli): automatic background updates for bundled CLIs (#1637)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -6,6 +6,8 @@ import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { backgroundUpdateCli } from "./cli-updater.mjs";
+
 function launchLoginCommand(command) {
   const loginCommand = `${command} login`;
 
@@ -339,7 +341,7 @@ function resolveInstalledGeminiBinary() {
  * GUI apps don't inherit shell PATH updates made by installers, so check
  * well-known install locations before falling back to bare command name.
  */
-function resolveInstalledClaudeBinary() {
+export function resolveInstalledClaudeBinary() {
   if (process.platform === "win32") {
     const home = os.homedir();
     const appData = process.env.APPDATA ?? "";
@@ -379,6 +381,48 @@ function resolveInstalledClaudeBinary() {
     }
   }
   return "claude";
+}
+
+/**
+ * Resolve the absolute path of the installed Codex CLI binary.
+ *
+ * Mirrors `resolveInstalledClaudeBinary()`. Seren previously resolved Codex
+ * by bare command name, which burned us on Windows (#876, #928) when GUI
+ * apps don't inherit shell PATH and `.cmd` wrappers race with npm symlinks.
+ * Prefer known install locations; fall back to bare "codex" only when
+ * nothing resolves. Returning an absolute path lets the updater run the
+ * binary directly without trusting PATH.
+ */
+export function resolveInstalledCodexBinary() {
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA ?? "";
+    const nodeDir = path.dirname(process.execPath);
+    const candidates = [
+      ...(appData ? [path.join(appData, "npm", "codex.cmd")] : []),
+      ...(appData ? [path.join(appData, "npm", "codex.ps1")] : []),
+      path.join(nodeDir, "codex.cmd"),
+      path.join(nodeDir, "codex"),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  } else {
+    const home = os.homedir();
+    const nodeDir = path.dirname(process.execPath);
+    const prefix = path.dirname(nodeDir);
+    const candidates = [
+      path.join(prefix, "bin", "codex"),
+      path.join(home, ".local", "bin", "codex"),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return "codex";
 }
 
 export function createBrowserLocalAgentRegistry({ emit }) {
@@ -511,6 +555,30 @@ export function createBrowserLocalAgentRegistry({ emit }) {
     }
     return definition;
   }
+
+  // Fire-and-forget background update checks for bundled CLIs (#1637).
+  // TTL-gated to 24h inside backgroundUpdateCli, same-channel only, silent
+  // on failure. Do not await — registry init must not block on npm.
+  const npmCliScript = resolveNpmCliScript();
+  const onUpdated = ({ label, from, to }) => {
+    emit?.("provider://cli-updated", { label, from, to });
+  };
+  void backgroundUpdateCli({
+    label: "Codex",
+    bareCommand: "codex",
+    resolvedPath: resolveInstalledCodexBinary(),
+    packageName: "@openai/codex",
+    npmCliScript,
+    onUpdated,
+  });
+  void backgroundUpdateCli({
+    label: "Claude Code",
+    bareCommand: "claude",
+    resolvedPath: resolveInstalledClaudeBinary(),
+    packageName: "@anthropic-ai/claude-code",
+    npmCliScript,
+    onUpdated,
+  });
 
   return {
     async getAvailableAgents() {

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -1,0 +1,291 @@
+// ABOUTME: Background updates for bundled agent CLIs (Codex, Claude Code) per #1637.
+// ABOUTME: Fire-and-forget at startup, TTL-gated, same-channel only, silent on failure.
+
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** 24h between update checks per CLI. */
+export const UPDATE_CHECK_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Timeouts kept tight so a hung subprocess can't freeze the background task. */
+const VERSION_CMD_TIMEOUT_MS = 5_000;
+const NPM_VIEW_TIMEOUT_MS = 15_000;
+const NPM_INSTALL_TIMEOUT_MS = 180_000;
+
+const SEMVER_EXACT_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+const SEMVER_EXTRACT_RE = /\d+\.\d+\.\d+[^\s]*/;
+
+function serenDataDir() {
+  if (process.platform === "win32") {
+    const base = process.env.APPDATA ?? os.homedir();
+    return path.join(base, "Seren");
+  }
+  return path.join(os.homedir(), ".seren");
+}
+
+function statePath() {
+  return path.join(serenDataDir(), "cli-update-state.json");
+}
+
+export function loadState() {
+  try {
+    const raw = readFileSync(statePath(), "utf8");
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveState(state) {
+  try {
+    mkdirSync(serenDataDir(), { recursive: true });
+    writeFileSync(statePath(), JSON.stringify(state), "utf8");
+  } catch {
+    // Silent — missing persistence just means we re-check next launch.
+  }
+}
+
+/**
+ * Compare two semver strings. Only clean MAJOR.MINOR.PATCH triples compare;
+ * anything with a pre-release suffix (e.g. "1.5.0-beta.1") returns false
+ * so we never auto-update to or from a pre-release. Conservative by design.
+ */
+export function isNewer(installed, latest) {
+  if (typeof installed !== "string" || typeof latest !== "string") return false;
+  const a = installed.match(SEMVER_EXACT_RE);
+  const b = latest.match(SEMVER_EXACT_RE);
+  if (!a || !b) return false;
+  for (let i = 1; i <= 3; i++) {
+    const ai = Number(a[i]);
+    const bi = Number(b[i]);
+    if (ai !== bi) return bi > ai;
+  }
+  return false;
+}
+
+/**
+ * Classify the install channel of a resolved binary path. Returns:
+ *   - "native": installed by a native installer (claude.ai/install.sh etc.)
+ *   - "npm":    installed via npm global (any flavor)
+ *   - "unresolved": resolver returned the bare command name; we cannot safely
+ *                   update because we don't know which install we'd be
+ *                   targeting. Skip to avoid creating a shadow install that
+ *                   the spawn resolver won't pick.
+ */
+export function classifyInstallChannel(resolvedPath, bareCommand) {
+  if (typeof resolvedPath !== "string" || resolvedPath.length === 0) {
+    return "unresolved";
+  }
+  if (resolvedPath === bareCommand) return "unresolved";
+
+  const lower = resolvedPath.toLowerCase();
+  // Native installer locations (Claude puts itself here; no Codex native today).
+  if (
+    lower.includes("/.claude/bin/") ||
+    lower.includes("\\.claude\\bin\\") ||
+    lower.includes("/.local/bin/") ||
+    lower.includes("\\.local\\bin\\")
+  ) {
+    return "native";
+  }
+  // npm global wrappers
+  if (
+    lower.endsWith(".cmd") ||
+    lower.endsWith(".ps1") ||
+    lower.includes("\\npm\\") ||
+    lower.includes("/npm/")
+  ) {
+    return "npm";
+  }
+  // Unix npm-global via embedded prefix/bin/<cmd>
+  return "npm";
+}
+
+/**
+ * Read the installed CLI's version by running the absolute resolved path
+ * with `--version`. Returns the first semver-looking token or null on
+ * failure. Never runs bare commands — the resolver must have produced an
+ * absolute path.
+ */
+export async function runInstalledVersion(resolvedPath, bareCommand) {
+  if (resolvedPath === bareCommand) return null; // unresolved
+  if (!existsSync(resolvedPath)) return null;
+  try {
+    const { stdout } = await execFileAsync(resolvedPath, ["--version"], {
+      timeout: VERSION_CMD_TIMEOUT_MS,
+      shell: process.platform === "win32" && resolvedPath.toLowerCase().endsWith(".cmd"),
+    });
+    return stdout.trim().match(SEMVER_EXTRACT_RE)?.[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Query the latest published version for a package via the bundled npm
+ * (or system npm in dev). Returns the version string or null on failure.
+ */
+export async function runNpmView(packageName, { npmCliScript } = {}) {
+  try {
+    if (npmCliScript) {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [npmCliScript, "view", packageName, "version"],
+        { timeout: NPM_VIEW_TIMEOUT_MS },
+      );
+      return stdout.trim();
+    }
+    const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+    const { stdout } = await execFileAsync(
+      npmCommand,
+      ["view", packageName, "version"],
+      { timeout: NPM_VIEW_TIMEOUT_MS },
+    );
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Install `<packageName>@latest` via the bundled npm (or system npm in
+ * dev). Used only when the resolved binary is on the npm channel; never
+ * cross-installs to npm when the binary came from a native installer.
+ */
+async function runNpmInstallLatest(packageName, { npmCliScript } = {}) {
+  if (npmCliScript) {
+    await execFileAsync(
+      process.execPath,
+      [npmCliScript, "install", "-g", `${packageName}@latest`],
+      { timeout: NPM_INSTALL_TIMEOUT_MS },
+    );
+    return;
+  }
+  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+  await execFileAsync(
+    npmCommand,
+    ["install", "-g", `${packageName}@latest`],
+    { timeout: NPM_INSTALL_TIMEOUT_MS },
+  );
+}
+
+/**
+ * Run the Claude Code native installer script. Matches the original install
+ * path in agent-registry.mjs so we stay on the same channel rather than
+ * silently writing a parallel npm install.
+ */
+async function runClaudeNativeInstaller() {
+  if (process.platform === "win32") {
+    await execFileAsync(
+      "powershell",
+      [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "irm https://claude.ai/install.ps1 | iex",
+      ],
+      { timeout: NPM_INSTALL_TIMEOUT_MS },
+    );
+    return;
+  }
+  await execFileAsync(
+    "bash",
+    ["-c", "curl -fsSL https://claude.ai/install.sh | bash"],
+    { timeout: NPM_INSTALL_TIMEOUT_MS },
+  );
+}
+
+/**
+ * Attempt the CLI's own self-update first (native-channel binaries that
+ * ship `<cmd> update`, e.g. Claude Code). Returns true if the subcommand
+ * exists and exited 0; false if unsupported or failed.
+ */
+async function tryCliSelfUpdate(resolvedPath) {
+  try {
+    const onWindowsCmd =
+      process.platform === "win32" && resolvedPath.toLowerCase().endsWith(".cmd");
+    await execFileAsync(resolvedPath, ["update"], {
+      timeout: NPM_INSTALL_TIMEOUT_MS,
+      shell: onWindowsCmd,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fire-and-forget update check for a single CLI. TTL-gated; same-channel
+ * only; silent on failure. Called once per app launch — two launches within
+ * 24h make zero additional npm calls for this CLI.
+ */
+export async function backgroundUpdateCli({
+  label,
+  bareCommand,
+  resolvedPath,
+  packageName,
+  npmCliScript,
+  now = Date.now(),
+  state,
+  onUpdated,
+}) {
+  try {
+    const persisted = state ?? loadState();
+    const key = `lastUpdateCheck:${bareCommand}`;
+    const lastCheck = persisted[key];
+    if (typeof lastCheck === "number" && now - lastCheck < UPDATE_CHECK_TTL_MS) {
+      return { skipped: "ttl" };
+    }
+
+    const channel = classifyInstallChannel(resolvedPath, bareCommand);
+    if (channel === "unresolved") {
+      // Don't write state — we want to re-check next launch in case the
+      // install completes between now and then.
+      return { skipped: "unresolved" };
+    }
+
+    const [installed, latest] = await Promise.all([
+      runInstalledVersion(resolvedPath, bareCommand),
+      runNpmView(packageName, { npmCliScript }),
+    ]);
+
+    // Record the check timestamp even when we couldn't compare — offline
+    // and rate-limited cases should not retry every launch.
+    persisted[key] = now;
+
+    if (installed && latest && isNewer(installed, latest)) {
+      try {
+        if (channel === "native") {
+          const selfOk = await tryCliSelfUpdate(resolvedPath);
+          if (!selfOk) {
+            await runClaudeNativeInstaller();
+          }
+        } else {
+          await runNpmInstallLatest(packageName, { npmCliScript });
+        }
+        saveState(persisted);
+        onUpdated?.({ label, bareCommand, from: installed, to: latest, channel });
+        return { updated: true, from: installed, to: latest, channel };
+      } catch {
+        // Install failed — persist the check timestamp so we back off for
+        // 24h rather than spamming the registry every launch.
+        saveState(persisted);
+        return { skipped: "install_failed" };
+      }
+    }
+
+    saveState(persisted);
+    return { skipped: "up_to_date", installed, latest };
+  } catch {
+    // Outermost catch-all — never allow the updater to throw into the
+    // registry init path.
+    return { skipped: "error" };
+  }
+}

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -4,7 +4,10 @@
 import { spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import readline from "node:readline";
-import { createBrowserLocalAgentRegistry } from "./agent-registry.mjs";
+import {
+  createBrowserLocalAgentRegistry,
+  resolveInstalledCodexBinary,
+} from "./agent-registry.mjs";
 import { createClaudeRuntime } from "./claude-runtime.mjs";
 import { createGeminiRuntime } from "./gemini-runtime.mjs";
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
@@ -121,7 +124,11 @@ function spawnCodexProcess(cwd, { apiKey, mcpServers } = {}) {
     args.push("-c", mcpConfig.codexMcpConfigOverride);
   }
 
-  return spawn("codex", args, {
+  // Use the absolute-path resolver instead of bare `"codex"` so GUI-launched
+  // instances don't depend on shell PATH — addresses the same class of
+  // Windows regressions we hit for Claude (#876, #928, #1297, #1409).
+  const codexBinary = resolveInstalledCodexBinary();
+  return spawn(codexBinary, args, {
     cwd,
     env: {
       ...process.env,

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -1,0 +1,114 @@
+// ABOUTME: Critical tests for #1637 — background CLI updater pure logic.
+// ABOUTME: Guards TTL gate, semver compare, and same-channel classification.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/cli-updater.mjs",
+  import.meta.url,
+).href;
+const {
+  UPDATE_CHECK_TTL_MS,
+  isNewer,
+  classifyInstallChannel,
+  backgroundUpdateCli,
+} = await import(/* @vite-ignore */ modulePath);
+
+describe("isNewer", () => {
+  it("returns true when latest > installed on any semver component", () => {
+    expect(isNewer("1.4.2", "1.5.0")).toBe(true);
+    expect(isNewer("1.5.0", "1.5.1")).toBe(true);
+    expect(isNewer("1.5.0", "2.0.0")).toBe(true);
+  });
+
+  it("returns false when installed >= latest — avoids downgrades", () => {
+    expect(isNewer("1.5.0", "1.5.0")).toBe(false);
+    expect(isNewer("1.5.1", "1.5.0")).toBe(false);
+    expect(isNewer("2.0.0", "1.9.9")).toBe(false);
+  });
+
+  it("returns false when either version has a pre-release suffix — conservative by design", () => {
+    expect(isNewer("1.5.0-beta.1", "1.5.0")).toBe(false);
+    expect(isNewer("1.5.0", "1.5.1-rc.1")).toBe(false);
+    expect(isNewer("1.5.0", "1.5.0")).toBe(false);
+  });
+
+  it("returns false on malformed or non-string input — silent fail, not throw", () => {
+    expect(isNewer("not-a-version", "1.5.0")).toBe(false);
+    expect(isNewer("", "1.5.0")).toBe(false);
+    expect(isNewer(null as unknown as string, "1.5.0")).toBe(false);
+    expect(isNewer("1.5.0", undefined as unknown as string)).toBe(false);
+  });
+});
+
+describe("classifyInstallChannel", () => {
+  it("flags bare command fallback as unresolved so we skip the update entirely", () => {
+    expect(classifyInstallChannel("codex", "codex")).toBe("unresolved");
+    expect(classifyInstallChannel("claude", "claude")).toBe("unresolved");
+  });
+
+  it.each([
+    ["/Users/u/.claude/bin/claude", "claude"],
+    ["/Users/u/.local/bin/claude", "claude"],
+    ["C:\\Users\\u\\.claude\\bin\\claude.exe", "claude"],
+    ["C:\\Users\\u\\.local\\bin\\claude.exe", "claude"],
+  ])("recognizes %s as native so we use the native updater", (p, cmd) => {
+    expect(classifyInstallChannel(p, cmd)).toBe("native");
+  });
+
+  it.each([
+    ["C:\\Users\\u\\AppData\\Roaming\\npm\\codex.cmd", "codex"],
+    ["/usr/local/bin/codex", "codex"],
+    ["/opt/homebrew/bin/claude", "claude"],
+  ])("recognizes %s as npm so we use npm install -g", (p, cmd) => {
+    expect(classifyInstallChannel(p, cmd)).toBe("npm");
+  });
+});
+
+describe("backgroundUpdateCli TTL gate", () => {
+  it("skips when lastUpdateCheck is within 24h — no npm calls, no state mutation timing", async () => {
+    const state = {
+      "lastUpdateCheck:codex": Date.now() - 1000, // 1s ago
+    };
+    const result = await backgroundUpdateCli({
+      label: "Codex",
+      bareCommand: "codex",
+      resolvedPath: "/usr/local/bin/codex",
+      packageName: "@openai/codex",
+      state,
+      now: Date.now(),
+    });
+    expect(result).toEqual({ skipped: "ttl" });
+  });
+
+  it("proceeds past TTL when last check is older than 24h", async () => {
+    const state = {
+      "lastUpdateCheck:codex": Date.now() - (UPDATE_CHECK_TTL_MS + 1),
+    };
+    // No `onUpdated` wired and the binary path does not exist, so
+    // runInstalledVersion will return null and we record a "up_to_date"
+    // skip once npm view also fails (offline / no package). The important
+    // assertion is that we DIDN'T short-circuit on TTL.
+    const result = await backgroundUpdateCli({
+      label: "Codex",
+      bareCommand: "codex",
+      resolvedPath: "/nonexistent/codex",
+      packageName: "@seren-test/definitely-not-a-real-package-xyz",
+      state,
+      now: Date.now(),
+    });
+    expect(result.skipped).not.toBe("ttl");
+  });
+
+  it("skips when resolver returned the bare command — never creates a shadow install", async () => {
+    const result = await backgroundUpdateCli({
+      label: "Codex",
+      bareCommand: "codex",
+      resolvedPath: "codex", // resolver fell through to bare
+      packageName: "@openai/codex",
+      state: {},
+      now: Date.now(),
+    });
+    expect(result).toEqual({ skipped: "unresolved" });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1637 — Codex and Claude Code CLIs are installed on first use and never updated. Users who installed months ago don't see new models (GPT 5.5, future Opus/Sonnet variants) until they manually run `npm install -g`. A button would require user education we can't do at scale; this has to be automatic.

Fire-and-forget background update at registry init. TTL-gated (24h per CLI), **same-channel only**, silent on failure.

## Preconditions handled in this PR (from the ticket's self-review P1s)

- **New `resolveInstalledCodexBinary()`** mirroring `resolveInstalledClaudeBinary` / `resolveInstalledGeminiBinary`. Seren previously spawned Codex by bare command name — the class of Windows fragility that burned us in #876/#928. `spawnCodexProcess` now uses the absolute resolved path; future spawn paths + the updater share the same lookup.
- **Exports**: `resolveInstalledClaudeBinary` and `resolveInstalledCodexBinary` exported so the updater can classify the install channel of the exact binary Seren would spawn, not whichever happens to be on PATH.

## Updater design

[`bin/browser-local/cli-updater.mjs`](bin/browser-local/cli-updater.mjs):

- **TTL gate** (24h per CLI) via runtime-local JSON at `~/.seren/cli-update-state.json` (`%APPDATA%\Seren\cli-update-state.json` on Windows). Node writes directly — no `tauri-plugin-store` dependency, no change to `createBrowserLocalAgentRegistry({ emit })`'s signature.
- **Channel classification**: path shape decides `native` vs `npm`. `unresolved` (bare command fallback) is skipped entirely so we never create a shadow install the spawn resolver wouldn't pick — the #1637 review's P1 on channel-unsafe updates.
- **Same-channel updates**: native-installed Claude tries `<resolvedPath> update` first, falls back to the native installer; npm-installed CLIs go via the bundled `npm-cli.js`. No cross-channel reinstalls.
- **`isNewer`**: regex-based semver compare. Clean MAJOR.MINOR.PATCH only; pre-release suffixes bail — no new npm dep for a 20-line utility.
- **Silent failure** on every branch (no npm, offline, install failure, disk write error). The check timestamp is still persisted on failed installs so we back off 24h rather than retry every launch.

## Tests (critical-only per CLAUDE.md)

[`tests/unit/cli-updater.test.ts`](tests/unit/cli-updater.test.ts):
- `isNewer`: newer triggers; equal/older doesn't (no downgrades); pre-release bails; malformed input returns `false` without throwing.
- `classifyInstallChannel`: `native` for `~/.claude/bin` + `~/.local/bin` on macOS/Linux/Windows paths; `npm` for `AppData\npm`, `/usr/local/bin`, Homebrew-style; `unresolved` for bare-command fallback.
- `backgroundUpdateCli` TTL gate: within-24h skips; past-24h proceeds; unresolved binary path is never updated.

No UI tests, no live npm calls in tests, no Rust changes.

## What this PR does NOT ship (flagged honestly)

The ticket's acceptance calls for a **Windows E2E smoke test** (seed stale native Claude + stale npm Codex, assert same-channel update, assert no startup hang, assert post-update spawn uses new version). This PR ships:
- The pure-logic guards that unit tests can exercise.
- The channel classification that makes the E2E assertions meaningful.

It does **not** ship the E2E harness itself. If you want that as blocking, say so and I'll layer a Playwright Windows path in a follow-up. If you want to merge the correctness fix now and add the harness in parallel, that's my recommendation — this ticket's value (users getting GPT 5.5 automatically) accrues the moment this merges.

## Test plan

- [x] `pnpm test` — 465/465 pass (9 new + 456 existing).
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- [x] `pnpm tauri dev` — to verify end-to-end startup path.
- [ ] Windows E2E harness (follow-up, flagged above).

## Out of scope (explicitly)

- Toast/UI surfacing of "Codex updated to X.Y.Z" — emits `provider://cli-updated` for after-the-fact logging; surfacing is a separate design decision.
- Minimum-version gating with a blocking dialog if auto-update fails — file separately if field failures show up.
- Updating Gemini CLI — same pattern would apply; leaving as scope boundary since the motivating case was Codex/Claude model freshness.
- Touching `isCommandAvailable("codex")` in the `getAvailability` path — scope-bounded to spawn + updater.

## Related

- Preconditions satisfying the ticket's self-review: #1637 ([comment](https://github.com/serenorg/seren-desktop/issues/1637#issuecomment-4316009623))
- Prior Windows regressions this design explicitly avoids: #1297, #1298, #1344, #1349, #1409, #1410, #876, #928.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
