### PR TITLE
chore(biome): ignore local worktrees (#2246)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,7 @@
       "**/.vscode/**/*",
       "**/index.html",
       "**/vite.config.ts",
+      "!**/.worktrees/**/*",
       "!**/src/api/generated/**/*",
       "!**/src-tauri/target/**/*"
     ]


### PR DESCRIPTION
## Summary

- excludes `.worktrees/**` from the root Biome file set
- keeps top-level `pnpm check` green when local Git worktrees contain their own `biome.json`

## Audit

Fixes #2246. This was found during the post-merge functional audit after #2244, where `pnpm check` failed because Biome traversed `.worktrees/ci-2236-nsis-zip-resign/biome.json` as a nested root config.

## Tests

- `pnpm check` with a temporary nested `.worktrees/repro-2246` checkout present