### PR TITLE
fix(tests): close #1834 — clear pre-existing tsc errors in test specs

### DIFF
--- a/tests/unit/synthetic-transcript.test.ts
+++ b/tests/unit/synthetic-transcript.test.ts
@@ -20,18 +20,21 @@ const {
 } = await import(/* @vite-ignore */ modulePath);
 
 interface JsonlRecord {
-  type: string;
+  type?: string;
   uuid?: string;
   parentUuid?: string | null;
   sessionId?: string;
-  message?: { content?: unknown };
   isCompactSummary?: boolean;
   isSyntheticAck?: boolean;
-  // biome-ignore lint/suspicious/noExplicitAny: test-only structural access
+  // biome-ignore lint/suspicious/noExplicitAny: test-only structural access — message and other shapes vary per record kind
   [key: string]: any;
 }
 
-function userTurn(uuid: string, parentUuid: string | null, text: string) {
+function userTurn(
+  uuid: string,
+  parentUuid: string | null,
+  text: string,
+): JsonlRecord {
   return {
     parentUuid,
     isSidechain: false,
@@ -50,7 +53,11 @@ function userTurn(uuid: string, parentUuid: string | null, text: string) {
   };
 }
 
-function assistantTextTurn(uuid: string, parentUuid: string, text: string) {
+function assistantTextTurn(
+  uuid: string,
+  parentUuid: string,
+  text: string,
+): JsonlRecord {
   return {
     parentUuid,
     isSidechain: false,
@@ -82,7 +89,7 @@ function assistantToolUseTurn(
   uuid: string,
   parentUuid: string,
   toolUseId: string,
-) {
+): JsonlRecord {
   return {
     parentUuid,
     isSidechain: false,
@@ -116,7 +123,7 @@ function userToolResultTurn(
   uuid: string,
   parentUuid: string,
   toolUseId: string,
-) {
+): JsonlRecord {
   return {
     parentUuid,
     isSidechain: false,
@@ -138,7 +145,7 @@ function userToolResultTurn(
   };
 }
 
-function attachmentRecord(parentUuid: string) {
+function attachmentRecord(parentUuid: string): JsonlRecord {
   return {
     parentUuid,
     isSidechain: false,

--- a/tests/unit/updater-store.test.ts
+++ b/tests/unit/updater-store.test.ts
@@ -64,7 +64,7 @@ describe("updaterStore install flow", () => {
     captureErrorMock.mockReset();
     // Vitest sets import.meta.env.DEV=true; the prod-only code paths under
     // test would otherwise short-circuit through isDevRuntime().
-    vi.stubEnv("DEV", "");
+    vi.stubEnv("DEV", false);
   });
 
   afterEach(() => {


### PR DESCRIPTION
Closes #1834.

## Summary

`pnpm tsc --noEmit` was reporting 3 pre-existing errors on `main` (the runtime suite passed — the failures were type-only). This PR clears them with the smallest reasonable changes, scoped to the two test files in the issue.

- **`tests/unit/synthetic-transcript.test.ts`** — annotate every record-helper (`userTurn`, `assistantTextTurn`, `assistantToolUseTurn`, `userToolResultTurn`, `attachmentRecord`) with `: JsonlRecord` so `parent[]` becomes a homogeneous array instead of a heterogeneous union that excluded `uuid` / `sessionId` on the attachment branch. Make `type` optional on the local `JsonlRecord` interface so `attachmentRecord` (which carries no `type`) fits. Drop the over-narrow `message?: { content?: unknown }` field — the helpers populate richer shapes (role, model, usage, etc.) and the existing `[key: string]: any` index signature already permits structural access without a fight.
- **`tests/unit/updater-store.test.ts`** — `vi.stubEnv("DEV", "")` → `vi.stubEnv("DEV", false)`. Vitest types require a boolean for `"PROD" | "DEV" | "SSR"`. Same falsy semantics at runtime; satisfies the signature.

## What did NOT change

- No production-source changes.
- No vitest version bump.
- No new test cases — typecheck cleanup, not new behavior.
- Runtime behavior in both specs is byte-identical: helpers still return the same object literals; `stubEnv("DEV", false)` is the same falsy as `""`.

## Test plan

- [x] `pnpm tsc --noEmit` exits 0 (down from 3 errors).
- [x] `pnpm test` — 871/871 unit tests pass.
- [x] Targeted: `pnpm vitest run tests/unit/synthetic-transcript.test.ts tests/unit/updater-store.test.ts` — 20/20 pass.
- [x] Biome: both files live outside the `**/src/**/*` include glob; nothing to lint.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
