### PR TITLE
fix(test): unbound spawnSession slice in #1625 regression (#1803)

### DIFF
--- a/tests/unit/agent-seren-memory-wiring.test.ts
+++ b/tests/unit/agent-seren-memory-wiring.test.ts
@@ -96,10 +96,16 @@ describe("#1625 — post-compaction re-bootstrap (via spawnSession)", () => {
     expect(compactFnStart, "compactAgentConversation must exist").toBeGreaterThan(
       0,
     );
-    const compactBody = agentStoreSource.slice(
+    // Slice to the next function so growth in compactAgentConversation
+    // doesn't push the spawnSession call past a fixed window.
+    const compactFnEnd = agentStoreSource.indexOf(
+      "async compactAndRetry(",
       compactFnStart,
-      compactFnStart + 8000,
     );
+    expect(compactFnEnd, "compactAndRetry must exist").toBeGreaterThan(
+      compactFnStart,
+    );
+    const compactBody = agentStoreSource.slice(compactFnStart, compactFnEnd);
     expect(compactBody).toContain("await this.spawnSession(");
   });
 });


### PR DESCRIPTION
## Summary

- The #1625 regression test in `tests/unit/agent-seren-memory-wiring.test.ts` source-string-asserts on a fixed 8000-char slice of `compactAgentConversation` looking for `"await this.spawnSession("`. The v3.29.1 batch (#1799 `contextWindowSize` `[1m]` mismatch gate + #1801 summary fabricate-completed guard) added code at the top of the function, pushing the first `spawnSession` call to character offset **8252** — 252 chars past the window. Test went red on `main`.
- Runtime behavior is unchanged — `compactAgentConversation` still calls `this.spawnSession` at four sites; the test was just measuring distance, not behavior.
- Slice from `compactFnStart` to the next function boundary (`compactAndRetry`) instead, so future legitimate growth of `compactAgentConversation` doesn't silently re-break this. Same shape as #1745 from v3.26.0.

Closes #1803. Unblocks the v3.29.1 retag.

## Test plan

- [x] `pnpm vitest run tests/unit/agent-seren-memory-wiring.test.ts` — 8/8 pass locally
- [x] `pnpm test` — 760/760 pass locally (105 files)
- [ ] CI green on this branch
