### PR TITLE
fix(mcp): add playwright Privy profile controls

### DIFF
--- a/mcp-servers/playwright-stealth/README.md
+++ b/mcp-servers/playwright-stealth/README.md
@@ -68,6 +68,31 @@ BROWSER_TYPE=moz-firefox node dist/index.js
 
 "edge" is accepted as an alias for "msedge".
 
+### Profile Compatibility Controls
+
+The default profile preserves existing behavior: headless launch, the safe
+stealth plugin for Chromium-based browsers, and the manual page init patch for
+Chromium pages. For sites that are sensitive to those signals, such as embedded
+wallet provisioning flows, set only the controls needed for that workflow:
+
+```bash
+# Launch a visible browser window instead of headless mode.
+SEREN_PLAYWRIGHT_HEADLESS=0 node dist/index.js
+
+# Skip the puppeteer-extra stealth plugin entirely.
+SEREN_PLAYWRIGHT_DISABLE_STEALTH=1 node dist/index.js
+
+# Keep stealth enabled but remove specific evasions by name.
+SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE=iframe.contentWindow,navigator.permissions node dist/index.js
+
+# Skip the hand-written addInitScript patch applied to new Chromium pages.
+SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH=1 node dist/index.js
+```
+
+The `SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE` value is a comma-separated list
+of evasion names. `chrome.app` is always disabled for macOS notarization
+compatibility.
+
 ### In Seren Desktop
 
 Configure the browser in MCP server settings by adding to the server's environment:
@@ -75,7 +100,8 @@ Configure the browser in MCP server settings by adding to the server's environme
 ```json
 {
   "env": {
-    "BROWSER_TYPE": "moz-firefox"
+    "BROWSER_TYPE": "moz-firefox",
+    "SEREN_PLAYWRIGHT_HEADLESS": "0"
   }
 }
 ```

--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -1,8 +1,10 @@
 // ABOUTME: Unit tests for multi-browser selection, detection, and configuration.
 // ABOUTME: Validates parseBrowserType, isChromiumBased, resolveBrowserName, and listInstalledBrowsers.
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  addPageInitPatchIfEnabled,
+  applyStealthPluginIfEnabled,
   createSafeStealthPlugin,
   detectDefaultBrowser,
   isChromiumBased,
@@ -11,6 +13,29 @@ import {
   parseBrowserType,
   resolveBrowserName,
 } from "../browser.js";
+
+const CONTROLLED_ENV_KEYS = [
+  "SEREN_PLAYWRIGHT_HEADLESS",
+  "SEREN_PLAYWRIGHT_DISABLE_STEALTH",
+  "SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE",
+  "SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH",
+] as const;
+
+const ORIGINAL_ENV = new Map(
+  CONTROLLED_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+afterEach(() => {
+  for (const key of CONTROLLED_ENV_KEYS) {
+    const originalValue = ORIGINAL_ENV.get(key);
+    if (originalValue === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalValue;
+    }
+  }
+  vi.restoreAllMocks();
+});
 
 describe("detectDefaultBrowser", () => {
   it("returns a system browser name", () => {
@@ -165,6 +190,18 @@ describe("createSafeStealthPlugin", () => {
     expect(plugin.enabledEvasions.has("chrome.app")).toBe(false);
   });
 
+  it("excludes env-requested evasions in addition to chrome.app", () => {
+    process.env.SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE =
+      "iframe.contentWindow, navigator.permissions";
+
+    const plugin = createSafeStealthPlugin();
+
+    expect(plugin.enabledEvasions.has("chrome.app")).toBe(false);
+    expect(plugin.enabledEvasions.has("iframe.contentWindow")).toBe(false);
+    expect(plugin.enabledEvasions.has("navigator.permissions")).toBe(false);
+    expect(plugin.enabledEvasions.has("navigator.webdriver")).toBe(true);
+  });
+
   it("keeps other stealth evasions enabled", () => {
     const plugin = createSafeStealthPlugin();
     // These core evasions must remain active for bot detection bypass
@@ -173,6 +210,59 @@ describe("createSafeStealthPlugin", () => {
     expect(plugin.enabledEvasions.has("chrome.runtime")).toBe(true);
     expect(plugin.enabledEvasions.has("navigator.webdriver")).toBe(true);
     expect(plugin.enabledEvasions.size).toBeGreaterThan(5);
+  });
+});
+
+describe("applyStealthPluginIfEnabled", () => {
+  it("applies the safe stealth plugin to chromium by default", () => {
+    const launcher = { use: vi.fn() };
+
+    const applied = applyStealthPluginIfEnabled("chromium", launcher as never);
+
+    expect(applied).toBe(true);
+    expect(launcher.use).toHaveBeenCalledOnce();
+    expect(launcher.use).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabledEvasions: expect.any(Set),
+      }),
+    );
+  });
+
+  it("does not apply the stealth plugin when disabled by env", () => {
+    process.env.SEREN_PLAYWRIGHT_DISABLE_STEALTH = "1";
+    const launcher = { use: vi.fn() };
+
+    const applied = applyStealthPluginIfEnabled("chromium", launcher as never);
+
+    expect(applied).toBe(false);
+    expect(launcher.use).not.toHaveBeenCalled();
+  });
+});
+
+describe("addPageInitPatchIfEnabled", () => {
+  it("adds the manual init patch to chromium pages by default", async () => {
+    const mockPage = { addInitScript: vi.fn() };
+
+    const added = await addPageInitPatchIfEnabled(
+      mockPage as never,
+      "chromium",
+    );
+
+    expect(added).toBe(true);
+    expect(mockPage.addInitScript).toHaveBeenCalledOnce();
+  });
+
+  it("skips the manual init patch when disabled by env", async () => {
+    process.env.SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH = "1";
+    const mockPage = { addInitScript: vi.fn() };
+
+    const added = await addPageInitPatchIfEnabled(
+      mockPage as never,
+      "chromium",
+    );
+
+    expect(added).toBe(false);
+    expect(mockPage.addInitScript).not.toHaveBeenCalled();
   });
 });
 
@@ -221,6 +311,7 @@ describe("launchBrowserWithFallback", () => {
       "chrome",
       "chromium",
       expect.objectContaining({
+        headless: true,
         executablePath:
           "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
       }),
@@ -230,7 +321,37 @@ describe("launchBrowserWithFallback", () => {
       "moz-firefox",
       "firefox",
       expect.objectContaining({
+        headless: true,
         executablePath: "/Applications/Firefox.app/Contents/MacOS/firefox",
+      }),
+    );
+  });
+
+  it("launches headed when SEREN_PLAYWRIGHT_HEADLESS is 0", async () => {
+    process.env.SEREN_PLAYWRIGHT_HEADLESS = "0";
+    const launchedBrowser = { close: vi.fn() } as never;
+    const launchBrowser = vi.fn().mockResolvedValueOnce(launchedBrowser);
+
+    await launchBrowserWithFallback(
+      "chrome",
+      [
+        {
+          name: "chrome",
+          browserName: "chromium",
+          executablePath:
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+          isChromiumBased: true,
+          stealthSupported: true,
+        },
+      ],
+      launchBrowser as never,
+    );
+
+    expect(launchBrowser).toHaveBeenCalledWith(
+      "chrome",
+      "chromium",
+      expect.objectContaining({
+        headless: false,
       }),
     );
   });
@@ -346,6 +467,6 @@ describe("listInstalledBrowsers", () => {
     // getBrowser() uses this path to launch directly via executablePath
     // instead of channel, which avoids Playwright plugin dependencies.
     expect(match).toBeDefined();
-    expect(match!.executablePath).toBeTruthy();
+    expect(match?.executablePath).toBeTruthy();
   });
 });

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -23,7 +23,7 @@ export interface InstalledBrowser {
   stealthSupported: boolean;
 }
 
-type BrowserEngine = "chromium" | "firefox" | "webkit";
+export type BrowserEngine = "chromium" | "firefox" | "webkit";
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
@@ -51,6 +51,13 @@ const DEFAULT_USER_AGENTS: Record<BrowserEngine, string> = {
   webkit:
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15",
 };
+
+export const PLAYWRIGHT_HEADLESS_ENV = "SEREN_PLAYWRIGHT_HEADLESS";
+export const DISABLE_STEALTH_ENV = "SEREN_PLAYWRIGHT_DISABLE_STEALTH";
+export const STEALTH_EVASIONS_DISABLE_ENV =
+  "SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE";
+export const DISABLE_PAGE_INIT_PATCH_ENV =
+  "SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH";
 
 // ── Browser Detection ──────────────────────────────────────────────────────────
 
@@ -228,7 +235,7 @@ function buildLaunchOptions(
   installed: InstalledBrowser[],
 ): Record<string, unknown> {
   const launchOptions: Record<string, unknown> = {
-    headless: true,
+    headless: shouldLaunchHeadless(),
   };
 
   if (isChromiumBased(engine)) {
@@ -341,10 +348,88 @@ export async function setBrowser(
  * dependency error at runtime while keeping all other stealth evasions
  * intact.  See: https://github.com/serenorg/seren-desktop/issues/1276
  */
-export function createSafeStealthPlugin(): ReturnType<typeof StealthPlugin> {
+export function createSafeStealthPlugin(
+  env: NodeJS.ProcessEnv = process.env,
+): ReturnType<typeof StealthPlugin> {
   const stealth = StealthPlugin();
   stealth.enabledEvasions.delete("chrome.app");
+  for (const evasion of getDisabledStealthEvasions(env)) {
+    stealth.enabledEvasions.delete(evasion);
+  }
   return stealth;
+}
+
+export function shouldLaunchHeadless(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env[PLAYWRIGHT_HEADLESS_ENV] !== "0";
+}
+
+export function shouldApplyStealthPlugin(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env[DISABLE_STEALTH_ENV] !== "1";
+}
+
+export function getDisabledStealthEvasions(
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  return (env[STEALTH_EVASIONS_DISABLE_ENV] ?? "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
+export function applyStealthPluginIfEnabled(
+  engine: BrowserEngine,
+  launcher: BrowserType & { use(plugin: unknown): void },
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!isChromiumBased(engine) || !shouldApplyStealthPlugin(env)) {
+    return false;
+  }
+
+  launcher.use(createSafeStealthPlugin(env));
+  return true;
+}
+
+export function shouldApplyPageInitPatch(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env[DISABLE_PAGE_INIT_PATCH_ENV] !== "1";
+}
+
+export async function addPageInitPatchIfEnabled(
+  targetPage: Page,
+  engine: BrowserEngine,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  if (!isChromiumBased(engine) || !shouldApplyPageInitPatch(env)) {
+    return false;
+  }
+
+  await targetPage.addInitScript(() => {
+    Object.defineProperty(navigator, "webdriver", {
+      get: () => false,
+    });
+
+    Object.defineProperty(navigator, "plugins", {
+      get: () => [1, 2, 3, 4, 5],
+    });
+
+    Object.defineProperty(navigator, "languages", {
+      get: () => ["en-US", "en"],
+    });
+
+    const originalQuery = window.navigator.permissions.query;
+    window.navigator.permissions.query = (parameters: PermissionDescriptor) =>
+      parameters.name === "notifications"
+        ? Promise.resolve({
+            state: Notification.permission,
+          } as PermissionStatus)
+        : originalQuery(parameters);
+  });
+  return true;
 }
 
 export async function getBrowser(): Promise<Browser> {
@@ -355,11 +440,14 @@ export async function getBrowser(): Promise<Browser> {
       const launched = await launchBrowserWithFallback(
         getActiveBrowserType(),
         installed,
-        async (browserName, engine, launchOptions) => {
-          if (isChromiumBased(engine) && !stealthApplied) {
-            (chromium as BrowserType & { use(plugin: unknown): void }).use(
-              createSafeStealthPlugin(),
-            );
+        async (_browserName, engine, launchOptions) => {
+          if (
+            !stealthApplied &&
+            applyStealthPluginIfEnabled(
+              engine,
+              chromium as BrowserType & { use(plugin: unknown): void },
+            )
+          ) {
             stealthApplied = true;
           }
 
@@ -399,31 +487,7 @@ export async function getPage(): Promise<Page> {
     page = await ctx.newPage();
 
     const engine = resolveBrowserName(getActiveBrowserType());
-    if (isChromiumBased(engine)) {
-      await page.addInitScript(() => {
-        Object.defineProperty(navigator, "webdriver", {
-          get: () => false,
-        });
-
-        Object.defineProperty(navigator, "plugins", {
-          get: () => [1, 2, 3, 4, 5],
-        });
-
-        Object.defineProperty(navigator, "languages", {
-          get: () => ["en-US", "en"],
-        });
-
-        const originalQuery = window.navigator.permissions.query;
-        window.navigator.permissions.query = (
-          parameters: PermissionDescriptor,
-        ) =>
-          parameters.name === "notifications"
-            ? Promise.resolve({
-                state: Notification.permission,
-              } as PermissionStatus)
-            : originalQuery(parameters);
-      });
-    }
+    await addPageInitPatchIfEnabled(page, engine);
   }
   return page;
 }


### PR DESCRIPTION
Closes #1956

## Summary
- Add env-controlled launch/profile switches for `playwright-stealth`: headed mode, full stealth disable, selective stealth evasion disable, and manual page init patch disable.
- Preserve existing default behavior when the new env vars are unset or not set to their opt-out values.
- Document the operator-facing profile controls in the Playwright Stealth MCP README.

## Tests
- `PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm --dir mcp-servers/playwright-stealth test`
- `PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm --dir mcp-servers/playwright-stealth build`
- `PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm exec biome check mcp-servers/playwright-stealth/src/browser.ts mcp-servers/playwright-stealth/src/__tests__/browser.test.ts mcp-servers/playwright-stealth/README.md`
- `git diff --check`

## Audit
- Default path remains headless with the safe Chromium stealth plugin and manual Chromium init patch.
- `SEREN_PLAYWRIGHT_HEADLESS=0` is the only headed-mode switch; unset/empty/other values remain headless.
- `SEREN_PLAYWRIGHT_DISABLE_STEALTH=1` skips `chromium.use(...)`; selective CSV evasions only affect plugin creation when stealth remains enabled.
- `SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH=1` skips the hand-written `page.addInitScript` path for new Chromium pages.