### PR TITLE
fix(skills): compact skill prompt by default; full body via explicit opt-in

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1651,7 +1651,20 @@ export const skills = {
           ? `\n> **Platform:** Windows. Python (\`python\` and \`python3\`) is bundled with Seren Desktop — no install needed. Skill docs commonly reference \`~/.config/seren/skills/<name>\` and forward-slash paths; on this machine:\n> - Replace any \`~/.config/seren/skills/<name>\` reference with the absolute runtime directory above.\n> - Use backslashes inside paths.\n> Always \`cd\` into the absolute runtime directory above before invoking skill scripts.`
           : "";
         const runtimeNote = `> **Skill runtime directory:** \`${runtimeDir}\`\n> Use this absolute path to reference skill files. Do not create local copies or fallback scaffolds.${platformNote}${depsNote}\n\n`;
-        if (opts?.mode === "compact") {
+        // #2041: compact is the default. Inlining every SKILL.md body shipped
+        // ~90K tokens of system-prompt overhead per turn at 30 active skills,
+        // pinning fresh sessions near the 200K cap before the user typed
+        // anything. Compact mode keeps the name + description + runtime path
+        // + "When to use" preview and tells the agent to open SKILL.md on
+        // demand — the agent's existing Read tool covers the fetch when a
+        // skill is actually invoked. Callers that genuinely need the full
+        // body (e.g. an explicit slash-command invocation) opt in via
+        // mode: "full".
+        if (opts?.mode === "full") {
+          contents.push(
+            `## Skill: ${skill.name}\n\n${runtimeNote}${parsed.content}`,
+          );
+        } else {
           contents.push(
             buildCompactSkillPrompt({
               skill,
@@ -1660,10 +1673,6 @@ export const skills = {
               runtimeNote,
               parsedContent: parsed.content,
             }),
-          );
-        } else {
-          contents.push(
-            `## Skill: ${skill.name}\n\n${runtimeNote}${parsed.content}`,
           );
         }
       }

--- a/tests/unit/skills-compact-context.test.ts
+++ b/tests/unit/skills-compact-context.test.ts
@@ -1,9 +1,25 @@
 // ABOUTME: Critical guard for #1960 — large active-skill sets must have a
 // ABOUTME: compact prompt form so first-turn Codex prompts do not overflow.
+// ABOUTME: #2041 makes compact the default — every active skill ships name +
+// ABOUTME: description only unless the caller explicitly opts into full mode.
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockInvoke = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: () => true,
+}));
 
 const skillsServiceSource = readFileSync(
   join(process.cwd(), "src/services/skills.ts"),
@@ -18,21 +34,91 @@ function methodBody(name: string): string {
   return skillsServiceSource.slice(start, end);
 }
 
-describe("#1960 — compact active-skill prompt context", () => {
-  it("getEnabledSkillsContent accepts a compact mode option", () => {
+const SKILL_MD_BODY_MARKER = "DO-NOT-INLINE-FULL-BODY-IN-COMPACT-MODE";
+const SKILL_MD = `---
+name: Test Skill
+description: A test skill
+---
+# Test Skill
+
+## When to Use
+
+Use when running the compact-default invariant test.
+
+## Body
+
+${SKILL_MD_BODY_MARKER}
+`;
+
+function fakeSkill() {
+  return {
+    id: "seren:test",
+    slug: "test",
+    name: "Test Skill",
+    description: "A test skill",
+    source: "seren" as const,
+    sourceUrl: "seren-skills:test",
+    tags: [],
+    scope: "user" as const,
+    skillsDir: "/Users/me/.config/seren/skills",
+    dirName: "test",
+    path: "",
+    installedAt: 0,
+    enabled: true,
+  };
+}
+
+describe("#1960 — compact active-skill prompt context (mode option exists)", () => {
+  it("getEnabledSkillsContent accepts a typed mode option", () => {
     const body = methodBody("async getEnabledSkillsContent");
 
     expect(skillsServiceSource).toContain("EnabledSkillsContentOptions");
     expect(body).toContain("opts?: EnabledSkillsContentOptions");
-    expect(body).toContain('opts?.mode === "compact"');
   });
 
-  it("compact mode keeps runtime paths and tells the agent to read SKILL.md on demand", () => {
+  it("compact path keeps runtime paths and tells the agent to read SKILL.md on demand", () => {
     const body = methodBody("async getEnabledSkillsContent");
 
     expect(body).toContain("buildCompactSkillPrompt");
     expect(skillsServiceSource).toContain("Before using this skill, open");
     expect(skillsServiceSource).toContain("SKILL.md");
     expect(skillsServiceSource).toContain("runtimeDir");
+  });
+});
+
+describe("#2041 — compact is the default; full is explicit opt-in", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "read_skill_content") return Promise.resolve(SKILL_MD);
+      return Promise.resolve(null);
+    });
+  });
+
+  it("emits compact content (no full body) when called with no opts", async () => {
+    // Before #2041: undefined opts → full body inlined → 30 skills paid
+    // ~90K tokens of system-prompt overhead per turn. The body marker
+    // must NOT appear in the default output; the compact "open SKILL.md"
+    // directive MUST appear.
+    const { skills } = await import("@/services/skills");
+    const content = await skills.getEnabledSkillsContent([
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture
+      fakeSkill() as any,
+    ]);
+    expect(content).not.toContain(SKILL_MD_BODY_MARKER);
+    expect(content).toContain("Before using this skill, open");
+  });
+
+  it("emits the full body when the caller explicitly opts into mode: 'full'", async () => {
+    // The escape hatch must still work — slash-command invocations and
+    // any caller that genuinely needs the full body can request it.
+    const { skills } = await import("@/services/skills");
+    const content = await skills.getEnabledSkillsContent(
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture
+      [fakeSkill() as any],
+      { mode: "full" },
+    );
+    expect(content).toContain(SKILL_MD_BODY_MARKER);
   });
 });


### PR DESCRIPTION
## Summary

- `getEnabledSkillsContent` now defaults to **compact** mode when no `opts` are passed. The previous default inlined the entire SKILL.md body for every active skill on every turn.
- Callers that genuinely need the full body opt in via `{ mode: "full" }` — preserves the escape hatch for slash-command invocations and any future explicit-load path.
- The agent picks up the full SKILL.md on demand via its existing `Read` tool when it decides to actually use a skill.

## Why

With ~30 active skills the system prompt was ~92% full before the user typed anything (~90K tokens of skill bodies). That was the upstream trigger for the predictive-compaction → SIGTERM chain in #2040: even after the #2040 PR fixes the denominator, the prompt itself was still pathological.

## Impact (30 active skills)

| | tokens |
| --- | --- |
| Before (full body inlined) | ~90K |
| After (compact name+desc+preview+runtime path) | ~6K |
| Reclaimed per turn | **~84K** |

The trade-off is one extra `Read` per skill the agent actually decides to invoke — bounded, paid only when the skill is used.

## Test plan

- [x] `tests/unit/skills-compact-context.test.ts` updated:
  - `#1960` source-shape tests retained (mode option still exists, compact path still tells the agent to open SKILL.md).
  - **Two new `#2041` behavioral tests:**
    1. No opts → emits compact content with `Before using this skill, open …` and NO full body marker.
    2. `mode: "full"` → emits the full body marker (escape hatch preserved).
- [x] Full vitest suite passes (1418/1418 — net +2 vs main).
- [x] Biome clean on touched files.

## Out of scope

- The defense-in-depth fallback at `agent.store.ts:3486-3503` (overflow-triggered compact re-fetch) is now effectively a no-op since compact is already the default. Left in place — it's harmless and self-documenting.

Fixes #2041. Stacks naturally with #2042 (denominator fix for #2040).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
