### PR TITLE
fix(chat): close #2002 — recap empty turn on length finish_reason

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -799,8 +799,20 @@ created if missing.",
                 accumulated_cost: cost,
             }
         } else {
+            // Empty assistant turns destroy cross-turn context (#1812, #2002).
+            // When the stream stopped because the model hit its output cap
+            // (finish_reason="length") without producing any content, backfill
+            // a recap so the user sees what happened and the next turn has
+            // usable history. Same recap shape as the MAX_TOOL_ROUNDS path.
+            let final_content = if content.is_empty()
+                && finish_reason.as_deref() == Some("length")
+            {
+                "(No response — model hit its output length cap. Try /compact or shortening the request and ask me to continue.)".to_string()
+            } else {
+                content
+            };
             StreamOutcome::Complete {
-                final_content: content,
+                final_content,
                 thinking: if thinking.is_empty() {
                     None
                 } else {
@@ -2686,6 +2698,41 @@ mod tests {
         match outcome {
             StreamOutcome::Complete { .. } => {}
             _ => panic!("Expected Complete outcome when no pending tool calls"),
+        }
+    }
+
+    #[test]
+    fn build_stream_outcome_backfills_empty_content_when_finish_reason_length() {
+        // Regression for #2002: a stream that finishes with finish_reason="length"
+        // and no content or tool calls used to emit Complete { final_content: "" },
+        // producing a blank assistant turn. The next user message arrived with no
+        // record of the truncation, so the model self-gaslit into denying it had
+        // done any work. Backfill final_content so the user sees what happened.
+        let outcome = ChatModelWorker::build_stream_outcome(
+            &Some("length".to_string()),
+            HashMap::new(),
+            String::new(),
+            String::new(),
+            0.405,
+        );
+        match outcome {
+            StreamOutcome::Complete {
+                final_content,
+                cost,
+                ..
+            } => {
+                assert!(
+                    !final_content.is_empty(),
+                    "Empty final_content on finish_reason=length destroys cross-turn context"
+                );
+                let lowered = final_content.to_lowercase();
+                assert!(
+                    lowered.contains("length") || lowered.contains("output"),
+                    "User-facing recap should explain the model hit its output cap, got: {final_content}"
+                );
+                assert_eq!(cost, 0.405);
+            }
+            other => panic!("Expected Complete outcome with explanatory recap, got: {:?}", other),
         }
     }
 


### PR DESCRIPTION
Closes #2002.

## Summary

- Backfill `final_content` in `build_stream_outcome` when the stream finishes with `finish_reason="length"` and produces no content or tool calls. Same recap shape as #1812.
- One critical regression test in `chat_model_worker::tests`.

## Why

`build_stream_outcome` (src-tauri/src/orchestrator/chat_model_worker.rs:782) treated every non-`tool_calls` finish_reason as `Complete` and passed `content` through verbatim. On long chats where the model hit its output cap mid-turn (`finish_reason="length"`, content empty, no tool_calls), the worker emitted `WorkerEvent::Complete { final_content: "" }`. The chat panel rendered a blank assistant turn — and the next user message arrived in conversation history with no record that anything had truncated. The model then "self-gaslit" on the next turn, denying it had done any prior work.

This is the same "empty assistant turns destroy cross-turn context" failure pattern that #1812 fixed for `MAX_TOOL_ROUNDS` and `StreamOutcome::Failed`. The `finish_reason="length"` path was the missed sibling.

## Repro from the original session (issue body has full console trace)

```
[ChatModelWorker] Stream ended: 2 chunks received, 6739 bytes remaining in buffer, accumulated 0 content bytes
[ChatModelWorker] Stream finish_reason detected: length
[ChatModelWorker] StreamOutcome::Complete received — round=15, content_len=0, cost=Some(0.40563799999999994)
```

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib build_stream_outcome_backfills_empty_content_when_finish_reason_length` — new test fails before fix, passes after.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib orchestrator::chat_model_worker` — 54/54 pass.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean (only pre-existing dead_code warnings in `embedded_runtime.rs`, unrelated).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
