### PR TITLE
Fix vertical workspace pane close behavior

### DIFF
--- a/src/components/layout/ThreadContent.tsx
+++ b/src/components/layout/ThreadContent.tsx
@@ -458,6 +458,12 @@ export const ThreadContent: Component<ThreadContentProps> = (props) => {
               const target = activeTargetFor(entry.window);
               return target !== undefined && dragTargetWindowId() === target.id;
             };
+            const closePane = (event: MouseEvent) => {
+              event.preventDefault();
+              event.stopPropagation();
+              const target = activeTargetFor(entry.window);
+              if (target) workspaceStore.closeWindow(target.id);
+            };
             const baseStyle = () => {
               const p = placement();
               if (p.hidden) return { display: "none" };
@@ -565,6 +571,51 @@ export const ThreadContent: Component<ThreadContentProps> = (props) => {
                 </Show>
                 <Show when={entry.window.kind === null}>
                   <PlaceholderPane focused={focused()} />
+                </Show>
+                <Show
+                  when={
+                    !hidden() &&
+                    workspaceStore.activeWorkspace.windows.length > 1
+                  }
+                >
+                  <button
+                    type="button"
+                    class="absolute top-2 left-2 z-20 inline-flex items-center justify-center w-6 h-6 rounded-[4px] border border-border/60 bg-surface-0/90 text-muted-foreground shadow-sm backdrop-blur-sm cursor-pointer transition-colors duration-100 hover:bg-surface-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/70"
+                    title="Close pane"
+                    aria-label="Close pane"
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                    }}
+                    onClick={closePane}
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 12 12"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <line
+                        x1="3"
+                        y1="3"
+                        x2="9"
+                        y2="9"
+                        stroke="currentColor"
+                        stroke-width="1.2"
+                        stroke-linecap="round"
+                      />
+                      <line
+                        x1="9"
+                        y1="3"
+                        x2="3"
+                        y2="9"
+                        stroke="currentColor"
+                        stroke-width="1.2"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </button>
                 </Show>
                 <Show
                   when={

--- a/src/stores/workspace.store.ts
+++ b/src/stores/workspace.store.ts
@@ -234,6 +234,19 @@ function focusedWindow(workspace: Workspace): WorkspaceWindow | null {
   );
 }
 
+function nearestNonEditorWindowIndex(
+  workspace: Workspace,
+  focusedIdx: number,
+): number {
+  for (let i = focusedIdx + 1; i < workspace.windows.length; i += 1) {
+    if (workspace.windows[i].kind !== "editor") return i;
+  }
+  for (let i = focusedIdx - 1; i >= 0; i -= 1) {
+    if (workspace.windows[i].kind !== "editor") return i;
+  }
+  return workspace.windows.findIndex((w) => w.kind !== "editor");
+}
+
 function windowById(windowId: string): WorkspaceWindow | null {
   for (const workspace of state.workspaces) {
     const window = workspace.windows.find((w) => w.id === windowId);
@@ -292,12 +305,29 @@ function bindThreadToWorkspace(
   const focused = focusedWindow(workspace) ?? workspace.windows[0];
 
   // Editor panes are persistent. Don't replace one with the picked thread -
-  // open the thread in a new pane next to the editor instead, mirroring
-  // bindEditorToWorkspace's behavior when a thread pane is focused.
+  // reuse a neighboring non-editor pane when one already exists. This keeps
+  // normal sidebar thread switches from accumulating extra vertical panes
+  // while preserving the editor pane.
   if (focused?.kind === "editor") {
     const focusedIdx = workspace.windows.findIndex(
       (w) => w.id === workspace.focusedWindowId,
     );
+    const reusableIdx = nearestNonEditorWindowIndex(workspace, focusedIdx);
+    if (reusableIdx >= 0) {
+      const reusableWindow = workspace.windows[reusableIdx];
+      setState("workspaces", idx, "windows", reusableIdx, {
+        id: reusableWindow.id,
+        threadId,
+        kind: thread.kind,
+        size: reusableWindow.size,
+      });
+      setState("workspaces", idx, "focusedWindowId", reusableWindow.id);
+      if (!state.workspaces[idx].hasHadContent) {
+        setState("workspaces", idx, "hasHadContent", true);
+      }
+      return;
+    }
+
     const insertAt =
       focusedIdx >= 0 ? focusedIdx + 1 : workspace.windows.length;
     const newId = newPaneId(number);
@@ -601,18 +631,18 @@ export const workspaceStore = {
    * a thread, the underlying thread is NOT deleted - it just leaves
    * this workspace. Focus moves to the previous (or next) pane.
    */
-  closeFocusedWindow(): void {
+  closeWindow(windowId: string): void {
     const wsIdx = state.workspaces.findIndex(
       (w) => w.number === state.activeNumber,
     );
     if (wsIdx < 0) return;
     const ws = state.workspaces[wsIdx];
-    const focusedIdx = ws.windows.findIndex((w) => w.id === ws.focusedWindowId);
-    if (focusedIdx < 0) return;
-    const closedWindow = ws.windows[focusedIdx];
+    const closedIdx = ws.windows.findIndex((w) => w.id === windowId);
+    if (closedIdx < 0) return;
+    const closedWindow = ws.windows[closedIdx];
     const nextWindows = [
-      ...ws.windows.slice(0, focusedIdx),
-      ...ws.windows.slice(focusedIdx + 1),
+      ...ws.windows.slice(0, closedIdx),
+      ...ws.windows.slice(closedIdx + 1),
     ];
     const closedWindowId = closedWindow.id;
     setState("workspaces", wsIdx, "windows", nextWindows);
@@ -622,7 +652,13 @@ export const workspaceStore = {
       "layout",
       removeWindowFromLayout(ws.layout, closedWindowId),
     );
-    const nextFocusIdx = Math.min(focusedIdx, nextWindows.length - 1);
+    const closedFocused = ws.focusedWindowId === closedWindowId;
+    const existingFocusIdx = nextWindows.findIndex(
+      (w) => w.id === ws.focusedWindowId,
+    );
+    const nextFocusIdx = closedFocused
+      ? Math.min(closedIdx, nextWindows.length - 1)
+      : existingFocusIdx;
     const nextFocusId = nextFocusIdx >= 0 ? nextWindows[nextFocusIdx].id : null;
     setState("workspaces", wsIdx, "focusedWindowId", nextFocusId);
 
@@ -635,6 +671,13 @@ export const workspaceStore = {
     // to switch threads.
     if (closedWindow.kind === "editor") return;
 
+    if (
+      !closedFocused &&
+      closedWindow.threadId !== threadStore.activeThreadId
+    ) {
+      return;
+    }
+
     if (nextFocusId !== null) {
       const nextThreadId = nextWindows[nextFocusIdx].threadId;
       if (nextThreadId !== threadStore.activeThreadId) {
@@ -642,6 +685,13 @@ export const workspaceStore = {
       }
     } else if (threadStore.activeThreadId !== null) {
       threadStore.setActiveThread(null);
+    }
+  },
+
+  closeFocusedWindow(): void {
+    const focusedWindowId = this.activeWorkspace.focusedWindowId;
+    if (focusedWindowId) {
+      this.closeWindow(focusedWindowId);
     }
   },
 

--- a/tests/unit/workspace-pane-close-affordance.test.ts
+++ b/tests/unit/workspace-pane-close-affordance.test.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Source-level guard for #2084 direct per-pane close affordance.
+// ABOUTME: Closing a vertical pane must not archive or terminate its thread.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const threadContentSource = readFileSync(
+  resolve("src/components/layout/ThreadContent.tsx"),
+  "utf-8",
+);
+
+describe("#2084 workspace pane close affordance", () => {
+  it("renders a direct pane close action wired to workspaceStore.closeWindow", () => {
+    expect(threadContentSource).toContain("Close pane");
+    expect(threadContentSource).toContain("workspaceStore.closeWindow(target.id)");
+    expect(threadContentSource).not.toContain("archiveThread(");
+    expect(threadContentSource).not.toContain("terminateSession(");
+  });
+});

--- a/tests/unit/workspace-store.test.ts
+++ b/tests/unit/workspace-store.test.ts
@@ -455,6 +455,27 @@ describe("workspaceStore", () => {
     expect(ws.focusedWindowId).toBe(ws.windows[0].id);
   });
 
+  it("reuses an existing non-editor pane when selecting a thread from an editor-focused workspace", async () => {
+    const { threadStore, workspaceStore } = await setup();
+
+    threadStore.setActiveThread("thread-1");
+    workspaceStore.bindEditorToWorkspace("/tmp/skill/SKILL.md");
+    expect(workspaceStore.activeWindow?.kind).toBe("editor");
+
+    threadStore.setActiveThread("thread-2");
+
+    const ws = workspaceStore.activeWorkspace;
+    const threadPanes = ws.windows.filter((w) => w.kind !== "editor");
+    expect(ws.windows).toHaveLength(2);
+    expect(ws.windows.filter((w) => w.kind === "editor")).toHaveLength(1);
+    expect(threadPanes).toHaveLength(1);
+    expect(threadPanes[0]).toMatchObject({
+      threadId: "thread-2",
+      kind: "chat",
+    });
+    expect(ws.focusedWindowId).toBe(threadPanes[0].id);
+  });
+
   it("focuses the active workspace pane when given a singleton pane id from another workspace", async () => {
     const { threadStore, workspaceStore } = await setup();
 
@@ -571,6 +592,28 @@ describe("workspaceStore", () => {
     const ws = workspaceStore.activeWorkspace;
     expect(ws.windows.map((w) => w.threadId)).toEqual(["thread-1"]);
     expect(ws.focusedWindowId).toBe(ws.windows[0].id);
+  });
+
+  it("closes a non-focused pane by id without killing the active thread", async () => {
+    const { threadStore, workspaceStore } = await setup();
+
+    threadStore.setActiveThread("thread-1");
+    workspaceStore.splitFocusedPane("row");
+    threadStore.setActiveThread("thread-2");
+
+    const wsBefore = workspaceStore.activeWorkspace;
+    const inactivePane = wsBefore.windows.find((w) => w.threadId === "thread-1");
+    const focusedPane = wsBefore.windows.find((w) => w.threadId === "thread-2");
+    expect(inactivePane).toBeDefined();
+    expect(focusedPane).toBeDefined();
+    expect(wsBefore.focusedWindowId).toBe(focusedPane?.id);
+
+    workspaceStore.closeWindow(inactivePane?.id ?? "");
+
+    const ws = workspaceStore.activeWorkspace;
+    expect(ws.windows.map((w) => w.threadId)).toEqual(["thread-2"]);
+    expect(ws.focusedWindowId).toBe(focusedPane?.id);
+    expect(threadStore.activeThreadId).toBe("thread-2");
   });
 
   it("clears the active thread when the last pane closes", async () => {


### PR DESCRIPTION
## Summary
- add non-destructive close-by-id support for workspace panes
- render a direct close affordance on each visible split pane
- reuse an existing non-editor pane when selecting threads from an editor-focused workspace

Fixes #2084

## Verification
- `./node_modules/.bin/vitest run tests/unit/workspace-store.test.ts tests/unit/workspace-pane-close-affordance.test.ts`
- `./node_modules/.bin/biome check src/stores/workspace.store.ts src/components/layout/ThreadContent.tsx tests/unit/workspace-store.test.ts tests/unit/workspace-pane-close-affordance.test.ts`
- `./node_modules/.bin/vite build`