### PR TITLE
fix(chat): close #1913 — collapse Seren Chat tool calls

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -34,6 +34,10 @@ import { createDragDrop } from "@/lib/drag-drop";
 import { openExternalLink } from "@/lib/external-link";
 import { openFileInTab } from "@/lib/files/service";
 import { formatDurationWithVerb } from "@/lib/format-duration";
+import {
+  groupConsecutiveToolCalls,
+  toToolCallEvent,
+} from "@/lib/group-tool-calls";
 import { pickAndReadAttachments } from "@/lib/images/attachments";
 import { isPaymentError } from "@/lib/payment-errors";
 import type { Attachment } from "@/lib/providers/types";
@@ -67,7 +71,6 @@ import {
   allowsSerenPrivateAgent,
   allowsSerenPublicModels,
 } from "@/services/organization-policy";
-import type { ToolCallEvent } from "@/services/providers";
 import { skills } from "@/services/skills";
 import { authStore, checkAuth } from "@/stores/auth.store";
 import { chatStore } from "@/stores/chat.store";
@@ -77,11 +80,7 @@ import { fileTreeState } from "@/stores/fileTree";
 import { providerStore } from "@/stores/provider.store";
 import { settingsStore } from "@/stores/settings.store";
 import { workspaceStore } from "@/stores/workspace.store";
-import {
-  isRetryableWorker,
-  type ToolCallData,
-  type UnifiedMessage,
-} from "@/types/conversation";
+import { isRetryableWorker, type UnifiedMessage } from "@/types/conversation";
 import RenderMarkdownWorker from "@/workers/render-markdown.worker?worker";
 import { CompactedMessage } from "./CompactedMessage";
 import { ImageAttachmentBar } from "./ImageAttachmentBar";
@@ -99,79 +98,6 @@ import { ToolCallGroup } from "./ToolCallGroup";
 import { ToolsetSelector } from "./ToolsetSelector";
 import { TransitionAnnouncement } from "./TransitionAnnouncement";
 import "highlight.js/styles/github-dark.css";
-
-/** Map orchestrator ToolCallData to the ToolCallEvent shape ToolCallCard expects. */
-function toToolCallEvent(data: ToolCallData): ToolCallEvent {
-  // Use pre-parsed parameters if available, otherwise parse arguments (backward compat)
-  let params: Record<string, unknown> | undefined = data.parameters;
-  if (!params && data.arguments) {
-    try {
-      params = JSON.parse(data.arguments);
-    } catch {
-      /* non-JSON arguments — skip */
-    }
-  }
-  return {
-    sessionId: "",
-    toolCallId: data.toolCallId,
-    title: data.title || data.name || "Tool",
-    kind: data.kind,
-    status: data.status,
-    parameters: params,
-    result: data.isError ? undefined : data.result,
-    error: data.isError ? data.result : undefined,
-  };
-}
-
-type GroupedMessage =
-  | { type: "single"; message: UnifiedMessage }
-  | {
-      type: "tool_group";
-      /**
-       * Stable identity for this group across regroup remounts (#1748).
-       * Derived from the first tool call's id so per-group UI state
-       * (expand/Tail) survives the rebuild.
-       */
-      id: string;
-      messages: UnifiedMessage[];
-      toolCalls: ToolCallEvent[];
-    };
-
-function flushToolGroup(group: UnifiedMessage[], out: GroupedMessage[]): void {
-  if (group.length === 0) return;
-  if (group.length >= 3) {
-    const toolCalls = group
-      .filter((m) => m.toolCall)
-      .map((m) => toToolCallEvent(m.toolCall as ToolCallData));
-    const id = toolCalls[0]?.toolCallId ?? group[0].id;
-    out.push({ type: "tool_group", id, messages: group, toolCalls });
-  } else {
-    for (const msg of group) {
-      out.push({ type: "single", message: msg });
-    }
-  }
-}
-
-/** Group consecutive tool_call messages into collapsed groups */
-function groupConsecutiveToolCalls(
-  messages: UnifiedMessage[],
-): GroupedMessage[] {
-  const grouped: GroupedMessage[] = [];
-  let currentGroup: UnifiedMessage[] = [];
-
-  for (const message of messages) {
-    if (message.type === "tool_call" && message.toolCall) {
-      currentGroup.push(message);
-    } else {
-      flushToolGroup(currentGroup, grouped);
-      currentGroup = [];
-      grouped.push({ type: "single", message });
-    }
-  }
-  flushToolGroup(currentGroup, grouped);
-
-  return grouped;
-}
 
 // Keywords that trigger publisher suggestions
 const SUGGESTION_KEYWORDS = [

--- a/src/lib/group-tool-calls.ts
+++ b/src/lib/group-tool-calls.ts
@@ -1,0 +1,87 @@
+// ABOUTME: Groups consecutive tool_call messages into a single collapsible block.
+// ABOUTME: tool_result rows render as null in chat, so they don't break a run of tool_calls.
+
+import type { ToolCallEvent } from "@/services/providers";
+import type { ToolCallData, UnifiedMessage } from "@/types/conversation";
+
+export type GroupedMessage =
+  | { type: "single"; message: UnifiedMessage }
+  | {
+      type: "tool_group";
+      /**
+       * Stable identity for this group across regroup remounts (#1748).
+       * Derived from the first tool call's id so per-group UI state
+       * (expand/Tail) survives the rebuild.
+       */
+      id: string;
+      messages: UnifiedMessage[];
+      toolCalls: ToolCallEvent[];
+    };
+
+/** Threshold at or above which consecutive tool calls collapse into a group. */
+export const TOOL_GROUP_THRESHOLD = 3;
+
+/** Map orchestrator ToolCallData to the ToolCallEvent shape ToolCallCard expects. */
+export function toToolCallEvent(data: ToolCallData): ToolCallEvent {
+  let params: Record<string, unknown> | undefined = data.parameters;
+  if (!params && data.arguments) {
+    try {
+      params = JSON.parse(data.arguments);
+    } catch {
+      /* non-JSON arguments — skip */
+    }
+  }
+  return {
+    sessionId: "",
+    toolCallId: data.toolCallId,
+    title: data.title || data.name || "Tool",
+    kind: data.kind,
+    status: data.status,
+    parameters: params,
+    result: data.isError ? undefined : data.result,
+    error: data.isError ? data.result : undefined,
+  };
+}
+
+function flushToolGroup(group: UnifiedMessage[], out: GroupedMessage[]): void {
+  if (group.length === 0) return;
+  if (group.length >= TOOL_GROUP_THRESHOLD) {
+    const toolCalls = group
+      .filter((m) => m.toolCall)
+      .map((m) => toToolCallEvent(m.toolCall as ToolCallData));
+    const id = toolCalls[0]?.toolCallId ?? group[0].id;
+    out.push({ type: "tool_group", id, messages: group, toolCalls });
+  } else {
+    for (const msg of group) {
+      out.push({ type: "single", message: msg });
+    }
+  }
+}
+
+/**
+ * Group consecutive tool_call messages into collapsed groups. tool_result
+ * messages are transparent here — they render as null in the chat surface
+ * (the result is already embedded in the matching tool_call row), so they
+ * must not break a consecutive run of tool calls. Without this, a turn of
+ * N shell commands renders as N expanded rows because each tool_result
+ * flushes a partial group below the threshold. See #1913.
+ */
+export function groupConsecutiveToolCalls(
+  messages: UnifiedMessage[],
+): GroupedMessage[] {
+  const grouped: GroupedMessage[] = [];
+  let currentGroup: UnifiedMessage[] = [];
+
+  for (const message of messages) {
+    if (message.type === "tool_call" && message.toolCall) {
+      currentGroup.push(message);
+    } else if (message.type !== "tool_result") {
+      flushToolGroup(currentGroup, grouped);
+      currentGroup = [];
+      grouped.push({ type: "single", message });
+    }
+  }
+  flushToolGroup(currentGroup, grouped);
+
+  return grouped;
+}

--- a/tests/unit/group-tool-calls.test.ts
+++ b/tests/unit/group-tool-calls.test.ts
@@ -1,0 +1,121 @@
+// ABOUTME: Pins Seren Chat tool-call collapse — tool_result must not break runs.
+// ABOUTME: Regression guard for #1913 (every shell command rendered as its own row).
+
+import { describe, expect, it } from "vitest";
+import { groupConsecutiveToolCalls } from "@/lib/group-tool-calls";
+import type {
+  MessageStatus,
+  ToolCallData,
+  UnifiedMessage,
+} from "@/types/conversation";
+
+function toolCall(id: string, command: string): UnifiedMessage {
+  const toolCall: ToolCallData = {
+    toolCallId: id,
+    title: "Bash",
+    kind: "bash",
+    status: "completed",
+    parameters: { command },
+  };
+  return {
+    id,
+    type: "tool_call",
+    role: "assistant",
+    content: "",
+    timestamp: 0,
+    status: "complete" as MessageStatus,
+    toolCallId: id,
+    toolCall,
+  };
+}
+
+function toolResult(id: string, content: string): UnifiedMessage {
+  return {
+    id: `${id}-result`,
+    type: "tool_result",
+    role: "assistant",
+    content,
+    timestamp: 0,
+    status: "complete" as MessageStatus,
+    toolCallId: id,
+  };
+}
+
+function assistantText(id: string, content: string): UnifiedMessage {
+  return {
+    id,
+    type: "assistant",
+    role: "assistant",
+    content,
+    timestamp: 0,
+    status: "complete" as MessageStatus,
+  };
+}
+
+describe("groupConsecutiveToolCalls", () => {
+  it("groups 3+ tool_calls even when tool_result rows are interleaved (#1913)", () => {
+    // What the orchestrator actually produces: tool_call → tool_result → ...
+    const messages: UnifiedMessage[] = [
+      toolCall("a", "ls"),
+      toolResult("a", "file.txt"),
+      toolCall("b", "pwd"),
+      toolResult("b", "/home"),
+      toolCall("c", "whoami"),
+      toolResult("c", "taariq"),
+    ];
+
+    const out = groupConsecutiveToolCalls(messages);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("tool_group");
+    if (out[0].type === "tool_group") {
+      expect(out[0].toolCalls).toHaveLength(3);
+      expect(out[0].id).toBe("a");
+    }
+  });
+
+  it("keeps fewer-than-threshold tool_calls as singles", () => {
+    const messages: UnifiedMessage[] = [
+      toolCall("a", "ls"),
+      toolResult("a", "file.txt"),
+      toolCall("b", "pwd"),
+      toolResult("b", "/home"),
+    ];
+
+    const out = groupConsecutiveToolCalls(messages);
+
+    expect(out.map((g) => g.type)).toEqual(["single", "single"]);
+  });
+
+  it("assistant text between tool_calls breaks the group", () => {
+    // Regression guard: tool_result is transparent, but real assistant text
+    // must still partition consecutive tool runs.
+    const messages: UnifiedMessage[] = [
+      toolCall("a", "ls"),
+      toolResult("a", "file.txt"),
+      toolCall("b", "pwd"),
+      toolResult("b", "/home"),
+      assistantText("text", "Let me think about this..."),
+      toolCall("c", "whoami"),
+      toolResult("c", "taariq"),
+      toolCall("d", "uname"),
+      toolResult("d", "darwin"),
+      toolCall("e", "echo hi"),
+      toolResult("e", "hi"),
+    ];
+
+    const out = groupConsecutiveToolCalls(messages);
+
+    // First two tool_calls (below threshold) → 2 singles, then the assistant
+    // text → 1 single, then the trailing 3 tool_calls → 1 group.
+    expect(out.map((g) => g.type)).toEqual([
+      "single",
+      "single",
+      "single",
+      "tool_group",
+    ]);
+    if (out[3].type === "tool_group") {
+      expect(out[3].toolCalls).toHaveLength(3);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Seren Chat now collapses consecutive shell tool calls into a single `ToolCallGroup` with a chevron, matching Agent Chat.
- Root cause: `groupConsecutiveToolCalls` (ChatContent.tsx) treated `tool_result` rows as group-breakers, so the >=3 threshold never fired in a normal `tool_call → tool_result → tool_call → ...` stream from the orchestrator. Fix: skip `tool_result` in the loop. The result data is already embedded in the matching `tool_call.result` (`services/orchestrator.ts:677-682`), and ChatContent renders `tool_result` rows as `null` downstream.
- Algorithm extracted to `src/lib/group-tool-calls.ts` so it is testable and shared.

## Why this is not a UI test

`groupConsecutiveToolCalls` is a pure data transform — input array → grouped output, no IO, no async, no SolidJS reactivity. Per CLAUDE.md "complex algorithms" qualify for TDD; the rendering itself is unchanged.

## Test plan

- [x] `tests/unit/group-tool-calls.test.ts` — 3 critical-only tests:
  - 3+ `tool_call`/`tool_result` pairs → 1 `tool_group` (pins the bug)
  - 2 pairs → 2 singles (threshold preserved)
  - assistant text between runs → text still breaks groups (regression guard)
- [x] Full Vitest suite: 1115/1115 pass
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec biome check` clean on changed files
- [ ] Manual: re-run a multi-step shell skill in Seren Chat after merge

## Out of scope

- Agent Chat (uses a different message union, already collapses correctly).
- EmployeeRunDetailModal event log.
- Individual ToolCallCard default-collapse state (already collapsed by default).

Closes #1913

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
