### PR TITLE
fix(cli-updater): atomic writes for cli-update-state.json (#1644)

### DIFF
--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -2,7 +2,14 @@
 // ABOUTME: Fire-and-forget at startup, TTL-gated, same-channel only, silent on failure.
 
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -29,6 +36,13 @@ function serenDataDir() {
 }
 
 function statePath() {
+  // Test-only override so tests can exercise saveState/loadState atomicity
+  // without touching the user's real ~/.seren/cli-update-state.json. Not a
+  // user-facing knob — undocumented on purpose.
+  const override = process.env.SEREN_CLI_UPDATER_STATE_PATH;
+  if (typeof override === "string" && override.length > 0) {
+    return override;
+  }
   return path.join(serenDataDir(), "cli-update-state.json");
 }
 
@@ -43,11 +57,26 @@ export function loadState() {
 }
 
 export function saveState(state) {
+  // Atomic write: serialize to a temp sibling, then rename. rename(2) is
+  // atomic on POSIX and on Windows NTFS for same-volume same-directory
+  // renames, which we satisfy by keeping the .tmp next to the target.
+  // Without this, a crash mid-write corrupts cli-update-state.json; loadState
+  // tolerates the parse error by returning {}, but TTL timestamps are lost
+  // and the updater re-checks every launch until network recovers — turning
+  // a transient registry blip into a launch-amplified hammer. See #1644.
+  const target = statePath();
+  const tmp = `${target}.tmp`;
   try {
     mkdirSync(serenDataDir(), { recursive: true });
-    writeFileSync(statePath(), JSON.stringify(state), "utf8");
+    writeFileSync(tmp, JSON.stringify(state), "utf8");
+    renameSync(tmp, target);
   } catch {
-    // Silent — missing persistence just means we re-check next launch.
+    // Best-effort tmp cleanup so a previous failed write doesn't leak.
+    try {
+      unlinkSync(tmp);
+    } catch {
+      // Nothing to clean up — silent.
+    }
   }
 }
 

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -1,7 +1,16 @@
 // ABOUTME: Critical tests for #1637 — background CLI updater pure logic.
 // ABOUTME: Guards TTL gate, semver compare, and same-channel classification.
 
-import { describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const modulePath = new URL(
   "../../bin/browser-local/cli-updater.mjs",
@@ -12,6 +21,8 @@ const {
   isNewer,
   classifyInstallChannel,
   backgroundUpdateCli,
+  loadState,
+  saveState,
 } = await import(/* @vite-ignore */ modulePath);
 
 describe("isNewer", () => {
@@ -110,5 +121,53 @@ describe("backgroundUpdateCli TTL gate", () => {
       now: Date.now(),
     });
     expect(result).toEqual({ skipped: "unresolved" });
+  });
+});
+
+describe("atomic state writes (#1644)", () => {
+  let tempDir: string;
+  let stateFile: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "seren-cli-updater-test-"));
+    stateFile = path.join(tempDir, "cli-update-state.json");
+    originalEnv = process.env.SEREN_CLI_UPDATER_STATE_PATH;
+    process.env.SEREN_CLI_UPDATER_STATE_PATH = stateFile;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SEREN_CLI_UPDATER_STATE_PATH;
+    } else {
+      process.env.SEREN_CLI_UPDATER_STATE_PATH = originalEnv;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("round-trips state across save+load — basic correctness", () => {
+    const written = { "lastUpdateCheck:codex": 1234567890 };
+    saveState(written);
+    expect(loadState()).toEqual(written);
+  });
+
+  it("does not leave a .tmp file behind on a successful save — temp rename completed", () => {
+    saveState({ ok: 1 });
+    expect(existsSync(`${stateFile}.tmp`)).toBe(false);
+    expect(existsSync(stateFile)).toBe(true);
+  });
+
+  it("preserves the prior known-good state when a partial .tmp from a prior crash exists — the rename is atomic, the tmp from the failed run does not corrupt loadState", () => {
+    saveState({ "lastUpdateCheck:codex": 100 });
+    // Simulate a prior crash mid-write: a stale .tmp exists with garbage,
+    // and the real state file is untouched. loadState must still read the
+    // good file, not the .tmp.
+    writeFileSync(`${stateFile}.tmp`, "{ this is not valid json", "utf8");
+    expect(loadState()).toEqual({ "lastUpdateCheck:codex": 100 });
+  });
+
+  it("returns {} on a corrupted state file rather than throwing — silent recovery", () => {
+    writeFileSync(stateFile, "{ corrupt", "utf8");
+    expect(loadState()).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1644. `saveState()` in [bin/browser-local/cli-updater.mjs](bin/browser-local/cli-updater.mjs) used a plain `writeFileSync` — not atomic. A crash mid-write corrupts `~/.seren/cli-update-state.json`; `loadState` catches the parse error and returns `{}`, but every TTL timestamp is lost on the next launch, turning a transient registry blip into a launch-amplified hammer.

## What changed

- `saveState`: write to `<target>.tmp`, then `renameSync(tmp, target)`. `rename(2)` is atomic on POSIX and on Windows NTFS for same-volume same-directory renames. Best-effort tmp cleanup on failure so a later successful save doesn't leak.
- Added an undocumented `SEREN_CLI_UPDATER_STATE_PATH` env override **purely for tests** — lets the test suite exercise atomicity against an isolated `os.tmpdir()` location without touching the user's real `~/.seren/cli-update-state.json`.

## Tests

`tests/unit/cli-updater.test.ts` — atomic state writes (#1644) describe block:
- `save+load round-trip` — basic correctness through the new code path.
- `successful save leaves no .tmp` — temp is renamed, not abandoned.
- `stale .tmp from a prior crash does not corrupt loadState` — proves `loadState` reads the live state file, not whichever junk a prior run left behind.
- `corrupted state file returns {} silently` — preserves the existing graceful-degrade contract.

## Test plan

- [x] `pnpm test` — 487/487 pass (4 new + 483 existing).
- [x] No new dependencies, no config changes, no UI.

## Out of scope

- Atomic writes for the upcoming `#1647` baseline-snapshot fields will reuse the same pattern; this PR establishes it. The baseline schema lands with #1647.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
