### PR TITLE
feat(memory): hybrid recall (BM25 offline fallback + score breakdown) — closes #1621

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6597,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "seren-memory-sdk"
 version = "0.1.0"
-source = "git+https://github.com/serenorg/seren-memory-sdk.git?branch=main#18945417d2fcdf9b777fc5aa9d7373849849c646"
+source = "git+https://github.com/serenorg/seren-memory-sdk.git?branch=main#ed22cff8aaf65566e7a753d1ee37c8a68722953b"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -81,6 +81,10 @@ pub struct RecallOutput {
     pub content: String,
     pub memory_type: String,
     pub relevance_score: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vector_score: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bm25_score: Option<f64>,
 }
 
 /// Output type for sync results (serializable to frontend).
@@ -160,6 +164,8 @@ pub async fn memory_remember(
         created_at: seren_memory_sdk::chrono::Utc::now(),
         synced: false,
         cloud_id: None,
+        feedback_signal: None,
+        pinned: false,
     };
     {
         let guard = state.cache.lock().map_err(|e| e.to_string())?;
@@ -202,24 +208,28 @@ pub async fn memory_recall(
                 content: r.content,
                 memory_type: r.memory_type,
                 relevance_score: r.relevance_score,
+                vector_score: r.vector_score,
+                bm25_score: r.bm25_score,
             })
             .collect()),
         Err(e) => {
-            // Offline fallback: search local cache.
             log::warn!("Cloud recall failed, trying local cache: {e}");
             state.ensure_cache()?;
             let guard = state.cache.lock().map_err(|e| e.to_string())?;
             if let Some(cache) = guard.as_ref() {
-                // Use a zero query embedding for local fallback (returns by insertion order).
+                // No offline embedding source on the desktop, so hybrid_search
+                // degrades to BM25-only — content-aware, unlike list_recent.
                 let local = cache
-                    .list_recent(limit.unwrap_or(10))
+                    .hybrid_search(&query, None, limit.unwrap_or(10))
                     .map_err(|e| e.to_string())?;
                 Ok(local
                     .into_iter()
-                    .map(|m| RecallOutput {
-                        content: m.content,
-                        memory_type: m.memory_type,
-                        relevance_score: m.relevance_score,
+                    .map(|r| RecallOutput {
+                        content: r.memory.content,
+                        memory_type: r.memory.memory_type,
+                        relevance_score: r.rrf_score,
+                        vector_score: r.vector_score,
+                        bm25_score: r.bm25_score,
                     })
                     .collect())
             } else {

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -10,6 +10,8 @@ export interface RecallResult {
   content: string;
   memory_type: string;
   relevance_score: number;
+  vector_score?: number;
+  bm25_score?: number;
 }
 
 export interface SyncResult {


### PR DESCRIPTION
## Summary

Closes #1621. Both upstream blockers shipped today (2026-05-01):
- [serenorg/seren-memory-sdk#5](https://github.com/serenorg/seren-memory-sdk/issues/5) — FTS5 + `hybrid_search` on `LocalCache` (CLOSED)
- [serenorg/seren-memory#6](https://github.com/serenorg/seren-memory/issues/6) — BM25 replacement + optional reranker (CLOSED)

This wires the desktop-side consumer:

- `src-tauri/src/commands/memory.rs:215` — offline fallback now calls `cache.hybrid_search(&query, None, limit)` instead of `cache.list_recent(limit)`. With `query_embedding=None` the SDK degrades to BM25-only ([cache.rs:337-348 upstream](https://github.com/serenorg/seren-memory-sdk/blob/main/src/cache.rs#L337-L348)), so degraded-mode recall is content-aware, not chronological.
- `RecallOutput` (Rust) and `RecallResult` (TS) gain optional `vector_score` / `bm25_score`, surfaced both from the cloud `RecallResult` (which now carries them) and from `RankedCachedMemory` on the offline path. Both fields skip-serialize when `None` so the wire shape stays additive for older cloud builds.
- `CachedMemory` constructor at `memory.rs:157` fills the SDK new `feedback_signal: None` and `pinned: false` fields (added alongside the FTS5 work).
- `Cargo.lock` SDK pin bumped to `ed22cff8`.

## Acceptance criteria (from #1621)

- [x] Offline fallback (SerenDB unreachable) returns keyword-matched memories, not chronological recents.
- [x] When SDK is upgraded, `vector_score` + `bm25_score` appear on recall results.
- [x] No regression in online recall quality — cloud path is unchanged in this repo (just plumbs the new optional fields through).

## Test plan

- [x] `cargo check --offline` passes.
- [x] `pnpm biome check src/services/memory.ts` clean.
- [ ] Smoke: trigger offline path (kill network), verify keyword-matched recall in dev tools.

Per CLAUDE.md TDD policy, no new tests added — wire-up to a tested SDK is not security/billing/complex-algorithm code. The SDK ships hybrid_search tests in seren-memory-sdk#5.
