### PR TITLE
Fix Meeting Mode capture prompt and deletion

### DIFF
--- a/src-tauri/src/audio/detect.rs
+++ b/src-tauri/src/audio/detect.rs
@@ -1,9 +1,19 @@
 // ABOUTME: Meeting auto-detect decision logic for capture arming.
-// ABOUTME: Uses passive platform audio activity probes, not process-name presence.
+// ABOUTME: Uses passive audio activity probes plus best-effort app naming.
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AudioActivity {
     pub input_active: bool,
+    pub source_app: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MeetingAutodetectResult {
+    pub detected: bool,
+    pub source_app: Option<String>,
 }
 
 /// Read whether the default input device is actively used by another app. The
@@ -17,9 +27,80 @@ pub fn should_start_capture(activity: AudioActivity) -> bool {
     activity.input_active
 }
 
+pub fn meeting_detection(activity: AudioActivity) -> MeetingAutodetectResult {
+    if should_start_capture(activity.clone()) {
+        return MeetingAutodetectResult {
+            detected: true,
+            source_app: activity.source_app,
+        };
+    }
+    MeetingAutodetectResult {
+        detected: false,
+        source_app: None,
+    }
+}
+
+fn known_call_app_from_process_list(process_list: &str) -> Option<String> {
+    let lower = process_list.to_lowercase();
+    for (needles, display) in KNOWN_CALL_APPS {
+        if needles.iter().any(|needle| lower.contains(needle)) {
+            return Some((*display).to_string());
+        }
+    }
+    None
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn known_call_app_from_system_processes() -> Option<String> {
+    let output = system_process_list()?;
+    known_call_app_from_process_list(&output)
+}
+
+#[cfg(target_os = "windows")]
+fn system_process_list() -> Option<String> {
+    let output = std::process::Command::new("tasklist")
+        .args(["/FO", "CSV", "/NH"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}
+
+#[cfg(target_os = "macos")]
+fn system_process_list() -> Option<String> {
+    let output = std::process::Command::new("ps")
+        .args(["-axo", "comm="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}
+
+const KNOWN_CALL_APPS: &[(&[&str], &str)] = &[
+    (&["zoom.us", "zoom.exe"], "Zoom"),
+    (&["discord"], "Discord"),
+    (&["whatsapp"], "WhatsApp"),
+    (
+        &["microsoft teams", "ms-teams", "teams.exe"],
+        "Microsoft Teams",
+    ),
+    (&["slack"], "Slack"),
+    (&["facetime"], "FaceTime"),
+    (&["telegram"], "Telegram"),
+    (&["google chrome", "chrome.exe"], "Google Chrome"),
+    (&["arc.app", "/arc", "arc.exe"], "Arc"),
+    (&["safari"], "Safari"),
+    (&["firefox"], "Firefox"),
+    (&["brave browser", "brave.exe"], "Brave"),
+];
+
 #[cfg(target_os = "macos")]
 mod platform_audio {
-    use super::AudioActivity;
+    use super::{AudioActivity, known_call_app_from_system_processes};
     use std::ffi::c_void;
 
     type OSStatus = i32;
@@ -58,8 +139,12 @@ mod platform_audio {
     }
 
     pub(super) fn probe_audio_activity() -> AudioActivity {
+        let input_active = default_input_device_is_running();
         AudioActivity {
-            input_active: default_input_device_is_running(),
+            input_active,
+            source_app: input_active
+                .then(known_call_app_from_system_processes)
+                .flatten(),
         }
     }
 
@@ -123,7 +208,7 @@ mod platform_audio {
 
 #[cfg(target_os = "windows")]
 mod platform_audio {
-    use super::AudioActivity;
+    use super::{AudioActivity, known_call_app_from_system_processes};
     use wasapi::initialize_mta;
     use windows::Win32::Media::Audio::{
         AudioSessionStateActive, IAudioSessionManager2, IMMDeviceEnumerator, MMDeviceEnumerator,
@@ -132,8 +217,12 @@ mod platform_audio {
     use windows::Win32::System::Com::{CLSCTX_ALL, CoCreateInstance};
 
     pub(super) fn probe_audio_activity() -> AudioActivity {
+        let input_active = default_capture_session_is_active();
         AudioActivity {
-            input_active: default_capture_session_is_active(),
+            input_active,
+            source_app: input_active
+                .then(known_call_app_from_system_processes)
+                .flatten(),
         }
     }
 
@@ -190,7 +279,10 @@ mod tests {
 
     #[test]
     fn should_start_capture_when_mic_is_in_use() {
-        assert!(should_start_capture(AudioActivity { input_active: true }));
+        assert!(should_start_capture(AudioActivity {
+            input_active: true,
+            ..Default::default()
+        }));
     }
 
     #[test]
@@ -200,11 +292,42 @@ mod tests {
 
     #[test]
     fn should_start_capture_when_input_device_is_active_for_browser_meetings() {
-        assert!(should_start_capture(AudioActivity { input_active: true }));
+        assert!(should_start_capture(AudioActivity {
+            input_active: true,
+            ..Default::default()
+        }));
     }
 
     #[test]
     fn should_not_start_capture_without_input_activity() {
         assert!(!should_start_capture(AudioActivity::default()));
+    }
+
+    #[test]
+    fn detection_includes_source_app_only_when_input_is_active() {
+        let inactive = meeting_detection(AudioActivity {
+            input_active: false,
+            source_app: Some("Discord".to_string()),
+        });
+        assert!(!inactive.detected);
+        assert_eq!(inactive.source_app, None);
+
+        let active = meeting_detection(AudioActivity {
+            input_active: true,
+            source_app: Some("Discord".to_string()),
+        });
+        assert!(active.detected);
+        assert_eq!(active.source_app.as_deref(), Some("Discord"));
+    }
+
+    #[test]
+    fn known_call_app_detection_prefers_specific_voice_apps_over_browsers() {
+        let processes = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\n\
+            /Applications/Discord.app/Contents/MacOS/Discord\n";
+
+        assert_eq!(
+            known_call_app_from_process_list(processes).as_deref(),
+            Some("Discord")
+        );
     }
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -4,7 +4,7 @@
 use crate::audio::capture::to_mono_16k;
 use crate::audio::chunker::Chunk;
 use crate::audio::cleanup::{build_cleanup_prompt, build_transform_prompt};
-use crate::audio::detect::{probe_audio_activity, should_start_capture};
+use crate::audio::detect::{MeetingAutodetectResult, meeting_detection, probe_audio_activity};
 use crate::audio::llm::{CompletionRequest, complete};
 use crate::audio::merge::merge_segments;
 use crate::audio::notes::{ParsedNotes, generate_notes};
@@ -56,6 +56,21 @@ pub async fn get_meeting(app: AppHandle, id: String) -> Result<Option<Meeting>, 
 #[tauri::command]
 pub async fn list_meetings(app: AppHandle, limit: Option<i32>) -> Result<Vec<Meeting>, String> {
     run_db(app, move |conn| select_meetings(conn, limit.unwrap_or(50))).await
+}
+
+#[tauri::command]
+pub async fn delete_meeting(app: AppHandle, id: String) -> Result<(), String> {
+    let deleted_id = id.clone();
+    run_db(app.clone(), move |conn| {
+        delete_meeting_record(conn, &id)?;
+        Ok(())
+    })
+    .await?;
+    let _ = app.emit(
+        "meeting://deleted",
+        serde_json::json!({ "meetingId": deleted_id }),
+    );
+    Ok(())
 }
 
 #[tauri::command]
@@ -625,9 +640,9 @@ pub fn list_meeting_templates() -> Vec<MeetingTemplate> {
 /// Probe audio activity, then decide whether a meeting capture should arm.
 /// Process presence alone must not surface a record prompt.
 #[tauri::command]
-pub fn meeting_autodetect() -> bool {
+pub fn meeting_autodetect() -> MeetingAutodetectResult {
     let activity = probe_audio_activity();
-    should_start_capture(activity)
+    meeting_detection(activity)
 }
 
 // --- Dictation (shares the transcribe + cleanup engines with Meeting Mode) --
@@ -802,6 +817,17 @@ pub fn select_meetings(conn: &Connection, limit: i32) -> Result<Vec<Meeting>> {
 
     stmt.query_map(params![limit], row_to_meeting)?
         .collect::<Result<Vec<_>>>()
+}
+
+pub fn delete_meeting_record(conn: &Connection, id: &str) -> Result<usize> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "DELETE FROM transcript_segments WHERE meeting_id = ?1",
+        params![id],
+    )?;
+    let deleted = tx.execute("DELETE FROM meetings WHERE id = ?1", params![id])?;
+    tx.commit()?;
+    Ok(deleted)
 }
 
 pub fn update_meeting_status_record(
@@ -1212,6 +1238,38 @@ mod tests {
         assert_eq!(segments[0].speaker_label, None);
         assert_eq!(segments[0].speaker_source, SpeakerSource::Channel);
         assert_eq!(segments[2].status, SegmentStatus::Gap);
+    }
+
+    #[test]
+    fn delete_meeting_record_removes_notes_and_transcript_segments() {
+        let conn = setup();
+        insert_meeting(&conn, meeting("meeting-1")).unwrap();
+        set_meeting_notes_record(&conn, "meeting-1", "notes", "{}").unwrap();
+        insert_transcript_segment(
+            &conn,
+            NewTranscriptSegment {
+                id: "segment-1".to_string(),
+                meeting_id: "meeting-1".to_string(),
+                seq: 0,
+                speaker: Speaker::Me,
+                text: "hello".to_string(),
+                start_ms: 0,
+                end_ms: 100,
+                status: SegmentStatus::Ok,
+                speaker_label: None,
+                speaker_source: SpeakerSource::Channel,
+                created_at: 30,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(delete_meeting_record(&conn, "meeting-1").unwrap(), 1);
+        assert!(select_meeting(&conn, "meeting-1").unwrap().is_none());
+        assert!(
+            select_transcript_segments(&conn, "meeting-1")
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -796,6 +796,7 @@ pub fn run() {
             commands::audio::create_meeting,
             commands::audio::get_meeting,
             commands::audio::list_meetings,
+            commands::audio::delete_meeting,
             commands::audio::update_meeting_status,
             commands::audio::update_meeting_notes,
             commands::audio::set_meeting_routed_skill,

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -646,6 +646,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
         onToggleSkills={handleToggleSkills}
         onToggleSettings={handleToggleSettings}
         recordPromptVisible={recordPromptVisible()}
+        recordPromptSourceApp={meetingStore.state.autoDetectSourceApp}
         onRecordConversation={() => void meetingStore.acceptAutoDetect()}
         onDismissRecordPrompt={() => meetingStore.dismissAutoDetect()}
       />

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -14,6 +14,7 @@ interface TitlebarProps {
   onToggleSkills: () => void;
   onToggleSettings: () => void;
   recordPromptVisible?: boolean;
+  recordPromptSourceApp?: string | null;
   onRecordConversation?: () => void;
   onDismissRecordPrompt?: () => void;
 }
@@ -143,6 +144,7 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
 
         <Show when={props.recordPromptVisible}>
           <RecordPrompt
+            sourceApp={props.recordPromptSourceApp}
             onRecord={() => props.onRecordConversation?.()}
             onDismiss={() => props.onDismissRecordPrompt?.()}
           />

--- a/src/components/meeting/CaptureWidget.tsx
+++ b/src/components/meeting/CaptureWidget.tsx
@@ -29,6 +29,7 @@ function meetingIdFromUrl(): string | null {
 
 export function CaptureWidget() {
   const meetingId = meetingIdFromUrl();
+  const fallbackStartedAt = Date.now();
   const [meeting, setMeeting] = createSignal<Meeting | null>(null);
   const [stopping, setStopping] = createSignal(false);
   // A ticking signal so the elapsed clock re-renders once per second.
@@ -38,6 +39,7 @@ export function CaptureWidget() {
   let clock: number | null = null;
 
   onMount(async () => {
+    clock = window.setInterval(() => setTick((value) => value + 1), 1000);
     if (!meetingId || !isTauriRuntime()) return;
 
     try {
@@ -51,8 +53,6 @@ export function CaptureWidget() {
     statusUnlisten = await listen<Meeting>("meeting://status", (event) => {
       if (event.payload.id === meetingId) setMeeting(event.payload);
     });
-
-    clock = window.setInterval(() => setTick((value) => value + 1), 1000);
   });
 
   onCleanup(() => {
@@ -61,6 +61,13 @@ export function CaptureWidget() {
   });
 
   const recording = () => meeting()?.status === "capturing";
+  const fallbackDuration = () => {
+    tick();
+    return formatDuration({
+      startedAt: fallbackStartedAt,
+      endedAt: null,
+    } as Meeting);
+  };
 
   const stop = async () => {
     if (!meetingId || stopping()) return;
@@ -73,7 +80,7 @@ export function CaptureWidget() {
   };
 
   return (
-    <div class="h-screen w-screen flex items-center gap-2.5 px-3 rounded-xl border border-border bg-surface-1/95 text-foreground select-none backdrop-blur">
+    <div class="h-full w-full overflow-hidden box-border flex items-center gap-2.5 px-3 rounded-xl border border-border bg-surface-1/95 text-foreground select-none backdrop-blur">
       <div
         data-tauri-drag-region
         class="min-w-0 flex flex-1 items-center gap-2.5"
@@ -87,7 +94,7 @@ export function CaptureWidget() {
         />
         <div class="min-w-0 flex-1 leading-tight">
           <div class="font-mono tabular-nums text-[13px]">
-            <Show when={meeting()} fallback="00:00">
+            <Show when={meeting()} fallback={fallbackDuration()}>
               {(active) => {
                 tick();
                 return formatDuration(active());

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -21,6 +21,27 @@ import { settingsStore } from "@/stores/settings.store";
 
 interface MeetingDetailProps {
   meeting: Meeting;
+  onRequestDelete?: (meeting: Meeting) => void;
+}
+
+function TrashGlyph() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M6.2 2.5h3.6M3.5 4.5h9M5 4.5l.4 8.2c.1.6.5.9 1.1.9h3c.6 0 1-.3 1.1-.9l.4-8.2M6.9 6.7v4.5M9.1 6.7v4.5"
+        stroke="currentColor"
+        stroke-width="1.35"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
 }
 
 function parseStructured(json: string | null): StructuredNotes | null {
@@ -89,6 +110,11 @@ export function MeetingDetail(props: MeetingDetailProps) {
   );
 
   const segments = () => meetingStore.state.liveSegments;
+  const deleteDisabled = () =>
+    props.meeting.status === "pending_capture" ||
+    props.meeting.status === "capturing" ||
+    props.meeting.status === "transcribing" ||
+    props.meeting.status === "agent_running";
 
   const jumpToSource = (text: string) => {
     const target = keywords(text);
@@ -125,15 +151,33 @@ export function MeetingDetail(props: MeetingDetailProps) {
   return (
     <div class="p-5 max-w-none">
       <div class="mb-5">
-        <h3 class="text-[18px] font-semibold tracking-normal">
-          {meetingTitle(props.meeting)}
-        </h3>
-        <div class="mt-1 flex items-center gap-3 text-[12px] text-muted-foreground">
-          <span>{STATUS_LABELS[props.meeting.status]}</span>
-          <span class="font-mono tabular-nums">
-            {formatDuration(props.meeting)}
-          </span>
-          <span>{props.meeting.sourceApp ?? "Desktop"}</span>
+        <div class="flex items-start justify-between gap-4">
+          <div class="min-w-0">
+            <h3 class="truncate text-[18px] font-semibold tracking-normal">
+              {meetingTitle(props.meeting)}
+            </h3>
+            <div class="mt-1 flex flex-wrap items-center gap-3 text-[12px] text-muted-foreground">
+              <span>{STATUS_LABELS[props.meeting.status]}</span>
+              <span class="font-mono tabular-nums">
+                {formatDuration(props.meeting)}
+              </span>
+              <span>{props.meeting.sourceApp ?? "Desktop"}</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            class="h-8 w-8 shrink-0 flex items-center justify-center rounded-md border border-destructive/35 bg-destructive/10 text-destructive transition-colors hover:bg-destructive/15 disabled:opacity-45 disabled:cursor-not-allowed"
+            onClick={() => props.onRequestDelete?.(props.meeting)}
+            disabled={deleteDisabled()}
+            title={
+              deleteDisabled()
+                ? "Stop capture before deleting"
+                : "Delete meeting"
+            }
+            aria-label="Delete meeting"
+          >
+            <TrashGlyph />
+          </button>
         </div>
         <Show when={props.meeting.failureReason}>
           {(reason) => (

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Uses meeting services and store; components never call Tauri IPC directly.
 
 import { createMemo, createSignal, For, onMount, Show } from "solid-js";
+import { ConfirmDialog } from "@/components/catalog/ConfirmDialog";
 import { MeetingDetail } from "@/components/meeting/MeetingDetail";
 import { MeetingSettings } from "@/components/meeting/MeetingSettings";
 import {
@@ -11,7 +12,7 @@ import {
   STATUS_LABELS,
 } from "@/lib/meeting-format";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
-import { createMeeting } from "@/services/meetings";
+import { createMeeting, type Meeting } from "@/services/meetings";
 import { meetingStore } from "@/stores/meeting.store";
 import { settingsStore } from "@/stores/settings.store";
 
@@ -55,6 +56,8 @@ export function MeetingPanel(props: MeetingPanelProps) {
   const [stopping, setStopping] = createSignal(false);
   const [title, setTitle] = createSignal("");
   const [showSettings, setShowSettings] = createSignal(false);
+  const [pendingDelete, setPendingDelete] = createSignal<Meeting | null>(null);
+  const [deleting, setDeleting] = createSignal(false);
 
   // The capture lifecycle (event listeners, auto-detect, widget/tray relays)
   // lives in AppShell so it survives this panel unmounting on close. The panel
@@ -72,6 +75,12 @@ export function MeetingPanel(props: MeetingPanelProps) {
   const activeMeeting = () => meetingStore.state.activeMeeting;
   const template = () => settingsStore.get("meetingTemplateId");
   const desktopRuntime = isTauriRuntime();
+  const deleteConfirmationMessage = () => {
+    const meeting = pendingDelete();
+    return meeting
+      ? `Delete "${meetingTitle(meeting)}"? Notes and transcript segments will be permanently removed.`
+      : "";
+  };
 
   // Create the meeting, then hand off to the store's gate. The store decides
   // whether to start immediately or surface the app-wide priming dialog, so
@@ -104,6 +113,20 @@ export function MeetingPanel(props: MeetingPanelProps) {
       meetingStore.resetAutoDetectDismissal();
     } finally {
       setStopping(false);
+    }
+  };
+
+  const deleteSelectedMeeting = async () => {
+    const meeting = pendingDelete();
+    if (!meeting || deleting()) return;
+    setDeleting(true);
+    try {
+      await meetingStore.deleteMeeting(meeting);
+      if (!meetingStore.state.error) {
+        setPendingDelete(null);
+      }
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -303,11 +326,28 @@ export function MeetingPanel(props: MeetingPanelProps) {
                 </div>
               }
             >
-              {(meeting) => <MeetingDetail meeting={meeting()} />}
+              {(meeting) => (
+                <MeetingDetail
+                  meeting={meeting()}
+                  onRequestDelete={(target) => setPendingDelete(target)}
+                />
+              )}
             </Show>
           </main>
         </div>
       </Show>
+      <ConfirmDialog
+        open={pendingDelete() !== null}
+        title="Delete meeting"
+        message={deleteConfirmationMessage()}
+        confirmLabel="Delete"
+        destructive
+        pending={deleting()}
+        onConfirm={() => void deleteSelectedMeeting()}
+        onCancel={() => {
+          if (!deleting()) setPendingDelete(null);
+        }}
+      />
     </section>
   );
 }

--- a/src/components/meeting/RecordPrompt.tsx
+++ b/src/components/meeting/RecordPrompt.tsx
@@ -6,6 +6,8 @@ interface RecordPromptProps {
   onRecord: () => void;
   /** Dismiss; won't re-nag for the same running app this session. */
   onDismiss: () => void;
+  /** Best-effort app label from the native audio activity probe. */
+  sourceApp?: string | null;
 }
 
 function MicGlyph() {
@@ -25,9 +27,11 @@ function MicGlyph() {
 }
 
 export function RecordPrompt(props: RecordPromptProps) {
+  const appLabel = () => props.sourceApp?.trim() || "Voice app";
+
   return (
     <div
-      class="flex h-8 w-[clamp(280px,42vw,430px)] min-w-0 items-center gap-2 rounded-md border border-accent/55 bg-primary-muted px-2 shadow-[0_0_0_1px_rgba(56,189,248,0.12),0_8px_24px_rgba(0,0,0,0.32)] backdrop-blur-sm animate-[fadeIn_200ms_ease]"
+      class="flex h-9 w-[clamp(300px,42vw,440px)] min-w-0 items-center gap-2 rounded-lg border border-accent/55 bg-popover px-2 shadow-[0_0_0_1px_rgba(56,189,248,0.12),0_8px_24px_rgba(0,0,0,0.32)] backdrop-blur-sm animate-[fadeIn_200ms_ease]"
       aria-label="Record detected conversation"
     >
       <span class="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent text-accent-foreground">
@@ -36,23 +40,23 @@ export function RecordPrompt(props: RecordPromptProps) {
       </span>
       <div class="flex min-w-0 flex-1 flex-col leading-tight">
         <span class="truncate text-[12px] font-medium text-foreground">
-          Record this conversation?
+          Call detected
         </span>
         <span class="truncate text-[10px] text-muted-foreground">
-          Active input detected. Capture transcript and notes.
+          {appLabel()}
         </span>
       </div>
       <div class="flex shrink-0 items-center gap-1">
         <button
           type="button"
-          class="h-6 rounded-md border border-accent bg-accent px-2 text-[11px] font-medium text-accent-foreground transition-colors hover:bg-primary-hover"
+          class="h-7 rounded-md border border-accent bg-accent px-2.5 text-[11px] font-medium text-accent-foreground transition-colors hover:bg-primary-hover"
           onClick={() => props.onRecord()}
         >
-          Record
+          Take notes
         </button>
         <button
           type="button"
-          class="h-6 rounded-md px-2 text-[11px] text-muted-foreground transition-colors hover:bg-accent/15 hover:text-foreground"
+          class="h-7 rounded-md px-2 text-[11px] text-muted-foreground transition-colors hover:bg-accent/15 hover:text-foreground"
           onClick={() => props.onDismiss()}
         >
           Not now

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -85,6 +85,10 @@ export function listMeetings(limit = 50): Promise<Meeting[]> {
   return invoke("list_meetings", { limit });
 }
 
+export function deleteMeeting(id: string): Promise<void> {
+  return invoke("delete_meeting", { id });
+}
+
 export function updateMeetingStatus(
   id: string,
   status: MeetingStatus,
@@ -255,6 +259,11 @@ export function listMeetingTemplates(): Promise<MeetingTemplate[]> {
  * Probe whether meeting capture should arm. Native side requires active input
  * activity; process presence alone is not enough.
  */
-export function meetingAutodetect(): Promise<boolean> {
+export interface MeetingAutodetectResult {
+  detected: boolean;
+  sourceApp: string | null;
+}
+
+export function meetingAutodetect(): Promise<MeetingAutodetectResult> {
   return invoke("meeting_autodetect");
 }

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -13,6 +13,7 @@ import {
 import {
   type CaptureStopOutcome,
   createMeeting,
+  deleteMeeting as deleteMeetingRecord,
   generateMeetingNotes,
   getMeetingTranscriptText,
   getTranscriptSegments,
@@ -49,6 +50,7 @@ interface MeetingState {
    * capturing. The titlebar surfaces an arm prompt; the user starts.
    */
   autoDetectSuggested: boolean;
+  autoDetectSourceApp: string | null;
   /**
    * The meeting awaiting first-run audio priming. Set when a start is requested
    * before the user has acknowledged the permission explainer; the app-wide
@@ -66,6 +68,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   isLoading: false,
   error: null,
   autoDetectSuggested: false,
+  autoDetectSourceApp: null,
   primingRequest: null,
 });
 
@@ -168,6 +171,7 @@ async function loadMeetings(): Promise<void> {
   setMeetingState("error", null);
   if (!isTauriRuntime()) {
     setMeetingState("meetings", []);
+    setMeetingState("autoDetectSourceApp", null);
     setMeetingState("isLoading", false);
     return;
   }
@@ -682,6 +686,35 @@ function clearError(): void {
   setMeetingState("error", null);
 }
 
+async function deleteMeeting(meeting: Meeting): Promise<void> {
+  if (!isTauriRuntime()) return;
+  setMeetingState("error", null);
+  if (
+    meeting.status === "pending_capture" ||
+    meeting.status === "capturing" ||
+    meeting.status === "transcribing" ||
+    meeting.status === "agent_running"
+  ) {
+    setMeetingState("error", "Stop or finish this meeting before deleting it.");
+    return;
+  }
+  try {
+    await deleteMeetingRecord(meeting.id);
+    const remaining = meetingState.meetings.filter(
+      (item) => item.id !== meeting.id,
+    );
+    setMeetingState("meetings", remaining);
+    if (meetingState.activeMeeting?.id === meeting.id) {
+      await setActiveMeeting(remaining[0] ?? null);
+    }
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Failed to delete meeting",
+    );
+  }
+}
+
 function isCapturing(ignoreMeetingId?: string): boolean {
   return meetingState.meetings.some(
     (meeting) =>
@@ -697,20 +730,24 @@ async function pollAutoDetect(): Promise<void> {
   if (!isTauriRuntime()) return;
   if (!settingsStore.get("meetingAutoDetectEnabled")) {
     setMeetingState("autoDetectSuggested", false);
+    setMeetingState("autoDetectSourceApp", null);
     return;
   }
   if (isCapturing()) {
     setMeetingState("autoDetectSuggested", false);
+    setMeetingState("autoDetectSourceApp", null);
     return;
   }
 
   try {
-    const detected = await meetingAutodetect();
-    if (!detected) {
+    const detection = await meetingAutodetect();
+    if (!detection.detected) {
       autoDetectDismissed = false;
       setMeetingState("autoDetectSuggested", false);
+      setMeetingState("autoDetectSourceApp", null);
       return;
     }
+    setMeetingState("autoDetectSourceApp", detection.sourceApp);
     setMeetingState("autoDetectSuggested", !autoDetectDismissed);
   } catch {
     // Probe failures are non-fatal; leave the prompt as-is.
@@ -739,10 +776,11 @@ function stopAutoDetect(): void {
 async function acceptAutoDetect(): Promise<void> {
   if (!isTauriRuntime()) return;
   if (isStarting || meetingState.primingRequest) return;
+  const sourceApp = meetingState.autoDetectSourceApp;
   dismissAutoDetect();
   const meeting = await createMeeting({
     title: `Meeting ${formatTime(Date.now())}`,
-    sourceApp: "Auto-detect",
+    sourceApp: meetingState.autoDetectSourceApp ?? sourceApp ?? "Auto-detect",
     templateId: settingsStore.get("meetingTemplateId"),
   });
   await requestCaptureStart(meeting);
@@ -776,6 +814,7 @@ export const meetingStore = {
   stopCapture,
   stopAndProcess,
   regenerateNotes,
+  deleteMeeting,
   clearError,
   startAutoDetect,
   stopAutoDetect,

--- a/tests/unit/meeting-autodetect-dismiss-reset.test.ts
+++ b/tests/unit/meeting-autodetect-dismiss-reset.test.ts
@@ -4,7 +4,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const m = vi.hoisted(() => ({
-  meetingAutodetect: vi.fn(async () => false),
+  meetingAutodetect: vi.fn(async () => ({
+    detected: false,
+    sourceApp: null,
+  })),
   listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
 }));
 
@@ -50,22 +53,34 @@ describe("meeting auto-detect dismissal reset (#2209)", () => {
   });
 
   it("re-arms the record prompt after the previously dismissed call app disappears", async () => {
-    m.meetingAutodetect.mockResolvedValueOnce(true);
+    m.meetingAutodetect.mockResolvedValueOnce({
+      detected: true,
+      sourceApp: "Discord",
+    });
     meetingStore.startAutoDetect();
     await Promise.resolve();
 
     expect(meetingStore.state.autoDetectSuggested).toBe(true);
+    expect(meetingStore.state.autoDetectSourceApp).toBe("Discord");
     meetingStore.dismissAutoDetect();
     expect(meetingStore.state.autoDetectSuggested).toBe(false);
 
-    m.meetingAutodetect.mockResolvedValueOnce(false);
+    m.meetingAutodetect.mockResolvedValueOnce({
+      detected: false,
+      sourceApp: null,
+    });
     await vi.advanceTimersByTimeAsync(5_000);
     expect(meetingStore.state.autoDetectSuggested).toBe(false);
+    expect(meetingStore.state.autoDetectSourceApp).toBeNull();
 
-    m.meetingAutodetect.mockResolvedValueOnce(true);
+    m.meetingAutodetect.mockResolvedValueOnce({
+      detected: true,
+      sourceApp: "Zoom",
+    });
     await vi.advanceTimersByTimeAsync(5_000);
 
     expect(m.meetingAutodetect).toHaveBeenCalledTimes(3);
     expect(meetingStore.state.autoDetectSuggested).toBe(true);
+    expect(meetingStore.state.autoDetectSourceApp).toBe("Zoom");
   });
 });

--- a/tests/unit/meeting-autodetect-settings-copy.test.ts
+++ b/tests/unit/meeting-autodetect-settings-copy.test.ts
@@ -26,8 +26,10 @@ describe("meeting auto-detect settings (#2215)", () => {
     expect(settingsSource).not.toContain("Add a meeting app");
     expect(settingsStoreSource).not.toContain("meetingAppAllowlist");
     expect(meetingStoreSource).not.toContain("meetingAppAllowlist");
-    expect(serviceSource).toContain("meetingAutodetect(): Promise<boolean>");
-    expect(nativeCommandSource).toContain("pub fn meeting_autodetect() -> bool");
+    expect(serviceSource).toContain("MeetingAutodetectResult");
+    expect(nativeCommandSource).toContain(
+      "pub fn meeting_autodetect() -> MeetingAutodetectResult",
+    );
     expect(detectionSource).toContain(
       "pub fn should_start_capture(activity: AudioActivity) -> bool",
     );

--- a/tests/unit/meeting-ui-regressions.test.ts
+++ b/tests/unit/meeting-ui-regressions.test.ts
@@ -56,4 +56,54 @@ describe("Meeting capture widget behavior (#2228)", () => {
     expect(widget).toContain("tick();");
     expect(widget).toContain('data-tauri-drag-region');
   });
+
+  it("renders as a compact widget instead of a screen-sized floating panel (#2231)", () => {
+    const widget = source("src/components/meeting/CaptureWidget.tsx");
+
+    expect(widget).not.toContain("h-screen w-screen");
+    expect(widget).toContain("h-full w-full");
+    expect(widget).toContain("overflow-hidden");
+  });
+});
+
+describe("Meeting auto-detect consent prompt (#2231)", () => {
+  it("surfaces the detected app name while keeping capture consent-first", () => {
+    const prompt = source("src/components/meeting/RecordPrompt.tsx");
+    const appShell = source("src/components/layout/AppShell.tsx");
+    const store = source("src/stores/meeting.store.ts");
+    const service = source("src/services/meetings.ts");
+    const nativeCommand = source("src-tauri/src/commands/audio.rs");
+
+    expect(prompt).toContain("sourceApp");
+    expect(prompt).toContain("Call detected");
+    expect(prompt).toContain("Take notes");
+    expect(prompt).not.toContain("Active input detected");
+    expect(appShell).toContain("recordPromptSourceApp");
+    expect(store).toContain("autoDetectSourceApp");
+    expect(store).toContain("sourceApp: meetingState.autoDetectSourceApp");
+    expect(service).toContain("MeetingAutodetectResult");
+    expect(nativeCommand).toContain("MeetingAutodetectResult");
+  });
+});
+
+describe("Meeting delete affordance (#2231)", () => {
+  it("wires confirmed deletion through the UI, store, service, and native command", () => {
+    const panel = source("src/components/meeting/MeetingPanel.tsx");
+    const detail = source("src/components/meeting/MeetingDetail.tsx");
+    const store = source("src/stores/meeting.store.ts");
+    const service = source("src/services/meetings.ts");
+    const nativeCommand = source("src-tauri/src/commands/audio.rs");
+    const lib = source("src-tauri/src/lib.rs");
+
+    expect(panel).toContain("ConfirmDialog");
+    expect(panel).toContain("pendingDelete");
+    expect(panel).toContain("deleteSelectedMeeting");
+    expect(detail).toContain("onRequestDelete");
+    expect(detail).toContain("Delete meeting");
+    expect(store).toContain("deleteMeeting");
+    expect(service).toContain('invoke("delete_meeting"');
+    expect(nativeCommand).toContain("pub async fn delete_meeting");
+    expect(nativeCommand).toContain("delete_meeting_record");
+    expect(lib).toContain("commands::audio::delete_meeting");
+  });
 });


### PR DESCRIPTION
## Summary

Closes #2231.

- Keep the floating capture widget bounded to its compact webview and add a fallback elapsed timer while meeting status loads.
- Return app-aware Meeting Mode auto-detect metadata and show a Granola-style `Call detected` prompt with the detected app when available.
- Add confirmed meeting deletion across UI, frontend store/service, Tauri command registration, and SQLite transcript cleanup.

## Verification

- `pnpm test`
- `pnpm test tests/unit/meeting-autodetect-dismiss-reset.test.ts tests/unit/meeting-autodetect-settings-copy.test.ts tests/unit/meeting-ui-regressions.test.ts`
- `pnpm exec biome check src/components/meeting/CaptureWidget.tsx src/components/meeting/RecordPrompt.tsx src/components/meeting/MeetingDetail.tsx src/components/meeting/MeetingPanel.tsx src/components/layout/Titlebar.tsx src/components/layout/AppShell.tsx src/stores/meeting.store.ts src/services/meetings.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib audio::detect::tests`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib commands::audio::tests::delete_meeting_record_removes_notes_and_transcript_segments`
- `git diff --check`

## Note

`pnpm exec tsc --noEmit` currently fails on an unrelated existing missing declaration for `../../bin/browser-local/logging.mjs` in `tests/unit/provider-runtime-log-prefix.test.ts`.
