### PR TITLE
fix(context): refuse poisoned <1M cache reads for [1m]-suffixed models

### DIFF
--- a/src/services/modelContextCache.ts
+++ b/src/services/modelContextCache.ts
@@ -26,7 +26,24 @@ export async function getCachedModelContextWindow(
       provider,
       modelId,
     });
-    return typeof result === "number" && result > 0 ? result : null;
+    if (typeof result !== "number" || result <= 0) return null;
+    // Mirror of the #1769 write guard at the read side. The write guard
+    // refuses to persist sub-1M windows for [1m]-suffixed models, but it
+    // cannot retroactively repair entries persisted before its introduction.
+    // The spawn fallback at agent.store.ts:2833 prefers cache over the
+    // defaultContextWindowFor 1M default, and #1798's promptComplete guard
+    // refuses to overwrite a spawn-time value when the CLI later reports a
+    // smaller window — so a single poisoned entry pins the session
+    // denominator at 200K until the cache is hand-cleaned. Discard the
+    // read instead, letting the spawn fall through to defaultContextWindowFor.
+    // #2040.
+    if (ONE_M_SUFFIX_RE.test(modelId) && result < ONE_M_TIER_MINIMUM) {
+      console.warn(
+        `[modelContextCache] discarding poisoned ${result.toLocaleString()} cache read for ${modelId} — [1m] tier minimum is ${ONE_M_TIER_MINIMUM.toLocaleString()}`,
+      );
+      return null;
+    }
+    return result;
   } catch (err) {
     console.warn("[modelContextCache] lookup failed", err);
     return null;

--- a/tests/unit/model-context-cache-tier-guard.test.ts
+++ b/tests/unit/model-context-cache-tier-guard.test.ts
@@ -1,5 +1,6 @@
 // ABOUTME: Critical guard for #1769 — recordModelContextWindow must refuse to
 // ABOUTME: persist sub-1M values for [1m]-suffixed models so the cache cannot poison future sessions.
+// ABOUTME: #2040 extends the same invariant to reads — a sub-1M cache entry that pre-dates #1769 must be discarded.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -97,5 +98,62 @@ describe("#1769 — recordModelContextWindow tier-downgrade guard", () => {
       contextWindow: 200_000,
     });
     expect(mockCaptureSupportError).not.toHaveBeenCalled();
+  });
+});
+
+describe("#2040 — getCachedModelContextWindow tier-read guard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("rejects a poisoned <1M cache read for a [1m]-suffixed model and returns null", async () => {
+    // The #1769 write guard cannot retroactively repair entries persisted
+    // before its introduction. Spawn-time falls back to the cache first
+    // (agent.store.ts:2833), and #1798's promptComplete guard refuses to
+    // overwrite a spawn-time value when the CLI later reports a smaller
+    // window. Without a read-side guard, one poisoned 200K pins the session
+    // denominator at 200K for life — exactly the SIGTERM trigger in #2040.
+    mockInvoke.mockResolvedValueOnce(200_000);
+    const { getCachedModelContextWindow } = await import(
+      "@/services/modelContextCache"
+    );
+    const result = await getCachedModelContextWindow(
+      "claude-code",
+      "claude-opus-4-7[1m]",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns valid 1M cache reads for [1m]-suffixed models unchanged", async () => {
+    // Defense against over-correction: a legitimately-stored 1M entry must
+    // pass through. Rejecting it would force every cold-start to re-derive
+    // the window via defaultContextWindowFor, which is correct today (1M)
+    // but couples the cache layer to that assumption.
+    mockInvoke.mockResolvedValueOnce(1_000_000);
+    const { getCachedModelContextWindow } = await import(
+      "@/services/modelContextCache"
+    );
+    const result = await getCachedModelContextWindow(
+      "claude-code",
+      "claude-opus-4-7[1m]",
+    );
+    expect(result).toBe(1_000_000);
+  });
+
+  it("returns bare-tier 200K cache reads unchanged", async () => {
+    // The read guard is gated on the [1m] suffix because bare IDs genuinely
+    // sit on the 200K tier per claude-runtime-1m-tier.test.ts:20-28.
+    // Rejecting bare 200K reads would break the cache for the un-suffixed
+    // picker entries.
+    mockInvoke.mockResolvedValueOnce(200_000);
+    const { getCachedModelContextWindow } = await import(
+      "@/services/modelContextCache"
+    );
+    const result = await getCachedModelContextWindow(
+      "claude-code",
+      "claude-opus-4-7",
+    );
+    expect(result).toBe(200_000);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a read-side mirror of the #1769 `[1m]` tier write guard in `getCachedModelContextWindow`.
- Discards cached sub-1M context-window entries for `[1m]`-suffixed Claude models so the spawn falls through to `defaultContextWindowFor` (1M) instead of pinning the session denominator at 200K.
- Removes the most common upstream trigger for the SIGTERM/auth-misclassification chain reported in #2040.

## Why this is the right scope

The bare-ID → 200K behavior is intentional and pinned by `tests/unit/claude-runtime-1m-tier.test.ts:20-28` — Anthropic actually gates the 1M tier on the suffix. The bug is not the default; it's that `getCachedModelContextWindow` returned poisoned pre-#1769 entries without tier validation, and the existing flow (#1798 promptComplete guard) refuses to overwrite spawn-time values when the CLI subsequently reports a smaller window. One poisoned cache entry was pinning the denominator at 200K for the entire session lifetime.

Full line-numbered analysis lives in [the audit comment on #2040](https://github.com/serenorg/seren-desktop/issues/2040#issuecomment-4546560018).

## Test plan

- [x] `tests/unit/model-context-cache-tier-guard.test.ts` — three new critical tests added to the existing tier-guard file (no new boilerplate):
  - Poisoned 200K cache for `[1m]` model → `null` (the fix).
  - Valid 1M cache for `[1m]` model → passthrough (regression guard against over-correction).
  - Bare 200K cache for un-suffixed model → passthrough (regression guard preserving the documented bare-tier invariant).
- [x] Full vitest suite passes (1419/1419).
- [x] Biome clean on touched files.
- [x] `tsc --noEmit` introduces no new errors (one pre-existing error in `codex-agent-image-context.test.ts` exists on `main`).

## Impact

For sessions on `claude-opus-4-7[1m]` (and the other 1M-capable variants) whose cache pre-dates #1769:

- Before: spawn reads 200K from cache, predictive-compact fires at ~140K tokens, SIGTERM, auth-misclassification banner.
- After: spawn discards the poisoned read, falls back to `defaultContextWindowFor` → 1M, predictive-compact threshold becomes ~700K, no spurious SIGTERM.

The downstream `isLikelyAuthError` misclassification chain stays as the original repro for #2040 and remains in scope of that ticket if Taariq wants it tightened separately.

Fixes #2040.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
