### PR TITLE
fix(agent): reject CLI '<synthetic>' placeholder so stream timeout can't poison currentModelId (#1739)

### DIFF
--- a/bin/browser-local/model-resolution.mjs
+++ b/bin/browser-local/model-resolution.mjs
@@ -68,6 +68,16 @@ export function chooseUpdatedModelId(
   if (typeof incomingMessageModel !== "string" || incomingMessageModel.length === 0) {
     return null;
   }
+  // Reject sentinel-bracketed placeholders. The Claude Code CLI emits
+  // synthesized assistant turns (e.g. on "Stream idle timeout - partial
+  // response received") with `message.model` set to internal placeholders
+  // like `<synthetic>`. Real Anthropic model ids never use angle brackets,
+  // so accepting these as ground truth poisons `session.currentModelId`
+  // and propagates to the next `--model` spawn arg, which the CLI hard-
+  // rejects with "issue with the selected model (<synthetic>)".
+  if (/^<.+>$/.test(incomingMessageModel)) {
+    return null;
+  }
   const records = Array.isArray(availableModelRecords)
     ? availableModelRecords
     : [];

--- a/tests/unit/claude-model-resolution.test.ts
+++ b/tests/unit/claude-model-resolution.test.ts
@@ -49,6 +49,17 @@ describe("chooseUpdatedModelId (#1635)", () => {
       chooseUpdatedModelId("claude-opus-4-5", "claude-opus-4-6", records),
     ).toBe("claude-opus-4-6");
   });
+
+  it("rejects sentinel-bracketed placeholders so CLI-fabricated turns can't poison currentModelId", () => {
+    // Repro for the stream-idle-timeout regression: Claude Code emits a
+    // synthesized assistant turn with `message.model = "<synthetic>"` after
+    // a partial-response timeout. Without this guard, `<synthetic>` flows
+    // into `session.currentModelId` and the next `--model` spawn arg, which
+    // the CLI hard-rejects ("issue with the selected model (<synthetic>)").
+    expect(
+      chooseUpdatedModelId("claude-opus-4-7", "<synthetic>", records),
+    ).toBeNull();
+  });
 });
 
 describe("inferCurrentModelId fuzzy tiers", () => {


### PR DESCRIPTION
## Summary

- Reject sentinel-bracketed strings (e.g. `<synthetic>`) in `chooseUpdatedModelId` so a Claude Code internal placeholder can't poison `session.currentModelId`.
- Previously: stream idle timeout -> CLI emits `message.model: "<synthetic>"` -> `currentModelId = "<synthetic>"` -> next standby spawn passes `--model <synthetic>` -> CLI rejects -> predictive compaction `failed_catastrophic`.
- Closes #1739.

## Test plan

- [x] `pnpm vitest run tests/unit/claude-model-resolution.test.ts` (7 passed, including new sentinel guard).
- [x] Existing `tests/unit/agent-model-observability.test.ts` and `tests/unit/claude-runtime-subagent-guard.test.ts` still pass.
- [x] #1635 ground-truth path preserved for unrecognized real model ids (e.g. `claude-opus-4-8`).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
