### PR TITLE
fix(mcp): close #1945 — inject playwright-stealth path env

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -527,11 +527,35 @@ pub fn run() {
             // skills spawned by those agents) inherits these vars and can
             // detect that it's running under Seren Desktop.
             // Spec: serenorg/seren-desktop#1496
+            //
+            // SEREN_PLAYWRIGHT_MCP_COMMAND lets skill subprocesses
+            // (prophet-arb-bot's automated browser flows) spawn the bundled
+            // playwright-stealth MCP server without hardcoding the macOS
+            // path. Resolved once here from the resource_dir so Windows and
+            // Linux inherit a working absolute command too. #1945.
+            //
             // SAFETY: set_var is unsafe in Rust 2024. Called exactly once
             // during app setup before any threads spawn child processes.
             unsafe {
                 std::env::set_var("SEREN_HOST", "seren-desktop");
                 std::env::set_var("SEREN_DESKTOP", "1");
+
+                let resource_dir = app.path().resource_dir().ok();
+                if let Some(script) =
+                    mcp::resolve_playwright_mcp_script_path_from(resource_dir.as_deref())
+                {
+                    let node = mcp::resolve_command_in_embedded_path("node");
+                    let cmd = mcp::format_playwright_mcp_command(&node, &script);
+                    log::info!("[MCP] SEREN_PLAYWRIGHT_MCP_COMMAND={}", cmd);
+                    std::env::set_var("SEREN_PLAYWRIGHT_MCP_COMMAND", cmd);
+                } else {
+                    log::warn!(
+                        "[MCP] playwright-stealth script not found on disk; \
+                         SEREN_PLAYWRIGHT_MCP_COMMAND not exported. Skill \
+                         subprocesses that need it will fail with a clear \
+                         setup error."
+                    );
+                }
             }
 
             // Build native menu bar for all platforms

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -235,12 +235,13 @@ fn has_working_node_modules(script_path: &std::path::Path) -> bool {
         .is_dir()
 }
 
-/// Resolve the bundled/dev Playwright MCP server script to an absolute path.
-#[tauri::command]
-pub fn resolve_playwright_mcp_script_path(app: tauri::AppHandle) -> String {
+/// Build the ordered candidate list for the playwright-stealth MCP script.
+/// Pure function — separates path search from filesystem checks so the
+/// resolver can be exercised from tests with a fixture tree. #1945.
+fn playwright_mcp_script_candidates(resource_dir: Option<&std::path::Path>) -> Vec<PathBuf> {
     let mut candidates: Vec<PathBuf> = Vec::new();
 
-    if let Ok(resource_dir) = app.path().resource_dir() {
+    if let Some(resource_dir) = resource_dir {
         candidates.push(resource_dir.join(PLAYWRIGHT_MCP_SCRIPT_RELATIVE_PATH));
         candidates.push(
             resource_dir
@@ -268,26 +269,69 @@ pub fn resolve_playwright_mcp_script_path(app: tauri::AppHandle) -> String {
         );
     }
 
+    candidates
+}
+
+/// Resolve the playwright-stealth MCP script to an absolute path from the
+/// candidate list. Prefers candidates whose `node_modules` is intact; falls
+/// back to existing-but-possibly-broken paths so the agent can still try.
+/// Returns `None` when no candidate exists on disk — callers must NOT publish
+/// a non-existent path as `SEREN_PLAYWRIGHT_MCP_COMMAND`. #1945.
+pub(crate) fn resolve_playwright_mcp_script_path_from(
+    resource_dir: Option<&std::path::Path>,
+) -> Option<PathBuf> {
+    let candidates = playwright_mcp_script_candidates(resource_dir);
+
     for candidate in &candidates {
         if candidate.exists() && has_working_node_modules(candidate) {
-            return candidate.to_string_lossy().to_string();
+            return Some(candidate.clone());
         }
     }
 
-    // Second pass: accept any candidate where the script exists, even without
-    // verified node_modules (better to attempt and get a clear error than skip).
     for candidate in &candidates {
         if candidate.exists() {
             log::warn!(
                 "[MCP] Resolved playwright script at {:?} but node_modules may be broken",
                 candidate
             );
-            return candidate.to_string_lossy().to_string();
+            return Some(candidate.clone());
         }
     }
 
+    None
+}
+
+/// Resolve the bundled/dev Playwright MCP server script to an absolute path.
+#[tauri::command]
+pub fn resolve_playwright_mcp_script_path(app: tauri::AppHandle) -> String {
+    let resource_dir = app.path().resource_dir().ok();
+    if let Some(path) = resolve_playwright_mcp_script_path_from(resource_dir.as_deref()) {
+        return path.to_string_lossy().to_string();
+    }
     // Last-resort fallback keeps backwards compatibility with existing settings.
     PLAYWRIGHT_MCP_SCRIPT_RELATIVE_PATH.to_string()
+}
+
+/// Build the `SEREN_PLAYWRIGHT_MCP_COMMAND` value: a shell-quoted full
+/// command string that skill subprocesses can execute to spawn the bundled
+/// playwright-stealth MCP server on macOS, Windows, or Linux. #1945.
+///
+/// Quoting rule: wrap any argument that contains a space or a double-quote
+/// in double quotes, escaping inner double quotes as `\"`. The skill
+/// subprocess is expected to feed the value to its platform shell as-is
+/// (cmd.exe on Windows, /bin/sh on POSIX), so this matches the quoting
+/// both shells tolerate without special expansion.
+pub(crate) fn format_playwright_mcp_command(node: &str, script: &std::path::Path) -> String {
+    fn shell_quote(arg: &str) -> String {
+        if !arg.contains(' ') && !arg.contains('"') {
+            return arg.to_string();
+        }
+        let escaped = arg.replace('"', "\\\"");
+        format!("\"{}\"", escaped)
+    }
+
+    let script_str = script.to_string_lossy();
+    format!("{} {}", shell_quote(node), shell_quote(&script_str))
 }
 
 /// Resolve a bare command name to an absolute path by searching the embedded PATH.
@@ -1028,6 +1072,111 @@ mod tests {
             MCP_INITIALIZE_TIMEOUT >= Duration::from_secs(5),
             "MCP_INITIALIZE_TIMEOUT too aggressive; got {:?}",
             MCP_INITIALIZE_TIMEOUT
+        );
+    }
+}
+
+// ============================================================================
+// #1945 — playwright-stealth MCP resolver tests (cross-platform).
+// Skill subprocesses (prophet-arb-bot) need an absolute, OS-aware spawn
+// command for the bundled playwright-stealth MCP. The previous resolver only
+// returned a string and fell back to a non-existent relative path on miss,
+// which made the env-var injection unsafe; these tests pin the new
+// `resolve_playwright_mcp_script_path_from` (Option<PathBuf>) and
+// `format_playwright_mcp_command` (shell-quoted) contracts.
+// ============================================================================
+
+#[cfg(test)]
+mod playwright_resolver_tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    /// Materialise a fake bundled playwright-stealth tree under `root` and
+    /// return the absolute path to the script. Without a valid
+    /// `node_modules/@modelcontextprotocol/sdk/` the resolver flags the
+    /// candidate as broken; create the marker dir so the happy path matches.
+    fn make_fake_bundle(root: &Path, with_node_modules: bool) -> PathBuf {
+        let package_dir = root.join("mcp-servers").join("playwright-stealth");
+        fs::create_dir_all(package_dir.join("dist")).unwrap();
+        let script = package_dir.join("dist").join("index.js");
+        fs::write(&script, b"// stub for tests\n").unwrap();
+        if with_node_modules {
+            fs::create_dir_all(
+                package_dir
+                    .join("node_modules")
+                    .join("@modelcontextprotocol")
+                    .join("sdk"),
+            )
+            .unwrap();
+        }
+        script
+    }
+
+    #[test]
+    fn returns_none_when_no_candidate_exists_on_disk() {
+        // Empty resource dir + no workspace bundle on this isolated tmp
+        // tree → resolver must return None so callers don't publish a
+        // bogus SEREN_PLAYWRIGHT_MCP_COMMAND. The pre-#1945 behaviour was
+        // to return the bare relative path, which would silently fail on
+        // Windows where the cwd-relative miss can't be exec'd.
+        let tmp = tempfile::tempdir().unwrap();
+        // Note: cwd / workspace_root / exe_dir candidates may exist in the
+        // dev tree, so we only assert the resource_dir branch. The resource
+        // dir is empty, so it contributes no matches; remaining candidates
+        // are out-of-test-control. The assertion here is structural: the
+        // function must be invocable with `None` resource_dir and a
+        // missing-bundle tmp dir without panicking, and return whatever the
+        // remaining fallbacks resolve to (Option<PathBuf>, not the bare
+        // relative-path String the legacy command returned).
+        let resolved = resolve_playwright_mcp_script_path_from(Some(tmp.path()));
+        // The result is either None or an existing absolute path — never a
+        // relative path that won't exec from an arbitrary cwd.
+        if let Some(path) = &resolved {
+            assert!(path.is_absolute(), "resolved path must be absolute, got {:?}", path);
+            assert!(path.exists(), "resolved path must exist, got {:?}", path);
+        }
+    }
+
+    #[test]
+    fn resource_dir_with_intact_bundle_is_preferred() {
+        let tmp = tempfile::tempdir().unwrap();
+        let expected = make_fake_bundle(tmp.path(), true);
+
+        let resolved = resolve_playwright_mcp_script_path_from(Some(tmp.path()))
+            .expect("resolver must return Some when the resource bundle exists");
+
+        // Canonicalise both sides — macOS turns /var/folders into /private/var.
+        let resolved_canon = resolved.canonicalize().unwrap_or(resolved);
+        let expected_canon = expected.canonicalize().unwrap_or(expected);
+        assert_eq!(resolved_canon, expected_canon);
+    }
+
+    #[test]
+    fn shell_quote_paths_with_spaces() {
+        // Windows install path under "Program Files" or
+        // "Application Support" contains spaces. The unquoted form would
+        // break cmd.exe / /bin/sh argument splitting; the skill expects a
+        // shell-quoted full command string.
+        let node = "/usr/local/bin/node";
+        let script = std::path::Path::new("/Applications/Seren Desktop.app/Resources/x.js");
+        let cmd = format_playwright_mcp_command(node, script);
+        assert_eq!(
+            cmd,
+            "/usr/local/bin/node \"/Applications/Seren Desktop.app/Resources/x.js\""
+        );
+    }
+
+    #[test]
+    fn shell_quote_skipped_for_simple_paths() {
+        // Don't add noise when neither token needs quoting — keeps the
+        // injected env value readable in logs.
+        let node = "/usr/local/bin/node";
+        let script = std::path::Path::new("/opt/seren/playwright-stealth/dist/index.js");
+        let cmd = format_playwright_mcp_command(node, script);
+        assert_eq!(
+            cmd,
+            "/usr/local/bin/node /opt/seren/playwright-stealth/dist/index.js"
         );
     }
 }

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -420,8 +420,16 @@ mod tests {
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("mock app builds");
 
+        // Open the store and ALWAYS reset the key — `tauri-plugin-store`
+        // persists `auth.json` to the mock runtime's data dir, which is
+        // shared across sibling test invocations on the same host. Without
+        // an explicit delete, a prior `mock_app_with_api_key(Some("..."))`
+        // call leaves the key on disk; the next `Some(None)` call inherits
+        // it and the "logged out" assertion fails. Per-test self-containment
+        // is the only safe contract here. #1945.
+        let store = app.store(AUTH_STORE).expect("auth store opens");
+        store.delete(SEREN_API_KEY_KEY);
         if let Some(api_key) = api_key {
-            let store = app.store(AUTH_STORE).expect("auth store opens");
             store.set(SEREN_API_KEY_KEY, json!(api_key));
         }
 


### PR DESCRIPTION
## Summary

- Resolve the bundled `playwright-stealth` MCP path once at Tauri setup and inject `SEREN_PLAYWRIGHT_MCP_COMMAND` into the process env so every shell-spawned skill subprocess (prophet-arb-bot, future skills) can find it on macOS, Windows, and Linux.
- Closes #1945

## Root cause

Per the prophet-arb-bot skill instructions, the Python subprocess spawns the bundled `playwright-stealth` MCP server. The skill hardcoded `/Applications/SerenDesktop.app/Contents/Resources/mcp-servers/playwright-stealth/` (macOS-only) and used `SEREN_PLAYWRIGHT_MCP_COMMAND` as override. On Windows the binary lives at `%LOCALAPPDATA%\SerenDesktop\mcp-servers\playwright-stealth\dist\index.js`; no shell-spawned subprocess could resolve it, and the `/create` flow blocked with `seren_desktop_playwright_mcp_unavailable`.

The log attached to #1945 confirms the desktop-side MCP connection to `playwright-stealth` succeeded (16:57:15), so the script exists — only the skill subprocess couldn't find it.

## Change

`src-tauri/src/mcp.rs`:
- Extract `playwright_mcp_script_candidates` (pure candidate list) and `resolve_playwright_mcp_script_path_from(resource_dir) -> Option<PathBuf>` from the existing `#[tauri::command]` so the resolver is callable from `setup()` without an `AppHandle` and testable with a tmp fixture tree.
- Add `format_playwright_mcp_command(node, script) -> String` — shell-quotes tokens containing spaces or `"` so paths like `/Applications/Seren Desktop.app/...` survive `cmd.exe` and `/bin/sh` argument splitting.
- Tauri command wrapper preserves backwards compatibility — returns relative path string on miss.

`src-tauri/src/lib.rs`:
- In `setup()`'s existing `unsafe { set_var(...) }` block (single-threaded), call the resolver and inject `SEREN_PLAYWRIGHT_MCP_COMMAND=<shell-quoted node-abs-path> <shell-quoted script-abs-path>`. If the script isn't on disk, log a warning instead of publishing a bogus path.

`src-tauri/src/shell.rs` (side fix):
- `mock_app_with_api_key` now always calls `store.delete(SEREN_API_KEY_KEY)` before optionally re-setting. `tauri-plugin-store` persists `auth.json` to the mock runtime's data dir on the real filesystem (`~/Library/Application Support/auth.json` on macOS); prior `Some(...)` test invocations were leaking the key into subsequent `None` invocations and breaking `execute_shell_command_leaves_seren_credentials_empty_when_logged_out` on any host that had ever run the suite. Per-test self-containment.

## Test plan

- [x] `cargo test --lib mcp::playwright_resolver_tests` — 4 invariants pass (returns Option, picks intact bundle, shell-quotes paths with spaces, no quoting for simple paths).
- [x] `cargo test --lib shell::tests` — 7/7 pass (including the pre-existing flake that's now stable).
- [x] `cargo test --lib` — all 500 Rust unit tests pass; 1 ignored.
- [x] `cargo check` clean on all three changed files.
- [ ] Manual on Windows: run prophet-arb-bot's `--command run --yes-live` and confirm `SEREN_PLAYWRIGHT_MCP_COMMAND` is set in the subprocess env and the cold-start OTP flow resolves the bundled binary.

## Files

- `src-tauri/src/mcp.rs` (+126 / -11) — resolver split, shell-quote helper, cross-platform tests.
- `src-tauri/src/lib.rs` (+24 / -0) — setup-time env injection.
- `src-tauri/src/shell.rs` (+8 / -2) — test-store flake fix.
