### PR TITLE
fix(mcp): surface gateway misbehavior to seren-core via captureSupportError

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -4,6 +4,7 @@
 import { MCP_GATEWAY_URL } from "@/lib/config";
 import { mcpClient } from "@/lib/mcp/client";
 import type { McpTool, McpToolResult } from "@/lib/mcp/types";
+import { captureSupportError } from "@/lib/support/hook";
 import { getSerenApiKey } from "@/lib/tauri-bridge";
 
 const SEREN_MCP_SERVER_NAME = "seren-gateway";
@@ -145,10 +146,12 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
   );
 
   if (pubResult.isError || !pubResult.content) {
-    console.warn(
-      "[MCP Gateway] list_agent_publishers returned error/empty content",
-      { isError: pubResult.isError, hasContent: !!pubResult.content },
-    );
+    const message = `list_agent_publishers returned error/empty content (isError=${!!pubResult.isError}, hasContent=${!!pubResult.content})`;
+    console.warn(`[MCP Gateway] ${message}`);
+    void captureSupportError({
+      kind: "McpGatewayPublisherListFailure",
+      message,
+    });
     return [];
   }
 
@@ -166,15 +169,22 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
         .map((p: { slug?: string; name?: string }) => p.slug ?? p.name)
         .filter(Boolean);
     } else {
-      console.warn(
-        "[MCP Gateway] list_agent_publishers returned no text content",
-      );
+      const message =
+        "list_agent_publishers returned no text content in response";
+      console.warn(`[MCP Gateway] ${message}`);
+      void captureSupportError({
+        kind: "McpGatewayPublisherListFailure",
+        message,
+      });
     }
   } catch (err) {
-    console.warn(
-      "[MCP Gateway] failed to parse list_agent_publishers response",
-      err,
-    );
+    const message = `failed to parse list_agent_publishers response: ${err instanceof Error ? err.message : String(err)}`;
+    console.warn(`[MCP Gateway] ${message}`);
+    void captureSupportError({
+      kind: "McpGatewayPublisherListParseFailure",
+      message,
+      stack: err instanceof Error && err.stack ? [err.stack] : undefined,
+    });
     return [];
   }
 
@@ -219,10 +229,13 @@ async function discoverPublisherTools(): Promise<GatewayTool[]> {
         const parsed = JSON.parse(textContent);
         tools = parsed.tools ?? parsed ?? [];
       } catch (err) {
-        console.warn(
-          `[MCP Gateway] failed to parse list_mcp_tools(${slug}) response`,
-          err,
-        );
+        const message = `failed to parse list_mcp_tools(${slug}) response: ${err instanceof Error ? err.message : String(err)}`;
+        console.warn(`[MCP Gateway] ${message}`);
+        void captureSupportError({
+          kind: "McpGatewayPublisherToolsParseFailure",
+          message,
+          stack: err instanceof Error && err.stack ? [err.stack] : undefined,
+        });
         return [];
       }
 


### PR DESCRIPTION
## Summary

- Wires `captureSupportError` into the **unexpected** fallthroughs in `discoverPublisherTools` (gateway error response, missing/malformed content, JSON parse failures). These create tickets in `serenorg/seren-core`.
- Skips captures for **legitimate empty states** (0 publishers, per-publisher empty/error). Those stay as `console.warn` from #1723.
- Dedup-by-signature in `captureSupportError` keeps a single bad state from flooding the support queue.

## Capture matrix

| Path | Capture? |
| ---- | -------- |
| `list_agent_publishers` `isError` or no content | yes |
| `list_agent_publishers` content has no text item | yes |
| `list_agent_publishers` JSON parse failure | yes |
| `list_agent_publishers` returned 0 publishers | no (legit) |
| Per-publisher `list_mcp_tools` error/empty | no (publisher may be REST-only) |
| Per-publisher `list_mcp_tools` parse failure | yes |

## Test plan

- [x] `pnpm vitest run` — 647 tests pass
- [x] `pnpm biome check src/services/mcp-gateway.ts` — clean
- [ ] Manual: simulate a malformed `list_agent_publishers` response and confirm one seren-core ticket is created (deduped on signature for repeats); confirm a "0 publishers" response creates no ticket

Closes #1724
