### PR TITLE
fix(build): prepare bundled Python for Windows packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,25 +278,6 @@ jobs:
             seren-desktop-publishers \
             seren-desktop-mcp
 
-      - name: Prepare embedded runtime (macOS arm64)
-        if: matrix.target == 'aarch64-apple-darwin'
-        run: pnpm prepare:runtime:darwin-arm64
-      - name: Prepare embedded runtime (macOS x64)
-        if: matrix.target == 'x86_64-apple-darwin'
-        run: pnpm prepare:runtime:darwin-x64
-      - name: Prepare embedded runtime (Windows x64)
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        run: pnpm prepare:runtime:win32-x64
-      - name: Prepare embedded Python (Windows x64)
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        run: pnpm prepare:python:win32-x64
-      - name: Prepare embedded runtime (Linux x64)
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: pnpm prepare:runtime:linux-x64
-      - name: Prepare embedded runtime (Linux arm64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: pnpm prepare:runtime:linux-arm64
-
       # macOS: Import certificates and setup keychain (skip if no certificate)
       - name: Import macOS certificates
         if: matrix.os == 'macos-latest' && env.HAS_APPLE_SIGNING == 'true'

--- a/build/prepare-tauri-build.ts
+++ b/build/prepare-tauri-build.ts
@@ -1,0 +1,202 @@
+// ABOUTME: Runs all resource preparation required before `tauri build`.
+// ABOUTME: Keeps platform runtimes, Windows Python, MCP servers, and provider runtime in one build hook.
+
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+type RuntimePlatform = "darwin" | "linux" | "win32";
+type RuntimeArch = "arm64" | "x64";
+
+export interface RuntimeTarget {
+  platform: RuntimePlatform;
+  arch: RuntimeArch;
+}
+
+export interface ResolveRuntimeTargetInput {
+  env?: Record<string, string | undefined>;
+  hostArch?: string;
+  hostPlatform?: string;
+  targetTriple?: string;
+}
+
+export interface TauriPreparationCommand {
+  label: string;
+  command: string;
+  args: string[];
+}
+
+function normalizePlatform(platform: string): RuntimePlatform {
+  switch (platform) {
+    case "darwin":
+    case "macos":
+      return "darwin";
+    case "linux":
+      return "linux";
+    case "windows":
+    case "win32":
+      return "win32";
+    default:
+      throw new Error(`Unsupported Tauri build platform: ${platform}`);
+  }
+}
+
+function normalizeArch(arch: string): RuntimeArch {
+  switch (arch) {
+    case "aarch64":
+    case "arm64":
+      return "arm64";
+    case "x64":
+    case "x86_64":
+      return "x64";
+    default:
+      throw new Error(`Unsupported Tauri build architecture: ${arch}`);
+  }
+}
+
+function targetFromTriple(targetTriple: string): RuntimeTarget | null {
+  const arch = targetTriple.startsWith("aarch64-")
+    ? "arm64"
+    : targetTriple.startsWith("x86_64-")
+      ? "x64"
+      : null;
+
+  if (!arch) return null;
+
+  if (targetTriple.includes("apple-darwin")) {
+    return { platform: "darwin", arch };
+  }
+  if (targetTriple.includes("unknown-linux")) {
+    return { platform: "linux", arch };
+  }
+  if (targetTriple.includes("pc-windows-msvc")) {
+    return { platform: "win32", arch };
+  }
+
+  return null;
+}
+
+function targetTripleFromEnv(env: Record<string, string | undefined>): string | undefined {
+  return (
+    env.TAURI_TARGET_TRIPLE ||
+    env.TAURI_ENV_TARGET_TRIPLE ||
+    env.CARGO_BUILD_TARGET ||
+    env.TARGET_TRIPLE ||
+    env.TARGET
+  );
+}
+
+export function resolveRuntimeTarget(input: ResolveRuntimeTargetInput = {}): RuntimeTarget {
+  const env = input.env ?? process.env;
+  if (input.targetTriple) {
+    const target = targetFromTriple(input.targetTriple);
+    if (target) return target;
+  }
+
+  const tauriPlatform = env.TAURI_ENV_PLATFORM;
+  const tauriArch = env.TAURI_ENV_ARCH;
+  if (tauriPlatform && tauriArch) {
+    return {
+      platform: normalizePlatform(tauriPlatform),
+      arch: normalizeArch(tauriArch),
+    };
+  }
+
+  const envTarget = targetTripleFromEnv(env);
+  if (envTarget) {
+    const target = targetFromTriple(envTarget);
+    if (target) return target;
+  }
+
+  return {
+    platform: normalizePlatform(input.hostPlatform ?? process.platform),
+    arch: normalizeArch(input.hostArch ?? process.arch),
+  };
+}
+
+export function buildTauriPreparationCommands(
+  target: RuntimeTarget,
+): TauriPreparationCommand[] {
+  const commands: TauriPreparationCommand[] = [
+    {
+      label: "Prepare MCP servers",
+      command: "pnpm",
+      args: ["prepare:mcp-servers"],
+    },
+    {
+      label: "Build provider runtime",
+      command: "pnpm",
+      args: ["build:provider-runtime"],
+    },
+    {
+      label: `Prepare embedded runtime (${target.platform}-${target.arch})`,
+      command: "pnpm",
+      args: [`prepare:runtime:${target.platform}-${target.arch}`],
+    },
+  ];
+
+  if (target.platform === "win32") {
+    commands.push({
+      label: `Prepare embedded Python (${target.platform}-${target.arch})`,
+      command: "pnpm",
+      args: [`prepare:python:${target.platform}-${target.arch}`],
+    });
+  }
+
+  commands.push({
+    label: "Sign embedded runtime",
+    command: "pnpm",
+    args: ["sign:embedded-runtime"],
+  });
+
+  return commands;
+}
+
+function executableFor(command: string): string {
+  if (process.platform === "win32" && command === "pnpm") {
+    return "pnpm.cmd";
+  }
+  return command;
+}
+
+function runCommand(command: TauriPreparationCommand): void {
+  console.log(`[prepare-tauri-build] ${command.label}`);
+  const result = spawnSync(executableFor(command.command), command.args, {
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${command.command} ${command.args.join(" ")} failed with exit code ${result.status}`,
+    );
+  }
+}
+
+export function prepareTauriBuild(): void {
+  const target = resolveRuntimeTarget();
+  console.log(
+    `[prepare-tauri-build] Resolved Tauri runtime target: ${target.platform}-${target.arch}`,
+  );
+
+  for (const command of buildTauriPreparationCommands(target)) {
+    runCommand(command);
+  }
+}
+
+const isCli = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+
+if (isCli) {
+  try {
+    prepareTauriBuild();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:runtime-smoke": "node ./scripts/smoke-local-provider-runtime.mjs",
     "test:synthetic-transcript-smoke": "node ./scripts/smoke-synthetic-transcript.mjs",
     "test:runtime-e2e": "node ./scripts/e2e-local-provider-runtime.mjs",
+    "prepare:tauri-build": "tsx build/prepare-tauri-build.ts",
     "prepare:runtime": "tsx build/darwin/prepare-embedded-runtime.ts",
     "prepare:runtime:darwin-x64": "tsx build/darwin/prepare-embedded-runtime.ts x64",
     "prepare:runtime:darwin-arm64": "tsx build/darwin/prepare-embedded-runtime.ts arm64",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   "build": {
     "beforeDevCommand": "pnpm prepare:mcp-servers && pnpm build:provider-runtime && pnpm dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "pnpm prepare:mcp-servers && pnpm build:provider-runtime && pnpm sign:embedded-runtime && pnpm build",
+    "beforeBuildCommand": "pnpm prepare:tauri-build && pnpm build",
     "frontendDist": "../dist"
   },
   "app": {

--- a/tests/unit/tauri-build-runtime-plan.test.ts
+++ b/tests/unit/tauri-build-runtime-plan.test.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Regression coverage for Windows bundles requiring embedded Python.
+// ABOUTME: Keeps Tauri build preparation from omitting python.exe again.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTauriPreparationCommands,
+  resolveRuntimeTarget,
+} from "../../build/prepare-tauri-build";
+
+function scriptNames(commands: ReturnType<typeof buildTauriPreparationCommands>) {
+  return commands.map((command) => command.args[0]);
+}
+
+describe("Tauri build runtime preparation", () => {
+  it("prepares bundled Python for Windows x64 builds before packaging", () => {
+    const target = resolveRuntimeTarget({
+      env: {
+        TAURI_ENV_PLATFORM: "windows",
+        TAURI_ENV_ARCH: "x86_64",
+      },
+      hostPlatform: "linux",
+      hostArch: "x64",
+    });
+
+    expect(target).toEqual({ platform: "win32", arch: "x64" });
+    expect(scriptNames(buildTauriPreparationCommands(target))).toEqual([
+      "prepare:mcp-servers",
+      "build:provider-runtime",
+      "prepare:runtime:win32-x64",
+      "prepare:python:win32-x64",
+      "sign:embedded-runtime",
+    ]);
+  });
+
+  it("does not run the Windows Python prep step for non-Windows builds", () => {
+    const target = resolveRuntimeTarget({
+      targetTriple: "aarch64-apple-darwin",
+      hostPlatform: "linux",
+      hostArch: "x64",
+    });
+
+    expect(target).toEqual({ platform: "darwin", arch: "arm64" });
+    expect(scriptNames(buildTauriPreparationCommands(target))).toEqual([
+      "prepare:mcp-servers",
+      "build:provider-runtime",
+      "prepare:runtime:darwin-arm64",
+      "sign:embedded-runtime",
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

Centralizes Tauri bundle preparation in `pnpm prepare:tauri-build` so every `tauri build` path prepares the platform embedded runtime before packaging.

Audit result:
- The Windows runtime health check was correctly failing because `embedded-runtime/win32-x64/python/python.exe` was absent from the packaged resources.
- `prepare:python:win32-x64` existed, but only the tag release workflow invoked it directly.
- `src-tauri/tauri.conf.json` `beforeBuildCommand` prepared MCP/provider assets but did not prepare the platform runtime or Windows Python, so local/CI/alpha Windows bundles could ship without bundled Python.

Fix:
- Adds a target-aware build prep script using Tauri hook env (`TAURI_ENV_PLATFORM`, `TAURI_ENV_ARCH`) plus target-triple fallbacks.
- Runs `prepare:runtime:<platform-arch>` for all builds.
- Runs `prepare:python:win32-<arch>` for Windows builds before packaging.
- Removes the duplicated release-workflow runtime-prep list so release builds use the same hook path as other Tauri builds.

## Related Issue

Fixes serenorg/seren-skills#837

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [x] No secrets or credentials in code

## Testing

- `./node_modules/.bin/vitest run tests/unit/tauri-build-runtime-plan.test.ts tests/unit/skill-runtime-platform-note.test.ts`
- `./node_modules/.bin/tsx -e "import { buildTauriPreparationCommands, resolveRuntimeTarget } from './build/prepare-tauri-build.ts'; const t = resolveRuntimeTarget({ env: { TAURI_ENV_PLATFORM: 'windows', TAURI_ENV_ARCH: 'x86_64' }, hostPlatform: 'linux', hostArch: 'x64' }); console.log(JSON.stringify({ target: t, scripts: buildTauriPreparationCommands(t).map(c => c.args[0]) }));"`
- `cargo test --manifest-path src-tauri/Cargo.toml embedded_runtime::tests`
- `git diff --check`
