### PR TITLE
Revert: quiet balance display and one-shot low-balance modal

### DIFF
--- a/src/components/common/BalanceDisplay.tsx
+++ b/src/components/common/BalanceDisplay.tsx
@@ -29,12 +29,13 @@ export const BalanceDisplay: Component = () => {
     return "normal";
   };
 
+  // Get state-specific classes
   const stateClasses = () => {
     switch (balanceState()) {
       case "critical":
-        return "text-destructive";
+        return "text-destructive border-destructive animate-pulse";
       case "low":
-        return "text-warning";
+        return "text-warning border-warning";
       case "unknown":
         return "text-muted-foreground";
       default:
@@ -63,27 +64,33 @@ export const BalanceDisplay: Component = () => {
     <Show when={showBalance()}>
       <div class="flex items-center gap-1">
         <button
-          type="button"
-          class={`flex items-center gap-1.5 py-1 px-2 bg-transparent border-none rounded-md text-sm font-medium cursor-pointer transition-colors duration-100 hover:bg-surface-2 ${stateClasses()}`}
+          class={`flex items-center gap-1.5 py-1.5 px-3 bg-muted border border-border rounded-md text-sm font-medium cursor-pointer transition-all duration-150 hover:bg-secondary hover:border-secondary ${stateClasses()}`}
           onClick={handleClick}
           title={lastUpdatedText()}
           aria-label={`SerenBucks balance: ${walletStore.formattedBalance}. Click to add funds.`}
         >
-          {/* Refresh is silent - last-known balance stays visible. */}
+          <Show when={walletState.isLoading}>
+            <span class="flex items-center justify-center w-[60px]">
+              <span class="w-3.5 h-3.5 border-2 border-border border-t-primary rounded-full animate-spin" />
+            </span>
+          </Show>
+
           <Show when={!walletState.isLoading && walletState.error}>
             <span class="text-destructive mr-1" title={walletState.error || ""}>
               &#9888;
             </span>
           </Show>
-          <span class="text-base" aria-hidden="true">
-            &#128176;
-          </span>
-          <span class="tabular-nums">{walletStore.formattedBalance}</span>
+
+          <Show when={!walletState.isLoading}>
+            <span class="text-base" aria-hidden="true">
+              &#128176;
+            </span>
+            <span class="tabular-nums">{walletStore.formattedBalance}</span>
+          </Show>
         </button>
 
         <button
-          type="button"
-          class="flex items-center justify-center w-7 h-7 p-0 bg-transparent border-none rounded text-base text-secondary-foreground cursor-pointer transition-colors duration-100 hover:bg-surface-2 hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+          class="flex items-center justify-center w-7 h-7 p-0 bg-transparent border-none rounded text-base text-secondary-foreground cursor-pointer transition-all duration-150 hover:bg-secondary hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
           onClick={handleRefresh}
           title="Refresh balance"
           aria-label="Refresh balance"

--- a/src/components/common/LowBalanceWarning.tsx
+++ b/src/components/common/LowBalanceWarning.tsx
@@ -102,21 +102,34 @@ export const LowBalanceWarning: Component<LowBalanceWarningProps> = (props) => {
   );
 };
 
-/** Modal fires at most once per JS context: invariant for "session". */
-let lowBalanceModalShownThisSession = false;
-
+/**
+ * Low balance modal that shows when balance first drops below threshold.
+ */
 export const LowBalanceModal: Component = () => {
   const [isVisible, setIsVisible] = createSignal(false);
+  const [lastNotifiedBalance, setLastNotifiedBalance] = createSignal<
+    number | null
+  >(null);
 
   const threshold = () => settingsStore.get("lowBalanceThreshold");
 
+  // Show modal when balance drops below threshold for the first time
   createEffect(() => {
-    if (lowBalanceModalShownThisSession) return;
     const balance = walletState.balance;
+    const thresh = threshold();
+    const lastNotified = lastNotifiedBalance();
+
     if (balance === null) return;
-    if (balance < threshold()) {
-      lowBalanceModalShownThisSession = true;
-      setIsVisible(true);
+
+    // Show if balance dropped below threshold and we haven't shown for this level
+    if (balance < thresh) {
+      if (lastNotified === null || balance < lastNotified) {
+        setIsVisible(true);
+        setLastNotifiedBalance(balance);
+      }
+    } else {
+      // Reset when balance goes above threshold
+      setLastNotifiedBalance(null);
     }
   });
 


### PR DESCRIPTION
## Summary
- Reverts 23d5557 (`refactor(wallet): quiet balance display and one-shot low-balance modal`).
- Restores prior `BalanceDisplay` and `LowBalanceWarning` behavior.

## Test plan
- [ ] Wallet panel shows balance with the prior styling (spinner during refresh, bordered figure).
- [ ] Low-balance modal re-pops on each threshold crossing as before.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com