### PR TITLE
fix(agent): setModel passes through non-catalog ids so predictive standby preserves model (#1677)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1766,11 +1766,20 @@ export function createClaudeRuntime({ emit }) {
       throw new Error(`Session not found: ${sessionId}`);
     }
 
+    // #1677 ground-truth principle (symmetric with chooseUpdatedModelId):
+    // the catalog (`initialize.models[]`) is advisory. The CLI's actual
+    // `set_model` response and the next `message.model` are authoritative.
+    // Pass through non-catalog ids — most importantly, ids that #1635 wrote
+    // to currentModelId from a prior `message.model` (e.g. an Opus tier the
+    // CLI runs but does not list as a switchable picker target). Throwing
+    // here breaks predictive-standby restoreSessionSettings on long threads.
     const targetModel =
       session.availableModelRecords.find((record) => record.modelId === modelId) ??
       null;
     if (!targetModel) {
-      throw new Error(`Unknown Claude model: ${modelId}`);
+      console.warn(
+        `[browser-local][claude] setModel: ${modelId} not in catalog (size=${session.availableModelRecords.length}); passing through to CLI`,
+      );
     }
 
     await sendControlRequest(
@@ -1782,7 +1791,7 @@ export function createClaudeRuntime({ emit }) {
       10_000,
     );
 
-    session.currentModelId = targetModel.modelId;
+    session.currentModelId = targetModel?.modelId ?? modelId;
     emit("provider://session-status", buildSessionStatus(session));
   }
 

--- a/tests/unit/claude-runtime-model-catalog.test.ts
+++ b/tests/unit/claude-runtime-model-catalog.test.ts
@@ -1,0 +1,58 @@
+// ABOUTME: Source-text regression guards for #1677 — setModel must pass
+// ABOUTME: through non-catalog model ids so #1635 ground-truth ids work.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const claudeRuntimeSource = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+
+describe("#1677 — setModel passes through non-catalog ids", () => {
+  it("setModel does NOT throw on unknown model ids", () => {
+    const fnStart = claudeRuntimeSource.indexOf("async function setModel(");
+    expect(fnStart, "setModel must exist").toBeGreaterThan(0);
+    const fnEnd = claudeRuntimeSource.indexOf("\n  }\n", fnStart);
+    expect(fnEnd).toBeGreaterThan(fnStart);
+    const fnBody = claudeRuntimeSource.slice(fnStart, fnEnd);
+
+    expect(
+      fnBody,
+      "setModel must not throw 'Unknown Claude model'",
+    ).not.toMatch(/throw new Error\(`Unknown Claude model:/);
+  });
+
+  it("setModel calls sendControlRequest with the raw modelId regardless of catalog match", () => {
+    const fnStart = claudeRuntimeSource.indexOf("async function setModel(");
+    const fnEnd = claudeRuntimeSource.indexOf("\n  }\n", fnStart);
+    const fnBody = claudeRuntimeSource.slice(fnStart, fnEnd);
+
+    // The control request must reference the raw modelId param so a
+    // non-catalog id passes through unchanged to the CLI.
+    expect(fnBody).toMatch(/subtype:\s*"set_model"/);
+    expect(fnBody).toMatch(/model:\s*modelId/);
+  });
+
+  it("setModel falls back to raw modelId for currentModelId when no catalog match", () => {
+    const fnStart = claudeRuntimeSource.indexOf("async function setModel(");
+    const fnEnd = claudeRuntimeSource.indexOf("\n  }\n", fnStart);
+    const fnBody = claudeRuntimeSource.slice(fnStart, fnEnd);
+
+    // `targetModel?.modelId ?? modelId` — keeps catalog-canonical id when
+    // available, but doesn't lose a non-catalog id either.
+    expect(fnBody).toContain("targetModel?.modelId ?? modelId");
+  });
+
+  it("setModel logs a warning (not an error) for non-catalog ids", () => {
+    const fnStart = claudeRuntimeSource.indexOf("async function setModel(");
+    const fnEnd = claudeRuntimeSource.indexOf("\n  }\n", fnStart);
+    const fnBody = claudeRuntimeSource.slice(fnStart, fnEnd);
+
+    // Visibility: passthrough must be observable in logs so we can debug
+    // CLI/catalog drift without a crash.
+    expect(fnBody).toMatch(/console\.warn\(/);
+    expect(fnBody).toContain("not in catalog");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1677. After a Claude Code thread crossed the predictive-compaction threshold, the spawned standby's `restoreSessionSettings` call failed with `Unknown Claude model: claude-opus-4-7`, the standby fell back to Claude Code's default, and on promotion the user saw the model visibly swap from Opus 4.7 to 4.5.

## Root cause

Asymmetry between `chooseUpdatedModelId` (#1635) and `setModel`:

- `chooseUpdatedModelId` accepts **non-catalog** ids as ground truth from `message.model`. This is the entire point of #1635 — the catalog is advisory; the CLI's reported model wins.
- `setModel` did a **strict** catalog lookup and threw on miss.

So a serving session's `currentModelId` could legitimately be a non-catalog value (e.g. `claude-opus-4-7`), and `restoreSessionSettings` copying it to a freshly-spawned standby would always fail.

## Fix

Warn-and-pass-through for non-catalog ids in [`setModel`](bin/browser-local/claude-runtime.mjs). The CLI's `set_model` response and the next `message.model` are authoritative — same principle as #1635.

```js
const targetModel =
  session.availableModelRecords.find((record) => record.modelId === modelId) ??
  null;
if (!targetModel) {
  console.warn(
    `[browser-local][claude] setModel: ${modelId} not in catalog (size=${session.availableModelRecords.length}); passing through to CLI`,
  );
}

await sendControlRequest(session, { subtype: "set_model", model: modelId }, 10_000);
session.currentModelId = targetModel?.modelId ?? modelId;
emit("provider://session-status", buildSessionStatus(session));
```

## Out of scope

The user's separate report ("switching to 4.6 keeps going back to 4.5") may be a CLI silent-fallback issue. We do **not** have verified evidence of `set_model` semantics for legacy Opus ids, so this PR does **NOT** touch `LEGACY_OPUS_RECORDS` or the picker. See [#1678](https://github.com/serenorg/seren-desktop/issues/1678) for the investigation.

## Tests (critical-only per CLAUDE.md)

[`tests/unit/claude-runtime-model-catalog.test.ts`](tests/unit/claude-runtime-model-catalog.test.ts) — source-text guards:

- `setModel` does NOT throw `Unknown Claude model:`.
- `setModel` calls `sendControlRequest` with the raw `modelId` regardless of catalog match.
- `setModel` falls back to the raw `modelId` for `session.currentModelId` when no catalog match (`targetModel?.modelId ?? modelId`).
- `setModel` logs a `console.warn` with `"not in catalog"` for visibility.

## Test plan

- [x] `pnpm vitest run` — 568/568 pass (existing 564 + 4 new).
- [ ] Manual: long Claude Code thread approaches predictive-compaction threshold; standby spawn no longer logs `Failed to set model: Unknown Claude model: <id>`; on promotion the model id matches the CLI's actual `message.model`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
