### PR TITLE
fix(skills): handle wrapped bundle download failures

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -198,6 +198,46 @@ function objectKeys(value: unknown): string {
   return keys.length > 0 ? `: ${keys.join(", ")}` : "";
 }
 
+function extractStructuredErrorMessage(
+  value: unknown,
+  depth = 0,
+): string | null {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object" || depth > 3) return null;
+
+  const obj = value as Record<string, unknown>;
+  for (const key of ["message", "detail", "error", "code"]) {
+    if (typeof obj[key] === "string") return obj[key];
+  }
+  for (const key of ["error", "message", "detail"]) {
+    const nested = obj[key];
+    if (nested && typeof nested === "object") {
+      const message = extractStructuredErrorMessage(nested, depth + 1);
+      if (message) return message;
+    }
+  }
+  return null;
+}
+
+function extractEnvelopeErrorMessage(
+  obj: Record<string, unknown>,
+): string | null {
+  if (typeof obj.error === "string") return obj.error;
+  if (obj.error && typeof obj.error === "object") {
+    const nested = extractStructuredErrorMessage(obj.error);
+    if (nested) return nested;
+  }
+  if (
+    typeof obj.message === "string" &&
+    (obj.error !== undefined ||
+      obj.code !== undefined ||
+      obj.status !== undefined)
+  ) {
+    return obj.message;
+  }
+  return null;
+}
+
 // Diagnostic for envelope-walking failures: walks the same data->result->body
 // chain that `findInResponseEnvelopes` uses and reports the keys at each
 // depth, so a "wrapped" bundle response like `{ data: { error: ... } }` is
@@ -220,15 +260,7 @@ function describeBundleEnvelope(value: unknown): string {
     const keys = Object.keys(obj).slice(0, 6);
     layers.push(`{${keys.join(",")}}`);
 
-    const errorMessage =
-      typeof obj.error === "string"
-        ? obj.error
-        : typeof obj.message === "string" &&
-            (obj.error !== undefined ||
-              obj.code !== undefined ||
-              obj.status !== undefined)
-          ? obj.message
-          : null;
+    const errorMessage = extractEnvelopeErrorMessage(obj);
     if (errorMessage) {
       return `: ${layers.join(" -> ")} (server error: ${errorMessage})`;
     }
@@ -277,6 +309,22 @@ function findInResponseEnvelopes<T>(
   return null;
 }
 
+function findApiResultFailure(
+  value: unknown,
+): { status: number; message: string | null } | null {
+  return findInResponseEnvelopes(value, (candidate) => {
+    const apiResult = candidate as { body?: unknown; status?: unknown };
+    if (typeof apiResult.status !== "number" || apiResult.status < 400) {
+      return null;
+    }
+
+    const message =
+      extractStructuredErrorMessage(apiResult.body) ??
+      extractEnvelopeErrorMessage(candidate as Record<string, unknown>);
+    return { status: apiResult.status, message };
+  });
+}
+
 function normalizeSkillsCatalogPage(
   value: unknown,
 ): SkillsCatalogResponsePage | null {
@@ -317,6 +365,15 @@ async function downloadSkillBundle(slug: string): Promise<SkillBundle> {
   if (error || !data) {
     const status = response ? `: ${response.status}` : "";
     throw new Error(`Failed to download skill ${slug}${status}`);
+  }
+  const apiResultFailure = findApiResultFailure(data);
+  if (apiResultFailure) {
+    const message = apiResultFailure.message
+      ? ` (${apiResultFailure.message})`
+      : "";
+    throw new Error(
+      `Failed to download skill ${slug}: ${apiResultFailure.status}${message}`,
+    );
   }
   const bundle = normalizeSkillBundle(data);
   if (!bundle) {

--- a/tests/unit/skills-index-api.test.ts
+++ b/tests/unit/skills-index-api.test.ts
@@ -254,7 +254,13 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
 
   it("surfaces server error envelopes when the bundle body carries an error payload", async () => {
     mockDownloadSkill.mockResolvedValueOnce({
-      data: { data: { error: "forbidden", code: "PUBLISHER_DENIED" } },
+      data: {
+        data: {
+          body: {
+            error: { code: "PUBLISHER_DENIED", message: "forbidden" },
+          },
+        },
+      },
     });
 
     const { skills } = await import("@/services/skills");
@@ -269,6 +275,36 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
         tags: [],
       }),
     ).rejects.toThrow(/forbidden/);
+  });
+
+  it("treats publisher ApiResultResponse failures as failed downloads", async () => {
+    mockDownloadSkill.mockResolvedValueOnce({
+      data: {
+        data: {
+          status: 404,
+          body: { error: { code: 404, message: "skill not found" } },
+          response_bytes: 50,
+          execution_time_ms: 33,
+          cost: "0",
+          asset_symbol: "USDC",
+        },
+      },
+    });
+
+    const { skills } = await import("@/services/skills");
+    await expect(
+      skills.fetchContent({
+        id: "seren:curve-gauge-yield-trader",
+        slug: "curve-gauge-yield-trader",
+        name: "Curve Gauge Yield Trader",
+        description: "",
+        source: "seren",
+        sourceUrl: "seren-skills:curve-gauge-yield-trader",
+        tags: [],
+      }),
+    ).rejects.toThrow(
+      "Failed to download skill curve-gauge-yield-trader: 404 (skill not found)",
+    );
   });
 
   it("throws when the API returns an error", async () => {


### PR DESCRIPTION
Fixes #1925.

## Summary
- Extract structured `body.error` messages from wrapped seren-skills bundle responses.
- Treat publisher `ApiResultResponse` envelopes with `status >= 400` as failed downloads before bundle normalization.
- Preserve the existing malformed-envelope diagnostic for non-ApiResultResponse bundle drift.

## Audit
- Reconfirmed #1925 is open and labeled bug.
- Reconfirmed live `seren-skills` download for `curve-gauge-yield-trader` returns a wrapped failure envelope with `status: 404` and `body.error.message: skill not found`.
- Final code path: `downloadSkillBundle` now checks `findApiResultFailure(data)` before `normalizeSkillBundle(data)`, so sync-state errors become `Failed to download skill curve-gauge-yield-trader: 404 (skill not found)` instead of `Unexpected seren-skills bundle response ... {error}`.

## Tests
- `./node_modules/.bin/vitest run tests/unit/skills-index-api.test.ts`
- `./node_modules/.bin/biome check src/services/skills.ts tests/unit/skills-index-api.test.ts`
- `git diff --check`

Note: `pnpm test tests/unit/skills-index-api.test.ts` did not reach Vitest in this isolated worktree because pnpm required interactive build-script approval. I ran the local Vitest binary directly after pnpm installed dependencies.