### PR TITLE
fix(meeting): meeting status never reaches done/failed after agent handoff [P1]

### DIFF
--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -434,12 +434,17 @@ async function runHandoff(meeting: Meeting): Promise<void> {
   conversationStore.setActiveConversation(conversation.id);
   try {
     await orchestrate(conversation.id, prompt);
+    // The agent finished: drive the status machine to a terminal state so the
+    // meeting doesn't sit at `agent_running` forever (#2158).
+    await updateMeetingStatus(meeting.id, "done", Date.now());
   } catch (error) {
     setMeetingState(
       "error",
       error instanceof Error ? error.message : "Agent handoff failed",
     );
+    await updateMeetingStatus(meeting.id, "failed", Date.now()).catch(() => {});
   }
+  await loadMeetings();
 }
 
 async function regenerateNotes(

--- a/tests/unit/meeting-handoff-terminal.test.ts
+++ b/tests/unit/meeting-handoff-terminal.test.ts
@@ -1,0 +1,131 @@
+// ABOUTME: Regression test for #2158 — a handed-off meeting must reach done/failed, not sit at agent_running forever.
+// ABOUTME: Drives the real stopAndProcess -> runHandoff flow with the agent run mocked.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const m = vi.hoisted(() => ({
+  updateMeetingStatus: vi.fn(async () => {}),
+  listMeetings: vi.fn(async () => []),
+  generateMeetingNotes: vi.fn(async () => ({
+    markdown: "notes",
+    structured: { summary: "s", actionItems: [], fields: {} },
+  })),
+  getMeetingTranscriptText: vi.fn(async () => "hello transcript"),
+  getTranscriptSegments: vi.fn(async () => []),
+  selectMeetingSkills: vi.fn(async () => ["s"]),
+  setMeetingRoutedSkill: vi.fn(async () => {}),
+  stopMeetingCapture: vi.fn(async () => {}),
+  listMeetingTemplates: vi.fn(async () => []),
+  orchestrate: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tauri-bridge")>()),
+  isTauriRuntime: () => true,
+}));
+vi.mock("@/services/meetings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/meetings")>()),
+  updateMeetingStatus: m.updateMeetingStatus,
+  listMeetings: m.listMeetings,
+  generateMeetingNotes: m.generateMeetingNotes,
+  getMeetingTranscriptText: m.getMeetingTranscriptText,
+  getTranscriptSegments: m.getTranscriptSegments,
+  selectMeetingSkills: m.selectMeetingSkills,
+  setMeetingRoutedSkill: m.setMeetingRoutedSkill,
+  stopMeetingCapture: m.stopMeetingCapture,
+  listMeetingTemplates: m.listMeetingTemplates,
+}));
+vi.mock("@/services/orchestrator", () => ({ orchestrate: m.orchestrate }));
+vi.mock("@/services/captureWidget", () => ({
+  closeCaptureWidget: vi.fn(),
+  openCaptureWidget: vi.fn(),
+  onWidgetStopRequest: vi.fn(() => () => {}),
+}));
+vi.mock("@/services/tray", () => ({
+  setTrayRecording: vi.fn(),
+  onTrayToggleCapture: vi.fn(() => () => {}),
+}));
+vi.mock("@/stores/conversation.store", () => ({
+  conversationStore: {
+    createConversationWithModel: vi.fn(async () => ({ id: "c1" })),
+    setActiveConversation: vi.fn(),
+  },
+}));
+vi.mock("@/stores/provider.store", () => ({
+  providerStore: { resolvedModel: () => "model", activeModel: "model" },
+}));
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: (key: string) =>
+      key === "meetingCustomTemplates" || key === "voiceCustomVocabulary"
+        ? []
+        : undefined,
+    set: vi.fn(),
+  },
+}));
+vi.mock("@/stores/skills.store", () => ({
+  skillsStore: {
+    enabledSkills: [
+      { slug: "s", name: "S", description: "", tags: ["meeting"], path: "/p" },
+    ],
+  },
+}));
+
+import type { Meeting } from "@/services/meetings";
+import { meetingStore } from "@/stores/meeting.store";
+
+function meeting(overrides: Partial<Meeting> = {}): Meeting {
+  return {
+    id: "m1",
+    title: "Sync",
+    sourceApp: "Manual",
+    startedAt: 0,
+    endedAt: 100,
+    status: "capturing",
+    templateId: null,
+    routedSkillSlug: null,
+    agentConversationId: null,
+    notesMarkdown: "notes",
+    notesStructJson: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("meetingStore handoff terminal status (#2158)", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(m)) fn.mockClear();
+    m.listMeetings.mockResolvedValue([meeting()]);
+  });
+
+  it("sets done after the agent run resolves", async () => {
+    m.orchestrate.mockResolvedValueOnce(undefined);
+
+    await meetingStore.stopAndProcess(meeting());
+
+    expect(m.orchestrate).toHaveBeenCalledTimes(1);
+    expect(m.updateMeetingStatus).toHaveBeenCalledWith(
+      "m1",
+      "done",
+      expect.any(Number),
+    );
+  });
+
+  it("sets failed when the agent run rejects", async () => {
+    m.orchestrate.mockRejectedValueOnce(new Error("boom"));
+
+    await meetingStore.stopAndProcess(meeting());
+
+    expect(m.updateMeetingStatus).toHaveBeenCalledWith(
+      "m1",
+      "failed",
+      expect.any(Number),
+    );
+    expect(m.updateMeetingStatus).not.toHaveBeenCalledWith(
+      "m1",
+      "done",
+      expect.any(Number),
+    );
+  });
+});


### PR DESCRIPTION
## Problem (P1 — status machine never terminates)

`runHandoff` set `agent_running` then `await orchestrate(...)`, but no code (store, orchestrator completion, or Rust) ever wrote `done`/`failed` afterward. A handed-off meeting sat at "Agent running" forever; the library never showed a meeting reaching `done`/`failed`.

## Fix (`meeting.store.ts`)

In `runHandoff`, after `await orchestrate(...)` resolves set `done`; in the `catch` set `failed` (it previously only set `state.error`). Reload the library after.

(No-skill / no-transcript paths still rest at `notes_ready` as designed — Granola parity; only the agent-run path was the non-terminating one.)

## Test (`tests/unit/meeting-handoff-terminal.test.ts`, vitest, green)

Drives the real `stopAndProcess → runHandoff` flow with the agent run mocked:
- `orchestrate` resolves → `updateMeetingStatus(id, "done", <ts>)`.
- `orchestrate` rejects → `updateMeetingStatus(id, "failed", <ts>)` and never `"done"`.

Closes #2158
