### PR TITLE
fix(test): repair tests/services/mcp-gateway.test.ts after #1725

### DIFF
--- a/tests/services/mcp-gateway.test.ts
+++ b/tests/services/mcp-gateway.test.ts
@@ -3,11 +3,23 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock tauri-bridge to avoid localStorage dependency in Node
+// Mock tauri-bridge to avoid localStorage dependency in Node.
 vi.mock("@/lib/tauri-bridge", () => ({
   getSerenApiKey: vi.fn().mockResolvedValue("test-api-key"),
   clearSerenApiKey: vi.fn().mockResolvedValue(undefined),
   isTauri: vi.fn().mockReturnValue(false),
+  isTauriRuntime: vi.fn().mockReturnValue(false),
+}));
+
+// Mock the support pipeline so captureSupportError is a no-op. Otherwise
+// fire-and-forget `void captureSupportError(...)` promises in
+// discoverPublisherTools resolve after the test finishes and surface as
+// unhandled rejections — which CI treats as failures even when the test
+// itself passes.
+vi.mock("@/lib/support/hook", () => ({
+  captureSupportError: vi.fn().mockResolvedValue(undefined),
+  captureUnknownError: vi.fn(),
+  appendSupportLog: vi.fn(),
 }));
 
 // Mock MCP OAuth
@@ -41,8 +53,10 @@ vi.mock("@/lib/mcp/client", () => ({
         },
       ],
     }),
+    // Valid JSON so discoverPublisherTools' parse step succeeds and the
+    // legitimate "0 publishers" branch runs (no captureSupportError fires).
     callToolHttp: vi.fn().mockResolvedValue({
-      content: [{ type: "text", text: "result" }],
+      content: [{ type: "text", text: '{"publishers":[]}' }],
       isError: false,
     }),
   },


### PR DESCRIPTION
## Summary

Restores green CI on `tests/services/mcp-gateway.test.ts` after #1725 exposed two latent bugs in the test:

1. `@/lib/tauri-bridge` mock missing `isTauriRuntime` — reached now that `captureSupportError` is on the discoverPublisherTools parse path.
2. `callToolHttp` default mock returned `"result"` (not valid JSON), tripping the new parse-failure capture on every test that used the default.

Plus: the `void captureSupportError(...)` fire-and-forget chain was emitting unhandled rejections that CI treats as failures even when the test itself passes.

## Changes

- `callToolHttp` default mock now returns `{"publishers":[]}` so `discoverPublisherTools` takes the legitimate "0 publishers" branch.
- `isTauriRuntime` added to the `@/lib/tauri-bridge` mock (defense-in-depth).
- `@/lib/support/hook` mocked so `captureSupportError` is a no-op — keeps the test focused on gateway logic, not on the support pipeline.

## Test plan

- [x] `pnpm vitest run tests/services/mcp-gateway.test.ts` — 9/9 pass, 0 unhandled errors (was 9/9 + 6 errors pre-fix)
- [x] `pnpm vitest run` — 647/647 pass
- [ ] CI green on this PR before merge

Closes #1727
