### PR TITLE
Fix Playwright stealth MCP browser fallback

### DIFF
--- a/mcp-servers/playwright-stealth/README.md
+++ b/mcp-servers/playwright-stealth/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server providing stealth browser automation with 
 
 ## Features
 
-- **Multi-Browser Support**: Chromium (default), Firefox, WebKit, Google Chrome, Microsoft Edge, and any installed Playwright browser
+- **Multi-Browser Support**: System-installed Google Chrome, Microsoft Edge, and Mozilla Firefox variants
 - **Runtime Browser Switching**: Discover installed browsers and switch between them via MCP tools
 - **Stealth Browser**: Uses `playwright-extra` with `puppeteer-extra-plugin-stealth` to avoid bot detection (Chromium-based browsers only)
 - **Anti-Detection Measures** (Chromium/Edge/Chrome only):
@@ -171,6 +171,9 @@ System browsers must be installed via their normal installers:
 - **Google Chrome**: [google.com/chrome](https://www.google.com/chrome/)
 - **Microsoft Edge**: [microsoft.com/edge](https://www.microsoft.com/edge)
 - **Mozilla Firefox**: [mozilla.org/firefox](https://www.mozilla.org/firefox/)
+
+If none of these system browsers is detected, the server fails closed instead
+of launching Playwright's managed `chromium`, `firefox`, or `webkit` binaries.
 
 ## How Stealth Works
 

--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Validates parseBrowserType, isChromiumBased, resolveBrowserName, and listInstalledBrowsers.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { InstalledBrowser } from "../browser.js";
 import {
   addPageInitPatchIfEnabled,
   applyStealthPluginIfEnabled,
@@ -13,6 +14,30 @@ import {
   parseBrowserType,
   resolveBrowserName,
 } from "../browser.js";
+
+const TEST_INSTALLED_BROWSERS: InstalledBrowser[] = [
+  {
+    name: "chrome",
+    browserName: "chromium",
+    executablePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    isChromiumBased: true,
+    stealthSupported: true,
+  },
+  {
+    name: "msedge",
+    browserName: "chromium",
+    executablePath: "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    isChromiumBased: true,
+    stealthSupported: true,
+  },
+  {
+    name: "moz-firefox",
+    browserName: "firefox",
+    executablePath: "/Applications/Firefox.app/Contents/MacOS/firefox",
+    isChromiumBased: false,
+    stealthSupported: false,
+  },
+];
 
 const CONTROLLED_ENV_KEYS = [
   "SEREN_PLAYWRIGHT_HEADLESS",
@@ -39,28 +64,38 @@ afterEach(() => {
 
 describe("detectDefaultBrowser", () => {
   it("returns a system browser name", () => {
-    const result = detectDefaultBrowser();
+    const result = detectDefaultBrowser(TEST_INSTALLED_BROWSERS);
     // Should never return a Playwright-bundled browser when system ones exist
     expect(["chromium", "firefox", "webkit"]).not.toContain(result);
   });
 
   it("returns a string", () => {
-    expect(typeof detectDefaultBrowser()).toBe("string");
+    expect(typeof detectDefaultBrowser(TEST_INSTALLED_BROWSERS)).toBe("string");
+  });
+
+  it("fails closed when no supported system browser is detected", () => {
+    expect(() => detectDefaultBrowser([])).toThrow(
+      "No supported system browser detected",
+    );
   });
 });
 
 describe("parseBrowserType", () => {
   it("auto-detects system browser for undefined", () => {
-    const result = parseBrowserType(undefined);
-    expect(result).toBe(detectDefaultBrowser());
+    const result = parseBrowserType(undefined, TEST_INSTALLED_BROWSERS);
+    expect(result).toBe(detectDefaultBrowser(TEST_INSTALLED_BROWSERS));
   });
 
   it("auto-detects system browser for empty string", () => {
-    expect(parseBrowserType("")).toBe(detectDefaultBrowser());
+    expect(parseBrowserType("", TEST_INSTALLED_BROWSERS)).toBe(
+      detectDefaultBrowser(TEST_INSTALLED_BROWSERS),
+    );
   });
 
   it("auto-detects system browser for whitespace-only string", () => {
-    expect(parseBrowserType("   ")).toBe(detectDefaultBrowser());
+    expect(parseBrowserType("   ", TEST_INSTALLED_BROWSERS)).toBe(
+      detectDefaultBrowser(TEST_INSTALLED_BROWSERS),
+    );
   });
 
   it("returns 'chrome' for 'chrome'", () => {
@@ -112,8 +147,8 @@ describe("parseBrowserType", () => {
 
   it("falls back with stderr warning for unknown value", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const result = parseBrowserType("safari");
-    expect(result).toBe(detectDefaultBrowser());
+    const result = parseBrowserType("safari", TEST_INSTALLED_BROWSERS);
+    expect(result).toBe(detectDefaultBrowser(TEST_INSTALLED_BROWSERS));
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining('Unknown or unsupported BROWSER_TYPE "safari"'),
     );
@@ -415,6 +450,16 @@ describe("launchBrowserWithFallback", () => {
       "Failed to launch any supported browser. Tried 3 candidate(s): chrome: chrome failed; msedge: edge failed; moz-firefox: firefox failed.",
     );
   });
+
+  it("never bare-launches a Playwright-bundled Chromium candidate", async () => {
+    const launchBrowser = vi.fn().mockResolvedValueOnce({ close: vi.fn() });
+
+    await expect(
+      launchBrowserWithFallback("chromium", [], launchBrowser as never),
+    ).rejects.toThrow("Playwright bundled browser");
+
+    expect(launchBrowser).not.toHaveBeenCalled();
+  });
 });
 
 describe("listInstalledBrowsers", () => {
@@ -471,13 +516,19 @@ describe("listInstalledBrowsers", () => {
     }
   });
 
-  it("default browser has a valid executablePath in the registry", () => {
+  it("default browser has a valid executablePath when browsers are detected", () => {
     const browsers = listInstalledBrowsers();
-    const defaultName = detectDefaultBrowser();
+    if (browsers.length === 0) {
+      expect(() => detectDefaultBrowser(browsers)).toThrow(
+        "No supported system browser detected",
+      );
+      return;
+    }
+
+    const defaultName = detectDefaultBrowser(browsers);
     const match = browsers.find((b) => b.name === defaultName);
-    // The default browser must exist in the registry with a real path —
     // getBrowser() uses this path to launch directly via executablePath
-    // instead of channel, which avoids Playwright plugin dependencies.
+    // instead of a bare Playwright-managed engine.
     expect(match).toBeDefined();
     expect(match?.executablePath).toBeTruthy();
   });

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -1,9 +1,7 @@
 // ABOUTME: Stealth browser management with multi-browser support and runtime switching.
-// ABOUTME: Detects installed browsers via Playwright registry; supports Chromium, Firefox, WebKit, Chrome, Edge channels.
+// ABOUTME: Detects installed browsers without using Playwright-managed browser binaries.
 
 import { existsSync } from "node:fs";
-import { createRequire } from "node:module";
-import { dirname } from "node:path";
 import type { Browser, BrowserContext, BrowserType, Page } from "playwright";
 import { chromium, firefox, webkit } from "playwright-extra";
 import StealthPlugin from "puppeteer-extra-plugin-stealth";
@@ -42,6 +40,12 @@ const SYSTEM_BROWSERS = new Set([
   "moz-firefox-nightly",
 ]);
 
+const PLAYWRIGHT_BUNDLED_BROWSER_NAMES = new Set([
+  "chromium",
+  "firefox",
+  "webkit",
+]);
+
 /** Default user agents per browser engine. */
 const DEFAULT_USER_AGENTS: Record<BrowserEngine, string> = {
   chromium:
@@ -65,43 +69,178 @@ const DEFAULT_DISABLED_STEALTH_EVASIONS = [
 
 // ── Browser Detection ──────────────────────────────────────────────────────────
 
-/** Minimal shape of Playwright's internal registry executable. */
-interface RegistryExecutable {
+interface SystemBrowserCandidate {
   name: string;
-  browserName: string | undefined;
-  executablePath(): string;
+  browserName: BrowserEngine;
+  executablePaths: string[];
 }
 
-const require_ = createRequire(import.meta.url);
+function candidate(
+  name: string,
+  browserName: BrowserEngine,
+  ...executablePaths: string[]
+): SystemBrowserCandidate {
+  return { name, browserName, executablePaths };
+}
 
-/** Query Playwright's internal registry for installed browsers. */
-export function listInstalledBrowsers(): InstalledBrowser[] {
-  const coreDir = dirname(require_.resolve("playwright-core/package.json"));
-  const registryPath = `${coreDir}/lib/server/registry/index.js`;
+function chromiumCandidate(
+  name: string,
+  ...executablePaths: string[]
+): SystemBrowserCandidate {
+  return candidate(name, "chromium", ...executablePaths);
+}
 
-  let registry: { registry: { executables(): RegistryExecutable[] } };
-  try {
-    registry = require_(registryPath);
-  } catch {
-    console.error(
-      "[playwright-stealth] Failed to load Playwright registry. Browser detection unavailable.",
-    );
-    return [];
+function firefoxCandidate(
+  name: string,
+  ...executablePaths: string[]
+): SystemBrowserCandidate {
+  return candidate(name, "firefox", ...executablePaths);
+}
+
+function firstExistingPath(paths: string[]): string | null {
+  for (const candidate of paths) {
+    if (candidate && existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function macApp(appName: string, executableName = appName): string {
+  return `/Applications/${appName}.app/Contents/MacOS/${executableName}`;
+}
+
+function windowsPaths(productPath: string, executableName: string): string[] {
+  const roots = [
+    process.env.PROGRAMFILES,
+    process.env["PROGRAMFILES(X86)"],
+    process.env.LOCALAPPDATA,
+  ].filter(Boolean) as string[];
+  return roots.map((root) => `${root}\\${productPath}\\${executableName}`);
+}
+
+function browserCandidatesForPlatform(): SystemBrowserCandidate[] {
+  if (process.platform === "darwin") {
+    return [
+      chromiumCandidate(
+        "chrome",
+        macApp("Google Chrome"),
+        macApp("Google Chrome for Testing"),
+      ),
+      chromiumCandidate("chrome-beta", macApp("Google Chrome Beta")),
+      chromiumCandidate("chrome-dev", macApp("Google Chrome Dev")),
+      chromiumCandidate("chrome-canary", macApp("Google Chrome Canary")),
+      chromiumCandidate("msedge", macApp("Microsoft Edge")),
+      chromiumCandidate("msedge-beta", macApp("Microsoft Edge Beta")),
+      chromiumCandidate("msedge-dev", macApp("Microsoft Edge Dev")),
+      chromiumCandidate("msedge-canary", macApp("Microsoft Edge Canary")),
+      firefoxCandidate("moz-firefox", macApp("Firefox", "firefox")),
+      firefoxCandidate(
+        "moz-firefox-beta",
+        macApp("Firefox Developer Edition", "firefox"),
+      ),
+      firefoxCandidate(
+        "moz-firefox-nightly",
+        macApp("Firefox Nightly", "firefox"),
+      ),
+    ];
   }
 
+  if (process.platform === "win32") {
+    return [
+      chromiumCandidate(
+        "chrome",
+        ...windowsPaths("Google\\Chrome\\Application", "chrome.exe"),
+      ),
+      chromiumCandidate(
+        "chrome-beta",
+        ...windowsPaths("Google\\Chrome Beta\\Application", "chrome.exe"),
+      ),
+      chromiumCandidate(
+        "chrome-dev",
+        ...windowsPaths("Google\\Chrome Dev\\Application", "chrome.exe"),
+      ),
+      chromiumCandidate(
+        "chrome-canary",
+        ...windowsPaths("Google\\Chrome SxS\\Application", "chrome.exe"),
+      ),
+      chromiumCandidate(
+        "msedge",
+        ...windowsPaths("Microsoft\\Edge\\Application", "msedge.exe"),
+      ),
+      chromiumCandidate(
+        "msedge-beta",
+        ...windowsPaths("Microsoft\\Edge Beta\\Application", "msedge.exe"),
+      ),
+      chromiumCandidate(
+        "msedge-dev",
+        ...windowsPaths("Microsoft\\Edge Dev\\Application", "msedge.exe"),
+      ),
+      chromiumCandidate(
+        "msedge-canary",
+        ...windowsPaths("Microsoft\\Edge SxS\\Application", "msedge.exe"),
+      ),
+      firefoxCandidate(
+        "moz-firefox",
+        ...windowsPaths("Mozilla Firefox", "firefox.exe"),
+      ),
+      firefoxCandidate(
+        "moz-firefox-beta",
+        ...windowsPaths("Mozilla Firefox Beta", "firefox.exe"),
+      ),
+      firefoxCandidate(
+        "moz-firefox-nightly",
+        ...windowsPaths("Firefox Nightly", "firefox.exe"),
+      ),
+    ];
+  }
+
+  return [
+    chromiumCandidate(
+      "chrome",
+      "/usr/bin/google-chrome",
+      "/usr/bin/google-chrome-stable",
+      "/opt/google/chrome/chrome",
+      "/usr/bin/chromium",
+      "/snap/bin/chromium",
+    ),
+    chromiumCandidate(
+      "chrome-beta",
+      "/usr/bin/google-chrome-beta",
+      "/opt/google/chrome-beta/chrome",
+    ),
+    chromiumCandidate(
+      "chrome-dev",
+      "/usr/bin/google-chrome-unstable",
+      "/opt/google/chrome-unstable/chrome",
+    ),
+    chromiumCandidate(
+      "msedge",
+      "/usr/bin/microsoft-edge",
+      "/usr/bin/microsoft-edge-stable",
+      "/opt/microsoft/msedge/msedge",
+    ),
+    chromiumCandidate(
+      "msedge-beta",
+      "/usr/bin/microsoft-edge-beta",
+      "/opt/microsoft/msedge-beta/msedge",
+    ),
+    chromiumCandidate(
+      "msedge-dev",
+      "/usr/bin/microsoft-edge-dev",
+      "/opt/microsoft/msedge-dev/msedge",
+    ),
+    firefoxCandidate("moz-firefox", "/usr/bin/firefox", "/snap/bin/firefox"),
+    firefoxCandidate("moz-firefox-beta", "/usr/bin/firefox-beta"),
+    firefoxCandidate("moz-firefox-nightly", "/usr/bin/firefox-nightly"),
+  ];
+}
+
+/** Detect supported system browsers without consulting Playwright-managed binaries. */
+export function listInstalledBrowsers(): InstalledBrowser[] {
   const results: InstalledBrowser[] = [];
 
-  for (const exe of registry.registry.executables()) {
-    if (!exe.browserName) continue;
+  for (const exe of browserCandidatesForPlatform()) {
     if (!SYSTEM_BROWSERS.has(exe.name)) continue;
-
-    let exePath: string;
-    try {
-      exePath = exe.executablePath();
-    } catch {
-      continue;
-    }
-
+    const exePath = firstExistingPath(exe.executablePaths);
     if (!exePath || !existsSync(exePath)) continue;
 
     results.push({
@@ -138,24 +277,22 @@ const SYSTEM_BROWSER_PREFERENCE = [
 ];
 
 /** Detect the best available system browser. */
-export function detectDefaultBrowser(): string {
-  const installed = listInstalledBrowsers();
+export function detectDefaultBrowser(
+  installed: InstalledBrowser[] = listInstalledBrowsers(),
+): string {
   const installedNames = new Set(installed.map((b) => b.name));
 
   for (const name of SYSTEM_BROWSER_PREFERENCE) {
     if (installedNames.has(name)) return name;
   }
 
-  // No system browser found — log instructions and fall back to chromium
   if (installed.length > 0) return installed[0].name;
 
-  console.error(
-    "[playwright-stealth] No system browser detected. " +
-      "Install Google Chrome, Microsoft Edge, or Mozilla Firefox " +
-      "for the best stealth experience. " +
-      "Falling back to Playwright's bundled Chromium (may be flagged by bot detection).",
+  throw new Error(
+    "[playwright-stealth] No supported system browser detected. " +
+      "Install Google Chrome, Microsoft Edge, or Mozilla Firefox. " +
+      "Playwright bundled browsers (chromium, firefox, webkit) are not supported by this MCP.",
   );
-  return "chromium";
 }
 
 export function isChromiumBased(browserName: string): boolean {
@@ -185,18 +322,21 @@ const BROWSER_ALIASES: Record<string, string> = {
 };
 
 /** Validate and normalize a browser type string. Auto-detects if not set. */
-export function parseBrowserType(value: string | undefined): string {
-  if (!value) return detectDefaultBrowser();
+export function parseBrowserType(
+  value: string | undefined,
+  installed?: InstalledBrowser[],
+): string {
+  if (!value) return detectDefaultBrowser(installed);
 
   const normalized = value.toLowerCase().trim();
-  if (!normalized) return detectDefaultBrowser();
+  if (!normalized) return detectDefaultBrowser(installed);
 
   const aliased = BROWSER_ALIASES[normalized];
   if (aliased) return aliased;
 
   if (SYSTEM_BROWSERS.has(normalized)) return normalized;
 
-  const fallback = detectDefaultBrowser();
+  const fallback = detectDefaultBrowser(installed);
   console.error(
     `[playwright-stealth] Unknown or unsupported BROWSER_TYPE "${value}". Falling back to ${fallback}.`,
   );
@@ -253,6 +393,10 @@ function buildLaunchOptions(
   const match = installed.find((b) => b.name === browserName);
   if (match) {
     launchOptions.executablePath = match.executablePath;
+  } else if (PLAYWRIGHT_BUNDLED_BROWSER_NAMES.has(browserName)) {
+    throw new Error(
+      `Playwright bundled browser "${browserName}" is not supported. Install and select a system browser instead.`,
+    );
   } else if (browserName !== engine) {
     launchOptions.channel = browserName;
   }
@@ -274,9 +418,9 @@ export async function launchBrowserWithFallback(
 
   for (const browserName of candidates) {
     const engine = resolveBrowserName(browserName);
-    const launchOptions = buildLaunchOptions(browserName, engine, installed);
 
     try {
+      const launchOptions = buildLaunchOptions(browserName, engine, installed);
       const launchedBrowser = await launchBrowser(
         browserName,
         engine,
@@ -296,10 +440,9 @@ export async function launchBrowserWithFallback(
 
 // ── State ──────────────────────────────────────────────────────────────────────
 
-// Lazy: eager resolution synchronously walked Playwright's registry at module
-// load, and a slow cold-disk probe could outrun the MCP stdio `initialize`
-// handshake — leaving the prophet-arb-bot Python child stuck on
-// `blocked_auth_unexpected:TimeoutError`. Resolve on first read instead (#1921).
+// Lazy: probing installed browser paths during module load can outrun the MCP
+// stdio `initialize` handshake on slow disks. Resolve on first read instead
+// (#1921).
 let activeBrowserName: string | null = null;
 let browser: Browser | null = null;
 let context: BrowserContext | null = null;


### PR DESCRIPTION
Closes #1962

## Summary

- replace Playwright private registry detection with OS-installed Chrome/Edge/Firefox executable probes
- fail closed when no supported system browser exists instead of falling back to Playwright-managed Chromium
- block bare `chromium`/`firefox`/`webkit` launch candidates before they reach the launcher
- align README support claims with installed-browser-only behavior

## Audit

Before fix:
- `detectDefaultBrowser()` returned `chromium` when no system browser was detected.
- `buildLaunchOptions()` did not set `executablePath` or `channel` for bare `chromium`.
- That allowed `chromium.launch(...)` to use Playwright-managed Chromium.
- `listInstalledBrowsers()` depended on a private Playwright registry path that is unstable in newer `playwright-core`.

After fix:
- browser discovery checks normal OS install paths only
- default detection throws when discovery returns no supported system browser
- bundled Playwright names are explicitly rejected by launch option construction
- `BROWSER_TYPE=chromium` still maps to installed Chrome through the alias path

## Tests

- `npm test -- src/__tests__/browser.test.ts`
- `npm run build`
- `npm test`
- `git diff --check`
