### PR TITLE
fix(agent): standby-success drain pivots via standbySessionId, not conversationId (#1772)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -4391,18 +4391,21 @@ Structured summary:`;
             "ready" as SessionStatus,
           );
           predictiveCompactBusy = false;
-          const owner = state.sessions[sessionId];
+          // Find the serving session via its standbySessionId backref. The
+          // serving's conversationId is the persisted thread id (e.g.
+          // 3fa906a4…), but the standby is spawned with conversationId =
+          // info.id (its own session id) and only inherits the serving's
+          // conversationId during promoteStandbyAndDispatch — i.e. AFTER
+          // promotion, well past this seed-completion tick. So a
+          // conversationId pivot finds zero matches and strands every
+          // queued #1749 prompt. Pivot through the standbySessionId backref
+          // set at agent.store.ts:3069 instead. #1772.
           let servingForDrain: string | null = null;
-          if (owner?.conversationId) {
-            for (const [sid, s] of Object.entries(state.sessions)) {
-              if (
-                s.conversationId === owner.conversationId &&
-                s.role === "serving"
-              ) {
-                setState("sessions", sid, "predictiveCompactInFlight", false);
-                if ((s.pendingPrompts ?? []).length > 0) {
-                  servingForDrain = sid;
-                }
+          for (const [sid, s] of Object.entries(state.sessions)) {
+            if (s.standbySessionId === sessionId && s.role === "serving") {
+              setState("sessions", sid, "predictiveCompactInFlight", false);
+              if ((s.pendingPrompts ?? []).length > 0) {
+                servingForDrain = sid;
               }
             }
           }

--- a/tests/unit/predictive-standby-success-drain-lookup.test.ts
+++ b/tests/unit/predictive-standby-success-drain-lookup.test.ts
@@ -1,0 +1,70 @@
+// ABOUTME: Critical guard for #1772 — standby-success drain in promptComplete must
+// ABOUTME: pivot via standbySessionId backref, not conversationId (which never matches).
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1772 — standby-success drain looks up serving via standbySessionId", () => {
+  it("standby branch of promptComplete pivots through standbySessionId, not conversationId", () => {
+    // The standby is spawned with conversationId = info.id (its own session
+    // id). It only inherits the serving's conversationId during
+    // promoteStandbyAndDispatch — AFTER promotion. At seed-completion time
+    // the standby's conversationId never matches the serving's, so a
+    // conversationId pivot returns zero matches: predictiveCompactInFlight
+    // stays stuck and #1749-enqueued prompts strand forever.
+    const branchAnchor =
+      'if (state.sessions[sessionId]?.role === "standby") {';
+    const branchStart = agentStoreSource.indexOf(branchAnchor);
+    expect(branchStart, "standby branch must exist").toBeGreaterThan(0);
+
+    // Slice up to the standby branch's break — just before the regular
+    // (non-standby) promptComplete handling begins.
+    const branchEnd = agentStoreSource.indexOf(
+      "// Flush any buffered tool events",
+      branchStart,
+    );
+    expect(branchEnd).toBeGreaterThan(branchStart);
+    const branchBody = agentStoreSource.slice(branchStart, branchEnd);
+
+    expect(
+      branchBody,
+      "lookup must pivot through standbySessionId backref",
+    ).toContain("s.standbySessionId === sessionId");
+    expect(
+      branchBody,
+      "the broken conversationId pivot must not return",
+    ).not.toContain("s.conversationId === owner.conversationId");
+  });
+
+  it("the matched serving session has predictiveCompactInFlight cleared and pendingPrompts drained", () => {
+    // Once the serving is found via the standbySessionId backref, the block
+    // must (a) clear the in-flight flag and (b) hand the head of the queue
+    // to a setTimeout(0)-deferred sendPrompt — same shape as the abort
+    // drain (#1769). Synchronous re-entry has caused store-update bugs.
+    const branchAnchor =
+      'if (state.sessions[sessionId]?.role === "standby") {';
+    const branchStart = agentStoreSource.indexOf(branchAnchor);
+    const branchEnd = agentStoreSource.indexOf(
+      "// Flush any buffered tool events",
+      branchStart,
+    );
+    const branchBody = agentStoreSource.slice(branchStart, branchEnd);
+
+    expect(branchBody).toContain(
+      'setState("sessions", sid, "predictiveCompactInFlight", false)',
+    );
+    expect(branchBody).toMatch(
+      /setState\("sessions",\s*drainTarget,\s*"pendingPrompts",\s*remaining\)/,
+    );
+    expect(branchBody).toContain("setTimeout(");
+    expect(branchBody).toContain(
+      "this.sendPrompt(\n                  nextPrompt,\n                  undefined,\n                  undefined,\n                  drainTarget,\n                )",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #1772 — predictive standby-success drain in `promptComplete` was looking up the serving session via `conversationId`, which never matches because the standby is spawned with its own session id as conversationId and only inherits the serving's conversationId during promotion (agent.store.ts:3402), AFTER this tick
- Pivots the lookup through `s.standbySessionId === sessionId` (the serving→standby backref set at agent.store.ts:3069 before the seed dispatches)
- Result: `predictiveCompactInFlight` clears on the serving, the head of `pendingPrompts` drains via `setTimeout(0)`, the drained `sendPrompt` re-enters and promotes-and-dispatches on the just-seeded standby

Bug surfaced in Taariq's transcript: serving `41ff9574` (conversationId `3fa906a4`) at 161% of cached 200K window, standby `0f871a8c` seeded successfully, no drain log, composer stuck.

## Test plan

- [x] `npx vitest run tests/unit/predictive-standby-success-drain-lookup.test.ts` — 2 tests pass with fix, 1 fails on broken code (verified by stashing the fix)
- [x] All adjacent predictive tests pass: `predictive-compact-failure-drain` (#1769), `predictive-drain-not-blocked` (#1673), `predictive-compact-race`, `predictive-compact-telemetry`, `compaction-queue-race`, `compaction-predictive-soft-fail`, `agent-standby-reclaim-guard` — 29/29
- [x] `biome check` clean on changed files

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
