### PR TITLE
Update default Codex agent model to GPT-5.5

### DIFF
--- a/src/lib/providers/seren.ts
+++ b/src/lib/providers/seren.ts
@@ -104,7 +104,7 @@ interface GatewayResponse<T> {
  */
 const DEFAULT_MODELS: ProviderModel[] = [
   // OpenAI
-  { id: "openai/gpt-5.4", name: "OpenAI GPT 5.4", contextWindow: 1050000 },
+  { id: "openai/gpt-5.5", name: "OpenAI GPT 5.5", contextWindow: 1050000 },
   // Anthropic
   {
     id: "anthropic/claude-opus-4.6",

--- a/src/stores/provider.store.ts
+++ b/src/stores/provider.store.ts
@@ -78,7 +78,7 @@ interface ProviderState {
 const DEFAULT_MODELS: Record<ProviderId, ProviderModel[]> = {
   seren: [
     // OpenAI
-    { id: "openai/gpt-5.4", name: "OpenAI GPT 5.4", contextWindow: 1050000 },
+    { id: "openai/gpt-5.5", name: "OpenAI GPT 5.5", contextWindow: 1050000 },
     // Anthropic
     {
       id: "anthropic/claude-opus-4.6",


### PR DESCRIPTION
## Summary
- update Seren default model entries from `openai/gpt-5.4` to `openai/gpt-5.5`
- keep the existing context window and provider ordering unchanged

Fixes #1706

## Validation
- `pnpm exec biome check src/stores/provider.store.ts src/lib/providers/seren.ts`
- `pnpm exec tsc --noEmit --pretty false` *(fails on pre-existing unrelated `tests/unit/cli-updater.test.ts(7,3): 'readFileSync' is declared but its value is never read`)*
