### PR TITLE
fix(chat): unify queued-message UI across Seren, Private, and Agent chats

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -1456,21 +1456,6 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
               onRemove={handleRemoveImage}
               isLoading={isAttaching()}
             />
-            <Show when={messageQueue().length > 0}>
-              <div class="flex items-center gap-2 px-3 py-2 bg-surface-2 border border-border rounded-lg text-xs text-muted-foreground">
-                <span>
-                  {messageQueue().length} message
-                  {messageQueue().length > 1 ? "s" : ""} queued
-                </span>
-                <button
-                  type="button"
-                  class="ml-auto bg-transparent border border-border text-muted-foreground px-2 py-0.5 rounded text-xs cursor-pointer hover:bg-surface-2 hover:text-foreground"
-                  onClick={() => setMessageQueue([])}
-                >
-                  Clear Queue
-                </button>
-              </div>
-            </Show>
             <div class="relative">
               <SlashCommandPopup
                 input={input()}
@@ -1641,6 +1626,19 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                 </Show>
                 <Show when={conversationIsLoading()}>
                   <ThinkingStatus />
+                </Show>
+                <Show when={messageQueue().length > 0}>
+                  <span class="flex items-center gap-2 px-2 py-1 bg-surface-2 border border-border rounded text-xs text-muted-foreground">
+                    {messageQueue().length} message
+                    {messageQueue().length > 1 ? "s" : ""} queued
+                    <button
+                      type="button"
+                      class="text-destructive hover:underline"
+                      onClick={() => setMessageQueue([])}
+                    >
+                      Clear
+                    </button>
+                  </span>
                 </Show>
                 <Show
                   when={

--- a/tests/unit/queue-indicator-unified.test.ts
+++ b/tests/unit/queue-indicator-unified.test.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Regression test for #1810 — Seren/Private (ChatContent) and Agent
+// ABOUTME: chats must render the queued-message indicator with the same markup.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const chatContentSource = readFileSync(
+  resolve("src/components/chat/ChatContent.tsx"),
+  "utf-8",
+);
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
+const CANONICAL_PILL_CLASSES =
+  "flex items-center gap-2 px-2 py-1 bg-surface-2 border border-border rounded text-xs text-muted-foreground";
+const CANONICAL_CLEAR_CLASSES = "text-destructive hover:underline";
+
+describe("#1810 — queued-message indicator is unified across chat surfaces", () => {
+  it("AgentChat still renders the canonical pill (source of truth)", () => {
+    expect(agentChatSource).toContain(CANONICAL_PILL_CLASSES);
+    expect(agentChatSource).toContain(CANONICAL_CLEAR_CLASSES);
+    expect(agentChatSource).toMatch(/>\s*Clear\s*</);
+  });
+
+  it("ChatContent renders the same canonical pill, not the legacy row", () => {
+    expect(chatContentSource).toContain(CANONICAL_PILL_CLASSES);
+    expect(chatContentSource).toContain(CANONICAL_CLEAR_CLASSES);
+  });
+
+  it("ChatContent no longer ships the divergent legacy markup", () => {
+    // Old full-width row above the textarea — distinguishing tokens that only
+    // appear in the pre-unification block.
+    expect(chatContentSource).not.toContain("Clear Queue");
+    expect(chatContentSource).not.toContain(
+      "ml-auto bg-transparent border border-border text-muted-foreground px-2 py-0.5 rounded text-xs cursor-pointer",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #1810. `ChatContent` (Seren + Private Chat) now renders the same compact pill-style "X message queued / Clear" indicator as `AgentChat`, placed in the bottom controls strip. Removes the divergent full-width row that previously sat above the textarea.
- Drops "Clear Queue" → "Clear" to match AgentChat. Clear handler stays `setMessageQueue([])` (local-signal API unchanged); state source intentionally not unified — visual parity only, smallest reasonable change.
- Adds `tests/unit/queue-indicator-unified.test.ts` — a single source-text regression test that locks both files to the canonical pill markup and forbids the legacy row from coming back.

## Test plan
- [x] `pnpm vitest run tests/unit/queue-indicator-unified.test.ts` — 3/3 pass.
- [x] Full unit suite has no NEW failures vs. main. Two pre-existing failures in `tests/unit/queued-input-history.test.ts` reproduce identically on `bdb87243` and are unrelated to this change — the test's anchor `if (conversationStore.isLoading) {` went stale when the code refactored to `if (conversationIsLoading()) {`. Will file separately.
- [x] `biome check` clean on changed files.
- [ ] Manual visual check: queue indicator appears in the bottom controls strip in Seren chat, Private chat, and Agent chat with identical styling.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
