### PR TITLE
fix(agent): deny AskUserQuestion with structured message (#1731)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -979,6 +979,28 @@ function handlePermissionRequest(emit, session, payload) {
 
   emitToolCall(emit, session, toolName, toolInput, toolUseId, "pending");
 
+  // AskUserQuestion (#1731): Claude Code's built-in interactive picker has
+  // no stream-json render path. If the call is auto-allowed (e.g. the
+  // session is in bypassPermissions, or AskUserQuestion was previously
+  // approved via allow_session), the CLI executes the tool with no UI and
+  // silently returns an empty answers payload — the agent reads "User has
+  // answered your questions: ." and proceeds as if the user chose nothing.
+  // Until Seren renders this picker natively, deny the call with a
+  // structured message that the agent can read as the tool result so it
+  // can fall back to plain-text Q&A intentionally. Runs BEFORE
+  // autoPermissionDecision so bypassPermissions sessions are covered too.
+  if (toolName === "AskUserQuestion") {
+    const message =
+      "AskUserQuestion is not supported in this surface. Ask the same question(s) as plain text in your reply and the user will answer in chat.";
+    emitToolResult(emit, session, toolUseId, message, true);
+    respondToControlRequest(session, payload, {
+      behavior: "deny",
+      message,
+      interrupt: false,
+    });
+    return;
+  }
+
   const autoDecision = autoPermissionDecision(session, toolName);
   if (autoDecision === "allow_once") {
     respondToControlRequest(

--- a/tests/unit/ask-user-question-deny.test.ts
+++ b/tests/unit/ask-user-question-deny.test.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Critical regression test for #1731 — AskUserQuestion has no
+// ABOUTME: stream-json transport in Seren so the harness denies it with a
+// ABOUTME: structured message instead of letting the CLI auto-resolve empty.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const claudeRuntime = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+
+describe("#1731 AskUserQuestion is denied with a structured message before auto-allow can fire", () => {
+  it("handlePermissionRequest short-circuits AskUserQuestion before autoPermissionDecision", () => {
+    // The CLI's built-in AskUserQuestion picker has no stream-json render
+    // path. If autoPermissionDecision returns "allow_once" (bypassPermissions
+    // mode, or a prior allow_session on the tool), the CLI executes the
+    // tool with no UI and returns an empty answer payload. The agent then
+    // proceeds as if the user "chose nothing." The guard must run BEFORE
+    // autoPermissionDecision so it covers the bypass path too.
+    const fnIdx = claudeRuntime.indexOf("function handlePermissionRequest(");
+    expect(fnIdx).toBeGreaterThan(0);
+    const region = claudeRuntime.slice(fnIdx, fnIdx + 4000);
+
+    const askIdx = region.indexOf("AskUserQuestion");
+    const autoIdx = region.indexOf("autoPermissionDecision(");
+    expect(askIdx, "AskUserQuestion must be referenced in the handler").toBeGreaterThan(0);
+    expect(autoIdx, "autoPermissionDecision call must exist").toBeGreaterThan(0);
+    expect(
+      askIdx,
+      "AskUserQuestion guard must run BEFORE autoPermissionDecision",
+    ).toBeLessThan(autoIdx);
+  });
+
+  it("the deny path responds to the control request and emits a tool result the agent can read", () => {
+    // Two pieces both must fire: respondToControlRequest with behavior:"deny"
+    // (so the CLI never executes AskUserQuestion and the deny message
+    // becomes the agent-visible tool result), AND emitToolResult (so the
+    // UI's tool call doesn't sit in "pending" forever). Skipping either one
+    // produces a worse symptom than the bug it replaces.
+    const fnIdx = claudeRuntime.indexOf("function handlePermissionRequest(");
+    const region = claudeRuntime.slice(fnIdx, fnIdx + 4000);
+    const askIdx = region.indexOf("AskUserQuestion");
+    expect(askIdx).toBeGreaterThan(0);
+    const guardBlock = region.slice(askIdx, askIdx + 1500);
+
+    expect(guardBlock).toMatch(/respondToControlRequest\(/);
+    expect(guardBlock).toMatch(/behavior:\s*"deny"/);
+    expect(guardBlock).toMatch(/emitToolResult\(/);
+    // The deny message must explain the surface limit so the agent can
+    // pivot to plain-text Q&A intentionally instead of acting on empty
+    // selections. We don't pin the exact wording — just that a
+    // human-readable explanation accompanies the deny.
+    expect(guardBlock).toMatch(/(plain[ -]text|not supported|surface)/i);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1731. Claude Code's built-in `AskUserQuestion` picker has no stream-json render path. When the harness auto-allows the `can_use_tool` request (bypassPermissions, or a prior `allow_session`), the CLI runs the tool with no UI and returns an empty answers payload — the agent reads `"User has answered your questions: ."` and proceeds as if the user chose nothing.

Until Seren renders the picker natively, intercept `AskUserQuestion` at the top of `handlePermissionRequest` (before `autoPermissionDecision` runs so bypass mode is covered too) and deny with `behavior:"deny"` plus a human-readable message that becomes the agent-visible tool result. `emitToolResult` also fires so the UI's pending tool call resolves with the explanation rather than disappearing.

The agent can now pivot to plain-text Q&A intentionally instead of acting on empty selections.

## Test plan

- [x] `pnpm test` — 649/649 passing (84 files), including the new critical test:
  - `tests/unit/ask-user-question-deny.test.ts` — pins the guard's placement before `autoPermissionDecision` and asserts both `respondToControlRequest(deny)` and `emitToolResult` fire with a surface-limit explanation
- [x] No biome impact (`bin/browser-local/*.mjs` is biome-ignored)
- [x] No regressions in existing permission flow — guard is keyed on `toolName === "AskUserQuestion"` and short-circuits only that one tool

## Out of scope

Rendering `AskUserQuestion` natively in Seren's chat surface — separate ticket once we have a target UX.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
