### PR TITLE
feat(meeting): post-call diarization for stable speaker IDs (#2183)

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -9,6 +9,7 @@ pub mod llm;
 pub mod merge;
 pub mod notes;
 pub mod pipeline;
+pub mod reconcile;
 pub mod templates;
 pub mod transcribe;
 pub mod types;

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -13,7 +13,7 @@ use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use uuid::Uuid;
 
-use crate::audio::capture::{AudioCaptureSource, PcmFrame};
+use crate::audio::capture::{AudioCaptureSource, PcmFrame, TARGET_SAMPLE_RATE};
 use crate::audio::chunker::{Chunk, ChunkCfg, StreamingChunker};
 use crate::audio::transcribe::{
     ChunkTranscriber, GatewayTranscriber, RetryConfig, TranscriptionMode,
@@ -29,9 +29,21 @@ pub trait SegmentSink: Send + Sync {
     async fn segment(&self, segment: TranscriptSegment);
 }
 
+/// Cap on the in-memory Them PCM buffer kept for the post-call diarization pass:
+/// ~90 minutes of 16 kHz mono i16 (≈173 MB). Past this the buffer stops growing
+/// so a marathon meeting can't exhaust memory; the post-call pass still covers the
+/// first ~90 minutes. Nothing is written to disk (privacy rule #2125).
+const MAX_THEM_BUFFER_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 60 * 90;
+
 /// Drive one capture stream end to end: read frames, chunk on silence, transcribe
 /// each window with retry, and hand finished segments to `sink`. A failed window
 /// becomes a `Gap` segment so audio is never silently dropped.
+///
+/// When `them_buffer` is `Some` (the Them stream only), each frame's samples are
+/// also appended to the shared buffer for the post-call diarization pass, capped
+/// at [`MAX_THEM_BUFFER_SAMPLES`]. The Me stream passes `None` and is never
+/// buffered. The lock-and-extend is per-frame and off the transcription path, so
+/// it does not slow the chunk/transcribe loop.
 pub async fn run_capture_stream(
     meeting_id: String,
     speaker: Speaker,
@@ -41,9 +53,13 @@ pub async fn run_capture_stream(
     cfg: ChunkCfg,
     retry: RetryConfig,
     sink: Arc<dyn SegmentSink>,
+    them_buffer: Option<Arc<StdMutex<Vec<i16>>>>,
 ) {
     let mut chunker = StreamingChunker::new(cfg);
     while let Some(frame) = frames.recv().await {
+        if let Some(buffer) = them_buffer.as_ref() {
+            buffer_them_samples(buffer, &frame.samples);
+        }
         for chunk in chunker.push(&frame.samples) {
             emit_segment(&meeting_id, &speaker, chunk, transcriber.as_ref(), retry, &seq, sink.as_ref())
                 .await;
@@ -53,6 +69,19 @@ pub async fn run_capture_stream(
         emit_segment(&meeting_id, &speaker, chunk, transcriber.as_ref(), retry, &seq, sink.as_ref())
             .await;
     }
+}
+
+/// Append a frame's samples to the Them buffer, stopping at the cap. Once full the
+/// buffer is frozen rather than ring-rotated so the post-call pass keeps a single
+/// contiguous timeline that lines up with the live segment timestamps.
+fn buffer_them_samples(buffer: &StdMutex<Vec<i16>>, samples: &[i16]) {
+    let mut buffer = buffer.lock().unwrap();
+    if buffer.len() >= MAX_THEM_BUFFER_SAMPLES {
+        return;
+    }
+    let remaining = MAX_THEM_BUFFER_SAMPLES - buffer.len();
+    let take = remaining.min(samples.len());
+    buffer.extend_from_slice(&samples[..take]);
 }
 
 async fn emit_segment(
@@ -159,6 +188,9 @@ struct ActiveCapture {
     // Native system-audio source (WASAPI loopback / Core Audio tap) feeding `them_tx`.
     system_source: Option<Box<dyn AudioCaptureSource>>,
     tasks: Vec<JoinHandle<()>>,
+    // Full Them PCM buffered in memory for the post-call diarization pass. The
+    // Them worker appends frames here; `stop` takes it for [`reconcile_meeting_speakers`].
+    them_audio: Arc<StdMutex<Vec<i16>>>,
 }
 
 /// A meeting's slot in the registry. `Stopping` is a tombstone left in the map
@@ -215,6 +247,10 @@ const STOP_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Default, Clone)]
 pub struct CaptureRegistry {
     active: Arc<StdMutex<HashMap<String, CaptureSlot>>>,
+    // Them PCM handed off by `stop`, keyed by meeting id, awaiting the post-call
+    // diarization pass. `reconcile_meeting_speakers` removes its entry; the buffer
+    // lives only in memory and is dropped once consumed (privacy rule #2125).
+    finished_them_audio: Arc<StdMutex<HashMap<String, Vec<i16>>>>,
 }
 
 impl CaptureRegistry {
@@ -237,6 +273,7 @@ impl CaptureRegistry {
         );
         let me_sink: Arc<dyn SegmentSink> = Arc::new(DbEmitSink { app: app.clone() });
         let (me_tx, me_rx) = unbounded_channel();
+        // The Me mic is single-speaker; it is never buffered for the post-call pass.
         let mut tasks = vec![tauri::async_runtime::spawn(run_capture_stream(
             meeting_id.to_string(),
             Speaker::Me,
@@ -246,7 +283,11 @@ impl CaptureRegistry {
             ChunkCfg::default(),
             RetryConfig::default(),
             me_sink,
+            None,
         ))];
+
+        // Shared buffer the Them worker fills for the post-call diarization pass.
+        let them_audio: Arc<StdMutex<Vec<i16>>> = Arc::new(StdMutex::new(Vec::new()));
 
         // System audio ("Them") via the native loopback/tap source, when supported.
         let mut them_tx = None;
@@ -266,6 +307,7 @@ impl CaptureRegistry {
                 ChunkCfg::default(),
                 RetryConfig::default(),
                 them_sink,
+                Some(them_audio.clone()),
             )));
             match source.start(tx.clone()) {
                 Ok(()) => them_tx = Some(tx),
@@ -282,6 +324,7 @@ impl CaptureRegistry {
                 them_tx,
                 system_source,
                 tasks,
+                them_audio,
             }),
         );
     }
@@ -376,9 +419,26 @@ impl CaptureRegistry {
                 log::warn!("[meeting] capture worker drain timed out for {meeting_id}; detaching");
             }
         }
+        // The workers have flushed: take the buffered Them PCM out of the capture
+        // (before it drops) and hand it to the post-call diarization pass. Done
+        // after the drain so any tail frames the Them worker buffered are included.
+        let buffered = std::mem::take(&mut *capture.them_audio.lock().unwrap());
+        if !buffered.is_empty() {
+            self.finished_them_audio
+                .lock()
+                .unwrap()
+                .insert(meeting_id.to_string(), buffered);
+        }
         // Always clear the tombstone — even on a timed-out drain — so the id is
         // never permanently blocked from a fresh capture (#2175).
         self.finish_stop(meeting_id);
+    }
+
+    /// Remove and return the Them PCM buffered for `meeting_id`'s post-call pass,
+    /// if any. The buffer is consumed once: a second call returns `None`, so the
+    /// in-memory audio is not retained after the reconcile pass reads it.
+    pub fn take_finished_them_audio(&self, meeting_id: &str) -> Option<Vec<i16>> {
+        self.finished_them_audio.lock().unwrap().remove(meeting_id)
     }
 }
 
@@ -470,6 +530,7 @@ mod tests {
                 max_backoff_ms: 0,
             },
             collected,
+            None,
         )
         .await;
 
@@ -512,6 +573,7 @@ mod tests {
                 max_backoff_ms: 0,
             },
             collected,
+            None,
         )
         .await;
 
@@ -547,6 +609,7 @@ mod tests {
                 them_tx: None,
                 system_source: None,
                 tasks: Vec::new(),
+                them_audio: Arc::new(StdMutex::new(Vec::new())),
             }),
         );
         assert!(registry.is_active("m1"));
@@ -589,6 +652,7 @@ mod tests {
                 them_tx: None,
                 system_source: None,
                 tasks: vec![hung],
+                them_audio: Arc::new(StdMutex::new(Vec::new())),
             }),
         );
 

--- a/src-tauri/src/audio/reconcile.rs
+++ b/src-tauri/src/audio/reconcile.rs
@@ -1,0 +1,161 @@
+// ABOUTME: Maps meeting-stable diarization labels onto live Them transcript segments.
+// ABOUTME: Pure time-overlap reconciliation, unit-tested independent of any I/O.
+
+use crate::audio::transcribe::DiarizedSegment;
+use crate::audio::types::TranscriptSegment;
+
+/// Milliseconds of overlap between two `[start, end)` time spans (0 if disjoint).
+fn overlap_ms(a_start: i64, a_end: i64, b_start: i64, b_end: i64) -> i64 {
+    (a_end.min(b_end) - a_start.max(b_start)).max(0)
+}
+
+/// Reconcile meeting-stable diarization labels from a single full-recording pass
+/// onto the live Them segments captured per streaming chunk.
+///
+/// For each live Them segment, find the diarized segments overlapping it in time
+/// and pick the label with the most total overlap duration; ties resolve to the
+/// label whose first overlapping diarized segment starts earliest. A live segment
+/// with no diarized overlap is skipped entirely (its existing label is left
+/// untouched). Returns `(segment_id, new_speaker_label)` only for segments that
+/// matched, so callers never write a label they didn't derive from overlap.
+pub fn reconcile_speaker_labels(
+    live_them: &[TranscriptSegment],
+    diarized: &[DiarizedSegment],
+) -> Vec<(String, String)> {
+    let mut mapping = Vec::new();
+
+    for live in live_them {
+        // (total overlap ms, earliest diarized start ms) per candidate label.
+        let mut totals: Vec<(String, i64, i64)> = Vec::new();
+        for seg in diarized {
+            let Some(label) = seg.speaker_label.as_ref() else {
+                continue;
+            };
+            let overlap = overlap_ms(live.start_ms, live.end_ms, seg.start_ms, seg.end_ms);
+            if overlap <= 0 {
+                continue;
+            }
+            match totals.iter_mut().find(|(l, _, _)| l == label) {
+                Some(entry) => {
+                    entry.1 += overlap;
+                    entry.2 = entry.2.min(seg.start_ms);
+                }
+                None => totals.push((label.clone(), overlap, seg.start_ms)),
+            }
+        }
+
+        // Most overlap wins; ties go to the earliest-starting diarized label.
+        let best = totals.into_iter().max_by(|a, b| {
+            a.1.cmp(&b.1) // larger total overlap first
+                .then_with(|| b.2.cmp(&a.2)) // then earlier start (smaller ms) first
+        });
+        if let Some((label, _, _)) = best {
+            mapping.push((live.id.clone(), label));
+        }
+    }
+
+    mapping
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::types::{SegmentStatus, Speaker, SpeakerSource};
+
+    fn live(id: &str, start_ms: i64, end_ms: i64) -> TranscriptSegment {
+        TranscriptSegment {
+            id: id.to_string(),
+            meeting_id: "m1".to_string(),
+            seq: 0,
+            speaker: Speaker::Them,
+            text: "hello".to_string(),
+            start_ms,
+            end_ms,
+            status: SegmentStatus::Ok,
+            speaker_label: None,
+            speaker_source: SpeakerSource::Channel,
+            created_at: 0,
+        }
+    }
+
+    fn diar(label: &str, start_ms: i64, end_ms: i64) -> DiarizedSegment {
+        DiarizedSegment {
+            speaker_label: Some(label.to_string()),
+            start_ms,
+            end_ms,
+            text: "x".to_string(),
+        }
+    }
+
+    #[test]
+    fn clean_overlap_maps_each_segment_to_its_diarized_label() {
+        let live_them = vec![live("s1", 0, 1_000), live("s2", 1_200, 2_000)];
+        let diarized = vec![diar("A", 0, 1_000), diar("B", 1_200, 2_000)];
+
+        let mapping = reconcile_speaker_labels(&live_them, &diarized);
+
+        assert_eq!(
+            mapping,
+            vec![
+                ("s1".to_string(), "A".to_string()),
+                ("s2".to_string(), "B".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn dominant_overlap_wins_when_a_segment_spans_two_labels() {
+        // Live [0,1000) overlaps A for 800ms ([0,800)) and B for 200ms ([800,1000)).
+        let live_them = vec![live("s1", 0, 1_000)];
+        let diarized = vec![diar("A", 0, 800), diar("B", 800, 2_000)];
+
+        let mapping = reconcile_speaker_labels(&live_them, &diarized);
+
+        assert_eq!(mapping, vec![("s1".to_string(), "A".to_string())]);
+    }
+
+    #[test]
+    fn equal_overlap_tie_breaks_to_the_earliest_starting_label() {
+        // Live [0,1000) overlaps B for 500ms ([500,1000)) and A for 500ms ([0,500)).
+        // Equal overlap -> the earlier-starting label (A, start 0) wins.
+        let live_them = vec![live("s1", 0, 1_000)];
+        let diarized = vec![diar("B", 500, 1_000), diar("A", 0, 500)];
+
+        let mapping = reconcile_speaker_labels(&live_them, &diarized);
+
+        assert_eq!(mapping, vec![("s1".to_string(), "A".to_string())]);
+    }
+
+    #[test]
+    fn segments_without_any_overlap_are_skipped() {
+        // s2 falls in a gap with no diarized coverage -> no mapping for it.
+        let live_them = vec![live("s1", 0, 1_000), live("s2", 5_000, 6_000)];
+        let diarized = vec![diar("A", 0, 1_000)];
+
+        let mapping = reconcile_speaker_labels(&live_them, &diarized);
+
+        assert_eq!(mapping, vec![("s1".to_string(), "A".to_string())]);
+    }
+
+    #[test]
+    fn empty_inputs_yield_no_mapping() {
+        assert!(reconcile_speaker_labels(&[], &[diar("A", 0, 1_000)]).is_empty());
+        assert!(reconcile_speaker_labels(&[live("s1", 0, 1_000)], &[]).is_empty());
+        assert!(reconcile_speaker_labels(&[], &[]).is_empty());
+    }
+
+    #[test]
+    fn diarized_segments_with_no_label_are_ignored() {
+        // A full-recording pass that returned a labelless segment must not produce
+        // a mapping from it (no stable speaker identity to assign).
+        let live_them = vec![live("s1", 0, 1_000)];
+        let diarized = vec![DiarizedSegment {
+            speaker_label: None,
+            start_ms: 0,
+            end_ms: 1_000,
+            text: "x".to_string(),
+        }];
+
+        assert!(reconcile_speaker_labels(&live_them, &diarized).is_empty());
+    }
+}

--- a/src-tauri/src/audio/transcribe.rs
+++ b/src-tauri/src/audio/transcribe.rs
@@ -283,6 +283,59 @@ impl GatewayTranscriber {
     }
 }
 
+/// POST one already-built envelope body to the Whisper publisher and return the
+/// unwrapped publisher body. Shared by the per-chunk live transcriber and the
+/// post-call full-recording pass so both speak to the Gateway the same way.
+async fn post_transcription(
+    app: &AppHandle,
+    client: &reqwest::Client,
+    body: String,
+) -> Result<serde_json::Value, TranscribeError> {
+    let url = format!(
+        "{}/publishers/{}/audio/transcriptions",
+        GATEWAY_BASE_URL, WHISPER_PUBLISHER
+    );
+
+    let response = crate::auth::authenticated_request(app, client, move |client, token| {
+        client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .bearer_auth(token)
+            .body(body.clone())
+    })
+    .await
+    .map_err(TranscribeError::Transport)?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let detail = response.text().await.unwrap_or_default();
+        return Err(TranscribeError::Transport(format!(
+            "whisper http {status}: {detail}"
+        )));
+    }
+
+    let value: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|err| TranscribeError::Transport(err.to_string()))?;
+
+    if let Some(status) = publisher_status(&value) {
+        if status != 200 {
+            let body = unwrap_publisher_body(&value);
+            let message = body
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("upstream error");
+            return Err(TranscribeError::Transport(format!(
+                "whisper upstream {status}: {message}"
+            )));
+        }
+    }
+
+    Ok(unwrap_publisher_body(&value).clone())
+}
+
 #[async_trait]
 impl ChunkTranscriber for GatewayTranscriber {
     async fn transcribe(&self, chunk: &Chunk) -> Result<Vec<DiarizedSegment>, TranscribeError> {
@@ -291,53 +344,76 @@ impl ChunkTranscriber for GatewayTranscriber {
             TranscriptionMode::Diarized => build_diarized_envelope(&wav).to_string(),
             TranscriptionMode::Text => build_whisper_envelope(&wav).to_string(),
         };
-        let url = format!(
-            "{}/publishers/{}/audio/transcriptions",
-            GATEWAY_BASE_URL, WHISPER_PUBLISHER
-        );
 
-        let response =
-            crate::auth::authenticated_request(&self.app, &self.client, move |client, token| {
-                client
-                    .post(&url)
-                    .header("Content-Type", "application/json")
-                    .bearer_auth(token)
-                    .body(body.clone())
-            })
-            .await
-            .map_err(TranscribeError::Transport)?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let detail = response.text().await.unwrap_or_default();
-            return Err(TranscribeError::Transport(format!(
-                "whisper http {status}: {detail}"
-            )));
-        }
-
-        let value: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|err| TranscribeError::Transport(err.to_string()))?;
-
-        if let Some(status) = publisher_status(&value) {
-            if status != 200 {
-                let body = unwrap_publisher_body(&value);
-                let message = body
-                    .get("error")
-                    .and_then(|error| error.get("message"))
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("upstream error");
-                return Err(TranscribeError::Transport(format!(
-                    "whisper upstream {status}: {message}"
-                )));
-            }
-        }
-
-        let body = unwrap_publisher_body(&value);
+        let body = post_transcription(&self.app, &self.client, body).await?;
         let chunk_len_ms = (chunk.end_ms as i64 - chunk.start_ms as i64).max(0);
-        parse_diarized_body(body, chunk_len_ms)
+        parse_diarized_body(&body, chunk_len_ms)
     }
+}
+
+/// OpenAI's transcription upload cap is ~25 MB. 16 kHz mono PCM16 is 32 KB/s, so
+/// a WAV stays under ~24 MB up to ~12.5 minutes. We split the full recording into
+/// the fewest segments at or under [`MAX_SPLIT_SAMPLES`] so each upload fits, then
+/// offset and concatenate the returned segments (see [`split_offsets`]).
+///
+/// 16 kHz * 60 s * 12 min = 11_520_000 samples (~23 MB WAV) — a safe margin
+/// below the 25 MB cap that leaves room for the 44-byte header and rounding.
+const MAX_SPLIT_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 60 * 12;
+
+/// Compute split boundaries over `total_samples` so each piece is at most
+/// `max_samples`. Returns `(start_sample, len_samples, cumulative_start_ms)` per
+/// piece, where `cumulative_start_ms` is the offset to add to each returned
+/// segment's timestamps so they line up against the original recording.
+///
+/// Labels reset across these few splits (each is an independent diarized call) —
+/// acceptable because splitting only happens for very long recordings, and the
+/// reconcile pass matches by time overlap, not by label identity.
+fn split_offsets(total_samples: usize, max_samples: usize) -> Vec<(usize, usize, i64)> {
+    if total_samples == 0 {
+        return Vec::new();
+    }
+    let max = max_samples.max(1);
+    let mut pieces = Vec::new();
+    let mut start = 0usize;
+    while start < total_samples {
+        let len = max.min(total_samples - start);
+        // ms = sample_index / sample_rate * 1000, integer-floored.
+        let cumulative_start_ms = (start as i64 * 1000) / TARGET_SAMPLE_RATE as i64;
+        pieces.push((start, len, cumulative_start_ms));
+        start += len;
+    }
+    pieces
+}
+
+/// Run ONE diarized pass over a full meeting recording and return its segments
+/// with timestamps relative to the start of the recording.
+///
+/// Stable speaker labels come from diarizing the WHOLE recording in one call (a
+/// fresh per-chunk pass resets labels every chunk — that is what #2127 hit). When
+/// the recording exceeds the OpenAI upload cap we fall back to the fewest splits
+/// and offset each piece's timestamps; labels reset across those splits, which is
+/// why reconcile matches by time, not by raw label.
+pub async fn transcribe_full_recording(
+    app: &AppHandle,
+    pcm: &[i16],
+) -> Result<Vec<DiarizedSegment>, TranscribeError> {
+    let client = reqwest::Client::new();
+    let pieces = split_offsets(pcm.len(), MAX_SPLIT_SAMPLES);
+    let mut all = Vec::new();
+    for (start, len, offset_ms) in pieces {
+        let slice = &pcm[start..start + len];
+        let wav = pcm16_to_wav(slice, TARGET_SAMPLE_RATE);
+        let body = build_diarized_envelope(&wav).to_string();
+        let unwrapped = post_transcription(app, &client, body).await?;
+        let piece_len_ms = (len as i64 * 1000) / TARGET_SAMPLE_RATE as i64;
+        let segments = parse_diarized_body(&unwrapped, piece_len_ms)?;
+        for mut segment in segments {
+            segment.start_ms += offset_ms;
+            segment.end_ms += offset_ms;
+            all.push(segment);
+        }
+    }
+    Ok(all)
 }
 
 #[cfg(test)]
@@ -557,5 +633,45 @@ mod tests {
             parse_diarized_body(&body, 1_000).unwrap_err(),
             TranscribeError::Empty
         );
+    }
+
+    #[test]
+    fn split_offsets_keeps_one_piece_under_the_cap() {
+        // A recording that fits in one upload is a single piece at offset 0.
+        let pieces = split_offsets(16_000 * 5, 16_000 * 12 * 60);
+        assert_eq!(pieces, vec![(0, 16_000 * 5, 0)]);
+    }
+
+    #[test]
+    fn split_offsets_partitions_with_cumulative_ms_offsets() {
+        // 25s of 16kHz samples split at a 10s cap -> 3 pieces (10s, 10s, 5s) with
+        // cumulative-start offsets of 0ms, 10_000ms, 20_000ms.
+        let max = 16_000 * 10;
+        let total = 16_000 * 25;
+        let pieces = split_offsets(total, max);
+        assert_eq!(
+            pieces,
+            vec![
+                (0, 16_000 * 10, 0),
+                (16_000 * 10, 16_000 * 10, 10_000),
+                (16_000 * 20, 16_000 * 5, 20_000),
+            ]
+        );
+        // The pieces fully cover the recording with no gaps or overlaps.
+        let covered: usize = pieces.iter().map(|(_, len, _)| len).sum();
+        assert_eq!(covered, total);
+    }
+
+    #[test]
+    fn split_offsets_handles_an_exact_multiple_of_the_cap() {
+        // Exactly two caps' worth -> two full pieces, no trailing empty piece.
+        let max = 16_000 * 10;
+        let pieces = split_offsets(max * 2, max);
+        assert_eq!(pieces, vec![(0, max, 0), (max, max, 10_000)]);
+    }
+
+    #[test]
+    fn split_offsets_is_empty_for_empty_input() {
+        assert!(split_offsets(0, 16_000 * 12 * 60).is_empty());
     }
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -9,9 +9,11 @@ use crate::audio::llm::{CompletionRequest, complete};
 use crate::audio::merge::merge_segments;
 use crate::audio::notes::{ParsedNotes, generate_notes};
 use crate::audio::pipeline::CaptureRegistry;
+use crate::audio::reconcile::reconcile_speaker_labels;
 use crate::audio::templates::{BUILT_IN_MEETING_TEMPLATES, MeetingTemplate};
 use crate::audio::transcribe::{
     GatewayTranscriber, RetryConfig, TranscribeError, transcribe_chunk_with_retry,
+    transcribe_full_recording,
 };
 use crate::audio::types::{
     Meeting, MeetingStatus, SegmentStatus, Speaker, SpeakerSource, TranscriptSegment,
@@ -218,6 +220,77 @@ pub async fn stop_meeting_capture(
     .await?;
     emit_meeting_status_by_id(&app, &lookup).await;
     Ok(())
+}
+
+/// Post-call diarization refinement: run ONE diarized pass over the full Them
+/// recording and stamp its meeting-stable speaker labels onto the live Them
+/// segments. The live path diarizes per streaming chunk (#2127), so its labels
+/// reset every chunk; one pass over the whole recording keeps a speaker's label
+/// stable across the meeting. Returns the count of segments relabeled.
+///
+/// Best-effort and additive: absent/short audio, a transcription failure, or no
+/// overlap returns `Ok(0)` and leaves existing labels untouched — it never
+/// corrupts what the live path already produced.
+#[tauri::command]
+pub async fn reconcile_meeting_speakers(
+    app: AppHandle,
+    registry: State<'_, CaptureRegistry>,
+    meeting_id: String,
+) -> Result<usize, String> {
+    // Take (and consume) the buffered Them PCM. Too little audio to be worth a
+    // diarized pass -> nothing to do.
+    let Some(pcm) = registry.take_finished_them_audio(&meeting_id) else {
+        return Ok(0);
+    };
+    // ~30 s of 16 kHz mono. Below this a single short turn gains nothing from a
+    // whole-recording pass; skip the cost.
+    const MIN_RECONCILE_SAMPLES: usize = crate::audio::capture::TARGET_SAMPLE_RATE as usize * 30;
+    if pcm.len() < MIN_RECONCILE_SAMPLES {
+        return Ok(0);
+    }
+
+    let diarized = match transcribe_full_recording(&app, &pcm).await {
+        Ok(segments) => segments,
+        Err(err) => {
+            log::warn!("[meeting] post-call diarization failed for {meeting_id}: {err}");
+            return Ok(0);
+        }
+    };
+    if diarized.is_empty() {
+        return Ok(0);
+    }
+
+    // Reconcile against only the live Them segments — the Me mic is single-speaker
+    // and is never relabeled by this pass.
+    let lookup = meeting_id.clone();
+    let live_them: Vec<TranscriptSegment> =
+        run_db(app.clone(), move |conn| select_transcript_segments(conn, &lookup))
+            .await?
+            .into_iter()
+            .filter(|segment| segment.speaker == Speaker::Them)
+            .collect();
+    if live_them.is_empty() {
+        return Ok(0);
+    }
+
+    let mapping = reconcile_speaker_labels(&live_them, &diarized);
+    if mapping.is_empty() {
+        return Ok(0);
+    }
+
+    let to_apply = mapping.clone();
+    let updated = run_db(app.clone(), move |conn| {
+        let mut count = 0usize;
+        for (id, label) in &to_apply {
+            update_transcript_segment_speaker(conn, id, label)?;
+            count += 1;
+        }
+        Ok(count)
+    })
+    .await?;
+
+    let _ = app.emit("meeting://segments-updated", serde_json::json!({ "meetingId": meeting_id }));
+    Ok(updated)
 }
 
 #[tauri::command]
@@ -523,6 +596,23 @@ pub fn select_transcript_segments(
 
     stmt.query_map(params![meeting_id], row_to_segment)?
         .collect::<Result<Vec<_>>>()
+}
+
+/// Stamp a meeting-stable diarization label onto one segment. Used by the
+/// post-call reconcile pass; only `speaker_label`/`speaker_source` change, so the
+/// segment's text, timing, and channel `speaker` (Me/Them) are left intact.
+pub fn update_transcript_segment_speaker(
+    conn: &Connection,
+    id: &str,
+    label: &str,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE transcript_segments
+         SET speaker_label = ?1, speaker_source = ?2
+         WHERE id = ?3",
+        params![label, SpeakerSource::Diarization.as_str(), id],
+    )?;
+    Ok(())
 }
 
 fn row_to_meeting(row: &rusqlite::Row<'_>) -> Result<Meeting> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -805,6 +805,7 @@ pub fn run() {
             commands::audio::start_meeting_capture,
             commands::audio::push_capture_frame,
             commands::audio::stop_meeting_capture,
+            commands::audio::reconcile_meeting_speakers,
             commands::audio::generate_meeting_notes,
             commands::audio::get_meeting_transcript_text,
             commands::audio::select_meeting_skills,

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -182,6 +182,16 @@ export function stopMeetingCapture(meetingId: string): Promise<void> {
   return invoke("stop_meeting_capture", { meetingId });
 }
 
+/**
+ * Post-call refinement: diarize the full Them recording in one pass and stamp
+ * meeting-stable speaker labels onto the live segments. Returns the number of
+ * segments relabeled. Best-effort on the backend — resolves to 0 when there's no
+ * buffered audio, the audio is too short, or diarization fails.
+ */
+export function reconcileMeetingSpeakers(meetingId: string): Promise<number> {
+  return invoke("reconcile_meeting_speakers", { meetingId });
+}
+
 export function generateMeetingNotes(input: {
   meetingId: string;
   model: string;

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -24,6 +24,7 @@ import {
   type Meeting,
   type MeetingTemplate,
   meetingAutodetect,
+  reconcileMeetingSpeakers,
   selectMeetingSkills,
   setMeetingRoutedSkill,
   startMeetingCapture as startBackendCapture,
@@ -75,6 +76,7 @@ let levelTimer: number | null = null;
 
 let transcriptUnlisten: UnlistenFn | null = null;
 let statusUnlisten: UnlistenFn | null = null;
+let segmentsUpdatedUnlisten: UnlistenFn | null = null;
 let widgetStopUnlisten: (() => void) | null = null;
 let trayToggleUnlisten: (() => void) | null = null;
 
@@ -177,6 +179,21 @@ async function startMeetingEventListeners(): Promise<void> {
     }
   });
 
+  // The post-call diarization pass relabeled some segments in place. Reload the
+  // active meeting's segments so the refreshed speaker labels show up live.
+  segmentsUpdatedUnlisten = await listen<{ meetingId: string }>(
+    "meeting://segments-updated",
+    (event) => {
+      const active = meetingState.activeMeeting;
+      if (active?.id !== event.payload.meetingId) return;
+      void getTranscriptSegments(event.payload.meetingId)
+        .then((segments) => setMeetingState("liveSegments", segments))
+        .catch(() => {
+          // Non-fatal: the existing labels stay; a manual refresh will reload.
+        });
+    },
+  );
+
   // The floating widget's Stop button can't run the notes/handoff flow in its
   // own webview, so it asks the main window to stop the capture it owns.
   widgetStopUnlisten = await onWidgetStopRequest((meetingId) => {
@@ -195,10 +212,12 @@ async function startMeetingEventListeners(): Promise<void> {
 function stopMeetingEventListeners(): void {
   transcriptUnlisten?.();
   statusUnlisten?.();
+  segmentsUpdatedUnlisten?.();
   widgetStopUnlisten?.();
   trayToggleUnlisten?.();
   transcriptUnlisten = null;
   statusUnlisten = null;
+  segmentsUpdatedUnlisten = null;
   widgetStopUnlisten = null;
   trayToggleUnlisten = null;
 }
@@ -377,6 +396,12 @@ async function stopAndProcess(meeting: Meeting): Promise<void> {
     await stopCapture(meeting.id);
     await loadMeetings();
     if (!isTauriRuntime()) return;
+
+    // Post-call speaker refinement: one diarized pass over the full Them
+    // recording, reconciled onto the live segments for meeting-stable labels.
+    // Fire-and-forget so it never delays notes; the segments-updated event
+    // refreshes the transcript when it lands. Best-effort on the backend.
+    void reconcileMeetingSpeakers(meeting.id).catch(() => {});
 
     const templatePrompt = await resolveTemplatePrompt(meeting.templateId);
     try {


### PR DESCRIPTION
Closes #2183. At call-end, runs ONE diarized pass over the full buffered **Them** recording (proven to yield meeting-stable A/B/… labels, unlike per-streaming-chunk) and reconciles those labels onto the live Them segments by timestamp overlap.

- **Buffer**: Them PCM accumulated in-memory only (no disk, #2125 W1-8), capped ~90 min; Me is never buffered. Tap is a short mutex memcpy off the transcribe path. Handed off on stop *after* the worker drain (tail frames included), *before* finish_stop (tombstone preserved, #2181/#2182 intact).
- **Pass**: `transcribe_full_recording` — one diarized call, or fewest ≤24 MB splits for long meetings (OpenAI ~25 MB cap), timestamps offset per split.
- **Reconcile**: pure time-overlap mapping — most-overlap label wins, ties→earliest, no-overlap→untouched; only writes derived labels. Updates `speaker_label`/`speaker_source`, emits `meeting://segments-updated`.
- **Best-effort**: every failure path is a no-op; existing labels never corrupted. Dictation + the live streaming path unchanged.
- 635 lib tests (+11: reconcile ×6, split ×4, transcribe ×1), cargo/tsc/biome green. Live call-end pass = release test.