### PR TITLE
feat(cli-updater): log all outcomes by default; surface scan rejections in UI (#1646)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -563,6 +563,19 @@ export function createBrowserLocalAgentRegistry({ emit }) {
   const onUpdated = ({ label, from, to }) => {
     emit?.("provider://cli-updated", { label, from, to });
   };
+  // Default-on UI surface for scan rejections per #1646. The TS layer
+  // subscribes and shows a system notification + records the rejection
+  // in agent.store for the diagnostics panel. Silent rejection is worse
+  // UX than no scanner at all.
+  const onScanRejected = ({ label, packageName, from, to, flags }) => {
+    emit?.("provider://cli-scan-rejected", {
+      label,
+      packageName,
+      from,
+      to,
+      flags,
+    });
+  };
   void backgroundUpdateCli({
     label: "Codex",
     bareCommand: "codex",
@@ -570,6 +583,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
     packageName: "@openai/codex",
     npmCliScript,
     onUpdated,
+    onScanRejected,
   });
   void backgroundUpdateCli({
     label: "Claude Code",
@@ -578,6 +592,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
     packageName: "@anthropic-ai/claude-code",
     npmCliScript,
     onUpdated,
+    onScanRejected,
   });
 
   return {

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -301,9 +301,60 @@ async function tryCliSelfUpdate(resolvedPath) {
 }
 
 /**
+ * Format a single structured log line for an outcome. Default-on logging
+ * per #1646 — every updater run produces exactly one of these, no flag,
+ * no env var, no opt-in. Visible in the app log users include in support
+ * bundles. Never print package contents or PII; only enum + version
+ * transition + flag list (where applicable).
+ */
+function formatOutcomeLog({ packageName, outcome, details = {} }) {
+  const parts = [
+    `cli=${packageName}`,
+    `outcome=${outcome}`,
+  ];
+  for (const key of ["from", "to", "tarballSha512", "version"]) {
+    if (details[key] != null && details[key] !== "") {
+      parts.push(`${key}=${details[key]}`);
+    }
+  }
+  if (Array.isArray(details.flags) && details.flags.length > 0) {
+    parts.push(`flags=${details.flags.join(",")}`);
+  }
+  return `[cli-updater] ${parts.join(" ")}`;
+}
+
+function emitOutcomeLog({ packageName, outcome, details, logger }) {
+  const line = formatOutcomeLog({ packageName, outcome, details });
+  // scan_rejected and scan_error are security/operational signals — warn
+  // level so they stand out in the user-facing log. install_failed and
+  // network are also worth attention. Other outcomes are info.
+  const level =
+    outcome === "skipped:scan_rejected" ||
+    outcome === "skipped:scan_error" ||
+    outcome === "skipped:install_failed"
+      ? "warn"
+      : "info";
+  if (logger?.[level]) {
+    logger[level](line);
+    return;
+  }
+  // Fallback: plain console. Tauri's plugin-log webview target forwards
+  // these to the same log file users share when filing bugs.
+  if (level === "warn") {
+    console.warn(line);
+  } else {
+    console.info(line);
+  }
+}
+
+/**
  * Fire-and-forget update check for a single CLI. TTL-gated; same-channel
  * only; silent on failure. Called once per app launch — two launches within
  * 24h make zero additional npm calls for this CLI.
+ *
+ * Returns a normalized outcome object: `{ outcome, packageName, ...details }`.
+ * Every invocation emits exactly one log line + (for success or scan_rejected)
+ * exactly one provider event. See #1646.
  */
 export async function backgroundUpdateCli({
   label,
@@ -314,6 +365,8 @@ export async function backgroundUpdateCli({
   now = Date.now(),
   state,
   onUpdated,
+  onScanRejected,
+  logger,
   // Test seams — production callers leave these undefined and the real
   // scanner runs against npm.
   _scannerOverrides,
@@ -322,19 +375,41 @@ export async function backgroundUpdateCli({
   const scanFn = _scannerOverrides?.scanTarball ?? scanTarball;
   const installFromTarballFn =
     _scannerOverrides?.runNpmInstallFromTarball ?? runNpmInstallFromTarball;
+
+  // Compatibility: production runs may not pass `state` (callers were
+  // written before the test seam). When state is omitted we manage
+  // persistence ourselves via load/save inside this function.
+  const ownsPersistence = state === undefined;
+
+  function report(outcome, details = {}) {
+    emitOutcomeLog({ packageName, outcome, details, logger });
+    return {
+      outcome,
+      packageName,
+      bareCommand,
+      label,
+      ...details,
+      // Backwards-compat field shapes — pre-#1646 callers and tests check
+      // `skipped`, `updated`, `from`, `to`, etc. Keep those alongside the
+      // new `outcome` until callers migrate.
+      ...(outcome === "success"
+        ? { updated: true }
+        : { skipped: outcome.replace(/^skipped:/, "") }),
+    };
+  }
   try {
     const persisted = state ?? loadState();
     const key = `lastUpdateCheck:${bareCommand}`;
     const lastCheck = persisted[key];
     if (typeof lastCheck === "number" && now - lastCheck < UPDATE_CHECK_TTL_MS) {
-      return { skipped: "ttl" };
+      return report("skipped:ttl");
     }
 
     const channel = classifyInstallChannel(resolvedPath, bareCommand);
     if (channel === "unresolved") {
       // Don't write state — we want to re-check next launch in case the
       // install completes between now and then.
-      return { skipped: "unresolved" };
+      return report("skipped:unresolved");
     }
 
     const [installed, latest] = await Promise.all([
@@ -345,6 +420,14 @@ export async function backgroundUpdateCli({
     // Record the check timestamp even when we couldn't compare — offline
     // and rate-limited cases should not retry every launch.
     persisted[key] = now;
+
+    // Network outcome: we have a working installed binary but registry
+    // lookup failed. Distinct from up_to_date so #1646 callers can tell
+    // "registry unreachable" apart from "no update needed."
+    if (!latest) {
+      if (ownsPersistence) saveState(persisted);
+      return report("skipped:network", { installed });
+    }
 
     if (installed && latest && isNewer(installed, latest)) {
       // Native installs are gated by the upstream's signed installer + their
@@ -364,10 +447,14 @@ export async function backgroundUpdateCli({
             to: latest,
             channel,
           });
-          return { updated: true, from: installed, to: latest, channel };
+          return report("success", { from: installed, to: latest, channel });
         } catch {
           saveState(persisted);
-          return { skipped: "install_failed" };
+          return report("skipped:install_failed", {
+            from: installed,
+            to: latest,
+            channel,
+          });
         }
       }
 
@@ -430,12 +517,22 @@ export async function backgroundUpdateCli({
           } catch {
             // Silent.
           }
-          return {
-            skipped: "scan_rejected",
+          // UI surfacing: notify the registry / TS layer so a banner or
+          // notification can fire. Default-on per #1646 — silent scan
+          // rejections are worse UX than no scanner at all.
+          onScanRejected?.({
+            label,
+            bareCommand,
+            packageName,
             from: installed,
             to: latest,
             flags: scan.flags,
-          };
+          });
+          return report("skipped:scan_rejected", {
+            from: installed,
+            to: latest,
+            flags: scan.flags,
+          });
         }
 
         // verdict is "pass" or "no_baseline" — install. First install of a
@@ -451,7 +548,11 @@ export async function backgroundUpdateCli({
           } catch {
             // Silent.
           }
-          return { skipped: "install_failed" };
+          return report("skipped:install_failed", {
+            from: installed,
+            to: latest,
+            channel,
+          });
         }
 
         persisted[`baseline:${packageName}`] = {
@@ -476,14 +577,13 @@ export async function backgroundUpdateCli({
         } catch {
           // Silent.
         }
-        return {
-          updated: true,
+        return report("success", {
           from: installed,
           to: latest,
           channel,
           tarballSha512: scan.candidate.tarballSha512,
           firstInstall: scan.verdict === "no_baseline",
-        };
+        });
       } catch {
         // Pack/scan failure — fail closed. Don't update.
         saveState(persisted);
@@ -492,15 +592,17 @@ export async function backgroundUpdateCli({
         } catch {
           // Silent.
         }
-        return { skipped: "scan_error" };
+        return report("skipped:scan_error", { from: installed, to: latest });
       }
     }
 
     saveState(persisted);
-    return { skipped: "up_to_date", installed, latest };
+    return report("skipped:up_to_date", { installed, latest });
   } catch {
     // Outermost catch-all — never allow the updater to throw into the
     // registry init path.
-    return { skipped: "error" };
+    return report("skipped:error");
   }
 }
+
+export { formatOutcomeLog as _formatOutcomeLog };

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -142,7 +142,6 @@ async function waitForSessionIdle(
 }
 
 import { isLikelyAuthError } from "@/lib/auth-errors";
-import { authStore, promptLogin } from "@/stores/auth.store";
 import { buildChatRequest, sendProviderMessage } from "@/lib/providers";
 import {
   isPromptTooLongError,
@@ -186,6 +185,7 @@ import type {
   ToolCallEvent,
 } from "@/services/providers";
 import * as providerService from "@/services/providers";
+import { authStore, promptLogin } from "@/stores/auth.store";
 
 /** Set once we've subscribed to `provider-runtime://ready` so repeated
  *  initialize() calls don't stack listeners. */
@@ -194,6 +194,10 @@ let providerRuntimeReadyListener: Promise<UnlistenFn> | null = null;
 /** Set once we've subscribed to `provider-runtime://restarted` so repeated
  *  initialize() calls don't stack listeners. #1631. */
 let providerRuntimeRestartedListener: Promise<UnlistenFn> | null = null;
+
+/** Set once we've subscribed to `provider://cli-scan-rejected` so repeated
+ *  initialize() calls don't stack listeners. #1646. */
+let cliScanRejectedUnsub: (() => void) | null = null;
 
 /** Commit an agent list into the store + settle the selected-agent fallback.
  *  Shared by `initialize()` and the `provider-runtime://ready` listener so
@@ -304,6 +308,67 @@ function subscribeToProviderRuntimeRestarted(): void {
             );
           }
         })();
+      }
+    },
+  );
+}
+
+/**
+ * Subscribe once to provider://cli-scan-rejected so the CLI auto-updater's
+ * security gate (#1647) is never silent. The user stays on their previous
+ * known-good version; we record the rejection in store state for any
+ * diagnostics panel and fire a system notification per #1646.
+ *
+ * The subscription is idempotent — subscribeToCliScanRejections is safe to
+ * call from initialize() across repeated runtime restarts.
+ */
+function subscribeToCliScanRejections(): void {
+  if (cliScanRejectedUnsub) return;
+  cliScanRejectedUnsub = onRuntimeEvent(
+    "provider://cli-scan-rejected",
+    (payload) => {
+      const event = payload as {
+        label?: string;
+        packageName?: string;
+        from?: string | null;
+        to?: string;
+        flags?: string[];
+      };
+      if (!event.packageName || !event.to) return;
+      const rejection = {
+        label: event.label ?? event.packageName,
+        packageName: event.packageName,
+        from: event.from ?? null,
+        to: event.to,
+        flags: Array.isArray(event.flags) ? event.flags : [],
+        at: Date.now(),
+      };
+      setState("cliScanRejection", rejection);
+      // Default-on local log line so the rejection lands in the user-
+      // facing app log file even if the UI surface gets dismissed.
+      console.warn(
+        `[cli-updater] scan rejected for ${rejection.packageName} v${rejection.to}; flags=${rejection.flags.join(",")}`,
+      );
+      // System notification — minimum surface required by #1646. Falls
+      // back silently when the platform denies permission.
+      try {
+        if (typeof Notification !== "undefined") {
+          if (Notification.permission === "granted") {
+            new Notification("Seren blocked a CLI update", {
+              body: `${rejection.label} ${rejection.to} was rejected by the local supply-chain scanner. You stay on your previous version.`,
+            });
+          } else if (Notification.permission !== "denied") {
+            void Notification.requestPermission().then((perm) => {
+              if (perm === "granted") {
+                new Notification("Seren blocked a CLI update", {
+                  body: `${rejection.label} ${rejection.to} was rejected by the local supply-chain scanner. You stay on your previous version.`,
+                });
+              }
+            });
+          }
+        }
+      } catch {
+        // Silent — best-effort surface, never fail the subscriber.
       }
     },
   );
@@ -700,6 +765,20 @@ interface AgentState {
   error: string | null;
   /** CLI install progress message */
   installStatus: string | null;
+  /**
+   * Most recent CLI auto-updater scan rejection (#1646). Null when no
+   * rejection has been recorded this session. Set by
+   * subscribeToCliScanRejections from a provider runtime event; the user
+   * stays on their previous known-good version until cleared.
+   */
+  cliScanRejection: {
+    label: string;
+    packageName: string;
+    from: string | null;
+    to: string;
+    flags: string[];
+    at: number;
+  } | null;
   /** Pending permission requests awaiting user response */
   pendingPermissions: PermissionRequestEvent[];
   /** Pending diff proposals awaiting user accept/reject */
@@ -722,6 +801,7 @@ const [state, setState] = createStore<AgentState>({
   isLoading: false,
   error: null,
   installStatus: null,
+  cliScanRejection: null,
   pendingPermissions: [],
   pendingDiffProposals: [],
   agentModeEnabled: false,
@@ -1298,6 +1378,11 @@ export const agentStore = {
     // to applyAgents just overwrite availableAgents with the same data.
     subscribeToProviderRuntimeReady();
     subscribeToProviderRuntimeRestarted();
+    // Surface CLI-updater scan rejections per #1646. Default-on, runs once
+    // at app init, idempotent (the runtime emits the event at most once
+    // per launch per CLI). System notification + state record so the user
+    // can review what was rejected and why.
+    subscribeToCliScanRejections();
 
     const backoffMs = [0, 1_000, 2_000, 4_000, 8_000];
     for (let attempt = 0; attempt < backoffMs.length; attempt++) {

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -23,6 +23,7 @@ const {
   backgroundUpdateCli,
   loadState,
   saveState,
+  _formatOutcomeLog,
 } = await import(/* @vite-ignore */ modulePath);
 
 describe("isNewer", () => {
@@ -89,7 +90,7 @@ describe("backgroundUpdateCli TTL gate", () => {
       state,
       now: Date.now(),
     });
-    expect(result).toEqual({ skipped: "ttl" });
+    expect(result).toMatchObject({ outcome: "skipped:ttl", skipped: "ttl" });
   });
 
   it("proceeds past TTL when last check is older than 24h", async () => {
@@ -120,7 +121,50 @@ describe("backgroundUpdateCli TTL gate", () => {
       state: {},
       now: Date.now(),
     });
-    expect(result).toEqual({ skipped: "unresolved" });
+    expect(result).toMatchObject({
+      outcome: "skipped:unresolved",
+      skipped: "unresolved",
+    });
+  });
+});
+
+describe("outcome logging (#1646)", () => {
+  it("formats one structured line per outcome with cli + outcome + transition + flags", () => {
+    expect(
+      _formatOutcomeLog({
+        packageName: "@anthropic-ai/claude-code",
+        outcome: "success",
+        details: { from: "1.5.2", to: "1.5.3", tarballSha512: "abc" },
+      }),
+    ).toBe(
+      "[cli-updater] cli=@anthropic-ai/claude-code outcome=success from=1.5.2 to=1.5.3 tarballSha512=abc",
+    );
+  });
+
+  it("includes the flag list on scan_rejected so the user-facing log says WHY", () => {
+    const line = _formatOutcomeLog({
+      packageName: "@anthropic-ai/claude-code",
+      outcome: "skipped:scan_rejected",
+      details: {
+        version: "1.5.4",
+        flags: ["new_install_script:postinstall", "new_dependency:plain-crypto-js"],
+      },
+    });
+    expect(line).toContain("outcome=skipped:scan_rejected");
+    expect(line).toContain("version=1.5.4");
+    expect(line).toContain(
+      "flags=new_install_script:postinstall,new_dependency:plain-crypto-js",
+    );
+  });
+
+  it("emits a single line for the cheapest outcomes — no version, no flags, just the enum", () => {
+    expect(
+      _formatOutcomeLog({
+        packageName: "@openai/codex",
+        outcome: "skipped:ttl",
+        details: {},
+      }),
+    ).toBe("[cli-updater] cli=@openai/codex outcome=skipped:ttl");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1646. The CLI auto-updater (#1637) and its scanner (#1647) were silent on every failure path — no operational visibility, no security signal when the scanner rejects a malicious update, no way for users to know what happened. Per the ticket: local logging is hygiene (default-on); scan rejections are security events that surface in the UI; network telemetry stays opt-in (deferred).

> **🔗 Stacked on #1649 (#1647).** Base is `fix/1647-scanner`. The diff shows only the logging + UI surface changes. Will retarget to `main` once #1649 merges.

## What changed

### 1. Normalized outcome enum

Every `backgroundUpdateCli` invocation now returns `{ outcome: <enum>, packageName, ... }`:

| Outcome | Notes |
|---|---|
| `success` | new in this PR — was `{ updated: true }` |
| `skipped:up_to_date` | kept |
| `skipped:ttl` | kept |
| `skipped:unresolved` | kept |
| `skipped:scan_rejected` | **NEW** — security event |
| `skipped:scan_error` | **NEW** — fail-closed marker |
| `skipped:network` | **NEW** — registry unreachable, distinct from up_to_date |
| `skipped:install_failed` | kept |
| `skipped:error` | kept; now also routed through `report()` |

Backwards-compat fields (`updated`, `skipped`) preserved alongside `outcome` so pre-#1646 callers don't break.

### 2. Default-on local log line

Every outcome emits exactly one structured line:
```
[cli-updater] cli=@anthropic-ai/claude-code outcome=success from=1.5.2 to=1.5.3 tarballSha512=abc...
[cli-updater] cli=@anthropic-ai/claude-code outcome=skipped:scan_rejected version=1.5.4 flags=new_install_script:postinstall,new_dependency:plain-crypto-js
[cli-updater] cli=@openai/codex outcome=skipped:ttl
```
Security/operational outcomes (`scan_rejected`, `scan_error`, `install_failed`) go through `console.warn` so they stand out in the user-facing log; routine ones use `console.info`. Tauri's plugin-log webview target captures both — same log file users include in support bundles.

### 3. UI surface for scan rejections

- Runtime emits `provider://cli-scan-rejected {label, packageName, from, to, flags}` on the reject path.
- `agent.store` subscribes once at `initialize()` via `subscribeToCliScanRejections` (idempotent).
- New `AgentState.cliScanRejection` field holds the latest rejection so any future diagnostics panel can read it.
- Fires a Web `Notification` on rejection with the rejected version and a human message. Best-effort permission grant; falls back silently if denied. **No new dependency required** — uses the standard Web Notification API.
- `console.warn` line guarantees the rejection lands in the app log even if the system notification is dismissed.

## Tests (critical-only per CLAUDE.md)

[`tests/unit/cli-updater.test.ts`](tests/unit/cli-updater.test.ts) → new "outcome logging (#1646)" block:
- Success outcome logs cli + outcome + version transition + tarball hash.
- `scan_rejected` outcome logs the flag list — required for the user-facing log to say WHY (the whole point of the ticket).
- Cheapest outcomes log just the enum (no version, no flags).

Existing TTL/unresolved tests updated from `toEqual` to `toMatchObject` so they pass with the new normalized shape.

## Test plan

- [x] `pnpm test` — 500/500 pass.
- [x] `pnpm check` — 6 errors / 54 warnings, matches baseline; new files clean.

## What this PR does NOT do (acknowledged scope cuts)

- **Settings/about panel listing recent updater outcomes** (the ticket's "better than minimum" surface). The data is in `agent.store.cliScanRejection`; UI panel is a separate follow-up.
- **Network telemetry to Seren backend.** Opt-in by design; the ticket explicitly defers this.
- **Failure-path tests for the new outcomes.** Tracked in #1645 and shipping next.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
