### PR TITLE
fix(chat): close #1997 — drain queued messages serially

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -876,6 +876,13 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       return;
     }
 
+    // Set loading synchronously before any await. orchestrate() also sets
+    // this, but only after we yield on persistMessage — a window wide
+    // enough for a fast user submission to slip past `conversationIsLoading()`
+    // in sendMessage() and start a parallel dispatch concurrent with the
+    // in-flight or about-to-fire drain (#1997).
+    conversationStore.setLoading(true, id);
+
     const userMessage: UnifiedMessage = {
       id: crypto.randomUUID(),
       type: "user",
@@ -915,24 +922,28 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       settingsStore.get("autoCompactPreserveMessages"),
     );
 
-    // Process message queue if there are queued messages.
-    // Capture the conversation ID to ensure the drain targets the same
-    // conversation even if the user switched threads during orchestration.
+    // Drain the next queued message strictly serially. We await the
+    // recursive call (instead of fire-and-forget setTimeout) so each next
+    // message can only start after the current orchestrate fully completes —
+    // no overlapping turns, no loading=false gap between drains, and no
+    // chance for a fast user submission to slip past `conversationIsLoading()`
+    // and start a parallel dispatch (#1997).
+    //
+    // Capture the conversation ID so the drain targets the same conversation
+    // even if the user switched threads during orchestration.
     const drainConversationId = id;
     const queue = messageQueue();
     if (queue.length > 0) {
       const [nextMessage, ...remainingQueue] = queue;
       setMessageQueue(remainingQueue);
       console.log("[ChatContent] Processing queued message:", nextMessage);
-      setTimeout(() => {
-        if (conversationId() === drainConversationId) {
-          sendMessageImmediate(nextMessage);
-        } else {
-          console.warn(
-            "[ChatContent] Skipping queued message — conversation changed",
-          );
-        }
-      }, 100);
+      if (conversationId() === drainConversationId) {
+        await sendMessageImmediate(nextMessage);
+      } else {
+        console.warn(
+          "[ChatContent] Skipping queued message — conversation changed",
+        );
+      }
     }
   };
 

--- a/tests/unit/chat-queue-serial-drain.test.ts
+++ b/tests/unit/chat-queue-serial-drain.test.ts
@@ -1,0 +1,88 @@
+// ABOUTME: Source-level regression test for #1997 — Seren Chat queued
+// ABOUTME: messages must drain strictly serially with no loading=false gap.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const chatContentSource = readFileSync(
+  resolve("src/components/chat/ChatContent.tsx"),
+  "utf-8",
+);
+
+function indexOrThrow(source: string, anchor: string): number {
+  const i = source.indexOf(anchor);
+  if (i < 0) {
+    throw new Error(
+      `anchor not found in source: ${JSON.stringify(anchor)}. ` +
+        `If the source was renamed, update this test's anchor — silent miss ` +
+        `would mask a real regression like #1997.`,
+    );
+  }
+  return i;
+}
+
+function sliceFunction(source: string, openAnchor: string): string {
+  // Grab a generous window starting at the function's first line. 200 lines
+  // is comfortably larger than sendMessageImmediate's body and still small
+  // enough that we won't accidentally match unrelated downstream code.
+  const start = indexOrThrow(source, openAnchor);
+  return source.slice(start).split("\n").slice(0, 200).join("\n");
+}
+
+describe("#1997 — queued messages drain strictly serially in Seren Chat", () => {
+  it("sendMessageImmediate sets loading=true synchronously before any await", () => {
+    const body = sliceFunction(
+      chatContentSource,
+      "const sendMessageImmediate = async (",
+    );
+
+    const setLoadingIdx = body.indexOf("conversationStore.setLoading(true, id)");
+    const firstAwaitIdx = body.indexOf("await ");
+    const addMessageIdx = body.indexOf(
+      "conversationStore.addMessage(userMessage, id)",
+    );
+
+    expect(
+      setLoadingIdx,
+      "setLoading(true, id) must be called early so the persistMessage yield " +
+        "does not expose a loading=false gap to concurrent submissions (#1997)",
+    ).toBeGreaterThanOrEqual(0);
+    expect(setLoadingIdx).toBeLessThan(firstAwaitIdx);
+    expect(setLoadingIdx).toBeLessThan(addMessageIdx);
+  });
+
+  it("the drain block awaits the recursive sendMessageImmediate, not setTimeout", () => {
+    const body = sliceFunction(
+      chatContentSource,
+      "const sendMessageImmediate = async (",
+    );
+
+    // The drain tail must contain an awaited recursive call.
+    expect(body).toContain("await sendMessageImmediate(nextMessage)");
+
+    // And must NOT contain the old fire-and-forget setTimeout pattern that
+    // created a 100ms loading=false gap and offered no serialization
+    // guarantee against concurrent submissions.
+    expect(body).not.toMatch(/setTimeout\(\s*\(\)\s*=>\s*\{[^}]*sendMessageImmediate\(/s);
+  });
+
+  it("the drain pops exactly one message per cycle and survives thread switch", () => {
+    const body = sliceFunction(
+      chatContentSource,
+      "const sendMessageImmediate = async (",
+    );
+
+    // Single-message pop: [head, ...rest] = queue is the canonical shape.
+    expect(body).toContain("const [nextMessage, ...remainingQueue] = queue;");
+    expect(body).toContain("setMessageQueue(remainingQueue);");
+
+    // Thread-switch guard still wraps the recursive call so a mid-drain
+    // thread switch aborts the chain cleanly instead of sending the next
+    // queued message into the wrong conversation.
+    expect(body).toContain("if (conversationId() === drainConversationId)");
+    expect(body).toContain(
+      "Skipping queued message — conversation changed",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Call `conversationStore.setLoading(true, id)` synchronously at the start of `sendMessageImmediate`, before the `persistMessage` await yields. This closes the loading=false gap that let a fast user submission bypass `conversationIsLoading()` and start a parallel dispatch.
- Replace `setTimeout(() => sendMessageImmediate(nextMessage), 100)` with `await sendMessageImmediate(nextMessage)`. Each drained message can only start after the current orchestrate fully completes — strictly serial.

Both changes are needed: the await fixes the recursion-level serialization, the setLoading covers the persistMessage-yield gap that survives even after the await refactor.

Closes #1997.

## Test plan

- [x] `npx vitest run tests/unit/chat-queue-serial-drain.test.ts` — 3/3 pass
- [x] `npx vitest run tests/unit/queued-input-history.test.ts tests/unit/queue-indicator-unified.test.ts tests/unit/chat-draft-cross-mount-persist.test.ts` — 10/10 pass (no regression in adjacent queue/draft suites)
- [x] `npx tsc --noEmit` — clean for changed files
- [x] `npx @biomejs/biome check src/components/chat/ChatContent.tsx tests/unit/chat-queue-serial-drain.test.ts` — clean
- [ ] Manual smoke: send #1; while streaming, queue #2-#5; verify each user message appears only after the prior assistant completes; verify "N messages queued" decrements one-at-a-time

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
