### PR TITLE
fix(meeting): live transcript ordered by completion-order seq, not capture order [P1]

### DIFF
--- a/src-tauri/src/audio/merge.rs
+++ b/src-tauri/src/audio/merge.rs
@@ -19,9 +19,14 @@ pub fn merge_segments(
         index += 1;
     }
 
+    // Order by capture time, then by the persisted capture/emission `seq` so a
+    // start_ms tie between the Me and Them streams resolves to capture order
+    // rather than always Me-before-Them. The insertion index is the final stable
+    // tiebreak when seq also ties (#2163).
     indexed.sort_by(|(left_index, left), (right_index, right)| {
         left.start_ms
             .cmp(&right.start_ms)
+            .then_with(|| left.seq.cmp(&right.seq))
             .then_with(|| left_index.cmp(right_index))
     });
 
@@ -89,6 +94,20 @@ mod tests {
 
         assert_eq!(merged[0].speaker, Speaker::Me);
         assert_eq!(merged[1].speaker, Speaker::Them);
+    }
+
+    #[test]
+    fn merge_segments_breaks_start_ties_by_capture_seq() {
+        // Same start_ms, but Them was captured first (lower seq): it must sort
+        // first. The pre-#2163 tiebreak always put Me first, scrambling order
+        // whenever the two streams' chunks shared a start_ms.
+        let me = vec![segment(Speaker::Me, 5, 100, SegmentStatus::Ok)];
+        let them = vec![segment(Speaker::Them, 2, 100, SegmentStatus::Ok)];
+
+        let merged = merge_segments(me, them);
+
+        assert_eq!(merged[0].speaker, Speaker::Them);
+        assert_eq!(merged[1].speaker, Speaker::Me);
     }
 
     #[test]

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -133,9 +133,13 @@ async function setActiveMeeting(meeting: Meeting | null): Promise<void> {
 function appendLiveSegment(segment: TranscriptSegment): void {
   setMeetingState("liveSegments", (segments) => {
     const withoutDuplicate = segments.filter((item) => item.id !== segment.id);
+    // Order by capture time, not completion order. `seq` is assigned when each
+    // chunk's transcription request returns, so the fast Me (whisper-1) vs slow
+    // Them (diarize) streams would otherwise interleave scrambled. startMs is the
+    // chunk's capture offset; seq only breaks exact-start ties (#2163).
     return [...withoutDuplicate, segment].sort((left, right) => {
-      if (left.seq !== right.seq) return left.seq - right.seq;
-      return left.startMs - right.startMs;
+      if (left.startMs !== right.startMs) return left.startMs - right.startMs;
+      return left.seq - right.seq;
     });
   });
 }

--- a/tests/unit/meeting-transcript-order.test.ts
+++ b/tests/unit/meeting-transcript-order.test.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Regression test for #2163 — live transcript orders by capture time, not completion-order seq.
+// ABOUTME: Fast Me (whisper-1) vs slow Them (diarize) streams must not interleave scrambled.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { TranscriptSegment } from "@/services/meetings";
+import { meetingStore } from "@/stores/meeting.store";
+
+let idCounter = 0;
+function seg(overrides: Partial<TranscriptSegment>): TranscriptSegment {
+  idCounter += 1;
+  return {
+    id: `seg-${idCounter}`,
+    meetingId: "m1",
+    seq: 0,
+    speaker: "me",
+    text: "x",
+    startMs: 0,
+    endMs: 0,
+    status: "ok",
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+describe("meetingStore.appendLiveSegment ordering (#2163)", () => {
+  beforeEach(async () => {
+    // setActiveMeeting(null) clears liveSegments (no runtime needed).
+    await meetingStore.setActiveMeeting(null);
+  });
+
+  it("orders by startMs even when seq (completion order) disagrees", () => {
+    // Them spoke first (startMs 0) but its slow transcription returned last
+    // (seq 2). Me spoke later (startMs 1000) but returned first (seq 1).
+    // Capture order must win: Them ("b") before Me ("a").
+    meetingStore.appendLiveSegment(
+      seg({ id: "a", speaker: "me", startMs: 1000, seq: 1 }),
+    );
+    meetingStore.appendLiveSegment(
+      seg({ id: "b", speaker: "them", startMs: 0, seq: 2 }),
+    );
+
+    expect(meetingStore.state.liveSegments.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+
+  it("breaks exact startMs ties by seq", () => {
+    meetingStore.appendLiveSegment(seg({ id: "x", startMs: 500, seq: 4 }));
+    meetingStore.appendLiveSegment(seg({ id: "y", startMs: 500, seq: 3 }));
+
+    expect(meetingStore.state.liveSegments.map((s) => s.id)).toEqual(["y", "x"]);
+  });
+});


### PR DESCRIPTION
## Problem (P1)

The shared `seq` counter is assigned when each chunk's transcription HTTP call **returns**, not when spoken. Me (`whisper-1`, fast) vs Them (`gpt-4o-transcribe-diarize`, slow) makes the skew systematic, so the live transcript — sorted by `seq` alone — interleaved scrambled. `assemble_transcript`'s merge tie-break always put Me before Them on a `start_ms` collision.

## Fix

Order by **capture time, then seq**:

- `meeting.store.ts appendLiveSegment`: sort by `(startMs, seq)` instead of `(seq, startMs)`. `startMs` is the chunk's capture offset; `seq` only breaks exact-start ties.
- `merge.rs merge_segments`: tie-break a `start_ms` collision by the persisted capture `seq` (then insertion index), so a Me/Them collision resolves to capture order rather than always Me-first.

The pipeline already offsets each segment's `start_ms` by its chunk start (`pipeline.rs:85`), so the Me/text fallback spans `[chunk_start, chunk_end]` — collisions are already rare; this fixes ordering when they happen.

> Note: the diarized "Them" per-speaker labels remain flattened to one channel in `assemble_transcript` — design §6 explicitly deferred true multi-speaker diarization, so that is intentionally out of scope here.

## Tests

- `cargo test --lib` (green): `merge_segments_breaks_start_ties_by_capture_seq`; existing stable-order/gap/interleave tests still pass.
- `tests/unit/meeting-transcript-order.test.ts` (vitest, green): live store orders by `startMs` when `seq` disagrees; exact-`startMs` ties break by `seq`.

Closes #2163