### PR TITLE
test(cli-updater): coverage for failure paths (#1645)

### DIFF
--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -368,13 +368,17 @@ export async function backgroundUpdateCli({
   onScanRejected,
   logger,
   // Test seams — production callers leave these undefined and the real
-  // scanner runs against npm.
+  // scanner + version commands run against npm/disk.
   _scannerOverrides,
+  _versionOverrides,
 }) {
   const packFn = _scannerOverrides?.npmPackToDirectory ?? npmPackToDirectory;
   const scanFn = _scannerOverrides?.scanTarball ?? scanTarball;
   const installFromTarballFn =
     _scannerOverrides?.runNpmInstallFromTarball ?? runNpmInstallFromTarball;
+  const installedVersionFn =
+    _versionOverrides?.runInstalledVersion ?? runInstalledVersion;
+  const npmViewFn = _versionOverrides?.runNpmView ?? runNpmView;
 
   // Compatibility: production runs may not pass `state` (callers were
   // written before the test seam). When state is omitted we manage
@@ -413,8 +417,8 @@ export async function backgroundUpdateCli({
     }
 
     const [installed, latest] = await Promise.all([
-      runInstalledVersion(resolvedPath, bareCommand),
-      runNpmView(packageName, { npmCliScript }),
+      installedVersionFn(resolvedPath, bareCommand),
+      npmViewFn(packageName, { npmCliScript }),
     ]);
 
     // Record the check timestamp even when we couldn't compare — offline

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -215,3 +215,212 @@ describe("atomic state writes (#1644)", () => {
     expect(loadState()).toEqual({});
   });
 });
+
+describe("failure paths (#1645)", () => {
+  let tempDir: string;
+  let stateFile: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "seren-failpath-test-"));
+    stateFile = path.join(tempDir, "cli-update-state.json");
+    originalEnv = process.env.SEREN_CLI_UPDATER_STATE_PATH;
+    process.env.SEREN_CLI_UPDATER_STATE_PATH = stateFile;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SEREN_CLI_UPDATER_STATE_PATH;
+    } else {
+      process.env.SEREN_CLI_UPDATER_STATE_PATH = originalEnv;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // Fresh state per test — spreading baseInvocation otherwise leaks the
+  // mutated state object between tests (TTL gets seeded by run #1 and
+  // every subsequent run short-circuits on TTL).
+  function freshInvocation() {
+    return {
+      label: "Codex",
+      bareCommand: "codex",
+      resolvedPath: "/usr/local/bin/codex",
+      packageName: "@openai/codex",
+      state: {} as Record<string, unknown>,
+      now: Date.now(),
+    };
+  }
+
+  it("registry unreachable returns skipped:network distinct from up_to_date — operator can tell the registry is down", async () => {
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.0",
+        runNpmView: async () => null, // network/timeout/registry error
+      },
+    });
+    expect(result).toMatchObject({
+      outcome: "skipped:network",
+      installed: "1.5.0",
+    });
+  });
+
+  it("malformed npm view response (non-semver string) does not crash — graceful skip", async () => {
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.0",
+        runNpmView: async () => "not-a-version",
+      },
+    });
+    // isNewer returns false on non-semver strings, so we land in up_to_date.
+    // Crucially: no throw, no scan attempt, nothing installed.
+    expect(result.outcome).toBe("skipped:up_to_date");
+  });
+
+  it("missing CLI binary on disk does not trigger an install — no installed version means we cannot compare safely", async () => {
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      resolvedPath: "/this/path/definitely/does/not/exist",
+      _versionOverrides: {
+        // Production runInstalledVersion returns null when the path is absent;
+        // the override mirrors that behavior explicitly.
+        runInstalledVersion: async () => null,
+        runNpmView: async () => "1.5.3",
+      },
+    });
+    // No install path was taken because we never resolved an installed
+    // version to diff against. up_to_date is the safe outcome here.
+    expect(result.outcome).toBe("skipped:up_to_date");
+  });
+
+  it("install_failed when the install subprocess throws — bookkeeping persisted, not silent", async () => {
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.0",
+        runNpmView: async () => "1.5.3",
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/fake.tgz",
+        scanTarball: async () => ({
+          verdict: "pass",
+          flags: [],
+          candidate: {
+            version: "1.5.3",
+            tarballSha512: "abc",
+            installScripts: {},
+            declaredDependencies: [],
+            files: [],
+            fileHashes: {},
+          },
+        }),
+        runNpmInstallFromTarball: async () => {
+          throw new Error("network error");
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      outcome: "skipped:install_failed",
+      from: "1.5.0",
+      to: "1.5.3",
+    });
+  });
+
+  it("scan_rejected with the actual flag list propagates — the user-facing log will say WHY", async () => {
+    const flags = ["new_install_script:postinstall", "new_dependency:plain-crypto-js"];
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.3",
+        runNpmView: async () => "1.5.4",
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/fake.tgz",
+        scanTarball: async () => ({ verdict: "reject", flags, candidate: null }),
+        runNpmInstallFromTarball: async () => {
+          throw new Error("must NOT install when scan rejects");
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      outcome: "skipped:scan_rejected",
+      from: "1.5.3",
+      to: "1.5.4",
+      flags,
+    });
+  });
+
+  it("scan_error fails closed when the scanner itself throws — never installs on scanner crash", async () => {
+    let installCalled = false;
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.0",
+        runNpmView: async () => "1.5.3",
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/fake.tgz",
+        scanTarball: async () => {
+          throw new Error("scanner exploded");
+        },
+        runNpmInstallFromTarball: async () => {
+          installCalled = true;
+        },
+      },
+    });
+    expect(installCalled).toBe(false);
+    expect(result.outcome).toBe("skipped:scan_error");
+  });
+
+  it("first install (no_baseline) proceeds with the install but seeds the baseline — subsequent updates ARE scanned", async () => {
+    const candidate = {
+      version: "1.5.3",
+      tarballSha512: "abc",
+      installScripts: {},
+      declaredDependencies: ["foo"],
+      files: ["package.json"],
+      fileHashes: { "package.json": "h" },
+    };
+    let installCalled = false;
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.0",
+        runNpmView: async () => "1.5.3",
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/fake.tgz",
+        scanTarball: async () => ({
+          verdict: "no_baseline",
+          flags: [],
+          candidate,
+        }),
+        runNpmInstallFromTarball: async () => {
+          installCalled = true;
+        },
+      },
+    });
+    expect(installCalled).toBe(true);
+    expect(result).toMatchObject({
+      outcome: "success",
+      firstInstall: true,
+      tarballSha512: "abc",
+    });
+  });
+
+  it("loadState returns {} on a missing file — first launch never throws", () => {
+    // No state file exists yet (beforeEach made an empty tempDir).
+    expect(loadState()).toEqual({});
+  });
+
+  it("saveState swallows write errors when the parent directory is read-only — we will retry next launch, not crash now", () => {
+    // Simulate a write failure by pointing the env var at a path whose
+    // parent is a regular file. mkdir -p will fail; saveState catches.
+    const blockedFile = path.join(tempDir, "blocker");
+    writeFileSync(blockedFile, "x", "utf8");
+    process.env.SEREN_CLI_UPDATER_STATE_PATH = path.join(blockedFile, "child.json");
+    // Should not throw.
+    expect(() => saveState({ a: 1 })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1645. The CLI auto-updater is silent on every failure path by design. That preserves clean UX in the success case but makes failure-path regressions invisible in production. The #1637 test suite covered happy paths only. This PR adds tests for every silent branch the ticket called out.

> **🔗 Stacked on #1650 (#1646).** Base is `fix/1646-outcome-logging`. The diff shows only the new tests + a 4-line test seam. Will retarget to `main` once #1650 merges.

## Failure paths now covered

| # | Path | Outcome asserted |
|---|---|---|
| 1 | Registry unreachable (`runNpmView` returns null) with installed version known | `skipped:network` distinct from `skipped:up_to_date` |
| 2 | Malformed npm view response (non-semver string) | No crash; lands in `up_to_date` |
| 3 | Missing CLI binary on disk (`runInstalledVersion` returns null) | No install triggered |
| 4 | Install subprocess throws | `skipped:install_failed` with `from`/`to` preserved |
| 5 | Scanner returns `reject` | `skipped:scan_rejected` carries the actual flag list |
| 6 | Scanner itself throws | `skipped:scan_error` fails closed; install fn never invoked |
| 7 | First install with `no_baseline` | Install proceeds AND baseline gets seeded |
| 8 | `loadState` on missing file | Returns `{}` (first launch path) |
| 9 | `saveState` to a path whose parent is a regular file | Swallows the error, does not throw |

## Test seam added (4 lines)

`_versionOverrides.{runInstalledVersion, runNpmView}` lets tests drive registry / installed-version probes without spawning subprocesses. Production callers leave it undefined; default behavior unchanged. Mirrors the existing `_scannerOverrides` pattern from #1647.

## Test infrastructure

`freshInvocation()` helper inside the `failure paths` describe block — spreading shared params previously leaked the mutated `state` object across tests (TTL got seeded by run #1, every subsequent run short-circuited on TTL). Each test now starts with `state = {}`.

## Test plan

- [x] `pnpm test` — 509/509 pass (9 new + 500 existing).
- [x] No new dependencies; no new files outside the test file and the 4-line override.

## What this PR does NOT do

- **Live npm subprocess tests.** The whole point of the override seam is that we don't run real npm in unit tests — fragile, slow, network-dependent. End-to-end coverage of npm pack / install is a follow-up if and when we add a CI smoke harness.
- **UI-side tests for the scan-rejected notification.** The notification is best-effort browser-API behavior; mocking Web Notification is more brittle than the value of the test.
- **Telemetry tests** (deferred per #1646).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
