### PR TITLE
fix(types): clear stale tsc errors (pdfjs v6 + untyped test import)

### DIFF
--- a/src/components/editor/PdfViewer.tsx
+++ b/src/components/editor/PdfViewer.tsx
@@ -28,6 +28,7 @@ export const PdfViewer: Component<PdfViewerProps> = (props) => {
 
   let canvasRef: HTMLCanvasElement | undefined;
   let pdfDoc: pdfjsLib.PDFDocumentProxy | null = null;
+  let loadingTask: pdfjsLib.PDFDocumentLoadingTask | null = null;
   let currentRenderTask: pdfjsLib.RenderTask | null = null;
 
   // Load PDF when file path changes
@@ -42,9 +43,12 @@ export const PdfViewer: Component<PdfViewerProps> = (props) => {
     if (currentRenderTask) {
       currentRenderTask.cancel();
     }
-    if (pdfDoc) {
-      pdfDoc.destroy();
+    // In pdfjs-dist v6, teardown is on the loading task (destroys doc + worker).
+    if (loadingTask) {
+      void loadingTask.destroy();
+      loadingTask = null;
     }
+    pdfDoc = null;
   });
 
   async function loadPdf(path: string) {
@@ -53,14 +57,15 @@ export const PdfViewer: Component<PdfViewerProps> = (props) => {
 
     try {
       // Clean up previous document
-      if (pdfDoc) {
-        pdfDoc.destroy();
-        pdfDoc = null;
+      if (loadingTask) {
+        void loadingTask.destroy();
+        loadingTask = null;
       }
+      pdfDoc = null;
 
-      // Load PDF using file:// URL
+      // Load PDF using a file:// URL (v6 getDocument takes init parameters).
       const url = `file://${path}`;
-      const loadingTask = pdfjsLib.getDocument(url);
+      loadingTask = pdfjsLib.getDocument({ url });
       pdfDoc = await loadingTask.promise;
 
       setTotalPages(pdfDoc.numPages);

--- a/tests/unit/codex-agent-image-context.test.ts
+++ b/tests/unit/codex-agent-image-context.test.ts
@@ -2,6 +2,7 @@
 // ABOUTME: reach Codex app-server as image user input items, not disappear.
 
 import { describe, expect, it } from "vitest";
+// @ts-expect-error - providers.mjs is a plain ESM harness without type declarations
 import { buildCodexTurnInput } from "../../bin/browser-local/providers.mjs";
 
 describe("#2016 — Codex agent prompt preserves image context", () => {


### PR DESCRIPTION
Closes #2129.

Clears the 4 stale `tsc --noEmit` errors on `main` (they don't fail `vite build`/CI but dirty the type-check).

- **PdfViewer.tsx** (3 errors): pdfjs-dist **v6** moved `destroy()` to `PDFDocumentLoadingTask` (the proxy only has `cleanup()`), and `getDocument()` now takes `DocumentInitParameters`. Keep the loading task, tear down via `loadingTask.destroy()`, and call `getDocument({ url })`.
- **codex-agent-image-context.test.ts** (1 error): the only static typed import of the plain-ESM `bin/browser-local/providers.mjs` harness gets a scoped `@ts-expect-error` — a sidecar `.d.mts` would cascade onto the module's other dynamic importers.

**Gates:** `tsc --noEmit` now **0 errors**; the affected vitest test passes; Biome clean. No runtime behavior change.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com