### PR TITLE
fix(cli-updater): merge on-disk state on save to prevent sibling key loss (#1655)

### DIFF
--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -67,11 +67,20 @@ export function saveState(state) {
   // tolerates the parse error by returning {}, but TTL timestamps are lost
   // and the updater re-checks every launch until network recovers — turning
   // a transient registry blip into a launch-amplified hammer. See #1644.
+  //
+  // Merge with the latest on-disk snapshot before writing. Two concurrent
+  // backgroundUpdateCli arms (Codex + Claude) each load → mutate → save
+  // independently; without merging, the second saver clobbers the first
+  // saver's per-CLI key. All callers in this file are additive (no key
+  // deletion), so a merge-on-write is semantically safe and narrows the
+  // race window from the full update lifecycle (seconds, including npm
+  // round-trip) to a load+rename pair (sub-millisecond). See #1655.
   const target = statePath();
   const tmp = `${target}.tmp`;
   try {
     mkdirSync(serenDataDir(), { recursive: true });
-    writeFileSync(tmp, JSON.stringify(state), "utf8");
+    const merged = { ...loadState(), ...state };
+    writeFileSync(tmp, JSON.stringify(merged), "utf8");
     renameSync(tmp, target);
   } catch {
     // Best-effort tmp cleanup so a previous failed write doesn't leak.

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -214,6 +214,25 @@ describe("atomic state writes (#1644)", () => {
     writeFileSync(stateFile, "{ corrupt", "utf8");
     expect(loadState()).toEqual({});
   });
+
+  // Regression for #1655. Two backgroundUpdateCli calls (Codex + Claude) run
+  // concurrently from agent-registry; each does loadState → mutate → saveState.
+  // Before the merge-on-write fix the second save clobbered the first save's
+  // per-CLI key (last-write-wins), which is what stranded one user's
+  // lastUpdateCheck:codex on disk and made the TTL gate misfire.
+  it("merges with on-disk keys on save so a partial write does not drop sibling keys (#1655)", () => {
+    saveState({
+      "lastUpdateCheck:codex": 100,
+      "lastUpdateCheck:claude": 200,
+    });
+    // Simulate the Claude arm saving a snapshot it loaded BEFORE the Codex
+    // arm's :codex write landed — i.e. the in-memory object only has :claude.
+    saveState({ "lastUpdateCheck:claude": 999 });
+    expect(loadState()).toEqual({
+      "lastUpdateCheck:codex": 100,
+      "lastUpdateCheck:claude": 999,
+    });
+  });
 });
 
 describe("failure paths (#1645)", () => {


### PR DESCRIPTION
## Summary

- `saveState()` now re-reads the on-disk snapshot and merges the caller's keys on top before the temp+rename. Closes #1655.
- The atomic temp+rename guard from #1644 still protects against torn reads. The race window narrows from the full update lifecycle (seconds, including npm round-trip + scanner) to a sub-millisecond load+rename pair.
- All `saveState(persisted)` call sites in [`cli-updater.mjs`](bin/browser-local/cli-updater.mjs) are additive (no key deletion — verified by inspection of every call site at lines 432, 446, 456, 517, 549, 570, 593, 603), so merge-on-write is semantically safe.

Concrete user impact: one report in the wild had `{"lastUpdateCheck:claude": ...}` in state but `outcome=skipped:ttl` for `@openai/codex` in the log — only possible if the Codex arm wrote `:codex`, then the Claude arm's `saveState` overwrote with a snapshot that didn't include the in-flight `:codex` write. That user is stuck on `@openai/codex@0.121.0` while npm latest is `0.125.0`. After this lands, both arms' writes coexist on disk and the TTL gate stops misfiring.

## Test plan

- [x] New regression test in [`tests/unit/cli-updater.test.ts`](tests/unit/cli-updater.test.ts): writes `{:codex, :claude}`, then writes a `:claude`-only object (mimicking the racing arm's stale snapshot), and asserts both keys survive. Failed red before the fix; passes after.
- [x] Full unit suite: `pnpm test` → 60 files, 515 tests, all green.
- [ ] Manual: delete `~/.seren/cli-update-state.json`, relaunch Seren Desktop, confirm both `lastUpdateCheck:codex` and `lastUpdateCheck:claude` are present after the parallel arms complete.
