### PR TITLE
fix(agent): validate spawn binary executability; guard codex spawn against unhandled 'error' (#1735)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -3,7 +3,7 @@
 
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, readdirSync, writeFileSync, unlinkSync } from "node:fs";
+import { accessSync, constants as fsConstants, existsSync, readdirSync, writeFileSync, unlinkSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -25,6 +25,25 @@ import { buildSyntheticTranscript as writeSyntheticJsonl } from "./synthetic-tra
  * and bare `spawn("claude")` may fail even when Claude Code is installed.
  * Check well-known install locations before falling back to bare command name.
  */
+/**
+ * Return true when `candidate` is a real, executable file. Symlinks resolve
+ * through to their target via `accessSync`; broken symlinks, non-executable
+ * files, and stale entries from a prior install all return false. #1735.
+ *
+ * Pure `existsSync` is not enough — it passes for broken symlinks and for
+ * files that lack the executable bit, both of which fail `spawn` with
+ * ENOENT/EACCES at runtime. The recovery path then surfaces "Spawn error"
+ * to the user with no usable diagnostic.
+ */
+function isExecutableCandidate(candidate) {
+  try {
+    accessSync(candidate, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function resolveClaudeBinary() {
   if (process.platform === "win32") {
     const home = os.homedir();
@@ -43,7 +62,7 @@ function resolveClaudeBinary() {
     ];
 
     for (const candidate of candidates) {
-      if (existsSync(candidate)) {
+      if (isExecutableCandidate(candidate)) {
         return candidate;
       }
     }
@@ -54,7 +73,7 @@ function resolveClaudeBinary() {
         encoding: "utf8",
         timeout: 5_000,
       }).trim().split(/\r?\n/)[0];
-      if (resolved) {
+      if (resolved && isExecutableCandidate(resolved)) {
         return resolved;
       }
     } catch {
@@ -75,7 +94,7 @@ function resolveClaudeBinary() {
   ];
 
   for (const candidate of candidates) {
-    if (existsSync(candidate)) {
+    if (isExecutableCandidate(candidate)) {
       return candidate;
     }
   }
@@ -86,7 +105,7 @@ function resolveClaudeBinary() {
       encoding: "utf8",
       timeout: 5_000,
     }).trim();
-    if (resolved) {
+    if (resolved && isExecutableCandidate(resolved)) {
       return resolved;
     }
   } catch {

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -854,6 +854,36 @@ function attachProcessListeners(emit, sessions, session) {
     }
   });
 
+  // Spawn-error guard (#1735): when the codex binary is missing or not
+  // executable, Node emits an 'error' event on the ChildProcess. Without
+  // a listener here, the default handling rethrows it as an
+  // uncaughtException, killing the entire provider-runtime helper —
+  // which takes down every agent runtime (claude, gemini, codex) for the
+  // user. Translate to a structured per-session error so the UI can
+  // surface "Codex is not installed" and the runtime stays alive.
+  session.process.on("error", (err) => {
+    const message =
+      err && err.code === "ENOENT"
+        ? "Codex binary not found. Install codex or fix the spawn path."
+        : `Codex spawn error: ${err?.message ?? String(err)}`;
+    console.warn(`[browser-local][codex] ${message}`);
+    sessions.delete(session.id);
+    if (session.currentPrompt) {
+      rejectCurrentPrompt(session, new Error(message));
+    }
+    rejectPendingRequests(session, new Error(message));
+    emit("provider://error", {
+      sessionId: session.id,
+      error: message,
+    });
+    session.status = "terminated";
+    emit("provider://session-status", {
+      sessionId: session.id,
+      status: "terminated",
+      agentSessionId: session.agentSessionId,
+    });
+  });
+
   session.process.on("exit", () => {
     const wasTracked = sessions.delete(session.id);
     if (!wasTracked) {

--- a/tests/unit/spawn-binary-validation.test.ts
+++ b/tests/unit/spawn-binary-validation.test.ts
@@ -1,0 +1,63 @@
+// ABOUTME: Critical regression tests for #1735 — resolveClaudeBinary must
+// ABOUTME: validate executability (not just existence), and codex spawn must
+// ABOUTME: attach an 'error' listener so a missing binary doesn't crash the
+// ABOUTME: provider-runtime via an unhandled ChildProcess error event.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const claudeRuntime = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+const providersRuntime = readFileSync(
+  resolve("bin/browser-local/providers.mjs"),
+  "utf-8",
+);
+
+describe("#1735 A1 — resolveClaudeBinary validates executability before returning a candidate", () => {
+  it("the candidate validator uses X_OK access in a try/catch and resolveClaudeBinary calls it", () => {
+    // existsSync alone is not enough: a broken symlink, a stale install
+    // entry, or a non-executable file passes existsSync but fails spawn
+    // with ENOENT/EACCES. The user's session at 2026-04-29 07:08:46
+    // returned ~/.local/bin/claude, which then failed at spawn time on
+    // every recovery attempt. Real fix: the candidate loop must validate
+    // executability before returning, and fall through on rejection.
+    //
+    // The validator may live as a helper next to resolveClaudeBinary;
+    // assert against the file as a whole (a) X_OK is checked inside a
+    // try/catch (the natural way to fall through on EACCES/ENOENT thrown
+    // by accessSync), and (b) resolveClaudeBinary uses the validator
+    // before returning a candidate.
+    expect(claudeRuntime).toMatch(
+      /try\s*\{[\s\S]*?(constants\.X_OK|fsConstants\.X_OK|X_OK)[\s\S]*?\}\s*catch/,
+    );
+    const fnIdx = claudeRuntime.indexOf("function resolveClaudeBinary(");
+    expect(fnIdx).toBeGreaterThan(0);
+    const fn = claudeRuntime.slice(fnIdx, fnIdx + 4000);
+    // The candidate loop must reference an executability gate, not just
+    // existsSync. Either inline (X_OK reference) or via a named helper
+    // whose name signals the check.
+    expect(fn).toMatch(/X_OK|isExecutableCandidate/);
+  });
+});
+
+describe("#1735 A2 — codex spawn attaches an 'error' listener so missing binary doesn't crash the runtime", () => {
+  it("attachProcessListeners registers a process 'error' listener", () => {
+    // When `/usr/local/bin/codex` is missing, Node emits an 'error' event
+    // on the ChildProcess. With no listener, Node's default re-throws as
+    // an uncaughtException, killing the entire provider-runtime helper —
+    // which then takes down every agent runtime (claude, gemini, codex).
+    // The fix attaches a listener that translates the spawn error into a
+    // structured per-session error event the UI can show.
+    const fnIdx = providersRuntime.indexOf("function attachProcessListeners(");
+    expect(fnIdx).toBeGreaterThan(0);
+    const fn = providersRuntime.slice(fnIdx, fnIdx + 2000);
+    expect(fn).toMatch(/session\.process\.on\(\s*"error"/);
+    // The listener must emit a provider://error so the UI surfaces a
+    // recoverable per-session failure rather than the runtime dying
+    // silently from the user's POV.
+    expect(fn).toMatch(/emit\([\s\S]*?provider:\/\/error/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1735. Two cooperating defects from the 2026-04-29 cascade.

**A1 — `resolveClaudeBinary` returned an ENOENT path.** The candidate loop in `bin/browser-local/claude-runtime.mjs` accepted any path that passed `existsSync`. Broken symlinks, non-executable files, and stale install entries all pass `existsSync` but fail `spawn` with ENOENT/EACCES. The user's `~/.local/bin/claude` resolved through to ENOENT on every recovery attempt — the loop never tried the next candidate or fell through to `which`. Fix: add `isExecutableCandidate(path)` using `accessSync(path, X_OK)` and gate every candidate (and the PATH-lookup result) on it.

**A2 — codex spawn ENOENT killed the provider-runtime.** `spawnCodexProcess` returned a `ChildProcess` with no `.on('error', ...)` listener. When `/usr/local/bin/codex` was missing, Node emitted an `'error'` event that — with no listener — rethrew as an uncaughtException at `node:internal/child_process:285`, killing the whole provider-runtime helper and taking down every agent runtime (claude, gemini, codex). Fix: attach an `'error'` listener inside `attachProcessListeners` that translates ENOENT into a structured "Codex binary not found" error and emits a per-session `provider://error` + terminated sessionStatus.

## Test plan

- [x] `pnpm test` — 661/661 passing (86 files), including 2 new critical-only assertions in `tests/unit/spawn-binary-validation.test.ts`:
  - `accessSync(..., X_OK)` is wrapped in a try/catch (the natural fall-through shape for the candidate loop)
  - `attachProcessListeners` registers a `session.process.on("error", ...)` listener that emits `provider://error`
- [x] `pnpm biome check` — no new warnings on the touched files (`bin/browser-local/*.mjs` is biome-ignored)
- [x] No regressions in #1297 / #1409 spawn coverage

## Out of scope

- Surfacing "this CLI is missing" in the chat UI (separate ticket).
- Auto-installing missing CLIs from the recovery path.
- Migrating off `existsSync` everywhere in the codebase — only the spawn-validation sites are touched.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
