### PR TITLE
fix(auth): close #1878 — login targets same binary as spawn

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -2,7 +2,14 @@
 // ABOUTME: Keeps provider metadata and per-agent setup logic separate from session runtime handling.
 
 import { execFile, spawn } from "node:child_process";
-import { closeSync, existsSync, openSync, readSync } from "node:fs";
+import {
+  accessSync,
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  openSync,
+  readSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -99,15 +106,71 @@ export function binaryRunsOnHost(filePath) {
   return fileArch === process.arch;
 }
 
-function launchLoginCommand(command) {
-  const loginCommand = `${command} login`;
+/**
+ * True when `candidate` exists and the current process has execute permission.
+ * Mirrors the spawn-time gate in claude-runtime.mjs so login and spawn agree
+ * on which candidates are viable. On Windows X_OK collapses to existence —
+ * which is the right semantic there (no separate exec bit). #1735, #1878.
+ */
+function isExecutableCandidate(candidate) {
+  try {
+    accessSync(candidate, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
+/**
+ * Build the shell command string that the platform terminal will execute.
+ * The resolved binary may be an absolute path that contains spaces (e.g.
+ * `/Users/Some User/.local/bin/claude`) or a single apostrophe. Naive
+ * interpolation breaks on both; previously this was unquoted and would
+ * silently fail or get re-parsed as multiple shell words.
+ *
+ * A path that's just the bare command name ("claude", "codex") passes
+ * through unquoted — the call site uses the sentinel when the resolver
+ * couldn't find an install, in which case we want the user's shell PATH
+ * to resolve the command. #1878.
+ */
+function buildLoginShellCommand(command) {
+  // No path separator and no whitespace → bare command, pass through.
+  // `path.sep` is `/` on POSIX and `\\` on Windows; check both since this
+  // function is platform-neutral.
+  const isBare = !/[\s/\\]/.test(command);
+  if (isBare) {
+    return `${command} login`;
+  }
+  // POSIX single-quote escape: close the quote, escape with backslash,
+  // reopen. AppleScript and POSIX shells both honor this idiom.
+  const quoted = `'${command.replace(/'/g, "'\\''")}'`;
+  return `${quoted} login`;
+}
+
+/**
+ * Launch `<command> login` in a new terminal window.
+ *
+ * Accepts either a bare command name (resolved by the user's shell PATH)
+ * or an absolute path returned by `resolveInstalled*Binary`. The latter
+ * guarantees that login targets the same binary `spawnSession` would have
+ * picked, preventing the auth/spawn split-brain in #1876.
+ *
+ * Exported for #1878 test coverage of shell-quoting behavior.
+ */
+export function launchLoginCommand(command) {
   if (process.platform === "darwin") {
+    const loginCommand = buildLoginShellCommand(command);
+    // AppleScript string layer: escape backslashes first, then double
+    // quotes. Without this, a path containing `"` would terminate the
+    // do-script string early and inject AppleScript.
+    const escapedForAppleScript = loginCommand
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"');
     spawn(
       "osascript",
       [
         "-e",
-        `tell application "Terminal" to do script "${loginCommand}"`,
+        `tell application "Terminal" to do script "${escapedForAppleScript}"`,
         "-e",
         'tell application "Terminal" to activate',
       ],
@@ -117,13 +180,21 @@ function launchLoginCommand(command) {
   }
 
   if (process.platform === "win32") {
-    spawn("cmd", ["/c", "start", "cmd", "/c", loginCommand], {
-      detached: true,
-      stdio: "ignore",
-    }).unref();
+    // `start` syntax: `start [title] [command]`. When the first quoted arg
+    // is present, `start` always treats it as the window title — so an
+    // unquoted path with spaces breaks parsing, and a quoted path silently
+    // becomes the title and never runs. Emit an explicit empty title to
+    // pin the window-title slot regardless of what the path looks like.
+    spawn(
+      "cmd",
+      ["/c", "start", "", command, "login"],
+      { detached: true, stdio: "ignore" },
+    ).unref();
     return;
   }
 
+  // x-terminal-emulator argv form: spaces survive argv boundaries, so the
+  // resolved absolute path needs no shell quoting.
   spawn("x-terminal-emulator", ["-e", command, "login"], {
     detached: true,
     stdio: "ignore",
@@ -530,8 +601,15 @@ export function resolveInstalledClaudeBinary() {
       // Distro package managers. #1665
       "/usr/bin/claude",
     ];
+    // Parity with claude-runtime's spawn-time gate (#1735): existsSync alone
+    // passes broken symlinks and non-executable files, both of which fail
+    // spawn at runtime. Login and spawn must agree, so use the same gate.
     for (const candidate of candidates) {
-      if (existsSync(candidate) && binaryRunsOnHost(candidate)) {
+      if (
+        existsSync(candidate) &&
+        isExecutableCandidate(candidate) &&
+        binaryRunsOnHost(candidate)
+      ) {
         return candidate;
       }
     }
@@ -632,7 +710,12 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         });
       },
       launchLogin() {
-        launchLoginCommand("codex");
+        // Login MUST target the same binary that providers.spawnCodex
+        // resolves (providers.mjs:130). Otherwise the OAuth flow writes
+        // credentials to one codex install while Seren spawns a different
+        // one. Mirrors the Gemini fix below (#1476) and Claude (#1878).
+        const resolved = resolveInstalledCodexBinary();
+        launchLoginCommand(resolved !== "codex" ? resolved : "codex");
       },
     },
     "claude-code": {
@@ -663,7 +746,14 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         return ensureClaudeCodeViaNativeInstaller(emit);
       },
       launchLogin() {
-        launchLoginCommand("claude");
+        // Login MUST target the same binary that claude-runtime resolves
+        // for spawnSession. When they diverge — or when both point at the
+        // same binary but `~/.claude/.credentials.json` was migrated from
+        // another machine — the OAuth flow writes a fresh token to one
+        // backend while the spawned claude reads from another and 401s on
+        // first prompt (#1876). Mirrors the Gemini fix (#1476).
+        const resolved = resolveInstalledClaudeBinary();
+        launchLoginCommand(resolved !== "claude" ? resolved : "claude");
       },
     },
     gemini: {

--- a/tests/unit/launch-login-resolver.test.ts
+++ b/tests/unit/launch-login-resolver.test.ts
@@ -1,0 +1,153 @@
+// ABOUTME: Regression guard for #1878 — launchLogin must resolve the same claude/codex binary as spawnSession.
+// ABOUTME: Source-text + behavioral coverage: resolver wiring, shell quoting on darwin/win32/linux, bare-name fallback.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const registryPath = resolve("bin/browser-local/agent-registry.mjs");
+const registrySource = readFileSync(registryPath, "utf-8");
+
+function sliceDefinition(key: string): string {
+  // Object literal keys may be quoted ("claude-code") or bare (codex).
+  const quoted = registrySource.indexOf(`"${key}": {`);
+  const bare = registrySource.indexOf(`\n    ${key}: {`);
+  const start = quoted >= 0 ? quoted : bare >= 0 ? bare + 1 : -1;
+  if (start < 0) throw new Error(`Definition not found: ${key}`);
+  const window = registrySource.slice(start, start + 4000);
+  const next = window.indexOf("\n    },\n    ");
+  return next > 0 ? window.slice(0, next) : window;
+}
+
+describe("#1878 — claude-code.launchLogin uses the spawn-time resolver", () => {
+  it("invokes resolveInstalledClaudeBinary before launchLoginCommand", () => {
+    const def = sliceDefinition("claude-code");
+    const resolverIdx = def.indexOf("resolveInstalledClaudeBinary(");
+    const commandIdx = def.indexOf("launchLoginCommand(");
+    expect(resolverIdx).toBeGreaterThan(0);
+    expect(commandIdx).toBeGreaterThan(resolverIdx);
+  });
+
+  it("does NOT call launchLoginCommand with the bare 'claude' literal", () => {
+    const def = sliceDefinition("claude-code");
+    expect(def).not.toMatch(/launchLoginCommand\(\s*"claude"\s*\)/);
+  });
+});
+
+describe("#1878 — codex.launchLogin uses the spawn-time resolver", () => {
+  it("invokes resolveInstalledCodexBinary before launchLoginCommand", () => {
+    const def = sliceDefinition("codex");
+    const resolverIdx = def.indexOf("resolveInstalledCodexBinary(");
+    const commandIdx = def.indexOf("launchLoginCommand(");
+    expect(resolverIdx).toBeGreaterThan(0);
+    expect(commandIdx).toBeGreaterThan(resolverIdx);
+  });
+
+  it("does NOT call launchLoginCommand with the bare 'codex' literal", () => {
+    const def = sliceDefinition("codex");
+    expect(def).not.toMatch(/launchLoginCommand\(\s*"codex"\s*\)/);
+  });
+});
+
+describe("#1878 — launchLoginCommand quotes paths safely on all platforms", () => {
+  const spawnMock = vi.fn();
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(() => ({
+      unref: () => undefined,
+    }));
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+      configurable: true,
+    });
+    vi.resetModules();
+  });
+
+  function setPlatform(value: NodeJS.Platform) {
+    Object.defineProperty(process, "platform", {
+      value,
+      configurable: true,
+    });
+  }
+
+  async function loadLaunchLoginCommand() {
+    vi.doMock("node:child_process", async () => {
+      const actual = await vi.importActual<typeof import("node:child_process")>(
+        "node:child_process",
+      );
+      return { ...actual, spawn: spawnMock };
+    });
+    // @ts-expect-error — .mjs source is JS; type info isn't generated.
+    const mod = await import("../../bin/browser-local/agent-registry.mjs");
+    return mod.launchLoginCommand as (command: string) => void;
+  }
+
+  it("macOS: single-quotes a path with a space and survives AppleScript layer", async () => {
+    setPlatform("darwin");
+    const launchLoginCommand = await loadLaunchLoginCommand();
+    const pathWithSpace = "/Users/Some User/.local/bin/claude";
+
+    launchLoginCommand(pathWithSpace);
+
+    expect(spawnMock).toHaveBeenCalled();
+    const [bin, args] = spawnMock.mock.calls[0];
+    expect(bin).toBe("osascript");
+    const script = (args as string[]).find((a) => a.includes("do script"));
+    expect(script).toBeDefined();
+    // The path must appear single-quoted inside the AppleScript so the shell
+    // sees one argument, not three space-split words.
+    expect(script).toContain(`'${pathWithSpace}' login`);
+  });
+
+  it("macOS: bare command passes through unquoted (no regression for PATH installs)", async () => {
+    setPlatform("darwin");
+    const launchLoginCommand = await loadLaunchLoginCommand();
+
+    launchLoginCommand("claude");
+
+    expect(spawnMock).toHaveBeenCalled();
+    const [, args] = spawnMock.mock.calls[0];
+    const script = (args as string[]).find((a) => a.includes("do script"));
+    expect(script).toContain("claude login");
+  });
+
+  it("Windows: emits explicit empty title before quoted path so start does not eat the path", async () => {
+    setPlatform("win32");
+    const launchLoginCommand = await loadLaunchLoginCommand();
+    const pathWithSpace = "C:\\Users\\Some User\\AppData\\Roaming\\npm\\claude.cmd";
+
+    launchLoginCommand(pathWithSpace);
+
+    expect(spawnMock).toHaveBeenCalled();
+    const [bin, args] = spawnMock.mock.calls[0];
+    expect(bin).toBe("cmd");
+    const argv = args as string[];
+    // start <title> <command>. Title must be the empty string when the path
+    // is quoted, otherwise start consumes the path as the window title.
+    const startIdx = argv.indexOf("start");
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    expect(argv[startIdx + 1]).toBe("");
+    expect(argv.slice(startIdx + 2).join(" ")).toContain(pathWithSpace);
+  });
+
+  it("Linux: passes the resolved absolute path as a single argv element", async () => {
+    setPlatform("linux");
+    const launchLoginCommand = await loadLaunchLoginCommand();
+    const pathWithSpace = "/home/some user/.local/bin/claude";
+
+    launchLoginCommand(pathWithSpace);
+
+    expect(spawnMock).toHaveBeenCalled();
+    const [bin, args] = spawnMock.mock.calls[0];
+    expect(bin).toBe("x-terminal-emulator");
+    const argv = args as string[];
+    // The resolved path is one argv element; spaces stay intact across argv.
+    expect(argv).toContain(pathWithSpace);
+    expect(argv).toContain("login");
+  });
+});


### PR DESCRIPTION
## Summary
- `claude-code.launchLogin` / `codex.launchLogin` now resolve through `resolveInstalledClaudeBinary` / `resolveInstalledCodexBinary` and pass the absolute path into `launchLoginCommand`, mirroring Gemini (#1476). This kills the auth/spawn split-brain that 401'd users on Migration-Assistant-migrated `~/.claude/` directories.
- Parity gate: `resolveInstalledClaudeBinary` now checks `X_OK` (matching the spawn-time gate from #1735), so login and spawn agree on which candidates are viable.
- `launchLoginCommand` hardened against shell-quoting bugs: macOS single-quotes + AppleScript escape, Windows uses explicit empty title before `start`, Linux argv form unchanged.

## Test plan
- [x] `pnpm vitest run tests/unit/launch-login-resolver.test.ts` — 8/8 pass (source-text wiring + cross-platform behavioral)
- [x] `pnpm test` — 989/989 pass, no regression
- [x] `pnpm tsc --noEmit` — clean
- [ ] Manual on a fresh ARM Mac with migrated `~/.claude/` — verify single login flow then send-prompt succeeds without removing `~/.claude/.credentials.json`

Closes #1876, closes #1878.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
