### PR TITLE
feat(terminal): close #2004 — theme the Claude Code CLI terminal thread

### DIFF
--- a/src/components/terminal/TerminalBuffer.tsx
+++ b/src/components/terminal/TerminalBuffer.tsx
@@ -1803,44 +1803,99 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
           </div>
         }
       >
-        {(current) => (
-          <>
-            <div class="flex items-center gap-2 px-3 py-2 border-b border-border bg-card">
-              <div class="flex-1 min-w-0">
-                <div class="text-[13px] font-medium text-foreground truncate">
-                  {current().title}
+        {(current) => {
+          // Trust signal for the themed Claude Code CLI chrome (#2004).
+          // Mirrors the launcher entry at ThreadSidebar.tsx:702, which is
+          // locked by launcher-redesign.test.ts to spawn `claude` with no
+          // flags. Per Anthropic's June 15, 2026 split, interactive
+          // `claude` in a terminal draws from the Pro/Max subscription
+          // pool — the pill below makes that visible to the user.
+          const isClaudeCli = () => current().command === "claude";
+          return (
+            <>
+              <div class="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-card">
+                <div class="flex-1 min-w-0 flex items-center gap-2.5">
+                  <Show when={isClaudeCli()}>
+                    <span
+                      aria-hidden="true"
+                      class="inline-block w-1.5 h-1.5 rounded-full bg-success shadow-[0_0_0_3px_rgba(52,211,153,0.12)]"
+                    />
+                  </Show>
+                  <div class="text-[13px] font-medium text-foreground truncate">
+                    {current().title}
+                  </div>
+                  <Show when={current().cwd}>
+                    <span class="text-[12px] font-mono text-secondary-foreground bg-surface-3 px-2 py-0.5 rounded border border-border truncate">
+                      {current().cwd}
+                    </span>
+                  </Show>
                 </div>
-                <div class="text-[11px] text-muted-foreground truncate">
-                  {current().cwd || "Current environment"} - {current().status}
-                </div>
+                <Show when={isClaudeCli()}>
+                  <div class="flex items-center gap-2 shrink-0">
+                    <span class="text-[11px] font-medium tracking-tight text-primary bg-primary-muted px-2.5 py-1 rounded-full border border-[color:rgba(56,189,248,0.22)]">
+                      Subscription · Pro/Max
+                    </span>
+                  </div>
+                </Show>
               </div>
-            </div>
 
-            {/* Canvas surface. role="application" + tabIndex=0 lets the
-                div receive focus + keyboard events; the application role
-                tells screen readers this is a widget with its own
-                keyboard model (matches xterm.js, vscode terminal, etc.).
-                Focus on mousedown so users can type without Tab-ing in. */}
-            <div
-              ref={surfaceRef}
-              class="flex-1 min-h-0 overflow-hidden bg-[#090b0f] outline-none cursor-text"
-              role="application"
-              aria-label="Terminal"
-              data-workspace-default-focus={
-                current().status === "running" ? "true" : undefined
-              }
-              // biome-ignore lint/a11y/noNoninteractiveTabindex: terminal surfaces are interactive widgets that own their keyboard model (matches xterm.js, vscode terminal pattern)
-              tabIndex={0}
-              onKeyDown={(e) => void handleKeyDown(e)}
-              onPaste={(e) => void handlePaste(e)}
-              onMouseDown={onSurfaceMouseDown}
-              onMouseMove={onSurfaceMouseMoveTracking}
-              onWheel={onSurfaceWheel}
-            >
-              <canvas ref={canvasRef} class="block pointer-events-none" />
-            </div>
-          </>
-        )}
+              {/* Canvas surface. role="application" + tabIndex=0 lets the
+                  div receive focus + keyboard events; the application role
+                  tells screen readers this is a widget with its own
+                  keyboard model (matches xterm.js, vscode terminal, etc.).
+                  Focus on mousedown so users can type without Tab-ing in. */}
+              <div
+                ref={surfaceRef}
+                class="flex-1 min-h-0 overflow-hidden bg-[#090b0f] outline-none cursor-text"
+                classList={{
+                  // Themed frame: drop-shadow + sky-400 glow only on the
+                  // claude CLI surface so plain Terminal threads keep their
+                  // existing chrome.
+                  "ring-1 ring-[color:var(--border-medium)] shadow-[var(--shadow-lg),var(--glow-primary)]":
+                    isClaudeCli(),
+                }}
+                role="application"
+                aria-label="Terminal"
+                data-workspace-default-focus={
+                  current().status === "running" ? "true" : undefined
+                }
+                // biome-ignore lint/a11y/noNoninteractiveTabindex: terminal surfaces are interactive widgets that own their keyboard model (matches xterm.js, vscode terminal pattern)
+                tabIndex={0}
+                onKeyDown={(e) => void handleKeyDown(e)}
+                onPaste={(e) => void handlePaste(e)}
+                onMouseDown={onSurfaceMouseDown}
+                onMouseMove={onSurfaceMouseMoveTracking}
+                onWheel={onSurfaceWheel}
+              >
+                <canvas ref={canvasRef} class="block pointer-events-none" />
+              </div>
+
+              <Show when={isClaudeCli()}>
+                <div class="flex items-center justify-end gap-3 px-4 py-2 text-[11px] text-muted-foreground border-t border-border bg-surface-0">
+                  <span>
+                    <kbd class="font-mono text-[10.5px] text-secondary-foreground bg-surface-3 border border-border rounded px-1.5 py-px">
+                      ⌃C
+                    </kbd>{" "}
+                    interrupt
+                  </span>
+                  <span>
+                    <kbd class="font-mono text-[10.5px] text-secondary-foreground bg-surface-3 border border-border rounded px-1.5 py-px">
+                      ⌃D
+                    </kbd>{" "}
+                    end session
+                  </span>
+                  <span>
+                    type{" "}
+                    <kbd class="font-mono text-[10.5px] text-secondary-foreground bg-surface-3 border border-border rounded px-1.5 py-px">
+                      /help
+                    </kbd>{" "}
+                    for slash commands
+                  </span>
+                </div>
+              </Show>
+            </>
+          );
+        }}
       </Show>
     </div>
   );

--- a/tests/unit/terminal-buffer-claude-cli.test.ts
+++ b/tests/unit/terminal-buffer-claude-cli.test.ts
@@ -1,0 +1,31 @@
+// ABOUTME: Critical regression guard for the themed Claude Code CLI terminal pill (#2004).
+// ABOUTME: Trust contract — the billing-pool label must only render when the buffer was
+// ABOUTME: spawned via `command: "claude"` (no flags), which is the interactive-pool boundary.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const terminalBufferTsx = readFileSync(
+  resolve("src/components/terminal/TerminalBuffer.tsx"),
+  "utf-8",
+);
+
+describe("TerminalBuffer — Claude Code CLI billing pill (#2004)", () => {
+  it("conditions the themed chrome on command === 'claude'", () => {
+    // The trust signal: the launcher entry at ThreadSidebar.tsx:702 spawns
+    // with { command: "claude" } and no flags (locked by launcher-redesign.test.ts).
+    // The pill must key off the SAME signal so anyone who later adds `-p` or
+    // `--output-format stream-json` to the command silently loses the pill —
+    // making the regression visible.
+    expect(terminalBufferTsx).toMatch(/command\s*===\s*"claude"/);
+  });
+
+  it("renders the 'Subscription · Pro/Max' label as the billing pill copy", () => {
+    // This copy is the user-facing trust contract. Per Anthropic's June 15, 2026
+    // classification, interactive `claude` in a terminal draws from the user's
+    // Pro/Max subscription quota — not the Agent SDK credit pool. If this string
+    // drifts, users get misled about which pool their session uses.
+    expect(terminalBufferTsx).toContain("Subscription · Pro/Max");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2004 — themes the existing "Claude Code CLI" terminal-thread launcher pane so users can tell at a glance that the thread draws from their Pro/Max subscription pool (not the Agent SDK credit pool).

- **"Subscription · Pro/Max" pill** in the header — the trust contract that mirrors the launcher's no-flag `command: "claude"` spawn locked by `tests/unit/launcher-redesign.test.ts`.
- **Monospaced CWD chip** so the working directory is glanceable without parsing the subtitle.
- **Frame + border + sky-400 glow** around the canvas surface — uses existing `--shadow-lg` + `--glow-primary` tokens, claude threads only.
- **Composer hint strip** under the canvas advertising ⌃C, ⌃D, `/help`.

All themed chrome is branched on `command === "claude"`. Plain Terminal threads keep their existing minimal header. Canvas paint internals are untouched — the renderer already uses JetBrains Mono per `styles.css:121`.

## Audit (issue ↔ fix ↔ impact)

| Acceptance criterion | Code path | Verified by |
|---|---|---|
| Open Sidebar → New → "Claude Code CLI" shows header bar, status pills, framed canvas, tuned mono font | `TerminalBuffer.tsx` render branch on `command === "claude"` (header pill + CWD chip + ring/shadow + composer hint) | Manual: `pnpm tauri dev`, smoke-tested launcher entry |
| Status pill reads "Subscription · Pro/Max" when spawned via the Claude Code CLI launcher | `TerminalBuffer.tsx` JSX literal `Subscription · Pro/Max` gated on `isClaudeCli()` | `tests/unit/terminal-buffer-claude-cli.test.ts` (file-string assertion) |
| Plain `Terminal` threads keep the existing chrome | Themed chrome wrapped in `<Show when={isClaudeCli()}>`; no changes to fall-through layout | Manual: open plain `Terminal` thread, no pill / no frame / no hint strip |
| No regression in `tests/unit/launcher-redesign.test.ts` (pins `command: "claude"` with no flags) | Untouched `ThreadSidebar.tsx`; that test file reads the sidebar source only | `pnpm vitest run tests/unit/launcher-redesign.test.ts` — 24 / 24 passed |

## Test plan

- [x] `pnpm vitest run tests/unit/terminal-buffer-claude-cli.test.ts tests/unit/launcher-redesign.test.ts` — 26 / 26 passed
- [x] `pnpm vitest run` — full unit sweep, **1392 / 1392 passed**
- [x] `pnpm check` on `src/components/terminal/TerminalBuffer.tsx` — no fixes applied
- [ ] `pnpm tauri dev` smoke: open Sidebar → "Claude Code CLI" → pill + chip + frame + hint strip render
- [ ] `pnpm tauri dev` smoke: open Sidebar → "Terminal" → existing minimal chrome preserved (regression)

## Files changed

- `src/components/terminal/TerminalBuffer.tsx` — JSX render branch on `command === "claude"`
- `tests/unit/terminal-buffer-claude-cli.test.ts` (NEW) — critical regression guard for the trust contract

## Related

- Issue: #2004
- Mockup: see issue body
- Tokens reference: `src/styles.css` (deep-navy gradient, surface-0..3, sky-400 primary, slate-alpha borders)
