### PR TITLE
feat(launcher): close #1832 — group +New menu with billing chips

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -134,6 +134,21 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
     }
   };
 
+  const handleNewAgent = async (
+    agentType: "claude-code" | "codex" | "gemini",
+  ) => {
+    setShowLauncher(false);
+    setLauncherQuery("");
+    const cwd = fileTreeState.rootPath;
+    if (!cwd) return;
+    setSpawning(true);
+    try {
+      await threadStore.createAgentThread(agentType, cwd);
+    } finally {
+      setSpawning(false);
+    }
+  };
+
   const handleSkillThread = async (skill: InstalledSkill | Skill) => {
     // Skills can only be toggled on an active thread
     const activeThread = threadStore.activeThread;
@@ -361,6 +376,84 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
     </svg>
   );
 
+  // Right-aligned chip telling the user *what surface / how it's billed*.
+  const LauncherChip: Component<{
+    variant: "paid" | "subscription" | "cli";
+    children: string;
+  }> = (chipProps) => {
+    const tone = () =>
+      chipProps.variant === "paid"
+        ? "bg-primary/10 text-primary/90 border-primary/25"
+        : chipProps.variant === "subscription"
+          ? "bg-purple-500/12 text-purple-300 border-purple-500/30"
+          : "bg-surface-3 text-muted-foreground border-border";
+    return (
+      <span
+        class={`text-[10px] font-semibold tracking-[0.04em] px-1.5 py-0.5 rounded-full border whitespace-nowrap ${tone()}`}
+      >
+        {chipProps.children}
+      </span>
+    );
+  };
+
+  // Frames a brand emoji as a CLI command — small bordered square with a
+  // `>_` corner badge — so CLI rows visually depart from chat-style agent rows.
+  const CliBrandIcon: Component<{ glyph: string }> = (iconProps) => (
+    <span class="relative inline-flex items-center justify-center w-[22px] h-[22px] rounded-[5px] border border-border bg-black/25 text-[12px] shrink-0">
+      <span aria-hidden="true">{iconProps.glyph}</span>
+      <span
+        aria-hidden="true"
+        class="absolute -bottom-1 -right-1.5 px-[3px] py-[1px] rounded-[3px] border border-border bg-surface-2 text-[8px] font-semibold leading-none text-muted-foreground font-mono"
+      >
+        &gt;_
+      </span>
+    </span>
+  );
+
+  const SectionLabel: Component<{ children: string }> = (labelProps) => (
+    <div class="px-3 pt-2.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70 select-none">
+      {labelProps.children}
+    </div>
+  );
+
+  const SectionDivider: Component = () => (
+    <div class="h-px bg-border/60 mx-3 my-1" />
+  );
+
+  const claudeAvailable = createMemo(() =>
+    agentStore.availableAgents.some(
+      (a) => a.type === "claude-code" && a.available,
+    ),
+  );
+  const codexAvailable = createMemo(() =>
+    agentStore.availableAgents.some((a) => a.type === "codex" && a.available),
+  );
+  const geminiAvailable = createMemo(() =>
+    agentStore.availableAgents.some((a) => a.type === "gemini" && a.available),
+  );
+  const showSerenChat = createMemo(() =>
+    allowsSerenPublicModels(authStore.privateChatPolicy),
+  );
+  const showSerenPrivate = createMemo(() =>
+    allowsSerenPrivateAgent(authStore.privateChatPolicy),
+  );
+  const showClaudeAgent = createMemo(
+    () => allowsClaudeAgent(authStore.privateChatPolicy) && claudeAvailable(),
+  );
+  const showCodexAgent = createMemo(
+    () => allowsCodexAgent(authStore.privateChatPolicy) && codexAvailable(),
+  );
+  const showGeminiAgent = createMemo(
+    () => allowsGeminiAgent(authStore.privateChatPolicy) && geminiAvailable(),
+  );
+  const hasChatSection = createMemo(
+    () => showSerenChat() || showSerenPrivate(),
+  );
+  const hasAgentSection = createMemo(
+    () => showClaudeAgent() || showCodexAgent() || showGeminiAgent(),
+  );
+  const hasCliSection = createMemo(() => claudeAvailable() || codexAvailable());
+
   return (
     <aside
       data-testid="thread-sidebar"
@@ -491,134 +584,135 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
 
           <Show when={showLauncher()}>
             <div class="absolute top-[calc(100%+4px)] left-3 right-3 max-h-[60vh] overflow-y-auto bg-surface-2 border border-border rounded-lg z-20 shadow-lg animate-[slideDown_150ms_ease] py-1">
-              {/* Primary Seren chat path */}
-              <Show when={allowsSerenPublicModels(authStore.privateChatPolicy)}>
+              {/* ---------- Chat ---------- */}
+              <Show when={hasChatSection()}>
+                <SectionLabel>Chat</SectionLabel>
+              </Show>
+              <Show when={showSerenChat()}>
                 <button
                   type="button"
                   data-testid="new-seren-chat"
                   class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
                   onClick={handleNewChat}
                 >
-                  <span class="text-[14px]">{"\u{1F4AC}"}</span>
-                  <div class="min-w-0">
+                  <span class="text-[14px] w-[22px] text-center shrink-0">
+                    {"\u{1F4AC}"}
+                  </span>
+                  <div class="flex-1 min-w-0">
                     <div class="font-medium">Seren Agent</div>
-                    <Show when={primaryChatLauncherDescription()}>
-                      <div class="text-[11px] text-muted-foreground">
-                        {primaryChatLauncherDescription()}
-                      </div>
-                    </Show>
+                    <div class="text-[11px] text-muted-foreground">
+                      {primaryChatLauncherDescription()}
+                    </div>
                   </div>
+                  <LauncherChip variant="paid">Pay-as-you-go</LauncherChip>
                 </button>
               </Show>
-
-              <Show when={allowsSerenPrivateAgent(authStore.privateChatPolicy)}>
+              <Show when={showSerenPrivate()}>
                 <button
                   type="button"
+                  data-testid="new-seren-private-agent"
                   class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
                   onClick={handleNewPrivateChat}
                 >
-                  <span class="text-[14px]">{"\u{1F512}"}</span>
-                  <span class="font-medium">Seren Agent (Private)</span>
+                  <span class="text-[14px] w-[22px] text-center shrink-0">
+                    {"\u{1F512}"}
+                  </span>
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium">Seren Agent (Private)</div>
+                    <div class="text-[11px] text-muted-foreground">
+                      Private SerenModels · AWS Bedrock &amp; Azure
+                    </div>
+                  </div>
+                  <LauncherChip variant="paid">Pay-as-you-go</LauncherChip>
                 </button>
               </Show>
 
-              {/* Claude Code Agent */}
+              {/* ---------- Coding agents ---------- */}
+              <Show when={hasAgentSection() && hasChatSection()}>
+                <SectionDivider />
+              </Show>
+              <Show when={hasAgentSection()}>
+                <SectionLabel>Coding agents</SectionLabel>
+              </Show>
+              <Show when={showClaudeAgent()}>
+                <button
+                  type="button"
+                  data-testid="new-claude-agent"
+                  class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
+                  onClick={() => void handleNewAgent("claude-code")}
+                >
+                  <span class="text-[14px] w-[22px] text-center shrink-0">
+                    {"\u{1F916}"}
+                  </span>
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium">Claude Code</div>
+                    <div class="text-[11px] text-muted-foreground">
+                      Anthropic \u00B7 chat-style coding agent
+                    </div>
+                  </div>
+                  <LauncherChip variant="subscription">
+                    Subscription
+                  </LauncherChip>
+                </button>
+              </Show>
+              <Show when={showCodexAgent()}>
+                <button
+                  type="button"
+                  data-testid="new-codex-agent"
+                  class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
+                  onClick={() => void handleNewAgent("codex")}
+                >
+                  <span class="text-[14px] w-[22px] text-center shrink-0">
+                    {"\u26A1"}
+                  </span>
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium">Codex</div>
+                    <div class="text-[11px] text-muted-foreground">
+                      OpenAI \u00B7 chat-style coding agent
+                    </div>
+                  </div>
+                  <LauncherChip variant="subscription">
+                    Subscription
+                  </LauncherChip>
+                </button>
+              </Show>
+              <Show when={showGeminiAgent()}>
+                <button
+                  type="button"
+                  data-testid="new-gemini-agent"
+                  class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
+                  onClick={() => void handleNewAgent("gemini")}
+                >
+                  <span class="text-[14px] w-[22px] text-center shrink-0">
+                    {"\u2728"}
+                  </span>
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium">Gemini</div>
+                    <div class="text-[11px] text-muted-foreground">
+                      Google \u00B7 chat-style coding agent
+                    </div>
+                  </div>
+                  <LauncherChip variant="subscription">
+                    Subscription
+                  </LauncherChip>
+                </button>
+              </Show>
+
+              {/* ---------- Command line ---------- */}
               <Show
                 when={
-                  allowsClaudeAgent(authStore.privateChatPolicy) &&
-                  agentStore.availableAgents.some(
-                    (a) => a.type === "claude-code" && a.available,
-                  )
+                  hasCliSection() && (hasChatSection() || hasAgentSection())
                 }
               >
-                <button
-                  type="button"
-                  class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
-                  onClick={async () => {
-                    setShowLauncher(false);
-                    const cwd = fileTreeState.rootPath;
-                    if (!cwd) return;
-                    setSpawning(true);
-                    try {
-                      await threadStore.createAgentThread("claude-code", cwd);
-                    } finally {
-                      setSpawning(false);
-                    }
-                  }}
-                >
-                  <span class="text-[14px]">{"\u{1F916}"}</span>
-                  <span class="font-medium">Claude Code Agent</span>
-                </button>
+                <SectionDivider />
               </Show>
-
-              {/* Codex Agent */}
-              <Show
-                when={
-                  allowsCodexAgent(authStore.privateChatPolicy) &&
-                  agentStore.availableAgents.some(
-                    (a) => a.type === "codex" && a.available,
-                  )
-                }
-              >
-                <button
-                  type="button"
-                  class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
-                  onClick={async () => {
-                    setShowLauncher(false);
-                    const cwd = fileTreeState.rootPath;
-                    if (!cwd) return;
-                    setSpawning(true);
-                    try {
-                      await threadStore.createAgentThread("codex", cwd);
-                    } finally {
-                      setSpawning(false);
-                    }
-                  }}
-                >
-                  <span class="text-[14px]">{"\u26A1"}</span>
-                  <span class="font-medium">Codex Agent</span>
-                </button>
+              <Show when={hasCliSection()}>
+                <SectionLabel>Command line</SectionLabel>
               </Show>
-
-              {/* Gemini Agent */}
-              <Show
-                when={
-                  allowsGeminiAgent(authStore.privateChatPolicy) &&
-                  agentStore.availableAgents.some(
-                    (a) => a.type === "gemini" && a.available,
-                  )
-                }
-              >
+              <Show when={claudeAvailable()}>
                 <button
                   type="button"
-                  class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
-                  onClick={async () => {
-                    setShowLauncher(false);
-                    const cwd = fileTreeState.rootPath;
-                    if (!cwd) return;
-                    setSpawning(true);
-                    try {
-                      await threadStore.createAgentThread("gemini", cwd);
-                    } finally {
-                      setSpawning(false);
-                    }
-                  }}
-                >
-                  <span class="text-[14px]">{"\u2728"}</span>
-                  <span class="font-medium">Gemini Agent</span>
-                </button>
-              </Show>
-
-              {/* Terminal section - kept at the bottom of the launcher.
-                The CLI shortcuts are gated on the same availability
-                signal that gates the matching agent above. */}
-              <Show
-                when={agentStore.availableAgents.some(
-                  (a) => a.type === "claude-code" && a.available,
-                )}
-              >
-                <button
-                  type="button"
+                  data-testid="new-claude-cli"
                   class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
                   onClick={() =>
                     void handleNewTerminal({
@@ -627,19 +721,21 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                     })
                   }
                 >
-                  <span class="text-[14px]">{"\u{1F916}"}</span>
-                  <span class="font-medium">Claude Code CLI</span>
-                  <TerminalIcon size={11} />
+                  <CliBrandIcon glyph={"\u{1F916}"} />
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium">Claude Code</div>
+                    <div class="text-[11px] text-muted-foreground">
+                      Runs <code class="font-mono text-[10px]">claude</code> in
+                      a terminal pane
+                    </div>
+                  </div>
+                  <LauncherChip variant="cli">CLI</LauncherChip>
                 </button>
               </Show>
-
-              <Show
-                when={agentStore.availableAgents.some(
-                  (a) => a.type === "codex" && a.available,
-                )}
-              >
+              <Show when={codexAvailable()}>
                 <button
                   type="button"
+                  data-testid="new-codex-cli"
                   class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
                   onClick={() =>
                     void handleNewTerminal({
@@ -648,19 +744,36 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                     })
                   }
                 >
-                  <span class="text-[14px]">{"⚡"}</span>
-                  <span class="font-medium">Codex CLI</span>
-                  <TerminalIcon size={11} />
+                  <CliBrandIcon glyph={"⚡"} />
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium">Codex</div>
+                    <div class="text-[11px] text-muted-foreground">
+                      Runs <code class="font-mono text-[10px]">codex</code> in a
+                      terminal pane
+                    </div>
+                  </div>
+                  <LauncherChip variant="cli">CLI</LauncherChip>
                 </button>
               </Show>
 
+              {/* ---------- Shell ---------- */}
+              <SectionDivider />
+              <SectionLabel>Shell</SectionLabel>
               <button
                 type="button"
+                data-testid="new-terminal"
                 class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
                 onClick={() => void handleNewTerminal({ title: "Terminal" })}
               >
-                <TerminalIcon />
-                <span class="font-medium">Terminal</span>
+                <span class="w-[22px] flex items-center justify-center shrink-0">
+                  <TerminalIcon />
+                </span>
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium">Terminal</div>
+                  <div class="text-[11px] text-muted-foreground">
+                    Plain shell at project root
+                  </div>
+                </div>
               </button>
             </div>
           </Show>

--- a/src/components/layout/ThreadTabBar.tsx
+++ b/src/components/layout/ThreadTabBar.tsx
@@ -21,6 +21,26 @@ import { authStore } from "@/stores/auth.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { type Thread, threadStore } from "@/stores/thread.store";
 
+// Right-aligned chip telling the user how a thread is billed.
+// Mirrors LauncherChip in ThreadSidebar.tsx — kept locally to avoid pulling
+// shared UI primitives across components for a single 7-row use case.
+const Chip: Component<{
+  variant: "paid" | "subscription";
+  children: string;
+}> = (chipProps) => {
+  const tone = () =>
+    chipProps.variant === "paid"
+      ? "bg-primary/10 text-primary/90 border-primary/25"
+      : "bg-purple-500/12 text-purple-300 border-purple-500/30";
+  return (
+    <span
+      class={`text-[10px] font-semibold tracking-[0.04em] px-1.5 py-0.5 rounded-full border whitespace-nowrap ${tone()}`}
+    >
+      {chipProps.children}
+    </span>
+  );
+};
+
 export const ThreadTabBar: Component = () => {
   const [showNewMenu, setShowNewMenu] = createSignal(false);
   let menuRef: HTMLDivElement | undefined;
@@ -182,31 +202,42 @@ export const ThreadTabBar: Component = () => {
         </button>
 
         <Show when={showNewMenu()}>
-          <div class="absolute top-full right-0 min-w-[160px] bg-surface-2 border border-border rounded-lg p-1 z-20 shadow-[var(--shadow-lg)] animate-[slideInDown_150ms_ease]">
+          <div class="absolute top-full right-0 min-w-[260px] bg-surface-2 border border-border rounded-lg p-1 z-20 shadow-[var(--shadow-lg)] animate-[slideInDown_150ms_ease]">
             <Show when={allowsSerenPublicModels(authStore.privateChatPolicy)}>
               <button
                 type="button"
-                class="flex items-center gap-2 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed text-left"
+                data-testid="new-seren-chat"
+                class="flex items-center gap-2.5 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed text-left"
                 onClick={handleNewChat}
               >
-                <span class="text-[13px] w-[18px] text-center">💬</span>
-                <div class="font-medium">Seren Agent</div>
+                <span class="text-[13px] w-[18px] text-center shrink-0">
+                  💬
+                </span>
+                <div class="flex-1 min-w-0 font-medium">Seren Agent</div>
+                <Chip variant="paid">Pay-as-you-go</Chip>
               </button>
             </Show>
             <Show when={allowsSerenPrivateAgent(authStore.privateChatPolicy)}>
               <button
                 type="button"
-                class="flex items-center gap-2 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed text-left"
+                data-testid="new-seren-private-agent"
+                class="flex items-center gap-2.5 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed text-left"
                 onClick={handleNewPrivateChat}
               >
-                <span class="text-[13px] w-[18px] text-center">🔒</span>
-                <div class="font-medium">Seren Agent (Private)</div>
+                <span class="text-[13px] w-[18px] text-center shrink-0">
+                  🔒
+                </span>
+                <div class="flex-1 min-w-0 font-medium">
+                  Seren Agent (Private)
+                </div>
+                <Chip variant="paid">Pay-as-you-go</Chip>
               </button>
             </Show>
             <Show when={allowsClaudeAgent(authStore.privateChatPolicy)}>
               <button
                 type="button"
-                class="flex items-center gap-2 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed"
+                data-testid="new-claude-agent"
+                class="flex items-center gap-2.5 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed text-left"
                 onClick={() => handleNewAgent("claude-code")}
                 disabled={!fileTreeState.rootPath}
                 title={
@@ -215,14 +246,18 @@ export const ThreadTabBar: Component = () => {
                     : undefined
                 }
               >
-                <span class="text-[13px] w-[18px] text-center">🤖</span>
-                Claude Code Agent
+                <span class="text-[13px] w-[18px] text-center shrink-0">
+                  🤖
+                </span>
+                <div class="flex-1 min-w-0 font-medium">Claude Code</div>
+                <Chip variant="subscription">Subscription</Chip>
               </button>
             </Show>
             <Show when={allowsCodexAgent(authStore.privateChatPolicy)}>
               <button
                 type="button"
-                class="flex items-center gap-2 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed"
+                data-testid="new-codex-agent"
+                class="flex items-center gap-2.5 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed text-left"
                 onClick={() => handleNewAgent("codex")}
                 disabled={!fileTreeState.rootPath}
                 title={
@@ -231,14 +266,18 @@ export const ThreadTabBar: Component = () => {
                     : undefined
                 }
               >
-                <span class="text-[13px] w-[18px] text-center">⚡</span>
-                Codex Agent
+                <span class="text-[13px] w-[18px] text-center shrink-0">
+                  ⚡
+                </span>
+                <div class="flex-1 min-w-0 font-medium">Codex</div>
+                <Chip variant="subscription">Subscription</Chip>
               </button>
             </Show>
             <Show when={allowsGeminiAgent(authStore.privateChatPolicy)}>
               <button
                 type="button"
-                class="flex items-center gap-2 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed"
+                data-testid="new-gemini-agent"
+                class="flex items-center gap-2.5 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed text-left"
                 onClick={() => handleNewAgent("gemini")}
                 disabled={!fileTreeState.rootPath}
                 title={
@@ -247,8 +286,11 @@ export const ThreadTabBar: Component = () => {
                     : undefined
                 }
               >
-                <span class="text-[13px] w-[18px] text-center">✨</span>
-                Gemini Agent
+                <span class="text-[13px] w-[18px] text-center shrink-0">
+                  ✨
+                </span>
+                <div class="flex-1 min-w-0 font-medium">Gemini</div>
+                <Chip variant="subscription">Subscription</Chip>
               </button>
             </Show>
           </div>

--- a/tests/unit/gemini-agent.test.ts
+++ b/tests/unit/gemini-agent.test.ts
@@ -165,17 +165,21 @@ describe("Gemini Agent — thread.store.ts auto-detect (#1471)", () => {
 });
 
 describe("Gemini Agent — UI surface (#1471)", () => {
-  it("ThreadTabBar '+ New' menu includes a Gemini Agent button", () => {
+  it("ThreadTabBar '+ New' menu includes a Gemini button", () => {
+    // Label dropped the "Agent" suffix in #1832 once the chip vocabulary was added —
+    // the chip + section header now convey the kind. Wiring = testid + handler.
     expect(threadTabBarTsx).toContain("allowsGeminiAgent");
-    expect(threadTabBarTsx).toContain("Gemini Agent");
+    expect(threadTabBarTsx).toContain('data-testid="new-gemini-agent"');
     expect(threadTabBarTsx).toContain('handleNewAgent("gemini")');
   });
 
-  it("ThreadSidebar agent launcher includes a Gemini Agent button", () => {
+  it("ThreadSidebar agent launcher includes a Gemini button", () => {
     expect(threadSidebarTsx).toContain("allowsGeminiAgent");
-    expect(threadSidebarTsx).toContain("Gemini Agent");
-    expect(threadSidebarTsx).toContain(
-      'threadStore.createAgentThread("gemini"',
+    expect(threadSidebarTsx).toContain('data-testid="new-gemini-agent"');
+    expect(threadSidebarTsx).toContain('handleNewAgent("gemini")');
+    // Helper still routes to threadStore.createAgentThread under the hood.
+    expect(threadSidebarTsx).toMatch(
+      /threadStore\.createAgentThread\(\s*agentType\s*,\s*cwd\s*\)/,
     );
   });
 

--- a/tests/unit/launcher-redesign.test.ts
+++ b/tests/unit/launcher-redesign.test.ts
@@ -1,0 +1,142 @@
+// ABOUTME: Critical regression guards for the +New launcher redesign (#1832).
+// ABOUTME: Asserts UX invariants — sections, chips, testids, copy — and preserves gating + dispatch.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sidebarTsx = readFileSync(
+  resolve("src/components/layout/ThreadSidebar.tsx"),
+  "utf-8",
+);
+const tabBarTsx = readFileSync(
+  resolve("src/components/layout/ThreadTabBar.tsx"),
+  "utf-8",
+);
+
+describe("ThreadSidebar — launcher sections (#1832)", () => {
+  it("renders the four section labels", () => {
+    expect(sidebarTsx).toContain(">Chat<");
+    expect(sidebarTsx).toContain(">Coding agents<");
+    expect(sidebarTsx).toContain(">Command line<");
+    expect(sidebarTsx).toContain(">Shell<");
+  });
+});
+
+describe("ThreadSidebar — stable testids on every row (#1832)", () => {
+  const testids = [
+    "new-seren-chat",
+    "new-seren-private-agent",
+    "new-claude-agent",
+    "new-codex-agent",
+    "new-gemini-agent",
+    "new-claude-cli",
+    "new-codex-cli",
+    "new-terminal",
+  ];
+  for (const id of testids) {
+    it(`row has data-testid="${id}"`, () => {
+      expect(sidebarTsx).toContain(`data-testid="${id}"`);
+    });
+  }
+});
+
+describe("ThreadSidebar — chip vocabulary (#1832)", () => {
+  // Biome formats JSX text content onto its own line, so the closing-tag
+  // child can be on a separate line from the opening tag — match across whitespace.
+  it("uses 'Pay-as-you-go' for both Seren tiers", () => {
+    const chips = sidebarTsx.match(/>\s*Pay-as-you-go\s*</g) ?? [];
+    expect(chips.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("uses 'Subscription' for Claude / Codex / Gemini coding-agent rows", () => {
+    const chips = sidebarTsx.match(/>\s*Subscription\s*</g) ?? [];
+    expect(chips.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("uses 'CLI' chip for the two CLI rows", () => {
+    const chips = sidebarTsx.match(/>\s*CLI\s*</g) ?? [];
+    expect(chips.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("ThreadSidebar — Seren Private subtitle clarifies AWS Bedrock & Azure (#1832)", () => {
+  it("subtitle mentions both Bedrock and Azure (not BYOK)", () => {
+    const privateRow = sidebarTsx.slice(
+      sidebarTsx.indexOf('data-testid="new-seren-private-agent"'),
+      sidebarTsx.indexOf('data-testid="new-seren-private-agent"') + 1200,
+    );
+    expect(privateRow).toContain("Bedrock");
+    expect(privateRow).toContain("Azure");
+    expect(privateRow).not.toMatch(/\bBYOK\b/);
+  });
+});
+
+describe("ThreadSidebar — gating preserved (#1832)", () => {
+  it("retains all five org-policy gates", () => {
+    expect(sidebarTsx).toContain("allowsSerenPublicModels(authStore.privateChatPolicy)");
+    expect(sidebarTsx).toContain("allowsSerenPrivateAgent(authStore.privateChatPolicy)");
+    expect(sidebarTsx).toContain("allowsClaudeAgent(authStore.privateChatPolicy)");
+    expect(sidebarTsx).toContain("allowsCodexAgent(authStore.privateChatPolicy)");
+    expect(sidebarTsx).toContain("allowsGeminiAgent(authStore.privateChatPolicy)");
+  });
+});
+
+describe("ThreadSidebar — dispatch preserved (#1832)", () => {
+  it("public Seren chat still calls createChatThreadWithOptions with provider 'seren'", () => {
+    expect(sidebarTsx).toMatch(
+      /createChatThreadWithOptions\("New Chat",\s*\{[^}]*provider:\s*"seren"/s,
+    );
+  });
+
+  it("private Seren chat still calls createChatThreadWithOptions with provider 'seren-private'", () => {
+    expect(sidebarTsx).toMatch(
+      /createChatThreadWithOptions\("New Private Chat",\s*\{[^}]*provider:\s*"seren-private"/s,
+    );
+  });
+
+  it("agent dispatch helper still calls createAgentThread with cwd", () => {
+    expect(sidebarTsx).toMatch(
+      /createAgentThread\(\s*agentType\s*,\s*cwd\s*\)/,
+    );
+  });
+
+  it("each coding agent row routes through handleNewAgent with the right type", () => {
+    expect(sidebarTsx).toContain('handleNewAgent("claude-code")');
+    expect(sidebarTsx).toContain('handleNewAgent("codex")');
+    expect(sidebarTsx).toContain('handleNewAgent("gemini")');
+  });
+
+  it("CLI rows dispatch via createTerminalThread with the correct title and command", () => {
+    expect(sidebarTsx).toMatch(
+      /handleNewTerminal\(\{\s*title:\s*"Claude Code CLI",\s*command:\s*"claude",?\s*\}\)/s,
+    );
+    expect(sidebarTsx).toMatch(
+      /handleNewTerminal\(\{\s*title:\s*"Codex CLI",\s*command:\s*"codex",?\s*\}\)/s,
+    );
+  });
+
+  it("plain Terminal still dispatches via createTerminalThread with title 'Terminal'", () => {
+    expect(sidebarTsx).toMatch(/handleNewTerminal\(\{\s*title:\s*"Terminal"\s*\}\)/);
+  });
+});
+
+describe("ThreadTabBar — chip vocabulary on the secondary +New menu (#1832)", () => {
+  it("Seren rows carry 'Pay-as-you-go' chip", () => {
+    const chips = tabBarTsx.match(/>\s*Pay-as-you-go\s*</g) ?? [];
+    expect(chips.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("Claude / Codex / Gemini rows carry 'Subscription' chip", () => {
+    const chips = tabBarTsx.match(/>\s*Subscription\s*</g) ?? [];
+    expect(chips.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("retains the same five org-policy gates as the sidebar", () => {
+    expect(tabBarTsx).toContain("allowsSerenPublicModels(authStore.privateChatPolicy)");
+    expect(tabBarTsx).toContain("allowsSerenPrivateAgent(authStore.privateChatPolicy)");
+    expect(tabBarTsx).toContain("allowsClaudeAgent(authStore.privateChatPolicy)");
+    expect(tabBarTsx).toContain("allowsCodexAgent(authStore.privateChatPolicy)");
+    expect(tabBarTsx).toContain("allowsGeminiAgent(authStore.privateChatPolicy)");
+  });
+});


### PR DESCRIPTION
Closes #1832.

## Summary

- Group the `+New` launcher rows under labeled sections — **Chat / Coding agents / Command line / Shell** — with thin dividers, so the user reads "what kind of thing is this" before reading the brand.
- Right-aligned chip on every row tells the user *how it's billed*: `Pay-as-you-go` (both Seren tiers — metered SerenModels), `Subscription` (Claude / Codex / Gemini agents — your own plan), `CLI` (terminal-launching rows).
- CLI rows wrap their brand emoji in a small terminal-frame container with a `>_` corner badge so they visually depart from coding-agent rows. The robot/bolt-emoji collision between Claude Code Agent vs Claude Code CLI (and Codex Agent vs Codex CLI) is gone.
- Seren Agent (Private) subtitle now reads *Private SerenModels · AWS Bedrock & Azure* — these are Seren-operated private cloud models, **NOT BYOK**.
- Drop the trailing "Agent" / "CLI" suffix from brand labels; the section header and chip already convey the kind.
- Add stable `data-testid` on every row (8 in sidebar, 5 in tab bar). Preserves existing `new-thread-button` and `new-seren-chat` E2E selectors.
- Centralize per-agent dispatch into a `handleNewAgent(type)` helper, removing three near-identical inline lambdas.

## What did NOT change

- `src/services/organization-policy.ts` is untouched. All five `allowsXxx` gates still gate the same rows.
- Dispatch behavior: `createChatThreadWithOptions / createAgentThread / createTerminalThread` call sites are intact, with the same arguments.
- CLI gating: still keyed only on `agentStore.availableAgents.has(...)`, not org policy. (Same as today.)
- E2E specs: untouched. All preserved selectors still resolve.

## Test plan

- [x] `pnpm test` — 871/871 unit tests pass.
- [x] `pnpm biome check src/components/layout/ThreadSidebar.tsx src/components/layout/ThreadTabBar.tsx` — clean.
- [x] New regression-guard suite `tests/unit/launcher-redesign.test.ts` (23 assertions) pins:
  - Four section labels are present.
  - Eight stable testids exist on the right rows.
  - Chip vocabulary: 2× Pay-as-you-go, 3× Subscription, 2× CLI in sidebar; same chips in tab bar.
  - Seren Private subtitle includes "Bedrock" and "Azure", not "BYOK".
  - All five org-policy gates remain.
  - All four dispatch paths preserved (helper + `handleNewAgent` rows + CLI title/command + plain Terminal).
- [x] `gemini-agent.test.ts` UI assertions updated to match the dropped "Agent" suffix; wiring contract (testid + `handleNewAgent("gemini")` + helper dispatch) tightened, not relaxed.
- [ ] Manual: sidebar `+ New` and tab-bar `+ New` open, render four labeled sections / chips / CLI-frame icons, dispatch each row to the correct surface.

## Out of scope

Three pre-existing TypeScript errors live in `tests/unit/synthetic-transcript.test.ts` and `tests/unit/updater-store.test.ts` on `main`. Not introduced by this PR — separate ticket.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
