### PR TITLE
Fix installed skill slash invocation on fresh startup

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -24,8 +24,8 @@ import { isAuthError, isLikelyAuthError } from "@/lib/auth-errors";
 import { collapseBuildOutput } from "@/lib/build-output";
 import {
   getCompletions,
-  matchSkillCommand,
   parseCommand,
+  resolveSkillCommand,
 } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { collapseDirectoryListings } from "@/lib/directory-listing";
@@ -756,7 +756,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       if (executeSlashCommand(trimmed)) return;
 
       // Check if the slash command matches an installed skill
-      const skillMatch = matchSkillCommand(trimmed);
+      const skillMatch = await resolveSkillCommand(trimmed);
       if (skillMatch) {
         const { skill, args } = skillMatch;
         console.log("[AgentChat] Skill invocation:", skill.slug, "args:", args);

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -26,8 +26,8 @@ import {
 } from "@/lib/chat-history-export";
 import {
   getCompletions,
-  matchSkillCommand,
   parseCommand,
+  resolveSkillCommand,
 } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { createDragDrop } from "@/lib/drag-drop";
@@ -686,7 +686,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       if (executeSlashCommand(trimmed)) return;
 
       // Check if the slash command matches an installed skill
-      const skillMatch = matchSkillCommand(trimmed);
+      const skillMatch = await resolveSkillCommand(trimmed);
       if (skillMatch) {
         const { skill, args } = skillMatch;
         console.log(

--- a/src/lib/commands/parser.ts
+++ b/src/lib/commands/parser.ts
@@ -93,6 +93,25 @@ export function matchSkillCommand(
 }
 
 /**
+ * Resolve a skill slash command, refreshing the installed inventory once when
+ * the in-memory store has not caught up with disk yet. This closes the fresh
+ * startup path where a valid `/skill-slug` could fall through to the agent as
+ * plain text before `skillsStore.refresh()` completed.
+ */
+export async function resolveSkillCommand(
+  input: string,
+): Promise<{ skill: InstalledSkill; args: string } | null> {
+  const immediateMatch = matchSkillCommand(input);
+  if (immediateMatch) return immediateMatch;
+
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("/")) return null;
+
+  await skillsStore.refreshInstalled();
+  return matchSkillCommand(input);
+}
+
+/**
  * Search installed skills whose slug or display name match a partial input.
  * Returns SlashCommand entries for the autocomplete popup.
  */

--- a/tests/unit/skill-payload-status.test.ts
+++ b/tests/unit/skill-payload-status.test.ts
@@ -140,6 +140,22 @@ describe("skill-install race fix (#1917)", () => {
     expect(matchSkillCommand("/legacy-skill")?.skill.slug).toBe("legacy-skill");
   });
 
+  it("resolveSkillCommand refreshes installed skills before letting a slash skill fall through", async () => {
+    const ready = installedSkill("prophet-arb-bot", { payloadStatus: "ready" });
+    mockSkillsService.listAllInstalled.mockResolvedValue([ready]);
+
+    const { matchSkillCommand, resolveSkillCommand } = await import(
+      "@/lib/commands/parser"
+    );
+
+    expect(matchSkillCommand("/prophet-arb-bot")).toBeNull();
+
+    const match = await resolveSkillCommand("/prophet-arb-bot");
+
+    expect(mockSkillsService.listAllInstalled).toHaveBeenCalledTimes(1);
+    expect(match?.skill.slug).toBe("prophet-arb-bot");
+  });
+
   it("getThreadSkills filters out skills with payloadStatus='failed' so the system prompt never sees them", async () => {
     const ready = installedSkill("ready-skill", { payloadStatus: "ready" });
     const failed = installedSkill("prophet-arb-bot", {


### PR DESCRIPTION
## Summary\n- Closes #1943.\n- Adds an async skill slash-command resolver that refreshes installed skills once after an in-memory miss, then retries matching.\n- Uses that resolver in both AgentChat and ChatContent so `/prophet-arb-bot` does not fall through as raw model text during fresh startup.\n\n## Audit\n- Issue reproduced from screenshot: Desktop sent `/prophet-arb-bot` through to the agent, which answered with its own unavailable-skill list.\n- Root cause: slash command matching used only the current `skillsStore.installed` snapshot; on a first-run/startup race the snapshot can be empty/stale before local skill inventory refresh completes.\n- Fix path: built-in commands still execute first; installed skills still honor enabled state and failed-payload blocking; only a skill miss triggers `refreshInstalled()` and one retry before fallback.\n- Impact: valid installed skill invocations become deterministic on startup; unknown slash text can still fall through after the retry.\n\n## Tests\n- `./node_modules/.bin/vitest run tests/unit/skill-payload-status.test.ts`\n- `./node_modules/.bin/biome check src/lib/commands/parser.ts src/components/chat/AgentChat.tsx src/components/chat/ChatContent.tsx`\n- `./node_modules/.bin/vite build`\n\n## Notes\n- The initial worktree test command attempted to hydrate dependencies and pnpm stopped before Vitest due unapproved build-script policy. Running the local Vitest binary after hydration completed successfully.