### PR TITLE
fix(claude-memory): close #1845 — retry transient HTTP 408/502/503/504

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -287,6 +287,36 @@ function App() {
         } catch (err) {
           // Reset so a later project/auth change can retry.
           claudeMemoryStartedForAuth = null;
+          // Emit telemetry so persistent failures (e.g. cold-start exhaustion,
+          // gateway outages) open a serenorg/seren-core ticket instead of dying
+          // silently in the dialog. #1845 — pre-fix, this entire failure class
+          // produced zero PostHog logs and zero error-tracking issues.
+          const errMessage = err instanceof Error ? err.message : String(err);
+          const errStack =
+            err instanceof Error && err.stack ? err.stack.split("\n") : [];
+          const httpStatusMatch = /returned HTTP (\d{3})/i.exec(errMessage);
+          const httpStatusCode = httpStatusMatch?.[1]
+            ? Number.parseInt(httpStatusMatch[1], 10)
+            : undefined;
+          try {
+            const { captureSupportError } = await import("@/lib/support/hook");
+            void captureSupportError({
+              kind: "claude_memory.start_failure",
+              message: errMessage,
+              stack: errStack,
+              http: {
+                method: "POST",
+                url: "https://api.serendb.com/publishers/seren-db/query",
+                status: httpStatusCode,
+                body: errMessage,
+              },
+            });
+          } catch (captureErr) {
+            // Telemetry must never block the user-facing dialog.
+            console.warn(
+              `[ClaudeMemory] captureSupportError unavailable: ${captureErr}`,
+            );
+          }
           await notifyUser(
             `The Claude memory interceptor could not start: ${err}. You can try again by toggling it off and on in Settings → Code Indexing → Claude Code Auto-Memory.`,
           );

--- a/src/services/claudeMemory.ts
+++ b/src/services/claudeMemory.ts
@@ -70,11 +70,24 @@ const DATABASE_READY_DELAY_MS = 2000;
  * but its Postgres backend is not yet routable by the `/query` endpoint.
  * Any of these on a `SELECT 1` means "wait and retry"; any OTHER error is
  * a real problem and should bubble up immediately.
+ *
+ * The `returned http <status>` markers anchor on the Rust formatter at
+ * `src-tauri/src/claude_memory.rs::SerenDbSqlClient::run_sql` (which emits
+ * `"SerenDB query returned HTTP {status}: {body}"`). 408 is the canonical
+ * empty-body edge-timeout signature when the SerenDB SQL backend is cold;
+ * 502/503/504 cover gateway-level transients during deploys, restarts, and
+ * saturation. 5xx responses that carry a concrete body (e.g. 500 carrying
+ * "Failed to connect to target database") still match via the connection
+ * markers above. #1845.
  */
 const DATABASE_NOT_READY_MARKERS = [
   "failed to connect to target database",
   "database not ready",
   "connection refused",
+  "returned http 408",
+  "returned http 502",
+  "returned http 503",
+  "returned http 504",
 ];
 
 function isDatabaseNotReadyError(err: unknown): boolean {
@@ -83,45 +96,45 @@ function isDatabaseNotReadyError(err: unknown): boolean {
 }
 
 /**
- * Poll a database with `SELECT 1` until it responds successfully, the
- * error stops looking like a cold-start, or we hit the max attempt count.
- * Returns once the database is queryable; throws on terminal errors or
- * timeout.
+ * Run a single SQL statement against SerenDB, retrying through the readiness
+ * marker set above when the failure looks like a cold backend or a gateway
+ * transient. The DDL leg of `ensureClaudeMemoryProvisioned` and the
+ * `SELECT 1` probe in `waitForDatabaseReady` both go through this helper so
+ * each leg gets the full 180-second cold-start budget — a single 408 on
+ * either path used to crash the entire interceptor start (#1845).
  *
- * This is the "Engineering 101" check the initial #1510 PR was missing:
- * a freshly-created SerenDB database is NOT immediately queryable via the
- * `/query` endpoint. The metadata write returns fast, but the Postgres
- * backend takes seconds (sometimes tens of seconds) to provision. The
- * only safe pattern is: create → poll until ready → DDL.
+ * The query must be safe to re-run on retry. The Claude memory DDL is
+ * idempotent (`CREATE TABLE IF NOT EXISTS`), and the readiness probe is
+ * `SELECT 1`. Do not pass non-idempotent statements through here.
  */
-export async function waitForDatabaseReady(
+async function runSqlWithReadinessRetry(
   projectId: string,
   branchId: string,
   databaseName: string,
+  query: string,
+  readOnly: boolean,
   maxAttempts: number = DATABASE_READY_MAX_ATTEMPTS,
   delayMs: number = DATABASE_READY_DELAY_MS,
   sleepFn: (ms: number) => Promise<void> = (ms) =>
     new Promise((r) => setTimeout(r, ms)),
-): Promise<void> {
+): Promise<unknown> {
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
-      await databases.runSql(
+      const result = await databases.runSql(
         projectId,
         branchId,
         databaseName,
-        "SELECT 1",
-        /* readOnly */ true,
+        query,
+        readOnly,
       );
       if (attempt > 1) {
         console.info(
-          `[ClaudeMemory] database "${databaseName}" became ready after ${attempt} attempts`,
+          `[ClaudeMemory] database "${databaseName}" served query after ${attempt} attempts`,
         );
       }
-      return;
+      return result;
     } catch (err) {
       if (!isDatabaseNotReadyError(err)) {
-        // Not a cold-start error — surface it immediately instead of
-        // burning the whole budget on a permanent failure.
         throw err;
       }
       if (attempt === maxAttempts) {
@@ -138,6 +151,42 @@ export async function waitForDatabaseReady(
       await sleepFn(delayMs);
     }
   }
+  // Exhausted the loop without returning or throwing — unreachable with the
+  // bounds above, but TypeScript can't prove it.
+  throw new Error("runSqlWithReadinessRetry exhausted without resolving");
+}
+
+/**
+ * Poll a database with `SELECT 1` until it responds successfully, the
+ * error stops looking like a cold-start, or we hit the max attempt count.
+ * Returns once the database is queryable; throws on terminal errors or
+ * timeout.
+ *
+ * Thin wrapper around `runSqlWithReadinessRetry`. A freshly-created SerenDB
+ * database is NOT immediately queryable via the `/query` endpoint — the
+ * metadata write returns fast, but the Postgres backend takes seconds
+ * (sometimes tens of seconds) to provision. The only safe pattern is:
+ * create → poll until ready → DDL.
+ */
+export async function waitForDatabaseReady(
+  projectId: string,
+  branchId: string,
+  databaseName: string,
+  maxAttempts: number = DATABASE_READY_MAX_ATTEMPTS,
+  delayMs: number = DATABASE_READY_DELAY_MS,
+  sleepFn: (ms: number) => Promise<void> = (ms) =>
+    new Promise((r) => setTimeout(r, ms)),
+): Promise<void> {
+  await runSqlWithReadinessRetry(
+    projectId,
+    branchId,
+    databaseName,
+    "SELECT 1",
+    /* readOnly */ true,
+    maxAttempts,
+    delayMs,
+    sleepFn,
+  );
 }
 
 export interface ClaudeMemoryStatus {
@@ -251,12 +300,14 @@ export async function ensureClaudeMemoryProvisioned(): Promise<ClaudeMemoryProvi
     CLAUDE_MEMORY_DATABASE_NAME,
   );
 
-  // Apply the table DDL. Idempotent — uses CREATE TABLE IF NOT EXISTS so
-  // running on every start is harmless.
+  // Apply the table DDL through the same readiness-retry helper as the
+  // SELECT 1 probe. The DDL is idempotent (CREATE TABLE IF NOT EXISTS), and
+  // a cold backend or transient gateway 408/502/503/504 between the probe
+  // and the DDL must not collapse the whole start (#1845).
   console.info(
     `[ClaudeMemory] applying claude_agent_preferences DDL to ${CLAUDE_MEMORY_DATABASE_NAME}`,
   );
-  await databases.runSql(
+  await runSqlWithReadinessRetry(
     project.id,
     branch.id,
     CLAUDE_MEMORY_DATABASE_NAME,

--- a/tests/services/claudeMemory.test.ts
+++ b/tests/services/claudeMemory.test.ts
@@ -172,6 +172,53 @@ describe("ensureClaudeMemoryProvisioned", () => {
     expect(databasesMock.runSql).not.toHaveBeenCalled();
   });
 
+  // #1845: A transient 408 on the DDL leg used to crash the entire
+  // interceptor start because the DDL was not wrapped in the same retry the
+  // readiness probe uses. Both legs must absorb cold-start blips.
+  it("survives a transient HTTP 408 on the DDL and persists IDs once it succeeds", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout"] });
+    try {
+      databasesMock.listProjects.mockResolvedValueOnce([
+        { id: "warm-proj", name: "claude-agent-prefs" },
+      ]);
+      databasesMock.listBranches.mockResolvedValueOnce([
+        { id: "warm-branch", name: "main" },
+      ]);
+      databasesMock.listDatabases.mockResolvedValueOnce([
+        { id: "warm-db", name: "claude_agent_prefs" },
+      ]);
+      // SELECT 1 succeeds, DDL fails once with 408 then succeeds.
+      databasesMock.runSql
+        .mockResolvedValueOnce({ columns: ["?column?"], row_count: 1, rows: [[1]] })
+        .mockRejectedValueOnce(new Error("SerenDB query returned HTTP 408: "))
+        .mockResolvedValueOnce({ columns: [], row_count: 0, rows: [] });
+
+      const promise = ensureClaudeMemoryProvisioned();
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toEqual({
+        projectId: "warm-proj",
+        branchId: "warm-branch",
+        databaseName: "claude_agent_prefs",
+      });
+      // Three calls: probe + DDL-fail + DDL-success. The DDL retry is what
+      // saves a session that would otherwise have crashed at start.
+      expect(databasesMock.runSql).toHaveBeenCalledTimes(3);
+      const ddlAttempt = databasesMock.runSql.mock.calls[2]!;
+      expect(ddlAttempt[3]).toContain(
+        "CREATE TABLE IF NOT EXISTS claude_agent_preferences",
+      );
+      // Persistence runs only after the DDL succeeds — proves recovery is end-to-end.
+      expect(settingsStoreMock.set).toHaveBeenCalledWith(
+        "claudeMemoryProjectId",
+        "warm-proj",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reuses an existing claude-agent-prefs project if one is found", async () => {
     // No persisted IDs, but the project already exists in the user's
     // SerenDB account from a previous machine or manual creation.
@@ -290,6 +337,58 @@ describe("waitForDatabaseReady", () => {
       ),
     ).rejects.toThrow(/did not become ready after 3 attempts/);
     expect(databasesMock.runSql).toHaveBeenCalledTimes(3);
+  });
+
+  // #1845: empty-body 408s from /publishers/seren-db/query are the canonical
+  // edge-timeout shape when the SerenDB SQL backend is cold. The retry loop
+  // must absorb them; otherwise a single transient 408 collapses the entire
+  // 180s cold-start budget.
+  it.each([408, 502, 503, 504])(
+    "retries on transient HTTP %i and resolves on success",
+    async (status) => {
+      databasesMock.runSql
+        .mockRejectedValueOnce(
+          new Error(`SerenDB query returned HTTP ${status}: `),
+        )
+        .mockResolvedValueOnce({ columns: ["?column?"], row_count: 1, rows: [[1]] });
+
+      const sleepMock = vi.fn(async () => {
+        /* no-op */
+      });
+      await waitForDatabaseReady(
+        "proj",
+        "branch",
+        "claude_agent_prefs",
+        5,
+        10,
+        sleepMock,
+      );
+      expect(databasesMock.runSql).toHaveBeenCalledTimes(2);
+      expect(sleepMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("still fails fast on terminal HTTP 401", async () => {
+    // Auth failures must not be swallowed by the retry loop — there is no
+    // amount of waiting that fixes a missing API key.
+    databasesMock.runSql.mockRejectedValueOnce(
+      new Error("SerenDB query returned HTTP 401: Unauthorized"),
+    );
+    const sleepMock = vi.fn(async () => {
+      /* no-op */
+    });
+    await expect(
+      waitForDatabaseReady(
+        "proj",
+        "branch",
+        "claude_agent_prefs",
+        10,
+        10,
+        sleepMock,
+      ),
+    ).rejects.toThrow(/401/);
+    expect(databasesMock.runSql).toHaveBeenCalledTimes(1);
+    expect(sleepMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `returned http 408|502|503|504` markers to `DATABASE_NOT_READY_MARKERS` so the readiness probe absorbs edge-timeout / gateway-transient HTTP responses instead of crashing the interceptor on a single blip.
- Extracts `runSqlWithReadinessRetry` so the DDL leg (`CREATE TABLE IF NOT EXISTS`) gets the same 180s cold-start budget the SELECT 1 probe always had.
- Wires the App.tsx start-failure handler to `captureSupportError`, including parsed HTTP status, so persistent failures actually open a `serenorg/seren-core` ticket instead of dying as a dialog.

Closes #1845.

## Test plan

- [x] `pnpm vitest run tests/services/claudeMemory.test.ts` — 16/16 pass (4 new parametric HTTP-marker tests, 1 fail-fast 401 test, 1 DDL-leg recovery test using fake timers, 10 existing tests unchanged)
- [x] `pnpm biome check` clean on touched files
- [x] No `src-tauri/` changes — Rust formatter is the contract markers anchor on
- [ ] Manual: trigger interceptor start against a cold backend; confirm the dialog no longer appears for a single transient and that an exhaustion case emits a `claude_memory.start_failure` support report
