### PR TITLE
fix(agent-store): budget active skill priming

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -84,6 +84,10 @@ export interface ProjectSkillsConfig {
   };
 }
 
+export interface EnabledSkillsContentOptions {
+  mode?: "full" | "compact";
+}
+
 /**
  * Transform an index entry to a Skill.
  *
@@ -549,6 +553,52 @@ function skillSlugFromSourceUrl(sourceUrl: string): string | null {
 
 function skillSourceUrlFromSlug(slug: string): string {
   return `seren-skills:${slug}`;
+}
+
+function extractMarkdownSectionPreview(
+  content: string,
+  heading: string,
+  maxChars: number,
+): string | null {
+  const lines = content.split(/\r?\n/);
+  const headingPattern = new RegExp(`^#{2,3}\\s+${heading}\\s*$`, "i");
+  const start = lines.findIndex((line) => headingPattern.test(line.trim()));
+  if (start < 0) return null;
+
+  const collected: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^#{1,3}\s+/.test(line.trim())) break;
+    collected.push(line);
+  }
+
+  const preview = collected.join("\n").trim();
+  if (!preview) return null;
+  return preview.length > maxChars
+    ? `${preview.slice(0, maxChars).trimEnd()}...`
+    : preview;
+}
+
+function buildCompactSkillPrompt(args: {
+  skill: InstalledSkill;
+  runtimeDir: string;
+  sep: string;
+  runtimeNote: string;
+  parsedContent: string;
+}): string {
+  const { skill, runtimeDir, sep, runtimeNote, parsedContent } = args;
+  const description = skill.description?.trim();
+  const whenToUse = extractMarkdownSectionPreview(
+    parsedContent,
+    "When to Use",
+    700,
+  );
+  const details = [
+    description ? `Description: ${description}` : null,
+    whenToUse ? `When to use:\n${whenToUse}` : null,
+    `Before using this skill, open \`${runtimeDir}${sep}SKILL.md\` and follow its full instructions.`,
+  ].filter((line): line is string => line !== null);
+
+  return `## Skill: ${skill.name}\n\n${runtimeNote}${details.join("\n\n")}`;
 }
 
 function isSerenUpstreamSource(value: string | undefined): boolean {
@@ -1574,6 +1624,7 @@ export const skills = {
    */
   async getEnabledSkillsContent(
     installedSkills: InstalledSkill[],
+    opts?: EnabledSkillsContentOptions,
   ): Promise<string> {
     const enabled = installedSkills.filter((s) => s.enabled);
 
@@ -1600,9 +1651,21 @@ export const skills = {
           ? `\n> **Platform:** Windows. Python (\`python\` and \`python3\`) is bundled with Seren Desktop — no install needed. Skill docs commonly reference \`~/.config/seren/skills/<name>\` and forward-slash paths; on this machine:\n> - Replace any \`~/.config/seren/skills/<name>\` reference with the absolute runtime directory above.\n> - Use backslashes inside paths.\n> Always \`cd\` into the absolute runtime directory above before invoking skill scripts.`
           : "";
         const runtimeNote = `> **Skill runtime directory:** \`${runtimeDir}\`\n> Use this absolute path to reference skill files. Do not create local copies or fallback scaffolds.${platformNote}${depsNote}\n\n`;
-        contents.push(
-          `## Skill: ${skill.name}\n\n${runtimeNote}${parsed.content}`,
-        );
+        if (opts?.mode === "compact") {
+          contents.push(
+            buildCompactSkillPrompt({
+              skill,
+              runtimeDir,
+              sep,
+              runtimeNote,
+              parsedContent: parsed.content,
+            }),
+          );
+        } else {
+          contents.push(
+            `## Skill: ${skill.name}\n\n${runtimeNote}${parsed.content}`,
+          );
+        }
       }
     }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -9,6 +9,7 @@ import {
   onRuntimeEvent,
 } from "@/lib/browser-local-runtime";
 import { runtimeHasCapability } from "@/lib/runtime";
+import { estimateTokens } from "@/lib/token-counter";
 import { getEnabledMcpServers, settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
 
@@ -146,6 +147,26 @@ export const PUBLISHER_LIVE_QUERY_INSTRUCTION =
  * priming block on sessions that received it.
  */
 const REPRIME_AFTER_MESSAGES = 30;
+
+/**
+ * First-turn skill priming must leave real room for the user's prompt, tool
+ * schemas, and the model's response. If a large active-skill set would exceed
+ * this safe input budget, buildPromptContext sends a compact manifest instead
+ * of every full SKILL.md body. #1960.
+ */
+export const PROMPT_PRIMING_CONTEXT_BUDGET_FRACTION = 0.8;
+export const PROMPT_PRIMING_RESERVED_OUTPUT_TOKENS = 8_000;
+
+function estimatePromptContextTokens(
+  prompt: string | undefined,
+  context: Array<Record<string, string>>,
+): number {
+  const contextText = context
+    .flatMap((entry) => Object.values(entry))
+    .filter((value) => typeof value === "string" && value.length > 0)
+    .join("\n\n");
+  return estimateTokens(`${prompt ?? ""}\n\n${contextText}`);
+}
 
 /** Await a session ready promise with a timeout to prevent infinite hangs */
 function waitForSessionReady(sessionId: string): Promise<void> {
@@ -1845,7 +1866,11 @@ export const agentStore = {
 
       try {
         const { merged: retryContext, newSignature } =
-          await this.buildPromptContext(newSessionId, promptContext);
+          await this.buildPromptContext(
+            newSessionId,
+            promptContext,
+            promptText as string,
+          );
         await providerService.sendPrompt(
           newSessionId,
           promptText as string,
@@ -3262,6 +3287,7 @@ export const agentStore = {
   async buildPromptContext(
     sessionId: string,
     context?: Array<Record<string, string>>,
+    promptForBudget?: string,
   ): Promise<{
     merged: Array<Record<string, string>> | undefined;
     newSignature: string | null;
@@ -3306,9 +3332,40 @@ export const agentStore = {
     }
 
     if (!alreadyPrimed) {
+      let deliveredSkillsContent = skillsContent;
       if (skillsContent) {
+        const maxSafeInputTokens = Math.max(
+          0,
+          Math.floor(
+            session.contextWindowSize * PROMPT_PRIMING_CONTEXT_BUDGET_FRACTION,
+          ) - PROMPT_PRIMING_RESERVED_OUTPUT_TOKENS,
+        );
+        const projectedFullPrimingTokens =
+          estimatePromptContextTokens(promptForBudget, mergedContext) +
+          estimateTokens(PUBLISHER_LIVE_QUERY_INSTRUCTION) +
+          estimateTokens(skillsContent);
+
+        if (projectedFullPrimingTokens > maxSafeInputTokens) {
+          console.warn(
+            `[AgentStore] Active skill primer exceeds safe input budget (${projectedFullPrimingTokens.toLocaleString()} > ${maxSafeInputTokens.toLocaleString()} tokens); using compact skill manifest (#1960)`,
+          );
+          try {
+            deliveredSkillsContent =
+              (await skillsStore.getThreadSkillsContent(
+                session.cwd,
+                session.conversationId,
+                { mode: "compact" },
+              )) || skillsContent;
+          } catch (error) {
+            console.warn(
+              "[AgentStore] Failed to load compact skill manifest; using full skill content:",
+              error,
+            );
+          }
+        }
+
         mergedContext = [
-          { type: "text", text: skillsContent },
+          { type: "text", text: deliveredSkillsContent },
           ...mergedContext,
         ];
       }
@@ -4649,6 +4706,7 @@ Structured summary:`;
       const { merged, newSignature } = await this.buildPromptContext(
         sessionId,
         context,
+        prompt,
       );
       // Apply the post-compaction prepend (one-shot) AFTER the user message
       // is rendered in the UI but BEFORE the IPC dispatch — the user's chat

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -15,6 +15,7 @@ import {
   type SkillsState,
 } from "@/lib/skills";
 import {
+  type EnabledSkillsContentOptions,
   isAuthStatus,
   isUpstreamManagedSkill,
   type ProjectSkillsConfig,
@@ -673,10 +674,12 @@ export const skillsStore = {
   async getThreadSkillsContent(
     projectRoot: string | null,
     threadId: string | null,
+    opts?: EnabledSkillsContentOptions,
   ): Promise<string> {
     await this.ensureContextLoaded(projectRoot, threadId);
     return skills.getEnabledSkillsContent(
       this.getThreadSkills(projectRoot, threadId),
+      opts,
     );
   },
 

--- a/tests/unit/agent-skills-priming.test.ts
+++ b/tests/unit/agent-skills-priming.test.ts
@@ -57,4 +57,26 @@ describe("agent skill context priming", () => {
     expect(retrySend).toBeGreaterThan(0);
     expect(retryMark).toBeGreaterThan(retrySend);
   });
+
+  it("#1960 budgets full skill priming before dispatch and falls back to a compact manifest", () => {
+    const body = methodBody("async buildPromptContext");
+
+    expect(body).toContain("estimatePromptContextTokens");
+    expect(body).toContain("PROMPT_PRIMING_CONTEXT_BUDGET_FRACTION");
+    expect(body).toContain("projectedFullPrimingTokens");
+    expect(body).toContain('mode: "compact"');
+    expect(body).toContain("deliveredSkillsContent");
+  });
+
+  it("#1960 keeps full skill content in the signature even when compact content is delivered", () => {
+    const body = methodBody("async buildPromptContext");
+
+    const signatureIdx = body.indexOf("const currentSignature");
+    const compactIdx = body.indexOf('mode: "compact"');
+    const returnIdx = body.indexOf("newSignature: alreadyPrimed ? null : currentSignature");
+
+    expect(signatureIdx).toBeGreaterThan(0);
+    expect(compactIdx).toBeGreaterThan(signatureIdx);
+    expect(returnIdx).toBeGreaterThan(compactIdx);
+  });
 });

--- a/tests/unit/skills-compact-context.test.ts
+++ b/tests/unit/skills-compact-context.test.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Critical guard for #1960 — large active-skill sets must have a
+// ABOUTME: compact prompt form so first-turn Codex prompts do not overflow.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const skillsServiceSource = readFileSync(
+  join(process.cwd(), "src/services/skills.ts"),
+  "utf8",
+);
+
+function methodBody(name: string): string {
+  const start = skillsServiceSource.indexOf(`${name}(`);
+  expect(start).toBeGreaterThan(0);
+  const end = skillsServiceSource.indexOf("\n  },", start);
+  expect(end).toBeGreaterThan(start);
+  return skillsServiceSource.slice(start, end);
+}
+
+describe("#1960 — compact active-skill prompt context", () => {
+  it("getEnabledSkillsContent accepts a compact mode option", () => {
+    const body = methodBody("async getEnabledSkillsContent");
+
+    expect(skillsServiceSource).toContain("EnabledSkillsContentOptions");
+    expect(body).toContain("opts?: EnabledSkillsContentOptions");
+    expect(body).toContain('opts?.mode === "compact"');
+  });
+
+  it("compact mode keeps runtime paths and tells the agent to read SKILL.md on demand", () => {
+    const body = methodBody("async getEnabledSkillsContent");
+
+    expect(body).toContain("buildCompactSkillPrompt");
+    expect(skillsServiceSource).toContain("Before using this skill, open");
+    expect(skillsServiceSource).toContain("SKILL.md");
+    expect(skillsServiceSource).toContain("runtimeDir");
+  });
+});


### PR DESCRIPTION
Closes #1960

## Summary

- Adds a safe input-budget check before first-turn active-skill priming is dispatched to Codex/agent runtimes.
- Keeps full active skill bodies when projected input fits the model context budget.
- Falls back to a compact active-skill manifest with runtime SKILL.md paths when full skill content would exceed the safe budget.
- Preserves the full-content signature for re-prime invalidation, so skill changes still force a fresh primer.

## Audit Results

- Reproduced from logs: new Codex sessions hit prompt-too-long before any compactable transcript existed.
- Root cause: Desktop-added full active skills could make the first prompt oversized; reactive compaction then returned skipped_nothing_to_compact.
- Fix impact: the oversized full-skill primer is avoided before provider dispatch; the single-message compaction branch remains only a genuine oversized-user-prompt fallback.

## Verification

- ./node_modules/.bin/vitest run tests/unit/agent-skills-priming.test.ts tests/unit/skills-compact-context.test.ts
- ./node_modules/.bin/biome check src/stores/agent.store.ts src/stores/skills.store.ts src/services/skills.ts tests/unit/agent-skills-priming.test.ts tests/unit/skills-compact-context.test.ts
- ./node_modules/.bin/tsc --noEmit