### PR TITLE
fix(terminal): close #2008 — augment PATH for Claude CLI spawn

### DIFF
--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -348,7 +348,7 @@ pub fn configure_embedded_runtime(app: &AppHandle) -> EmbeddedRuntimePaths {
     paths
 }
 
-fn extend_path_with_common_bins(current_path: &str, path_separator: &str) -> String {
+pub(crate) fn extend_path_with_common_bins(current_path: &str, path_separator: &str) -> String {
     let mut entries: Vec<String> = current_path
         .split(path_separator)
         .filter(|p| !p.is_empty())

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -1923,6 +1923,12 @@ pub fn terminal_create_buffer(
     }
     builder.env("TERM", "xterm-256color");
     builder.env("COLORTERM", "truecolor");
+    // GUI-launched Tauri processes inherit a PATH that's missing the
+    // CLI install dirs (`~/.local/bin`, `~/.claude/bin`, Homebrew),
+    // so a `claude` thread would print "Native installation exists
+    // but ~/.local/bin is not in your PATH". Hand the child the same
+    // augmented PATH provider workers get (#2008).
+    builder.env("PATH", augmented_path_for_terminal());
 
     let mut child = pair
         .slave
@@ -2586,6 +2592,22 @@ fn build_command(initial_command: Option<&str>) -> CommandBuilder {
     }
 }
 
+/// PATH for terminal child processes — the parent process PATH plus
+/// the CLI install dirs (`~/.claude/bin`, `~/.local/bin`, Homebrew,
+/// `%APPDATA%\npm`) a GUI-launched Tauri app typically misses.
+///
+/// Single source of truth for both the PTY spawn and the `claude
+/// --version` probe so a regression in one surface can't desync from
+/// the other.
+fn augmented_path_for_terminal() -> String {
+    #[cfg(target_os = "windows")]
+    let path_separator = ";";
+    #[cfg(not(target_os = "windows"))]
+    let path_separator = ":";
+    let current = env::var("PATH").unwrap_or_default();
+    crate::embedded_runtime::extend_path_with_common_bins(&current, path_separator)
+}
+
 fn default_shell() -> String {
     if cfg!(target_os = "windows") {
         env::var("COMSPEC").unwrap_or_else(|_| "powershell.exe".to_string())
@@ -2640,6 +2662,7 @@ fn unix_millis() -> i64 {
 #[tauri::command]
 pub fn terminal_claude_version() -> Option<String> {
     let output = std::process::Command::new("claude")
+        .env("PATH", augmented_path_for_terminal())
         .arg("--version")
         .output()
         .ok()?;
@@ -2673,6 +2696,36 @@ mod tests {
     #[test]
     fn empty_cwd_is_none() {
         assert!(normalize_cwd(Some(" ".to_string())).unwrap().is_none());
+    }
+
+    /// Regression guard for #2008. Both the PTY spawn (so the in-PTY
+    /// `claude` CLI stops printing "Native installation exists but
+    /// ~/.local/bin is not in your PATH") and the `terminal_claude_version`
+    /// probe (so the header version pill from #2007 renders instead of
+    /// silently `None`-ing) rely on this helper to inject the common bin
+    /// directories a GUI-launched Tauri process is missing.
+    #[test]
+    fn augmented_path_for_terminal_includes_common_bins() {
+        let path = augmented_path_for_terminal();
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        {
+            let home = std::env::var("HOME").expect("HOME must be set for this test");
+            let expected = format!("{}/.local/bin", home);
+            assert!(
+                path.split(':').any(|p| p == expected),
+                "expected {expected} to be in augmented PATH, got: {path}",
+            );
+        }
+        #[cfg(target_os = "windows")]
+        {
+            let userprofile = std::env::var("USERPROFILE")
+                .expect("USERPROFILE must be set for this test");
+            let expected = format!(r"{}\.claude\bin", userprofile);
+            assert!(
+                path.split(';').any(|p| p == expected),
+                "expected {expected} to be in augmented PATH, got: {path}",
+            );
+        }
     }
 
     fn cell_at(snap: &GridSnapshot, row: u16, col: u16) -> char {


### PR DESCRIPTION
## Summary

Closes #2008 — Claude Code CLI inside the Seren terminal thread was printing a `Native installation exists but ~/.local/bin is not in your PATH` warning, and the `claude X.Y.Z` version pill from #2007 was silently absent from the header. Both surfaces share one root cause: a GUI-launched Tauri process on macOS inherits a PATH missing the CLI install dirs (`~/.local/bin`, `~/.claude/bin`, Homebrew), so the in-PTY CLI nags and the one-shot `claude --version` probe returns `Err` → `<Show when={claudeCliVersion()}>` correctly suppresses the pill.

Fix is to hand both spawn sites the same augmented PATH provider workers already get from `embedded_runtime::extend_path_with_common_bins` — promoted from `fn` to `pub(crate) fn` so `terminal.rs` can reuse it instead of duplicating the bin list a third time.

## Changes

- `src-tauri/src/embedded_runtime.rs` — `extend_path_with_common_bins` is now `pub(crate)`. No behavior change.
- `src-tauri/src/terminal.rs` —
  - New `augmented_path_for_terminal()` helper. Single source of truth: reads parent PATH, delegates to the existing common-bins extender.
  - `create_terminal` PTY builder sets `PATH` on the child alongside the existing `TERM` / `COLORTERM` env.
  - `terminal_claude_version` sets `PATH` on its `Command` before `--version`.
- `src-tauri/src/terminal.rs` tests — one regression assertion (`augmented_path_for_terminal_includes_common_bins`) that fails the build if the helper stops appending `~/.local/bin` (or `\.claude\bin` on Windows). Guards both fixes via the shared helper — no duplicate per-site assertions.

## Why this helper instead of `get_embedded_path()`

`embedded_runtime::get_embedded_path()` already returns a fully-augmented PATH for provider children, but it also prepends the bundled Node runtime. That's correct for ACP/MCP children but wrong for the user-facing terminal — a user typing `node` should get *their* node, not our sandboxed one. `extend_path_with_common_bins` is the right layer: just the missing system bins, none of our embedded tooling.

## Test plan

- [x] `cargo test --lib terminal::tests::augmented_path` — passes
- [x] `cargo test --lib` — full Rust suite passes
- [x] `cargo check --lib` — clean (pre-existing dead-code warnings only)
- [ ] `pnpm tauri dev` smoke: open the Claude Code terminal thread → no `~/.local/bin is not in your PATH` warning, `claude X.Y.Z` pill renders next to the Subscription pill
- [ ] `pnpm tauri dev` smoke: plain Terminal thread still launches normally (PATH augmentation is additive, doesn't break `$SHELL` profile loading)
