### PR TITLE
fix(compaction): resilient summarizer policy + cooldown (#2106)

### DIFF
--- a/src/lib/compaction/summarizer-policy.ts
+++ b/src/lib/compaction/summarizer-policy.ts
@@ -1,0 +1,246 @@
+// ABOUTME: Resilient summarizer policy for compaction — fallback, cooldown, no-drop (#2106).
+// ABOUTME: Shared by chat and agent paths so summarization failures never drop history.
+
+/** Run the summary with a given model id; resolves to the summary text. */
+export type SummarizerAttempt = (model: string) => Promise<string>;
+
+export interface SummarizerPolicyInput {
+  /** Preferred summarizer model. */
+  primaryModel: string;
+  /** Models tried, in order, when the primary fails or returns garbage. */
+  fallbackModels?: string[];
+  /** Invoke the summarizer with a model id. */
+  attempt: SummarizerAttempt;
+  /** Treat an error as an auth failure that a token refresh might fix. */
+  isAuthError?: (err: unknown) => boolean;
+  /** Refresh auth once on an auth error; resolves true if a refresh happened. */
+  refreshAuth?: () => Promise<boolean>;
+  /** Reject empty/garbage summaries so the policy falls through. Default: non-empty. */
+  isValidSummary?: (summary: string) => boolean;
+  /** Build a deterministic local summary when every model attempt fails. */
+  deterministicFallback?: () => string;
+}
+
+export type SummarizerOutcome =
+  | { status: "ok"; summary: string; model: string; usedFallbackModel: boolean }
+  | { status: "fallback"; summary: string; reason: string }
+  | { status: "aborted"; reason: string };
+
+function defaultIsValidSummary(summary: string): boolean {
+  return typeof summary === "string" && summary.trim().length > 0;
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Drive a summary through a resilient policy: primary model, auth-refresh retry,
+ * fallback model(s), then a deterministic local summary. Only returns `aborted`
+ * when no model AND no deterministic fallback can produce a summary — the caller
+ * must then leave history intact (no-drop). #2106.
+ */
+export async function runSummarizerWithPolicy(
+  input: SummarizerPolicyInput,
+): Promise<SummarizerOutcome> {
+  const {
+    primaryModel,
+    fallbackModels = [],
+    attempt,
+    isAuthError = () => false,
+    refreshAuth,
+    isValidSummary = defaultIsValidSummary,
+    deterministicFallback,
+  } = input;
+
+  let lastError = "unknown summarizer failure";
+
+  const tryModel = async (
+    model: string,
+  ): Promise<{ ok: true; summary: string } | { ok: false; err: unknown }> => {
+    try {
+      const summary = await attempt(model);
+      if (isValidSummary(summary)) return { ok: true, summary };
+      return {
+        ok: false,
+        err: new Error("summarizer returned an invalid summary"),
+      };
+    } catch (err) {
+      return { ok: false, err };
+    }
+  };
+
+  // Primary attempt.
+  let result = await tryModel(primaryModel);
+  if (result.ok) {
+    return {
+      status: "ok",
+      summary: result.summary,
+      model: primaryModel,
+      usedFallbackModel: false,
+    };
+  }
+  lastError = errMessage(result.err);
+
+  // Auth-refresh retry on the primary, once.
+  if (isAuthError(result.err) && refreshAuth) {
+    const refreshed = await refreshAuth();
+    if (refreshed) {
+      result = await tryModel(primaryModel);
+      if (result.ok) {
+        return {
+          status: "ok",
+          summary: result.summary,
+          model: primaryModel,
+          usedFallbackModel: false,
+        };
+      }
+      lastError = errMessage(result.err);
+    }
+  }
+
+  // Fallback models, in order.
+  for (const fallbackModel of fallbackModels) {
+    const fallbackResult = await tryModel(fallbackModel);
+    if (fallbackResult.ok) {
+      return {
+        status: "ok",
+        summary: fallbackResult.summary,
+        model: fallbackModel,
+        usedFallbackModel: true,
+      };
+    }
+    lastError = errMessage(fallbackResult.err);
+  }
+
+  // Deterministic local fallback so compaction can proceed without dropping
+  // history even when the summarizer provider is fully unavailable.
+  if (deterministicFallback) {
+    try {
+      const summary = deterministicFallback();
+      if (summary && summary.trim().length > 0) {
+        return { status: "fallback", summary, reason: lastError };
+      }
+    } catch (err) {
+      lastError = errMessage(err);
+    }
+  }
+
+  // No-drop abort: caller must keep the original history intact.
+  return { status: "aborted", reason: lastError };
+}
+
+// ============================================================================
+// Deterministic fallback summary
+// ============================================================================
+
+/** One compacted turn reduced to the fields the deterministic summary reads. */
+export interface FallbackTurn {
+  role: "user" | "assistant" | "system" | "tool" | "other";
+  content: string;
+  toolName?: string;
+  toolResult?: string;
+}
+
+const RESOURCE_RE = /(?:https?:\/\/[^\s"'<>]+)|(?:[\w.@-]+\/[\w./@-]+)/g;
+
+function clampText(text: string, max: number): string {
+  const t = text.trim().replace(/\s+/g, " ");
+  return t.length > max ? `${t.slice(0, max)}…` : t;
+}
+
+function extractResources(turns: FallbackTurn[]): string[] {
+  const found = new Set<string>();
+  for (const t of turns) {
+    const haystack = `${t.content}\n${t.toolResult ?? ""}`;
+    for (const match of haystack.matchAll(RESOURCE_RE)) {
+      const token = match[0];
+      if (token.length >= 3 && token.length <= 200) found.add(token);
+    }
+  }
+  return Array.from(found).slice(0, 12);
+}
+
+/**
+ * Build a conservative, clearly-marked fallback summary from the compacted
+ * turns. It records only observable facts — the latest user ask, the tool names
+ * that ran, and file/resource identifiers seen in the transcript — and never
+ * asserts completed work. Marked as a fallback so downstream consumers re-verify.
+ */
+export function buildDeterministicFallbackSummary(
+  turns: FallbackTurn[],
+): string {
+  const userAsks = turns
+    .filter((t) => t.role === "user")
+    .map((t) => t.content.trim())
+    .filter((c) => c.length > 0);
+  const latestAsk = userAsks.length
+    ? clampText(userAsks[userAsks.length - 1], 280)
+    : "none recorded";
+
+  const toolNames = Array.from(
+    new Set(
+      turns
+        .filter((t) => t.role === "tool" && t.toolName)
+        .map((t) => t.toolName as string),
+    ),
+  );
+  const resources = extractResources(turns);
+
+  return [
+    "[FALLBACK SUMMARY — generated locally without the summarizer model; incomplete. Re-read the workspace and verify before acting on any claim.]",
+    "ACTIVE_TASK: none recorded (fallback)",
+    "COMPLETED: none verified (fallback)",
+    "IN_PROGRESS: none recorded (fallback)",
+    "BLOCKERS: summarizer model was unavailable at compaction",
+    "DECISIONS: none recorded (fallback)",
+    `RESOURCES: ${resources.length ? resources.join(", ") : "none"}`,
+    `REMAINING: ${
+      toolNames.length
+        ? `continue work involving tools: ${toolNames.join(", ")}`
+        : "none recorded"
+    }`,
+    `LATEST_USER_REQUEST: ${latestAsk}`,
+  ].join("\n");
+}
+
+// ============================================================================
+// Cooldown
+// ============================================================================
+
+/** Default cooldown after a summarizer failure before auto-compact retries. */
+export const DEFAULT_COMPACTION_COOLDOWN_MS = 60_000;
+
+/**
+ * Per-key cooldown so a failing summarizer is not hammered on every auto-compact
+ * tick. Keyed by conversation id so it survives the session re-spawn that a
+ * reactive compaction performs.
+ */
+export class CompactionCooldown {
+  private until = new Map<string, number>();
+
+  isCoolingDown(key: string, now: number): boolean {
+    const expiry = this.until.get(key);
+    if (expiry == null) return false;
+    if (now >= expiry) {
+      this.until.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  enter(
+    key: string,
+    now: number,
+    durationMs = DEFAULT_COMPACTION_COOLDOWN_MS,
+  ): void {
+    this.until.set(key, now + durationMs);
+  }
+
+  clear(key: string): void {
+    this.until.delete(key);
+  }
+}
+
+/** Process-wide cooldown shared by chat and agent compaction. */
+export const compactionCooldown = new CompactionCooldown();

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -18,6 +18,11 @@ import {
   pruneCompactedHistory,
 } from "@/lib/compaction/prune";
 import {
+  buildDeterministicFallbackSummary,
+  compactionCooldown,
+  runSummarizerWithPolicy,
+} from "@/lib/compaction/summarizer-policy";
+import {
   buildIterativeCompactionPrompt,
   buildSummaryLineage,
   type SummaryLineage,
@@ -103,6 +108,15 @@ const AGGRESSIVE_RETRY_PRESERVE_COUNT = 2;
  * long. Replaces the old fixed retry preserve count with a token budget. #2104.
  */
 const AGGRESSIVE_RETRY_TAIL_RATIO = 0.15;
+
+/**
+ * Primary and fallback models for the compaction summarizer. Both route through
+ * the public "seren" provider. The fallback is tried when the primary errors,
+ * times out, or returns an invalid summary, before the deterministic local
+ * fallback. #2106.
+ */
+const SUMMARY_PRIMARY_MODEL = "anthropic/claude-sonnet-4";
+const SUMMARY_FALLBACK_MODELS = ["anthropic/claude-3-5-sonnet"];
 
 /**
  * Global cap = 1 simultaneous predictive compaction across the whole app.
@@ -3949,22 +3963,56 @@ export const agentStore = {
       // stale from a previous chat thread (e.g. seren-private). The
       // compaction summary is an internal operation — it must not
       // depend on UI provider state.
-      const summaryModel = "anthropic/claude-sonnet-4";
-      const summaryRequest = buildChatRequest(summaryPrompt, summaryModel);
-      let summary: string;
-      try {
-        summary = await sendProviderMessage("seren", summaryRequest);
-      } catch (firstErr) {
-        // If auth expired, attempt a token refresh and retry once
-        const msg = firstErr instanceof Error ? firstErr.message : "";
-        if (msg.includes("Not authenticated") || msg.includes("401")) {
-          const refreshed = await refreshAccessToken();
-          if (!refreshed) throw firstErr;
-          summary = await sendProviderMessage("seren", summaryRequest);
-        } else {
-          throw firstErr;
+      //
+      // Resilient policy (#2106): primary model, auth-refresh retry, fallback
+      // model, then a deterministic local summary. Only aborts (no-drop) when
+      // none of those can produce a summary — the serving session is left
+      // intact and a cooldown backs auto-compact off the failing summarizer.
+      const summaryOutcome = await runSummarizerWithPolicy({
+        primaryModel: SUMMARY_PRIMARY_MODEL,
+        fallbackModels: SUMMARY_FALLBACK_MODELS,
+        attempt: (model) =>
+          sendProviderMessage("seren", buildChatRequest(summaryPrompt, model)),
+        isAuthError: (e) => {
+          const m = e instanceof Error ? e.message : String(e);
+          return m.includes("Not authenticated") || m.includes("401");
+        },
+        refreshAuth: refreshAccessToken,
+        deterministicFallback: () =>
+          buildDeterministicFallbackSummary(prunable),
+      });
+
+      if (summaryOutcome.status === "aborted") {
+        // No-drop abort: do NOT terminate or replace the serving session.
+        // Cool down so auto-compact stops hammering the failing summarizer.
+        compactionCooldown.enter(conversationId, Date.now());
+        if (mode === "reactive") {
+          setState("sessions", sessionId, "isCompacting", false);
+          setState(
+            "sessions",
+            sessionId,
+            "error",
+            "Compaction paused — the summarizer is unavailable. Your conversation is intact.",
+          );
         }
+        console.warn(
+          `[compact.abort] summarizer unavailable, history kept intact: ${summaryOutcome.reason}`,
+        );
+        return { outcome: "failed_catastrophic" };
       }
+      if (summaryOutcome.status === "fallback") {
+        // Deterministic local summary used — cool down and warn, but proceed
+        // so compaction still relieves the context pressure.
+        compactionCooldown.enter(conversationId, Date.now());
+        console.warn(
+          `[compact.fallback] using deterministic local summary: ${summaryOutcome.reason}`,
+        );
+      } else if (summaryOutcome.usedFallbackModel) {
+        console.info(
+          `[compact.fallback_model] summary produced by fallback model ${summaryOutcome.model}`,
+        );
+      }
+      let summary = summaryOutcome.summary;
 
       // Post-generation verify-before-acting banner. Travels with `summary`
       // itself so BOTH downstream consumers carry it: the passive-prepend
@@ -4500,6 +4548,16 @@ export const agentStore = {
     if (predictiveCompactBusy) return;
     const session = state.sessions[sessionId];
     if (!session || session.predictiveCompactInFlight) return;
+
+    // Back off after a recent summarizer failure so auto-compact (both the
+    // 70% predictive and the 85% reactive-auto triggers route here) does not
+    // hammer a failing summarizer every promptComplete tick. #2106.
+    if (compactionCooldown.isCoolingDown(session.conversationId, Date.now())) {
+      console.info(
+        "[AgentStore] kickPredictiveCompact: in summarizer cooldown — skipping",
+      );
+      return;
+    }
 
     predictiveCompactBusy = true;
     setState("sessions", sessionId, "predictiveCompactInFlight", true);

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -2,10 +2,16 @@
 // ABOUTME: Stores conversations, messages, and provides persistence via Tauri.
 
 import { createStore } from "solid-js/store";
+import { isLikelyAuthError } from "@/lib/auth-errors";
 import {
   type PrunableMessage,
   pruneCompactedHistory,
 } from "@/lib/compaction/prune";
+import {
+  buildDeterministicFallbackSummary,
+  compactionCooldown,
+  runSummarizerWithPolicy,
+} from "@/lib/compaction/summarizer-policy";
 import {
   buildIterativeCompactionPrompt,
   buildSummaryLineage,
@@ -34,6 +40,7 @@ import {
   updateConversation as updateConversationDb,
 } from "@/lib/tauri-bridge";
 import { getModelContextLimit } from "@/lib/token-counter";
+import { refreshAccessToken } from "@/services/auth";
 import type { Message } from "@/services/chat";
 import { sendMessage } from "@/services/chat";
 import type { AgentType } from "@/services/providers";
@@ -742,12 +749,42 @@ export const chatStore = {
       const compactionProvider: ProviderId = isChatProvider(selectedProvider)
         ? selectedProvider
         : providerStore.activeProvider;
-      const summary = await sendMessage(
-        summaryPrompt,
-        activeConvo?.selectedModel ?? this.selectedModel,
-        compactionProvider,
-        undefined,
-      );
+
+      // Resilient policy (#2106): primary attempt, auth-refresh retry, then a
+      // deterministic local summary. On abort the messages are NOT replaced —
+      // the conversation is kept intact (no-drop) and a cooldown backs the
+      // auto-compact trigger off the failing summarizer. The conversation's
+      // bound model/provider is single-sourced, so there is no safe alternate
+      // chat model to try; the deterministic fallback covers provider outages.
+      const summaryOutcome = await runSummarizerWithPolicy({
+        primaryModel: activeConvo?.selectedModel ?? this.selectedModel,
+        attempt: (model) =>
+          sendMessage(summaryPrompt, model, compactionProvider, undefined),
+        isAuthError: (e) =>
+          isLikelyAuthError(e instanceof Error ? e.message : String(e)),
+        refreshAuth: refreshAccessToken,
+        deterministicFallback: () =>
+          buildDeterministicFallbackSummary(prunable),
+      });
+
+      if (summaryOutcome.status === "aborted") {
+        compactionCooldown.enter(conversationId, Date.now());
+        setState(
+          "error",
+          "Compaction paused — the summarizer is unavailable. Your conversation is intact.",
+        );
+        console.warn(
+          `[chatStore] compaction aborted (no-drop): ${summaryOutcome.reason}`,
+        );
+        return;
+      }
+      if (summaryOutcome.status === "fallback") {
+        compactionCooldown.enter(conversationId, Date.now());
+        console.warn(
+          `[chatStore] using deterministic local summary: ${summaryOutcome.reason}`,
+        );
+      }
+      const summary = summaryOutcome.summary;
 
       const preCompactionMessages: PreCompactionMessage[] = toCompact
         .filter((m) => m.role === "user" || m.role === "assistant")
@@ -850,6 +887,17 @@ export const chatStore = {
     if (!enabled) return;
     if (state.isCompacting) return;
     if (state.isLoading) return;
+
+    // Back off auto-compaction after a recent summarizer failure so we don't
+    // call a failing summarizer on every message. Manual compaction is not
+    // gated — the user asked for it explicitly. #2106.
+    const conversationId = state.activeConversationId;
+    if (
+      conversationId &&
+      compactionCooldown.isCoolingDown(conversationId, Date.now())
+    ) {
+      return;
+    }
 
     if (this.shouldCompact(threshold)) {
       await this.compactConversation(preserveCount);

--- a/tests/unit/compaction-summarizer-policy.test.ts
+++ b/tests/unit/compaction-summarizer-policy.test.ts
@@ -1,0 +1,131 @@
+// ABOUTME: Unit tests for the resilient summarizer policy (#2106).
+// ABOUTME: Fallback model, auth-refresh retry, deterministic fallback, no-drop, cooldown.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildDeterministicFallbackSummary,
+  CompactionCooldown,
+  type FallbackTurn,
+  runSummarizerWithPolicy,
+} from "@/lib/compaction/summarizer-policy";
+
+describe("#2106 runSummarizerWithPolicy", () => {
+  it("returns the primary summary on success", async () => {
+    const out = await runSummarizerWithPolicy({
+      primaryModel: "primary",
+      attempt: async () => "GOOD SUMMARY",
+    });
+    expect(out).toEqual({
+      status: "ok",
+      summary: "GOOD SUMMARY",
+      model: "primary",
+      usedFallbackModel: false,
+    });
+  });
+
+  it("refreshes auth and retries the primary once on an auth error", async () => {
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("401 Not authenticated"))
+      .mockResolvedValueOnce("AFTER REFRESH");
+    const refreshAuth = vi.fn(async () => true);
+    const out = await runSummarizerWithPolicy({
+      primaryModel: "primary",
+      attempt,
+      isAuthError: (e) => String(e).includes("401"),
+      refreshAuth,
+    });
+    expect(refreshAuth).toHaveBeenCalledTimes(1);
+    expect(out.status).toBe("ok");
+    if (out.status === "ok") expect(out.summary).toBe("AFTER REFRESH");
+  });
+
+  it("falls back to a secondary model when the primary keeps failing", async () => {
+    const attempt = vi.fn(async (model: string) => {
+      if (model === "primary") throw new Error("provider 500");
+      return "FALLBACK MODEL SUMMARY";
+    });
+    const out = await runSummarizerWithPolicy({
+      primaryModel: "primary",
+      fallbackModels: ["secondary"],
+      attempt,
+    });
+    expect(out.status).toBe("ok");
+    if (out.status === "ok") {
+      expect(out.model).toBe("secondary");
+      expect(out.usedFallbackModel).toBe(true);
+    }
+  });
+
+  it("treats an empty/garbage summary as a failure and falls through", async () => {
+    const out = await runSummarizerWithPolicy({
+      primaryModel: "primary",
+      attempt: async () => "   ",
+      deterministicFallback: () => "LOCAL FALLBACK",
+    });
+    expect(out.status).toBe("fallback");
+    if (out.status === "fallback") expect(out.summary).toBe("LOCAL FALLBACK");
+  });
+
+  it("produces a deterministic fallback when every model attempt fails", async () => {
+    const out = await runSummarizerWithPolicy({
+      primaryModel: "primary",
+      fallbackModels: ["secondary"],
+      attempt: async () => {
+        throw new Error("everything down");
+      },
+      deterministicFallback: () => "LOCAL FALLBACK SUMMARY",
+    });
+    expect(out.status).toBe("fallback");
+    if (out.status === "fallback") {
+      expect(out.summary).toBe("LOCAL FALLBACK SUMMARY");
+      expect(out.reason).toContain("everything down");
+    }
+  });
+
+  it("aborts (no-drop) when no model and no deterministic fallback can produce a summary", async () => {
+    const out = await runSummarizerWithPolicy({
+      primaryModel: "primary",
+      attempt: async () => {
+        throw new Error("provider unavailable");
+      },
+    });
+    expect(out.status).toBe("aborted");
+    if (out.status === "aborted") expect(out.reason).toContain("provider unavailable");
+  });
+});
+
+describe("#2106 buildDeterministicFallbackSummary", () => {
+  const turns: FallbackTurn[] = [
+    { role: "user", content: "Please refactor the auth module" },
+    {
+      role: "tool",
+      content: "",
+      toolName: "read_file",
+      toolResult: "contents of src/services/auth.ts",
+    },
+    { role: "assistant", content: "Looking at the file now" },
+    { role: "user", content: "Actually, also update src/stores/auth.store.ts" },
+  ];
+
+  it("captures the latest user request, tool names, and resources, marked as fallback", () => {
+    const summary = buildDeterministicFallbackSummary(turns);
+    expect(summary).toContain("FALLBACK SUMMARY");
+    expect(summary).toContain("LATEST_USER_REQUEST: Actually, also update");
+    expect(summary).toContain("read_file");
+    expect(summary).toContain("src/services/auth.ts");
+    // Never asserts completed work.
+    expect(summary).toContain("COMPLETED: none verified (fallback)");
+  });
+});
+
+describe("#2106 CompactionCooldown", () => {
+  it("reports cooldown within the window and clears after it expires", () => {
+    const cd = new CompactionCooldown();
+    cd.enter("conv-1", 1_000, 5_000);
+    expect(cd.isCoolingDown("conv-1", 2_000)).toBe(true);
+    expect(cd.isCoolingDown("conv-1", 6_001)).toBe(false);
+    // A second, unrelated conversation is unaffected.
+    expect(cd.isCoolingDown("conv-2", 2_000)).toBe(false);
+  });
+});

--- a/tests/unit/compaction-summarizer-wiring.test.ts
+++ b/tests/unit/compaction-summarizer-wiring.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Locks the #2106 resilient-summarizer wiring in both stores.
+// ABOUTME: Both paths run the policy, no-drop on abort, and gate auto-compact on cooldown.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const chatStore = readFileSync(resolve("src/stores/chat.store.ts"), "utf-8");
+const agentStore = readFileSync(resolve("src/stores/agent.store.ts"), "utf-8");
+
+describe("#2106 agent compaction runs the resilient summarizer policy", () => {
+  it("drives the summary through runSummarizerWithPolicy with a fallback model", () => {
+    expect(agentStore).toContain("runSummarizerWithPolicy({");
+    expect(agentStore).toContain("fallbackModels: SUMMARY_FALLBACK_MODELS");
+    expect(agentStore).toContain("deterministicFallback: () =>");
+  });
+
+  it("no-drop on abort: returns without terminating, enters cooldown", () => {
+    expect(agentStore).toContain('summaryOutcome.status === "aborted"');
+    expect(agentStore).toContain("compactionCooldown.enter(conversationId");
+    expect(agentStore).toContain("history kept intact");
+  });
+
+  it("gates auto-compaction on the cooldown in kickPredictiveCompact", () => {
+    expect(agentStore).toContain(
+      "compactionCooldown.isCoolingDown(session.conversationId",
+    );
+  });
+});
+
+describe("#2106 chat compaction runs the resilient summarizer policy", () => {
+  it("drives the summary through runSummarizerWithPolicy with a deterministic fallback", () => {
+    expect(chatStore).toContain("runSummarizerWithPolicy({");
+    expect(chatStore).toContain("deterministicFallback:");
+    expect(chatStore).toContain("buildDeterministicFallbackSummary(prunable)");
+  });
+
+  it("no-drop on abort: returns before replacing messages, enters cooldown", () => {
+    expect(chatStore).toContain('summaryOutcome.status === "aborted"');
+    expect(chatStore).toContain("compactionCooldown.enter(conversationId");
+    // The abort branch must return before the message-replacement setState.
+    const abortIdx = chatStore.indexOf('summaryOutcome.status === "aborted"');
+    const replaceIdx = chatStore.indexOf(
+      'setState("messages", conversationId, toPreserve)',
+    );
+    expect(abortIdx).toBeGreaterThan(0);
+    expect(replaceIdx).toBeGreaterThan(abortIdx);
+  });
+
+  it("gates auto-compaction on the cooldown in checkAutoCompact", () => {
+    expect(chatStore).toContain("compactionCooldown.isCoolingDown(conversationId");
+  });
+});


### PR DESCRIPTION
Closes #2106.

## Problem
Summarization is the shared point of failure for compaction. The agent path retried **only on auth refresh**; the chat path had **no retry** and just set `Failed to compact conversation`. Neither had a fallback model, a deterministic local summary, or a cooldown — so a summarizer/provider incident meant repeated failed calls and risked dropping history.

## Fix
New shared policy `src/lib/compaction/summarizer-policy.ts`:
- **`runSummarizerWithPolicy()`** — primary model → auth-refresh retry → fallback model(s) → deterministic local summary → **no-drop abort**. Invalid/empty summaries are treated as failures and fall through.
- **`buildDeterministicFallbackSummary()`** — a conservative, clearly-marked (`[FALLBACK SUMMARY — …]`) summary built only from observable facts (latest user ask, tool names that ran, file/resource identifiers). Never asserts completed work — reuses the anti-fabrication stance.
- **`CompactionCooldown`** — per-conversation backoff (default 60s) so auto-compact stops hammering a failing summarizer.

## Wiring
- **agent.store.ts** — summary runs through the policy with a fallback model (`anthropic/claude-3-5-sonnet`). On **abort** the serving session is left intact (no terminate/replace) and a cooldown is set; `kickPredictiveCompact` (which both the 70% predictive and 85% reactive-auto triggers route through) skips while in cooldown. `compactAndRetry` (user-blocking) is **not** cooldown-gated.
- **chat.store.ts** — summary runs through the policy with a deterministic fallback. On **abort**, messages are not replaced (no-drop) and a cooldown is set; `checkAutoCompact` skips while in cooldown. Manual compaction is not gated.

## Acceptance criteria
- [x] Shared summarizer policy for chat + agent
- [x] Primary attempt, auth-refresh retry, fallback model retry, deterministic local fallback, no-drop abort
- [x] If no LLM/deterministic summary can be produced, history is left intact
- [x] Failed attempts set a per-conversation cooldown so auto-compact backs off
- [x] Fallback summaries marked incomplete with concrete continuity fields
- [x] Session/UI state surfaces a concise warning on abort
- [x] Tests: primary→fallback success, transient-failure cooldown, deterministic fallback, no-drop abort, chat/agent parity

## Tests
- `tests/unit/compaction-summarizer-policy.test.ts` (8) + `tests/unit/compaction-summarizer-wiring.test.ts`
- Full suite green: **214 files / 1537 tests**

Builds on #2103 + #2104 + #2105 (already merged).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com