### PR TITLE
feat(stt): add meeting transcript foundations

### DIFF
--- a/src-tauri/src/audio/chunker.rs
+++ b/src-tauri/src/audio/chunker.rs
@@ -1,0 +1,218 @@
+// ABOUTME: Energy-based VAD chunker for near-real-time Whisper windows.
+// ABOUTME: Splits 16-bit mono PCM on sustained silence with max-window guards.
+
+#[derive(Debug, Clone, Copy)]
+pub struct ChunkCfg {
+    pub sample_rate: u32,
+    pub frame_ms: u32,
+    pub silence_ms: u32,
+    pub min_window_ms: u32,
+    pub max_window_ms: u32,
+    pub rms_threshold: f32,
+}
+
+impl Default for ChunkCfg {
+    fn default() -> Self {
+        Self {
+            sample_rate: 16_000,
+            frame_ms: 20,
+            silence_ms: 500,
+            min_window_ms: 250,
+            max_window_ms: 20_000,
+            rms_threshold: 350.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Chunk {
+    pub start_ms: u32,
+    pub end_ms: u32,
+    pub samples: Vec<i16>,
+}
+
+pub fn chunk(samples: &[i16], cfg: ChunkCfg) -> Vec<Chunk> {
+    if samples.is_empty() || cfg.sample_rate == 0 || cfg.frame_ms == 0 {
+        return Vec::new();
+    }
+
+    let frame_samples = samples_for_ms(cfg.sample_rate, cfg.frame_ms).max(1);
+    let silence_frames_needed = (cfg.silence_ms / cfg.frame_ms).max(1);
+    let mut chunks = Vec::new();
+    let mut speech_start: Option<usize> = None;
+    let mut last_speech_end = 0usize;
+    let mut silent_frames = 0u32;
+    let mut frame_start = 0usize;
+
+    while frame_start < samples.len() {
+        let frame_end = (frame_start + frame_samples).min(samples.len());
+        let frame = &samples[frame_start..frame_end];
+        let is_speech = rms(frame) >= cfg.rms_threshold;
+
+        if is_speech {
+            if speech_start.is_none() {
+                speech_start = Some(frame_start);
+            }
+            silent_frames = 0;
+            last_speech_end = frame_end;
+        } else if speech_start.is_some() {
+            silent_frames += 1;
+        }
+
+        if let Some(start) = speech_start {
+            let current_ms = duration_ms(start, frame_end, cfg.sample_rate);
+            if current_ms >= cfg.max_window_ms {
+                push_chunk(&mut chunks, samples, start, frame_end, cfg.sample_rate);
+                speech_start = None;
+                last_speech_end = 0;
+                silent_frames = 0;
+            } else if silent_frames >= silence_frames_needed {
+                let window_ms = duration_ms(start, last_speech_end, cfg.sample_rate);
+                if window_ms >= cfg.min_window_ms {
+                    push_chunk(
+                        &mut chunks,
+                        samples,
+                        start,
+                        last_speech_end,
+                        cfg.sample_rate,
+                    );
+                }
+                speech_start = None;
+                last_speech_end = 0;
+                silent_frames = 0;
+            }
+        }
+
+        frame_start = frame_end;
+    }
+
+    if let Some(start) = speech_start {
+        let end = if last_speech_end > start {
+            last_speech_end
+        } else {
+            samples.len()
+        };
+        if duration_ms(start, end, cfg.sample_rate) >= cfg.min_window_ms {
+            push_chunk(&mut chunks, samples, start, end, cfg.sample_rate);
+        }
+    }
+
+    chunks
+}
+
+fn push_chunk(
+    chunks: &mut Vec<Chunk>,
+    samples: &[i16],
+    start: usize,
+    end: usize,
+    sample_rate: u32,
+) {
+    chunks.push(Chunk {
+        start_ms: sample_to_ms(start, sample_rate),
+        end_ms: sample_to_ms(end, sample_rate),
+        samples: samples[start..end].to_vec(),
+    });
+}
+
+fn samples_for_ms(sample_rate: u32, ms: u32) -> usize {
+    ((sample_rate as u64 * ms as u64) / 1000) as usize
+}
+
+fn sample_to_ms(sample: usize, sample_rate: u32) -> u32 {
+    ((sample as u64 * 1000) / sample_rate as u64) as u32
+}
+
+fn duration_ms(start: usize, end: usize, sample_rate: u32) -> u32 {
+    sample_to_ms(end.saturating_sub(start), sample_rate)
+}
+
+fn rms(samples: &[i16]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+
+    let sum = samples
+        .iter()
+        .map(|sample| {
+            let value = *sample as f64;
+            value * value
+        })
+        .sum::<f64>();
+
+    (sum / samples.len() as f64).sqrt() as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> ChunkCfg {
+        ChunkCfg {
+            sample_rate: 1_000,
+            frame_ms: 10,
+            silence_ms: 50,
+            min_window_ms: 40,
+            max_window_ms: 200,
+            rms_threshold: 100.0,
+        }
+    }
+
+    fn pcm(value: i16, ms: usize) -> Vec<i16> {
+        vec![value; ms]
+    }
+
+    #[test]
+    fn chunk_one_utterance_between_silences() {
+        let samples = [pcm(0, 100), pcm(1_000, 80), pcm(0, 100)].concat();
+
+        let chunks = chunk(&samples, cfg());
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].start_ms, 100);
+        assert_eq!(chunks[0].end_ms, 180);
+    }
+
+    #[test]
+    fn chunk_two_utterances_split_by_long_pause() {
+        let samples = [
+            pcm(0, 50),
+            pcm(1_000, 60),
+            pcm(0, 70),
+            pcm(1_000, 60),
+            pcm(0, 50),
+        ]
+        .concat();
+
+        let chunks = chunk(&samples, cfg());
+
+        assert_eq!(chunks.len(), 2);
+        assert_eq!((chunks[0].start_ms, chunks[0].end_ms), (50, 110));
+        assert_eq!((chunks[1].start_ms, chunks[1].end_ms), (180, 240));
+    }
+
+    #[test]
+    fn chunk_forces_split_at_max_window() {
+        let samples = [pcm(0, 20), pcm(1_000, 450), pcm(0, 20)].concat();
+
+        let chunks = chunk(&samples, cfg());
+
+        assert_eq!(chunks.len(), 3);
+        assert_eq!((chunks[0].start_ms, chunks[0].end_ms), (20, 220));
+        assert_eq!((chunks[1].start_ms, chunks[1].end_ms), (220, 420));
+        assert_eq!((chunks[2].start_ms, chunks[2].end_ms), (420, 470));
+        assert!(
+            chunks
+                .iter()
+                .all(|chunk| chunk.end_ms - chunk.start_ms <= cfg().max_window_ms)
+        );
+    }
+
+    #[test]
+    fn chunk_all_silence_returns_no_chunks() {
+        let samples = pcm(0, 500);
+
+        let chunks = chunk(&samples, cfg());
+
+        assert!(chunks.is_empty());
+    }
+}

--- a/src-tauri/src/audio/detect.rs
+++ b/src-tauri/src/audio/detect.rs
@@ -1,0 +1,58 @@
+// ABOUTME: Pure meeting auto-detect decision logic for capture arming.
+// ABOUTME: Keeps OS process probes separate from testable policy rules.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunningProcess {
+    pub name: String,
+}
+
+pub fn should_start_capture(
+    processes: &[RunningProcess],
+    mic_in_use: bool,
+    meeting_app_allowlist: &[String],
+) -> bool {
+    if mic_in_use {
+        return true;
+    }
+
+    processes.iter().any(|process| {
+        meeting_app_allowlist.iter().any(|allowed| {
+            let allowed = allowed.trim();
+            !allowed.is_empty()
+                && process
+                    .name
+                    .to_lowercase()
+                    .contains(&allowed.to_lowercase())
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_start_capture_when_mic_is_in_use() {
+        assert!(should_start_capture(&[], true, &[]));
+    }
+
+    #[test]
+    fn should_start_capture_when_allowlisted_meeting_app_runs() {
+        let processes = vec![RunningProcess {
+            name: "Zoom.exe".to_string(),
+        }];
+        let allowlist = vec!["zoom".to_string()];
+
+        assert!(should_start_capture(&processes, false, &allowlist));
+    }
+
+    #[test]
+    fn should_not_start_capture_for_unrelated_processes() {
+        let processes = vec![RunningProcess {
+            name: "Spotify.exe".to_string(),
+        }];
+        let allowlist = vec!["zoom".to_string(), "teams".to_string()];
+
+        assert!(!should_start_capture(&processes, false, &allowlist));
+    }
+}

--- a/src-tauri/src/audio/merge.rs
+++ b/src-tauri/src/audio/merge.rs
@@ -1,0 +1,101 @@
+// ABOUTME: Merges independently transcribed Me/Them streams by timestamp.
+// ABOUTME: Preserves gap segments and assigns final chronological sequence ids.
+
+use crate::audio::types::TranscriptSegment;
+
+pub fn merge_segments(
+    me: Vec<TranscriptSegment>,
+    them: Vec<TranscriptSegment>,
+) -> Vec<TranscriptSegment> {
+    let mut indexed = Vec::with_capacity(me.len() + them.len());
+    let mut index = 0usize;
+
+    for segment in me {
+        indexed.push((index, segment));
+        index += 1;
+    }
+    for segment in them {
+        indexed.push((index, segment));
+        index += 1;
+    }
+
+    indexed.sort_by(|(left_index, left), (right_index, right)| {
+        left.start_ms
+            .cmp(&right.start_ms)
+            .then_with(|| left_index.cmp(right_index))
+    });
+
+    indexed
+        .into_iter()
+        .enumerate()
+        .map(|(seq, (_, mut segment))| {
+            segment.seq = seq as i64;
+            segment
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::types::{SegmentStatus, Speaker};
+
+    fn segment(
+        speaker: Speaker,
+        seq: i64,
+        start_ms: i64,
+        status: SegmentStatus,
+    ) -> TranscriptSegment {
+        TranscriptSegment {
+            id: format!("seg-{}-{}", seq, start_ms),
+            meeting_id: "meeting-1".to_string(),
+            seq,
+            speaker,
+            text: format!("segment {}", seq),
+            start_ms,
+            end_ms: start_ms + 100,
+            status,
+            created_at: 1,
+        }
+    }
+
+    #[test]
+    fn merge_segments_orders_interleaved_timestamps() {
+        let me = vec![
+            segment(Speaker::Me, 0, 100, SegmentStatus::Ok),
+            segment(Speaker::Me, 1, 400, SegmentStatus::Ok),
+        ];
+        let them = vec![
+            segment(Speaker::Them, 0, 200, SegmentStatus::Ok),
+            segment(Speaker::Them, 1, 300, SegmentStatus::Ok),
+        ];
+
+        let merged = merge_segments(me, them);
+
+        let starts: Vec<i64> = merged.iter().map(|segment| segment.start_ms).collect();
+        let seqs: Vec<i64> = merged.iter().map(|segment| segment.seq).collect();
+        assert_eq!(starts, vec![100, 200, 300, 400]);
+        assert_eq!(seqs, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn merge_segments_keeps_stable_order_on_ties() {
+        let me = vec![segment(Speaker::Me, 0, 100, SegmentStatus::Ok)];
+        let them = vec![segment(Speaker::Them, 0, 100, SegmentStatus::Ok)];
+
+        let merged = merge_segments(me, them);
+
+        assert_eq!(merged[0].speaker, Speaker::Me);
+        assert_eq!(merged[1].speaker, Speaker::Them);
+    }
+
+    #[test]
+    fn merge_segments_preserves_gap_segments() {
+        let me = vec![segment(Speaker::Me, 0, 100, SegmentStatus::Gap)];
+        let them = vec![segment(Speaker::Them, 0, 50, SegmentStatus::Ok)];
+
+        let merged = merge_segments(me, them);
+
+        assert_eq!(merged[1].status, SegmentStatus::Gap);
+    }
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,0 +1,10 @@
+// ABOUTME: Shared audio pipeline primitives for meeting capture and dictation.
+// ABOUTME: Exposes transcript, chunking, merge, retry, and notes parsing modules.
+
+pub mod chunker;
+pub mod detect;
+pub mod merge;
+pub mod notes;
+pub mod templates;
+pub mod transcribe;
+pub mod types;

--- a/src-tauri/src/audio/notes.rs
+++ b/src-tauri/src/audio/notes.rs
@@ -1,0 +1,158 @@
+// ABOUTME: Parses Tier-1 meeting notes output into markdown plus structured data.
+// ABOUTME: Fails closed on malformed model JSON while preserving readable notes.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StructuredNotes {
+    pub summary: String,
+    pub action_items: Vec<String>,
+    pub fields: BTreeMap<String, Value>,
+}
+
+impl Default for StructuredNotes {
+    fn default() -> Self {
+        Self {
+            summary: String::new(),
+            action_items: Vec::new(),
+            fields: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ParsedNotes {
+    pub markdown: String,
+    pub structured: StructuredNotes,
+}
+
+#[derive(Debug, Deserialize)]
+struct NotesBlock {
+    summary: Option<String>,
+    action_items: Option<Vec<Value>>,
+    fields: Option<BTreeMap<String, Value>>,
+}
+
+pub fn parse_notes_output(raw: &str) -> ParsedNotes {
+    let Some((before, json, after)) = extract_json_fence(raw) else {
+        return ParsedNotes {
+            markdown: raw.trim().to_string(),
+            structured: StructuredNotes::default(),
+        };
+    };
+
+    let markdown = [before.trim(), after.trim()]
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    match serde_json::from_str::<NotesBlock>(&json) {
+        Ok(block) => ParsedNotes {
+            markdown,
+            structured: StructuredNotes {
+                summary: block.summary.unwrap_or_default(),
+                action_items: block
+                    .action_items
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(action_item_to_text)
+                    .collect(),
+                fields: block.fields.unwrap_or_default(),
+            },
+        },
+        Err(_) => ParsedNotes {
+            markdown: raw.trim().to_string(),
+            structured: StructuredNotes::default(),
+        },
+    }
+}
+
+fn extract_json_fence(raw: &str) -> Option<(&str, String, &str)> {
+    let fence_start = raw.find("```json")?;
+    let content_start = raw[fence_start..].find('\n')? + fence_start + 1;
+    let fence_end = raw[content_start..].find("```")? + content_start;
+    Some((
+        &raw[..fence_start],
+        raw[content_start..fence_end].trim().to_string(),
+        &raw[fence_end + 3..],
+    ))
+}
+
+fn action_item_to_text(value: Value) -> Option<String> {
+    match value {
+        Value::String(text) => {
+            let trimmed = text.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        Value::Object(map) => ["title", "text", "description"]
+            .iter()
+            .find_map(|key| map.get(*key).and_then(Value::as_str))
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_notes_output_extracts_markdown_and_structured_block() {
+        let raw = r#"# Notes
+
+- Good call.
+
+```json
+{
+  "summary": "Discovery call",
+  "action_items": ["Send recap", {"title": "Draft proposal"}],
+  "fields": {"company": "Acme"}
+}
+```
+"#;
+
+        let parsed = parse_notes_output(raw);
+
+        assert_eq!(parsed.markdown, "# Notes\n\n- Good call.");
+        assert_eq!(parsed.structured.summary, "Discovery call");
+        assert_eq!(
+            parsed.structured.action_items,
+            vec!["Send recap".to_string(), "Draft proposal".to_string()]
+        );
+        assert_eq!(
+            parsed
+                .structured
+                .fields
+                .get("company")
+                .and_then(Value::as_str),
+            Some("Acme")
+        );
+    }
+
+    #[test]
+    fn parse_notes_output_falls_back_when_json_missing() {
+        let raw = "# Notes\n\nNo JSON today.";
+
+        let parsed = parse_notes_output(raw);
+
+        assert_eq!(parsed.markdown, raw);
+        assert_eq!(parsed.structured, StructuredNotes::default());
+    }
+
+    #[test]
+    fn parse_notes_output_falls_back_when_json_is_malformed() {
+        let raw = "# Notes\n\n```json\n{\"summary\":\n```\n";
+
+        let parsed = parse_notes_output(raw);
+
+        assert_eq!(parsed.markdown, raw.trim());
+        assert_eq!(parsed.structured, StructuredNotes::default());
+    }
+}

--- a/src-tauri/src/audio/templates.rs
+++ b/src-tauri/src/audio/templates.rs
@@ -1,0 +1,41 @@
+// ABOUTME: Built-in Tier-1 meeting note templates for Meeting Mode.
+// ABOUTME: Provides stable ids that settings and meeting records can reference.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MeetingTemplate {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub prompt: &'static str,
+}
+
+pub const BUILT_IN_MEETING_TEMPLATES: &[MeetingTemplate] = &[
+    MeetingTemplate {
+        id: "sales_call",
+        name: "Sales Call",
+        prompt: "Summarize qualification, pain, stakeholders, objections, decision process, and next steps.",
+    },
+    MeetingTemplate {
+        id: "discovery",
+        name: "Discovery",
+        prompt: "Capture goals, constraints, current workflow, urgency, budget signals, and unanswered questions.",
+    },
+    MeetingTemplate {
+        id: "one_on_one",
+        name: "1:1",
+        prompt: "Capture wins, blockers, feedback, decisions, commitments, and follow-up dates.",
+    },
+    MeetingTemplate {
+        id: "user_interview",
+        name: "User Interview",
+        prompt: "Capture jobs-to-be-done, quotes, workflow details, pain points, workarounds, and product opportunities.",
+    },
+    MeetingTemplate {
+        id: "stand_up",
+        name: "Stand-up",
+        prompt: "Capture yesterday, today, blockers, owners, and commitments.",
+    },
+];
+
+pub fn default_template_id() -> &'static str {
+    "discovery"
+}

--- a/src-tauri/src/audio/transcribe.rs
+++ b/src-tauri/src/audio/transcribe.rs
@@ -1,0 +1,164 @@
+// ABOUTME: Retryable transcription boundary for Whisper chunk requests.
+// ABOUTME: Keeps retry policy deterministic and injectable for unit tests.
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::audio::chunker::Chunk;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum TranscribeError {
+    #[error("transcription transport failed: {0}")]
+    Transport(String),
+    #[error("transcription returned no text")]
+    Empty,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RetryConfig {
+    pub max_attempts: usize,
+    pub initial_backoff_ms: u64,
+    pub max_backoff_ms: u64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            initial_backoff_ms: 250,
+            max_backoff_ms: 2_000,
+        }
+    }
+}
+
+#[async_trait]
+pub trait ChunkTranscriber {
+    async fn transcribe(&self, chunk: &Chunk) -> Result<String, TranscribeError>;
+}
+
+pub async fn transcribe_chunk_with_retry<T>(
+    transcriber: &T,
+    chunk: &Chunk,
+    cfg: RetryConfig,
+) -> Result<String, TranscribeError>
+where
+    T: ChunkTranscriber + Sync,
+{
+    let attempts = cfg.max_attempts.max(1);
+    let mut backoff_ms = cfg.initial_backoff_ms;
+    let mut last_error = TranscribeError::Empty;
+
+    for attempt in 1..=attempts {
+        match transcriber.transcribe(chunk).await {
+            Ok(text) if !text.trim().is_empty() => return Ok(text),
+            Ok(_) => last_error = TranscribeError::Empty,
+            Err(err) => last_error = err,
+        }
+
+        if attempt < attempts && backoff_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+            backoff_ms = next_backoff(backoff_ms, cfg.max_backoff_ms);
+        }
+    }
+
+    Err(last_error)
+}
+
+fn next_backoff(current: u64, max: u64) -> u64 {
+    if max == 0 {
+        return 0;
+    }
+    current.saturating_mul(2).min(max)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    struct FakeTranscriber {
+        responses: Mutex<Vec<Result<String, TranscribeError>>>,
+        attempts: AtomicUsize,
+    }
+
+    impl FakeTranscriber {
+        fn new(responses: Vec<Result<String, TranscribeError>>) -> Self {
+            Self {
+                responses: Mutex::new(responses),
+                attempts: AtomicUsize::new(0),
+            }
+        }
+
+        fn attempts(&self) -> usize {
+            self.attempts.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl ChunkTranscriber for Arc<FakeTranscriber> {
+        async fn transcribe(&self, _chunk: &Chunk) -> Result<String, TranscribeError> {
+            self.attempts.fetch_add(1, Ordering::SeqCst);
+            self.responses.lock().unwrap().remove(0)
+        }
+    }
+
+    fn chunk() -> Chunk {
+        Chunk {
+            start_ms: 0,
+            end_ms: 100,
+            samples: vec![1, 2, 3],
+        }
+    }
+
+    fn cfg() -> RetryConfig {
+        RetryConfig {
+            max_attempts: 3,
+            initial_backoff_ms: 0,
+            max_backoff_ms: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn transcribe_chunk_returns_successful_text() {
+        let transcriber = Arc::new(FakeTranscriber::new(vec![Ok("hello".to_string())]));
+
+        let result = transcribe_chunk_with_retry(&transcriber, &chunk(), cfg()).await;
+
+        assert_eq!(result.unwrap(), "hello");
+        assert_eq!(transcriber.attempts(), 1);
+    }
+
+    #[tokio::test]
+    async fn transcribe_chunk_retries_before_success() {
+        let transcriber = Arc::new(FakeTranscriber::new(vec![
+            Err(TranscribeError::Transport("timeout".to_string())),
+            Err(TranscribeError::Transport("502".to_string())),
+            Ok("eventually".to_string()),
+        ]));
+
+        let result = transcribe_chunk_with_retry(&transcriber, &chunk(), cfg()).await;
+
+        assert_eq!(result.unwrap(), "eventually");
+        assert_eq!(transcriber.attempts(), 3);
+    }
+
+    #[tokio::test]
+    async fn transcribe_chunk_returns_error_after_attempts_exhausted() {
+        let transcriber = Arc::new(FakeTranscriber::new(vec![
+            Err(TranscribeError::Transport("timeout".to_string())),
+            Err(TranscribeError::Transport("502".to_string())),
+            Err(TranscribeError::Transport("500".to_string())),
+        ]));
+
+        let result = transcribe_chunk_with_retry(&transcriber, &chunk(), cfg()).await;
+
+        assert_eq!(
+            result.unwrap_err(),
+            TranscribeError::Transport("500".to_string())
+        );
+        assert_eq!(transcriber.attempts(), 3);
+    }
+}

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -1,0 +1,132 @@
+// ABOUTME: Serializable meeting and transcript data shapes shared by Rust IPC.
+// ABOUTME: Mirrors the SQLite meeting schema and live transcript events.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Speaker {
+    Me,
+    Them,
+}
+
+impl Speaker {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Me => "me",
+            Self::Them => "them",
+        }
+    }
+}
+
+impl TryFrom<&str> for Speaker {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "me" => Ok(Self::Me),
+            "them" => Ok(Self::Them),
+            _ => Err(format!("Unknown transcript speaker: {}", value)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MeetingStatus {
+    Capturing,
+    Transcribing,
+    NotesReady,
+    AgentRunning,
+    Done,
+    Failed,
+}
+
+impl MeetingStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Capturing => "capturing",
+            Self::Transcribing => "transcribing",
+            Self::NotesReady => "notes_ready",
+            Self::AgentRunning => "agent_running",
+            Self::Done => "done",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl TryFrom<&str> for MeetingStatus {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "capturing" => Ok(Self::Capturing),
+            "transcribing" => Ok(Self::Transcribing),
+            "notes_ready" => Ok(Self::NotesReady),
+            "agent_running" => Ok(Self::AgentRunning),
+            "done" => Ok(Self::Done),
+            "failed" => Ok(Self::Failed),
+            _ => Err(format!("Unknown meeting status: {}", value)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SegmentStatus {
+    Ok,
+    Gap,
+}
+
+impl SegmentStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Gap => "gap",
+        }
+    }
+}
+
+impl TryFrom<&str> for SegmentStatus {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "ok" => Ok(Self::Ok),
+            "gap" => Ok(Self::Gap),
+            _ => Err(format!("Unknown transcript segment status: {}", value)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Meeting {
+    pub id: String,
+    pub title: String,
+    pub source_app: Option<String>,
+    pub started_at: i64,
+    pub ended_at: Option<i64>,
+    pub status: MeetingStatus,
+    pub template_id: Option<String>,
+    pub routed_skill_slug: Option<String>,
+    pub agent_conversation_id: Option<String>,
+    pub notes_markdown: Option<String>,
+    pub notes_struct_json: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TranscriptSegment {
+    pub id: String,
+    pub meeting_id: String,
+    pub seq: i64,
+    pub speaker: Speaker,
+    pub text: String,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub status: SegmentStatus,
+    pub created_at: i64,
+}

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1,0 +1,424 @@
+// ABOUTME: Tauri commands for Meeting Mode persistence and transcript history.
+// ABOUTME: Stores meetings and transcript segments without persisting raw audio.
+
+use crate::audio::types::{Meeting, MeetingStatus, SegmentStatus, Speaker, TranscriptSegment};
+use crate::services::database::DbPool;
+use rusqlite::{Connection, OptionalExtension, Result, params};
+use tauri::{AppHandle, Manager};
+use uuid::Uuid;
+
+#[tauri::command]
+pub async fn create_meeting(
+    app: AppHandle,
+    title: String,
+    source_app: Option<String>,
+    started_at: Option<i64>,
+    template_id: Option<String>,
+) -> Result<Meeting, String> {
+    let now = now_ms();
+    let meeting = NewMeeting {
+        id: Uuid::new_v4().to_string(),
+        title,
+        source_app,
+        started_at: started_at.unwrap_or(now),
+        template_id,
+        now,
+    };
+
+    run_db(app, move |conn| insert_meeting(conn, meeting)).await
+}
+
+#[tauri::command]
+pub async fn get_meeting(app: AppHandle, id: String) -> Result<Option<Meeting>, String> {
+    run_db(app, move |conn| select_meeting(conn, &id)).await
+}
+
+#[tauri::command]
+pub async fn list_meetings(app: AppHandle, limit: Option<i32>) -> Result<Vec<Meeting>, String> {
+    run_db(app, move |conn| select_meetings(conn, limit.unwrap_or(50))).await
+}
+
+#[tauri::command]
+pub async fn update_meeting_status(
+    app: AppHandle,
+    id: String,
+    status: MeetingStatus,
+    ended_at: Option<i64>,
+) -> Result<(), String> {
+    run_db(app, move |conn| {
+        update_meeting_status_record(conn, &id, status, ended_at, now_ms())
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn update_meeting_notes(
+    app: AppHandle,
+    id: String,
+    notes_markdown: String,
+    notes_struct_json: String,
+) -> Result<(), String> {
+    run_db(app, move |conn| {
+        conn.execute(
+            "UPDATE meetings
+             SET notes_markdown = ?1, notes_struct_json = ?2, status = ?3, updated_at = ?4
+             WHERE id = ?5",
+            params![
+                notes_markdown,
+                notes_struct_json,
+                MeetingStatus::NotesReady.as_str(),
+                now_ms(),
+                id
+            ],
+        )?;
+        Ok(())
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn set_meeting_routed_skill(
+    app: AppHandle,
+    id: String,
+    routed_skill_slug: Option<String>,
+    agent_conversation_id: Option<String>,
+) -> Result<(), String> {
+    run_db(app, move |conn| {
+        conn.execute(
+            "UPDATE meetings
+             SET routed_skill_slug = ?1, agent_conversation_id = ?2, updated_at = ?3
+             WHERE id = ?4",
+            params![routed_skill_slug, agent_conversation_id, now_ms(), id],
+        )?;
+        Ok(())
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn append_transcript_segment(
+    app: AppHandle,
+    meeting_id: String,
+    seq: i64,
+    speaker: Speaker,
+    text: String,
+    start_ms: i64,
+    end_ms: i64,
+    status: SegmentStatus,
+) -> Result<TranscriptSegment, String> {
+    let segment = NewTranscriptSegment {
+        id: Uuid::new_v4().to_string(),
+        meeting_id,
+        seq,
+        speaker,
+        text,
+        start_ms,
+        end_ms,
+        status,
+        created_at: now_ms(),
+    };
+
+    run_db(app, move |conn| insert_transcript_segment(conn, segment)).await
+}
+
+#[tauri::command]
+pub async fn get_transcript_segments(
+    app: AppHandle,
+    meeting_id: String,
+) -> Result<Vec<TranscriptSegment>, String> {
+    run_db(app, move |conn| {
+        select_transcript_segments(conn, &meeting_id)
+    })
+    .await
+}
+
+#[derive(Debug, Clone)]
+pub struct NewMeeting {
+    pub id: String,
+    pub title: String,
+    pub source_app: Option<String>,
+    pub started_at: i64,
+    pub template_id: Option<String>,
+    pub now: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewTranscriptSegment {
+    pub id: String,
+    pub meeting_id: String,
+    pub seq: i64,
+    pub speaker: Speaker,
+    pub text: String,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub status: SegmentStatus,
+    pub created_at: i64,
+}
+
+pub fn insert_meeting(conn: &Connection, meeting: NewMeeting) -> Result<Meeting> {
+    conn.execute(
+        "INSERT INTO meetings (
+            id, title, source_app, started_at, ended_at, status, template_id,
+            routed_skill_slug, agent_conversation_id, notes_markdown,
+            notes_struct_json, created_at, updated_at
+         )
+         VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, NULL, NULL, NULL, NULL, ?7, ?7)",
+        params![
+            meeting.id,
+            meeting.title,
+            meeting.source_app,
+            meeting.started_at,
+            MeetingStatus::Capturing.as_str(),
+            meeting.template_id,
+            meeting.now
+        ],
+    )?;
+
+    select_meeting(conn, &meeting.id)?.ok_or(rusqlite::Error::QueryReturnedNoRows)
+}
+
+pub fn select_meeting(conn: &Connection, id: &str) -> Result<Option<Meeting>> {
+    conn.query_row(
+        "SELECT id, title, source_app, started_at, ended_at, status, template_id,
+                routed_skill_slug, agent_conversation_id, notes_markdown,
+                notes_struct_json, created_at, updated_at
+         FROM meetings
+         WHERE id = ?1",
+        params![id],
+        row_to_meeting,
+    )
+    .optional()
+}
+
+pub fn select_meetings(conn: &Connection, limit: i32) -> Result<Vec<Meeting>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, title, source_app, started_at, ended_at, status, template_id,
+                routed_skill_slug, agent_conversation_id, notes_markdown,
+                notes_struct_json, created_at, updated_at
+         FROM meetings
+         ORDER BY started_at DESC
+         LIMIT ?1",
+    )?;
+
+    stmt.query_map(params![limit], row_to_meeting)?
+        .collect::<Result<Vec<_>>>()
+}
+
+pub fn update_meeting_status_record(
+    conn: &Connection,
+    id: &str,
+    status: MeetingStatus,
+    ended_at: Option<i64>,
+    updated_at: i64,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE meetings SET status = ?1, ended_at = ?2, updated_at = ?3 WHERE id = ?4",
+        params![status.as_str(), ended_at, updated_at, id],
+    )?;
+    Ok(())
+}
+
+pub fn insert_transcript_segment(
+    conn: &Connection,
+    segment: NewTranscriptSegment,
+) -> Result<TranscriptSegment> {
+    conn.execute(
+        "INSERT INTO transcript_segments (
+            id, meeting_id, seq, speaker, text, start_ms, end_ms, status, created_at
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            segment.id,
+            segment.meeting_id,
+            segment.seq,
+            segment.speaker.as_str(),
+            segment.text,
+            segment.start_ms,
+            segment.end_ms,
+            segment.status.as_str(),
+            segment.created_at
+        ],
+    )?;
+
+    Ok(TranscriptSegment {
+        id: segment.id,
+        meeting_id: segment.meeting_id,
+        seq: segment.seq,
+        speaker: segment.speaker,
+        text: segment.text,
+        start_ms: segment.start_ms,
+        end_ms: segment.end_ms,
+        status: segment.status,
+        created_at: segment.created_at,
+    })
+}
+
+pub fn select_transcript_segments(
+    conn: &Connection,
+    meeting_id: &str,
+) -> Result<Vec<TranscriptSegment>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, meeting_id, seq, speaker, text, start_ms, end_ms, status, created_at
+         FROM transcript_segments
+         WHERE meeting_id = ?1
+         ORDER BY seq ASC",
+    )?;
+
+    stmt.query_map(params![meeting_id], row_to_segment)?
+        .collect::<Result<Vec<_>>>()
+}
+
+fn row_to_meeting(row: &rusqlite::Row<'_>) -> Result<Meeting> {
+    let status: String = row.get(5)?;
+    Ok(Meeting {
+        id: row.get(0)?,
+        title: row.get(1)?,
+        source_app: row.get(2)?,
+        started_at: row.get(3)?,
+        ended_at: row.get(4)?,
+        status: MeetingStatus::try_from(status.as_str()).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
+            )
+        })?,
+        template_id: row.get(6)?,
+        routed_skill_slug: row.get(7)?,
+        agent_conversation_id: row.get(8)?,
+        notes_markdown: row.get(9)?,
+        notes_struct_json: row.get(10)?,
+        created_at: row.get(11)?,
+        updated_at: row.get(12)?,
+    })
+}
+
+fn row_to_segment(row: &rusqlite::Row<'_>) -> Result<TranscriptSegment> {
+    let speaker: String = row.get(3)?;
+    let status: String = row.get(7)?;
+    Ok(TranscriptSegment {
+        id: row.get(0)?,
+        meeting_id: row.get(1)?,
+        seq: row.get(2)?,
+        speaker: Speaker::try_from(speaker.as_str()).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(
+                3,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
+            )
+        })?,
+        text: row.get(4)?,
+        start_ms: row.get(5)?,
+        end_ms: row.get(6)?,
+        status: SegmentStatus::try_from(status.as_str()).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(
+                7,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
+            )
+        })?,
+        created_at: row.get(8)?,
+    })
+}
+
+async fn run_db<T>(
+    app: AppHandle,
+    f: impl FnOnce(&Connection) -> Result<T> + Send + 'static,
+) -> Result<T, String>
+where
+    T: Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(move || {
+        let pool = app.state::<DbPool>();
+        pool.with_connection(f)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::database::setup_schema;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+        conn
+    }
+
+    fn meeting(id: &str) -> NewMeeting {
+        NewMeeting {
+            id: id.to_string(),
+            title: "Customer discovery".to_string(),
+            source_app: Some("Zoom".to_string()),
+            started_at: 10,
+            template_id: Some("discovery".to_string()),
+            now: 20,
+        }
+    }
+
+    #[test]
+    fn meeting_persistence_round_trips_status_and_fields() {
+        let conn = setup();
+
+        let created = insert_meeting(&conn, meeting("meeting-1")).unwrap();
+        update_meeting_status_record(&conn, "meeting-1", MeetingStatus::Done, Some(100), 101)
+            .unwrap();
+        let loaded = select_meeting(&conn, "meeting-1").unwrap().unwrap();
+
+        assert_eq!(created.status, MeetingStatus::Capturing);
+        assert_eq!(loaded.status, MeetingStatus::Done);
+        assert_eq!(loaded.ended_at, Some(100));
+        assert_eq!(loaded.title, "Customer discovery");
+        assert_eq!(loaded.source_app.as_deref(), Some("Zoom"));
+        assert_eq!(loaded.template_id.as_deref(), Some("discovery"));
+    }
+
+    #[test]
+    fn transcript_segments_round_trip_ordered_by_seq() {
+        let conn = setup();
+        insert_meeting(&conn, meeting("meeting-1")).unwrap();
+
+        for seq in [2, 0, 1] {
+            insert_transcript_segment(
+                &conn,
+                NewTranscriptSegment {
+                    id: format!("segment-{}", seq),
+                    meeting_id: "meeting-1".to_string(),
+                    seq,
+                    speaker: if seq == 1 { Speaker::Them } else { Speaker::Me },
+                    text: format!("text {}", seq),
+                    start_ms: seq * 100,
+                    end_ms: seq * 100 + 50,
+                    status: if seq == 2 {
+                        SegmentStatus::Gap
+                    } else {
+                        SegmentStatus::Ok
+                    },
+                    created_at: 30 + seq,
+                },
+            )
+            .unwrap();
+        }
+
+        let segments = select_transcript_segments(&conn, "meeting-1").unwrap();
+
+        assert_eq!(
+            segments
+                .iter()
+                .map(|segment| segment.seq)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        assert_eq!(segments[1].speaker, Speaker::Them);
+        assert_eq!(segments[2].status, SegmentStatus::Gap);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_store::StoreExt;
 
 pub mod commands {
+    pub mod audio;
     pub mod auth;
     pub mod chat;
     pub mod claude_memory;
@@ -31,6 +32,7 @@ pub mod services {
     pub mod vector_store;
 }
 
+pub mod audio;
 mod auth;
 mod claude_memory;
 mod claude_setup;
@@ -781,6 +783,15 @@ pub fn run() {
             // Rust-backed Gateway API bridge
             commands::gateway_http::gateway_http_start,
             commands::gateway_http::gateway_http_cancel,
+            // Meeting Mode persistence commands
+            commands::audio::create_meeting,
+            commands::audio::get_meeting,
+            commands::audio::list_meetings,
+            commands::audio::update_meeting_status,
+            commands::audio::update_meeting_notes,
+            commands::audio::set_meeting_routed_skill,
+            commands::audio::append_transcript_segment,
+            commands::audio::get_transcript_segments,
             // Conversation commands
             commands::chat::create_conversation,
             commands::chat::list_conversations,

--- a/src-tauri/src/orchestrator/classifier.rs
+++ b/src-tauri/src/orchestrator/classifier.rs
@@ -354,6 +354,28 @@ pub fn select_relevant_skills(prompt: &str, skills: &[SkillRef]) -> Vec<String> 
         .collect()
 }
 
+/// Select installed skills that explicitly declare meeting handling.
+///
+/// Meeting Mode calls this at call-end, where relying on transcript text would
+/// make routing accidental. The tag must come from the skill metadata that was
+/// parsed from SKILL.md frontmatter by the frontend.
+#[allow(dead_code)]
+pub fn select_meeting_skills(skills: &[SkillRef]) -> Vec<String> {
+    skills
+        .iter()
+        .filter(|skill| {
+            skill.tags.iter().any(|tag| {
+                let normalized = tag.trim().to_lowercase();
+                matches!(
+                    normalized.as_str(),
+                    "meeting" | "meetings" | "meeting-mode" | "meeting_mode"
+                )
+            })
+        })
+        .map(|skill| skill.slug.clone())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -541,6 +563,31 @@ mod tests {
         let result = classify("Help me git commit my code changes", &skills);
         assert_eq!(result.task_type, "code_generation");
         assert_eq!(result.relevant_skills, vec!["git-commit"]);
+    }
+
+    #[test]
+    fn meeting_skill_selection_uses_declared_tags_only() {
+        let skills = vec![
+            make_skill("sales-notes", "Sales Notes", &["meeting"]),
+            make_skill("crm-writer", "CRM Writer", &["meeting-mode"]),
+            make_skill("recap", "Meeting Recap", &["document"]),
+        ];
+
+        let result = select_meeting_skills(&skills);
+
+        assert_eq!(
+            result,
+            vec!["sales-notes".to_string(), "crm-writer".to_string()]
+        );
+    }
+
+    #[test]
+    fn meeting_skill_selection_returns_empty_without_tag() {
+        let skills = vec![make_skill("recap", "Meeting Recap", &["document"])];
+
+        let result = select_meeting_skills(&skills);
+
+        assert!(result.is_empty());
     }
 
     // =========================================================================

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -327,6 +327,48 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
         [],
     )?;
 
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS meetings (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            source_app TEXT,
+            started_at INTEGER NOT NULL,
+            ended_at INTEGER,
+            status TEXT NOT NULL,
+            template_id TEXT,
+            routed_skill_slug TEXT,
+            agent_conversation_id TEXT,
+            notes_markdown TEXT,
+            notes_struct_json TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            FOREIGN KEY (agent_conversation_id) REFERENCES conversations(id)
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS transcript_segments (
+            id TEXT PRIMARY KEY,
+            meeting_id TEXT NOT NULL,
+            seq INTEGER NOT NULL,
+            speaker TEXT NOT NULL,
+            text TEXT NOT NULL,
+            start_ms INTEGER NOT NULL,
+            end_ms INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_segments_meeting
+         ON transcript_segments(meeting_id, seq)",
+        [],
+    )?;
+
     // Migration: add agent conversation columns if they don't exist (for existing DBs)
     let has_kind: bool = conn
         .prepare("SELECT kind FROM conversations LIMIT 1")

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -20,6 +20,7 @@ import { ArchivedEmployeeDetail } from "@/components/employees/ArchivedEmployeeD
 import { EmployeeDetail } from "@/components/employees/EmployeeDetail";
 import { InboxList } from "@/components/inbox/InboxList";
 import { ThreadSidebar } from "@/components/layout/ThreadSidebar";
+import { MeetingPanel } from "@/components/meeting/MeetingPanel";
 import { SessionPanel } from "@/components/session/SessionPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import {
@@ -70,6 +71,7 @@ export type SlidePanelView =
   | "account"
   | "tasks"
   | "sessions"
+  | "meetings"
   | "skills"
   | null;
 
@@ -80,6 +82,7 @@ const PERSISTABLE_VIEWS: ReadonlySet<NonNullable<SlidePanelView>> = new Set([
   "database",
   "tasks",
   "sessions",
+  "meetings",
   "skills",
 ]);
 
@@ -406,6 +409,8 @@ export const AppShell: Component<AppShellProps> = (props) => {
       setSlidePanel("tasks");
     } else if (p === "sessions") {
       setSlidePanel("sessions");
+    } else if (p === "meetings") {
+      setSlidePanel("meetings");
     } else if (p === "skills") {
       setSlidePanel("skills");
     }
@@ -698,6 +703,9 @@ export const AppShell: Component<AppShellProps> = (props) => {
             </Match>
             <Match when={slidePanel() === "sessions"}>
               <SessionPanel onClose={handleCloseSlidePanel} />
+            </Match>
+            <Match when={slidePanel() === "meetings"}>
+              <MeetingPanel onClose={handleCloseSlidePanel} />
             </Match>
             <Match when={slidePanel() === "skills"}>
               <SkillsExplorer panelMode />

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -1085,6 +1085,39 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
             Sessions
           </button>
 
+          <button
+            type="button"
+            data-testid="meetings-button"
+            class="flex w-full px-3 py-2 text-left text-[12px] text-muted-foreground hover:text-foreground hover:bg-surface-1/50 transition-colors items-center gap-2"
+            onClick={() =>
+              window.dispatchEvent(
+                new CustomEvent("seren:open-panel", { detail: "meetings" }),
+              )
+            }
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+              role="img"
+              aria-label="Meetings"
+            >
+              <path
+                d="M4.5 7a3.5 3.5 0 0 1 7 0v1.2a3.5 3.5 0 0 1-7 0V7Z"
+                stroke="currentColor"
+                stroke-width="1.2"
+              />
+              <path
+                d="M2.5 8a5.5 5.5 0 0 0 11 0M8 13.5V15"
+                stroke="currentColor"
+                stroke-width="1.2"
+                stroke-linecap="round"
+              />
+            </svg>
+            Meetings
+          </button>
+
           <Show when={threadStore.runningCount > 0}>
             <div class="px-3 py-2 border-t border-border/30">
               <span class="text-[11px] text-status-running flex items-center gap-1.5">

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -1,0 +1,368 @@
+// ABOUTME: Slide-panel interface for Meeting Mode library, recorder, and details.
+// ABOUTME: Uses meeting services and store; components never call Tauri IPC directly.
+
+import {
+  createMemo,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+import {
+  createMeeting,
+  type Meeting,
+  type TranscriptSegment,
+  updateMeetingStatus,
+} from "@/services/meetings";
+import { meetingStore } from "@/stores/meeting.store";
+import { settingsStore } from "@/stores/settings.store";
+
+interface MeetingPanelProps {
+  onClose: () => void;
+}
+
+function formatTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatDuration(meeting: Meeting): string {
+  const end = meeting.endedAt ?? Date.now();
+  const totalSeconds = Math.max(
+    0,
+    Math.floor((end - meeting.startedAt) / 1000),
+  );
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+function meetingTitle(meeting: Meeting): string {
+  return meeting.title.trim() || `Meeting ${formatTime(meeting.startedAt)}`;
+}
+
+const STATUS_LABELS: Record<Meeting["status"], string> = {
+  capturing: "Capturing",
+  transcribing: "Transcribing",
+  notes_ready: "Notes ready",
+  agent_running: "Agent running",
+  done: "Done",
+  failed: "Failed",
+};
+
+function MicGlyph() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      role="img"
+      aria-label="Microphone"
+    >
+      <path d="M8 10a2 2 0 0 0 2-2V4a2 2 0 1 0-4 0v4a2 2 0 0 0 2 2Z" />
+      <path d="M4.5 7a.5.5 0 0 0-1 0 4.5 4.5 0 0 0 4 4.47V13.5H6a.5.5 0 0 0 0 1h4a.5.5 0 0 0 0-1H8.5v-2.03A4.5 4.5 0 0 0 12.5 7a.5.5 0 0 0-1 0 3.5 3.5 0 1 1-7 0Z" />
+    </svg>
+  );
+}
+
+function StopGlyph() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      role="img"
+      aria-label="Stop"
+    >
+      <rect x="4" y="4" width="8" height="8" rx="1.5" />
+    </svg>
+  );
+}
+
+function TranscriptRow(props: { segment: TranscriptSegment }) {
+  return (
+    <div class="grid grid-cols-[52px_1fr] gap-3 py-2 border-b border-border/50 last:border-b-0">
+      <div
+        class="text-[11px] font-mono tabular-nums"
+        classList={{
+          "text-foreground": props.segment.speaker === "me",
+          "text-muted-foreground": props.segment.speaker === "them",
+        }}
+      >
+        {props.segment.speaker === "me" ? "Me" : "Them"}
+      </div>
+      <div
+        class="text-[13px] leading-5"
+        classList={{
+          "text-muted-foreground italic": props.segment.status === "gap",
+          "text-foreground": props.segment.status === "ok",
+        }}
+      >
+        {props.segment.status === "gap" ? "Transcript gap" : props.segment.text}
+      </div>
+    </div>
+  );
+}
+
+export function MeetingPanel(props: MeetingPanelProps) {
+  const [starting, setStarting] = createSignal(false);
+  const [stopping, setStopping] = createSignal(false);
+  const [title, setTitle] = createSignal("");
+
+  onMount(() => {
+    void meetingStore.loadMeetings();
+    void meetingStore.startMeetingEventListeners();
+  });
+
+  onCleanup(() => meetingStore.stopMeetingEventListeners());
+
+  const activeCapture = createMemo(() =>
+    meetingStore.state.meetings.find((meeting) =>
+      ["capturing", "transcribing", "agent_running"].includes(meeting.status),
+    ),
+  );
+
+  const activeMeeting = () => meetingStore.state.activeMeeting;
+  const template = () => settingsStore.get("meetingTemplateId");
+  const desktopRuntime = isTauriRuntime();
+
+  const startManualCapture = async () => {
+    if (!desktopRuntime || starting()) return;
+    setStarting(true);
+    try {
+      const meeting = await createMeeting({
+        title: title().trim() || `Meeting ${formatTime(Date.now())}`,
+        sourceApp: "Manual",
+        templateId: template(),
+      });
+      setTitle("");
+      await meetingStore.loadMeetings();
+      await meetingStore.setActiveMeeting(meeting);
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const stopManualCapture = async () => {
+    const meeting = activeCapture();
+    if (!desktopRuntime || !meeting || stopping()) return;
+    setStopping(true);
+    try {
+      await updateMeetingStatus(meeting.id, "done", Date.now());
+      await meetingStore.loadMeetings();
+      const updated = meetingStore.state.meetings.find(
+        (item) => item.id === meeting.id,
+      );
+      await meetingStore.setActiveMeeting(updated ?? null);
+    } finally {
+      setStopping(false);
+    }
+  };
+
+  return (
+    <section class="h-full min-h-0 flex flex-col bg-surface-1 text-foreground">
+      <header class="px-5 pt-5 pb-4 border-b border-border">
+        <div class="flex items-center justify-between gap-4 pr-8">
+          <div class="min-w-0">
+            <h2 class="text-[15px] font-semibold tracking-normal">Meetings</h2>
+            <div class="mt-1 text-[12px] text-muted-foreground">
+              {meetingStore.state.meetings.length} saved
+            </div>
+          </div>
+          <button
+            type="button"
+            class="w-7 h-7 flex items-center justify-center rounded-md border border-border bg-surface-2 text-muted-foreground hover:text-foreground hover:bg-surface-3 transition-colors"
+            onClick={props.onClose}
+            title="Close"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M4 4l8 8M12 4l-8 8"
+                stroke="currentColor"
+                stroke-width="1.4"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </header>
+
+      <div class="p-4 border-b border-border bg-surface-0/40">
+        <div class="flex items-center gap-3">
+          <div class="flex items-center gap-1.5 h-8 px-2 rounded-md border border-border bg-surface-1">
+            <For each={[0, 1, 2, 3, 4, 5, 6]}>
+              {(bar) => (
+                <span
+                  class="w-0.5 rounded-full bg-primary/80 transition-all"
+                  classList={{
+                    "animate-[voicePulse_1s_ease-in-out_infinite]":
+                      activeCapture() !== undefined,
+                  }}
+                  style={{
+                    height: activeCapture()
+                      ? `${8 + ((bar * 7) % 18)}px`
+                      : "4px",
+                    "animation-delay": `${bar * 80}ms`,
+                  }}
+                />
+              )}
+            </For>
+          </div>
+          <input
+            class="min-w-0 flex-1 h-8 rounded-md border border-border bg-surface-1 px-2.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary/60"
+            placeholder="Meeting title"
+            value={title()}
+            onInput={(event) => setTitle(event.currentTarget.value)}
+            disabled={activeCapture() !== undefined}
+          />
+          <Show
+            when={activeCapture()}
+            fallback={
+              <button
+                type="button"
+                class="h-8 w-9 flex items-center justify-center rounded-md border border-primary/40 bg-primary/10 text-primary hover:bg-primary/15 disabled:opacity-60"
+                onClick={startManualCapture}
+                disabled={starting() || !desktopRuntime}
+                title={
+                  desktopRuntime ? "Start capture" : "Desktop runtime required"
+                }
+              >
+                <MicGlyph />
+              </button>
+            }
+          >
+            <button
+              type="button"
+              class="h-8 w-9 flex items-center justify-center rounded-md border border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/15 disabled:opacity-60"
+              onClick={stopManualCapture}
+              disabled={stopping() || !desktopRuntime}
+              title={
+                desktopRuntime ? "Stop capture" : "Desktop runtime required"
+              }
+            >
+              <StopGlyph />
+            </button>
+          </Show>
+        </div>
+        <Show when={activeCapture()}>
+          {(meeting) => (
+            <div class="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+              <span class="w-1.5 h-1.5 rounded-full bg-destructive animate-pulse" />
+              <span class="font-mono tabular-nums">
+                {formatDuration(meeting())}
+              </span>
+              <span>{meetingTitle(meeting())}</span>
+            </div>
+          )}
+        </Show>
+      </div>
+
+      <div class="min-h-0 flex-1 grid grid-cols-[220px_1fr]">
+        <aside class="min-h-0 overflow-auto border-r border-border bg-surface-0/30">
+          <Show
+            when={meetingStore.state.meetings.length > 0}
+            fallback={
+              <div class="p-4 text-[13px] text-muted-foreground">
+                No meetings saved.
+              </div>
+            }
+          >
+            <For each={meetingStore.state.meetings}>
+              {(meeting) => {
+                const selected = () => activeMeeting()?.id === meeting.id;
+                return (
+                  <button
+                    type="button"
+                    class="w-full text-left px-3 py-2.5 border-b border-border/50 bg-transparent hover:bg-surface-2 transition-colors"
+                    classList={{
+                      "bg-surface-2 text-foreground": selected(),
+                      "text-muted-foreground": !selected(),
+                    }}
+                    onClick={() => void meetingStore.setActiveMeeting(meeting)}
+                  >
+                    <div class="text-[13px] font-medium truncate">
+                      {meetingTitle(meeting)}
+                    </div>
+                    <div class="mt-1 flex items-center justify-between gap-2 text-[11px]">
+                      <span>{formatTime(meeting.startedAt)}</span>
+                      <span>{STATUS_LABELS[meeting.status]}</span>
+                    </div>
+                  </button>
+                );
+              }}
+            </For>
+          </Show>
+        </aside>
+
+        <main class="min-h-0 overflow-auto">
+          <Show
+            when={activeMeeting()}
+            fallback={
+              <div class="h-full flex items-center justify-center text-[13px] text-muted-foreground">
+                Select a meeting.
+              </div>
+            }
+          >
+            {(meeting) => (
+              <div class="p-5 max-w-[720px]">
+                <div class="mb-5">
+                  <h3 class="text-[18px] font-semibold tracking-normal">
+                    {meetingTitle(meeting())}
+                  </h3>
+                  <div class="mt-1 flex items-center gap-3 text-[12px] text-muted-foreground">
+                    <span>{STATUS_LABELS[meeting().status]}</span>
+                    <span class="font-mono tabular-nums">
+                      {formatDuration(meeting())}
+                    </span>
+                    <span>{meeting().sourceApp ?? "Desktop"}</span>
+                  </div>
+                </div>
+
+                <section class="mb-6">
+                  <div class="mb-2 text-[12px] font-medium text-muted-foreground">
+                    Notes
+                  </div>
+                  <div class="min-h-[96px] whitespace-pre-wrap rounded-md border border-border bg-surface-0/50 p-3 text-[13px] leading-5">
+                    {meeting().notesMarkdown ?? "Notes will appear here."}
+                  </div>
+                </section>
+
+                <section>
+                  <div class="mb-2 text-[12px] font-medium text-muted-foreground">
+                    Transcript
+                  </div>
+                  <Show
+                    when={meetingStore.state.liveSegments.length > 0}
+                    fallback={
+                      <div class="rounded-md border border-border bg-surface-0/50 p-3 text-[13px] text-muted-foreground">
+                        No transcript yet.
+                      </div>
+                    }
+                  >
+                    <div class="rounded-md border border-border bg-surface-0/50 px-3">
+                      <For each={meetingStore.state.liveSegments}>
+                        {(segment) => <TranscriptRow segment={segment} />}
+                      </For>
+                    </div>
+                  </Show>
+                </section>
+              </div>
+            )}
+          </Show>
+        </main>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/audio/dictationCleanup.ts
+++ b/src/lib/audio/dictationCleanup.ts
@@ -1,0 +1,29 @@
+// ABOUTME: Local dictation cleanup helpers shared by voice input surfaces.
+// ABOUTME: Removes common fillers and applies user vocabulary casing.
+
+const FILLER_PATTERN =
+  /\b(?:um+|uh+|erm+|ah+|like|you know|i mean|sort of|kind of)\b/gi;
+
+export function cleanupDictationText(
+  raw: string,
+  vocabulary: string[] = [],
+): string {
+  const collapsed = raw
+    .replace(FILLER_PATTERN, " ")
+    .replace(/\s+([,.!?;:])/g, "$1")
+    .replace(/([,.!?;:]){2,}/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!collapsed) return "";
+
+  const withVocabulary = vocabulary
+    .map((term) => term.trim())
+    .filter(Boolean)
+    .reduce((text, term) => {
+      const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      return text.replace(new RegExp(`\\b${escaped}\\b`, "gi"), term);
+    }, collapsed);
+
+  return withVocabulary.charAt(0).toUpperCase() + withVocabulary.slice(1);
+}

--- a/src/lib/audio/useVoiceInput.ts
+++ b/src/lib/audio/useVoiceInput.ts
@@ -2,7 +2,9 @@
 // ABOUTME: Manages MediaRecorder lifecycle, audio capture, and Whisper API calls.
 
 import { createSignal, onCleanup } from "solid-js";
+import { cleanupDictationText } from "@/lib/audio/dictationCleanup";
 import { transcribeAudio } from "@/services/seren-whisper";
+import { settingsStore } from "@/stores/settings.store";
 
 export type VoiceState = "idle" | "recording" | "transcribing" | "error";
 
@@ -88,8 +90,16 @@ export function useVoiceInput(onTranscript: (text: string) => void) {
             typeof text,
           );
           if (text?.trim()) {
-            console.log("[VoiceInput] Calling onTranscript with:", text.trim());
-            onTranscript(text.trim());
+            const transcript = settingsStore.get("voiceCleanupEnabled")
+              ? cleanupDictationText(
+                  text,
+                  settingsStore.get("voiceCustomVocabulary"),
+                )
+              : text.trim();
+            console.log("[VoiceInput] Calling onTranscript with:", transcript);
+            if (transcript) {
+              onTranscript(transcript);
+            }
           } else {
             console.log("[VoiceInput] No text returned from transcription");
           }

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -1,0 +1,128 @@
+// ABOUTME: Frontend service wrappers for Meeting Mode Tauri commands.
+// ABOUTME: Keeps meeting persistence and transcript IPC out of Solid components.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export type Speaker = "me" | "them";
+export type MeetingStatus =
+  | "capturing"
+  | "transcribing"
+  | "notes_ready"
+  | "agent_running"
+  | "done"
+  | "failed";
+export type SegmentStatus = "ok" | "gap";
+
+export interface Meeting {
+  id: string;
+  title: string;
+  sourceApp: string | null;
+  startedAt: number;
+  endedAt: number | null;
+  status: MeetingStatus;
+  templateId: string | null;
+  routedSkillSlug: string | null;
+  agentConversationId: string | null;
+  notesMarkdown: string | null;
+  notesStructJson: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface TranscriptSegment {
+  id: string;
+  meetingId: string;
+  seq: number;
+  speaker: Speaker;
+  text: string;
+  startMs: number;
+  endMs: number;
+  status: SegmentStatus;
+  createdAt: number;
+}
+
+export interface CreateMeetingInput {
+  title: string;
+  sourceApp?: string | null;
+  startedAt?: number | null;
+  templateId?: string | null;
+}
+
+export interface AppendTranscriptSegmentInput {
+  meetingId: string;
+  seq: number;
+  speaker: Speaker;
+  text: string;
+  startMs: number;
+  endMs: number;
+  status: SegmentStatus;
+}
+
+export function createMeeting(input: CreateMeetingInput): Promise<Meeting> {
+  return invoke("create_meeting", {
+    title: input.title,
+    sourceApp: input.sourceApp ?? null,
+    startedAt: input.startedAt ?? null,
+    templateId: input.templateId ?? null,
+  });
+}
+
+export function getMeeting(id: string): Promise<Meeting | null> {
+  return invoke("get_meeting", { id });
+}
+
+export function listMeetings(limit = 50): Promise<Meeting[]> {
+  return invoke("list_meetings", { limit });
+}
+
+export function updateMeetingStatus(
+  id: string,
+  status: MeetingStatus,
+  endedAt?: number | null,
+): Promise<void> {
+  return invoke("update_meeting_status", { id, status, endedAt });
+}
+
+export function updateMeetingNotes(
+  id: string,
+  notesMarkdown: string,
+  notesStructJson: string,
+): Promise<void> {
+  return invoke("update_meeting_notes", {
+    id,
+    notesMarkdown,
+    notesStructJson,
+  });
+}
+
+export function setMeetingRoutedSkill(
+  id: string,
+  routedSkillSlug?: string | null,
+  agentConversationId?: string | null,
+): Promise<void> {
+  return invoke("set_meeting_routed_skill", {
+    id,
+    routedSkillSlug,
+    agentConversationId,
+  });
+}
+
+export function appendTranscriptSegment(
+  input: AppendTranscriptSegmentInput,
+): Promise<TranscriptSegment> {
+  return invoke("append_transcript_segment", {
+    meetingId: input.meetingId,
+    seq: input.seq,
+    speaker: input.speaker,
+    text: input.text,
+    startMs: input.startMs,
+    endMs: input.endMs,
+    status: input.status,
+  });
+}
+
+export function getTranscriptSegments(
+  meetingId: string,
+): Promise<TranscriptSegment[]> {
+  return invoke("get_transcript_segments", { meetingId });
+}

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -1,0 +1,132 @@
+// ABOUTME: Solid store for Meeting Mode library and live transcript state.
+// ABOUTME: Owns loading, active meeting selection, and transcript event updates.
+
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { createStore } from "solid-js/store";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+import {
+  getTranscriptSegments,
+  listMeetings,
+  type Meeting,
+  type TranscriptSegment,
+} from "@/services/meetings";
+
+interface MeetingState {
+  meetings: Meeting[];
+  activeMeeting: Meeting | null;
+  liveSegments: TranscriptSegment[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+const [meetingState, setMeetingState] = createStore<MeetingState>({
+  meetings: [],
+  activeMeeting: null,
+  liveSegments: [],
+  isLoading: false,
+  error: null,
+});
+
+let transcriptUnlisten: UnlistenFn | null = null;
+let statusUnlisten: UnlistenFn | null = null;
+
+async function loadMeetings(): Promise<void> {
+  setMeetingState("isLoading", true);
+  setMeetingState("error", null);
+  if (!isTauriRuntime()) {
+    setMeetingState("meetings", []);
+    setMeetingState("isLoading", false);
+    return;
+  }
+
+  try {
+    const meetings = await listMeetings();
+    setMeetingState("meetings", meetings);
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Failed to load meetings",
+    );
+  } finally {
+    setMeetingState("isLoading", false);
+  }
+}
+
+async function setActiveMeeting(meeting: Meeting | null): Promise<void> {
+  setMeetingState("activeMeeting", meeting);
+  if (!meeting) {
+    setMeetingState("liveSegments", []);
+    return;
+  }
+  if (!isTauriRuntime()) {
+    setMeetingState("liveSegments", []);
+    return;
+  }
+
+  try {
+    const segments = await getTranscriptSegments(meeting.id);
+    setMeetingState("liveSegments", segments);
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Failed to load transcript",
+    );
+  }
+}
+
+function appendLiveSegment(segment: TranscriptSegment): void {
+  setMeetingState("liveSegments", (segments) => {
+    const withoutDuplicate = segments.filter((item) => item.id !== segment.id);
+    return [...withoutDuplicate, segment].sort((left, right) => {
+      if (left.seq !== right.seq) return left.seq - right.seq;
+      return left.startMs - right.startMs;
+    });
+  });
+}
+
+async function startMeetingEventListeners(): Promise<void> {
+  stopMeetingEventListeners();
+  if (!isTauriRuntime()) return;
+
+  transcriptUnlisten = await listen<TranscriptSegment>(
+    "meeting://transcript-chunk",
+    (event) => {
+      const active = meetingState.activeMeeting;
+      if (active?.id === event.payload.meetingId) {
+        appendLiveSegment(event.payload);
+      }
+    },
+  );
+
+  statusUnlisten = await listen<Meeting>("meeting://status", (event) => {
+    setMeetingState("meetings", (meetings) => {
+      const next = meetings.some((meeting) => meeting.id === event.payload.id)
+        ? meetings.map((meeting) =>
+            meeting.id === event.payload.id ? event.payload : meeting,
+          )
+        : [event.payload, ...meetings];
+      return next.sort((left, right) => right.startedAt - left.startedAt);
+    });
+    if (meetingState.activeMeeting?.id === event.payload.id) {
+      setMeetingState("activeMeeting", event.payload);
+    }
+  });
+}
+
+function stopMeetingEventListeners(): void {
+  transcriptUnlisten?.();
+  statusUnlisten?.();
+  transcriptUnlisten = null;
+  statusUnlisten = null;
+}
+
+export const meetingStore = {
+  get state(): MeetingState {
+    return meetingState;
+  },
+  loadMeetings,
+  setActiveMeeting,
+  appendLiveSegment,
+  startMeetingEventListeners,
+  stopMeetingEventListeners,
+};

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -153,6 +153,13 @@ export interface Settings {
 
   // Voice settings
   voiceAutoSubmit: boolean;
+  voiceCleanupEnabled: boolean;
+  voiceCustomVocabulary: string[];
+
+  // Meeting settings
+  meetingAutoDetectEnabled: boolean;
+  meetingTemplateId: string;
+  meetingAppAllowlist: string[];
 
   // General settings
   telemetryEnabled: boolean;
@@ -246,6 +253,12 @@ const DEFAULT_SETTINGS: Settings = {
   claudeReasoningEffort: "medium",
   // Voice
   voiceAutoSubmit: true,
+  voiceCleanupEnabled: true,
+  voiceCustomVocabulary: [],
+  // Meeting
+  meetingAutoDetectEnabled: true,
+  meetingTemplateId: "discovery",
+  meetingAppAllowlist: ["zoom", "teams", "meet", "slack", "webex"],
   // General
   telemetryEnabled: true,
 };

--- a/tests/unit/dictation-cleanup.test.ts
+++ b/tests/unit/dictation-cleanup.test.ts
@@ -1,0 +1,19 @@
+// ABOUTME: Tests dictation cleanup behavior for filler removal and vocabulary casing.
+// ABOUTME: Covers local text rules used by the upgraded voice input hook.
+
+import { describe, expect, it } from "vitest";
+import { cleanupDictationText } from "@/lib/audio/dictationCleanup";
+
+describe("cleanupDictationText", () => {
+  it("removes fillers and normalizes spacing", () => {
+    expect(cleanupDictationText("um send this, uh, today")).toBe(
+      "Send this, today",
+    );
+  });
+
+  it("applies custom vocabulary casing", () => {
+    expect(
+      cleanupDictationText("tell serenbucks to route this", ["SerenBucks"]),
+    ).toBe("Tell SerenBucks to route this");
+  });
+});


### PR DESCRIPTION
## Summary

Refs #2119.

This adds the shared STT foundation needed by Meeting Mode and Dictation:

- Rust audio primitives for VAD chunking, dual-stream transcript merging, transcription retry boundaries, notes JSON parsing, meeting templates, and meeting auto-detect policy.
- SQLite-backed Meeting Mode persistence for meetings and transcript segments, exposed through typed Tauri commands.
- Frontend Meeting panel, sidebar entry, meeting store/service wrappers, and browser-runtime guards so the panel is safe in Vite/browser smoke runs.
- Dictation cleanup settings and text cleanup helper with focused unit coverage.

## Scope note

This intentionally does not close #2119 yet. Native Windows WASAPI/macOS capture, live Whisper HTTP orchestration, full call-end agent kickoff, CRM approval routing, and global/in-app streaming dictation UX still remain on the parent issue.

## Verification

- Passed: `cargo test --manifest-path src-tauri/Cargo.toml audio -- --nocapture`
- Passed: `cargo test --manifest-path src-tauri/Cargo.toml meeting_skill -- --nocapture`
- Passed: `cargo test --manifest-path src-tauri/Cargo.toml -- --nocapture` (590 passed, 1 ignored)
- Passed: `./node_modules/.bin/vitest run tests/unit/dictation-cleanup.test.ts`
- Passed: `./node_modules/.bin/vitest run` (1549 tests)
- Passed: `./node_modules/.bin/vite build` after final store audit fix
- Passed: targeted `./node_modules/.bin/biome check ...`
- Passed: Playwright browser smoke for opening the Meeting panel; found and fixed an initial browser-runtime Tauri event listener rejection.
- Passed: `git diff --cached --check`
- Passed: GitHub CI run `27088695790`, including frontend, lint, Rust, E2E, Linux build, macOS build, and `build (windows-latest)`.
- Passed: AWS Windows Server 2022 targeted audio harness on `i-0a575b70ba969fb6e`, importing the committed `src-tauri/src/audio` module by path: 16 audio tests passed.
- Known unrelated repo-level failure: `./node_modules/.bin/tsc --noEmit --pretty false` still fails on existing `PdfViewer.tsx` PDF.js typing errors and missing declaration for `bin/browser-local/providers.mjs`.
- AWS note: full `cargo test --lib audio -- --nocapture` on the temporary Server 2022 GNU harness built the Tauri test binary, but that binary could not start because of the host WebView/WebView2 loader runtime (`STATUS_ENTRYPOINT_NOT_FOUND`). The committed audio module was validated on AWS via the targeted harness above, and the full Windows Tauri package build passed in GitHub CI.

## Functional audit

Walked the new panel in browser mode with Playwright. The only issue found in the implemented path was the Meeting store attempting Tauri event registration outside the desktop runtime; this PR includes the runtime guard fix. No remaining P0/P1 issues were found in the implemented code paths during the walkthrough.