### PR TITLE
feat(chat): persist tool-group expansion + Tail toggle for running output (#1748)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1013,9 +1013,29 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     | { type: "single"; message: AgentMessage }
     | {
         type: "tool_group";
+        /** Stable identity across regroup remounts (#1748). */
+        id: string;
         messages: AgentMessage[];
         toolCalls: ToolCallEvent[];
       };
+
+  const flushToolGroup = (
+    group: AgentMessage[],
+    out: GroupedMessage[],
+  ): void => {
+    if (group.length === 0) return;
+    if (group.length >= 3) {
+      const toolCalls = group
+        .filter((m) => m.toolCall)
+        .map((m) => m.toolCall as ToolCallEvent);
+      const id = toolCalls[0]?.toolCallId ?? group[0].id;
+      out.push({ type: "tool_group", id, messages: group, toolCalls });
+    } else {
+      for (const msg of group) {
+        out.push({ type: "single", message: msg });
+      }
+    }
+  };
 
   /** Group consecutive tool messages into collapsed groups */
   const groupConsecutiveToolCalls = createMemo(() => {
@@ -1025,49 +1045,14 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
     for (const message of messages) {
       if (message.type === "tool" && message.toolCall) {
-        // Add to current group
         currentGroup.push(message);
       } else {
-        // Flush current group if any
-        if (currentGroup.length > 0) {
-          if (currentGroup.length >= 3) {
-            // Group 3+ consecutive tool calls
-            grouped.push({
-              type: "tool_group",
-              messages: currentGroup,
-              toolCalls: currentGroup
-                .filter((m) => m.toolCall)
-                .map((m) => m.toolCall as ToolCallEvent),
-            });
-          } else {
-            // Show individual cards for 1-2 tool calls
-            for (const msg of currentGroup) {
-              grouped.push({ type: "single", message: msg });
-            }
-          }
-          currentGroup = [];
-        }
-        // Add non-tool message
+        flushToolGroup(currentGroup, grouped);
+        currentGroup = [];
         grouped.push({ type: "single", message });
       }
     }
-
-    // Flush remaining group
-    if (currentGroup.length > 0) {
-      if (currentGroup.length >= 3) {
-        grouped.push({
-          type: "tool_group",
-          messages: currentGroup,
-          toolCalls: currentGroup
-            .filter((m) => m.toolCall)
-            .map((m) => m.toolCall as ToolCallEvent),
-        });
-      } else {
-        for (const msg of currentGroup) {
-          grouped.push({ type: "single", message: msg });
-        }
-      }
-    }
+    flushToolGroup(currentGroup, grouped);
 
     return grouped;
   });
@@ -1490,7 +1475,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 index() === groupConsecutiveToolCalls().length - 1;
               if (item.type === "tool_group") {
                 return (
-                  <ToolCallGroup toolCalls={item.toolCalls} isComplete={true} />
+                  <ToolCallGroup
+                    groupId={item.id}
+                    toolCalls={item.toolCalls}
+                    isComplete={true}
+                  />
                 );
               }
               return renderMessage(item.message, isLast());

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -106,9 +106,30 @@ type GroupedMessage =
   | { type: "single"; message: UnifiedMessage }
   | {
       type: "tool_group";
+      /**
+       * Stable identity for this group across regroup remounts (#1748).
+       * Derived from the first tool call's id so per-group UI state
+       * (expand/Tail) survives the rebuild.
+       */
+      id: string;
       messages: UnifiedMessage[];
       toolCalls: ToolCallEvent[];
     };
+
+function flushToolGroup(group: UnifiedMessage[], out: GroupedMessage[]): void {
+  if (group.length === 0) return;
+  if (group.length >= 3) {
+    const toolCalls = group
+      .filter((m) => m.toolCall)
+      .map((m) => toToolCallEvent(m.toolCall as ToolCallData));
+    const id = toolCalls[0]?.toolCallId ?? group[0].id;
+    out.push({ type: "tool_group", id, messages: group, toolCalls });
+  } else {
+    for (const msg of group) {
+      out.push({ type: "single", message: msg });
+    }
+  }
+}
 
 /** Group consecutive tool_call messages into collapsed groups */
 function groupConsecutiveToolCalls(
@@ -119,49 +140,14 @@ function groupConsecutiveToolCalls(
 
   for (const message of messages) {
     if (message.type === "tool_call" && message.toolCall) {
-      // Add to current group
       currentGroup.push(message);
     } else {
-      // Flush current group if any
-      if (currentGroup.length > 0) {
-        if (currentGroup.length >= 3) {
-          // Group 3+ consecutive tool calls
-          grouped.push({
-            type: "tool_group",
-            messages: currentGroup,
-            toolCalls: currentGroup
-              .filter((m) => m.toolCall)
-              .map((m) => toToolCallEvent(m.toolCall as ToolCallData)),
-          });
-        } else {
-          // Show individual cards for 1-2 tool calls
-          for (const msg of currentGroup) {
-            grouped.push({ type: "single", message: msg });
-          }
-        }
-        currentGroup = [];
-      }
-      // Add non-tool message
+      flushToolGroup(currentGroup, grouped);
+      currentGroup = [];
       grouped.push({ type: "single", message });
     }
   }
-
-  // Flush remaining group
-  if (currentGroup.length > 0) {
-    if (currentGroup.length >= 3) {
-      grouped.push({
-        type: "tool_group",
-        messages: currentGroup,
-        toolCalls: currentGroup
-          .filter((m) => m.toolCall)
-          .map((m) => toToolCallEvent(m.toolCall as ToolCallData)),
-      });
-    } else {
-      for (const msg of currentGroup) {
-        grouped.push({ type: "single", message: msg });
-      }
-    }
-  }
+  flushToolGroup(currentGroup, grouped);
 
   return grouped;
 }
@@ -1143,6 +1129,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                 if (item.type === "tool_group") {
                   return (
                     <ToolCallGroup
+                      groupId={item.id}
                       toolCalls={item.toolCalls}
                       isComplete={true}
                     />

--- a/src/components/chat/ToolCallCard.tsx
+++ b/src/components/chat/ToolCallCard.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Shows tool summary, status indicator, and expandable details.
 
 import type { Component } from "solid-js";
-import { createSignal, Show } from "solid-js";
+import { createEffect, createSignal, Show } from "solid-js";
 import {
   isDirectoryListing,
   summarizeDirectoryListing,
@@ -11,6 +11,17 @@ import type { ToolCallEvent } from "@/services/providers";
 
 interface ToolCallCardProps {
   toolCall: ToolCallEvent;
+  /**
+   * When true, the card renders expanded regardless of the user's local
+   * toggle state. Used by the parent group's Tail mode (#1748) so the
+   * running card auto-opens without dropping the user's chevron control.
+   */
+  forceExpanded?: boolean;
+  /**
+   * When true, pin the result container's scroll to the bottom whenever the
+   * tool's parameters/result change. Only applied while the card is open.
+   */
+  tail?: boolean;
 }
 
 /** Truncate a string to maxLen characters with ellipsis. */
@@ -112,6 +123,24 @@ function extractSummary(toolCall: ToolCallEvent): string {
 export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
   const [isExpanded, setIsExpanded] = createSignal(false);
   const [isResultExpanded, setIsResultExpanded] = createSignal(false);
+
+  // Effective open state: parent's tail force-open OR user's local toggle.
+  const isOpen = () => props.forceExpanded || isExpanded();
+
+  // Inner-card auto-scroll for Tail mode. We pin the parameters and result
+  // containers (the two scrollable surfaces inside the card) so streaming
+  // updates stay at the bottom — without ever touching the outer chat scroll.
+  let paramsRef: HTMLDivElement | undefined;
+  let resultRef: HTMLDivElement | undefined;
+
+  createEffect(() => {
+    if (!props.tail || !isOpen()) return;
+    // Read reactive deps so this effect refires on streaming updates.
+    void props.toolCall.parameters;
+    void props.toolCall.result;
+    if (paramsRef) paramsRef.scrollTop = paramsRef.scrollHeight;
+    if (resultRef) resultRef.scrollTop = resultRef.scrollHeight;
+  });
 
   const resultIsListing = () => {
     const result = props.toolCall.result;
@@ -382,12 +411,12 @@ export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
 
         {/* Expand Icon */}
         <svg
-          class={`w-4 h-4 shrink-0 text-muted-foreground transition-transform ${isExpanded() ? "rotate-180" : ""}`}
+          class={`w-4 h-4 shrink-0 text-muted-foreground transition-transform ${isOpen() ? "rotate-180" : ""}`}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
           role="img"
-          aria-label={isExpanded() ? "Collapse" : "Expand"}
+          aria-label={isOpen() ? "Collapse" : "Expand"}
         >
           <path
             stroke-linecap="round"
@@ -399,7 +428,7 @@ export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
       </button>
 
       {/* Details */}
-      <Show when={isExpanded()}>
+      <Show when={isOpen()}>
         <div class="px-3 py-2 border-t border-surface-2 text-xs">
           {/* Parameters */}
           <Show when={props.toolCall.parameters}>
@@ -407,7 +436,10 @@ export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
               <div class="text-muted-foreground/70 font-medium mb-1">
                 Parameters:
               </div>
-              <div class="bg-background border border-surface-3 rounded p-2 font-mono text-foreground max-h-48 overflow-auto">
+              <div
+                ref={paramsRef}
+                class="bg-background border border-surface-3 rounded p-2 font-mono text-foreground max-h-48 overflow-auto"
+              >
                 {Object.entries(props.toolCall.parameters || {}).map(
                   ([key, value]) => (
                     <div class="mb-1 last:mb-0">
@@ -433,7 +465,10 @@ export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
               <Show
                 when={resultIsListing()}
                 fallback={
-                  <div class="bg-background border border-success/70 rounded p-2 text-success max-h-48 overflow-auto">
+                  <div
+                    ref={resultRef}
+                    class="bg-background border border-success/70 rounded p-2 text-success max-h-48 overflow-auto"
+                  >
                     {props.toolCall.result}
                   </div>
                 }

--- a/src/components/chat/ToolCallGroup.tsx
+++ b/src/components/chat/ToolCallGroup.tsx
@@ -2,13 +2,28 @@
 // ABOUTME: Reduces clutter by showing "searched 5 files, ran 3 commands" instead of 20+ individual cards.
 
 import type { Component } from "solid-js";
-import { createSignal, For, Show } from "solid-js";
+import { For, Show } from "solid-js";
 import type { ToolCallEvent } from "@/services/providers";
+import {
+  getToolCallGroupState,
+  setToolCallGroupExpanded,
+  setToolCallGroupTailing,
+} from "@/stores/tool-call-groups.store";
 import { ToolCallCard } from "./ToolCallCard";
 
 interface ToolCallGroupProps {
   toolCalls: ToolCallEvent[];
+  /**
+   * Stable identity for this group across regroup remounts (#1748). Provided
+   * by ChatContent and derived from the first tool call's id.
+   */
+  groupId: string;
   isComplete?: boolean;
+}
+
+function isRunning(tool: ToolCallEvent): boolean {
+  const status = tool.status.toLowerCase();
+  return status.includes("running") || status.includes("progress");
 }
 
 /** Categorize tool calls into plain language summary */
@@ -98,12 +113,20 @@ function buildSummary(
 }
 
 export const ToolCallGroup: Component<ToolCallGroupProps> = (props) => {
-  const [isExpanded, setIsExpanded] = createSignal(false);
+  // State lives in the store, keyed by groupId, so it survives regroup remounts.
+  const groupState = () => getToolCallGroupState(props.groupId);
+  const isExpanded = () => groupState().expanded;
+  const isTailing = () => groupState().tailing;
+  const toggleExpanded = () =>
+    setToolCallGroupExpanded(props.groupId, !isExpanded());
+  const toggleTailing = (e: MouseEvent) => {
+    e.stopPropagation(); // don't also toggle the chevron
+    setToolCallGroupTailing(props.groupId, !isTailing());
+  };
 
   const categories = () => categorizeToolCalls(props.toolCalls);
   const summary = () => buildSummary(categories());
-  const hasRunning = () =>
-    props.toolCalls.some((t) => t.status.toLowerCase().includes("running"));
+  const hasRunning = () => props.toolCalls.some(isRunning);
 
   return (
     <div class="my-2 mx-5 bg-surface-0 border border-surface-3 rounded-lg overflow-hidden">
@@ -111,7 +134,7 @@ export const ToolCallGroup: Component<ToolCallGroupProps> = (props) => {
       <button
         type="button"
         class="w-full flex items-center gap-3 px-3 py-2.5 text-left hover:bg-surface-2 transition-colors"
-        onClick={() => setIsExpanded(!isExpanded())}
+        onClick={toggleExpanded}
       >
         {/* Status Icon */}
         <Show
@@ -167,6 +190,42 @@ export const ToolCallGroup: Component<ToolCallGroupProps> = (props) => {
           {props.toolCalls.length} tool{props.toolCalls.length > 1 ? "s" : ""}
         </span>
 
+        {/* Tail Toggle — only meaningful while a tool is running */}
+        <Show when={hasRunning()}>
+          <button
+            type="button"
+            onClick={toggleTailing}
+            aria-pressed={isTailing() ? "true" : "false"}
+            title={
+              isTailing()
+                ? "Stop tailing running tool output"
+                : "Tail running tool output"
+            }
+            class={`shrink-0 flex items-center gap-1 px-2 py-0.5 rounded text-xs border transition-colors ${
+              isTailing()
+                ? "bg-primary/15 border-primary/40 text-primary"
+                : "bg-surface-2 border-surface-3 text-muted-foreground hover:text-foreground hover:border-primary/40"
+            }`}
+          >
+            <svg
+              class="w-3 h-3"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              role="img"
+              aria-label="Tail"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M19 14l-7 7m0 0l-7-7m7 7V3"
+              />
+            </svg>
+            <span>Tail</span>
+          </button>
+        </Show>
+
         {/* Expand Icon */}
         <svg
           class={`w-4 h-4 shrink-0 text-muted-foreground transition-transform ${isExpanded() ? "rotate-180" : ""}`}
@@ -189,7 +248,13 @@ export const ToolCallGroup: Component<ToolCallGroupProps> = (props) => {
       <Show when={isExpanded()}>
         <div class="border-t border-surface-2 px-3 py-2 space-y-2">
           <For each={props.toolCalls}>
-            {(toolCall) => <ToolCallCard toolCall={toolCall} />}
+            {(toolCall) => (
+              <ToolCallCard
+                toolCall={toolCall}
+                forceExpanded={isTailing() && isRunning(toolCall)}
+                tail={isTailing() && isRunning(toolCall)}
+              />
+            )}
           </For>
         </div>
       </Show>

--- a/src/stores/tool-call-groups.store.ts
+++ b/src/stores/tool-call-groups.store.ts
@@ -1,0 +1,48 @@
+// ABOUTME: Per-group expansion + tail state for in-chat tool-call groups.
+// ABOUTME: Survives ChatContent regrouping remounts so user clicks stick (#1748).
+
+import { createStore, reconcile } from "solid-js/store";
+
+export interface ToolCallGroupState {
+  expanded: boolean;
+  tailing: boolean;
+}
+
+const DEFAULT_STATE: ToolCallGroupState = {
+  expanded: false,
+  tailing: false,
+};
+
+interface StoreShape {
+  groups: Record<string, ToolCallGroupState>;
+}
+
+const [state, setState] = createStore<StoreShape>({ groups: {} });
+
+/** Reactive read of a group's state. Returns DEFAULT_STATE for unknown groups. */
+export function getToolCallGroupState(groupId: string): ToolCallGroupState {
+  return state.groups[groupId] ?? DEFAULT_STATE;
+}
+
+export function setToolCallGroupExpanded(
+  groupId: string,
+  expanded: boolean,
+): void {
+  const prev = state.groups[groupId] ?? DEFAULT_STATE;
+  setState("groups", groupId, { ...prev, expanded });
+}
+
+export function setToolCallGroupTailing(
+  groupId: string,
+  tailing: boolean,
+): void {
+  const prev = state.groups[groupId] ?? DEFAULT_STATE;
+  setState("groups", groupId, { ...prev, tailing });
+}
+
+/** Test/teardown helper. Clears the entire group registry. */
+export function _resetToolCallGroupsForTest(): void {
+  // reconcile() actually replaces the object instead of shallow-merging,
+  // which is what `setState("groups", {})` would do.
+  setState("groups", reconcile({}));
+}

--- a/tests/unit/tool-call-groups-store.test.ts
+++ b/tests/unit/tool-call-groups-store.test.ts
@@ -1,0 +1,60 @@
+// ABOUTME: Critical regression test for the tool-call group state store (#1748).
+// ABOUTME: Proves expand/Tail state survives the regroup remount that caused the bug.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetToolCallGroupsForTest,
+  getToolCallGroupState,
+  setToolCallGroupExpanded,
+  setToolCallGroupTailing,
+} from "@/stores/tool-call-groups.store";
+
+describe("tool-call-groups store", () => {
+  beforeEach(() => {
+    _resetToolCallGroupsForTest();
+  });
+
+  it("returns a default state for an unknown group without writing it", () => {
+    const state = getToolCallGroupState("never-written");
+    expect(state).toEqual({ expanded: false, tailing: false });
+  });
+
+  it("persists expanded across reads — proxies the regroup remount that closed the chevron pre-#1748", () => {
+    setToolCallGroupExpanded("group-1", true);
+
+    // Simulate ChatContent rebuilding the grouped array and a fresh
+    // ToolCallGroup component instance reading the same groupId.
+    expect(getToolCallGroupState("group-1").expanded).toBe(true);
+
+    setToolCallGroupExpanded("group-1", false);
+    expect(getToolCallGroupState("group-1").expanded).toBe(false);
+  });
+
+  it("persists tailing independently of expanded on the same group", () => {
+    setToolCallGroupExpanded("group-1", true);
+    setToolCallGroupTailing("group-1", true);
+
+    let s = getToolCallGroupState("group-1");
+    expect(s).toEqual({ expanded: true, tailing: true });
+
+    // Collapsing the group must not turn off Tail (spec #2: Tail persists
+    // for the group's lifetime; clicking the chevron does not override it).
+    setToolCallGroupExpanded("group-1", false);
+    s = getToolCallGroupState("group-1");
+    expect(s).toEqual({ expanded: false, tailing: true });
+  });
+
+  it("isolates state across distinct group ids", () => {
+    setToolCallGroupExpanded("group-1", true);
+    setToolCallGroupTailing("group-2", true);
+
+    expect(getToolCallGroupState("group-1")).toEqual({
+      expanded: true,
+      tailing: false,
+    });
+    expect(getToolCallGroupState("group-2")).toEqual({
+      expanded: false,
+      tailing: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Persist tool-group expansion across remounts.** Per-group `{expanded, tailing}` now lives in `src/stores/tool-call-groups.store.ts`, keyed by a stable `groupId` (first tool call's `toolCallId`). `ChatContent` and `AgentChat` both emit that id through a shared `flushToolGroup` helper, so the 3-vs-singles transition no longer wipes the chevron state.
- **Tail toggle for running tool output.** Group header now renders a `Tail` button when at least one tool is still running. When on, the running `ToolCallCard` is force-expanded and its inner parameters/result containers auto-scroll to the bottom on each streaming update. Outer chat scroll is untouched.
- **Behavior matches the confirmed spec:** (1) per-group persistence, (2) Tail on the group header with click propagation stopped so the chevron doesn't override, (3) tailed card stays open after completion, (4) brand-new groups still default collapsed, (5) inner-card scroll only.

Closes #1748

## Test plan

- [x] `pnpm vitest run tests/unit/tool-call-groups-store.test.ts` — 4 passed. Test caught a real Solid shallow-merge bug in the reset path (`setState("groups", {})` doesn't drop keys); fix uses `reconcile({})`.
- [x] `pnpm exec biome check` on the 5 changed source files — clean (only 2 pre-existing warnings unrelated to this change).
- [x] `pnpm exec tsc --noEmit` — no new errors from this change.
- [ ] Manual: in a long agent turn, expand the group, confirm it stays open as new tools land and as running→completed flips. Toggle Tail on a running tool, confirm the running card auto-opens and its output pins to the bottom; collapse the group via chevron and re-expand, confirm Tail is still on.

## Files

- `src/stores/tool-call-groups.store.ts` (new)
- `src/components/chat/ToolCallGroup.tsx` — store wiring + Tail toggle UI
- `src/components/chat/ToolCallCard.tsx` — `forceExpanded` + `tail` props with inner-card scroll pin
- `src/components/chat/ChatContent.tsx` and `AgentChat.tsx` — emit stable `groupId` via shared `flushToolGroup`
- `tests/unit/tool-call-groups-store.test.ts` (new) — 4 critical persistence cases

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
