### PR TITLE
fix(meeting): concurrent Stop (widget/tray/panel) double-runs notes + agent handoff [P1]

### DIFF
--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -86,6 +86,11 @@ const AUTO_DETECT_POLL_MS = 5_000;
 // so a double-trigger can't launch two mic streams for the same session.
 let isStarting = false;
 
+// Stops in flight, keyed by meeting id. Two stop sources (widget + panel, tray +
+// panel) can fire near-simultaneously and both pass the status check, double-
+// running notes + the agent handoff. This guard makes the second a no-op (#2162).
+const processingMeetings = new Set<string>();
+
 async function loadMeetings(): Promise<void> {
   setMeetingState("isLoading", true);
   setMeetingState("error", null);
@@ -356,41 +361,51 @@ async function resolveTemplatePrompt(
 }
 
 // End capture, generate Tier-1 notes, then hand off to a tagged skill if one is
-// installed. With no meeting skill, it stops at notes (Granola parity).
+// installed. With no meeting skill, it stops at notes (Granola parity). A single
+// in-flight guard per meeting keeps two near-simultaneous stop sources (widget,
+// tray, panel) from double-running notes + the agent handoff (#2162).
 async function stopAndProcess(meeting: Meeting): Promise<void> {
-  await stopCapture(meeting.id);
-  await loadMeetings();
-  if (!isTauriRuntime()) return;
-
-  const templatePrompt = await resolveTemplatePrompt(meeting.templateId);
+  if (processingMeetings.has(meeting.id)) return;
+  processingMeetings.add(meeting.id);
   try {
-    await generateMeetingNotes({
-      meetingId: meeting.id,
-      model: providerStore.resolvedModel(),
-      templatePrompt,
-      vocabulary: settingsStore.get("voiceCustomVocabulary"),
-    });
-  } catch (error) {
-    // Notes failed: the backend left the meeting at `transcribing` (it only
-    // sets notes_ready on success). Mark it failed and stop — don't fall
-    // through to runHandoff and auto-invoke a skill on an empty meeting (#2159).
-    setMeetingState(
-      "error",
-      error instanceof Error ? error.message : "Notes generation failed",
-    );
-    await updateMeetingStatus(meeting.id, "failed", Date.now()).catch(() => {});
+    await stopCapture(meeting.id);
     await loadMeetings();
-    await setActiveMeeting(
-      meetingState.meetings.find((m) => m.id === meeting.id) ?? null,
-    );
-    return;
-  }
-  await loadMeetings();
-  const refreshed =
-    meetingState.meetings.find((m) => m.id === meeting.id) ?? null;
-  await setActiveMeeting(refreshed);
+    if (!isTauriRuntime()) return;
 
-  await runHandoff(meeting);
+    const templatePrompt = await resolveTemplatePrompt(meeting.templateId);
+    try {
+      await generateMeetingNotes({
+        meetingId: meeting.id,
+        model: providerStore.resolvedModel(),
+        templatePrompt,
+        vocabulary: settingsStore.get("voiceCustomVocabulary"),
+      });
+    } catch (error) {
+      // Notes failed: the backend left the meeting at `transcribing` (it only
+      // sets notes_ready on success). Mark it failed and stop — don't fall
+      // through to runHandoff and auto-invoke a skill on an empty meeting (#2159).
+      setMeetingState(
+        "error",
+        error instanceof Error ? error.message : "Notes generation failed",
+      );
+      await updateMeetingStatus(meeting.id, "failed", Date.now()).catch(
+        () => {},
+      );
+      await loadMeetings();
+      await setActiveMeeting(
+        meetingState.meetings.find((m) => m.id === meeting.id) ?? null,
+      );
+      return;
+    }
+    await loadMeetings();
+    const refreshed =
+      meetingState.meetings.find((m) => m.id === meeting.id) ?? null;
+    await setActiveMeeting(refreshed);
+
+    await runHandoff(meeting);
+  } finally {
+    processingMeetings.delete(meeting.id);
+  }
 }
 
 async function runHandoff(meeting: Meeting): Promise<void> {

--- a/tests/unit/meeting-concurrent-stop.test.ts
+++ b/tests/unit/meeting-concurrent-stop.test.ts
@@ -1,0 +1,120 @@
+// ABOUTME: Regression test for #2162 — concurrent stop sources must not double-run notes + agent handoff.
+// ABOUTME: Two near-simultaneous stops (widget/tray/panel) for one meeting should process it once.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const m = vi.hoisted(() => ({
+  updateMeetingStatus: vi.fn(async () => {}),
+  listMeetings: vi.fn(async () => []),
+  generateMeetingNotes: vi.fn(async () => ({
+    markdown: "notes",
+    structured: { summary: "s", actionItems: [], fields: {} },
+  })),
+  getMeetingTranscriptText: vi.fn(async () => "hello transcript"),
+  getTranscriptSegments: vi.fn(async () => []),
+  selectMeetingSkills: vi.fn(async () => ["s"]),
+  setMeetingRoutedSkill: vi.fn(async () => {}),
+  stopMeetingCapture: vi.fn(async () => {}),
+  listMeetingTemplates: vi.fn(async () => []),
+  orchestrate: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tauri-bridge")>()),
+  isTauriRuntime: () => true,
+}));
+vi.mock("@/services/meetings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/meetings")>()),
+  updateMeetingStatus: m.updateMeetingStatus,
+  listMeetings: m.listMeetings,
+  generateMeetingNotes: m.generateMeetingNotes,
+  getMeetingTranscriptText: m.getMeetingTranscriptText,
+  getTranscriptSegments: m.getTranscriptSegments,
+  selectMeetingSkills: m.selectMeetingSkills,
+  setMeetingRoutedSkill: m.setMeetingRoutedSkill,
+  stopMeetingCapture: m.stopMeetingCapture,
+  listMeetingTemplates: m.listMeetingTemplates,
+}));
+vi.mock("@/services/orchestrator", () => ({ orchestrate: m.orchestrate }));
+vi.mock("@/services/captureWidget", () => ({
+  closeCaptureWidget: vi.fn(),
+  openCaptureWidget: vi.fn(),
+  onWidgetStopRequest: vi.fn(() => () => {}),
+}));
+vi.mock("@/services/tray", () => ({
+  setTrayRecording: vi.fn(),
+  onTrayToggleCapture: vi.fn(() => () => {}),
+}));
+vi.mock("@/stores/conversation.store", () => ({
+  conversationStore: {
+    createConversationWithModel: vi.fn(async () => ({ id: "c1" })),
+    setActiveConversation: vi.fn(),
+  },
+}));
+vi.mock("@/stores/provider.store", () => ({
+  providerStore: { resolvedModel: () => "model", activeModel: "model" },
+}));
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: (key: string) =>
+      key === "meetingCustomTemplates" || key === "voiceCustomVocabulary"
+        ? []
+        : undefined,
+    set: vi.fn(),
+  },
+}));
+vi.mock("@/stores/skills.store", () => ({
+  skillsStore: {
+    enabledSkills: [
+      { slug: "s", name: "S", description: "", tags: ["meeting"], path: "/p" },
+    ],
+  },
+}));
+
+import type { Meeting } from "@/services/meetings";
+import { meetingStore } from "@/stores/meeting.store";
+
+function meeting(overrides: Partial<Meeting> = {}): Meeting {
+  return {
+    id: "m1",
+    title: "Sync",
+    sourceApp: "Manual",
+    startedAt: 0,
+    endedAt: 100,
+    status: "capturing",
+    templateId: null,
+    routedSkillSlug: null,
+    agentConversationId: null,
+    notesMarkdown: "notes",
+    notesStructJson: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("meetingStore concurrent stop guard (#2162)", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(m)) fn.mockClear();
+    m.listMeetings.mockResolvedValue([meeting()]);
+  });
+
+  it("processes a meeting once when two stops fire near-simultaneously", async () => {
+    // Two stop sources race for the same meeting (e.g. widget relay + panel).
+    await Promise.all([
+      meetingStore.stopAndProcess(meeting()),
+      meetingStore.stopAndProcess(meeting()),
+    ]);
+
+    expect(m.generateMeetingNotes).toHaveBeenCalledTimes(1);
+    expect(m.orchestrate).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a fresh stop after the first one finishes", async () => {
+    await meetingStore.stopAndProcess(meeting());
+    await meetingStore.stopAndProcess(meeting());
+
+    expect(m.generateMeetingNotes).toHaveBeenCalledTimes(2);
+    expect(m.orchestrate).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Problem (P1 — concurrent Stop double-runs notes + agent handoff)

Two stop sources (widget + panel, or tray + panel) firing near-simultaneously both pass the status check → `generateMeetingNotes` runs twice and `runHandoff` creates two agent conversations / two `orchestrate()` calls (two CRM-bound runs). `stopAndProcess`/`runHandoff` had no shared in-flight guard, and the `capturing → transcribing` flip lands only after `stopCapture() → loadMeetings()`, so both callers pass.

## Fix (`meeting.store.ts`)

A module-level in-flight `Set<meetingId>` (`processingMeetings`), symmetric to the `isStarting` guard: `stopAndProcess` returns early if the meeting is already being processed, and clears the entry in a `finally`.

## Test (`tests/unit/meeting-concurrent-stop.test.ts`, vitest, green)

- Two near-simultaneous `stopAndProcess` calls for one meeting → `generateMeetingNotes` and `orchestrate` each run exactly once.
- A fresh stop after the first finishes still runs (guard releases).

Closes #2162
