### PR TITLE
fix(provider): close #1761 by routing 1M-tier picker entries through [1m] suffix

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -438,10 +438,51 @@ const LEGACY_OPUS_RECORDS = [
   },
 ];
 
+// 1M-tier picker entries. Anthropic gates the 1M tier on a `[1m]` suffix in
+// the model id; without the suffix, the API serves the 200K tier. Surfacing
+// these as distinct picker entries lets the user opt into the wider window
+// per-session — selecting one routes the suffixed id straight through the
+// CLI's set_model control, which forwards it to the API and triggers the
+// `context-1m-2025-08-07` beta header. #1761.
+function makeOneMTierRecord(baseId, displayBase) {
+  return {
+    modelId: `${baseId}[1m]`,
+    name: `${displayBase} (1M context)`,
+    description: `${displayBase} on the 1M-token context tier`,
+    supportsEffort: false,
+    supportedEffortLevels: [],
+    isDefault: false,
+  };
+}
+
+const ONE_M_TIER_RECORDS = [
+  makeOneMTierRecord("claude-opus-4-7", "Opus 4.7"),
+  makeOneMTierRecord("claude-opus-4-6", "Opus 4.6"),
+  makeOneMTierRecord("claude-opus-4-5", "Opus 4.5"),
+  makeOneMTierRecord("claude-sonnet-4-7", "Sonnet 4.7"),
+  makeOneMTierRecord("claude-sonnet-4-6", "Sonnet 4.6"),
+  makeOneMTierRecord("claude-sonnet-4-5", "Sonnet 4.5"),
+];
+
 function augmentWithLegacyOpus(records) {
   const existingIds = new Set(records.map((r) => r.modelId));
-  const extras = LEGACY_OPUS_RECORDS.filter((r) => !existingIds.has(r.modelId));
-  return [...extras, ...records];
+  const legacyExtras = LEGACY_OPUS_RECORDS.filter(
+    (r) => !existingIds.has(r.modelId),
+  );
+  // 1M-tier entries are prepended only when the bare base id is reported by
+  // the CLI catalog OR the legacy fallback brought it in. That keeps the
+  // picker honest — we don't advertise a 1M variant of a model the active
+  // CLI doesn't ship.
+  const knownBareIds = new Set([
+    ...records.map((r) => r.modelId),
+    ...legacyExtras.map((r) => r.modelId),
+  ]);
+  const oneMExtras = ONE_M_TIER_RECORDS.filter(
+    (r) =>
+      !existingIds.has(r.modelId) &&
+      knownBareIds.has(r.modelId.replace(/\[1m\]$/i, "")),
+  );
+  return [...oneMExtras, ...legacyExtras, ...records];
 }
 
 function combinePrompt(prompt, context) {
@@ -687,25 +728,31 @@ function buildClaudeArgs({
   return args;
 }
 
-// Mirror of CLAUDE_1M_MODELS in src/stores/agent.store.ts. The CLI does not
-// always populate result.modelUsage[*].contextWindow (single-turn shortcuts,
-// abort paths, single-message --output-format runs), so the runtime needs
-// its own derivation table to keep `meta.contextWindow` reliable on every
-// prompt-complete. Without this, the desktop's auto-compaction gauge stays
-// pinned to the cold-start default (200K) and trips premature compaction on
-// 1M-tier sessions. #1754.
-const CLAUDE_1M_MODELS = new Set([
-  "claude-opus-4-7",
+// Mirror of CLAUDE_1M_TIER_CAPABLE_MODELS in src/stores/agent.store.ts. Set
+// membership identifies the bare model IDs whose `[1m]` suffix variant is
+// served on the 1M tier; the bare ID itself defaults to 200K. Anthropic gates
+// the 1M tier on the `[1m]` suffix in the model id (CLI sends the
+// `context-1m-2025-08-07` beta header, API returns `contextWindow: 1000000`).
+// Without the suffix, every Opus/Sonnet bare-id request lands on 200K. #1761.
+const CLAUDE_1M_TIER_CAPABLE_MODELS = new Set([
+  "claude-opus-4-5",
   "claude-opus-4-6",
-  "claude-sonnet-4-7",
+  "claude-opus-4-7",
+  "claude-sonnet-4-5",
   "claude-sonnet-4-6",
+  "claude-sonnet-4-7",
 ]);
 
 function inferClaudeContextWindow(modelId) {
   if (typeof modelId !== "string" || modelId.length === 0) return undefined;
-  if (/\[1m\]$/i.test(modelId)) return 1_000_000;
-  const normalized = modelId.replace(/\[1m\]$/i, "");
-  if (CLAUDE_1M_MODELS.has(normalized)) return 1_000_000;
+  // CLI keys modelUsage by the resolved API id, sometimes with a date suffix
+  // like "claude-opus-4-7-20251201". Strip date and `[1m]` so the lookup
+  // matches the canonical bare id.
+  const stripped = modelId.replace(/\[1m\]$/i, "");
+  const normalized = stripped.replace(/-\d{8}$/, "");
+  if (/\[1m\]$/i.test(modelId)) {
+    return CLAUDE_1M_TIER_CAPABLE_MODELS.has(normalized) ? 1_000_000 : undefined;
+  }
   if (normalized.startsWith("claude-")) return 200_000;
   return undefined;
 }
@@ -2099,3 +2146,11 @@ export function createClaudeRuntime({ emit }) {
     buildSyntheticTranscript,
   };
 }
+
+// Test-only re-exports — internal helpers exposed for unit tests so the
+// 1M-tier semantics can be exercised without spinning up a full session.
+export {
+  inferClaudeContextWindow as _inferClaudeContextWindow,
+  augmentWithLegacyOpus as _augmentWithLegacyOpus,
+  ONE_M_TIER_RECORDS as _ONE_M_TIER_RECORDS,
+};

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -30,6 +30,33 @@ const NPM_INSTALL_TIMEOUT_MS = 180_000;
 const SEMVER_EXACT_RE = /^(\d+)\.(\d+)\.(\d+)$/;
 const SEMVER_EXTRACT_RE = /\d+\.\d+\.\d+[^\s]*/;
 
+/**
+ * Per-package minimum required version. When the resolved binary is below
+ * the baseline we ignore the 24h TTL and force an update on the next launch.
+ * This unsticks installs that were poisoned by an old `cli-tools/package.json`
+ * caret pin (e.g. `^2.1.30`) or by a transient registry failure that the TTL
+ * then masked for months. Bumped together with #1761 so users gain access to
+ * the JS→native migration boundary at 2.1.120 and the Opus 4.7 catalog. */
+export const CLI_MIN_VERSION_BASELINE = {
+  "@anthropic-ai/claude-code": "2.1.120",
+};
+
+/** Returns true when `installed` is a clean semver below `baseline`. */
+export function isBelowBaseline(installed, baseline) {
+  if (typeof installed !== "string" || typeof baseline !== "string") {
+    return false;
+  }
+  const a = installed.match(SEMVER_EXACT_RE);
+  const b = baseline.match(SEMVER_EXACT_RE);
+  if (!a || !b) return false;
+  for (let i = 1; i <= 3; i++) {
+    const ai = Number(a[i]);
+    const bi = Number(b[i]);
+    if (ai !== bi) return ai < bi;
+  }
+  return false;
+}
+
 function serenDataDir() {
   if (process.platform === "win32") {
     const base = process.env.APPDATA ?? os.homedir();
@@ -414,9 +441,6 @@ export async function backgroundUpdateCli({
     const persisted = state ?? loadState();
     const key = `lastUpdateCheck:${bareCommand}`;
     const lastCheck = persisted[key];
-    if (typeof lastCheck === "number" && now - lastCheck < UPDATE_CHECK_TTL_MS) {
-      return report("skipped:ttl");
-    }
 
     const channel = classifyInstallChannel(resolvedPath, bareCommand);
     if (channel === "unresolved") {
@@ -425,10 +449,22 @@ export async function backgroundUpdateCli({
       return report("skipped:unresolved");
     }
 
-    const [installed, latest] = await Promise.all([
-      installedVersionFn(resolvedPath, bareCommand),
-      npmViewFn(packageName, { npmCliScript }),
-    ]);
+    // Read installed version up-front so the baseline gate can override TTL.
+    // The npm view is still deferred until we decide whether to run.
+    const installed = await installedVersionFn(resolvedPath, bareCommand);
+    const baseline = CLI_MIN_VERSION_BASELINE[packageName];
+    const belowBaseline =
+      typeof baseline === "string" && isBelowBaseline(installed, baseline);
+
+    if (
+      !belowBaseline &&
+      typeof lastCheck === "number" &&
+      now - lastCheck < UPDATE_CHECK_TTL_MS
+    ) {
+      return report("skipped:ttl");
+    }
+
+    const latest = await npmViewFn(packageName, { npmCliScript });
 
     // Record the check timestamp even when we couldn't compare — offline
     // and rate-limited cases should not retry every launch.

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -194,25 +194,27 @@ async function waitForStandbySeed(
   return state.sessions[standbyId]?.seedCompleted === true;
 }
 
-/** Claude Code model IDs that ship with a 1M-token context tier. The CLI
- * advertises the variant either as a bracketed suffix (`claude-opus-4-7[1m]`)
- * or as the bare ID once the tier has been negotiated; both forms hit this
- * helper. The first promptComplete still upserts the CLI-reported window via
- * recordModelContextWindow, so this is just the cold-start default. #1749. */
-const CLAUDE_1M_MODELS = new Set([
-  "claude-opus-4-7",
+/** Claude Code model IDs that ship a 1M-token context tier behind the
+ * `[1m]` suffix. Bare IDs default to 200K — Anthropic gates the 1M tier on
+ * the suffix, which the CLI translates into a `context-1m-2025-08-07` beta
+ * header. The first promptComplete still upserts the CLI-reported window via
+ * recordModelContextWindow, so this is just the cold-start default. #1761. */
+const CLAUDE_1M_TIER_CAPABLE_MODELS = new Set([
+  "claude-opus-4-5",
   "claude-opus-4-6",
-  "claude-sonnet-4-7",
+  "claude-opus-4-7",
+  "claude-sonnet-4-5",
   "claude-sonnet-4-6",
+  "claude-sonnet-4-7",
 ]);
 
 function defaultContextWindowFor(agentType: string, modelId?: string): number {
   if (agentType === "codex") return 1_000_000;
   if (agentType === "gemini") return 1_000_000;
   if (agentType === "claude-code" && modelId) {
-    const normalized = modelId.replace(/\[1m\]$/i, "");
-    if (CLAUDE_1M_MODELS.has(normalized) || /\[1m\]$/i.test(modelId)) {
-      return 1_000_000;
+    if (/\[1m\]$/i.test(modelId)) {
+      const stripped = modelId.replace(/\[1m\]$/i, "").replace(/-\d{8}$/, "");
+      if (CLAUDE_1M_TIER_CAPABLE_MODELS.has(stripped)) return 1_000_000;
     }
   }
   return 200_000;
@@ -617,6 +619,10 @@ export interface ActiveSession {
   predictiveCompactInFlight?: boolean;
   /** Sibling standby session id while predictive compaction is warming. */
   standbySessionId?: string | null;
+  /** True once a tier-promise drift has been captured to the support
+   *  pipeline, so the same session doesn't spam captureSupportError on every
+   *  promptComplete. #1761. */
+  contextWindowMismatchReported?: boolean;
 }
 
 // ============================================================================
@@ -4443,6 +4449,39 @@ Structured summary:`;
             typeof reportedContextWindow === "number" &&
             reportedContextWindow > 0
           ) {
+            // Surface tier-promise drift to the support pipeline. If the
+            // picker entry's id ends in `[1m]` but the runtime reported a
+            // window below 1M, the request never opted into the 1M tier
+            // upstream and the gauge will lie about every subsequent turn.
+            // Capture once per session so we get a regression signal without
+            // spamming. #1761.
+            const sess = state.sessions[sessionId];
+            const expectedFromPicker = defaultContextWindowFor(
+              sess?.info?.agentType ?? "",
+              sess?.currentModelId,
+            );
+            if (
+              !sess?.contextWindowMismatchReported &&
+              expectedFromPicker > reportedContextWindow &&
+              /\[1m\]$/i.test(sess?.currentModelId ?? "")
+            ) {
+              setState(
+                "sessions",
+                sessionId,
+                "contextWindowMismatchReported",
+                true,
+              );
+              void captureSupportError({
+                kind: "agent.context_window_tier_mismatch",
+                message: `Picker promised ${expectedFromPicker.toLocaleString()} but CLI reported ${reportedContextWindow.toLocaleString()} for ${sess?.currentModelId}`,
+                stack: [],
+                agentContext: {
+                  model: sess?.currentModelId,
+                  provider: sess?.info?.agentType,
+                  tool_calls: [],
+                },
+              });
+            }
             setState(
               "sessions",
               sessionId,
@@ -4452,7 +4491,6 @@ Structured summary:`;
             // Persist (provider, modelId) -> contextWindow so next spawn of
             // this model starts with the correct value instead of the
             // agent-type default. Fire-and-forget; failures are non-fatal.
-            const sess = state.sessions[sessionId];
             const modelKey = sess?.currentModelId;
             const provider = sess?.info?.agentType;
             if (modelKey && provider) {

--- a/tests/unit/claude-runtime-1m-tier.test.ts
+++ b/tests/unit/claude-runtime-1m-tier.test.ts
@@ -1,0 +1,134 @@
+// ABOUTME: Critical guards for #1761 — Claude Code 1M context tier translation.
+// ABOUTME: Verifies bare IDs default to 200K and only [1m]-suffixed IDs unlock 1M.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const {
+  _inferClaudeContextWindow: inferClaudeContextWindow,
+  _augmentWithLegacyOpus: augmentWithLegacyOpus,
+  _ONE_M_TIER_RECORDS: ONE_M_TIER_RECORDS,
+} = await import(/* @vite-ignore */ modulePath);
+
+describe("inferClaudeContextWindow — tier-aware semantics", () => {
+  it("returns 200K for bare 1M-capable opus IDs (no [1m] suffix)", () => {
+    // Anthropic gates the 1M tier on the [1m] suffix. A bare claude-opus-4-7
+    // request lands on the 200K tier upstream. The desktop's cold-start
+    // default must match that reality so the gauge denominator is honest
+    // when the user picks the bare entry.
+    expect(inferClaudeContextWindow("claude-opus-4-7")).toBe(200_000);
+    expect(inferClaudeContextWindow("claude-opus-4-6")).toBe(200_000);
+    expect(inferClaudeContextWindow("claude-sonnet-4-6")).toBe(200_000);
+  });
+
+  it("returns 1M only for [1m]-suffixed 1M-capable IDs", () => {
+    expect(inferClaudeContextWindow("claude-opus-4-7[1m]")).toBe(1_000_000);
+    expect(inferClaudeContextWindow("claude-opus-4-6[1m]")).toBe(1_000_000);
+    expect(inferClaudeContextWindow("claude-opus-4-5[1m]")).toBe(1_000_000);
+    expect(inferClaudeContextWindow("claude-sonnet-4-7[1m]")).toBe(1_000_000);
+    expect(inferClaudeContextWindow("claude-sonnet-4-6[1m]")).toBe(1_000_000);
+    expect(inferClaudeContextWindow("claude-sonnet-4-5[1m]")).toBe(1_000_000);
+  });
+
+  it("strips Anthropic's date suffix before the 1M-tier lookup", () => {
+    // The CLI keys modelUsage by the resolved API id, which can include a
+    // YYYYMMDD suffix (e.g. claude-opus-4-7-20251201[1m]). The lookup must
+    // canonicalize before comparing against CLAUDE_1M_TIER_CAPABLE_MODELS.
+    expect(inferClaudeContextWindow("claude-opus-4-7-20251201[1m]")).toBe(
+      1_000_000,
+    );
+    expect(inferClaudeContextWindow("claude-opus-4-7-20251201")).toBe(200_000);
+  });
+
+  it("returns undefined for non-Claude or unknown IDs", () => {
+    expect(inferClaudeContextWindow("")).toBeUndefined();
+    expect(inferClaudeContextWindow("gpt-5")).toBeUndefined();
+    expect(inferClaudeContextWindow(undefined)).toBeUndefined();
+    expect(inferClaudeContextWindow(null)).toBeUndefined();
+  });
+});
+
+describe("augmentWithLegacyOpus — picker exposes 1M-tier variants", () => {
+  it("prepends a [1m] entry only when the bare base is in the catalog", () => {
+    // The CLI catalog is the source of truth for which models the user can
+    // actually run. We never advertise a 1M variant of a model the active
+    // CLI doesn't ship — the alternative is a picker entry that produces a
+    // silent API failure when selected.
+    const cliCatalog = [
+      {
+        modelId: "claude-opus-4-7",
+        name: "Opus 4.7",
+        description: "",
+        supportsEffort: false,
+        supportedEffortLevels: [],
+        isDefault: true,
+      },
+      {
+        modelId: "claude-sonnet-4-6",
+        name: "Sonnet 4.6",
+        description: "",
+        supportsEffort: false,
+        supportedEffortLevels: [],
+        isDefault: false,
+      },
+    ];
+
+    const augmented = augmentWithLegacyOpus(cliCatalog);
+    const ids = augmented.map((r: { modelId: string }) => r.modelId);
+
+    expect(ids).toContain("claude-opus-4-7[1m]");
+    expect(ids).toContain("claude-sonnet-4-6[1m]");
+    // claude-sonnet-4-7 is not in the CLI catalog and not in LEGACY_OPUS_RECORDS
+    // → its [1m] variant must NOT appear so we don't make a false promise.
+    expect(ids).not.toContain("claude-sonnet-4-7[1m]");
+  });
+
+  it("does not duplicate [1m] entries the CLI already advertises", () => {
+    const cliCatalog = [
+      {
+        modelId: "claude-opus-4-7",
+        name: "Opus 4.7",
+        description: "",
+        supportsEffort: false,
+        supportedEffortLevels: [],
+        isDefault: true,
+      },
+      {
+        modelId: "claude-opus-4-7[1m]",
+        name: "Opus 4.7 (1M)",
+        description: "",
+        supportsEffort: false,
+        supportedEffortLevels: [],
+        isDefault: false,
+      },
+    ];
+
+    const augmented = augmentWithLegacyOpus(cliCatalog);
+    const oneMCount = augmented.filter(
+      (r: { modelId: string }) => r.modelId === "claude-opus-4-7[1m]",
+    ).length;
+    expect(oneMCount).toBe(1);
+  });
+
+  it("ONE_M_TIER_RECORDS covers the same set as CLAUDE_1M_TIER_CAPABLE_MODELS", () => {
+    // The runtime picker entries and the desktop store's tier table must
+    // agree on which bare IDs unlock 1M. A divergence here means a picker
+    // entry the desktop won't recognize as 1M-capable, or vice versa.
+    const oneMBareIds = [
+      ...(ONE_M_TIER_RECORDS as Array<{ modelId: string }>).map((r) =>
+        r.modelId.replace(/\[1m\]$/i, ""),
+      ),
+    ].sort();
+    expect(oneMBareIds).toEqual([
+      "claude-opus-4-5",
+      "claude-opus-4-6",
+      "claude-opus-4-7",
+      "claude-sonnet-4-5",
+      "claude-sonnet-4-6",
+      "claude-sonnet-4-7",
+    ]);
+  });
+});

--- a/tests/unit/claude-runtime-cleanups.test.ts
+++ b/tests/unit/claude-runtime-cleanups.test.ts
@@ -11,30 +11,34 @@ const claudeRuntime = readFileSync(
 );
 
 describe("#1754 — Claude provider runtime infers contextWindow when CLI omits modelUsage", () => {
-  it("inferClaudeContextWindow exists and enumerates known 1M-tier Claude IDs", () => {
-    // The 1M Claude variants must be enumerated here so a fresh session on
-    // claude-opus-4-7 reports its real window even when the CLI's result
-    // event has empty modelUsage. The set must mirror CLAUDE_1M_MODELS in
-    // src/stores/agent.store.ts so the runtime and the store agree on
-    // cold-start defaults.
+  it("inferClaudeContextWindow exists and enumerates 1M-tier-capable Claude IDs", () => {
+    // The 1M-tier-capable bare IDs must be enumerated here so a fresh
+    // session on claude-opus-4-7[1m] reports its real window even when the
+    // CLI's result event has empty modelUsage. The set must mirror
+    // CLAUDE_1M_TIER_CAPABLE_MODELS in src/stores/agent.store.ts so the
+    // runtime and the store agree on cold-start defaults. #1761.
     expect(claudeRuntime).toContain("function inferClaudeContextWindow(");
     expect(claudeRuntime).toContain('"claude-opus-4-7"');
     expect(claudeRuntime).toContain('"claude-opus-4-6"');
+    expect(claudeRuntime).toContain('"claude-opus-4-5"');
     expect(claudeRuntime).toContain('"claude-sonnet-4-7"');
     expect(claudeRuntime).toContain('"claude-sonnet-4-6"');
+    expect(claudeRuntime).toContain('"claude-sonnet-4-5"');
   });
 
-  it("inferClaudeContextWindow handles the [1m] suffix variant", () => {
-    // The CLI advertises the 1M tier as a bracketed suffix
-    // (`claude-opus-4-7[1m]`). The helper must accept the suffix form so a
-    // brand-new model that has not yet been added to the explicit set still
-    // reports the right window via the suffix path.
+  it("inferClaudeContextWindow checks for the [1m] suffix and the 1M-tier set", () => {
+    // The 1M tier is gated on the `[1m]` suffix upstream; the helper must
+    // detect the suffix and look the canonical bare id up in the
+    // 1M-tier-capable set. Behavioural assertions live in
+    // claude-runtime-1m-tier.test.ts; this test guards the function's
+    // structural anchors so the regression cannot quietly disappear.
     const fnStart = claudeRuntime.indexOf("function inferClaudeContextWindow(");
     const fnEnd = claudeRuntime.indexOf("\n}\n", fnStart);
     const fnBody = claudeRuntime.slice(fnStart, fnEnd);
     expect(fnBody).toContain("\\[1m\\]");
-    expect(fnBody).toMatch(/return\s+1_000_000/);
-    expect(fnBody).toMatch(/return\s+200_000/);
+    expect(fnBody).toContain("CLAUDE_1M_TIER_CAPABLE_MODELS");
+    expect(fnBody).toContain("1_000_000");
+    expect(fnBody).toContain("200_000");
   });
 
   it("buildPromptMeta takes a fallbackModelId and uses inference when modelUsage lacks contextWindow", () => {

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -1,13 +1,7 @@
 // ABOUTME: Critical tests for #1637 — background CLI updater pure logic.
 // ABOUTME: Guards TTL gate, semver compare, and same-channel classification.
 
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -19,6 +13,8 @@ const modulePath = new URL(
 const {
   UPDATE_CHECK_TTL_MS,
   isNewer,
+  isBelowBaseline,
+  CLI_MIN_VERSION_BASELINE,
   classifyInstallChannel,
   backgroundUpdateCli,
   loadState,
@@ -125,6 +121,80 @@ describe("backgroundUpdateCli TTL gate", () => {
       outcome: "skipped:unresolved",
       skipped: "unresolved",
     });
+  });
+
+  it("ignores the 24h TTL when the installed version is below the package baseline (#1761)", async () => {
+    // Users on stale CLI versions (e.g. 2.1.30 from a poisoned cli-tools
+    // package.json pin) would otherwise stay on the old binary for 24h
+    // every launch. The baseline gate must override TTL so the upgrade
+    // path runs on the very next launch after the desktop ships this fix.
+    // We mock npm view to return null so the install path short-circuits
+    // at `skipped:network` — the assertion is that we got past TTL, not
+    // that we shelled out to the registry.
+    const state = {
+      "lastUpdateCheck:claude": Date.now() - 1000, // well within TTL
+    };
+    const result = await backgroundUpdateCli({
+      label: "Claude Code",
+      bareCommand: "claude",
+      resolvedPath: "/Users/u/.local/bin/claude",
+      packageName: "@anthropic-ai/claude-code",
+      state,
+      now: Date.now(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "2.1.30",
+        runNpmView: async () => null,
+      },
+    });
+    expect(result.skipped).not.toBe("ttl");
+  });
+
+  it("honors TTL when the installed version is at or above the baseline", async () => {
+    const state = {
+      "lastUpdateCheck:claude": Date.now() - 1000,
+    };
+    const result = await backgroundUpdateCli({
+      label: "Claude Code",
+      bareCommand: "claude",
+      resolvedPath: "/Users/u/.local/bin/claude",
+      packageName: "@anthropic-ai/claude-code",
+      state,
+      now: Date.now(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "2.1.123",
+        runNpmView: async () => null,
+      },
+    });
+    expect(result).toMatchObject({ outcome: "skipped:ttl", skipped: "ttl" });
+  });
+});
+
+describe("isBelowBaseline (#1761)", () => {
+  it("returns true when installed is older on any semver component", () => {
+    expect(isBelowBaseline("2.1.30", "2.1.120")).toBe(true);
+    expect(isBelowBaseline("2.0.99", "2.1.0")).toBe(true);
+    expect(isBelowBaseline("1.99.99", "2.0.0")).toBe(true);
+  });
+
+  it("returns false when installed is at or above the baseline", () => {
+    expect(isBelowBaseline("2.1.120", "2.1.120")).toBe(false);
+    expect(isBelowBaseline("2.1.123", "2.1.120")).toBe(false);
+    expect(isBelowBaseline("3.0.0", "2.1.120")).toBe(false);
+  });
+
+  it("returns false on unparseable input — never blocks an update on bad data", () => {
+    expect(isBelowBaseline(null, "2.1.120")).toBe(false);
+    expect(isBelowBaseline("2.1.30-rc.1", "2.1.120")).toBe(false);
+    expect(isBelowBaseline("2.1.30", "")).toBe(false);
+  });
+
+  it("Claude Code baseline is at the JS→native migration boundary", () => {
+    // 2.1.120 is the first native-binary release. Below this, users miss
+    // the Opus 4.7 catalog and the binary structure the install detection
+    // expects. The baseline must not regress without explicit reasoning.
+    expect(CLI_MIN_VERSION_BASELINE["@anthropic-ai/claude-code"]).toBe(
+      "2.1.120",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds 1M-tier picker entries (`claude-opus-4-{5,6,7}[1m]`, `claude-sonnet-4-{5,6,7}[1m]`) so users can opt into the wider window per-session; the suffix routes through the CLI's `set_model` control and triggers the `context-1m-2025-08-07` beta header upstream.
- Bare model IDs now default to 200K — Anthropic gates the 1M tier on the suffix, so `CLAUDE_1M_TIER_CAPABLE_MODELS` and `defaultContextWindowFor` were the source of the lying gauge in the bug report.
- Tier-promise drift guard captures one `captureSupportError` per session when the CLI reports a smaller window than the picker promised, so future regressions surface in the support pipeline instead of silently mis-reading 17%/32% as 83%/162%.
- `cli-updater` baseline bumped to 2.1.120 — the JS-to-native migration boundary that ships Opus 4.7. When installed is below baseline the 24h TTL is ignored so users on stale 2.1.30 do not sit on the wrong CLI for another day.

## Investigation summary

- Verified Anthropic's CLI gates 1M on `[1m]` via the binary's `S47`/`R47` resolver and the `context-1m-2025-08-07` header strings (matched in 2.1.123 native binary).
- Verified the SDK's `result.modelUsage` Zod schema (`b.record(b.string(), {..., contextWindow: b.number(), ...})`) is unchanged across 2.1.30 (JS) and 2.1.123 (native), so no parser changes needed.
- Verified seren-desktop's spawn path (`spawn(claudeBin, claudeArgs)`), install resolver (`resolveInstalledClaudeBinary` for `~/.local/bin/claude`, `~/.claude/bin/claude`, npm-global `<prefix>/bin/claude`, and Windows `claude.cmd` shim), and PATH builder all work cross-platform with the post-migration native binary; tested locally against the user's `~/.local/bin/claude` to 2.1.123 install.

## Test plan

- [x] `pnpm test` — 720 unit tests pass (full suite)
- [x] `pnpm vitest run tests/unit/claude-runtime-1m-tier.test.ts` — 7 critical tests for the tier translation
- [x] `pnpm vitest run tests/unit/cli-updater.test.ts` — TTL gate + new baseline gate (38 tests)
- [x] `pnpm vitest run tests/unit/claude-runtime-cleanups.test.ts` — #1754 regression guards updated to match new shape
- [x] `pnpm tsc --noEmit -p tsconfig.json` — clean for files in scope (`updater-store.test.ts:67` is pre-existing on main, unrelated)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — passes after `pnpm prepare:mcp-servers`
- [ ] Smoke against a 1M-capable session in a real desktop run — recommend a manual verification pass with the picker showing "Opus 4.7 (1M context)" and the gauge reading at the 1M denominator.

Closes #1761.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
