### PR TITLE
fix(skills): close #1891 — silent refresh from upstream

### DIFF
--- a/src/components/sidebar/SkillsExplorer.tsx
+++ b/src/components/sidebar/SkillsExplorer.tsx
@@ -41,7 +41,6 @@ import {
   skills as skillsService,
 } from "@/services/skills";
 import { skillsCatalogOptions } from "@/services/skills-query";
-import { agentStore } from "@/stores/agent.store";
 import { authStore } from "@/stores/auth.store";
 import { fileTreeState } from "@/stores/fileTree";
 import { skillPublishStore } from "@/stores/skill-publish.store";
@@ -348,32 +347,6 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
     skillsStore.installed.filter(
       (skill) => syncStatusFor(skill)?.hasLocalChanges,
     ).length;
-
-  const getAffectedLiveThreadIds = (skill: InstalledSkill) => {
-    return threadStore.threads.flatMap((thread) => {
-      if (thread.kind !== "agent" || !thread.isLive) return [];
-      const effectiveSkills = skillsStore.getThreadSkills(
-        thread.projectRoot,
-        thread.id,
-      );
-      return effectiveSkills.some(
-        (activeSkill) => activeSkill.path === skill.path,
-      )
-        ? [thread.id]
-        : [];
-    });
-  };
-
-  const restartAffectedLiveThreads = async (threadIds: string[]) => {
-    for (const threadId of threadIds) {
-      const thread = threadStore.threads.find((entry) => entry.id === threadId);
-      if (!thread || thread.kind !== "agent") continue;
-      await agentStore.resumeAgentConversation(
-        thread.id,
-        thread.projectRoot ?? undefined,
-      );
-    }
-  };
 
   const syncStatusLabel = (status: SkillSyncStatus | null | undefined) => {
     if (!status) return null;
@@ -810,49 +783,15 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
       if (!confirmOverwrite) return;
     }
 
-    const affectedThreadIds = getAffectedLiveThreadIds(skill);
-    if (affectedThreadIds.length > 0) {
-      const confirmRestart = await confirm(
-        `${skill.name} is active in ${affectedThreadIds.length} live agent thread${affectedThreadIds.length === 1 ? "" : "s"}.\n\nSeren can stop those sessions, refresh the skill, and resume them so the next prompt runs against the updated files.\n\nContinue?`,
-        {
-          title: "Restart live agent sessions?",
-          kind: "warning",
-        },
-      );
-      if (!confirmRestart) return;
-    }
-
     setActionInProgress(skill.id);
-    let stoppedLiveThreads = false;
-    const terminatedThreadIds: string[] = [];
     try {
-      if (affectedThreadIds.length > 0) {
-        for (const threadId of affectedThreadIds) {
-          const liveSession = Object.values(agentStore.sessions).find(
-            (session) => session.conversationId === threadId,
-          );
-          if (!liveSession) continue;
-          await agentStore.terminateSession(liveSession.info.id);
-          terminatedThreadIds.push(threadId);
-        }
-        stoppedLiveThreads = terminatedThreadIds.length > 0;
-      }
-
       const refreshed = await skillsService.refreshInstalledSkill(skill, {
         expectedLocalManagedState: existingStatus.localManagedState,
       });
       skillsStore.replaceInstalled(refreshed.installed);
       setSyncStatusFor(refreshed.installed.path, refreshed.syncStatus);
-
-      if (terminatedThreadIds.length > 0) {
-        await restartAffectedLiveThreads(terminatedThreadIds);
-        stoppedLiveThreads = false;
-      }
     } catch (err) {
       console.error("[SkillsExplorer] Failed to refresh installed skill:", err);
-      if (stoppedLiveThreads) {
-        await restartAffectedLiveThreads(terminatedThreadIds);
-      }
       await loadSyncStatus(skill);
     } finally {
       setActionInProgress(null);
@@ -1598,18 +1537,6 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                                     {(file) => <li>{file}</li>}
                                   </For>
                                 </ul>
-                              </div>
-                            </Show>
-                            <Show
-                              when={getAffectedLiveThreadIds(skill).length > 0}
-                            >
-                              <div class="mt-2 text-warning">
-                                {getAffectedLiveThreadIds(skill).length} live
-                                agent thread
-                                {getAffectedLiveThreadIds(skill).length === 1
-                                  ? ""
-                                  : "s"}{" "}
-                                currently reference this skill.
                               </div>
                             </Show>
                             <Show when={syncStatusFor(skill)?.error}>

--- a/tests/unit/skills-auto-sync.test.ts
+++ b/tests/unit/skills-auto-sync.test.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Test that refresh() auto-refreshes stale upstream-managed skills.
-// ABOUTME: Verifies concurrency guard (#1289), summary tracking, #1155, and #1558.
+// ABOUTME: Verifies concurrency guard (#1289), summary tracking, #1155, #1558, and silent-refresh contract (#1891).
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSkillsService = vi.hoisted(() => ({
@@ -480,5 +482,27 @@ describe("backfill triggers for slug/dirName mismatch (#1558)", () => {
     await skillsStore.refresh();
 
     expect(mockSkillsService.backfillSyncState).toHaveBeenCalled();
+  });
+});
+
+describe("silent skill refresh contract (#1891)", () => {
+  // Source-level contract for the manual-refresh path in SkillsExplorer.
+  // The component must not kill live agent sessions on "Refresh from upstream",
+  // and must not surface a modal/confirm asking to restart them. Refresh is a
+  // pure disk write; new files take effect on the next session spawn.
+  const explorerSource = readFileSync(
+    resolve(__dirname, "../../src/components/sidebar/SkillsExplorer.tsx"),
+    "utf-8",
+  );
+
+  it("does not terminate live agent sessions from the refresh handler", () => {
+    expect(explorerSource).not.toContain("terminateSession");
+    expect(explorerSource).not.toContain("resumeAgentConversation");
+  });
+
+  it("does not prompt to restart live agent sessions on refresh", () => {
+    expect(explorerSource).not.toContain("Restart live agent sessions");
+    expect(explorerSource).not.toContain("getAffectedLiveThreadIds");
+    expect(explorerSource).not.toContain("restartAffectedLiveThreads");
   });
 });


### PR DESCRIPTION
## Summary
- Refresh-from-upstream now writes the bundle silently — no modal, no live-session termination, no respawn-from-history.
- Removes the misleading "X live threads reference this skill" banner in the detail view.
- Overwrite-local-changes confirm is preserved (different prompt, legitimate destructive-action gate).

## Why
Clicking "Refresh from upstream" on a skill active in the current chat was killing the live agent session mid-stream and respawning it from SQLite — the user's mental model was "I broke my chat." New skill files only take effect at session-spawn anyway, so the terminate/respawn dance bought nothing and cost the user any in-flight tool call.

## Code paths removed
- `handleRefreshInstalledSkill`: confirm modal, `terminateSession` loop, success-path `restartAffectedLiveThreads`, error-path `restartAffectedLiveThreads`.
- `getAffectedLiveThreadIds` helper (no longer needed).
- `restartAffectedLiveThreads` helper (no longer needed).
- Live-thread reference banner in the skill detail view (misleading once refresh is silent).
- `agentStore` import (no longer used in this file).

## Test plan
- [x] Failing source-contract test added to `tests/unit/skills-auto-sync.test.ts` covering manual-path silent refresh (no `terminateSession`, no `resumeAgentConversation`, no "Restart live agent sessions" prompt).
- [x] `pnpm vitest run tests/unit/skills-auto-sync.test.ts` — 16/16 pass after fix.
- [x] `pnpm vitest run` (full suite) — 131 files / 1015 tests pass.
- [x] `pnpm tsc --noEmit` clean.
- [x] `biome check` clean on changed files.

Closes #1891

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
