### PR TITLE
fix(agent): route 85% auto-compact through kickPredictiveCompact (#1716)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -4431,22 +4431,24 @@ Structured summary:`;
                 // we just declined to compact. Show the modal.
                 requestSignInModal();
               } else {
-                // Explicit undefined for pendingUserPrompt: the prompt that
-                // just produced this promptComplete already succeeded, so we
-                // do NOT retry it — retrying would duplicate the turn. Queued
-                // prompts handled via pendingPrompts transfer inside compaction.
                 // Predictive mode (#1675): spawn a standby alongside the live
                 // serving session instead of tearing it down. The next user
                 // submit promotes the standby; the chatbox stays mounted so
                 // there is no flash. The standby-not-ready fallback in
                 // sendPrompt handles the race when the user submits before
                 // the seed completes.
-                this.compactAgentConversation(
-                  sessionId,
-                  settingsStore.settings.autoCompactPreserveMessages,
-                  undefined,
-                  { mode: "predictive" },
-                );
+                //
+                // #1716: route through `kickPredictiveCompact` rather than
+                // calling `compactAgentConversation` directly. The helper
+                // flips `predictiveCompactBusy` and `predictiveCompactInFlight`
+                // synchronously before the first await, so the 70% predictive
+                // block below short-circuits on the same `promptComplete`.
+                // Calling `compactAgentConversation` directly bypassed both
+                // flags and let the 70% block kick a second concurrent
+                // standby that orphaned the first. Queued prompts and
+                // pendingUserPrompt handling already live inside
+                // `kickPredictiveCompact` -> `compactAgentConversation`.
+                void this.kickPredictiveCompact(sessionId);
               }
             }
           }

--- a/tests/unit/agent-predictive-compaction.test.ts
+++ b/tests/unit/agent-predictive-compaction.test.ts
@@ -50,6 +50,65 @@ describe("#1631 — kickPredictiveCompact + promoteStandbyAndDispatch", () => {
     expect(agentStoreSource).toContain("if (predictiveCompactBusy) return");
   });
 
+  it("#1716 — sets predictiveCompactBusy + predictiveCompactInFlight synchronously before the first await", () => {
+    // The duplicate-spawn race (#1716) was: the 85% auto-compact branch
+    // called compactAgentConversation directly, so the global mutex
+    // (`predictiveCompactBusy`) and per-session flag
+    // (`predictiveCompactInFlight`) stayed false until well after the
+    // first `await` (the Sonnet-4 summary call). The 70% predictive block
+    // that ran on the same `promptComplete` event then saw clean guards
+    // and kicked a SECOND standby — orphaning the first.
+    //
+    // The fix routes the 85% branch through `kickPredictiveCompact`,
+    // which is the only caller that flips both flags synchronously
+    // before any `await`. Guard against a regression that pushes the
+    // flag flip after an `await` (which would re-open the race).
+    const fnStart = agentStoreSource.indexOf("async kickPredictiveCompact(");
+    expect(fnStart, "kickPredictiveCompact must exist").toBeGreaterThan(0);
+    const fnEnd = agentStoreSource.indexOf("\n  },", fnStart);
+    const fnBody = agentStoreSource.slice(fnStart, fnEnd);
+
+    const busyFlipIdx = fnBody.indexOf("predictiveCompactBusy = true");
+    const inFlightFlipIdx = fnBody.indexOf(
+      'setState("sessions", sessionId, "predictiveCompactInFlight", true)',
+    );
+    const firstAwaitIdx = fnBody.indexOf("await ");
+
+    expect(busyFlipIdx, "predictiveCompactBusy must be flipped true").toBeGreaterThan(
+      0,
+    );
+    expect(
+      inFlightFlipIdx,
+      "predictiveCompactInFlight must be flipped true",
+    ).toBeGreaterThan(0);
+    expect(firstAwaitIdx, "first await must exist").toBeGreaterThan(0);
+    expect(
+      busyFlipIdx,
+      "predictiveCompactBusy must flip BEFORE the first await",
+    ).toBeLessThan(firstAwaitIdx);
+    expect(
+      inFlightFlipIdx,
+      "predictiveCompactInFlight must flip BEFORE the first await",
+    ).toBeLessThan(firstAwaitIdx);
+  });
+
+  it("#1716 — 85% auto-compact branch and 70% predictive branch both gate on the same per-session flag", () => {
+    // Without this contract the orphan-standby race returns: the 85%
+    // branch could route through kickPredictiveCompact while the 70%
+    // branch still gates on something else, and a third concurrent path
+    // would be created. Both branches must observe predictiveCompactInFlight.
+    const promptCompleteAnchor = "Predictive compaction — warm a replacement";
+    const promptCompleteIdx = agentStoreSource.indexOf(promptCompleteAnchor);
+    expect(promptCompleteIdx).toBeGreaterThan(0);
+    const block = agentStoreSource.slice(
+      promptCompleteIdx,
+      promptCompleteIdx + 1000,
+    );
+    expect(block).toContain("!sess.predictiveCompactInFlight");
+    expect(block).toContain("PREDICTIVE_COMPACT_THRESHOLD");
+    expect(block).toContain("this.kickPredictiveCompact(sessionId)");
+  });
+
   it("promoteStandbyAndDispatch swaps serving/standby at turn boundary", () => {
     expect(agentStoreSource).toContain("async promoteStandbyAndDispatch(");
     // serving gets terminated after the transcript transfers to the promoted id.

--- a/tests/unit/auto-compact-predictive.test.ts
+++ b/tests/unit/auto-compact-predictive.test.ts
@@ -10,15 +10,53 @@ const agentStoreSource = readFileSync(
   "utf-8",
 );
 
-describe("#1675 — auto-compact-from-promptComplete uses predictive mode", () => {
-  it("passes { mode: \"predictive\" } so the chatbox stays mounted", () => {
-    // The flash regression: if this call defaults to reactive, terminateSession
-    // deletes the active session, hasSession() flips to false, and
-    // <Show when={hasSession()}> unmounts the input area until the new session
-    // registers. Predictive mode warms a standby alongside the live session
-    // and promotes it on the NEXT user submit — no teardown, no flash.
-    expect(agentStoreSource).toContain(
-      "settingsStore.settings.autoCompactPreserveMessages,\n                  undefined,\n                  { mode: \"predictive\" },",
+describe("#1675 / #1716 — auto-compact-from-promptComplete uses predictive mode", () => {
+  it("routes through kickPredictiveCompact so the chatbox stays mounted (#1675) AND the predictive mutex is set before the first await (#1716)", () => {
+    // The flash regression (#1675): if compaction defaults to reactive,
+    // terminateSession deletes the active session, hasSession() flips to
+    // false, and <Show when={hasSession()}> unmounts the input area until
+    // the new session registers. Predictive mode warms a standby alongside
+    // the live session and promotes it on the NEXT user submit.
+    //
+    // The duplicate-spawn regression (#1716): calling compactAgentConversation
+    // directly bypasses `kickPredictiveCompact`, which is the only caller
+    // that flips `predictiveCompactBusy` / `predictiveCompactInFlight`
+    // synchronously before the first await. The 70% predictive block that
+    // runs immediately after in the same promptComplete handler then sees
+    // clean guards and spawns a SECOND standby, orphaning the first.
+    //
+    // Routing through `kickPredictiveCompact` (which itself uses predictive
+    // mode internally) fixes both at once.
+    const autoCompactAnchor = "Auto-compact check runs BEFORE drain (#1623)";
+    const drainAnchor = "Drain the prompt queue for this session";
+    const autoCompactIdx = agentStoreSource.indexOf(autoCompactAnchor);
+    const drainIdx = agentStoreSource.indexOf(drainAnchor);
+    expect(autoCompactIdx, "auto-compact anchor must exist").toBeGreaterThan(0);
+    expect(drainIdx, "drain anchor must exist").toBeGreaterThan(autoCompactIdx);
+    const block = agentStoreSource.slice(autoCompactIdx, drainIdx);
+
+    // The auto-compact branch must call kickPredictiveCompact, NOT
+    // compactAgentConversation directly.
+    expect(block).toContain("this.kickPredictiveCompact(sessionId)");
+    expect(block).not.toMatch(
+      /this\.compactAgentConversation\(\s*sessionId,\s*settingsStore\.settings\.autoCompactPreserveMessages/,
+    );
+  });
+
+  it("kickPredictiveCompact still drives compactAgentConversation in predictive mode", () => {
+    // Belt-and-suspenders: the call site changed from a direct invocation
+    // to the mutexed helper, but the helper itself must still pass
+    // `mode: "predictive"` — otherwise the chatbox flash regression
+    // returns even though the duplicate-spawn race is fixed.
+    const helperStart = agentStoreSource.indexOf(
+      "async kickPredictiveCompact(",
+    );
+    expect(helperStart, "kickPredictiveCompact must exist").toBeGreaterThan(0);
+    const helperEnd = agentStoreSource.indexOf("\n  },", helperStart);
+    const helperBody = agentStoreSource.slice(helperStart, helperEnd);
+    expect(helperBody).toContain('mode: "predictive"');
+    expect(helperBody).toContain(
+      "settingsStore.settings.autoCompactPreserveMessages",
     );
   });
 });

--- a/tests/unit/compaction-auth-gate.test.ts
+++ b/tests/unit/compaction-auth-gate.test.ts
@@ -22,21 +22,27 @@ describe("#1639 — auto-compact auth gate", () => {
     );
   });
 
-  it("checks authStore.isAuthenticated before calling compactAgentConversation", () => {
+  it("checks authStore.isAuthenticated before kicking predictive compaction", () => {
+    // Post-#1716: the auto-compact branch routes through
+    // `this.kickPredictiveCompact(sessionId)` instead of calling
+    // `compactAgentConversation` directly. The auth gate must still
+    // dominate the kick — otherwise an unauthenticated user at >=85%
+    // usage triggers a Sonnet-4 summary call that will fail at the
+    // gateway and burn telemetry.
     const authCheck = "if (!authStore.isAuthenticated)";
-    const compactCall = "this.compactAgentConversation(";
-    const authCheckIdx = agentStoreSource.indexOf(authCheck);
-    expect(authCheckIdx, "auth check must exist").toBeGreaterThan(0);
-
-    // The auth check must appear before the compact call in the auto-compact block
+    const kickCall = "this.kickPredictiveCompact(sessionId)";
     const autoCompactAnchor = "Auto-compact check runs BEFORE drain (#1623)";
     const autoCompactIdx = agentStoreSource.indexOf(autoCompactAnchor);
+    expect(autoCompactIdx, "auto-compact anchor must exist").toBeGreaterThan(
+      0,
+    );
+
     const authCheckAfterAnchor = agentStoreSource.indexOf(
       authCheck,
       autoCompactIdx,
     );
-    const compactCallAfterAnchor = agentStoreSource.indexOf(
-      compactCall,
+    const kickCallAfterAnchor = agentStoreSource.indexOf(
+      kickCall,
       autoCompactIdx,
     );
     expect(
@@ -44,9 +50,13 @@ describe("#1639 — auto-compact auth gate", () => {
       "auth check must appear after auto-compact anchor",
     ).toBeGreaterThan(autoCompactIdx);
     expect(
+      kickCallAfterAnchor,
+      "auto-compact branch must call kickPredictiveCompact",
+    ).toBeGreaterThan(autoCompactIdx);
+    expect(
       authCheckAfterAnchor,
-      "auth check must appear before compactAgentConversation call",
-    ).toBeLessThan(compactCallAfterAnchor);
+      "auth check must appear before kickPredictiveCompact call",
+    ).toBeLessThan(kickCallAfterAnchor);
   });
 
   it("calls requestSignInModal() when auth check fails in auto-compact path (#1661 — was promptLogin, now real modal)", () => {

--- a/tests/unit/compaction-queue-race.test.ts
+++ b/tests/unit/compaction-queue-race.test.ts
@@ -60,11 +60,35 @@ describe("#1623 — compactAgentConversation transfers pendingPrompts to new ses
     );
   });
 
-  it("auto-compact-from-promptComplete passes undefined for pendingUserPrompt", () => {
+  it("auto-compact-from-promptComplete does not retry the just-completed prompt (#1716 routes via kickPredictiveCompact)", () => {
     // The prompt that produced this promptComplete already succeeded — we
     // MUST NOT retry it or the user sees a duplicate turn.
-    expect(agentStoreSource).toContain(
-      "settingsStore.settings.autoCompactPreserveMessages,\n                  undefined,",
+    //
+    // Post-#1716, the auto-compact branch routes through
+    // `this.kickPredictiveCompact(sessionId)` rather than calling
+    // `compactAgentConversation` directly. `kickPredictiveCompact` does
+    // not accept a pendingUserPrompt param, and its internal compact call
+    // hardcodes `undefined` — so the no-retry contract still holds, just
+    // one indirection deeper.
+    const autoCompactAnchor = "Auto-compact check runs BEFORE drain (#1623)";
+    const drainAnchor = "Drain the prompt queue for this session";
+    const autoCompactIdx = agentStoreSource.indexOf(autoCompactAnchor);
+    const drainIdx = agentStoreSource.indexOf(drainAnchor);
+    const autoCompactBlock = agentStoreSource.slice(autoCompactIdx, drainIdx);
+    expect(autoCompactBlock).toContain("this.kickPredictiveCompact(sessionId)");
+    // The auto-compact branch must NOT pass any pendingUserPrompt arg —
+    // it has no business retrying the just-completed prompt.
+    expect(autoCompactBlock).not.toMatch(
+      /kickPredictiveCompact\(sessionId,\s*[^)]/,
+    );
+
+    // kickPredictiveCompact's internal compactAgentConversation call must
+    // still pass undefined for pendingUserPrompt.
+    const kickStart = agentStoreSource.indexOf("async kickPredictiveCompact(");
+    const kickEnd = agentStoreSource.indexOf("\n  },", kickStart);
+    const kickBody = agentStoreSource.slice(kickStart, kickEnd);
+    expect(kickBody).toMatch(
+      /this\.compactAgentConversation\([\s\S]*?undefined,[\s\S]*?\{ mode: "predictive" \}/,
     );
   });
 


### PR DESCRIPTION
Closes #1716.

## Summary

- One-line fix in [src/stores/agent.store.ts](src/stores/agent.store.ts): the 85% auto-compact branch now routes through `this.kickPredictiveCompact(sessionId)` instead of calling `compactAgentConversation(..., { mode: "predictive" })` directly. `kickPredictiveCompact` is the only caller that flips `predictiveCompactBusy` and `predictiveCompactInFlight` synchronously before the first `await`, so the 70% predictive block that runs immediately after on the same `promptComplete` short-circuits instead of kicking a second concurrent standby.
- Tests updated to match the post-fix shape and to lock in the load-bearing invariants:
  - [tests/unit/auto-compact-predictive.test.ts](tests/unit/auto-compact-predictive.test.ts) — was hard-coding the buggy direct-call shape (Codex P1). Now asserts the auto-compact branch routes via the mutexed helper, and the helper still passes `mode: "predictive"` (preserves the #1675 chatbox-flash fix).
  - [tests/unit/compaction-auth-gate.test.ts](tests/unit/compaction-auth-gate.test.ts) — was asserting auth check precedes `compactAgentConversation`, the wrong call. Now asserts auth check precedes `kickPredictiveCompact`.
  - [tests/unit/compaction-queue-race.test.ts](tests/unit/compaction-queue-race.test.ts) — was checking the buggy direct call passed `undefined` for `pendingUserPrompt`. Now asserts the auto-compact branch passes no extra args to `kickPredictiveCompact`, and the helper's internal `compactAgentConversation` call still passes `undefined` for `pendingUserPrompt` (no duplicate-turn regression).
  - [tests/unit/agent-predictive-compaction.test.ts](tests/unit/agent-predictive-compaction.test.ts) — adds two new load-bearing tests:
    - `predictiveCompactBusy` and `predictiveCompactInFlight` flip synchronously **before** the first `await` inside `kickPredictiveCompact`. This is the exact invariant that catches #1716; pushing either flag flip behind an `await` reopens the race.
    - The 85% auto-compact and 70% predictive branches both gate on the same per-session `predictiveCompactInFlight` flag — preventing a third concurrent path from being added in the future.

## Codex P1 review resolutions

| # | Codex P1 finding | Resolution in this PR |
|---|---|---|
| P0 | The 85% branch still calls `compactAgentConversation` directly, bypassing the mutex | Fixed in [src/stores/agent.store.ts](src/stores/agent.store.ts) — branch now calls `kickPredictiveCompact`. |
| P1 | `auto-compact-predictive` test hard-codes the buggy direct call and would block the fix | Rewritten — now asserts the post-fix routing AND the chatbox-flash invariant. |
| P1 | `compaction-auth-gate` and `agent-predictive-compaction` don't cover the real fix shape | `compaction-auth-gate` asserts auth precedes `kickPredictiveCompact`; `agent-predictive-compaction` gets two new tests on synchronous mutex flipping and shared per-session gating. |
| Assumption | Is the global one-at-a-time predictive contract intentional? | Yes — `serving.standbySessionId` is a single-pointer slot. Two concurrent standby spawns leave one orphaned by definition. Single-flag mutex is the correct semantics; no priority policy needed. |

## Test plan

- [x] `pnpm vitest run tests/unit/auto-compact-predictive.test.ts tests/unit/agent-predictive-compaction.test.ts tests/unit/compaction-queue-race.test.ts tests/unit/predictive-drain-not-blocked.test.ts tests/unit/compaction-predictive-soft-fail.test.ts tests/unit/compaction-auth-gate.test.ts` — 50/50 passed (the same suite Codex ran, now exercising the post-fix shape).
- [x] `pnpm test` — 81/81 files passed, 641/641 tests (was 638 before; +3 new #1716 assertions).
- [x] `pnpm exec biome format` clean on all touched files.
- [x] `pnpm tsc --noEmit` clean (only pre-existing unused-import warning in `tests/unit/cli-updater.test.ts`).
- [ ] Manual repro: serving session at >=85% input usage produces exactly **one** `Predictive compaction: standby … seeding` log per `promptComplete`, not two. Validate after merge in the next over-85% session.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
