### PR TITLE
fix(playwright-stealth): close #1923 — speak both stdio framings

### DIFF
--- a/mcp-servers/playwright-stealth/README.md
+++ b/mcp-servers/playwright-stealth/README.md
@@ -173,6 +173,9 @@ Use this server instead of standard Playwright when:
   - `puppeteer-extra-plugin-stealth` - Anti-detection plugin
   - `@modelcontextprotocol/sdk` - MCP protocol implementation
 - **Transport**: stdio (command-line invocation)
+  - Accepts legacy newline-delimited JSON-RPC used by Seren Desktop.
+  - Accepts `Content-Length` framed JSON-RPC used by first-party MCP gateways.
+  - Responses mirror the framing mode used by the caller's request.
 
 ## License
 

--- a/mcp-servers/playwright-stealth/src/__tests__/stdio_framing.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/stdio_framing.test.ts
@@ -1,0 +1,190 @@
+// ABOUTME: End-to-end contract tests for first-party MCP stdio framing modes.
+
+import { spawn, spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+type Child = ReturnType<typeof spawn>;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, "../..");
+const serverPath = path.join(packageRoot, "dist", "index.js");
+const tscPath = path.join(packageRoot, "node_modules", "typescript", "bin", "tsc");
+
+const initializeRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: {
+      name: "stdio-framing-test",
+      version: "1.0.0",
+    },
+  },
+};
+
+const children = new Set<Child>();
+
+function buildServer(): void {
+  const result = spawnSync(process.execPath, [tscPath], {
+    cwd: packageRoot,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to build playwright-stealth MCP server.\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+}
+
+function startServer(): { child: Child; stderr: string[] } {
+  const stderr: string[] = [];
+  const child = spawn(process.execPath, [serverPath], {
+    cwd: packageRoot,
+    env: {
+      ...process.env,
+      BROWSER_TYPE: "chrome",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  children.add(child);
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr.push(chunk.toString("utf8"));
+  });
+
+  return { child, stderr };
+}
+
+function stopServer(child: Child): void {
+  children.delete(child);
+  if (!child.killed) {
+    child.kill("SIGTERM");
+  }
+}
+
+function waitForStdout(
+  child: Child,
+  stderr: string[],
+  predicate: (buffer: Buffer) => unknown,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let stdout = Buffer.alloc(0);
+    const timeout = setTimeout(() => {
+      reject(
+        new Error(
+          `Timed out waiting for MCP response.\nstdout:\n${stdout.toString("utf8")}\nstderr:\n${stderr.join("")}`,
+        ),
+      );
+    }, 5000);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout = Buffer.concat([stdout, chunk]);
+      const result = predicate(stdout);
+      if (result) {
+        clearTimeout(timeout);
+        resolve(result);
+      }
+    });
+
+    child.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      reject(
+        new Error(
+          `MCP server exited before response (code=${code}, signal=${signal}).\nstderr:\n${stderr.join("")}`,
+        ),
+      );
+    });
+  });
+}
+
+function parseLineResponse(buffer: Buffer): unknown | null {
+  const lineEnd = buffer.indexOf("\n");
+  if (lineEnd === -1) {
+    return null;
+  }
+
+  return JSON.parse(buffer.toString("utf8", 0, lineEnd));
+}
+
+function parseContentLengthResponse(buffer: Buffer): unknown | null {
+  const headerEnd = buffer.indexOf("\r\n\r\n");
+  if (headerEnd === -1) {
+    return null;
+  }
+
+  const headers = buffer.toString("utf8", 0, headerEnd);
+  const match = headers.match(/(?:^|\r\n)Content-Length:\s*(\d+)(?:\r\n|$)/i);
+  if (!match) {
+    throw new Error(`Missing Content-Length header in response: ${headers}`);
+  }
+
+  const bodyStart = headerEnd + 4;
+  const bodyEnd = bodyStart + Number(match[1]);
+  if (buffer.length < bodyEnd) {
+    return null;
+  }
+
+  return JSON.parse(buffer.toString("utf8", bodyStart, bodyEnd));
+}
+
+beforeAll(buildServer);
+
+afterEach(() => {
+  for (const child of children) {
+    stopServer(child);
+  }
+});
+
+describe("playwright-stealth MCP stdio framing", () => {
+  it("returns a Content-Length initialize response for the Prophet gateway framing", async () => {
+    const { child, stderr } = startServer();
+    const responsePromise = waitForStdout(
+      child,
+      stderr,
+      parseContentLengthResponse,
+    );
+    const body = JSON.stringify(initializeRequest);
+
+    child.stdin?.write(
+      `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`,
+    );
+
+    const response = await responsePromise;
+    expect(response).toMatchObject({
+      jsonrpc: "2.0",
+      id: initializeRequest.id,
+      result: {
+        protocolVersion: "2024-11-05",
+        serverInfo: {
+          name: "playwright-stealth",
+          version: "1.0.0",
+        },
+      },
+    });
+  });
+
+  it("keeps newline-delimited initialize responses for the Desktop MCP client", async () => {
+    const { child, stderr } = startServer();
+    const responsePromise = waitForStdout(child, stderr, parseLineResponse);
+
+    child.stdin?.write(`${JSON.stringify(initializeRequest)}\n`);
+
+    const response = await responsePromise;
+    expect(response).toMatchObject({
+      jsonrpc: "2.0",
+      id: initializeRequest.id,
+      result: {
+        protocolVersion: "2024-11-05",
+        serverInfo: {
+          name: "playwright-stealth",
+          version: "1.0.0",
+        },
+      },
+    });
+  });
+});

--- a/mcp-servers/playwright-stealth/src/dual_stdio_transport.ts
+++ b/mcp-servers/playwright-stealth/src/dual_stdio_transport.ts
@@ -1,0 +1,227 @@
+// ABOUTME: Stdio MCP transport that accepts both legacy newline JSON-RPC and
+// ABOUTME: Content-Length framed JSON-RPC used by newer first-party callers.
+
+import process from "node:process";
+import type { Readable, Writable } from "node:stream";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  JSONRPCMessageSchema,
+  type JSONRPCMessage,
+} from "@modelcontextprotocol/sdk/types.js";
+
+type FramingMode = "line" | "content-length";
+
+type HeaderBoundary = {
+  index: number;
+  length: number;
+};
+
+type ParsedMessage = {
+  message: JSONRPCMessage;
+  framing: FramingMode;
+};
+
+const CONTENT_LENGTH_PREFIX = "content-length:";
+
+function parseMessage(json: string): JSONRPCMessage {
+  return JSONRPCMessageSchema.parse(JSON.parse(json));
+}
+
+function findHeaderBoundary(buffer: Buffer): HeaderBoundary | null {
+  const crlf = buffer.indexOf("\r\n\r\n");
+  const lf = buffer.indexOf("\n\n");
+
+  if (crlf === -1 && lf === -1) {
+    return null;
+  }
+
+  if (crlf !== -1 && (lf === -1 || crlf < lf)) {
+    return { index: crlf, length: 4 };
+  }
+
+  return { index: lf, length: 2 };
+}
+
+function extractContentLength(headers: string): number | null {
+  const match = headers.match(/(?:^|\r?\n)content-length:\s*(\d+)\s*(?:\r?\n|$)/i);
+  if (!match) {
+    return null;
+  }
+
+  const length = Number(match[1]);
+  return Number.isSafeInteger(length) && length >= 0 ? length : null;
+}
+
+function mayBeContentLengthHeader(buffer: Buffer): boolean {
+  const prefix = buffer
+    .subarray(0, Math.min(buffer.length, CONTENT_LENGTH_PREFIX.length))
+    .toString("utf8")
+    .toLowerCase();
+
+  return (
+    prefix.startsWith(CONTENT_LENGTH_PREFIX) ||
+    CONTENT_LENGTH_PREFIX.startsWith(prefix)
+  );
+}
+
+function serializeLineMessage(message: JSONRPCMessage): string {
+  return `${JSON.stringify(message)}\n`;
+}
+
+function serializeContentLengthMessage(message: JSONRPCMessage): string {
+  const json = JSON.stringify(message);
+  return `Content-Length: ${Buffer.byteLength(json, "utf8")}\r\n\r\n${json}`;
+}
+
+/**
+ * The MCP SDK version currently bundled here only supports newline-delimited
+ * stdio messages. Seren Desktop still uses that legacy framing, while the
+ * Prophet skill's Python gateway speaks the newer Content-Length framing. This
+ * transport accepts either form and mirrors the response framing used by the
+ * caller that initialized the process.
+ */
+export class DualStdioServerTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  private buffer?: Buffer;
+  private responseFraming: FramingMode = "line";
+  private started = false;
+
+  private readonly onData = (chunk: Buffer) => {
+    this.buffer = this.buffer ? Buffer.concat([this.buffer, chunk]) : chunk;
+    this.processReadBuffer();
+  };
+
+  private readonly onError = (error: Error) => {
+    this.onerror?.(error);
+  };
+
+  constructor(
+    private readonly stdin: Readable = process.stdin,
+    private readonly stdout: Writable = process.stdout,
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.started) {
+      throw new Error(
+        "DualStdioServerTransport already started! If using Server class, note that connect() calls start() automatically.",
+      );
+    }
+
+    this.started = true;
+    this.stdin.on("data", this.onData);
+    this.stdin.on("error", this.onError);
+  }
+
+  async close(): Promise<void> {
+    this.stdin.off("data", this.onData);
+    this.stdin.off("error", this.onError);
+    this.buffer = undefined;
+    this.onclose?.();
+  }
+
+  send(message: JSONRPCMessage): Promise<void> {
+    return new Promise((resolve) => {
+      const payload =
+        this.responseFraming === "content-length"
+          ? serializeContentLengthMessage(message)
+          : serializeLineMessage(message);
+
+      if (this.stdout.write(payload)) {
+        resolve();
+      } else {
+        this.stdout.once("drain", resolve);
+      }
+    });
+  }
+
+  private processReadBuffer(): void {
+    while (true) {
+      try {
+        const parsed = this.readMessage();
+        if (parsed === null) {
+          break;
+        }
+
+        this.responseFraming = parsed.framing;
+        this.onmessage?.(parsed.message);
+      } catch (error) {
+        this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+  }
+
+  private readMessage(): ParsedMessage | null {
+    if (!this.buffer || this.buffer.length === 0) {
+      return null;
+    }
+
+    if (mayBeContentLengthHeader(this.buffer)) {
+      return this.readContentLengthMessage();
+    }
+
+    return this.readLineMessage();
+  }
+
+  private readContentLengthMessage(): ParsedMessage | null {
+    if (!this.buffer) {
+      return null;
+    }
+
+    const boundary = findHeaderBoundary(this.buffer);
+    if (!boundary) {
+      return null;
+    }
+
+    const headers = this.buffer.toString("utf8", 0, boundary.index);
+    const contentLength = extractContentLength(headers);
+    if (contentLength === null) {
+      this.buffer = this.buffer.subarray(boundary.index + boundary.length);
+      throw new Error("Invalid MCP stdio frame: missing valid Content-Length header");
+    }
+
+    const bodyStart = boundary.index + boundary.length;
+    const bodyEnd = bodyStart + contentLength;
+    if (this.buffer.length < bodyEnd) {
+      return null;
+    }
+
+    const body = this.buffer.toString("utf8", bodyStart, bodyEnd);
+    this.buffer = this.buffer.subarray(bodyEnd);
+
+    return {
+      message: parseMessage(body),
+      framing: "content-length",
+    };
+  }
+
+  private readLineMessage(): ParsedMessage | null {
+    if (!this.buffer) {
+      return null;
+    }
+
+    while (this.buffer.length > 0) {
+      const lineEnd = this.buffer.indexOf("\n");
+      if (lineEnd === -1) {
+        return null;
+      }
+
+      const rawLine = this.buffer.toString("utf8", 0, lineEnd);
+      this.buffer = this.buffer.subarray(lineEnd + 1);
+      const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+
+      if (line.trim().length === 0) {
+        continue;
+      }
+
+      return {
+        message: parseMessage(line),
+        framing: "line",
+      };
+    }
+
+    return null;
+  }
+}

--- a/mcp-servers/playwright-stealth/src/index.ts
+++ b/mcp-servers/playwright-stealth/src/index.ts
@@ -3,12 +3,12 @@
 // ABOUTME: MCP server entry point for Playwright stealth browser automation
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { getActiveBrowserType } from "./browser.js";
+import { DualStdioServerTransport } from "./dual_stdio_transport.js";
 import * as tools from "./tools.js";
 
 const server = new Server(
@@ -357,10 +357,10 @@ async function main() {
   // any browser detection happens. `getActiveBrowserType()` lazily walks
   // Playwright's registry — a slow probe was timing out the prophet-arb-bot
   // Python child on cold start (#1921).
-  const transport = new StdioServerTransport();
+  const transport = new DualStdioServerTransport();
   await server.connect(transport);
   console.error(
-    `[playwright-stealth] Stdio transport ready; default browser: ${getActiveBrowserType()}`,
+    `[playwright-stealth] Stdio transport ready; framing: line-jsonrpc, content-length; default browser: ${getActiveBrowserType()}`,
   );
 }
 


### PR DESCRIPTION
## Summary
- The packaged `playwright-stealth` MCP server only spoke newline-delimited JSON-RPC. The `prophet-arb-bot` Python gateway frames requests with `Content-Length`, so initialize timed out even though the binary was alive (issue #1923).
- Replace `StdioServerTransport` with a new `DualStdioServerTransport` that detects the caller's framing on the first read and mirrors the response in the same framing.
- Add an end-to-end contract test that spawns the built server and asserts both framings return a valid `initialize` response.

## Test plan
- [x] `cd mcp-servers/playwright-stealth && npm test` — 45 tests pass (4 suites, including the 2 new stdio framing tests).
- [x] `cd mcp-servers/playwright-stealth && npx tsc --noEmit` — clean type-check.
- [ ] Repro on packaged Desktop binary at `/Applications/SerenDesktop.app/.../playwright-stealth/dist/index.js` after the next release that picks up this build.

Closes #1923.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
