### PR TITLE
fix(agent): persist per-model context window from CLI metadata

### DIFF
--- a/src-tauri/src/commands/model_context_cache.rs
+++ b/src-tauri/src/commands/model_context_cache.rs
@@ -1,0 +1,137 @@
+// ABOUTME: Tauri commands that persist per-model context windows learned from CLI metadata.
+// ABOUTME: Lets compaction thresholds stay correct for new models without hand-edited catalogs.
+
+use crate::services::database::{DbPool, init_db};
+use rusqlite::{Connection, OptionalExtension, params};
+use tauri::{AppHandle, Manager};
+
+#[tauri::command]
+pub async fn get_model_context_window(
+    app: AppHandle,
+    provider: String,
+    model_id: String,
+) -> Result<Option<i64>, String> {
+    run_db(app, move |conn| {
+        conn.query_row(
+            "SELECT context_window FROM model_context_cache
+             WHERE provider = ?1 AND model_id = ?2",
+            params![provider, model_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn record_model_context_window(
+    app: AppHandle,
+    provider: String,
+    model_id: String,
+    context_window: i64,
+) -> Result<(), String> {
+    if context_window <= 0 {
+        return Err("context_window must be positive".into());
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_millis() as i64;
+
+    run_db(app, move |conn| {
+        conn.execute(
+            "INSERT INTO model_context_cache (provider, model_id, context_window, updated_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(provider, model_id) DO UPDATE SET
+               context_window = excluded.context_window,
+               updated_at = excluded.updated_at",
+            params![provider, model_id, context_window, now],
+        )?;
+        Ok(())
+    })
+    .await
+}
+
+async fn run_db<T>(
+    app: AppHandle,
+    task: impl FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
+) -> Result<T, String>
+where
+    T: Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(move || {
+        if let Some(pool) = app.try_state::<DbPool>() {
+            pool.with_connection(|conn| task(conn))
+        } else {
+            let conn = init_db(&app).map_err(|err| err.to_string())?;
+            task(&conn).map_err(|err| err.to_string())
+        }
+    })
+    .await
+    .map_err(|err| err.to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::services::database::setup_schema;
+    use rusqlite::{Connection, params};
+
+    fn open() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+        conn
+    }
+
+    fn upsert(conn: &Connection, provider: &str, model_id: &str, context_window: i64, ts: i64) {
+        conn.execute(
+            "INSERT INTO model_context_cache (provider, model_id, context_window, updated_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(provider, model_id) DO UPDATE SET
+               context_window = excluded.context_window,
+               updated_at = excluded.updated_at",
+            params![provider, model_id, context_window, ts],
+        )
+        .unwrap();
+    }
+
+    fn read(conn: &Connection, provider: &str, model_id: &str) -> Option<(i64, i64)> {
+        conn.query_row(
+            "SELECT context_window, updated_at FROM model_context_cache
+             WHERE provider = ?1 AND model_id = ?2",
+            params![provider, model_id],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .ok()
+    }
+
+    #[test]
+    fn roundtrip_returns_stored_context_window() {
+        let conn = open();
+        upsert(&conn, "anthropic", "claude-opus-4-7", 1_000_000, 100);
+
+        let got = read(&conn, "anthropic", "claude-opus-4-7");
+        assert_eq!(got, Some((1_000_000, 100)));
+    }
+
+    #[test]
+    fn upsert_replaces_prior_value_for_same_key() {
+        let conn = open();
+        upsert(&conn, "anthropic", "claude-opus-4-7", 200_000, 100);
+        upsert(&conn, "anthropic", "claude-opus-4-7", 1_000_000, 200);
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM model_context_cache
+                 WHERE provider = 'anthropic' AND model_id = 'claude-opus-4-7'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(
+            read(&conn, "anthropic", "claude-opus-4-7"),
+            Some((1_000_000, 200))
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod commands {
     pub mod gateway_http;
     pub mod indexing;
     pub mod memory;
+    pub mod model_context_cache;
     pub mod orchestrator;
     pub mod session;
     pub mod web;
@@ -763,6 +764,9 @@ pub fn run() {
             commands::chat::get_messages,
             commands::chat::clear_conversation_history,
             commands::chat::clear_all_history,
+            // Model context-window cache
+            commands::model_context_cache::get_model_context_window,
+            commands::model_context_cache::record_model_context_window,
             sync::start_watching,
             sync::stop_watching,
             sync::get_sync_status,

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -443,6 +443,20 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
     )
     .ok();
 
+    // Persisted context-window observations keyed by (provider, model_id).
+    // Populated from CLI prompt-completion metadata so the catalog does not
+    // need to be edited every time a new model ships.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS model_context_cache (
+            provider TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            context_window INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (provider, model_id)
+        )",
+        [],
+    )?;
+
     // Migration: Create default conversation for orphan messages
     migrate_orphan_messages(conn)?;
 

--- a/src/services/modelContextCache.ts
+++ b/src/services/modelContextCache.ts
@@ -1,0 +1,37 @@
+// ABOUTME: Reads and writes per-model context windows learned from CLI prompt metadata.
+// ABOUTME: Lets the spawn-time fallback in agent.store stay correct as new models ship.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export async function getCachedModelContextWindow(
+  provider: string,
+  modelId: string,
+): Promise<number | null> {
+  try {
+    const result = await invoke<number | null>("get_model_context_window", {
+      provider,
+      modelId,
+    });
+    return typeof result === "number" && result > 0 ? result : null;
+  } catch (err) {
+    console.warn("[modelContextCache] lookup failed", err);
+    return null;
+  }
+}
+
+export async function recordModelContextWindow(
+  provider: string,
+  modelId: string,
+  contextWindow: number,
+): Promise<void> {
+  if (!Number.isFinite(contextWindow) || contextWindow <= 0) return;
+  try {
+    await invoke("record_model_context_window", {
+      provider,
+      modelId,
+      contextWindow: Math.round(contextWindow),
+    });
+  } catch (err) {
+    console.warn("[modelContextCache] record failed", err);
+  }
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -193,6 +193,10 @@ import {
   bootstrapMemoryContext,
   storeAssistantResponse,
 } from "@/services/memory";
+import {
+  getCachedModelContextWindow,
+  recordModelContextWindow,
+} from "@/services/modelContextCache";
 import type {
   AgentEvent,
   AgentInfo,
@@ -1929,6 +1933,16 @@ export const agentStore = {
         // Create session state
         const hasRestoredMessages =
           opts?.restoredMessages && opts.restoredMessages.length > 0;
+        // Prefer the per-model context window we previously learned from CLI
+        // metadata; fall back to the agent-type default. The first session of a
+        // brand-new model still hits the default for one prompt, then the
+        // promptComplete capture below upserts the real value for next time.
+        const cachedContextWindow = opts?.initialModelId
+          ? await getCachedModelContextWindow(
+              resolvedAgentType,
+              opts.initialModelId,
+            )
+          : null;
         const session: ActiveSession = {
           info,
           messages: opts?.restoredMessages ?? [],
@@ -1947,11 +1961,12 @@ export const agentStore = {
             ? opts?.restoredMessages?.length
             : undefined,
           contextWindowSize:
-            resolvedAgentType === "codex"
+            cachedContextWindow ??
+            (resolvedAgentType === "codex"
               ? 400_000
               : resolvedAgentType === "gemini"
                 ? 1_000_000
-                : 200_000,
+                : 200_000),
           bootstrapPromptContext: finalBootstrapContext,
           pendingPrompts: [],
           role: opts?.role ?? "serving",
@@ -4242,6 +4257,19 @@ Structured summary:`;
               "contextWindowSize",
               reportedContextWindow,
             );
+            // Persist (provider, modelId) -> contextWindow so next spawn of
+            // this model starts with the correct value instead of the
+            // agent-type default. Fire-and-forget; failures are non-fatal.
+            const sess = state.sessions[sessionId];
+            const modelKey = sess?.currentModelId;
+            const provider = sess?.info?.agentType;
+            if (modelKey && provider) {
+              void recordModelContextWindow(
+                provider,
+                modelKey,
+                reportedContextWindow,
+              );
+            }
           }
           if (inputTokens != null) {
             setState("sessions", sessionId, "lastInputTokens", inputTokens);


### PR DESCRIPTION
## Summary

- Persists `(provider, model_id) -> context_window` to SQLite as soon as the CLI reports it via `meta.contextWindow`. Next session spawn of the same model reads from this cache, so 1M-context Claude models stop hitting auto-compaction at the 200k fallback.
- Self-updating: a new model used once is correct from the second prompt onward, with no JSON file edits, no code change, no release.
- Cold-start tradeoff: the first prompt of a brand-new model still uses the agent-type fallback; the existing `DEFAULT_MODELS` and `augmentWithLegacyOpus` keep serving as the seed for known models.

## Changes

- `src-tauri/src/services/database.rs`: new `model_context_cache(provider, model_id, context_window, updated_at)` table.
- `src-tauri/src/commands/model_context_cache.rs`: `get_model_context_window` and `record_model_context_window` Tauri commands.
- `src-tauri/src/lib.rs`: register the new commands.
- `src/services/modelContextCache.ts`: thin TS wrappers around `invoke`.
- `src/stores/agent.store.ts`:
  - spawn fallback now consults the cache before agent-type defaults
  - `promptComplete` capture path upserts `(agentType, currentModelId) -> contextWindow`

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml model_context_cache` — roundtrip + upsert-replaces tests pass
- [x] `pnpm vitest run` — 605 tests pass
- [x] `pnpm biome check src/services/modelContextCache.ts src/stores/agent.store.ts` — clean
- [ ] Manual: launch on `claude-opus-4-7`, send one prompt, kill the session, spawn a fresh session — confirm console logs `(N% of 1,000,000 context)` instead of `200,000`

Closes #1700
