### PR TITLE
fix(files): strip path:line[:col] anchor from agent file links (#1746)

### DIFF
--- a/src/lib/files/service.ts
+++ b/src/lib/files/service.ts
@@ -197,16 +197,42 @@ function entriesToNodes(entries: FileEntry[]): FileNode[] {
   }));
 }
 
+const HASH_ANCHOR = /^(.+?)#L(\d+)(?:-L?\d+)?$/;
+const COLON_ANCHOR = /^(.+?):(\d+)(?::\d+)?$/;
+
+function matchAnchor(rawPath: string): RegExpMatchArray | null {
+  return rawPath.match(HASH_ANCHOR) ?? rawPath.match(COLON_ANCHOR);
+}
+
+/**
+ * Strip a trailing line/column anchor from an agent-generated file link.
+ * Handles `#L42`, `#L10-L20`, `:42`, and `:42:5`. Returns the input unchanged
+ * if no anchor is present (including Windows paths like `C:\foo\bar.md`).
+ */
+export function stripLineAnchor(rawPath: string): string {
+  const match = matchAnchor(rawPath);
+  return match ? match[1] : rawPath;
+}
+
+/**
+ * Extract the line number from an agent-generated file link, or undefined
+ * if no anchor is present.
+ */
+export function extractLineAnchor(rawPath: string): number | undefined {
+  const match = matchAnchor(rawPath);
+  return match ? Number.parseInt(match[2], 10) : undefined;
+}
+
 /**
  * Open a file in a tab.
  */
 export async function openFileInTab(rawPath: string): Promise<void> {
-  // Strip line/column anchors (#L79, #L10-L20) from the path before reading.
-  // Agent-generated links include these for navigation but the OS can't open
-  // a file with '#' in the name.
-  const anchorMatch = rawPath.match(/^(.+?)#L(\d+)(?:-L?\d+)?$/);
-  const path = anchorMatch ? anchorMatch[1] : rawPath;
-  const line = anchorMatch ? Number.parseInt(anchorMatch[2], 10) : undefined;
+  // Strip line/column anchors before reading. Agents emit two styles:
+  // markdown anchors (#L79, #L10-L20) and grep/editor refs
+  // (path:line, path:line:col). Both must be removed before readFile.
+  // Non-greedy + end-anchor preserves Windows drive letters like C:\foo.md.
+  const path = stripLineAnchor(rawPath);
+  const line = extractLineAnchor(rawPath);
 
   console.log(
     "[openFileInTab] Opening file:",

--- a/tests/unit/file-link-anchor.test.ts
+++ b/tests/unit/file-link-anchor.test.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Critical regression test for agent-link line/column anchor stripping.
+// ABOUTME: Guards openFileInTab against passing :line[:col] suffixes to readFile (#1746).
+
+import { describe, expect, it } from "vitest";
+import { extractLineAnchor, stripLineAnchor } from "@/lib/files/service";
+
+describe("file-link anchor parsing", () => {
+  it("strips grep/editor :line and :line:col suffixes", () => {
+    expect(stripLineAnchor("/Users/x/Downloads/audit.md:44")).toBe(
+      "/Users/x/Downloads/audit.md",
+    );
+    expect(stripLineAnchor("src/lib/files/service.ts:203:7")).toBe(
+      "src/lib/files/service.ts",
+    );
+    expect(extractLineAnchor("/Users/x/Downloads/audit.md:44")).toBe(44);
+  });
+
+  it("strips markdown #L anchors and ranges", () => {
+    expect(stripLineAnchor("src/lib/files/service.ts#L42")).toBe(
+      "src/lib/files/service.ts",
+    );
+    expect(stripLineAnchor("src/lib/files/service.ts#L10-L20")).toBe(
+      "src/lib/files/service.ts",
+    );
+    expect(extractLineAnchor("src/lib/files/service.ts#L10-L20")).toBe(10);
+  });
+
+  it("preserves Windows drive-letter paths", () => {
+    expect(stripLineAnchor("C:\\Users\\x\\file.md")).toBe(
+      "C:\\Users\\x\\file.md",
+    );
+    expect(extractLineAnchor("C:\\Users\\x\\file.md")).toBeUndefined();
+  });
+
+  it("returns plain paths unchanged when no anchor is present", () => {
+    expect(stripLineAnchor("/Users/x/Downloads/audit.md")).toBe(
+      "/Users/x/Downloads/audit.md",
+    );
+    expect(extractLineAnchor("/Users/x/Downloads/audit.md")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- `openFileInTab` only stripped `#L42` markdown anchors, so any agent that followed the system-prompt convention `file_path:line_number` produced unclickable links — the `:44` suffix went straight to `readFile`.
- Extend the strip to also match `:line` and `:line:col`. Kept end-anchored + non-greedy so Windows drive-letter paths (`C:\foo\bar.md`) are preserved.
- Extracted `stripLineAnchor` / `extractLineAnchor` as pure helpers; covered with a unit test.

Closes #1746

## Test plan

- [x] `pnpm vitest run tests/unit/file-link-anchor.test.ts` — 4 passed
- [x] `pnpm exec biome check src/lib/files/service.ts` — clean
- [x] `pnpm exec tsc --noEmit` — no new errors from this change
- [ ] Manual: click an agent-rendered link of the form `[file.md:44](file.md:44)` and confirm the editor opens at the file

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
