### PR TITLE
fix(playwright-stealth): close #1921 — defer browser detection past MCP handshake

### DIFF
--- a/mcp-servers/playwright-stealth/src/__tests__/cold_start.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/cold_start.test.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Regression guard for #1921 — top-level browser detection must not
+// ABOUTME: run at module load, otherwise the MCP stdio handshake stalls and the
+// ABOUTME: prophet-arb-bot Python child times out before `initialize` returns.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("browser.ts cold-start contract (#1921)", () => {
+  let originalBrowserType: string | undefined;
+
+  beforeEach(() => {
+    originalBrowserType = process.env.BROWSER_TYPE;
+    delete process.env.BROWSER_TYPE;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalBrowserType === undefined) {
+      delete process.env.BROWSER_TYPE;
+    } else {
+      process.env.BROWSER_TYPE = originalBrowserType;
+    }
+    vi.resetModules();
+  });
+
+  it("defers BROWSER_TYPE resolution until first getActiveBrowserType() call", async () => {
+    // The bug: browser.ts used to resolve `activeBrowserName` at module-load
+    // time, which synchronously walked Playwright's registry. On a cold macOS
+    // disk that probe can outrun the Python child's MCP-init timeout, so the
+    // server never reaches `server.connect(transport)` and the caller sees
+    // `TimeoutError: Timed out waiting for response from playwright-stealth MCP`.
+    //
+    // This test pins the lazy contract: setting BROWSER_TYPE *after* import
+    // must still propagate, which is only true when resolution happens on the
+    // first getter call rather than at module init.
+    const browserModule = await import("../browser.js");
+    process.env.BROWSER_TYPE = "msedge";
+
+    expect(browserModule.getActiveBrowserType()).toBe("msedge");
+  });
+});

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -285,7 +285,11 @@ export async function launchBrowserWithFallback(
 
 // ── State ──────────────────────────────────────────────────────────────────────
 
-let activeBrowserName: string = parseBrowserType(process.env.BROWSER_TYPE);
+// Lazy: eager resolution synchronously walked Playwright's registry at module
+// load, and a slow cold-disk probe could outrun the MCP stdio `initialize`
+// handshake — leaving the prophet-arb-bot Python child stuck on
+// `blocked_auth_unexpected:TimeoutError`. Resolve on first read instead (#1921).
+let activeBrowserName: string | null = null;
 let browser: Browser | null = null;
 let context: BrowserContext | null = null;
 let page: Page | null = null;
@@ -294,6 +298,9 @@ let stealthApplied = false;
 // ── Public API ─────────────────────────────────────────────────────────────────
 
 export function getActiveBrowserType(): string {
+  if (activeBrowserName === null) {
+    activeBrowserName = parseBrowserType(process.env.BROWSER_TYPE);
+  }
   return activeBrowserName;
 }
 
@@ -346,7 +353,7 @@ export async function getBrowser(): Promise<Browser> {
 
     try {
       const launched = await launchBrowserWithFallback(
-        activeBrowserName,
+        getActiveBrowserType(),
         installed,
         async (browserName, engine, launchOptions) => {
           if (isChromiumBased(engine) && !stealthApplied) {
@@ -375,7 +382,7 @@ export async function getBrowser(): Promise<Browser> {
 export async function getContext(): Promise<BrowserContext> {
   if (!context) {
     const b = await getBrowser();
-    const engine = resolveBrowserName(activeBrowserName);
+    const engine = resolveBrowserName(getActiveBrowserType());
     context = await b.newContext({
       userAgent: DEFAULT_USER_AGENTS[engine],
       viewport: { width: 1920, height: 1080 },
@@ -391,7 +398,7 @@ export async function getPage(): Promise<Page> {
     const ctx = await getContext();
     page = await ctx.newPage();
 
-    const engine = resolveBrowserName(activeBrowserName);
+    const engine = resolveBrowserName(getActiveBrowserType());
     if (isChromiumBased(engine)) {
       await page.addInitScript(() => {
         Object.defineProperty(navigator, "webdriver", {

--- a/mcp-servers/playwright-stealth/src/index.ts
+++ b/mcp-servers/playwright-stealth/src/index.ts
@@ -353,11 +353,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 async function main() {
-  console.error(
-    `[playwright-stealth] Starting with browser: ${getActiveBrowserType()}`,
-  );
+  // Connect stdio first so the MCP `initialize` handshake can resolve before
+  // any browser detection happens. `getActiveBrowserType()` lazily walks
+  // Playwright's registry — a slow probe was timing out the prophet-arb-bot
+  // Python child on cold start (#1921).
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  console.error(
+    `[playwright-stealth] Stdio transport ready; default browser: ${getActiveBrowserType()}`,
+  );
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary

Closes #1921 — prophet-arb-bot cold start used to fail with `blocked_auth_unexpected:TimeoutError:Timed out waiting for response from playwright-stealth MCP` because the bundled MCP server's `browser.ts` ran a synchronous Playwright-registry probe at module load. On a cold macOS disk that probe can outrun the MCP `initialize` handshake window, so the server never reaches `server.connect(transport)` and the Python child sees a transport-level timeout.

Repro confirmed against `~/Downloads/20260515_Prophet_Arb.log` on v3.35.3.

## Fix (two touchpoints, ~15 LOC + 1 regression test)

- **`mcp-servers/playwright-stealth/src/browser.ts`** — switch `activeBrowserName` from eager (`= parseBrowserType(process.env.BROWSER_TYPE)`) to lazy (`: string | null = null`). `getActiveBrowserType()` resolves on first read and caches. Internal callers (`getBrowser`, `getContext`, `getPage`) now go through the getter so they never read the unresolved null directly.
- **`mcp-servers/playwright-stealth/src/index.ts`** — flip `main()` so `await server.connect(transport)` runs before the startup-log line. Otherwise the log's `getActiveBrowserType()` call would force the slow probe *before* the handshake.

`setBrowser()`'s explicit assignment path is unchanged.

## Test plan

- [x] **Regression test (critical)** — `mcp-servers/playwright-stealth/src/__tests__/cold_start.test.ts` sets `process.env.BROWSER_TYPE` **after** importing the module and asserts `getActiveBrowserType()` returns the post-import value. That's only possible when resolution is deferred. Verified the test **fails on main** (`expected 'chromium' to be 'msedge'`) and **passes after the fix**.
- [x] `vitest run` — all 39 non-browser-launch unit tests pass. The 4 pre-existing failures (`detectDefaultBrowser`, `default browser has a valid executablePath`, both `getCookie`) require system browsers / `npx playwright install` and reproduce identically on `main` — unrelated to this change.
- [x] `tsc --noEmit` — clean.
- [x] `biome check` — only a pre-existing `noUnusedFunctionParameters` warning on an unrelated callback param, reproducible on `main`.
- [ ] Manual: cold-start Seren Desktop with a stale Prophet session cache, run `/prophet-arb-bot`, confirm validation reaches `status=ok` or `status=ok_no_fills` instead of `blocked_auth_unexpected:TimeoutError`.

## Related

- #1883 (closed) — fixed Claude CLI's bare-`node` resolution for `--mcp-config`. Complementary; this issue is what happens *after* the spawn succeeds — server module init was stalling the `initialize` response.
- #1276 / #1278 — earlier launch-time browser fixes. Unrelated to module init.
