### PR TITLE
fix(chat): close #1775 - tolerate Seren Notes id envelope variants

### DIFF
--- a/src/lib/save-to-notes.ts
+++ b/src/lib/save-to-notes.ts
@@ -10,6 +10,51 @@ import { getToken } from "@/services/auth";
 
 const RETRY_DELAYS_MS = [10_000, 20_000];
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Walk a parsed JSON response from POST /publishers/seren-notes/notes and
+// return the upstream note id. Tolerates every envelope we have observed:
+//   • upstream raw: { id, ... }
+//   • upstream NoteDataResponse: { data: { id, ... } }
+//   • Gateway publisher-proxy: { data: { status, body, cost } } where body
+//     is either a parsed object or a JSON-encoded string (older proxy build).
+//   • DataResponse with extra siblings (e.g. request_id) that block the
+//     strict outer unwrap in unwrapDataResponse.
+// Returns the first UUID-shaped id encountered; nothing else opens a valid
+// notes.serendb.com URL, so we refuse anything that isn't a UUID.
+export function extractNoteId(value: unknown): string | undefined {
+  const seen = new WeakSet<object>();
+  const queue: unknown[] = [value];
+  while (queue.length) {
+    const node = queue.shift();
+    if (typeof node === "string") {
+      // Some Gateway builds JSON-encode the upstream body as a string.
+      if (node.startsWith("{") || node.startsWith("[")) {
+        try {
+          queue.push(JSON.parse(node));
+        } catch {
+          // Not JSON, ignore.
+        }
+      }
+      continue;
+    }
+    if (!node || typeof node !== "object") continue;
+    if (seen.has(node as object)) continue;
+    seen.add(node as object);
+    const record = node as Record<string, unknown>;
+    if (typeof record.id === "string" && UUID_RE.test(record.id)) {
+      return record.id;
+    }
+    for (const child of Object.values(record)) {
+      if (child && (typeof child === "object" || typeof child === "string")) {
+        queue.push(child);
+      }
+    }
+  }
+  return undefined;
+}
+
 export async function saveToSerenNotes(
   title: string,
   content: string,
@@ -44,11 +89,29 @@ export async function saveToSerenNotes(
     }
 
     const result = await response.json();
-    const payload = unwrapPublisherBody(result) as
+    // Try the documented envelope first; fall back to a tolerant walk that
+    // covers proxy variants (string-encoded body, missing `status` key, extra
+    // top-level siblings) so a saved note still resolves to a usable URL.
+    const direct = unwrapPublisherBody(result) as
       | { data?: { id?: string }; id?: string }
+      | string
       | undefined;
-    const noteId = payload?.data?.id ?? payload?.id;
-    if (!noteId) throw new Error("Note created but ID missing from response");
+    let noteId: string | undefined;
+    if (direct && typeof direct === "object") {
+      noteId = direct.data?.id ?? direct.id;
+    }
+    if (!noteId) {
+      noteId = extractNoteId(result);
+    }
+    if (!noteId) {
+      console.error(
+        "[SerenNotes] Saved note but could not extract id. Response:",
+        JSON.stringify(result).slice(0, 800),
+      );
+      throw new Error(
+        "Note saved to Seren Notes but the URL could not be opened.",
+      );
+    }
 
     openExternalLink(`https://notes.serendb.com/notes/${noteId}`);
     return;

--- a/tests/unit/save-to-notes-extract-id.test.ts
+++ b/tests/unit/save-to-notes-extract-id.test.ts
@@ -1,0 +1,64 @@
+// ABOUTME: Regression tests for Seren Notes id extraction across publisher envelopes.
+// ABOUTME: Closes #1775 — "Note created but ID missing from response" after Download Chat.
+
+import { describe, expect, it } from "vitest";
+
+import { extractNoteId } from "@/lib/save-to-notes";
+
+const UUID = "041e7a55-261b-4e6d-8cb4-ef4ad656a54a";
+
+describe("extractNoteId", () => {
+  it("finds the id when the gateway returns the upstream NoteDataResponse wrapped in the publisher proxy envelope", () => {
+    // {data: {status, body, cost}} where body is the upstream {data: {id, ...}}.
+    expect(
+      extractNoteId({
+        data: {
+          status: 201,
+          body: { data: { id: UUID, title: "x", format: "markdown" } },
+          cost: "0.0005",
+        },
+      }),
+    ).toBe(UUID);
+  });
+
+  it("finds the id when the proxy body is JSON-encoded as a string (older gateway build)", () => {
+    expect(
+      extractNoteId({
+        data: {
+          status: 201,
+          body: JSON.stringify({ data: { id: UUID, title: "x" } }),
+          cost: "0.0005",
+        },
+      }),
+    ).toBe(UUID);
+  });
+
+  it("finds the id when the gateway adds extra siblings that block the strict outer DataResponse unwrap", () => {
+    // request_id at the top level prevents unwrapDataResponse from stripping `data`,
+    // which is exactly what made the original payload?.data?.id ?? payload?.id chain
+    // resolve to undefined and surface the user-visible "ID missing" error.
+    expect(
+      extractNoteId({
+        request_id: "abc",
+        data: {
+          status: 201,
+          body: { data: { id: UUID } },
+          cost: "0.0005",
+        },
+      }),
+    ).toBe(UUID);
+  });
+
+  it("finds the id when the upstream body is returned verbatim with no proxy envelope", () => {
+    expect(extractNoteId({ data: { id: UUID, title: "x" } })).toBe(UUID);
+    expect(extractNoteId({ id: UUID, title: "x" })).toBe(UUID);
+  });
+
+  it("rejects non-UUID strings so we never open https://notes.serendb.com/notes/<garbage>", () => {
+    expect(extractNoteId({ id: "not-a-uuid" })).toBeUndefined();
+    expect(extractNoteId({ data: { id: "12345" } })).toBeUndefined();
+    expect(extractNoteId({})).toBeUndefined();
+    expect(extractNoteId(null)).toBeUndefined();
+    expect(extractNoteId("plain string")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Close #1775 — Download Chat saved the note upstream but bubbled "Note created but ID missing from response" because the resolver only handled two of the publisher-proxy envelope shapes the Gateway actually returns.
- New `extractNoteId` walks the parsed response, JSON-parses string bodies (older proxy build), and returns the first UUID-shaped `id` it finds, so the note URL hand-off survives every observed envelope.
- Reworded the fallback alert to reflect reality — by the time we surface it, the note has already saved; only the redirect to `notes.serendb.com` failed.

## Root cause
- Upstream `POST /notes` returns 201 with `NoteDataResponse` → `{data: {id: <uuid>, ...}}` (per `https://notes.serendb.com/api/openapi.json`).
- Gateway publisher proxy can wrap that as `{data: {status, body, cost}}`, where `body` is either parsed JSON or, on older proxy builds, a JSON-encoded string. Some responses also carry sibling top-level fields (e.g. `request_id`), which blocks `unwrapDataResponse`'s strict outer unwrap (it only strips when the only keys are `data`/`pagination`).
- The previous chain `payload?.data?.id ?? payload?.id` matched none of those layouts, so every save threw and surfaced "Note created but ID missing from response" even though the note existed in Seren Notes (Taariq's live console captured the exact stack).

## Test plan
- [x] `pnpm vitest run tests/unit/save-to-notes-extract-id.test.ts` — 5/5 covering the four envelope shapes + non-UUID rejection
- [x] `pnpm vitest run tests/unit/publisher-response.test.ts` — existing helpers untouched
- [x] `biome check src/lib/save-to-notes.ts` clean
- [ ] Manual: click Download Chat in AgentChat with an authenticated session; expect `https://notes.serendb.com/notes/<uuid>` to open in the browser

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
