### PR TITLE
fix(agent): close #1862 — arch-validate claude before spawn

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -2,11 +2,102 @@
 // ABOUTME: Keeps provider metadata and per-agent setup logic separate from session runtime handling.
 
 import { execFile, spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { closeSync, existsSync, openSync, readSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import { backgroundUpdateCli } from "./cli-updater.mjs";
+
+/**
+ * Map a binary file's CPU architecture to Node's `process.arch` taxonomy.
+ *
+ * Reads Mach-O (macOS), ELF (Linux), and PE/COFF (Windows) headers without
+ * executing the file. Returns `"universal"` for fat Mach-O binaries (every
+ * slice is shipped, kernel picks the matching one). Returns `null` when the
+ * file isn't a recognized native binary — scripts and unknown formats fall
+ * through to the spawn site, which surfaces a real OS error instead of us
+ * silently rejecting something we can't classify.
+ *
+ * Exists for #1862: a wrong-arch claude binary at `~/.local/bin/claude`
+ * shadowed our working npm-installed arm64 build and spawned with
+ * `Bad CPU type in executable` (-86 / EBADARCH).
+ */
+function readBinaryArch(filePath) {
+  let fd;
+  try {
+    fd = openSync(filePath, "r");
+    const head = Buffer.alloc(64);
+    const headBytes = readSync(fd, head, 0, 64, 0);
+    if (headBytes < 8) return null;
+
+    // Mach-O 64-bit, little-endian. magic = MH_MAGIC_64 (0xFEEDFACF on disk).
+    if (head.readUInt32LE(0) === 0xfeedfacf) {
+      const cputype = head.readUInt32LE(4);
+      if (cputype === 0x0100000c) return "arm64"; // CPU_TYPE_ARM | ABI64
+      if (cputype === 0x01000007) return "x64";   // CPU_TYPE_X86 | ABI64
+      return null;
+    }
+
+    // Universal Mach-O (fat). Both BE and LE variants exist. Either way the
+    // kernel picks the right slice — treat as runnable on any host.
+    const beMagic = head.readUInt32BE(0);
+    if (beMagic === 0xcafebabe || beMagic === 0xcafebabf) {
+      return "universal";
+    }
+
+    // ELF: 7F 'E' 'L' 'F'. e_machine at offset 18 (2 bytes, endianness from EI_DATA).
+    if (head.readUInt32LE(0) === 0x464c457f) {
+      const isLE = head.readUInt8(5) === 1;
+      const machine = isLE ? head.readUInt16LE(18) : head.readUInt16BE(18);
+      if (machine === 0x3e) return "x64";    // EM_X86_64
+      if (machine === 0xb7) return "arm64";  // EM_AARCH64
+      if (machine === 0x28) return "arm";    // EM_ARM
+      if (machine === 0x03) return "ia32";   // EM_386
+      return null;
+    }
+
+    // PE/COFF: "MZ" DOS header, 32-bit PE offset at 0x3C, then "PE\0\0" +
+    // IMAGE_FILE_HEADER. Machine is the first 2 bytes after the signature.
+    if (head.readUInt16LE(0) === 0x5a4d) {
+      const peOffset = head.readUInt32LE(0x3c);
+      if (peOffset < 0 || peOffset > 0x10000) return null;
+      const peBuf = Buffer.alloc(8);
+      const peBytes = readSync(fd, peBuf, 0, 8, peOffset);
+      if (peBytes < 8) return null;
+      if (peBuf.readUInt32LE(0) !== 0x00004550) return null; // "PE\0\0"
+      const machine = peBuf.readUInt16LE(4);
+      if (machine === 0x8664) return "x64";    // IMAGE_FILE_MACHINE_AMD64
+      if (machine === 0xaa64) return "arm64";  // IMAGE_FILE_MACHINE_ARM64
+      if (machine === 0x14c) return "ia32";    // IMAGE_FILE_MACHINE_I386
+      return null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch {}
+    }
+  }
+}
+
+/**
+ * Returns true when the binary at `filePath` can be executed on the current
+ * host. Universal Mach-O and unrecognized formats (scripts, missing files)
+ * are treated as runnable so callers don't silently skip legitimate install
+ * shapes — only positively-identified arch mismatches are rejected.
+ *
+ * Use this to filter resolver candidates so a lingering wrong-arch binary
+ * stops shadowing a working install at a lower-priority path.
+ */
+export function binaryRunsOnHost(filePath) {
+  const fileArch = readBinaryArch(filePath);
+  if (fileArch === null || fileArch === "universal") {
+    return true;
+  }
+  return fileArch === process.arch;
+}
 
 function launchLoginCommand(command) {
   const loginCommand = `${command} login`;
@@ -152,8 +243,25 @@ async function ensureClaudeCodeViaNativeInstaller(emit) {
     return existing;
   }
 
+  // `which`/`where` may resolve to a path not covered by resolveInstalledClaudeBinary
+  // (a custom user PATH location). Arch-check the resolved path so a wrong-arch
+  // binary on PATH doesn't get spawned and fail with EBADARCH (#1862).
   if (await isCommandAvailable("claude")) {
-    return "claude";
+    try {
+      const whichCommand = process.platform === "win32" ? "where" : "which";
+      const resolvedPath = (await execText(whichCommand, ["claude"]))
+        .split(/\r?\n/)[0]
+        .trim();
+      if (
+        resolvedPath &&
+        existsSync(resolvedPath) &&
+        binaryRunsOnHost(resolvedPath)
+      ) {
+        return "claude";
+      }
+    } catch {
+      // which/where failed — fall through to install
+    }
   }
 
   // Strategy 1: Official native installer (PowerShell on Windows, bash on Unix)
@@ -185,7 +293,12 @@ async function ensureClaudeCodeViaNativeInstaller(emit) {
       });
     });
 
-    // Verify the binary actually landed where we expect
+    // Verify the binary actually landed where we expect AND that it's the
+    // right arch for this host. `resolveInstalledClaudeBinary` skips wrong-arch
+    // candidates, so a returned sentinel here means either no install dropped
+    // or install.sh dropped a wrong-arch slice (e.g. uname -m fooled by a
+    // Rosetta'd parent context). Both cases fall through to npm install, which
+    // uses our embedded arm64/x64 node and gets the arch right by construction. #1862
     const resolved = resolveInstalledClaudeBinary();
     if (resolved !== "claude") {
       emit("provider://cli-install-progress", {
@@ -195,8 +308,10 @@ async function ensureClaudeCodeViaNativeInstaller(emit) {
       return resolved;
     }
 
-    // Installer returned success but binary not found — treat as failure
-    console.warn("[agent-registry] Native installer succeeded but binary not found at expected paths");
+    console.warn(
+      "[agent-registry] Native installer succeeded but no arch-compatible binary " +
+        `was found at expected paths (host=${process.arch}). Falling back to npm install.`,
+    );
     nativeInstallerFailed = true;
   } catch (nativeError) {
     console.warn("[agent-registry] Native installer failed:", nativeError.message);
@@ -362,6 +477,11 @@ function resolveInstalledGeminiBinary() {
  * Resolve the installed Claude Code binary path.
  * GUI apps don't inherit shell PATH updates made by installers, so check
  * well-known install locations before falling back to bare command name.
+ *
+ * Candidates are filtered through `binaryRunsOnHost` so a leftover wrong-arch
+ * binary at one path (e.g. ~/.local/bin/claude dropped by a Rosetta'd install
+ * run) cannot shadow a working arch-matched install at a lower-priority path.
+ * See #1862.
  */
 export function resolveInstalledClaudeBinary() {
   if (process.platform === "win32") {
@@ -390,7 +510,7 @@ export function resolveInstalledClaudeBinary() {
       path.join(home, ".npm-global", "claude.cmd"),
     ];
     for (const candidate of candidates) {
-      if (existsSync(candidate)) {
+      if (existsSync(candidate) && binaryRunsOnHost(candidate)) {
         return candidate;
       }
     }
@@ -411,7 +531,7 @@ export function resolveInstalledClaudeBinary() {
       "/usr/bin/claude",
     ];
     for (const candidate of candidates) {
-      if (existsSync(candidate)) {
+      if (existsSync(candidate) && binaryRunsOnHost(candidate)) {
         return candidate;
       }
     }

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -16,6 +16,7 @@ import {
   DEFAULT_CLAUDE_EFFORT,
 } from "./effort.mjs";
 import { updatePeakInputTokens } from "./usage.mjs";
+import { binaryRunsOnHost } from "./agent-registry.mjs";
 import { chooseUpdatedModelId, inferCurrentModelId } from "./model-resolution.mjs";
 import {
   buildSyntheticTranscript as writeSyntheticJsonl,
@@ -64,8 +65,10 @@ function resolveClaudeBinary() {
       path.join(nodeDir, "claude"),
     ];
 
+    // binaryRunsOnHost rejects a wrong-arch binary that would otherwise pass
+    // the executability gate and then crash at spawn with EBADARCH. #1862
     for (const candidate of candidates) {
-      if (isExecutableCandidate(candidate)) {
+      if (isExecutableCandidate(candidate) && binaryRunsOnHost(candidate)) {
         return candidate;
       }
     }
@@ -76,7 +79,7 @@ function resolveClaudeBinary() {
         encoding: "utf8",
         timeout: 5_000,
       }).trim().split(/\r?\n/)[0];
-      if (resolved && isExecutableCandidate(resolved)) {
+      if (resolved && isExecutableCandidate(resolved) && binaryRunsOnHost(resolved)) {
         return resolved;
       }
     } catch {
@@ -96,8 +99,10 @@ function resolveClaudeBinary() {
     path.join(prefix, "bin", "claude"),
   ];
 
+  // binaryRunsOnHost rejects a wrong-arch binary that would otherwise pass
+  // the executability gate and then crash at spawn with EBADARCH. #1862
   for (const candidate of candidates) {
-    if (isExecutableCandidate(candidate)) {
+    if (isExecutableCandidate(candidate) && binaryRunsOnHost(candidate)) {
       return candidate;
     }
   }
@@ -108,7 +113,7 @@ function resolveClaudeBinary() {
       encoding: "utf8",
       timeout: 5_000,
     }).trim();
-    if (resolved && isExecutableCandidate(resolved)) {
+    if (resolved && isExecutableCandidate(resolved) && binaryRunsOnHost(resolved)) {
       return resolved;
     }
   } catch {
@@ -1728,15 +1733,34 @@ export function createClaudeRuntime({ emit }) {
       });
     }
 
-    // Catch spawn errors (e.g. ENOENT) to prevent crashing the provider runtime.
+    // Catch spawn errors (e.g. ENOENT, EBADARCH) to prevent crashing the provider runtime.
     processHandle.on("error", (spawnError) => {
       console.error(`[browser-local][claude] Spawn error: ${spawnError.message}`);
       sessions.delete(sessionId);
+      // macOS surfaces a wrong-arch binary as `errno: -86` / "Bad CPU type in
+      // executable" (EBADARCH). It hits when a prior install dropped the wrong
+      // slice (e.g. x86_64 claude on an arm64 Mac without Rosetta) and our
+      // resolver couldn't see that path was unusable. Surface a specific,
+      // actionable error so the user doesn't see "spawn Unknown system error -86". #1862
+      const isBadArch =
+        spawnError.errno === -86 ||
+        spawnError.code === "EBADARCH" ||
+        /bad cpu type in executable/i.test(spawnError.message ?? "");
+      let errorMessage;
+      if (spawnError.code === "ENOENT") {
+        errorMessage = `Claude Code CLI not found at "${claudeBin}". Install it from https://claude.ai/download`;
+      } else if (isBadArch) {
+        errorMessage =
+          `Claude Code CLI at "${claudeBin}" is the wrong CPU type for this Mac ` +
+          `(host arch: ${process.arch}). Install Rosetta 2 with ` +
+          `'softwareupdate --install-rosetta --agree-to-license', or delete that ` +
+          `binary and let Seren reinstall via npm on next launch.`;
+      } else {
+        errorMessage = `Failed to start Claude Code: ${spawnError.message}`;
+      }
       emit("provider://error", {
         sessionId,
-        error: spawnError.code === "ENOENT"
-          ? `Claude Code CLI not found at "${claudeBin}". Install it from https://claude.ai/download`
-          : `Failed to start Claude Code: ${spawnError.message}`,
+        error: errorMessage,
       });
       emit("provider://session-status", {
         sessionId,

--- a/tests/unit/claude-bin-arch-check.test.ts
+++ b/tests/unit/claude-bin-arch-check.test.ts
@@ -1,0 +1,138 @@
+// ABOUTME: Critical guard for #1862 — binaryRunsOnHost must reject wrong-arch
+// ABOUTME: Mach-O/ELF/PE binaries so a wrong-arch claude no longer spawns with EBADARCH.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/agent-registry.mjs",
+  import.meta.url,
+).href;
+const { binaryRunsOnHost } = (await import(/* @vite-ignore */ modulePath)) as {
+  binaryRunsOnHost: (filePath: string) => boolean;
+};
+
+// Mach-O 64-bit little-endian magic (modern macOS binaries).
+const MH_MAGIC_64 = Buffer.from([0xcf, 0xfa, 0xed, 0xfe]);
+const MACHO_CPUTYPE_X86_64 = Buffer.from([0x07, 0x00, 0x00, 0x01]);
+const MACHO_CPUTYPE_ARM64 = Buffer.from([0x0c, 0x00, 0x00, 0x01]);
+
+// Universal Mach-O fat header (BE magic). cputype slices follow but the kernel
+// picks the matching one — universals are always runnable.
+const FAT_MAGIC = Buffer.from([0xca, 0xfe, 0xba, 0xbe]);
+
+// ELF: 7F 'E' 'L' 'F', then class=64-bit, data=little-endian. Machine field
+// lives at offset 18 (e_machine, 2 bytes LE).
+function elfHeader(machine: number): Buffer {
+  const buf = Buffer.alloc(64, 0);
+  buf.writeUInt8(0x7f, 0);
+  buf.writeUInt8(0x45, 1); // E
+  buf.writeUInt8(0x4c, 2); // L
+  buf.writeUInt8(0x46, 3); // F
+  buf.writeUInt8(0x02, 4); // EI_CLASS = ELFCLASS64
+  buf.writeUInt8(0x01, 5); // EI_DATA = ELFDATA2LSB (little-endian)
+  buf.writeUInt16LE(machine, 18);
+  return buf;
+}
+
+// PE/COFF: "MZ" header, PE offset at 0x3C, then "PE\0\0" + IMAGE_FILE_HEADER
+// where Machine is the first 2 bytes after the signature.
+function peHeader(machine: number): Buffer {
+  const peOffset = 0x80;
+  const buf = Buffer.alloc(peOffset + 8, 0);
+  buf.writeUInt16LE(0x5a4d, 0); // "MZ"
+  buf.writeUInt32LE(peOffset, 0x3c);
+  buf.writeUInt32LE(0x00004550, peOffset); // "PE\0\0"
+  buf.writeUInt16LE(machine, peOffset + 4); // IMAGE_FILE_HEADER.Machine
+  return buf;
+}
+
+function machoHeader(cputype: Buffer): Buffer {
+  return Buffer.concat([
+    MH_MAGIC_64,
+    cputype,
+    Buffer.alloc(20, 0), // pad out the rest of the mach_header_64 we need
+  ]);
+}
+
+describe("#1862 — binaryRunsOnHost arch detection", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), "arch-check-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFixture(name: string, bytes: Buffer): string {
+    const p = path.join(tmpDir, name);
+    writeFileSync(p, bytes);
+    return p;
+  }
+
+  it("accepts a Mach-O matching this host's process.arch", () => {
+    const cputype = process.arch === "arm64" ? MACHO_CPUTYPE_ARM64 : MACHO_CPUTYPE_X86_64;
+    const fixture = writeFixture("matching.bin", machoHeader(cputype));
+    expect(binaryRunsOnHost(fixture)).toBe(true);
+  });
+
+  it("rejects a Mach-O whose cputype does NOT match this host (the #1862 bug)", () => {
+    // Pick the OPPOSITE arch from the host. This is the exact failure mode
+    // on the M5: x86_64 claude binary on arm64 host → spawn returns -86.
+    const wrongCputype = process.arch === "arm64" ? MACHO_CPUTYPE_X86_64 : MACHO_CPUTYPE_ARM64;
+    const fixture = writeFixture("wrong-arch.bin", machoHeader(wrongCputype));
+    expect(binaryRunsOnHost(fixture)).toBe(false);
+  });
+
+  it("accepts a universal (fat) Mach-O regardless of host arch", () => {
+    // Universals contain every slice; kernel picks the matching one. Don't
+    // reject what the kernel will happily run.
+    const fixture = writeFixture("universal.bin", Buffer.concat([FAT_MAGIC, Buffer.alloc(60, 0)]));
+    expect(binaryRunsOnHost(fixture)).toBe(true);
+  });
+
+  it("accepts an ELF whose e_machine matches this host", () => {
+    // EM_X86_64 = 0x3E, EM_AARCH64 = 0xB7
+    const machine = process.arch === "arm64" ? 0xb7 : 0x3e;
+    const fixture = writeFixture("matching.elf", elfHeader(machine));
+    expect(binaryRunsOnHost(fixture)).toBe(true);
+  });
+
+  it("rejects an ELF whose e_machine does NOT match this host", () => {
+    const wrongMachine = process.arch === "arm64" ? 0x3e : 0xb7;
+    const fixture = writeFixture("wrong.elf", elfHeader(wrongMachine));
+    expect(binaryRunsOnHost(fixture)).toBe(false);
+  });
+
+  it("accepts a PE/COFF whose Machine matches this host", () => {
+    // IMAGE_FILE_MACHINE_AMD64 = 0x8664, IMAGE_FILE_MACHINE_ARM64 = 0xAA64
+    const machine = process.arch === "arm64" ? 0xaa64 : 0x8664;
+    const fixture = writeFixture("matching.exe", peHeader(machine));
+    expect(binaryRunsOnHost(fixture)).toBe(true);
+  });
+
+  it("rejects a PE/COFF whose Machine does NOT match this host", () => {
+    const wrongMachine = process.arch === "arm64" ? 0x8664 : 0xaa64;
+    const fixture = writeFixture("wrong.exe", peHeader(wrongMachine));
+    expect(binaryRunsOnHost(fixture)).toBe(false);
+  });
+
+  it("accepts non-binary files (shell scripts, text) so we don't reject what we can't classify", () => {
+    // Wrapper scripts and shebang launchers are legitimate claude install
+    // forms in some environments. If we can't read a CPU type, defer to the
+    // spawn — it will surface a real error.
+    const fixture = writeFixture("script.sh", Buffer.from("#!/bin/sh\necho hi\n"));
+    expect(binaryRunsOnHost(fixture)).toBe(true);
+  });
+
+  it("accepts missing files (defers to existsSync upstream)", () => {
+    // resolvers check existsSync before calling binaryRunsOnHost; if a file
+    // disappears between those calls, treat it as runnable so we don't
+    // silently skip a candidate the upstream caller intended to use.
+    expect(binaryRunsOnHost(path.join(tmpDir, "does-not-exist"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Resolves #1862 - a wrong-arch claude binary (e.g. x86_64 dropped by claude.ai/install.sh on an arm64 Mac) no longer shadows a working install and no longer spawns with the opaque `spawn Unknown system error -86`.
- Arch-validates every resolver candidate via Mach-O / ELF / PE header inspection (`binaryRunsOnHost`). Mismatched binaries are skipped, so a leftover at `~/.local/bin/claude` falls through to the embedded-npm install path which is arch-correct by construction.
- Spawn-error handler now branches on errno -86 / EBADARCH and surfaces an actionable message naming the bad binary, the host arch, and the two remediation steps (install Rosetta, or let Seren reinstall via npm).

## Test plan

- [x] `pnpm vitest run tests/unit/claude-bin-arch-check.test.ts` - 9/9 pass, covers Mach-O matching/mismatching, universal Mach-O, ELF x64/arm64, PE AMD64/ARM64, non-binary script, missing file.
- [x] `pnpm vitest run` - full suite 981/981 pass (including the #1735 executability-gate guard which still references X_OK inside resolveClaudeBinary).
- [x] `pnpm build:provider-runtime` - bundles updated source into `src-tauri/embedded-runtime/provider-runtime/`. Verified `binaryRunsOnHost`, `readBinaryArch`, and the EBADARCH branch are present in the built artifact.
- [ ] Manual on affected M5: delete `~/.local/bin/claude`, relaunch Seren, confirm first spawn either (a) routes to the embedded npm install path and spawns the arm64 binary, or (b) if a wrong-arch binary persists somewhere, the UI shows the new Rosetta/reinstall guidance instead of the bare error code.

## Immediate user unblock (no app update needed)

```
softwareupdate --install-rosetta --agree-to-license
```

With Rosetta installed the existing x86_64 claude runs under translation while the fix ships.
