### PR TITLE
feat(agent): pre-flight Claude session JSONL existence before --resume

### DIFF
--- a/src-tauri/src/claude_memory.rs
+++ b/src-tauri/src/claude_memory.rs
@@ -128,6 +128,16 @@ pub fn claude_projects_root() -> Result<PathBuf, String> {
     Ok(home.join(".claude").join("projects"))
 }
 
+/// Build the path Claude CLI uses for a session transcript:
+/// `<root>/<encoded(cwd)>/sessions/<session_id>.jsonl`.
+/// Pure path construction — caller decides whether to stat or read.
+pub fn session_jsonl_path(root: &Path, project_cwd: &Path, session_id: &str) -> PathBuf {
+    let encoded = encode_project_dir(project_cwd);
+    root.join(&encoded)
+        .join("sessions")
+        .join(format!("{session_id}.jsonl"))
+}
+
 /// Encode an absolute project directory the same way Claude Code does:
 /// `/Users/a/b` → `-Users-a-b`.
 pub fn encode_project_dir(cwd: &Path) -> String {
@@ -986,6 +996,40 @@ mod tests {
         assert_eq!(
             normalize_git_remote("https://user:token@GitHub.com/serenorg/seren-desktop/"),
             "github.com/serenorg/seren-desktop"
+        );
+    }
+
+    #[test]
+    fn session_jsonl_path_constructs_expected_layout_and_detects_presence() {
+        // Mirrors Claude CLI's on-disk layout:
+        //   <root>/<encoded(cwd)>/sessions/<session_id>.jsonl
+        // Test that (a) the path is constructed correctly and (b) is_file()
+        // returns true only when a real file exists at that path. Both legs
+        // are required for #1657 — frontend depends on the file-presence
+        // signal to decide whether to skip --resume.
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        let cwd = tmp.path().join("Projects").join("seren-desktop");
+        fs::create_dir_all(&cwd).expect("create fake cwd");
+        let session_id = "6b43ee5e-5699-486b-98c5-bbf42f703a19";
+
+        let path_before = session_jsonl_path(root, &cwd, session_id);
+        assert!(
+            !path_before.is_file(),
+            "missing session must NOT be reported as present (this is the stale-session case the fix addresses)",
+        );
+
+        // Materialize the file the way Claude CLI would. Path layout assertion:
+        // /<root>/<encoded>/sessions/<id>.jsonl
+        let session_dir = path_before
+            .parent()
+            .expect("session jsonl must have a parent dir");
+        assert!(session_dir.ends_with("sessions"), "second-to-last segment must be 'sessions'");
+        fs::create_dir_all(session_dir).expect("create sessions dir");
+        fs::write(&path_before, b"{\"stub\":true}\n").expect("write stub session");
+        assert!(
+            path_before.is_file(),
+            "present session file MUST be reported as present so --resume is allowed",
         );
     }
 

--- a/src-tauri/src/commands/claude_memory.rs
+++ b/src-tauri/src/commands/claude_memory.rs
@@ -152,6 +152,22 @@ pub async fn claude_memory_migrate_existing(
 }
 
 /// Resolve a stable project identifier for `project_cwd` (git remote or UUID).
+/// Check whether Claude CLI's session JSONL file exists on disk for the given
+/// project cwd + session id. Used by the frontend to skip `--resume` when the
+/// stored session ID points at a missing file (CLI cleaned up its sessions
+/// dir, app reinstall, cross-machine sync). Without this pre-flight, the
+/// resume attempt fails with `code=1: No conversation found with session ID:
+/// <id>` and surfaces a "Claude Code request failed" error event before the
+/// recovery fallback kicks in (#1657).
+#[tauri::command]
+pub fn claude_session_exists(
+    project_cwd: String,
+    session_id: String,
+) -> Result<bool, String> {
+    let root = claude_memory::claude_projects_root()?;
+    Ok(claude_memory::session_jsonl_path(&root, Path::new(&project_cwd), &session_id).is_file())
+}
+
 #[tauri::command]
 pub fn claude_memory_get_project_identity(
     project_cwd: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -863,6 +863,7 @@ pub fn run() {
             commands::claude_memory::claude_memory_get_project_identity,
             commands::claude_memory::claude_memory_render_memory_md,
             commands::claude_memory::claude_memory_run_sql,
+            commands::claude_memory::claude_session_exists,
             // Runtime session commands
             commands::session::create_runtime_session,
             commands::session::get_runtime_session,

--- a/src/services/claudeMemory.ts
+++ b/src/services/claudeMemory.ts
@@ -352,6 +352,25 @@ export async function getClaudeProjectIdentity(
 }
 
 /**
+ * Returns true when Claude CLI's session JSONL file exists on disk for the
+ * given project cwd + session id. Used by `resumeAgentConversation` to skip
+ * `--resume` when the stored session ID points at a missing file (CLI
+ * cleaned up old sessions, app reinstall, cross-machine sync) — without this
+ * pre-flight, the spawn fails with `code=1: No conversation found with
+ * session ID: <id>` and surfaces a "Claude Code request failed" error event.
+ * Browser runtime: returns false (no CLI sessions to check). See #1657.
+ */
+export async function claudeSessionExists(
+  projectCwd: string,
+  sessionId: string,
+): Promise<boolean> {
+  if (!isTauriRuntime()) {
+    return false;
+  }
+  return invoke<boolean>("claude_session_exists", { projectCwd, sessionId });
+}
+
+/**
  * Render `~/.claude/projects/<encoded(projectCwd)>/MEMORY.md` from the
  * `claude_agent_preferences` SerenDB table, so Claude Code reads fresh
  * content at the start of its next session.

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -165,6 +165,7 @@ import {
   setAgentConversationTitle as setAgentConversationTitleDb,
 } from "@/lib/tauri-bridge";
 import { refreshAccessToken } from "@/services/auth";
+import { claudeSessionExists } from "@/services/claudeMemory";
 import {
   bootstrapMemoryContext,
   storeAssistantResponse,
@@ -2368,9 +2369,38 @@ export const agentStore = {
       return null;
     }
 
+    // Pre-flight: skip --resume entirely when Claude CLI's session JSONL is
+    // missing. The CLI cleans up old session files, app reinstalls drop the
+    // ~/.claude dir, and cross-machine sync doesn't carry CLI session files —
+    // so a stored remoteSessionId can routinely point at nothing. Without this
+    // check, the spawn fails with `code=1: No conversation found with session
+    // ID: <id>` and surfaces a "Claude Code request failed" error event before
+    // the resume-fallback path takes over (#1657). Best-effort: if the IPC
+    // check itself fails, fall through to the existing spawn-and-recover path
+    // so we never regress.
+    let effectiveResumeId: string | undefined = remoteSessionId;
+    if (agentType === "claude-code") {
+      try {
+        const exists = await claudeSessionExists(resumeCwd, remoteSessionId);
+        if (!exists) {
+          console.info(
+            "[AgentStore] Claude session file missing for",
+            remoteSessionId,
+            "— skipping --resume, spawning fresh",
+          );
+          effectiveResumeId = undefined;
+        }
+      } catch (err) {
+        console.warn(
+          "[AgentStore] claudeSessionExists check failed; spawning with --resume:",
+          err,
+        );
+      }
+    }
+
     const sessionId = await this.spawnSession(resumeCwd, agentType, {
       localSessionId: conversationId,
-      resumeAgentSessionId: remoteSessionId,
+      resumeAgentSessionId: effectiveResumeId,
       conversationTitle: convo.title,
       restoredMessages,
       bootstrapPromptContext: pendingBootstrapPromptContext,

--- a/tests/unit/claude-session-preflight.test.ts
+++ b/tests/unit/claude-session-preflight.test.ts
@@ -1,0 +1,87 @@
+// ABOUTME: Regression test for #1657 — resumeAgentConversation must call
+// ABOUTME: claudeSessionExists before the initial spawn for claude-code agents,
+// ABOUTME: and must skip --resume when the JSONL file is missing.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const claudeMemorySource = readFileSync(
+  resolve("src/services/claudeMemory.ts"),
+  "utf-8",
+);
+
+function extractResumeAgentConversationBody(): string {
+  const start = agentStoreSource.indexOf("async resumeAgentConversation(");
+  if (start < 0) return "";
+  const after = agentStoreSource.indexOf("\n  async ", start + 1);
+  return after < 0
+    ? agentStoreSource.slice(start)
+    : agentStoreSource.slice(start, after);
+}
+
+describe("#1657 — claudeSessionExists pre-flight before --resume", () => {
+  const body = extractResumeAgentConversationBody();
+
+  it("services/claudeMemory exports claudeSessionExists invoking the Tauri command", () => {
+    expect(claudeMemorySource).toContain(
+      "export async function claudeSessionExists(",
+    );
+    expect(claudeMemorySource).toContain('invoke<boolean>("claude_session_exists"');
+    // Browser runtime degrades to false (no CLI sessions to check). Without
+    // this guard, the chat panel inside a non-Tauri shell would always think
+    // the file exists and try --resume, which is a guaranteed failure.
+    expect(claudeMemorySource).toContain("if (!isTauriRuntime()) {");
+  });
+
+  it("agent.store imports claudeSessionExists from the service module", () => {
+    expect(agentStoreSource).toContain(
+      'import { claudeSessionExists } from "@/services/claudeMemory"',
+    );
+  });
+
+  it("resumeAgentConversation calls claudeSessionExists before the initial resume spawn", () => {
+    // resumeAgentConversation has multiple spawnSession calls (early-exit
+    // branch, initial-resume, post-failure fallback). The pre-flight must
+    // run BEFORE the initial resume spawn — the one that actually passes
+    // resumeAgentSessionId. Use that specific call as the anchor.
+    expect(body, "function body must be non-empty").not.toBe("");
+    const checkIdx = body.indexOf("claudeSessionExists(");
+    const initialResumeSpawnIdx = body.indexOf(
+      "resumeAgentSessionId: effectiveResumeId",
+    );
+    expect(checkIdx, "must call claudeSessionExists").toBeGreaterThan(0);
+    expect(
+      initialResumeSpawnIdx,
+      "must pass effectiveResumeId to the initial resume spawn",
+    ).toBeGreaterThan(0);
+    expect(
+      checkIdx,
+      "claudeSessionExists must be called BEFORE the initial resume spawn",
+    ).toBeLessThan(initialResumeSpawnIdx);
+  });
+
+  it("guard is gated on agentType === 'claude-code'", () => {
+    // Codex and other agents must not pay the IPC cost of the check.
+    const guardIdx = body.indexOf('agentType === "claude-code"');
+    const checkIdx = body.indexOf("claudeSessionExists(");
+    expect(guardIdx).toBeGreaterThan(0);
+    expect(guardIdx).toBeLessThan(checkIdx);
+  });
+
+  it("when the file is missing, the spawn drops --resume by setting effectiveResumeId to undefined", () => {
+    expect(body).toContain("effectiveResumeId = undefined");
+    expect(body).toContain("resumeAgentSessionId: effectiveResumeId");
+  });
+
+  it("falls through to the spawn-and-recover path if the IPC check itself errors", () => {
+    // A failure in the existence check must NOT regress to a hard error.
+    // The catch arm must log a warning and proceed with the original
+    // remoteSessionId so the existing fallback path still runs.
+    expect(body).toContain("claudeSessionExists check failed");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1657. Companion to #1656 — that one collapsed the wasted middle resume-retry; this one eliminates the **first** failed spawn entirely when the Claude CLI session JSONL file isn't on disk.

When the stored agent session ID points at a missing file (CLI cleaned up its sessions dir, app reinstall, cross-machine sync), the spawn fails with `code=1: No conversation found with session ID: <id>` and surfaces a `"Claude Code request failed"` error event. After this PR: single fresh spawn, zero error events.

## Changes

- **`src-tauri/src/claude_memory.rs`** — new helper `session_jsonl_path(root, project_cwd, session_id) -> PathBuf`. Pure path construction reusing the existing `encode_project_dir`.
- **`src-tauri/src/commands/claude_memory.rs`** — new Tauri command `claude_session_exists(project_cwd, session_id) -> Result<bool, String>` calling `is_file()` on the helper output.
- **`src-tauri/src/lib.rs`** — registered in `invoke_handler!`.
- **`src/services/claudeMemory.ts`** — new wrapper `claudeSessionExists(projectCwd, sessionId)`. Browser runtime returns `false` (no CLI sessions to check).
- **`src/stores/agent.store.ts:resumeAgentConversation`** — calls the wrapper before the initial spawn for `claude-code` agents. When the file is missing, zeroes `effectiveResumeId` so `spawnSession` runs without `--resume`. Best-effort: if the IPC check errors, falls through to the existing spawn-and-recover path so we don't regress.

## Tests

- **Rust** (`claude_memory::tests::session_jsonl_path_constructs_expected_layout_and_detects_presence`): builds a `TempDir`, asserts (a) `session_jsonl_path` produces `<root>/<encoded(cwd)>/sessions/<id>.jsonl`, (b) `is_file()` returns `false` before the file is written and `true` after.
- **TS** (`tests/unit/claude-session-preflight.test.ts`): 6 source-level assertions:
  1. `claudeSessionExists` exported, calls `invoke<boolean>("claude_session_exists", ...)`, returns `false` outside Tauri.
  2. `agent.store` imports the wrapper from `@/services/claudeMemory`.
  3. The pre-flight check is positioned BEFORE the initial resume `spawnSession` call (the one that passes `effectiveResumeId`).
  4. Guard is gated on `agentType === "claude-code"` so Codex/Gemini don't pay the IPC cost.
  5. Missing-file path zeros out `effectiveResumeId` and the spawn passes `resumeAgentSessionId: effectiveResumeId`.
  6. Catch arm logs `"claudeSessionExists check failed"` so an IPC error doesn't regress to a hard failure.

**Verified**: reverting the fix fails 6 of 6 new TS assertions. Cargo test passes. Full suite: 524 TS tests pass.

## Verification (manual)

Open a thread whose Claude CLI session JSONL no longer exists. Pre-fix (already #1656-clean): one failed spawn + one fresh spawn + one error toast. Post-fix: single fresh spawn, no error toast.

## Related

- Builds on #1656 (already merged).
- The future automatic error-reporting pipeline (#1630, #148) would have surfaced this bug as a triaged ticket via the same auto-bundle path.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
