### PR TITLE
fix(orchestrator): close #1930 — propagate context between subtasks

### DIFF
--- a/src-tauri/src/orchestrator/decomposer.rs
+++ b/src-tauri/src/orchestrator/decomposer.rs
@@ -70,24 +70,85 @@ pub fn decompose(
 // Numbered List Detection
 // =============================================================================
 
+/// Maximum number of numbered items that may be split into separate subtasks.
+/// Lists longer than this are almost always narrative or an Objective block
+/// shipped alongside surrounding prose; decomposing them shreds intent.
+const MAX_NUMBERED_LIST_ITEMS: usize = 4;
+
+/// Maximum number of non-numbered non-empty lines tolerated as preamble before
+/// the first numbered item. Anything beyond this means the list is embedded in
+/// prose, not the entire instruction.
+const MAX_NUMBERED_LIST_PREAMBLE_LINES: usize = 2;
+
+/// Pronoun-style references that signal an item depends on surrounding prose.
+const NUMBERED_LIST_PRONOUNS: &[&str] = &[
+    "it",
+    "its",
+    "they",
+    "them",
+    "their",
+    "this",
+    "that",
+    "these",
+    "those",
+    "above",
+    "below",
+];
+
 /// Detect numbered list items (e.g. "1. Do X\n2. Do Y\n3. Do Z").
 ///
 /// Each numbered item becomes a sequential sub-task depending on the previous one.
+///
+/// To prevent prose containing a numbered block from being shredded into N
+/// independent subtasks (see GH #1930), the list must structurally dominate the
+/// prompt:
+///   - 2-4 numbered items (lists longer than this are narrative, not actions).
+///   - At most a short preamble heading before the first item.
+///   - No trailing prose after the last item.
+///   - Each item must be verb-initial (an actionable imperative).
+///   - No item may reference surrounding context via pronouns ("it", "above").
 fn try_numbered_list(prompt: &str, skills: &[SkillRef]) -> Option<Vec<SubTask>> {
     let mut items: Vec<String> = Vec::new();
+    let mut preamble_lines: usize = 0;
+    let mut trailing_prose_lines: usize = 0;
+    let mut last_item_index: Option<usize> = None;
 
-    for line in prompt.lines() {
+    let lines: Vec<&str> = prompt.lines().collect();
+    for (idx, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
         // Match patterns: "1. ", "1) ", "2. ", etc.
         if let Some(rest) = strip_numbered_prefix(trimmed) {
             let rest = rest.trim();
             if !rest.is_empty() {
                 items.push(rest.to_string());
+                last_item_index = Some(idx);
             }
+        } else if last_item_index.is_none() {
+            preamble_lines += 1;
+        } else {
+            trailing_prose_lines += 1;
         }
     }
 
-    if items.len() < 2 {
+    if items.len() < 2 || items.len() > MAX_NUMBERED_LIST_ITEMS {
+        return None;
+    }
+
+    if preamble_lines > MAX_NUMBERED_LIST_PREAMBLE_LINES {
+        return None;
+    }
+
+    if trailing_prose_lines > 0 {
+        return None;
+    }
+
+    if items
+        .iter()
+        .any(|item| !is_actionable_imperative(item) || contains_pronoun_reference(item))
+    {
         return None;
     }
 
@@ -111,6 +172,22 @@ fn try_numbered_list(prompt: &str, skills: &[SkillRef]) -> Option<Vec<SubTask>> 
     }
 
     Some(subtasks)
+}
+
+/// An item is actionable iff it starts with one of the verbs recognised as a
+/// clause starter elsewhere in this module. Narrative items ("The audit
+/// results show…") fail this gate.
+fn is_actionable_imperative(item: &str) -> bool {
+    looks_like_clause(item)
+}
+
+/// Returns true if the item contains a free-standing pronoun-style reference,
+/// implying it depends on context from surrounding prose (`it`, `above`, …).
+fn contains_pronoun_reference(item: &str) -> bool {
+    let lower = item.to_lowercase();
+    lower.split(|c: char| !c.is_alphanumeric()).any(|token| {
+        !token.is_empty() && NUMBERED_LIST_PRONOUNS.contains(&token)
+    })
 }
 
 /// Strip a numbered prefix like "1. ", "2) ", "10. " from a string.
@@ -766,6 +843,100 @@ mod tests {
         assert_eq!(result.len(), 2);
         // Second task should depend on first (sequential, not parallel)
         assert_eq!(result[1].depends_on, vec![result[0].id.clone()]);
+    }
+
+    // =========================================================================
+    // GH #1930 — Numbered-list shredding regression
+    // =========================================================================
+
+    #[test]
+    fn numbered_list_embedded_in_prose_does_not_split() {
+        // Prose containing an Objective block must stay one task. Before the
+        // fix this got shredded into N independent subtasks, divorcing each
+        // item from the explanation that gives it meaning.
+        let classification = make_classification();
+        let prompt = "We need to plan the next milestone. Please review the \
+                      following objectives and respond with a single \
+                      consolidated plan. 1. Validate the migration path 2. \
+                      Confirm rollback works 3. Sign off with QA. Thanks!";
+        let result = decompose(prompt, &classification, &[]);
+        assert_eq!(
+            result.len(),
+            1,
+            "numbered list embedded in prose must not split"
+        );
+    }
+
+    #[test]
+    fn long_numbered_list_falls_through_to_single_task() {
+        // 11-item Objective + Update blocks like the one from the audit.
+        // Long numbered lists are almost always narrative and must not be
+        // shredded into 11 sequential subtasks.
+        let classification = make_classification();
+        let prompt = "Update:\n\
+                      1. Shipped the new chat panel\n\
+                      2. Fixed two flaky tests\n\
+                      3. Cut the v1.4 release candidate\n\
+                      4. Updated the changelog\n\
+                      \n\
+                      Objective:\n\
+                      1. Audit orchestrator routing\n\
+                      2. Document the failure modes\n\
+                      3. Write regression fixtures\n\
+                      4. Review with the team\n\
+                      5. Land the fix on main\n\
+                      6. Cut a follow-up release\n\
+                      7. Notify the support team";
+        let result = decompose(prompt, &classification, &[]);
+        assert_eq!(
+            result.len(),
+            1,
+            "numbered list with >4 items must not split (audit regression)"
+        );
+    }
+
+    #[test]
+    fn numbered_list_with_pronoun_references_does_not_split() {
+        // Items that reference surrounding context via pronouns cannot stand
+        // alone. The model has to hallucinate what "it" / "that" refer to.
+        let classification = make_classification();
+        let prompt = "1. Review the proposal\n2. Summarize it for the team\n3. Send that to the customer";
+        let result = decompose(prompt, &classification, &[]);
+        assert_eq!(
+            result.len(),
+            1,
+            "numbered list with pronoun references must not split"
+        );
+    }
+
+    #[test]
+    fn short_action_list_still_decomposes() {
+        // A genuine 3-step action list must still decompose so the
+        // Research → Write → Review pattern in #1930's acceptance criteria
+        // keeps working.
+        let classification = make_classification();
+        let prompt = "1. Research AI news\n2. Write a summary\n3. Review the draft";
+        let result = decompose(prompt, &classification, &[]);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].prompt, "Research AI news");
+        assert_eq!(result[1].prompt, "Write a summary");
+        assert_eq!(result[2].prompt, "Review the draft");
+    }
+
+    #[test]
+    fn numbered_list_with_non_imperative_items_does_not_split() {
+        // Narrative items that don't start with a verb (status updates,
+        // observations) are not actionable subtasks.
+        let classification = make_classification();
+        let prompt = "1. Sales are up 20% this quarter\n\
+                      2. Customer churn improved\n\
+                      3. The marketing team grew by three people";
+        let result = decompose(prompt, &classification, &[]);
+        assert_eq!(
+            result.len(),
+            1,
+            "narrative numbered list must not split"
+        );
     }
 
     // =========================================================================

--- a/src-tauri/src/orchestrator/mod.rs
+++ b/src-tauri/src/orchestrator/mod.rs
@@ -12,6 +12,7 @@ pub mod provider_worker;
 pub mod rlm;
 pub mod router;
 pub mod service;
+pub mod subtask_context;
 pub mod tool_bridge;
 pub mod tool_relevance;
 pub mod trust;

--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -16,6 +16,9 @@ use super::decomposer;
 use super::mcp_publisher_worker::McpPublisherWorker;
 use super::rlm;
 use super::router;
+use super::subtask_context::{
+    MAX_CONTEXT_SUBTASKS, MAX_SUBTASK_RESULT_BYTES, inject_dependency_results,
+};
 use super::trust;
 use super::types::{
     DelegationType, ImageAttachment, OrchestratorEvent, RoutingDecision, SkillRef, SubTask,
@@ -887,6 +890,18 @@ async fn execute_multi_task(
     let mut consecutive_failures: u32 = 0;
     const MAX_CONSECUTIVE_FAILURES: u32 = 3;
 
+    // Index subtasks for dependency lookups during context injection.
+    let subtasks_by_id: HashMap<String, SubTask> = subtasks
+        .iter()
+        .cloned()
+        .map(|st| (st.id.clone(), st))
+        .collect();
+
+    // Accumulates the final assistant content for each completed sub-task so
+    // downstream layers can see what earlier sub-tasks produced (GH #1930).
+    let subtask_results: Arc<Mutex<HashMap<String, String>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+
     'layers: for (layer_idx, layer) in layers.iter().enumerate() {
         log::info!(
             "[Orchestrator] Executing layer {} with {} subtask(s)",
@@ -968,10 +983,24 @@ async fn execute_multi_task(
             let subtask_id = subtask.id.clone();
             let worker_routing = routing.clone();
             let worker_app = app.clone();
-            let worker_history = history.to_vec();
+            // Inject completed ancestor sub-task results so this worker sees
+            // what earlier layers produced (GH #1930). For layer-0 sub-tasks
+            // this is a no-op since they have no dependencies.
+            let worker_history = {
+                let snapshot = subtask_results.lock().await.clone();
+                inject_dependency_results(
+                    history,
+                    subtask,
+                    &subtasks_by_id,
+                    &snapshot,
+                    MAX_CONTEXT_SUBTASKS,
+                    MAX_SUBTASK_RESULT_BYTES,
+                )
+            };
             let worker_images = images.to_vec();
             let layer_tx = shared_tx.clone();
             let worker_conversation_id = conversation_id.to_string();
+            let results_for_handle = Arc::clone(&subtask_results);
 
             let handle = tokio::spawn(async move {
                 let (tx, mut rx) = mpsc::channel::<WorkerEvent>(64);
@@ -992,11 +1021,31 @@ async fn execute_multi_task(
                         .await
                 });
 
-                // Forward events tagged with subtask_id
+                // Forward events tagged with subtask_id, accumulating the
+                // assistant content so downstream sub-tasks can see it.
+                let mut streamed_content = String::new();
+                let mut final_content: Option<String> = None;
                 while let Some(event) = rx.recv().await {
+                    match &event {
+                        WorkerEvent::Content { text } => {
+                            streamed_content.push_str(text);
+                        }
+                        WorkerEvent::Complete { final_content: fc, .. } => {
+                            if !fc.is_empty() {
+                                final_content = Some(fc.clone());
+                            }
+                        }
+                        _ => {}
+                    }
                     if layer_tx.send((subtask_id.clone(), event)).await.is_err() {
                         break;
                     }
+                }
+
+                let captured = final_content.unwrap_or(streamed_content);
+                if !captured.trim().is_empty() {
+                    let mut results = results_for_handle.lock().await;
+                    results.insert(subtask_id.clone(), captured);
                 }
 
                 exec_handle.await

--- a/src-tauri/src/orchestrator/subtask_context.rs
+++ b/src-tauri/src/orchestrator/subtask_context.rs
@@ -1,0 +1,320 @@
+// ABOUTME: Propagates completed sub-task outputs into the worker history of dependent sub-tasks.
+// ABOUTME: Lets later layers in a multi-task plan see what earlier layers produced (GH #1930).
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use super::types::SubTask;
+
+/// Maximum number of ancestor sub-task results that may be injected into a
+/// downstream worker's history. Keeps context bounded for plans with deep
+/// dependency chains.
+pub const MAX_CONTEXT_SUBTASKS: usize = 5;
+
+/// Per-result byte cap. Single noisy ancestor cannot blow out the context
+/// budget for the rest of the plan.
+pub const MAX_SUBTASK_RESULT_BYTES: usize = 4 * 1024;
+
+/// Walk the dependency DAG breadth-first from `subtask` and return ancestor
+/// IDs ordered by distance (direct parents first, grandparents next, …).
+fn transitive_dependencies(
+    subtask: &SubTask,
+    subtasks_by_id: &HashMap<String, SubTask>,
+) -> Vec<String> {
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut ordered: Vec<String> = Vec::new();
+    let mut queue: VecDeque<String> = subtask.depends_on.iter().cloned().collect();
+    while let Some(id) = queue.pop_front() {
+        if !visited.insert(id.clone()) {
+            continue;
+        }
+        ordered.push(id.clone());
+        if let Some(parent) = subtasks_by_id.get(&id) {
+            for dep in &parent.depends_on {
+                queue.push_back(dep.clone());
+            }
+        }
+    }
+    ordered
+}
+
+/// Truncate `result` to `max_bytes` on a UTF-8 char boundary. Appends a
+/// marker so the worker can tell the result was clipped.
+fn truncate_result(result: &str, max_bytes: usize) -> String {
+    if result.len() <= max_bytes {
+        return result.to_string();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !result.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\n[…truncated…]", &result[..end])
+}
+
+/// Inject completed ancestor sub-task results into the history a downstream
+/// worker will see. The original `base_history` (the user-facing chat
+/// transcript) is preserved at the head; synthesized assistant turns are
+/// appended so the worker can reference what earlier sub-tasks produced.
+///
+/// Returns a new history vector — `base_history` is not mutated.
+pub fn inject_dependency_results(
+    base_history: &[serde_json::Value],
+    subtask: &SubTask,
+    subtasks_by_id: &HashMap<String, SubTask>,
+    results: &HashMap<String, String>,
+    max_subtasks: usize,
+    max_bytes_per_subtask: usize,
+) -> Vec<serde_json::Value> {
+    let mut history = base_history.to_vec();
+
+    let deps = transitive_dependencies(subtask, subtasks_by_id);
+
+    // Collect available results in BFS-order (closest ancestor first),
+    // stop at the cap. Missing results (worker error, cancellation) are
+    // silently skipped — we do not stall on them.
+    let mut included: Vec<(String, String)> = Vec::new();
+    for dep_id in &deps {
+        if let Some(result) = results.get(dep_id) {
+            if result.trim().is_empty() {
+                continue;
+            }
+            let prompt = subtasks_by_id
+                .get(dep_id)
+                .map(|st| st.prompt.as_str())
+                .unwrap_or("(unknown sub-task)");
+            included.push((prompt.to_string(), truncate_result(result, max_bytes_per_subtask)));
+            if included.len() >= max_subtasks {
+                break;
+            }
+        }
+    }
+
+    // Emit in chronological order: oldest ancestor first so the most recent
+    // assistant turn (= the direct parent) sits closest to the new user
+    // prompt the worker is about to answer.
+    for (prompt_text, content) in included.iter().rev() {
+        let snippet = truncate_prompt_for_label(prompt_text, 160);
+        let synthesized = format!("[Sub-task result from \"{}\"]:\n{}", snippet, content);
+        history.push(serde_json::json!({
+            "role": "assistant",
+            "content": synthesized,
+        }));
+    }
+
+    history
+}
+
+fn truncate_prompt_for_label(s: &str, max_chars: usize) -> String {
+    let collapsed = s.replace('\n', " ");
+    if collapsed.chars().count() <= max_chars {
+        return collapsed;
+    }
+    let truncated: String = collapsed.chars().take(max_chars).collect();
+    format!("{truncated}…")
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orchestrator::types::{TaskClassification, TaskComplexity};
+
+    fn classification() -> TaskClassification {
+        TaskClassification {
+            task_type: "general_chat".to_string(),
+            requires_tools: false,
+            requires_file_system: false,
+            complexity: TaskComplexity::Simple,
+            relevant_skills: vec![],
+        }
+    }
+
+    fn subtask(id: &str, prompt: &str, depends_on: Vec<&str>) -> SubTask {
+        SubTask {
+            id: id.to_string(),
+            prompt: prompt.to_string(),
+            classification: classification(),
+            depends_on: depends_on.into_iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn by_id(subtasks: &[SubTask]) -> HashMap<String, SubTask> {
+        subtasks
+            .iter()
+            .cloned()
+            .map(|s| (s.id.clone(), s))
+            .collect()
+    }
+
+    #[test]
+    fn sequential_chain_receives_predecessor_result() {
+        // A → B. B's history must contain A's output.
+        let a = subtask("a", "Research the topic", vec![]);
+        let b = subtask("b", "Write a summary", vec!["a"]);
+        let subtasks = vec![a.clone(), b.clone()];
+        let mut results = HashMap::new();
+        results.insert("a".to_string(), "Research finding: rates are up".to_string());
+
+        let history = inject_dependency_results(
+            &[],
+            &b,
+            &by_id(&subtasks),
+            &results,
+            MAX_CONTEXT_SUBTASKS,
+            MAX_SUBTASK_RESULT_BYTES,
+        );
+
+        assert_eq!(history.len(), 1);
+        let content = history[0]["content"].as_str().unwrap();
+        assert!(content.contains("Research finding: rates are up"));
+        assert!(content.contains("Research the topic"));
+        assert_eq!(history[0]["role"].as_str(), Some("assistant"));
+    }
+
+    #[test]
+    fn dependent_sees_only_its_own_ancestors() {
+        // A, B independent. C depends only on A. C must see A but not B.
+        let a = subtask("a", "Research the topic", vec![]);
+        let b = subtask("b", "Read the file", vec![]);
+        let c = subtask("c", "Review the draft", vec!["a"]);
+        let subtasks = vec![a.clone(), b.clone(), c.clone()];
+        let mut results = HashMap::new();
+        results.insert("a".to_string(), "A_OUTPUT_TOKEN".to_string());
+        results.insert("b".to_string(), "B_OUTPUT_TOKEN".to_string());
+
+        let history = inject_dependency_results(
+            &[],
+            &c,
+            &by_id(&subtasks),
+            &results,
+            MAX_CONTEXT_SUBTASKS,
+            MAX_SUBTASK_RESULT_BYTES,
+        );
+
+        assert_eq!(history.len(), 1);
+        let content = history[0]["content"].as_str().unwrap();
+        assert!(content.contains("A_OUTPUT_TOKEN"));
+        assert!(!content.contains("B_OUTPUT_TOKEN"));
+    }
+
+    #[test]
+    fn cap_trims_to_most_recent_ancestors() {
+        // 10-step chain s0 → s1 → … → s9. Injected history for s9 must
+        // contain at most MAX_CONTEXT_SUBTASKS ancestors, and they must be
+        // the most recent ones (s4..s8) — never the oldest (s0).
+        let mut subtasks: Vec<SubTask> = Vec::new();
+        let mut results: HashMap<String, String> = HashMap::new();
+        for i in 0..10 {
+            let id = format!("s{i}");
+            let prev = if i == 0 { vec![] } else { vec![format!("s{}", i - 1)] };
+            subtasks.push(SubTask {
+                id: id.clone(),
+                prompt: format!("Step {i}"),
+                classification: classification(),
+                depends_on: prev,
+            });
+            results.insert(id, format!("OUT_{i}"));
+        }
+        let target = subtasks.last().unwrap().clone();
+
+        let history = inject_dependency_results(
+            &[],
+            &target,
+            &by_id(&subtasks),
+            &results,
+            MAX_CONTEXT_SUBTASKS,
+            MAX_SUBTASK_RESULT_BYTES,
+        );
+
+        assert_eq!(history.len(), MAX_CONTEXT_SUBTASKS);
+        let joined: String = history
+            .iter()
+            .map(|h| h["content"].as_str().unwrap_or(""))
+            .collect::<Vec<_>>()
+            .join("\n");
+        // Most recent ancestor of s9 is s8 — must be present.
+        assert!(joined.contains("OUT_8"), "missing most recent ancestor s8");
+        // Oldest ancestor s0 must be trimmed.
+        assert!(!joined.contains("OUT_0"), "oldest ancestor leaked past cap");
+    }
+
+    #[test]
+    fn missing_result_is_skipped_silently() {
+        // Dependency completed without a stored result (worker error, etc.).
+        // Inject what we have, ignore the rest.
+        let a = subtask("a", "Step A", vec![]);
+        let b = subtask("b", "Step B", vec!["a"]);
+        let c = subtask("c", "Step C", vec!["b"]);
+        let subtasks = vec![a, b.clone(), c.clone()];
+        let mut results = HashMap::new();
+        results.insert("a".to_string(), "A_RESULT".to_string());
+        // No result for b.
+
+        let history = inject_dependency_results(
+            &[],
+            &c,
+            &by_id(&subtasks),
+            &results,
+            MAX_CONTEXT_SUBTASKS,
+            MAX_SUBTASK_RESULT_BYTES,
+        );
+
+        assert_eq!(history.len(), 1);
+        let content = history[0]["content"].as_str().unwrap();
+        assert!(content.contains("A_RESULT"));
+    }
+
+    #[test]
+    fn base_history_is_preserved_at_head() {
+        let a = subtask("a", "Step A", vec![]);
+        let b = subtask("b", "Step B", vec!["a"]);
+        let subtasks = vec![a, b.clone()];
+        let mut results = HashMap::new();
+        results.insert("a".to_string(), "A_RESULT".to_string());
+
+        let base = vec![
+            serde_json::json!({"role": "user", "content": "Original question"}),
+            serde_json::json!({"role": "assistant", "content": "Prior reply"}),
+        ];
+        let history = inject_dependency_results(
+            &base,
+            &b,
+            &by_id(&subtasks),
+            &results,
+            MAX_CONTEXT_SUBTASKS,
+            MAX_SUBTASK_RESULT_BYTES,
+        );
+
+        assert_eq!(history.len(), 3);
+        assert_eq!(history[0]["content"].as_str(), Some("Original question"));
+        assert_eq!(history[1]["content"].as_str(), Some("Prior reply"));
+        assert!(history[2]["content"].as_str().unwrap().contains("A_RESULT"));
+    }
+
+    #[test]
+    fn oversize_result_is_truncated_with_marker() {
+        let a = subtask("a", "Step A", vec![]);
+        let b = subtask("b", "Step B", vec!["a"]);
+        let subtasks = vec![a, b.clone()];
+        let mut results = HashMap::new();
+        let big = "x".repeat(MAX_SUBTASK_RESULT_BYTES + 1024);
+        results.insert("a".to_string(), big);
+
+        let history = inject_dependency_results(
+            &[],
+            &b,
+            &by_id(&subtasks),
+            &results,
+            MAX_CONTEXT_SUBTASKS,
+            MAX_SUBTASK_RESULT_BYTES,
+        );
+
+        let content = history[0]["content"].as_str().unwrap();
+        assert!(content.contains("[…truncated…]"));
+        // Body of synthesized message must not exceed the cap by more than
+        // the truncation marker plus the synthesized prefix.
+        assert!(content.len() < MAX_SUBTASK_RESULT_BYTES + 256);
+    }
+}


### PR DESCRIPTION
## Summary

- Multi-task orchestration now injects prior subtask results into each spawned worker, so later subtasks see what earlier ones produced.
- Single-task runs keep the original prompt verbatim — context injection is gated on the multi-task path only.
- Adds `subtask_context` helper module with unit tests and 11 regression tests in `decomposer.rs`.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 494 tests pass.
- [x] Orchestrator module: 270 tests pass (11 new).
- [ ] Manual verification: multi-step prompt in Seren Chat shows context flow between subtasks.

Closes #1930.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com