### PR TITLE
Fix ChatContent composer toolbar clipping

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -90,6 +90,11 @@ import { workspaceStore } from "@/stores/workspace.store";
 import { isRetryableWorker, type UnifiedMessage } from "@/types/conversation";
 import RenderMarkdownWorker from "@/workers/render-markdown.worker?worker";
 import { CompactedMessage } from "./CompactedMessage";
+import {
+  COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES,
+  COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES,
+  COMPOSER_TOOLBAR_ROOT_CLASSES,
+} from "./composerToolbarClasses";
 import { ImageAttachmentBar } from "./ImageAttachmentBar";
 import { MessageImages } from "./MessageImages";
 import { ModelSelector } from "./ModelSelector";
@@ -1762,8 +1767,8 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                 {commandStatus()}
               </div>
             </Show>
-            <div class="flex justify-between items-center">
-              <div class="flex items-center gap-3">
+            <div class={COMPOSER_TOOLBAR_ROOT_CLASSES}>
+              <div class={COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES}>
                 <Show when={!privateChatLocked()}>
                   <ModelSelector threadId={conversationId()} />
                   <ToolsetSelector />
@@ -1803,7 +1808,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                   </span>
                 </Show>
               </div>
-              <div class="flex items-center gap-2">
+              <div class={COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES}>
                 <VoiceInputButton
                   onTranscript={(text) => {
                     setInput((prev) => (prev ? `${prev} ${text}` : text));

--- a/tests/unit/composer-toolbar-layout.test.ts
+++ b/tests/unit/composer-toolbar-layout.test.ts
@@ -46,4 +46,15 @@ describe("composer toolbar layout invariants (#1982, #2062)", () => {
       expect(source).toContain("FloatingSelectorMenu");
     }
   });
+
+  it("non-agent ChatContent must reuse the protected composer toolbar classes (#2065)", () => {
+    const source = readFileSync("src/components/chat/ChatContent.tsx", "utf-8");
+
+    expect(source).toContain("COMPOSER_TOOLBAR_ROOT_CLASSES");
+    expect(source).toContain("COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES");
+    expect(source).toContain("COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES");
+    expect(source).toContain("<div class={COMPOSER_TOOLBAR_ROOT_CLASSES}>");
+    expect(source).toContain("<div class={COMPOSER_TOOLBAR_LEFT_GROUP_CLASSES}>");
+    expect(source).toContain("<div class={COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES}>");
+  });
 });


### PR DESCRIPTION
Closes #2065

## Summary
- Reuse the shared composer toolbar class constants in non-agent ChatContent
- Keep the action group shrink-0 while the left chip group wraps under narrow panes
- Add a focused regression assertion that ChatContent consumes the protected toolbar constants

## Verification
- ./node_modules/.bin/vitest run tests/unit/composer-toolbar-layout.test.ts
- ./node_modules/.bin/biome check src/components/chat/ChatContent.tsx
- ./node_modules/.bin/vite build