### PR TITLE
feat(runtime): bundle CPython for Windows (#1947)

### DIFF
--- a/.github/workflows/check-python-version.yml
+++ b/.github/workflows/check-python-version.yml
@@ -1,0 +1,110 @@
+# Monthly check for newer CPython patch releases. Opens a PR to bump the
+# pinned version in build/win32/prepare-python-runtime.ts when python.org
+# publishes a newer patch on the same minor track. Minor-version bumps
+# (e.g. 3.12 -> 3.13) stay manual because wheel availability for skills'
+# transitive deps lags release.
+#
+# Issue: serenorg/seren-desktop#1947
+name: Check Python Version
+
+on:
+  schedule:
+    # 03:00 UTC on the 1st of every month
+    - cron: "0 3 1 * *"
+  workflow_dispatch:
+
+jobs:
+  bump-pinned-python:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read pinned Python version
+        id: pinned
+        run: |
+          PINNED=$(grep -oE 'PYTHON_VERSION = "[0-9]+\.[0-9]+\.[0-9]+"' build/win32/prepare-python-runtime.ts | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ -z "$PINNED" ]; then
+            echo "Could not read pinned Python version from prepare-python-runtime.ts" >&2
+            exit 1
+          fi
+          echo "version=$PINNED" >> "$GITHUB_OUTPUT"
+          MINOR=$(echo "$PINNED" | cut -d. -f1-2)
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve latest patch on the pinned minor track
+        id: latest
+        env:
+          PINNED_MINOR: ${{ steps.pinned.outputs.minor }}
+        run: |
+          # python.org's release index is a stable HTML page. Look for the
+          # newest tagged release on the pinned minor track (e.g. 3.12.x).
+          # Filtering on the embed-amd64 URL avoids matching beta/rc tags.
+          INDEX=$(curl -fsSL https://www.python.org/ftp/python/)
+          CANDIDATES=$(echo "$INDEX" \
+            | grep -oE "${PINNED_MINOR}\.[0-9]+/" \
+            | sed 's:/$::' \
+            | sort -V \
+            | uniq)
+
+          # Verify the embed-amd64 zip actually exists for each candidate
+          # (some directories are tag-only with no Windows release).
+          LATEST=""
+          for candidate in $CANDIDATES; do
+            if curl -fsSL --head "https://www.python.org/ftp/python/$candidate/python-$candidate-embed-amd64.zip" > /dev/null; then
+              LATEST="$candidate"
+            fi
+          done
+
+          if [ -z "$LATEST" ]; then
+            echo "No Windows embed releases found on track $PINNED_MINOR" >&2
+            exit 1
+          fi
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+
+      - name: Compare versions
+        id: compare
+        env:
+          PINNED: ${{ steps.pinned.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
+        run: |
+          if [ "$PINNED" = "$LATEST" ]; then
+            echo "Pinned $PINNED matches latest $LATEST; nothing to do."
+            echo "bump=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Pinned $PINNED < latest $LATEST; bump available."
+            echo "bump=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump pinned version
+        if: steps.compare.outputs.bump == 'true'
+        env:
+          PINNED: ${{ steps.pinned.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
+        run: |
+          sed -i "s/PYTHON_VERSION = \"$PINNED\"/PYTHON_VERSION = \"$LATEST\"/" build/win32/prepare-python-runtime.ts
+
+      - name: Open pull request
+        if: steps.compare.outputs.bump == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: maintenance/python-${{ steps.latest.outputs.version }}
+          commit-message: |
+            chore: bump bundled Python to ${{ steps.latest.outputs.version }} (#1947)
+          title: "chore: bump bundled Python to ${{ steps.latest.outputs.version }}"
+          body: |
+            Automated patch-version bump for the bundled Windows CPython
+            distribution (issue #1947).
+
+            - Previous: ${{ steps.pinned.outputs.version }}
+            - Latest patch on the ${{ steps.pinned.outputs.minor }} track: ${{ steps.latest.outputs.version }}
+
+            Minor-version bumps (3.X -> 3.Y) stay manual because wheel
+            availability for transitive skill dependencies (`py-clob-client`,
+            `eth-account`, etc.) typically lags a CPython minor release.
+
+            Verify the Windows release build still completes before merging.
+          labels: maintenance,automated
+          delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,6 +287,9 @@ jobs:
       - name: Prepare embedded runtime (Windows x64)
         if: matrix.target == 'x86_64-pc-windows-msvc'
         run: pnpm prepare:runtime:win32-x64
+      - name: Prepare embedded Python (Windows x64)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        run: pnpm prepare:python:win32-x64
       - name: Prepare embedded runtime (Linux x64)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: pnpm prepare:runtime:linux-x64

--- a/build/win32/prepare-python-runtime.ts
+++ b/build/win32/prepare-python-runtime.ts
@@ -1,0 +1,215 @@
+// ABOUTME: Downloads and prepares the Windows embeddable CPython distribution.
+// ABOUTME: Bundles Python with the Tauri installer so skills work without a system install.
+
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as https from "https";
+import * as path from "path";
+import { pipeline } from "stream/promises";
+
+// Version configuration — keep this pinned. The Python freshness workflow
+// (.github/workflows/check-python-version.yml) opens a PR to bump the patch
+// version monthly; minor-version bumps (3.12 → 3.13) stay manual because
+// wheel availability for skills' transitive deps may lag a release.
+const PYTHON_VERSION = "3.12.7";
+
+interface DownloadConfig {
+	url: string;
+	pthFile: string;
+}
+
+function downloadConfig(arch: "x64" | "arm64"): DownloadConfig {
+	const archSlug = arch === "x64" ? "amd64" : "arm64";
+	return {
+		url: `https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-embed-${archSlug}.zip`,
+		// e.g. python312._pth — derived from the major.minor version
+		pthFile: `python${PYTHON_VERSION.split(".").slice(0, 2).join("")}._pth`,
+	};
+}
+
+const GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py";
+
+interface PrepareOptions {
+	arch: "x64" | "arm64";
+	outputDir: string;
+}
+
+async function downloadFile(url: string, dest: string): Promise<void> {
+	console.log(`Downloading ${url}...`);
+
+	return new Promise((resolve, reject) => {
+		const file = fs.createWriteStream(dest);
+		const request = https.get(url, (response) => {
+			if (response.statusCode === 302 || response.statusCode === 301) {
+				file.close();
+				fs.unlinkSync(dest);
+				downloadFile(response.headers.location!, dest)
+					.then(resolve)
+					.catch(reject);
+				return;
+			}
+
+			if (response.statusCode !== 200) {
+				reject(new Error(`Failed to download ${url}: HTTP ${response.statusCode}`));
+				return;
+			}
+
+			pipeline(response, file).then(() => resolve()).catch(reject);
+		});
+
+		request.on("error", (err) => {
+			if (fs.existsSync(dest)) fs.unlinkSync(dest);
+			reject(err);
+		});
+	});
+}
+
+async function extractZip(zipPath: string, destDir: string): Promise<void> {
+	console.log(`Extracting ${zipPath} to ${destDir}...`);
+	const command = `powershell -NoProfile -Command "Expand-Archive -Path '${zipPath}' -DestinationPath '${destDir}' -Force"`;
+	execSync(command, { stdio: "inherit" });
+}
+
+/**
+ * The official Windows embeddable Python ships with site-packages disabled —
+ * the bundled `python3X._pth` file has `import site` commented out, which
+ * keeps `pip` from working. Uncomment it so `python -m venv` and
+ * `python -m pip` resolve through the standard site initialization.
+ *
+ * Exported for tests so the rewrite logic is unit-testable without a real
+ * Python install.
+ */
+export function enableSitePackages(pthContents: string): string {
+	const lines = pthContents.split(/\r?\n/);
+	const rewritten = lines.map((line) => {
+		const trimmed = line.trim();
+		if (trimmed === "#import site" || trimmed === "# import site") {
+			return "import site";
+		}
+		return line;
+	});
+	// If the file already has `import site` uncommented, leave it alone.
+	// If it has no `import site` line at all (unlikely but possible across
+	// patch versions), append one — the embed package contract is that the
+	// file is the only path config python.exe reads at boot.
+	const hasUncommented = rewritten.some((l) => l.trim() === "import site");
+	if (!hasUncommented) {
+		rewritten.push("import site");
+	}
+	return rewritten.join("\n");
+}
+
+async function installPip(pythonDir: string): Promise<void> {
+	console.log(`Bootstrapping pip in ${pythonDir}...`);
+	const getPipPath = path.join(pythonDir, "get-pip.py");
+	await downloadFile(GET_PIP_URL, getPipPath);
+
+	const pythonExe = path.join(pythonDir, "python.exe");
+	execSync(
+		`"${pythonExe}" "${getPipPath}" --no-warn-script-location --disable-pip-version-check`,
+		{ stdio: "inherit" },
+	);
+
+	fs.unlinkSync(getPipPath);
+}
+
+async function preparePython(options: PrepareOptions): Promise<string> {
+	const { arch, outputDir } = options;
+	const cfg = downloadConfig(arch);
+	const pythonDir = path.join(outputDir, "python");
+
+	if (fs.existsSync(pythonDir)) {
+		console.log(`Python directory already exists at ${pythonDir}, skipping...`);
+		return pythonDir;
+	}
+
+	fs.mkdirSync(pythonDir, { recursive: true });
+
+	const zipPath = path.join(outputDir, `python-${arch}.zip`);
+	await downloadFile(cfg.url, zipPath);
+	await extractZip(zipPath, pythonDir);
+
+	// Enable site-packages so pip and venv work out of the box.
+	const pthPath = path.join(pythonDir, cfg.pthFile);
+	if (fs.existsSync(pthPath)) {
+		const original = fs.readFileSync(pthPath, "utf-8");
+		fs.writeFileSync(pthPath, enableSitePackages(original));
+	} else {
+		console.warn(`[prepare-python-runtime] Expected ${cfg.pthFile} not found; pip may not work.`);
+	}
+
+	// Provide a `python3.exe` alias alongside `python.exe`. Skills written
+	// for Linux/macOS invoke `python3` directly; without the alias the
+	// agent has to translate every invocation. The Windows embed package
+	// only ships `python.exe`, so we copy it as `python3.exe` — CPython
+	// doesn't dispatch on argv[0] on Windows, the two names behave
+	// identically. Costs ~25 KB on disk (the executable is a thin
+	// launcher; the heavy bits live in `python3X.dll`, which is shared).
+	const pythonExe = path.join(pythonDir, "python.exe");
+	const python3Exe = path.join(pythonDir, "python3.exe");
+	if (fs.existsSync(pythonExe) && !fs.existsSync(python3Exe)) {
+		fs.copyFileSync(pythonExe, python3Exe);
+	}
+
+	// Bootstrap pip into the embedded interpreter so skills can run
+	// `python -m venv .venv && pip install -r requirements.txt` directly.
+	// Only run pip install when the build host can execute the downloaded
+	// python.exe — i.e. the host is Windows. Cross-platform CI prepares
+	// the zip extraction only; pip install happens on the Windows runner.
+	if (process.platform === "win32") {
+		await installPip(pythonDir);
+	} else {
+		console.log(
+			"[prepare-python-runtime] Skipping pip bootstrap on non-Windows host — " +
+				"the embedded python.exe cannot execute here. The Windows release runner " +
+				"will run this script and install pip.",
+		);
+	}
+
+	fs.unlinkSync(zipPath);
+
+	console.log(`Python prepared at ${pythonDir}`);
+	return pythonDir;
+}
+
+export async function preparePythonRuntime(
+	arch: "x64" | "arm64",
+	outputDir: string,
+): Promise<{ pythonDir: string }> {
+	console.log(`Preparing embedded Python runtime for Windows ${arch}...`);
+
+	fs.mkdirSync(outputDir, { recursive: true });
+	const pythonDir = await preparePython({ arch, outputDir });
+
+	const manifestPath = path.join(outputDir, "embedded-python.json");
+	const manifest = {
+		python: PYTHON_VERSION,
+		arch,
+		platform: "win32",
+		preparedAt: new Date().toISOString(),
+		pipBootstrapped: process.platform === "win32",
+	};
+	fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+	console.log("Embedded Python runtime prepared successfully.");
+	return { pythonDir };
+}
+
+// CLI entry point (ESM compatible). Mirrors prepare-embedded-runtime.ts so
+// `pnpm prepare:python:win32-<arch>` writes alongside the Node bundle.
+const isCli = import.meta.url === `file://${process.argv[1]}`;
+if (isCli) {
+	const arch = (process.argv[2] as "x64" | "arm64") || "x64";
+	const outputDir =
+		process.argv[3] ||
+		path.join(process.cwd(), "src-tauri", "embedded-runtime", `win32-${arch}`);
+
+	preparePythonRuntime(arch, outputDir)
+		.then(() => process.exit(0))
+		.catch((err) => {
+			console.error("Failed to prepare embedded Python runtime:", err);
+			process.exit(1);
+		});
+}
+
+export { PYTHON_VERSION };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "prepare:runtime:darwin-arm64": "tsx build/darwin/prepare-embedded-runtime.ts arm64",
     "prepare:runtime:win32-x64": "tsx build/win32/prepare-embedded-runtime.ts x64",
     "prepare:runtime:win32-arm64": "tsx build/win32/prepare-embedded-runtime.ts arm64",
+    "prepare:python:win32-x64": "tsx build/win32/prepare-python-runtime.ts x64",
+    "prepare:python:win32-arm64": "tsx build/win32/prepare-python-runtime.ts arm64",
     "prepare:runtime:linux-x64": "tsx build/linux/prepare-embedded-runtime.ts x64",
     "prepare:runtime:linux-arm64": "tsx build/linux/prepare-embedded-runtime.ts arm64",
     "prepare:mcp-servers": "tsx scripts/prepare-mcp-servers.ts"

--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -16,6 +16,31 @@ pub struct EmbeddedRuntimePaths {
     pub node_dir: Option<PathBuf>,
     pub git_dir: Option<PathBuf>,
     pub bin_dir: Option<PathBuf>,
+    /// Bundled CPython directory (Windows only). When set, contains
+    /// `python.exe` and `pythonw.exe` from the official Windows embeddable
+    /// distribution. macOS and Linux ship a usable Python in the base OS,
+    /// so this field is always `None` there.
+    pub python_dir: Option<PathBuf>,
+}
+
+/// Check whether `runtime_dir/python/` contains the Windows embeddable
+/// CPython distribution staged by `prepare:python:win32-*`. Returns the
+/// directory path (the one PATH should be pointed at — `python.exe`'s
+/// parent) if the layout looks valid; `None` otherwise.
+///
+/// Extracted as a small pure helper so the discovery contract is unit-
+/// testable on every CI runner, not only Windows hosts. The Windows
+/// embeddable package always ships `python.exe` at the top of the zip;
+/// using its presence as the validity probe keeps the check tight enough
+/// to avoid false positives if some unrelated `python/` directory ever
+/// landed under `embedded-runtime/`.
+fn embedded_python_dir(runtime_dir: &std::path::Path) -> Option<PathBuf> {
+    let python_path = runtime_dir.join("python");
+    if python_path.join("python.exe").exists() {
+        Some(python_path)
+    } else {
+        None
+    }
 }
 
 /// Returns the platform-specific subdirectory name (e.g., "darwin-arm64", "win32-x64").
@@ -102,12 +127,23 @@ pub fn discover_embedded_runtime(app: &AppHandle) -> EmbeddedRuntimePaths {
                 node_dir: None,
                 git_dir: None,
                 bin_dir: None,
+                python_dir: None,
             };
         }
     };
 
     let mut node_dir: Option<PathBuf> = None;
     let mut git_dir: Option<PathBuf> = None;
+
+    // Bundled CPython is Windows-only — macOS and Linux ship a usable
+    // system Python (issue #1947). The probe is platform-agnostic: it
+    // just checks for `python/python.exe` under the runtime dir, so we
+    // could call it on every OS, but skipping it on Unix saves a syscall.
+    let python_dir: Option<PathBuf> = if cfg!(target_os = "windows") {
+        embedded_python_dir(&runtime_dir)
+    } else {
+        None
+    };
 
     #[cfg(target_os = "windows")]
     {
@@ -169,6 +205,7 @@ pub fn discover_embedded_runtime(app: &AppHandle) -> EmbeddedRuntimePaths {
         node_dir,
         git_dir,
         bin_dir,
+        python_dir,
     }
 }
 
@@ -187,6 +224,9 @@ pub fn configure_embedded_runtime(app: &AppHandle) -> EmbeddedRuntimePaths {
     }
     if let Some(ref bin_dir) = paths.bin_dir {
         paths_to_add.push(bin_dir.to_string_lossy().to_string());
+    }
+    if let Some(ref python_dir) = paths.python_dir {
+        paths_to_add.push(python_dir.to_string_lossy().to_string());
     }
 
     // Compute the new PATH but store it instead of modifying global env
@@ -491,6 +531,46 @@ mod tests {
         }
     }
 
+    /// Critical test for serenorg/seren-desktop#1947.
+    ///
+    /// Confirms the Windows-only Python bundle discovery contract: the
+    /// helper returns the bundled directory only when `python/python.exe`
+    /// is actually present. Three scenarios cover the failure modes that
+    /// would silently break Python skills on Windows if regressed:
+    ///
+    /// 1. No `python/` subdirectory at all → must return `None` (this is
+    ///    the macOS / Linux state and the state on a Windows build where
+    ///    `prepare:python:win32-*` was not run).
+    /// 2. Empty `python/` subdirectory → must return `None`. Without the
+    ///    executable probe, a stray empty directory would be PATH-added
+    ///    and `python` invocations would silently miss.
+    /// 3. `python/python.exe` exists → must return the `python/` dir.
+    ///    This is the path PATH gets prepended with, so the contract is
+    ///    that we point at the directory, not the executable.
+    ///
+    /// Runs on every CI host because the helper is platform-agnostic;
+    /// the cfg gating in `discover_embedded_runtime` is just an
+    /// optimization to skip a syscall on Unix.
+    #[test]
+    fn embedded_python_dir_requires_python_exe() {
+        use std::fs;
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let runtime_dir = tmp.path();
+
+        // 1. No python/ subdir → None.
+        assert_eq!(embedded_python_dir(runtime_dir), None);
+
+        // 2. Empty python/ subdir → None.
+        fs::create_dir_all(runtime_dir.join("python")).expect("create python dir");
+        assert_eq!(embedded_python_dir(runtime_dir), None);
+
+        // 3. python/python.exe exists → returns the python/ dir.
+        fs::write(runtime_dir.join("python").join("python.exe"), b"stub")
+            .expect("write python.exe stub");
+        let found = embedded_python_dir(runtime_dir).expect("python_dir discovered");
+        assert_eq!(found, runtime_dir.join("python"));
+    }
+
     #[test]
     fn sanitize_spawn_env_is_idempotent() {
         // Calling the helper twice should produce the same effect as
@@ -527,7 +607,9 @@ pub fn get_embedded_runtime_info(app: AppHandle) -> Result<serde_json::Value, St
     Ok(serde_json::json!({
         "node_dir": paths.node_dir.as_ref().map(|p| p.to_string_lossy().to_string()),
         "git_dir": paths.git_dir.as_ref().map(|p| p.to_string_lossy().to_string()),
+        "python_dir": paths.python_dir.as_ref().map(|p| p.to_string_lossy().to_string()),
         "node_available": paths.node_dir.is_some(),
         "git_available": paths.git_dir.is_some(),
+        "python_available": paths.python_dir.is_some(),
     }))
 }

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -159,6 +159,15 @@ async fn execute_shell_command_inner(
     // separate `py` launcher that always finds a real interpreter. When we
     // see both conditions — stub stderr and a rewritable `python` token —
     // retry once via the launcher.
+    //
+    // GH #1947: once `prepare:python:win32-*` has staged the embeddable
+    // CPython under `embedded-runtime/win32-*/python/`, that directory is
+    // prepended to the child PATH by `get_embedded_path()`, so `python`
+    // resolves to the bundled interpreter BEFORE the WindowsApps stub
+    // can intercept and this retry never fires. The block stays as the
+    // safety net for builds where the Python bundle is missing (e.g. dev
+    // hosts that have not run `pnpm prepare:python:win32-x64`) and the
+    // user does happen to have the python.org `py` launcher installed.
     #[cfg(target_os = "windows")]
     {
         if looks_like_windows_apps_python_stub(&result.stderr) {

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1540,7 +1540,7 @@ export const skills = {
           ? `\n> **Shared dependencies:** \`${runtimeDir}${sep}_deps${sep}\` contains shared files from declared \`includes\` paths.\n`
           : "";
         const platformNote = isWindowsRuntime
-          ? `\n> **Platform:** Windows. Skill docs commonly use Unix conventions (\`python3\`, \`~/.config/seren/skills/<name>\`, forward-slash paths). On this machine, translate before running:\n> - Use \`python\` (or \`py\`) instead of \`python3\`.\n> - Replace any \`~/.config/seren/skills/<name>\` reference with the absolute runtime directory above.\n> - Use backslashes inside paths.\n> Always \`cd\` into the absolute runtime directory above before invoking skill scripts.`
+          ? `\n> **Platform:** Windows. Python (\`python\` and \`python3\`) is bundled with Seren Desktop — no install needed. Skill docs commonly reference \`~/.config/seren/skills/<name>\` and forward-slash paths; on this machine:\n> - Replace any \`~/.config/seren/skills/<name>\` reference with the absolute runtime directory above.\n> - Use backslashes inside paths.\n> Always \`cd\` into the absolute runtime directory above before invoking skill scripts.`
           : "";
         const runtimeNote = `> **Skill runtime directory:** \`${runtimeDir}\`\n> Use this absolute path to reference skill files. Do not create local copies or fallback scaffolds.${platformNote}${depsNote}\n\n`;
         contents.push(


### PR DESCRIPTION
Closes #1947

## Summary

- Bundle Windows-embeddable CPython 3.12.7 under `embedded-runtime/win32-*/python/` alongside Node and Git, prepend it to the child PATH from `embedded_runtime.rs`, and add a monthly freshness check that opens a PR for newer CPython patches.
- 91 of 109 skills in `seren-skills` shell out to `python3`/`python`/`pip`. Windows has no system Python, so today they hit the Microsoft Store stub and fail. With this change the bundled Python wins on PATH first.
- Existing WindowsApps stub-retry from #1908 stays as the safety net for builds without the bundle (dev hosts that have not run `prepare:python:win32-x64`).

## Files

| Path | Change |
| --- | --- |
| `build/win32/prepare-python-runtime.ts` | New: downloads embed zip, uncomments `import site` in `python3X._pth`, copies `python.exe` to `python3.exe` so Unix-convention skill scripts work unchanged, bootstraps pip via `get-pip.py` on Windows hosts. |
| `package.json` | New `prepare:python:win32-x64` / `prepare:python:win32-arm64` scripts. |
| `src-tauri/src/embedded_runtime.rs` | `EmbeddedRuntimePaths.python_dir` (Windows-only), new `embedded_python_dir()` discovery helper, `get_embedded_path()` includes it, `get_embedded_runtime_info` exposes it. |
| `src-tauri/src/shell.rs` | Comment update referencing #1947 — bundled Python wins on PATH before the stub-retry from #1908 fires. |
| `.github/workflows/release.yml` | New `Prepare embedded Python (Windows x64)` step. |
| `.github/workflows/check-python-version.yml` | New: monthly cron + workflow_dispatch, reads `PYTHON_VERSION`, hits python.org for the latest patch on the pinned minor track, opens a PR via `peter-evans/create-pull-request@v6`. |
| `src/services/skills.ts` | Windows platform note: Python is bundled, no install needed, drop the `python3 -> python` translation guidance. |

## Tests

`cargo test --manifest-path src-tauri/Cargo.toml --lib embedded_runtime::` — 3 passed including the new critical test.

`embedded_python_dir_requires_python_exe` covers the three discovery states:

1. No `python/` subdirectory → `None` (macOS/Linux + Windows builds without the bundle).
2. Empty `python/` subdirectory → `None` (stray dir guard).
3. `python/python.exe` present → returns the `python/` dir.

The probe is platform-agnostic so the test runs on every CI host, not only Windows runners.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` clean.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib embedded_runtime::` 3/3 passing.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib shell::` 7/7 passing (existing Windows stub-retry tests still green).
- [x] `node_modules/.bin/biome check src/services/skills.ts` clean.
- [ ] CI Windows runner exercises `pnpm prepare:python:win32-x64` end-to-end on the next release build.
- [ ] Smoke a Python-dependent skill (e.g. `kraken/grid-trader`) on a clean Windows VM after the next release.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
