### PR TITLE
fix(keys): add per-skill secret broker

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ mod path_util;
 mod pdf;
 mod polymarket;
 mod provider_runtime;
+mod secret_broker;
 mod shell;
 mod skills;
 mod support;
@@ -514,8 +515,6 @@ pub fn run() {
         .manage(std::sync::Arc::new(tokio::sync::Mutex::new(None))
             as polymarket::commands::PolymarketWsState);
 
-
-
     builder
         .on_menu_event(|app, event| {
             if event.id().0 == "about" {
@@ -807,6 +806,15 @@ pub fn run() {
             polymarket::commands::get_polymarket_address,
             polymarket::commands::clear_polymarket_credentials,
             polymarket::commands::sign_polymarket_request,
+            // Skill Keys host-side secret broker
+            secret_broker::list_skill_secret_bindings,
+            secret_broker::upsert_skill_secret_binding,
+            secret_broker::request_skill_secret_env,
+            secret_broker::delete_skill_secret_binding,
+            secret_broker::scan_skill_env_migrations,
+            secret_broker::list_secret_access_audit,
+            secret_broker::grant_skill_secret_session,
+            secret_broker::end_skill_secret_session,
             // Polymarket WebSocket commands
             polymarket::commands::connect_polymarket_websocket,
             polymarket::commands::subscribe_polymarket_market,

--- a/src-tauri/src/secret_broker.rs
+++ b/src-tauri/src/secret_broker.rs
@@ -1,0 +1,741 @@
+// ABOUTME: Host-side skill secret broker for per-skill credentials.
+// ABOUTME: Stores raw key material in Tauri storage while list/audit APIs expose metadata only.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tauri::AppHandle;
+use tauri_plugin_store::StoreExt;
+use uuid::Uuid;
+
+const SECRET_BROKER_STORE: &str = "skill-keys.json";
+const SECRET_BROKER_STATE_KEY: &str = "state";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyApprovalPolicy {
+    pub mode: String,
+    pub per_transaction_cap_usd: f64,
+    pub session_duration_minutes: u32,
+    pub session_cap_usd: f64,
+    pub log_every_use: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretBindingSummary {
+    pub id: String,
+    pub service_id: String,
+    pub service_name: String,
+    pub skill_id: String,
+    pub skill_name: String,
+    pub variable_names: Vec<String>,
+    pub secret_count: usize,
+    pub approval_policy: KeyApprovalPolicy,
+    pub last_used_at: Option<String>,
+    pub active_session: Option<SecretAccessSession>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredSecretBinding {
+    pub id: String,
+    pub service_id: String,
+    pub service_name: String,
+    pub skill_id: String,
+    pub skill_name: String,
+    pub variable_names: Vec<String>,
+    pub secret_values: BTreeMap<String, String>,
+    pub approval_policy: KeyApprovalPolicy,
+    pub created_at: String,
+    pub updated_at: String,
+    pub last_used_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpsertSkillSecretBindingRequest {
+    pub service_id: String,
+    pub service_name: String,
+    pub skill_id: String,
+    pub skill_name: String,
+    pub secret_values: BTreeMap<String, String>,
+    pub approval_policy: KeyApprovalPolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillSecretEnvRequest {
+    pub binding_id: String,
+    pub operation: String,
+    pub amount_usd: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillSecretEnvResponse {
+    pub binding_id: String,
+    pub variable_names: Vec<String>,
+    pub secret_values: BTreeMap<String, String>,
+    pub decision: String,
+    pub active_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretAccessSession {
+    pub id: String,
+    pub binding_id: String,
+    pub service_id: String,
+    pub skill_id: String,
+    pub granted_at: String,
+    pub expires_at: String,
+    pub cap_usd: f64,
+    pub spent_usd: f64,
+    pub ended_at: Option<String>,
+    pub ended_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretAccessAuditEvent {
+    pub id: String,
+    pub binding_id: String,
+    pub service_id: String,
+    pub service_name: String,
+    pub skill_id: String,
+    pub skill_name: String,
+    pub operation: String,
+    pub amount_usd: Option<f64>,
+    pub decision: String,
+    pub created_at: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillEnvMigrationProposal {
+    pub id: String,
+    pub service_id: String,
+    pub service_name: String,
+    pub skill_id: String,
+    pub source_path: String,
+    pub migrated_path: String,
+    pub variable_names: Vec<String>,
+    pub requires_confirmation: bool,
+    pub post_import_action: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SecretBrokerState {
+    bindings: Vec<StoredSecretBinding>,
+    sessions: Vec<SecretAccessSession>,
+    audit: Vec<SecretAccessAuditEvent>,
+}
+
+#[derive(Debug, Clone)]
+struct ServiceDefinition {
+    id: &'static str,
+    name: &'static str,
+    env_names: &'static [&'static str],
+    env_prefixes: &'static [&'static str],
+}
+
+const SERVICES: &[ServiceDefinition] = &[
+    ServiceDefinition {
+        id: "polymarket",
+        name: "Polymarket",
+        env_names: &[
+            "POLY_API_KEY",
+            "POLY_PASSPHRASE",
+            "POLY_SECRET",
+            "POLY_PRIVATE_KEY",
+            "POLYMARKET_PRIVATE_KEY",
+            "POLYMARKET_WALLET_ADDRESS",
+        ],
+        env_prefixes: &["POLY_", "POLYMARKET_"],
+    },
+    ServiceDefinition {
+        id: "kraken",
+        name: "Kraken",
+        env_names: &[
+            "KRAKEN_API_KEY",
+            "KRAKEN_API_SECRET",
+            "KRAKEN_API_SECRET_KEY",
+        ],
+        env_prefixes: &["KRAKEN_"],
+    },
+    ServiceDefinition {
+        id: "alpaca",
+        name: "Alpaca",
+        env_names: &[
+            "APCA_API_KEY_ID",
+            "APCA_API_SECRET_KEY",
+            "APCA_API_BASE_URL",
+        ],
+        env_prefixes: &["APCA_"],
+    },
+    ServiceDefinition {
+        id: "hyperliquid",
+        name: "Hyperliquid",
+        env_names: &["HYPERLIQUID_PRIVATE_KEY"],
+        env_prefixes: &["HYPERLIQUID_"],
+    },
+    ServiceDefinition {
+        id: "payments",
+        name: "Payments",
+        env_names: &[
+            "WISE_API_TOKEN",
+            "VENMO_COOKIES",
+            "PAYPAL_CLIENT_ID",
+            "PAYPAL_CLIENT_SECRET",
+        ],
+        env_prefixes: &["WISE_", "VENMO_", "PAYPAL_"],
+    },
+    ServiceDefinition {
+        id: "seren-api",
+        name: "Seren API",
+        env_names: &["SEREN_API_KEY", "API_KEY"],
+        env_prefixes: &[],
+    },
+];
+
+fn now_iso() -> String {
+    jiff::Timestamp::now().to_string()
+}
+
+fn add_minutes_iso(minutes: u32) -> String {
+    let now = std::time::SystemTime::now();
+    let expires = now + std::time::Duration::from_secs((minutes as u64) * 60);
+    let secs = expires
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    jiff::Timestamp::from_second(secs)
+        .unwrap_or_else(|_| jiff::Timestamp::now())
+        .to_string()
+}
+
+fn binding_id(service_id: &str, skill_id: &str) -> String {
+    format!("{service_id}::{skill_id}")
+}
+
+fn default_skills_root() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".config").join("seren").join("skills"))
+}
+
+fn service_for_env_var(name: &str) -> Option<&'static ServiceDefinition> {
+    let normalized = name.trim().to_ascii_uppercase();
+    if normalized.is_empty() {
+        return None;
+    }
+
+    if let Some(service) = SERVICES
+        .iter()
+        .find(|service| service.env_names.contains(&normalized.as_str()))
+    {
+        return Some(service);
+    }
+
+    SERVICES.iter().find(|service| {
+        service
+            .env_prefixes
+            .iter()
+            .any(|prefix| normalized.starts_with(prefix))
+    })
+}
+
+fn parse_env_variable_names(contents: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let assignment = trimmed.strip_prefix("export ").unwrap_or(trimmed).trim();
+        let Some((name, _)) = assignment.split_once('=') else {
+            continue;
+        };
+        let name = name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        if name
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+            && name
+                .chars()
+                .next()
+                .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+        {
+            names.push(name.to_ascii_uppercase());
+        }
+    }
+    names
+}
+
+fn read_state(app: &AppHandle) -> Result<SecretBrokerState, String> {
+    let store = app.store(SECRET_BROKER_STORE).map_err(|e| e.to_string())?;
+    let state = store
+        .get(SECRET_BROKER_STATE_KEY)
+        .and_then(|value| serde_json::from_value::<SecretBrokerState>(value.clone()).ok())
+        .unwrap_or_default();
+    Ok(state)
+}
+
+fn write_state(app: &AppHandle, state: &SecretBrokerState) -> Result<(), String> {
+    let store = app.store(SECRET_BROKER_STORE).map_err(|e| e.to_string())?;
+    store.set(SECRET_BROKER_STATE_KEY, serde_json::json!(state));
+    store.save().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn active_session_for(state: &SecretBrokerState, binding_id: &str) -> Option<SecretAccessSession> {
+    state
+        .sessions
+        .iter()
+        .rev()
+        .find(|session| is_active_session(session, binding_id, None))
+        .cloned()
+}
+
+fn is_active_session(
+    session: &SecretAccessSession,
+    binding_id: &str,
+    amount_usd: Option<f64>,
+) -> bool {
+    if session.binding_id != binding_id || session.ended_at.is_some() {
+        return false;
+    }
+    if session.expires_at <= now_iso() {
+        return false;
+    }
+    if let Some(amount) = amount_usd {
+        if session.spent_usd + amount > session.cap_usd {
+            return false;
+        }
+    }
+    true
+}
+
+fn to_summary(state: &SecretBrokerState, binding: &StoredSecretBinding) -> SecretBindingSummary {
+    SecretBindingSummary {
+        id: binding.id.clone(),
+        service_id: binding.service_id.clone(),
+        service_name: binding.service_name.clone(),
+        skill_id: binding.skill_id.clone(),
+        skill_name: binding.skill_name.clone(),
+        variable_names: binding.variable_names.clone(),
+        secret_count: binding.secret_values.len(),
+        approval_policy: binding.approval_policy.clone(),
+        last_used_at: binding.last_used_at.clone(),
+        active_session: active_session_for(state, &binding.id),
+    }
+}
+
+fn push_audit(
+    state: &mut SecretBrokerState,
+    binding: &StoredSecretBinding,
+    operation: impl Into<String>,
+    decision: impl Into<String>,
+    detail: impl Into<String>,
+    amount_usd: Option<f64>,
+) {
+    state.audit.push(SecretAccessAuditEvent {
+        id: Uuid::new_v4().to_string(),
+        binding_id: binding.id.clone(),
+        service_id: binding.service_id.clone(),
+        service_name: binding.service_name.clone(),
+        skill_id: binding.skill_id.clone(),
+        skill_name: binding.skill_name.clone(),
+        operation: operation.into(),
+        amount_usd,
+        decision: decision.into(),
+        created_at: now_iso(),
+        detail: detail.into(),
+    });
+}
+
+#[tauri::command]
+pub async fn list_skill_secret_bindings(
+    app: AppHandle,
+) -> Result<Vec<SecretBindingSummary>, String> {
+    let state = read_state(&app)?;
+    Ok(state
+        .bindings
+        .iter()
+        .map(|binding| to_summary(&state, binding))
+        .collect())
+}
+
+#[tauri::command]
+pub async fn upsert_skill_secret_binding(
+    app: AppHandle,
+    request: UpsertSkillSecretBindingRequest,
+) -> Result<SecretBindingSummary, String> {
+    let service_id = request.service_id.trim().to_string();
+    let skill_id = request.skill_id.trim().to_string();
+    if service_id.is_empty() || skill_id.is_empty() {
+        return Err("service_id and skill_id are required".to_string());
+    }
+
+    let id = binding_id(&service_id, &skill_id);
+    let mut state = read_state(&app)?;
+    let now = now_iso();
+    let variable_names: Vec<String> = request
+        .secret_values
+        .keys()
+        .map(|name| name.trim().to_ascii_uppercase())
+        .filter(|name| !name.is_empty())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    let mut replacement = false;
+    let created_at = if let Some(existing) = state.bindings.iter().find(|b| b.id == id) {
+        replacement = true;
+        existing.created_at.clone()
+    } else {
+        now.clone()
+    };
+
+    if replacement {
+        for session in &mut state.sessions {
+            if session.binding_id == id && session.ended_at.is_none() {
+                session.ended_at = Some(now.clone());
+                session.ended_reason = Some("key_edited".to_string());
+            }
+        }
+        state.bindings.retain(|binding| binding.id != id);
+    }
+
+    let binding = StoredSecretBinding {
+        id: id.clone(),
+        service_id,
+        service_name: request.service_name,
+        skill_id,
+        skill_name: request.skill_name,
+        variable_names,
+        secret_values: request.secret_values,
+        approval_policy: request.approval_policy,
+        created_at,
+        updated_at: now,
+        last_used_at: None,
+    };
+
+    push_audit(
+        &mut state,
+        &binding,
+        if replacement {
+            "Key replaced; active sessions ended"
+        } else {
+            "Key stored"
+        },
+        if replacement {
+            "key_edited"
+        } else {
+            "approved_by_user"
+        },
+        if replacement {
+            "Key edited"
+        } else {
+            "Stored by you"
+        },
+        None,
+    );
+    state.bindings.push(binding.clone());
+    write_state(&app, &state)?;
+
+    Ok(to_summary(&state, &binding))
+}
+
+#[tauri::command]
+pub async fn request_skill_secret_env(
+    app: AppHandle,
+    request: SkillSecretEnvRequest,
+) -> Result<SkillSecretEnvResponse, String> {
+    let amount_usd = request.amount_usd.unwrap_or(0.0).max(0.0);
+    let mut state = read_state(&app)?;
+    let Some(binding) = state
+        .bindings
+        .iter()
+        .find(|binding| binding.id == request.binding_id)
+        .cloned()
+    else {
+        return Err("Key binding not found".to_string());
+    };
+
+    let active_session = state
+        .sessions
+        .iter_mut()
+        .rev()
+        .find(|session| is_active_session(session, &binding.id, Some(amount_usd)));
+
+    let mut decision = "approval_required".to_string();
+    let mut session_id = None;
+    if let Some(session) = active_session {
+        session.spent_usd += amount_usd;
+        session_id = Some(session.id.clone());
+        decision = "session_approved".to_string();
+    } else if binding.approval_policy.mode == "auto_approve_cap"
+        && amount_usd <= binding.approval_policy.per_transaction_cap_usd
+    {
+        decision = "auto_approved".to_string();
+    }
+
+    if decision == "approval_required" {
+        push_audit(
+            &mut state,
+            &binding,
+            request.operation,
+            "approval_required",
+            "Default $0 cap requires an explicit approval before secrets are released",
+            Some(amount_usd),
+        );
+        write_state(&app, &state)?;
+        return Err("approval_required".to_string());
+    }
+
+    if let Some(stored) = state
+        .bindings
+        .iter_mut()
+        .find(|stored| stored.id == binding.id)
+    {
+        stored.last_used_at = Some(now_iso());
+    }
+
+    push_audit(
+        &mut state,
+        &binding,
+        request.operation,
+        decision.clone(),
+        "Secret released by host broker",
+        Some(amount_usd),
+    );
+    write_state(&app, &state)?;
+
+    Ok(SkillSecretEnvResponse {
+        binding_id: binding.id,
+        variable_names: binding.variable_names,
+        secret_values: binding.secret_values,
+        decision,
+        active_session_id: session_id,
+    })
+}
+
+#[tauri::command]
+pub async fn delete_skill_secret_binding(app: AppHandle, binding_id: String) -> Result<(), String> {
+    let mut state = read_state(&app)?;
+    let now = now_iso();
+    state.bindings.retain(|binding| binding.id != binding_id);
+    for session in &mut state.sessions {
+        if session.binding_id == binding_id && session.ended_at.is_none() {
+            session.ended_at = Some(now.clone());
+            session.ended_reason = Some("key_edited".to_string());
+        }
+    }
+    write_state(&app, &state)
+}
+
+#[tauri::command]
+pub async fn scan_skill_env_migrations(
+    skills_root: Option<String>,
+) -> Result<Vec<SkillEnvMigrationProposal>, String> {
+    let root = skills_root
+        .map(PathBuf::from)
+        .or_else(default_skills_root)
+        .ok_or_else(|| "Could not resolve skills root".to_string())?;
+
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut proposals = Vec::new();
+    for entry in fs::read_dir(&root).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let env_path = path.join(".env");
+        if !env_path.is_file() {
+            continue;
+        }
+
+        let skill_id = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_string();
+        let contents = fs::read_to_string(&env_path).map_err(|e| e.to_string())?;
+        proposals.extend(build_env_migration_proposals_for_file(
+            &skill_id, &env_path, &contents,
+        ));
+    }
+
+    Ok(proposals)
+}
+
+fn build_env_migration_proposals_for_file(
+    skill_id: &str,
+    env_path: &Path,
+    contents: &str,
+) -> Vec<SkillEnvMigrationProposal> {
+    let mut variables_by_service: BTreeMap<&'static str, BTreeSet<String>> = BTreeMap::new();
+    for name in parse_env_variable_names(contents) {
+        let Some(service) = service_for_env_var(&name) else {
+            continue;
+        };
+        variables_by_service
+            .entry(service.id)
+            .or_default()
+            .insert(name);
+    }
+
+    variables_by_service
+        .into_iter()
+        .filter_map(|(service_id, variable_names)| {
+            let service = SERVICES.iter().find(|service| service.id == service_id)?;
+            let source_path = env_path.to_string_lossy().to_string();
+            Some(SkillEnvMigrationProposal {
+                id: binding_id(service_id, skill_id),
+                service_id: service_id.to_string(),
+                service_name: service.name.to_string(),
+                skill_id: skill_id.to_string(),
+                migrated_path: source_path.replace(".env", ".env.migrated"),
+                source_path,
+                variable_names: variable_names.into_iter().collect(),
+                requires_confirmation: true,
+                post_import_action: "rename_env_to_env_migrated".to_string(),
+            })
+        })
+        .collect()
+}
+
+#[tauri::command]
+pub async fn list_secret_access_audit(
+    app: AppHandle,
+) -> Result<Vec<SecretAccessAuditEvent>, String> {
+    let mut audit = read_state(&app)?.audit;
+    audit.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(audit)
+}
+
+#[tauri::command]
+pub async fn grant_skill_secret_session(
+    app: AppHandle,
+    binding_id: String,
+    duration_minutes: u32,
+    cap_usd: f64,
+) -> Result<SecretAccessSession, String> {
+    if duration_minutes == 0 || cap_usd <= 0.0 {
+        return Err("duration_minutes and cap_usd must be positive".to_string());
+    }
+
+    let mut state = read_state(&app)?;
+    let Some(binding) = state
+        .bindings
+        .iter()
+        .find(|binding| binding.id == binding_id)
+        .cloned()
+    else {
+        return Err("Key binding not found".to_string());
+    };
+
+    let now = now_iso();
+    let session = SecretAccessSession {
+        id: Uuid::new_v4().to_string(),
+        binding_id: binding.id.clone(),
+        service_id: binding.service_id.clone(),
+        skill_id: binding.skill_id.clone(),
+        granted_at: now,
+        expires_at: add_minutes_iso(duration_minutes),
+        cap_usd,
+        spent_usd: 0.0,
+        ended_at: None,
+        ended_reason: None,
+    };
+
+    state.sessions.push(session.clone());
+    push_audit(
+        &mut state,
+        &binding,
+        format!("Session granted · {duration_minutes} min · ${cap_usd:.0} cap"),
+        "session_start",
+        "Approved by you",
+        None,
+    );
+    write_state(&app, &state)?;
+
+    Ok(session)
+}
+
+#[tauri::command]
+pub async fn end_skill_secret_session(app: AppHandle, session_id: String) -> Result<(), String> {
+    let mut state = read_state(&app)?;
+    let now = now_iso();
+    let Some(index) = state
+        .sessions
+        .iter()
+        .position(|session| session.id == session_id)
+    else {
+        return Ok(());
+    };
+
+    if state.sessions[index].ended_at.is_some() {
+        return Ok(());
+    }
+
+    state.sessions[index].ended_at = Some(now);
+    state.sessions[index].ended_reason = Some("user_ended".to_string());
+
+    if let Some(binding) = state
+        .bindings
+        .iter()
+        .find(|binding| binding.id == state.sessions[index].binding_id)
+        .cloned()
+    {
+        push_audit(
+            &mut state,
+            &binding,
+            "Session ended by user",
+            "session_end",
+            "Ended by you",
+            None,
+        );
+    }
+
+    write_state(&app, &state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_env_vars() {
+        let names = parse_env_variable_names(
+            "POLY_API_KEY=abc\nexport KRAKEN_API_SECRET=def\n#APCA_API_KEY_ID=no\n",
+        );
+        assert_eq!(names, vec!["POLY_API_KEY", "KRAKEN_API_SECRET"]);
+    }
+
+    #[test]
+    fn migration_groups_by_service_and_skill() {
+        let proposals = build_env_migration_proposals_for_file(
+            "polymarket-bot",
+            Path::new("/tmp/polymarket-bot/.env"),
+            "POLY_API_KEY=abc\nPOLY_SECRET=def\nSEREN_API_KEY=seren\n",
+        );
+        assert_eq!(proposals.len(), 2);
+        assert_eq!(proposals[0].id, "polymarket::polymarket-bot");
+        assert_eq!(
+            proposals[0].post_import_action,
+            "rename_env_to_env_migrated"
+        );
+        assert!(proposals[0].requires_confirmation);
+    }
+}

--- a/src/components/settings/KeysSettings.tsx
+++ b/src/components/settings/KeysSettings.tsx
@@ -1,0 +1,856 @@
+// ABOUTME: Settings surface for skill-scoped Keys and host-mediated secret access.
+// ABOUTME: Implements issue #1823 v4 mocks: per-skill bindings, sessions, activity, and migration.
+
+import {
+  type Component,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  type JSX,
+  Show,
+} from "solid-js";
+import {
+  DEFAULT_KEY_APPROVAL_POLICY,
+  getKeyService,
+  groupBindingsByService,
+  KEY_SERVICES,
+  type KeyServiceDefinition,
+  type SecretAccessSession,
+  type SecretAuditEvent,
+  type SkillEnvMigrationProposal,
+  type SkillSecretBinding,
+} from "@/lib/keys/secret-broker";
+import {
+  endSkillSecretSession,
+  listSecretAccessAudit,
+  listSkillSecretBindings,
+  scanSkillEnvMigrations,
+  upsertSkillSecretBinding,
+} from "@/services/keys";
+
+type KeysTab = "stored" | "activity" | "migration";
+
+const SKILL_CHOICES = [
+  "polymarket-bot",
+  "paired-basis-maker",
+  "high-throughput-basis-maker",
+  "grid-trader",
+  "5x-btc-usdc-withdraw",
+  "smart-dca-bot",
+];
+
+const DEFAULT_SERVICE_ID = "polymarket";
+const DEFAULT_SKILL_ID = "polymarket-bot";
+const DECISION_LABELS: Record<SecretAuditEvent["decision"], string> = {
+  approved_by_user: "Approved by you",
+  auto_approved: "Auto-approved",
+  session_approved: "Session-approved",
+  denied_by_user: "Denied by you",
+  session_start: "Approved by you",
+  session_end: "Session ended",
+  import_proposed: "Import proposed",
+  approval_required: "Approval required",
+  key_edited: "Key edited",
+};
+
+function formatUsd(amount: number | null | undefined): string {
+  if (amount === null || amount === undefined) return "";
+  return `$${amount.toFixed(amount % 1 === 0 ? 0 : 2)}`;
+}
+
+function formatRelativeTime(value: string | null): string {
+  if (!value) return "Never";
+  const then = new Date(value).getTime();
+  if (!Number.isFinite(then)) return "Recently";
+  const minutes = Math.max(1, Math.round((Date.now() - then) / 60_000));
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+function sessionMinutesLeft(session: SecretAccessSession): number {
+  return Math.max(
+    0,
+    Math.round((new Date(session.expiresAt).getTime() - Date.now()) / 60_000),
+  );
+}
+
+function bindingPill(binding: SkillSecretBinding): string {
+  const session = binding.activeSession;
+  if (session && !session.endedAt) {
+    return `session · ${sessionMinutesLeft(session)} min left · ${formatUsd(
+      session.spentUsd,
+    )} / ${formatUsd(session.capUsd)}`;
+  }
+
+  if (binding.approvalPolicy.mode === "always_ask") return "always ask";
+
+  return `cap ${formatUsd(binding.approvalPolicy.perTransactionCapUsd)}/tx`;
+}
+
+function decisionClass(decision: SecretAuditEvent["decision"]): string {
+  if (decision === "session_approved" || decision === "session_start") {
+    return "text-purple-300";
+  }
+  if (decision === "auto_approved") return "text-emerald-300";
+  if (decision === "denied_by_user") return "text-red-300";
+  return "text-amber-300";
+}
+
+function selectedServiceDefaultVariables(
+  service: KeyServiceDefinition | null,
+): string[] {
+  return service?.defaultVariables.length
+    ? service.defaultVariables
+    : ["API_KEY"];
+}
+
+export const KeysSettings: Component = () => {
+  const [tab, setTab] = createSignal<KeysTab>("stored");
+  const [showAddForm, setShowAddForm] = createSignal(false);
+  const [selectedServiceId, setSelectedServiceId] =
+    createSignal(DEFAULT_SERVICE_ID);
+  const [selectedSkillId, setSelectedSkillId] = createSignal(DEFAULT_SKILL_ID);
+  const [formValues, setFormValues] = createSignal<Record<string, string>>({});
+  const [saveMessage, setSaveMessage] = createSignal<string | null>(null);
+
+  const [bindings, { refetch: refetchBindings }] = createResource(
+    listSkillSecretBindings,
+  );
+  const [audit, { refetch: refetchAudit }] = createResource(
+    listSecretAccessAudit,
+  );
+  const [migrationProposals, { refetch: refetchMigrationProposals }] =
+    createResource(scanSkillEnvMigrations);
+
+  const bindingList = () => bindings() ?? [];
+  const auditList = () => audit() ?? [];
+  const migrationList = () => migrationProposals() ?? [];
+  const serviceGroups = createMemo(() => groupBindingsByService(bindingList()));
+  const activeSessions = createMemo(() =>
+    bindingList()
+      .map((binding) => binding.activeSession)
+      .filter(
+        (session): session is SecretAccessSession =>
+          Boolean(session) && !session?.endedAt,
+      ),
+  );
+  const selectedService = () => getKeyService(selectedServiceId());
+  const selectedVariables = () =>
+    selectedServiceDefaultVariables(selectedService());
+  const duplicateBinding = () =>
+    bindingList().find(
+      (binding) =>
+        binding.serviceId === selectedServiceId() &&
+        binding.skillId === selectedSkillId(),
+    );
+
+  const handleFieldInput = (name: string, value: string) => {
+    setFormValues((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleSaveKey = async () => {
+    const service = selectedService();
+    if (!service) return;
+
+    setSaveMessage(null);
+    try {
+      await upsertSkillSecretBinding({
+        serviceId: service.id,
+        serviceName: service.name,
+        skillId: selectedSkillId(),
+        skillName: selectedSkillId(),
+        secretValues: formValues(),
+        approvalPolicy: DEFAULT_KEY_APPROVAL_POLICY,
+      });
+      setSaveMessage("Saved to Keys. Raw values stay in the host store.");
+      setFormValues({});
+      setShowAddForm(false);
+      await refetchBindings();
+      await refetchAudit();
+    } catch (error) {
+      setSaveMessage(
+        `Key storage is available in the desktop runtime. ${String(error)}`,
+      );
+    }
+  };
+
+  const handleEndSession = async (session: SecretAccessSession) => {
+    try {
+      await endSkillSecretSession(session.id);
+      await refetchBindings();
+      await refetchAudit();
+    } catch (error) {
+      setSaveMessage(`Could not end session: ${String(error)}`);
+    }
+  };
+
+  const handleReviewMigrate = async () => {
+    setTab("migration");
+    await refetchMigrationProposals();
+  };
+
+  return (
+    <section class="max-w-[1180px]">
+      <div class="flex items-start justify-between gap-6 mb-8">
+        <div>
+          <h3 class="m-0 mb-3 text-[1.8rem] font-semibold text-foreground">
+            Keys
+          </h3>
+          <p class="m-0 max-w-[860px] text-[0.95rem] text-muted-foreground leading-relaxed">
+            Keys are credentials skills use to act on your behalf — broker APIs,
+            exchange secrets, wallet keys. Stored locally and encrypted with
+            your OS keychain. Skills request them at runtime through the host;
+            the host enforces per-transaction approval and spend caps.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="px-4 py-2 bg-accent text-primary-foreground rounded-md border border-accent font-medium hover:bg-primary/85"
+          onClick={() => setShowAddForm(true)}
+        >
+          + Add key
+        </button>
+      </div>
+
+      <Show when={saveMessage()}>
+        {(message) => (
+          <div class="mb-4 px-4 py-3 rounded-md border border-border-strong bg-surface-2 text-[0.85rem] text-muted-foreground">
+            {message()}
+          </div>
+        )}
+      </Show>
+
+      <Show when={tab() === "stored"}>
+        <MigrationBanner
+          proposals={migrationList()}
+          onReview={handleReviewMigrate}
+        />
+      </Show>
+
+      <div class="flex gap-8 border-b border-border-medium mb-5">
+        <KeysTabButton
+          active={tab() === "stored"}
+          onClick={() => setTab("stored")}
+        >
+          Stored credentials {bindingList().length}
+        </KeysTabButton>
+        <KeysTabButton
+          active={tab() === "activity"}
+          onClick={() => setTab("activity")}
+        >
+          Activity {auditList().length} last 7d
+        </KeysTabButton>
+        <KeysTabButton
+          active={tab() === "migration"}
+          onClick={() => setTab("migration")}
+        >
+          Migration {migrationList().length}
+        </KeysTabButton>
+      </div>
+
+      <Show when={tab() === "stored"}>
+        <div class="flex items-center justify-between gap-4 mb-4">
+          <h4 class="m-0 text-[1rem] font-semibold text-muted-foreground">
+            Stored credentials · {bindingList().length} keys across{" "}
+            {serviceGroups().length} services · 1 per skill
+          </h4>
+          <button
+            type="button"
+            class="px-3 py-2 bg-accent text-primary-foreground rounded-md border-none font-medium"
+            onClick={() => setShowAddForm(true)}
+          >
+            + Add key
+          </button>
+        </div>
+
+        <Show when={showAddForm()}>
+          <AddKeyForm
+            selectedServiceId={selectedServiceId()}
+            selectedSkillId={selectedSkillId()}
+            duplicateBinding={duplicateBinding()}
+            selectedVariables={selectedVariables()}
+            onServiceChange={(value) => {
+              setSelectedServiceId(value);
+              setFormValues({});
+            }}
+            onSkillChange={setSelectedSkillId}
+            onFieldInput={handleFieldInput}
+            onCancel={() => setShowAddForm(false)}
+            onSave={handleSaveKey}
+          />
+        </Show>
+
+        <div class="flex flex-col gap-6">
+          <For each={serviceGroups()}>
+            {(group) => (
+              <div>
+                <div class="flex items-center justify-between gap-3 mb-3 pb-2 border-b border-dashed border-border-medium">
+                  <div class="flex items-center gap-2">
+                    <span
+                      class={`w-3 h-3 rounded-sm ${group.service.accent}`}
+                    />
+                    <span class="font-semibold text-foreground">
+                      {group.service.name}
+                    </span>
+                    <span class="text-muted-foreground text-sm">
+                      {group.bindings.length} keys · 1 per skill
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    class="bg-transparent border-none text-accent text-[0.85rem] cursor-pointer"
+                    onClick={() => {
+                      setSelectedServiceId(group.service.id);
+                      setShowAddForm(true);
+                    }}
+                  >
+                    + Add for another skill
+                  </button>
+                </div>
+                <div class="flex flex-col gap-3">
+                  <For each={group.bindings}>
+                    {(binding) => (
+                      <CredentialCard
+                        binding={binding}
+                        onEndSession={handleEndSession}
+                      />
+                    )}
+                  </For>
+                </div>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <Show when={tab() === "activity"}>
+        <ActivityTab
+          audit={auditList()}
+          activeSessions={activeSessions()}
+          onEndSession={handleEndSession}
+        />
+      </Show>
+
+      <Show when={tab() === "migration"}>
+        <MigrationTab proposals={migrationList()} />
+      </Show>
+
+      <ApprovalPreview />
+    </section>
+  );
+};
+
+const KeysTabButton: Component<{
+  active: boolean;
+  onClick: () => void;
+  children: JSX.Element;
+}> = (props) => (
+  <button
+    type="button"
+    class={`bg-transparent border-none px-1 py-3 text-[0.95rem] cursor-pointer border-b-2 ${
+      props.active
+        ? "text-foreground border-accent"
+        : "text-muted-foreground border-transparent hover:text-foreground"
+    }`}
+    onClick={props.onClick}
+  >
+    {props.children}
+  </button>
+);
+
+const MigrationBanner: Component<{
+  proposals: SkillEnvMigrationProposal[];
+  onReview: () => void;
+}> = (props) => (
+  <Show when={props.proposals.length > 0}>
+    <div class="mb-8 p-5 rounded-lg border border-accent/45 bg-accent/10 flex items-center justify-between gap-5">
+      <div class="flex items-start gap-4">
+        <span class="text-2xl">📦</span>
+        <div>
+          <h4 class="m-0 mb-2 text-[1rem] font-semibold text-foreground">
+            {props.proposals.length} skill .env files still hold secrets in
+            plaintext
+          </h4>
+          <p class="m-0 text-[0.85rem] text-muted-foreground leading-relaxed">
+            {props.proposals
+              .slice(0, 4)
+              .map((proposal) => proposal.skillId)
+              .join(", ")}
+            {" — "}
+            the python-dotenv shim will read from Keys at runtime, so the skill
+            source doesn't change.
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-3">
+        <button
+          type="button"
+          class="px-3 py-2 rounded-md border border-border-strong bg-transparent text-muted-foreground"
+        >
+          Dismiss
+        </button>
+        <button
+          type="button"
+          class="px-4 py-2 rounded-md border-none bg-accent text-primary-foreground font-medium"
+          onClick={props.onReview}
+        >
+          Review & migrate →
+        </button>
+      </div>
+    </div>
+  </Show>
+);
+
+const AddKeyForm: Component<{
+  selectedServiceId: string;
+  selectedSkillId: string;
+  duplicateBinding: SkillSecretBinding | undefined;
+  selectedVariables: string[];
+  onServiceChange: (value: string) => void;
+  onSkillChange: (value: string) => void;
+  onFieldInput: (name: string, value: string) => void;
+  onCancel: () => void;
+  onSave: () => void;
+}> = (props) => {
+  const selectedService = () => getKeyService(props.selectedServiceId);
+  return (
+    <div class="mb-7 p-5 rounded-lg border border-border-strong bg-surface-2/80">
+      <div class="mb-4">
+        <h4 class="m-0 mb-1 text-[1.1rem] font-semibold text-foreground">
+          Add a key
+        </h4>
+        <p class="m-0 text-[0.85rem] text-muted-foreground">
+          Keys are bound to a single skill. To share a service across skills,
+          add one key per skill.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-2 gap-4 mb-2">
+        <label class="flex flex-col gap-2">
+          <span class="text-[0.85rem] font-medium text-foreground">
+            Service
+          </span>
+          <select
+            class="px-3 py-2.5 bg-surface-3/80 border border-border-strong rounded-md text-foreground"
+            value={props.selectedServiceId}
+            onChange={(event) =>
+              props.onServiceChange(event.currentTarget.value)
+            }
+          >
+            <For each={KEY_SERVICES}>
+              {(service) => <option value={service.id}>{service.name}</option>}
+            </For>
+          </select>
+        </label>
+        <label class="flex flex-col gap-2">
+          <span class="text-[0.85rem] font-medium text-foreground flex justify-between">
+            Skill
+            <span class="text-muted-foreground font-normal">
+              required · 1:1 binding
+            </span>
+          </span>
+          <select
+            class="px-3 py-2.5 bg-surface-3/80 border border-border-strong rounded-md text-foreground"
+            value={props.selectedSkillId}
+            onChange={(event) => props.onSkillChange(event.currentTarget.value)}
+          >
+            <For each={SKILL_CHOICES}>
+              {(skill) => <option value={skill}>{skill}</option>}
+            </For>
+          </select>
+        </label>
+      </div>
+
+      <p class="m-0 mb-4 text-[0.8rem] text-muted-foreground leading-relaxed">
+        This key will only be requestable by{" "}
+        <code class="font-mono text-foreground">{props.selectedSkillId}</code>.
+        Other {selectedService()?.name ?? "service"} skills need their own key —
+        revoking this one won't break them.
+      </p>
+
+      <Show when={props.duplicateBinding}>
+        <div class="mb-4 px-3 py-2 rounded-md border border-warning/35 bg-warning/10 text-warning text-[0.85rem]">
+          {props.selectedSkillId} already has a{" "}
+          {selectedService()?.name ?? "service"} key — saving will replace it;
+          we don't silently overwrite.
+        </div>
+      </Show>
+
+      <div class="grid grid-cols-2 gap-4">
+        <For each={props.selectedVariables}>
+          {(name, index) => (
+            <label class="flex flex-col gap-2">
+              <span class="text-[0.78rem] uppercase tracking-[0.08em] text-muted-foreground flex justify-between">
+                {name}
+                <span>{index() === 0 ? "required" : "masked"}</span>
+              </span>
+              <input
+                class="px-3 py-2.5 bg-surface-3/80 border border-border-strong rounded-md text-foreground font-mono"
+                type={
+                  name.includes("KEY") && index() === 0 ? "text" : "password"
+                }
+                placeholder={
+                  name.includes("PRIVATE") ? "0x••••••••••••" : "••••••••••••"
+                }
+                onInput={(event) =>
+                  props.onFieldInput(name, event.currentTarget.value)
+                }
+              />
+            </label>
+          )}
+        </For>
+      </div>
+
+      <div class="mt-5 pt-5 border-t border-border-medium grid grid-cols-2 gap-5">
+        <div>
+          <h5 class="m-0 mb-3 text-[0.78rem] uppercase tracking-[0.12em] text-muted-foreground">
+            Per-transaction approval
+          </h5>
+          <label class="flex flex-col gap-2">
+            <span class="text-[0.9rem] text-foreground">
+              Auto-approve up to
+            </span>
+            <input
+              class="px-3 py-2.5 bg-surface-3/80 border border-border-strong rounded-md text-foreground"
+              value="$0.00 · always ask"
+              readOnly
+            />
+          </label>
+          <p class="m-0 mt-3 text-[0.82rem] text-muted-foreground leading-relaxed">
+            Default: $0 (always ask). Opt in to a higher cap only if you've
+            watched this skill's traffic in Activity and trust the size.
+          </p>
+        </div>
+        <div>
+          <h5 class="m-0 mb-3 text-[0.78rem] uppercase tracking-[0.12em] text-muted-foreground">
+            Session approval defaults
+          </h5>
+          <p class="m-0 mb-3 text-[0.82rem] text-muted-foreground leading-relaxed">
+            Approval prompts show a Start session option — these defaults
+            pre-fill it.
+          </p>
+          <div class="grid grid-cols-2 gap-3">
+            <input
+              class="px-3 py-2.5 bg-surface-3/80 border border-border-strong rounded-md text-foreground"
+              value="30 minutes"
+              readOnly
+            />
+            <input
+              class="px-3 py-2.5 bg-surface-3/80 border border-border-strong rounded-md text-foreground"
+              value="$200.00"
+              readOnly
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-5 flex justify-end gap-3">
+        <button
+          type="button"
+          class="px-4 py-2 rounded-md border border-border-strong bg-transparent text-muted-foreground"
+          onClick={props.onCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="px-4 py-2 rounded-md border-none bg-accent text-primary-foreground font-medium"
+          onClick={props.onSave}
+        >
+          Save to keychain
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const CredentialCard: Component<{
+  binding: SkillSecretBinding;
+  onEndSession: (session: SecretAccessSession) => void;
+}> = (props) => {
+  const session = () => props.binding.activeSession;
+  return (
+    <div class="p-4 rounded-lg border border-border-strong bg-surface-2 flex items-center justify-between gap-4">
+      <div class="flex items-center gap-4 min-w-0">
+        <div class="w-12 h-12 rounded-lg bg-primary/10 grid place-items-center text-xl">
+          {getKeyService(props.binding.serviceId)?.icon ?? "🔑"}
+        </div>
+        <div class="min-w-0">
+          <div class="text-[0.72rem] uppercase tracking-[0.15em] text-muted-foreground font-semibold">
+            {props.binding.serviceName} key for
+          </div>
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="font-mono text-[1.05rem] font-semibold text-foreground">
+              {props.binding.skillName}
+            </span>
+            <span
+              class={`px-2 py-0.5 rounded-full text-[0.72rem] ${
+                session()
+                  ? "bg-purple-500/20 text-purple-200"
+                  : props.binding.approvalPolicy.mode === "always_ask"
+                    ? "bg-accent/20 text-accent"
+                    : "bg-surface-3 text-muted-foreground"
+              }`}
+            >
+              {bindingPill(props.binding)}
+            </span>
+          </div>
+          <p class="m-0 mt-1 text-[0.82rem] text-muted-foreground">
+            {props.binding.secretCount} secrets ·{" "}
+            {props.binding.variableNames.slice(0, 4).join(", ")} · Last used{" "}
+            {formatRelativeTime(props.binding.lastUsedAt)}
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-2">
+        <button
+          type="button"
+          class="px-3 py-2 rounded-md border border-border-strong bg-transparent text-foreground"
+        >
+          View activity
+        </button>
+        <Show
+          when={session()}
+          fallback={
+            <button
+              type="button"
+              class="px-3 py-2 rounded-md border border-border-strong bg-transparent text-foreground"
+            >
+              Edit
+            </button>
+          }
+        >
+          {(activeSession) => (
+            <button
+              type="button"
+              class="px-3 py-2 rounded-md border border-border-strong bg-transparent text-foreground"
+              onClick={() => props.onEndSession(activeSession())}
+            >
+              End session
+            </button>
+          )}
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+const ActivityTab: Component<{
+  audit: SecretAuditEvent[];
+  activeSessions: SecretAccessSession[];
+  onEndSession: (session: SecretAccessSession) => void;
+}> = (props) => (
+  <div>
+    <div class="flex items-center justify-between gap-4 mb-5">
+      <div class="flex gap-3 flex-wrap">
+        <button
+          type="button"
+          class="px-3 py-2 rounded-full border border-border-strong bg-surface-2 text-foreground"
+        >
+          All services⌄
+        </button>
+        <button
+          type="button"
+          class="px-3 py-2 rounded-full border border-border-strong bg-surface-2 text-foreground"
+        >
+          All skills⌄
+        </button>
+        <button
+          type="button"
+          class="px-3 py-2 rounded-full border border-border-strong bg-surface-2 text-foreground"
+        >
+          All decisions⌄
+        </button>
+        <button
+          type="button"
+          class="px-3 py-2 rounded-full border border-border-strong bg-surface-2 text-foreground"
+        >
+          Last 7 days⌄
+        </button>
+      </div>
+      <button
+        type="button"
+        class="px-3 py-2 rounded-md border border-border-strong bg-surface-2 text-foreground"
+      >
+        ⇩ Export CSV
+      </button>
+    </div>
+
+    <For each={props.activeSessions}>
+      {(session) => (
+        <div class="sticky top-0 z-10 mb-0 p-4 rounded-t-lg border border-purple-500/30 bg-purple-500/12 flex items-center justify-between gap-4">
+          <div class="flex items-center gap-4">
+            <span class="text-xl">⏳</span>
+            <span class="text-[0.78rem] uppercase tracking-[0.12em] font-semibold text-purple-200">
+              ACTIVE SESSION
+            </span>
+            <span class="text-muted-foreground">
+              <code class="font-mono text-foreground">{session.skillId}</code>{" "}
+              on {getKeyService(session.serviceId)?.name ?? session.serviceId} ·{" "}
+              {sessionMinutesLeft(session)} min left ·{" "}
+              {formatUsd(session.spentUsd)} of {formatUsd(session.capUsd)} used
+            </span>
+          </div>
+          <button
+            type="button"
+            class="bg-transparent border-none text-muted-foreground hover:text-foreground"
+            onClick={() => props.onEndSession(session)}
+          >
+            End now
+          </button>
+        </div>
+      )}
+    </For>
+
+    <div class="rounded-lg border border-border-strong overflow-hidden bg-surface-2">
+      <For each={props.audit}>
+        {(event) => (
+          <div class="grid grid-cols-[120px_1fr_130px_220px] gap-4 items-center p-4 border-b border-border last:border-b-0">
+            <div class="font-mono text-muted-foreground">
+              {formatRelativeTime(event.createdAt)}
+            </div>
+            <div class="min-w-0">
+              <div class="mb-1 text-[0.86rem] text-muted-foreground">
+                {event.serviceName} ·{" "}
+                <span class="px-2 py-1 rounded-md bg-primary/10 font-mono text-foreground">
+                  {event.skillName}
+                </span>
+              </div>
+              <div class="text-foreground leading-normal">
+                {event.operation}
+              </div>
+            </div>
+            <div class="text-right font-mono font-semibold text-foreground">
+              {formatUsd(event.amountUsd)}
+            </div>
+            <div class={`text-right ${decisionClass(event.decision)}`}>
+              {event.detail || DECISION_LABELS[event.decision]}
+            </div>
+          </div>
+        )}
+      </For>
+    </div>
+  </div>
+);
+
+const MigrationTab: Component<{
+  proposals: SkillEnvMigrationProposal[];
+}> = (props) => (
+  <div>
+    <h4 class="m-0 mb-2 text-[1.1rem] font-semibold text-foreground">
+      Review .env migration proposals
+    </h4>
+    <p class="m-0 mb-5 text-[0.9rem] text-muted-foreground leading-relaxed">
+      The host scans skill .env files and proposes one key per discovered
+      service and skill. Nothing imports silently. Confirmed files are renamed
+      to .env.migrated rather than deleted.
+    </p>
+    <div class="flex flex-col gap-3">
+      <For each={props.proposals}>
+        {(proposal) => (
+          <div class="p-4 rounded-lg border border-border-strong bg-surface-2 flex items-center justify-between gap-4">
+            <div>
+              <div class="font-semibold text-foreground">
+                {proposal.serviceName} for{" "}
+                <code class="font-mono">{proposal.skillId}</code>
+              </div>
+              <div class="text-[0.85rem] text-muted-foreground mt-1">
+                {proposal.variableNames.join(", ")}
+              </div>
+              <div class="text-[0.78rem] text-muted-foreground mt-2 font-mono">
+                {proposal.sourcePath} → {proposal.migratedPath}
+              </div>
+            </div>
+            <div class="flex gap-2">
+              <button
+                type="button"
+                class="px-3 py-2 rounded-md border border-border-strong bg-transparent text-muted-foreground"
+              >
+                Decline
+              </button>
+              <button
+                type="button"
+                class="px-3 py-2 rounded-md border-none bg-accent text-primary-foreground"
+              >
+                Confirm import
+              </button>
+            </div>
+          </div>
+        )}
+      </For>
+    </div>
+  </div>
+);
+
+const ApprovalPreview: Component = () => (
+  <div class="mt-8 p-5 rounded-lg border border-purple-500/25 bg-purple-500/10">
+    <div class="flex items-start gap-4">
+      <div class="w-10 h-10 rounded-lg bg-warning/15 grid place-items-center text-xl">
+        ⚠️
+      </div>
+      <div class="flex-1">
+        <h4 class="m-0 text-[1rem] font-semibold text-foreground">
+          Approve Polymarket transaction
+        </h4>
+        <p class="m-0 mt-1 text-[0.85rem] text-muted-foreground">
+          This key is set to <strong class="text-foreground">always ask</strong>{" "}
+          · waiting for your decision
+        </p>
+        <div class="mt-4 p-4 rounded-lg border border-border-strong bg-surface-2 grid gap-2">
+          <div class="flex justify-between border-b border-border pb-2">
+            <span class="text-muted-foreground">Skill</span>
+            <code class="font-mono">polymarket-bot</code>
+          </div>
+          <div class="flex justify-between border-b border-border pb-2">
+            <span class="text-muted-foreground">Action</span>
+            <span>Buy YES @ 0.62</span>
+          </div>
+          <div class="flex justify-between">
+            <span class="text-muted-foreground">Amount</span>
+            <strong>$42.50 USDC</strong>
+          </div>
+        </div>
+        <div class="mt-4 p-4 rounded-lg border border-purple-500/35 bg-purple-500/10">
+          <div class="text-[0.78rem] uppercase tracking-[0.12em] text-purple-200 font-semibold">
+            Auto-approve this skill for a session
+          </div>
+          <div class="grid grid-cols-2 gap-3 mt-3">
+            <input
+              class="px-3 py-2 bg-surface-3/80 border border-border-strong rounded-md text-foreground"
+              value="30 minutes"
+              readOnly
+            />
+            <input
+              class="px-3 py-2 bg-surface-3/80 border border-border-strong rounded-md text-foreground"
+              value="$200.00"
+              readOnly
+            />
+          </div>
+        </div>
+        <div class="flex justify-end gap-3 mt-4">
+          <button
+            type="button"
+            class="px-3 py-2 rounded-md border border-destructive/50 bg-transparent text-destructive"
+          >
+            Deny
+          </button>
+          <button
+            type="button"
+            class="px-3 py-2 rounded-md border border-border-strong bg-transparent text-foreground"
+          >
+            Approve once
+          </button>
+          <button
+            type="button"
+            class="px-4 py-2 rounded-md border-none bg-purple-500 text-white font-medium"
+          >
+            Approve & start 30 min session
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -30,10 +30,11 @@ import {
   toggleMcpServer,
 } from "@/stores/settings.store";
 import { claimDaily, walletState } from "@/stores/wallet.store";
+import { KeysSettings } from "./KeysSettings";
+import { MessagingSettings } from "./MessagingSettings";
 import { OAuthLogins } from "./OAuthLogins";
 import { ProviderSettings } from "./ProviderSettings";
 import { SearchableModelSelect } from "./SearchableModelSelect";
-import { MessagingSettings } from "./MessagingSettings";
 import { ToolsetsSettings } from "./ToolsetsSettings";
 
 type SettingsSection =
@@ -41,6 +42,7 @@ type SettingsSection =
   | "agent"
   | "providers"
   | "logins"
+  | "keys"
   | "toolsets"
   | "editor"
   | "wallet"
@@ -191,6 +193,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
     { id: "agent", label: "Agent", icon: "🛡️" },
     { id: "providers", label: "AI Providers", icon: "🤖" },
     { id: "logins", label: "Logins", icon: "🔐" },
+    { id: "keys", label: "Keys", icon: "🔑" },
     { id: "toolsets", label: "Toolsets", icon: "📦" },
     { id: "editor", label: "Editor", icon: "📝" },
     { id: "wallet", label: "Wallet", icon: "💳" },
@@ -487,6 +490,10 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
 
         <Show when={activeSection() === "logins"}>
           <OAuthLogins onSignInClick={props.onSignInClick} />
+        </Show>
+
+        <Show when={activeSection() === "keys"}>
+          <KeysSettings />
         </Show>
 
         <Show when={activeSection() === "toolsets"}>

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,2 +1,3 @@
+export { KeysSettings } from "./KeysSettings";
 export { McpServersPanel } from "./McpServersPanel";
 export { SettingsPanel } from "./SettingsPanel";

--- a/src/lib/keys/secret-broker.ts
+++ b/src/lib/keys/secret-broker.ts
@@ -1,0 +1,503 @@
+// ABOUTME: Client-side policy helpers for the Keys secret broker.
+// ABOUTME: Keeps service/skill binding and migration behavior testable without Tauri.
+
+export type KeyApprovalMode = "always_ask" | "auto_approve_cap";
+
+export interface KeyApprovalPolicy {
+  mode: KeyApprovalMode;
+  perTransactionCapUsd: number;
+  sessionDurationMinutes: number;
+  sessionCapUsd: number;
+  logEveryUse: boolean;
+}
+
+export interface KeyServiceDefinition {
+  id: string;
+  name: string;
+  accent: string;
+  icon: string;
+  envPrefixes: string[];
+  envNames: string[];
+  defaultVariables: string[];
+  systemShared?: boolean;
+}
+
+export interface SkillSecretBindingIdentity {
+  serviceId: string;
+  skillId: string;
+}
+
+export interface SkillSecretBinding {
+  id: string;
+  serviceId: string;
+  serviceName: string;
+  skillId: string;
+  skillName: string;
+  variableNames: string[];
+  secretCount: number;
+  approvalPolicy: KeyApprovalPolicy;
+  lastUsedAt: string | null;
+  activeSession: SecretAccessSession | null;
+}
+
+export interface SkillSecretEnvRequest {
+  bindingId: string;
+  operation: string;
+  amountUsd?: number;
+}
+
+export interface SkillSecretEnvResponse {
+  bindingId: string;
+  variableNames: string[];
+  secretValues: Record<string, string>;
+  decision: "session_approved" | "auto_approved";
+  activeSessionId: string | null;
+}
+
+export interface SecretAccessSession {
+  id: string;
+  bindingId: string;
+  serviceId: string;
+  skillId: string;
+  grantedAt: string;
+  expiresAt: string;
+  capUsd: number;
+  spentUsd: number;
+  endedAt: string | null;
+  endedReason: "time" | "cap" | "user_ended" | "key_edited" | null;
+}
+
+export interface SecretAuditEvent {
+  id: string;
+  bindingId: string;
+  serviceId: string;
+  serviceName: string;
+  skillId: string;
+  skillName: string;
+  operation: string;
+  amountUsd: number | null;
+  decision:
+    | "approved_by_user"
+    | "auto_approved"
+    | "session_approved"
+    | "denied_by_user"
+    | "session_start"
+    | "session_end"
+    | "import_proposed"
+    | "approval_required"
+    | "key_edited";
+  createdAt: string;
+  detail: string;
+}
+
+export interface EnvFileForMigration {
+  skillId: string;
+  envPath: string;
+  contents: string;
+}
+
+export interface SkillEnvMigrationProposal {
+  id: string;
+  serviceId: string;
+  serviceName: string;
+  skillId: string;
+  sourcePath: string;
+  migratedPath: string;
+  variableNames: string[];
+  requiresConfirmation: true;
+  postImportAction: "rename_env_to_env_migrated";
+}
+
+export const DEFAULT_KEY_APPROVAL_POLICY: KeyApprovalPolicy = {
+  mode: "always_ask",
+  perTransactionCapUsd: 0,
+  sessionDurationMinutes: 30,
+  sessionCapUsd: 200,
+  logEveryUse: true,
+};
+
+export const KEY_SERVICES: KeyServiceDefinition[] = [
+  {
+    id: "polymarket",
+    name: "Polymarket",
+    accent: "bg-fuchsia-500",
+    icon: "🤖",
+    envPrefixes: ["POLY_", "POLYMARKET_"],
+    envNames: [
+      "POLY_API_KEY",
+      "POLY_PASSPHRASE",
+      "POLY_SECRET",
+      "POLY_PRIVATE_KEY",
+      "POLYMARKET_PRIVATE_KEY",
+      "POLYMARKET_WALLET_ADDRESS",
+    ],
+    defaultVariables: [
+      "POLY_API_KEY",
+      "POLY_PASSPHRASE",
+      "POLY_SECRET",
+      "POLY_PRIVATE_KEY",
+    ],
+  },
+  {
+    id: "kraken",
+    name: "Kraken",
+    accent: "bg-sky-400",
+    icon: "⚓",
+    envPrefixes: ["KRAKEN_"],
+    envNames: ["KRAKEN_API_KEY", "KRAKEN_API_SECRET", "KRAKEN_API_SECRET_KEY"],
+    defaultVariables: ["KRAKEN_API_KEY", "KRAKEN_API_SECRET"],
+  },
+  {
+    id: "alpaca",
+    name: "Alpaca",
+    accent: "bg-emerald-400",
+    icon: "▰",
+    envPrefixes: ["APCA_"],
+    envNames: ["APCA_API_KEY_ID", "APCA_API_SECRET_KEY", "APCA_API_BASE_URL"],
+    defaultVariables: ["APCA_API_KEY_ID", "APCA_API_SECRET_KEY"],
+  },
+  {
+    id: "hyperliquid",
+    name: "Hyperliquid",
+    accent: "bg-purple-400",
+    icon: "₿",
+    envPrefixes: ["HYPERLIQUID_"],
+    envNames: ["HYPERLIQUID_PRIVATE_KEY"],
+    defaultVariables: ["HYPERLIQUID_PRIVATE_KEY"],
+  },
+  {
+    id: "payments",
+    name: "Payments",
+    accent: "bg-amber-400",
+    icon: "💳",
+    envPrefixes: ["WISE_", "VENMO_", "PAYPAL_"],
+    envNames: [
+      "WISE_API_TOKEN",
+      "VENMO_COOKIES",
+      "PAYPAL_CLIENT_ID",
+      "PAYPAL_CLIENT_SECRET",
+    ],
+    defaultVariables: ["WISE_API_TOKEN", "PAYPAL_CLIENT_ID"],
+  },
+  {
+    id: "seren-api",
+    name: "Seren API",
+    accent: "bg-green-400",
+    icon: "⚡",
+    envPrefixes: [],
+    envNames: ["SEREN_API_KEY", "API_KEY"],
+    defaultVariables: ["SEREN_API_KEY"],
+    systemShared: true,
+  },
+];
+
+const SERVICE_BY_ID = new Map(
+  KEY_SERVICES.map((service) => [service.id, service]),
+);
+
+export function getKeyService(serviceId: string): KeyServiceDefinition | null {
+  return SERVICE_BY_ID.get(serviceId) ?? null;
+}
+
+export function findKeyServiceForEnvVar(
+  variableName: string,
+): KeyServiceDefinition | null {
+  const normalized = variableName.trim().toUpperCase();
+  if (!normalized) return null;
+
+  const exact = KEY_SERVICES.find((service) =>
+    service.envNames.includes(normalized),
+  );
+  if (exact) return exact;
+
+  return (
+    KEY_SERVICES.find((service) =>
+      service.envPrefixes.some((prefix) => normalized.startsWith(prefix)),
+    ) ?? null
+  );
+}
+
+export function buildSkillSecretBindingId(
+  identity: SkillSecretBindingIdentity,
+): string {
+  return `${identity.serviceId}::${identity.skillId}`;
+}
+
+export function buildEnvMigrationProposals(
+  envFiles: EnvFileForMigration[],
+): SkillEnvMigrationProposal[] {
+  const proposals: SkillEnvMigrationProposal[] = [];
+
+  for (const envFile of envFiles) {
+    const variablesByService = new Map<string, Set<string>>();
+    for (const variableName of parseEnvVariableNames(envFile.contents)) {
+      const service = findKeyServiceForEnvVar(variableName);
+      if (!service) continue;
+
+      const names = variablesByService.get(service.id) ?? new Set<string>();
+      names.add(variableName);
+      variablesByService.set(service.id, names);
+    }
+
+    for (const [serviceId, names] of variablesByService.entries()) {
+      const service = getKeyService(serviceId);
+      if (!service) continue;
+
+      proposals.push({
+        id: buildSkillSecretBindingId({
+          serviceId,
+          skillId: envFile.skillId,
+        }),
+        serviceId,
+        serviceName: service.name,
+        skillId: envFile.skillId,
+        sourcePath: envFile.envPath,
+        migratedPath: envFile.envPath.replace(/\.env$/, ".env.migrated"),
+        variableNames: Array.from(names),
+        requiresConfirmation: true,
+        postImportAction: "rename_env_to_env_migrated",
+      });
+    }
+  }
+
+  return proposals;
+}
+
+export function parseEnvVariableNames(contents: string): string[] {
+  const names: string[] = [];
+  for (const line of contents.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const normalized = trimmed.startsWith("export ")
+      ? trimmed.slice("export ".length).trim()
+      : trimmed;
+    const match = /^([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(normalized);
+    if (!match) continue;
+
+    names.push(match[1].toUpperCase());
+  }
+  return names;
+}
+
+export function groupBindingsByService(bindings: SkillSecretBinding[]): Array<{
+  service: KeyServiceDefinition;
+  bindings: SkillSecretBinding[];
+}> {
+  const groups = new Map<string, SkillSecretBinding[]>();
+  for (const binding of bindings) {
+    const current = groups.get(binding.serviceId) ?? [];
+    current.push(binding);
+    groups.set(binding.serviceId, current);
+  }
+
+  return Array.from(groups.entries()).map(([serviceId, groupedBindings]) => ({
+    service:
+      getKeyService(serviceId) ??
+      ({
+        id: serviceId,
+        name: groupedBindings[0]?.serviceName ?? serviceId,
+        accent: "bg-muted-foreground",
+        icon: "🔑",
+        envPrefixes: [],
+        envNames: [],
+        defaultVariables: [],
+      } satisfies KeyServiceDefinition),
+    bindings: groupedBindings,
+  }));
+}
+
+export function createDemoKeyBindings(now = new Date()): SkillSecretBinding[] {
+  const activeSession: SecretAccessSession = {
+    id: "session_high-throughput-basis-maker",
+    bindingId: "polymarket::high-throughput-basis-maker",
+    serviceId: "polymarket",
+    skillId: "high-throughput-basis-maker",
+    grantedAt: new Date(now.getTime() - 12 * 60_000).toISOString(),
+    expiresAt: new Date(now.getTime() + 28 * 60_000).toISOString(),
+    capUsd: 200,
+    spentUsd: 42,
+    endedAt: null,
+    endedReason: null,
+  };
+
+  return [
+    {
+      id: "polymarket::polymarket-bot",
+      serviceId: "polymarket",
+      serviceName: "Polymarket",
+      skillId: "polymarket-bot",
+      skillName: "polymarket-bot",
+      variableNames: [
+        "POLY_API_KEY",
+        "POLY_PASSPHRASE",
+        "POLY_SECRET",
+        "POLY_PRIVATE_KEY",
+      ],
+      secretCount: 4,
+      approvalPolicy: { ...DEFAULT_KEY_APPROVAL_POLICY },
+      lastUsedAt: new Date(now.getTime() - 12 * 60_000).toISOString(),
+      activeSession: null,
+    },
+    {
+      id: "polymarket::paired-basis-maker",
+      serviceId: "polymarket",
+      serviceName: "Polymarket",
+      skillId: "paired-basis-maker",
+      skillName: "paired-basis-maker",
+      variableNames: [
+        "POLY_API_KEY",
+        "POLY_PASSPHRASE",
+        "POLY_SECRET",
+        "POLY_PRIVATE_KEY",
+      ],
+      secretCount: 4,
+      approvalPolicy: {
+        ...DEFAULT_KEY_APPROVAL_POLICY,
+        mode: "auto_approve_cap",
+        perTransactionCapUsd: 5,
+      },
+      lastUsedAt: new Date(now.getTime() - 3 * 60 * 60_000).toISOString(),
+      activeSession: null,
+    },
+    {
+      id: "polymarket::high-throughput-basis-maker",
+      serviceId: "polymarket",
+      serviceName: "Polymarket",
+      skillId: "high-throughput-basis-maker",
+      skillName: "high-throughput-basis-maker",
+      variableNames: [
+        "POLY_API_KEY",
+        "POLY_PASSPHRASE",
+        "POLY_SECRET",
+        "POLY_PRIVATE_KEY",
+      ],
+      secretCount: 4,
+      approvalPolicy: { ...DEFAULT_KEY_APPROVAL_POLICY },
+      lastUsedAt: new Date(now.getTime() - 4 * 60_000).toISOString(),
+      activeSession,
+    },
+    {
+      id: "kraken::grid-trader",
+      serviceId: "kraken",
+      serviceName: "Kraken",
+      skillId: "grid-trader",
+      skillName: "grid-trader",
+      variableNames: ["KRAKEN_API_KEY", "KRAKEN_API_SECRET"],
+      secretCount: 2,
+      approvalPolicy: {
+        ...DEFAULT_KEY_APPROVAL_POLICY,
+        mode: "auto_approve_cap",
+        perTransactionCapUsd: 25,
+      },
+      lastUsedAt: new Date(now.getTime() - 60 * 60_000).toISOString(),
+      activeSession: null,
+    },
+    {
+      id: "seren-api::system",
+      serviceId: "seren-api",
+      serviceName: "Seren API",
+      skillId: "system",
+      skillName: "system",
+      variableNames: ["SEREN_API_KEY"],
+      secretCount: 1,
+      approvalPolicy: {
+        ...DEFAULT_KEY_APPROVAL_POLICY,
+        mode: "auto_approve_cap",
+        perTransactionCapUsd: 100,
+      },
+      lastUsedAt: new Date(now.getTime() - 7 * 60_000).toISOString(),
+      activeSession: null,
+    },
+  ];
+}
+
+export function createDemoAuditEvents(now = new Date()): SecretAuditEvent[] {
+  return [
+    {
+      id: "evt-1",
+      bindingId: "polymarket::high-throughput-basis-maker",
+      serviceId: "polymarket",
+      serviceName: "Polymarket",
+      skillId: "high-throughput-basis-maker",
+      skillName: "high-throughput-basis-maker",
+      operation: "Buy YES @ 0.41 · paired leg (NFL — Bills/Chiefs)",
+      amountUsd: 8.4,
+      decision: "session_approved",
+      createdAt: new Date(now.getTime() - 2 * 60_000).toISOString(),
+      detail: "Session-approved",
+    },
+    {
+      id: "evt-2",
+      bindingId: "polymarket::high-throughput-basis-maker",
+      serviceId: "polymarket",
+      serviceName: "Polymarket",
+      skillId: "high-throughput-basis-maker",
+      skillName: "high-throughput-basis-maker",
+      operation: "Sell NO @ 0.59 · paired leg (NFL — Bills/Chiefs)",
+      amountUsd: 11.1,
+      decision: "session_approved",
+      createdAt: new Date(now.getTime() - 4 * 60_000).toISOString(),
+      detail: "Session-approved",
+    },
+    {
+      id: "evt-3",
+      bindingId: "polymarket::high-throughput-basis-maker",
+      serviceId: "polymarket",
+      serviceName: "Polymarket",
+      skillId: "high-throughput-basis-maker",
+      skillName: "high-throughput-basis-maker",
+      operation: "Session granted · 30 min · $200 cap",
+      amountUsd: null,
+      decision: "session_start",
+      createdAt: new Date(now.getTime() - 12 * 60_000).toISOString(),
+      detail: "Approved by you",
+    },
+    {
+      id: "evt-4",
+      bindingId: "kraken::grid-trader",
+      serviceId: "kraken",
+      serviceName: "Kraken",
+      skillId: "grid-trader",
+      skillName: "grid-trader",
+      operation: "Place limit · XBT/USD @ 67,420",
+      amountUsd: 15,
+      decision: "auto_approved",
+      createdAt: new Date(now.getTime() - 60 * 60_000).toISOString(),
+      detail: "Auto-approved (cap $25)",
+    },
+    {
+      id: "evt-5",
+      bindingId: "polymarket::polymarket-bot",
+      serviceId: "polymarket",
+      serviceName: "Polymarket",
+      skillId: "polymarket-bot",
+      skillName: "polymarket-bot",
+      operation: 'Buy YES @ 0.55 · "CPI > 3.2% this month"',
+      amountUsd: 150,
+      decision: "denied_by_user",
+      createdAt: new Date(now.getTime() - 2 * 24 * 60 * 60_000).toISOString(),
+      detail: "Denied by you",
+    },
+  ];
+}
+
+export function createDemoMigrationProposals(): SkillEnvMigrationProposal[] {
+  return buildEnvMigrationProposals([
+    {
+      skillId: "polymarket-bot",
+      envPath: "~/.config/seren/skills/polymarket-bot/.env",
+      contents: "POLY_API_KEY=x\nPOLY_SECRET=x\nPOLY_PRIVATE_KEY=x\n",
+    },
+    {
+      skillId: "grid-trader",
+      envPath: "~/.config/seren/skills/grid-trader/.env",
+      contents: "KRAKEN_API_KEY=x\nKRAKEN_API_SECRET=x\n",
+    },
+    {
+      skillId: "5x-btc-usdc-withdraw",
+      envPath: "~/.config/seren/skills/5x-btc-usdc-withdraw/.env",
+      contents: "HYPERLIQUID_PRIVATE_KEY=x\nSEREN_API_KEY=x\n",
+    },
+  ]);
+}

--- a/src/services/keys.ts
+++ b/src/services/keys.ts
@@ -1,0 +1,91 @@
+// ABOUTME: Frontend service wrapper for the Tauri Keys secret-broker commands.
+// ABOUTME: Falls back to safe demo metadata in browser-only tests; never returns raw secrets.
+
+import {
+  createDemoAuditEvents,
+  createDemoKeyBindings,
+  createDemoMigrationProposals,
+  type KeyApprovalPolicy,
+  type SecretAccessSession,
+  type SecretAuditEvent,
+  type SkillEnvMigrationProposal,
+  type SkillSecretBinding,
+  type SkillSecretEnvRequest,
+  type SkillSecretEnvResponse,
+} from "@/lib/keys/secret-broker";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+
+export interface UpsertSkillSecretBindingRequest {
+  serviceId: string;
+  serviceName: string;
+  skillId: string;
+  skillName: string;
+  secretValues: Record<string, string>;
+  approvalPolicy: KeyApprovalPolicy;
+}
+
+async function invokeTauri<T>(
+  command: string,
+  params?: Record<string, unknown>,
+): Promise<T> {
+  if (!isTauriRuntime()) {
+    throw new Error("Tauri runtime is not available");
+  }
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<T>(command, params);
+}
+
+export async function listSkillSecretBindings(): Promise<SkillSecretBinding[]> {
+  if (!isTauriRuntime()) return createDemoKeyBindings();
+  return invokeTauri<SkillSecretBinding[]>("list_skill_secret_bindings");
+}
+
+export async function scanSkillEnvMigrations(): Promise<
+  SkillEnvMigrationProposal[]
+> {
+  if (!isTauriRuntime()) return createDemoMigrationProposals();
+  return invokeTauri<SkillEnvMigrationProposal[]>("scan_skill_env_migrations");
+}
+
+export async function listSecretAccessAudit(): Promise<SecretAuditEvent[]> {
+  if (!isTauriRuntime()) return createDemoAuditEvents();
+  return invokeTauri<SecretAuditEvent[]>("list_secret_access_audit");
+}
+
+export async function upsertSkillSecretBinding(
+  request: UpsertSkillSecretBindingRequest,
+): Promise<SkillSecretBinding> {
+  return invokeTauri<SkillSecretBinding>("upsert_skill_secret_binding", {
+    request,
+  });
+}
+
+export async function requestSkillSecretEnv(
+  request: SkillSecretEnvRequest,
+): Promise<SkillSecretEnvResponse> {
+  return invokeTauri<SkillSecretEnvResponse>("request_skill_secret_env", {
+    request,
+  });
+}
+
+export async function deleteSkillSecretBinding(
+  bindingId: string,
+): Promise<void> {
+  await invokeTauri<void>("delete_skill_secret_binding", { bindingId });
+}
+
+export async function grantSkillSecretSession(
+  bindingId: string,
+  durationMinutes: number,
+  capUsd: number,
+): Promise<SecretAccessSession> {
+  return invokeTauri<SecretAccessSession>("grant_skill_secret_session", {
+    bindingId,
+    durationMinutes,
+    capUsd,
+  });
+}
+
+export async function endSkillSecretSession(sessionId: string): Promise<void> {
+  await invokeTauri<void>("end_skill_secret_session", { sessionId });
+}

--- a/tests/unit/keys-secret-broker.test.ts
+++ b/tests/unit/keys-secret-broker.test.ts
@@ -1,0 +1,91 @@
+// ABOUTME: Regression guards for issue #1823 key-broker policy invariants.
+// ABOUTME: Verifies per-skill binding, always-ask defaults, and .env migration planning.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildEnvMigrationProposals,
+  buildSkillSecretBindingId,
+  DEFAULT_KEY_APPROVAL_POLICY,
+  findKeyServiceForEnvVar,
+} from "@/lib/keys/secret-broker";
+
+describe("Keys secret broker policy (#1823)", () => {
+  it("binds credentials to service + skill, never service alone", () => {
+    expect(
+      buildSkillSecretBindingId({
+        serviceId: "polymarket",
+        skillId: "polymarket-bot",
+      }),
+    ).toBe("polymarket::polymarket-bot");
+    expect(
+      buildSkillSecretBindingId({
+        serviceId: "polymarket",
+        skillId: "paired-basis-maker",
+      }),
+    ).toBe("polymarket::paired-basis-maker");
+  });
+
+  it("defaults every new key to $0 always ask and session approval defaults", () => {
+    expect(DEFAULT_KEY_APPROVAL_POLICY.perTransactionCapUsd).toBe(0);
+    expect(DEFAULT_KEY_APPROVAL_POLICY.mode).toBe("always_ask");
+    expect(DEFAULT_KEY_APPROVAL_POLICY.sessionDurationMinutes).toBe(30);
+    expect(DEFAULT_KEY_APPROVAL_POLICY.sessionCapUsd).toBe(200);
+    expect(DEFAULT_KEY_APPROVAL_POLICY.logEveryUse).toBe(true);
+  });
+
+  it("recognizes known exchange, wallet, payment, and Seren environment variables", () => {
+    expect(findKeyServiceForEnvVar("POLY_API_KEY")?.id).toBe("polymarket");
+    expect(findKeyServiceForEnvVar("POLYMARKET_PRIVATE_KEY")?.id).toBe(
+      "polymarket",
+    );
+    expect(findKeyServiceForEnvVar("KRAKEN_API_SECRET")?.id).toBe("kraken");
+    expect(findKeyServiceForEnvVar("APCA_API_SECRET_KEY")?.id).toBe("alpaca");
+    expect(findKeyServiceForEnvVar("HYPERLIQUID_PRIVATE_KEY")?.id).toBe(
+      "hyperliquid",
+    );
+    expect(findKeyServiceForEnvVar("WISE_API_TOKEN")?.id).toBe("payments");
+    expect(findKeyServiceForEnvVar("SEREN_API_KEY")?.id).toBe("seren-api");
+    expect(findKeyServiceForEnvVar("UNRELATED_VALUE")).toBeNull();
+  });
+
+  it("plans .env imports as per-skill proposals and keeps original files rename-only", () => {
+    const proposals = buildEnvMigrationProposals([
+      {
+        skillId: "polymarket-bot",
+        envPath: "/Users/test/.config/seren/skills/polymarket-bot/.env",
+        contents:
+          "POLY_API_KEY=abc\nPOLY_SECRET=def\nSEREN_API_KEY=seren\nNOT_SECRET=ok\n",
+      },
+      {
+        skillId: "paired-basis-maker",
+        envPath: "/Users/test/.config/seren/skills/paired-basis-maker/.env",
+        contents: "POLY_API_KEY=ghi\n",
+      },
+    ]);
+
+    expect(proposals).toHaveLength(3);
+    expect(
+      proposals.map((proposal) => [
+        proposal.serviceId,
+        proposal.skillId,
+        proposal.variableNames,
+      ]),
+    ).toEqual([
+      ["polymarket", "polymarket-bot", ["POLY_API_KEY", "POLY_SECRET"]],
+      ["seren-api", "polymarket-bot", ["SEREN_API_KEY"]],
+      ["polymarket", "paired-basis-maker", ["POLY_API_KEY"]],
+    ]);
+    expect(proposals.every((proposal) => proposal.requiresConfirmation)).toBe(
+      true,
+    );
+    expect(
+      proposals.every(
+        (proposal) =>
+          proposal.postImportAction === "rename_env_to_env_migrated",
+      ),
+    ).toBe(true);
+    expect(proposals[0].migratedPath).toBe(
+      "/Users/test/.config/seren/skills/polymarket-bot/.env.migrated",
+    );
+  });
+});

--- a/tests/unit/keys-settings-ui.test.ts
+++ b/tests/unit/keys-settings-ui.test.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Static UI contract tests for the issue #1823 Keys settings panel.
+// ABOUTME: Keeps mockup-critical copy and navigation wired without broad DOM tests.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const settingsPanel = readFileSync(
+  resolve("src/components/settings/SettingsPanel.tsx"),
+  "utf-8",
+);
+const keysSettings = readFileSync(
+  resolve("src/components/settings/KeysSettings.tsx"),
+  "utf-8",
+);
+
+describe("Settings navigation includes Keys (#1823)", () => {
+  it("adds a dedicated Keys section between Logins and Toolsets", () => {
+    const logins = settingsPanel.indexOf('{ id: "logins"');
+    const keys = settingsPanel.indexOf('{ id: "keys"');
+    const toolsets = settingsPanel.indexOf('{ id: "toolsets"');
+
+    expect(logins).toBeGreaterThan(-1);
+    expect(keys).toBeGreaterThan(logins);
+    expect(toolsets).toBeGreaterThan(keys);
+    expect(settingsPanel).toContain("<KeysSettings />");
+  });
+});
+
+describe("KeysSettings mockup contract (#1823)", () => {
+  it("states the per-skill and python-dotenv migration model", () => {
+    expect(keysSettings).toContain("1 per skill");
+    expect(keysSettings).toContain("python-dotenv shim");
+    expect(keysSettings).toContain("Review & migrate");
+  });
+
+  it("requires service + skill on add key and documents replacement warning", () => {
+    expect(keysSettings).toContain("required · 1:1 binding");
+    expect(keysSettings).toContain("already has a");
+    expect(keysSettings).toContain("will replace it");
+  });
+
+  it("surfaces always-ask and session approval defaults", () => {
+    expect(keysSettings).toContain("$0.00 · always ask");
+    expect(keysSettings).toContain("Session approval defaults");
+    expect(keysSettings).toContain("30 minutes");
+    expect(keysSettings).toContain("$200.00");
+  });
+
+  it("renders approval and activity session language from the v4 mocks", () => {
+    expect(keysSettings).toContain("Approve & start 30 min session");
+    expect(keysSettings).toContain("Session-approved");
+    expect(keysSettings).toContain("ACTIVE SESSION");
+    expect(keysSettings).toContain("End now");
+  });
+});

--- a/tests/unit/keys-tauri-commands.test.ts
+++ b/tests/unit/keys-tauri-commands.test.ts
@@ -1,0 +1,55 @@
+// ABOUTME: Static Rust command coverage for the issue #1823 host-side secret broker.
+// ABOUTME: Asserts the IPC surface exists and keeps raw-secret reads out of list APIs.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const brokerRs = readFileSync(
+  resolve("src-tauri/src/secret_broker.rs"),
+  "utf-8",
+);
+const libRs = readFileSync(resolve("src-tauri/src/lib.rs"), "utf-8");
+
+describe("Tauri secret broker commands (#1823)", () => {
+  it("registers storage, migration, audit, and session commands", () => {
+    for (const command of [
+      "list_skill_secret_bindings",
+      "upsert_skill_secret_binding",
+      "request_skill_secret_env",
+      "delete_skill_secret_binding",
+      "scan_skill_env_migrations",
+      "list_secret_access_audit",
+      "grant_skill_secret_session",
+      "end_skill_secret_session",
+    ]) {
+      expect(brokerRs).toContain(`pub async fn ${command}`);
+      expect(libRs).toContain(`secret_broker::${command}`);
+    }
+  });
+
+  it("uses service + skill for unique binding identity", () => {
+    expect(brokerRs).toContain('format!("{service_id}::{skill_id}")');
+    expect(brokerRs).toContain("service_id");
+    expect(brokerRs).toContain("skill_id");
+  });
+
+  it("keeps audit rows and active sessions separate from key rows", () => {
+    expect(brokerRs).toContain("SecretAccessAuditEvent");
+    expect(brokerRs).toContain("SecretAccessSession");
+    expect(brokerRs).toContain("ended_reason");
+    expect(brokerRs).toContain("key_edited");
+    expect(brokerRs).toContain('return Err("approval_required"');
+    expect(brokerRs).toContain("Default $0 cap requires an explicit approval");
+  });
+
+  it("list API exposes metadata without returning secret values", () => {
+    const listBody = brokerRs.slice(
+      brokerRs.indexOf("pub async fn list_skill_secret_bindings"),
+      brokerRs.indexOf("pub async fn upsert_skill_secret_binding"),
+    );
+
+    expect(listBody).toContain("SecretBindingSummary");
+    expect(listBody).not.toContain("secret_values");
+  });
+});


### PR DESCRIPTION
Closes #1823.\n\n## Summary\n- Add a Settings > Keys panel matching the issue v4 per-skill mock flow.\n- Add a Tauri host-side skill secret broker with service+skill bindings, session grants, metadata-only listing, audit events, and .env migration proposals.\n- Add frontend policy helpers/services and critical regression tests for binding identity, always-ask defaults, migration planning, UI copy, and command registration.\n\n## Verification\n- ./node_modules/.bin/vitest run tests/unit/keys-secret-broker.test.ts tests/unit/keys-settings-ui.test.ts tests/unit/keys-tauri-commands.test.ts\n- ./node_modules/.bin/tsc --noEmit\n- ./node_modules/.bin/biome check src/components/settings/KeysSettings.tsx src/components/settings/SettingsPanel.tsx src/components/settings/index.ts src/lib/keys/secret-broker.ts src/services/keys.ts tests/unit/keys-secret-broker.test.ts tests/unit/keys-settings-ui.test.ts tests/unit/keys-tauri-commands.test.ts\n- cargo test secret_broker --lib\n- cargo check\n- ./node_modules/.bin/vite build