### PR TITLE
fix(chat): make Tail stream live tool output

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -763,6 +763,7 @@ pub fn run() {
             files::reveal_in_file_manager,
             // Shell command execution (requires frontend approval)
             shell::execute_shell_command,
+            shell::execute_shell_command_streaming,
             shell::run_skill_script,
             shell::diagnose_shell_network,
             // Interactive terminal buffers

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -5,9 +5,17 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Emitter, Runtime};
 use tauri_plugin_store::StoreExt;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
+use tokio::sync::mpsc;
+
+/// Tauri event channel for streaming Bash stdout/stderr while the command
+/// is still running (#2100). Payload: [`ShellProgressEvent`]. Subscribed
+/// by the frontend in `src/services/shell-progress.ts`.
+const SHELL_PROGRESS_EVENT: &str = "shell://progress";
+const SHELL_PROGRESS_CHANNEL_DEPTH: usize = 256;
 
 const AUTH_STORE: &str = "auth.json";
 const SEREN_API_KEY_KEY: &str = "seren_api_key";
@@ -96,6 +104,25 @@ pub struct CommandResult {
     pub timed_out: bool,
 }
 
+/// One stdout/stderr line emitted by a streaming shell tool call (#2100).
+/// Bare type so shell.rs stays unaware of WorkerEvent / orchestrator wiring.
+#[derive(Debug, Clone)]
+pub struct StreamChunk {
+    pub text: String,
+    pub is_stderr: bool,
+}
+
+/// Payload of the `shell://progress` Tauri event. Each event carries a single
+/// stdout or stderr chunk for one in-flight shell tool call (#2100).
+#[derive(Debug, Clone, Serialize)]
+struct ShellProgressEvent {
+    #[serde(rename = "toolCallId")]
+    tool_call_id: String,
+    chunk: String,
+    #[serde(rename = "isStderr")]
+    is_stderr: bool,
+}
+
 #[tauri::command]
 pub async fn execute_shell_command<R: Runtime>(
     app: AppHandle<R>,
@@ -109,7 +136,62 @@ pub async fn execute_shell_command<R: Runtime>(
         None
     };
 
-    execute_shell_command_inner(command, timeout_secs, api_key.as_deref()).await
+    execute_shell_command_inner(command, timeout_secs, api_key.as_deref(), None).await
+}
+
+/// Streaming variant of [`execute_shell_command`] used by the frontend
+/// tool executor for `execute_command` calls (#2100). Forwards every stdout
+/// and stderr line through the `shell://progress` Tauri event tagged with
+/// `tool_call_id`, then returns the same [`CommandResult`] as the
+/// buffered command. The final payload is still authoritative — chunks are
+/// for live display only and the receiver is free to drop them.
+#[tauri::command]
+pub async fn execute_shell_command_streaming<R: Runtime>(
+    app: AppHandle<R>,
+    command: String,
+    timeout_secs: Option<u64>,
+    inject_seren_credentials: Option<bool>,
+    tool_call_id: String,
+) -> Result<CommandResult, String> {
+    if tool_call_id.trim().is_empty() {
+        return Err("tool_call_id must not be empty".to_string());
+    }
+
+    let api_key = if should_inject_seren_credentials(&command, inject_seren_credentials) {
+        read_stored_seren_api_key(&app)?
+    } else {
+        None
+    };
+
+    let (chunk_tx, mut chunk_rx) = mpsc::channel::<StreamChunk>(SHELL_PROGRESS_CHANNEL_DEPTH);
+    let emit_app = app.clone();
+    let emit_id = tool_call_id.clone();
+    let forwarder = tokio::spawn(async move {
+        while let Some(chunk) = chunk_rx.recv().await {
+            let payload = ShellProgressEvent {
+                tool_call_id: emit_id.clone(),
+                chunk: chunk.text,
+                is_stderr: chunk.is_stderr,
+            };
+            if let Err(e) = emit_app.emit(SHELL_PROGRESS_EVENT, &payload) {
+                log::warn!(
+                    "[Shell] Failed to emit shell://progress for {}: {}",
+                    emit_id,
+                    e
+                );
+            }
+        }
+    });
+
+    let result =
+        execute_shell_command_inner(command, timeout_secs, api_key.as_deref(), Some(chunk_tx))
+            .await;
+
+    // Wait for the forwarder to drain the rest of the channel so the
+    // frontend has every chunk in hand before the result settles. The
+    // channel closes when execute_shell_command_inner drops the sender.
+    let _ = forwarder.await;
+    result
 }
 
 /// Execute an AI tool shell command with optional stored Seren auth injection.
@@ -129,14 +211,14 @@ pub async fn execute_shell_command_for_tool<R: Runtime>(
         None
     };
 
-    execute_shell_command_inner(command, timeout_secs, api_key.as_deref()).await
+    execute_shell_command_inner(command, timeout_secs, api_key.as_deref(), None).await
 }
 
 pub async fn execute_shell_command_without_seren_credentials(
     command: String,
     timeout_secs: Option<u64>,
 ) -> Result<CommandResult, String> {
-    execute_shell_command_inner(command, timeout_secs, None).await
+    execute_shell_command_inner(command, timeout_secs, None, None).await
 }
 
 #[tauri::command]
@@ -173,6 +255,7 @@ async fn execute_shell_command_inner(
     command: String,
     timeout_secs: Option<u64>,
     seren_api_key: Option<&str>,
+    progress: Option<mpsc::Sender<StreamChunk>>,
 ) -> Result<CommandResult, String> {
     if command.trim().is_empty() {
         return Err("Command must not be empty".to_string());
@@ -182,7 +265,7 @@ async fn execute_shell_command_inner(
         .unwrap_or(DEFAULT_TIMEOUT_SECS)
         .min(MAX_TIMEOUT_SECS);
 
-    let result = spawn_one_shot(&command, secs, seren_api_key).await?;
+    let result = spawn_one_shot(&command, secs, seren_api_key, progress.clone()).await?;
 
     // GH #1908: on Windows, when the user has no real Python on PATH but the
     // App Execution Alias for Python is still enabled, `python …` is routed
@@ -204,14 +287,13 @@ async fn execute_shell_command_inner(
     {
         if looks_like_windows_apps_python_stub(&result.stderr) {
             if let Some(retry_command) = translate_python_to_py_launcher(&command) {
-                log::info!(
-                    "[Shell] WindowsApps Python stub detected; retrying via `py` launcher"
-                );
-                return spawn_one_shot(&retry_command, secs, seren_api_key).await;
+                log::info!("[Shell] WindowsApps Python stub detected; retrying via `py` launcher");
+                return spawn_one_shot(&retry_command, secs, seren_api_key, progress).await;
             }
         }
     }
 
+    let _ = progress;
     Ok(result)
 }
 
@@ -351,6 +433,7 @@ async fn spawn_one_shot(
     command: &str,
     secs: u64,
     seren_api_key: Option<&str>,
+    progress: Option<mpsc::Sender<StreamChunk>>,
 ) -> Result<CommandResult, String> {
     let timeout = Duration::from_secs(secs);
 
@@ -426,29 +509,132 @@ async fn spawn_one_shot(
         &command[..command.len().min(500)]
     );
 
-    let child = cmd
+    let mut child = cmd
         .spawn()
         .map_err(|e| format!("Failed to spawn command: {}", e))?;
 
-    match tokio::time::timeout(timeout, child.wait_with_output()).await {
-        Ok(Ok(output)) => {
-            let stdout = truncate_output(String::from_utf8_lossy(&output.stdout).to_string());
-            let stderr = truncate_output(String::from_utf8_lossy(&output.stderr).to_string());
-            Ok(CommandResult {
-                stdout,
-                stderr,
-                exit_code: output.status.code(),
-                timed_out: false,
-            })
+    // No progress sink: keep the buffered fast path. Every existing caller
+    // (Tauri command, skill scripts, non-streaming tool execution) hits
+    // this branch and behaves bit-for-bit as before.
+    let Some(progress) = progress else {
+        return match tokio::time::timeout(timeout, child.wait_with_output()).await {
+            Ok(Ok(output)) => {
+                let stdout = truncate_output(String::from_utf8_lossy(&output.stdout).to_string());
+                let stderr = truncate_output(String::from_utf8_lossy(&output.stderr).to_string());
+                Ok(CommandResult {
+                    stdout,
+                    stderr,
+                    exit_code: output.status.code(),
+                    timed_out: false,
+                })
+            }
+            Ok(Err(e)) => Err(format!("Command execution failed: {}", e)),
+            Err(_) => Ok(CommandResult {
+                stdout: String::new(),
+                stderr: format!("Command timed out after {} seconds", secs),
+                exit_code: None,
+                timed_out: true,
+            }),
+        };
+    };
+
+    // Streaming path: read stdout and stderr line by line, forward each
+    // line through `progress` for the LIVE Tail pane (#2100), and keep
+    // accumulating the full text for the final ToolResult.
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to capture stderr".to_string())?;
+
+    let stdout_tx = progress.clone();
+    let stdout_task = tokio::spawn(async move {
+        let mut acc = String::new();
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line).await {
+                Ok(0) => break,
+                Ok(_) => {
+                    acc.push_str(&line);
+                    // try_send drops the chunk if the receiver is full or
+                    // gone — we'd rather miss a UI tick than block the
+                    // tool's stdout pipe and stall the child process.
+                    let _ = stdout_tx.try_send(StreamChunk {
+                        text: line.clone(),
+                        is_stderr: false,
+                    });
+                }
+                Err(_) => break,
+            }
         }
-        Ok(Err(e)) => Err(format!("Command execution failed: {}", e)),
-        Err(_) => Ok(CommandResult {
-            stdout: String::new(),
-            stderr: format!("Command timed out after {} seconds", secs),
-            exit_code: None,
-            timed_out: true,
-        }),
+        acc
+    });
+
+    let stderr_tx = progress;
+    let stderr_task = tokio::spawn(async move {
+        let mut acc = String::new();
+        let mut reader = BufReader::new(stderr);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line).await {
+                Ok(0) => break,
+                Ok(_) => {
+                    acc.push_str(&line);
+                    let _ = stderr_tx.try_send(StreamChunk {
+                        text: line.clone(),
+                        is_stderr: true,
+                    });
+                }
+                Err(_) => break,
+            }
+        }
+        acc
+    });
+
+    let wait_result = tokio::time::timeout(timeout, child.wait()).await;
+
+    // Whether we timed out or finished cleanly, both reader tasks have to
+    // run to EOF before we can return the accumulated output. On timeout
+    // the kill below closes the pipes, which gives the readers their EOF.
+    let timed_out = wait_result.is_err();
+    let exit_code = match &wait_result {
+        Ok(Ok(status)) => status.code(),
+        Ok(Err(_)) | Err(_) => None,
+    };
+    if timed_out {
+        let _ = child.kill().await;
     }
+
+    let stdout_text = stdout_task.await.unwrap_or_default();
+    let stderr_text = stderr_task.await.unwrap_or_default();
+
+    if let Ok(Err(e)) = wait_result {
+        return Err(format!("Command execution failed: {}", e));
+    }
+
+    let stderr_final = if timed_out {
+        let mut s = format!("Command timed out after {} seconds", secs);
+        if !stderr_text.is_empty() {
+            s.push('\n');
+            s.push_str(&stderr_text);
+        }
+        s
+    } else {
+        stderr_text
+    };
+
+    Ok(CommandResult {
+        stdout: truncate_output(stdout_text),
+        stderr: truncate_output(stderr_final),
+        exit_code,
+        timed_out,
+    })
 }
 
 fn read_stored_seren_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<Option<String>, String> {
@@ -802,5 +988,68 @@ mod tests {
             validate_skill_script_cwd("prophet-arb-bot", other_dir.to_string_lossy().as_ref())
                 .expect_err("wrong skill cwd should fail closed");
         assert!(err.contains("runtime directory"));
+    }
+
+    /// Critical-path test for #2100: the streaming shell path must forward
+    /// each stdout line through the progress channel AS it arrives AND
+    /// still return the full accumulated stdout in `CommandResult`. If
+    /// either side regresses the LIVE pane goes dark or the model loses
+    /// the tool result. The test runs three `echo`s separated by `sleep`
+    /// so the lines genuinely cross the pipe one at a time.
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn streaming_path_forwards_chunks_and_buffers_final_result() {
+        let (tx, mut rx) = mpsc::channel::<StreamChunk>(32);
+
+        let result = execute_shell_command_inner(
+            "echo line-one; sleep 0.05; echo line-two; sleep 0.05; echo line-three".to_string(),
+            Some(5),
+            None,
+            Some(tx),
+        )
+        .await
+        .expect("streaming command succeeds");
+
+        let mut chunks = Vec::new();
+        while let Some(chunk) = rx.recv().await {
+            chunks.push(chunk);
+        }
+
+        let stdout_lines: Vec<&str> = chunks
+            .iter()
+            .filter(|c| !c.is_stderr)
+            .map(|c| c.text.trim_end_matches('\n'))
+            .collect();
+        assert_eq!(
+            stdout_lines,
+            vec!["line-one", "line-two", "line-three"],
+            "streaming progress must emit one chunk per stdout line, in order"
+        );
+
+        assert_eq!(result.exit_code, Some(0));
+        assert_eq!(
+            result.stdout, "line-one\nline-two\nline-three\n",
+            "final CommandResult.stdout must match the joined chunks so the model still sees the complete tool output"
+        );
+        assert!(!result.timed_out);
+    }
+
+    /// Critical-path regression for #2100: the non-streaming path (every
+    /// existing caller — the Tauri command, skill scripts, the chat
+    /// frontend tool when not opting into streaming) must keep returning
+    /// identical buffered output. Guards the `progress: None` branch in
+    /// `spawn_one_shot` from being broken by future refactors.
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn non_streaming_path_unchanged_buffered_output() {
+        let result =
+            execute_shell_command_inner("echo alpha; echo beta".to_string(), Some(5), None, None)
+                .await
+                .expect("buffered command succeeds");
+
+        assert_eq!(result.exit_code, Some(0));
+        assert_eq!(result.stdout, "alpha\nbeta\n");
+        assert_eq!(result.stderr, "");
+        assert!(!result.timed_out);
     }
 }

--- a/src/components/chat/ToolCallCard.tsx
+++ b/src/components/chat/ToolCallCard.tsx
@@ -127,10 +127,12 @@ export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
   // Effective open state: parent's tail force-open OR user's local toggle.
   const isOpen = () => props.forceExpanded || isExpanded();
 
-  // Inner-card auto-scroll for Tail mode. We pin the parameters and result
-  // containers (the two scrollable surfaces inside the card) so streaming
-  // updates stay at the bottom — without ever touching the outer chat scroll.
+  // Inner-card auto-scroll for Tail mode. We pin the parameters, the live
+  // stdout/stderr pane, and the result container (the scrollable surfaces
+  // inside the card) so streaming updates stay at the bottom — without
+  // ever touching the outer chat scroll.
   let paramsRef: HTMLDivElement | undefined;
+  let liveRef: HTMLDivElement | undefined;
   let resultRef: HTMLDivElement | undefined;
 
   createEffect(() => {
@@ -138,9 +140,44 @@ export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
     // Read reactive deps so this effect refires on streaming updates.
     void props.toolCall.parameters;
     void props.toolCall.result;
+    void props.toolCall.partialResult;
     if (paramsRef) paramsRef.scrollTop = paramsRef.scrollHeight;
+    if (liveRef) liveRef.scrollTop = liveRef.scrollHeight;
     if (resultRef) resultRef.scrollTop = resultRef.scrollHeight;
   });
+
+  const isToolRunning = (): boolean => {
+    const status = props.toolCall.status.toLowerCase();
+    return status.includes("running") || status.includes("progress");
+  };
+
+  const hasLivePartial = (): boolean => {
+    const partial = props.toolCall.partialResult;
+    return Boolean(partial && partial.length > 0 && isToolRunning());
+  };
+
+  const partialByteCount = (): number => {
+    const partial = props.toolCall.partialResult;
+    if (!partial) return 0;
+    return new TextEncoder().encode(partial).length;
+  };
+
+  const partialLineCount = (): number => {
+    const partial = props.toolCall.partialResult;
+    if (!partial) return 0;
+    let n = 0;
+    for (let i = 0; i < partial.length; i++) {
+      if (partial.charCodeAt(i) === 10) n++;
+    }
+    if (!partial.endsWith("\n")) n++;
+    return n;
+  };
+
+  const formatBytes = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
 
   const resultIsListing = () => {
     const result = props.toolCall.result;
@@ -452,6 +489,36 @@ export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
                     </div>
                   ),
                 )}
+              </div>
+            </div>
+          </Show>
+
+          {/* Live stdout / stderr (#2100) — only while a streaming tool
+              is still running. Replaced by the Result pane once the
+              final content lands and partialResult is cleared. */}
+          <Show when={hasLivePartial()}>
+            <div class="mb-3">
+              <div class="flex items-center justify-between mb-1">
+                <div class="flex items-center gap-2">
+                  <span class="text-muted-foreground/70 font-medium">
+                    stdout
+                  </span>
+                  <span class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-pink-500/15 border border-pink-500/40 text-pink-300">
+                    <span class="w-1.5 h-1.5 rounded-full bg-pink-400 animate-pulse" />
+                    Live
+                  </span>
+                </div>
+                <span class="text-[10px] tabular-nums text-muted-foreground/70 font-mono">
+                  {formatBytes(partialByteCount())} · {partialLineCount()}{" "}
+                  {partialLineCount() === 1 ? "line" : "lines"}
+                </span>
+              </div>
+              <div
+                ref={liveRef}
+                class="bg-background border border-pink-500/30 rounded p-2 font-mono text-foreground/90 max-h-60 overflow-auto whitespace-pre-wrap"
+              >
+                {props.toolCall.partialResult}
+                <span class="inline-block w-1.5 h-3 ml-0.5 align-[-1px] bg-pink-400 animate-pulse" />
               </div>
             </div>
           </Show>

--- a/src/components/chat/ToolCallGroup.tsx
+++ b/src/components/chat/ToolCallGroup.tsx
@@ -2,12 +2,14 @@
 // ABOUTME: Reduces clutter by showing "searched 5 files, ran 3 commands" instead of 20+ individual cards.
 
 import type { Component } from "solid-js";
-import { For, Show } from "solid-js";
+import { createEffect, For, Show } from "solid-js";
 import type { ToolCallEvent } from "@/services/providers";
 import {
   getToolCallGroupState,
+  markToolCallTailed,
   setToolCallGroupExpanded,
   setToolCallGroupTailing,
+  wasToolCallTailed,
 } from "@/stores/tool-call-groups.store";
 import { ToolCallCard } from "./ToolCallCard";
 
@@ -127,6 +129,23 @@ export const ToolCallGroup: Component<ToolCallGroupProps> = (props) => {
   const categories = () => categorizeToolCalls(props.toolCalls);
   const summary = () => buildSummary(categories());
   const hasRunning = () => props.toolCalls.some(isRunning);
+
+  // Sticky-expand (#2100): record each tool call that Tail force-expands
+  // while it is running, so the card stays open through completion instead
+  // of snapping shut the instant the result lands.
+  createEffect(() => {
+    if (!isTailing()) return;
+    for (const tc of props.toolCalls) {
+      if (isRunning(tc)) {
+        markToolCallTailed(props.groupId, tc.toolCallId);
+      }
+    }
+  });
+
+  const shouldForceOpen = (tc: ToolCallEvent): boolean => {
+    if (!isTailing()) return false;
+    return isRunning(tc) || wasToolCallTailed(props.groupId, tc.toolCallId);
+  };
 
   return (
     <div class="my-2 mx-5 bg-surface-0 border border-surface-3 rounded-lg overflow-hidden">
@@ -251,7 +270,7 @@ export const ToolCallGroup: Component<ToolCallGroupProps> = (props) => {
             {(toolCall) => (
               <ToolCallCard
                 toolCall={toolCall}
-                forceExpanded={isTailing() && isRunning(toolCall)}
+                forceExpanded={shouldForceOpen(toolCall)}
                 tail={isTailing() && isRunning(toolCall)}
               />
             )}

--- a/src/lib/group-tool-calls.ts
+++ b/src/lib/group-tool-calls.ts
@@ -40,6 +40,7 @@ export function toToolCallEvent(data: ToolCallData): ToolCallEvent {
     parameters: params,
     result: data.isError ? undefined : data.result,
     error: data.isError ? data.result : undefined,
+    partialResult: data.partialResult,
   };
 }
 

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -11,6 +11,7 @@ import {
   callSerenTool,
   type PaymentProxyInfo,
 } from "@/services/mcp-gateway";
+import { startShellProgressListener } from "@/services/shell-progress";
 import { x402Service } from "@/services/x402";
 import { getApprovalRequirement, requiresApproval } from "./approval-config";
 import { parseGatewayToolName, parseMcpToolName } from "./definitions";
@@ -380,7 +381,8 @@ export async function executeTool(toolCall: ToolCall): Promise<ToolResult> {
           command: string;
           timeoutSecs: number;
           injectSerenCredentials?: boolean;
-        } = { command, timeoutSecs };
+          toolCallId: string;
+        } = { command, timeoutSecs, toolCallId: toolCall.id };
         if (typeof args.inject_seren_credentials === "boolean") {
           invokeArgs.injectSerenCredentials = args.inject_seren_credentials;
         }
@@ -394,12 +396,18 @@ export async function executeTool(toolCall: ToolCall): Promise<ToolResult> {
           };
         }
 
+        // Backs the Tail / LIVE pane (#2100). Idempotent — first call
+        // attaches the global subscription, subsequent ones await zero
+        // work. Awaited so a chunk emitted before the bridge is up
+        // doesn't get dropped.
+        await startShellProgressListener();
+
         const cmdResult = await invoke<{
           stdout: string;
           stderr: string;
           exit_code: number | null;
           timed_out: boolean;
-        }>("execute_shell_command", invokeArgs);
+        }>("execute_shell_command_streaming", invokeArgs);
 
         if (cmdResult.timed_out) {
           result = `Command timed out after ${timeoutSecs} seconds.\nstderr: ${cmdResult.stderr}`;

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -506,6 +506,10 @@ function handleToolResult(
           status: newStatus,
           result: event.content,
           isError: event.is_error,
+          // The streamed partial buffer is superseded by the final
+          // result content; drop it so the UI swaps to the result pane
+          // and we don't keep two copies of the output around (#2100).
+          partialResult: undefined,
         },
       },
       conversationId,

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -96,6 +96,14 @@ export interface ToolCallEvent {
   parameters?: Record<string, unknown>;
   result?: string;
   error?: string;
+  /**
+   * Live stdout/stderr accumulated while a streaming tool is running (#2100).
+   * Populated by the `shell://progress` listener for the in-process Bash
+   * `execute_command` tool. Cleared when the final `result` lands. UI
+   * surfaces it via the LIVE pane in `ToolCallCard` while `status` is
+   * "running"; for tools that don't stream it stays undefined.
+   */
+  partialResult?: string;
 }
 
 export interface ToolResultEvent {

--- a/src/services/shell-progress.ts
+++ b/src/services/shell-progress.ts
@@ -1,0 +1,49 @@
+// ABOUTME: Bridges `shell://progress` Tauri events into the conversation store.
+// ABOUTME: Backs the Tail / LIVE pane for the in-process Bash tool (#2100).
+
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { conversationStore } from "@/stores/conversation.store";
+
+interface ShellProgressPayload {
+  toolCallId: string;
+  chunk: string;
+  isStderr: boolean;
+}
+
+let unlisten: UnlistenFn | null = null;
+let starting: Promise<void> | null = null;
+
+/**
+ * Subscribe to streaming Bash output and append each chunk to the matching
+ * tool_call message's `toolCall.partialResult`. Idempotent — repeat calls
+ * are no-ops while the subscription is already active. Awaitable so callers
+ * can defer to the listener being attached before triggering a streaming
+ * command.
+ */
+export async function startShellProgressListener(): Promise<void> {
+  if (unlisten) return;
+  if (starting) return starting;
+  starting = (async () => {
+    try {
+      unlisten = await listen<ShellProgressPayload>(
+        "shell://progress",
+        (event) => {
+          const { toolCallId, chunk } = event.payload;
+          if (!toolCallId || !chunk) return;
+          conversationStore.appendToolCallPartial(toolCallId, chunk);
+        },
+      );
+    } finally {
+      starting = null;
+    }
+  })();
+  return starting;
+}
+
+/** Tear down the subscription. Test/teardown helper. */
+export async function stopShellProgressListener(): Promise<void> {
+  if (unlisten) {
+    unlisten();
+    unlisten = null;
+  }
+}

--- a/src/stores/conversation.store.ts
+++ b/src/stores/conversation.store.ts
@@ -123,6 +123,23 @@ function generateTitle(content: string): string {
   return `${lastSpace > 10 ? truncated.slice(0, lastSpace) : truncated}…`;
 }
 
+function findConversationIdForToolCall(toolCallId: string): string | null {
+  for (const [conversationId, messages] of Object.entries(state.messages)) {
+    if (
+      messages.some(
+        (msg) =>
+          msg.type === "tool_call" &&
+          msg.toolCall &&
+          (msg.toolCallId === toolCallId ||
+            msg.toolCall.toolCallId === toolCallId),
+      )
+    ) {
+      return conversationId;
+    }
+  }
+  return null;
+}
+
 export const conversationStore = {
   // === Getters ===
 
@@ -543,6 +560,43 @@ export const conversationStore = {
     setState("streamingContent", conversationId, "");
     setState("streamingThinking", conversationId, "");
     setState("streamingStalled", conversationId, false);
+  },
+
+  /**
+   * Append a stdout/stderr chunk to a running tool_call message's
+   * `toolCall.partialResult` (#2100). When a caller does not provide a
+   * conversation id, locate the loaded conversation that owns the
+   * toolCallId so live shell output keeps landing even if the user
+   * switches threads mid-command. Cleared when the final `tool_result`
+   * lands (see orchestrator.handleToolResult).
+   */
+  appendToolCallPartial(
+    toolCallId: string,
+    chunk: string,
+    conversationId?: string | null,
+  ) {
+    const targetConversationId =
+      conversationId ?? findConversationIdForToolCall(toolCallId);
+    if (!targetConversationId) return;
+    setState("messages", targetConversationId, (msgs = []) =>
+      msgs.map((msg) => {
+        if (
+          msg.type !== "tool_call" ||
+          !msg.toolCall ||
+          (msg.toolCallId !== toolCallId &&
+            msg.toolCall.toolCallId !== toolCallId)
+        ) {
+          return msg;
+        }
+        return {
+          ...msg,
+          toolCall: {
+            ...msg.toolCall,
+            partialResult: (msg.toolCall.partialResult ?? "") + chunk,
+          },
+        };
+      }),
+    );
   },
 
   // === Loading/error ===

--- a/src/stores/tool-call-groups.store.ts
+++ b/src/stores/tool-call-groups.store.ts
@@ -6,11 +6,19 @@ import { createStore, reconcile } from "solid-js/store";
 export interface ToolCallGroupState {
   expanded: boolean;
   tailing: boolean;
+  /**
+   * Tool call ids that Tail force-expanded while they were running (#2100).
+   * Read by the group renderer to keep finished cards open instead of
+   * snapping shut the instant the result lands. Cleared when the user
+   * toggles Tail off so a re-enable does not resurrect stale completions.
+   */
+  tailedToolCallIds: string[];
 }
 
 const DEFAULT_STATE: ToolCallGroupState = {
   expanded: false,
   tailing: false,
+  tailedToolCallIds: [],
 };
 
 interface StoreShape {
@@ -37,7 +45,38 @@ export function setToolCallGroupTailing(
   tailing: boolean,
 ): void {
   const prev = state.groups[groupId] ?? DEFAULT_STATE;
-  setState("groups", groupId, { ...prev, tailing });
+  setState("groups", groupId, {
+    ...prev,
+    tailing,
+    // Turning Tail off drops the sticky-expand memory so the next enable
+    // starts clean. We do NOT clear when toggling on — that would erase
+    // the very entries we want to keep visible.
+    tailedToolCallIds: tailing ? prev.tailedToolCallIds : [],
+  });
+}
+
+/**
+ * Mark a tool call as having been Tail-expanded during its run. Idempotent;
+ * a no-op if the id is already present. Called from a reactive effect in
+ * ToolCallGroup whenever a running card is rendered with forceExpanded=true.
+ */
+export function markToolCallTailed(groupId: string, toolCallId: string): void {
+  const prev = state.groups[groupId] ?? DEFAULT_STATE;
+  if (prev.tailedToolCallIds.includes(toolCallId)) return;
+  setState("groups", groupId, {
+    ...prev,
+    tailedToolCallIds: [...prev.tailedToolCallIds, toolCallId],
+  });
+}
+
+/** Reactive check: was this tool call expanded by Tail while it was running? */
+export function wasToolCallTailed(
+  groupId: string,
+  toolCallId: string,
+): boolean {
+  const group = state.groups[groupId];
+  if (!group) return false;
+  return group.tailedToolCallIds.includes(toolCallId);
 }
 
 /** Test/teardown helper. Clears the entire group registry. */

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -95,6 +95,12 @@ export interface ToolCallData {
   arguments?: string;
   parameters?: Record<string, unknown>;
   result?: string;
+  /**
+   * Live stdout/stderr buffer while a streaming tool is running (#2100).
+   * Populated by the `shell://progress` listener for `execute_command`.
+   * Cleared once `result` lands. Mirrors `ToolCallEvent.partialResult`.
+   */
+  partialResult?: string;
   isError?: boolean;
 }
 

--- a/tests/unit/conversation-store.test.ts
+++ b/tests/unit/conversation-store.test.ts
@@ -202,6 +202,37 @@ describe("conversationStore", () => {
       expect(conversationStore.streamingContent).toBe("");
       expect(conversationStore.streamingThinking).toBe("");
     });
+
+    it("appends tool-call partial output by tool id even when another conversation is active (#2100)", async () => {
+      const source = await conversationStore.createConversation("stream source");
+      conversationStore.addMessage(
+        makeMessage({
+          id: "tool-msg-2100",
+          type: "tool_call",
+          role: "assistant",
+          content: "Bash",
+          status: "streaming",
+          toolCallId: "tc-stream-2100",
+          toolCall: {
+            toolCallId: "tc-stream-2100",
+            title: "Bash",
+            kind: "bash",
+            status: "running",
+          },
+        }),
+        source.id,
+      );
+
+      const other = await conversationStore.createConversation("active other");
+      expect(conversationStore.activeConversationId).toBe(other.id);
+
+      conversationStore.appendToolCallPartial("tc-stream-2100", "line one\n");
+      conversationStore.appendToolCallPartial("tc-stream-2100", "line two\n");
+
+      const [toolMessage] = conversationStore.getMessagesFor(source.id);
+      expect(toolMessage.toolCall?.partialResult).toBe("line one\nline two\n");
+      expect(conversationStore.getMessagesFor(other.id)).toEqual([]);
+    });
   });
 
   describe("loading and error state", () => {

--- a/tests/unit/group-tool-calls.test.ts
+++ b/tests/unit/group-tool-calls.test.ts
@@ -118,4 +118,23 @@ describe("groupConsecutiveToolCalls", () => {
       expect(out[3].toolCalls).toHaveLength(3);
     }
   });
+
+  it("preserves partialResult on grouped tool calls so Tail can render live output (#2100)", () => {
+    const a = toolCall("a", "for i in 1 2 3; do echo $i; sleep 1; done");
+    if (a.toolCall) {
+      a.toolCall.status = "running";
+      a.toolCall.partialResult = "1\n2\n";
+    }
+
+    const out = groupConsecutiveToolCalls([
+      a,
+      toolCall("b", "pwd"),
+      toolCall("c", "whoami"),
+    ]);
+
+    expect(out[0].type).toBe("tool_group");
+    if (out[0].type === "tool_group") {
+      expect(out[0].toolCalls[0].partialResult).toBe("1\n2\n");
+    }
+  });
 });

--- a/tests/unit/tool-call-groups-store.test.ts
+++ b/tests/unit/tool-call-groups-store.test.ts
@@ -1,13 +1,17 @@
-// ABOUTME: Critical regression test for the tool-call group state store (#1748).
-// ABOUTME: Proves expand/Tail state survives the regroup remount that caused the bug.
+// ABOUTME: Critical regression tests for the tool-call group state store.
+// ABOUTME: Covers regroup-remount survival (#1748) and Tail sticky-expand (#2100).
 
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   _resetToolCallGroupsForTest,
   getToolCallGroupState,
+  markToolCallTailed,
   setToolCallGroupExpanded,
   setToolCallGroupTailing,
+  wasToolCallTailed,
 } from "@/stores/tool-call-groups.store";
+
+const EMPTY_TAILED: string[] = [];
 
 describe("tool-call-groups store", () => {
   beforeEach(() => {
@@ -16,7 +20,11 @@ describe("tool-call-groups store", () => {
 
   it("returns a default state for an unknown group without writing it", () => {
     const state = getToolCallGroupState("never-written");
-    expect(state).toEqual({ expanded: false, tailing: false });
+    expect(state).toEqual({
+      expanded: false,
+      tailing: false,
+      tailedToolCallIds: EMPTY_TAILED,
+    });
   });
 
   it("persists expanded across reads — proxies the regroup remount that closed the chevron pre-#1748", () => {
@@ -35,26 +43,64 @@ describe("tool-call-groups store", () => {
     setToolCallGroupTailing("group-1", true);
 
     let s = getToolCallGroupState("group-1");
-    expect(s).toEqual({ expanded: true, tailing: true });
+    expect(s.expanded).toBe(true);
+    expect(s.tailing).toBe(true);
 
     // Collapsing the group must not turn off Tail (spec #2: Tail persists
     // for the group's lifetime; clicking the chevron does not override it).
     setToolCallGroupExpanded("group-1", false);
     s = getToolCallGroupState("group-1");
-    expect(s).toEqual({ expanded: false, tailing: true });
+    expect(s.expanded).toBe(false);
+    expect(s.tailing).toBe(true);
   });
 
   it("isolates state across distinct group ids", () => {
     setToolCallGroupExpanded("group-1", true);
     setToolCallGroupTailing("group-2", true);
 
-    expect(getToolCallGroupState("group-1")).toEqual({
-      expanded: true,
-      tailing: false,
-    });
-    expect(getToolCallGroupState("group-2")).toEqual({
-      expanded: false,
-      tailing: true,
-    });
+    expect(getToolCallGroupState("group-1").expanded).toBe(true);
+    expect(getToolCallGroupState("group-1").tailing).toBe(false);
+    expect(getToolCallGroupState("group-2").expanded).toBe(false);
+    expect(getToolCallGroupState("group-2").tailing).toBe(true);
+  });
+
+  // ===== Sticky-expand (#2100) =====
+  //
+  // The bug: Tail's forceExpanded predicate gated on `isRunning(toolCall)`,
+  // so cards snapped shut the instant a tool finished. The fix is to record
+  // each tool-call id that Tail force-expanded while running, and keep it
+  // open through completion. These tests guard the contract.
+
+  it("tracks tailed tool-call ids idempotently and scopes them per group", () => {
+    setToolCallGroupTailing("group-1", true);
+
+    expect(wasToolCallTailed("group-1", "tc-abc")).toBe(false);
+
+    markToolCallTailed("group-1", "tc-abc");
+    markToolCallTailed("group-1", "tc-abc");
+
+    expect(wasToolCallTailed("group-1", "tc-abc")).toBe(true);
+    expect(wasToolCallTailed("group-2", "tc-abc")).toBe(false);
+    expect(getToolCallGroupState("group-1").tailedToolCallIds).toEqual([
+      "tc-abc",
+    ]);
+  });
+
+  it("keeps sticky ids on redundant Tail enable and clears them when Tail turns off", () => {
+    setToolCallGroupTailing("group-1", true);
+    markToolCallTailed("group-1", "tc-abc");
+
+    setToolCallGroupTailing("group-1", true);
+    expect(wasToolCallTailed("group-1", "tc-abc")).toBe(true);
+
+    setToolCallGroupTailing("group-1", false);
+
+    const cleared = getToolCallGroupState("group-1");
+    expect(cleared.tailing).toBe(false);
+    expect(cleared.tailedToolCallIds).toEqual([]);
+
+    // Re-enable: must start clean, not surface previously-tailed ids.
+    setToolCallGroupTailing("group-1", true);
+    expect(wasToolCallTailed("group-1", "tc-abc")).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #2100

## Summary
- keep tool cards Tail-expanded through completion so final results do not snap shut
- stream Bash stdout/stderr through a Tauri shell progress event into grouped tool-call cards
- render a compact LIVE output pane with byte/line counters and preserve final buffered tool results

## Verification
- Focused frontend unit tests passed
- Rust shell streaming regression tests passed
- Vite production build passed
- GitHub CI passed: commit subjects, lint, frontend tests, Rust tests, and production-bundle E2E

## Notes
- Full TypeScript project check is currently blocked by existing unrelated PdfViewer/provider declaration errors.
- Biome check on touched TypeScript files exits 0 with existing optional-chain warnings.