### PR TITLE
test(memory): update orchestrator provenance guard

### DIFF
--- a/tests/unit/thread-provider-runtime-contract.test.ts
+++ b/tests/unit/thread-provider-runtime-contract.test.ts
@@ -43,7 +43,7 @@ describe("thread provider runtime contract", () => {
     const handleComplete = sourceBetween(
       orchestratorSource,
       "function handleComplete(",
-      "// Store conversation to memory if enabled",
+      "// Extract structured memories from the transcript after the answer lands.",
     );
     expect(handleComplete).toContain("provider: stream.provider");
     expect(handleComplete).toContain("modelId: stream.modelId ?? undefined");


### PR DESCRIPTION
Follow-up to #2086.

## Summary
- fixes the post-merge `test-frontend` CI failure by updating `tests/unit/thread-provider-runtime-contract.test.ts` to slice `handleComplete` at the new structured-memory extraction comment
- no production code changes

## Failed CI Context
- PR #2086 failed `test-frontend` in `tests/unit/thread-provider-runtime-contract.test.ts`
- failure: `persists live orchestrator assistant rows with provider and model provenance` could not find the old `// Store conversation to memory if enabled` marker

## Tests
- `/Users/taariqlewis/Projects/Seren_Projects/seren-desktop/node_modules/.bin/vitest run tests/unit/thread-provider-runtime-contract.test.ts tests/unit/chat-memory-affordance.test.ts tests/unit/agent-seren-memory-wiring.test.ts tests/services/memory.test.ts`
- `git diff --check`

## Note
- Biome ignores this test path, so `biome check tests/unit/thread-provider-runtime-contract.test.ts` processes zero files.