### PR TITLE
fix(agent): close #1827 — suppress reactive-compaction seed-ack leak

### DIFF
--- a/src/lib/scrub-agent-markup.ts
+++ b/src/lib/scrub-agent-markup.ts
@@ -4,6 +4,12 @@
 const PATTERNS: RegExp[] = [
   /<system-reminder>[\s\S]*?<\/system-reminder>/g,
   /<command-(message|name|args)>[\s\S]*?<\/command-\1>/g,
+  // #1827: post-compaction seed-ack stock pattern. The compaction seed prompt
+  // ("Confirm you have this context… wait for the user's next message") plus
+  // the runtime's <system-reminder> injections produce a meta-acknowledgement
+  // turn. The role==="standby" event filter is the primary guard; this regex
+  // is the second layer for races, refactors, and seed-prompt rewordings.
+  /I(?:'ll| will) acknowledge the system reminders\.[^\n]*?standing by[.!]?/gi,
 ];
 
 /**

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3189,9 +3189,16 @@ Structured summary:`;
       const priorModelId = session.currentModelId;
       await this.terminateSession(sessionId);
 
+      // Spawn the respawn as role="standby" so the seed prompt's
+      // acknowledgement turn is filtered by the handleSessionEvent guard
+      // (~line 4434) instead of streaming into the user-visible chat as
+      // "I'll acknowledge the system reminders…standing by". After the seed
+      // settles via waitForSessionIdle below, role flips back to "serving"
+      // and seedCompleted is cleared so the user's retry runs visibly. #1827.
       const newSessionId = await this.spawnSession(cwd, agentType, {
         localSessionId: conversationId,
         initialModelId: priorModelId,
+        role: "standby",
       });
 
       if (!newSessionId) {
@@ -3248,6 +3255,13 @@ Structured summary:`;
       await this.restoreSessionSettings(session, newSessionId);
       await providerService.sendPrompt(newSessionId, seedPrompt);
       await waitForSessionIdle(newSessionId);
+
+      // Seed has fully settled — release the standby filter so the caller's
+      // retry (`compactAndRetry`) renders the user's actual response. Reset
+      // seedCompleted so the next promptComplete is treated as a real turn,
+      // not a second seed by the standby short-circuit at ~line 4485. #1827.
+      setState("sessions", newSessionId, "role", "serving");
+      setState("sessions", newSessionId, "seedCompleted", undefined);
 
       return { outcome: "succeeded", newSessionId };
     } catch (error) {

--- a/tests/unit/compact-reactive-seed-ack-leak.test.ts
+++ b/tests/unit/compact-reactive-seed-ack-leak.test.ts
@@ -1,0 +1,67 @@
+// ABOUTME: Critical regression for #1827 — the reactive compaction respawn
+// ABOUTME: must use role: "standby" so the seed-ack is filtered, then flip to
+// ABOUTME: "serving" before returning so the user's retry runs visibly.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+/** Region of compactAgentConversation's reactive branch. */
+function reactiveBranch(): string {
+  const start = agentStoreSource.indexOf(
+    "// Reactive path: terminate old, spawn fresh serving",
+  );
+  if (start < 0) throw new Error("reactive-branch anchor not found");
+  // The branch ends at `return { outcome: "succeeded", newSessionId };`
+  // followed by the catch block. Take a generous window.
+  const end = agentStoreSource.indexOf("} catch (error) {", start);
+  if (end < 0) throw new Error("reactive-branch end anchor not found");
+  return agentStoreSource.slice(start, end);
+}
+
+describe("#1827 — reactive compaction must not leak the seed-ack into the UI", () => {
+  it("reactive respawn passes role: \"standby\" so messageChunk events are filtered", () => {
+    // The role-based event filter at handleSessionEvent (~line 4434) is the
+    // ONLY thing that prevents the seed-prompt response from streaming into
+    // the user-visible chat as an assistant message. Predictive already does
+    // this; reactive must too. Without the role, the user sees the model's
+    // stock acknowledgement ("I'll acknowledge the system reminders…").
+    const region = reactiveBranch();
+    expect(region).toMatch(
+      /spawnSession\(cwd,\s*agentType,\s*\{[\s\S]*?role:\s*"standby"/,
+    );
+  });
+
+  it("reactive respawn flips role back to \"serving\" before returning", () => {
+    // The session must serve the user's retried prompt visibly. After the
+    // seed has completed and idle is reached, the role flip + seedCompleted
+    // reset are both required: serving so events render, seedCompleted reset
+    // so the next promptComplete is treated as a real turn (not a second
+    // seed) by the standby short-circuit at line ~4485.
+    const region = reactiveBranch();
+    expect(region).toMatch(
+      /setState\("sessions",\s*newSessionId,\s*"role",\s*"serving"\)/,
+    );
+    expect(region).toMatch(
+      /setState\("sessions",\s*newSessionId,\s*"seedCompleted",\s*undefined\)/,
+    );
+  });
+
+  it("role flip happens AFTER waitForSessionIdle (so the seed-ack is fully consumed first)", () => {
+    // Flipping early would re-expose the seed-ack mid-stream. The waitFor
+    // / send / wait sequence must finish before the role swap, otherwise
+    // the standby filter releases while messageChunks are still arriving.
+    const region = reactiveBranch();
+    const idleIdx = region.indexOf("waitForSessionIdle(newSessionId)");
+    const roleFlipIdx = region.indexOf(
+      'setState("sessions", newSessionId, "role", "serving")',
+    );
+    expect(idleIdx).toBeGreaterThan(0);
+    expect(roleFlipIdx).toBeGreaterThan(idleIdx);
+  });
+});

--- a/tests/unit/scrub-agent-markup.test.ts
+++ b/tests/unit/scrub-agent-markup.test.ts
@@ -60,4 +60,45 @@ describe("scrubAgentMarkup", () => {
     expect(scrubAgentMarkup("")).toBe("");
     expect(scrubAgentMarkup("   \n\n  ")).toBe("");
   });
+
+  // #1827: post-compaction stock acknowledgement leak. The seed prompt
+  // ("Confirm you have this context… wait for the user's next message")
+  // combined with the runtime's <system-reminder> injections triggers a
+  // stock training-data response. If a race / refactor lets this turn
+  // escape the role==="standby" event filter, scrubAgentMarkup must drop
+  // it so it never persists into the transcript or Seren memory.
+  describe("#1827 — drops the post-compaction seed-ack stock pattern", () => {
+    it("drops the literal observed wording", () => {
+      const input =
+        "I'll acknowledge the system reminders. No user request to act on yet—standing by";
+      expect(scrubAgentMarkup(input)).toBe("");
+    });
+
+    it("drops the variant with an ASCII hyphen instead of em-dash", () => {
+      const input =
+        "I'll acknowledge the system reminders. No user request to act on yet - standing by.";
+      expect(scrubAgentMarkup(input)).toBe("");
+    });
+
+    it("drops the variant with leading whitespace and a trailing period", () => {
+      const input =
+        "  I'll acknowledge the system reminders. No user request to act on yet, standing by.  ";
+      expect(scrubAgentMarkup(input)).toBe("");
+    });
+
+    it("drops the 'I will acknowledge' (no contraction) variant", () => {
+      const input =
+        "I will acknowledge the system reminders. No user request to act on yet—standing by";
+      expect(scrubAgentMarkup(input)).toBe("");
+    });
+
+    it("preserves a real assistant turn that merely contains 'standing by' as a phrase", () => {
+      // Don't false-positive on legitimate prose. The stock pattern requires
+      // the "I('ll| will) acknowledge the system reminders" preamble to
+      // anchor the match.
+      const input =
+        "The validator service is healthy and standing by for traffic.";
+      expect(scrubAgentMarkup(input)).toBe(input);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #1827. Post-compaction, users were seeing the model's seed-prompt acknowledgement turn streamed into the chat as `I'll acknowledge the system reminders. No user request to act on yet—standing by`, followed by a generic skills menu when they replied. Root cause: the reactive compaction respawn spawned the new session with the default `role: "serving"`, so the `handleSessionEvent` standby filter at [`agent.store.ts:4434-4442`](https://github.com/serenorg/seren-desktop/blob/main/src/stores/agent.store.ts#L4434-L4442) (which already prevents this on the predictive path) never fired.

- **Fix #1 — Reactive respawn now spawns role="standby"** ([`agent.store.ts:3192-3202`](src/stores/agent.store.ts)). After the seed settles via `waitForSessionIdle`, role flips back to `"serving"` and `seedCompleted` is cleared so the caller's retry (`compactAndRetry`) renders visibly.
- **Fix #2 — Defensive scrubber pattern** ([`src/lib/scrub-agent-markup.ts`](src/lib/scrub-agent-markup.ts)). Catches the stock-acknowledgement prose if a future race / refactor / reword lets it slip the role filter. Both `scrubAgentMarkup` call sites already drop the message on empty result.

The two larger architectural fixes (#3 — replace seed turn with passive prepend; #4 — bring synthetic-transcript path to reactive + flip default) are documented in #1827 as follow-ups.

## Audit confirmation (re-checked at commit time)

- `spawnSession` standby branches verified safe for the reactive path: idle Claude reclaim is skipped (no parallel session anyway after `terminateSession(sessionId)`), `createAgentConversation` skip is fine because `localSessionId === conversationId` already has a row.
- `handleSessionEvent` filter drops the seed-ack `messageChunk` / `userMessage` / `toolCall` / `toolResult` / `diff` / `planUpdate` events while standby.
- `promptComplete` standby short-circuit sets `seedCompleted=true`, sets status to `ready`, finds no serving session pointing back (reactive has none), no false drain. `predictiveCompactBusy = false` is a no-op for reactive.
- Role flip happens AFTER `waitForSessionIdle` returns — pinned by a positional test.
- 109 unit test files / 816 tests pass.

## Test plan

- [x] `pnpm vitest run tests/unit/compact-reactive-seed-ack-leak.test.ts` — 3 tests, source-introspection style matching #1733 / #1800
- [x] `pnpm vitest run tests/unit/scrub-agent-markup.test.ts` — 14 tests (5 new for stock-ack pattern + 1 false-positive guard)
- [x] Full unit suite: 816 tests passing
- [x] Compaction-related sweep (`compact-retry-codex`, `compaction-queue-race`, `compaction-session-removal-guard`, `predictive-compact-spawn-fixes`, `predictive-compact-failure-drain`, `agent-store-summary-anti-fabrication`, plus the two new files): 56 tests passing
- [x] `biome check` on changed files clean (the 4 pre-existing errors elsewhere are not introduced here)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
