### PR TITLE
feat(telemetry): predictive-compaction structural failures call captureSupportError instead of silent warn (#1741)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -63,6 +63,20 @@ export const BUDGET_REACTIVE_COMPACT_MS = 90_000;
 export const BUDGET_CRASH_MS = 60_000;
 
 /**
+ * Predictive-compaction failure classifier (#1741). Errors thrown inside
+ * `kickPredictiveCompact` fall into two buckets: transient races (spawn
+ * returned null, "Session not found" mid-compaction, etc.) that the user
+ * never notices, and structural CLI rejections that are 100% repro on the
+ * affected install (model-poison from #1739, missing CLI binary, missing
+ * parent transcript JSONL). The blanket downgrade in #152 silenced both.
+ * This regex matches the structural class so those — and only those —
+ * escalate to `captureSupportError` and open a serenorg/seren-core ticket.
+ * Add new patterns here when a new structural failure mode is identified.
+ */
+export const PREDICTIVE_STRUCTURAL_FAILURE_RE =
+  /issue with the selected model|model.*not exist|ENOENT|schema_drift|Parent JSONL transcript not found/i;
+
+/**
  * Instruction prepended to every agent session telling Claude Code / Codex
  * that the Seren MCP gateway exists and MUST be queried live before refusing
  * any third-party service. Intentionally does NOT embed a snapshot of
@@ -3102,10 +3116,31 @@ Structured summary:`;
       // log so the support pipeline doesn't capture every standby-spawn race
       // as a public bug report. The reactive path stays catastrophic. #152.
       if (mode === "predictive") {
+        const errMessage =
+          error instanceof Error ? error.message : String(error);
         console.warn(
           "[AgentStore] Predictive standby compaction failed (non-fatal):",
-          error instanceof Error ? error.message : String(error),
+          errMessage,
         );
+        // Triage by error signature (#1741). The original blanket downgrade
+        // (#152) silenced every standby-spawn race so the support pipeline
+        // didn't get spammed by transient noise. But the same path also
+        // swallowed STRUCTURAL CLI rejections that are 100% repro on the
+        // affected user (e.g. #1739's `<synthetic>` model poison producing
+        // "issue with the selected model"). Only the structural class
+        // escalates to captureSupportError; transient races stay quiet.
+        if (PREDICTIVE_STRUCTURAL_FAILURE_RE.test(errMessage)) {
+          void captureSupportError({
+            kind: "agent.predictive_compact_failed",
+            message: errMessage,
+            stack: error instanceof Error && error.stack ? [error.stack] : [],
+            agentContext: {
+              model: session.currentModelId,
+              provider: session.info.agentType,
+              tool_calls: [],
+            },
+          });
+        }
         // Clear standbySessionId pointer if it was wired up before the throw
         // so the next sendPrompt doesn't try to promote a dead standby. The
         // serving session itself is untouched (isCompacting was never set in

--- a/tests/unit/predictive-compact-telemetry.test.ts
+++ b/tests/unit/predictive-compact-telemetry.test.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Critical regression for #1741 — predictive-compaction structural failures must open seren-core tickets.
+// ABOUTME: Pre-fix the catch block silenced every failure with console.warn, hiding 100%-repro CLI rejections.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PREDICTIVE_STRUCTURAL_FAILURE_RE } from "../../src/stores/agent.store";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1741 — predictive-compaction telemetry triage", () => {
+  it("classifier matches structural CLI rejections (incl. #1739 model poison) and skips transient spawn races", () => {
+    // Structural — must open a seren-core ticket.
+    expect(
+      PREDICTIVE_STRUCTURAL_FAILURE_RE.test(
+        "There's an issue with the selected model (<synthetic>). It may not exist or you may not have access to it.",
+      ),
+    ).toBe(true);
+
+    // Transient — the original #152 rationale (don't spam support on races) still holds.
+    expect(
+      PREDICTIVE_STRUCTURAL_FAILURE_RE.test(
+        "synthetic standby spawn returned null",
+      ),
+    ).toBe(false);
+  });
+
+  it("predictive catch block routes structural failures through captureSupportError, gated by the classifier", () => {
+    // Locate the `mode === "predictive"` catch path (anchored on the
+    // unique downgrade message from the original #152 implementation) and
+    // verify it both tests the classifier AND calls captureSupportError.
+    // Without both, the support pipeline either over-fires (every race)
+    // or under-fires (today's bug) — the fix is the AND.
+    const catchIdx = agentStoreSource.indexOf(
+      "Predictive standby compaction failed (non-fatal):",
+    );
+    expect(catchIdx).toBeGreaterThan(0);
+    const catchBody = agentStoreSource.slice(catchIdx, catchIdx + 2500);
+    expect(catchBody).toContain("PREDICTIVE_STRUCTURAL_FAILURE_RE.test(");
+    expect(catchBody).toContain("captureSupportError({");
+    expect(catchBody).toContain('kind: "agent.predictive_compact_failed"');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1741. The predictive-compaction catch block downgraded every failure to `console.warn` per #152 — sound rationale (don't spam support on transient spawn races) but it also swallowed structural CLI rejections that are 100% repro on the affected install. The #1739 `<synthetic>` model-poison failure went silent in the wild because of this.

This PR triages by error signature:

- **Structural** ("issue with the selected model", "model not exist", "ENOENT", "schema_drift", "Parent JSONL transcript not found") -> call `captureSupportError({ kind: "agent.predictive_compact_failed", ... })` -> seren-core ticket opens.
- **Transient** (everything else, e.g. "synthetic standby spawn returned null", "Session not found") -> stays on `console.warn` as before, no ticket.

The classifier lives in a single exported regex (`PREDICTIVE_STRUCTURAL_FAILURE_RE`) so the structural-failure list is the unit of change when a new mode is identified.

## Test plan

- [x] `pnpm vitest run tests/unit/predictive-compact-telemetry.test.ts` passes (2 critical asserts: classifier behavior + catch-block wiring).
- [x] Existing `tests/unit/agent-turn-error.test.ts`, `tests/unit/support-pipeline-loud-failures.test.ts`, `tests/unit/support-reporting.test.ts`, `tests/unit/predictive-compact-spawn-fixes.test.ts` still pass (38 tests).
- [x] Biome clean on changed files.
- [x] No new tsc errors introduced (pre-existing errors in `tests/unit/cli-updater.test.ts` and `tests/unit/updater-store.test.ts` are unrelated).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
