### PR TITLE
fix(agent): guard reactive compaction against session removal mid-flight (#150)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2935,6 +2935,21 @@ Structured summary:`;
         );
       }
 
+      // The new session entry can disappear between spawn return and the
+      // first setState if `provider-runtime://restarted` fires (which drops
+      // every session) or another path calls terminateSession on the same
+      // id. Without this guard the next setState traverses
+      // `state.sessions[newSessionId].compactedSummary` and throws an
+      // unhelpful TypeError "undefined is not an object (evaluating 'e[r]')"
+      // from inside the SolidJS store reconciler — captured as a public
+      // support report. Throw a clean error so the catch block runs the
+      // recovery path with a meaningful message. #150.
+      if (!state.sessions[newSessionId]) {
+        throw new Error(
+          "CompactionFailure: new session was removed before settings could be restored",
+        );
+      }
+
       setState("sessions", newSessionId, "compactedSummary", compactedSummary);
 
       // UI history is decoupled from model context (#1631). The new session

--- a/tests/unit/compaction-session-removal-guard.test.ts
+++ b/tests/unit/compaction-session-removal-guard.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Source-level regression tests for #150 — reactive compaction
+// ABOUTME: must guard against a session removed between spawn and setState.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+const compactStart = agentStoreSource.indexOf(
+  "async compactAgentConversation(",
+);
+const compactEnd = agentStoreSource.indexOf(
+  "async compactAndRetry(",
+  compactStart,
+);
+const compactBody = agentStoreSource.slice(compactStart, compactEnd);
+
+describe("#150 — reactive compaction guards against session removal mid-flight", () => {
+  it("checks state.sessions[newSessionId] exists BEFORE the first setState write", () => {
+    // The provider-runtime restart listener drops every session entry; an
+    // external terminateSession call does the same. Without this guard the
+    // first setState path-traversal threw a raw TypeError ("undefined is
+    // not an object (evaluating 'e[r]')") which the support hook captured
+    // as a public bug report.
+    const guardIdx = compactBody.indexOf("!state.sessions[newSessionId]");
+    expect(
+      guardIdx,
+      "session-removal guard must exist after spawnSession",
+    ).toBeGreaterThan(0);
+
+    const firstSetStateIdx = compactBody.indexOf(
+      'setState("sessions", newSessionId, "compactedSummary"',
+    );
+    expect(firstSetStateIdx).toBeGreaterThan(0);
+    expect(
+      guardIdx,
+      "guard must precede the first setState that writes to the new session",
+    ).toBeLessThan(firstSetStateIdx);
+  });
+
+  it("guard throws a clean Error so the recovery branch fires with a meaningful message", () => {
+    const guardIdx = compactBody.indexOf("!state.sessions[newSessionId]");
+    const region = compactBody.slice(guardIdx, guardIdx + 500);
+    expect(region).toContain("throw new Error(");
+    // The error message must be specific enough that the support pipeline
+    // does not flatten it into another TypeError-shaped report.
+    expect(region).toMatch(/CompactionFailure:[^"]*removed/);
+  });
+
+  it("guard runs AFTER the null-spawn check so we don't shadow that error", () => {
+    const nullSpawnIdx = compactBody.indexOf(
+      'CompactionFailure: new session spawn returned null',
+    );
+    const removalGuardIdx = compactBody.indexOf("!state.sessions[newSessionId]");
+    expect(nullSpawnIdx).toBeGreaterThan(0);
+    expect(removalGuardIdx).toBeGreaterThan(nullSpawnIdx);
+  });
+});


### PR DESCRIPTION
## Summary
- Between `await spawnSession` and the first setState write in the reactive compaction path, the new session entry can disappear: `provider-runtime://restarted` drops every session, and an external `terminateSession` does the same for one. The next `setState("sessions", newSessionId, ...)` path-traversed into an undefined map entry and threw a raw `TypeError: undefined is not an object (evaluating 'e[r]')` from inside the SolidJS store reconciler — captured as a public support report.
- Add a clean session-existence guard right after the spawn-null check. The guard throws a meaningful `CompactionFailure: new session was removed before settings could be restored` so the existing catch's recovery branch fires (the old session was already terminated, the recovery spawns a fresh one with the saved transcript).
- Adds a source-level regression test at `tests/unit/compaction-session-removal-guard.test.ts`.

Closes serenorg/seren-core#150

## Test plan
- [x] `pnpm vitest run tests/unit/compaction-session-removal-guard.test.ts` — 3/3 pass
- [x] `pnpm vitest run` (full suite) — 598/598 pass

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
