### PR TITLE
fix(agent): drop --resume immediately when first spawn fails

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2380,45 +2380,26 @@ export const agentStore = {
 
     // Legacy Claude conversations can reference session IDs that no longer
     // exist on disk. In that case, fall back to a fresh session for the same
-    // persisted conversation instead of failing hard.
+    // persisted conversation instead of failing hard. (#1656: previously this
+    // path retried with the SAME bad resumeAgentSessionId before giving up,
+    // producing a wasted 2nd `--resume` attempt + a duplicate "Claude Code
+    // request failed" error event. Drop --resume immediately.)
     if (!sessionId && agentType === "claude-code") {
       console.warn(
-        "[AgentStore] Claude resume failed, starting a fresh session for conversation",
+        "[AgentStore] Claude resume failed, spawning fresh session for conversation",
         conversationId,
         state.error,
       );
-      // Try resuming the remote session (preserves history). If the session
-      // file is corrupted, this will also fail — fall through to fresh.
-      let fallbackSessionId = await this.spawnSession(resumeCwd, agentType, {
+      const persisted = await loadPersistedAgentHistory(conversationId);
+      const fallbackSessionId = await this.spawnSession(resumeCwd, agentType, {
         localSessionId: conversationId,
-        resumeAgentSessionId: remoteSessionId,
         conversationTitle: convo.title,
-        restoredMessages,
-        bootstrapPromptContext: pendingBootstrapPromptContext,
+        restoredMessages:
+          persisted.messages.length > 0 ? persisted.messages : undefined,
+        bootstrapPromptContext: persisted.context || undefined,
         initialModelId: convo.agent_model_id ?? undefined,
         initialPermissionMode: convo.agent_permission_mode ?? undefined,
       });
-
-      // If resume-based fallback also failed, the session file is likely
-      // corrupted (Claude CLI exits code=1 with no stderr). Start a
-      // completely fresh session without --resume. Load persisted messages
-      // from SQLite so the user sees their history and the agent gets context.
-      if (!fallbackSessionId) {
-        console.warn(
-          "[AgentStore] Resume fallback also failed — spawning without --resume for",
-          conversationId,
-        );
-        const persisted = await loadPersistedAgentHistory(conversationId);
-        fallbackSessionId = await this.spawnSession(resumeCwd, agentType, {
-          localSessionId: conversationId,
-          conversationTitle: convo.title,
-          restoredMessages:
-            persisted.messages.length > 0 ? persisted.messages : undefined,
-          bootstrapPromptContext: persisted.context || undefined,
-          initialModelId: convo.agent_model_id ?? undefined,
-          initialPermissionMode: convo.agent_permission_mode ?? undefined,
-        });
-      }
 
       if (fallbackSessionId) {
         // Clear error state and remove stale error messages left by the

--- a/tests/unit/resume-fallback-no-double-resume.test.ts
+++ b/tests/unit/resume-fallback-no-double-resume.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Regression test for #1656 — resumeAgentConversation must not retry
+// ABOUTME: with the same bad --resume session ID after the first spawn fails.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+/**
+ * Slice the body of `resumeAgentConversation` so we can grep within it without
+ * matching unrelated occurrences elsewhere in the (5000+ line) file. End-of-
+ * function is the next `\n  async ` (indent-2 method declaration); brittle
+ * only against an indentation refactor of the whole file, which would catch
+ * many tests at once.
+ */
+function extractResumeAgentConversationBody(): string {
+  const start = agentStoreSource.indexOf("async resumeAgentConversation(");
+  if (start < 0) return "";
+  const after = agentStoreSource.indexOf("\n  async ", start + 1);
+  return after < 0
+    ? agentStoreSource.slice(start)
+    : agentStoreSource.slice(start, after);
+}
+
+describe("#1656 — resume-fallback drops --resume immediately", () => {
+  const body = extractResumeAgentConversationBody();
+
+  it("contains exactly ONE `resumeAgentSessionId:` reference inside the function", () => {
+    // The initial spawn at line ~2371 references resumeAgentSessionId. The
+    // BUG was a second reference at line ~2394 — the wasted middle attempt
+    // that retried with the same bad ID. After the fix, exactly one
+    // reference remains.
+    expect(body, "function body must be non-empty").not.toBe("");
+    const matches = body.match(/resumeAgentSessionId:/g) ?? [];
+    expect(
+      matches.length,
+      "resumeAgentConversation must reference resumeAgentSessionId exactly once (initial spawn). A second reference indicates the wasted middle retry has been reintroduced.",
+    ).toBe(1);
+  });
+
+  it("first fallback path no longer carries `resumeAgentSessionId`", () => {
+    // The fallback that runs after the initial spawn fails MUST NOT pass
+    // a resume id. The fix collapses the prior two fallback branches into
+    // one fresh-spawn branch.
+    expect(body).toContain("Claude resume failed, spawning fresh session");
+    // The previous middle-attempt log line is gone.
+    expect(body).not.toContain(
+      "Resume fallback also failed — spawning without --resume",
+    );
+  });
+
+  it("fallback uses persisted history seeding (loadPersistedAgentHistory)", () => {
+    // Without the resume CLI session, the fresh session must seed from
+    // SQLite-persisted history so the user keeps their transcript context.
+    expect(body).toContain("loadPersistedAgentHistory(conversationId)");
+    expect(body).toContain("persisted.messages.length > 0");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1656.

When a stored Claude CLI session ID was missing on disk, `resumeAgentConversation` retried with the **same bad** `resumeAgentSessionId` before finally giving up. The middle retry is dead weight — always fails the same way — but adds ~3s of loading and surfaces a second `"Claude Code request failed"` error event to the chat panel.

Repro (from user log): conversation `5092bf7a-...` had stored agent session `6b43ee5e-...` missing from `sessions/<id>.jsonl`. Three spawns fired: 1st with `--resume 6b43ee5e` → fail, 2nd with `--resume 6b43ee5e` (same ID!) → fail, 3rd without `--resume` → success.

## Fix — `src/stores/agent.store.ts:2384-2421`

Collapse the two fallback branches into one. After the initial spawn fails, go straight to `loadPersistedAgentHistory(conversationId)` and spawn fresh with no `resumeAgentSessionId`. ~10 lines removed.

## Test

`tests/unit/resume-fallback-no-double-resume.test.ts`:
1. `resumeAgentConversation` body contains exactly **one** `resumeAgentSessionId:` reference (initial spawn only).
2. Removed log line `"Resume fallback also failed — spawning without --resume"` is gone (replaced by single `"Claude resume failed, spawning fresh session"`).
3. Fallback path uses `loadPersistedAgentHistory(conversationId)` for transcript seeding.

**Verified**: reverting the fix fails 2 of the 3 assertions. 517 tests pass (3 new). TSC clean.

## Verification (manual repro)

Switch to a thread whose Claude CLI session JSONL no longer exists. Pre-fix: 3 spawn attempts visible in console + 2 error toasts. Post-fix: 1 failed spawn + 1 successful fresh spawn + 1 error toast.

## Related

- Companion: #1657 — pre-flight `claude_session_exists()` check that eliminates even the first failed spawn for stale sessions. Lands after this.
- The future automatic error-reporting pipeline (#1630, #148) would have surfaced this as a triaged ticket.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
