### PR TITLE
fix(agent): close #1825 — durable fork JSONL before --resume

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -17,7 +17,10 @@ import {
 } from "./effort.mjs";
 import { updatePeakInputTokens } from "./usage.mjs";
 import { chooseUpdatedModelId, inferCurrentModelId } from "./model-resolution.mjs";
-import { buildSyntheticTranscript as writeSyntheticJsonl } from "./synthetic-transcript.mjs";
+import {
+  buildSyntheticTranscript as writeSyntheticJsonl,
+  writeForkedTranscript,
+} from "./synthetic-transcript.mjs";
 
 /**
  * Resolve the full path to the `claude` binary.
@@ -756,7 +759,6 @@ function sendControlRequest(session, request, timeoutMs = 30_000) {
 function buildClaudeArgs({
   sessionId,
   resumeSessionId,
-  forkSession,
   preferredModel,
   mcpConfigJson,
   effort,
@@ -794,14 +796,8 @@ function buildClaudeArgs({
 
   if (resumeSessionId) {
     args.push("--resume", resumeSessionId);
-  }
-
-  if (!resumeSessionId || forkSession) {
+  } else {
     args.push("--session-id", sessionId);
-  }
-
-  if (forkSession) {
-    args.push("--fork-session");
   }
 
   if (preferredModel) {
@@ -1588,7 +1584,6 @@ export function createClaudeRuntime({ emit }) {
   // the promise resolves. Before spawning with a reused ID, we await
   // this to prevent the old exit handler from deleting the new session.
   const exitPromises = new Map();
-  const silentEmit = () => {};
 
   function createSessionRecord({
     sessionId,
@@ -1692,7 +1687,6 @@ export function createClaudeRuntime({ emit }) {
     const claudeArgs = buildClaudeArgs({
       sessionId: remoteSessionId,
       resumeSessionId: resumeAgentSessionId ?? null,
-      forkSession: false,
       preferredModel,
       mcpConfigJson: mcpConfig.claudeMcpConfigJson,
       effort: effectiveEffort,
@@ -2079,6 +2073,14 @@ export function createClaudeRuntime({ emit }) {
   }
 
   async function forkSession({ sessionId }) {
+    // #1825: write the forked transcript to disk directly instead of relying
+    // on the CLI's fork flag to flush. The CLI persists the new session
+    // file lazily on first turn, but the previous helper killed the temp
+    // process immediately after `initialize`, leaving the returned id
+    // pointing at no on-disk JSONL. The next spawn would then fail with
+    // "No conversation found with session ID: <id>". Mirroring the
+    // synthetic-transcript pre-warm path (#1713) — pure read + identity copy
+    // with sessionId rewritten — eliminates the race entirely.
     const session = sessions.get(sessionId);
     if (!session) {
       throw new Error(`Session not found: ${sessionId}`);
@@ -2089,112 +2091,28 @@ export function createClaudeRuntime({ emit }) {
       throw new Error("Claude session does not have a resumable session id yet.");
     }
 
-    const historyPath = await findSessionJsonlPath(session.cwd, sourceAgentSessionId);
-    if (!historyPath) {
+    const parentJsonlPath = await findSessionJsonlPath(
+      session.cwd,
+      sourceAgentSessionId,
+    );
+    if (!parentJsonlPath) {
       throw new Error(`Claude session not found: ${sourceAgentSessionId}`);
     }
 
     const forkedAgentSessionId = randomUUID();
-    const tempLocalSessionId = randomUUID();
-    const claudeBin = resolveClaudeBinary();
-    const forkArgs = buildClaudeArgs({
-      sessionId: forkedAgentSessionId,
-      resumeSessionId: sourceAgentSessionId,
-      forkSession: true,
-      preferredModel: session.currentModelId,
-      mcpConfigJson: session.mcpConfigJson,
-      effort: session.reasoningEffort,
-    });
-    const processHandle = spawn(
-      claudeBin,
-      forkArgs,
-      {
-        cwd: session.cwd,
-        env: {
-          ...process.env,
-          ...(session.spawnEnv ?? {}),
-          PATH: buildExtendedPath(),
-        },
-        stdio: ["pipe", "pipe", "pipe"],
-        shell: resolveSpawnShell(claudeBin),
-      },
+    const outputJsonlPath = path.join(
+      claudeProjectsRoot(),
+      encodeProjectDirName(session.cwd),
+      `${forkedAgentSessionId}.jsonl`,
     );
 
-    // Clean up MCP config temp file when the process exits
-    if (forkArgs._mcpTempFile) {
-      const tempFile = forkArgs._mcpTempFile;
-      processHandle.on("exit", () => {
-        try { unlinkSync(tempFile); } catch {}
-      });
-    }
-
-    // Catch spawn errors to prevent crashing the provider runtime.
-    processHandle.on("error", (spawnError) => {
-      console.error(`[browser-local][claude] Fork spawn error: ${spawnError.message}`);
+    await writeForkedTranscript({
+      parentJsonlPath,
+      outputJsonlPath,
+      forkedSessionId: forkedAgentSessionId,
     });
 
-    const tempSession = createSessionRecord({
-      sessionId: tempLocalSessionId,
-      cwd: session.cwd,
-      processHandle,
-      timeoutSecs: session.timeoutSecs,
-      agentSessionId: forkedAgentSessionId,
-      currentModelId: session.currentModelId,
-      currentModeId: session.currentModeId,
-      mcpConfigJson: session.mcpConfigJson,
-      spawnEnv: session.spawnEnv,
-      reasoningEffort: session.reasoningEffort,
-    });
-    const tempSessions = new Map([[tempSession.id, tempSession]]);
-    attachProcessListeners(silentEmit, tempSessions, tempSession, new Map());
-
-    try {
-      const initResult = await sendControlRequest(
-        tempSession,
-        {
-          subtype: "initialize",
-          hooks: null,
-        },
-        20_000,
-      );
-
-      tempSession.availableModelRecords = augmentWithLegacyOpus(
-        normalizeModelRecords(initResult),
-      );
-      // Symmetric with spawnSession's post-init handling — preserve the
-      // `[1m]` suffix from the seed `currentModelId` when the CLI echoes the
-      // bare equivalent in initResult.model. See #1776.
-      const inferredFromInit = inferCurrentModelId(
-        initResult?.model ?? null,
-        tempSession.availableModelRecords,
-      );
-      tempSession.currentModelId =
-        chooseUpdatedModelId(
-          tempSession.currentModelId,
-          inferredFromInit,
-          tempSession.availableModelRecords,
-        ) ??
-        inferredFromInit ??
-        tempSession.currentModelId;
-
-      if (!tempSession.agentSessionId) {
-        throw new Error("Claude fork did not return a resumable session id.");
-      }
-
-      return tempSession.agentSessionId;
-    } finally {
-      tempSessions.delete(tempSession.id);
-      rejectPendingControlRequests(
-        tempSession,
-        new Error("Fork helper session terminated."),
-      );
-      rejectCurrentPrompt(
-        tempSession,
-        new Error("Fork helper session terminated."),
-      );
-      tempSession.output.close();
-      killChildTree(processHandle);
-    }
+    return forkedAgentSessionId;
   }
 
   async function buildSyntheticTranscript({

--- a/bin/browser-local/synthetic-transcript.mjs
+++ b/bin/browser-local/synthetic-transcript.mjs
@@ -1,5 +1,5 @@
 // ABOUTME: Build synthetic Claude Code JSONL transcripts for predictive compaction (#1713).
-// ABOUTME: Slices the parent's tail, prepends a structured summary turn pair, rewrites session/parent ids.
+// ABOUTME: Also writes forked transcripts on disk for the fork primitive (#1825).
 
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
@@ -272,6 +272,62 @@ export const SYNTHETIC_TRANSCRIPT_INTERNALS = {
   SYNTHETIC_ACK_TEXT,
   SYNTHETIC_MODEL_FALLBACK,
 };
+
+/**
+ * Build the records for a forked transcript (#1825). Pure identity copy of
+ * the parent records with `sessionId` rewritten to the new id; uuid and
+ * parentUuid chains are preserved verbatim because Claude CLI's `--resume`
+ * indexes the chain by uuid and any in-tail rewrite would break resume.
+ *
+ * Caller writes the result to `<projectDir>/<forkedSessionId>.jsonl` so the
+ * file is durably on disk before returning to the spawn-side `--resume`.
+ */
+export function buildForkedTranscriptRecords({
+  parentRecords,
+  forkedSessionId,
+}) {
+  if (!Array.isArray(parentRecords)) {
+    throw new TypeError("parentRecords must be an array");
+  }
+  if (parentRecords.length === 0) {
+    throw new Error("Parent transcript is empty — nothing to fork.");
+  }
+  if (!forkedSessionId || typeof forkedSessionId !== "string") {
+    throw new TypeError("forkedSessionId must be a non-empty string");
+  }
+
+  return parentRecords.map((record) => {
+    const next = { ...record };
+    if (Object.hasOwn(next, "sessionId")) {
+      next.sessionId = forkedSessionId;
+    }
+    return next;
+  });
+}
+
+/**
+ * Read a parent JSONL, write a forked JSONL with the rewritten sessionId.
+ * Returns the new id and path so the caller (claude-runtime forkSession) can
+ * hand them straight to spawnSession's `--resume` without a process spawn.
+ */
+export async function writeForkedTranscript({
+  parentJsonlPath,
+  outputJsonlPath,
+  forkedSessionId,
+}) {
+  const parentRecords = await readJsonlFile(parentJsonlPath);
+  const records = buildForkedTranscriptRecords({
+    parentRecords,
+    forkedSessionId,
+  });
+  const payload = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+  await fs.writeFile(outputJsonlPath, payload, "utf8");
+  return {
+    forkedSessionId,
+    forkedJsonlPath: outputJsonlPath,
+    recordCount: records.length,
+  };
+}
 
 /**
  * Static self-check used by the cli-updater hook (#1654 / #1713 §4.7).

--- a/src-tauri/src/claude_memory.rs
+++ b/src-tauri/src/claude_memory.rs
@@ -129,13 +129,14 @@ pub fn claude_projects_root() -> Result<PathBuf, String> {
 }
 
 /// Build the path Claude CLI uses for a session transcript:
-/// `<root>/<encoded(cwd)>/sessions/<session_id>.jsonl`.
-/// Pure path construction — caller decides whether to stat or read.
+/// `<root>/<encoded(cwd)>/<session_id>.jsonl`. The pre-#1825 implementation
+/// added a `sessions/` subdir that Claude Code never creates, so
+/// `claude_session_exists` always returned false and the resume-side gate
+/// from #1657 silently skipped --resume on every reload. Pure path
+/// construction — caller decides whether to stat or read.
 pub fn session_jsonl_path(root: &Path, project_cwd: &Path, session_id: &str) -> PathBuf {
     let encoded = encode_project_dir(project_cwd);
-    root.join(&encoded)
-        .join("sessions")
-        .join(format!("{session_id}.jsonl"))
+    root.join(&encoded).join(format!("{session_id}.jsonl"))
 }
 
 /// Encode an absolute project directory the same way Claude Code does:
@@ -1001,12 +1002,15 @@ mod tests {
 
     #[test]
     fn session_jsonl_path_constructs_expected_layout_and_detects_presence() {
-        // Mirrors Claude CLI's on-disk layout:
-        //   <root>/<encoded(cwd)>/sessions/<session_id>.jsonl
-        // Test that (a) the path is constructed correctly and (b) is_file()
-        // returns true only when a real file exists at that path. Both legs
-        // are required for #1657 — frontend depends on the file-presence
-        // signal to decide whether to skip --resume.
+        // Mirrors Claude CLI's real on-disk layout:
+        //   <root>/<encoded(cwd)>/<session_id>.jsonl
+        // The pre-#1825 implementation pointed at a `sessions/` subdir that
+        // Claude Code does not create — `claude_session_exists` therefore
+        // always returned false and the resume-side gate from #1657 silently
+        // skipped --resume on every reload. The test now codifies the real
+        // layout (a flat `<id>.jsonl` directly under the encoded project
+        // dir) so any future drift back to the bogus `sessions/` segment
+        // fails fast.
         let tmp = TempDir::new().expect("tempdir");
         let root = tmp.path();
         let cwd = tmp.path().join("Projects").join("seren-desktop");
@@ -1019,13 +1023,23 @@ mod tests {
             "missing session must NOT be reported as present (this is the stale-session case the fix addresses)",
         );
 
-        // Materialize the file the way Claude CLI would. Path layout assertion:
-        // /<root>/<encoded>/sessions/<id>.jsonl
+        // Layout assertion: <id>.jsonl lives directly inside the encoded
+        // project dir — there is NO `sessions/` segment in the real CLI
+        // layout. The parent dir must equal the encoded project dir.
         let session_dir = path_before
             .parent()
             .expect("session jsonl must have a parent dir");
-        assert!(session_dir.ends_with("sessions"), "second-to-last segment must be 'sessions'");
-        fs::create_dir_all(session_dir).expect("create sessions dir");
+        assert!(
+            !session_dir.ends_with("sessions"),
+            "real Claude Code layout has no `sessions/` subdir — the pre-#1825 path was wrong",
+        );
+        assert_eq!(
+            session_dir.file_name().and_then(|n| n.to_str()),
+            Some(encode_project_dir(&cwd).as_str()),
+            "session jsonl must live directly under <root>/<encoded(cwd)>",
+        );
+
+        fs::create_dir_all(session_dir).expect("create encoded project dir");
         fs::write(&path_before, b"{\"stub\":true}\n").expect("write stub session");
         assert!(
             path_before.is_file(),

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -5822,6 +5822,38 @@ Structured summary:`;
         );
         return null;
       }
+
+      // #1825 sanity gate: the native-fork helper claims success only when a
+      // forked JSONL is durable on disk, but a CLI version skew or a write
+      // failure could still leave us with a non-resumable id. If the file
+      // cannot be confirmed, drop the resume id and fall back to the
+      // bootstrap-context branch — the same shape useNativeFork=false uses.
+      // Mirrors the protective gate resumeAgentConversation got in #1657.
+      let resumableJsonlExists = true;
+      if (agentType === "claude-code" && newAgentSessionId) {
+        try {
+          resumableJsonlExists = await claudeSessionExists(
+            cwd,
+            newAgentSessionId,
+          );
+        } catch (err) {
+          console.warn(
+            "[AgentStore] forkConversation: claudeSessionExists check failed; falling back to bootstrap context:",
+            err,
+          );
+          resumableJsonlExists = false;
+        }
+      }
+      if (!resumableJsonlExists) {
+        console.warn(
+          "[AgentStore] forkConversation: forked Claude JSONL missing for",
+          newAgentSessionId,
+          "— falling back to bootstrap context",
+        );
+        newAgentSessionId = undefined;
+        bootstrapPromptContext =
+          buildForkBootstrapContext(session, forkedMessages) ?? undefined;
+      }
     } else {
       bootstrapPromptContext =
         buildForkBootstrapContext(session, forkedMessages) ?? undefined;
@@ -5851,9 +5883,10 @@ Structured summary:`;
     }
 
     // 3. Spawn a new local session for the fork.
+    const resumeAgentSessionId = newAgentSessionId;
     const newSessionId = await this.spawnSession(cwd, agentType, {
       localSessionId: newConversationId,
-      resumeAgentSessionId: newAgentSessionId,
+      resumeAgentSessionId,
       conversationTitle: forkTitle,
       restoredMessages: forkedMessages,
       bootstrapPromptContext,

--- a/tests/unit/agent-fork-jsonl-flush.test.ts
+++ b/tests/unit/agent-fork-jsonl-flush.test.ts
@@ -1,0 +1,106 @@
+// ABOUTME: Critical regression guards for #1825 — fork JSONL must be durable
+// ABOUTME: before --resume; forkConversation must gate on claudeSessionExists.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const claudeRuntimeSource = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+
+const forkStart = agentStoreSource.indexOf("async forkConversation(");
+const forkEnd = agentStoreSource.indexOf(
+  "addErrorMessage(sessionId: string",
+  forkStart,
+);
+const forkBody = agentStoreSource.slice(forkStart, forkEnd);
+
+describe("#1825 — forkConversation gates on claudeSessionExists between native fork and spawn", () => {
+  it("imports claudeSessionExists from the claudeMemory service", () => {
+    // Same service the resume-side gate uses (#1657); reusing it keeps the
+    // existence check unified and means a single Rust `claude_session_exists`
+    // command underwrites both code paths.
+    expect(agentStoreSource).toMatch(
+      /import\s*\{[^}]*claudeSessionExists[^}]*\}\s*from\s*["']@\/services\/claudeMemory["']/,
+    );
+  });
+
+  it("calls claudeSessionExists after nativeForkSession returns and before the resume-side spawnSession", () => {
+    expect(forkStart).toBeGreaterThan(0);
+    const nativeForkIdx = forkBody.indexOf("nativeForkSession(");
+    const existsIdx = forkBody.indexOf("claudeSessionExists(");
+    const spawnIdx = forkBody.indexOf("spawnSession(");
+    expect(nativeForkIdx, "nativeForkSession call missing").toBeGreaterThan(0);
+    expect(existsIdx, "claudeSessionExists call missing").toBeGreaterThan(0);
+    expect(spawnIdx, "spawnSession call missing").toBeGreaterThan(0);
+    // Order: nativeForkSession → claudeSessionExists → spawnSession.
+    expect(existsIdx).toBeGreaterThan(nativeForkIdx);
+    expect(spawnIdx).toBeGreaterThan(existsIdx);
+  });
+
+  it("falls back to bootstrapPromptContext when the fork JSONL does not exist", () => {
+    // When the existence check returns false (or throws), the call site must
+    // drop newAgentSessionId and seed the new session through
+    // buildForkBootstrapContext — exactly the shape the useNativeFork=false
+    // branch already uses. Without this, a missing-file outcome surfaces the
+    // raw spawn failure to the user instead of degrading gracefully.
+    expect(forkBody).toContain("buildForkBootstrapContext(");
+    // Source-level shape: there must be a branch that, in response to a
+    // negative existence check, sets bootstrapPromptContext from the helper.
+    // We assert the absence of the dangerous shape (passing
+    // newAgentSessionId straight through without an existence guard) by
+    // requiring that the spawnSession call's resumeAgentSessionId arg is
+    // resolved through a guarded local rather than the raw native-fork id.
+    expect(forkBody).not.toMatch(
+      /spawnSession\([^)]*resumeAgentSessionId:\s*newAgentSessionId,/s,
+    );
+  });
+});
+
+describe("#1825 — forkSession writes the JSONL directly instead of spawning a temp Claude", () => {
+  it("forkSession does not pass --fork-session and does not spawn a child process", () => {
+    const fnIdx = claudeRuntimeSource.indexOf("async function forkSession(");
+    expect(fnIdx, "forkSession function missing").toBeGreaterThan(0);
+    // Find the function body. forkSession is at module scope inside
+    // createClaudeRuntime; the next async/function at module level closes it.
+    // A simple bounded slice is enough — every assertion below operates on
+    // the body, not the rest of the file.
+    const bodyEnd = claudeRuntimeSource.indexOf(
+      "\n  async function ",
+      fnIdx + 30,
+    );
+    const fnBody = claudeRuntimeSource.slice(
+      fnIdx,
+      bodyEnd > 0 ? bodyEnd : fnIdx + 4000,
+    );
+
+    // No more temp-process spawn. The race we are eliminating is precisely
+    // the one where a temp Claude exits before its fork JSONL flushes.
+    expect(fnBody).not.toContain("spawn(");
+    expect(fnBody).not.toContain("--fork-session");
+    expect(fnBody).not.toContain("forkSession: true");
+    expect(fnBody).not.toContain("attachProcessListeners");
+    expect(fnBody).not.toContain("sendControlRequest");
+    expect(fnBody).not.toContain("killChildTree");
+  });
+
+  it("forkSession resolves the parent JSONL via findSessionJsonlPath and writes to projectsRoot", () => {
+    const fnIdx = claudeRuntimeSource.indexOf("async function forkSession(");
+    const bodyEnd = claudeRuntimeSource.indexOf(
+      "\n  async function ",
+      fnIdx + 30,
+    );
+    const fnBody = claudeRuntimeSource.slice(
+      fnIdx,
+      bodyEnd > 0 ? bodyEnd : fnIdx + 4000,
+    );
+    expect(fnBody).toContain("findSessionJsonlPath(");
+    expect(fnBody).toContain("writeForkedTranscript(");
+  });
+});

--- a/tests/unit/claude-runtime-1m-tier-postinit.test.ts
+++ b/tests/unit/claude-runtime-1m-tier-postinit.test.ts
@@ -30,19 +30,28 @@ describe("#1776 — post-init currentModelId resolution preserves [1m]", () => {
     expect(block).toContain("inferredFromInit");
   });
 
-  it("forkSession applies the same chooseUpdatedModelId protection symmetrically", () => {
-    // The fork path (#1635 resume + branch) repeats the post-init resolution
-    // for the temporary control session it spins up to derive a resumable
-    // agentSessionId. Without the same [1m]-preservation logic, forking a
-    // 1M-tier conversation drops the suffix on the new branch.
-    const forkAnchor =
-      'tempSession.availableModelRecords = augmentWithLegacyOpus(';
-    const idx = claudeRuntimeSource.indexOf(forkAnchor);
-    expect(idx, "forkSession post-init block must exist").toBeGreaterThan(0);
-
-    const block = claudeRuntimeSource.slice(idx, idx + 1200);
-    expect(block).toContain("chooseUpdatedModelId(");
-    expect(block).toContain("tempSession.currentModelId,");
+  it("forkSession delegates [1m] preservation to the next spawnSession boot — no temp init block", () => {
+    // #1825: forkSession no longer spins up a temporary control session to
+    // derive a resumable id; it writes the forked JSONL directly. The
+    // [1m]-preservation logic is therefore single-sourced in spawnSession's
+    // post-init block (asserted above) — the next user spawn against the
+    // forked JSONL applies it. Asserting the absence of a duplicate fork-side
+    // block locks in the single-source invariant and prevents the temp
+    // helper from being reintroduced as a "just to derive currentModelId"
+    // shortcut, which would re-open the JSONL-flush race the fix closed.
+    const fnIdx = claudeRuntimeSource.indexOf("async function forkSession(");
+    expect(fnIdx, "forkSession function missing").toBeGreaterThan(0);
+    const bodyEnd = claudeRuntimeSource.indexOf(
+      "\n  async function ",
+      fnIdx + 30,
+    );
+    const fnBody = claudeRuntimeSource.slice(
+      fnIdx,
+      bodyEnd > 0 ? bodyEnd : fnIdx + 4000,
+    );
+    expect(fnBody).not.toContain("augmentWithLegacyOpus(");
+    expect(fnBody).not.toContain("tempSession");
+    expect(fnBody).not.toContain("chooseUpdatedModelId(");
   });
 
   it("DEFAULT_PREFERRED_MODEL is the [1m]-tier Opus 4.7 id", () => {

--- a/tests/unit/synthetic-transcript.test.ts
+++ b/tests/unit/synthetic-transcript.test.ts
@@ -13,6 +13,8 @@ const modulePath = new URL(
 const {
   buildSyntheticTranscript,
   buildSyntheticTranscriptRecords,
+  buildForkedTranscriptRecords,
+  writeForkedTranscript,
   findCutIndex,
   isRealUserTurn,
 } = await import(/* @vite-ignore */ modulePath);
@@ -313,6 +315,88 @@ describe("buildSyntheticTranscriptRecords (#1713 — splice safety, Codex P1)", 
     }) as JsonlRecord[];
     expect(out[0].isCompactSummary).toBe(true);
     expect(out[1].isSyntheticAck).toBe(true);
+  });
+});
+
+describe("buildForkedTranscriptRecords (#1825 — direct-write fork primitive)", () => {
+  it("rewrites sessionId on every record and preserves uuid + parentUuid chain verbatim", () => {
+    // Fork is a pure identity copy with the sessionId field rewritten — no
+    // summary/ack splice, no parentUuid mutation. The CLI's `--resume` only
+    // reads the chain by uuid, so any in-tail rewrite would break resume.
+    const parent = [
+      userTurn("u1", null, "first"),
+      assistantTextTurn("a1", "u1", "first reply"),
+      userTurn("u2", "a1", "second"),
+      assistantToolUseTurn("a2", "u2", "toolu_x"),
+      userToolResultTurn("t1", "a2", "toolu_x"),
+      assistantTextTurn("a3", "t1", "done"),
+      attachmentRecord("u2"),
+    ];
+    const out = buildForkedTranscriptRecords({
+      parentRecords: parent,
+      forkedSessionId: "FORK-NEW-ID",
+    }) as JsonlRecord[];
+
+    expect(out).toHaveLength(parent.length);
+    for (let i = 0; i < parent.length; i += 1) {
+      expect(out[i].uuid).toBe(parent[i].uuid);
+      expect(out[i].parentUuid).toBe(parent[i].parentUuid);
+      if (Object.hasOwn(parent[i], "sessionId")) {
+        expect(out[i].sessionId).toBe("FORK-NEW-ID");
+      }
+    }
+    // Original records must be untouched (pure function).
+    expect(parent[0].sessionId).toBe("PARENT");
+  });
+
+  it("rejects empty parent records — caller must fall back to bootstrap context", () => {
+    expect(() =>
+      buildForkedTranscriptRecords({
+        parentRecords: [],
+        forkedSessionId: "FORK-NEW-ID",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("writeForkedTranscript (#1825 — fork JSONL exists on disk before return)", () => {
+  it("reads parent JSONL, writes forked JSONL with rewritten sessionId, returns the new path", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "forked-transcript-"));
+    const parentPath = path.join(dir, "parent.jsonl");
+    const outputPath = path.join(dir, "fork.jsonl");
+    const parent = [
+      userTurn("u1", null, "first"),
+      assistantTextTurn("a1", "u1", "first reply"),
+      userTurn("u2", "a1", "second"),
+      assistantTextTurn("a2", "u2", "second reply"),
+    ];
+    writeFileSync(
+      parentPath,
+      parent.map((r) => JSON.stringify(r)).join("\n") + "\n",
+      "utf8",
+    );
+
+    const result = await writeForkedTranscript({
+      parentJsonlPath: parentPath,
+      outputJsonlPath: outputPath,
+      forkedSessionId: "FORK-NEW-ID",
+    });
+
+    expect(result.forkedSessionId).toBe("FORK-NEW-ID");
+    expect(result.forkedJsonlPath).toBe(outputPath);
+
+    const written = readFileSync(outputPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+    expect(written).toHaveLength(parent.length);
+    for (const rec of written) {
+      expect(rec.sessionId).toBe("FORK-NEW-ID");
+    }
+    expect(written[0].uuid).toBe("u1");
+    expect(written[0].parentUuid).toBeNull();
+    expect(written[3].uuid).toBe("a2");
+    expect(written[3].parentUuid).toBe("u2");
   });
 });
 


### PR DESCRIPTION
## Summary

- Closes #1825 — fork conversation no longer fails with "No conversation found with session ID: …".
- Replace the temp-spawn `--fork-session` dance with a direct JSONL write that mirrors the predictive-compaction (#1713) pre-warm path; eliminates the temp-process flush race entirely.
- Add the missing post-fork sanity gate so `forkConversation` falls back to `bootstrapPromptContext` when the forked JSONL cannot be confirmed on disk — same protective shape `resumeAgentConversation` got in #1657.
- Audit-discovered `session_jsonl_path` layout bug fixed: real Claude Code stores `<root>/<encoded>/<id>.jsonl` directly (verified on disk); the prior code added a `sessions/` subdir that the CLI never creates, so `claude_session_exists` had been silently returning false on every call — making the #1657 resume-side gate skip `--resume` for every reload. Path corrected; existing test rewritten to assert the real layout instead of codifying the bug.

## Test plan

- [x] `pnpm vitest run tests/unit/synthetic-transcript.test.ts tests/unit/agent-fork-jsonl-flush.test.ts tests/unit/agent-fork-after-promotion.test.ts tests/unit/claude-runtime-1m-tier-postinit.test.ts tests/unit/claude-runtime-cleanups.test.ts tests/unit/claude-runtime-1m-tier.test.ts tests/unit/claude-runtime-model-catalog.test.ts tests/unit/claude-runtime-subagent-guard.test.ts` → 51/51 green.
- [x] `pnpm test` → 829/830 green; the single failure is `compaction-auth-gate.test.ts > #1639` and reproduces on clean `origin/main` (pre-existing, separate ticket).
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` → 450/450 green, includes the rewritten `session_jsonl_path_constructs_expected_layout_and_detects_presence`.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` clean.
- [x] `pnpm check` clean on src-included files (`bin/`, `src-tauri/`, `tests/` are outside Biome scope per `biome.json`).
- [ ] Manual: open the Tauri shell, run any single Claude turn so a parent JSONL exists, click "Fork from this message" on a head-of-conversation assistant message → forked thread spawns and resumes the parent transcript without the prior `forkConversation: spawn failed` error event.

