### PR TITLE
fix(terminal): close #2012 — emit CSI Z for Shift+Tab

### DIFF
--- a/src/components/terminal/TerminalBuffer.tsx
+++ b/src/components/terminal/TerminalBuffer.tsx
@@ -22,6 +22,7 @@ import {
 import { appearanceState } from "@/stores/appearance.store";
 import { terminalStore } from "@/stores/terminal.store";
 import { threadStore } from "@/stores/thread.store";
+import { encodeKeyEventToBytes } from "./keyEncoding";
 
 interface GridCell {
   ch: number;
@@ -1525,11 +1526,16 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
 
   /**
    * Translate a KeyboardEvent into the byte sequence the PTY expects
-   * and write it to the active buffer. Covers printable chars, Enter,
-   * Backspace, Tab, Esc, arrow keys (DECCKM-aware), Home/End/PageUp/
-   * PageDown/Delete, Ctrl+letter chords, and Ctrl+C via the signal
-   * API. Modifier-rich combinations (Shift+Arrow etc.) and the Kitty
-   * keyboard protocol are not yet handled.
+   * and write it to the active buffer. The pure encoding table lives
+   * in `./keyEncoding`; this handler only owns the two side-effecting
+   * branches the encoder can't express — the clipboard copy chord and
+   * the Ctrl+C SIGINT path — and the snapToBottom + write plumbing.
+   *
+   * Modifier+arrow combinations (Shift+Up, Ctrl+Up, etc.) still fall
+   * through to plain arrow encoding — the xterm modifyOtherKeys / CSI
+   * 1;mod sequences are not yet generated. Apps that key off
+   * modifier+arrow (tmux pane resize, some vim plugins) will see only
+   * the bare arrow.
    */
   const handleKeyDown = async (event: KeyboardEvent) => {
     const current = buffer();
@@ -1567,79 +1573,9 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
       return;
     }
 
-    // Other Ctrl-letter chords map to control bytes 0x01-0x1A.
-    if (event.ctrlKey && k.length === 1 && /[a-zA-Z]/.test(k)) {
-      event.preventDefault();
-      snapToBottom();
-      const code = k.toUpperCase().charCodeAt(0) - 64;
-      await terminalStore.write(id, String.fromCharCode(code));
-      return;
-    }
-
-    // Arrow keys + Home/End honor DECSET 1 (DECCKM application cursor
-    // keys) when the backend has it on. vim sets DECCKM as part of
-    // its alt-screen entry; without this branch its cursor keys do
-    // nothing. PageUp/PageDown/Delete are xterm tilde sequences
-    // (`\x1b[5~`, `\x1b[6~`, `\x1b[3~`) and have no app-mode variants
-    // in standard xterm, so they stay constant below.
-    //
-    // Modifier+arrow (Shift+Up, Ctrl+Up, etc.) currently falls through
-    // to plain arrow encoding - the xterm modifyOtherKeys / CSI 1;mod
-    // sequences (e.g. `\x1b[1;5A` for Ctrl+Up) are not yet generated.
-    // Apps that key off modifier+arrow (tmux pane resize, some vim
-    // plugins) will see only the bare arrow.
-    const decckm = grid()?.cursorKeysApp ?? false;
-    const arrowPrefix = decckm ? "\x1bO" : "\x1b[";
-
-    let bytes: string | null = null;
-    switch (k) {
-      case "Enter":
-        bytes = "\r";
-        break;
-      case "Backspace":
-        bytes = "\x7f";
-        break;
-      case "Tab":
-        bytes = "\t";
-        break;
-      case "Escape":
-        bytes = "\x1b";
-        break;
-      case "ArrowUp":
-        bytes = `${arrowPrefix}A`;
-        break;
-      case "ArrowDown":
-        bytes = `${arrowPrefix}B`;
-        break;
-      case "ArrowRight":
-        bytes = `${arrowPrefix}C`;
-        break;
-      case "ArrowLeft":
-        bytes = `${arrowPrefix}D`;
-        break;
-      case "Home":
-        bytes = decckm ? "\x1bOH" : "\x1b[H";
-        break;
-      case "End":
-        bytes = decckm ? "\x1bOF" : "\x1b[F";
-        break;
-      case "PageUp":
-        bytes = "\x1b[5~";
-        break;
-      case "PageDown":
-        bytes = "\x1b[6~";
-        break;
-      case "Delete":
-        bytes = "\x1b[3~";
-        break;
-      default:
-        // Single printable character (may be multi-byte UTF-8 once
-        // serialized; terminal_write takes a string).
-        if (k.length === 1 && !event.metaKey && !event.altKey) {
-          bytes = k;
-        }
-        break;
-    }
+    const bytes = encodeKeyEventToBytes(event, {
+      cursorKeysApp: grid()?.cursorKeysApp ?? false,
+    });
     if (bytes !== null) {
       event.preventDefault();
       snapToBottom();

--- a/src/components/terminal/keyEncoding.ts
+++ b/src/components/terminal/keyEncoding.ts
@@ -1,0 +1,95 @@
+// ABOUTME: Pure key→bytes encoder for the Claude Code CLI terminal — the wire-level
+// ABOUTME: contract with the spawned subprocess. Stays free of DOM, store, and Tauri.
+
+/**
+ * Minimum surface of a DOM KeyboardEvent the encoder reads. Tests pass plain
+ * objects; the React/Solid handler passes the live event directly.
+ */
+export type KeyEventSnapshot = Pick<
+  KeyboardEvent,
+  "key" | "shiftKey" | "ctrlKey" | "altKey" | "metaKey"
+>;
+
+export interface KeyEncodingOptions {
+  /**
+   * DECCKM (DECSET 1) — when on, arrows and Home/End emit SS3 sequences
+   * (`\x1bO…`) instead of CSI (`\x1b[…`). Vim's alt screen turns this on as
+   * part of `:set termguicolors`-era init; without it vim cursor keys send
+   * `\x1b[A` and the editor treats them as literal Esc sequences.
+   */
+  cursorKeysApp: boolean;
+}
+
+/**
+ * Translate a single KeyboardEvent into the byte sequence the PTY expects.
+ * Returns `null` when the event should be ignored by the writer (the caller
+ * may still handle it via a separate path — copy chord, Ctrl+C signal, etc).
+ *
+ * Side-effecting branches (clipboard, SIGINT) live in the component handler
+ * and run *before* this function is consulted — they are intentionally not
+ * encoded here so this module can be tested in isolation.
+ */
+export function encodeKeyEventToBytes(
+  event: KeyEventSnapshot,
+  options: KeyEncodingOptions,
+): string | null {
+  const k = event.key;
+
+  // Ctrl-letter chords map to control bytes 0x01–0x1A (Ctrl+A → SOH, Ctrl+Z →
+  // SUB). The Ctrl+C SIGINT path is handled by the component handler before
+  // this function is called, so we never see it here.
+  if (event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey) {
+    if (k.length === 1 && /[a-zA-Z]/.test(k)) {
+      return String.fromCharCode(k.toUpperCase().charCodeAt(0) - 64);
+    }
+  }
+
+  const arrowPrefix = options.cursorKeysApp ? "\x1bO" : "\x1b[";
+
+  switch (k) {
+    case "Enter":
+      return "\r";
+    case "Backspace":
+      return "\x7f";
+    case "Tab":
+      // Shift+Tab → CSI Z (terminfo `kcbt`, xterm reverse-tab). Claude Code
+      // CLI's permission prompts and option pickers reverse-cycle on this
+      // exact byte sequence. Ctrl+Tab / Alt+Tab fall through to null because
+      // the OS / browser typically owns those chords and stealing them would
+      // break window/pane switchers users rely on.
+      if (event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey) {
+        return "\x1b[Z";
+      }
+      if (event.ctrlKey || event.altKey || event.metaKey) {
+        return null;
+      }
+      return "\t";
+    case "Escape":
+      return "\x1b";
+    case "ArrowUp":
+      return `${arrowPrefix}A`;
+    case "ArrowDown":
+      return `${arrowPrefix}B`;
+    case "ArrowRight":
+      return `${arrowPrefix}C`;
+    case "ArrowLeft":
+      return `${arrowPrefix}D`;
+    case "Home":
+      return options.cursorKeysApp ? "\x1bOH" : "\x1b[H";
+    case "End":
+      return options.cursorKeysApp ? "\x1bOF" : "\x1b[F";
+    case "PageUp":
+      return "\x1b[5~";
+    case "PageDown":
+      return "\x1b[6~";
+    case "Delete":
+      return "\x1b[3~";
+    default:
+      // Single printable character. Meta / Alt are excluded so OS chords
+      // (Cmd+W, Alt+F, etc.) don't leak into the PTY as raw text.
+      if (k.length === 1 && !event.metaKey && !event.altKey) {
+        return k;
+      }
+      return null;
+  }
+}

--- a/tests/unit/terminal-key-encoding.test.ts
+++ b/tests/unit/terminal-key-encoding.test.ts
@@ -1,0 +1,119 @@
+// ABOUTME: Wire-level contract for the Claude Code CLI terminal's keystroke encoder (#2012).
+// ABOUTME: Every byte sequence here is what the spawned CLI actually reads on stdin — if a
+// ABOUTME: row drifts, raw-mode TUIs (Claude Code menus, vim, less) silently misbehave.
+
+import { describe, expect, it } from "vitest";
+import {
+  type KeyEventSnapshot,
+  encodeKeyEventToBytes,
+} from "../../src/components/terminal/keyEncoding";
+
+function key(overrides: Partial<KeyEventSnapshot> & { key: string }): KeyEventSnapshot {
+  return {
+    shiftKey: false,
+    ctrlKey: false,
+    altKey: false,
+    metaKey: false,
+    ...overrides,
+  };
+}
+
+describe("encodeKeyEventToBytes — Tab and Shift+Tab (#2012)", () => {
+  it("plain Tab sends a literal \\t — preserves forward-completion", () => {
+    expect(encodeKeyEventToBytes(key({ key: "Tab" }), { cursorKeysApp: false })).toBe("\t");
+  });
+
+  it("Shift+Tab sends CSI Z (\\x1b[Z) — the xterm reverse-tab Claude menus need", () => {
+    // terminfo capability `kcbt`. Without this byte sequence Claude Code CLI's
+    // reverse-cycle in permission prompts / option pickers is unreachable.
+    expect(
+      encodeKeyEventToBytes(key({ key: "Tab", shiftKey: true }), { cursorKeysApp: false }),
+    ).toBe("\x1b[Z");
+  });
+
+  it("Ctrl+Tab and Alt+Tab fall through to null — OS/browser owns those chords", () => {
+    expect(encodeKeyEventToBytes(key({ key: "Tab", ctrlKey: true }), { cursorKeysApp: false })).toBeNull();
+    expect(encodeKeyEventToBytes(key({ key: "Tab", altKey: true }), { cursorKeysApp: false })).toBeNull();
+  });
+});
+
+describe("encodeKeyEventToBytes — pre-existing encoding table (regression guard)", () => {
+  const opts = { cursorKeysApp: false };
+
+  it("Enter → \\r", () => {
+    expect(encodeKeyEventToBytes(key({ key: "Enter" }), opts)).toBe("\r");
+  });
+
+  it("Backspace → \\x7f (DEL, not \\b — bash and readline expect this)", () => {
+    expect(encodeKeyEventToBytes(key({ key: "Backspace" }), opts)).toBe("\x7f");
+  });
+
+  it("Escape → \\x1b", () => {
+    expect(encodeKeyEventToBytes(key({ key: "Escape" }), opts)).toBe("\x1b");
+  });
+
+  it("PageUp / PageDown / Delete → xterm tilde sequences", () => {
+    expect(encodeKeyEventToBytes(key({ key: "PageUp" }), opts)).toBe("\x1b[5~");
+    expect(encodeKeyEventToBytes(key({ key: "PageDown" }), opts)).toBe("\x1b[6~");
+    expect(encodeKeyEventToBytes(key({ key: "Delete" }), opts)).toBe("\x1b[3~");
+  });
+});
+
+describe("encodeKeyEventToBytes — DECCKM cursor key application mode", () => {
+  it("arrows emit CSI sequences when cursorKeysApp=false (normal mode)", () => {
+    const opts = { cursorKeysApp: false };
+    expect(encodeKeyEventToBytes(key({ key: "ArrowUp" }), opts)).toBe("\x1b[A");
+    expect(encodeKeyEventToBytes(key({ key: "ArrowDown" }), opts)).toBe("\x1b[B");
+    expect(encodeKeyEventToBytes(key({ key: "ArrowRight" }), opts)).toBe("\x1b[C");
+    expect(encodeKeyEventToBytes(key({ key: "ArrowLeft" }), opts)).toBe("\x1b[D");
+    expect(encodeKeyEventToBytes(key({ key: "Home" }), opts)).toBe("\x1b[H");
+    expect(encodeKeyEventToBytes(key({ key: "End" }), opts)).toBe("\x1b[F");
+  });
+
+  it("arrows emit SS3 sequences when cursorKeysApp=true (DECSET 1 — vim's alt screen)", () => {
+    const opts = { cursorKeysApp: true };
+    expect(encodeKeyEventToBytes(key({ key: "ArrowUp" }), opts)).toBe("\x1bOA");
+    expect(encodeKeyEventToBytes(key({ key: "ArrowDown" }), opts)).toBe("\x1bOB");
+    expect(encodeKeyEventToBytes(key({ key: "ArrowRight" }), opts)).toBe("\x1bOC");
+    expect(encodeKeyEventToBytes(key({ key: "ArrowLeft" }), opts)).toBe("\x1bOD");
+    expect(encodeKeyEventToBytes(key({ key: "Home" }), opts)).toBe("\x1bOH");
+    expect(encodeKeyEventToBytes(key({ key: "End" }), opts)).toBe("\x1bOF");
+  });
+});
+
+describe("encodeKeyEventToBytes — Ctrl-letter chords map to control bytes 0x01–0x1A", () => {
+  const opts = { cursorKeysApp: false };
+
+  it("Ctrl+A → 0x01, Ctrl+Z → 0x1A — readline word-nav and SIGTSTP", () => {
+    expect(encodeKeyEventToBytes(key({ key: "a", ctrlKey: true }), opts)).toBe("\x01");
+    expect(encodeKeyEventToBytes(key({ key: "z", ctrlKey: true }), opts)).toBe("\x1a");
+  });
+
+  it("Ctrl+L → 0x0C — common clear-screen chord", () => {
+    expect(encodeKeyEventToBytes(key({ key: "l", ctrlKey: true }), opts)).toBe("\x0c");
+  });
+
+  it("upper-case letter with Ctrl produces the same control byte — case-insensitive", () => {
+    expect(encodeKeyEventToBytes(key({ key: "A", ctrlKey: true }), opts)).toBe("\x01");
+  });
+});
+
+describe("encodeKeyEventToBytes — printable characters and out-of-scope keys", () => {
+  const opts = { cursorKeysApp: false };
+
+  it("single printable char passes through", () => {
+    expect(encodeKeyEventToBytes(key({ key: "a" }), opts)).toBe("a");
+    expect(encodeKeyEventToBytes(key({ key: "?" }), opts)).toBe("?");
+  });
+
+  it("printable char with metaKey or altKey is null — handler routes those elsewhere or ignores them", () => {
+    expect(encodeKeyEventToBytes(key({ key: "a", metaKey: true }), opts)).toBeNull();
+    expect(encodeKeyEventToBytes(key({ key: "a", altKey: true }), opts)).toBeNull();
+  });
+
+  it("unknown / multi-char keys (F1, Shift, dead keys) return null", () => {
+    expect(encodeKeyEventToBytes(key({ key: "F1" }), opts)).toBeNull();
+    expect(encodeKeyEventToBytes(key({ key: "Shift" }), opts)).toBeNull();
+    expect(encodeKeyEventToBytes(key({ key: "Dead" }), opts)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #2012 — the Claude Code CLI terminal swallowed Shift+Tab, so reverse-cycle in permission prompts / `/login` chooser / slash-command pickers was unreachable from Seren Desktop.
- `TerminalBuffer.tsx:handleKeyDown`'s Tab branch sent literal `\t` regardless of `event.shiftKey`; the xterm reverse-tab sequence `\x1b[Z` (CSI Z, terminfo `kcbt`) never reached the spawned CLI.
- Extracts the key→bytes table into `src/components/terminal/keyEncoding.ts` so the wire-level PTY contract is unit-testable without driving the SolidJS component. The two side-effecting branches the encoder can't express — the clipboard copy chord and the Ctrl+C SIGINT path — stay in `handleKeyDown` and still run before the encoder is consulted.
- Adds the Shift+Tab → `\x1b[Z` branch (gated on no other modifiers, since Ctrl+Tab / Alt+Tab belong to the OS/browser). Side benefit: Ctrl+Tab and Alt+Tab now return `null` at the encoder instead of leaking a stray `\t` to the PTY — matches xterm's default-mode behavior.
- 15 new behavior tests pin the full encoding table (Enter, Backspace, Escape, Tab, Shift+Tab, arrows in both DECCKM modes, Home/End, PageUp/PageDown/Delete, Ctrl-letter chords, printable chars). The next regression surfaces at compile time, not via a user report.

## Audit (re-confirmed end-to-end)

| Path | Before | After |
| ---- | ------ | ----- |
| Plain Tab | `\t` | `\t` (unchanged) |
| Shift+Tab | `\t` — **bug** | `\x1b[Z` — fixed |
| Ctrl+Tab / Alt+Tab | stray `\t` to PTY | `null` (no byte; matches xterm) |
| Enter / Backspace / Escape / arrows / Home / End / PageUp / PageDown / Delete / Ctrl-letter / printable | identical | identical (verified by tests) |
| Copy chord (Cmd+C / Ctrl+Shift+C) | clipboard | clipboard (handler branch unchanged) |
| Ctrl+C (no shift) | SIGINT | SIGINT (handler branch unchanged) |

## Out of scope (filed as needed if surfaced)

- Modifier+arrow → xterm CSI 1;mod sequences. Already documented YAGNI gap; Claude Code CLI menus don't depend on them.
- Kitty keyboard protocol.
- Alt+Backspace word-delete (`\x1b\x7f`).

## Test plan

- [x] `pnpm vitest run tests/unit/terminal-key-encoding.test.ts` — 15/15 pass.
- [x] `pnpm vitest run tests/unit/terminal-buffer-claude-cli.test.ts` — 8/8 pass (pre-existing themed-pill guards still hold post-refactor).
- [x] `pnpm vitest run` — full suite 191 files / 1413 tests pass.
- [x] `biome check` clean on touched `src/` files.
- [ ] Manual: open a Claude Code CLI thread, trigger an option-cycle menu (permission prompt or `/login`), confirm Shift+Tab reverse-cycles.

Closes #2012.
