### PR TITLE
fix(agent): close #1854 — log claude spawn args at spawn site

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1695,6 +1695,16 @@ export function createClaudeRuntime({ emit }) {
       mcpConfigJson: mcpConfig.claudeMcpConfigJson,
       effort: effectiveEffort,
     });
+    // Surface the resolved --model value at every spawn so UI/runtime model
+    // mismatches (e.g. picker shows [1m] but the spawned session reports a
+    // 200K window) are diagnosable without ad-hoc instrumentation. Goes to
+    // stderr so it shares the [ProviderRuntime stderr] channel with other
+    // browser-local diagnostics; mcpConfigJson is intentionally omitted to
+    // avoid surfacing publisher credentials embedded in the inline config.
+    // See #1854.
+    console.error(
+      `[browser-local][claude] spawn sessionId=${remoteSessionId} preferredModel="${preferredModel}"`,
+    );
     const processHandle = spawn(
       claudeBin,
       claudeArgs,
@@ -2191,4 +2201,5 @@ export {
   DEFAULT_PREFERRED_MODEL as _DEFAULT_PREFERRED_MODEL,
   comparePickerEntries as _comparePickerEntries,
   resolveSpawnShell as _resolveSpawnShell,
+  buildClaudeArgs as _buildClaudeArgs,
 };

--- a/tests/unit/claude-runtime-spawn-args.test.ts
+++ b/tests/unit/claude-runtime-spawn-args.test.ts
@@ -1,0 +1,47 @@
+// ABOUTME: Critical guard for #1854 — buildClaudeArgs must preserve the [1m]
+// ABOUTME: suffix on --model so 1M-tier sessions actually request the wide window.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const { _buildClaudeArgs: buildClaudeArgs } = await import(
+  /* @vite-ignore */ modulePath
+);
+
+describe("buildClaudeArgs — --model arg preservation (#1854)", () => {
+  it("emits --model with the literal [1m]-suffixed id, no stripping", () => {
+    // The 1M-tier upstream contract requires the bracketed suffix to reach
+    // the spawned `claude` CLI verbatim — Anthropic gates the wide window on
+    // it. If a future refactor splits, normalises, or canonicalises the
+    // model id before push, every 1M session silently demotes to 200K and
+    // the gauge denominator goes wrong without any user-visible signal.
+    const args: string[] = buildClaudeArgs({
+      sessionId: "test-session-id",
+      resumeSessionId: null,
+      preferredModel: "claude-opus-4-7[1m]",
+      mcpConfigJson: null,
+      effort: "default",
+    });
+
+    const modelIdx = args.indexOf("--model");
+    expect(modelIdx).toBeGreaterThan(-1);
+    expect(args[modelIdx + 1]).toBe("claude-opus-4-7[1m]");
+  });
+
+  it("omits --model entirely when preferredModel is falsy", () => {
+    // Cold-start callers may pass no model; we must not push --model with
+    // an empty value (the CLI rejects an empty model arg).
+    const args: string[] = buildClaudeArgs({
+      sessionId: "test-session-id",
+      resumeSessionId: null,
+      preferredModel: undefined,
+      mcpConfigJson: null,
+      effort: "default",
+    });
+
+    expect(args.indexOf("--model")).toBe(-1);
+  });
+});


### PR DESCRIPTION
Closes #1854.

## Summary

- Add a `console.error` diagnostic line at the `claude-runtime.mjs` spawn site that surfaces `sessionId` and the resolved `preferredModel` (the value pushed as `--model` to the spawned `claude` CLI).
- Lock `[1m]` suffix preservation in `buildClaudeArgs` with a critical regression test so a future refactor that strips the bracket cannot silently demote every 1M session to 200K.

## Why

A dead-chat thread showed the UI picker reading "Opus 4.7 [1M]" while the same session's `[AgentStore] Agent usage` logged `(77% of 200,000 context)`. Two distinct mechanisms could produce this — a stale-spawn UI bug or a `contextWindowSize` seeding race — and the spawn site emitted no log on success, so they were indistinguishable. This change adds the observability needed to pick between them on the next repro.

## Code paths touched

- `bin/browser-local/claude-runtime.mjs` (source of truth; bundled into `src-tauri/embedded-runtime/...` by `scripts/build-provider-runtime.ts`):
  - +9 lines (6-line comment + 3-line `console.error` call) immediately after `buildClaudeArgs` and before `spawn(...)`.
  - +1 line: test-only re-export `buildClaudeArgs as _buildClaudeArgs`.
- `tests/unit/claude-runtime-spawn-args.test.ts` (new): 2 critical tests covering `[1m]` preservation and falsy-model omission via the new `_buildClaudeArgs` export.

No frontend, Rust, or model-picker changes. No behavior change for any user.

## Security

`mcpConfigJson` is intentionally NOT logged. The inline config may contain publisher credentials.

## Test plan

- [x] `pnpm vitest run tests/unit/claude-runtime-spawn-args.test.ts` — 2/2 pass
- [x] `pnpm vitest run tests/unit/claude-runtime-1m-tier.test.ts tests/unit/claude-runtime-cleanups.test.ts tests/unit/claude-runtime-spawn-args.test.ts` — 20/20 pass (no regression in adjacent runtime tests)
- [x] Biome ignores both touched files; pre-existing lint diagnostics on `main` are unrelated to this change
- [ ] Manual repro after merge: spawn a Claude Code session, confirm `[browser-local][claude] spawn sessionId=… preferredModel="…"` appears in DevTools `[ProviderRuntime stderr]` lines

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
