### PR TITLE
fix(lint): green the biome build gate (#2125 Q-3)

### DIFF
--- a/src/components/settings/MessagingSettings.tsx
+++ b/src/components/settings/MessagingSettings.tsx
@@ -1,15 +1,15 @@
 // ABOUTME: Settings panel for Telegram, Discord, and WhatsApp messaging transports.
 // ABOUTME: Token input for Telegram/Discord; QR code pairing for WhatsApp.
 
+import { invoke } from "@tauri-apps/api/core";
 import {
   type Component,
   createSignal,
   For,
-  Show,
   onCleanup,
   onMount,
+  Show,
 } from "solid-js";
-import { invoke } from "@tauri-apps/api/core";
 
 interface PlatformStatus {
   platform: string;

--- a/src/lib/skills/host.ts
+++ b/src/lib/skills/host.ts
@@ -1,8 +1,7 @@
 // ABOUTME: Host compatibility helper for skill exclusion contract.
 // ABOUTME: Implements the serenorg/seren-desktop#1496 host-marker spec.
 
-import type { InstalledSkill, Skill } from "./types";
-import type { SkillMetadata } from "./types";
+import type { InstalledSkill, Skill, SkillMetadata } from "./types";
 
 /**
  * The host token injected by Seren Desktop at runtime.
@@ -53,7 +52,6 @@ export function filterHostCompatibleCatalog<
   T extends Skill & { excludeHosts?: string[] },
 >(catalog: T[], host: string = CURRENT_HOST): T[] {
   return catalog.filter(
-    (entry) =>
-      !entry.excludeHosts || !entry.excludeHosts.includes(host),
+    (entry) => !entry.excludeHosts || !entry.excludeHosts.includes(host),
   );
 }


### PR DESCRIPTION
Greens `pnpm check` / `pnpm lint` (was 3 errors). Auto-fix only (import-organize + optional-chain) in 2 non-STT files; tsc clean. Unblocks the #2125 release gate. Remaining 50 warnings are pre-existing non-STT debt, tracked separately. Refs #2125.