### PR TITLE
fix(agent): predictive compaction must not block prompt-queue drain (#1673)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2752,7 +2752,18 @@ export const agentStore = {
       return "skipped_nothing_to_compact";
     }
 
-    setState("sessions", sessionId, "isCompacting", true);
+    // isCompacting signals "this serving session is being torn down and
+    // re-spawned" — it gates `sendPrompt` and the promptComplete drain so
+    // a queued prompt is not dispatched onto a dying session. Predictive
+    // mode warms a standby alongside a still-running serving session
+    // (#1631); flipping isCompacting on the serving session there makes
+    // the drain block at the bottom of promptComplete skip indefinitely
+    // and queued prompts get stuck (#1673). Predictive mode has its own
+    // gates (`predictiveCompactInFlight` per-session, `predictiveCompactBusy`
+    // module-level) — only the reactive branch should set isCompacting.
+    if (mode === "reactive") {
+      setState("sessions", sessionId, "isCompacting", true);
+    }
 
     // Hoisted for catch-handler access — the reactive path terminates the
     // old session, so recovery needs these if anything downstream throws. #1639.
@@ -2832,11 +2843,13 @@ Structured summary:`;
       if (mode === "predictive") {
         // Predictive path: spawn a STANDBY session alongside the live one.
         // No teardown, no UI side-effects — the next user submit promotes it.
+        // isCompacting is intentionally NOT set on the serving session here
+        // (#1673); concurrency is gated by `predictiveCompactInFlight` and
+        // the module-level `predictiveCompactBusy` mutex.
         const standbyId = await this.spawnSession(cwd, agentType, {
           role: "standby",
         });
         if (!standbyId) {
-          setState("sessions", sessionId, "isCompacting", false);
           throw new Error(
             "CompactionFailure: predictive standby spawn returned null",
           );
@@ -2848,7 +2861,6 @@ Structured summary:`;
         await providerService.sendPrompt(standbyId, seedPrompt);
         // promptComplete handler detects role==="standby" and sets
         // seedCompleted + releases predictiveCompactBusy.
-        setState("sessions", sessionId, "isCompacting", false);
         console.info(
           `[AgentStore] Predictive compaction: standby ${standbyId} seeding for serving ${sessionId}`,
         );
@@ -4182,10 +4194,15 @@ Structured summary:`;
 
         // Drain the prompt queue for this session. This runs in the store
         // regardless of which thread the UI is showing, so background threads
-        // don't stall. Guard against compaction — if the auto-compact block
-        // above fired, `isCompacting` is already true, the session will be
-        // terminated and re-spawned, and the queue will be transferred to
-        // the new session by compactAgentConversation (#1623).
+        // don't stall. Guard against reactive compaction only — if the
+        // auto-compact block above fired in reactive mode, `isCompacting`
+        // was set synchronously (before the first await in
+        // compactAgentConversation), the session is about to be terminated,
+        // and the queue will be transferred to the new session inside
+        // compactAgentConversation (#1623). Predictive compaction (#1631)
+        // does NOT set isCompacting on the serving session (#1673), so the
+        // guard correctly lets the drain proceed onto the still-running
+        // serving session.
         if (!isHistoryReplay && !state.sessions[sessionId]?.isCompacting) {
           const queue = state.sessions[sessionId]?.pendingPrompts ?? [];
           if (queue.length > 0) {

--- a/tests/unit/predictive-drain-not-blocked.test.ts
+++ b/tests/unit/predictive-drain-not-blocked.test.ts
@@ -1,0 +1,80 @@
+// ABOUTME: Regression guards for #1673 — predictive compaction must not flip
+// ABOUTME: isCompacting on the serving session and block the drain queue.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1673 — predictive compaction does not block drain", () => {
+  it("compactAgentConversation flips isCompacting=true only inside the reactive branch", () => {
+    // The buggy version had `setState("sessions", sessionId, "isCompacting", true)`
+    // unconditionally before the mode branch. The fix gates the flip on
+    // mode === "reactive". Predictive mode runs alongside the live serving
+    // session and must not signal teardown.
+    const fnStart = agentStoreSource.indexOf(
+      "async compactAgentConversation(",
+    );
+    expect(fnStart, "compactAgentConversation must exist").toBeGreaterThan(0);
+    const fnEnd = agentStoreSource.indexOf(
+      "async compactAndRetry(",
+      fnStart,
+    );
+    const fnBody = agentStoreSource.slice(fnStart, fnEnd);
+
+    // Exactly one true-flip on isCompacting in this function.
+    const flips = fnBody.match(
+      /setState\("sessions",\s*sessionId,\s*"isCompacting",\s*true\)/g,
+    );
+    expect(flips, "exactly one isCompacting=true flip").toHaveLength(1);
+
+    // That flip must be reactive-gated. We assert by string adjacency: the
+    // `if (mode === "reactive") {` opener must precede the flip with no
+    // intervening close-brace at the same scope.
+    const reactiveGateIdx = fnBody.indexOf('if (mode === "reactive")');
+    const flipIdx = fnBody.indexOf(
+      'setState("sessions", sessionId, "isCompacting", true)',
+    );
+    expect(reactiveGateIdx, "reactive gate must exist").toBeGreaterThan(0);
+    expect(flipIdx).toBeGreaterThan(reactiveGateIdx);
+
+    // The slice between gate and flip must contain only whitespace + "{".
+    const between = fnBody.slice(
+      reactiveGateIdx + 'if (mode === "reactive")'.length,
+      flipIdx,
+    );
+    expect(between.trim()).toBe("{");
+  });
+
+  it("predictive branch does not write isCompacting on the serving session", () => {
+    const branchStart = agentStoreSource.indexOf('if (mode === "predictive")');
+    expect(branchStart).toBeGreaterThan(0);
+    // Reactive branch follows immediately after the predictive block returns;
+    // capture the predictive body up to its `return "succeeded";`.
+    const branchEnd = agentStoreSource.indexOf(
+      'return "succeeded";',
+      branchStart,
+    );
+    expect(branchEnd).toBeGreaterThan(branchStart);
+    const branchBody = agentStoreSource.slice(branchStart, branchEnd);
+
+    expect(
+      branchBody,
+      "predictive branch must not flip isCompacting on the serving session",
+    ).not.toContain('"isCompacting"');
+  });
+
+  it("drain-guard comment in promptComplete documents the predictive carve-out", () => {
+    // The pre-#1673 comment claimed the guard was correct because compaction
+    // would always transfer the queue to the new session. That contract only
+    // holds for reactive mode. The updated comment must mention predictive
+    // mode explicitly so the next reader does not regress the design.
+    expect(agentStoreSource).toContain(
+      "Predictive compaction (#1631)\n        // does NOT set isCompacting on the serving session (#1673)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1673. Queued (typed-while-busy) prompts were getting stuck indefinitely after the in-flight prompt completed, whenever the serving session crossed the 70% predictive-compaction threshold. User had to manually re-send their typed message.

## Root cause

[`compactAgentConversation`](src/stores/agent.store.ts) flipped `isCompacting=true` on the serving session **unconditionally** before the mode branch:

```ts
setState("sessions", sessionId, "isCompacting", true);  // wrong for predictive
// …
if (mode === "predictive") { /* spawn standby alongside live serving */ }
```

That flip is correct for **reactive** mode (#1623): the serving session is torn down, the queue is transferred to the freshly-spawned new session inside `compactAgentConversation`, and the drain block at the bottom of `promptComplete` correctly skips. For **predictive** mode (#1631) the serving session keeps running and `pendingPrompts` is never transferred, so the drain skip is wrong — and because `isCompacting` is later cleared but nothing re-triggers the drain, the queue stays stuck.

## Fix

| Where | Change |
|---|---|
| [agent.store.ts](src/stores/agent.store.ts) compactAgentConversation | Gate `isCompacting=true` flip on `mode === "reactive"`. Predictive mode uses its own gates (`predictiveCompactInFlight`, `predictiveCompactBusy`). |
| Predictive branch | Remove now-redundant `isCompacting=false` writes (one in standby-spawn-failure, one on success). |
| Drain-guard comment | Updated to document the predictive carve-out so the design isn't regressed by future readers. |

## Tests (critical-only per CLAUDE.md)

`tests/unit/predictive-drain-not-blocked.test.ts` — source-text guards:
- exactly **one** `isCompacting=true` flip in `compactAgentConversation`, and it is **reactive-gated** (slice between gate and flip is just whitespace + `{`).
- predictive branch contains no writes to `isCompacting`.
- drain-guard comment documents the predictive carve-out.

## Test plan

- [x] `pnpm vitest run` — 557/557 pass (existing 554 + 3 new).
- [ ] Manual: long-running thread approaches 70% context, queue a prompt while the agent is busy, watch the queued prompt auto-drain after the in-flight prompt completes (predictive standby spawns alongside, drain proceeds onto serving session).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
