### PR TITLE
fix(meeting): align auto-detect settings with input gate

### DIFF
--- a/src-tauri/src/audio/detect.rs
+++ b/src-tauri/src/audio/detect.rs
@@ -13,7 +13,7 @@ pub fn probe_audio_activity() -> AudioActivity {
     platform_audio::probe_audio_activity()
 }
 
-pub fn should_start_capture(activity: AudioActivity, _meeting_app_allowlist: &[String]) -> bool {
+pub fn should_start_capture(activity: AudioActivity) -> bool {
     activity.input_active
 }
 
@@ -190,33 +190,21 @@ mod tests {
 
     #[test]
     fn should_start_capture_when_mic_is_in_use() {
-        assert!(should_start_capture(
-            AudioActivity { input_active: true },
-            &[],
-        ));
+        assert!(should_start_capture(AudioActivity { input_active: true }));
     }
 
     #[test]
-    fn should_not_start_capture_when_allowlisted_meeting_app_has_no_input_activity() {
-        let allowlist = vec!["discord".to_string()];
-
-        assert!(!should_start_capture(AudioActivity::default(), &allowlist));
+    fn should_not_start_capture_when_app_has_no_input_activity() {
+        assert!(!should_start_capture(AudioActivity::default()));
     }
 
     #[test]
     fn should_start_capture_when_input_device_is_active_for_browser_meetings() {
-        let allowlist = vec!["meet".to_string()];
-
-        assert!(should_start_capture(
-            AudioActivity { input_active: true },
-            &allowlist,
-        ));
+        assert!(should_start_capture(AudioActivity { input_active: true }));
     }
 
     #[test]
     fn should_not_start_capture_without_input_activity() {
-        let allowlist = vec!["zoom".to_string(), "teams".to_string()];
-
-        assert!(!should_start_capture(AudioActivity::default(), &allowlist));
+        assert!(!should_start_capture(AudioActivity::default()));
     }
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -362,9 +362,9 @@ pub fn list_meeting_templates() -> Vec<MeetingTemplate> {
 /// Probe audio activity, then decide whether a meeting capture should arm.
 /// Process presence alone must not surface a record prompt.
 #[tauri::command]
-pub fn meeting_autodetect(allowlist: Vec<String>) -> bool {
+pub fn meeting_autodetect() -> bool {
     let activity = probe_audio_activity();
-    should_start_capture(activity, &allowlist)
+    should_start_capture(activity)
 }
 
 // --- Dictation (shares the transcribe + cleanup engines with Meeting Mode) --

--- a/src/components/meeting/MeetingSettings.tsx
+++ b/src/components/meeting/MeetingSettings.tsx
@@ -24,7 +24,6 @@ function FieldLabel(props: { children: string; hint?: string }) {
 export function MeetingSettings() {
   const [builtins, setBuiltins] = createSignal<MeetingTemplate[]>([]);
   const [vocabTerm, setVocabTerm] = createSignal("");
-  const [allowlistApp, setAllowlistApp] = createSignal("");
   const [tplName, setTplName] = createSignal("");
   const [tplPrompt, setTplPrompt] = createSignal("");
 
@@ -38,7 +37,6 @@ export function MeetingSettings() {
 
   const customTemplates = () => settingsStore.get("meetingCustomTemplates");
   const vocabulary = () => settingsStore.get("voiceCustomVocabulary");
-  const allowlist = () => settingsStore.get("meetingAppAllowlist");
 
   const allTemplates = () => [...builtins(), ...customTemplates()];
 
@@ -53,20 +51,6 @@ export function MeetingSettings() {
     settingsStore.set(
       "voiceCustomVocabulary",
       vocabulary().filter((t) => t !== term),
-    );
-  };
-
-  const addAllowlistApp = () => {
-    const app = allowlistApp().trim().toLowerCase();
-    if (!app || allowlist().includes(app)) return;
-    settingsStore.set("meetingAppAllowlist", [...allowlist(), app]);
-    setAllowlistApp("");
-  };
-
-  const removeAllowlistApp = (app: string) => {
-    settingsStore.set(
-      "meetingAppAllowlist",
-      allowlist().filter((a) => a !== app),
     );
   };
 
@@ -230,7 +214,7 @@ export function MeetingSettings() {
 
       <section>
         <label class="flex items-center justify-between gap-3 cursor-pointer">
-          <FieldLabel hint="Auto-arm capture when a known meeting app is running.">
+          <FieldLabel hint="Show the titlebar prompt when active microphone input is detected. Capture still waits for you to press Record.">
             Auto-detect meetings
           </FieldLabel>
           <input
@@ -245,39 +229,6 @@ export function MeetingSettings() {
             }
           />
         </label>
-        <div class="mt-2 flex flex-wrap gap-1.5">
-          <For each={allowlist()}>
-            {(app) => (
-              <span class="inline-flex items-center gap-1 rounded border border-border bg-surface-1 px-1.5 py-0.5 text-[12px] text-foreground">
-                {app}
-                <button
-                  type="button"
-                  class="text-muted-foreground hover:text-destructive"
-                  onClick={() => removeAllowlistApp(app)}
-                  aria-label={`Remove ${app}`}
-                >
-                  ×
-                </button>
-              </span>
-            )}
-          </For>
-        </div>
-        <div class="mt-2 flex gap-2">
-          <input
-            class="h-8 flex-1 rounded-md border border-border bg-surface-1 px-2.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary/60"
-            placeholder="Add a meeting app (e.g. zoom)"
-            value={allowlistApp()}
-            onInput={(event) => setAllowlistApp(event.currentTarget.value)}
-            onKeyDown={(event) => event.key === "Enter" && addAllowlistApp()}
-          />
-          <button
-            type="button"
-            class="h-8 px-3 rounded-md border border-border bg-surface-2 text-[12px] text-foreground hover:bg-surface-3"
-            onClick={addAllowlistApp}
-          >
-            Add
-          </button>
-        </div>
       </section>
     </div>
   );

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -227,8 +227,8 @@ export function listMeetingTemplates(): Promise<MeetingTemplate[]> {
 
 /**
  * Probe whether meeting capture should arm. Native side requires active input
- * activity; an idle allowlisted app process is not enough.
+ * activity; process presence alone is not enough.
  */
-export function meetingAutodetect(allowlist: string[]): Promise<boolean> {
-  return invoke("meeting_autodetect", { allowlist });
+export function meetingAutodetect(): Promise<boolean> {
+  return invoke("meeting_autodetect");
 }

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -647,9 +647,7 @@ async function pollAutoDetect(): Promise<void> {
   }
 
   try {
-    const detected = await meetingAutodetect(
-      settingsStore.get("meetingAppAllowlist"),
-    );
+    const detected = await meetingAutodetect();
     if (!detected) {
       autoDetectDismissed = false;
       setMeetingState("autoDetectSuggested", false);

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -159,7 +159,6 @@ export interface Settings {
   // Meeting settings
   meetingAutoDetectEnabled: boolean;
   meetingTemplateId: string;
-  meetingAppAllowlist: string[];
   meetingCustomTemplates: { id: string; name: string; prompt: string }[];
   meetingDefaultSkill: string;
   /**
@@ -272,7 +271,6 @@ const DEFAULT_SETTINGS: Settings = {
   // Meeting
   meetingAutoDetectEnabled: true,
   meetingTemplateId: "discovery",
-  meetingAppAllowlist: ["zoom", "discord", "teams", "meet", "slack", "webex"],
   meetingCustomTemplates: [],
   meetingDefaultSkill: "",
   meetingStableSpeakers: false,

--- a/tests/unit/meeting-autodetect-dismiss-reset.test.ts
+++ b/tests/unit/meeting-autodetect-dismiss-reset.test.ts
@@ -21,7 +21,6 @@ vi.mock("@/stores/settings.store", () => ({
   settingsStore: {
     get: (key: string) => {
       if (key === "meetingAutoDetectEnabled") return true;
-      if (key === "meetingAppAllowlist") return ["zoom"];
       return undefined;
     },
     set: vi.fn(),

--- a/tests/unit/meeting-autodetect-settings-copy.test.ts
+++ b/tests/unit/meeting-autodetect-settings-copy.test.ts
@@ -1,0 +1,35 @@
+// ABOUTME: Regression coverage for #2215 auto-detect settings copy.
+// ABOUTME: Prevents no-op meeting-app allowlist controls after input gating.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string): string {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("meeting auto-detect settings (#2215)", () => {
+  it("describes active input detection without exposing a no-op app allowlist", () => {
+    const settingsSource = source("src/components/meeting/MeetingSettings.tsx");
+    const settingsStoreSource = source("src/stores/settings.store.ts");
+    const meetingStoreSource = source("src/stores/meeting.store.ts");
+    const serviceSource = source("src/services/meetings.ts");
+    const nativeCommandSource = source("src-tauri/src/commands/audio.rs");
+    const detectionSource = source("src-tauri/src/audio/detect.rs");
+
+    expect(settingsSource).toContain("active microphone input");
+    expect(settingsSource).not.toContain("meetingAppAllowlist");
+    expect(settingsSource).not.toContain("known meeting app");
+    expect(settingsSource).not.toContain("Add a meeting app");
+    expect(settingsStoreSource).not.toContain("meetingAppAllowlist");
+    expect(meetingStoreSource).not.toContain("meetingAppAllowlist");
+    expect(serviceSource).toContain("meetingAutodetect(): Promise<boolean>");
+    expect(nativeCommandSource).toContain("pub fn meeting_autodetect() -> bool");
+    expect(detectionSource).toContain(
+      "pub fn should_start_capture(activity: AudioActivity) -> bool",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the no-op meeting app allowlist controls from Meeting settings now that #2211 gates on active input instead of process names.
- Update the Auto-detect meetings hint to describe active microphone input and explicit Record consent.
- Remove the ignored allowlist argument from the TS service/store path and Tauri command/policy function.

## Audit
- Follow-up walkthrough found settings still exposed `meetingAppAllowlist` and said auto-detect used known running meeting apps.
- The native detector no longer uses process names, so that UI was a stale privacy/control surface.

## Verification
- `pnpm vitest run tests/unit/meeting-autodetect-settings-copy.test.ts` failed before the fix, then passed after implementation.
- `pnpm vitest run tests/unit/meeting-autodetect-settings-copy.test.ts tests/unit/meeting-autodetect-dismiss-reset.test.ts tests/unit/record-prompt-placement.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml audio::detect --lib`
- `pnpm test`
- `pnpm check` (passes with existing repo warnings)
- `pnpm build` (passes with existing Rolldown/node_modules warnings)
- `rustfmt --edition 2024 --check src-tauri/src/audio/detect.rs src-tauri/src/commands/audio.rs`
- `git diff --check`

Closes #2215