### PR TITLE
fix(updater): close #1794 - acknowledgement modal + log breadcrumbs

### DIFF
--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -1,4 +1,5 @@
 import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { message } from "@tauri-apps/plugin-dialog";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type DownloadEvent } from "@tauri-apps/plugin-updater";
 import { createStore } from "solid-js/store";
@@ -63,7 +64,7 @@ async function initUpdater(): Promise<void> {
   }
 
   if (isDevRuntime()) {
-    console.log("[Updater] Dev build — skipping update check");
+    console.info("[Updater] Dev build — skipping update check");
     setState({ status: "unsupported" });
     return;
   }
@@ -72,8 +73,12 @@ async function initUpdater(): Promise<void> {
 
   // Auto-install on startup only (#1720). Mid-session interval re-checks keep
   // today's manual-pill behavior so the user is not forced to restart while
-  // working.
+  // working. The acknowledgement modal (#1794) sets expectations about the
+  // 2–7 minute install window during which Seren is killed and has no UI —
+  // without it users see "app stopped, nothing happens" and assume failure.
+  // OK is the only choice: skipped upgrades mean users on old broken builds.
   if (state.status === "available") {
+    await acknowledgeAutoInstall(state.availableVersion);
     await installAvailableUpdate();
   }
 
@@ -97,11 +102,11 @@ async function checkForUpdates(_manual = false): Promise<void> {
   setState({ status: "checking", error: null });
 
   try {
-    console.log("[Updater] Checking for updates...");
+    console.info("[Updater] Checking for updates...");
     const update = await check();
 
     if (update) {
-      console.log("[Updater] Update available:", update.version);
+      console.info("[Updater] Update available:", update.version);
       pendingUpdate = update;
       setState({
         status: "available",
@@ -110,7 +115,7 @@ async function checkForUpdates(_manual = false): Promise<void> {
         error: null,
       });
     } else {
-      console.log("[Updater] No update available");
+      console.info("[Updater] No update available");
       pendingUpdate = null;
       setState({
         status: "up_to_date",
@@ -129,9 +134,9 @@ async function checkForUpdates(_manual = false): Promise<void> {
 
 async function clearBrowsingDataBeforeRestart(): Promise<void> {
   try {
-    console.log("[Updater] Clearing webview browsing data before restart...");
+    console.info("[Updater] Clearing webview browsing data before restart...");
     await getCurrentWebview().clearAllBrowsingData();
-    console.log("[Updater] Webview browsing data cleared");
+    console.info("[Updater] Webview browsing data cleared");
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
     console.warn(
@@ -142,6 +147,25 @@ async function clearBrowsingDataBeforeRestart(): Promise<void> {
       type: "updater",
       phase: "clear_browsing_data",
     });
+  }
+}
+
+async function acknowledgeAutoInstall(
+  version: string | undefined,
+): Promise<void> {
+  const headline = version
+    ? `Seren is updating to v${version}.`
+    : "Seren is installing an update.";
+  try {
+    await message(
+      `${headline}\n\nThe app will close for ~3 minutes during install, then reopen automatically. Don't worry if the window disappears — it will come back.`,
+      { title: "Update starting", kind: "info", okLabel: "OK" },
+    );
+  } catch (error) {
+    // Dialog plugin failure must not block the install path. Telemetry only.
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.warn("[Updater] Acknowledgement dialog failed:", err.message);
+    telemetry.captureError(err, { type: "updater", phase: "acknowledge" });
   }
 }
 
@@ -159,7 +183,7 @@ async function installAvailableUpdate(): Promise<void> {
     return;
   }
 
-  console.log("[Updater] Starting download and install...");
+  console.info("[Updater] Starting download and install...");
   let downloaded = 0;
   setState({
     status: "downloading",
@@ -174,7 +198,7 @@ async function installAvailableUpdate(): Promise<void> {
       if (progress.event === "Started") {
         const total = progress.data.contentLength ?? 0;
         if (total > 0) {
-          console.log(`[Updater] Download started, size: ${total} bytes`);
+          console.info(`[Updater] Download started, size: ${total} bytes`);
           setState({ totalBytes: total });
         }
         return;
@@ -190,12 +214,12 @@ async function installAvailableUpdate(): Promise<void> {
         return;
       }
 
-      console.log("[Updater] Download finished, installing...");
+      console.info("[Updater] Download finished, installing...");
       setState({ status: "installing", progressPercent: 100 });
     });
-    console.log("[Updater] Install complete");
+    console.info("[Updater] Install complete");
     await clearBrowsingDataBeforeRestart();
-    console.log("[Updater] Relaunching after install...");
+    console.info("[Updater] Relaunching after install...");
     await relaunch();
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
## Summary

- Pre-install acknowledgement modal sets expectations before the silent NSIS install kills `Seren.exe` for 2-7 minutes
- `console.log → console.info` at 11 sites in `updater.store.ts` so the entire updater flow leaves breadcrumbs in production log files
- No new dependencies — uses already-installed `@tauri-apps/plugin-dialog`

## Why

User log analysis on #1794 (Mayo's 17.6k-line log) showed:

| Question | Answer |
| -------- | ------ |
| Is the updater functionally broken on this user? | No — 51 successful auto-updates over Feb-May |
| What's the user-visible symptom? | NSIS preinstall hook kills Seren.exe → 2-7 minute silent install gap → relaunch fires |
| Why couldn't we see updater progress in the log file? | `tauri-plugin-log` filters `console.log` (mapped to debug) at Info release level, so 51 auto-updates left zero breadcrumbs |

Root cause: a UX gap, not a functional bug. Users see the app vanish, nothing happens for several minutes, conclude updater is broken — when in fact `RunAsUser` does relaunch within 130-400 seconds.

## Changes

**1. Acknowledgement modal** (`src/stores/updater.store.ts:80-83`, helper at `:153-171`)

Before calling `installAvailableUpdate()` from the auto-startup path, show a one-button OK modal:

> Seren is updating to v3.28.4.
>
> The app will close for ~3 minutes during install, then reopen automatically. Don't worry if the window disappears — it will come back.

Per Taariq's direction: **OK is the only choice**. Skipped upgrades leave users on broken builds; the modal is informational, not gating. Wrapped in try/catch so a dialog plugin failure cannot block the install path.

Manual install path (Titlebar Update pill → `installAvailableUpdate`) is unchanged — user already clicked, no need to re-confirm.

**2. Production-log observability** (11 sites, lines 66, 100, 104, 113, 132, 134, 162, 177, 193, 196, 198)

Mechanical `console.log → console.info` rename. After this, every future updater run leaves a breadcrumb trail at `~/AppData/Local/com.serenorg.serendesktop/logs/`:

```
[Updater] Checking for updates...
[Updater] Update available: 3.28.5
[Updater] Starting download and install...
[Updater] Download started, size: 119813456 bytes
[Updater] Download finished, installing...
[Updater] Install complete
[Updater] Relaunching after install...
```

so the next "auto-update broke for me" report is actually diagnosable.

## Test plan

- [x] `pnpm vitest run tests/unit/updater-store.test.ts` — 4 existing tests pass; the auto-install test (#1720) implicitly verifies the modal failure path doesn't block install
- [x] `pnpm test` — full suite (753 tests) green
- [x] `pnpm check src/stores/updater.store.ts` — Biome clean
- [x] `npx vite build` — production bundle builds
- [ ] Post-merge: confirm a real update on Windows shows the new modal and the updater breadcrumbs land in the log file

## Test rationale

No new tests added. Per [CLAUDE.md](https://github.com/serenorg/seren-desktop/blob/main/CLAUDE.md): TDD scoped to security utilities, core business logic (billing/wallet/API), and complex algorithms; "Don't test mocked behavior" forbids testing the plugin-dialog integration. The change is mechanical (log-level rename, semantically identical) plus a Tauri plugin call. The dialog-must-not-block-install safety property is implicitly covered by the existing `initUpdater silently installs an available update on startup` test, which doesn't mock `@tauri-apps/plugin-dialog` and still asserts `downloadAndInstall` + `relaunch` fire after `acknowledgeAutoInstall` runs against a non-Tauri test environment.

## Out of scope (deferred)

Proposal #3 from [the ticket comment](https://github.com/serenorg/seren-desktop/issues/1794#issuecomment-4373308409) — explicit `getCurrentWindow().setFocus()` on relaunch — was speculative and the bundle-hash transition fingerprint in Mayo's logs shows the relaunched window does come up. Will revisit if followup user reports confirm a focus problem.

Closes #1794

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
