### PR TITLE
fix(agent): close #1800 — summary cannot fabricate completed state

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2923,14 +2923,23 @@ export const agentStore = {
 
       // Generate a structured summary via Gateway API (not via the agent —
       // its context is what's overloaded). Uses a hard-capped schema to keep
-      // the summary under 200 tokens, down from ~700 with freeform "500 words".
+      // the summary under ~200 tokens, down from ~700 with freeform "500 words".
       // This reduces prompt tokens on every subsequent call by ~70%.
-      const summaryPrompt = `Summarize this AI agent conversation into EXACTLY this structured format. Each field must be 1-2 short sentences max. Total output must be under 150 tokens.
+      //
+      // #1800 — anti-fabrication: the prior single-bucket state field and
+      // unconstrained file-mention field invited the model to collapse
+      // intent expressed during the conversation into claims about
+      // completed artifacts on disk. Replace them with explicit
+      // evidence-bucketed fields and require an explicit "none" when empty,
+      // so the model can no longer satisfy the template shape with
+      // confabulations. The `NEXT:` agent-action wording from #1733 is kept.
+      const summaryPrompt = `Summarize this AI agent conversation into EXACTLY this structured format. Each field must be 1-2 short sentences max. Total output must be under 200 tokens. If a field has nothing to report, write 'none' — DO NOT invent content to fill the shape.
 
 GOAL: <what the user is trying to accomplish>
-FILES: <files created or modified, comma-separated paths only>
+FILES_TOUCHED: <files actually created or modified by tool calls executed in this conversation; comma-separated paths only; write 'none' if no file-mutating tool call ran>
 DECISIONS: <key technical decisions made>
-STATE: <what is done vs in progress>
+DONE: <only items with explicit verifiable artifacts; format 'item — at <path or db.table>'; write 'none' if no artifact has been produced>
+DISCUSSED_NOT_DONE: <intent statements, plans, todos with no artifact yet; write 'none' if everything discussed has been done>
 NEXT: <what the agent should do next to continue the work>
 
 Conversation:
@@ -2959,6 +2968,15 @@ Structured summary:`;
           throw firstErr;
         }
       }
+
+      // Post-generation verify-before-acting banner. Travels with `summary`
+      // itself so BOTH downstream consumers carry it: the seed-prompt path
+      // a few lines below AND the synthetic-transcript JSONL path that
+      // `buildSyntheticTranscript()` writes to disk. A banner placed only
+      // on the seedPrompt would miss the synthetic path entirely (which is
+      // the default for claude-code agents, gated by
+      // `compactSyntheticTranscript`). #1800.
+      summary = `${summary.trim()}\n\nVERIFY-BEFORE-ACTING: Files, projects, and databases mentioned above may not exist on disk. Re-read the workspace, list .worktrees/, and resolve SerenDB projects/tables before acting on any claim.`;
 
       const compactedSummary: AgentCompactedSummary = {
         content: summary,

--- a/tests/unit/agent-store-summary-anti-fabrication.test.ts
+++ b/tests/unit/agent-store-summary-anti-fabrication.test.ts
@@ -1,0 +1,100 @@
+// ABOUTME: Critical guard for #1800 — the compaction summary template must
+// ABOUTME: separate done-vs-discussed AND the post-generation banner must travel with `summary` so both consumer paths inherit it.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+// Slice the agent.store source forward from a fixed anchor and return a
+// window large enough to contain the compactAgentConversation body.
+function regionAfter(anchor: string, len = 4000): string {
+  const idx = agentStoreSource.indexOf(anchor);
+  if (idx < 0) {
+    throw new Error(`anchor not found in agent.store.ts: ${anchor}`);
+  }
+  return agentStoreSource.slice(idx, idx + len);
+}
+
+describe("#1800 — compaction summary cannot fabricate completed state", () => {
+  // Pre-#1800: the template carried `STATE: <what is done vs in progress>`
+  // and `FILES: <files created or modified>` with no evidence constraint.
+  // The Sonnet 4 summarizer collapsed intent expressed during the
+  // conversation into claims about completed artifacts on disk — observed
+  // in #1797 where a session that had only DISCUSSED Day 1 work produced
+  // "Day 1 complete - tracking infrastructure ready, 12 YouTube URLs
+  // approved, yt-dlp installed, bad synthetic data purged" along with
+  // FILES: paths to a journal and SerenDB project that did not exist.
+  // The post-compaction agent then trusted the summary, skipped
+  // re-verification, and started spending against external paid services
+  // on the assumption that prerequisite artifacts already existed.
+
+  it("template buckets state into DONE and DISCUSSED_NOT_DONE with explicit artifact-path requirement", () => {
+    const region = regionAfter("async compactAgentConversation(", 6000);
+    // The two new evidence-bucketed fields must both be present.
+    expect(region).toMatch(/DONE:/);
+    expect(region).toMatch(/DISCUSSED_NOT_DONE:/);
+    // The DONE: field must require a verifiable artifact path/table — not
+    // just a freeform claim. If a future edit relaxes the format clause
+    // back to e.g. `DONE: <items completed>`, the gauge regresses.
+    expect(region).toMatch(
+      /DONE:\s*<only items with explicit verifiable artifacts/,
+    );
+    // The bare `STATE:` field that invited the failure mode must not
+    // come back. We match the exact pre-#1800 shape so that legitimate
+    // future field names containing "STATE" (e.g. AGENT_STATE) are not
+    // false-positives.
+    expect(region).not.toMatch(/STATE:\s*<what is done vs in progress>/);
+  });
+
+  it("template buckets file mentions into FILES_TOUCHED with a tool-call evidence constraint", () => {
+    const region = regionAfter("async compactAgentConversation(", 6000);
+    // FILES_TOUCHED must explicitly tie its scope to tool calls executed
+    // in the conversation, not the looser pre-#1800 wording that allowed
+    // the model to count "discussed" or "proposed" files as touched.
+    expect(region).toMatch(
+      /FILES_TOUCHED:\s*<files actually created or modified by tool calls/,
+    );
+    // The pre-#1800 unconstrained `FILES: <files created or modified` line
+    // must not be reintroduced.
+    expect(region).not.toMatch(/FILES:\s*<files created or modified/);
+  });
+
+  it("template instructs the model to write 'none' for empty fields instead of fabricating to fill the shape", () => {
+    // Without this instruction the model fills empty fields with
+    // confabulations to satisfy the template shape — which is exactly
+    // how a session that had done nothing produced "Day 1 complete" in
+    // the #1797 repro.
+    const region = regionAfter("async compactAgentConversation(", 6000);
+    expect(region).toMatch(
+      /If a field has nothing to report, write 'none' — DO NOT invent content/,
+    );
+  });
+
+  it("verify-before-acting banner is appended to `summary` BEFORE assignment to compactedSummary, so both seed-prompt and synthetic-transcript paths inherit it", () => {
+    // Both consumer paths read `summary` after this point: the seed
+    // prompt embeds it as `${summary}` (consumed by the legacy predictive
+    // and reactive respawn paths), and `buildSyntheticTranscript()`
+    // receives it as the third arg (consumed by the synthetic-transcript
+    // path that is the default for claude-code agents). Mutating
+    // `summary` itself is the only single-edit position that covers both
+    // — a banner placed only on seedPrompt would miss the synthetic path
+    // entirely. This test pins both the banner content and its position
+    // relative to the `compactedSummary` assignment.
+    const idx = agentStoreSource.indexOf(
+      "const compactedSummary: AgentCompactedSummary = {",
+    );
+    expect(idx).toBeGreaterThan(0);
+    // Window backwards from the assignment to find the banner write.
+    const preceding = agentStoreSource.slice(Math.max(0, idx - 1500), idx);
+    expect(preceding).toMatch(/summary\s*=\s*`\$\{summary\.trim\(\)\}/);
+    expect(preceding).toMatch(/VERIFY-BEFORE-ACTING:/);
+    expect(preceding).toMatch(
+      /may not exist on disk[\s\S]{0,200}before acting on any claim/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #1800 (which closes #1797). Auto-compaction summaries were fabricating completed state — collapsing intent expressed during the conversation into claims about completed artifacts on disk. Two coordinated changes in `compactAgentConversation`.
- **Template upgrade.** Replace `STATE: <what is done vs in progress>` and `FILES: <files created or modified>` with explicit evidence-bucketed fields: `DONE: <only items with explicit verifiable artifacts; format 'item — at <path or db.table>'>`, `DISCUSSED_NOT_DONE:`, and `FILES_TOUCHED:` constrained to "files actually created or modified by tool calls executed in this conversation". Both new buckets require an explicit `'none'` when empty so the model cannot satisfy the template shape with confabulations. Token budget bumps from 150 → 200.
- **Verify-before-acting banner.** Appended to `summary` immediately after generation, BEFORE assignment to `compactedSummary`. Position is critical: `summary` flows into both the seed-prompt path AND the synthetic-transcript JSONL path that `buildSyntheticTranscript()` writes to disk. Mutating `summary` itself is the only single-edit position that covers both consumer paths — a banner placed only on the seedPrompt would miss the synthetic path entirely (which is the default for claude-code agents, gated by `compactSyntheticTranscript`).
- Out of scope: workspace re-derivation (deferred — Tauri-only and breaks browser-local). Chat-store compaction template untouched (no fabrication observed there).

## Test plan
- [x] `pnpm test tests/unit/agent-store-summary-anti-fabrication.test.ts` — 4/4 pass
- [x] Compaction-adjacent cluster passes: `pnpm test` on 11 compaction-related test files (predictive-compact-spawn-fixes, compaction-auth-gate, compaction-scrollback, compaction-session-removal-guard, compaction-queue-race, compaction-predictive-soft-fail, auto-compact-predictive, agent-predictive-compaction, predictive-compact-race, predictive-drain-not-blocked, agent-store-context-window-tier-guard) — 75/75 pass
- [x] `pnpm check src/stores/agent.store.ts tests/unit/agent-store-summary-anti-fabrication.test.ts` — clean
- [ ] Post-merge: trigger a real compaction in browser-local against a session with discussed-but-not-done work, verify the summary now shows `DONE: none` / `DISCUSSED_NOT_DONE: <items>` and the post-compaction agent re-verifies file paths before acting.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
