### PR TITLE
fix(agent): fork & resume tolerate sessionId != conversationId after promotion (#1682)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2258,9 +2258,12 @@ export const agentStore = {
     conversationId: string,
     cwd?: string,
   ): Promise<string | null> {
-    // If already running, just focus it.
-    if (state.sessions[conversationId]) {
-      setState("activeSessionId", conversationId);
+    // If already running, just focus it. Use the conversationId-aware helper
+    // — state.sessions is keyed by sessionId, and after a predictive-compaction
+    // promotion the running session id no longer matches the conversation. #1682.
+    const existing = this.getSessionForConversation(conversationId);
+    if (existing) {
+      setState("activeSessionId", existing.info.id);
       return conversationId;
     }
 
@@ -5198,7 +5201,10 @@ Structured summary:`;
     conversationId: string,
     fromMessageId: string,
   ): Promise<string | null> {
-    const session = state.sessions[conversationId];
+    // state.sessions is keyed by runtime sessionId, which only matches the
+    // conversationId on cold-start. After a predictive-compaction promotion
+    // the two diverge — fork must resolve via the conversationId field. #1682.
+    const session = this.getSessionForConversation(conversationId);
     if (!session) {
       console.error("[AgentStore] forkConversation: session not found");
       return null;
@@ -5224,15 +5230,16 @@ Structured summary:`;
 
     if (useNativeFork) {
       try {
-        newAgentSessionId =
-          await providerService.nativeForkSession(conversationId);
+        newAgentSessionId = await providerService.nativeForkSession(
+          session.info.id,
+        );
       } catch (err) {
         console.error(
           "[AgentStore] forkConversation: native fork failed:",
           err,
         );
         this.addErrorMessage(
-          conversationId,
+          session.info.id,
           `Fork failed: ${err instanceof Error ? err.message : String(err)}`,
         );
         return null;

--- a/tests/unit/agent-fork-after-promotion.test.ts
+++ b/tests/unit/agent-fork-after-promotion.test.ts
@@ -1,0 +1,48 @@
+// ABOUTME: Source-level regression tests for #1682 — fork & resume survive
+// ABOUTME: sessionId !== conversationId after a predictive-compaction promotion.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+const forkStart = agentStoreSource.indexOf("async forkConversation(");
+const forkEnd = agentStoreSource.indexOf(
+  "addErrorMessage(sessionId: string",
+  forkStart,
+);
+const forkBody = agentStoreSource.slice(forkStart, forkEnd);
+
+const resumeStart = agentStoreSource.indexOf("async resumeAgentConversation(");
+const resumeBody = agentStoreSource.slice(resumeStart, resumeStart + 2000);
+
+describe("#1682 — forkConversation tolerates promoted sessions", () => {
+  it("locates the session via the conversationId-aware helper, not the sessionId-keyed index", () => {
+    expect(forkStart).toBeGreaterThan(0);
+    expect(forkBody).not.toMatch(/state\.sessions\[conversationId\]/);
+    expect(forkBody).toContain("getSessionForConversation(conversationId)");
+  });
+
+  it("hands the runtime sessionId (session.info.id) to nativeForkSession", () => {
+    expect(forkBody).toMatch(/nativeForkSession\(\s*session\.info\.id,?\s*\)/);
+    expect(forkBody).not.toMatch(/nativeForkSession\(\s*conversationId\s*\)/);
+  });
+
+  it("reports native-fork failures against session.info.id, matching addErrorMessage's sessionId contract", () => {
+    expect(forkBody).toMatch(
+      /this\.addErrorMessage\(\s*session\.info\.id,/,
+    );
+  });
+});
+
+describe("#1682 — resumeAgentConversation tolerates promoted sessions", () => {
+  it("checks for an already-running session via the conversationId-aware helper", () => {
+    expect(resumeStart).toBeGreaterThan(0);
+    expect(resumeBody).not.toMatch(/state\.sessions\[conversationId\]/);
+    expect(resumeBody).toContain("getSessionForConversation(conversationId)");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #1682. Fork was silently broken on any conversation that had been touched by predictive-compaction promotion: `forkConversation` looked up `state.sessions[conversationId]`, but the map is keyed by runtime sessionId — the two only coincide on cold-start sessions.
- Same lookup bug existed in `resumeAgentConversation`. Both now resolve via the existing `getSessionForConversation(conversationId)` helper.
- The native-fork failure path also mis-routed: it called `nativeForkSession(conversationId)` (the provider runtime keys its sessions map by sessionId) and `addErrorMessage(conversationId, …)` (sessionId-keyed). Both now pass `session.info.id`.

## Test plan

- [x] `pnpm vitest run tests/unit/agent-fork-after-promotion.test.ts` — 4 source-level regression assertions, red on `main`, green after the patch.
- [x] `pnpm vitest run` — full unit suite (587 tests) green.
- [x] `pnpm biome check` clean on the edited files.
- [ ] Manual smoke (browser-local): trigger predictive-compaction promotion on a thread, then fork from a message — fork resolves, navigates to the new conversation, no console error.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
