### PR TITLE
Focus runtime console on actionable errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ A **publisher** is anything a skill can call when it needs to do something - a b
 
 ---
 
+## Development
+
+The runtime console is quiet by default so errors and warnings stay easy to find. To inspect normal success-path breadcrumbs during a deep lifecycle investigation, enable verbose runtime console logging in DevTools:
+
+```js
+localStorage.setItem("seren.debug.verboseConsole", "true");
+```
+
+Set the value to `"false"` or remove the key to return to the default error-focused console.
+
+---
+
 ## Links
 
 - [Seren Website](https://serendb.com)

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -138,7 +138,7 @@ pub async fn refresh_access_token(app: &tauri::AppHandle) -> Result<String, Stri
     store_tokens(app, new_access_token, new_refresh_token)?;
     let _ = app.emit("auth:token-refreshed", ());
 
-    log::info!("[auth] Token refreshed successfully");
+    log::debug!("[auth] Token refreshed successfully");
     Ok(new_access_token.to_string())
 }
 
@@ -175,7 +175,7 @@ where
     }
 
     // 401 — attempt refresh and retry
-    log::info!("[auth] Got 401, attempting token refresh...");
+    log::debug!("[auth] Got 401, attempting token refresh...");
     let new_token = refresh_access_token(app).await?;
 
     build_request(client, &new_token)

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -459,7 +459,7 @@ pub async fn mcp_connect(
     // so we cannot rely on the OS to find commands that live in /opt/homebrew/bin etc.
     let resolved_command = resolve_command_in_embedded_path(&command);
 
-    log::info!(
+    log::debug!(
         "[MCP:{}] Connecting: command={:?} (resolved={:?}), args={:?}",
         server_name,
         command,
@@ -596,7 +596,7 @@ pub async fn mcp_connect(
     writeln!(process.stdin, "{}", notification).map_err(|e| e.to_string())?;
     process.stdin.flush().map_err(|e| e.to_string())?;
 
-    log::info!(
+    log::debug!(
         "[MCP:{}] Connected successfully (server: {} v{})",
         server_name,
         init_result.server_info.name,

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -113,7 +113,7 @@ pub fn checkpoint_wal(conn: &Connection, mode: WalCheckpointMode) -> Result<()> 
 pub fn checkpoint_managed_db(app: &AppHandle, reason: &str) {
     if let Some(pool) = app.try_state::<DbPool>() {
         match pool.checkpoint_wal(WalCheckpointMode::Truncate) {
-            Ok(()) => log::info!("[Database] WAL checkpoint(TRUNCATE) completed: {}", reason),
+            Ok(()) => log::debug!("[Database] WAL checkpoint(TRUNCATE) completed: {}", reason),
             Err(err) => log::warn!(
                 "[Database] WAL checkpoint(TRUNCATE) failed during {}: {}",
                 reason,
@@ -165,7 +165,7 @@ pub fn save_message_record(conn: &Connection, message: &PersistedMessage) -> Res
         return Err(err);
     }
 
-    log::info!(
+    log::debug!(
         "[Database] Persisted message {} for conversation {}",
         message.id,
         message.conversation_id

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -46,6 +46,7 @@ import {
   mapAgentModelToChat,
 } from "@/lib/rate-limit-fallback";
 import { escapeHtmlWithSkillsAndLinks } from "@/lib/render-markdown";
+import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import { saveToSerenNotes } from "@/lib/save-to-notes";
 import {
   canAcceptSkillDrop,
@@ -186,7 +187,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     const thread = props.threadId
       ? threadStore.threads.find((candidate) => candidate.id === props.threadId)
       : threadStore.activeThread;
-    if (!thread || thread.kind !== "agent") return null;
+    if (thread?.kind !== "agent") return null;
     return thread;
   });
 
@@ -265,7 +266,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     if (slugs.size === 0) return null;
     for (let i = messages.length - 1; i >= 0; i -= 1) {
       const message = messages[i];
-      if (!message || message.type !== "user") continue;
+      if (message?.type !== "user") continue;
       const match = message.content.match(/^\/([a-zA-Z][a-zA-Z0-9:_-]*)/);
       if (!match) continue;
       const slug = match[1];
@@ -552,28 +553,28 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
     try {
       const sessionId = await agentStore.resumeAgentConversation(thread.id);
-      console.log("[AgentChat] Session resumed:", sessionId);
+      verboseRuntimeConsole.debug("[AgentChat] Session resumed:", sessionId);
     } catch (error) {
       console.error("[AgentChat] Failed to resume session:", error);
     }
   };
 
   const handleAttachImages = async () => {
-    console.log(
+    verboseRuntimeConsole.debug(
       "[AgentChat] handleAttachImages called, hasSession:",
       hasSession(),
     );
 
     // Prevent multiple concurrent attach operations
     if (isAttaching()) {
-      console.log("[AgentChat] Already attaching, skipping");
+      verboseRuntimeConsole.debug("[AgentChat] Already attaching, skipping");
       return;
     }
 
     setIsAttaching(true);
     try {
       const files = await pickAndReadAttachments();
-      console.log(
+      verboseRuntimeConsole.debug(
         "[AgentChat] pickAndReadAttachments returned:",
         files.length,
         "files",
@@ -582,7 +583,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       if (files.length > 0) {
         setAttachedImages((prev) => {
           const newAttachments = [...prev, ...files];
-          console.log(
+          verboseRuntimeConsole.debug(
             "[AgentChat] Updating attachedImages, prev:",
             prev.length,
             "adding:",
@@ -593,12 +594,14 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           return newAttachments;
         });
         // Log the current state after the update
-        console.log(
+        verboseRuntimeConsole.debug(
           "[AgentChat] attachedImages after update:",
           attachedImages().length,
         );
       } else {
-        console.log("[AgentChat] No files selected or dialog cancelled");
+        verboseRuntimeConsole.debug(
+          "[AgentChat] No files selected or dialog cancelled",
+        );
       }
     } catch (error) {
       console.error("[AgentChat] handleAttachImages error:", error);
@@ -734,7 +737,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const sendMessage = async () => {
     const trimmed = input().trim();
     const images = attachedImages();
-    console.log("[AgentChat] sendMessage called:", {
+    verboseRuntimeConsole.debug("[AgentChat] sendMessage called:", {
       hasText: !!trimmed,
       attachments: images.length,
       mimeTypes: images.map((a) => a.mimeType),
@@ -774,7 +777,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         // bail before dispatching the prompt. Without this, the async spawn
         // resolves after Cancel and the user's prompt sneaks through.
         if (!agentStore.isTurnInFlight(thread.id)) {
-          console.info("[AgentChat] cold-start cancelled during spawn");
+          verboseRuntimeConsole.debug(
+            "[AgentChat] cold-start cancelled during spawn",
+          );
           if (sid) await agentStore.terminateSession(sid);
           return;
         }
@@ -822,7 +827,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       const skillMatch = await resolveSkillCommand(trimmed);
       if (skillMatch) {
         const { skill, args } = skillMatch;
-        console.log("[AgentChat] Skill invocation:", skill.slug, "args:", args);
+        verboseRuntimeConsole.debug(
+          "[AgentChat] Skill invocation:",
+          skill.slug,
+          "args:",
+          args,
+        );
 
         setInput("");
         setHistoryIndex(-1);
@@ -875,7 +885,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       setInput("");
       setHistoryIndex(-1);
       setSavedInput("");
-      console.log("[AgentChat] Message queued:", trimmed);
+      verboseRuntimeConsole.debug("[AgentChat] Message queued:", trimmed);
       return;
     }
 
@@ -891,7 +901,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     // Split attachments: images go as agent context blocks; docreader files get extracted to text
     const imageAttachments = images.filter((a) => !isDocreaderMime(a.mimeType));
     const docAttachments = images.filter((a) => isDocreaderMime(a.mimeType));
-    console.log("[AgentChat] Attachment split:", {
+    verboseRuntimeConsole.debug("[AgentChat] Attachment split:", {
       imageAttachments: imageAttachments.length,
       docAttachments: docAttachments.map((d) => d.name),
     });
@@ -901,7 +911,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     if (docAttachments.length > 0) {
       setIsProcessingDocs(true);
       setCommandStatus("Processing documents…");
-      console.log(
+      verboseRuntimeConsole.debug(
         "[AgentChat] Starting DocReader processing for",
         docAttachments.length,
         "documents",
@@ -909,7 +919,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       try {
         const docBlocks = await Promise.all(
           docAttachments.map(async (doc: Attachment) => {
-            console.log(
+            verboseRuntimeConsole.debug(
               "[AgentChat] Processing document:",
               doc.name,
               doc.mimeType,
@@ -917,7 +927,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               doc.base64.length,
             );
             const text = await readDocument(doc);
-            console.log(
+            verboseRuntimeConsole.debug(
               "[AgentChat] DocReader success for",
               doc.name,
               "extracted",
@@ -939,7 +949,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       }
       setCommandStatus(null);
       setIsProcessingDocs(false);
-      console.log(
+      verboseRuntimeConsole.debug(
         "[AgentChat] DocReader complete, prompt length:",
         promptWithDocs.length,
       );
@@ -975,13 +985,13 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     // and the sendPrompt dispatch, or during an awaited skill/doc load.
     // Honor the cancel before dispatching so the prompt never leaks through.
     if (thread && !agentStore.isTurnInFlight(thread.id)) {
-      console.info(
+      verboseRuntimeConsole.debug(
         "[AgentChat] sendMessage: cancel detected before dispatch — skipping sendPrompt",
       );
       return;
     }
 
-    console.log(
+    verboseRuntimeConsole.debug(
       "[AgentChat] Sending prompt to agent runtime, context blocks:",
       context?.length ?? 0,
     );
@@ -1046,7 +1056,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
   const handleRunSkillEvent = (event: Event) => {
     const detail = (event as CustomEvent<RunSkillEventDetail>).detail;
-    if (!detail || detail.kind !== "agent") return;
+    if (detail?.kind !== "agent") return;
     const thread = activeAgentThread();
     if (!thread || thread.id !== detail.threadId) return;
 

--- a/src/lib/mcp/serendb.ts
+++ b/src/lib/mcp/serendb.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Seren MCP Gateway configuration for built-in gateway access.
 // ABOUTME: Manages the builtin server entry that represents the REST-based gateway connection.
 
+import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import {
   addMcpServer,
   mcpSettings,
@@ -46,7 +47,7 @@ export async function addSerenDbServer(): Promise<void> {
     await removeMcpServer(SERENDB_SERVER_NAME);
   }
 
-  console.log("[Seren MCP] Adding builtin server config");
+  verboseRuntimeConsole.debug("[Seren MCP] Adding builtin server config");
   await addMcpServer(serenDbServerConfig);
 }
 

--- a/src/lib/runtime-console.ts
+++ b/src/lib/runtime-console.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Opt-in runtime console breadcrumbs for normal success paths.
+// ABOUTME: Keeps production console output focused on actionable warnings/errors.
+
+export const RUNTIME_VERBOSE_CONSOLE_KEY = "seren.debug.verboseConsole";
+
+type DebugStorage = Pick<Storage, "getItem">;
+
+function runtimeConsoleStorage(): DebugStorage | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isEnabled(value: string | null): boolean {
+  if (!value) return false;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+export function shouldLogVerboseRuntimeConsole(
+  storage: DebugStorage | null = runtimeConsoleStorage(),
+): boolean {
+  return isEnabled(storage?.getItem(RUNTIME_VERBOSE_CONSOLE_KEY) ?? null);
+}
+
+export const verboseRuntimeConsole = {
+  debug(...args: unknown[]): void {
+    if (shouldLogVerboseRuntimeConsole()) {
+      console.debug(...args);
+    }
+  },
+
+  debugWithStorage(storage: DebugStorage | null, ...args: unknown[]): void {
+    if (shouldLogVerboseRuntimeConsole(storage)) {
+      console.debug(...args);
+    }
+  },
+};

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -4,6 +4,7 @@
 import { MCP_GATEWAY_URL } from "@/lib/config";
 import { mcpClient } from "@/lib/mcp/client";
 import type { McpTool, McpToolResult } from "@/lib/mcp/types";
+import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import { captureSupportError } from "@/lib/support/hook";
 import { getSerenApiKey } from "@/lib/tauri-bridge";
 
@@ -292,14 +293,18 @@ export async function needsMcpAuth(): Promise<boolean> {
 export async function initializeGateway(): Promise<void> {
   // Return cached data if still valid
   if (isCacheValid() && isConnected) {
-    console.log("[MCP Gateway] Using cached tools (still valid)");
+    verboseRuntimeConsole.debug(
+      "[MCP Gateway] Using cached tools (still valid)",
+    );
     return;
   }
 
   if (loadingPromise) return loadingPromise;
 
   loadingPromise = (async () => {
-    console.log("[MCP Gateway] Initializing via MCP protocol...");
+    verboseRuntimeConsole.debug(
+      "[MCP Gateway] Initializing via MCP protocol...",
+    );
 
     // Get Seren API key (auto-created after OAuth login)
     const apiKey = await getSerenApiKey();
@@ -317,14 +322,16 @@ export async function initializeGateway(): Promise<void> {
     try {
       // Connect to Seren MCP Gateway via HTTP streaming transport
       // The API key is passed as the bearer token
-      console.log(`[MCP Gateway] Connecting to ${MCP_GATEWAY_URL}...`);
+      verboseRuntimeConsole.debug(
+        `[MCP Gateway] Connecting to ${MCP_GATEWAY_URL}...`,
+      );
       await mcpClient.connectHttp(
         SEREN_MCP_SERVER_NAME,
         MCP_GATEWAY_URL,
         apiKey,
       );
       isConnected = true;
-      console.log("[MCP Gateway] Connected successfully");
+      verboseRuntimeConsole.debug("[MCP Gateway] Connected successfully");
 
       // Get the connection and its tools
       const connection = mcpClient.getConnection(SEREN_MCP_SERVER_NAME);
@@ -363,7 +370,7 @@ export async function initializeGateway(): Promise<void> {
             (t) => !existingNames.has(t.tool.name),
           );
           cachedTools = [...cachedTools, ...newTools];
-          console.log(
+          verboseRuntimeConsole.debug(
             `[MCP Gateway] Discovered ${newTools.length} additional publisher tools`,
           );
         }
@@ -374,7 +381,7 @@ export async function initializeGateway(): Promise<void> {
 
       lastFetchedAt = Date.now();
 
-      console.log(
+      verboseRuntimeConsole.debug(
         `[MCP Gateway] Initialized with ${cachedTools.length} tools via MCP protocol`,
       );
     } catch (error) {

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -15,6 +15,7 @@ import {
   updateSkill,
 } from "@/api/seren-skills";
 import { log } from "@/lib/logger";
+import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import {
   computeContentHash,
   getSkillPath,
@@ -472,7 +473,9 @@ async function fetchSerenSkills(skipCache = false): Promise<Skill[]> {
     if (cached) {
       const { timestamp, data } = JSON.parse(cached);
       if (Date.now() - timestamp < INDEX_CACHE_DURATION) {
-        log.info("[Skills] Using cached seren-skills catalog");
+        verboseRuntimeConsole.debug(
+          "[Skills] Using cached seren-skills catalog",
+        );
         return data as Skill[];
       }
     }
@@ -503,7 +506,11 @@ async function fetchSerenSkills(skipCache = false): Promise<Skill[]> {
       }),
     );
   }
-  log.info("[Skills] Fetched", skills.length, "skills from seren-skills");
+  verboseRuntimeConsole.debug(
+    "[Skills] Fetched",
+    skills.length,
+    "skills from seren-skills",
+  );
   return skills;
 }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -33,6 +33,7 @@ import {
   selectCompactionWindow,
 } from "@/lib/compaction/window";
 import { runtimeHasCapability } from "@/lib/runtime";
+import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import { estimateTokens } from "@/lib/token-counter";
 import { getEnabledMcpServers, settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
@@ -3779,7 +3780,7 @@ export const agentStore = {
    * Set the active session.
    */
   setActiveSession(sessionId: string | null) {
-    console.log(
+    verboseRuntimeConsole.debug(
       "[AgentRuntime] setActiveSession - old:",
       state.activeSessionId,
       "new:",
@@ -4773,7 +4774,7 @@ export const agentStore = {
     forSessionId?: string,
   ) {
     const sessionId = forSessionId ?? state.activeSessionId;
-    console.log("[AgentStore] sendPrompt called:", {
+    verboseRuntimeConsole.debug("[AgentStore] sendPrompt called:", {
       sessionId,
       prompt: prompt.slice(0, 50),
     });
@@ -5020,7 +5021,7 @@ export const agentStore = {
       ...(options?.docNames?.length ? { docNames: options.docNames } : {}),
     };
 
-    console.log(
+    verboseRuntimeConsole.debug(
       "[AgentRuntime] Adding user message to session:",
       sessionId,
       "conversationId:",
@@ -5070,7 +5071,9 @@ export const agentStore = {
       }
     }
 
-    console.log("[AgentStore] Calling providerService.sendPrompt...");
+    verboseRuntimeConsole.debug(
+      "[AgentStore] Calling providerService.sendPrompt...",
+    );
     try {
       const { merged, newSignature } = await this.buildPromptContext(
         sessionId,
@@ -5087,7 +5090,9 @@ export const agentStore = {
       if (newSignature !== null) {
         this.markPromptContextPrimed(sessionId, newSignature);
       }
-      console.log("[AgentStore] sendPrompt completed successfully");
+      verboseRuntimeConsole.debug(
+        "[AgentStore] sendPrompt completed successfully",
+      );
     } catch (error) {
       const agentLabel = agentDisplayName(
         state.sessions[sessionId]?.info.agentType,
@@ -5790,7 +5795,7 @@ export const agentStore = {
             setState("sessions", sessionId, "lastInputTokens", inputTokens);
             const ctxSize =
               state.sessions[sessionId]?.contextWindowSize ?? 200_000;
-            console.log(
+            verboseRuntimeConsole.debug(
               `[AgentStore] Agent usage: ${inputTokens} input tokens`,
               `(${Math.round((inputTokens / ctxSize) * 100)}% of ${ctxSize.toLocaleString()} context)`,
             );
@@ -6941,7 +6946,7 @@ export const agentStore = {
         duration,
         finalOutputValidation,
       };
-      console.log(
+      verboseRuntimeConsole.debug(
         "[AgentRuntime] Adding assistant message to session:",
         sessionId,
         "conversationId:",

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -4,6 +4,7 @@
 import { createStore } from "solid-js/store";
 import { addSerenDbServer, removeSerenDbServer } from "@/lib/mcp/serendb";
 import { runtimeHasCapability } from "@/lib/runtime";
+import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import {
   clearSerenApiKey,
   getSerenApiKey,
@@ -66,15 +67,19 @@ async function ensureApiKey(): Promise<boolean> {
     // Check if we already have a stored API key
     const existingKey = await getSerenApiKey();
     if (existingKey) {
-      console.log("[Auth Store] Using existing stored API key");
+      verboseRuntimeConsole.debug("[Auth Store] Using existing stored API key");
       return true;
     }
 
     // No stored key - create a new one
-    console.log("[Auth Store] No stored API key, creating new one...");
+    verboseRuntimeConsole.debug(
+      "[Auth Store] No stored API key, creating new one...",
+    );
     const apiKey = await createApiKey();
     await storeSerenApiKey(apiKey);
-    console.log("[Auth Store] API key created and stored successfully");
+    verboseRuntimeConsole.debug(
+      "[Auth Store] API key created and stored successfully",
+    );
     return true;
   } catch (error) {
     console.error("[Auth Store] Failed to ensure API key:", error);
@@ -93,21 +98,30 @@ async function initializeMcpInBackground(): Promise<void> {
   }
 
   try {
-    console.log("[Auth Store] Adding Seren MCP server config...");
+    verboseRuntimeConsole.debug(
+      "[Auth Store] Adding Seren MCP server config...",
+    );
     await addSerenDbServer();
 
-    console.log("[Auth Store] Initializing MCP Gateway (background)...");
+    verboseRuntimeConsole.debug(
+      "[Auth Store] Initializing MCP Gateway (background)...",
+    );
     await initializeGateway();
-    console.log("[Auth Store] MCP Gateway initialized successfully");
+    verboseRuntimeConsole.debug(
+      "[Auth Store] MCP Gateway initialized successfully",
+    );
     setState("mcpConnected", true);
 
     // Trigger auto-connect for local MCP servers
     const { initMcpAutoConnect } = await import("@/lib/mcp/auto-connect");
-    console.log(
+    verboseRuntimeConsole.debug(
       "[Auth Store] Triggering MCP auto-connect for local servers...",
     );
     const results = await initMcpAutoConnect();
-    console.log("[Auth Store] MCP auto-connect results:", results);
+    verboseRuntimeConsole.debug(
+      "[Auth Store] MCP auto-connect results:",
+      results,
+    );
   } catch (error) {
     console.error("[Auth Store] Failed to initialize MCP:", error);
     setState("mcpConnected", false);
@@ -277,7 +291,9 @@ export async function initAuthRuntimeBindings(): Promise<void> {
     requestSignInModal();
   });
   await listen("auth:token-refreshed", async () => {
-    console.info("[Auth Store] Token refreshed event from backend");
+    verboseRuntimeConsole.debug(
+      "[Auth Store] Token refreshed event from backend",
+    );
     try {
       await restoreAuthenticatedSession();
     } catch (error) {

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -6,6 +6,7 @@ import { untrack } from "solid-js";
 import { createStore } from "solid-js/store";
 import { log } from "@/lib/logger";
 import { queryClient } from "@/lib/query-client";
+import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import {
   filterHostCompatibleCatalog,
   type InstalledSkill,
@@ -108,7 +109,7 @@ function applyAvailableCatalog(all: Skill[]): void {
   const available = filterHostCompatibleCatalog(all);
   const excluded = all.length - available.length;
   setState("available", available);
-  log.info(
+  verboseRuntimeConsole.debug(
     "[SkillsStore] Loaded",
     available.length,
     "available skills",
@@ -793,7 +794,7 @@ export const skillsStore = {
       const installed = all.filter((skill) => isSkillCompatibleWithHost(skill));
       const excluded = all.length - installed.length;
       if (excluded > 0) {
-        log.info(
+        verboseRuntimeConsole.debug(
           "[SkillsStore]",
           excluded,
           "installed skill(s) host-excluded from Desktop",
@@ -806,7 +807,11 @@ export const skillsStore = {
       }
 
       setState("installed", installed);
-      log.info("[SkillsStore] Loaded", installed.length, "installed skills");
+      verboseRuntimeConsole.debug(
+        "[SkillsStore] Loaded",
+        installed.length,
+        "installed skills",
+      );
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to load installed skills";

--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -3,6 +3,7 @@
 
 import { createStore } from "solid-js/store";
 import { PROVIDER_CONFIGS, type ProviderId } from "@/lib/providers/types";
+import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import { type InstalledSkill, parseSkillMd } from "@/lib/skills";
 import { archiveAgentConversation } from "@/lib/tauri-bridge";
 import {
@@ -757,7 +758,7 @@ export const threadStore = {
       const liveSession = Object.values(agentStore.sessions).find(
         (s) => s.conversationId === id,
       );
-      console.log(
+      verboseRuntimeConsole.debug(
         "[Thread] selectThread - looking for session with conversationId:",
         id,
         "found:",

--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -3,6 +3,7 @@ import { message } from "@tauri-apps/plugin-dialog";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type DownloadEvent } from "@tauri-apps/plugin-updater";
 import { createStore } from "solid-js/store";
+import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 import { telemetry } from "@/services/telemetry";
 
@@ -64,7 +65,7 @@ async function initUpdater(): Promise<void> {
   }
 
   if (isDevRuntime()) {
-    console.info("[Updater] Dev build — skipping update check");
+    verboseRuntimeConsole.debug("[Updater] Dev build — skipping update check");
     setState({ status: "unsupported" });
     return;
   }
@@ -102,11 +103,14 @@ async function checkForUpdates(_manual = false): Promise<void> {
   setState({ status: "checking", error: null });
 
   try {
-    console.info("[Updater] Checking for updates...");
+    verboseRuntimeConsole.debug("[Updater] Checking for updates...");
     const update = await check();
 
     if (update) {
-      console.info("[Updater] Update available:", update.version);
+      verboseRuntimeConsole.debug(
+        "[Updater] Update available:",
+        update.version,
+      );
       pendingUpdate = update;
       setState({
         status: "available",
@@ -115,7 +119,7 @@ async function checkForUpdates(_manual = false): Promise<void> {
         error: null,
       });
     } else {
-      console.info("[Updater] No update available");
+      verboseRuntimeConsole.debug("[Updater] No update available");
       pendingUpdate = null;
       setState({
         status: "up_to_date",
@@ -134,9 +138,11 @@ async function checkForUpdates(_manual = false): Promise<void> {
 
 async function clearBrowsingDataBeforeRestart(): Promise<void> {
   try {
-    console.info("[Updater] Clearing webview browsing data before restart...");
+    verboseRuntimeConsole.debug(
+      "[Updater] Clearing webview browsing data before restart...",
+    );
     await getCurrentWebview().clearAllBrowsingData();
-    console.info("[Updater] Webview browsing data cleared");
+    verboseRuntimeConsole.debug("[Updater] Webview browsing data cleared");
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
     console.warn(
@@ -183,7 +189,7 @@ async function installAvailableUpdate(): Promise<void> {
     return;
   }
 
-  console.info("[Updater] Starting download and install...");
+  verboseRuntimeConsole.debug("[Updater] Starting download and install...");
   let downloaded = 0;
   setState({
     status: "downloading",
@@ -198,7 +204,9 @@ async function installAvailableUpdate(): Promise<void> {
       if (progress.event === "Started") {
         const total = progress.data.contentLength ?? 0;
         if (total > 0) {
-          console.info(`[Updater] Download started, size: ${total} bytes`);
+          verboseRuntimeConsole.debug(
+            `[Updater] Download started, size: ${total} bytes`,
+          );
           setState({ totalBytes: total });
         }
         return;
@@ -214,12 +222,12 @@ async function installAvailableUpdate(): Promise<void> {
         return;
       }
 
-      console.info("[Updater] Download finished, installing...");
+      verboseRuntimeConsole.debug("[Updater] Download finished, installing...");
       setState({ status: "installing", progressPercent: 100 });
     });
-    console.info("[Updater] Install complete");
+    verboseRuntimeConsole.debug("[Updater] Install complete");
     await clearBrowsingDataBeforeRestart();
-    console.info("[Updater] Relaunching after install...");
+    verboseRuntimeConsole.debug("[Updater] Relaunching after install...");
     await relaunch();
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));

--- a/tests/unit/console-noise-policy.test.ts
+++ b/tests/unit/console-noise-policy.test.ts
@@ -1,0 +1,78 @@
+// ABOUTME: Source-level guard for #2128 runtime console noise reduction.
+// ABOUTME: Ensures routine success logs stay debug-gated while failures stay visible.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function source(path: string): string {
+  return readFileSync(resolve(path), "utf-8");
+}
+
+describe("#2128 console noise policy", () => {
+  it("keeps database maintenance success logs below production info level", () => {
+    const database = source("src-tauri/src/services/database.rs");
+
+    expect(database).toMatch(
+      /log::debug!\(\s*"\[Database\] WAL checkpoint\(TRUNCATE\) completed: \{\}"/,
+    );
+    expect(database).toMatch(
+      /log::debug!\(\s*"\[Database\] Persisted message \{\} for conversation \{\}"/,
+    );
+    expect(database).toMatch(
+      /log::warn!\(\s*"\[Database\] WAL checkpoint\(TRUNCATE\) failed during \{\}: \{\}"/,
+    );
+    expect(database).toMatch(
+      /log::error!\(\s*"\[Database\] Failed to persist message \{\} for conversation \{\}: \{\}"/,
+    );
+  });
+
+  it("does not use raw console logging for named routine frontend success paths", () => {
+    const files = [
+      "src/stores/auth.store.ts",
+      "src/services/mcp-gateway.ts",
+      "src/components/chat/AgentChat.tsx",
+      "src/stores/agent.store.ts",
+      "src/stores/thread.store.ts",
+      "src/stores/updater.store.ts",
+    ];
+
+    const forbiddenSnippets = [
+      'console.log("[Auth Store] Using existing stored API key")',
+      'console.log("[Auth Store] Adding Seren MCP server config...")',
+      'console.log("[Auth Store] Initializing MCP Gateway (background)...")',
+      'console.log("[Auth Store] MCP Gateway initialized successfully")',
+      'console.log(\n      "[Auth Store] Triggering MCP auto-connect for local servers...",',
+      'console.log("[Auth Store] MCP auto-connect results:", results)',
+      'console.log("[MCP Gateway] Using cached tools (still valid)")',
+      'console.log("[MCP Gateway] Initializing via MCP protocol...")',
+      "console.log(`[MCP Gateway] Connecting to ${MCP_GATEWAY_URL}...`)",
+      'console.log("[MCP Gateway] Connected successfully")',
+      'console.log(\n        `[MCP Gateway] Initialized with ${cachedTools.length} tools via MCP protocol`,',
+      'console.log("[AgentChat] sendMessage called:",',
+      'console.log("[AgentChat] Attachment split:",',
+      'console.log(\n      "[AgentChat] Sending prompt to agent runtime, context blocks:",',
+      'console.log("[AgentStore] sendPrompt called:",',
+      'console.log(\n      "[AgentRuntime] Adding user message to session:",',
+      'console.log("[AgentStore] Calling providerService.sendPrompt...")',
+      'console.log("[AgentStore] sendPrompt completed successfully")',
+      'console.log(\n        "[AgentRuntime] Adding assistant message to session:",',
+      'console.log(\n      "[AgentRuntime] setActiveSession - old:",',
+      'console.log(\n        "[Thread] selectThread - looking for session with conversationId:",',
+      'console.info("[Updater] Checking for updates...")',
+      'console.info("[Updater] Update available:", update.version)',
+      'console.info("[Updater] No update available")',
+    ];
+
+    const combined = files.map((file) => source(file)).join("\n");
+    for (const snippet of forbiddenSnippets) {
+      expect(combined).not.toContain(snippet);
+    }
+  });
+
+  it("documents the opt-in verbose console switch in the README", () => {
+    expect(source("README.md")).toContain(
+      "localStorage.setItem(\"seren.debug.verboseConsole\", \"true\")",
+    );
+  });
+});

--- a/tests/unit/runtime-console.test.ts
+++ b/tests/unit/runtime-console.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Regression coverage for the opt-in verbose runtime console switch.
+// ABOUTME: Keeps routine success breadcrumbs out of the default production console.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  RUNTIME_VERBOSE_CONSOLE_KEY,
+  shouldLogVerboseRuntimeConsole,
+  verboseRuntimeConsole,
+} from "@/lib/runtime-console";
+
+function storageWith(value: string | null): Pick<Storage, "getItem"> {
+  return {
+    getItem(key: string) {
+      return key === RUNTIME_VERBOSE_CONSOLE_KEY ? value : null;
+    },
+  };
+}
+
+describe("verbose runtime console logging", () => {
+  it("is disabled by default", () => {
+    expect(shouldLogVerboseRuntimeConsole(storageWith(null))).toBe(false);
+    expect(shouldLogVerboseRuntimeConsole(storageWith("false"))).toBe(false);
+  });
+
+  it("accepts explicit localStorage truthy values", () => {
+    expect(shouldLogVerboseRuntimeConsole(storageWith("true"))).toBe(true);
+    expect(shouldLogVerboseRuntimeConsole(storageWith("1"))).toBe(true);
+    expect(shouldLogVerboseRuntimeConsole(storageWith("on"))).toBe(true);
+  });
+
+  it("does not write to the console unless enabled", () => {
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    verboseRuntimeConsole.debugWithStorage(storageWith(null), "quiet");
+    expect(debug).not.toHaveBeenCalled();
+
+    verboseRuntimeConsole.debugWithStorage(storageWith("true"), "visible");
+    expect(debug).toHaveBeenCalledWith("visible");
+
+    debug.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #2128

## Summary
- add an explicit `seren.debug.verboseConsole` gate for routine frontend runtime breadcrumbs
- move normal backend auth/MCP/database success logs from info to debug
- document the opt-in verbose console switch in README
- add focused regression tests for the console policy

## Audit
- Default console now keeps the named startup/chat/thread/updater/skills success paths quiet unless verbose logging is enabled.
- Existing warn/error paths for failed DB checkpoints, failed persistence, auth/MCP failures, provider failures, compaction/recovery, permissions, rate limits, and updater install failures remain visible.
- Agent spawn IPC-boundary diagnostics are intentionally left visible because existing tests require them for non-hanging spawn failures.

## Verification
- `./node_modules/.bin/vitest run tests/unit/runtime-console.test.ts tests/unit/console-noise-policy.test.ts tests/unit/agent-runtime-event-debug.test.ts tests/unit/agent-session-events.test.ts tests/unit/agent-spawn-status.test.ts tests/unit/idle-reclaim-race-1852.test.ts tests/unit/console-error-reportable.test.ts tests/unit/skills-list-installed.test.ts tests/unit/skills-index-api.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/biome check README.md src/lib/runtime-console.ts src/stores/auth.store.ts src/lib/mcp/serendb.ts src/services/mcp-gateway.ts src/components/chat/AgentChat.tsx src/stores/agent.store.ts src/stores/thread.store.ts src/stores/updater.store.ts src/stores/skills.store.ts src/services/skills.ts`
- `cargo test database --lib` (with local untracked `src-tauri/mcp-servers/playwright-stealth` resource symlinked into the worktree for Tauri build-script verification, then removed)