### PR TITLE
feat(terminal): close #2006 — finish remaining #2004 scope items

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -769,6 +769,7 @@ pub fn run() {
             terminal::terminal_grid_snapshot,
             terminal::terminal_grid_scrollback,
             terminal::terminal_signal,
+            terminal::terminal_claude_version,
             // Web fetch command
             commands::web::web_fetch,
             // Rust-backed Gateway API bridge

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -2630,6 +2630,33 @@ fn unix_millis() -> i64 {
         .as_millis() as i64
 }
 
+/// One-shot probe of `claude --version` for the header pill (#2006).
+///
+/// Runs the binary out-of-band from any PTY, parses the first whitespace
+/// token from stdout, returns `None` on any failure (binary missing,
+/// non-zero exit, parse miss). The header pill renders behind a
+/// `<Show when={claudeCliVersion()}>` so a `None` simply omits the pill —
+/// the Subscription pill and the rest of the themed chrome are unaffected.
+#[tauri::command]
+pub fn terminal_claude_version() -> Option<String> {
+    let output = std::process::Command::new("claude")
+        .arg("--version")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    // `claude --version` prints e.g. "2.1.148 (Claude Code)". Strip to the
+    // first whitespace-delimited token so the pill stays compact.
+    let token = stdout.split_whitespace().next()?;
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/components/terminal/TerminalBuffer.tsx
+++ b/src/components/terminal/TerminalBuffer.tsx
@@ -126,6 +126,12 @@ const COLOR_BG = "#090b0f";
 const COLOR_FG = "#d7dde8";
 const COLOR_CURSOR = "#d7dde8";
 const COLOR_CURSOR_FG = "#090b0f";
+// Claude-themed paint colors (#2006). Gated on `isClaudeCli()` so plain
+// Terminal threads keep their existing cursor/selection vocabulary.
+// Sky-400 ties the cursor + selection to the Subscription pill and the
+// ring/glow chrome rendered by the same gate.
+const COLOR_CURSOR_CLAUDE = "#38bdf8";
+const COLOR_CURSOR_FG_CLAUDE = "#090b0f";
 const DIM_ALPHA = 0.82;
 
 // Color packing matches src-tauri/src/terminal.rs:
@@ -257,6 +263,9 @@ interface SelectionRange {
 }
 
 const SELECTION_OVERLAY_FILL = "rgba(80, 130, 200, 0.4)";
+// Claude-themed selection overlay (#2006). Sky-400 alpha. Kept low so
+// selected glyphs stay readable on the dark canvas.
+const SELECTION_OVERLAY_FILL_CLAUDE = "rgba(56, 189, 248, 0.25)";
 
 /**
  * Normalize a SelectionRange so the returned [start, end] pair is in
@@ -411,6 +420,27 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
   let wheelAccumulator = 0;
 
   const buffer = createMemo(() => terminalStore.getBuffer(activeBufferId()));
+  // #2006 — trust signal used by paint code (cursor, selection, line-height)
+  // AND by the header/footer JSX. Mirrors the launcher entry at
+  // ThreadSidebar.tsx:702, which is locked by launcher-redesign.test.ts to
+  // spawn `claude` with no flags. Drift here silently loses every themed
+  // surface, so the file-string regression test in
+  // tests/unit/terminal-buffer-claude-cli.test.ts pins the predicate.
+  const isClaudeCli = () => buffer()?.command === "claude";
+  // #2006 — version pill copy. Fetches once via the cached terminalStore
+  // helper, only when the active thread is a Claude CLI thread. The pill
+  // renders behind <Show when={claudeCliVersion()}> so a null (probe
+  // failed, binary missing) gracefully omits the pill.
+  const [claudeCliVersion, setClaudeCliVersion] = createSignal<string | null>(
+    null,
+  );
+  createEffect(() => {
+    if (!isClaudeCli()) return;
+    if (claudeCliVersion()) return;
+    void terminalStore.getClaudeCliVersion().then((v) => {
+      if (v) setClaudeCliVersion(v);
+    });
+  });
 
   const pruneScrollbackCache = (base: number, len: number) => {
     const end = base + len;
@@ -1025,8 +1055,13 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
     // that gives breathing room without looking double-spaced.
     const fbAscent = m.fontBoundingBoxAscent;
     const fbDescent = m.fontBoundingBoxDescent;
-    const h =
-      fbAscent !== undefined && fbDescent !== undefined
+    // #2006 — claude threads bump line-height to 1.6 for breathing room
+    // matching the rest of the app's typography. The fontBoundingBox path
+    // gives ~1.2-1.3, so override unconditionally for claude. Plain
+    // Terminal threads keep the 1.4 convention via font metrics or fallback.
+    const h = isClaudeCli()
+      ? Math.ceil(fontSize * 1.6)
+      : fbAscent !== undefined && fbDescent !== undefined
         ? Math.ceil(fbAscent + fbDescent)
         : Math.ceil(fontSize * 1.4);
     setCellW(w);
@@ -1384,7 +1419,13 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
     // highlight blends with text but BEFORE the cursor block.
     if (sel) {
       const [start, end] = normalizeSelection(sel);
-      ctx.fillStyle = SELECTION_OVERLAY_FILL;
+      // #2006 — claude threads use sky-400 alpha to tie selection to the
+      // Subscription pill + ring/glow. Plain Terminal threads keep the
+      // muted blue. The createEffect at the bottom of the component tracks
+      // isClaudeCli so a thread switch triggers a full repaint.
+      ctx.fillStyle = isClaudeCli()
+        ? SELECTION_OVERLAY_FILL_CLAUDE
+        : SELECTION_OVERLAY_FILL;
       for (const r of rowsToPaint) {
         if (r < start.row || r > end.row || r >= g.rows) continue;
         const startCol = r === start.row ? start.col : 0;
@@ -1409,10 +1450,15 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
       const cursorWidth = (cell?.width ?? 1) === 2 ? 2 * w : w;
       const cx = g.cursorCol * w;
       const cy = g.cursorRow * h;
-      ctx.fillStyle = COLOR_CURSOR;
+      // #2006 — claude threads use a sky-400 cursor; plain Terminal stays
+      // on the off-white default. Inverted-glyph foreground stays dark in
+      // both cases so the cell character reads against either fill.
+      ctx.fillStyle = isClaudeCli() ? COLOR_CURSOR_CLAUDE : COLOR_CURSOR;
       ctx.fillRect(cx, cy, cursorWidth, h);
       if (cell && cell.ch !== 0 && cell.width > 0) {
-        ctx.fillStyle = COLOR_CURSOR_FG;
+        ctx.fillStyle = isClaudeCli()
+          ? COLOR_CURSOR_FG_CLAUDE
+          : COLOR_CURSOR_FG;
         ctx.font = fontForAttrs(cell.attrs ?? 0, fontSize);
         ctx.fillText(String.fromCodePoint(cell.ch), cx, cy);
       }
@@ -1433,12 +1479,18 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
     void cellW();
     void cellH();
     void terminalFontSize();
+    // #2006 — track isClaudeCli so cursor + selection repaint with the
+    // sky-400 vs default palette when the user switches thread types.
+    void isClaudeCli();
     needsFullRepaint = true;
     scheduleFrame();
   });
 
   createEffect(() => {
     void terminalFontSize();
+    // #2006 — track isClaudeCli so line-height (1.6 vs 1.4) recomputes when
+    // the user switches between a Claude CLI thread and a plain Terminal.
+    void isClaudeCli();
     measureCell();
     pushResize();
   });
@@ -1804,12 +1856,14 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
         }
       >
         {(current) => {
-          // Trust signal for the themed Claude Code CLI chrome (#2004).
+          // Trust signal for the themed Claude Code CLI chrome (#2004, #2006).
           // Mirrors the launcher entry at ThreadSidebar.tsx:702, which is
           // locked by launcher-redesign.test.ts to spawn `claude` with no
           // flags. Per Anthropic's June 15, 2026 split, interactive
           // `claude` in a terminal draws from the Pro/Max subscription
           // pool — the pill below makes that visible to the user.
+          // Mirrors the component-scoped `isClaudeCli` so paint code +
+          // header chrome share the exact same predicate.
           const isClaudeCli = () => current().command === "claude";
           return (
             <>
@@ -1832,6 +1886,16 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
                 </div>
                 <Show when={isClaudeCli()}>
                   <div class="flex items-center gap-2 shrink-0">
+                    <Show when={claudeCliVersion()}>
+                      {(version) => (
+                        <span
+                          data-testid="claude-cli-version-pill"
+                          class="text-[11px] font-mono tracking-tight text-secondary-foreground bg-surface-3 px-2 py-0.5 rounded-full border border-border"
+                        >
+                          {`claude ${version()}`}
+                        </span>
+                      )}
+                    </Show>
                     <span class="text-[11px] font-medium tracking-tight text-primary bg-primary-muted px-2.5 py-1 rounded-full border border-[color:rgba(56,189,248,0.22)]">
                       Subscription · Pro/Max
                     </span>
@@ -1854,6 +1918,19 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
                   "ring-1 ring-[color:var(--border-medium)] shadow-[var(--shadow-lg),var(--glow-primary)]":
                     isClaudeCli(),
                 }}
+                // #2006 — subtle sky-400 radial wash at the top of the
+                // claude CLI canvas. The wash sits on background-IMAGE so
+                // it composites over the existing background-color (the
+                // bg-[#090b0f] class), keeping the canvas readable while
+                // bonding the surface to the rest of the themed chrome.
+                style={
+                  isClaudeCli()
+                    ? {
+                        "background-image":
+                          "radial-gradient(ellipse at top, rgba(56, 189, 248, 0.08) 0%, transparent 60%)",
+                      }
+                    : undefined
+                }
                 role="application"
                 aria-label="Terminal"
                 data-workspace-default-focus={

--- a/src/stores/terminal.store.ts
+++ b/src/stores/terminal.store.ts
@@ -181,4 +181,24 @@ export const terminalStore = {
     exitUnlisten = null;
     setState("initialized", false);
   },
+
+  /**
+   * One-shot probe of `claude --version` (#2006). Returns the version
+   * token shown by the binary (e.g. "2.1.148"), or null if the binary
+   * is unavailable / the output isn't parseable. Cached at module
+   * scope so the IPC round-trip happens at most once per session.
+   */
+  async getClaudeCliVersion(): Promise<string | null> {
+    if (cachedClaudeVersion !== UNSET) return cachedClaudeVersion;
+    try {
+      const version = await invoke<string | null>("terminal_claude_version");
+      cachedClaudeVersion = version ?? null;
+    } catch {
+      cachedClaudeVersion = null;
+    }
+    return cachedClaudeVersion;
+  },
 };
+
+const UNSET: unique symbol = Symbol("unset");
+let cachedClaudeVersion: string | null | typeof UNSET = UNSET;

--- a/tests/unit/terminal-buffer-claude-cli.test.ts
+++ b/tests/unit/terminal-buffer-claude-cli.test.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Critical regression guard for the themed Claude Code CLI terminal pill (#2004).
+// ABOUTME: Critical regression guard for the themed Claude Code CLI terminal pill (#2004, #2006).
 // ABOUTME: Trust contract — the billing-pool label must only render when the buffer was
 // ABOUTME: spawned via `command: "claude"` (no flags), which is the interactive-pool boundary.
 
@@ -27,5 +27,50 @@ describe("TerminalBuffer — Claude Code CLI billing pill (#2004)", () => {
     // Pro/Max subscription quota — not the Agent SDK credit pool. If this string
     // drifts, users get misled about which pool their session uses.
     expect(terminalBufferTsx).toContain("Subscription · Pro/Max");
+  });
+});
+
+describe("TerminalBuffer — remaining #2004 scope items (#2006)", () => {
+  it("declares a sky-400 cursor color constant for claude threads", () => {
+    // Plain Terminal threads keep #d7dde8 (COLOR_CURSOR). Claude threads
+    // get sky-400 (#38bdf8) so the cursor matches the rest of the themed
+    // chrome. Drifting off this exact hex would silently lose the visual
+    // bond between cursor and the Subscription pill / glow ring.
+    expect(terminalBufferTsx).toMatch(/COLOR_CURSOR_CLAUDE\s*=\s*"#38bdf8"/);
+  });
+
+  it("declares a sky-400 selection overlay constant for claude threads", () => {
+    // Plain Terminal threads keep the muted blue (SELECTION_OVERLAY_FILL).
+    // Claude threads use sky-400 alpha so selection blends with the
+    // accent. The alpha must stay low (~0.25) so selected glyphs remain
+    // readable on the dark canvas.
+    expect(terminalBufferTsx).toMatch(
+      /SELECTION_OVERLAY_FILL_CLAUDE\s*=\s*"rgba\(56,\s*189,\s*248,/,
+    );
+  });
+
+  it("applies a 1.6 line-height multiplier for claude threads", () => {
+    // Default terminal convention is 1.4. The #2004 scope explicitly
+    // bumps to ~1.6 for claude threads so the JetBrains Mono body has
+    // breathing room matching the rest of the app's typography. Both
+    // the fontBoundingBox branch and the fallback must respect it.
+    expect(terminalBufferTsx).toMatch(/fontSize\s*\*\s*1\.6/);
+  });
+
+  it("renders a radial sky-400 wash on the canvas surface for claude threads", () => {
+    // The wash is CSS-only on the surface host div (not the canvas
+    // itself, which is painted by JS). Gated on isClaudeCli() so plain
+    // Terminal threads stay flat.
+    expect(terminalBufferTsx).toMatch(
+      /radial-gradient\([^)]*rgba\(56,\s*189,\s*248,/,
+    );
+  });
+
+  it("renders a version pill with copy 'claude X.Y.Z' for claude threads", () => {
+    // The version pill sits next to the Subscription pill in the
+    // header. Copy starts with the literal "claude " so users can
+    // tell which interpreter version their thread bound to.
+    expect(terminalBufferTsx).toMatch(/data-testid="claude-cli-version-pill"/);
+    expect(terminalBufferTsx).toMatch(/`claude \$\{[^}]+\}`/);
   });
 });


### PR DESCRIPTION
## Summary

Closes #2006 — ships the 5 scope items from #2004 that PR #2005 left out.
All themed chrome stays branched on `command === "claude"` so plain Terminal
threads keep the existing minimal header.

- **Sky-400 cursor** for claude threads (paint reads new `COLOR_CURSOR_CLAUDE`).
- **Sky-400 selection overlay** at 0.25 alpha (lower than the muted-blue default's 0.4 so brighter hue keeps glyphs readable).
- **1.6 line-height** on canvas cells for claude threads — overrides both the fontBoundingBox branch and the 1.4 fallback. Plain Terminal threads stay on the existing rule.
- **Radial sky-400 wash** on the canvas surface div via inline `background-image` (composites over the existing `bg-[#090b0f]` background-color).
- **`claude X.Y.Z` version pill** alongside the Subscription pill. New one-shot Tauri command `terminal_claude_version` shells `claude --version`, parses the first whitespace token, returns `Option<String>`. Cached at module scope in `terminalStore` so the IPC round-trip runs at most once per session. Pill renders behind `<Show when={claudeCliVersion()}>` so probe failure (missing binary, parse miss) silently omits the pill without breaking the Subscription pill or the rest of the chrome.

## Audit (issue ↔ fix ↔ impact)

| #2006 item | Pre-PR state | Fix | Impact when isClaudeCli() |
|---|---|---|---|
| 1.6 line-height | `Math.ceil(fontSize * 1.4)` (fallback only); fontBoundingBox path gives ~1.2-1.3 | `measureCell` branches on `isClaudeCli()`, returns `Math.ceil(fontSize * 1.6)` for claude; non-claude unchanged. `createEffect` tracks `isClaudeCli` so thread-switch re-measures. | +~5px row height at 14px font for claude threads |
| Sky-400 cursor | `COLOR_CURSOR = "#d7dde8"` only | New `COLOR_CURSOR_CLAUDE = "#38bdf8"` (and `_FG_CLAUDE`); cursor paint conditionally selects. `createEffect` tracks `isClaudeCli` for repaint on thread switch. | Cursor block matches Subscription pill + ring/glow |
| Sky-400 selection | `SELECTION_OVERLAY_FILL = "rgba(80, 130, 200, 0.4)"` only | New `SELECTION_OVERLAY_FILL_CLAUDE = "rgba(56, 189, 248, 0.25)"`; selection paint conditionally selects | Selected text bonds to themed accent |
| Radial wash | Not implemented | Inline `style.background-image` on surface div, gated on `isClaudeCli()` | Soft sky-400 ellipse at canvas top (~8% alpha, fades to transparent at 60%) |
| Version pill | Not implemented | New Tauri cmd → cached store helper → memo + JSX pill | `claude 2.1.148` pill next to Subscription pill |

## Test coverage

`tests/unit/terminal-buffer-claude-cli.test.ts` extended from 2 → 7 file-string
assertions. Each new assertion pins one of the previously-unprotected scope items:

- gated cursor color constant (`#38bdf8`)
- gated selection color constant (sky-400 alpha)
- 1.6 line-height multiplier
- radial sky-400 wash on the surface
- version pill JSX (`data-testid` + ``claude ${...}`` literal)

Existing assertions (predicate + Subscription pill copy) preserved.

## Test plan

- [x] `./node_modules/.bin/vitest run tests/unit/terminal-buffer-claude-cli.test.ts` — 7/7 pass
- [x] `./node_modules/.bin/vitest run` — 1397/1397 pass (was 1392 before)
- [x] `./node_modules/.bin/biome check` on changed files — clean
- [x] `cargo check --lib` in `src-tauri/` — clean (4 pre-existing unrelated warnings)
- [ ] `pnpm tauri dev` smoke: open Sidebar → "Claude Code CLI" → cursor + selection sky-400, wash visible at top, version pill renders next to Subscription pill, line spacing visibly larger
- [ ] `pnpm tauri dev` smoke: open Sidebar → "Terminal" → unchanged minimal chrome (no cursor recolor, no wash, no pill)
- [ ] `pnpm tauri dev` smoke: switch from a Claude CLI thread to a plain Terminal thread → cell metrics re-measure (no leftover 1.6 spacing) and cursor/selection switch palettes

## Files changed

- `src/components/terminal/TerminalBuffer.tsx` — paint gates, surface style, header pill JSX, version signal
- `src/stores/terminal.store.ts` — `getClaudeCliVersion()` helper + module-scope cache
- `src-tauri/src/terminal.rs` — `terminal_claude_version` Tauri command
- `src-tauri/src/lib.rs` — register command in invoke_handler
- `tests/unit/terminal-buffer-claude-cli.test.ts` — 5 new regression assertions

## Related

- Closes #2006
- Follow-up to #2005 / #2004

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
