### PR TITLE
fix(providers): preserve multimodal blocks for Anthropic (#2089)

### DIFF
--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -6,8 +6,12 @@ import type {
   AuthOptions,
   ChatMessage,
   ChatRequest,
+  ContentBlock,
+  DocumentContentBlock,
+  ImageContentBlock,
   ProviderAdapter,
   ProviderModel,
+  TextContentBlock,
 } from "./types";
 
 /**
@@ -53,31 +57,108 @@ const DEFAULT_MODELS: ProviderModel[] = [
 ];
 
 /**
- * Convert messages to Anthropic format.
- * Anthropic requires system message to be separate from messages array.
+ * Anthropic native image source block.
+ * Either base64 (with media_type + data) or a remote URL.
+ */
+type AnthropicImageBlock = {
+  type: "image";
+  source:
+    | { type: "base64"; media_type: string; data: string }
+    | { type: "url"; url: string };
+};
+
+type AnthropicContentBlock =
+  | TextContentBlock
+  | AnthropicImageBlock
+  | DocumentContentBlock;
+
+/**
+ * Parse a data URL into media type + raw base64 payload.
+ * Returns null when the input is not a data URL.
+ */
+function parseDataUrl(url: string): { mediaType: string; data: string } | null {
+  if (!url.startsWith("data:")) return null;
+  const comma = url.indexOf(",");
+  if (comma < 0) return null;
+  const meta = url.slice(5, comma);
+  const data = url.slice(comma + 1);
+  const semi = meta.indexOf(";");
+  const mediaType = semi >= 0 ? meta.slice(0, semi) : meta;
+  if (!mediaType) return null;
+  return { mediaType, data };
+}
+
+/**
+ * Convert one OpenAI-format image_url block to Anthropic's image block shape.
+ * Anthropic accepts base64 sources or remote URLs; data: URLs must be split
+ * into media_type + raw base64.
+ */
+function imageUrlToAnthropic(block: ImageContentBlock): AnthropicImageBlock {
+  const url = block.image_url.url;
+  const parsed = parseDataUrl(url);
+  if (parsed) {
+    return {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: parsed.mediaType,
+        data: parsed.data,
+      },
+    };
+  }
+  return {
+    type: "image",
+    source: { type: "url", url },
+  };
+}
+
+/**
+ * Convert a content array to Anthropic-compatible blocks. Preserves text and
+ * document blocks; rewrites image_url blocks into Anthropic's image shape.
+ */
+function toAnthropicBlocks(blocks: ContentBlock[]): AnthropicContentBlock[] {
+  return blocks.map((b) =>
+    b.type === "image_url" ? imageUrlToAnthropic(b) : b,
+  );
+}
+
+/**
+ * Flatten content to plain text for the system field, which Anthropic accepts
+ * as a string. Non-text blocks are dropped — the system prompt cannot carry
+ * attachments.
+ */
+function toSystemText(content: string | ContentBlock[]): string {
+  if (typeof content === "string") return content;
+  return content
+    .filter((b): b is TextContentBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+}
+
+/**
+ * Convert messages to Anthropic format. The system message is split off into
+ * its own field; user/assistant content arrays preserve text + image +
+ * document blocks (#2089 — the old path collapsed every array to text and
+ * silently dropped image attachments).
  */
 function convertToAnthropicFormat(messages: ChatMessage[]): {
   system?: string;
-  messages: Array<{ role: "user" | "assistant"; content: string }>;
+  messages: Array<{
+    role: "user" | "assistant";
+    content: string | AnthropicContentBlock[];
+  }>;
 } {
   const systemMessage = messages.find((m) => m.role === "system");
   const otherMessages = messages.filter((m) => m.role !== "system");
 
-  const normalizeContent = (
-    content: string | import("./types").ContentBlock[],
-  ): string => {
-    if (typeof content === "string") return content;
-    return content
-      .filter((b): b is import("./types").TextContentBlock => b.type === "text")
-      .map((b) => b.text)
-      .join("\n");
-  };
-
   return {
-    system: systemMessage ? normalizeContent(systemMessage.content) : undefined,
+    system: systemMessage ? toSystemText(systemMessage.content) : undefined,
     messages: otherMessages.map((m) => ({
       role: m.role as "user" | "assistant",
-      content: normalizeContent(m.content),
+      content:
+        typeof m.content === "string"
+          ? m.content
+          : toAnthropicBlocks(m.content),
     })),
   };
 }

--- a/tests/unit/anthropic-image-attachments.test.ts
+++ b/tests/unit/anthropic-image-attachments.test.ts
@@ -1,0 +1,178 @@
+// ABOUTME: Regression test for #2089 — Anthropic provider must preserve
+// ABOUTME: image_url and document content blocks instead of stripping them to text.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const appFetchMock = vi.fn<typeof fetch>();
+
+vi.mock("@/lib/fetch", () => ({
+  appFetch: appFetchMock,
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function readPostedBody(): Promise<Record<string, unknown>> {
+  expect(appFetchMock).toHaveBeenCalledTimes(1);
+  const init = appFetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+  const raw = init?.body;
+  expect(typeof raw).toBe("string");
+  return JSON.parse(raw as string);
+}
+
+describe("anthropic provider — multimodal payload (#2089)", () => {
+  beforeEach(() => {
+    appFetchMock.mockReset();
+    appFetchMock.mockResolvedValue(
+      jsonResponse({ content: [{ type: "text", text: "ok" }] }),
+    );
+  });
+
+  it("converts data-URL image_url blocks to Anthropic image source", async () => {
+    const { anthropicProvider } = await import("@/lib/providers/anthropic");
+
+    await anthropicProvider.sendMessage(
+      {
+        model: "claude-3-5-sonnet-20241022",
+        stream: false,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image_url",
+                image_url: {
+                  url: "data:image/png;base64,aGVsbG8=",
+                },
+              },
+              { type: "text", text: "what's in this image?" },
+            ],
+          },
+        ],
+      },
+      "sk-ant-test",
+    );
+
+    const body = await readPostedBody();
+    const messages = body.messages as Array<{
+      role: string;
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(Array.isArray(messages[0].content)).toBe(true);
+    expect(messages[0].content).toEqual([
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: "aGVsbG8=",
+        },
+      },
+      { type: "text", text: "what's in this image?" },
+    ]);
+  });
+
+  it("converts https image_url blocks to Anthropic URL source", async () => {
+    const { anthropicProvider } = await import("@/lib/providers/anthropic");
+
+    await anthropicProvider.sendMessage(
+      {
+        model: "claude-3-5-sonnet-20241022",
+        stream: false,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image_url",
+                image_url: { url: "https://example.com/cat.jpg" },
+              },
+              { type: "text", text: "describe" },
+            ],
+          },
+        ],
+      },
+      "sk-ant-test",
+    );
+
+    const body = await readPostedBody();
+    const messages = body.messages as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(messages[0].content[0]).toEqual({
+      type: "image",
+      source: { type: "url", url: "https://example.com/cat.jpg" },
+    });
+  });
+
+  it("preserves Anthropic-native document (PDF) blocks unchanged", async () => {
+    const { anthropicProvider } = await import("@/lib/providers/anthropic");
+
+    await anthropicProvider.sendMessage(
+      {
+        model: "claude-3-5-sonnet-20241022",
+        stream: false,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "document",
+                source: {
+                  type: "base64",
+                  media_type: "application/pdf",
+                  data: "JVBERi0=",
+                },
+              },
+              { type: "text", text: "summarize" },
+            ],
+          },
+        ],
+      },
+      "sk-ant-test",
+    );
+
+    const body = await readPostedBody();
+    const messages = body.messages as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(messages[0].content[0]).toEqual({
+      type: "document",
+      source: {
+        type: "base64",
+        media_type: "application/pdf",
+        data: "JVBERi0=",
+      },
+    });
+    expect(messages[0].content[1]).toEqual({
+      type: "text",
+      text: "summarize",
+    });
+  });
+
+  it("keeps plain-string system message as a string", async () => {
+    const { anthropicProvider } = await import("@/lib/providers/anthropic");
+
+    await anthropicProvider.sendMessage(
+      {
+        model: "claude-3-5-sonnet-20241022",
+        stream: false,
+        messages: [
+          { role: "system", content: "you are helpful" },
+          { role: "user", content: "hi" },
+        ],
+      },
+      "sk-ant-test",
+    );
+
+    const body = await readPostedBody();
+    expect(body.system).toBe("you are helpful");
+    const messages = body.messages as Array<{ role: string; content: unknown }>;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toEqual({ role: "user", content: "hi" });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #2089. `convertToAnthropicFormat()` flattened every message's `ContentBlock[]` to a text-only string, silently dropping `image_url` and `document` blocks before the request reached `api.anthropic.com`. The composer thumbnail came from local UI state, so the loss was invisible until the model replied as if no image existed.
- Rewrites the converter to keep block arrays intact: text passes through, OpenAI-shape `image_url` blocks become Anthropic `{type:"image", source:{base64|url, ...}}` blocks (data: URLs split into `media_type` + raw base64), and Anthropic-native `document` blocks pass through unchanged.
- Audit confirmed OpenAI, Seren, and Seren-private adapters already forward `request.messages` verbatim and the upstream accepts `image_url` natively, so no change was needed there. Rust orchestrator path (`chat_model_worker.rs:516-559`) was already correct. No Gemini JS provider exists.

## Test plan

- [x] `pnpm vitest run tests/unit/anthropic-image-attachments.test.ts` — new regression test covering all four multimodal shapes
- [x] `pnpm vitest run` — full unit suite (1460/1460 passing)
- [x] `pnpm biome check src/lib/providers/anthropic.ts tests/unit/anthropic-image-attachments.test.ts`
- [ ] Manual: attach a PNG, send "what's in this image?" against an Anthropic provider chat, confirm description

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
