### PR TITLE
fix(orchestrator): close #2033 — pin trust-fallback test to sampler

### DIFF
--- a/src-tauri/src/orchestrator/trust.rs
+++ b/src-tauri/src/orchestrator/trust.rs
@@ -836,32 +836,57 @@ mod tests {
     }
 
     #[test]
-    fn get_model_rankings_with_community_prior_fetch_failure_falls_back_to_local() {
-        let conn = setup_test_db();
-        let now = now_ms();
-
-        insert_eval_signal_at(&conn, "good", "general_chat", "model-good", 1, None, now);
-        insert_eval_signal_at(&conn, "bad", "general_chat", "model-bad", 0, None, now);
+    fn empty_community_priors_match_no_priors_in_sample_model_rankings() {
+        // The fallback contract: when the community-priors fetch returns no
+        // usable priors (network failure surfaced as `Some(empty_map)`, or the
+        // caller skips the fetch and passes `None`), the sampler must produce
+        // the same rankings as the local-only path given the same local stats
+        // and the same RNG state.
+        //
+        // The earlier shape of this test compared two top-level wrappers —
+        // `get_model_rankings` and `get_model_rankings_with_community_priors`
+        // — which each capture their own `SystemTime::now()` inside
+        // `load_model_stats[_at]`. The two `now` values drift by microseconds
+        // between calls; the resulting decay-weighted alpha/beta drift too,
+        // producing different Beta-distribution samples from otherwise
+        // identical seeded RNGs. That made the test flaky in CI (#2033).
+        //
+        // The fallback contract lives at the sampler, not at the wrappers, so
+        // assert it there with identical stats and identical seeded RNG state.
+        let mut stats: HashMap<String, ModelStats> = HashMap::new();
+        stats.insert(
+            "model-good".to_string(),
+            ModelStats {
+                weighted_positive: 3.0,
+                weighted_negative: 0.5,
+                cost_sum: 0.0,
+                cost_count: 0,
+            },
+        );
+        stats.insert(
+            "model-bad".to_string(),
+            ModelStats {
+                weighted_positive: 0.2,
+                weighted_negative: 4.0,
+                cost_sum: 0.0,
+                cost_count: 0,
+            },
+        );
 
         let models = vec!["model-good".to_string(), "model-bad".to_string()];
 
-        let mut local_rng = seeded_rng();
-        let local = get_model_rankings(&conn, &mut local_rng, "general_chat", &models, 0.0);
+        let mut none_rng = seeded_rng();
+        let with_none = sample_model_rankings(&mut none_rng, &models, &stats, None, 0.0);
 
-        let mut fallback_rng = seeded_rng();
-        let fallback = get_model_rankings_with_community_priors(
-            &conn,
-            &mut fallback_rng,
-            "general_chat",
-            &models,
-            &HashMap::new(),
-            0.0,
-        );
+        let empty_priors: HashMap<String, CommunityPrior> = HashMap::new();
+        let mut empty_rng = seeded_rng();
+        let with_empty =
+            sample_model_rankings(&mut empty_rng, &models, &stats, Some(&empty_priors), 0.0);
 
-        assert_eq!(fallback.len(), local.len());
-        for (fallback, local) in fallback.iter().zip(local.iter()) {
-            assert_eq!(fallback.model_id, local.model_id);
-            assert_eq!(fallback.score, local.score);
+        assert_eq!(with_empty.len(), with_none.len());
+        for (empty, none) in with_empty.iter().zip(with_none.iter()) {
+            assert_eq!(empty.model_id, none.model_id);
+            assert_eq!(empty.score, none.score);
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #2033.

- Replaced `trust::tests::get_model_rankings_with_community_prior_fetch_failure_falls_back_to_local` with `empty_community_priors_match_no_priors_in_sample_model_rankings`.
- The new test asserts the same fallback contract at the function where it lives — `sample_model_rankings` — with identical pre-computed stats and identical seeded RNG state.
- No production code changed. Net test count is unchanged (one replaced by one).

## Audit

**Root cause (confirmed by reading `src-tauri/src/orchestrator/trust.rs`):**

- `get_model_rankings` at `trust.rs:128` captures `SystemTime::now()` itself at line 139, then passes that timestamp to `load_model_stats_at`.
- `get_model_rankings_with_community_priors` at `trust.rs:149` instead calls `load_model_stats` at line 161, which captures its own `SystemTime::now()` at line 177.
- The two `now` values differ by the microsecond-to-millisecond gap between the two function calls.
- `accumulate_stats` at `trust.rs:250` computes `age_ms = now - row.created_at` and `weight = 0.5_f64.powf(age_ms / DECAY_HALF_LIFE_MS)`.
- Slight `now` drift → slight `weight` drift → slightly different `weighted_positive` / `weighted_negative` → slightly different `alpha` / `beta_param` passed to `Beta::new(...)` at `trust.rs:331` → slightly different `rng.sample(dist)` output → different scores → different rankings.
- The original test asserted `assert_eq!(fallback.score, local.score)` on those two RNG-driven scores, so when the drift crossed a floating-point sample boundary, the test failed. That is the flake.

**Why the new test is deterministic:**

- It calls `sample_model_rankings` directly with a pre-built `HashMap<String, ModelStats>` literal. No `SystemTime::now()`, no decay computation between the two calls.
- Both calls receive the same `stats`, same `models`, same `cost_weight`, same freshly seeded `StdRng::seed_from_u64(42)`.
- The only difference is `None` vs `Some(&HashMap::new())`. That is the precise contract the test is meant to cover: "fetch failure surfaced as empty priors must produce the same ranking as the local-only path."
- Inside `sample_model_rankings` at `trust.rs:318-329`: `community_priors.and_then(|priors| priors.get(model_id))` returns `None` for every model when priors is `Some(empty)` or `None`, so `.unwrap_or((local_alpha, local_beta))` is taken on both code paths. Same alpha/beta, same Beta dist, same RNG draws, byte-identical output.

**Impact:**

- Eliminates the `trust::tests::get_model_rankings_with_community_prior_fetch_failure_falls_back_to_local` flake that blocked #2030 and #2023 with no actual code regression.
- No change to `get_model_rankings`, `get_model_rankings_with_community_priors`, `sample_model_rankings`, or any other production function. Pre-existing dead-code warnings on the two wrapper functions are unrelated (#2015 added them; they are not yet wired into the router).
- 200/200 local runs pass deterministically. Full `orchestrator::trust::tests::` suite: 17/17 pass.

## Test plan

- [x] `cargo test --release --lib orchestrator::trust::tests::empty_community_priors_match_no_priors_in_sample_model_rankings` — passes
- [x] `cargo test --release --lib orchestrator::trust::tests::` — 17/17 pass
- [x] 200x loop of the new test — 200/200 pass
- [x] Audit: walked through `sample_model_rankings` (`trust.rs:292-362`) line by line to confirm `None` vs `Some(empty)` take the same code path
