### PR TITLE
fix(meeting): R3 integration defects — lifecycle, tray priming, orphan cleanup (#2149)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset", "devtools", "tray-icon", "image-png"] }
+tauri = { version = "2", features = ["protocol-asset", "devtools", "tray-icon", "image-png", "macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/audio/detect.rs
+++ b/src-tauri/src/audio/detect.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Pure meeting auto-detect decision logic for capture arming.
 // ABOUTME: Keeps OS process probes separate from testable policy rules.
 
-use sysinfo::{ProcessRefreshKind, RefreshKind, System};
+use sysinfo::{ProcessRefreshKind, RefreshKind, System, UpdateKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunningProcess {
@@ -13,8 +13,14 @@ pub struct RunningProcess {
 /// Reliable mic-in-use detection is not portable across macOS/Windows/Linux, so
 /// we report `mic_in_use = false` and lean on the meeting-app allowlist path.
 pub fn probe_running_processes() -> Vec<RunningProcess> {
+    // Force the executable path to be resolved so `name()` is derived from the
+    // exe basename on every platform. `ProcessRefreshKind::nothing()` leaves the
+    // name empty for processes whose kernel-side name isn't readable, which
+    // breaks the allowlist match. `with_exe(Always)` is the minimal kind that
+    // guarantees a populated name.
     let system = System::new_with_specifics(
-        RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()),
+        RefreshKind::nothing()
+            .with_processes(ProcessRefreshKind::nothing().with_exe(UpdateKind::Always)),
     );
 
     system

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,6 +11,7 @@
     "frontendDist": "../dist"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "title": "Seren",

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -20,6 +20,7 @@ import { ArchivedEmployeeDetail } from "@/components/employees/ArchivedEmployeeD
 import { EmployeeDetail } from "@/components/employees/EmployeeDetail";
 import { InboxList } from "@/components/inbox/InboxList";
 import { ThreadSidebar } from "@/components/layout/ThreadSidebar";
+import { AudioPrimingDialog } from "@/components/meeting/AudioPrimingDialog";
 import { MeetingPanel } from "@/components/meeting/MeetingPanel";
 import { SessionPanel } from "@/components/session/SessionPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
@@ -57,6 +58,7 @@ import {
 } from "@/stores/editor.sessions";
 import { employeeStore } from "@/stores/employees.store";
 import { fileTreeState } from "@/stores/fileTree";
+import { meetingStore } from "@/stores/meeting.store";
 import { skillPublishStore } from "@/stores/skill-publish.store";
 import { skillsStore } from "@/stores/skills.store";
 import { threadStore } from "@/stores/thread.store";
@@ -576,6 +578,13 @@ export const AppShell: Component<AppShellProps> = (props) => {
     initEditorSessionPersistence();
     void restoreEditorSessions();
 
+    // Meeting capture lifecycle lives here, in the always-mounted shell, so the
+    // widget Stop relay, tray toggle, and transcript listeners survive the
+    // MeetingPanel unmounting when its slide panel closes. Started once per app
+    // session; torn down on shell cleanup.
+    void meetingStore.startMeetingEventListeners();
+    meetingStore.startAutoDetect();
+
     window.addEventListener("seren:open-panel", handleOpenPanel);
     window.addEventListener("seren:open-settings", handleOpenSettings);
     document.addEventListener("focusin", handleFocusIn);
@@ -597,6 +606,8 @@ export const AppShell: Component<AppShellProps> = (props) => {
 
   onCleanup(() => {
     unsubscribeWorkspaceRemoved();
+    meetingStore.stopMeetingEventListeners();
+    meetingStore.stopAutoDetect();
     window.removeEventListener("seren:open-panel", handleOpenPanel);
     window.removeEventListener("seren:open-settings", handleOpenSettings);
     document.removeEventListener("focusin", handleFocusIn);
@@ -753,6 +764,16 @@ export const AppShell: Component<AppShellProps> = (props) => {
             </Show>
           );
         }}
+      </Show>
+
+      {/* First-run audio-permission explainer, surfaced app-wide so non-panel
+          start paths (tray, auto-detect) gate on it too. Driven by the meeting
+          store's pending priming request. */}
+      <Show when={meetingStore.state.primingRequest}>
+        <AudioPrimingDialog
+          onContinue={() => void meetingStore.confirmPriming()}
+          onCancel={() => meetingStore.cancelPriming()}
+        />
       </Show>
 
       {/* Layout-level blocking sign-in modal — fires on mid-session expiry,

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -1,15 +1,7 @@
 // ABOUTME: Slide-panel interface for Meeting Mode library, recorder, and details.
 // ABOUTME: Uses meeting services and store; components never call Tauri IPC directly.
 
-import {
-  createMemo,
-  createSignal,
-  For,
-  onCleanup,
-  onMount,
-  Show,
-} from "solid-js";
-import { AudioPrimingDialog } from "@/components/meeting/AudioPrimingDialog";
+import { createMemo, createSignal, For, onMount, Show } from "solid-js";
 import { MeetingDetail } from "@/components/meeting/MeetingDetail";
 import { MeetingSettings } from "@/components/meeting/MeetingSettings";
 import {
@@ -63,17 +55,12 @@ export function MeetingPanel(props: MeetingPanelProps) {
   const [stopping, setStopping] = createSignal(false);
   const [title, setTitle] = createSignal("");
   const [showSettings, setShowSettings] = createSignal(false);
-  const [showPriming, setShowPriming] = createSignal(false);
 
+  // The capture lifecycle (event listeners, auto-detect, widget/tray relays)
+  // lives in AppShell so it survives this panel unmounting on close. The panel
+  // only refreshes its own list when it opens.
   onMount(() => {
     void meetingStore.loadMeetings();
-    void meetingStore.startMeetingEventListeners();
-    meetingStore.startAutoDetect();
-  });
-
-  onCleanup(() => {
-    meetingStore.stopMeetingEventListeners();
-    meetingStore.stopAutoDetect();
   });
 
   const activeCapture = createMemo(() =>
@@ -86,7 +73,13 @@ export function MeetingPanel(props: MeetingPanelProps) {
   const template = () => settingsStore.get("meetingTemplateId");
   const desktopRuntime = isTauriRuntime();
 
-  const beginCapture = async () => {
+  // Create the meeting, then hand off to the store's gate. The store decides
+  // whether to start immediately or surface the app-wide priming dialog, so
+  // every start path (panel, tray, auto-detect) honors the first-run gate.
+  const startManualCapture = async () => {
+    if (!desktopRuntime || starting()) return;
+    // A priming dialog is already pending a start; don't create a second one.
+    if (meetingStore.state.primingRequest) return;
     setStarting(true);
     try {
       const meeting = await createMeeting({
@@ -96,31 +89,11 @@ export function MeetingPanel(props: MeetingPanelProps) {
       });
       setTitle("");
       meetingStore.dismissAutoDetect();
-      await meetingStore.startCapture(meeting);
-      await meetingStore.loadMeetings();
-      await meetingStore.setActiveMeeting(meeting);
+      await meetingStore.requestCaptureStart(meeting);
     } finally {
       setStarting(false);
     }
   };
-
-  const startManualCapture = async () => {
-    if (!desktopRuntime || starting()) return;
-    // First run: prime the audio-permission explainer before the OS prompt.
-    if (!settingsStore.get("meetingAudioPrimed")) {
-      setShowPriming(true);
-      return;
-    }
-    await beginCapture();
-  };
-
-  const confirmPriming = async () => {
-    setShowPriming(false);
-    settingsStore.set("meetingAudioPrimed", true);
-    await beginCapture();
-  };
-
-  const cancelPriming = () => setShowPriming(false);
 
   const stopManualCapture = async () => {
     const meeting = activeCapture();
@@ -305,13 +278,6 @@ export function MeetingPanel(props: MeetingPanelProps) {
             ×
           </button>
         </div>
-      </Show>
-
-      <Show when={showPriming()}>
-        <AudioPrimingDialog
-          onContinue={() => void confirmPriming()}
-          onCancel={cancelPriming}
-        />
       </Show>
 
       <Show when={!showSettings()} fallback={<MeetingSettings />}>

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -50,6 +50,13 @@ interface MeetingState {
    * nothing is capturing. The panel surfaces an arm prompt; the user starts.
    */
   autoDetectSuggested: boolean;
+  /**
+   * The meeting awaiting first-run audio priming. Set when a start is requested
+   * before the user has acknowledged the permission explainer; the app-wide
+   * priming dialog reads this so every start path (panel, tray, auto-detect)
+   * honors the gate, not just the panel button.
+   */
+  primingRequest: Meeting | null;
 }
 
 const [meetingState, setMeetingState] = createStore<MeetingState>({
@@ -60,6 +67,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   isLoading: false,
   error: null,
   autoDetectSuggested: false,
+  primingRequest: null,
 });
 
 let captureHandle: MeetingCaptureHandle | null = null;
@@ -73,6 +81,10 @@ let trayToggleUnlisten: (() => void) | null = null;
 let autoDetectTimer: number | null = null;
 let autoDetectDismissed = false;
 const AUTO_DETECT_POLL_MS = 5_000;
+
+// Shared in-flight guard across every start caller (panel, tray, auto-detect)
+// so a double-trigger can't launch two mic streams for the same session.
+let isStarting = false;
 
 async function loadMeetings(): Promise<void> {
   setMeetingState("isLoading", true);
@@ -188,10 +200,18 @@ async function startCapture(meeting: Meeting): Promise<void> {
   try {
     captureHandle = await startMeetingMicCapture(meeting.id);
   } catch (error) {
+    // The backend capture already started; tear it down and mark the meeting
+    // failed so it doesn't linger as a "capturing" zombie, and make sure the
+    // widget/tray aren't left signalling an active capture that never began.
+    await stopBackendCapture(meeting.id).catch(() => {});
+    await updateMeetingStatus(meeting.id, "failed", Date.now()).catch(() => {});
+    void closeCaptureWidget();
+    void setTrayRecording(false);
     setMeetingState(
       "error",
       error instanceof Error ? error.message : "Microphone unavailable",
     );
+    await loadMeetings();
     return;
   }
   if (levelTimer !== null) window.clearInterval(levelTimer);
@@ -200,6 +220,49 @@ async function startCapture(meeting: Meeting): Promise<void> {
   }, 60);
   void openCaptureWidget(meeting.id);
   void setTrayRecording(true);
+}
+
+// Start a freshly-created meeting and surface it as the active one. Shared by
+// every start caller (panel, tray, auto-detect) behind a single in-flight guard
+// so a double-trigger can't launch two mic streams.
+async function beginCapture(meeting: Meeting): Promise<void> {
+  if (!isTauriRuntime() || isStarting) return;
+  if (isCapturing()) return;
+  isStarting = true;
+  try {
+    await startCapture(meeting);
+    await loadMeetings();
+    await setActiveMeeting(meeting);
+  } finally {
+    isStarting = false;
+  }
+}
+
+// First-run gate shared by every start path. If the user has already
+// acknowledged the audio-permission explainer, start immediately; otherwise
+// stash the meeting and let the app-wide priming dialog drive the decision.
+async function requestCaptureStart(meeting: Meeting): Promise<void> {
+  if (!isTauriRuntime()) return;
+  if (settingsStore.get("meetingAudioPrimed")) {
+    await beginCapture(meeting);
+    return;
+  }
+  setMeetingState("primingRequest", meeting);
+}
+
+// User accepted the explainer: remember the choice, start the stashed meeting,
+// and clear the request.
+async function confirmPriming(): Promise<void> {
+  const meeting = meetingState.primingRequest;
+  setMeetingState("primingRequest", null);
+  if (!meeting) return;
+  settingsStore.set("meetingAudioPrimed", true);
+  await beginCapture(meeting);
+}
+
+// User dismissed the explainer: abort the pending start without capturing.
+function cancelPriming(): void {
+  setMeetingState("primingRequest", null);
 }
 
 async function stopCapture(meetingId: string): Promise<void> {
@@ -224,7 +287,8 @@ async function stopCapture(meetingId: string): Promise<void> {
 }
 
 // Tray Start/Stop action: stop the active capture if one is running, otherwise
-// create + start a manual capture (mirrors MeetingPanel's manual start path).
+// create + request a manual capture. Routing through `requestCaptureStart`
+// means the tray honors the first-run priming gate just like the panel button.
 async function toggleCaptureFromTray(): Promise<void> {
   if (!isTauriRuntime()) return;
   const active = meetingState.meetings.find(
@@ -234,14 +298,13 @@ async function toggleCaptureFromTray(): Promise<void> {
     await stopAndProcess(active);
     return;
   }
+  if (isStarting || meetingState.primingRequest) return;
   const meeting = await createMeeting({
     title: `Meeting ${formatTime(Date.now())}`,
     sourceApp: "Tray",
     templateId: settingsStore.get("meetingTemplateId"),
   });
-  await startCapture(meeting);
-  await loadMeetings();
-  await setActiveMeeting(meeting);
+  await requestCaptureStart(meeting);
 }
 
 let templateCache: MeetingTemplate[] | null = null;
@@ -444,6 +507,9 @@ export const meetingStore = {
   startMeetingEventListeners,
   stopMeetingEventListeners,
   startCapture,
+  requestCaptureStart,
+  confirmPriming,
+  cancelPriming,
   stopCapture,
   stopAndProcess,
   regenerateNotes,


### PR DESCRIPTION
Fixes #2149 (P0/P1 from the R3 walkthrough audit). Hoists capture lifecycle to always-mounted AppShell (widget/tray Stop survive panel close); moves first-run priming gate into the store so tray + auto-detect honor it; cleans up backend capture + widget/tray on mic failure (no zombie meeting); adds store-level in-flight start guard; adds macOSPrivateApi (+ macos-private-api tauri feature) for the transparent widget; robust process-name probe. cargo check + 612 tests + tsc + biome + vite build green on macOS. Refs #2125.