### PR TITLE
fix(meeting): keep mic capture pulled on macOS

### DIFF
--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -40,12 +40,24 @@ const MAX_THEM_BUFFER_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 60 * 90;
 #[serde(rename_all = "camelCase")]
 pub struct CaptureStopSummary {
     pub had_capture: bool,
+    pub push_frame_count: u64,
+    pub accepted_push_frame_count: u64,
+    pub dropped_push_frame_count: u64,
+    pub dropped_push_sample_count: u64,
     pub frame_count: u64,
     pub sample_count: u64,
     pub speech_frame_count: u64,
     pub chunk_count: u64,
     pub emitted_segment_count: u64,
     pub emitted_gap_count: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct CaptureIngressSummary {
+    push_frame_count: u64,
+    accepted_push_frame_count: u64,
+    dropped_push_frame_count: u64,
+    dropped_push_sample_count: u64,
 }
 
 #[derive(Default)]
@@ -81,9 +93,13 @@ impl CaptureStreamStats {
         self.emitted_gap_count.fetch_add(1, Ordering::Relaxed);
     }
 
-    pub fn summary(&self, had_capture: bool) -> CaptureStopSummary {
+    fn summary(&self, had_capture: bool, ingress: CaptureIngressSummary) -> CaptureStopSummary {
         CaptureStopSummary {
             had_capture,
+            push_frame_count: ingress.push_frame_count,
+            accepted_push_frame_count: ingress.accepted_push_frame_count,
+            dropped_push_frame_count: ingress.dropped_push_frame_count,
+            dropped_push_sample_count: ingress.dropped_push_sample_count,
             frame_count: self.frame_count.load(Ordering::Relaxed),
             sample_count: self.sample_count.load(Ordering::Relaxed),
             speech_frame_count: self.speech_frame_count.load(Ordering::Relaxed),
@@ -394,6 +410,7 @@ const STOP_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Default, Clone)]
 pub struct CaptureRegistry {
     active: Arc<StdMutex<HashMap<String, CaptureSlot>>>,
+    ingress: Arc<StdMutex<HashMap<String, CaptureIngressSummary>>>,
     // Them PCM handed off by `stop`, keyed by meeting id, awaiting the post-call
     // diarization pass. `reconcile_meeting_speakers` removes its entry; the buffer
     // lives only in memory and is dropped once consumed (privacy rule #2125).
@@ -424,6 +441,7 @@ impl CaptureRegistry {
         // Me and Them share one sequence counter so segments order globally.
         let seq = Arc::new(AtomicI64::new(0));
         let stats = Arc::new(CaptureStreamStats::default());
+        self.reset_ingress_summary(meeting_id);
 
         // Me is the single-speaker mic -> plain whisper-1 text (cheap); only the
         // multi-speaker Them stream is diarized (#2152).
@@ -506,17 +524,76 @@ impl CaptureRegistry {
 
     /// Push a normalized 16 kHz mono frame into the capture stream for `speaker`.
     pub fn push_frame(&self, meeting_id: &str, speaker: Speaker, samples: Vec<i16>) {
+        let sample_count = samples.len() as u64;
         let active = self.active.lock().unwrap();
-        if let Some(CaptureSlot::Active(capture)) = active.get(meeting_id) {
-            let sender = match speaker {
-                Speaker::Me => Some(&capture.me_tx),
-                // The system ("Them") stream arrives once native capture lands.
-                Speaker::Them => capture.them_tx.as_ref(),
-            };
-            if let Some(sender) = sender {
-                let _ = sender.send(PcmFrame { samples });
+        let drop_reason = match active.get(meeting_id) {
+            Some(CaptureSlot::Active(capture)) => {
+                let sender = match &speaker {
+                    Speaker::Me => Some(&capture.me_tx),
+                    // The system ("Them") stream arrives once native capture lands.
+                    Speaker::Them => capture.them_tx.as_ref(),
+                };
+                if let Some(sender) = sender {
+                    if sender.send(PcmFrame { samples }).is_ok() {
+                        drop(active);
+                        self.record_accepted_push_frame(meeting_id);
+                        return;
+                    }
+                    "channel_closed"
+                } else {
+                    "speaker_not_captured"
+                }
             }
+            Some(CaptureSlot::Stopping) => "stopping",
+            None => "no_slot",
+        };
+        drop(active);
+
+        let ingress = self.record_dropped_push_frame(meeting_id, sample_count);
+        if should_log_dropped_push(ingress.dropped_push_frame_count) {
+            log::warn!(
+                "[meeting] capture frame dropped for {meeting_id}; speaker={} reason={} dropped_frames={} dropped_samples={}",
+                speaker.as_str(),
+                drop_reason,
+                ingress.dropped_push_frame_count,
+                ingress.dropped_push_sample_count
+            );
         }
+    }
+
+    fn reset_ingress_summary(&self, meeting_id: &str) {
+        self.ingress
+            .lock()
+            .unwrap()
+            .insert(meeting_id.to_string(), CaptureIngressSummary::default());
+    }
+
+    fn record_accepted_push_frame(&self, meeting_id: &str) {
+        let mut ingress = self.ingress.lock().unwrap();
+        let summary = ingress.entry(meeting_id.to_string()).or_default();
+        summary.push_frame_count += 1;
+        summary.accepted_push_frame_count += 1;
+    }
+
+    fn record_dropped_push_frame(
+        &self,
+        meeting_id: &str,
+        sample_count: u64,
+    ) -> CaptureIngressSummary {
+        let mut ingress = self.ingress.lock().unwrap();
+        let summary = ingress.entry(meeting_id.to_string()).or_default();
+        summary.push_frame_count += 1;
+        summary.dropped_push_frame_count += 1;
+        summary.dropped_push_sample_count += sample_count;
+        *summary
+    }
+
+    fn take_ingress_summary(&self, meeting_id: &str) -> CaptureIngressSummary {
+        self.ingress
+            .lock()
+            .unwrap()
+            .remove(meeting_id)
+            .unwrap_or_default()
     }
 
     /// Take the active capture for draining and leave a `Stopping` tombstone, all
@@ -565,7 +642,8 @@ impl CaptureRegistry {
         drain_timeout: Duration,
     ) -> CaptureStopSummary {
         let Some(mut capture) = self.begin_stop(meeting_id) else {
-            return CaptureStopSummary::default();
+            let ingress = self.take_ingress_summary(meeting_id);
+            return CaptureStreamStats::default().summary(false, ingress);
         };
         // Stop the native source first so it stops feeding the "Them" channel.
         if let Some(mut source) = capture.system_source.take() {
@@ -582,9 +660,14 @@ impl CaptureRegistry {
                 log::warn!("[meeting] capture worker drain timed out for {meeting_id}; detaching");
             }
         }
-        let summary = capture.stats.summary(true);
+        let ingress = self.take_ingress_summary(meeting_id);
+        let summary = capture.stats.summary(true, ingress);
         log::info!(
-            "[meeting] capture stop summary for {meeting_id}: frames={} speech_frames={} chunks={} emitted_segments={} emitted_gaps={}",
+            "[meeting] capture stop summary for {meeting_id}: push_frames={} accepted_push_frames={} dropped_push_frames={} dropped_push_samples={} frames={} speech_frames={} chunks={} emitted_segments={} emitted_gaps={}",
+            summary.push_frame_count,
+            summary.accepted_push_frame_count,
+            summary.dropped_push_frame_count,
+            summary.dropped_push_sample_count,
             summary.frame_count,
             summary.speech_frame_count,
             summary.chunk_count,
@@ -613,6 +696,10 @@ impl CaptureRegistry {
     pub fn take_finished_them_audio(&self, meeting_id: &str) -> Option<Vec<i16>> {
         self.finished_them_audio.lock().unwrap().remove(meeting_id)
     }
+}
+
+fn should_log_dropped_push(drop_count: u64) -> bool {
+    drop_count <= 5 || drop_count.is_power_of_two()
 }
 
 #[cfg(test)]
@@ -763,7 +850,7 @@ mod tests {
         assert_eq!(segments.len(), 1);
         assert_eq!(segments[0].status, SegmentStatus::Gap);
         assert!(segments[0].text.is_empty());
-        let summary = stats.summary(true);
+        let summary = stats.summary(true, CaptureIngressSummary::default());
         assert!(summary.had_capture);
         assert!(summary.frame_count > 0);
         assert!(summary.speech_frame_count > 0);
@@ -884,7 +971,27 @@ mod tests {
         assert_eq!(summary.frame_count, 0);
         assert_eq!(summary.chunk_count, 0);
         assert_eq!(summary.emitted_segment_count, 0);
+        assert_eq!(summary.push_frame_count, 0);
+        assert_eq!(summary.dropped_push_frame_count, 0);
         assert!(!registry.slot_occupied("m1"));
+    }
+
+    #[tokio::test]
+    async fn stop_summary_reports_frames_dropped_before_active_capture() {
+        let registry = CaptureRegistry::default();
+
+        registry.push_frame("m1", Speaker::Me, vec![1, 2, 3]);
+
+        let summary = registry
+            .stop_with_timeout("m1", Duration::from_millis(50))
+            .await;
+
+        assert!(!summary.had_capture);
+        assert_eq!(summary.frame_count, 0);
+        assert_eq!(summary.push_frame_count, 1);
+        assert_eq!(summary.accepted_push_frame_count, 0);
+        assert_eq!(summary.dropped_push_frame_count, 1);
+        assert_eq!(summary.dropped_push_sample_count, 3);
     }
 
     struct FailingSource {

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -239,6 +239,10 @@ pub async fn stop_meeting_capture(
 
     let outcome = StopMeetingCaptureOutcome {
         had_capture: summary.had_capture,
+        push_frame_count: summary.push_frame_count,
+        accepted_push_frame_count: summary.accepted_push_frame_count,
+        dropped_push_frame_count: summary.dropped_push_frame_count,
+        dropped_push_sample_count: summary.dropped_push_sample_count,
         frame_count: summary.frame_count,
         sample_count: summary.sample_count,
         speech_frame_count: summary.speech_frame_count,
@@ -276,6 +280,10 @@ pub async fn stop_meeting_capture(
 #[serde(rename_all = "camelCase")]
 pub struct StopMeetingCaptureOutcome {
     pub had_capture: bool,
+    pub push_frame_count: u64,
+    pub accepted_push_frame_count: u64,
+    pub dropped_push_frame_count: u64,
+    pub dropped_push_sample_count: u64,
     pub frame_count: u64,
     pub sample_count: u64,
     pub speech_frame_count: u64,
@@ -296,12 +304,30 @@ fn stop_capture_failure_reason(
         return None;
     }
     if !summary.had_capture {
+        if summary.dropped_push_frame_count > 0 {
+            return Some(
+                "Audio frames reached Seren, but Meeting capture had no active stream to accept them. Restart capture; if it repeats, send logs with the dropped-frame counters."
+                    .to_string(),
+            );
+        }
         return Some(
             "Meeting capture was no longer active when Stop was pressed. Restart Seren and start capture again."
                 .to_string(),
         );
     }
     if summary.frame_count == 0 {
+        if summary.accepted_push_frame_count > 0 {
+            return Some(
+                "Audio frames reached Meeting capture, but the transcription worker did not process them. Restart capture; if it repeats, send logs with the accepted-frame counters."
+                    .to_string(),
+            );
+        }
+        if summary.dropped_push_frame_count > 0 {
+            return Some(
+                "Audio frames reached Seren, but were dropped before transcription. Restart capture; if it repeats, send logs with the dropped-frame counters."
+                    .to_string(),
+            );
+        }
         return Some(
             "No audio reached Meeting capture. Check microphone and system-audio permissions, then start capture again."
                 .to_string(),
@@ -1020,11 +1046,41 @@ mod tests {
             chunk_count: 0,
             emitted_segment_count: 0,
             emitted_gap_count: 0,
+            ..Default::default()
         };
 
         let reason = stop_capture_failure_reason(&summary, 0, 0).unwrap();
 
         assert!(reason.contains("No audio reached Meeting capture"));
+    }
+
+    #[test]
+    fn stop_capture_failure_reason_describes_dropped_capture_frames() {
+        let summary = crate::audio::pipeline::CaptureStopSummary {
+            had_capture: true,
+            push_frame_count: 1,
+            dropped_push_frame_count: 1,
+            dropped_push_sample_count: 128,
+            ..Default::default()
+        };
+
+        let reason = stop_capture_failure_reason(&summary, 0, 0).unwrap();
+
+        assert!(reason.contains("dropped before transcription"));
+    }
+
+    #[test]
+    fn stop_capture_failure_reason_describes_unprocessed_accepted_frames() {
+        let summary = crate::audio::pipeline::CaptureStopSummary {
+            had_capture: true,
+            push_frame_count: 1,
+            accepted_push_frame_count: 1,
+            ..Default::default()
+        };
+
+        let reason = stop_capture_failure_reason(&summary, 0, 0).unwrap();
+
+        assert!(reason.contains("transcription worker did not process"));
     }
 
     #[test]
@@ -1037,6 +1093,7 @@ mod tests {
             chunk_count: 1,
             emitted_segment_count: 1,
             emitted_gap_count: 0,
+            ..Default::default()
         };
 
         let reason = stop_capture_failure_reason(&summary, 0, 0).unwrap();
@@ -1054,6 +1111,7 @@ mod tests {
             chunk_count: 1,
             emitted_segment_count: 1,
             emitted_gap_count: 0,
+            ..Default::default()
         };
 
         assert_eq!(stop_capture_failure_reason(&summary, 1, 1), None);

--- a/src/lib/audio/captureContext.ts
+++ b/src/lib/audio/captureContext.ts
@@ -2,7 +2,8 @@
 // ABOUTME: Resumes the context so a suspended-by-default WKWebView can't silently capture nothing.
 
 /**
- * Create an `AudioContext` at `sampleRate` and guarantee it is actually running.
+ * Create an `AudioContext` and guarantee it is actually running. When
+ * `sampleRate` is omitted, the WebView picks the hardware rate.
  *
  * WKWebView/Safari — and any context created outside a user gesture — start an
  * `AudioContext` in the `suspended` state. While suspended a `ScriptProcessor`'s
@@ -11,9 +12,12 @@
  * and fail loudly if it cannot run, rather than record silence.
  */
 export async function createRunningAudioContext(
-  sampleRate: number,
+  sampleRate?: number,
 ): Promise<AudioContext> {
-  const context = new AudioContext({ sampleRate });
+  const context =
+    sampleRate === undefined
+      ? new AudioContext()
+      : new AudioContext({ sampleRate });
   await context.resume();
   if (context.state !== "running") {
     await context.close().catch(() => {});

--- a/src/lib/audio/dictationCapture.ts
+++ b/src/lib/audio/dictationCapture.ts
@@ -2,16 +2,16 @@
 // ABOUTME: Transcribes ~1.5s chunks (or on silence) via transcribe_pcm and emits live partial text.
 
 import { createRunningAudioContext } from "@/lib/audio/captureContext";
+import { connectPulledScriptProcessor } from "@/lib/audio/scriptProcessor";
 import { transcribePcm } from "@/services/dictation";
 
-const TARGET_SAMPLE_RATE = 16_000;
 // Transcribe roughly every 1.5s of audio so text appears live as the user speaks.
-const CHUNK_SAMPLES = Math.floor(TARGET_SAMPLE_RATE * 1.5);
+const CHUNK_SECONDS = 1.5;
 // A short run of quiet samples ends a phrase early so partials feel responsive.
 const SILENCE_RMS = 0.012;
-const SILENCE_FLUSH_SAMPLES = Math.floor(TARGET_SAMPLE_RATE * 0.6);
+const SILENCE_FLUSH_SECONDS = 0.6;
 // Never fire a chunk on a tiny sliver of audio (avoids empty/garbled partials).
-const MIN_FLUSH_SAMPLES = Math.floor(TARGET_SAMPLE_RATE * 0.4);
+const MIN_FLUSH_SECONDS = 0.4;
 
 export interface DictationCaptureHandle {
   /** Current input amplitude in 0..1 for the HUD meter (0 on silence). */
@@ -36,10 +36,10 @@ function frameRms(input: Float32Array): number {
 }
 
 /**
- * Begin streaming the microphone for dictation. The browser resamples to
- * 16 kHz mono (the AudioContext rate), so frames are pipeline-ready. Each
- * flushed chunk is transcribed and surfaced through `onPartial`; transcripts
- * are serialized so the concatenated result stays in order.
+ * Begin streaming the microphone for dictation. Use the hardware context rate
+ * and let Rust normalize frames before transcription. Each flushed chunk is
+ * transcribed and surfaced through `onPartial`; transcripts are serialized so
+ * the concatenated result stays in order.
  */
 export async function startDictationCapture(
   onPartial: (text: string) => void,
@@ -50,7 +50,7 @@ export async function startDictationCapture(
 
   let context: AudioContext;
   try {
-    context = await createRunningAudioContext(TARGET_SAMPLE_RATE);
+    context = await createRunningAudioContext();
   } catch (error) {
     // Release the mic we just opened so a failed start can't leave it live.
     for (const track of stream.getTracks()) {
@@ -64,10 +64,11 @@ export async function startDictationCapture(
   analyser.fftSize = 512;
   source.connect(analyser);
 
-  const processor = context.createScriptProcessor(4096, 1, 1);
-  // Route through a muted gain so onaudioprocess fires without echoing the mic.
-  const mute = context.createGain();
-  mute.gain.value = 0;
+  const chunkSamples = Math.floor(context.sampleRate * CHUNK_SECONDS);
+  const silenceFlushSamples = Math.floor(
+    context.sampleRate * SILENCE_FLUSH_SECONDS,
+  );
+  const minFlushSamples = Math.floor(context.sampleRate * MIN_FLUSH_SECONDS);
 
   let buffer: number[] = [];
   let quietSamples = 0;
@@ -81,8 +82,7 @@ export async function startDictationCapture(
         const text = await transcribePcm({
           samples: frame,
           channels: 1,
-          // The WebView may ignore the 16 kHz request; report the real rate so
-          // the Rust pipeline resamples correctly.
+          // Report the context's real hardware rate so Rust can resample accurately.
           sampleRate: context.sampleRate,
         });
         const trimmed = text.trim();
@@ -97,14 +97,14 @@ export async function startDictationCapture(
   };
 
   const flush = () => {
-    if (buffer.length < MIN_FLUSH_SAMPLES) return;
+    if (buffer.length < minFlushSamples) return;
     const frame = buffer;
     buffer = [];
     quietSamples = 0;
     queueTranscription(frame);
   };
 
-  processor.onaudioprocess = (event) => {
+  const processor = connectPulledScriptProcessor(context, source, (event) => {
     const channel = event.inputBuffer.getChannelData(0);
     floatToPcm16(channel, buffer);
 
@@ -115,17 +115,12 @@ export async function startDictationCapture(
     }
 
     if (
-      buffer.length >= CHUNK_SAMPLES ||
-      (quietSamples >= SILENCE_FLUSH_SAMPLES &&
-        buffer.length >= MIN_FLUSH_SAMPLES)
+      buffer.length >= chunkSamples ||
+      (quietSamples >= silenceFlushSamples && buffer.length >= minFlushSamples)
     ) {
       flush();
     }
-  };
-
-  source.connect(processor);
-  processor.connect(mute);
-  mute.connect(context.destination);
+  });
 
   const timeData = new Uint8Array(analyser.frequencyBinCount);
   const level = () => {
@@ -147,7 +142,6 @@ export async function startDictationCapture(
       queueTranscription(frame);
     }
     processor.disconnect();
-    mute.disconnect();
     analyser.disconnect();
     source.disconnect();
     for (const track of stream.getTracks()) {

--- a/src/lib/audio/meetingCapture.ts
+++ b/src/lib/audio/meetingCapture.ts
@@ -1,12 +1,12 @@
 // ABOUTME: Webview microphone capture for the Meeting Mode "Me" stream.
-// ABOUTME: Streams 16 kHz mono PCM frames to the Rust pipeline and exposes live amplitude.
+// ABOUTME: Streams microphone PCM frames to the Rust pipeline and exposes live amplitude.
 
 import { createRunningAudioContext } from "@/lib/audio/captureContext";
+import { connectPulledScriptProcessor } from "@/lib/audio/scriptProcessor";
 import { pushCaptureFrame } from "@/services/meetings";
 
-const TARGET_SAMPLE_RATE = 16_000;
 // Flush roughly every 250 ms so the Rust chunker sees audio promptly.
-const FLUSH_SAMPLES = TARGET_SAMPLE_RATE / 4;
+const FLUSH_SECONDS = 0.25;
 
 export interface MeetingCaptureHandle {
   /** Current input amplitude in 0..1 for the recorder meter (0 on silence). */
@@ -23,8 +23,8 @@ function floatToPcm16(input: Float32Array, out: number[]): void {
 }
 
 /**
- * Begin capturing the microphone as the meeting "Me" stream. The browser
- * resamples to 16 kHz mono (the AudioContext rate), so frames are pipeline-ready.
+ * Begin capturing the microphone as the meeting "Me" stream. Use the hardware
+ * context rate and let Rust normalize frames to the pipeline's 16 kHz mono rate.
  */
 export async function startMeetingMicCapture(
   meetingId: string,
@@ -35,7 +35,7 @@ export async function startMeetingMicCapture(
 
   let context: AudioContext;
   try {
-    context = await createRunningAudioContext(TARGET_SAMPLE_RATE);
+    context = await createRunningAudioContext();
   } catch (error) {
     // Release the mic we just opened so a failed start can't leave it live.
     for (const track of stream.getTracks()) {
@@ -49,11 +49,10 @@ export async function startMeetingMicCapture(
   analyser.fftSize = 512;
   source.connect(analyser);
 
-  const processor = context.createScriptProcessor(4096, 1, 1);
-  // Route the processor through a muted gain so onaudioprocess fires without
-  // playing the microphone back through the speakers.
-  const mute = context.createGain();
-  mute.gain.value = 0;
+  const flushSamples = Math.max(
+    1,
+    Math.floor(context.sampleRate * FLUSH_SECONDS),
+  );
 
   let buffer: number[] = [];
   const flush = () => {
@@ -65,22 +64,17 @@ export async function startMeetingMicCapture(
       speaker: "me",
       samples: frame,
       channels: 1,
-      // Report the context's real rate; the WebView may ignore the 16 kHz
-      // request and the Rust pipeline resamples whatever rate it receives.
+      // Report the context's real hardware rate so Rust can resample accurately.
       sampleRate: context.sampleRate,
     });
   };
 
-  processor.onaudioprocess = (event) => {
+  const processor = connectPulledScriptProcessor(context, source, (event) => {
     floatToPcm16(event.inputBuffer.getChannelData(0), buffer);
-    if (buffer.length >= FLUSH_SAMPLES) {
+    if (buffer.length >= flushSamples) {
       flush();
     }
-  };
-
-  source.connect(processor);
-  processor.connect(mute);
-  mute.connect(context.destination);
+  });
 
   const timeData = new Uint8Array(analyser.frequencyBinCount);
   const level = () => {
@@ -97,7 +91,6 @@ export async function startMeetingMicCapture(
     processor.onaudioprocess = null;
     flush();
     processor.disconnect();
-    mute.disconnect();
     analyser.disconnect();
     source.disconnect();
     for (const track of stream.getTracks()) {

--- a/src/lib/audio/scriptProcessor.ts
+++ b/src/lib/audio/scriptProcessor.ts
@@ -1,0 +1,29 @@
+// ABOUTME: ScriptProcessor capture helpers for WebViews where zero-gain graphs can stop pulling.
+// ABOUTME: Keeps mic capture audible-output-free while forcing the processor to render.
+
+export function silenceScriptProcessorOutput(
+  event: AudioProcessingEvent,
+): void {
+  for (
+    let channel = 0;
+    channel < event.outputBuffer.numberOfChannels;
+    channel += 1
+  ) {
+    event.outputBuffer.getChannelData(channel).fill(0);
+  }
+}
+
+export function connectPulledScriptProcessor(
+  context: AudioContext,
+  source: AudioNode,
+  onProcess: (event: AudioProcessingEvent) => void,
+): ScriptProcessorNode {
+  const processor = context.createScriptProcessor(4096, 1, 1);
+  processor.onaudioprocess = (event) => {
+    silenceScriptProcessorOutput(event);
+    onProcess(event);
+  };
+  source.connect(processor);
+  processor.connect(context.destination);
+  return processor;
+}

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -187,6 +187,10 @@ export function pushCaptureFrame(input: {
 
 export interface CaptureStopOutcome {
   hadCapture: boolean;
+  pushFrameCount: number;
+  acceptedPushFrameCount: number;
+  droppedPushFrameCount: number;
+  droppedPushSampleCount: number;
   frameCount: number;
   sampleCount: number;
   speechFrameCount: number;

--- a/tests/unit/meeting-mic-capture-pull.test.ts
+++ b/tests/unit/meeting-mic-capture-pull.test.ts
@@ -1,0 +1,121 @@
+// ABOUTME: Regression coverage for #2221 macOS Meeting capture producing zero PCM.
+// ABOUTME: Ensures the mic ScriptProcessor is pulled directly and reports hardware rate.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const m = vi.hoisted(() => ({
+  pushCaptureFrame: vi.fn(async () => {}),
+}));
+
+vi.mock("@/services/meetings", () => ({
+  pushCaptureFrame: m.pushCaptureFrame,
+}));
+
+import { startMeetingMicCapture } from "@/lib/audio/meetingCapture";
+
+const instances: FakeAudioContext[] = [];
+
+class FakeAudioNode {
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+class FakeAnalyser extends FakeAudioNode {
+  fftSize = 0;
+  frequencyBinCount = 4;
+  getByteTimeDomainData = vi.fn((target: Uint8Array) => {
+    target.fill(128);
+  });
+}
+
+class FakeScriptProcessor extends FakeAudioNode {
+  onaudioprocess: ((event: AudioProcessingEvent) => void) | null = null;
+}
+
+class FakeAudioContext {
+  options: AudioContextOptions | undefined;
+  sampleRate = 48_000;
+  state: AudioContextState = "suspended";
+  destination = new FakeAudioNode();
+  source = new FakeAudioNode();
+  analyser = new FakeAnalyser();
+  processor = new FakeScriptProcessor();
+  resume = vi.fn(async () => {
+    this.state = "running";
+  });
+  close = vi.fn(async () => {});
+  createMediaStreamSource = vi.fn(() => this.source);
+  createAnalyser = vi.fn(() => this.analyser);
+  createScriptProcessor = vi.fn(() => this.processor);
+
+  constructor(options?: AudioContextOptions) {
+    this.options = options;
+    instances.push(this);
+  }
+}
+
+function audioProcessEvent(input: Float32Array, output: Float32Array) {
+  return {
+    inputBuffer: {
+      getChannelData: vi.fn(() => input),
+    },
+    outputBuffer: {
+      numberOfChannels: 1,
+      getChannelData: vi.fn(() => output),
+    },
+  } as unknown as AudioProcessingEvent;
+}
+
+beforeEach(() => {
+  instances.length = 0;
+  m.pushCaptureFrame.mockClear();
+  vi.stubGlobal("AudioContext", FakeAudioContext);
+  vi.stubGlobal("navigator", {
+    mediaDevices: {
+      getUserMedia: vi.fn(async () => ({
+        getTracks: () => [{ stop: vi.fn() }],
+      })),
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("startMeetingMicCapture", () => {
+  it("pulls the processor directly to destination and flushes using the real sample rate", async () => {
+    const handle = await startMeetingMicCapture("m1");
+    const context = instances[0];
+    const input = new Float32Array(4096).fill(0.5);
+    const output = new Float32Array(4096).fill(0.25);
+
+    expect(context.source.connect).toHaveBeenCalledWith(context.processor);
+    expect(context.processor.connect).toHaveBeenCalledWith(context.destination);
+    expect(context.options).toBeUndefined();
+
+    for (let i = 0; i < 2; i += 1) {
+      context.processor.onaudioprocess?.(audioProcessEvent(input, output));
+    }
+    expect(m.pushCaptureFrame).not.toHaveBeenCalled();
+
+    context.processor.onaudioprocess?.(audioProcessEvent(input, output));
+
+    expect([...output]).toEqual(Array(4096).fill(0));
+    expect(m.pushCaptureFrame).toHaveBeenCalledOnce();
+    const sent = m.pushCaptureFrame.mock.calls[0][0];
+    expect(sent).toMatchObject({
+      meetingId: "m1",
+      speaker: "me",
+      channels: 1,
+      sampleRate: 48_000,
+    });
+    expect(sent.samples).toHaveLength(12_288);
+    expect(sent.samples[0]).toBe(16_384);
+
+    await handle.stop();
+    expect(context.processor.onaudioprocess).toBeNull();
+    expect(context.processor.disconnect).toHaveBeenCalledOnce();
+    expect(context.close).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/meeting-notes-failure-gate.test.ts
+++ b/tests/unit/meeting-notes-failure-gate.test.ts
@@ -119,6 +119,10 @@ describe("meetingStore notes-failure gates handoff (#2159)", () => {
   it("marks failed and skips notes when capture stop reports no transcript output", async () => {
     m.stopMeetingCapture.mockResolvedValueOnce({
       hadCapture: true,
+      pushFrameCount: 0,
+      acceptedPushFrameCount: 0,
+      droppedPushFrameCount: 0,
+      droppedPushSampleCount: 0,
       frameCount: 0,
       sampleCount: 0,
       speechFrameCount: 0,


### PR DESCRIPTION
Fixes #2221.

## What changed
- Use the WebView hardware-rate AudioContext for Meeting and dictation capture, then report the real sample rate to Rust for resampling.
- Replace the zero-gain ScriptProcessor graph with a direct destination pull that explicitly zeros the output buffer, so WKWebView cannot optimize away `onaudioprocess` behind a muted gain.
- Add Rust ingress counters for `push_capture_frame` calls, accepted pushes, dropped pushes, and dropped samples, with stop-summary logging and more precise failure reasons.

## Audit results
- Prior PRs #2196, #2210, #2218, and #2220 fixed startup/resume/failure surfacing, but none proved the WebView PCM callback was being pulled.
- New code path audit found one additional diagnostic edge: accepted frames with zero worker-processed frames. This PR handles that with a dedicated failure reason and test.
- No new P0/P1 issues found in the updated Meeting/dictation capture path after the audit. Real microphone permission validation still requires an interactive macOS app run.

## Verification
- `pnpm test -- tests/unit/meeting-mic-capture-pull.test.ts` (Vitest runs full suite: 233 files / 1586 tests)
- `pnpm test -- tests/unit/capture-context.test.ts tests/unit/meeting-mic-capture-pull.test.ts` (Vitest runs full suite: 233 files / 1586 tests)
- `cargo test -q dropped --lib`
- `cargo test -q stop_capture_failure_reason --lib`
- `cargo test -q --lib` (650 passed, 1 ignored)
- `pnpm check` (exit 0; pre-existing lint warnings outside this change)
- `pnpm build`