### PR TITLE
fix(audio): WASAPI loopback start() returns Ok before init — silent dead Them stream [P1]

### DIFF
--- a/src-tauri/src/audio/capture/mod.rs
+++ b/src-tauri/src/audio/capture/mod.rs
@@ -9,6 +9,9 @@ pub mod macos;
 #[cfg(target_os = "windows")]
 pub mod windows;
 
+use std::sync::mpsc::SyncSender;
+use std::thread::JoinHandle;
+
 use thiserror::Error;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -41,6 +44,36 @@ pub enum CaptureError {
 pub trait AudioCaptureSource: Send {
     fn start(&mut self, sink: FrameSender) -> Result<(), CaptureError>;
     fn stop(&mut self);
+}
+
+/// Spawn `worker` on a dedicated OS thread and block until it reports readiness.
+///
+/// The worker must send exactly one verdict on the channel: `Ok(())` once its
+/// capture stream is live, or `Err(_)` if initialization failed. This returns the
+/// running thread handle once `Ok` is seen, the worker's error (after joining) on
+/// failure, or a `Device` error if the worker exits without signaling (panic /
+/// early return). It exists so sources whose real init runs on a non-`Send` worker
+/// thread (WASAPI loopback) can report the *true* init result to their caller
+/// instead of an unconditional `Ok` that masks a dead stream (#2157).
+pub fn spawn_with_readiness<F>(worker: F) -> Result<JoinHandle<()>, CaptureError>
+where
+    F: FnOnce(SyncSender<Result<(), CaptureError>>) + Send + 'static,
+{
+    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+    let handle = std::thread::spawn(move || worker(ready_tx));
+    match ready_rx.recv() {
+        Ok(Ok(())) => Ok(handle),
+        Ok(Err(err)) => {
+            let _ = handle.join();
+            Err(err)
+        }
+        Err(_) => {
+            let _ = handle.join();
+            Err(CaptureError::Device(
+                "capture worker exited before signaling readiness".to_string(),
+            ))
+        }
+    }
 }
 
 /// Downmix interleaved PCM to mono and resample to [`TARGET_SAMPLE_RATE`].
@@ -96,6 +129,43 @@ pub fn resample_to_16k(mono: &[i16], sample_rate: u32) -> Vec<i16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn spawn_with_readiness_returns_handle_when_worker_signals_ok() {
+        let ran = Arc::new(AtomicBool::new(false));
+        let flag = ran.clone();
+        let handle = spawn_with_readiness(move |ready| {
+            flag.store(true, Ordering::SeqCst);
+            ready.send(Ok(())).unwrap();
+        })
+        .expect("a worker that signals Ok yields a running handle");
+        handle.join().unwrap();
+        assert!(ran.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn spawn_with_readiness_propagates_worker_init_error() {
+        // An init failure on the worker thread must surface to the caller, not be
+        // swallowed as a phantom-live stream (the #2157 regression).
+        let err = spawn_with_readiness(|ready| {
+            ready
+                .send(Err(CaptureError::Device("no render endpoint".to_string())))
+                .unwrap();
+        })
+        .expect_err("init failure must be returned");
+        assert_eq!(err, CaptureError::Device("no render endpoint".to_string()));
+    }
+
+    #[test]
+    fn spawn_with_readiness_errors_when_worker_exits_without_signaling() {
+        // A worker that drops its sender without sending (panic / early return)
+        // must not be reported as a live capture.
+        let err = spawn_with_readiness(|_ready| {})
+            .expect_err("a silent worker exit must surface as an error");
+        assert!(matches!(err, CaptureError::Device(_)));
+    }
 
     #[test]
     fn mono_at_target_rate_passes_through_unchanged() {

--- a/src-tauri/src/audio/capture/windows.rs
+++ b/src-tauri/src/audio/capture/windows.rs
@@ -4,11 +4,14 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::SyncSender;
 use std::thread::JoinHandle;
 
 use wasapi::{Direction, ShareMode, get_default_device, initialize_mta};
 
-use super::{AudioCaptureSource, CaptureError, FrameSender, PcmFrame, to_mono_16k};
+use super::{
+    AudioCaptureSource, CaptureError, FrameSender, PcmFrame, spawn_with_readiness, to_mono_16k,
+};
 
 // How long to block waiting for the next WASAPI buffer before re-checking stop.
 const EVENT_TIMEOUT_MS: u32 = 1000;
@@ -40,11 +43,12 @@ impl AudioCaptureSource for WasapiLoopbackSource {
         self.stop_flag.store(false, Ordering::SeqCst);
         let stop = self.stop_flag.clone();
         // The WASAPI client is not Send, so it is owned entirely on this thread.
-        let handle = std::thread::spawn(move || {
-            if let Err(err) = run_loopback(&stop, &sink) {
-                log::warn!("[wasapi] loopback capture stopped: {err}");
-            }
-        });
+        // Block until run_loopback reports the stream is live (or init failed) so
+        // a real failure (no render endpoint, COM error) is returned to the caller
+        // instead of leaving the "Them" worker blocked on a silent channel (#2157).
+        let handle = spawn_with_readiness(move |ready| {
+            run_loopback(&stop, &sink, &ready);
+        })?;
         self.handle = Some(handle);
         Ok(())
     }
@@ -57,44 +61,71 @@ impl AudioCaptureSource for WasapiLoopbackSource {
     }
 }
 
-fn run_loopback(stop: &AtomicBool, sink: &FrameSender) -> Result<(), String> {
-    initialize_mta()
-        .ok()
-        .map_err(|err| format!("COM init failed: {err:?}"))?;
+/// Initialize WASAPI loopback capture, signal readiness through `ready`, then pump
+/// frames until `stop` is set. The init result is reported on `ready` exactly once:
+/// `Err` if any init step fails (the stream never started), or `Ok` after the
+/// stream is live. Read failures during the capture loop only end the loop.
+fn run_loopback(stop: &AtomicBool, sink: &FrameSender, ready: &SyncSender<Result<(), CaptureError>>) {
+    // Report an init-step failure to the caller and stop: the device is not live.
+    macro_rules! init {
+        ($step:expr) => {
+            match $step {
+                Ok(value) => value,
+                Err(err) => {
+                    let _ = ready.send(Err(CaptureError::Device(err.to_string())));
+                    return;
+                }
+            }
+        };
+    }
 
-    let device = get_default_device(&Direction::Render).map_err(|err| err.to_string())?;
-    let mut audio_client = device.get_iaudioclient().map_err(|err| err.to_string())?;
-    let format = audio_client.get_mixformat().map_err(|err| err.to_string())?;
+    init!(
+        initialize_mta()
+            .ok()
+            .map_err(|err| format!("COM init failed: {err:?}"))
+    );
+
+    let device = init!(get_default_device(&Direction::Render).map_err(|err| err.to_string()));
+    let mut audio_client = init!(device.get_iaudioclient().map_err(|err| err.to_string()));
+    let format = init!(audio_client.get_mixformat().map_err(|err| err.to_string()));
     let (_default_period, min_period) =
-        audio_client.get_periods().map_err(|err| err.to_string())?;
+        init!(audio_client.get_periods().map_err(|err| err.to_string()));
 
-    audio_client
-        .initialize_client(
-            &format,
-            min_period,
-            &Direction::Capture,
-            &ShareMode::Shared,
-            true,
-        )
-        .map_err(|err| err.to_string())?;
+    init!(
+        audio_client
+            .initialize_client(
+                &format,
+                min_period,
+                &Direction::Capture,
+                &ShareMode::Shared,
+                true,
+            )
+            .map_err(|err| err.to_string())
+    );
 
-    let h_event = audio_client.set_get_eventhandle().map_err(|err| err.to_string())?;
-    let capture_client = audio_client
-        .get_audiocaptureclient()
-        .map_err(|err| err.to_string())?;
+    let h_event = init!(audio_client.set_get_eventhandle().map_err(|err| err.to_string()));
+    let capture_client = init!(
+        audio_client
+            .get_audiocaptureclient()
+            .map_err(|err| err.to_string())
+    );
 
     let channels = format.get_nchannels();
     let sample_rate = format.get_samplespersec();
     let bits = format.get_bitspersample();
     let block_align = format.get_blockalign() as usize;
 
-    audio_client.start_stream().map_err(|err| err.to_string())?;
+    init!(audio_client.start_stream().map_err(|err| err.to_string()));
+
+    // The stream is live: report success. From here, errors only end the loop.
+    let _ = ready.send(Ok(()));
 
     let mut bytes: VecDeque<u8> = VecDeque::new();
     while !stop.load(Ordering::SeqCst) {
-        capture_client
-            .read_from_device_to_deque(&mut bytes)
-            .map_err(|err| err.to_string())?;
+        if let Err(err) = capture_client.read_from_device_to_deque(&mut bytes) {
+            log::warn!("[wasapi] loopback read failed: {err}");
+            break;
+        }
 
         let frame_count = if block_align == 0 {
             0
@@ -117,7 +148,6 @@ fn run_loopback(stop: &AtomicBool, sink: &FrameSender) -> Result<(), String> {
     }
 
     let _ = audio_client.stop_stream();
-    Ok(())
 }
 
 /// Pop one interleaved sample from the byte queue and convert it to i16. The


### PR DESCRIPTION
## Problem (P1 — silent data loss on Windows, the primary platform)

`WasapiLoopbackSource::start` spawned the capture thread and **unconditionally returned `Ok(())`**; `run_loopback`'s COM/device init errors were only `log::warn!`-ed on the worker thread. `pipeline.rs` took that `Ok` as "live" and set `them_tx = Some(tx)`, so the Them worker blocked on `frames.recv()` forever — any init failure (no render endpoint, COM error) captured the whole remote side as silence with no diagnostic.

## Fix

- `WasapiLoopbackSource::start` now blocks on a readiness signal from `run_loopback` and returns the real init `Result`. `run_loopback` reports `Err` if any init step fails (the stream never started) or `Ok` once `start_stream()` succeeds; read failures during the loop only end the loop.
- Extracted `spawn_with_readiness` into `capture/mod.rs` (platform-independent) so the handshake is unit-tested without WASAPI hardware.
- No pipeline change needed: `pipeline.rs:250-255` already degrades to mic-only (logged) when `source.start` returns `Err` — that path is now actually reachable.

## Tests

`capture/mod.rs` (host, `cargo test --lib`, green):
- `spawn_with_readiness_returns_handle_when_worker_signals_ok`
- `spawn_with_readiness_propagates_worker_init_error` (the regression: init failure now surfaces instead of a phantom-live stream)
- `spawn_with_readiness_errors_when_worker_exits_without_signaling`

## Verification notes

- Host `cargo test --lib` green (3 new tests + existing suite).
- `windows.rs` itself is `#[cfg(target_os = "windows")]`; the change mirrors the exact pre-existing (CI-green) calling conventions and adds only a std readiness handshake. Local `--target x86_64-pc-windows-gnu` check is blocked by `aws-lc-sys`'s mingw C toolchain (environmental, unrelated). **Authoritative gate: the CI `build (windows-latest)` job (`pnpm tauri build`, msvc) runs on this PR.**

Closes #2157