### PR TITLE
fix(mcp): close #1883 — resolve bare "node" for Claude/Codex MCP

### DIFF
--- a/bin/browser-local/mcp-config.mjs
+++ b/bin/browser-local/mcp-config.mjs
@@ -1,10 +1,37 @@
 // ABOUTME: Shared MCP configuration builder for direct provider runtimes.
 // ABOUTME: Normalizes Seren's MCP settings into provider-specific Claude/Codex formats.
 
+import path from "node:path";
+
 const SEREN_MCP_SERVER_NAME = "seren-mcp";
 const SEREN_MCP_API_KEY_ENV = "SEREN_API_KEY";
 const SEREN_MCP_GATEWAY_URL =
   process.env.SEREN_MCP_GATEWAY_URL ?? "https://mcp.serendb.com/mcp";
+
+// serenorg/seren-desktop#1883 — Claude / Codex CLIs are compiled binaries that
+// spawn stdio MCP children via libc execvp() against their own minimal PATH.
+// A bare "node" command fails silently in that resolution, so the playwright
+// MCP (and any other embedded node-based stdio server) never starts. The Rust
+// provider-runtime supervisor injects SEREN_EMBEDDED_NODE_BIN with the
+// absolute path to the embedded node binary it already spawned the runtime
+// with; we rewrite "node" to that absolute path before emitting the CLI
+// configs so the child CLI can exec it without a PATH lookup. Absolute paths
+// and other bare commands (npx, python, ...) pass through unchanged.
+function resolveLocalServerCommand(command) {
+  if (typeof command !== "string" || command.length === 0) {
+    return command;
+  }
+  if (path.isAbsolute(command) || command.includes(path.sep)) {
+    return command;
+  }
+  if (command === "node") {
+    const embeddedNode = process.env.SEREN_EMBEDDED_NODE_BIN;
+    if (typeof embeddedNode === "string" && embeddedNode.length > 0) {
+      return embeddedNode;
+    }
+  }
+  return command;
+}
 
 function trimToNull(value) {
   if (typeof value !== "string") {
@@ -107,7 +134,7 @@ function buildClaudeMcpConfig(servers) {
 
     mcpServers[server.name] = {
       type: "stdio",
-      command: server.command,
+      command: resolveLocalServerCommand(server.command),
       args: server.args ?? [],
       env: server.env ?? {},
     };
@@ -132,7 +159,7 @@ function buildCodexMcpOverride(servers) {
     }
 
     mcpServers[server.name] = {
-      command: server.command,
+      command: resolveLocalServerCommand(server.command),
       args: server.args ?? [],
       ...(server.env && Object.keys(server.env).length > 0
         ? { env: server.env }

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -351,6 +351,16 @@ fn spawn_node_process(
         command.env("PATH", embedded_path);
     }
 
+    // serenorg/seren-desktop#1883 — local stdio MCP servers (playwright,
+    // future bundled tools) are emitted by the provider runtime with
+    // `command: "node"`. The Claude / Codex CLIs are compiled binaries that
+    // resolve stdio MCP commands via libc execvp against their own minimal
+    // PATH, so a bare "node" silently fails to spawn and the agent never
+    // sees the tools. Expose the absolute embedded node binary so
+    // `mcp-config.mjs` can rewrite `node` → absolute path before emitting
+    // the per-CLI config JSON / TOML.
+    command.env("SEREN_EMBEDDED_NODE_BIN", node_bin);
+
     crate::embedded_runtime::sanitize_spawn_env(&mut command);
 
     command

--- a/tests/unit/mcp-config-node-resolve.test.ts
+++ b/tests/unit/mcp-config-node-resolve.test.ts
@@ -1,0 +1,106 @@
+// ABOUTME: Regression guard for #1883 — bare "node" stdio commands must resolve to embedded node absolute path.
+// ABOUTME: Claude/Codex CLIs execvp() against their own minimal PATH; without an absolute path the MCP child silently never spawns.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const MODULE_PATH = "../../bin/browser-local/mcp-config.mjs";
+const PLAYWRIGHT_SCRIPT = "/Applications/SerenDesktop.app/Contents/Resources/mcp-servers/playwright-stealth/dist/index.js";
+const EMBEDDED_NODE = "/Applications/SerenDesktop.app/Contents/Resources/embedded-runtime/darwin-arm64/node/bin/node";
+
+const PLAYWRIGHT_SERVER = {
+  name: "playwright",
+  type: "local",
+  enabled: true,
+  command: "node",
+  args: [PLAYWRIGHT_SCRIPT],
+  env: {},
+};
+
+async function loadModule() {
+  vi.resetModules();
+  return await import(MODULE_PATH);
+}
+
+describe("#1883 — mcp-config resolves bare 'node' to embedded node binary", () => {
+  const originalEmbeddedNode = process.env.SEREN_EMBEDDED_NODE_BIN;
+
+  beforeEach(() => {
+    delete process.env.SEREN_EMBEDDED_NODE_BIN;
+  });
+
+  afterEach(() => {
+    if (originalEmbeddedNode === undefined) {
+      delete process.env.SEREN_EMBEDDED_NODE_BIN;
+    } else {
+      process.env.SEREN_EMBEDDED_NODE_BIN = originalEmbeddedNode;
+    }
+  });
+
+  it("Claude config: rewrites command:'node' to absolute path when SEREN_EMBEDDED_NODE_BIN is set", async () => {
+    process.env.SEREN_EMBEDDED_NODE_BIN = EMBEDDED_NODE;
+    const { buildProviderMcpConfig } = await loadModule();
+
+    const { claudeMcpConfigJson } = buildProviderMcpConfig({
+      apiKey: "test-key",
+      mcpServers: [PLAYWRIGHT_SERVER],
+    });
+
+    const parsed = JSON.parse(claudeMcpConfigJson);
+    expect(parsed.mcpServers.playwright).toBeDefined();
+    expect(parsed.mcpServers.playwright.type).toBe("stdio");
+    expect(parsed.mcpServers.playwright.command).toBe(EMBEDDED_NODE);
+    expect(parsed.mcpServers.playwright.args).toEqual([PLAYWRIGHT_SCRIPT]);
+  });
+
+  it("Claude config: leaves command:'node' bare when SEREN_EMBEDDED_NODE_BIN is unset (dev fallback)", async () => {
+    const { buildProviderMcpConfig } = await loadModule();
+
+    const { claudeMcpConfigJson } = buildProviderMcpConfig({
+      apiKey: "test-key",
+      mcpServers: [PLAYWRIGHT_SERVER],
+    });
+
+    const parsed = JSON.parse(claudeMcpConfigJson);
+    expect(parsed.mcpServers.playwright.command).toBe("node");
+  });
+
+  it("Claude config: never overrides commands that are already absolute paths", async () => {
+    process.env.SEREN_EMBEDDED_NODE_BIN = EMBEDDED_NODE;
+    const { buildProviderMcpConfig } = await loadModule();
+
+    const customAbsolute = "/usr/local/bin/some-other-node";
+    const { claudeMcpConfigJson } = buildProviderMcpConfig({
+      apiKey: "test-key",
+      mcpServers: [{ ...PLAYWRIGHT_SERVER, command: customAbsolute }],
+    });
+
+    const parsed = JSON.parse(claudeMcpConfigJson);
+    expect(parsed.mcpServers.playwright.command).toBe(customAbsolute);
+  });
+
+  it("Claude config: never overrides non-node bare commands (e.g. npx, python)", async () => {
+    process.env.SEREN_EMBEDDED_NODE_BIN = EMBEDDED_NODE;
+    const { buildProviderMcpConfig } = await loadModule();
+
+    const { claudeMcpConfigJson } = buildProviderMcpConfig({
+      apiKey: "test-key",
+      mcpServers: [{ ...PLAYWRIGHT_SERVER, name: "py", command: "python" }],
+    });
+
+    const parsed = JSON.parse(claudeMcpConfigJson);
+    expect(parsed.mcpServers.py.command).toBe("python");
+  });
+
+  it("Codex config: rewrites command:'node' to absolute path when SEREN_EMBEDDED_NODE_BIN is set", async () => {
+    process.env.SEREN_EMBEDDED_NODE_BIN = EMBEDDED_NODE;
+    const { buildProviderMcpConfig } = await loadModule();
+
+    const { codexMcpConfigOverride } = buildProviderMcpConfig({
+      apiKey: "test-key",
+      mcpServers: [PLAYWRIGHT_SERVER],
+    });
+
+    expect(codexMcpConfigOverride).toContain(`"command"=${JSON.stringify(EMBEDDED_NODE)}`);
+    expect(codexMcpConfigOverride).not.toContain(`"command"="node"`);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1883.

Claude / Codex CLIs are compiled binaries that spawn stdio MCP children via libc `execvp()` against their own minimal PATH. The provider runtime was emitting bare `command: "node"` in `--mcp-config` JSON / TOML, so the playwright MCP (and any other embedded-node stdio server) silently failed to spawn — agents saw `mcp__seren-mcp__*` (HTTP) fine but never `mcp__playwright__*`. This mirrors the absolute-path resolution Tauri's `mcp.rs::resolve_command_in_embedded_path` already does for its own local MCP transport.

- `src-tauri/src/provider_runtime.rs` — inject `SEREN_EMBEDDED_NODE_BIN` into the provider runtime spawn env with the absolute path to the embedded node binary.
- `bin/browser-local/mcp-config.mjs` — `resolveLocalServerCommand()` rewrites bare `node` → `SEREN_EMBEDDED_NODE_BIN` in both `buildClaudeMcpConfig` and `buildCodexMcpOverride`. Absolute paths and non-`node` bare commands pass through untouched.

Unblocks the `prophet-*` skills, `browser-automation`, and `customer-support-intake`.

## Test plan

- [x] `pnpm vitest run tests/unit/mcp-config-node-resolve.test.ts` — new regression test (5 cases) green.
- [x] `pnpm vitest run tests/unit/` — full unit suite (972 tests) green.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 464 Rust unit tests pass.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- [ ] Manual: launch built app, run a Claude Code session, confirm `mcp__playwright__playwright_navigate` is callable.
- [ ] Manual: `ps -ax | grep playwright-stealth | grep -v grep` shows one `node` child per running Claude session plus one for Tauri's own connection (currently only the Tauri one).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
