### PR TITLE
fix(auth): close #1860 — public Gateway calls work signed out

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -35,6 +35,16 @@ fn get_refresh_token(app: &tauri::AppHandle) -> Result<Option<String>, String> {
         .and_then(|v| v.as_str().map(String::from)))
 }
 
+/// True when either an access token or a refresh token is present.
+///
+/// Callers use this to decide whether a Gateway request should attach
+/// stored auth at all. A signed-out cold start has neither token, so public
+/// endpoints (catalog, provider list) must go through unauthenticated rather
+/// than failing through the refresh path. See #1860.
+pub fn has_stored_credentials(app: &tauri::AppHandle) -> bool {
+    get_access_token(app).is_ok() || matches!(get_refresh_token(app), Ok(Some(_)))
+}
+
 /// Store new tokens after a successful refresh.
 fn store_tokens(
     app: &tauri::AppHandle,
@@ -62,6 +72,9 @@ fn clear_tokens(app: &tauri::AppHandle) -> Result<(), String> {
 /// Attempt to refresh the access token using the stored refresh token.
 ///
 /// Returns the new access token on success.
+/// On missing refresh token: clears tokens and returns an error WITHOUT
+/// emitting `auth:session-expired` — that state is "never signed in", not
+/// session expiry.
 /// On 401 from the refresh endpoint: clears both tokens, emits
 /// `auth:session-expired` to the frontend, and returns an error.
 /// On network error: does NOT clear tokens (user may be temporarily offline).
@@ -78,8 +91,11 @@ pub async fn refresh_access_token(app: &tauri::AppHandle) -> Result<String, Stri
     let refresh_token = match get_refresh_token(app)? {
         Some(rt) => rt,
         None => {
+            // No refresh token means never-signed-in or already-logged-out,
+            // not session expiry. Emitting auth:session-expired here turned
+            // every signed-out Gateway call into a spurious sign-in-modal
+            // request. See #1860.
             let _ = clear_tokens(app);
-            let _ = app.emit("auth:session-expired", ());
             return Err("No refresh token available".to_string());
         }
     };
@@ -143,7 +159,7 @@ where
     let token = match get_access_token(app) {
         Ok(t) => t,
         Err(_) => {
-            log::info!("[auth] No access token in store, attempting refresh...");
+            log::debug!("[auth] No access token in store, attempting refresh...");
             refresh_access_token(app).await?
         }
     };

--- a/src-tauri/src/commands/gateway_http.rs
+++ b/src-tauri/src/commands/gateway_http.rs
@@ -87,6 +87,21 @@ fn should_use_stored_auth(url: &Url, headers: &HeaderMap) -> bool {
     !headers.contains_key(AUTHORIZATION) && !should_skip_stored_auth(url.path())
 }
 
+/// Decide whether to attach stored auth to a Gateway request.
+///
+/// Returns true only when the caller did not pass their own Authorization
+/// header, the path is not an auth-bootstrap endpoint, AND the desktop has
+/// stored credentials. Without credentials the request goes unauthenticated
+/// so public endpoints keep working while signed out instead of failing
+/// through the refresh path. See #1860.
+fn should_attach_stored_auth(
+    url: &Url,
+    headers: &HeaderMap,
+    has_stored_credentials: bool,
+) -> bool {
+    should_use_stored_auth(url, headers) && has_stored_credentials
+}
+
 fn build_header_map(raw_headers: &HashMap<String, String>) -> Result<HeaderMap, String> {
     let mut headers = HeaderMap::new();
 
@@ -181,7 +196,8 @@ pub async fn gateway_http_start(
         .build()
         .map_err(|e| format!("Failed to create gateway HTTP client: {}", e))?;
 
-    let response = if should_use_stored_auth(&url, &headers) {
+    let has_credentials = crate::auth::has_stored_credentials(&app);
+    let response = if should_attach_stored_auth(&url, &headers, has_credentials) {
         crate::auth::authenticated_request(&app, &client, |client, token| {
             build_request(
                 client,
@@ -319,5 +335,24 @@ mod tests {
 
         let refresh = Url::parse("https://api.serendb.com/auth/refresh").unwrap();
         assert!(!should_use_stored_auth(&refresh, &no_auth_headers));
+    }
+
+    #[test]
+    fn attach_stored_auth_requires_credentials_for_protected_paths() {
+        let no_auth_headers = HeaderMap::new();
+        let catalog =
+            Url::parse("https://api.serendb.com/publishers/seren-skills/skills").unwrap();
+
+        // Signed-out cold start: public catalog must go through unauthenticated
+        // instead of failing through the refresh path. Regression guard for #1860.
+        assert!(!should_attach_stored_auth(&catalog, &no_auth_headers, false));
+
+        // Signed-in: same path attaches the bearer token via authenticated_request.
+        assert!(should_attach_stored_auth(&catalog, &no_auth_headers, true));
+
+        // Auth-bootstrap endpoints stay unauthenticated even when credentials exist,
+        // so /auth/refresh does not loop into itself.
+        let refresh = Url::parse("https://api.serendb.com/auth/refresh").unwrap();
+        assert!(!should_attach_stored_auth(&refresh, &no_auth_headers, true));
     }
 }

--- a/tests/unit/skills-refresh-signed-out.test.ts
+++ b/tests/unit/skills-refresh-signed-out.test.ts
@@ -1,0 +1,118 @@
+// ABOUTME: Regression test that refreshAvailable populates the public catalog
+// ABOUTME: when the auth store reports signed-out. Guards against #1860.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSkillsService = vi.hoisted(() => ({
+  fetchAllSkills: vi.fn().mockResolvedValue([]),
+  fetchOwnedSkills: vi.fn().mockResolvedValue([]),
+  listAllInstalled: vi.fn().mockResolvedValue([]),
+  backfillSyncState: vi.fn().mockResolvedValue(0),
+  inspectSyncStatus: vi.fn().mockResolvedValue({ updateAvailable: false }),
+  refreshInstalledSkill: vi
+    .fn()
+    .mockResolvedValue({ installed: {}, syncStatus: null }),
+  isUpstreamManagedSkill: vi.fn().mockReturnValue(false),
+  renameSkillDir: vi.fn().mockResolvedValue("/skills/renamed/SKILL.md"),
+  clearCache: vi.fn(),
+  install: vi.fn(),
+  readProjectConfig: vi.fn().mockResolvedValue(null),
+  writeProjectConfig: vi.fn().mockResolvedValue(undefined),
+  clearProjectConfig: vi.fn().mockResolvedValue(undefined),
+  getThreadSkills: vi.fn().mockResolvedValue(null),
+  setThreadSkills: vi.fn().mockResolvedValue(undefined),
+  clearThreadSkills: vi.fn().mockResolvedValue(undefined),
+  getEnabledSkillsContent: vi.fn().mockResolvedValue(""),
+}));
+
+const mockAuthState = vi.hoisted(() => ({
+  isAuthenticated: false,
+}));
+
+vi.mock("solid-js/store", () => ({
+  createStore: <T extends Record<string, unknown>>(initial: T) => {
+    const state = { ...initial } as Record<string, unknown>;
+    const setState = (...args: unknown[]) => {
+      if (args.length === 2 && typeof args[0] === "string") {
+        state[args[0] as string] = args[1];
+      }
+    };
+    return [state, setState];
+  },
+}));
+
+vi.mock("@/stores/fileTree", () => ({
+  getFileTreeState: () => ({ rootPath: "/test/project" }),
+  get fileTreeState() {
+    return { rootPath: "/test/project" };
+  },
+}));
+
+vi.mock("@/stores/auth.store", () => ({
+  authStore: mockAuthState,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/services/skills", () => {
+  class SkillsApiError extends Error {
+    status?: number;
+    constructor(message: string, status?: number) {
+      super(message);
+      this.name = "SkillsApiError";
+      this.status = status;
+    }
+  }
+  return {
+    skills: {
+      fetchAllSkills: mockSkillsService.fetchAllSkills,
+      fetchOwnedSkills: mockSkillsService.fetchOwnedSkills,
+      listAllInstalled: mockSkillsService.listAllInstalled,
+      backfillSyncState: mockSkillsService.backfillSyncState,
+      inspectSyncStatus: mockSkillsService.inspectSyncStatus,
+      refreshInstalledSkill: mockSkillsService.refreshInstalledSkill,
+      renameSkillDir: mockSkillsService.renameSkillDir,
+      clearCache: mockSkillsService.clearCache,
+      install: mockSkillsService.install,
+      readProjectConfig: mockSkillsService.readProjectConfig,
+      writeProjectConfig: mockSkillsService.writeProjectConfig,
+      clearProjectConfig: mockSkillsService.clearProjectConfig,
+      getThreadSkills: mockSkillsService.getThreadSkills,
+      setThreadSkills: mockSkillsService.setThreadSkills,
+      clearThreadSkills: mockSkillsService.clearThreadSkills,
+      getEnabledSkillsContent: mockSkillsService.getEnabledSkillsContent,
+    },
+    isUpstreamManagedSkill: mockSkillsService.isUpstreamManagedSkill,
+    SkillsApiError,
+    isAuthStatus: (status: number | undefined) =>
+      status === 401 || status === 403,
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthState.isAuthenticated = false;
+});
+
+describe("skillsStore.refreshAvailable when signed out (#1860)", () => {
+  it("fetches the public catalog even when the user is not authenticated", async () => {
+    mockSkillsService.fetchAllSkills.mockResolvedValueOnce([
+      {
+        id: "seren:public-skill",
+        slug: "public-skill",
+        name: "Public Skill",
+        description: "Visible without sign-in",
+        source: "seren",
+        sourceUrl: "seren-skills:public-skill",
+        tags: [],
+      },
+    ]);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refreshAvailable();
+
+    expect(mockSkillsService.fetchAllSkills).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Send signed-out Gateway requests unauthenticated instead of failing through the refresh path — public endpoints (catalog, provider list) now load on cold start without sign-in.
- Stop emitting `auth:session-expired` when there is no refresh token in the store. Real 401-from-refresh still escalates correctly.
- Demote the "No access token in store, attempting refresh..." log to DEBUG so signed-out boot is quiet.

Closes #1860.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib commands::gateway_http::tests` — new `attach_stored_auth_requires_credentials_for_protected_paths` plus existing decision tests pass.
- [x] `pnpm vitest run tests/unit/skills-refresh-signed-out.test.ts` — new regression guard locks in the contract that `refreshAvailable` fetches the catalog when signed-out (no wrong frontend `isAuthenticated` guard).
- [x] `pnpm test` — full vitest suite (972 tests) green.
- [x] `cargo build --manifest-path src-tauri/Cargo.toml --lib` — clean.
- [ ] Manual: cold start signed-out → Skills catalog loads, no `Session expired event from backend` spam, no sign-in modal request from cold boot.
