### PR TITLE
fix(meeting): sort reloaded transcript segments by capture time

### DIFF
--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -128,7 +128,7 @@ async function setActiveMeeting(meeting: Meeting | null): Promise<void> {
 
   try {
     const segments = await getTranscriptSegments(meeting.id);
-    setMeetingState("liveSegments", segments);
+    setMeetingState("liveSegments", sortSegmentsByCapture(segments));
   } catch (error) {
     setMeetingState(
       "error",
@@ -137,17 +137,26 @@ async function setActiveMeeting(meeting: Meeting | null): Promise<void> {
   }
 }
 
+// Order transcript segments by capture time, not completion order. `seq` is
+// assigned when each chunk's transcription request returns, so the fast Me
+// (whisper-1) vs slow Them (diarize) streams would otherwise interleave
+// scrambled. startMs is the chunk's capture offset; seq only breaks exact-start
+// ties (#2163). Every path that sets liveSegments — live append AND the reload
+// paths (setActiveMeeting, the post-call segments-updated refresh) — must run
+// through this so the DB's `ORDER BY seq` rows don't render scrambled (#2197).
+export function sortSegmentsByCapture(
+  segments: readonly TranscriptSegment[],
+): TranscriptSegment[] {
+  return [...segments].sort((left, right) => {
+    if (left.startMs !== right.startMs) return left.startMs - right.startMs;
+    return left.seq - right.seq;
+  });
+}
+
 function appendLiveSegment(segment: TranscriptSegment): void {
   setMeetingState("liveSegments", (segments) => {
     const withoutDuplicate = segments.filter((item) => item.id !== segment.id);
-    // Order by capture time, not completion order. `seq` is assigned when each
-    // chunk's transcription request returns, so the fast Me (whisper-1) vs slow
-    // Them (diarize) streams would otherwise interleave scrambled. startMs is the
-    // chunk's capture offset; seq only breaks exact-start ties (#2163).
-    return [...withoutDuplicate, segment].sort((left, right) => {
-      if (left.startMs !== right.startMs) return left.startMs - right.startMs;
-      return left.seq - right.seq;
-    });
+    return sortSegmentsByCapture([...withoutDuplicate, segment]);
   });
 }
 
@@ -187,7 +196,9 @@ async function startMeetingEventListeners(): Promise<void> {
       const active = meetingState.activeMeeting;
       if (active?.id !== event.payload.meetingId) return;
       void getTranscriptSegments(event.payload.meetingId)
-        .then((segments) => setMeetingState("liveSegments", segments))
+        .then((segments) =>
+          setMeetingState("liveSegments", sortSegmentsByCapture(segments)),
+        )
         .catch(() => {
           // Non-fatal: the existing labels stay; a manual refresh will reload.
         });

--- a/tests/unit/meeting-transcript-order.test.ts
+++ b/tests/unit/meeting-transcript-order.test.ts
@@ -3,7 +3,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import type { TranscriptSegment } from "@/services/meetings";
-import { meetingStore } from "@/stores/meeting.store";
+import { meetingStore, sortSegmentsByCapture } from "@/stores/meeting.store";
 
 let idCounter = 0;
 function seg(overrides: Partial<TranscriptSegment>): TranscriptSegment {
@@ -47,5 +47,35 @@ describe("meetingStore.appendLiveSegment ordering (#2163)", () => {
     meetingStore.appendLiveSegment(seg({ id: "y", startMs: 500, seq: 3 }));
 
     expect(meetingStore.state.liveSegments.map((s) => s.id)).toEqual(["y", "x"]);
+  });
+});
+
+describe("sortSegmentsByCapture reload ordering (#2197)", () => {
+  it("sorts a DB batch (seq order) back into capture order", () => {
+    // getTranscriptSegments returns rows ORDER BY seq ASC. After the post-call
+    // diarize pass, Them (spoke first, startMs 0) returned last (seq 2) and Me
+    // (spoke later, startMs 1000) returned first (seq 1). The reload must show
+    // capture order — Them before Me — not the raw seq order.
+    const dbOrder = [
+      seg({ id: "me", speaker: "me", startMs: 1000, seq: 1 }),
+      seg({ id: "them", speaker: "them", startMs: 0, seq: 2 }),
+    ];
+
+    expect(sortSegmentsByCapture(dbOrder).map((s) => s.id)).toEqual([
+      "them",
+      "me",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      seg({ id: "b", startMs: 200, seq: 1 }),
+      seg({ id: "a", startMs: 100, seq: 2 }),
+    ];
+    const before = input.map((s) => s.id);
+
+    sortSegmentsByCapture(input);
+
+    expect(input.map((s) => s.id)).toEqual(before);
   });
 });


### PR DESCRIPTION
## Problem

The live meeting transcript renders in capture order **while recording**, but **re-scrambles into transcription-completion order** the moment the post-call diarization pass lands, and again on every reopen from the library. Found in the post-#2194 functional walk-through.

## Root cause

`seq` is assigned when a chunk's transcription request *returns* (`src-tauri/src/audio/pipeline.rs:112`) — completion order, not capture order — and the fast Me stream (`whisper-1`) finishes before the slow Them stream (`gpt-4o-transcribe-diarize`). `appendLiveSegment` knows this and sorts by `startMs` (`src/stores/meeting.store.ts:147-150`), but the two **reload** paths assigned the raw DB rows, which come back `ORDER BY seq ASC` (`src-tauri/src/commands/audio.rs:594`):

- `setActiveMeeting` (`meeting.store.ts:130-131`)
- the `meeting://segments-updated` listener (`meeting.store.ts:189-190`)

`reconcile_meeting_speakers` emits `segments-updated` for every meeting with ≥30s of Them audio (`audio.rs:247-292`) — i.e. essentially every two-party call — so the transcript visibly reorders right after the call ends. (Notes were already correct: the notes path sorts via `merge.rs:26-31`.)

## Fix

Extract the `startMs`-then-`seq` comparator into `sortSegmentsByCapture(segments)` and run **all three** `liveSegments` writers through it (live append + both reload sites). One comparator, all paths consistent.

## Tests

- `tests/unit/meeting-transcript-order.test.ts` — new `#2197` cases: a DB batch in `seq` order sorts back to capture order; the helper does not mutate its input. Existing `#2163` append-ordering cases still green.
- Full suite green: **1571 passed**; `biome lint`/`check` exit 0; `tsc --noEmit` clean on changed files.

Closes #2197

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
