### PR TITLE
fix(sidebar): anchor folder order to last activity (#2093)

### DIFF
--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -27,6 +27,7 @@ import { terminalStore } from "@/stores/terminal.store";
 
 const LAST_ACTIVE_THREAD_KEY = "seren:lastActiveThread";
 const PROJECT_ORDER_KEY = "seren:projectOrder";
+const FOLDER_LAST_ACTIVITY_KEY = "seren:folderLastActivity";
 
 export type ThreadKind = "chat" | "agent" | "terminal" | "editor";
 
@@ -59,6 +60,32 @@ function loadProjectOrder(): string[] {
 function persistProjectOrder(order: string[]): void {
   try {
     localStorage.setItem(PROJECT_ORDER_KEY, JSON.stringify(order));
+  } catch {
+    // Non-fatal
+  }
+}
+
+function loadFolderLastActivity(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(FOLDER_LAST_ACTIVITY_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const out: Record<string, number> = {};
+      for (const [k, v] of Object.entries(parsed)) {
+        if (typeof v === "number" && Number.isFinite(v)) out[k] = v;
+      }
+      return out;
+    }
+  } catch {
+    // Ignore
+  }
+  return {};
+}
+
+function persistFolderLastActivity(map: Record<string, number>): void {
+  try {
+    localStorage.setItem(FOLDER_LAST_ACTIVITY_KEY, JSON.stringify(map));
   } catch {
     // Non-fatal
   }
@@ -129,6 +156,14 @@ interface ThreadState {
    * falls through to recency sort. Persisted across sessions.
    */
   projectOrder: string[];
+  /**
+   * Per-folder last-activity timestamp (ms since epoch). Bumped when the user
+   * selects a thread in that folder. Closing/archiving a thread does NOT
+   * touch this map, so the folder keeps its sidebar position after a close.
+   * Persisted across sessions; absent entries fall back to the folder's
+   * max thread creation time so the first-launch ordering is unchanged.
+   */
+  folderLastActivity: Record<string, number>;
 }
 
 export type SkillLaunchMode = "replace" | "add";
@@ -147,6 +182,7 @@ const [state, setState] = createStore<ThreadState>({
   activeThreadKind: null,
   preferChat: false,
   projectOrder: loadProjectOrder(),
+  folderLastActivity: loadFolderLastActivity(),
 });
 
 // Expose the user's current navigation target to agent.store's idle-reclaim
@@ -565,12 +601,35 @@ export const threadStore = {
       }
     }
 
+    // Two-tier sort: folders that contain a running thread come first so an
+    // active agent always anchors its folder to the top. Within each tier
+    // we sort by the folder's recorded last-activity timestamp, falling
+    // back to max thread creation time for folders the user has never
+    // selected into (preserves first-launch ordering for existing users).
+    //
+    // We deliberately key off `folderLastActivity` instead of recomputing
+    // max(thread.timestamp) on every read: closing a thread removes it
+    // from the filtered list and used to drop the folder's sort key to
+    // whatever older thread remained, which shoved the folder down the
+    // sidebar even though the user had just been working there.
+    const folderRunning = (root: string): boolean =>
+      (groups.get(root) ?? []).some((t) => t.status === "running");
+    const folderActivity = (root: string): number => {
+      const recorded = state.folderLastActivity[root];
+      if (typeof recorded === "number") return recorded;
+      const threads = groups.get(root) ?? [];
+      return threads.length === 0
+        ? 0
+        : Math.max(...threads.map((t) => t.timestamp));
+    };
+
     const unranked = realRoots
       .filter((root) => !seen.has(root))
       .sort((a, b) => {
-        const aMax = Math.max(...(groups.get(a) ?? []).map((t) => t.timestamp));
-        const bMax = Math.max(...(groups.get(b) ?? []).map((t) => t.timestamp));
-        return bMax - aMax;
+        const aRunning = folderRunning(a);
+        const bRunning = folderRunning(b);
+        if (aRunning !== bRunning) return aRunning ? -1 : 1;
+        return folderActivity(b) - folderActivity(a);
       });
 
     for (const root of [...ordered, ...unranked]) {
@@ -616,6 +675,30 @@ export const threadStore = {
   // --------------------------------------------------------------------------
 
   /**
+   * Record that the user is actively working in `projectRoot`. The folder's
+   * sidebar position is anchored to this timestamp, so closing a thread
+   * inside the folder no longer drops it down the list. `timestamp`
+   * defaults to `Date.now()`; tests pass an explicit value.
+   */
+  noteFolderActivity(projectRoot: string | null, timestamp?: number): void {
+    if (!projectRoot) return;
+    const next = {
+      ...state.folderLastActivity,
+      [projectRoot]: timestamp ?? Date.now(),
+    };
+    setState("folderLastActivity", next);
+    persistFolderLastActivity(next);
+  },
+
+  /**
+   * Read the recorded last-activity timestamp for a folder. Returns
+   * undefined when the folder has never been selected into.
+   */
+  getFolderLastActivity(projectRoot: string): number | undefined {
+    return state.folderLastActivity[projectRoot];
+  },
+
+  /**
    * Select a thread by ID. Updates the underlying store (conversation or agent)
    * to match.
    */
@@ -628,6 +711,7 @@ export const threadStore = {
     if (thread?.projectRoot && thread.projectRoot !== fileTreeState.rootPath) {
       setRootPath(thread.projectRoot);
     }
+    this.noteFolderActivity(thread?.projectRoot ?? null);
 
     if (kind === "chat") {
       conversationStore.setActiveConversation(id);
@@ -985,9 +1069,11 @@ export const threadStore = {
       activeThreadId: null,
       activeThreadKind: null,
       preferChat: false,
+      folderLastActivity: {},
     });
     try {
       localStorage.removeItem(LAST_ACTIVE_THREAD_KEY);
+      localStorage.removeItem(FOLDER_LAST_ACTIVITY_KEY);
     } catch {
       // Non-fatal
     }

--- a/tests/unit/thread-store.test.ts
+++ b/tests/unit/thread-store.test.ts
@@ -543,6 +543,113 @@ describe("threadStore", () => {
       expect(groups[2].projectRoot).toBeNull();
       expect(groups[2].folderName).toBe("No project");
     });
+
+    // #2093 — Closing a thread inside a folder must not push that folder
+    // down the sidebar. The folder's sort key is anchored by the last
+    // time the user *selected into* it, not by the max creation time of
+    // its surviving open threads.
+    it("keeps a folder in place after its newest thread is closed", () => {
+      mockConversations.conversations = [
+        {
+          id: "x-old",
+          title: "Older in X",
+          createdAt: 1000,
+          selectedModel: "test",
+          selectedProvider: null,
+          projectRoot: "/Users/dev/project-x",
+          isArchived: false,
+        },
+        {
+          id: "x-new",
+          title: "Newest in X (about to close)",
+          createdAt: 3000,
+          selectedModel: "test",
+          selectedProvider: null,
+          projectRoot: "/Users/dev/project-x",
+          isArchived: false,
+        },
+        {
+          id: "y-thread",
+          title: "Only thread in Y",
+          createdAt: 2000,
+          selectedModel: "test",
+          selectedProvider: null,
+          projectRoot: "/Users/dev/project-y",
+          isArchived: false,
+        },
+      ];
+
+      // User worked in X most recently — that activity anchors the folder.
+      threadStore.noteFolderActivity("/Users/dev/project-x", 5000);
+      threadStore.noteFolderActivity("/Users/dev/project-y", 4000);
+
+      const before = threadStore.groupedThreads.map((g) => g.projectRoot);
+      expect(before).toEqual([
+        "/Users/dev/project-x",
+        "/Users/dev/project-y",
+      ]);
+
+      // Close the newest thread in X (this is the bug repro: pre-fix the
+      // sort fell back to max(remaining createdAt) = 1000, dropping X
+      // below Y).
+      mockConversations.conversations = mockConversations.conversations.filter(
+        (c) => c.id !== "x-new",
+      );
+
+      const after = threadStore.groupedThreads.map((g) => g.projectRoot);
+      expect(after).toEqual([
+        "/Users/dev/project-x",
+        "/Users/dev/project-y",
+      ]);
+    });
+
+    // #2093 — Folders that contain a running thread are pinned above
+    // idle folders so an active agent always tells the user where their
+    // work is happening, even when an idle folder has a newer recorded
+    // activity timestamp.
+    it("pins folders with running threads above idle folders", () => {
+      mockConversations.conversations = [
+        {
+          id: "idle-recent",
+          title: "Idle but most-recent activity",
+          createdAt: 1000,
+          selectedModel: "test",
+          selectedProvider: null,
+          projectRoot: "/Users/dev/project-idle",
+          isArchived: false,
+        },
+      ];
+      mockAgentConversations.push({
+        id: "agent-running",
+        title: "Running agent in another folder",
+        created_at: 500,
+        agent_type: "claude-code",
+        agent_session_id: "sess-running",
+        agent_cwd: "/Users/dev/project-running",
+        agent_model_id: null,
+        project_id: null,
+        project_root: "/Users/dev/project-running",
+        is_archived: false,
+      });
+      mockSessions["sess-running"] = {
+        conversationId: "agent-running",
+        info: {
+          id: "sess-running",
+          status: "prompting",
+          agentType: "claude-code",
+        },
+      };
+
+      // Idle folder has the more-recent recorded activity timestamp.
+      threadStore.noteFolderActivity("/Users/dev/project-idle", 9000);
+      threadStore.noteFolderActivity("/Users/dev/project-running", 1000);
+
+      const order = threadStore.groupedThreads.map((g) => g.projectRoot);
+      expect(order).toEqual([
+        "/Users/dev/project-running",
+        "/Users/dev/project-idle",
+      ]);
+    });
   });
 
   describe("selectThread", () => {


### PR DESCRIPTION
## Summary
- Anchor each sidebar folder to a recorded `folderLastActivity` timestamp (bumped on `selectThread`, never on `archiveThread`), so closing a thread no longer slides its folder to the bottom of the sidebar.
- Sort folders into two tiers: folders containing a running thread first, then by recorded activity (falling back to max thread creation time so first-launch ordering is unchanged for existing users).
- Closes #2093.

## Why this happened
`groupedThreads` used `Math.max(...threads.map(t => t.timestamp))` over only the currently-open threads (`!isArchived`). `Thread.timestamp` is the conversation's `createdAt`, never bumped. Close the newest-created thread and the folder's sort key dropped to whatever older thread remained — sometimes years older — so the folder slid to the bottom even though the user was just working there.

## Test plan
- [x] `pnpm vitest run tests/unit/thread-store.test.ts` — 26 tests pass, including the two new critical tests for #2093
- [x] `pnpm vitest run` full suite — 1467 tests pass
- [x] Verified the close-then-stay-put test fails against the pre-fix store
- [x] Manual: open a thread in folder A, then close it — folder A holds its sidebar position
- [x] Manual: start a running agent in folder B while folder A has more recent activity — folder B sorts above A

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
