### PR TITLE
fix(agent): close #2031 — aggressive reactive compaction retry

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -74,6 +74,15 @@ const SESSION_READY_TIMEOUT_MS = 30_000;
 export const PREDICTIVE_COMPACT_THRESHOLD = 0.7;
 
 /**
+ * Reactive compaction's last-ditch preserve count. When the configured
+ * `autoCompactPreserveMessages` leaves nothing to summarize (short session,
+ * heavy per-message token cost), `compactAndRetry` retries with this count
+ * — keeping only the most recent user/assistant pair so the session
+ * actually shrinks below the model window. #2031.
+ */
+const AGGRESSIVE_RETRY_PRESERVE_COUNT = 2;
+
+/**
  * Global cap = 1 simultaneous predictive compaction across the whole app.
  * Prevents 3x Sonnet 4 calls and 3x Node subprocesses when multiple threads
  * cross the threshold in the same promptComplete tick. #1631.
@@ -4278,16 +4287,34 @@ Structured summary:`;
       // session. We trust that id and do the retry locally — splitting
       // dispatch across both functions, or re-deriving the id via a state
       // lookup, regressed for #1757.
-      const result = await this.compactAgentConversation(
+      let result = await this.compactAgentConversation(
         sessionId,
         settingsStore.settings.autoCompactPreserveMessages,
       );
 
-      // Propagate non-success outcomes directly. "skipped" means the message
-      // count was already under the preserve threshold (nothing to compact);
-      // "failed_catastrophic" means spawn or summary threw. Chat fallback is
-      // only correct for the latter; the former means a single prompt is too
-      // large and Chat would fail identically — show an error instead.
+      // Reactive compaction must recover from short-but-token-heavy sessions
+      // — a handful of tool turns can carry 200K+ tokens. When the configured
+      // preserve count leaves nothing to summarize, retry with a minimal
+      // preserve count (last user/assistant pair) so the session actually
+      // shrinks. Only give up when even that has nothing to act on. #2031.
+      if (result.outcome === "skipped_nothing_to_compact") {
+        const remaining = state.sessions[sessionId]?.messages.length ?? 0;
+        if (remaining > AGGRESSIVE_RETRY_PRESERVE_COUNT) {
+          console.info(
+            `[AgentStore] compactAndRetry: configured preserve count left nothing to compact (${remaining} messages); retrying with preserveCount=${AGGRESSIVE_RETRY_PRESERVE_COUNT}`,
+          );
+          result = await this.compactAgentConversation(
+            sessionId,
+            AGGRESSIVE_RETRY_PRESERVE_COUNT,
+          );
+        }
+      }
+
+      // Propagate non-success outcomes directly. "skipped" after the
+      // aggressive retry means the session is too small to compact at all
+      // (one or two messages) — Chat would fail identically, so caller
+      // surfaces an honest error. "failed_catastrophic" still routes to
+      // the Chat fallback.
       if (result.outcome !== "succeeded") {
         return result.outcome;
       }
@@ -5879,12 +5906,19 @@ Structured summary:`;
                   console.error("[AgentStore] Auto-failover failed:", err);
                 });
               } else if (outcome === "skipped_nothing_to_compact") {
+                // After #2031, this branch is only reached when the session
+                // has too few messages to compact even with the aggressive
+                // preserve count (1-2 messages). The prior banner blamed the
+                // user's last message specifically — accurate only when the
+                // session is genuinely a single huge prompt, but misleading
+                // when the user did not type a huge message. Speak to the
+                // session as a whole and tell them what will actually help.
                 console.warn(
-                  "[AgentStore] Compaction skipped (nothing to compact). Likely a single oversized prompt — surfacing error to user without Chat fallback.",
+                  "[AgentStore] Compaction skipped (nothing to compact). Session is too small to compact — surfacing error to user without Chat fallback.",
                 );
                 this.addErrorMessage(
                   sessionId,
-                  "Your last message is too large for this agent's context window. Try shortening it, attaching files instead of pasting content, or starting a new thread.",
+                  "This thread is too full for the model's context window and there is nothing left to compact. Start a new thread to continue.",
                 );
               }
               return outcome;

--- a/tests/unit/compact-retry-aggressive-fallback.test.ts
+++ b/tests/unit/compact-retry-aggressive-fallback.test.ts
@@ -1,0 +1,70 @@
+// ABOUTME: #2031 — compactAndRetry must aggressively retry with a smaller
+// ABOUTME: preserveCount when the first compactAgentConversation skips, so
+// ABOUTME: short-but-token-heavy sessions are not dead-ended by the banner.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+function functionBody(anchor: string): string {
+  const start = agentStoreSource.indexOf(anchor);
+  if (start < 0) {
+    throw new Error(`anchor not found in agent.store.ts: ${anchor}`);
+  }
+  const end = agentStoreSource.indexOf("\n  },", start);
+  if (end < 0) {
+    throw new Error(`could not find function end for: ${anchor}`);
+  }
+  return agentStoreSource.slice(start, end);
+}
+
+describe("#2031 — compactAndRetry recovers short-but-token-heavy sessions", () => {
+  it("aggressively retries with a smaller preserveCount when the first compactAgentConversation skips", () => {
+    // The first call uses the user's configured preserve count. If that skips
+    // because messages.length <= preserveCount, the session is still too big
+    // to send — we keep just the last user/assistant pair (preserveCount = 2)
+    // and try again. Without this fallback the user sees a misleading
+    // "shorten your message" banner for a message they did not type.
+    const body = functionBody("async compactAndRetry(");
+
+    // Two calls into compactAgentConversation — the configured one AND the
+    // aggressive one.
+    const calls = body.match(/this\.compactAgentConversation\(/g);
+    expect(
+      calls,
+      "compactAndRetry must call compactAgentConversation twice (configured, then aggressive)",
+    ).toBeTruthy();
+    expect(calls?.length).toBeGreaterThanOrEqual(2);
+
+    // The aggressive retry is gated on the first call returning
+    // skipped_nothing_to_compact. Anything else (succeeded, failed_catastrophic,
+    // cancelled) must propagate without a retry.
+    expect(body).toMatch(/skipped_nothing_to_compact/);
+
+    // Aggressive preserveCount is the named constant AGGRESSIVE_RETRY_PRESERVE_COUNT.
+    expect(body).toMatch(
+      /this\.compactAgentConversation\(\s*sessionId\s*,\s*AGGRESSIVE_RETRY_PRESERVE_COUNT/,
+    );
+    // The constant must be 2 — keep only the last user/assistant pair.
+    expect(agentStoreSource).toMatch(
+      /const\s+AGGRESSIVE_RETRY_PRESERVE_COUNT\s*=\s*2\b/,
+    );
+  });
+
+  it("updates the user-facing banner so it stops blaming the user's message", () => {
+    // The pre-#2031 banner read "Your last message is too large for this
+    // agent's context window. Try shortening it..." — accurate only when the
+    // single most-recent message is itself oversized. After #2031, that case
+    // is the only one that still reaches this branch (the aggressive retry
+    // handles every session with > 2 messages), so the banner can be plain
+    // and honest: the session is full, start a new thread. The misleading
+    // "shorten it / attach files instead of pasting" guidance must go.
+    expect(agentStoreSource).not.toMatch(/Try shortening it/i);
+    expect(agentStoreSource).not.toMatch(/attaching files instead of pasting/i);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2031.

- `compactAndRetry` now retries `compactAgentConversation` with `preserveCount = AGGRESSIVE_RETRY_PRESERVE_COUNT (2)` when the configured count leaves nothing to summarize. Short-but-token-heavy Codex sessions (a few tool turns easily produce 200K+ tokens across 6-10 messages) actually compact instead of dead-ending the user.
- The reactive `skipped_nothing_to_compact` banner is rewritten so the only case it now reaches — a session with `messages.length <= 2` — gets an honest message ("This thread is too full... Start a new thread to continue.") instead of telling the user to shorten input they did not type.

## Audit

Issue: `compactAndRetry` at `src/stores/agent.store.ts:4263` called `compactAgentConversation` with the user's configured preserve count (default 10). `compactAgentConversation` at `src/stores/agent.store.ts:3768` returned `skipped_nothing_to_compact` when `messages.length <= preserveCount` — true for short Codex sessions even when token usage was hundreds of thousands. The error event handler at `src/stores/agent.store.ts:5881` then surfaced a banner blaming the user's last message, which was misleading whenever the user had not pasted a huge prompt.

Fix paths re-confirmed:
- Bug-triggering case (6-10 messages, huge tokens): first call skips → retry with `preserveCount=2` summarizes the older messages → `compactAndRetry` returns `retried`, the user's prompt is re-sent on a fresh session.
- Genuine "nothing to compact" case (1-2 messages): first call skips → `remaining <= 2` so retry is skipped → caller shows the new accurate banner.
- Normal long session: first call succeeds → retry branch not entered → existing behavior preserved.
- Catastrophic failure: outcome is not `skipped_nothing_to_compact` → retry branch not entered → existing Chat fallback path preserved.
- Cancelled: catch block returns `"cancelled"` → existing behavior preserved.

Impact:
- New module constant `AGGRESSIVE_RETRY_PRESERVE_COUNT = 2` near the existing `PREDICTIVE_COMPACT_THRESHOLD` constant.
- 1 modified function (`compactAndRetry`), 1 updated banner (`skipped_nothing_to_compact` branch).
- 1 new test file with 2 critical assertions (retry pattern present; misleading copy removed).
- Full vitest suite green (193 files, 1416 tests).

## Test plan

- [x] `npx vitest run tests/unit/compact-retry-aggressive-fallback.test.ts` — 2 new tests pass
- [x] `npx vitest run` (full suite) — 1416 tests pass
- [x] Adjacent compaction suites (`compact-retry-codex`, `compact-no-seed-prompt`, `auto-compact-predictive`, `agent-predictive-compaction`, `compaction-auth-gate`, `compaction-prepend-format`, `prompt-too-long-streamed-content-removed`, `rate-limit-fallback`) — 85 tests pass with no regression
- [x] Biome check on touched source file — clean
