### PR TITLE
fix(support): wrap string-only console.error sites so the support pipeline captures them (#1684)

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -140,7 +140,9 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
         const marketplaceSkill = skill as Skill;
         const content = await skillsService.fetchContent(marketplaceSkill);
         if (!content) {
-          console.error("[ThreadSidebar] Failed to fetch skill content");
+          console.error(
+            new Error("[ThreadSidebar] Failed to fetch skill content"),
+          );
           return;
         }
         await skillsStore.install(marketplaceSkill, content, "seren");
@@ -156,7 +158,9 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
             s.dirName === marketplaceSkill.slug,
         );
         if (!found) {
-          console.error("[ThreadSidebar] Skill installed but not found");
+          console.error(
+            new Error("[ThreadSidebar] Skill installed but not found"),
+          );
           return;
         }
         installedSkill = found;

--- a/src/lib/images/attachments.ts
+++ b/src/lib/images/attachments.ts
@@ -241,7 +241,9 @@ export async function pickFiles(): Promise<string[]> {
   try {
     // Ensure the dialog module is available
     if (typeof open !== "function") {
-      console.error("[attachments] Dialog 'open' function not available");
+      console.error(
+        new Error("[attachments] Dialog 'open' function not available"),
+      );
       throw new Error(
         "File dialog not available - dialog plugin may not be initialized",
       );

--- a/src/services/docreader.ts
+++ b/src/services/docreader.ts
@@ -3,8 +3,8 @@
 
 import { apiBase } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
-import { unwrapPublisherBody } from "@/lib/publisher-response";
 import type { Attachment } from "@/lib/providers/types";
+import { unwrapPublisherBody } from "@/lib/publisher-response";
 import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 import { updateBalanceFromError } from "@/stores/wallet.store";
@@ -72,7 +72,7 @@ export async function readDocument(attachment: Attachment): Promise<string> {
   if (!shouldUseRustGatewayAuth(url)) {
     const token = await getToken();
     if (!token) {
-      console.error("[DocReader] No auth token available");
+      console.error(new Error("[DocReader] No auth token available"));
       throw new Error(
         "Document processing requires a Seren account. Sign in to continue.",
       );

--- a/src/services/wallet.ts
+++ b/src/services/wallet.ts
@@ -44,7 +44,7 @@ export async function fetchBalance() {
   }
 
   if (!data?.data) {
-    console.error("[Wallet] No balance data in response");
+    console.error(new Error("[Wallet] No balance data in response"));
     throw new Error("No balance data returned");
   }
 

--- a/src/services/x402.ts
+++ b/src/services/x402.ts
@@ -281,7 +281,9 @@ function createX402Service() {
 
     // If no valid payment options, fail
     if (!hasPrepaid && !hasCrypto) {
-      console.error("No valid payment options in requirements");
+      console.error(
+        new Error("[x402] No valid payment options in requirements"),
+      );
       return null;
     }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -5206,7 +5206,9 @@ Structured summary:`;
     // the two diverge — fork must resolve via the conversationId field. #1682.
     const session = this.getSessionForConversation(conversationId);
     if (!session) {
-      console.error("[AgentStore] forkConversation: session not found");
+      console.error(
+        new Error("[AgentStore] forkConversation: session not found"),
+      );
       return null;
     }
 
@@ -5217,7 +5219,9 @@ Structured summary:`;
     const allMessages = session.messages;
     const forkIndex = allMessages.findIndex((m) => m.id === fromMessageId);
     if (forkIndex === -1) {
-      console.error("[AgentStore] forkConversation: message not found");
+      console.error(
+        new Error("[AgentStore] forkConversation: message not found"),
+      );
       return null;
     }
     const forkedMessages = allMessages.slice(0, forkIndex + 1);
@@ -5282,7 +5286,7 @@ Structured summary:`;
     });
 
     if (!newSessionId) {
-      console.error("[AgentStore] forkConversation: spawn failed");
+      console.error(new Error("[AgentStore] forkConversation: spawn failed"));
       return null;
     }
 

--- a/tests/unit/console-error-reportable.test.ts
+++ b/tests/unit/console-error-reportable.test.ts
@@ -1,0 +1,50 @@
+// ABOUTME: Source-level invariant for #1684 — every console.error in src/ must
+// ABOUTME: pass an Error (or stack-bearing object) so the support pipeline can capture it.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SRC = resolve("src");
+const STRING_ONLY_ERROR = /console\.error\("[^"]*"\)\s*;/g;
+
+function* walkSourceFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      // src/api/generated/ is regenerated from openapi/ — out of scope.
+      if (entry === "generated") continue;
+      yield* walkSourceFiles(full);
+      continue;
+    }
+    if (/\.tsx?$/.test(entry)) yield full;
+  }
+}
+
+function findStringOnlyErrors(): string[] {
+  const offenders: string[] = [];
+  for (const file of walkSourceFiles(SRC)) {
+    const source = readFileSync(file, "utf-8");
+    const lines = source.split("\n");
+    lines.forEach((line, idx) => {
+      if (STRING_ONLY_ERROR.test(line)) {
+        offenders.push(`${file}:${idx + 1}: ${line.trim()}`);
+      }
+      STRING_ONLY_ERROR.lastIndex = 0;
+    });
+  }
+  return offenders;
+}
+
+describe("#1684 — console.error invariant", () => {
+  it("no console.error in src/ uses a single string-literal arg (it would bypass the support pipeline gate)", () => {
+    // Gate: src/lib/support/hook.ts looks for an Error (or stack-bearing
+    // object) among the args before forwarding. A string-only console.error
+    // logs to the dev console but never lands in serenorg/seren-core. Wrap
+    // as `console.error(new Error("..."))` so the pipeline can capture it,
+    // or use `console.warn` if it's genuinely non-reportable.
+    const offenders = findStringOnlyErrors();
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #1684. The support pipeline only forwards `console.error(...)` when an arg is an `Error` (or stack-bearing object) — see the gate at `src/lib/support/hook.ts:392-397`. Nine call sites in `src/` were passing only a string literal and never reached the Gateway as a result.
- Wraps each as `console.error(new Error("..."))`. The descriptive string becomes the `Error.message`, which is the field the dedup signature in `support_report_signatures` is computed from, and the stack points exactly at the throw site.
- Concrete proof: the `forkConversation: session not found` site we just patched in #1683 was reproducible in production but never opened a support-report issue (cf. `serenorg/seren-core#150`, `#151`, which *did* land because they had `Error` objects).

## Sites updated

| File | Site |
| --- | --- |
| `src/stores/agent.store.ts:5209` | `forkConversation: session not found` |
| `src/stores/agent.store.ts:5220` | `forkConversation: message not found` |
| `src/stores/agent.store.ts:5285` | `forkConversation: spawn failed` |
| `src/components/layout/ThreadSidebar.tsx:143` | `Failed to fetch skill content` |
| `src/components/layout/ThreadSidebar.tsx:159` | `Skill installed but not found` |
| `src/lib/images/attachments.ts:244` | `Dialog 'open' function not available` |
| `src/services/wallet.ts:47` | `No balance data in response` |
| `src/services/docreader.ts:75` | `No auth token available` |
| `src/services/x402.ts:284` | `No valid payment options in requirements` |

## Regression guard

`tests/unit/console-error-reportable.test.ts` walks every `.ts`/`.tsx` under `src/` (skipping `src/api/generated/`) and asserts the count of `console.error("plain string");` is zero. Future devs choose between `console.error(new Error(...))` (reportable) and `console.warn(...)` (logged but not forwarded).

## Test plan

- [x] `pnpm vitest run tests/unit/console-error-reportable.test.ts` — RED on `main`, GREEN after the wraps.
- [x] `pnpm vitest run` — full unit suite (588 tests) green.
- [x] `pnpm biome check` clean on the six edited source files.
- [ ] Manual smoke after merge: trigger one of the wrapped sites in dev, confirm a `support-report` issue lands in `serenorg/seren-core` within ~30s (worker tick interval).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
