### PR TITLE
fix(meeting): ended_at wiped on agent_running transition corrupts persisted duration [P2]

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -450,8 +450,14 @@ pub fn update_meeting_status_record(
     ended_at: Option<i64>,
     updated_at: i64,
 ) -> Result<()> {
+    // `ended_at` is set once, when capture stops. COALESCE keeps the existing
+    // value when the caller passes None (status-only transitions like
+    // agent_running/done), so the capture-end time survives the agent handoff
+    // instead of being nulled and later overwritten with the agent-finish time
+    // (#2174). A Some value still overwrites (e.g. stop_meeting_capture).
     conn.execute(
-        "UPDATE meetings SET status = ?1, ended_at = ?2, updated_at = ?3 WHERE id = ?4",
+        "UPDATE meetings SET status = ?1, ended_at = COALESCE(?2, ended_at), updated_at = ?3
+         WHERE id = ?4",
         params![status.as_str(), ended_at, updated_at, id],
     )?;
     Ok(())
@@ -660,6 +666,44 @@ mod tests {
         assert_eq!(loaded.title, "Customer discovery");
         assert_eq!(loaded.source_app.as_deref(), Some("Zoom"));
         assert_eq!(loaded.template_id.as_deref(), Some("discovery"));
+    }
+
+    #[test]
+    fn status_update_preserves_ended_at_unless_overwritten() {
+        // #2174: ended_at is stamped once at capture stop; status-only transitions
+        // (None) must preserve it; a Some value still overwrites.
+        let conn = setup();
+        insert_meeting(&conn, meeting("meeting-1")).unwrap();
+
+        // Capture stops: ended_at set.
+        update_meeting_status_record(
+            &conn,
+            "meeting-1",
+            MeetingStatus::Transcribing,
+            Some(500),
+            501,
+        )
+        .unwrap();
+        // Status-only transition (handoff): None must keep ended_at = 500.
+        update_meeting_status_record(&conn, "meeting-1", MeetingStatus::AgentRunning, None, 600)
+            .unwrap();
+        assert_eq!(
+            select_meeting(&conn, "meeting-1").unwrap().unwrap().ended_at,
+            Some(500)
+        );
+        // Done with None still preserves the capture-end time.
+        update_meeting_status_record(&conn, "meeting-1", MeetingStatus::Done, None, 700).unwrap();
+        assert_eq!(
+            select_meeting(&conn, "meeting-1").unwrap().unwrap().ended_at,
+            Some(500)
+        );
+        // A Some value overwrites.
+        update_meeting_status_record(&conn, "meeting-1", MeetingStatus::Failed, Some(900), 901)
+            .unwrap();
+        assert_eq!(
+            select_meeting(&conn, "meeting-1").unwrap().unwrap().ended_at,
+            Some(900)
+        );
     }
 
     #[test]

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -281,18 +281,24 @@ async function cancelPriming(): Promise<void> {
   await loadMeetings();
 }
 
-// At startup, any meeting still marked `capturing` is stale — no live capture
-// survives a restart. Mark them failed so a crashed or force-quit session
-// can't strand a zombie that blocks isCapturing() and every future start (#2160).
+// At startup, any meeting left mid-pipeline is stale — no capture, notes pass,
+// or agent run survives a restart. `capturing` zombies block isCapturing() and
+// every future start (#2160); `transcribing`/`agent_running` zombies show a
+// misleading badge and (for agent_running) a runaway timer (#2174). Fail them
+// all; ended_at is preserved (no arg) where the capture had already ended.
+const STALE_STATUSES = new Set(["capturing", "transcribing", "agent_running"]);
+
 async function reconcileStaleCaptures(): Promise<void> {
   if (!isTauriRuntime()) return;
   try {
     const meetings = await listMeetings();
-    const stale = meetings.filter((meeting) => meeting.status === "capturing");
+    const stale = meetings.filter((meeting) =>
+      STALE_STATUSES.has(meeting.status),
+    );
     if (stale.length === 0) return;
     await Promise.all(
       stale.map((meeting) =>
-        updateMeetingStatus(meeting.id, "failed", Date.now()).catch(() => {}),
+        updateMeetingStatus(meeting.id, "failed").catch(() => {}),
       ),
     );
     await loadMeetings();
@@ -463,14 +469,16 @@ async function runHandoff(meeting: Meeting): Promise<void> {
   try {
     await orchestrate(conversation.id, prompt);
     // The agent finished: drive the status machine to a terminal state so the
-    // meeting doesn't sit at `agent_running` forever (#2158).
-    await updateMeetingStatus(meeting.id, "done", Date.now());
+    // meeting doesn't sit at `agent_running` forever (#2158). Pass no ended_at
+    // so the capture-end timestamp set at stop survives instead of being
+    // overwritten with the agent-finish time (#2174).
+    await updateMeetingStatus(meeting.id, "done");
   } catch (error) {
     setMeetingState(
       "error",
       error instanceof Error ? error.message : "Agent handoff failed",
     );
-    await updateMeetingStatus(meeting.id, "failed", Date.now()).catch(() => {});
+    await updateMeetingStatus(meeting.id, "failed").catch(() => {});
   }
   await loadMeetings();
 }

--- a/tests/unit/meeting-concurrent-stop.test.ts
+++ b/tests/unit/meeting-concurrent-stop.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const m = vi.hoisted(() => ({
   updateMeetingStatus: vi.fn(async () => {}),
-  listMeetings: vi.fn(async () => []),
+  listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
   generateMeetingNotes: vi.fn(async () => ({
     markdown: "notes",
     structured: { summary: "s", actionItems: [], fields: {} },

--- a/tests/unit/meeting-handoff-terminal.test.ts
+++ b/tests/unit/meeting-handoff-terminal.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const m = vi.hoisted(() => ({
   updateMeetingStatus: vi.fn(async () => {}),
-  listMeetings: vi.fn(async () => []),
+  listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
   generateMeetingNotes: vi.fn(async () => ({
     markdown: "notes",
     structured: { summary: "s", actionItems: [], fields: {} },
@@ -105,11 +105,8 @@ describe("meetingStore handoff terminal status (#2158)", () => {
     await meetingStore.stopAndProcess(meeting());
 
     expect(m.orchestrate).toHaveBeenCalledTimes(1);
-    expect(m.updateMeetingStatus).toHaveBeenCalledWith(
-      "m1",
-      "done",
-      expect.any(Number),
-    );
+    // Terminal transition carries no ended_at so the capture-end time survives (#2174).
+    expect(m.updateMeetingStatus).toHaveBeenCalledWith("m1", "done");
   });
 
   it("sets failed when the agent run rejects", async () => {
@@ -117,15 +114,7 @@ describe("meetingStore handoff terminal status (#2158)", () => {
 
     await meetingStore.stopAndProcess(meeting());
 
-    expect(m.updateMeetingStatus).toHaveBeenCalledWith(
-      "m1",
-      "failed",
-      expect.any(Number),
-    );
-    expect(m.updateMeetingStatus).not.toHaveBeenCalledWith(
-      "m1",
-      "done",
-      expect.any(Number),
-    );
+    expect(m.updateMeetingStatus).toHaveBeenCalledWith("m1", "failed");
+    expect(m.updateMeetingStatus).not.toHaveBeenCalledWith("m1", "done");
   });
 });

--- a/tests/unit/meeting-notes-failure-gate.test.ts
+++ b/tests/unit/meeting-notes-failure-gate.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const m = vi.hoisted(() => ({
   updateMeetingStatus: vi.fn(async () => {}),
-  listMeetings: vi.fn(async () => []),
+  listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
   generateMeetingNotes: vi.fn(async () => ({
     markdown: "notes",
     structured: { summary: "s", actionItems: [], fields: {} },

--- a/tests/unit/meeting-priming-cancel.test.ts
+++ b/tests/unit/meeting-priming-cancel.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const services = vi.hoisted(() => ({
   updateMeetingStatus: vi.fn(async () => {}),
-  listMeetings: vi.fn(async () => []),
+  listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
 }));
 
 vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
@@ -66,23 +66,28 @@ describe("meetingStore priming cancel + reconcile (#2160)", () => {
     expect(services.listMeetings).toHaveBeenCalled();
   });
 
-  it("reconcileStaleCaptures fails leftover capturing rows, leaves others", async () => {
+  it("reconcileStaleCaptures fails leftover mid-pipeline rows, leaves terminal ones", async () => {
     services.listMeetings.mockResolvedValueOnce([
-      meeting({ id: "stale", status: "capturing" }),
+      meeting({ id: "cap", status: "capturing" }),
+      meeting({ id: "trans", status: "transcribing" }),
+      meeting({ id: "agent", status: "agent_running" }),
       meeting({ id: "done1", status: "done" }),
+      meeting({ id: "notes", status: "notes_ready" }),
     ]);
 
     await meetingStore.reconcileStaleCaptures();
 
-    expect(services.updateMeetingStatus).toHaveBeenCalledWith(
-      "stale",
-      "failed",
-      expect.any(Number),
-    );
-    expect(services.updateMeetingStatus).not.toHaveBeenCalledWith(
-      "done1",
-      "failed",
-      expect.any(Number),
-    );
+    // Fail every mid-pipeline zombie, with no ended_at so a captured row keeps
+    // its capture-end time (#2174).
+    for (const id of ["cap", "trans", "agent"]) {
+      expect(services.updateMeetingStatus).toHaveBeenCalledWith(id, "failed");
+    }
+    // Terminal/resting rows are left alone.
+    for (const id of ["done1", "notes"]) {
+      expect(services.updateMeetingStatus).not.toHaveBeenCalledWith(
+        id,
+        "failed",
+      );
+    }
   });
 });


### PR DESCRIPTION
## Severity: P2 — `ended_at` wiped on the agent handoff, corrupting persisted meeting duration

Found by the post-#2158/#2164 functional audit.

### Problem
`update_meeting_status_record` wrote `ended_at = ?2` unconditionally. `stop_meeting_capture` stamps `ended_at = Some(capture-end)`, but `runHandoff`'s status-only `agent_running` transition (no `endedAt`) NULLed it, and the #2158 `done` transition then stored `Date.now()` — the **agent-finish** time, not capture-end. Result: every skill-handoff meeting persists a duration of `capture length + entire agent runtime`.

### Fix
- Rust: `ended_at = COALESCE(?2, ended_at)` — `None` preserves the existing value (set once at capture stop), `Some` overwrites (e.g. `stop_meeting_capture`).
- `runHandoff` `done`/`failed` now pass no `endedAt`, so the capture-end time survives.
- Broaden `reconcileStaleCaptures` to also fail `transcribing`/`agent_running` zombies left by a crash (recoverable via Regenerate, but they showed a misleading badge / runaway timer).
- Type the four meeting store-test `listMeetings` mocks so `tsc --noEmit` is clean (they inferred `never[]`).

### Tests (green)
- Rust `cargo test --lib`: `status_update_preserves_ended_at_unless_overwritten` — None preserves through agent_running/done, Some overwrites.
- vitest: updated `meeting-handoff-terminal` (done/failed carry no ended_at) and `meeting-priming-cancel` (reconcile fails capturing/transcribing/agent_running, leaves done/notes_ready). Full suite green; `tsc --noEmit` = 0 errors.

Closes #2174
