### PR TITLE
fix(support): surface submission failures as console.warn with report signature (#1736)

### DIFF
--- a/src/lib/support/hook.ts
+++ b/src/lib/support/hook.ts
@@ -248,33 +248,66 @@ export function appendSupportLog(
   }
 }
 
-async function submitPayload(payload: SupportReportPayload): Promise<void> {
+type SubmitOutcome = { status: "ok" } | { status: "failed"; reason: string };
+
+async function submitPayload(
+  payload: SupportReportPayload,
+): Promise<SubmitOutcome> {
   if (isTauriRuntime()) {
-    await rawInvoke("submit_support_report", { bundle: payload });
-    return;
+    try {
+      await rawInvoke("submit_support_report", { bundle: payload });
+      return { status: "ok" };
+    } catch (err) {
+      return {
+        status: "failed",
+        reason: `tauri-invoke: ${redactString(normalizeError(err).message)}`,
+      };
+    }
   }
 
   const apiKey = await getSerenApiKey();
-  if (!apiKey) return;
-  await fetch(`${API_BASE}/support/report`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
-  });
+  if (!apiKey) {
+    return { status: "failed", reason: "no-api-key" };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE}/support/report`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    return {
+      status: "failed",
+      reason: `fetch: ${redactString(normalizeError(err).message)}`,
+    };
+  }
+
+  if (!response.ok) {
+    return { status: "failed", reason: `http-${response.status}` };
+  }
+  return { status: "ok" };
 }
 
-function logSubmitFailure(error: unknown): void {
-  if (typeof console.debug !== "function") return;
+/**
+ * Log a submit failure in a way that a user or operator can audit later.
+ * Uses `console.warn` so it lands in the support log slice (the install
+ * hook captures `console.warn` to `appendSupportLog` without recursing
+ * into `captureSupportError`, which is reserved for `console.error`).
+ * The signature prefix is included so a user reporting "I saw an error
+ * but no ticket exists" can correlate with which capture dropped. #1736.
+ */
+function logSubmitFailure(signature: string, reason: string): void {
   try {
-    console.debug(
-      "[support-report] submit failed",
-      redactString(normalizeError(error).message),
+    console.warn(
+      `[support-report] submit failed (signature=${signature.slice(0, 8)}, reason=${reason})`,
     );
   } catch {
-    // Drop debug failures; support reporting must never recurse on itself.
+    // Drop log failures; support reporting must never recurse on itself.
   }
 }
 
@@ -336,7 +369,21 @@ export async function captureSupportError(
   );
 
   showSupportToast();
-  void submitPayload(payload).catch(logSubmitFailure);
+  void submitPayload(payload)
+    .then((outcome) => {
+      if (outcome.status === "failed") {
+        logSubmitFailure(signature, outcome.reason);
+      }
+    })
+    .catch((err) => {
+      // submitPayload itself is structured to never throw, but a thrown
+      // exception from the surrounding plumbing (e.g. payload serialization
+      // edge case) should still be loud, not silent.
+      logSubmitFailure(
+        signature,
+        `unexpected: ${redactString(normalizeError(err).message)}`,
+      );
+    });
 }
 
 export function captureUnknownError(kind: string, error: unknown): void {

--- a/tests/unit/support-pipeline-loud-failures.test.ts
+++ b/tests/unit/support-pipeline-loud-failures.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Critical regression test for #1736 — support-pipeline submission
+// ABOUTME: failures must surface as console.warn with the report signature so
+// ABOUTME: silent drops can be diagnosed instead of vanishing into console.debug.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const hookSource = readFileSync(
+  resolve("src/lib/support/hook.ts"),
+  "utf-8",
+);
+
+describe("#1736 support-pipeline submission failures are loud, not silent", () => {
+  it("submitPayload surfaces non-2xx fetch responses as a failure (response.ok / status check)", () => {
+    // The original `await fetch(...)` swallowed non-2xx responses because
+    // fetch only throws on network errors, not on HTTP errors. Without an
+    // explicit response.ok check, a Gateway 5xx looks like success and
+    // captureSupportError's `.catch(...)` never fires.
+    const fnIdx = hookSource.indexOf("async function submitPayload(");
+    expect(fnIdx).toBeGreaterThan(0);
+    const fn = hookSource.slice(fnIdx, fnIdx + 2000);
+    expect(fn).toMatch(/response\.ok|response\.status|\.status\s*[<>=!]/);
+  });
+
+  it("the no-api-key silent skip is at minimum logged with a structured reason", () => {
+    // The browser path returned silently when getSerenApiKey() was empty.
+    // Auth refreshes during the user's session can leave the key briefly
+    // unset; when that races a console.error capture, the report drops
+    // without any signal. Require that the no-api-key branch logs a
+    // recognizable reason — pinning the literal token "no-api-key" so a
+    // rename in the warn message does not silently regress the audit
+    // trail.
+    expect(hookSource).toMatch(/no-api-key/);
+  });
+
+  it("submission failure logging uses console.warn (not console.debug) and includes the report signature", () => {
+    // console.debug is below the support log slice's level threshold and
+    // also below most operator log filters. The warn carries the failure
+    // reason and the report signature (or a short prefix) so a user can
+    // correlate "I saw an error" with "this is why no ticket exists."
+    // console.warn is captured to the support log slice via the install
+    // hook's wrapper without recursing into captureSupportError, so the
+    // re-entrancy guard at hook.ts:52 stays intact.
+    expect(hookSource).toMatch(/console\.warn\([^)]*support-report/);
+    // Pin the signature reference in the warn payload so the correlation
+    // hook is auditable.
+    const warnIdx = hookSource.search(/console\.warn\([^)]*support-report/);
+    expect(warnIdx).toBeGreaterThan(0);
+    const region = hookSource.slice(warnIdx, warnIdx + 300);
+    expect(region).toMatch(/signature/);
+  });
+});

--- a/tests/unit/support-reporting.test.ts
+++ b/tests/unit/support-reporting.test.ts
@@ -177,7 +177,7 @@ describe("support report hook behavior", () => {
   beforeEach(() => {
     installBrowserGlobals();
     vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "debug").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.stubGlobal(
       "fetch",
       vi.fn(() => Promise.resolve(new Response(null, { status: 201 }))),
@@ -248,7 +248,7 @@ describe("support report hook behavior", () => {
     expect(supportHooks.seenSignatures()).toHaveLength(2);
   });
 
-  it("logs submit failures through console.debug without re-entering reporting", async () => {
+  it("logs submit failures through console.warn with the report signature without re-entering reporting (#1736)", async () => {
     localStorage.setItem("seren_api_key", "seren_test_key");
     vi.stubGlobal(
       "fetch",
@@ -262,15 +262,20 @@ describe("support report hook behavior", () => {
     });
     await flushSupportPipeline();
 
-    // Match the redacted form with a regex so the assertion stays robust if
-    // the message format ever expands (e.g. `Error: ...`); the regression
-    // intent is "the raw token must not appear" - that's what we lock in.
-    expect(console.debug).toHaveBeenCalledWith(
-      "[support-report] submit failed",
-      expect.stringMatching(/Bearer \[REDACTED\]/),
+    // The warn line shape is "[support-report] submit failed (signature=..., reason=...)".
+    // Two regression guarantees we lock in:
+    // 1. Redaction works — raw "Bearer secret-token" must not appear in the log
+    //    (only the redacted "Bearer [REDACTED]" form does). #1736 keeps the
+    //    redactString call from the original logSubmitFailure path.
+    // 2. The line is loud (console.warn) so it lands in the support log slice
+    //    rather than vanishing into console.debug — without this, silent
+    //    submission failures like the 2026-04-29 cascade are invisible.
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^\[support-report\] submit failed \(signature=[0-9a-f]{1,16}, reason=.*Bearer \[REDACTED\].*\)$/,
+      ),
     );
-    expect(console.debug).not.toHaveBeenCalledWith(
-      "[support-report] submit failed",
+    expect(console.warn).not.toHaveBeenCalledWith(
       expect.stringContaining("secret-token"),
     );
   });


### PR DESCRIPTION
## Summary

Closes #1736. The 2026-04-29 cascade fired ~7 distinct `console.error` calls with `Error` instances attached — every one qualified for support-pipeline capture per [src/lib/support/hook.ts:392-397](src/lib/support/hook.ts#L392-L397). Zero tickets landed on `serenorg/seren-core` for that day.

Three holes plugged in `submitPayload`'s failure surface:

1. **Non-2xx responses are now failures.** Previously a Gateway 5xx looked like success because `fetch` only throws on network errors. New `response.ok` check converts non-2xx into a structured `http-<status>` failure.
2. **Missing `apiKey` no longer returns silently.** Auth-refresh windows where the key is briefly unset returned a no-op success; now they return `no-api-key` and the caller logs it.
3. **`submitPayload` returns a typed `SubmitOutcome` instead of throwing.** `captureSupportError` routes failures through `logSubmitFailure`, which uses `console.warn` (captured to the support log slice via the install hook's wrapper — no recursion into `captureSupportError`) with a structured line:
   ```
   [support-report] submit failed (signature=<8-hex>, reason=<tag>)
   ```
   The signature prefix lets a user correlate "I saw an error but no ticket exists" with which capture dropped.

## Test plan

- [x] `pnpm test` — 664/664 passing (87 files), including 3 new critical-only assertions in `tests/unit/support-pipeline-loud-failures.test.ts`:
  - `submitPayload` references `response.ok` / status check
  - `no-api-key` reason token is present in source
  - `console.warn` line shape includes `[support-report]` and `signature`
- [x] Existing `tests/unit/support-reporting.test.ts` updated from `console.debug` → `console.warn` matcher; redaction regression guarantee preserved (raw `Bearer secret-token` must not appear).
- [x] `pnpm biome check src/lib/support/hook.ts` — clean (zero warnings, zero errors).
- [x] Re-entrancy guard at `hook.ts:52` intact — `console.warn` is captured to log slice but does not recurse into `captureSupportError` (only `console.error` does).

## Out of scope

- Refactoring `submitPayload` into a single Tauri-only / Gateway-only transport.
- User-visible "retry submit" UI.
- Per-error dedupe tuning beyond `seenSignatures`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
