### PR TITLE
fix(compaction): count chat request overhead

### DIFF
--- a/src/lib/compaction/chat-request-accounting.ts
+++ b/src/lib/compaction/chat-request-accounting.ts
@@ -1,0 +1,129 @@
+// ABOUTME: Chat/orchestrator request-envelope token accounting for compaction (#2115).
+// ABOUTME: Counts request overhead beyond visible messages: system, tools, skills, summaries.
+
+import {
+  type AccountedMessage,
+  estimateAccountedMessageTokens,
+  estimateValueTokens,
+} from "@/lib/compaction/token-accounting";
+import { estimateTokens } from "@/lib/token-counter";
+
+/**
+ * Small synchronous shape for thread-effective skills. The Rust orchestrator
+ * loads full SKILL.md content only after query classification, so the UI gauge
+ * cannot know exact skill prompt bytes ahead of time. This metadata is the
+ * exact frontend payload sent in `installed_skills`, and future cached
+ * SKILL.md estimates can be added without changing chat-store call sites.
+ */
+export interface ChatSkillEstimate {
+  slug: string;
+  name: string;
+  description?: string;
+  tags?: string[];
+  path?: string;
+}
+
+export interface ChatRequestTokenEstimateInput {
+  messages: AccountedMessage[];
+  /** Static/system prompt content known synchronously by the UI. */
+  systemPrompt?: string;
+  /** Tool schemas/capabilities sent to the orchestrator. */
+  toolSchemas?: unknown;
+  /** Thread-effective skill metadata sent to the orchestrator. */
+  skills?: ChatSkillEstimate[];
+  /** Compacted summary injected as a system history message. */
+  compactedSummary?: string | null;
+  /** Conservative reserve for async memory/repo/semantic context. */
+  dynamicContextReserveTokens?: number;
+}
+
+export interface ChatRequestTokenEstimate {
+  totalTokens: number;
+  messageTokens: number;
+  systemPromptTokens: number;
+  toolSchemaTokens: number;
+  skillTokens: number;
+  compactedSummaryTokens: number;
+  dynamicContextReserveTokens: number;
+}
+
+/**
+ * Stable approximation of the Rust ChatModelWorker's always-on system prompt:
+ * current date, Seren-auth/tool rules, file-output rules, publisher routing,
+ * and tone behavior. The exact prompt is assembled in Rust, but this captures
+ * its persistent token load so the gauge no longer counts only transcript text.
+ */
+export const CHAT_ORCHESTRATOR_BASE_SYSTEM_PROMPT =
+  "Current date (UTC): <date>. Use this date for dated artifacts unless the user supplies a different date.\n\n" +
+  "You are a helpful AI assistant running inside Seren Desktop. The user is authenticated and tool calls are pre-authenticated through Seren Gateway. Never ask for API keys or environment variables; call tools directly.\n\n" +
+  "File output rules: respect requested paths and filenames; expand ~/ as home; when asked for a PDF, use write_pdf_from_html directly with complete self-contained HTML.\n\n" +
+  "Publisher-routing rules: prefer connected gateway publisher tools for Gmail, GitHub, Slack, Jira, and similar services over browser automation when a matching gateway publisher tool is available.\n\n" +
+  "Tone and behavior: be concise; do not use empty praise; push back honestly; never deny tools before checking the actual tool list.";
+
+function estimateMessages(messages: AccountedMessage[]): number {
+  let total = 0;
+  for (const message of messages) {
+    total += estimateAccountedMessageTokens(message);
+  }
+  return total;
+}
+
+function estimateSkills(skills: ChatSkillEstimate[] | undefined): number {
+  if (!skills?.length) return 0;
+  return estimateValueTokens(
+    skills.map((skill) => ({
+      slug: skill.slug,
+      name: skill.name,
+      description: skill.description ?? "",
+      tags: skill.tags ?? [],
+      path: skill.path ?? "",
+    })),
+  );
+}
+
+function estimateCompactedSummary(summary: string | null | undefined): number {
+  if (!summary) return 0;
+  return estimateTokens(
+    `Here is a summary of the earlier part of this conversation:\n\n${summary}`,
+  );
+}
+
+/**
+ * Estimate the full chat request envelope used by the compaction gauge and
+ * auto-compact trigger. This intentionally counts more than visible messages:
+ * the actual request includes a system prompt, tool schemas, skill metadata,
+ * compacted-summary injection, and sometimes async memory/repo context.
+ */
+export function estimateChatRequestTokens(
+  input: ChatRequestTokenEstimateInput,
+): ChatRequestTokenEstimate {
+  const messageTokens = estimateMessages(input.messages);
+  const systemPromptTokens = estimateTokens(
+    input.systemPrompt ?? CHAT_ORCHESTRATOR_BASE_SYSTEM_PROMPT,
+  );
+  const toolSchemaTokens = estimateValueTokens(input.toolSchemas);
+  const skillTokens = estimateSkills(input.skills);
+  const compactedSummaryTokens = estimateCompactedSummary(
+    input.compactedSummary,
+  );
+  const dynamicContextReserveTokens = Math.max(
+    0,
+    input.dynamicContextReserveTokens ?? 0,
+  );
+
+  return {
+    totalTokens:
+      messageTokens +
+      systemPromptTokens +
+      toolSchemaTokens +
+      skillTokens +
+      compactedSummaryTokens +
+      dynamicContextReserveTokens,
+    messageTokens,
+    systemPromptTokens,
+    toolSchemaTokens,
+    skillTokens,
+    compactedSummaryTokens,
+    dynamicContextReserveTokens,
+  };
+}

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -4,6 +4,10 @@
 import { createStore } from "solid-js/store";
 import { isLikelyAuthError } from "@/lib/auth-errors";
 import {
+  type ChatSkillEstimate,
+  estimateChatRequestTokens,
+} from "@/lib/compaction/chat-request-accounting";
+import {
   type PrunableMessage,
   pruneCompactedHistory,
   relieveOverBudgetTail,
@@ -21,7 +25,6 @@ import {
 import {
   type AccountedMessage,
   estimateAccountedMessageTokens,
-  estimateRequestTokens,
 } from "@/lib/compaction/token-accounting";
 import {
   type CompactionWindowItem,
@@ -41,11 +44,16 @@ import {
   updateConversation as updateConversationDb,
 } from "@/lib/tauri-bridge";
 import { getModelContextLimit } from "@/lib/token-counter";
+import { getAllTools } from "@/lib/tools";
 import { refreshAccessToken } from "@/services/auth";
 import type { Message } from "@/services/chat";
 import { sendMessage } from "@/services/chat";
 import type { AgentType } from "@/services/providers";
+import { authStore } from "@/stores/auth.store";
+import { fileTreeState } from "@/stores/fileTree";
 import { providerStore } from "@/stores/provider.store";
+import { settingsStore } from "@/stores/settings.store";
+import { skillsStore } from "@/stores/skills.store";
 
 const DEFAULT_MODEL = "arcee-ai/trinity-large-thinking";
 const MAX_MESSAGES_PER_CONVERSATION = 1000;
@@ -172,6 +180,62 @@ function accountedChatMessage(m: Message): AccountedMessage {
   return { content: m.content, imageParts: m.images?.length ?? 0 };
 }
 
+const MEMORY_CONTEXT_RESERVE_TOKENS = 2048;
+const PROJECT_CONTEXT_RESERVE_TOKENS = 2048;
+
+function skillToEstimate(skill: {
+  slug: string;
+  name: string;
+  description?: string;
+  tags?: string[];
+  path?: string;
+}): ChatSkillEstimate {
+  return {
+    slug: skill.slug,
+    name: skill.name,
+    description: skill.description,
+    tags: skill.tags,
+    path: skill.path,
+  };
+}
+
+function estimateDynamicChatContextReserve(projectRoot: string | null): number {
+  let reserve = 0;
+  if (settingsStore.get("memoryEnabled") && authStore.isAuthenticated) {
+    reserve += MEMORY_CONTEXT_RESERVE_TOKENS;
+  }
+  // The Rust worker can inject live repo context, and the legacy JS path can
+  // inject semantic code context, when a project is open. Exact bytes are async
+  // and query-dependent, so reserve a conservative synchronous budget. #2115.
+  if (projectRoot) {
+    reserve += PROJECT_CONTEXT_RESERVE_TOKENS;
+  }
+  return reserve;
+}
+
+function estimateActiveChatRequestTokens({
+  conversationId,
+  messages,
+  compactedSummary,
+}: {
+  conversationId: string | null;
+  messages: Message[];
+  compactedSummary?: CompactedSummary;
+}): number {
+  const projectRoot = fileTreeState.rootPath;
+  const skills = skillsStore
+    .getThreadSkills(projectRoot, conversationId)
+    .map(skillToEstimate);
+
+  return estimateChatRequestTokens({
+    messages: messages.map(accountedChatMessage),
+    toolSchemas: getAllTools(),
+    skills,
+    compactedSummary: compactedSummary?.content,
+    dynamicContextReserveTokens: estimateDynamicChatContextReserve(projectRoot),
+  }).totalTokens;
+}
+
 export const chatStore = {
   // ============================================================================
   // Getters
@@ -255,8 +319,10 @@ export const chatStore = {
    * images at a flat per-image cost (#2105).
    */
   get estimatedTokens(): number {
-    return estimateRequestTokens({
-      messages: this.messages.map(accountedChatMessage),
+    return estimateActiveChatRequestTokens({
+      conversationId: state.activeConversationId,
+      messages: this.messages,
+      compactedSummary: this.compactedSummary,
     });
   },
 
@@ -655,8 +721,10 @@ export const chatStore = {
   shouldCompact(thresholdPercent: number): boolean {
     const limit = getModelContextLimit(this.selectedModel);
     if (limit <= 0) return false;
-    const tokens = estimateRequestTokens({
-      messages: this.messages.map(accountedChatMessage),
+    const tokens = estimateActiveChatRequestTokens({
+      conversationId: state.activeConversationId,
+      messages: this.messages,
+      compactedSummary: this.compactedSummary,
     });
     return (tokens / limit) * 100 >= thresholdPercent;
   },

--- a/tests/unit/chat-request-accounting.test.ts
+++ b/tests/unit/chat-request-accounting.test.ts
@@ -1,0 +1,84 @@
+// ABOUTME: Critical coverage for #2115 chat compaction request-overhead accounting.
+// ABOUTME: Ensures tool schemas, system prompt, and skills affect the trigger estimate.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  estimateChatRequestTokens,
+  type ChatSkillEstimate,
+} from "@/lib/compaction/chat-request-accounting";
+
+describe("#2115 estimateChatRequestTokens", () => {
+  it("counts system prompt, tool schemas, and skill metadata even when messages are unchanged", () => {
+    const messages = [{ content: "same user-visible conversation" }];
+    const base = estimateChatRequestTokens({ messages });
+
+    const skills: ChatSkillEstimate[] = [
+      {
+        slug: "large-skill",
+        name: "Large Skill",
+        description: "z".repeat(4000),
+        tags: ["automation", "context"],
+        path: "/Users/example/.config/seren/skills/large-skill/SKILL.md",
+      },
+    ];
+
+    const withOverhead = estimateChatRequestTokens({
+      messages,
+      systemPrompt: "x".repeat(4000),
+      toolSchemas: [
+        {
+          type: "function",
+          function: {
+            name: "large_tool",
+            description: "y".repeat(4000),
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+            },
+          },
+        },
+      ],
+      skills,
+    });
+
+    expect(withOverhead.messageTokens).toBe(base.messageTokens);
+    expect(withOverhead.systemPromptTokens).toBeGreaterThan(900);
+    expect(withOverhead.toolSchemaTokens).toBeGreaterThan(900);
+    expect(withOverhead.skillTokens).toBeGreaterThan(900);
+    expect(withOverhead.totalTokens).toBeGreaterThan(base.totalTokens + 2700);
+  });
+
+  it("includes compacted-summary injection and optional dynamic context reserve", () => {
+    const estimate = estimateChatRequestTokens({
+      messages: [{ content: "tail" }],
+      compactedSummary:
+        "ACTIVE_TASK: audit compaction\nRESOURCES: src/stores/chat.store.ts",
+      dynamicContextReserveTokens: 2048,
+    });
+
+    expect(estimate.compactedSummaryTokens).toBeGreaterThan(0);
+    expect(estimate.dynamicContextReserveTokens).toBe(2048);
+    expect(estimate.totalTokens).toBe(
+      estimate.messageTokens +
+        estimate.systemPromptTokens +
+        estimate.toolSchemaTokens +
+        estimate.skillTokens +
+        estimate.compactedSummaryTokens +
+        estimate.dynamicContextReserveTokens,
+    );
+  });
+});
+
+describe("#2115 chatStore wiring", () => {
+  it("uses chat request accounting instead of message-only request accounting", () => {
+    const chatStore = readFileSync(
+      resolve("src/stores/chat.store.ts"),
+      "utf-8",
+    );
+
+    expect(chatStore).toContain("estimateActiveChatRequestTokens(");
+    expect(chatStore).not.toContain("estimateRequestTokens({\n      messages");
+  });
+});

--- a/tests/unit/compaction-pruning-wiring.test.ts
+++ b/tests/unit/compaction-pruning-wiring.test.ts
@@ -30,7 +30,8 @@ describe("#2105 chat compaction prunes history and counts media in the gauge", (
   });
 
   it("the gauge and the trigger count attached images via request accounting", () => {
-    expect(chatStore).toContain("estimateRequestTokens(");
+    expect(chatStore).toContain("estimateActiveChatRequestTokens(");
+    expect(chatStore).toContain("estimateChatRequestTokens({");
     expect(chatStore).toContain("accountedChatMessage");
     // The content-only counter is no longer the source of truth for the gauge.
     expect(chatStore).not.toContain("estimateConversationTokens(this.messages)");


### PR DESCRIPTION
## Summary

Fixes #2115.

Adds chat/orchestrator request-envelope token accounting so the chat context gauge and auto-compact trigger count more than visible message text:

- base orchestrator/system prompt overhead
- tool schema payloads from the active tool inventory
- thread-effective skill metadata sent in capabilities
- compacted-summary system injection
- bounded reserve for async memory/repo/semantic context

## Audit result

The original issue was confirmed: `chatStore.estimatedTokens` and `shouldCompact()` used message-only request accounting even though the orchestrator request can include large tool definitions, skill metadata/content, compacted-summary system messages, memory context, repo context, and semantic context. This fix routes both gauge and trigger through one helper, `estimateActiveChatRequestTokens()`, backed by an auditable token breakdown.

This intentionally uses conservative synchronous accounting. Exact Rust-side skill content and BM25-selected tool subset are query-dependent, so the UI counts available tool schemas and thread-effective skill metadata rather than trying to run async request construction inside a getter.

## Tests

- `/Users/taariqlewis/Projects/Seren_Projects/seren-desktop/node_modules/.bin/vitest run tests/unit/chat-request-accounting.test.ts`
- `/Users/taariqlewis/Projects/Seren_Projects/seren-desktop/node_modules/.bin/vitest run tests/unit/chat-request-accounting.test.ts tests/unit/compaction-pruning-wiring.test.ts tests/unit/compaction-token-accounting.test.ts tests/unit/compaction-window.test.ts tests/unit/compaction-summary.test.ts tests/unit/compaction-summarizer-policy.test.ts`
- `/Users/taariqlewis/Projects/Seren_Projects/seren-desktop/node_modules/.bin/biome check src/lib/compaction/chat-request-accounting.ts src/stores/chat.store.ts tests/unit/chat-request-accounting.test.ts tests/unit/compaction-pruning-wiring.test.ts`

Typecheck was also run and still reports only the known unrelated PDF/provider declaration failures from main.
