### PR TITLE
feat(updater): silently install available update on app startup (#1720)

### DIFF
--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -70,6 +70,13 @@ async function initUpdater(): Promise<void> {
 
   await checkForUpdates();
 
+  // Auto-install on startup only (#1720). Mid-session interval re-checks keep
+  // today's manual-pill behavior so the user is not forced to restart while
+  // working.
+  if (state.status === "available") {
+    await installAvailableUpdate();
+  }
+
   // Re-check every 15 minutes so the badge appears without requiring a restart
   setInterval(() => {
     if (state.status !== "downloading" && state.status !== "installing") {

--- a/tests/unit/updater-store.test.ts
+++ b/tests/unit/updater-store.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests the updater install sequence around browsing-data clearing.
 // ABOUTME: Verifies updates clear the current webview cache before restart without blocking relaunch.
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockStoreState,
@@ -62,6 +62,13 @@ describe("updaterStore install flow", () => {
     relaunchMock.mockReset();
     clearAllBrowsingDataMock.mockReset();
     captureErrorMock.mockReset();
+    // Vitest sets import.meta.env.DEV=true; the prod-only code paths under
+    // test would otherwise short-circuit through isDevRuntime().
+    vi.stubEnv("DEV", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("clears browsing data before relaunching an installed update", async () => {
@@ -85,6 +92,37 @@ describe("updaterStore install flow", () => {
     expect(clearAllBrowsingDataMock.mock.invocationCallOrder[0]).toBeLessThan(
       relaunchMock.mock.invocationCallOrder[0],
     );
+  });
+
+  it("initUpdater silently installs an available update on startup (#1720)", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const downloadAndInstallMock = vi.fn(async () => {});
+    checkMock.mockResolvedValue({
+      version: "1.3.53",
+      downloadAndInstall: downloadAndInstallMock,
+    });
+    clearAllBrowsingDataMock.mockResolvedValue(undefined);
+    relaunchMock.mockResolvedValue(undefined);
+
+    const { updaterStore } = await import("@/stores/updater.store");
+
+    await updaterStore.initUpdater();
+
+    expect(downloadAndInstallMock).toHaveBeenCalledOnce();
+    expect(relaunchMock).toHaveBeenCalledOnce();
+  });
+
+  it("initUpdater does not install when no update is available (#1720)", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const downloadAndInstallMock = vi.fn(async () => {});
+    checkMock.mockResolvedValue(null);
+
+    const { updaterStore } = await import("@/stores/updater.store");
+
+    await updaterStore.initUpdater();
+
+    expect(downloadAndInstallMock).not.toHaveBeenCalled();
+    expect(relaunchMock).not.toHaveBeenCalled();
   });
 
   it("still relaunches if browsing-data clearing fails", async () => {


### PR DESCRIPTION
## Summary

Closes #1720. On app startup, when `checkForUpdates()` resolves to `status="available"`, immediately invoke `installAvailableUpdate()` so the user sees no Update pill and zero clicks. Existing download → clear-browsing-data → relaunch path runs unchanged. The 15-minute interval re-check keeps today's manual-pill behavior so mid-session relaunch is never forced on a working user.

## Changes

- `src/stores/updater.store.ts`: after `initUpdater`'s startup `checkForUpdates()`, branch on `state.status === "available"` to call `installAvailableUpdate()`. 7 lines.
- `tests/unit/updater-store.test.ts`: two new critical tests (per #1720 acceptance), plus `vi.stubEnv("DEV", "")` so the prod-only paths are reachable in vitest.

## What I did NOT touch

- The 15-min interval body — already only calls `checkForUpdates`. Structural guarantee is stronger than a fake-timer test.
- Dev-runtime guard, non-Tauri runtime guard, error/telemetry path — unchanged.
- Titlebar UI — `status="downloading"` and `status="installing"` already render the in-progress bar.

## Test plan

- [x] `pnpm vitest run tests/unit/updater-store.test.ts` — 4/4 pass (2 new + 2 existing).
- [x] `pnpm test` — full suite 647/647 pass.
- [x] `pnpm biome check src/stores/updater.store.ts` — clean.
- [ ] Manual smoke (prod build): release a +1 patch tag, install previous version, launch — confirm titlebar progresses through downloading → installing without user input, then app relaunches into new version.

## Acceptance criteria → status

- [x] Tauri prod build, available update on startup → auto-install path runs (covered by new test).
- [x] No update available → no install path (covered by new test).
- [x] 15-min interval re-check does not auto-install — guaranteed by source structure (`setInterval` body only calls `checkForUpdates`).
- [x] Update check failure on startup → app remains usable, telemetry captures error (existing behavior unchanged).
- [x] Dev runtime → no auto-install (existing `isDevRuntime` short-circuit unchanged).
- [x] No regression on existing `tests/unit/updater-store.test.ts`.
