### PR TITLE
chore(lint): format playwright-stealth sources to green pnpm check

### DIFF
--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -19,14 +19,16 @@ const TEST_INSTALLED_BROWSERS: InstalledBrowser[] = [
   {
     name: "chrome",
     browserName: "chromium",
-    executablePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    executablePath:
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     isChromiumBased: true,
     stealthSupported: true,
   },
   {
     name: "msedge",
     browserName: "chromium",
-    executablePath: "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    executablePath:
+      "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
     isChromiumBased: true,
     stealthSupported: true,
   },

--- a/mcp-servers/playwright-stealth/src/__tests__/stdio_framing.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/stdio_framing.test.ts
@@ -10,7 +10,13 @@ type Child = ReturnType<typeof spawn>;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(__dirname, "../..");
 const serverPath = path.join(packageRoot, "dist", "index.js");
-const tscPath = path.join(packageRoot, "node_modules", "typescript", "bin", "tsc");
+const tscPath = path.join(
+  packageRoot,
+  "node_modules",
+  "typescript",
+  "bin",
+  "tsc",
+);
 
 const initializeRequest = {
   jsonrpc: "2.0",

--- a/mcp-servers/playwright-stealth/src/tool_definitions.ts
+++ b/mcp-servers/playwright-stealth/src/tool_definitions.ts
@@ -7,8 +7,7 @@ export const NAVIGATION_WAIT_UNTIL_VALUES = [
   "networkidle",
 ] as const;
 
-export type NavigationWaitUntil =
-  (typeof NAVIGATION_WAIT_UNTIL_VALUES)[number];
+export type NavigationWaitUntil = (typeof NAVIGATION_WAIT_UNTIL_VALUES)[number];
 
 export type NavigateOptions = {
   waitUntil?: NavigationWaitUntil;


### PR DESCRIPTION
## What
`pnpm check` (Biome) was failing on **3 format-only errors** in the vendored `mcp-servers/playwright-stealth` sources:
- `src/__tests__/browser.test.ts`
- `src/__tests__/stdio_framing.test.ts`
- `src/tool_definitions.ts`

Applied Biome safe formatting to that directory only (whitespace / line-wrapping; **no behavior change**). `biome check` now reports **0 errors** (exit 0).

## Why
This is the **A1 / Q-3** item from the STT gap analysis — `pnpm check` was red (a release-blocking gate), although `pnpm lint` was already green. None of the errors were in STT code; they were pre-existing format drift in vendored MCP-server sources.

## Follow-up (not in this PR)
Consider excluding `mcp-servers/` from Biome `includes` so vendored MCP-server sources don't gate the build (more robust than formatting files that `pnpm prepare:mcp-servers` may regenerate). Same root cause also makes `.worktrees/` worktrees break `pnpm check` (nested-root config) — worth addressing together.

## Test
- `biome check` → **0 errors** (was 3); exit 0.
- Format-only diff: 3 files, +12 / −5.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
