### PR TITLE
fix(build): spawn pnpm hook commands through Windows shell

### DIFF
--- a/build/prepare-tauri-build.ts
+++ b/build/prepare-tauri-build.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Keeps platform runtimes, Windows Python, MCP servers, and provider runtime in one build hook.
 
 import { spawnSync } from "node:child_process";
+import type { SpawnSyncOptions } from "node:child_process";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -160,10 +161,17 @@ function executableFor(command: string): string {
   return command;
 }
 
+export function spawnOptionsForPlatform(
+  platform: NodeJS.Platform | RuntimePlatform,
+): Pick<SpawnSyncOptions, "shell"> {
+  return { shell: platform === "win32" };
+}
+
 function runCommand(command: TauriPreparationCommand): void {
   console.log(`[prepare-tauri-build] ${command.label}`);
   const result = spawnSync(executableFor(command.command), command.args, {
     env: process.env,
+    ...spawnOptionsForPlatform(process.platform),
     stdio: "inherit",
   });
 

--- a/tests/unit/tauri-build-runtime-plan.test.ts
+++ b/tests/unit/tauri-build-runtime-plan.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildTauriPreparationCommands,
   resolveRuntimeTarget,
+  spawnOptionsForPlatform,
 } from "../../build/prepare-tauri-build";
 
 function scriptNames(commands: ReturnType<typeof buildTauriPreparationCommands>) {
@@ -47,5 +48,11 @@ describe("Tauri build runtime preparation", () => {
       "prepare:runtime:darwin-arm64",
       "sign:embedded-runtime",
     ]);
+  });
+
+  it("runs pnpm through a shell on Windows so .cmd shims can spawn", () => {
+    expect(spawnOptionsForPlatform("win32").shell).toBe(true);
+    expect(spawnOptionsForPlatform("darwin").shell).toBe(false);
+    expect(spawnOptionsForPlatform("linux").shell).toBe(false);
   });
 });


### PR DESCRIPTION
## Description

Follow-up to #2055 after the Windows build job exposed a Windows-specific spawn issue in the new Tauri build-prep runner.

Audit result:
- The hook resolved the correct target and reached `prepare:tauri-build` on Windows.
- It failed at the first nested pnpm command with `spawnSync pnpm.cmd EINVAL`.
- Root cause: Node cannot spawn `.cmd` shims directly on Windows without shell execution.

Fix:
- Adds a small spawn-options helper.
- Uses `shell: true` only on Windows so `pnpm.cmd` can execute.
- Keeps direct spawn behavior on macOS/Linux.

## Related Issue

Follow-up for serenorg/seren-skills#837 and serenorg/seren-desktop#2055.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [x] No secrets or credentials in code

## Testing

- `./node_modules/.bin/vitest run tests/unit/tauri-build-runtime-plan.test.ts tests/unit/prepare-python-cli-detection.test.ts`
- `./node_modules/.bin/tsx -e "import { spawnOptionsForPlatform } from './build/prepare-tauri-build.ts'; console.log(JSON.stringify({ win32: spawnOptionsForPlatform('win32'), linux: spawnOptionsForPlatform('linux') }));"`
- `git diff --check`
