### PR TITLE
fix(csp): allow data: URIs in font-src for Monaco bundled fonts

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc://localhost http://ipc.localhost ws://127.0.0.1:* http://127.0.0.1:* https://api.serendb.com https://api.github.com https://raw.githubusercontent.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai https://*.thirdweb.com https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org https://*.base.org https://pub-714fe894394345a0a8a102fbac2b208f.r2.dev; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' asset: https: data:; font-src 'self' https://fonts.gstatic.com; frame-src http://127.0.0.1:* http://localhost:*",
+      "csp": "default-src 'self'; connect-src 'self' ipc://localhost http://ipc.localhost ws://127.0.0.1:* http://127.0.0.1:* https://api.serendb.com https://api.github.com https://raw.githubusercontent.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai https://*.thirdweb.com https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org https://*.base.org https://pub-714fe894394345a0a8a102fbac2b208f.r2.dev; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' asset: https: data:; font-src 'self' data: https://fonts.gstatic.com; frame-src http://127.0.0.1:* http://localhost:*",
       "assetProtocol": {
         "enable": true,
         "scope": [


### PR DESCRIPTION
## Summary

- Add `data:` to the `font-src` CSP directive in `src-tauri/tauri.conf.json` so Monaco's bundled woff2/woff fonts (embedded as `data:font/woff2;base64,…` inside the Vite output) load instead of being rejected by WebKit.

## Why

Monaco ships its codicon font and editor glyphs inline as base64 data URIs in `dist/assets/index-*.js`. Without `data:` in `font-src`, every `@font-face` rule Monaco installs is rejected, codicons render as missing-glyph boxes, and the console fills with `Refused to load data:font/woff2;base64,…` on every editor mount. Mirrors the existing `img-src 'self' asset: https: data:` policy.

## Test plan

- [ ] `pnpm tauri dev` — open any editor surface, confirm no `data:font` CSP errors in DevTools console
- [ ] Codicons render correctly in the editor gutter and tabs

Fixes #2035
