### PR TITLE
fix(ci): close #1778 - cap commit subjects at 72 chars

### DIFF
--- a/.github/scripts/agent_fix.py
+++ b/.github/scripts/agent_fix.py
@@ -102,7 +102,12 @@ Rules (from CLAUDE.md):
 - Make the smallest reasonable change.
 - Never skip pre-commit hooks (never use --no-verify).
 - All new branches must follow the pattern: fix/issue-{{number}}.
-- Commit message must end with:
+- Commit subject (first line) MUST be a Conventional Commit ≤72 chars
+  (CI enforces via scripts/check-commit-msg.sh, see #1778). Put any
+  implementation detail, file paths, line numbers, and rationale in the
+  commit body — separated from the subject by a blank line. Do NOT bundle
+  multi-paragraph summaries into the subject line.
+- Commit body must end with:
   Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
   Email: hello@serendb.com
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-commit-subjects:
+    # Validates each non-merge commit subject in the PR diff against
+    # scripts/check-commit-msg.sh — same script the local commit-msg hook uses.
+    # Catches what the local hook misses when a contributor hasn't opted in.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Validate PR commit subjects
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -e
+          subjects=$(git log --no-merges --format='%s' "$BASE_SHA..$HEAD_SHA")
+          if [ -z "$subjects" ]; then
+            echo "No non-merge commits in PR diff; nothing to validate."
+            exit 0
+          fi
+          fail=0
+          while IFS= read -r line; do
+            if ! bash scripts/check-commit-msg.sh "$line"; then
+              fail=1
+            fi
+          done <<< "$subjects"
+          exit "$fail"
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,11 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 - `test:` Adding tests
 - `chore:` Maintenance
 
+The **subject line** (first line) must be ≤72 characters. Put implementation
+detail — file paths, line numbers, rationale, trade-offs — in the commit
+**body**, separated from the subject by a blank line. CI enforces both rules
+on every PR commit via `scripts/check-commit-msg.sh` (see #1778).
+
 Examples:
 
 - `feat: add model selection dropdown`

--- a/scripts/check-commit-msg.sh
+++ b/scripts/check-commit-msg.sh
@@ -9,6 +9,12 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
+# Subject length cap. #1778 made this a hard rule after multi-thousand-char
+# subjects landed on main from the agent harness bundling full implementation
+# summaries into the subject line. Override with MAX_SUBJECT_LEN=<n> for local
+# experiments — CI pins the cap.
+MAX_SUBJECT_LEN="${MAX_SUBJECT_LEN:-72}"
+
 # Accept either a file path (local hook passes the .git/COMMIT_EDITMSG path)
 # or a literal message string (CI passes the line via xargs -I or process subst).
 # An empty-string arg is allowed — git aborts before the hook ever runs on
@@ -39,11 +45,8 @@ esac
 # Types: feat, fix, chore, docs, style, refactor, perf, test, build, ci, revert, hotfix
 pattern='^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert|hotfix)(\([^)]+\))?!?: .+'
 
-if echo "$msg" | grep -Eq "$pattern"; then
-  exit 0
-fi
-
-cat >&2 <<EOF
+if ! echo "$msg" | grep -Eq "$pattern"; then
+  cat >&2 <<EOF
 ✗ Commit message does not follow conventional-commit format.
 
   Got: $msg
@@ -60,5 +63,28 @@ cat >&2 <<EOF
   See https://www.conventionalcommits.org/ for the full spec.
   Bypass with --no-verify only in emergencies.
 EOF
+  exit 1
+fi
 
-exit 1
+# Format passed; now enforce subject length (#1778).
+subject_len="${#msg}"
+if [ "$subject_len" -gt "$MAX_SUBJECT_LEN" ]; then
+  cat >&2 <<EOF
+✗ Commit subject is $subject_len chars; max is $MAX_SUBJECT_LEN.
+
+  Got: $msg
+
+  Move implementation detail into the commit body (a blank line below the
+  subject), keeping the first line a short Conventional Commit summary.
+
+  Examples:
+    fix(agent): close #1234 — short summary here
+    (blank line)
+    Long-form rationale, file paths, line numbers, and trade-offs go here.
+
+  See https://www.conventionalcommits.org/ §1 (subject) and §2 (body).
+EOF
+  exit 1
+fi
+
+exit 0

--- a/tests/unit/check-commit-msg.test.ts
+++ b/tests/unit/check-commit-msg.test.ts
@@ -7,9 +7,12 @@ import { describe, expect, it } from "vitest";
 
 const SCRIPT = resolve(__dirname, "../../scripts/check-commit-msg.sh");
 
-function run(message: string): { ok: boolean; stderr: string } {
+function run(message: string, env?: Record<string, string>): { ok: boolean; stderr: string } {
   try {
-    execFileSync("bash", [SCRIPT, message], { stdio: ["ignore", "ignore", "pipe"] });
+    execFileSync("bash", [SCRIPT, message], {
+      stdio: ["ignore", "ignore", "pipe"],
+      env: { ...process.env, ...(env ?? {}) },
+    });
     return { ok: true, stderr: "" };
   } catch (err) {
     const stderr = (err as { stderr?: Buffer }).stderr?.toString() ?? "";
@@ -68,5 +71,28 @@ describe("check-commit-msg.sh — rejects", () => {
 
   it("type with empty parens scope", () => {
     expect(run("fix(): empty scope").ok).toBe(false);
+  });
+});
+
+describe("check-commit-msg.sh — subject length cap (#1778)", () => {
+  // 73 chars: well-formed conventional-commit, one over the default cap.
+  const overCap = `fix(agent): ${"a".repeat(73 - "fix(agent): ".length)}`;
+
+  it("rejects subjects longer than the default 72-char cap", () => {
+    expect(overCap.length).toBe(73);
+    const r = run(overCap);
+    expect(r.ok).toBe(false);
+    expect(r.stderr).toContain("Commit subject is 73 chars");
+    expect(r.stderr).toContain("max is 72");
+  });
+
+  it("respects MAX_SUBJECT_LEN override (so the cap can be tuned, not forked)", () => {
+    expect(run(overCap, { MAX_SUBJECT_LEN: "100" }).ok).toBe(true);
+  });
+
+  it("does not gate Merge/Revert prefixes on length (git generates these and they can be long)", () => {
+    const longMerge = `Merge pull request #1234 from ${"x".repeat(120)}`;
+    expect(longMerge.length).toBeGreaterThan(72);
+    expect(run(longMerge).ok).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a 72-char subject cap to `scripts/check-commit-msg.sh` (override via `MAX_SUBJECT_LEN` for local experiments; CI does not export it).
- Wires the script into a new `check-commit-subjects` CI job that validates every non-merge commit subject in a PR diff.
- Tightens `.github/scripts/agent_fix.py` SYSTEM prompt so the CI-failure agent stops bundling multi-paragraph implementation summaries into the subject. **Attribution/signature block requirement is preserved per Taariq** — only the framing changed from "commit message" to "commit body" since the block belongs in the body, not the subject.
- Documents the cap in `CONTRIBUTING.md`.

Closes #1778.

## Test plan

- [x] `pnpm vitest run tests/unit/check-commit-msg.test.ts` — all 15 tests green (12 existing + 3 new for the length cap)
- [x] Sanity-checked the CI inline shell logic locally with a mixed pass/fail subject batch — non-zero exit on the failing subject
- [x] Own commit subject (54 bytes) passes the new script
- [ ] CI green on this PR (will verify in the run after push)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
