### PR TITLE
Preserve repo skill content for publisher duplicates

### DIFF
--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -57,6 +57,35 @@ export interface Skill {
   source: SkillSource;
   /** URL to fetch full SKILL.md content */
   sourceUrl?: string;
+  /**
+   * Live Seren publisher slug attached to a repo-backed skill. This preserves
+   * the richer seren-skills SKILL.md while keeping publisher availability and
+   * execution metadata discoverable.
+   */
+  publisherSlug?: string;
+  /** URL to fetch the live publisher-generated skill.md, when available. */
+  publisherSourceUrl?: string;
+  /** Human-readable publisher name, when attached to a repo-backed skill. */
+  publisherName?: string;
+  /** Live publisher catalog description, when attached to a repo-backed skill. */
+  publisherDescription?: string;
+  /** Publisher integration type, used to understand execution mode. */
+  publisherType?: string;
+  /** Publisher-declared capabilities for task matching and availability. */
+  publisherCapabilities?: string[];
+  /** Publisher endpoint definitions for live execution/discovery. */
+  publisherEndpoints?: Array<{
+    method: string;
+    path: string;
+    description?: string | null;
+    access?: string;
+    is_default?: boolean;
+    is_protected?: boolean;
+  }>;
+  /** External API URL for API publishers, when exposed by the catalog. */
+  publisherApiUrl?: string | null;
+  /** MCP endpoint URL for MCP publishers, when exposed by the catalog. */
+  publisherMcpEndpoint?: string | null;
   /** Tags for categorization and filtering */
   tags: string[];
   /** Author name or organization */

--- a/src/services/catalog.ts
+++ b/src/services/catalog.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Uses generated hey-api SDK for type-safe API calls.
 
 import {
+  type EndpointDefinition,
   getStorePublisher,
   listStorePublishers,
   type PublisherResponse,
@@ -42,6 +43,10 @@ export interface Publisher {
   unique_agents_served: number;
   // Metadata
   categories: string[];
+  capabilities: string[];
+  endpoints: EndpointDefinition[];
+  api_url: string | null;
+  mcp_endpoint: string | null;
   is_verified: boolean;
   is_active: boolean;
 }
@@ -130,6 +135,10 @@ function transformPublisher(raw: RawPublisher): Publisher {
     total_transactions: raw.total_queries || 0,
     unique_agents_served: raw.unique_agents_served || 0,
     categories,
+    capabilities: raw.capabilities ?? [],
+    endpoints: raw.endpoints ?? [],
+    api_url: raw.api_url ?? null,
+    mcp_endpoint: raw.mcp_endpoint ?? null,
     is_verified: raw.is_verified ?? false,
     is_active: raw.is_active ?? true,
   };
@@ -311,6 +320,10 @@ export const catalog = {
       total_transactions: 0,
       unique_agents_served: 0,
       categories: suggestion.capabilities || [],
+      capabilities: suggestion.capabilities || [],
+      endpoints: [],
+      api_url: null,
+      mcp_endpoint: null,
       is_verified: false,
       is_active: true,
     }));

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -615,6 +615,15 @@ function publisherToSkill(publisher: Publisher): Skill {
     description: publisher.description,
     source: "seren" as SkillSource,
     sourceUrl: `${apiBase}/publishers/${publisher.slug}/skill.md`,
+    publisherSlug: publisher.slug,
+    publisherSourceUrl: `${apiBase}/publishers/${publisher.slug}/skill.md`,
+    publisherName: publisher.resource_name || publisher.name,
+    publisherDescription: publisher.description,
+    publisherType: publisher.publisher_type,
+    publisherCapabilities: publisher.capabilities ?? [],
+    publisherEndpoints: publisher.endpoints ?? [],
+    publisherApiUrl: publisher.api_url ?? null,
+    publisherMcpEndpoint: publisher.mcp_endpoint ?? null,
     tags,
     author: publisher.name,
   };
@@ -629,13 +638,34 @@ function skillMergeKey(skill: Skill, publisherSlugs: Set<string>): string {
     const publisherSlug = skill.slug.slice("seren-".length);
     if (publisherSlugs.has(publisherSlug)) {
       // seren-skills indexes publisher wrappers as category-prefixed slugs
-      // (e.g. seren/seren-bounty -> seren-seren-bounty). Prefer the live
-      // publisher record when that stable upstream slug is present.
+      // (e.g. seren/seren-bounty -> seren-seren-bounty). Collapse them onto
+      // the live publisher slug, but merge precedence is handled separately.
       return publisherSlug;
     }
   }
 
   return skill.slug;
+}
+
+function mergePublisherMetadata(
+  repoSkill: Skill,
+  publisherSkill: Skill,
+): Skill {
+  return {
+    ...repoSkill,
+    id: `${repoSkill.source}:${publisherSkill.slug}`,
+    slug: publisherSkill.slug,
+    tags: [...new Set([...repoSkill.tags, ...publisherSkill.tags])],
+    publisherSlug: publisherSkill.slug,
+    publisherSourceUrl: publisherSkill.sourceUrl,
+    publisherName: publisherSkill.name,
+    publisherDescription: publisherSkill.description,
+    publisherType: publisherSkill.publisherType,
+    publisherCapabilities: publisherSkill.publisherCapabilities,
+    publisherEndpoints: publisherSkill.publisherEndpoints,
+    publisherApiUrl: publisherSkill.publisherApiUrl,
+    publisherMcpEndpoint: publisherSkill.publisherMcpEndpoint,
+  };
 }
 
 /**
@@ -768,7 +798,9 @@ export const skills = {
       this.fetchPublisherSkills(skipCache),
     ]);
 
-    // Merge skills, with publisher skills taking precedence for duplicates
+    // Merge skills by canonical publisher slug. When a seren-skills wrapper is
+    // present, keep its richer SKILL.md/sourceUrl and attach live publisher
+    // metadata for availability/execution.
     const skillMap = new Map<string, Skill>();
     const publisherSlugs = new Set(publisherSkills.map((skill) => skill.slug));
 
@@ -777,9 +809,17 @@ export const skills = {
       skillMap.set(skillMergeKey(skill, publisherSlugs), skill);
     }
 
-    // Publisher skills override index skills (they're more up-to-date)
+    // Publisher-only skills remain available; repo-backed duplicates keep repo
+    // content while gaining publisher metadata.
     for (const skill of publisherSkills) {
-      skillMap.set(skillMergeKey(skill, publisherSlugs), skill);
+      const mergeKey = skillMergeKey(skill, publisherSlugs);
+      const existingSkill = skillMap.get(mergeKey);
+      skillMap.set(
+        mergeKey,
+        existingSkill?.source === "serenorg"
+          ? mergePublisherMetadata(existingSkill, skill)
+          : skill,
+      );
     }
 
     return Array.from(skillMap.values());

--- a/tests/unit/skills-publisher-dedupe.test.ts
+++ b/tests/unit/skills-publisher-dedupe.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Regression coverage for live publisher-backed skill de-duplication.
-// ABOUTME: Ensures seren-skills wrappers do not duplicate live publisher records.
+// ABOUTME: Ensures wrappers keep repo content while retaining publisher metadata.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -51,7 +51,7 @@ describe("skills.fetchAllSkills publisher-backed de-dupe", () => {
     installLocalStorageMock();
   });
 
-  it("prefers the live publisher skill over the seren-skills wrapper", async () => {
+  it("canonicalizes publisher wrappers but preserves seren-skills content", async () => {
     mockAppFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -80,6 +80,15 @@ describe("skills.fetchAllSkills publisher-backed de-dupe", () => {
         description: "Live publisher-backed bounty protocol",
         publisher_type: "mcp",
         categories: ["bounties"],
+        capabilities: ["bounty-creation"],
+        endpoints: [
+          {
+            method: "POST",
+            path: "/events/ingest",
+            description: "Ingest bounty protocol events",
+          },
+        ],
+        mcp_endpoint: "https://api.example.com/mcp",
         is_active: true,
       },
       {
@@ -103,9 +112,29 @@ describe("skills.fetchAllSkills publisher-backed de-dupe", () => {
     ]);
     expect(allSkills.find((skill) => skill.slug === "seren-bounty")).toMatchObject(
       {
-        source: "seren",
-        description: "Live publisher-backed bounty protocol",
+        id: "serenorg:seren-bounty",
+        source: "serenorg",
+        sourceUrl:
+          "https://raw.githubusercontent.com/serenorg/seren-skills/main/seren/seren-bounty/SKILL.md",
+        description: "Repo wrapper for SerenBounty",
+        publisherSlug: "seren-bounty",
+        publisherName: "SerenBounty",
+        publisherDescription: "Live publisher-backed bounty protocol",
+        publisherType: "mcp",
+        publisherCapabilities: ["bounty-creation"],
+        publisherEndpoints: [
+          {
+            method: "POST",
+            path: "/events/ingest",
+            description: "Ingest bounty protocol events",
+          },
+        ],
+        publisherMcpEndpoint: "https://api.example.com/mcp",
       },
     );
+    expect(
+      allSkills.find((skill) => skill.slug === "seren-bounty")
+        ?.publisherSourceUrl,
+    ).toContain("/publishers/seren-bounty/skill.md");
   });
 });


### PR DESCRIPTION
## Summary
- Canonicalize publisher-backed skill duplicates to the live publisher slug while preserving the `seren-skills` repo-backed `SKILL.md` as the primary content source.
- Attach live publisher metadata to the merged skill record, including capabilities, endpoint definitions, publisher type, and API/MCP endpoint URLs.
- Update the focused publisher de-dupe regression test to assert the new precedence rule and attached execution metadata.

Fixes #1704

## Verification
- `pnpm test tests/unit/skills-publisher-dedupe.test.ts`
- `pnpm exec biome check src/services/skills.ts src/services/catalog.ts src/lib/skills/types.ts tests/unit/skills-publisher-dedupe.test.ts`
- `pnpm exec tsc --noEmit --pretty false` *(fails on unrelated existing `tests/unit/cli-updater.test.ts` unused `readFileSync` import)*
