### PR TITLE
fix(agent): #1749 enqueue user prompts during predictive-compact spawn race

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -177,6 +177,30 @@ async function waitForStandbySeed(
   return state.sessions[standbyId]?.seedCompleted === true;
 }
 
+/** Claude Code model IDs that ship with a 1M-token context tier. The CLI
+ * advertises the variant either as a bracketed suffix (`claude-opus-4-7[1m]`)
+ * or as the bare ID once the tier has been negotiated; both forms hit this
+ * helper. The first promptComplete still upserts the CLI-reported window via
+ * recordModelContextWindow, so this is just the cold-start default. #1749. */
+const CLAUDE_1M_MODELS = new Set([
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-4-7",
+  "claude-sonnet-4-6",
+]);
+
+function defaultContextWindowFor(agentType: string, modelId?: string): number {
+  if (agentType === "codex") return 400_000;
+  if (agentType === "gemini") return 1_000_000;
+  if (agentType === "claude-code" && modelId) {
+    const normalized = modelId.replace(/\[1m\]$/i, "");
+    if (CLAUDE_1M_MODELS.has(normalized) || /\[1m\]$/i.test(modelId)) {
+      return 1_000_000;
+    }
+  }
+  return 200_000;
+}
+
 import { isLikelyAuthError } from "@/lib/auth-errors";
 import { buildChatRequest, sendProviderMessage } from "@/lib/providers";
 import {
@@ -1986,11 +2010,7 @@ export const agentStore = {
             : undefined,
           contextWindowSize:
             cachedContextWindow ??
-            (resolvedAgentType === "codex"
-              ? 400_000
-              : resolvedAgentType === "gemini"
-                ? 1_000_000
-                : 200_000),
+            defaultContextWindowFor(resolvedAgentType, opts?.initialModelId),
           bootstrapPromptContext: finalBootstrapContext,
           pendingPrompts: [],
           role: opts?.role ?? "serving",
@@ -3356,6 +3376,14 @@ Structured summary:`;
     setState("sessions", standbyId, "conversationId", conversationId);
     setState("sessions", standbyId, "role", "serving");
     setState("sessions", standbyId, "seedCompleted", undefined);
+    // Transfer queued prompts. The #1749 enqueue-during-spawn-race guard in
+    // sendPrompt parks user prompts on the serving session while
+    // predictiveCompactInFlight=true; without this transfer those prompts
+    // would be lost when terminateSession deletes the serving session below.
+    const carriedQueue = serving.pendingPrompts ?? [];
+    if (carriedQueue.length > 0) {
+      setState("sessions", standbyId, "pendingPrompts", [...carriedQueue]);
+    }
 
     // Make the promoted standby the active session BEFORE the old serving
     // session is torn down. Without this, terminateSession's auto-pickup
@@ -3465,6 +3493,39 @@ Structured summary:`;
         options?.docNames,
       );
       this.clearTurnError(threadId);
+    }
+
+    // Predictive-compact race guard (#1749): auto-compact kicks
+    // `kickPredictiveCompact` which sets `predictiveCompactInFlight=true`
+    // synchronously, but the standby session is only spawned ~10s later
+    // (line ~3029). If the user submits during that window, the existing
+    // standbySessionId block below is a no-op and the prompt would dispatch
+    // on the overloaded serving session, growing context further (e.g. 127% →
+    // 183%). Enqueue instead — the standby's promptComplete handler kicks a
+    // drain once seedCompleted=true, which re-enters sendPrompt with the
+    // standby ready and promotes-and-dispatches normally.
+    if (
+      sessionId &&
+      session &&
+      session.role === "serving" &&
+      session.predictiveCompactInFlight &&
+      !session.standbySessionId &&
+      session.lastInputTokens != null &&
+      session.contextWindowSize > 0 &&
+      session.lastInputTokens / session.contextWindowSize >=
+        settingsStore.settings.autoCompactThreshold / 100
+    ) {
+      console.info(
+        `[AgentStore] sendPrompt: predictive compact in-flight at ${Math.round(
+          (session.lastInputTokens / session.contextWindowSize) * 100,
+        )}% — enqueuing prompt until standby is seeded (#1749)`,
+      );
+      // Keep turnInFlight=true (matching the #1623 isCompacting branch
+      // below) so the UI keeps showing "sending..." until the dispatched
+      // prompt actually completes on the promoted standby. The standby's
+      // seed-complete handler kicks the drain that dispatches this prompt.
+      this.enqueuePrompt(sessionId, prompt);
+      return;
     }
 
     // Predictive swap: if a warm standby is ready, promote it at this turn
@@ -4305,6 +4366,7 @@ Structured summary:`;
           );
           predictiveCompactBusy = false;
           const owner = state.sessions[sessionId];
+          let servingForDrain: string | null = null;
           if (owner?.conversationId) {
             for (const [sid, s] of Object.entries(state.sessions)) {
               if (
@@ -4312,7 +4374,34 @@ Structured summary:`;
                 s.role === "serving"
               ) {
                 setState("sessions", sid, "predictiveCompactInFlight", false);
+                if ((s.pendingPrompts ?? []).length > 0) {
+                  servingForDrain = sid;
+                }
               }
+            }
+          }
+          // Drain any prompts the user enqueued via the #1749 race guard while
+          // this standby was being spawned. The drained sendPrompt will see
+          // standbySessionId set + seedCompleted=true and route through
+          // promoteStandbyAndDispatch, which carries the remaining queue
+          // across the swap.
+          if (servingForDrain) {
+            const drainTarget = servingForDrain;
+            const queue = state.sessions[drainTarget]?.pendingPrompts ?? [];
+            const [nextPrompt, ...remaining] = queue;
+            if (nextPrompt != null) {
+              setState("sessions", drainTarget, "pendingPrompts", remaining);
+              console.info(
+                `[AgentStore] Standby ${sessionId} seeded — draining queued prompt on ${drainTarget} (#1749)`,
+              );
+              setTimeout(() => {
+                void this.sendPrompt(
+                  nextPrompt,
+                  undefined,
+                  undefined,
+                  drainTarget,
+                );
+              }, 0);
             }
           }
           break;

--- a/tests/unit/compaction-queue-race.test.ts
+++ b/tests/unit/compaction-queue-race.test.ts
@@ -109,11 +109,12 @@ describe("#1623 — sendPrompt defensive guard against compaction race", () => {
     // The guard must live BEFORE the session.info.status === "error" branch
     // because a compacting session still has an otherwise-valid status.
     // Window widened to accommodate the predictive-swap block added in #1631
-    // before the compacting guard. The invariant we care about is that the
-    // compacting guard still fires BEFORE the `status === "error"` branch.
+    // and the predictive-compact-race guard added in #1749, both before the
+    // compacting guard. The invariant we care about is that the compacting
+    // guard still fires BEFORE the `status === "error"` branch.
     const sendPromptWindow = agentStoreSource.slice(
       sendPromptStart,
-      sendPromptStart + 5000,
+      sendPromptStart + 7000,
     );
     expect(sendPromptWindow).toContain("session?.isCompacting");
     expect(sendPromptWindow).toContain("this.enqueuePrompt(sessionId, prompt)");

--- a/tests/unit/gemini-agent.test.ts
+++ b/tests/unit/gemini-agent.test.ts
@@ -138,8 +138,17 @@ describe("Gemini Agent — agent.store.ts wiring (#1471)", () => {
   it("contextWindowSize defaults to 1M for gemini", () => {
     // Gemini 2.5 Pro has a 1M+ context window — defaulting to 200k like
     // Claude would silently throttle the agent. Regression guard.
-    expect(agentStoreTs).toMatch(
-      /resolvedAgentType\s*===\s*"gemini"[^?]*\?\s*1_000_000/,
+    // #1749: this default now lives in defaultContextWindowFor; the spawn
+    // block delegates via that helper. Assert the helper still maps gemini
+    // to 1M.
+    const helperStart = agentStoreTs.indexOf(
+      "function defaultContextWindowFor(",
+    );
+    expect(helperStart, "defaultContextWindowFor must exist").toBeGreaterThan(0);
+    const helperEnd = agentStoreTs.indexOf("\n}\n", helperStart);
+    const helperBody = agentStoreTs.slice(helperStart, helperEnd);
+    expect(helperBody).toMatch(
+      /agentType\s*===\s*"gemini"\)?\s*return\s*1_000_000/,
     );
   });
 

--- a/tests/unit/predictive-compact-race.test.ts
+++ b/tests/unit/predictive-compact-race.test.ts
@@ -1,0 +1,167 @@
+// ABOUTME: Regression guards for #1749 — predictive compaction race where
+// ABOUTME: sendPrompt dispatches on overloaded serving session before standby is ready.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1749 — sendPrompt enqueues instead of dispatching when predictive compact is in flight", () => {
+  it("guard fires when predictiveCompactInFlight=true, no standby yet, and usage >= autoCompactThreshold", () => {
+    // The bug: kickPredictiveCompact flips predictiveCompactInFlight=true
+    // synchronously (agent.store.ts:3292-3293) but standbySessionId is not
+    // populated until the spawn round-trip completes (~10s later, line ~3029).
+    // sendPrompt only intercepted on standbySessionId, so a user submit during
+    // the spawn window dispatched on the overloaded serving session and grew
+    // context further (127% → 183% in the reported transcript). The guard
+    // must check predictiveCompactInFlight AND !standbySessionId AND
+    // critical-usage so a fast user does not get held up below the threshold.
+    const sendPromptStart = agentStoreSource.indexOf(
+      "async sendPrompt(\n    prompt: string",
+    );
+    expect(sendPromptStart, "sendPrompt must exist").toBeGreaterThan(0);
+    // Guard must live before the "standbySessionId" promote-or-wait block.
+    const standbyBlockIdx = agentStoreSource.indexOf(
+      "// Predictive swap: if a warm standby is ready",
+      sendPromptStart,
+    );
+    expect(standbyBlockIdx).toBeGreaterThan(sendPromptStart);
+
+    const guardWindow = agentStoreSource.slice(sendPromptStart, standbyBlockIdx);
+    expect(guardWindow).toContain("session.predictiveCompactInFlight");
+    expect(guardWindow).toContain("!session.standbySessionId");
+    expect(guardWindow).toContain(
+      "settingsStore.settings.autoCompactThreshold / 100",
+    );
+    expect(guardWindow).toContain("this.enqueuePrompt(sessionId, prompt)");
+  });
+
+  it("guard does not reset turnInFlight (UI stays in 'sending' until dispatch completes)", () => {
+    // Matches the #1623 isCompacting re-enqueue contract: when a prompt is
+    // queued for a session that is about to swap, the turn IS still in
+    // flight conceptually — the UI must keep showing "sending..." until the
+    // promoted session's promptComplete clears it. Resetting turnInFlight to
+    // false here would let the user fire-and-forget more prompts before the
+    // first one even dispatches, and would hide the spinner mid-turn.
+    const guardStart = agentStoreSource.indexOf(
+      "// Predictive-compact race guard (#1749)",
+    );
+    expect(guardStart, "race guard must be tagged with #1749").toBeGreaterThan(
+      0,
+    );
+    const guardEnd = agentStoreSource.indexOf("\n    }\n", guardStart);
+    expect(guardEnd).toBeGreaterThan(guardStart);
+    const guardBlock = agentStoreSource.slice(guardStart, guardEnd);
+    expect(guardBlock).not.toMatch(/setTurnInFlight\([^)]+,\s*false\)/);
+  });
+});
+
+describe("#1749 — promoteStandbyAndDispatch carries pendingPrompts across the swap", () => {
+  it("transfers serving.pendingPrompts to the standby BEFORE terminateSession deletes serving", () => {
+    // Without this transfer, prompts queued by the race guard above would be
+    // dropped on the floor when terminateSession deletes serving from
+    // state.sessions. The transfer must happen before the terminateSession
+    // call.
+    const fnStart = agentStoreSource.indexOf("async promoteStandbyAndDispatch(");
+    expect(fnStart, "promoteStandbyAndDispatch must exist").toBeGreaterThan(0);
+    const terminateIdx = agentStoreSource.indexOf(
+      "this.terminateSession(servingSessionId",
+      fnStart,
+    );
+    expect(terminateIdx).toBeGreaterThan(fnStart);
+
+    const preTerminate = agentStoreSource.slice(fnStart, terminateIdx);
+    expect(preTerminate).toContain("serving.pendingPrompts");
+    expect(preTerminate).toMatch(
+      /setState\(\s*"sessions",\s*standbyId,\s*"pendingPrompts"/,
+    );
+  });
+});
+
+describe("#1749 — standby seedCompleted handler drains the serving queue", () => {
+  it("when standby's seed promptComplete fires, drains a queued prompt on the matching serving session", () => {
+    // Without this drain trigger, prompts the race guard parked on the
+    // serving session's pendingPrompts would sit there forever — the user
+    // never sees a reply because no event re-enters sendPrompt for them.
+    // The drain must happen inside the standby branch of the promptComplete
+    // handler, after seedCompleted=true and predictiveCompactInFlight=false
+    // have been written.
+    const standbyBranch = agentStoreSource.indexOf(
+      'state.sessions[sessionId]?.role === "standby"',
+    );
+    expect(standbyBranch, "standby promptComplete branch must exist").toBeGreaterThan(
+      0,
+    );
+    const branchEnd = agentStoreSource.indexOf("\n          break;\n", standbyBranch);
+    expect(branchEnd).toBeGreaterThan(standbyBranch);
+    const branchBody = agentStoreSource.slice(standbyBranch, branchEnd);
+
+    // Must drain when serving has pendingPrompts.
+    expect(branchBody).toMatch(/pendingPrompts/);
+    // Must dispatch via sendPrompt on the serving session (not the standby).
+    expect(branchBody).toContain("this.sendPrompt(");
+    // Must reference #1749 so future readers know why this drain exists.
+    expect(branchBody).toContain("#1749");
+  });
+});
+
+describe("#1749 — defaultContextWindowFor recognises 1M Claude variants at spawn time", () => {
+  it("the spawn-time fallback delegates to defaultContextWindowFor with agentType + initialModelId", () => {
+    // The pre-#1749 fallback hardcoded 200_000 for Claude regardless of the
+    // model — so a session on claude-opus-4-7 (1M) reported 127%/183% usage
+    // on a model that actually had plenty of room, kicking premature
+    // compaction. The helper centralises the cold-start default and lets
+    // 1M-tier Claude IDs report their real window.
+    expect(agentStoreSource).toContain(
+      "defaultContextWindowFor(resolvedAgentType, opts?.initialModelId)",
+    );
+    // The old inline ternary cascade must be gone from the spawn block.
+    const spawnBlockIdx = agentStoreSource.indexOf("const cachedContextWindow");
+    const spawnBlockEnd = agentStoreSource.indexOf(
+      "bootstrapPromptContext: finalBootstrapContext",
+      spawnBlockIdx,
+    );
+    const spawnBlock = agentStoreSource.slice(spawnBlockIdx, spawnBlockEnd);
+    expect(spawnBlock).not.toMatch(/resolvedAgentType\s*===\s*"codex"/);
+  });
+
+  it("the helper maps known 1M Claude IDs to 1_000_000 and unknowns to 200_000", () => {
+    const helperStart = agentStoreSource.indexOf(
+      "function defaultContextWindowFor(",
+    );
+    expect(helperStart, "defaultContextWindowFor must exist").toBeGreaterThan(0);
+    const helperEnd = agentStoreSource.indexOf("\n}\n", helperStart);
+    const helperBody = agentStoreSource.slice(helperStart, helperEnd);
+
+    // Codex / Gemini cases must still return their existing defaults.
+    expect(helperBody).toContain('agentType === "codex"');
+    expect(helperBody).toContain("400_000");
+    expect(helperBody).toContain('agentType === "gemini"');
+    expect(helperBody).toContain("1_000_000");
+
+    // Claude 1M models must be enumerated explicitly so a brand-new install
+    // hits the right window on the very first turn (before the CLI's
+    // meta.contextWindow has had a chance to upsert).
+    expect(agentStoreSource).toContain('"claude-opus-4-7"');
+    expect(agentStoreSource).toContain('"claude-sonnet-4-6"');
+    // Default for anything unknown is still 200_000.
+    expect(helperBody).toContain("200_000");
+  });
+
+  it("the [1m] suffix variant also maps to 1M context", () => {
+    // The CLI advertises the 1M tier as a bracketed suffix
+    // (`claude-opus-4-7[1m]`); both the bare ID and the bracketed form
+    // must hit the 1M branch so a fresh session does not start at 200K
+    // and trigger premature auto-compaction.
+    const helperStart = agentStoreSource.indexOf(
+      "function defaultContextWindowFor(",
+    );
+    const helperEnd = agentStoreSource.indexOf("\n}\n", helperStart);
+    const helperBody = agentStoreSource.slice(helperStart, helperEnd);
+    expect(helperBody).toContain("\\[1m\\]");
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #1749. Adds a third `sendPrompt` guard so that when `predictiveCompactInFlight=true && !standbySessionId && usage >= autoCompactThreshold`, the prompt enqueues onto the serving session instead of dispatching on it. The standby's seed-completion handler now drains that queue, and `promoteStandbyAndDispatch` carries `pendingPrompts` across the swap so the queued prompt survives.
- Lifts the spawn-time `contextWindowSize` cascade into `defaultContextWindowFor`, which recognises 1M-tier Claude IDs (`claude-opus-4-7`, `claude-sonnet-4-6`, plus the `[1m]` bracket form). Pre-fix sessions on `claude-opus-4-7` reported 127%/183% on a model with plenty of room and tripped the race above.
- Adds `tests/unit/predictive-compact-race.test.ts` with 7 source-string regression guards covering the new branch, the queue carry-over, the standby-drain trigger, and `defaultContextWindowFor` behavior. Updates `gemini-agent.test.ts` and `compaction-queue-race.test.ts` to reflect the helper extraction and the wider `sendPrompt` window.

## Test plan

- [x] `pnpm test` — 90 files, 678 tests pass.
- [x] `pnpm check src/stores/agent.store.ts` — clean.
- [x] `pnpm tsc --noEmit` — no new errors (two pre-existing failures in unrelated test files).
- [ ] Manual repro on a long session: force `lastInputTokens` past `autoCompactThreshold * contextWindowSize`, send two prompts back-to-back during the predictive spawn window, confirm the second prompt does not dispatch on the overloaded session and that both turns eventually complete on the promoted standby.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
