### PR TITLE
fix(agent): auto-compact at 85% must not flash the chatbox (#1675)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -141,6 +141,28 @@ async function waitForSessionIdle(
   }
 }
 
+/** Maximum time sendPrompt waits for a predictive standby's seed prompt to
+ * complete when the serving session is at critical context usage (#1675). */
+const STANDBY_SEED_WAIT_MS = 5_000;
+
+/** Wait for a standby session's seed prompt to complete (seedCompleted=true).
+ * Returns true if the seed finished within the timeout, false otherwise.
+ * Returns false immediately if the standby was removed (e.g. terminated).
+ * #1675. */
+async function waitForStandbySeed(
+  standbyId: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const standby = state.sessions[standbyId];
+    if (!standby) return false;
+    if (standby.seedCompleted === true) return true;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return state.sessions[standbyId]?.seedCompleted === true;
+}
+
 import { isLikelyAuthError } from "@/lib/auth-errors";
 import { buildChatRequest, sendProviderMessage } from "@/lib/providers";
 import {
@@ -3231,7 +3253,46 @@ Structured summary:`;
         return;
       }
       if (standby) {
-        // Standby not ready yet — cancel it; old serving handles this prompt.
+        // Standby not ready yet. When the serving session is at or above the
+        // auto-compact threshold (#1675), the next prompt is likely to overflow
+        // the model context — falling through to dispatch on the overloaded
+        // serving session would trigger compactAndRetry → reactive teardown →
+        // chatbox flash. Wait briefly for the seed to complete instead, then
+        // promote-and-dispatch on the standby. Below the threshold, retain the
+        // original "cancel and dispatch on serving" behaviour so a fast user
+        // is not held up unnecessarily.
+        const usagePct =
+          session.lastInputTokens && session.contextWindowSize
+            ? session.lastInputTokens / session.contextWindowSize
+            : 0;
+        const criticalThreshold =
+          settingsStore.settings.autoCompactThreshold / 100;
+        if (usagePct >= criticalThreshold) {
+          console.info(
+            `[AgentStore] Standby not ready at submit but context critical (${Math.round(
+              usagePct * 100,
+            )}%) — awaiting seed`,
+          );
+          const seeded = await waitForStandbySeed(
+            session.standbySessionId,
+            STANDBY_SEED_WAIT_MS,
+          );
+          if (seeded) {
+            console.info(
+              `[AgentStore] Promoting just-seeded standby ${session.standbySessionId}`,
+            );
+            await this.promoteStandbyAndDispatch(
+              sessionId!,
+              prompt,
+              context,
+              options,
+            );
+            return;
+          }
+          console.info(
+            `[AgentStore] Standby did not seed within ${STANDBY_SEED_WAIT_MS}ms — falling through to serving`,
+          );
+        }
         console.info(
           "[AgentStore] Standby not ready at submit; cancelling warm-up",
         );
@@ -4161,10 +4222,17 @@ Structured summary:`;
                 // just produced this promptComplete already succeeded, so we
                 // do NOT retry it — retrying would duplicate the turn. Queued
                 // prompts handled via pendingPrompts transfer inside compaction.
+                // Predictive mode (#1675): spawn a standby alongside the live
+                // serving session instead of tearing it down. The next user
+                // submit promotes the standby; the chatbox stays mounted so
+                // there is no flash. The standby-not-ready fallback in
+                // sendPrompt handles the race when the user submits before
+                // the seed completes.
                 this.compactAgentConversation(
                   sessionId,
                   settingsStore.settings.autoCompactPreserveMessages,
                   undefined,
+                  { mode: "predictive" },
                 );
               }
             }

--- a/tests/unit/auto-compact-predictive.test.ts
+++ b/tests/unit/auto-compact-predictive.test.ts
@@ -1,0 +1,113 @@
+// ABOUTME: Regression guards for #1675 — auto-compaction at the user-configured
+// ABOUTME: threshold must use predictive mode and must not flash the chatbox.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1675 — auto-compact-from-promptComplete uses predictive mode", () => {
+  it("passes { mode: \"predictive\" } so the chatbox stays mounted", () => {
+    // The flash regression: if this call defaults to reactive, terminateSession
+    // deletes the active session, hasSession() flips to false, and
+    // <Show when={hasSession()}> unmounts the input area until the new session
+    // registers. Predictive mode warms a standby alongside the live session
+    // and promotes it on the NEXT user submit — no teardown, no flash.
+    expect(agentStoreSource).toContain(
+      "settingsStore.settings.autoCompactPreserveMessages,\n                  undefined,\n                  { mode: \"predictive\" },",
+    );
+  });
+});
+
+describe("#1675 — compactAndRetry still uses reactive (failed-prompt retry)", () => {
+  it("does not pass mode:predictive to compactAndRetry's compactAgentConversation call", () => {
+    // compactAndRetry runs when a prompt has ALREADY failed (prompt_too_long)
+    // on a session that is now effectively dead. There is no live session to
+    // promote a standby onto — we MUST tear down and retry on a fresh session.
+    // This is the one path that legitimately needs reactive mode.
+    const fnStart = agentStoreSource.indexOf("async compactAndRetry(");
+    expect(fnStart, "compactAndRetry must exist").toBeGreaterThan(0);
+    const fnEnd = agentStoreSource.indexOf("\n  },", fnStart);
+    const fnBody = agentStoreSource.slice(fnStart, fnEnd);
+
+    // The compactAgentConversation call inside compactAndRetry should not
+    // mention predictive mode at all — defaults to reactive.
+    const callIdx = fnBody.indexOf("this.compactAgentConversation(");
+    expect(callIdx, "compactAndRetry must call compactAgentConversation").toBeGreaterThan(0);
+    const callBlock = fnBody.slice(callIdx, callIdx + 400);
+    expect(callBlock).not.toContain("predictive");
+    expect(callBlock).toContain("lastPrompt,");
+  });
+});
+
+describe("#1675 — sendPrompt awaits standby seed when context is critical", () => {
+  it("uses autoCompactThreshold to gate the bounded wait", () => {
+    // Without the gate, every standby-not-ready submit would block for up to
+    // STANDBY_SEED_WAIT_MS — terrible UX at low context (predictive 70%
+    // standby simply lost the race). The gate ensures the wait only runs when
+    // the next prompt is genuinely likely to overflow the serving session.
+    expect(agentStoreSource).toContain(
+      "settingsStore.settings.autoCompactThreshold / 100",
+    );
+  });
+
+  it("calls waitForStandbySeed with the bounded timeout", () => {
+    // The whole point of #1675 is: instead of cancelling the standby and
+    // falling through to a doomed dispatch on the overloaded serving session
+    // (which causes a reactive teardown via compactAndRetry), wait briefly
+    // for the seed and promote.
+    expect(agentStoreSource).toContain(
+      "waitForStandbySeed(\n            session.standbySessionId,\n            STANDBY_SEED_WAIT_MS,\n          )",
+    );
+  });
+
+  it("promotes the standby when the seed completes within the timeout", () => {
+    // Static check: the success path of waitForStandbySeed inside sendPrompt
+    // must invoke promoteStandbyAndDispatch — otherwise the standby is wasted
+    // and the prompt still goes to the overloaded session.
+    const sendPromptStart = agentStoreSource.indexOf(
+      "async sendPrompt(\n    prompt: string",
+    );
+    expect(sendPromptStart, "sendPrompt must exist").toBeGreaterThan(0);
+    const sendPromptWindow = agentStoreSource.slice(
+      sendPromptStart,
+      sendPromptStart + 8000,
+    );
+    const waitIdx = sendPromptWindow.indexOf("waitForStandbySeed(");
+    expect(waitIdx, "waitForStandbySeed must be called inside sendPrompt").toBeGreaterThan(0);
+    const afterWait = sendPromptWindow.slice(waitIdx, waitIdx + 800);
+    expect(afterWait).toContain("promoteStandbyAndDispatch(");
+  });
+});
+
+describe("#1675 — waitForStandbySeed helper", () => {
+  it("returns false when the standby session is missing", () => {
+    // If the standby was terminated mid-wait, the loop must not spin until
+    // the deadline — bail immediately. This matches the rest of the file's
+    // guard pattern (waitForSessionIdle reads through state.sessions[id]?).
+    const fnStart = agentStoreSource.indexOf(
+      "async function waitForStandbySeed(",
+    );
+    expect(fnStart, "waitForStandbySeed helper must exist").toBeGreaterThan(0);
+    const fnBody = agentStoreSource.slice(fnStart, fnStart + 1000);
+    expect(fnBody).toContain("if (!standby) return false;");
+    expect(fnBody).toContain("standby.seedCompleted === true");
+  });
+
+  it("STANDBY_SEED_WAIT_MS is bounded and short", () => {
+    // The wait blocks the user's submit. Keep it short enough that a worst-
+    // case wait is still tolerable (under ~5s) and long enough that a typical
+    // seed prompt (~1-3s) actually completes.
+    const constMatch = agentStoreSource.match(
+      /const STANDBY_SEED_WAIT_MS = (\d+(?:_\d+)?);/,
+    );
+    expect(constMatch, "STANDBY_SEED_WAIT_MS constant must exist").not.toBeNull();
+    const value = Number(constMatch![1].replace(/_/g, ""));
+    expect(value).toBeGreaterThanOrEqual(2_000);
+    expect(value).toBeLessThanOrEqual(10_000);
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-compact at the user-configured threshold (default 85%) now uses **predictive** mode — spawns a standby alongside the live serving session instead of tearing it down. The chatbox stays mounted; no flash.
- `sendPrompt`'s "standby not ready at submit" fallback now **waits briefly** (5s, bounded) for the seed to complete when the serving session is at or above the auto-compact threshold. Below the threshold, the original cancel-and-dispatch behaviour is retained so a fast user is not held up.
- Closes #1675.

## Why both edits

Edit #1 alone has a known gap: if the user submits a new prompt before the standby's seed completes, today's code at [src/stores/agent.store.ts:3233](src/stores/agent.store.ts#L3233) cancels the standby and dispatches on the still-overloaded serving session. At 85% headroom that prompt is likely to overflow → triggers `compactAndRetry` → reactive teardown → same chatbox flash. Edit #2 closes that gap with a bounded wait gated on context usage so it only fires when it's needed.

| Scenario | Today | After fix |
| --- | --- | --- |
| User waits long enough for standby to seed | Reactive flash | Promote-and-dispatch ✓ |
| User submits fast, prompt fits overloaded session | Reactive flash | Standby cancelled, prompt succeeds ✓ |
| User submits fast, prompt overflows | Reactive flash | Bounded wait for standby, then promote ✓ |

Reactive mode is preserved for the cases that actually need it: `compactAndRetry` (failed-prompt retry on a dead session) and the manual Compact button.

## Test plan

- [x] `pnpm vitest run tests/unit/auto-compact-predictive.test.ts tests/unit/compaction-queue-race.test.ts tests/unit/predictive-drain-not-blocked.test.ts` — 17/17 passing
- [x] `pnpm test` — 564/564 passing
- [x] Biome warnings on touched lines: only the same `sessionId!` non-null pattern already used throughout this file; no new warning categories introduced

## Out of scope

- Decoupling the UI flash from session deletion entirely (`<Show when={hasSession()}>` change). Deferred — not needed once the trigger is predictive.
- Removing reactive mode.
- Changing the predictive 70% threshold.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
