### PR TITLE
fix(fork): close #1836 — encode underscore and dot like Claude Code does

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -241,11 +241,15 @@ function killChildTree(child) {
   }
 }
 
-function encodeProjectDirName(cwd) {
+export function encodeProjectDirName(cwd) {
+  // Claude Code collapses every non-`[a-zA-Z0-9-]` char to `-` (so `_` and `.`
+  // also become `-`). Restricting to just `/` produces a directory that
+  // doesn't exist for cwds like `/Users/x/Foo_Bar` — fork's outputJsonlPath
+  // then writes into a non-existent dir and ENOENTs. (#1836)
   const resolved = path.resolve(cwd);
   const unixPath = resolved.replaceAll("\\", "/");
   const sanitized = unixPath.replace(/^\/+/, "").replaceAll(":", "");
-  return `-${sanitized.replaceAll("/", "-")}`;
+  return `-${sanitized.replace(/[^a-zA-Z0-9-]/g, "-")}`;
 }
 
 function claudeProjectsRoot() {

--- a/scripts/smoke-synthetic-transcript.mjs
+++ b/scripts/smoke-synthetic-transcript.mjs
@@ -15,11 +15,9 @@ const {
   buildSyntheticTranscript,
 } = await import(new URL("bin/browser-local/synthetic-transcript.mjs", ROOT).href);
 
-function encodeProjectDirName(cwd) {
-  const resolved = path.resolve(cwd);
-  const sanitized = resolved.replace(/^\/+/, "").replaceAll(":", "");
-  return `-${sanitized.replaceAll("/", "-")}`;
-}
+const { encodeProjectDirName } = await import(
+  new URL("bin/browser-local/claude-runtime.mjs", ROOT).href
+);
 
 function claudeProjectsRoot() {
   return path.join(os.homedir(), ".claude", "projects");

--- a/src-tauri/src/claude_memory.rs
+++ b/src-tauri/src/claude_memory.rs
@@ -140,7 +140,8 @@ pub fn session_jsonl_path(root: &Path, project_cwd: &Path, session_id: &str) -> 
 }
 
 /// Encode an absolute project directory the same way Claude Code does:
-/// `/Users/a/b` → `-Users-a-b`.
+/// `/Users/a/b` → `-Users-a-b`. Every non-`[a-zA-Z0-9-]` char (including `_`
+/// and `.`) collapses to `-`, matching the CLI's on-disk convention. (#1836)
 pub fn encode_project_dir(cwd: &Path) -> String {
     let resolved = cwd
         .canonicalize()
@@ -148,7 +149,11 @@ pub fn encode_project_dir(cwd: &Path) -> String {
         .to_string_lossy()
         .replace('\\', "/");
     let sanitized = resolved.trim_start_matches('/').replace(':', "");
-    format!("-{}", sanitized.replace('/', "-"))
+    let normalized: String = sanitized
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
+        .collect();
+    format!("-{normalized}")
 }
 
 /// True when `path` is a `.md` file inside a Claude project's `memory/` subdir
@@ -1091,6 +1096,26 @@ mod tests {
             extract_claude_project_dir_name(path),
             Some("-Users-x-foo".to_string())
         );
+    }
+
+    #[test]
+    fn encode_project_dir_collapses_underscore_dot_and_other_specials() {
+        // #1836: every non-`[a-zA-Z0-9-]` char in the absolute cwd collapses
+        // to `-`, matching the Claude Code CLI's on-disk naming. Restricting
+        // to just `/` produced encoded names that didn't exist on disk for
+        // any cwd containing `_` (e.g. `Foo_Bar`) or `.` (e.g. `.app`),
+        // breaking fork, MEMORY.md render, and `claude_session_exists`.
+        let cwd = Path::new("/Users/x/Projects/Seren_Projects/seren-bounty");
+        assert_eq!(
+            encode_project_dir(cwd),
+            "-Users-x-Projects-Seren-Projects-seren-bounty"
+        );
+
+        let dotted = Path::new("/Users/x/.claude/plugins");
+        assert_eq!(encode_project_dir(dotted), "-Users-x--claude-plugins");
+
+        let plain = Path::new("/Users/x/Projects/seren-desktop");
+        assert_eq!(encode_project_dir(plain), "-Users-x-Projects-seren-desktop");
     }
 
     #[test]

--- a/tests/unit/claude-projects-encode.test.ts
+++ b/tests/unit/claude-projects-encode.test.ts
@@ -1,0 +1,29 @@
+// ABOUTME: Regression guard for #1836 — JS encoder must collapse `_`, `.`, and
+// ABOUTME: any other non-`[a-zA-Z0-9-]` char to `-`, matching the Claude CLI.
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — .mjs source is JS; type info isn't generated.
+import { encodeProjectDirName } from "../../bin/browser-local/claude-runtime.mjs";
+
+describe("#1836 — encodeProjectDirName matches Claude Code's on-disk naming", () => {
+  it("collapses underscores so paths like /Users/x/Foo_Bar/proj resolve to the real dir", () => {
+    // Pre-fix: this returned `-Users-x-Foo_Bar-proj`, a dir Claude Code never
+    // creates — fork's outputJsonlPath then ENOENT'd.
+    expect(
+      encodeProjectDirName("/Users/x/Projects/Seren_Projects/seren-bounty"),
+    ).toBe("-Users-x-Projects-Seren-Projects-seren-bounty");
+  });
+
+  it("collapses dots so /Users/x/.claude/plugins becomes --claude (double dash)", () => {
+    expect(encodeProjectDirName("/Users/x/.claude/plugins")).toBe(
+      "-Users-x--claude-plugins",
+    );
+  });
+
+  it("preserves existing dashes inside path segments", () => {
+    expect(encodeProjectDirName("/Users/x/Projects/seren-desktop")).toBe(
+      "-Users-x-Projects-seren-desktop",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Both project-dir encoders (`bin/browser-local/claude-runtime.mjs::encodeProjectDirName` and `src-tauri/src/claude_memory.rs::encode_project_dir`) only collapsed `/` to `-`, missing `_` and `.`. Claude Code itself collapses every non-`[a-zA-Z0-9-]` char. Result: any cwd containing `_` or `.` (e.g. `Seren_Projects`, `.claude`) generated an encoded name no directory on disk matched, and writes ENOENT'd.
- Most visible symptom: `forkConversation` failed with `ENOENT: no such file or directory, open '…/-Users-x-Projects-Seren_Projects-…/<uuid>.jsonl'`. See full audit in commit body for the latent paths this also unblocks (synthetic-transcript writer, MEMORY.md render, `--resume` gate).
- Removed a third copy of the same broken encoder in `scripts/smoke-synthetic-transcript.mjs` by importing the now-exported function.
- Tests added on both sides exercising `Seren_Projects`, `.claude`, and the no-op case.

## Audit included in commit

Full per-call-site classification (`Latent bug now unblocked` / `Bug masked by fallback` / `Round-trip safe` / `No migration needed`) is in the commit message. No DB migration is required — the watcher reads encoded names directly from on-disk paths Claude Code created, so stored `claude_agent_preferences` rows are already keyed correctly.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib claude_memory` — 22/22 pass
- [x] `pnpm vitest run tests/unit/claude-projects-encode.test.ts tests/unit/agent-fork-jsonl-flush.test.ts` — 8/8 pass
- [ ] Manual: open the desktop app from `/Users/x/Projects/Seren_Projects/<project>`, send a Claude prompt, click "Fork" on the head message — fork should succeed (no ENOENT in console).
- [ ] Manual: same project, force a predictive compaction — synthetic-transcript pre-warm should succeed.
- [ ] Manual: same project, restart app, observe MEMORY.md is now rendered to the correct on-disk dir.

Closes #1836.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
