### PR TITLE
fix(mcp): log silent fallthroughs in discoverPublisherTools

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -144,7 +144,13 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
     { name: "list_agent_publishers", arguments: {} },
   );
 
-  if (pubResult.isError || !pubResult.content) return [];
+  if (pubResult.isError || !pubResult.content) {
+    console.warn(
+      "[MCP Gateway] list_agent_publishers returned error/empty content",
+      { isError: pubResult.isError, hasContent: !!pubResult.content },
+    );
+    return [];
+  }
 
   let publisherSlugs: string[] = [];
   try {
@@ -159,12 +165,23 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
       publisherSlugs = pubs
         .map((p: { slug?: string; name?: string }) => p.slug ?? p.name)
         .filter(Boolean);
+    } else {
+      console.warn(
+        "[MCP Gateway] list_agent_publishers returned no text content",
+      );
     }
-  } catch {
+  } catch (err) {
+    console.warn(
+      "[MCP Gateway] failed to parse list_agent_publishers response",
+      err,
+    );
     return [];
   }
 
-  if (publisherSlugs.length === 0) return [];
+  if (publisherSlugs.length === 0) {
+    console.warn("[MCP Gateway] list_agent_publishers returned 0 publishers");
+    return [];
+  }
 
   // Cache the full publisher list — this is the canonical source of callable
   // publishers, regardless of whether they expose first-class MCP tools.
@@ -178,7 +195,13 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
         SEREN_MCP_SERVER_NAME,
         { name: "list_mcp_tools", arguments: { publisher: slug } },
       );
-      if (toolResult.isError || !toolResult.content) return [];
+      if (toolResult.isError || !toolResult.content) {
+        console.warn(
+          `[MCP Gateway] list_mcp_tools(${slug}) returned error/empty content`,
+          { isError: toolResult.isError, hasContent: !!toolResult.content },
+        );
+        return [];
+      }
 
       const contentArray = toolResult.content as Array<{
         type: string;
@@ -195,7 +218,11 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
       try {
         const parsed = JSON.parse(textContent);
         tools = parsed.tools ?? parsed ?? [];
-      } catch {
+      } catch (err) {
+        console.warn(
+          `[MCP Gateway] failed to parse list_mcp_tools(${slug}) response`,
+          err,
+        );
         return [];
       }
 


### PR DESCRIPTION
## Summary

- Replaces silent `return []` paths in `discoverPublisherTools` with `console.warn` that names which fallthrough fired (`list_agent_publishers` error, empty content, parse failure, 0 publishers, per-publisher tool list errors).
- No logic change. Pure observability so the next 0-tool gateway init is diagnosable from console alone.

## Why no auto-relogin fallback

Considered and stripped during review. We don't yet know whether 0 tools is auth-related or a legitimate empty state (no entitlements, server-side empty), and forcing logout on a legitimate empty state is actively wrong UX. Once these new logs land and we capture a real reproduction, we'll know which fallthrough actually fires and can decide if a recovery action is warranted.

## Test plan

- [x] `pnpm vitest run` — 647 tests pass
- [x] `pnpm biome check src/services/mcp-gateway.ts` — clean
- [ ] Manual: trigger a 0-tool gateway init (e.g. invalid API key); confirm console shows a `[MCP Gateway]` warn with the specific reason

Closes #1722
