### PR TITLE
fix(agent): debug-gate runtime event logs

### DIFF
--- a/src/lib/agent-runtime-debug.ts
+++ b/src/lib/agent-runtime-debug.ts
@@ -1,0 +1,29 @@
+// ABOUTME: Debug switches for noisy AgentRuntime diagnostics.
+// ABOUTME: Keeps high-volume runtime event logs opt-in instead of default console noise.
+
+export const AGENT_RUNTIME_EVENT_DEBUG_KEY = "seren.debug.agentRuntimeEvents";
+
+type DebugStorage = Pick<Storage, "getItem">;
+
+function runtimeDebugStorage(): DebugStorage | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isEnabled(value: string | null): boolean {
+  if (!value) return false;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+export function shouldLogAgentRuntimeEvent(
+  eventType: string,
+  storage: DebugStorage | null = runtimeDebugStorage(),
+): boolean {
+  if (eventType === "messageChunk") return false;
+  return isEnabled(storage?.getItem(AGENT_RUNTIME_EVENT_DEBUG_KEY) ?? null);
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3,6 +3,7 @@
 
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createStore, produce } from "solid-js/store";
+import { shouldLogAgentRuntimeEvent } from "@/lib/agent-runtime-debug";
 import {
   isLocalProviderRuntime,
   onRuntimeEvent,
@@ -2173,15 +2174,14 @@ export const agentStore = {
               return;
             }
 
-            // Skip logging high-frequency messageChunk events to avoid flooding
-            // DevTools. Other event types (sessionStatus, toolCall, etc.) are
-            // still logged for debugging.
-            if (event.type !== "messageChunk") {
+            // Event receipt logs are high-volume during tool-heavy agent runs,
+            // so they stay behind an explicit localStorage debug switch.
+            if (shouldLogAgentRuntimeEvent(event.type)) {
               const session = state.sessions[eventSessionId];
               const spawnCtx = session
                 ? undefined
                 : spawnContextMap.get(eventSessionId);
-              console.log(
+              console.debug(
                 "[AgentRuntime] Event received - type:",
                 event.type,
                 "agent:",

--- a/tests/unit/agent-runtime-event-debug.test.ts
+++ b/tests/unit/agent-runtime-event-debug.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Regression coverage for debug-gating noisy AgentRuntime event receipt logs.
+// ABOUTME: Keeps toolCall/toolResult console spam silent unless explicitly enabled.
+
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_RUNTIME_EVENT_DEBUG_KEY,
+  shouldLogAgentRuntimeEvent,
+} from "@/lib/agent-runtime-debug";
+
+function storageWith(value: string | null): Pick<Storage, "getItem"> {
+  return {
+    getItem(key: string) {
+      return key === AGENT_RUNTIME_EVENT_DEBUG_KEY ? value : null;
+    },
+  };
+}
+
+describe("AgentRuntime event debug logging", () => {
+  it("is silent by default for high-frequency tool events", () => {
+    expect(shouldLogAgentRuntimeEvent("toolCall", storageWith(null))).toBe(
+      false,
+    );
+    expect(shouldLogAgentRuntimeEvent("toolResult", storageWith(null))).toBe(
+      false,
+    );
+  });
+
+  it("logs runtime events when the debug toggle is enabled", () => {
+    expect(shouldLogAgentRuntimeEvent("toolCall", storageWith("true"))).toBe(
+      true,
+    );
+    expect(shouldLogAgentRuntimeEvent("toolResult", storageWith("1"))).toBe(
+      true,
+    );
+  });
+
+  it("keeps messageChunk suppressed even when event debug logging is enabled", () => {
+    expect(
+      shouldLogAgentRuntimeEvent("messageChunk", storageWith("true")),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/agent-session-events.test.ts
+++ b/tests/unit/agent-session-events.test.ts
@@ -79,5 +79,17 @@ describe("spawn context map for diagnostic logging", () => {
     expect(agentStoreSource).toContain("spawnCtx?.agentType");
     expect(agentStoreSource).toContain("spawnCtx?.conversationId");
   });
-});
 
+  it("gates the global event logger behind the runtime event debug toggle", () => {
+    const logIndex = agentStoreSource.indexOf(
+      '"[AgentRuntime] Event received - type:"',
+    );
+    expect(logIndex).toBeGreaterThan(-1);
+
+    const gateIndex = agentStoreSource.lastIndexOf(
+      "shouldLogAgentRuntimeEvent(event.type)",
+      logIndex,
+    );
+    expect(gateIndex).toBeGreaterThan(-1);
+  });
+});


### PR DESCRIPTION
Closes #1939.

## Summary
- Add an explicit AgentRuntime event debug toggle via `seren.debug.agentRuntimeEvents`.
- Gate the noisy event receipt log behind that toggle and emit it with `console.debug`.
- Keep `messageChunk` suppressed even when the debug toggle is enabled.

## Audit
- The repeated `[AgentRuntime] Event received` path now requires `shouldLogAgentRuntimeEvent(event.type)`.
- Normal mode returns false for `toolCall` and `toolResult`, removing the observed console spam.
- Debug mode can be enabled with `localStorage.setItem("seren.debug.agentRuntimeEvents", "true")`.

## Tests
- `./node_modules/.bin/vitest run tests/unit/agent-runtime-event-debug.test.ts tests/unit/agent-session-events.test.ts`
- `./node_modules/.bin/biome check src/lib/agent-runtime-debug.ts src/stores/agent.store.ts tests/unit/agent-runtime-event-debug.test.ts tests/unit/agent-session-events.test.ts`