### PR TITLE
fix(logging): label provider logs by runtime mode

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -22,6 +22,7 @@ import {
   buildSyntheticTranscript as writeSyntheticJsonl,
   writeForkedTranscript,
 } from "./synthetic-transcript.mjs";
+import { providerLogPrefix } from "./logging.mjs";
 
 /**
  * Resolve the full path to the `claude` binary.
@@ -1365,7 +1366,9 @@ function handleSystemMessage(emit, session, payload) {
 
     case "hook_response":
       if (payload.outcome === "error" && payload.stderr) {
-        console.warn(`[browser-local][claude] Hook error: ${payload.stderr}`);
+        console.warn(
+          `${session.logPrefix ?? providerLogPrefix("claude")} Hook error: ${payload.stderr}`,
+        );
       }
       return;
 
@@ -1436,8 +1439,12 @@ function handleAssistantMessage(emit, session, payload) {
       nextModelId != null &&
       previousModelId === nextModelId;
     if (!isNoOpResolution) {
+      const logPrefix = session.logPrefix ?? providerLogPrefix("claude");
       console.warn(
-        `[browser-local][claude] chooseUpdatedModelId: previous=${previousModelId ?? "<unset>"}, incoming=${message.model ?? "<missing>"}, resolved=${nextModelId ?? "<null>"}`,
+        `${logPrefix} chooseUpdatedModelId: ` +
+          `previous=${previousModelId ?? "<unset>"}, ` +
+          `incoming=${message.model ?? "<missing>"}, ` +
+          `resolved=${nextModelId ?? "<null>"}`,
       );
     }
     if (nextModelId != null && nextModelId !== session.currentModelId) {
@@ -1605,6 +1612,7 @@ function handleLine(emit, session, line) {
 }
 
 function attachProcessListeners(emit, sessions, session, exitPromises) {
+  const logPrefix = session.logPrefix ?? providerLogPrefix("claude");
   session.output.on("line", (line) => handleLine(emit, session, line));
 
   // Buffer the last stderr lines so exit diagnostics include the reason.
@@ -1614,7 +1622,7 @@ function attachProcessListeners(emit, sessions, session, exitPromises) {
   session.process.stderr.on("data", (chunk) => {
     const message = String(chunk).trim();
     if (message.length > 0) {
-      console.log(`[browser-local][claude] ${message}`);
+      console.log(`${logPrefix} ${message}`);
       stderrLines.push(message);
       if (stderrLines.length > MAX_STDERR_LINES) {
         stderrLines.shift();
@@ -1637,11 +1645,11 @@ function attachProcessListeners(emit, sessions, session, exitPromises) {
 
     if (stderrTail) {
       console.error(
-        `[browser-local][claude] Process exited (${exitDetail}) stderr:\n${stderrTail}`,
+        `${logPrefix} Process exited (${exitDetail}) stderr:\n${stderrTail}`,
       );
     } else {
       console.warn(
-        `[browser-local][claude] Process exited (${exitDetail}) with no stderr`,
+        `${logPrefix} Process exited (${exitDetail}) with no stderr`,
       );
     }
 
@@ -1689,8 +1697,9 @@ function attachProcessListeners(emit, sessions, session, exitPromises) {
   });
 }
 
-export function createClaudeRuntime({ emit }) {
+export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) {
   const sessions = new Map();
+  const claudeLogPrefix = providerLogPrefix("claude", runtimeMode);
   // Tracks pending exit cleanup per session ID. When a process exits,
   // the promise resolves. Before spawning with a reused ID, we await
   // this to prevent the old exit handler from deleting the new session.
@@ -1719,6 +1728,7 @@ export function createClaudeRuntime({ emit }) {
       pendingControlRequests: new Map(),
       nextControlRequestId: 1,
       pendingPermissions: new Map(),
+      logPrefix: claudeLogPrefix,
       currentPrompt: null,
       currentPromptHasStreamedText: false,
       currentPromptHasStreamedThinking: false,
@@ -1808,17 +1818,18 @@ export function createClaudeRuntime({ emit }) {
     // mismatches (e.g. picker shows [1m] but the spawned session reports a
     // 200K window) are diagnosable without ad-hoc instrumentation. Goes to
     // stderr so it shares the [ProviderRuntime stderr] channel with other
-    // browser-local diagnostics; mcpConfigJson is intentionally omitted to
+    // provider-runtime diagnostics; mcpConfigJson is intentionally omitted to
     // avoid surfacing publisher credentials embedded in the inline config.
     // See #1854.
     // Print BOTH ids: `sessionId` is the Seren-side handle every frontend
     // event is tagged with, while `agentSessionId` is the Claude CLI's
     // internal session id (used in --resume and JSONL paths). Logging
-    // only the latter made the [browser-local][claude] spawn line
+    // only the latter made the Claude spawn line
     // useless when correlating with [AgentRuntime] Event received logs
     // in the renderer console. #1889
     console.error(
-      `[browser-local][claude] spawn sessionId=${sessionId} agentSessionId=${remoteSessionId} preferredModel="${preferredModel}"`,
+      `${claudeLogPrefix} spawn sessionId=${sessionId} ` +
+        `agentSessionId=${remoteSessionId} preferredModel="${preferredModel}"`,
     );
     const processHandle = spawn(
       claudeBin,
@@ -1845,7 +1856,7 @@ export function createClaudeRuntime({ emit }) {
 
     // Catch spawn errors (e.g. ENOENT, EBADARCH) to prevent crashing the provider runtime.
     processHandle.on("error", (spawnError) => {
-      console.error(`[browser-local][claude] Spawn error: ${spawnError.message}`);
+      console.error(`${claudeLogPrefix} Spawn error: ${spawnError.message}`);
       sessions.delete(sessionId);
       // macOS surfaces a wrong-arch binary as `errno: -86` / "Bad CPU type in
       // executable" (EBADARCH). It hits when a prior install dropped the wrong
@@ -1955,7 +1966,7 @@ export function createClaudeRuntime({ emit }) {
             resumeAgentSessionId,
           ).catch((err) => {
             console.warn(
-              "[browser-local][claude] history replay failed:",
+              `${claudeLogPrefix} history replay failed:`,
               err?.message ?? err,
             );
           })
@@ -2191,9 +2202,11 @@ export function createClaudeRuntime({ emit }) {
     const targetModel =
       session.availableModelRecords.find((record) => record.modelId === modelId) ??
       null;
+    const logPrefix = session.logPrefix ?? claudeLogPrefix;
     if (!targetModel) {
       console.warn(
-        `[browser-local][claude] setModel: ${modelId} not in catalog (size=${session.availableModelRecords.length}); passing through to CLI`,
+        `${logPrefix} setModel: ${modelId} not in catalog ` +
+          `(size=${session.availableModelRecords.length}); passing through to CLI`,
       );
     }
 
@@ -2216,7 +2229,7 @@ export function createClaudeRuntime({ emit }) {
       responseSummary = "<unserializable>";
     }
     console.warn(
-      `[browser-local][claude] setModel ack: requested=${modelId}, response=${responseSummary}`,
+      `${logPrefix} setModel ack: requested=${modelId}, response=${responseSummary}`,
     );
 
     session.currentModelId = targetModel?.modelId ?? modelId;

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -9,6 +9,7 @@ import path from "node:path";
 import readline from "node:readline";
 
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
+import { providerLogPrefix } from "./logging.mjs";
 
 // ============================================================================
 // Binary resolution
@@ -244,6 +245,7 @@ function createGeminiSessionRecord({
   processHandle,
   timeoutSecs,
   currentModeId,
+  logPrefix,
 }) {
   return {
     id: sessionId,
@@ -256,6 +258,7 @@ function createGeminiSessionRecord({
     pendingRequests: new Map(),
     nextRequestId: 1,
     pendingPermissions: new Map(),
+    logPrefix,
     currentPrompt: null,
     agentSessionId: undefined,
     timeoutSecs: timeoutSecs ?? undefined,
@@ -598,6 +601,7 @@ function buildSessionStatus(session, status = session.status) {
 }
 
 function attachProcessListeners(emit, sessions, session) {
+  const logPrefix = session.logPrefix ?? providerLogPrefix("gemini");
   session.output.on("line", (line) => handleLine(emit, session, line));
 
   // Buffer the latest stderr lines so the spawn-time catch block has
@@ -611,7 +615,7 @@ function attachProcessListeners(emit, sessions, session) {
     session.stderrTail = (session.stderrTail + message).slice(-4096);
     const trimmed = message.trim();
     if (trimmed.length > 0) {
-      console.log(`[browser-local][gemini] ${trimmed}`);
+      console.log(`${logPrefix} ${trimmed}`);
     }
 
     // Proactively detect auth failures from stderr while initialize is
@@ -654,8 +658,9 @@ function attachProcessListeners(emit, sessions, session) {
 // Public factory
 // ============================================================================
 
-export function createGeminiRuntime({ emit }) {
+export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) {
   const sessions = new Map();
+  const geminiLogPrefix = providerLogPrefix("gemini", runtimeMode);
 
   async function spawnSession(params) {
     const {
@@ -681,6 +686,7 @@ export function createGeminiRuntime({ emit }) {
       processHandle,
       timeoutSecs,
       currentModeId: resolvedMode,
+      logPrefix: geminiLogPrefix,
     });
 
     sessions.set(sessionId, session);
@@ -1009,8 +1015,11 @@ export function createGeminiRuntime({ emit }) {
     // this assignment; the picker change only takes effect on the next
     // session spawn. Surface this so the user can see the disconnect in
     // logs instead of silently sending prompts to the wrong model. #1718.
+    const logPrefix = session.logPrefix ?? geminiLogPrefix;
     console.warn(
-      `[browser-local][gemini] setModel: ${modelId} stored as session intent — no-op against the running CLI process (Gemini --model is fixed at spawn time). The next session spawn will use this model.`,
+      `${logPrefix} setModel: ${modelId} stored as session intent — ` +
+        "no-op against the running CLI process (Gemini --model is fixed at " +
+        "spawn time). The next session spawn will use this model.",
     );
   }
 

--- a/bin/browser-local/logging.mjs
+++ b/bin/browser-local/logging.mjs
@@ -1,0 +1,21 @@
+// ABOUTME: Provider-runtime log prefix helpers shared by local agent runtimes.
+// ABOUTME: Keeps desktop-native logs from inheriting browser-local directory names.
+
+const LOG_TOKEN_RE = /^[a-z0-9][a-z0-9-]*$/;
+const FALLBACK_RUNTIME_MODE = "provider-runtime";
+
+function normalizeLogToken(value, fallback) {
+  const normalized =
+    typeof value === "string" ? value.trim().toLowerCase() : "";
+  return LOG_TOKEN_RE.test(normalized) ? normalized : fallback;
+}
+
+export function normalizeRuntimeLogMode(runtimeMode) {
+  return normalizeLogToken(runtimeMode, FALLBACK_RUNTIME_MODE);
+}
+
+export function providerLogPrefix(providerName, runtimeMode) {
+  const runtime = normalizeRuntimeLogMode(runtimeMode);
+  const provider = normalizeLogToken(providerName, "");
+  return provider ? `[${runtime}][${provider}]` : `[${runtime}]`;
+}

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -10,6 +10,7 @@ import {
 } from "./agent-registry.mjs";
 import { createClaudeRuntime } from "./claude-runtime.mjs";
 import { createGeminiRuntime } from "./gemini-runtime.mjs";
+import { providerLogPrefix } from "./logging.mjs";
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
 
 function isAuthError(message) {
@@ -902,13 +903,18 @@ function handleLine(emit, session, line) {
   }
 }
 
-function attachProcessListeners(emit, sessions, session) {
+function attachProcessListeners(
+  emit,
+  sessions,
+  session,
+  logPrefix = providerLogPrefix("codex"),
+) {
   session.output.on("line", (line) => handleLine(emit, session, line));
 
   session.process.stderr.on("data", (chunk) => {
     const message = String(chunk).trim();
     if (message.length > 0) {
-      console.log(`[browser-local][codex] ${message}`);
+      console.log(`${logPrefix} ${message}`);
     }
   });
 
@@ -924,7 +930,7 @@ function attachProcessListeners(emit, sessions, session) {
       err && err.code === "ENOENT"
         ? "Codex binary not found. Install codex or fix the spawn path."
         : `Codex spawn error: ${err?.message ?? String(err)}`;
-    console.warn(`[browser-local][codex] ${message}`);
+    console.warn(`${logPrefix} ${message}`);
     sessions.delete(session.id);
     if (session.currentPrompt) {
       rejectCurrentPrompt(session, new Error(message));
@@ -973,11 +979,12 @@ function attachProcessListeners(emit, sessions, session) {
   });
 }
 
-export function createProviderHandlers({ emit }) {
+export function createProviderHandlers({ emit, runtimeMode = "provider-runtime" }) {
   const sessions = new Map();
+  const codexLogPrefix = providerLogPrefix("codex", runtimeMode);
   const agentRegistry = createBrowserLocalAgentRegistry({ emit });
-  const claudeRuntime = createClaudeRuntime({ emit });
-  const geminiRuntime = createGeminiRuntime({ emit });
+  const claudeRuntime = createClaudeRuntime({ emit, runtimeMode });
+  const geminiRuntime = createGeminiRuntime({ emit, runtimeMode });
 
   async function withTemporaryCodexSession(cwd, callback) {
     const processHandle = spawnCodexProcess(cwd);
@@ -988,7 +995,7 @@ export function createProviderHandlers({ emit }) {
       currentModeId: "auto",
     });
     const tempSessions = new Map([[session.id, session]]);
-    attachProcessListeners(() => {}, tempSessions, session);
+    attachProcessListeners(() => {}, tempSessions, session, codexLogPrefix);
 
     try {
       await sendRequest(session, "initialize", buildInitializeParams(), 15_000);
@@ -1054,7 +1061,7 @@ export function createProviderHandlers({ emit }) {
     });
 
     sessions.set(sessionId, session);
-    attachProcessListeners(emit, sessions, session);
+    attachProcessListeners(emit, sessions, session, codexLogPrefix);
 
     try {
       await sendRequest(session, "initialize", buildInitializeParams(), 15_000);
@@ -1067,7 +1074,7 @@ export function createProviderHandlers({ emit }) {
       try {
         modelListResult = await sendRequest(session, "model/list", {}, 10_000);
       } catch (error) {
-        console.warn("[browser-local] Codex model/list failed:", error);
+        console.warn(`${codexLogPrefix} model/list failed:`, error);
         // If the process was terminated during model/list, don't continue
         // to thread/start on a dead process — it will just time out.
         const errMsg = error instanceof Error ? error.message : String(error);
@@ -1145,7 +1152,7 @@ export function createProviderHandlers({ emit }) {
         servedModelId !== requestedModelId
       ) {
         console.warn(
-          `[browser-local][codex] threadResult.model: requested=${requestedModelId}, served=${servedModelId}`,
+          `${codexLogPrefix} threadResult.model: requested=${requestedModelId}, served=${servedModelId}`,
         );
       }
       session.currentModelId =

--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -14,6 +14,8 @@ import { handleRpcMessage, registerHandler } from "./browser-local/rpc.mjs";
 process.env.SEREN_HOST = "seren-desktop";
 process.env.SEREN_DESKTOP = "1";
 
+const RUNTIME_MODE = "desktop-native";
+
 function usage() {
   console.log(`
 Usage: seren-provider-runtime [--host <address>] [--port <number>] [--token <value>]
@@ -71,7 +73,10 @@ function parseArgs(argv) {
 }
 
 function registerProviderHandlers() {
-  const providerHandlers = createProviderHandlers({ emit });
+  const providerHandlers = createProviderHandlers({
+    emit,
+    runtimeMode: RUNTIME_MODE,
+  });
 
   registerHandler("provider_spawn", providerHandlers.spawnSession);
   registerHandler("provider_prompt", providerHandlers.sendPrompt);
@@ -132,7 +137,7 @@ function startServer(config) {
   const server = http.createServer((req, res) => {
     if (req.url === "/__seren/health") {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: true, mode: "desktop-native" }));
+      res.end(JSON.stringify({ ok: true, mode: RUNTIME_MODE }));
       return;
     }
 
@@ -200,7 +205,7 @@ function startServer(config) {
     console.log(
       JSON.stringify({
         ok: true,
-        mode: "desktop-native",
+        mode: RUNTIME_MODE,
         host: config.host,
         port,
         token: config.token,

--- a/bin/seren-desktop.mjs
+++ b/bin/seren-desktop.mjs
@@ -33,6 +33,7 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const rootDir = resolve(__dirname, "..");
 const distDir = join(rootDir, "dist");
 const indexHtmlPath = join(distDir, "index.html");
+const RUNTIME_MODE = "browser-local";
 
 function usage() {
   console.log(`
@@ -151,7 +152,7 @@ function contentTypeForPath(pathname) {
 
 function injectRuntimeConfig(html, origin, projectRoot) {
   const runtimeConfig = {
-    mode: "browser-local",
+    mode: RUNTIME_MODE,
     capabilities: {
       agents: true,
       localFiles: true,
@@ -230,7 +231,10 @@ function registerBrowserLocalHandlers() {
   registerHandler("save_file_dialog", saveFileDialog);
   registerHandler("reveal_in_file_manager", revealInFileManager);
 
-  const providerHandlers = createProviderHandlers({ emit });
+  const providerHandlers = createProviderHandlers({
+    emit,
+    runtimeMode: RUNTIME_MODE,
+  });
 
   registerHandler("provider_spawn", providerHandlers.spawnSession);
   registerHandler("provider_prompt", providerHandlers.sendPrompt);
@@ -321,7 +325,7 @@ function main() {
       res.end(
         JSON.stringify({
           ok: true,
-          mode: "browser-local",
+          mode: RUNTIME_MODE,
           token: authToken,
           projectRoot,
         }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3713,16 +3713,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.2:
-    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.2:
-    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   seroval-plugins@1.5.4:
     resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
     engines: {node: '>=10'}
@@ -9147,10 +9137,6 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
-
-  semver@7.8.2: {}
-
-  semver@7.8.2: {}
 
   semver@7.8.2: {}
 

--- a/tests/unit/claude-spawn-replay-deferred.test.ts
+++ b/tests/unit/claude-spawn-replay-deferred.test.ts
@@ -102,10 +102,10 @@ describe("#1889 — spawn stderr log surfaces both Seren and Claude session ids"
     // Frontend events are tagged with the Seren-side `sessionId` (the value
     // of `session.id`). The stderr log previously only printed the Claude
     // CLI's `remoteSessionId`/`agentSessionId`, making the
-    // [browser-local][claude] spawn line useless when correlating with
+    // runtime-prefixed Claude spawn line useless when correlating with
     // [AgentRuntime] Event received logs in the renderer console.
     expect(runtimeSource).toMatch(
-      /\[browser-local\]\[claude\] spawn sessionId=\$\{(session\.id|sessionId)\}[\s\S]*?agentSessionId=\$\{remoteSessionId\}/,
+      /\$\{claudeLogPrefix\} spawn sessionId=\$\{(session\.id|sessionId)\}[\s\S]*?agentSessionId=\$\{remoteSessionId\}/,
     );
   });
 });

--- a/tests/unit/provider-runtime-log-prefix.test.ts
+++ b/tests/unit/provider-runtime-log-prefix.test.ts
@@ -1,0 +1,58 @@
+// ABOUTME: Regression coverage for #2195 provider runtime log prefixes.
+// ABOUTME: Desktop-native logs must not claim they came from browser-local.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { providerLogPrefix } from "../../bin/browser-local/logging.mjs";
+
+const runtimeLogFiles = [
+  "bin/browser-local/claude-runtime.mjs",
+  "bin/browser-local/gemini-runtime.mjs",
+  "bin/browser-local/providers.mjs",
+];
+
+function readSource(path: string): string {
+  return readFileSync(resolve(path), "utf8");
+}
+
+describe("#2195 — provider runtime log prefixes", () => {
+  it("formats provider logs with the actual runtime mode", () => {
+    expect(providerLogPrefix("claude", "desktop-native")).toBe(
+      "[desktop-native][claude]",
+    );
+    expect(providerLogPrefix("codex", "browser-local")).toBe(
+      "[browser-local][codex]",
+    );
+    expect(providerLogPrefix("gemini", "bad mode\n")).toBe(
+      "[provider-runtime][gemini]",
+    );
+  });
+
+  it("does not hard-code browser-local in provider console logs", () => {
+    const hardCodedBrowserLocalConsolePrefix =
+      /console\.(?:log|warn|error)\s*\([\s\S]{0,160}?(?:`|")\[browser-local\]/g;
+
+    const offenders = runtimeLogFiles.flatMap((path) => {
+      const source = readSource(path);
+      return Array.from(source.matchAll(hardCodedBrowserLocalConsolePrefix)).map(
+        (match) => {
+          const line = source.slice(0, match.index).split("\n").length;
+          return `${path}:${line}`;
+        },
+      );
+    });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("threads explicit runtime modes from both local runtime entry points", () => {
+    const nativeEntry = readSource("bin/provider-runtime.mjs");
+    const browserLocalEntry = readSource("bin/seren-desktop.mjs");
+
+    expect(nativeEntry).toContain('const RUNTIME_MODE = "desktop-native"');
+    expect(nativeEntry).toContain("runtimeMode: RUNTIME_MODE");
+    expect(browserLocalEntry).toContain('const RUNTIME_MODE = "browser-local"');
+    expect(browserLocalEntry).toContain("runtimeMode: RUNTIME_MODE");
+  });
+});


### PR DESCRIPTION
Closes #2195

## Summary
- add a shared provider log-prefix helper that formats prefixes from the active runtime mode
- thread browser-local vs desktop-native mode from both local runtime entry points into Claude, Codex, and Gemini logging
- remove duplicate pnpm lockfile semver entries that prevented pnpm from parsing the synced main lockfile

## Tests
- pnpm lint (exit 0; existing Biome warnings in unrelated src/components/session and EmployeeRunDetailModal paths)
- pnpm test -- tests/unit/provider-runtime-log-prefix.test.ts tests/unit/claude-spawn-replay-deferred.test.ts (runs full unit suite: 227 files, 1574 tests passed)
- node bin/provider-runtime.mjs --host 127.0.0.1 --port 0 --token test-token (spot-check emitted mode=desktop-native)