### PR TITLE
fix(sidebar): stop folder reorder on thread click (#2095)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -986,6 +986,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       "[AgentChat] Sending prompt to agent runtime, context blocks:",
       context?.length ?? 0,
     );
+    // Real agent activity in this thread bumps its folder's sidebar rank
+    // (#2095). Selection clicks intentionally do not — only sends do.
+    if (thread) threadStore.noteThreadActivity(thread.id);
     const docNames =
       docAttachments.length > 0 ? docAttachments.map((d) => d.name) : undefined;
     await agentStore.sendPrompt(

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -41,6 +41,7 @@ import { fileTreeState } from "@/stores/fileTree";
 import { AUTO_MODEL_ID, providerStore } from "@/stores/provider.store";
 import { settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
+import { threadStore } from "@/stores/thread.store";
 import type { UnifiedMessage, WorkerType } from "@/types/conversation";
 
 // =============================================================================
@@ -179,6 +180,10 @@ export async function orchestrate(
   // Show loading indicator immediately so the user sees feedback right
   // after hitting Enter — before history, memory, and skill context load.
   conversationStore.setLoading(true, conversationId);
+
+  // Real agent activity in this thread bumps its folder's sidebar rank
+  // (#2095). Navigation clicks intentionally do not — only sends do.
+  threadStore.noteThreadActivity(conversationId);
 
   // Save params for retry support
   lastOrchestrationParams = { conversationId, prompt, images };

--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -603,24 +603,23 @@ export const threadStore = {
 
     // Two-tier sort: folders that contain a running thread come first so an
     // active agent always anchors its folder to the top. Within each tier
-    // we sort by the folder's recorded last-activity timestamp, falling
-    // back to max thread creation time for folders the user has never
-    // selected into (preserves first-launch ordering for existing users).
+    // we sort by max(recorded folder activity, max thread timestamp) — the
+    // recorded value acts as a floor that prevents close-drops, and the
+    // thread max lets new threads bubble the folder naturally without
+    // having to bump on every selection.
     //
-    // We deliberately key off `folderLastActivity` instead of recomputing
-    // max(thread.timestamp) on every read: closing a thread removes it
-    // from the filtered list and used to drop the folder's sort key to
-    // whatever older thread remained, which shoved the folder down the
-    // sidebar even though the user had just been working there.
+    // Switching threads is navigation, not activity (#2095). Real activity
+    // is `noteThreadActivity`, fired from chat orchestrate and agent
+    // dispatch. Closes anchor via `archiveThread` so a folder with no
+    // recorded sends still stays in place after closing its newest thread.
     const folderRunning = (root: string): boolean =>
       (groups.get(root) ?? []).some((t) => t.status === "running");
     const folderActivity = (root: string): number => {
-      const recorded = state.folderLastActivity[root];
-      if (typeof recorded === "number") return recorded;
+      const recorded = state.folderLastActivity[root] ?? 0;
       const threads = groups.get(root) ?? [];
-      return threads.length === 0
-        ? 0
-        : Math.max(...threads.map((t) => t.timestamp));
+      const fromThreads =
+        threads.length === 0 ? 0 : Math.max(...threads.map((t) => t.timestamp));
+      return Math.max(recorded, fromThreads);
     };
 
     const unranked = realRoots
@@ -692,10 +691,23 @@ export const threadStore = {
 
   /**
    * Read the recorded last-activity timestamp for a folder. Returns
-   * undefined when the folder has never been selected into.
+   * undefined when the folder has never recorded an activity bump.
    */
   getFolderLastActivity(projectRoot: string): number | undefined {
     return state.folderLastActivity[projectRoot];
+  },
+
+  /**
+   * Bump the folder containing `threadId`. This is the production hook for
+   * real agent activity — chat orchestrate and agent dispatch — and is the
+   * only path that should rewrite folder order from user-driven work.
+   * Navigation clicks intentionally do not call this. No-op when the
+   * thread is unknown or has no projectRoot.
+   */
+  noteThreadActivity(threadId: string): void {
+    const thread = this.threads.find((t) => t.id === threadId);
+    if (!thread?.projectRoot) return;
+    this.noteFolderActivity(thread.projectRoot);
   },
 
   /**
@@ -711,7 +723,9 @@ export const threadStore = {
     if (thread?.projectRoot && thread.projectRoot !== fileTreeState.rootPath) {
       setRootPath(thread.projectRoot);
     }
-    this.noteFolderActivity(thread?.projectRoot ?? null);
+    // Selection is navigation, not folder activity (#2095). Real activity
+    // bumps happen in `noteThreadActivity`, called from orchestrate and
+    // AgentChat dispatch.
 
     if (kind === "chat") {
       conversationStore.setActiveConversation(id);
@@ -986,6 +1000,21 @@ export const threadStore = {
    * Archive a thread.
    */
   async archiveThread(id: string, kind: ThreadKind) {
+    // Anchor the folder before the thread disappears (#2093, #2095).
+    // Without click-time bumps from selectThread, the only way to keep a
+    // folder in place when the user closes its newest thread is to
+    // snapshot the folder's current peak before the row is gone.
+    const closing = this.threads.find((t) => t.id === id);
+    const closingRoot = closing?.projectRoot ?? null;
+    if (closingRoot) {
+      const peers = this.threads.filter((t) => t.projectRoot === closingRoot);
+      if (peers.length > 0) {
+        const peak = Math.max(...peers.map((t) => t.timestamp));
+        const recorded = state.folderLastActivity[closingRoot] ?? 0;
+        if (peak > recorded) this.noteFolderActivity(closingRoot, peak);
+      }
+    }
+
     if (kind === "chat") {
       await conversationStore.archiveConversation(id);
     } else if (kind === "agent") {

--- a/tests/unit/thread-store.test.ts
+++ b/tests/unit/thread-store.test.ts
@@ -653,6 +653,81 @@ describe("threadStore", () => {
   });
 
   describe("selectThread", () => {
+    // #2095 — Switching threads is navigation, not folder activity.
+    // selectThread must not write into folderLastActivity, otherwise every
+    // click reshuffles the sidebar even with zero agent activity. The bump
+    // moves to real activity sites (orchestrate + AgentChat dispatch).
+    it("does not bump folder activity on selection", () => {
+      mockConversations.conversations = [
+        {
+          id: "chat-a",
+          title: "Folder A thread",
+          createdAt: 1000,
+          selectedModel: "test",
+          selectedProvider: null,
+          projectRoot: "/Users/dev/project-a",
+          isArchived: false,
+        },
+        {
+          id: "chat-b",
+          title: "Folder B thread",
+          createdAt: 2000,
+          selectedModel: "test",
+          selectedProvider: null,
+          projectRoot: "/Users/dev/project-b",
+          isArchived: false,
+        },
+      ];
+
+      // Folder B was the user's last real activity, anchoring it on top.
+      threadStore.noteFolderActivity("/Users/dev/project-b", 5000);
+      threadStore.noteFolderActivity("/Users/dev/project-a", 3000);
+      const before = threadStore.groupedThreads.map((g) => g.projectRoot);
+      expect(before).toEqual(["/Users/dev/project-b", "/Users/dev/project-a"]);
+
+      // Click the thread in A. No message sent, nothing typed — pure nav.
+      threadStore.selectThread("chat-a", "chat");
+
+      // Folder activity must NOT have been touched.
+      expect(threadStore.getFolderLastActivity("/Users/dev/project-a")).toBe(
+        3000,
+      );
+      expect(threadStore.getFolderLastActivity("/Users/dev/project-b")).toBe(
+        5000,
+      );
+      // And the visible order must not have changed.
+      const after = threadStore.groupedThreads.map((g) => g.projectRoot);
+      expect(after).toEqual(["/Users/dev/project-b", "/Users/dev/project-a"]);
+    });
+
+    // #2095 — Real agent activity (chat send, agent dispatch) bumps the
+    // folder via noteThreadActivity. This is the production hook that
+    // replaces the selectThread-time bump.
+    it("noteThreadActivity bumps folderLastActivity for the thread's folder", () => {
+      mockConversations.conversations = [
+        {
+          id: "chat-a",
+          title: "Thread in A",
+          createdAt: 1000,
+          selectedModel: "test",
+          selectedProvider: null,
+          projectRoot: "/Users/dev/project-a",
+          isArchived: false,
+        },
+      ];
+
+      const before =
+        threadStore.getFolderLastActivity("/Users/dev/project-a");
+      expect(before).toBeUndefined();
+
+      threadStore.noteThreadActivity("chat-a");
+
+      const after =
+        threadStore.getFolderLastActivity("/Users/dev/project-a");
+      expect(typeof after).toBe("number");
+      expect(after).toBeGreaterThan(0);
+    });
+
     it("selects a chat thread and delegates to conversationStore", () => {
       threadStore.selectThread("chat-1", "chat");
 
@@ -945,6 +1020,72 @@ describe("threadStore", () => {
       await threadStore.archiveThread("chat-2", "chat");
 
       expect(threadStore.activeThreadId).toBe("chat-1");
+    });
+
+    // #2093 + #2095 — Closing the newest thread in a folder must not drop
+    // the folder. Pre-#2095 this relied on selectThread bumping
+    // folderLastActivity on every click; now that click-time bumps are
+    // gone, archiveThread itself has to anchor the folder by snapshotting
+    // the pre-close max(thread.timestamp) before the thread disappears.
+    it("anchors folder order on archive so closing the newest thread doesn't drop the folder", async () => {
+      mockConversations.conversations = [
+        {
+          id: "x-old",
+          title: "Older in X",
+          createdAt: 1000,
+          selectedModel: "test",
+          selectedProvider: null,
+          projectRoot: "/Users/dev/project-x",
+          isArchived: false,
+        },
+        {
+          id: "x-new",
+          title: "Newest in X (about to close)",
+          createdAt: 3000,
+          selectedModel: "test",
+          selectedProvider: null,
+          projectRoot: "/Users/dev/project-x",
+          isArchived: false,
+        },
+        {
+          id: "y-thread",
+          title: "Only thread in Y",
+          createdAt: 2000,
+          selectedModel: "test",
+          selectedProvider: null,
+          projectRoot: "/Users/dev/project-y",
+          isArchived: false,
+        },
+      ];
+
+      // No recorded activity — user has not sent a message yet.
+      expect(
+        threadStore.getFolderLastActivity("/Users/dev/project-x"),
+      ).toBeUndefined();
+      expect(
+        threadStore.getFolderLastActivity("/Users/dev/project-y"),
+      ).toBeUndefined();
+
+      const before = threadStore.groupedThreads.map((g) => g.projectRoot);
+      expect(before).toEqual([
+        "/Users/dev/project-x",
+        "/Users/dev/project-y",
+      ]);
+
+      // Archive the newest thread in X. The archive call must snapshot
+      // X's pre-close max(thread.timestamp) before x-new disappears.
+      await threadStore.archiveThread("x-new", "chat");
+      // Simulate the conversation store dropping the archived row from the
+      // visible list (vi.mocked archiveConversation is a no-op).
+      mockConversations.conversations = mockConversations.conversations.filter(
+        (c) => c.id !== "x-new",
+      );
+
+      const after = threadStore.groupedThreads.map((g) => g.projectRoot);
+      expect(after).toEqual([
+        "/Users/dev/project-x",
+        "/Users/dev/project-y",
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary

- Stops folders from reordering when the user clicks between threads — selection is navigation, not folder activity.
- Moves the activity bump to the two real agent-send sites (`orchestrate()` for chat, `AgentChat.sendMessage()` for agent dispatch) via a new `noteThreadActivity(threadId)` helper.
- Anchors the #2093 close-doesn't-drop behavior via an `archiveThread` snapshot so it no longer depends on click-time bumps.

#2094 introduced the regression by using `selectThread` as the proxy for "activity in this folder." That fired on every click, so the sidebar shuffled whenever the user navigated, even with no agent activity and no typing.

## What changed

- `src/stores/thread.store.ts`
  - `selectThread` no longer calls `noteFolderActivity` — clicking does not reorder folders.
  - `folderActivity` switches from `recorded ?? fromThreads` to `max(recorded, fromThreads)` so a recorded value acts as a floor (prevents close-drops) while new threads still bubble naturally via their `createdAt`.
  - New `noteThreadActivity(threadId)` resolves the thread's folder and bumps it. Public hook for real-activity callers.
  - `archiveThread` snapshots the folder's pre-close `max(thread.timestamp)` before delegating, so the #2093 anchor doesn't depend on click-time bumps from `selectThread`.
- `src/services/orchestrator.ts` — chat `orchestrate()` calls `threadStore.noteThreadActivity(conversationId)` at the top, right after `setLoading(true)`.
- `src/components/chat/AgentChat.tsx` — `sendMessage()` calls `threadStore.noteThreadActivity(thread.id)` at the dispatch site, after the late-cancel guard.

## Tests

Critical-only additions to `tests/unit/thread-store.test.ts`:

- `selectThread does not bump folder activity on selection` — clicking a thread in folder A leaves `folderLastActivity` for both A and B unchanged and the sidebar order untouched.
- `noteThreadActivity bumps folderLastActivity for the thread's folder` — the new public API for real activity sites.
- `anchors folder order on archive so closing the newest thread doesn't drop the folder` — covers the case where the user has never sent a message and just closes a thread.

Existing tests for the running-tier pin and the recorded-activity anchor still pass.

29/29 `thread-store.test.ts`, 1470/1470 full unit suite.

## Test plan

- [ ] CI green.
- [ ] Manually verify in `pnpm tauri dev`: open two folders with idle threads, click between them — sidebar order does NOT change.
- [ ] Manually verify: send a message in a thread in a lower-ranked folder; folder bubbles to top.
- [ ] Manually verify: close the newest thread in a folder — folder stays in place (regression check for #2093).
- [ ] Manually verify: an agent running in a folder still pins that folder above idle folders.

Fixes #2095

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
