### PR TITLE
fix(audio): resume the capture AudioContext so mic capture isn't silent

### DIFF
--- a/src/lib/audio/captureContext.ts
+++ b/src/lib/audio/captureContext.ts
@@ -1,0 +1,25 @@
+// ABOUTME: Creates a running Web Audio context for webview microphone capture.
+// ABOUTME: Resumes the context so a suspended-by-default WKWebView can't silently capture nothing.
+
+/**
+ * Create an `AudioContext` at `sampleRate` and guarantee it is actually running.
+ *
+ * WKWebView/Safari — and any context created outside a user gesture — start an
+ * `AudioContext` in the `suspended` state. While suspended a `ScriptProcessor`'s
+ * `onaudioprocess` never fires, so microphone capture silently produces no PCM
+ * (the meeting/dictation "records nothing then fails" bug). Resume the context
+ * and fail loudly if it cannot run, rather than record silence.
+ */
+export async function createRunningAudioContext(
+  sampleRate: number,
+): Promise<AudioContext> {
+  const context = new AudioContext({ sampleRate });
+  await context.resume();
+  if (context.state !== "running") {
+    await context.close().catch(() => {});
+    throw new Error(
+      "Audio capture could not start: the audio context is suspended.",
+    );
+  }
+  return context;
+}

--- a/src/lib/audio/dictationCapture.ts
+++ b/src/lib/audio/dictationCapture.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Streaming webview microphone capture for dictation.
 // ABOUTME: Transcribes ~1.5s chunks (or on silence) via transcribe_pcm and emits live partial text.
 
+import { createRunningAudioContext } from "@/lib/audio/captureContext";
 import { transcribePcm } from "@/services/dictation";
 
 const TARGET_SAMPLE_RATE = 16_000;
@@ -47,7 +48,16 @@ export async function startDictationCapture(
     audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
   });
 
-  const context = new AudioContext({ sampleRate: TARGET_SAMPLE_RATE });
+  let context: AudioContext;
+  try {
+    context = await createRunningAudioContext(TARGET_SAMPLE_RATE);
+  } catch (error) {
+    // Release the mic we just opened so a failed start can't leave it live.
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+    throw error;
+  }
   const source = context.createMediaStreamSource(stream);
 
   const analyser = context.createAnalyser();

--- a/src/lib/audio/meetingCapture.ts
+++ b/src/lib/audio/meetingCapture.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Webview microphone capture for the Meeting Mode "Me" stream.
 // ABOUTME: Streams 16 kHz mono PCM frames to the Rust pipeline and exposes live amplitude.
 
+import { createRunningAudioContext } from "@/lib/audio/captureContext";
 import { pushCaptureFrame } from "@/services/meetings";
 
 const TARGET_SAMPLE_RATE = 16_000;
@@ -32,7 +33,16 @@ export async function startMeetingMicCapture(
     audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
   });
 
-  const context = new AudioContext({ sampleRate: TARGET_SAMPLE_RATE });
+  let context: AudioContext;
+  try {
+    context = await createRunningAudioContext(TARGET_SAMPLE_RATE);
+  } catch (error) {
+    // Release the mic we just opened so a failed start can't leave it live.
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+    throw error;
+  }
   const source = context.createMediaStreamSource(stream);
 
   const analyser = context.createAnalyser();

--- a/tests/unit/capture-context.test.ts
+++ b/tests/unit/capture-context.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Verifies createRunningAudioContext resumes the context and fails loudly
+// ABOUTME: when WKWebView leaves it suspended — the root cause of silent capture (#2194).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createRunningAudioContext } from "@/lib/audio/captureContext";
+
+let resumeTargetState: AudioContextState;
+const instances: FakeAudioContext[] = [];
+
+class FakeAudioContext {
+  sampleRate: number;
+  state: AudioContextState = "suspended";
+  resume = vi.fn(async () => {
+    this.state = resumeTargetState;
+  });
+  close = vi.fn(async () => {});
+
+  constructor(options: { sampleRate: number }) {
+    this.sampleRate = options.sampleRate;
+    instances.push(this);
+  }
+}
+
+beforeEach(() => {
+  resumeTargetState = "running";
+  instances.length = 0;
+  vi.stubGlobal("AudioContext", FakeAudioContext);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createRunningAudioContext", () => {
+  it("resumes a suspended context and returns it running", async () => {
+    const context = await createRunningAudioContext(16_000);
+
+    expect(context.state).toBe("running");
+    expect(context.sampleRate).toBe(16_000);
+    const fake = context as unknown as FakeAudioContext;
+    expect(fake.resume).toHaveBeenCalledOnce();
+    expect(fake.close).not.toHaveBeenCalled();
+  });
+
+  it("throws and closes the context when it cannot leave suspended", async () => {
+    resumeTargetState = "suspended";
+
+    await expect(createRunningAudioContext(16_000)).rejects.toThrow(/suspended/);
+    expect(instances).toHaveLength(1);
+    expect(instances[0].close).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Problem

On macOS (native `desktop-native` app) **every Meeting Mode capture ran its full duration then failed with an empty transcript**, and the recorder meter stayed flat. Evidence: `transcript_segments` = 0 across all meetings (not even `Gap` segments), zero `[meeting]` lines in the Rust log, and `getUserMedia` succeeded (a denied mic fails at ~0s). The level meter is computed **entirely in the webview** from the `AnalyserNode`, so a flat meter proves the webview's own `AudioContext` had no audio — upstream of all IPC, transcription, and the native tap.

## Root cause

`meetingCapture.ts` / `dictationCapture.ts` create `new AudioContext({ sampleRate })` but **never call `context.resume()`**. WKWebView/Safari (and any context created off a user gesture) start an `AudioContext` `suspended`; while suspended a `ScriptProcessorNode`'s `onaudioprocess` never fires → zero PCM frames pushed → empty transcript → `generate_meeting_notes` returns `"no transcript to summarize"` → meeting flips to `failed`.

## Fix

- New `src/lib/audio/captureContext.ts` → `createRunningAudioContext(sampleRate)`: create, `resume()`, and **fail loudly** (closing the context) if it cannot leave `suspended`.
- Route both `meetingCapture` and `dictationCapture` through it (removes the duplicated context setup), releasing the just-opened mic on a context-start failure so `startCapture`'s catch surfaces a real error instead of a silent capture that records nothing.

## Tests

- `tests/unit/capture-context.test.ts` — guard branch: running → returns; stays suspended → throws + closes.
- Full suite green: **1569 passed**; `biome lint`/`check` exit 0; `tsc --noEmit` clean on the changed files.

## Validation note

This is browser-runtime glue — the unit test covers the guard decision, but the **true** validation is a live macOS run (real meeting produces non-empty segments and reaches `done`; dictation shows live partials). Tracked on the issue's acceptance list.

Closes #2194

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
