### PR TITLE
ci(windows): pre-build EV-sign embedded-runtime payload (#2235)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,54 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
 
+      # Windows: stage + EV-sign the embedded runtime payload BEFORE `tauri build`
+      # so the signatures are baked into the NSIS installer AND the .nsis.zip
+      # updater bundle (#2235). The unsigned node.exe / Git-for-Windows binaries
+      # / Python DLLs / sidecars are what Smart App Control blocks once extracted
+      # to %LOCALAPPDATA%\SerenDesktop\embedded-runtime on the user's machine.
+      #
+      # We stage the runtime here, flatten every signable into one directory, run
+      # a single SSL.com batch_sign (its per-file TOTP throttle makes per-dir
+      # signing prohibitively slow), copy the signed files back, then build with
+      # SEREN_TAURI_SKIP_PREP so the build does not re-download and clobber them.
+      - name: Stage embedded runtime for signing (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        env:
+          CARGO_BUILD_TARGET: ${{ matrix.target }}
+        run: pnpm prepare:tauri-build
+
+      - name: Flatten embedded runtime signables (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          node scripts/flatten-windows-signables.mjs `
+            sign-staging/unsigned `
+            sign-staging/manifest.json `
+            src-tauri/embedded-runtime `
+            src-tauri/mcp-servers
+
+      - name: Batch-sign embedded runtime (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        uses: sslcom/esigner-codesign@v1.3.2
+        with:
+          command: batch_sign
+          username: ${{ secrets.ES_USERNAME }}
+          password: ${{ secrets.ES_PASSWORD }}
+          credential_id: ${{ secrets.ES_CREDENTIAL_ID }}
+          totp_secret: ${{ secrets.ES_TOTP_SECRET }}
+          dir_path: sign-staging/unsigned
+          output_path: sign-staging/signed
+          environment_name: PROD
+          malware_block: true
+
+      - name: Restore signed embedded runtime (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          node scripts/restore-windows-signables.mjs `
+            sign-staging/signed `
+            sign-staging/manifest.json
+
       # Build the app (with signing for macOS when certificates available)
       # Note: APPLE_ID/PASSWORD/TEAM_ID removed to prevent Tauri's internal notarization
       # Notarization is handled separately with polling in the "Notarize macOS app" step
@@ -339,6 +387,11 @@ jobs:
         run: pnpm tauri build --verbose --target ${{ matrix.target }} --bundles deb,appimage
       - name: Build Tauri app (unsigned, other)
         if: matrix.os != 'macos-latest' && !startsWith(matrix.os, 'ubuntu')
+        env:
+          # On the Windows signing path the embedded runtime was already staged
+          # and EV-signed above; skip re-preparation so the build does not
+          # overwrite the signed binaries with fresh unsigned downloads (#2235).
+          SEREN_TAURI_SKIP_PREP: ${{ (matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true') && '1' || '' }}
         run: pnpm tauri build --target ${{ matrix.target }}
       - name: Build Tauri app (unsigned, macOS without signing)
         if: matrix.os == 'macos-latest' && env.HAS_APPLE_SIGNING != 'true'
@@ -666,17 +719,16 @@ jobs:
           }
           Write-Host "NSIS setup .exe is properly signed."
 
-      # Recursive Authenticode check over the Tauri-produced app bundle
-      # (Seren.exe + any shipped .exe/.dll). Reports unsigned files but is
-      # non-blocking pending follow-up: full embedded-runtime signing (Git for
-      # Windows binaries, bundled node.exe, sidecars) is tracked separately
-      # because it needs CI-side staging-dir batch signing not in this PR.
-      # The report lets us see the actual exposure surface for SmartScreen
-      # reputation building.
-      - name: Audit Windows payload signature coverage (non-blocking)
+      # Recursive Authenticode check over every loose .exe/.dll the Tauri build
+      # emits under bundle/. Now that the embedded runtime is EV-signed pre-build
+      # (#2235), any unsigned/invalid file here is a real regression — a missed
+      # signing root or a signer that silently dropped a file — so this is a hard
+      # gate, not a warning. Deep verification of the binaries packed INSIDE the
+      # installer / updater archives is done by the extraction checks in #2236
+      # (.nsis.zip) and #2237 ($PLUGINSDIR helper DLLs).
+      - name: Audit Windows payload signature coverage
         id: audit_windows_payload
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
-        continue-on-error: true
         shell: pwsh
         run: |
           $bundleRoot = "src-tauri/target/${{ matrix.target }}/release/bundle"
@@ -696,9 +748,11 @@ jobs:
           Write-Host "Signed files in bundle: $($validFiles.Count)"
           Write-Host "Unsigned/invalid files in bundle: $($unsignedFiles.Count)"
           if ($unsignedFiles.Count -gt 0) {
-            Write-Host "::warning::Unsigned files in Windows payload (follow-up #2230 embedded-runtime signing):"
+            Write-Host "::error::Unsigned/invalid .exe/.dll in Windows payload after embedded-runtime signing (#2235):"
             $unsignedFiles | Format-Table -AutoSize | Out-String | Write-Host
+            exit 1
           }
+          Write-Host "All loose .exe/.dll in the Windows bundle are validly signed."
 
       # Scan the Tauri-generated NSI / NSH output for unresolved ${...}
       # placeholders. #2230 showed "${product_name} is running" rendering

--- a/build/prepare-tauri-build.ts
+++ b/build/prepare-tauri-build.ts
@@ -185,7 +185,26 @@ function runCommand(command: TauriPreparationCommand): void {
   }
 }
 
+// The Windows release path stages the embedded runtime, batch-signs it, then
+// runs `tauri build` — whose `beforeBuildCommand` would otherwise re-run this
+// preparation and overwrite the freshly signed binaries with fresh unsigned
+// downloads. The signing step sets SEREN_TAURI_SKIP_PREP so the second pass
+// reuses the already-staged, already-signed runtime.
+export function shouldSkipPreparation(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const flag = env.SEREN_TAURI_SKIP_PREP?.trim().toLowerCase();
+  return flag === "1" || flag === "true";
+}
+
 export function prepareTauriBuild(): void {
+  if (shouldSkipPreparation()) {
+    console.log(
+      "[prepare-tauri-build] SEREN_TAURI_SKIP_PREP set — runtime already staged and signed; skipping preparation.",
+    );
+    return;
+  }
+
   const target = resolveRuntimeTarget();
   console.log(
     `[prepare-tauri-build] Resolved Tauri runtime target: ${target.platform}-${target.arch}`,

--- a/scripts/flatten-windows-signables.mjs
+++ b/scripts/flatten-windows-signables.mjs
@@ -1,0 +1,72 @@
+// ABOUTME: Flattens every Authenticode-signable file under the given roots into one staging dir for a single batch-sign (#2235).
+// ABOUTME: SSL.com batch_sign is non-recursive and TOTP-throttled per file, so one flat dir + manifest beats per-directory signing.
+
+import { copyFileSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, join } from "node:path";
+import process from "node:process";
+
+// Extensions Windows Authenticode can sign and that Smart App Control evaluates
+// when loaded: native executables, libraries, Node addons, and Python extension
+// modules (.pyd are DLLs). Anything else (.cmd, .json, .txt, .py) is left alone.
+const SIGNABLE = new Set([".exe", ".dll", ".node", ".pyd"]);
+
+function walk(dir, out) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (entry.isFile() && SIGNABLE.has(extname(entry.name).toLowerCase())) {
+      out.push(full);
+    }
+  }
+}
+
+const [, , stagingDir, manifestPath, ...roots] = process.argv;
+
+if (!stagingDir || !manifestPath || roots.length === 0) {
+  console.error(
+    "Usage: flatten-windows-signables.mjs <staging-dir> <manifest-path> <root-dir>...",
+  );
+  process.exit(2);
+}
+
+const found = [];
+for (const root of roots) {
+  let isDir = false;
+  try {
+    isDir = statSync(root).isDirectory();
+  } catch {
+    isDir = false;
+  }
+  if (!isDir) {
+    console.warn(`[flatten] Skipping missing root: ${root}`);
+    continue;
+  }
+  walk(root, found);
+}
+
+// Sort for deterministic flat names across runs.
+found.sort();
+
+mkdirSync(stagingDir, { recursive: true });
+
+const manifest = [];
+found.forEach((original, index) => {
+  // Zero-padded index prefix keeps flat names unique even when basenames
+  // collide (Git for Windows ships many same-named DLLs). Original extension
+  // is preserved so the signer dispatches on file type correctly.
+  const flat = `${String(index + 1).padStart(5, "0")}__${basename(original)}`;
+  copyFileSync(original, join(stagingDir, flat));
+  manifest.push({ flat, original });
+});
+
+// The manifest is written OUTSIDE the staging dir so the staging dir holds only
+// signable binaries — SSL.com batch_sign signs every file in its input dir and
+// would choke on a non-PE manifest.json.
+mkdirSync(dirname(manifestPath), { recursive: true });
+writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+console.log(
+  `[flatten] Flattened ${manifest.length} signable file(s) to ${stagingDir} (manifest: ${manifestPath})`,
+);
+process.exit(0);

--- a/scripts/restore-windows-signables.mjs
+++ b/scripts/restore-windows-signables.mjs
@@ -1,0 +1,48 @@
+// ABOUTME: Copies batch-signed files from the staging output dir back to their original locations via the manifest (#2235).
+// ABOUTME: Fails loud and atomically if the signer dropped any file, so a half-signed payload can never ship (the #2223 shape).
+
+import { copyFileSync, existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+
+const [, , signedDir, manifestPath] = process.argv;
+
+if (!signedDir || !manifestPath) {
+  console.error("Usage: restore-windows-signables.mjs <signed-dir> <manifest.json>");
+  process.exit(2);
+}
+
+let manifest;
+try {
+  statSync(manifestPath);
+  manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+} catch (err) {
+  console.error(`[restore] Cannot read manifest ${manifestPath}: ${err instanceof Error ? err.message : err}`);
+  process.exit(2);
+}
+
+if (!Array.isArray(manifest)) {
+  console.error("[restore] Manifest is not an array.");
+  process.exit(2);
+}
+
+// Validate the full set first. The signer either covered everything or it
+// failed — never restore a partial set, or unsigned binaries reach users.
+const missing = manifest.filter((entry) => !existsSync(join(signedDir, entry.flat)));
+if (missing.length > 0) {
+  console.error(
+    `[restore] Signer did not produce ${missing.length} of ${manifest.length} expected file(s):`,
+  );
+  for (const entry of missing) {
+    console.error(`  missing: ${entry.flat}  (for ${entry.original})`);
+  }
+  console.error("[restore] Refusing to restore a partially-signed payload.");
+  process.exit(1);
+}
+
+for (const entry of manifest) {
+  copyFileSync(join(signedDir, entry.flat), entry.original);
+}
+
+console.log(`[restore] Restored ${manifest.length} signed file(s) to original locations.`);
+process.exit(0);

--- a/tests/unit/tauri-build-runtime-plan.test.ts
+++ b/tests/unit/tauri-build-runtime-plan.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildTauriPreparationCommands,
   resolveRuntimeTarget,
+  shouldSkipPreparation,
   spawnOptionsForPlatform,
 } from "../../build/prepare-tauri-build";
 
@@ -54,5 +55,14 @@ describe("Tauri build runtime preparation", () => {
     expect(spawnOptionsForPlatform("win32").shell).toBe(true);
     expect(spawnOptionsForPlatform("darwin").shell).toBe(false);
     expect(spawnOptionsForPlatform("linux").shell).toBe(false);
+  });
+
+  it("skips preparation when SEREN_TAURI_SKIP_PREP is set so the signed runtime survives pass two (#2235)", () => {
+    expect(shouldSkipPreparation({ SEREN_TAURI_SKIP_PREP: "1" })).toBe(true);
+    expect(shouldSkipPreparation({ SEREN_TAURI_SKIP_PREP: "true" })).toBe(true);
+    expect(shouldSkipPreparation({ SEREN_TAURI_SKIP_PREP: "TRUE" })).toBe(true);
+    expect(shouldSkipPreparation({ SEREN_TAURI_SKIP_PREP: "0" })).toBe(false);
+    expect(shouldSkipPreparation({ SEREN_TAURI_SKIP_PREP: "" })).toBe(false);
+    expect(shouldSkipPreparation({})).toBe(false);
   });
 });

--- a/tests/unit/windows-signables.test.ts
+++ b/tests/unit/windows-signables.test.ts
@@ -1,0 +1,239 @@
+// ABOUTME: Tests the flatten/restore CLI pair that batch-signs the Windows embedded-runtime payload (#2235).
+// ABOUTME: Pins collision-safe flattening, manifest round-trip, and the fail-loud gap when the signer drops a file.
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const FLATTEN = join(process.cwd(), "scripts/flatten-windows-signables.mjs");
+const RESTORE = join(process.cwd(), "scripts/restore-windows-signables.mjs");
+
+function run(script: string, args: string[]) {
+  return spawnSync("node", [script, ...args], { encoding: "utf8" });
+}
+
+function write(path: string, content = "x") {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+}
+
+interface ManifestEntry {
+  flat: string;
+  original: string;
+}
+
+describe("flatten-windows-signables", () => {
+  let tmp: string;
+  let staging: string;
+  let manifestPath: string;
+
+  function readManifest(): ManifestEntry[] {
+    return JSON.parse(readFileSync(manifestPath, "utf8"));
+  }
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "winsign-"));
+    staging = join(tmp, "staging");
+    manifestPath = join(tmp, "manifest.json");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("collects only Authenticode-signable extensions, ignoring data files", () => {
+    const root = join(tmp, "embedded-runtime");
+    write(join(root, "node", "node.exe"));
+    write(join(root, "git", "cmd", "git.exe"));
+    write(join(root, "git", "mingw64", "bin", "libcurl.dll"));
+    write(join(root, "python", "python313.dll"));
+    write(join(root, "python", "_ssl.pyd"));
+    write(join(root, "node", "npm.cmd")); // not signable
+    write(join(root, "embedded-runtime.json")); // not signable
+    write(join(root, "git", "README.txt")); // not signable
+
+    const result = run(FLATTEN, [staging, manifestPath, root]);
+
+    expect(result.status).toBe(0);
+    const manifest = readManifest();
+    const originals = manifest.map((e) => e.original).sort();
+    expect(originals).toEqual(
+      [
+        join(root, "git", "cmd", "git.exe"),
+        join(root, "git", "mingw64", "bin", "libcurl.dll"),
+        join(root, "node", "node.exe"),
+        join(root, "python", "_ssl.pyd"),
+        join(root, "python", "python313.dll"),
+      ].sort(),
+    );
+    // The signed dir holds ONLY binaries — the manifest lives outside it so the
+    // SSL.com batch signer never tries to sign a non-PE file.
+    const staged = readdirSync(staging);
+    expect(staged.length).toBe(5);
+    expect(staged).not.toContain("manifest.json");
+  });
+
+  it("gives colliding basenames distinct flat names and keeps them separable", () => {
+    const root = join(tmp, "runtime");
+    write(join(root, "mingw64", "bin", "zlib1.dll"), "A");
+    write(join(root, "usr", "bin", "zlib1.dll"), "B");
+
+    const result = run(FLATTEN, [staging, manifestPath, root]);
+
+    expect(result.status).toBe(0);
+    const manifest = readManifest();
+    expect(manifest.length).toBe(2);
+    // Flat names are unique even though basenames collide.
+    const flats = manifest.map((e) => e.flat);
+    expect(new Set(flats).size).toBe(2);
+    // Each flat file preserves its source bytes, so signing then restore is faithful.
+    for (const entry of manifest) {
+      const expected = readFileSync(entry.original, "utf8");
+      expect(readFileSync(join(staging, entry.flat), "utf8")).toBe(expected);
+    }
+  });
+
+  it("flat names preserve the original extension so the signer recognizes file type", () => {
+    const root = join(tmp, "runtime");
+    write(join(root, "node.exe"));
+    write(join(root, "a.dll"));
+    write(join(root, "b.node"));
+
+    run(FLATTEN, [staging, manifestPath, root]);
+
+    for (const entry of readManifest()) {
+      expect(entry.flat.endsWith(entry.original.slice(entry.original.lastIndexOf(".")))).toBe(true);
+    }
+  });
+
+  it("merges multiple roots into one staging dir", () => {
+    const r1 = join(tmp, "embedded-runtime");
+    const r2 = join(tmp, "mcp-servers");
+    write(join(r1, "node.exe"));
+    write(join(r2, "playwright", "chromium.node"));
+
+    const result = run(FLATTEN, [staging, manifestPath, r1, r2]);
+
+    expect(result.status).toBe(0);
+    expect(readManifest().length).toBe(2);
+  });
+
+  it("skips missing roots without failing (arch-specific dirs may be absent)", () => {
+    const present = join(tmp, "present");
+    write(join(present, "node.exe"));
+    const absent = join(tmp, "does-not-exist");
+
+    const result = run(FLATTEN, [staging, manifestPath, present, absent]);
+
+    expect(result.status).toBe(0);
+    expect(readManifest().length).toBe(1);
+  });
+
+  it("writes an empty manifest and exits 0 when no signables are found", () => {
+    const root = join(tmp, "runtime");
+    write(join(root, "readme.txt"));
+
+    const result = run(FLATTEN, [staging, manifestPath, root]);
+
+    expect(result.status).toBe(0);
+    expect(readManifest()).toEqual([]);
+  });
+
+  it("exits with a usage error when no roots are given", () => {
+    const result = run(FLATTEN, [staging, manifestPath]);
+    expect(result.status).toBe(2);
+  });
+});
+
+describe("restore-windows-signables", () => {
+  let tmp: string;
+  let staging: string;
+  let signed: string;
+  let manifestPath: string;
+
+  function readManifest(): ManifestEntry[] {
+    return JSON.parse(readFileSync(manifestPath, "utf8"));
+  }
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "winrestore-"));
+    staging = join(tmp, "staging");
+    signed = join(tmp, "signed");
+    manifestPath = join(tmp, "manifest.json");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("copies signed files back over the originals via the manifest", () => {
+    const root = join(tmp, "runtime");
+    write(join(root, "a", "node.exe"), "unsigned-node");
+    write(join(root, "b", "git.exe"), "unsigned-git");
+
+    run(FLATTEN, [staging, manifestPath, root]);
+    const manifest = readManifest();
+
+    // Simulate the signer: emit "signed" copies into the signed dir.
+    mkdirSync(signed, { recursive: true });
+    for (const entry of manifest) {
+      writeFileSync(join(signed, entry.flat), `signed:${entry.original}`);
+    }
+
+    const result = run(RESTORE, [signed, manifestPath]);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(join(root, "a", "node.exe"), "utf8")).toBe(
+      `signed:${join(root, "a", "node.exe")}`,
+    );
+    expect(readFileSync(join(root, "b", "git.exe"), "utf8")).toBe(
+      `signed:${join(root, "b", "git.exe")}`,
+    );
+  });
+
+  it("fails loud and names the gap when the signer dropped a file (#2223 silent-failure shape)", () => {
+    const root = join(tmp, "runtime");
+    write(join(root, "node.exe"));
+    write(join(root, "git.exe"));
+
+    run(FLATTEN, [staging, manifestPath, root]);
+    const manifest = readManifest();
+
+    // Signer only produced ONE of the two expected outputs.
+    mkdirSync(signed, { recursive: true });
+    writeFileSync(join(signed, manifest[0].flat), "signed");
+
+    const result = run(RESTORE, [signed, manifestPath]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(manifest[1].flat);
+    // Atomic: nothing is restored when the set is incomplete.
+    expect(readFileSync(manifest[0].original, "utf8")).toBe("x");
+  });
+
+  it("exits cleanly on an empty manifest (signing disabled / nothing to do)", () => {
+    mkdirSync(signed, { recursive: true });
+    const manifestPath = join(tmp, "manifest.json");
+    writeFileSync(manifestPath, "[]");
+
+    const result = run(RESTORE, [signed, manifestPath]);
+
+    expect(result.status).toBe(0);
+  });
+
+  it("exits with a usage error when the manifest is missing", () => {
+    mkdirSync(signed, { recursive: true });
+    const result = run(RESTORE, [signed, join(tmp, "nope.json")]);
+    expect(result.status).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2235 (follow-up to #2230 / #2234).

The bundled `node.exe`, Git-for-Windows binaries, Python DLLs, sidecars, and mcp-server `.node` addons shipped **unsigned** inside the NSIS installer and the `.nsis.zip` updater bundle. Smart App Control blocks those files once they're extracted to `%LOCALAPPDATA%\SerenDesktop\embedded-runtime`, producing "Microsoft cannot verify the publisher" prompts.

This signs the whole payload **before `tauri build`** so signatures are baked into both the installer payload and the updater archive automatically — exactly what the ticket asks for.

## What changed

- **`scripts/flatten-windows-signables.mjs`** — gathers every `.exe`/`.dll`/`.node`/`.pyd` under `embedded-runtime` + `mcp-servers` into one staging dir with a collision-safe, deterministic manifest (Git-for-Windows ships many same-named DLLs). One flat dir → **one** SSL.com `batch_sign` (its per-file TOTP throttle, called out in the ticket, makes per-directory signing prohibitively slow).
- **`scripts/restore-windows-signables.mjs`** — copies signed files back via the manifest; **fails loud + atomically** if the signer dropped any file (the silent-failure shape from #2223).
- **`build/prepare-tauri-build.ts`** — `SEREN_TAURI_SKIP_PREP` guard so the build's `beforeBuildCommand` preparation pass can't re-download and clobber the freshly signed binaries.
- **`.github/workflows/release.yml`** — Windows path: stage runtime → flatten → `batch_sign` → restore → build (prep-skipped). The bundle signature-coverage audit is **promoted from a warning to a hard gate**.

## Tests

- `tests/unit/windows-signables.test.ts` — 11 black-box tests (real temp dirs, no mocks): extension filtering, collision-safe flattening, manifest round-trip, multi-root, missing-root tolerance, empty payload, and the fail-loud/atomic restore gap.
- `tests/unit/tauri-build-runtime-plan.test.ts` — `shouldSkipPreparation` truth table.
- Full suite: **1616/1616 pass**. `release.yml` validates as YAML.

## What this PR does NOT do (layered into follow-ups)

Binaries packed *inside* the archives can't be checked without extraction. Deep verification is in **#2236** (extract `.nsis.zip`) and **#2237** (extract setup `.exe`, verify `$PLUGINSDIR` helper DLLs).

## Validation status

The SSL.com signing path only runs on a real Windows release tag (secrets + TOTP). Logic is unit-tested and YAML-validated locally; **end-to-end signing must be validated on a Windows CI release** — not exercised here. ⚠️ Watch release wall-clock: batch-signing the full Git-for-Windows tree is the dominant cost; if it exceeds the 45-min budget, switch Git to MinGit or move to an HSM `signtool` path (follow-up).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com