### PR TITLE
fix(chat): restore agent selector popovers

### DIFF
--- a/src/components/chat/AgentEffortSelector.tsx
+++ b/src/components/chat/AgentEffortSelector.tsx
@@ -2,7 +2,8 @@
 // ABOUTME: Renders whenever the active session exposes a reasoning_effort select config option (Codex, Claude Code).
 
 import type { Component } from "solid-js";
-import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { createSignal, For, Show } from "solid-js";
+import { FloatingSelectorMenu } from "@/components/chat/FloatingSelectorMenu";
 import { type ActiveSession, agentStore } from "@/stores/agent.store";
 
 interface Props {
@@ -24,20 +25,6 @@ export const AgentEffortSelector: Component<Props> = (props) => {
     const current = opt.options.find((v) => v.value === opt.currentValue);
     return current?.name ?? opt.currentValue;
   };
-
-  const handleClickOutside = (event: MouseEvent) => {
-    if (dropdownRef && !dropdownRef.contains(event.target as Node)) {
-      setIsOpen(false);
-    }
-  };
-
-  onMount(() => {
-    document.addEventListener("mousedown", handleClickOutside);
-  });
-
-  onCleanup(() => {
-    document.removeEventListener("mousedown", handleClickOutside);
-  });
 
   const selectValue = (valueId: string) => {
     agentStore.setConfigOption(
@@ -92,43 +79,46 @@ export const AgentEffortSelector: Component<Props> = (props) => {
           </svg>
         </button>
 
-        <Show when={isOpen()}>
-          <div class="absolute bottom-full left-0 mb-1 w-56 bg-surface-0 border border-surface-3 rounded-lg shadow-lg z-50 overflow-hidden">
-            <div class="px-3 py-2 border-b border-surface-2 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
-              Reasoning Effort
-            </div>
-            <For each={option()?.options ?? []}>
-              {(opt) => (
-                <button
-                  type="button"
-                  class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 ${
-                    opt.value === option()?.currentValue ? "bg-surface-2" : ""
-                  }`}
-                  onClick={() => selectValue(opt.value)}
-                >
-                  <div class="flex items-center justify-between">
-                    <span class="text-sm text-foreground">{opt.name}</span>
-                    <Show when={opt.value === option()?.currentValue}>
-                      <svg
-                        class="w-4 h-4 text-green-500"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                        role="img"
-                        aria-label="Selected"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    </Show>
-                  </div>
-                </button>
-              )}
-            </For>
+        <FloatingSelectorMenu
+          open={isOpen()}
+          anchor={() => dropdownRef}
+          onRequestClose={() => setIsOpen(false)}
+          class="w-56"
+        >
+          <div class="px-3 py-2 border-b border-surface-2 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+            Reasoning Effort
           </div>
-        </Show>
+          <For each={option()?.options ?? []}>
+            {(opt) => (
+              <button
+                type="button"
+                class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 ${
+                  opt.value === option()?.currentValue ? "bg-surface-2" : ""
+                }`}
+                onClick={() => selectValue(opt.value)}
+              >
+                <div class="flex items-center justify-between">
+                  <span class="text-sm text-foreground">{opt.name}</span>
+                  <Show when={opt.value === option()?.currentValue}>
+                    <svg
+                      class="w-4 h-4 text-green-500"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      role="img"
+                      aria-label="Selected"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clip-rule="evenodd"
+                      />
+                    </svg>
+                  </Show>
+                </div>
+              </button>
+            )}
+          </For>
+        </FloatingSelectorMenu>
       </div>
     </Show>
   );

--- a/src/components/chat/AgentModeSelector.tsx
+++ b/src/components/chat/AgentModeSelector.tsx
@@ -2,7 +2,8 @@
 // ABOUTME: Shows available modes reported by the active agent runtime and sends set_mode commands.
 
 import type { Component } from "solid-js";
-import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { createSignal, For, Show } from "solid-js";
+import { FloatingSelectorMenu } from "@/components/chat/FloatingSelectorMenu";
 import { type ActiveSession, agentStore } from "@/stores/agent.store";
 
 interface Props {
@@ -22,20 +23,6 @@ export const AgentModeSelector: Component<Props> = (props) => {
     const mode = availableModes().find((m) => m.modeId === id);
     return mode?.name ?? id;
   };
-
-  const handleClickOutside = (event: MouseEvent) => {
-    if (dropdownRef && !dropdownRef.contains(event.target as Node)) {
-      setIsOpen(false);
-    }
-  };
-
-  onMount(() => {
-    document.addEventListener("mousedown", handleClickOutside);
-  });
-
-  onCleanup(() => {
-    document.removeEventListener("mousedown", handleClickOutside);
-  });
 
   const selectMode = (modeId: string) => {
     agentStore.setPermissionMode(modeId, props.session?.info.id);
@@ -86,50 +73,53 @@ export const AgentModeSelector: Component<Props> = (props) => {
           </svg>
         </button>
 
-        <Show when={isOpen()}>
-          <div class="absolute bottom-full left-0 mb-1 w-72 bg-surface-0 border border-surface-3 rounded-lg shadow-lg z-50 overflow-hidden">
-            <div class="px-3 py-2 border-b border-surface-2 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
-              Permission Mode
-            </div>
-            <For each={availableModes()}>
-              {(mode) => (
-                <button
-                  type="button"
-                  class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 ${
-                    mode.modeId === currentModeId() ? "bg-surface-2" : ""
-                  }`}
-                  onClick={() => selectMode(mode.modeId)}
-                >
-                  <div class="flex items-center justify-between">
-                    <div class="flex flex-col gap-0.5">
-                      <span class="text-sm text-foreground">{mode.name}</span>
-                      <Show when={mode.description}>
-                        <span class="text-[11px] text-muted-foreground">
-                          {mode.description}
-                        </span>
-                      </Show>
-                    </div>
-                    <Show when={mode.modeId === currentModeId()}>
-                      <svg
-                        class="w-4 h-4 text-green-500 flex-shrink-0 ml-2"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                        role="img"
-                        aria-label="Selected"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
+        <FloatingSelectorMenu
+          open={isOpen()}
+          anchor={() => dropdownRef}
+          onRequestClose={() => setIsOpen(false)}
+          class="w-72"
+        >
+          <div class="px-3 py-2 border-b border-surface-2 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+            Permission Mode
+          </div>
+          <For each={availableModes()}>
+            {(mode) => (
+              <button
+                type="button"
+                class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 ${
+                  mode.modeId === currentModeId() ? "bg-surface-2" : ""
+                }`}
+                onClick={() => selectMode(mode.modeId)}
+              >
+                <div class="flex items-center justify-between">
+                  <div class="flex flex-col gap-0.5">
+                    <span class="text-sm text-foreground">{mode.name}</span>
+                    <Show when={mode.description}>
+                      <span class="text-[11px] text-muted-foreground">
+                        {mode.description}
+                      </span>
                     </Show>
                   </div>
-                </button>
-              )}
-            </For>
-          </div>
-        </Show>
+                  <Show when={mode.modeId === currentModeId()}>
+                    <svg
+                      class="w-4 h-4 text-green-500 flex-shrink-0 ml-2"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      role="img"
+                      aria-label="Selected"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clip-rule="evenodd"
+                      />
+                    </svg>
+                  </Show>
+                </div>
+              </button>
+            )}
+          </For>
+        </FloatingSelectorMenu>
       </div>
     </Show>
   );

--- a/src/components/chat/AgentModelSelector.tsx
+++ b/src/components/chat/AgentModelSelector.tsx
@@ -2,7 +2,8 @@
 // ABOUTME: Shows available models reported by the active agent runtime and sends set_model commands.
 
 import type { Component } from "solid-js";
-import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { createSignal, For, Show } from "solid-js";
+import { FloatingSelectorMenu } from "@/components/chat/FloatingSelectorMenu";
 import { type ActiveSession, agentStore } from "@/stores/agent.store";
 
 interface Props {
@@ -30,20 +31,6 @@ export const AgentModelSelector: Component<Props> = (props) => {
     const model = availableModels().find((m) => m.modelId === id);
     return model?.name ?? id;
   };
-
-  const handleClickOutside = (event: MouseEvent) => {
-    if (dropdownRef && !dropdownRef.contains(event.target as Node)) {
-      setIsOpen(false);
-    }
-  };
-
-  onMount(() => {
-    document.addEventListener("mousedown", handleClickOutside);
-  });
-
-  onCleanup(() => {
-    document.removeEventListener("mousedown", handleClickOutside);
-  });
 
   const selectModel = (modelId: string) => {
     agentStore.setModel(modelId, props.session?.info.id);
@@ -94,52 +81,55 @@ export const AgentModelSelector: Component<Props> = (props) => {
           </svg>
         </button>
 
-        <Show when={isOpen()}>
-          <div class="absolute bottom-full left-0 mb-1 w-64 bg-surface-0 border border-surface-3 rounded-lg shadow-lg z-50 overflow-hidden">
-            <div class="px-3 py-2 border-b border-surface-2 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
-              Agent Model
-            </div>
-            <For each={availableModels()}>
-              {(model) => (
-                <button
-                  type="button"
-                  class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 ${
-                    model.modelId === displayModelId() ? "bg-surface-2" : ""
-                  }`}
-                  onClick={() => selectModel(model.modelId)}
-                >
-                  <div class="flex items-center justify-between gap-2">
-                    <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-                      <span class="text-sm text-foreground font-medium">
-                        {model.name}
+        <FloatingSelectorMenu
+          open={isOpen()}
+          anchor={() => dropdownRef}
+          onRequestClose={() => setIsOpen(false)}
+          class="w-64"
+        >
+          <div class="px-3 py-2 border-b border-surface-2 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+            Agent Model
+          </div>
+          <For each={availableModels()}>
+            {(model) => (
+              <button
+                type="button"
+                class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 ${
+                  model.modelId === displayModelId() ? "bg-surface-2" : ""
+                }`}
+                onClick={() => selectModel(model.modelId)}
+              >
+                <div class="flex items-center justify-between gap-2">
+                  <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                    <span class="text-sm text-foreground font-medium">
+                      {model.name}
+                    </span>
+                    <Show when={model.description}>
+                      <span class="text-[11px] text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap">
+                        {model.description}
                       </span>
-                      <Show when={model.description}>
-                        <span class="text-[11px] text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap">
-                          {model.description}
-                        </span>
-                      </Show>
-                    </div>
-                    <Show when={model.modelId === displayModelId()}>
-                      <svg
-                        class="w-4 h-4 text-green-500 flex-shrink-0"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                        role="img"
-                        aria-label="Selected"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
                     </Show>
                   </div>
-                </button>
-              )}
-            </For>
-          </div>
-        </Show>
+                  <Show when={model.modelId === displayModelId()}>
+                    <svg
+                      class="w-4 h-4 text-green-500 flex-shrink-0"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      role="img"
+                      aria-label="Selected"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clip-rule="evenodd"
+                      />
+                    </svg>
+                  </Show>
+                </div>
+              </button>
+            )}
+          </For>
+        </FloatingSelectorMenu>
       </div>
     </Show>
   );

--- a/src/components/chat/FloatingSelectorMenu.tsx
+++ b/src/components/chat/FloatingSelectorMenu.tsx
@@ -1,0 +1,87 @@
+// ABOUTME: Portal-backed floating menu for compact composer selectors.
+// ABOUTME: Keeps dropdowns visible when their toolbar row scrolls horizontally.
+
+import type { Component, JSX } from "solid-js";
+import { createEffect, createSignal, onCleanup, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+import { FLOATING_SELECTOR_MENU_BASE_CLASSES } from "@/components/chat/floatingSelectorMenuClasses";
+
+interface Props {
+  open: boolean;
+  anchor: () => HTMLElement | undefined;
+  class?: string;
+  onRequestClose: () => void;
+  children: JSX.Element;
+}
+
+export const FloatingSelectorMenu: Component<Props> = (props) => {
+  const [style, setStyle] = createSignal<JSX.CSSProperties>({});
+  let menuRef: HTMLDivElement | undefined;
+
+  const updatePosition = () => {
+    const anchor = props.anchor();
+    if (!anchor) return;
+
+    const anchorRect = anchor.getBoundingClientRect();
+    const menuRect = menuRef?.getBoundingClientRect();
+    const menuWidth = menuRect?.width ?? anchorRect.width;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const gutter = 8;
+    const left = Math.max(
+      gutter,
+      Math.min(anchorRect.left, viewportWidth - menuWidth - gutter),
+    );
+    const bottom = Math.max(gutter, viewportHeight - anchorRect.top + 6);
+
+    setStyle({
+      left: `${left}px`,
+      bottom: `${bottom}px`,
+    });
+  };
+
+  createEffect(() => {
+    if (!props.open) return;
+
+    updatePosition();
+    const raf = window.requestAnimationFrame(updatePosition);
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+
+    onCleanup(() => {
+      window.cancelAnimationFrame(raf);
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    });
+  });
+
+  createEffect(() => {
+    if (!props.open) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (props.anchor()?.contains(target) || menuRef?.contains(target)) return;
+      props.onRequestClose();
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    onCleanup(() => {
+      document.removeEventListener("mousedown", handlePointerDown);
+    });
+  });
+
+  return (
+    <Show when={props.open}>
+      <Portal mount={document.body}>
+        <div
+          ref={menuRef}
+          class={`${FLOATING_SELECTOR_MENU_BASE_CLASSES} ${props.class ?? ""}`}
+          style={style()}
+        >
+          {props.children}
+        </div>
+      </Portal>
+    </Show>
+  );
+};

--- a/src/components/chat/ThreadProviderSwitcher.tsx
+++ b/src/components/chat/ThreadProviderSwitcher.tsx
@@ -3,14 +3,8 @@
 // ABOUTME: in one click via switchChatProvider.
 
 import type { Component } from "solid-js";
-import {
-  createMemo,
-  createSignal,
-  For,
-  onCleanup,
-  onMount,
-  Show,
-} from "solid-js";
+import { createMemo, createSignal, For, Show } from "solid-js";
+import { FloatingSelectorMenu } from "@/components/chat/FloatingSelectorMenu";
 import { ProviderIcon } from "@/components/chat/ProviderIcon";
 import { PROVIDER_CONFIGS, type ProviderId } from "@/lib/providers";
 import {
@@ -117,24 +111,6 @@ export const ThreadProviderSwitcher: Component<Props> = (props) => {
     agentStore.availableAgents.filter((a) => a.available),
   );
 
-  const handleDocumentClick = (event: MouseEvent) => {
-    if (!isOpen()) return;
-    if (
-      containerRef &&
-      event.target instanceof Node &&
-      !containerRef.contains(event.target)
-    ) {
-      setIsOpen(false);
-    }
-  };
-
-  onMount(() => {
-    document.addEventListener("click", handleDocumentClick);
-  });
-  onCleanup(() => {
-    document.removeEventListener("click", handleDocumentClick);
-  });
-
   const selectChatProvider = async (providerId: ProviderId) => {
     if (current()?.kind === "chat" && current()?.provider === providerId) {
       setIsOpen(false);
@@ -212,64 +188,67 @@ export const ThreadProviderSwitcher: Component<Props> = (props) => {
         </span>
       </button>
 
-      <Show when={isOpen()}>
-        <div class="absolute bottom-full left-0 mb-1 min-w-[220px] bg-surface-0 border border-surface-3 rounded-lg shadow-lg z-50 overflow-hidden">
-          <Show when={chatProviders().length > 0}>
-            <div class="px-3 py-1.5 bg-surface-3 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
-              Chat
-            </div>
-            <For each={chatProviders()}>
-              {(providerId) => {
-                const isCurrent = () =>
-                  current()?.kind === "chat" &&
-                  current()?.provider === providerId;
-                return (
-                  <button
-                    type="button"
-                    class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 flex items-center gap-2 ${
-                      isCurrent() ? "bg-surface-2" : ""
-                    }`}
-                    onClick={() => {
-                      void selectChatProvider(providerId);
-                    }}
-                  >
-                    <ProviderIcon provider={providerId} size={14} />
-                    <span class="text-sm text-foreground">
-                      {PROVIDER_CONFIGS[providerId].name}
-                    </span>
-                  </button>
-                );
-              }}
-            </For>
-          </Show>
-          <Show when={availableAgents().length > 0}>
-            <div class="px-3 py-1.5 bg-surface-3 text-[10px] uppercase tracking-wider text-muted-foreground font-medium border-t border-surface-2">
-              External agents
-            </div>
-            <For each={availableAgents()}>
-              {(agent) => {
-                const isCurrent = () =>
-                  current()?.kind === "agent" &&
-                  current()?.agentType === agent.type;
-                return (
-                  <button
-                    type="button"
-                    class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 flex items-center gap-2 ${
-                      isCurrent() ? "bg-surface-2" : ""
-                    }`}
-                    onClick={() => selectAgent(agent.type)}
-                  >
-                    <ProviderIcon provider={agent.type} size={14} />
-                    <span class="text-sm text-foreground">
-                      {agentDisplayName(agent.type)}
-                    </span>
-                  </button>
-                );
-              }}
-            </For>
-          </Show>
-        </div>
-      </Show>
+      <FloatingSelectorMenu
+        open={isOpen()}
+        anchor={() => containerRef}
+        onRequestClose={() => setIsOpen(false)}
+        class="min-w-[220px]"
+      >
+        <Show when={chatProviders().length > 0}>
+          <div class="px-3 py-1.5 bg-surface-3 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+            Chat
+          </div>
+          <For each={chatProviders()}>
+            {(providerId) => {
+              const isCurrent = () =>
+                current()?.kind === "chat" &&
+                current()?.provider === providerId;
+              return (
+                <button
+                  type="button"
+                  class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 flex items-center gap-2 ${
+                    isCurrent() ? "bg-surface-2" : ""
+                  }`}
+                  onClick={() => {
+                    void selectChatProvider(providerId);
+                  }}
+                >
+                  <ProviderIcon provider={providerId} size={14} />
+                  <span class="text-sm text-foreground">
+                    {PROVIDER_CONFIGS[providerId].name}
+                  </span>
+                </button>
+              );
+            }}
+          </For>
+        </Show>
+        <Show when={availableAgents().length > 0}>
+          <div class="px-3 py-1.5 bg-surface-3 text-[10px] uppercase tracking-wider text-muted-foreground font-medium border-t border-surface-2">
+            External agents
+          </div>
+          <For each={availableAgents()}>
+            {(agent) => {
+              const isCurrent = () =>
+                current()?.kind === "agent" &&
+                current()?.agentType === agent.type;
+              return (
+                <button
+                  type="button"
+                  class={`w-full text-left px-3 py-2 border-b border-surface-2 last:border-b-0 transition-colors cursor-pointer hover:bg-surface-2 flex items-center gap-2 ${
+                    isCurrent() ? "bg-surface-2" : ""
+                  }`}
+                  onClick={() => selectAgent(agent.type)}
+                >
+                  <ProviderIcon provider={agent.type} size={14} />
+                  <span class="text-sm text-foreground">
+                    {agentDisplayName(agent.type)}
+                  </span>
+                </button>
+              );
+            }}
+          </For>
+        </Show>
+      </FloatingSelectorMenu>
     </div>
   );
 };

--- a/src/components/chat/floatingSelectorMenuClasses.ts
+++ b/src/components/chat/floatingSelectorMenuClasses.ts
@@ -1,0 +1,5 @@
+// ABOUTME: Tailwind class invariants for portal-backed selector menus.
+// ABOUTME: Shared with tests so toolbar overflow cannot silently re-clip menus.
+
+export const FLOATING_SELECTOR_MENU_BASE_CLASSES =
+  "fixed bg-surface-0 border border-surface-3 rounded-lg shadow-lg z-[1000] overflow-hidden";

--- a/tests/unit/composer-toolbar-layout.test.ts
+++ b/tests/unit/composer-toolbar-layout.test.ts
@@ -1,12 +1,15 @@
 // ABOUTME: Critical regression test for agent composer toolbar layout invariants.
 // ABOUTME: Guards against Cancel-button clipping when chip row grows (#1982).
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES,
   COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES,
   COMPOSER_TOOLBAR_ROOT_CLASSES,
 } from "@/components/chat/composerToolbarClasses";
+import { FLOATING_SELECTOR_MENU_BASE_CLASSES } from "@/components/chat/floatingSelectorMenuClasses";
 
 describe("composer toolbar layout invariants (#1982)", () => {
   it("right group must be pinned with shrink-0 so Cancel/Send is never clipped", () => {
@@ -25,5 +28,20 @@ describe("composer toolbar layout invariants (#1982)", () => {
   it("root toolbar must keep gap between the two groups", () => {
     expect(COMPOSER_TOOLBAR_ROOT_CLASSES).toMatch(/\bjustify-between\b/);
     expect(COMPOSER_TOOLBAR_ROOT_CLASSES).toMatch(/\bgap-\d+\b/);
+  });
+
+  it("agent selector menus must escape the left group's scroll clipping (#1992)", () => {
+    expect(COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES).toMatch(/\boverflow-x-auto\b/);
+    expect(FLOATING_SELECTOR_MENU_BASE_CLASSES).toMatch(/\bfixed\b/);
+
+    for (const file of [
+      "src/components/chat/ThreadProviderSwitcher.tsx",
+      "src/components/chat/AgentModelSelector.tsx",
+      "src/components/chat/AgentModeSelector.tsx",
+      "src/components/chat/AgentEffortSelector.tsx",
+    ]) {
+      const source = readFileSync(resolve(file), "utf-8");
+      expect(source).toContain("FloatingSelectorMenu");
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #1992.
- Moves the agent footer provider/model/mode/effort selector menus into a shared portal-backed fixed-position floating menu.
- Preserves the #1982 horizontal scroll behavior that keeps Send/Cancel visible while preventing dropdown content from being clipped by that scroll row.

## Regression
- Regression introduced by 47bfaff2e / PR #1983, which added `overflow-x-auto` to the agent composer left toolbar group. CSS overflow made the absolute dropdown menus render inside a clipping scroll container, so the chevrons changed state but the option surfaces were hidden.

## Tests
- `node_modules/.bin/vitest run tests/unit/composer-toolbar-layout.test.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/vitest run`
- `node_modules/.bin/vite build`
- `node_modules/.bin/biome check src/components/chat/FloatingSelectorMenu.tsx src/components/chat/floatingSelectorMenuClasses.ts src/components/chat/AgentModelSelector.tsx src/components/chat/AgentModeSelector.tsx src/components/chat/AgentEffortSelector.tsx src/components/chat/ThreadProviderSwitcher.tsx tests/unit/composer-toolbar-layout.test.ts`