### PR TITLE
fix(agent): close #1757 compactAndRetry false-fail on Codex + latent Claude Code double-dispatch

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -124,6 +124,8 @@ function waitForSessionReady(sessionId: string): Promise<void> {
  * transient or "no-op" outcomes keep the user inside the agent session.
  *
  * - `retried`: compaction succeeded AND the user's last prompt was re-sent.
+ *   Returned by `compactAndRetry` only — `compactAgentConversation` never
+ *   retries; that responsibility lives with the caller.
  * - `succeeded`: compaction succeeded, no prompt to retry.
  * - `skipped_nothing_to_compact`: message count is below `preserveCount`;
  *   the session was already too small to compact. Usually means a single
@@ -136,6 +138,21 @@ export type CompactionOutcome =
   | "succeeded"
   | "skipped_nothing_to_compact"
   | "failed_catastrophic";
+
+/**
+ * Return shape of `compactAgentConversation`. The new session id is plumbed
+ * back to callers so they don't have to re-derive it by searching
+ * `state.sessions` for a matching `conversationId` — that lookup falsely
+ * fails for agents like Codex where `sessionId === conversationId` (#1757).
+ *
+ * `newSessionId` is set on reactive success (the post-compaction serving
+ * session). On predictive success the standby id is stored on the parent
+ * via `standbySessionId`; predictive callers consult that pointer instead.
+ */
+type CompactAgentResult = {
+  outcome: Exclude<CompactionOutcome, "retried">;
+  newSessionId?: string;
+};
 
 /** Wait for a session to return to 'ready' (not 'prompting') with a timeout.
  * Used after sending the compaction seed prompt to avoid racing with the retry. */
@@ -2846,26 +2863,17 @@ export const agentStore = {
     sessionId: string,
     preserveCount: number,
     /**
-     * Optional prompt to retry on the new session after compaction. Callers
-     * pass this when a send failed mid-flight (e.g. `compactAndRetry`). The
-     * auto-compact-from-promptComplete path passes `undefined` because the
-     * previous prompt already completed successfully — retrying it would
-     * duplicate. Queued prompts are handled separately via the pendingPrompts
-     * transfer below — see #1623.
-     */
-    pendingUserPrompt?: string,
-    /**
      * Predictive mode spawns a warm standby (role="standby") WITHOUT
      * terminating the old serving session. The new session is visible to
      * events but invisible to the UI until `promoteStandbyAndDispatch`
      * promotes it on the next user submit. #1631.
      */
     opts?: { mode?: "reactive" | "predictive" },
-  ): Promise<CompactionOutcome> {
+  ): Promise<CompactAgentResult> {
     const mode = opts?.mode ?? "reactive";
     const session = state.sessions[sessionId];
     if (!session || session.isCompacting) {
-      return "skipped_nothing_to_compact";
+      return { outcome: "skipped_nothing_to_compact" };
     }
 
     const messages = session.messages;
@@ -2873,7 +2881,7 @@ export const agentStore = {
       console.info(
         "[AgentStore] Not enough messages to compact (message count below preserve threshold)",
       );
-      return "skipped_nothing_to_compact";
+      return { outcome: "skipped_nothing_to_compact" };
     }
 
     // isCompacting signals "this serving session is being torn down and
@@ -3019,7 +3027,7 @@ Structured summary:`;
             console.info(
               `[compact.synthetic.success] standby ${syntheticStandbyId} resumed synthetic transcript ${syntheticAgentSessionId} for serving ${sessionId}`,
             );
-            return "succeeded";
+            return { outcome: "succeeded", newSessionId: syntheticStandbyId };
           } catch (err) {
             // Defensive fallback: any failure (CLI rejects file, parent
             // JSONL unreadable, write fails) drops through to today's
@@ -3043,7 +3051,7 @@ Structured summary:`;
           console.warn(
             "[AgentStore] Predictive standby spawn returned null — keeping serving session, will retry next turn",
           );
-          return "failed_catastrophic";
+          return { outcome: "failed_catastrophic" };
         }
         setState("sessions", standbyId, "compactedSummary", compactedSummary);
         setState("sessions", sessionId, "standbySessionId", standbyId);
@@ -3055,7 +3063,7 @@ Structured summary:`;
         console.info(
           `[AgentStore] Predictive compaction: standby ${standbyId} seeding for serving ${sessionId}`,
         );
-        return "succeeded";
+        return { outcome: "succeeded", newSessionId: standbyId };
       }
 
       // Reactive path: terminate old, spawn fresh serving, seed, retry.
@@ -3114,22 +3122,17 @@ Structured summary:`;
         `[AgentStore] Compacted ${toCompact.length} messages, preserved ${toPreserve.length}. Seeding new session.`,
       );
 
-      // Wait for the new session to be ready, then restore settings and seed
+      // Wait for the new session to be ready, then restore settings and seed.
+      // We deliberately stop here: dispatching the user's failed prompt is the
+      // caller's job (`compactAndRetry`). Doing it inline produced two bugs in
+      // one function — see #1757. The contract is "produce a fresh, idle,
+      // seeded session and return its id"; nothing more.
       await waitForSessionReady(newSessionId);
       await this.restoreSessionSettings(session, newSessionId);
       await providerService.sendPrompt(newSessionId, seedPrompt);
       await waitForSessionIdle(newSessionId);
 
-      if (pendingUserPrompt) {
-        console.info(
-          "[AgentStore] Retrying user prompt after auto-compaction:",
-          pendingUserPrompt.slice(0, 60),
-        );
-        setState("sessions", newSessionId, "lastUserPrompt", pendingUserPrompt);
-        await providerService.sendPrompt(newSessionId, pendingUserPrompt);
-        return "retried";
-      }
-      return "succeeded";
+      return { outcome: "succeeded", newSessionId };
     } catch (error) {
       // Predictive warm-up failures are not catastrophic — the serving
       // session is still alive and the user can keep working. Downgrade the
@@ -3168,7 +3171,7 @@ Structured summary:`;
         if (state.sessions[sessionId]?.standbySessionId) {
           setState("sessions", sessionId, "standbySessionId", null);
         }
-        return "failed_catastrophic";
+        return { outcome: "failed_catastrophic" };
       }
       console.error(
         "[AgentStore] Failed to compact agent conversation (catastrophic):",
@@ -3204,7 +3207,7 @@ Structured summary:`;
           );
         }
       }
-      return "failed_catastrophic";
+      return { outcome: "failed_catastrophic" };
     }
   },
 
@@ -3226,12 +3229,13 @@ Structured summary:`;
     );
 
     try {
-      // Retry the last prompt that failed — this entry point is called from
-      // sendPrompt's error handler when the CLI rejected for context overflow.
-      const outcome = await this.compactAgentConversation(
+      // compactAgentConversation returns the id of the fresh, seeded, idle
+      // session. We trust that id and do the retry locally — splitting
+      // dispatch across both functions, or re-deriving the id via a state
+      // lookup, regressed for #1757.
+      const result = await this.compactAgentConversation(
         sessionId,
         settingsStore.settings.autoCompactPreserveMessages,
-        lastPrompt,
       );
 
       // Propagate non-success outcomes directly. "skipped" means the message
@@ -3239,42 +3243,20 @@ Structured summary:`;
       // "failed_catastrophic" means spawn or summary threw. Chat fallback is
       // only correct for the latter; the former means a single prompt is too
       // large and Chat would fail identically — show an error instead.
-      if (outcome === "skipped_nothing_to_compact") {
-        return outcome;
-      }
-      if (outcome === "failed_catastrophic") {
-        return outcome;
+      if (result.outcome !== "succeeded") {
+        return result.outcome;
       }
 
-      // After compaction, the old session is terminated and a new one exists.
-      // Find the new session by conversation ID.
-      const convoId = session.conversationId;
-      const newEntry = Object.entries(state.sessions).find(
-        ([, s]) => s.conversationId === convoId && !s.isCompacting,
-      );
-      if (!newEntry) {
+      const newSessionId = result.newSessionId;
+      if (!newSessionId) {
+        // Defensive: the type contract guarantees newSessionId on
+        // "succeeded", but if it ever drifts we treat the absence as
+        // catastrophic so the caller can fall back to Chat.
         console.warn(
-          "[AgentStore] compactAndRetry: new session not found after compaction — treating as catastrophic",
+          "[AgentStore] compactAndRetry: succeeded outcome without newSessionId — treating as catastrophic",
         );
         return "failed_catastrophic";
       }
-
-      const [newSessionId] = newEntry;
-
-      // If the search returned the original session, compaction never
-      // swapped it out — treat as catastrophic so the user isn't silently
-      // stuck on a full session.
-      if (newSessionId === sessionId) {
-        console.warn(
-          "[AgentStore] compactAndRetry: new session matches old session id — compaction did not swap",
-        );
-        return "failed_catastrophic";
-      }
-
-      // compactAgentConversation sends the seed prompt before returning, so the
-      // session may still be in 'prompting' state. Wait for it to go idle before
-      // sending the user's original prompt to avoid a concurrent-prompt race.
-      await waitForSessionIdle(newSessionId);
 
       // Retry the original prompt if available; otherwise leave the
       // compacted session ready for the user's next input.
@@ -3282,6 +3264,7 @@ Structured summary:`;
         console.info(
           `[AgentStore] Compaction complete, retrying prompt on session ${newSessionId}`,
         );
+        setState("sessions", newSessionId, "lastUserPrompt", lastPrompt);
         await providerService.sendPrompt(newSessionId, lastPrompt);
         return "retried";
       }
@@ -3312,17 +3295,16 @@ Structured summary:`;
     predictiveCompactBusy = true;
     setState("sessions", sessionId, "predictiveCompactInFlight", true);
     try {
-      const outcome = await this.compactAgentConversation(
+      const result = await this.compactAgentConversation(
         sessionId,
         settingsStore.settings.autoCompactPreserveMessages,
-        undefined,
         { mode: "predictive" },
       );
-      if (outcome !== "succeeded") {
+      if (result.outcome !== "succeeded") {
         // Silent abort — serving session is still healthy.
         console.warn(
           "[AgentStore] kickPredictiveCompact: non-success outcome",
-          outcome,
+          result.outcome,
         );
         predictiveCompactBusy = false;
         setState("sessions", sessionId, "predictiveCompactInFlight", false);

--- a/tests/unit/auto-compact-predictive.test.ts
+++ b/tests/unit/auto-compact-predictive.test.ts
@@ -78,7 +78,11 @@ describe("#1675 — compactAndRetry still uses reactive (failed-prompt retry)", 
     expect(callIdx, "compactAndRetry must call compactAgentConversation").toBeGreaterThan(0);
     const callBlock = fnBody.slice(callIdx, callIdx + 400);
     expect(callBlock).not.toContain("predictive");
-    expect(callBlock).toContain("lastPrompt,");
+    // Post-#1757 compactAndRetry retries lastPrompt itself — the helper
+    // never sees it. Verify the retry dispatch lives in compactAndRetry.
+    expect(fnBody).toMatch(
+      /providerService\.sendPrompt\(newSessionId,\s*lastPrompt\)/,
+    );
   });
 });
 

--- a/tests/unit/compact-retry-codex.test.ts
+++ b/tests/unit/compact-retry-codex.test.ts
@@ -1,0 +1,159 @@
+// ABOUTME: Regression tests for #1757 — compactAndRetry must trust the new
+// ABOUTME: sessionId returned by compactAgentConversation, dispatch the retry
+// ABOUTME: prompt exactly once, and never search state.sessions for it.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+function functionBody(anchor: string): string {
+  const start = agentStoreSource.indexOf(anchor);
+  if (start < 0) {
+    throw new Error(`anchor not found in agent.store.ts: ${anchor}`);
+  }
+  const end = agentStoreSource.indexOf("\n  },", start);
+  if (end < 0) {
+    throw new Error(`could not find function end for: ${anchor}`);
+  }
+  return agentStoreSource.slice(start, end);
+}
+
+describe("#1757 — compactAgentConversation returns the new sessionId", () => {
+  it("declares the CompactAgentResult shape with newSessionId on the type", () => {
+    expect(agentStoreSource).toMatch(
+      /type CompactAgentResult\s*=\s*\{[\s\S]*?outcome:\s*Exclude<CompactionOutcome,\s*"retried">[\s\S]*?newSessionId\?:\s*string[\s\S]*?\}/,
+    );
+  });
+
+  it("compactAgentConversation's return type is CompactAgentResult", () => {
+    expect(agentStoreSource).toMatch(
+      /async compactAgentConversation\([\s\S]*?\):\s*Promise<CompactAgentResult>/,
+    );
+  });
+
+  it("reactive success returns { outcome: 'succeeded', newSessionId }", () => {
+    const body = functionBody("async compactAgentConversation(");
+    // Reactive path's success return — newSessionId is the local const from
+    // the post-terminate spawn at this site.
+    expect(body).toMatch(
+      /return\s*\{\s*outcome:\s*"succeeded",\s*newSessionId\s*\}/,
+    );
+  });
+
+  it("predictive standby success returns { outcome: 'succeeded', newSessionId: standbyId }", () => {
+    const body = functionBody("async compactAgentConversation(");
+    expect(body).toMatch(
+      /return\s*\{\s*outcome:\s*"succeeded",\s*newSessionId:\s*standbyId\s*\}/,
+    );
+  });
+
+  it("synthetic-transcript success returns { outcome: 'succeeded', newSessionId: syntheticStandbyId }", () => {
+    const body = functionBody("async compactAgentConversation(");
+    expect(body).toMatch(
+      /return\s*\{\s*outcome:\s*"succeeded",\s*newSessionId:\s*syntheticStandbyId\s*\}/,
+    );
+  });
+});
+
+describe("#1757 — compactAndRetry no longer searches state.sessions for the new id", () => {
+  it("does not iterate state.sessions to re-derive the new sessionId", () => {
+    const body = functionBody("async compactAndRetry(");
+    // The brittle lookup is gone — we trust what compactAgentConversation
+    // returned. This guards against the reintroduction of the bug.
+    expect(body).not.toContain("Object.entries(state.sessions)");
+    expect(body).not.toMatch(/state\.sessions\[[\s\S]*?conversationId/);
+  });
+
+  it("does not run a 'newSessionId === sessionId' swap-check", () => {
+    const body = functionBody("async compactAndRetry(");
+    // For Codex, sessionId === conversationId always, and the reactive spawn
+    // passes localSessionId: conversationId — so the new id is bit-identical
+    // to the old. The old swap-check false-failed and dropped users into Chat
+    // (with a misleading reason=rate_limit) AFTER a successful compaction.
+    expect(body).not.toMatch(/newSessionId\s*===\s*sessionId/);
+    expect(body).not.toContain("compaction did not swap");
+  });
+
+  it("reads newSessionId off the returned result, not a state lookup", () => {
+    const body = functionBody("async compactAndRetry(");
+    expect(body).toMatch(/const\s+newSessionId\s*=\s*result\.newSessionId/);
+  });
+});
+
+describe("#1757 — retry prompt is dispatched exactly once, by compactAndRetry", () => {
+  it("compactAgentConversation does NOT call sendPrompt for any pendingUserPrompt", () => {
+    // Pre-fix, compactAgentConversation called sendPrompt for the user's
+    // failed prompt internally AND compactAndRetry called sendPrompt again
+    // after its lookup succeeded — a latent double-dispatch on the path
+    // where the swap-check passed (Claude Code). The fix moves dispatch out
+    // of compactAgentConversation entirely; the helper sends only the seed.
+    const body = functionBody("async compactAgentConversation(");
+    // Assert: the only sendPrompt call references the seedPrompt local.
+    const sendPromptCalls = body.match(
+      /providerService\.sendPrompt\([^)]*\)/g,
+    );
+    expect(sendPromptCalls, "compactAgentConversation must call sendPrompt").toBeTruthy();
+    for (const call of sendPromptCalls ?? []) {
+      expect(
+        call,
+        "compactAgentConversation must only sendPrompt the seedPrompt — the retry belongs to compactAndRetry",
+      ).toContain("seedPrompt");
+    }
+    // Belt-and-braces: pendingUserPrompt and lastUserPrompt arguments must
+    // never appear on a sendPrompt inside this function.
+    expect(body).not.toMatch(
+      /providerService\.sendPrompt\([^)]*pendingUserPrompt/,
+    );
+    expect(body).not.toMatch(
+      /providerService\.sendPrompt\([^)]*lastUserPrompt/,
+    );
+  });
+
+  it("compactAndRetry invokes sendPrompt for lastPrompt exactly once", () => {
+    const body = functionBody("async compactAndRetry(");
+    const calls = body.match(
+      /providerService\.sendPrompt\([^)]*lastPrompt[^)]*\)/g,
+    );
+    expect(calls, "compactAndRetry must dispatch the retry prompt").toBeTruthy();
+    expect(
+      calls?.length,
+      "exactly one retry dispatch — anything else risks duplicate user turns",
+    ).toBe(1);
+  });
+
+  it("compactAndRetry passes only sessionId and preserveCount to compactAgentConversation", () => {
+    const body = functionBody("async compactAndRetry(");
+    // The helper's signature is now (sessionId, preserveCount, opts?). We
+    // call it with two positional args and no opts — reactive default mode.
+    expect(body).toMatch(
+      /this\.compactAgentConversation\(\s*sessionId,\s*settingsStore\.settings\.autoCompactPreserveMessages,?\s*\)/,
+    );
+  });
+});
+
+describe("#1757 — kickPredictiveCompact consumes the new result shape", () => {
+  it("destructures result.outcome from compactAgentConversation's return", () => {
+    const body = functionBody("async kickPredictiveCompact(");
+    expect(body).toMatch(
+      /const\s+result\s*=\s*await\s+this\.compactAgentConversation\(/,
+    );
+    expect(body).toContain("result.outcome");
+  });
+
+  it("does not pass a positional retry-prompt sentinel", () => {
+    const body = functionBody("async kickPredictiveCompact(");
+    // Old shape was (sessionId, count, undefined, { mode: "predictive" }).
+    // New shape collapses the param: (sessionId, count, { mode: "predictive" }).
+    expect(body).not.toMatch(
+      /this\.compactAgentConversation\([\s\S]*?undefined,[\s\S]*?\{ mode: "predictive" \}/,
+    );
+    expect(body).toMatch(
+      /this\.compactAgentConversation\([\s\S]*?\{ mode: "predictive" \}/,
+    );
+  });
+});

--- a/tests/unit/compaction-predictive-soft-fail.test.ts
+++ b/tests/unit/compaction-predictive-soft-fail.test.ts
@@ -41,10 +41,12 @@ describe("#152 — predictive standby spawn null is non-catastrophic", () => {
       predictiveIdx,
     );
     // The block after the null check should warn, not error, and must return
-    // an outcome (not throw).
-    const block = compactBody.slice(nullCheckIdx, nullCheckIdx + 600);
+    // an outcome (not throw). Post-#1757 the return is a structured object.
+    const block = compactBody.slice(nullCheckIdx, nullCheckIdx + 800);
     expect(block).toMatch(/console\.warn\(/);
-    expect(block).toContain('return "failed_catastrophic"');
+    expect(block).toMatch(
+      /return\s*\{\s*outcome:\s*"failed_catastrophic"\s*\}/,
+    );
   });
 
   it("catch block treats predictive mode as non-fatal", () => {

--- a/tests/unit/compaction-queue-race.test.ts
+++ b/tests/unit/compaction-queue-race.test.ts
@@ -47,14 +47,18 @@ describe("#1623 — compactAgentConversation transfers pendingPrompts to new ses
     );
   });
 
-  it("takes an explicit pendingUserPrompt parameter (not session.lastUserPrompt)", () => {
-    // The old code read session.lastUserPrompt inline, which retried
-    // whatever the last sendPrompt set — in the auto-compact path that was
-    // the just-completed prompt, causing a duplicate turn. An explicit param
-    // lets callers distinguish "failed in-flight prompt" (compactAndRetry)
-    // from "prompt completed successfully" (auto-compact from promptComplete).
-    expect(agentStoreSource).toContain("pendingUserPrompt?: string,");
-    // The inline read must be gone.
+  it("compactAgentConversation does not accept a retry-prompt parameter (#1757)", () => {
+    // Post-#1757, retry dispatch is the caller's responsibility.
+    // compactAgentConversation produces a fresh, idle, seeded session and
+    // returns its id; nothing more. Reintroducing a pendingUserPrompt-style
+    // param would re-open the double-dispatch latent in the old design
+    // (Codex short-circuited via the swap-check; Claude Code double-sent).
+    const fnStart = agentStoreSource.indexOf("async compactAgentConversation(");
+    expect(fnStart, "compactAgentConversation must exist").toBeGreaterThan(0);
+    const sigEnd = agentStoreSource.indexOf("): Promise<", fnStart);
+    const signature = agentStoreSource.slice(fnStart, sigEnd);
+    expect(signature).not.toMatch(/pendingUserPrompt/);
+    // The inline read must also be gone.
     expect(agentStoreSource).not.toContain(
       "const pendingUserPrompt = session.lastUserPrompt;",
     );
@@ -64,12 +68,12 @@ describe("#1623 — compactAgentConversation transfers pendingPrompts to new ses
     // The prompt that produced this promptComplete already succeeded — we
     // MUST NOT retry it or the user sees a duplicate turn.
     //
-    // Post-#1716, the auto-compact branch routes through
+    // Post-#1716 the auto-compact branch routes through
     // `this.kickPredictiveCompact(sessionId)` rather than calling
-    // `compactAgentConversation` directly. `kickPredictiveCompact` does
-    // not accept a pendingUserPrompt param, and its internal compact call
-    // hardcodes `undefined` — so the no-retry contract still holds, just
-    // one indirection deeper.
+    // `compactAgentConversation` directly. Post-#1757 compactAgentConversation
+    // never retries at all — there is no retry-prompt param to forward — so
+    // the no-retry contract is now structural, not a question of which
+    // sentinel value gets passed.
     const autoCompactAnchor = "Auto-compact check runs BEFORE drain (#1623)";
     const drainAnchor = "Drain the prompt queue for this session";
     const autoCompactIdx = agentStoreSource.indexOf(autoCompactAnchor);
@@ -81,21 +85,25 @@ describe("#1623 — compactAgentConversation transfers pendingPrompts to new ses
     expect(autoCompactBlock).not.toMatch(
       /kickPredictiveCompact\(sessionId,\s*[^)]/,
     );
-
-    // kickPredictiveCompact's internal compactAgentConversation call must
-    // still pass undefined for pendingUserPrompt.
-    const kickStart = agentStoreSource.indexOf("async kickPredictiveCompact(");
-    const kickEnd = agentStoreSource.indexOf("\n  },", kickStart);
-    const kickBody = agentStoreSource.slice(kickStart, kickEnd);
-    expect(kickBody).toMatch(
-      /this\.compactAgentConversation\([\s\S]*?undefined,[\s\S]*?\{ mode: "predictive" \}/,
-    );
   });
 
-  it("compactAndRetry passes lastPrompt for pendingUserPrompt", () => {
-    // The failed-prompt retry path must still work — it IS a real retry.
-    expect(agentStoreSource).toContain(
-      "settingsStore.settings.autoCompactPreserveMessages,\n        lastPrompt,",
+  it("compactAndRetry retries the failed prompt itself, after compactAgentConversation returns (#1757)", () => {
+    // The failed-prompt retry path must still work — it IS a real retry —
+    // but the dispatch lives in compactAndRetry, not compactAgentConversation.
+    // Single responsibility per function, no double-dispatch.
+    const fnStart = agentStoreSource.indexOf("async compactAndRetry(");
+    expect(fnStart, "compactAndRetry must exist").toBeGreaterThan(0);
+    const fnEnd = agentStoreSource.indexOf("\n  },", fnStart);
+    const fnBody = agentStoreSource.slice(fnStart, fnEnd);
+
+    // The retry sendPrompt is in compactAndRetry's body, gated on lastPrompt.
+    expect(fnBody).toMatch(
+      /if \(lastPrompt\) \{[\s\S]*?providerService\.sendPrompt\(newSessionId,\s*lastPrompt\)/,
+    );
+    // And compactAndRetry's compactAgentConversation call passes neither
+    // a retry prompt nor a positional sentinel for one.
+    expect(fnBody).not.toMatch(
+      /this\.compactAgentConversation\(\s*sessionId,\s*[^,]+,\s*lastPrompt/,
     );
   });
 });

--- a/tests/unit/predictive-drain-not-blocked.test.ts
+++ b/tests/unit/predictive-drain-not-blocked.test.ts
@@ -54,9 +54,11 @@ describe("#1673 — predictive compaction does not block drain", () => {
     const branchStart = agentStoreSource.indexOf('if (mode === "predictive")');
     expect(branchStart).toBeGreaterThan(0);
     // Reactive branch follows immediately after the predictive block returns;
-    // capture the predictive body up to its `return "succeeded";`.
+    // capture the predictive body up to its terminal "succeeded" return.
+    // Post-#1757 returns the structured result shape so we anchor on the
+    // standby-id field that the predictive path always carries.
     const branchEnd = agentStoreSource.indexOf(
-      'return "succeeded";',
+      'newSessionId: standbyId',
       branchStart,
     );
     expect(branchEnd).toBeGreaterThan(branchStart);


### PR DESCRIPTION
## Summary
- Closes #1757. `compactAgentConversation` now returns `{ outcome, newSessionId? }` so `compactAndRetry` stops re-deriving the new session id via `Object.entries(state.sessions).find(...)`. The brittle swap-check (`newSessionId === sessionId`) is gone — for Codex, `sessionId === conversationId` and the reactive spawn passes `localSessionId: conversationId`, so the new id was bit-identical to the old and the check false-failed after a clean compaction (user got dropped into Chat with a misleading `reason=rate_limit`).
- Same change also closes a latent double-dispatch for Claude Code. `compactAgentConversation` previously called `sendPrompt(newSessionId, pendingUserPrompt)` internally and `compactAndRetry` called `sendPrompt(newSessionId, lastPrompt)` again after its lookup. The Codex bug masked it because the swap-check short-circuited first. Retry dispatch now lives in exactly one place.
- `kickPredictiveCompact` no longer passes the now-defunct `pendingUserPrompt` sentinel positional arg. The synthetic-transcript and predictive-standby success paths return their respective ids; reactive success returns the newly-spawned id.

## Test plan
- [x] `npx vitest run` — 701 passed, 0 failed (93 files)
- [x] `npx tsc --noEmit` — only pre-existing errors in `cli-updater.test.ts` and `updater-store.test.ts` (unrelated, present on `main`)
- [x] `biome check src/stores/agent.store.ts` — no fixes
- [x] New regression test `tests/unit/compact-retry-codex.test.ts` asserts the structural invariants of the fix:
  - `compactAgentConversation`'s return type is `Promise<CompactAgentResult>`
  - reactive/predictive/synthetic paths each return `newSessionId`
  - `compactAndRetry` does not iterate `state.sessions`, has no swap-check, reads `result.newSessionId` directly, and dispatches the retry exactly once
  - `kickPredictiveCompact` consumes `result.outcome` and no longer passes the sentinel positional arg
- [x] Updated existing tests (`compaction-queue-race.test.ts`, `auto-compact-predictive.test.ts`, `compaction-predictive-soft-fail.test.ts`, `predictive-drain-not-blocked.test.ts`) for the new return shape

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
