### PR TITLE
fix(agent): surface CLI silent-fallback in the model picker (#1678)

### DIFF
--- a/src/components/chat/AgentModelSelector.tsx
+++ b/src/components/chat/AgentModelSelector.tsx
@@ -23,6 +23,23 @@ export const AgentModelSelector: Component<Props> = (props) => {
     return model?.name ?? id;
   };
 
+  // CLI silent-fallback notice (#1678 Option B). Set by the agent store when
+  // the runtime's `message.model` ground truth disagrees with the user's last
+  // explicit selection — surfaces here as an inline warning instead of letting
+  // the picker silently snap back to the actual model.
+  const fallbackNotice = () => props.session?.modelFallbackNotice;
+  const fallbackTitle = () => {
+    const notice = fallbackNotice();
+    if (!notice) return null;
+    const requestedName =
+      availableModels().find((m) => m.modelId === notice.requested)?.name ??
+      notice.requested;
+    const actualName =
+      availableModels().find((m) => m.modelId === notice.actual)?.name ??
+      notice.actual;
+    return `You selected ${requestedName}; the CLI is running ${actualName}. Some Claude Code installs silently fall back when the requested model isn't available.`;
+  };
+
   const handleClickOutside = (event: MouseEvent) => {
     if (dropdownRef && !dropdownRef.contains(event.target as Node)) {
       setIsOpen(false);
@@ -69,6 +86,22 @@ export const AgentModelSelector: Component<Props> = (props) => {
           <span class="font-medium max-w-[120px] truncate">
             {currentModelName() ?? "Model"}
           </span>
+          <Show when={fallbackNotice()}>
+            <svg
+              class="w-3 h-3 text-yellow-500 flex-shrink-0"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              role="img"
+              aria-label="Model fallback warning"
+            >
+              <title>{fallbackTitle() ?? ""}</title>
+              <path
+                fill-rule="evenodd"
+                d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a1 1 0 011 1v4a1 1 0 11-2 0V6a1 1 0 011-1zm0 9a1 1 0 100-2 1 1 0 000 2z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </Show>
           <svg
             class={`w-3 h-3 text-muted-foreground transition-transform ${isOpen() ? "rotate-180" : ""}`}
             fill="none"

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -479,6 +479,23 @@ export interface ActiveSession {
    * runtime state. Cleared once an event acknowledges the new value.
    */
   pendingModelId?: string;
+  /**
+   * Last model id the user explicitly clicked in the picker (#1678 Option B).
+   * Persists past `pendingModelId`'s clear-on-ack so we can keep comparing
+   * the user's intent against `message.model` ground truth (#1635). When the
+   * runtime reports a `currentModelId` that diverges from this, the CLI is
+   * silently falling back — surface the gap to the picker via
+   * `modelFallbackNotice` rather than letting the picker visibly snap back.
+   */
+  userSelectedModelId?: string;
+  /**
+   * Set when `models.currentModelId` from the runtime disagrees with
+   * `userSelectedModelId`. The picker reads this to render an inline warning
+   * ("requested X, CLI is running Y") so users on legacy Opus tiers
+   * understand why their selection didn't take. Cleared when the two line
+   * up again. #1678.
+   */
+  modelFallbackNotice?: { requested: string; actual: string } | null;
   /** Available models reported by the agent */
   availableModels?: AgentModelInfo[];
   /** Currently selected mode ID (if agent supports mode selection) */
@@ -3834,6 +3851,11 @@ Structured summary:`;
     if (!sessionId) return;
 
     setState("sessions", sessionId, "pendingModelId", modelId);
+    setState("sessions", sessionId, "userSelectedModelId", modelId);
+    // The user just made a fresh selection — clear any stale fallback
+    // notice from a previous selection so the picker doesn't carry an
+    // out-of-date warning forward. #1678.
+    setState("sessions", sessionId, "modelFallbackNotice", null);
     setState("sessions", sessionId, "currentModelId", modelId);
     try {
       await providerService.setModel(sessionId, modelId);
@@ -5138,6 +5160,25 @@ Structured summary:`;
         "availableModels",
         models.availableModels,
       );
+
+      // CLI silent-fallback detection (#1678 Option B). Once the setModel
+      // ack has cleared `pendingModelId`, the next `message.model` from the
+      // CLI is ground truth via #1635 and lands here as
+      // `models.currentModelId`. If that disagrees with the user's last
+      // explicit selection, the CLI accepted the request but is running
+      // something else — record the gap so the picker can surface it
+      // instead of letting `currentModelId` silently snap back.
+      const userSelected = state.sessions[sessionId]?.userSelectedModelId;
+      if (!pending && userSelected) {
+        if (userSelected !== models.currentModelId) {
+          setState("sessions", sessionId, "modelFallbackNotice", {
+            requested: userSelected,
+            actual: models.currentModelId,
+          });
+        } else {
+          setState("sessions", sessionId, "modelFallbackNotice", null);
+        }
+      }
     }
 
     // Extract mode state from session status events (e.g. ready with modes,

--- a/tests/unit/cli-model-fallback-notice.test.ts
+++ b/tests/unit/cli-model-fallback-notice.test.ts
@@ -1,0 +1,63 @@
+// ABOUTME: Source-level regression tests for #1678 — surface CLI silent
+// ABOUTME: model fallback to the picker without removing legacy Opus entries.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const selectorSource = readFileSync(
+  resolve("src/components/chat/AgentModelSelector.tsx"),
+  "utf-8",
+);
+
+describe("#1678 Option B — CLI silent fallback surfaces to the picker", () => {
+  it("ActiveSession carries userSelectedModelId (intent) and modelFallbackNotice (divergence)", () => {
+    // userSelectedModelId persists past pendingModelId's clear-on-ack so we
+    // can keep comparing against the user's last clicked id even after the
+    // setModel ack has matched the request.
+    expect(agentStoreSource).toMatch(/userSelectedModelId\?:\s*string/);
+    // The divergence record carries both ids so the UI can show the gap
+    // verbatim ("requested X, CLI is running Y").
+    expect(agentStoreSource).toMatch(
+      /modelFallbackNotice\?:\s*\{\s*requested:\s*string;\s*actual:\s*string\s*\}\s*\|\s*null/,
+    );
+  });
+
+  it("setModel records the user's intent in userSelectedModelId before the IPC call", () => {
+    // Without this, a follow-up message.model that disagrees with the user's
+    // last click is indistinguishable from an externally-driven model change.
+    const idx = agentStoreSource.indexOf("async setModel(");
+    expect(idx).toBeGreaterThan(0);
+    const region = agentStoreSource.slice(idx, idx + 2000);
+    expect(region).toMatch(
+      /setState\("sessions",\s*sessionId,\s*"userSelectedModelId",\s*modelId\)/,
+    );
+  });
+
+  it("sessionStatus handler records modelFallbackNotice when CLI's model diverges from user's selection", () => {
+    // After the pending guard at line ~5118, if the user picked something
+    // (userSelectedModelId set, no pending) and the runtime is reporting a
+    // different actual currentModelId, write a notice so the picker can
+    // surface it. Clears when they line up again.
+    const idx = agentStoreSource.indexOf("pending === models.currentModelId");
+    expect(idx).toBeGreaterThan(0);
+    const region = agentStoreSource.slice(idx, idx + 2500);
+    expect(region).toMatch(/userSelectedModelId/);
+    expect(region).toMatch(/modelFallbackNotice/);
+    // Must store both the requested (user intent) and actual (CLI ground
+    // truth) — verify the notice payload references the userSelected source
+    // and the runtime's actual currentModelId.
+    expect(region).toMatch(/requested:\s*userSelected/);
+    expect(region).toMatch(/actual:\s*models\.currentModelId/);
+  });
+
+  it("AgentModelSelector renders the divergence indicator next to the picker", () => {
+    // Picker must read the notice off the session and surface it. We don't
+    // pin a specific glyph — just that the notice is visible somehow.
+    expect(selectorSource).toMatch(/modelFallbackNotice/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1678. Implements **Option B** from the issue: surface the CLI's silent model fallback to the picker rather than letting `currentModelId` snap back to the actual model without explanation.

## Why Option B (not A or C)

The issue lists three candidates and explicitly says: "we do **NOT** have verified evidence of `set_model` semantics for legacy Opus ids" — so:

- **A. Remove `LEGACY_OPUS_RECORDS`**: aggressive, removes legitimate access for users on tiers Anthropic still accepts.
- **C. Gate `LEGACY_OPUS_RECORDS` by CLI version**: requires a CLI-version → fallback-behavior table we don't have data to build.
- **B. Surface a non-blocking notification on divergence**: deterministic, no behavior loss, gives the user the truth ("you selected X; the CLI is running Y").

## Root cause (recap from #1678)

1. User clicks Opus 4.6 → `setModel` records `pendingModelId = "claude-opus-4-6"`.
2. Runtime sends `set_model` control request; CLI accepts it but runs its default upstream.
3. setModel ack arrives with `currentModelId = "claude-opus-4-6"` → `pendingModelId` clears (#1670).
4. User submits a prompt. Assistant message arrives with `message.model = "claude-opus-4-5"`.
5. `chooseUpdatedModelId` (#1635) makes that ground truth → runtime emits sessionStatus with `currentModelId = "claude-opus-4-5"`.
6. Frontend has no `pendingModelId` anymore (cleared at step 3), so the guard from #1670 lets the new value through. **Picker silently flips to 4.5.**

## Fix shape

- `ActiveSession` adds `userSelectedModelId` (sticky user intent) and `modelFallbackNotice: { requested, actual } | null`.
- `setModel` writes both `pendingModelId` (existing #1670 mechanic) and `userSelectedModelId` (new, persists past the ack), and clears any stale notice.
- The `sessionStatus` handler, after the existing `pendingModelId` guard, compares `models.currentModelId` to `userSelectedModelId`. On divergence: record the gap. On agreement: clear it.
- `AgentModelSelector` reads `modelFallbackNotice` and renders a small yellow warning glyph next to the model name, with a tooltip ("You selected X; the CLI is running Y. Some Claude Code installs silently fall back when the requested model isn't available.").

## What this does NOT do

- Doesn't remove `LEGACY_OPUS_RECORDS` from `bin/browser-local/claude-runtime.mjs` (Option A).
- Doesn't gate the picker by CLI version (Option C).
- Doesn't change `chooseUpdatedModelId` — `message.model` stays ground truth (#1635 invariant intact).
- Doesn't touch the `pendingModelId` clobber-guard (#1670 invariant intact).

## Test plan

- [x] `pnpm vitest run tests/unit/cli-model-fallback-notice.test.ts` — 4/4 pass; RED on `main`, GREEN after.
- [x] `pnpm vitest run tests/unit/agent-model-clobber.test.ts` — existing #1670 guards still pass.
- [x] `pnpm vitest run tests/unit/claude-model-resolution.test.ts` — existing #1635 guards still pass.
- [x] `pnpm biome check` clean on the edited files (14 pre-existing warnings unchanged).
- [ ] Manual smoke: pick Opus 4.6 in the agent dropdown, send a prompt, observe a yellow ⚠ next to the model name when `message.model` reports 4.5; pick another model and confirm the warning clears.

Note: full vitest suite has one unrelated flake (`tests/unit/cli-updater.test.ts > proceeds past TTL when last check is older than 24h`) that times out under load. Verified pre-existing — passes in isolation, also flakes on `main` without my changes.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
