### PR TITLE
ci(windows): fail loud when CodeSignTool produces no signed output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -589,15 +589,21 @@ jobs:
           $signedDir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis-signed"
           $targetDir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis"
 
-          if (Test-Path $signedDir) {
-            Write-Host "Copying signed files from $signedDir to $targetDir"
-            Get-ChildItem -Path $signedDir -Filter "*.exe" | ForEach-Object {
-              Copy-Item -Path $_.FullName -Destination $targetDir -Force
-              Write-Host "Copied: $($_.Name)"
-            }
-          } else {
+          if (-not (Test-Path $signedDir)) {
             Write-Host "Signed output directory not found: $signedDir"
             exit 1
+          }
+
+          $signedExes = @(Get-ChildItem -Path $signedDir -Filter "*.exe")
+          if ($signedExes.Count -eq 0) {
+            Write-Host "No signed .exe files found in $signedDir — CodeSignTool likely failed silently (check the 'Sign Windows NSIS installer' step log)."
+            exit 1
+          }
+
+          Write-Host "Copying signed files from $signedDir to $targetDir"
+          foreach ($file in $signedExes) {
+            Copy-Item -Path $file.FullName -Destination $targetDir -Force
+            Write-Host "Copied: $($file.Name)"
           }
 
       # Restore updater artifacts (.sig, .nsis.zip) back to NSIS dir


### PR DESCRIPTION
## Summary
- Make `Copy signed NSIS installer` fail with a clear message when `nsis-signed/` contains zero `.exe` files, instead of silently succeeding and letting `Verify Windows code signing` catch it five steps later with no diagnostic context.
- Triggered by v3.51.4 release run [27185072120](https://github.com/serenorg/seren-desktop/actions/runs/27185072120/job/80252180909) — SSL.com OAuth/CSC endpoint returned HTML, CodeSignTool failed with `Unexpected character (<) at position 0`, but `sslcom/esigner-codesign@v1.3.2` exited 0 and the empty signed dir slipped through.

## Test plan
- [ ] CI green on this PR (the change only affects Windows release flow; touch path is workflow-only)
- [ ] On next tagged release, confirm a successful Windows signing run still copies the signed `.exe` and the Verify step passes
- [ ] If SSL.com flakes again, confirm the Copy step now fails with the new diagnostic message instead of Verify

Closes #2222

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
