### PR TITLE
fix(meeting): gate record prompt on active input

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4524,15 +4524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4758,16 +4749,6 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
  "objc2-core-foundation",
 ]
 
@@ -7018,7 +6999,6 @@ dependencies = [
  "serenity",
  "sha2 0.10.9",
  "sqlite-vec",
- "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
@@ -7049,6 +7029,7 @@ dependencies = [
  "wacore",
  "wasapi",
  "whatsapp-rust",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -7570,20 +7551,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.62.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,7 +39,6 @@ serde_json = "1"
 rusqlite = { version = "0.33", features = ["bundled"] }
 sqlite-vec = "0.1"
 notify = "8"
-sysinfo = { version = "0.38", default-features = false, features = ["system"] }
 lazy_static = "1"
 tokio = { version = "1", features = ["process", "io-util", "sync", "io-std", "time"] }
 tokio-util = { version = "0.7", features = ["compat"] }
@@ -105,6 +104,11 @@ tauri-plugin-single-instance = "2"
 # System-audio ("Them") loopback capture for Meeting Mode.
 [target.'cfg(target_os = "windows")'.dependencies]
 wasapi = "0.15"
+windows = { version = "0.57", features = [
+    "Win32_Foundation",
+    "Win32_Media_Audio",
+    "Win32_System_Com",
+] }
 
 # System-audio ("Them") process-tap capture for Meeting Mode (CoreAudio + ObjC FFI).
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/src/audio/detect.rs
+++ b/src-tauri/src/audio/detect.rs
@@ -1,56 +1,187 @@
-// ABOUTME: Pure meeting auto-detect decision logic for capture arming.
-// ABOUTME: Keeps OS process probes separate from testable policy rules.
+// ABOUTME: Meeting auto-detect decision logic for capture arming.
+// ABOUTME: Uses passive platform audio activity probes, not process-name presence.
 
-use sysinfo::{ProcessRefreshKind, RefreshKind, System, UpdateKind};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RunningProcess {
-    pub name: String,
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AudioActivity {
+    pub input_active: bool,
 }
 
-/// Enumerate running process names via sysinfo. This is OS I/O kept out of the
-/// pure `should_start_capture` policy so the decision stays unit-testable.
-/// Reliable mic-in-use detection is not portable across macOS/Windows/Linux, so
-/// we report `mic_in_use = false` and lean on the meeting-app allowlist path.
-pub fn probe_running_processes() -> Vec<RunningProcess> {
-    // Force the executable path to be resolved so `name()` is derived from the
-    // exe basename on every platform. `ProcessRefreshKind::nothing()` leaves the
-    // name empty for processes whose kernel-side name isn't readable, which
-    // breaks the allowlist match. `with_exe(Always)` is the minimal kind that
-    // guarantees a populated name.
-    let system = System::new_with_specifics(
-        RefreshKind::nothing()
-            .with_processes(ProcessRefreshKind::nothing().with_exe(UpdateKind::Always)),
-    );
-
-    system
-        .processes()
-        .values()
-        .map(|process| RunningProcess {
-            name: process.name().to_string_lossy().into_owned(),
-        })
-        .collect()
+/// Read whether the default input device is actively used by another app. The
+/// platform probes are passive OS status checks; they do not open or record mic
+/// audio.
+pub fn probe_audio_activity() -> AudioActivity {
+    platform_audio::probe_audio_activity()
 }
 
-pub fn should_start_capture(
-    processes: &[RunningProcess],
-    mic_in_use: bool,
-    meeting_app_allowlist: &[String],
-) -> bool {
-    if mic_in_use {
-        return true;
+pub fn should_start_capture(activity: AudioActivity, _meeting_app_allowlist: &[String]) -> bool {
+    activity.input_active
+}
+
+#[cfg(target_os = "macos")]
+mod platform_audio {
+    use super::AudioActivity;
+    use std::ffi::c_void;
+
+    type OSStatus = i32;
+    type AudioObjectID = u32;
+    type AudioObjectPropertySelector = u32;
+    type AudioObjectPropertyScope = u32;
+    type AudioObjectPropertyElement = u32;
+
+    const NO_ERR: OSStatus = 0;
+    const K_AUDIO_OBJECT_SYSTEM_OBJECT: AudioObjectID = 1;
+    const K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL: AudioObjectPropertyScope = fourcc(b"glob");
+    const K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN: AudioObjectPropertyElement = 0;
+    const K_AUDIO_HARDWARE_PROPERTY_DEFAULT_INPUT_DEVICE: AudioObjectPropertySelector =
+        fourcc(b"dIn ");
+    const K_AUDIO_DEVICE_PROPERTY_DEVICE_IS_RUNNING_SOMEWHERE: AudioObjectPropertySelector =
+        fourcc(b"gone");
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct AudioObjectPropertyAddress {
+        selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement,
     }
 
-    processes.iter().any(|process| {
-        meeting_app_allowlist.iter().any(|allowed| {
-            let allowed = allowed.trim();
-            !allowed.is_empty()
-                && process
-                    .name
-                    .to_lowercase()
-                    .contains(&allowed.to_lowercase())
-        })
-    })
+    #[link(name = "CoreAudio", kind = "framework")]
+    unsafe extern "C" {
+        fn AudioObjectGetPropertyData(
+            in_object_id: AudioObjectID,
+            in_address: *const AudioObjectPropertyAddress,
+            in_qualifier_data_size: u32,
+            in_qualifier_data: *const c_void,
+            io_data_size: *mut u32,
+            out_data: *mut c_void,
+        ) -> OSStatus;
+    }
+
+    pub(super) fn probe_audio_activity() -> AudioActivity {
+        AudioActivity {
+            input_active: default_input_device_is_running(),
+        }
+    }
+
+    const fn fourcc(code: &[u8; 4]) -> u32 {
+        ((code[0] as u32) << 24)
+            | ((code[1] as u32) << 16)
+            | ((code[2] as u32) << 8)
+            | (code[3] as u32)
+    }
+
+    fn default_input_device_is_running() -> bool {
+        let Some(device_id) = audio_object_u32(
+            K_AUDIO_OBJECT_SYSTEM_OBJECT,
+            K_AUDIO_HARDWARE_PROPERTY_DEFAULT_INPUT_DEVICE,
+        ) else {
+            return false;
+        };
+        if device_id == 0 {
+            return false;
+        }
+
+        audio_object_u32(
+            device_id,
+            K_AUDIO_DEVICE_PROPERTY_DEVICE_IS_RUNNING_SOMEWHERE,
+        )
+        .is_some_and(|running| running != 0)
+    }
+
+    fn audio_object_u32(
+        object_id: AudioObjectID,
+        selector: AudioObjectPropertySelector,
+    ) -> Option<u32> {
+        let address = AudioObjectPropertyAddress {
+            selector,
+            scope: K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL,
+            element: K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+        };
+        let mut value = 0_u32;
+        let mut size = std::mem::size_of::<u32>() as u32;
+
+        // SAFETY: `object_id` and property selector are read-only CoreAudio
+        // queries; all pointers reference live stack values for this call.
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object_id,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut size,
+                &mut value as *mut u32 as *mut c_void,
+            )
+        };
+
+        if status == NO_ERR && size as usize == std::mem::size_of::<u32>() {
+            Some(value)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod platform_audio {
+    use super::AudioActivity;
+    use wasapi::initialize_mta;
+    use windows::Win32::Media::Audio::{
+        AudioSessionStateActive, IAudioSessionManager2, IMMDeviceEnumerator, MMDeviceEnumerator,
+        eCapture, eCommunications,
+    };
+    use windows::Win32::System::Com::{CLSCTX_ALL, CoCreateInstance};
+
+    pub(super) fn probe_audio_activity() -> AudioActivity {
+        AudioActivity {
+            input_active: default_capture_session_is_active(),
+        }
+    }
+
+    fn default_capture_session_is_active() -> bool {
+        if initialize_mta().ok().is_err() {
+            return false;
+        }
+
+        let enumerator: IMMDeviceEnumerator =
+            match unsafe { CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL) } {
+                Ok(enumerator) => enumerator,
+                Err(_) => return false,
+            };
+        let Ok(device) = (unsafe { enumerator.GetDefaultAudioEndpoint(eCapture, eCommunications) })
+        else {
+            return false;
+        };
+        let Ok(manager) = (unsafe { device.Activate::<IAudioSessionManager2>(CLSCTX_ALL, None) })
+        else {
+            return false;
+        };
+        let Ok(sessions) = (unsafe { manager.GetSessionEnumerator() }) else {
+            return false;
+        };
+        let Ok(count) = (unsafe { sessions.GetCount() }) else {
+            return false;
+        };
+
+        for index in 0..count {
+            let Ok(session) = (unsafe { sessions.GetSession(index) }) else {
+                continue;
+            };
+            if unsafe { session.GetState() }.is_ok_and(|state| state == AudioSessionStateActive) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod platform_audio {
+    use super::AudioActivity;
+
+    pub(super) fn probe_audio_activity() -> AudioActivity {
+        AudioActivity::default()
+    }
 }
 
 #[cfg(test)]
@@ -59,26 +190,33 @@ mod tests {
 
     #[test]
     fn should_start_capture_when_mic_is_in_use() {
-        assert!(should_start_capture(&[], true, &[]));
+        assert!(should_start_capture(
+            AudioActivity { input_active: true },
+            &[],
+        ));
     }
 
     #[test]
-    fn should_start_capture_when_allowlisted_meeting_app_runs() {
-        let processes = vec![RunningProcess {
-            name: "Zoom.exe".to_string(),
-        }];
-        let allowlist = vec!["zoom".to_string()];
+    fn should_not_start_capture_when_allowlisted_meeting_app_has_no_input_activity() {
+        let allowlist = vec!["discord".to_string()];
 
-        assert!(should_start_capture(&processes, false, &allowlist));
+        assert!(!should_start_capture(AudioActivity::default(), &allowlist));
     }
 
     #[test]
-    fn should_not_start_capture_for_unrelated_processes() {
-        let processes = vec![RunningProcess {
-            name: "Spotify.exe".to_string(),
-        }];
+    fn should_start_capture_when_input_device_is_active_for_browser_meetings() {
+        let allowlist = vec!["meet".to_string()];
+
+        assert!(should_start_capture(
+            AudioActivity { input_active: true },
+            &allowlist,
+        ));
+    }
+
+    #[test]
+    fn should_not_start_capture_without_input_activity() {
         let allowlist = vec!["zoom".to_string(), "teams".to_string()];
 
-        assert!(!should_start_capture(&processes, false, &allowlist));
+        assert!(!should_start_capture(AudioActivity::default(), &allowlist));
     }
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -4,7 +4,7 @@
 use crate::audio::capture::to_mono_16k;
 use crate::audio::chunker::Chunk;
 use crate::audio::cleanup::{build_cleanup_prompt, build_transform_prompt};
-use crate::audio::detect::{probe_running_processes, should_start_capture};
+use crate::audio::detect::{probe_audio_activity, should_start_capture};
 use crate::audio::llm::{CompletionRequest, complete};
 use crate::audio::merge::merge_segments;
 use crate::audio::notes::{ParsedNotes, generate_notes};
@@ -359,13 +359,12 @@ pub fn list_meeting_templates() -> Vec<MeetingTemplate> {
     BUILT_IN_MEETING_TEMPLATES.to_vec()
 }
 
-/// Probe running processes and decide whether a meeting capture should arm.
-/// mic-in-use detection is not portable, so the decision relies on the
-/// allowlist (see `probe_running_processes`).
+/// Probe audio activity, then decide whether a meeting capture should arm.
+/// Process presence alone must not surface a record prompt.
 #[tauri::command]
 pub fn meeting_autodetect(allowlist: Vec<String>) -> bool {
-    let processes = probe_running_processes();
-    should_start_capture(&processes, false, &allowlist)
+    let activity = probe_audio_activity();
+    should_start_capture(activity, &allowlist)
 }
 
 // --- Dictation (shares the transcribe + cleanup engines with Meeting Mode) --

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -22,7 +22,6 @@ import { InboxList } from "@/components/inbox/InboxList";
 import { ThreadSidebar } from "@/components/layout/ThreadSidebar";
 import { AudioPrimingDialog } from "@/components/meeting/AudioPrimingDialog";
 import { MeetingPanel } from "@/components/meeting/MeetingPanel";
-import { RecordPrompt } from "@/components/meeting/RecordPrompt";
 import { SessionPanel } from "@/components/session/SessionPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import {
@@ -628,12 +627,22 @@ export const AppShell: Component<AppShellProps> = (props) => {
     shortcuts.unregister("focusEditor");
   });
 
+  const recordPromptVisible = () =>
+    meetingStore.state.autoDetectSuggested &&
+    !meetingStore.state.primingRequest &&
+    !meetingStore.state.meetings.some(
+      (meeting) => meeting.status === "capturing",
+    );
+
   return (
     <div class="flex flex-col h-screen bg-background text-foreground">
       <Titlebar
         onSignInClick={handleSignInClick}
         onToggleSkills={handleToggleSkills}
         onToggleSettings={handleToggleSettings}
+        recordPromptVisible={recordPromptVisible()}
+        onRecordConversation={() => void meetingStore.acceptAutoDetect()}
+        onDismissRecordPrompt={() => meetingStore.dismissAutoDetect()}
       />
 
       <div class="flex flex-1 overflow-hidden relative">
@@ -777,22 +786,6 @@ export const AppShell: Component<AppShellProps> = (props) => {
         <AudioPrimingDialog
           onContinue={() => void meetingStore.confirmPriming()}
           onCancel={() => void meetingStore.cancelPriming()}
-        />
-      </Show>
-
-      {/* App-wide Granola-style record prompt: surfaced anywhere (not just the
-          Meetings panel) when the auto-detect poll sees a call app and nothing
-          is capturing or priming. Replaces push-to-talk dictation as the entry. */}
-      <Show
-        when={
-          meetingStore.state.autoDetectSuggested &&
-          !meetingStore.state.primingRequest &&
-          !meetingStore.state.meetings.some((m) => m.status === "capturing")
-        }
-      >
-        <RecordPrompt
-          onRecord={() => void meetingStore.acceptAutoDetect()}
-          onDismiss={() => meetingStore.dismissAutoDetect()}
         />
       </Show>
 

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -4,6 +4,7 @@
 import { type Component, Show } from "solid-js";
 import { BalanceDisplay } from "@/components/common/BalanceDisplay";
 import { WorkspaceBar } from "@/components/layout/WorkspaceBar";
+import { RecordPrompt } from "@/components/meeting/RecordPrompt";
 import { authStore } from "@/stores/auth.store";
 import { updaterStore } from "@/stores/updater.store";
 
@@ -11,6 +12,9 @@ interface TitlebarProps {
   onSignInClick: () => void;
   onToggleSkills: () => void;
   onToggleSettings: () => void;
+  recordPromptVisible?: boolean;
+  onRecordConversation?: () => void;
+  onDismissRecordPrompt?: () => void;
 }
 
 const DOWNLOAD_QUIPS = [
@@ -114,6 +118,13 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
             <span>⚠</span>
             <span>Update failed - Retry</span>
           </button>
+        </Show>
+
+        <Show when={props.recordPromptVisible}>
+          <RecordPrompt
+            onRecord={() => props.onRecordConversation?.()}
+            onDismiss={() => props.onDismissRecordPrompt?.()}
+          />
         </Show>
 
         <Show when={authStore.isAuthenticated}>

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -251,7 +251,7 @@ export function MeetingPanel(props: MeetingPanelProps) {
         )}
       </Show>
 
-      {/* Auto-detect now surfaces app-wide via RecordPrompt (AppShell); the
+      {/* Auto-detect now surfaces app-wide via RecordPrompt (titlebar); the
           in-panel banner was a dead spot (only visible with this panel open). */}
 
       <Show when={!showSettings()} fallback={<MeetingSettings />}>

--- a/src/components/meeting/RecordPrompt.tsx
+++ b/src/components/meeting/RecordPrompt.tsx
@@ -1,5 +1,5 @@
-// ABOUTME: App-wide, non-modal prompt offering to record when a call app is detected.
-// ABOUTME: Granola-style "Record this conversation?" — the capture entry point, not push-to-talk.
+// ABOUTME: Compact titlebar prompt offering to record when input activity is detected.
+// ABOUTME: Capture entry point for meeting mode, not push-to-talk.
 
 interface RecordPromptProps {
   /** Start recording the detected conversation. */
@@ -26,36 +26,37 @@ function MicGlyph() {
 
 export function RecordPrompt(props: RecordPromptProps) {
   return (
-    <div class="pointer-events-none fixed bottom-6 right-6 z-50">
-      <div class="pointer-events-auto flex items-center gap-3 rounded-xl border border-border bg-surface-2/95 px-4 py-3 shadow-lg backdrop-blur-sm animate-[fadeIn_200ms_ease]">
-        <span class="relative flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent/15 text-accent">
-          <span class="absolute h-2.5 w-2.5 rounded-full bg-accent animate-[voicePulse_1.4s_ease-in-out_infinite]" />
-          <MicGlyph />
+    <div
+      class="flex h-8 w-[clamp(280px,42vw,430px)] min-w-0 items-center gap-2 rounded-md border border-accent/55 bg-primary-muted px-2 shadow-[0_0_0_1px_rgba(56,189,248,0.12),0_8px_24px_rgba(0,0,0,0.32)] backdrop-blur-sm animate-[fadeIn_200ms_ease]"
+      aria-label="Record detected conversation"
+    >
+      <span class="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent text-accent-foreground">
+        <span class="absolute h-2 w-2 rounded-full bg-accent-foreground/75 animate-[voicePulse_1.4s_ease-in-out_infinite]" />
+        <MicGlyph />
+      </span>
+      <div class="flex min-w-0 flex-1 flex-col leading-tight">
+        <span class="truncate text-[12px] font-medium text-foreground">
+          Record this conversation?
         </span>
-        <div class="flex min-w-0 flex-col">
-          <span class="text-[13px] font-medium text-foreground">
-            Record this conversation?
-          </span>
-          <span class="text-[11px] text-muted-foreground">
-            A call looks active — capture a transcript &amp; notes.
-          </span>
-        </div>
-        <div class="ml-2 flex shrink-0 items-center gap-1.5">
-          <button
-            type="button"
-            class="h-7 rounded-md border border-accent/50 bg-accent/15 px-3 text-[12px] font-medium text-accent transition-colors hover:bg-accent/25"
-            onClick={() => props.onRecord()}
-          >
-            Record
-          </button>
-          <button
-            type="button"
-            class="h-7 rounded-md px-2.5 text-[12px] text-muted-foreground transition-colors hover:bg-surface-3 hover:text-foreground"
-            onClick={() => props.onDismiss()}
-          >
-            Not now
-          </button>
-        </div>
+        <span class="truncate text-[10px] text-muted-foreground">
+          Active input detected. Capture transcript and notes.
+        </span>
+      </div>
+      <div class="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          class="h-6 rounded-md border border-accent bg-accent px-2 text-[11px] font-medium text-accent-foreground transition-colors hover:bg-primary-hover"
+          onClick={() => props.onRecord()}
+        >
+          Record
+        </button>
+        <button
+          type="button"
+          class="h-6 rounded-md px-2 text-[11px] text-muted-foreground transition-colors hover:bg-accent/15 hover:text-foreground"
+          onClick={() => props.onDismiss()}
+        >
+          Not now
+        </button>
       </div>
     </div>
   );

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -226,8 +226,8 @@ export function listMeetingTemplates(): Promise<MeetingTemplate[]> {
 }
 
 /**
- * Probe running processes and report whether a meeting capture should arm
- * (an allowlisted meeting app is running). mic-in-use is not probed.
+ * Probe whether meeting capture should arm. Native side requires active input
+ * activity; an idle allowlisted app process is not enough.
  */
 export function meetingAutodetect(allowlist: string[]): Promise<boolean> {
   return invoke("meeting_autodetect", { allowlist });

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -47,8 +47,8 @@ interface MeetingState {
   isLoading: boolean;
   error: string | null;
   /**
-   * True when the auto-detect poll has seen an allowlisted meeting app while
-   * nothing is capturing. The panel surfaces an arm prompt; the user starts.
+   * True when the auto-detect poll has seen active input while nothing is
+   * capturing. The titlebar surfaces an arm prompt; the user starts.
    */
   autoDetectSuggested: boolean;
   /**
@@ -633,8 +633,8 @@ function isCapturing(): boolean {
 }
 
 // Opt-in poll: while "auto-detect meetings" is on and nothing is capturing,
-// probe for an allowlisted meeting app and surface an arm prompt. The user
-// still presses start — capture is never auto-armed without consent.
+// probe for active input and surface an arm prompt. The user still presses
+// start; capture is never auto-armed without consent.
 async function pollAutoDetect(): Promise<void> {
   if (!isTauriRuntime()) return;
   if (!settingsStore.get("meetingAutoDetectEnabled")) {
@@ -692,8 +692,8 @@ async function acceptAutoDetect(): Promise<void> {
   await requestCaptureStart(meeting);
 }
 
-// Hide the prompt until the next time no meeting app is detected, so a single
-// dismissal doesn't re-nag on every poll for the same running app.
+// Hide the prompt until the next time no input activity is detected, so a
+// single dismissal doesn't re-nag on every poll during the same call.
 function dismissAutoDetect(): void {
   autoDetectDismissed = true;
   setMeetingState("autoDetectSuggested", false);

--- a/tests/unit/record-prompt-placement.test.ts
+++ b/tests/unit/record-prompt-placement.test.ts
@@ -1,0 +1,26 @@
+// ABOUTME: Regression coverage for #2211 titlebar placement of the record prompt.
+// ABOUTME: Prevents the prompt from returning to a bottom-right composer overlay.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string): string {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("record prompt placement (#2211)", () => {
+  it("renders from the titlebar before the balance display, not as a fixed bottom overlay", () => {
+    const recordPromptSource = source("src/components/meeting/RecordPrompt.tsx");
+    const titlebarSource = source("src/components/layout/Titlebar.tsx");
+
+    expect(recordPromptSource).not.toContain("fixed bottom");
+    expect(recordPromptSource).not.toContain("right-6");
+    expect(titlebarSource.indexOf("<RecordPrompt")).toBeGreaterThan(-1);
+    expect(titlebarSource.indexOf("<RecordPrompt")).toBeLessThan(
+      titlebarSource.indexOf("<BalanceDisplay"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Move the auto-detect record prompt into the titlebar immediately before the SerenBucks balance so it no longer covers composer controls.
- Replace process-name meeting auto-detect with passive platform input-activity checks on macOS CoreAudio and Windows WASAPI.
- Add focused regressions for idle allowlisted apps and titlebar prompt placement.

## Audit
- Screenshot failure: `~/Desktop/three.png` showed the bottom-right prompt covering composer controls.
- Prior path: `RecordPrompt` rendered fixed bottom/right from `AppShell`; `meeting_autodetect` armed from allowlisted running process names.
- Local process snapshot showed Discord running while the user was only typing, matching the idle false-positive path.
- Prior related work reviewed: #2203/#2205 introduced the current prompt placement; #2209/#2210 were capture-failure visibility, not this trigger/placement failure.

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml audio::detect --lib`
- `pnpm vitest run tests/unit/meeting-autodetect-dismiss-reset.test.ts tests/unit/record-prompt-placement.test.ts`
- `pnpm test`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `pnpm check` (passes with existing Biome warnings)
- `pnpm build`
- Windows app-level cross-check is blocked in this macOS environment by missing `x86_64-pc-windows-gnu` C headers from `aws-lc-sys`; isolated Windows WASAPI probe type-check passed.
- Functional screenshot walkthrough verified default shell has no bottom overlay and forced titlebar prompt sits left of balance at 1440px and 1024px.

Closes #2211