### PR TITLE
ci(windows): re-pack and verify .nsis.zip updater bundle (#2236)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -719,6 +719,87 @@ jobs:
           }
           Write-Host "NSIS setup .exe is properly signed."
 
+      # The .nsis.zip updater bundle is what pendingUpdate.downloadAndInstall()
+      # consumes — NOT the public setup .exe. Tauri builds the .nsis.zip during
+      # `tauri build`, zipping the setup .exe BEFORE our post-build EV signing
+      # runs, so the installer inside the bundle is unsigned even though the
+      # loose setup .exe got signed. Rebuild the bundle from the now-signed
+      # setup .exe and re-sign the .nsis.zip.sig with the Tauri updater key —
+      # mirrors the macOS .app.tar.gz re-pack/re-sign pattern above (#2236).
+      - name: Re-pack and re-sign .nsis.zip updater bundle (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          $nsisDir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis"
+          $zip = Get-ChildItem -Path $nsisDir -Filter "*.nsis.zip" | Select-Object -First 1
+          if (-not $zip) {
+            Write-Host "No .nsis.zip updater bundle found in $nsisDir — skipping re-pack."
+            exit 0
+          }
+          $setup = Get-ChildItem -Path $nsisDir -Filter "*-setup.exe" | Select-Object -First 1
+          if (-not $setup) {
+            Write-Host "::error::.nsis.zip present but no *-setup.exe to pack into it."
+            exit 1
+          }
+          # The setup .exe must already be EV-signed (verified in the step above).
+          $sig = Get-AuthenticodeSignature -FilePath $setup.FullName
+          if ($sig.Status -ne "Valid") {
+            Write-Host "::error::Refusing to pack an unsigned setup .exe into the updater bundle: $($sig.Status)"
+            exit 1
+          }
+          Write-Host "Re-packing $($zip.Name) from signed $($setup.Name)..."
+          Remove-Item -Path $zip.FullName -Force
+          Remove-Item -Path "$($zip.FullName).sig" -Force -ErrorAction SilentlyContinue
+          # Compress-Archive stores the file at the archive root by basename,
+          # matching the layout Tauri's updater expects.
+          Compress-Archive -Path $setup.FullName -DestinationPath $zip.FullName -CompressionLevel Optimal -Force
+          Write-Host "Re-signing $($zip.Name) with the Tauri updater key..."
+          pnpm tauri signer sign -k "$env:TAURI_SIGNING_PRIVATE_KEY" -p "$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD" $zip.FullName
+          if (-not (Test-Path "$($zip.FullName).sig")) {
+            Write-Host "::error::Updater signature not produced: $($zip.FullName).sig"
+            exit 1
+          }
+          Write-Host "Re-packed and re-signed the .nsis.zip updater bundle."
+
+      # Verify the re-packed updater bundle on the actual bytes the updater will
+      # deliver: extract it and confirm every .exe/.dll inside reports a Valid
+      # Authenticode signature. We have been bitten before by Tauri repacking
+      # artifacts and losing signatures, so this is a hard gate (#2236).
+      - name: Verify .nsis.zip updater bundle signatures (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          $nsisDir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis"
+          $zip = Get-ChildItem -Path $nsisDir -Filter "*.nsis.zip" | Select-Object -First 1
+          if (-not $zip) {
+            Write-Host "No .nsis.zip to verify — skipping."
+            exit 0
+          }
+          $extractDir = Join-Path $env:RUNNER_TEMP "nsis-zip-verify"
+          if (Test-Path $extractDir) { Remove-Item -Path $extractDir -Recurse -Force }
+          Expand-Archive -Path $zip.FullName -DestinationPath $extractDir -Force
+          $files = @(Get-ChildItem -Path $extractDir -Recurse -Include "*.exe","*.dll" -File)
+          if ($files.Count -eq 0) {
+            Write-Host "::error::.nsis.zip contained no .exe/.dll to verify — unexpected updater layout."
+            exit 1
+          }
+          $unsigned = @()
+          foreach ($f in $files) {
+            $sig = Get-AuthenticodeSignature -FilePath $f.FullName
+            if ($sig.Status -eq "Valid") {
+              Write-Host "  Valid: $($f.Name)"
+            } else {
+              $unsigned += "$($f.Name): $($sig.Status)"
+            }
+          }
+          if ($unsigned.Count -gt 0) {
+            Write-Host "::error::Unsigned/invalid binaries inside .nsis.zip updater bundle:"
+            $unsigned | ForEach-Object { Write-Host "    $_" }
+            exit 1
+          }
+          Write-Host "All binaries inside the .nsis.zip updater bundle are validly signed."
+          Remove-Item -Path $extractDir -Recurse -Force
+
       # Recursive Authenticode check over every loose .exe/.dll the Tauri build
       # emits under bundle/. Now that the embedded runtime is EV-signed pre-build
       # (#2235), any unsigned/invalid file here is a real regression — a missed


### PR DESCRIPTION
## Summary

Closes #2236 (follow-up to #2230 / #2234, builds on #2235).

The `.nsis.zip` is what `pendingUpdate.downloadAndInstall()` consumes — **not** the public setup `.exe`. Tauri builds the `.nsis.zip` *during* `tauri build`, zipping the setup `.exe` **before** our post-build EV signing runs. So the installer inside the updater bundle shipped **unsigned** even though the loose setup `.exe` got signed — and Smart App Control blocks the post-update binaries on Windows 11.

## What changed (`release.yml`, Windows path)

1. **Re-pack** — after the setup `.exe` is signed and verified, rebuild the `.nsis.zip` from the now-signed `.exe` and **re-sign `.nsis.zip.sig`** with the Tauri updater key. This mirrors the existing macOS `.app.tar.gz` re-pack/re-sign flow. Refuses to pack an unsigned `.exe` (defensive).
2. **Verify (hard gate)** — extract the re-packed `.nsis.zip` and fail the build unless every `.exe`/`.dll` inside reports a `Valid` Authenticode signature.

Ordering is correct: re-pack runs **before** the updater-bundle upload, so `latest.json` (built from the uploaded `.sig`) and the R2 artifacts embed the regenerated signature — no signature mismatch.

## Tests

No unit test: this is pure CI orchestration of `Compress-Archive` / `Expand-Archive` / `Get-AuthenticodeSignature` / `tauri signer`. A unit test would only assert mocked shell behavior, which CLAUDE.md forbids. Validated by YAML parse; end-to-end coverage comes from the Windows release run.

## Validation status

⚠️ The re-pack/re-sign + verify only execute on a Windows release tag (signing secrets + Tauri key). Verified locally as valid YAML and correct step ordering against the `latest.json`/R2 flow; the real check is the Windows release run.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com