### PR TITLE
fix(compaction): align synthetic tail with token budget (#2111)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -116,7 +116,11 @@ const AGGRESSIVE_RETRY_TAIL_RATIO = 0.15;
  * fallback. #2106.
  */
 const SUMMARY_PRIMARY_MODEL = "anthropic/claude-sonnet-4";
-const SUMMARY_FALLBACK_MODELS = ["anthropic/claude-3-5-sonnet"];
+// Fast, cheap model recognized by the seren provider catalog — ideal for a
+// fallback summarizer. A model id outside the catalog/migration map would be
+// rejected by the gateway, dead-ending the fallback tier before the
+// deterministic local summary. #2111.
+const SUMMARY_FALLBACK_MODELS = ["anthropic/claude-haiku-4.5"];
 
 /**
  * Global cap = 1 simultaneous predictive compaction across the whole app.
@@ -4093,7 +4097,18 @@ export const agentStore = {
         ? `Prior work summary:\n${summary}\n\n<prior_messages>\n${preservedContext}\n</prior_messages>`
         : `Prior work summary:\n${summary}`;
 
-      const userTurnCount = Math.max(1, Math.ceil(toPreserve.length / 2));
+      // The synthetic-transcript builder interprets this as a count of REAL
+      // user turns to keep from the parent JSONL (findCutIndex in
+      // synthetic-transcript.mjs). Now that the tail is token-budgeted (#2104),
+      // toPreserve has a variable mix of user/assistant/tool messages, so
+      // `length / 2` no longer tracks its user-turn span — overcounting in a
+      // tool-heavy tail would preserve older turns the summary already covers,
+      // duplicating context and risking re-overflow. Count the real user turns
+      // actually in the token-selected tail. #2111.
+      const userTurnCount = Math.max(
+        1,
+        toPreserve.filter((m) => m.type === "user").length,
+      );
       const syntheticEnabled =
         settingsStore.settings.compactSyntheticTranscript &&
         agentType === "claude-code";

--- a/tests/unit/synthetic-userturn-count.test.ts
+++ b/tests/unit/synthetic-userturn-count.test.ts
@@ -1,0 +1,28 @@
+// ABOUTME: Regression test for #2111 — synthetic-transcript user-turn count must
+// ABOUTME: align with the token-budgeted tail, and the fallback model must be in-catalog.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStore = readFileSync(resolve("src/stores/agent.store.ts"), "utf-8");
+
+describe("#2111 synthetic-transcript boundary matches the token-budgeted tail", () => {
+  it("derives userTurnCount from the real user turns in toPreserve, not length/2", () => {
+    // findCutIndex (synthetic-transcript.mjs) treats this as a count of REAL
+    // user turns; under #2104's token-budgeted tail, length/2 diverges.
+    expect(agentStore).toContain(
+      'toPreserve.filter((m) => m.type === "user").length',
+    );
+    expect(agentStore).not.toContain("Math.ceil(toPreserve.length / 2)");
+  });
+});
+
+describe("#2111 fallback summarizer model is in the seren catalog", () => {
+  it("uses a recognized fallback model id, not the unlisted claude-3-5-sonnet", () => {
+    expect(agentStore).toContain(
+      'SUMMARY_FALLBACK_MODELS = ["anthropic/claude-haiku-4.5"]',
+    );
+    expect(agentStore).not.toContain("anthropic/claude-3-5-sonnet");
+  });
+});


### PR DESCRIPTION
Closes #2111. Found by the post-merge audit of #2103–#2106.

## Problem
#2104 made the compaction tail **token-budgeted** (variable size), but the claude-code **synthetic-transcript** path still derived its boundary from a message-count heuristic:
- `src/stores/agent.store.ts` `userTurnCount = Math.max(1, Math.ceil(toPreserve.length / 2))`
- `bin/browser-local/synthetic-transcript.mjs:36-44` `findCutIndex` interprets that as a count of **real user turns**.

Pre-#2104 (`toPreserve` = 10 messages) `ceil(10/2)=5` roughly matched. Post-#2104, a tool-heavy `toPreserve` has far fewer user turns than `length/2`, so the synthetic JSONL preserves **more** user turns than the token boundary intended — turns the structured summary already covers — duplicating context and risking re-overflow in the **default** claude-code path.

## Fix
Count the real user turns actually present in the token-selected tail:
```ts
const userTurnCount = Math.max(1, toPreserve.filter((m) => m.type === "user").length);
```

Also switch the fallback summarizer model from the unlisted `anthropic/claude-3-5-sonnet` (not in the seren `DEFAULT_MODELS`/migration map) to `anthropic/claude-haiku-4.5` (in-catalog, fast/cheap) so the fallback tier is actually reachable before the deterministic local summary.

## Tests
- `tests/unit/synthetic-userturn-count.test.ts`
- Full suite green: **215 files / 1539 tests**

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com