### PR TITLE
fix(agent): stop sessionStatus from clobbering user-selected model (#1670)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -446,6 +446,12 @@ export interface ActiveSession {
   promptStartTime?: number;
   /** Currently selected model ID (if agent supports model selection) */
   currentModelId?: string;
+  /**
+   * Model ID of an in-flight setModel call, used to ignore stale
+   * sessionStatus frames whose models.currentModelId reflects pre-switch
+   * runtime state. Cleared once an event acknowledges the new value.
+   */
+  pendingModelId?: string;
   /** Available models reported by the agent */
   availableModels?: AgentModelInfo[];
   /** Currently selected mode ID (if agent supports mode selection) */
@@ -3635,9 +3641,10 @@ Structured summary:`;
     const sessionId = forSessionId ?? state.activeSessionId;
     if (!sessionId) return;
 
+    setState("sessions", sessionId, "pendingModelId", modelId);
+    setState("sessions", sessionId, "currentModelId", modelId);
     try {
       await providerService.setModel(sessionId, modelId);
-      setState("sessions", sessionId, "currentModelId", modelId);
       const session = state.sessions[sessionId];
       if (session) {
         void setAgentConversationModelIdDb(
@@ -4874,13 +4881,29 @@ Structured summary:`;
       }
     }
 
-    // Extract model state from session status events (e.g. ready with models)
+    // Extract model state from session status events (e.g. ready with models).
+    // Stale frames in flight at the moment of a user-initiated setModel still
+    // carry the pre-switch currentModelId — they must NOT clobber the new
+    // selection. While a pendingModelId is set, only accept events whose
+    // currentModelId matches the pending value (the runtime ack); otherwise
+    // hold. availableModels is always safe to update.
     if (data?.models) {
       const models = data.models as {
         currentModelId: string;
         availableModels: AgentModelInfo[];
       };
-      setState("sessions", sessionId, "currentModelId", models.currentModelId);
+      const pending = state.sessions[sessionId]?.pendingModelId;
+      if (!pending || pending === models.currentModelId) {
+        setState(
+          "sessions",
+          sessionId,
+          "currentModelId",
+          models.currentModelId,
+        );
+        if (pending) {
+          setState("sessions", sessionId, "pendingModelId", undefined);
+        }
+      }
       setState(
         "sessions",
         sessionId,

--- a/tests/unit/agent-model-clobber.test.ts
+++ b/tests/unit/agent-model-clobber.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Guards against a regression where stale sessionStatus frames clobber
+// ABOUTME: the user-selected model. See issue #1670.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("model selector clobber race (issue #1670)", () => {
+  it("declares pendingModelId on the session type", () => {
+    expect(agentStoreSource).toContain("pendingModelId?: string");
+  });
+
+  it("setModel writes pendingModelId before the IPC call", () => {
+    const setMarker = 'setState("sessions", sessionId, "pendingModelId", modelId)';
+    const ipcMarker = "await providerService.setModel(sessionId, modelId)";
+    const setIdx = agentStoreSource.indexOf(setMarker);
+    const ipcIdx = agentStoreSource.indexOf(ipcMarker);
+    expect(setIdx).toBeGreaterThan(-1);
+    expect(ipcIdx).toBeGreaterThan(-1);
+    expect(setIdx).toBeLessThan(ipcIdx);
+  });
+
+  it("sessionStatus handler guards currentModelId on pendingModelId", () => {
+    expect(agentStoreSource).toContain(
+      "const pending = state.sessions[sessionId]?.pendingModelId",
+    );
+    expect(agentStoreSource).toContain(
+      "if (!pending || pending === models.currentModelId)",
+    );
+  });
+
+  it("sessionStatus handler clears pendingModelId on ack", () => {
+    expect(agentStoreSource).toContain(
+      'setState("sessions", sessionId, "pendingModelId", undefined)',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #1670 — agent model selector reverts to the previous model after the user picks a new one.
- Adds a per-session `pendingModelId` guard so stale `sessionStatus` frames stop clobbering the user's selection.
- One critical regression test in the existing source-string style.

## Why this works

`agent.store.setModel` and the `sessionStatus` event handler were both unconditional writers to `session.currentModelId`. The runtime emits many `sessionStatus` frames per turn, and frames already in flight at the moment of selection still carry the pre-switch model id, overwriting the optimistic update.

After this PR:

- `setModel` records `pendingModelId` before the IPC call.
- The `sessionStatus` handler only accepts `models.currentModelId` while pending if it matches the pending value (the runtime ack). On match, pending clears.
- `availableModels` still updates unconditionally — it doesn't conflict with user choice.
- Initial seed (no `currentModelId` set, no pending) and externally-driven model changes (no pending) keep working.

## Test plan

- [x] `pnpm vitest run tests/unit/agent-model-clobber.test.ts` — new test, 4 assertions, passing.
- [x] `pnpm vitest run tests/unit/agent-session-events.test.ts` — sanity, still passing.
- [x] Biome — no new errors on changed files; pre-existing repo warnings only.
- [ ] Manual: select Opus 4.6 in the agent dropdown, run a multi-tool turn, confirm selection sticks across the burst of `sessionStatus` events.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
