### PR TITLE
fix(agent): close #1765 — treat 'Task cancelled' as graceful in compactAndRetry, not a Chat-fallback trigger

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -130,6 +130,11 @@ function waitForSessionReady(sessionId: string): Promise<void> {
  * - `skipped_nothing_to_compact`: message count is below `preserveCount`;
  *   the session was already too small to compact. Usually means a single
  *   message is gigantic — Chat fallback would not help.
+ * - `cancelled`: a Stop / predictive-promotion teardown / other graceful
+ *   cancel propagated up as "Task cancelled" while compaction or the
+ *   retry was in flight. Not a defect — the error event handler's
+ *   graceful-cancel branch already restores UI state. Chat fallback would
+ *   be wrong, since the user's intent was to stop, not to switch modes.
  * - `failed_catastrophic`: unrecoverable failure (spawn failed, summary API
  *   threw after refresh, agent runtime broken). Chat fallback is correct.
  */
@@ -137,6 +142,7 @@ export type CompactionOutcome =
   | "retried"
   | "succeeded"
   | "skipped_nothing_to_compact"
+  | "cancelled"
   | "failed_catastrophic";
 
 /**
@@ -3279,6 +3285,13 @@ Structured summary:`;
       );
       return "succeeded";
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("Task cancelled")) {
+        console.info(
+          "[AgentStore] compactAndRetry cancelled — Stop / teardown propagated 'Task cancelled' through the retry; not a fallback condition",
+        );
+        return "cancelled";
+      }
       console.error(
         "[AgentStore] compactAndRetry threw — treating as catastrophic:",
         error,


### PR DESCRIPTION
## Summary

- Closes #1765. `compactAndRetry`'s catch block treated every thrown error — including the graceful `Task cancelled` thrown by `providerService.sendPrompt` when Stop / predictive-promotion teardown fires mid-retry — as `failed_catastrophic`, which forced the session through `acceptRateLimitFallback()` into Seren Chat with `reason=prompt_too_long`.
- Adds a `cancelled` variant to `CompactionOutcome` and returns it when the catch block sees "Task cancelled". Both `.then` consumers (error-event path at `agent.store.ts:4807-4828`, streamed-content path at `agent.store.ts:5527-5551`) only act on `failed_catastrophic` / `skipped_nothing_to_compact`, so the new variant falls through to the no-op branch.
- The graceful-cancel branch in the error event handler (`agent.store.ts:4694`) already adds the cancel chat message and resets status to `ready`. No duplicate banner, no UI regression.

## Test plan

- [x] Biome check on `src/stores/agent.store.ts` clean.
- [x] TypeScript typecheck clean for the changed file (the one TS error in `tests/unit/updater-store.test.ts` pre-exists on `main`).
- [ ] Manual: cancel a prompt while compaction-retry is in flight on Codex. Session stays on agent runtime, no `[AgentFallback] Switched to chat: ... reason=prompt_too_long` log line, cancel chat message appears once.

No unit test added — the catch-block change is a string match, and exercising `compactAndRetry` end-to-end requires mocking `providerService.sendPrompt`, the SolidJS state, and `compactAgentConversation`. CLAUDE.md prohibits testing mocked behavior.
