### PR TITLE
fix(auth): rename promptLogin -> clearAuthState + add real session-expired modal (#1661)

### DIFF
--- a/src/components/auth/SessionExpiredModal.tsx
+++ b/src/components/auth/SessionExpiredModal.tsx
@@ -1,0 +1,66 @@
+// ABOUTME: Layout-level blocking modal that fires on mid-session sign-in requests.
+// ABOUTME: Subscribes to authStore.signInModalRequested and renders the SignIn form.
+
+import { type Component, Show } from "solid-js";
+import { authStore, dismissSignInModal } from "@/stores/auth.store";
+import { SignIn } from "./SignIn";
+
+/**
+ * Blocking sign-in modal for mid-flow session expiry, refresh-token failure,
+ * and the `/login` slash command. Distinct from ChatContent's local sign-in
+ * gate (which fires on send attempts) and from the passive titlebar Sign In
+ * button (which is always-on whenever the user is unauthenticated).
+ *
+ * Mounts once at the layout root so it works in every UI mode (agent thread,
+ * chat thread, settings panel). See #1661.
+ */
+export const SessionExpiredModal: Component = () => {
+  const handleSuccess = () => {
+    dismissSignInModal();
+  };
+
+  const handleDismiss = () => {
+    // Honest dismiss — the user explicitly chose to ignore the modal. The
+    // titlebar Sign In button stays as the lower-friction surface; the next
+    // mid-flow event (refresh failure, auto-compact skip) will re-raise.
+    dismissSignInModal();
+  };
+
+  return (
+    <Show when={authStore.signInModalRequested}>
+      <div
+        class="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="session-expired-modal-title"
+      >
+        <div class="relative w-full max-w-md mx-4 bg-surface-0 border border-surface-3 rounded-lg shadow-2xl">
+          <div class="px-6 py-5 border-b border-surface-2">
+            <h2
+              id="session-expired-modal-title"
+              class="m-0 text-lg font-semibold text-foreground"
+            >
+              Sign in to continue
+            </h2>
+            <p class="mt-2 mb-0 text-sm text-muted-foreground leading-normal">
+              Your Seren session has expired. Sign in to keep going — your
+              current conversation is preserved.
+            </p>
+          </div>
+          <div class="px-6 py-5">
+            <SignIn onSuccess={handleSuccess} />
+          </div>
+          <div class="px-6 py-3 border-t border-surface-2 flex justify-end">
+            <button
+              type="button"
+              class="px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors bg-transparent border-none cursor-pointer"
+              onClick={handleDismiss}
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+};

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -9,6 +9,7 @@ import {
   onMount,
   Switch,
 } from "solid-js";
+import { SessionExpiredModal } from "@/components/auth/SessionExpiredModal";
 import { SignIn } from "@/components/auth/SignIn";
 import { StatusBar } from "@/components/common/StatusBar";
 import { EditorContent } from "@/components/editor/EditorContent";
@@ -163,6 +164,12 @@ export const AppShell: Component<AppShellProps> = (props) => {
       </div>
 
       <StatusBar />
+
+      {/* Layout-level blocking sign-in modal — fires on mid-session expiry,
+          refresh-token failure, and the /login slash command. Distinct from
+          the passive titlebar Sign In button (always-on when unauthenticated)
+          and from ChatContent's local pre-send gate. See #1661. */}
+      <SessionExpiredModal />
     </div>
   );
 };

--- a/src/lib/commands/registry.ts
+++ b/src/lib/commands/registry.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Commands are organized by tier and registered at module load.
 
 import { agentStore } from "@/stores/agent.store";
-import { promptLogin } from "@/stores/auth.store";
+import { requestSignInModal } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
 import { providerStore } from "@/stores/provider.store";
@@ -161,7 +161,10 @@ registry.register({
   description: "Sign in to Seren",
   panels: ["chat", "agent"],
   execute: (ctx) => {
-    promptLogin();
+    // /login is an explicit user action — do not invalidate their session
+    // if they are already authenticated. The modal lets them switch
+    // accounts or re-auth without dropping their current state. See #1661.
+    requestSignInModal();
     ctx.clearInput();
     ctx.showStatus("Opening sign in...");
     return true;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -15,7 +15,7 @@ import {
   storeToken,
 } from "@/lib/tauri-bridge";
 import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
-import { promptLogin } from "@/stores/auth.store";
+import { clearAuthState, requestSignInModal } from "@/stores/auth.store";
 
 export interface LoginResponse {
   data: {
@@ -138,7 +138,8 @@ export async function logout(): Promise<void> {
 export async function refreshAccessToken(): Promise<boolean> {
   const refreshToken = await getRefreshToken();
   if (!refreshToken) {
-    promptLogin();
+    clearAuthState();
+    requestSignInModal();
     return false;
   }
 
@@ -157,7 +158,8 @@ export async function refreshAccessToken(): Promise<boolean> {
       if (response.status === 401) {
         await clearToken();
         await clearRefreshToken();
-        promptLogin();
+        clearAuthState();
+        requestSignInModal();
       }
       return false;
     }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -186,7 +186,7 @@ import type {
   ToolCallEvent,
 } from "@/services/providers";
 import * as providerService from "@/services/providers";
-import { authStore, promptLogin } from "@/stores/auth.store";
+import { authStore, requestSignInModal } from "@/stores/auth.store";
 
 /** Set once we've subscribed to `provider-runtime://ready` so repeated
  *  initialize() calls don't stack listeners. */
@@ -4132,7 +4132,12 @@ Structured summary:`;
                 console.warn(
                   "[AgentStore] Skipping auto-compaction — user is not authenticated",
                 );
-                promptLogin();
+                // State is already false (the guard above proved it). The
+                // pre-#1661 code called promptLogin() here, which was a
+                // no-op state flip. The user needs visible escalation —
+                // their context is already approaching the model limit and
+                // we just declined to compact. Show the modal.
+                requestSignInModal();
               } else {
                 // Explicit undefined for pendingUserPrompt: the prompt that
                 // just produced this promptComplete already succeeded, so we

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -34,6 +34,16 @@ interface AuthState {
   /** Whether MCP Gateway is connected */
   mcpConnected: boolean;
   privateChatPolicy: OrganizationPrivateChatPolicy | null;
+  /**
+   * Set true when something asks for the user-visible sign-in modal —
+   * mid-session expiry, a `/login` slash command, refresh-token failure.
+   * The layout-level <SessionExpiredModal /> subscribes to this signal and
+   * shows the blocking modal. Distinct from `isAuthenticated` so we can
+   * tell "user is signed out" (passive titlebar button) apart from
+   * "user needs to know they're signed out RIGHT NOW" (modal).
+   * See #1661.
+   */
+  signInModalRequested: boolean;
 }
 
 const [state, setState] = createStore<AuthState>({
@@ -42,6 +52,7 @@ const [state, setState] = createStore<AuthState>({
   isAuthenticated: false,
   mcpConnected: false,
   privateChatPolicy: null,
+  signInModalRequested: false,
 });
 
 let authBindingsInitialized = false;
@@ -206,10 +217,16 @@ export async function logout(): Promise<void> {
 }
 
 /**
- * Show the sign-in prompt by clearing authentication state.
- * Used by the /login slash command and session-expired events.
+ * Pure state mutation: clear the user, isAuthenticated, and privateChatPolicy
+ * fields. Does NOT show any UI. Use this when you've decided the auth state
+ * is no longer valid (refresh failed, IPC told us tokens died, /login slash
+ * command). If you also want the user to know they need to sign in right now,
+ * call `requestSignInModal()` separately.
+ *
+ * Renamed from `promptLogin` (which lied — it never prompted anything;
+ * see #1661).
  */
-export function promptLogin(): void {
+export function clearAuthState(): void {
   setState({
     isAuthenticated: false,
     user: null,
@@ -217,8 +234,28 @@ export function promptLogin(): void {
   });
 }
 
-// Listen for session-expired events from the desktop runtime (e.g. both tokens dead).
-// Sets isAuthenticated = false so the UI shows the sign-in prompt.
+/**
+ * Ask the layout-level <SessionExpiredModal /> to show. Pure UI signal —
+ * does NOT touch auth state. Pair with `clearAuthState()` when you also
+ * need to invalidate the session. See #1661.
+ */
+export function requestSignInModal(): void {
+  setState("signInModalRequested", true);
+}
+
+/**
+ * Hide the session-expired modal. Called when the user successfully signs
+ * in (or explicitly dismisses).
+ */
+export function dismissSignInModal(): void {
+  setState("signInModalRequested", false);
+}
+
+// Listen for session-expired events from the desktop runtime (both tokens
+// dead, or backend explicitly told us to re-auth). The Rust side already
+// cleared its own state; we mirror that into the frontend store AND raise
+// the modal so the user gets visible escalation instead of just a passive
+// titlebar button. See #1661.
 export async function initAuthRuntimeBindings(): Promise<void> {
   if (authBindingsInitialized || !isTauriRuntime()) {
     return;
@@ -228,7 +265,8 @@ export async function initAuthRuntimeBindings(): Promise<void> {
   const { listen } = await import("@tauri-apps/api/event");
   await listen("auth:session-expired", () => {
     console.warn("[Auth Store] Session expired event from backend");
-    promptLogin();
+    clearAuthState();
+    requestSignInModal();
   });
 }
 

--- a/tests/unit/auth-clear-state.test.ts
+++ b/tests/unit/auth-clear-state.test.ts
@@ -1,0 +1,61 @@
+// ABOUTME: Critical tests for #1661 — clearAuthState / requestSignInModal separation.
+// ABOUTME: Locks the rule that auth state and the sign-in modal are independent concerns.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  authStore,
+  clearAuthState,
+  dismissSignInModal,
+  requestSignInModal,
+} from "@/stores/auth.store";
+
+describe("clearAuthState (#1661)", () => {
+  it("flips isAuthenticated, user, privateChatPolicy and does NOT touch the modal signal", () => {
+    requestSignInModal(); // pre-set the modal flag so we can prove the separation
+    expect(authStore.signInModalRequested).toBe(true);
+
+    clearAuthState();
+
+    expect(authStore.isAuthenticated).toBe(false);
+    expect(authStore.user).toBeNull();
+    expect(authStore.privateChatPolicy).toBeNull();
+    // The whole point of the rename: clearing auth state must not also flip
+    // the modal signal. Pre-#1661 promptLogin conflated the two; that conflation
+    // is what made the auto-compact call site dead code.
+    expect(authStore.signInModalRequested).toBe(true);
+
+    dismissSignInModal();
+  });
+});
+
+describe("requestSignInModal / dismissSignInModal (#1661)", () => {
+  it("requestSignInModal flips the signal and does NOT touch auth state", () => {
+    // Treat the test environment as if the user were authenticated. We can't
+    // setAuthenticated() without provisioning, so just confirm the modal
+    // signal moves independently of whatever auth state is.
+    const beforeAuth = authStore.isAuthenticated;
+    const beforeUser = authStore.user;
+    const beforePolicy = authStore.privateChatPolicy;
+
+    requestSignInModal();
+
+    expect(authStore.signInModalRequested).toBe(true);
+    expect(authStore.isAuthenticated).toBe(beforeAuth);
+    expect(authStore.user).toBe(beforeUser);
+    expect(authStore.privateChatPolicy).toBe(beforePolicy);
+
+    dismissSignInModal();
+  });
+
+  it("dismissSignInModal clears the signal and does NOT touch auth state", () => {
+    requestSignInModal();
+    const beforeAuth = authStore.isAuthenticated;
+
+    dismissSignInModal();
+
+    expect(authStore.signInModalRequested).toBe(false);
+    expect(authStore.isAuthenticated).toBe(beforeAuth);
+  });
+});
+

--- a/tests/unit/compaction-auth-gate.test.ts
+++ b/tests/unit/compaction-auth-gate.test.ts
@@ -16,9 +16,9 @@ const authServiceSource = readFileSync(
 );
 
 describe("#1639 — auto-compact auth gate", () => {
-  it("imports authStore and promptLogin from auth.store", () => {
+  it("imports authStore and the modal-trigger from auth.store (#1661 renamed promptLogin)", () => {
     expect(agentStoreSource).toContain(
-      'import { authStore, promptLogin } from "@/stores/auth.store"',
+      'import { authStore, requestSignInModal } from "@/stores/auth.store"',
     );
   });
 
@@ -49,14 +49,14 @@ describe("#1639 — auto-compact auth gate", () => {
     ).toBeLessThan(compactCallAfterAnchor);
   });
 
-  it("calls promptLogin() when auth check fails in auto-compact path", () => {
+  it("calls requestSignInModal() when auth check fails in auto-compact path (#1661 — was promptLogin, now real modal)", () => {
     const autoCompactAnchor = "Auto-compact check runs BEFORE drain (#1623)";
     const drainAnchor = "Drain the prompt queue for this session";
     const autoCompactIdx = agentStoreSource.indexOf(autoCompactAnchor);
     const drainIdx = agentStoreSource.indexOf(drainAnchor);
 
     const authBlock = agentStoreSource.slice(autoCompactIdx, drainIdx);
-    expect(authBlock).toContain("promptLogin()");
+    expect(authBlock).toContain("requestSignInModal()");
   });
 
   it("logs a warning when skipping compaction due to auth", () => {
@@ -81,42 +81,43 @@ describe("#1639 — predictive-compact auth gate", () => {
   });
 });
 
-describe("#1639 — refreshAccessToken calls promptLogin on terminal failure", () => {
-  it("imports promptLogin from auth.store", () => {
+describe("#1639 — refreshAccessToken pairs clearAuthState + requestSignInModal on terminal failure (#1661 rename)", () => {
+  it("imports clearAuthState and requestSignInModal from auth.store", () => {
     expect(authServiceSource).toContain(
-      'import { promptLogin } from "@/stores/auth.store"',
+      'import { clearAuthState, requestSignInModal } from "@/stores/auth.store"',
     );
   });
 
-  it("calls promptLogin when no refresh token is available", () => {
-    // Find the "if (!refreshToken)" block and verify promptLogin is called
+  it("clears auth state AND requests the sign-in modal when no refresh token is available", () => {
     const noTokenIdx = authServiceSource.indexOf("if (!refreshToken)");
     expect(noTokenIdx).toBeGreaterThan(0);
-    const blockAfter = authServiceSource.slice(noTokenIdx, noTokenIdx + 100);
-    expect(blockAfter).toContain("promptLogin()");
+    const blockAfter = authServiceSource.slice(noTokenIdx, noTokenIdx + 200);
+    expect(blockAfter).toContain("clearAuthState()");
+    expect(blockAfter).toContain("requestSignInModal()");
   });
 
-  it("calls promptLogin on 401 from refresh endpoint", () => {
-    // Find the 401 handling block inside refreshAccessToken
+  it("clears auth state AND requests the sign-in modal on 401 from refresh endpoint", () => {
     const refreshFnIdx = authServiceSource.indexOf(
       "async function refreshAccessToken",
     );
-    const fnBody = authServiceSource.slice(refreshFnIdx, refreshFnIdx + 1200);
+    const fnBody = authServiceSource.slice(refreshFnIdx, refreshFnIdx + 1400);
     const clear401Block = fnBody.indexOf("response.status === 401");
     expect(clear401Block).toBeGreaterThan(0);
-    const afterClear = fnBody.slice(clear401Block, clear401Block + 200);
-    expect(afterClear).toContain("promptLogin()");
+    const afterClear = fnBody.slice(clear401Block, clear401Block + 300);
+    expect(afterClear).toContain("clearAuthState()");
+    expect(afterClear).toContain("requestSignInModal()");
   });
 
-  it("does NOT call promptLogin on network errors (user may be offline)", () => {
+  it("does NOT trigger the modal on network errors (user may be offline)", () => {
     const refreshFnIdx = authServiceSource.indexOf(
       "async function refreshAccessToken",
     );
-    const fnBody = authServiceSource.slice(refreshFnIdx, refreshFnIdx + 1200);
+    const fnBody = authServiceSource.slice(refreshFnIdx, refreshFnIdx + 1400);
     const catchBlock = fnBody.indexOf("} catch {");
     expect(catchBlock).toBeGreaterThan(0);
-    const afterCatch = fnBody.slice(catchBlock, catchBlock + 150);
-    expect(afterCatch).not.toContain("promptLogin");
+    const afterCatch = fnBody.slice(catchBlock, catchBlock + 200);
+    expect(afterCatch).not.toContain("requestSignInModal");
+    expect(afterCatch).not.toContain("clearAuthState");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1661. `promptLogin()` was misnamed and partially dead — it never prompted anything, just flipped state. Mid-session expiry produced no blocking modal; users kept chatting through context overflow with the only escalation being a small passive titlebar button they routinely missed (see `~/Desktop/ph.png`).

## Audit findings (dead + misleading code)

| Site | Issue | Action |
|---|---|---|
| `auth.store.ts:212-218` `promptLogin()` | Function name lies; it doesn't prompt | Renamed to `clearAuthState()` |
| `auth.store.ts:209,221` JSDoc + comments | "Show the sign-in prompt by clearing state" | Replaced with accurate descriptions |
| `agent.store.ts:4135` | Called `promptLogin()` AFTER `!isAuthenticated` guard proved state already false. Pure no-op | Replaced with `requestSignInModal()` — real user-visible escalation |
| `lib/commands/registry.ts:164` `/login` slash | Called `promptLogin()` + `ctx.showStatus("Opening sign in...")` — nothing opened, status was a false promise | Replaced with `requestSignInModal()` — status now true |

## Changes

**1. Rename + split concerns** ([auth.store.ts](src/stores/auth.store.ts))
- `promptLogin()` → `clearAuthState()`. Honest name. Pure state mutation.
- New `requestSignInModal()` toggles `authStore.signInModalRequested`. Pure UI signal.
- New `dismissSignInModal()` clears the signal.

The two concerns are now independent. Pre-#1661 conflation is exactly what made the auto-compact call site dead code.

**2. Real layout-level modal** ([SessionExpiredModal.tsx](src/components/auth/SessionExpiredModal.tsx))
- New blocking modal with the existing `<SignIn />` form embedded.
- Mounted once at `AppShell.tsx` so it works in agent threads, chat threads, settings panel — every UI mode.
- Auto-dismisses on successful sign-in.

**3. Updated call sites**
- `auth:session-expired` IPC listener: now calls **both** `clearAuthState()` and `requestSignInModal()`.
- `refreshAccessToken` (no-refresh-token + 401 paths): same pair.
- `/login` slash: `requestSignInModal()` only — explicit user action, do not invalidate their session.
- `agent.store.ts` auto-compact skip: `requestSignInModal()` (the dead `promptLogin()` is gone).

## Tests (critical-only per CLAUDE.md)

[`tests/unit/auth-clear-state.test.ts`](tests/unit/auth-clear-state.test.ts) — locks the separation:
- `clearAuthState()` flips auth fields, does NOT touch the modal signal.
- `requestSignInModal()` flips the modal signal, does NOT touch auth state.
- `dismissSignInModal()` clears the signal cleanly.

[`tests/unit/compaction-auth-gate.test.ts`](tests/unit/compaction-auth-gate.test.ts) — updated for the rename:
- agent.store imports `requestSignInModal` (not `promptLogin`).
- auto-compact path calls `requestSignInModal()`.
- `refreshAccessToken` pairs `clearAuthState()` + `requestSignInModal()` on no-token and 401.
- Existing "does NOT trigger on network errors" guard preserved.

No tests for the modal's own rendering — UI smoke value is low; the source-text tests + the layout mount catch the wiring.

## What stays

- Titlebar passive Sign In button — low-friction surface for users who manually sign out or boot fresh.
- ChatContent local pre-send sign-in modal — different trigger (user tries to send while unauthenticated in Seren chat).
- AgentChat session-error banner with auth-pattern detection — different trigger (agent message content).

## Test plan

- [x] `pnpm test` — 527/527 pass.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- [ ] Manual: log in, clear refresh token, send a message in agent mode, modal appears.

## Out of scope

- Network-level retry for the refresh-token endpoint (separate concern).
- Proactive "session expires in N minutes" warning (file separately).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
