### PR TITLE
Fix weakly bounded agent loops

### DIFF
--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -1,6 +1,7 @@
 // ABOUTME: Configures embedded Node.js and Git runtime paths at application startup.
 // ABOUTME: Stores bundled runtime directories for injection into child process environments.
 
+use serde::Serialize;
 use std::env;
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -21,6 +22,93 @@ pub struct EmbeddedRuntimePaths {
     /// distribution. macOS and Linux ship a usable Python in the base OS,
     /// so this field is always `None` there.
     pub python_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeHealthIssue {
+    pub component: String,
+    pub message: String,
+    pub remediation: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeHealthReport {
+    pub ok: bool,
+    pub platform: String,
+    pub issues: Vec<RuntimeHealthIssue>,
+}
+
+impl RuntimeHealthReport {
+    pub fn to_error_message(&self) -> String {
+        if self.ok {
+            return "Runtime health check passed".to_string();
+        }
+
+        let details = self
+            .issues
+            .iter()
+            .map(|issue| {
+                format!(
+                    "- {}: {} Fix: {}",
+                    issue.component, issue.message, issue.remediation
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        format!(
+            "Windows bundled runtime health check failed before chat execution.\n{}",
+            details
+        )
+    }
+}
+
+/// Validate the runtime pieces that must exist before chat-mode agents start
+/// debugging from inside the user's paid turn. Windows is intentionally
+/// fail-closed because it does not have reliable system Python/Node fallback
+/// semantics for skill execution.
+pub fn runtime_health_report_for_os(
+    platform: &str,
+    paths: &EmbeddedRuntimePaths,
+    playwright_script: Option<&std::path::Path>,
+) -> RuntimeHealthReport {
+    let mut issues = Vec::new();
+
+    if platform == "windows" {
+        if paths.node_dir.is_none() {
+            issues.push(RuntimeHealthIssue {
+                component: "bundled Node.js".to_string(),
+                message: "embedded-runtime node directory was not found".to_string(),
+                remediation: format!(
+                    "run `pnpm prepare:runtime:{}` before packaging",
+                    platform_subdir()
+                ),
+            });
+        }
+        if paths.python_dir.is_none() {
+            issues.push(RuntimeHealthIssue {
+                component: "bundled Python".to_string(),
+                message: "embedded-runtime python/python.exe was not found".to_string(),
+                remediation: format!(
+                    "run `pnpm prepare:python:{}` before packaging",
+                    platform_subdir()
+                ),
+            });
+        }
+        if playwright_script.is_none() {
+            issues.push(RuntimeHealthIssue {
+                component: "Playwright MCP".to_string(),
+                message: "playwright-stealth MCP script with intact node_modules was not found".to_string(),
+                remediation: "run `pnpm prepare:mcp-servers` and include the prepared bundle in app resources".to_string(),
+            });
+        }
+    }
+
+    RuntimeHealthReport {
+        ok: issues.is_empty(),
+        platform: platform.to_string(),
+        issues,
+    }
 }
 
 /// Check whether `runtime_dir/python/` contains the Windows embeddable
@@ -569,6 +657,47 @@ mod tests {
             .expect("write python.exe stub");
         let found = embedded_python_dir(runtime_dir).expect("python_dir discovered");
         assert_eq!(found, runtime_dir.join("python"));
+    }
+
+    #[test]
+    fn windows_runtime_health_fails_closed_without_node_python_or_playwright() {
+        let paths = EmbeddedRuntimePaths {
+            node_dir: None,
+            git_dir: None,
+            bin_dir: None,
+            python_dir: None,
+        };
+
+        let report = runtime_health_report_for_os("windows", &paths, None);
+
+        assert!(!report.ok);
+        assert_eq!(report.issues.len(), 3);
+        let message = report.to_error_message();
+        assert!(message.contains("bundled Node.js"));
+        assert!(message.contains("bundled Python"));
+        assert!(message.contains("Playwright MCP"));
+    }
+
+    #[test]
+    fn windows_runtime_health_passes_with_required_runtime_paths() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let node_dir = tmp.path().join("node");
+        let python_dir = tmp.path().join("python");
+        let playwright = tmp
+            .path()
+            .join("mcp-servers/playwright-stealth/dist/index.js");
+
+        let paths = EmbeddedRuntimePaths {
+            node_dir: Some(node_dir),
+            git_dir: None,
+            bin_dir: None,
+            python_dir: Some(python_dir),
+        };
+
+        let report = runtime_health_report_for_os("windows", &paths, Some(&playwright));
+
+        assert!(report.ok, "unexpected issues: {:?}", report.issues);
+        assert!(report.to_error_message().contains("passed"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -758,6 +758,7 @@ pub fn run() {
             files::reveal_in_file_manager,
             // Shell command execution (requires frontend approval)
             shell::execute_shell_command,
+            shell::run_skill_script,
             shell::diagnose_shell_network,
             // Interactive terminal buffers
             terminal::terminal_create_buffer,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -274,7 +274,8 @@ fn playwright_mcp_script_candidates(resource_dir: Option<&std::path::Path>) -> V
 
 /// Resolve the playwright-stealth MCP script to an absolute path from the
 /// candidate list. Prefers candidates whose `node_modules` is intact; falls
-/// back to existing-but-possibly-broken paths so the agent can still try.
+/// closed when an existing candidate is incomplete so packaging drift does
+/// not turn into a paid runtime-debugging loop.
 /// Returns `None` when no candidate exists on disk — callers must NOT publish
 /// a non-existent path as `SEREN_PLAYWRIGHT_MCP_COMMAND`. #1945.
 pub(crate) fn resolve_playwright_mcp_script_path_from(
@@ -291,10 +292,9 @@ pub(crate) fn resolve_playwright_mcp_script_path_from(
     for candidate in &candidates {
         if candidate.exists() {
             log::warn!(
-                "[MCP] Resolved playwright script at {:?} but node_modules may be broken",
+                "[MCP] Ignoring playwright script at {:?} because node_modules is incomplete",
                 candidate
             );
-            return Some(candidate.clone());
         }
     }
 
@@ -1150,6 +1150,22 @@ mod playwright_resolver_tests {
         let resolved_canon = resolved.canonicalize().unwrap_or(resolved);
         let expected_canon = expected.canonicalize().unwrap_or(expected);
         assert_eq!(resolved_canon, expected_canon);
+    }
+
+    #[test]
+    fn resource_dir_with_broken_bundle_fails_closed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let broken = make_fake_bundle(tmp.path(), false);
+
+        let resolved = resolve_playwright_mcp_script_path_from(Some(tmp.path()));
+
+        assert!(
+            resolved
+                .as_ref()
+                .map(|path| path != &broken)
+                .unwrap_or(true),
+            "resolver must not return a script whose node_modules marker is missing"
+        );
     }
 
     #[test]

--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -24,8 +24,18 @@ const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
 const DEFAULT_PUBLISHER_SLUG: &str = "seren-models";
 
 /// Maximum number of tool execution rounds before forcing completion.
-/// Context window limits and cost naturally cap long sessions.
-const MAX_TOOL_ROUNDS: usize = 100;
+/// This is a product guardrail, not a context-window fallback: when hit, the
+/// user gets a checkpoint message and must explicitly ask the agent to continue.
+const MAX_TOOL_ROUNDS: usize = 20;
+
+/// Maximum number of tool calls allowed in one chat turn before checkpointing.
+const MAX_TOOL_CALLS_PER_TURN: usize = 60;
+
+/// Maximum failed tool calls allowed in one chat turn before checkpointing.
+const MAX_TOOL_FAILURES_PER_TURN: usize = 12;
+
+/// Maximum reported Gateway spend for one chat turn before checkpointing.
+const MAX_TURN_COST_USD: f64 = 2.0;
 
 /// Connect timeout for the HTTP client (seconds).
 const CONNECT_TIMEOUT_SECS: u64 = 30;
@@ -1154,7 +1164,6 @@ created if missing.",
                 | "path_exists"
                 | "create_directory"
                 | "seren_web_fetch"
-                | "execute_command"
         )
     }
 
@@ -1199,6 +1208,96 @@ created if missing.",
                 false
             }
         }
+    }
+
+    /// Track repeated identical tool failures within a single `execute()`
+    /// invocation. Returns true after the same non-parse failure class repeats
+    /// 3 times consecutively. This catches raw diagnostic loops where the model
+    /// keeps probing the same broken runtime path or shell command after the
+    /// app has already supplied the relevant error.
+    fn track_repeated_tool_failure_loop(
+        tracker: &mut Option<(String, usize)>,
+        tool_name: &str,
+        result_content: &str,
+        is_error: bool,
+    ) -> bool {
+        if !is_error {
+            *tracker = None;
+            return false;
+        }
+
+        let first_line = result_content
+            .lines()
+            .find(|line| !line.trim().is_empty())
+            .unwrap_or(result_content)
+            .trim();
+        let signature = format!(
+            "{}|{}",
+            tool_name,
+            &first_line[..first_line.floor_char_boundary(first_line.len().min(160))]
+        );
+
+        match tracker {
+            Some((sig, count)) if sig == &signature => {
+                *count += 1;
+                *count >= 3
+            }
+            _ => {
+                *tracker = Some((signature, 1));
+                false
+            }
+        }
+    }
+
+    fn turn_guard_recap(
+        total_cost: f64,
+        tool_call_count: usize,
+        tool_failure_count: usize,
+    ) -> Option<String> {
+        let reason = if total_cost >= MAX_TURN_COST_USD {
+            Some(format!(
+                "reported turn cost reached ${:.2} (cap ${:.2})",
+                total_cost, MAX_TURN_COST_USD
+            ))
+        } else if tool_call_count >= MAX_TOOL_CALLS_PER_TURN {
+            Some(format!(
+                "tool-call count reached {} (cap {})",
+                tool_call_count, MAX_TOOL_CALLS_PER_TURN
+            ))
+        } else if tool_failure_count >= MAX_TOOL_FAILURES_PER_TURN {
+            Some(format!(
+                "failed tool-call count reached {} (cap {})",
+                tool_failure_count, MAX_TOOL_FAILURES_PER_TURN
+            ))
+        } else {
+            None
+        }?;
+
+        Some(format!(
+            "(Paused: {}. {} tool calls fired this turn, {} failed. Ask me to continue if you want another diagnostic pass.)",
+            reason, tool_call_count, tool_failure_count
+        ))
+    }
+
+    fn runtime_health_error_for_chat(app: &tauri::AppHandle) -> Option<String> {
+        #[cfg(target_os = "windows")]
+        {
+            let paths = crate::embedded_runtime::discover_embedded_runtime(app);
+            let resource_dir = app.path().resource_dir().ok();
+            let playwright_script =
+                crate::mcp::resolve_playwright_mcp_script_path_from(resource_dir.as_deref());
+            let report = crate::embedded_runtime::runtime_health_report_for_os(
+                "windows",
+                &paths,
+                playwright_script.as_deref(),
+            );
+            if !report.ok {
+                return Some(report.to_error_message());
+            }
+        }
+
+        let _ = app;
+        None
     }
 
     /// Execute a local tool by name with the given arguments.
@@ -1451,6 +1550,15 @@ impl Worker for ChatModelWorker {
         // Reset cancellation flag
         *self.cancelled.lock().await = false;
 
+        if let Some(message) = Self::runtime_health_error_for_chat(app) {
+            let _ = event_tx
+                .send(WorkerEvent::Error {
+                    message: message.clone(),
+                })
+                .await;
+            return Err(message);
+        }
+
         // Extract publishers whose tools were called in recent conversation turns.
         // This feeds Phase 3 (conversation-aware boosting) of tool relevance.
         let recent_publishers = extract_recent_publishers(conversation_context);
@@ -1510,6 +1618,7 @@ impl Worker for ChatModelWorker {
         // synthetic recap when the loop ends with empty content — empty
         // assistant turns wipe cross-turn context for the next user prompt.
         let mut parse_error_tracker: Option<(String, usize)> = None;
+        let mut repeated_failure_tracker: Option<(String, usize)> = None;
         let mut tool_call_count: usize = 0;
         let mut tool_failure_count: usize = 0;
 
@@ -1647,6 +1756,26 @@ impl Worker for ChatModelWorker {
                         tool_calls.len()
                     );
                     total_cost += accumulated_cost;
+
+                    if let Some(recap) =
+                        Self::turn_guard_recap(total_cost, tool_call_count, tool_failure_count)
+                    {
+                        log::warn!("[ChatModelWorker] Turn guard triggered before tool execution");
+                        event_tx
+                            .send(WorkerEvent::Complete {
+                                final_content: recap,
+                                thinking: None,
+                                cost: if total_cost > 0.0 {
+                                    Some(total_cost)
+                                } else {
+                                    None
+                                },
+                                rlm_steps: None,
+                            })
+                            .await
+                            .map_err(|e| format!("Failed to send Complete event: {}", e))?;
+                        break;
+                    }
 
                     if round == MAX_TOOL_ROUNDS {
                         log::warn!(
@@ -1810,6 +1939,58 @@ impl Worker for ChatModelWorker {
                                     final_content: recap,
                                     thinking: None,
                                     cost: total,
+                                    rlm_steps: None,
+                                })
+                                .await;
+                            return Ok(());
+                        }
+                        if !is_parse_error
+                            && Self::track_repeated_tool_failure_loop(
+                                &mut repeated_failure_tracker,
+                                &tc.name,
+                                &result_content,
+                                is_error,
+                            )
+                        {
+                            let recap = format!(
+                                "(Aborted: tool '{}' returned the same error 3 times in a row. \
+                                 Continuing would likely keep burning funds on the same failed diagnostic. \
+                                 {} tool calls fired this turn, {} failed.)",
+                                tc.name, tool_call_count, tool_failure_count
+                            );
+                            log::warn!(
+                                "[ChatModelWorker] Repeated failure loop detected for tool '{}'. Aborting with recap.",
+                                tc.name
+                            );
+                            let _ = event_tx
+                                .send(WorkerEvent::Complete {
+                                    final_content: recap,
+                                    thinking: None,
+                                    cost: if total_cost > 0.0 {
+                                        Some(total_cost)
+                                    } else {
+                                        None
+                                    },
+                                    rlm_steps: None,
+                                })
+                                .await;
+                            return Ok(());
+                        }
+                        if let Some(recap) =
+                            Self::turn_guard_recap(total_cost, tool_call_count, tool_failure_count)
+                        {
+                            log::warn!(
+                                "[ChatModelWorker] Turn guard triggered after tool execution"
+                            );
+                            let _ = event_tx
+                                .send(WorkerEvent::Complete {
+                                    final_content: recap,
+                                    thinking: None,
+                                    cost: if total_cost > 0.0 {
+                                        Some(total_cost)
+                                    } else {
+                                        None
+                                    },
                                     rlm_steps: None,
                                 })
                                 .await;
@@ -2509,6 +2690,31 @@ mod tests {
     }
 
     #[test]
+    fn execute_command_routes_to_frontend_for_shell_approval() {
+        assert!(
+            !ChatModelWorker::is_local_tool("execute_command"),
+            "execute_command must not execute directly in the Rust chat loop; \
+             it has to route through the frontend shell approval path"
+        );
+    }
+
+    #[test]
+    fn turn_guard_recap_blocks_cost_tool_and_failure_runaways() {
+        let cost_recap = ChatModelWorker::turn_guard_recap(MAX_TURN_COST_USD, 2, 0)
+            .expect("cost cap should checkpoint");
+        assert!(cost_recap.contains("reported turn cost"));
+        assert!(cost_recap.contains("Ask me to continue"));
+
+        let tool_recap = ChatModelWorker::turn_guard_recap(0.0, MAX_TOOL_CALLS_PER_TURN, 0)
+            .expect("tool cap should checkpoint");
+        assert!(tool_recap.contains("tool-call count"));
+
+        let failure_recap = ChatModelWorker::turn_guard_recap(0.0, 20, MAX_TOOL_FAILURES_PER_TURN)
+            .expect("failure cap should checkpoint");
+        assert!(failure_recap.contains("failed tool-call count"));
+    }
+
+    #[test]
     fn gateway_status_retryable_classification() {
         // 5xx — all retryable (transient upstream/server failure)
         assert!(gateway_status_is_retryable(500));
@@ -2638,6 +2844,32 @@ mod tests {
             "list_directory",
             r#"{"path":"b"}"#,
             true
+        ));
+    }
+
+    #[test]
+    fn track_repeated_tool_failure_loop_aborts_after_three_same_errors() {
+        let mut tracker: Option<(String, usize)> = None;
+        let error =
+            "stderr: Python was not found; run without arguments to install from Microsoft Store";
+
+        assert!(!ChatModelWorker::track_repeated_tool_failure_loop(
+            &mut tracker,
+            "run_skill_script",
+            error,
+            true,
+        ));
+        assert!(!ChatModelWorker::track_repeated_tool_failure_loop(
+            &mut tracker,
+            "run_skill_script",
+            error,
+            true,
+        ));
+        assert!(ChatModelWorker::track_repeated_tool_failure_loop(
+            &mut tracker,
+            "run_skill_script",
+            error,
+            true,
         ));
     }
 

--- a/src-tauri/src/orchestrator/tool_relevance.rs
+++ b/src-tauri/src/orchestrator/tool_relevance.rs
@@ -33,7 +33,8 @@ const RECENCY_BOOST: f32 = 2.0;
 
 /// Local tools that are always included regardless of BM25 score.
 /// These are fundamental capabilities the model needs constant access to —
-/// without them it cannot read/write files or execute commands.
+/// without them it cannot read/write files or run structured skill scripts.
+/// Raw shell remains available when relevant, but is intentionally not pinned.
 const PINNED_TOOL_NAMES: &[&str] = &[
     "read_file",
     "read_file_base64",
@@ -43,7 +44,7 @@ const PINNED_TOOL_NAMES: &[&str] = &[
     "path_exists",
     "create_directory",
     "seren_web_fetch",
-    "execute_command",
+    "run_skill_script",
     // Built-in Seren tools use seren__ prefix (not gateway__) and bypass BM25
     // entirely — they're always included like file tools. Pin them here as a
     // safety net in case the tool set grows beyond the model budget.
@@ -795,8 +796,8 @@ mod tests {
             "Fetch a URL and return its content",
         ));
         tools.push(make_tool(
-            "execute_command",
-            "Execute a shell command on the user machine",
+            "run_skill_script",
+            "Run a Seren skill script with structured argv",
         ));
 
         // Add pinned gateway tools (must match gateway__{publisher}__{tool} format)
@@ -868,7 +869,7 @@ mod tests {
         // playwright tool docs. Browser automation is a fundamental capability
         // with no shell substitute — the prophet-bounty-runner skill literally
         // cannot drive the Privy OTP login without playwright_navigate. Pin all
-        // 15 playwright tools the same way file/exec/seren__ tools are pinned.
+        // 15 playwright tools the same way file/structured-skill/seren__ tools are pinned.
         //
         // Faithful reproduction: load gmail and seren__ tools whose docs DO
         // match the query so they win BM25, plus enough noise to push the

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -2,6 +2,8 @@
 // ABOUTME: Runs commands with timeout and output capture, invoked via Tauri IPC.
 
 use serde::Serialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tauri::{AppHandle, Runtime};
 use tauri_plugin_store::StoreExt;
@@ -137,6 +139,36 @@ pub async fn execute_shell_command_without_seren_credentials(
     execute_shell_command_inner(command, timeout_secs, None).await
 }
 
+#[tauri::command]
+pub async fn run_skill_script<R: Runtime>(
+    app: AppHandle<R>,
+    skill_slug: String,
+    cwd: String,
+    argv: Vec<String>,
+    env: Option<HashMap<String, String>>,
+    timeout_secs: Option<u64>,
+    inject_seren_credentials: Option<bool>,
+) -> Result<CommandResult, String> {
+    let cwd = validate_skill_script_cwd(&skill_slug, &cwd)?;
+    let (program, args) = validate_skill_script_argv(&argv)?;
+    let api_key = if inject_seren_credentials.unwrap_or(true) {
+        read_stored_seren_api_key(&app)?
+    } else {
+        None
+    };
+
+    spawn_argv(
+        &skill_slug,
+        &cwd,
+        &program,
+        &args,
+        env.unwrap_or_default(),
+        timeout_secs,
+        api_key.as_deref(),
+    )
+    .await
+}
+
 async fn execute_shell_command_inner(
     command: String,
     timeout_secs: Option<u64>,
@@ -181,6 +213,138 @@ async fn execute_shell_command_inner(
     }
 
     Ok(result)
+}
+
+fn validate_skill_script_cwd(skill_slug: &str, cwd: &str) -> Result<PathBuf, String> {
+    let trimmed_slug = skill_slug.trim();
+    if trimmed_slug.is_empty() {
+        return Err("skill_slug must not be empty".to_string());
+    }
+    if !trimmed_slug
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err("skill_slug may contain only letters, numbers, '-' and '_'".to_string());
+    }
+
+    let cwd_path = PathBuf::from(cwd);
+    if !cwd_path.is_dir() {
+        return Err(format!("skill cwd is not a directory: {}", cwd));
+    }
+    let file_name = cwd_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    if file_name != trimmed_slug {
+        return Err(format!(
+            "skill cwd must be the runtime directory for '{}', got '{}'",
+            trimmed_slug, cwd
+        ));
+    }
+
+    Ok(cwd_path)
+}
+
+fn validate_skill_script_argv(argv: &[String]) -> Result<(String, Vec<String>), String> {
+    let Some(program) = argv.first() else {
+        return Err("argv must include a program".to_string());
+    };
+    let program = program.trim();
+    if program.is_empty() {
+        return Err("argv[0] must not be empty".to_string());
+    }
+    Ok((program.to_string(), argv.iter().skip(1).cloned().collect()))
+}
+
+async fn spawn_argv(
+    skill_slug: &str,
+    cwd: &Path,
+    program: &str,
+    args: &[String],
+    env_vars: HashMap<String, String>,
+    timeout_secs: Option<u64>,
+    seren_api_key: Option<&str>,
+) -> Result<CommandResult, String> {
+    let secs = timeout_secs
+        .unwrap_or(DEFAULT_TIMEOUT_SECS)
+        .min(MAX_TIMEOUT_SECS);
+    let timeout = Duration::from_secs(secs);
+    let resolved_program = crate::mcp::resolve_command_in_embedded_path(program);
+
+    let mut cmd = Command::new(&resolved_program);
+    cmd.args(args)
+        .current_dir(cwd)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    let embedded_path = crate::embedded_runtime::get_embedded_path();
+    if !embedded_path.is_empty() {
+        let sep = if cfg!(target_os = "windows") {
+            ";"
+        } else {
+            ":"
+        };
+        let system_path = std::env::var("PATH").unwrap_or_default();
+        let combined = if system_path.is_empty() {
+            embedded_path.to_string()
+        } else {
+            format!("{}{}{}", embedded_path, sep, system_path)
+        };
+        cmd.env("PATH", combined);
+    }
+
+    crate::embedded_runtime::sanitize_spawn_env(&mut cmd);
+
+    for (key, value) in env_vars {
+        cmd.env(key, value);
+    }
+
+    cmd.env_remove("SEREN_API_KEY");
+    cmd.env_remove("API_KEY");
+    if let Some(api_key) = seren_api_key.filter(|key| !key.is_empty()) {
+        cmd.env("SEREN_API_KEY", api_key);
+        cmd.env("API_KEY", api_key);
+    }
+
+    log::info!(
+        "[SkillScript] spawning: skill={} cwd={} timeout={}s program={} args={:?}",
+        skill_slug,
+        cwd.display(),
+        secs,
+        resolved_program,
+        args
+    );
+
+    let child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to spawn skill script: {}", e))?;
+
+    match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(output)) => {
+            let stdout = truncate_output(String::from_utf8_lossy(&output.stdout).to_string());
+            let stderr = truncate_output(String::from_utf8_lossy(&output.stderr).to_string());
+            Ok(CommandResult {
+                stdout,
+                stderr,
+                exit_code: output.status.code(),
+                timed_out: false,
+            })
+        }
+        Ok(Err(e)) => Err(format!("Skill script execution failed: {}", e)),
+        Err(_) => Ok(CommandResult {
+            stdout: String::new(),
+            stderr: format!("Skill script timed out after {} seconds", secs),
+            exit_code: None,
+            timed_out: true,
+        }),
+    }
 }
 
 async fn spawn_one_shot(
@@ -602,5 +766,41 @@ mod tests {
         // No-python commands return None so the retry path stays inert.
         assert!(translate_python_to_py_launcher("ls -la").is_none());
         assert!(translate_python_to_py_launcher("").is_none());
+    }
+
+    #[test]
+    fn validate_skill_script_argv_rejects_empty_program() {
+        assert!(validate_skill_script_argv(&[]).is_err());
+        assert!(validate_skill_script_argv(&["".to_string()]).is_err());
+
+        let (program, args) = validate_skill_script_argv(&[
+            "python3".to_string(),
+            "scripts/agent.py".to_string(),
+            "--config".to_string(),
+            "config.json".to_string(),
+        ])
+        .expect("valid argv");
+
+        assert_eq!(program, "python3");
+        assert_eq!(args, ["scripts/agent.py", "--config", "config.json"]);
+    }
+
+    #[test]
+    fn validate_skill_script_cwd_requires_matching_runtime_directory() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let skill_dir = tmp.path().join("prophet-arb-bot");
+        std::fs::create_dir_all(&skill_dir).expect("create skill dir");
+
+        let resolved =
+            validate_skill_script_cwd("prophet-arb-bot", skill_dir.to_string_lossy().as_ref())
+                .expect("matching skill cwd should pass");
+        assert_eq!(resolved, skill_dir);
+
+        let other_dir = tmp.path().join("other-skill");
+        std::fs::create_dir_all(&other_dir).expect("create other dir");
+        let err =
+            validate_skill_script_cwd("prophet-arb-bot", other_dir.to_string_lossy().as_ref())
+                .expect_err("wrong skill cwd should fail closed");
+        assert!(err.contains("runtime directory"));
     }
 }

--- a/src/lib/tools/definitions.ts
+++ b/src/lib/tools/definitions.ts
@@ -373,6 +373,54 @@ export const FILE_TOOLS: ToolDefinition[] = [
       },
     },
   },
+  {
+    type: "function",
+    function: {
+      name: "run_skill_script",
+      description:
+        "Run a Seren skill script with a structured argv array and explicit cwd. " +
+        "Prefer this over execute_command for skill runtimes, especially on Windows, " +
+        "because it avoids shell quoting and starts in the requested directory. " +
+        "Always requires user approval before execution.",
+      parameters: {
+        type: "object",
+        properties: {
+          skill_slug: {
+            type: "string",
+            description:
+              "Skill folder slug, e.g. 'prophet-arb-bot'. The cwd directory name must match.",
+          },
+          cwd: {
+            type: "string",
+            description:
+              "Absolute skill runtime directory to run from, e.g. '/Users/me/.config/seren/skills/prophet-arb-bot'.",
+          },
+          argv: {
+            type: "array",
+            description:
+              "Program and arguments as separate items, e.g. ['python3','scripts/agent.py','--config','config.json'].",
+            items: { type: "string" },
+          },
+          env: {
+            type: "object",
+            description:
+              "Optional environment variables to add for this process. Do not include secrets unless the user provided them.",
+          },
+          timeout_secs: {
+            type: "number",
+            description:
+              "Timeout in seconds (default: 30, max: 300). Use longer timeouts for install or scan commands.",
+          },
+          inject_seren_credentials: {
+            type: "boolean",
+            description:
+              "Defaults to true for skill scripts so Desktop auth is available as SEREN_API_KEY and API_KEY.",
+          },
+        },
+        required: ["skill_slug", "cwd", "argv"],
+      },
+    },
+  },
 ];
 
 /**

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -413,6 +413,77 @@ export async function executeTool(toolCall: ToolCall): Promise<ToolResult> {
         break;
       }
 
+      case "run_skill_script": {
+        const skillSlug = args.skill_slug as string;
+        const cwd = args.cwd as string;
+        const argv = args.argv as unknown;
+        if (!skillSlug || typeof skillSlug !== "string") {
+          throw new Error("Invalid skill_slug: must be a non-empty string");
+        }
+        if (!cwd || typeof cwd !== "string") {
+          throw new Error("Invalid cwd: must be a non-empty string");
+        }
+        if (
+          !Array.isArray(argv) ||
+          argv.length === 0 ||
+          argv.some((item) => typeof item !== "string" || item.length === 0)
+        ) {
+          throw new Error("Invalid argv: must be a non-empty string array");
+        }
+        const timeoutSecs = (args.timeout_secs as number) ?? 30;
+        const preview = `${cwd}> ${argv.map((item) => JSON.stringify(item)).join(" ")}`;
+        const approved = await requestShellApproval(preview, timeoutSecs);
+        if (!approved) {
+          return {
+            tool_call_id: toolCall.id,
+            content: "Skill script was not approved by user",
+            is_error: true,
+          };
+        }
+
+        const invokeArgs: {
+          skillSlug: string;
+          cwd: string;
+          argv: string[];
+          env?: Record<string, string>;
+          timeoutSecs: number;
+          injectSerenCredentials?: boolean;
+        } = {
+          skillSlug,
+          cwd,
+          argv,
+          timeoutSecs,
+        };
+        if (
+          args.env &&
+          typeof args.env === "object" &&
+          !Array.isArray(args.env)
+        ) {
+          invokeArgs.env = args.env as Record<string, string>;
+        }
+        if (typeof args.inject_seren_credentials === "boolean") {
+          invokeArgs.injectSerenCredentials = args.inject_seren_credentials;
+        }
+
+        const cmdResult = await invoke<{
+          stdout: string;
+          stderr: string;
+          exit_code: number | null;
+          timed_out: boolean;
+        }>("run_skill_script", invokeArgs);
+
+        if (cmdResult.timed_out) {
+          result = `Skill script timed out after ${timeoutSecs} seconds.\nstderr: ${cmdResult.stderr}`;
+        } else {
+          const parts: string[] = [];
+          if (cmdResult.stdout) parts.push(`stdout:\n${cmdResult.stdout}`);
+          if (cmdResult.stderr) parts.push(`stderr:\n${cmdResult.stderr}`);
+          parts.push(`exit_code: ${cmdResult.exit_code ?? "unknown"}`);
+          result = parts.join("\n\n");
+        }
+        break;
+      }
+
       default:
         throw new Error(`Unknown tool: ${name}`);
     }


### PR DESCRIPTION
Closes #1986

## Summary
- Add per-turn cost, tool-call, failure, and repeated-failure guardrails in chat orchestration.
- Route raw shell execution through the frontend approval path and add structured run_skill_script for skill runtimes.
- Fail closed on missing Windows bundled Node/Python/Playwright runtime and reject incomplete Playwright MCP bundles.

## Tests
- cargo test --lib execute_command_routes_to_frontend_for_shell_approval
- cargo test --lib turn_guard_recap_blocks_cost_tool_and_failure_runaways
- cargo test --lib track_repeated_tool_failure_loop_aborts_after_three_same_errors
- cargo test --lib windows_runtime_health
- cargo test --lib validate_skill_script
- cargo test --lib resource_dir_with_broken_bundle_fails_closed
- cargo test --lib pinned_local_tools_always_included
- ./node_modules/.bin/biome check src/lib/tools/definitions.ts src/lib/tools/executor.ts
- git diff --check