### PR TITLE
fix(release): close #1842 — rebind tag on undraft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -857,14 +857,25 @@ jobs:
             }
 
             if (publishTarget.draft) {
-              console.log(`Setting release ${publishTarget.id} to published (non-draft)`);
+              console.log(`Setting release ${publishTarget.id} to published (non-draft) and binding tag ${tagName} @ ${context.sha}`);
               await github.rest.repos.updateRelease({
                 owner,
                 repo,
                 release_id: publishTarget.id,
-                draft: false
+                draft: false,
+                tag_name: tagName,
+                target_commitish: context.sha
               });
               console.log('Release published successfully!');
+            } else if (publishTarget.tag_name !== tagName) {
+              console.log(`Release ${publishTarget.id} is published but tagged ${publishTarget.tag_name}; rebinding to ${tagName} @ ${context.sha}`);
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: publishTarget.id,
+                tag_name: tagName,
+                target_commitish: context.sha
+              });
             } else {
               console.log(`Release ${publishTarget.id} for tag ${tagName} is already published; skipping undraft`);
             }
@@ -1037,12 +1048,31 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const tagName = '${{ github.ref_name }}';
+            const initialReleaseId = '${{ needs.create-release.outputs.release_id }}';
 
-            const { data: release } = await github.rest.repos.getReleaseByTag({
-              owner,
-              repo,
-              tag: tagName
-            });
+            let release;
+            try {
+              const { data } = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag: tagName
+              });
+              release = data;
+              console.log(`Resolved release by tag ${tagName}: ${release.id}`);
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              const fallbackReleaseId = Number(initialReleaseId);
+              if (!Number.isFinite(fallbackReleaseId)) {
+                throw new Error(`No release for tag ${tagName} and invalid fallback ID: ${initialReleaseId}`);
+              }
+              console.log(`No release resolves by tag ${tagName}; falling back to release ID ${fallbackReleaseId}`);
+              const { data } = await github.rest.repos.getRelease({
+                owner,
+                repo,
+                release_id: fallbackReleaseId
+              });
+              release = data;
+            }
 
             const existingAssets = await github.rest.repos.listReleaseAssets({
               owner,


### PR DESCRIPTION
## Summary

- In `publish-release` undraft call: set `tag_name` + `target_commitish` so the published release is properly bound to the git tag (root cause of #1842, where v3.33.0 stayed tagged `untagged-51023b7926917090be93` after publishing). Also rebind if the release is already published but mistagged.
- In `Upload latest.json to GitHub release` step: add the same `getReleaseByTag → fallback releaseId` pattern the earlier `Publish release` step already uses, so a mistagged release can't cascade-fail the rest of the workflow.

Closes #1842.

## Background

Run https://github.com/serenorg/seren-desktop/actions/runs/25525740448 failed at the `Upload latest.json to GitHub release` step with HTTP 404 from `getReleaseByTag('v3.33.0')`. The release record had `tag_name="untagged-51023b7926917090be93"` because the draft was created that way and `updateRelease({draft: false})` doesn't touch tag binding. The earlier `Publish release` step survived this because it has a `fallbackReleaseId` path; the `latest.json` step did not. The cascade also blocked the `Upload installer files to R2` step that runs after it.

The v3.33.0 release was patched and the workflow re-run; this PR makes the workflow self-correcting for future runs.

## Test plan

- [ ] Cut a fresh tag and confirm the released record has `tag_name=v<version>` (not `untagged-...`).
- [ ] Confirm `latest.json` lands on the GitHub release.
- [ ] Confirm `Upload installer files to R2` step runs to completion.
