### PR TITLE
fix(employees): redact raw 5xx HTML bodies from user-facing errors

### DIFF
--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,0 +1,99 @@
+// ABOUTME: Format SDK errors for user display. Redacts raw HTML upstream-error
+// ABOUTME: bodies in favor of clean status-based messages.
+
+const STATUS_TEXT: Record<number, string> = {
+  400: "Bad Request",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "Not Found",
+  408: "Request Timeout",
+  409: "Conflict",
+  413: "Payload Too Large",
+  422: "Unprocessable Entity",
+  429: "Too Many Requests",
+  500: "Server Error",
+  502: "Bad Gateway",
+  503: "Service Temporarily Unavailable",
+  504: "Gateway Timeout",
+};
+
+function looksLikeHtml(value: string): boolean {
+  const trimmed = value.trimStart();
+  if (trimmed.startsWith("<!doctype") || trimmed.startsWith("<!DOCTYPE")) {
+    return true;
+  }
+  if (trimmed.startsWith("<")) return true;
+  return /<(html|body|head|title|center)\b/i.test(value);
+}
+
+function statusMessage(
+  response: Response | undefined,
+  fallback: string,
+): string {
+  const status = response?.status;
+  if (typeof status !== "number" || status === 0) return fallback;
+  const text =
+    STATUS_TEXT[status] ??
+    (status >= 500 ? "Server Error" : status >= 400 ? "Request Failed" : "");
+  return text ? `${text} (${status})` : `HTTP ${status}`;
+}
+
+export function formatApiError(
+  error: unknown,
+  response: Response | undefined,
+  fallback: string,
+): string {
+  if (!error) return statusMessage(response, fallback);
+
+  if (error instanceof Error) {
+    return error.message || statusMessage(response, fallback);
+  }
+
+  if (typeof error === "string") {
+    if (error.length === 0) return statusMessage(response, fallback);
+    if (looksLikeHtml(error)) return statusMessage(response, fallback);
+    return error;
+  }
+
+  if (typeof error === "number" || typeof error === "boolean") {
+    return String(error);
+  }
+
+  if (typeof error === "object") {
+    const obj = error as Record<string, unknown>;
+    for (const key of [
+      "message",
+      "detail",
+      "error_description",
+      "error_message",
+      "error",
+      "title",
+      "reason",
+    ]) {
+      const value = obj[key];
+      if (
+        typeof value === "string" &&
+        value.length > 0 &&
+        !looksLikeHtml(value)
+      ) {
+        return value;
+      }
+    }
+    if (typeof obj.status === "number" || typeof obj.code === "string") {
+      const status = typeof obj.status === "number" ? obj.status : null;
+      const code = typeof obj.code === "string" ? obj.code : null;
+      const tag = [status, code].filter(Boolean).join(" ");
+      if (tag) return `HTTP ${tag}`;
+    }
+    try {
+      const dump = JSON.stringify(error);
+      if (dump && dump !== "{}") {
+        return dump.length > 240 ? `${dump.slice(0, 237)}...` : dump;
+      }
+    } catch {
+      // Circular ref; fall through.
+    }
+  }
+
+  return statusMessage(response, fallback);
+}

--- a/src/services/employee-approvals.ts
+++ b/src/services/employee-approvals.ts
@@ -5,6 +5,7 @@ import {
   type CloudPendingApprovalRun,
   serenCloudPendingApprovals,
 } from "@/api/seren-cloud";
+import { formatApiError } from "@/lib/api-errors";
 
 export type OrgPendingApprovalRun = {
   runId: string;
@@ -16,19 +17,6 @@ export type OrgPendingApprovalRun = {
   statusMessage: string | null;
   pendingCount: number;
 };
-
-function asMessage(error: unknown, fallback: string): string {
-  if (!error) return fallback;
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  if (typeof error === "object") {
-    const obj = error as Record<string, unknown>;
-    if (typeof obj.message === "string") return obj.message;
-    if (typeof obj.detail === "string") return obj.detail;
-    if (typeof obj.error === "string") return obj.error;
-  }
-  return fallback;
-}
 
 function fromCloud(row: CloudPendingApprovalRun): OrgPendingApprovalRun {
   return {
@@ -45,13 +33,13 @@ function fromCloud(row: CloudPendingApprovalRun): OrgPendingApprovalRun {
 
 export const employeeApprovals = {
   async listOrg(limit = 100): Promise<OrgPendingApprovalRun[]> {
-    const { data, error } = await serenCloudPendingApprovals({
+    const { data, error, response } = await serenCloudPendingApprovals({
       query: { limit },
       throwOnError: false,
     });
     if (error) {
       throw new Error(
-        `Failed to load pending approvals: ${asMessage(error, "")}`,
+        `Failed to load pending approvals: ${formatApiError(error, response, "")}`,
       );
     }
     return (data?.data ?? []).map(fromCloud);

--- a/src/services/employees-runtime.ts
+++ b/src/services/employees-runtime.ts
@@ -8,6 +8,7 @@ import {
   serenCloudDeploymentRunStream,
   serenCloudRun,
 } from "@/api/seren-cloud";
+import { formatApiError } from "@/lib/api-errors";
 
 interface ActiveRun {
   controller: AbortController;
@@ -73,45 +74,6 @@ export interface RunResult {
   runId: string | null;
   thinking: string | null;
   errorMessage: string | null;
-}
-
-function asMessage(error: unknown, fallback: string): string {
-  if (!error) return fallback;
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error.length > 0 ? error : fallback;
-  if (typeof error === "number" || typeof error === "boolean") {
-    return String(error);
-  }
-  if (typeof error === "object") {
-    const obj = error as Record<string, unknown>;
-    for (const key of [
-      "message",
-      "detail",
-      "error_description",
-      "error_message",
-      "error",
-      "title",
-      "reason",
-    ]) {
-      const value = obj[key];
-      if (typeof value === "string" && value.length > 0) return value;
-    }
-    if (typeof obj.status === "number" || typeof obj.code === "string") {
-      const status = typeof obj.status === "number" ? obj.status : null;
-      const code = typeof obj.code === "string" ? obj.code : null;
-      const tag = [status, code].filter(Boolean).join(" ");
-      if (tag) return `HTTP ${tag}`;
-    }
-    try {
-      const dump = JSON.stringify(error);
-      if (dump && dump !== "{}") {
-        return dump.length > 240 ? `${dump.slice(0, 237)}...` : dump;
-      }
-    } catch {
-      // Fall through to fallback if the body has a circular ref.
-    }
-  }
-  return fallback;
 }
 
 function fallbackTextFromResult(result: unknown): string {
@@ -295,8 +257,9 @@ async function pollUntilTerminal(
     });
     if (r.error || !r.data?.data) {
       throw new Error(
-        `Failed to read run ${runId}: ${asMessage(
+        `Failed to read run ${runId}: ${formatApiError(
           r.error,
+          r.response,
           "missing run data",
         )}`,
       );
@@ -453,8 +416,9 @@ export async function runEmployeeMessage(
     });
     if (created.error) {
       throw new Error(
-        `Failed to start employee run: ${asMessage(
+        `Failed to start employee run: ${formatApiError(
           created.error,
+          created.response,
           "the cloud trigger returned an error with no message",
         )}`,
       );

--- a/src/services/employees.ts
+++ b/src/services/employees.ts
@@ -30,6 +30,7 @@ import {
   serenCloudDeploymentRuns,
   serenCloudRun,
 } from "@/api/seren-cloud";
+import { formatApiError } from "@/lib/api-errors";
 import type {
   EmployeeDetail,
   EmployeePatch,
@@ -44,19 +45,6 @@ import type {
   ModelChoice,
   NewEmployeeInput,
 } from "@/lib/employees/types";
-
-function asMessage(error: unknown, fallback: string): string {
-  if (!error) return fallback;
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  if (typeof error === "object") {
-    const obj = error as Record<string, unknown>;
-    if (typeof obj.message === "string") return obj.message;
-    if (typeof obj.detail === "string") return obj.detail;
-    if (typeof obj.error === "string") return obj.error;
-  }
-  return fallback;
-}
 
 function deriveModelChoice(row: CloudDeploymentSummary): ModelChoice {
   const reason = row.managed_agent?.routing_reason?.toLowerCase();
@@ -276,11 +264,13 @@ function updateSpecFromPatch(patch: EmployeePatch): AgentSpecUpdate {
 
 export const employees = {
   async list(): Promise<EmployeeSummary[]> {
-    const { data, error } = await serenAgentListDeployments({
+    const { data, error, response } = await serenAgentListDeployments({
       throwOnError: false,
     });
     if (error) {
-      throw new Error(`Failed to list employees: ${asMessage(error, "")}`);
+      throw new Error(
+        `Failed to list employees: ${formatApiError(error, response, "")}`,
+      );
     }
     const rows = data?.data ?? [];
     return rows.map(summaryFromCloud);
@@ -288,14 +278,16 @@ export const employees = {
 
   async get(id: string): Promise<EmployeeDetail> {
     const [
-      { data: listData, error: listError },
+      { data: listData, error: listError, response: listResponse },
       { data: detailData, error: detailError, response: detailResponse },
     ] = await Promise.all([
       serenAgentListDeployments({ throwOnError: false }),
       serenAgentGetManagedDeployment({ path: { id }, throwOnError: false }),
     ]);
     if (listError) {
-      throw new Error(`Failed to load employee: ${asMessage(listError, "")}`);
+      throw new Error(
+        `Failed to load employee: ${formatApiError(listError, listResponse, "")}`,
+      );
     }
     const summary = (listData?.data ?? []).find((row) => row.id === id);
     if (!summary) {
@@ -320,82 +312,97 @@ export const employees = {
           contextBudgetTokens: null,
         };
       }
-      throw new Error(`Failed to load employee: ${asMessage(detailError, "")}`);
+      throw new Error(
+        `Failed to load employee: ${formatApiError(detailError, detailResponse, "")}`,
+      );
     }
     return detailFromManaged(detailData.data, base);
   },
 
   async deploy(input: NewEmployeeInput): Promise<EmployeeSummary> {
-    const { data, error } = await serenAgentDeploy({
+    const { data, error, response } = await serenAgentDeploy({
       body: specFromInput(input),
       throwOnError: false,
     });
     if (error || !data?.data) {
-      throw new Error(`Failed to deploy employee: ${asMessage(error, "")}`);
+      throw new Error(
+        `Failed to deploy employee: ${formatApiError(error, response, "")}`,
+      );
     }
     return summaryFromCloud(data.data);
   },
 
   async update(id: string, patch: EmployeePatch): Promise<EmployeeSummary> {
-    const { data, error } = await serenAgentUpdateManagedDeployment({
+    const { data, error, response } = await serenAgentUpdateManagedDeployment({
       path: { id },
       body: updateSpecFromPatch(patch),
       throwOnError: false,
     });
     if (error || !data?.data) {
-      throw new Error(`Failed to update employee: ${asMessage(error, "")}`);
+      throw new Error(
+        `Failed to update employee: ${formatApiError(error, response, "")}`,
+      );
     }
     return summaryFromCloud(data.data);
   },
 
   async remove(id: string): Promise<void> {
-    const { error } = await serenAgentDeleteManagedDeployment({
-      path: { id },
-      throwOnError: false,
-    });
-    if (error) {
-      throw new Error(`Failed to delete employee: ${asMessage(error, "")}`);
-    }
-  },
-
-  async suspend(id: string): Promise<void> {
-    const { error } = await serenAgentStopManagedDeployment({
-      path: { id },
-      throwOnError: false,
-    });
-    if (error) {
-      throw new Error(`Failed to suspend employee: ${asMessage(error, "")}`);
-    }
-  },
-
-  async wake(id: string): Promise<void> {
-    const { error } = await serenAgentStartManagedDeployment({
-      path: { id },
-      throwOnError: false,
-    });
-    if (error) {
-      throw new Error(`Failed to wake employee: ${asMessage(error, "")}`);
-    }
-  },
-
-  async listPrivateModels(): Promise<PrivateModelCatalogEntry[]> {
-    const { data, error } = await serenAgentPrivateModels({
-      throwOnError: false,
-    });
-    if (error) {
-      throw new Error(`Failed to list private models: ${asMessage(error, "")}`);
-    }
-    return data?.data?.models ?? [];
-  },
-
-  async listRevisions(id: string): Promise<EmployeeRevision[]> {
-    const { data, error } = await serenAgentListManagedDeploymentRevisions({
+    const { error, response } = await serenAgentDeleteManagedDeployment({
       path: { id },
       throwOnError: false,
     });
     if (error) {
       throw new Error(
-        `Failed to list employee revisions: ${asMessage(error, "")}`,
+        `Failed to delete employee: ${formatApiError(error, response, "")}`,
+      );
+    }
+  },
+
+  async suspend(id: string): Promise<void> {
+    const { error, response } = await serenAgentStopManagedDeployment({
+      path: { id },
+      throwOnError: false,
+    });
+    if (error) {
+      throw new Error(
+        `Failed to suspend employee: ${formatApiError(error, response, "")}`,
+      );
+    }
+  },
+
+  async wake(id: string): Promise<void> {
+    const { error, response } = await serenAgentStartManagedDeployment({
+      path: { id },
+      throwOnError: false,
+    });
+    if (error) {
+      throw new Error(
+        `Failed to wake employee: ${formatApiError(error, response, "")}`,
+      );
+    }
+  },
+
+  async listPrivateModels(): Promise<PrivateModelCatalogEntry[]> {
+    const { data, error, response } = await serenAgentPrivateModels({
+      throwOnError: false,
+    });
+    if (error) {
+      throw new Error(
+        `Failed to list private models: ${formatApiError(error, response, "")}`,
+      );
+    }
+    return data?.data?.models ?? [];
+  },
+
+  async listRevisions(id: string): Promise<EmployeeRevision[]> {
+    const { data, error, response } =
+      await serenAgentListManagedDeploymentRevisions({
+        path: { id },
+        throwOnError: false,
+      });
+    if (error) {
+      throw new Error(
+        `Failed to list employee revisions: ${formatApiError(error, response, "")}`,
       );
     }
     const rows = data?.data ?? [];
@@ -406,12 +413,14 @@ export const employees = {
     deploymentId: string,
     runId: string,
   ): Promise<EmployeeRunDetail> {
-    const { data, error } = await serenCloudDeploymentRun({
+    const { data, error, response } = await serenCloudDeploymentRun({
       path: { id: deploymentId, run_id: runId },
       throwOnError: false,
     });
     if (error || !data?.data) {
-      throw new Error(`Failed to load run: ${asMessage(error, "")}`);
+      throw new Error(
+        `Failed to load run: ${formatApiError(error, response, "")}`,
+      );
     }
     return runDetailFromCloud(data.data);
   },
@@ -420,12 +429,14 @@ export const employees = {
     deploymentId: string,
     runId: string,
   ): Promise<EmployeeRunArtifact[]> {
-    const { data, error } = await serenCloudDeploymentRunArtifacts({
+    const { data, error, response } = await serenCloudDeploymentRunArtifacts({
       path: { id: deploymentId, run_id: runId },
       throwOnError: false,
     });
     if (error) {
-      throw new Error(`Failed to list run artifacts: ${asMessage(error, "")}`);
+      throw new Error(
+        `Failed to list run artifacts: ${formatApiError(error, response, "")}`,
+      );
     }
     const rows = data?.data ?? [];
     return rows.map(artifactFromCloud);
@@ -435,13 +446,15 @@ export const employees = {
     id: string,
     limit = 20,
   ): Promise<{ rows: EmployeeRun[]; hasMore: boolean; total: number }> {
-    const { data, error } = await serenCloudDeploymentRuns({
+    const { data, error, response } = await serenCloudDeploymentRuns({
       path: { id },
       query: { limit },
       throwOnError: false,
     });
     if (error) {
-      throw new Error(`Failed to list employee runs: ${asMessage(error, "")}`);
+      throw new Error(
+        `Failed to list employee runs: ${formatApiError(error, response, "")}`,
+      );
     }
     const rows = data?.data ?? [];
     return {
@@ -455,13 +468,14 @@ export const employees = {
     deploymentId: string,
     runId: string,
   ): Promise<EmployeeRunPendingApprovals> {
-    const { data, error } = await serenCloudDeploymentRunPendingApprovals({
-      path: { id: deploymentId, run_id: runId },
-      throwOnError: false,
-    });
+    const { data, error, response } =
+      await serenCloudDeploymentRunPendingApprovals({
+        path: { id: deploymentId, run_id: runId },
+        throwOnError: false,
+      });
     if (error || !data?.data) {
       throw new Error(
-        `Failed to load pending approvals: ${asMessage(error, "")}`,
+        `Failed to load pending approvals: ${formatApiError(error, response, "")}`,
       );
     }
     return pendingApprovalsFromCloud(data.data);
@@ -471,7 +485,7 @@ export const employees = {
     deploymentId: string,
     request: EmployeeRunResumeRequest,
   ): Promise<{ runId: string | null; status: string }> {
-    const { data, error } = await serenCloudRun({
+    const { data, error, response } = await serenCloudRun({
       path: { id: deploymentId },
       body: {
         resume_checkpoint_id: request.checkpointId,
@@ -484,7 +498,9 @@ export const employees = {
       throwOnError: false,
     });
     if (error || !data?.data) {
-      throw new Error(`Failed to resume run: ${asMessage(error, "")}`);
+      throw new Error(
+        `Failed to resume run: ${formatApiError(error, response, "")}`,
+      );
     }
     return {
       runId: data.data.run_id ?? null,
@@ -493,13 +509,17 @@ export const employees = {
   },
 
   async rollback(id: string, revisionId: string): Promise<EmployeeSummary> {
-    const { data, error } = await serenAgentRollbackManagedDeployment({
-      path: { id },
-      body: { revision_id: revisionId },
-      throwOnError: false,
-    });
+    const { data, error, response } = await serenAgentRollbackManagedDeployment(
+      {
+        path: { id },
+        body: { revision_id: revisionId },
+        throwOnError: false,
+      },
+    );
     if (error || !data?.data) {
-      throw new Error(`Failed to roll back employee: ${asMessage(error, "")}`);
+      throw new Error(
+        `Failed to roll back employee: ${formatApiError(error, response, "")}`,
+      );
     }
     return summaryFromCloud(data.data);
   },

--- a/tests/unit/api-errors.test.ts
+++ b/tests/unit/api-errors.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Critical tests for formatApiError - the helper that translates SDK errors
+// ABOUTME: into user-facing messages without leaking raw HTML upstream-error bodies.
+
+import { describe, expect, it } from "vitest";
+import { formatApiError } from "@/lib/api-errors";
+
+const html503 = `<html>
+ <head><title>503 Service Temporarily Unavailable</title></head>
+ <body>
+ <center><h1>503 Service Temporarily Unavailable</h1></center>
+ </body>
+ </html>`;
+
+function makeResponse(status: number): Response {
+  return new Response(null, { status });
+}
+
+describe("formatApiError", () => {
+  it("collapses raw HTML 503 bodies into a status-based message", () => {
+    // The exact symptom from issue #1848: hey-api throws the HTML body as a
+    // string when JSON.parse fails; we must NOT splice it into a user toast.
+    const msg = formatApiError(html503, makeResponse(503), "fallback");
+    expect(msg).not.toContain("<html");
+    expect(msg).not.toContain("<title");
+    expect(msg).toBe("Service Temporarily Unavailable (503)");
+  });
+
+  it("uses status-based message for any HTML 5xx body, not just 503", () => {
+    const html502 = "<html><body><h1>502 Bad Gateway</h1></body></html>";
+    expect(formatApiError(html502, makeResponse(502), "")).toBe(
+      "Bad Gateway (502)",
+    );
+  });
+
+  it("preserves structured JSON error detail", () => {
+    const err = { detail: "Deployment is suspended" };
+    expect(formatApiError(err, makeResponse(409), "fallback")).toBe(
+      "Deployment is suspended",
+    );
+  });
+
+  it("falls back to provided fallback for empty string error", () => {
+    expect(formatApiError("", undefined, "no message provided")).toBe(
+      "no message provided",
+    );
+  });
+
+  it("returns plain string errors unchanged when not HTML", () => {
+    expect(
+      formatApiError("rate limited", makeResponse(429), "fallback"),
+    ).toBe("rate limited");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `formatApiError(error, response, fallback)` (`src/lib/api-errors.ts`) that detects raw HTML upstream-error bodies and substitutes a clean status-based message (e.g. `Service Temporarily Unavailable (503)`).
- Wires it through every throwing call site in `employees.ts`, `employees-runtime.ts`, and `employee-approvals.ts`; removes the three duplicated `asMessage` helpers.
- Adds 5 critical unit tests (`tests/unit/api-errors.test.ts`) covering the reported HTML 503 case, an HTML 502 5xx case, structured JSON `detail`, empty-string fallback, and a non-HTML plain string error.

Closes #1848

## Root cause

The hey-api generated client (`src/api/generated/.../client.gen.ts:192-201`) reads the response body as text, attempts `JSON.parse`, and on failure throws the raw text:

```ts
const textError = await response.text();
let jsonError: unknown;
try { jsonError = JSON.parse(textError); } catch { /* noop */ }
throw jsonError ?? textError;
```

With `throwOnError: false`, the catch path returns `{ error: <raw HTML string>, response }`. Each service then ran a local `asMessage` helper that spliced the HTML straight into the user-visible Error.

## Test plan

- [x] `pnpm vitest run tests/unit/api-errors.test.ts` (5/5 pass)
- [x] `pnpm test` (947/947 pass)
- [x] `tsc --noEmit` clean
- [x] `pnpm check` clean on touched files
