### PR TITLE
fix(launcher): close #1884 — render real · in vendor subtitle

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -627,7 +627,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                   <div class="flex-1 min-w-0">
                     <div class="font-medium">Claude Code</div>
                     <div class="text-[11px] text-muted-foreground">
-                      Anthropic \u00B7 chat-style coding agent
+                      Anthropic · chat-style coding agent
                     </div>
                   </div>
                   <LauncherChip variant="subscription">
@@ -648,7 +648,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                   <div class="flex-1 min-w-0">
                     <div class="font-medium">Codex</div>
                     <div class="text-[11px] text-muted-foreground">
-                      OpenAI \u00B7 chat-style coding agent
+                      OpenAI · chat-style coding agent
                     </div>
                   </div>
                   <LauncherChip variant="subscription">
@@ -669,7 +669,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                   <div class="flex-1 min-w-0">
                     <div class="font-medium">Gemini</div>
                     <div class="text-[11px] text-muted-foreground">
-                      Google \u00B7 chat-style coding agent
+                      Google · chat-style coding agent
                     </div>
                   </div>
                   <LauncherChip variant="subscription">

--- a/tests/unit/launcher-redesign.test.ts
+++ b/tests/unit/launcher-redesign.test.ts
@@ -140,3 +140,11 @@ describe("ThreadTabBar — chip vocabulary on the secondary +New menu (#1832)", 
     expect(tabBarTsx).toContain("allowsGeminiAgent(authStore.privateChatPolicy)");
   });
 });
+
+describe("ThreadSidebar — JSX text uses real · char, never literal \\u00B7", () => {
+  // JSX text content is plain HTML, not a JS string literal: `\uXXXX` is
+  // 6 visible characters, not an escape. Use the actual char (see L603).
+  it("contains no literal '\\u00B7' byte sequence", () => {
+    expect(sidebarTsx).not.toMatch(/\\u00B7/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace literal `·` JS-escape with the actual `·` (U+00B7) byte in three rows of `ThreadSidebar.tsx` (Claude Code, Codex, Gemini).
- Add a 1-assertion regression guard in `tests/unit/launcher-redesign.test.ts` that asserts the file never reintroduces a literal `·` byte sequence.

JSX text content is plain HTML — `\uXXXX` is 6 visible characters, not an escape. The Seren Agent (Private) row at L603 already uses the actual `·` character correctly; this change brings the three coding-agent rows into line.

Closes #1884.

## Test plan

- [x] `vitest run tests/unit/launcher-redesign.test.ts` — 24 passed (was 23 + 1 red before the fix)
- [x] Full `vitest run` — 995/996 passed; the 1 failure is `cli-updater.test.ts` timing flake, passes 38/38 in isolation, unrelated to text-only changes here
- [x] `biome check` on touched files — clean
- [x] Re-grep `\\u00[0-9A-Fa-f]{2}` across `*.tsx` — only remaining hit is `SessionTimeline.tsx:17` (`">_"`), inside a JS string literal where the escape correctly resolves to `>` — not a bug

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com