### PR TITLE
fix(audio): chunk long transcripts so notes do not blow context (#2134)

### DIFF
--- a/src-tauri/src/audio/notes.rs
+++ b/src-tauri/src/audio/notes.rs
@@ -117,9 +117,46 @@ pub fn build_notes_prompt(transcript: &str, template_prompt: &str, vocabulary: &
     )
 }
 
+/// Character budget per Tier-1 notes pass. Long meetings get chunked into windows
+/// under this size so the model context never overflows. ~24K chars ≈ 6K tokens,
+/// which leaves headroom on small-context (8K) and large-context (200K+) providers.
+pub const TRANSCRIPT_CHAR_BUDGET: usize = 24_000;
+
 /// Generate Tier-1 notes: prompt the selected model, then parse markdown + struct.
-/// Returns parsed notes even when the model omits the JSON block (parser fails safe).
+/// Long transcripts (over [`TRANSCRIPT_CHAR_BUDGET`]) are summarized in line-aligned
+/// chunks, then reduced into a single set of notes — so a 60-minute meeting won't
+/// exceed the model's context. Returns parsed notes even when the model omits the
+/// JSON block (parser fails safe).
 pub async fn generate_notes(
+    app: &tauri::AppHandle,
+    model: String,
+    transcript: &str,
+    template_prompt: &str,
+    vocabulary: &[String],
+) -> Result<ParsedNotes, String> {
+    if transcript.chars().count() <= TRANSCRIPT_CHAR_BUDGET {
+        return generate_notes_single(app, model, transcript, template_prompt, vocabulary).await;
+    }
+
+    let chunks = chunk_transcript_by_chars(transcript, TRANSCRIPT_CHAR_BUDGET);
+    let mut partials = Vec::with_capacity(chunks.len());
+    for chunk in chunks.iter() {
+        let partial =
+            generate_notes_single(app, model.clone(), chunk, template_prompt, vocabulary).await?;
+        partials.push(partial);
+    }
+
+    let combined = combine_partials_text(&partials);
+    let reduce_template = format!(
+        "This meeting was very long; the input below is an ordered list of \
+         section summaries from earlier passes. Produce ONE coherent set of \
+         meeting notes that subsumes them. {template_prompt}",
+        template_prompt = template_prompt.trim(),
+    );
+    generate_notes_single(app, model, &combined, &reduce_template, vocabulary).await
+}
+
+async fn generate_notes_single(
     app: &tauri::AppHandle,
     model: String,
     transcript: &str,
@@ -137,6 +174,63 @@ pub async fn generate_notes(
     )
     .await?;
     Ok(parse_notes_output(&raw))
+}
+
+/// Split `transcript` into chunks no larger than `budget` chars, breaking on line
+/// boundaries so a "Me:"/"Them:" utterance is never split mid-text. A single line
+/// longer than `budget` is hard-split into `budget`-sized pieces so callers never
+/// produce a chunk that would overflow the model context.
+pub fn chunk_transcript_by_chars(transcript: &str, budget: usize) -> Vec<String> {
+    assert!(budget > 0, "transcript budget must be > 0");
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+    for line in transcript.split('\n') {
+        if line.chars().count() > budget {
+            if !current.is_empty() {
+                chunks.push(std::mem::take(&mut current));
+            }
+            for piece in hard_split(line, budget) {
+                chunks.push(piece);
+            }
+            continue;
+        }
+        let separator = if current.is_empty() { 0 } else { 1 };
+        if current.chars().count() + separator + line.chars().count() > budget {
+            chunks.push(std::mem::take(&mut current));
+        }
+        if !current.is_empty() {
+            current.push('\n');
+        }
+        current.push_str(line);
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+fn hard_split(line: &str, budget: usize) -> Vec<String> {
+    let mut pieces = Vec::new();
+    let mut buffer = String::new();
+    for ch in line.chars() {
+        if buffer.chars().count() == budget {
+            pieces.push(std::mem::take(&mut buffer));
+        }
+        buffer.push(ch);
+    }
+    if !buffer.is_empty() {
+        pieces.push(buffer);
+    }
+    pieces
+}
+
+fn combine_partials_text(partials: &[ParsedNotes]) -> String {
+    partials
+        .iter()
+        .enumerate()
+        .map(|(idx, partial)| format!("## Section {}\n{}", idx + 1, partial.markdown.trim()))
+        .collect::<Vec<_>>()
+        .join("\n\n")
 }
 
 #[cfg(test)]
@@ -194,5 +288,55 @@ mod tests {
 
         assert_eq!(parsed.markdown, raw.trim());
         assert_eq!(parsed.structured, StructuredNotes::default());
+    }
+
+    #[test]
+    fn chunk_transcript_packs_lines_under_budget_and_preserves_every_line() {
+        let transcript = (1..=12)
+            .map(|i| format!("Me: utterance number {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let chunks = chunk_transcript_by_chars(&transcript, 60);
+
+        assert!(chunks.len() > 1, "long transcript should chunk");
+        for chunk in &chunks {
+            assert!(
+                chunk.chars().count() <= 60,
+                "chunk exceeds budget: {} chars",
+                chunk.chars().count()
+            );
+        }
+        // Every line preserved exactly once, no chunk splits a line mid-text.
+        let joined = chunks.join("\n");
+        for line in transcript.split('\n') {
+            assert!(joined.contains(line), "missing line: {line}");
+        }
+    }
+
+    #[test]
+    fn chunk_transcript_returns_single_chunk_when_under_budget() {
+        let transcript = "Me: hi\nThem: hello";
+
+        let chunks = chunk_transcript_by_chars(transcript, 1000);
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], transcript);
+    }
+
+    #[test]
+    fn chunk_transcript_hard_splits_a_single_line_that_exceeds_budget() {
+        let huge = "x".repeat(150);
+        let transcript = format!("Me: {huge}");
+
+        let chunks = chunk_transcript_by_chars(&transcript, 50);
+
+        for chunk in &chunks {
+            assert!(
+                chunk.chars().count() <= 50,
+                "hard-split chunk over budget"
+            );
+        }
+        assert_eq!(chunks.concat().chars().count(), transcript.chars().count());
     }
 }


### PR DESCRIPTION
## Summary
- `generate_meeting_notes` used to build one prompt from the entire transcript; a long (60-min) meeting could exceed the model's context window and fail.
- Transcripts over `TRANSCRIPT_CHAR_BUDGET` (~24k chars / ~6k tokens) are now split on line boundaries (never breaking a `Me:` / `Them:` utterance), summarized per chunk, then reduced into one coherent set of notes via a final pass.
- Short transcripts stay on the single-pass path — no extra latency for normal meetings.

Closes #2134.

## Test plan
- [x] `cargo test --lib` green (610 passing, +3 new chunking tests; no regressions)
- [x] `chunk_transcript_packs_lines_under_budget_and_preserves_every_line` — every input line preserved exactly once across chunks; no chunk exceeds budget.
- [x] `chunk_transcript_returns_single_chunk_when_under_budget` — no-op path for normal meetings.
- [x] `chunk_transcript_hard_splits_a_single_line_that_exceeds_budget` — pathological single huge line still fits in budget after hard split.
- [ ] Manual: drive a >24k-char transcript through `generate_meeting_notes`; confirm notes return without context-window errors and read coherently across sections.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
