### PR TITLE
fix(mcp): close #1887 — wire Gemini session/new mcpServers

### DIFF
--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -8,6 +8,8 @@ import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 
+import { buildProviderMcpConfig } from "./mcp-config.mjs";
+
 // ============================================================================
 // Binary resolution
 // ============================================================================
@@ -221,7 +223,7 @@ function buildInitializeParams() {
 // Spawn / session record
 // ============================================================================
 
-function spawnGeminiProcess(cwd) {
+function spawnGeminiProcess(cwd, { extraEnv = {} } = {}) {
   const binary = resolveGeminiBinary();
   return spawn(binary, ["--acp"], {
     cwd,
@@ -229,6 +231,7 @@ function spawnGeminiProcess(cwd) {
       ...process.env,
       // Force unbuffered stdout so the parent reads ACP messages promptly.
       NODE_NO_READLINE: "1",
+      ...extraEnv,
     },
     stdio: ["pipe", "pipe", "pipe"],
     shell: process.platform === "win32",
@@ -658,6 +661,8 @@ export function createGeminiRuntime({ emit }) {
     const {
       cwd,
       localSessionId,
+      apiKey,
+      mcpServers,
       approvalPolicy,
       sandboxMode,
       networkEnabled,
@@ -666,7 +671,10 @@ export function createGeminiRuntime({ emit }) {
 
     const sessionId = localSessionId ?? randomUUID();
     const resolvedMode = geminiApprovalMode(approvalPolicy, sandboxMode);
-    const processHandle = spawnGeminiProcess(cwd);
+    const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
+    const processHandle = spawnGeminiProcess(cwd, {
+      extraEnv: mcpConfig.childEnv,
+    });
     const session = createGeminiSessionRecord({
       sessionId,
       cwd,
@@ -687,6 +695,13 @@ export function createGeminiRuntime({ emit }) {
         15_000,
       );
       session.geminiVersion = initResult?.agentInfo?.version ?? null;
+      // Per ACP, the client (us) is responsible for honoring the agent's
+      // advertised mcpCapabilities. gemini-cli v0.41.x advertises
+      // { http: true, sse: true }; we still gate here so a future build
+      // that drops one of those degrades cleanly instead of erroring on
+      // session/new. Stdio MCP is mandatory and does not need a flag.
+      const mcpCapabilities =
+        initResult?.agentCapabilities?.mcpCapabilities ?? {};
 
       // Verify the session is still tracked before proceeding to session/new.
       // A terminated process during init would otherwise hang on a dead pipe.
@@ -694,15 +709,16 @@ export function createGeminiRuntime({ emit }) {
         throw new Error("Gemini session was terminated during initialization.");
       }
 
-      // ACP step 2: create a new session in the requested cwd
+      // ACP step 2: create a new session in the requested cwd, wired up with
+      // the user's configured MCP servers (#1887). The gemini-cli child is a
+      // separate process and cannot see the Tauri-side MCP supervisor, so the
+      // wiring must be passed explicitly on every session/new.
       const sessionResult = await sendRequest(
         session,
         "session/new",
         {
           cwd,
-          // mcpServers is required by the schema; empty array is valid and
-          // means "no MCP servers" — the desktop manages MCP separately.
-          mcpServers: [],
+          mcpServers: mcpConfig.geminiMcpServers(mcpCapabilities),
         },
         20_000,
       );

--- a/bin/browser-local/mcp-config.mjs
+++ b/bin/browser-local/mcp-config.mjs
@@ -170,6 +170,54 @@ function buildCodexMcpOverride(servers) {
   return `mcp_servers=${encodeTomlValue(mcpServers)}`;
 }
 
+// serenorg/seren-desktop#1887 — Gemini consumes MCP via the ACP `session/new`
+// JSON-RPC `mcpServers` parameter, a discriminated union on `type` with
+// `headers`/`env` encoded as `[{name, value}]` arrays. Returned as a function
+// so the caller can pass the live `mcpCapabilities` block from `initialize`,
+// dropping HTTP/SSE entries if the running gemini-cli build does not
+// advertise support for them.
+function encodeGeminiPairs(record) {
+  return Object.entries(record ?? {}).map(([name, value]) => ({ name, value }));
+}
+
+function buildGeminiMcpServers(servers, { mcpCapabilities = {} } = {}) {
+  if (servers.length === 0) return [];
+  const supportsHttp = mcpCapabilities.http === true;
+  const supportsSse = mcpCapabilities.sse === true;
+
+  const out = [];
+  for (const server of servers) {
+    if (server.type === "http") {
+      if (!supportsHttp) continue;
+      out.push({
+        type: "http",
+        name: server.name,
+        url: server.url,
+        headers: encodeGeminiPairs(server.headers),
+      });
+      continue;
+    }
+    if (server.type === "sse") {
+      if (!supportsSse) continue;
+      out.push({
+        type: "sse",
+        name: server.name,
+        url: server.url,
+        headers: encodeGeminiPairs(server.headers),
+      });
+      continue;
+    }
+    out.push({
+      type: "stdio",
+      name: server.name,
+      command: resolveLocalServerCommand(server.command),
+      args: server.args ?? [],
+      env: encodeGeminiPairs(server.env),
+    });
+  }
+  return out;
+}
+
 export function buildProviderMcpConfig({ apiKey, mcpServers } = {}) {
   const normalizedServers = dedupeServers([
     createRemoteSerenServer(apiKey),
@@ -185,5 +233,7 @@ export function buildProviderMcpConfig({ apiKey, mcpServers } = {}) {
         : { [SEREN_MCP_API_KEY_ENV]: trimToNull(apiKey) },
     claudeMcpConfigJson: buildClaudeMcpConfig(normalizedServers),
     codexMcpConfigOverride: buildCodexMcpOverride(normalizedServers),
+    geminiMcpServers: (mcpCapabilities) =>
+      buildGeminiMcpServers(normalizedServers, { mcpCapabilities }),
   };
 }

--- a/tests/unit/mcp-config-gemini.test.ts
+++ b/tests/unit/mcp-config-gemini.test.ts
@@ -1,0 +1,109 @@
+// ABOUTME: Regression guard for #1887 — Gemini session/new must receive a populated mcpServers array.
+// ABOUTME: Verifies the ACP wire shape: discriminated union on type, headers/env as [{name,value}] arrays, capability gate honored.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const MODULE_PATH = "../../bin/browser-local/mcp-config.mjs";
+const PLAYWRIGHT_SCRIPT = "/Applications/SerenDesktop.app/Contents/Resources/mcp-servers/playwright-stealth/dist/index.js";
+const EMBEDDED_NODE = "/Applications/SerenDesktop.app/Contents/Resources/embedded-runtime/darwin-arm64/node/bin/node";
+
+const PLAYWRIGHT_SERVER = {
+  name: "playwright",
+  type: "local",
+  enabled: true,
+  command: "node",
+  args: [PLAYWRIGHT_SCRIPT],
+  env: { FOO: "bar" },
+};
+
+async function loadModule() {
+  vi.resetModules();
+  return await import(MODULE_PATH);
+}
+
+describe("#1887 — buildProviderMcpConfig emits Gemini-shaped mcpServers", () => {
+  const originalEmbeddedNode = process.env.SEREN_EMBEDDED_NODE_BIN;
+
+  beforeEach(() => {
+    delete process.env.SEREN_EMBEDDED_NODE_BIN;
+  });
+
+  afterEach(() => {
+    if (originalEmbeddedNode === undefined) {
+      delete process.env.SEREN_EMBEDDED_NODE_BIN;
+    } else {
+      process.env.SEREN_EMBEDDED_NODE_BIN = originalEmbeddedNode;
+    }
+  });
+
+  it("empty input → returns [] (never undefined, never null)", async () => {
+    const { buildProviderMcpConfig } = await loadModule();
+    const { geminiMcpServers } = buildProviderMcpConfig({ apiKey: null, mcpServers: [] });
+    expect(typeof geminiMcpServers).toBe("function");
+    expect(geminiMcpServers({ http: true })).toEqual([]);
+  });
+
+  it("stdio: emits ACP shape (type/name/command/args/env-as-pairs) and applies #1883 node resolution", async () => {
+    process.env.SEREN_EMBEDDED_NODE_BIN = EMBEDDED_NODE;
+    const { buildProviderMcpConfig } = await loadModule();
+
+    const { geminiMcpServers } = buildProviderMcpConfig({
+      apiKey: null,
+      mcpServers: [PLAYWRIGHT_SERVER],
+    });
+
+    const result = geminiMcpServers({ http: false });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: "stdio",
+      name: "playwright",
+      command: EMBEDDED_NODE,
+      args: [PLAYWRIGHT_SCRIPT],
+      env: [{ name: "FOO", value: "bar" }],
+    });
+  });
+
+  it("http: emits seren-mcp entry with headers-as-pairs when mcpCapabilities.http=true", async () => {
+    const { buildProviderMcpConfig } = await loadModule();
+
+    const { geminiMcpServers } = buildProviderMcpConfig({
+      apiKey: "test-key",
+      mcpServers: [],
+    });
+
+    const result = geminiMcpServers({ http: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("http");
+    expect(result[0].name).toBe("seren-mcp");
+    expect(result[0].url).toMatch(/^https?:\/\//);
+    expect(result[0].headers).toEqual([
+      { name: "Authorization", value: "Bearer ${SEREN_API_KEY}" },
+    ]);
+  });
+
+  it("http: drops seren-mcp when mcpCapabilities.http is false (capability gate)", async () => {
+    const { buildProviderMcpConfig } = await loadModule();
+
+    const { geminiMcpServers } = buildProviderMcpConfig({
+      apiKey: "test-key",
+      mcpServers: [PLAYWRIGHT_SERVER],
+    });
+
+    const result = geminiMcpServers({ http: false });
+    // Only the stdio entry should remain; the HTTP seren-mcp is dropped.
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("stdio");
+    expect(result[0].name).toBe("playwright");
+  });
+
+  it("childEnv carries SEREN_API_KEY so the gemini-cli child can resolve the Authorization header", async () => {
+    const { buildProviderMcpConfig } = await loadModule();
+
+    const { childEnv } = buildProviderMcpConfig({
+      apiKey: "test-key",
+      mcpServers: [],
+    });
+
+    expect(childEnv.SEREN_API_KEY).toBe("test-key");
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #1887. Gemini sessions spawned by Seren Desktop were registering zero MCP servers because `gemini-runtime.mjs:705` hard-coded `mcpServers: []` in the `session/new` payload — no `seren-mcp` gateway, no local stdio MCP servers, no `mcp__*__*` tools available to skills.
- Adds `buildGeminiMcpServers` alongside the existing Claude/Codex encoders in `mcp-config.mjs`. Emits the discriminated-union shape gemini-cli v0.41.x expects (`{type, name, ...}` with `headers`/`env` as `[{name, value}]` arrays) and reuses `resolveLocalServerCommand` so the #1883 bare-`node` fix also covers Gemini stdio servers.
- Capability-gates HTTP/SSE on the `mcpCapabilities` block returned by `initialize`, so a future gemini-cli that drops one of those degrades cleanly instead of erroring on `session/new`.
- Threads `childEnv` (carrying `SEREN_API_KEY`) into the gemini-cli spawn env so the HTTP MCP `Authorization: Bearer ${SEREN_API_KEY}` header resolves.

## Test plan

- [x] New regression test `tests/unit/mcp-config-gemini.test.ts` covers the five critical cases: empty input, stdio with `SEREN_EMBEDDED_NODE_BIN` resolution, HTTP entry shape, capability gate dropping HTTP when `mcpCapabilities.http=false`, and `childEnv` carrying `SEREN_API_KEY`.
- [x] `pnpm vitest run` — 1006/1006 tests pass.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- [x] Manual smoke: open a Gemini session in `pnpm tauri dev` with a local stdio MCP enabled in Settings → Publisher MCPs; confirm the agent lists `mcp__*__*` tools.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
