### PR TITLE
fix(agent): close #1805 — recover from mid-prompt session death

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1127,18 +1127,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                   onClick={() => {
                     const id = activeAgentThread()?.id;
                     if (!id) return;
-                    const ts = agentStore.getThreadState(id);
-                    const text = ts.lastPromptText ?? message.content;
-                    agentStore.clearTurnError(id);
-                    void agentStore.sendPrompt(
-                      text,
-                      ts.lastPromptContext,
-                      {
-                        displayContent: ts.lastPromptDisplay,
-                        docNames: ts.lastPromptDocNames,
-                      },
-                      threadSessionId() ?? undefined,
-                    );
+                    void agentStore.retryLastPrompt(id);
                   }}
                 >
                   Retry

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1367,6 +1367,92 @@ export const agentStore = {
     setState("threadStates", threadId, "turnError", null);
   },
 
+  /**
+   * Re-dispatch the last submitted prompt for a thread. Used by the inline
+   * "Couldn't send. Retry" link after a turn fails (#1631) or after a
+   * mid-prompt session death (#1805). Consolidates retry logic so callers
+   * don't need to know whether the session is still alive.
+   *
+   * Path A — live ready session: dispatch directly via sendPrompt.
+   * Path B — no live session (terminated, removed, or never created):
+   *   resumeAgentConversation respawns from SQLite-persisted history, then
+   *   sendPrompt dispatches against the new session id.
+   */
+  async retryLastPrompt(threadId: string): Promise<void> {
+    const ts = state.threadStates[threadId];
+    if (!ts?.lastPromptText) {
+      console.warn(
+        "[AgentStore] retryLastPrompt: no lastPromptText for thread",
+        threadId,
+      );
+      return;
+    }
+
+    const promptText = ts.lastPromptText;
+    const promptContext = ts.lastPromptContext;
+    const promptDisplay = ts.lastPromptDisplay;
+    const promptDocNames = ts.lastPromptDocNames;
+
+    this.clearTurnError(threadId);
+
+    const live = this.getSessionForConversation(threadId);
+    const liveStatus = live?.info.status;
+    const isUsable =
+      live && liveStatus !== "error" && liveStatus !== "terminated";
+
+    let targetSessionId: string | null | undefined = isUsable
+      ? live.info.id
+      : undefined;
+
+    if (!targetSessionId) {
+      try {
+        targetSessionId = await this.resumeAgentConversation(threadId);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error("[AgentStore] retryLastPrompt: respawn failed:", message);
+        this.setTurnError(threadId, "crash_ceiling", message);
+        return;
+      }
+      if (!targetSessionId) {
+        this.setTurnError(
+          threadId,
+          "crash_ceiling",
+          "Session could not be respawned for retry.",
+        );
+        return;
+      }
+      // resumeAgentConversation returns the conversationId when the session
+      // already exists; for a brand-new spawn the returned id is the new
+      // sessionId. Either way, look up the live session for dispatch.
+      const respawned = this.getSessionForConversation(threadId);
+      if (!respawned) {
+        this.setTurnError(
+          threadId,
+          "crash_ceiling",
+          "Session respawn returned without a live session.",
+        );
+        return;
+      }
+      targetSessionId = respawned.info.id;
+    }
+
+    try {
+      await this.sendPrompt(
+        promptText,
+        promptContext,
+        {
+          displayContent: promptDisplay,
+          docNames: promptDocNames,
+        },
+        targetSessionId,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("[AgentStore] retryLastPrompt: dispatch failed:", message);
+      this.setTurnError(threadId, "crash_ceiling", message);
+    }
+  },
+
   _submitTurnErrorReport(
     threadId: string,
     kind: ErrorKind,
@@ -4945,6 +5031,36 @@ Structured summary:`;
           this.addErrorMessage(sessionId, event.data.error);
         } else {
           this.addErrorMessage(sessionId, event.data.error);
+
+          // Mid-prompt session death — runtime emits one of these strings
+          // when the child process is terminated or exits while a control
+          // request is pending. sendPrompt's catch block at line ~3819 only
+          // fires for synchronous IPC failures; post-dispatch deaths arrive
+          // here as async events and miss the existing recovery path.
+          // Without this branch, session.info.status stays "prompting" and
+          // turnInFlight stays true, so ThinkingStatus runs indefinitely.
+          // Catalog covers all three providers (#1805).
+          const errStr = String(event.data.error);
+          const isSessionDeath =
+            errStr.includes("Session terminated") ||
+            errStr.includes("stopped before request completed") ||
+            errStr.includes("stopped while prompt was active") ||
+            errStr.includes("Worker thread dropped");
+          const deathConvoId = state.sessions[sessionId]?.conversationId;
+          if (
+            isSessionDeath &&
+            deathConvoId &&
+            this.isTurnInFlight(deathConvoId)
+          ) {
+            setState(
+              "sessions",
+              sessionId,
+              "info",
+              "status",
+              "ready" as SessionStatus,
+            );
+            this.setTurnError(deathConvoId, "crash_ceiling", errStr);
+          }
         }
         break;
       }
@@ -5488,6 +5604,26 @@ Structured summary:`;
       if (entry) {
         entry.resolve();
         sessionReadyPromises.delete(sessionId);
+      }
+    }
+
+    // Belt-and-suspenders for the case where session-status: terminated/error
+    // arrives without a paired provider://error event (e.g. no pending control
+    // request at the moment of death). The error-event branch in
+    // handleSessionEvent is the primary detector; this catches the gap.
+    // #1805.
+    if (status === "terminated" || status === "error") {
+      const convoId = state.sessions[sessionId]?.conversationId;
+      if (
+        convoId &&
+        this.isTurnInFlight(convoId) &&
+        !this.getTurnError(convoId)
+      ) {
+        this.setTurnError(
+          convoId,
+          "crash_ceiling",
+          `Session ${status} mid-prompt`,
+        );
       }
     }
   },

--- a/tests/unit/agent-session-died-mid-prompt.test.ts
+++ b/tests/unit/agent-session-died-mid-prompt.test.ts
@@ -1,0 +1,168 @@
+// ABOUTME: Source-level regression tests for #1805 — mid-prompt session death recovery.
+// ABOUTME: Wires runtime-emitted death strings into setTurnError so the inline Retry link surfaces.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
+const claudeRuntimeSource = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+const codexRuntimeSource = readFileSync(
+  resolve("bin/browser-local/providers.mjs"),
+  "utf-8",
+);
+const geminiRuntimeSource = readFileSync(
+  resolve("bin/browser-local/gemini-runtime.mjs"),
+  "utf-8",
+);
+
+describe("#1805 — death-string catalog matches what runtimes emit", () => {
+  // The error event handler's session-death detection MUST stay in sync with
+  // the strings the runtimes actually emit. If the runtime adds a new death
+  // path with a different prefix, this test should be the canary.
+
+  it("Claude runtime emits the documented death strings", () => {
+    expect(claudeRuntimeSource).toContain(
+      '"Session terminated before request completed."',
+    );
+    expect(claudeRuntimeSource).toContain(
+      "Claude Code stopped before request completed",
+    );
+    expect(claudeRuntimeSource).toContain(
+      "Claude Code stopped while prompt was active",
+    );
+  });
+
+  it("Codex runtime emits the documented death strings", () => {
+    expect(codexRuntimeSource).toContain(
+      '"Codex App Server stopped before request completed."',
+    );
+    expect(codexRuntimeSource).toContain(
+      '"Worker thread dropped while prompt was active."',
+    );
+    expect(codexRuntimeSource).toContain(
+      '"Session terminated before request completed."',
+    );
+  });
+
+  it("Gemini runtime emits the documented death strings", () => {
+    expect(geminiRuntimeSource).toContain(
+      '"Gemini agent stopped before request completed."',
+    );
+    expect(geminiRuntimeSource).toContain(
+      '"Session terminated before request completed."',
+    );
+  });
+});
+
+describe("#1805 — error event handler detects mid-prompt session death", () => {
+  it("matches the four substring patterns covering all three providers", () => {
+    expect(agentStoreSource).toContain('errStr.includes("Session terminated")');
+    expect(agentStoreSource).toContain(
+      'errStr.includes("stopped before request completed")',
+    );
+    expect(agentStoreSource).toContain(
+      'errStr.includes("stopped while prompt was active")',
+    );
+    expect(agentStoreSource).toContain(
+      'errStr.includes("Worker thread dropped")',
+    );
+  });
+
+  it("only triggers when turnInFlight is true for the conversation", () => {
+    const detect = agentStoreSource.indexOf("isSessionDeath");
+    expect(detect).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(detect, detect + 1500);
+    expect(body).toContain("this.isTurnInFlight(deathConvoId)");
+  });
+
+  it("resets session status to ready and routes through setTurnError", () => {
+    const detect = agentStoreSource.indexOf("isSessionDeath");
+    expect(detect).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(detect, detect + 1500);
+    expect(body).toContain('"ready" as SessionStatus');
+    expect(body).toContain(
+      'this.setTurnError(deathConvoId, "crash_ceiling"',
+    );
+  });
+});
+
+describe("#1805 — handleStatusChange safety net", () => {
+  it("fires when status becomes terminated/error while turnInFlight is true", () => {
+    // Belt-and-suspenders for the case where session-status arrives without
+    // a paired provider://error event.
+    const idx = agentStoreSource.indexOf(
+      "Belt-and-suspenders for the case where session-status",
+    );
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 800);
+    expect(body).toContain('status === "terminated" || status === "error"');
+    expect(body).toContain("this.isTurnInFlight(convoId)");
+    expect(body).toContain("!this.getTurnError(convoId)");
+    expect(body).toMatch(
+      /this\.setTurnError\(\s*convoId,\s*"crash_ceiling"/,
+    );
+  });
+});
+
+describe("#1805 — retryLastPrompt consolidator", () => {
+  it("is a public async method on agentStore", () => {
+    expect(agentStoreSource).toContain("async retryLastPrompt(threadId: string)");
+  });
+
+  it("bails when no lastPromptText is recorded", () => {
+    const idx = agentStoreSource.indexOf("async retryLastPrompt(threadId");
+    const body = agentStoreSource.slice(idx, idx + 3000);
+    expect(body).toContain("ts?.lastPromptText");
+    expect(body).toMatch(/no lastPromptText for thread/);
+  });
+
+  it("clears prior turnError before dispatching", () => {
+    const idx = agentStoreSource.indexOf("async retryLastPrompt(threadId");
+    const body = agentStoreSource.slice(idx, idx + 3000);
+    expect(body).toContain("this.clearTurnError(threadId)");
+  });
+
+  it("dispatches against the live session when one is usable", () => {
+    const idx = agentStoreSource.indexOf("async retryLastPrompt(threadId");
+    const body = agentStoreSource.slice(idx, idx + 3000);
+    expect(body).toContain("this.getSessionForConversation(threadId)");
+    expect(body).toContain('liveStatus !== "error" && liveStatus !== "terminated"');
+  });
+
+  it("falls back to resumeAgentConversation when no live session exists", () => {
+    const idx = agentStoreSource.indexOf("async retryLastPrompt(threadId");
+    const body = agentStoreSource.slice(idx, idx + 3000);
+    expect(body).toContain("this.resumeAgentConversation(threadId)");
+  });
+
+  it("re-arms turnError on dispatch failure so the user can retry again", () => {
+    const idx = agentStoreSource.indexOf("async retryLastPrompt(threadId");
+    const body = agentStoreSource.slice(idx, idx + 3000);
+    expect(body).toContain('this.setTurnError(threadId, "crash_ceiling"');
+  });
+});
+
+describe("#1805 — Retry button uses retryLastPrompt", () => {
+  it("delegates to agentStore.retryLastPrompt(activeAgentThread().id)", () => {
+    expect(agentChatSource).toContain("agentStore.retryLastPrompt(");
+    // No leftover direct sendPrompt call from the inline retry click handler.
+    // The retry click handler block must not contain the old direct dispatch.
+    const idx = agentChatSource.indexOf("Couldn't send.");
+    expect(idx).toBeGreaterThan(0);
+    const block = agentChatSource.slice(idx, idx + 1500);
+    expect(block).toContain("agentStore.retryLastPrompt(");
+    expect(block).not.toContain("ts.lastPromptText");
+  });
+});

--- a/tests/unit/agent-turn-error.test.ts
+++ b/tests/unit/agent-turn-error.test.ts
@@ -71,10 +71,17 @@ describe("#1631 — inline error bubble + retry link", () => {
     expect(agentChatSource).toMatch(/>\s*Retry\s*<\/button>/);
   });
 
-  it("retry link re-calls sendPrompt with the stored last-prompt record", () => {
-    expect(agentChatSource).toContain("agentStore.clearTurnError(");
-    expect(agentChatSource).toContain("agentStore.sendPrompt(");
-    expect(agentChatSource).toContain("ts.lastPromptText");
+  it("retry link delegates to retryLastPrompt consolidator (#1805)", () => {
+    expect(agentChatSource).toContain("agentStore.retryLastPrompt(");
+  });
+
+  it("retryLastPrompt resends the stored last-prompt record", () => {
+    const idx = agentStoreSource.indexOf("async retryLastPrompt(threadId");
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 3000);
+    expect(body).toContain("ts.lastPromptText");
+    expect(body).toContain("this.clearTurnError(threadId)");
+    expect(body).toContain("this.sendPrompt(");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1805. When the agent provider runtime SIGTERMs its child mid-prompt, the runtime emits an async `provider://error` event whose body falls into the unmatched else-branch in `case "error"` at `src/stores/agent.store.ts:4946-4948`. That branch only appends an error chat bubble — it does not reset session status, clear `turnInFlight`, or surface a Retry link. Result: `ThinkingStatus` ran for 70+ minutes in the field with no upper bound.

Three localized changes wire the session-death path through the existing `#1631` `setTurnError` + inline-Retry infrastructure:

- **Death detection in the error event handler.** Match `Session terminated`, `stopped before request completed`, `stopped while prompt was active`, `Worker thread dropped` — full catalog across Claude, Codex, Gemini. On match, reset session status to `ready` and call `setTurnError(convoId, "crash_ceiling", errStr)`. Reuse `crash_ceiling` rather than adding a new `ErrorKind`.
- **handleStatusChange safety net.** When status becomes `terminated`/`error` while `turnInFlight=true` and no `turnError` is set, fire `setTurnError` with `crash_ceiling`. Catches the gap where status arrives without a paired error event.
- **`retryLastPrompt(threadId)` consolidator.** New public method that reads `lastPromptText` from `threadStates`, dispatches against the live session if usable, otherwise respawns via `resumeAgentConversation` and dispatches against the new session id. Inline Retry button rewires from raw `sendPrompt` to this method, so clicking Retry after a session death actually works.

## Audit

Verified against the full death-string catalog by reading every `rejectPendingControlRequests` / `rejectCurrentPrompt` callsite in `bin/browser-local/{claude-runtime,providers,gemini-runtime}.mjs`. Confirmed no overlap with existing `case "error"` predicates (`isTimeoutError`, `isPromptTooLongError`, `isRateLimitError`, `Task cancelled`, `unresponsive`, `Permission request timed out`, `Reconnecting`).

Considered Option A (keep dead-session skeleton in `state.sessions`). Rejected: would touch 15+ iterators of `state.sessions`, two of which are actively dangerous — `getIdleClaudeSessionIds` (would loop on terminated skeletons) and `terminateSession`'s `remainingIds[0]` active-session picker. Option B's consolidator localizes the fix to one new method.

## Test plan

- [x] `pnpm vitest run tests/unit/agent-session-died-mid-prompt.test.ts tests/unit/agent-turn-error.test.ts` — 25 tests pass.
- [x] `pnpm test` — full suite, 775 tests, 106 files, all pass.
- [x] `pnpm biome check` on touched files — no new errors.
- [x] `pnpm tsc --noEmit` — no errors in touched files (one pre-existing error in `tests/unit/updater-store.test.ts` from #1721, unrelated).

## Out of scope

Already-wedged threads (the original bug repro at 70+ minutes) — their error event already arrived and was discarded. Cancel still unsticks them. A separate watchdog (`recoverWedgedThread` after N minutes of `turnInFlight=true` with no streamed chunks) belongs in its own ticket.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
