### PR TITLE
fix(dictation): push-to-talk tap-race leaks the microphone (stays hot) [P1]

### DIFF
--- a/src/lib/audio/useVoiceInput.ts
+++ b/src/lib/audio/useVoiceInput.ts
@@ -45,8 +45,18 @@ export function useVoiceInput(
   const [error, setError] = createSignal<string | null>(null);
 
   let capture: DictationCaptureHandle | null = null;
+  // A start is awaiting getUserMedia; `stopRequested` is set if a stop (a fast
+  // push-to-talk tap, blur, or cleanup) arrives before that resolves so the
+  // pending handle is torn down on arrival instead of leaking the live mic.
+  let starting = false;
+  let stopRequested = false;
 
   async function startRecording() {
+    // Don't overwrite a live handle or launch a second concurrent start; either
+    // would orphan a MediaStream with no stopper (the #2161 leak).
+    if (starting || capture) return;
+    starting = true;
+    stopRequested = false;
     try {
       setError(null);
 
@@ -57,9 +67,18 @@ export function useVoiceInput(
         );
       }
 
-      capture = await startDictationCapture((partial) => {
+      const handle = await startDictationCapture((partial) => {
         options.onPartial?.(partial);
       });
+      if (stopRequested) {
+        // A stop landed while we were acquiring the mic: release it now and
+        // never publish the handle, so the OS mic indicator goes dark.
+        stopRequested = false;
+        await handle.stop().catch(() => {});
+        setVoiceState("idle");
+        return;
+      }
+      capture = handle;
       setVoiceState("listening");
     } catch (err) {
       console.error("[VoiceInput] startRecording error:", err);
@@ -77,10 +96,19 @@ export function useVoiceInput(
       }
       setError(message);
       setVoiceState("error");
+    } finally {
+      starting = false;
     }
   }
 
   async function stopRecording() {
+    if (starting && !capture) {
+      // The start is still acquiring the mic; flag it so startRecording tears
+      // the handle down on arrival rather than publishing a stream nobody stops.
+      stopRequested = true;
+      setVoiceState("idle");
+      return;
+    }
     const handle = capture;
     capture = null;
     if (!handle) {
@@ -137,6 +165,9 @@ export function useVoiceInput(
   }
 
   onCleanup(() => {
+    // Also cancel a start that's still in flight, so an unmount mid-acquisition
+    // releases the mic instead of leaking it.
+    stopRequested = true;
     if (capture) {
       void capture.stop();
       capture = null;

--- a/tests/unit/voice-input-tap-race.test.ts
+++ b/tests/unit/voice-input-tap-race.test.ts
@@ -1,0 +1,82 @@
+// ABOUTME: Regression test for #2161 — a push-to-talk tap (stop before getUserMedia resolves) must not leak the mic.
+// ABOUTME: Drives the real useVoiceInput hook with a controllable capture promise.
+
+import { createRoot } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => {
+  const state: { resolve?: (value: unknown) => void } = {};
+  const stopSpy = vi.fn(async () => "");
+  const startMock = vi.fn(
+    () =>
+      new Promise((resolve) => {
+        state.resolve = resolve;
+      }),
+  );
+  return { state, stopSpy, startMock };
+});
+
+vi.mock("@/lib/audio/dictationCapture", () => ({
+  startDictationCapture: h.startMock,
+}));
+vi.mock("@/services/dictation", () => ({
+  cleanupDictationText: vi.fn(async (text: string) => text),
+  transformSelection: vi.fn(),
+  transcribePcm: vi.fn(),
+}));
+vi.mock("@/stores/provider.store", () => ({
+  providerStore: { resolvedModel: () => "model" },
+}));
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: { get: () => false },
+}));
+
+import { useVoiceInput } from "@/lib/audio/useVoiceInput";
+
+describe("useVoiceInput push-to-talk tap race (#2161)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn() },
+      platform: "MacIntel",
+    });
+    h.startMock.mockClear();
+    h.stopSpy.mockClear();
+    h.state.resolve = undefined;
+  });
+
+  it("releases the mic when stop arrives before getUserMedia resolves", async () => {
+    await createRoot(async (dispose) => {
+      const voice = useVoiceInput(() => {});
+
+      // Fast tap: start, then stop before the capture promise resolves.
+      const startPromise = voice.startRecording();
+      await voice.stopRecording();
+      expect(voice.voiceState()).toBe("idle");
+
+      // The mic finally becomes available — after the user already let go.
+      h.state.resolve?.({ stop: h.stopSpy, level: () => 0 });
+      await startPromise;
+
+      // The pending handle must be torn down, never published.
+      expect(h.stopSpy).toHaveBeenCalledTimes(1);
+      expect(voice.level()).toBe(0);
+      expect(voice.voiceState()).toBe("idle");
+      dispose();
+    });
+  });
+
+  it("ignores a second start while one is already acquiring the mic", async () => {
+    await createRoot(async (dispose) => {
+      const voice = useVoiceInput(() => {});
+
+      const first = voice.startRecording();
+      const second = voice.startRecording(); // guarded: must be a no-op
+      h.state.resolve?.({ stop: h.stopSpy, level: () => 0.5 });
+      await Promise.all([first, second]);
+
+      expect(h.startMock).toHaveBeenCalledTimes(1);
+      expect(voice.voiceState()).toBe("listening");
+      dispose();
+    });
+  });
+});


### PR DESCRIPTION
## Problem (P1)

`beginHold → void startRecording()` assigns the mic handle only after `startDictationCapture` (→ `getUserMedia`) resolves. A `keyup` before that runs `endHold → stopRecording`, which reads a still-`null` handle and returns. The pending start then resolves and assigns a live MediaStream/AudioContext with **no stopper**; the next tap overwrites it (another leak). The OS mic indicator stays lit and leaks compound per tap.

## Fix (`useVoiceInput.ts`)

- Track `starting` (a start is awaiting `getUserMedia`) and `stopRequested`.
- If a stop (tap, blur, or `onCleanup`) arrives while a start is in flight, `startRecording` awaits `handle.stop()` on arrival and never publishes the handle.
- `startRecording` is a no-op if a start is already in flight or a handle already exists, so a live handle is never overwritten.
- `onCleanup` also sets `stopRequested` so an unmount mid-acquisition releases the mic.

## Test (`tests/unit/voice-input-tap-race.test.ts`, vitest, green)

Drives the real hook with a controllable capture promise:
- stop before `getUserMedia` resolves → the resolved handle's `stop()` is called once, nothing is published (`level()===0`, state `idle`).
- a second `startRecording` while one is in flight is a no-op (`startDictationCapture` called once).

Closes #2161
