### PR TITLE
test(chat): repair stale queued-input-history test (#1813)

### DIFF
--- a/tests/unit/queued-input-history.test.ts
+++ b/tests/unit/queued-input-history.test.ts
@@ -1,9 +1,9 @@
 // ABOUTME: Regression test for #1624 — queued prompts must be persisted to
-// ABOUTME: input history so up-arrow recall works.
+// ABOUTME: input history so up-arrow recall works. Reaffirmed after #1813.
 
-import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
 
 const agentChatSource = readFileSync(
   resolve("src/components/chat/AgentChat.tsx"),
@@ -19,16 +19,38 @@ const chatContentSource = readFileSync(
  * runs when the user submits while the agent is still mid-turn (AgentChat) or
  * the conversation is still streaming (ChatContent). Bounded to 40 lines so
  * we don't accidentally match the direct-send path below it.
+ *
+ * Throws on miss: a stale anchor caused by a rename would otherwise mask a
+ * real regression like #1813. Loud failure naming the missing anchor is the
+ * only acceptable behavior here.
  */
 function extractQueueBranch(source: string, anchor: string): string {
   const start = source.indexOf(anchor);
-  if (start < 0) return "";
+  if (start < 0) {
+    throw new Error(
+      `extractQueueBranch: anchor not found in source: ${JSON.stringify(anchor)}. ` +
+        `If the source was renamed (e.g. conversationStore.isLoading → conversationIsLoading()), ` +
+        `update this test's anchor — silent miss would mask a real regression like #1813.`,
+    );
+  }
   const lines = source.slice(start).split("\n").slice(0, 40);
   return lines.join("\n");
 }
 
+/**
+ * Return the index of the first character of `anchor` in `source`, or throw.
+ * Used to assert one block appears upstream of another in the same function.
+ */
+function indexOrThrow(source: string, anchor: string): number {
+  const i = source.indexOf(anchor);
+  if (i < 0) {
+    throw new Error(`anchor not found in source: ${JSON.stringify(anchor)}`);
+  }
+  return i;
+}
+
 describe("#1624 — queued prompts appear in up-arrow input history", () => {
-  it("AgentChat queue branch calls appendInputHistory", () => {
+  it("AgentChat persists inside its queued branch (per-thread state design)", () => {
     const branch = extractQueueBranch(
       agentChatSource,
       "if (isPrompting()) {",
@@ -36,35 +58,56 @@ describe("#1624 — queued prompts appear in up-arrow input history", () => {
     expect(branch, "agent queued branch must exist").toContain(
       "agentStore.enqueuePrompt",
     );
-    // The fix: persist to input history even when the prompt is queued.
     expect(branch).toContain("appendInputHistory");
     expect(branch).toContain("setPersistedInputs");
+    expect(branch).toContain("next.length > 200");
   });
 
-  it("ChatContent queue branch calls appendInputHistory", () => {
+  // ChatContent's design (post-#1810 / post-b48ecd3e) consolidated the
+  // duplicated persist blocks into a single unconditional persist at the top
+  // of sendMessage. Asserting persist lives INSIDE the queue branch (the old
+  // shape) is wrong for this surface — the contract is "persist runs before
+  // the queue branch returns," so queued prompts can't bypass history. This
+  // test locks ordering, not location.
+  it("ChatContent persists before reaching the queued return (#1813)", () => {
+    const persistIdx = indexOrThrow(
+      chatContentSource,
+      "appendInputHistory(convId, trimmed)",
+    );
+    const queueBranchIdx = indexOrThrow(
+      chatContentSource,
+      "if (conversationIsLoading()) {",
+    );
+    expect(
+      persistIdx,
+      "persist block must appear before the queued return so queued prompts hit history",
+    ).toBeLessThan(queueBranchIdx);
+
+    // The queued branch itself must still be reached for queueing to happen,
+    // and must contain setMessageQueue.
     const branch = extractQueueBranch(
       chatContentSource,
-      "if (conversationStore.isLoading) {",
+      "if (conversationIsLoading()) {",
     );
-    expect(branch, "chat queued branch must exist").toContain(
-      "setMessageQueue",
-    );
-    expect(branch).toContain("appendInputHistory");
-    expect(branch).toContain("setPersistedInputs");
+    expect(branch).toContain("setMessageQueue");
   });
 
-  it("both queued branches cap history at 200 entries like the direct path", () => {
-    // Prevents the queued path from growing history unbounded while the direct
-    // path caps — silent divergence in behavior would be a regression.
-    const agentBranch = extractQueueBranch(
-      agentChatSource,
-      "if (isPrompting()) {",
-    );
-    const chatBranch = extractQueueBranch(
+  it("ChatContent's upstream persist enforces the 200-entry cap", () => {
+    // Slice from sendMessage start (function declaration) up to the queue
+    // branch — that span is the single persist block. Ensures the unconditional
+    // persist hasn't silently dropped its bound while the rest of the function
+    // grew around it.
+    const sendMessageIdx = indexOrThrow(
       chatContentSource,
-      "if (conversationStore.isLoading) {",
+      "const sendMessage = async (",
     );
-    expect(agentBranch).toContain("next.length > 200");
-    expect(chatBranch).toContain("next.length > 200");
+    const queueBranchIdx = indexOrThrow(
+      chatContentSource,
+      "if (conversationIsLoading()) {",
+    );
+    const span = chatContentSource.slice(sendMessageIdx, queueBranchIdx);
+    expect(span).toContain("appendInputHistory");
+    expect(span).toContain("setPersistedInputs");
+    expect(span).toContain("next.length > 200");
   });
 });


### PR DESCRIPTION
## Summary
- Closes #1813. The test `tests/unit/queued-input-history.test.ts` has been silently red on `main` since [b48ecd3e](https://github.com/serenorg/seren-desktop/commit/b48ecd3ecadca7b5814eebac43319611032d6cfd) renamed `conversationStore.isLoading` → `conversationIsLoading()` and consolidated duplicated persist blocks into a single unconditional persist at the top of `sendMessage`. Anchor went stale, `extractQueueBranch` returned `""` on miss, every assertion failed with a confusing message that read like a real regression.
- **No production code change.** Verified end-to-end that queued chat prompts still hit the persist block (`appendInputHistory` + 200-cap) at [ChatContent.tsx:673-684](src/components/chat/ChatContent.tsx#L673-L684) before reaching the queued return at [ChatContent.tsx:762](src/components/chat/ChatContent.tsx#L762).
- Test repairs: (a) update stale anchor; (b) `extractQueueBranch` now throws on missing anchor with a message naming the missing string; (c) ChatContent contract restated as ordering — assert `appendInputHistory(convId, trimmed)` appears upstream of the queued-branch return — so future moves of the persist block below the queue branch fail the test loudly. AgentChat's in-branch contract is unchanged.

## Test plan
- [x] `pnpm vitest run tests/unit/queued-input-history.test.ts` — 3/3 pass on this branch.
- [x] Sanity-checked the test does real work: temporarily deleted the persist block at ChatContent.tsx:673-684, ran the suite, watched the two ChatContent assertions fail with clear messages, then restored.
- [x] Full unit suite: 805/806 pass. The single remaining failure (`tests/unit/cli-updater.test.ts > backgroundUpdateCli TTL gate > proceeds past TTL when last check is older than 24h`) is a pre-existing flake — passes in isolation on both `main` and this branch, only fails inside the full-suite run. Unrelated.
- [x] `biome check` clean on the changed test file.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
