### PR TITLE
fix(agent): close #1807 — strip CLI scaffolding from assistant turns

### DIFF
--- a/src/lib/scrub-agent-markup.ts
+++ b/src/lib/scrub-agent-markup.ts
@@ -1,0 +1,23 @@
+// ABOUTME: Strip Claude Code CLI scaffolding tags from model output before
+// ABOUTME: persistence, rendering, and Seren memory storage. #1807.
+
+const PATTERNS: RegExp[] = [
+  /<system-reminder>[\s\S]*?<\/system-reminder>/g,
+  /<command-(message|name|args)>[\s\S]*?<\/command-\1>/g,
+];
+
+/**
+ * Remove Claude Code scaffolding tags that the model occasionally echoes into
+ * its assistant text. Persisting them poisons the JSONL transcript and Seren
+ * memory, which makes the model continue extending the pattern on subsequent
+ * turns. `<command-stdout>` / `<local-command-stdout>` are intentionally
+ * preserved — they are legitimate captured shell output.
+ */
+export function scrubAgentMarkup(text: string): string {
+  if (!text) return text;
+  let result = text;
+  for (const pattern of PATTERNS) {
+    result = result.replace(pattern, "");
+  }
+  return result.replace(/\n{3,}/g, "\n\n").trim();
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -234,6 +234,7 @@ import {
   isTimeoutError,
   performAgentFallback,
 } from "@/lib/rate-limit-fallback";
+import { scrubAgentMarkup } from "@/lib/scrub-agent-markup";
 import { captureSupportError } from "@/lib/support/hook";
 import {
   clearConversationHistory,
@@ -5329,16 +5330,19 @@ Structured summary:`;
       setState("sessions", sessionId, "streamingThinkingTimestamp", undefined);
     }
     if (session.streamingContent) {
-      const contentMsg: AgentMessage = {
-        id: crypto.randomUUID(),
-        type: "assistant",
-        content: session.streamingContent,
-        timestamp: session.streamingContentTimestamp ?? Date.now(),
-      };
-      setState("sessions", sessionId, "messages", (msgs) => [
-        ...msgs,
-        contentMsg,
-      ]);
+      const scrubbed = scrubAgentMarkup(session.streamingContent);
+      if (scrubbed) {
+        const contentMsg: AgentMessage = {
+          id: crypto.randomUUID(),
+          type: "assistant",
+          content: scrubbed,
+          timestamp: session.streamingContentTimestamp ?? Date.now(),
+        };
+        setState("sessions", sessionId, "messages", (msgs) => [
+          ...msgs,
+          contentMsg,
+        ]);
+      }
       // Do NOT persist this intermediate flush — it captures partial streaming
       // text (often raw file contents from tool results) that would pollute
       // the restored conversation history on restart. Only
@@ -5678,6 +5682,20 @@ Structured summary:`;
         return;
       }
 
+      // Strip Claude Code scaffolding tags (<system-reminder>, <command-*>)
+      // before persisting or rendering. The model occasionally echoes those
+      // tags into its assistant text when a CLI skill (e.g. /loop) is active;
+      // letting them through pollutes the JSONL transcript and Seren memory,
+      // which makes the model continue extending the pattern on every
+      // subsequent turn. #1807.
+      const scrubbed = scrubAgentMarkup(session.streamingContent);
+      if (scrubbed.length === 0) {
+        setState("sessions", sessionId, "streamingContent", "");
+        setState("sessions", sessionId, "streamingContentTimestamp", undefined);
+        setState("sessions", sessionId, "promptStartTime", undefined);
+        return;
+      }
+
       // Calculate duration if we have a start time
       const duration = session.promptStartTime
         ? Date.now() - session.promptStartTime
@@ -5686,7 +5704,7 @@ Structured summary:`;
       const message: AgentMessage = {
         id: crypto.randomUUID(),
         type: "assistant",
-        content: session.streamingContent,
+        content: scrubbed,
         timestamp: session.streamingContentTimestamp ?? Date.now(),
         duration,
       };
@@ -5696,7 +5714,7 @@ Structured summary:`;
         "conversationId:",
         session.conversationId,
         "content:",
-        session.streamingContent.slice(0, 50),
+        scrubbed.slice(0, 50),
       );
       setState("sessions", sessionId, "messages", (msgs) => [...msgs, message]);
       if (session.conversationId)
@@ -5709,10 +5727,9 @@ Structured summary:`;
       if (
         !isReplay &&
         settingsStore.settings.memoryEnabled &&
-        session.streamingContent.trim().length > 0 &&
-        !isLikelyAuthError(session.streamingContent)
+        !isLikelyAuthError(scrubbed)
       ) {
-        storeAssistantResponse(session.streamingContent, {
+        storeAssistantResponse(scrubbed, {
           model: `agent:${session.info.agentType}`,
           userQuery: session.lastUserPrompt,
         }).catch((err) => {
@@ -5723,8 +5740,8 @@ Structured summary:`;
       // If the agent streamed a short auth error as text, surface it as a session error
       // so the error banner with the Login button appears. Long messages are skipped
       // to avoid false positives when the agent discusses auth topics in normal output.
-      if (isLikelyAuthError(session.streamingContent)) {
-        setState("sessions", sessionId, "error", session.streamingContent);
+      if (isLikelyAuthError(scrubbed)) {
+        setState("sessions", sessionId, "error", scrubbed);
       }
 
       // Prompt-too-long is detected exclusively from the CLI's structured

--- a/tests/unit/agent-scrub-wiring.test.ts
+++ b/tests/unit/agent-scrub-wiring.test.ts
@@ -1,0 +1,71 @@
+// ABOUTME: Source-string wiring assertions for #1807 — the scrubber must run
+// ABOUTME: at every assistant-message construction site and at the memory call.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+describe("#1807 — scrubAgentMarkup is wired into agent.store.ts", () => {
+  it("agent.store.ts imports scrubAgentMarkup", () => {
+    expect(agentStoreSource).toContain(
+      'import { scrubAgentMarkup } from "@/lib/scrub-agent-markup"',
+    );
+  });
+
+  it("finalizeStreamingContent scrubs streamingContent before constructing the assistant message", () => {
+    const fnStart = agentStoreSource.indexOf(
+      "finalizeStreamingContent(sessionId: string",
+    );
+    expect(fnStart, "finalizeStreamingContent must exist").toBeGreaterThan(0);
+    const fnSlice = agentStoreSource.slice(fnStart, fnStart + 6000);
+    expect(fnSlice).toContain("scrubAgentMarkup(session.streamingContent)");
+    // The persisted message must be built from the scrubbed value.
+    const messageBlock = fnSlice.slice(
+      fnSlice.indexOf("const message: AgentMessage = {"),
+      fnSlice.indexOf("setState(\"sessions\", sessionId, \"messages\", (msgs) => [...msgs, message]);"),
+    );
+    expect(messageBlock).toContain("content: scrubbed,");
+    expect(messageBlock).not.toContain("content: session.streamingContent,");
+  });
+
+  it("finalizeStreamingContent drops the message when scrubbed content is empty", () => {
+    const fnStart = agentStoreSource.indexOf(
+      "finalizeStreamingContent(sessionId: string",
+    );
+    const fnSlice = agentStoreSource.slice(fnStart, fnStart + 6000);
+    // An early-return on length===0 prevents an empty bubble from rendering
+    // and keeps Seren memory from receiving a blank assistant turn.
+    expect(fnSlice).toMatch(/scrubbed\.length\s*===\s*0/);
+  });
+
+  it("storeAssistantResponse is called with the scrubbed content, not the raw streamingContent", () => {
+    const fnStart = agentStoreSource.indexOf(
+      "finalizeStreamingContent(sessionId: string",
+    );
+    const fnSlice = agentStoreSource.slice(fnStart, fnStart + 6000);
+    const memoryCallStart = fnSlice.indexOf("storeAssistantResponse(");
+    expect(memoryCallStart).toBeGreaterThan(0);
+    const memoryCall = fnSlice.slice(memoryCallStart, memoryCallStart + 200);
+    expect(memoryCall).toContain("storeAssistantResponse(scrubbed,");
+  });
+
+  it("handleToolCall intermediate flush scrubs streamingContent before constructing the visible message", () => {
+    const fnStart = agentStoreSource.indexOf(
+      "handleToolCall(sessionId: string, toolCall:",
+    );
+    expect(fnStart, "handleToolCall must exist").toBeGreaterThan(0);
+    const fnSlice = agentStoreSource.slice(
+      fnStart,
+      agentStoreSource.indexOf("handleToolResult(", fnStart),
+    );
+    expect(fnSlice).toContain("scrubAgentMarkup(session.streamingContent)");
+    // The intermediate contentMsg must be built from the scrubbed value too,
+    // and skipped entirely when scrubbing leaves nothing.
+    expect(fnSlice).toContain("content: scrubbed,");
+  });
+});

--- a/tests/unit/scrub-agent-markup.test.ts
+++ b/tests/unit/scrub-agent-markup.test.ts
@@ -1,0 +1,63 @@
+// ABOUTME: Unit tests for the Claude Code scaffolding-tag scrubber. #1807.
+// ABOUTME: Pure string transformation — no mocks, no fixtures.
+
+import { describe, expect, it } from "vitest";
+import { scrubAgentMarkup } from "@/lib/scrub-agent-markup";
+
+describe("scrubAgentMarkup", () => {
+  it("strips a single-line <system-reminder> block", () => {
+    const input = "Hello.\n<system-reminder>do not use tools</system-reminder>\nWorld.";
+    expect(scrubAgentMarkup(input)).toBe("Hello.\n\nWorld.");
+  });
+
+  it("strips a multi-line <system-reminder> block as observed in #1807", () => {
+    const input = [
+      "Resuming.",
+      "<system-reminder>",
+      "You are in the dynamic mode of the loop skill, where there is no",
+      "fixed interval. Use ScheduleWakeup to schedule the next iteration.",
+      "</system-reminder>",
+      "Done.",
+    ].join("\n");
+    expect(scrubAgentMarkup(input)).toBe("Resuming.\n\nDone.");
+  });
+
+  it("strips <command-message>, <command-name>, and <command-args> blocks", () => {
+    const input =
+      "Reply.\n<command-message>loop is running…</command-message>\n<command-name>/loop</command-name>\n<command-args>5m</command-args>\nEnd.";
+    expect(scrubAgentMarkup(input)).toBe("Reply.\n\nEnd.");
+  });
+
+  it("does not collapse mismatched <command-*> open/close pairs", () => {
+    const input = "<command-message>x</command-name>";
+    expect(scrubAgentMarkup(input)).toBe(input);
+  });
+
+  it("preserves <command-stdout> and <local-command-stdout> — those are legitimate captured shell output", () => {
+    const input =
+      "<local-command-stdout>file: build/main.js</local-command-stdout>\n<command-stdout>npm install ok</command-stdout>";
+    expect(scrubAgentMarkup(input)).toBe(input);
+  });
+
+  it("returns an empty string when the input is only scaffolding", () => {
+    const input =
+      "<system-reminder>noop</system-reminder>\n<command-name>/loop</command-name>";
+    expect(scrubAgentMarkup(input)).toBe("");
+  });
+
+  it("leaves normal markdown / code fences untouched", () => {
+    const input = "```ts\nconst x: number = 1;\n```\n\n# Heading\n\n- bullet";
+    expect(scrubAgentMarkup(input)).toBe(input);
+  });
+
+  it("strips multiple system-reminder blocks in the same message", () => {
+    const input =
+      "<system-reminder>a</system-reminder>middle<system-reminder>b</system-reminder>";
+    expect(scrubAgentMarkup(input)).toBe("middle");
+  });
+
+  it("returns the input unchanged when given an empty or whitespace-only string", () => {
+    expect(scrubAgentMarkup("")).toBe("");
+    expect(scrubAgentMarkup("   \n\n  ")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1807. The Claude Code model occasionally echoes its own CLI scaffolding (`<system-reminder>`, `<command-message>`, `<command-name>`, `<command-args>`) into assistant text when a CLI skill (e.g. `/loop`) is active. Today those tags survive into the chat bubble, SQLite, and Seren memory — and on the next turn the model sees them replayed as legitimate prior history and keeps extending the pattern.

This adds `scrubAgentMarkup` and applies it at the two assistant-message construction sites in `agent.store.ts` plus the `storeAssistantResponse` call. If scrubbing leaves the message empty, drop it. `<command-stdout>` / `<local-command-stdout>` are intentionally preserved.

## Changes

- `src/lib/scrub-agent-markup.ts` — pure scrubber, two regex patterns.
- `src/stores/agent.store.ts` — wire scrubber into `finalizeStreamingContent` (drops empty results before any persistence) and the `handleToolCall` intermediate flush.
- `tests/unit/scrub-agent-markup.test.ts` — 9 unit tests for the scrubber.
- `tests/unit/agent-scrub-wiring.test.ts` — 5 source-string assertions matching the project's existing wiring-check pattern (`agent-history-persistence.test.ts`, `agent-seren-memory-wiring.test.ts`).

## Test plan

- [x] `pnpm vitest run tests/unit/scrub-agent-markup.test.ts tests/unit/agent-scrub-wiring.test.ts` — 14/14 passing.
- [x] `pnpm test` — 789/789 passing, no regressions.
- [x] `pnpm check src/lib/scrub-agent-markup.ts src/stores/agent.store.ts` — clean.
- [x] `pnpm tsc --noEmit` — only pre-existing error in `tests/unit/updater-store.test.ts` (untouched, present on `main`).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
