### PR TITLE
fix(skills): silence false-positive install warnings (#1856)

### DIFF
--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -4,7 +4,7 @@
 use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::AppHandle;
 use url::Url;
 
@@ -825,12 +825,54 @@ pub fn validate_skill_payload(skills_dir: String, slug: String) -> Result<Vec<St
 
     for path in referenced {
         let full_path = skill_dir.join(&path);
-        if !full_path.exists() {
+        if !full_path.exists() && !has_template_sibling(&skill_dir, &path) {
             missing.push(path);
         }
     }
 
     Ok(missing)
+}
+
+/// Returns true when `path` is a user-provisioned target whose template
+/// sibling (`.example` / `.template` / `.sample`) ships in the bundle.
+/// SKILL.md routinely instructs users to copy the template — flagging the
+/// uncopied target as "missing" is a false positive.
+fn has_template_sibling(skill_dir: &Path, path: &str) -> bool {
+    let rel = Path::new(path);
+    let file_name = match rel.file_name().and_then(|n| n.to_str()) {
+        Some(name) => name,
+        None => return false,
+    };
+    let parent_dir = match rel.parent() {
+        Some(p) => skill_dir.join(p),
+        None => skill_dir.to_path_buf(),
+    };
+
+    const INFIXES: [&str; 3] = ["example", "template", "sample"];
+
+    // Pattern A: dotfile suffix (`.env` -> `.env.example`).
+    for infix in INFIXES {
+        if parent_dir.join(format!("{}.{}", file_name, infix)).exists() {
+            return true;
+        }
+    }
+
+    // Pattern B: extension infix (`config.json` -> `config.example.json`).
+    if let (Some(stem), Some(ext)) = (
+        rel.file_stem().and_then(|s| s.to_str()),
+        rel.extension().and_then(|e| e.to_str()),
+    ) {
+        for infix in INFIXES {
+            if parent_dir
+                .join(format!("{}.{}.{}", stem, infix, ext))
+                .exists()
+            {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 /// Rename a skill directory when the resolved slug no longer matches the
@@ -1422,6 +1464,69 @@ Run [agent](scripts/agent.py) with `requirements.txt`.
 
         let missing = validate_skill_payload(skills_dir, "test-skill".to_string()).unwrap();
         assert!(missing.is_empty(), "all referenced files should be present");
+    }
+
+    #[test]
+    fn validate_skill_payload_skips_files_with_example_sibling() {
+        // Real-world case: SKILL.md instructs `Copy config.example.json to config.json`.
+        // config.example.json ships in the bundle; config.json is user-provisioned.
+        // The validator must not flag it as missing.
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().to_string_lossy().to_string();
+
+        let content = r#"# Test
+Copy `config.example.json` to `config.json`.
+"#;
+        let extras = serde_json::json!([
+            {"path": "config.example.json", "content": "{}"},
+        ]);
+
+        install_skill(
+            skills_dir.clone(),
+            "test-skill".to_string(),
+            content.to_string(),
+            Some(extras.to_string()),
+            None,
+        )
+        .unwrap();
+
+        let missing = validate_skill_payload(skills_dir, "test-skill".to_string()).unwrap();
+        assert!(
+            !missing.contains(&"config.json".to_string()),
+            "config.json must not be flagged when config.example.json sibling exists, got {:?}",
+            missing,
+        );
+    }
+
+    #[test]
+    fn validate_skill_payload_still_flags_truly_missing_files() {
+        // Regression guard: the user-provisioned-template skip must not
+        // hide genuinely broken references (file with no .example sibling).
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().to_string_lossy().to_string();
+
+        let content = r#"# Test
+Run [agent](scripts/agent.py) and read `config.example.json`.
+"#;
+        let extras = serde_json::json!([
+            {"path": "config.example.json", "content": "{}"},
+        ]);
+
+        install_skill(
+            skills_dir.clone(),
+            "test-skill".to_string(),
+            content.to_string(),
+            Some(extras.to_string()),
+            None,
+        )
+        .unwrap();
+
+        let missing = validate_skill_payload(skills_dir, "test-skill".to_string()).unwrap();
+        assert!(
+            missing.contains(&"scripts/agent.py".to_string()),
+            "scripts/agent.py has no .example sibling and must still be flagged, got {:?}",
+            missing,
+        );
     }
 
     #[test]

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -198,6 +198,52 @@ function objectKeys(value: unknown): string {
   return keys.length > 0 ? `: ${keys.join(", ")}` : "";
 }
 
+// Diagnostic for envelope-walking failures: walks the same data->result->body
+// chain that `findInResponseEnvelopes` uses and reports the keys at each
+// depth, so a "wrapped" bundle response like `{ data: { error: ... } }` is
+// debuggable from the user-facing error string alone. Surfaces a server
+// error envelope when one is detected at any depth.
+function describeBundleEnvelope(value: unknown): string {
+  if (!value || typeof value !== "object") return "";
+  const layers: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = value;
+  let depth = 0;
+  while (
+    current &&
+    typeof current === "object" &&
+    !seen.has(current) &&
+    depth < 5
+  ) {
+    seen.add(current);
+    const obj = current as Record<string, unknown>;
+    const keys = Object.keys(obj).slice(0, 6);
+    layers.push(`{${keys.join(",")}}`);
+
+    const errorMessage =
+      typeof obj.error === "string"
+        ? obj.error
+        : typeof obj.message === "string" &&
+            (obj.error !== undefined ||
+              obj.code !== undefined ||
+              obj.status !== undefined)
+          ? obj.message
+          : null;
+    if (errorMessage) {
+      return `: ${layers.join(" -> ")} (server error: ${errorMessage})`;
+    }
+
+    const next =
+      (obj.data && typeof obj.data === "object" ? obj.data : null) ??
+      (obj.result && typeof obj.result === "object" ? obj.result : null) ??
+      (obj.body && typeof obj.body === "object" ? obj.body : null);
+    if (!next) break;
+    current = next;
+    depth++;
+  }
+  return layers.length > 0 ? `: ${layers.join(" -> ")}` : "";
+}
+
 // Generated SDK responses come back wrapped in unpredictable layers of
 // {data,result,body} envelopes at runtime. Walk the envelope tree breadth-first
 // and return the first object that satisfies `match`. Shared so list and
@@ -275,7 +321,7 @@ async function downloadSkillBundle(slug: string): Promise<SkillBundle> {
   const bundle = normalizeSkillBundle(data);
   if (!bundle) {
     throw new Error(
-      `Unexpected seren-skills bundle response for ${slug}${objectKeys(data)}`,
+      `Unexpected seren-skills bundle response for ${slug}${describeBundleEnvelope(data)}`,
     );
   }
   return bundle;

--- a/tests/unit/skills-index-api.test.ts
+++ b/tests/unit/skills-index-api.test.ts
@@ -229,6 +229,48 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
     ).rejects.toThrow("Unexpected seren-skills bundle response for gamma");
   });
 
+  it("includes inner envelope keys when a wrapped bundle response cannot be normalized", async () => {
+    // Mirror of the production failure: the SDK returned `{ data: <inner> }`
+    // and the inner envelope is missing the bundle fields. The error must
+    // surface BOTH outer and inner keys so we can root-cause without
+    // redeploying the desktop client.
+    mockDownloadSkill.mockResolvedValueOnce({
+      data: { data: { content_hash: "abc" } },
+    });
+
+    const { skills } = await import("@/services/skills");
+    await expect(
+      skills.fetchContent({
+        id: "seren:wrapped",
+        slug: "wrapped",
+        name: "Wrapped",
+        description: "",
+        source: "seren",
+        sourceUrl: "seren-skills:wrapped",
+        tags: [],
+      }),
+    ).rejects.toThrow(/content_hash/);
+  });
+
+  it("surfaces server error envelopes when the bundle body carries an error payload", async () => {
+    mockDownloadSkill.mockResolvedValueOnce({
+      data: { data: { error: "forbidden", code: "PUBLISHER_DENIED" } },
+    });
+
+    const { skills } = await import("@/services/skills");
+    await expect(
+      skills.fetchContent({
+        id: "seren:denied",
+        slug: "denied",
+        name: "Denied",
+        description: "",
+        source: "seren",
+        sourceUrl: "seren-skills:denied",
+        tags: [],
+      }),
+    ).rejects.toThrow(/forbidden/);
+  });
+
   it("throws when the API returns an error", async () => {
     mockDownloadSkill.mockResolvedValueOnce({
       error: { message: "not found" },


### PR DESCRIPTION
## Summary

Closes #1856.

- Rust: `validate_skill_payload` now treats a referenced file as user-provisioned (not "missing") when an `.example` / `.template` / `.sample` sibling ships in the bundle. Kills the false-positive `Incomplete install: <slug>` sidebar warning that fired every time a user (re)installed `curve-gauge-yield-trader` and similar skills whose SKILL.md says `Copy config.example.json to config.json`.
- TypeScript: replace the single-level `objectKeys(data)` diagnostic in the bundle download error with a walker that reports keys at every envelope depth and surfaces server error envelopes when present. Next occurrence of `Unexpected seren-skills bundle response` will look like `{data} -> {error,code} (server error: forbidden)` instead of an undebuggable `: data`.

## Scope of the fix

- Issue #2 (template false-positive) is a true root-cause fix verified end-to-end against the actual user-reported case (`config.example.json` → `config.json`).
- Issue #1 (envelope error) is a diagnostic improvement. Without API access I cannot confirm the exact server-side cause of the malformed inner envelope reported by Taariq; the fix makes the next occurrence self-diagnosing in production so we can either patch the publisher or loosen the matcher with concrete evidence.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib skills::` — 23 passed (4 in `validate_skill_payload`, including new `_skips_files_with_example_sibling` and `_still_flags_truly_missing_files`).
- [x] `pnpm vitest run tests/unit` — 937 passed across 120 files (no regressions).
- [x] `pnpm check` on changed files — clean.
- [ ] Manual: install `curve-gauge-yield-trader` after merge → no `Incomplete install` banner.
- [ ] Manual: trigger sync poll on installed skills → if a real bundle response fails to normalize, the surfaced error includes inner envelope shape.
