### PR TITLE
feat(cli-updater): scanner + outcome logging + failure-path tests (relands #1649, #1650, #1651)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -563,6 +563,19 @@ export function createBrowserLocalAgentRegistry({ emit }) {
   const onUpdated = ({ label, from, to }) => {
     emit?.("provider://cli-updated", { label, from, to });
   };
+  // Default-on UI surface for scan rejections per #1646. The TS layer
+  // subscribes and shows a system notification + records the rejection
+  // in agent.store for the diagnostics panel. Silent rejection is worse
+  // UX than no scanner at all.
+  const onScanRejected = ({ label, packageName, from, to, flags }) => {
+    emit?.("provider://cli-scan-rejected", {
+      label,
+      packageName,
+      from,
+      to,
+      flags,
+    });
+  };
   void backgroundUpdateCli({
     label: "Codex",
     bareCommand: "codex",
@@ -570,6 +583,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
     packageName: "@openai/codex",
     npmCliScript,
     onUpdated,
+    onScanRejected,
   });
   void backgroundUpdateCli({
     label: "Claude Code",
@@ -578,6 +592,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
     packageName: "@anthropic-ai/claude-code",
     npmCliScript,
     onUpdated,
+    onScanRejected,
   });
 
   return {

--- a/bin/browser-local/cli-scanner.mjs
+++ b/bin/browser-local/cli-scanner.mjs
@@ -1,0 +1,424 @@
+// ABOUTME: Local-only supply-chain scanner for the CLI auto-updater (#1647).
+// ABOUTME: Diffs an npm pack against the last-known-good baseline + runs static heuristics.
+
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const NPM_PACK_TIMEOUT_MS = 120_000;
+const TAR_TIMEOUT_MS = 60_000;
+
+/**
+ * Files we expect to see touched on a normal release (allowed-change list).
+ * Anything outside this set being added or content-changed across a patch
+ * version is flagged as suspicious by the diff. Conservative: missing
+ * entries here just mean "more flags" (false positives), not skipped checks.
+ */
+const ENTRY_POINT_DIRS = new Set(["dist", "lib", "build", "src", "bin"]);
+
+/**
+ * Static-check thresholds. Tuned to be loose enough that legitimate updates
+ * pass on common CLIs, tight enough to flag axios/chalk/Shai-Hulud-style
+ * additions of obfuscated payloads.
+ */
+const ENTROPY_FLAG_THRESHOLD = 7.5; // bits/byte for .js files
+const BASE64_LITERAL_FLAG_BYTES = 2 * 1024;
+const ENTRY_POINT_SIZE_GROWTH_RATIO = 1.5;
+
+const BASE64_LITERAL_RE = /["'`]([A-Za-z0-9+/=]{2730,}|[A-Za-z0-9+/=]{2048,}={0,2})["'`]/g;
+const EVAL_INVOCATION_RE = /\beval\s*\(/g;
+const NEW_FUNCTION_RE = /\bnew\s+Function\s*\(/g;
+const DYNAMIC_REQUIRE_RE = /\brequire\s*\(\s*[^"'`)\s][^)]*\)/g;
+const HOSTNAME_RE = /(https?:\/\/|[a-z0-9.-]+\.[a-z]{2,})/gi;
+
+export function computeSha512(absPath) {
+  const hash = createHash("sha512");
+  hash.update(readFileSync(absPath));
+  return hash.digest("hex");
+}
+
+/**
+ * Run `npm pack <pkg>@<version> --pack-destination=<dir>`. Returns the
+ * absolute path of the downloaded tarball. npm pack does NOT execute
+ * install scripts — that only happens during `npm install`. So this
+ * leaves the bits inert on disk, ready for inspection.
+ */
+export async function npmPackToDirectory({
+  packageName,
+  version,
+  destinationDir,
+  npmCliScript,
+}) {
+  mkdirSync(destinationDir, { recursive: true });
+  const args = npmCliScript
+    ? [
+        npmCliScript,
+        "pack",
+        `${packageName}@${version}`,
+        "--pack-destination",
+        destinationDir,
+      ]
+    : ["pack", `${packageName}@${version}`, "--pack-destination", destinationDir];
+  const exec = npmCliScript
+    ? process.execPath
+    : process.platform === "win32"
+      ? "npm.cmd"
+      : "npm";
+  const { stdout } = await execFileAsync(exec, args, {
+    timeout: NPM_PACK_TIMEOUT_MS,
+  });
+  // npm pack prints the tarball filename on the last non-empty stdout line.
+  const filename = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .at(-1);
+  if (!filename) {
+    throw new Error("npm pack did not report a filename");
+  }
+  const absolute = path.join(destinationDir, filename);
+  if (!existsSync(absolute)) {
+    throw new Error(`npm pack output not found on disk: ${absolute}`);
+  }
+  return absolute;
+}
+
+/**
+ * Extract a .tgz into destinationDir. Uses the system `tar` (built-in on
+ * macOS/Linux, present in Windows 10+).
+ */
+export async function extractTarball({ tarballPath, destinationDir }) {
+  mkdirSync(destinationDir, { recursive: true });
+  await execFileAsync(
+    "tar",
+    ["-xzf", tarballPath, "-C", destinationDir],
+    { timeout: TAR_TIMEOUT_MS },
+  );
+  // npm tarballs always extract into a top-level "package" directory.
+  const root = path.join(destinationDir, "package");
+  if (!existsSync(root)) {
+    throw new Error(`Extracted tarball missing 'package' root at ${root}`);
+  }
+  return root;
+}
+
+/** List files under root, relative paths, depth-first. Skips symlinks. */
+export function walkFiles(root) {
+  const out = [];
+  function visit(dir) {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const abs = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        visit(abs);
+      } else if (entry.isFile()) {
+        out.push(path.relative(root, abs));
+      }
+    }
+  }
+  visit(root);
+  return out.sort();
+}
+
+/**
+ * Build a snapshot of the package: scripts, deps, file hashes, top-level
+ * file list, declared install hooks. This snapshot becomes the baseline
+ * stored after a successful install.
+ */
+export function buildPackageSnapshot(extractedRoot) {
+  const pkgPath = path.join(extractedRoot, "package.json");
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  } catch (err) {
+    throw new Error(`package.json missing or invalid: ${err.message}`);
+  }
+  const scripts = pkg.scripts && typeof pkg.scripts === "object" ? pkg.scripts : {};
+  const installScriptNames = ["preinstall", "install", "postinstall"];
+  const installScripts = {};
+  for (const key of installScriptNames) {
+    if (typeof scripts[key] === "string" && scripts[key].length > 0) {
+      installScripts[key] = scripts[key];
+    }
+  }
+  const declaredDependencies = Object.keys({
+    ...(pkg.dependencies ?? {}),
+    ...(pkg.optionalDependencies ?? {}),
+  }).sort();
+
+  const files = walkFiles(extractedRoot);
+  const fileHashes = {};
+  for (const rel of files) {
+    fileHashes[rel] = computeSha512(path.join(extractedRoot, rel));
+  }
+
+  return {
+    version: typeof pkg.version === "string" ? pkg.version : null,
+    installScripts,
+    declaredDependencies,
+    files,
+    fileHashes,
+  };
+}
+
+/**
+ * Diff a candidate snapshot against the last-known-good baseline.
+ * Returns a list of human-readable flag strings; empty array means clean.
+ * Flags that would later require manual investigation include enough
+ * detail (filenames, depnames) to triage without re-running the scan.
+ */
+export function diffSnapshots(baseline, candidate) {
+  const flags = [];
+
+  // Install scripts: any new install hook is the axios pattern.
+  const baselineHooks = baseline?.installScripts ?? {};
+  const candidateHooks = candidate.installScripts ?? {};
+  for (const hook of ["preinstall", "install", "postinstall"]) {
+    const had = typeof baselineHooks[hook] === "string";
+    const has = typeof candidateHooks[hook] === "string";
+    if (!had && has) {
+      flags.push(`new_install_script:${hook}`);
+    } else if (had && has && baselineHooks[hook] !== candidateHooks[hook]) {
+      flags.push(`changed_install_script:${hook}`);
+    }
+  }
+
+  // Dependency additions: new runtime deps are inherently suspicious on a
+  // patch/minor bump. Don't flag removals — that's just cleanup.
+  const baselineDeps = new Set(baseline?.declaredDependencies ?? []);
+  for (const dep of candidate.declaredDependencies ?? []) {
+    if (!baselineDeps.has(dep)) {
+      flags.push(`new_dependency:${dep}`);
+    }
+  }
+
+  // New top-level files (depth 1) that didn't exist before.
+  const baselineFiles = new Set(baseline?.files ?? []);
+  for (const file of candidate.files ?? []) {
+    if (!baselineFiles.has(file)) {
+      const depth = file.split("/").length;
+      const topLevel = depth === 1;
+      const inEntryDir = depth > 1 && ENTRY_POINT_DIRS.has(file.split("/")[0]);
+      if (topLevel || inEntryDir) {
+        flags.push(`new_file:${file}`);
+      }
+    }
+  }
+
+  // File-content hash changes for files that should be invariant across
+  // a patch release (LICENSE, README) — these usually only change on
+  // minor/major bumps, and a patch-version change here is suspicious.
+  const baselineHashes = baseline?.fileHashes ?? {};
+  for (const file of candidate.files ?? []) {
+    const candidateHash = candidate.fileHashes?.[file];
+    const baselineHash = baselineHashes[file];
+    if (!baselineHash || !candidateHash) continue;
+    if (candidateHash !== baselineHash) {
+      const lower = file.toLowerCase();
+      if (lower === "license" || lower === "license.md" || lower === "readme.md") {
+        flags.push(`changed_invariant:${file}`);
+      }
+    }
+  }
+
+  return flags;
+}
+
+function shannonEntropy(buffer) {
+  if (!buffer || buffer.length === 0) return 0;
+  const counts = new Array(256).fill(0);
+  for (const byte of buffer) counts[byte]++;
+  let entropy = 0;
+  const len = buffer.length;
+  for (const count of counts) {
+    if (count === 0) continue;
+    const p = count / len;
+    entropy -= p * Math.log2(p);
+  }
+  return entropy;
+}
+
+/**
+ * Run static heuristics on the extracted package contents. Operates on
+ * .js / .mjs / .cjs files only. Returns flag strings; empty = clean.
+ */
+export function runStaticChecks(
+  extractedRoot,
+  { hostnameAllowlist = [], baseline = null } = {},
+) {
+  const flags = [];
+  const allowed = new Set(hostnameAllowlist.map((h) => h.toLowerCase()));
+  const files = walkFiles(extractedRoot);
+
+  for (const rel of files) {
+    if (!/\.(c?js|mjs)$/.test(rel)) continue;
+    const abs = path.join(extractedRoot, rel);
+    let content;
+    let buffer;
+    try {
+      buffer = readFileSync(abs);
+      content = buffer.toString("utf8");
+    } catch {
+      continue;
+    }
+
+    if (EVAL_INVOCATION_RE.test(content)) {
+      flags.push(`eval_call:${rel}`);
+    }
+    EVAL_INVOCATION_RE.lastIndex = 0;
+
+    if (NEW_FUNCTION_RE.test(content)) {
+      flags.push(`new_function:${rel}`);
+    }
+    NEW_FUNCTION_RE.lastIndex = 0;
+
+    if (DYNAMIC_REQUIRE_RE.test(content)) {
+      flags.push(`dynamic_require:${rel}`);
+    }
+    DYNAMIC_REQUIRE_RE.lastIndex = 0;
+
+    // Newly-introduced child_process usage in a file that didn't have it.
+    const usesChildProcess =
+      content.includes('require("child_process")') ||
+      content.includes("require('child_process')") ||
+      content.includes('require("node:child_process")') ||
+      content.includes("require('node:child_process')") ||
+      content.includes('from "child_process"') ||
+      content.includes("from 'child_process'") ||
+      content.includes('from "node:child_process"') ||
+      content.includes("from 'node:child_process'");
+    if (usesChildProcess) {
+      const baselineHash = baseline?.fileHashes?.[rel];
+      const candidateHash = computeSha512(abs);
+      if (!baselineHash) {
+        flags.push(`child_process_in_new_file:${rel}`);
+      } else if (baselineHash !== candidateHash) {
+        flags.push(`child_process_in_changed_file:${rel}`);
+      }
+    }
+
+    // Large base64-encoded literals at the top level rarely show up in
+    // legitimate JS — usually they encode payloads or PII.
+    let match;
+    BASE64_LITERAL_RE.lastIndex = 0;
+    while ((match = BASE64_LITERAL_RE.exec(content)) !== null) {
+      if (match[1].length >= BASE64_LITERAL_FLAG_BYTES) {
+        flags.push(
+          `large_base64_literal:${rel}:${match[1].length}b`,
+        );
+        break;
+      }
+    }
+
+    // Entropy on the raw file bytes — packed/obfuscated payloads usually
+    // sit well above 7.5 bits/byte; readable JS is typically 4.5–5.5.
+    const entropy = shannonEntropy(buffer);
+    if (entropy >= ENTROPY_FLAG_THRESHOLD) {
+      flags.push(`high_entropy:${rel}:${entropy.toFixed(2)}`);
+    }
+
+    // Hostname allowlist: if a non-allowlisted hostname appears in a file
+    // that's growing, flag it. Per-CLI allowlists are passed in.
+    if (allowed.size > 0) {
+      const hostnames = new Set();
+      let m;
+      HOSTNAME_RE.lastIndex = 0;
+      while ((m = HOSTNAME_RE.exec(content)) !== null) {
+        const raw = m[0].toLowerCase();
+        const host = raw.replace(/^https?:\/\//, "").split("/")[0];
+        if (host.length > 0) hostnames.add(host);
+      }
+      for (const host of hostnames) {
+        if (!allowed.has(host) && !isHostAllowed(host, allowed)) {
+          flags.push(`unallowed_host:${rel}:${host}`);
+        }
+      }
+    }
+
+    // Entry-point file size growth check: only meaningful if we have a
+    // baseline file size. We approximate via baseline file presence; a
+    // real growth ratio would need explicit baseline file sizes, deferred.
+    if (baseline?.fileSizes && baseline.fileSizes[rel] != null) {
+      const baseSize = baseline.fileSizes[rel];
+      if (baseSize > 0 && buffer.length / baseSize >= ENTRY_POINT_SIZE_GROWTH_RATIO) {
+        flags.push(
+          `entry_point_growth:${rel}:${baseSize}->${buffer.length}`,
+        );
+      }
+    }
+  }
+
+  return flags;
+}
+
+function isHostAllowed(host, allowed) {
+  // Allow exact-match and suffix-match (api.openai.com matches openai.com).
+  for (const a of allowed) {
+    if (host === a || host.endsWith(`.${a}`)) return true;
+  }
+  return false;
+}
+
+/**
+ * Top-level scan entry point. Caller has already npm-packed the candidate
+ * version to a tarball. We extract, snapshot, diff, and static-check.
+ *
+ * Verdict:
+ *   - "pass" with empty flags: install the tarball, persist the new
+ *     snapshot as the baseline.
+ *   - "reject" with non-empty flags: skip install, surface flags via the
+ *     #1646 outcome enum.
+ *   - "no_baseline": first install of this CLI; nothing to diff against.
+ *     Caller decides whether to seed-and-install or refuse.
+ */
+export async function scanTarball({
+  tarballPath,
+  baseline,
+  workDir,
+  hostnameAllowlist,
+}) {
+  const extractedRoot = await extractTarball({
+    tarballPath,
+    destinationDir: workDir,
+  });
+  const candidate = buildPackageSnapshot(extractedRoot);
+  candidate.tarballSha512 = computeSha512(tarballPath);
+
+  if (!baseline) {
+    return {
+      verdict: "no_baseline",
+      flags: [],
+      candidate,
+      extractedRoot,
+    };
+  }
+
+  const diffFlags = diffSnapshots(baseline, candidate);
+  const staticFlags = runStaticChecks(extractedRoot, {
+    hostnameAllowlist,
+    baseline,
+  });
+  const allFlags = [...diffFlags, ...staticFlags];
+  return {
+    verdict: allFlags.length === 0 ? "pass" : "reject",
+    flags: allFlags,
+    candidate,
+    extractedRoot,
+  };
+}

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -301,9 +301,60 @@ async function tryCliSelfUpdate(resolvedPath) {
 }
 
 /**
+ * Format a single structured log line for an outcome. Default-on logging
+ * per #1646 — every updater run produces exactly one of these, no flag,
+ * no env var, no opt-in. Visible in the app log users include in support
+ * bundles. Never print package contents or PII; only enum + version
+ * transition + flag list (where applicable).
+ */
+function formatOutcomeLog({ packageName, outcome, details = {} }) {
+  const parts = [
+    `cli=${packageName}`,
+    `outcome=${outcome}`,
+  ];
+  for (const key of ["from", "to", "tarballSha512", "version"]) {
+    if (details[key] != null && details[key] !== "") {
+      parts.push(`${key}=${details[key]}`);
+    }
+  }
+  if (Array.isArray(details.flags) && details.flags.length > 0) {
+    parts.push(`flags=${details.flags.join(",")}`);
+  }
+  return `[cli-updater] ${parts.join(" ")}`;
+}
+
+function emitOutcomeLog({ packageName, outcome, details, logger }) {
+  const line = formatOutcomeLog({ packageName, outcome, details });
+  // scan_rejected and scan_error are security/operational signals — warn
+  // level so they stand out in the user-facing log. install_failed and
+  // network are also worth attention. Other outcomes are info.
+  const level =
+    outcome === "skipped:scan_rejected" ||
+    outcome === "skipped:scan_error" ||
+    outcome === "skipped:install_failed"
+      ? "warn"
+      : "info";
+  if (logger?.[level]) {
+    logger[level](line);
+    return;
+  }
+  // Fallback: plain console. Tauri's plugin-log webview target forwards
+  // these to the same log file users share when filing bugs.
+  if (level === "warn") {
+    console.warn(line);
+  } else {
+    console.info(line);
+  }
+}
+
+/**
  * Fire-and-forget update check for a single CLI. TTL-gated; same-channel
  * only; silent on failure. Called once per app launch — two launches within
  * 24h make zero additional npm calls for this CLI.
+ *
+ * Returns a normalized outcome object: `{ outcome, packageName, ...details }`.
+ * Every invocation emits exactly one log line + (for success or scan_rejected)
+ * exactly one provider event. See #1646.
  */
 export async function backgroundUpdateCli({
   label,
@@ -314,6 +365,8 @@ export async function backgroundUpdateCli({
   now = Date.now(),
   state,
   onUpdated,
+  onScanRejected,
+  logger,
   // Test seams — production callers leave these undefined and the real
   // scanner runs against npm.
   _scannerOverrides,
@@ -322,19 +375,41 @@ export async function backgroundUpdateCli({
   const scanFn = _scannerOverrides?.scanTarball ?? scanTarball;
   const installFromTarballFn =
     _scannerOverrides?.runNpmInstallFromTarball ?? runNpmInstallFromTarball;
+
+  // Compatibility: production runs may not pass `state` (callers were
+  // written before the test seam). When state is omitted we manage
+  // persistence ourselves via load/save inside this function.
+  const ownsPersistence = state === undefined;
+
+  function report(outcome, details = {}) {
+    emitOutcomeLog({ packageName, outcome, details, logger });
+    return {
+      outcome,
+      packageName,
+      bareCommand,
+      label,
+      ...details,
+      // Backwards-compat field shapes — pre-#1646 callers and tests check
+      // `skipped`, `updated`, `from`, `to`, etc. Keep those alongside the
+      // new `outcome` until callers migrate.
+      ...(outcome === "success"
+        ? { updated: true }
+        : { skipped: outcome.replace(/^skipped:/, "") }),
+    };
+  }
   try {
     const persisted = state ?? loadState();
     const key = `lastUpdateCheck:${bareCommand}`;
     const lastCheck = persisted[key];
     if (typeof lastCheck === "number" && now - lastCheck < UPDATE_CHECK_TTL_MS) {
-      return { skipped: "ttl" };
+      return report("skipped:ttl");
     }
 
     const channel = classifyInstallChannel(resolvedPath, bareCommand);
     if (channel === "unresolved") {
       // Don't write state — we want to re-check next launch in case the
       // install completes between now and then.
-      return { skipped: "unresolved" };
+      return report("skipped:unresolved");
     }
 
     const [installed, latest] = await Promise.all([
@@ -345,6 +420,14 @@ export async function backgroundUpdateCli({
     // Record the check timestamp even when we couldn't compare — offline
     // and rate-limited cases should not retry every launch.
     persisted[key] = now;
+
+    // Network outcome: we have a working installed binary but registry
+    // lookup failed. Distinct from up_to_date so #1646 callers can tell
+    // "registry unreachable" apart from "no update needed."
+    if (!latest) {
+      if (ownsPersistence) saveState(persisted);
+      return report("skipped:network", { installed });
+    }
 
     if (installed && latest && isNewer(installed, latest)) {
       // Native installs are gated by the upstream's signed installer + their
@@ -364,10 +447,14 @@ export async function backgroundUpdateCli({
             to: latest,
             channel,
           });
-          return { updated: true, from: installed, to: latest, channel };
+          return report("success", { from: installed, to: latest, channel });
         } catch {
           saveState(persisted);
-          return { skipped: "install_failed" };
+          return report("skipped:install_failed", {
+            from: installed,
+            to: latest,
+            channel,
+          });
         }
       }
 
@@ -430,12 +517,22 @@ export async function backgroundUpdateCli({
           } catch {
             // Silent.
           }
-          return {
-            skipped: "scan_rejected",
+          // UI surfacing: notify the registry / TS layer so a banner or
+          // notification can fire. Default-on per #1646 — silent scan
+          // rejections are worse UX than no scanner at all.
+          onScanRejected?.({
+            label,
+            bareCommand,
+            packageName,
             from: installed,
             to: latest,
             flags: scan.flags,
-          };
+          });
+          return report("skipped:scan_rejected", {
+            from: installed,
+            to: latest,
+            flags: scan.flags,
+          });
         }
 
         // verdict is "pass" or "no_baseline" — install. First install of a
@@ -451,7 +548,11 @@ export async function backgroundUpdateCli({
           } catch {
             // Silent.
           }
-          return { skipped: "install_failed" };
+          return report("skipped:install_failed", {
+            from: installed,
+            to: latest,
+            channel,
+          });
         }
 
         persisted[`baseline:${packageName}`] = {
@@ -476,14 +577,13 @@ export async function backgroundUpdateCli({
         } catch {
           // Silent.
         }
-        return {
-          updated: true,
+        return report("success", {
           from: installed,
           to: latest,
           channel,
           tarballSha512: scan.candidate.tarballSha512,
           firstInstall: scan.verdict === "no_baseline",
-        };
+        });
       } catch {
         // Pack/scan failure — fail closed. Don't update.
         saveState(persisted);
@@ -492,15 +592,17 @@ export async function backgroundUpdateCli({
         } catch {
           // Silent.
         }
-        return { skipped: "scan_error" };
+        return report("skipped:scan_error", { from: installed, to: latest });
       }
     }
 
     saveState(persisted);
-    return { skipped: "up_to_date", installed, latest };
+    return report("skipped:up_to_date", { installed, latest });
   } catch {
     // Outermost catch-all — never allow the updater to throw into the
     // registry init path.
-    return { skipped: "error" };
+    return report("skipped:error");
   }
 }
+
+export { formatOutcomeLog as _formatOutcomeLog };

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -368,13 +368,17 @@ export async function backgroundUpdateCli({
   onScanRejected,
   logger,
   // Test seams — production callers leave these undefined and the real
-  // scanner runs against npm.
+  // scanner + version commands run against npm/disk.
   _scannerOverrides,
+  _versionOverrides,
 }) {
   const packFn = _scannerOverrides?.npmPackToDirectory ?? npmPackToDirectory;
   const scanFn = _scannerOverrides?.scanTarball ?? scanTarball;
   const installFromTarballFn =
     _scannerOverrides?.runNpmInstallFromTarball ?? runNpmInstallFromTarball;
+  const installedVersionFn =
+    _versionOverrides?.runInstalledVersion ?? runInstalledVersion;
+  const npmViewFn = _versionOverrides?.runNpmView ?? runNpmView;
 
   // Compatibility: production runs may not pass `state` (callers were
   // written before the test seam). When state is omitted we manage
@@ -413,8 +417,8 @@ export async function backgroundUpdateCli({
     }
 
     const [installed, latest] = await Promise.all([
-      runInstalledVersion(resolvedPath, bareCommand),
-      runNpmView(packageName, { npmCliScript }),
+      installedVersionFn(resolvedPath, bareCommand),
+      npmViewFn(packageName, { npmCliScript }),
     ]);
 
     // Record the check timestamp even when we couldn't compare — offline

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -7,12 +7,15 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+
+import { npmPackToDirectory, scanTarball } from "./cli-scanner.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -205,6 +208,53 @@ async function runNpmInstallLatest(packageName, { npmCliScript } = {}) {
 }
 
 /**
+ * Install from an already-downloaded local tarball. Used after the scanner
+ * passes — we install the exact bytes we scanned, not whatever the registry
+ * serves at install time. Eliminates the post-scan/pre-install TOCTOU window.
+ */
+async function runNpmInstallFromTarball(tarballPath, { npmCliScript } = {}) {
+  if (npmCliScript) {
+    await execFileAsync(
+      process.execPath,
+      [npmCliScript, "install", "-g", tarballPath],
+      { timeout: NPM_INSTALL_TIMEOUT_MS },
+    );
+    return;
+  }
+  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+  await execFileAsync(
+    npmCommand,
+    ["install", "-g", tarballPath],
+    { timeout: NPM_INSTALL_TIMEOUT_MS },
+  );
+}
+
+/**
+ * Per-CLI hostname allowlists for the static-check scanner. Strings the
+ * upstream's published code is expected to contain; anything outside this
+ * set in a flagged file gets a `unallowed_host` flag (#1647).
+ *
+ * Use parent domains — suffix matching in the scanner accepts subdomains.
+ */
+const HOSTNAME_ALLOWLIST = {
+  "@anthropic-ai/claude-code": [
+    "anthropic.com",
+    "claude.ai",
+    "claude.com",
+    "github.com",
+    "githubusercontent.com",
+    "googleapis.com",
+    "amazonaws.com",
+  ],
+  "@openai/codex": [
+    "openai.com",
+    "oaistatic.com",
+    "github.com",
+    "githubusercontent.com",
+  ],
+};
+
+/**
  * Run the Claude Code native installer script. Matches the original install
  * path in agent-registry.mjs so we stay on the same channel rather than
  * silently writing a parallel npm install.
@@ -264,7 +314,14 @@ export async function backgroundUpdateCli({
   now = Date.now(),
   state,
   onUpdated,
+  // Test seams — production callers leave these undefined and the real
+  // scanner runs against npm.
+  _scannerOverrides,
 }) {
+  const packFn = _scannerOverrides?.npmPackToDirectory ?? npmPackToDirectory;
+  const scanFn = _scannerOverrides?.scanTarball ?? scanTarball;
+  const installFromTarballFn =
+    _scannerOverrides?.runNpmInstallFromTarball ?? runNpmInstallFromTarball;
   try {
     const persisted = state ?? loadState();
     const key = `lastUpdateCheck:${bareCommand}`;
@@ -290,23 +347,152 @@ export async function backgroundUpdateCli({
     persisted[key] = now;
 
     if (installed && latest && isNewer(installed, latest)) {
-      try {
-        if (channel === "native") {
+      // Native installs are gated by the upstream's signed installer + their
+      // own self-update mechanism; we don't have a tarball to scan. Keep
+      // existing flow. npm channel updates are scanned per #1647.
+      if (channel === "native") {
+        try {
           const selfOk = await tryCliSelfUpdate(resolvedPath);
           if (!selfOk) {
             await runClaudeNativeInstaller();
           }
-        } else {
-          await runNpmInstallLatest(packageName, { npmCliScript });
+          saveState(persisted);
+          onUpdated?.({
+            label,
+            bareCommand,
+            from: installed,
+            to: latest,
+            channel,
+          });
+          return { updated: true, from: installed, to: latest, channel };
+        } catch {
+          saveState(persisted);
+          return { skipped: "install_failed" };
         }
-        saveState(persisted);
-        onUpdated?.({ label, bareCommand, from: installed, to: latest, channel });
-        return { updated: true, from: installed, to: latest, channel };
+      }
+
+      // npm channel: pack-extract-scan-install-baseline.
+      const stagingDir = path.join(
+        serenDataDir(),
+        "scan-staging",
+        bareCommand,
+        latest,
+      );
+      // Best-effort cleanup of any leftover staging from a prior crashed run.
+      try {
+        rmSync(stagingDir, { recursive: true, force: true });
       } catch {
-        // Install failed — persist the check timestamp so we back off for
-        // 24h rather than spamming the registry every launch.
+        // Silent.
+      }
+      try {
+        const tarballPath = await packFn({
+          packageName,
+          version: latest,
+          destinationDir: stagingDir,
+          npmCliScript,
+        });
+        const baseline = persisted[`baseline:${packageName}`];
+        const scan = await scanFn({
+          tarballPath,
+          baseline,
+          workDir: path.join(stagingDir, "extracted"),
+          hostnameAllowlist: HOSTNAME_ALLOWLIST[packageName] ?? [],
+        });
+
+        if (scan.verdict === "reject") {
+          // Quarantine: leave the rejected tarball + flag list on disk under
+          // ~/.seren/scan-rejected/<cli>/<version>/ for later inspection.
+          const quarantine = path.join(
+            serenDataDir(),
+            "scan-rejected",
+            bareCommand,
+            latest,
+          );
+          try {
+            mkdirSync(quarantine, { recursive: true });
+            writeFileSync(
+              path.join(quarantine, "flags.json"),
+              JSON.stringify({ flags: scan.flags, version: latest }, null, 2),
+              "utf8",
+            );
+          } catch {
+            // Best-effort — never fail the update path on quarantine I/O.
+          }
+          persisted[`lastScanReject:${packageName}`] = {
+            version: latest,
+            flags: scan.flags,
+            at: now,
+          };
+          saveState(persisted);
+          // Cleanup staging now that we've recorded the rejection.
+          try {
+            rmSync(stagingDir, { recursive: true, force: true });
+          } catch {
+            // Silent.
+          }
+          return {
+            skipped: "scan_rejected",
+            from: installed,
+            to: latest,
+            flags: scan.flags,
+          };
+        }
+
+        // verdict is "pass" or "no_baseline" — install. First install of a
+        // CLI is unguarded by design (no baseline to diff against); the
+        // candidate snapshot becomes the seed baseline so subsequent
+        // updates ARE scanned.
+        try {
+          await installFromTarballFn(tarballPath, { npmCliScript });
+        } catch {
+          saveState(persisted);
+          try {
+            rmSync(stagingDir, { recursive: true, force: true });
+          } catch {
+            // Silent.
+          }
+          return { skipped: "install_failed" };
+        }
+
+        persisted[`baseline:${packageName}`] = {
+          version: latest,
+          tarballSha512: scan.candidate.tarballSha512,
+          installScripts: scan.candidate.installScripts,
+          declaredDependencies: scan.candidate.declaredDependencies,
+          files: scan.candidate.files,
+          fileHashes: scan.candidate.fileHashes,
+        };
         saveState(persisted);
-        return { skipped: "install_failed" };
+        onUpdated?.({
+          label,
+          bareCommand,
+          from: installed,
+          to: latest,
+          channel,
+          tarballSha512: scan.candidate.tarballSha512,
+        });
+        try {
+          rmSync(stagingDir, { recursive: true, force: true });
+        } catch {
+          // Silent.
+        }
+        return {
+          updated: true,
+          from: installed,
+          to: latest,
+          channel,
+          tarballSha512: scan.candidate.tarballSha512,
+          firstInstall: scan.verdict === "no_baseline",
+        };
+      } catch {
+        // Pack/scan failure — fail closed. Don't update.
+        saveState(persisted);
+        try {
+          rmSync(stagingDir, { recursive: true, force: true });
+        } catch {
+          // Silent.
+        }
+        return { skipped: "scan_error" };
       }
     }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -142,7 +142,6 @@ async function waitForSessionIdle(
 }
 
 import { isLikelyAuthError } from "@/lib/auth-errors";
-import { authStore, promptLogin } from "@/stores/auth.store";
 import { buildChatRequest, sendProviderMessage } from "@/lib/providers";
 import {
   isPromptTooLongError,
@@ -186,6 +185,7 @@ import type {
   ToolCallEvent,
 } from "@/services/providers";
 import * as providerService from "@/services/providers";
+import { authStore, promptLogin } from "@/stores/auth.store";
 
 /** Set once we've subscribed to `provider-runtime://ready` so repeated
  *  initialize() calls don't stack listeners. */
@@ -194,6 +194,10 @@ let providerRuntimeReadyListener: Promise<UnlistenFn> | null = null;
 /** Set once we've subscribed to `provider-runtime://restarted` so repeated
  *  initialize() calls don't stack listeners. #1631. */
 let providerRuntimeRestartedListener: Promise<UnlistenFn> | null = null;
+
+/** Set once we've subscribed to `provider://cli-scan-rejected` so repeated
+ *  initialize() calls don't stack listeners. #1646. */
+let cliScanRejectedUnsub: (() => void) | null = null;
 
 /** Commit an agent list into the store + settle the selected-agent fallback.
  *  Shared by `initialize()` and the `provider-runtime://ready` listener so
@@ -304,6 +308,67 @@ function subscribeToProviderRuntimeRestarted(): void {
             );
           }
         })();
+      }
+    },
+  );
+}
+
+/**
+ * Subscribe once to provider://cli-scan-rejected so the CLI auto-updater's
+ * security gate (#1647) is never silent. The user stays on their previous
+ * known-good version; we record the rejection in store state for any
+ * diagnostics panel and fire a system notification per #1646.
+ *
+ * The subscription is idempotent — subscribeToCliScanRejections is safe to
+ * call from initialize() across repeated runtime restarts.
+ */
+function subscribeToCliScanRejections(): void {
+  if (cliScanRejectedUnsub) return;
+  cliScanRejectedUnsub = onRuntimeEvent(
+    "provider://cli-scan-rejected",
+    (payload) => {
+      const event = payload as {
+        label?: string;
+        packageName?: string;
+        from?: string | null;
+        to?: string;
+        flags?: string[];
+      };
+      if (!event.packageName || !event.to) return;
+      const rejection = {
+        label: event.label ?? event.packageName,
+        packageName: event.packageName,
+        from: event.from ?? null,
+        to: event.to,
+        flags: Array.isArray(event.flags) ? event.flags : [],
+        at: Date.now(),
+      };
+      setState("cliScanRejection", rejection);
+      // Default-on local log line so the rejection lands in the user-
+      // facing app log file even if the UI surface gets dismissed.
+      console.warn(
+        `[cli-updater] scan rejected for ${rejection.packageName} v${rejection.to}; flags=${rejection.flags.join(",")}`,
+      );
+      // System notification — minimum surface required by #1646. Falls
+      // back silently when the platform denies permission.
+      try {
+        if (typeof Notification !== "undefined") {
+          if (Notification.permission === "granted") {
+            new Notification("Seren blocked a CLI update", {
+              body: `${rejection.label} ${rejection.to} was rejected by the local supply-chain scanner. You stay on your previous version.`,
+            });
+          } else if (Notification.permission !== "denied") {
+            void Notification.requestPermission().then((perm) => {
+              if (perm === "granted") {
+                new Notification("Seren blocked a CLI update", {
+                  body: `${rejection.label} ${rejection.to} was rejected by the local supply-chain scanner. You stay on your previous version.`,
+                });
+              }
+            });
+          }
+        }
+      } catch {
+        // Silent — best-effort surface, never fail the subscriber.
       }
     },
   );
@@ -700,6 +765,20 @@ interface AgentState {
   error: string | null;
   /** CLI install progress message */
   installStatus: string | null;
+  /**
+   * Most recent CLI auto-updater scan rejection (#1646). Null when no
+   * rejection has been recorded this session. Set by
+   * subscribeToCliScanRejections from a provider runtime event; the user
+   * stays on their previous known-good version until cleared.
+   */
+  cliScanRejection: {
+    label: string;
+    packageName: string;
+    from: string | null;
+    to: string;
+    flags: string[];
+    at: number;
+  } | null;
   /** Pending permission requests awaiting user response */
   pendingPermissions: PermissionRequestEvent[];
   /** Pending diff proposals awaiting user accept/reject */
@@ -722,6 +801,7 @@ const [state, setState] = createStore<AgentState>({
   isLoading: false,
   error: null,
   installStatus: null,
+  cliScanRejection: null,
   pendingPermissions: [],
   pendingDiffProposals: [],
   agentModeEnabled: false,
@@ -1298,6 +1378,11 @@ export const agentStore = {
     // to applyAgents just overwrite availableAgents with the same data.
     subscribeToProviderRuntimeReady();
     subscribeToProviderRuntimeRestarted();
+    // Surface CLI-updater scan rejections per #1646. Default-on, runs once
+    // at app init, idempotent (the runtime emits the event at most once
+    // per launch per CLI). System notification + state record so the user
+    // can review what was rejected and why.
+    subscribeToCliScanRejections();
 
     const backoffMs = [0, 1_000, 2_000, 4_000, 8_000];
     for (let attempt = 0; attempt < backoffMs.length; attempt++) {

--- a/tests/unit/cli-scanner.test.ts
+++ b/tests/unit/cli-scanner.test.ts
@@ -1,0 +1,171 @@
+// ABOUTME: Critical tests for #1647 — local diff + static-check scanner.
+// ABOUTME: Locks the gate behavior; no live npm pack / no network in tests.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/cli-scanner.mjs",
+  import.meta.url,
+).href;
+const {
+  buildPackageSnapshot,
+  diffSnapshots,
+  runStaticChecks,
+} = await import(/* @vite-ignore */ modulePath);
+
+let tempRoot: string;
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(path.join(tmpdir(), "seren-cli-scanner-test-"));
+});
+
+afterEach(() => {
+  rmSync(tempRoot, { recursive: true, force: true });
+});
+
+function writePackage(files: Record<string, string>) {
+  const pkgDir = path.join(tempRoot, "package");
+  mkdirSync(pkgDir, { recursive: true });
+  for (const [rel, contents] of Object.entries(files)) {
+    const abs = path.join(pkgDir, rel);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, contents, "utf8");
+  }
+  return pkgDir;
+}
+
+describe("buildPackageSnapshot", () => {
+  it("captures install scripts, declared deps, files, and hashes", () => {
+    const pkgDir = writePackage({
+      "package.json": JSON.stringify({
+        name: "@test/x",
+        version: "1.0.0",
+        scripts: { postinstall: "node setup.js", build: "tsc" },
+        dependencies: { foo: "1.0.0", bar: "^2.0.0" },
+      }),
+      "dist/index.js": "module.exports = {};",
+    });
+    const snap = buildPackageSnapshot(pkgDir);
+    expect(snap.version).toBe("1.0.0");
+    expect(snap.installScripts).toEqual({ postinstall: "node setup.js" });
+    expect(snap.declaredDependencies).toEqual(["bar", "foo"]);
+    expect(snap.files).toContain("package.json");
+    expect(snap.files).toContain("dist/index.js");
+    expect(typeof snap.fileHashes["package.json"]).toBe("string");
+  });
+});
+
+describe("diffSnapshots — the axios pattern", () => {
+  const baseline = {
+    installScripts: {},
+    declaredDependencies: ["foo"],
+    files: ["package.json", "dist/index.js"],
+    fileHashes: { "package.json": "h1", "dist/index.js": "h2" },
+  };
+
+  it("flags a newly-introduced postinstall script — exactly the axios attack pattern", () => {
+    const candidate = {
+      installScripts: { postinstall: "node payload.js" },
+      declaredDependencies: ["foo"],
+      files: ["package.json", "dist/index.js"],
+      fileHashes: { "package.json": "h1-changed", "dist/index.js": "h2" },
+    };
+    expect(diffSnapshots(baseline, candidate)).toContain(
+      "new_install_script:postinstall",
+    );
+  });
+
+  it("flags a newly-added runtime dependency — Shai-Hulud / axios style dep injection", () => {
+    const candidate = {
+      installScripts: {},
+      declaredDependencies: ["foo", "plain-crypto-js"],
+      files: baseline.files,
+      fileHashes: baseline.fileHashes,
+    };
+    expect(diffSnapshots(baseline, candidate)).toContain(
+      "new_dependency:plain-crypto-js",
+    );
+  });
+
+  it("flags a new top-level file or new file in an entry-point directory", () => {
+    const candidate = {
+      installScripts: {},
+      declaredDependencies: ["foo"],
+      files: [...baseline.files, "stealth.js", "dist/payload.js"],
+      fileHashes: { ...baseline.fileHashes, "stealth.js": "h3", "dist/payload.js": "h4" },
+    };
+    const flags = diffSnapshots(baseline, candidate);
+    expect(flags).toContain("new_file:stealth.js");
+    expect(flags).toContain("new_file:dist/payload.js");
+  });
+
+  it("does not flag dep removals or non-entry-point new files — those are not the attack pattern", () => {
+    const candidate = {
+      installScripts: {},
+      declaredDependencies: [],
+      files: [...baseline.files, "test/extra.spec.js"],
+      fileHashes: { ...baseline.fileHashes, "test/extra.spec.js": "h5" },
+    };
+    const flags = diffSnapshots(baseline, candidate);
+    expect(flags).not.toContain("new_dependency:foo");
+    expect(flags).not.toContain("new_file:test/extra.spec.js");
+  });
+
+  it("returns an empty array for a clean version bump (same scripts, deps, files)", () => {
+    expect(diffSnapshots(baseline, baseline)).toEqual([]);
+  });
+});
+
+describe("runStaticChecks — the chalk/debug pattern", () => {
+  it("flags eval(), new Function(), and dynamic require — code-injection markers", () => {
+    const pkgDir = writePackage({
+      "package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+      "lib/a.js": "module.exports = function() { eval('1+1'); };",
+      "lib/b.js": "const f = new Function('return 1');",
+      "lib/c.js": "const r = require(name);",
+    });
+    const flags = runStaticChecks(pkgDir);
+    expect(flags.some((f: string) => f.startsWith("eval_call:lib/a.js"))).toBe(true);
+    expect(flags.some((f: string) => f.startsWith("new_function:lib/b.js"))).toBe(
+      true,
+    );
+    expect(
+      flags.some((f: string) => f.startsWith("dynamic_require:lib/c.js")),
+    ).toBe(true);
+  });
+
+  it("flags newly-introduced child_process imports — Shai-Hulud bundles often add this", () => {
+    const pkgDir = writePackage({
+      "package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+      "lib/x.js": 'const cp = require("child_process");',
+    });
+    // Baseline did not have this file at all.
+    const flags = runStaticChecks(pkgDir, { baseline: { fileHashes: {} } });
+    expect(
+      flags.some((f: string) => f.startsWith("child_process_in_new_file:lib/x.js")),
+    ).toBe(true);
+  });
+
+  it("flags large base64 literals — payload smuggling marker", () => {
+    const big = "A".repeat(3000);
+    const pkgDir = writePackage({
+      "package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+      "lib/p.js": `module.exports = "${big}";`,
+    });
+    const flags = runStaticChecks(pkgDir);
+    expect(
+      flags.some((f: string) => f.startsWith("large_base64_literal:lib/p.js")),
+    ).toBe(true);
+  });
+
+  it("clean readable JS produces no flags — keeps false-positive rate low", () => {
+    const pkgDir = writePackage({
+      "package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+      "lib/clean.js": "module.exports = function add(a, b) { return a + b; };",
+    });
+    expect(runStaticChecks(pkgDir)).toEqual([]);
+  });
+});

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -215,3 +215,212 @@ describe("atomic state writes (#1644)", () => {
     expect(loadState()).toEqual({});
   });
 });
+
+describe("failure paths (#1645)", () => {
+  let tempDir: string;
+  let stateFile: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "seren-failpath-test-"));
+    stateFile = path.join(tempDir, "cli-update-state.json");
+    originalEnv = process.env.SEREN_CLI_UPDATER_STATE_PATH;
+    process.env.SEREN_CLI_UPDATER_STATE_PATH = stateFile;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SEREN_CLI_UPDATER_STATE_PATH;
+    } else {
+      process.env.SEREN_CLI_UPDATER_STATE_PATH = originalEnv;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // Fresh state per test — spreading baseInvocation otherwise leaks the
+  // mutated state object between tests (TTL gets seeded by run #1 and
+  // every subsequent run short-circuits on TTL).
+  function freshInvocation() {
+    return {
+      label: "Codex",
+      bareCommand: "codex",
+      resolvedPath: "/usr/local/bin/codex",
+      packageName: "@openai/codex",
+      state: {} as Record<string, unknown>,
+      now: Date.now(),
+    };
+  }
+
+  it("registry unreachable returns skipped:network distinct from up_to_date — operator can tell the registry is down", async () => {
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.0",
+        runNpmView: async () => null, // network/timeout/registry error
+      },
+    });
+    expect(result).toMatchObject({
+      outcome: "skipped:network",
+      installed: "1.5.0",
+    });
+  });
+
+  it("malformed npm view response (non-semver string) does not crash — graceful skip", async () => {
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.0",
+        runNpmView: async () => "not-a-version",
+      },
+    });
+    // isNewer returns false on non-semver strings, so we land in up_to_date.
+    // Crucially: no throw, no scan attempt, nothing installed.
+    expect(result.outcome).toBe("skipped:up_to_date");
+  });
+
+  it("missing CLI binary on disk does not trigger an install — no installed version means we cannot compare safely", async () => {
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      resolvedPath: "/this/path/definitely/does/not/exist",
+      _versionOverrides: {
+        // Production runInstalledVersion returns null when the path is absent;
+        // the override mirrors that behavior explicitly.
+        runInstalledVersion: async () => null,
+        runNpmView: async () => "1.5.3",
+      },
+    });
+    // No install path was taken because we never resolved an installed
+    // version to diff against. up_to_date is the safe outcome here.
+    expect(result.outcome).toBe("skipped:up_to_date");
+  });
+
+  it("install_failed when the install subprocess throws — bookkeeping persisted, not silent", async () => {
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.0",
+        runNpmView: async () => "1.5.3",
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/fake.tgz",
+        scanTarball: async () => ({
+          verdict: "pass",
+          flags: [],
+          candidate: {
+            version: "1.5.3",
+            tarballSha512: "abc",
+            installScripts: {},
+            declaredDependencies: [],
+            files: [],
+            fileHashes: {},
+          },
+        }),
+        runNpmInstallFromTarball: async () => {
+          throw new Error("network error");
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      outcome: "skipped:install_failed",
+      from: "1.5.0",
+      to: "1.5.3",
+    });
+  });
+
+  it("scan_rejected with the actual flag list propagates — the user-facing log will say WHY", async () => {
+    const flags = ["new_install_script:postinstall", "new_dependency:plain-crypto-js"];
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.3",
+        runNpmView: async () => "1.5.4",
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/fake.tgz",
+        scanTarball: async () => ({ verdict: "reject", flags, candidate: null }),
+        runNpmInstallFromTarball: async () => {
+          throw new Error("must NOT install when scan rejects");
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      outcome: "skipped:scan_rejected",
+      from: "1.5.3",
+      to: "1.5.4",
+      flags,
+    });
+  });
+
+  it("scan_error fails closed when the scanner itself throws — never installs on scanner crash", async () => {
+    let installCalled = false;
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.0",
+        runNpmView: async () => "1.5.3",
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/fake.tgz",
+        scanTarball: async () => {
+          throw new Error("scanner exploded");
+        },
+        runNpmInstallFromTarball: async () => {
+          installCalled = true;
+        },
+      },
+    });
+    expect(installCalled).toBe(false);
+    expect(result.outcome).toBe("skipped:scan_error");
+  });
+
+  it("first install (no_baseline) proceeds with the install but seeds the baseline — subsequent updates ARE scanned", async () => {
+    const candidate = {
+      version: "1.5.3",
+      tarballSha512: "abc",
+      installScripts: {},
+      declaredDependencies: ["foo"],
+      files: ["package.json"],
+      fileHashes: { "package.json": "h" },
+    };
+    let installCalled = false;
+    const result = await backgroundUpdateCli({
+      ...freshInvocation(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "1.5.0",
+        runNpmView: async () => "1.5.3",
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/fake.tgz",
+        scanTarball: async () => ({
+          verdict: "no_baseline",
+          flags: [],
+          candidate,
+        }),
+        runNpmInstallFromTarball: async () => {
+          installCalled = true;
+        },
+      },
+    });
+    expect(installCalled).toBe(true);
+    expect(result).toMatchObject({
+      outcome: "success",
+      firstInstall: true,
+      tarballSha512: "abc",
+    });
+  });
+
+  it("loadState returns {} on a missing file — first launch never throws", () => {
+    // No state file exists yet (beforeEach made an empty tempDir).
+    expect(loadState()).toEqual({});
+  });
+
+  it("saveState swallows write errors when the parent directory is read-only — we will retry next launch, not crash now", () => {
+    // Simulate a write failure by pointing the env var at a path whose
+    // parent is a regular file. mkdir -p will fail; saveState catches.
+    const blockedFile = path.join(tempDir, "blocker");
+    writeFileSync(blockedFile, "x", "utf8");
+    process.env.SEREN_CLI_UPDATER_STATE_PATH = path.join(blockedFile, "child.json");
+    // Should not throw.
+    expect(() => saveState({ a: 1 })).not.toThrow();
+  });
+});

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -23,6 +23,7 @@ const {
   backgroundUpdateCli,
   loadState,
   saveState,
+  _formatOutcomeLog,
 } = await import(/* @vite-ignore */ modulePath);
 
 describe("isNewer", () => {
@@ -89,7 +90,7 @@ describe("backgroundUpdateCli TTL gate", () => {
       state,
       now: Date.now(),
     });
-    expect(result).toEqual({ skipped: "ttl" });
+    expect(result).toMatchObject({ outcome: "skipped:ttl", skipped: "ttl" });
   });
 
   it("proceeds past TTL when last check is older than 24h", async () => {
@@ -120,7 +121,50 @@ describe("backgroundUpdateCli TTL gate", () => {
       state: {},
       now: Date.now(),
     });
-    expect(result).toEqual({ skipped: "unresolved" });
+    expect(result).toMatchObject({
+      outcome: "skipped:unresolved",
+      skipped: "unresolved",
+    });
+  });
+});
+
+describe("outcome logging (#1646)", () => {
+  it("formats one structured line per outcome with cli + outcome + transition + flags", () => {
+    expect(
+      _formatOutcomeLog({
+        packageName: "@anthropic-ai/claude-code",
+        outcome: "success",
+        details: { from: "1.5.2", to: "1.5.3", tarballSha512: "abc" },
+      }),
+    ).toBe(
+      "[cli-updater] cli=@anthropic-ai/claude-code outcome=success from=1.5.2 to=1.5.3 tarballSha512=abc",
+    );
+  });
+
+  it("includes the flag list on scan_rejected so the user-facing log says WHY", () => {
+    const line = _formatOutcomeLog({
+      packageName: "@anthropic-ai/claude-code",
+      outcome: "skipped:scan_rejected",
+      details: {
+        version: "1.5.4",
+        flags: ["new_install_script:postinstall", "new_dependency:plain-crypto-js"],
+      },
+    });
+    expect(line).toContain("outcome=skipped:scan_rejected");
+    expect(line).toContain("version=1.5.4");
+    expect(line).toContain(
+      "flags=new_install_script:postinstall,new_dependency:plain-crypto-js",
+    );
+  });
+
+  it("emits a single line for the cheapest outcomes — no version, no flags, just the enum", () => {
+    expect(
+      _formatOutcomeLog({
+        packageName: "@openai/codex",
+        outcome: "skipped:ttl",
+        details: {},
+      }),
+    ).toBe("[cli-updater] cli=@openai/codex outcome=skipped:ttl");
   });
 });
 


### PR DESCRIPTION
## Summary

Relands the stacked CLI-updater feature work that was previously merged into intermediate branches (`fix/1647-scanner`, `fix/1646-outcome-logging`) instead of main. Branches have been deleted upstream; these commits are cherry-picked from the original PR head refs.

## Commits (in order)

1. **feat(cli-updater): local-only diff + static-check scan before install (#1647)** — closes #1647 for real. Adds `bin/browser-local/cli-scanner.mjs` plus tests. Gates npm installs on a local diff against the last-known-good baseline + static checks (new postinstall, new deps, eval, entropy, etc.). No external scanner service, offline-capable.
2. **feat(cli-updater): log all outcomes by default; surface scan rejections in UI (#1646)** — closes #1646 for real. Default-on structured logging of every updater outcome. Scan rejections surface in the UI as security events.
3. **test(cli-updater): coverage for failure paths (#1645)** — closes #1645 for real. Covers network timeout, malformed npm response, install failure, scan rejection, state corruption.

## Why this PR exists

The original PRs (#1649, #1650, #1651) were all merged, but into each other stacked feature branches, not into main. Main never received the feature code. Issues #1645, #1646, #1647 were closed as completed based on that merge chain. This PR reopens the merge against main so the code actually ships.

## Duplicate atomic-writes commit

The original stack also contained `b819f37a fix(cli-updater): atomic writes for cli-update-state.json (#1644)`, which has now landed on main via #1648 as `373b1bc5` with byte-identical content (md5 verified). That commit was skipped in this cherry-pick chain to avoid a no-op.

## Target release

v3.19.0 (MINOR — two feat commits).

## Test plan
- [ ] CI green (pnpm test 487+ pass, cargo check clean)
- [ ] Scanner rejects a synthetic axios-style fixture (new dep in patch bump) during install
- [ ] Rejection surfaces in app UI as a security event
- [ ] Outcome log entries appear in the standard app log
