### PR TITLE
feat(meeting): OpenAI diarized transcription (#2127)

### DIFF
--- a/src-tauri/src/audio/merge.rs
+++ b/src-tauri/src/audio/merge.rs
@@ -38,7 +38,7 @@ pub fn merge_segments(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::audio::types::{SegmentStatus, Speaker};
+    use crate::audio::types::{SegmentStatus, Speaker, SpeakerSource};
 
     fn segment(
         speaker: Speaker,
@@ -55,6 +55,8 @@ mod tests {
             start_ms,
             end_ms: start_ms + 100,
             status,
+            speaker_label: None,
+            speaker_source: SpeakerSource::Channel,
             created_at: 1,
         }
     }

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -17,7 +17,7 @@ use crate::audio::chunker::{Chunk, ChunkCfg, StreamingChunker};
 use crate::audio::transcribe::{
     ChunkTranscriber, GatewayTranscriber, RetryConfig, transcribe_chunk_with_retry,
 };
-use crate::audio::types::{SegmentStatus, Speaker, TranscriptSegment};
+use crate::audio::types::{SegmentStatus, Speaker, SpeakerSource, TranscriptSegment};
 use crate::commands::audio::{NewTranscriptSegment, insert_transcript_segment, now_ms};
 use crate::services::database::DbPool;
 
@@ -62,22 +62,54 @@ async fn emit_segment(
     seq: &AtomicI64,
     sink: &dyn SegmentSink,
 ) {
-    let (text, status) = match transcribe_chunk_with_retry(transcriber, &chunk, retry).await {
-        Ok(text) => (text, SegmentStatus::Ok),
-        Err(_) => (String::new(), SegmentStatus::Gap),
-    };
-    let segment = TranscriptSegment {
-        id: Uuid::new_v4().to_string(),
-        meeting_id: meeting_id.to_string(),
-        seq: seq.fetch_add(1, Ordering::SeqCst),
-        speaker: speaker.clone(),
-        text,
-        start_ms: chunk.start_ms as i64,
-        end_ms: chunk.end_ms as i64,
-        status,
-        created_at: now_ms(),
-    };
-    sink.segment(segment).await;
+    let chunk_start = chunk.start_ms as i64;
+    let chunk_end = chunk.end_ms as i64;
+    match transcribe_chunk_with_retry(transcriber, &chunk, retry).await {
+        Ok(diarized) => {
+            // One transcript segment per diarized utterance. The capture channel
+            // still decides Me/Them; the model label is metadata for a future
+            // per-speaker correction UI. Offset each utterance by the chunk start.
+            for utterance in diarized {
+                let speaker_source = if utterance.speaker_label.is_some() {
+                    SpeakerSource::Diarization
+                } else {
+                    SpeakerSource::Channel
+                };
+                let segment = TranscriptSegment {
+                    id: Uuid::new_v4().to_string(),
+                    meeting_id: meeting_id.to_string(),
+                    seq: seq.fetch_add(1, Ordering::SeqCst),
+                    speaker: speaker.clone(),
+                    text: utterance.text,
+                    start_ms: chunk_start + utterance.start_ms,
+                    end_ms: chunk_start + utterance.end_ms,
+                    status: SegmentStatus::Ok,
+                    speaker_label: utterance.speaker_label,
+                    speaker_source,
+                    created_at: now_ms(),
+                };
+                sink.segment(segment).await;
+            }
+        }
+        Err(_) => {
+            // A failed window becomes a single Gap spanning the chunk so audio is
+            // never silently dropped.
+            let segment = TranscriptSegment {
+                id: Uuid::new_v4().to_string(),
+                meeting_id: meeting_id.to_string(),
+                seq: seq.fetch_add(1, Ordering::SeqCst),
+                speaker: speaker.clone(),
+                text: String::new(),
+                start_ms: chunk_start,
+                end_ms: chunk_end,
+                status: SegmentStatus::Gap,
+                speaker_label: None,
+                speaker_source: SpeakerSource::Channel,
+                created_at: now_ms(),
+            };
+            sink.segment(segment).await;
+        }
+    }
 }
 
 /// Production sink: persist the segment to SQLite, then emit it to the webview.
@@ -98,6 +130,8 @@ impl SegmentSink for DbEmitSink {
             start_ms: segment.start_ms,
             end_ms: segment.end_ms,
             status: segment.status.clone(),
+            speaker_label: segment.speaker_label.clone(),
+            speaker_source: segment.speaker_source,
             created_at: segment.created_at,
         };
         let persisted = tauri::async_runtime::spawn_blocking(move || {
@@ -165,7 +199,7 @@ impl CaptureRegistry {
         let seq = Arc::new(AtomicI64::new(0));
 
         let me_transcriber: Arc<dyn ChunkTranscriber + Send + Sync> =
-            Arc::new(GatewayTranscriber::new(app.clone()));
+            Arc::new(GatewayTranscriber::new_diarized(app.clone()));
         let me_sink: Arc<dyn SegmentSink> = Arc::new(DbEmitSink { app: app.clone() });
         let (me_tx, me_rx) = unbounded_channel();
         let mut tasks = vec![tauri::async_runtime::spawn(run_capture_stream(
@@ -184,7 +218,7 @@ impl CaptureRegistry {
         let mut system_source = system_audio_source();
         if let Some(source) = system_source.as_mut() {
             let them_transcriber: Arc<dyn ChunkTranscriber + Send + Sync> =
-                Arc::new(GatewayTranscriber::new(app.clone()));
+                Arc::new(GatewayTranscriber::new_diarized(app.clone()));
             let them_sink: Arc<dyn SegmentSink> = Arc::new(DbEmitSink { app: app.clone() });
             let (tx, rx) = unbounded_channel();
             tasks.push(tauri::async_runtime::spawn(run_capture_stream(
@@ -269,12 +303,20 @@ mod tests {
         async fn transcribe(
             &self,
             _chunk: &Chunk,
-        ) -> Result<String, crate::audio::transcribe::TranscribeError> {
+        ) -> Result<
+            Vec<crate::audio::transcribe::DiarizedSegment>,
+            crate::audio::transcribe::TranscribeError,
+        > {
             let mut texts = self.texts.lock().unwrap();
             if texts.is_empty() {
                 Err(crate::audio::transcribe::TranscribeError::Empty)
             } else {
-                Ok(texts.remove(0))
+                Ok(vec![crate::audio::transcribe::DiarizedSegment {
+                    speaker_label: None,
+                    start_ms: 0,
+                    end_ms: 100,
+                    text: texts.remove(0),
+                }])
             }
         }
     }

--- a/src-tauri/src/audio/transcribe.rs
+++ b/src-tauri/src/audio/transcribe.rs
@@ -14,6 +14,9 @@ use crate::orchestrator::gateway_envelope::{publisher_status, unwrap_publisher_b
 const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
 const WHISPER_PUBLISHER: &str = "seren-whisper";
 const WHISPER_MODEL: &str = "whisper-1";
+const DIARIZE_MODEL: &str = "gpt-4o-transcribe-diarize";
+const DIARIZE_RESPONSE_FORMAT: &str = "diarized_json";
+const DIARIZE_CHUNKING_STRATEGY: &str = "auto";
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum TranscribeError {
@@ -21,6 +24,19 @@ pub enum TranscribeError {
     Transport(String),
     #[error("transcription returned no text")]
     Empty,
+}
+
+/// One diarized utterance returned by the transcriber. `speaker_label` is the raw
+/// model label (e.g. "A", "speaker_0") when diarization is available, else `None`.
+/// `start_ms`/`end_ms` are relative to the start of the chunk (offset is applied by
+/// the pipeline). Plain-text responses yield a single segment with `speaker_label`
+/// `None` spanning the whole chunk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiarizedSegment {
+    pub speaker_label: Option<String>,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub text: String,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -42,14 +58,19 @@ impl Default for RetryConfig {
 
 #[async_trait]
 pub trait ChunkTranscriber {
-    async fn transcribe(&self, chunk: &Chunk) -> Result<String, TranscribeError>;
+    async fn transcribe(&self, chunk: &Chunk) -> Result<Vec<DiarizedSegment>, TranscribeError>;
+}
+
+/// A transcription result is "empty" when it has no segment carrying non-blank text.
+fn has_text(segments: &[DiarizedSegment]) -> bool {
+    segments.iter().any(|segment| !segment.text.trim().is_empty())
 }
 
 pub async fn transcribe_chunk_with_retry<T>(
     transcriber: &T,
     chunk: &Chunk,
     cfg: RetryConfig,
-) -> Result<String, TranscribeError>
+) -> Result<Vec<DiarizedSegment>, TranscribeError>
 where
     T: ChunkTranscriber + Sync + ?Sized,
 {
@@ -59,7 +80,7 @@ where
 
     for attempt in 1..=attempts {
         match transcriber.transcribe(chunk).await {
-            Ok(text) if !text.trim().is_empty() => return Ok(text),
+            Ok(segments) if has_text(&segments) => return Ok(segments),
             Ok(_) => last_error = TranscribeError::Empty,
             Err(err) => last_error = err,
         }
@@ -108,7 +129,8 @@ pub fn pcm16_to_wav(samples: &[i16], sample_rate: u32) -> Vec<u8> {
     buf
 }
 
-/// Build the Gateway multipart-envelope body for a Whisper transcription request.
+/// Build the Gateway multipart-envelope body for a plain-text Whisper request.
+/// Used by dictation, which stays on `whisper-1` text transcription.
 pub fn build_whisper_envelope(wav: &[u8]) -> serde_json::Value {
     let encoded = base64::engine::general_purpose::STANDARD.encode(wav);
     json!({
@@ -124,26 +146,150 @@ pub fn build_whisper_envelope(wav: &[u8]) -> serde_json::Value {
     })
 }
 
+/// Build the Gateway multipart-envelope body for a diarized transcription request.
+/// Adds `model`, `response_format`, and `chunking_strategy` so the proxied OpenAI
+/// call returns per-speaker `diarized_json` segments.
+pub fn build_diarized_envelope(wav: &[u8]) -> serde_json::Value {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(wav);
+    json!({
+        "parts": [
+            { "name": "model", "value": DIARIZE_MODEL },
+            { "name": "response_format", "value": DIARIZE_RESPONSE_FORMAT },
+            { "name": "chunking_strategy", "value": DIARIZE_CHUNKING_STRATEGY },
+            {
+                "name": "file",
+                "filename": "audio.wav",
+                "content_type": "audio/wav",
+                "data": encoded
+            }
+        ]
+    })
+}
+
+/// Whether a transcriber requests diarized segments or plain whisper text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranscriptionMode {
+    /// `gpt-4o-transcribe-diarize` -> `diarized_json` (Meeting Mode).
+    Diarized,
+    /// `whisper-1` plain text (dictation).
+    Text,
+}
+
+/// Parse an unwrapped transcription body into diarized segments.
+///
+/// If the body carries a diarized `segments` array, each entry maps to a
+/// [`DiarizedSegment`] with its model speaker label and start/end converted from
+/// seconds to milliseconds relative to the chunk. If there is no segments array
+/// but there is a `text` field, returns a single segment spanning the chunk with
+/// no speaker label, so plain-text (non-diarized) responses still work. Empty or
+/// whitespace-only text yields [`TranscribeError::Empty`].
+fn parse_diarized_body(
+    body: &serde_json::Value,
+    chunk_len_ms: i64,
+) -> Result<Vec<DiarizedSegment>, TranscribeError> {
+    // Tolerate either "segments" (documented) or "chunks" as the array key.
+    let array = body
+        .get("segments")
+        .or_else(|| body.get("chunks"))
+        .and_then(serde_json::Value::as_array);
+
+    if let Some(entries) = array {
+        let segments: Vec<DiarizedSegment> = entries
+            .iter()
+            .filter_map(|entry| {
+                let text = entry
+                    .get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+                if text.is_empty() {
+                    return None;
+                }
+                let speaker_label = entry
+                    .get("speaker")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+                    .filter(|label| !label.is_empty());
+                let start_ms = seconds_to_ms(entry.get("start"));
+                let end_ms = seconds_to_ms(entry.get("end")).max(start_ms);
+                Some(DiarizedSegment {
+                    speaker_label,
+                    start_ms,
+                    end_ms,
+                    text,
+                })
+            })
+            .collect();
+        if !segments.is_empty() {
+            return Ok(segments);
+        }
+        // An empty/all-blank segments array still falls through to the top-level
+        // `text` (if any) so a partly-populated response is not silently dropped.
+    }
+
+    // Plain-text fallback: a single segment spanning the whole chunk.
+    let text = body
+        .get("text")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if text.is_empty() {
+        return Err(TranscribeError::Empty);
+    }
+    Ok(vec![DiarizedSegment {
+        speaker_label: None,
+        start_ms: 0,
+        end_ms: chunk_len_ms,
+        text,
+    }])
+}
+
+/// Read an OpenAI timestamp (float seconds) into milliseconds, defaulting to 0.
+fn seconds_to_ms(value: Option<&serde_json::Value>) -> i64 {
+    value
+        .and_then(serde_json::Value::as_f64)
+        .map(|seconds| (seconds * 1000.0).round() as i64)
+        .filter(|ms| *ms >= 0)
+        .unwrap_or(0)
+}
+
 /// Real [`ChunkTranscriber`] that POSTs a chunk to the Seren Whisper publisher.
 pub struct GatewayTranscriber {
     app: AppHandle,
     client: reqwest::Client,
+    mode: TranscriptionMode,
 }
 
 impl GatewayTranscriber {
+    /// A plain-text whisper transcriber (dictation).
     pub fn new(app: AppHandle) -> Self {
         Self {
             app,
             client: reqwest::Client::new(),
+            mode: TranscriptionMode::Text,
+        }
+    }
+
+    /// A diarized transcriber (Meeting Mode).
+    pub fn new_diarized(app: AppHandle) -> Self {
+        Self {
+            app,
+            client: reqwest::Client::new(),
+            mode: TranscriptionMode::Diarized,
         }
     }
 }
 
 #[async_trait]
 impl ChunkTranscriber for GatewayTranscriber {
-    async fn transcribe(&self, chunk: &Chunk) -> Result<String, TranscribeError> {
+    async fn transcribe(&self, chunk: &Chunk) -> Result<Vec<DiarizedSegment>, TranscribeError> {
         let wav = pcm16_to_wav(&chunk.samples, TARGET_SAMPLE_RATE);
-        let body = build_whisper_envelope(&wav).to_string();
+        let body = match self.mode {
+            TranscriptionMode::Diarized => build_diarized_envelope(&wav).to_string(),
+            TranscriptionMode::Text => build_whisper_envelope(&wav).to_string(),
+        };
         let url = format!(
             "{}/publishers/{}/audio/transcriptions",
             GATEWAY_BASE_URL, WHISPER_PUBLISHER
@@ -188,16 +334,8 @@ impl ChunkTranscriber for GatewayTranscriber {
         }
 
         let body = unwrap_publisher_body(&value);
-        let text = body
-            .get("text")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default()
-            .trim()
-            .to_string();
-        if text.is_empty() {
-            return Err(TranscribeError::Empty);
-        }
-        Ok(text)
+        let chunk_len_ms = (chunk.end_ms as i64 - chunk.start_ms as i64).max(0);
+        parse_diarized_body(body, chunk_len_ms)
     }
 }
 
@@ -210,12 +348,12 @@ mod tests {
     };
 
     struct FakeTranscriber {
-        responses: Mutex<Vec<Result<String, TranscribeError>>>,
+        responses: Mutex<Vec<Result<Vec<DiarizedSegment>, TranscribeError>>>,
         attempts: AtomicUsize,
     }
 
     impl FakeTranscriber {
-        fn new(responses: Vec<Result<String, TranscribeError>>) -> Self {
+        fn new(responses: Vec<Result<Vec<DiarizedSegment>, TranscribeError>>) -> Self {
             Self {
                 responses: Mutex::new(responses),
                 attempts: AtomicUsize::new(0),
@@ -227,9 +365,19 @@ mod tests {
         }
     }
 
+    /// Build a single plain-text segment, mirroring the text fallback shape.
+    fn text_segment(text: &str) -> Vec<DiarizedSegment> {
+        vec![DiarizedSegment {
+            speaker_label: None,
+            start_ms: 0,
+            end_ms: 100,
+            text: text.to_string(),
+        }]
+    }
+
     #[async_trait]
     impl ChunkTranscriber for Arc<FakeTranscriber> {
-        async fn transcribe(&self, _chunk: &Chunk) -> Result<String, TranscribeError> {
+        async fn transcribe(&self, _chunk: &Chunk) -> Result<Vec<DiarizedSegment>, TranscribeError> {
             self.attempts.fetch_add(1, Ordering::SeqCst);
             self.responses.lock().unwrap().remove(0)
         }
@@ -253,11 +401,11 @@ mod tests {
 
     #[tokio::test]
     async fn transcribe_chunk_returns_successful_text() {
-        let transcriber = Arc::new(FakeTranscriber::new(vec![Ok("hello".to_string())]));
+        let transcriber = Arc::new(FakeTranscriber::new(vec![Ok(text_segment("hello"))]));
 
         let result = transcribe_chunk_with_retry(&transcriber, &chunk(), cfg()).await;
 
-        assert_eq!(result.unwrap(), "hello");
+        assert_eq!(result.unwrap(), text_segment("hello"));
         assert_eq!(transcriber.attempts(), 1);
     }
 
@@ -266,12 +414,12 @@ mod tests {
         let transcriber = Arc::new(FakeTranscriber::new(vec![
             Err(TranscribeError::Transport("timeout".to_string())),
             Err(TranscribeError::Transport("502".to_string())),
-            Ok("eventually".to_string()),
+            Ok(text_segment("eventually")),
         ]));
 
         let result = transcribe_chunk_with_retry(&transcriber, &chunk(), cfg()).await;
 
-        assert_eq!(result.unwrap(), "eventually");
+        assert_eq!(result.unwrap(), text_segment("eventually"));
         assert_eq!(transcriber.attempts(), 3);
     }
 
@@ -318,5 +466,95 @@ mod tests {
         assert_eq!(parts[1]["name"], "file");
         assert_eq!(parts[1]["content_type"], "audio/wav");
         assert!(!parts[1]["data"].as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn build_diarized_envelope_carries_diarize_params_and_file() {
+        let envelope = build_diarized_envelope(&[0x52, 0x49, 0x46, 0x46]);
+        let parts = envelope["parts"].as_array().unwrap();
+
+        assert_eq!(parts[0]["name"], "model");
+        assert_eq!(parts[0]["value"], "gpt-4o-transcribe-diarize");
+        assert_eq!(parts[1]["name"], "response_format");
+        assert_eq!(parts[1]["value"], "diarized_json");
+        assert_eq!(parts[2]["name"], "chunking_strategy");
+        assert_eq!(parts[2]["value"], "auto");
+        assert_eq!(parts[3]["name"], "file");
+        assert!(!parts[3]["data"].as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_diarized_body_maps_segments_with_labels_and_ms() {
+        // Representative diarized_json body: segments with speaker labels and
+        // float-second start/end timestamps relative to the chunk.
+        let body = serde_json::json!({
+            "task": "transcribe",
+            "duration": 3.0,
+            "text": "Hi there. Hello.",
+            "segments": [
+                {
+                    "type": "transcript.text.segment",
+                    "id": "seg_0",
+                    "start": 0.0,
+                    "end": 1.5,
+                    "speaker": "A",
+                    "text": " Hi there. "
+                },
+                {
+                    "type": "transcript.text.segment",
+                    "id": "seg_1",
+                    "start": 1.8,
+                    "end": 3.0,
+                    "speaker": "B",
+                    "text": "Hello."
+                }
+            ]
+        });
+
+        let segments = parse_diarized_body(&body, 3_000).unwrap();
+
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].speaker_label.as_deref(), Some("A"));
+        assert_eq!(segments[0].start_ms, 0);
+        assert_eq!(segments[0].end_ms, 1_500);
+        assert_eq!(segments[0].text, "Hi there.");
+        assert_eq!(segments[1].speaker_label.as_deref(), Some("B"));
+        assert_eq!(segments[1].start_ms, 1_800);
+        assert_eq!(segments[1].end_ms, 3_000);
+        assert_eq!(segments[1].text, "Hello.");
+    }
+
+    #[test]
+    fn parse_diarized_body_falls_back_to_single_text_segment() {
+        // No segments array (diarization unavailable) -> one whole-chunk segment.
+        let body = serde_json::json!({ "text": "  plain transcript  " });
+
+        let segments = parse_diarized_body(&body, 4_200).unwrap();
+
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].speaker_label, None);
+        assert_eq!(segments[0].start_ms, 0);
+        assert_eq!(segments[0].end_ms, 4_200);
+        assert_eq!(segments[0].text, "plain transcript");
+    }
+
+    #[test]
+    fn parse_diarized_body_empty_text_is_empty_error() {
+        let body = serde_json::json!({ "text": "   " });
+        assert_eq!(
+            parse_diarized_body(&body, 1_000).unwrap_err(),
+            TranscribeError::Empty
+        );
+    }
+
+    #[test]
+    fn parse_diarized_body_all_blank_segments_is_empty_error() {
+        let body = serde_json::json!({
+            "segments": [ { "speaker": "A", "start": 0.0, "end": 1.0, "text": "  " } ]
+        });
+        assert_eq!(
+            parse_diarized_body(&body, 1_000).unwrap_err(),
+            TranscribeError::Empty
+        );
     }
 }

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -71,6 +71,36 @@ impl TryFrom<&str> for MeetingStatus {
     }
 }
 
+/// Where a segment's `speaker` came from: the capture channel (mic = Me, system
+/// audio = Them) or the transcription model's diarization labels.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SpeakerSource {
+    Channel,
+    Diarization,
+}
+
+impl SpeakerSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Channel => "channel",
+            Self::Diarization => "diarization",
+        }
+    }
+}
+
+impl TryFrom<&str> for SpeakerSource {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "channel" => Ok(Self::Channel),
+            "diarization" => Ok(Self::Diarization),
+            _ => Err(format!("Unknown speaker source: {}", value)),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SegmentStatus {
@@ -128,5 +158,9 @@ pub struct TranscriptSegment {
     pub start_ms: i64,
     pub end_ms: i64,
     pub status: SegmentStatus,
+    /// Raw diarization label from the model (e.g. "A", "speaker_0"), if any.
+    pub speaker_label: Option<String>,
+    /// Whether `speaker` was assigned by the capture channel or by diarization.
+    pub speaker_source: SpeakerSource,
     pub created_at: i64,
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -13,7 +13,9 @@ use crate::audio::templates::{BUILT_IN_MEETING_TEMPLATES, MeetingTemplate};
 use crate::audio::transcribe::{
     GatewayTranscriber, RetryConfig, TranscribeError, transcribe_chunk_with_retry,
 };
-use crate::audio::types::{Meeting, MeetingStatus, SegmentStatus, Speaker, TranscriptSegment};
+use crate::audio::types::{
+    Meeting, MeetingStatus, SegmentStatus, Speaker, SpeakerSource, TranscriptSegment,
+};
 use crate::orchestrator::types::SkillRef;
 use crate::services::database::DbPool;
 use rusqlite::{Connection, OptionalExtension, Result, params};
@@ -148,6 +150,9 @@ pub async fn append_transcript_segment(
         start_ms,
         end_ms,
         status,
+        // Manual appends carry the channel speaker, not a diarization label.
+        speaker_label: None,
+        speaker_source: SpeakerSource::Channel,
         created_at: now_ms(),
     };
 
@@ -288,7 +293,11 @@ pub async fn transcribe_pcm(
     };
     let transcriber = GatewayTranscriber::new(app);
     match transcribe_chunk_with_retry(&transcriber, &chunk, RetryConfig::default()).await {
-        Ok(text) => Ok(text),
+        Ok(segments) => Ok(segments
+            .into_iter()
+            .map(|segment| segment.text)
+            .collect::<Vec<_>>()
+            .join(" ")),
         Err(TranscribeError::Empty) => Ok(String::new()),
         Err(err) => Err(err.to_string()),
     }
@@ -380,6 +389,8 @@ pub struct NewTranscriptSegment {
     pub start_ms: i64,
     pub end_ms: i64,
     pub status: SegmentStatus,
+    pub speaker_label: Option<String>,
+    pub speaker_source: SpeakerSource,
     pub created_at: i64,
 }
 
@@ -452,9 +463,10 @@ pub fn insert_transcript_segment(
 ) -> Result<TranscriptSegment> {
     conn.execute(
         "INSERT INTO transcript_segments (
-            id, meeting_id, seq, speaker, text, start_ms, end_ms, status, created_at
+            id, meeting_id, seq, speaker, text, start_ms, end_ms, status,
+            speaker_label, speaker_source, created_at
          )
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
         params![
             segment.id,
             segment.meeting_id,
@@ -464,6 +476,8 @@ pub fn insert_transcript_segment(
             segment.start_ms,
             segment.end_ms,
             segment.status.as_str(),
+            segment.speaker_label,
+            segment.speaker_source.as_str(),
             segment.created_at
         ],
     )?;
@@ -477,6 +491,8 @@ pub fn insert_transcript_segment(
         start_ms: segment.start_ms,
         end_ms: segment.end_ms,
         status: segment.status,
+        speaker_label: segment.speaker_label,
+        speaker_source: segment.speaker_source,
         created_at: segment.created_at,
     })
 }
@@ -486,7 +502,8 @@ pub fn select_transcript_segments(
     meeting_id: &str,
 ) -> Result<Vec<TranscriptSegment>> {
     let mut stmt = conn.prepare(
-        "SELECT id, meeting_id, seq, speaker, text, start_ms, end_ms, status, created_at
+        "SELECT id, meeting_id, seq, speaker, text, start_ms, end_ms, status,
+                speaker_label, speaker_source, created_at
          FROM transcript_segments
          WHERE meeting_id = ?1
          ORDER BY seq ASC",
@@ -524,6 +541,20 @@ fn row_to_meeting(row: &rusqlite::Row<'_>) -> Result<Meeting> {
 fn row_to_segment(row: &rusqlite::Row<'_>) -> Result<TranscriptSegment> {
     let speaker: String = row.get(3)?;
     let status: String = row.get(7)?;
+    // Legacy rows (pre-diarization) have NULL speaker_source; treat them as channel.
+    let speaker_source: Option<String> = row.get(9)?;
+    let speaker_source = speaker_source
+        .as_deref()
+        .map(SpeakerSource::try_from)
+        .transpose()
+        .map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(
+                9,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
+            )
+        })?
+        .unwrap_or(SpeakerSource::Channel);
     Ok(TranscriptSegment {
         id: row.get(0)?,
         meeting_id: row.get(1)?,
@@ -545,7 +576,9 @@ fn row_to_segment(row: &rusqlite::Row<'_>) -> Result<TranscriptSegment> {
                 Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
             )
         })?,
-        created_at: row.get(8)?,
+        speaker_label: row.get(8)?,
+        speaker_source,
+        created_at: row.get(10)?,
     })
 }
 
@@ -650,6 +683,16 @@ mod tests {
                     } else {
                         SegmentStatus::Ok
                     },
+                    speaker_label: if seq == 1 {
+                        Some("A".to_string())
+                    } else {
+                        None
+                    },
+                    speaker_source: if seq == 1 {
+                        SpeakerSource::Diarization
+                    } else {
+                        SpeakerSource::Channel
+                    },
                     created_at: 30 + seq,
                 },
             )
@@ -666,6 +709,10 @@ mod tests {
             vec![0, 1, 2]
         );
         assert_eq!(segments[1].speaker, Speaker::Them);
+        assert_eq!(segments[1].speaker_label.as_deref(), Some("A"));
+        assert_eq!(segments[1].speaker_source, SpeakerSource::Diarization);
+        assert_eq!(segments[0].speaker_label, None);
+        assert_eq!(segments[0].speaker_source, SpeakerSource::Channel);
         assert_eq!(segments[2].status, SegmentStatus::Gap);
     }
 
@@ -684,6 +731,8 @@ mod tests {
                 start_ms: 0,
                 end_ms: 100,
                 status: SegmentStatus::Ok,
+                speaker_label: None,
+                speaker_source: SpeakerSource::Channel,
                 created_at: 1,
             },
         )

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -357,6 +357,8 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             start_ms INTEGER NOT NULL,
             end_ms INTEGER NOT NULL,
             status TEXT NOT NULL,
+            speaker_label TEXT,
+            speaker_source TEXT,
             created_at INTEGER NOT NULL,
             FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
         )",
@@ -368,6 +370,30 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
          ON transcript_segments(meeting_id, seq)",
         [],
     )?;
+
+    // Migration: add diarization columns to transcript_segments for existing DBs.
+    // Both are nullable so the round-trip of older rows is preserved.
+    let has_speaker_label: bool = conn
+        .prepare("SELECT speaker_label FROM transcript_segments LIMIT 1")
+        .is_ok();
+    if !has_speaker_label {
+        conn.execute(
+            "ALTER TABLE transcript_segments ADD COLUMN speaker_label TEXT",
+            [],
+        )
+        .ok();
+    }
+
+    let has_speaker_source: bool = conn
+        .prepare("SELECT speaker_source FROM transcript_segments LIMIT 1")
+        .is_ok();
+    if !has_speaker_source {
+        conn.execute(
+            "ALTER TABLE transcript_segments ADD COLUMN speaker_source TEXT",
+            [],
+        )
+        .ok();
+    }
 
     // Migration: add agent conversation columns if they don't exist (for existing DBs)
     let has_kind: bool = conn

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -29,6 +29,8 @@ export interface Meeting {
   updatedAt: number;
 }
 
+export type SpeakerSource = "channel" | "diarization";
+
 export interface TranscriptSegment {
   id: string;
   meetingId: string;
@@ -38,6 +40,10 @@ export interface TranscriptSegment {
   startMs: number;
   endMs: number;
   status: SegmentStatus;
+  /** Raw diarization label from the model (e.g. "A"), if any. */
+  speakerLabel?: string | null;
+  /** Whether `speaker` came from the capture channel or model diarization. */
+  speakerSource?: SpeakerSource;
   createdAt: number;
 }
 


### PR DESCRIPTION
Closes #2127 (client side). Meeting Mode transcriber now sends `gpt-4o-transcribe-diarize` + `response_format=diarized_json` + `chunking_strategy=auto`; `ChunkTranscriber` returns speaker-labeled segments; the pipeline emits one segment per diarized utterance (channel still decides Me/Them; model `speaker_label` + `speaker_source` stored for a future per-speaker correction UI). **Text fallback**: a plain `{text}` body yields one channel-attributed segment per chunk — identical to today, so zero regression if the model/publisher returns no diarization. Additive guarded schema migration (no data loss). **Dictation untouched** — `transcribe_pcm` stays `whisper-1` text. The `seren-whisper` publisher is a transparent OpenAI proxy (forwards params, returns full body); if param-allowlisting blocks the new fields that's a one-line gateway config flag. 617 lib tests (612+5), cargo check/tsc/biome green on macOS. Runtime diarized call = the release test.