### PR TITLE
fix(agent): stop wiping persisted thread history on resume + send (#1663)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -690,15 +690,6 @@ async function loadPersistedAgentHistory(
   }
 }
 
-function clearLegacyAgentTranscript(conversationId: string): void {
-  clearConversationHistory(conversationId).catch((error) =>
-    console.warn(
-      "[AgentStore] Failed to clear legacy provider transcript:",
-      error,
-    ),
-  );
-}
-
 // ============================================================================
 // State
 // ============================================================================
@@ -2449,9 +2440,12 @@ export const agentStore = {
     }
 
     if (sessionId) {
-      if (!pendingBootstrapPromptContext) {
-        clearLegacyAgentTranscript(conversationId);
-      }
+      // NOTE (#1663): pre-fix code called clearLegacyAgentTranscript here on
+      // every successful resume without a bootstrap context. That deleted
+      // every row in the messages table for this conversation_id, wiping
+      // the persisted user/assistant history that loadPersistedAgentHistory
+      // had just loaded. Removed: persistAgentMessage is the source of
+      // truth for thread history; nothing in the resume path should clear it.
       clearSpawnFailures(conversationId);
       void this.refreshRecentAgentConversations(200).catch(() => {});
     } else {
@@ -2571,11 +2565,16 @@ export const agentStore = {
   },
 
   clearBootstrapPromptContext(sessionId: string) {
+    // NOTE (#1663): pre-fix code also called clearLegacyAgentTranscript on
+    // the conversationId here, which fired after every successful sendPrompt
+    // and wiped the messages table for the conversation. The clear was a
+    // vestige of the pre-#1562 storage model where the metadata-bootstrap
+    // path was the primary persistence and per-message rows were "legacy."
+    // After #1562 made persistAgentMessage primary, this clear became
+    // actively destructive. We keep the bootstrap-context clear (the
+    // session has consumed its seed); we do NOT touch user/assistant
+    // history.
     this.setBootstrapPromptContext(sessionId, undefined);
-    const conversationId = state.sessions[sessionId]?.conversationId;
-    if (conversationId) {
-      clearLegacyAgentTranscript(conversationId);
-    }
   },
 
   async restoreSessionSettings(

--- a/tests/unit/agent-history-persistence.test.ts
+++ b/tests/unit/agent-history-persistence.test.ts
@@ -60,3 +60,46 @@ describe("agent message persistence guards", () => {
     expect(finalizeBody).toContain("persistAgentMessage(");
   });
 });
+
+describe("#1663 — agent thread history must not be wiped on resume or send", () => {
+  it("clearLegacyAgentTranscript no longer exists — the function that wiped history every send and every resume is gone", () => {
+    // Match the function definition itself, not historical NOTE comments.
+    expect(agentStoreSource).not.toContain(
+      "function clearLegacyAgentTranscript",
+    );
+  });
+
+  it("resumeAgentConversation does not invoke any clear-history call on successful resume (#1663)", () => {
+    const fnIdx = agentStoreSource.indexOf("async resumeAgentConversation");
+    expect(fnIdx).toBeGreaterThan(0);
+    const nextFn = agentStoreSource.indexOf("\n  async ", fnIdx + 30);
+    const slice = agentStoreSource.slice(
+      fnIdx,
+      nextFn > fnIdx ? nextFn : fnIdx + 12000,
+    );
+    // Strip line comments so historical NOTEs documenting the fix don't
+    // count as live calls.
+    const code = slice.replace(/\/\/.*$/gm, "");
+    expect(code).not.toMatch(/clearLegacyAgentTranscript\s*\(/);
+  });
+
+  it("clearBootstrapPromptContext does not invoke any clear-history call (#1663)", () => {
+    const fnIdx = agentStoreSource.indexOf(
+      "clearBootstrapPromptContext(sessionId",
+    );
+    expect(fnIdx).toBeGreaterThan(0);
+    const slice = agentStoreSource.slice(fnIdx, fnIdx + 1200);
+    const code = slice.replace(/\/\/.*$/gm, "");
+    expect(code).not.toMatch(/clearLegacyAgentTranscript\s*\(/);
+    expect(code).not.toMatch(/clearConversationHistory\s*\(/);
+  });
+
+  it("clearSessionMessages still clears persisted history — the user-initiated 'Clear messages' button must keep working", () => {
+    const fnIdx = agentStoreSource.indexOf("clearSessionMessages(sessionId");
+    expect(fnIdx).toBeGreaterThan(0);
+    const slice = agentStoreSource.slice(fnIdx, fnIdx + 800);
+    expect(slice).toContain(
+      "clearConversationHistory(session.conversationId)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1663. **P0 data loss.** Agent thread chat history was wiped on every successful prompt completion AND on every thread re-open. Verified against the user's actual DB: 343 agent conversations, only 48 with any messages, last persisted user/assistant message 2026-04-24 21:00:23 UTC despite continuous use after that.

## Blast radius

`clearLegacyAgentTranscript(conversationId)` called from two paths that fire during normal use:

1. `resumeAgentConversation:2453` — every thread re-open without `pendingBootstrapPromptContext`.
2. `clearBootstrapPromptContext:2577` — called from `sendPrompt:3396` (after every successful prompt) and `sendPrompt:3499` (after a successful retry).

Both invoked `clearConversationHistory(conversationId)` which DELETEs all rows in the `messages` table for that conversation_id. The wipe is destructive and runs after every save.

## History

- **#1562** (Mar 9) made `persistAgentMessage` the primary user/assistant persistence path.
- **#1384** (Apr 1) added `clearLegacyAgentTranscript` to migrate off an older "legacy provider transcript" scheme.
- Combined effect: after #1562, `persistAgentMessage` is the source of truth — but the clear from #1384 was still firing. It became actively destructive, wiping the new primary store every time.

## Changes

- Delete `clearLegacyAgentTranscript` (function body removed).
- Remove the call from `resumeAgentConversation` — replaced with an inline NOTE explaining why we removed it.
- Remove the call from `clearBootstrapPromptContext` — kept the `setBootstrapPromptContext(sessionId, undefined)` (the session has consumed its seed); we do NOT touch user/assistant history.

`clearSessionMessages` (the explicit user "Clear messages" button via `AgentChat:556`) calls `clearConversationHistory` directly and is unaffected — that path is the one user-facing clear and stays.

## Tests (critical-only per CLAUDE.md)

`tests/unit/agent-history-persistence.test.ts` gains a `#1663` describe block:

- `clearLegacyAgentTranscript` function definition is gone.
- `resumeAgentConversation` has no clear-history call (live, not in NOTE comments).
- `clearBootstrapPromptContext` has no clear-history call.
- `clearSessionMessages` STILL calls `clearConversationHistory` (user "Clear messages" affordance preserved).

Why source-text tests over runtime: the wipe was a Tauri command bridge to SQLite. Mocking the Tauri runtime + SQLite to drive a "send → assert row → resume → assert row still there" round-trip costs more than it returns. The source-text guards directly assert the structural rule that fixes the bug.

## Test plan

- [x] `pnpm test` — 531/531 pass (4 new + 527 existing).
- [x] `cargo check` — clean.
- [ ] Manual: send message → restart → reopen thread → message visible.
- [ ] Manual: send message → send another → DB still contains both pairs.

## Out of scope

- Recovering already-deleted history. The wipe was destructive; affected users' transcripts are gone. This PR prevents future loss only.
- Auditing the metadata-bootstrap path (compaction's seed transfer). Independent, intact, not the data-loss surface.
- Adding a "your history was wiped" notification. Not actionable retroactively.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
