### PR TITLE
fix(playwright-stealth): make navigate load-state configurable

### DIFF
--- a/mcp-servers/playwright-stealth/README.md
+++ b/mcp-servers/playwright-stealth/README.md
@@ -148,6 +148,13 @@ await playwright_set_browser({ browser: "firefox" });
 // Navigate to a site
 await playwright_navigate({ url: "https://example.com" });
 
+// Use a stricter wait only when the target can actually become idle
+await playwright_navigate({
+  url: "https://example.com",
+  waitUntil: "networkidle",
+  timeout: 10000,
+});
+
 // Extract data
 const content = await playwright_extract_content();
 
@@ -176,6 +183,15 @@ Use this server instead of standard Playwright when:
   - Accepts legacy newline-delimited JSON-RPC used by Seren Desktop.
   - Accepts `Content-Length` framed JSON-RPC used by first-party MCP gateways.
   - Responses mirror the framing mode used by the caller's request.
+- **Navigation waits**: `playwright_navigate` defaults to Playwright's `load`
+  event. Callers may pass `waitUntil: "domcontentloaded"` or
+  `waitUntil: "networkidle"` and `timeout` in milliseconds when they need
+  different semantics. Avoid `networkidle` for SPAs that keep websocket,
+  GraphQL, auth-refresh, or analytics requests alive.
+- **Timeout layering**: When this server is driven by another subprocess, keep
+  the MCP-side navigation timeout strictly lower than the client-side request
+  timeout. Equal timeouts can cause the client to report an opaque transport
+  timeout before it receives Playwright's own error envelope.
 
 ## License
 

--- a/mcp-servers/playwright-stealth/src/__tests__/navigate.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/navigate.test.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Tests for navigate load-state defaults and MCP schema options.
+// ABOUTME: Guards SPA-safe navigation behavior used by Python subprocess callers.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createNavigateToolDefinition } from "../tool_definitions.js";
+import { navigate } from "../tools.js";
+
+const mocks = vi.hoisted(() => ({
+  goto: vi.fn(),
+  getPage: vi.fn(),
+}));
+
+vi.mock("../browser.js", () => ({
+  closeBrowser: vi.fn(),
+  getActiveBrowserType: vi.fn(() => "chrome"),
+  getContext: vi.fn(),
+  getPage: mocks.getPage,
+  listInstalledBrowsers: vi.fn(() => []),
+  resetPage: vi.fn(),
+  setBrowser: vi.fn(),
+}));
+
+describe("navigate", () => {
+  beforeEach(() => {
+    mocks.goto.mockReset();
+    mocks.getPage.mockReset();
+    mocks.goto.mockResolvedValue(undefined);
+    mocks.getPage.mockResolvedValue({ goto: mocks.goto });
+  });
+
+  it("defaults to the load event instead of networkidle", async () => {
+    await expect(navigate("https://example.test")).resolves.toBe(
+      "Navigated to https://example.test",
+    );
+
+    expect(mocks.goto).toHaveBeenCalledWith("https://example.test", {
+      waitUntil: "load",
+      timeout: 30_000,
+    });
+  });
+
+  it("passes explicit waitUntil and timeout options through to Playwright", async () => {
+    await navigate("https://example.test/create", {
+      waitUntil: "domcontentloaded",
+      timeout: 12_000,
+    });
+
+    expect(mocks.goto).toHaveBeenCalledWith("https://example.test/create", {
+      waitUntil: "domcontentloaded",
+      timeout: 12_000,
+    });
+  });
+
+  it("exposes waitUntil and timeout in the MCP tool schema", () => {
+    const definition = createNavigateToolDefinition();
+
+    expect(definition.inputSchema.properties.waitUntil).toMatchObject({
+      type: "string",
+      enum: ["load", "domcontentloaded", "networkidle"],
+    });
+    expect(definition.inputSchema.properties.timeout).toMatchObject({
+      type: "number",
+    });
+    expect(definition.inputSchema.required).toEqual(["url"]);
+  });
+});

--- a/mcp-servers/playwright-stealth/src/index.ts
+++ b/mcp-servers/playwright-stealth/src/index.ts
@@ -9,6 +9,10 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { getActiveBrowserType } from "./browser.js";
 import { DualStdioServerTransport } from "./dual_stdio_transport.js";
+import {
+  createNavigateToolDefinition,
+  type NavigateOptions,
+} from "./tool_definitions.js";
 import * as tools from "./tools.js";
 
 const server = new Server(
@@ -26,20 +30,7 @@ const server = new Server(
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: [
-      {
-        name: "playwright_navigate",
-        description: "Navigate to a URL with stealth features enabled",
-        inputSchema: {
-          type: "object",
-          properties: {
-            url: {
-              type: "string",
-              description: "The URL to navigate to",
-            },
-          },
-          required: ["url"],
-        },
-      },
+      createNavigateToolDefinition(),
       {
         name: "playwright_screenshot",
         description: "Capture a screenshot of the current page",
@@ -325,7 +316,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     switch (name) {
       case "playwright_navigate":
-        result = await tools.navigate(args.url as string);
+        result = await tools.navigate(args.url as string, {
+          waitUntil: args.waitUntil as NavigateOptions["waitUntil"],
+          timeout: args.timeout as number | undefined,
+        });
         break;
       case "playwright_screenshot":
         result = await tools.screenshot(args.name as string | undefined);

--- a/mcp-servers/playwright-stealth/src/tool_definitions.ts
+++ b/mcp-servers/playwright-stealth/src/tool_definitions.ts
@@ -1,0 +1,43 @@
+// ABOUTME: MCP tool schema builders shared between the server and tests.
+// ABOUTME: Keeps tool contract changes covered without starting the stdio server.
+
+export const NAVIGATION_WAIT_UNTIL_VALUES = [
+  "load",
+  "domcontentloaded",
+  "networkidle",
+] as const;
+
+export type NavigationWaitUntil =
+  (typeof NAVIGATION_WAIT_UNTIL_VALUES)[number];
+
+export type NavigateOptions = {
+  waitUntil?: NavigationWaitUntil;
+  timeout?: number;
+};
+
+export function createNavigateToolDefinition() {
+  return {
+    name: "playwright_navigate",
+    description: "Navigate to a URL with stealth features enabled",
+    inputSchema: {
+      type: "object",
+      properties: {
+        url: {
+          type: "string",
+          description: "The URL to navigate to",
+        },
+        waitUntil: {
+          type: "string",
+          enum: NAVIGATION_WAIT_UNTIL_VALUES,
+          description:
+            "Page-load wait condition. Defaults to 'load'; SPAs with heartbeats often never reach 'networkidle'.",
+        },
+        timeout: {
+          type: "number",
+          description: "Navigation timeout in milliseconds. Defaults to 30000.",
+        },
+      },
+      required: ["url"],
+    },
+  };
+}

--- a/mcp-servers/playwright-stealth/src/tools.ts
+++ b/mcp-servers/playwright-stealth/src/tools.ts
@@ -11,15 +11,24 @@ import {
   resetPage,
   setBrowser,
 } from "./browser.js";
+import type { NavigateOptions } from "./tool_definitions.js";
 
 type CookieInput = Parameters<BrowserContext["addCookies"]>[0][number];
 type WaitForSelectorOptions = NonNullable<
   Parameters<Page["waitForSelector"]>[1]
 >;
 
-export async function navigate(url: string): Promise<string> {
+const DEFAULT_NAVIGATION_TIMEOUT_MS = 30_000;
+
+export async function navigate(
+  url: string,
+  options?: NavigateOptions,
+): Promise<string> {
   const page = await getPage();
-  await page.goto(url, { waitUntil: "networkidle" });
+  await page.goto(url, {
+    waitUntil: options?.waitUntil ?? "load",
+    timeout: options?.timeout ?? DEFAULT_NAVIGATION_TIMEOUT_MS,
+  });
   return `Navigated to ${url}`;
 }
 


### PR DESCRIPTION
Closes #1949.

## Summary
- Change `playwright_navigate` default wait condition from `networkidle` to `load` so SPA targets with background heartbeats do not hang by default.
- Add `waitUntil` and `timeout` options to the MCP tool schema and dispatch path.
- Document SPA navigation waits and the MCP/client timeout layering race.

## Tests
- TDD red: `npm test -- navigate.test.ts` failed against the original hardcoded `networkidle` behavior.
- `npm run build`
- `npm test`

## Audit
- Confirmed no runtime `page.goto(...networkidle...)` default remains in `mcp-servers/playwright-stealth/src`.
- Remaining `networkidle` references are the explicit schema enum, docs for opt-in usage, and focused tests.
- `dist/` is ignored by this repo; local build generated the bundled server for verification, but source files are the committed artifact.