### PR TITLE
fix(mcp/playwright-stealth): restore headless default

### DIFF
--- a/mcp-servers/playwright-stealth/README.md
+++ b/mcp-servers/playwright-stealth/README.md
@@ -70,16 +70,16 @@ BROWSER_TYPE=moz-firefox node dist/index.js
 
 ### Profile Compatibility Controls
 
-The default profile is Privy-compatible: headed launch, the safe stealth plugin
-for Chromium-based browsers, `iframe.contentWindow` and
-`navigator.permissions` evasions disabled, and the manual page init patch off.
-This supports embedded-wallet provisioning flows while preserving the remaining
-Chromium stealth evasions. Set only the controls needed when a workflow needs
-the older full-stealth/headless profile or a custom profile:
+The default profile launches headless with the safe stealth plugin for
+Chromium-based browsers, `iframe.contentWindow` and `navigator.permissions`
+evasions disabled, and the manual page init patch off. The disabled evasions
+and the init-patch-off default keep embedded-wallet provisioning flows like
+Privy working when a caller opts into a headed launch. Set only the controls
+needed when a workflow needs a headed launch or a custom stealth profile:
 
 ```bash
-# Opt back into headless mode.
-SEREN_PLAYWRIGHT_HEADLESS=1 node dist/index.js
+# Opt into a headed launch (required for embedded-wallet flows like Privy/Prophet).
+SEREN_PLAYWRIGHT_HEADLESS=0 node dist/index.js
 
 # Skip the puppeteer-extra stealth plugin entirely.
 SEREN_PLAYWRIGHT_DISABLE_STEALTH=1 node dist/index.js

--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -358,7 +358,7 @@ describe("launchBrowserWithFallback", () => {
       "chrome",
       "chromium",
       expect.objectContaining({
-        headless: false,
+        headless: true,
         executablePath:
           "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
       }),
@@ -368,7 +368,7 @@ describe("launchBrowserWithFallback", () => {
       "moz-firefox",
       "firefox",
       expect.objectContaining({
-        headless: false,
+        headless: true,
         executablePath: "/Applications/Firefox.app/Contents/MacOS/firefox",
       }),
     );
@@ -399,6 +399,35 @@ describe("launchBrowserWithFallback", () => {
       "chromium",
       expect.objectContaining({
         headless: true,
+      }),
+    );
+  });
+
+  it("launches headed when SEREN_PLAYWRIGHT_HEADLESS is 0", async () => {
+    process.env.SEREN_PLAYWRIGHT_HEADLESS = "0";
+    const launchedBrowser = { close: vi.fn() } as never;
+    const launchBrowser = vi.fn().mockResolvedValueOnce(launchedBrowser);
+
+    await launchBrowserWithFallback(
+      "chrome",
+      [
+        {
+          name: "chrome",
+          browserName: "chromium",
+          executablePath:
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+          isChromiumBased: true,
+          stealthSupported: true,
+        },
+      ],
+      launchBrowser as never,
+    );
+
+    expect(launchBrowser).toHaveBeenCalledWith(
+      "chrome",
+      "chromium",
+      expect.objectContaining({
+        headless: false,
       }),
     );
   });

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -509,7 +509,7 @@ export function createSafeStealthPlugin(
 export function shouldLaunchHeadless(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return env[PLAYWRIGHT_HEADLESS_ENV] === "1";
+  return env[PLAYWRIGHT_HEADLESS_ENV] !== "0";
 }
 
 export function shouldApplyStealthPlugin(


### PR DESCRIPTION
## Summary

- Revert `shouldLaunchHeadless` to `!== "0"` so the bundled `playwright-stealth` MCP server launches headless by default again. Headed launches now require `SEREN_PLAYWRIGHT_HEADLESS=0`.
- The other Privy-compatibility defaults from #1959 are unchanged: the `iframe.contentWindow` + `navigator.permissions` evasions stay disabled, and the manual page init patch stays off.
- README "Profile Compatibility Controls" section updated to reflect the headless-default phrasing.

Closes #1994.

## Why

PR #1959 flipped the headless default from opt-out (`!== "0"`) to opt-in (`=== "1"`). That means every caller who doesn't set the env var pops a visible browser window. The README still ships `SEREN_PLAYWRIGHT_HEADLESS="0"` as the "In Seren Desktop" example — that override only makes sense when headless is the default. Restore the default so the docs, CI scenarios, and existing skill SKILL.md files match runtime behavior.

## Skill regression caveat

Skills using the headed default for embedded-wallet flows must now set `SEREN_PLAYWRIGHT_HEADLESS=0` themselves. Known impact:

- `seren-skills/prophet/prophet-arb-bot` — `/create` drives Prophet's embedded wallet. Its SKILL.md does not currently export `SEREN_PLAYWRIGHT_HEADLESS=0`. Updating the skill is tracked separately and is not part of this PR.

## Test plan

- [x] `npx vitest run` in `mcp-servers/playwright-stealth`: 66/66 pass (was 65/66 before fix; added 1 new test for `=0` opt-out path).
- [ ] Local Seren Desktop smoke: invoke a Playwright MCP tool without setting `SEREN_PLAYWRIGHT_HEADLESS` and confirm no browser window appears.
- [ ] Confirm `SEREN_PLAYWRIGHT_HEADLESS=0` in a publisher config still pops a window when intended.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
