### PR TITLE
Add native social login to desktop

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1,0 +1,109 @@
+// ABOUTME: Host-side authentication commands for native SerenDB sign-in.
+// ABOUTME: Opens system-browser OAuth flows without exposing token material.
+
+use std::collections::HashMap;
+use tauri_plugin_opener::OpenerExt;
+use url::Url;
+
+const CLIENT_ID: &str = "seren-desktop";
+const REDIRECT_URI: &str = "http://127.0.0.1:8787/auth/callback";
+
+#[tauri::command]
+pub async fn start_social_login(
+    app: tauri::AppHandle,
+    provider: String,
+    auth_url: String,
+) -> Result<(), String> {
+    let auth_url = validate_authorize_url(&auth_url, &provider)?;
+    let open_url = resolve_provider_redirect(&auth_url)
+        .await?
+        .unwrap_or_else(|| auth_url.to_string());
+
+    app.opener()
+        .open_url(open_url, None::<&str>)
+        .map_err(|e| format!("Failed to open browser: {}", e))
+}
+
+fn validate_authorize_url(auth_url: &str, provider: &str) -> Result<Url, String> {
+    if !matches!(provider, "github" | "google" | "microsoft") {
+        return Err("Unsupported social login provider".to_string());
+    }
+
+    let url = Url::parse(auth_url).map_err(|e| format!("Invalid social login URL: {}", e))?;
+    let is_secure = url.scheme() == "https" || is_local_http_url(&url);
+    if !is_secure {
+        return Err("Social login URL must use HTTPS".to_string());
+    }
+    if url.host_str() == Some("console.serendb.com") {
+        return Err("Social login must not route through console.serendb.com".to_string());
+    }
+
+    if url.path() != "/oauth2/authorize" {
+        return Err("Unexpected social login authorize path".to_string());
+    }
+
+    let query: HashMap<String, String> = url.query_pairs().into_owned().collect();
+    if query.get("client_id").map(String::as_str) != Some(CLIENT_ID) {
+        return Err("Unexpected social login client_id".to_string());
+    }
+    if query.get("response_type").map(String::as_str) != Some("code") {
+        return Err("Unexpected social login response_type".to_string());
+    }
+    if query.get("redirect_uri").map(String::as_str) != Some(REDIRECT_URI) {
+        return Err("Unexpected social login redirect_uri".to_string());
+    }
+    if query.get("provider").map(String::as_str) != Some(provider) {
+        return Err("Social login provider mismatch".to_string());
+    }
+    if query.get("code_challenge_method").map(String::as_str) != Some("S256") {
+        return Err("Social login must use S256 PKCE".to_string());
+    }
+    if !query.contains_key("code_challenge") || !query.contains_key("state") {
+        return Err("Social login URL missing PKCE state".to_string());
+    }
+
+    Ok(url)
+}
+
+fn is_local_http_url(url: &Url) -> bool {
+    url.scheme() == "http"
+        && matches!(
+            url.host_str(),
+            Some("localhost") | Some("127.0.0.1") | Some("::1")
+        )
+}
+
+async fn resolve_provider_redirect(auth_url: &Url) -> Result<Option<String>, String> {
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let response = client
+        .get(auth_url.as_str())
+        .send()
+        .await
+        .map_err(|e| format!("Failed to start social login: {}", e))?;
+
+    if !response.status().is_redirection() {
+        return Ok(None);
+    }
+
+    let location = response
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or("Social login redirect missing Location header")?;
+
+    if location.contains("console.serendb.com") {
+        return Err("Social login unexpectedly routed through console.serendb.com".to_string());
+    }
+
+    let location_url =
+        Url::parse(location).map_err(|e| format!("Invalid social login redirect: {}", e))?;
+    if location_url.scheme() != "https" {
+        return Err("Unexpected social login redirect scheme".to_string());
+    }
+
+    Ok(Some(location.to_string()))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_store::StoreExt;
 
 pub mod commands {
+    pub mod auth;
     pub mod chat;
     pub mod claude_memory;
     pub mod cli_installer;
@@ -861,6 +862,7 @@ pub fn run() {
             clear_oauth_credentials,
             get_oauth_providers,
             // OAuth browser flow commands
+            commands::auth::start_social_login,
             start_oauth_browser_flow,
             get_oauth_callback_port,
             // Build info

--- a/src-tauri/src/oauth_callback_server.rs
+++ b/src-tauri/src/oauth_callback_server.rs
@@ -1,10 +1,20 @@
 // ABOUTME: OAuth callback HTTP server for localhost OAuth redirects.
 // ABOUTME: Runs on all builds to support Windows (no deep links) and dev mode.
 
+use serde::Serialize;
 use std::sync::Arc;
 use std::thread;
 use tauri::{AppHandle, Emitter};
 use tiny_http::{Response, Server};
+use url::form_urlencoded;
+
+#[derive(Clone, Debug, Default, Serialize)]
+struct SocialLoginCallbackPayload {
+    code: Option<String>,
+    state: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
 
 /// Handle to the running OAuth server. Unblocks the listener on drop
 /// so the background thread exits cleanly when the app shuts down.
@@ -35,14 +45,72 @@ pub fn start_oauth_callback_server(app_handle: AppHandle) -> Option<OAuthServerH
     let thread_server = Arc::clone(&server);
 
     thread::spawn(move || {
-        log::info!("[OAuth Server] Listening on http://localhost:8787/oauth/callback");
+        log::info!(
+            "[OAuth Server] Listening on http://localhost:8787/oauth/callback and /auth/callback"
+        );
 
         for request in thread_server.incoming_requests() {
-            let url = request.url();
+            let url = request.url().to_string();
 
-            // Only handle /oauth/callback path
-            if url.starts_with("/oauth/callback") {
-                log::info!("[OAuth Server] Received callback: {}", url);
+            if url.starts_with("/auth/callback") {
+                log::info!("[OAuth Server] Received social login callback");
+
+                let payload = parse_social_login_callback(&url);
+                if let Err(e) = app_handle.emit("social-login-callback", payload) {
+                    log::error!("[OAuth Server] Failed to emit social login event: {}", e);
+                }
+
+                let html = r#"
+                    <!DOCTYPE html>
+                    <html>
+                    <head>
+                        <title>Return to Seren Desktop</title>
+                        <style>
+                            body {
+                                font-family: system-ui, -apple-system, sans-serif;
+                                display: flex;
+                                align-items: center;
+                                justify-content: center;
+                                height: 100vh;
+                                margin: 0;
+                                background: #f5f5f5;
+                            }
+                            .container {
+                                text-align: center;
+                                background: white;
+                                padding: 2rem;
+                                border-radius: 8px;
+                                box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+                            }
+                            h1 { color: #111827; margin: 0 0 0.5rem; }
+                            p { color: #666; margin: 0; }
+                        </style>
+                    </head>
+                    <body>
+                        <div class="container">
+                            <h1>You can return to Seren Desktop</h1>
+                            <p>Sign-in is complete.</p>
+                        </div>
+                        <script>
+                            setTimeout(() => window.close(), 1000);
+                        </script>
+                    </body>
+                    </html>
+                "#;
+
+                let response = Response::from_string(html).with_header(
+                    tiny_http::Header::from_bytes(
+                        &b"Content-Type"[..],
+                        &b"text/html; charset=utf-8"[..],
+                    )
+                    .unwrap(),
+                );
+
+                if let Err(e) = request.respond(response) {
+                    log::error!("[OAuth Server] Failed to send response: {}", e);
+                }
+            } else if url.starts_with("/oauth/callback") {
+                log::info!("[OAuth Server] Received publisher OAuth callback: {}", url);
 
                 // Build full callback URL (localhost:8787 + path + query)
                 let callback_url = format!("http://localhost:8787{}", url);
@@ -114,4 +182,21 @@ pub fn start_oauth_callback_server(app_handle: AppHandle) -> Option<OAuthServerH
     });
 
     Some(OAuthServerHandle { server })
+}
+
+fn parse_social_login_callback(url: &str) -> SocialLoginCallbackPayload {
+    let query = url.split_once('?').map(|(_, query)| query).unwrap_or("");
+    let mut payload = SocialLoginCallbackPayload::default();
+
+    for (key, value) in form_urlencoded::parse(query.as_bytes()) {
+        match key.as_ref() {
+            "code" => payload.code = Some(value.into_owned()),
+            "state" => payload.state = Some(value.into_owned()),
+            "error" => payload.error = Some(value.into_owned()),
+            "error_description" => payload.error_description = Some(value.into_owned()),
+            _ => {}
+        }
+    }
+
+    payload
 }

--- a/src/assets/oauth-logos/microsoft.svg
+++ b/src/assets/oauth-logos/microsoft.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2 2H9V9H2V2Z" fill="#F25022"/>
+  <path d="M11 2H18V9H11V2Z" fill="#7FBA00"/>
+  <path d="M2 11H9V18H2V11Z" fill="#00A4EF"/>
+  <path d="M11 11H18V18H11V11Z" fill="#FFB900"/>
+</svg>

--- a/src/components/auth/SignIn.tsx
+++ b/src/components/auth/SignIn.tsx
@@ -1,11 +1,29 @@
 // ABOUTME: Sign-in form component for user authentication.
-// ABOUTME: Handles email/password login.
+// ABOUTME: Handles email/password and social provider login.
 
-import { type Component, createSignal, Show } from "solid-js";
+import { type Component, createSignal, For, Show } from "solid-js";
+import githubLogo from "@/assets/oauth-logos/github.svg";
+import googleLogo from "@/assets/oauth-logos/google.svg";
+import microsoftLogo from "@/assets/oauth-logos/microsoft.svg";
 import { openExternalLink } from "@/lib/external-link";
 import { login } from "@/services/auth";
+import {
+  type SocialLoginProvider,
+  startSocialLogin,
+} from "@/services/social-login";
 
-type LoginPhase = "credentials" | "signing-in" | "completing";
+type OAuthLoginPhase = `oauth-${SocialLoginProvider}`;
+type LoginPhase = "credentials" | "signing-in" | "completing" | OAuthLoginPhase;
+
+const SOCIAL_PROVIDERS: Array<{
+  id: SocialLoginProvider;
+  label: string;
+  logo: string;
+}> = [
+  { id: "github", label: "GitHub", logo: githubLogo },
+  { id: "google", label: "Google", logo: googleLogo },
+  { id: "microsoft", label: "Microsoft", logo: microsoftLogo },
+];
 
 interface SignInProps {
   onSuccess: () => Promise<void> | void;
@@ -18,6 +36,34 @@ export const SignIn: Component<SignInProps> = (props) => {
   const [phase, setPhase] = createSignal<LoginPhase>("credentials");
 
   const isLoading = () => phase() !== "credentials";
+
+  const oauthPhaseFor = (provider: SocialLoginProvider): OAuthLoginPhase =>
+    `oauth-${provider}`;
+
+  const completeSignIn = async () => {
+    setPhase("completing");
+    try {
+      await props.onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sign-in setup failed");
+      setPhase("credentials");
+    }
+  };
+
+  const handleSocialLogin = async (provider: SocialLoginProvider) => {
+    setError("");
+    setPhase(oauthPhaseFor(provider));
+
+    try {
+      await startSocialLogin(provider);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Social sign-in failed");
+      setPhase("credentials");
+      return;
+    }
+
+    await completeSignIn();
+  };
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -44,13 +90,7 @@ export const SignIn: Component<SignInProps> = (props) => {
     }
 
     // Phase 2: Complete
-    setPhase("completing");
-    try {
-      await props.onSuccess();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Sign-in setup failed");
-      setPhase("credentials");
-    }
+    await completeSignIn();
   };
 
   const getButtonText = () => {
@@ -76,6 +116,37 @@ export const SignIn: Component<SignInProps> = (props) => {
             {error()}
           </div>
         </Show>
+
+        <div class="flex flex-col gap-3">
+          <For each={SOCIAL_PROVIDERS}>
+            {(provider) => (
+              <button
+                type="button"
+                aria-label={`Sign in with ${provider.label}`}
+                class="w-full h-11 px-4 bg-background/70 border border-border rounded-lg text-[14px] font-medium text-foreground cursor-pointer transition-all duration-150 hover:bg-surface-2 hover:border-primary/40 disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-3"
+                disabled={isLoading()}
+                onClick={() => {
+                  void handleSocialLogin(provider.id);
+                }}
+              >
+                <img src={provider.logo} alt="" class="w-5 h-5 shrink-0" />
+                <span>
+                  {phase() === oauthPhaseFor(provider.id)
+                    ? `Opening ${provider.label}...`
+                    : `Sign in with ${provider.label}`}
+                </span>
+              </button>
+            )}
+          </For>
+        </div>
+
+        <div class="my-6 flex items-center gap-3">
+          <div class="h-px flex-1 bg-border" />
+          <span class="text-[11px] font-semibold text-muted-foreground">
+            OR SIGN IN WITH EMAIL
+          </span>
+          <div class="h-px flex-1 bg-border" />
+        </div>
 
         <form class="flex flex-col gap-5" onSubmit={handleSubmit}>
           <div class="flex flex-col gap-2">
@@ -115,7 +186,8 @@ export const SignIn: Component<SignInProps> = (props) => {
             />
             <button
               type="button"
-              class="self-end mt-1 bg-transparent border-none p-0 text-[12px] text-primary/70 cursor-pointer hover:underline"
+              class="self-end mt-1 bg-transparent border-none p-0 text-[12px] text-primary/70 cursor-pointer hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoading()}
               onClick={() =>
                 openExternalLink("https://console.serendb.com/forgot-password")
               }
@@ -144,7 +216,8 @@ export const SignIn: Component<SignInProps> = (props) => {
           Don't have an account?{" "}
           <button
             type="button"
-            class="bg-transparent border-none p-0 text-primary cursor-pointer hover:underline"
+            class="bg-transparent border-none p-0 text-primary cursor-pointer hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={isLoading()}
             onClick={() =>
               openExternalLink("https://console.serendb.com/signup")
             }

--- a/src/services/social-login.ts
+++ b/src/services/social-login.ts
@@ -1,0 +1,239 @@
+// ABOUTME: Native SerenDB social sign-in flow for desktop.
+// ABOUTME: Uses PKCE, loopback callback events, and secure token storage.
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentUser, listOrganizations } from "@/api";
+import { apiBase } from "@/lib/config";
+import { appFetch } from "@/lib/fetch";
+import {
+  storeDefaultOrganizationId,
+  storeRefreshToken,
+  storeToken,
+} from "@/lib/tauri-bridge";
+
+export type SocialLoginProvider = "github" | "google" | "microsoft";
+
+export interface SocialLoginResult {
+  access_token: string;
+  refresh_token: string;
+  default_organization_id: string;
+  expires_in?: number;
+}
+
+interface SocialLoginCallbackPayload {
+  code?: string;
+  state?: string;
+  error?: string;
+  error_description?: string;
+}
+
+interface TokenPayload {
+  access_token: string;
+  refresh_token: string;
+  default_organization_id?: string;
+  expires_in?: number;
+}
+
+const CLIENT_ID = "seren-desktop";
+const REDIRECT_URI = "http://127.0.0.1:8787/auth/callback";
+const CODE_VERIFIER_LENGTH = 64;
+const STATE_LENGTH = 32;
+
+function generateRandomString(length: number): string {
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+  const randomValues = new Uint8Array(length);
+  crypto.getRandomValues(randomValues);
+  return Array.from(randomValues, (value) => chars[value % chars.length]).join(
+    "",
+  );
+}
+
+async function generateCodeChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(hash)));
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function buildAuthorizeUrl(
+  provider: SocialLoginProvider,
+  state: string,
+  codeChallenge: string,
+): string {
+  const url = new URL("/oauth2/authorize", apiBase);
+  url.search = new URLSearchParams({
+    client_id: CLIENT_ID,
+    response_type: "code",
+    redirect_uri: REDIRECT_URI,
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    provider,
+  }).toString();
+  return url.toString();
+}
+
+function getTokenPayload(json: unknown): TokenPayload {
+  const record = isRecord(json) && isRecord(json.data) ? json.data : json;
+  if (!isRecord(record)) {
+    throw new Error("Token exchange response was not an object");
+  }
+
+  const accessToken = record.access_token;
+  const refreshToken = record.refresh_token;
+  if (typeof accessToken !== "string" || typeof refreshToken !== "string") {
+    throw new Error("Token exchange response missing tokens");
+  }
+
+  return {
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    default_organization_id:
+      typeof record.default_organization_id === "string"
+        ? record.default_organization_id
+        : undefined,
+    expires_in:
+      typeof record.expires_in === "number" ? record.expires_in : undefined,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function exchangeCodeForTokens(
+  code: string,
+  codeVerifier: string,
+): Promise<TokenPayload> {
+  const tokenUrl = new URL("/oauth2/token", apiBase).toString();
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: REDIRECT_URI,
+    client_id: CLIENT_ID,
+    code_verifier: codeVerifier,
+  });
+
+  const response = await appFetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(
+      detail
+        ? `Social login token exchange failed: ${detail}`
+        : "Social login token exchange failed",
+    );
+  }
+
+  return getTokenPayload(await response.json());
+}
+
+async function resolveDefaultOrganizationId(
+  tokenDefaultOrganizationId: string | undefined,
+): Promise<string> {
+  const { data: userData } = await getCurrentUser({ throwOnError: false });
+  const currentDefaultOrgId = userData?.data?.default_organization_id;
+  if (currentDefaultOrgId) {
+    return currentDefaultOrgId;
+  }
+
+  if (tokenDefaultOrganizationId) {
+    return tokenDefaultOrganizationId;
+  }
+
+  const { data: orgData } = await listOrganizations({ throwOnError: false });
+  const organizations = orgData?.data ?? [];
+  const fallbackOrganization =
+    organizations.find((organization) => organization.is_personal) ??
+    organizations[0];
+  if (fallbackOrganization?.id) {
+    return fallbackOrganization.id;
+  }
+
+  throw new Error("Unable to determine default organization");
+}
+
+function createCallbackWaiter(expectedState: string): {
+  handler: (event: { payload: SocialLoginCallbackPayload }) => void;
+  promise: Promise<SocialLoginCallbackPayload>;
+} {
+  let resolveCallback!: (payload: SocialLoginCallbackPayload) => void;
+  let rejectCallback!: (error: Error) => void;
+  const promise = new Promise<SocialLoginCallbackPayload>((resolve, reject) => {
+    resolveCallback = resolve;
+    rejectCallback = reject;
+  });
+
+  return {
+    handler: (event) => {
+      const payload = event.payload;
+
+      if (payload.error) {
+        rejectCallback(
+          new Error(
+            payload.error_description
+              ? `${payload.error}: ${payload.error_description}`
+              : payload.error,
+          ),
+        );
+        return;
+      }
+
+      if (!payload.code || !payload.state) {
+        rejectCallback(new Error("OAuth callback missing authorization code"));
+        return;
+      }
+
+      if (payload.state !== expectedState) {
+        rejectCallback(new Error("OAuth state mismatch. Please try again."));
+        return;
+      }
+
+      resolveCallback(payload);
+    },
+    promise,
+  };
+}
+
+export async function startSocialLogin(
+  provider: SocialLoginProvider,
+): Promise<SocialLoginResult> {
+  const codeVerifier = generateRandomString(CODE_VERIFIER_LENGTH);
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+  const state = generateRandomString(STATE_LENGTH);
+  const authUrl = buildAuthorizeUrl(provider, state, codeChallenge);
+  const callbackWaiter = createCallbackWaiter(state);
+  const unlisten: UnlistenFn = await listen<SocialLoginCallbackPayload>(
+    "social-login-callback",
+    callbackWaiter.handler,
+  );
+
+  try {
+    await invoke("start_social_login", { provider, authUrl });
+    const callback = await callbackWaiter.promise;
+
+    const tokenPayload = await exchangeCodeForTokens(
+      callback.code ?? "",
+      codeVerifier,
+    );
+    await storeToken(tokenPayload.access_token);
+    await storeRefreshToken(tokenPayload.refresh_token);
+    const defaultOrganizationId = await resolveDefaultOrganizationId(
+      tokenPayload.default_organization_id,
+    );
+    await storeDefaultOrganizationId(defaultOrganizationId);
+
+    return {
+      ...tokenPayload,
+      default_organization_id: defaultOrganizationId,
+    };
+  } finally {
+    unlisten();
+  }
+}

--- a/tests/services/social-login.test.ts
+++ b/tests/services/social-login.test.ts
@@ -1,0 +1,190 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentUser, listOrganizations } from "@/api";
+import { appFetch } from "@/lib/fetch";
+import {
+  storeDefaultOrganizationId,
+  storeRefreshToken,
+  storeToken,
+} from "@/lib/tauri-bridge";
+import { startSocialLogin } from "@/services/social-login";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock("@/lib/fetch", () => ({
+  appFetch: vi.fn(),
+}));
+
+vi.mock("@/api", () => ({
+  getCurrentUser: vi.fn(),
+  listOrganizations: vi.fn(),
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  storeDefaultOrganizationId: vi.fn(),
+  storeRefreshToken: vi.fn(),
+  storeToken: vi.fn(),
+}));
+
+const invokeMock = vi.mocked(invoke);
+const listenMock = vi.mocked(listen);
+const appFetchMock = vi.mocked(appFetch);
+const getCurrentUserMock = vi.mocked(getCurrentUser);
+const listOrganizationsMock = vi.mocked(listOrganizations);
+const storeTokenMock = vi.mocked(storeToken);
+const storeRefreshTokenMock = vi.mocked(storeRefreshToken);
+const storeDefaultOrganizationIdMock = vi.mocked(storeDefaultOrganizationId);
+
+type SocialLoginCallback = (event: {
+  payload: { code?: string; state?: string; error?: string };
+}) => void | Promise<void>;
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function waitForInvoke() {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (invokeMock.mock.calls.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("start_social_login was not invoked");
+}
+
+async function s256(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Buffer.from(digest).toString("base64url");
+}
+
+async function startAndCompleteSocialLogin(provider: "github" | "google") {
+  let callback: SocialLoginCallback | undefined;
+  const unlisten = vi.fn();
+  listenMock.mockImplementation(async (_event, handler) => {
+    callback = handler as SocialLoginCallback;
+    return unlisten;
+  });
+
+  invokeMock.mockResolvedValue(undefined);
+  appFetchMock.mockResolvedValue(
+    jsonResponse({
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      expires_in: 3600,
+    }),
+  );
+  getCurrentUserMock.mockResolvedValue({
+    data: { data: { default_organization_id: "org-current" } },
+  } as Awaited<ReturnType<typeof getCurrentUser>>);
+  listOrganizationsMock.mockResolvedValue({
+    data: { data: [{ id: "org-list", is_personal: true }] },
+  } as Awaited<ReturnType<typeof listOrganizations>>);
+
+  const promise = startSocialLogin(provider);
+  await waitForInvoke();
+
+  const [, { authUrl }] = invokeMock.mock.calls[0] as [
+    string,
+    { provider: string; authUrl: string },
+  ];
+  const authorizeUrl = new URL(authUrl);
+  const state = authorizeUrl.searchParams.get("state");
+  expect(state).toBeTruthy();
+
+  await callback?.({ payload: { code: "auth-code", state: state ?? "" } });
+  const result = await promise;
+
+  return { authorizeUrl, result, unlisten };
+}
+
+describe("social login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds the native OAuth authorize URL with provider and S256 PKCE", async () => {
+    const { authorizeUrl } = await startAndCompleteSocialLogin("github");
+
+    expect(invokeMock).toHaveBeenCalledWith("start_social_login", {
+      provider: "github",
+      authUrl: expect.stringContaining("https://api.serendb.com/oauth2/authorize"),
+    });
+    expect(authorizeUrl.origin).toBe("https://api.serendb.com");
+    expect(authorizeUrl.pathname).toBe("/oauth2/authorize");
+    expect(authorizeUrl.searchParams.get("client_id")).toBe("seren-desktop");
+    expect(authorizeUrl.searchParams.get("response_type")).toBe("code");
+    expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(
+      "http://127.0.0.1:8787/auth/callback",
+    );
+    expect(authorizeUrl.searchParams.get("provider")).toBe("github");
+    expect(authorizeUrl.searchParams.get("code_challenge_method")).toBe("S256");
+
+    const [, tokenInit] = appFetchMock.mock.calls[0];
+    const tokenBody = new URLSearchParams(tokenInit?.body as string);
+    expect(authorizeUrl.searchParams.get("code_challenge")).toBe(
+      await s256(tokenBody.get("code_verifier") ?? ""),
+    );
+  });
+
+  it("exchanges the callback code and persists tokens plus default organization", async () => {
+    const { result, unlisten } = await startAndCompleteSocialLogin("google");
+
+    expect(appFetchMock).toHaveBeenCalledWith(
+      "https://api.serendb.com/oauth2/token",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      }),
+    );
+    const [, tokenInit] = appFetchMock.mock.calls[0];
+    const tokenBody = new URLSearchParams(tokenInit?.body as string);
+    expect(tokenBody.get("grant_type")).toBe("authorization_code");
+    expect(tokenBody.get("code")).toBe("auth-code");
+    expect(tokenBody.get("client_id")).toBe("seren-desktop");
+    expect(tokenBody.get("redirect_uri")).toBe(
+      "http://127.0.0.1:8787/auth/callback",
+    );
+    expect(tokenBody.get("code_verifier")).toBeTruthy();
+
+    expect(storeTokenMock).toHaveBeenCalledWith("access-token");
+    expect(storeRefreshTokenMock).toHaveBeenCalledWith("refresh-token");
+    expect(getCurrentUserMock).toHaveBeenCalledWith({ throwOnError: false });
+    expect(storeDefaultOrganizationIdMock).toHaveBeenCalledWith("org-current");
+    expect(result.default_organization_id).toBe("org-current");
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects callbacks with a mismatched state before exchanging tokens", async () => {
+    let callback: SocialLoginCallback | undefined;
+    const unlisten = vi.fn();
+    listenMock.mockImplementation(async (_event, handler) => {
+      callback = handler as SocialLoginCallback;
+      return unlisten;
+    });
+    invokeMock.mockResolvedValue(undefined);
+
+    const promise = startSocialLogin("github");
+    await waitForInvoke();
+
+    await callback?.({
+      payload: { code: "auth-code", state: "wrong-state" },
+    });
+
+    await expect(promise).rejects.toThrow("OAuth state mismatch");
+    expect(appFetchMock).not.toHaveBeenCalled();
+    expect(storeTokenMock).not.toHaveBeenCalled();
+    expect(storeRefreshTokenMock).not.toHaveBeenCalled();
+    expect(storeDefaultOrganizationIdMock).not.toHaveBeenCalled();
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add GitHub, Google, and Microsoft sign-in buttons to the desktop login card
- add PKCE social-login service using /oauth2/authorize provider fast-path, /auth/callback loopback events, and secure tauri-bridge token storage
- add Tauri start_social_login command plus /auth/callback loopback handling

Fixes #2050

## Tests
- ../issue-2039/node_modules/.bin/vitest run tests/services/social-login.test.ts
- ../issue-2039/node_modules/.bin/biome check src/components/auth/SignIn.tsx src/services/social-login.ts tests/services/social-login.test.ts
- rustfmt --edition 2024 --check --config skip_children=true src/lib.rs src/oauth_callback_server.rs src/commands/auth.rs
- cargo check (with temporary local src-tauri/mcp-servers/playwright-stealth symlink for the existing Tauri resource path)
- ../issue-2039/node_modules/.bin/vite build (with temporary local node_modules symlink; completed with existing Rolldown annotation/chunk warnings)
- git diff --check

## Audit
- Reconfirmed no access or refresh tokens are logged; persistence goes through tauri-bridge secure storage.
- Reconfirmed callback state mismatch rejects before token exchange or persistence.
- Reconfirmed the host command rejects console.serendb.com routing and resolves the Gateway provider redirect before opening the browser.
- Reconfirmed companion serenorg/seren-core#180 is closed as completed.