### PR TITLE
fix(compaction): tool/media-aware pruning + token accounting (#2105)

### DIFF
--- a/src/lib/compaction/prune.ts
+++ b/src/lib/compaction/prune.ts
@@ -1,0 +1,199 @@
+// ABOUTME: Tool/media-aware pre-pruning of compacted history before summarization (#2105).
+// ABOUTME: Dedupes tool output, summarizes stale results, strips old media, bounds JSON args.
+
+import {
+  type AccountedMessage,
+  estimateAccountedMessageTokens,
+} from "@/lib/compaction/token-accounting";
+
+/** A transcript message in the shape the pruner needs. */
+export interface PrunableMessage {
+  id: string;
+  role: "user" | "assistant" | "system" | "tool" | "other";
+  content: string;
+  /** Tool result text (tool messages only). */
+  toolResult?: string;
+  /** Tool name/title for back-references and summaries. */
+  toolName?: string;
+  /** Tool-call arguments serialized as JSON (tool/assistant messages). */
+  toolArgs?: string;
+  /** Number of image/media parts on this message. */
+  imageParts?: number;
+}
+
+export interface PruneOptions {
+  /** Tool results longer than this are replaced with a one-line summary. Default 800. */
+  maxToolResultChars?: number;
+  /** Tool-call arguments longer than this are truncated (kept JSON-valid). Default 1000. */
+  maxToolArgChars?: number;
+  /**
+   * Messages at index >= this are the protected tail and are left untouched.
+   * Defaults to the full length (prune everything). Callers pass the active
+   * tail boundary so the latest turn keeps its full fidelity.
+   */
+  protectedFromIndex?: number;
+}
+
+export interface PruneStats {
+  duplicateToolResults: number;
+  summarizedToolResults: number;
+  strippedMediaParts: number;
+  truncatedToolArgs: number;
+  tokensBefore: number;
+  tokensAfter: number;
+}
+
+export interface PruneResult {
+  messages: PrunableMessage[];
+  stats: PruneStats;
+}
+
+const DEFAULT_MAX_TOOL_RESULT_CHARS = 800;
+const DEFAULT_MAX_TOOL_ARG_CHARS = 1_000;
+
+function toAccounted(m: PrunableMessage): AccountedMessage {
+  return {
+    content: m.content,
+    toolArgs: m.toolArgs,
+    toolResult: m.toolResult,
+    imageParts: m.imageParts,
+  };
+}
+
+function sumTokens(messages: PrunableMessage[], end: number): number {
+  let total = 0;
+  for (let i = 0; i < end; i++) {
+    total += estimateAccountedMessageTokens(toAccounted(messages[i]));
+  }
+  return total;
+}
+
+/** One-line, information-bearing replacement for a large/stale tool result. */
+function summarizeToolResult(m: PrunableMessage): string {
+  const name = m.toolName ?? "tool";
+  const raw = m.toolResult ?? "";
+  const firstLine = raw.split("\n", 1)[0]?.slice(0, 120) ?? "";
+  return `[${name} result — ${raw.length} chars; first line: "${firstLine}"; full output dropped at compaction]`;
+}
+
+/** Recursively shorten long string leaves so the result stays valid JSON. */
+function truncateJsonValue(value: unknown, cap: number): unknown {
+  if (typeof value === "string") {
+    return value.length > cap ? `${value.slice(0, cap)}…[truncated]` : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => truncateJsonValue(v, cap));
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      out[key] = truncateJsonValue(
+        (value as Record<string, unknown>)[key],
+        cap,
+      );
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Truncate large tool-call arguments while preserving JSON validity. Parses the
+ * args and shortens long string leaves; if the payload is not valid JSON it is
+ * wrapped in a valid `{ "_truncated": ... }` envelope rather than sliced into
+ * malformed JSON that a downstream provider would reject. #2105.
+ */
+export function truncateJsonArgs(args: string, maxChars: number): string {
+  if (args.length <= maxChars) return args;
+  try {
+    return JSON.stringify(truncateJsonValue(JSON.parse(args), maxChars));
+  } catch {
+    return JSON.stringify({ _truncated: args.slice(0, maxChars) });
+  }
+}
+
+/**
+ * Pre-prune compacted history outside the protected tail: dedupe repeated tool
+ * output to back-references, summarize stale large results, strip old media
+ * payloads (keeping the latest media-bearing turn intact), and bound oversized
+ * tool-call arguments. Lowers both the summarizer input and the post-compaction
+ * prompt size for tool-heavy and multimodal sessions.
+ */
+export function pruneCompactedHistory(
+  messages: PrunableMessage[],
+  options: PruneOptions = {},
+): PruneResult {
+  const maxToolResultChars =
+    options.maxToolResultChars ?? DEFAULT_MAX_TOOL_RESULT_CHARS;
+  const maxToolArgChars = options.maxToolArgChars ?? DEFAULT_MAX_TOOL_ARG_CHARS;
+  const protectedFrom = Math.min(
+    options.protectedFromIndex ?? messages.length,
+    messages.length,
+  );
+
+  const stats: PruneStats = {
+    duplicateToolResults: 0,
+    summarizedToolResults: 0,
+    strippedMediaParts: 0,
+    truncatedToolArgs: 0,
+    tokensBefore: sumTokens(messages, protectedFrom),
+    tokensAfter: 0,
+  };
+
+  const out = messages.map((m) => ({ ...m }));
+
+  // Latest media-bearing message across the WHOLE transcript — its media is
+  // kept so an active multimodal task still works.
+  let latestMediaIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if ((messages[i].imageParts ?? 0) > 0) {
+      latestMediaIndex = i;
+      break;
+    }
+  }
+
+  // Seed dedupe with tool results that live in the protected tail so a pruned
+  // older copy back-references the newest retained copy even when that copy is
+  // in the tail.
+  const seen = new Set<string>();
+  for (let i = protectedFrom; i < messages.length; i++) {
+    const r = messages[i].toolResult;
+    if (messages[i].role === "tool" && r) seen.add(r);
+  }
+
+  // Walk newest -> oldest within the pruned region so the newest copy of a
+  // duplicated result is the one retained.
+  for (let i = protectedFrom - 1; i >= 0; i--) {
+    const m = out[i];
+
+    if (m.role === "tool" && m.toolResult) {
+      if (seen.has(m.toolResult)) {
+        m.toolResult = `[duplicate of a more recent ${m.toolName ?? "tool"} result — omitted at compaction]`;
+        stats.duplicateToolResults++;
+      } else {
+        seen.add(m.toolResult);
+        if (m.toolResult.length > maxToolResultChars) {
+          m.toolResult = summarizeToolResult(m);
+          stats.summarizedToolResults++;
+        }
+      }
+    }
+
+    // Strip stale media outside the latest media-bearing turn.
+    if ((m.imageParts ?? 0) > 0 && i < latestMediaIndex) {
+      const stripped = m.imageParts ?? 0;
+      stats.strippedMediaParts += stripped;
+      m.imageParts = 0;
+      m.content = `${m.content}\n[${stripped} image(s) removed at compaction]`;
+    }
+
+    // Bound oversized tool-call arguments, keeping JSON valid.
+    if (m.toolArgs && m.toolArgs.length > maxToolArgChars) {
+      m.toolArgs = truncateJsonArgs(m.toolArgs, maxToolArgChars);
+      stats.truncatedToolArgs++;
+    }
+  }
+
+  stats.tokensAfter = sumTokens(out, protectedFrom);
+  return { messages: out, stats };
+}

--- a/src/lib/compaction/token-accounting.ts
+++ b/src/lib/compaction/token-accounting.ts
@@ -1,0 +1,69 @@
+// ABOUTME: Request-level token accounting for compaction — counts system, tools, args, media (#2105).
+// ABOUTME: Uses a flat per-image cost instead of raw base64 length so the gauge stops missing.
+
+import { estimateTokens } from "@/lib/token-counter";
+
+/**
+ * Flat token cost charged per image/media part. Real providers bill images at
+ * a roughly fixed tile cost, NOT proportional to the base64 payload length, so
+ * counting raw base64 characters (what content-only estimation effectively did
+ * by ignoring them, or over-counts when inlined) misreads the gauge badly. A
+ * conservative flat estimate keeps multimodal sessions honest. #2105.
+ */
+export const IMAGE_TOKEN_COST = 1_600;
+
+/** One message reduced to the token-bearing parts of a provider request. */
+export interface AccountedMessage {
+  /** Plain text content. */
+  content?: string;
+  /** Tool-call arguments — object or pre-serialized string. */
+  toolArgs?: unknown;
+  /** Tool result text. */
+  toolResult?: string;
+  /** Number of image/media parts attached to this message. */
+  imageParts?: number;
+}
+
+export interface RequestTokenInput {
+  /** System prompt / priming block. */
+  systemPrompt?: string;
+  /** Tool schema definitions sent with the request (array or string). */
+  toolSchemas?: unknown;
+  messages: AccountedMessage[];
+}
+
+/** Token cost of an arbitrary value: strings directly, everything else as JSON. */
+export function estimateValueTokens(value: unknown): number {
+  if (value == null) return 0;
+  if (typeof value === "string") return estimateTokens(value);
+  try {
+    return estimateTokens(JSON.stringify(value));
+  } catch {
+    return 0;
+  }
+}
+
+/** Token cost of a single message including tool args, tool result, and media. */
+export function estimateAccountedMessageTokens(m: AccountedMessage): number {
+  return (
+    estimateTokens(m.content ?? "") +
+    estimateValueTokens(m.toolArgs) +
+    estimateTokens(m.toolResult ?? "") +
+    Math.max(0, m.imageParts ?? 0) * IMAGE_TOKEN_COST
+  );
+}
+
+/**
+ * Estimate the full request token load: system prompt + tool schemas + every
+ * message's content, tool-call arguments, tool results, and media parts. This
+ * is the request-level view the content-only counter missed — the source of
+ * false context-gauge readings in tool-heavy and multimodal sessions.
+ */
+export function estimateRequestTokens(input: RequestTokenInput): number {
+  let total = estimateTokens(input.systemPrompt ?? "");
+  total += estimateValueTokens(input.toolSchemas);
+  for (const m of input.messages) {
+    total += estimateAccountedMessageTokens(m);
+  }
+  return total;
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -14,10 +14,15 @@ import {
   onRuntimeEvent,
 } from "@/lib/browser-local-runtime";
 import {
+  type PrunableMessage,
+  pruneCompactedHistory,
+} from "@/lib/compaction/prune";
+import {
   buildIterativeCompactionPrompt,
   buildSummaryLineage,
   type SummaryLineage,
 } from "@/lib/compaction/summary";
+import { estimateAccountedMessageTokens } from "@/lib/compaction/token-accounting";
 import {
   type CompactionWindowItem,
   selectCompactionWindow,
@@ -3832,15 +3837,19 @@ export const agentStore = {
     let compactTurn = 0;
     const windowItems: CompactionWindowItem[] = messages.map((m) => {
       if (m.type === "user") compactTurn++;
-      const toolTokens = m.toolCall?.result
-        ? estimateTokens(m.toolCall.result)
-        : 0;
       const role =
         m.type === "user" || m.type === "assistant" || m.type === "tool"
           ? m.type
           : "other";
+      // Request-aware token cost: content + tool-call arguments + tool result,
+      // so the boundary is accurate in tool-heavy turns where the arguments and
+      // output dominate, not just the message text. #2105.
       return {
-        tokens: estimateTokens(m.content) + toolTokens,
+        tokens: estimateAccountedMessageTokens({
+          content: m.content,
+          toolArgs: m.toolCall?.parameters,
+          toolResult: m.toolCall?.result,
+        }),
         role,
         groupId: `t${compactTurn}`,
       };
@@ -3895,8 +3904,38 @@ export const agentStore = {
       // and the #1733 agent-action continuation framing, and it no longer
       // asks the model to predict the next user ask.
       const previousSummary = session.compactedSummary?.content ?? null;
-      const newTurns = toCompact
-        .map((m) => `${m.type.toUpperCase()}: ${m.content}`)
+
+      // Pre-prune the compacted history before summarization: dedupe repeated
+      // tool output to back-references, summarize stale large results, and
+      // bound oversized tool-call arguments. This both shrinks the summarizer
+      // input and lets the summary capture tool outcomes (previously dropped,
+      // since only message content was fed in). #2105.
+      const prunable: PrunableMessage[] = toCompact.map((m) => ({
+        id: m.id,
+        role:
+          m.type === "user" || m.type === "assistant" || m.type === "tool"
+            ? m.type
+            : "other",
+        content: m.content,
+        toolResult: m.toolCall?.result,
+        toolName: m.toolCall?.title,
+        toolArgs: m.toolCall?.parameters
+          ? JSON.stringify(m.toolCall.parameters)
+          : undefined,
+      }));
+      const pruned = pruneCompactedHistory(prunable, {
+        protectedFromIndex: prunable.length,
+      });
+      console.info(
+        `[compact.prune] ${pruned.stats.duplicateToolResults} dup, ${pruned.stats.summarizedToolResults} summarized, ${pruned.stats.truncatedToolArgs} args trimmed, tokens ${pruned.stats.tokensBefore}->${pruned.stats.tokensAfter}`,
+      );
+      const newTurns = pruned.messages
+        .map((m) => {
+          if (m.role === "tool" && m.toolResult) {
+            return `TOOL(${m.toolName ?? "tool"}): ${m.toolResult}`;
+          }
+          return `${m.role.toUpperCase()}: ${m.content}`;
+        })
         .join("\n\n");
       const summaryPrompt = buildIterativeCompactionPrompt({
         previousSummary,

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -3,10 +3,19 @@
 
 import { createStore } from "solid-js/store";
 import {
+  type PrunableMessage,
+  pruneCompactedHistory,
+} from "@/lib/compaction/prune";
+import {
   buildIterativeCompactionPrompt,
   buildSummaryLineage,
   type SummaryLineage,
 } from "@/lib/compaction/summary";
+import {
+  type AccountedMessage,
+  estimateAccountedMessageTokens,
+  estimateRequestTokens,
+} from "@/lib/compaction/token-accounting";
 import {
   type CompactionWindowItem,
   selectCompactionWindow,
@@ -24,12 +33,7 @@ import {
   type UnifiedConversationRow,
   updateConversation as updateConversationDb,
 } from "@/lib/tauri-bridge";
-import {
-  estimateConversationTokens,
-  estimateMessageTokens,
-  getModelContextLimit,
-  shouldTriggerCompaction,
-} from "@/lib/token-counter";
+import { getModelContextLimit } from "@/lib/token-counter";
 import type { Message } from "@/services/chat";
 import { sendMessage } from "@/services/chat";
 import type { AgentType } from "@/services/providers";
@@ -151,6 +155,15 @@ function generateTitle(content: string): string {
   return `${lastSpace > 10 ? truncated.slice(0, lastSpace) : truncated}…`;
 }
 
+/**
+ * Reduce a chat message to its token-bearing parts so the gauge and the
+ * compaction trigger count attached images at a flat cost instead of ignoring
+ * them — the source of context-gauge misses in multimodal chats. #2105.
+ */
+function accountedChatMessage(m: Message): AccountedMessage {
+  return { content: m.content, imageParts: m.images?.length ?? 0 };
+}
+
 export const chatStore = {
   // ============================================================================
   // Getters
@@ -230,10 +243,13 @@ export const chatStore = {
   },
 
   /**
-   * Get estimated token count for the active conversation.
+   * Get estimated token count for the active conversation, including attached
+   * images at a flat per-image cost (#2105).
    */
   get estimatedTokens(): number {
-    return estimateConversationTokens(this.messages);
+    return estimateRequestTokens({
+      messages: this.messages.map(accountedChatMessage),
+    });
   },
 
   /**
@@ -626,13 +642,15 @@ export const chatStore = {
 
   /**
    * Check if compaction should be triggered for the active conversation.
+   * Counts attached images so multimodal chats don't under-read the gauge. #2105.
    */
   shouldCompact(thresholdPercent: number): boolean {
-    return shouldTriggerCompaction(
-      this.messages,
-      this.selectedModel,
-      thresholdPercent,
-    );
+    const limit = getModelContextLimit(this.selectedModel);
+    if (limit <= 0) return false;
+    const tokens = estimateRequestTokens({
+      messages: this.messages.map(accountedChatMessage),
+    });
+    return (tokens / limit) * 100 >= thresholdPercent;
   },
 
   /**
@@ -665,7 +683,7 @@ export const chatStore = {
       // tail when the budget allows. The latest user message is always
       // anchored into the preserved tail. #2104.
       const items: CompactionWindowItem[] = messages.map((m) => ({
-        tokens: estimateMessageTokens(m),
+        tokens: estimateAccountedMessageTokens(accountedChatMessage(m)),
         role:
           m.role === "user" || m.role === "assistant" || m.role === "system"
             ? m.role
@@ -694,7 +712,23 @@ export const chatStore = {
       // the newest window — otherwise context summarized by an earlier
       // compaction silently disappears. #2103.
       const previousSummary = activeConvo?.compactedSummary?.content ?? null;
-      const newTurns = toCompact
+
+      // Pre-prune the compacted history before summarization: strip stale image
+      // payloads outside the latest media-bearing turn so multimodal chats feed
+      // a leaner transcript into the summarizer. #2105.
+      const prunable: PrunableMessage[] = toCompact.map((m) => ({
+        id: m.id,
+        role:
+          m.role === "user" || m.role === "assistant" || m.role === "system"
+            ? m.role
+            : "other",
+        content: m.content,
+        imageParts: m.images?.length ?? 0,
+      }));
+      const pruned = pruneCompactedHistory(prunable, {
+        protectedFromIndex: prunable.length,
+      });
+      const newTurns = pruned.messages
         .map((m) => `${m.role.toUpperCase()}: ${m.content}`)
         .join("\n\n");
       const summaryPrompt = buildIterativeCompactionPrompt({

--- a/tests/unit/compaction-prune.test.ts
+++ b/tests/unit/compaction-prune.test.ts
@@ -1,0 +1,113 @@
+// ABOUTME: Unit tests for tool/media-aware compaction pre-pruning (#2105).
+// ABOUTME: Duplicate tool output, stale media, large results, oversized JSON args.
+
+import { describe, expect, it } from "vitest";
+import {
+  type PrunableMessage,
+  pruneCompactedHistory,
+  truncateJsonArgs,
+} from "@/lib/compaction/prune";
+
+function tool(
+  id: string,
+  name: string,
+  result: string,
+  extra: Partial<PrunableMessage> = {},
+): PrunableMessage {
+  return { id, role: "tool", content: "", toolName: name, toolResult: result, ...extra };
+}
+
+describe("#2105 pruneCompactedHistory — duplicate tool output", () => {
+  it("replaces older duplicate tool results with a back-reference to the newest copy", () => {
+    const fileBody = "FILE CONTENTS ".repeat(50);
+    const messages: PrunableMessage[] = [
+      tool("t1", "read_file", fileBody),
+      { id: "a1", role: "assistant", content: "thinking" },
+      tool("t2", "read_file", fileBody), // newest identical read
+    ];
+    const { messages: out, stats } = pruneCompactedHistory(messages);
+    expect(stats.duplicateToolResults).toBe(1);
+    // Older copy becomes a back-reference; newest copy is retained (or summarized).
+    expect(out[0].toolResult).toContain("duplicate of a more recent");
+    expect(out[2].toolResult).not.toContain("duplicate of a more recent");
+  });
+});
+
+describe("#2105 pruneCompactedHistory — stale large results", () => {
+  it("summarizes a large tool result into a one-line information-bearing string", () => {
+    const big = `first line of output\n${"x".repeat(5000)}`;
+    const { messages: out, stats } = pruneCompactedHistory(
+      [tool("t1", "run_command", big)],
+      { maxToolResultChars: 800 },
+    );
+    expect(stats.summarizedToolResults).toBe(1);
+    const summary = out[0].toolResult ?? "";
+    expect(summary.length).toBeLessThan(big.length);
+    // Information-bearing, not opaque: names the tool, size, and first line.
+    expect(summary).toContain("run_command");
+    expect(summary).toContain("first line of output");
+    expect(summary).toContain("dropped at compaction");
+  });
+});
+
+describe("#2105 pruneCompactedHistory — stale media", () => {
+  it("strips old image payloads but keeps the latest media-bearing turn", () => {
+    const messages: PrunableMessage[] = [
+      { id: "u1", role: "user", content: "old screenshot", imageParts: 1 },
+      { id: "u2", role: "user", content: "later", imageParts: 0 },
+      { id: "u3", role: "user", content: "newest screenshot", imageParts: 2 },
+    ];
+    const { messages: out, stats } = pruneCompactedHistory(messages);
+    expect(stats.strippedMediaParts).toBe(1);
+    expect(out[0].imageParts).toBe(0);
+    expect(out[0].content).toContain("image(s) removed");
+    // Latest media-bearing turn is preserved intact.
+    expect(out[2].imageParts).toBe(2);
+  });
+});
+
+describe("#2105 pruneCompactedHistory — oversized tool-call arguments", () => {
+  it("truncates large write_file args while keeping the JSON valid", () => {
+    const args = JSON.stringify({
+      path: "src/big.ts",
+      content: "x".repeat(8000),
+    });
+    const { messages: out, stats } = pruneCompactedHistory(
+      [tool("t1", "write_file", "ok", { toolArgs: args })],
+      { maxToolArgChars: 500 },
+    );
+    expect(stats.truncatedToolArgs).toBe(1);
+    const truncated = out[0].toolArgs ?? "";
+    expect(truncated.length).toBeLessThan(args.length);
+    // Still valid JSON, and the structural key survives.
+    const parsed = JSON.parse(truncated);
+    expect(parsed.path).toBe("src/big.ts");
+    expect(parsed.content).toContain("truncated");
+  });
+});
+
+describe("#2105 truncateJsonArgs", () => {
+  it("wraps non-JSON payloads in a valid envelope", () => {
+    const out = truncateJsonArgs("not json ".repeat(500), 100);
+    expect(() => JSON.parse(out)).not.toThrow();
+    expect(JSON.parse(out)._truncated).toBeDefined();
+  });
+});
+
+describe("#2105 pruneCompactedHistory — protected tail and token reduction", () => {
+  it("leaves the protected tail untouched and reduces estimated tokens", () => {
+    const big = "DATA ".repeat(2000);
+    const messages: PrunableMessage[] = [
+      tool("t1", "read_file", big),
+      tool("t2", "read_file", big), // duplicate of t1
+      { id: "u1", role: "user", content: "keep me", imageParts: 1 }, // protected
+    ];
+    const { messages: out, stats } = pruneCompactedHistory(messages, {
+      protectedFromIndex: 2,
+    });
+    // Protected tail message is unchanged.
+    expect(out[2].content).toBe("keep me");
+    expect(out[2].imageParts).toBe(1);
+    expect(stats.tokensAfter).toBeLessThan(stats.tokensBefore);
+  });
+});

--- a/tests/unit/compaction-pruning-wiring.test.ts
+++ b/tests/unit/compaction-pruning-wiring.test.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Locks the #2105 pruning + request-accounting wiring in both stores.
+// ABOUTME: Compacted history is pruned before summarization; the gauge counts media.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const chatStore = readFileSync(resolve("src/stores/chat.store.ts"), "utf-8");
+const agentStore = readFileSync(resolve("src/stores/agent.store.ts"), "utf-8");
+
+describe("#2105 agent compaction prunes history and accounts tool tokens", () => {
+  it("pre-prunes the compacted window before building summarizer input", () => {
+    expect(agentStore).toContain("pruneCompactedHistory(");
+    expect(agentStore).toContain("protectedFromIndex: prunable.length");
+  });
+
+  it("feeds tool results into the summarizer via the pruned history", () => {
+    expect(agentStore).toContain("TOOL(${m.toolName ?? \"tool\"}): ${m.toolResult}");
+  });
+
+  it("counts tool-call arguments and results in the boundary token cost", () => {
+    expect(agentStore).toContain("estimateAccountedMessageTokens({");
+    expect(agentStore).toContain("toolArgs: m.toolCall?.parameters");
+  });
+});
+
+describe("#2105 chat compaction prunes history and counts media in the gauge", () => {
+  it("pre-prunes the compacted window before building summarizer input", () => {
+    expect(chatStore).toContain("pruneCompactedHistory(");
+  });
+
+  it("the gauge and the trigger count attached images via request accounting", () => {
+    expect(chatStore).toContain("estimateRequestTokens(");
+    expect(chatStore).toContain("accountedChatMessage");
+    // The content-only counter is no longer the source of truth for the gauge.
+    expect(chatStore).not.toContain("estimateConversationTokens(this.messages)");
+  });
+});

--- a/tests/unit/compaction-token-accounting.test.ts
+++ b/tests/unit/compaction-token-accounting.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Unit tests for request-level token accounting (#2105).
+// ABOUTME: System prompt, tool schemas, tool args, tool results, and flat image cost.
+
+import { describe, expect, it } from "vitest";
+import {
+  estimateAccountedMessageTokens,
+  estimateRequestTokens,
+  IMAGE_TOKEN_COST,
+} from "@/lib/compaction/token-accounting";
+
+describe("#2105 request token accounting", () => {
+  it("counts a single image at a flat cost, independent of base64 length", () => {
+    const tiny = estimateAccountedMessageTokens({ content: "", imageParts: 1 });
+    expect(tiny).toBe(IMAGE_TOKEN_COST);
+    // Two identical-content messages differing only by image count differ by
+    // exactly the flat cost — not by any base64 payload size.
+    const two = estimateAccountedMessageTokens({ content: "hi", imageParts: 2 });
+    const zero = estimateAccountedMessageTokens({ content: "hi", imageParts: 0 });
+    expect(two - zero).toBe(2 * IMAGE_TOKEN_COST);
+  });
+
+  it("includes tool-call arguments and tool results in the message cost", () => {
+    const withTools = estimateAccountedMessageTokens({
+      content: "call it",
+      toolArgs: { path: "/very/long/path/that/costs/tokens", mode: "w" },
+      toolResult: "a".repeat(400),
+    });
+    const contentOnly = estimateAccountedMessageTokens({ content: "call it" });
+    expect(withTools).toBeGreaterThan(contentOnly);
+  });
+
+  it("includes system prompt and tool schemas in the request total", () => {
+    const base = estimateRequestTokens({
+      messages: [{ content: "hello" }],
+    });
+    const withExtras = estimateRequestTokens({
+      systemPrompt: "x".repeat(4000),
+      toolSchemas: [{ name: "read_file", description: "y".repeat(4000) }],
+      messages: [{ content: "hello" }],
+    });
+    // System prompt (~1000 tok) + tool schemas (~1000 tok) must be reflected.
+    expect(withExtras - base).toBeGreaterThan(1_500);
+  });
+});


### PR DESCRIPTION
Closes #2105.

## Problem
The token counter was **message-content-only**: tool schemas, tool-call arguments, and attached images were invisible to the context gauge (false readings in tool-heavy / multimodal sessions). And the compacted history fed to the summarizer still carried duplicate tool dumps, stale screenshots, and oversized JSON args.

## Fix
Two shared helpers:

**`src/lib/compaction/token-accounting.ts`**
- `estimateRequestTokens()` / `estimateAccountedMessageTokens()` count system prompt, tool schemas, tool-call arguments, tool results, and media.
- Media uses a **flat `IMAGE_TOKEN_COST`** (1,600) instead of raw base64 length.

**`src/lib/compaction/prune.ts`** — `pruneCompactedHistory()`:
- Dedupes repeated identical tool results → **back-reference** to the newest retained copy.
- Replaces stale large tool results with a **one-line, information-bearing** summary (tool name, size, first line) — not an opaque placeholder.
- Strips old image/media payloads **outside the latest media-bearing turn**, leaving a text placeholder.
- Truncates oversized tool-call arguments while keeping the **JSON valid** (`truncateJsonArgs`).
- Leaves the **protected tail untouched**; reports before/after token stats.

## Wiring
- **agent.store.ts** — boundary token cost now includes tool args + results; the compacted window is pruned before summarization and tool results are folded into the summarizer input (previously dropped, so the summary missed tool outcomes).
- **chat.store.ts** — the gauge (`estimatedTokens`) and the auto-compact trigger (`shouldCompact`) count attached images via request accounting; the compacted window is pruned before summarization.

## Acceptance criteria
- [x] Shared request-level estimator (content + system + tool schemas + tool args + media)
- [x] Flat per-image/media cost
- [x] Pre-pruning pass for compacted history outside the protected tail
- [x] Duplicate tool results → back-references; large results → one-line summaries; stale media stripped; large args JSON-valid-truncated
- [x] Applied to chat compaction and agent predictive/reactive compaction
- [x] Tests: duplicate file reads, stale screenshots, large JSON results, large `write_file` args, request estimates with tool schemas

## Tests
- `tests/unit/compaction-token-accounting.test.ts` (3) + `tests/unit/compaction-prune.test.ts` (6) + `tests/unit/compaction-pruning-wiring.test.ts`
- Full suite green: **212 files / 1523 tests**

Builds on #2103 + #2104 (already merged).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com