### PR TITLE
Fix Agent Chat image attachments for Codex

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -104,6 +104,55 @@ function codexModes(session) {
   };
 }
 
+function getContextText(context) {
+  return Array.isArray(context)
+    ? context
+        .map((entry) => entry?.text)
+        .filter((value) => typeof value === "string" && value.length > 0)
+        .join("\n\n")
+    : "";
+}
+
+function toDataImageUrl(entry) {
+  if (!entry || entry.type !== "image") return null;
+  if (typeof entry.url === "string" && entry.url.length > 0) return entry.url;
+
+  const data = typeof entry.data === "string" ? entry.data : entry.base64;
+  const mimeType =
+    typeof entry.mimeType === "string" && entry.mimeType.length > 0
+      ? entry.mimeType
+      : typeof entry.mime_type === "string" && entry.mime_type.length > 0
+        ? entry.mime_type
+        : "image/png";
+
+  if (typeof data !== "string" || data.length === 0) return null;
+  if (data.startsWith("data:")) return data;
+  return `data:${mimeType};base64,${data}`;
+}
+
+export function buildCodexTurnInput(prompt, context) {
+  const contextText = getContextText(context);
+  const combinedPrompt = [contextText, prompt].filter(Boolean).join("\n\n");
+  const input = [];
+
+  if (combinedPrompt) {
+    input.push({
+      type: "text",
+      text: combinedPrompt,
+      text_elements: [],
+    });
+  }
+
+  if (Array.isArray(context)) {
+    for (const entry of context) {
+      const url = toDataImageUrl(entry);
+      if (url) input.push({ type: "image", url });
+    }
+  }
+
+  return input;
+}
+
 function buildInitializeParams() {
   return {
     clientInfo: {
@@ -1165,14 +1214,6 @@ export function createProviderHandlers({ emit }) {
       throw new Error("Another prompt is already active for this session.");
     }
 
-    const contextText = Array.isArray(context)
-      ? context
-          .map((entry) => entry?.text)
-          .filter((value) => typeof value === "string" && value.length > 0)
-          .join("\n\n")
-      : "";
-    const combinedPrompt = [contextText, prompt].filter(Boolean).join("\n\n");
-
     session.status = "prompting";
     session.latestTurnUsage = undefined;
     emit("provider://session-status", {
@@ -1194,13 +1235,7 @@ export function createProviderHandlers({ emit }) {
         "turn/start",
         {
           threadId: session.agentSessionId,
-          input: [
-            {
-              type: "text",
-              text: combinedPrompt,
-              text_elements: [],
-            },
-          ],
+          input: buildCodexTurnInput(prompt, context),
           ...(session.currentModelId ? { model: session.currentModelId } : {}),
           ...(session.reasoningEffort
             ? { effort: session.reasoningEffort }

--- a/tests/unit/codex-agent-image-context.test.ts
+++ b/tests/unit/codex-agent-image-context.test.ts
@@ -1,0 +1,30 @@
+// ABOUTME: Regression guard for #2016 — Agent Chat image attachments must
+// ABOUTME: reach Codex app-server as image user input items, not disappear.
+
+import { describe, expect, it } from "vitest";
+import { buildCodexTurnInput } from "../../bin/browser-local/providers.mjs";
+
+describe("#2016 — Codex agent prompt preserves image context", () => {
+  it("maps Agent Chat image context records to Codex image turn input items", () => {
+    const input = buildCodexTurnInput("Why is this menu item missing?", [
+      { type: "text", text: "Skill primer" },
+      {
+        type: "image",
+        data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+        mimeType: "image/png",
+      },
+    ]);
+
+    expect(input).toEqual([
+      {
+        type: "text",
+        text: "Skill primer\n\nWhy is this menu item missing?",
+        text_elements: [],
+      },
+      {
+        type: "image",
+        url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #2016

## Summary
- Map Agent Chat image context records to Codex app-server `image` user input items.
- Preserve existing text-context concatenation for skills, publishers, and prompt text.
- Add a focused regression test proving a screenshot attachment reaches Codex as a data URL image item.

## Audit
Cause: `AgentChat.tsx` sent image context records, but `bin/browser-local/providers.mjs` reduced context to `entry.text` only before `turn/start`. The screenshot existed in the frontend logs but was dropped before the Codex request payload.

Fix path: `buildCodexTurnInput()` now produces the existing text item plus one Codex `image` item per valid image context record.

Impact: Codex Agent sessions can inspect user-attached PNG/JPEG/GIF/WebP data URLs instead of hallucinating from missing visual context.

## Tests
- `../../node_modules/.bin/vitest run tests/unit/codex-agent-image-context.test.ts`
- `node --check bin/browser-local/providers.mjs`
