### PR TITLE
feat(mcp): close #1918 — add playwright_get_cookie tool

### DIFF
--- a/mcp-servers/playwright-stealth/README.md
+++ b/mcp-servers/playwright-stealth/README.md
@@ -44,6 +44,7 @@ This MCP server is automatically configured in Seren Desktop. It provides the sa
 - `playwright_reset` - Reset page
 - `playwright_list_browsers` - List all installed browsers available for automation
 - `playwright_set_browser` - Switch to a different installed browser at runtime
+- `playwright_get_cookie` - Read a cookie value (including HttpOnly cookies) from the active page's origin
 
 ## Browser Configuration
 

--- a/mcp-servers/playwright-stealth/src/__tests__/get_cookie.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/get_cookie.test.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Tests for the playwright_get_cookie tool — verifies HttpOnly cookies
+// ABOUTME: are readable via BrowserContext where document.cookie cannot see them.
+
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { closeBrowser, getContext, getPage } from "../browser.js";
+import { getCookie } from "../tools.js";
+
+const ORIGIN = "https://example.test";
+
+async function navigateToOrigin(): Promise<void> {
+  const page = await getPage();
+  await page.route(`${ORIGIN}/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<html><body>ok</body></html>",
+    });
+  });
+  await page.goto(`${ORIGIN}/`);
+}
+
+describe("getCookie", () => {
+  beforeEach(async () => {
+    const ctx = await getContext();
+    await ctx.clearCookies();
+  });
+
+  afterAll(async () => {
+    await closeBrowser();
+  });
+
+  it("returns the value of an HttpOnly cookie scoped to the active origin", async () => {
+    await navigateToOrigin();
+    const ctx = await getContext();
+    await ctx.addCookies([
+      {
+        name: "privy-refresh-token",
+        value: "refresh-token-abc",
+        domain: "example.test",
+        path: "/",
+        httpOnly: true,
+        secure: true,
+        sameSite: "Lax",
+      },
+    ]);
+
+    const result = await getCookie("privy-refresh-token");
+    expect(result).toEqual({ value: "refresh-token-abc" });
+  });
+
+  it("returns { value: null } when no cookie with that name exists", async () => {
+    await navigateToOrigin();
+
+    const result = await getCookie("nonexistent-cookie");
+    expect(result).toEqual({ value: null });
+  });
+});

--- a/mcp-servers/playwright-stealth/src/index.ts
+++ b/mcp-servers/playwright-stealth/src/index.ts
@@ -221,6 +221,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ["browser"],
         },
       },
+      {
+        name: "playwright_get_cookie",
+        description:
+          "Read a cookie value from the current browser context. Works for HttpOnly cookies, which document.cookie / playwright_evaluate cannot see. Returns { value: string | null } — null if no cookie with that name exists for the active page's origin.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "Cookie name to read.",
+            },
+          },
+          required: ["name"],
+        },
+      },
     ],
   };
 });
@@ -288,6 +303,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         break;
       case "playwright_list_browsers":
         result = tools.listBrowsers();
+        break;
+      case "playwright_get_cookie":
+        result = await tools.getCookie(args.name as string);
         break;
       case "playwright_set_browser": {
         const browserArg =

--- a/mcp-servers/playwright-stealth/src/tools.ts
+++ b/mcp-servers/playwright-stealth/src/tools.ts
@@ -40,6 +40,18 @@ export async function evaluate(script: string): Promise<unknown> {
   return await page.evaluate(script);
 }
 
+// page.context().cookies() reads from the BrowserContext server-side, so
+// HttpOnly cookies are visible — unlike document.cookie / page.evaluate
+// which only see JS-readable cookies.
+export async function getCookie(
+  name: string,
+): Promise<{ value: string | null }> {
+  const page = await getPage();
+  const cookies = await page.context().cookies(page.url());
+  const match = cookies.find((c) => c.name === name);
+  return { value: match ? match.value : null };
+}
+
 export async function extractContent(selector?: string): Promise<string> {
   const page = await getPage();
   if (selector) {


### PR DESCRIPTION
## Summary

- Adds `playwright_get_cookie` tool to the bundled `playwright-stealth` MCP server so HttpOnly cookies (e.g. Privy's `privy-refresh-token`, `privy-token`, `privy-session`) become readable. `document.cookie` / `playwright_evaluate` cannot see HttpOnly cookies; `page.context().cookies()` runs server-side and does.
- Returns `{ value: string | null }`, scoped by the active page's URL so cookies from unrelated origins in the same context do not leak.
- Unblocks the Prophet/Privy OTP cookie-capture step that fails closed with `PrivyAuthFailed: Privy did not set privy-refresh-token cookie` in `seren-skills/prophet/prophet-arb-bot` (parent issue #579).

## Audit

- **Issue confirmed.** `mcp-servers/playwright-stealth/src/index.ts` previously advertised exactly 15 tools; none read cookies. `src/tools.ts` had no cookie path through `BrowserContext`.
- **Fix.** Added `getCookie` in `src/tools.ts` calling `page.context().cookies(page.url())`. Wired into `ListToolsRequestSchema` and the `CallToolRequestSchema` switch in `src/index.ts`. README tool list updated.
- **Impact.** 15 tools to 16 tools. Existing 15 unchanged (all 40 `browser.test.ts` cases still pass). Return shape matches the consumer-side branch already present at `prophet-arb-bot/scripts/otp_worker/playwright_client.py:262-278` (no coordinated release required).

## Test plan

- [x] `npx vitest run` — **42/42 pass** (40 existing + 2 new).
- [x] `npx tsc --noEmit` — clean compile.
- [x] `npm run build` — clean compile; `dist/tools.js` and `dist/index.js` include `getCookie` and `playwright_get_cookie`.
- [x] `npx biome check` on changed files — clean.
- [x] New tests use a real headless browser (no mocks per `CLAUDE.md`) with hermetic `page.route` intercepts; verify HttpOnly cookie reads return the value and missing cookies return `{ value: null }`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
