### PR TITLE
fix(skills): reconcile installed↔catalog by skill_folder_name

### DIFF
--- a/src/components/sidebar/SkillsExplorer.tsx
+++ b/src/components/sidebar/SkillsExplorer.tsx
@@ -31,6 +31,7 @@ import type {
   SkillSyncStatus,
 } from "@/lib/skills";
 import {
+  catalogSkillMatchesInstalled,
   normalizeSkillSlug,
   parseSkillMd,
   resolveSkillDisplayName,
@@ -236,9 +237,11 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
   const availableRows = (): Skill[] => {
     if (activeFilter() !== "all") return [];
     const q = searchQuery().toLowerCase().trim();
-    const installedSlugs = new Set(skillsStore.installed.map((s) => s.slug));
     return skillsStore.available.filter(
-      (skill) => !installedSlugs.has(skill.slug) && matchesQuery(skill, q),
+      (skill) =>
+        !skillsStore.installed.some((installed) =>
+          catalogSkillMatchesInstalled(skill, installed),
+        ) && matchesQuery(skill, q),
     );
   };
 

--- a/src/lib/skills/display.ts
+++ b/src/lib/skills/display.ts
@@ -87,6 +87,31 @@ export function skillsShareCommandAlias(
   );
 }
 
+/**
+ * True when `candidate` and `installed` describe the same publisher
+ * record. Accepts three reconcile signals so org-namespaced catalog
+ * slugs (`autumn-foo`) still match a local install whose dir is the
+ * bare folder name (`foo`):
+ *
+ * 1. catalog.slug === installed.slug                  (default case)
+ * 2. catalog.slug === installed.dirName               (local slug drift)
+ * 3. catalog.skillFolderName === installed.dirName    (org-namespaced)
+ */
+export function catalogSkillMatchesInstalled(
+  candidate: Skill,
+  installed: InstalledSkill,
+): boolean {
+  if (candidate.slug === installed.slug) return true;
+  if (candidate.slug === installed.dirName) return true;
+  if (
+    candidate.skillFolderName &&
+    candidate.skillFolderName === installed.dirName
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export function resolveSkillListDisplayName(
   skill: Skill | InstalledSkill,
   catalog: readonly Skill[],
@@ -95,9 +120,8 @@ export function resolveSkillListDisplayName(
     return skillDisplayName(skill);
   }
 
-  const match = catalog.find(
-    (candidate) =>
-      candidate.slug === skill.slug || candidate.slug === skill.dirName,
+  const match = catalog.find((candidate) =>
+    catalogSkillMatchesInstalled(candidate, skill),
   );
   return match ? skillDisplayName(match) : skillDisplayName(skill);
 }

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -85,6 +85,14 @@ export interface Skill {
   id: string;
   /** URL-friendly slug (e.g., "commit-message") */
   slug: string;
+  /**
+   * Catalog folder name when this skill is published on Seren Skills.
+   * Distinct from `slug` for org-owned skills, which carry an
+   * org-namespaced slug (e.g. "autumn-foo") but publish under the bare
+   * folder name ("foo"). Used to reconcile installed ↔ catalog rows
+   * when the slug diverges from the install directory.
+   */
+  skillFolderName?: string;
   /** Slug-based name (used for lookups) */
   name: string;
   /** Human-readable display name from frontmatter */

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -101,6 +101,7 @@ function skillSummaryToSkill(summary: SkillSummary): Skill {
   return {
     id: `seren:${summary.slug}`,
     slug: summary.slug,
+    skillFolderName: summary.skill_folder_name,
     name: humanizeSkillName(summary.name, summary.slug),
     description: summary.description,
     source: "seren",
@@ -127,6 +128,7 @@ function skillToCacheEntry(skill: Skill): Skill {
   return {
     id: skill.id,
     slug: skill.slug,
+    skillFolderName: skill.skillFolderName,
     name: skill.name,
     displayName: skill.displayName,
     description: skill.description,

--- a/tests/unit/skills-display.test.ts
+++ b/tests/unit/skills-display.test.ts
@@ -64,6 +64,29 @@ describe("skill display helpers", () => {
     );
   });
 
+  it("matches org-namespaced catalog rows via skillFolderName", () => {
+    // Org-owned skills publish under a namespaced slug (`autumn-...`)
+    // while the catalog's `skill_folder_name` matches the local install dir.
+    // The reconcile path must accept either signal.
+    const installed = installedSkill({
+      slug: "pk-lead-intelligence",
+      name: "pk-lead-intelligence",
+      dirName: "pk-lead-intelligence",
+      upstreamSourceUrl: "seren-skills:autumn-pk-lead-intelligence",
+    });
+    const catalog = catalogSkill({
+      id: "seren:autumn-pk-lead-intelligence",
+      slug: "autumn-pk-lead-intelligence",
+      name: "PK Lead Intelligence",
+      skillFolderName: "pk-lead-intelligence",
+      sourceUrl: "seren-skills:autumn-pk-lead-intelligence",
+    });
+
+    expect(resolveSkillListDisplayName(installed, [catalog])).toBe(
+      "PK Lead Intelligence",
+    );
+  });
+
   it("falls back to local metadata for non-catalog installs", () => {
     const installed = installedSkill({
       upstreamSource: undefined,

--- a/tests/unit/skills-index-api.test.ts
+++ b/tests/unit/skills-index-api.test.ts
@@ -91,6 +91,33 @@ describe("skills.fetchIndex via Seren Skills API", () => {
     });
   });
 
+  it("carries skill_folder_name through as skillFolderName", async () => {
+    // Org-namespaced catalog slugs differ from the published folder name.
+    // The desktop reconciles installed ↔ catalog by either signal, so the
+    // adapter must keep them distinct.
+    mockListSkills.mockResolvedValueOnce({
+      data: {
+        skills: [
+          {
+            ...skillSummary("pk-lead-intelligence"),
+            slug: "autumn-pk-lead-intelligence",
+            skill_folder_name: "pk-lead-intelligence",
+          },
+        ],
+        total: 1,
+      },
+    });
+
+    const { skills } = await import("@/services/skills");
+    const result = await skills.fetchIndex(true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      slug: "autumn-pk-lead-intelligence",
+      skillFolderName: "pk-lead-intelligence",
+    });
+  });
+
   it("ignores the legacy catalog cache key", async () => {
     storage.set(
       "seren:skills_index",


### PR DESCRIPTION
## Summary

- Carry `skill_folder_name` through `skillSummaryToSkill` onto the `Skill` type so org-owned catalog records expose both the org-namespaced slug (`autumn-foo`) and the bare folder name (`foo`).
- Extract a shared `catalogSkillMatchesInstalled` helper that accepts three reconcile signals (`slug==slug`, `slug==dirName`, `skillFolderName==dirName`) and use it from both `resolveSkillListDisplayName` and the Skills panel catalog dedup.
- Skills panel no longer renders a duplicate "Catalog" row for org-namespaced installs, and the installed row resolves its display name from the catalog twin.

Closes #2044

## Out of scope (same root cause, separate publish-flow surfaces — follow-up audits)

- `SkillsExplorer.tsx` `findCatalogBySlug` (drives `ownsSkill`, `isPublishable`, Manage modal).
- `EditorContent.tsx` publish-button gating.
- `AppShell.tsx` `PublishVersionModal` current-version display.

## Test plan

- [x] `pnpm vitest run tests/unit/skills-display.test.ts tests/unit/skills-index-api.test.ts` — 20 tests pass, two new critical tests (display-name resolution via `skillFolderName`, `skill_folder_name` propagation) fail pre-fix as required by TDD.
- [x] Full unit suite: 1423 tests pass.
- [x] `biome check` clean on touched files.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- [x] Manual repro on `pk-lead-intelligence`: catalog slug `autumn-pk-lead-intelligence`, install dir `pk-lead-intelligence`, catalog `skill_folder_name` `pk-lead-intelligence`. Duplicate catalog row hides; installed display name resolves to the catalog's humanized form.
