### PR TITLE
Fix frontend auth state after token refresh

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -136,6 +136,7 @@ pub async fn refresh_access_token(app: &tauri::AppHandle) -> Result<String, Stri
     let new_refresh_token = data.get("refresh_token").and_then(|v| v.as_str());
 
     store_tokens(app, new_access_token, new_refresh_token)?;
+    let _ = app.emit("auth:token-refreshed", ());
 
     log::info!("[auth] Token refreshed successfully");
     Ok(new_access_token.to_string())

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -27,6 +27,10 @@ export interface AuthError {
   code?: string;
 }
 
+interface RefreshAccessTokenOptions {
+  promptOnFailure?: boolean;
+}
+
 // Client-side login rate limiting (exponential backoff)
 const loginRateLimit = {
   attempts: 0,
@@ -126,11 +130,16 @@ export async function logout(): Promise<void> {
  * Refresh the access token using the stored refresh token.
  * @returns true if refresh succeeded, false if refresh token is missing or invalid
  */
-export async function refreshAccessToken(): Promise<boolean> {
+export async function refreshAccessToken(
+  options: RefreshAccessTokenOptions = {},
+): Promise<boolean> {
+  const { promptOnFailure = true } = options;
   const refreshToken = await getRefreshToken();
   if (!refreshToken) {
     clearAuthState();
-    requestSignInModal();
+    if (promptOnFailure) {
+      requestSignInModal();
+    }
     return false;
   }
 
@@ -146,7 +155,9 @@ export async function refreshAccessToken(): Promise<boolean> {
         await clearToken();
         await clearRefreshToken();
         clearAuthState();
-        requestSignInModal();
+        if (promptOnFailure) {
+          requestSignInModal();
+        }
       }
       return false;
     }
@@ -183,10 +194,24 @@ export async function isLoggedIn(): Promise<boolean> {
   }
 
   try {
-    const { data, error } = await getCurrentUser({ throwOnError: false });
+    const { data, error, response } = await getCurrentUser({
+      throwOnError: false,
+    });
 
     if (data?.data) {
       return true;
+    }
+
+    if (response?.status === 401 && (await getRefreshToken())) {
+      const refreshed = await refreshAccessToken({ promptOnFailure: false });
+      if (refreshed) {
+        const { data: retryData } = await getCurrentUser({
+          throwOnError: false,
+        });
+        if (retryData?.data) {
+          return true;
+        }
+      }
     }
 
     if (error) {

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -124,6 +124,28 @@ async function loadPrivateChatPolicy(): Promise<void> {
   }
 }
 
+async function activateAuthenticatedSession(user?: User): Promise<void> {
+  await loadPrivateChatPolicy();
+
+  const hasApiKey = await ensureApiKey();
+  if (!hasApiKey) {
+    console.warn("[Auth Store] Could not ensure API key - MCP may not work");
+  }
+
+  setState({
+    ...(user !== undefined ? { user } : {}),
+    isAuthenticated: true,
+    signInModalRequested: false,
+  });
+
+  // Initialize MCP Gateway in background (non-blocking)
+  void initializeMcpInBackground();
+}
+
+export async function restoreAuthenticatedSession(): Promise<void> {
+  await activateAuthenticatedSession();
+}
+
 async function resetSkillsCatalog(): Promise<void> {
   try {
     const { skillsStore } = await import("@/stores/skills.store");
@@ -149,17 +171,7 @@ export async function checkAuth(): Promise<void> {
       return;
     }
 
-    await loadPrivateChatPolicy();
-
-    const hasApiKey = await ensureApiKey();
-    if (!hasApiKey) {
-      console.warn("[Auth Store] Could not ensure API key - MCP may not work");
-    }
-
-    setState("isAuthenticated", true);
-
-    // Initialize MCP Gateway in background (non-blocking)
-    void initializeMcpInBackground();
+    await activateAuthenticatedSession();
   } finally {
     setState("isLoading", false);
   }
@@ -176,22 +188,7 @@ export async function checkAuth(): Promise<void> {
 export async function setAuthenticated(user: User): Promise<void> {
   setState("isLoading", true);
   try {
-    await loadPrivateChatPolicy();
-
-    const hasApiKey = await ensureApiKey();
-    if (!hasApiKey) {
-      console.warn(
-        "[Auth Store] Could not ensure API key after login - MCP may not work",
-      );
-    }
-
-    setState({
-      user,
-      isAuthenticated: true,
-    });
-
-    // Initialize MCP Gateway in background (non-blocking)
-    void initializeMcpInBackground();
+    await activateAuthenticatedSession(user);
   } finally {
     setState("isLoading", false);
   }
@@ -278,6 +275,17 @@ export async function initAuthRuntimeBindings(): Promise<void> {
     console.warn("[Auth Store] Session expired event from backend");
     clearAuthState();
     requestSignInModal();
+  });
+  await listen("auth:token-refreshed", async () => {
+    console.info("[Auth Store] Token refreshed event from backend");
+    try {
+      await restoreAuthenticatedSession();
+    } catch (error) {
+      console.warn(
+        "[Auth Store] Failed to restore auth state after backend refresh:",
+        error,
+      );
+    }
   });
 }
 

--- a/tests/unit/auth-rust-events.test.ts
+++ b/tests/unit/auth-rust-events.test.ts
@@ -1,0 +1,26 @@
+// ABOUTME: Source guard for Rust auth refresh lifecycle events.
+// ABOUTME: Ensures backend refresh success can repair frontend auth state.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const rustAuthSource = readFileSync(resolve("src-tauri/src/auth.rs"), "utf-8");
+
+describe("Rust auth refresh events", () => {
+  it("emits auth:token-refreshed after storing refreshed tokens", () => {
+    const storeIdx = rustAuthSource.indexOf("store_tokens(app, new_access_token");
+    const successLogIdx = rustAuthSource.indexOf(
+      "[auth] Token refreshed successfully",
+      storeIdx,
+    );
+    const refreshedEventIdx = rustAuthSource.indexOf(
+      'app.emit("auth:token-refreshed"',
+      storeIdx,
+    );
+
+    expect(storeIdx).toBeGreaterThan(0);
+    expect(refreshedEventIdx).toBeGreaterThan(storeIdx);
+    expect(refreshedEventIdx).toBeLessThan(successLogIdx);
+  });
+});

--- a/tests/unit/auth-service-refresh-login.test.ts
+++ b/tests/unit/auth-service-refresh-login.test.ts
@@ -1,0 +1,83 @@
+// ABOUTME: Regression tests for expired access tokens with still-valid refresh tokens.
+// ABOUTME: Prevents cold-start false sign-out when /auth/me returns 401.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  refreshToken: vi.fn(),
+  getToken: vi.fn<() => Promise<string | null>>(),
+  getRefreshToken: vi.fn<() => Promise<string | null>>(),
+  storeToken: vi.fn<(token: string) => Promise<void>>(),
+  storeRefreshToken: vi.fn<(token: string) => Promise<void>>(),
+  storeDefaultOrganizationId: vi.fn<(id: string) => Promise<void>>(),
+  clearToken: vi.fn<() => Promise<void>>(),
+  clearRefreshToken: vi.fn<() => Promise<void>>(),
+  clearDefaultOrganizationId: vi.fn<() => Promise<void>>(),
+  clearAuthState: vi.fn<() => void>(),
+  requestSignInModal: vi.fn<() => void>(),
+}));
+
+vi.mock("@/api", () => ({
+  getCurrentUser: mocks.getCurrentUser,
+  refreshToken: mocks.refreshToken,
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  getToken: mocks.getToken,
+  getRefreshToken: mocks.getRefreshToken,
+  storeToken: mocks.storeToken,
+  storeRefreshToken: mocks.storeRefreshToken,
+  storeDefaultOrganizationId: mocks.storeDefaultOrganizationId,
+  clearToken: mocks.clearToken,
+  clearRefreshToken: mocks.clearRefreshToken,
+  clearDefaultOrganizationId: mocks.clearDefaultOrganizationId,
+}));
+
+vi.mock("@/stores/auth.store", () => ({
+  clearAuthState: mocks.clearAuthState,
+  requestSignInModal: mocks.requestSignInModal,
+}));
+
+describe("auth service refresh during login validation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("uses a valid refresh token before declaring the user signed out", async () => {
+    mocks.getToken.mockResolvedValue("expired-access-token");
+    mocks.getRefreshToken.mockResolvedValue("valid-refresh-token");
+    mocks.getCurrentUser
+      .mockResolvedValueOnce({
+        error: { message: "Unauthorized" },
+        response: new Response(null, { status: 401 }),
+      })
+      .mockResolvedValueOnce({
+        data: { data: { id: "user-1", email: "u@test", name: "User" } },
+      });
+    mocks.refreshToken.mockResolvedValue({
+      data: {
+        data: {
+          access_token: "fresh-access-token",
+          refresh_token: "fresh-refresh-token",
+        },
+      },
+    });
+
+    const { isLoggedIn } = await import("@/services/auth");
+
+    await expect(isLoggedIn()).resolves.toBe(true);
+
+    expect(mocks.refreshToken).toHaveBeenCalledWith({
+      body: { refresh_token: "valid-refresh-token" },
+      throwOnError: false,
+    });
+    expect(mocks.storeToken).toHaveBeenCalledWith("fresh-access-token");
+    expect(mocks.storeRefreshToken).toHaveBeenCalledWith("fresh-refresh-token");
+    expect(mocks.getCurrentUser).toHaveBeenCalledTimes(2);
+    expect(mocks.clearToken).not.toHaveBeenCalled();
+    expect(mocks.clearAuthState).not.toHaveBeenCalled();
+    expect(mocks.requestSignInModal).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/auth-store-apikey-ordering.test.ts
+++ b/tests/unit/auth-store-apikey-ordering.test.ts
@@ -18,8 +18,11 @@ const {
   runtimeHasCapabilityMock,
   getPolicyMock,
   storedKeyRef,
+  listenMock,
+  eventListeners,
 } = vi.hoisted(() => {
   const storedKey: { value: string | null } = { value: null };
+  const listeners = new Map<string, (event?: unknown) => unknown>();
   return {
     storedKeyRef: storedKey,
     getSerenApiKeyMock: vi.fn(async () => storedKey.value),
@@ -39,6 +42,11 @@ const {
     removeSerenDbServerMock: vi.fn(async () => {}),
     runtimeHasCapabilityMock: vi.fn(() => false),
     getPolicyMock: vi.fn(async () => null),
+    eventListeners: listeners,
+    listenMock: vi.fn(async (event: string, handler: (event?: unknown) => unknown) => {
+      listeners.set(event, handler);
+      return vi.fn();
+    }),
   };
 });
 
@@ -73,7 +81,18 @@ vi.mock("@/services/organization-policy", () => ({
   getDefaultOrganizationPrivateChatPolicy: getPolicyMock,
 }));
 
-import { authStore, checkAuth, setAuthenticated } from "@/stores/auth.store";
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: listenMock,
+}));
+
+import {
+  authStore,
+  checkAuth,
+  clearAuthState,
+  initAuthRuntimeBindings,
+  requestSignInModal,
+  setAuthenticated,
+} from "@/stores/auth.store";
 
 function resetAuthStore() {
   // Drop internal state by calling logout(): resets user, isAuthenticated,
@@ -85,11 +104,20 @@ function resetAuthStore() {
     false;
   (authStore as unknown as { isLoading: boolean }).isLoading = true;
   (authStore as unknown as { user: unknown }).user = null;
+  (authStore as unknown as { mcpConnected: boolean }).mcpConnected = false;
+  (authStore as unknown as { privateChatPolicy: unknown }).privateChatPolicy =
+    null;
+  (
+    authStore as unknown as { signInModalRequested: boolean }
+  ).signInModalRequested = false;
 }
 
 describe("auth.store #1613 — API key before isAuthenticated flips", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    eventListeners.clear();
+    isTauriRuntimeMock.mockReturnValue(false);
+    runtimeHasCapabilityMock.mockReturnValue(false);
     resetAuthStore();
   });
 
@@ -159,5 +187,38 @@ describe("auth.store #1613 — API key before isAuthenticated flips", () => {
     expect(storeSerenApiKeyMock).not.toHaveBeenCalled();
     expect(authAtGetTime).toBe(false);
     expect(authStore.isAuthenticated).toBe(true);
+  });
+
+  it("backend token refresh event restores auth after provisioning key and dismisses stale modal", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    storedKeyRef.value = null;
+
+    let authAtStoreTime: boolean | null = null;
+    storeSerenApiKeyMock.mockImplementationOnce(async (key: string) => {
+      authAtStoreTime = authStore.isAuthenticated;
+      storedKeyRef.value = key;
+    });
+
+    requestSignInModal();
+    clearAuthState();
+    expect(authStore.isAuthenticated).toBe(false);
+    expect(authStore.signInModalRequested).toBe(true);
+
+    await initAuthRuntimeBindings();
+
+    expect(listenMock).toHaveBeenCalledWith(
+      "auth:token-refreshed",
+      expect.any(Function),
+    );
+
+    const onTokenRefreshed = eventListeners.get("auth:token-refreshed");
+    expect(onTokenRefreshed).toBeTypeOf("function");
+    await onTokenRefreshed?.();
+
+    expect(storeSerenApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(createApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(authAtStoreTime).toBe(false);
+    expect(authStore.isAuthenticated).toBe(true);
+    expect(authStore.signInModalRequested).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Fix cold-start auth validation so an expired access token with a valid refresh token does not mark the desktop signed out.
- Emit `auth:token-refreshed` from the Rust backend after refreshed tokens are stored.
- Restore the Solid auth store from backend refresh events after preserving the existing API-key-before-authenticated ordering, and clear stale session-expired modal state.

Fixes #1984

## Audit Result
The console showed successful backend refreshes while frontend consumers still saw `authStore.isAuthenticated === false`. The issue had two code paths: frontend `isLoggedIn` did not try refresh on `/auth/me` 401, and the Rust refresh path had no success event for the webview to reconcile stale auth state.

## Tests
- `./node_modules/.bin/vitest run tests/unit/auth-store-apikey-ordering.test.ts tests/unit/auth-service-refresh-login.test.ts tests/unit/auth-rust-events.test.ts tests/unit/compaction-auth-gate.test.ts tests/unit/fetch-retry.test.ts`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `rustfmt --edition 2024 --check src-tauri/src/auth.rs`
- `cargo check`