### PR TITLE
fix(mcp): default playwright stealth to privy profile

### DIFF
--- a/mcp-servers/playwright-stealth/README.md
+++ b/mcp-servers/playwright-stealth/README.md
@@ -70,28 +70,33 @@ BROWSER_TYPE=moz-firefox node dist/index.js
 
 ### Profile Compatibility Controls
 
-The default profile preserves existing behavior: headless launch, the safe
-stealth plugin for Chromium-based browsers, and the manual page init patch for
-Chromium pages. For sites that are sensitive to those signals, such as embedded
-wallet provisioning flows, set only the controls needed for that workflow:
+The default profile is Privy-compatible: headed launch, the safe stealth plugin
+for Chromium-based browsers, `iframe.contentWindow` and
+`navigator.permissions` evasions disabled, and the manual page init patch off.
+This supports embedded-wallet provisioning flows while preserving the remaining
+Chromium stealth evasions. Set only the controls needed when a workflow needs
+the older full-stealth/headless profile or a custom profile:
 
 ```bash
-# Launch a visible browser window instead of headless mode.
-SEREN_PLAYWRIGHT_HEADLESS=0 node dist/index.js
+# Opt back into headless mode.
+SEREN_PLAYWRIGHT_HEADLESS=1 node dist/index.js
 
 # Skip the puppeteer-extra stealth plugin entirely.
 SEREN_PLAYWRIGHT_DISABLE_STEALTH=1 node dist/index.js
 
 # Keep stealth enabled but remove specific evasions by name.
-SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE=iframe.contentWindow,navigator.permissions node dist/index.js
+SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE=navigator.webdriver node dist/index.js
 
-# Skip the hand-written addInitScript patch applied to new Chromium pages.
-SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH=1 node dist/index.js
+# Opt back into the hand-written addInitScript patch for new Chromium pages.
+SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH=0 node dist/index.js
 ```
 
 The `SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE` value is a comma-separated list
-of evasion names. `chrome.app` is always disabled for macOS notarization
-compatibility.
+of evasion names. When the variable is unset, `iframe.contentWindow` and
+`navigator.permissions` are disabled by default. When it is set, the provided
+list replaces the default disabled set; set it to an empty string to opt back
+into all stealth evasions except `chrome.app`, which is always disabled for
+macOS notarization compatibility.
 
 ### In Seren Desktop
 

--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -185,21 +185,33 @@ describe("resolveBrowserName", () => {
 });
 
 describe("createSafeStealthPlugin", () => {
-  it("excludes chrome.app evasion for macOS notarization compatibility", () => {
+  it("excludes chrome.app and Privy-incompatible evasions by default", () => {
     const plugin = createSafeStealthPlugin();
-    expect(plugin.enabledEvasions.has("chrome.app")).toBe(false);
-  });
-
-  it("excludes env-requested evasions in addition to chrome.app", () => {
-    process.env.SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE =
-      "iframe.contentWindow, navigator.permissions";
-
-    const plugin = createSafeStealthPlugin();
-
     expect(plugin.enabledEvasions.has("chrome.app")).toBe(false);
     expect(plugin.enabledEvasions.has("iframe.contentWindow")).toBe(false);
     expect(plugin.enabledEvasions.has("navigator.permissions")).toBe(false);
-    expect(plugin.enabledEvasions.has("navigator.webdriver")).toBe(true);
+  });
+
+  it("lets an empty env value opt back into the full stealth evasion set", () => {
+    process.env.SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE = "";
+
+    const plugin = createSafeStealthPlugin();
+
+    expect(plugin.enabledEvasions.has("chrome.app")).toBe(false);
+    expect(plugin.enabledEvasions.has("iframe.contentWindow")).toBe(true);
+    expect(plugin.enabledEvasions.has("navigator.permissions")).toBe(true);
+  });
+
+  it("uses env-requested evasions instead of the default disabled set", () => {
+    process.env.SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE =
+      "navigator.webdriver";
+
+    const plugin = createSafeStealthPlugin();
+
+    expect(plugin.enabledEvasions.has("chrome.app")).toBe(false);
+    expect(plugin.enabledEvasions.has("iframe.contentWindow")).toBe(true);
+    expect(plugin.enabledEvasions.has("navigator.permissions")).toBe(true);
+    expect(plugin.enabledEvasions.has("navigator.webdriver")).toBe(false);
   });
 
   it("keeps other stealth evasions enabled", () => {
@@ -240,20 +252,7 @@ describe("applyStealthPluginIfEnabled", () => {
 });
 
 describe("addPageInitPatchIfEnabled", () => {
-  it("adds the manual init patch to chromium pages by default", async () => {
-    const mockPage = { addInitScript: vi.fn() };
-
-    const added = await addPageInitPatchIfEnabled(
-      mockPage as never,
-      "chromium",
-    );
-
-    expect(added).toBe(true);
-    expect(mockPage.addInitScript).toHaveBeenCalledOnce();
-  });
-
-  it("skips the manual init patch when disabled by env", async () => {
-    process.env.SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH = "1";
+  it("skips the manual init patch by default", async () => {
     const mockPage = { addInitScript: vi.fn() };
 
     const added = await addPageInitPatchIfEnabled(
@@ -263,6 +262,19 @@ describe("addPageInitPatchIfEnabled", () => {
 
     expect(added).toBe(false);
     expect(mockPage.addInitScript).not.toHaveBeenCalled();
+  });
+
+  it("adds the manual init patch when opted back in by env", async () => {
+    process.env.SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH = "0";
+    const mockPage = { addInitScript: vi.fn() };
+
+    const added = await addPageInitPatchIfEnabled(
+      mockPage as never,
+      "chromium",
+    );
+
+    expect(added).toBe(true);
+    expect(mockPage.addInitScript).toHaveBeenCalledOnce();
   });
 });
 
@@ -311,7 +323,7 @@ describe("launchBrowserWithFallback", () => {
       "chrome",
       "chromium",
       expect.objectContaining({
-        headless: true,
+        headless: false,
         executablePath:
           "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
       }),
@@ -321,14 +333,14 @@ describe("launchBrowserWithFallback", () => {
       "moz-firefox",
       "firefox",
       expect.objectContaining({
-        headless: true,
+        headless: false,
         executablePath: "/Applications/Firefox.app/Contents/MacOS/firefox",
       }),
     );
   });
 
-  it("launches headed when SEREN_PLAYWRIGHT_HEADLESS is 0", async () => {
-    process.env.SEREN_PLAYWRIGHT_HEADLESS = "0";
+  it("launches headless when SEREN_PLAYWRIGHT_HEADLESS is 1", async () => {
+    process.env.SEREN_PLAYWRIGHT_HEADLESS = "1";
     const launchedBrowser = { close: vi.fn() } as never;
     const launchBrowser = vi.fn().mockResolvedValueOnce(launchedBrowser);
 
@@ -351,7 +363,7 @@ describe("launchBrowserWithFallback", () => {
       "chrome",
       "chromium",
       expect.objectContaining({
-        headless: false,
+        headless: true,
       }),
     );
   });

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -58,6 +58,10 @@ export const STEALTH_EVASIONS_DISABLE_ENV =
   "SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE";
 export const DISABLE_PAGE_INIT_PATCH_ENV =
   "SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH";
+const DEFAULT_DISABLED_STEALTH_EVASIONS = [
+  "iframe.contentWindow",
+  "navigator.permissions",
+];
 
 // ── Browser Detection ──────────────────────────────────────────────────────────
 
@@ -362,7 +366,7 @@ export function createSafeStealthPlugin(
 export function shouldLaunchHeadless(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return env[PLAYWRIGHT_HEADLESS_ENV] !== "0";
+  return env[PLAYWRIGHT_HEADLESS_ENV] === "1";
 }
 
 export function shouldApplyStealthPlugin(
@@ -374,7 +378,10 @@ export function shouldApplyStealthPlugin(
 export function getDisabledStealthEvasions(
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
-  return (env[STEALTH_EVASIONS_DISABLE_ENV] ?? "")
+  const raw = env[STEALTH_EVASIONS_DISABLE_ENV];
+  if (raw === undefined) return [...DEFAULT_DISABLED_STEALTH_EVASIONS];
+
+  return raw
     .split(",")
     .map((name) => name.trim())
     .filter(Boolean);
@@ -396,7 +403,7 @@ export function applyStealthPluginIfEnabled(
 export function shouldApplyPageInitPatch(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return env[DISABLE_PAGE_INIT_PATCH_ENV] !== "1";
+  return env[DISABLE_PAGE_INIT_PATCH_ENV] === "0";
 }
 
 export async function addPageInitPatchIfEnabled(


### PR DESCRIPTION
## Summary
- flip bundled playwright-stealth defaults to the Privy-compatible profile: headed launch, default-disabled iframe.contentWindow/navigator.permissions evasions, and page init patch off
- preserve opt-back-in env behavior for headless launch, exact evasion override lists, and the manual page init patch
- update README profile controls to describe the new default and old-profile escape hatches

Closes #1958.

## Tests
- npm test -- src/__tests__/browser.test.ts
- npm test
- npm run build
- git diff --check