### PR TITLE
Fix terminal browser-mode init

### DIFF
--- a/src/stores/terminal.store.ts
+++ b/src/stores/terminal.store.ts
@@ -4,6 +4,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createStore, produce } from "solid-js/store";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
 import { fileTreeState } from "@/stores/fileTree";
 
 export type TerminalStatus = "running" | "exited";
@@ -72,6 +73,7 @@ export const terminalStore = {
   async init() {
     if (state.initialized) return;
     setState("initialized", true);
+    if (!isTauriRuntime()) return;
 
     exitUnlisten = await listen<TerminalExitEvent>(
       "terminal://exit",

--- a/tests/unit/terminal-store-browser-guard.test.ts
+++ b/tests/unit/terminal-store-browser-guard.test.ts
@@ -1,0 +1,80 @@
+// ABOUTME: Regression test for #2238 — browser/dev startup must not call Tauri terminal event APIs.
+// ABOUTME: Keeps terminalStore.init safe for Vite/Playwright browser-mode smoke runs.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { isTauriRuntimeMock, invokeMock, listenMock, unlistenMock } = vi.hoisted(
+  () => ({
+    isTauriRuntimeMock: vi.fn<() => boolean>(),
+    invokeMock: vi.fn(),
+    listenMock: vi.fn(),
+    unlistenMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: isTauriRuntimeMock,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: listenMock,
+}));
+
+describe("terminalStore browser runtime guard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    isTauriRuntimeMock.mockReset();
+    invokeMock.mockReset();
+    listenMock.mockReset();
+    unlistenMock.mockReset();
+  });
+
+  it("marks initialized in browser mode without touching Tauri APIs", async () => {
+    isTauriRuntimeMock.mockReturnValue(false);
+    invokeMock.mockRejectedValue(new Error("browser mode must not invoke"));
+    listenMock.mockRejectedValue(new Error("browser mode must not listen"));
+
+    const { terminalStore } = await import("@/stores/terminal.store");
+
+    await expect(terminalStore.init()).resolves.toBeUndefined();
+
+    expect(terminalStore.buffers).toEqual([]);
+    expect(listenMock).not.toHaveBeenCalled();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("still binds terminal exit listener and loads buffers in Tauri", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    listenMock.mockResolvedValue(unlistenMock);
+    invokeMock.mockResolvedValue([
+      {
+        id: "terminal-1",
+        title: "Terminal",
+        cwd: "/tmp",
+        command: null,
+        cols: 100,
+        rows: 28,
+        status: "running",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+
+    const { terminalStore } = await import("@/stores/terminal.store");
+
+    await terminalStore.init();
+
+    expect(listenMock).toHaveBeenCalledWith(
+      "terminal://exit",
+      expect.any(Function),
+    );
+    expect(invokeMock).toHaveBeenCalledWith("terminal_list_buffers");
+    expect(terminalStore.buffers).toHaveLength(1);
+    terminalStore.dispose();
+    expect(unlistenMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary\n- guard terminalStore.init() outside Tauri so browser/dev startup does not call Tauri event APIs\n- add focused regression coverage for browser and Tauri init behavior\n\nCloses #2238\n\n## Verification\n- pnpm test tests/unit/terminal-store-browser-guard.test.ts\n- pnpm lint (exits 0; reports existing unrelated warnings in session/employees components)\n- browser smoke on http://127.0.0.1:1421/ confirmed Meeting panel renders and pageErrors=[], transformCallbackErrors=[]