### PR TITLE
fix(e2e): replace flaky networkidle with load (#2144)

### DIFF
--- a/tests/e2e/agent-spawn.spec.ts
+++ b/tests/e2e/agent-spawn.spec.ts
@@ -14,7 +14,7 @@ test.describe("Agent Spawn Feedback", () => {
     page.on("pageerror", (err) => errors.push(err.message));
 
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
     await page.waitForTimeout(2_000);
 
     // Try to create a new agent thread — this will attempt to spawn Claude

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -38,7 +38,7 @@ test.describe("Authentication", () => {
 
     // Navigate to app and click on Chat tab to see sign-in form
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
 
     // Click Chat tab to show sign-in form for unauthenticated user
     await page.click("text=Chat");
@@ -63,7 +63,7 @@ test.describe("Authentication", () => {
   test("forgot password link opens external URL", async ({ page, context }) => {
     // Navigate to app and click on Chat tab to see sign-in form
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
 
     // Click Chat tab to show sign-in form for unauthenticated user
     await page.click("text=Chat");
@@ -93,7 +93,7 @@ test.describe("Authentication", () => {
   test("sign up link opens external URL", async ({ page, context }) => {
     // Navigate to app and click on Chat tab to see sign-in form
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
 
     // Click Chat tab to show sign-in form for unauthenticated user
     await page.click("text=Chat");

--- a/tests/e2e/production-bundle.spec.ts
+++ b/tests/e2e/production-bundle.spec.ts
@@ -11,7 +11,7 @@ test.describe("Production Bundle Integrity", () => {
     page.on("pageerror", (err) => errors.push(err.message));
 
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
 
     // Wait for app to fully initialize
     await page.waitForTimeout(2_000);
@@ -35,7 +35,7 @@ test.describe("Production Bundle Integrity", () => {
     page.on("pageerror", (err) => errors.push(err.message));
 
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
 
     // Interact with UI to trigger reactive store evaluations
     const sidebar = page.getByTestId("thread-sidebar");
@@ -84,7 +84,7 @@ test.describe("Production Bundle Integrity", () => {
 
     // Reload so the app picks up the persisted thread on init
     await page.reload();
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
     await page.waitForTimeout(2_000);
 
     const tdzErrors = errors.filter(
@@ -117,7 +117,7 @@ test.describe("Production Bundle Integrity", () => {
     });
 
     await page.reload();
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
     await page.waitForTimeout(2_000);
 
     const tdzErrors = errors.filter(
@@ -139,7 +139,7 @@ test.describe("Production Bundle Integrity", () => {
     page.on("pageerror", (err) => errors.push(err.message));
 
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
 
     // Create a thread, then interact with multiple panels
     const newBtn = page.getByTestId("new-thread-button");

--- a/tests/e2e/session-panel.spec.ts
+++ b/tests/e2e/session-panel.spec.ts
@@ -13,7 +13,7 @@ test.describe.skip("Session Panel", () => {
     page.on("pageerror", (err) => errors.push(err.message));
 
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
 
     (page as any).__capturedErrors = errors;
   });

--- a/tests/e2e/thread-lifecycle.spec.ts
+++ b/tests/e2e/thread-lifecycle.spec.ts
@@ -9,7 +9,7 @@ test.describe("Thread Lifecycle", () => {
     page.on("pageerror", (err) => errors.push(err.message));
 
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("load");
 
     (page as any).__capturedErrors = errors;
   });


### PR DESCRIPTION
## Summary
- CI run [27107885801](https://github.com/serenorg/seren-desktop/actions/runs/27107885801) timed out on `page.waitForLoadState("networkidle")` across `production-bundle`, `thread-lifecycle`, and `session-panel` specs. The next CI run on `main` (`27108239296`, audit-fix #2145) passed the same E2E job in 1m22s with no frontend change between them — i.e. a one-time flake.
- Root cause is the well-known Playwright `networkidle` race: the state requires 500ms of zero network activity, which a SolidJS app with gateway heartbeats / MCP polling / telemetry never reliably satisfies under CI load. Playwright's own docs warn against it.
- Swap `networkidle` for the standard `load` state in all 11 sites across 5 e2e specs. `load` fires once the bundle is parsed and the `window.load` event has run, which is what these tests actually want before sampling `pageerror` or querying test-ids. Downstream `waitForTimeout(2_000)` and `expect(...).toBeVisible({timeout: 10_000})` calls already handle the post-load hydration window.

Closes #2144.

## Test plan
- [x] `grep -rn networkidle tests/` returns zero hits.
- [x] All `waitForLoadState(...)` calls switched to `"load"`.
- [ ] CI green on the merged PR (the real proof).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
