### PR TITLE
fix(agent): #1776 — remove keyword-based prompt-too-long compaction loop + reattach [1m] tier post-spawn

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1769,11 +1769,23 @@ export function createClaudeRuntime({ emit }) {
       session.availableModelRecords = augmentWithLegacyOpus(
         normalizeModelRecords(initResult),
       );
+      // Route the inferred id through chooseUpdatedModelId so the `[1m]`
+      // suffix from the spawn-time `--model` arg is preserved when the CLI
+      // echoes the bare equivalent in initResult.model. Without this the
+      // post-init clobber strips `[1m]` from every fresh `[1m]` thread,
+      // poisoning the picker and the next setModel arg with the 200K-tier
+      // bare id even though the session is actually running on 1M. #1776.
+      const inferredFromInit = inferCurrentModelId(
+        initResult?.model ?? null,
+        session.availableModelRecords,
+      );
       session.currentModelId =
-        inferCurrentModelId(
-          initResult?.model ?? null,
+        chooseUpdatedModelId(
+          session.currentModelId,
+          inferredFromInit,
           session.availableModelRecords,
         ) ??
+        inferredFromInit ??
         session.currentModelId;
 
       // The launched session stays in its default permission flow until we
@@ -2149,11 +2161,21 @@ export function createClaudeRuntime({ emit }) {
       tempSession.availableModelRecords = augmentWithLegacyOpus(
         normalizeModelRecords(initResult),
       );
+      // Symmetric with spawnSession's post-init handling — preserve the
+      // `[1m]` suffix from the seed `currentModelId` when the CLI echoes the
+      // bare equivalent in initResult.model. See #1776.
+      const inferredFromInit = inferCurrentModelId(
+        initResult?.model ?? null,
+        tempSession.availableModelRecords,
+      );
       tempSession.currentModelId =
-        inferCurrentModelId(
-          initResult?.model ?? null,
+        chooseUpdatedModelId(
+          tempSession.currentModelId,
+          inferredFromInit,
           tempSession.availableModelRecords,
-        ) ?? tempSession.currentModelId;
+        ) ??
+        inferredFromInit ??
+        tempSession.currentModelId;
 
       if (!tempSession.agentSessionId) {
         throw new Error("Claude fork did not return a resumable session id.");

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -4837,8 +4837,9 @@ Structured summary:`;
           !state.sessions[sessionId]?.promptTooLongHandled
         ) {
           // Context window full — try compaction + retry before falling back.
-          // Guard with promptTooLongHandled to prevent duplicate fallbacks
-          // when the error is also detected in streamed content.
+          // The structured is_error event from the runtime is the only signal
+          // we trust for prompt-too-long; promptTooLongHandled prevents this
+          // path from racing with the rejection-reason check in sendPrompt.
           console.info("[AgentStore] Prompt too long detected in error event");
           setState("sessions", sessionId, "promptTooLongHandled", true);
 
@@ -5564,45 +5565,12 @@ Structured summary:`;
         setState("sessions", sessionId, "error", session.streamingContent);
       }
 
-      // If the agent's response is a prompt-too-long error (context window full),
-      // try compaction + retry before falling back to Chat mode.
-      // Guard with promptTooLongHandled to prevent duplicate fallbacks when
-      // the error is detected in both streamed content and the error event.
-      if (
-        isPromptTooLongError(session.streamingContent) &&
-        !session.promptTooLongHandled
-      ) {
-        console.info(
-          "[AgentStore] Prompt too long detected in streamed content",
-        );
-        setState("sessions", sessionId, "promptTooLongHandled", true);
-        const compactPromise = this.compactAndRetry(sessionId).then(
-          (outcome) => {
-            if (outcome === "failed_catastrophic") {
-              console.error(
-                "[AgentStore] Compaction failed catastrophically from streamed content — falling back to Chat",
-              );
-              setState("sessions", sessionId, "promptTooLong", true);
-              this.acceptRateLimitFallback().catch((err) => {
-                console.error(
-                  "[AgentStore] Auto-failover from streamed content failed:",
-                  err,
-                );
-              });
-            } else if (outcome === "skipped_nothing_to_compact") {
-              console.warn(
-                "[AgentStore] Compaction skipped for streamed content — single prompt too large",
-              );
-              this.addErrorMessage(
-                sessionId,
-                "Your last message is too large for this agent's context window. Try shortening it, attaching files instead of pasting content, or starting a new thread.",
-              );
-            }
-            return outcome;
-          },
-        );
-        setState("sessions", sessionId, "compactRetryPromise", compactPromise);
-      }
+      // Prompt-too-long is detected exclusively from the CLI's structured
+      // is_error result event (handled at the "error" event branch above).
+      // The runtime emits provider://error only when payload.is_error is set,
+      // so that path is the canonical signal. Scanning streamed assistant
+      // prose for context-window keywords self-triggered compaction whenever
+      // the model discussed those topics in normal output (#1776).
 
       setState("sessions", sessionId, "streamingContent", "");
       setState("sessions", sessionId, "streamingContentTimestamp", undefined);

--- a/tests/unit/claude-runtime-1m-tier-postinit.test.ts
+++ b/tests/unit/claude-runtime-1m-tier-postinit.test.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Critical guard for #1776 — post-init overwrite of session.currentModelId
+// ABOUTME: must route through chooseUpdatedModelId so the [1m] suffix is preserved.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const claudeRuntimeSource = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+
+describe("#1776 — post-init currentModelId resolution preserves [1m]", () => {
+  it("spawnSession routes the inferred init.model through chooseUpdatedModelId", () => {
+    // Anthropic echoes the bare resolved id (e.g. claude-opus-4-7) in
+    // initResult.model even when the session was spawned with --model
+    // claude-opus-4-7[1m]. Resolving the bare echo via inferCurrentModelId
+    // alone clobbers the [1m] suffix and leaves the picker (and the next
+    // setModel arg) on the 200K-tier id while the session is actually
+    // running on 1M. chooseUpdatedModelId carries the existing #1763
+    // [1m]-preservation guard — reuse it here so spawn-time and per-message
+    // resolution agree on the tier marker.
+    const spawnAnchor = "augmentWithLegacyOpus(\n        normalizeModelRecords(initResult),\n      );";
+    const idx = claudeRuntimeSource.indexOf(spawnAnchor);
+    expect(idx, "spawnSession post-init block must exist").toBeGreaterThan(0);
+
+    const block = claudeRuntimeSource.slice(idx, idx + 1200);
+    expect(block).toContain("chooseUpdatedModelId(");
+    expect(block).toContain("session.currentModelId,");
+    expect(block).toContain("inferredFromInit");
+  });
+
+  it("forkSession applies the same chooseUpdatedModelId protection symmetrically", () => {
+    // The fork path (#1635 resume + branch) repeats the post-init resolution
+    // for the temporary control session it spins up to derive a resumable
+    // agentSessionId. Without the same [1m]-preservation logic, forking a
+    // 1M-tier conversation drops the suffix on the new branch.
+    const forkAnchor =
+      'tempSession.availableModelRecords = augmentWithLegacyOpus(';
+    const idx = claudeRuntimeSource.indexOf(forkAnchor);
+    expect(idx, "forkSession post-init block must exist").toBeGreaterThan(0);
+
+    const block = claudeRuntimeSource.slice(idx, idx + 1200);
+    expect(block).toContain("chooseUpdatedModelId(");
+    expect(block).toContain("tempSession.currentModelId,");
+  });
+
+  it("DEFAULT_PREFERRED_MODEL is the [1m]-tier Opus 4.7 id", () => {
+    // The fresh-thread fallback must default to the 1M-tier variant so the
+    // picker shows it as the default selection out of the box. Combined with
+    // the chooseUpdatedModelId reuse above, this gives fresh threads a 1M
+    // window without requiring picker discovery.
+    expect(claudeRuntimeSource).toContain(
+      'const DEFAULT_PREFERRED_MODEL = "claude-opus-4-7[1m]";',
+    );
+  });
+});

--- a/tests/unit/prompt-too-long-streamed-content-removed.test.ts
+++ b/tests/unit/prompt-too-long-streamed-content-removed.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Critical guard for #1776 — prompt-too-long must NOT be detected by
+// ABOUTME: keyword-scanning streamed assistant content; only structured signals.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1776 — no keyword scan on streamed assistant content", () => {
+  it("isPromptTooLongError is never called against session.streamingContent", () => {
+    // The 17-pattern detector at rate-limit-fallback.ts is correct for short
+    // structured error envelopes from the CLI. Calling it on unbounded
+    // streamed assistant prose self-triggered compaction whenever the model
+    // discussed context-window topics, killing the agent process and seeding
+    // a fresh session in a loop. The structured `is_error` event from the
+    // runtime (handled in the "error" event branch above finalizeStreamingContent)
+    // is the canonical signal; nothing in the streamed-content path should
+    // pattern-match assistant prose to decide whether to compact.
+    expect(agentStoreSource).not.toMatch(
+      /isPromptTooLongError\(\s*session\.streamingContent\s*\)/,
+    );
+    expect(agentStoreSource).not.toContain(
+      "Prompt too long detected in streamed content",
+    );
+  });
+
+  it("structured error-event detection path remains intact", () => {
+    // The fix removes only the streamed-content scan. The structured error
+    // event handler must still detect prompt_too_long and run compactAndRetry,
+    // since that is the canonical signal we now rely on exclusively.
+    expect(agentStoreSource).toContain(
+      "isPromptTooLongError(String(event.data.error))",
+    );
+    expect(agentStoreSource).toContain(
+      "[AgentStore] Prompt too long detected in error event",
+    );
+  });
+});


### PR DESCRIPTION
Closes #1776.

## Summary

- Delete the streamed-content keyword scan in `finalizeStreamingContent` ([src/stores/agent.store.ts:5571-5605](src/stores/agent.store.ts#L5571)). The 17-pattern detector was false-positiving on normal model output that mentioned context-window topics, kicking compactAndRetry → SIGTERM → respawn → repeat. Real prompt-too-long detection stays via the structured `is_error` event at [agent.store.ts:4836](src/stores/agent.store.ts#L4836) and the rejection-reason check at [agent.store.ts:3935](src/stores/agent.store.ts#L3935).
- Reattach the `[1m]` suffix at post-init in [bin/browser-local/claude-runtime.mjs](bin/browser-local/claude-runtime.mjs) by routing the inferred id through `chooseUpdatedModelId` (which already carries the #1763 `[1m]`-preservation guard) instead of `inferCurrentModelId` raw. Anthropic echoes the bare resolved id in `initResult.model` even when the session was spawned with `--model claude-opus-4-7[1m]`; without this, the post-init clobber strips the suffix from every fresh `[1m]` thread, leaving the picker on the 200K-tier id even though `DEFAULT_PREFERRED_MODEL` already targets `claude-opus-4-7[1m]`.

## Test plan

- [x] `tests/unit/prompt-too-long-streamed-content-removed.test.ts` — asserts `isPromptTooLongError(session.streamingContent)` is no longer called and the structured-event path is intact
- [x] `tests/unit/claude-runtime-1m-tier-postinit.test.ts` — asserts spawn and fork post-init blocks both route through `chooseUpdatedModelId(currentModelId, inferredFromInit, ...)` and the `DEFAULT_PREFERRED_MODEL` literal stays at `claude-opus-4-7[1m]`
- [x] Full unit suite: 743/743 passing on the worktree
- [ ] Manual: open a fresh agent thread, confirm picker shows `Opus 4.7 1M` as default and `setModel ack: requested=claude-opus-4-7[1m]` in logs
- [ ] Manual: ask the agent to discuss prompt-too-long topics; confirm no `[AgentStore] Prompt too long detected in streamed content` log line and no respawn loop
- [ ] Manual: actually fill the context window with a real overflow; confirm structured-event path still triggers compactAndRetry

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
