### PR TITLE
fix(agent-registry): revert Gemini resolver expansion — keytar guardrail (#1665 follow-up)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -298,13 +298,32 @@ async function ensureClaudeCodeViaNativeInstaller(emit) {
  * can trigger ensureCli() to install via the embedded runtime's npm.
  */
 function resolveInstalledGeminiBinary() {
+  // IMPORTANT: Gemini intentionally does NOT include /usr/local/bin,
+  // /opt/homebrew/bin, /usr/bin (Unix), or C:\Program Files\nodejs\
+  // (Windows MSI) in its candidate list — even though Codex and Claude
+  // do post-#1665. The Homebrew gemini-cli formula (and other system
+  // installs that don't run npm scripts) skip the keytar postinstall, so
+  // a system-installed gemini binary cannot read its own keychain when
+  // spawned from a GUI app and fails first-run auth with a misleading
+  // "GEMINI_API_KEY environment variable" message (#1476).
+  //
+  // Mirroring the deliberate exclusion in `resolveGeminiBinary` at
+  // bin/browser-local/gemini-runtime.mjs:30. If install-detection here
+  // discovered a system Gemini, ensureCli() would return "available" and
+  // skip the bundled-runtime install where keytar IS run correctly. The
+  // spawn path (which intentionally still excludes the same locations)
+  // would then fall through to bare "gemini", PATH would resolve the
+  // broken system install, and auth would silently fail. Keep the
+  // bundled+user-local-only restriction here too.
+  //
+  // The auto-updater (#1637) returning skipped:unresolved for Gemini in
+  // this configuration is the intended outcome — we do not want to
+  // auto-update a binary we can't safely spawn. See #1665 PR for the
+  // full audit.
   if (process.platform === "win32") {
     const home = os.homedir();
     const appData = process.env.APPDATA ?? "";
     const nodeDir = path.dirname(process.execPath);
-    const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
-    const programFilesX86 =
-      process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
     const candidates = [
       // npm global install via embedded runtime's npm (prefix = node dir on Windows)
       path.join(nodeDir, "gemini.cmd"),
@@ -313,11 +332,6 @@ function resolveInstalledGeminiBinary() {
       ...(appData ? [path.join(appData, "npm", "gemini.cmd")] : []),
       // Generic install fallbacks
       path.join(home, ".local", "bin", "gemini.exe"),
-      // System-wide Node MSI install (default before npm prefix moved to APPDATA). #1665
-      path.join(programFiles, "nodejs", "gemini.cmd"),
-      path.join(programFilesX86, "nodejs", "gemini.cmd"),
-      // Explicit user prefix (`.npmrc` prefix=$HOME/.npm-global). #1665
-      path.join(home, ".npm-global", "gemini.cmd"),
     ];
     for (const candidate of candidates) {
       if (existsSync(candidate)) {
@@ -334,12 +348,6 @@ function resolveInstalledGeminiBinary() {
       path.join(prefix, "bin", "gemini"),
       // Generic user-local install fallbacks
       path.join(home, ".local", "bin", "gemini"),
-      // System npm prefix /usr/local (default on Intel macOS + most Linux distros). #1665
-      "/usr/local/bin/gemini",
-      // Homebrew on Apple Silicon. #1665
-      "/opt/homebrew/bin/gemini",
-      // Distro package managers (apt, dnf). Rare for npm globals; last. #1665
-      "/usr/bin/gemini",
     ];
     for (const candidate of candidates) {
       if (existsSync(candidate)) {

--- a/tests/unit/agent-resolver-paths.test.ts
+++ b/tests/unit/agent-resolver-paths.test.ts
@@ -23,11 +23,10 @@ function sliceFn(name: string): string {
   return registrySource.slice(start, end);
 }
 
-describe("#1665 — Unix resolver paths cover system npm + Homebrew", () => {
+describe("#1665 — Claude + Codex Unix resolvers cover system npm + Homebrew", () => {
   it.each([
     "resolveInstalledClaudeBinary",
     "resolveInstalledCodexBinary",
-    "resolveInstalledGeminiBinary",
   ])("%s includes /usr/local/bin (system npm prefix)", (name) => {
     const fn = sliceFn(name);
     const cmd = name
@@ -40,7 +39,6 @@ describe("#1665 — Unix resolver paths cover system npm + Homebrew", () => {
   it.each([
     "resolveInstalledClaudeBinary",
     "resolveInstalledCodexBinary",
-    "resolveInstalledGeminiBinary",
   ])("%s includes /opt/homebrew/bin (Homebrew on Apple Silicon)", (name) => {
     const fn = sliceFn(name);
     const cmd = name
@@ -51,28 +49,63 @@ describe("#1665 — Unix resolver paths cover system npm + Homebrew", () => {
   });
 });
 
-describe("#1665 — Windows resolver paths cover MSI + user prefix", () => {
+describe("#1665 — Claude + Codex Windows resolvers cover MSI + user prefix", () => {
   it.each([
     "resolveInstalledClaudeBinary",
     "resolveInstalledCodexBinary",
-    "resolveInstalledGeminiBinary",
   ])("%s reads ProgramFiles env for the system MSI install", (name) => {
     const fn = sliceFn(name);
-    expect(fn).toContain('process.env.ProgramFiles');
+    expect(fn).toContain("process.env.ProgramFiles");
     expect(fn).toContain('"nodejs"');
   });
 
   it.each([
     "resolveInstalledClaudeBinary",
     "resolveInstalledCodexBinary",
-    "resolveInstalledGeminiBinary",
   ])("%s includes <HOME>/.npm-global for explicit user prefix", (name) => {
     const fn = sliceFn(name);
     expect(fn).toContain('".npm-global"');
   });
 });
 
-describe("#1665 — preference order preserved (regression guard)", () => {
+describe("#1665 follow-up — Gemini resolver INTENTIONALLY excludes system + Homebrew paths (#1476 keytar)", () => {
+  // The Homebrew gemini-cli formula skips the keytar postinstall, so a
+  // system-installed gemini cannot read its own keychain when spawned from
+  // a GUI app and silently fails first-run auth. Mirroring the deliberate
+  // exclusion in resolveGeminiBinary at gemini-runtime.mjs.
+  it("does NOT include /usr/local/bin/gemini", () => {
+    const fn = sliceFn("resolveInstalledGeminiBinary");
+    expect(fn).not.toContain("/usr/local/bin/gemini");
+  });
+
+  it("does NOT include /opt/homebrew/bin/gemini", () => {
+    const fn = sliceFn("resolveInstalledGeminiBinary");
+    expect(fn).not.toContain("/opt/homebrew/bin/gemini");
+  });
+
+  it("does NOT include /usr/bin/gemini", () => {
+    const fn = sliceFn("resolveInstalledGeminiBinary");
+    expect(fn).not.toContain("/usr/bin/gemini");
+  });
+
+  it("does NOT read ProgramFiles\\nodejs (Windows MSI install)", () => {
+    const fn = sliceFn("resolveInstalledGeminiBinary");
+    expect(fn).not.toContain("process.env.ProgramFiles");
+  });
+
+  it("does NOT include <HOME>\\.npm-global on Windows", () => {
+    const fn = sliceFn("resolveInstalledGeminiBinary");
+    expect(fn).not.toContain('".npm-global"');
+  });
+
+  it("DOES include the bundled-runtime prefix and ~/.local/bin (the safe channels)", () => {
+    const fn = sliceFn("resolveInstalledGeminiBinary");
+    expect(fn).toContain('path.join(prefix, "bin", "gemini")');
+    expect(fn).toContain('path.join(home, ".local", "bin", "gemini")');
+  });
+});
+
+describe("#1665 — preference order preserved for Claude + Codex (regression guard)", () => {
   it("Claude resolver still checks ~/.claude/bin BEFORE /usr/local/bin (native installer wins over system npm)", () => {
     const fn = sliceFn("resolveInstalledClaudeBinary");
     const claudeBinIdx = fn.indexOf('".claude"');
@@ -82,21 +115,12 @@ describe("#1665 — preference order preserved (regression guard)", () => {
     expect(claudeBinIdx).toBeLessThan(usrLocalIdx);
   });
 
-  it("Unix resolvers still check the embedded-prefix BEFORE /usr/local/bin (bundled wins over system)", () => {
-    for (const name of [
-      "resolveInstalledCodexBinary",
-      "resolveInstalledGeminiBinary",
-    ]) {
-      const fn = sliceFn(name);
-      const cmd = name
-        .replace("resolveInstalled", "")
-        .replace("Binary", "")
-        .toLowerCase();
-      const prefixIdx = fn.indexOf(`path.join(prefix, "bin", "${cmd}")`);
-      const usrLocalIdx = fn.indexOf(`/usr/local/bin/${cmd}`);
-      expect(prefixIdx).toBeGreaterThan(0);
-      expect(usrLocalIdx).toBeGreaterThan(0);
-      expect(prefixIdx).toBeLessThan(usrLocalIdx);
-    }
+  it("Codex resolver still checks the embedded-prefix BEFORE /usr/local/bin (bundled wins over system)", () => {
+    const fn = sliceFn("resolveInstalledCodexBinary");
+    const prefixIdx = fn.indexOf('path.join(prefix, "bin", "codex")');
+    const usrLocalIdx = fn.indexOf("/usr/local/bin/codex");
+    expect(prefixIdx).toBeGreaterThan(0);
+    expect(usrLocalIdx).toBeGreaterThan(0);
+    expect(prefixIdx).toBeLessThan(usrLocalIdx);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1665 / [#1666](https://github.com/serenorg/seren-desktop/pull/1666). Reverts the **Gemini-specific** path additions while leaving Codex and Claude additions in place.

The Gemini additions bypassed a deliberate guardrail in [`gemini-runtime.mjs:15-29`](bin/browser-local/gemini-runtime.mjs#L15-L29):

> *"IMPORTANT: prefer the embedded-runtime npm install path over ANY system install. The Homebrew gemini-cli formula skips the keytar postinstall, so a Homebrew binary on PATH cannot read its own keychain when spawned from a GUI app and fails with `GEMINI_API_KEY environment variable` (#1476). Falling back to a Homebrew install would silently break first-run auth."*

I missed this comment when making #1665. The result was: install-detection finding `/usr/local/bin/gemini` → `ensureCli` returns "available" → bundled install skipped → spawn-side resolver still excludes system paths (correctly) → falls through to bare `"gemini"` → PATH resolves broken Homebrew install → auth silently fails.

## Why Codex and Claude additions are kept

| CLI | Spawn-side resolver | Keytar issue | #1665 status |
|---|---|---|---|
| Codex | Same as install-detection (single resolver) | No | ✅ Keep additions |
| Claude | Separate, with `which claude` PATH fallback | No | ✅ Keep additions — spawn safety net catches `/usr/local/bin/claude` |
| Gemini | Separate, **intentionally excludes system paths**, no PATH fallback | **Yes (#1476)** | ❌ Revert additions — keep guardrail intact |

## What changed

- `resolveInstalledGeminiBinary`: removed `/usr/local/bin/gemini`, `/opt/homebrew/bin/gemini`, `/usr/bin/gemini` (Unix); removed `ProgramFiles\nodejs\gemini.cmd`, `ProgramFiles(x86)\nodejs\gemini.cmd`, `.npm-global\gemini.cmd` (Windows).
- Added a prominent block comment at the top of `resolveInstalledGeminiBinary` referencing #1476 + the parallel restriction in `gemini-runtime.mjs`, so a future edit doesn't re-introduce this same regression.
- Codex + Claude additions: unchanged.

## Tests (critical-only per CLAUDE.md)

`tests/unit/agent-resolver-paths.test.ts`:
- Updated path-presence assertions: Claude + Codex still asserted to include `/usr/local/bin/<cmd>`, `/opt/homebrew/bin/<cmd>`, `ProgramFiles\nodejs`, `.npm-global`.
- New `#1665 follow-up` describe block asserts Gemini resolver does **NOT** include any of: `/usr/local/bin/gemini`, `/opt/homebrew/bin/gemini`, `/usr/bin/gemini`, `process.env.ProgramFiles`, `.npm-global`.
- Positive guard: Gemini DOES still include the bundled prefix + `~/.local/bin` (the safe channels).
- Preference-order tests split: Claude + Codex retain bundled-before-system; Gemini test removed (no system entries to order against).

## Test plan

- [x] `pnpm test` — 547/547 pass.
- [x] `cargo check` — clean.

## Acceptance

- [ ] Gemini auto-updater shows `outcome=skipped:unresolved` when no bundled install exists (intended — we do not auto-update a binary we can't safely spawn).
- [ ] Codex + Claude continue to discover system-npm installs (unchanged from #1665).
- [ ] No regression in #1476 first-run Gemini auth.

## Related

- #1665 — original ticket; this is the documented follow-up.
- #1476 — Homebrew gemini-cli keytar postinstall bug that motivates the exclusion.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
