### PR TITLE
fix(audio): start() blocks a tokio worker across native init; run on blocking pool [P2]

### DIFF
--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -209,7 +209,10 @@ pub fn transcription_mode_for(speaker: &Speaker) -> TranscriptionMode {
 const STOP_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Tauri-managed registry of active meeting captures, keyed by meeting id.
-#[derive(Default)]
+///
+/// `Clone` shares the same `active` map (it only wraps an `Arc`), so the start
+/// command can hand a handle to a blocking thread without copying state (#2176).
+#[derive(Default, Clone)]
 pub struct CaptureRegistry {
     active: Arc<StdMutex<HashMap<String, CaptureSlot>>>,
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -178,7 +178,13 @@ pub async fn start_meeting_capture(
     registry: State<'_, CaptureRegistry>,
     meeting_id: String,
 ) -> Result<(), String> {
-    registry.start(&app, &meeting_id);
+    // start() blocks on native WASAPI/Core Audio init (#2157). Run it on the
+    // blocking pool so it never stalls a tokio worker thread; the registry is an
+    // Arc handle, so the clone shares the same state (#2176).
+    let registry = (*registry).clone();
+    tauri::async_runtime::spawn_blocking(move || registry.start(&app, &meeting_id))
+        .await
+        .map_err(|err| err.to_string())?;
     Ok(())
 }
 


### PR DESCRIPTION
## Severity: P2 — meeting capture `start()` blocks a tokio worker thread

Found by the post-#2157 functional audit (#2176).

### Problem
`start_meeting_capture` (an `async` command) called the synchronous `registry.start(&app, &meeting_id)` directly in the command body. Since #2157 made `start()` block until native WASAPI / Core Audio init completes (the readiness handshake), that init runs **on a tokio async-runtime worker thread**, blocking it for the whole init; concurrent starts could starve the pool.

### Fix
Run `start()` via `tauri::async_runtime::spawn_blocking` so it executes on the blocking pool and never stalls an async worker. `CaptureRegistry` now derives `Clone` — it only wraps an `Arc`, so the handle handed to the blocking closure shares the same `active` map. The `start()` logic is otherwise unchanged (same lock, same guard, same task spawns), so behavior is identical.

### Scope note (honest)
This addresses the ticket's primary harm — blocking the async executor. The registry mutex is still briefly held across `source.start()` (now on the blocking thread), so a *second concurrent meeting's* `push_frame`/`is_active` could stall on the lock during that init window. Fully removing that would require a reserve-build restructure (a `Starting` slot state + stop-during-start handling) — meaningful concurrency surface for a concurrent-meeting flow the app doesn't actually do (YAGNI + risk I can't Windows-runtime-validate). Filed-as-residual; not pursued.

### Verification
`cargo test --lib` green (52 audio tests; behavior-preserving). No new unit test: this is a threading/glue change in an IPC command (no new testable logic; testing it would require a mocked Tauri harness, which the project forbids). CI's Windows build compiles the path.

Closes #2176
