### PR TITLE
fix(chat): render Claude <think> blocks as Thinking cards

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -19,6 +19,7 @@ import { AgentPermissionDialog } from "@/components/agent/AgentPermissionDialog"
 import { DiffProposalDialog } from "@/components/agent/DiffProposalDialog";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
+import { extractAgentThinkingMarkup } from "@/lib/agent-thinking-markup";
 import { isAuthError, isLikelyAuthError } from "@/lib/auth-errors";
 import { collapseBuildOutput } from "@/lib/build-output";
 import {
@@ -225,11 +226,19 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   // The worker returns HTML via onmessage → setHtmlCache → reactive DOM update.
   createEffect(() => {
     for (const msg of threadMessages()) {
+      const visibleAssistantContent =
+        msg.type === "assistant"
+          ? extractAgentThinkingMarkup(msg.content).content
+          : "";
       if (
         msg.type === "assistant" &&
+        visibleAssistantContent &&
         untrack(() => htmlCache[msg.id]) === undefined
       ) {
-        markdownWorker.postMessage({ id: msg.id, markdown: msg.content });
+        markdownWorker.postMessage({
+          id: msg.id,
+          markdown: visibleAssistantContent,
+        });
       }
     }
   });
@@ -1221,21 +1230,30 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         );
       }
 
-      case "assistant":
+      case "assistant": {
+        const normalized = extractAgentThinkingMarkup(message.content);
+        const visibleContent = normalized.content;
         return (
           <article class="group/msg relative px-5 py-4 border-b border-surface-2 [contain:layout]">
+            <Show when={normalized.thinking}>
+              <div class={visibleContent ? "mb-3" : ""}>
+                <ThinkingBlock thinking={normalized.thinking} />
+              </div>
+            </Show>
             <Show
               when={isLastMessage && isLikelyAuthError(message.content)}
               fallback={
-                <div
-                  class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
-                  innerHTML={collapseBuildOutput(
-                    collapseDirectoryListings(
-                      htmlCache[message.id] ??
-                        escapeHtml(message.content).replace(/\n/g, "<br>"),
-                    ),
-                  )}
-                />
+                <Show when={visibleContent}>
+                  <div
+                    class="text-sm leading-relaxed text-foreground break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-surface-2 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-surface-1 [&_pre]:border [&_pre]:border-border [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-border [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline"
+                    innerHTML={collapseBuildOutput(
+                      collapseDirectoryListings(
+                        htmlCache[message.id] ??
+                          escapeHtml(visibleContent).replace(/\n/g, "<br>"),
+                      ),
+                    )}
+                  />
+                </Show>
               }
             >
               <div class="px-3 py-2 border rounded-md text-sm bg-warning/10 border-warning/40 text-warning">
@@ -1300,6 +1318,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             </Show>
           </article>
         );
+      }
 
       case "thought":
         return (

--- a/src/lib/agent-thinking-markup.ts
+++ b/src/lib/agent-thinking-markup.ts
@@ -1,0 +1,138 @@
+// ABOUTME: Normalizes Claude-style <think> blocks out of visible assistant text.
+// ABOUTME: Keeps raw model reasoning in the existing ThinkingBlock rendering path. #1911.
+
+export interface AgentThinkingMarkupParts {
+  content: string;
+  thinking: string;
+}
+
+export interface AgentThinkingMarkupStreamState {
+  insideThink: boolean;
+  pending: string;
+}
+
+const THINK_OPEN = "<think>";
+const THINK_CLOSE = "</think>";
+
+function normalizeFinalText(text: string): string {
+  return text
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function findMarker(source: string, marker: string): number {
+  return source.toLowerCase().indexOf(marker);
+}
+
+function longestMarkerPrefixSuffix(source: string, marker: string): string {
+  const lowerSource = source.toLowerCase();
+  const maxLength = Math.min(marker.length - 1, source.length);
+
+  for (let length = maxLength; length > 0; length -= 1) {
+    if (marker.startsWith(lowerSource.slice(-length))) {
+      return source.slice(-length);
+    }
+  }
+
+  return "";
+}
+
+export function createAgentThinkingMarkupStreamState(): AgentThinkingMarkupStreamState {
+  return { insideThink: false, pending: "" };
+}
+
+export function extractAgentThinkingMarkup(
+  text: string,
+): AgentThinkingMarkupParts {
+  if (!text?.toLowerCase().includes(THINK_OPEN)) {
+    return { content: text, thinking: "" };
+  }
+
+  const contentParts: string[] = [];
+  const thinkingParts: string[] = [];
+  let source = text;
+
+  while (source.length > 0) {
+    const openIndex = findMarker(source, THINK_OPEN);
+    if (openIndex === -1) {
+      contentParts.push(source);
+      break;
+    }
+
+    contentParts.push(source.slice(0, openIndex));
+    const afterOpen = source.slice(openIndex + THINK_OPEN.length);
+    const closeIndex = findMarker(afterOpen, THINK_CLOSE);
+
+    if (closeIndex === -1) {
+      thinkingParts.push(afterOpen);
+      break;
+    }
+
+    thinkingParts.push(afterOpen.slice(0, closeIndex));
+    source = afterOpen.slice(closeIndex + THINK_CLOSE.length);
+  }
+
+  return {
+    content: normalizeFinalText(contentParts.join("")),
+    thinking: normalizeFinalText(thinkingParts.join("\n\n")),
+  };
+}
+
+export function consumeAgentThinkingMarkupChunk(
+  state: AgentThinkingMarkupStreamState,
+  chunk: string,
+): AgentThinkingMarkupParts {
+  if (!chunk && !state.pending) {
+    return { content: "", thinking: "" };
+  }
+
+  let source = state.pending + chunk;
+  state.pending = "";
+  let content = "";
+  let thinking = "";
+
+  while (source.length > 0) {
+    const marker = state.insideThink ? THINK_CLOSE : THINK_OPEN;
+    const markerIndex = findMarker(source, marker);
+
+    if (markerIndex !== -1) {
+      const beforeMarker = source.slice(0, markerIndex);
+      if (state.insideThink) {
+        thinking += beforeMarker;
+      } else {
+        content += beforeMarker;
+      }
+      state.insideThink = !state.insideThink;
+      source = source.slice(markerIndex + marker.length);
+      continue;
+    }
+
+    const pending = longestMarkerPrefixSuffix(source, marker);
+    const emit = source.slice(0, source.length - pending.length);
+    if (state.insideThink) {
+      thinking += emit;
+    } else {
+      content += emit;
+    }
+    state.pending = pending;
+    break;
+  }
+
+  return { content, thinking };
+}
+
+export function flushAgentThinkingMarkupRemainder(
+  state: AgentThinkingMarkupStreamState,
+): AgentThinkingMarkupParts {
+  const pending = state.pending;
+  state.pending = "";
+
+  if (!pending) {
+    return { content: "", thinking: "" };
+  }
+
+  return state.insideThink
+    ? { content: "", thinking: pending }
+    : { content: pending, thinking: "" };
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -322,6 +322,13 @@ function defaultContextWindowFor(agentType: string, modelId?: string): number {
   return 200_000;
 }
 
+import {
+  type AgentThinkingMarkupParts,
+  type AgentThinkingMarkupStreamState,
+  consumeAgentThinkingMarkupChunk,
+  createAgentThinkingMarkupStreamState,
+  flushAgentThinkingMarkupRemainder,
+} from "@/lib/agent-thinking-markup";
 import { isLikelyAuthError } from "@/lib/auth-errors";
 import { buildChatRequest, sendProviderMessage } from "@/lib/providers";
 import {
@@ -1086,6 +1093,10 @@ const LEGACY_CLAUDE_LOCAL_SESSION_ID_RE = /^session-\d+$/;
 const CHUNK_FLUSH_MS = 50;
 const chunkBufs = new Map<string, { content: string; thinking: string }>();
 const chunkFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const thinkingMarkupStreamStates = new Map<
+  string,
+  AgentThinkingMarkupStreamState
+>();
 
 // Tool event accumulation buffers — plain JS, not reactive.
 // During high-velocity tool-call chains (e.g. Codex doing 20+ sequential
@@ -1100,6 +1111,60 @@ interface PendingToolEvent {
 const toolEventBufs = new Map<string, PendingToolEvent[]>();
 const toolEventFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+function thinkingMarkupStateFor(
+  sessionId: string,
+): AgentThinkingMarkupStreamState {
+  let parserState = thinkingMarkupStreamStates.get(sessionId);
+  if (!parserState) {
+    parserState = createAgentThinkingMarkupStreamState();
+    thinkingMarkupStreamStates.set(sessionId, parserState);
+  }
+  return parserState;
+}
+
+function appendThinkingMarkupParts(
+  sessionId: string,
+  parts: AgentThinkingMarkupParts,
+): void {
+  if (parts.content) {
+    setState(
+      "sessions",
+      sessionId,
+      "streamingContent",
+      (c) => c + parts.content,
+    );
+  }
+  if (parts.thinking) {
+    const session = state.sessions[sessionId];
+    if (session && !session.streamingThinking) {
+      setState(
+        "sessions",
+        sessionId,
+        "streamingThinkingTimestamp",
+        session.streamingThinkingTimestamp ??
+          session.streamingContentTimestamp ??
+          Date.now(),
+      );
+    }
+    setState(
+      "sessions",
+      sessionId,
+      "streamingThinking",
+      (c) => c + parts.thinking,
+    );
+  }
+}
+
+function flushThinkingMarkupStreamState(sessionId: string): void {
+  const parserState = thinkingMarkupStreamStates.get(sessionId);
+  if (!parserState) return;
+  appendThinkingMarkupParts(
+    sessionId,
+    flushAgentThinkingMarkupRemainder(parserState),
+  );
+  thinkingMarkupStreamStates.delete(sessionId);
+}
+
 function flushChunkBuf(sessionId: string): void {
   const timer = chunkFlushTimers.get(sessionId);
   if (timer !== undefined) {
@@ -1109,7 +1174,13 @@ function flushChunkBuf(sessionId: string): void {
   const buf = chunkBufs.get(sessionId);
   if (!buf) return;
   if (buf.content) {
-    setState("sessions", sessionId, "streamingContent", (c) => c + buf.content);
+    appendThinkingMarkupParts(
+      sessionId,
+      consumeAgentThinkingMarkupChunk(
+        thinkingMarkupStateFor(sessionId),
+        buf.content,
+      ),
+    );
     buf.content = "";
   }
   if (buf.thinking) {
@@ -1130,6 +1201,7 @@ function clearChunkBuf(sessionId: string): void {
     chunkFlushTimers.delete(sessionId);
   }
   chunkBufs.delete(sessionId);
+  thinkingMarkupStreamStates.delete(sessionId);
 }
 
 function clearToolEventBuf(sessionId: string): void {
@@ -1156,6 +1228,7 @@ function disposeAgentStoreRuntimeBindings(): void {
   }
   chunkFlushTimers.clear();
   chunkBufs.clear();
+  thinkingMarkupStreamStates.clear();
   for (const timer of toolEventFlushTimers.values()) {
     clearTimeout(timer);
   }
@@ -5737,6 +5810,7 @@ Structured summary:`;
     // Flush buffered chunks before reading streamingContent so tool cards
     // appear in correct chronological order relative to assistant text.
     flushChunkBuf(sessionId);
+    flushThinkingMarkupStreamState(sessionId);
     if (session.streamingThinking) {
       const thinkingMsg: AgentMessage = {
         id: crypto.randomUUID(),
@@ -6060,6 +6134,7 @@ Structured summary:`;
     const isReplay = opts?.isReplay ?? false;
     // Flush any buffered chunks before reading store state
     flushChunkBuf(sessionId);
+    flushThinkingMarkupStreamState(sessionId);
 
     const session = state.sessions[sessionId];
     if (!session) return;

--- a/tests/unit/agent-thinking-markup-wiring.test.ts
+++ b/tests/unit/agent-thinking-markup-wiring.test.ts
@@ -1,0 +1,67 @@
+// ABOUTME: Source-level wiring checks for #1911 thinking markup normalization.
+// ABOUTME: Keeps the pure parser test connected to the agent store and renderer.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
+describe("#1911 — Claude <think> markup is routed to ThinkingBlock", () => {
+  it("agent.store.ts routes raw content chunks through the streaming thinking parser", () => {
+    expect(agentStoreSource).toContain(
+      'from "@/lib/agent-thinking-markup"',
+    );
+
+    const flushStart = agentStoreSource.indexOf(
+      "function flushChunkBuf(sessionId: string)",
+    );
+    expect(flushStart, "flushChunkBuf must exist").toBeGreaterThan(0);
+    const flushSlice = agentStoreSource.slice(flushStart, flushStart + 1400);
+    const appendStart = agentStoreSource.indexOf(
+      "function appendThinkingMarkupParts(",
+    );
+    expect(appendStart, "appendThinkingMarkupParts must exist").toBeGreaterThan(
+      0,
+    );
+    const appendSlice = agentStoreSource.slice(appendStart, appendStart + 1600);
+
+    expect(flushSlice).toContain("consumeAgentThinkingMarkupChunk(");
+    expect(appendSlice).toContain('"streamingContent"');
+    expect(appendSlice).toContain('"streamingThinking"');
+  });
+
+  it("finalization drains pending partial <think> markup before constructing messages", () => {
+    const fnStart = agentStoreSource.indexOf(
+      "finalizeStreamingContent(sessionId: string",
+    );
+    expect(fnStart, "finalizeStreamingContent must exist").toBeGreaterThan(0);
+    const fnSlice = agentStoreSource.slice(fnStart, fnStart + 1200);
+
+    expect(fnSlice).toContain("flushChunkBuf(sessionId)");
+    expect(fnSlice).toContain("flushThinkingMarkupStreamState(sessionId)");
+  });
+
+  it("AgentChat renders legacy persisted <think> markup as a ThinkingBlock fallback", () => {
+    expect(agentChatSource).toContain("extractAgentThinkingMarkup");
+
+    const assistantStart = agentChatSource.indexOf('case "assistant":');
+    expect(assistantStart, "assistant render branch must exist").toBeGreaterThan(
+      0,
+    );
+    const assistantSlice = agentChatSource.slice(
+      assistantStart,
+      agentChatSource.indexOf('case "thought":', assistantStart),
+    );
+
+    expect(assistantSlice).toContain("<ThinkingBlock");
+    expect(assistantSlice).not.toContain("markdown: msg.content");
+  });
+});

--- a/tests/unit/agent-thinking-markup.test.ts
+++ b/tests/unit/agent-thinking-markup.test.ts
@@ -1,0 +1,67 @@
+// ABOUTME: Regression tests for Claude <think> blocks leaking into chat text. #1911.
+// ABOUTME: Pure string/state transformations only; UI/store wiring is tested separately.
+
+import { describe, expect, it } from "vitest";
+import {
+  consumeAgentThinkingMarkupChunk,
+  createAgentThinkingMarkupStreamState,
+  extractAgentThinkingMarkup,
+  flushAgentThinkingMarkupRemainder,
+} from "@/lib/agent-thinking-markup";
+
+describe("agent thinking markup normalizer", () => {
+  it("extracts finalized <think> blocks without losing assistant text", () => {
+    const input = [
+      "First, I will inspect the runtime.",
+      "<think>",
+      "The parser needs to split this from visible content.",
+      "</think>",
+      "The fix is to render this answer normally.",
+    ].join("\n");
+
+    expect(extractAgentThinkingMarkup(input)).toEqual({
+      thinking: "The parser needs to split this from visible content.",
+      content:
+        "First, I will inspect the runtime.\n\nThe fix is to render this answer normally.",
+    });
+  });
+
+  it("streams split <think> tags into thinking instead of visible content", () => {
+    const state = createAgentThinkingMarkupStreamState();
+
+    const first = consumeAgentThinkingMarkupChunk(
+      state,
+      "Visible before.\n<thi",
+    );
+    const second = consumeAgentThinkingMarkupChunk(
+      state,
+      "nk>internal plan</th",
+    );
+    const third = consumeAgentThinkingMarkupChunk(
+      state,
+      "ink>\nVisible after.",
+    );
+
+    expect(first).toEqual({ content: "Visible before.\n", thinking: "" });
+    expect(second).toEqual({ content: "", thinking: "internal plan" });
+    expect(third).toEqual({ content: "\nVisible after.", thinking: "" });
+    expect(flushAgentThinkingMarkupRemainder(state)).toEqual({
+      content: "",
+      thinking: "",
+    });
+  });
+
+  it("treats an unclosed final <think> block as thinking", () => {
+    const state = createAgentThinkingMarkupStreamState();
+    const chunk = consumeAgentThinkingMarkupChunk(
+      state,
+      "<think>still reasoning",
+    );
+
+    expect(chunk).toEqual({ content: "", thinking: "still reasoning" });
+    expect(flushAgentThinkingMarkupRemainder(state)).toEqual({
+      content: "",
+      thinking: "",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #1911
- Split raw Claude `<think>...</think>` content into the existing ThinkingBlock path instead of visible assistant text
- Route live streaming `<think>` chunks into `streamingThinking`, including tags split across chunks
- Render legacy persisted assistant messages with raw `<think>` markup through the Thinking card fallback

## Audit
- History check found the original thinking UI in 01b92090, Claude effort enablement in #1607 / 17dc5999, dead ThinkingToggle cleanup in #1606 / 6f218d1, and scrubber scaffolding behavior in #1840 / a81b8314
- This patch preserves existing structured `thought` messages and the `<thinking>` scaffolding scrubber; only raw `<think>` model markup is normalized as user-visible Thinking content

## Tests
- `node_modules/.bin/vitest run tests/unit/agent-thinking-markup.test.ts tests/unit/agent-thinking-markup-wiring.test.ts tests/unit/scrub-agent-markup.test.ts tests/unit/agent-scrub-wiring.test.ts`
- `node_modules/.bin/biome check src/lib/agent-thinking-markup.ts src/stores/agent.store.ts src/components/chat/AgentChat.tsx tests/unit/agent-thinking-markup.test.ts tests/unit/agent-thinking-markup-wiring.test.ts`