### PR TITLE
fix(chat): close #1902 — restore tool types after thread switch

### DIFF
--- a/src/stores/conversation.store.ts
+++ b/src/stores/conversation.store.ts
@@ -463,11 +463,13 @@ export const conversationStore = {
             const metaFields = deserializeMetadata(m.metadata);
             return {
               id: m.id,
-              type: (metaFields.workerType
-                ? "assistant"
-                : m.role === "user"
-                  ? "user"
-                  : "assistant") as UnifiedMessage["type"],
+              type: (metaFields.type
+                ? metaFields.type
+                : metaFields.workerType
+                  ? "assistant"
+                  : m.role === "user"
+                    ? "user"
+                    : "assistant") as UnifiedMessage["type"],
               role: m.role as UnifiedMessage["role"],
               content: m.content,
               timestamp: m.timestamp,

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -113,6 +113,7 @@ export interface ChatContextData {
 /** Versioned metadata blob stored in the database `metadata` TEXT column. */
 export interface MessageMetadata {
   v: 1;
+  message_type?: MessageType | null;
   worker_type?: WorkerType | null;
   model_id?: string | null;
   task_type?: string | null;
@@ -130,9 +131,27 @@ export interface MessageMetadata {
   } | null;
 }
 
+/**
+ * Message types that need a persisted discriminator. Plain user/assistant
+ * messages don't — `role` is authoritative for those. Without this, loading
+ * a tool_call/tool_result back from the database collapses it to a generic
+ * assistant bubble and renders the raw JSON content as markdown.
+ */
+const PERSISTED_DISCRIMINATOR_TYPES: ReadonlySet<MessageType> = new Set([
+  "tool_call",
+  "tool_result",
+  "diff",
+  "thought",
+  "transition",
+  "reroute",
+  "error",
+]);
+
 /** Serialize orchestrator fields from a UnifiedMessage into a metadata JSON string. */
 export function serializeMetadata(msg: UnifiedMessage): string | null {
+  const needsTypeDiscriminator = PERSISTED_DISCRIMINATOR_TYPES.has(msg.type);
   if (
+    !needsTypeDiscriminator &&
     !msg.workerType &&
     !msg.modelId &&
     !msg.taskType &&
@@ -145,6 +164,7 @@ export function serializeMetadata(msg: UnifiedMessage): string | null {
   }
   const meta: MessageMetadata = {
     v: 1,
+    message_type: needsTypeDiscriminator ? msg.type : null,
     worker_type: msg.workerType ?? null,
     model_id: msg.modelId ?? null,
     task_type: msg.taskType ?? null,
@@ -181,6 +201,12 @@ export function deserializeMetadata(
       return {};
     }
     const result: Partial<UnifiedMessage> = {};
+    if (
+      typeof meta.message_type === "string" &&
+      PERSISTED_DISCRIMINATOR_TYPES.has(meta.message_type as MessageType)
+    ) {
+      result.type = meta.message_type as MessageType;
+    }
     if (typeof meta.worker_type === "string") {
       result.workerType = meta.worker_type as WorkerType;
     }

--- a/tests/unit/conversation-store.test.ts
+++ b/tests/unit/conversation-store.test.ts
@@ -328,5 +328,66 @@ describe("conversationStore", () => {
       expect(msgs[0].modelId).toBe("gemini-2.5-flash");
       expect(msgs[0].taskType).toBe("code_generation");
     });
+
+    it("restores tool_call and tool_result types from persisted metadata", async () => {
+      const bridge = await import("@/lib/tauri-bridge");
+      vi.mocked(bridge.getConversations).mockResolvedValueOnce([
+        {
+          id: "conv-tools",
+          title: "Tool Chat",
+          created_at: 1000,
+          selected_model: null,
+          selected_provider: null,
+          project_root: null,
+          is_archived: false,
+          employee_id: null,
+        },
+      ]);
+      vi.mocked(bridge.getMessages).mockResolvedValueOnce([
+        {
+          id: "msg-call",
+          conversation_id: "conv-tools",
+          role: "assistant",
+          content: "",
+          model: null,
+          timestamp: 3000,
+          metadata: JSON.stringify({
+            v: 1,
+            message_type: "tool_call",
+            worker_type: "orchestrator",
+            tool_call: {
+              id: "tc-99",
+              name: "list_projects",
+              arguments: "{}",
+            },
+          }),
+        },
+        {
+          id: "msg-result",
+          conversation_id: "conv-tools",
+          role: "assistant",
+          content: '{"name":"gitignore","is_directory":false}',
+          model: null,
+          timestamp: 3001,
+          metadata: JSON.stringify({
+            v: 1,
+            message_type: "tool_result",
+            worker_type: "orchestrator",
+            tool_call: {
+              id: "tc-99",
+              name: "list_projects",
+            },
+          }),
+        },
+      ]);
+
+      await conversationStore.loadHistory();
+
+      const msgs = conversationStore.getMessagesFor("conv-tools");
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0].type).toBe("tool_call");
+      expect(msgs[0].toolCall?.toolCallId).toBe("tc-99");
+      expect(msgs[1].type).toBe("tool_result");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `loadHistory()` was forcing every persisted message to `user`/`assistant`, so tool_call and tool_result messages came back with the wrong type after a thread switch — falling through to the markdown renderer and dumping the stored raw JSON tool output as plain text in the chat.
- Adds a `message_type` discriminator to `MessageMetadata` for the seven types that cannot be inferred from `role` (tool_call, tool_result, diff, thought, transition, reroute, error), persists it through `serializeMetadata`, restores it through `deserializeMetadata`, and uses it in `loadHistory`.
- Backward-compatible: rows without the discriminator still load via the existing worker_type/role fallback.

Closes #1902.

## Test plan
- [x] New critical TDD test: `loadHistory restores tool_call and tool_result types from persisted metadata` (fails before fix, passes after)
- [x] Existing `conversation-store` and `conversation-types` suites still pass (56 tests)
- [x] Full repo vitest suite passes (1099/1099)
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on changed source files
- [ ] Manual: run an MCP tool turn, switch threads, switch back — historical tool result now renders as a `ToolCallCard`, not raw JSON

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com