### PR TITLE
fix: persist Codex replay history

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -750,6 +750,10 @@ export interface ActiveSession {
   streamingThinking: string;
   /** Timestamp for current streaming assistant chunk buffer (ms epoch). */
   streamingContentTimestamp?: number;
+  /** True when current streaming assistant content came from history replay. */
+  streamingContentReplay?: boolean;
+  /** Stable replay assistant message id for chunk/message boundaries. */
+  streamingContentMessageId?: string;
   /** Timestamp for current streaming thinking chunk buffer (ms epoch). */
   streamingThinkingTimestamp?: number;
   /** Buffered replay user text that may arrive as multiple chunks. */
@@ -3315,12 +3319,20 @@ export const agentStore = {
       }
     }
 
+    // Codex provider replay is authoritative. A partial local SQLite cache
+    // would otherwise suppress replay and leave only the final output visible.
+    const restoredMessagesForSpawn =
+      agentType === "codex" && effectiveResumeId ? [] : restoredMessages;
+    const bootstrapPromptContextForSpawn =
+      agentType === "codex" && effectiveResumeId
+        ? undefined
+        : pendingBootstrapPromptContext;
     const sessionId = await this.spawnSession(resumeCwd, agentType, {
       localSessionId: conversationId,
       resumeAgentSessionId: effectiveResumeId,
       conversationTitle: convo.title,
-      restoredMessages,
-      bootstrapPromptContext: pendingBootstrapPromptContext,
+      restoredMessages: restoredMessagesForSpawn,
+      bootstrapPromptContext: bootstrapPromptContextForSpawn,
       initialModelId: convo.agent_model_id ?? undefined,
       initialPermissionMode: convo.agent_permission_mode ?? undefined,
     });
@@ -4833,6 +4845,8 @@ Structured summary:`;
     clearChunkBuf(sessionId);
     setState("sessions", sessionId, "streamingContent", "");
     setState("sessions", sessionId, "streamingContentTimestamp", undefined);
+    setState("sessions", sessionId, "streamingContentReplay", undefined);
+    setState("sessions", sessionId, "streamingContentMessageId", undefined);
     setState("sessions", sessionId, "streamingThinking", "");
     setState("sessions", sessionId, "streamingThinkingTimestamp", undefined);
     setState("sessions", sessionId, "pendingUserMessage", "");
@@ -5373,6 +5387,10 @@ Structured summary:`;
           event.data.text,
           event.data.isThought,
           event.data.timestamp,
+          {
+            replay: event.data.replay === true,
+            messageId: event.data.messageId,
+          },
         );
         break;
 
@@ -6060,7 +6078,7 @@ Structured summary:`;
     }
 
     const userMsg: AgentMessage = {
-      id: crypto.randomUUID(),
+      id: session.pendingUserMessageId ?? crypto.randomUUID(),
       type: "user",
       content: session.pendingUserMessage,
       timestamp: session.pendingUserMessageTimestamp ?? Date.now(),
@@ -6132,12 +6150,16 @@ Structured summary:`;
     text: string,
     isThought?: boolean,
     timestamp?: number,
+    meta?: { replay?: boolean; messageId?: string },
   ) {
-    const session = state.sessions[sessionId];
+    let session = state.sessions[sessionId];
     if (!session) return;
 
     // Skip replay assistant/thought chunks when we have restored messages.
     if (session.skipHistoryReplay) return;
+
+    const isReplayChunk = meta?.replay === true;
+    const messageId = isReplayChunk ? meta?.messageId : undefined;
 
     let buf = chunkBufs.get(sessionId);
     if (!buf) {
@@ -6157,6 +6179,34 @@ Structured summary:`;
       }
       buf.thinking += text;
     } else {
+      if (
+        isReplayChunk &&
+        messageId &&
+        session.streamingContentMessageId &&
+        session.streamingContentMessageId !== messageId
+      ) {
+        flushChunkBuf(sessionId);
+        flushThinkingMarkupStreamState(sessionId);
+        this.finalizeStreamingContent(sessionId, { isReplay: true });
+        session = state.sessions[sessionId];
+        if (!session) return;
+        buf = chunkBufs.get(sessionId);
+        if (!buf) {
+          buf = { content: "", thinking: "" };
+          chunkBufs.set(sessionId, buf);
+        }
+      }
+      if (isReplayChunk) {
+        setState("sessions", sessionId, "streamingContentReplay", true);
+        if (messageId) {
+          setState(
+            "sessions",
+            sessionId,
+            "streamingContentMessageId",
+            messageId,
+          );
+        }
+      }
       // Set timestamp on the very first content chunk (cheap — fires once)
       if (!session.streamingContent && !buf.content) {
         setState(
@@ -6282,7 +6332,7 @@ Structured summary:`;
       const scrubbed = scrubAgentMarkup(session.streamingContent);
       if (scrubbed) {
         const contentMsg: AgentMessage = {
-          id: crypto.randomUUID(),
+          id: session.streamingContentMessageId ?? crypto.randomUUID(),
           type: "assistant",
           content: scrubbed,
           timestamp: session.streamingContentTimestamp ?? Date.now(),
@@ -6291,14 +6341,21 @@ Structured summary:`;
           ...msgs,
           contentMsg,
         ]);
+        if (session.streamingContentReplay === true && session.conversationId) {
+          persistAgentMessage(
+            session.conversationId,
+            contentMsg,
+            session.info.agentType,
+          );
+        }
       }
-      // Do NOT persist this intermediate flush — it captures partial streaming
-      // text (often raw file contents from tool results) that would pollute
-      // the restored conversation history on restart. Only
-      // finalizeStreamingContent (called at promptComplete) should persist
-      // assistant messages.
+      // Live intermediate flushes capture partial streaming text and must
+      // stay UI-only. Replay-marked chunks are complete historical assistant
+      // messages, so they were persisted above before the tool card interrupts.
       setState("sessions", sessionId, "streamingContent", "");
       setState("sessions", sessionId, "streamingContentTimestamp", undefined);
+      setState("sessions", sessionId, "streamingContentReplay", undefined);
+      setState("sessions", sessionId, "streamingContentMessageId", undefined);
     }
 
     // Skip duplicate if a message with this toolCallId already exists
@@ -6598,7 +6655,9 @@ Structured summary:`;
   },
 
   finalizeStreamingContent(sessionId: string, opts?: { isReplay?: boolean }) {
-    const isReplay = opts?.isReplay ?? false;
+    const isReplay =
+      opts?.isReplay === true ||
+      state.sessions[sessionId]?.streamingContentReplay === true;
     // Flush any buffered chunks before reading store state
     flushChunkBuf(sessionId);
     flushThinkingMarkupStreamState(sessionId);
@@ -6648,6 +6707,8 @@ Structured summary:`;
         }
         setState("sessions", sessionId, "streamingContent", "");
         setState("sessions", sessionId, "streamingContentTimestamp", undefined);
+        setState("sessions", sessionId, "streamingContentReplay", undefined);
+        setState("sessions", sessionId, "streamingContentMessageId", undefined);
         setState("sessions", sessionId, "promptStartTime", undefined);
         return;
       }
@@ -6662,6 +6723,8 @@ Structured summary:`;
       if (scrubbed.length === 0) {
         setState("sessions", sessionId, "streamingContent", "");
         setState("sessions", sessionId, "streamingContentTimestamp", undefined);
+        setState("sessions", sessionId, "streamingContentReplay", undefined);
+        setState("sessions", sessionId, "streamingContentMessageId", undefined);
         setState("sessions", sessionId, "promptStartTime", undefined);
         return;
       }
@@ -6677,7 +6740,7 @@ Structured summary:`;
       const safeContent = finalOutputValidation.safeDisplayText;
 
       const message: AgentMessage = {
-        id: crypto.randomUUID(),
+        id: session.streamingContentMessageId ?? crypto.randomUUID(),
         type: "assistant",
         content: safeContent,
         timestamp: session.streamingContentTimestamp ?? Date.now(),
@@ -6734,6 +6797,8 @@ Structured summary:`;
 
       setState("sessions", sessionId, "streamingContent", "");
       setState("sessions", sessionId, "streamingContentTimestamp", undefined);
+      setState("sessions", sessionId, "streamingContentReplay", undefined);
+      setState("sessions", sessionId, "streamingContentMessageId", undefined);
       // Clear the start time
       setState("sessions", sessionId, "promptStartTime", undefined);
     }

--- a/tests/unit/agent-history-persistence.test.ts
+++ b/tests/unit/agent-history-persistence.test.ts
@@ -66,11 +66,63 @@ describe("agent message persistence guards", () => {
     }
   });
 
-  it("handleToolCall does NOT persist intermediate streaming flush", () => {
-    // The handleToolCall method flushes streamingContent into an assistant
-    // message for UI ordering, but must NOT persist it — these intermediate
-    // messages capture partial text (often file contents) that would pollute
-    // the restored conversation history on restart.
+  it("messageChunk forwards replay identity into handleMessageChunk", () => {
+    const caseIdx = agentStoreSource.indexOf('case "messageChunk"');
+    expect(caseIdx).toBeGreaterThan(0);
+    const caseBody = agentStoreSource.slice(
+      caseIdx,
+      agentStoreSource.indexOf('case "toolCall"', caseIdx),
+    );
+
+    expect(caseBody).toContain("replay: event.data.replay === true");
+    expect(caseBody).toContain("messageId: event.data.messageId");
+  });
+
+  it("handleMessageChunk uses replay message ids as assistant boundaries", () => {
+    const handlerIdx = agentStoreSource.indexOf("\n  handleMessageChunk(");
+    expect(handlerIdx).toBeGreaterThan(0);
+    const handlerBody = agentStoreSource.slice(
+      handlerIdx,
+      agentStoreSource.indexOf("enqueueToolEvent(", handlerIdx),
+    );
+
+    expect(handlerBody).toContain("streamingContentMessageId");
+    expect(handlerBody).toContain(
+      "this.finalizeStreamingContent(sessionId, { isReplay: true })",
+    );
+  });
+
+  it("replayed user and assistant messages reuse provider ids for SQLite upsert", () => {
+    const userHandlerIdx = agentStoreSource.indexOf(
+      "flushPendingUserMessage(sessionId: string)",
+    );
+    expect(userHandlerIdx).toBeGreaterThan(0);
+    const userHandlerBody = agentStoreSource.slice(
+      userHandlerIdx,
+      agentStoreSource.indexOf("appendReplayUserChunk(", userHandlerIdx),
+    );
+    expect(userHandlerBody).toContain(
+      "id: session.pendingUserMessageId ?? crypto.randomUUID()",
+    );
+
+    const finalizeIdx = agentStoreSource.indexOf(
+      "finalizeStreamingContent(sessionId: string",
+    );
+    expect(finalizeIdx).toBeGreaterThan(0);
+    const finalizeBody = agentStoreSource.slice(
+      finalizeIdx,
+      agentStoreSource.indexOf("async forkConversation(", finalizeIdx),
+    );
+    expect(finalizeBody).toContain(
+      "id: session.streamingContentMessageId ?? crypto.randomUUID()",
+    );
+  });
+
+  it("handleToolCall persists only replayed intermediate assistant flushes", () => {
+    // Live handleToolCall still flushes streamingContent into the UI for
+    // ordering without persisting partial text. History replay chunks are
+    // different: they are complete historical assistant messages, so the
+    // replay-marked flush must persist before the tool card interrupts it.
     const toolCallHandler = agentStoreSource.slice(
       agentStoreSource.indexOf("handleToolCall(sessionId: string, toolCall:"),
     );
@@ -86,8 +138,27 @@ describe("agent message persistence guards", () => {
     );
     expect(flushBlock.length).toBeGreaterThan(0);
 
-    // The flush block must NOT contain a persistAgentMessage call
-    expect(flushBlock).not.toContain("persistAgentMessage(");
+    expect(flushBlock).toContain("session.streamingContentReplay === true");
+    const persistIdx = flushBlock.indexOf("persistAgentMessage(");
+    const replayGuardIdx = flushBlock.indexOf(
+      "session.streamingContentReplay === true",
+    );
+    expect(persistIdx).toBeGreaterThan(replayGuardIdx);
+  });
+
+  it("Codex resume lets provider replay repair partial SQLite history", () => {
+    const resumeIdx = agentStoreSource.indexOf("async resumeAgentConversation");
+    expect(resumeIdx).toBeGreaterThan(0);
+    const resumeBody = agentStoreSource.slice(
+      resumeIdx,
+      agentStoreSource.indexOf("async resumeRemoteSession(", resumeIdx),
+    );
+
+    expect(resumeBody).toContain("const restoredMessagesForSpawn =");
+    expect(resumeBody).toContain(
+      'agentType === "codex" && effectiveResumeId ? [] : restoredMessages',
+    );
+    expect(resumeBody).toContain("restoredMessages: restoredMessagesForSpawn");
   });
 
   it("finalizeStreamingContent DOES persist assistant messages", () => {

--- a/tests/unit/agent-seren-memory-wiring.test.ts
+++ b/tests/unit/agent-seren-memory-wiring.test.ts
@@ -62,7 +62,7 @@ describe("#1625 — finalizeStreamingContent writes assistant turns to memory", 
     expect(agentStoreSource).toContain(
       "finalizeStreamingContent(sessionId: string, opts?: { isReplay?: boolean })",
     );
-    expect(agentStoreSource).toContain("const isReplay = opts?.isReplay");
+    expect(agentStoreSource).toMatch(/const\s+isReplay\s*=\s*opts\?\.isReplay/);
   });
 
   it("non-replay path calls storeAssistantResponse with the agent tag", () => {


### PR DESCRIPTION
Closes #2061.

## Summary
- Let Codex resumed sessions use provider replay as the authoritative transcript so partial local SQLite caches do not suppress full history replay.
- Carry replay `messageId` / `replay` metadata through assistant chunks, split replay messages on provider ids, and persist replayed assistant flushes before tool cards.
- Reuse provider ids for replayed user/assistant messages so SQLite `INSERT OR REPLACE` can upsert replay rows instead of creating duplicates.

## Tests
- `vitest run tests/unit/agent-history-persistence.test.ts tests/unit/agent-seren-memory-wiring.test.ts tests/unit/agent-thinking-markup-wiring.test.ts`
- `biome check src/stores/agent.store.ts tests/unit/agent-history-persistence.test.ts tests/unit/agent-seren-memory-wiring.test.ts`
- `vitest run`

## Known Existing Blocker
- `tsc --noEmit` still fails on the existing unrelated missing declaration for `tests/unit/codex-agent-image-context.test.ts` importing `../../bin/browser-local/providers.mjs`.