### PR TITLE
fix(release): retry transient asset uploads in publish-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -762,6 +762,11 @@ jobs:
       - name: Publish release
         uses: actions/github-script@v9
         with:
+          # uploads.github.com occasionally exceeds undici's 5min Headers
+          # Timeout on large updater archives. The upload loop is idempotent
+          # (skips assets already present on the release), so retry transient
+          # failures instead of dying mid-walk and stranding R2 mirror steps.
+          retries: 3
           script: |
             const fs = require('fs');
             const path = require('path');


### PR DESCRIPTION
## Summary

- Adds `retries: 3` to the `Publish release` github-script step in `.github/workflows/release.yml`.
- Recovers from transient `uploads.github.com` failures (e.g. undici Headers Timeout on large updater archives) without restarting the whole publish job.
- Idempotent — relies on the existing `existingNames.has` skip in the upload loop, so already-uploaded assets are not re-sent on retry.

Closes #2048. Context: [v3.46.5 run 26481449849](https://github.com/serenorg/seren-desktop/actions/runs/26481449849/job/77982525324) died mid-walk after a 158MB POST timed out at 302s, stranding 3 missing assets, the un-draft step, and every R2 mirror/latest.json step.

## Test plan

- [ ] After merge, rerun the failed \`publish-release\` job on the v3.46.5 workflow run via \`gh run rerun 26481449849 --failed\`.
- [ ] Confirm draft \`untagged-530d963928915ed88785\` is un-drafted, tag \`v3.46.5\` is bound, and all 16 assets are present on the release.
- [ ] Confirm R2 \`latest.json\` reports version \`3.46.5\` and links to v3.46.5 artifacts.
- [ ] Confirm R2 \`v3.46.5/\` directory contains all installers + updater tar.gz/sig pairs.