### PR TITLE
fix(orchestrator): close #1895 — pin playwright, fix recency

### DIFF
--- a/src-tauri/src/orchestrator/tool_relevance.rs
+++ b/src-tauri/src/orchestrator/tool_relevance.rs
@@ -54,6 +54,26 @@ const PINNED_TOOL_NAMES: &[&str] = &[
     "seren__create_project",
     "seren__list_databases",
     "seren__create_database",
+    // Browser automation — fundamental capability with no shell substitute.
+    // Skills like prophet-bounty-runner require these to drive the Privy OTP
+    // flow; without them the agent has no way to log in to web services that
+    // lack a dedicated publisher. BM25 evicts them mid-thread whenever the
+    // next user prompt does not share keywords with browser tool docs (#1895).
+    "mcp__playwright__playwright_navigate",
+    "mcp__playwright__playwright_navigate_back",
+    "mcp__playwright__playwright_navigate_forward",
+    "mcp__playwright__playwright_click",
+    "mcp__playwright__playwright_hover",
+    "mcp__playwright__playwright_press",
+    "mcp__playwright__playwright_fill",
+    "mcp__playwright__playwright_select",
+    "mcp__playwright__playwright_evaluate",
+    "mcp__playwright__playwright_extract_content",
+    "mcp__playwright__playwright_screenshot",
+    "mcp__playwright__playwright_list_browsers",
+    "mcp__playwright__playwright_set_browser",
+    "mcp__playwright__playwright_reset",
+    "mcp__playwright__playwright_close",
 ];
 
 /// Model-aware tool cap: returns (max_tools, token_budget) for the given model.
@@ -789,6 +809,23 @@ mod tests {
         tools.push(make_tool("seren__list_databases", "List Seren databases"));
         tools.push(make_tool("seren__create_database", "Create a Seren database"));
 
+        // Browser automation (mcp__playwright__*) — same first-class status.
+        tools.push(make_tool("mcp__playwright__playwright_navigate", "Navigate browser"));
+        tools.push(make_tool("mcp__playwright__playwright_navigate_back", "Go back"));
+        tools.push(make_tool("mcp__playwright__playwright_navigate_forward", "Go forward"));
+        tools.push(make_tool("mcp__playwright__playwright_click", "Click element"));
+        tools.push(make_tool("mcp__playwright__playwright_hover", "Hover element"));
+        tools.push(make_tool("mcp__playwright__playwright_press", "Press key"));
+        tools.push(make_tool("mcp__playwright__playwright_fill", "Fill input"));
+        tools.push(make_tool("mcp__playwright__playwright_select", "Select dropdown"));
+        tools.push(make_tool("mcp__playwright__playwright_evaluate", "Evaluate JS"));
+        tools.push(make_tool("mcp__playwright__playwright_extract_content", "Extract page text"));
+        tools.push(make_tool("mcp__playwright__playwright_screenshot", "Capture screenshot"));
+        tools.push(make_tool("mcp__playwright__playwright_list_browsers", "List browsers"));
+        tools.push(make_tool("mcp__playwright__playwright_set_browser", "Choose browser"));
+        tools.push(make_tool("mcp__playwright__playwright_reset", "Reset browser"));
+        tools.push(make_tool("mcp__playwright__playwright_close", "Close browser"));
+
         // Fill with gateway tools so total exceeds budget
         for i in 0..62 {
             tools.push(make_tool(
@@ -820,6 +857,76 @@ mod tests {
                 found,
                 "pinned tool '{}' must always be included, but was dropped",
                 pinned_name
+            );
+        }
+    }
+
+    #[test]
+    fn playwright_mcp_tools_survive_non_playwright_query() {
+        // #1895: GLM 5.1 lost mcp__playwright__* tools mid-thread because the
+        // next user prompt ("taariq@serendb.com, gmail") shared no tokens with
+        // playwright tool docs. Browser automation is a fundamental capability
+        // with no shell substitute — the prophet-bounty-runner skill literally
+        // cannot drive the Privy OTP login without playwright_navigate. Pin all
+        // 15 playwright tools the same way file/exec/seren__ tools are pinned.
+        //
+        // Faithful reproduction: load gmail and seren__ tools whose docs DO
+        // match the query so they win BM25, plus enough noise to push the
+        // playwright tools below the 120-tool default cap by position. Without
+        // pinning, the playwright tools get evicted.
+        let mut tools: Vec<serde_json::Value> = Vec::new();
+
+        let playwright_names = [
+            "mcp__playwright__playwright_navigate",
+            "mcp__playwright__playwright_navigate_back",
+            "mcp__playwright__playwright_navigate_forward",
+            "mcp__playwright__playwright_click",
+            "mcp__playwright__playwright_hover",
+            "mcp__playwright__playwright_press",
+            "mcp__playwright__playwright_fill",
+            "mcp__playwright__playwright_select",
+            "mcp__playwright__playwright_evaluate",
+            "mcp__playwright__playwright_extract_content",
+            "mcp__playwright__playwright_screenshot",
+            "mcp__playwright__playwright_list_browsers",
+            "mcp__playwright__playwright_set_browser",
+            "mcp__playwright__playwright_reset",
+            "mcp__playwright__playwright_close",
+        ];
+
+        // Build a tool pool that genuinely exhausts the 120-tool budget with
+        // scored matches. Eight publishers × 20 tools whose docs include
+        // "gmail" so they all score > 0; per-publisher cap is 25 so 6+
+        // publishers can fully participate before the budget fills.
+        for pub_idx in 0..8 {
+            for tool_idx in 0..20 {
+                tools.push(make_tool(
+                    &format!("gateway__svc_{pub_idx}__action_{tool_idx}"),
+                    "Gmail-style inbox messaging operation for mail handling",
+                ));
+            }
+        }
+        // Playwright tools at the end — score 0 against the query, no shared
+        // publisher with the matchers above, so without pinning they fall
+        // outside the selection window.
+        for name in playwright_names {
+            tools.push(make_tool(name, "Browser automation primitive"));
+        }
+        assert!(tools.len() > 120);
+
+        // The actual prompt from the GLM bug report turn 4. Tokens are
+        // ["taariq", "serendb", "com", "gmail"] — gmail matches gmail tools
+        // strongly; playwright tool docs have zero overlap.
+        let result = select("taariq@serendb.com, gmail", &tools);
+
+        for name in playwright_names {
+            let found = result
+                .iter()
+                .any(|t| t.pointer("/function/name").and_then(|v| v.as_str()) == Some(name));
+            assert!(
+                found,
+                "pinned playwright tool '{}' must survive a non-playwright query",
+                name
             );
         }
     }

--- a/src/services/orchestrator-history.ts
+++ b/src/services/orchestrator-history.ts
@@ -1,0 +1,143 @@
+// ABOUTME: Serializes conversation messages for the Rust orchestrator.
+// ABOUTME: Preserves assistant tool_calls[] + tool replies so the recency boost fires (#1895).
+
+import type { UnifiedMessage } from "@/types/conversation";
+
+/**
+ * OpenAI-format tool_call object emitted on assistant messages. Matches what
+ * the Rust `extract_recent_publishers` (src-tauri/src/orchestrator/chat_model_worker.rs)
+ * reads at `tool_calls[].function.name`.
+ */
+interface SerializedToolCall {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+/** Shape of one serialized history row sent to the Rust orchestrator. */
+export interface SerializedMessage extends Record<string, unknown> {
+  role: "user" | "assistant" | "system" | "tool";
+  content: string;
+  tool_calls?: SerializedToolCall[];
+  tool_call_id?: string;
+}
+
+/**
+ * Serialize conversation messages into the format expected by the Rust backend.
+ *
+ * The Rust `tool_relevance::extract_recent_publishers` walks this output
+ * looking for `tool_calls[]` on assistant rows to compute the recency boost
+ * added in #1283. The orchestrator chat path also forwards the history into
+ * the gateway's OpenAI-compatible chat-completions endpoint, which requires
+ * every entry in `tool_calls[]` to be followed by a matching
+ * `role: "tool", tool_call_id` reply. Both invariants must hold:
+ *
+ * 1. Assistant rows carry `tool_calls[]` so the Rust recency boost can fire.
+ * 2. Each tool_call is paired with the recorded tool result so the gateway
+ *    accepts the conversation as well-formed across turn boundaries.
+ *
+ * Without (1), publishers like playwright, gmail, kraken age out of BM25 the
+ * moment the next user prompt doesn't share keywords with the tool docs (#1895).
+ * Without (2), the gateway 400s with "messages must include a tool message
+ * after assistant tool_calls".
+ */
+export function serializeHistory(
+  messages: UnifiedMessage[],
+): SerializedMessage[] {
+  const out: SerializedMessage[] = [];
+  let pendingAssistantIdx: number | null = null;
+
+  const flushPendingAssistant = () => {
+    pendingAssistantIdx = null;
+  };
+
+  for (const m of messages) {
+    if (m.status !== "complete") continue;
+
+    if (m.type === "tool_call" && m.toolCall) {
+      // Attach this tool call to the most recent assistant row. If there is
+      // no preceding assistant row, drop the call — orphan tool calls would
+      // violate the OpenAI contract regardless.
+      if (pendingAssistantIdx === null) continue;
+      const assistant = out[pendingAssistantIdx];
+      const name = m.toolCall.name ?? m.toolCall.kind ?? m.toolCall.title;
+      if (!name) continue;
+      const calls = (assistant.tool_calls ??= []);
+      calls.push({
+        id: m.toolCall.toolCallId,
+        type: "function",
+        function: {
+          name,
+          arguments: m.toolCall.arguments ?? "",
+        },
+      });
+      continue;
+    }
+
+    if (m.type === "tool_result" && m.toolCallId) {
+      // Emit the matching tool reply so the OpenAI contract is satisfied for
+      // the historical turn. The Rust worker loop rebuilds the live turn's
+      // tool messages independently — this branch only restores the bridge
+      // for tool calls that already completed in earlier turns.
+      out.push({
+        role: "tool",
+        tool_call_id: m.toolCallId,
+        content: m.content,
+      });
+      // A tool result terminates a tool-call sequence; the next tool_call row
+      // must belong to a new assistant turn, not this one.
+      flushPendingAssistant();
+      continue;
+    }
+
+    // Local UI affordances do not belong in gateway history.
+    if (
+      m.type === "transition" ||
+      m.type === "reroute" ||
+      m.type === "diff" ||
+      m.type === "thought" ||
+      m.type === "error"
+    ) {
+      continue;
+    }
+
+    if (m.role !== "user" && m.role !== "assistant") continue;
+
+    const serialized: SerializedMessage = {
+      role: m.role,
+      content: m.content,
+    };
+    out.push(serialized);
+    pendingAssistantIdx = m.role === "assistant" ? out.length - 1 : null;
+  }
+
+  return dropOrphanToolCalls(out);
+}
+
+/**
+ * Belt-and-braces: if an assistant row ended up with tool_calls but the
+ * stream was cut before the corresponding tool_result rows were persisted,
+ * strip the orphaned ids so the gateway doesn't reject the payload. Mutates
+ * each affected assistant in place rather than copying the full array.
+ */
+function dropOrphanToolCalls(out: SerializedMessage[]): SerializedMessage[] {
+  const seenToolReplyIds = new Set<string>();
+  for (const msg of out) {
+    if (msg.role === "tool" && typeof msg.tool_call_id === "string") {
+      seenToolReplyIds.add(msg.tool_call_id);
+    }
+  }
+  for (const msg of out) {
+    if (msg.role !== "assistant" || !msg.tool_calls) continue;
+    const kept = msg.tool_calls.filter((tc) => seenToolReplyIds.has(tc.id));
+    if (kept.length === 0) {
+      delete msg.tool_calls;
+    } else {
+      msg.tool_calls = kept;
+    }
+  }
+  return out;
+}

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -14,6 +14,7 @@ import {
   type ToolResultEvent,
 } from "@/services/employees-runtime";
 import { storeAssistantResponse } from "@/services/memory";
+import { serializeHistory } from "@/services/orchestrator-history";
 import {
   allowsClaudeAgent,
   allowsCodexAgent,
@@ -1005,30 +1006,6 @@ function flushStreamingToMessage(conversationId: string): void {
       startTime: Date.now(),
     });
   }
-}
-
-/**
- * Serialize conversation messages into the format expected by the Rust backend.
- * Only includes user and assistant messages (not system, tool, transition, etc.)
- */
-function serializeHistory(
-  messages: UnifiedMessage[],
-): Record<string, unknown>[] {
-  return messages
-    .filter(
-      (m) =>
-        (m.role === "user" || m.role === "assistant") &&
-        m.type !== "transition" &&
-        m.type !== "reroute" &&
-        m.type !== "tool_call" &&
-        m.type !== "tool_result" &&
-        m.type !== "diff" &&
-        m.status === "complete",
-    )
-    .map((m) => ({
-      role: m.role,
-      content: m.content,
-    }));
 }
 
 /**

--- a/tests/unit/orchestrator-serialize-history.test.ts
+++ b/tests/unit/orchestrator-serialize-history.test.ts
@@ -1,0 +1,133 @@
+// ABOUTME: Pins the serializeHistory contract that the Rust recency boost depends on.
+// ABOUTME: Without tool_calls[] on assistant rows, extract_recent_publishers returns [] (#1895).
+
+import { describe, expect, it } from "vitest";
+import { serializeHistory } from "@/services/orchestrator-history";
+import type { ToolCallData, UnifiedMessage } from "@/types/conversation";
+
+function makeMessage(overrides: Partial<UnifiedMessage>): UnifiedMessage {
+  return {
+    id: overrides.id ?? `msg-${Math.random()}`,
+    type: "assistant",
+    role: "assistant",
+    content: "",
+    timestamp: Date.now(),
+    status: "complete",
+    ...overrides,
+  };
+}
+
+function makeToolCallRow(name: string, idSuffix: string): UnifiedMessage {
+  const toolCall: ToolCallData = {
+    toolCallId: `tc-${idSuffix}`,
+    title: name,
+    kind: name,
+    status: "complete",
+    name,
+    arguments: "{}",
+  };
+  return makeMessage({
+    id: `tool-${idSuffix}`,
+    type: "tool_call",
+    role: "assistant",
+    toolCall,
+  });
+}
+
+function makeToolResultRow(idSuffix: string, content: string): UnifiedMessage {
+  return makeMessage({
+    id: `result-${idSuffix}`,
+    type: "tool_result",
+    role: "assistant",
+    content,
+    toolCallId: `tc-${idSuffix}`,
+  });
+}
+
+describe("serializeHistory (#1895)", () => {
+  it("attaches tool_calls[] to the assistant turn so Rust can read publisher recency", () => {
+    // Reproduces the GLM #1895 thread shape: user prompt → assistant prose +
+    // playwright tool call → tool result → next user prompt. The Rust
+    // extract_recent_publishers (tool_relevance.rs) scans assistant rows for
+    // a tool_calls[] array; without it the 2x recency boost from #1283 never
+    // fires and any MCP publisher (playwright, gmail, kraken, …) silently
+    // ages out of the next turn's BM25 budget.
+    const history: UnifiedMessage[] = [
+      makeMessage({
+        id: "u1",
+        type: "user",
+        role: "user",
+        content: "/prophet-bounty-runner",
+      }),
+      makeMessage({
+        id: "a1",
+        type: "assistant",
+        role: "assistant",
+        content: "Starting the Prophet Bounty Runner.",
+      }),
+      makeToolCallRow("mcp__playwright__playwright_list_browsers", "1"),
+      makeMessage({
+        id: "tr1",
+        type: "tool_result",
+        role: "assistant",
+        content: '[{"name":"chrome"}]',
+        toolCallId: "tc-1",
+      }),
+    ];
+
+    const serialized = serializeHistory(history);
+
+    const assistant = serialized.find((m) => m.role === "assistant");
+    expect(assistant, "assistant message must be retained").toBeDefined();
+    const toolCalls = assistant?.tool_calls;
+    expect(
+      Array.isArray(toolCalls),
+      "assistant.tool_calls[] must be present so extract_recent_publishers sees the publisher",
+    ).toBe(true);
+    expect(toolCalls).toHaveLength(1);
+    expect((toolCalls as Array<Record<string, unknown>>)[0]).toMatchObject({
+      type: "function",
+      function: { name: "mcp__playwright__playwright_list_browsers" },
+    });
+  });
+
+  it("drops orphan tool_calls so the gateway never sees an assistant without its tool reply", () => {
+    // OpenAI-compatible gateways reject any assistant row whose `tool_calls[]`
+    // lacks a matching `role: "tool"` follow-up. The conversation store can
+    // hold a half-streamed turn (tool_call persisted, tool_result still
+    // pending) — those orphans must be stripped before history reaches the
+    // gateway, otherwise the entire next chat turn would 400 (#1895).
+    const history: UnifiedMessage[] = [
+      makeMessage({
+        id: "u1",
+        type: "user",
+        role: "user",
+        content: "/prophet-bounty-runner",
+      }),
+      makeMessage({
+        id: "a1",
+        type: "assistant",
+        role: "assistant",
+        content: "Step 1.",
+      }),
+      makeToolCallRow("mcp__playwright__playwright_navigate", "complete"),
+      makeToolResultRow("complete", "ok"),
+      makeToolCallRow("mcp__playwright__playwright_click", "orphan"),
+    ];
+
+    const serialized = serializeHistory(history);
+    const assistant = serialized.find((m) => m.role === "assistant");
+    const toolCalls = assistant?.tool_calls as
+      | Array<{ id: string }>
+      | undefined;
+
+    expect(toolCalls, "tool_calls must exist for the matched pair").toBeDefined();
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls?.[0].id).toBe("tc-complete");
+
+    // The tool reply for the matched call must still ride along so the
+    // gateway accepts the conversation as well-formed.
+    const toolReply = serialized.find((m) => m.role === "tool");
+    expect(toolReply?.tool_call_id).toBe("tc-complete");
+  });
+});


### PR DESCRIPTION
## Summary

- Pin all 15 `mcp__playwright__*` tools in `PINNED_TOOL_NAMES` so BM25 cannot evict them mid-thread. Browser automation is a fundamental capability with no shell substitute; skills like `prophet-bounty-runner` literally cannot drive the Privy OTP flow without `playwright_navigate`.
- Restore the recency-boost data path. `serializeHistory` was filtering out every `tool_call`/`tool_result` row and mapping assistant rows to `{role, content}` only, so the `tool_calls[]` evidence the Rust `extract_recent_publishers` reads (added in #1283) never reached Rust. Every MCP publisher (gmail, kraken, polymarket, slack, …) was at the same risk as playwright once its keywords stopped matching the next user prompt.
- Extract `serializeHistory` into `src/services/orchestrator-history.ts` so it can be unit-tested without dragging in `@tanstack/solid-query` and the rest of `orchestrator.ts`. The new implementation walks messages in order, attaches `tool_call` rows to the preceding assistant's `tool_calls[]`, emits `role: "tool"` replies for matching `tool_result` rows, and drops orphan tool_calls so the OpenAI/Anthropic chat-completions contract is satisfied across turn boundaries.

Closes #1895.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 465 passed, 0 failed (baseline + new `playwright_mcp_tools_survive_non_playwright_query`).
- [x] `vitest run tests/unit/orchestrator-serialize-history.test.ts` — 2 passed (recency-boost contract + orphan-tool_calls guard). Confirmed RED against the prior implementation, GREEN after.
- [x] `vitest run` — 979 passed (vs. 977 on `main`); the 15 pre-existing failures are environment-only `@tanstack/solid-query` import errors unrelated to this PR.
- [x] `biome check` on the two changed `src/**` files — clean.

## Prior PRs audited (none reverted)

| PR | Did | Why this PR doesn't conflict |
|----|-----|------------------------------|
| #1248 | Pinned local file/exec tools | This PR adds to the pinned set, doesn't replace it |
| #1397 → #1423 | Pinned `seren__*` built-ins | Same: additive |
| #1283 | Added BM25 + recency boost | This PR restores the data path the recency boost needs |
| #1267, #1236 | Raised `MAX_TOOLS` caps | Unchanged |
| #1592 | Added publisher-routing rules to system prompt | Unchanged |
| #1886 (closes #1883) | Resolved bare `"node"` for Claude CLI MCP | Different code path; unchanged |
| #1894 (closes #1893) | Collapsed `model_budget` overrides | Unchanged |

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
