### PR TITLE
fix(wallet): surface deposit error detail and fix support dedupe (#1838)

### DIFF
--- a/src/lib/support/hook.ts
+++ b/src/lib/support/hook.ts
@@ -180,6 +180,7 @@ export const __supportReportingTestHooks = import.meta.env.DEV
   ? {
       rememberSignature,
       seenSignatures: () => [...seenSignatures.keys()],
+      logSlice: () => [...logSlice],
       reset: () => {
         seenSignatures.clear();
         logSlice.splice(0);
@@ -309,9 +310,21 @@ export async function captureSupportError(
     capturing = false;
   }
 
-  const signature = await supportSignature(error);
+  const signature = await supportSignature(error, input.http);
   if (!isValidSignature(signature)) return;
-  if (!rememberSignature(signature)) return;
+  if (!rememberSignature(signature)) {
+    // Pre-fix this returned silently — combined with the kind-only signature
+    // for HTTP errors (#1838), an entire session's worth of distinct 4xx
+    // failures vanished after the first one. Leave a breadcrumb in the log
+    // slice so the next non-deduped report carries evidence of suppressed
+    // captures.
+    appendSupportLog(
+      "WARN",
+      "support-report",
+      `dropped duplicate signature: ${signature.slice(0, 8)}`,
+    );
+    return;
+  }
 
   const [ids, build] = await Promise.all([getSupportIds(), getBuildInfo()]);
   const installId = ids.install_id.toLowerCase();

--- a/src/lib/support/signature.ts
+++ b/src/lib/support/signature.ts
@@ -1,4 +1,7 @@
-import type { SupportReportErrorInfo } from "./types";
+// ABOUTME: Signature builder for support reports — keys dedupe by error shape.
+// ABOUTME: Folds HTTP request shape into the input when the stack is empty.
+
+import type { SupportReportErrorInfo, SupportReportHttpInfo } from "./types";
 
 function normalizeFrame(frame: string): string {
   return frame
@@ -7,6 +10,21 @@ function normalizeFrame(frame: string): string {
     .replace(/[A-Z]:\\Users\\[^\\\s)]+/gi, "$HOME")
     .replace(/:\d+:\d+/g, ":N:N")
     .trim();
+}
+
+function normalizeUrlPath(url: string): string {
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    pathname = url;
+  }
+  return pathname
+    .replace(
+      /\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+      "/$ID",
+    )
+    .replace(/\/\d+/g, "/$N");
 }
 
 async function sha256Hex(input: string): Promise<string> {
@@ -23,7 +41,19 @@ async function sha256Hex(input: string): Promise<string> {
 
 export async function supportSignature(
   error: SupportReportErrorInfo,
+  http?: SupportReportHttpInfo,
 ): Promise<string> {
   const topFrames = error.stack.slice(0, 3).map(normalizeFrame).join("\n");
-  return sha256Hex(`${error.kind}\n${topFrames}`);
+  // When the stack is empty (e.g. captures from `captureHttpFailure`), keying
+  // on `kind` alone collapses every distinct HTTP failure to one signature, so
+  // a session's first 4xx burns the dedupe slot for every later one. Fold the
+  // request shape — method, normalized path, status — into the input so HTTP
+  // failures dedupe per endpoint rather than globally. Path normalization
+  // strips query strings, UUIDs, and numeric IDs so /users/123 and /users/456
+  // still collapse together.
+  const httpKey =
+    topFrames.length === 0 && http
+      ? `\n${http.method} ${normalizeUrlPath(http.url)} ${http.status ?? "?"}`
+      : "";
+  return sha256Hex(`${error.kind}\n${topFrames}${httpKey}`);
 }

--- a/src/services/wallet.ts
+++ b/src/services/wallet.ts
@@ -57,13 +57,34 @@ export async function fetchBalance() {
  * @throws Error if not authenticated or network error
  */
 export async function initiateTopUp(amount: number) {
-  const { data, error } = await createDeposit({
+  const { data, error, response } = await createDeposit({
     body: { amount_cents: Math.round(amount * 100) },
     throwOnError: false,
   });
 
   if (error) {
-    throw new Error("Failed to initiate top-up");
+    const status = response?.status;
+    let serverMessage: string | undefined;
+    if (typeof error === "string") {
+      serverMessage = error;
+    } else if (error && typeof error === "object") {
+      const body = error as Record<string, unknown>;
+      if (typeof body.message === "string") {
+        serverMessage = body.message;
+      } else if (typeof body.error === "string") {
+        serverMessage = body.error;
+      } else if (typeof body.detail === "string") {
+        serverMessage = body.detail;
+      }
+    }
+
+    console.error("[Wallet] Error initiating top-up:", { status, error });
+    const detail = serverMessage
+      ? `${status ?? "request failed"} — ${serverMessage}`
+      : status
+        ? `HTTP ${status}`
+        : "request failed";
+    throw new Error(`Failed to initiate top-up: ${detail}`);
   }
 
   if (!data?.data) {

--- a/tests/unit/wallet-deposit-errors-1838.test.ts
+++ b/tests/unit/wallet-deposit-errors-1838.test.ts
@@ -1,0 +1,158 @@
+// ABOUTME: Critical regression tests for #1838 — wallet deposit errors must
+// ABOUTME: surface server detail, HTTP signatures must not collapse session-wide.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api", () => ({
+  createDeposit: vi.fn(),
+}));
+
+import { createDeposit } from "@/api";
+import {
+  __supportReportingTestHooks,
+  captureSupportError,
+} from "@/lib/support/hook";
+import { supportSignature } from "@/lib/support/signature";
+import { initiateTopUp } from "@/services/wallet";
+
+if (!__supportReportingTestHooks) {
+  throw new Error(
+    "__supportReportingTestHooks unavailable; run tests with import.meta.env.DEV=true",
+  );
+}
+const supportHooks = __supportReportingTestHooks;
+
+function installBrowserGlobals(): void {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+    key: (index: number) => [...store.keys()][index] ?? null,
+    get length() {
+      return store.size;
+    },
+  });
+  vi.stubGlobal("navigator", { platform: "MacIntel" });
+  vi.stubGlobal("window", {
+    addEventListener: vi.fn(),
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout,
+  });
+}
+
+async function flushSupportPipeline(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+describe("#1838 supportSignature differentiates HTTP failures by endpoint", () => {
+  it("HTTP errors with empty stack but different endpoints produce different signatures", async () => {
+    // Pre-fix every captureHttpFailure produced sha256("http_error\n"), so the
+    // first 4xx of a session burned the dedupe slot for every later one (e.g.
+    // a /wallet/balance 401 silenced every /wallet/deposit 4xx that followed).
+    // Folding the request shape into the signature is the load-bearing fix.
+    const depositSig = await supportSignature(
+      {
+        kind: "http_error",
+        message: "POST https://api.serendb.com/wallet/deposit returned 400",
+        stack: [],
+      },
+      {
+        method: "POST",
+        url: "https://api.serendb.com/wallet/deposit",
+        status: 400,
+      },
+    );
+    const balanceSig = await supportSignature(
+      {
+        kind: "http_error",
+        message: "GET https://api.serendb.com/wallet/balance returned 401",
+        stack: [],
+      },
+      {
+        method: "GET",
+        url: "https://api.serendb.com/wallet/balance",
+        status: 401,
+      },
+    );
+
+    expect(depositSig).toMatch(/^[a-f0-9]{64}$/);
+    expect(balanceSig).toMatch(/^[a-f0-9]{64}$/);
+    expect(depositSig).not.toBe(balanceSig);
+  });
+});
+
+describe("#1838 captureSupportError leaves a trail when dedupe drops a capture", () => {
+  beforeEach(() => {
+    installBrowserGlobals();
+    localStorage.setItem("seren_api_key", "seren_test_key");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(null, { status: 201 }))),
+    );
+  });
+
+  afterEach(() => {
+    supportHooks.reset();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("dedupe-dropped captures append a log_slice entry so the drop is visible in the next report", async () => {
+    const input = {
+      kind: "http_error",
+      message: "POST /wallet/deposit returned 400",
+      stack: [],
+      http: {
+        method: "POST",
+        url: "https://api.serendb.com/wallet/deposit",
+        status: 400,
+      },
+    };
+
+    await captureSupportError(input);
+    await flushSupportPipeline();
+    const before = supportHooks.logSlice();
+
+    // Same kind+stack+http → same signature → must dedupe-drop. Pre-fix this
+    // returned silently with no log, no warn, no log_slice entry, leaving
+    // operators with no way to correlate "I saw an error" with "no ticket".
+    await captureSupportError(input);
+    await flushSupportPipeline();
+
+    const after = supportHooks.logSlice();
+    expect(after.length).toBeGreaterThan(before.length);
+    const tail = after.at(-1);
+    expect(tail?.module).toBe("support-report");
+    expect(tail?.message).toMatch(/dropped duplicate signature/);
+  });
+});
+
+describe("#1838 initiateTopUp surfaces server status and message", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(createDeposit).mockReset();
+  });
+
+  it("throws an Error containing the HTTP status and the server-supplied message on 4xx", async () => {
+    vi.mocked(createDeposit).mockResolvedValue({
+      data: undefined,
+      error: { message: "Amount exceeds per-purchase limit of $300" },
+      response: new Response(null, { status: 400 }),
+    } as unknown as Awaited<ReturnType<typeof createDeposit>>);
+
+    // Pre-fix this threw a hardcoded "Failed to initiate top-up" with no
+    // status, no body, no console.error — operators had nothing to grep.
+    await expect(initiateTopUp(500)).rejects.toThrow(
+      /400.*Amount exceeds per-purchase limit of \$300/,
+    );
+    expect(console.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1838.

### What changed

- **`src/services/wallet.ts initiateTopUp`** — reads `response.status` and the server's `message`/`error`/`detail` field; throws `Failed to initiate top-up: <status> — <message>`. `console.error` mirrors `fetchBalance` so operators have a grep target. The same `initiateTopUp` powers `LowBalanceWarning`'s auto top-up, so that path also benefits.
- **`src/lib/support/signature.ts supportSignature`** — accepts an optional `http` argument. When the stack is empty (the path `captureHttpFailure` always takes), folds `method + normalized URL path + status` into the hashed input. URL normalization strips query strings and replaces UUIDs / numeric IDs with placeholders so `/users/123` and `/users/456` still dedupe together. Pre-fix every HTTP failure produced `sha256("http_error\n")`, collapsing a session's worth of distinct 4xx into one signature.
- **`src/lib/support/hook.ts captureSupportError`** — passes `input.http` to `supportSignature`; when `rememberSignature` rejects a duplicate, appends a `WARN` `log_slice` entry (`dropped duplicate signature: <8-char-prefix>`). The next non-deduped report now carries evidence of the suppression instead of the operator wondering why no ticket exists.

### Tests

`tests/unit/wallet-deposit-errors-1838.test.ts` — three regression tests, no overlap with existing coverage:
1. `supportSignature` produces different hashes for two HTTP failures with empty stacks but different endpoints.
2. The second `captureSupportError` call with the same input leaves a `dropped duplicate signature` line in `log_slice`.
3. `initiateTopUp` propagates HTTP status + server message in the thrown Error.

`pnpm test` — 929/929 unit tests pass. No regressions in the existing 18 `support-reporting` tests.

### Out of scope

Issue #1838 lists six bugs. This PR fixes 1, 3, 4. Bug 2 (`customFetch` doesn't log) stops being load-bearing once 1+3+4 are in. Bugs 5 (OpenAPI `DepositRequest` max field) and 6 (DepositModal pre-flight gate using the structured 4xx response) are deferred until serenorg/seren-core#165 ships the upstream contract.

### Verification path

For Taariq's repro (Add SerenBucks $500 → backend 4xx):
- DepositModal will now show `Failed to initiate top-up: 400 — <server-supplied reason>` instead of the hardcoded string.
- `console.error` `[Wallet] Error initiating top-up:` will be visible in DevTools.
- The support pipeline will produce a per-endpoint signature, so this 4xx no longer collides with whatever earlier HTTP failure burned the dedupe slot. If it does still get deduped legitimately, the next report's `log_slice` carries a `dropped duplicate signature` breadcrumb.
