### PR TITLE
fix(e2e): stabilize flaky thread-sidebar count against async seed race

### DIFF
--- a/tests/e2e/thread-lifecycle.spec.ts
+++ b/tests/e2e/thread-lifecycle.spec.ts
@@ -46,6 +46,13 @@ test.describe("Thread Lifecycle", () => {
   });
 
   test("creating a chat thread adds it to the sidebar", async ({ page }) => {
+    // Browser-fallback seeds one default chat thread on load (loadHistory's
+    // catch path, #1630). Wait for that seeded thread to render before sampling
+    // the baseline — otherwise the count is captured mid-hydration and races the
+    // seed, giving threadsBefore=0 and a final count of 2 (flaky, #2179).
+    await expect(page.getByTestId("thread-item").first()).toBeVisible({
+      timeout: 10_000,
+    });
     const threadsBefore = await page.getByTestId("thread-item").count();
 
     await page.getByTestId("new-thread-button").click();


### PR DESCRIPTION
## Auto-filed CI failure (#2179): `test-e2e` flaked on main

`tests/e2e/thread-lifecycle.spec.ts:48 "creating a chat thread adds it to the sidebar"` intermittently failed with `toHaveCount` expected `1`, received `2`.

### Root cause (test-timing race, not an app bug)
In browser-fallback mode (the production-bundle E2E, no Tauri), `conversationStore.loadHistory()` throws (`listConversations` requires Tauri), hits its `catch`, and **asynchronously seeds one default chat thread** (the #1630 first-launch behavior). The test sampled `threadsBefore` immediately after load:
- seed renders **before** the sample → `threadsBefore=1` → create → `2` → assert `1+1=2` ✓
- seed renders **after** the sample → `threadsBefore=0` → create (seed also lands) → `2` → assert `0+1=1` ✗

The assertion stayed at 2 for the full 10s timeout — i.e. a genuine baseline race, not a transient. The app does **not** double-create; it seeds one default + one from the click.

### Fix
Wait for the seeded thread to render (`getByTestId("thread-item").first()` visible) **before** sampling `threadsBefore`, so the baseline is deterministic. No app change.

### Verification
Reproducing a CI-timing flake on a fast local machine is unreliable (the old test passes locally because the seed lands before the sample), so the meaningful gate is CI itself — where it flaked. This PR's `test-e2e` job runs the exact prod-bundle suite; I'll also re-run it to confirm stability.

Closes #2179
