### PR TITLE
fix(compaction): act on over-budget tail flag (#2113)

### DIFF
--- a/src/lib/compaction/prune.ts
+++ b/src/lib/compaction/prune.ts
@@ -197,3 +197,40 @@ export function pruneCompactedHistory(
   stats.tokensAfter = sumTokens(out, protectedFrom);
   return { messages: out, stats };
 }
+
+export interface TailReliefResult {
+  /** The tail with its reducible payloads pruned. */
+  messages: PrunableMessage[];
+  /** Estimated tail tokens before pruning. */
+  tailTokensBefore: number;
+  /** Estimated tail tokens after pruning. */
+  tailTokensAfter: number;
+  /** True when the pruned tail still exceeds `tailBudget` (irreducible content). */
+  stillOverBudget: boolean;
+  stats: PruneStats;
+}
+
+/**
+ * Relieve an over-budget preserved tail by pruning its reducible payloads —
+ * stale media, duplicate/large tool results, oversized tool-call arguments —
+ * across the whole tail (no protected region). Used when
+ * `selectCompactionWindow` reports `overBudget`: summarizing the prefix cannot
+ * shrink a tail the boundary was forced to keep, so the tail itself is pruned.
+ * Plain user/assistant text is never truncated, so a verbatim oversized message
+ * can remain over budget — reported via `stillOverBudget` so the caller can
+ * surface it instead of silently leaving the context gauge pegged. #2113.
+ */
+export function relieveOverBudgetTail(
+  tail: PrunableMessage[],
+  tailBudget: number,
+  options: PruneOptions = {},
+): TailReliefResult {
+  const pruned = pruneCompactedHistory(tail, options);
+  return {
+    messages: pruned.messages,
+    tailTokensBefore: pruned.stats.tokensBefore,
+    tailTokensAfter: pruned.stats.tokensAfter,
+    stillOverBudget: pruned.stats.tokensAfter > tailBudget,
+    stats: pruned.stats,
+  };
+}

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3880,9 +3880,21 @@ export const agentStore = {
     const toCompact = messages.slice(0, tailWindow.cutIndex);
     const toPreserve = messages.slice(tailWindow.cutIndex);
     if (toCompact.length === 0) {
-      console.info(
-        "[AgentStore] Token budget preserves the whole tail — nothing to compact",
-      );
+      if (tailWindow.overBudget) {
+        // Soft-ceiling (#2113): the anchored tail alone exceeds the budget and
+        // there is no older prefix to summarize. The serving transcript is left
+        // intact — the agent runtime manages its own context window, and the
+        // post-compaction prepend is already per-message bounded on the normal
+        // path — but surface the condition so a stuck context gauge is visible
+        // instead of being reported as plain "nothing to compact".
+        console.warn(
+          `[AgentStore] over-budget tail with no compactable prefix (tail ${tailWindow.tailTokens} > budget ${tailWindow.tailBudget}); serving transcript left intact`,
+        );
+      } else {
+        console.info(
+          "[AgentStore] Token budget preserves the whole tail — nothing to compact",
+        );
+      }
       return { outcome: "skipped_nothing_to_compact" };
     }
 

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -6,6 +6,7 @@ import { isLikelyAuthError } from "@/lib/auth-errors";
 import {
   type PrunableMessage,
   pruneCompactedHistory,
+  relieveOverBudgetTail,
 } from "@/lib/compaction/prune";
 import {
   buildDeterministicFallbackSummary,
@@ -704,13 +705,58 @@ export const chatStore = {
         minTailMessages: 2,
       });
       const toCompact = messages.slice(0, tailWindow.cutIndex);
-      const toPreserve = messages.slice(tailWindow.cutIndex);
-      if (toCompact.length === 0) {
-        // The whole tail fits the budget — usage is low enough that there is
-        // nothing worth compacting this pass.
-        console.log(
-          "[chatStore] Token budget preserves the whole tail — nothing to compact",
+      let toPreserve = messages.slice(tailWindow.cutIndex);
+
+      // Act on the soft-ceiling flag (#2113). When the anchored tail itself
+      // exceeds the budget, summarizing the prefix cannot clear it — so prune
+      // the tail's reducible payloads (stale media) in place. Plain user text is
+      // never truncated, so a verbatim oversized message can stay over budget;
+      // surface that instead of silently leaving the context gauge pegged.
+      if (tailWindow.overBudget) {
+        const relief = relieveOverBudgetTail(
+          toPreserve.map((m) => ({
+            id: m.id,
+            role:
+              m.role === "user" || m.role === "assistant" || m.role === "system"
+                ? m.role
+                : "other",
+            content: m.content,
+            imageParts: m.images?.length ?? 0,
+          })),
+          tailWindow.tailBudget,
         );
+        toPreserve = toPreserve.map((m, i) => {
+          const pruned = relief.messages[i];
+          if ((m.images?.length ?? 0) > 0 && (pruned.imageParts ?? 0) === 0) {
+            return { ...m, images: [], content: pruned.content };
+          }
+          return m;
+        });
+        console.log(
+          `[chatStore] over-budget tail pruned ${relief.tailTokensBefore}->${relief.tailTokensAfter} tokens`,
+        );
+        if (relief.stillOverBudget) {
+          console.warn(
+            "[chatStore] preserved tail still exceeds budget after pruning (irreducible content) — gauge may stay elevated",
+          );
+        }
+      }
+
+      if (toCompact.length === 0) {
+        if (tailWindow.overBudget) {
+          // No older prefix to summarize, but the tail relief above shrank
+          // reducible payloads — persist it so the gauge reflects the drop.
+          setState("messages", conversationId, toPreserve);
+          console.log(
+            "[chatStore] no compactable prefix; persisted pruned over-budget tail",
+          );
+        } else {
+          // The whole tail fits the budget — usage is low enough that there is
+          // nothing worth compacting this pass.
+          console.log(
+            "[chatStore] Token budget preserves the whole tail — nothing to compact",
+          );
+        }
         return;
       }
 

--- a/tests/unit/compaction-prune.test.ts
+++ b/tests/unit/compaction-prune.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   type PrunableMessage,
   pruneCompactedHistory,
+  relieveOverBudgetTail,
   truncateJsonArgs,
 } from "@/lib/compaction/prune";
 
@@ -109,5 +110,50 @@ describe("#2105 pruneCompactedHistory — protected tail and token reduction", (
     expect(out[2].content).toBe("keep me");
     expect(out[2].imageParts).toBe(1);
     expect(stats.tokensAfter).toBeLessThan(stats.tokensBefore);
+  });
+});
+
+describe("#2113 relieveOverBudgetTail — acts on the over-budget tail flag", () => {
+  it("shrinks a tail with reducible payloads and tracks the budget", () => {
+    const big = `head line\n${"x".repeat(6000)}`;
+    const tail: PrunableMessage[] = [
+      tool("t1", "read_file", big),
+      tool("t2", "read_file", big), // duplicate of t1
+      { id: "u1", role: "user", content: "continue" },
+    ];
+    const relieved = relieveOverBudgetTail(tail, 0);
+    // Reducible payloads (duplicate + large tool result) were pruned.
+    expect(relieved.tailTokensAfter).toBeLessThan(relieved.tailTokensBefore);
+    // budget 0 -> still over budget after pruning.
+    expect(relieved.stillOverBudget).toBe(true);
+    // The same pruned tail is within a generous budget.
+    expect(
+      relieveOverBudgetTail(tail, Number.MAX_SAFE_INTEGER).stillOverBudget,
+    ).toBe(false);
+  });
+
+  it("never truncates verbatim user text and reports it still over budget", () => {
+    const hugeText = "word ".repeat(4000);
+    const tail: PrunableMessage[] = [
+      { id: "u1", role: "user", content: hugeText },
+    ];
+    const relieved = relieveOverBudgetTail(tail, 50);
+    // Plain user text is irreducible — no reduction, content preserved verbatim.
+    expect(relieved.tailTokensAfter).toBe(relieved.tailTokensBefore);
+    expect(relieved.messages[0].content).toBe(hugeText);
+    expect(relieved.stillOverBudget).toBe(true);
+  });
+
+  it("strips stale media in the tail but keeps the latest media-bearing turn", () => {
+    const tail: PrunableMessage[] = [
+      { id: "u1", role: "user", content: "old shot", imageParts: 2 },
+      { id: "u2", role: "user", content: "newest shot", imageParts: 1 },
+    ];
+    const relieved = relieveOverBudgetTail(tail, 0);
+    expect(relieved.stats.strippedMediaParts).toBe(2);
+    expect(relieved.messages[0].imageParts).toBe(0);
+    // Latest media-bearing turn keeps its media for the active task.
+    expect(relieved.messages[1].imageParts).toBe(1);
+    expect(relieved.tailTokensAfter).toBeLessThan(relieved.tailTokensBefore);
   });
 });

--- a/tests/unit/compaction-summarizer-wiring.test.ts
+++ b/tests/unit/compaction-summarizer-wiring.test.ts
@@ -38,9 +38,13 @@ describe("#2106 chat compaction runs the resilient summarizer policy", () => {
   it("no-drop on abort: returns before replacing messages, enters cooldown", () => {
     expect(chatStore).toContain('summaryOutcome.status === "aborted"');
     expect(chatStore).toContain("compactionCooldown.enter(conversationId");
-    // The abort branch must return before the message-replacement setState.
+    // The main (post-summary) message-replacement must come after the abort
+    // check so an aborted summary never drops messages. #2113 added a separate,
+    // earlier persist in the no-prefix over-budget branch that returns before
+    // summarization, so assert against the LAST replacement — the post-summary
+    // one this invariant is about.
     const abortIdx = chatStore.indexOf('summaryOutcome.status === "aborted"');
-    const replaceIdx = chatStore.indexOf(
+    const replaceIdx = chatStore.lastIndexOf(
       'setState("messages", conversationId, toPreserve)',
     );
     expect(abortIdx).toBeGreaterThan(0);

--- a/tests/unit/compaction-window-wiring.test.ts
+++ b/tests/unit/compaction-window-wiring.test.ts
@@ -36,3 +36,14 @@ describe("#2104 agent compaction uses the token-budgeted selector", () => {
     expect(agentStore).toContain("tailRatio: AGGRESSIVE_RETRY_TAIL_RATIO");
   });
 });
+
+describe("#2113 compaction acts on the over-budget tail flag", () => {
+  it("chat prunes and persists an over-budget anchored tail", () => {
+    expect(chatStore).toContain("tailWindow.overBudget");
+    expect(chatStore).toContain("relieveOverBudgetTail(");
+  });
+
+  it("agent surfaces an over-budget tail with no compactable prefix", () => {
+    expect(agentStore).toContain("tailWindow.overBudget");
+  });
+});


### PR DESCRIPTION
## What

Makes both compaction callers act on the `selectCompactionWindow` `overBudget` flag (introduced in #2104 / PR #2108), which they previously ignored.

Closes #2113.

## Why

`selectCompactionWindow` flags `overBudget` when the forced preserved tail — held by the min-tail floor, the latest-user anchor, or whole tool/turn group integrity — costs more than the tail budget. When a single anchored message exceeds the budget, the cut lands at index 0, `toCompact` is empty, and compaction no-ops. The context gauge then never clears (P2 — safe, no wedge, but the gauge stays pegged).

## How

- **`relieveOverBudgetTail` (`prune.ts`)** — a thin, tested wrapper over the existing `pruneCompactedHistory` that prunes a tail's *reducible* payloads (stale media, duplicate/large tool results, oversized tool-call args) and reports `stillOverBudget`. Plain user/assistant text is never truncated.
- **Chat** — on `overBudget`, prune the preserved tail's media in place and persist it, even when there is no prefix to summarize. Irreducible verbatim user text is surfaced via a warning instead of a silent no-op.
- **Agent** — the post-compaction prepend is already per-message bounded (2000/500 chars), so the normal path already mitigates an over-budget tail. The only gap is the no-compactable-prefix branch — surface the condition there instead of reporting plain "nothing to compact". The serving transcript is left intact (the agent runtime manages its own context window).

## Out of scope

Truncating a user's verbatim active request, and respawning the live agent serving session from a pruned transcript when there is no summary prefix (higher risk; the agent runtime already does its own context management).

## Tests

- `compaction-prune.test.ts` — 3 new behavioral tests for `relieveOverBudgetTail`: reducible payloads shrink + budget tracking, verbatim user text never truncated (reports `stillOverBudget`), stale media stripped while the latest media turn is kept.
- `compaction-window-wiring.test.ts` — locks both callers acting on `tailWindow.overBudget`.
- `compaction-summarizer-wiring.test.ts` — updated the #2106 chat no-drop guard to assert against the last (post-summary) message replacement, since the new no-prefix branch adds an earlier persist that returns before summarization. Intent preserved.

**Full unit suite: 215 files / 1544 tests pass. Biome clean on changed files. `tsc` adds no new errors (the 4 pre-existing PdfViewer/test errors are unchanged from `main`).**

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
