### PR TITLE
fix(chat): resume thread from SQLite on Login / Restart Session (#2097)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -480,11 +480,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
   };
 
-  // Get the current working directory from file tree
-  const getCwd = () => {
-    return fileTreeState.rootPath || null;
-  };
-
   // Refresh project-scoped remote sessions (agent source-of-truth) and focus
   // any live session tied to the selected folder.
   // Skip refresh if a prompt is active to avoid backend rejection.
@@ -544,18 +539,21 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     if (hasSession()) setAwaitingLogin(null);
   });
 
-  const startSession = async (agentType: AgentType = lockedAgentType()) => {
-    const cwd = getCwd();
-    if (!cwd) {
-      console.warn("[AgentChat] No folder open, cannot start session");
+  // Restart for the currently selected thread by resuming from SQLite.
+  // The bare spawnSession(cwd, agentType) path silently dropped the
+  // thread.id ↔ conversationId binding and stranded persisted history,
+  // leaving the chat blank after Login / Restart Session. #2097.
+  const startSession = async () => {
+    const thread = activeAgentThread();
+    if (!thread) {
+      console.warn("[AgentChat] No active thread to start session");
       return;
     }
-    console.log("[AgentChat] Starting session with cwd:", cwd);
     try {
-      const sessionId = await agentStore.spawnSession(cwd, agentType);
-      console.log("[AgentChat] Session started:", sessionId);
+      const sessionId = await agentStore.resumeAgentConversation(thread.id);
+      console.log("[AgentChat] Session resumed:", sessionId);
     } catch (error) {
-      console.error("[AgentChat] Failed to start session:", error);
+      console.error("[AgentChat] Failed to resume session:", error);
     }
   };
 
@@ -1866,9 +1864,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 type="button"
                 class="px-2 py-1 text-xs font-medium bg-success text-background rounded hover:brightness-110"
                 onClick={() => {
-                  const agentType = awaitingLogin();
                   setAwaitingLogin(null);
-                  if (agentType) startSession(agentType);
+                  startSession();
                 }}
               >
                 Start Session

--- a/tests/unit/chat-empties-after-login-2097.test.ts
+++ b/tests/unit/chat-empties-after-login-2097.test.ts
@@ -1,0 +1,36 @@
+// ABOUTME: #2097 regression — Login / Restart Session must resume the active
+// ABOUTME: thread from SQLite instead of cold-spawning a fresh bare session.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
+describe("#2097 — startSession resumes the active thread", () => {
+  const startSessionIdx = agentChatSource.indexOf("const startSession = async");
+  const startSessionBody = agentChatSource.slice(
+    startSessionIdx,
+    startSessionIdx + 1500,
+  );
+
+  it("delegates to resumeAgentConversation so SQLite history is reloaded", () => {
+    expect(startSessionIdx).toBeGreaterThan(0);
+    expect(startSessionBody).toContain("agentStore.resumeAgentConversation(");
+  });
+
+  it("passes the active thread id so the new session inherits the thread's conversationId binding", () => {
+    expect(startSessionBody).toMatch(
+      /resumeAgentConversation\(\s*thread\.id\s*\)/,
+    );
+  });
+
+  it("does not fall through to a bare spawnSession (the #2097 regression path)", () => {
+    // Pre-fix the body unconditionally called agentStore.spawnSession(cwd, agentType),
+    // which dropped the thread binding and left messages stranded in SQLite.
+    expect(startSessionBody).not.toContain("agentStore.spawnSession(");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2097.

The Login and Restart Session buttons in `AgentChat` both route through `startSession()`, which cold-spawned a bare session via `agentStore.spawnSession(cwd, agentType)`. That call:

- Used `fileTreeState.rootPath` instead of the thread's persisted `project_root` / `agent_cwd` (cwd drift).
- Omitted `localSessionId`, so the new session's `conversationId` was a fresh `info.id` instead of the existing `thread.id` — `getMessagesForConversation(thread.id)` then returned `[]`.
- Did not pass `restoredMessages`, so the SQLite-persisted history was never reloaded into the session.

Net effect: the chat window went blank after Login → Start Session or Restart Session.

This change rewrites `startSession()` to delegate to `agentStore.resumeAgentConversation(thread.id)`, which:

- Loads `restoredMessages` via `loadPersistedAgentHistory` (`agent.store.ts:3229-3237`).
- Spawns with `localSessionId: conversationId`, which `claude-runtime.mjs:1764` honors as the new session id (`const sessionId = localSessionId ?? randomUUID()`), so `info.id === thread.id` and the conversationId binding survives.
- Uses the persisted `convo.project_root?.trim() || convo.agent_cwd?.trim()` instead of the current file-tree root (fixes cwd drift).
- Restores `bootstrapPromptContext`, `initialModelId`, `initialPermissionMode`, and Claude `--resume` context.

The `sendMessage` cold-start path at `AgentChat.tsx:768` is untouched — it already passed `localSessionId: thread.id` correctly and is the only path used for first-spawn from an empty pane. The two existing call sites of `startSession()` (Restart Session button at `:1823-1837` and post-login Start Session button at `:1864-1873`) both target an active thread, so the parameter-less form is correct; the now-unused `agentType` argument is dropped from both. The dead `getCwd` helper is removed.

## Audit trace (post-fix)

1. User clicks Login → `terminateSession(sid)` deletes `state.sessions[sid]`. Messages remain in SQLite. Banner shows.
2. User completes login → clicks Start Session → `startSession()`.
3. `activeAgentThread()` returns the still-selected thread.
4. `resumeAgentConversation(thread.id)` reads `DbAgentConversation`, hydrates `restoredMessages` from SQLite, spawns with `localSessionId: thread.id` and `cwd: project_root`.
5. New session lands at `state.sessions[thread.id]` with `conversationId: thread.id` and `messages: restoredMessages`.
6. `threadMessages()` memo re-runs, finds the new session, returns the persisted messages; the `<Show when={threadMessages().length > 0}>` branch renders.

## Test plan

- [x] `tests/unit/chat-empties-after-login-2097.test.ts` — source-level regression test asserting `startSession()` routes through `resumeAgentConversation(thread.id)` and does not fall through to `agentStore.spawnSession(`.
- [x] Full unit suite: 204 files / 1470 tests pass.
- [x] Biome warning count unchanged from main on `AgentChat.tsx` (3 pre-existing).
- [x] `tsc --noEmit` introduces zero new errors (PdfViewer / codex-image errors are pre-existing on main).
- [ ] Manual smoke: trigger Claude Code auth error → Login → Start Session → confirm prior messages render and the new session resumes in the thread's original cwd.

## Files changed

- `src/components/chat/AgentChat.tsx` — `startSession()` rewritten; `getCwd` removed; post-login button updated.
- `tests/unit/chat-empties-after-login-2097.test.ts` — new regression test.
