### PR TITLE
feat(stt): wire the STT pipeline, notes, routing, UI, and dictation (PR1)

### DIFF
--- a/src-tauri/src/audio/capture/fake.rs
+++ b/src-tauri/src/audio/capture/fake.rs
@@ -1,0 +1,44 @@
+// ABOUTME: Deterministic capture source that replays preloaded PCM frames.
+// ABOUTME: Drives pipeline tests and dev runs without real audio hardware.
+
+use super::{AudioCaptureSource, CaptureError, FrameSender, PcmFrame};
+
+/// A capture source that emits a fixed list of frames, then closes the stream.
+///
+/// Used by pipeline tests and dev replay: `start` synchronously pushes every
+/// frame into the sink and returns, dropping the sink so the channel closes and
+/// the consumer sees end-of-stream. Fully deterministic — no threads, no clock.
+pub struct FakePcmSource {
+    frames: Vec<Vec<i16>>,
+}
+
+impl FakePcmSource {
+    /// Build a source from one contiguous buffer split into fixed-size frames.
+    pub fn from_samples(samples: Vec<i16>, frame_len: usize) -> Self {
+        let frame_len = frame_len.max(1);
+        let frames = samples
+            .chunks(frame_len)
+            .map(<[i16]>::to_vec)
+            .collect::<Vec<_>>();
+        Self { frames }
+    }
+
+    /// Build a source from explicit frames.
+    pub fn from_frames(frames: Vec<Vec<i16>>) -> Self {
+        Self { frames }
+    }
+}
+
+impl AudioCaptureSource for FakePcmSource {
+    fn start(&mut self, sink: FrameSender) -> Result<(), CaptureError> {
+        for samples in self.frames.drain(..) {
+            // A dropped receiver is not an error for a replay source.
+            let _ = sink.send(PcmFrame { samples });
+        }
+        Ok(())
+    }
+
+    fn stop(&mut self) {
+        self.frames.clear();
+    }
+}

--- a/src-tauri/src/audio/capture/mod.rs
+++ b/src-tauri/src/audio/capture/mod.rs
@@ -1,0 +1,128 @@
+// ABOUTME: Capture-source abstraction and PCM format utilities for Meeting Mode.
+// ABOUTME: Sources emit 16 kHz mono i16 frames; downmix/resample math is unit-tested.
+
+pub mod fake;
+
+use thiserror::Error;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// Pipeline-facing sample rate. Every source normalizes to this before emitting.
+pub const TARGET_SAMPLE_RATE: u32 = 16_000;
+
+/// A buffer of 16 kHz mono signed-16 PCM samples produced by a capture source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PcmFrame {
+    pub samples: Vec<i16>,
+}
+
+/// Channel a source pushes frames into. Dropping every sender closes the stream.
+pub type FrameSender = UnboundedSender<PcmFrame>;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum CaptureError {
+    #[error("audio device unavailable: {0}")]
+    Device(String),
+    #[error("audio capture unsupported on this platform/build: {0}")]
+    Unsupported(String),
+}
+
+/// A single capture stream (mic, system audio, …) normalized to 16 kHz mono PCM.
+///
+/// `start` begins delivering frames into `sink` and returns once capture is live;
+/// frames continue asynchronously until `stop` is called or the source ends (which
+/// it signals by dropping its `sink`, closing the channel). Implementations must be
+/// `Send` so the pipeline can own them across threads.
+pub trait AudioCaptureSource: Send {
+    fn start(&mut self, sink: FrameSender) -> Result<(), CaptureError>;
+    fn stop(&mut self);
+}
+
+/// Downmix interleaved PCM to mono and resample to [`TARGET_SAMPLE_RATE`].
+///
+/// `channels` is the interleaved channel count of `samples`; `sample_rate` is its
+/// source rate. Pure and deterministic — this is the critical math under test.
+pub fn to_mono_16k(samples: &[i16], channels: u16, sample_rate: u32) -> Vec<i16> {
+    let mono = downmix_to_mono(samples, channels);
+    resample_to_16k(&mono, sample_rate)
+}
+
+/// Average interleaved channels into a single mono track.
+pub fn downmix_to_mono(samples: &[i16], channels: u16) -> Vec<i16> {
+    if channels <= 1 {
+        return samples.to_vec();
+    }
+    let channels = channels as usize;
+    samples
+        .chunks(channels)
+        .map(|frame| {
+            let sum: i32 = frame.iter().map(|s| *s as i32).sum();
+            (sum / frame.len() as i32) as i16
+        })
+        .collect()
+}
+
+/// Linearly resample a mono track to [`TARGET_SAMPLE_RATE`].
+pub fn resample_to_16k(mono: &[i16], sample_rate: u32) -> Vec<i16> {
+    if sample_rate == TARGET_SAMPLE_RATE || mono.is_empty() || sample_rate == 0 {
+        return mono.to_vec();
+    }
+
+    let out_len =
+        ((mono.len() as u64 * TARGET_SAMPLE_RATE as u64) / sample_rate as u64) as usize;
+    if out_len == 0 {
+        return Vec::new();
+    }
+
+    let ratio = sample_rate as f64 / TARGET_SAMPLE_RATE as f64;
+    let last = mono.len() - 1;
+    (0..out_len)
+        .map(|i| {
+            let src_pos = i as f64 * ratio;
+            let idx = src_pos.floor() as usize;
+            let frac = src_pos - idx as f64;
+            let a = mono[idx.min(last)] as f64;
+            let b = mono[(idx + 1).min(last)] as f64;
+            (a + (b - a) * frac).round() as i16
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mono_at_target_rate_passes_through_unchanged() {
+        let samples = vec![0, 100, -100, 32_000];
+        assert_eq!(to_mono_16k(&samples, 1, TARGET_SAMPLE_RATE), samples);
+    }
+
+    #[test]
+    fn stereo_downmix_averages_channel_pairs() {
+        // [L,R, L,R] at 16 kHz -> [(100+300)/2, (200+400)/2]
+        let samples = vec![100, 300, 200, 400];
+        assert_eq!(to_mono_16k(&samples, 2, TARGET_SAMPLE_RATE), vec![200, 300]);
+    }
+
+    #[test]
+    fn downsample_48k_to_16k_picks_every_third_sample() {
+        // 6 mono samples at 48 kHz -> 2 at 16 kHz (ratio 3.0, integer taps).
+        let mono = vec![0, 10, 20, 30, 40, 50];
+        let out = resample_to_16k(&mono, 48_000);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out, vec![0, 30]);
+    }
+
+    #[test]
+    fn upsample_8k_to_16k_interpolates_between_samples() {
+        // 2 mono samples at 8 kHz -> 4 at 16 kHz (ratio 0.5), linear interpolation.
+        let mono = vec![0, 100];
+        let out = resample_to_16k(&mono, 8_000);
+        assert_eq!(out, vec![0, 50, 100, 100]);
+    }
+
+    #[test]
+    fn empty_input_yields_empty_output() {
+        assert!(to_mono_16k(&[], 2, 48_000).is_empty());
+    }
+}

--- a/src-tauri/src/audio/chunker.rs
+++ b/src-tauri/src/audio/chunker.rs
@@ -31,9 +31,20 @@ pub struct Chunk {
     pub samples: Vec<i16>,
 }
 
+/// Split a complete PCM buffer into speech chunks on silence boundaries.
 pub fn chunk(samples: &[i16], cfg: ChunkCfg) -> Vec<Chunk> {
+    chunk_stream(samples, cfg, true).0
+}
+
+/// Split a PCM buffer, returning `(completed_chunks, consumed_samples)`.
+///
+/// When `at_end` is false the trailing in-progress utterance is NOT emitted and
+/// is left unconsumed (its start index is the keep-point) so a live stream can
+/// finish it once more audio arrives. `consumed_samples` is the prefix the caller
+/// may discard. When `at_end` is true the remainder is flushed and fully consumed.
+pub fn chunk_stream(samples: &[i16], cfg: ChunkCfg, at_end: bool) -> (Vec<Chunk>, usize) {
     if samples.is_empty() || cfg.sample_rate == 0 || cfg.frame_ms == 0 {
-        return Vec::new();
+        return (Vec::new(), samples.len());
     }
 
     let frame_samples = samples_for_ms(cfg.sample_rate, cfg.frame_ms).max(1);
@@ -86,18 +97,66 @@ pub fn chunk(samples: &[i16], cfg: ChunkCfg) -> Vec<Chunk> {
         frame_start = frame_end;
     }
 
-    if let Some(start) = speech_start {
-        let end = if last_speech_end > start {
-            last_speech_end
-        } else {
-            samples.len()
-        };
-        if duration_ms(start, end, cfg.sample_rate) >= cfg.min_window_ms {
-            push_chunk(&mut chunks, samples, start, end, cfg.sample_rate);
+    let consumed = if at_end {
+        if let Some(start) = speech_start {
+            let end = if last_speech_end > start {
+                last_speech_end
+            } else {
+                samples.len()
+            };
+            if duration_ms(start, end, cfg.sample_rate) >= cfg.min_window_ms {
+                push_chunk(&mut chunks, samples, start, end, cfg.sample_rate);
+            }
+        }
+        samples.len()
+    } else {
+        // Keep only the in-progress utterance; everything before it is resolved.
+        speech_start.unwrap_or(samples.len())
+    };
+
+    (chunks, consumed)
+}
+
+/// Stateful driver that feeds a live stream into [`chunk_stream`], emitting
+/// completed chunks with absolute timestamps and discarding consumed audio.
+pub struct StreamingChunker {
+    cfg: ChunkCfg,
+    buffer: Vec<i16>,
+    base_sample: usize,
+}
+
+impl StreamingChunker {
+    pub fn new(cfg: ChunkCfg) -> Self {
+        Self {
+            cfg,
+            buffer: Vec::new(),
+            base_sample: 0,
         }
     }
 
-    chunks
+    /// Append samples and return any chunks that just completed (absolute ms).
+    pub fn push(&mut self, samples: &[i16]) -> Vec<Chunk> {
+        self.buffer.extend_from_slice(samples);
+        self.drain(false)
+    }
+
+    /// Flush the final in-progress utterance at end of stream (absolute ms).
+    pub fn finish(&mut self) -> Vec<Chunk> {
+        self.drain(true)
+    }
+
+    fn drain(&mut self, at_end: bool) -> Vec<Chunk> {
+        let base_ms = sample_to_ms(self.base_sample, self.cfg.sample_rate);
+        let (mut chunks, consumed) = chunk_stream(&self.buffer, self.cfg, at_end);
+        for chunk in &mut chunks {
+            chunk.start_ms = chunk.start_ms.saturating_add(base_ms);
+            chunk.end_ms = chunk.end_ms.saturating_add(base_ms);
+        }
+        let consumed = consumed.min(self.buffer.len());
+        self.buffer.drain(0..consumed);
+        self.base_sample += consumed;
+        chunks
+    }
 }
 
 fn push_chunk(
@@ -214,5 +273,25 @@ mod tests {
         let chunks = chunk(&samples, cfg());
 
         assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn streaming_chunker_emits_on_close_and_flushes_remainder() {
+        let mut streaming = StreamingChunker::new(cfg());
+
+        // In-progress speech (no trailing silence) emits nothing yet.
+        let first = streaming.push(&[pcm(0, 50), pcm(1_000, 80)].concat());
+        assert!(first.is_empty());
+
+        // A following silence closes the utterance into one chunk, with absolute ms.
+        let second = streaming.push(&pcm(0, 60));
+        assert_eq!(second.len(), 1);
+        assert_eq!((second[0].start_ms, second[0].end_ms), (50, 130));
+
+        // A new utterance stays buffered until the stream ends.
+        let third = streaming.push(&pcm(1_000, 50));
+        assert!(third.is_empty());
+        let flushed = streaming.finish();
+        assert_eq!(flushed.len(), 1);
     }
 }

--- a/src-tauri/src/audio/cleanup.rs
+++ b/src-tauri/src/audio/cleanup.rs
@@ -1,0 +1,114 @@
+// ABOUTME: Shared text-cleanup prompt assembly for meeting notes and dictation.
+// ABOUTME: One vocabulary-aware engine so notes and dictation never duplicate logic.
+
+/// Build the clause asking the model to respect the user's custom vocabulary.
+/// Returns an empty string when no usable terms are supplied.
+pub fn vocabulary_clause(vocabulary: &[String]) -> String {
+    let terms: Vec<&str> = vocabulary
+        .iter()
+        .map(|term| term.trim())
+        .filter(|term| !term.is_empty())
+        .collect();
+    if terms.is_empty() {
+        return String::new();
+    }
+    format!(
+        "Preserve and correctly spell these domain terms when they occur: {}.",
+        terms.join(", ")
+    )
+}
+
+/// The cleanup directives reused by both notes generation and dictation cleanup.
+/// This is the single shared engine the two consumers compose into their prompts.
+pub fn cleanup_directives(vocabulary: &[String]) -> String {
+    let mut directives = String::from(
+        "Remove filler words and false starts, fix punctuation and capitalization, \
+         and keep the speaker's meaning and wording intact. Do not invent content.",
+    );
+    let vocab = vocabulary_clause(vocabulary);
+    if !vocab.is_empty() {
+        directives.push(' ');
+        directives.push_str(&vocab);
+    }
+    directives
+}
+
+/// Prompt to clean a single block of dictated text (raw -> polished).
+pub fn build_cleanup_prompt(raw_text: &str, vocabulary: &[String]) -> String {
+    format!(
+        "{}\n\nReturn only the cleaned text with no preamble or commentary.\n\nText:\n{}",
+        cleanup_directives(vocabulary),
+        raw_text.trim()
+    )
+}
+
+/// Prompt to transform a selection per a spoken instruction (edit-by-voice).
+pub fn build_transform_prompt(
+    selection: &str,
+    instruction: &str,
+    vocabulary: &[String],
+) -> String {
+    let vocab = vocabulary_clause(vocabulary);
+    let vocab_line = if vocab.is_empty() {
+        String::new()
+    } else {
+        format!("\n{}", vocab)
+    };
+    format!(
+        "Apply this instruction to the selected text and return only the rewritten text \
+         with no preamble or commentary.{}\n\nInstruction: {}\n\nSelected text:\n{}",
+        vocab_line,
+        instruction.trim(),
+        selection.trim()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vocabulary_clause_filters_blank_terms() {
+        let vocab = vec![
+            "Affinity".to_string(),
+            "  ".to_string(),
+            "".to_string(),
+            "SerenBucks".to_string(),
+        ];
+        let clause = vocabulary_clause(&vocab);
+        assert!(clause.contains("Affinity"));
+        assert!(clause.contains("SerenBucks"));
+        // Blank entries must not leave dangling separators.
+        assert!(!clause.contains(", ,"));
+    }
+
+    #[test]
+    fn vocabulary_clause_is_empty_without_terms() {
+        assert!(vocabulary_clause(&[]).is_empty());
+        assert!(vocabulary_clause(&["   ".to_string()]).is_empty());
+    }
+
+    #[test]
+    fn cleanup_directives_appends_vocabulary_when_present() {
+        let plain = cleanup_directives(&[]);
+        assert!(!plain.contains("domain terms"));
+        let with_vocab = cleanup_directives(&["Glide".to_string()]);
+        assert!(with_vocab.contains("Glide"));
+        assert!(with_vocab.contains("domain terms"));
+    }
+
+    #[test]
+    fn build_cleanup_prompt_embeds_text_and_directives() {
+        let prompt = build_cleanup_prompt("um so like the thing", &["Kraken".to_string()]);
+        assert!(prompt.contains("um so like the thing"));
+        assert!(prompt.contains("Remove filler words"));
+        assert!(prompt.contains("Kraken"));
+    }
+
+    #[test]
+    fn build_transform_prompt_embeds_instruction_and_selection() {
+        let prompt = build_transform_prompt("first second third", "make this a bullet list", &[]);
+        assert!(prompt.contains("make this a bullet list"));
+        assert!(prompt.contains("first second third"));
+    }
+}

--- a/src-tauri/src/audio/cleanup.rs
+++ b/src-tauri/src/audio/cleanup.rs
@@ -70,13 +70,13 @@ mod tests {
     #[test]
     fn vocabulary_clause_filters_blank_terms() {
         let vocab = vec![
-            "Affinity".to_string(),
+            "Postgres".to_string(),
             "  ".to_string(),
             "".to_string(),
             "SerenBucks".to_string(),
         ];
         let clause = vocabulary_clause(&vocab);
-        assert!(clause.contains("Affinity"));
+        assert!(clause.contains("Postgres"));
         assert!(clause.contains("SerenBucks"));
         // Blank entries must not leave dangling separators.
         assert!(!clause.contains(", ,"));
@@ -92,8 +92,8 @@ mod tests {
     fn cleanup_directives_appends_vocabulary_when_present() {
         let plain = cleanup_directives(&[]);
         assert!(!plain.contains("domain terms"));
-        let with_vocab = cleanup_directives(&["Glide".to_string()]);
-        assert!(with_vocab.contains("Glide"));
+        let with_vocab = cleanup_directives(&["Grafana".to_string()]);
+        assert!(with_vocab.contains("Grafana"));
         assert!(with_vocab.contains("domain terms"));
     }
 

--- a/src-tauri/src/audio/llm.rs
+++ b/src-tauri/src/audio/llm.rs
@@ -1,0 +1,81 @@
+// ABOUTME: Single-shot chat completion via the Seren Gateway (no streaming).
+// ABOUTME: One prompt -> one text using the user's selected model; shared by notes + dictation.
+
+use serde_json::{Value, json};
+use tauri::AppHandle;
+
+use crate::orchestrator::gateway_envelope::{publisher_status, unwrap_publisher_body};
+
+const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
+const PUBLISHER_SLUG: &str = "seren-models";
+
+/// A single chat-completion request routed through the user's selected model.
+pub struct CompletionRequest {
+    pub model: String,
+    pub system: Option<String>,
+    pub prompt: String,
+}
+
+/// Run one prompt through the same Gateway chat path the app uses for chat and
+/// return the assistant's text. Non-streaming; reuses the authed Gateway bridge.
+pub async fn complete(app: &AppHandle, request: CompletionRequest) -> Result<String, String> {
+    if request.model.trim().is_empty() {
+        return Err("no model selected for completion".to_string());
+    }
+    let client = reqwest::Client::new();
+    let url = format!("{GATEWAY_BASE_URL}/publishers/{PUBLISHER_SLUG}/chat/completions");
+
+    let mut messages = Vec::new();
+    if let Some(system) = &request.system {
+        messages.push(json!({ "role": "system", "content": system }));
+    }
+    messages.push(json!({ "role": "user", "content": request.prompt }));
+    let body = json!({
+        "model": request.model,
+        "messages": messages,
+        "stream": false,
+    })
+    .to_string();
+
+    let response = crate::auth::authenticated_request(app, &client, move |client, token| {
+        client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .bearer_auth(token)
+            .body(body.clone())
+    })
+    .await?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let detail = response.text().await.unwrap_or_default();
+        return Err(format!("chat completion http {status}: {detail}"));
+    }
+
+    let value: Value = response.json().await.map_err(|err| err.to_string())?;
+    if let Some(status) = publisher_status(&value) {
+        if status != 200 {
+            let body = unwrap_publisher_body(&value);
+            let message = body
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("upstream error");
+            return Err(format!("chat completion upstream {status}: {message}"));
+        }
+    }
+
+    let body = unwrap_publisher_body(&value);
+    let content = body
+        .get("choices")
+        .and_then(|choices| choices.get(0))
+        .and_then(|choice| choice.get("message"))
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if content.trim().is_empty() {
+        return Err("chat completion returned no content".to_string());
+    }
+    Ok(content)
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,7 +1,9 @@
 // ABOUTME: Shared audio pipeline primitives for meeting capture and dictation.
 // ABOUTME: Exposes transcript, chunking, merge, retry, and notes parsing modules.
 
+pub mod capture;
 pub mod chunker;
+pub mod cleanup;
 pub mod detect;
 pub mod merge;
 pub mod notes;

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -7,6 +7,7 @@ pub mod cleanup;
 pub mod detect;
 pub mod merge;
 pub mod notes;
+pub mod pipeline;
 pub mod templates;
 pub mod transcribe;
 pub mod types;

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -5,6 +5,7 @@ pub mod capture;
 pub mod chunker;
 pub mod cleanup;
 pub mod detect;
+pub mod llm;
 pub mod merge;
 pub mod notes;
 pub mod pipeline;

--- a/src-tauri/src/audio/notes.rs
+++ b/src-tauri/src/audio/notes.rs
@@ -99,6 +99,46 @@ fn action_item_to_text(value: Value) -> Option<String> {
     }
 }
 
+/// Build the Tier-1 notes prompt for a transcript under a template, reusing the
+/// shared cleanup engine so notes and dictation never diverge on vocabulary.
+pub fn build_notes_prompt(transcript: &str, template_prompt: &str, vocabulary: &[String]) -> String {
+    format!(
+        "You are taking structured notes from a meeting transcript.\n\n\
+         {cleanup}\n\n\
+         Notes focus: {template}\n\n\
+         Write concise markdown notes (short headers and bullet points). After the \
+         markdown, append a fenced ```json block with exactly this shape: \
+         {{\"summary\": string, \"action_items\": string[], \"fields\": object}}. \
+         Do not add commentary outside the notes and the JSON block.\n\n\
+         Transcript:\n{transcript}",
+        cleanup = crate::audio::cleanup::cleanup_directives(vocabulary),
+        template = template_prompt.trim(),
+        transcript = transcript.trim(),
+    )
+}
+
+/// Generate Tier-1 notes: prompt the selected model, then parse markdown + struct.
+/// Returns parsed notes even when the model omits the JSON block (parser fails safe).
+pub async fn generate_notes(
+    app: &tauri::AppHandle,
+    model: String,
+    transcript: &str,
+    template_prompt: &str,
+    vocabulary: &[String],
+) -> Result<ParsedNotes, String> {
+    let prompt = build_notes_prompt(transcript, template_prompt, vocabulary);
+    let raw = crate::audio::llm::complete(
+        app,
+        crate::audio::llm::CompletionRequest {
+            model,
+            system: None,
+            prompt,
+        },
+    )
+    .await?;
+    Ok(parse_notes_output(&raw))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -1,0 +1,333 @@
+// ABOUTME: Live transcription orchestrator: frames -> chunk -> transcribe -> persist -> emit.
+// ABOUTME: Owns per-meeting capture streams and the call-end drain; testable via a fake source.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use async_trait::async_trait;
+use tauri::async_runtime::JoinHandle;
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+use uuid::Uuid;
+
+use crate::audio::capture::PcmFrame;
+use crate::audio::chunker::{Chunk, ChunkCfg, StreamingChunker};
+use crate::audio::transcribe::{
+    ChunkTranscriber, GatewayTranscriber, RetryConfig, transcribe_chunk_with_retry,
+};
+use crate::audio::types::{SegmentStatus, Speaker, TranscriptSegment};
+use crate::commands::audio::{NewTranscriptSegment, insert_transcript_segment, now_ms};
+use crate::services::database::DbPool;
+
+/// Receives finished transcript segments (persist + emit in prod, collect in tests).
+#[async_trait]
+pub trait SegmentSink: Send + Sync {
+    async fn segment(&self, segment: TranscriptSegment);
+}
+
+/// Drive one capture stream end to end: read frames, chunk on silence, transcribe
+/// each window with retry, and hand finished segments to `sink`. A failed window
+/// becomes a `Gap` segment so audio is never silently dropped.
+pub async fn run_capture_stream(
+    meeting_id: String,
+    speaker: Speaker,
+    mut frames: UnboundedReceiver<PcmFrame>,
+    transcriber: Arc<dyn ChunkTranscriber + Send + Sync>,
+    seq: Arc<AtomicI64>,
+    cfg: ChunkCfg,
+    retry: RetryConfig,
+    sink: Arc<dyn SegmentSink>,
+) {
+    let mut chunker = StreamingChunker::new(cfg);
+    while let Some(frame) = frames.recv().await {
+        for chunk in chunker.push(&frame.samples) {
+            emit_segment(&meeting_id, &speaker, chunk, transcriber.as_ref(), retry, &seq, sink.as_ref())
+                .await;
+        }
+    }
+    for chunk in chunker.finish() {
+        emit_segment(&meeting_id, &speaker, chunk, transcriber.as_ref(), retry, &seq, sink.as_ref())
+            .await;
+    }
+}
+
+async fn emit_segment(
+    meeting_id: &str,
+    speaker: &Speaker,
+    chunk: Chunk,
+    transcriber: &(dyn ChunkTranscriber + Send + Sync),
+    retry: RetryConfig,
+    seq: &AtomicI64,
+    sink: &dyn SegmentSink,
+) {
+    let (text, status) = match transcribe_chunk_with_retry(transcriber, &chunk, retry).await {
+        Ok(text) => (text, SegmentStatus::Ok),
+        Err(_) => (String::new(), SegmentStatus::Gap),
+    };
+    let segment = TranscriptSegment {
+        id: Uuid::new_v4().to_string(),
+        meeting_id: meeting_id.to_string(),
+        seq: seq.fetch_add(1, Ordering::SeqCst),
+        speaker: speaker.clone(),
+        text,
+        start_ms: chunk.start_ms as i64,
+        end_ms: chunk.end_ms as i64,
+        status,
+        created_at: now_ms(),
+    };
+    sink.segment(segment).await;
+}
+
+/// Production sink: persist the segment to SQLite, then emit it to the webview.
+struct DbEmitSink {
+    app: AppHandle,
+}
+
+#[async_trait]
+impl SegmentSink for DbEmitSink {
+    async fn segment(&self, segment: TranscriptSegment) {
+        let app = self.app.clone();
+        let row = NewTranscriptSegment {
+            id: segment.id.clone(),
+            meeting_id: segment.meeting_id.clone(),
+            seq: segment.seq,
+            speaker: segment.speaker.clone(),
+            text: segment.text.clone(),
+            start_ms: segment.start_ms,
+            end_ms: segment.end_ms,
+            status: segment.status.clone(),
+            created_at: segment.created_at,
+        };
+        let persisted = tauri::async_runtime::spawn_blocking(move || {
+            let pool = app.state::<DbPool>();
+            pool.with_connection(|conn| insert_transcript_segment(conn, row))
+        })
+        .await;
+        match persisted {
+            Ok(Ok(_)) => {}
+            Ok(Err(err)) => {
+                log::warn!("[meeting] failed to persist transcript segment: {err}")
+            }
+            Err(err) => log::warn!("[meeting] transcript persist task failed: {err}"),
+        }
+        let _ = self.app.emit("meeting://transcript-chunk", &segment);
+    }
+}
+
+/// One in-flight meeting's capture streams and their worker tasks.
+struct ActiveCapture {
+    me_tx: UnboundedSender<PcmFrame>,
+    // The system ("Them") stream is wired by native capture in a later change.
+    them_tx: Option<UnboundedSender<PcmFrame>>,
+    tasks: Vec<JoinHandle<()>>,
+}
+
+/// Tauri-managed registry of active meeting captures, keyed by meeting id.
+#[derive(Default)]
+pub struct CaptureRegistry {
+    active: Arc<StdMutex<HashMap<String, ActiveCapture>>>,
+}
+
+impl CaptureRegistry {
+    /// Begin capturing the "Me" stream for `meeting_id`. Frames arrive via
+    /// [`CaptureRegistry::push_frame`]; the worker transcribes and persists them.
+    pub fn start(&self, app: &AppHandle, meeting_id: &str) {
+        let mut active = self.active.lock().unwrap();
+        if active.contains_key(meeting_id) {
+            return;
+        }
+        let seq = Arc::new(AtomicI64::new(0));
+        let sink: Arc<dyn SegmentSink> = Arc::new(DbEmitSink { app: app.clone() });
+        let transcriber: Arc<dyn ChunkTranscriber + Send + Sync> =
+            Arc::new(GatewayTranscriber::new(app.clone()));
+
+        let (me_tx, me_rx) = unbounded_channel();
+        let task = tauri::async_runtime::spawn(run_capture_stream(
+            meeting_id.to_string(),
+            Speaker::Me,
+            me_rx,
+            transcriber,
+            seq.clone(),
+            ChunkCfg::default(),
+            RetryConfig::default(),
+            sink,
+        ));
+
+        active.insert(
+            meeting_id.to_string(),
+            ActiveCapture {
+                me_tx,
+                them_tx: None,
+                tasks: vec![task],
+            },
+        );
+    }
+
+    /// Whether a capture is currently active for `meeting_id`.
+    pub fn is_active(&self, meeting_id: &str) -> bool {
+        self.active.lock().unwrap().contains_key(meeting_id)
+    }
+
+    /// Push a normalized 16 kHz mono frame into the capture stream for `speaker`.
+    pub fn push_frame(&self, meeting_id: &str, speaker: Speaker, samples: Vec<i16>) {
+        let active = self.active.lock().unwrap();
+        if let Some(capture) = active.get(meeting_id) {
+            let sender = match speaker {
+                Speaker::Me => Some(&capture.me_tx),
+                // The system ("Them") stream arrives once native capture lands.
+                Speaker::Them => capture.them_tx.as_ref(),
+            };
+            if let Some(sender) = sender {
+                let _ = sender.send(PcmFrame { samples });
+            }
+        }
+    }
+
+    /// Stop capture for `meeting_id`, draining and finishing all worker tasks.
+    pub async fn stop(&self, meeting_id: &str) {
+        let capture = self.active.lock().unwrap().remove(meeting_id);
+        let Some(capture) = capture else {
+            return;
+        };
+        // Dropping the senders closes the channels so the workers flush and exit.
+        drop(capture.me_tx);
+        drop(capture.them_tx);
+        for task in capture.tasks {
+            let _ = task.await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct SequenceTranscriber {
+        texts: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl ChunkTranscriber for SequenceTranscriber {
+        async fn transcribe(
+            &self,
+            _chunk: &Chunk,
+        ) -> Result<String, crate::audio::transcribe::TranscribeError> {
+            let mut texts = self.texts.lock().unwrap();
+            if texts.is_empty() {
+                Err(crate::audio::transcribe::TranscribeError::Empty)
+            } else {
+                Ok(texts.remove(0))
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct CollectingSink {
+        segments: Mutex<Vec<TranscriptSegment>>,
+    }
+
+    #[async_trait]
+    impl SegmentSink for CollectingSink {
+        async fn segment(&self, segment: TranscriptSegment) {
+            self.segments.lock().unwrap().push(segment);
+        }
+    }
+
+    fn test_cfg() -> ChunkCfg {
+        ChunkCfg {
+            sample_rate: 1_000,
+            frame_ms: 10,
+            silence_ms: 50,
+            min_window_ms: 40,
+            max_window_ms: 200,
+            rms_threshold: 100.0,
+        }
+    }
+
+    fn pcm(value: i16, ms: usize) -> Vec<i16> {
+        vec![value; ms]
+    }
+
+    #[tokio::test]
+    async fn pipeline_yields_ordered_segments_from_a_fake_source() {
+        use crate::audio::capture::AudioCaptureSource;
+        use crate::audio::capture::fake::FakePcmSource;
+
+        // Two utterances separated by silence -> two transcribed segments.
+        let samples = [pcm(1_000, 80), pcm(0, 60), pcm(1_000, 80), pcm(0, 60)].concat();
+        let (tx, rx) = unbounded_channel();
+        FakePcmSource::from_samples(samples, 1_000).start(tx).unwrap();
+
+        let transcriber: Arc<dyn ChunkTranscriber + Send + Sync> = Arc::new(SequenceTranscriber {
+            texts: Mutex::new(vec!["first".to_string(), "second".to_string()]),
+        });
+        let sink = Arc::new(CollectingSink::default());
+        let collected: Arc<dyn SegmentSink> = sink.clone();
+
+        run_capture_stream(
+            "meeting-1".to_string(),
+            Speaker::Me,
+            rx,
+            transcriber,
+            Arc::new(AtomicI64::new(0)),
+            test_cfg(),
+            RetryConfig {
+                max_attempts: 1,
+                initial_backoff_ms: 0,
+                max_backoff_ms: 0,
+            },
+            collected,
+        )
+        .await;
+
+        let segments = sink.segments.lock().unwrap();
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].text, "first");
+        assert_eq!(segments[0].seq, 0);
+        assert_eq!(segments[0].speaker, Speaker::Me);
+        assert_eq!(segments[1].text, "second");
+        assert_eq!(segments[1].seq, 1);
+        assert_eq!(segments[1].status, SegmentStatus::Ok);
+    }
+
+    #[tokio::test]
+    async fn pipeline_marks_failed_windows_as_gaps() {
+        use crate::audio::capture::AudioCaptureSource;
+        use crate::audio::capture::fake::FakePcmSource;
+
+        let samples = [pcm(1_000, 80), pcm(0, 60)].concat();
+        let (tx, rx) = unbounded_channel();
+        FakePcmSource::from_samples(samples, 1_000).start(tx).unwrap();
+
+        // No texts -> transcription always fails -> the window becomes a gap.
+        let transcriber: Arc<dyn ChunkTranscriber + Send + Sync> = Arc::new(SequenceTranscriber {
+            texts: Mutex::new(vec![]),
+        });
+        let sink = Arc::new(CollectingSink::default());
+        let collected: Arc<dyn SegmentSink> = sink.clone();
+
+        run_capture_stream(
+            "meeting-1".to_string(),
+            Speaker::Me,
+            rx,
+            transcriber,
+            Arc::new(AtomicI64::new(0)),
+            test_cfg(),
+            RetryConfig {
+                max_attempts: 1,
+                initial_backoff_ms: 0,
+                max_backoff_ms: 0,
+            },
+            collected,
+        )
+        .await;
+
+        let segments = sink.segments.lock().unwrap();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].status, SegmentStatus::Gap);
+        assert!(segments[0].text.is_empty());
+    }
+}

--- a/src-tauri/src/audio/templates.rs
+++ b/src-tauri/src/audio/templates.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Built-in Tier-1 meeting note templates for Meeting Mode.
 // ABOUTME: Provides stable ids that settings and meeting records can reference.
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub struct MeetingTemplate {
     pub id: &'static str,
     pub name: &'static str,

--- a/src-tauri/src/audio/transcribe.rs
+++ b/src-tauri/src/audio/transcribe.rs
@@ -2,9 +2,18 @@
 // ABOUTME: Keeps retry policy deterministic and injectable for unit tests.
 
 use async_trait::async_trait;
+use base64::Engine;
+use serde_json::json;
+use tauri::AppHandle;
 use thiserror::Error;
 
+use crate::audio::capture::TARGET_SAMPLE_RATE;
 use crate::audio::chunker::Chunk;
+use crate::orchestrator::gateway_envelope::{publisher_status, unwrap_publisher_body};
+
+const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
+const WHISPER_PUBLISHER: &str = "seren-whisper";
+const WHISPER_MODEL: &str = "whisper-1";
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum TranscribeError {
@@ -42,7 +51,7 @@ pub async fn transcribe_chunk_with_retry<T>(
     cfg: RetryConfig,
 ) -> Result<String, TranscribeError>
 where
-    T: ChunkTranscriber + Sync,
+    T: ChunkTranscriber + Sync + ?Sized,
 {
     let attempts = cfg.max_attempts.max(1);
     let mut backoff_ms = cfg.initial_backoff_ms;
@@ -69,6 +78,127 @@ fn next_backoff(current: u64, max: u64) -> u64 {
         return 0;
     }
     current.saturating_mul(2).min(max)
+}
+
+/// Encode 16 kHz mono PCM as a WAV byte buffer (RIFF / PCM16, little-endian).
+pub fn pcm16_to_wav(samples: &[i16], sample_rate: u32) -> Vec<u8> {
+    const CHANNELS: u16 = 1;
+    const BITS_PER_SAMPLE: u16 = 16;
+    let block_align = CHANNELS * (BITS_PER_SAMPLE / 8);
+    let byte_rate = sample_rate * block_align as u32;
+    let data_len = (samples.len() as u32) * (BITS_PER_SAMPLE / 8) as u32;
+
+    let mut buf = Vec::with_capacity(44 + data_len as usize);
+    buf.extend_from_slice(b"RIFF");
+    buf.extend_from_slice(&(36 + data_len).to_le_bytes());
+    buf.extend_from_slice(b"WAVE");
+    buf.extend_from_slice(b"fmt ");
+    buf.extend_from_slice(&16u32.to_le_bytes()); // PCM fmt chunk size
+    buf.extend_from_slice(&1u16.to_le_bytes()); // audio format = PCM
+    buf.extend_from_slice(&CHANNELS.to_le_bytes());
+    buf.extend_from_slice(&sample_rate.to_le_bytes());
+    buf.extend_from_slice(&byte_rate.to_le_bytes());
+    buf.extend_from_slice(&block_align.to_le_bytes());
+    buf.extend_from_slice(&BITS_PER_SAMPLE.to_le_bytes());
+    buf.extend_from_slice(b"data");
+    buf.extend_from_slice(&data_len.to_le_bytes());
+    for sample in samples {
+        buf.extend_from_slice(&sample.to_le_bytes());
+    }
+    buf
+}
+
+/// Build the Gateway multipart-envelope body for a Whisper transcription request.
+pub fn build_whisper_envelope(wav: &[u8]) -> serde_json::Value {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(wav);
+    json!({
+        "parts": [
+            { "name": "model", "value": WHISPER_MODEL },
+            {
+                "name": "file",
+                "filename": "audio.wav",
+                "content_type": "audio/wav",
+                "data": encoded
+            }
+        ]
+    })
+}
+
+/// Real [`ChunkTranscriber`] that POSTs a chunk to the Seren Whisper publisher.
+pub struct GatewayTranscriber {
+    app: AppHandle,
+    client: reqwest::Client,
+}
+
+impl GatewayTranscriber {
+    pub fn new(app: AppHandle) -> Self {
+        Self {
+            app,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl ChunkTranscriber for GatewayTranscriber {
+    async fn transcribe(&self, chunk: &Chunk) -> Result<String, TranscribeError> {
+        let wav = pcm16_to_wav(&chunk.samples, TARGET_SAMPLE_RATE);
+        let body = build_whisper_envelope(&wav).to_string();
+        let url = format!(
+            "{}/publishers/{}/audio/transcriptions",
+            GATEWAY_BASE_URL, WHISPER_PUBLISHER
+        );
+
+        let response =
+            crate::auth::authenticated_request(&self.app, &self.client, move |client, token| {
+                client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .bearer_auth(token)
+                    .body(body.clone())
+            })
+            .await
+            .map_err(TranscribeError::Transport)?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let detail = response.text().await.unwrap_or_default();
+            return Err(TranscribeError::Transport(format!(
+                "whisper http {status}: {detail}"
+            )));
+        }
+
+        let value: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|err| TranscribeError::Transport(err.to_string()))?;
+
+        if let Some(status) = publisher_status(&value) {
+            if status != 200 {
+                let body = unwrap_publisher_body(&value);
+                let message = body
+                    .get("error")
+                    .and_then(|error| error.get("message"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("upstream error");
+                return Err(TranscribeError::Transport(format!(
+                    "whisper upstream {status}: {message}"
+                )));
+            }
+        }
+
+        let body = unwrap_publisher_body(&value);
+        let text = body
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if text.is_empty() {
+            return Err(TranscribeError::Empty);
+        }
+        Ok(text)
+    }
 }
 
 #[cfg(test)]
@@ -160,5 +290,33 @@ mod tests {
             TranscribeError::Transport("500".to_string())
         );
         assert_eq!(transcriber.attempts(), 3);
+    }
+
+    #[test]
+    fn pcm16_to_wav_writes_a_valid_riff_pcm_header() {
+        let wav = pcm16_to_wav(&[0, 1, -1, 32_767], 16_000);
+
+        assert_eq!(&wav[0..4], b"RIFF");
+        assert_eq!(&wav[8..12], b"WAVE");
+        assert_eq!(&wav[36..40], b"data");
+        assert_eq!(
+            u32::from_le_bytes([wav[24], wav[25], wav[26], wav[27]]),
+            16_000
+        );
+        // 4 samples * 2 bytes = 8 bytes of data; 44-byte header.
+        assert_eq!(u32::from_le_bytes([wav[40], wav[41], wav[42], wav[43]]), 8);
+        assert_eq!(wav.len(), 44 + 8);
+    }
+
+    #[test]
+    fn build_whisper_envelope_carries_model_and_base64_file() {
+        let envelope = build_whisper_envelope(&[0x52, 0x49, 0x46, 0x46]);
+        let parts = envelope["parts"].as_array().unwrap();
+
+        assert_eq!(parts[0]["name"], "model");
+        assert_eq!(parts[0]["value"], "whisper-1");
+        assert_eq!(parts[1]["name"], "file");
+        assert_eq!(parts[1]["content_type"], "audio/wav");
+        assert!(!parts[1]["data"].as_str().unwrap().is_empty());
     }
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -2,10 +2,16 @@
 // ABOUTME: Stores meetings and transcript segments without persisting raw audio.
 
 use crate::audio::capture::to_mono_16k;
+use crate::audio::chunker::Chunk;
+use crate::audio::cleanup::{build_cleanup_prompt, build_transform_prompt};
+use crate::audio::llm::{CompletionRequest, complete};
 use crate::audio::merge::merge_segments;
 use crate::audio::notes::{ParsedNotes, generate_notes};
 use crate::audio::pipeline::CaptureRegistry;
 use crate::audio::templates::{BUILT_IN_MEETING_TEMPLATES, MeetingTemplate};
+use crate::audio::transcribe::{
+    GatewayTranscriber, RetryConfig, TranscribeError, transcribe_chunk_with_retry,
+};
 use crate::audio::types::{Meeting, MeetingStatus, SegmentStatus, Speaker, TranscriptSegment};
 use crate::orchestrator::types::SkillRef;
 use crate::services::database::DbPool;
@@ -233,6 +239,80 @@ pub fn select_meeting_skills(skills: Vec<SkillRef>) -> Vec<String> {
 #[tauri::command]
 pub fn list_meeting_templates() -> Vec<MeetingTemplate> {
     BUILT_IN_MEETING_TEMPLATES.to_vec()
+}
+
+// --- Dictation (shares the transcribe + cleanup engines with Meeting Mode) --
+
+/// Transcribe a single dictation chunk; returns "" for silence rather than erroring.
+#[tauri::command]
+pub async fn transcribe_pcm(
+    app: AppHandle,
+    samples: Vec<i16>,
+    channels: u16,
+    sample_rate: u32,
+) -> Result<String, String> {
+    let normalized = to_mono_16k(&samples, channels.max(1), sample_rate);
+    if normalized.is_empty() {
+        return Ok(String::new());
+    }
+    let chunk = Chunk {
+        start_ms: 0,
+        end_ms: 0,
+        samples: normalized,
+    };
+    let transcriber = GatewayTranscriber::new(app);
+    match transcribe_chunk_with_retry(&transcriber, &chunk, RetryConfig::default()).await {
+        Ok(text) => Ok(text),
+        Err(TranscribeError::Empty) => Ok(String::new()),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+/// Polish dictated text through the shared cleanup engine + custom vocabulary.
+#[tauri::command]
+pub async fn cleanup_dictation_text(
+    app: AppHandle,
+    text: String,
+    model: String,
+    vocabulary: Vec<String>,
+) -> Result<String, String> {
+    if text.trim().is_empty() {
+        return Ok(String::new());
+    }
+    let prompt = build_cleanup_prompt(&text, &vocabulary);
+    complete(
+        &app,
+        CompletionRequest {
+            model,
+            system: None,
+            prompt,
+        },
+    )
+    .await
+}
+
+/// Edit-by-voice: transform a selection per a spoken instruction.
+#[tauri::command]
+pub async fn transform_selection(
+    app: AppHandle,
+    selection: String,
+    instruction: String,
+    model: String,
+    vocabulary: Vec<String>,
+) -> Result<String, String> {
+    if selection.trim().is_empty() {
+        return Err("nothing selected to transform".to_string());
+    }
+    let prompt = build_transform_prompt(&selection, &instruction, &vocabulary);
+    complete(
+        &app,
+        CompletionRequest {
+            model,
+            system: None,
+            prompt,
+        },
+    )
+    .await
 }
 
 /// Assemble persisted segments into a chronological "Me/Them" transcript.

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1,10 +1,16 @@
 // ABOUTME: Tauri commands for Meeting Mode persistence and transcript history.
 // ABOUTME: Stores meetings and transcript segments without persisting raw audio.
 
+use crate::audio::capture::to_mono_16k;
+use crate::audio::merge::merge_segments;
+use crate::audio::notes::{ParsedNotes, generate_notes};
+use crate::audio::pipeline::CaptureRegistry;
+use crate::audio::templates::{BUILT_IN_MEETING_TEMPLATES, MeetingTemplate};
 use crate::audio::types::{Meeting, MeetingStatus, SegmentStatus, Speaker, TranscriptSegment};
+use crate::orchestrator::types::SkillRef;
 use crate::services::database::DbPool;
 use rusqlite::{Connection, OptionalExtension, Result, params};
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Manager, State};
 use uuid::Uuid;
 
 #[tauri::command]
@@ -59,21 +65,30 @@ pub async fn update_meeting_notes(
     notes_struct_json: String,
 ) -> Result<(), String> {
     run_db(app, move |conn| {
-        conn.execute(
-            "UPDATE meetings
-             SET notes_markdown = ?1, notes_struct_json = ?2, status = ?3, updated_at = ?4
-             WHERE id = ?5",
-            params![
-                notes_markdown,
-                notes_struct_json,
-                MeetingStatus::NotesReady.as_str(),
-                now_ms(),
-                id
-            ],
-        )?;
-        Ok(())
+        set_meeting_notes_record(conn, &id, &notes_markdown, &notes_struct_json)
     })
     .await
+}
+
+fn set_meeting_notes_record(
+    conn: &Connection,
+    id: &str,
+    markdown: &str,
+    struct_json: &str,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE meetings
+         SET notes_markdown = ?1, notes_struct_json = ?2, status = ?3, updated_at = ?4
+         WHERE id = ?5",
+        params![
+            markdown,
+            struct_json,
+            MeetingStatus::NotesReady.as_str(),
+            now_ms(),
+            id
+        ],
+    )?;
+    Ok(())
 }
 
 #[tauri::command]
@@ -130,6 +145,113 @@ pub async fn get_transcript_segments(
         select_transcript_segments(conn, &meeting_id)
     })
     .await
+}
+
+// --- Capture lifecycle + Tier-1 intelligence -------------------------------
+
+#[tauri::command]
+pub async fn start_meeting_capture(
+    app: AppHandle,
+    registry: State<'_, CaptureRegistry>,
+    meeting_id: String,
+) -> Result<(), String> {
+    registry.start(&app, &meeting_id);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn push_capture_frame(
+    registry: State<'_, CaptureRegistry>,
+    meeting_id: String,
+    speaker: Speaker,
+    samples: Vec<i16>,
+    channels: u16,
+    sample_rate: u32,
+) -> Result<(), String> {
+    let normalized = to_mono_16k(&samples, channels.max(1), sample_rate);
+    registry.push_frame(&meeting_id, speaker, normalized);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn stop_meeting_capture(
+    app: AppHandle,
+    registry: State<'_, CaptureRegistry>,
+    meeting_id: String,
+) -> Result<(), String> {
+    registry.stop(&meeting_id).await;
+    let ended = now_ms();
+    let id = meeting_id;
+    run_db(app, move |conn| {
+        update_meeting_status_record(conn, &id, MeetingStatus::Transcribing, Some(ended), ended)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn generate_meeting_notes(
+    app: AppHandle,
+    meeting_id: String,
+    model: String,
+    template_prompt: String,
+    vocabulary: Vec<String>,
+) -> Result<ParsedNotes, String> {
+    let lookup = meeting_id.clone();
+    let segments =
+        run_db(app.clone(), move |conn| select_transcript_segments(conn, &lookup)).await?;
+    let transcript = assemble_transcript(segments);
+    if transcript.trim().is_empty() {
+        return Err("no transcript to summarize".to_string());
+    }
+
+    let parsed = generate_notes(&app, model, &transcript, &template_prompt, &vocabulary).await?;
+    let struct_json = serde_json::to_string(&parsed.structured).map_err(|err| err.to_string())?;
+    let markdown = parsed.markdown.clone();
+    let id = meeting_id;
+    run_db(app, move |conn| {
+        set_meeting_notes_record(conn, &id, &markdown, &struct_json)
+    })
+    .await?;
+    Ok(parsed)
+}
+
+#[tauri::command]
+pub async fn get_meeting_transcript_text(
+    app: AppHandle,
+    meeting_id: String,
+) -> Result<String, String> {
+    let segments = run_db(app, move |conn| select_transcript_segments(conn, &meeting_id)).await?;
+    Ok(assemble_transcript(segments))
+}
+
+/// Return the slugs of installed skills tagged to handle meetings (0 / 1 / many).
+#[tauri::command]
+pub fn select_meeting_skills(skills: Vec<SkillRef>) -> Vec<String> {
+    crate::orchestrator::classifier::select_meeting_skills(&skills)
+}
+
+#[tauri::command]
+pub fn list_meeting_templates() -> Vec<MeetingTemplate> {
+    BUILT_IN_MEETING_TEMPLATES.to_vec()
+}
+
+/// Assemble persisted segments into a chronological "Me/Them" transcript.
+fn assemble_transcript(segments: Vec<TranscriptSegment>) -> String {
+    let (me, them): (Vec<_>, Vec<_>) = segments
+        .into_iter()
+        .partition(|segment| segment.speaker == Speaker::Me);
+    merge_segments(me, them)
+        .into_iter()
+        .filter(|segment| segment.status == SegmentStatus::Ok && !segment.text.trim().is_empty())
+        .map(|segment| {
+            let speaker = match segment.speaker {
+                Speaker::Me => "Me",
+                Speaker::Them => "Them",
+            };
+            format!("{speaker}: {}", segment.text.trim())
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -336,7 +336,7 @@ where
     .map_err(|e| e.to_string())?
 }
 
-fn now_ms() -> i64 {
+pub(crate) fn now_ms() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -623,4 +623,34 @@ mod tests {
         assert_eq!(segments[1].speaker, Speaker::Them);
         assert_eq!(segments[2].status, SegmentStatus::Gap);
     }
+
+    #[test]
+    fn rerunning_schema_setup_preserves_existing_meeting_data() {
+        let conn = setup();
+        insert_meeting(&conn, meeting("meeting-1")).unwrap();
+        insert_transcript_segment(
+            &conn,
+            NewTranscriptSegment {
+                id: "segment-1".to_string(),
+                meeting_id: "meeting-1".to_string(),
+                seq: 0,
+                speaker: Speaker::Me,
+                text: "hello".to_string(),
+                start_ms: 0,
+                end_ms: 100,
+                status: SegmentStatus::Ok,
+                created_at: 1,
+            },
+        )
+        .unwrap();
+
+        // Simulate updating an app with a pre-existing chat.db: schema setup runs
+        // again at startup. CREATE TABLE IF NOT EXISTS must not drop prior data.
+        setup_schema(&conn).unwrap();
+
+        assert!(select_meeting(&conn, "meeting-1").unwrap().is_some());
+        let segments = select_transcript_segments(&conn, "meeting-1").unwrap();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].text, "hello");
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -514,6 +514,7 @@ pub fn run() {
         .manage(mcp::McpState::new())
         .manage(mcp::HttpMcpState::new())
         .manage(orchestrator::service::OrchestratorState::new())
+        .manage(audio::pipeline::CaptureRegistry::default())
         .manage(orchestrator::eval::EvalState::new())
         .manage(orchestrator::tool_bridge::ToolResultBridge::new())
         .manage(provider_runtime::ProviderRuntimeState::new())
@@ -792,6 +793,14 @@ pub fn run() {
             commands::audio::set_meeting_routed_skill,
             commands::audio::append_transcript_segment,
             commands::audio::get_transcript_segments,
+            // Meeting Mode capture + intelligence commands
+            commands::audio::start_meeting_capture,
+            commands::audio::push_capture_frame,
+            commands::audio::stop_meeting_capture,
+            commands::audio::generate_meeting_notes,
+            commands::audio::get_meeting_transcript_text,
+            commands::audio::select_meeting_skills,
+            commands::audio::list_meeting_templates,
             // Conversation commands
             commands::chat::create_conversation,
             commands::chat::list_conversations,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -801,6 +801,10 @@ pub fn run() {
             commands::audio::get_meeting_transcript_text,
             commands::audio::select_meeting_skills,
             commands::audio::list_meeting_templates,
+            // Dictation commands
+            commands::audio::transcribe_pcm,
+            commands::audio::cleanup_dictation_text,
+            commands::audio::transform_selection,
             // Conversation commands
             commands::chat::create_conversation,
             commands::chat::list_conversations,

--- a/src-tauri/src/orchestrator/classifier.rs
+++ b/src-tauri/src/orchestrator/classifier.rs
@@ -593,13 +593,13 @@ mod tests {
     #[test]
     fn meeting_skill_selection_returns_single_tagged_skill() {
         let skills = vec![
-            make_skill("affinity", "Affinity", &["meetings"]),
+            make_skill("crm-notes", "CRM Notes", &["meetings"]),
             make_skill("recap", "Meeting Recap", &["document"]),
         ];
 
         let result = select_meeting_skills(&skills);
 
-        assert_eq!(result, vec!["affinity".to_string()]);
+        assert_eq!(result, vec!["crm-notes".to_string()]);
     }
 
     // =========================================================================

--- a/src-tauri/src/orchestrator/classifier.rs
+++ b/src-tauri/src/orchestrator/classifier.rs
@@ -590,6 +590,18 @@ mod tests {
         assert!(result.is_empty());
     }
 
+    #[test]
+    fn meeting_skill_selection_returns_single_tagged_skill() {
+        let skills = vec![
+            make_skill("affinity", "Affinity", &["meetings"]),
+            make_skill("recap", "Meeting Recap", &["document"]),
+        ];
+
+        let result = select_meeting_skills(&skills);
+
+        assert_eq!(result, vec!["affinity".to_string()]);
+    }
+
     // =========================================================================
     // Publisher & Expanded Research Tests
     // =========================================================================

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -17,6 +17,7 @@ import {
 import { createStore } from "solid-js/store";
 import { AgentPermissionDialog } from "@/components/agent/AgentPermissionDialog";
 import { DiffProposalDialog } from "@/components/agent/DiffProposalDialog";
+import { DictationHud } from "@/components/chat/DictationHud";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { extractAgentThinkingMarkup } from "@/lib/agent-thinking-markup";
@@ -2032,6 +2033,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                     }
                   }}
                 />
+                <DictationHud getTextarea={() => inputRef} />
                 <Show
                   when={isPrompting()}
                   fallback={

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -16,6 +16,7 @@ import {
 } from "solid-js";
 import { createStore } from "solid-js/store";
 import { SignIn } from "@/components/auth/SignIn";
+import { DictationHud } from "@/components/chat/DictationHud";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { SlidePanel } from "@/components/layout/SlidePanel";
@@ -2047,6 +2048,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                     }
                   }}
                 />
+                <DictationHud getTextarea={() => inputRef} />
                 <Show
                   when={conversationIsLoading()}
                   fallback={

--- a/src/components/chat/DictationHud.tsx
+++ b/src/components/chat/DictationHud.tsx
@@ -1,0 +1,311 @@
+// ABOUTME: Bottom-center, audio-reactive dictation capsule with push-to-talk and edit-by-voice.
+// ABOUTME: Streams live transcript into the active composer; hold right Option/Alt to talk.
+
+import { createSignal, Index, onCleanup, onMount, Show } from "solid-js";
+import { startDictationCapture } from "@/lib/audio/dictationCapture";
+import { useVoiceInput } from "@/lib/audio/useVoiceInput";
+import { transformSelection } from "@/services/dictation";
+import { providerStore } from "@/stores/provider.store";
+import { settingsStore } from "@/stores/settings.store";
+
+// Right Option (macOS) / right Alt (Win/Linux) is the push-to-talk hold key.
+const PUSH_TO_TALK_CODE = "AltRight";
+const BAR_COUNT = 5;
+// Edit-by-voice listens this long for a spoken instruction before transforming.
+const EDIT_LISTEN_MS = 3500;
+
+interface DictationHudProps {
+  /** Resolve the composer textarea so transcripts write at the cursor. */
+  getTextarea: () => HTMLTextAreaElement | undefined;
+}
+
+/**
+ * Write `next` into the textarea and notify Solid via a native input event so
+ * the composer's bound signal/store stays the source of truth.
+ */
+function writeTextarea(
+  textarea: HTMLTextAreaElement,
+  next: string,
+  caret: number,
+): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(textarea, next);
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  textarea.focus();
+  textarea.setSelectionRange(caret, caret);
+}
+
+function MicGlyph() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-label="Dictation"
+      role="img"
+    >
+      <path d="M8 10a2 2 0 0 0 2-2V4a2 2 0 1 0-4 0v4a2 2 0 0 0 2 2Z" />
+      <path d="M4.5 7a.5.5 0 0 0-1 0 4.5 4.5 0 0 0 4 4.473V13.5H6a.5.5 0 0 0 0 1h4a.5.5 0 0 0 0-1H8.5v-2.027A4.5 4.5 0 0 0 12.5 7a.5.5 0 0 0-1 0 3.5 3.5 0 1 1-7 0Z" />
+    </svg>
+  );
+}
+
+function WandGlyph() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-label="Edit by voice"
+      role="img"
+    >
+      <path d="M9.5 1.5a.5.5 0 0 1 .5.5l.41 1.09L11.5 4a.5.5 0 0 1 0 .94l-1.09.41L10 6.5a.5.5 0 0 1-.94 0l-.41-1.09L7.5 4.94a.5.5 0 0 1 0-.94l1.15-.41L9.06 2A.5.5 0 0 1 9.5 1.5ZM3.05 6.5a.5.5 0 0 1 .7 0l5.75 5.75a.5.5 0 0 1 0 .7l-1.3 1.3a.5.5 0 0 1-.7 0L1.75 8.5a.5.5 0 0 1 0-.7l1.3-1.3Zm.35 1.4-.6.6L7.5 13.6l.6-.6L3.4 7.9Z" />
+    </svg>
+  );
+}
+
+export function DictationHud(props: DictationHudProps) {
+  // 0..1 amplitudes for the reactive bars while listening.
+  const [bars, setBars] = createSignal<number[]>(new Array(BAR_COUNT).fill(0));
+  const [editing, setEditing] = createSignal(false);
+  const [editError, setEditError] = createSignal<string | null>(null);
+
+  let rafId: number | undefined;
+  let holding = false;
+  let editErrorTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Span [start, end) of the text this dictation session has written. Partials
+  // grow `end`; the final cleaned text replaces the whole span (no double-insert).
+  let sessionStart = 0;
+  let sessionEnd = 0;
+  let sessionLive = "";
+
+  const beginSession = () => {
+    const textarea = props.getTextarea();
+    if (!textarea) return;
+    sessionStart = textarea.selectionStart;
+    sessionEnd = sessionStart;
+    sessionLive = "";
+  };
+
+  const replaceSession = (text: string) => {
+    const textarea = props.getTextarea();
+    if (!textarea) return;
+    const value = textarea.value;
+    const next = value.slice(0, sessionStart) + text + value.slice(sessionEnd);
+    sessionEnd = sessionStart + text.length;
+    writeTextarea(textarea, next, sessionEnd);
+  };
+
+  const appendPartial = (partial: string) => {
+    sessionLive = sessionLive ? `${sessionLive} ${partial}` : partial;
+    replaceSession(sessionLive);
+  };
+
+  const settleFinal = (text: string) => {
+    // Swap the live span for the cleaned final; if nothing changed, keep as-is.
+    if (text) replaceSession(text);
+  };
+
+  const { voiceState, error, startRecording, stopRecording, level } =
+    useVoiceInput(settleFinal, { onPartial: appendPartial });
+
+  const isListening = () => voiceState() === "listening";
+
+  const animate = () => {
+    const amp = level();
+    setBars((prev) => {
+      const next = prev.slice(1);
+      // Center bars taller than edges for a natural waveform shape.
+      next.push(Math.min(1, amp * (0.6 + Math.random() * 0.8)));
+      return next;
+    });
+    rafId = requestAnimationFrame(animate);
+  };
+
+  const stopAnimation = () => {
+    if (rafId !== undefined) {
+      cancelAnimationFrame(rafId);
+      rafId = undefined;
+    }
+    setBars(new Array(BAR_COUNT).fill(0));
+  };
+
+  const beginHold = () => {
+    if (holding || editing()) return;
+    holding = true;
+    beginSession();
+    void startRecording();
+    rafId = requestAnimationFrame(animate);
+  };
+
+  const endHold = () => {
+    if (!holding) return;
+    holding = false;
+    stopAnimation();
+    void stopRecording();
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.code !== PUSH_TO_TALK_CODE || event.repeat) return;
+    beginHold();
+  };
+
+  const onKeyUp = (event: KeyboardEvent) => {
+    if (event.code !== PUSH_TO_TALK_CODE) return;
+    endHold();
+  };
+
+  const onBlur = () => {
+    // Window lost focus mid-hold: stop cleanly so the mic is released.
+    if (holding) endHold();
+  };
+
+  onMount(() => {
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", onBlur);
+  });
+
+  onCleanup(() => {
+    window.removeEventListener("keydown", onKeyDown);
+    window.removeEventListener("keyup", onKeyUp);
+    window.removeEventListener("blur", onBlur);
+    stopAnimation();
+    clearTimeout(editErrorTimer);
+  });
+
+  const flashEditError = (message: string) => {
+    setEditError(message);
+    clearTimeout(editErrorTimer);
+    editErrorTimer = setTimeout(() => setEditError(null), 3000);
+  };
+
+  // Edit-by-voice: capture a short spoken instruction, transform the current
+  // textarea selection in place. Scoped to the chat composer textarea only.
+  const runEditByVoice = async () => {
+    if (editing() || isListening()) return;
+    const textarea = props.getTextarea();
+    if (!textarea) return;
+
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const selection = textarea.value.slice(start, end);
+    if (!selection.trim()) {
+      flashEditError("Select text to edit by voice");
+      return;
+    }
+
+    setEditing(true);
+    setEditError(null);
+    try {
+      const capture = await startDictationCapture(() => {});
+      await new Promise((resolve) => setTimeout(resolve, EDIT_LISTEN_MS));
+      const instruction = (await capture.stop()).trim();
+      if (!instruction) {
+        flashEditError("No instruction heard");
+        return;
+      }
+
+      const replacement = await transformSelection(
+        selection,
+        instruction,
+        providerStore.activeModel,
+        settingsStore.get("voiceCustomVocabulary"),
+      );
+
+      const value = textarea.value;
+      const next = value.slice(0, start) + replacement + value.slice(end);
+      writeTextarea(textarea, next, start + replacement.length);
+    } catch (err) {
+      console.error("[DictationHud] edit-by-voice failed:", err);
+      flashEditError(
+        err instanceof Error ? err.message : "Edit by voice failed",
+      );
+    } finally {
+      setEditing(false);
+    }
+  };
+
+  const statusLabel = () => {
+    if (editing()) return "Editing selection…";
+    if (voiceState() === "transcribing") return "Transcribing…";
+    if (isListening()) return "Listening…";
+    if (voiceState() === "error") return error() || "Voice error";
+    return "Hold ⌥ to dictate";
+  };
+
+  const busy = () => isListening() || editing();
+
+  return (
+    <div class="pointer-events-none fixed bottom-6 left-1/2 z-50 -translate-x-1/2">
+      <div
+        class="pointer-events-auto flex items-center gap-2.5 rounded-full border border-border bg-surface-2/95 px-3.5 py-2 shadow-lg backdrop-blur-sm transition-colors duration-200"
+        classList={{
+          "border-accent/60 shadow-[0_4px_20px_var(--accent)]": isListening(),
+          "border-success/60": editing(),
+        }}
+      >
+        <span
+          class="flex h-6 w-6 items-center justify-center rounded-full text-muted-foreground transition-colors"
+          classList={{
+            "bg-accent/15 text-accent": isListening(),
+            "bg-success/15 text-success": editing(),
+          }}
+        >
+          <Show
+            when={voiceState() === "transcribing" || editing()}
+            fallback={<MicGlyph />}
+          >
+            <span class="h-3 w-3 animate-spin rounded-full border-2 border-surface-3 border-t-current" />
+          </Show>
+        </span>
+
+        <Show
+          when={isListening()}
+          fallback={
+            <span
+              class="text-xs font-medium text-muted-foreground transition-colors"
+              classList={{ "text-success": editing() }}
+            >
+              {statusLabel()}
+            </span>
+          }
+        >
+          <div class="flex h-5 items-center gap-[3px]">
+            <Index each={bars()}>
+              {(amp) => (
+                <span
+                  class="w-[3px] rounded-full bg-accent transition-[height] duration-75"
+                  style={{ height: `${Math.max(10, amp() * 100)}%` }}
+                />
+              )}
+            </Index>
+          </div>
+        </Show>
+
+        <button
+          type="button"
+          class="flex h-6 w-6 items-center justify-center rounded-full border border-border bg-transparent text-muted-foreground transition-colors hover:bg-surface-3 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+          classList={{ "border-success/60 text-success": editing() }}
+          disabled={busy()}
+          onClick={() => void runEditByVoice()}
+          title="Edit selection by voice"
+        >
+          <WandGlyph />
+        </button>
+
+        <Show when={editError()}>
+          <div class="pointer-events-none absolute bottom-[calc(100%+8px)] left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-surface-2 px-2.5 py-1.5 text-xs text-destructive">
+            {editError()}
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/DictationHud.tsx
+++ b/src/components/chat/DictationHud.tsx
@@ -215,7 +215,7 @@ export function DictationHud(props: DictationHudProps) {
       const replacement = await transformSelection(
         selection,
         instruction,
-        providerStore.activeModel,
+        providerStore.resolvedModel(),
         settingsStore.get("voiceCustomVocabulary"),
       );
 

--- a/src/components/chat/VoiceInputButton.tsx
+++ b/src/components/chat/VoiceInputButton.tsx
@@ -44,7 +44,7 @@ export function VoiceInputButton(props: VoiceInputButtonProps) {
 
   const title = (): string => {
     const state = voiceState();
-    if (state === "recording") return "Stop recording";
+    if (state === "listening") return "Stop recording";
     if (state === "transcribing") return "Transcribing...";
     if (state === "error") return error() || "Voice input error";
     return "Voice input";
@@ -63,7 +63,7 @@ export function VoiceInputButton(props: VoiceInputButtonProps) {
         type="button"
         class="flex items-center justify-center w-8 h-8 border-none rounded-md bg-transparent text-muted-foreground cursor-pointer transition-all duration-150 relative shrink-0 hover:bg-surface-2 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
         classList={{
-          "text-destructive bg-destructive/10": voiceState() === "recording",
+          "text-destructive bg-destructive/10": voiceState() === "listening",
           "text-muted-foreground cursor-wait": voiceState() === "transcribing",
           "text-destructive": voiceState() === "error",
         }}
@@ -74,7 +74,7 @@ export function VoiceInputButton(props: VoiceInputButtonProps) {
         <Show when={voiceState() === "transcribing"} fallback={<MicIcon />}>
           <div class="w-4 h-4 border-2 border-surface-3 border-t-muted-foreground rounded-full animate-spin" />
         </Show>
-        <Show when={voiceState() === "recording"}>
+        <Show when={voiceState() === "listening"}>
           <div class="absolute top-1 right-1 w-2 h-2 rounded-full bg-destructive animate-[voicePulse_1s_ease-in-out_infinite]" />
         </Show>
         <Show when={voiceState() === "error" && error()}>

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -1,0 +1,256 @@
+// ABOUTME: Meeting detail "notes canvas": rendered notes, template picker, regenerate, transcript.
+// ABOUTME: AI notes render muted; transcript shows Me bright / Them muted with jump-to-source.
+
+import { createMemo, createSignal, For, onMount, Show } from "solid-js";
+import {
+  formatDuration,
+  meetingTitle,
+  STATUS_LABELS,
+} from "@/lib/meeting-format";
+import { renderMarkdown } from "@/lib/render-markdown";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+import {
+  listMeetingTemplates,
+  type Meeting,
+  type MeetingTemplate,
+  type StructuredNotes,
+  type TranscriptSegment,
+} from "@/services/meetings";
+import { meetingStore } from "@/stores/meeting.store";
+import { settingsStore } from "@/stores/settings.store";
+
+interface MeetingDetailProps {
+  meeting: Meeting;
+}
+
+function parseStructured(json: string | null): StructuredNotes | null {
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json) as Partial<StructuredNotes>;
+    return {
+      summary: parsed.summary ?? "",
+      actionItems: parsed.actionItems ?? [],
+      fields: parsed.fields ?? {},
+    };
+  } catch {
+    return null;
+  }
+}
+
+const STOPWORDS = new Set([
+  "the",
+  "a",
+  "an",
+  "to",
+  "and",
+  "of",
+  "for",
+  "on",
+  "in",
+  "with",
+  "we",
+  "i",
+  "you",
+  "is",
+  "are",
+  "will",
+]);
+
+function keywords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((word) => word.length > 2 && !STOPWORDS.has(word));
+}
+
+export function MeetingDetail(props: MeetingDetailProps) {
+  const [templates, setTemplates] = createSignal<MeetingTemplate[]>([]);
+  const [selectedTemplate, setSelectedTemplate] = createSignal(
+    props.meeting.templateId ?? settingsStore.get("meetingTemplateId"),
+  );
+  const [regenerating, setRegenerating] = createSignal(false);
+  const [highlightedSeq, setHighlightedSeq] = createSignal<number | null>(null);
+
+  const rows = new Map<number, HTMLElement>();
+
+  onMount(async () => {
+    let builtins: MeetingTemplate[] = [];
+    try {
+      builtins = await listMeetingTemplates();
+    } catch {
+      builtins = [];
+    }
+    setTemplates([...builtins, ...settingsStore.get("meetingCustomTemplates")]);
+  });
+
+  const structured = createMemo(() =>
+    parseStructured(props.meeting.notesStructJson),
+  );
+
+  const segments = () => meetingStore.state.liveSegments;
+
+  const jumpToSource = (text: string) => {
+    const target = keywords(text);
+    if (target.length === 0) return;
+    let best: TranscriptSegment | null = null;
+    let bestScore = 0;
+    for (const segment of segments()) {
+      if (segment.status !== "ok") continue;
+      const words = new Set(keywords(segment.text));
+      const score = target.reduce((acc, k) => acc + (words.has(k) ? 1 : 0), 0);
+      if (score > bestScore) {
+        bestScore = score;
+        best = segment;
+      }
+    }
+    if (best && bestScore > 0) {
+      setHighlightedSeq(best.seq);
+      rows
+        .get(best.seq)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  };
+
+  const regenerate = async () => {
+    if (regenerating()) return;
+    setRegenerating(true);
+    try {
+      await meetingStore.regenerateNotes(props.meeting, selectedTemplate());
+    } finally {
+      setRegenerating(false);
+    }
+  };
+
+  return (
+    <div class="p-5 max-w-[760px]">
+      <div class="mb-5">
+        <h3 class="text-[18px] font-semibold tracking-normal">
+          {meetingTitle(props.meeting)}
+        </h3>
+        <div class="mt-1 flex items-center gap-3 text-[12px] text-muted-foreground">
+          <span>{STATUS_LABELS[props.meeting.status]}</span>
+          <span class="font-mono tabular-nums">
+            {formatDuration(props.meeting)}
+          </span>
+          <span>{props.meeting.sourceApp ?? "Desktop"}</span>
+        </div>
+      </div>
+
+      <div class="mb-4 flex items-center gap-2">
+        <span class="text-[12px] text-muted-foreground">Templates</span>
+        <select
+          class="h-7 rounded-md border border-border bg-surface-1 px-2 text-[12px] text-foreground focus:outline-none focus:border-primary/60"
+          value={selectedTemplate()}
+          onChange={(event) => setSelectedTemplate(event.currentTarget.value)}
+        >
+          <For each={templates()}>
+            {(template) => <option value={template.id}>{template.name}</option>}
+          </For>
+        </select>
+        <button
+          type="button"
+          class="h-7 px-2.5 rounded-md border border-primary/40 bg-primary/10 text-[12px] text-primary hover:bg-primary/15 disabled:opacity-60"
+          onClick={regenerate}
+          disabled={regenerating() || !isTauriRuntime()}
+          title="Regenerate notes with the selected template"
+        >
+          {regenerating() ? "Regenerating…" : "Regenerate"}
+        </button>
+      </div>
+
+      <section class="mb-6">
+        <div class="mb-2 text-[12px] font-medium text-muted-foreground">
+          Notes
+        </div>
+        <Show
+          when={props.meeting.notesMarkdown}
+          fallback={
+            <div class="min-h-[88px] rounded-md border border-border bg-surface-0/50 p-3 text-[13px] text-muted-foreground">
+              Notes will appear here after capture.
+            </div>
+          }
+        >
+          {(markdown) => (
+            <div
+              class="meeting-notes rounded-md border border-border bg-surface-0/50 p-3 text-[13px] leading-6 text-muted-foreground [&_h1]:text-foreground [&_h2]:text-foreground [&_strong]:text-foreground"
+              innerHTML={renderMarkdown(markdown())}
+            />
+          )}
+        </Show>
+      </section>
+
+      <Show when={structured()?.actionItems.length}>
+        <section class="mb-6">
+          <div class="mb-2 text-[12px] font-medium text-muted-foreground">
+            Action items
+          </div>
+          <ul class="space-y-1">
+            <For each={structured()?.actionItems ?? []}>
+              {(item) => (
+                <li>
+                  <button
+                    type="button"
+                    class="text-left w-full text-[13px] text-foreground hover:text-primary flex items-start gap-2"
+                    onClick={() => jumpToSource(item)}
+                    title="Jump to the related transcript moment"
+                  >
+                    <span class="text-primary/70 mt-0.5">⌕</span>
+                    <span>{item}</span>
+                  </button>
+                </li>
+              )}
+            </For>
+          </ul>
+        </section>
+      </Show>
+
+      <section>
+        <div class="mb-2 text-[12px] font-medium text-muted-foreground">
+          Transcript
+        </div>
+        <Show
+          when={segments().length > 0}
+          fallback={
+            <div class="rounded-md border border-border bg-surface-0/50 p-3 text-[13px] text-muted-foreground">
+              No transcript yet.
+            </div>
+          }
+        >
+          <div class="rounded-md border border-border bg-surface-0/50 px-3">
+            <For each={segments()}>
+              {(segment) => (
+                <div
+                  ref={(el) => rows.set(segment.seq, el)}
+                  class="grid grid-cols-[52px_1fr] gap-3 py-2 border-b border-border/50 last:border-b-0 transition-colors"
+                  classList={{
+                    "bg-primary/10": highlightedSeq() === segment.seq,
+                  }}
+                >
+                  <div
+                    class="text-[11px] font-mono tabular-nums"
+                    classList={{
+                      "text-foreground": segment.speaker === "me",
+                      "text-muted-foreground": segment.speaker === "them",
+                    }}
+                  >
+                    {segment.speaker === "me" ? "Me" : "Them"}
+                  </div>
+                  <div
+                    class="text-[13px] leading-5"
+                    classList={{
+                      "text-muted-foreground italic": segment.status === "gap",
+                      "text-foreground": segment.status === "ok",
+                    }}
+                  >
+                    {segment.status === "gap" ? "Transcript gap" : segment.text}
+                  </div>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </section>
+    </div>
+  );
+}

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -9,49 +9,21 @@ import {
   onMount,
   Show,
 } from "solid-js";
-import { isTauriRuntime } from "@/lib/tauri-bridge";
+import { MeetingDetail } from "@/components/meeting/MeetingDetail";
 import {
-  createMeeting,
-  type Meeting,
-  type TranscriptSegment,
-} from "@/services/meetings";
+  formatDuration,
+  formatTime,
+  meetingTitle,
+  STATUS_LABELS,
+} from "@/lib/meeting-format";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+import { createMeeting } from "@/services/meetings";
 import { meetingStore } from "@/stores/meeting.store";
 import { settingsStore } from "@/stores/settings.store";
 
 interface MeetingPanelProps {
   onClose: () => void;
 }
-
-function formatTime(ms: number): string {
-  return new Date(ms).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-function formatDuration(meeting: Meeting): string {
-  const end = meeting.endedAt ?? Date.now();
-  const totalSeconds = Math.max(
-    0,
-    Math.floor((end - meeting.startedAt) / 1000),
-  );
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
-}
-
-function meetingTitle(meeting: Meeting): string {
-  return meeting.title.trim() || `Meeting ${formatTime(meeting.startedAt)}`;
-}
-
-const STATUS_LABELS: Record<Meeting["status"], string> = {
-  capturing: "Capturing",
-  transcribing: "Transcribing",
-  notes_ready: "Notes ready",
-  agent_running: "Agent running",
-  done: "Done",
-  failed: "Failed",
-};
 
 function MicGlyph() {
   return (
@@ -81,31 +53,6 @@ function StopGlyph() {
     >
       <rect x="4" y="4" width="8" height="8" rx="1.5" />
     </svg>
-  );
-}
-
-function TranscriptRow(props: { segment: TranscriptSegment }) {
-  return (
-    <div class="grid grid-cols-[52px_1fr] gap-3 py-2 border-b border-border/50 last:border-b-0">
-      <div
-        class="text-[11px] font-mono tabular-nums"
-        classList={{
-          "text-foreground": props.segment.speaker === "me",
-          "text-muted-foreground": props.segment.speaker === "them",
-        }}
-      >
-        {props.segment.speaker === "me" ? "Me" : "Them"}
-      </div>
-      <div
-        class="text-[13px] leading-5"
-        classList={{
-          "text-muted-foreground italic": props.segment.status === "gap",
-          "text-foreground": props.segment.status === "ok",
-        }}
-      >
-        {props.segment.status === "gap" ? "Transcript gap" : props.segment.text}
-      </div>
-    </div>
   );
 }
 
@@ -310,51 +257,7 @@ export function MeetingPanel(props: MeetingPanelProps) {
               </div>
             }
           >
-            {(meeting) => (
-              <div class="p-5 max-w-[720px]">
-                <div class="mb-5">
-                  <h3 class="text-[18px] font-semibold tracking-normal">
-                    {meetingTitle(meeting())}
-                  </h3>
-                  <div class="mt-1 flex items-center gap-3 text-[12px] text-muted-foreground">
-                    <span>{STATUS_LABELS[meeting().status]}</span>
-                    <span class="font-mono tabular-nums">
-                      {formatDuration(meeting())}
-                    </span>
-                    <span>{meeting().sourceApp ?? "Desktop"}</span>
-                  </div>
-                </div>
-
-                <section class="mb-6">
-                  <div class="mb-2 text-[12px] font-medium text-muted-foreground">
-                    Notes
-                  </div>
-                  <div class="min-h-[96px] whitespace-pre-wrap rounded-md border border-border bg-surface-0/50 p-3 text-[13px] leading-5">
-                    {meeting().notesMarkdown ?? "Notes will appear here."}
-                  </div>
-                </section>
-
-                <section>
-                  <div class="mb-2 text-[12px] font-medium text-muted-foreground">
-                    Transcript
-                  </div>
-                  <Show
-                    when={meetingStore.state.liveSegments.length > 0}
-                    fallback={
-                      <div class="rounded-md border border-border bg-surface-0/50 p-3 text-[13px] text-muted-foreground">
-                        No transcript yet.
-                      </div>
-                    }
-                  >
-                    <div class="rounded-md border border-border bg-surface-0/50 px-3">
-                      <For each={meetingStore.state.liveSegments}>
-                        {(segment) => <TranscriptRow segment={segment} />}
-                      </For>
-                    </div>
-                  </Show>
-                </section>
-              </div>
-            )}
+            {(meeting) => <MeetingDetail meeting={meeting()} />}
           </Show>
         </main>
       </div>

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -14,7 +14,6 @@ import {
   createMeeting,
   type Meeting,
   type TranscriptSegment,
-  updateMeetingStatus,
 } from "@/services/meetings";
 import { meetingStore } from "@/stores/meeting.store";
 import { settingsStore } from "@/stores/settings.store";
@@ -123,8 +122,8 @@ export function MeetingPanel(props: MeetingPanelProps) {
   onCleanup(() => meetingStore.stopMeetingEventListeners());
 
   const activeCapture = createMemo(() =>
-    meetingStore.state.meetings.find((meeting) =>
-      ["capturing", "transcribing", "agent_running"].includes(meeting.status),
+    meetingStore.state.meetings.find(
+      (meeting) => meeting.status === "capturing",
     ),
   );
 
@@ -142,6 +141,7 @@ export function MeetingPanel(props: MeetingPanelProps) {
         templateId: template(),
       });
       setTitle("");
+      await meetingStore.startCapture(meeting);
       await meetingStore.loadMeetings();
       await meetingStore.setActiveMeeting(meeting);
     } finally {
@@ -154,12 +154,7 @@ export function MeetingPanel(props: MeetingPanelProps) {
     if (!desktopRuntime || !meeting || stopping()) return;
     setStopping(true);
     try {
-      await updateMeetingStatus(meeting.id, "done", Date.now());
-      await meetingStore.loadMeetings();
-      const updated = meetingStore.state.meetings.find(
-        (item) => item.id === meeting.id,
-      );
-      await meetingStore.setActiveMeeting(updated ?? null);
+      await meetingStore.stopAndProcess(meeting);
     } finally {
       setStopping(false);
     }
@@ -203,21 +198,21 @@ export function MeetingPanel(props: MeetingPanelProps) {
         <div class="flex items-center gap-3">
           <div class="flex items-center gap-1.5 h-8 px-2 rounded-md border border-border bg-surface-1">
             <For each={[0, 1, 2, 3, 4, 5, 6]}>
-              {(bar) => (
-                <span
-                  class="w-0.5 rounded-full bg-primary/80 transition-all"
-                  classList={{
-                    "animate-[voicePulse_1s_ease-in-out_infinite]":
-                      activeCapture() !== undefined,
-                  }}
-                  style={{
-                    height: activeCapture()
-                      ? `${8 + ((bar * 7) % 18)}px`
-                      : "4px",
-                    "animation-delay": `${bar * 80}ms`,
-                  }}
-                />
-              )}
+              {(bar) => {
+                const height = () => {
+                  if (!activeCapture()) return 4;
+                  const level = meetingStore.state.captureLevel;
+                  // Vary bars so the meter reads as a meter, driven by real amplitude.
+                  const variation = 0.6 + 0.4 * Math.sin((bar + 1) * 1.7);
+                  return Math.max(3, Math.min(22, 3 + level * 26 * variation));
+                };
+                return (
+                  <span
+                    class="w-0.5 rounded-full bg-primary/80 transition-[height] duration-75"
+                    style={{ height: `${height()}px` }}
+                  />
+                );
+              }}
             </For>
           </div>
           <input

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -10,6 +10,7 @@ import {
   Show,
 } from "solid-js";
 import { MeetingDetail } from "@/components/meeting/MeetingDetail";
+import { MeetingSettings } from "@/components/meeting/MeetingSettings";
 import {
   formatDuration,
   formatTime,
@@ -60,6 +61,7 @@ export function MeetingPanel(props: MeetingPanelProps) {
   const [starting, setStarting] = createSignal(false);
   const [stopping, setStopping] = createSignal(false);
   const [title, setTitle] = createSignal("");
+  const [showSettings, setShowSettings] = createSignal(false);
 
   onMount(() => {
     void meetingStore.loadMeetings();
@@ -117,27 +119,51 @@ export function MeetingPanel(props: MeetingPanelProps) {
               {meetingStore.state.meetings.length} saved
             </div>
           </div>
-          <button
-            type="button"
-            class="w-7 h-7 flex items-center justify-center rounded-md border border-border bg-surface-2 text-muted-foreground hover:text-foreground hover:bg-surface-3 transition-colors"
-            onClick={props.onClose}
-            title="Close"
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="none"
-              aria-hidden="true"
+          <div class="flex items-center gap-1.5">
+            <button
+              type="button"
+              class="w-7 h-7 flex items-center justify-center rounded-md border border-border bg-surface-2 hover:bg-surface-3 transition-colors"
+              classList={{
+                "text-primary": showSettings(),
+                "text-muted-foreground hover:text-foreground": !showSettings(),
+              }}
+              onClick={() => setShowSettings((value) => !value)}
+              title="Meeting settings"
             >
-              <path
-                d="M4 4l8 8M12 4l-8 8"
-                stroke="currentColor"
-                stroke-width="1.4"
-                stroke-linecap="round"
-              />
-            </svg>
-          </button>
+              <svg
+                width="15"
+                height="15"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-label="Settings"
+                role="img"
+              >
+                <path d="M8 5.5A2.5 2.5 0 1 0 8 10.5 2.5 2.5 0 0 0 8 5.5Zm0 1.2a1.3 1.3 0 1 1 0 2.6 1.3 1.3 0 0 1 0-2.6Z" />
+                <path d="M7.3 1.5a.7.7 0 0 1 1.4 0l.1.9c.4.1.8.3 1.1.5l.8-.5a.7.7 0 0 1 1 1l-.5.8c.2.3.4.7.5 1.1l.9.1a.7.7 0 0 1 0 1.4l-.9.1c-.1.4-.3.8-.5 1.1l.5.8a.7.7 0 0 1-1 1l-.8-.5c-.3.2-.7.4-1.1.5l-.1.9a.7.7 0 0 1-1.4 0l-.1-.9c-.4-.1-.8-.3-1.1-.5l-.8.5a.7.7 0 0 1-1-1l.5-.8c-.2-.3-.4-.7-.5-1.1l-.9-.1a.7.7 0 0 1 0-1.4l.9-.1c.1-.4.3-.8.5-1.1l-.5-.8a.7.7 0 0 1 1-1l.8.5c.3-.2.7-.4 1.1-.5l.1-.9Z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              class="w-7 h-7 flex items-center justify-center rounded-md border border-border bg-surface-2 text-muted-foreground hover:text-foreground hover:bg-surface-3 transition-colors"
+              onClick={props.onClose}
+              title="Close"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 16 16"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M4 4l8 8M12 4l-8 8"
+                  stroke="currentColor"
+                  stroke-width="1.4"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
       </header>
 
@@ -211,56 +237,60 @@ export function MeetingPanel(props: MeetingPanelProps) {
         </Show>
       </div>
 
-      <div class="min-h-0 flex-1 grid grid-cols-[220px_1fr]">
-        <aside class="min-h-0 overflow-auto border-r border-border bg-surface-0/30">
-          <Show
-            when={meetingStore.state.meetings.length > 0}
-            fallback={
-              <div class="p-4 text-[13px] text-muted-foreground">
-                No meetings saved.
-              </div>
-            }
-          >
-            <For each={meetingStore.state.meetings}>
-              {(meeting) => {
-                const selected = () => activeMeeting()?.id === meeting.id;
-                return (
-                  <button
-                    type="button"
-                    class="w-full text-left px-3 py-2.5 border-b border-border/50 bg-transparent hover:bg-surface-2 transition-colors"
-                    classList={{
-                      "bg-surface-2 text-foreground": selected(),
-                      "text-muted-foreground": !selected(),
-                    }}
-                    onClick={() => void meetingStore.setActiveMeeting(meeting)}
-                  >
-                    <div class="text-[13px] font-medium truncate">
-                      {meetingTitle(meeting)}
-                    </div>
-                    <div class="mt-1 flex items-center justify-between gap-2 text-[11px]">
-                      <span>{formatTime(meeting.startedAt)}</span>
-                      <span>{STATUS_LABELS[meeting.status]}</span>
-                    </div>
-                  </button>
-                );
-              }}
-            </For>
-          </Show>
-        </aside>
+      <Show when={!showSettings()} fallback={<MeetingSettings />}>
+        <div class="min-h-0 flex-1 grid grid-cols-[220px_1fr]">
+          <aside class="min-h-0 overflow-auto border-r border-border bg-surface-0/30">
+            <Show
+              when={meetingStore.state.meetings.length > 0}
+              fallback={
+                <div class="p-4 text-[13px] text-muted-foreground">
+                  No meetings saved.
+                </div>
+              }
+            >
+              <For each={meetingStore.state.meetings}>
+                {(meeting) => {
+                  const selected = () => activeMeeting()?.id === meeting.id;
+                  return (
+                    <button
+                      type="button"
+                      class="w-full text-left px-3 py-2.5 border-b border-border/50 bg-transparent hover:bg-surface-2 transition-colors"
+                      classList={{
+                        "bg-surface-2 text-foreground": selected(),
+                        "text-muted-foreground": !selected(),
+                      }}
+                      onClick={() =>
+                        void meetingStore.setActiveMeeting(meeting)
+                      }
+                    >
+                      <div class="text-[13px] font-medium truncate">
+                        {meetingTitle(meeting)}
+                      </div>
+                      <div class="mt-1 flex items-center justify-between gap-2 text-[11px]">
+                        <span>{formatTime(meeting.startedAt)}</span>
+                        <span>{STATUS_LABELS[meeting.status]}</span>
+                      </div>
+                    </button>
+                  );
+                }}
+              </For>
+            </Show>
+          </aside>
 
-        <main class="min-h-0 overflow-auto">
-          <Show
-            when={activeMeeting()}
-            fallback={
-              <div class="h-full flex items-center justify-center text-[13px] text-muted-foreground">
-                Select a meeting.
-              </div>
-            }
-          >
-            {(meeting) => <MeetingDetail meeting={meeting()} />}
-          </Show>
-        </main>
-      </div>
+          <main class="min-h-0 overflow-auto">
+            <Show
+              when={activeMeeting()}
+              fallback={
+                <div class="h-full flex items-center justify-center text-[13px] text-muted-foreground">
+                  Select a meeting.
+                </div>
+              }
+            >
+              {(meeting) => <MeetingDetail meeting={meeting()} />}
+            </Show>
+          </main>
+        </div>
+      </Show>
     </section>
   );
 }

--- a/src/components/meeting/MeetingSettings.tsx
+++ b/src/components/meeting/MeetingSettings.tsx
@@ -1,0 +1,284 @@
+// ABOUTME: Meeting Mode + dictation settings: templates, vocabulary, routing, auto-detect.
+// ABOUTME: Reads/writes settingsStore; follows the global theme with no state pills.
+
+import { createSignal, For, onMount, Show } from "solid-js";
+import {
+  listMeetingTemplates,
+  type MeetingTemplate,
+} from "@/services/meetings";
+import { settingsStore } from "@/stores/settings.store";
+
+function FieldLabel(props: { children: string; hint?: string }) {
+  return (
+    <div class="mb-1.5">
+      <div class="text-[13px] font-medium text-foreground">
+        {props.children}
+      </div>
+      <Show when={props.hint}>
+        <div class="text-[11px] text-muted-foreground">{props.hint}</div>
+      </Show>
+    </div>
+  );
+}
+
+export function MeetingSettings() {
+  const [builtins, setBuiltins] = createSignal<MeetingTemplate[]>([]);
+  const [vocabTerm, setVocabTerm] = createSignal("");
+  const [allowlistApp, setAllowlistApp] = createSignal("");
+  const [tplName, setTplName] = createSignal("");
+  const [tplPrompt, setTplPrompt] = createSignal("");
+
+  onMount(async () => {
+    try {
+      setBuiltins(await listMeetingTemplates());
+    } catch {
+      setBuiltins([]);
+    }
+  });
+
+  const customTemplates = () => settingsStore.get("meetingCustomTemplates");
+  const vocabulary = () => settingsStore.get("voiceCustomVocabulary");
+  const allowlist = () => settingsStore.get("meetingAppAllowlist");
+
+  const allTemplates = () => [...builtins(), ...customTemplates()];
+
+  const addVocab = () => {
+    const term = vocabTerm().trim();
+    if (!term || vocabulary().includes(term)) return;
+    settingsStore.set("voiceCustomVocabulary", [...vocabulary(), term]);
+    setVocabTerm("");
+  };
+
+  const removeVocab = (term: string) => {
+    settingsStore.set(
+      "voiceCustomVocabulary",
+      vocabulary().filter((t) => t !== term),
+    );
+  };
+
+  const addAllowlistApp = () => {
+    const app = allowlistApp().trim().toLowerCase();
+    if (!app || allowlist().includes(app)) return;
+    settingsStore.set("meetingAppAllowlist", [...allowlist(), app]);
+    setAllowlistApp("");
+  };
+
+  const removeAllowlistApp = (app: string) => {
+    settingsStore.set(
+      "meetingAppAllowlist",
+      allowlist().filter((a) => a !== app),
+    );
+  };
+
+  const addCustomTemplate = () => {
+    const name = tplName().trim();
+    const prompt = tplPrompt().trim();
+    if (!name || !prompt) return;
+    const id = `custom-${name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+    if (allTemplates().some((t) => t.id === id)) return;
+    settingsStore.set("meetingCustomTemplates", [
+      ...customTemplates(),
+      { id, name, prompt },
+    ]);
+    setTplName("");
+    setTplPrompt("");
+  };
+
+  const removeCustomTemplate = (id: string) => {
+    settingsStore.set(
+      "meetingCustomTemplates",
+      customTemplates().filter((t) => t.id !== id),
+    );
+  };
+
+  return (
+    <div class="min-h-0 flex-1 overflow-auto p-5 max-w-[640px] space-y-6">
+      <section>
+        <FieldLabel hint="Used for new meetings and notes generation.">
+          Default template
+        </FieldLabel>
+        <select
+          class="h-8 w-full rounded-md border border-border bg-surface-1 px-2 text-[13px] text-foreground focus:outline-none focus:border-primary/60"
+          value={settingsStore.get("meetingTemplateId")}
+          onChange={(event) =>
+            settingsStore.set("meetingTemplateId", event.currentTarget.value)
+          }
+        >
+          <For each={allTemplates()}>
+            {(template) => <option value={template.id}>{template.name}</option>}
+          </For>
+        </select>
+      </section>
+
+      <section>
+        <FieldLabel hint="A template is a prompt that shapes the note structure.">
+          Custom templates
+        </FieldLabel>
+        <div class="space-y-2">
+          <For each={customTemplates()}>
+            {(template) => (
+              <div class="flex items-start gap-2 rounded-md border border-border bg-surface-0/50 p-2">
+                <div class="min-w-0 flex-1">
+                  <div class="text-[13px] text-foreground">{template.name}</div>
+                  <div class="text-[11px] text-muted-foreground truncate">
+                    {template.prompt}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  class="text-[11px] text-muted-foreground hover:text-destructive"
+                  onClick={() => removeCustomTemplate(template.id)}
+                >
+                  Remove
+                </button>
+              </div>
+            )}
+          </For>
+          <input
+            class="h-8 w-full rounded-md border border-border bg-surface-1 px-2.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary/60"
+            placeholder="Template name"
+            value={tplName()}
+            onInput={(event) => setTplName(event.currentTarget.value)}
+          />
+          <textarea
+            class="min-h-[60px] w-full rounded-md border border-border bg-surface-1 px-2.5 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary/60"
+            placeholder="Prompt: what the notes should capture…"
+            value={tplPrompt()}
+            onInput={(event) => setTplPrompt(event.currentTarget.value)}
+          />
+          <button
+            type="button"
+            class="h-8 px-3 rounded-md border border-primary/40 bg-primary/10 text-[12px] text-primary hover:bg-primary/15"
+            onClick={addCustomTemplate}
+          >
+            Add template
+          </button>
+        </div>
+      </section>
+
+      <section>
+        <FieldLabel hint="Terms the cleanup engine should keep and spell correctly (shared with dictation).">
+          Custom vocabulary
+        </FieldLabel>
+        <div class="flex flex-wrap gap-1.5 mb-2">
+          <For each={vocabulary()}>
+            {(term) => (
+              <span class="inline-flex items-center gap-1 rounded border border-border bg-surface-1 px-1.5 py-0.5 text-[12px] text-foreground">
+                {term}
+                <button
+                  type="button"
+                  class="text-muted-foreground hover:text-destructive"
+                  onClick={() => removeVocab(term)}
+                  aria-label={`Remove ${term}`}
+                >
+                  ×
+                </button>
+              </span>
+            )}
+          </For>
+        </div>
+        <div class="flex gap-2">
+          <input
+            class="h-8 flex-1 rounded-md border border-border bg-surface-1 px-2.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary/60"
+            placeholder="Add a term (e.g. Affinity)"
+            value={vocabTerm()}
+            onInput={(event) => setVocabTerm(event.currentTarget.value)}
+            onKeyDown={(event) => event.key === "Enter" && addVocab()}
+          />
+          <button
+            type="button"
+            class="h-8 px-3 rounded-md border border-border bg-surface-2 text-[12px] text-foreground hover:bg-surface-3"
+            onClick={addVocab}
+          >
+            Add
+          </button>
+        </div>
+      </section>
+
+      <section>
+        <FieldLabel hint="Slug of the installed meeting skill to use when several match.">
+          Default routing skill
+        </FieldLabel>
+        <input
+          class="h-8 w-full rounded-md border border-border bg-surface-1 px-2.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary/60"
+          placeholder="e.g. glide/affinity-proposals (blank = first match)"
+          value={settingsStore.get("meetingDefaultSkill")}
+          onInput={(event) =>
+            settingsStore.set("meetingDefaultSkill", event.currentTarget.value)
+          }
+        />
+      </section>
+
+      <section>
+        <label class="flex items-center justify-between gap-3 cursor-pointer">
+          <FieldLabel hint="Clean up filler and punctuation in notes and dictation.">
+            AI cleanup
+          </FieldLabel>
+          <input
+            type="checkbox"
+            class="h-4 w-4 accent-primary"
+            checked={settingsStore.get("voiceCleanupEnabled")}
+            onChange={(event) =>
+              settingsStore.set(
+                "voiceCleanupEnabled",
+                event.currentTarget.checked,
+              )
+            }
+          />
+        </label>
+      </section>
+
+      <section>
+        <label class="flex items-center justify-between gap-3 cursor-pointer">
+          <FieldLabel hint="Auto-arm capture when a known meeting app is running.">
+            Auto-detect meetings
+          </FieldLabel>
+          <input
+            type="checkbox"
+            class="h-4 w-4 accent-primary"
+            checked={settingsStore.get("meetingAutoDetectEnabled")}
+            onChange={(event) =>
+              settingsStore.set(
+                "meetingAutoDetectEnabled",
+                event.currentTarget.checked,
+              )
+            }
+          />
+        </label>
+        <div class="mt-2 flex flex-wrap gap-1.5">
+          <For each={allowlist()}>
+            {(app) => (
+              <span class="inline-flex items-center gap-1 rounded border border-border bg-surface-1 px-1.5 py-0.5 text-[12px] text-foreground">
+                {app}
+                <button
+                  type="button"
+                  class="text-muted-foreground hover:text-destructive"
+                  onClick={() => removeAllowlistApp(app)}
+                  aria-label={`Remove ${app}`}
+                >
+                  ×
+                </button>
+              </span>
+            )}
+          </For>
+        </div>
+        <div class="mt-2 flex gap-2">
+          <input
+            class="h-8 flex-1 rounded-md border border-border bg-surface-1 px-2.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary/60"
+            placeholder="Add a meeting app (e.g. zoom)"
+            value={allowlistApp()}
+            onInput={(event) => setAllowlistApp(event.currentTarget.value)}
+            onKeyDown={(event) => event.key === "Enter" && addAllowlistApp()}
+          />
+          <button
+            type="button"
+            class="h-8 px-3 rounded-md border border-border bg-surface-2 text-[12px] text-foreground hover:bg-surface-3"
+            onClick={addAllowlistApp}
+          >
+            Add
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/audio/dictationCapture.ts
+++ b/src/lib/audio/dictationCapture.ts
@@ -71,7 +71,9 @@ export async function startDictationCapture(
         const text = await transcribePcm({
           samples: frame,
           channels: 1,
-          sampleRate: TARGET_SAMPLE_RATE,
+          // The WebView may ignore the 16 kHz request; report the real rate so
+          // the Rust pipeline resamples correctly.
+          sampleRate: context.sampleRate,
         });
         const trimmed = text.trim();
         if (trimmed) {

--- a/src/lib/audio/dictationCapture.ts
+++ b/src/lib/audio/dictationCapture.ts
@@ -1,0 +1,151 @@
+// ABOUTME: Streaming webview microphone capture for dictation.
+// ABOUTME: Transcribes ~1.5s chunks (or on silence) via transcribe_pcm and emits live partial text.
+
+import { transcribePcm } from "@/services/dictation";
+
+const TARGET_SAMPLE_RATE = 16_000;
+// Transcribe roughly every 1.5s of audio so text appears live as the user speaks.
+const CHUNK_SAMPLES = Math.floor(TARGET_SAMPLE_RATE * 1.5);
+// A short run of quiet samples ends a phrase early so partials feel responsive.
+const SILENCE_RMS = 0.012;
+const SILENCE_FLUSH_SAMPLES = Math.floor(TARGET_SAMPLE_RATE * 0.6);
+// Never fire a chunk on a tiny sliver of audio (avoids empty/garbled partials).
+const MIN_FLUSH_SAMPLES = Math.floor(TARGET_SAMPLE_RATE * 0.4);
+
+export interface DictationCaptureHandle {
+  /** Current input amplitude in 0..1 for the HUD meter (0 on silence). */
+  level: () => number;
+  /** Stop capture, flush the tail, release the mic, and return the full raw transcript. */
+  stop: () => Promise<string>;
+}
+
+function floatToPcm16(input: Float32Array, out: number[]): void {
+  for (let i = 0; i < input.length; i += 1) {
+    const clamped = Math.max(-1, Math.min(1, input[i]));
+    out.push(Math.round(clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff));
+  }
+}
+
+function frameRms(input: Float32Array): number {
+  let sum = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    sum += input[i] * input[i];
+  }
+  return Math.sqrt(sum / Math.max(1, input.length));
+}
+
+/**
+ * Begin streaming the microphone for dictation. The browser resamples to
+ * 16 kHz mono (the AudioContext rate), so frames are pipeline-ready. Each
+ * flushed chunk is transcribed and surfaced through `onPartial`; transcripts
+ * are serialized so the concatenated result stays in order.
+ */
+export async function startDictationCapture(
+  onPartial: (text: string) => void,
+): Promise<DictationCaptureHandle> {
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+  });
+
+  const context = new AudioContext({ sampleRate: TARGET_SAMPLE_RATE });
+  const source = context.createMediaStreamSource(stream);
+
+  const analyser = context.createAnalyser();
+  analyser.fftSize = 512;
+  source.connect(analyser);
+
+  const processor = context.createScriptProcessor(4096, 1, 1);
+  // Route through a muted gain so onaudioprocess fires without echoing the mic.
+  const mute = context.createGain();
+  mute.gain.value = 0;
+
+  let buffer: number[] = [];
+  let quietSamples = 0;
+  // Serialized chain of transcription work; stop() awaits this before the tail.
+  let pending: Promise<void> = Promise.resolve();
+  let transcript = "";
+
+  const queueTranscription = (frame: number[]) => {
+    pending = pending.then(async () => {
+      try {
+        const text = await transcribePcm({
+          samples: frame,
+          channels: 1,
+          sampleRate: TARGET_SAMPLE_RATE,
+        });
+        const trimmed = text.trim();
+        if (trimmed) {
+          transcript = transcript ? `${transcript} ${trimmed}` : trimmed;
+          onPartial(trimmed);
+        }
+      } catch (err) {
+        console.error("[dictationCapture] transcribe chunk failed:", err);
+      }
+    });
+  };
+
+  const flush = () => {
+    if (buffer.length < MIN_FLUSH_SAMPLES) return;
+    const frame = buffer;
+    buffer = [];
+    quietSamples = 0;
+    queueTranscription(frame);
+  };
+
+  processor.onaudioprocess = (event) => {
+    const channel = event.inputBuffer.getChannelData(0);
+    floatToPcm16(channel, buffer);
+
+    if (frameRms(channel) < SILENCE_RMS) {
+      quietSamples += channel.length;
+    } else {
+      quietSamples = 0;
+    }
+
+    if (
+      buffer.length >= CHUNK_SAMPLES ||
+      (quietSamples >= SILENCE_FLUSH_SAMPLES &&
+        buffer.length >= MIN_FLUSH_SAMPLES)
+    ) {
+      flush();
+    }
+  };
+
+  source.connect(processor);
+  processor.connect(mute);
+  mute.connect(context.destination);
+
+  const timeData = new Uint8Array(analyser.frequencyBinCount);
+  const level = () => {
+    analyser.getByteTimeDomainData(timeData);
+    let sum = 0;
+    for (let i = 0; i < timeData.length; i += 1) {
+      const centered = (timeData[i] - 128) / 128;
+      sum += centered * centered;
+    }
+    return Math.min(1, Math.sqrt(sum / timeData.length) * 3);
+  };
+
+  const stop = async (): Promise<string> => {
+    processor.onaudioprocess = null;
+    // Flush whatever remains, even if shorter than the usual minimum.
+    if (buffer.length > 0) {
+      const frame = buffer;
+      buffer = [];
+      queueTranscription(frame);
+    }
+    processor.disconnect();
+    mute.disconnect();
+    analyser.disconnect();
+    source.disconnect();
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+    await context.close();
+    // Wait for every queued chunk (including the tail) to resolve.
+    await pending;
+    return transcript;
+  };
+
+  return { level, stop };
+}

--- a/src/lib/audio/meetingCapture.ts
+++ b/src/lib/audio/meetingCapture.ts
@@ -55,7 +55,9 @@ export async function startMeetingMicCapture(
       speaker: "me",
       samples: frame,
       channels: 1,
-      sampleRate: TARGET_SAMPLE_RATE,
+      // Report the context's real rate; the WebView may ignore the 16 kHz
+      // request and the Rust pipeline resamples whatever rate it receives.
+      sampleRate: context.sampleRate,
     });
   };
 

--- a/src/lib/audio/meetingCapture.ts
+++ b/src/lib/audio/meetingCapture.ts
@@ -1,0 +1,98 @@
+// ABOUTME: Webview microphone capture for the Meeting Mode "Me" stream.
+// ABOUTME: Streams 16 kHz mono PCM frames to the Rust pipeline and exposes live amplitude.
+
+import { pushCaptureFrame } from "@/services/meetings";
+
+const TARGET_SAMPLE_RATE = 16_000;
+// Flush roughly every 250 ms so the Rust chunker sees audio promptly.
+const FLUSH_SAMPLES = TARGET_SAMPLE_RATE / 4;
+
+export interface MeetingCaptureHandle {
+  /** Current input amplitude in 0..1 for the recorder meter (0 on silence). */
+  level: () => number;
+  /** Stop capture, flush the tail, and release the microphone. */
+  stop: () => Promise<void>;
+}
+
+function floatToPcm16(input: Float32Array, out: number[]): void {
+  for (let i = 0; i < input.length; i += 1) {
+    const clamped = Math.max(-1, Math.min(1, input[i]));
+    out.push(Math.round(clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff));
+  }
+}
+
+/**
+ * Begin capturing the microphone as the meeting "Me" stream. The browser
+ * resamples to 16 kHz mono (the AudioContext rate), so frames are pipeline-ready.
+ */
+export async function startMeetingMicCapture(
+  meetingId: string,
+): Promise<MeetingCaptureHandle> {
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+  });
+
+  const context = new AudioContext({ sampleRate: TARGET_SAMPLE_RATE });
+  const source = context.createMediaStreamSource(stream);
+
+  const analyser = context.createAnalyser();
+  analyser.fftSize = 512;
+  source.connect(analyser);
+
+  const processor = context.createScriptProcessor(4096, 1, 1);
+  // Route the processor through a muted gain so onaudioprocess fires without
+  // playing the microphone back through the speakers.
+  const mute = context.createGain();
+  mute.gain.value = 0;
+
+  let buffer: number[] = [];
+  const flush = () => {
+    if (buffer.length === 0) return;
+    const frame = buffer;
+    buffer = [];
+    void pushCaptureFrame({
+      meetingId,
+      speaker: "me",
+      samples: frame,
+      channels: 1,
+      sampleRate: TARGET_SAMPLE_RATE,
+    });
+  };
+
+  processor.onaudioprocess = (event) => {
+    floatToPcm16(event.inputBuffer.getChannelData(0), buffer);
+    if (buffer.length >= FLUSH_SAMPLES) {
+      flush();
+    }
+  };
+
+  source.connect(processor);
+  processor.connect(mute);
+  mute.connect(context.destination);
+
+  const timeData = new Uint8Array(analyser.frequencyBinCount);
+  const level = () => {
+    analyser.getByteTimeDomainData(timeData);
+    let sum = 0;
+    for (let i = 0; i < timeData.length; i += 1) {
+      const centered = (timeData[i] - 128) / 128;
+      sum += centered * centered;
+    }
+    return Math.min(1, Math.sqrt(sum / timeData.length) * 3);
+  };
+
+  const stop = async () => {
+    processor.onaudioprocess = null;
+    flush();
+    processor.disconnect();
+    mute.disconnect();
+    analyser.disconnect();
+    source.disconnect();
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+    await context.close();
+  };
+
+  return { level, stop };
+}

--- a/src/lib/audio/useVoiceInput.ts
+++ b/src/lib/audio/useVoiceInput.ts
@@ -100,7 +100,7 @@ export function useVoiceInput(
       const transcript = settingsStore.get("voiceCleanupEnabled")
         ? await cleanupDictationText(
             trimmed,
-            providerStore.activeModel,
+            providerStore.resolvedModel(),
             settingsStore.get("voiceCustomVocabulary"),
           )
         : trimmed;

--- a/src/lib/audio/useVoiceInput.ts
+++ b/src/lib/audio/useVoiceInput.ts
@@ -1,21 +1,16 @@
-// ABOUTME: SolidJS hook for microphone recording and speech-to-text transcription.
-// ABOUTME: Manages MediaRecorder lifecycle, audio capture, and Whisper API calls.
+// ABOUTME: SolidJS hook for streaming microphone dictation with live partial transcripts.
+// ABOUTME: Drives transcribe_pcm chunking and the shared LLM cleanup engine, preserving its toggle API.
 
 import { createSignal, onCleanup } from "solid-js";
-import { cleanupDictationText } from "@/lib/audio/dictationCleanup";
-import { transcribeAudio } from "@/services/seren-whisper";
+import {
+  type DictationCaptureHandle,
+  startDictationCapture,
+} from "@/lib/audio/dictationCapture";
+import { cleanupDictationText } from "@/services/dictation";
+import { providerStore } from "@/stores/provider.store";
 import { settingsStore } from "@/stores/settings.store";
 
-export type VoiceState = "idle" | "recording" | "transcribing" | "error";
-
-const MIME_PREFERENCES = ["audio/webm", "audio/mp4", "audio/ogg"];
-
-function getSupportedMimeType(): string {
-  for (const mime of MIME_PREFERENCES) {
-    if (MediaRecorder.isTypeSupported(mime)) return mime;
-  }
-  return "";
-}
+export type VoiceState = "idle" | "listening" | "transcribing" | "error";
 
 /**
  * Get platform-appropriate instructions for enabling microphone access.
@@ -32,16 +27,26 @@ function getMicrophonePermissionInstructions(): string {
   return "your system settings";
 }
 
-export function useVoiceInput(onTranscript: (text: string) => void) {
+export interface VoiceInputOptions {
+  /** Fired with each transcribed chunk while listening (live partial text). */
+  onPartial?: (text: string) => void;
+}
+
+/**
+ * Stream microphone audio to the dictation pipeline. `onTranscript` receives
+ * the final (optionally LLM-cleaned) text after the user stops; `onPartial`
+ * (via options) receives live chunks as the user speaks.
+ */
+export function useVoiceInput(
+  onTranscript: (text: string) => void,
+  options: VoiceInputOptions = {},
+) {
   const [voiceState, setVoiceState] = createSignal<VoiceState>("idle");
   const [error, setError] = createSignal<string | null>(null);
 
-  let recorder: MediaRecorder | null = null;
-  let chunks: Blob[] = [];
-  let activeMimeType = "";
+  let capture: DictationCaptureHandle | null = null;
 
   async function startRecording() {
-    let stream: MediaStream | null = null;
     try {
       setError(null);
 
@@ -52,70 +57,11 @@ export function useVoiceInput(onTranscript: (text: string) => void) {
         );
       }
 
-      activeMimeType = getSupportedMimeType();
-      const options: MediaRecorderOptions = activeMimeType
-        ? { mimeType: activeMimeType }
-        : {};
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      recorder = new MediaRecorder(stream, options);
-      chunks = [];
-
-      recorder.ondataavailable = (e) => {
-        console.log("[VoiceInput] ondataavailable, size:", e.data.size);
-        if (e.data.size > 0) chunks.push(e.data);
-      };
-
-      recorder.onstop = async () => {
-        console.log("[VoiceInput] onstop fired, chunks:", chunks.length);
-        stream?.getTracks().forEach((t) => t.stop());
-        const mimeType = activeMimeType || "audio/webm";
-        const blob = new Blob(chunks, { type: mimeType });
-        chunks = [];
-
-        console.log("[VoiceInput] Blob size:", blob.size, "type:", mimeType);
-        if (blob.size === 0) {
-          console.log("[VoiceInput] Empty blob, returning to idle");
-          setVoiceState("idle");
-          return;
-        }
-
-        setVoiceState("transcribing");
-        try {
-          console.log("[VoiceInput] Sending blob for transcription");
-          const text = await transcribeAudio(blob, mimeType);
-          console.log(
-            "[VoiceInput] Transcription result:",
-            JSON.stringify(text),
-            "type:",
-            typeof text,
-          );
-          if (text?.trim()) {
-            const transcript = settingsStore.get("voiceCleanupEnabled")
-              ? cleanupDictationText(
-                  text,
-                  settingsStore.get("voiceCustomVocabulary"),
-                )
-              : text.trim();
-            console.log("[VoiceInput] Calling onTranscript with:", transcript);
-            if (transcript) {
-              onTranscript(transcript);
-            }
-          } else {
-            console.log("[VoiceInput] No text returned from transcription");
-          }
-          setVoiceState("idle");
-        } catch (err) {
-          console.error("[VoiceInput] Transcription error:", err);
-          setError(err instanceof Error ? err.message : "Transcription failed");
-          setVoiceState("error");
-        }
-      };
-
-      recorder.start();
-      console.log("[VoiceInput] Recording started, mimeType:", activeMimeType);
-      setVoiceState("recording");
+      capture = await startDictationCapture((partial) => {
+        options.onPartial?.(partial);
+      });
+      setVoiceState("listening");
     } catch (err) {
-      stream?.getTracks().forEach((t) => t.stop());
       console.error("[VoiceInput] startRecording error:", err);
       let message: string;
       if (err instanceof DOMException && err.name === "NotAllowedError") {
@@ -134,20 +80,54 @@ export function useVoiceInput(onTranscript: (text: string) => void) {
     }
   }
 
-  function stopRecording() {
-    console.log("[VoiceInput] stopRecording called, state:", recorder?.state);
-    if (recorder?.state === "recording") {
-      recorder.stop();
+  async function stopRecording() {
+    const handle = capture;
+    capture = null;
+    if (!handle) {
+      setVoiceState("idle");
+      return;
+    }
+
+    setVoiceState("transcribing");
+    try {
+      const raw = await handle.stop();
+      const trimmed = raw.trim();
+      if (!trimmed) {
+        setVoiceState("idle");
+        return;
+      }
+
+      const transcript = settingsStore.get("voiceCleanupEnabled")
+        ? await cleanupDictationText(
+            trimmed,
+            providerStore.activeModel,
+            settingsStore.get("voiceCustomVocabulary"),
+          )
+        : trimmed;
+
+      if (transcript.trim()) {
+        onTranscript(transcript.trim());
+      }
+      setVoiceState("idle");
+    } catch (err) {
+      console.error("[VoiceInput] transcription error:", err);
+      setError(err instanceof Error ? err.message : "Transcription failed");
+      setVoiceState("error");
     }
   }
 
+  /** Current capture amplitude in 0..1 (0 when not listening). */
+  function level(): number {
+    return capture?.level() ?? 0;
+  }
+
   function toggle() {
-    console.log("[VoiceInput] toggle called, voiceState:", voiceState());
-    if (voiceState() === "recording") {
-      stopRecording();
-    } else if (voiceState() === "idle" || voiceState() === "error") {
+    const state = voiceState();
+    if (state === "listening") {
+      void stopRecording();
+    } else if (state === "idle" || state === "error") {
       clearError();
-      startRecording();
+      void startRecording();
     }
   }
 
@@ -157,11 +137,19 @@ export function useVoiceInput(onTranscript: (text: string) => void) {
   }
 
   onCleanup(() => {
-    if (recorder?.state === "recording") {
-      recorder.stream.getTracks().forEach((t) => t.stop());
-      recorder.stop();
+    if (capture) {
+      void capture.stop();
+      capture = null;
     }
   });
 
-  return { voiceState, error, toggle, clearError };
+  return {
+    voiceState,
+    error,
+    toggle,
+    clearError,
+    startRecording,
+    stopRecording,
+    level,
+  };
 }

--- a/src/lib/meeting-format.ts
+++ b/src/lib/meeting-format.ts
@@ -1,0 +1,35 @@
+// ABOUTME: Shared display formatting for Meeting Mode surfaces.
+// ABOUTME: Time, duration, title, and status labels used by the panel and detail view.
+
+import type { Meeting } from "@/services/meetings";
+
+export function formatTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function formatDuration(meeting: Meeting): string {
+  const end = meeting.endedAt ?? Date.now();
+  const totalSeconds = Math.max(
+    0,
+    Math.floor((end - meeting.startedAt) / 1000),
+  );
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function meetingTitle(meeting: Meeting): string {
+  return meeting.title.trim() || `Meeting ${formatTime(meeting.startedAt)}`;
+}
+
+export const STATUS_LABELS: Record<Meeting["status"], string> = {
+  capturing: "Capturing",
+  transcribing: "Transcribing",
+  notes_ready: "Notes ready",
+  agent_running: "Agent running",
+  done: "Done",
+  failed: "Failed",
+};

--- a/src/services/dictation.ts
+++ b/src/services/dictation.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Frontend service wrappers for the dictation Tauri commands.
+// ABOUTME: Keeps PCM transcription and the shared LLM cleanup/transform IPC out of Solid components.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export interface PcmChunk {
+  samples: number[];
+  channels: number;
+  sampleRate: number;
+}
+
+/**
+ * Transcribe a single dictation PCM chunk to text. Returns "" for silence.
+ */
+export function transcribePcm(chunk: PcmChunk): Promise<string> {
+  return invoke("transcribe_pcm", {
+    samples: chunk.samples,
+    channels: chunk.channels,
+    sampleRate: chunk.sampleRate,
+  });
+}
+
+/**
+ * Run raw dictation text through the shared Rust LLM cleanup engine.
+ * Honors the active model and the user's custom vocabulary.
+ */
+export function cleanupDictationText(
+  text: string,
+  model: string,
+  vocabulary: string[],
+): Promise<string> {
+  return invoke("cleanup_dictation_text", { text, model, vocabulary });
+}
+
+/**
+ * Edit-by-voice: apply a spoken instruction to a selected span of text.
+ * Returns the rewritten selection.
+ */
+export function transformSelection(
+  selection: string,
+  instruction: string,
+  model: string,
+  vocabulary: string[],
+): Promise<string> {
+  return invoke("transform_selection", {
+    selection,
+    instruction,
+    model,
+    vocabulary,
+  });
+}

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -126,3 +126,78 @@ export function getTranscriptSegments(
 ): Promise<TranscriptSegment[]> {
   return invoke("get_transcript_segments", { meetingId });
 }
+
+export interface StructuredNotes {
+  summary: string;
+  actionItems: string[];
+  fields: Record<string, unknown>;
+}
+
+export interface ParsedNotes {
+  markdown: string;
+  structured: StructuredNotes;
+}
+
+export interface MeetingTemplate {
+  id: string;
+  name: string;
+  prompt: string;
+}
+
+export interface SkillRef {
+  slug: string;
+  name: string;
+  description: string;
+  tags: string[];
+  path: string;
+}
+
+export function startMeetingCapture(meetingId: string): Promise<void> {
+  return invoke("start_meeting_capture", { meetingId });
+}
+
+export function pushCaptureFrame(input: {
+  meetingId: string;
+  speaker: Speaker;
+  samples: number[];
+  channels: number;
+  sampleRate: number;
+}): Promise<void> {
+  return invoke("push_capture_frame", {
+    meetingId: input.meetingId,
+    speaker: input.speaker,
+    samples: input.samples,
+    channels: input.channels,
+    sampleRate: input.sampleRate,
+  });
+}
+
+export function stopMeetingCapture(meetingId: string): Promise<void> {
+  return invoke("stop_meeting_capture", { meetingId });
+}
+
+export function generateMeetingNotes(input: {
+  meetingId: string;
+  model: string;
+  templatePrompt: string;
+  vocabulary: string[];
+}): Promise<ParsedNotes> {
+  return invoke("generate_meeting_notes", {
+    meetingId: input.meetingId,
+    model: input.model,
+    templatePrompt: input.templatePrompt,
+    vocabulary: input.vocabulary,
+  });
+}
+
+export function getMeetingTranscriptText(meetingId: string): Promise<string> {
+  return invoke("get_meeting_transcript_text", { meetingId });
+}
+
+export function selectMeetingSkills(skills: SkillRef[]): Promise<string[]> {
+  return invoke("select_meeting_skills", { skills });
+}
+
+export function listMeetingTemplates(): Promise<MeetingTemplate[]> {
+  return invoke("list_meeting_templates");
+}

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -3,18 +3,37 @@
 
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createStore } from "solid-js/store";
+import {
+  type MeetingCaptureHandle,
+  startMeetingMicCapture,
+} from "@/lib/audio/meetingCapture";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 import {
+  generateMeetingNotes,
+  getMeetingTranscriptText,
   getTranscriptSegments,
   listMeetings,
+  listMeetingTemplates,
   type Meeting,
+  type MeetingTemplate,
+  selectMeetingSkills,
+  setMeetingRoutedSkill,
+  startMeetingCapture as startBackendCapture,
+  stopMeetingCapture as stopBackendCapture,
   type TranscriptSegment,
+  updateMeetingStatus,
 } from "@/services/meetings";
+import { orchestrate } from "@/services/orchestrator";
+import { conversationStore } from "@/stores/conversation.store";
+import { providerStore } from "@/stores/provider.store";
+import { settingsStore } from "@/stores/settings.store";
+import { skillsStore } from "@/stores/skills.store";
 
 interface MeetingState {
   meetings: Meeting[];
   activeMeeting: Meeting | null;
   liveSegments: TranscriptSegment[];
+  captureLevel: number;
   isLoading: boolean;
   error: string | null;
 }
@@ -23,9 +42,13 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   meetings: [],
   activeMeeting: null,
   liveSegments: [],
+  captureLevel: 0,
   isLoading: false,
   error: null,
 });
+
+let captureHandle: MeetingCaptureHandle | null = null;
+let levelTimer: number | null = null;
 
 let transcriptUnlisten: UnlistenFn | null = null;
 let statusUnlisten: UnlistenFn | null = null;
@@ -120,6 +143,147 @@ function stopMeetingEventListeners(): void {
   statusUnlisten = null;
 }
 
+async function startCapture(meeting: Meeting): Promise<void> {
+  if (!isTauriRuntime()) return;
+  await startBackendCapture(meeting.id);
+  try {
+    captureHandle = await startMeetingMicCapture(meeting.id);
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Microphone unavailable",
+    );
+    return;
+  }
+  if (levelTimer !== null) window.clearInterval(levelTimer);
+  levelTimer = window.setInterval(() => {
+    setMeetingState("captureLevel", captureHandle?.level() ?? 0);
+  }, 60);
+}
+
+async function stopCapture(meetingId: string): Promise<void> {
+  if (levelTimer !== null) {
+    window.clearInterval(levelTimer);
+    levelTimer = null;
+  }
+  setMeetingState("captureLevel", 0);
+  if (captureHandle) {
+    try {
+      await captureHandle.stop();
+    } catch {
+      // The audio graph may already be torn down; ignore.
+    }
+    captureHandle = null;
+  }
+  if (isTauriRuntime()) {
+    await stopBackendCapture(meetingId);
+  }
+}
+
+let templateCache: MeetingTemplate[] | null = null;
+
+async function resolveTemplatePrompt(
+  templateId: string | null,
+): Promise<string> {
+  if (!templateCache) {
+    try {
+      templateCache = await listMeetingTemplates();
+    } catch {
+      templateCache = [];
+    }
+  }
+  const custom = settingsStore.get("meetingCustomTemplates");
+  const match = [...templateCache, ...custom].find((t) => t.id === templateId);
+  return match?.prompt ?? "Summarize key points, decisions, and next steps.";
+}
+
+// End capture, generate Tier-1 notes, then hand off to a tagged skill if one is
+// installed. With no meeting skill, it stops at notes (Granola parity).
+async function stopAndProcess(meeting: Meeting): Promise<void> {
+  await stopCapture(meeting.id);
+  await loadMeetings();
+  if (!isTauriRuntime()) return;
+
+  const templatePrompt = await resolveTemplatePrompt(meeting.templateId);
+  try {
+    await generateMeetingNotes({
+      meetingId: meeting.id,
+      model: providerStore.activeModel,
+      templatePrompt,
+      vocabulary: settingsStore.get("voiceCustomVocabulary"),
+    });
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Notes generation failed",
+    );
+  }
+  await loadMeetings();
+  const refreshed =
+    meetingState.meetings.find((m) => m.id === meeting.id) ?? null;
+  await setActiveMeeting(refreshed);
+
+  await runHandoff(meeting);
+}
+
+async function runHandoff(meeting: Meeting): Promise<void> {
+  const skillRefs = skillsStore.enabledSkills.map((skill) => ({
+    slug: skill.slug,
+    name: skill.name,
+    description: skill.description ?? "",
+    tags: skill.tags ?? [],
+    path: skill.path,
+  }));
+
+  let meetingSlugs: string[] = [];
+  try {
+    meetingSlugs = await selectMeetingSkills(skillRefs);
+  } catch {
+    meetingSlugs = [];
+  }
+  if (meetingSlugs.length === 0) return;
+
+  const defaultSlug = settingsStore.get("meetingDefaultSkill");
+  const chosenSlug =
+    defaultSlug && meetingSlugs.includes(defaultSlug)
+      ? defaultSlug
+      : meetingSlugs[0];
+  const chosen = skillRefs.find((skill) => skill.slug === chosenSlug);
+  if (!chosen) return;
+
+  const transcript = await getMeetingTranscriptText(meeting.id).catch(() => "");
+  const notes =
+    meetingState.meetings.find((m) => m.id === meeting.id)?.notesMarkdown ?? "";
+
+  const conversation = await conversationStore.createConversationWithModel(
+    `Meeting: ${meeting.title}`.slice(0, 80),
+    providerStore.activeModel,
+  );
+  await setMeetingRoutedSkill(meeting.id, chosenSlug, conversation.id);
+  await updateMeetingStatus(meeting.id, "agent_running");
+  await loadMeetings();
+
+  const prompt = [
+    `Process this completed meeting using the ${chosen.name} meeting skill` +
+      (chosen.tags.length ? ` (tags: ${chosen.tags.join(", ")})` : "") +
+      ".",
+    notes ? `Meeting notes:\n${notes}` : "",
+    transcript ? `Transcript:\n${transcript}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  conversationStore.setActiveConversation(conversation.id);
+  try {
+    await orchestrate(conversation.id, prompt);
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Agent handoff failed",
+    );
+  }
+}
+
 export const meetingStore = {
   get state(): MeetingState {
     return meetingState;
@@ -129,4 +293,7 @@ export const meetingStore = {
   appendLiveSegment,
   startMeetingEventListeners,
   stopMeetingEventListeners,
+  startCapture,
+  stopCapture,
+  stopAndProcess,
 };

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -284,6 +284,31 @@ async function runHandoff(meeting: Meeting): Promise<void> {
   }
 }
 
+async function regenerateNotes(
+  meeting: Meeting,
+  templateId: string,
+): Promise<void> {
+  if (!isTauriRuntime()) return;
+  const templatePrompt = await resolveTemplatePrompt(templateId);
+  try {
+    await generateMeetingNotes({
+      meetingId: meeting.id,
+      model: providerStore.activeModel,
+      templatePrompt,
+      vocabulary: settingsStore.get("voiceCustomVocabulary"),
+    });
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Notes generation failed",
+    );
+  }
+  await loadMeetings();
+  const refreshed =
+    meetingState.meetings.find((m) => m.id === meeting.id) ?? null;
+  await setActiveMeeting(refreshed);
+}
+
 export const meetingStore = {
   get state(): MeetingState {
     return meetingState;
@@ -296,4 +321,5 @@ export const meetingStore = {
   startCapture,
   stopCapture,
   stopAndProcess,
+  regenerateNotes,
 };

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -208,7 +208,7 @@ async function stopAndProcess(meeting: Meeting): Promise<void> {
   try {
     await generateMeetingNotes({
       meetingId: meeting.id,
-      model: providerStore.activeModel,
+      model: providerStore.resolvedModel(),
       templatePrompt,
       vocabulary: settingsStore.get("voiceCustomVocabulary"),
     });
@@ -293,7 +293,7 @@ async function regenerateNotes(
   try {
     await generateMeetingNotes({
       meetingId: meeting.id,
-      model: providerStore.activeModel,
+      model: providerStore.resolvedModel(),
       templatePrompt,
       vocabulary: settingsStore.get("voiceCustomVocabulary"),
     });

--- a/src/stores/provider.store.ts
+++ b/src/stores/provider.store.ts
@@ -458,6 +458,19 @@ function getModels(providerId: ProviderId): ProviderModel[] {
 }
 
 /**
+ * Resolve a concrete model id for direct Gateway calls (notes, dictation
+ * cleanup, edit-by-voice). The normal chat path lets the router resolve the
+ * "auto" sentinel; a direct publisher call cannot send "auto", so fall back to
+ * the first available model for the active provider.
+ */
+function resolvedModel(): string {
+  const active = state.activeModel;
+  if (active && active !== AUTO_MODEL_ID) return active;
+  const models = state.providerModels[state.activeProvider] ?? [];
+  return models[0]?.id ?? active;
+}
+
+/**
  * Clear any validation error.
  */
 function clearValidationError(): void {
@@ -519,6 +532,7 @@ export const providerStore = {
   setActiveModel,
   setProviderModels,
   getModels,
+  resolvedModel,
   clearValidationError,
   getUnconfiguredProviders,
 };

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -160,6 +160,8 @@ export interface Settings {
   meetingAutoDetectEnabled: boolean;
   meetingTemplateId: string;
   meetingAppAllowlist: string[];
+  meetingCustomTemplates: { id: string; name: string; prompt: string }[];
+  meetingDefaultSkill: string;
 
   // General settings
   telemetryEnabled: boolean;
@@ -259,6 +261,8 @@ const DEFAULT_SETTINGS: Settings = {
   meetingAutoDetectEnabled: true,
   meetingTemplateId: "discovery",
   meetingAppAllowlist: ["zoom", "teams", "meet", "slack", "webex"],
+  meetingCustomTemplates: [],
+  meetingDefaultSkill: "",
   // General
   telemetryEnabled: true,
 };


### PR DESCRIPTION
## Summary

Part of #2125. **PR1 of 2** — the fully automated-test-green core of the STT R1 upgrade. It turns the merged-but-inert foundations (#2120) into a working pipeline: pressing **Start** now captures real audio and streams a live transcript; **Stop** generates Tier-1 notes and hands off to a tag-routed skill; in-app dictation streams with cleanup, custom vocabulary, and edit-by-voice.

**PR2 (separate branch, for a Windows + macOS 14.4+ hardware pass)** will add native system-audio capture (the "Them" stream), meeting auto-detect, permission priming, the floating capture widget, and the tray live indicator — everything that needs cross-OS screen-recording proof that can't be produced from this environment.

## What this closes (PR1 scope)

**Capture / pipeline (W1 partial, W2)**
- `AudioCaptureSource` trait + pure 16 kHz downmix/resample util (TDD) + deterministic fake source.
- Real Whisper client: PCM→WAV→`/publishers/seren-whisper` envelope, retry/backoff, failed window → `gap`.
- Live orchestrator loop: frames → streaming VAD chunker → transcribe → merge → persist → `meeting://transcript-chunk`. The assembled wiring is covered by an automated fake-source test (ordered segments; gaps on failure).
- Meeting "Me" stream captured via the webview mic (16 kHz mono) → `push_capture_frame`. (Native cpal mic + system audio = PR2.)

**Intelligence (W3)** — Tier-1 notes via the existing chat-model path + the existing parser; built-in + custom templates with picker & regenerate; one shared cleanup engine reused by notes + dictation.

**Agency (W4)** — tag-based meeting-skill routing (no slug literals; grep-clean), call-end `orchestrate()` kickoff, 0 / 1 / many branches; the CRM write is still gated by the existing ActionConfirmation (unchanged).

**Data (W5-2)** — automated test proves schema setup is non-destructive on re-run (existing `chat.db`, no data loss).

**UI (W6 partial)** — recorder meter driven by real amplitude (flat on silence); notes canvas (markdown render, AI text muted, jump-to-source, template picker, regenerate); meeting settings (templates, vocabulary, routing, auto-detect toggle + app allowlist); follows global light/dark, zero pills.

**Dictation (W7)** — streaming partial text; cleanup toggle + custom vocabulary (shared engine); edit-by-voice (transform a composer selection by a spoken instruction); bottom-center HUD with idle/listening/transcribing + right-Option push-to-talk.

## Deferred to PR2 (needs hardware)
- W1-1 / W1-2 native system-audio capture (WASAPI loopback + Core Audio process tap) — the "Them" stream.
- W1-5 auto-detect OS probes/arming; W1-7 permission priming + denial helper.
- W6-2 floating capture widget; W6-4 tray live indicator.
- E2E-1 manual cross-platform run; the §6 recording-attached boxes; the published-release gate.

## Gates — all green for these changes
- `cargo test --lib`: **607 passed, 0 failed** (downmix, streaming chunker, transcribe retry + WAV/envelope build, pipeline wiring, notes parse, meeting routing 0/1/many, migration safety).
- `vitest run`: **1549 passed**.
- `tsc --noEmit`: zero new errors (the 4 reported are the pre-existing PdfViewer/test baseline, identical on `main`).
- `biome check`: changed files clean (the 3 errors / 53 warnings are the unchanged `main` baseline).

Critical-logic tests are present and non-duplicated; no UI/mock-only tests. **No new Rust dependencies.**

## Honest notes
- The app could not be run with a microphone/Tauri shell from this environment, so the live capture → transcribe → insert path and push-to-talk are verified by types + lint + tests + review, not a live recording. The webview capture is standard Web Audio (`AudioContext({sampleRate:16000})` → ScriptProcessor → i16 frames).
- Reference docs under `docs/plans/` remain gitignored and uncommitted, as required.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
