### PR TITLE
fix(claude-runtime): close #1935 — split text/thinking stream guards

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1284,8 +1284,16 @@ function handleSystemMessage(emit, session, payload) {
 function handleAssistantMessage(emit, session, payload) {
   const message = payload?.message ?? {};
   const blocks = Array.isArray(message.content) ? message.content : [];
-  const sawStreamedAssistant =
-    session.currentPrompt != null && session.currentPromptHasChunks === true;
+  // Track text vs thinking suppression independently — Claude Code's
+  // stream-json reliably emits text_delta partials but may omit thinking_delta
+  // for Opus 4.7. A single boolean dropped the only carrier of reasoning
+  // content from the final assistant envelope when text streamed alone. #1935.
+  const sawStreamedText =
+    session.currentPrompt != null &&
+    session.currentPromptHasStreamedText === true;
+  const sawStreamedThinking =
+    session.currentPrompt != null &&
+    session.currentPromptHasStreamedThinking === true;
 
   // Track the largest per-turn input across tool-call iterations. message.usage
   // is the authoritative per-API-call count from Anthropic — see #1611.
@@ -1348,8 +1356,8 @@ function handleAssistantMessage(emit, session, payload) {
   for (const block of blocks) {
     switch (block?.type) {
       case "text":
-        if (!sawStreamedAssistant && typeof block.text === "string" && block.text.length > 0) {
-          session.currentPromptHasChunks = true;
+        if (!sawStreamedText && typeof block.text === "string" && block.text.length > 0) {
+          session.currentPromptHasStreamedText = true;
           emit("provider://message-chunk", {
             sessionId: session.id,
             text: block.text,
@@ -1359,11 +1367,11 @@ function handleAssistantMessage(emit, session, payload) {
 
       case "thinking":
         if (
-          !sawStreamedAssistant &&
+          !sawStreamedThinking &&
           typeof block.thinking === "string" &&
           block.thinking.length > 0
         ) {
-          session.currentPromptHasChunks = true;
+          session.currentPromptHasStreamedThinking = true;
           emit("provider://message-chunk", {
             sessionId: session.id,
             text: block.thinking,
@@ -1406,13 +1414,14 @@ function handleStreamEvent(emit, session, payload) {
   const event = payload?.event ?? {};
   switch (event.type) {
     case "message_start":
-      session.currentPromptHasChunks = false;
+      session.currentPromptHasStreamedText = false;
+      session.currentPromptHasStreamedThinking = false;
       return;
 
     case "content_block_delta": {
       const delta = event.delta ?? {};
       if (delta.type === "text_delta" && typeof delta.text === "string") {
-        session.currentPromptHasChunks = true;
+        session.currentPromptHasStreamedText = true;
         emit("provider://message-chunk", {
           sessionId: session.id,
           text: delta.text,
@@ -1421,7 +1430,7 @@ function handleStreamEvent(emit, session, payload) {
         delta.type === "thinking_delta" &&
         typeof delta.thinking === "string"
       ) {
-        session.currentPromptHasChunks = true;
+        session.currentPromptHasStreamedThinking = true;
         emit("provider://message-chunk", {
           sessionId: session.id,
           text: delta.thinking,
@@ -1618,7 +1627,8 @@ export function createClaudeRuntime({ emit }) {
       nextControlRequestId: 1,
       pendingPermissions: new Map(),
       currentPrompt: null,
-      currentPromptHasChunks: false,
+      currentPromptHasStreamedText: false,
+      currentPromptHasStreamedThinking: false,
       allowedTools: new Set(),
       toolInputs: new Map(),
       agentSessionId,
@@ -1904,7 +1914,8 @@ export function createClaudeRuntime({ emit }) {
 
     const combinedPrompt = combinePrompt(prompt, context);
     session.status = "prompting";
-    session.currentPromptHasChunks = false;
+    session.currentPromptHasStreamedText = false;
+    session.currentPromptHasStreamedThinking = false;
     emit("provider://session-status", {
       sessionId,
       status: "prompting",
@@ -2254,4 +2265,6 @@ export {
   comparePickerEntries as _comparePickerEntries,
   resolveSpawnShell as _resolveSpawnShell,
   buildClaudeArgs as _buildClaudeArgs,
+  handleAssistantMessage as _handleAssistantMessage,
+  handleStreamEvent as _handleStreamEvent,
 };

--- a/tests/unit/claude-runtime-thinking-from-final-message.test.ts
+++ b/tests/unit/claude-runtime-thinking-from-final-message.test.ts
@@ -1,0 +1,134 @@
+// ABOUTME: Critical regression for #1935 — final-message thinking blocks must
+// ABOUTME: reach the UI when only text_delta partials streamed in the same turn.
+
+import { describe, expect, it, vi } from "vitest";
+
+const runtimeUrl = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const mod = await import(/* @vite-ignore */ runtimeUrl);
+
+const handleAssistantMessage = mod._handleAssistantMessage as (
+  emit: (channel: string, payload: Record<string, unknown>) => void,
+  session: Record<string, unknown>,
+  payload: Record<string, unknown>,
+) => void;
+const handleStreamEvent = mod._handleStreamEvent as (
+  emit: (channel: string, payload: Record<string, unknown>) => void,
+  session: Record<string, unknown>,
+  payload: Record<string, unknown>,
+) => void;
+
+function makeSession(): Record<string, unknown> {
+  return {
+    id: "session-1",
+    agentSessionId: "agent-1",
+    currentPrompt: { resolve: () => {}, reject: () => {} },
+    currentPromptHasStreamedText: false,
+    currentPromptHasStreamedThinking: false,
+    currentPromptHasChunks: false,
+    currentModelId: "claude-opus-4-7[1m]",
+    availableModelRecords: [],
+    peakInputTokens: 0,
+  };
+}
+
+describe("#1935 thinking-block emission from final assistant message", () => {
+  it("emits thinking-block when only text_delta streamed (Opus 4.7 with --effort medium)", () => {
+    // Reproduces the production failure: Claude Code's stream-json reliably
+    // emits text_delta partials but does NOT emit thinking_delta partials for
+    // Opus 4.7. The pre-fix single-flag guard suppressed BOTH text and
+    // thinking blocks from the final aggregated assistant message once any
+    // streamed chunk arrived — silently dropping the only carrier of
+    // reasoning content. Post-fix, text and thinking suppression are tracked
+    // independently.
+    const session = makeSession();
+    const emit = vi.fn();
+
+    handleStreamEvent(emit, session, {
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Hello " },
+      },
+    });
+
+    emit.mockClear();
+
+    handleAssistantMessage(emit, session, {
+      type: "assistant",
+      message: {
+        model: "claude-opus-4-7",
+        content: [
+          { type: "thinking", thinking: "Reasoning step.", signature: "sig" },
+          { type: "text", text: "Hello world" },
+        ],
+      },
+    });
+
+    const chunks = emit.mock.calls.filter(
+      ([channel]) => channel === "provider://message-chunk",
+    );
+    const thinkingEmit = chunks.find(([, payload]) => payload.isThought);
+    const textEmit = chunks.find(
+      ([, payload]) => !payload.isThought && payload.text === "Hello world",
+    );
+
+    expect(thinkingEmit, "thinking block must be emitted").toBeDefined();
+    expect(thinkingEmit?.[1]).toMatchObject({
+      sessionId: "session-1",
+      text: "Reasoning step.",
+      isThought: true,
+    });
+    expect(
+      textEmit,
+      "text block must NOT be re-emitted (already streamed)",
+    ).toBeUndefined();
+  });
+
+  it("does not duplicate thinking when thinking_delta also streamed", () => {
+    // De-dup safety: when partials cover both block types, the final message
+    // must suppress both. Guards against the fix over-correcting.
+    const session = makeSession();
+    const emit = vi.fn();
+
+    handleStreamEvent(emit, session, {
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "thinking_delta", thinking: "Reasoning " },
+      },
+    });
+    handleStreamEvent(emit, session, {
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 1,
+        delta: { type: "text_delta", text: "Hello " },
+      },
+    });
+
+    emit.mockClear();
+
+    handleAssistantMessage(emit, session, {
+      type: "assistant",
+      message: {
+        model: "claude-opus-4-7",
+        content: [
+          { type: "thinking", thinking: "Reasoning step.", signature: "sig" },
+          { type: "text", text: "Hello world" },
+        ],
+      },
+    });
+
+    const chunks = emit.mock.calls.filter(
+      ([channel]) => channel === "provider://message-chunk",
+    );
+    expect(chunks, "neither block may re-emit when both streamed").toHaveLength(
+      0,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #1935
- Splits the single `currentPromptHasChunks` flag at `bin/browser-local/claude-runtime.mjs:1287` into two independent flags: `currentPromptHasStreamedText` and `currentPromptHasStreamedThinking`
- Suppresses each final-message block type only against its own flag, so a text-only partial stream no longer drops the final thinking block

## Root Cause

The pre-fix guard read one boolean for both block types:

```js
const sawStreamedAssistant =
  session.currentPrompt != null && session.currentPromptHasChunks === true;
```

The first `text_delta` partial set `currentPromptHasChunks = true`, after which the final aggregated `assistant` envelope's `text` AND `thinking` blocks were both skipped at lines 1351 / 1361. Claude Code's stream-json on Opus 4.7 with `--effort medium` reliably emits `text_delta` partials but does not emit `thinking_delta` partials — so the final `{type: "thinking"}` block was the only carrier of reasoning content, and it was silently dropped before reaching `streamingThinking`. Result: zero Thinking cards rendered, regardless of #1912.

## Fix

Track text and thinking partials on the session independently:

- `text_delta` partial → `session.currentPromptHasStreamedText = true`
- `thinking_delta` partial → `session.currentPromptHasStreamedThinking = true`
- Final `text` block emitted only if `!sawStreamedText`
- Final `thinking` block emitted only if `!sawStreamedThinking`
- Both reset on `message_start` and on `sendPrompt`

Original de-dup intent preserved: when both partial streams cover both block types, neither block re-emits from the final message.

## Downstream Impact

The downstream pipeline (`provider_worker.rs` → `providers.ts` `messageChunk` → `agent.store` `handleMessageChunk` → `streamingThinking` → `finalizeStreamingContent` → `type:"thought"` message → `<ThinkingBlock>`) requires no changes — it was already wired correctly. The parser was discarding valid input.

## Tests

Critical regression: `tests/unit/claude-runtime-thinking-from-final-message.test.ts`

- **Test 1** — text-only partials must not block thinking emission (the production failure): pre-fix FAIL, post-fix PASS
- **Test 2** — when both partial streams cover both block types, neither re-emits (de-dup safety): post-fix PASS

Plus 100 existing tests across 16 claude-runtime / agent-thinking test files continue to pass. Failures in `skills-auto-sync.test.ts` etc. are pre-existing on main (missing `@tanstack/solid-query` from node_modules) and unrelated to this change.

```
node_modules/.bin/vitest run tests/unit/claude-runtime tests/unit/claude- tests/unit/agent-thinking
# Test Files  16 passed (16)
# Tests       100 passed (100)
```

## Test Plan

- [x] Pre-fix regression test fails with shared-flag suppression
- [x] Post-fix regression test passes with split flags
- [x] No claude-runtime / agent-thinking regressions
- [x] Spawn args unchanged (`--effort medium`, `--include-partial-messages` still on)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com