### PR TITLE
P0: add local context intelligence outline seam

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6812,6 +6812,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -6952,6 +6953,9 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
+ "tree-sitter",
+ "tree-sitter-rust",
+ "tree-sitter-typescript",
  "unicode-width",
  "url",
  "urlencoding",
@@ -7348,6 +7352,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "string_cache"
@@ -8698,6 +8708,46 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -75,6 +75,9 @@ log = "0.4"
 tauri-plugin-log = "2"
 anyhow = "1"
 dirs = "6"
+tree-sitter = "0.26.9"
+tree-sitter-rust = "0.24.2"
+tree-sitter-typescript = "0.23.2"
 
 tokio-tungstenite = { version = "0.28" }
 

--- a/src-tauri/src/commands/context_intelligence.rs
+++ b/src-tauri/src/commands/context_intelligence.rs
@@ -1,0 +1,52 @@
+use crate::services::context_intelligence::{
+    SourceOutline, build_source_outline, run_ordered_batch,
+};
+use serde::Serialize;
+use std::path::Path;
+
+#[derive(Debug, Serialize)]
+pub struct BatchIndexFileResult {
+    pub path: String,
+    pub outline: Option<SourceOutline>,
+    pub error: Option<String>,
+}
+
+#[tauri::command]
+pub fn seren_index_source(path: String, source: String) -> Result<SourceOutline, String> {
+    build_source_outline(&path, &source)
+}
+
+#[tauri::command]
+pub async fn seren_index_file(path: String) -> Result<SourceOutline, String> {
+    let source = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| format!("failed to read {path}: {e}"))?;
+    build_source_outline(&path, &source)
+}
+
+#[tauri::command]
+pub async fn seren_batch_index_files(paths: Vec<String>) -> Vec<BatchIndexFileResult> {
+    let jobs = paths.into_iter().map(|path| async move {
+        match read_and_index_file(&path).await {
+            Ok(outline) => BatchIndexFileResult {
+                path,
+                outline: Some(outline),
+                error: None,
+            },
+            Err(error) => BatchIndexFileResult {
+                path,
+                outline: None,
+                error: Some(error),
+            },
+        }
+    });
+
+    run_ordered_batch(jobs.collect()).await
+}
+
+async fn read_and_index_file(path: &str) -> Result<SourceOutline, String> {
+    let source = tokio::fs::read_to_string(Path::new(path))
+        .await
+        .map_err(|e| format!("failed to read {path}: {e}"))?;
+    build_source_outline(path, &source)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub mod commands {
     pub mod chat;
     pub mod claude_memory;
     pub mod cli_installer;
+    pub mod context_intelligence;
     pub mod employees_archive;
     pub mod gateway_http;
     pub mod indexing;
@@ -23,6 +24,7 @@ pub mod commands {
 
 pub mod services {
     pub mod chunker;
+    pub mod context_intelligence;
     pub mod database;
     pub mod indexer;
     pub mod vector_store;
@@ -881,6 +883,10 @@ pub fn run() {
             commands::indexing::chunk_file,
             commands::indexing::estimate_indexing,
             commands::indexing::compute_file_hash,
+            // Local context-intelligence commands for agent-owned code inspection.
+            commands::context_intelligence::seren_index_source,
+            commands::context_intelligence::seren_index_file,
+            commands::context_intelligence::seren_batch_index_files,
             // Skills commands
             skills::get_default_project_dir,
             skills::get_seren_skill_authoring_dir,

--- a/src-tauri/src/services/context_intelligence.rs
+++ b/src-tauri/src/services/context_intelligence.rs
@@ -1,0 +1,324 @@
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use tree_sitter::{Language, Node, Parser};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceOutline {
+    pub language: String,
+    pub items: Vec<SourceOutlineItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceOutlineItem {
+    pub kind: String,
+    pub name: String,
+    pub signature: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+pub fn build_source_outline(path: &str, source: &str) -> Result<SourceOutline, String> {
+    let language = detect_outline_language(path)
+        .ok_or_else(|| format!("unsupported source language for outline: {path}"))?;
+    let tree_language = tree_sitter_language(language);
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tree_language)
+        .map_err(|e| format!("failed to load {language} grammar: {e}"))?;
+    let tree = parser
+        .parse(source, None)
+        .ok_or_else(|| format!("failed to parse {path}"))?;
+
+    let items = match language {
+        "rust" => collect_rust_items(tree.root_node(), source),
+        "typescript" | "tsx" => collect_typescript_items(tree.root_node(), source),
+        _ => Vec::new(),
+    };
+
+    Ok(SourceOutline {
+        language: language.to_string(),
+        items,
+    })
+}
+
+pub async fn run_ordered_batch<Fut, T>(jobs: Vec<Fut>) -> Vec<T>
+where
+    Fut: Future<Output = T>,
+{
+    futures::future::join_all(jobs).await
+}
+
+fn detect_outline_language(path: &str) -> Option<&'static str> {
+    let ext = path.rsplit('.').next()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "rs" => Some("rust"),
+        "ts" => Some("typescript"),
+        "tsx" => Some("tsx"),
+        _ => None,
+    }
+}
+
+fn tree_sitter_language(language: &str) -> Language {
+    match language {
+        "rust" => tree_sitter_rust::LANGUAGE.into(),
+        "tsx" => tree_sitter_typescript::LANGUAGE_TSX.into(),
+        "typescript" => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        _ => unreachable!("unsupported tree-sitter language: {language}"),
+    }
+}
+
+fn collect_rust_items(root: Node<'_>, source: &str) -> Vec<SourceOutlineItem> {
+    root.named_children(&mut root.walk())
+        .filter_map(|node| match node.kind() {
+            "use_declaration" => Some(item(
+                "import",
+                normalize_prefixed_statement(node_text(node, source), "use"),
+                node,
+                source,
+            )),
+            "struct_item" => Some(named_item("struct", node, source)),
+            "enum_item" => Some(named_item("enum", node, source)),
+            "trait_item" => Some(named_item("trait", node, source)),
+            "function_item" => Some(named_item("function", node, source)),
+            "impl_item" => Some(item(
+                "impl",
+                rust_impl_name(node_text(node, source)),
+                node,
+                source,
+            )),
+            "mod_item" => Some(named_item("module", node, source)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn collect_typescript_items(root: Node<'_>, source: &str) -> Vec<SourceOutlineItem> {
+    let mut items = Vec::new();
+    for node in root.named_children(&mut root.walk()) {
+        push_typescript_item(&mut items, node, source);
+    }
+    items
+}
+
+fn push_typescript_item(items: &mut Vec<SourceOutlineItem>, node: Node<'_>, source: &str) {
+    match node.kind() {
+        "import_statement" => items.push(item(
+            "import",
+            normalize_prefixed_statement(node_text(node, source), "import"),
+            node,
+            source,
+        )),
+        "type_alias_declaration" => items.push(named_item("type", node, source)),
+        "interface_declaration" => items.push(named_item("interface", node, source)),
+        "function_declaration" => items.push(named_item("function", node, source)),
+        "class_declaration" => items.push(named_item("class", node, source)),
+        "lexical_declaration" | "variable_declaration" => {
+            if let Some(name) = first_variable_name(node, source) {
+                items.push(item("const", name, node, source));
+            }
+        }
+        "export_statement" => {
+            for child in node.named_children(&mut node.walk()) {
+                push_typescript_item(items, child, source);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn named_item(kind: &str, node: Node<'_>, source: &str) -> SourceOutlineItem {
+    item(kind, node_name(node, source), node, source)
+}
+
+fn item(kind: &str, name: String, node: Node<'_>, source: &str) -> SourceOutlineItem {
+    SourceOutlineItem {
+        kind: kind.to_string(),
+        name,
+        signature: first_line(node_text(node, source)),
+        start_line: node.start_position().row + 1,
+        end_line: node.end_position().row + 1,
+    }
+}
+
+fn node_name(node: Node<'_>, source: &str) -> String {
+    node.child_by_field_name("name")
+        .map(|child| node_text(child, source).trim().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| fallback_name(node_text(node, source)))
+}
+
+fn first_variable_name(node: Node<'_>, source: &str) -> Option<String> {
+    for child in node.named_children(&mut node.walk()) {
+        if child.kind() == "variable_declarator" {
+            return child
+                .child_by_field_name("name")
+                .map(|name| node_text(name, source).trim().to_string())
+                .filter(|name| !name.is_empty());
+        }
+    }
+    None
+}
+
+fn rust_impl_name(text: &str) -> String {
+    let head = text
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .trim_start_matches("impl")
+        .trim();
+    let before_brace = head.split('{').next().unwrap_or(head).trim();
+    if let Some((_, target)) = before_brace.rsplit_once(" for ") {
+        return clean_identifier(target);
+    }
+    clean_identifier(before_brace)
+}
+
+fn normalize_prefixed_statement(text: &str, prefix: &str) -> String {
+    text.trim()
+        .trim_start_matches(prefix)
+        .trim()
+        .trim_end_matches(';')
+        .trim()
+        .to_string()
+}
+
+fn fallback_name(text: &str) -> String {
+    let first = text.lines().next().unwrap_or_default();
+    first.split_whitespace().nth(1).unwrap_or(first).to_string()
+}
+
+fn clean_identifier(text: &str) -> String {
+    text.trim()
+        .trim_start_matches('<')
+        .trim_end_matches('{')
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .trim_matches(|ch: char| matches!(ch, '<' | '>' | '{' | '(' | ')'))
+        .to_string()
+}
+
+fn first_line(text: &str) -> String {
+    text.lines().next().unwrap_or_default().trim().to_string()
+}
+
+fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
+    node.utf8_text(source.as_bytes()).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn indexes_tsx_symbols_with_exact_lines() {
+        let source = r#"import { createSignal } from "solid-js";
+
+type User = {
+  id: string;
+};
+
+export interface Props {
+  user: User;
+}
+
+export function Profile(props: Props) {
+  const [count] = createSignal(0);
+  return <section>{props.user.id}{count()}</section>;
+}
+
+const helper = () => "ok";
+"#;
+
+        let outline = build_source_outline("Profile.tsx", source).expect("tsx outline");
+
+        assert_eq!(outline.language, "tsx");
+        assert_eq!(
+            outline
+                .items
+                .iter()
+                .map(|item| (
+                    item.kind.as_str(),
+                    item.name.as_str(),
+                    item.start_line,
+                    item.end_line
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("import", "{ createSignal } from \"solid-js\"", 1, 1),
+                ("type", "User", 3, 5),
+                ("interface", "Props", 7, 9),
+                ("function", "Profile", 11, 14),
+                ("const", "helper", 16, 16),
+            ]
+        );
+    }
+
+    #[test]
+    fn indexes_rust_symbols_with_exact_lines() {
+        let source = r#"use serde::Serialize;
+
+pub struct RunConfig {
+    pub limit: usize,
+}
+
+impl RunConfig {
+    pub fn new(limit: usize) -> Self {
+        Self { limit }
+    }
+}
+
+pub async fn run_scan(config: RunConfig) -> usize {
+    config.limit
+}
+"#;
+
+        let outline = build_source_outline("scanner.rs", source).expect("rust outline");
+
+        assert_eq!(outline.language, "rust");
+        assert_eq!(
+            outline
+                .items
+                .iter()
+                .map(|item| (
+                    item.kind.as_str(),
+                    item.name.as_str(),
+                    item.start_line,
+                    item.end_line
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("import", "serde::Serialize", 1, 1),
+                ("struct", "RunConfig", 3, 5),
+                ("impl", "RunConfig", 7, 11),
+                ("function", "run_scan", 13, 15),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_preserves_input_order_while_running_concurrently() {
+        let started = Instant::now();
+        let jobs: Vec<Pin<Box<dyn Future<Output = &'static str> + Send>>> = vec![
+            Box::pin(async {
+                tokio::time::sleep(Duration::from_millis(80)).await;
+                "slow"
+            }),
+            Box::pin(async {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                "fast"
+            }),
+        ];
+        let results = run_ordered_batch(jobs).await;
+
+        assert_eq!(results, vec!["slow", "fast"]);
+        assert!(
+            started.elapsed() < Duration::from_millis(140),
+            "batch work should run concurrently, not serially"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Rust-backed local context-intelligence service using tree-sitter for compact source outlines.
- Exposes Tauri commands for `seren_index_source`, `seren_index_file`, and ordered batch file indexing.
- Adds the first MVP seam for the agent-owned context plane tracked in #2018 without duplicating the existing vector index.

## Audit / Cause
Seren already has semantic vector indexing, but agent sessions still lack a deterministic local source-outline tool. The existing chunker is optimized for vector chunks, not before-read code structure. This PR adds the local backend surface needed for agent-owned compact inspection and batch composition.

## Tests
- `cargo test context_intelligence --lib`
- `cargo check --lib`

`cargo check --lib` passes with existing unrelated dead-code warnings in `embedded_runtime.rs` and `orchestrator/trust.rs`.

Fixes #2018
