### PR TITLE
fix(agent): graceful 'Task cancelled' events are logged without firing capture (#1708)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -4448,19 +4448,29 @@ Structured summary:`;
         this.handleStatusChange(sessionId, event.data.status, event.data);
         break;
 
-      case "error":
-        // Log full error content for diagnostics (helps debug cascade crashes)
-        console.error(
-          `[AgentStore] Error event for session ${sessionId} (${agentDisplayName(state.sessions[sessionId]?.info.agentType)}):`,
-          event.data.error,
-        );
+      case "error": {
+        // Graceful "Task cancelled" is a system/user-initiated cancel
+        // (predictive-compaction promotion teardown, Stop button, etc.) and
+        // not a defect. Detect it before the diagnostic console.error so
+        // the cancel branch can log strings only — the support hook's
+        // capture filter requires an Error instance / stack-bearing object,
+        // and a plain string skips the public-bug-report path. Mirrors the
+        // RPC-timeout filter from #1699. #1708.
+        const errorMessage = String(event.data.error);
+        const isGracefulCancel = errorMessage.includes("Task cancelled");
+        const errorPrefix = `[AgentStore] Error event for session ${sessionId} (${agentDisplayName(state.sessions[sessionId]?.info.agentType)}):`;
+        if (isGracefulCancel) {
+          console.error(errorPrefix, errorMessage);
+        } else {
+          console.error(errorPrefix, event.data.error);
+        }
 
         // Clean up any in-flight streaming and tool cards
         this.flushPendingUserMessage(sessionId);
         this.finalizeStreamingContent(sessionId);
         this.markPendingToolCallsComplete(sessionId);
 
-        if (String(event.data.error).includes("Task cancelled")) {
+        if (isGracefulCancel) {
           // User-initiated cancellation: record in chat history but don't
           // show the persistent error banner (it's not a real error).
           const cancelMsg: AgentMessage = {
@@ -4626,6 +4636,7 @@ Structured summary:`;
           this.addErrorMessage(sessionId, event.data.error);
         }
         break;
+      }
 
       case "permissionRequest": {
         const permEvent = event.data as PermissionRequestEvent;

--- a/tests/unit/error-event-task-cancelled-noise.test.ts
+++ b/tests/unit/error-event-task-cancelled-noise.test.ts
@@ -1,0 +1,74 @@
+// ABOUTME: Source-level regression for #1708 — graceful "Task cancelled"
+// ABOUTME: events must not be captured by the support pipeline as bug reports.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+// Slice the body of the `case "error":` branch in handleSessionEvent so
+// substring assertions are scoped to just this branch. There's an
+// unrelated `case "error":` in another switch — anchor on the block-open
+// brace to disambiguate, and on the next case clause to bound the slice.
+const errorCaseStart = agentStoreSource.indexOf('case "error": {');
+const errorCaseEnd = agentStoreSource.indexOf(
+  'case "permissionRequest":',
+  errorCaseStart,
+);
+const errorCaseBody = agentStoreSource.slice(errorCaseStart, errorCaseEnd);
+
+describe("#1708 — graceful 'Task cancelled' is logged without firing capture", () => {
+  it("the case 'error' branch detects 'Task cancelled' before the diagnostic console.error fires", () => {
+    // The cancel-detection check must precede the diagnostic console.error
+    // so the call site can pick the string-only signature for graceful
+    // cancels. Otherwise the support hook captures the Error instance
+    // before our existing graceful-cancel handler runs.
+    const detectIdx = errorCaseBody.indexOf('"Task cancelled"');
+    const consoleIdx = errorCaseBody.indexOf("console.error(");
+    expect(detectIdx, "Task cancelled string must exist").toBeGreaterThan(0);
+    expect(consoleIdx, "console.error must exist").toBeGreaterThan(0);
+    expect(detectIdx).toBeLessThan(consoleIdx);
+  });
+
+  it("the graceful-cancel branch calls console.error WITHOUT forwarding event.data.error", () => {
+    // Mirror #1699: log strings only so the support hook's capture filter
+    // (Error instance / stack-bearing object) does not forward this to
+    // the Gateway. Real errors continue to forward the Error instance.
+    const cancelBranchIdx = errorCaseBody.indexOf("isGracefulCancel");
+    expect(
+      cancelBranchIdx,
+      "isGracefulCancel guard must exist in case 'error'",
+    ).toBeGreaterThan(0);
+    // First console.error after the guard must NOT pass event.data.error
+    // as a forwarded Error candidate. Bound the search so we don't bleed
+    // into the non-cancel branch.
+    const region = errorCaseBody.slice(
+      cancelBranchIdx,
+      cancelBranchIdx + 600,
+    );
+    const firstConsoleErr = region.indexOf("console.error(");
+    expect(firstConsoleErr).toBeGreaterThan(0);
+    const elseIdx = region.indexOf("} else {");
+    expect(elseIdx).toBeGreaterThan(firstConsoleErr);
+    const cancelBranchOnly = region.slice(firstConsoleErr, elseIdx);
+    expect(cancelBranchOnly).not.toMatch(/event\.data\.error/);
+  });
+
+  it("the non-cancel branch still forwards event.data.error so real defects are captured", () => {
+    // Guard against a regression that silences ALL "error" events.
+    const cancelBranchIdx = errorCaseBody.indexOf("isGracefulCancel");
+    const region = errorCaseBody.slice(
+      cancelBranchIdx,
+      cancelBranchIdx + 800,
+    );
+    const elseIdx = region.indexOf("} else {");
+    expect(elseIdx).toBeGreaterThan(0);
+    const elseBranch = region.slice(elseIdx, elseIdx + 400);
+    expect(elseBranch).toContain("console.error(");
+    expect(elseBranch).toContain("event.data.error");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #1708. The `case "error"` branch in `handleSessionEvent` (`src/stores/agent.store.ts:4451`) was forwarding `event.data.error` as an `Error` instance to a diagnostic `console.error`. The support hook's capture filter (`src/lib/support/hook.ts:392-397`) saw the Error and filed a public bug report — `serenorg/seren-core#154` is the latest one, but every SIGTERM-during-promotion produces a fresh issue because the dedup signature is sensitive to the bundle hash.
- Detect `"Task cancelled"` before the diagnostic `console.error`. Cancel branch logs strings only so the capture filter skips it; non-cancel branch still forwards the `Error` so real defects continue to be captured.
- Mirrors the RPC-timeout filter from #1699 — same pattern, same shape.

## Why this was missed initially

The handler at line 4473 already recognised graceful cancels and rendered them inline (no banner) — but the diagnostic `console.error` 20 lines above it ran first and was reached on every event, not just real errors. The support pipeline gate sat in front of the inline-cancel handler.

## Test plan

- [x] `pnpm vitest run tests/unit/error-event-task-cancelled-noise.test.ts` — 3/3 pass; RED on `main`, GREEN after the patch.
- [x] `pnpm vitest run` — full suite (609 tests) green.
- [x] `pnpm biome check src/stores/agent.store.ts` — no new errors (12 pre-existing warnings unchanged).
- [ ] Manual smoke after merge: trigger a predictive-compaction promotion and confirm no new `Task cancelled` issue appears in `serenorg/seren-core` within ~30s of the SIGTERM.

Closes serenorg/seren-core#154

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
