### PR TITLE
fix(agent-registry): expand resolver paths for system npm + Homebrew + Windows MSI (#1665)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -302,6 +302,9 @@ function resolveInstalledGeminiBinary() {
     const home = os.homedir();
     const appData = process.env.APPDATA ?? "";
     const nodeDir = path.dirname(process.execPath);
+    const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+    const programFilesX86 =
+      process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
     const candidates = [
       // npm global install via embedded runtime's npm (prefix = node dir on Windows)
       path.join(nodeDir, "gemini.cmd"),
@@ -310,6 +313,11 @@ function resolveInstalledGeminiBinary() {
       ...(appData ? [path.join(appData, "npm", "gemini.cmd")] : []),
       // Generic install fallbacks
       path.join(home, ".local", "bin", "gemini.exe"),
+      // System-wide Node MSI install (default before npm prefix moved to APPDATA). #1665
+      path.join(programFiles, "nodejs", "gemini.cmd"),
+      path.join(programFilesX86, "nodejs", "gemini.cmd"),
+      // Explicit user prefix (`.npmrc` prefix=$HOME/.npm-global). #1665
+      path.join(home, ".npm-global", "gemini.cmd"),
     ];
     for (const candidate of candidates) {
       if (existsSync(candidate)) {
@@ -326,6 +334,12 @@ function resolveInstalledGeminiBinary() {
       path.join(prefix, "bin", "gemini"),
       // Generic user-local install fallbacks
       path.join(home, ".local", "bin", "gemini"),
+      // System npm prefix /usr/local (default on Intel macOS + most Linux distros). #1665
+      "/usr/local/bin/gemini",
+      // Homebrew on Apple Silicon. #1665
+      "/opt/homebrew/bin/gemini",
+      // Distro package managers (apt, dnf). Rare for npm globals; last. #1665
+      "/usr/bin/gemini",
     ];
     for (const candidate of candidates) {
       if (existsSync(candidate)) {
@@ -346,6 +360,9 @@ export function resolveInstalledClaudeBinary() {
     const home = os.homedir();
     const appData = process.env.APPDATA ?? "";
     const nodeDir = path.dirname(process.execPath);
+    const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+    const programFilesX86 =
+      process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
     const candidates = [
       // Native installer location (install.ps1 puts it here)
       path.join(home, ".local", "bin", "claude.exe"),
@@ -358,6 +375,11 @@ export function resolveInstalledClaudeBinary() {
       // npm global install via embedded runtime's npm (prefix = node dir on Windows)
       path.join(nodeDir, "claude.cmd"),
       path.join(nodeDir, "claude"),
+      // System-wide Node MSI install (default before npm prefix moved to APPDATA). #1665
+      path.join(programFiles, "nodejs", "claude.cmd"),
+      path.join(programFilesX86, "nodejs", "claude.cmd"),
+      // Explicit user prefix. #1665
+      path.join(home, ".npm-global", "claude.cmd"),
     ];
     for (const candidate of candidates) {
       if (existsSync(candidate)) {
@@ -373,6 +395,12 @@ export function resolveInstalledClaudeBinary() {
       path.join(home, ".local", "bin", "claude"),
       // npm global install via embedded runtime's npm
       path.join(prefix, "bin", "claude"),
+      // System npm prefix /usr/local. #1665
+      "/usr/local/bin/claude",
+      // Homebrew on Apple Silicon. #1665
+      "/opt/homebrew/bin/claude",
+      // Distro package managers. #1665
+      "/usr/bin/claude",
     ];
     for (const candidate of candidates) {
       if (existsSync(candidate)) {
@@ -395,13 +423,22 @@ export function resolveInstalledClaudeBinary() {
  */
 export function resolveInstalledCodexBinary() {
   if (process.platform === "win32") {
+    const home = os.homedir();
     const appData = process.env.APPDATA ?? "";
     const nodeDir = path.dirname(process.execPath);
+    const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+    const programFilesX86 =
+      process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
     const candidates = [
       ...(appData ? [path.join(appData, "npm", "codex.cmd")] : []),
       ...(appData ? [path.join(appData, "npm", "codex.ps1")] : []),
       path.join(nodeDir, "codex.cmd"),
       path.join(nodeDir, "codex"),
+      // System-wide Node MSI install. #1665
+      path.join(programFiles, "nodejs", "codex.cmd"),
+      path.join(programFilesX86, "nodejs", "codex.cmd"),
+      // Explicit user prefix. #1665
+      path.join(home, ".npm-global", "codex.cmd"),
     ];
     for (const candidate of candidates) {
       if (existsSync(candidate)) {
@@ -415,6 +452,13 @@ export function resolveInstalledCodexBinary() {
     const candidates = [
       path.join(prefix, "bin", "codex"),
       path.join(home, ".local", "bin", "codex"),
+      // System npm prefix /usr/local — Intel macOS + most Linux distros. The
+      // verified miss in #1665 (taariq's codex was here, resolver failed).
+      "/usr/local/bin/codex",
+      // Homebrew on Apple Silicon. #1665
+      "/opt/homebrew/bin/codex",
+      // Distro package managers. #1665
+      "/usr/bin/codex",
     ];
     for (const candidate of candidates) {
       if (existsSync(candidate)) {

--- a/tests/unit/agent-resolver-paths.test.ts
+++ b/tests/unit/agent-resolver-paths.test.ts
@@ -1,0 +1,102 @@
+// ABOUTME: Regression guard for #1665 — CLI resolvers must include system npm + Homebrew + Windows MSI paths.
+// ABOUTME: Source-text tests because resolvers run against real fs.existsSync; mocking the filesystem here is more brittle than the value of the test.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const registrySource = readFileSync(
+  resolve("bin/browser-local/agent-registry.mjs"),
+  "utf-8",
+);
+
+function sliceFn(name: string): string {
+  const start = registrySource.indexOf(`function ${name}`);
+  if (start < 0) throw new Error(`Function not found: ${name}`);
+  // Bound the slice to the next top-level `function ` declaration. Falls back
+  // to a generous window so a slight refactor doesn't make the test silently
+  // skip detection.
+  const next = registrySource.indexOf("\nfunction ", start + 10);
+  const exportNext = registrySource.indexOf("\nexport function ", start + 10);
+  const ends = [next, exportNext].filter((n) => n > 0);
+  const end = ends.length > 0 ? Math.min(...ends) : start + 4000;
+  return registrySource.slice(start, end);
+}
+
+describe("#1665 — Unix resolver paths cover system npm + Homebrew", () => {
+  it.each([
+    "resolveInstalledClaudeBinary",
+    "resolveInstalledCodexBinary",
+    "resolveInstalledGeminiBinary",
+  ])("%s includes /usr/local/bin (system npm prefix)", (name) => {
+    const fn = sliceFn(name);
+    const cmd = name
+      .replace("resolveInstalled", "")
+      .replace("Binary", "")
+      .toLowerCase();
+    expect(fn).toContain(`/usr/local/bin/${cmd}`);
+  });
+
+  it.each([
+    "resolveInstalledClaudeBinary",
+    "resolveInstalledCodexBinary",
+    "resolveInstalledGeminiBinary",
+  ])("%s includes /opt/homebrew/bin (Homebrew on Apple Silicon)", (name) => {
+    const fn = sliceFn(name);
+    const cmd = name
+      .replace("resolveInstalled", "")
+      .replace("Binary", "")
+      .toLowerCase();
+    expect(fn).toContain(`/opt/homebrew/bin/${cmd}`);
+  });
+});
+
+describe("#1665 — Windows resolver paths cover MSI + user prefix", () => {
+  it.each([
+    "resolveInstalledClaudeBinary",
+    "resolveInstalledCodexBinary",
+    "resolveInstalledGeminiBinary",
+  ])("%s reads ProgramFiles env for the system MSI install", (name) => {
+    const fn = sliceFn(name);
+    expect(fn).toContain('process.env.ProgramFiles');
+    expect(fn).toContain('"nodejs"');
+  });
+
+  it.each([
+    "resolveInstalledClaudeBinary",
+    "resolveInstalledCodexBinary",
+    "resolveInstalledGeminiBinary",
+  ])("%s includes <HOME>/.npm-global for explicit user prefix", (name) => {
+    const fn = sliceFn(name);
+    expect(fn).toContain('".npm-global"');
+  });
+});
+
+describe("#1665 — preference order preserved (regression guard)", () => {
+  it("Claude resolver still checks ~/.claude/bin BEFORE /usr/local/bin (native installer wins over system npm)", () => {
+    const fn = sliceFn("resolveInstalledClaudeBinary");
+    const claudeBinIdx = fn.indexOf('".claude"');
+    const usrLocalIdx = fn.indexOf("/usr/local/bin/claude");
+    expect(claudeBinIdx).toBeGreaterThan(0);
+    expect(usrLocalIdx).toBeGreaterThan(0);
+    expect(claudeBinIdx).toBeLessThan(usrLocalIdx);
+  });
+
+  it("Unix resolvers still check the embedded-prefix BEFORE /usr/local/bin (bundled wins over system)", () => {
+    for (const name of [
+      "resolveInstalledCodexBinary",
+      "resolveInstalledGeminiBinary",
+    ]) {
+      const fn = sliceFn(name);
+      const cmd = name
+        .replace("resolveInstalled", "")
+        .replace("Binary", "")
+        .toLowerCase();
+      const prefixIdx = fn.indexOf(`path.join(prefix, "bin", "${cmd}")`);
+      const usrLocalIdx = fn.indexOf(`/usr/local/bin/${cmd}`);
+      expect(prefixIdx).toBeGreaterThan(0);
+      expect(usrLocalIdx).toBeGreaterThan(0);
+      expect(prefixIdx).toBeLessThan(usrLocalIdx);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1665. CLI install resolvers checked too few locations. Verified user's codex was at `/usr/local/bin/codex` — the standard system npm prefix on Intel macOS and most Linux distros — and the resolver fell through to bare `"codex"`, which made the auto-updater (#1637) skip it as `outcome=skipped:unresolved`. Same gap on Windows (MSI Node installer puts npm globals at `C:\Program Files\nodejs\`, not covered).

## Verified, not guessed

- `which codex` → `/usr/local/bin/codex` (symlink to `/usr/local/lib/node_modules/@openai/codex/bin/codex.js`).
- That's the system npm `/usr/local` prefix — **not** Homebrew (would be `/opt/homebrew/bin` on ARM Macs or different `Cellar` symlink target).
- Console: `[cli-updater] cli=@openai/codex outcome=skipped:unresolved`.
- Both Windows and macOS/Linux are impacted by the same class of gap.

## What changed

All three resolvers (`resolveInstalledClaudeBinary`, `resolveInstalledCodexBinary`, `resolveInstalledGeminiBinary`) gain new candidate paths.

### Unix (added)
- `/usr/local/bin/<cmd>` — system npm, the verified miss.
- `/opt/homebrew/bin/<cmd>` — Homebrew on Apple Silicon.
- `/usr/bin/<cmd>` — apt/dnf/etc., last priority.

### Windows (added)
- `<ProgramFiles>\nodejs\<cmd>.cmd` — Node MSI default before npm prefix moved to APPDATA.
- `<ProgramFiles(x86)>\nodejs\<cmd>.cmd` — 32-bit MSI install.
- `<HOME>\.npm-global\<cmd>.cmd` — explicit user prefix via `.npmrc`.

### Preference order preserved
Bundled-runtime + native-installer paths stay FIRST. Same-channel preference per #1637's design — a broken system install must not shadow our working bundled one. The existing Gemini comment (`"check FIRST so a broken Homebrew install doesn't shadow our working bundled one"`) explains the rule; the tests now lock it in.

## Tests (critical-only per CLAUDE.md)

`tests/unit/agent-resolver-paths.test.ts` — source-text guards:
- All three resolvers include `/usr/local/bin/<cmd>` on Unix.
- All three resolvers include `/opt/homebrew/bin/<cmd>` on Unix.
- All three resolvers read `process.env.ProgramFiles` + `"nodejs"` on Windows.
- All three resolvers include `.npm-global` on Windows.
- Preference order: `~/.claude/bin` checked BEFORE `/usr/local/bin` for Claude (native > system); embedded prefix checked BEFORE `/usr/local/bin` for Codex + Gemini (bundled > system).

Why source-text over runtime: resolvers call `fs.existsSync` against the real filesystem. Mocking that or building a fixture is more brittle than directly asserting the structural rule.

## Test plan

- [x] `pnpm test` — 545/545 pass (14 new + 531 existing).
- [x] `cargo check` — clean.
- [ ] Manual on macOS: launch Seren, observe `[cli-updater] cli=@openai/codex outcome=skipped:ttl` (or `outcome=success`) — NOT `skipped:unresolved`.

## Out of scope

- Chocolatey / Scoop install paths — niche.
- `process.env.PATH` walking — broader change.
- nvm / fnm / volta version-manager paths — pick-one ambiguity.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
