### PR TITLE
fix(agent): seal cache poisoning, queue stranding, and warn-spam in 1M-tier predictive compaction (#1769)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1314,16 +1314,20 @@ function handleAssistantMessage(emit, session, payload) {
       message.model,
       session.availableModelRecords,
     );
-    // Trace resolutions when something actually moves — transitions, picker
-    // disagreements, missing fields — so #1718's diagnostic intent is
-    // preserved. Steady-state no-ops (previous=incoming=resolved) carry no
-    // signal; the Rust stderr bridge wraps every line as log::warn!, so
-    // logging them every turn was spamming the desktop log (#1755).
+    // Trace resolutions when something actually moves — transitions, missing
+    // fields — so #1718's diagnostic intent is preserved. Suppress when the
+    // resolver's output matches the previous session state, regardless of
+    // what `incoming` was: the [1m]-preservation guard (#1763) makes the
+    // Anthropic bare-id echoback (`incoming=claude-opus-4-7`) get rewritten
+    // to the suffixed id on every parent message, so the prior strict
+    // `previous === incoming === resolved` check (#1755) only suppressed the
+    // un-suffixed steady-state and spammed once per turn for every 1M-tier
+    // user. A resolution where session state does not change carries no
+    // signal — the mutation block below is the source of truth for actual
+    // model swaps. #1769.
     const isNoOpResolution =
       previousModelId != null &&
-      message.model != null &&
       nextModelId != null &&
-      previousModelId === message.model &&
       previousModelId === nextModelId;
     if (!isNoOpResolution) {
       console.warn(

--- a/src/services/modelContextCache.ts
+++ b/src/services/modelContextCache.ts
@@ -2,6 +2,20 @@
 // ABOUTME: Lets the spawn-time fallback in agent.store stay correct as new models ship.
 
 import { invoke } from "@tauri-apps/api/core";
+import { captureSupportError } from "@/lib/support/hook";
+
+// Anthropic's 1M tier minimum. Mirrors the [1m] branch of
+// `defaultContextWindowFor` in src/stores/agent.store.ts; inlined here to
+// avoid a circular import (agent.store already imports this module).
+const ONE_M_TIER_MINIMUM = 1_000_000;
+const ONE_M_SUFFIX_RE = /\[1m\]$/i;
+
+// Process-lifetime dedup so a single poisoned upstream report only opens one
+// support ticket per (provider, modelId) pair, even if the same value is
+// re-attempted many times within a session. The in-session alarm at
+// agent.store.ts:4476 handles the per-session signal; this set covers the
+// cross-session leakage that the per-session gate cannot see.
+const alertedTierMismatches = new Set<string>();
 
 export async function getCachedModelContextWindow(
   provider: string,
@@ -25,6 +39,35 @@ export async function recordModelContextWindow(
   contextWindow: number,
 ): Promise<void> {
   if (!Number.isFinite(contextWindow) || contextWindow <= 0) return;
+
+  // The desktop spawns 1M-tier sessions on the [1m] suffix. If the upstream
+  // CLI ever reports a window smaller than 1M for a [1m] model — gateway
+  // downgrade, account tier loss, transient CLI bug — persisting that value
+  // would poison every future session of the same model with the smaller
+  // window, silently collapsing the auto-compact gauge denominator long after
+  // the in-session alarm has been silenced for that session. Refuse the
+  // write and surface the leakage exactly once per (provider, modelId). #1769.
+  if (ONE_M_SUFFIX_RE.test(modelId) && contextWindow < ONE_M_TIER_MINIMUM) {
+    console.warn(
+      `[modelContextCache] refusing to persist ${contextWindow.toLocaleString()} for ${modelId} — [1m] tier minimum is ${ONE_M_TIER_MINIMUM.toLocaleString()}`,
+    );
+    const dedupKey = `${provider}:${modelId}`;
+    if (!alertedTierMismatches.has(dedupKey)) {
+      alertedTierMismatches.add(dedupKey);
+      void captureSupportError({
+        kind: "agent.context_window_tier_mismatch",
+        message: `Refused to persist ${contextWindow.toLocaleString()} context window for [1m]-tier model ${modelId} (provider=${provider})`,
+        stack: [],
+        agentContext: {
+          model: modelId,
+          provider,
+          tool_calls: [],
+        },
+      });
+    }
+    return;
+  }
+
   try {
     await invoke("record_model_context_window", {
       provider,

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3327,6 +3327,7 @@ Structured summary:`;
         );
         predictiveCompactBusy = false;
         setState("sessions", sessionId, "predictiveCompactInFlight", false);
+        this.drainAfterPredictiveAbort(sessionId);
       }
       // On success, the standby's promptComplete handler clears both flags.
     } catch (err) {
@@ -3336,7 +3337,31 @@ Structured summary:`;
       );
       predictiveCompactBusy = false;
       setState("sessions", sessionId, "predictiveCompactInFlight", false);
+      this.drainAfterPredictiveAbort(sessionId);
     }
+  },
+
+  /**
+   * Drain the head of `pendingPrompts` after a predictive compaction aborts.
+   * Prompts land in the queue via the #1749 race guard in `sendPrompt` while
+   * a standby is being warmed; the standby-success drain at the bottom of
+   * `promptComplete` only fires when the seed completes. When the seed fails
+   * (e.g. Gateway 504), the queue is otherwise stranded forever. Mirror the
+   * standard drain shape: dispatch the head, let its promptComplete drain
+   * the next entry. #1769.
+   */
+  drainAfterPredictiveAbort(sessionId: string): void {
+    const queue = state.sessions[sessionId]?.pendingPrompts ?? [];
+    if (queue.length === 0) return;
+    const [nextPrompt, ...remaining] = queue;
+    if (nextPrompt == null) return;
+    setState("sessions", sessionId, "pendingPrompts", remaining);
+    console.info(
+      `[AgentStore] Predictive compact aborted — draining queued prompt on ${sessionId} (#1769)`,
+    );
+    setTimeout(() => {
+      void this.sendPrompt(nextPrompt, undefined, undefined, sessionId);
+    }, 0);
   },
 
   /**

--- a/tests/unit/claude-runtime-cleanups.test.ts
+++ b/tests/unit/claude-runtime-cleanups.test.ts
@@ -86,19 +86,23 @@ describe("#1755 — chooseUpdatedModelId log skips no-op resolutions", () => {
     expect(region).toMatch(/if\s*\(\s*!isNoOpResolution\s*\)/);
   });
 
-  it("the no-op short-circuit requires all three fields to match (previous, incoming, resolved)", () => {
-    // A weaker check (e.g. only previous === incoming) would suppress
-    // legitimate divergence cases where the picker resolved a different
-    // id than the assistant's self-report — exactly the case #1718 was
-    // built to catch. All three must be equal AND non-null for the log
-    // to be safely suppressed.
+  it("the no-op short-circuit suppresses whenever the resolver's output matches the previous session state (#1769)", () => {
+    // The earlier strict form required previous === incoming === resolved.
+    // That left the [1m]-preservation steady-state un-suppressed: Anthropic
+    // echoes back the bare id (e.g. claude-opus-4-7), the resolver re-applies
+    // the `[1m]` suffix, and `previous !== incoming` always — so the WARN
+    // fired every parent message for every 1M-tier user. The mutation block
+    // immediately below remains the source of truth for actual model swaps;
+    // when resolved equals the previous session state nothing material
+    // happened, so the diagnostic carries no signal worth logging.
     const noopIdx = claudeRuntime.indexOf("isNoOpResolution");
     expect(noopIdx).toBeGreaterThan(0);
     const region = claudeRuntime.slice(noopIdx, noopIdx + 600);
     expect(region).toContain("previousModelId != null");
-    expect(region).toContain("message.model != null");
     expect(region).toContain("nextModelId != null");
-    expect(region).toContain("previousModelId === message.model");
     expect(region).toContain("previousModelId === nextModelId");
+    // Must NOT keep the strict incoming check — that is the regression we
+    // are removing. Asserting the absence locks the looser form in place.
+    expect(region).not.toContain("previousModelId === message.model");
   });
 });

--- a/tests/unit/model-context-cache-tier-guard.test.ts
+++ b/tests/unit/model-context-cache-tier-guard.test.ts
@@ -1,0 +1,101 @@
+// ABOUTME: Critical guard for #1769 — recordModelContextWindow must refuse to
+// ABOUTME: persist sub-1M values for [1m]-suffixed models so the cache cannot poison future sessions.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockInvoke = vi.hoisted(() => vi.fn());
+const mockCaptureSupportError = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
+vi.mock("@/lib/support/hook", () => ({
+  captureSupportError: mockCaptureSupportError,
+}));
+
+describe("#1769 — recordModelContextWindow tier-downgrade guard", () => {
+  beforeEach(() => {
+    // Module-level dedup Set must reset between cases so each test starts
+    // with a clean alert state. Without this, a prior test's alert would
+    // hide the next test's expected fire.
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("refuses to persist a 200K window for a [1m]-suffixed model and fires the mismatch alarm", async () => {
+    const { recordModelContextWindow } = await import(
+      "@/services/modelContextCache"
+    );
+    await recordModelContextWindow(
+      "claude-code",
+      "claude-opus-4-7[1m]",
+      200_000,
+    );
+    expect(mockInvoke).not.toHaveBeenCalled();
+    expect(mockCaptureSupportError).toHaveBeenCalledTimes(1);
+    expect(mockCaptureSupportError.mock.calls[0][0]).toMatchObject({
+      kind: "agent.context_window_tier_mismatch",
+      agentContext: {
+        model: "claude-opus-4-7[1m]",
+        provider: "claude-code",
+      },
+    });
+  });
+
+  it("dedups the alarm to one capture per (provider, modelId) within a process lifetime", async () => {
+    const { recordModelContextWindow } = await import(
+      "@/services/modelContextCache"
+    );
+    await recordModelContextWindow(
+      "claude-code",
+      "claude-opus-4-7[1m]",
+      200_000,
+    );
+    await recordModelContextWindow(
+      "claude-code",
+      "claude-opus-4-7[1m]",
+      150_000,
+    );
+    // Same (provider, modelId) key on both calls — only one ticket should
+    // open even though the cache layer refused twice.
+    expect(mockCaptureSupportError).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists the value when the [1m] model reports the full 1M window", async () => {
+    const { recordModelContextWindow } = await import(
+      "@/services/modelContextCache"
+    );
+    await recordModelContextWindow(
+      "claude-code",
+      "claude-opus-4-7[1m]",
+      1_000_000,
+    );
+    expect(mockInvoke).toHaveBeenCalledWith("record_model_context_window", {
+      provider: "claude-code",
+      modelId: "claude-opus-4-7[1m]",
+      contextWindow: 1_000_000,
+    });
+    expect(mockCaptureSupportError).not.toHaveBeenCalled();
+  });
+
+  it("persists sub-1M values for bare (200K-tier) Claude IDs without alarming", async () => {
+    // The guard is gated on the [1m] suffix because Anthropic's bare IDs
+    // genuinely sit on the 200K tier — refusing those would break the cache
+    // for the unsuffixed picker entries.
+    const { recordModelContextWindow } = await import(
+      "@/services/modelContextCache"
+    );
+    await recordModelContextWindow(
+      "claude-code",
+      "claude-opus-4-7",
+      200_000,
+    );
+    expect(mockInvoke).toHaveBeenCalledWith("record_model_context_window", {
+      provider: "claude-code",
+      modelId: "claude-opus-4-7",
+      contextWindow: 200_000,
+    });
+    expect(mockCaptureSupportError).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/predictive-compact-failure-drain.test.ts
+++ b/tests/unit/predictive-compact-failure-drain.test.ts
@@ -1,0 +1,76 @@
+// ABOUTME: Critical guard for #1769 — kickPredictiveCompact's non-success and catch
+// ABOUTME: branches must drain pendingPrompts so #1749-enqueued prompts never strand.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1769 — kickPredictiveCompact drains pendingPrompts on abort", () => {
+  it("non-success and catch branches both call drainAfterPredictiveAbort", () => {
+    // Without this, the #1749 race-guard queue (pendingPrompts populated when
+    // the user submits while a standby is being warmed) is stranded forever
+    // when the standby's seed prompt fails — e.g. the Gateway 504 in the
+    // user-reported transcript. The standby-success drain at promptComplete
+    // only fires when the seed completes; abort needs its own dispatch path.
+    const fnStart = agentStoreSource.indexOf("async kickPredictiveCompact(");
+    expect(fnStart, "kickPredictiveCompact must exist").toBeGreaterThan(0);
+    // The drain helper is declared on the same object literal, immediately
+    // after kickPredictiveCompact — slice past it so the assertions below
+    // count the call sites inside kickPredictiveCompact, not the helper body.
+    const drainHelperStart = agentStoreSource.indexOf(
+      "drainAfterPredictiveAbort(sessionId: string)",
+      fnStart,
+    );
+    expect(drainHelperStart, "drain helper must follow kick").toBeGreaterThan(
+      fnStart,
+    );
+    const kickBody = agentStoreSource.slice(fnStart, drainHelperStart);
+
+    const drainCalls = kickBody.match(
+      /this\.drainAfterPredictiveAbort\(sessionId\)/g,
+    );
+    expect(
+      drainCalls,
+      "kickPredictiveCompact must call drainAfterPredictiveAbort in both abort branches",
+    ).toHaveLength(2);
+
+    // Each drain call must run AFTER the predictiveCompactInFlight flag is
+    // cleared on the same branch. Otherwise the drained sendPrompt re-enters
+    // and trips the #1749 enqueue guard, restranding the prompt.
+    const nonSuccessFlagClear = kickBody.indexOf(
+      'setState("sessions", sessionId, "predictiveCompactInFlight", false)',
+    );
+    const firstDrain = kickBody.indexOf(
+      "this.drainAfterPredictiveAbort(sessionId)",
+    );
+    expect(nonSuccessFlagClear).toBeGreaterThan(0);
+    expect(firstDrain).toBeGreaterThan(nonSuccessFlagClear);
+  });
+
+  it("drainAfterPredictiveAbort dispatches the head of pendingPrompts via setTimeout", () => {
+    // Mirrors the standard drain shape used at the bottom of the
+    // promptComplete handler and in the standby-success drain. Synchronous
+    // dispatch would re-enter sendPrompt before the current call stack
+    // unwinds, which has caused store-update reentrancy bugs in the past.
+    const helperStart = agentStoreSource.indexOf(
+      "drainAfterPredictiveAbort(sessionId: string)",
+    );
+    expect(helperStart).toBeGreaterThan(0);
+    const helperEnd = agentStoreSource.indexOf("\n  },", helperStart);
+    const helperBody = agentStoreSource.slice(helperStart, helperEnd);
+
+    expect(helperBody).toContain("pendingPrompts");
+    expect(helperBody).toMatch(
+      /setState\("sessions",\s*sessionId,\s*"pendingPrompts",\s*remaining\)/,
+    );
+    expect(helperBody).toContain("setTimeout(");
+    expect(helperBody).toContain(
+      "this.sendPrompt(nextPrompt, undefined, undefined, sessionId)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1769. Three compounding regressions that surfaced together in a long Claude Code session on `claude-opus-4-7[1m]` (user transcript: 102% of 200,000 context warning, 504 from standby seed, two follow-up prompts stuck in `pendingPrompts`, and the WARN spam from `chooseUpdatedModelId`).

- **Cache-layer guard** ([src/services/modelContextCache.ts](src/services/modelContextCache.ts)) refuses to persist a sub-1M context window for any `[1m]`-suffixed model and fires `captureSupportError` once per `(provider, modelId)` per process, so a single transient gateway downgrade can no longer poison every future spawn of the same model.
- **Drain-on-abort helper** ([src/stores/agent.store.ts](src/stores/agent.store.ts#L3353-L3372)) is called from both `kickPredictiveCompact`'s non-success and catch branches after the `predictiveCompactInFlight` flag clears. It dispatches the head of `pendingPrompts` via `setTimeout(…, 0)`, mirroring the standard drain shape. The standby-success drain at [agent.store.ts:4378-4406](src/stores/agent.store.ts#L4378-L4406) only fires when the seed completes; this rescues prompts when it fails (today's 504).
- **Tighter no-op suppression** ([bin/browser-local/claude-runtime.mjs:1322-1336](bin/browser-local/claude-runtime.mjs#L1322-L1336)) drops the strict `previous === incoming === resolved` gate to `previous === resolved` so the `[1m]`-preservation steady-state stops emitting one WARN per parent message for every 1M-tier user. The mutation block immediately below remains the source of truth for actual model swaps.

## Test plan

- [x] Targeted: `pnpm test tests/unit/model-context-cache-tier-guard.test.ts tests/unit/predictive-compact-failure-drain.test.ts tests/unit/claude-runtime-cleanups.test.ts` — 12/12 pass
- [x] Full vitest suite — 736/736 pass
- [x] `pnpm check` on touched files — clean (5 pre-existing biome errors elsewhere are independent of this PR)
- [ ] Manual: long-running Claude Code session at 70%+ context, simulate Gateway 504 on standby seed, confirm queued prompts drain instead of stranding
- [ ] Manual: verify the `chooseUpdatedModelId` WARN no longer appears on every parent message in a 1M-tier session

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
