### PR TITLE
fix(chat): close #573 — strip tool calls from chat history export

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -21,6 +21,10 @@ import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { DepositModal } from "@/components/wallet/DepositModal";
 import { isAuthError, isContextOverflowError } from "@/lib/auth-errors";
 import {
+  formatChatHistoryMarkdown,
+  hasExportableMessages,
+} from "@/lib/chat-history-export";
+import {
   getCompletions,
   matchSkillCommand,
   parseCommand,
@@ -1000,20 +1004,12 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
 
   const copyAllChatHistory = async () => {
     const messages = conversationMessages();
-    if (messages.length === 0) {
+    if (!hasExportableMessages(messages)) {
       alert("No chat history to copy");
       return;
     }
 
-    // Format messages as markdown
-    let markdown = "# Chat History\n\n";
-    for (const msg of messages) {
-      if (msg.role === "user") {
-        markdown += `**You:** ${msg.content}\n\n`;
-      } else if (msg.role === "assistant") {
-        markdown += `**Assistant:** ${msg.content}\n\n`;
-      }
-    }
+    const markdown = formatChatHistoryMarkdown(messages);
 
     try {
       await navigator.clipboard.writeText(markdown);
@@ -1029,20 +1025,13 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
   const downloadChatHistory = async () => {
     if (isSaving()) return;
     const messages = conversationMessages();
-    if (messages.length === 0) return;
+    if (!hasExportableMessages(messages)) return;
 
-    const dateStr = new Date().toISOString().split("T")[0];
+    const now = new Date();
+    const dateStr = now.toISOString().split("T")[0];
     const title = `Chat History - ${dateStr}`;
 
-    let markdown = "# Chat History\n\n";
-    markdown += `*Exported ${new Date().toLocaleString()}*\n\n---\n\n`;
-    for (const msg of messages) {
-      if (msg.role === "user") {
-        markdown += `**You:** ${msg.content}\n\n`;
-      } else if (msg.role === "assistant") {
-        markdown += `**Assistant:** ${msg.content}\n\n`;
-      }
-    }
+    const markdown = formatChatHistoryMarkdown(messages, { exportedAt: now });
 
     setIsSaving(true);
     try {

--- a/src/lib/chat-history-export.ts
+++ b/src/lib/chat-history-export.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Renders a conversation as plain-text markdown for copy/save exports.
+// ABOUTME: Filters out tool calls, tool results, and other non-chat message types.
+
+import type { UnifiedMessage } from "@/types/conversation";
+
+export interface ChatHistoryExportMessage {
+  type: UnifiedMessage["type"];
+  content: string;
+}
+
+/**
+ * Format a chat conversation as markdown.
+ *
+ * Only `user` and `assistant` message types are included. Tool calls, tool
+ * results, diffs, thoughts, transitions, reroutes, and error messages are
+ * filtered out so that exports contain only the human-readable chat.
+ *
+ * `role`-based filtering is unsafe here: tool calls and tool results are
+ * persisted with `role: "assistant"` but carry the tool name or raw JSON
+ * payload as content. Filtering must use the `type` discriminator.
+ */
+export function formatChatHistoryMarkdown(
+  messages: readonly ChatHistoryExportMessage[],
+  options: { header?: string; exportedAt?: Date } = {},
+): string {
+  const header = options.header ?? "# Chat History";
+  let markdown = `${header}\n\n`;
+  if (options.exportedAt) {
+    markdown += `*Exported ${options.exportedAt.toLocaleString()}*\n\n---\n\n`;
+  }
+  for (const msg of messages) {
+    if (msg.type === "user") {
+      markdown += `**You:** ${msg.content}\n\n`;
+    } else if (msg.type === "assistant") {
+      markdown += `**Assistant:** ${msg.content}\n\n`;
+    }
+  }
+  return markdown;
+}
+
+/** Returns true if the conversation has at least one user or assistant message. */
+export function hasExportableMessages(
+  messages: readonly ChatHistoryExportMessage[],
+): boolean {
+  return messages.some((m) => m.type === "user" || m.type === "assistant");
+}

--- a/tests/unit/chat-history-export.test.ts
+++ b/tests/unit/chat-history-export.test.ts
@@ -1,0 +1,67 @@
+// ABOUTME: Verifies chat export excludes tool calls and tool results.
+// ABOUTME: Regression guard for #573 — exports leaked raw tool JSON as "Assistant:" lines.
+
+import { describe, expect, it } from "vitest";
+import {
+  formatChatHistoryMarkdown,
+  hasExportableMessages,
+} from "@/lib/chat-history-export";
+import type { ChatHistoryExportMessage } from "@/lib/chat-history-export";
+
+describe("formatChatHistoryMarkdown", () => {
+  it("excludes tool_call and tool_result messages", () => {
+    const messages: ChatHistoryExportMessage[] = [
+      { type: "user", content: "/prophet-arb-bot" },
+      { type: "assistant", content: "I'll help you set up the Prophet Arb Bot." },
+      { type: "tool_call", content: "seren__list_projects" },
+      { type: "tool_result", content: '[{"text":"{\\"data\\":[...]}"}]' },
+      { type: "assistant", content: "You're authenticated." },
+    ];
+
+    const md = formatChatHistoryMarkdown(messages);
+
+    expect(md).toContain("**You:** /prophet-arb-bot");
+    expect(md).toContain("**Assistant:** I'll help you set up");
+    expect(md).toContain("**Assistant:** You're authenticated.");
+    expect(md).not.toContain("seren__list_projects");
+    expect(md).not.toContain('[{"text"');
+  });
+
+  it("excludes non-chat message types", () => {
+    const messages: ChatHistoryExportMessage[] = [
+      { type: "user", content: "edit foo.ts" },
+      { type: "thought", content: "internal reasoning" },
+      { type: "diff", content: "--- a\n+++ b" },
+      { type: "transition", content: "routing to worker" },
+      { type: "reroute", content: "switching model" },
+      { type: "error", content: "rate limited" },
+      { type: "assistant", content: "Done." },
+    ];
+
+    const md = formatChatHistoryMarkdown(messages);
+
+    expect(md).toContain("**You:** edit foo.ts");
+    expect(md).toContain("**Assistant:** Done.");
+    expect(md).not.toContain("internal reasoning");
+    expect(md).not.toContain("--- a");
+    expect(md).not.toContain("routing to worker");
+    expect(md).not.toContain("switching model");
+    expect(md).not.toContain("rate limited");
+  });
+
+  it("hasExportableMessages returns false when only tool messages exist", () => {
+    const messages: ChatHistoryExportMessage[] = [
+      { type: "tool_call", content: "seren__list_projects" },
+      { type: "tool_result", content: '{"data":[]}' },
+    ];
+    expect(hasExportableMessages(messages)).toBe(false);
+  });
+
+  it("hasExportableMessages returns true when chat messages exist", () => {
+    const messages: ChatHistoryExportMessage[] = [
+      { type: "tool_call", content: "x" },
+      { type: "user", content: "hi" },
+    ];
+    expect(hasExportableMessages(messages)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Chat export (copy + Save to Notes) leaked `Assistant: <tool-name>` and `Assistant: [{\"text\":...}]` lines because `tool_call` and `tool_result` messages are persisted with `role: \"assistant\"`.
- Filter exports by the `type` discriminator (`user`/`assistant`) instead of `role`, so tool calls, tool results, diffs, thoughts, transitions, reroutes, and errors all stay out.
- Extract a pure helper (`src/lib/chat-history-export.ts`) so the behavior is unit-tested.

Closes serenorg/seren-skills#573.

## Test plan

- [x] `vitest run tests/unit/chat-history-export.test.ts` — 4 tests, all pass.
- [x] `tsc --noEmit` clean.
- [x] `biome check` clean on changed src files.
- [ ] Manual: open a thread that invoked an MCP tool, run Copy Chat — confirm export contains only user/assistant text, no tool name or JSON dump.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com