### PR TITLE
fix(test): unbound predictive-catch slice so #1742 growth doesn't break #152 source assertions (#1744)

### DIFF
--- a/tests/unit/compaction-predictive-soft-fail.test.ts
+++ b/tests/unit/compaction-predictive-soft-fail.test.ts
@@ -53,8 +53,9 @@ describe("#152 — predictive standby spawn null is non-catastrophic", () => {
     // with the Error instance.
     const catchIdx = compactBody.indexOf("} catch (error) {");
     expect(catchIdx, "catch block must exist").toBeGreaterThan(0);
-    const catchBody = compactBody.slice(catchIdx, catchIdx + 1500);
-    // Guard: predictive branch is checked first
+    // Slice to end of the function so growth in the predictive branch
+    // doesn't push the catastrophic log past a fixed window.
+    const catchBody = compactBody.slice(catchIdx);
     const predictiveCatchIdx = catchBody.indexOf('if (mode === "predictive")');
     const catastrophicLogIdx = catchBody.indexOf(
       "Failed to compact agent conversation (catastrophic)",
@@ -62,6 +63,10 @@ describe("#152 — predictive standby spawn null is non-catastrophic", () => {
     expect(
       predictiveCatchIdx,
       "predictive branch must be inside catch",
+    ).toBeGreaterThan(0);
+    expect(
+      catastrophicLogIdx,
+      "catastrophic console.error must exist after the predictive branch",
     ).toBeGreaterThan(0);
     expect(
       predictiveCatchIdx,
@@ -73,7 +78,7 @@ describe("#152 — predictive standby spawn null is non-catastrophic", () => {
     // Without this, the next sendPrompt's standby-promotion path would try
     // to promote a session id that is gone or unreachable.
     const catchIdx = compactBody.indexOf("} catch (error) {");
-    const catchBody = compactBody.slice(catchIdx, catchIdx + 1500);
+    const catchBody = compactBody.slice(catchIdx);
     expect(catchBody).toMatch(/standbySessionId/);
     expect(catchBody).toMatch(/setState\([^)]*standbySessionId[^)]*null/);
   });


### PR DESCRIPTION
## Summary

- `compaction-predictive-soft-fail.test.ts` source-string-asserts on a fixed 1500-char slice of the predictive catch block. PR #1742 grew that branch (added `captureSupportError` triage), pushing the catastrophic `console.error` and the `standbySessionId` clear past the window — both assertions failed even though the runtime behavior is unchanged.
- Slice from `catchIdx` to end of `compactBody` instead. The body is already bounded by the next function (`compactAndRetry`), so this is self-bounding without a magic length.
- Also adds an explicit `expect(catastrophicLogIdx).toBeGreaterThan(0)` so a future deletion of the catastrophic log fails loud instead of accidentally satisfying `predictiveCatchIdx < -1` style off-by-one logic.

Closes #1744. Unblocks the v3.26.0 retag.

## Test plan

- [x] `pnpm vitest run tests/unit/compaction-predictive-soft-fail.test.ts` — 4/4 pass locally
- [x] `pnpm test` — 667/667 pass locally (88 files)
- [ ] CI green on this branch
