### PR TITLE
fix(claude-runtime): close #1889 — defer history replay off spawn await path

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1707,8 +1707,14 @@ export function createClaudeRuntime({ emit }) {
     // browser-local diagnostics; mcpConfigJson is intentionally omitted to
     // avoid surfacing publisher credentials embedded in the inline config.
     // See #1854.
+    // Print BOTH ids: `sessionId` is the Seren-side handle every frontend
+    // event is tagged with, while `agentSessionId` is the Claude CLI's
+    // internal session id (used in --resume and JSONL paths). Logging
+    // only the latter made the [browser-local][claude] spawn line
+    // useless when correlating with [AgentRuntime] Event received logs
+    // in the renderer console. #1889
     console.error(
-      `[browser-local][claude] spawn sessionId=${remoteSessionId} preferredModel="${preferredModel}"`,
+      `[browser-local][claude] spawn sessionId=${sessionId} agentSessionId=${remoteSessionId} preferredModel="${preferredModel}"`,
     );
     const processHandle = spawn(
       claudeBin,
@@ -1829,18 +1835,40 @@ export function createClaudeRuntime({ emit }) {
       );
       session.currentModeId = resolvedMode;
 
-      if (resumeAgentSessionId) {
-        await replayClaudeHistoryBestEffort(
-          emit,
-          session,
-          cwd,
-          resumeAgentSessionId,
-        );
-      }
+      // Replay runs off the spawn await path. Awaiting it here blocks the
+      // JSON-RPC return until the entire transcript has streamed as live
+      // events, so the frontend's spawn ack arrives AFTER every replay
+      // event — events get parked in pendingSessionEvents (no session
+      // record yet), and the "Evaluating…" spinner sticks because turn
+      // bookkeeping rides the same drain. Kick replay off in the
+      // background and defer the "ready" emit until it drains so the
+      // frontend's readyPromise still gates sendPrompt. #1889
+      const replayPromise = resumeAgentSessionId
+        ? replayClaudeHistoryBestEffort(
+            emit,
+            session,
+            cwd,
+            resumeAgentSessionId,
+          ).catch((err) => {
+            console.warn(
+              "[browser-local][claude] history replay failed:",
+              err?.message ?? err,
+            );
+          })
+        : Promise.resolve();
 
-      session.status = "ready";
-
-      emit("provider://session-status", buildSessionStatus(session, "ready"));
+      replayPromise.then(() => {
+        // The session may have been terminated mid-replay (user closed
+        // the thread). Only flip status + emit if our record is still
+        // the active one for this sessionId.
+        if (sessions.get(sessionId) === session) {
+          session.status = "ready";
+          emit(
+            "provider://session-status",
+            buildSessionStatus(session, "ready"),
+          );
+        }
+      });
 
       return {
         id: session.id,

--- a/tests/unit/claude-spawn-replay-deferred.test.ts
+++ b/tests/unit/claude-spawn-replay-deferred.test.ts
@@ -1,0 +1,111 @@
+// ABOUTME: Regression test for #1889 — Claude spawnSession must NOT await
+// ABOUTME: replayClaudeHistoryBestEffort; replay runs in background, "ready" emit defers.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const runtimeSource = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+
+/**
+ * Slice the body of the inner `async function spawnSession(params)` defined
+ * inside `createClaudeRuntime` so assertions don't match unrelated references
+ * elsewhere in the (2000+ line) module. End-of-function is the next
+ * `\n  async function ` declaration (sibling closure methods share indent-2).
+ */
+function extractSpawnSessionBody(): string {
+  const start = runtimeSource.indexOf("async function spawnSession(params)");
+  if (start < 0) return "";
+  const after = runtimeSource.indexOf("\n  async function ", start + 1);
+  return after < 0
+    ? runtimeSource.slice(start)
+    : runtimeSource.slice(start, after);
+}
+
+describe("#1889 — Claude spawnSession defers history replay off the await path", () => {
+  const body = extractSpawnSessionBody();
+
+  it("function body extraction succeeds (guard against refactor breakage)", () => {
+    expect(body, "spawnSession body must be non-empty").not.toBe("");
+    expect(body).toContain("sendControlRequest");
+  });
+
+  it("does NOT await replayClaudeHistoryBestEffort", () => {
+    // The bug: `await replayClaudeHistoryBestEffort(...)` inside spawnSession
+    // blocks the JSON-RPC return until the entire transcript has streamed as
+    // live events. Frontend's spawn-ack arrives after the events, inverting
+    // event ordering and sticking the "Evaluating…" spinner.
+    const awaitedReplay = /await\s+replayClaudeHistoryBestEffort\s*\(/.test(
+      body,
+    );
+    expect(
+      awaitedReplay,
+      "spawnSession must NOT await replayClaudeHistoryBestEffort — replay must run in the background so the spawn IPC returns before replay events fire.",
+    ).toBe(false);
+  });
+
+  it("kicks off replay as a background promise with .catch error handling", () => {
+    // Background replay must still surface failures via console.warn so a
+    // corrupt transcript doesn't fail silently.
+    expect(
+      body,
+      "spawnSession must call replayClaudeHistoryBestEffort with a chained .catch so failures are logged.",
+    ).toMatch(/replayClaudeHistoryBestEffort\([\s\S]*?\)\s*\.catch\s*\(/);
+  });
+
+  it("defers the 'ready' status emit until replay drains", () => {
+    // The frontend's readyPromise resolves on a real-time sessionStatus
+    // event with status="ready". Emitting "ready" before replay completes
+    // would unblock sendPrompt while history was still streaming, racing
+    // user prompts against replay tool events.
+    expect(
+      body,
+      "spawnSession must emit 'ready' inside a `.then(...)` on the replay promise, not synchronously after spawn setup.",
+    ).toMatch(
+      /\.then\s*\(\s*\(\s*\)\s*=>\s*\{[\s\S]*?provider:\/\/session-status[\s\S]*?\}\s*\)/,
+    );
+  });
+
+  it("guards the deferred 'ready' emit against terminated sessions", () => {
+    // If the user closes the thread mid-replay, the session record is
+    // deleted from the `sessions` Map. The deferred emit must check the
+    // session is still tracked before mutating its status and emitting,
+    // otherwise we resurrect a torn-down session in the frontend.
+    expect(
+      body,
+      "deferred 'ready' emit must guard against the session being terminated during replay.",
+    ).toMatch(/sessions\.get\(sessionId\)\s*===\s*session/);
+  });
+
+  it("spawn return reports the pre-replay status (still 'initializing')", () => {
+    // After the fix, spawnSession returns BEFORE replay finishes. At return
+    // time the session is still in 'initializing' state — the deferred
+    // emit flips it to 'ready' later. The literal status value isn't what
+    // matters; what matters is that `session.status = "ready"` happens
+    // INSIDE the deferred .then, not before the return.
+    const readyAssignmentInThen =
+      /\.then\s*\(\s*\(\s*\)\s*=>\s*\{[\s\S]*?session\.status\s*=\s*"ready"[\s\S]*?\}\s*\)/.test(
+        body,
+      );
+    expect(
+      readyAssignmentInThen,
+      "session.status = 'ready' must happen inside the deferred .then(...), not synchronously before the spawn return.",
+    ).toBe(true);
+  });
+});
+
+describe("#1889 — spawn stderr log surfaces both Seren and Claude session ids", () => {
+  it("logs Seren-side sessionId AND agentSessionId for cross-referencing", () => {
+    // Frontend events are tagged with the Seren-side `sessionId` (the value
+    // of `session.id`). The stderr log previously only printed the Claude
+    // CLI's `remoteSessionId`/`agentSessionId`, making the
+    // [browser-local][claude] spawn line useless when correlating with
+    // [AgentRuntime] Event received logs in the renderer console.
+    expect(runtimeSource).toMatch(
+      /\[browser-local\]\[claude\] spawn sessionId=\$\{(session\.id|sessionId)\}[\s\S]*?agentSessionId=\$\{remoteSessionId\}/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Defers `replayClaudeHistoryBestEffort` off the `spawnSession` await path so the JSON-RPC spawn ack returns immediately after init + permission_mode, before any replay events fire.
- The `provider://session-status` "ready" emit now runs inside `replayPromise.then(...)`, guarded against the session being terminated mid-replay. Frontend `readyPromise` still gates `sendPrompt` correctly.
- Spawn stderr line now logs both `sessionId` (Seren-side) and `agentSessionId` (Claude CLI side) for renderer-log cross-referencing.

Closes #1889.

## Why

`spawnSession` in `bin/browser-local/claude-runtime.mjs` was awaiting the full history replay before returning. Replay streams every JSONL entry as live `user-message` / `message-chunk` / `tool-call` / `tool-result` events, then a terminal `prompt-complete` with `historyReplay: true`. Because the IPC return was on that await path, the frontend received every replay event before `await providerService.spawnAgent` resolved. The session wasn't yet registered in `state.sessions`, so events parked in `pendingSessionEvents` and only drained after the spawn ack — inverting the spawn-vs-events ordering and sticking the "Evaluating…" spinner.

Gemini (`gemini-runtime.mjs:660-739`) and Codex (`providers.mjs:969-1010`) don't have a replay step, so this is Claude-specific.

## Test plan

- [x] `pnpm vitest run tests/unit/claude-spawn-replay-deferred.test.ts` — 7/7 green (red before the fix, all 6 invariant tests fail).
- [x] Full unit suite: `pnpm vitest run` — 1013/1013 green, no regressions.
- [x] Source audit: only one call site of `replayClaudeHistoryBestEffort`, inside the deferred promise (not awaited). `session.status = "ready"` only set at end-of-turn handler, the deferred replay emit, and cancel handler — never synchronously inside `spawnSession`.
- [ ] Manual smoke (post-merge): resume a Claude chat with non-trivial history in `pnpm browser:local`; verify renderer logs show `Spawn result` → `setActiveSession` BEFORE the replay event burst, and `Evaluating…` clears on the first promptComplete.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
