### PR TITLE
fix(dev): approve pnpm build scripts

### DIFF
--- a/mcp-servers/playwright-stealth/pnpm-workspace.yaml
+++ b/mcp-servers/playwright-stealth/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - "."
+
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+packages:
+  - "."
+
+allowBuilds:
+  bufferutil: false
+  esbuild: true
+  keccak: false
+  utf-8-validate: false

--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -96,7 +96,11 @@ function main(): void {
   // Use --node-linker=hoisted to create real files instead of pnpm symlinks.
   // Symlinks don't survive Tauri bundling or macOS notarization, so without
   // this the ws package is missing from the app bundle at runtime.
-  run("pnpm", ["install", "--prod", "--ignore-scripts", "--node-linker=hoisted"], destDir);
+  run(
+    "pnpm",
+    ["install", "--prod", "--ignore-workspace", "--ignore-scripts", "--node-linker=hoisted"],
+    destDir,
+  );
 
   writeFileSync(
     markerPath,


### PR DESCRIPTION
Closes #2206

## Summary
- add a checked-in pnpm-workspace.yaml build approval policy for pnpm v11
- allow esbuild's required postinstall binary setup
- explicitly deny optional native accelerator builds for bufferutil, utf-8-validate, and keccak so ignored builds are intentional instead of fatal

## Tests
- pnpm lint (red before fix with ERR_PNPM_IGNORED_BUILDS; green after fix)
- rm -rf node_modules && pnpm lint (fresh dependency state green)
- pnpm test -- tests/unit/provider-runtime-log-prefix.test.ts tests/unit/claude-spawn-replay-deferred.test.ts (runs full unit suite: 227 files, 1574 tests passed)