### PR TITLE
fix(scrub): close #1840 — strip cross-mismatched scaffolding pairs

### DIFF
--- a/src/lib/scrub-agent-markup.ts
+++ b/src/lib/scrub-agent-markup.ts
@@ -2,8 +2,17 @@
 // ABOUTME: persistence, rendering, and Seren memory storage. #1807.
 
 const PATTERNS: RegExp[] = [
-  /<system-reminder>[\s\S]*?<\/system-reminder>/g,
+  // #1840: accept either close tag for the scaffolding families. The model
+  // occasionally opens a <system-reminder> block and closes it with
+  // </thinking> (or vice versa); the well-formed pair regex no-ops and raw
+  // markup leaks into the rendered chat bubble.
+  /<system-reminder>[\s\S]*?<\/(?:system-reminder|thinking)>/g,
+  /<thinking>[\s\S]*?<\/(?:thinking|system-reminder)>/g,
   /<command-(message|name|args)>[\s\S]*?<\/command-\1>/g,
+  // Sweep orphan scaffolding tags that escape paired matching (truncation,
+  // partial streams, or model-emitted bare markers). These are
+  // model-internal and must never reach the user.
+  /<\/?(?:system-reminder|thinking)>/g,
   // #1827: post-compaction seed-ack stock pattern. The compaction seed prompt
   // ("Confirm you have this context… wait for the user's next message") plus
   // the runtime's <system-reminder> injections produce a meta-acknowledgement

--- a/tests/unit/scrub-agent-markup.test.ts
+++ b/tests/unit/scrub-agent-markup.test.ts
@@ -101,4 +101,31 @@ describe("scrubAgentMarkup", () => {
       expect(scrubAgentMarkup(input)).toBe(input);
     });
   });
+
+  // #1840: model occasionally opens a <system-reminder> block and closes it
+  // with </thinking> (or vice versa). The well-formed pair regex no-ops and
+  // raw scaffolding leaks into the rendered chat bubble.
+  describe("#1840 — strips cross-mismatched scaffolding pairs and orphan tags", () => {
+    it("strips the observed <system-reminder>...</thinking> leak", () => {
+      const input =
+        "Proceeding to Phase 8 — Polymarket discovery.\n<system-reminder> This is a reminder that your todo list is currently empty. DO NOT mention this to the user. </thinking>";
+      expect(scrubAgentMarkup(input)).toBe(
+        "Proceeding to Phase 8 — Polymarket discovery.",
+      );
+    });
+
+    it("strips the symmetric <thinking>...</system-reminder> mismatched pair", () => {
+      const input =
+        "Hello.\n<thinking>internal monologue</system-reminder>\nWorld.";
+      expect(scrubAgentMarkup(input)).toBe("Hello.\n\nWorld.");
+    });
+
+    it("strips orphan scaffolding tags that escape paired matching", () => {
+      const input =
+        "Phase done. </thinking>\nNext: <system-reminder> partial open.";
+      expect(scrubAgentMarkup(input)).toBe(
+        "Phase done. \nNext:  partial open.",
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Closes #1840.
- Accepts either close tag for `<system-reminder>` and `<thinking>` scaffolding families so cross-mismatched pairs (`<system-reminder>...</thinking>`, observed in production) are stripped.
- Sweeps orphan opens/closes that escape paired matching (truncation, partial streams, model-emitted bare markers).
- Existing well-formed pair, `<command-*>` preservation, and seed-ack scrubber behavior unchanged.

## Test plan

- [x] `pnpm vitest run tests/unit/scrub-agent-markup.test.ts` — 17/17 pass (14 prior + 3 new).
- [x] Biome check clean.
- [x] Critical-only TDD: observed leak, symmetric mismatch, orphan tags. No mocks, no UI churn — pure string transform at the choke point used by both `flushStreamingContent` and `finalizeStreamingContent` in `agent.store.ts`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com