### PR TITLE
fix(agent): close #1798 — gate contextWindowSize on [1m] mismatch

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -4501,11 +4501,17 @@ Structured summary:`;
               sess?.info?.agentType ?? "",
               sess?.currentModelId,
             );
-            if (
-              !sess?.contextWindowMismatchReported &&
+            // The denominator of the auto-compact gauge. Mirror of the
+            // cache-layer guard in modelContextCache.ts (#1769) at the
+            // in-memory layer: when the CLI echoes a sub-1M window for a
+            // [1m]-suffixed session, refuse the in-memory overwrite so the
+            // spawn-time 1M denominator survives the whole session. Without
+            // this, compaction fires at ~178K (89% of 200K) instead of
+            // ~890K — exactly 5x too early — for every 1M-tier user. #1798.
+            const isOneMTierMismatch =
               expectedFromPicker > reportedContextWindow &&
-              /\[1m\]$/i.test(sess?.currentModelId ?? "")
-            ) {
+              /\[1m\]$/i.test(sess?.currentModelId ?? "");
+            if (isOneMTierMismatch && !sess?.contextWindowMismatchReported) {
               setState(
                 "sessions",
                 sessionId,
@@ -4523,23 +4529,25 @@ Structured summary:`;
                 },
               });
             }
-            setState(
-              "sessions",
-              sessionId,
-              "contextWindowSize",
-              reportedContextWindow,
-            );
-            // Persist (provider, modelId) -> contextWindow so next spawn of
-            // this model starts with the correct value instead of the
-            // agent-type default. Fire-and-forget; failures are non-fatal.
-            const modelKey = sess?.currentModelId;
-            const provider = sess?.info?.agentType;
-            if (modelKey && provider) {
-              void recordModelContextWindow(
-                provider,
-                modelKey,
+            if (!isOneMTierMismatch) {
+              setState(
+                "sessions",
+                sessionId,
+                "contextWindowSize",
                 reportedContextWindow,
               );
+              // Persist (provider, modelId) -> contextWindow so next spawn of
+              // this model starts with the correct value instead of the
+              // agent-type default. Fire-and-forget; failures are non-fatal.
+              const modelKey = sess?.currentModelId;
+              const provider = sess?.info?.agentType;
+              if (modelKey && provider) {
+                void recordModelContextWindow(
+                  provider,
+                  modelKey,
+                  reportedContextWindow,
+                );
+              }
             }
           }
           if (inputTokens != null) {

--- a/tests/unit/agent-store-context-window-tier-guard.test.ts
+++ b/tests/unit/agent-store-context-window-tier-guard.test.ts
@@ -1,0 +1,64 @@
+// ABOUTME: Critical guard for #1798 — the in-memory contextWindowSize write
+// ABOUTME: in promptComplete must skip on a [1m]-tier mismatch so the spawn-time 1M denominator survives.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1798 — in-memory contextWindowSize tier-guard", () => {
+  // Pre-#1798: agent.store.ts:4526 wrote
+  //   setState("sessions", sessionId, "contextWindowSize", reportedContextWindow)
+  // unconditionally any time meta.contextWindow > 0. The tier-mismatch
+  // predicate immediately above only triggered captureSupportError. So a
+  // [1m]-suffixed session that started with a correctly-resolved 1M window
+  // got clobbered to 200K on the first promptComplete because the CLI's
+  // bare-id echoback in modelUsage falls through inferClaudeContextWindow
+  // to 200K — auto-compaction then fired at ~178K (89% of 200K) instead of
+  // the intended ~890K, exactly 5x too early. The cache-layer guard from
+  // #1769 only prevented persistence; the in-memory state was already
+  // poisoned for the rest of the session.
+
+  it("declares an isOneMTierMismatch predicate that combines the picker-vs-CLI gap with the [1m] suffix check", () => {
+    // The predicate must be hoisted out of the support-capture block so
+    // both the in-memory write and the cache call can read it. If a future
+    // refactor inlines it back into the captureSupportError gate, the
+    // unconditional overwrite returns and #1798 reopens.
+    expect(agentStoreSource).toMatch(
+      /const\s+isOneMTierMismatch\s*=\s*[\s\S]{0,200}expectedFromPicker\s*>\s*reportedContextWindow[\s\S]{0,200}\/\\\[1m\\\]\$\/i\.test\(/,
+    );
+  });
+
+  it("guards the in-memory contextWindowSize setState behind !isOneMTierMismatch and pulls the recordModelContextWindow call into the same branch", () => {
+    // Both the in-memory write (the actual auto-compact denominator) AND
+    // the cache write must skip on tier mismatch. The cache layer at
+    // modelContextCache.ts:50 also refuses, but having the agent.store
+    // skip the call avoids the redundant captureSupportError path the
+    // cache layer fires when refusing — keeping the in-store
+    // contextWindowMismatchReported gate as the single source of truth.
+    const anchor = "if (!isOneMTierMismatch) {";
+    const idx = agentStoreSource.indexOf(anchor);
+    expect(idx).toBeGreaterThan(0);
+    const region = agentStoreSource.slice(idx, idx + 800);
+    expect(region).toMatch(
+      /setState\([\s\S]{0,80}"contextWindowSize"[\s\S]{0,80}reportedContextWindow/,
+    );
+    expect(region).toMatch(/recordModelContextWindow\(/);
+  });
+
+  it("does not contain an unconditional setState contextWindowSize call outside the tier-mismatch gate", () => {
+    // Regression sentinel: a future edit that re-introduces the
+    // unconditional overwrite (the exact pre-#1798 shape) must fail this
+    // assertion. The pre-fix shape was the literal block:
+    //   setState("sessions", sessionId, "contextWindowSize", reportedContextWindow)
+    // sitting at the top level of the `if (reportedContextWindow > 0)`
+    // block, immediately following the captureSupportError closing brace.
+    const preFixShape =
+      /\}\s*\n\s*setState\(\s*\n\s*"sessions",\s*\n\s*sessionId,\s*\n\s*"contextWindowSize",\s*\n\s*reportedContextWindow,\s*\n\s*\);/;
+    expect(agentStoreSource).not.toMatch(preFixShape);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #1798. The auto-compact gauge denominator (`state.sessions[sessionId].contextWindowSize`) was being clobbered from 1M to 200K on the first `promptComplete` for every `[1m]`-tier session, firing compaction at ~178K (89% of 200K) instead of ~890K — exactly 5x too early. Lifts the existing tier-mismatch predicate at `agent.store.ts:4504-4525` out of the support-capture gate into a top-level `isOneMTierMismatch` const, then uses it to gate both the in-memory `setState("contextWindowSize", ...)` and the `recordModelContextWindow` cache call. Capture-once support ticket logic is preserved exactly as-is.
- Three prior fixes (#1700, #1733, #1761, #1769) all bandaged downstream layers — picker routing, cache persistence, support telemetry — and left the in-memory denominator overwrite untouched. The audit on #1798 walks each one.
- Side audit captured in the issue: two compounding failure modes silenced the support ticket #1761 added — browser-local mode requires an API key for `submitPayload`, and `rememberSignature` consumes the dedup slot even on submit failure. Out of scope for this PR; tracked as follow-ups.

## Test plan
- [x] `pnpm test tests/unit/agent-store-context-window-tier-guard.test.ts` — 3/3 pass
- [x] Related cluster passes: `pnpm test tests/unit/model-context-cache-tier-guard.test.ts tests/unit/auto-compact-predictive.test.ts tests/unit/compaction-auth-gate.test.ts tests/unit/predictive-compact-spawn-fixes.test.ts tests/unit/agent-predictive-compaction.test.ts` — 50/50 pass
- [x] `pnpm check src/stores/agent.store.ts tests/unit/agent-store-context-window-tier-guard.test.ts` — clean
- [ ] Post-merge: verify in browser-local that a real `claude-opus-4-7[1m]` session no longer compacts at ~178K. Expected behavior: gauge sits at ~17% after the same workload that previously hit 89%.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
