### PR TITLE
feat(agent): instrument Claude/Codex/Gemini runtimes for model-state observability (#1718)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1096,10 +1096,19 @@ function handleAssistantMessage(emit, session, payload) {
   // set_model control request that the CLI ignores (or that falls back to
   // a different model upstream) leaves the UI showing a model the session
   // isn't actually running. See #1635.
+  const previousModelId = session.currentModelId;
   const nextModelId = chooseUpdatedModelId(
-    session.currentModelId,
+    previousModelId,
     message.model,
     session.availableModelRecords,
+  );
+  // Trace every resolution — both the changing path and the steady-state — so
+  // when the picker disagrees with the assistant's self-report (#1718) we can
+  // read message.model directly from the log instead of guessing. The line
+  // ends up in `~/Library/Logs/com.serendb.desktop/SerenDesktop.log` via the
+  // ProviderRuntime stderr bridge.
+  console.warn(
+    `[browser-local][claude] chooseUpdatedModelId: previous=${previousModelId ?? "<unset>"}, incoming=${message.model ?? "<missing>"}, resolved=${nextModelId ?? "<null>"}`,
   );
   if (nextModelId != null && nextModelId !== session.currentModelId) {
     session.currentModelId = nextModelId;
@@ -1783,13 +1792,26 @@ export function createClaudeRuntime({ emit }) {
       );
     }
 
-    await sendControlRequest(
+    const setModelResponse = await sendControlRequest(
       session,
       {
         subtype: "set_model",
         model: modelId,
       },
       10_000,
+    );
+    // Log the raw control response so silent CLI fallbacks (some control
+    // APIs return an "actual model used" field that disagrees with the
+    // request) become visible. Stringification is bounded to keep the log
+    // line under a sane size. #1718.
+    let responseSummary;
+    try {
+      responseSummary = JSON.stringify(setModelResponse).slice(0, 500);
+    } catch {
+      responseSummary = "<unserializable>";
+    }
+    console.warn(
+      `[browser-local][claude] setModel ack: requested=${modelId}, response=${responseSummary}`,
     );
 
     session.currentModelId = targetModel?.modelId ?? modelId;

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -988,6 +988,14 @@ export function createGeminiRuntime({ emit }) {
     }
     session.currentModelId = modelId;
     emit("provider://session-status", buildSessionStatus(session));
+    // Phase 1 limitation: Gemini's --model flag is set at spawn time. The
+    // running gemini-cli process keeps its spawn-time model regardless of
+    // this assignment; the picker change only takes effect on the next
+    // session spawn. Surface this so the user can see the disconnect in
+    // logs instead of silently sending prompts to the wrong model. #1718.
+    console.warn(
+      `[browser-local][gemini] setModel: ${modelId} stored as session intent — no-op against the running CLI process (Gemini --model is fixed at spawn time). The next session spawn will use this model.`,
+    );
   }
 
   return {

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -1042,11 +1042,26 @@ export function createProviderHandlers({ emit }) {
         threadResult?.threadId ??
         session.agentSessionId;
       session.codexVersion = threadResult?.thread?.cliVersion ?? session.codexVersion;
-      session.currentModelId =
-        threadResult?.model ??
+      const requestedModelId =
         getSelectedModelRecord(session)?.modelId ??
         session.availableModelRecords[0]?.modelId ??
         null;
+      const servedModelId = threadResult?.model ?? null;
+      // Codex's only place where a CLI silent fallback can surface is the
+      // thread/start (or thread/resume) response — message.model is not
+      // emitted by the codex stream the way Anthropic's is. Log when the
+      // CLI hands us back a different model than we requested. #1718.
+      if (
+        servedModelId &&
+        requestedModelId &&
+        servedModelId !== requestedModelId
+      ) {
+        console.warn(
+          `[browser-local][codex] threadResult.model: requested=${requestedModelId}, served=${servedModelId}`,
+        );
+      }
+      session.currentModelId =
+        servedModelId ?? requestedModelId ?? null;
       session.reasoningEffort =
         threadResult?.reasoningEffort ??
         getSelectedModelRecord(session)?.defaultReasoningEffort ??

--- a/tests/unit/agent-model-observability.test.ts
+++ b/tests/unit/agent-model-observability.test.ts
@@ -1,0 +1,90 @@
+// ABOUTME: Source-level regression tests for #1718 — instrument all three
+// ABOUTME: agent runtimes (Claude / Codex / Gemini) so picker/runtime model
+// ABOUTME: divergence is always visible in the app log.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const claudeRuntime = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+const providersRuntime = readFileSync(
+  resolve("bin/browser-local/providers.mjs"),
+  "utf-8",
+);
+const geminiRuntime = readFileSync(
+  resolve("bin/browser-local/gemini-runtime.mjs"),
+  "utf-8",
+);
+
+describe("#1718 Claude runtime — chooseUpdatedModelId + set_model are logged", () => {
+  it("logs every chooseUpdatedModelId resolution in the message handler", () => {
+    // The message handler calls chooseUpdatedModelId (#1635). Without a log
+    // here, the only signal that the CLI's `message.model` disagrees with
+    // the picker is the visible UI flip — there is no record we can audit
+    // after the fact. The log line must include `previous`, `incoming`, and
+    // `resolved` so the diagnosis is unambiguous.
+    const callIdx = claudeRuntime.indexOf("chooseUpdatedModelId(");
+    expect(callIdx).toBeGreaterThan(0);
+    const region = claudeRuntime.slice(callIdx, callIdx + 1200);
+    expect(region).toMatch(/console\.(log|info|warn)\(/);
+    expect(region).toMatch(/chooseUpdatedModelId/);
+    expect(region).toMatch(/previous/);
+    expect(region).toMatch(/incoming/);
+    expect(region).toMatch(/resolved/);
+  });
+
+  it("logs every set_model control response so silent CLI fallbacks are visible", () => {
+    // Find the setModel function and verify a log is emitted around the
+    // sendControlRequest response. The existing #1679 "not in catalog"
+    // warn only fires on the catalog-miss path; we need a log on the
+    // success path too so we can see what the CLI actually accepted.
+    const fnIdx = claudeRuntime.indexOf("async function setModel(");
+    expect(fnIdx).toBeGreaterThan(0);
+    const region = claudeRuntime.slice(fnIdx, fnIdx + 2000);
+    expect(region).toMatch(/sendControlRequest\([\s\S]*?set_model/);
+    // At least one console call after the control request that surfaces
+    // either the requested model id or the response payload.
+    const after = region.slice(region.indexOf("sendControlRequest"));
+    expect(after).toMatch(/console\.(log|info|warn)\([\s\S]*?(set_model|requested)/);
+  });
+});
+
+describe("#1718 Codex runtime — thread/start model adoption is logged", () => {
+  it("logs when threadResult.model differs from the requested selection", () => {
+    // Codex picks `threadResult.model ?? selected ?? records[0]` after
+    // thread/start. If thread/start hands back a different id than what the
+    // user picked, that's the only place a fallback can surface — log it.
+    const idx = providersRuntime.indexOf(
+      "session.currentModelId =\n        threadResult?.model",
+    );
+    // Tolerate either the multi-line or single-line styling, fall back to
+    // a substring that pins both fields together.
+    const anchor =
+      idx > 0
+        ? idx
+        : providersRuntime.indexOf("threadResult?.model ??");
+    expect(anchor).toBeGreaterThan(0);
+    const region = providersRuntime.slice(anchor - 400, anchor + 1200);
+    expect(region).toMatch(/console\.(log|info|warn)\(/);
+    expect(region).toMatch(/threadResult/);
+    expect(region).toMatch(/(requested|served|selected)/);
+  });
+});
+
+describe("#1718 Gemini runtime — mid-session setModel surfaces as a warn", () => {
+  it("setModel emits a console.warn explaining it is a no-op until the next spawn", () => {
+    // Mid-session setModel does not plumb to gemini-cli (Phase 1 limitation
+    // documented in the runtime). Without a log the user can change the
+    // picker and never know the running process is unchanged.
+    const fnIdx = geminiRuntime.indexOf("async function setModel(");
+    expect(fnIdx).toBeGreaterThan(0);
+    const region = geminiRuntime.slice(fnIdx, fnIdx + 1200);
+    expect(region).toContain("console.warn(");
+    // Pin the message text so the warn cannot be silently rewritten into
+    // something less honest.
+    expect(region).toMatch(/(no-op|spawn[ -]time)/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1718. Behavior-neutral diagnostic logging across all three agent runtimes so picker-vs-reality model divergence stops being invisible. Direct response to my own undebuggable claim in the conversation that led to #1718 — I owed Taariq evidence and didn't have any.

## What lands

| Runtime | What's logged |
| --- | --- |
| Claude (`bin/browser-local/claude-runtime.mjs`) | Every `chooseUpdatedModelId` resolution: `previous=…, incoming=…, resolved=…`. `setModel` ack: `requested=…, response=<json>`. |
| Codex (`bin/browser-local/providers.mjs`) | After `thread/start` or `thread/resume`, when `threadResult.model` differs from the requested model: `requested=…, served=…`. |
| Gemini (`bin/browser-local/gemini-runtime.mjs`) | `setModel` warn: explicit "no-op against the running CLI process — Gemini --model is fixed at spawn time. Next spawn will use this model." |

All three lines route through `ProviderRuntime stderr` and land in `~/Library/Logs/com.serendb.desktop/SerenDesktop.log`.

## Test plan

- [x] `tests/unit/agent-model-observability.test.ts` — 4 source-level assertions, RED on `main`, GREEN after.
- [x] `pnpm vitest run` — full suite **645/645 pass**.
- [x] Biome — `bin/browser-local/*.mjs` is excluded by config; existing `src/` files unchanged.
- [ ] Manual: pick Opus 4.7 in the picker, send a prompt; tail the app log and confirm a `chooseUpdatedModelId: previous=…, incoming=…, resolved=…` line appears with the raw `message.model` value.

## Out of scope (deliberate)

- Removing `LEGACY_OPUS_RECORDS` (unchanged from #1678).
- Mid-session model re-spawn for Gemini (Phase 2, separate ticket once we have evidence the diagnostic logging exposes silent fallback that justifies the work).
- Any change to `chooseUpdatedModelId`, the pendingModelId guard, or the #1714 fallback indicator. #1635 ground-truth contract intact.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
