### PR TITLE
fix(compaction): token-budgeted tail selection (#2104)

### DIFF
--- a/src/lib/compaction/window.ts
+++ b/src/lib/compaction/window.ts
@@ -1,0 +1,159 @@
+// ABOUTME: Token-budgeted compaction tail selection shared by chat and agent paths (#2104).
+// ABOUTME: Replaces fixed preserve counts so one oversized message can't overflow the model.
+
+/**
+ * One transcript message reduced to the fields the boundary selector needs.
+ * `tokens` is supplied by the caller (content-only today; tool/media-aware
+ * accounting lands in #2105 without changing this contract).
+ */
+export interface CompactionWindowItem {
+  /** Estimated token cost of this message. */
+  tokens: number;
+  /** Coarse role used for latest-user anchoring. */
+  role: "user" | "assistant" | "system" | "tool" | "other";
+  /**
+   * Group key for messages that must not be split across the compaction
+   * boundary (e.g. an assistant turn and the tool results it produced).
+   * Messages sharing a non-null key are kept together in the preserved tail.
+   */
+  groupId?: string | null;
+}
+
+export interface SelectCompactionWindowOptions {
+  /** Total model/agent context window in tokens. */
+  contextLimit: number;
+  /** Fraction of the window the preserved tail may occupy. Default 0.35. */
+  targetTailRatio?: number;
+  /** Tokens held back from the tail budget for the model response. Default 0. */
+  reservedResponseTokens?: number;
+  /** Never preserve fewer than this many tail messages when available. Default 2. */
+  minTailMessages?: number;
+  /** Absolute ceiling on preserved-tail tokens, regardless of ratio. */
+  maxTailTokens?: number;
+  /** Force the latest user message into the tail. Default true. */
+  anchorLatestUser?: boolean;
+}
+
+export interface CompactionWindow {
+  /** Preserved tail is `items.slice(cutIndex)`; compacted half is the prefix. */
+  cutIndex: number;
+  /** Number of preserved tail messages (`items.length - cutIndex`). */
+  preserveCount: number;
+  /** Estimated tokens in the preserved tail. */
+  tailTokens: number;
+  /** Token budget the tail was selected against. */
+  tailBudget: number;
+  /** True when the minimum tail alone exceeded the budget (soft ceiling hit). */
+  overBudget: boolean;
+}
+
+const DEFAULT_TARGET_TAIL_RATIO = 0.35;
+const DEFAULT_MIN_TAIL_MESSAGES = 2;
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, value));
+}
+
+/** Snap a cut backward so it never lands inside a tool/turn group. */
+function snapToGroupStart(items: CompactionWindowItem[], cut: number): number {
+  if (cut <= 0 || cut >= items.length) return cut;
+  const g = items[cut].groupId;
+  if (g == null) return cut;
+  let j = cut;
+  while (j > 0 && items[j - 1].groupId === g) j--;
+  return j;
+}
+
+function sumTokens(items: CompactionWindowItem[], fromIndex: number): number {
+  let total = 0;
+  for (let i = fromIndex; i < items.length; i++) total += items[i].tokens;
+  return total;
+}
+
+/**
+ * Choose the compaction boundary by token budget instead of a fixed message
+ * count. Walks backward from the newest message, preserving messages until the
+ * tail budget is hit, while (1) keeping at least `minTailMessages`, (2) never
+ * splitting a tool/turn group, and (3) anchoring the latest user message into
+ * the tail. The soft ceiling guarantees compaction still runs even when the
+ * last message alone exceeds the budget — it just flags `overBudget`.
+ */
+export function selectCompactionWindow(
+  items: CompactionWindowItem[],
+  options: SelectCompactionWindowOptions,
+): CompactionWindow {
+  const n = items.length;
+  const targetTailRatio = options.targetTailRatio ?? DEFAULT_TARGET_TAIL_RATIO;
+  const reserved = options.reservedResponseTokens ?? 0;
+  const anchorLatestUser = options.anchorLatestUser ?? true;
+  const minTail =
+    n === 0
+      ? 0
+      : clamp(options.minTailMessages ?? DEFAULT_MIN_TAIL_MESSAGES, 1, n);
+
+  const ratioBudget = Math.max(
+    0,
+    options.contextLimit * targetTailRatio - reserved,
+  );
+  const tailBudget = Math.min(
+    options.maxTailTokens ?? Number.POSITIVE_INFINITY,
+    ratioBudget,
+  );
+
+  if (n === 0) {
+    return {
+      cutIndex: 0,
+      preserveCount: 0,
+      tailTokens: 0,
+      tailBudget,
+      overBudget: false,
+    };
+  }
+
+  // Backward walk: force-include the minimum tail, then keep going while the
+  // running tail total stays within budget.
+  let cut = n;
+  let acc = 0;
+  for (let i = n - 1; i >= 0; i--) {
+    const countIfIncluded = n - i;
+    if (countIfIncluded <= minTail) {
+      acc += items[i].tokens;
+      cut = i;
+      continue;
+    }
+    if (acc + items[i].tokens <= tailBudget) {
+      acc += items[i].tokens;
+      cut = i;
+    } else {
+      break;
+    }
+  }
+
+  cut = snapToGroupStart(items, cut);
+
+  // Anchor the latest user message: it must be inside the preserved tail so
+  // the post-compaction model sees the active request verbatim.
+  if (anchorLatestUser) {
+    let lastUser = -1;
+    for (let i = n - 1; i >= 0; i--) {
+      if (items[i].role === "user") {
+        lastUser = i;
+        break;
+      }
+    }
+    if (lastUser >= 0 && cut > lastUser) {
+      cut = snapToGroupStart(items, lastUser);
+    }
+  }
+
+  const tailTokens = sumTokens(items, cut);
+  return {
+    cutIndex: cut,
+    preserveCount: n - cut,
+    tailTokens,
+    tailBudget,
+    // overBudget reports the soft-ceiling case: the tail we were forced to keep
+    // (min floor / latest-user anchor / whole group) costs more than the budget.
+    overBudget: tailTokens > tailBudget,
+  };
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -18,6 +18,10 @@ import {
   buildSummaryLineage,
   type SummaryLineage,
 } from "@/lib/compaction/summary";
+import {
+  type CompactionWindowItem,
+  selectCompactionWindow,
+} from "@/lib/compaction/window";
 import { runtimeHasCapability } from "@/lib/runtime";
 import { estimateTokens } from "@/lib/token-counter";
 import { getEnabledMcpServers, settingsStore } from "@/stores/settings.store";
@@ -79,13 +83,21 @@ const SESSION_READY_TIMEOUT_MS = 30_000;
 export const PREDICTIVE_COMPACT_THRESHOLD = 0.7;
 
 /**
- * Reactive compaction's last-ditch preserve count. When the configured
+ * Reactive compaction's last-ditch message-count guard. When the configured
  * `autoCompactPreserveMessages` leaves nothing to summarize (short session,
- * heavy per-message token cost), `compactAndRetry` retries with this count
- * — keeping only the most recent user/assistant pair so the session
- * actually shrinks below the model window. #2031.
+ * heavy per-message token cost), `compactAndRetry` retries with this lower
+ * guard so the token-budgeted window selector can run on the session at all.
+ * #2031.
  */
 const AGGRESSIVE_RETRY_PRESERVE_COUNT = 2;
+
+/**
+ * Tail budget used on the aggressive retry. A tighter fraction of the context
+ * window than the default so the post-compaction tail shrinks hard when an
+ * earlier compaction (or the configured count) still left the prompt too
+ * long. Replaces the old fixed retry preserve count with a token budget. #2104.
+ */
+const AGGRESSIVE_RETRY_TAIL_RATIO = 0.15;
 
 /**
  * Global cap = 1 simultaneous predictive compaction across the whole app.
@@ -3788,7 +3800,7 @@ export const agentStore = {
      * events but invisible to the UI until `promoteStandbyAndDispatch`
      * promotes it on the next user submit. #1631.
      */
-    opts?: { mode?: "reactive" | "predictive" },
+    opts?: { mode?: "reactive" | "predictive"; tailRatio?: number },
   ): Promise<CompactAgentResult> {
     const mode = opts?.mode ?? "reactive";
     const session = state.sessions[sessionId];
@@ -3800,6 +3812,49 @@ export const agentStore = {
     if (messages.length <= preserveCount) {
       console.info(
         "[AgentStore] Not enough messages to compact (message count below preserve threshold)",
+      );
+      return { outcome: "skipped_nothing_to_compact" };
+    }
+
+    // Token-budgeted boundary instead of a fixed preserve count: walk back from
+    // the newest message by token cost so a single huge tool result or model
+    // response can't survive into the post-compaction tail and overflow the
+    // window again. Tool results are grouped into their user-led turn so a
+    // result is never split from the turn that produced it, and the latest
+    // user message is always anchored into the tail. #2104.
+    const compactContextLimit =
+      session.contextWindowSize > 0
+        ? session.contextWindowSize
+        : defaultContextWindowFor(
+            session.info.agentType,
+            session.currentModelId,
+          );
+    let compactTurn = 0;
+    const windowItems: CompactionWindowItem[] = messages.map((m) => {
+      if (m.type === "user") compactTurn++;
+      const toolTokens = m.toolCall?.result
+        ? estimateTokens(m.toolCall.result)
+        : 0;
+      const role =
+        m.type === "user" || m.type === "assistant" || m.type === "tool"
+          ? m.type
+          : "other";
+      return {
+        tokens: estimateTokens(m.content) + toolTokens,
+        role,
+        groupId: `t${compactTurn}`,
+      };
+    });
+    const tailWindow = selectCompactionWindow(windowItems, {
+      contextLimit: compactContextLimit,
+      minTailMessages: 2,
+      targetTailRatio: opts?.tailRatio,
+    });
+    const toCompact = messages.slice(0, tailWindow.cutIndex);
+    const toPreserve = messages.slice(tailWindow.cutIndex);
+    if (toCompact.length === 0) {
+      console.info(
+        "[AgentStore] Token budget preserves the whole tail — nothing to compact",
       );
       return { outcome: "skipped_nothing_to_compact" };
     }
@@ -3825,9 +3880,7 @@ export const agentStore = {
     const conversationId = session.conversationId;
 
     try {
-      // Split messages into those to summarize and those to keep
-      const toCompact = messages.slice(0, messages.length - preserveCount);
-      const toPreserve = messages.slice(-preserveCount);
+      // toCompact / toPreserve were selected by token budget above (#2104).
 
       // Generate a structured summary via Gateway API (not via the agent —
       // its context is what's overloaded). Uses a hard-capped schema to keep
@@ -4326,18 +4379,19 @@ export const agentStore = {
 
       // Reactive compaction must recover from short-but-token-heavy sessions
       // — a handful of tool turns can carry 200K+ tokens. When the configured
-      // preserve count leaves nothing to summarize, retry with a minimal
-      // preserve count (last user/assistant pair) so the session actually
-      // shrinks. Only give up when even that has nothing to act on. #2031.
+      // count guard leaves nothing to summarize, retry with a lower guard AND
+      // a tighter tail budget so the token window shrinks the session below the
+      // model window. Only give up when even that has nothing to act on. #2031/#2104.
       if (result.outcome === "skipped_nothing_to_compact") {
         const remaining = state.sessions[sessionId]?.messages.length ?? 0;
         if (remaining > AGGRESSIVE_RETRY_PRESERVE_COUNT) {
           console.info(
-            `[AgentStore] compactAndRetry: configured preserve count left nothing to compact (${remaining} messages); retrying with preserveCount=${AGGRESSIVE_RETRY_PRESERVE_COUNT}`,
+            `[AgentStore] compactAndRetry: configured count left nothing to compact (${remaining} messages); retrying with a tighter tail budget (ratio=${AGGRESSIVE_RETRY_TAIL_RATIO})`,
           );
           result = await this.compactAgentConversation(
             sessionId,
             AGGRESSIVE_RETRY_PRESERVE_COUNT,
+            { tailRatio: AGGRESSIVE_RETRY_TAIL_RATIO },
           );
         }
       }

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -7,6 +7,10 @@ import {
   buildSummaryLineage,
   type SummaryLineage,
 } from "@/lib/compaction/summary";
+import {
+  type CompactionWindowItem,
+  selectCompactionWindow,
+} from "@/lib/compaction/window";
 import { PROVIDER_CONFIGS, type ProviderId } from "@/lib/providers/types";
 import {
   archiveConversation as archiveConversationDb,
@@ -22,6 +26,7 @@ import {
 } from "@/lib/tauri-bridge";
 import {
   estimateConversationTokens,
+  estimateMessageTokens,
   getModelContextLimit,
   shouldTriggerCompaction,
 } from "@/lib/token-counter";
@@ -647,16 +652,42 @@ export const chatStore = {
     setState("isCompacting", true);
 
     try {
-      // Split messages into those to compact and those to preserve
-      const toCompact = messages.slice(0, messages.length - preserveCount);
-      const toPreserve = messages.slice(-preserveCount);
-
       // Use the active conversation's bound provider/model to compact so
       // the thread's selected runtime — not a global default — produces
       // the summary.
       const activeConvo = state.conversations.find(
         (c) => c.id === conversationId,
       );
+
+      // Token-budgeted boundary instead of a fixed preserve count: keep the
+      // recent tail by token budget so one oversized message can't overflow
+      // the model after compaction, and lightweight chats keep more of their
+      // tail when the budget allows. The latest user message is always
+      // anchored into the preserved tail. #2104.
+      const items: CompactionWindowItem[] = messages.map((m) => ({
+        tokens: estimateMessageTokens(m),
+        role:
+          m.role === "user" || m.role === "assistant" || m.role === "system"
+            ? m.role
+            : "other",
+        groupId: null,
+      }));
+      const tailWindow = selectCompactionWindow(items, {
+        contextLimit: getModelContextLimit(
+          activeConvo?.selectedModel ?? this.selectedModel,
+        ),
+        minTailMessages: 2,
+      });
+      const toCompact = messages.slice(0, tailWindow.cutIndex);
+      const toPreserve = messages.slice(tailWindow.cutIndex);
+      if (toCompact.length === 0) {
+        // The whole tail fits the budget — usage is low enough that there is
+        // nothing worth compacting this pass.
+        console.log(
+          "[chatStore] Token budget preserves the whole tail — nothing to compact",
+        );
+        return;
+      }
 
       // Carry the prior compacted summary forward so a second (or later)
       // compaction iteratively updates it instead of rebuilding from only

--- a/tests/unit/compaction-scrollback.test.ts
+++ b/tests/unit/compaction-scrollback.test.ts
@@ -38,8 +38,13 @@ vi.mock("@/services/chat", async () => {
   };
 });
 
-import { chatStore } from "@/stores/chat.store";
 import type { Message } from "@/services/chat";
+import { chatStore } from "@/stores/chat.store";
+
+// Large enough that one message alone exceeds the default-model tail budget
+// (100k window × 0.35 ≈ 35k tokens ≈ 140k chars), forcing the token-budgeted
+// selector to push it into the compacted half. #2104.
+const BIG = "x".repeat(150_000);
 
 function makeMessage(
   id: string,
@@ -61,21 +66,22 @@ describe("chat.store compaction #1616 — preCompactionMessages are preserved", 
     vi.clearAllMocks();
   });
 
-  it("stores pre-compaction user+assistant messages on the summary", async () => {
+  it("stores compacted user+assistant messages on the summary and filters system", async () => {
     const convo = await chatStore.createConversation("Compaction test");
     const base = 1_700_000_000_000;
+    // a2 is oversized, so the token-budgeted boundary lands right after it:
+    // u1,a1,s1,u2,a2 are compacted and u3,a3 are preserved (#2104).
     const msgs: Message[] = [
       makeMessage("u1", "user", "How do I deploy?", base),
       makeMessage("a1", "assistant", "Use the release workflow.", base + 1),
       makeMessage("s1", "system", "system note", base + 2),
       makeMessage("u2", "user", "What about rollbacks?", base + 3),
-      makeMessage("a2", "assistant", "Cherry-pick the fix.", base + 4),
+      makeMessage("a2", "assistant", BIG, base + 4),
       makeMessage("u3", "user", "Latest?", base + 5),
       makeMessage("a3", "assistant", "On main.", base + 6),
     ];
     chatStore.setMessages(convo.id, msgs);
 
-    // Preserve 2 most recent — compact the other 5 (3 user, 2 assistant, 1 system).
     await chatStore.compactConversation(2);
 
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
@@ -85,8 +91,8 @@ describe("chat.store compaction #1616 — preCompactionMessages are preserved", 
     expect(summary?.originalMessageCount).toBe(5);
 
     // Pre-compaction scrollback contains every user+assistant message that was
-    // compacted, in original order, with content intact. The system message is
-    // intentionally filtered out — we only preserve conversational text.
+    // compacted, in original order. The system message is intentionally
+    // filtered out — we only preserve conversational text.
     const preserved = summary?.preCompactionMessages ?? [];
     expect(preserved.map((m) => m.id)).toEqual(["u1", "a1", "u2", "a2"]);
     expect(preserved.map((m) => m.type)).toEqual([
@@ -96,9 +102,8 @@ describe("chat.store compaction #1616 — preCompactionMessages are preserved", 
       "assistant",
     ]);
     expect(preserved[0].content).toBe("How do I deploy?");
-    expect(preserved[3].content).toBe("Cherry-pick the fix.");
 
-    // The 2 preserved messages remain on the conversation.
+    // The latest user message is anchored into the preserved tail (#2104).
     expect(chatStore.messages).toHaveLength(2);
     expect(chatStore.messages[0].id).toBe("u3");
     expect(chatStore.messages[1].id).toBe("a3");
@@ -108,34 +113,35 @@ describe("chat.store compaction #1616 — preCompactionMessages are preserved", 
     const convo = await chatStore.createConversation("Second compaction");
     const base = 1_700_000_000_000;
 
-    // Round 1 — 4 messages, preserve 1.
+    // Round 1 — a1 is oversized, so u1,a1 are compacted and u2,a2 preserved.
     chatStore.setMessages(convo.id, [
       makeMessage("u1", "user", "old q", base),
-      makeMessage("a1", "assistant", "old a", base + 1),
+      makeMessage("a1", "assistant", BIG, base + 1),
       makeMessage("u2", "user", "old q2", base + 2),
       makeMessage("a2", "assistant", "old a2", base + 3),
     ]);
     await chatStore.compactConversation(1);
 
     const firstRound = chatStore.activeConversation?.compactedSummary;
-    expect(firstRound?.preCompactionMessages?.map((m) => m.id)).toEqual([
-      "u1",
-      "a1",
-      "u2",
-    ]);
+    const firstIds = firstRound?.preCompactionMessages?.map((m) => m.id) ?? [];
+    expect(firstIds).toContain("u1");
+    expect(firstIds).toContain("a1");
 
-    // Round 2 — append 3 more, compact again preserving 1.
+    // Round 2 — append a fresh batch; a4 is oversized, so u2,a2,u3,a3 compact
+    // and a4,u5 stay anchored in the tail.
     chatStore.setMessages(convo.id, [
       ...(chatStore.messages ?? []),
       makeMessage("u3", "user", "mid q", base + 10),
       makeMessage("a3", "assistant", "mid a", base + 11),
-      makeMessage("u4", "user", "new q", base + 12),
+      makeMessage("u4", "user", "more q", base + 12),
+      makeMessage("a4", "assistant", BIG, base + 13),
+      makeMessage("u5", "user", "new q", base + 14),
     ]);
     await chatStore.compactConversation(1);
 
     const secondRound = chatStore.activeConversation?.compactedSummary;
     // Prior compactedSummary is overwritten — only the most-recent batch is
-    // retained, so memory does not accumulate across compactions.
+    // retained, so scrollback memory does not accumulate across compactions.
     const ids = secondRound?.preCompactionMessages?.map((m) => m.id) ?? [];
     expect(ids).not.toContain("u1");
     expect(ids).not.toContain("a1");

--- a/tests/unit/compaction-window-wiring.test.ts
+++ b/tests/unit/compaction-window-wiring.test.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Locks the #2104 token-budgeted boundary wiring in both stores.
+// ABOUTME: Predictive, reactive, and retry compaction must all use the shared selector.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const chatStore = readFileSync(resolve("src/stores/chat.store.ts"), "utf-8");
+const agentStore = readFileSync(resolve("src/stores/agent.store.ts"), "utf-8");
+
+describe("#2104 chat compaction uses the token-budgeted selector", () => {
+  it("splits on the selector's cut index, not a fixed preserve count", () => {
+    expect(chatStore).toContain("selectCompactionWindow(");
+    expect(chatStore).toContain("messages.slice(0, tailWindow.cutIndex)");
+    expect(chatStore).not.toContain(
+      "messages.slice(0, messages.length - preserveCount)",
+    );
+  });
+});
+
+describe("#2104 agent compaction uses the token-budgeted selector", () => {
+  it("splits on the selector's cut index for predictive and reactive paths", () => {
+    expect(agentStore).toContain("selectCompactionWindow(");
+    expect(agentStore).toContain("messages.slice(0, tailWindow.cutIndex)");
+    expect(agentStore).not.toContain(
+      "messages.slice(0, messages.length - preserveCount)",
+    );
+  });
+
+  it("groups tool results into their turn so a tool result is never split off", () => {
+    // groupId is keyed per user-led turn; the selector keeps groups whole.
+    expect(agentStore).toContain("groupId: `t${compactTurn}`");
+  });
+
+  it("the prompt-too-long retry uses a tighter tail budget, not a magic count", () => {
+    expect(agentStore).toContain("tailRatio: AGGRESSIVE_RETRY_TAIL_RATIO");
+  });
+});

--- a/tests/unit/compaction-window.test.ts
+++ b/tests/unit/compaction-window.test.ts
@@ -1,0 +1,129 @@
+// ABOUTME: Unit tests for token-budgeted compaction tail selection (#2104).
+// ABOUTME: Covers oversized tail messages, lightweight growth, anchoring, tool groups.
+
+import { describe, expect, it } from "vitest";
+import {
+  type CompactionWindowItem,
+  selectCompactionWindow,
+} from "@/lib/compaction/window";
+
+function item(
+  tokens: number,
+  role: CompactionWindowItem["role"] = "assistant",
+  groupId: string | null = null,
+): CompactionWindowItem {
+  return { tokens, role, groupId };
+}
+
+describe("#2104 selectCompactionWindow — token budget", () => {
+  it("shrinks the tail when a single preserved message is huge (fixed-count overflow case)", () => {
+    // 10 messages; the old fixed preserveCount=10 would keep all of them,
+    // including a 90k-token tool dump that alone blows a 100k window.
+    const items = [
+      ...Array.from({ length: 7 }, () => item(500, "assistant")),
+      item(90_000, "tool"),
+      item(400, "user"),
+      item(300, "assistant"),
+    ];
+    const { preserveCount, cutIndex } = selectCompactionWindow(items, {
+      contextLimit: 100_000,
+      targetTailRatio: 0.35, // 35k tail budget
+      minTailMessages: 2,
+    });
+    // The 90k dump must be pushed into the compacted half, not preserved.
+    expect(cutIndex).toBeGreaterThan(7);
+    expect(preserveCount).toBeLessThan(10);
+  });
+
+  it("grows the tail beyond a small fixed count when messages are lightweight", () => {
+    // 40 tiny messages; the old preserveCount=10 would drop 30 needlessly.
+    const items = Array.from({ length: 40 }, (_, i) =>
+      item(50, i % 2 === 0 ? "user" : "assistant"),
+    );
+    const { preserveCount } = selectCompactionWindow(items, {
+      contextLimit: 100_000,
+      targetTailRatio: 0.35,
+      minTailMessages: 2,
+    });
+    // 40 * 50 = 2000 tokens, well under the 35k budget → keep them all.
+    expect(preserveCount).toBe(40);
+  });
+
+  it("always anchors the latest user message into the preserved tail", () => {
+    // Latest user message sits near the front; budget alone would drop it.
+    const items = [
+      item(200, "user"), // index 0 — the latest *user* turn is later though
+      ...Array.from({ length: 30 }, () => item(2_000, "assistant")),
+      item(150, "user"), // index 31 — latest user
+      item(60_000, "assistant"), // index 32 — huge final assistant
+    ];
+    const { cutIndex } = selectCompactionWindow(items, {
+      contextLimit: 100_000,
+      targetTailRatio: 0.35,
+      minTailMessages: 1,
+    });
+    // cut must be at or before the latest user message (index 31).
+    expect(cutIndex).toBeLessThanOrEqual(31);
+  });
+
+  it("never splits a tool group across the compaction boundary", () => {
+    // A tool group [assistant, tool, tool] tagged 'g5' sits at the budget edge.
+    const items = [
+      ...Array.from({ length: 5 }, () => item(4_000, "assistant")),
+      item(3_000, "assistant", "g5"),
+      item(3_000, "tool", "g5"),
+      item(3_000, "tool", "g5"),
+      item(200, "user"),
+      item(200, "assistant"),
+    ];
+    const { cutIndex } = selectCompactionWindow(items, {
+      contextLimit: 100_000,
+      targetTailRatio: 0.12, // ~12k budget — boundary falls inside g5
+      minTailMessages: 2,
+    });
+    // The preserved tail must not begin in the middle of group g5: either
+    // the whole group is preserved or none of it is.
+    const tail = items.slice(cutIndex);
+    const tailG5 = tail.filter((m) => m.groupId === "g5").length;
+    expect(tailG5 === 0 || tailG5 === 3).toBe(true);
+  });
+
+  it("still makes compaction progress when the active turn alone exceeds the budget (soft ceiling)", () => {
+    // A long transcript whose most recent user turn is enormous (huge
+    // assistant + tool dump). One oversized turn must not block compaction:
+    // the older prefix is still compacted, and the over-budget tail is flagged.
+    const items = [
+      ...Array.from({ length: 8 }, () => item(2_000, "assistant")),
+      item(400, "user"),
+      item(80_000, "assistant"),
+      item(80_000, "tool"),
+    ];
+    const result = selectCompactionWindow(items, {
+      contextLimit: 100_000,
+      targetTailRatio: 0.35,
+      minTailMessages: 2,
+    });
+    // Progress made — the old prefix is compacted, not preserved wholesale.
+    expect(result.cutIndex).toBeGreaterThan(0);
+    expect(result.preserveCount).toBeLessThan(items.length);
+    // The forced active-turn tail exceeds the budget — flagged for telemetry.
+    expect(result.overBudget).toBe(true);
+  });
+
+  it("caps the tail at maxTailTokens regardless of ratio", () => {
+    const items = Array.from({ length: 100 }, () => item(1_000, "assistant"));
+    const { tailTokens } = selectCompactionWindow(items, {
+      contextLimit: 1_000_000,
+      targetTailRatio: 0.5, // would allow 500k
+      maxTailTokens: 20_000,
+      minTailMessages: 2,
+    });
+    expect(tailTokens).toBeLessThanOrEqual(20_000);
+  });
+
+  it("returns an empty preserve for an empty transcript", () => {
+    const r = selectCompactionWindow([], { contextLimit: 100_000 });
+    expect(r.preserveCount).toBe(0);
+    expect(r.cutIndex).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #2104.

## Problem
Compaction chose its boundary by a **fixed message count** (`autoCompactPreserveMessages`, default 10):
- Ten preserved messages can hold a massive tool result, image payload, or code dump and **still overflow the provider** after compaction has already run.
- The reverse hurts too: lightweight chats dropped context the budget could safely have kept.

## Fix
New shared selector `src/lib/compaction/window.ts` — `selectCompactionWindow(items, opts)`:
- Walks backward from the newest message accumulating token cost; keeps the tail within a budget (`targetTailRatio`, default **0.35** of the context window, with an optional `maxTailTokens` ceiling).
- **Minimum tail** floor so the last exchange is always kept.
- **Never splits a tool/turn group** across the boundary (group-snap).
- **Anchors the latest user message** into the preserved tail.
- **Soft ceiling**: when the forced tail (floor / anchor / whole group) exceeds the budget it still runs and flags `overBudget` — one oversized message can't block compaction.

Both stores now split on `tailWindow.cutIndex`:
- **chat.store.ts** — per-message content tokens, model context limit.
- **agent.store.ts** — content + tool-result tokens, session context window, tool results grouped into their user-led turn. Predictive, reactive, and the prompt-too-long retry all use the selector; the retry passes a **tighter tail ratio (0.15)** instead of the magic `AGGRESSIVE_RETRY_PRESERVE_COUNT`.

## Acceptance criteria
- [x] Shared, token-budgeted boundary selector used by both stores
- [x] Latest user message always in the preserved tail
- [x] Tool call/result groups never split
- [x] Minimum tail + soft ceiling so one oversized message can't prevent compaction
- [x] Predictive, reactive, and retry all use the same selector
- [x] Tests: huge tool output in the old fixed tail, lightweight-grows-tail, latest-user anchoring, tool-pair integrity, soft ceiling, max-tail cap

## Tests
- `tests/unit/compaction-window.test.ts` — selector behavior (7 cases)
- `tests/unit/compaction-window-wiring.test.ts` — both stores use the selector; retry uses the tail ratio
- `tests/unit/compaction-scrollback.test.ts` (#1616) updated to drive the token boundary
- Full suite green: **209 files / 1509 tests**

Builds on #2103 (already merged).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com