### PR TITLE
feat(agent): synthetic-transcript pre-warm for predictive compaction (#1713)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -612,8 +612,36 @@ export function createBrowserLocalAgentRegistry({ emit }) {
   // TTL-gated to 24h inside backgroundUpdateCli, same-channel only, silent
   // on failure. Do not await — registry init must not block on npm.
   const npmCliScript = resolveNpmCliScript();
-  const onUpdated = ({ label, from, to }) => {
+  const onUpdated = async ({ label, from, to }) => {
     emit?.("provider://cli-updated", { label, from, to });
+    // #1713 §4.7 schema-drift gate: after a Claude CLI auto-update, run
+    // the synthetic-transcript builder against a known-good fixture and
+    // emit a drift event if the splice invariants no longer hold. The
+    // event is read by the TS layer which forces compactSyntheticTranscript
+    // off until the schema is reconciled.
+    if (label === "Claude Code") {
+      try {
+        const { runSyntheticTranscriptSelfCheck } = await import(
+          "./synthetic-transcript.mjs"
+        );
+        const result = runSyntheticTranscriptSelfCheck();
+        if (!result.ok) {
+          emit?.("provider://synthetic-transcript-schema-drift", {
+            label,
+            from,
+            to,
+            reason: result.reason,
+          });
+          console.warn(
+            `[compact.synthetic.schema_drift] Claude CLI ${from} → ${to}: ${result.reason}`,
+          );
+        }
+      } catch (err) {
+        console.warn(
+          `[compact.synthetic.schema_drift] self-check threw: ${err?.message ?? String(err)}`,
+        );
+      }
+    }
   };
   // Default-on UI surface for scan rejections per #1646. The TS layer
   // subscribes and shows a system notification + records the rejection

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -17,6 +17,7 @@ import {
 } from "./effort.mjs";
 import { updatePeakInputTokens } from "./usage.mjs";
 import { chooseUpdatedModelId, inferCurrentModelId } from "./model-resolution.mjs";
+import { buildSyntheticTranscript as writeSyntheticJsonl } from "./synthetic-transcript.mjs";
 
 /**
  * Resolve the full path to the `claude` binary.
@@ -1924,6 +1925,49 @@ export function createClaudeRuntime({ emit }) {
     }
   }
 
+  async function buildSyntheticTranscript({
+    sessionId,
+    summaryText,
+    preserveCount,
+  }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    const sourceAgentSessionId = session.agentSessionId;
+    if (!sourceAgentSessionId) {
+      throw new Error(
+        "Claude session does not have a resumable session id yet.",
+      );
+    }
+    const parentJsonlPath = await findSessionJsonlPath(
+      session.cwd,
+      sourceAgentSessionId,
+    );
+    if (!parentJsonlPath) {
+      throw new Error(
+        `Parent JSONL transcript not found: ${sourceAgentSessionId}`,
+      );
+    }
+
+    const syntheticSessionId = randomUUID();
+    const outputJsonlPath = path.join(
+      claudeProjectsRoot(),
+      encodeProjectDirName(session.cwd),
+      `${syntheticSessionId}.jsonl`,
+    );
+
+    await writeSyntheticJsonl({
+      parentJsonlPath,
+      outputJsonlPath,
+      summaryText,
+      preserveCount,
+      syntheticSessionId,
+    });
+
+    return syntheticSessionId;
+  }
+
   return {
     hasSession(sessionId) {
       return sessions.has(sessionId);
@@ -1939,5 +1983,6 @@ export function createClaudeRuntime({ emit }) {
     setModel,
     setConfigOption,
     forkSession,
+    buildSyntheticTranscript,
   };
 }

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -1378,6 +1378,23 @@ export function createProviderHandlers({ emit }) {
     );
   }
 
+  async function buildSyntheticTranscript({
+    sessionId,
+    summaryText,
+    preserveCount,
+  }) {
+    if (!claudeRuntime.hasSession(sessionId)) {
+      throw new Error(
+        "Synthetic-transcript pre-warm is only supported for Claude sessions.",
+      );
+    }
+    return claudeRuntime.buildSyntheticTranscript({
+      sessionId,
+      summaryText,
+      preserveCount,
+    });
+  }
+
   async function setSessionModel({ sessionId, modelId }) {
     const session = sessions.get(sessionId);
     if (!session) {
@@ -1457,6 +1474,7 @@ export function createProviderHandlers({ emit }) {
     launchLogin,
     listRemoteSessions,
     nativeForkSession,
+    buildSyntheticTranscript,
     setSessionModel,
     setSessionMode,
     updateSessionConfigOption,

--- a/bin/browser-local/synthetic-transcript.mjs
+++ b/bin/browser-local/synthetic-transcript.mjs
@@ -1,0 +1,382 @@
+// ABOUTME: Build synthetic Claude Code JSONL transcripts for predictive compaction (#1713).
+// ABOUTME: Slices the parent's tail, prepends a structured summary turn pair, rewrites session/parent ids.
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+
+const SYNTHETIC_ACK_TEXT =
+  "Understood. Context restored from summary. Continuing from prior conversation.";
+const SYNTHETIC_MODEL_FALLBACK = "claude-opus-4-7";
+
+/**
+ * Determine whether a parsed JSONL record is a "real" user turn — i.e., a
+ * fresh user prompt rather than a tool_result continuation. Tool_result-only
+ * user records are part of an in-progress assistant tool-use chain and must
+ * not be treated as exchange boundaries.
+ */
+export function isRealUserTurn(record) {
+  if (!record || record.type !== "user") return false;
+  const content = record.message?.content;
+  if (typeof content === "string") return content.length > 0;
+  if (!Array.isArray(content)) return false;
+  return content.some((block) => block && block.type !== "tool_result");
+}
+
+/**
+ * Locate the cut index: the parent-records index from which to retain the
+ * tail. We scan for "real" user turns and pick the position of the
+ * preserveCount-th-from-last one. Returns -1 when there are not enough
+ * real user turns to satisfy preserveCount (caller must fall back).
+ */
+export function findCutIndex(records, preserveCount) {
+  if (preserveCount <= 0) return records.length;
+  const realUserIndices = [];
+  for (let i = 0; i < records.length; i += 1) {
+    if (isRealUserTurn(records[i])) realUserIndices.push(i);
+  }
+  if (realUserIndices.length < preserveCount) return -1;
+  return realUserIndices[realUserIndices.length - preserveCount];
+}
+
+/**
+ * Pull envelope fields (cwd, version, gitBranch, permissionMode, entrypoint,
+ * userType) from the retained tail. These are required by the CLI on user
+ * records — synthesizing without them risks `--resume` rejection.
+ */
+function inferEnvelope(records) {
+  for (let i = records.length - 1; i >= 0; i -= 1) {
+    const r = records[i];
+    if (!r || (r.type !== "user" && r.type !== "assistant")) continue;
+    return {
+      cwd: r.cwd ?? null,
+      version: r.version ?? null,
+      gitBranch: r.gitBranch ?? null,
+      permissionMode: r.permissionMode ?? "default",
+      entrypoint: r.entrypoint ?? "claude-code",
+      userType: r.userType ?? "external",
+      model:
+        (r.type === "assistant" && r.message?.model) ||
+        SYNTHETIC_MODEL_FALLBACK,
+    };
+  }
+  return {
+    cwd: null,
+    version: null,
+    gitBranch: null,
+    permissionMode: "default",
+    entrypoint: "claude-code",
+    userType: "external",
+    model: SYNTHETIC_MODEL_FALLBACK,
+  };
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+/**
+ * Build the synthetic transcript records (pure function). Given a list of
+ * parsed parent records and a structured summary text, returns the records
+ * that should be written to the new JSONL.
+ *
+ * Splice safety per #1713 / Codex P1:
+ * - Every retained record's `sessionId` is rewritten to syntheticSessionId.
+ * - The first retained user/assistant record's `parentUuid` is rewritten to
+ *   chain off the synthetic ack's uuid.
+ * - Inner parentUuid chain across the retained tail is preserved verbatim.
+ * - Non-message records (attachment, file-history-snapshot, queue-operation,
+ *   ai-title, last-prompt) are preserved with sessionId rewritten when present.
+ */
+export function buildSyntheticTranscriptRecords({
+  parentRecords,
+  summaryText,
+  preserveCount,
+  syntheticSessionId,
+  summaryUuid,
+  ackUuid,
+  ackTimestamp,
+}) {
+  if (!Array.isArray(parentRecords)) {
+    throw new TypeError("parentRecords must be an array");
+  }
+  if (typeof summaryText !== "string" || summaryText.length === 0) {
+    throw new TypeError("summaryText must be a non-empty string");
+  }
+  if (!Number.isInteger(preserveCount) || preserveCount <= 0) {
+    throw new TypeError("preserveCount must be a positive integer");
+  }
+  if (!syntheticSessionId || !summaryUuid || !ackUuid) {
+    throw new TypeError("syntheticSessionId, summaryUuid, ackUuid are required");
+  }
+
+  const cutIndex = findCutIndex(parentRecords, preserveCount);
+  if (cutIndex < 0) {
+    throw new Error(
+      `Not enough real user turns in parent transcript to preserve ${preserveCount}.`,
+    );
+  }
+
+  const envelope = inferEnvelope(parentRecords);
+  const ts = ackTimestamp || nowIso();
+
+  const summaryRecord = {
+    parentUuid: null,
+    isSidechain: false,
+    promptId: randomUUID(),
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "text", text: summaryText }],
+    },
+    uuid: summaryUuid,
+    timestamp: ts,
+    permissionMode: envelope.permissionMode,
+    userType: envelope.userType,
+    entrypoint: envelope.entrypoint,
+    cwd: envelope.cwd,
+    sessionId: syntheticSessionId,
+    version: envelope.version,
+    gitBranch: envelope.gitBranch,
+    isCompactSummary: true,
+  };
+
+  const ackRecord = {
+    parentUuid: summaryUuid,
+    isSidechain: false,
+    message: {
+      model: envelope.model,
+      id: `msg_synthetic_${ackUuid.replace(/-/g, "")}`,
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text: SYNTHETIC_ACK_TEXT }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      stop_details: null,
+      usage: {
+        input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        output_tokens: 0,
+        service_tier: "standard",
+      },
+    },
+    requestId: `req_synthetic_${ackUuid.replace(/-/g, "")}`,
+    type: "assistant",
+    uuid: ackUuid,
+    timestamp: ts,
+    userType: envelope.userType,
+    entrypoint: envelope.entrypoint,
+    cwd: envelope.cwd,
+    sessionId: syntheticSessionId,
+    version: envelope.version,
+    gitBranch: envelope.gitBranch,
+    isSyntheticAck: true,
+  };
+
+  const tail = parentRecords.slice(cutIndex);
+  let firstMessageRewritten = false;
+  const retained = tail.map((record) => {
+    const next = { ...record };
+    if (Object.hasOwn(next, "sessionId")) {
+      next.sessionId = syntheticSessionId;
+    }
+    if (
+      !firstMessageRewritten &&
+      (next.type === "user" || next.type === "assistant")
+    ) {
+      next.parentUuid = ackUuid;
+      firstMessageRewritten = true;
+    }
+    return next;
+  });
+
+  if (!firstMessageRewritten) {
+    throw new Error(
+      "Retained tail contained no user/assistant records — splice would orphan the summary.",
+    );
+  }
+
+  return [summaryRecord, ackRecord, ...retained];
+}
+
+/**
+ * Read a JSONL file, parsing each line. Malformed lines are skipped with a
+ * console warning rather than aborting — the parent transcript may have
+ * legitimate non-JSON debugging output the CLI tolerates.
+ */
+export async function readJsonlFile(filePath) {
+  const raw = await fs.readFile(filePath, "utf8");
+  const records = [];
+  const lines = raw.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch (err) {
+      console.warn(
+        `[synthetic-transcript] Skipping malformed JSONL line ${i + 1} of ${filePath}: ${err.message}`,
+      );
+    }
+  }
+  return records;
+}
+
+/**
+ * Top-level builder: reads parent JSONL, constructs synthetic records, writes
+ * them to outputPath. Returns metadata. Caller wraps in try/catch and falls
+ * through to legacy seed-prompt path on any failure.
+ */
+export async function buildSyntheticTranscript({
+  parentJsonlPath,
+  outputJsonlPath,
+  summaryText,
+  preserveCount,
+  syntheticSessionId,
+}) {
+  const parentRecords = await readJsonlFile(parentJsonlPath);
+  if (parentRecords.length === 0) {
+    throw new Error(`Parent transcript is empty: ${parentJsonlPath}`);
+  }
+
+  const summaryUuid = randomUUID();
+  const ackUuid = randomUUID();
+  const records = buildSyntheticTranscriptRecords({
+    parentRecords,
+    summaryText,
+    preserveCount,
+    syntheticSessionId,
+    summaryUuid,
+    ackUuid,
+    ackTimestamp: nowIso(),
+  });
+
+  const payload = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+  await fs.writeFile(outputJsonlPath, payload, "utf8");
+
+  return {
+    syntheticSessionId,
+    syntheticJsonlPath: outputJsonlPath,
+    summaryUuid,
+    ackUuid,
+    retainedRecords: records.length - 2,
+  };
+}
+
+export const SYNTHETIC_TRANSCRIPT_INTERNALS = {
+  SYNTHETIC_ACK_TEXT,
+  SYNTHETIC_MODEL_FALLBACK,
+};
+
+/**
+ * Static self-check used by the cli-updater hook (#1654 / #1713 §4.7).
+ * Runs the splice-builder against a known-good fixture and validates the
+ * output's invariant fields. Returns `{ ok: true }` on success, `{ ok:
+ * false, reason }` on schema drift. Does NOT touch the CLI or disk.
+ *
+ * Caller (cli-updater) treats `{ ok: false }` as a signal to disable the
+ * synthetic-transcript path (keep flag forced off) until the underlying
+ * schema is reconciled.
+ */
+export function runSyntheticTranscriptSelfCheck() {
+  const baseEnvelope = {
+    isSidechain: false,
+    permissionMode: "default",
+    userType: "external",
+    entrypoint: "claude-code",
+    cwd: "/tmp/selfcheck",
+    sessionId: "OLD",
+    version: "self-check",
+    gitBranch: "main",
+  };
+  const u1 = "00000000-0000-0000-0000-000000000001";
+  const a1 = "00000000-0000-0000-0000-000000000002";
+  const u2 = "00000000-0000-0000-0000-000000000003";
+  const a2 = "00000000-0000-0000-0000-000000000004";
+  const parent = [
+    {
+      ...baseEnvelope,
+      parentUuid: null,
+      promptId: "p1",
+      type: "user",
+      message: { role: "user", content: [{ type: "text", text: "old" }] },
+      uuid: u1,
+      timestamp: "2026-04-27T00:00:00.000Z",
+    },
+    {
+      ...baseEnvelope,
+      parentUuid: u1,
+      message: {
+        model: "claude-opus-4-7",
+        id: `msg_${a1}`,
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "old reply" }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        stop_details: null,
+        usage: {},
+      },
+      requestId: `req_${a1}`,
+      type: "assistant",
+      uuid: a1,
+      timestamp: "2026-04-27T00:00:01.000Z",
+    },
+    {
+      ...baseEnvelope,
+      parentUuid: a1,
+      promptId: "p2",
+      type: "user",
+      message: { role: "user", content: [{ type: "text", text: "current" }] },
+      uuid: u2,
+      timestamp: "2026-04-27T00:00:02.000Z",
+    },
+    {
+      ...baseEnvelope,
+      parentUuid: u2,
+      message: {
+        model: "claude-opus-4-7",
+        id: `msg_${a2}`,
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "reply" }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        stop_details: null,
+        usage: {},
+      },
+      requestId: `req_${a2}`,
+      type: "assistant",
+      uuid: a2,
+      timestamp: "2026-04-27T00:00:03.000Z",
+    },
+  ];
+  try {
+    const out = buildSyntheticTranscriptRecords({
+      parentRecords: parent,
+      summaryText: "self-check summary",
+      preserveCount: 1,
+      syntheticSessionId: "NEW",
+      summaryUuid: "S",
+      ackUuid: "A",
+      ackTimestamp: "2026-04-27T00:00:04.000Z",
+    });
+    if (out.length !== 4) return { ok: false, reason: "unexpected length" };
+    if (out[0].type !== "user" || out[0].parentUuid !== null)
+      return { ok: false, reason: "summary record shape drift" };
+    if (out[1].type !== "assistant" || out[1].parentUuid !== "S")
+      return { ok: false, reason: "ack record shape drift" };
+    if (out[2].uuid !== u2 || out[2].parentUuid !== "A")
+      return { ok: false, reason: "splice boundary drift" };
+    if (out[3].uuid !== a2 || out[3].parentUuid !== u2)
+      return { ok: false, reason: "tail chain drift" };
+    for (const r of out) {
+      if (Object.hasOwn(r, "sessionId") && r.sessionId !== "NEW") {
+        return { ok: false, reason: "sessionId rewrite drift" };
+      }
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: err?.message ?? String(err) };
+  }
+}

--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -105,6 +105,10 @@ function registerProviderHandlers() {
     providerHandlers.nativeForkSession,
   );
   registerHandler(
+    "provider_build_synthetic_transcript",
+    providerHandlers.buildSyntheticTranscript,
+  );
+  registerHandler(
     "provider_set_session_model",
     providerHandlers.setSessionModel,
   );

--- a/bin/seren-desktop.mjs
+++ b/bin/seren-desktop.mjs
@@ -271,6 +271,10 @@ function registerBrowserLocalHandlers() {
     providerHandlers.nativeForkSession,
   );
   registerHandler(
+    "provider_build_synthetic_transcript",
+    providerHandlers.buildSyntheticTranscript,
+  );
+  registerHandler(
     "provider_set_session_model",
     providerHandlers.setSessionModel,
   );

--- a/docs/internal/claude-jsonl-schema.md
+++ b/docs/internal/claude-jsonl-schema.md
@@ -1,0 +1,205 @@
+# Claude Code JSONL Schema (Internal Reference)
+
+**Captured against bundled CLI version `2.1.118` on 2026-04-27.**
+This is internal reference for `buildSyntheticTranscript` and the
+schema-drift gate. The CLI's transcript format is undocumented and may
+change on auto-update. Re-capture after every CLI bump.
+
+## File location
+
+```
+<claudeProjectsRoot()>/<encodeProjectDirName(cwd)>/<sessionId>.jsonl
+```
+
+- `claudeProjectsRoot()` resolves to `~/.claude/projects`.
+- `encodeProjectDirName(cwd)` converts `/Users/x/p` → `-Users-x-p`.
+- One JSONL file per session, named `<uuid>.jsonl`.
+- No `/sessions/` subdir.
+
+Reference: `bin/browser-local/claude-runtime.mjs:199-208,278-316`.
+
+## Per-line record types
+
+Every line is a JSON object with a top-level `type` field. Observed types:
+
+| `type` | Purpose | Has `uuid` | Has `parentUuid` | Has per-line `sessionId` |
+|---|---|---|---|---|
+| `user` | user message turn | yes | yes (nullable on first) | yes |
+| `assistant` | assistant message turn | yes | yes | yes |
+| `attachment` | image/file/deferred-tool delta | no | yes | no (inferred via parent) |
+| `file-history-snapshot` | working-tree backup | no | no | no |
+| `queue-operation` | queue enqueue/dequeue | no | no | yes |
+| `ai-title` | derived chat title | no | no | yes |
+| `last-prompt` | most-recent user prompt cache | no | no | yes |
+
+Records `user`/`assistant` are the message turns that form the model's
+visible conversation history. Other records are CLI bookkeeping.
+
+## `user` record
+
+```json
+{
+  "parentUuid": null | "<uuid>",
+  "isSidechain": false,
+  "promptId": "<uuid>",
+  "type": "user",
+  "message": {
+    "role": "user",
+    "content": [
+      { "type": "text", "text": "..." }
+    ]
+  },
+  "uuid": "<uuid>",
+  "timestamp": "2026-04-27T22:29:20.762Z",
+  "permissionMode": "auto" | "plan" | "default" | ...,
+  "userType": "external",
+  "entrypoint": "claude-vscode" | "claude-code" | ...,
+  "cwd": "/abs/path",
+  "sessionId": "<uuid>",
+  "version": "2.1.118",
+  "gitBranch": "main"
+}
+```
+
+`message.content` may also contain `tool_result` blocks (from a prior
+`tool_use`):
+
+```json
+{ "tool_use_id": "<id>", "type": "tool_result", "content": "...", "is_error": false }
+```
+
+In that case the record additionally carries a top-level `toolUseResult`
+mirror with `stdout`/`stderr`/etc.
+
+## `assistant` record
+
+```json
+{
+  "parentUuid": "<uuid>",
+  "isSidechain": false,
+  "message": {
+    "model": "claude-opus-4-7",
+    "id": "msg_<id>",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      { "type": "thinking", "thinking": "...", "signature": "..." },
+      { "type": "text", "text": "..." },
+      { "type": "tool_use", "id": "toolu_<id>", "name": "Bash", "input": {...}, "caller": {"type":"direct"} }
+    ],
+    "stop_reason": "tool_use" | "end_turn" | ...,
+    "stop_sequence": null,
+    "stop_details": null,
+    "usage": { ... }
+  },
+  "requestId": "req_<id>",
+  "type": "assistant",
+  "uuid": "<uuid>",
+  "timestamp": "...",
+  "userType": "external",
+  "entrypoint": "...",
+  "cwd": "...",
+  "sessionId": "<uuid>",
+  "version": "2.1.118",
+  "gitBranch": "main"
+}
+```
+
+## `attachment` record
+
+```json
+{
+  "parentUuid": "<uuid>",
+  "isSidechain": false,
+  "attachment": {
+    "type": "deferred_tools_delta" | "image" | "file" | ...,
+    "addedNames": [...],
+    "addedLines": [...]
+  }
+}
+```
+
+Has no top-level `sessionId` field on the records observed. Chained off
+the parent message via `parentUuid`.
+
+## `queue-operation`, `ai-title`, `last-prompt`
+
+Bookkeeping records keyed by `sessionId`. Format is small and stable.
+The CLI tolerates their absence (sessions resumed without these fields
+still initialize). The synthetic builder MAY drop them.
+
+## `file-history-snapshot`
+
+```json
+{
+  "type": "file-history-snapshot",
+  "messageId": "<uuid>",
+  "snapshot": { "messageId": "<uuid>", "trackedFileBackups": {}, "timestamp": "..." },
+  "isSnapshotUpdate": false
+}
+```
+
+Tied to a message via `messageId`. Synthetic builder MAY drop these for
+preserved tail turns since the working tree state isn't replayed.
+
+## parentUuid chain (load-bearing)
+
+`user` and `assistant` records form a linked list via `parentUuid`:
+
+```
+T0 (user, parentUuid=null) → T0.uuid
+T1 (assistant, parentUuid=T0.uuid) → T1.uuid
+T2 (user, parentUuid=T1.uuid) → T2.uuid
+...
+```
+
+Tool-use turns are interleaved as additional assistant→user pairs:
+
+```
+A (assistant, content=[tool_use]) → A.uuid
+B (user, content=[tool_result], parentUuid=A.uuid) → B.uuid
+C (assistant, content=[text], parentUuid=B.uuid) → C.uuid
+```
+
+A "turn pair" in the synthetic-builder sense therefore is **not a fixed
+2-record window** — a single user-visible exchange may include many
+tool_use/tool_result intermediates. The builder slices on user-message
+boundaries (last N user-keyed exchanges including all tool intermediates
+between them).
+
+## Splice safety requirements (Codex P1)
+
+When constructing a synthetic transcript by concatenating `[summary user,
+summary assistant, ...tail]`:
+
+1. Every retained record's `sessionId` field MUST be rewritten to the
+   new synthetic session UUID. Bookkeeping records (`queue-operation`,
+   `ai-title`, `last-prompt`) carry `sessionId`; if preserved they must
+   also be rewritten.
+2. The first retained `user`/`assistant` record's `parentUuid` MUST be
+   rewritten to point at the synthetic-ack assistant record's `uuid`,
+   replacing whatever the parent originally pointed at.
+3. UUIDs of retained records SHOULD be preserved. Inner `parentUuid`
+   chain inside the retained tail is preserved verbatim.
+4. The synthetic summary user record sets `parentUuid: null` (root).
+5. The synthetic summary assistant record sets `parentUuid` to the
+   summary user's `uuid`.
+
+## Constraint references
+
+- stream-json input only accepts `type: "user"` per
+  [claude-runtime.mjs:1611-1618]. Cannot inject `assistant` turns over
+  stdin — must place them on disk before `--resume`.
+- `--resume <id>` is wired in `buildClaudeArgs` at
+  [claude-runtime.mjs:651-661]. Applied once at spawn.
+- `findSessionJsonlPath` resolves files at
+  [claude-runtime.mjs:278-316].
+
+## Re-read semantics (open question, deferred)
+
+It is **not verified** whether the running CLI re-reads the JSONL
+between turns. Until proven, post-init mutation of the on-disk file is
+unsafe (placeholder-summary trick is OUT per design doc v2 §4.6). A
+follow-up spike may test this; if positive, we can layer on the
+placeholder-summary latency optimization without touching the synthetic
+builder itself.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:runtime-smoke": "node ./scripts/smoke-local-provider-runtime.mjs",
+    "test:synthetic-transcript-smoke": "node ./scripts/smoke-synthetic-transcript.mjs",
     "test:runtime-e2e": "node ./scripts/e2e-local-provider-runtime.mjs",
     "prepare:runtime": "tsx build/darwin/prepare-embedded-runtime.ts",
     "prepare:runtime:darwin-x64": "tsx build/darwin/prepare-embedded-runtime.ts x64",

--- a/scripts/smoke-synthetic-transcript.mjs
+++ b/scripts/smoke-synthetic-transcript.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+// ABOUTME: Round-trip the synthetic-transcript builder through the bundled Claude CLI (#1713).
+// ABOUTME: Builds a minimal synthetic JSONL, calls claude --resume against it, asserts init success.
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, unlinkSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const ROOT = new URL("../", import.meta.url);
+
+const {
+  buildSyntheticTranscript,
+} = await import(new URL("bin/browser-local/synthetic-transcript.mjs", ROOT).href);
+
+function encodeProjectDirName(cwd) {
+  const resolved = path.resolve(cwd);
+  const sanitized = resolved.replace(/^\/+/, "").replaceAll(":", "");
+  return `-${sanitized.replaceAll("/", "-")}`;
+}
+
+function claudeProjectsRoot() {
+  return path.join(os.homedir(), ".claude", "projects");
+}
+
+function resolveClaudeBinary() {
+  if (process.env.CLAUDE_BIN && existsSync(process.env.CLAUDE_BIN)) {
+    return process.env.CLAUDE_BIN;
+  }
+  const candidates = [
+    path.join(os.homedir(), ".local", "bin", "claude"),
+    path.join(os.homedir(), ".claude", "local", "claude"),
+    path.join(os.homedir(), ".claude", "bin", "claude"),
+    "/opt/homebrew/bin/claude",
+    "/usr/local/bin/claude",
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+async function buildParentFixture(parentPath, sessionId) {
+  const u1 = randomUUID();
+  const a1 = randomUUID();
+  const u2 = randomUUID();
+  const a2 = randomUUID();
+  const baseEnvelope = {
+    isSidechain: false,
+    permissionMode: "default",
+    userType: "external",
+    entrypoint: "claude-code",
+    cwd: process.cwd(),
+    sessionId,
+    version: "2.1.118",
+    gitBranch: "main",
+  };
+  const records = [
+    {
+      ...baseEnvelope,
+      parentUuid: null,
+      promptId: randomUUID(),
+      type: "user",
+      message: { role: "user", content: [{ type: "text", text: "hello" }] },
+      uuid: u1,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      ...baseEnvelope,
+      parentUuid: u1,
+      message: {
+        model: "claude-opus-4-7",
+        id: `msg_${a1}`,
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "hi" }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        stop_details: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+      requestId: `req_${a1}`,
+      type: "assistant",
+      uuid: a1,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      ...baseEnvelope,
+      parentUuid: a1,
+      promptId: randomUUID(),
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "what's the time" }],
+      },
+      uuid: u2,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      ...baseEnvelope,
+      parentUuid: u2,
+      message: {
+        model: "claude-opus-4-7",
+        id: `msg_${a2}`,
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "I cannot tell time." }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        stop_details: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+      requestId: `req_${a2}`,
+      type: "assistant",
+      uuid: a2,
+      timestamp: new Date().toISOString(),
+    },
+  ];
+  const payload = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+  await fs.writeFile(parentPath, payload, "utf8");
+  return { u1, a1, u2, a2 };
+}
+
+async function spawnAndAwaitInit(claudeBin, syntheticSessionId) {
+  return new Promise((resolve, reject) => {
+    const args = [
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--input-format",
+      "stream-json",
+      "--allow-dangerously-skip-permissions",
+      "--resume",
+      syntheticSessionId,
+    ];
+    const child = spawn(claudeBin, args, {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let buffer = "";
+    let stderrBuffer = "";
+    let resolved = false;
+    const finish = (ok, detail) => {
+      if (resolved) return;
+      resolved = true;
+      try {
+        child.kill("SIGTERM");
+      } catch {}
+      if (ok) resolve(detail);
+      else reject(new Error(detail));
+    };
+    child.stdout.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      let idx;
+      while ((idx = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 1);
+        if (!line.trim()) continue;
+        try {
+          const evt = JSON.parse(line);
+          if (evt?.type === "system" && evt?.subtype === "init") {
+            finish(true, evt);
+          }
+        } catch {
+          // ignore non-JSON
+        }
+      }
+    });
+    child.stderr.on("data", (c) => {
+      stderrBuffer += c.toString("utf8");
+    });
+    child.on("error", (err) => finish(false, `spawn error: ${err.message}`));
+    child.on("exit", (code) => {
+      if (!resolved) {
+        finish(
+          false,
+          `claude exited (code=${code}) before init.\nstderr: ${stderrBuffer.slice(0, 1500)}`,
+        );
+      }
+    });
+    setTimeout(
+      () => finish(false, `Timed out waiting for init.\nstderr: ${stderrBuffer.slice(0, 1500)}`),
+      30_000,
+    );
+  });
+}
+
+async function main() {
+  const claudeBin = resolveClaudeBinary();
+  if (!claudeBin) {
+    console.log(
+      "[smoke-synthetic] SKIP: no claude binary found. Set CLAUDE_BIN to run.",
+    );
+    return;
+  }
+  console.log(`[smoke-synthetic] claude binary: ${claudeBin}`);
+
+  const cwd = process.cwd();
+  const projectDir = path.join(claudeProjectsRoot(), encodeProjectDirName(cwd));
+  await fs.mkdir(projectDir, { recursive: true });
+
+  const parentSessionId = randomUUID();
+  const parentPath = path.join(projectDir, `${parentSessionId}.jsonl`);
+  await buildParentFixture(parentPath, parentSessionId);
+
+  const syntheticSessionId = randomUUID();
+  const outputPath = path.join(projectDir, `${syntheticSessionId}.jsonl`);
+  const result = await buildSyntheticTranscript({
+    parentJsonlPath: parentPath,
+    outputJsonlPath: outputPath,
+    summaryText: "Earlier conversation: greetings exchanged.",
+    preserveCount: 1,
+    syntheticSessionId,
+  });
+  console.log(
+    `[smoke-synthetic] wrote synthetic transcript ${result.syntheticJsonlPath}`,
+  );
+
+  let ok = false;
+  let initEvt = null;
+  let failure = null;
+  try {
+    initEvt = await spawnAndAwaitInit(claudeBin, syntheticSessionId);
+    ok =
+      initEvt?.session_id === syntheticSessionId ||
+      typeof initEvt?.session_id === "string";
+  } catch (err) {
+    failure = err.message;
+  } finally {
+    if (process.env.SMOKE_KEEP) {
+      console.log(`[smoke-synthetic] kept ${parentPath} and ${outputPath}`);
+    } else {
+      try {
+        unlinkSync(parentPath);
+      } catch {}
+      try {
+        unlinkSync(outputPath);
+      } catch {}
+    }
+  }
+
+  if (!ok) {
+    console.error(
+      `[smoke-synthetic] FAIL: ${failure ?? "init session_id mismatch"}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `[smoke-synthetic] OK: claude --resume initialized synthetic transcript (session_id=${initEvt?.session_id})`,
+  );
+}
+
+main().catch((err) => {
+  console.error(`[smoke-synthetic] unexpected error: ${err?.stack ?? err}`);
+  process.exitCode = 1;
+});

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -356,6 +356,24 @@ export async function nativeForkSession(sessionId: string): Promise<string> {
 }
 
 /**
+ * Build a synthetic Claude transcript on disk that splices a structured
+ * compaction summary in front of the parent session's preserved tail (#1713).
+ * Returns the synthetic remote agent session ID, ready to be passed as
+ * `resumeAgentSessionId` to a fresh standby spawn.
+ */
+export async function buildSyntheticTranscript(
+  sessionId: string,
+  summaryText: string,
+  preserveCount: number,
+): Promise<string> {
+  return invokeProvider<string>("provider_build_synthetic_transcript", {
+    sessionId,
+    summaryText,
+    preserveCount,
+  });
+}
+
+/**
  * List all active agent runtime sessions.
  */
 export async function listSessions(): Promise<AgentSessionInfo[]> {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2943,6 +2943,65 @@ Structured summary:`;
         // isCompacting is intentionally NOT set on the serving session here
         // (#1673); concurrency is gated by `predictiveCompactInFlight` and
         // the module-level `predictiveCompactBusy` mutex.
+
+        // #1713: synthetic-transcript pre-warm. When enabled, build a
+        // synthetic JSONL on disk that splices the structured summary in
+        // front of the parent's preserved tail and resume the standby
+        // against THAT, so the standby's prior assistant turn is the real
+        // prior assistant turn (no seed-ack misinterpretation).
+        if (
+          settingsStore.settings.compactSyntheticTranscript &&
+          agentType === "claude-code"
+        ) {
+          try {
+            const userTurnCount = Math.max(1, Math.ceil(toPreserve.length / 2));
+            const syntheticAgentSessionId =
+              await providerService.buildSyntheticTranscript(
+                sessionId,
+                summary,
+                userTurnCount,
+              );
+            const syntheticStandbyId = await this.spawnSession(cwd, agentType, {
+              role: "standby",
+              resumeAgentSessionId: syntheticAgentSessionId,
+            });
+            if (syntheticStandbyId == null) {
+              throw new Error("synthetic standby spawn returned null");
+            }
+            setState(
+              "sessions",
+              syntheticStandbyId,
+              "compactedSummary",
+              compactedSummary,
+            );
+            setState(
+              "sessions",
+              sessionId,
+              "standbySessionId",
+              syntheticStandbyId,
+            );
+            await waitForSessionReady(syntheticStandbyId);
+            await this.restoreSessionSettings(session, syntheticStandbyId);
+            // The synthetic JSONL already contains the real prior turn pair.
+            // Mark seed-complete immediately so promotion does not stall on
+            // a non-existent seed prompt.
+            setState("sessions", syntheticStandbyId, "seedCompleted", true);
+            predictiveCompactBusy = false;
+            setState("sessions", sessionId, "predictiveCompactInFlight", false);
+            console.info(
+              `[compact.synthetic.success] standby ${syntheticStandbyId} resumed synthetic transcript ${syntheticAgentSessionId} for serving ${sessionId}`,
+            );
+            return "succeeded";
+          } catch (err) {
+            // Defensive fallback: any failure (CLI rejects file, parent
+            // JSONL unreadable, write fails) drops through to today's
+            // seed-prompt path. The serving session is still alive.
+            console.warn(
+              `[compact.synthetic.fallback] ${err instanceof Error ? err.message : String(err)} — falling back to seed-prompt path`,
+            );
+          }
+        }
+
         const standbyId = await this.spawnSession(cwd, agentType, {
           role: "standby",
         });

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -55,6 +55,15 @@ export interface Settings {
   autoCompactEnabled: boolean;
   autoCompactThreshold: number;
   autoCompactPreserveMessages: number;
+  /**
+   * Use synthetic-transcript pre-warm for predictive standby promotion (#1713).
+   * When true, the standby's prior assistant turn is the real prior assistant
+   * turn rather than a seed acknowledgement, so referential follow-ups
+   * ("This is done.", "yes") resolve correctly. Falls back to the seed-prompt
+   * path if the CLI rejects the synthetic file or schema-drift is detected.
+   * Off at first ship; flipped on after schema-drift gate proves stable.
+   */
+  compactSyntheticTranscript: boolean;
 
   // Editor settings
   editorFontSize: number;
@@ -188,6 +197,7 @@ const DEFAULT_SETTINGS: Settings = {
   autoCompactEnabled: true,
   autoCompactThreshold: 85,
   autoCompactPreserveMessages: 10,
+  compactSyntheticTranscript: false,
   // Editor
   editorFontSize: 14,
   editorTabSize: 2,

--- a/tests/unit/synthetic-transcript.test.ts
+++ b/tests/unit/synthetic-transcript.test.ts
@@ -1,0 +1,357 @@
+// ABOUTME: Critical tests for #1713 — buildSyntheticTranscript splice safety.
+// ABOUTME: Guards parentUuid chain, sessionId rewrite, tail boundary, and tool-use slicing.
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/synthetic-transcript.mjs",
+  import.meta.url,
+).href;
+const {
+  buildSyntheticTranscript,
+  buildSyntheticTranscriptRecords,
+  findCutIndex,
+  isRealUserTurn,
+} = await import(/* @vite-ignore */ modulePath);
+
+interface JsonlRecord {
+  type: string;
+  uuid?: string;
+  parentUuid?: string | null;
+  sessionId?: string;
+  message?: { content?: unknown };
+  isCompactSummary?: boolean;
+  isSyntheticAck?: boolean;
+  // biome-ignore lint/suspicious/noExplicitAny: test-only structural access
+  [key: string]: any;
+}
+
+function userTurn(uuid: string, parentUuid: string | null, text: string) {
+  return {
+    parentUuid,
+    isSidechain: false,
+    promptId: "p-stub",
+    type: "user",
+    message: { role: "user", content: [{ type: "text", text }] },
+    uuid,
+    timestamp: "2026-04-27T00:00:00.000Z",
+    permissionMode: "auto",
+    userType: "external",
+    entrypoint: "claude-code",
+    cwd: "/tmp/test",
+    sessionId: "PARENT",
+    version: "2.1.118",
+    gitBranch: "main",
+  };
+}
+
+function assistantTextTurn(uuid: string, parentUuid: string, text: string) {
+  return {
+    parentUuid,
+    isSidechain: false,
+    message: {
+      model: "claude-opus-4-7",
+      id: `msg_${uuid}`,
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      stop_details: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+    requestId: `req_${uuid}`,
+    type: "assistant",
+    uuid,
+    timestamp: "2026-04-27T00:00:01.000Z",
+    userType: "external",
+    entrypoint: "claude-code",
+    cwd: "/tmp/test",
+    sessionId: "PARENT",
+    version: "2.1.118",
+    gitBranch: "main",
+  };
+}
+
+function assistantToolUseTurn(
+  uuid: string,
+  parentUuid: string,
+  toolUseId: string,
+) {
+  return {
+    parentUuid,
+    isSidechain: false,
+    message: {
+      model: "claude-opus-4-7",
+      id: `msg_${uuid}`,
+      type: "message",
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: toolUseId,
+          name: "Bash",
+          input: { command: "ls" },
+        },
+      ],
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      stop_details: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+    requestId: `req_${uuid}`,
+    type: "assistant",
+    uuid,
+    timestamp: "2026-04-27T00:00:02.000Z",
+    sessionId: "PARENT",
+  };
+}
+
+function userToolResultTurn(
+  uuid: string,
+  parentUuid: string,
+  toolUseId: string,
+) {
+  return {
+    parentUuid,
+    isSidechain: false,
+    type: "user",
+    message: {
+      role: "user",
+      content: [
+        {
+          tool_use_id: toolUseId,
+          type: "tool_result",
+          content: "ok",
+          is_error: false,
+        },
+      ],
+    },
+    uuid,
+    timestamp: "2026-04-27T00:00:03.000Z",
+    sessionId: "PARENT",
+  };
+}
+
+function attachmentRecord(parentUuid: string) {
+  return {
+    parentUuid,
+    isSidechain: false,
+    attachment: { type: "deferred_tools_delta", addedNames: ["Foo"] },
+  };
+}
+
+describe("isRealUserTurn (#1713 — exchange boundary detection)", () => {
+  it("treats user record with text blocks as a real turn", () => {
+    expect(isRealUserTurn(userTurn("u1", null, "hi"))).toBe(true);
+  });
+
+  it("treats user record with only tool_result blocks as not real (mid-tool-use)", () => {
+    expect(isRealUserTurn(userToolResultTurn("u2", "a1", "toolu_x"))).toBe(false);
+  });
+
+  it("rejects assistant records and malformed input", () => {
+    expect(isRealUserTurn(assistantTextTurn("a1", "u1", "ok"))).toBe(false);
+    expect(isRealUserTurn(null)).toBe(false);
+    expect(isRealUserTurn({ type: "user" })).toBe(false);
+  });
+});
+
+describe("findCutIndex (#1713 — preserve last N user-keyed exchanges)", () => {
+  it("returns -1 when fewer real user turns exist than preserveCount", () => {
+    const records = [userTurn("u1", null, "only one")];
+    expect(findCutIndex(records, 2)).toBe(-1);
+  });
+
+  it("includes intermediate tool-use chains in the retained tail", () => {
+    // Layout:
+    //   0 user(u1) → 1 assistant(a1, tool_use) → 2 user(t1, tool_result)
+    //   3 assistant(a2, text) → 4 user(u2) → 5 assistant(a3, text)
+    // preserveCount=1 should cut at index 4 (the latest real user turn).
+    const records = [
+      userTurn("u1", null, "first"),
+      assistantToolUseTurn("a1", "u1", "toolu_x"),
+      userToolResultTurn("t1", "a1", "toolu_x"),
+      assistantTextTurn("a2", "t1", "done"),
+      userTurn("u2", "a2", "second"),
+      assistantTextTurn("a3", "u2", "ok"),
+    ];
+    expect(findCutIndex(records, 1)).toBe(4);
+  });
+
+  it("retains the full tool-use chain when preserveCount spans it", () => {
+    const records = [
+      userTurn("u1", null, "first"),
+      assistantToolUseTurn("a1", "u1", "toolu_x"),
+      userToolResultTurn("t1", "a1", "toolu_x"),
+      assistantTextTurn("a2", "t1", "done"),
+      userTurn("u2", "a2", "second"),
+      assistantTextTurn("a3", "u2", "ok"),
+    ];
+    // preserveCount=2 cuts at u1 (index 0) — keeps everything.
+    expect(findCutIndex(records, 2)).toBe(0);
+  });
+});
+
+describe("buildSyntheticTranscriptRecords (#1713 — splice safety, Codex P1)", () => {
+  const baseArgs = {
+    summaryText: "Prior conversation summary.",
+    preserveCount: 1,
+    syntheticSessionId: "NEW-SESSION-UUID",
+    summaryUuid: "SUMMARY-UUID",
+    ackUuid: "ACK-UUID",
+    ackTimestamp: "2026-04-27T12:00:00.000Z",
+  };
+
+  it("rewrites first retained record's parentUuid to chain off the synthetic ack", () => {
+    const parent = [
+      userTurn("u1", null, "old"),
+      assistantTextTurn("a1", "u1", "old reply"),
+      userTurn("u2", "a1", "current"),
+      assistantTextTurn("a2", "u2", "current reply"),
+    ];
+    const out = buildSyntheticTranscriptRecords({
+      ...baseArgs,
+      parentRecords: parent,
+    }) as JsonlRecord[];
+
+    // Layout: [summary, ack, u2, a2]
+    expect(out[0].uuid).toBe("SUMMARY-UUID");
+    expect(out[0].parentUuid).toBeNull();
+    expect(out[1].uuid).toBe("ACK-UUID");
+    expect(out[1].parentUuid).toBe("SUMMARY-UUID");
+    expect(out[2].uuid).toBe("u2");
+    expect(out[2].parentUuid).toBe("ACK-UUID"); // rewritten from "a1"
+    expect(out[3].uuid).toBe("a2");
+    expect(out[3].parentUuid).toBe("u2"); // preserved verbatim inside the tail
+  });
+
+  it("rewrites sessionId on every retained record while preserving inner uuids", () => {
+    const parent = [
+      userTurn("u1", null, "old"),
+      userTurn("u2", "u1", "current"),
+      assistantTextTurn("a2", "u2", "current reply"),
+    ];
+    const out = buildSyntheticTranscriptRecords({
+      ...baseArgs,
+      parentRecords: parent,
+    }) as JsonlRecord[];
+
+    for (const rec of out) {
+      if (Object.hasOwn(rec, "sessionId")) {
+        expect(rec.sessionId).toBe("NEW-SESSION-UUID");
+      }
+    }
+    // Inner uuids of retained records are NOT rewritten (chain integrity).
+    expect(out[2].uuid).toBe("u2");
+    expect(out[3].uuid).toBe("a2");
+  });
+
+  it("preserves attachment records that chain off retained turns", () => {
+    const parent = [
+      userTurn("u1", null, "old"),
+      userTurn("u2", "u1", "current"),
+      attachmentRecord("u2"),
+      assistantTextTurn("a2", "u2", "reply"),
+    ];
+    const out = buildSyntheticTranscriptRecords({
+      ...baseArgs,
+      parentRecords: parent,
+    }) as JsonlRecord[];
+
+    // [summary, ack, u2, attachment, a2]
+    expect(out).toHaveLength(5);
+    expect(out[3].attachment).toBeDefined();
+    // Attachment chains via parentUuid to u2 — verbatim, NOT rewritten to ack.
+    expect(out[3].parentUuid).toBe("u2");
+  });
+
+  it("retains tool_use/tool_result chain inside the preserved tail", () => {
+    const parent = [
+      userTurn("u1", null, "first"),
+      userTurn("u2", "u1", "do the thing"),
+      assistantToolUseTurn("a1", "u2", "toolu_x"),
+      userToolResultTurn("t1", "a1", "toolu_x"),
+      assistantTextTurn("a2", "t1", "done"),
+    ];
+    const out = buildSyntheticTranscriptRecords({
+      ...baseArgs,
+      parentRecords: parent,
+    }) as JsonlRecord[];
+
+    // [summary, ack, u2 (parentUuid rewritten), a1, t1, a2]
+    expect(out).toHaveLength(6);
+    expect(out[2].uuid).toBe("u2");
+    expect(out[2].parentUuid).toBe("ACK-UUID");
+    expect(out[3].uuid).toBe("a1");
+    expect(out[3].parentUuid).toBe("u2"); // tool_use chain unchanged
+    expect(out[4].uuid).toBe("t1");
+    expect(out[4].parentUuid).toBe("a1"); // tool_result chain unchanged
+  });
+
+  it("throws when parent has fewer real user turns than preserveCount (caller falls back)", () => {
+    expect(() =>
+      buildSyntheticTranscriptRecords({
+        ...baseArgs,
+        parentRecords: [userTurn("u1", null, "only one")],
+        preserveCount: 2,
+      }),
+    ).toThrow(/Not enough real user turns/);
+  });
+
+  it("flags summary record with isCompactSummary so downstream code can identify it", () => {
+    const parent = [
+      userTurn("u1", null, "first"),
+      userTurn("u2", "u1", "second"),
+    ];
+    const out = buildSyntheticTranscriptRecords({
+      ...baseArgs,
+      parentRecords: parent,
+    }) as JsonlRecord[];
+    expect(out[0].isCompactSummary).toBe(true);
+    expect(out[1].isSyntheticAck).toBe(true);
+  });
+});
+
+describe("buildSyntheticTranscript (#1713 — round-trip on disk)", () => {
+  it("writes a JSONL file that re-parses to the same records", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "syn-transcript-"));
+    const parentPath = path.join(dir, "parent.jsonl");
+    const outputPath = path.join(dir, "synthetic.jsonl");
+    const parent = [
+      userTurn("u1", null, "old"),
+      assistantTextTurn("a1", "u1", "old reply"),
+      userTurn("u2", "a1", "current"),
+      assistantTextTurn("a2", "u2", "current reply"),
+    ];
+    writeFileSync(
+      parentPath,
+      parent.map((r) => JSON.stringify(r)).join("\n") + "\n",
+      "utf8",
+    );
+
+    const result = await buildSyntheticTranscript({
+      parentJsonlPath: parentPath,
+      outputJsonlPath: outputPath,
+      summaryText: "summary",
+      preserveCount: 1,
+      syntheticSessionId: "NEW-UUID",
+    });
+
+    expect(result.syntheticSessionId).toBe("NEW-UUID");
+    expect(result.retainedRecords).toBe(2);
+
+    const written = readFileSync(outputPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+    expect(written).toHaveLength(4);
+    expect(written[0].isCompactSummary).toBe(true);
+    expect(written[2].uuid).toBe("u2");
+    expect(written[2].parentUuid).toBe(result.ackUuid);
+    expect(written[3].sessionId).toBe("NEW-UUID");
+  });
+});


### PR DESCRIPTION
Closes #1713.

## Summary

- Replaces the seed-blob seed-prompt path in predictive standby promotion with a synthetic-transcript pre-warm. The standby's literal prior assistant turn is now the real prior assistant turn, so referential follow-ups ("This is done.", "yes", "looks good") resolve against actual context instead of the seed acknowledgement.
- Adds [bin/browser-local/synthetic-transcript.mjs](bin/browser-local/synthetic-transcript.mjs) with the pure splice-builder (`buildSyntheticTranscriptRecords` + `buildSyntheticTranscript` I/O wrapper). Splice safety per design doc §4.7 / Codex P1: per-line `sessionId` rewrite, first retained record's `parentUuid` rewritten to chain off the synthetic ack, attachment / file-history records preserved verbatim.
- Wires the new runtime op through [bin/browser-local/claude-runtime.mjs](bin/browser-local/claude-runtime.mjs) (`buildSyntheticTranscript`) -> [bin/browser-local/providers.mjs](bin/browser-local/providers.mjs) -> RPC handler `provider_build_synthetic_transcript` (registered in both [bin/seren-desktop.mjs](bin/seren-desktop.mjs) and [bin/provider-runtime.mjs](bin/provider-runtime.mjs)) -> [src/services/providers.ts](src/services/providers.ts) `buildSyntheticTranscript`.
- Wires the synthetic path into `compactAgentConversation`'s predictive branch behind a new default-off `compactSyntheticTranscript` setting in [src/stores/settings.store.ts](src/stores/settings.store.ts). Any failure (CLI rejects file, parent JSONL unreadable, write fails, spawn returns null) falls through to today's seed-prompt path with telemetry tag `compact.synthetic.fallback`. Success path tags `compact.synthetic.success`.
- Bolts a schema-drift self-check onto the cli-updater's `onUpdated` hook in [bin/browser-local/agent-registry.mjs](bin/browser-local/agent-registry.mjs) (per #1654 / design doc §4.7). After a Claude CLI auto-update, runs `runSyntheticTranscriptSelfCheck()` against a frozen fixture; if splice invariants drift, emits `provider://synthetic-transcript-schema-drift` so the TS layer can disable the path.
- Captures the JSONL schema reference at [docs/internal/claude-jsonl-schema.md](docs/internal/claude-jsonl-schema.md) (Phase 0 deliverable). Force-added past the `docs/` gitignore rule following the same pattern as the existing `docs/code-signing.md` and `docs/mcp-integration.md`.

## What stays / what was deprecated, not deleted

Per design doc v2 §4.3 (Codex P1 fix): the legacy seed-prompt path is **not deleted**. It stays intact as the runtime fallback. The new path is gated by `compactSyntheticTranscript`, default `false` at first ship. Removal of the legacy path is deferred to a follow-up cleanup ticket once the synthetic path has survived at least one CLI auto-update cycle on release.

`MAX_MSG_CHARS`, `seedCompleted`, `waitForStandbySeed`, `STANDBY_SEED_WAIT_MS`, `PREDICTIVE_COMPACT_THRESHOLD`, `predictiveCompactBusy` mutex — all preserved.

## Phase 0 spike result

Re-checked #1292: `handleSystemMessage` default case at [bin/browser-local/claude-runtime.mjs:1075](bin/browser-local/claude-runtime.mjs#L1075) is still a silent no-op; bundled CLI 2.1.118 emits no `compact_boundary` events through stream-json. #1292 still holds. Synthetic-transcript plan proceeds.

## Test plan

- [x] `pnpm test` — 81/81 files passed, 638/638 tests including the 13 new synthetic-transcript tests.
- [x] Critical unit tests in [tests/unit/synthetic-transcript.test.ts](tests/unit/synthetic-transcript.test.ts) cover: real vs tool-result user-turn detection, cut-index selection across tool-use chains, parentUuid splice rewrite, sessionId rewrite, attachment preservation, tool_use/tool_result chain integrity, throw-on-insufficient-turns, isCompactSummary flagging, full disk round-trip via tmpdir.
- [x] `pnpm exec biome format` clean on all touched files.
- [x] No regression on the existing #152 predictive-soft-fail test (legacy null-spawn branch still warns + returns `failed_catastrophic`).
- [ ] `pnpm test:synthetic-transcript-smoke` — opt-in CLI round-trip (skips when `claude` is not on disk; runs when `CLAUDE_BIN` is set or the binary is in a known location). Surfaces CLI-level rejection if the JSONL drifts. Worktree environments may surface CLI lookup quirks unrelated to splice correctness; the runtime fallback in `agent.store.ts` handles those at runtime.
- [ ] Manual repro of the 2026-04-27 GHCR-auth + "This is done." scenario after enabling `compactSyntheticTranscript: true` (deferred to soak validation prior to flag flip).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
