### PR TITLE
fix(agent): close #1941 — XML-frame compaction prepend

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3404,6 +3404,13 @@ Structured summary:`;
       // and the user had to re-supply them. Tighter cap on tool results
       // because they can be huge file contents / JSON dumps; user and
       // assistant text gets the original 2000-char ceiling. #1858.
+      //
+      // Items are wrapped in XML-style tags rather than `USER: ` /
+      // `TOOL_RESULT (…): ` prefixes. Raw transcript prefixes match Claude
+      // Code's own stream-json output verbatim — Opus 4.7 then continues
+      // the transcript inside its assistant content instead of treating
+      // the block as quoted context, bleeding the prepend into the chat
+      // and starving the Thinking budget. #1941.
       const MAX_MSG_CHARS = 2000;
       const MAX_TOOL_CHARS = 500;
       const preservedContext = toPreserve
@@ -3413,23 +3420,26 @@ Structured summary:`;
               m.content.length > MAX_MSG_CHARS
                 ? `${m.content.slice(0, MAX_MSG_CHARS)}... [truncated]`
                 : m.content;
-            return `${m.type.toUpperCase()}: ${content}`;
+            if (m.type === "user") {
+              return `<prior_user>${content}</prior_user>`;
+            }
+            return `<prior_assistant>${content}</prior_assistant>`;
           }
           if (m.type === "tool" && m.toolCall?.result) {
-            const title = m.toolCall.title || "tool";
+            const title = (m.toolCall.title || "tool").replace(/"/g, "'");
             const result = m.toolCall.result;
             const trimmed =
               result.length > MAX_TOOL_CHARS
                 ? `${result.slice(0, MAX_TOOL_CHARS)}... [truncated]`
                 : result;
-            return `TOOL_RESULT (${title}): ${trimmed}`;
+            return `<prior_tool name="${title}">${trimmed}</prior_tool>`;
           }
           return null;
         })
         .filter((s): s is string => s !== null)
         .join("\n\n");
       const prependText = preservedContext
-        ? `Prior work summary:\n${summary}\n\nRecent messages:\n${preservedContext}`
+        ? `Prior work summary:\n${summary}\n\n<prior_messages>\n${preservedContext}\n</prior_messages>`
         : `Prior work summary:\n${summary}`;
 
       const userTurnCount = Math.max(1, Math.ceil(toPreserve.length / 2));

--- a/tests/unit/compaction-prepend-format.test.ts
+++ b/tests/unit/compaction-prepend-format.test.ts
@@ -1,0 +1,73 @@
+// ABOUTME: #1941 — compaction prepend must not look like a Claude Code transcript.
+// ABOUTME: Raw "USER:" / "TOOL_RESULT (" prefixes prime Opus 4.7 to continue the
+// ABOUTME: transcript inside its assistant content, bleeding into the chat.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+function preservedContextBlock(): string {
+  // Narrow to the preserved-context formatter and prepend wrapper. The
+  // summarizer-input prompt earlier in compactAgentConversation legitimately
+  // uses `${m.type.toUpperCase()}: ${m.content}` because that text feeds a
+  // summarization request, not a continuation request — different codepath,
+  // not the bleed source. Anchor on the formatter's variable name so
+  // assertions are scoped to the bug surface.
+  const start = agentStoreSource.indexOf("const preservedContext = toPreserve");
+  if (start < 0) {
+    throw new Error("preservedContext formatter not found in agent.store.ts");
+  }
+  const end = agentStoreSource.indexOf("const userTurnCount", start);
+  if (end < 0) {
+    throw new Error("could not find prepend-wrapper end");
+  }
+  return agentStoreSource.slice(start, end);
+}
+
+describe("#1941 — preserved-context format does not mimic Claude Code stream-json", () => {
+  it("does not emit raw USER:/ASSISTANT: line prefixes for preserved messages", () => {
+    // The bleed in wut.png matched these literal prefixes verbatim. The
+    // template that produced them was `${m.type.toUpperCase()}: ${content}`
+    // which expanded to `USER: …` / `ASSISTANT: …`. Banning the template
+    // string itself is the durable check — banning the expanded output
+    // would false-positive on legitimate uses of "USER:" elsewhere.
+    const body = preservedContextBlock();
+    expect(
+      body,
+      "Recent-messages formatter must not concatenate `<TYPE>: ` style prefixes",
+    ).not.toMatch(/m\.type\.toUpperCase\(\)\s*\}\s*:/);
+  });
+
+  it("does not emit raw TOOL_RESULT (title): prefix for preserved tool results", () => {
+    const body = preservedContextBlock();
+    expect(
+      body,
+      "Recent-messages formatter must not produce TOOL_RESULT (title): output",
+    ).not.toMatch(/TOOL_RESULT\s*\(\$\{/);
+  });
+
+  it("wraps preserved messages in <prior_user>/<prior_assistant>/<prior_tool> tags", () => {
+    const body = preservedContextBlock();
+    expect(body).toMatch(/<prior_user>/);
+    expect(body).toMatch(/<\/prior_user>/);
+    expect(body).toMatch(/<prior_assistant>/);
+    expect(body).toMatch(/<\/prior_assistant>/);
+    expect(body).toMatch(/<prior_tool\b/);
+    expect(body).toMatch(/<\/prior_tool>/);
+  });
+
+  it("wraps the recent-messages window in a <prior_messages> block, not a 'Recent messages:' label", () => {
+    const body = preservedContextBlock();
+    expect(
+      body,
+      "Block label 'Recent messages:' reads as transcript framing; use <prior_messages> instead",
+    ).not.toMatch(/Recent messages:/);
+    expect(body).toMatch(/<prior_messages>/);
+    expect(body).toMatch(/<\/prior_messages>/);
+  });
+});


### PR DESCRIPTION
## Summary

- XML-frame the post-compaction prepend so Opus 4.7 stops echoing it as a Claude Code transcript inside its assistant content
- Closes #1941

## Root cause (see #1941)

`src/stores/agent.store.ts:3416/3425` emitted raw `USER: …` / `ASSISTANT: …` / `TOOL_RESULT (Bash: …): …` line prefixes — the exact shape Claude Code stream-json uses for its own transcript. Wrapped as `Prior work summary:\n…\n\nRecent messages:\n<preserved>`, the prepend reads as a transcript the model is being asked to continue. Opus 4.7 obliged: it emitted `TOOL_RESULT (…)`, `USER: [Request interrupted by user]`, `USER: <prior prompt>` inside its assistant content (visible verbatim in `wut.png`), and the bleed consumed the output budget before any Thinking block could render.

## Change

Wrap preserved items in XML-style tags that the model reads as quoted context, not as continuable output:

| Before | After |
| --- | --- |
| `USER: …` | `<prior_user>…</prior_user>` |
| `ASSISTANT: …` | `<prior_assistant>…</prior_assistant>` |
| `TOOL_RESULT (Bash: …): …` | `<prior_tool name="Bash: …">…</prior_tool>` |
| `Recent messages:\n<items>` | `<prior_messages>\n<items>\n</prior_messages>` |

#1858's original intent (preserve tool handles and IDs across compaction) is unchanged — only the delimiters move out of transcript shape.

## Test plan

- [x] `pnpm vitest run tests/unit/compaction-prepend-format.test.ts` — 4 new invariants pass (no `${m.type.toUpperCase()}: ` template, no `TOOL_RESULT (${…})` template, three `prior_*` tags present, no `Recent messages:` label)
- [x] `pnpm vitest run` on the 6 neighboring compaction tests (`compact-no-seed-prompt`, `compact-retry-codex`, `compaction-queue-race`, `auto-compact-predictive`, `agent-store-summary-anti-fabrication`, `synthetic-transcript`) — 61/61 still green
- [x] `biome check` clean on changed files
- [ ] Manual: trigger auto-compaction on a session; confirm chat does not show `TOOL_RESULT (…)` / `USER:` lines and Thinking card renders on the post-compaction turn
