### PR TITLE
fix(agent): scrub generated skill primer from chat history

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -23,6 +23,10 @@ import { extractAgentThinkingMarkup } from "@/lib/agent-thinking-markup";
 import { isAuthError, isLikelyAuthError } from "@/lib/auth-errors";
 import { collapseBuildOutput } from "@/lib/build-output";
 import {
+  formatChatHistoryMarkdown,
+  hasExportableMessages,
+} from "@/lib/chat-history-export";
+import {
   getCompletions,
   isInvokableSkill,
   parseCommand,
@@ -620,20 +624,14 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
   const copyAllChatHistory = async () => {
     const messages = threadMessages();
-    if (messages.length === 0) {
+    if (!hasExportableMessages(messages)) {
       alert("No chat history to copy");
       return;
     }
 
-    // Format messages as markdown
-    let markdown = "# Agent Chat History\n\n";
-    for (const msg of messages) {
-      if (msg.type === "user") {
-        markdown += `**You:** ${msg.content}\n\n`;
-      } else if (msg.type === "assistant") {
-        markdown += `**Agent:** ${msg.content}\n\n`;
-      }
-    }
+    const markdown = formatChatHistoryMarkdown(messages, {
+      header: "# Agent Chat History",
+    });
 
     try {
       await navigator.clipboard.writeText(markdown);
@@ -649,20 +647,16 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const downloadChatHistory = async () => {
     if (isSaving()) return;
     const messages = threadMessages();
-    if (messages.length === 0) return;
+    if (!hasExportableMessages(messages)) return;
 
-    const dateStr = new Date().toISOString().split("T")[0];
+    const now = new Date();
+    const dateStr = now.toISOString().split("T")[0];
     const title = `Agent Chat History - ${dateStr}`;
 
-    let markdown = "# Agent Chat History\n\n";
-    markdown += `*Exported ${new Date().toLocaleString()}*\n\n---\n\n`;
-    for (const msg of messages) {
-      if (msg.type === "user") {
-        markdown += `**You:** ${msg.content}\n\n`;
-      } else if (msg.type === "assistant") {
-        markdown += `**Agent:** ${msg.content}\n\n`;
-      }
-    }
+    const markdown = formatChatHistoryMarkdown(messages, {
+      header: "# Agent Chat History",
+      exportedAt: now,
+    });
 
     setIsSaving(true);
     try {

--- a/src/lib/chat-history-export.ts
+++ b/src/lib/chat-history-export.ts
@@ -1,11 +1,39 @@
 // ABOUTME: Renders a conversation as plain-text markdown for copy/save exports.
 // ABOUTME: Filters out tool calls, tool results, and other non-chat message types.
 
-import type { UnifiedMessage } from "@/types/conversation";
-
 export interface ChatHistoryExportMessage {
-  type: UnifiedMessage["type"];
+  type: string;
   content: string;
+}
+
+const ACTIVE_SKILLS_HEADER = "# Active Skills";
+const PUBLISHER_PRIMER_MARKERS = ["list_agent_publishers", "call_publisher"];
+const SKILL_MANIFEST_MARKERS = [
+  "Skill runtime directory",
+  "Before using this skill, open",
+  "/SKILL.md",
+];
+
+export function isGeneratedPromptPrimer(content: string): boolean {
+  const trimmed = content.trimStart();
+  const hasActiveSkillsHeader = trimmed.includes(ACTIVE_SKILLS_HEADER);
+  if (!hasActiveSkillsHeader) return false;
+
+  const hasPublisherPrimer = PUBLISHER_PRIMER_MARKERS.every((marker) =>
+    trimmed.includes(marker),
+  );
+  const hasSkillManifest = SKILL_MANIFEST_MARKERS.some((marker) =>
+    trimmed.includes(marker),
+  );
+
+  return hasPublisherPrimer || hasSkillManifest;
+}
+
+function exportableMessageContent(
+  message: ChatHistoryExportMessage,
+): string | null {
+  if (isGeneratedPromptPrimer(message.content)) return null;
+  return message.content;
 }
 
 /**
@@ -29,10 +57,13 @@ export function formatChatHistoryMarkdown(
     markdown += `*Exported ${options.exportedAt.toLocaleString()}*\n\n---\n\n`;
   }
   for (const msg of messages) {
+    const content = exportableMessageContent(msg);
+    if (content === null) continue;
+
     if (msg.type === "user") {
-      markdown += `**You:** ${msg.content}\n\n`;
+      markdown += `**You:** ${content}\n\n`;
     } else if (msg.type === "assistant") {
-      markdown += `**Assistant:** ${msg.content}\n\n`;
+      markdown += `**Assistant:** ${content}\n\n`;
     }
   }
   return markdown;
@@ -42,5 +73,9 @@ export function formatChatHistoryMarkdown(
 export function hasExportableMessages(
   messages: readonly ChatHistoryExportMessage[],
 ): boolean {
-  return messages.some((m) => m.type === "user" || m.type === "assistant");
+  return messages.some(
+    (m) =>
+      (m.type === "user" || m.type === "assistant") &&
+      exportableMessageContent(m) !== null,
+  );
 }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -13,6 +13,7 @@ import {
   isLocalProviderRuntime,
   onRuntimeEvent,
 } from "@/lib/browser-local-runtime";
+import { isGeneratedPromptPrimer } from "@/lib/chat-history-export";
 import {
   type PrunableMessage,
   pruneCompactedHistory,
@@ -6267,9 +6268,9 @@ export const agentStore = {
       return;
     }
 
-    // Skill context can arrive as a userMessage event when the provider stores
-    // context items as user turns. Discard it — same as in finalizeStreamingContent.
-    if (session.pendingUserMessage.trimStart().startsWith("# Active Skills")) {
+    // Provider replay can store prompt primers as user turns. Discard them,
+    // including the #2212 shape where publisher text precedes Active Skills.
+    if (isGeneratedPromptPrimer(session.pendingUserMessage)) {
       setState("sessions", sessionId, "pendingUserMessage", "");
       setState("sessions", sessionId, "pendingUserMessageId", undefined);
       setState("sessions", sessionId, "pendingUserMessageTimestamp", undefined);
@@ -6897,9 +6898,9 @@ export const agentStore = {
       // calls: the first chunk starts with '# Active Skills' (caught here), but
       // subsequent chunks of the same block start mid-content. The
       // isSkippingSkillContext flag ensures those continuations are also dropped.
-      const isSkillContextStart = session.streamingContent
-        .trimStart()
-        .startsWith("# Active Skills");
+      const isSkillContextStart = isGeneratedPromptPrimer(
+        session.streamingContent,
+      );
       if (isSkillContextStart || session.isSkippingSkillContext) {
         if (isSkillContextStart) {
           setState("sessions", sessionId, "isSkippingSkillContext", true);

--- a/tests/unit/agent-skills-priming.test.ts
+++ b/tests/unit/agent-skills-priming.test.ts
@@ -75,4 +75,18 @@ describe("agent skill context priming", () => {
     expect(compactIdx).toBeGreaterThan(signatureIdx);
     expect(returnIdx).toBeGreaterThan(compactIdx);
   });
+
+  it("#2212 filters generated primer replay even when publisher text precedes active skills", () => {
+    const start = agentStoreSource.indexOf(
+      "flushPendingUserMessage(sessionId: string)",
+    );
+    expect(start).toBeGreaterThan(0);
+    const end = agentStoreSource.indexOf("\n  },", start);
+    expect(end).toBeGreaterThan(start);
+    const body = agentStoreSource.slice(start, end);
+
+    expect(agentStoreSource).toContain("isGeneratedPromptPrimer");
+    expect(body).toContain("isGeneratedPromptPrimer(session.pendingUserMessage)");
+    expect(body).not.toContain('startsWith("# Active Skills")');
+  });
 });

--- a/tests/unit/chat-history-export.test.ts
+++ b/tests/unit/chat-history-export.test.ts
@@ -64,4 +64,35 @@ describe("formatChatHistoryMarkdown", () => {
     ];
     expect(hasExportableMessages(messages)).toBe(true);
   });
+
+  it("#2212 excludes generated publisher and active-skills primer content embedded in chat rows", () => {
+    const messages: ChatHistoryExportMessage[] = [
+      {
+        type: "user",
+        content:
+          "You have access to a Seren MCP gateway with callable publishers via your seren-mcp tools (list_agent_publishers, call_publisher).\n\n# Active Skills\n\n## Skill: Demo\n\n> **Skill runtime directory:** `/Users/me/.config/seren/skills/demo`\n\nBefore using this skill, open `/Users/me/.config/seren/skills/demo/SKILL.md` and follow its full instructions.",
+      },
+      { type: "assistant", content: "Ready." },
+    ];
+
+    const md = formatChatHistoryMarkdown(messages);
+
+    expect(md).not.toContain("# Active Skills");
+    expect(md).not.toContain("list_agent_publishers");
+    expect(md).not.toContain("Skill runtime directory");
+    expect(md).toContain("**Assistant:** Ready.");
+  });
+
+  it("#2212 keeps normal user discussion about active skills", () => {
+    const messages: ChatHistoryExportMessage[] = [
+      {
+        type: "user",
+        content: "Why did the phrase # Active Skills appear in my chat?",
+      },
+    ];
+
+    const md = formatChatHistoryMarkdown(messages);
+
+    expect(md).toContain("Why did the phrase # Active Skills appear");
+  });
 });


### PR DESCRIPTION
Closes #2212.

## Summary

- Adds a shared generated-primer detector for publisher/active-skill prompt blocks embedded in chat rows.
- Uses that detector in `agent.store.ts` so Codex provider replay does not append/persist generated primer text as a visible `user` message, including the regression shape where publisher live-query text appears before `# Active Skills`.
- Reuses the shared chat-history formatter from Agent Chat copy/download so persisted polluted rows are scrubbed from support/export logs.
- Adds focused regression tests for the replay guard and export sanitizer without broad duplicate coverage.

## Audit Results

Prior fixes checked:

- #1102 filtered assistant replay skill-context messages.
- #1111 filtered user-message replay only when content started with `# Active Skills` and suppressed assistant continuations.
- #1961 reduced repeated active-skill priming.
- #2043 made compact skill context the default.

Regression cause: publisher live-query priming can precede active-skill content, and `bin/browser-local/providers.mjs` combines context plus user prompt into Codex text input. Codex replay can emit that combined input as a `userMessage`, bypassing the old starts-with guard.

Impact of this fix:

- Future replayed generated primer rows are discarded at the agent-store boundary.
- Existing polluted rows are filtered during Agent Chat copy/download and normal chat export.
- Normal user discussion that merely mentions `# Active Skills` remains exportable.

## Verification

- `pnpm test tests/unit/chat-history-export.test.ts tests/unit/agent-skills-priming.test.ts`
- `pnpm test tests/unit/agent-history-persistence.test.ts tests/unit/codex-agent-image-context.test.ts tests/unit/publisher-live-query-instruction.test.ts tests/unit/chat-history-export.test.ts tests/unit/agent-skills-priming.test.ts`
- `pnpm test` — 230 files, 1581 tests passed
- `pnpm exec biome check src/lib/chat-history-export.ts src/stores/agent.store.ts src/components/chat/AgentChat.tsx tests/unit/chat-history-export.test.ts tests/unit/agent-skills-priming.test.ts`
- `pnpm check` — exits 0; existing warnings outside changed files remain
- `pnpm build` — exits 0; existing Vite/Rolldown dependency warnings remain
- Functional sanitizer audit via `pnpm exec tsx -e ...` confirms generated primer drops, normal discussion remains, and assistant text remains.

Note: `pnpm exec tsc --noEmit --pretty false` currently fails on an existing repo issue in `tests/unit/provider-runtime-log-prefix.test.ts`: missing declaration for `../../bin/browser-local/logging.mjs`. This patch does not touch that path.
