### PR TITLE
fix(meeting): cancelling first-run priming strands a capturing zombie [P1]

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -583,6 +583,9 @@ export const AppShell: Component<AppShellProps> = (props) => {
     // MeetingPanel unmounting when its slide panel closes. Started once per app
     // session; torn down on shell cleanup.
     void meetingStore.startMeetingEventListeners();
+    // Fail any meeting left `capturing` by a crash/force-quit so it can't block
+    // every future capture (#2160).
+    void meetingStore.reconcileStaleCaptures();
     meetingStore.startAutoDetect();
 
     window.addEventListener("seren:open-panel", handleOpenPanel);
@@ -772,7 +775,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
       <Show when={meetingStore.state.primingRequest}>
         <AudioPrimingDialog
           onContinue={() => void meetingStore.confirmPriming()}
-          onCancel={() => meetingStore.cancelPriming()}
+          onCancel={() => void meetingStore.cancelPriming()}
         />
       </Show>
 

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -264,9 +264,36 @@ async function confirmPriming(): Promise<void> {
   await beginCapture(meeting);
 }
 
-// User dismissed the explainer: abort the pending start without capturing.
-function cancelPriming(): void {
+// User dismissed the explainer: abort the pending start. The meeting row was
+// created `capturing` before the gate, so mark it failed (mirroring the
+// mic-failure cleanup) — otherwise isCapturing() stays true forever and blocks
+// every future capture, even across restarts (#2160).
+async function cancelPriming(): Promise<void> {
+  const meeting = meetingState.primingRequest;
   setMeetingState("primingRequest", null);
+  if (!meeting || !isTauriRuntime()) return;
+  await updateMeetingStatus(meeting.id, "failed", Date.now()).catch(() => {});
+  await loadMeetings();
+}
+
+// At startup, any meeting still marked `capturing` is stale — no live capture
+// survives a restart. Mark them failed so a crashed or force-quit session
+// can't strand a zombie that blocks isCapturing() and every future start (#2160).
+async function reconcileStaleCaptures(): Promise<void> {
+  if (!isTauriRuntime()) return;
+  try {
+    const meetings = await listMeetings();
+    const stale = meetings.filter((meeting) => meeting.status === "capturing");
+    if (stale.length === 0) return;
+    await Promise.all(
+      stale.map((meeting) =>
+        updateMeetingStatus(meeting.id, "failed", Date.now()).catch(() => {}),
+      ),
+    );
+    await loadMeetings();
+  } catch {
+    // Non-fatal: the panel still loads the (possibly stale) list on open.
+  }
 }
 
 async function stopCapture(meetingId: string): Promise<void> {
@@ -514,6 +541,7 @@ export const meetingStore = {
   requestCaptureStart,
   confirmPriming,
   cancelPriming,
+  reconcileStaleCaptures,
   stopCapture,
   stopAndProcess,
   regenerateNotes,

--- a/tests/unit/meeting-priming-cancel.test.ts
+++ b/tests/unit/meeting-priming-cancel.test.ts
@@ -1,0 +1,88 @@
+// ABOUTME: Regression test for #2160 — cancelling first-run priming and startup reconcile must not strand a capturing zombie.
+// ABOUTME: A leftover `capturing` row blocks isCapturing() and every future start.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const services = vi.hoisted(() => ({
+  updateMeetingStatus: vi.fn(async () => {}),
+  listMeetings: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tauri-bridge")>()),
+  isTauriRuntime: () => true,
+}));
+vi.mock("@/services/meetings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/meetings")>()),
+  updateMeetingStatus: services.updateMeetingStatus,
+  listMeetings: services.listMeetings,
+}));
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: { get: () => false, set: vi.fn() },
+}));
+
+import type { Meeting } from "@/services/meetings";
+import { meetingStore } from "@/stores/meeting.store";
+
+function meeting(overrides: Partial<Meeting> = {}): Meeting {
+  return {
+    id: "m1",
+    title: "T",
+    sourceApp: "Manual",
+    startedAt: 0,
+    endedAt: null,
+    status: "capturing",
+    templateId: null,
+    routedSkillSlug: null,
+    agentConversationId: null,
+    notesMarkdown: null,
+    notesStructJson: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("meetingStore priming cancel + reconcile (#2160)", () => {
+  beforeEach(() => {
+    services.updateMeetingStatus.mockClear();
+    services.listMeetings.mockReset();
+    services.listMeetings.mockResolvedValue([]);
+  });
+
+  it("cancelPriming marks the stashed capturing meeting failed", async () => {
+    // Not yet primed -> requestCaptureStart stashes the (already-capturing) row.
+    await meetingStore.requestCaptureStart(meeting({ id: "z1" }));
+    expect(meetingStore.state.primingRequest?.id).toBe("z1");
+
+    await meetingStore.cancelPriming();
+
+    expect(meetingStore.state.primingRequest).toBeNull();
+    expect(services.updateMeetingStatus).toHaveBeenCalledWith(
+      "z1",
+      "failed",
+      expect.any(Number),
+    );
+    expect(services.listMeetings).toHaveBeenCalled();
+  });
+
+  it("reconcileStaleCaptures fails leftover capturing rows, leaves others", async () => {
+    services.listMeetings.mockResolvedValueOnce([
+      meeting({ id: "stale", status: "capturing" }),
+      meeting({ id: "done1", status: "done" }),
+    ]);
+
+    await meetingStore.reconcileStaleCaptures();
+
+    expect(services.updateMeetingStatus).toHaveBeenCalledWith(
+      "stale",
+      "failed",
+      expect.any(Number),
+    );
+    expect(services.updateMeetingStatus).not.toHaveBeenCalledWith(
+      "done1",
+      "failed",
+      expect.any(Number),
+    );
+  });
+});


### PR DESCRIPTION
## Problem (P1 — first-run priming cancel wedges the whole feature)

`createMeeting` writes a `MeetingStatus::Capturing` row and emits `meeting://status` **before** the first-run priming gate, so the store adds a `capturing` row while the dialog is up. The meeting is stashed in `primingRequest`; `cancelPriming` only cleared `primingRequest`, leaving the `capturing` row. Then `isCapturing()` stayed permanently true → `beginCapture` early-returned for every future start (panel/tray/auto-detect), and the zombie survived restarts (no startup reconciliation).

## Fix (`meeting.store.ts` + `AppShell.tsx`)

- `cancelPriming` now marks the stashed meeting `failed` (mirroring the mic-failure cleanup) and reloads.
- New `reconcileStaleCaptures()`, run once at `AppShell` startup, fails any meeting still `capturing` after a crash/force-quit — no live capture survives a restart.
- `AppShell`'s `onCancel` now `void`-calls the async `cancelPriming`.

## Test (`tests/unit/meeting-priming-cancel.test.ts`, vitest, green)

- `cancelPriming` after `requestCaptureStart` (un-primed) marks the stashed meeting `failed` and reloads.
- `reconcileStaleCaptures` fails a leftover `capturing` row and leaves a `done` row untouched.

Closes #2160
