### PR TITLE
fix(agent): standby promotion owns activeSessionId and defers SIGTERM past dispatch (#1686)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2633,8 +2633,26 @@ export const agentStore = {
 
   /**
    * Terminate a session.
+   *
+   * `opts.nextActiveSessionId` — when supplied and the terminated session was
+   * the active one, the supplied id replaces the default first-remaining-key
+   * fallback. Pass an explicit value (or `null` for "no active session") from
+   * call sites that know where the user should land next, e.g. standby
+   * promotion. #1686.
+   *
+   * `opts.skipProviderKill` — when true, the synchronous state cleanup runs
+   * but the provider-IPC `terminateSession` call (which sends SIGTERM to the
+   * child) is the caller's responsibility. Used by `promoteStandbyAndDispatch`
+   * to defer the kill until the new prompt has been dispatched, so the
+   * SIGTERM cannot race the standby's first turn. #1686.
    */
-  async terminateSession(sessionId: string) {
+  async terminateSession(
+    sessionId: string,
+    opts?: {
+      nextActiveSessionId?: string | null;
+      skipProviderKill?: boolean;
+    },
+  ) {
     const session = state.sessions[sessionId];
     if (!session) return;
 
@@ -2665,10 +2683,12 @@ export const agentStore = {
       );
     }
 
-    try {
-      await providerService.terminateSession(sessionId);
-    } catch (error) {
-      console.error("Failed to terminate session:", error);
+    if (!opts?.skipProviderKill) {
+      try {
+        await providerService.terminateSession(sessionId);
+      } catch (error) {
+        console.error("Failed to terminate session:", error);
+      }
     }
 
     // Clean up ready promise if still pending
@@ -2683,12 +2703,22 @@ export const agentStore = {
       }),
     );
 
-    // Switch to another session if this was active
+    // Switch to another session if this was active. Callers that know which
+    // session should become active (e.g. standby promotion) pass it via
+    // opts.nextActiveSessionId; otherwise fall back to the first remaining
+    // key, which preserves the historical behaviour for ad-hoc terminations.
+    // #1686.
     if (state.activeSessionId === sessionId) {
-      const remainingIds = Object.keys(state.sessions).filter(
-        (id) => id !== sessionId,
-      );
-      setState("activeSessionId", remainingIds[0] ?? null);
+      let next: string | null;
+      if (opts && "nextActiveSessionId" in opts) {
+        next = opts.nextActiveSessionId ?? null;
+      } else {
+        const remainingIds = Object.keys(state.sessions).filter(
+          (id) => id !== sessionId,
+        );
+        next = remainingIds[0] ?? null;
+      }
+      setState("activeSessionId", next);
     }
 
     // Stop global event subscription when no sessions remain.
@@ -3146,12 +3176,34 @@ Structured summary:`;
     setState("sessions", standbyId!, "role", "serving");
     setState("sessions", standbyId!, "seedCompleted", undefined);
 
-    // Clear the serving pointer before terminating so late events from the
-    // old session are fully dropped.
-    await this.terminateSession(servingSessionId);
+    // Make the promoted standby the active session BEFORE the old serving
+    // session is torn down. Without this, terminateSession's auto-pickup
+    // branch lands on the first remaining key (an unrelated session) and the
+    // UI's view of activeSessionId no longer matches the session actually
+    // serving the user's prompt. #1686.
+    setState("activeSessionId", standbyId!);
 
-    // Dispatch on the promoted session.
-    await this.sendPrompt(prompt, context, options, standbyId!);
+    // Two-phase teardown of the old serving session. Phase 1 (synchronous
+    // state cleanup) drops late events from the old child immediately, so
+    // dispatch on the standby is unaffected. Phase 2 (the provider-IPC kill
+    // that sends SIGTERM) is deferred to after sendPrompt resolves so the
+    // SIGTERM cannot race the standby's first turn. #1686.
+    await this.terminateSession(servingSessionId, {
+      nextActiveSessionId: standbyId!,
+      skipProviderKill: true,
+    });
+
+    try {
+      // Dispatch on the promoted session.
+      await this.sendPrompt(prompt, context, options, standbyId!);
+    } finally {
+      // Phase 2: now that dispatch has settled, reap the old child.
+      try {
+        await providerService.terminateSession(servingSessionId);
+      } catch (error) {
+        console.warn("[AgentStore] Deferred provider terminate failed:", error);
+      }
+    }
   },
 
   /**

--- a/tests/unit/agent-predictive-compaction.test.ts
+++ b/tests/unit/agent-predictive-compaction.test.ts
@@ -54,7 +54,11 @@ describe("#1631 — kickPredictiveCompact + promoteStandbyAndDispatch", () => {
     expect(agentStoreSource).toContain("async promoteStandbyAndDispatch(");
     // serving gets terminated after the transcript transfers to the promoted id.
     expect(agentStoreSource).toContain('setState("sessions", standbyId!, "role", "serving")');
-    expect(agentStoreSource).toContain("await this.terminateSession(servingSessionId)");
+    // The terminate call now passes opts (#1686) — match the call site loosely
+    // so the formatting of the opts object doesn't regress this test.
+    expect(agentStoreSource).toMatch(
+      /await this\.terminateSession\(\s*servingSessionId,\s*\{/,
+    );
   });
 
   it("sendPrompt checks for a ready standby and promotes when present", () => {

--- a/tests/unit/standby-promotion-sigterm.test.ts
+++ b/tests/unit/standby-promotion-sigterm.test.ts
@@ -1,0 +1,103 @@
+// ABOUTME: Source-level regression tests for #1686 — standby promotion must
+// ABOUTME: own activeSessionId and defer the provider-IPC kill past dispatch.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+const promoteStart = agentStoreSource.indexOf("async promoteStandbyAndDispatch(");
+const promoteEnd = agentStoreSource.indexOf(
+  "async abortTurn(",
+  promoteStart,
+);
+const promoteBody = agentStoreSource.slice(promoteStart, promoteEnd);
+
+const terminateStart = agentStoreSource.indexOf("async terminateSession(");
+const terminateEnd = agentStoreSource.indexOf(
+  "setActiveSession(sessionId:",
+  terminateStart,
+);
+const terminateBody = agentStoreSource.slice(terminateStart, terminateEnd);
+
+describe("#1686 — terminateSession accepts an explicit nextActiveSessionId", () => {
+  it("declares the opts parameter with nextActiveSessionId and skipProviderKill", () => {
+    expect(promoteStart).toBeGreaterThan(0);
+    expect(terminateStart).toBeGreaterThan(0);
+    // Signature check: opts is optional and exposes both keys. The whitespace
+    // tolerance keeps the test stable across Biome formatting changes.
+    expect(terminateBody).toMatch(/nextActiveSessionId\?:\s*string\s*\|\s*null/);
+    expect(terminateBody).toMatch(/skipProviderKill\?:\s*boolean/);
+  });
+
+  it("uses opts.nextActiveSessionId when provided instead of remainingIds[0]", () => {
+    // The auto-pickup fallback (remainingIds[0]) must remain reachable so
+    // existing callers that pass no opts keep their behaviour, but the
+    // explicit branch must come first.
+    const explicitIdx = terminateBody.indexOf(
+      'if (opts && "nextActiveSessionId" in opts)',
+    );
+    const fallbackIdx = terminateBody.indexOf("remainingIds[0]");
+    expect(explicitIdx, "explicit-next branch must exist").toBeGreaterThan(0);
+    expect(fallbackIdx, "fallback must remain").toBeGreaterThan(explicitIdx);
+  });
+
+  it("gates the provider-IPC kill on skipProviderKill", () => {
+    expect(terminateBody).toContain("if (!opts?.skipProviderKill)");
+    expect(terminateBody).toMatch(
+      /if \(!opts\?\.skipProviderKill\)\s*\{[\s\S]*?providerService\.terminateSession\(sessionId\)/,
+    );
+  });
+});
+
+describe("#1686 — promoteStandbyAndDispatch fixes the activeSessionId mismatch", () => {
+  it("sets activeSessionId to the promoted standby BEFORE terminating the old serving session", () => {
+    const setActiveIdx = promoteBody.indexOf(
+      'setState("activeSessionId", standbyId!)',
+    );
+    const terminateCallIdx = promoteBody.indexOf("this.terminateSession(servingSessionId");
+    expect(setActiveIdx, "activeSessionId must be set in promote body").toBeGreaterThan(0);
+    expect(terminateCallIdx, "terminateSession call must exist").toBeGreaterThan(0);
+    expect(
+      setActiveIdx,
+      "activeSessionId must be set BEFORE terminateSession is called",
+    ).toBeLessThan(terminateCallIdx);
+  });
+
+  it("passes nextActiveSessionId: standbyId! to terminateSession as defense-in-depth", () => {
+    expect(promoteBody).toMatch(
+      /this\.terminateSession\(\s*servingSessionId,\s*\{[\s\S]*?nextActiveSessionId:\s*standbyId!/,
+    );
+  });
+});
+
+describe("#1686 — promoteStandbyAndDispatch defers the provider kill past dispatch", () => {
+  it("requests skipProviderKill on the pre-dispatch terminateSession call", () => {
+    expect(promoteBody).toMatch(
+      /this\.terminateSession\(\s*servingSessionId,\s*\{[\s\S]*?skipProviderKill:\s*true/,
+    );
+  });
+
+  it("invokes providerService.terminateSession AFTER sendPrompt, inside a finally block", () => {
+    const sendPromptIdx = promoteBody.indexOf(
+      "this.sendPrompt(prompt, context, options, standbyId!)",
+    );
+    const finallyIdx = promoteBody.indexOf("finally", sendPromptIdx);
+    const providerKillIdx = promoteBody.indexOf(
+      "providerService.terminateSession(servingSessionId)",
+      finallyIdx,
+    );
+    expect(sendPromptIdx, "sendPrompt call must exist").toBeGreaterThan(0);
+    expect(finallyIdx, "finally block must follow sendPrompt").toBeGreaterThan(
+      sendPromptIdx,
+    );
+    expect(
+      providerKillIdx,
+      "deferred providerService.terminateSession must live inside the finally",
+    ).toBeGreaterThan(finallyIdx);
+  });
+});


### PR DESCRIPTION
## Summary

- `terminateSession()` accepts `opts.nextActiveSessionId` (explicit fallback) and `opts.skipProviderKill` (defer the SIGTERM); existing call sites with no opts keep current behavior.
- `promoteStandbyAndDispatch` now (1) sets `activeSessionId = standbyId` before teardown, (2) does state-only termination of the old serving session before dispatch, and (3) issues the provider-IPC kill in a `finally` after `sendPrompt` resolves so the SIGTERM cannot race the new turn.
- New regression test `tests/unit/standby-promotion-sigterm.test.ts` enforces the contract; existing predictive-compaction test updated to match the new call shape.

Fixes #1686.

## Test plan

- [x] `pnpm vitest run tests/unit/standby-promotion-sigterm.test.ts` (7/7 pass)
- [x] `pnpm test` full suite (595/595 pass)
- [x] `pnpm biome check` on changed files (no errors introduced)
- [ ] Manual smoke: trigger a predictive-compaction promotion at >threshold context, confirm console no longer shows `setActiveSession new: <unrelated>` after `Promoting standby ...`, and the `Process exited (code=143)` log appears AFTER the prompt completes (not interleaved with `Adding user message`)
