### PR TITLE
fix(skills): close #1917 — block partial installs from agent prompt

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -860,6 +860,7 @@ pub fn run() {
             skills::list_skill_dirs,
             skills::install_skill,
             skills::validate_skill_payload,
+            skills::log_skill_install_failure,
             skills::rename_skill_dir,
             skills::remove_skill,
             skills::read_skill_content,

--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -833,6 +833,94 @@ pub fn validate_skill_payload(skills_dir: String, slug: String) -> Result<Vec<St
     Ok(missing)
 }
 
+/// Append one JSON line per install/refresh failure to a long-lived log file.
+///
+/// Issue serenorg/seren-desktop#1917: when `validate_skill_payload` reports
+/// missing files post-install, callers used to only log to the in-memory
+/// console. That made silent partial-installs invisible after an app restart
+/// and caused agents to scaffold from scratch (e.g. Windows users hitting
+/// `prophet-arb-bot`). This command writes a durable audit line so the
+/// failure survives the process and can be inspected after the fact.
+///
+/// Schema (one JSON object per line, append-only):
+///   {
+///     "timestamp": "2026-05-15T16:00:00.000Z",
+///     "slug": "<skill slug>",
+///     "phase": "install" | "refresh",
+///     "missingFiles": ["scripts/agent.py", ...]
+///   }
+#[tauri::command]
+pub fn log_skill_install_failure(
+    log_path: String,
+    slug: String,
+    phase: String,
+    missing_files: Vec<String>,
+) -> Result<(), String> {
+    use std::io::Write;
+
+    let path = PathBuf::from(&log_path);
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create log directory: {}", e))?;
+        }
+    }
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("Failed to read clock: {}", e))?;
+    let secs = timestamp.as_secs();
+    let millis = timestamp.subsec_millis();
+    // ISO-8601 (UTC). Hand-formatted so we don't pull in a date crate.
+    let datetime = format_iso8601_utc(secs, millis);
+
+    let entry = serde_json::json!({
+        "timestamp": datetime,
+        "slug": slug,
+        "phase": phase,
+        "missingFiles": missing_files,
+    });
+    let mut line = serde_json::to_string(&entry)
+        .map_err(|e| format!("Failed to serialize log entry: {}", e))?;
+    line.push('\n');
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| format!("Failed to open install log {}: {}", path.display(), e))?;
+    file.write_all(line.as_bytes())
+        .map_err(|e| format!("Failed to write install-log entry: {}", e))?;
+
+    Ok(())
+}
+
+fn format_iso8601_utc(secs: u64, millis: u32) -> String {
+    // Days since 1970-01-01 (UTC). Civil-from-days conversion (Howard Hinnant).
+    const SECS_PER_DAY: u64 = 86_400;
+    let days = (secs / SECS_PER_DAY) as i64;
+    let seconds_in_day = secs % SECS_PER_DAY;
+    let hour = (seconds_in_day / 3600) as u32;
+    let minute = ((seconds_in_day % 3600) / 60) as u32;
+    let second = (seconds_in_day % 60) as u32;
+
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let year = if month <= 2 { y + 1 } else { y };
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        year, month, day, hour, minute, second, millis
+    )
+}
+
 /// Returns true when `path` is a user-provisioned target whose template
 /// sibling (`.example` / `.template` / `.sample`) ships in the bundle.
 /// SKILL.md routinely instructs users to copy the template — flagging the
@@ -1770,5 +1858,114 @@ Run [agent](scripts/agent.py) and read `config.example.json`.
         let payload = list_skill_payload_files(skills_dir, "test-skill".to_string()).unwrap();
         assert_eq!(payload.len(), 1);
         assert_eq!(payload[0].path, "scripts/agent.py");
+    }
+
+    #[test]
+    fn log_skill_install_failure_appends_jsonl_line() {
+        // Critical regression guard for #1917: install/refresh failures must
+        // produce a durable audit line so silent partial-installs are never
+        // invisible. The TS layer calls this after validate_skill_payload
+        // returns missing files; this test pins the on-disk schema.
+        let tmp = TempDir::new().unwrap();
+        let log_path = tmp.path().join("skill-install.log");
+
+        log_skill_install_failure(
+            log_path.to_string_lossy().to_string(),
+            "prophet-arb-bot".to_string(),
+            "install".to_string(),
+            vec![
+                "scripts/agent.py".to_string(),
+                "requirements.txt".to_string(),
+            ],
+        )
+        .unwrap();
+
+        let raw = fs::read_to_string(&log_path).unwrap();
+        let line = raw.trim_end();
+        assert!(!line.is_empty(), "log file should contain one JSONL line");
+
+        let entry: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert_eq!(entry["slug"], "prophet-arb-bot");
+        assert_eq!(entry["phase"], "install");
+        assert_eq!(
+            entry["missingFiles"],
+            serde_json::json!(["scripts/agent.py", "requirements.txt"])
+        );
+        assert!(
+            entry["timestamp"].as_str().is_some(),
+            "timestamp must be an ISO-8601 string, got {:?}",
+            entry["timestamp"]
+        );
+
+        // Append-only: a second call adds a new line, never truncates.
+        log_skill_install_failure(
+            log_path.to_string_lossy().to_string(),
+            "another-skill".to_string(),
+            "refresh".to_string(),
+            vec!["lib/missing.py".to_string()],
+        )
+        .unwrap();
+
+        let after = fs::read_to_string(&log_path).unwrap();
+        assert_eq!(after.lines().count(), 2);
+    }
+
+    #[test]
+    fn install_skill_writes_sync_state_atomically_with_payload() {
+        // Regression guard for #1917: `.seren-sync.json` must land in the
+        // staging directory before the rename, so a partial install can
+        // never produce an active skill dir with payload files but no
+        // sync manifest (or vice versa). The agent's downstream payload
+        // check relies on the manifest matching the on-disk files.
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        fs::create_dir_all(&skills_dir).unwrap();
+
+        let extra_files = serde_json::json!([
+            { "path": "scripts/agent.py", "content": "print('hi')\n" }
+        ])
+        .to_string();
+        let sync_state = serde_json::json!({
+            "version": 1,
+            "upstreamSource": "seren",
+            "upstreamSourceUrl": "seren-skills:prophet-arb-bot",
+            "syncedAt": 1,
+            "managedFiles": { "SKILL.md": "abc" },
+        })
+        .to_string();
+
+        install_skill(
+            skills_dir.to_string_lossy().to_string(),
+            "prophet-arb-bot".to_string(),
+            "# Prophet Arb Bot\n".to_string(),
+            Some(extra_files),
+            Some(sync_state),
+        )
+        .unwrap();
+
+        let active_dir = skills_dir.join("prophet-arb-bot");
+        assert!(active_dir.join("SKILL.md").exists());
+        assert!(active_dir.join("scripts/agent.py").exists());
+        assert!(
+            active_dir.join(".seren-sync.json").exists(),
+            "sync state must land alongside payload in the activated dir"
+        );
+
+        // And the staging dir must be cleaned up — no stray `*.installing.*`
+        // sibling left behind that could fool a future scan.
+        let leftover_staging: Vec<_> = fs::read_dir(&skills_dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .contains(".installing.")
+            })
+            .collect();
+        assert!(
+            leftover_staging.is_empty(),
+            "no .installing.* leftovers expected"
+        );
     }
 }

--- a/src/lib/commands/parser.ts
+++ b/src/lib/commands/parser.ts
@@ -77,6 +77,13 @@ export function matchSkillCommand(
 
   for (const skill of installed) {
     if (!skill.enabled) continue;
+    // Issue #1917 — block invocation of skills whose payload didn't fully
+    // land on disk. Letting the slash command through here would inject the
+    // SKILL.md into the agent's system prompt with the absolute runtime
+    // directory header pointing at an empty directory; the agent would then
+    // scaffold from scratch. Treat failed-payload skills as if they don't
+    // exist; the user sees them in the sidebar with their failure marker.
+    if (skill.payloadStatus === "failed") continue;
     if (skill.slug.toLowerCase() === lower) {
       return { skill, args };
     }
@@ -96,6 +103,9 @@ function searchInstalledSkills(partial: string): SlashCommand[] {
   const results: SlashCommand[] = [];
   for (const skill of installed) {
     if (!skill.enabled) continue;
+    // Hide failed-payload skills from autocomplete so the user can't
+    // accidentally tab-complete into a skill we know we'd block (#1917).
+    if (skill.payloadStatus === "failed") continue;
 
     const slugMatch = skill.slug.toLowerCase().startsWith(partial);
     const nameMatch = skill.name.toLowerCase().startsWith(partial);

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -192,6 +192,17 @@ export interface InstalledSkill extends Skill {
   upstreamSourceUrl?: string;
   /** Persisted sync metadata for upstream-managed files */
   syncState?: SkillSyncState | null;
+  /**
+   * Result of post-install / post-refresh payload validation (#1917).
+   * `'failed'` means SKILL.md references files that are missing from disk
+   * and have no template sibling (`config.example.json`-style). The skill
+   * row is kept in `state.installed` so the user can see it, but slash
+   * commands and system-prompt injection skip it until a successful
+   * refresh moves it back to `'ready'`.
+   */
+  payloadStatus?: "ready" | "failed";
+  /** Files referenced by SKILL.md but missing from disk after install. */
+  missingPayloadFiles?: string[];
 }
 
 /**

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -525,6 +525,98 @@ async function fetchRemoteSkillRevision(
   return remoteRevisionFromBundle(await downloadSkillBundle(slug));
 }
 
+/**
+ * Validate post-install/post-refresh payload files. If any are missing,
+ * (a) append a durable line to the per-scope install log so the failure
+ * survives an app restart, and (b) attempt one silent retry via the
+ * supplied closure (typically a re-fetch + reinstall). Returns the final
+ * status the caller should stamp on the InstalledSkill.
+ *
+ * Issue serenorg/seren-desktop#1917 — closes the race where a partial
+ * install would still get its SKILL.md injected into the agent's system
+ * prompt, causing the agent to scaffold from scratch over an empty dir.
+ */
+async function validateAndRetryInstall(args: {
+  skillsDir: string;
+  slug: string;
+  phase: "install" | "refresh";
+  retry: (() => Promise<boolean | null>) | null;
+}): Promise<{ status: "ready" | "failed"; missingFiles: string[] }> {
+  const { skillsDir, slug, phase, retry } = args;
+  const installLogPath = `${skillsDir.replace(/[/\\]+$/, "")}/.install-log.jsonl`;
+
+  const missing = await validatePayloadSafe(skillsDir, slug);
+  if (missing.length === 0) {
+    return { status: "ready", missingFiles: [] };
+  }
+
+  log.warn(
+    `[Skills] Payload validation failed after ${phase} of ${slug} — missing:`,
+    missing,
+  );
+  await logInstallFailure(installLogPath, slug, phase, missing);
+
+  if (retry) {
+    try {
+      const retried = await retry();
+      if (retried) {
+        const afterRetry = await validatePayloadSafe(skillsDir, slug);
+        if (afterRetry.length === 0) {
+          log.info(`[Skills] Auto-retry recovered ${slug} after ${phase}`);
+          return { status: "ready", missingFiles: [] };
+        }
+        log.warn(
+          `[Skills] Auto-retry of ${slug} (${phase}) still missing:`,
+          afterRetry,
+        );
+        await logInstallFailure(installLogPath, slug, phase, afterRetry);
+        return { status: "failed", missingFiles: afterRetry };
+      }
+    } catch (error) {
+      log.warn(`[Skills] Auto-retry of ${slug} (${phase}) threw:`, error);
+    }
+  }
+
+  return { status: "failed", missingFiles: missing };
+}
+
+async function validatePayloadSafe(
+  skillsDir: string,
+  slug: string,
+): Promise<string[]> {
+  if (!isTauriRuntime()) return [];
+  try {
+    return await invoke<string[]>("validate_skill_payload", {
+      skillsDir,
+      slug,
+    });
+  } catch (error) {
+    log.warn("[Skills] validate_skill_payload threw:", error);
+    return [];
+  }
+}
+
+async function logInstallFailure(
+  logPath: string,
+  slug: string,
+  phase: "install" | "refresh",
+  missingFiles: string[],
+): Promise<void> {
+  if (!isTauriRuntime()) return;
+  try {
+    await invoke("log_skill_install_failure", {
+      logPath,
+      slug,
+      phase,
+      missingFiles,
+    });
+  } catch (error) {
+    // Logging failure must never bubble — it would mask the real install
+    // error we are trying to record.
+    log.warn("[Skills] log_skill_install_failure threw:", error);
+  }
+}
+
 async function fetchUpstreamSkillBundle(skill: {
   sourceUrl?: string;
   slug?: string;
@@ -1083,26 +1175,33 @@ export const skills = {
 
     log.info("[Skills] Installed skill:", skill.slug, "to", scope, "scope");
 
-    // Validate payload after install
-    try {
-      const missingFiles = await invoke<string[]>("validate_skill_payload", {
-        skillsDir,
-        slug: skill.slug,
-      });
-      if (missingFiles.length > 0) {
-        // These are user-provisioned files (requirements.txt, config.json, etc.)
-        // referenced in the SKILL.md but not included in the marketplace payload.
-        // Demote to debug — absence is expected and not an install failure.
-        log.debug(
-          "[Skills] Skill",
-          skill.slug,
-          "references files not present in payload (user must provision):",
-          missingFiles,
-        );
-      }
-    } catch (error) {
-      log.warn("[Skills] Payload validation failed:", error);
-    }
+    // Validate payload after install (#1917). If files are missing on disk
+    // we attempt one silent retry by re-fetching the upstream bundle, then
+    // mark payloadStatus so slash-command + system-prompt callers can skip
+    // the skill until a refresh succeeds.
+    const validation = await validateAndRetryInstall({
+      skillsDir,
+      slug: skill.slug,
+      phase: "install",
+      retry:
+        skill.source === "seren" && skill.sourceUrl
+          ? async () => {
+              const bundle = await fetchUpstreamSkillBundle(skill);
+              if (!bundle) return null;
+              await invoke<string>("install_skill", {
+                skillsDir,
+                slug: skill.slug,
+                content: bundle.skillMd,
+                extraFiles:
+                  bundle.payloadFiles.length > 0
+                    ? JSON.stringify(bundle.payloadFiles)
+                    : null,
+                syncStateJson: syncState ? JSON.stringify(syncState) : null,
+              });
+              return true;
+            }
+          : null,
+    });
 
     return {
       ...skill,
@@ -1118,6 +1217,11 @@ export const skills = {
       upstreamSource: syncState?.upstreamSource,
       upstreamSourceUrl: syncState?.upstreamSourceUrl ?? skill.sourceUrl,
       syncState,
+      payloadStatus: validation.status,
+      missingPayloadFiles:
+        validation.missingFiles.length > 0
+          ? validation.missingFiles
+          : undefined,
       // Override with parsed metadata in case it differs
       name: resolveSkillDisplayName(parsed, skill.slug),
       displayName: parsed.metadata.displayName,
@@ -1364,6 +1468,25 @@ export const skills = {
       syncStateJson: JSON.stringify(syncState),
     });
 
+    const validation = await validateAndRetryInstall({
+      skillsDir: skill.skillsDir,
+      slug: skill.dirName,
+      phase: "refresh",
+      // Refresh already pulled the freshest bundle. A second fetch is unlikely
+      // to recover from a write failure on this machine, so retry with the
+      // same in-memory bundle to ride out a transient fs hiccup.
+      retry: async () => {
+        await invoke<string>("install_skill", {
+          skillsDir: skill.skillsDir,
+          slug: skill.dirName,
+          content: bundle.skillMd,
+          extraFiles: JSON.stringify(bundle.payloadFiles),
+          syncStateJson: JSON.stringify(syncState),
+        });
+        return true;
+      },
+    });
+
     const hash = await computeContentHash(bundle.skillMd);
     const parsed = parseSkillMd(bundle.skillMd);
     const refreshed: InstalledSkill = {
@@ -1375,6 +1498,11 @@ export const skills = {
       upstreamSource: syncState.upstreamSource,
       upstreamSourceUrl: syncState.upstreamSourceUrl,
       syncState,
+      payloadStatus: validation.status,
+      missingPayloadFiles:
+        validation.missingFiles.length > 0
+          ? validation.missingFiles
+          : undefined,
     };
 
     return {

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -518,17 +518,23 @@ export const skillsStore = {
     // including "seren-desktop" is never resolved, even if a stale
     // project config or cached ref still points at it.
     // Spec: serenorg/seren-desktop#1496
+    // Also fail-closed on payload validation (#1917): a skill whose
+    // referenced files didn't make it onto disk must never reach the
+    // agent's system prompt — otherwise the agent ls's the empty
+    // runtime directory and tries to scaffold from scratch.
     if (Array.isArray(refs)) {
-      return this.resolveRefs(refs).filter((skill) =>
-        isSkillCompatibleWithHost(skill),
+      return this.resolveRefs(refs).filter(
+        (skill) =>
+          isSkillCompatibleWithHost(skill) && skill.payloadStatus !== "failed",
       );
     }
 
     // No override yet — fall back to project/global defaults so existing
     // threads don't lose their skills on upgrade. New threads get an
     // explicit empty override when the user first toggles a skill.
-    return this.getProjectSkills(projectRoot).filter((skill) =>
-      isSkillCompatibleWithHost(skill),
+    return this.getProjectSkills(projectRoot).filter(
+      (skill) =>
+        isSkillCompatibleWithHost(skill) && skill.payloadStatus !== "failed",
     );
   },
 

--- a/tests/unit/skill-payload-status.test.ts
+++ b/tests/unit/skill-payload-status.test.ts
@@ -1,0 +1,166 @@
+// ABOUTME: Critical tests for the skill-install race fix (#1917).
+// ABOUTME: Verifies failed-payload skills are filtered from slash-command matching
+// ABOUTME: and from system-prompt injection so the agent never sees a partially-installed skill.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSkillsService = vi.hoisted(() => ({
+  fetchAllSkills: vi.fn().mockResolvedValue([]),
+  fetchOwnedSkills: vi.fn().mockResolvedValue([]),
+  listAllInstalled: vi.fn().mockResolvedValue([]),
+  backfillSyncState: vi.fn().mockResolvedValue(0),
+  inspectSyncStatus: vi.fn().mockResolvedValue({ updateAvailable: false }),
+  refreshInstalledSkill: vi.fn().mockResolvedValue({ installed: {}, syncStatus: null }),
+  isUpstreamManagedSkill: vi.fn().mockReturnValue(false),
+  renameSkillDir: vi.fn().mockResolvedValue("/skills/renamed/SKILL.md"),
+  clearCache: vi.fn(),
+  install: vi.fn(),
+  readProjectConfig: vi.fn().mockResolvedValue(null),
+  writeProjectConfig: vi.fn().mockResolvedValue(undefined),
+  clearProjectConfig: vi.fn().mockResolvedValue(undefined),
+  getThreadSkills: vi.fn().mockResolvedValue(null),
+  setThreadSkills: vi.fn().mockResolvedValue(undefined),
+  clearThreadSkills: vi.fn().mockResolvedValue(undefined),
+  getEnabledSkillsContent: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("solid-js/store", () => ({
+  createStore: <T extends Record<string, unknown>>(initial: T) => {
+    const state = { ...initial } as Record<string, unknown>;
+    const setState = (key: string, value: unknown) => {
+      state[key] = value;
+    };
+    return [state, setState];
+  },
+}));
+
+vi.mock("@/stores/fileTree", () => ({
+  getFileTreeState: () => ({ rootPath: "/test/project" }),
+  get fileTreeState() {
+    return { rootPath: "/test/project" };
+  },
+}));
+
+vi.mock("@/stores/auth.store", () => ({
+  authStore: { isAuthenticated: true },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/services/skills", () => {
+  class SkillsApiError extends Error {
+    status?: number;
+    constructor(message: string, status?: number) {
+      super(message);
+      this.name = "SkillsApiError";
+      this.status = status;
+    }
+  }
+  return {
+    skills: {
+      fetchAllSkills: mockSkillsService.fetchAllSkills,
+      fetchOwnedSkills: mockSkillsService.fetchOwnedSkills,
+      listAllInstalled: mockSkillsService.listAllInstalled,
+      backfillSyncState: mockSkillsService.backfillSyncState,
+      inspectSyncStatus: mockSkillsService.inspectSyncStatus,
+      refreshInstalledSkill: mockSkillsService.refreshInstalledSkill,
+      renameSkillDir: mockSkillsService.renameSkillDir,
+      clearCache: mockSkillsService.clearCache,
+      install: mockSkillsService.install,
+      readProjectConfig: mockSkillsService.readProjectConfig,
+      writeProjectConfig: mockSkillsService.writeProjectConfig,
+      clearProjectConfig: mockSkillsService.clearProjectConfig,
+      getThreadSkills: mockSkillsService.getThreadSkills,
+      setThreadSkills: mockSkillsService.setThreadSkills,
+      clearThreadSkills: mockSkillsService.clearThreadSkills,
+      getEnabledSkillsContent: mockSkillsService.getEnabledSkillsContent,
+    },
+    isUpstreamManagedSkill: mockSkillsService.isUpstreamManagedSkill,
+    SkillsApiError,
+    isAuthStatus: (status: number | undefined) =>
+      status === 401 || status === 403,
+  };
+});
+
+function installedSkill(slug: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `local:${slug}`,
+    slug,
+    name: slug,
+    displayName: slug,
+    description: "",
+    source: "local" as const,
+    tags: [],
+    scope: "seren" as const,
+    skillsDir: "/skills",
+    dirName: slug,
+    path: `/skills/${slug}/SKILL.md`,
+    installedAt: 1,
+    enabled: true,
+    contentHash: "hash",
+    ...overrides,
+  };
+}
+
+describe("skill-install race fix (#1917)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("matchSkillCommand returns null for a skill flagged payloadStatus='failed'", async () => {
+    const failed = installedSkill("prophet-arb-bot", {
+      payloadStatus: "failed",
+      missingPayloadFiles: ["scripts/agent.py"],
+    });
+    mockSkillsService.listAllInstalled.mockResolvedValue([failed]);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refreshInstalled();
+
+    const { matchSkillCommand } = await import("@/lib/commands/parser");
+    const match = matchSkillCommand("/prophet-arb-bot");
+
+    expect(match).toBeNull();
+  });
+
+  it("matchSkillCommand returns the skill normally when payloadStatus is 'ready' or absent", async () => {
+    const ready = installedSkill("prophet-arb-bot", { payloadStatus: "ready" });
+    const legacy = installedSkill("legacy-skill"); // payloadStatus undefined — back-compat
+    mockSkillsService.listAllInstalled.mockResolvedValue([ready, legacy]);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refreshInstalled();
+
+    const { matchSkillCommand } = await import("@/lib/commands/parser");
+
+    expect(matchSkillCommand("/prophet-arb-bot")?.skill.slug).toBe("prophet-arb-bot");
+    expect(matchSkillCommand("/legacy-skill")?.skill.slug).toBe("legacy-skill");
+  });
+
+  it("getThreadSkills filters out skills with payloadStatus='failed' so the system prompt never sees them", async () => {
+    const ready = installedSkill("ready-skill", { payloadStatus: "ready" });
+    const failed = installedSkill("prophet-arb-bot", {
+      payloadStatus: "failed",
+      missingPayloadFiles: ["scripts/agent.py"],
+    });
+    mockSkillsService.listAllInstalled.mockResolvedValue([ready, failed]);
+    mockSkillsService.readProjectConfig.mockResolvedValue({
+      version: 1,
+      skills: { enabled: ["seren:ready-skill", "seren:prophet-arb-bot"] },
+    });
+    mockSkillsService.getThreadSkills.mockResolvedValue(null);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refreshInstalled();
+    await skillsStore.ensureContextLoaded("/test/project", "thread-1");
+
+    const effective = skillsStore.getThreadSkills("/test/project", "thread-1");
+
+    const slugs = effective.map((s) => s.slug);
+    expect(slugs).toContain("ready-skill");
+    expect(slugs).not.toContain("prophet-arb-bot");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1917 — closes the install/invoke race where a Windows install with a silent fs write failure (AV quarantine, MAX_PATH, transient permission) left the rename succeeding but payload files missing, the skill row added to `state.installed`, and the SKILL.md injected into the agent's system prompt with the absolute runtime-directory header. The agent then `ls`'d an empty dir and tried to scaffold from scratch, burning ~$10 of API credit per recurrence (reproduced on v3.35.3, commit `b00be92e`).

## Fix (four touch points per ticket spec)

- **`src-tauri/src/skills.rs`** — `.seren-sync.json` already lands atomically in the staging dir via `write_skill_tree` before the rename; added regression test `install_skill_writes_sync_state_atomically_with_payload` that pins the invariant. New `log_skill_install_failure` Tauri command appends one JSON line per failure to `<skills-dir>/.install-log.jsonl` so the failure survives an app restart (hand-rolled ISO-8601 formatter, no date-crate dependency).
- **`src/services/skills.ts`** — new `validateAndRetryInstall()` helper runs after every install and refresh. Calls `validate_skill_payload`, fires one silent retry (re-fetch upstream bundle on install, re-write same in-memory bundle on refresh), then stamps `payloadStatus: 'ready' | 'failed'` plus `missingPayloadFiles` on the `InstalledSkill` row.
- **`src/stores/skills.store.ts`** — `getThreadSkills` now filters `payloadStatus !== 'failed'` for both thread-override and project-default code paths. `getThreadSkillsContent` inherits the filter transitively.
- **`src/lib/commands/parser.ts`** — `matchSkillCommand` and `searchInstalledSkills` skip failed-payload skills, so `/<slug>` invocation and autocomplete can't reach the agent's system prompt with a broken skill.

The failed row stays in `state.installed` so the user still sees the skill in the sidebar; only invocation and prompt injection are blocked. Existing successful installs are unaffected — `payloadStatus` is optional and absence is treated as ready (back-compat for already-installed skills before this PR).

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib skills::` — 25 skill tests pass, including the two new regression guards.
- [x] `vitest run tests/unit/skill-payload-status.test.ts` — 3 tests pass: matchSkillCommand rejects failed-payload slug, accepts ready/legacy, getThreadSkills filters failed out of effective set.
- [x] `biome check` — clean on all 5 touched files.
- [x] `tsc --noEmit` — clean.
- [ ] Manual: install a skill, delete a payload file from disk, refresh — confirm the skill stays in the sidebar but `/<slug>` is silently rejected and `.install-log.jsonl` gets a line.
- [ ] Manual: confirm `.install-log.jsonl` line schema is parseable and human-readable.

## Related

- serenorg/seren-skills#570 (closed) — original report
- serenorg/seren-skills#577 — active recurrence on v3.35.3 Windows
- #1097 — added the silent refetch path this PR now logs and gates
- #1892 — removed the modal that previously surfaced refetch failures
