### PR TITLE
fix(agent): predictive standby spawn null is non-catastrophic (#152)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2902,9 +2902,15 @@ Structured summary:`;
           role: "standby",
         });
         if (!standbyId) {
-          throw new Error(
-            "CompactionFailure: predictive standby spawn returned null",
+          // Predictive warm-up is best-effort — the serving session is still
+          // alive and the user can keep working. Throwing here would route
+          // through the catastrophic catch and surface as a captured support
+          // report; downgrade to a warn so the support pipeline ignores it
+          // and let kickPredictiveCompact's normal flag-reset path run. #152.
+          console.warn(
+            "[AgentStore] Predictive standby spawn returned null — keeping serving session, will retry next turn",
           );
+          return "failed_catastrophic";
         }
         setState("sessions", standbyId, "compactedSummary", compactedSummary);
         setState("sessions", sessionId, "standbySessionId", standbyId);
@@ -2973,6 +2979,24 @@ Structured summary:`;
       }
       return "succeeded";
     } catch (error) {
+      // Predictive warm-up failures are not catastrophic — the serving
+      // session is still alive and the user can keep working. Downgrade the
+      // log so the support pipeline doesn't capture every standby-spawn race
+      // as a public bug report. The reactive path stays catastrophic. #152.
+      if (mode === "predictive") {
+        console.warn(
+          "[AgentStore] Predictive standby compaction failed (non-fatal):",
+          error instanceof Error ? error.message : String(error),
+        );
+        // Clear standbySessionId pointer if it was wired up before the throw
+        // so the next sendPrompt doesn't try to promote a dead standby. The
+        // serving session itself is untouched (isCompacting was never set in
+        // predictive mode, #1673).
+        if (state.sessions[sessionId]?.standbySessionId) {
+          setState("sessions", sessionId, "standbySessionId", null);
+        }
+        return "failed_catastrophic";
+      }
       console.error(
         "[AgentStore] Failed to compact agent conversation (catastrophic):",
         error,

--- a/tests/unit/compaction-predictive-soft-fail.test.ts
+++ b/tests/unit/compaction-predictive-soft-fail.test.ts
@@ -1,0 +1,80 @@
+// ABOUTME: Source-level regression tests for #152 — predictive standby
+// ABOUTME: failures must not trigger the catastrophic-error capture path.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+const compactStart = agentStoreSource.indexOf(
+  "async compactAgentConversation(",
+);
+const compactEnd = agentStoreSource.indexOf(
+  "async compactAndRetry(",
+  compactStart,
+);
+const compactBody = agentStoreSource.slice(compactStart, compactEnd);
+
+describe("#152 — predictive standby spawn null is non-catastrophic", () => {
+  it("predictive null-spawn branch does NOT throw 'CompactionFailure: predictive standby spawn returned null'", () => {
+    // Throwing routed through the catastrophic catch which logs
+    // console.error(string, errorObj) — captured as a support report. The
+    // serving session is still healthy on a predictive null-spawn, so the
+    // user-visible failure was pure noise.
+    expect(compactBody).not.toContain(
+      'throw new Error(\n            "CompactionFailure: predictive standby spawn returned null"',
+    );
+    expect(compactBody).not.toContain(
+      '"CompactionFailure: predictive standby spawn returned null"',
+    );
+  });
+
+  it("predictive null-spawn branch warns (not errors) and returns failed_catastrophic", () => {
+    const predictiveIdx = compactBody.indexOf('if (mode === "predictive")');
+    expect(predictiveIdx, "predictive branch must exist").toBeGreaterThan(0);
+    const nullCheckIdx = compactBody.indexOf("!standbyId", predictiveIdx);
+    expect(nullCheckIdx, "null-standby check must exist").toBeGreaterThan(
+      predictiveIdx,
+    );
+    // The block after the null check should warn, not error, and must return
+    // an outcome (not throw).
+    const block = compactBody.slice(nullCheckIdx, nullCheckIdx + 600);
+    expect(block).toMatch(/console\.warn\(/);
+    expect(block).toContain('return "failed_catastrophic"');
+  });
+
+  it("catch block treats predictive mode as non-fatal", () => {
+    // Errors thrown after the null-spawn check (e.g. setState on a standby
+    // killed mid-compaction) must also warn rather than fire console.error
+    // with the Error instance.
+    const catchIdx = compactBody.indexOf("} catch (error) {");
+    expect(catchIdx, "catch block must exist").toBeGreaterThan(0);
+    const catchBody = compactBody.slice(catchIdx, catchIdx + 1500);
+    // Guard: predictive branch is checked first
+    const predictiveCatchIdx = catchBody.indexOf('if (mode === "predictive")');
+    const catastrophicLogIdx = catchBody.indexOf(
+      "Failed to compact agent conversation (catastrophic)",
+    );
+    expect(
+      predictiveCatchIdx,
+      "predictive branch must be inside catch",
+    ).toBeGreaterThan(0);
+    expect(
+      predictiveCatchIdx,
+      "predictive branch must run BEFORE the catastrophic console.error",
+    ).toBeLessThan(catastrophicLogIdx);
+  });
+
+  it("catch block clears standbySessionId pointer when predictive fails after wiring", () => {
+    // Without this, the next sendPrompt's standby-promotion path would try
+    // to promote a session id that is gone or unreachable.
+    const catchIdx = compactBody.indexOf("} catch (error) {");
+    const catchBody = compactBody.slice(catchIdx, catchIdx + 1500);
+    expect(catchBody).toMatch(/standbySessionId/);
+    expect(catchBody).toMatch(/setState\([^)]*standbySessionId[^)]*null/);
+  });
+});


### PR DESCRIPTION
## Summary
- Predictive warm-up is best-effort — the serving session is still alive when a standby spawn fails. Throwing routed through the catastrophic catch and captured the failure as a public support report (`CompactionFailure: predictive standby spawn returned null`).
- Downgrade the null-spawn branch to `console.warn` and return `failed_catastrophic` directly, bypassing the catch's `console.error(string, errorObj)` (the support hook only captures when an Error instance is passed).
- Treat any throw inside the predictive branch as non-fatal in the catch (clear `standbySessionId` so the next `sendPrompt` does not promote a dead standby; the serving session itself is untouched because `isCompacting` was never set in predictive mode, see #1673).
- Adds a source-level regression test at `tests/unit/compaction-predictive-soft-fail.test.ts`.

Closes serenorg/seren-core#152

## Test plan
- [x] `pnpm vitest run tests/unit/compaction-predictive-soft-fail.test.ts` — 4/4 pass
- [x] `pnpm vitest run` (full suite) — 599/599 pass
- [x] Adjacent compaction tests still pass (auto-compact-predictive, predictive-drain-not-blocked, standby-promotion-sigterm, compaction-queue-race, compaction-auth-gate, agent-predictive-compaction)
- [x] Biome — no new warnings

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
