### PR TITLE
fix(agent): close #1858 — picker tier pin + prepend keeps tool IDs

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3322,16 +3322,38 @@ Structured summary:`;
       // prompt — the post-compaction context-restore mechanism. No seed
       // turn is sent to the model; the prepend is consumed exactly once on
       // the first dispatch via `consumeCompactionPrepend`. #1829.
+      //
+      // Tool messages must ride along: MCP tool results carry the resource
+      // handles the conversation is actually manipulating (Google Sheets
+      // spreadsheet IDs, SerenDB project handles, R2 keys, ...). The
+      // structured summary template has no slot for opaque identifiers and
+      // caps each field at 1-2 sentences, so handles got summarized away
+      // and the user had to re-supply them. Tighter cap on tool results
+      // because they can be huge file contents / JSON dumps; user and
+      // assistant text gets the original 2000-char ceiling. #1858.
       const MAX_MSG_CHARS = 2000;
+      const MAX_TOOL_CHARS = 500;
       const preservedContext = toPreserve
-        .filter((m) => m.type === "user" || m.type === "assistant")
         .map((m) => {
-          const content =
-            m.content.length > MAX_MSG_CHARS
-              ? `${m.content.slice(0, MAX_MSG_CHARS)}... [truncated]`
-              : m.content;
-          return `${m.type.toUpperCase()}: ${content}`;
+          if (m.type === "user" || m.type === "assistant") {
+            const content =
+              m.content.length > MAX_MSG_CHARS
+                ? `${m.content.slice(0, MAX_MSG_CHARS)}... [truncated]`
+                : m.content;
+            return `${m.type.toUpperCase()}: ${content}`;
+          }
+          if (m.type === "tool" && m.toolCall?.result) {
+            const title = m.toolCall.title || "tool";
+            const result = m.toolCall.result;
+            const trimmed =
+              result.length > MAX_TOOL_CHARS
+                ? `${result.slice(0, MAX_TOOL_CHARS)}... [truncated]`
+                : result;
+            return `TOOL_RESULT (${title}): ${trimmed}`;
+          }
+          return null;
         })
+        .filter((s): s is string => s !== null)
         .join("\n\n");
       const prependText = preservedContext
         ? `Prior work summary:\n${summary}\n\nRecent messages:\n${preservedContext}`
@@ -4514,21 +4536,37 @@ Structured summary:`;
   async setModel(modelId: string, forSessionId?: string) {
     const sessionId = forSessionId ?? state.activeSessionId;
     if (!sessionId) return;
+    const session = state.sessions[sessionId];
+    if (!session) return;
 
     setState("sessions", sessionId, "pendingModelId", modelId);
     setState("sessions", sessionId, "userSelectedModelId", modelId);
     setState("sessions", sessionId, "currentModelId", modelId);
+    // The auto-compact denominator must follow the picker. Prior fixes
+    // (#1700, #1733, #1761, #1769, #1798) hardened the CLI-report path
+    // into contextWindowSize. The picker-driven mid-session swap path
+    // was never wired: switching `claude-opus-4-7` -> `claude-opus-4-7[1m]`
+    // left the spawn-time 200K denominator in place, so compaction fired
+    // at ~88% of 200K instead of waiting for ~88% of 1M — exactly 5x too
+    // early on every 1M-tier upgrade. Recompute against the new tier here;
+    // the next promptComplete's #1798 isOneMTierMismatch guard refines
+    // the value if the runtime emits something different. Reset the
+    // once-per-session alarm so the gate re-arms cleanly for the new
+    // tier. #1858.
+    setState(
+      "sessions",
+      sessionId,
+      "contextWindowSize",
+      defaultContextWindowFor(session.info.agentType, modelId),
+    );
+    setState("sessions", sessionId, "contextWindowMismatchReported", false);
     try {
       await providerService.setModel(sessionId, modelId);
-      const session = state.sessions[sessionId];
-      if (session) {
-        void setAgentConversationModelIdDb(
-          session.conversationId,
-          modelId,
-        ).catch((error) => {
+      void setAgentConversationModelIdDb(session.conversationId, modelId).catch(
+        (error) => {
           console.warn("Failed to persist agent model selection", error);
-        });
-      }
+        },
+      );
     } catch (error) {
       console.error("[AgentStore] Failed to set model:", error);
     }

--- a/tests/unit/setmodel-context-window-and-prepend-tool-results.test.ts
+++ b/tests/unit/setmodel-context-window-and-prepend-tool-results.test.ts
@@ -1,0 +1,104 @@
+// ABOUTME: Critical pins for #1858 — setModel must update contextWindowSize so
+// ABOUTME: mid-session [1m] upgrades stop firing auto-compact 5x early, and the
+// ABOUTME: passive prepend must keep tool-result content so MCP resource IDs survive.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+/**
+ * Slice a fixed-size window forward from a unique anchor. The two fixes in
+ * #1858 each live in a tightly localized region, so a windowed slice keeps
+ * the assertions immune to drift in unrelated code below.
+ */
+function regionAfter(anchor: string, len: number): string {
+  const start = agentStoreSource.indexOf(anchor);
+  if (start < 0) {
+    throw new Error(`anchor not found in agent.store.ts: ${anchor}`);
+  }
+  return agentStoreSource.slice(start, start + len);
+}
+
+describe("#1858 Defect 1 — setModel updates contextWindowSize on mid-session model swap", () => {
+  // Pre-#1858: setModel updated currentModelId/pendingModelId/userSelectedModelId
+  // and persisted the choice to SQLite, but never recomputed contextWindowSize.
+  // Switching `claude-opus-4-7` -> `claude-opus-4-7[1m]` mid-conversation left
+  // the auto-compact denominator pinned at the spawn-time 200K, so compaction
+  // fired at ~88% of 200K (~176K tokens) instead of waiting for ~88% of 1M
+  // (~880K). All prior fixes (#1700, #1733, #1761, #1769, #1798) hardened the
+  // CLI-report -> contextWindowSize path; setModel was the remaining hole.
+
+  const setModelRegion = () =>
+    regionAfter("async setModel(modelId: string, forSessionId?: string)", 1500);
+
+  it("setModel writes contextWindowSize from defaultContextWindowFor against the new modelId", () => {
+    // The picker promise is the new denominator. The CLI-report path's
+    // #1798 isOneMTierMismatch guard refines this on the next promptComplete
+    // if the runtime emits a different value. Without this write, the
+    // denominator stays whatever the spawn picked.
+    expect(setModelRegion()).toMatch(
+      /setState\(\s*"sessions",\s*sessionId,\s*"contextWindowSize",\s*defaultContextWindowFor\(/,
+    );
+  });
+
+  it("setModel clears contextWindowMismatchReported so the once-per-session alarm re-arms for the new tier", () => {
+    // The #1798 alarm is one-shot per session. Switching to a [1m] tier must
+    // reset the gate so a future CLI downgrade for the new tier is captured,
+    // not silenced by a prior tier's alarm having already fired.
+    expect(setModelRegion()).toMatch(
+      /setState\(\s*"sessions",\s*sessionId,\s*"contextWindowMismatchReported",\s*false,?\s*\)/,
+    );
+  });
+
+  it("setModel passes the session's agentType (not a hardcoded provider) into defaultContextWindowFor", () => {
+    // Hardcoding "claude-code" would silently mis-tier Codex and Gemini
+    // sessions if the picker is ever wired up there in the future. Use the
+    // session's own agentType so the lookup stays correct across providers.
+    expect(setModelRegion()).toMatch(
+      /defaultContextWindowFor\(\s*[\w.?]+\.info\.agentType/,
+    );
+  });
+});
+
+describe("#1858 Defect 2 — passive prepend preserves tool-result content", () => {
+  // Pre-#1858: the prepend builder filtered toPreserve to user/assistant only,
+  // dropping every `tool` message. MCP tool results (Google Sheets spreadsheet
+  // IDs, SerenDB project handles, R2 keys, ...) ride on toolCall.result and
+  // were lost on every compaction. The structured summary template has no
+  // resource-id slot, so opaque handles got summarized away and the user had
+  // to re-supply them post-compaction.
+
+  // Anchor on the unique "Build the structured prepend up-front" comment that
+  // introduces the prepend-builder block in compactAgentConversation. This
+  // keeps assertions inside the prepend region only — not the toCompact
+  // serialization above it nor the post-prepend spawn flows below.
+  const prependRegion = () =>
+    regionAfter("Build the structured prepend up-front", 2500);
+
+  it("prepend builder includes m.type === \"tool\" alongside user/assistant", () => {
+    // The filter must allow tool messages through. Pre-fix shape was a literal
+    // .filter((m) => m.type === "user" || m.type === "assistant") which silently
+    // dropped tool. Pin the presence of the "tool" branch.
+    expect(prependRegion()).toMatch(/m\.type\s*===\s*"tool"/);
+  });
+
+  it("prepend builder reads toolCall.result so the actual MCP payload is what gets prepended", () => {
+    // The result string is the only field carrying the resource handle the
+    // compaction needs to preserve. toolCall.title alone is not enough —
+    // titles are e.g. "search google" with no payload.
+    expect(prependRegion()).toMatch(/toolCall(?:\?\.|\.)result/);
+  });
+
+  it("prepend builder applies a tighter character cap to tool results than to user/assistant turns", () => {
+    // Tool results can be huge (full file contents, JSON dumps). Capping
+    // them at the same 2000-char ceiling as user/assistant turns lets a
+    // single verbose tool result dominate the prepend. The fix introduces
+    // a tighter MAX_TOOL_CHARS or equivalent literal.
+    expect(prependRegion()).toMatch(/MAX_TOOL_CHARS\s*=\s*\d+/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1858. Two compounding defects in auto-compaction, observed in production:

- **Defect 1 (5x early trigger):** an Opus 4.7 [1M context] session triggered compaction at 175,826 tokens — 88% of 200K, but only ~17% of the 1M tier the picker promised. Root cause: `setModel` updated `currentModelId`/`pendingModelId`/`userSelectedModelId` and persisted to SQLite but never recomputed `contextWindowSize`. Every prior context-window fix (#1700, #1733, #1761, #1769, #1798) hardened the **CLI-report → contextWindowSize** pipeline; the **picker → setModel → contextWindowSize** path was the remaining hole.
- **Defect 2 (lossy prepend):** the passive-prepend builder filtered `toPreserve` to user/assistant only, dropping every `tool` message. MCP tool results carry resource handles (Google Sheets spreadsheet IDs, SerenDB project handles, R2 keys, ...) on `toolCall.result`. The structured summary template caps each field at 1-2 sentences with no slot for opaque identifiers, so handles got summarized away and the user had to re-paste them after every compaction.

## Fix

- **`setModel` (`src/stores/agent.store.ts:4536`)** — recompute `contextWindowSize = defaultContextWindowFor(session.info.agentType, modelId)` immediately on picker change, then reset `contextWindowMismatchReported` so the once-per-session #1798 alarm re-arms cleanly for the new tier. The next `promptComplete`'s existing `isOneMTierMismatch` guard refines the value if the runtime emits a different one.
- **Prepend builder (`src/stores/agent.store.ts:3320`)** — switch `filter+map` to `map+filter`. Tool messages with non-empty `toolCall.result` emit as `TOOL_RESULT (title): ...` lines, capped at 500 chars (vs 2000 for user/assistant) so one verbose JSON dump can't dominate the prepend.

## Composition with prior fixes

- **#1700 (CLI metadata cache)** — unchanged. `setModel` doesn't touch the cache; cache lookups at spawn still drive cold-start.
- **#1733 (initialModelId threading)** — unchanged. All seven spawn sites still pass `initialModelId`.
- **#1761 ([1m] picker routing)** — unchanged. Picker entries still resolve through the `[1m]` suffix.
- **#1769 (cache-layer sub-1M refusal)** — unchanged. Cache writer still refuses sub-1M for `[1m]` models.
- **#1798 (in-memory CLI-report guard)** — unchanged. The `isOneMTierMismatch` predicate still gates the CLI-report-driven write at `promptComplete` time, just on whatever value `setModel` left in place.

## Tests

`tests/unit/setmodel-context-window-and-prepend-tool-results.test.ts` (new, 6 critical pins). Source-pin pattern matching `agent-store-context-window-tier-guard.test.ts` (#1798) and `predictive-compact-spawn-fixes.test.ts` (#1733). No duplicate of #1798/#1769 coverage — those layers are unchanged.

- 971/971 unit tests pass
- `biome check` clean
- `tsc --noEmit` clean

## Test plan

- [ ] Spawn an Opus 4.7 (bare) session; verify auto-compact gauge at 200K denominator.
- [ ] Switch picker to "Opus 4.7 [1M context]"; verify gauge denominator immediately becomes 1M without a turn round-trip.
- [ ] Run a turn that returns a Google Sheets tool result (e.g. `mcp_search_call_publisher` against the Google Sheets MCP); push the conversation past the auto-compact threshold; verify the post-compaction agent still has the spreadsheet ID without the user re-pasting it.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
