### PR TITLE
feat(orchestrator): blend community prior into trust ranking

### DIFF
--- a/src-tauri/src/orchestrator/eval.rs
+++ b/src-tauri/src/orchestrator/eval.rs
@@ -1,8 +1,9 @@
 // ABOUTME: Eval signal service for collecting satisfaction feedback.
 // ABOUTME: Queues feature vectors for batch sync to the Gateway API.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -29,6 +30,119 @@ pub struct EvalSignal {
 }
 
 const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
+
+/// Aggregate Beta posterior for a (task_type, model_id) pair.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CommunityPrior {
+    pub alpha: f64,
+    pub beta: f64,
+    pub sample_size: u64,
+}
+
+impl CommunityPrior {
+    pub(crate) fn is_valid(&self) -> bool {
+        self.alpha.is_finite() && self.beta.is_finite() && self.alpha > 0.0 && self.beta > 0.0
+    }
+}
+
+/// Fetch the aggregate community prior for one (task_type, model_id) pair.
+///
+/// This is best-effort by design: any timeout, network failure, non-success
+/// response, or malformed payload returns `None` so routing can continue with
+/// the local posterior only.
+pub async fn fetch_community_prior(
+    auth_token: &str,
+    task_type: &str,
+    model_id: &str,
+    timeout: Duration,
+) -> Option<CommunityPrior> {
+    let client = reqwest::Client::new();
+    fetch_community_prior_with_client(&client, auth_token, task_type, model_id, timeout).await
+}
+
+/// Fetch community priors for a candidate model set in parallel.
+pub async fn fetch_community_priors(
+    auth_token: &str,
+    task_type: &str,
+    model_ids: &[String],
+    timeout: Duration,
+) -> HashMap<String, CommunityPrior> {
+    let futures = model_ids.iter().cloned().map(|model_id| {
+        let token = auth_token.to_string();
+        let task_type = task_type.to_string();
+        async move {
+            fetch_community_prior(&token, &task_type, &model_id, timeout)
+                .await
+                .map(|prior| (model_id, prior))
+        }
+    });
+
+    futures::future::join_all(futures)
+        .await
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+async fn fetch_community_prior_with_client(
+    client: &reqwest::Client,
+    auth_token: &str,
+    task_type: &str,
+    model_id: &str,
+    timeout: Duration,
+) -> Option<CommunityPrior> {
+    let request = async {
+        let url = format!(
+            "{}/eval/community-prior?task_type={}&model_id={}",
+            GATEWAY_BASE_URL,
+            urlencoding::encode(task_type),
+            urlencoding::encode(model_id)
+        );
+        let response = client.get(url).bearer_auth(auth_token).send().await.ok()?;
+
+        if response.status() == reqwest::StatusCode::NO_CONTENT
+            || response.status() == reqwest::StatusCode::NOT_FOUND
+        {
+            return None;
+        }
+
+        if !response.status().is_success() {
+            log::debug!(
+                "[eval] Community prior fetch returned {} for task_type={} model_id={}",
+                response.status(),
+                task_type,
+                model_id
+            );
+            return None;
+        }
+
+        let value = response.json::<serde_json::Value>().await.ok()?;
+        parse_community_prior(value).filter(CommunityPrior::is_valid)
+    };
+
+    match tokio::time::timeout(timeout, request).await {
+        Ok(prior) => prior,
+        Err(_) => {
+            log::debug!(
+                "[eval] Community prior fetch timed out for task_type={} model_id={}",
+                task_type,
+                model_id
+            );
+            None
+        }
+    }
+}
+
+fn parse_community_prior(value: serde_json::Value) -> Option<CommunityPrior> {
+    serde_json::from_value::<CommunityPrior>(value.clone())
+        .ok()
+        .or_else(|| {
+            value
+                .get("data")
+                .cloned()
+                .and_then(|data| serde_json::from_value::<CommunityPrior>(data).ok())
+        })
+}
 
 /// Managed state for the eval signal queue.
 pub struct EvalState {

--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -5,6 +5,7 @@ use log;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::{Mutex, mpsc, watch};
 use uuid::Uuid;
@@ -25,6 +26,8 @@ use super::types::{
     TransitionEvent, UserCapabilities, WorkerEvent, WorkerType,
 };
 use super::worker::Worker;
+
+const COMMUNITY_PRIOR_TIMEOUT_MS: u64 = 200;
 
 // =============================================================================
 // Orchestrator State
@@ -99,6 +102,88 @@ fn get_fallback_model(current_model: &str) -> Option<&str> {
         // Haiku has no faster fallback
         _ => None,
     }
+}
+
+async fn get_rankings_for_task(
+    app: &AppHandle,
+    task_type: &str,
+    available_models: &[String],
+    cost_weight: f64,
+) -> Vec<trust::ModelRanking> {
+    if available_models.is_empty() {
+        return vec![];
+    }
+
+    let app_for_db = app.clone();
+    let task_type_for_db = task_type.to_string();
+    let models_for_db = available_models.to_vec();
+    let models_for_fetch = available_models.to_vec();
+    let task_type_for_fetch = task_type.to_string();
+
+    let local_stats = tauri::async_runtime::spawn_blocking(move || {
+        let conn = crate::services::database::init_db(&app_for_db).ok()?;
+        Some(trust::load_model_stats(
+            &conn,
+            &task_type_for_db,
+            &models_for_db,
+        ))
+    });
+
+    let community_priors =
+        fetch_community_priors_for_rankings(app.clone(), task_type_for_fetch, models_for_fetch);
+    let (stats_result, community_priors) = tokio::join!(local_stats, community_priors);
+    let stats = match stats_result {
+        Ok(Some(stats)) => stats,
+        _ => return vec![],
+    };
+
+    if !community_priors.is_empty() {
+        log::debug!(
+            "[Orchestrator] Applying {} community prior(s) for task_type={}",
+            community_priors.len(),
+            task_type
+        );
+    }
+
+    let mut rng = rand::rng();
+    let community_priors = if community_priors.is_empty() {
+        None
+    } else {
+        Some(&community_priors)
+    };
+    trust::sample_model_rankings(
+        &mut rng,
+        available_models,
+        &stats,
+        community_priors,
+        cost_weight,
+    )
+}
+
+async fn fetch_community_priors_for_rankings(
+    app: AppHandle,
+    task_type: String,
+    available_models: Vec<String>,
+) -> HashMap<String, super::eval::CommunityPrior> {
+    let token = match crate::auth::get_access_token(&app) {
+        Ok(token) => token,
+        Err(err) => {
+            log::debug!(
+                "[Orchestrator] Skipping community prior fetch for task_type={}: {}",
+                task_type,
+                err
+            );
+            return HashMap::new();
+        }
+    };
+
+    super::eval::fetch_community_priors(
+        &token,
+        &task_type,
+        &available_models,
+        Duration::from_millis(COMMUNITY_PRIOR_TIMEOUT_MS),
+    )
+    .await
 }
 
 // =============================================================================
@@ -288,28 +373,13 @@ async fn execute_single_task(
 ) -> Result<(), String> {
     // Compute Thompson sampling rankings before routing
     let mut capabilities = capabilities.clone();
-    let app_for_db = app.clone();
-    let task_type_for_db = subtask.classification.task_type.clone();
-    let available_models = capabilities.available_models.clone();
-
-    let (rankings, _) = tauri::async_runtime::spawn_blocking(move || {
-        match crate::services::database::init_db(&app_for_db) {
-            Ok(conn) => {
-                let mut rng = rand::rng();
-                let rankings = trust::get_model_rankings(
-                    &conn,
-                    &mut rng,
-                    &task_type_for_db,
-                    &available_models,
-                    0.1,
-                );
-                (rankings, true)
-            }
-            Err(_) => (vec![], false),
-        }
-    })
-    .await
-    .unwrap_or((vec![], false));
+    let rankings = get_rankings_for_task(
+        app,
+        &subtask.classification.task_type,
+        &capabilities.available_models,
+        0.1,
+    )
+    .await;
 
     capabilities.model_rankings = rankings
         .iter()
@@ -915,27 +985,13 @@ async fn execute_multi_task(
         for subtask in layer {
             // Compute rankings for this subtask's task_type
             let mut subtask_caps = capabilities.clone();
-            let app_for_rank = app.clone();
-            let task_type_for_rank = subtask.classification.task_type.clone();
-            let models_for_rank = subtask_caps.available_models.clone();
-
-            let rankings = tauri::async_runtime::spawn_blocking(move || {
-                match crate::services::database::init_db(&app_for_rank) {
-                    Ok(conn) => {
-                        let mut rng = rand::rng();
-                        trust::get_model_rankings(
-                            &conn,
-                            &mut rng,
-                            &task_type_for_rank,
-                            &models_for_rank,
-                            0.1,
-                        )
-                    }
-                    Err(_) => vec![],
-                }
-            })
-            .await
-            .unwrap_or_default();
+            let rankings = get_rankings_for_task(
+                app,
+                &subtask.classification.task_type,
+                &subtask_caps.available_models,
+                0.1,
+            )
+            .await;
 
             subtask_caps.model_rankings = rankings
                 .iter()

--- a/src-tauri/src/orchestrator/trust.rs
+++ b/src-tauri/src/orchestrator/trust.rs
@@ -1,10 +1,12 @@
 // ABOUTME: Trust graduation and satisfaction-driven model ranking.
 // ABOUTME: Thompson sampling selects models based on user feedback with cost weighting.
 
+use super::eval::CommunityPrior;
 use rand::{Rng, RngExt};
 use rand_distr::Beta;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Minimum number of signals before trust can be evaluated.
 const MIN_SIGNALS: u32 = 5;
@@ -87,6 +89,9 @@ const DECAY_HALF_LIFE_MS: f64 = 30.0 * 24.0 * 60.0 * 60.0 * 1000.0;
 /// Only query signals from the last 180 days.
 const SIGNAL_CUTOFF_MS: i64 = 180 * 24 * 60 * 60 * 1000;
 
+/// Community priors reach full confidence at 50 aggregate observations.
+const COMMUNITY_PRIOR_FULL_CONFIDENCE_SAMPLE_SIZE: f64 = 50.0;
+
 /// Model ranking produced by Thompson sampling.
 #[derive(Debug, Clone)]
 pub struct ModelRanking {
@@ -103,8 +108,8 @@ struct SignalRow {
 }
 
 /// Accumulated weighted stats for a single model.
-#[derive(Default)]
-struct ModelStats {
+#[derive(Clone, Default)]
+pub(crate) struct ModelStats {
     weighted_positive: f64,
     weighted_negative: f64,
     cost_sum: f64,
@@ -136,9 +141,54 @@ pub fn get_model_rankings<R: Rng>(
         .unwrap_or_default()
         .as_millis() as i64;
 
+    let stats = load_model_stats_at(conn, task_type, available_models, now);
+    sample_model_rankings(rng, available_models, &stats, None, cost_weight)
+}
+
+/// Compute Thompson sampling rankings with best-effort community priors.
+pub fn get_model_rankings_with_community_priors<R: Rng>(
+    conn: &Connection,
+    rng: &mut R,
+    task_type: &str,
+    available_models: &[String],
+    community_priors: &HashMap<String, CommunityPrior>,
+    cost_weight: f64,
+) -> Vec<ModelRanking> {
+    if available_models.is_empty() {
+        return vec![];
+    }
+
+    let stats = load_model_stats(conn, task_type, available_models);
+    sample_model_rankings(
+        rng,
+        available_models,
+        &stats,
+        Some(community_priors),
+        cost_weight,
+    )
+}
+
+/// Load time-decayed local stats from SQLite for the ranking sampler.
+pub(crate) fn load_model_stats(
+    conn: &Connection,
+    task_type: &str,
+    available_models: &[String],
+) -> HashMap<String, ModelStats> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    load_model_stats_at(conn, task_type, available_models, now)
+}
+
+fn load_model_stats_at(
+    conn: &Connection,
+    task_type: &str,
+    available_models: &[String],
+    now: i64,
+) -> HashMap<String, ModelStats> {
     let rows = query_signals(conn, task_type, available_models, now);
-    let stats = accumulate_stats(&rows, now);
-    sample_and_rank(rng, available_models, &stats, cost_weight)
+    accumulate_stats(&rows, now)
 }
 
 /// Query eval_signals for the given task_type and models within the cutoff window.
@@ -197,8 +247,8 @@ fn query_signals(
 }
 
 /// Accumulate time-decayed weighted stats per model from raw signal rows.
-fn accumulate_stats(rows: &[SignalRow], now: i64) -> std::collections::HashMap<String, ModelStats> {
-    let mut stats: std::collections::HashMap<String, ModelStats> = std::collections::HashMap::new();
+fn accumulate_stats(rows: &[SignalRow], now: i64) -> HashMap<String, ModelStats> {
+    let mut stats: HashMap<String, ModelStats> = HashMap::new();
 
     for row in rows {
         let age_ms = (now - row.created_at).max(0) as f64;
@@ -220,11 +270,30 @@ fn accumulate_stats(rows: &[SignalRow], now: i64) -> std::collections::HashMap<S
     stats
 }
 
+/// Blend a local Beta posterior with a confidence-weighted community posterior.
+pub fn blend_community_prior(
+    local_alpha: f64,
+    local_beta: f64,
+    community: &CommunityPrior,
+    confidence: f64,
+) -> (f64, f64) {
+    let confidence = confidence.clamp(0.0, 1.0);
+    (
+        local_alpha + confidence * community.alpha,
+        local_beta + confidence * community.beta,
+    )
+}
+
+fn community_prior_confidence(prior: &CommunityPrior) -> f64 {
+    (prior.sample_size as f64 / COMMUNITY_PRIOR_FULL_CONFIDENCE_SAMPLE_SIZE).min(1.0)
+}
+
 /// Sample from Beta distributions and apply cost penalty to produce final rankings.
-fn sample_and_rank<R: Rng>(
+pub(crate) fn sample_model_rankings<R: Rng>(
     rng: &mut R,
     available_models: &[String],
-    stats: &std::collections::HashMap<String, ModelStats>,
+    stats: &HashMap<String, ModelStats>,
+    community_priors: Option<&HashMap<String, CommunityPrior>>,
     cost_weight: f64,
 ) -> Vec<ModelRanking> {
     // Compute max average cost across all models (for normalization)
@@ -242,10 +311,22 @@ fn sample_and_rank<R: Rng>(
     let mut rankings: Vec<ModelRanking> = available_models
         .iter()
         .map(|model_id| {
-            let (alpha, beta_param) = match stats.get(model_id) {
+            let (local_alpha, local_beta) = match stats.get(model_id) {
                 Some(s) => (s.weighted_positive + 1.0, s.weighted_negative + 1.0),
                 None => (1.0, 1.0), // Uniform prior for unseen models
             };
+            let (alpha, beta_param) = community_priors
+                .and_then(|priors| priors.get(model_id))
+                .filter(|prior| prior.is_valid())
+                .map(|prior| {
+                    blend_community_prior(
+                        local_alpha,
+                        local_beta,
+                        prior,
+                        community_prior_confidence(prior),
+                    )
+                })
+                .unwrap_or((local_alpha, local_beta));
 
             let sample = match Beta::new(alpha, beta_param) {
                 Ok(dist) => rng.sample(dist),
@@ -295,8 +376,10 @@ fn model_cost_tier(model_id: &str) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::orchestrator::eval::CommunityPrior;
     use crate::services::database::setup_schema;
     use rand::SeedableRng;
+    use std::collections::HashMap;
 
     fn setup_test_db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
@@ -359,6 +442,14 @@ mod tests {
 
     fn seeded_rng() -> rand::rngs::StdRng {
         rand::rngs::StdRng::seed_from_u64(42)
+    }
+
+    fn prior(alpha: f64, beta: f64, sample_size: u64) -> CommunityPrior {
+        CommunityPrior {
+            alpha,
+            beta,
+            sample_size,
+        }
     }
 
     #[test]
@@ -655,6 +746,123 @@ mod tests {
             cheap_first >= 18,
             "model-cheap should rank first most of the time, but only did {cheap_first}/30"
         );
+    }
+
+    #[test]
+    fn blend_community_prior_zero_confidence_is_local_only() {
+        let community = prior(20.0, 5.0, 25);
+
+        let blended = blend_community_prior(3.0, 2.0, &community, 0.0);
+
+        assert_eq!(blended, (3.0, 2.0));
+    }
+
+    #[test]
+    fn blend_community_prior_equal_to_full_local_doubles_alpha_beta() {
+        let community = prior(3.0, 2.0, 50);
+
+        let blended = blend_community_prior(3.0, 2.0, &community, 1.0);
+
+        assert_eq!(blended, (6.0, 4.0));
+    }
+
+    #[test]
+    fn blend_community_prior_shifts_ranking_under_sparse_local_signals() {
+        let conn = setup_test_db();
+        let now = now_ms();
+
+        insert_eval_signal_at(
+            &conn,
+            "local-positive",
+            "general_chat",
+            "model-local-favorite",
+            1,
+            None,
+            now,
+        );
+        insert_eval_signal_at(
+            &conn,
+            "community-negative",
+            "general_chat",
+            "model-community-favorite",
+            0,
+            None,
+            now,
+        );
+
+        let models = vec![
+            "model-local-favorite".to_string(),
+            "model-community-favorite".to_string(),
+        ];
+        let mut community_priors = HashMap::new();
+        community_priors.insert(
+            "model-community-favorite".to_string(),
+            prior(1000.0, 1.0, 50),
+        );
+
+        let mut local_first_without_prior = 0;
+        let mut community_first_with_prior = 0;
+
+        for seed in 0..20 {
+            let mut local_rng = rand::rngs::StdRng::seed_from_u64(seed);
+            let local_rankings =
+                get_model_rankings(&conn, &mut local_rng, "general_chat", &models, 0.0);
+            if local_rankings[0].model_id == "model-local-favorite" {
+                local_first_without_prior += 1;
+            }
+
+            let mut blended_rng = rand::rngs::StdRng::seed_from_u64(seed);
+            let blended_rankings = get_model_rankings_with_community_priors(
+                &conn,
+                &mut blended_rng,
+                "general_chat",
+                &models,
+                &community_priors,
+                0.0,
+            );
+            if blended_rankings[0].model_id == "model-community-favorite" {
+                community_first_with_prior += 1;
+            }
+        }
+
+        assert!(
+            local_first_without_prior >= 14,
+            "sparse local signal should favor model-local-favorite before blending, got {local_first_without_prior}/20"
+        );
+        assert!(
+            community_first_with_prior >= 19,
+            "community prior should shift sparse ranking, got {community_first_with_prior}/20"
+        );
+    }
+
+    #[test]
+    fn get_model_rankings_with_community_prior_fetch_failure_falls_back_to_local() {
+        let conn = setup_test_db();
+        let now = now_ms();
+
+        insert_eval_signal_at(&conn, "good", "general_chat", "model-good", 1, None, now);
+        insert_eval_signal_at(&conn, "bad", "general_chat", "model-bad", 0, None, now);
+
+        let models = vec!["model-good".to_string(), "model-bad".to_string()];
+
+        let mut local_rng = seeded_rng();
+        let local = get_model_rankings(&conn, &mut local_rng, "general_chat", &models, 0.0);
+
+        let mut fallback_rng = seeded_rng();
+        let fallback = get_model_rankings_with_community_priors(
+            &conn,
+            &mut fallback_rng,
+            "general_chat",
+            &models,
+            &HashMap::new(),
+            0.0,
+        );
+
+        assert_eq!(fallback.len(), local.len());
+        for (fallback, local) in fallback.iter().zip(local.iter()) {
+            assert_eq!(fallback.model_id, local.model_id);
+            assert_eq!(fallback.score, local.score);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #2014

## Summary
- add best-effort Gateway community-prior fetch for eval routing priors
- blend confidence-weighted community Beta posteriors into local Thompson sampling
- share ranking enrichment across single-task and multi-task orchestrator paths

## Tests
- cargo test orchestrator::trust --lib
- cargo test orchestrator::eval --lib
- cargo test orchestrator::service --lib

## Audit
- eval-signal POST schema and write path unchanged
- absent/failed community prior falls back to local-only rankings
- community prior fetch is timeout-bounded at 200ms and runs alongside local stat loading