### PR TITLE
fix(mcp): configure playwright stealth ping timeout

### DIFF
--- a/mcp-servers/playwright-stealth/README.md
+++ b/mcp-servers/playwright-stealth/README.md
@@ -80,6 +80,23 @@ Configure the browser in MCP server settings by adding to the server's environme
 }
 ```
 
+### Ping / Idle Timeout
+
+By default, the bundled transport keeps its existing stdio behavior. Agents
+that keep a browser session warm while doing long server-side work between MCP
+tool calls can opt into an idle watchdog with `PLAYWRIGHT_MCP_PING_TIMEOUT_MS`:
+
+```bash
+# Keep the MCP transport alive through long no-traffic windows.
+PLAYWRIGHT_MCP_PING_TIMEOUT_MS=300000 node dist/index.js
+```
+
+Leave the variable unset for casual use. For workflows with long no-traffic
+windows between `tools/call` requests, such as waiting on a remote AI
+calculation before returning to the browser, use `300000` (5 minutes) or higher.
+Seren Desktop and skill subprocesses pass this variable through to the bundled
+MCP child when it is present in the process environment.
+
 ### Runtime Browser Switching
 
 Use MCP tools to discover and switch browsers during a session:
@@ -183,6 +200,9 @@ Use this server instead of standard Playwright when:
   - Accepts legacy newline-delimited JSON-RPC used by Seren Desktop.
   - Accepts `Content-Length` framed JSON-RPC used by first-party MCP gateways.
   - Responses mirror the framing mode used by the caller's request.
+  - `PLAYWRIGHT_MCP_PING_TIMEOUT_MS` optionally closes an idle transport after
+    the configured no-traffic window. Leave unset to preserve the default
+    bundled behavior.
 - **Navigation waits**: `playwright_navigate` defaults to Playwright's `load`
   event. Callers may pass `waitUntil: "domcontentloaded"` or
   `waitUntil: "networkidle"` and `timeout` in milliseconds when they need

--- a/mcp-servers/playwright-stealth/src/__tests__/ping_timeout.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/ping_timeout.test.ts
@@ -1,0 +1,76 @@
+// ABOUTME: Guards the configurable MCP idle ping timeout used by long browser workflows.
+
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DualStdioServerTransport,
+  pingTimeoutMsFromEnv,
+} from "../dual_stdio_transport.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("playwright-stealth MCP ping timeout", () => {
+  it("maps PLAYWRIGHT_MCP_PING_TIMEOUT_MS to the transport idle timeout", () => {
+    expect(
+      pingTimeoutMsFromEnv({ PLAYWRIGHT_MCP_PING_TIMEOUT_MS: "2000" }),
+    ).toBe(2000);
+  });
+
+  it("leaves idle timeout disabled when the env var is unset", async () => {
+    vi.useFakeTimers();
+    const transport = new DualStdioServerTransport(
+      new PassThrough(),
+      new PassThrough(),
+      { idleTimeoutMs: pingTimeoutMsFromEnv({}) },
+    );
+    let closed = false;
+    transport.onclose = () => {
+      closed = true;
+    };
+
+    await transport.start();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(closed).toBe(false);
+    await transport.close();
+  });
+
+  it("closes after the configured no-traffic idle timeout", async () => {
+    vi.useFakeTimers();
+    const transport = new DualStdioServerTransport(
+      new PassThrough(),
+      new PassThrough(),
+      { idleTimeoutMs: 2_000 },
+    );
+    let closed = false;
+    transport.onclose = () => {
+      closed = true;
+    };
+
+    await transport.start();
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(closed).toBe(true);
+  });
+
+  it("keeps the transport open when idle time is below the configured timeout", async () => {
+    vi.useFakeTimers();
+    const transport = new DualStdioServerTransport(
+      new PassThrough(),
+      new PassThrough(),
+      { idleTimeoutMs: 10_000 },
+    );
+    let closed = false;
+    transport.onclose = () => {
+      closed = true;
+    };
+
+    await transport.start();
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(closed).toBe(false);
+    await transport.close();
+  });
+});

--- a/mcp-servers/playwright-stealth/src/dual_stdio_transport.ts
+++ b/mcp-servers/playwright-stealth/src/dual_stdio_transport.ts
@@ -5,8 +5,8 @@ import process from "node:process";
 import type { Readable, Writable } from "node:stream";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
-  JSONRPCMessageSchema,
   type JSONRPCMessage,
+  JSONRPCMessageSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
 type FramingMode = "line" | "content-length";
@@ -21,7 +21,24 @@ type ParsedMessage = {
   framing: FramingMode;
 };
 
+type TransportOptions = {
+  idleTimeoutMs?: number;
+};
+
 const CONTENT_LENGTH_PREFIX = "content-length:";
+const PLAYWRIGHT_MCP_PING_TIMEOUT_ENV = "PLAYWRIGHT_MCP_PING_TIMEOUT_MS";
+
+export function pingTimeoutMsFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): number | undefined {
+  const raw = env[PLAYWRIGHT_MCP_PING_TIMEOUT_ENV]?.trim();
+  if (!raw) {
+    return undefined;
+  }
+
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
 
 function parseMessage(json: string): JSONRPCMessage {
   return JSONRPCMessageSchema.parse(JSON.parse(json));
@@ -43,7 +60,9 @@ function findHeaderBoundary(buffer: Buffer): HeaderBoundary | null {
 }
 
 function extractContentLength(headers: string): number | null {
-  const match = headers.match(/(?:^|\r?\n)content-length:\s*(\d+)\s*(?:\r?\n|$)/i);
+  const match = headers.match(
+    /(?:^|\r?\n)content-length:\s*(\d+)\s*(?:\r?\n|$)/i,
+  );
   if (!match) {
     return null;
   }
@@ -86,10 +105,13 @@ export class DualStdioServerTransport implements Transport {
   onmessage?: (message: JSONRPCMessage) => void;
 
   private buffer?: Buffer;
+  private idleTimeout?: ReturnType<typeof setTimeout>;
   private responseFraming: FramingMode = "line";
+  private closed = false;
   private started = false;
 
   private readonly onData = (chunk: Buffer) => {
+    this.resetIdleTimeout();
     this.buffer = this.buffer ? Buffer.concat([this.buffer, chunk]) : chunk;
     this.processReadBuffer();
   };
@@ -101,6 +123,7 @@ export class DualStdioServerTransport implements Transport {
   constructor(
     private readonly stdin: Readable = process.stdin,
     private readonly stdout: Writable = process.stdout,
+    private readonly options: TransportOptions = {},
   ) {}
 
   async start(): Promise<void> {
@@ -113,9 +136,19 @@ export class DualStdioServerTransport implements Transport {
     this.started = true;
     this.stdin.on("data", this.onData);
     this.stdin.on("error", this.onError);
+    this.resetIdleTimeout();
   }
 
   async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    if (this.idleTimeout) {
+      clearTimeout(this.idleTimeout);
+      this.idleTimeout = undefined;
+    }
     this.stdin.off("data", this.onData);
     this.stdin.off("error", this.onError);
     this.buffer = undefined;
@@ -123,6 +156,8 @@ export class DualStdioServerTransport implements Transport {
   }
 
   send(message: JSONRPCMessage): Promise<void> {
+    this.resetIdleTimeout();
+
     return new Promise((resolve) => {
       const payload =
         this.responseFraming === "content-length"
@@ -137,6 +172,24 @@ export class DualStdioServerTransport implements Transport {
     });
   }
 
+  private resetIdleTimeout(): void {
+    if (this.idleTimeout) {
+      clearTimeout(this.idleTimeout);
+      this.idleTimeout = undefined;
+    }
+
+    const idleTimeoutMs = this.options.idleTimeoutMs;
+    if (!this.started || this.closed || idleTimeoutMs === undefined) {
+      return;
+    }
+
+    this.idleTimeout = setTimeout(() => {
+      this.idleTimeout = undefined;
+      void this.close();
+    }, idleTimeoutMs);
+    this.idleTimeout.unref?.();
+  }
+
   private processReadBuffer(): void {
     while (true) {
       try {
@@ -148,7 +201,9 @@ export class DualStdioServerTransport implements Transport {
         this.responseFraming = parsed.framing;
         this.onmessage?.(parsed.message);
       } catch (error) {
-        this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+        this.onerror?.(
+          error instanceof Error ? error : new Error(String(error)),
+        );
       }
     }
   }
@@ -179,7 +234,9 @@ export class DualStdioServerTransport implements Transport {
     const contentLength = extractContentLength(headers);
     if (contentLength === null) {
       this.buffer = this.buffer.subarray(boundary.index + boundary.length);
-      throw new Error("Invalid MCP stdio frame: missing valid Content-Length header");
+      throw new Error(
+        "Invalid MCP stdio frame: missing valid Content-Length header",
+      );
     }
 
     const bodyStart = boundary.index + boundary.length;

--- a/mcp-servers/playwright-stealth/src/index.ts
+++ b/mcp-servers/playwright-stealth/src/index.ts
@@ -8,7 +8,10 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { getActiveBrowserType } from "./browser.js";
-import { DualStdioServerTransport } from "./dual_stdio_transport.js";
+import {
+  DualStdioServerTransport,
+  pingTimeoutMsFromEnv,
+} from "./dual_stdio_transport.js";
 import {
   createNavigateToolDefinition,
   type NavigateOptions,
@@ -443,7 +446,13 @@ async function main() {
   // any browser detection happens. `getActiveBrowserType()` lazily walks
   // Playwright's registry — a slow probe was timing out the prophet-arb-bot
   // Python child on cold start (#1921).
-  const transport = new DualStdioServerTransport();
+  const transport = new DualStdioServerTransport(
+    process.stdin,
+    process.stdout,
+    {
+      idleTimeoutMs: pingTimeoutMsFromEnv(),
+    },
+  );
   await server.connect(transport);
   console.error(
     `[playwright-stealth] Stdio transport ready; framing: line-jsonrpc, content-length; default browser: ${getActiveBrowserType()}`,

--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -597,6 +597,27 @@ mod tests {
             "every POLLUTING_PARENT_ENV_VARS entry must appear exactly once as a removal"
         );
     }
+
+    #[test]
+    fn sanitize_spawn_env_preserves_playwright_ping_timeout_var() {
+        // serenorg/seren-desktop#1954: skills may opt into a longer idle
+        // heartbeat window by setting this env var before spawning the bundled
+        // playwright-stealth MCP. The Electron/env scrubber must not strip it.
+        let mut cmd = tokio::process::Command::new("/bin/true");
+
+        sanitize_spawn_env(&mut cmd);
+
+        let removed = cmd
+            .as_std()
+            .get_envs()
+            .any(|(key, value)| {
+                key == "PLAYWRIGHT_MCP_PING_TIMEOUT_MS" && value.is_none()
+            });
+        assert!(
+            !removed,
+            "sanitize_spawn_env must preserve PLAYWRIGHT_MCP_PING_TIMEOUT_MS for child MCP spawns"
+        );
+    }
 }
 
 /// Tauri command to get embedded runtime information (for debugging/UI)


### PR DESCRIPTION
## Summary
- Add PLAYWRIGHT_MCP_PING_TIMEOUT_MS parsing for the bundled playwright-stealth MCP transport.
- Keep idle timeout disabled when unset, preserving current bundled behavior.
- Add focused transport and Desktop env-sanitizer regression coverage.
- Document the 300000ms recommendation for long no-traffic browser workflows.

## Audit
- Issue path confirmed: prophet-arb-bot needs a longer no-traffic window between MCP tools/call requests during Prophet seed calc.
- Fix path: index.ts reads the env once and passes idleTimeoutMs into DualStdioServerTransport; the timer is only armed for positive integer values.
- Spawn impact: sanitize_spawn_env does not remove PLAYWRIGHT_MCP_PING_TIMEOUT_MS, so Desktop/skill child process inheritance remains intact.
- Default impact: unset env produces undefined and no idle watchdog, so existing consumers keep current behavior.

## Tests
- PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm --dir mcp-servers/playwright-stealth test -- src/__tests__/ping_timeout.test.ts
- pnpm exec biome check mcp-servers/playwright-stealth/src/dual_stdio_transport.ts mcp-servers/playwright-stealth/src/index.ts mcp-servers/playwright-stealth/src/__tests__/ping_timeout.test.ts
- PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm --dir mcp-servers/playwright-stealth build
- cargo test sanitize_spawn_env_preserves_playwright_ping_timeout_var --lib

Closes #1954