### PR TITLE
fix: wrap agent composer toolbar so the Skills chip stays visible (#2062)

### DIFF
--- a/src/components/chat/composerToolbarClasses.ts
+++ b/src/components/chat/composerToolbarClasses.ts
@@ -1,11 +1,11 @@
 // ABOUTME: Tailwind class invariants for the agent composer toolbar layout.
-// ABOUTME: Guards against regression of the Cancel-button-clip bug (#1982).
+// ABOUTME: Guards the Cancel-clip bug (#1982) and the Skills-chip-clip bug (#2062).
 
 export const COMPOSER_TOOLBAR_ROOT_CLASSES =
-  "flex justify-between items-center gap-2";
+  "flex justify-between items-start gap-2";
 
 export const COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES =
-  "flex items-center gap-3 min-w-0 flex-1 overflow-x-auto scrollbar-none";
+  "flex items-center gap-3 min-w-0 flex-1 flex-wrap";
 
 export const COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES =
   "flex items-center gap-2 shrink-0";

--- a/tests/unit/composer-toolbar-layout.test.ts
+++ b/tests/unit/composer-toolbar-layout.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Critical regression test for agent composer toolbar layout invariants.
-// ABOUTME: Guards against Cancel-button clipping when chip row grows (#1982).
+// ABOUTME: Guards #1982 (Send/Cancel never clipped) and #2062 (Skills chip stays visible via wrap).
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -11,27 +11,29 @@ import {
 } from "@/components/chat/composerToolbarClasses";
 import { FLOATING_SELECTOR_MENU_BASE_CLASSES } from "@/components/chat/floatingSelectorMenuClasses";
 
-describe("composer toolbar layout invariants (#1982)", () => {
-  it("right group must be pinned with shrink-0 so Cancel/Send is never clipped", () => {
+describe("composer toolbar layout invariants (#1982, #2062)", () => {
+  it("right group must be pinned with shrink-0 so Cancel/Send is never clipped (#1982)", () => {
     expect(COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES).toMatch(/\bshrink-0\b/);
   });
 
-  it("left group must shrink (min-w-0 + flex-1) before pushing the right group off-screen", () => {
+  it("left group must shrink (min-w-0 + flex-1) before pushing the right group off-screen (#1982)", () => {
     expect(COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES).toMatch(/\bmin-w-0\b/);
     expect(COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES).toMatch(/\bflex-1\b/);
   });
 
-  it("left group must allow horizontal scroll so clipped chips remain reachable", () => {
-    expect(COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES).toMatch(/\boverflow-x-auto\b/);
+  it("left group must wrap (not scroll) so overflowing chips like Skills stay visible when the docked Skills panel narrows the pane (#2062)", () => {
+    expect(COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES).toMatch(/\bflex-wrap\b/);
+    // Horizontal scroll silently hid the last chip (Skills) off-screen; wrapping replaces it.
+    expect(COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES).not.toMatch(/\boverflow-x-auto\b/);
   });
 
-  it("root toolbar must keep gap between the two groups", () => {
+  it("root toolbar must keep justify-between + gap and top-align the pinned group when the left group wraps (#2062)", () => {
     expect(COMPOSER_TOOLBAR_ROOT_CLASSES).toMatch(/\bjustify-between\b/);
     expect(COMPOSER_TOOLBAR_ROOT_CLASSES).toMatch(/\bgap-\d+\b/);
+    expect(COMPOSER_TOOLBAR_ROOT_CLASSES).toMatch(/\bitems-start\b/);
   });
 
-  it("agent selector menus must escape the left group's scroll clipping (#1992)", () => {
-    expect(COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES).toMatch(/\boverflow-x-auto\b/);
+  it("agent selector menus must use fixed-positioned portals so they escape the toolbar regardless of wrap/overflow (#1992)", () => {
     expect(FLOATING_SELECTOR_MENU_BASE_CLASSES).toMatch(/\bfixed\b/);
 
     for (const file of [


### PR DESCRIPTION
## Summary

Fixes the **Skills button being cut off** in the bottom row of agentic controls when the Skills drawer is open (Closes #2062). All composer controls now stay visible.

**Root cause:** The Skills drawer is the only *docked* `SlidePanel` — it renders as an in-flow `relative shrink-0` flex sibling that narrows `<main>` instead of overlaying it. The agent composer's left chip group used `overflow-x-auto scrollbar-none` (the #1982 Cancel-clip fix), so once the pane narrowed the overflowing trailing chips scrolled off-screen with no usable affordance. The **Skills** button is the last chip, so it was the first to disappear.

**Fix:** Swap horizontal scroll for `flex-wrap` on the left chip group so overflowing chips drop to a second row and stay visible; top-align the root (`items-start`) so the pinned right group (Voice + Send) aligns to the first chip row.

| Group | Before | After |
| ----- | ------ | ----- |
| root  | `flex justify-between items-center gap-2` | `flex justify-between items-start gap-2` |
| left  | `flex items-center gap-3 min-w-0 flex-1 overflow-x-auto scrollbar-none` | `flex items-center gap-3 min-w-0 flex-1 flex-wrap` |
| right | `flex items-center gap-2 shrink-0` | unchanged |

## Why this is safe

- **#1982 (Send/Cancel clip) preserved.** That was a root-level contract: left yields width (`min-w-0 flex-1`), right pinned (`shrink-0`), `justify-between`. All untouched — only the overflow behavior changes (wrap instead of scroll), so Send/Cancel are never clipped.
- **#1992 (selector menus) unaffected.** The menus render via a `Portal` to `document.body` with `fixed` positioning, independent of toolbar overflow. `overflow-x-auto` was in fact the original *cause* of #1992; removing it removes a clipping ancestor.
- `scrollbar-none` was an undefined no-op utility in this project; dropped alongside `overflow-x-auto`.

## Scope

Only `AgentChat` consumes these shared constants, so the change is confined to the agent composer toolbar. The non-agent `ChatContent` toolbar uses its own inline classes and is **not** affected by the docked-panel narrowing (noted as a separate follow-up in #2062).

## Test plan

- [x] `pnpm vitest run tests/unit/composer-toolbar-layout.test.ts` — updated critical invariant test now asserts wrap (not scroll), decouples the #1992 guard from `overflow-x-auto`; **5/5 pass** (TDD: red → green confirmed).
- [x] Full unit suite: **1442/1442 pass**.
- [x] Biome clean on changed source.
- [ ] Manual: open the agent composer, open the Skills drawer, confirm the chip row wraps and the Skills chip stays visible (could not run the Tauri GUI in this environment — verified via class-invariant tests + static code-path audit, which is the project's established strategy for this toolbar).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
