### PR TITLE
fix(skills): close #570 — Windows command translation note

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1402,13 +1402,19 @@ export const skills = {
       const content = await this.readContent(skill);
       if (content) {
         const parsed = parseSkillMd(content);
-        const runtimeDir = `${skill.skillsDir}/${skill.dirName}`;
+        const isWindowsRuntime =
+          skill.skillsDir.includes("\\") || /^[A-Za-z]:/.test(skill.skillsDir);
+        const sep = isWindowsRuntime ? "\\" : "/";
+        const runtimeDir = `${skill.skillsDir}${sep}${skill.dirName}`;
         const hasIncludes =
           parsed.metadata.includes && parsed.metadata.includes.length > 0;
         const depsNote = hasIncludes
-          ? `\n> **Shared dependencies:** \`${runtimeDir}/_deps/\` contains shared files from declared \`includes\` paths.\n`
+          ? `\n> **Shared dependencies:** \`${runtimeDir}${sep}_deps${sep}\` contains shared files from declared \`includes\` paths.\n`
           : "";
-        const runtimeNote = `> **Skill runtime directory:** \`${runtimeDir}\`\n> Use this absolute path to reference skill files. Do not create local copies or fallback scaffolds.${depsNote}\n\n`;
+        const platformNote = isWindowsRuntime
+          ? `\n> **Platform:** Windows. Skill docs commonly use Unix conventions (\`python3\`, \`~/.config/seren/skills/<name>\`, forward-slash paths). On this machine, translate before running:\n> - Use \`python\` (or \`py\`) instead of \`python3\`.\n> - Replace any \`~/.config/seren/skills/<name>\` reference with the absolute runtime directory above.\n> - Use backslashes inside paths.\n> Always \`cd\` into the absolute runtime directory above before invoking skill scripts.`
+          : "";
+        const runtimeNote = `> **Skill runtime directory:** \`${runtimeDir}\`\n> Use this absolute path to reference skill files. Do not create local copies or fallback scaffolds.${platformNote}${depsNote}\n\n`;
         contents.push(
           `## Skill: ${skill.name}\n\n${runtimeNote}${parsed.content}`,
         );

--- a/tests/unit/skill-runtime-platform-note.test.ts
+++ b/tests/unit/skill-runtime-platform-note.test.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Regression for serenorg/seren-skills#570 — verify the runtime
+// directory note tells Windows users how to translate Unix-style commands.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockInvoke = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: () => true,
+}));
+
+const SKILL_MD = `---
+name: Test Skill
+description: A test
+---
+# Test Skill
+Run \`python3 scripts/agent.py\` from \`~/.config/seren/skills/test\`.`;
+
+type FakeOverrides = {
+  skillsDir?: string;
+  dirName?: string;
+};
+
+function fakeSkill(overrides: FakeOverrides = {}) {
+  return {
+    id: "seren:test",
+    slug: "test",
+    name: "Test Skill",
+    description: "A test",
+    source: "seren" as const,
+    sourceUrl: "seren-skills:test",
+    tags: [],
+    scope: "user" as const,
+    skillsDir: overrides.skillsDir ?? "/Users/me/.config/seren/skills",
+    dirName: overrides.dirName ?? "test",
+    path: "",
+    installedAt: 0,
+    enabled: true,
+  };
+}
+
+describe("skill runtime directory injection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "read_skill_content") return Promise.resolve(SKILL_MD);
+      return Promise.resolve(null);
+    });
+  });
+
+  it("emits the absolute runtime dir on Unix and adds no Windows translation note", async () => {
+    const { skills } = await import("@/services/skills");
+    const content = await skills.getEnabledSkillsContent([
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture
+      fakeSkill() as any,
+    ]);
+
+    expect(content).toContain(
+      "**Skill runtime directory:** `/Users/me/.config/seren/skills/test`",
+    );
+    expect(content).not.toMatch(/Platform:[*\s]*Windows/i);
+  });
+
+  it("emits a Windows translation note when skillsDir is a Windows path", async () => {
+    const { skills } = await import("@/services/skills");
+    const content = await skills.getEnabledSkillsContent([
+      fakeSkill({
+        skillsDir: "C:\\Users\\Unkno\\AppData\\Local\\SerenDesktop\\skills",
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture
+      }) as any,
+    ]);
+
+    expect(content).toContain(
+      "**Skill runtime directory:** `C:\\Users\\Unkno\\AppData\\Local\\SerenDesktop\\skills\\test`",
+    );
+    expect(content).toMatch(/Platform:[*\s]*Windows/i);
+    expect(content.toLowerCase()).toContain("python3");
+    expect(content.toLowerCase()).toContain("python");
+    expect(content.toLowerCase()).toContain("~/.config/seren/skills");
+  });
+});


### PR DESCRIPTION
## Summary

- Detect a Windows skill runtime and emit a per-skill translation note in the system prompt: use `python` (or `py`) for `python3`, substitute the absolute runtime directory for any `~/.config/seren/skills/<name>` reference, and use backslashes in paths.
- Use the platform path separator inside the injected runtime directory itself (was hardcoded `/`).

## Why

ticket: serenorg/seren-skills#570

Windows users running `/prophet-arb-bot` saw the model loop on `execute_command` failures: `python3` returns Windows' "Python was not found" stub; falling back to `python` ran from the install CWD, hitting `python: can't open file 'C:\Users\...\SerenDesktop\scripts\agent.py'`. The model was reasoning correctly — it followed the literal Unix-only instructions in `SKILL.md`. Every skill in the catalog uses the same `python3` + tilde-path pattern, so a single-skill rewrite wouldn't have solved it. This change patches the injection point once and covers every skill.

## Verification

- `src/services/skills.ts:1401-1426` — Windows runtime now triggers a `**Platform:** Windows` note in the runtime-directory frontmatter; Unix users see no change.
- `tests/unit/skill-runtime-platform-note.test.ts` — two assertions: Unix path emits no Windows note; Windows path emits the note and uses `\` separator in the injected absolute path.

## Test plan

- [x] `pnpm vitest run tests/unit/skill-runtime-platform-note.test.ts` passes (2/2).
- [x] Adjacent skill suites still pass (`skill-includes`, `skills-index-api`, `skills-list-installed`, `agent-skills-priming`, `skill-invocation-directive`, `skill-host-exclusion` — 40/40).
- [x] `npx biome check src/services/skills.ts` clean.
- [x] `npx tsc --noEmit` clean for changed files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com