### PR TITLE
fix: prewire Opus 4.8 1M tier

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -575,6 +575,7 @@ function makeOneMTierRecord(baseId, displayBase) {
 }
 
 const ONE_M_TIER_RECORDS = [
+  makeOneMTierRecord("claude-opus-4-8", "Opus 4.8"),
   makeOneMTierRecord("claude-opus-4-7", "Opus 4.7"),
   makeOneMTierRecord("claude-opus-4-6", "Opus 4.6"),
   makeOneMTierRecord("claude-opus-4-5", "Opus 4.5"),
@@ -911,6 +912,7 @@ const CLAUDE_1M_TIER_CAPABLE_MODELS = new Set([
   "claude-opus-4-5",
   "claude-opus-4-6",
   "claude-opus-4-7",
+  "claude-opus-4-8",
   "claude-sonnet-4-5",
   "claude-sonnet-4-6",
   "claude-sonnet-4-7",

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -341,6 +341,7 @@ const CLAUDE_1M_TIER_CAPABLE_MODELS = new Set([
   "claude-opus-4-5",
   "claude-opus-4-6",
   "claude-opus-4-7",
+  "claude-opus-4-8",
   "claude-sonnet-4-5",
   "claude-sonnet-4-6",
   "claude-sonnet-4-7",

--- a/tests/unit/claude-runtime-1m-tier.test.ts
+++ b/tests/unit/claude-runtime-1m-tier.test.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Critical guards for #1761 — Claude Code 1M context tier translation.
 // ABOUTME: Verifies bare IDs default to 200K and only [1m]-suffixed IDs unlock 1M.
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const modulePath = new URL(
@@ -16,18 +18,35 @@ const {
   _resolveSpawnShell: resolveSpawnShell,
 } = await import(/* @vite-ignore */ modulePath);
 
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+function extractQuotedSetValues(source: string, constName: string): string[] {
+  const start = source.indexOf(`const ${constName} = new Set([`);
+  expect(start, `${constName} must exist`).toBeGreaterThan(0);
+  const end = source.indexOf("]);", start);
+  expect(end, `${constName} must close`).toBeGreaterThan(start);
+  return [...source.slice(start, end).matchAll(/"([^"]+)"/g)]
+    .map((match) => match[1])
+    .sort();
+}
+
 describe("inferClaudeContextWindow — tier-aware semantics", () => {
   it("returns 200K for bare 1M-capable opus IDs (no [1m] suffix)", () => {
     // Anthropic gates the 1M tier on the [1m] suffix. A bare claude-opus-4-7
     // request lands on the 200K tier upstream. The desktop's cold-start
     // default must match that reality so the gauge denominator is honest
     // when the user picks the bare entry.
+    expect(inferClaudeContextWindow("claude-opus-4-8")).toBe(200_000);
     expect(inferClaudeContextWindow("claude-opus-4-7")).toBe(200_000);
     expect(inferClaudeContextWindow("claude-opus-4-6")).toBe(200_000);
     expect(inferClaudeContextWindow("claude-sonnet-4-6")).toBe(200_000);
   });
 
   it("returns 1M only for [1m]-suffixed 1M-capable IDs", () => {
+    expect(inferClaudeContextWindow("claude-opus-4-8[1m]")).toBe(1_000_000);
     expect(inferClaudeContextWindow("claude-opus-4-7[1m]")).toBe(1_000_000);
     expect(inferClaudeContextWindow("claude-opus-4-6[1m]")).toBe(1_000_000);
     expect(inferClaudeContextWindow("claude-opus-4-5[1m]")).toBe(1_000_000);
@@ -84,9 +103,25 @@ describe("augmentWithLegacyOpus — picker exposes 1M-tier variants", () => {
 
     expect(ids).toContain("claude-opus-4-7[1m]");
     expect(ids).toContain("claude-sonnet-4-6[1m]");
+    expect(ids).not.toContain("claude-opus-4-8[1m]");
     // claude-sonnet-4-7 is not in the CLI catalog and not in LEGACY_OPUS_RECORDS
     // → its [1m] variant must NOT appear so we don't make a false promise.
     expect(ids).not.toContain("claude-sonnet-4-7[1m]");
+
+    const augmentedWithOpus48 = augmentWithLegacyOpus([
+      ...cliCatalog,
+      {
+        modelId: "claude-opus-4-8",
+        name: "Opus 4.8",
+        description: "",
+        supportsEffort: false,
+        supportedEffortLevels: [],
+        isDefault: false,
+      },
+    ]);
+    expect(
+      augmentedWithOpus48.map((r: { modelId: string }) => r.modelId),
+    ).toContain("claude-opus-4-8[1m]");
   });
 
   it("does not duplicate [1m] entries the CLI already advertises", () => {
@@ -125,14 +160,19 @@ describe("augmentWithLegacyOpus — picker exposes 1M-tier variants", () => {
         r.modelId.replace(/\[1m\]$/i, ""),
       ),
     ].sort();
-    expect(oneMBareIds).toEqual([
+    const expectedOneMBareIds = [
       "claude-opus-4-5",
       "claude-opus-4-6",
       "claude-opus-4-7",
+      "claude-opus-4-8",
       "claude-sonnet-4-5",
       "claude-sonnet-4-6",
       "claude-sonnet-4-7",
-    ]);
+    ];
+    expect(oneMBareIds).toEqual(expectedOneMBareIds);
+    expect(
+      extractQuotedSetValues(agentStoreSource, "CLAUDE_1M_TIER_CAPABLE_MODELS"),
+    ).toEqual(expectedOneMBareIds);
   });
 
   it("promotes the [1m] sibling of the CLI default and pins it to slot one (#1763)", () => {


### PR DESCRIPTION
Closes #2057

## Summary
- add claude-opus-4-8[1m] to runtime 1M-tier picker records
- add claude-opus-4-8 to runtime and frontend cold-start 1M capability sets
- add focused regression coverage for no-phantom picker behavior, 1M inference, and runtime/store set parity

## Audit
- confirmed augmentWithLegacyOpus only emits Opus 4.8[1m] when the CLI catalog reports bare claude-opus-4-8
- confirmed DEFAULT_PREFERRED_MODEL remains claude-opus-4-7[1m]
- confirmed cli-updater floor remains 2.1.120

## Tests
- ./node_modules/.bin/vitest run tests/unit/claude-runtime-1m-tier.test.ts
- ./node_modules/.bin/vitest run tests/unit/claude-runtime-1m-tier.test.ts tests/unit/claude-model-resolution.test.ts tests/unit/claude-runtime-cleanups.test.ts tests/unit/predictive-compact-race.test.ts tests/unit/setmodel-context-window-and-prepend-tool-results.test.ts tests/unit/model-context-cache-tier-guard.test.ts
- ./node_modules/.bin/biome check bin/browser-local/claude-runtime.mjs src/stores/agent.store.ts tests/unit/claude-runtime-1m-tier.test.ts
- git diff --check