### PR TITLE
fix(status-bar): use active agent's display name, not hardcoded 'Codex:' (#1669)

### DIFF
--- a/src/components/common/StatusBar.tsx
+++ b/src/components/common/StatusBar.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Displays status messages, MCP state, autocomplete status, and connection state.
 
 import { type Component, createMemo } from "solid-js";
-import { agentStore } from "@/stores/agent.store";
+import { agentDisplayName, agentStore } from "@/stores/agent.store";
 import { autocompleteStore } from "@/stores/autocomplete.store";
 import { AutocompleteStatus } from "./AutocompleteStatus";
 import { McpStatusIndicator } from "./McpStatusIndicator";
@@ -24,7 +24,11 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
           ),
       )
       .at(-1);
-    return running ? `Codex: ${running.content}` : "Working...";
+    if (!running) return "Working...";
+    // Use the active agent's display name — pre-#1669 this was hardcoded
+    // "Codex:" regardless of agent, which surfaced as "Codex: <bash command>"
+    // in Claude Code and Gemini threads too.
+    return `${agentDisplayName(session.info.agentType)}: ${running.content}`;
   });
 
   return (

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -527,7 +527,7 @@ export interface ActiveSession {
 
 const FORK_BOOTSTRAP_MAX_MSG_CHARS = 2_000;
 
-function agentDisplayName(agentType?: string): string {
+export function agentDisplayName(agentType?: string): string {
   switch (agentType) {
     case "codex":
       return "Codex";

--- a/tests/unit/status-bar-prefix.test.ts
+++ b/tests/unit/status-bar-prefix.test.ts
@@ -1,0 +1,31 @@
+// ABOUTME: Regression guard for #1669 — StatusBar must NOT hardcode "Codex:" as the running tool prefix.
+// ABOUTME: The prefix has to come from the active agent's display name so Claude/Gemini threads don't show "Codex:".
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const statusBarSource = readFileSync(
+  resolve("src/components/common/StatusBar.tsx"),
+  "utf-8",
+);
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1669 — StatusBar agent prefix", () => {
+  it('does NOT hardcode "Codex: " as the running tool prefix', () => {
+    expect(statusBarSource).not.toContain("`Codex: ${");
+    expect(statusBarSource).not.toMatch(/["']Codex: ["']/);
+  });
+
+  it("derives the prefix from agentDisplayName so Claude / Codex / Gemini sessions all get the right label", () => {
+    expect(statusBarSource).toContain("agentDisplayName");
+    expect(statusBarSource).toContain("session.info.agentType");
+  });
+
+  it("agentDisplayName is exported from agent.store so StatusBar can import it", () => {
+    expect(agentStoreSource).toContain("export function agentDisplayName");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1669. The bottom-of-app status bar hardcoded `Codex: ` as the prefix for the active session's running tool call, regardless of which agent was actually running. Single-agent residue from before Codex / Claude Code / Gemini all coexisted.

User screenshot caught it: Claude Code thread, a Bash tool running `find . -name "*.rs" ...`, status bar reports `Codex: cd /Users/.../Projects/Seren_Projects && find . ...`.

## Changes

- Export `agentDisplayName` from `src/stores/agent.store.ts` (was module-local).
- `src/components/common/StatusBar.tsx` derives the prefix from `session.info.agentType` via `agentDisplayName(...)`.

| agent | prefix |
|---|---|
| `claude-code` | `Claude Code: ` |
| `codex` | `Codex: ` |
| `gemini` | `Gemini: ` |
| (unknown) | `Agent: ` |

## Tests (critical-only per CLAUDE.md)

`tests/unit/status-bar-prefix.test.ts` — source-text guards:
- StatusBar does NOT hardcode `"Codex: "` (regression guard).
- StatusBar references `agentDisplayName` + `session.info.agentType`.
- `agentDisplayName` is exported from `agent.store`.

## Test plan

- [x] `pnpm test` — 550/550 pass.
- [ ] Manual: Claude Code thread → run a Bash tool → status bar reads `Claude Code: <command>`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
