### PR TITLE
test(wallet): close #2000 — pin notification batch clock

### DIFF
--- a/tests/unit/wallet-received-notification-batch.test.ts
+++ b/tests/unit/wallet-received-notification-batch.test.ts
@@ -35,6 +35,10 @@ describe("wallet received-transfer notification batches", () => {
     walletMocks.markWalletNotificationRead.mockResolvedValue(undefined);
     resetWalletState();
 
+    // Pin the clock inside the 24h notify window for the fixture timestamps below.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-05-20T22:33:00Z"));
+
     class MockNotification {
       static permission = "granted";
       static requestPermission = vi.fn();
@@ -54,6 +58,7 @@ describe("wallet received-transfer notification batches", () => {
   afterEach(() => {
     resetWalletState();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it("notifies unread received transfers oldest-first and marks each read", async () => {


### PR DESCRIPTION
## Summary
- `tests/unit/wallet-received-notification-batch.test.ts` is a time bomb. Fixture timestamps (`2026-05-20T22:30–22:32Z`) only sit inside the wallet store's 24h `FIRST_SEEN_RECEIVED_TRANSFER_NOTIFY_WINDOW_MS` when the test runs within a day of authorship. With real-clock evaluation 32+ hours later, `isRecentReceivedTransfer` returned `false`, no `new Notification` was constructed, and the batch assertion saw length 0.
- Pin the test clock to `2026-05-20T22:33:00Z` via `vi.useFakeTimers({ shouldAdvanceTime: true })` + `vi.setSystemTime(...)` so the fixtures stay inside the window regardless of wall-clock drift. `shouldAdvanceTime: true` keeps `vi.waitFor` and real microtask scheduling intact.

Closes #2000.

## Test plan
- [x] `vitest run tests/unit/wallet-received-notification-batch.test.ts` — passes (1/1)
- [x] Full `vitest run` on main with patch applied — 1390/1390 pass
- [ ] CI `test-frontend` green on PR
