### PR TITLE
fix(agent): standby spawn drops cached context window; promoted standby regresses to ack turn (#1733)

### DIFF
--- a/bin/browser-local/synthetic-transcript.mjs
+++ b/bin/browser-local/synthetic-transcript.mjs
@@ -4,9 +4,14 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 
-const SYNTHETIC_ACK_TEXT =
-  "Understood. Context restored from summary. Continuing from prior conversation.";
-const SYNTHETIC_MODEL_FALLBACK = "claude-opus-4-7";
+// Action-oriented framing (#1733): the prior wording "Understood. Context
+// restored from summary. Continuing from prior conversation." primed the
+// promoted standby into another acknowledgement turn instead of the next
+// agentic action — see the questionnaire-stall repro. Keep this short and
+// active so the agent's next turn picks up the user's flow rather than
+// re-confirming context receipt.
+const SYNTHETIC_ACK_TEXT = "Resuming the task.";
+const SYNTHETIC_MODEL_FALLBACK = "claude-opus-4-7[1m]";
 
 /**
  * Determine whether a parsed JSONL record is a "real" user turn — i.e., a

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -287,6 +287,7 @@ function subscribeToProviderRuntimeRestarted(): void {
         cwd: s.cwd,
         agentType: s.info.agentType,
         messages: s.messages,
+        currentModelId: s.currentModelId,
       }));
       for (const { id } of snapshot) terminatedSessionIds.add(id);
       setState(
@@ -311,6 +312,7 @@ function subscribeToProviderRuntimeRestarted(): void {
             {
               localSessionId: snap.conversationId,
               restoredMessages: snap.messages,
+              initialModelId: snap.currentModelId,
             },
           );
           if (!newId) {
@@ -2875,7 +2877,7 @@ GOAL: <what the user is trying to accomplish>
 FILES: <files created or modified, comma-separated paths only>
 DECISIONS: <key technical decisions made>
 STATE: <what is done vs in progress>
-NEXT: <what the user will likely ask next>
+NEXT: <what the agent should do next to continue the work>
 
 Conversation:
 ${toCompact.map((m) => `${m.type.toUpperCase()}: ${m.content}`).join("\n\n")}
@@ -2955,6 +2957,7 @@ Structured summary:`;
             const syntheticStandbyId = await this.spawnSession(cwd, agentType, {
               role: "standby",
               resumeAgentSessionId: syntheticAgentSessionId,
+              initialModelId: session.currentModelId,
             });
             if (syntheticStandbyId == null) {
               throw new Error("synthetic standby spawn returned null");
@@ -2995,6 +2998,7 @@ Structured summary:`;
 
         const standbyId = await this.spawnSession(cwd, agentType, {
           role: "standby",
+          initialModelId: session.currentModelId,
         });
         if (!standbyId) {
           // Predictive warm-up is best-effort — the serving session is still
@@ -3021,10 +3025,14 @@ Structured summary:`;
       }
 
       // Reactive path: terminate old, spawn fresh serving, seed, retry.
+      // Capture model id before terminate so the new session inherits the
+      // cached per-model context window via #1700.
+      const priorModelId = session.currentModelId;
       await this.terminateSession(sessionId);
 
       const newSessionId = await this.spawnSession(cwd, agentType, {
         localSessionId: conversationId,
+        initialModelId: priorModelId,
       });
 
       if (!newSessionId) {
@@ -3123,6 +3131,7 @@ Structured summary:`;
         try {
           const recoveryId = await this.spawnSession(cwd, agentType, {
             localSessionId: conversationId,
+            initialModelId: session.currentModelId,
           });
           if (recoveryId) {
             setState("sessions", recoveryId, "messages", fullTranscript);
@@ -3725,6 +3734,7 @@ Structured summary:`;
           const newSessionId = await this.spawnSession(cwd, agentType, {
             localSessionId: session.conversationId,
             bootstrapPromptContext: session.bootstrapPromptContext,
+            initialModelId: session.currentModelId,
           });
           if (newSessionId) {
             await this.restoreSessionSettings(session, newSessionId);
@@ -5504,6 +5514,7 @@ Structured summary:`;
       conversationTitle: forkTitle,
       restoredMessages: forkedMessages,
       bootstrapPromptContext,
+      initialModelId: session.currentModelId,
     });
 
     if (!newSessionId) {

--- a/tests/unit/compaction-auth-gate.test.ts
+++ b/tests/unit/compaction-auth-gate.test.ts
@@ -162,8 +162,9 @@ describe("#1639 — compaction failure preserves transcript", () => {
     expect(agentStoreSource).toContain(
       "Attempting recovery — restoring",
     );
-    expect(agentStoreSource).toContain(
-      'localSessionId: conversationId,\n          });',
-    );
+    // Recovery spawn passes localSessionId so the new session inherits the
+    // conversation. (#1733 added initialModelId here too — the closing brace
+    // no longer immediately follows localSessionId.)
+    expect(agentStoreSource).toContain("localSessionId: conversationId,");
   });
 });

--- a/tests/unit/predictive-compact-spawn-fixes.test.ts
+++ b/tests/unit/predictive-compact-spawn-fixes.test.ts
@@ -1,0 +1,135 @@
+// ABOUTME: Critical regression tests for #1733 — every spawnSession site that
+// ABOUTME: continues an existing conversation must pass initialModelId, the
+// ABOUTME: synthetic-transcript ack text must not prime acknowledgement mode,
+// ABOUTME: and the opus-4-7 fallback must use the 1M variant.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const syntheticTranscriptSource = readFileSync(
+  resolve("bin/browser-local/synthetic-transcript.mjs"),
+  "utf-8",
+);
+
+/**
+ * Slice the agent.store source forward from a fixed anchor and return a
+ * window large enough to contain the spawnSession call's opts object.
+ * Anchors are unique strings that uniquely identify each call site so the
+ * test does not rely on line numbers (which drift).
+ */
+function regionAfter(anchor: string, len = 600): string {
+  const idx = agentStoreSource.indexOf(anchor);
+  if (idx < 0) {
+    throw new Error(`anchor not found in agent.store.ts: ${anchor}`);
+  }
+  return agentStoreSource.slice(idx, idx + len);
+}
+
+describe("#1733 Bug A — every continuation spawnSession site passes initialModelId", () => {
+  // Every site below continues an existing conversation with a known
+  // currentModelId. Without initialModelId, the cache lookup at
+  // src/stores/agent.store.ts:1948 short-circuits and the spawn falls to the
+  // 200K agent-type default — which fires predictive-compaction 5x earlier
+  // than the actual 1M-context model can handle. #1700 already wired the
+  // cache; these sites just need to feed it.
+
+  it("synthetic-standby spawn passes initialModelId", () => {
+    expect(
+      regionAfter("const syntheticStandbyId = await this.spawnSession("),
+    ).toMatch(/initialModelId:/);
+  });
+
+  it("predictive-standby spawn passes initialModelId", () => {
+    expect(
+      regionAfter("const standbyId = await this.spawnSession(cwd, agentType, {"),
+    ).toMatch(/initialModelId:/);
+  });
+
+  it("reactive-compaction respawn passes initialModelId", () => {
+    // The respawn that follows `await this.terminateSession(sessionId)` in
+    // compactAgentConversation. We anchor on the unique post-terminate line
+    // that precedes the spawn.
+    const anchor = "await this.terminateSession(sessionId);";
+    const idx = agentStoreSource.indexOf(anchor);
+    expect(idx).toBeGreaterThan(0);
+    const region = agentStoreSource.slice(idx, idx + 800);
+    expect(region).toMatch(/spawnSession\([\s\S]*?initialModelId:/);
+  });
+
+  it("compaction-recovery spawn passes initialModelId", () => {
+    // Anchor on the warn that precedes the recovery spawn block.
+    expect(
+      regionAfter("Attempting recovery — restoring"),
+    ).toMatch(/spawnSession\([\s\S]*?initialModelId:/);
+  });
+
+  it("session-crash recovery spawn passes initialModelId", () => {
+    expect(regionAfter("const doRecovery =")).toMatch(/initialModelId:/);
+  });
+
+  it("fork spawn passes initialModelId", () => {
+    expect(
+      regionAfter("// 3. Spawn a new local session for the fork."),
+    ).toMatch(/initialModelId:/);
+  });
+
+  it("crash-ceiling restore passes initialModelId via the snapshot", () => {
+    // The snapshot map at the top of provider-runtime://restarted captures
+    // the fields needed to respawn each session. modelId must be in there
+    // for the restore spawn (line ~308) to receive it as initialModelId.
+    expect(
+      regionAfter('"[AgentStore] provider-runtime://restarted'),
+    ).toMatch(/currentModelId/);
+    expect(regionAfter("agentStore.spawnSession(\n            snap.cwd,")).toMatch(
+      /initialModelId:/,
+    );
+  });
+});
+
+describe("#1733 Bug B — synthetic-transcript ack does not prime acknowledgement mode", () => {
+  it("SYNTHETIC_ACK_TEXT value lacks the framing keywords that primed regression", () => {
+    // The original wording "Understood. Context restored from summary.
+    // Continuing from prior conversation." caused the promoted standby to
+    // respond with another acknowledgement turn instead of continuing the
+    // user's flow (real symptom: questionnaire stalled at Q18). Pin the
+    // literal const VALUE — comments are allowed to reference the old
+    // wording for historical context, but the value itself must not.
+    const match = syntheticTranscriptSource.match(
+      /SYNTHETIC_ACK_TEXT\s*=\s*"([^"]+)"/,
+    );
+    expect(match, "SYNTHETIC_ACK_TEXT must be a single-line string literal").not.toBeNull();
+    const value = match?.[1] ?? "";
+    expect(value).not.toMatch(/Context restored from summary/);
+    expect(value).not.toMatch(/Continuing from prior conversation/);
+    expect(value).not.toMatch(/Understood\.\s*Context restored/);
+  });
+
+  it("compaction summary template asks about agent action, not predicted user behavior", () => {
+    // The summary's NEXT: line drove the LLM to predict user behavior, which
+    // made the post-compaction agent treat the user's next prompt as
+    // confirmation rather than a fresh instruction. The new wording must
+    // direct the summarizer toward agent action.
+    const idx = agentStoreSource.indexOf("async compactAgentConversation(");
+    expect(idx).toBeGreaterThan(0);
+    const region = agentStoreSource.slice(idx, idx + 6000);
+    expect(region).toMatch(/NEXT:/);
+    expect(region).not.toMatch(/NEXT:\s*<what the user will likely ask next>/);
+  });
+});
+
+describe("#1733 Bug C — opus-4-7 fallback uses the 1M variant", () => {
+  it("SYNTHETIC_MODEL_FALLBACK is the [1m] tier, not the bare 200K id", () => {
+    // The fallback shows up in synthetic ack records when the parent
+    // transcript can't supply a model. Defaulting to the 200K variant means
+    // the cache eventually persists 200K for the whole class of sessions
+    // that fall through this path. Use the 1M tier id explicitly.
+    expect(syntheticTranscriptSource).toMatch(
+      /SYNTHETIC_MODEL_FALLBACK\s*=\s*"claude-opus-4-7\[1m\]"/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1733. Three coupled defects on the predictive-compaction path, all visible in a single 2026-04-29 user session.

**A. Seven `spawnSession` call sites silently drop the cached per-model context window.** #1700 caches `(provider, model_id) → context_window` and reads it at spawn time *only when `initialModelId` is supplied*. The crash-ceiling restore, synthetic standby, predictive standby, reactive compaction respawn, compaction-recovery, session-crash recovery, and fork spawns all omitted it — falling through to the `claude-code` 200K default. On a 1M-context model this fires predictive-compaction 5x earlier than warranted. Fix: thread `initialModelId` (from `session.currentModelId` or `snap.currentModelId`) into all seven sites. The crash-ceiling snapshot is extended to capture `currentModelId` first.

**B. Promoted standby regresses to an acknowledgement turn instead of continuing the user's flow.** Real repro: questionnaire stalled at Q18 with the agent replying *"Acknowledged. ... Standing by for Q18"* instead of asking the next question. Root cause: the synthetic-transcript ack record was *"Understood. Context restored from summary. Continuing from prior conversation."* — meta-commentary that primes the LLM into "I just confirmed context" mode. Combined with the summary template's `NEXT: <what the user will likely ask next>` (predicts user behavior, not agent action), the agent reads the next user message as readiness-signaling and confirms again. Fix: reword `SYNTHETIC_ACK_TEXT` to *"Resuming the task."* and change `NEXT:` to describe agent action.

**C. `SYNTHETIC_MODEL_FALLBACK` defaulted to the 200K variant.** Use `claude-opus-4-7[1m]` so any fallthrough session lands on the 1M tier the cache will then persist.

## Test plan

- [x] `pnpm test` — 659/659 passing (85 files), including 10 new critical-only assertions in `tests/unit/predictive-compact-spawn-fixes.test.ts`:
  - 7 call-site pins for `initialModelId`
  - `SYNTHETIC_ACK_TEXT` value (not source) lacks the regression-priming keywords
  - Summary `NEXT:` template no longer predicts user behavior
  - `SYNTHETIC_MODEL_FALLBACK` is the `[1m]` tier
- [x] `pnpm biome check src/stores/agent.store.ts` — clean (zero warnings, zero errors)
- [x] Existing `compaction-auth-gate.test.ts` recovery-spawn assertion relaxed to track the new `initialModelId:` line; no other existing test regressions
- [x] No regressions in #1700 / #1713 / #1716 coverage (the cache write path, synthetic-transcript structural invariants, and standby-mutex behavior are untouched)

## Out of scope

- Replacing the synthetic-transcript path with a different compaction strategy.
- Surfacing model variant ([1m] vs base) in the picker UI.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
