### PR TITLE
fix(chat): close #1792 - retry on SerenNotes inner 408 cold-start

### DIFF
--- a/src/lib/save-to-notes.ts
+++ b/src/lib/save-to-notes.ts
@@ -4,7 +4,7 @@
 import { API_BASE } from "@/lib/config";
 import { openExternalLink } from "@/lib/external-link";
 import { appFetch } from "@/lib/fetch";
-import { unwrapPublisherBody } from "@/lib/publisher-response";
+import { publisherStatus, unwrapPublisherBody } from "@/lib/publisher-response";
 import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 
@@ -89,6 +89,25 @@ export async function saveToSerenNotes(
     }
 
     const result = await response.json();
+
+    // Publisher-inner 408: Gateway returns transport 200 with the upstream
+    // status carried inside the {data:{status,body,cost}} envelope. The
+    // transport-408 branch above never fires for this case, so the original
+    // cold-start retry was a no-op every time. Treat inner 408 the same as
+    // transport 408 — and surface other inner-error statuses without
+    // attempting to extract a note id we know is not there.
+    const innerStatus = publisherStatus(result);
+    if (innerStatus === 408) {
+      if (attempt < RETRY_DELAYS_MS.length) {
+        await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]));
+        continue;
+      }
+      throw new Error("Seren Notes timed out");
+    }
+    if (innerStatus !== undefined && innerStatus >= 400) {
+      throw new Error(`Notes API returned ${innerStatus}`);
+    }
+
     // Try the documented envelope first; fall back to a tolerant walk that
     // covers proxy variants (string-encoded body, missing `status` key, extra
     // top-level siblings) so a saved note still resolves to a usable URL.

--- a/tests/unit/save-to-notes-inner-408-retry.test.ts
+++ b/tests/unit/save-to-notes-inner-408-retry.test.ts
@@ -1,0 +1,116 @@
+// ABOUTME: Verifies the publisher-inner 408 retry path in saveToSerenNotes.
+// ABOUTME: Closes the cold-start half of #1775 — Gateway returns transport 200
+// ABOUTME: with the upstream status carried inside the envelope.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAppFetch = vi.hoisted(() => vi.fn());
+const mockOpenExternalLink = vi.hoisted(() => vi.fn());
+const mockGetToken = vi.hoisted(() => vi.fn());
+const mockShouldUseRustGatewayAuth = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/fetch", () => ({ appFetch: mockAppFetch }));
+vi.mock("@/lib/external-link", () => ({
+  openExternalLink: mockOpenExternalLink,
+}));
+vi.mock("@/services/auth", () => ({ getToken: mockGetToken }));
+vi.mock("@/lib/tauri-fetch", () => ({
+  shouldUseRustGatewayAuth: mockShouldUseRustGatewayAuth,
+}));
+vi.mock("@/lib/config", () => ({ API_BASE: "https://api.serendb.com" }));
+
+const UUID = "041e7a55-261b-4e6d-8cb4-ef4ad656a54a";
+
+function makeResponse(payload: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  } as unknown as Response;
+}
+
+describe("saveToSerenNotes — publisher-inner 408 cold-start retry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockGetToken.mockResolvedValue("test-token");
+    mockShouldUseRustGatewayAuth.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries when the gateway envelope reports inner 408 and opens the URL after the upstream warms up", async () => {
+    // First attempt: the exact envelope captured from Taariq's console — gateway
+    // wrapped the upstream's 30s timeout in a publisher-proxy DataResponse.
+    // Second attempt: upstream warmed up, returns the documented NoteDataResponse
+    // (status 201) inside the same envelope.
+    mockAppFetch
+      .mockResolvedValueOnce(
+        makeResponse({
+          data: {
+            status: 408,
+            body: "",
+            response_bytes: 0,
+            execution_time_ms: 30054,
+            cost: "0",
+            asset_symbol: "USDC",
+            payment_source: "prepaid_balance",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeResponse({
+          data: {
+            status: 201,
+            body: { data: { id: UUID, title: "Chat", format: "markdown" } },
+            cost: "0.0005",
+          },
+        }),
+      );
+
+    const { saveToSerenNotes } = await import("@/lib/save-to-notes");
+    const promise = saveToSerenNotes("Chat History", "# hi");
+
+    // First fetch fires before any timer.
+    await Promise.resolve();
+    expect(mockAppFetch).toHaveBeenCalledTimes(1);
+
+    // The retry sleep is 10s; advance past it and let the second fetch land.
+    await vi.advanceTimersByTimeAsync(10_000);
+    await promise;
+
+    expect(mockAppFetch).toHaveBeenCalledTimes(2);
+    expect(mockOpenExternalLink).toHaveBeenCalledWith(
+      `https://notes.serendb.com/notes/${UUID}`,
+    );
+  });
+
+  it("throws 'Seren Notes timed out' after all retries see inner 408", async () => {
+    // Three responses (initial + 10s + 20s retries), all cold.
+    for (let i = 0; i < 3; i++) {
+      mockAppFetch.mockResolvedValueOnce(
+        makeResponse({
+          data: { status: 408, body: "", execution_time_ms: 30054, cost: "0" },
+        }),
+      );
+    }
+
+    const { saveToSerenNotes } = await import("@/lib/save-to-notes");
+    const promise = saveToSerenNotes("Chat History", "# hi").catch(
+      (e: Error) => e,
+    );
+
+    // Drain both retry sleeps, then await the rejection.
+    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(20_000);
+    const error = (await promise) as Error;
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("Seren Notes timed out");
+    expect(mockAppFetch).toHaveBeenCalledTimes(3);
+    expect(mockOpenExternalLink).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #1792 and #1775. Download Chat surfaces a generic "Failed to save to Seren Notes. Are you logged in?" alert on the first click after the SerenNotes publisher scales to zero. Captured envelope from Taariq's live console:

  ```json
  {"data":{"status":408,"body":"","response_bytes":0,"execution_time_ms":30054,"cost":"0","asset_symbol":"USDC","payment_source":"prepaid_balance"}}
  ```

  Gateway returned **transport 200** with the upstream's 30s timeout carried inside the publisher-proxy envelope. The existing retry only checked `response.status === 408` — that branch never fired, so execution always fell through to the id extractor with an empty body. The cold-start was a no-op.

- Fix in [src/lib/save-to-notes.ts](src/lib/save-to-notes.ts): after `response.json()`, read the inner status via `publisherStatus(result)`. On 408, take the same `RETRY_DELAYS_MS = [10_000, 20_000]` backoff the transport-408 branch uses; on any other 4xx/5xx inner status, throw `Notes API returned <status>` without attempting to extract an id from an error envelope.

- Cost: ~+30s wall-clock on the first click after a cold start (one upstream timeout + 10s sleep + one warm request). Probed `notes.serendb.com` twice during this audit — 364ms / 323ms once warm — so subsequent clicks return immediately.

## Test plan
- [x] `pnpm vitest run tests/unit/save-to-notes-inner-408-retry.test.ts` — 2/2 (cold-start envelope → retry → success; three-attempts-408 → "Seren Notes timed out", no external link opened)
- [x] `pnpm vitest run tests/unit/save-to-notes-extract-id.test.ts tests/unit/publisher-response.test.ts` — 10/10 still pass
- [x] `biome check src/lib/save-to-notes.ts` clean
- [ ] Manual: click Download Chat in AgentChat after the SerenNotes publisher has been idle long enough to scale to zero; expect a ~30s pause then `https://notes.serendb.com/notes/<uuid>` to open

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
