### PR TITLE
fix(meetings): preserve transcripts and improve review UI

### DIFF
--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -37,6 +37,7 @@ pub enum MeetingStatus {
     PendingCapture,
     Capturing,
     Transcribing,
+    TranscriptReady,
     NotesReady,
     AgentRunning,
     Done,
@@ -49,6 +50,7 @@ impl MeetingStatus {
             Self::PendingCapture => "pending_capture",
             Self::Capturing => "capturing",
             Self::Transcribing => "transcribing",
+            Self::TranscriptReady => "transcript_ready",
             Self::NotesReady => "notes_ready",
             Self::AgentRunning => "agent_running",
             Self::Done => "done",
@@ -65,6 +67,7 @@ impl TryFrom<&str> for MeetingStatus {
             "pending_capture" => Ok(Self::PendingCapture),
             "capturing" => Ok(Self::Capturing),
             "transcribing" => Ok(Self::Transcribing),
+            "transcript_ready" => Ok(Self::TranscriptReady),
             "notes_ready" => Ok(Self::NotesReady),
             "agent_running" => Ok(Self::AgentRunning),
             "done" => Ok(Self::Done),
@@ -168,4 +171,18 @@ pub struct TranscriptSegment {
     /// Whether `speaker` was assigned by the capture channel or by diarization.
     pub speaker_source: SpeakerSource,
     pub created_at: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MeetingStatus;
+
+    #[test]
+    fn transcript_ready_status_round_trips_through_storage_value() {
+        assert_eq!(MeetingStatus::TranscriptReady.as_str(), "transcript_ready");
+        assert_eq!(
+            MeetingStatus::try_from("transcript_ready"),
+            Ok(MeetingStatus::TranscriptReady)
+        );
+    }
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -106,7 +106,11 @@ fn set_meeting_notes_record(
 ) -> Result<()> {
     conn.execute(
         "UPDATE meetings
-         SET notes_markdown = ?1, notes_struct_json = ?2, status = ?3, updated_at = ?4
+         SET notes_markdown = ?1,
+             notes_struct_json = ?2,
+             status = ?3,
+             failure_reason = NULL,
+             updated_at = ?4
          WHERE id = ?5",
         params![
             markdown,
@@ -849,7 +853,7 @@ pub fn update_meeting_status_record_with_failure_reason_and_diagnostics(
         "UPDATE meetings
          SET status = ?1,
              ended_at = COALESCE(?2, ended_at),
-             failure_reason = CASE WHEN ?1 = 'failed' THEN ?3 ELSE NULL END,
+             failure_reason = CASE WHEN ?1 IN ('failed', 'transcript_ready') THEN ?3 ELSE NULL END,
              capture_diagnostics_json = COALESCE(?4, capture_diagnostics_json),
              updated_at = ?5
          WHERE id = ?6",

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -339,6 +339,10 @@ export const AppShell: Component<AppShellProps> = (props) => {
     setSlidePanel((v) => (v === "settings" ? null : "settings"));
   };
 
+  const handleToggleMeetings = () => {
+    setSlidePanel((v) => (v === "meetings" ? null : "meetings"));
+  };
+
   const handleToggleSkills = () => {
     setSlidePanel((v) => (v === "skills" ? null : "skills"));
   };
@@ -638,6 +642,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
     <div class="flex flex-col h-screen bg-background text-foreground">
       <Titlebar
         onSignInClick={handleSignInClick}
+        onToggleMeetings={handleToggleMeetings}
         onToggleSkills={handleToggleSkills}
         onToggleSettings={handleToggleSettings}
         recordPromptVisible={recordPromptVisible()}
@@ -710,6 +715,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
           open={slidePanel() !== null}
           onClose={handleCloseSlidePanel}
           docked={slidePanel() === "skills"}
+          reader={slidePanel() === "meetings"}
           wide={slidePanel() === "settings"}
         >
           <Switch>

--- a/src/components/layout/SlidePanel.tsx
+++ b/src/components/layout/SlidePanel.tsx
@@ -14,6 +14,7 @@ interface SlidePanelProps {
   open: boolean;
   onClose: () => void;
   wide?: boolean;
+  reader?: boolean;
   docked?: boolean;
   children: JSX.Element;
 }
@@ -74,8 +75,9 @@ export const SlidePanel: Component<SlidePanelProps> = (props) => {
   // persisted preference, clamped against the current viewport so a width
   // saved on a larger display does not overflow on a smaller one.
   const effectiveWidth = () => clampWidth(storedWidth(), viewportWidth());
-  const panelWidth = () => (props.wide ? "860px" : `${effectiveWidth()}px`);
-  const resizable = () => !props.wide;
+  const panelWidth = () =>
+    props.reader ? "1040px" : props.wide ? "860px" : `${effectiveWidth()}px`;
+  const resizable = () => !props.wide && !props.reader;
 
   const handleResizeStart = (event: PointerEvent) => {
     if (!resizable()) return;

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -1085,39 +1085,6 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
             Sessions
           </button>
 
-          <button
-            type="button"
-            data-testid="meetings-button"
-            class="flex w-full px-3 py-2 text-left text-[12px] text-muted-foreground hover:text-foreground hover:bg-surface-1/50 transition-colors items-center gap-2"
-            onClick={() =>
-              window.dispatchEvent(
-                new CustomEvent("seren:open-panel", { detail: "meetings" }),
-              )
-            }
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="none"
-              role="img"
-              aria-label="Meetings"
-            >
-              <path
-                d="M4.5 7a3.5 3.5 0 0 1 7 0v1.2a3.5 3.5 0 0 1-7 0V7Z"
-                stroke="currentColor"
-                stroke-width="1.2"
-              />
-              <path
-                d="M2.5 8a5.5 5.5 0 0 0 11 0M8 13.5V15"
-                stroke="currentColor"
-                stroke-width="1.2"
-                stroke-linecap="round"
-              />
-            </svg>
-            Meetings
-          </button>
-
           <Show when={threadStore.runningCount > 0}>
             <div class="px-3 py-2 border-t border-border/30">
               <span class="text-[11px] text-status-running flex items-center gap-1.5">

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -10,6 +10,7 @@ import { updaterStore } from "@/stores/updater.store";
 
 interface TitlebarProps {
   onSignInClick: () => void;
+  onToggleMeetings: () => void;
   onToggleSkills: () => void;
   onToggleSettings: () => void;
   recordPromptVisible?: boolean;
@@ -39,6 +40,26 @@ function formatBytes(bytes: number): string {
   const sizes = ["B", "KB", "MB", "GB"];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return `${(bytes / k ** i).toFixed(1)} ${sizes[i]}`;
+}
+
+function MeetingsIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.4"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      role="img"
+      aria-label="Meetings"
+    >
+      <path d="M8 9.8a2.25 2.25 0 0 0 2.25-2.25V4.25a2.25 2.25 0 0 0-4.5 0v3.3A2.25 2.25 0 0 0 8 9.8Z" />
+      <path d="M3.8 7.25a4.2 4.2 0 0 0 8.4 0M8 11.45V14M6.25 14h3.5" />
+    </svg>
+  );
 }
 
 export const Titlebar: Component<TitlebarProps> = (props) => {
@@ -130,6 +151,16 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
         <Show when={authStore.isAuthenticated}>
           <BalanceDisplay />
         </Show>
+
+        <button
+          type="button"
+          data-testid="titlebar-meetings-button"
+          class="flex items-center justify-center w-7 h-7 border-none rounded-md bg-transparent text-muted-foreground cursor-pointer transition-all duration-100 hover:bg-surface-2 hover:text-foreground active:scale-95"
+          onClick={props.onToggleMeetings}
+          title="Meetings"
+        >
+          <MeetingsIcon />
+        </button>
 
         <button
           type="button"

--- a/src/components/meeting/CaptureWidget.tsx
+++ b/src/components/meeting/CaptureWidget.tsx
@@ -32,7 +32,7 @@ export function CaptureWidget() {
   const [meeting, setMeeting] = createSignal<Meeting | null>(null);
   const [stopping, setStopping] = createSignal(false);
   // A ticking signal so the elapsed clock re-renders once per second.
-  const [, setTick] = createSignal(0);
+  const [tick, setTick] = createSignal(0);
 
   let statusUnlisten: (() => void) | null = null;
   let clock: number | null = null;
@@ -73,27 +73,32 @@ export function CaptureWidget() {
   };
 
   return (
-    <div
-      data-tauri-drag-region
-      class="h-screen w-screen flex items-center gap-2.5 px-3 rounded-xl border border-border bg-surface-1/95 text-foreground select-none backdrop-blur"
-    >
-      <span
-        class="w-2 h-2 shrink-0 rounded-full"
-        classList={{
-          "bg-destructive animate-pulse": recording(),
-          "bg-muted-foreground": !recording(),
-        }}
-      />
-      <div class="min-w-0 flex-1 leading-tight">
-        <div class="font-mono tabular-nums text-[13px]">
-          <Show when={meeting()} fallback="00:00">
-            {(active) => formatDuration(active())}
-          </Show>
-        </div>
-        <div class="truncate text-[10px] text-muted-foreground">
-          <Show when={meeting()} fallback="Recording">
-            {(active) => meetingTitle(active())}
-          </Show>
+    <div class="h-screen w-screen flex items-center gap-2.5 px-3 rounded-xl border border-border bg-surface-1/95 text-foreground select-none backdrop-blur">
+      <div
+        data-tauri-drag-region
+        class="min-w-0 flex flex-1 items-center gap-2.5"
+      >
+        <span
+          class="w-2 h-2 shrink-0 rounded-full"
+          classList={{
+            "bg-destructive animate-pulse": recording(),
+            "bg-muted-foreground": !recording(),
+          }}
+        />
+        <div class="min-w-0 flex-1 leading-tight">
+          <div class="font-mono tabular-nums text-[13px]">
+            <Show when={meeting()} fallback="00:00">
+              {(active) => {
+                tick();
+                return formatDuration(active());
+              }}
+            </Show>
+          </div>
+          <div class="truncate text-[10px] text-muted-foreground">
+            <Show when={meeting()} fallback="Recording">
+              {(active) => meetingTitle(active())}
+            </Show>
+          </div>
         </div>
       </div>
       <button

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -123,7 +123,7 @@ export function MeetingDetail(props: MeetingDetailProps) {
   };
 
   return (
-    <div class="p-5 max-w-[760px]">
+    <div class="p-5 max-w-none">
       <div class="mb-5">
         <h3 class="text-[18px] font-semibold tracking-normal">
           {meetingTitle(props.meeting)}
@@ -135,13 +135,17 @@ export function MeetingDetail(props: MeetingDetailProps) {
           </span>
           <span>{props.meeting.sourceApp ?? "Desktop"}</span>
         </div>
-        <Show
-          when={
-            props.meeting.status === "failed" && props.meeting.failureReason
-          }
-        >
+        <Show when={props.meeting.failureReason}>
           {(reason) => (
-            <div class="mt-3 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-[12px] leading-5 text-destructive">
+            <div
+              class="mt-3 rounded-md border p-3 text-[12px] leading-5"
+              classList={{
+                "border-destructive/30 bg-destructive/10 text-destructive":
+                  props.meeting.status === "failed",
+                "border-warning/30 bg-warning/10 text-warning":
+                  props.meeting.status !== "failed",
+              }}
+            >
               {reason()}
             </div>
           )}
@@ -233,7 +237,7 @@ export function MeetingDetail(props: MeetingDetailProps) {
               {(segment) => (
                 <div
                   ref={(el) => rows.set(segment.seq, el)}
-                  class="grid grid-cols-[52px_1fr] gap-3 py-2 border-b border-border/50 last:border-b-0 transition-colors"
+                  class="grid grid-cols-[64px_minmax(0,1fr)] gap-3 py-2 border-b border-border/50 last:border-b-0 transition-colors"
                   classList={{
                     "bg-primary/10": highlightedSeq() === segment.seq,
                   }}
@@ -248,7 +252,7 @@ export function MeetingDetail(props: MeetingDetailProps) {
                     {segment.speaker === "me" ? "Me" : "Them"}
                   </div>
                   <div
-                    class="text-[13px] leading-5"
+                    class="min-w-0 break-words text-[13px] leading-5"
                     classList={{
                       "text-muted-foreground italic": segment.status === "gap",
                       "text-foreground": segment.status === "ok",

--- a/src/lib/meeting-format.ts
+++ b/src/lib/meeting-format.ts
@@ -29,6 +29,7 @@ export const STATUS_LABELS: Record<Meeting["status"], string> = {
   pending_capture: "Starting",
   capturing: "Capturing",
   transcribing: "Transcribing",
+  transcript_ready: "Transcript ready",
   notes_ready: "Notes ready",
   agent_running: "Agent running",
   done: "Done",

--- a/src/services/captureWidget.ts
+++ b/src/services/captureWidget.ts
@@ -5,6 +5,52 @@ import { isTauriRuntime } from "@/lib/tauri-bridge";
 
 const WIDGET_LABEL = "capture-widget";
 const WIDGET_STOP_EVENT = "meeting://widget-stop";
+const WIDGET_WIDTH = 220;
+const WIDGET_HEIGHT = 80;
+const WIDGET_MARGIN = 16;
+const TITLEBAR_CLEARANCE = 48;
+
+interface WidgetPosition {
+  x: number;
+  y: number;
+}
+
+export async function captureWidgetPosition(): Promise<WidgetPosition> {
+  const { currentMonitor, getCurrentWindow, primaryMonitor } = await import(
+    "@tauri-apps/api/window"
+  );
+
+  try {
+    const appWindow = getCurrentWindow();
+    const [position, size, scaleFactor] = await Promise.all([
+      appWindow.outerPosition(),
+      appWindow.outerSize(),
+      appWindow.scaleFactor(),
+    ]);
+    const scale = scaleFactor || 1;
+    return {
+      x: Math.round(
+        position.x / scale + size.width / scale - WIDGET_WIDTH - WIDGET_MARGIN,
+      ),
+      y: Math.round(position.y / scale + TITLEBAR_CLEARANCE),
+    };
+  } catch {
+    const monitor = (await currentMonitor()) ?? (await primaryMonitor());
+    if (!monitor) {
+      return { x: WIDGET_MARGIN, y: WIDGET_MARGIN };
+    }
+    const scale = monitor.scaleFactor || 1;
+    return {
+      x: Math.round(
+        monitor.position.x / scale +
+          monitor.size.width / scale -
+          WIDGET_WIDTH -
+          WIDGET_MARGIN,
+      ),
+      y: Math.round(monitor.position.y / scale + TITLEBAR_CLEARANCE),
+    };
+  }
+}
 
 /**
  * Open the floating capture widget when a meeting capture starts. The widget
@@ -15,10 +61,13 @@ const WIDGET_STOP_EVENT = "meeting://widget-stop";
 export async function openCaptureWidget(meetingId: string): Promise<void> {
   if (!isTauriRuntime()) return;
   const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+  const { LogicalPosition } = await import("@tauri-apps/api/window");
+  const position = await captureWidgetPosition();
 
   const existing = await WebviewWindow.getByLabel(WIDGET_LABEL);
   if (existing) {
     try {
+      await existing.setPosition(new LogicalPosition(position.x, position.y));
       await existing.show();
       await existing.setFocus();
     } catch {
@@ -31,8 +80,10 @@ export async function openCaptureWidget(meetingId: string): Promise<void> {
   const widget = new WebviewWindow(WIDGET_LABEL, {
     url,
     title: "Meeting capture",
-    width: 220,
-    height: 80,
+    x: position.x,
+    y: position.y,
+    width: WIDGET_WIDTH,
+    height: WIDGET_HEIGHT,
     resizable: false,
     decorations: false,
     alwaysOnTop: true,

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -8,6 +8,7 @@ export type MeetingStatus =
   | "pending_capture"
   | "capturing"
   | "transcribing"
+  | "transcript_ready"
   | "notes_ready"
   | "agent_running"
   | "done"

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -545,16 +545,32 @@ async function stopAndProcess(meeting: Meeting): Promise<void> {
         vocabulary: settingsStore.get("voiceCustomVocabulary"),
       });
     } catch (error) {
-      // Notes failed: the backend left the meeting at `transcribing` (it only
-      // sets notes_ready on success). Mark it failed and stop — don't fall
-      // through to runHandoff and auto-invoke a skill on an empty meeting (#2159).
+      // Notes failed: keep successful transcripts usable instead of marking the
+      // recording failed. Only true empty-transcript cases remain failed (#2227).
       const reason = notesFailureReason(error);
       console.error(
         "[meeting] post-capture processing failed",
         { meetingId: meeting.id, reason },
         error,
       );
-      await failMeeting(meeting.id, reason);
+      const transcript = await getMeetingTranscriptText(meeting.id).catch(
+        () => "",
+      );
+      if (transcript.trim()) {
+        await updateMeetingStatus(
+          meeting.id,
+          "transcript_ready",
+          null,
+          reason,
+        ).catch(() => {});
+        await loadMeetings();
+        const refreshed =
+          meetingState.meetings.find((m) => m.id === meeting.id) ?? null;
+        await setActiveMeeting(refreshed);
+        setMeetingState("error", reason);
+      } else {
+        await failMeeting(meeting.id, notesFailureReason(error));
+      }
       return;
     }
     await loadMeetings();

--- a/tests/unit/meeting-notes-failure-gate.test.ts
+++ b/tests/unit/meeting-notes-failure-gate.test.ts
@@ -93,15 +93,36 @@ function meeting(overrides: Partial<Meeting> = {}): Meeting {
   };
 }
 
-describe("meetingStore notes-failure gates handoff (#2159)", () => {
+describe("meetingStore notes-failure gates handoff (#2159 / #2227)", () => {
   beforeEach(() => {
     for (const fn of Object.values(m)) fn.mockClear();
     m.listMeetings.mockResolvedValue([meeting()]);
     m.getMeetingTranscriptText.mockResolvedValue("hello transcript");
   });
 
-  it("marks failed and skips handoff when notes generation throws", async () => {
-    m.generateMeetingNotes.mockRejectedValueOnce(new Error("notes boom"));
+  it("keeps a transcripted meeting usable and skips handoff when notes generation throws", async () => {
+    m.generateMeetingNotes.mockRejectedValueOnce(
+      new Error("chat completion returned no content"),
+    );
+
+    await meetingStore.stopAndProcess(meeting());
+
+    expect(m.updateMeetingStatus).toHaveBeenCalledWith(
+      "m1",
+      "transcript_ready",
+      null,
+      expect.stringContaining("Meeting notes could not be generated"),
+    );
+    // No handoff: the skill router and agent run must never fire.
+    expect(m.selectMeetingSkills).not.toHaveBeenCalled();
+    expect(m.orchestrate).not.toHaveBeenCalled();
+  });
+
+  it("still marks failed when notes generation fails because no transcript exists", async () => {
+    m.generateMeetingNotes.mockRejectedValueOnce(
+      new Error("no transcript to summarize"),
+    );
+    m.getMeetingTranscriptText.mockResolvedValueOnce("   ");
 
     await meetingStore.stopAndProcess(meeting());
 
@@ -109,9 +130,8 @@ describe("meetingStore notes-failure gates handoff (#2159)", () => {
       "m1",
       "failed",
       expect.any(Number),
-      expect.stringContaining("Meeting notes could not be generated"),
+      expect.stringContaining("No transcript was captured"),
     );
-    // No handoff: the skill router and agent run must never fire.
     expect(m.selectMeetingSkills).not.toHaveBeenCalled();
     expect(m.orchestrate).not.toHaveBeenCalled();
   });

--- a/tests/unit/meeting-ui-regressions.test.ts
+++ b/tests/unit/meeting-ui-regressions.test.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Source-level guards for Meeting Mode usability regressions from #2228.
+// ABOUTME: Keeps capture controls reachable and transcript review out of the narrow sidebar layout.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string): string {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("Meeting Mode top-right entry point (#2228)", () => {
+  it("opens Meetings from a titlebar icon instead of the lower-left text row", () => {
+    const titlebar = source("src/components/layout/Titlebar.tsx");
+    const appShell = source("src/components/layout/AppShell.tsx");
+    const sidebar = source("src/components/layout/ThreadSidebar.tsx");
+
+    expect(titlebar).toContain("onToggleMeetings");
+    expect(titlebar).toContain('data-testid="titlebar-meetings-button"');
+    expect(titlebar.indexOf('title="Meetings"')).toBeLessThan(
+      titlebar.indexOf('title="Settings"'),
+    );
+    expect(appShell).toContain("handleToggleMeetings");
+    expect(appShell).toContain("onToggleMeetings={handleToggleMeetings}");
+    expect(sidebar).not.toContain('data-testid="meetings-button"');
+  });
+});
+
+describe("Meeting Mode transcript layout (#2228)", () => {
+  it("uses a reader-width slide panel and removes the narrow detail max-width", () => {
+    const appShell = source("src/components/layout/AppShell.tsx");
+    const slidePanel = source("src/components/layout/SlidePanel.tsx");
+    const detail = source("src/components/meeting/MeetingDetail.tsx");
+
+    expect(appShell).toContain('reader={slidePanel() === "meetings"}');
+    expect(slidePanel).toContain("reader?: boolean");
+    expect(slidePanel).toContain('props.reader ? "1040px"');
+    expect(detail).toContain("max-w-none");
+    expect(detail).not.toContain("max-w-[760px]");
+  });
+});
+
+describe("Meeting capture widget behavior (#2228)", () => {
+  it("positions the widget near the top-right and keeps its timer reactive", () => {
+    const widgetService = source("src/services/captureWidget.ts");
+    const widget = source("src/components/meeting/CaptureWidget.tsx");
+
+    expect(widgetService).toContain("captureWidgetPosition");
+    expect(widgetService).toContain("currentMonitor");
+    expect(widgetService).toContain("WIDGET_MARGIN");
+    expect(widgetService).toContain("x:");
+    expect(widgetService).toContain("y:");
+    expect(widget).toContain("const [tick, setTick]");
+    expect(widget).toContain("tick();");
+    expect(widget).toContain('data-tauri-drag-region');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2227.
Fixes #2228.

This PR addresses the transcript bugs reported in `~/Downloads/Logs/20260609_Transcript_Bugs.md` after the native recording path landed:

- preserve a successful transcript when notes generation returns `chat completion returned no content` instead of marking the whole recording failed
- add a durable `transcript_ready` meeting status for transcript-success / notes-failed cases
- keep the notes failure reason visible as a recoverable warning while leaving the transcript reviewable
- move the Meetings entry point to a top-right titlebar icon near Settings and remove the lower-left text row
- widen the Meetings slide panel for transcript review and remove the narrow detail max-width
- place the floating capture widget near the top-right of the current app window/monitor
- make the floating widget timer reactive and keep the Stop button outside the drag region

## Audit Notes

The log showed native capture working and transcript segments emitted/persisted, followed by notes generation failure:

`native_mic_ready=true system_audio_ready=true apm_ready=true ... emitted_segments=335 ... persistedTextSegmentCount>0`

The frontend then caught `generateMeetingNotes` failure in `stopAndProcess` and called `failMeeting`, which overwrote a successful transcript with a failed meeting state. The UI issues came from the Meetings panel using the default narrow slide-panel width, `MeetingDetail` using a `max-w-[760px]` cap inside that panel, and the capture widget opening without explicit `x/y` placement while its timer signal was never read.

## Tests

- `pnpm test -- tests/unit/meeting-notes-failure-gate.test.ts tests/unit/meeting-ui-regressions.test.ts` (runs all 1,593 unit tests in this repo setup)
- `cargo test --manifest-path src-tauri/Cargo.toml audio::types::tests::transcript_ready_status_round_trips_through_storage_value`
- `cargo test --manifest-path src-tauri/Cargo.toml` (658 passed, 1 ignored)
- `pnpm exec biome check src/components/layout/AppShell.tsx src/components/layout/SlidePanel.tsx src/components/layout/ThreadSidebar.tsx src/components/layout/Titlebar.tsx src/components/meeting/CaptureWidget.tsx src/components/meeting/MeetingDetail.tsx src/lib/meeting-format.ts src/services/captureWidget.ts src/services/meetings.ts src/stores/meeting.store.ts tests/unit/meeting-notes-failure-gate.test.ts tests/unit/meeting-ui-regressions.test.ts`
- `pnpm check` (exits 0; reports existing unrelated warnings in session/employee files)
- `pnpm build`

`pnpm exec tsc --noEmit` is not a repo script and currently fails on an unrelated pre-existing missing declaration for `bin/browser-local/logging.mjs` in `tests/unit/provider-runtime-log-prefix.test.ts`.