### PR TITLE
fix(provider): #1754 infer meta.contextWindow + #1755 drop chooseUpdatedModelId no-op log spam

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -687,7 +687,30 @@ function buildClaudeArgs({
   return args;
 }
 
-function buildPromptMeta(result, peakInputTokens) {
+// Mirror of CLAUDE_1M_MODELS in src/stores/agent.store.ts. The CLI does not
+// always populate result.modelUsage[*].contextWindow (single-turn shortcuts,
+// abort paths, single-message --output-format runs), so the runtime needs
+// its own derivation table to keep `meta.contextWindow` reliable on every
+// prompt-complete. Without this, the desktop's auto-compaction gauge stays
+// pinned to the cold-start default (200K) and trips premature compaction on
+// 1M-tier sessions. #1754.
+const CLAUDE_1M_MODELS = new Set([
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-4-7",
+  "claude-sonnet-4-6",
+]);
+
+function inferClaudeContextWindow(modelId) {
+  if (typeof modelId !== "string" || modelId.length === 0) return undefined;
+  if (/\[1m\]$/i.test(modelId)) return 1_000_000;
+  const normalized = modelId.replace(/\[1m\]$/i, "");
+  if (CLAUDE_1M_MODELS.has(normalized)) return 1_000_000;
+  if (normalized.startsWith("claude-")) return 200_000;
+  return undefined;
+}
+
+function buildPromptMeta(result, peakInputTokens, fallbackModelId) {
   const usage = result?.usage ?? {};
   // Prefer per-turn peak tracked from assistant message usage events — the
   // authoritative per-API-call input size. The final turn in a multi-turn
@@ -721,13 +744,20 @@ function buildPromptMeta(result, peakInputTokens) {
   const outputTokens =
     typeof usage.output_tokens === "number" ? usage.output_tokens : undefined;
 
-  // Extract context window size from modelUsage if available.
+  // Extract context window size from modelUsage if available; otherwise
+  // derive it from the resolved model id. The CLI does not always populate
+  // modelUsage on result events, and when it doesn't the desktop store has
+  // no other channel to learn the window. #1754.
   const modelUsage = result?.modelUsage ?? {};
-  const firstModel = Object.values(modelUsage)[0];
-  const contextWindow =
+  const firstModelKey = Object.keys(modelUsage)[0];
+  const firstModel = firstModelKey != null ? modelUsage[firstModelKey] : undefined;
+  let contextWindow =
     typeof firstModel?.contextWindow === "number"
       ? firstModel.contextWindow
       : undefined;
+  if (contextWindow == null) {
+    contextWindow = inferClaudeContextWindow(firstModelKey ?? fallbackModelId);
+  }
 
   return {
     meta: {
@@ -1154,14 +1184,22 @@ function handleAssistantMessage(emit, session, payload) {
       message.model,
       session.availableModelRecords,
     );
-    // Trace every resolution — both the changing path and the steady-state —
-    // so when the picker disagrees with the assistant's self-report (#1718)
-    // we can read message.model directly from the log instead of guessing.
-    // The line ends up in `~/Library/Logs/com.serendb.desktop/SerenDesktop.log`
-    // via the ProviderRuntime stderr bridge.
-    console.warn(
-      `[browser-local][claude] chooseUpdatedModelId: previous=${previousModelId ?? "<unset>"}, incoming=${message.model ?? "<missing>"}, resolved=${nextModelId ?? "<null>"}`,
-    );
+    // Trace resolutions when something actually moves — transitions, picker
+    // disagreements, missing fields — so #1718's diagnostic intent is
+    // preserved. Steady-state no-ops (previous=incoming=resolved) carry no
+    // signal; the Rust stderr bridge wraps every line as log::warn!, so
+    // logging them every turn was spamming the desktop log (#1755).
+    const isNoOpResolution =
+      previousModelId != null &&
+      message.model != null &&
+      nextModelId != null &&
+      previousModelId === message.model &&
+      previousModelId === nextModelId;
+    if (!isNoOpResolution) {
+      console.warn(
+        `[browser-local][claude] chooseUpdatedModelId: previous=${previousModelId ?? "<unset>"}, incoming=${message.model ?? "<missing>"}, resolved=${nextModelId ?? "<null>"}`,
+      );
+    }
     if (nextModelId != null && nextModelId !== session.currentModelId) {
       session.currentModelId = nextModelId;
       emit("provider://session-status", buildSessionStatus(session));
@@ -1266,7 +1304,7 @@ function handleResult(emit, session, payload) {
   emit("provider://prompt-complete", {
     sessionId: session.id,
     stopReason: payload?.stop_reason ?? (payload?.is_error ? "error" : "end_turn"),
-    ...buildPromptMeta(payload, peakInputTokens),
+    ...buildPromptMeta(payload, peakInputTokens, session.currentModelId),
   });
   // Reset for the next prompt. Peak is prompt-scoped, not session-scoped.
   session.peakInputTokens = 0;

--- a/tests/unit/claude-runtime-cleanups.test.ts
+++ b/tests/unit/claude-runtime-cleanups.test.ts
@@ -1,0 +1,100 @@
+// ABOUTME: Regression guards for #1754 (meta.contextWindow inference fallback)
+// ABOUTME: and #1755 (chooseUpdatedModelId no-op log suppression).
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const claudeRuntime = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+
+describe("#1754 — Claude provider runtime infers contextWindow when CLI omits modelUsage", () => {
+  it("inferClaudeContextWindow exists and enumerates known 1M-tier Claude IDs", () => {
+    // The 1M Claude variants must be enumerated here so a fresh session on
+    // claude-opus-4-7 reports its real window even when the CLI's result
+    // event has empty modelUsage. The set must mirror CLAUDE_1M_MODELS in
+    // src/stores/agent.store.ts so the runtime and the store agree on
+    // cold-start defaults.
+    expect(claudeRuntime).toContain("function inferClaudeContextWindow(");
+    expect(claudeRuntime).toContain('"claude-opus-4-7"');
+    expect(claudeRuntime).toContain('"claude-opus-4-6"');
+    expect(claudeRuntime).toContain('"claude-sonnet-4-7"');
+    expect(claudeRuntime).toContain('"claude-sonnet-4-6"');
+  });
+
+  it("inferClaudeContextWindow handles the [1m] suffix variant", () => {
+    // The CLI advertises the 1M tier as a bracketed suffix
+    // (`claude-opus-4-7[1m]`). The helper must accept the suffix form so a
+    // brand-new model that has not yet been added to the explicit set still
+    // reports the right window via the suffix path.
+    const fnStart = claudeRuntime.indexOf("function inferClaudeContextWindow(");
+    const fnEnd = claudeRuntime.indexOf("\n}\n", fnStart);
+    const fnBody = claudeRuntime.slice(fnStart, fnEnd);
+    expect(fnBody).toContain("\\[1m\\]");
+    expect(fnBody).toMatch(/return\s+1_000_000/);
+    expect(fnBody).toMatch(/return\s+200_000/);
+  });
+
+  it("buildPromptMeta takes a fallbackModelId and uses inference when modelUsage lacks contextWindow", () => {
+    // The pre-fix code only read result.modelUsage[0].contextWindow. When
+    // the CLI omitted modelUsage entirely (single-turn shortcuts, abort
+    // paths), no meta.contextWindow was emitted and the desktop store
+    // stayed at the cold-start default — premature auto-compaction
+    // followed. The helper must accept a fallback model id and fall back
+    // to inferClaudeContextWindow when modelUsage doesn't carry one.
+    const sigIdx = claudeRuntime.indexOf("function buildPromptMeta(");
+    expect(sigIdx).toBeGreaterThan(0);
+    const sigLine = claudeRuntime.slice(sigIdx, sigIdx + 200);
+    expect(sigLine).toMatch(
+      /function buildPromptMeta\(\s*result,\s*peakInputTokens,\s*fallbackModelId\s*\)/,
+    );
+
+    const fnEnd = claudeRuntime.indexOf("\n}\n", sigIdx);
+    const fnBody = claudeRuntime.slice(sigIdx, fnEnd);
+    // Inference must run when the CLI-supplied window is null/undefined.
+    expect(fnBody).toMatch(/contextWindow\s*==\s*null/);
+    expect(fnBody).toContain("inferClaudeContextWindow(");
+  });
+
+  it("the prompt-complete emit passes session.currentModelId as the fallback", () => {
+    // Without this, `inferClaudeContextWindow` has no signal when modelUsage
+    // is fully absent — the inferred window would always be undefined and
+    // the fix collapses to the pre-#1754 behaviour.
+    expect(claudeRuntime).toContain(
+      "buildPromptMeta(payload, peakInputTokens, session.currentModelId)",
+    );
+  });
+});
+
+describe("#1755 — chooseUpdatedModelId log skips no-op resolutions", () => {
+  it("the parent-message handler computes isNoOpResolution before logging", () => {
+    // The Rust stderr bridge wraps every line as log::warn!, so the
+    // pre-fix code spammed a WARN for every steady-state turn (the user's
+    // transcript shows 4+ identical lines back-to-back). The fix gates
+    // the log on a no-op short-circuit while preserving #1718's intent
+    // for transitions and picker disagreements.
+    const callIdx = claudeRuntime.indexOf("chooseUpdatedModelId(");
+    expect(callIdx).toBeGreaterThan(0);
+    const region = claudeRuntime.slice(callIdx, callIdx + 1500);
+    expect(region).toContain("isNoOpResolution");
+    expect(region).toMatch(/if\s*\(\s*!isNoOpResolution\s*\)/);
+  });
+
+  it("the no-op short-circuit requires all three fields to match (previous, incoming, resolved)", () => {
+    // A weaker check (e.g. only previous === incoming) would suppress
+    // legitimate divergence cases where the picker resolved a different
+    // id than the assistant's self-report — exactly the case #1718 was
+    // built to catch. All three must be equal AND non-null for the log
+    // to be safely suppressed.
+    const noopIdx = claudeRuntime.indexOf("isNoOpResolution");
+    expect(noopIdx).toBeGreaterThan(0);
+    const region = claudeRuntime.slice(noopIdx, noopIdx + 600);
+    expect(region).toContain("previousModelId != null");
+    expect(region).toContain("message.model != null");
+    expect(region).toContain("nextModelId != null");
+    expect(region).toContain("previousModelId === message.model");
+    expect(region).toContain("previousModelId === nextModelId");
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #1754. `buildPromptMeta` now falls back to `inferClaudeContextWindow(firstKey ?? session.currentModelId)` when `result.modelUsage[0].contextWindow` is missing. The 1M-tier table mirrors `CLAUDE_1M_MODELS` in `src/stores/agent.store.ts` so runtime and store agree on cold-start defaults; the bracketed `[1m]` suffix is also recognised for forward compatibility.
- Closes #1755. The parent-message handler now suppresses the `chooseUpdatedModelId` `console.warn` when the resolution is a steady-state no-op (`previous=incoming=resolved`, all non-null). Transitions, picker disagreements, and missing fields still log so #1718's diagnostic intent is preserved; the Rust stderr bridge no longer surfaces a WARN every steady-state turn.

## Test plan

- [x] New `tests/unit/claude-runtime-cleanups.test.ts` (6 tests) covers the inference helper, the `buildPromptMeta` fallback, and the no-op log gate.
- [x] `pnpm test` — 92 files, 688 tests pass.
- [x] `pnpm tsc --noEmit` — no new errors (two pre-existing failures in unrelated test files).
- [ ] Manual repro: load a session on `claude-opus-4-7`, force a single-turn shortcut where `result.modelUsage` is `{}`, confirm `meta.contextWindow` is still `1_000_000` and the gauge does not pin to 200K. Then exercise a steady-state turn and confirm no `chooseUpdatedModelId` line appears in `~/Library/Logs/com.serendb.desktop/SerenDesktop.log`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
