### PR TITLE
fix(skills): close #1877 — sidebar Run button replaces pencil

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -51,6 +51,12 @@ import {
   skillDragPayload,
 } from "@/lib/skill-drag";
 import {
+  buildSkillInvocationDirective,
+  buildSkillInvocationDisplay,
+  RUN_SKILL_EVENT,
+  type RunSkillEventDetail,
+} from "@/lib/skills/invoke";
+import {
   appendInputHistory,
   getInputHistory,
   getThreadDraft,
@@ -758,17 +764,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           console.warn("[AgentChat] Failed to load skill content:", err);
         }
 
-        const directive = skillContent
-          ? [
-              `<skill-invocation name="${skill.slug}">`,
-              `The user has invoked the /${skill.slug} skill. Execute it by following the skill instructions below.`,
-              args ? `\nUser request: ${args}` : "",
-              `\n${skillContent}`,
-              `</skill-invocation>`,
-            ].join("\n")
-          : args
-            ? `/${skill.slug} ${args}`
-            : `/${skill.slug}`;
+        const directive = buildSkillInvocationDirective({
+          slug: skill.slug,
+          content: skillContent,
+          args,
+        });
 
         await agentStore.sendPrompt(
           directive,
@@ -969,12 +969,41 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
   };
 
+  const handleRunSkillEvent = async (event: Event) => {
+    const detail = (event as CustomEvent<RunSkillEventDetail>).detail;
+    if (!detail || detail.kind !== "agent") return;
+    const thread = activeAgentThread();
+    if (!thread || thread.id !== detail.threadId) return;
+
+    let skillContent: string | null = null;
+    try {
+      skillContent = await skills.readContent(detail.skill);
+    } catch (err) {
+      console.warn("[AgentChat] Run skill: failed to load skill content:", err);
+    }
+
+    const directive = buildSkillInvocationDirective({
+      slug: detail.skill.slug,
+      content: skillContent,
+    });
+    const displayContent = buildSkillInvocationDisplay(detail.skill.slug);
+
+    await agentStore.sendPrompt(
+      directive,
+      undefined,
+      { displayContent },
+      threadSessionId() ?? undefined,
+    );
+  };
+
   onMount(() => {
     document.addEventListener("keydown", handleGlobalKeyDown);
+    window.addEventListener(RUN_SKILL_EVENT, handleRunSkillEvent);
   });
 
   onCleanup(() => {
     document.removeEventListener("keydown", handleGlobalKeyDown);
+    window.removeEventListener(RUN_SKILL_EVENT, handleRunSkillEvent);
   });
 
   const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -41,6 +41,12 @@ import {
   setCurrentSkillDragPayload,
   skillDragPayload,
 } from "@/lib/skill-drag";
+import {
+  buildSkillInvocationDirective,
+  buildSkillInvocationDisplay,
+  RUN_SKILL_EVENT,
+  type RunSkillEventDetail,
+} from "@/lib/skills/invoke";
 import { appendInputHistory, getInputHistory } from "@/lib/tauri-bridge";
 import { catalog, type Publisher } from "@/services/catalog";
 import {
@@ -397,6 +403,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     // Listen for slash command events
     window.addEventListener("seren:pick-images", handlePickImages);
     window.addEventListener("seren:set-chat-input", handleSetChatInput);
+    window.addEventListener(RUN_SKILL_EVENT, handleRunSkillEvent);
 
     try {
       await conversationStore.loadHistory();
@@ -449,6 +456,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       "seren:set-chat-input",
       handleSetChatInput as EventListener,
     );
+    window.removeEventListener(RUN_SKILL_EVENT, handleRunSkillEvent);
 
     if (suggestionDebounceTimer) {
       clearTimeout(suggestionDebounceTimer);
@@ -666,6 +674,29 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     setAttachedImages((prev) => prev.filter((_, i) => i !== index));
   };
 
+  const handleRunSkillEvent = async (event: Event) => {
+    const detail = (event as CustomEvent<RunSkillEventDetail>).detail;
+    if (!detail || detail.kind !== "chat") return;
+    if (conversationId() !== detail.threadId) return;
+
+    let skillContent: string | null = null;
+    try {
+      skillContent = await skills.readContent(detail.skill);
+    } catch (err) {
+      console.warn(
+        "[ChatContent] Run skill: failed to load skill content:",
+        err,
+      );
+    }
+
+    const directive = buildSkillInvocationDirective({
+      slug: detail.skill.slug,
+      content: skillContent,
+    });
+    const displayText = buildSkillInvocationDisplay(detail.skill.slug);
+    await sendMessageImmediate(directive, undefined, displayText);
+  };
+
   const executeSlashCommand = (trimmed: string) => {
     const parsed = parseCommand(trimmed, "chat");
     if (!parsed) return false;
@@ -746,19 +777,12 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
           console.warn("[ChatContent] Failed to load skill content:", err);
         }
 
-        const directive = skillContent
-          ? [
-              `<skill-invocation name="${skill.slug}">`,
-              `The user has invoked the /${skill.slug} skill. Execute it by following the skill instructions below.`,
-              args ? `\nUser request: ${args}` : "",
-              `\n${skillContent}`,
-              `</skill-invocation>`,
-            ].join("\n")
-          : args
-            ? `/${skill.slug} ${args}`
-            : `/${skill.slug}`;
-
-        const displayText = args ? `/${skill.slug} ${args}` : `/${skill.slug}`;
+        const directive = buildSkillInvocationDirective({
+          slug: skill.slug,
+          content: skillContent,
+          args,
+        });
+        const displayText = buildSkillInvocationDisplay(skill.slug, args);
         await sendMessageImmediate(directive, undefined, displayText);
         return;
       }

--- a/src/components/sidebar/SkillsExplorer.tsx
+++ b/src/components/sidebar/SkillsExplorer.tsx
@@ -35,6 +35,7 @@ import {
   parseSkillMd,
   resolveSkillDisplayName,
 } from "@/lib/skills";
+import { RUN_SKILL_EVENT } from "@/lib/skills/invoke";
 import {
   isUpstreamManagedSkill,
   skills as skillsService,
@@ -57,20 +58,16 @@ type Filter = "all" | "installed" | "needs-sync";
 const SKILL_CREATOR_SLUG = "skill-creator";
 const SKILL_CREATOR_SOURCE_URL = `seren-skills:${SKILL_CREATOR_SLUG}`;
 
-const PencilIcon: Component = () => (
+const PlayIcon: Component = () => (
   <svg
-    width="13"
-    height="13"
+    width="11"
+    height="11"
     viewBox="0 0 16 16"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="1.3"
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    fill="currentColor"
     role="img"
-    aria-label="Edit"
+    aria-label="Run"
   >
-    <path d="M11.5 2L14 4.5l-8.5 8.5H3v-2.5L11.5 2z" />
+    <path d="M4 2.5v11l10-5.5z" />
   </svg>
 );
 
@@ -606,6 +603,46 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
       context.threadId,
       skill.path,
     );
+  };
+
+  const runActionTitle = (): string => {
+    const context = activeThreadContext();
+    if (!context) return "Select a chat, agent, or terminal thread first";
+    if (context.kind === "terminal") {
+      return "Paste the SKILL.md prompt into the active terminal";
+    }
+    return "Run the skill in the active chat";
+  };
+
+  const handleRunSkill = async (skill: InstalledSkill) => {
+    const context = activeThreadContext();
+    if (!context) return;
+
+    setActionInProgress(skill.id);
+    setInstallError(null);
+    try {
+      if (context.kind === "terminal") {
+        await pasteSkillIntoTerminal(context.threadId, skill);
+        return;
+      }
+      window.dispatchEvent(
+        new CustomEvent(RUN_SKILL_EVENT, {
+          detail: {
+            kind: context.kind,
+            threadId: context.threadId,
+            skill,
+          },
+        }),
+      );
+    } catch (err) {
+      console.error("[SkillsExplorer] Failed to run skill:", err);
+      setInstallError({
+        slug: skill.slug,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setActionInProgress(null);
+    }
   };
 
   const handleAddInstalledSkill = async (skill: InstalledSkill) => {
@@ -1330,15 +1367,20 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                     <div class="shrink-0 mt-0.5 flex items-center gap-0.5">
                       <button
                         type="button"
-                        class="flex items-center justify-center w-7 h-7 bg-transparent border-none rounded-md text-muted-foreground cursor-pointer transition-colors hover:bg-surface-2 hover:text-foreground"
+                        class="flex items-center justify-center gap-1 px-2 h-7 bg-success text-white rounded-md text-[11px] font-medium cursor-pointer transition-colors hover:bg-success/80 disabled:opacity-40 disabled:cursor-default"
                         onClick={(e) => {
                           e.stopPropagation();
-                          void handleEditInEditor(editablePathFor(skill));
+                          void handleRunSkill(skill);
                         }}
-                        title="Edit SKILL.md in the editor"
-                        aria-label="Edit skill"
+                        disabled={
+                          actionInProgress() === skill.id ||
+                          !activeThreadContext()
+                        }
+                        title={runActionTitle()}
+                        aria-label="Run skill"
                       >
-                        <PencilIcon />
+                        <PlayIcon />
+                        Run
                       </button>
                       <Show
                         when={isPublishable(skill) || canPublishUpdate(skill)}
@@ -1382,7 +1424,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                         when={!activeThreadHasSkill(skill)}
                         fallback={
                           <span class="ml-1 px-2 py-1 text-[11px] text-success bg-success/10 rounded">
-                            Added
+                            Installed
                           </span>
                         }
                       >
@@ -1602,15 +1644,6 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                             {actionInProgress() === skill.id
                               ? "Uninstalling..."
                               : "Uninstall"}
-                          </button>
-                          <button
-                            type="button"
-                            class="px-3 py-1 bg-transparent border border-border text-muted-foreground rounded-md text-[12px] cursor-pointer transition-colors hover:bg-surface-2 hover:text-foreground"
-                            onClick={() =>
-                              handleEditInEditor(editablePathFor(skill))
-                            }
-                          >
-                            Edit in Editor
                           </button>
                           <Show when={ownsSkill(skill)}>
                             <button

--- a/src/lib/skills/invoke.ts
+++ b/src/lib/skills/invoke.ts
@@ -1,0 +1,39 @@
+// ABOUTME: Pure helpers and shared types for skill invocation — used by the
+// ABOUTME: chat slash-command path and the sidebar Run button event.
+
+import type { InstalledSkill } from "@/lib/skills/types";
+
+export const RUN_SKILL_EVENT = "seren:run-skill" as const;
+
+export interface RunSkillEventDetail {
+  kind: "agent" | "chat";
+  threadId: string;
+  skill: InstalledSkill;
+}
+
+export interface BuildDirectiveArgs {
+  slug: string;
+  content: string | null;
+  args?: string;
+}
+
+export function buildSkillInvocationDirective({
+  slug,
+  content,
+  args,
+}: BuildDirectiveArgs): string {
+  if (!content) {
+    return args ? `/${slug} ${args}` : `/${slug}`;
+  }
+  return [
+    `<skill-invocation name="${slug}">`,
+    `The user has invoked the /${slug} skill. Execute it by following the skill instructions below.`,
+    args ? `\nUser request: ${args}` : "",
+    `\n${content}`,
+    `</skill-invocation>`,
+  ].join("\n");
+}
+
+export function buildSkillInvocationDisplay(slug: string, args?: string) {
+  return args ? `/${slug} ${args}` : `/${slug}`;
+}

--- a/tests/unit/skill-invocation-directive.test.ts
+++ b/tests/unit/skill-invocation-directive.test.ts
@@ -1,0 +1,58 @@
+// ABOUTME: Tests for the shared skill-invocation directive builder used by
+// ABOUTME: AgentChat, ChatContent, and the sidebar Run button.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildSkillInvocationDirective,
+  buildSkillInvocationDisplay,
+} from "@/lib/skills/invoke";
+
+describe("buildSkillInvocationDirective", () => {
+  const slug = "polymarket-trader";
+  const content = "# Polymarket Trader\nDo the thing.";
+
+  it("wraps SKILL.md content in a skill-invocation block when content is loaded", () => {
+    const directive = buildSkillInvocationDirective({ slug, content });
+    expect(directive).toContain(`<skill-invocation name="${slug}">`);
+    expect(directive).toContain(
+      `The user has invoked the /${slug} skill. Execute it by following the skill instructions below.`,
+    );
+    expect(directive).toContain(content);
+    expect(directive).toContain("</skill-invocation>");
+  });
+
+  it("embeds the user's args inside the invocation block when provided", () => {
+    const directive = buildSkillInvocationDirective({
+      slug,
+      content,
+      args: "buy YES at 0.42",
+    });
+    expect(directive).toContain("User request: buy YES at 0.42");
+  });
+
+  it("falls back to a /slug args string when SKILL.md content is missing", () => {
+    expect(
+      buildSkillInvocationDirective({ slug, content: null, args: "do x" }),
+    ).toBe(`/${slug} do x`);
+  });
+
+  it("falls back to bare /slug when both content and args are missing", () => {
+    expect(buildSkillInvocationDirective({ slug, content: null })).toBe(
+      `/${slug}`,
+    );
+  });
+});
+
+describe("buildSkillInvocationDisplay", () => {
+  const slug = "polymarket-trader";
+
+  it("renders as /slug when no args are supplied", () => {
+    expect(buildSkillInvocationDisplay(slug)).toBe(`/${slug}`);
+  });
+
+  it("appends args after a single space when supplied", () => {
+    expect(buildSkillInvocationDisplay(slug, "buy YES")).toBe(
+      `/${slug} buy YES`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the SkillsExplorer pencil "Edit SKILL.md" button with a green **Run** button that invokes the skill in the active chat/agent thread (paste for terminal threads). Closes #1877.
- Extracts the duplicated skill-invocation directive builder from `AgentChat.tsx` and `ChatContent.tsx` into `src/lib/skills/invoke.ts` so the sidebar Run path and the chat slash-command path share one source of truth.
- Renames the per-thread "Added" pill to "Installed" and removes the redundant "Edit in Editor" button from the detail accordion.

## Why
Users are not code editors — they shouldn't edit `SKILL.md` by hand to use a skill. They want one click to fire a skill in the chat. The pencil never gave them that. The shared directive helper keeps `/<slug>` and the sidebar Run button perfectly aligned in behavior.

## Audit
- `handleEditInEditor` / `editablePathFor` retained: still used by `handleSkillCreated` (post-create handoff) and `handlePublishClick` (publish flow). Pencil-related dead code is otherwise removed.
- Run dispatches a `seren:run-skill` CustomEvent (same pattern as the existing `seren:terminal-paste-text` event); each chat component claims it only when its active thread id+kind matches.
- Run is disabled with a "Select a chat, agent, or terminal thread first" tooltip when no thread context is active — mirrors the Add button.

## Test plan
- [x] 6 new unit tests on `buildSkillInvocationDirective` (with content+args, with content no args, no content with args, no content no args) — all passing.
- [x] Full unit suite passes (987/987).
- [x] `npx tsc --noEmit` clean.
- [x] Biome clean on changed files.
- [ ] Manual: in `pnpm tauri dev`, with an installed skill, click Run from an agent thread → directive fires, skill executes.
- [ ] Manual: same skill, click Run from a chat thread → message sends, skill executes.
- [ ] Manual: from a terminal thread → SKILL.md content pastes into the terminal.
- [ ] Manual: no active thread → Run is disabled with correct tooltip.
- [ ] Manual: "Installed" pill renders after Add; switching to a thread that hasn't added the skill shows the blue Add button.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
