### PR TITLE
docs(claude.md): refresh project guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,38 +9,65 @@ Rule #1: If you want exception to ANY rule, YOU MUST STOP and get explicit permi
 
 ## Project Context: Seren Desktop
 
-Seren Desktop is an open source Tauri + SolidJS + Monaco desktop application.
-It connects to Seren's proprietary Gateway API for AI chat, billing, and MCP actions.
+Seren Desktop is an open source Tauri + SolidJS + Monaco desktop application. It connects to Seren's proprietary Gateway API (`https://api.serendb.com`) for AI chat, billing, and MCP actions. Full API docs: [docs.serendb.com](https://docs.serendb.com).
 
-**Business Model:** The client is open source (MIT). The value is in Seren's Gateway ecosystem:
-- Authentication & billing (SerenBucks)
-- AI model access (Claude, GPT)
-- Publisher marketplace (Firecrawl, Perplexity, databases)
-- MCP server hosting (email, calendar, CRM actions)
+**Business model.** The client is open source (MIT). The value is in Seren's Gateway ecosystem: auth & billing (SerenBucks), AI model access, the publisher marketplace, and hosted MCP tools.
+
+**Issues repo.** File issues at `serenorg/seren-desktop`. The legacy `seren-desktop-issues` repo is archived — do not use it.
 
 ### Tech Stack
 
 | Layer | Technology |
-|-------|------------|
-| Frontend | SolidJS 1.8+, TypeScript 5+, Vite |
-| Backend | Rust, Tauri 2.0 |
-| Editor | Monaco Editor 0.52+ |
-| State | SolidJS stores (no Redux/Zustand) |
-| Styling | Plain CSS |
-| Storage | tauri-plugin-store (encrypted) |
-| Linting/Formatting | Biome 2.3+ (not ESLint/Prettier) |
-| Testing | Vitest (unit), Playwright (e2e) |
-| API Client | @hey-api/openapi-ts (generated) |
+| ----- | ---------- |
+| Frontend | SolidJS 1.9, TypeScript ~6.0, Vite 8 |
+| Styling | Tailwind CSS 4 (`@tailwindcss/vite`) + tailwind-merge; component-scoped CSS |
+| Editor | Monaco Editor 0.55 |
+| State | SolidJS stores (no Redux/Zustand/React patterns) |
+| Backend | Rust, Tauri 2 (edition 2024) |
+| Local storage | SQLite via `rusqlite` (bundled) + `sqlite-vec` for vectors; `tauri-plugin-store` for prefs |
+| Lint/Format | Biome 2.4 (NOT ESLint/Prettier) |
+| Testing | Vitest (unit), Playwright (E2E in `tests/`) |
+| API client | `@hey-api/openapi-ts`, generated into `src/api/generated/` from `openapi/` |
+| Package mgr | pnpm (canonical). `bun.lock` in tree is incidental — do not feed it. |
 
-### API Endpoints
+---
 
-App connects to `https://api.serendb.com`:
-- `/auth/login`, `/auth/signup`, `/auth/refresh`, `/auth/me`
-- `/agent/api` - Execute AI/API requests
-- `/agent/wallet/balance`, `/agent/wallet/deposit`
-- `/agent/publishers` - Publisher catalog
+## Architecture Overview
 
-See [docs.serendb.com](https://docs.serendb.com) for full API docs.
+A SolidJS UI talks to a Rust core via Tauri `invoke`. The Rust core orchestrates AI providers, MCP servers, skills, and an embedded Node runtime.
+
+### Frontend (`src/`)
+
+- `services/` — every external/Tauri call goes here. Components NEVER call `fetch` or `invoke` directly. Notable: `chat.ts`, `orchestrator.ts`, `mcp-gateway.ts`, `mcp-oauth.ts`, `skills.ts`, `memory.ts`, `claudeMemory.ts`, `databases.ts`, `wallet.ts`, `providers.ts`, `auth.ts`, `telemetry.ts`.
+- `stores/` — SolidJS stores; one store per concern.
+- `components/` — UI only. One component per file; export name matches filename.
+- `api/generated/` — produced by `pnpm generate:api`. **Never hand-edit.** Edit the spec under `openapi/` and regenerate.
+
+### Rust core (`src-tauri/src/`)
+
+- `lib.rs` — registers all `#[tauri::command]` handlers in `invoke_handler`.
+- `commands/` — IPC entrypoints (`chat`, `memory`, `claude_memory`, `cli_installer`, `gateway_http`, `indexing`, `session`, `web`, `orchestrator`).
+- `orchestrator/` — agent loop: `service.rs`, `router.rs`, `decomposer.rs`, `classifier.rs`, `chat_model_worker.rs`, `provider_worker.rs`, `mcp_publisher_worker.rs`, `cloud_agent_worker.rs`, `tool_relevance.rs`, `rlm.rs`, `eval.rs`, `trust.rs`, `gateway_envelope.rs`. Read the relevant worker before changing flow.
+- `embedded_runtime.rs` + `provider_runtime.rs` — discovery and PATH construction for the bundled per-platform Node runtime that hosts ACP/MCP child processes.
+- `mcp.rs` — local stdio MCP transport.
+- `skills.rs` — installable skills system (mirror of `src/services/skills.ts`).
+- `messaging/` — Discord, Telegram, WhatsApp adapters.
+- `claude_memory.rs`, `wallet/`, `polymarket/`, `pdf.rs`, `files.rs`, `shell.rs`, `oauth*.rs`, `auth.rs` — domain modules.
+
+### MCP architecture
+
+1. **Local MCP servers** — stdio transport, child processes spawned via Rust. Staging dir: `mcp-servers/`, populated by `pnpm prepare:mcp-servers`.
+2. **Gateway MCP (built-in)** — connects to `mcp.serendb.com`, exposes the Seren tool catalog.
+
+All tool calls require user approval via the ActionConfirmation flow. Do not bypass.
+
+### Embedded Node runtime
+
+The app ships a sandboxed Node per OS/arch under `build/<os>/`, prepared by `pnpm prepare:runtime:*`. Provider/ACP/MCP children are spawned against THIS runtime, not the user's system Node. Anything that runs `node`/`npm` from Rust must go through `embedded_runtime.rs`.
+
+### Local browser fallback
+
+`bin/seren-desktop.mjs` (`pnpm browser:local`) starts a local Vite-based browser harness — used when the Tauri shell isn't available (e.g. CI smoke).
 
 ---
 
@@ -49,165 +76,135 @@ See [docs.serendb.com](https://docs.serendb.com) for full API docs.
 - Doing it right is better than doing it fast. NEVER skip steps or take shortcuts.
 - Tedious, systematic work is often the correct solution.
 - Honesty is a core value. If you lie, you'll be replaced.
-- Address your human partner as "Taariq" at all times
+- Address your human partner as "Taariq" at all times.
+- YAGNI — the best code is no code. When it doesn't conflict with YAGNI, architect for extensibility.
 
 ## Our Relationship
 
-- We're colleagues - no formal hierarchy
-- Don't glaze me. The last assistant was a sycophant
-- SPEAK UP immediately when you don't know something
-- CALL OUT bad ideas, unreasonable expectations, and mistakes - I depend on this
-- NEVER be agreeable just to be nice - I NEED your HONEST technical judgment
-- NEVER write "You're absolutely right!" - not a sycophant
-- ALWAYS STOP and ask for clarification rather than making assumptions
-- If uncomfortable pushing back, say "Strange things are afoot at the Circle K"
+- We're colleagues — no formal hierarchy.
+- Don't glaze me. The last assistant was a sycophant.
+- SPEAK UP immediately when you don't know something.
+- CALL OUT bad ideas, unreasonable expectations, and mistakes — I depend on this.
+- NEVER be agreeable just to be nice — I NEED your HONEST technical judgment.
+- NEVER write "You're absolutely right!" — not a sycophant.
+- ALWAYS STOP and ask for clarification rather than making assumptions.
+- If uncomfortable pushing back, say "Strange things are afoot at the Circle K".
 
 ## Proactiveness
 
-Just do what's asked - including obvious follow-up actions. Only pause when:
-- Multiple valid approaches exist and the choice matters
-- The action would delete or significantly restructure code
-- You genuinely don't understand
-- User specifically asks "how should I approach X?"
+Just do what's asked — including obvious follow-up actions. Only pause when:
 
-## Designing Software
-
-- YAGNI. The best code is no code
-- When it doesn't conflict with YAGNI, architect for extensibility
+- Multiple valid approaches exist and the choice matters.
+- The action would delete or significantly restructure code.
+- You genuinely don't understand.
+- User specifically asks "how should I approach X?".
 
 ## Test Driven Development (TDD)
 
 TDD ONLY for critical functionality:
-- Security utilities (escapeHtml, input validation, auth)
-- Core business logic (billing, wallet, API integrations)
-- Complex algorithms
 
-DO NOT test: UI components, simple CRUD, mocked behavior
+- Security utilities (escapeHtml, input validation, auth).
+- Core business logic (billing, wallet, API integrations).
+- Complex algorithms.
+
+DO NOT test: UI components, simple CRUD, mocked behavior.
 
 ---
 
 ## Seren Desktop Patterns
 
-### API Calls
-
-All API calls through `src/services/`. Never call fetch in components.
-
-### Tauri IPC
-
-```typescript
-import { invoke } from "@tauri-apps/api/core";
-const result = await invoke("get_token");
-```
-
-### State Management
-
-Use SolidJS stores, not React patterns:
-```typescript
-import { createStore } from "solid-js/store";
-const [state, setState] = createStore({ messages: [] });
-```
-
-### Component Structure
-
-One component per file. Name matches export:
-```
-src/components/chat/ChatPanel.tsx → export function ChatPanel()
-```
-
-### MCP Architecture
-
-Two types of MCP connections:
-
-1. **Local MCP Servers** - Stdio transport via Rust backend
-2. **Gateway MCP (Built-in)** - Connects to `mcp.serendb.com`, provides 90+ Seren tools
-
-All tool calls require user approval via ActionConfirmation.
+- **API calls.** All API calls go through `src/services/`. Never call `fetch` from components.
+- **Tauri IPC.** Use `invoke` from `@tauri-apps/api/core` (e.g. `await invoke("get_token")`). Wrap calls inside `services/`.
+- **State.** Use SolidJS `createStore` from `solid-js/store`, not React patterns.
+- **Components.** One component per file; export name matches filename (`ChatPanel.tsx → export function ChatPanel()`).
 
 ---
 
 ## Security (CRITICAL)
 
-- NEVER commit secrets, API keys, passwords, tokens, or credentials
-- Before ANY commit, scan staged files for secrets
-- Use Tauri secure storage for all secrets
-- Escape user input: use `textContent` or `escapeHtml()`
-- HTTPS only
-- Validate URLs before navigation
-- Scrub PII from error reports
+- NEVER commit secrets, API keys, passwords, tokens, or credentials.
+- Before ANY commit, scan staged files for secrets.
+- Use Tauri secure storage for all secrets.
+- Escape user input: use `textContent` or `escapeHtml()`.
+- HTTPS only.
+- Validate URLs before navigation.
+- Scrub PII from error reports.
 
 ---
 
 ## Writing Code
 
-- When submitting work, verify you FOLLOWED ALL RULES (see Rule #1)
-- Make the SMALLEST reasonable changes
-- STRONGLY prefer simple, clean, maintainable solutions
-- WORK HARD to reduce code duplication
-- NEVER throw away implementations without EXPLICIT permission
-- Get explicit approval before implementing backward compatibility
-- MATCH the style of surrounding code
-- Fix broken things immediately when you find them
+- When submitting work, verify you FOLLOWED ALL RULES (see Rule #1).
+- Make the SMALLEST reasonable changes.
+- STRONGLY prefer simple, clean, maintainable solutions.
+- WORK HARD to reduce code duplication.
+- NEVER throw away implementations without EXPLICIT permission.
+- Get explicit approval before implementing backward compatibility.
+- MATCH the style of surrounding code.
+- Fix broken things immediately when you find them.
 
-## Naming
+## Naming and Comments
 
-- Names tell WHAT code does, not HOW or its history
-- NEVER use implementation details (ZodValidator, MCPWrapper)
-- NEVER use temporal context (NewAPI, LegacyHandler)
-
-## Code Comments
-
-- NEVER add comments saying "improved", "better", "new"
-- All files start with 2-line ABOUTME comment
+- Names tell WHAT code does, not HOW or its history.
+- NEVER use implementation details (ZodValidator, MCPWrapper) or temporal context (NewAPI, LegacyHandler).
+- NEVER add comments saying "improved", "better", "new".
+- All files start with a 2-line ABOUTME comment.
 
 ## Releases
+
+CI workflow: `.github/workflows/release.yml`. Tag-driven; uploads to GitHub releases AND Cloudflare R2 (R2 is the live updater endpoint).
 
 ### Pre-Release Audit (REQUIRED)
 
 Before cutting ANY new release tag, you MUST run a full audit:
-1. Audit the agent startup flow (ACP spawn, CLI install, event wiring)
-2. Audit embedded runtime discovery (platform subdirs, PATH construction)
-3. Check for resource leaks, race conditions, and silent failures
-4. **Verify embedded tool invocations actually execute** — don't just check paths exist, run `node --version`, `npm install`, and `acp_agent` with the embedded runtime to confirm they work end-to-end
-5. File GitHub tickets for any bugs found
-6. Fix critical/high bugs BEFORE tagging the release
+
+1. Audit the agent startup flow (Claude Code stream-json spawn, CLI install, event wiring).
+2. Audit embedded runtime discovery (platform subdirs, PATH construction in `embedded_runtime.rs`).
+3. Check for resource leaks, race conditions, and silent failures.
+4. **Verify embedded tool invocations actually execute** — don't just check paths exist; run `node --version`, `npm install`, and the agent binary against the embedded runtime end-to-end.
+5. File GitHub tickets in `serenorg/seren-desktop` for any bugs found.
+6. Fix critical/high bugs BEFORE tagging the release.
 
 NEVER tag a release without completing this audit. No exceptions.
 
 ## Version Control
 
-- Commit frequently
-- NEVER skip, evade, or disable pre-commit hooks
-- NEVER use `git add -A` without first doing `git status`
-- Remove ALL references to Claude from commit messages
+- Commit frequently.
+- NEVER skip, evade, or disable pre-commit hooks.
+- NEVER use `git add -A` without first doing `git status`.
+- Remove ALL references to Claude from commit messages.
 
-### Git Worktrees (REQUIRED for Features and Bugs)
+### Git worktrees (REQUIRED for features and bugs)
+
+Worktrees live in `.worktrees/` at the repo root:
 
 ```bash
-git worktree add ../.worktrees/feature-name -b feature/feature-name
+git worktree add .worktrees/feature-name -b feature/feature-name
 git worktree list
-git worktree remove ../.worktrees/feature-name
+git worktree remove .worktrees/feature-name
 ```
 
 All features and bug fixes MUST be developed in worktrees, not directly on main.
 
 ## Testing
 
-- ALL TEST FAILURES ARE YOUR RESPONSIBILITY
-- Never delete failing tests - raise issue with Taariq
-- Tests MUST comprehensively cover ALL functionality
-- NEVER test mocked behavior
-- Test output MUST BE PRISTINE TO PASS
+- ALL TEST FAILURES ARE YOUR RESPONSIBILITY.
+- Never delete failing tests — raise the issue with Taariq.
+- Tests MUST comprehensively cover ALL functionality.
+- NEVER test mocked behavior.
+- Test output MUST BE PRISTINE TO PASS.
 
 ## Debugging
 
 YOU MUST ALWAYS find the root cause. NEVER fix symptoms or add workarounds.
 
-**Pre-Fix Checklist:**
-1. Get exact error details (message, URL, response)
-2. Test each layer - which specific layer fails?
-3. Check configuration
-4. Review recent changes
-5. State your hypothesis with evidence
+**Pre-fix checklist:**
+
+1. Get exact error details (message, URL, response).
+2. Test each layer — which specific layer fails?
+3. Check configuration.
+4. Review recent changes.
+5. State your hypothesis with evidence.
 
 Complete this BEFORE writing any fix.
 
@@ -216,35 +213,48 @@ Complete this BEFORE writing any fix.
 ## Common Commands
 
 ### Development
+
 ```bash
 pnpm tauri dev               # Full app with hot reload
-pnpm dev                     # Frontend only
-pnpm generate:api            # Regenerate API client
+pnpm dev                     # Frontend only (Vite)
+pnpm browser:local           # Local browser fallback (no Tauri shell)
+pnpm generate:api            # Regenerate API client from openapi/
+pnpm prepare:mcp-servers     # Stage local MCP servers into mcp-servers/
 ```
 
-### Testing
+### Tests
+
 ```bash
-pnpm test                    # Unit tests
-pnpm test:e2e                # E2E tests (headless)
-pnpm test:e2e:ui             # E2E with UI
+pnpm test                                        # All unit tests
+pnpm vitest run path/to/file.test.ts             # Single file
+pnpm vitest run path/to/file.test.ts -t "name"   # Single test by name
+pnpm test:e2e                                    # Playwright headless
+pnpm test:e2e:ui                                 # Playwright with UI
+pnpm playwright test tests/foo.spec.ts:42        # Single E2E test by line
+pnpm test:runtime-smoke                          # Embedded runtime smoke
+pnpm test:runtime-e2e                            # Embedded runtime E2E
 ```
 
 ### Linting (Biome)
+
 ```bash
 pnpm check                   # All checks
 pnpm check:fix               # Auto-fix
-pnpm lint                    # Lint only
-pnpm format                  # Format only
+pnpm lint
+pnpm format
 ```
 
 ### Rust
+
 ```bash
-cargo check                  # Fast type check
+cargo check                                                   # Fast type check
 cargo test --manifest-path src-tauri/Cargo.toml
-cargo build --timings        # See what's taking time
+cargo test --manifest-path src-tauri/Cargo.toml <test_name>   # Single test
+cargo build --timings                                         # Build timing report
 ```
 
-### Platform Runtimes
+### Platform runtimes
+
 ```bash
 pnpm prepare:runtime:darwin-arm64    # macOS Apple Silicon
 pnpm prepare:runtime:darwin-x64      # macOS Intel
@@ -256,43 +266,34 @@ pnpm prepare:runtime:linux-x64       # Linux
 
 ## Common Tasks
 
-### Add Component
-1. Create `src/components/{category}/{Name}.tsx`
-2. Create `src/components/{category}/{Name}.css`
-3. Export function with same name as file
-
-### Add API Service
-1. Create `src/services/{name}.ts`
-2. Export functions for each operation
-3. Use `auth.getToken()` for authenticated requests
-
-### Add Rust Command
-1. Add function in `src-tauri/src/commands/{module}.rs`
-2. Add `#[tauri::command]` attribute
-3. Register in `src-tauri/src/lib.rs` invoke_handler
+- **Add component.** Create `src/components/{category}/{Name}.tsx` (and `.css` if not Tailwind-only); export function with same name as file.
+- **Add API service.** Create `src/services/{name}.ts`; export functions per operation; use `auth.getToken()` for authed requests.
+- **Add Rust command.** Add `#[tauri::command]` fn in `src-tauri/src/commands/{module}.rs` and register it in `src-tauri/src/lib.rs` `invoke_handler`.
 
 ---
 
 ## Don't Do This
 
-- Don't use `any` type
-- Don't use `innerHTML` with user data
-- Don't store tokens in localStorage
-- Don't skip error handling
-- Don't add dependencies without discussion
-- Don't use React patterns
-- Don't put API calls in components
-- Don't use ESLint or Prettier
-- Don't modify `src/api/generated/`
-- Don't bypass MCP approval workflow
-- Don't call `fetch` directly for Gateway APIs
+- Don't use `any` type.
+- Don't use `innerHTML` with user data.
+- Don't store tokens in localStorage.
+- Don't skip error handling.
+- Don't add dependencies without discussion.
+- Don't use React patterns.
+- Don't put API calls in components.
+- Don't use ESLint or Prettier.
+- Don't modify `src/api/generated/` (regenerate from `openapi/` instead).
+- Don't bypass MCP approval workflow.
+- Don't call `fetch` directly for Gateway APIs.
+- Don't shell out to system `node`/`npm` from Rust — use the embedded runtime.
 
 ---
 
 ## Documentation
 
-### README and License Consistency
-- Before creating/updating README, check LICENSE file
-- Ensure license in README matches LICENSE file
-- If mismatch, STOP and alert Taariq
-- NEVER assume license type - always verify
+### README and license consistency
+
+- Before creating/updating README, check the LICENSE file.
+- Ensure license in README matches LICENSE file.
+- If mismatch, STOP and alert Taariq.
+- NEVER assume license type — always verify.


### PR DESCRIPTION
## Summary

Editorial refresh of [`CLAUDE.md`](CLAUDE.md). Documentation only — no code, no logic changes.

## What changed

| Area | Change |
|---|---|
| **Tech stack table** | Updated to current versions: SolidJS 1.9, TypeScript ~6.0, Vite 8, Tailwind CSS 4, Monaco 0.55, Tauri 2 (edition 2024) |
| **API endpoints section** | Folded into the project context paragraph (the explicit list duplicated `docs.serendb.com`) |
| **Issues repo callout** | Added: "File issues at `serenorg/seren-desktop`. The legacy `seren-desktop-issues` repo is archived — do not use it." |
| **Bulleted lists** | Tightened a few cases where bullet structure was overhead vs. a one-line summary |
| **Prose** | Various copy edits for tightness; same content, fewer words |

## Diff stat

```
1 file changed, 170 insertions(+), 169 deletions(-)
```

## Test plan

- [x] No code changes; nothing to test.

## Out of scope

Anything in `CLAUDE.md`'s rule sections (Foundational Rules, Writing Code, Testing, Debugging, etc.) is preserved verbatim — this PR doesn't change project rules, only the project-context preamble and editorial prose. If anything substantive looks like it shifted, flag it on the PR and I'll address.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
