### PR TITLE
fix(auth): surface Sign In on context overflow when session expired (#1652)

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -19,7 +19,7 @@ import { SignIn } from "@/components/auth/SignIn";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { DepositModal } from "@/components/wallet/DepositModal";
-import { isAuthError } from "@/lib/auth-errors";
+import { isAuthError, isContextOverflowError } from "@/lib/auth-errors";
 import {
   getCompletions,
   matchSkillCommand,
@@ -701,12 +701,11 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
       }
     }
 
-    // If using Seren provider and not authenticated, prompt sign-in
-    if (
-      (providerStore.activeProvider === "seren" ||
-        providerStore.activeProvider === "seren-private") &&
-      !authStore.isAuthenticated
-    ) {
+    // If not authenticated, prompt sign-in — every provider eventually depends
+    // on Seren auth for auto-compaction (#1641), so scoping this to Seren
+    // providers hid the real failure as a "Prompt is too long" dead-end on
+    // Claude Code and other agents (#1652).
+    if (!authStore.isAuthenticated) {
       if (!opts?.skipAuthGate) {
         setShowSignInPrompt(true);
       }
@@ -773,11 +772,9 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     // this, a session-expired state can still start an orchestrator turn
     // with no access token and no publishers, producing silent "no file
     // found" failures while the user believes the turn is running normally.
-    if (
-      (providerStore.activeProvider === "seren" ||
-        providerStore.activeProvider === "seren-private") &&
-      !authStore.isAuthenticated
-    ) {
+    // Not provider-scoped: compaction depends on Seren auth regardless of
+    // which provider is active (#1652).
+    if (!authStore.isAuthenticated) {
       setShowSignInPrompt(true);
       return;
     }
@@ -1273,7 +1270,13 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                         >
                           <div class="mt-2 px-2 py-1.5 bg-destructive/10 border border-destructive/40 rounded flex items-center gap-2 text-xs text-destructive">
                             <Show
-                              when={!isAuthError(message.error)}
+                              when={
+                                !isAuthError(message.error) &&
+                                !(
+                                  isContextOverflowError(message.error) &&
+                                  !authStore.isAuthenticated
+                                )
+                              }
                               fallback={
                                 <>
                                   <span>

--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -52,3 +52,23 @@ export function isLikelyAuthError(msg: string | null | undefined): boolean {
   if (msg.length > AUTH_ERROR_MAX_LENGTH) return false;
   return AUTH_ERROR_PATTERNS.some((pattern) => pattern.test(msg));
 }
+
+/** Patterns that indicate a context-window overflow from the provider. */
+const CONTEXT_OVERFLOW_PATTERNS = [
+  /prompt is too long/i,
+  /context (length|window).*exceed/i,
+];
+
+/**
+ * Check if an error message indicates the provider rejected the prompt
+ * because the conversation exceeded its context window. When the user is
+ * also unauthenticated this is a hidden auth failure — auto-compaction
+ * is gated on auth (#1641), so the overflow is the symptom, not the cause.
+ * See #1652.
+ */
+export function isContextOverflowError(
+  msg: string | null | undefined,
+): boolean {
+  if (!msg) return false;
+  return CONTEXT_OVERFLOW_PATTERNS.some((pattern) => pattern.test(msg));
+}

--- a/tests/unit/auth-context-overflow-signin.test.ts
+++ b/tests/unit/auth-context-overflow-signin.test.ts
@@ -1,0 +1,95 @@
+// ABOUTME: Regression tests for #1652 — context-overflow on expired session must surface Sign In.
+// ABOUTME: Covers isContextOverflowError, banner wiring, and provider-scoped pre-send gate removal.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { isContextOverflowError } from "@/lib/auth-errors";
+
+const chatContentSource = readFileSync(
+  resolve("src/components/chat/ChatContent.tsx"),
+  "utf-8",
+);
+
+describe("#1652 — isContextOverflowError", () => {
+  it("matches the strings Anthropic returns on context overflow", () => {
+    expect(isContextOverflowError("Prompt is too long")).toBe(true);
+    expect(isContextOverflowError("prompt is too long: 897960 tokens > 200000")).toBe(true);
+    expect(isContextOverflowError("context length exceeded")).toBe(true);
+    expect(isContextOverflowError("context window exceeded")).toBe(true);
+  });
+
+  it("does not false-positive on normal text", () => {
+    expect(isContextOverflowError(null)).toBe(false);
+    expect(isContextOverflowError(undefined)).toBe(false);
+    expect(isContextOverflowError("")).toBe(false);
+    expect(isContextOverflowError("The prompt is short and well-formed")).toBe(false);
+    expect(isContextOverflowError("Here is some context about the project")).toBe(false);
+  });
+});
+
+describe("#1652 — per-message banner shows Sign In on context-overflow when unauthenticated", () => {
+  it("imports isContextOverflowError from auth-errors", () => {
+    expect(chatContentSource).toContain(
+      "isContextOverflowError",
+    );
+    expect(chatContentSource).toMatch(
+      /from ["']@\/lib\/auth-errors["']/,
+    );
+  });
+
+  it("banner treats context-overflow as session-expired iff !authStore.isAuthenticated", () => {
+    // The Show-when predicate must combine isAuthError with a context-overflow
+    // branch gated on !authStore.isAuthenticated. We assert on the anchor
+    // string so the banner fallback (the Sign In button) fires for the
+    // "Prompt is too long" case when the user is signed out.
+    const bannerAnchor = "Session expired. Please sign in to continue.";
+    const bannerIdx = chatContentSource.indexOf(bannerAnchor);
+    expect(bannerIdx, "session-expired banner anchor must exist").toBeGreaterThan(0);
+
+    // Walk backwards from the banner anchor to the governing `Show when={...}`
+    // — the predicate for that Show must reference both isAuthError and the
+    // context-overflow + unauthenticated condition.
+    const showOpen = chatContentSource.lastIndexOf("<Show", bannerIdx);
+    expect(showOpen, "governing Show must exist before banner").toBeGreaterThan(0);
+    const predicate = chatContentSource.slice(showOpen, bannerIdx);
+
+    expect(predicate).toContain("isAuthError(message.error)");
+    expect(predicate).toContain("isContextOverflowError(message.error)");
+    expect(predicate).toContain("!authStore.isAuthenticated");
+  });
+});
+
+describe("#1652 — pre-send sign-in gate is not provider-scoped", () => {
+  it("does not scope the sign-in gate to seren / seren-private providers", () => {
+    // Before the fix there were two guards of the form
+    //   (activeProvider === "seren" || activeProvider === "seren-private") && !isAuthenticated
+    // that bypassed the Sign In prompt on Claude Code and other providers.
+    // Locate every call site of setShowSignInPrompt(true) inside a pre-send
+    // gate and assert the provider scoping is gone.
+    const gateCall = 'setShowSignInPrompt(true)';
+    let idx = 0;
+    let gateCount = 0;
+    while ((idx = chatContentSource.indexOf(gateCall, idx)) !== -1) {
+      // Look at the 400 chars preceding each gate call — the governing `if`
+      // condition lives there for the pre-send guards. Skip the <button
+      // onClick> site (short window, no `if (`).
+      const window = chatContentSource.slice(Math.max(0, idx - 400), idx);
+      if (window.includes("if (") && window.includes("!authStore.isAuthenticated")) {
+        expect(
+          window,
+          "pre-send gate must not check activeProvider === 'seren'",
+        ).not.toMatch(/activeProvider === ["']seren["']/);
+        expect(
+          window,
+          "pre-send gate must not check activeProvider === 'seren-private'",
+        ).not.toMatch(/activeProvider === ["']seren-private["']/);
+        gateCount++;
+      }
+      idx += gateCall.length;
+    }
+
+    // Both pre-send gates (sendMessage + sendMessageImmediate) must exist.
+    expect(gateCount, "both pre-send gates must still guard on auth").toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `isContextOverflowError()` helper in [`src/lib/auth-errors.ts`](src/lib/auth-errors.ts) matching `prompt is too long` and `context (length|window).*exceed`.
- Extend the per-message banner predicate in [`ChatContent.tsx`](src/components/chat/ChatContent.tsx) to treat context overflow as session-expired when `!authStore.isAuthenticated`, so the Sign In button surfaces.
- Drop the `seren` / `seren-private` provider scoping on both pre-send sign-in gates. Auto-compaction depends on Seren auth regardless of provider, so scoping hid the real failure on Claude Code as a `Prompt is too long` dead-end.

Closes #1652. Builds on the compaction auth-gate shipped in #1641.

## Test plan

- [x] `tests/unit/auth-context-overflow-signin.test.ts` — covers `isContextOverflowError`, the banner predicate wiring, and the provider-scoping removal on both pre-send gates.
- [x] Full unit suite still green (`pnpm test` — 59 files, 492 tests).
- [ ] Manual: force refresh-token removal mid-conversation on a Claude Code thread, confirm the next send shows the Sign In modal instead of `Prompt is too long`.
- [ ] Manual: same on a Seren / Seren-private thread — behavior should be unchanged (Sign In modal still fires, just via the collapsed gate).
