### PR TITLE
fix(orchestrator): drop orphan tool replies from history

### DIFF
--- a/src/services/orchestrator-history.ts
+++ b/src/services/orchestrator-history.ts
@@ -114,22 +114,26 @@ export function serializeHistory(
     pendingAssistantIdx = m.role === "assistant" ? out.length - 1 : null;
   }
 
-  return dropOrphanToolCalls(out);
+  return dropUnpairedToolMessages(out);
 }
 
 /**
- * Belt-and-braces: if an assistant row ended up with tool_calls but the
- * stream was cut before the corresponding tool_result rows were persisted,
- * strip the orphaned ids so the gateway doesn't reject the payload. Mutates
- * each affected assistant in place rather than copying the full array.
+ * Belt-and-braces: keep only complete assistant tool_call <-> tool reply
+ * pairs. Providers reject either side when its counterpart is missing:
+ * - assistant.tool_calls[] without matching role: "tool" replies
+ * - role: "tool" replies without matching assistant.tool_calls[]
  */
-function dropOrphanToolCalls(out: SerializedMessage[]): SerializedMessage[] {
+function dropUnpairedToolMessages(
+  out: SerializedMessage[],
+): SerializedMessage[] {
   const seenToolReplyIds = new Set<string>();
   for (const msg of out) {
     if (msg.role === "tool" && typeof msg.tool_call_id === "string") {
       seenToolReplyIds.add(msg.tool_call_id);
     }
   }
+
+  const keptToolCallIds = new Set<string>();
   for (const msg of out) {
     if (msg.role !== "assistant" || !msg.tool_calls) continue;
     const kept = msg.tool_calls.filter((tc) => seenToolReplyIds.has(tc.id));
@@ -137,7 +141,17 @@ function dropOrphanToolCalls(out: SerializedMessage[]): SerializedMessage[] {
       delete msg.tool_calls;
     } else {
       msg.tool_calls = kept;
+      for (const tc of kept) {
+        keptToolCallIds.add(tc.id);
+      }
     }
   }
-  return out;
+
+  return out.filter((msg) => {
+    if (msg.role !== "tool") return true;
+    return (
+      typeof msg.tool_call_id === "string" &&
+      keptToolCallIds.has(msg.tool_call_id)
+    );
+  });
 }

--- a/tests/unit/orchestrator-serialize-history.test.ts
+++ b/tests/unit/orchestrator-serialize-history.test.ts
@@ -130,4 +130,39 @@ describe("serializeHistory (#1895)", () => {
     const toolReply = serialized.find((m) => m.role === "tool");
     expect(toolReply?.tool_call_id).toBe("tc-complete");
   });
+
+  it("drops orphan tool replies so providers never see function outputs without matching calls", () => {
+    // Reproduces GH #574: a completed prior tool_result can remain in stored
+    // history after its assistant tool_call row was compacted, filtered, or not
+    // serialized. OpenAI-compatible providers reject that as
+    // "No tool call found for function call output with call_id ...".
+    const history: UnifiedMessage[] = [
+      makeMessage({
+        id: "u1",
+        type: "user",
+        role: "user",
+        content: "Run Prophet Arb Bot.",
+      }),
+      makeMessage({
+        id: "a1",
+        type: "assistant",
+        role: "assistant",
+        content: "Checking local paths.",
+      }),
+      makeMessage({
+        id: "orphan-result",
+        type: "tool_result",
+        role: "assistant",
+        content: "false",
+        toolCallId: "toolu_bdrk_01JYn7yvn44yHMH4M7UpUgcw",
+      }),
+    ];
+
+    const serialized = serializeHistory(history);
+
+    expect(serialized.some((m) => m.role === "tool")).toBe(false);
+    expect(
+      serialized.find((m) => m.role === "assistant")?.tool_calls,
+    ).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- audit issue serenorg/seren-skills#574 and the attached Tauri log failure: OpenAI-compatible gateway rejected a stored function output with call_id toolu_bdrk_01JYn7yvn44yHMH4M7UpUgcw because the corresponding assistant tool call was not in serialized history
- keep only complete assistant tool_call <-> role: tool reply pairs when serializing orchestrator history
- add a regression test for orphan tool replies so providers never receive function outputs without matching calls

Fixes serenorg/seren-skills#574

## Tests
- ./node_modules/.bin/vitest run tests/unit/orchestrator-serialize-history.test.ts
- ./node_modules/.bin/biome check src/services/orchestrator-history.ts tests/unit/orchestrator-serialize-history.test.ts
- git diff --check