### PR TITLE
fix(windows): drain Seren children before update (#2230)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,9 @@ jobs:
             echo ""
             echo "## Note"
             echo ""
-            echo "This is an alpha release. Windows builds are EV code signed. macOS builds are signed; if notarization is still processing, run: \`xattr -cr /Volumes/SerenDesktop/SerenDesktop.app\`"
+            echo "This is an alpha release. macOS builds are signed; if notarization is still processing, run: \`xattr -cr /Volumes/SerenDesktop/SerenDesktop.app\`"
+            echo ""
+            echo "<!-- WINDOWS_SIGNING_NOTE -->"
           } > release_notes.md
 
           echo "Generated release notes:"
@@ -277,6 +279,21 @@ jobs:
             . \
             seren-desktop-publishers \
             seren-desktop-mcp
+
+      # Windows: gate v* tag releases on signing being available.
+      # Without this, a misconfigured secret causes us to ship an unsigned
+      # Windows binary that Smart App Control immediately blocks (#2230 audit
+      # P1 "Release workflow can claim EV signing even when Windows signing
+      # is skipped"). For tag pushes that ARE production releases, refuse to
+      # proceed rather than ship unsigned.
+      - name: Require Windows signing for tag releases
+        if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/v') && env.HAS_WINDOWS_SIGNING != 'true'
+        shell: bash
+        run: |
+          echo "::error::Windows signing secrets (ES_USERNAME et al.) are not configured."
+          echo "::error::Refusing to publish an unsigned Windows artifact for ${GITHUB_REF}."
+          echo "::error::Either configure SSL.com eSigner secrets or push a non-v* tag for unsigned dev builds."
+          exit 1
 
       # macOS: Import certificates and setup keychain (skip if no certificate)
       - name: Import macOS certificates
@@ -621,27 +638,83 @@ jobs:
             Remove-Item -Path $tempDir -Force
           }
 
-      # Verify Windows code signing
-      - name: Verify Windows code signing
+      # Verify Windows code signing on the NSIS setup .exe AND every shipped
+      # .exe inside the installed app payload. The prior check only validated
+      # the outer setup .exe, which left bundled Seren.exe + sidecars unsigned
+      # in the install payload and triggered Smart App Control blocks on
+      # users' machines (#2230 audit P0/P1 #1).
+      - name: Verify Windows code signing (NSIS setup .exe)
+        id: verify_windows_setup
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
         shell: pwsh
         run: |
-          Write-Host "Verifying code signatures..."
-
-          # Verify NSIS installer
+          Write-Host "Verifying NSIS setup .exe signatures..."
           $nsisFiles = Get-ChildItem -Path "src-tauri/target/${{ matrix.target }}/release/bundle/nsis" -Filter "*.exe"
+          if ($nsisFiles.Count -eq 0) {
+            Write-Host "::error::No NSIS .exe files found to verify"
+            exit 1
+          }
           foreach ($file in $nsisFiles) {
             Write-Host "Checking signature for: $($file.FullName)"
             $sig = Get-AuthenticodeSignature -FilePath $file.FullName
             if ($sig.Status -eq "Valid") {
-              Write-Host "✓ Valid signature: $($sig.SignerCertificate.Subject)"
+              Write-Host "  Valid signature: $($sig.SignerCertificate.Subject)"
             } else {
-              Write-Host "✗ Invalid or missing signature: $($sig.Status)"
+              Write-Host "::error::Invalid or missing signature on $($file.FullName): $($sig.Status)"
               exit 1
             }
           }
+          Write-Host "NSIS setup .exe is properly signed."
 
-          Write-Host "NSIS installer is properly signed!"
+      # Recursive Authenticode check over the Tauri-produced app bundle
+      # (Seren.exe + any shipped .exe/.dll). Reports unsigned files but is
+      # non-blocking pending follow-up: full embedded-runtime signing (Git for
+      # Windows binaries, bundled node.exe, sidecars) is tracked separately
+      # because it needs CI-side staging-dir batch signing not in this PR.
+      # The report lets us see the actual exposure surface for SmartScreen
+      # reputation building.
+      - name: Audit Windows payload signature coverage (non-blocking)
+        id: audit_windows_payload
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $bundleRoot = "src-tauri/target/${{ matrix.target }}/release/bundle"
+          $unsignedFiles = @()
+          $validFiles = @()
+          Get-ChildItem -Path $bundleRoot -Recurse -Include "*.exe","*.dll" -File | ForEach-Object {
+            $sig = Get-AuthenticodeSignature -FilePath $_.FullName
+            if ($sig.Status -eq "Valid") {
+              $validFiles += $_.FullName
+            } else {
+              $unsignedFiles += [PSCustomObject]@{
+                Path = $_.FullName.Substring($bundleRoot.Length).TrimStart("/\")
+                Status = $sig.Status.ToString()
+              }
+            }
+          }
+          Write-Host "Signed files in bundle: $($validFiles.Count)"
+          Write-Host "Unsigned/invalid files in bundle: $($unsignedFiles.Count)"
+          if ($unsignedFiles.Count -gt 0) {
+            Write-Host "::warning::Unsigned files in Windows payload (follow-up #2230 embedded-runtime signing):"
+            $unsignedFiles | Format-Table -AutoSize | Out-String | Write-Host
+          }
+
+      # Scan the Tauri-generated NSI / NSH output for unresolved ${...}
+      # placeholders. #2230 showed "${product_name} is running" rendering
+      # literally in the installer UI, which means a template variable
+      # leaked through unsubstituted. Fail the build if any are found so
+      # this regression cannot ship to users again.
+      - name: Scan NSIS template for unresolved placeholders
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $nsiRoot = "src-tauri/target/${{ matrix.target }}/release/nsis"
+          if (-not (Test-Path $nsiRoot)) {
+            Write-Host "No generated NSIS template directory at $nsiRoot — skipping scan"
+            exit 0
+          }
+          node scripts/scan-nsis-placeholders.mjs $nsiRoot
 
       # Upload artifacts
       - name: Upload Windows NSIS
@@ -849,6 +922,40 @@ jobs:
             if (publishTarget.id !== uploadTarget.id) {
               console.log(`Canonical release changed from ${uploadTarget.id} to ${publishTarget.id}; syncing artifacts to the latest canonical release`);
               await syncArtifactsToRelease(publishTarget);
+            }
+
+            // Resolve the Windows-signed claim against actual artifact
+            // presence. The build job's `Require Windows signing for tag
+            // releases` step refuses to publish unsigned for v* tags, and
+            // the `Verify Windows code signing (NSIS setup .exe)` step
+            // fails the build on signature mismatch. So if a Windows setup
+            // .exe lands here for a v* tag, signing succeeded. For other
+            // tag formats (dev builds), don't claim signing happened.
+            //
+            // #2230 audit item I: prior workflow unconditionally claimed
+            // "Windows builds are EV code signed" in release notes even when
+            // the unsigned build path produced the artifact.
+            const isProductionTag = tagName.startsWith('v');
+            const hasWindowsArtifact = fs.existsSync(artifactsDir)
+              && fs.readdirSync(artifactsDir).some((entry) => {
+                const dir = path.join(artifactsDir, entry);
+                if (!fs.statSync(dir).isDirectory()) return false;
+                return fs.readdirSync(dir).some((f) => f.endsWith('-setup.exe'));
+              });
+            const windowsSignedClaim = isProductionTag && hasWindowsArtifact
+              ? 'Windows builds are EV code signed. If you still see a SmartScreen warning, click "More info" → "Run anyway"; reputation builds with installs.'
+              : 'Windows artifacts in this release are NOT EV code signed.';
+            const noteMarker = '<!-- WINDOWS_SIGNING_NOTE -->';
+            if (publishTarget.body && publishTarget.body.includes(noteMarker)) {
+              const updatedBody = publishTarget.body.replace(noteMarker, windowsSignedClaim);
+              console.log(`Resolving Windows signing note: tag=${tagName} hasWindowsArtifact=${hasWindowsArtifact}`);
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: publishTarget.id,
+                body: updatedBody,
+              });
+              publishTarget.body = updatedBody;
             }
 
             if (publishTarget.draft) {

--- a/scripts/scan-nsis-placeholders.mjs
+++ b/scripts/scan-nsis-placeholders.mjs
@@ -1,0 +1,93 @@
+// ABOUTME: CI guard that scans generated NSIS template output for unresolved ${...} placeholders.
+// ABOUTME: Catches regressions like #2230 where "${product_name} is running" rendered literally to users.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+
+// Names that legitimately appear unresolved in template SOURCE files (.nsi
+// shipped by tauri-bundler that uses ${VAR} as substitution placeholders).
+// These are only allowed when the file is a pristine source template; if
+// they appear in the OUTPUT, that's the bug. We scan the build output
+// directory, not the source template, so this allowlist stays empty.
+const ALLOWED_UNRESOLVED = new Set([]);
+
+// NSIS itself uses ${SYMBOL} for !define expansion. The TEMPLATE has many of
+// these intentionally — `${BUILD_DIR}`, `${ARCH}`, `${INSTALLERICON}`, etc.
+// We're hunting for ones that should have been substituted by the BUNDLER
+// before emitting the NSI to disk: things named like {{handlebars}} or
+// snake_case_token. Tauri's substitution uses both `{{}}` and `${}` syntaxes
+// historically. The screenshot in #2230 showed literal `${product_name}` —
+// lowercase with underscores. That's the shape we treat as suspicious.
+const SUSPECT_PATTERN = /\$\{[a-z][a-z0-9_]*\}/g;
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (entry.isFile() && /\.(nsi|nsh)$/i.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function scan(file) {
+  const text = readFileSync(file, "utf8");
+  const findings = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trimStart().startsWith(";")) continue;
+    for (const match of line.matchAll(SUSPECT_PATTERN)) {
+      const token = match[0];
+      if (ALLOWED_UNRESOLVED.has(token)) continue;
+      findings.push({ line: i + 1, token, context: line.trim() });
+    }
+  }
+  return findings;
+}
+
+const rootArg = process.argv[2];
+if (!rootArg) {
+  console.error("Usage: scan-nsis-placeholders.mjs <generated-nsis-dir>");
+  process.exit(2);
+}
+
+try {
+  statSync(rootArg);
+} catch {
+  console.error(`Path not found: ${rootArg}`);
+  process.exit(2);
+}
+
+const files = walk(rootArg);
+if (files.length === 0) {
+  console.log(`No .nsi/.nsh files under ${rootArg}; nothing to scan.`);
+  process.exit(0);
+}
+
+let totalFindings = 0;
+for (const file of files) {
+  const findings = scan(file);
+  if (findings.length === 0) continue;
+  totalFindings += findings.length;
+  console.log(`\nUnresolved placeholders in ${file}:`);
+  for (const f of findings) {
+    console.log(`  line ${f.line}: ${f.token}`);
+    console.log(`    ${f.context}`);
+  }
+}
+
+if (totalFindings > 0) {
+  console.error(
+    `\nFAIL: ${totalFindings} unresolved \${lowercase_token} placeholder(s) in generated NSIS output.`,
+  );
+  console.error(
+    "This is the regression from #2230 — Tauri's NSI template variable did not substitute, so users see the literal placeholder text in the installer UI.",
+  );
+  process.exit(1);
+}
+
+console.log(`OK: scanned ${files.length} NSIS file(s), no unresolved placeholders.`);

--- a/src-tauri/nsis/installer-hooks.nsh
+++ b/src-tauri/nsis/installer-hooks.nsh
@@ -1,28 +1,75 @@
 ; ABOUTME: NSIS installer hooks for Seren Desktop.
-; ABOUTME: Kills running Seren and orphaned embedded-runtime processes to prevent file-lock errors.
+; ABOUTME: Path-scoped cleanup of Seren-owned processes — never kills user's unrelated node.exe.
+
+; Defensive define: if Tauri's generated NSI template references
+; ${PRODUCT_NAME} or ${product_name} without first defining the symbol
+; (#2230 screenshot showed the literal placeholder in the "App is running"
+; prompt), provide a fallback so the installer UI shows a real string. NSIS
+; !ifndef is a no-op when the symbol is already defined upstream, so this
+; is safe to land regardless of which Tauri version emits the template.
+!ifndef PRODUCT_NAME
+  !define PRODUCT_NAME "SerenDesktop"
+!endif
+!ifndef product_name
+  !define product_name "${PRODUCT_NAME}"
+!endif
 
 !macro NSIS_HOOK_PREINSTALL
-  ; Kill Seren main process and its child process tree
+  ; Primary cleanup is the signed in-app updater path
+  ; (commands::updater::updater_pre_install). This NSIS hook is a fallback
+  ; for: first-time installs over a crashed prior version, sideloaded
+  ; installer runs that bypass the in-app updater, and cases where Smart
+  ; App Control blocked the in-app path.
+  ;
+  ; The hook is intentionally CONSERVATIVE: it must NEVER kill the user's
+  ; unrelated node.exe. The prior nuclear `taskkill /F /IM node.exe`
+  ; destroyed running editors, build watchers, and dev servers across
+  ; entire Windows boxes (#2230 audit item C).
+
+  ; 1. Kill Seren.exe by image name. Safe — no other vendor ships an
+  ;    executable called Seren.exe. /T flattens the process tree, which
+  ;    catches every provider-runtime / MCP / claude CLI child spawned
+  ;    by the running app.
   nsExec::ExecToStack 'taskkill /F /IM "Seren.exe" /T'
   Pop $0
   Pop $1
-  ; Brief pause for child processes to exit
   Sleep 1500
 
-  ; Kill ALL node.exe processes. This is the nuclear option but the only
-  ; reliable approach through NSIS:
+  ; 2. Path-scoped sweep for ORPHANED node.exe children whose parent died
+  ;    but who still hold an executable mapping on the bundled node.exe.
+  ;    Without this, an old install whose Seren.exe crashed without
+  ;    cleaning up its tree blocks the file-replace step.
   ;
-  ; - PowerShell $_ variables get eaten by NSIS's own $ interpolation
-  ; - wmic + cmd /c for /f has nested quoting issues inside nsExec
-  ; - The user is actively installing — killing node.exe is expected
+  ;    PowerShell is dropped to %TEMP% as a .ps1 file so we don't fight
+  ;    NSIS's $-interpolation rules inside a long inline -Command (the
+  ;    prior author tried inline and reverted; see git history). Each
+  ;    NSIS-source $$ emits one literal $ so $_, $env, and $installRoot
+  ;    reach PowerShell intact.
   ;
-  ; This catches: embedded provider-runtime, playwright MCP server,
-  ; claude CLI, and any other orphaned node.exe holding file locks.
-  nsExec::ExecToStack 'taskkill /F /IM "node.exe" /T'
+  ;    Filter by ExecutablePath under %LOCALAPPDATA%\SerenDesktop\
+  ;    embedded-runtime\**. The user's system node.exe at C:\Program
+  ;    Files\nodejs\node.exe cannot match.
+  FileOpen $9 "$TEMP\seren-preinstall-cleanup.ps1" w
+  FileWrite $9 'try {$\r$\n'
+  FileWrite $9 '  $$installRoot = Join-Path -Path $$env:LOCALAPPDATA -ChildPath "SerenDesktop\embedded-runtime"$\r$\n'
+  FileWrite $9 '  Get-CimInstance Win32_Process -ErrorAction Stop |$\r$\n'
+  FileWrite $9 '    Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$installRoot, [System.StringComparison]::OrdinalIgnoreCase) } |$\r$\n'
+  FileWrite $9 '    ForEach-Object { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }$\r$\n'
+  FileWrite $9 '} catch {}$\r$\n'
+  FileClose $9
+
+  ; -ExecutionPolicy Bypass restricts the looser policy to this invocation
+  ; only; it does not persist after PowerShell exits. The try/catch in the
+  ; script swallows failures so a locked-down system cannot fail the
+  ; installer — Seren.exe was already killed above.
+  nsExec::ExecToStack 'powershell.exe -ExecutionPolicy Bypass -NonInteractive -WindowStyle Hidden -File "$TEMP\seren-preinstall-cleanup.ps1"'
   Pop $0
   Pop $1
+  Delete "$TEMP\seren-preinstall-cleanup.ps1"
 
-  ; Allow OS to release file handles after process termination.
-  ; 3 seconds — Windows can take longer than Linux to release locks.
+  ; Allow the kernel to flush file handles after TerminateProcess. Windows
+  ; can take longer than Linux to release locks, especially under Defender
+  ; real-time scanning. The in-app pre-install path polls for release
+  ; explicitly; here we just sleep.
   Sleep 3000
 !macroend

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1,0 +1,207 @@
+// ABOUTME: Pre-install shutdown command invoked by the in-app updater before downloadAndInstall.
+// ABOUTME: Drains Seren-owned child processes, blocks new spawns, and waits for Windows file handles to release.
+
+use serde::Serialize;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Manager, State};
+
+use crate::{mcp, provider_runtime, terminal};
+
+/// Global flag set by `updater_pre_install` and cleared only by relaunch.
+/// While set, spawn-side commands must reject new child processes so the
+/// install window stays drained. Cleared on process exit when the new build
+/// boots fresh.
+#[derive(Default)]
+pub struct ShutdownGuard {
+    locked: AtomicBool,
+}
+
+impl ShutdownGuard {
+    pub fn engage(&self) {
+        self.locked.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_engaged(&self) -> bool {
+        self.locked.load(Ordering::Acquire)
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreInstallReport {
+    pub mcp_drained: bool,
+    pub terminals_drained: bool,
+    pub provider_runtime_drained: bool,
+    pub claude_memory_drained: bool,
+    pub handle_released: bool,
+    pub locked_node_path: Option<String>,
+    pub elapsed_ms: u128,
+}
+
+/// Drain every Seren-owned child process tree and wait until the bundled
+/// `node.exe` file handle is writeable. Must be called by the frontend
+/// updater BEFORE `pendingUpdate.downloadAndInstall()` runs, so the NSIS
+/// installer never sees a locked embedded-runtime payload.
+///
+/// Returns a report so the renderer can surface a precise failure to the
+/// user if any drain phase didn't complete.
+#[tauri::command]
+pub async fn updater_pre_install(
+    app: AppHandle,
+    guard: State<'_, Arc<ShutdownGuard>>,
+) -> Result<PreInstallReport, String> {
+    let start = Instant::now();
+
+    // Engage the guard FIRST so any in-flight spawn races see it and abort.
+    guard.engage();
+
+    log::info!("[Updater] Pre-install shutdown engaged");
+
+    // Stop the claude-memory file watcher. It spawns no children itself but
+    // holds a notify watcher handle on the user's `~/.claude/projects` tree,
+    // which is unrelated to install but cheap to drain for a clean restart.
+    let claude_memory_drained = tokio::task::spawn_blocking(crate::claude_memory::stop_watcher)
+        .await
+        .map(|res| res.is_ok())
+        .unwrap_or(false);
+
+    // Drain MCP stdio children. These spawn `node.exe` from the bundled
+    // runtime; the children frequently keep file locks on `node.exe`
+    // (Windows holds the executable mapping open until the last reference
+    // exits).
+    let mcp_drained = if let Some(state) = app.try_state::<mcp::McpState>() {
+        state.kill_all();
+        true
+    } else {
+        false
+    };
+
+    // Drain interactive terminal PTYs. On Windows ConPTY, dropping the
+    // master does not reliably terminate the shell tree — the existing
+    // `kill_all` does `taskkill /F /T` to flatten the tree.
+    let terminals_drained = if let Some(state) = app.try_state::<terminal::TerminalState>() {
+        state.kill_all();
+        true
+    } else {
+        false
+    };
+
+    // Drain the provider runtime supervisor. This is the largest holder of
+    // the embedded `node.exe` handle.
+    let provider_runtime_drained =
+        if let Some(state) = app.try_state::<provider_runtime::ProviderRuntimeState>() {
+            state.kill_sync();
+            true
+        } else {
+            false
+        };
+
+    // Allow the kernel to flush handles after taskkill. Windows can take
+    // several seconds, especially with Defender real-time scanning enabled.
+    // We don't block on the full timeout if the handle is already releaseable.
+    let (handle_released, locked_node_path) = wait_for_node_handle_release(&app).await;
+
+    let report = PreInstallReport {
+        mcp_drained,
+        terminals_drained,
+        provider_runtime_drained,
+        claude_memory_drained,
+        handle_released,
+        locked_node_path,
+        elapsed_ms: start.elapsed().as_millis(),
+    };
+
+    log::info!("[Updater] Pre-install shutdown report: {:?}", report);
+
+    if !handle_released {
+        // Don't fail — the renderer will warn the user and let them retry
+        // or proceed. Returning an error here would block the install for
+        // platforms (Linux/macOS) where this check is a no-op.
+        log::warn!(
+            "[Updater] Embedded node handle still locked after drain: {:?}",
+            report.locked_node_path
+        );
+    }
+
+    Ok(report)
+}
+
+/// Poll the bundled `node.exe` file with FILE_GENERIC_WRITE access until the
+/// kernel releases the handle or the deadline expires. On non-Windows targets
+/// this is a no-op that immediately returns `(true, None)` — the issue is
+/// Windows-specific (#2230).
+async fn wait_for_node_handle_release(app: &AppHandle) -> (bool, Option<String>) {
+    let node_path = bundled_node_path(app);
+    let Some(path) = node_path else {
+        return (true, None);
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = path;
+        return (true, None);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        const MAX_WAIT: Duration = Duration::from_secs(15);
+        const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+        let path_str = path.to_string_lossy().to_string();
+        let deadline = Instant::now() + MAX_WAIT;
+
+        loop {
+            if can_open_for_write(&path) {
+                return (true, None);
+            }
+            if Instant::now() >= deadline {
+                return (false, Some(path_str));
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn can_open_for_write(path: &std::path::Path) -> bool {
+    // OpenOptions::write(true) maps to GENERIC_WRITE on Windows, which the
+    // kernel rejects with ERROR_SHARING_VIOLATION if any process still has
+    // the executable image mapped. This is exactly the condition NSIS hits
+    // when it tries to overwrite node.exe — we mirror it here so we know
+    // we can safely hand control to the installer.
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create(false)
+        .open(path)
+        .is_ok()
+}
+
+fn bundled_node_path(app: &AppHandle) -> Option<PathBuf> {
+    let paths = crate::embedded_runtime::discover_embedded_runtime(app);
+    let node_dir = paths.node_dir?;
+    let candidate = if cfg!(target_os = "windows") {
+        node_dir.join("node.exe")
+    } else {
+        node_dir.join("node")
+    };
+    candidate.exists().then_some(candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shutdown_guard_engages_atomically() {
+        let guard = ShutdownGuard::default();
+        assert!(!guard.is_engaged());
+        guard.engage();
+        assert!(guard.is_engaged());
+        // Engaging twice is idempotent.
+        guard.engage();
+        assert!(guard.is_engaged());
+    }
+}

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -5,7 +5,9 @@ use serde::Serialize;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+#[cfg(target_os = "windows")]
+use std::time::Duration;
+use std::time::Instant;
 use tauri::{AppHandle, Manager, State};
 
 use crate::{mcp, provider_runtime, terminal};
@@ -22,6 +24,10 @@ pub struct ShutdownGuard {
 impl ShutdownGuard {
     pub fn engage(&self) {
         self.locked.store(true, Ordering::SeqCst);
+    }
+
+    pub fn release(&self) {
+        self.locked.store(false, Ordering::SeqCst);
     }
 
     pub fn is_engaged(&self) -> bool {
@@ -129,6 +135,19 @@ pub async fn updater_pre_install(
     Ok(report)
 }
 
+/// Release the shutdown guard so provider runtime / MCP can spawn again.
+/// Called from the renderer when downloadAndInstall fails — without this
+/// the user is left unable to use the app until they manually restart
+/// (#2230 functional audit).
+#[tauri::command]
+pub async fn updater_pre_install_release(
+    guard: State<'_, Arc<ShutdownGuard>>,
+) -> Result<(), String> {
+    guard.release();
+    log::info!("[Updater] Pre-install shutdown released (install failed or cancelled)");
+    Ok(())
+}
+
 /// Poll the bundled `node.exe` file with FILE_GENERIC_WRITE access until the
 /// kernel releases the handle or the deadline expires. On non-Windows targets
 /// this is a no-op that immediately returns `(true, None)` — the issue is
@@ -201,6 +220,21 @@ mod tests {
         guard.engage();
         assert!(guard.is_engaged());
         // Engaging twice is idempotent.
+        guard.engage();
+        assert!(guard.is_engaged());
+    }
+
+    #[test]
+    fn shutdown_guard_releases_on_install_failure() {
+        // After a failed update, the renderer must be able to disengage the
+        // guard so the user is not locked out of provider runtime / MCP
+        // until they restart the app.
+        let guard = ShutdownGuard::default();
+        guard.engage();
+        assert!(guard.is_engaged());
+        guard.release();
+        assert!(!guard.is_engaged());
+        // Re-engaging after release works (a second update attempt).
         guard.engage();
         assert!(guard.is_engaged());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -896,6 +896,7 @@ pub fn run() {
             provider_runtime::provider_runtime_get_config,
             provider_runtime::provider_runtime_stop,
             commands::updater::updater_pre_install,
+            commands::updater::updater_pre_install_release,
             // CLI installer commands
             commands::cli_installer::check_cli_installed,
             commands::cli_installer::install_cli_tool,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub mod commands {
     pub mod orchestrator;
     pub mod provider_runtime;
     pub mod session;
+    pub mod updater;
     pub mod web;
 }
 
@@ -519,6 +520,9 @@ pub fn run() {
         .manage(orchestrator::eval::EvalState::new())
         .manage(orchestrator::tool_bridge::ToolResultBridge::new())
         .manage(provider_runtime::ProviderRuntimeState::new())
+        .manage(std::sync::Arc::new(
+            commands::updater::ShutdownGuard::default(),
+        ))
         .manage(services::database::WalCheckpointTask::default())
         .manage(messaging::MessagingState::new())
         .manage(std::sync::Arc::new(tokio::sync::Mutex::new(None))
@@ -891,6 +895,7 @@ pub fn run() {
             embedded_runtime::get_embedded_runtime_info,
             provider_runtime::provider_runtime_get_config,
             provider_runtime::provider_runtime_stop,
+            commands::updater::updater_pre_install,
             // CLI installer commands
             commands::cli_installer::check_cli_installed,
             commands::cli_installer::install_cli_tool,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -448,12 +448,27 @@ fn collect_process_diagnostics(process: &mut McpProcess, base_error: &str) -> St
 /// Connect to an MCP server
 #[tauri::command]
 pub async fn mcp_connect(
+    app: tauri::AppHandle,
     state: State<'_, McpState>,
     server_name: String,
     command: String,
     args: Vec<String>,
     env: Option<HashMap<String, String>>,
 ) -> Result<McpInitializeResult, String> {
+    // Same rationale as provider_runtime_get_config: once the updater has
+    // engaged the shutdown guard, refuse to spawn new stdio MCP children so
+    // they can't re-lock the bundled node.exe between the pre-install drain
+    // and the NSIS file-replace step (#2230).
+    if let Some(guard) = app.try_state::<std::sync::Arc<crate::commands::updater::ShutdownGuard>>()
+    {
+        if guard.is_engaged() {
+            return Err(format!(
+                "Update in progress — MCP connect for '{}' refused",
+                server_name
+            ));
+        }
+    }
+
     // Resolve bare command names (e.g. "node") to absolute paths using the embedded PATH.
     // The parent process PATH may be minimal when launched from Finder/Dock on macOS,
     // so we cannot rely on the OS to find commands that live in /opt/homebrew/bin etc.

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -507,6 +507,16 @@ pub async fn provider_runtime_get_config(
     app: AppHandle,
     state: State<'_, ProviderRuntimeState>,
 ) -> Result<ProviderRuntimeConfig, String> {
+    // Once the updater has engaged the shutdown guard, refuse to spawn a new
+    // node child. The orchestrator can race the install window otherwise and
+    // re-lock the bundled node.exe between pre-install shutdown and the NSIS
+    // file-replace step (#2230).
+    if let Some(guard) = app.try_state::<std::sync::Arc<crate::commands::updater::ShutdownGuard>>()
+    {
+        if guard.is_engaged() {
+            return Err("Update in progress — provider runtime spawn refused".to_string());
+        }
+    }
     state.ensure_started(&app).await
 }
 

--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { message } from "@tauri-apps/plugin-dialog";
 import { relaunch } from "@tauri-apps/plugin-process";
@@ -175,6 +176,57 @@ async function acknowledgeAutoInstall(
   }
 }
 
+interface PreInstallReport {
+  mcpDrained: boolean;
+  terminalsDrained: boolean;
+  providerRuntimeDrained: boolean;
+  claudeMemoryDrained: boolean;
+  handleReleased: boolean;
+  lockedNodePath: string | null;
+  elapsedMs: number;
+}
+
+/** Drain Seren-owned child processes before handing control to the NSIS
+ *  installer / macOS updater. Failure to drain on Windows is the root cause
+ *  of #2230's "Error opening file for writing: node.exe" — a stale bundled
+ *  node.exe child keeps the executable mapped and the installer cannot
+ *  overwrite it. The native command also engages a shutdown guard so any
+ *  orchestrator run that fires DURING the download (which can take minutes)
+ *  cannot re-spawn the runtime mid-install.
+ *
+ *  On macOS / Linux this is a defensive call — handle locking is not the
+ *  issue, but draining MCP/terminal children before the updater swaps the
+ *  .app bundle keeps the post-relaunch state clean. */
+async function preInstallShutdown(): Promise<PreInstallReport | null> {
+  if (!isTauriRuntime()) return null;
+  try {
+    const report = await invoke<PreInstallReport>("updater_pre_install");
+    verboseRuntimeConsole.debug("[Updater] Pre-install drain report:", report);
+    if (!report.handleReleased) {
+      // Log but continue — the install may still succeed if the lock clears
+      // before NSIS reaches the file-replace step. Surfacing as an error
+      // here would block users whose runtime drained correctly but where
+      // the handle-release poll timed out under heavy Defender scanning.
+      console.warn(
+        "[Updater] Bundled node handle did not release during pre-install drain:",
+        report.lockedNodePath,
+      );
+      telemetry.captureError(
+        new Error(
+          `Updater pre-install handle lock: ${report.lockedNodePath ?? "unknown"}`,
+        ),
+        { type: "updater", phase: "pre_install_handle_lock" },
+      );
+    }
+    return report;
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.warn("[Updater] Pre-install shutdown failed:", err.message);
+    telemetry.captureError(err, { type: "updater", phase: "pre_install" });
+    return null;
+  }
+}
+
 async function installAvailableUpdate(): Promise<void> {
   if (!isTauriRuntime()) {
     console.warn("[Updater] Install skipped: not Tauri runtime");
@@ -198,6 +250,13 @@ async function installAvailableUpdate(): Promise<void> {
     totalBytes: 0,
     progressPercent: 0,
   });
+
+  // Drain Seren-owned children BEFORE the download begins so the shutdown
+  // guard stays engaged for the full download+install window. Otherwise the
+  // orchestrator can spawn fresh node.exe processes during the multi-minute
+  // download and re-lock the bundled runtime by the time NSIS reaches the
+  // file-replace step (#2230).
+  await preInstallShutdown();
 
   try {
     await pendingUpdate.downloadAndInstall((progress: DownloadEvent) => {

--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -293,6 +293,25 @@ async function installAvailableUpdate(): Promise<void> {
     console.error("[Updater] Install failed:", err.message);
     telemetry.captureError(err, { type: "updater", phase: "install" });
     setState({ status: "error", error: err.message });
+    // Release the native shutdown guard so the user can keep using the app
+    // without restarting. Without this, provider runtime / MCP spawns stay
+    // blocked until manual restart, which is bad UX after a failed update.
+    if (isTauriRuntime()) {
+      try {
+        await invoke("updater_pre_install_release");
+      } catch (releaseError) {
+        // Best-effort — if release fails, the next successful update or app
+        // restart will clear the guard.
+        const releaseErr =
+          releaseError instanceof Error
+            ? releaseError
+            : new Error(String(releaseError));
+        console.warn(
+          "[Updater] Failed to release pre-install guard after install failure:",
+          releaseErr.message,
+        );
+      }
+    }
   }
 }
 

--- a/tests/unit/scan-nsis-placeholders.test.ts
+++ b/tests/unit/scan-nsis-placeholders.test.ts
@@ -1,0 +1,83 @@
+// ABOUTME: Tests for the CI guard that catches unresolved NSIS placeholders.
+// ABOUTME: Pins the #2230 regression shape — literal ${lowercase_token} leaking into installer UI.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const SCRIPT = join(process.cwd(), "scripts/scan-nsis-placeholders.mjs");
+
+function runScanner(dir: string) {
+  return spawnSync("node", [SCRIPT, dir], { encoding: "utf8" });
+}
+
+describe("scan-nsis-placeholders", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "nsis-scan-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("fails when an unresolved ${product_name} placeholder appears (#2230)", () => {
+    writeFileSync(
+      join(tmp, "installer.nsi"),
+      [
+        "; Generated NSI fragment",
+        'MessageBox MB_OK "${product_name} is running! Click OK to kill it"',
+        "",
+      ].join("\n"),
+    );
+
+    const result = runScanner(tmp);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("${product_name}");
+    expect(result.stderr).toContain("FAIL");
+  });
+
+  it("passes when only uppercase NSIS symbols are present", () => {
+    // ${INSTDIR}, ${BUILD_DIR}, ${MUI_PRODUCT} etc. are legitimate NSIS
+    // !define expansions. Only lowercase-with-underscores tokens match the
+    // bundler-substitution shape we're hunting for.
+    writeFileSync(
+      join(tmp, "installer.nsi"),
+      [
+        'OutFile "${BUILD_DIR}\\setup.exe"',
+        "InstallDir ${INSTDIR}",
+        "!define MUI_PRODUCT ${PRODUCT_NAME}",
+      ].join("\n"),
+    );
+
+    const result = runScanner(tmp);
+
+    expect(result.status).toBe(0);
+  });
+
+  it("ignores commented-out placeholder mentions", () => {
+    writeFileSync(
+      join(tmp, "installer.nsi"),
+      [
+        "; This template used to leak ${product_name} into the dialog",
+        '!define PRODUCT_NAME "SerenDesktop"',
+      ].join("\n"),
+    );
+
+    const result = runScanner(tmp);
+
+    expect(result.status).toBe(0);
+  });
+
+  it("returns 0 with no .nsi files present", () => {
+    writeFileSync(join(tmp, "README.txt"), "not nsi");
+
+    const result = runScanner(tmp);
+
+    expect(result.status).toBe(0);
+  });
+});

--- a/tests/unit/updater-store.test.ts
+++ b/tests/unit/updater-store.test.ts
@@ -10,6 +10,7 @@ const {
   relaunchMock,
   clearAllBrowsingDataMock,
   captureErrorMock,
+  invokeMock,
 } = vi.hoisted(() => ({
   mockStoreState: {} as Record<string, unknown>,
   isTauriRuntimeMock: vi.fn<() => boolean>(),
@@ -17,6 +18,7 @@ const {
   relaunchMock: vi.fn(),
   clearAllBrowsingDataMock: vi.fn(),
   captureErrorMock: vi.fn(),
+  invokeMock: vi.fn(),
 }));
 
 vi.mock("solid-js/store", () => ({
@@ -31,6 +33,10 @@ vi.mock("solid-js/store", () => ({
 
 vi.mock("@/lib/tauri-bridge", () => ({
   isTauriRuntime: isTauriRuntimeMock,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
 }));
 
 vi.mock("@tauri-apps/plugin-updater", () => ({
@@ -62,6 +68,16 @@ describe("updaterStore install flow", () => {
     relaunchMock.mockReset();
     clearAllBrowsingDataMock.mockReset();
     captureErrorMock.mockReset();
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue({
+      mcpDrained: true,
+      terminalsDrained: true,
+      providerRuntimeDrained: true,
+      claudeMemoryDrained: true,
+      handleReleased: true,
+      lockedNodePath: null,
+      elapsedMs: 10,
+    });
     // Vitest sets import.meta.env.DEV=true; the prod-only code paths under
     // test would otherwise short-circuit through isDevRuntime().
     vi.stubEnv("DEV", false);
@@ -123,6 +139,98 @@ describe("updaterStore install flow", () => {
 
     expect(downloadAndInstallMock).not.toHaveBeenCalled();
     expect(relaunchMock).not.toHaveBeenCalled();
+  });
+
+  it("drains Seren-owned children before downloadAndInstall (#2230)", async () => {
+    // The bundled node.exe is held open by the provider runtime / MCP
+    // children. If we let downloadAndInstall run without draining first,
+    // the NSIS file-replace step on Windows fails with "Error opening file
+    // for writing: node.exe". Pin the call order so a future refactor that
+    // moves the drain after download can't ship without failing this test.
+    isTauriRuntimeMock.mockReturnValue(true);
+    const downloadAndInstallMock = vi.fn(async () => {});
+    checkMock.mockResolvedValue({
+      version: "1.3.53",
+      downloadAndInstall: downloadAndInstallMock,
+    });
+    clearAllBrowsingDataMock.mockResolvedValue(undefined);
+    relaunchMock.mockResolvedValue(undefined);
+
+    const { updaterStore } = await import("@/stores/updater.store");
+
+    await updaterStore.checkForUpdates();
+    await updaterStore.installAvailableUpdate();
+
+    expect(invokeMock).toHaveBeenCalledWith("updater_pre_install");
+    expect(downloadAndInstallMock).toHaveBeenCalledOnce();
+    expect(invokeMock.mock.invocationCallOrder[0]).toBeLessThan(
+      downloadAndInstallMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("continues install when pre-install handle release times out", async () => {
+    // The pre-install command can succeed at draining but still report the
+    // bundled node handle as locked under heavy Defender scanning. We log
+    // and continue rather than block the install — the actual file-replace
+    // may still succeed if the kernel flushes the handle by the time NSIS
+    // gets there.
+    isTauriRuntimeMock.mockReturnValue(true);
+    invokeMock.mockResolvedValue({
+      mcpDrained: true,
+      terminalsDrained: true,
+      providerRuntimeDrained: true,
+      claudeMemoryDrained: true,
+      handleReleased: false,
+      lockedNodePath: "C:\\Users\\u\\AppData\\Local\\SerenDesktop\\embedded-runtime\\win32-x64\\node\\node.exe",
+      elapsedMs: 15000,
+    });
+    const downloadAndInstallMock = vi.fn(async () => {});
+    checkMock.mockResolvedValue({
+      version: "1.3.53",
+      downloadAndInstall: downloadAndInstallMock,
+    });
+    clearAllBrowsingDataMock.mockResolvedValue(undefined);
+    relaunchMock.mockResolvedValue(undefined);
+
+    const { updaterStore } = await import("@/stores/updater.store");
+
+    await updaterStore.checkForUpdates();
+    await updaterStore.installAvailableUpdate();
+
+    expect(downloadAndInstallMock).toHaveBeenCalledOnce();
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("pre-install handle lock"),
+      }),
+      { type: "updater", phase: "pre_install_handle_lock" },
+    );
+  });
+
+  it("continues install when pre-install command itself fails", async () => {
+    // The pre-install command can fail (e.g. permission, IPC race). The
+    // updater must not block — the in-app drain is defense in depth on top
+    // of the installer-side NSIS hook. Failing here would strand users on
+    // broken builds with no path forward.
+    isTauriRuntimeMock.mockReturnValue(true);
+    invokeMock.mockRejectedValue(new Error("ipc unavailable"));
+    const downloadAndInstallMock = vi.fn(async () => {});
+    checkMock.mockResolvedValue({
+      version: "1.3.53",
+      downloadAndInstall: downloadAndInstallMock,
+    });
+    clearAllBrowsingDataMock.mockResolvedValue(undefined);
+    relaunchMock.mockResolvedValue(undefined);
+
+    const { updaterStore } = await import("@/stores/updater.store");
+
+    await updaterStore.checkForUpdates();
+    await updaterStore.installAvailableUpdate();
+
+    expect(downloadAndInstallMock).toHaveBeenCalledOnce();
+    expect(captureErrorMock).toHaveBeenCalledWith(expect.any(Error), {
+      type: "updater",
+      phase: "pre_install",
+    });
   });
 
   it("still relaunches if browsing-data clearing fails", async () => {

--- a/tests/unit/updater-store.test.ts
+++ b/tests/unit/updater-store.test.ts
@@ -233,6 +233,34 @@ describe("updaterStore install flow", () => {
     });
   });
 
+  it("releases the shutdown guard when downloadAndInstall fails (#2230)", async () => {
+    // Without releasing, the user is locked out of provider runtime / MCP
+    // until they manually restart — terrible UX after a transient download
+    // failure. This test pins the failure-path cleanup.
+    isTauriRuntimeMock.mockReturnValue(true);
+    const downloadAndInstallMock = vi.fn(async () => {
+      throw new Error("network drop mid-download");
+    });
+    checkMock.mockResolvedValue({
+      version: "1.3.53",
+      downloadAndInstall: downloadAndInstallMock,
+    });
+
+    const { updaterStore } = await import("@/stores/updater.store");
+
+    await updaterStore.checkForUpdates();
+    await updaterStore.installAvailableUpdate();
+
+    expect(downloadAndInstallMock).toHaveBeenCalledOnce();
+    // The first invoke is updater_pre_install (engage), the second after
+    // failure is updater_pre_install_release.
+    const releaseCall = invokeMock.mock.calls.find(
+      (call) => call[0] === "updater_pre_install_release",
+    );
+    expect(releaseCall).toBeDefined();
+    expect(mockStoreState.status).toBe("error");
+  });
+
   it("still relaunches if browsing-data clearing fails", async () => {
     isTauriRuntimeMock.mockReturnValue(true);
     const downloadAndInstallMock = vi.fn(async () => {});


### PR DESCRIPTION
## Summary

Fixes the Windows install/update file-lock errors and SmartScreen-block notifications reported in #2230.

The bundled `node.exe` was being held open by provider-runtime / MCP / claude CLI children so NSIS could not overwrite `embedded-runtime\win32-x64\node\node.exe`, and the prior NSIS hook killed *every* `node.exe` on the machine as a workaround — destroying the user's unrelated editors and dev servers.

**What changes**

- **`updater_pre_install` Tauri command** drains MCP, terminal PTY, provider runtime, and claude-memory watcher, then polls the bundled `node.exe` with `FILE_GENERIC_WRITE` until the kernel releases the handle. Renderer calls it BEFORE `downloadAndInstall()` so the drain covers the multi-minute download window. `ShutdownGuard` refuses new provider-runtime / MCP spawns once engaged, so in-flight orchestrator runs cannot re-lock the runtime mid-install.
- **`installer-hooks.nsh`** replaces nuclear `taskkill /IM node.exe` with a path-scoped PowerShell sweep filtered to `%LOCALAPPDATA%\SerenDesktop\embedded-runtime\**`. The user's system `node.exe` at `C:\Program Files\nodejs\node.exe` is untouched. Defensive `!define PRODUCT_NAME` so Tauri's NSI template cannot render the literal `${product_name} is running` prompt seen in the issue screenshots.
- **`release.yml`** gates v* tag publishes on `HAS_WINDOWS_SIGNING` (no more silent unsigned releases for production tags), resolves the EV-signed release-notes claim against actual artifact presence instead of unconditionally claiming it, and runs a recursive Authenticode audit over every shipped `.exe`/`.dll` so we can see the actual signing coverage.
- **`scripts/scan-nsis-placeholders.mjs`** CI guard fails the build if any lowercase `${token}` leaks through Tauri's NSI substitution again.

**What's deferred to follow-ups (filed separately)**

Embedded-runtime payload signing (Git for Windows binaries, bundled `node.exe`, sidecars) and `.nsis.zip` updater re-signing both need staging-dir batch signing that requires real Windows CI smoke testing. Those are tracked in separate tickets so this PR can ship the user-visible install-blocking fix immediately.

## Test plan

- [x] `cargo test commands::updater::tests::shutdown_guard_engages_atomically` — passes
- [x] `pnpm vitest run` — 1600/1600 pass, including 3 new pre-install drain ordering / failure-handling tests + 4 NSIS placeholder scanner tests
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean (only pre-existing warnings)
- [x] `pnpm dlx js-yaml .github/workflows/release.yml` — valid
- [x] Biome check on modified files — clean
- [ ] Smoke install on Windows 11 VM with Defender + Smart App Control enabled (manual — needs the existing AWS test box)
- [ ] In-app upgrade from v1.3.52 to v1.3.53 on Windows 11 — confirm no `node.exe` file-lock error
- [ ] Confirm release notes correctly omit/include the EV-signed line based on signing presence

Closes #2230 for the install-blocking surface; tracking follow-ups for embedded-runtime + updater payload signing.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
