### PR TITLE
fix(build): detect Windows CLI invocation in prepare-python-runtime (#2053)

### DIFF
--- a/build/win32/prepare-python-runtime.ts
+++ b/build/win32/prepare-python-runtime.ts
@@ -6,6 +6,7 @@ import * as fs from "fs";
 import * as https from "https";
 import * as path from "path";
 import { pipeline } from "stream/promises";
+import { pathToFileURL } from "node:url";
 
 // Version configuration — keep this pinned. The Python freshness workflow
 // (.github/workflows/check-python-version.yml) opens a PR to bump the patch
@@ -195,10 +196,30 @@ export async function preparePythonRuntime(
 	return { pythonDir };
 }
 
+// Cross-platform check for "this module was invoked as a CLI". On Windows,
+// `import.meta.url` is `file:///D:/.../prepare-python-runtime.ts` (POSIX
+// slashes, three slashes after `file:`) while `process.argv[1]` is a
+// backslash path with a drive letter — naive string-concat comparisons miss
+// every Windows invocation and the script exits as a silent no-op, leaving
+// `embedded-runtime/win32-x64/python/` empty in every Windows installer
+// (serenorg/seren-desktop#2053). `pathToFileURL` normalises both forms.
+//
+// Exported for the regression test in `tests/unit/prepare-python-cli-detection.test.ts`.
+export function isInvokedAsCli(
+	importMetaUrl: string,
+	argv1: string | undefined,
+): boolean {
+	if (!argv1) return false;
+	try {
+		return importMetaUrl === pathToFileURL(argv1).href;
+	} catch {
+		return false;
+	}
+}
+
 // CLI entry point (ESM compatible). Mirrors prepare-embedded-runtime.ts so
 // `pnpm prepare:python:win32-<arch>` writes alongside the Node bundle.
-const isCli = import.meta.url === `file://${process.argv[1]}`;
-if (isCli) {
+if (isInvokedAsCli(import.meta.url, process.argv[1])) {
 	const arch = (process.argv[2] as "x64" | "arm64") || "x64";
 	const outputDir =
 		process.argv[3] ||

--- a/tests/unit/prepare-python-cli-detection.test.ts
+++ b/tests/unit/prepare-python-cli-detection.test.ts
@@ -1,0 +1,24 @@
+// ABOUTME: Regression test for serenorg/seren-desktop#2053.
+// ABOUTME: Asserts the Python prepare script detects CLI invocation on Windows.
+
+import { describe, expect, it } from "vitest";
+import { pathToFileURL } from "node:url";
+
+import { isInvokedAsCli } from "../../build/win32/prepare-python-runtime";
+
+describe("prepare-python-runtime CLI detection (regression #2053)", () => {
+  // Before the fix, the script gated its CLI body on
+  //   import.meta.url === `file://${process.argv[1]}`
+  // which on Windows compared `file:///D:/a/.../prepare-python-runtime.ts`
+  // (POSIX, three slashes) to `file://D:\a\...\prepare-python-runtime.ts`
+  // (backslashes, two slashes, drive letter parsed as host). The strings
+  // never matched, so `pnpm prepare:python:win32-x64` exited as a no-op,
+  // the installer shipped without `python.exe`, and the runtime health
+  // check fired for every Windows user. This single assertion locks the
+  // contract: a backslash Windows path must resolve as "invoked as CLI".
+  it("matches when argv[1] is a Windows-style backslash path", () => {
+    const winArgv =
+      "D:\\a\\seren-desktop\\seren-desktop\\build\\win32\\prepare-python-runtime.ts";
+    expect(isInvokedAsCli(pathToFileURL(winArgv).href, winArgv)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the broken `import.meta.url === \`file://\${process.argv[1]}\`` CLI guard in `build/win32/prepare-python-runtime.ts` with `pathToFileURL`-normalised comparison so the Python prepare script actually runs on the Windows release runner.
- Add a single regression test asserting a backslash Windows `argv[1]` resolves as "invoked as CLI".

## Root cause

On Windows, `import.meta.url` is `file:///D:/.../prepare-python-runtime.ts` (POSIX slashes, three slashes after `file:`) while `process.argv[1]` is `D:\\a\\...\\prepare-python-runtime.ts` (backslashes, drive letter). Naive string-concat comparison never matched, so the CLI body was skipped, the script exited in ~3 seconds with no output, and every shipped Windows installer was missing `embedded-runtime/win32-x64/python/python.exe`. The runtime health check correctly surfaced the missing bundle to the user.

The peer scripts (`build/{win32,darwin,linux}/prepare-embedded-runtime.ts`) don't have this guard at all — they run unconditionally at module load. Python was the outlier.

CI evidence from v3.46.5 Windows-x64 build (run [26481449849](https://github.com/serenorg/seren-desktop/actions/runs/26481449849)):
```
23:41:05  Run pnpm prepare:python:win32-x64
23:41:06  > tsx build/win32/prepare-python-runtime.ts x64
          (no output — exits silently)
23:41:09  Running beforeBuildCommand …
```
3 seconds total; Node prepare on the same runner took ~60s.

## Audit (full path re-trace)

Only step 2 below was broken — every other link in the chain is already correct.

1. CI runs `pnpm prepare:python:win32-x64` → `.github/workflows/release.yml:290-292` ✅
2. **Script detects CLI invocation on Windows** → fixed here ✅
3. Download / extract Python 3.12.7 to `src-tauri/embedded-runtime/win32-x64/python/` → `preparePython()` unchanged ✅
4. Bootstrap pip (Windows-runner-only) + `python3.exe` alias + `embedded-python.json` → unchanged ✅
5. Tauri bundles `embedded-runtime/` into installer resources → `tauri.conf.json:76-79` unchanged ✅
6. `discover_embedded_runtime` probes `resource_dir/embedded-runtime/win32-x64/python/python.exe` → `embedded_runtime.rs:125-131,226-234` unchanged ✅
7. Python dir prepended to spawn PATH → `embedded_runtime.rs:303-340` unchanged ✅
8. Health check passes when `python_dir.is_some()` → `embedded_runtime.rs:77-97` unchanged ✅

## Test plan

- [x] vitest unit: `tests/unit/prepare-python-cli-detection.test.ts` — fails before fix (`isInvokedAsCli is not a function`), passes after.
- [x] Full unit suite: 1431 / 1431 passing locally.
- [ ] Next release build's `Prepare embedded Python (Windows x64)` step shows real download/extract output and takes >30s.
- [ ] Shipped NSIS installer contains `resources/_up_/embedded-runtime/win32-x64/python/python.exe`.
- [ ] Fresh Windows install can create and run a private skill without the bundled-Python health-check banner.

## Closes

- Closes #2053
- Closes serenorg/seren-skills#837

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com