### PR TITLE
fix(provider): close #1758 by forwarding Codex modelContextWindow so predictive compaction fires before context exhaustion

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -487,18 +487,27 @@ function emitToolResult(emit, session, item) {
   session.toolOutputs.delete(toolCallId);
 }
 
-function normalizeTurnUsage(tokenUsage) {
+export function normalizeTurnUsage(tokenUsage) {
   const last = tokenUsage?.last ?? tokenUsage?.total ?? null;
   if (!last) {
     return undefined;
   }
 
-  return {
+  const meta = {
     usage: {
       input_tokens: last.inputTokens,
       output_tokens: last.outputTokens,
     },
   };
+
+  if (
+    typeof tokenUsage?.modelContextWindow === "number" &&
+    tokenUsage.modelContextWindow > 0
+  ) {
+    meta.contextWindow = tokenUsage.modelContextWindow;
+  }
+
+  return meta;
 }
 
 function buildApprovalToolCall(method, params) {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -190,7 +190,7 @@ const CLAUDE_1M_MODELS = new Set([
 ]);
 
 function defaultContextWindowFor(agentType: string, modelId?: string): number {
-  if (agentType === "codex") return 400_000;
+  if (agentType === "codex") return 1_000_000;
   if (agentType === "gemini") return 1_000_000;
   if (agentType === "claude-code" && modelId) {
     const normalized = modelId.replace(/\[1m\]$/i, "");

--- a/tests/unit/codex-token-usage-meta.test.ts
+++ b/tests/unit/codex-token-usage-meta.test.ts
@@ -1,0 +1,87 @@
+// ABOUTME: Critical test for #1758 — normalizeTurnUsage forwards modelContextWindow.
+// ABOUTME: Without this, predictive compaction never fires for Codex sessions.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/providers.mjs",
+  import.meta.url,
+).href;
+const { normalizeTurnUsage } = await import(/* @vite-ignore */ modulePath);
+
+const breakdown = (overrides: Record<string, number> = {}) => ({
+  inputTokens: 15670,
+  cachedInputTokens: 6528,
+  outputTokens: 21,
+  reasoningOutputTokens: 14,
+  totalTokens: 15691,
+  ...overrides,
+});
+
+describe("normalizeTurnUsage", () => {
+  it("forwards modelContextWindow as meta.contextWindow when CLI reports it", () => {
+    const meta = normalizeTurnUsage({
+      last: breakdown(),
+      total: breakdown(),
+      modelContextWindow: 258_400,
+    });
+    expect(meta).toEqual({
+      usage: { input_tokens: 15670, output_tokens: 21 },
+      contextWindow: 258_400,
+    });
+  });
+
+  it("omits contextWindow when modelContextWindow is null", () => {
+    const meta = normalizeTurnUsage({
+      last: breakdown(),
+      total: breakdown(),
+      modelContextWindow: null,
+    });
+    expect(meta).toEqual({
+      usage: { input_tokens: 15670, output_tokens: 21 },
+    });
+    expect(meta.contextWindow).toBeUndefined();
+  });
+
+  it("omits contextWindow when modelContextWindow is missing", () => {
+    const meta = normalizeTurnUsage({
+      last: breakdown(),
+      total: breakdown(),
+    });
+    expect(meta.contextWindow).toBeUndefined();
+  });
+
+  it("rejects zero or negative modelContextWindow as invalid signal", () => {
+    expect(
+      normalizeTurnUsage({
+        last: breakdown(),
+        total: breakdown(),
+        modelContextWindow: 0,
+      }).contextWindow,
+    ).toBeUndefined();
+    expect(
+      normalizeTurnUsage({
+        last: breakdown(),
+        total: breakdown(),
+        modelContextWindow: -1,
+      }).contextWindow,
+    ).toBeUndefined();
+  });
+
+  it("falls back to total when last is missing", () => {
+    const meta = normalizeTurnUsage({
+      total: breakdown({ inputTokens: 999, outputTokens: 11 }),
+      modelContextWindow: 258_400,
+    });
+    expect(meta).toEqual({
+      usage: { input_tokens: 999, output_tokens: 11 },
+      contextWindow: 258_400,
+    });
+  });
+
+  it("returns undefined when both last and total are missing", () => {
+    expect(normalizeTurnUsage({ modelContextWindow: 258_400 })).toBeUndefined();
+    expect(normalizeTurnUsage(undefined)).toBeUndefined();
+    expect(normalizeTurnUsage(null)).toBeUndefined();
+  });
+});

--- a/tests/unit/predictive-compact-race.test.ts
+++ b/tests/unit/predictive-compact-race.test.ts
@@ -139,7 +139,6 @@ describe("#1749 — defaultContextWindowFor recognises 1M Claude variants at spa
 
     // Codex / Gemini cases must still return their existing defaults.
     expect(helperBody).toContain('agentType === "codex"');
-    expect(helperBody).toContain("400_000");
     expect(helperBody).toContain('agentType === "gemini"');
     expect(helperBody).toContain("1_000_000");
 


### PR DESCRIPTION
## Summary

- Forwards `tokenUsage.modelContextWindow` from the upstream Codex `thread/tokenUsage/updated` notification through `bin/browser-local/providers.mjs` to `meta.contextWindow` on `prompt-complete`. The desktop's store consumer at `src/stores/agent.store.ts:4458-4483` was already wired to use it; only the bridge field was missing.
- Bumps the Codex cold-start default from `400_000` to `1_000_000` in `defaultContextWindowFor`. This default only matters before the CLI's first `meta.contextWindow` upserts.
- Closes #1758.

## Why

Long Codex sessions hit a visible model-side error before the desktop's predictive compaction could swap a fresh session in. The 70% predictive trigger never fired because `lastInputTokens` and `contextWindowSize` never got real values. Same desktop, Claude Code path, predictive standby fires invisibly at 73% — the only thing missing was the bridge surfacing the data.

## Pre-flight verification

Before patching, I spawned `codex app-server` directly with a minimal JSON-RPC harness and captured a real `thread/tokenUsage/updated` payload to confirm upstream emits the field. Result for `gpt-5.5`:

```json
{
  "tokenUsage": {
    "last": { "inputTokens": 15670, "outputTokens": 21, ... },
    "total": { ... },
    "modelContextWindow": 258400
  }
}
```

So the field is reliably populated. Note: live model reports 258K, not 1M — the cold-start default of 1M is generous, but it gets overridden by the CLI on turn 1 anyway, so it only affects pre-first-turn-completion behavior.

## Test plan

- [x] `pnpm vitest run tests/unit/codex-token-usage-meta.test.ts` — new tests, 6/6 pass
- [x] `pnpm vitest run tests/unit/predictive-compact-race.test.ts` — updated (dropped stale `400_000` source-text assertion)
- [x] `pnpm test` — full unit suite, 694/694 pass
- [x] `pnpm check bin/browser-local/providers.mjs src/stores/agent.store.ts tests/unit/codex-token-usage-meta.test.ts` — clean

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
