### PR TITLE
fix(sidebar): close #1915 — surface active indicator for chat threads

### DIFF
--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -279,19 +279,28 @@ export const threadStore = {
    * from agentStore into a single unified list.
    */
   get threads(): Thread[] {
-    // Chat conversations -> Thread
+    // Chat conversations -> Thread. A chat is "running" while the
+    // orchestrator is waiting on the model (loading[id]) or streaming
+    // tokens back (streamingContent[id] non-empty). The sidebar's green
+    // active dot keys off `status === "running"`, so this is what
+    // surfaces it for Seren chat and Private chat. (#1915)
     const chatThreads: Thread[] = conversationStore.conversations
       .filter((c) => !c.isArchived)
-      .map((c) => ({
-        id: c.id,
-        title: c.title,
-        kind: "chat" as const,
-        status: "idle" as ThreadStatus,
-        projectRoot: c.projectRoot,
-        employeeId: c.employeeId,
-        timestamp: c.createdAt,
-        isLive: false,
-      }));
+      .map((c) => {
+        const isActive =
+          conversationStore.getLoadingFor(c.id) ||
+          conversationStore.getStreamingContentFor(c.id) !== "";
+        return {
+          id: c.id,
+          title: c.title,
+          kind: "chat" as const,
+          status: (isActive ? "running" : "idle") as ThreadStatus,
+          projectRoot: c.projectRoot,
+          employeeId: c.employeeId,
+          timestamp: c.createdAt,
+          isLive: isActive,
+        };
+      });
 
     // Agent conversations -> Thread
     const agentThreads: Thread[] = agentStore.recentAgentConversations

--- a/tests/unit/thread-store.test.ts
+++ b/tests/unit/thread-store.test.ts
@@ -44,6 +44,8 @@ const mockConversations = {
     isArchived: boolean;
   }>,
   activeConversationId: null as string | null,
+  streamingContent: {} as Record<string, string>,
+  loading: {} as Record<string, boolean>,
 };
 
 vi.mock("@/stores/conversation.store", () => ({
@@ -54,6 +56,10 @@ vi.mock("@/stores/conversation.store", () => ({
     get activeConversationId() {
       return mockConversations.activeConversationId;
     },
+    getStreamingContentFor: (id: string) =>
+      mockConversations.streamingContent[id] ?? "",
+    getLoadingFor: (id: string) =>
+      mockConversations.loading[id] ?? false,
     setActiveConversation: vi.fn((id: string | null) => {
       mockConversations.activeConversationId = id;
     }),
@@ -155,6 +161,8 @@ describe("threadStore", () => {
     // Reset mock state
     mockConversations.conversations = [];
     mockConversations.activeConversationId = null;
+    mockConversations.streamingContent = {};
+    mockConversations.loading = {};
     mockFileTreeState.rootPath = "/Users/dev/project-a";
     Object.keys(mockSessions).forEach((k) => delete mockSessions[k]);
     mockAgentConversations.length = 0;
@@ -262,6 +270,51 @@ describe("threadStore", () => {
       const threads = threadStore.threads;
       expect(threads[0].status).toBe("running");
       expect(threads[0].isLive).toBe(true);
+    });
+
+    // #1915 — Seren chat and Private chat threads must surface the same
+    // green active indicator as agent threads. The sidebar renders the
+    // indicator whenever `thread.status === "running"`, so chat threads
+    // need to map streaming/loading state from conversationStore into
+    // `status` instead of being hardcoded as idle.
+    it("reflects streaming/loading state for chat threads", () => {
+      mockConversations.conversations = [
+        {
+          id: "chat-streaming",
+          title: "Streaming chat",
+          createdAt: 3000,
+          selectedModel: "test",
+          selectedProvider: "seren",
+          projectRoot: null,
+          isArchived: false,
+        },
+        {
+          id: "chat-loading",
+          title: "Private chat waiting for first token",
+          createdAt: 2000,
+          selectedModel: "test",
+          selectedProvider: "seren-private",
+          projectRoot: null,
+          isArchived: false,
+        },
+        {
+          id: "chat-idle",
+          title: "Idle chat",
+          createdAt: 1000,
+          selectedModel: "test",
+          selectedProvider: "seren",
+          projectRoot: null,
+          isArchived: false,
+        },
+      ];
+      mockConversations.streamingContent["chat-streaming"] = "partial tokens";
+      mockConversations.loading["chat-loading"] = true;
+
+      const threads = threadStore.threads;
+      const byId = new Map(threads.map((t) => [t.id, t]));
+      expect(byId.get("chat-streaming")?.status).toBe("running");
+      expect(byId.get("chat-loading")?.status).toBe("running");
+      expect(byId.get("chat-idle")?.status).toBe("idle");
     });
   });
 


### PR DESCRIPTION
## Summary

- Closes #1915
- Derives chat thread `status` from `conversationStore.getLoadingFor(id)` and `getStreamingContentFor(id)` instead of hardcoding `"idle"`, so the sidebar's green pulsing dot lights up for Seren chat and Private chat threads while a turn is running.
- Private chat shares the same `kind: "chat"` mapping path as Seren chat (it's just a chat created with `provider: "seren-private"`), so the same change covers both.
- The indicator JSX in `ThreadSidebar.tsx` is unchanged — it already keys off `thread.status === "running"`. The bug lived entirely in the store mapping that hid that signal from the indicator.

## Audit

- `setLoading(true)` fires at the start of every chat turn in `src/services/orchestrator.ts:163`. `setLoading(false)` + `finalizeStreaming()` fire at the end (lines 274–276). Together they bracket the full active-turn window.
- Three sidebar indicator sites all consume the same `status === "running"` signal: per-row dot (`ThreadSidebar.tsx:970-979`), project group dot (`861-867`), and collapsed pane dot (`1156-1173`). They all light up automatically after this change.
- `isLive` flips from hardcoded `false` to `isActive` for parity with agent/terminal threads; no other consumer in `src/` reads `isLive`, so the change is observably scoped to the indicator.

## Test plan

- [x] `pnpm vitest run tests/unit/thread-store.test.ts` — 17/17 pass (including the new `reflects streaming/loading state for chat threads`)
- [x] Full unit suite — `1116/1116 tests pass`
- [x] `biome check src/stores/thread.store.ts` — clean
- [x] `tsc --noEmit` — clean
- [ ] Manual smoke: open a Seren chat, send a prompt, verify the row in the sidebar shows the pulsing green dot while streaming and clears when finalized
- [ ] Manual smoke: same for Private chat
