### PR TITLE
Fix publisher-backed skill de-dupe

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -620,6 +620,24 @@ function publisherToSkill(publisher: Publisher): Skill {
   };
 }
 
+function skillMergeKey(skill: Skill, publisherSlugs: Set<string>): string {
+  if (skill.source === "seren") {
+    return skill.slug;
+  }
+
+  if (skill.source === "serenorg" && skill.slug.startsWith("seren-")) {
+    const publisherSlug = skill.slug.slice("seren-".length);
+    if (publisherSlugs.has(publisherSlug)) {
+      // seren-skills indexes publisher wrappers as category-prefixed slugs
+      // (e.g. seren/seren-bounty -> seren-seren-bounty). Prefer the live
+      // publisher record when that stable upstream slug is present.
+      return publisherSlug;
+    }
+  }
+
+  return skill.slug;
+}
+
 /**
  * Skills service for Seren Desktop.
  */
@@ -752,15 +770,16 @@ export const skills = {
 
     // Merge skills, with publisher skills taking precedence for duplicates
     const skillMap = new Map<string, Skill>();
+    const publisherSlugs = new Set(publisherSkills.map((skill) => skill.slug));
 
     // Add index skills first
     for (const skill of indexSkills) {
-      skillMap.set(skill.slug, skill);
+      skillMap.set(skillMergeKey(skill, publisherSlugs), skill);
     }
 
     // Publisher skills override index skills (they're more up-to-date)
     for (const skill of publisherSkills) {
-      skillMap.set(skill.slug, skill);
+      skillMap.set(skillMergeKey(skill, publisherSlugs), skill);
     }
 
     return Array.from(skillMap.values());
@@ -1519,8 +1538,7 @@ export const skills = {
       // equals the marketplace slug even when resolveSkillSlug() derives a
       // different slug from SKILL.md frontmatter name).
       const repoMatch =
-        repoSkillsBySlug.get(skill.slug) ??
-        repoSkillsBySlug.get(skill.dirName);
+        repoSkillsBySlug.get(skill.slug) ?? repoSkillsBySlug.get(skill.dirName);
       const publisherMatch =
         publisherSkillsBySlug.get(skill.slug) ??
         publisherSkillsBySlug.get(skill.dirName);

--- a/tests/unit/skills-publisher-dedupe.test.ts
+++ b/tests/unit/skills-publisher-dedupe.test.ts
@@ -1,0 +1,111 @@
+// ABOUTME: Regression coverage for live publisher-backed skill de-duplication.
+// ABOUTME: Ensures seren-skills wrappers do not duplicate live publisher records.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAppFetch = vi.hoisted(() => vi.fn());
+const mockCatalogList = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/fetch", () => ({
+  appFetch: mockAppFetch,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@/services/catalog", () => ({
+  catalog: {
+    list: mockCatalogList,
+  },
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: () => true,
+}));
+
+function installLocalStorageMock(): void {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+  });
+}
+
+describe("skills.fetchAllSkills publisher-backed de-dupe", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    installLocalStorageMock();
+  });
+
+  it("prefers the live publisher skill over the seren-skills wrapper", async () => {
+    mockAppFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        version: "2",
+        updatedAt: "2026-04-27T00:00:00Z",
+        skills: [
+          {
+            slug: "seren-seren-bounty",
+            name: "seren-bounty",
+            description: "Repo wrapper for SerenBounty",
+            source: "serenorg",
+            sourceUrl:
+              "https://raw.githubusercontent.com/serenorg/seren-skills/main/seren/seren-bounty/SKILL.md",
+            tags: [],
+          },
+        ],
+        tree: [],
+      }),
+    });
+
+    mockCatalogList.mockResolvedValue([
+      {
+        slug: "seren-bounty",
+        name: "SerenBounty",
+        resource_name: "SerenBounty",
+        description: "Live publisher-backed bounty protocol",
+        publisher_type: "mcp",
+        categories: ["bounties"],
+        is_active: true,
+      },
+      {
+        slug: "seren-swarm",
+        name: "SerenSwarm",
+        resource_name: "SerenSwarm",
+        description: "Separate collaborative bounty network",
+        publisher_type: "mcp",
+        categories: ["bounties"],
+        is_active: true,
+      },
+    ]);
+
+    const { skills } = await import("@/services/skills");
+
+    const allSkills = await skills.fetchAllSkills(true);
+
+    expect(allSkills.map((skill) => skill.slug)).toEqual([
+      "seren-bounty",
+      "seren-swarm",
+    ]);
+    expect(allSkills.find((skill) => skill.slug === "seren-bounty")).toMatchObject(
+      {
+        source: "seren",
+        description: "Live publisher-backed bounty protocol",
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- canonicalize `seren-skills` publisher wrapper slugs against live publisher slugs during skills catalog merge
- keep the existing publisher-wins precedence when a static wrapper and live publisher both exist
- add one focused regression test for the `seren-seren-bounty` / `seren-bounty` duplicate case while preserving `seren-swarm` as distinct

Fixes #1702

## Tests
- `pnpm test tests/unit/skills-publisher-dedupe.test.ts`
- `pnpm exec biome check src/services/skills.ts tests/unit/skills-publisher-dedupe.test.ts`
