### PR TITLE
fix(agent): close #1852 — silence self-inflicted reclaim noise

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -26,6 +26,28 @@ const spawningConversations = new Set<string>();
  *  into new/live sessions. Cleared when the global subscriber is torn down. */
 const terminatedSessionIds = new Set<string>();
 
+/** Session IDs that the agent store just terminated programmatically. The
+ *  runtime emits "Session terminated before request completed." (and other
+ *  death-string `provider://error` events) when in-flight control requests
+ *  reject during a programmatic kill — those are self-inflicted and must
+ *  not surface as user-visible chat errors. The error handler short-circuits
+ *  death-string events for ids in this set. Cleared at the end of
+ *  terminateSession after the IPC kill completes. #1852. */
+const expectedTerminateSessionIds = new Set<string>();
+
+/** Lazy getter for the user's current navigation target, registered by
+ *  thread.store. `getIdleClaudeSessionIds` consults this so a parallel spawn's
+ *  preemptive idle-reclaim never targets the conversation the user is viewing —
+ *  even when `state.activeSessionId` has not yet been updated for that thread.
+ *  thread.store -> agent.store is the existing import direction; the reverse
+ *  would cycle, so we use a registration callback instead. #1852. */
+let activeNavigationThreadIdGetter: (() => string | null) | null = null;
+export function registerActiveNavigationThreadIdGetter(
+  getter: () => string | null,
+): void {
+  activeNavigationThreadIdGetter = getter;
+}
+
 /** Lightweight context for sessions that are mid-spawn (IPC call in flight).
  *  Populated before providerService.spawnAgent and cleaned up after the session
  *  is registered in state.sessions. The global event logger consults this map
@@ -1212,6 +1234,7 @@ function isRetryableClaudeInitError(message: string): boolean {
 
 function getIdleClaudeSessionIds(excludeConversationId?: string): string[] {
   const activeId = state.activeSessionId;
+  const navTarget = activeNavigationThreadIdGetter?.() ?? null;
   return Object.entries(state.sessions)
     .filter(([id, session]) => {
       if (session.info.agentType !== "claude-code") return false;
@@ -1224,6 +1247,16 @@ function getIdleClaudeSessionIds(excludeConversationId?: string): string[] {
         excludeConversationId &&
         session.conversationId === excludeConversationId
       ) {
+        return false;
+      }
+      // Honour the user's navigation intent. selectThread sets the active
+      // thread synchronously, but a freshly-clicked thread's session may not
+      // yet be reflected in `state.activeSessionId` (the live-session branch
+      // marks it synchronously after #1852, but a respawning thread is
+      // briefly without an active session id). Excluding by conversationId
+      // closes that window so a parallel spawn's preemptive reclaim cannot
+      // kill the session the user just navigated to. #1852.
+      if (navTarget && session.conversationId === navTarget) {
         return false;
       }
       // Keep actively prompting sessions alive; only reclaim idle/errored ones.
@@ -1968,6 +2001,14 @@ export const agentStore = {
         rejectReady = reject;
       });
 
+      // Filter status events by the spawn's own session id. Without this
+      // filter a `terminated`/`error` event from an unrelated session can
+      // abort the new spawn, and a `ready` from an unrelated session can
+      // resolve the readyPromise with the wrong id. Seeded from
+      // localSessionId when the caller pre-allocated one (resume / re-spawn);
+      // otherwise updated to info.id once spawnAgent returns. #1852.
+      let expectedReadySessionId: string | null = localSessionId ?? null;
+
       // Listen to session status events temporarily so ready-state resolution does
       // not depend on global event routing order.
       const tempUnsubscribe =
@@ -1977,6 +2018,12 @@ export const agentStore = {
             console.log("[AgentStore] Received session status event:", data);
             if (state.sessions[data.sessionId]) {
               this.handleStatusChange(data.sessionId, data.status, data);
+            }
+            if (
+              expectedReadySessionId &&
+              data.sessionId !== expectedReadySessionId
+            ) {
+              return;
             }
             if (data.status === "ready" && resolveReady) {
               resolveReady(data.sessionId);
@@ -2203,6 +2250,7 @@ export const agentStore = {
           opts?.initialModelId,
         );
         console.log("[AgentStore] Spawn result:", info);
+        expectedReadySessionId = info.id;
 
         // The new session is alive — immediately clear the terminated flag so
         // early events (configOptionsUpdate, sessionStatus with models/modes)
@@ -3035,6 +3083,13 @@ export const agentStore = {
     // subscriber immediately starts dropping late-arriving events.
     terminatedSessionIds.add(sessionId);
 
+    // Mark this kill as self-inflicted BEFORE the IPC fires, so any
+    // death-string `provider://error` event the runtime emits while
+    // tearing down (rejected control requests, etc.) is silently
+    // discarded by the error handler instead of surfacing as chat noise.
+    // The flag is cleared at the end of this function. #1852.
+    expectedTerminateSessionIds.add(sessionId);
+
     // Dismiss any pending ActionConfirmation dialogs whose owning session is
     // going away — the user must not approve a tool call against a dead
     // session. If the promoted/new session still wants the tool, it will
@@ -3104,6 +3159,10 @@ export const agentStore = {
       terminatedSessionIds.clear();
       spawnContextMap.clear();
     }
+
+    // Self-inflicted death window is over: any further death-string events
+    // for this id are no longer ours to suppress. #1852.
+    expectedTerminateSessionIds.delete(sessionId);
   },
 
   /**
@@ -5342,8 +5401,6 @@ Structured summary:`;
           );
           this.addErrorMessage(sessionId, event.data.error);
         } else {
-          this.addErrorMessage(sessionId, event.data.error);
-
           // Mid-prompt session death — runtime emits one of these strings
           // when the child process is terminated or exits while a control
           // request is pending. sendPrompt's catch block at line ~3819 only
@@ -5358,6 +5415,24 @@ Structured summary:`;
             errStr.includes("stopped before request completed") ||
             errStr.includes("stopped while prompt was active") ||
             errStr.includes("Worker thread dropped");
+
+          // Self-inflicted death: agentStore.terminateSession just killed
+          // this session (e.g. preemptive idle-reclaim before a parallel
+          // spawn). The runtime emits the death string when in-flight
+          // control requests reject; the user did not experience a crash
+          // and must not see a stuck error banner. The cleanups above
+          // (flushPendingUserMessage, finalizeStreamingContent,
+          // markPendingToolCallsComplete) already ran; just return. #1852.
+          if (isSessionDeath && expectedTerminateSessionIds.has(sessionId)) {
+            console.info(
+              "[AgentStore] Suppressing self-inflicted death-string event:",
+              sessionId,
+            );
+            break;
+          }
+
+          this.addErrorMessage(sessionId, event.data.error);
+
           const deathConvoId = state.sessions[sessionId]?.conversationId;
           if (
             isSessionDeath &&

--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -11,7 +11,10 @@ import {
   type SessionStatus,
 } from "@/services/providers";
 import { skills as skillsService } from "@/services/skills";
-import { agentStore } from "@/stores/agent.store";
+import {
+  agentStore,
+  registerActiveNavigationThreadIdGetter,
+} from "@/stores/agent.store";
 import { chatStore } from "@/stores/chat.store";
 import { conversationStore } from "@/stores/conversation.store";
 import { editorSessionStore } from "@/stores/editor.sessions";
@@ -140,6 +143,12 @@ const [state, setState] = createStore<ThreadState>({
   preferChat: false,
   projectOrder: loadProjectOrder(),
 });
+
+// Expose the user's current navigation target to agent.store's idle-reclaim
+// filter without forming a circular import. The getter is invoked lazily by
+// getIdleClaudeSessionIds, so referencing `state` here is safe even though
+// thread.store has only just begun evaluating. #1852.
+registerActiveNavigationThreadIdGetter(() => state.activeThreadId);
 
 // ============================================================================
 // Helpers
@@ -506,6 +515,13 @@ export const threadStore = {
         liveSession?.info.id,
       );
       if (liveSession) {
+        // Mark active synchronously so a parallel spawn's preemptive
+        // idle-reclaim cannot kill the session the user just clicked.
+        // Without this, state.activeSessionId still points at the previous
+        // thread until listSessions resolves, and getIdleClaudeSessionIds
+        // sees the just-clicked session as "idle and not active". #1852.
+        agentStore.setActiveSession(liveSession.info.id);
+
         // Verify the session actually exists in the Rust backend.
         // After an app restart the JS store may hold stale sessions
         // whose backend process is gone.
@@ -517,26 +533,21 @@ export const threadStore = {
           const alive = backendSessions.some(
             (s) => s.id === liveSession.info.id,
           );
-          if (alive) {
-            agentStore.setActiveSession(liveSession.info.id);
-          } else {
-            console.warn(
-              "[Thread] Session",
-              liveSession.info.id,
-              "exists in store but not in backend - resuming",
-            );
-            agentStore.setActiveSession(null);
-            await agentStore.terminateSession(liveSession.info.id);
-            if (
-              state.activeThreadId !== id ||
-              state.activeThreadKind !== kind
-            ) {
-              return;
-            }
-            const cwd = thread?.projectRoot || fileTreeState.rootPath;
-            if (cwd) {
-              void agentStore.resumeAgentConversation(id, cwd);
-            }
+          if (alive) return;
+
+          console.warn(
+            "[Thread] Session",
+            liveSession.info.id,
+            "exists in store but not in backend - resuming",
+          );
+          agentStore.setActiveSession(null);
+          await agentStore.terminateSession(liveSession.info.id);
+          if (state.activeThreadId !== id || state.activeThreadKind !== kind) {
+            return;
+          }
+          const cwd = thread?.projectRoot || fileTreeState.rootPath;
+          if (cwd) {
+            void agentStore.resumeAgentConversation(id, cwd);
           }
         });
       } else {

--- a/tests/unit/agent-session-died-mid-prompt.test.ts
+++ b/tests/unit/agent-session-died-mid-prompt.test.ts
@@ -90,7 +90,10 @@ describe("#1805 — error event handler detects mid-prompt session death", () =>
   it("resets session status to ready and routes through setTurnError", () => {
     const detect = agentStoreSource.indexOf("isSessionDeath");
     expect(detect).toBeGreaterThan(0);
-    const body = agentStoreSource.slice(detect, detect + 1500);
+    // Window widened past the #1852 self-inflicted-suppression block which
+    // now sits between isSessionDeath detection and the setTurnError
+    // recovery branch.
+    const body = agentStoreSource.slice(detect, detect + 2500);
     expect(body).toContain('"ready" as SessionStatus');
     expect(body).toContain(
       'this.setTurnError(deathConvoId, "crash_ceiling"',

--- a/tests/unit/idle-reclaim-race-1852.test.ts
+++ b/tests/unit/idle-reclaim-race-1852.test.ts
@@ -1,0 +1,118 @@
+// ABOUTME: Source-level regression tests for #1852 — post-promptComplete idle-reclaim race.
+// ABOUTME: Pins navigation-intent getter, expectedTerminate suppression, and ready-subscriber filter.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const threadStoreSource = readFileSync(
+  resolve("src/stores/thread.store.ts"),
+  "utf-8",
+);
+
+describe("#1852 — Fix 2: idle-reclaim honours navigation intent", () => {
+  it("agent.store exports a registration hook for the navigation-intent getter", () => {
+    expect(agentStoreSource).toContain(
+      "export function registerActiveNavigationThreadIdGetter",
+    );
+  });
+
+  it("thread.store registers its activeThreadId as the navigation-intent getter", () => {
+    expect(threadStoreSource).toContain(
+      "registerActiveNavigationThreadIdGetter",
+    );
+    const idx = threadStoreSource.indexOf(
+      "registerActiveNavigationThreadIdGetter(",
+    );
+    // The registration call (not the import) must reference state.activeThreadId.
+    const callBlock = threadStoreSource.slice(idx, idx + 200);
+    expect(callBlock).toContain("state.activeThreadId");
+  });
+
+  it("getIdleClaudeSessionIds excludes sessions whose conversationId matches the navigation target", () => {
+    const idx = agentStoreSource.indexOf("function getIdleClaudeSessionIds");
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 1500);
+    expect(body).toContain("activeNavigationThreadIdGetter");
+    expect(body).toMatch(/session\.conversationId\s*===\s*navTarget/);
+  });
+});
+
+describe("#1852 — Fix 3: self-inflicted terminates do not surface in chat", () => {
+  it("declares an expectedTerminateSessionIds set", () => {
+    expect(agentStoreSource).toMatch(
+      /const expectedTerminateSessionIds\s*=\s*new Set<string>\(\)/,
+    );
+  });
+
+  it("agentStore.terminateSession adds the session id BEFORE the provider IPC kill", () => {
+    const idx = agentStoreSource.indexOf("async terminateSession(");
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStoreSource.slice(idx, idx + 2000);
+    const addIdx = body.indexOf("expectedTerminateSessionIds.add(sessionId)");
+    const ipcIdx = body.indexOf("providerService.terminateSession(sessionId)");
+    expect(addIdx).toBeGreaterThan(0);
+    expect(ipcIdx).toBeGreaterThan(0);
+    expect(addIdx).toBeLessThan(ipcIdx);
+  });
+
+  it("agentStore.terminateSession deletes the flag after cleanup", () => {
+    const idx = agentStoreSource.indexOf("async terminateSession(");
+    // The function body spans cleanup of permissions/diffs, the IPC kill,
+    // session-state removal, active-session reassignment, and global-
+    // subscriber teardown — keep the window wide enough to cover all of it.
+    const body = agentStoreSource.slice(idx, idx + 5000);
+    expect(body).toContain(
+      "expectedTerminateSessionIds.delete(sessionId)",
+    );
+  });
+
+  it("the error handler short-circuits death-string events for expected terminates BEFORE addErrorMessage", () => {
+    const idx = agentStoreSource.indexOf("isSessionDeath");
+    expect(idx).toBeGreaterThan(0);
+    // Walk backwards to the enclosing `case "error"` block, then forward to
+    // make sure the expectedTerminate guard sits ahead of the addErrorMessage
+    // call. We assert the relative order so a refactor cannot silently
+    // re-introduce the chat-noise regression.
+    const caseIdx = agentStoreSource.lastIndexOf('case "error"', idx);
+    expect(caseIdx).toBeGreaterThan(0);
+    const block = agentStoreSource.slice(caseIdx, idx + 2000);
+    const guardIdx = block.indexOf(
+      "expectedTerminateSessionIds.has(sessionId)",
+    );
+    const addErrIdx = block.lastIndexOf(
+      "this.addErrorMessage(sessionId, event.data.error)",
+    );
+    expect(guardIdx).toBeGreaterThan(0);
+    expect(addErrIdx).toBeGreaterThan(0);
+    expect(guardIdx).toBeLessThan(addErrIdx);
+  });
+});
+
+describe("#1852 — Fix 4: temp ready-subscriber filters by the spawn's own session id", () => {
+  it("declares an expectedReadySessionId variable seeded from localSessionId", () => {
+    expect(agentStoreSource).toMatch(
+      /let expectedReadySessionId[^=]*=\s*localSessionId\s*\?\?\s*null/,
+    );
+  });
+
+  it("the temp subscriber gates resolveReady/rejectReady on session-id equality", () => {
+    const idx = agentStoreSource.indexOf("Received session status event:");
+    expect(idx).toBeGreaterThan(0);
+    const block = agentStoreSource.slice(idx, idx + 1500);
+    expect(block).toMatch(
+      /data\.sessionId\s*!==\s*expectedReadySessionId/,
+    );
+  });
+
+  it("expectedReadySessionId is updated to info.id after spawnAgent returns", () => {
+    const idx = agentStoreSource.indexOf("[AgentStore] Spawn result:");
+    expect(idx).toBeGreaterThan(0);
+    const block = agentStoreSource.slice(idx, idx + 500);
+    expect(block).toContain("expectedReadySessionId = info.id");
+  });
+});

--- a/tests/unit/thread-store.test.ts
+++ b/tests/unit/thread-store.test.ts
@@ -139,6 +139,7 @@ vi.mock("@/stores/agent.store", () => ({
     spawnSession: vi.fn(),
     refreshRecentAgentConversations: vi.fn(),
   },
+  registerActiveNavigationThreadIdGetter: vi.fn(),
 }));
 
 // Import after mocks are set up
@@ -348,6 +349,37 @@ describe("threadStore", () => {
       expect(threadStore.activeThreadKind).toBe("agent");
     });
 
+    // #1852 — Without synchronous active marking, a parallel spawn's
+    // preemptive idle-reclaim runs against state.activeSessionId from the
+    // *previous* thread and kills the just-clicked session before
+    // listSessions resolves.
+    it("marks live agent session active synchronously, before listSessions resolves", () => {
+      mockAgentConversations.push({
+        id: "agent-1",
+        title: "Agent",
+        created_at: 1000,
+        agent_type: "claude-code",
+        agent_session_id: "sess-1",
+        agent_cwd: "/dev",
+        agent_model_id: null,
+        project_id: null,
+        project_root: "/Users/dev/project-a",
+        is_archived: false,
+      });
+      mockSessions["sess-1"] = {
+        conversationId: "agent-1",
+        info: { id: "sess-1", status: "ready", agentType: "claude-code" },
+      };
+
+      vi.mocked(listSessions).mockImplementationOnce(
+        () => new Promise<AgentSessionInfo[]>(() => {}),
+      );
+
+      threadStore.selectThread("agent-1", "agent");
+
+      expect(agentStore.setActiveSession).toHaveBeenCalledWith("sess-1");
+    });
+
     it("ignores stale session checks after switching threads", async () => {
       mockConversations.conversations = [
         {
@@ -388,6 +420,10 @@ describe("threadStore", () => {
       );
 
       threadStore.selectThread("agent-1", "agent");
+      // Synchronous active marking from #1852 — captured here so we can
+      // distinguish it from any (unwanted) call made by the late resolution.
+      const callsAfterAgentClick = vi.mocked(agentStore.setActiveSession).mock
+        .calls.length;
       threadStore.selectThread("chat-1", "chat");
       resolveBackendSessions?.([
         {
@@ -408,7 +444,12 @@ describe("threadStore", () => {
       expect(conversationStore.setActiveConversation).toHaveBeenCalledWith(
         "chat-1",
       );
-      expect(agentStore.setActiveSession).not.toHaveBeenCalledWith("sess-1");
+      // The late listSessions resolution must not fire any further
+      // setActiveSession call — the early-return at the top of the
+      // resolution block enforces that. #1852.
+      expect(vi.mocked(agentStore.setActiveSession).mock.calls.length).toBe(
+        callsAfterAgentClick,
+      );
       expect(agentStore.resumeAgentConversation).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Closes #1852.

## Summary

A four-way race let a parallel spawn's preemptive idle-reclaim kill the session the user just navigated to and surface the runtime's `Session terminated before request completed.` string as a stuck chat banner with no Retry path.

- `selectThread` now marks the live session active synchronously (before the async `listSessions` liveness check), so the just-clicked session is protected by `state.activeSessionId`.
- `getIdleClaudeSessionIds` also consults a `thread.store`-registered navigation-intent getter and excludes any session whose `conversationId` matches the user's active thread.
- `agentStore.terminateSession` marks self-inflicted kills in `expectedTerminateSessionIds`; the error handler short-circuits death-string events for those ids so the runtime's teardown noise never reaches `addErrorMessage` or fires a `crash_ceiling` Retry.
- The temp ready-promise subscriber filters by the spawn's own session id (`localSessionId` -> `info.id` after `spawnAgent` returns), so unrelated `terminated`/`error` events cannot abort the new spawn and unrelated `ready` events cannot resolve it with the wrong id.

The existing #1805 mid-prompt-death Retry path is preserved.

## Test plan

- [x] `pnpm test tests/unit/idle-reclaim-race-1852.test.ts` — new source-level pins for Fixes 2/3/4
- [x] `pnpm test tests/unit/thread-store.test.ts` — Fix 1 runtime test (synchronous active marking with delayed listSessions); pre-existing `ignores stale session checks after switching threads` updated to pin the post-fix invariant
- [x] `pnpm test tests/unit/agent-session-died-mid-prompt.test.ts` — #1805 regression suite still green; one slice window widened to span the new suppression block
- [x] `pnpm test` — full suite: 122 files / 961 tests pass
- [x] `pnpm check src/stores/agent.store.ts src/stores/thread.store.ts tests/unit/...` — clean
- [x] `npx tsc --noEmit` — clean
