### PR TITLE
fix(terminal): restore copy/paste in Claude Code CLI surface

### DIFF
--- a/src/components/terminal/TerminalBuffer.tsx
+++ b/src/components/terminal/TerminalBuffer.tsx
@@ -14,6 +14,10 @@ import {
   Show,
 } from "solid-js";
 import {
+  ContextMenu,
+  type ContextMenuItem,
+} from "@/components/common/ContextMenu";
+import {
   canAcceptSkillDrop,
   setCurrentSkillDragPayload,
   skillDragPayload,
@@ -306,6 +310,18 @@ function selectionText(grid: GridSnapshot, sel: SelectionRange): string {
 }
 
 /**
+ * Build a SelectionRange that covers every cell of the visible grid.
+ * Used by the right-click context menu's "Select All" action so the
+ * user can grab the whole screen without dragging.
+ */
+function selectAllGrid(grid: GridSnapshot): SelectionRange {
+  return {
+    anchor: { row: 0, col: 0 },
+    head: { row: Math.max(0, grid.rows - 1), col: Math.max(0, grid.cols - 1) },
+  };
+}
+
+/**
  * Best-effort clipboard write. Tauri's webview generally exposes the
  * Async Clipboard API, but some platforms / configurations don't, so
  * fall back to a hidden textarea + execCommand("copy").
@@ -361,6 +377,17 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
     () => appearanceState.appearance.terminalFontSize,
   );
   const [selection, setSelection] = createSignal<SelectionRange | null>(null);
+  // Right-click context menu state. null = closed; { x, y } = open at viewport coords.
+  // Reuses the shared ContextMenu primitive (src/components/common/ContextMenu.tsx).
+  const [ctxMenu, setCtxMenu] = createSignal<{ x: number; y: number } | null>(
+    null,
+  );
+  // Off-screen mirror node that holds the selected text so window.getSelection()
+  // returns a real DOM Range. Without this, the system Edit > Copy menu item
+  // (Tauri PredefinedMenuItem::copy in src-tauri/src/lib.rs) silently no-ops
+  // on the canvas surface because Chromium only fires a `copy` event when
+  // there is a DOM selection. #2091.
+  let selectionMirrorRef: HTMLSpanElement | undefined;
 
   let unlistenDiff: UnlistenFn | null = null;
   let resizeObserver: ResizeObserver | null = null;
@@ -1524,6 +1551,104 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
     }),
   );
 
+  // Mirror the canvas selection into an off-screen DOM range so the system
+  // Edit > Copy menu (Tauri PredefinedMenuItem::copy) — which only fires a
+  // browser `copy` event when window.getSelection() is non-empty — copies
+  // the right text. Pointing the document selection at our hidden span has
+  // no visible effect (the span is positioned at -10000px) and the canvas
+  // owns its own selection rendering, so this purely serves the system
+  // clipboard path. Cleared when the terminal selection is empty so we
+  // never hijack a real selection in the chat or Monaco editor. #2091.
+  createEffect(() => {
+    const sel = selection();
+    const g = grid();
+    const mirror = selectionMirrorRef;
+    if (!mirror) return;
+    const docSel = window.getSelection();
+    if (!docSel) return;
+    if (!sel || !g) {
+      mirror.textContent = "";
+      if (mirror.firstChild && docSel.containsNode(mirror.firstChild, true)) {
+        docSel.removeAllRanges();
+      }
+      return;
+    }
+    const text = selectionText(g, sel);
+    if (!text) {
+      mirror.textContent = "";
+      return;
+    }
+    mirror.textContent = text;
+    const node = mirror.firstChild;
+    if (!node) return;
+    docSel.removeAllRanges();
+    docSel.setBaseAndExtent(node, 0, node, text.length);
+  });
+
+  /**
+   * Right-click handler for the terminal surface. Replaces the default
+   * Tauri webview menu (which only ships "Reload" / "Inspect Element" in
+   * dev and nothing in production) with a discoverable Copy / Paste /
+   * Select All popover. Cmd+C still owns the keyboard path; this is the
+   * mouse-driven complement. #2091.
+   */
+  const openContextMenu = (event: MouseEvent) => {
+    event.preventDefault();
+    setCtxMenu({ x: event.clientX, y: event.clientY });
+  };
+
+  const closeContextMenu = () => setCtxMenu(null);
+
+  const contextMenuItems = (): ContextMenuItem[] => {
+    const current = buffer();
+    const running = current?.status === "running";
+    const sel = selection();
+    const g = grid();
+    const hasSelection = !!sel && !!g && selectionText(g, sel).length > 0;
+    return [
+      {
+        label: "Copy",
+        shortcut: "⌘C",
+        disabled: !hasSelection,
+        onClick: () => {
+          if (!sel || !g) return;
+          void writeClipboard(selectionText(g, sel));
+        },
+      },
+      {
+        label: "Paste",
+        shortcut: "⌘V",
+        disabled: !running,
+        onClick: () => {
+          void (async () => {
+            try {
+              const text = await navigator.clipboard.readText();
+              if (text) {
+                surfaceRef?.focus();
+                await writePromptText(text);
+              }
+            } catch {
+              // Clipboard read may be denied; nothing to do.
+            }
+          })();
+        },
+      },
+      { label: "", separator: true, onClick: () => {} },
+      {
+        label: "Select All",
+        disabled: !g,
+        onClick: () => {
+          const snapshot = grid();
+          if (!snapshot) return;
+          // The selection signal is watched by the repaint createEffect
+          // above, so updating it triggers a full canvas redraw on the
+          // next animation frame — no manual repaint needed.
+          setSelection(selectAllGrid(snapshot));
+        },
+      },
+    ];
+  };
+
   /**
    * Translate a KeyboardEvent into the byte sequence the PTY expects
    * and write it to the active buffer. The pure encoding table lives
@@ -1879,8 +2004,27 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
                 onMouseDown={onSurfaceMouseDown}
                 onMouseMove={onSurfaceMouseMoveTracking}
                 onWheel={onSurfaceWheel}
+                onContextMenu={openContextMenu}
               >
                 <canvas ref={canvasRef} class="block pointer-events-none" />
+                {/* Hidden DOM mirror of the canvas selection. The system
+                    Edit > Copy menu (Tauri PredefinedMenuItem::copy) only
+                    fires a `copy` event when window.getSelection() is
+                    non-empty; pointing the document selection at this
+                    off-screen span makes that path produce the right text
+                    without changing any menu-bar wiring. #2091. */}
+                <span
+                  ref={selectionMirrorRef}
+                  data-testid="terminal-selection-mirror"
+                  aria-hidden="true"
+                  style={{
+                    position: "absolute",
+                    left: "-10000px",
+                    top: "0",
+                    "white-space": "pre",
+                    "user-select": "text",
+                  }}
+                />
               </div>
 
               <Show when={isClaudeCli()}>
@@ -1909,6 +2053,16 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
             </>
           );
         }}
+      </Show>
+      <Show when={ctxMenu()}>
+        {(pos) => (
+          <ContextMenu
+            x={pos().x}
+            y={pos().y}
+            items={contextMenuItems()}
+            onClose={closeContextMenu}
+          />
+        )}
       </Show>
     </div>
   );

--- a/tests/unit/terminal-buffer-copy-paste.test.ts
+++ b/tests/unit/terminal-buffer-copy-paste.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Critical regression guard for the Claude Code CLI copy/paste UX (#2091).
+// ABOUTME: Locks the two wiring invariants that make Edit > Copy and right-click work:
+// ABOUTME: (1) the terminal surface owns oncontextmenu and renders a ContextMenu,
+// ABOUTME: (2) the terminal selection is mirrored into a hidden DOM range so the
+// ABOUTME: system Edit > Copy / PredefinedMenuItem::copy path produces real text.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const terminalBufferTsx = readFileSync(
+  resolve("src/components/terminal/TerminalBuffer.tsx"),
+  "utf-8",
+);
+
+describe("TerminalBuffer — right-click context menu (#2091)", () => {
+  it("imports the shared ContextMenu primitive", () => {
+    // Reusing src/components/common/ContextMenu.tsx instead of forking a
+    // bespoke popover keeps the keyboard/escape/scroll-close behavior
+    // identical to FileTree and AgentChat's existing menus.
+    expect(terminalBufferTsx).toMatch(
+      /from\s+["']@\/components\/common\/ContextMenu["']/,
+    );
+  });
+
+  it("attaches an onContextMenu handler to the terminal surface div", () => {
+    // The surface <div> (role="application") is where the user right-clicks.
+    // Without this handler, Tauri's default webview context menu wins and
+    // ships only "Reload" / "Inspect Element" — the exact regression in
+    // the bug report.
+    expect(terminalBufferTsx).toMatch(/onContextMenu=\{/);
+  });
+
+  it("renders the ContextMenu with Copy, Paste, and Select All actions", () => {
+    // Lock the visible action set so a future drive-by edit can't quietly
+    // delete an action and reintroduce the original UX gap.
+    expect(terminalBufferTsx).toMatch(/label:\s*"Copy"/);
+    expect(terminalBufferTsx).toMatch(/label:\s*"Paste"/);
+    expect(terminalBufferTsx).toMatch(/label:\s*"Select All"/);
+  });
+});
+
+describe("TerminalBuffer — system Edit > Copy via DOM selection mirror (#2091)", () => {
+  it("declares a hidden selection-mirror span the canvas selection writes into", () => {
+    // The canvas is custom-painted; the browser sees no DOM selection,
+    // so PredefinedMenuItem::copy in src-tauri/src/lib.rs becomes a
+    // no-op. Mirroring the terminal selection text into an off-screen
+    // span and pointing window.getSelection() at it makes the system
+    // Edit > Copy path produce the right text WITHOUT changing any
+    // menu-bar wiring (which would otherwise regress Monaco + chat
+    // inputs).
+    expect(terminalBufferTsx).toMatch(/data-testid="terminal-selection-mirror"/);
+  });
+
+  it("syncs window.getSelection() to the mirror whenever the terminal selection changes", () => {
+    // The mirror is dead weight unless we point the document selection
+    // at it. The setBaseAndExtent call is the load-bearing line — drop
+    // it and Edit > Copy silently regresses again.
+    expect(terminalBufferTsx).toMatch(/window\.getSelection\(\)/);
+    expect(terminalBufferTsx).toMatch(/setBaseAndExtent|addRange/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2091 — copy/paste broken in the Claude Code CLI terminal surface inside SerenDesktop.

The canvas-painted terminal surface had no DOM selection, so two paths failed:

- **System Edit > Copy** (`PredefinedMenuItem::copy` in `src-tauri/src/lib.rs`) was a silent no-op because Chromium/WebKit only fires a `copy` event when `window.getSelection()` is non-empty.
- **Right-click** showed only the default Tauri webview menu (Reload / Inspect Element in dev, nothing in production) because there was no `oncontextmenu` handler on the surface.

The only working copy path was the undiscoverable `Cmd+C` / `Ctrl+Shift+C` keyboard chord.

## What changed

`src/components/terminal/TerminalBuffer.tsx`:

1. **Right-click context menu** on the terminal surface, rendered via the shared `ContextMenu` primitive (`src/components/common/ContextMenu.tsx`) with Copy / Paste / Select All actions. Copy and Paste reuse the existing `selectionText` + `writeClipboard` and `writePromptText` (bracketed-paste-aware) pipelines. Select All swaps in `selectAllGrid(grid)`.

2. **Off-screen DOM selection mirror** — a hidden `<span>` the terminal selection writes into, with `window.getSelection().setBaseAndExtent` pointing at it. The system Edit > Copy path now sees a real DOM selection and produces the right text without touching the menubar wiring (which would otherwise regress Edit > Copy for Monaco and chat inputs). The mirror is cleared and the document selection is released when the terminal selection is `null`, and the release is guarded by `Selection.containsNode` so we never clobber a foreign selection elsewhere in the app.

`Cmd+C` / `Ctrl+Shift+C` keep ownership of their `handleKeyDown` path; the `Ctrl+C` SIGINT path is unchanged.

## Tests

`tests/unit/terminal-buffer-copy-paste.test.ts` — five critical regression guards on the wiring invariants:

- `ContextMenu` import path
- `onContextMenu` handler on the surface
- Copy / Paste / Select All action labels
- `terminal-selection-mirror` element
- `window.getSelection().setBaseAndExtent` mirror sync

Failing on `main`, passing on this branch.

## Test plan

- [x] `pnpm vitest run tests/unit/terminal-buffer-copy-paste.test.ts` — 5/5 pass
- [x] Full unit suite: 1465/1465 pass
- [x] `tsc --noEmit` — no new TS errors (same 4 pre-existing on main)
- [x] `biome check` on changed files — no new errors (same 6 pre-existing warnings on main)
- [ ] Manual: right-click in Claude CLI thread shows Copy / Paste / Select All
- [ ] Manual: Edit > Copy with terminal selection writes the selected text
- [ ] Manual: Cmd+C still works as before
- [ ] Manual: Edit > Copy in chat input / Monaco still works (no regression)

Closes #2091
