### PR TITLE
fix(playwright-mcp): close #1937 — add cookies, init-script, wait-for-selector

### DIFF
--- a/mcp-servers/playwright-stealth/src/__tests__/add_cookies.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/add_cookies.test.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Tests for the playwright_add_cookies tool — verifies an HttpOnly
+// ABOUTME: cookie written via addCookies is readable through getCookie.
+
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { closeBrowser, getContext, getPage } from "../browser.js";
+import { addCookies, getCookie } from "../tools.js";
+
+const ORIGIN = "https://example.test";
+
+async function navigateToOrigin(): Promise<void> {
+  const page = await getPage();
+  await page.route(`${ORIGIN}/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<html><body>ok</body></html>",
+    });
+  });
+  await page.goto(`${ORIGIN}/`);
+}
+
+describe("addCookies", () => {
+  beforeEach(async () => {
+    const ctx = await getContext();
+    await ctx.clearCookies();
+  });
+
+  afterAll(async () => {
+    await closeBrowser();
+  });
+
+  it("writes an HttpOnly cookie that getCookie can read back", async () => {
+    await navigateToOrigin();
+
+    const result = await addCookies([
+      {
+        name: "privy-refresh-token",
+        value: "refresh-token-abc",
+        domain: "example.test",
+        path: "/",
+        httpOnly: true,
+        secure: true,
+        sameSite: "Lax",
+      },
+    ]);
+
+    expect(result).toBe("Added 1 cookie(s)");
+    const read = await getCookie("privy-refresh-token");
+    expect(read).toEqual({ value: "refresh-token-abc" });
+  });
+});

--- a/mcp-servers/playwright-stealth/src/__tests__/add_init_script.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/add_init_script.test.ts
@@ -1,0 +1,39 @@
+// ABOUTME: Tests for the playwright_add_init_script tool — verifies a script
+// ABOUTME: registered on the context runs before page scripts on navigation.
+
+import { afterAll, describe, expect, it } from "vitest";
+import { closeBrowser, getPage, resetPage } from "../browser.js";
+import { addInitScript, evaluate } from "../tools.js";
+
+const ORIGIN = "https://example.test";
+
+describe("addInitScript", () => {
+  afterAll(async () => {
+    await closeBrowser();
+  });
+
+  it("runs registered script before page scripts on every navigation", async () => {
+    // Fresh page so a previously-installed init script from another test
+    // cannot mask whether the new one actually fired.
+    await resetPage();
+    const page = await getPage();
+    await page.route(`${ORIGIN}/**`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<html><body>ok</body></html>",
+      });
+    });
+
+    const result = await addInitScript(
+      "window.localStorage.setItem('seren-session', 'jwt-xyz');",
+    );
+    expect(result).toBe("Init script registered");
+
+    await page.goto(`${ORIGIN}/`);
+    const value = await evaluate(
+      "window.localStorage.getItem('seren-session')",
+    );
+    expect(value).toBe("jwt-xyz");
+  });
+});

--- a/mcp-servers/playwright-stealth/src/__tests__/wait_for_selector.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/wait_for_selector.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Tests for the playwright_wait_for_selector tool — verifies it
+// ABOUTME: resolves on asynchronous element insert and rejects on timeout.
+
+import { afterAll, describe, expect, it } from "vitest";
+import { closeBrowser, getPage, resetPage } from "../browser.js";
+import { waitForSelector } from "../tools.js";
+
+const ORIGIN = "https://example.test";
+
+async function navigateWithBody(body: string): Promise<void> {
+  await resetPage();
+  const page = await getPage();
+  await page.route(`${ORIGIN}/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<html><body>${body}</body></html>`,
+    });
+  });
+  await page.goto(`${ORIGIN}/`);
+}
+
+describe("waitForSelector", () => {
+  afterAll(async () => {
+    await closeBrowser();
+  });
+
+  it("resolves once an asynchronously-inserted selector becomes visible", async () => {
+    await navigateWithBody(
+      "<script>setTimeout(() => { const d = document.createElement('div'); d.id = 'late'; d.textContent = 'hi'; document.body.appendChild(d); }, 50);</script>",
+    );
+
+    const result = await waitForSelector("#late", { timeout: 5000 });
+    expect(result).toBe("Selector ready: #late");
+  });
+
+  it("rejects when the selector never appears within the timeout", async () => {
+    await navigateWithBody("<div>empty</div>");
+
+    await expect(waitForSelector("#never", { timeout: 250 })).rejects.toThrow();
+  });
+});

--- a/mcp-servers/playwright-stealth/src/index.ts
+++ b/mcp-servers/playwright-stealth/src/index.ts
@@ -236,6 +236,79 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ["name"],
         },
       },
+      {
+        name: "playwright_add_cookies",
+        description:
+          "Write cookies to the current browser context. Supports HttpOnly and Secure cookies that playwright_evaluate cannot set. Each cookie requires either (domain + path) or url. Used to restore cached authentication sessions before navigation.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            cookies: {
+              type: "array",
+              description: "Cookies to add to the browser context.",
+              items: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  value: { type: "string" },
+                  url: { type: "string" },
+                  domain: { type: "string" },
+                  path: { type: "string" },
+                  expires: { type: "number" },
+                  httpOnly: { type: "boolean" },
+                  secure: { type: "boolean" },
+                  sameSite: {
+                    type: "string",
+                    enum: ["Strict", "Lax", "None"],
+                  },
+                },
+                required: ["name", "value"],
+              },
+            },
+          },
+          required: ["cookies"],
+        },
+      },
+      {
+        name: "playwright_add_init_script",
+        description:
+          "Register a JavaScript snippet to run before any page script on every navigation in the active context. Used to seed window.localStorage / window.sessionStorage with cached tokens before the page's SPA bootstrap code runs.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            script: {
+              type: "string",
+              description:
+                "JavaScript source to execute in page context before the page's own scripts.",
+            },
+          },
+          required: ["script"],
+        },
+      },
+      {
+        name: "playwright_wait_for_selector",
+        description:
+          "Wait for a selector to reach the requested state before continuing. Returns once the element matches; rejects with a Playwright TimeoutError if it does not appear in time. Default state is 'visible', default timeout is 30000ms.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            selector: {
+              type: "string",
+              description: "CSS selector to wait for.",
+            },
+            state: {
+              type: "string",
+              enum: ["attached", "detached", "visible", "hidden"],
+              description: "Selector state to wait for. Defaults to 'visible'.",
+            },
+            timeout: {
+              type: "number",
+              description: "Timeout in milliseconds. Defaults to 30000.",
+            },
+          },
+          required: ["selector"],
+        },
+      },
     ],
   };
 });
@@ -306,6 +379,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         break;
       case "playwright_get_cookie":
         result = await tools.getCookie(args.name as string);
+        break;
+      case "playwright_add_cookies":
+        result = await tools.addCookies(
+          args.cookies as Parameters<typeof tools.addCookies>[0],
+        );
+        break;
+      case "playwright_add_init_script":
+        result = await tools.addInitScript(args.script as string);
+        break;
+      case "playwright_wait_for_selector":
+        result = await tools.waitForSelector(args.selector as string, {
+          state: args.state as
+            | "attached"
+            | "detached"
+            | "visible"
+            | "hidden"
+            | undefined,
+          timeout: args.timeout as number | undefined,
+        });
         break;
       case "playwright_set_browser": {
         const browserArg =

--- a/mcp-servers/playwright-stealth/src/tools.ts
+++ b/mcp-servers/playwright-stealth/src/tools.ts
@@ -1,14 +1,21 @@
 // ABOUTME: MCP tool implementations for stealth browser automation.
 // ABOUTME: Includes browser discovery and runtime switching tools.
 
+import type { BrowserContext, Page } from "playwright";
 import {
   closeBrowser,
   getActiveBrowserType,
+  getContext,
   getPage,
   listInstalledBrowsers,
   resetPage,
   setBrowser,
 } from "./browser.js";
+
+type CookieInput = Parameters<BrowserContext["addCookies"]>[0][number];
+type WaitForSelectorOptions = NonNullable<
+  Parameters<Page["waitForSelector"]>[1]
+>;
 
 export async function navigate(url: string): Promise<string> {
   const page = await getPage();
@@ -50,6 +57,30 @@ export async function getCookie(
   const cookies = await page.context().cookies(page.url());
   const match = cookies.find((c) => c.name === name);
   return { value: match ? match.value : null };
+}
+
+export async function addCookies(cookies: CookieInput[]): Promise<string> {
+  const ctx = await getContext();
+  await ctx.addCookies(cookies);
+  return `Added ${cookies.length} cookie(s)`;
+}
+
+// Registers a script that runs before any page script on every navigation
+// in the active context. Used to restore tokens into localStorage/sessionStorage
+// before the SPA's bootstrap code runs.
+export async function addInitScript(script: string): Promise<string> {
+  const ctx = await getContext();
+  await ctx.addInitScript(script);
+  return "Init script registered";
+}
+
+export async function waitForSelector(
+  selector: string,
+  options?: WaitForSelectorOptions,
+): Promise<string> {
+  const page = await getPage();
+  await page.waitForSelector(selector, options ?? {});
+  return `Selector ready: ${selector}`;
 }
 
 export async function extractContent(selector?: string): Promise<string> {


### PR DESCRIPTION
## Summary

- Adds `playwright_add_cookies`, `playwright_add_init_script`, and `playwright_wait_for_selector` to the `playwright-stealth` MCP server.
- Three Playwright primitives the LLM previously had no way to invoke from the connected MCP namespace — required for session restore (cookies + localStorage seeding before SPA bootstrap) and for awaiting dynamic UI.
- Test coverage is critical-path only: 4 assertions across 3 files. No mocked behavior.

## Closes

Closes #1937.

## Unblocks (not in this PR)

#636 — prophet-arb-bot SKILL.md explicitly says *\"Do not drive `mcp__playwright__*` for `/create`\"* because the connected MCP couldn't set Prophet session cookies, inject the JWT into the origin's `localStorage` before navigation, or wait for `/create` form fields to mount. All three blockers are now removed. The actual subprocess → connected-MCP migration is a follow-up.

## Test plan

- [x] `npm test` in `mcp-servers/playwright-stealth/` — all 4 new tests pass alongside the existing `getCookie` regression (6/6). The 2 pre-existing `browser.test.ts` env-sensitive failures are unchanged versus `main`.
- [x] `npx tsc --noEmit` clean.
- [x] `biome check` clean on changed files.
- [ ] Reviewer eyeball: schemas in `index.ts` match Playwright's `addCookies` / `addInitScript` / `waitForSelector` parameter shapes (types are derived via `Parameters<...>` so they track Playwright upgrades automatically).

## Note on return-string variance from issue

`playwright_add_cookies` returns `\"Added N cookie(s)\"` rather than the issue body's example `\"Added N cookies\"` — the `(s)` form is grammatically safer for the dynamic count case (`1 cookie(s)` vs `1 cookies`). The asserted test value matches the implementation.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com