### PR TITLE
Implement Verified Agent Output finalization

### DIFF
--- a/src/lib/agent-output-validation/claims.ts
+++ b/src/lib/agent-output-validation/claims.ts
@@ -1,0 +1,96 @@
+// ABOUTME: Deterministic claim extraction for Verified Agent Output.
+// ABOUTME: Finds concrete completion claims without relying on model self-reporting.
+
+import type { ClaimKind, ExtractedClaim } from "./types";
+
+type ClaimMatcher = {
+  kind: ClaimKind;
+  pattern: RegExp;
+};
+
+const CLAIM_MATCHERS: ClaimMatcher[] = [
+  {
+    kind: "email_sent",
+    pattern:
+      /\b(sent|emailed|delivered|posted)\b[\s\S]{0,80}\b(email|e-mail|message|gmail|outlook)\b/i,
+  },
+  {
+    kind: "draft_created",
+    pattern:
+      /\b(created|prepared|saved|wrote)\b[\s\S]{0,80}\b(email draft|draft email|draft|gmail draft|outlook draft)\b/i,
+  },
+  {
+    kind: "file_write",
+    pattern:
+      /\b(created|wrote|saved|generated|added)\b[\s\S]{0,80}\b(file|document|readme|markdown|json|csv|ya?ml|\.([a-z0-9]{1,8}))\b/i,
+  },
+  {
+    kind: "file_edit",
+    pattern:
+      /\b(edited|updated|modified|patched|changed|fixed)\b[\s\S]{0,100}\b(file|code|source|component|module|\.([a-z0-9]{1,8}))\b/i,
+  },
+  {
+    kind: "db_persisted",
+    pattern:
+      /\b(saved|persisted|stored|inserted|upserted|wrote|committed)\b[\s\S]{0,100}\b(database|db|serendb|postgres|sql|table|record|row)\b/i,
+  },
+  {
+    kind: "publisher_unavailable",
+    pattern:
+      /\b(unavailable|not available|not configured|could not access|can't access|cannot access|no .*integration|no .*tool|publisher .*not found)\b/i,
+  },
+  {
+    kind: "browser_action",
+    pattern:
+      /\b(clicked|opened|navigated|filled|selected|screenshotted|scraped|extracted|took a screenshot)\b[\s\S]{0,100}\b(browser|website|page|form|button|screenshot|url)\b/i,
+  },
+  {
+    kind: "tool_completed",
+    pattern:
+      /\b(completed|finished|ran|executed|submitted|posted|called)\b[\s\S]{0,80}\b(tool|command|script|request|job|workflow|operation)\b/i,
+  },
+];
+
+export function extractClaims(finalText: string): ExtractedClaim[] {
+  const sentences = splitSentences(finalText);
+  const claims: ExtractedClaim[] = [];
+
+  sentences.forEach((sentence, sentenceIndex) => {
+    const sentenceClaims: ExtractedClaim[] = [];
+    for (const matcher of CLAIM_MATCHERS) {
+      const match = matcher.pattern.exec(sentence.text);
+      if (!match) continue;
+      sentenceClaims.push({
+        id: `${sentenceIndex}:${matcher.kind}`,
+        kind: matcher.kind,
+        text: sentence.text.trim(),
+        sentence: sentence.text.trim(),
+        sentenceIndex,
+        sentenceOffset: match.index,
+      });
+    }
+    claims.push(...dedupeSentenceClaims(sentenceClaims));
+  });
+
+  return claims;
+}
+
+export function splitSentences(
+  text: string,
+): Array<{ index: number; text: string }> {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) return [];
+  const matches = normalized.match(/[^.!?]+[.!?]?/g);
+  return (matches ?? [normalized])
+    .map((part, index) => ({ index, text: part.trim() }))
+    .filter((part) => part.text.length > 0);
+}
+
+function dedupeSentenceClaims(claims: ExtractedClaim[]): ExtractedClaim[] {
+  const seen = new Set<ClaimKind>();
+  return claims.filter((claim) => {
+    if (seen.has(claim.kind)) return false;
+    seen.add(claim.kind);
+    return true;
+  });
+}

--- a/src/lib/agent-output-validation/evidence.ts
+++ b/src/lib/agent-output-validation/evidence.ts
@@ -1,0 +1,198 @@
+// ABOUTME: Evidence extractors for final-output validation.
+// ABOUTME: Normalizes chat, orchestrator, and local-agent ledgers.
+
+import type { ChatMessageWithTools } from "@/lib/providers/types";
+import type { UnifiedMessage } from "@/types/conversation";
+import type { DiffEvidence, FinalizationEvidence, ToolEvidence } from "./types";
+
+interface AgentLikeMessage {
+  id?: string;
+  type: string;
+  content?: string;
+  timestamp?: number;
+  toolCallId?: string;
+  toolCall?: {
+    toolCallId: string;
+    title: string;
+    kind: string;
+    status: string;
+    name?: string;
+    result?: string;
+    error?: string;
+    isError?: boolean;
+  };
+  diff?: {
+    path: string;
+    toolCallId?: string;
+    sessionId?: string;
+    oldText?: string;
+    newText?: string;
+  };
+}
+
+const ERROR_RESULT_RE =
+  /(^|\b)(error|failed|failure|denied|rejected|not approved|permission denied|element not found|timed out|timeout)(\b|:)/i;
+
+export function extractEvidenceFromUnifiedMessages(
+  messages: readonly UnifiedMessage[],
+): FinalizationEvidence {
+  const tools: ToolEvidence[] = [];
+  const diffs: DiffEvidence[] = [];
+
+  for (const message of messages) {
+    if (message.type === "diff" && message.diff) {
+      diffs.push({
+        path: message.diff.path,
+        toolCallId: message.diff.toolCallId ?? message.toolCallId,
+      });
+    }
+    if (message.toolCall) {
+      tools.push(
+        normalizeToolEvidence({
+          id: message.toolCall.toolCallId,
+          name: message.toolCall.name ?? message.toolCall.title,
+          title: message.toolCall.title,
+          kind: message.toolCall.kind,
+          status: message.toolCall.status,
+          result: message.toolCall.result,
+          isError: message.toolCall.isError,
+        }),
+      );
+    }
+  }
+
+  return { tools: dedupeTools(tools), diffs };
+}
+
+export function extractEvidenceFromAgentMessages(
+  messages: readonly AgentLikeMessage[],
+): FinalizationEvidence {
+  const tools: ToolEvidence[] = [];
+  const diffs: DiffEvidence[] = [];
+
+  for (const message of messages) {
+    if (message.type === "diff" && message.diff) {
+      diffs.push({
+        path: message.diff.path,
+        toolCallId: message.diff.toolCallId ?? message.toolCallId,
+      });
+    }
+    if (message.toolCall) {
+      tools.push(
+        normalizeToolEvidence({
+          id: message.toolCall.toolCallId,
+          name: message.toolCall.name ?? message.toolCall.title,
+          title: message.toolCall.title,
+          kind: message.toolCall.kind,
+          status: message.toolCall.status,
+          result: message.toolCall.result ?? message.toolCall.error,
+          isError: message.toolCall.isError ?? Boolean(message.toolCall.error),
+        }),
+      );
+    }
+  }
+
+  return { tools: dedupeTools(tools), diffs };
+}
+
+export function extractEvidenceFromToolLoopMessages(
+  messages: readonly ChatMessageWithTools[],
+): FinalizationEvidence {
+  const calls = new Map<
+    string,
+    { name: string; title: string; kind: string }
+  >();
+  const tools: ToolEvidence[] = [];
+
+  for (const message of messages) {
+    if (message.role === "assistant") {
+      for (const call of message.tool_calls ?? []) {
+        calls.set(call.id, {
+          name: call.function.name,
+          title: call.function.name,
+          kind: inferKindFromName(call.function.name),
+        });
+      }
+    }
+    if (message.role === "tool" && message.tool_call_id) {
+      const call = calls.get(message.tool_call_id);
+      const content = stringifyContent(message.content);
+      tools.push(
+        normalizeToolEvidence({
+          id: message.tool_call_id,
+          name: call?.name ?? "tool",
+          title: call?.title ?? "tool",
+          kind: call?.kind ?? "tool",
+          status: ERROR_RESULT_RE.test(content) ? "error" : "completed",
+          result: content,
+        }),
+      );
+    }
+  }
+
+  return { tools: dedupeTools(tools), diffs: [] };
+}
+
+function normalizeToolEvidence(input: {
+  id: string;
+  name?: string;
+  title?: string;
+  kind?: string;
+  status?: string;
+  result?: string;
+  isError?: boolean;
+}): ToolEvidence {
+  const result = input.result;
+  const status = input.status || "completed";
+  const isError =
+    input.isError === true ||
+    isErrorStatus(status) ||
+    ERROR_RESULT_RE.test(result ?? "");
+  return {
+    id: input.id,
+    name: input.name || input.title || input.kind || "tool",
+    title: input.title || input.name || input.kind || "tool",
+    kind: input.kind || inferKindFromName(input.name ?? input.title ?? ""),
+    status,
+    result,
+    isError,
+  };
+}
+
+function dedupeTools(tools: ToolEvidence[]): ToolEvidence[] {
+  const byId = new Map<string, ToolEvidence>();
+  for (const tool of tools) {
+    const existing = byId.get(tool.id);
+    if (!existing || existing.result == null) {
+      byId.set(tool.id, tool);
+      continue;
+    }
+    if (tool.result != null) {
+      byId.set(tool.id, tool);
+    }
+  }
+  return [...byId.values()];
+}
+
+function isErrorStatus(status: string): boolean {
+  return /error|failed|failure|denied|rejected|cancelled|canceled/i.test(
+    status,
+  );
+}
+
+function inferKindFromName(name: string): string {
+  if (/gmail|outlook|email|draft|message/i.test(name)) return "email";
+  if (/sql|database|db|serendb|postgres/i.test(name)) return "database";
+  if (/playwright|browser|screenshot|click|navigate|fill/i.test(name)) {
+    return "browser";
+  }
+  if (/file|write|edit|patch|diff|directory/i.test(name)) return "file";
+  if (/publisher|gateway|mcp/i.test(name)) return "publisher";
+  return "tool";
+}
+
+function stringifyContent(content: ChatMessageWithTools["content"]): string {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  return JSON.stringify(content);
+}

--- a/src/lib/agent-output-validation/index.ts
+++ b/src/lib/agent-output-validation/index.ts
@@ -1,0 +1,21 @@
+// ABOUTME: Public API for Verified Agent Output finalization.
+// ABOUTME: Central export keeps all finalization paths on the same contract.
+
+export { extractClaims } from "./claims";
+export {
+  extractEvidenceFromAgentMessages,
+  extractEvidenceFromToolLoopMessages,
+  extractEvidenceFromUnifiedMessages,
+} from "./evidence";
+export { INITIAL_FINALIZATION_RULES } from "./rules";
+export type {
+  ClaimKind,
+  DiffEvidence,
+  ExtractedClaim,
+  FinalizationEvidence,
+  FinalizationRule,
+  FinalOutputValidationReport,
+  ToolEvidence,
+  ValidatedClaim,
+} from "./types";
+export { validateFinalOutput } from "./validateFinalOutput";

--- a/src/lib/agent-output-validation/rules.ts
+++ b/src/lib/agent-output-validation/rules.ts
@@ -1,0 +1,115 @@
+// ABOUTME: Deterministic rule registry for Verified Agent Output.
+// ABOUTME: Rules are versioned code, owned by this codebase and extended by PR.
+
+import type {
+  ExtractedClaim,
+  FinalizationEvidence,
+  FinalizationRule,
+} from "./types";
+
+function hasDraftEvidence(evidence: FinalizationEvidence): boolean {
+  return evidence.tools.some(
+    (tool) =>
+      !tool.isError &&
+      !isPendingStatus(tool.status) &&
+      /\bdraft|drafts|create_draft|post_drafts/i.test(
+        `${tool.name} ${tool.title} ${tool.kind} ${tool.result ?? ""}`,
+      ),
+  );
+}
+
+function isPendingStatus(status: string): boolean {
+  return /pending|running|in[_-]?progress|approval|waiting/i.test(status);
+}
+
+function rewriteFileChange(): string {
+  return "I could not verify that the file was changed.";
+}
+
+function rewriteEmailSent(
+  _claim: ExtractedClaim,
+  evidence: FinalizationEvidence,
+): string {
+  if (hasDraftEvidence(evidence)) {
+    return "I prepared the email draft, but I could not verify that it was sent.";
+  }
+  return "I could not verify that the email was sent.";
+}
+
+export const INITIAL_FINALIZATION_RULES: FinalizationRule[] = [
+  {
+    id: "file_write_claim_requires_diff_or_successful_file_tool",
+    claimKind: "file_write",
+    requiredEvidence: { anyOf: ["diff", "successful_file_tool"] },
+    severity: "rewrite",
+    safeRewrite: rewriteFileChange,
+  },
+  {
+    id: "file_edit_claim_requires_diff_or_successful_file_tool",
+    claimKind: "file_edit",
+    requiredEvidence: { anyOf: ["diff", "successful_file_tool"] },
+    severity: "rewrite",
+    safeRewrite: rewriteFileChange,
+  },
+  {
+    id: "email_sent_claim_requires_successful_send_tool",
+    claimKind: "email_sent",
+    requiredEvidence: { anyOf: ["successful_email_send_tool"] },
+    severity: "rewrite",
+    safeRewrite: rewriteEmailSent,
+  },
+  {
+    id: "draft_created_claim_requires_successful_draft_tool",
+    claimKind: "draft_created",
+    requiredEvidence: { anyOf: ["successful_email_draft_tool"] },
+    severity: "rewrite",
+    safeRewrite: () => "I could not verify that the draft was created.",
+  },
+  {
+    id: "db_persisted_claim_requires_successful_db_tool",
+    claimKind: "db_persisted",
+    requiredEvidence: { anyOf: ["successful_db_write_tool"] },
+    severity: "rewrite",
+    safeRewrite: () =>
+      "I could not verify that the data was saved to the database.",
+  },
+  {
+    id: "publisher_unavailable_claim_requires_failed_live_verification",
+    claimKind: "publisher_unavailable",
+    requiredEvidence: { anyOf: ["failed_publisher_verification_tool"] },
+    severity: "rewrite",
+    safeRewrite: () => "I could not verify that the service is unavailable.",
+  },
+  {
+    id: "tool_completed_claim_rejects_pending_approval",
+    claimKind: "tool_completed",
+    requiredEvidence: { anyOf: ["no_pending_matching_tool"] },
+    severity: "rewrite",
+    safeRewrite: () => "I could not verify that the action completed.",
+  },
+  {
+    id: "tool_completed_claim_rejects_is_error_result",
+    claimKind: "tool_completed",
+    requiredEvidence: { anyOf: ["successful_tool_result"] },
+    severity: "rewrite",
+    safeRewrite: () => "I could not verify that the action completed.",
+  },
+  {
+    id: "browser_action_claim_requires_successful_browser_tool",
+    claimKind: "browser_action",
+    requiredEvidence: { anyOf: ["successful_browser_tool"] },
+    severity: "rewrite",
+    safeRewrite: () => "I could not verify that the browser action completed.",
+  },
+  {
+    id: "no_memory_storage_for_unverified_completion_claims",
+    claimKind: "tool_completed",
+    requiredEvidence: { anyOf: ["all_completion_claims_verified"] },
+    severity: "block_memory",
+    safeRewrite: () => "I could not verify that the action completed.",
+  },
+];
+
+export function getRulesForClaim(kind: string): FinalizationRule[] {
+  return INITIAL_FINALIZATION_RULES.filter((rule) => rule.claimKind === kind);
+}

--- a/src/lib/agent-output-validation/types.ts
+++ b/src/lib/agent-output-validation/types.ts
@@ -1,0 +1,83 @@
+// ABOUTME: Shared types for Verified Agent Output finalization.
+// ABOUTME: Models final-answer claims, execution evidence, and validation reports.
+
+export type ClaimKind =
+  | "file_write"
+  | "file_edit"
+  | "email_sent"
+  | "draft_created"
+  | "db_persisted"
+  | "publisher_unavailable"
+  | "tool_completed"
+  | "browser_action";
+
+export type ClaimStatus = "verified" | "unverified";
+
+export type RuleSeverity = "rewrite" | "warn" | "block_memory";
+export type ReportSeverity = "ok" | "warn" | "rewrite";
+
+export interface EvidenceRequirement {
+  anyOf: string[];
+}
+
+export interface ExtractedClaim {
+  id: string;
+  kind: ClaimKind;
+  text: string;
+  sentence: string;
+  sentenceIndex: number;
+  sentenceOffset: number;
+}
+
+export interface ValidatedClaim extends ExtractedClaim {
+  status: ClaimStatus;
+  ruleId: string;
+  evidenceToolCallIds: string[];
+  reason?: string;
+  safeRewrite?: string;
+}
+
+export interface ToolEvidence {
+  id: string;
+  name: string;
+  title: string;
+  kind: string;
+  status: string;
+  result?: string;
+  isError: boolean;
+}
+
+export interface DiffEvidence {
+  path: string;
+  toolCallId?: string;
+}
+
+export interface FinalizationEvidence {
+  tools: ToolEvidence[];
+  diffs: DiffEvidence[];
+}
+
+export interface FinalizationRule {
+  id: string;
+  claimKind: ClaimKind;
+  requiredEvidence: EvidenceRequirement;
+  severity: RuleSeverity;
+  safeRewrite: (
+    claim: ExtractedClaim,
+    evidence: FinalizationEvidence,
+  ) => string;
+}
+
+export interface FinalOutputValidationReport {
+  displayText: string;
+  safeDisplayText: string;
+  claims: ValidatedClaim[];
+  severity: ReportSeverity;
+  canStoreMemory: boolean;
+  blockedRuleIds: string[];
+}
+
+export interface ValidateFinalOutputInput {
+  finalText: string;
+  evidence: FinalizationEvidence;
+}

--- a/src/lib/agent-output-validation/validateFinalOutput.ts
+++ b/src/lib/agent-output-validation/validateFinalOutput.ts
@@ -1,0 +1,253 @@
+// ABOUTME: Validates final assistant text against actual run-ledger evidence.
+// ABOUTME: Rewrites unsupported completion claims before render, persistence, or memory.
+
+import { extractClaims, splitSentences } from "./claims";
+import { INITIAL_FINALIZATION_RULES } from "./rules";
+import type {
+  ClaimKind,
+  ExtractedClaim,
+  FinalizationEvidence,
+  FinalizationRule,
+  FinalOutputValidationReport,
+  ToolEvidence,
+  ValidatedClaim,
+  ValidateFinalOutputInput,
+} from "./types";
+
+export function validateFinalOutput({
+  finalText,
+  evidence,
+}: ValidateFinalOutputInput): FinalOutputValidationReport {
+  const displayText = finalText.trim();
+  const claims = extractClaims(displayText).map((claim) =>
+    validateClaim(claim, evidence),
+  );
+  const hasUnverified = claims.some((claim) => claim.status === "unverified");
+  const safeDisplayText = hasUnverified
+    ? buildSafeDisplayText(displayText, claims, evidence)
+    : displayText;
+
+  return {
+    displayText,
+    safeDisplayText,
+    claims,
+    severity: hasUnverified ? "rewrite" : "ok",
+    canStoreMemory: !hasUnverified,
+    blockedRuleIds: hasUnverified
+      ? ["no_memory_storage_for_unverified_completion_claims"]
+      : [],
+  };
+}
+
+function validateClaim(
+  claim: ExtractedClaim,
+  evidence: FinalizationEvidence,
+): ValidatedClaim {
+  const rule = ruleForClaim(claim.kind);
+  const matchingPending = findMatchingTools(claim.kind, evidence.tools).filter(
+    isPendingTool,
+  );
+  if (matchingPending.length > 0) {
+    return unverified(
+      claim,
+      rule,
+      evidence,
+      "Matching tool call is still pending approval or execution.",
+    );
+  }
+
+  const matchingFailed = findMatchingTools(claim.kind, evidence.tools).filter(
+    isFailedTool,
+  );
+  const evidenceIds = verifiedEvidenceIds(claim.kind, evidence);
+  if (evidenceIds.length > 0) {
+    return {
+      ...claim,
+      status: "verified",
+      ruleId: rule.id,
+      evidenceToolCallIds: evidenceIds,
+    };
+  }
+
+  if (matchingFailed.length > 0) {
+    return unverified(
+      claim,
+      rule,
+      evidence,
+      "Matching tool call failed or returned an error result.",
+    );
+  }
+
+  return unverified(claim, rule, evidence, "No matching successful evidence.");
+}
+
+function verifiedEvidenceIds(
+  kind: ClaimKind,
+  evidence: FinalizationEvidence,
+): string[] {
+  switch (kind) {
+    case "file_write":
+    case "file_edit": {
+      const diffIds = evidence.diffs
+        .map((diff) => diff.toolCallId)
+        .filter((id): id is string => Boolean(id));
+      const fileToolIds = successfulMatchingTools(kind, evidence.tools).map(
+        (tool) => tool.id,
+      );
+      return dedupe([...diffIds, ...fileToolIds]);
+    }
+    case "email_sent":
+    case "draft_created":
+    case "db_persisted":
+    case "browser_action":
+    case "tool_completed":
+      return successfulMatchingTools(kind, evidence.tools).map(
+        (tool) => tool.id,
+      );
+    case "publisher_unavailable":
+      return evidence.tools
+        .filter(isFailedPublisherVerificationTool)
+        .map((tool) => tool.id);
+  }
+}
+
+function buildSafeDisplayText(
+  displayText: string,
+  claims: ValidatedClaim[],
+  evidence: FinalizationEvidence,
+): string {
+  const sentences = splitSentences(displayText);
+  const unverifiedBySentence = new Map<number, ValidatedClaim[]>();
+  for (const claim of claims) {
+    if (claim.status === "verified") continue;
+    const existing = unverifiedBySentence.get(claim.sentenceIndex) ?? [];
+    existing.push(claim);
+    unverifiedBySentence.set(claim.sentenceIndex, existing);
+  }
+
+  const safeSentences = sentences.map((sentence) => {
+    const unverifiedClaims = unverifiedBySentence.get(sentence.index);
+    if (!unverifiedClaims || unverifiedClaims.length === 0) {
+      return sentence.text;
+    }
+    const rewrites = [...unverifiedClaims]
+      .sort((a, b) => a.sentenceOffset - b.sentenceOffset)
+      .map((claim) => {
+        const rule = ruleForClaim(claim.kind);
+        return rule.safeRewrite(claim, evidence);
+      });
+    return dedupe(rewrites).join(" ");
+  });
+
+  return safeSentences.join(" ").trim();
+}
+
+function ruleForClaim(kind: ClaimKind): FinalizationRule {
+  const rule = INITIAL_FINALIZATION_RULES.find(
+    (candidate) => candidate.claimKind === kind,
+  );
+  if (!rule) {
+    throw new Error(`Missing finalization rule for claim kind: ${kind}`);
+  }
+  return rule;
+}
+
+function unverified(
+  claim: ExtractedClaim,
+  rule: FinalizationRule,
+  evidence: FinalizationEvidence,
+  reason: string,
+): ValidatedClaim {
+  return {
+    ...claim,
+    status: "unverified",
+    ruleId: rule.id,
+    evidenceToolCallIds: [],
+    reason,
+    safeRewrite: rule.safeRewrite(claim, evidence),
+  };
+}
+
+function successfulMatchingTools(
+  kind: ClaimKind,
+  tools: readonly ToolEvidence[],
+): ToolEvidence[] {
+  return findMatchingTools(kind, tools).filter(
+    (tool) => !isPendingTool(tool) && !isFailedTool(tool),
+  );
+}
+
+function findMatchingTools(
+  kind: ClaimKind,
+  tools: readonly ToolEvidence[],
+): ToolEvidence[] {
+  switch (kind) {
+    case "file_write":
+    case "file_edit":
+      return tools.filter((tool) =>
+        matchesTool(tool, /write_file|create_file|edit|patch|diff|file/i),
+      );
+    case "email_sent":
+      return tools.filter((tool) =>
+        matchesTool(
+          tool,
+          /messages?_send|post_messages_send|send_email|send-message|\bsend\b/i,
+        ),
+      );
+    case "draft_created":
+      return tools.filter((tool) =>
+        matchesTool(tool, /draft|drafts|create_draft|post_drafts/i),
+      );
+    case "db_persisted":
+      return tools.filter((tool) =>
+        matchesTool(
+          tool,
+          /run_sql|run_sql_transaction|database|serendb|postgres|db/i,
+        ),
+      );
+    case "publisher_unavailable":
+      return tools.filter((tool) =>
+        matchesTool(tool, /publisher|gateway|list_agent_publishers|mcp/i),
+      );
+    case "browser_action":
+      return tools.filter((tool) =>
+        matchesTool(
+          tool,
+          /playwright|browser|screenshot|click|navigate|fill|select|scrape|extract/i,
+        ),
+      );
+    case "tool_completed":
+      return [...tools];
+  }
+}
+
+function matchesTool(tool: ToolEvidence, pattern: RegExp): boolean {
+  return pattern.test(
+    `${tool.name} ${tool.title} ${tool.kind} ${tool.result ?? ""}`,
+  );
+}
+
+function isFailedPublisherVerificationTool(tool: ToolEvidence): boolean {
+  return (
+    isFailedTool(tool) &&
+    matchesTool(
+      tool,
+      /publisher|gateway|list_agent_publishers|call_publisher|mcp/i,
+    )
+  );
+}
+
+function isFailedTool(tool: ToolEvidence): boolean {
+  return (
+    tool.isError ||
+    /error|failed|failure|denied|rejected|cancelled|canceled/i.test(tool.status)
+  );
+}
+
+function isPendingTool(tool: ToolEvidence): boolean {
+  return /pending|running|in[_-]?progress|approval|waiting/i.test(tool.status);
+}
+
+function dedupe<T>(items: T[]): T[] {
+  return [...new Set(items)];
+}

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -2,6 +2,11 @@
 // ABOUTME: Routes requests through provider abstraction for Seren, Anthropic, OpenAI, Gemini.
 
 import { invoke } from "@tauri-apps/api/core";
+import {
+  extractEvidenceFromToolLoopMessages,
+  type FinalOutputValidationReport,
+  validateFinalOutput,
+} from "@/lib/agent-output-validation";
 import { isTextMime, toDataUrl } from "@/lib/images/attachments";
 import { retrieveCodeContext } from "@/lib/indexing/context-retrieval";
 import {
@@ -255,7 +260,12 @@ export type ToolStreamEvent =
   | { type: "thinking"; thinking: string }
   | { type: "tool_calls"; toolCalls: ToolCall[] }
   | { type: "tool_results"; results: ToolResult[] }
-  | { type: "complete"; finalContent: string; finalThinking?: string }
+  | {
+      type: "complete";
+      finalContent: string;
+      finalThinking?: string;
+      finalOutputValidation?: FinalOutputValidationReport;
+    }
   | {
       type: "iteration_limit";
       currentIteration: number;
@@ -560,6 +570,7 @@ export async function* streamMessageWithTools(
 
   // Accumulated content across all iterations
   let fullContent = "";
+  let yieldedContent = "";
   let hasExecutedTools = false;
   let hasNudged = false;
 
@@ -578,20 +589,13 @@ export async function* streamMessageWithTools(
     );
     console.log("[streamMessageWithTools] Got response:", response);
 
-    // Yield content if present
-    if (response.content) {
-      console.log(
-        "[streamMessageWithTools] Yielding content:",
-        response.content.substring(0, 100),
-      );
-      fullContent += response.content;
-      yield { type: "content", content: response.content };
-    } else {
-      console.log("[streamMessageWithTools] No content in response");
-    }
-
     // Check if model wants to call tools
     if (!response.tool_calls || response.tool_calls.length === 0) {
+      if (response.content) {
+        fullContent += response.content;
+      } else {
+        console.log("[streamMessageWithTools] No content in response");
+      }
       // Model returned no tool calls. If we executed tools but got no text
       // response, the model may have silently stopped mid-task. Nudge it once
       // to complete the task or explain what happened.
@@ -618,17 +622,49 @@ export async function* streamMessageWithTools(
         "[streamMessageWithTools] No tool_calls, completing with content length:",
         fullContent.length,
       );
+      const finalOutputValidation = validateFinalOutput({
+        finalText: fullContent,
+        evidence: extractEvidenceFromToolLoopMessages(messages),
+      });
+      fullContent = finalOutputValidation.safeDisplayText;
 
       // Store conversation to memory if enabled
-      storeAssistantResponse(fullContent, {
-        model,
-        userQuery: content,
-      }).catch((err) => {
-        console.warn("[streamMessageWithTools] Failed to store memory:", err);
-      });
+      if (finalOutputValidation.canStoreMemory) {
+        storeAssistantResponse(fullContent, {
+          model,
+          userQuery: content,
+        }).catch((err) => {
+          console.warn("[streamMessageWithTools] Failed to store memory:", err);
+        });
+      }
 
-      yield { type: "complete", finalContent: fullContent };
+      const safeDelta = fullContent.startsWith(yieldedContent)
+        ? fullContent.slice(yieldedContent.length)
+        : fullContent;
+      if (safeDelta) {
+        yieldedContent += safeDelta;
+        yield { type: "content", content: safeDelta };
+      }
+      yield {
+        type: "complete",
+        finalContent: fullContent,
+        finalOutputValidation,
+      };
       return;
+    }
+
+    // Non-final assistant text can accompany tool calls. It is not persisted as
+    // the final answer; the final turn is validated after tool execution.
+    if (response.content) {
+      console.log(
+        "[streamMessageWithTools] Yielding content:",
+        response.content.substring(0, 100),
+      );
+      fullContent += response.content;
+      yieldedContent += response.content;
+      yield { type: "content", content: response.content };
+    } else {
+      console.log("[streamMessageWithTools] No content in response");
     }
 
     // Yield tool calls for UI
@@ -708,6 +744,7 @@ export async function* continueToolIteration(
 ): AsyncGenerator<ToolStreamEvent> {
   const { messages, model, tools, fullContent: existingContent } = state;
   let fullContent = existingContent;
+  let yieldedContent = existingContent;
   let hasExecutedTools = false;
   let hasNudged = false;
 
@@ -723,7 +760,6 @@ export async function* continueToolIteration(
 
     if (response.content) {
       fullContent += response.content;
-      yield { type: "content", content: response.content };
     }
 
     if (!response.tool_calls || response.tool_calls.length === 0) {
@@ -747,14 +783,37 @@ export async function* continueToolIteration(
       }
 
       // Store conversation to memory if enabled
-      storeAssistantResponse(fullContent, {
-        model,
-      }).catch((err) => {
-        console.warn("[continueToolIteration] Failed to store memory:", err);
+      const finalOutputValidation = validateFinalOutput({
+        finalText: fullContent,
+        evidence: extractEvidenceFromToolLoopMessages(messages),
       });
+      fullContent = finalOutputValidation.safeDisplayText;
+      if (finalOutputValidation.canStoreMemory) {
+        storeAssistantResponse(fullContent, {
+          model,
+        }).catch((err) => {
+          console.warn("[continueToolIteration] Failed to store memory:", err);
+        });
+      }
 
-      yield { type: "complete", finalContent: fullContent };
+      const safeDelta = fullContent.startsWith(yieldedContent)
+        ? fullContent.slice(yieldedContent.length)
+        : fullContent;
+      if (safeDelta) {
+        yieldedContent += safeDelta;
+        yield { type: "content", content: safeDelta };
+      }
+      yield {
+        type: "complete",
+        finalContent: fullContent,
+        finalOutputValidation,
+      };
       return;
+    }
+
+    if (response.content) {
+      yieldedContent += response.content;
+      yield { type: "content", content: response.content };
     }
 
     yield { type: "tool_calls", toolCalls: response.tool_calls };

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -3,6 +3,10 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import {
+  extractEvidenceFromUnifiedMessages,
+  validateFinalOutput,
+} from "@/lib/agent-output-validation";
 import type {
   Attachment,
   ProviderId,
@@ -567,6 +571,13 @@ function handleComplete(
   // Use accumulated streaming content or fall back to final_content
   const content =
     conversationStore.getStreamingContentFor(conversationId) || finalContent;
+  const finalOutputValidation = validateFinalOutput({
+    finalText: content,
+    evidence: extractEvidenceFromUnifiedMessages(
+      conversationStore.getMessagesFor(conversationId),
+    ),
+  });
+  const safeContent = finalOutputValidation.safeDisplayText;
   const thinkingContent =
     conversationStore.getStreamingThinkingFor(conversationId) ||
     thinking ||
@@ -586,7 +597,7 @@ function handleComplete(
     id: stream.messageId,
     type: "assistant",
     role: "assistant",
-    content,
+    content: safeContent,
     thinking: thinkingContent,
     timestamp: Date.now(),
     status: "complete",
@@ -595,6 +606,7 @@ function handleComplete(
     modelId: stream.modelId ?? undefined,
     duration,
     cost,
+    finalOutputValidation,
     rlmSteps,
   };
 
@@ -605,9 +617,11 @@ function handleComplete(
 
   // Store conversation to memory if enabled
   const model = stream.modelId || providerStore.activeModel || "unknown";
-  storeAssistantResponse(content, { model }).catch((err) => {
-    console.warn("[orchestrator] Failed to store memory:", err);
-  });
+  if (finalOutputValidation.canStoreMemory) {
+    storeAssistantResponse(safeContent, { model }).catch((err) => {
+      console.warn("[orchestrator] Failed to store memory:", err);
+    });
+  }
 }
 
 /**
@@ -866,17 +880,24 @@ async function runEmployeeTurn(
     });
     conversationStore.finalizeStreaming(conversationId);
     const duration = Date.now() - stream.startTime;
+    const finalOutputValidation = validateFinalOutput({
+      finalText: result.text,
+      evidence: extractEvidenceFromUnifiedMessages(
+        conversationStore.getMessagesFor(conversationId),
+      ),
+    });
     const assistantMessage: UnifiedMessage = {
       id: stream.messageId,
       type: "assistant",
       role: "assistant",
-      content: result.text,
+      content: finalOutputValidation.safeDisplayText,
       timestamp: Date.now(),
       status: "complete",
       workerType: "employee",
       thinking: result.thinking ?? undefined,
       modelId: undefined,
       duration,
+      finalOutputValidation,
       request: { prompt },
     };
     conversationStore.addMessage(assistantMessage, conversationId);

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3,6 +3,11 @@
 
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createStore, produce } from "solid-js/store";
+import {
+  extractEvidenceFromAgentMessages,
+  type FinalOutputValidationReport,
+  validateFinalOutput,
+} from "@/lib/agent-output-validation";
 import { shouldLogAgentRuntimeEvent } from "@/lib/agent-runtime-debug";
 import {
   isLocalProviderRuntime,
@@ -660,6 +665,8 @@ export interface AgentMessage {
   duration?: number;
   /** Total cost in SerenBucks for this message's query, reported by Gateway. */
   cost?: number;
+  /** Verified Agent Output report for final assistant messages. */
+  finalOutputValidation?: FinalOutputValidationReport;
   /** Names of documents processed via DocReader for this message. */
   docNames?: string[];
   /** Producer provenance — the agent type that emitted this message. */
@@ -1056,6 +1063,14 @@ function serializeAgentConversationMetadata(
     : null;
 }
 
+function serializeAgentMessageMetadata(msg: AgentMessage): string | null {
+  if (!msg.finalOutputValidation) return null;
+  return JSON.stringify({
+    v: 1,
+    final_output_validation: msg.finalOutputValidation,
+  });
+}
+
 /**
  * Persist an agent message to SQLite so history survives session restarts.
  * Only user and assistant messages are stored — tool calls, diffs, and
@@ -1082,7 +1097,7 @@ function persistAgentMessage(
     msg.content,
     null,
     msg.timestamp,
-    null,
+    serializeAgentMessageMetadata(msg),
     provider,
   ).catch((error) =>
     console.warn("[AgentStore] Failed to persist agent message:", error),
@@ -6544,13 +6559,19 @@ Structured summary:`;
       const duration = session.promptStartTime
         ? Date.now() - session.promptStartTime
         : undefined;
+      const finalOutputValidation = validateFinalOutput({
+        finalText: scrubbed,
+        evidence: extractEvidenceFromAgentMessages(session.messages),
+      });
+      const safeContent = finalOutputValidation.safeDisplayText;
 
       const message: AgentMessage = {
         id: crypto.randomUUID(),
         type: "assistant",
-        content: scrubbed,
+        content: safeContent,
         timestamp: session.streamingContentTimestamp ?? Date.now(),
         duration,
+        finalOutputValidation,
       };
       console.log(
         "[AgentRuntime] Adding assistant message to session:",
@@ -6558,7 +6579,7 @@ Structured summary:`;
         "conversationId:",
         session.conversationId,
         "content:",
-        scrubbed.slice(0, 50),
+        safeContent.slice(0, 50),
       );
       setState("sessions", sessionId, "messages", (msgs) => [...msgs, message]);
       if (session.conversationId)
@@ -6575,9 +6596,10 @@ Structured summary:`;
       if (
         !isReplay &&
         settingsStore.settings.memoryEnabled &&
-        !isLikelyAuthError(scrubbed)
+        !isLikelyAuthError(safeContent) &&
+        finalOutputValidation.canStoreMemory
       ) {
-        storeAssistantResponse(scrubbed, {
+        storeAssistantResponse(safeContent, {
           model: `agent:${session.info.agentType}`,
           userQuery: session.lastUserPrompt,
         }).catch((err) => {
@@ -6588,8 +6610,8 @@ Structured summary:`;
       // If the agent streamed a short auth error as text, surface it as a session error
       // so the error banner with the Login button appears. Long messages are skipped
       // to avoid false positives when the agent discusses auth topics in normal output.
-      if (isLikelyAuthError(scrubbed)) {
-        setState("sessions", sessionId, "error", scrubbed);
+      if (isLikelyAuthError(safeContent)) {
+        setState("sessions", sessionId, "error", safeContent);
       }
 
       // Prompt-too-long is detected exclusively from the CLI's structured

--- a/src/stores/conversation.store.ts
+++ b/src/stores/conversation.store.ts
@@ -81,6 +81,7 @@ function dbToUnifiedMessage(m: DbMessage): UnifiedMessage {
     taskType: metaFields.taskType,
     duration: metaFields.duration,
     cost: metaFields.cost,
+    finalOutputValidation: metaFields.finalOutputValidation,
     toolCall: metaFields.toolCall,
     diff: metaFields.diff,
   };

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Unified message and conversation types for the orchestrator.
 // ABOUTME: Replaces separate chat and local-agent message models.
 
+import type { FinalOutputValidationReport } from "@/lib/agent-output-validation";
 import type { Attachment } from "@/lib/providers/types";
 
 /** Source that produced this message */
@@ -64,6 +65,8 @@ export interface UnifiedMessage {
   duration?: number;
   /** Total cost in SerenBucks for this message's query, reported by Gateway. */
   cost?: number;
+  /** Verified Agent Output report for final assistant messages. */
+  finalOutputValidation?: FinalOutputValidationReport;
   toolCallId?: string;
   toolCall?: ToolCallData;
   diff?: DiffData;
@@ -121,6 +124,7 @@ export interface MessageMetadata {
   task_type?: string | null;
   duration?: number | null;
   cost?: number | null;
+  final_output_validation?: FinalOutputValidationReport | null;
   tool_call?: {
     id: string;
     name: string;
@@ -172,6 +176,7 @@ export function serializeMetadata(msg: UnifiedMessage): string | null {
     task_type: msg.taskType ?? null,
     duration: msg.duration ?? null,
     cost: msg.cost ?? null,
+    final_output_validation: msg.finalOutputValidation ?? null,
     tool_call: msg.toolCall
       ? {
           id: msg.toolCall.toolCallId,
@@ -217,6 +222,13 @@ export function deserializeMetadata(
     if (typeof meta.duration === "number" && meta.duration > 0)
       result.duration = meta.duration;
     if (typeof meta.cost === "number" && meta.cost > 0) result.cost = meta.cost;
+    if (
+      meta.final_output_validation &&
+      typeof meta.final_output_validation === "object"
+    ) {
+      result.finalOutputValidation =
+        meta.final_output_validation as FinalOutputValidationReport;
+    }
     if (meta.tool_call && typeof meta.tool_call === "object") {
       const tc = meta.tool_call as Record<string, string>;
       result.toolCall = {

--- a/tests/unit/agent-output-validation.test.ts
+++ b/tests/unit/agent-output-validation.test.ts
@@ -1,0 +1,329 @@
+// ABOUTME: Contract tests for #1987 Verified Agent Output finalization.
+// ABOUTME: Ensures final assistant claims are backed by execution-ledger evidence.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  extractEvidenceFromAgentMessages,
+  extractEvidenceFromToolLoopMessages,
+  extractEvidenceFromUnifiedMessages,
+  INITIAL_FINALIZATION_RULES,
+  validateFinalOutput,
+} from "@/lib/agent-output-validation";
+import type { UnifiedMessage } from "@/types/conversation";
+
+const requiredRuleIds = [
+  "file_write_claim_requires_diff_or_successful_file_tool",
+  "file_edit_claim_requires_diff_or_successful_file_tool",
+  "email_sent_claim_requires_successful_send_tool",
+  "draft_created_claim_requires_successful_draft_tool",
+  "db_persisted_claim_requires_successful_db_tool",
+  "publisher_unavailable_claim_requires_failed_live_verification",
+  "tool_completed_claim_rejects_pending_approval",
+  "tool_completed_claim_rejects_is_error_result",
+  "browser_action_claim_requires_successful_browser_tool",
+  "no_memory_storage_for_unverified_completion_claims",
+] as const;
+
+function unifiedTool(
+  overrides: Partial<UnifiedMessage> & {
+    toolCall: NonNullable<UnifiedMessage["toolCall"]>;
+  },
+): UnifiedMessage {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    type: "tool_call",
+    role: "assistant",
+    content: overrides.content ?? overrides.toolCall.title,
+    timestamp: Date.now(),
+    status: "complete",
+    toolCallId: overrides.toolCall.toolCallId,
+    ...overrides,
+  };
+}
+
+describe("#1987 Verified Agent Output", () => {
+  it("ships the complete deterministic rule registry", () => {
+    expect(INITIAL_FINALIZATION_RULES.map((rule) => rule.id)).toEqual(
+      requiredRuleIds,
+    );
+  });
+
+  it("verifies a file-write claim with matching diff evidence", () => {
+    const evidence = extractEvidenceFromUnifiedMessages([
+      {
+        id: "diff-1",
+        type: "diff",
+        role: "assistant",
+        content: "File changed: README.md",
+        timestamp: Date.now(),
+        status: "complete",
+        toolCallId: "tool-1",
+        diff: {
+          path: "README.md",
+          oldText: "",
+          newText: "# Verified",
+          toolCallId: "tool-1",
+        },
+      },
+    ]);
+
+    const report = validateFinalOutput({
+      finalText: "I created README.md.",
+      evidence,
+    });
+
+    expect(report.safeDisplayText).toBe("I created README.md.");
+    expect(report.canStoreMemory).toBe(true);
+    expect(report.claims).toMatchObject([
+      {
+        kind: "file_write",
+        status: "verified",
+        evidenceToolCallIds: ["tool-1"],
+      },
+    ]);
+  });
+
+  it("rewrites failed and pending completion claims before memory storage", () => {
+    const evidence = extractEvidenceFromUnifiedMessages([
+      unifiedTool({
+        toolCallId: "tool-failed",
+        toolCall: {
+          toolCallId: "tool-failed",
+          title: "write_file",
+          kind: "file",
+          name: "write_file",
+          status: "error",
+          isError: true,
+          result: "Error: permission denied",
+        },
+      }),
+      unifiedTool({
+        toolCallId: "tool-pending",
+        toolCall: {
+          toolCallId: "tool-pending",
+          title: "send_email",
+          kind: "gmail",
+          name: "gateway__gmail__post_messages_send",
+          status: "pending",
+        },
+      }),
+    ]);
+
+    const report = validateFinalOutput({
+      finalText: "I wrote the file and sent the email.",
+      evidence,
+    });
+
+    expect(report.safeDisplayText).toBe(
+      "I could not verify that the file was changed. I could not verify that the email was sent.",
+    );
+    expect(report.canStoreMemory).toBe(false);
+    expect(report.claims.map((claim) => claim.status)).toEqual([
+      "unverified",
+      "unverified",
+    ]);
+  });
+
+  it("distinguishes email drafts from sent email", () => {
+    const evidence = extractEvidenceFromUnifiedMessages([
+      unifiedTool({
+        toolCallId: "draft-1",
+        toolCall: {
+          toolCallId: "draft-1",
+          title: "Create Gmail draft",
+          kind: "gmail",
+          name: "gateway__gmail__post_drafts",
+          status: "completed",
+          result: '{"id":"draft-123"}',
+        },
+      }),
+    ]);
+
+    const report = validateFinalOutput({
+      finalText: "I created the email draft and sent the email.",
+      evidence,
+    });
+
+    expect(report.claims).toMatchObject([
+      { kind: "email_sent", status: "unverified" },
+      { kind: "draft_created", status: "verified" },
+    ]);
+    expect(report.safeDisplayText).toBe(
+      "I prepared the email draft, but I could not verify that it was sent.",
+    );
+  });
+
+  it("verifies DB persistence and requires live verification before unavailable claims", () => {
+    const dbEvidence = extractEvidenceFromUnifiedMessages([
+      unifiedTool({
+        toolCallId: "db-1",
+        toolCall: {
+          toolCallId: "db-1",
+          title: "run_sql_transaction",
+          kind: "serendb",
+          name: "mcp__seren_mcp__run_sql_transaction",
+          status: "completed",
+          result: "COMMIT",
+        },
+      }),
+    ]);
+
+    const dbReport = validateFinalOutput({
+      finalText: "I saved the record to the database.",
+      evidence: dbEvidence,
+    });
+    expect(dbReport.claims[0]).toMatchObject({
+      kind: "db_persisted",
+      status: "verified",
+      evidenceToolCallIds: ["db-1"],
+    });
+
+    const unavailableWithoutCheck = validateFinalOutput({
+      finalText: "GitHub is unavailable in this session.",
+      evidence: extractEvidenceFromUnifiedMessages([]),
+    });
+    expect(unavailableWithoutCheck.safeDisplayText).toBe(
+      "I could not verify that the service is unavailable.",
+    );
+
+    const unavailableWithFailedCheck = validateFinalOutput({
+      finalText: "GitHub is unavailable in this session.",
+      evidence: extractEvidenceFromUnifiedMessages([
+        unifiedTool({
+          toolCallId: "verify-1",
+          toolCall: {
+            toolCallId: "verify-1",
+            title: "list_agent_publishers",
+            kind: "seren-mcp",
+            name: "mcp__seren_mcp__list_agent_publishers",
+            status: "error",
+            isError: true,
+            result: "Publisher github-api not found",
+          },
+        }),
+      ]),
+    });
+    expect(unavailableWithFailedCheck.claims[0]).toMatchObject({
+      kind: "publisher_unavailable",
+      status: "verified",
+      evidenceToolCallIds: ["verify-1"],
+    });
+  });
+
+  it("validates browser claims against browser-tool evidence", () => {
+    const successReport = validateFinalOutput({
+      finalText: "I took a screenshot of the website.",
+      evidence: extractEvidenceFromUnifiedMessages([
+        unifiedTool({
+          toolCallId: "browser-1",
+          toolCall: {
+            toolCallId: "browser-1",
+            title: "playwright_screenshot",
+            kind: "browser",
+            name: "playwright_screenshot",
+            status: "completed",
+            result: "/tmp/screenshot.png",
+          },
+        }),
+      ]),
+    });
+    expect(successReport.claims[0]).toMatchObject({
+      kind: "browser_action",
+      status: "verified",
+    });
+
+    const failedReport = validateFinalOutput({
+      finalText: "I clicked the button on the website.",
+      evidence: extractEvidenceFromUnifiedMessages([
+        unifiedTool({
+          toolCallId: "browser-2",
+          toolCall: {
+            toolCallId: "browser-2",
+            title: "playwright_click",
+            kind: "browser",
+            name: "playwright_click",
+            status: "error",
+            isError: true,
+            result: "Element not found",
+          },
+        }),
+      ]),
+    });
+    expect(failedReport.safeDisplayText).toBe(
+      "I could not verify that the browser action completed.",
+    );
+  });
+
+  it("normalizes evidence from local-agent and direct chat finalization paths", () => {
+    const agentReport = validateFinalOutput({
+      finalText: "I updated the file.",
+      evidence: extractEvidenceFromAgentMessages([
+        {
+          id: "agent-diff",
+          type: "diff",
+          content: "Modified: src/app.ts",
+          timestamp: Date.now(),
+          toolCallId: "agent-tool",
+          diff: {
+            sessionId: "session-1",
+            toolCallId: "agent-tool",
+            path: "src/app.ts",
+            oldText: "old",
+            newText: "new",
+          },
+        },
+      ]),
+    });
+    expect(agentReport.claims[0]).toMatchObject({
+      kind: "file_edit",
+      status: "verified",
+    });
+
+    const chatReport = validateFinalOutput({
+      finalText: "I sent the email.",
+      evidence: extractEvidenceFromToolLoopMessages([
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "chat-send",
+              type: "function",
+              function: {
+                name: "gateway__gmail__post_messages_send",
+                arguments: "{}",
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "chat-send",
+          content: '{"id":"msg-123"}',
+        },
+      ]),
+    });
+    expect(chatReport.claims[0]).toMatchObject({
+      kind: "email_sent",
+      status: "verified",
+      evidenceToolCallIds: ["chat-send"],
+    });
+  });
+
+  it("wires validation into all required finalization paths", () => {
+    const chatSource = readFileSync("src/services/chat.ts", "utf8");
+    const orchestratorSource = readFileSync(
+      "src/services/orchestrator.ts",
+      "utf8",
+    );
+    const agentSource = readFileSync("src/stores/agent.store.ts", "utf8");
+
+    expect(chatSource).toContain("extractEvidenceFromToolLoopMessages");
+    expect(chatSource).toContain("finalOutputValidation");
+    expect(orchestratorSource).toContain("extractEvidenceFromUnifiedMessages");
+    expect(orchestratorSource).toContain("finalOutputValidation");
+    expect(agentSource).toContain("extractEvidenceFromAgentMessages");
+    expect(agentSource).toContain("finalOutputValidation");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Verified Agent Output validation for concrete final-answer claims against execution-ledger evidence.
- Rewrites unsupported file/email/db/browser/publisher completion claims before final render/persistence and blocks memory storage for unverified completion claims.
- Wires the contract into direct chat/tool-loop, orchestrator, employee, and local-agent finalization paths.
- Persists validation reports in message metadata for support/eval inspection.

Fixes #1987.

## Tests

- `./node_modules/.bin/vitest run tests/unit/agent-output-validation.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/biome check src/lib/agent-output-validation src/services/chat.ts src/services/orchestrator.ts src/stores/agent.store.ts src/stores/conversation.store.ts src/types/conversation.ts tests/unit/agent-output-validation.test.ts`
- `git diff --check`