### PR TITLE
fix(chat): pin Cancel button in composer toolbar (#1982)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -84,6 +84,11 @@ import RenderMarkdownWorker from "@/workers/render-markdown.worker?worker";
 import { AgentEffortSelector } from "./AgentEffortSelector";
 import { AgentModelSelector } from "./AgentModelSelector";
 import { AgentModeSelector } from "./AgentModeSelector";
+import {
+  COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES,
+  COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES,
+  COMPOSER_TOOLBAR_ROOT_CLASSES,
+} from "./composerToolbarClasses";
 import { DiffCard } from "./DiffCard";
 import { ImageAttachmentBar } from "./ImageAttachmentBar";
 import { PlanHeader } from "./PlanHeader";
@@ -1958,8 +1963,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 {commandStatus()}
               </div>
             </Show>
-            <div class="flex justify-between items-center">
-              <div class="flex items-center gap-3">
+            <div class={COMPOSER_TOOLBAR_ROOT_CLASSES}>
+              <div class={COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES}>
                 <Show
                   when={props.threadId}
                   fallback={
@@ -1996,9 +2001,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                   }}
                 />
 
-                <Show when={isPrompting()}>
-                  <ThinkingStatus startTime={promptStartTime} />
-                </Show>
                 <Show when={messageQueue().length > 0}>
                   <span class="flex items-center gap-2 px-2 py-1 bg-surface-2 border border-border rounded text-xs text-muted-foreground">
                     {messageQueue().length} message
@@ -2016,7 +2018,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                   </span>
                 </Show>
               </div>
-              <div class="flex items-center gap-2">
+              <div class={COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES}>
                 <VoiceInputButton
                   mode="agent"
                   onTranscript={(text) => {

--- a/src/components/chat/composerToolbarClasses.ts
+++ b/src/components/chat/composerToolbarClasses.ts
@@ -1,0 +1,11 @@
+// ABOUTME: Tailwind class invariants for the agent composer toolbar layout.
+// ABOUTME: Guards against regression of the Cancel-button-clip bug (#1982).
+
+export const COMPOSER_TOOLBAR_ROOT_CLASSES =
+  "flex justify-between items-center gap-2";
+
+export const COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES =
+  "flex items-center gap-3 min-w-0 flex-1 overflow-x-auto scrollbar-none";
+
+export const COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES =
+  "flex items-center gap-2 shrink-0";

--- a/tests/unit/composer-toolbar-layout.test.ts
+++ b/tests/unit/composer-toolbar-layout.test.ts
@@ -1,0 +1,29 @@
+// ABOUTME: Critical regression test for agent composer toolbar layout invariants.
+// ABOUTME: Guards against Cancel-button clipping when chip row grows (#1982).
+
+import { describe, expect, it } from "vitest";
+import {
+  COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES,
+  COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES,
+  COMPOSER_TOOLBAR_ROOT_CLASSES,
+} from "@/components/chat/composerToolbarClasses";
+
+describe("composer toolbar layout invariants (#1982)", () => {
+  it("right group must be pinned with shrink-0 so Cancel/Send is never clipped", () => {
+    expect(COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES).toMatch(/\bshrink-0\b/);
+  });
+
+  it("left group must shrink (min-w-0 + flex-1) before pushing the right group off-screen", () => {
+    expect(COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES).toMatch(/\bmin-w-0\b/);
+    expect(COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES).toMatch(/\bflex-1\b/);
+  });
+
+  it("left group must allow horizontal scroll so clipped chips remain reachable", () => {
+    expect(COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES).toMatch(/\boverflow-x-auto\b/);
+  });
+
+  it("root toolbar must keep gap between the two groups", () => {
+    expect(COMPOSER_TOOLBAR_ROOT_CLASSES).toMatch(/\bjustify-between\b/);
+    expect(COMPOSER_TOOLBAR_ROOT_CLASSES).toMatch(/\bgap-\d+\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1982. The composer toolbar in `AgentChat.tsx` clipped the **Cancel** button when the left chip row grew during prompting. Three CSS-only fixes:

- Pin right group with `shrink-0`; let left group shrink first via `min-w-0 flex-1` so the Cancel/Send button is always fully visible.
- Drop the redundant inline `ThinkingStatus` from the chip row — the banner above the textarea already shows working state + elapsed time.
- Add `overflow-x-auto` on the chip row so any remaining clipped chips stay reachable by horizontal scroll.

Layout classes are extracted to `src/components/chat/composerToolbarClasses.ts` and guarded by `tests/unit/composer-toolbar-layout.test.ts`.

## Test plan

- [x] `npx vitest run tests/unit/composer-toolbar-layout.test.ts` — 4/4 pass
- [x] `npx vitest run` — 1331/1331 pass, no regressions
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke: open agent chat in a narrow window, submit a long-running prompt, confirm Cancel stays clickable.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
