### PR TITLE
fix(meeting): surface capture failure causes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -61,13 +61,29 @@ pub async fn run_capture_stream(
             buffer_them_samples(buffer, &frame.samples);
         }
         for chunk in chunker.push(&frame.samples) {
-            emit_segment(&meeting_id, &speaker, chunk, transcriber.as_ref(), retry, &seq, sink.as_ref())
-                .await;
+            emit_segment(
+                &meeting_id,
+                &speaker,
+                chunk,
+                transcriber.as_ref(),
+                retry,
+                &seq,
+                sink.as_ref(),
+            )
+            .await;
         }
     }
     for chunk in chunker.finish() {
-        emit_segment(&meeting_id, &speaker, chunk, transcriber.as_ref(), retry, &seq, sink.as_ref())
-            .await;
+        emit_segment(
+            &meeting_id,
+            &speaker,
+            chunk,
+            transcriber.as_ref(),
+            retry,
+            &seq,
+            sink.as_ref(),
+        )
+        .await;
     }
 }
 
@@ -257,10 +273,12 @@ impl CaptureRegistry {
     /// Begin capturing the "Me" stream for `meeting_id`. Frames arrive via
     /// [`CaptureRegistry::push_frame`]; the worker transcribes and persists them.
     pub fn start(&self, app: &AppHandle, meeting_id: &str) {
+        log::info!("[meeting] capture registry start requested for {meeting_id}");
         let mut active = self.active.lock().unwrap();
         // Reject if the id is already live OR draining (`Stopping` tombstone): a
         // start that raced a still-running stop must not insert a second capture.
         if active.contains_key(meeting_id) {
+            log::warn!("[meeting] capture start ignored; slot already occupied for {meeting_id}");
             return;
         }
         // Me and Them share one sequence counter so segments order globally.
@@ -310,13 +328,19 @@ impl CaptureRegistry {
                 Some(them_audio.clone()),
             )));
             match source.start(tx.clone()) {
-                Ok(()) => them_tx = Some(tx),
+                Ok(()) => {
+                    log::info!("[meeting] system-audio capture started for {meeting_id}");
+                    them_tx = Some(tx);
+                }
                 Err(err) => {
                     log::warn!("[meeting] system-audio capture unavailable: {err}")
                 }
             }
+        } else {
+            log::info!("[meeting] system-audio capture unsupported on this platform");
         }
 
+        let has_system_audio = them_tx.is_some();
         active.insert(
             meeting_id.to_string(),
             CaptureSlot::Active(ActiveCapture {
@@ -326,6 +350,10 @@ impl CaptureRegistry {
                 tasks,
                 them_audio,
             }),
+        );
+        log::info!(
+            "[meeting] capture registry active for {meeting_id}; system_audio={}",
+            has_system_audio
         );
     }
 
@@ -509,7 +537,9 @@ mod tests {
         // Two utterances separated by silence -> two transcribed segments.
         let samples = [pcm(1_000, 80), pcm(0, 60), pcm(1_000, 80), pcm(0, 60)].concat();
         let (tx, rx) = unbounded_channel();
-        FakePcmSource::from_samples(samples, 1_000).start(tx).unwrap();
+        FakePcmSource::from_samples(samples, 1_000)
+            .start(tx)
+            .unwrap();
 
         let transcriber: Arc<dyn ChunkTranscriber + Send + Sync> = Arc::new(SequenceTranscriber {
             texts: Mutex::new(vec!["first".to_string(), "second".to_string()]),
@@ -551,7 +581,9 @@ mod tests {
 
         let samples = [pcm(1_000, 80), pcm(0, 60)].concat();
         let (tx, rx) = unbounded_channel();
-        FakePcmSource::from_samples(samples, 1_000).start(tx).unwrap();
+        FakePcmSource::from_samples(samples, 1_000)
+            .start(tx)
+            .unwrap();
 
         // No texts -> transcription always fails -> the window becomes a gap.
         let transcriber: Arc<dyn ChunkTranscriber + Send + Sync> = Arc::new(SequenceTranscriber {
@@ -587,7 +619,10 @@ mod tests {
     fn me_uses_plain_text_and_them_is_diarized() {
         // #2152 cost contract: the single-speaker mic must NOT use the costly
         // diarize model; only the multi-speaker system stream is diarized.
-        assert_eq!(transcription_mode_for(&Speaker::Me), TranscriptionMode::Text);
+        assert_eq!(
+            transcription_mode_for(&Speaker::Me),
+            TranscriptionMode::Text
+        );
         assert_eq!(
             transcription_mode_for(&Speaker::Them),
             TranscriptionMode::Diarized

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -143,6 +143,7 @@ pub struct Meeting {
     pub agent_conversation_id: Option<String>,
     pub notes_markdown: Option<String>,
     pub notes_struct_json: Option<String>,
+    pub failure_reason: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -63,10 +63,18 @@ pub async fn update_meeting_status(
     id: String,
     status: MeetingStatus,
     ended_at: Option<i64>,
+    failure_reason: Option<String>,
 ) -> Result<(), String> {
     let lookup = id.clone();
     run_db(app.clone(), move |conn| {
-        update_meeting_status_record(conn, &id, status, ended_at, now_ms())
+        update_meeting_status_record_with_failure_reason(
+            conn,
+            &id,
+            status,
+            ended_at,
+            failure_reason.as_deref(),
+            now_ms(),
+        )
     })
     .await?;
     emit_meeting_status_by_id(&app, &lookup).await;
@@ -263,12 +271,13 @@ pub async fn reconcile_meeting_speakers(
     // Reconcile against only the live Them segments — the Me mic is single-speaker
     // and is never relabeled by this pass.
     let lookup = meeting_id.clone();
-    let live_them: Vec<TranscriptSegment> =
-        run_db(app.clone(), move |conn| select_transcript_segments(conn, &lookup))
-            .await?
-            .into_iter()
-            .filter(|segment| segment.speaker == Speaker::Them)
-            .collect();
+    let live_them: Vec<TranscriptSegment> = run_db(app.clone(), move |conn| {
+        select_transcript_segments(conn, &lookup)
+    })
+    .await?
+    .into_iter()
+    .filter(|segment| segment.speaker == Speaker::Them)
+    .collect();
     if live_them.is_empty() {
         return Ok(0);
     }
@@ -289,7 +298,10 @@ pub async fn reconcile_meeting_speakers(
     })
     .await?;
 
-    let _ = app.emit("meeting://segments-updated", serde_json::json!({ "meetingId": meeting_id }));
+    let _ = app.emit(
+        "meeting://segments-updated",
+        serde_json::json!({ "meetingId": meeting_id }),
+    );
     Ok(updated)
 }
 
@@ -302,8 +314,10 @@ pub async fn generate_meeting_notes(
     vocabulary: Vec<String>,
 ) -> Result<ParsedNotes, String> {
     let lookup = meeting_id.clone();
-    let segments =
-        run_db(app.clone(), move |conn| select_transcript_segments(conn, &lookup)).await?;
+    let segments = run_db(app.clone(), move |conn| {
+        select_transcript_segments(conn, &lookup)
+    })
+    .await?;
     let transcript = assemble_transcript(segments);
     if transcript.trim().is_empty() {
         return Err("no transcript to summarize".to_string());
@@ -327,7 +341,10 @@ pub async fn get_meeting_transcript_text(
     app: AppHandle,
     meeting_id: String,
 ) -> Result<String, String> {
-    let segments = run_db(app, move |conn| select_transcript_segments(conn, &meeting_id)).await?;
+    let segments = run_db(app, move |conn| {
+        select_transcript_segments(conn, &meeting_id)
+    })
+    .await?;
     Ok(assemble_transcript(segments))
 }
 
@@ -478,9 +495,9 @@ pub fn insert_meeting(conn: &Connection, meeting: NewMeeting) -> Result<Meeting>
         "INSERT INTO meetings (
             id, title, source_app, started_at, ended_at, status, template_id,
             routed_skill_slug, agent_conversation_id, notes_markdown,
-            notes_struct_json, created_at, updated_at
+            notes_struct_json, failure_reason, created_at, updated_at
          )
-         VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, NULL, NULL, NULL, NULL, ?7, ?7)",
+         VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, NULL, NULL, NULL, NULL, NULL, ?7, ?7)",
         params![
             meeting.id,
             meeting.title,
@@ -499,7 +516,7 @@ pub fn select_meeting(conn: &Connection, id: &str) -> Result<Option<Meeting>> {
     conn.query_row(
         "SELECT id, title, source_app, started_at, ended_at, status, template_id,
                 routed_skill_slug, agent_conversation_id, notes_markdown,
-                notes_struct_json, created_at, updated_at
+                notes_struct_json, failure_reason, created_at, updated_at
          FROM meetings
          WHERE id = ?1",
         params![id],
@@ -512,7 +529,7 @@ pub fn select_meetings(conn: &Connection, limit: i32) -> Result<Vec<Meeting>> {
     let mut stmt = conn.prepare(
         "SELECT id, title, source_app, started_at, ended_at, status, template_id,
                 routed_skill_slug, agent_conversation_id, notes_markdown,
-                notes_struct_json, created_at, updated_at
+                notes_struct_json, failure_reason, created_at, updated_at
          FROM meetings
          ORDER BY started_at DESC
          LIMIT ?1",
@@ -529,15 +546,30 @@ pub fn update_meeting_status_record(
     ended_at: Option<i64>,
     updated_at: i64,
 ) -> Result<()> {
+    update_meeting_status_record_with_failure_reason(conn, id, status, ended_at, None, updated_at)
+}
+
+pub fn update_meeting_status_record_with_failure_reason(
+    conn: &Connection,
+    id: &str,
+    status: MeetingStatus,
+    ended_at: Option<i64>,
+    failure_reason: Option<&str>,
+    updated_at: i64,
+) -> Result<()> {
     // `ended_at` is set once, when capture stops. COALESCE keeps the existing
     // value when the caller passes None (status-only transitions like
     // agent_running/done), so the capture-end time survives the agent handoff
     // instead of being nulled and later overwritten with the agent-finish time
     // (#2174). A Some value still overwrites (e.g. stop_meeting_capture).
     conn.execute(
-        "UPDATE meetings SET status = ?1, ended_at = COALESCE(?2, ended_at), updated_at = ?3
-         WHERE id = ?4",
-        params![status.as_str(), ended_at, updated_at, id],
+        "UPDATE meetings
+         SET status = ?1,
+             ended_at = COALESCE(?2, ended_at),
+             failure_reason = CASE WHEN ?1 = 'failed' THEN ?3 ELSE NULL END,
+             updated_at = ?4
+         WHERE id = ?5",
+        params![status.as_str(), ended_at, failure_reason, updated_at, id],
     )?;
     Ok(())
 }
@@ -601,11 +633,7 @@ pub fn select_transcript_segments(
 /// Stamp a meeting-stable diarization label onto one segment. Used by the
 /// post-call reconcile pass; only `speaker_label`/`speaker_source` change, so the
 /// segment's text, timing, and channel `speaker` (Me/Them) are left intact.
-pub fn update_transcript_segment_speaker(
-    conn: &Connection,
-    id: &str,
-    label: &str,
-) -> Result<()> {
+pub fn update_transcript_segment_speaker(conn: &Connection, id: &str, label: &str) -> Result<()> {
     conn.execute(
         "UPDATE transcript_segments
          SET speaker_label = ?1, speaker_source = ?2
@@ -635,8 +663,9 @@ fn row_to_meeting(row: &rusqlite::Row<'_>) -> Result<Meeting> {
         agent_conversation_id: row.get(8)?,
         notes_markdown: row.get(9)?,
         notes_struct_json: row.get(10)?,
-        created_at: row.get(11)?,
-        updated_at: row.get(12)?,
+        failure_reason: row.get(11)?,
+        created_at: row.get(12)?,
+        updated_at: row.get(13)?,
     })
 }
 
@@ -762,6 +791,7 @@ mod tests {
         assert_eq!(loaded.title, "Customer discovery");
         assert_eq!(loaded.source_app.as_deref(), Some("Zoom"));
         assert_eq!(loaded.template_id.as_deref(), Some("discovery"));
+        assert_eq!(loaded.failure_reason, None);
     }
 
     #[test]
@@ -784,21 +814,45 @@ mod tests {
         update_meeting_status_record(&conn, "meeting-1", MeetingStatus::AgentRunning, None, 600)
             .unwrap();
         assert_eq!(
-            select_meeting(&conn, "meeting-1").unwrap().unwrap().ended_at,
+            select_meeting(&conn, "meeting-1")
+                .unwrap()
+                .unwrap()
+                .ended_at,
             Some(500)
         );
         // Done with None still preserves the capture-end time.
         update_meeting_status_record(&conn, "meeting-1", MeetingStatus::Done, None, 700).unwrap();
         assert_eq!(
-            select_meeting(&conn, "meeting-1").unwrap().unwrap().ended_at,
+            select_meeting(&conn, "meeting-1")
+                .unwrap()
+                .unwrap()
+                .ended_at,
             Some(500)
         );
         // A Some value overwrites.
-        update_meeting_status_record(&conn, "meeting-1", MeetingStatus::Failed, Some(900), 901)
-            .unwrap();
+        update_meeting_status_record_with_failure_reason(
+            &conn,
+            "meeting-1",
+            MeetingStatus::Failed,
+            Some(900),
+            Some("Microphone access is blocked."),
+            901,
+        )
+        .unwrap();
+        let failed = select_meeting(&conn, "meeting-1").unwrap().unwrap();
+        assert_eq!(failed.ended_at, Some(900));
         assert_eq!(
-            select_meeting(&conn, "meeting-1").unwrap().unwrap().ended_at,
-            Some(900)
+            failed.failure_reason.as_deref(),
+            Some("Microphone access is blocked.")
+        );
+
+        update_meeting_status_record(&conn, "meeting-1", MeetingStatus::Done, None, 950).unwrap();
+        assert_eq!(
+            select_meeting(&conn, "meeting-1")
+                .unwrap()
+                .unwrap()
+                .failure_reason,
+            None
         );
     }
 

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -340,6 +340,7 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             agent_conversation_id TEXT,
             notes_markdown TEXT,
             notes_struct_json TEXT,
+            failure_reason TEXT,
             created_at INTEGER NOT NULL,
             updated_at INTEGER NOT NULL,
             FOREIGN KEY (agent_conversation_id) REFERENCES conversations(id)
@@ -393,6 +394,15 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             [],
         )
         .ok();
+    }
+
+    // Migration: add persisted failure reasons to meetings for existing DBs.
+    let has_failure_reason: bool = conn
+        .prepare("SELECT failure_reason FROM meetings LIMIT 1")
+        .is_ok();
+    if !has_failure_reason {
+        conn.execute("ALTER TABLE meetings ADD COLUMN failure_reason TEXT", [])
+            .ok();
     }
 
     // Migration: add agent conversation columns if they don't exist (for existing DBs)

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -135,6 +135,17 @@ export function MeetingDetail(props: MeetingDetailProps) {
           </span>
           <span>{props.meeting.sourceApp ?? "Desktop"}</span>
         </div>
+        <Show
+          when={
+            props.meeting.status === "failed" && props.meeting.failureReason
+          }
+        >
+          {(reason) => (
+            <div class="mt-3 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-[12px] leading-5 text-destructive">
+              {reason()}
+            </div>
+          )}
+        </Show>
       </div>
 
       <div class="mb-4 flex items-center gap-2">

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -25,6 +25,7 @@ export interface Meeting {
   agentConversationId: string | null;
   notesMarkdown: string | null;
   notesStructJson: string | null;
+  failureReason?: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -85,8 +86,14 @@ export function updateMeetingStatus(
   id: string,
   status: MeetingStatus,
   endedAt?: number | null,
+  failureReason?: string | null,
 ): Promise<void> {
-  return invoke("update_meeting_status", { id, status, endedAt });
+  return invoke("update_meeting_status", {
+    id,
+    status,
+    endedAt,
+    failureReason,
+  });
 }
 
 export function updateMeetingNotes(

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -93,6 +93,63 @@ let isStarting = false;
 // running notes + the agent handoff. This guard makes the second a no-op (#2162).
 const processingMeetings = new Set<string>();
 
+function meetingErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Unknown error";
+}
+
+function captureStartupFailureReason(error: unknown): string {
+  const name = error instanceof DOMException ? error.name : "";
+  const message = meetingErrorMessage(error).toLowerCase();
+  if (
+    name === "NotAllowedError" ||
+    name === "SecurityError" ||
+    message.includes("permission") ||
+    message.includes("denied")
+  ) {
+    return "Microphone access is blocked. Allow microphone access for Seren, then start capture again.";
+  }
+  if (
+    name === "NotFoundError" ||
+    message.includes("requested device not found")
+  ) {
+    return "No microphone was found. Connect or enable a microphone, then start capture again.";
+  }
+  if (message.includes("audio context is suspended")) {
+    return "Audio capture could not start because the audio engine is suspended. Click Start capture again from the app window.";
+  }
+  if (message.includes("media devices") || message.includes("getusermedia")) {
+    return "Microphone capture is unavailable in this desktop WebView. Restart Seren and try capture again.";
+  }
+  return `Meeting capture could not start: ${meetingErrorMessage(error)}`;
+}
+
+function notesFailureReason(error: unknown): string {
+  const message = meetingErrorMessage(error);
+  if (message.toLowerCase().includes("no transcript")) {
+    return "No transcript was captured. Check microphone and system-audio permissions, then start capture again.";
+  }
+  return `Meeting notes could not be generated: ${message}`;
+}
+
+async function failMeeting(
+  meetingId: string,
+  reason: string,
+  endedAt: number | null = Date.now(),
+): Promise<void> {
+  await updateMeetingStatus(meetingId, "failed", endedAt, reason).catch(
+    () => {},
+  );
+  await loadMeetings();
+  setMeetingState("error", reason);
+  const refreshed =
+    meetingState.meetings.find((meeting) => meeting.id === meetingId) ?? null;
+  if (meetingState.activeMeeting?.id === meetingId || refreshed) {
+    await setActiveMeeting(refreshed);
+  }
+}
+
 async function loadMeetings(): Promise<void> {
   setMeetingState("isLoading", true);
   setMeetingState("error", null);
@@ -233,25 +290,37 @@ function stopMeetingEventListeners(): void {
   trayToggleUnlisten = null;
 }
 
-async function startCapture(meeting: Meeting): Promise<void> {
-  if (!isTauriRuntime()) return;
-  await startBackendCapture(meeting.id);
+async function startCapture(meeting: Meeting): Promise<boolean> {
+  if (!isTauriRuntime()) return false;
+  console.info("[meeting] capture start requested", { meetingId: meeting.id });
+  let backendStarted = false;
   try {
+    await startBackendCapture(meeting.id);
+    backendStarted = true;
+    console.info("[meeting] backend capture started", {
+      meetingId: meeting.id,
+    });
     captureHandle = await startMeetingMicCapture(meeting.id);
+    console.info("[meeting] microphone capture started", {
+      meetingId: meeting.id,
+    });
   } catch (error) {
     // The backend capture already started; tear it down and mark the meeting
     // failed so it doesn't linger as a "capturing" zombie, and make sure the
     // widget/tray aren't left signalling an active capture that never began.
-    await stopBackendCapture(meeting.id).catch(() => {});
-    await updateMeetingStatus(meeting.id, "failed", Date.now()).catch(() => {});
+    if (backendStarted) {
+      await stopBackendCapture(meeting.id).catch(() => {});
+    }
     void closeCaptureWidget();
     void setTrayRecording(false);
-    setMeetingState(
-      "error",
-      error instanceof Error ? error.message : "Microphone unavailable",
+    const reason = captureStartupFailureReason(error);
+    console.error(
+      "[meeting] capture startup failed",
+      { meetingId: meeting.id, reason },
+      error,
     );
-    await loadMeetings();
-    return;
+    await failMeeting(meeting.id, reason);
+    return false;
   }
   if (levelTimer !== null) window.clearInterval(levelTimer);
   levelTimer = window.setInterval(() => {
@@ -259,6 +328,7 @@ async function startCapture(meeting: Meeting): Promise<void> {
   }, 60);
   void openCaptureWidget(meeting.id);
   void setTrayRecording(true);
+  return true;
 }
 
 // Start a freshly-created meeting and surface it as the active one. Shared by
@@ -269,9 +339,12 @@ async function beginCapture(meeting: Meeting): Promise<void> {
   if (isCapturing()) return;
   isStarting = true;
   try {
-    await startCapture(meeting);
+    const started = await startCapture(meeting);
+    if (!started) return;
     await loadMeetings();
-    await setActiveMeeting(meeting);
+    await setActiveMeeting(
+      meetingState.meetings.find((item) => item.id === meeting.id) ?? meeting,
+    );
   } finally {
     isStarting = false;
   }
@@ -307,8 +380,10 @@ async function cancelPriming(): Promise<void> {
   const meeting = meetingState.primingRequest;
   setMeetingState("primingRequest", null);
   if (!meeting || !isTauriRuntime()) return;
-  await updateMeetingStatus(meeting.id, "failed", Date.now()).catch(() => {});
-  await loadMeetings();
+  await failMeeting(
+    meeting.id,
+    "Capture was canceled before audio permissions were requested.",
+  );
 }
 
 // At startup, any meeting left mid-pipeline is stale — no capture, notes pass,
@@ -328,7 +403,12 @@ async function reconcileStaleCaptures(): Promise<void> {
     if (stale.length === 0) return;
     await Promise.all(
       stale.map((meeting) =>
-        updateMeetingStatus(meeting.id, "failed").catch(() => {}),
+        updateMeetingStatus(
+          meeting.id,
+          "failed",
+          null,
+          "Seren restarted before this meeting finished processing.",
+        ).catch(() => {}),
       ),
     );
     await loadMeetings();
@@ -428,17 +508,13 @@ async function stopAndProcess(meeting: Meeting): Promise<void> {
       // Notes failed: the backend left the meeting at `transcribing` (it only
       // sets notes_ready on success). Mark it failed and stop — don't fall
       // through to runHandoff and auto-invoke a skill on an empty meeting (#2159).
-      setMeetingState(
-        "error",
-        error instanceof Error ? error.message : "Notes generation failed",
+      const reason = notesFailureReason(error);
+      console.error(
+        "[meeting] post-capture processing failed",
+        { meetingId: meeting.id, reason },
+        error,
       );
-      await updateMeetingStatus(meeting.id, "failed", Date.now()).catch(
-        () => {},
-      );
-      await loadMeetings();
-      await setActiveMeeting(
-        meetingState.meetings.find((m) => m.id === meeting.id) ?? null,
-      );
+      await failMeeting(meeting.id, reason);
       return;
     }
     await loadMeetings();
@@ -512,11 +588,11 @@ async function runHandoff(meeting: Meeting): Promise<void> {
     // overwritten with the agent-finish time (#2174).
     await updateMeetingStatus(meeting.id, "done");
   } catch (error) {
-    setMeetingState(
-      "error",
-      error instanceof Error ? error.message : "Agent handoff failed",
+    const reason = `Agent handoff failed: ${meetingErrorMessage(error)}`;
+    setMeetingState("error", reason);
+    await updateMeetingStatus(meeting.id, "failed", null, reason).catch(
+      () => {},
     );
-    await updateMeetingStatus(meeting.id, "failed").catch(() => {});
   }
   await loadMeetings();
 }
@@ -565,7 +641,7 @@ async function pollAutoDetect(): Promise<void> {
     setMeetingState("autoDetectSuggested", false);
     return;
   }
-  if (isCapturing() || autoDetectDismissed) {
+  if (isCapturing()) {
     setMeetingState("autoDetectSuggested", false);
     return;
   }
@@ -574,7 +650,12 @@ async function pollAutoDetect(): Promise<void> {
     const detected = await meetingAutodetect(
       settingsStore.get("meetingAppAllowlist"),
     );
-    setMeetingState("autoDetectSuggested", detected);
+    if (!detected) {
+      autoDetectDismissed = false;
+      setMeetingState("autoDetectSuggested", false);
+      return;
+    }
+    setMeetingState("autoDetectSuggested", !autoDetectDismissed);
   } catch {
     // Probe failures are non-fatal; leave the prompt as-is.
   }

--- a/tests/unit/meeting-autodetect-dismiss-reset.test.ts
+++ b/tests/unit/meeting-autodetect-dismiss-reset.test.ts
@@ -1,0 +1,72 @@
+// ABOUTME: Regression coverage for #2209 — dismissed auto-record prompts must re-arm after calls end.
+// ABOUTME: The poll must still probe while dismissed so a later call can prompt again.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const m = vi.hoisted(() => ({
+  meetingAutodetect: vi.fn(async () => false),
+  listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
+}));
+
+vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tauri-bridge")>()),
+  isTauriRuntime: () => true,
+}));
+vi.mock("@/services/meetings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/meetings")>()),
+  meetingAutodetect: m.meetingAutodetect,
+  listMeetings: m.listMeetings,
+}));
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: (key: string) => {
+      if (key === "meetingAutoDetectEnabled") return true;
+      if (key === "meetingAppAllowlist") return ["zoom"];
+      return undefined;
+    },
+    set: vi.fn(),
+  },
+}));
+
+import type { Meeting } from "@/services/meetings";
+import { meetingStore } from "@/stores/meeting.store";
+
+describe("meeting auto-detect dismissal reset (#2209)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", {
+      setInterval: globalThis.setInterval,
+      clearInterval: globalThis.clearInterval,
+    });
+    m.meetingAutodetect.mockReset();
+    m.listMeetings.mockResolvedValue([]);
+    meetingStore.stopAutoDetect();
+    meetingStore.resetAutoDetectDismissal();
+  });
+
+  afterEach(() => {
+    meetingStore.stopAutoDetect();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("re-arms the record prompt after the previously dismissed call app disappears", async () => {
+    m.meetingAutodetect.mockResolvedValueOnce(true);
+    meetingStore.startAutoDetect();
+    await Promise.resolve();
+
+    expect(meetingStore.state.autoDetectSuggested).toBe(true);
+    meetingStore.dismissAutoDetect();
+    expect(meetingStore.state.autoDetectSuggested).toBe(false);
+
+    m.meetingAutodetect.mockResolvedValueOnce(false);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(meetingStore.state.autoDetectSuggested).toBe(false);
+
+    m.meetingAutodetect.mockResolvedValueOnce(true);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(m.meetingAutodetect).toHaveBeenCalledTimes(3);
+    expect(meetingStore.state.autoDetectSuggested).toBe(true);
+  });
+});

--- a/tests/unit/meeting-capture-start-failure.test.ts
+++ b/tests/unit/meeting-capture-start-failure.test.ts
@@ -1,0 +1,129 @@
+// ABOUTME: Regression coverage for #2209 — capture startup failures must be loud and persistent.
+// ABOUTME: A mic/WebAudio failure should not leave only a silent Failed row.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const m = vi.hoisted(() => ({
+  startMeetingCapture: vi.fn(async () => {}),
+  stopMeetingCapture: vi.fn(async () => {}),
+  updateMeetingStatus: vi.fn(async () => {}),
+  listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
+  getTranscriptSegments: vi.fn(async () => []),
+  startMeetingMicCapture: vi.fn(async () => {
+    throw new DOMException("Permission denied", "NotAllowedError");
+  }),
+  closeCaptureWidget: vi.fn(),
+  openCaptureWidget: vi.fn(),
+  setTrayRecording: vi.fn(),
+}));
+
+vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tauri-bridge")>()),
+  isTauriRuntime: () => true,
+}));
+vi.mock("@/lib/audio/meetingCapture", () => ({
+  startMeetingMicCapture: m.startMeetingMicCapture,
+}));
+vi.mock("@/services/meetings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/meetings")>()),
+  startMeetingCapture: m.startMeetingCapture,
+  stopMeetingCapture: m.stopMeetingCapture,
+  updateMeetingStatus: m.updateMeetingStatus,
+  listMeetings: m.listMeetings,
+  getTranscriptSegments: m.getTranscriptSegments,
+}));
+vi.mock("@/services/captureWidget", () => ({
+  closeCaptureWidget: m.closeCaptureWidget,
+  openCaptureWidget: m.openCaptureWidget,
+  onWidgetStopRequest: vi.fn(() => () => {}),
+}));
+vi.mock("@/services/tray", () => ({
+  setTrayRecording: m.setTrayRecording,
+  onTrayToggleCapture: vi.fn(() => () => {}),
+}));
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: (key: string) => key === "meetingAudioPrimed",
+    set: vi.fn(),
+  },
+}));
+vi.mock("@/stores/provider.store", () => ({
+  providerStore: { resolvedModel: () => "model", activeModel: "model" },
+}));
+vi.mock("@/stores/skills.store", () => ({
+  skillsStore: { enabledSkills: [] },
+}));
+
+import type { Meeting } from "@/services/meetings";
+import { meetingStore } from "@/stores/meeting.store";
+
+function meeting(overrides: Partial<Meeting> = {}): Meeting {
+  return {
+    id: "m1",
+    title: "Sync",
+    sourceApp: "Manual",
+    startedAt: 0,
+    endedAt: null,
+    status: "capturing",
+    templateId: null,
+    routedSkillSlug: null,
+    agentConversationId: null,
+    notesMarkdown: null,
+    notesStructJson: null,
+    failureReason: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("meetingStore capture startup failure visibility (#2209)", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(m)) fn.mockClear();
+    m.startMeetingMicCapture.mockRejectedValue(
+      new DOMException("Permission denied", "NotAllowedError"),
+    );
+    m.listMeetings.mockResolvedValue([
+      meeting({
+        status: "failed",
+        failureReason:
+          "Microphone access is blocked. Allow microphone access for Seren, then start capture again.",
+      }),
+    ]);
+    meetingStore.clearError();
+  });
+
+  it("marks the meeting failed with an actionable reason and logs the startup error", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    await meetingStore.requestCaptureStart(meeting());
+
+    expect(m.startMeetingCapture).toHaveBeenCalledWith("m1");
+    expect(m.stopMeetingCapture).toHaveBeenCalledWith("m1");
+    expect(m.updateMeetingStatus).toHaveBeenCalledWith(
+      "m1",
+      "failed",
+      expect.any(Number),
+      expect.stringContaining("Microphone access is blocked"),
+    );
+    expect(m.openCaptureWidget).not.toHaveBeenCalled();
+    expect(m.closeCaptureWidget).toHaveBeenCalled();
+    expect(m.setTrayRecording).toHaveBeenCalledWith(false);
+    expect(meetingStore.state.error).toContain("Microphone access is blocked");
+    expect(consoleInfo).toHaveBeenCalledWith(
+      "[meeting] capture start requested",
+      { meetingId: "m1" },
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "[meeting] capture startup failed",
+      expect.objectContaining({ meetingId: "m1" }),
+      expect.any(DOMException),
+    );
+
+    consoleError.mockRestore();
+    consoleInfo.mockRestore();
+  });
+});

--- a/tests/unit/meeting-handoff-terminal.test.ts
+++ b/tests/unit/meeting-handoff-terminal.test.ts
@@ -114,7 +114,12 @@ describe("meetingStore handoff terminal status (#2158)", () => {
 
     await meetingStore.stopAndProcess(meeting());
 
-    expect(m.updateMeetingStatus).toHaveBeenCalledWith("m1", "failed");
+    expect(m.updateMeetingStatus).toHaveBeenCalledWith(
+      "m1",
+      "failed",
+      null,
+      expect.stringContaining("Agent handoff failed"),
+    );
     expect(m.updateMeetingStatus).not.toHaveBeenCalledWith("m1", "done");
   });
 });

--- a/tests/unit/meeting-notes-failure-gate.test.ts
+++ b/tests/unit/meeting-notes-failure-gate.test.ts
@@ -109,6 +109,7 @@ describe("meetingStore notes-failure gates handoff (#2159)", () => {
       "m1",
       "failed",
       expect.any(Number),
+      expect.stringContaining("Meeting notes could not be generated"),
     );
     // No handoff: the skill router and agent run must never fire.
     expect(m.selectMeetingSkills).not.toHaveBeenCalled();

--- a/tests/unit/meeting-priming-cancel.test.ts
+++ b/tests/unit/meeting-priming-cancel.test.ts
@@ -62,6 +62,7 @@ describe("meetingStore priming cancel + reconcile (#2160)", () => {
       "z1",
       "failed",
       expect.any(Number),
+      expect.stringContaining("canceled"),
     );
     expect(services.listMeetings).toHaveBeenCalled();
   });
@@ -80,7 +81,12 @@ describe("meetingStore priming cancel + reconcile (#2160)", () => {
     // Fail every mid-pipeline zombie, with no ended_at so a captured row keeps
     // its capture-end time (#2174).
     for (const id of ["cap", "trans", "agent"]) {
-      expect(services.updateMeetingStatus).toHaveBeenCalledWith(id, "failed");
+      expect(services.updateMeetingStatus).toHaveBeenCalledWith(
+        id,
+        "failed",
+        null,
+        expect.stringContaining("Seren restarted"),
+      );
     }
     // Terminal/resting rows are left alone.
     for (const id of ["done1", "notes"]) {


### PR DESCRIPTION
Fixes #2209

## Summary
- persist `failure_reason` on failed meetings and show it in Meeting detail
- make capture startup failures loud in Console and the Meeting panel instead of leaving only a silent Failed row
- prevent failed startup cleanup from being overwritten by a stale active meeting reload
- re-arm the app-wide auto-record prompt after a dismissed call app disappears
- add native capture lifecycle logs for macOS/Windows system-audio startup and fallback

## Failure audit
- User log `~/Downloads/Logs/20260608_record_fail2.log` and follow-up console output showed provider/app startup only; no `[meeting]`/`meeting://` diagnostics after capture attempts.
- Screenshots showed repeated Meeting rows immediately marked `Failed`, no transcript/notes, and no visible failure cause.
- Prior PRs #2208/#2186, #2196/#2194, #2205/#2203, #2150, #2169, and #2182 covered adjacent post-call, AudioContext, prompt, and lifecycle issues but not this silent startup/failure-cause path.

## Verification
- `pnpm vitest run tests/unit/meeting-capture-start-failure.test.ts tests/unit/meeting-autodetect-dismiss-reset.test.ts tests/unit/meeting-priming-cancel.test.ts tests/unit/meeting-notes-failure-gate.test.ts tests/unit/meeting-handoff-terminal.test.ts tests/unit/meeting-concurrent-stop.test.ts tests/unit/meeting-speaker-reconcile-gate.test.ts tests/unit/meeting-transcript-order.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml audio --lib`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`

## Functional audit
- Manual startup failure: backend partial start is stopped, widget/tray indicators are cleared, failed row stores a reason, panel error stays visible, and Console logs the startup phase and error.
- Empty transcript/notes failure: failed row stores an actionable no-transcript or notes error and does not route to agent handoff.
- Auto-detect prompt: dismissal suppresses the current detected app, but polling continues; seeing no app resets dismissal so the next call can prompt.
- Native system audio: macOS/Windows source failures remain non-fatal to mic capture but now emit visible native logs.