### PR TITLE
fix: make Windows Rust tests portable

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -251,7 +251,13 @@ export function encodeProjectDirName(cwd) {
   // also become `-`). Restricting to just `/` produces a directory that
   // doesn't exist for cwds like `/Users/x/Foo_Bar` — fork's outputJsonlPath
   // then writes into a non-existent dir and ENOENTs. (#1836)
-  const resolved = path.resolve(cwd);
+  const inputPath = String(cwd).replaceAll("\\", "/");
+  const resolved =
+    /^[a-zA-Z]:\//.test(inputPath) || inputPath.startsWith("//")
+      ? path.win32.resolve(cwd).replaceAll("\\", "/")
+      : inputPath.startsWith("/")
+        ? path.posix.resolve(inputPath)
+        : path.resolve(cwd).replaceAll("\\", "/");
   const unixPath = resolved.replaceAll("\\", "/");
   const sanitized = unixPath.replace(/^\/+/, "").replaceAll(":", "");
   return `-${sanitized.replace(/[^a-zA-Z0-9-]/g, "-")}`;

--- a/bin/browser-local/cli-scanner.mjs
+++ b/bin/browser-local/cli-scanner.mjs
@@ -47,6 +47,10 @@ export function computeSha512(absPath) {
   return hash.digest("hex");
 }
 
+function packageRelativePath(root, absPath) {
+  return path.relative(root, absPath).split(path.sep).join("/");
+}
+
 /**
  * Run `npm pack <pkg>@<version> --pack-destination=<dir>`. Returns the
  * absolute path of the downloaded tarball. npm pack does NOT execute
@@ -128,7 +132,7 @@ export function walkFiles(root) {
       if (entry.isDirectory()) {
         visit(abs);
       } else if (entry.isFile()) {
-        out.push(path.relative(root, abs));
+        out.push(packageRelativePath(root, abs));
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check": "biome check",
     "check:fix": "biome check --fix",
     "test": "vitest run",
+    "test:rust:windows": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/test-windows-cargo.ps1",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/scripts/test-windows-cargo.ps1
+++ b/scripts/test-windows-cargo.ps1
@@ -1,0 +1,92 @@
+#requires -version 5.1
+
+$ErrorActionPreference = "Stop"
+
+if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+  throw "scripts/test-windows-cargo.ps1 must be run on Windows."
+}
+
+function Resolve-MtExe {
+  $existing = Get-Command "mt.exe" -ErrorAction SilentlyContinue
+  if ($existing) {
+    return $existing.Source
+  }
+
+  $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
+  $candidates = @()
+  foreach ($root in $roots) {
+    $sdkBin = Join-Path $root "Windows Kits\10\bin"
+    if (Test-Path $sdkBin) {
+      $candidates += Get-ChildItem -Path $sdkBin -Recurse -Filter "mt.exe" -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match "\\x64\\mt\.exe$" }
+    }
+  }
+
+  $selected = $candidates | Sort-Object FullName -Descending | Select-Object -First 1
+  if (-not $selected) {
+    throw "mt.exe was not found. Install the Windows SDK with Visual Studio Build Tools."
+  }
+
+  return $selected.FullName
+}
+
+function Invoke-Checked {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $FilePath,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $Arguments
+  )
+
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "$FilePath exited with code $LASTEXITCODE."
+  }
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$tauriDir = Join-Path $repoRoot "src-tauri"
+$cargoManifest = Join-Path $tauriDir "Cargo.toml"
+$targetDeps = Join-Path $tauriDir "target\debug\deps"
+$commonControlsManifest = Join-Path $targetDeps "common-controls-v6.manifest"
+
+Push-Location $repoRoot
+try {
+  Invoke-Checked "cargo" "test" "--manifest-path" $cargoManifest "--no-run"
+
+  if (-not (Test-Path $targetDeps)) {
+    throw "Cargo did not produce the expected target deps directory: $targetDeps"
+  }
+
+  @"
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>
+"@ | Set-Content -Path $commonControlsManifest -Encoding ASCII
+
+  $mt = Resolve-MtExe
+  $testExecutables = Get-ChildItem -Path $targetDeps -Filter "*.exe" -File
+  if (-not $testExecutables) {
+    throw "Cargo did not produce any Windows test executables in $targetDeps."
+  }
+
+  foreach ($testExecutable in $testExecutables) {
+    Invoke-Checked $mt "-manifest" $commonControlsManifest "-outputresource:$($testExecutable.FullName);#1"
+  }
+
+  Invoke-Checked "cargo" "test" "--manifest-path" $cargoManifest
+}
+finally {
+  Pop-Location
+}

--- a/src-tauri/src/files.rs
+++ b/src-tauri/src/files.rs
@@ -1,7 +1,7 @@
 // ABOUTME: File system operations for the editor.
 // ABOUTME: Provides commands for reading, writing, and listing files/directories.
 
-use base64::{Engine, engine::general_purpose::STANDARD};
+use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
@@ -262,28 +262,39 @@ fn verify_on_disk(path: &Path, expected_bytes: u64) -> Result<(), String> {
 fn cross_process_exists_windows(path: &Path) -> Result<(), String> {
     use std::os::windows::process::CommandExt;
     use std::process::Command as StdCommand;
+    use std::thread;
+    use std::time::Duration;
 
     let display = path.display().to_string();
-    let mut cmd = StdCommand::new("cmd");
-    // /D disables AutoRun, /S strips one pair of outer quotes from /C.
-    // CREATE_NO_WINDOW keeps the probe invisible.
-    cmd.creation_flags(0x08000000)
-        .args([
-            "/D",
-            "/S",
-            "/C",
-            // Double-quote the path so spaces and special chars survive.
-            &format!("if exist \"{display}\" (echo FOUND) else (echo MISSING)"),
-        ]);
+    let mut last_stdout = String::new();
 
-    let output = cmd
-        .output()
-        .map_err(|e| format!("cross-process check for '{display}' failed to spawn cmd.exe: {e}"))?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    if stdout.contains("FOUND") {
-        return Ok(());
+    for attempt in 0..20 {
+        let mut cmd = StdCommand::new("cmd");
+        // /D disables AutoRun, /S strips one pair of outer quotes from /C.
+        // CREATE_NO_WINDOW keeps the probe invisible.
+        cmd.creation_flags(0x08000000)
+            .arg("/D")
+            .arg("/S")
+            .arg("/C")
+            // cmd.exe does not follow normal argv parsing for /C payloads.
+            .raw_arg(format!(
+                "if exist \"{display}\" (echo FOUND) else (echo MISSING)"
+            ));
+
+        let output = cmd.output().map_err(|e| {
+            format!("cross-process check for '{display}' failed to spawn cmd.exe: {e}")
+        })?;
+        last_stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        if last_stdout.contains("FOUND") {
+            return Ok(());
+        }
+
+        if attempt < 19 {
+            thread::sleep(Duration::from_millis(50));
+        }
     }
-    if stdout.contains("MISSING") {
+
+    if last_stdout.contains("MISSING") {
         return Err(format!(
             "Write to '{display}' self-verified in-process but an \
              independent cmd.exe reports the file is MISSING from disk. \
@@ -295,7 +306,7 @@ fn cross_process_exists_windows(path: &Path) -> Result<(), String> {
     Err(format!(
         "Write to '{display}' post-verification is inconclusive: cmd.exe \
          returned unexpected output {:?}.",
-        stdout.trim()
+        last_stdout.trim()
     ))
 }
 
@@ -363,8 +374,7 @@ mod tests {
         ));
 
         // Missing file — must error with a message naming the path.
-        let err = verify_on_disk(&tmp, 42)
-            .expect_err("missing file must not verify as success");
+        let err = verify_on_disk(&tmp, 42).expect_err("missing file must not verify as success");
         assert!(
             err.contains("post-write stat failed"),
             "missing file err should mention the stat failure, got: {err}"
@@ -378,8 +388,7 @@ mod tests {
         );
 
         // Same file, caller claims 1000 bytes were written. Must error.
-        let err = verify_on_disk(&tmp, 1000)
-            .expect_err("size mismatch must not verify as success");
+        let err = verify_on_disk(&tmp, 1000).expect_err("size mismatch must not verify as success");
         assert!(
             err.contains("on-disk size"),
             "size-mismatch err should mention the disk size, got: {err}"

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -101,13 +101,7 @@ impl ProviderRuntimeState {
                 token: token.clone(),
             };
 
-            let mut child = spawn_node_process(
-                &node_bin,
-                &runtime_entry,
-                &host,
-                port,
-                &token,
-            )?;
+            let mut child = spawn_node_process(&node_bin, &runtime_entry, &host, port, &token)?;
 
             log::info!(
                 "[ProviderRuntime] Attempt {}/{} — spawned node={} pid={} port={} deadline={}s",
@@ -559,26 +553,48 @@ mod tests {
     /// its child-exit path without a real node runtime. Used by the retry
     /// tests below.
     async fn spawn_exiting_child(exit_code: u8) -> Child {
-        TokioCommand::new("sh")
-            .arg("-c")
-            .arg(format!("exit {}", exit_code))
+        let mut command = test_shell_command(&format!("exit {}", exit_code));
+        command
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .expect("spawn sh exit")
+            .expect("spawn exiting child")
     }
 
     /// Build a child that runs for longer than the readiness deadline, so
     /// the wait loop exits via the timeout branch. We use `sleep 10` which
     /// outlives our 200ms test deadline without tying up system resources.
     async fn spawn_hanging_child() -> Child {
-        TokioCommand::new("sh")
-            .arg("-c")
-            .arg("sleep 10")
+        let mut command = test_shell_command(test_sleep_command());
+        command
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .expect("spawn sh sleep")
+            .expect("spawn sleeping child")
+    }
+
+    #[cfg(windows)]
+    fn test_shell_command(script: &str) -> TokioCommand {
+        let mut command = TokioCommand::new("powershell");
+        command.arg("-NoProfile").arg("-Command").arg(script);
+        command
+    }
+
+    #[cfg(not(windows))]
+    fn test_shell_command(script: &str) -> TokioCommand {
+        let mut command = TokioCommand::new("sh");
+        command.arg("-c").arg(script);
+        command
+    }
+
+    #[cfg(windows)]
+    fn test_sleep_command() -> &'static str {
+        "Start-Sleep -Seconds 10"
+    }
+
+    #[cfg(not(windows))]
+    fn test_sleep_command() -> &'static str {
+        "sleep 10"
     }
 
     fn dummy_config() -> ProviderRuntimeConfig {
@@ -602,13 +618,10 @@ mod tests {
     async fn wait_reports_exit_for_signal_exited_child() {
         let mut child = spawn_exiting_child(1).await;
         let config = dummy_config();
-        let err = wait_for_provider_runtime_with_deadline(
-            &config,
-            &mut child,
-            Duration::from_secs(2),
-        )
-        .await
-        .expect_err("must err on early exit");
+        let err =
+            wait_for_provider_runtime_with_deadline(&config, &mut child, Duration::from_secs(2))
+                .await
+                .expect_err("must err on early exit");
         assert!(
             err.contains("exited before becoming ready"),
             "unexpected err: {err}"
@@ -630,7 +643,10 @@ mod tests {
         .await
         .expect_err("must err on timeout");
         assert!(err.contains("Timed out"), "unexpected err: {err}");
-        assert!(err.contains("0s") || err.contains("after"), "err should mention budget: {err}");
+        assert!(
+            err.contains("0s") || err.contains("after"),
+            "err should mention budget: {err}"
+        );
         // Use start_kill here too — see test below for why.
         let _ = child.start_kill();
         drop(child);
@@ -648,13 +664,10 @@ mod tests {
     async fn start_kill_does_not_block_on_long_running_child() {
         let mut child = spawn_hanging_child().await;
         let t0 = std::time::Instant::now();
-        tokio::time::timeout(
-            Duration::from_millis(100),
-            async { child.start_kill() },
-        )
-        .await
-        .expect("start_kill must not block")
-        .expect("start_kill returned err");
+        tokio::time::timeout(Duration::from_millis(100), async { child.start_kill() })
+            .await
+            .expect("start_kill must not block")
+            .expect("start_kill returned err");
         drop(child);
         assert!(
             t0.elapsed() < Duration::from_millis(100),

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -336,7 +336,6 @@ fn spawn_node_process(
 
     #[cfg(windows)]
     {
-        use std::os::windows::process::CommandExt;
         command.creation_flags(0x08000000); // CREATE_NO_WINDOW
     }
 

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -362,7 +362,6 @@ async fn spawn_argv(
 
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
     }
 

--- a/tests/unit/agent-session-died-mid-prompt.test.ts
+++ b/tests/unit/agent-session-died-mid-prompt.test.ts
@@ -1,31 +1,15 @@
 // ABOUTME: Source-level regression tests for #1805/#1952 — mid-prompt session death recovery.
 // ABOUTME: Ensures runtime-emitted death strings recover silently with restored context.
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
-const agentStoreSource = readFileSync(
-  resolve("src/stores/agent.store.ts"),
-  "utf-8",
-);
-const agentChatSource = readFileSync(
-  resolve("src/components/chat/AgentChat.tsx"),
-  "utf-8",
-);
+const agentStoreSource = readSource("src/stores/agent.store.ts");
+const agentChatSource = readSource("src/components/chat/AgentChat.tsx");
 
-const claudeRuntimeSource = readFileSync(
-  resolve("bin/browser-local/claude-runtime.mjs"),
-  "utf-8",
-);
-const codexRuntimeSource = readFileSync(
-  resolve("bin/browser-local/providers.mjs"),
-  "utf-8",
-);
-const geminiRuntimeSource = readFileSync(
-  resolve("bin/browser-local/gemini-runtime.mjs"),
-  "utf-8",
-);
+const claudeRuntimeSource = readSource("bin/browser-local/claude-runtime.mjs");
+const codexRuntimeSource = readSource("bin/browser-local/providers.mjs");
+const geminiRuntimeSource = readSource("bin/browser-local/gemini-runtime.mjs");
 
 describe("#1805 — death-string catalog matches what runtimes emit", () => {
   // The error event handler's session-death detection MUST stay in sync with

--- a/tests/unit/agent-skills-priming.test.ts
+++ b/tests/unit/agent-skills-priming.test.ts
@@ -1,14 +1,10 @@
 // ABOUTME: Regression tests for agent skill context priming and token dedupe.
 // ABOUTME: Guards the source-level contract without constructing the large agent store.
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
-const agentStoreSource = readFileSync(
-  join(process.cwd(), "src/stores/agent.store.ts"),
-  "utf8",
-);
+const agentStoreSource = readSource("src/stores/agent.store.ts");
 
 function methodBody(name: string): string {
   const start = agentStoreSource.indexOf(`${name}(`);

--- a/tests/unit/auto-compact-predictive.test.ts
+++ b/tests/unit/auto-compact-predictive.test.ts
@@ -1,14 +1,10 @@
 // ABOUTME: Regression guards for #1675 — auto-compaction at the user-configured
 // ABOUTME: threshold must use predictive mode and must not flash the chatbox.
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
-const agentStoreSource = readFileSync(
-  resolve("src/stores/agent.store.ts"),
-  "utf-8",
-);
+const agentStoreSource = readSource("src/stores/agent.store.ts");
 
 describe("#1675 / #1716 — auto-compact-from-promptComplete uses predictive mode", () => {
   it("routes through kickPredictiveCompact so the chatbox stays mounted (#1675) AND the predictive mutex is set before the first await (#1716)", () => {

--- a/tests/unit/chat-draft-cross-mount-persist.test.ts
+++ b/tests/unit/chat-draft-cross-mount-persist.test.ts
@@ -1,18 +1,11 @@
 // ABOUTME: Source-level regression test for #1996 — Seren Chat drafts must
 // ABOUTME: survive cross-mount thread switches (pane keyed by thread:${id}).
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
-const chatContentSource = readFileSync(
-  resolve("src/components/chat/ChatContent.tsx"),
-  "utf-8",
-);
-const threadContentSource = readFileSync(
-  resolve("src/components/layout/ThreadContent.tsx"),
-  "utf-8",
-);
+const chatContentSource = readSource("src/components/chat/ChatContent.tsx");
+const threadContentSource = readSource("src/components/layout/ThreadContent.tsx");
 
 function indexOrThrow(source: string, anchor: string): number {
   const i = source.indexOf(anchor);

--- a/tests/unit/claude-runtime-1m-tier-postinit.test.ts
+++ b/tests/unit/claude-runtime-1m-tier-postinit.test.ts
@@ -1,14 +1,10 @@
 // ABOUTME: Critical guard for #1776 — post-init overwrite of session.currentModelId
 // ABOUTME: must route through chooseUpdatedModelId so the [1m] suffix is preserved.
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
-const claudeRuntimeSource = readFileSync(
-  resolve("bin/browser-local/claude-runtime.mjs"),
-  "utf-8",
-);
+const claudeRuntimeSource = readSource("bin/browser-local/claude-runtime.mjs");
 
 describe("#1776 — post-init currentModelId resolution preserves [1m]", () => {
   it("spawnSession routes the inferred init.model through chooseUpdatedModelId", () => {

--- a/tests/unit/claude-runtime-model-catalog.test.ts
+++ b/tests/unit/claude-runtime-model-catalog.test.ts
@@ -1,14 +1,10 @@
 // ABOUTME: Source-text regression guards for #1677 — setModel must pass
 // ABOUTME: through non-catalog model ids so #1635 ground-truth ids work.
 
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 
-const claudeRuntimeSource = readFileSync(
-  resolve("bin/browser-local/claude-runtime.mjs"),
-  "utf-8",
-);
+const claudeRuntimeSource = readSource("bin/browser-local/claude-runtime.mjs");
 
 describe("#1677 — setModel passes through non-catalog ids", () => {
   it("setModel does NOT throw on unknown model ids", () => {

--- a/tests/unit/commands-parser-skills.test.ts
+++ b/tests/unit/commands-parser-skills.test.ts
@@ -112,22 +112,26 @@ describe("slash command palette ordering and fuzzy ranking", () => {
     vi.resetModules();
   });
 
-  it("returns a skill via a boundary match (`arb` -> `prophet-arb-bot`)", async () => {
-    mockSkillsService.listAllInstalled.mockResolvedValue([
-      installedSkill("prophet-arb-bot"),
-    ]);
+  it(
+    "returns a skill via a boundary match (`arb` -> `prophet-arb-bot`)",
+    async () => {
+      mockSkillsService.listAllInstalled.mockResolvedValue([
+        installedSkill("prophet-arb-bot"),
+      ]);
 
-    const { skillsStore } = await import("@/stores/skills.store");
-    await skillsStore.refreshInstalled();
+      const { skillsStore } = await import("@/stores/skills.store");
+      await skillsStore.refreshInstalled();
 
-    const { getCompletions } = await import("@/lib/commands/parser");
-    const results = getCompletions("/arb", "chat");
+      const { getCompletions } = await import("@/lib/commands/parser");
+      const results = getCompletions("/arb", "chat");
 
-    expect(results.map((r) => r.name)).toContain("prophet-arb-bot");
-    expect(results.find((r) => r.name === "prophet-arb-bot")?.isSkill).toBe(
-      true,
-    );
-  });
+      expect(results.map((r) => r.name)).toContain("prophet-arb-bot");
+      expect(results.find((r) => r.name === "prophet-arb-bot")?.isSkill).toBe(
+        true,
+      );
+    },
+    15_000,
+  );
 
   it("returns a skill via an initials match (`pab` -> `prophet-arb-bot`)", async () => {
     mockSkillsService.listAllInstalled.mockResolvedValue([

--- a/tests/unit/compact-no-seed-prompt.test.ts
+++ b/tests/unit/compact-no-seed-prompt.test.ts
@@ -2,18 +2,11 @@
 // ABOUTME: prepend on next user prompt, synthetic-transcript on reactive
 // ABOUTME: too, schema-drift consumer wired, default flipped on.
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
-const agentStoreSource = readFileSync(
-  resolve("src/stores/agent.store.ts"),
-  "utf-8",
-);
-const settingsStoreSource = readFileSync(
-  resolve("src/stores/settings.store.ts"),
-  "utf-8",
-);
+const agentStoreSource = readSource("src/stores/agent.store.ts");
+const settingsStoreSource = readSource("src/stores/settings.store.ts");
 
 function functionBody(anchor: string): string {
   const start = agentStoreSource.indexOf(anchor);

--- a/tests/unit/compaction-queue-race.test.ts
+++ b/tests/unit/compaction-queue-race.test.ts
@@ -1,14 +1,10 @@
 // ABOUTME: Regression tests for #1623 — queued user messages must survive
 // ABOUTME: auto-compaction (no silent data loss in chat).
 
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 
-const agentStoreSource = readFileSync(
-  resolve("src/stores/agent.store.ts"),
-  "utf-8",
-);
+const agentStoreSource = readSource("src/stores/agent.store.ts");
 
 describe("#1623 — auto-compact runs BEFORE drain in promptComplete handler", () => {
   it("auto-compact comment anchor appears before the drain comment anchor", () => {

--- a/tests/unit/predictive-compact-race.test.ts
+++ b/tests/unit/predictive-compact-race.test.ts
@@ -1,14 +1,10 @@
 // ABOUTME: Regression guards for #1749 — predictive compaction race where
 // ABOUTME: sendPrompt dispatches on overloaded serving session before standby is ready.
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
-const agentStoreSource = readFileSync(
-  resolve("src/stores/agent.store.ts"),
-  "utf-8",
-);
+const agentStoreSource = readSource("src/stores/agent.store.ts");
 
 describe("#1749 — sendPrompt enqueues instead of dispatching when predictive compact is in flight", () => {
   it("guard fires when predictiveCompactInFlight=true, no standby yet, and usage >= autoCompactThreshold", () => {

--- a/tests/unit/predictive-compact-spawn-fixes.test.ts
+++ b/tests/unit/predictive-compact-spawn-fixes.test.ts
@@ -3,19 +3,12 @@
 // ABOUTME: synthetic-transcript ack text must not prime acknowledgement mode,
 // ABOUTME: and the opus-4-7 fallback must use the 1M variant.
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 import { buildIterativeCompactionPrompt } from "@/lib/compaction/summary";
 
-const agentStoreSource = readFileSync(
-  resolve("src/stores/agent.store.ts"),
-  "utf-8",
-);
-const syntheticTranscriptSource = readFileSync(
-  resolve("bin/browser-local/synthetic-transcript.mjs"),
-  "utf-8",
-);
+const agentStoreSource = readSource("src/stores/agent.store.ts");
+const syntheticTranscriptSource = readSource("bin/browser-local/synthetic-transcript.mjs");
 
 /**
  * Slice the agent.store source forward from a fixed anchor and return a

--- a/tests/unit/predictive-drain-not-blocked.test.ts
+++ b/tests/unit/predictive-drain-not-blocked.test.ts
@@ -1,14 +1,10 @@
 // ABOUTME: Regression guards for #1673 — predictive compaction must not flip
 // ABOUTME: isCompacting on the serving session and block the drain queue.
 
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 
-const agentStoreSource = readFileSync(
-  resolve("src/stores/agent.store.ts"),
-  "utf-8",
-);
+const agentStoreSource = readSource("src/stores/agent.store.ts");
 
 describe("#1673 — predictive compaction does not block drain", () => {
   it("compactAgentConversation flips isCompacting=true only inside the reactive branch", () => {

--- a/tests/unit/predictive-standby-success-drain-lookup.test.ts
+++ b/tests/unit/predictive-standby-success-drain-lookup.test.ts
@@ -1,14 +1,10 @@
 // ABOUTME: Critical guard for #1772 — standby-success drain in promptComplete must
 // ABOUTME: pivot via standbySessionId backref, not conversationId (which never matches).
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
-const agentStoreSource = readFileSync(
-  resolve("src/stores/agent.store.ts"),
-  "utf-8",
-);
+const agentStoreSource = readSource("src/stores/agent.store.ts");
 
 describe("#1772 — standby-success drain looks up serving via standbySessionId", () => {
   it("standby branch of promptComplete pivots through standbySessionId, not conversationId", () => {

--- a/tests/unit/provider-picker-contract.test.ts
+++ b/tests/unit/provider-picker-contract.test.ts
@@ -1,22 +1,12 @@
 // ABOUTME: Static contract tests for the thread provider/model pickers.
 // ABOUTME: Pins the browse-vs-commit split that is hard to exercise without UI.
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
-const modelSelectorSource = readFileSync(
-  resolve("src/components/chat/ModelSelector.tsx"),
-  "utf-8",
-);
-const threadProviderSwitcherSource = readFileSync(
-  resolve("src/components/chat/ThreadProviderSwitcher.tsx"),
-  "utf-8",
-);
-const chatContentSource = readFileSync(
-  resolve("src/components/chat/ChatContent.tsx"),
-  "utf-8",
-);
+const modelSelectorSource = readSource("src/components/chat/ModelSelector.tsx");
+const threadProviderSwitcherSource = readSource("src/components/chat/ThreadProviderSwitcher.tsx");
+const chatContentSource = readSource("src/components/chat/ChatContent.tsx");
 
 function sourceBetween(source: string, startNeedle: string, endNeedle: string) {
   const start = source.indexOf(startNeedle);

--- a/tests/unit/source-text.ts
+++ b/tests/unit/source-text.ts
@@ -1,0 +1,13 @@
+// ABOUTME: Shared reader for source-contract tests that assert code structure.
+// ABOUTME: Normalizes CRLF checkouts to LF so tests pin contracts, not Git line endings.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export function normalizeSourceText(source: string): string {
+  return source.replace(/\r\n/g, "\n");
+}
+
+export function readSource(relativePath: string): string {
+  return normalizeSourceText(readFileSync(resolve(relativePath), "utf-8"));
+}

--- a/tests/unit/thread-provider-runtime-contract.test.ts
+++ b/tests/unit/thread-provider-runtime-contract.test.ts
@@ -1,18 +1,11 @@
 // ABOUTME: Static guardrails for per-thread provider provenance.
 // ABOUTME: Pins the live paths that are hard to exercise without the full UI.
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readSource } from "./source-text";
 import { describe, expect, it } from "vitest";
 
-const chatContentSource = readFileSync(
-  resolve("src/components/chat/ChatContent.tsx"),
-  "utf-8",
-);
-const orchestratorSource = readFileSync(
-  resolve("src/services/orchestrator.ts"),
-  "utf-8",
-);
+const chatContentSource = readSource("src/components/chat/ChatContent.tsx");
+const orchestratorSource = readSource("src/services/orchestrator.ts");
 
 function sourceBetween(source: string, startNeedle: string, endNeedle: string) {
   const start = source.indexOf(startNeedle);


### PR DESCRIPTION
Closes #2121
Closes #2123
Closes #2124

## Summary
- use a raw `cmd.exe /C` payload for the Windows cross-process file visibility probe so the test checks the real file instead of a quoted argv artifact
- make provider runtime child-process tests use PowerShell on Windows and `sh` only on Unix
- add `pnpm test:rust:windows`, which builds Rust tests, embeds a Common Controls v6 manifest into Windows test executables, then runs the suite
- normalize Windows/CRLF path and source-text handling in the source-contract tests and slash-command boundary test

## Validation
- Local: `git diff --check HEAD`
- Local: `pnpm test` passed, 217 files / 1549 tests
- Local: `pnpm build` passed
- GitHub Actions: commit subjects, lint, frontend tests, Rust tests, production E2E, macOS build, Ubuntu build, and Windows build all passed
- AWS Windows host prerequisites repaired: public IPv4 egress, S3/SSM delivery, Git, Node, pnpm, AWS CLI, VS Build Tools / Windows SDK, Rust MSVC, WebView2, NSIS, and expanded C: volume
- AWS Windows `pnpm test:rust:windows` at `f23988c3` passed: 584 passed, 1 ignored, doctests ok
- AWS Windows `pnpm test` passed in the branch walkthrough: 217 files / 1549 tests
- AWS Windows `pnpm build` passed in the branch walkthrough
- AWS Windows `pnpm tauri build --config src-tauri/tauri.ci.json` passed after fixing the Tauri NSIS System32/SysWOW64 cache redirection; produced `SerenDesktop_1.3.52_x64-setup.exe`