### PR TITLE
Preserve Claude model capability flags

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -402,7 +402,80 @@ function buildAvailableModels(session) {
     modelId: record.modelId,
     name: record.name,
     description: record.description,
+    supportsFastMode: record.supportsFastMode === true,
+    supportsAutoMode: record.supportsAutoMode === true,
+    supportsAdaptiveThinking: record.supportsAdaptiveThinking === true,
   }));
+}
+
+function getSelectedModelRecord(session) {
+  if (typeof session.currentModelId === "string" && session.currentModelId) {
+    return (
+      session.availableModelRecords.find(
+        (record) => record.modelId === session.currentModelId,
+      ) ?? null
+    );
+  }
+
+  return (
+    session.availableModelRecords.find((record) => record.isDefault) ??
+    session.availableModelRecords[0] ??
+    null
+  );
+}
+
+function selectedModelSupportsFastMode(session) {
+  return getSelectedModelRecord(session)?.supportsFastMode === true;
+}
+
+function buildFastModeConfigOption(session) {
+  if (!selectedModelSupportsFastMode(session)) {
+    return null;
+  }
+
+  return {
+    id: "fast_mode",
+    name: "Fast Mode",
+    description: "Toggles Claude Code fast mode for this session.",
+    type: "select",
+    currentValue: session.fastModeEnabled === true ? "on" : "off",
+    options: [
+      {
+        value: "on",
+        name: "On",
+        description: "Enable fast mode for future turns in this session.",
+      },
+      {
+        value: "off",
+        name: "Off",
+        description: "Use the model's standard behavior.",
+      },
+    ],
+  };
+}
+
+function buildConfigOptions(session) {
+  const options = [buildEffortConfigOption(session.reasoningEffort)];
+  const fastModeOption = buildFastModeConfigOption(session);
+  if (fastModeOption) {
+    options.push(fastModeOption);
+  }
+  return options;
+}
+
+function buildFastModeFlagSettings(valueId) {
+  switch (valueId) {
+    case "on":
+      return { fastMode: true };
+    case "off":
+      return { fastMode: null };
+    default:
+      throw new Error(`Unsupported fast mode value: ${valueId}`);
+  }
+}
+
+function isFastModeEnabledValue(valueId) {
+  return buildFastModeFlagSettings(valueId).fastMode === true;
 }
 
 function buildSessionStatus(session, status = session.status) {
@@ -426,7 +499,7 @@ function buildSessionStatus(session, status = session.status) {
         }
       : {}),
     modes: buildModeState(session.currentModeId),
-    configOptions: [buildEffortConfigOption(session.reasoningEffort)],
+    configOptions: buildConfigOptions(session),
   };
 }
 
@@ -438,6 +511,9 @@ function normalizeModelRecords(result) {
       name: record?.displayName ?? record?.value ?? "Unknown model",
       description: record?.description ?? undefined,
       supportsEffort: record?.supportsEffort === true,
+      supportsFastMode: record?.supportsFastMode === true,
+      supportsAutoMode: record?.supportsAutoMode === true,
+      supportsAdaptiveThinking: record?.supportsAdaptiveThinking === true,
       supportedEffortLevels: Array.isArray(record?.supportedEffortLevels)
         ? record.supportedEffortLevels.filter(
             (effort) => typeof effort === "string",
@@ -459,6 +535,9 @@ const LEGACY_OPUS_RECORDS = [
     name: "Opus 4.5",
     description: "Previous Opus generation — lower cost than 4.7",
     supportsEffort: false,
+    supportsFastMode: false,
+    supportsAutoMode: false,
+    supportsAdaptiveThinking: false,
     supportedEffortLevels: [],
     isDefault: false,
   },
@@ -467,6 +546,9 @@ const LEGACY_OPUS_RECORDS = [
     name: "Opus 4.6",
     description: "Opus 4.6 — mid-tier Opus",
     supportsEffort: false,
+    supportsFastMode: false,
+    supportsAutoMode: false,
+    supportsAdaptiveThinking: false,
     supportedEffortLevels: [],
     isDefault: false,
   },
@@ -484,6 +566,9 @@ function makeOneMTierRecord(baseId, displayBase) {
     name: `${displayBase} (1M context)`,
     description: `${displayBase} on the 1M-token context tier`,
     supportsEffort: false,
+    supportsFastMode: false,
+    supportsAutoMode: false,
+    supportsAdaptiveThinking: false,
     supportedEffortLevels: [],
     isDefault: false,
   };
@@ -1639,6 +1724,7 @@ export function createClaudeRuntime({ emit }) {
       currentModeId,
       mcpConfigJson,
       spawnEnv,
+      fastModeEnabled: false,
       reasoningEffort:
         normalizeEffort(reasoningEffort) ?? DEFAULT_CLAUDE_EFFORT,
       // Peak per-turn input tokens across the current prompt's tool-call
@@ -2126,17 +2212,38 @@ export function createClaudeRuntime({ emit }) {
     );
 
     session.currentModelId = targetModel?.modelId ?? modelId;
+    session.fastModeEnabled = false;
     emit("provider://session-status", buildSessionStatus(session));
   }
 
   async function setConfigOption({ sessionId, configId, valueId }) {
-    if (configId !== "reasoning_effort") {
-      return null;
-    }
     const session = sessions.get(sessionId);
     if (!session) {
       return null;
     }
+
+    if (configId === "fast_mode") {
+      if (!selectedModelSupportsFastMode(session)) {
+        throw new Error("Fast mode is not supported by the selected Claude model.");
+      }
+      const settings = buildFastModeFlagSettings(valueId);
+      await sendControlRequest(
+        session,
+        {
+          subtype: "apply_flag_settings",
+          settings,
+        },
+        10_000,
+      );
+      session.fastModeEnabled = isFastModeEnabledValue(valueId);
+      emit("provider://session-status", buildSessionStatus(session));
+      return null;
+    }
+
+    if (configId !== "reasoning_effort") {
+      return null;
+    }
+
     const normalized = normalizeEffort(valueId);
     if (!normalized) {
       throw new Error(`Unsupported reasoning effort: ${valueId}`);
@@ -2265,6 +2372,9 @@ export {
   comparePickerEntries as _comparePickerEntries,
   resolveSpawnShell as _resolveSpawnShell,
   buildClaudeArgs as _buildClaudeArgs,
+  normalizeModelRecords as _normalizeModelRecords,
+  buildSessionStatus as _buildSessionStatus,
+  buildFastModeFlagSettings as _buildFastModeFlagSettings,
   handleAssistantMessage as _handleAssistantMessage,
   handleStreamEvent as _handleStreamEvent,
 };

--- a/bin/browser-local/effort.mjs
+++ b/bin/browser-local/effort.mjs
@@ -1,7 +1,7 @@
 // ABOUTME: Pure helpers for Claude Code reasoning effort.
 // ABOUTME: Extracted so buildClaudeArgs mapping can be unit-tested without spawning a process.
 
-export const CLAUDE_EFFORT_VALUES = ["low", "medium", "high", "xhigh"];
+export const CLAUDE_EFFORT_VALUES = ["low", "medium", "high", "xhigh", "max"];
 export const DEFAULT_CLAUDE_EFFORT = "medium";
 
 export function normalizeEffort(value) {

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -82,6 +82,7 @@ import { threadStore } from "@/stores/thread.store";
 import { workspaceStore } from "@/stores/workspace.store";
 import RenderMarkdownWorker from "@/workers/render-markdown.worker?worker";
 import { AgentEffortSelector } from "./AgentEffortSelector";
+import { AgentFastModeSelector } from "./AgentFastModeSelector";
 import { AgentModelSelector } from "./AgentModelSelector";
 import { AgentModeSelector } from "./AgentModeSelector";
 import {
@@ -1979,6 +1980,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 </Show>
                 <AgentModelSelector session={threadSession()} />
                 <AgentModeSelector session={threadSession()} />
+                <AgentFastModeSelector session={threadSession()} />
                 <AgentEffortSelector session={threadSession()} />
                 <SkillsButton
                   recentSkill={recentSkill()}

--- a/src/components/chat/AgentFastModeSelector.tsx
+++ b/src/components/chat/AgentFastModeSelector.tsx
@@ -1,0 +1,79 @@
+// ABOUTME: Toggle for Claude Code fast mode when the active model supports it.
+// ABOUTME: Uses the generic provider config-option bridge.
+
+import type { Component } from "solid-js";
+import { Show } from "solid-js";
+import { type ActiveSession, agentStore } from "@/stores/agent.store";
+
+interface Props {
+  session: ActiveSession | null;
+}
+
+export const AgentFastModeSelector: Component<Props> = (props) => {
+  const availableModels = () => props.session?.availableModels ?? [];
+  const displayModelId = () =>
+    props.session?.userSelectedModelId ?? props.session?.currentModelId;
+
+  const currentModelSupportsFastMode = () => {
+    const id = displayModelId();
+    if (!id) return false;
+    return (
+      availableModels().find((model) => model.modelId === id)
+        ?.supportsFastMode === true
+    );
+  };
+
+  const option = () => {
+    const fastModeOption =
+      props.session?.configOptions?.find(
+        (config) => config.id === "fast_mode" && config.type === "select",
+      ) ?? null;
+    return fastModeOption && currentModelSupportsFastMode()
+      ? fastModeOption
+      : null;
+  };
+
+  const isOn = () => option()?.currentValue === "on";
+
+  const toggleFastMode = () => {
+    if (!option()) return;
+    agentStore.setConfigOption(
+      "fast_mode",
+      isOn() ? "off" : "on",
+      props.session?.info.id,
+    );
+  };
+
+  return (
+    <Show when={option()}>
+      <button
+        type="button"
+        class={`flex items-center gap-1.5 px-2 py-1 border rounded-md text-xs cursor-pointer transition-colors ${
+          isOn()
+            ? "bg-amber-500/15 border-amber-500/40 text-amber-700 dark:text-amber-300 hover:bg-amber-500/20"
+            : "bg-surface-2 border-surface-3 text-foreground hover:bg-surface-3"
+        }`}
+        aria-pressed={isOn()}
+        title={isOn() ? "Disable fast mode" : "Enable fast mode"}
+        onClick={toggleFastMode}
+      >
+        <svg
+          class="w-3 h-3"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          role="img"
+          aria-label="Fast mode"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M13 3L4 14h7l-1 7 9-11h-7l1-7z"
+          />
+        </svg>
+        <span class="font-medium">Fast</span>
+      </button>
+    </Show>
+  );
+};

--- a/src/components/chat/AgentModelSelector.tsx
+++ b/src/components/chat/AgentModelSelector.tsx
@@ -4,7 +4,11 @@
 import type { Component } from "solid-js";
 import { createSignal, For, Show } from "solid-js";
 import { FloatingSelectorMenu } from "@/components/chat/FloatingSelectorMenu";
-import { type ActiveSession, agentStore } from "@/stores/agent.store";
+import {
+  type ActiveSession,
+  type AgentModelInfo,
+  agentStore,
+} from "@/stores/agent.store";
 
 interface Props {
   session: ActiveSession | null;
@@ -36,6 +40,25 @@ export const AgentModelSelector: Component<Props> = (props) => {
     agentStore.setModel(modelId, props.session?.info.id);
     setIsOpen(false);
   };
+
+  const capabilityBadges = (model: AgentModelInfo) =>
+    [
+      {
+        label: "Fast",
+        title: "Supports fast mode",
+        visible: model.supportsFastMode === true,
+      },
+      {
+        label: "Auto",
+        title: "Supports auto permission mode",
+        visible: model.supportsAutoMode === true,
+      },
+      {
+        label: "Adaptive",
+        title: "Supports adaptive thinking",
+        visible: model.supportsAdaptiveThinking === true,
+      },
+    ].filter((badge) => badge.visible);
 
   return (
     <Show when={availableModels().length > 0}>
@@ -85,7 +108,7 @@ export const AgentModelSelector: Component<Props> = (props) => {
           open={isOpen()}
           anchor={() => dropdownRef}
           onRequestClose={() => setIsOpen(false)}
-          class="w-64"
+          class="w-80 max-w-[calc(100vw-2rem)]"
         >
           <div class="px-3 py-2 border-b border-surface-2 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
             Agent Model
@@ -110,21 +133,33 @@ export const AgentModelSelector: Component<Props> = (props) => {
                       </span>
                     </Show>
                   </div>
-                  <Show when={model.modelId === displayModelId()}>
-                    <svg
-                      class="w-4 h-4 text-green-500 flex-shrink-0"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      role="img"
-                      aria-label="Selected"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                        clip-rule="evenodd"
-                      />
-                    </svg>
-                  </Show>
+                  <div class="flex items-center justify-end gap-1 flex-shrink-0">
+                    <For each={capabilityBadges(model)}>
+                      {(badge) => (
+                        <span
+                          class="px-1.5 py-0.5 rounded border border-surface-3 bg-surface-1 text-[10px] leading-none text-muted-foreground font-medium"
+                          title={badge.title}
+                        >
+                          {badge.label}
+                        </span>
+                      )}
+                    </For>
+                    <Show when={model.modelId === displayModelId()}>
+                      <svg
+                        class="w-4 h-4 text-green-500 flex-shrink-0"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                        role="img"
+                        aria-label="Selected"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clip-rule="evenodd"
+                        />
+                      </svg>
+                    </Show>
+                  </div>
                 </div>
               </button>
             )}

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -189,6 +189,9 @@ export interface SessionStatusEvent {
       modelId: string;
       name: string;
       description?: string;
+      supportsFastMode?: boolean;
+      supportsAutoMode?: boolean;
+      supportsAdaptiveThinking?: boolean;
     }>;
   };
   modes?: {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -729,6 +729,9 @@ export interface AgentModelInfo {
   modelId: string;
   name: string;
   description?: string;
+  supportsFastMode?: boolean;
+  supportsAutoMode?: boolean;
+  supportsAdaptiveThinking?: boolean;
 }
 
 export interface AgentModeInfo {

--- a/tests/unit/agent-model-capability-badges.test.ts
+++ b/tests/unit/agent-model-capability-badges.test.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Source-level guard for #2058 — the agent model picker must render
+// ABOUTME: read-only capability badges from runtime model flags.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const selectorSource = readFileSync(
+  resolve("src/components/chat/AgentModelSelector.tsx"),
+  "utf-8",
+);
+const fastSelectorSource = readFileSync(
+  resolve("src/components/chat/AgentFastModeSelector.tsx"),
+  "utf-8",
+);
+const chatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
+describe("#2058 agent model capability UI", () => {
+  it("renders Fast, Auto, and Adaptive badges from model capability flags", () => {
+    expect(selectorSource).toContain("capabilityBadges");
+    expect(selectorSource).toContain("supportsFastMode");
+    expect(selectorSource).toContain("supportsAutoMode");
+    expect(selectorSource).toContain("supportsAdaptiveThinking");
+    expect(selectorSource).toContain('label: "Fast"');
+    expect(selectorSource).toContain('label: "Auto"');
+    expect(selectorSource).toContain('label: "Adaptive"');
+  });
+
+  it("mounts the fast-mode selector next to the model/mode/effort controls", () => {
+    expect(chatSource).toContain("AgentFastModeSelector");
+    expect(fastSelectorSource).toContain('id === "fast_mode"');
+    expect(fastSelectorSource).toContain("supportsFastMode");
+    expect(fastSelectorSource).toMatch(/setConfigOption\(\s*"fast_mode"/);
+  });
+});

--- a/tests/unit/claude-effort.test.ts
+++ b/tests/unit/claude-effort.test.ts
@@ -18,7 +18,7 @@ const {
 } = mod;
 
 describe("normalizeEffort", () => {
-  it.each(["low", "medium", "high", "xhigh"] as const)(
+  it.each(["low", "medium", "high", "xhigh", "max"] as const)(
     "accepts %s",
     (value) => {
       expect(normalizeEffort(value)).toBe(value);
@@ -31,7 +31,6 @@ describe("normalizeEffort", () => {
 
   const invalidCases: Array<{ value: unknown; note: string }> = [
     { value: "minimal", note: "rejected to avoid a confusing translation to low" },
-    { value: "max", note: "not in seren's selector set" },
     { value: "", note: "empty string" },
     { value: "garbage", note: "unknown" },
     { value: null, note: "non-string" },
@@ -57,13 +56,14 @@ describe("buildEffortArgs", () => {
 });
 
 describe("buildEffortConfigOption", () => {
-  it("exposes exactly the four values seren supports for Claude Code", () => {
+  it("exposes exactly the five values Claude Code supports", () => {
     const opt = buildEffortConfigOption("medium");
     expect(opt.options.map((o: { value: string }) => o.value)).toEqual([
       "low",
       "medium",
       "high",
       "xhigh",
+      "max",
     ]);
   });
 
@@ -84,6 +84,12 @@ describe("buildEffortConfigOption", () => {
   });
 
   it("value set matches what the CLI accepts (lock against drift)", () => {
-    expect(CLAUDE_EFFORT_VALUES).toEqual(["low", "medium", "high", "xhigh"]);
+    expect(CLAUDE_EFFORT_VALUES).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
   });
 });

--- a/tests/unit/claude-fast-mode-config.test.ts
+++ b/tests/unit/claude-fast-mode-config.test.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Critical guards for #2058 — fast mode is a gated Claude config
+// ABOUTME: option that maps to the CLI's apply_flag_settings control request.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const {
+  _buildSessionStatus: buildSessionStatus,
+  _buildFastModeFlagSettings: buildFastModeFlagSettings,
+} = await import(/* @vite-ignore */ modulePath);
+
+function sessionWithFastSupport(supportsFastMode: boolean) {
+  return {
+    id: "session-1",
+    status: "ready",
+    agentSessionId: "agent-session-1",
+    claudeVersion: "2.1.156",
+    currentModelId: "default",
+    currentModeId: "default",
+    reasoningEffort: "medium",
+    fastModeEnabled: false,
+    availableModelRecords: [
+      {
+        modelId: "default",
+        name: "Default",
+        description: "Default model",
+        supportsEffort: true,
+        supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+        supportsFastMode,
+        supportsAutoMode: true,
+        supportsAdaptiveThinking: true,
+        isDefault: true,
+      },
+    ],
+  };
+}
+
+describe("#2058 Claude fast mode config", () => {
+  it("emits a fast_mode select option only for the selected fast-capable model", () => {
+    const capableStatus = buildSessionStatus(sessionWithFastSupport(true));
+    expect(
+      capableStatus.configOptions?.find(
+        (option: { id: string }) => option.id === "fast_mode",
+      ),
+    ).toMatchObject({
+      id: "fast_mode",
+      type: "select",
+      currentValue: "off",
+      options: [
+        { value: "on", name: "On" },
+        { value: "off", name: "Off" },
+      ],
+    });
+
+    const unsupportedStatus = buildSessionStatus(sessionWithFastSupport(false));
+    expect(
+      unsupportedStatus.configOptions?.some(
+        (option: { id: string }) => option.id === "fast_mode",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not fall back to the default model when currentModelId is unknown", () => {
+    const status = buildSessionStatus({
+      ...sessionWithFastSupport(true),
+      currentModelId: "non-catalog-model",
+    });
+
+    expect(
+      status.configOptions?.some(
+        (option: { id: string }) => option.id === "fast_mode",
+      ),
+    ).toBe(false);
+  });
+
+  it("maps UI values to the apply_flag_settings fastMode payload", () => {
+    expect(buildFastModeFlagSettings("on")).toEqual({ fastMode: true });
+    expect(buildFastModeFlagSettings("off")).toEqual({ fastMode: null });
+  });
+
+  it("rejects unknown fast_mode values before they can reach the CLI", () => {
+    expect(() => buildFastModeFlagSettings("enabled")).toThrow(
+      "Unsupported fast mode value",
+    );
+  });
+});

--- a/tests/unit/claude-runtime-capability-flags.test.ts
+++ b/tests/unit/claude-runtime-capability-flags.test.ts
@@ -1,0 +1,86 @@
+// ABOUTME: Critical guards for #2058 — Claude CLI model capability flags must
+// ABOUTME: survive runtime normalization and session-status projection.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const {
+  _normalizeModelRecords: normalizeModelRecords,
+  _buildSessionStatus: buildSessionStatus,
+  _augmentWithLegacyOpus: augmentWithLegacyOpus,
+} = await import(/* @vite-ignore */ modulePath);
+
+describe("#2058 Claude model capability flags", () => {
+  it("preserves live initialize model flags through session status availableModels", () => {
+    const records = normalizeModelRecords({
+      models: [
+        {
+          value: "default",
+          displayName: "Default (recommended)",
+          description: "Opus 4.8 with 1M context",
+          supportsEffort: true,
+          supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+          supportsFastMode: true,
+          supportsAutoMode: true,
+          supportsAdaptiveThinking: true,
+        },
+      ],
+    });
+
+    const status = buildSessionStatus({
+      id: "session-1",
+      status: "ready",
+      agentSessionId: "agent-session-1",
+      claudeVersion: "2.1.156",
+      availableModelRecords: records,
+      currentModelId: "default",
+      currentModeId: "default",
+      reasoningEffort: "medium",
+      fastModeEnabled: false,
+    });
+
+    expect(status.models?.availableModels).toEqual([
+      {
+        modelId: "default",
+        name: "Default (recommended)",
+        description: "Opus 4.8 with 1M context",
+        supportsFastMode: true,
+        supportsAutoMode: true,
+        supportsAdaptiveThinking: true,
+      },
+    ]);
+  });
+
+  it("defaults synthetic picker entries to no capability flags", () => {
+    const augmented = augmentWithLegacyOpus([
+      {
+        modelId: "claude-opus-4-7",
+        name: "Opus 4.7",
+        description: "Opus 4.7",
+        supportsEffort: true,
+        supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+        supportsFastMode: true,
+        supportsAutoMode: true,
+        supportsAdaptiveThinking: true,
+        isDefault: true,
+      },
+    ]) as Array<{
+      modelId: string;
+      supportsFastMode?: boolean;
+      supportsAutoMode?: boolean;
+      supportsAdaptiveThinking?: boolean;
+    }>;
+
+    const synthetic = augmented.find(
+      (record) => record.modelId === "claude-opus-4-6",
+    );
+    expect(synthetic).toMatchObject({
+      supportsFastMode: false,
+      supportsAutoMode: false,
+      supportsAdaptiveThinking: false,
+    });
+  });
+});


### PR DESCRIPTION
Closes #2058

## Summary
- preserve Claude `supportsFastMode`, `supportsAutoMode`, and `supportsAdaptiveThinking` through runtime normalization and session status
- surface read-only Fast / Auto / Adaptive badges in the agent model picker
- add a gated Fast toolbar toggle backed by the existing config-option bridge and `apply_flag_settings`
- add Claude effort `max` to runtime args and selector options

## Live CLI probe
- Probed `~/.local/bin/claude` -> Claude Code `2.1.156` on 2026-05-28.
- `initialize` returned model keys with exact casing: `supportsFastMode`, `supportsAutoMode`, `supportsAdaptiveThinking`; `supportedEffortLevels` included `max`.
- Sample counts from the live `models[]`: `supportsFastMode` truthy on 2/5, `supportsAutoMode` truthy on 4/5, `supportsAdaptiveThinking` truthy on 4/5.
- `apply_flag_settings` accepted `{ fastMode: true }`, `{ fastMode: null }`, and `{ fastMode: true, model: "claude-opus-4-7[1m]" }`; the runtime sends the bare `fastMode` payload confirmed by the probe.

## Validation
- `./node_modules/.bin/vitest run tests/unit/claude-effort.test.ts tests/unit/claude-runtime-capability-flags.test.ts tests/unit/claude-fast-mode-config.test.ts tests/unit/agent-model-capability-badges.test.ts`
- `./node_modules/.bin/vitest run tests/unit/claude-runtime-1m-tier.test.ts tests/unit/claude-runtime-model-catalog.test.ts tests/unit/claude-runtime-spawn-args.test.ts tests/unit/picker-sticky-model.test.ts tests/unit/agent-model-observability.test.ts`
- `./node_modules/.bin/biome check src/services/providers.ts src/stores/agent.store.ts src/components/chat/AgentModelSelector.tsx src/components/chat/AgentFastModeSelector.tsx src/components/chat/AgentChat.tsx tests/unit/claude-effort.test.ts tests/unit/claude-runtime-capability-flags.test.ts tests/unit/claude-fast-mode-config.test.ts tests/unit/agent-model-capability-badges.test.ts`
- `node --check bin/browser-local/claude-runtime.mjs`
- `node --check bin/browser-local/effort.mjs`
- `git diff --check`

Note: full `tsc --noEmit` is currently blocked by existing `tests/unit/codex-agent-image-context.test.ts` missing declarations for `../../bin/browser-local/providers.mjs`, unrelated to this PR. Full repo `biome check` is also blocked by existing unrelated diagnostics and the stale Biome schema URL; the touched files pass.
