### PR TITLE
ci(windows): sign NSIS helper DLLs in tauri cache (#2237)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -620,6 +620,66 @@ jobs:
           echo "Files in $BUNDLE_DIR:"
           ls -la "$BUNDLE_DIR/"
 
+      # The NSIS helper DLLs (System.dll, nsExec.dll, nsDialogs.dll,
+      # nsis_tauri_utils.dll) ship inside the tauri-bundler NSIS cache and
+      # makensis compiles them INTO the setup .exe. At install they are
+      # extracted to %TEMP%\nsXXXX.tmp and loaded, so Smart App Control blocks
+      # them when unsigned regardless of the outer installer's signature
+      # (#2237 / #2230). The first `tauri build` above populated the cache; sign
+      # those DLLs in place, then rebuild so makensis embeds the signed copies.
+      # This is the fix we own — no upstream tauri dependency.
+      - name: Flatten NSIS helper DLLs for signing (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          $nsisCache = Join-Path $env:LOCALAPPDATA "tauri\NSIS"
+          if (-not (Test-Path $nsisCache)) {
+            Write-Host "::error::Tauri NSIS cache not found at $nsisCache after build — cannot sign helper DLLs (#2237)."
+            exit 1
+          }
+          $plugins = Join-Path $nsisCache "Plugins"
+          node scripts/flatten-windows-signables.mjs `
+            nsis-plugin-staging/unsigned `
+            nsis-plugin-staging/manifest.json `
+            $plugins
+          $count = @(Get-Content nsis-plugin-staging/manifest.json | ConvertFrom-Json).Count
+          if ($count -eq 0) {
+            Write-Host "::error::No NSIS plugin DLLs found under $plugins — nothing to sign (#2237)."
+            exit 1
+          }
+          Write-Host "Found $count NSIS helper DLL(s) to sign."
+
+      - name: Batch-sign NSIS helper DLLs (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        uses: sslcom/esigner-codesign@v1.3.2
+        with:
+          command: batch_sign
+          username: ${{ secrets.ES_USERNAME }}
+          password: ${{ secrets.ES_PASSWORD }}
+          credential_id: ${{ secrets.ES_CREDENTIAL_ID }}
+          totp_secret: ${{ secrets.ES_TOTP_SECRET }}
+          dir_path: nsis-plugin-staging/unsigned
+          output_path: nsis-plugin-staging/signed
+          environment_name: PROD
+          malware_block: true
+
+      - name: Restore signed NSIS helper DLLs to cache (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          node scripts/restore-windows-signables.mjs `
+            nsis-plugin-staging/signed `
+            nsis-plugin-staging/manifest.json
+
+      # Rebuild so makensis recompiles the installer with the now-signed helper
+      # DLLs. Cargo reuses the pass-1 target dir and SEREN_TAURI_SKIP_PREP keeps
+      # the already-signed embedded runtime in place, so this pass only re-bundles.
+      - name: Rebuild with signed NSIS helper DLLs (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        env:
+          SEREN_TAURI_SKIP_PREP: "1"
+        run: pnpm tauri build --target ${{ matrix.target }}
+
       # Move updater artifacts (.sig, .nsis.zip) out of NSIS dir before code signing
       # so SSL.com's batch_sign doesn't choke on non-exe files
       - name: Move updater artifacts before code signing
@@ -834,6 +894,61 @@ jobs:
             exit 1
           }
           Write-Host "All loose .exe/.dll in the Windows bundle are validly signed."
+
+      # Deepest gate: 7-Zip can unpack an NSIS installer, exposing the files it
+      # would extract at runtime — the $PLUGINSDIR helper DLLs (#2237) AND the
+      # whole embedded runtime (#2235), which are otherwise hidden inside the
+      # compressed setup .exe. Confirm every embedded .exe/.dll/.node carries a
+      # Valid Authenticode signature. This is what a user's Smart App Control
+      # actually evaluates, so a failure here means a real publisher prompt.
+      - name: Verify embedded installer payload signatures (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          $nsisDir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis"
+          $setup = Get-ChildItem -Path $nsisDir -Filter "*-setup.exe" | Select-Object -First 1
+          if (-not $setup) {
+            Write-Host "::error::No setup .exe found to deep-verify."
+            exit 1
+          }
+          $sevenZip = "7z"
+          if (-not (Get-Command 7z -ErrorAction SilentlyContinue)) {
+            $sevenZip = "C:\Program Files\7-Zip\7z.exe"
+          }
+          $extractDir = Join-Path $env:RUNNER_TEMP "setup-exe-verify"
+          if (Test-Path $extractDir) { Remove-Item -Path $extractDir -Recurse -Force }
+          # NSIS extraction emits warnings (exit 1) for the script sections; only
+          # a fatal error (>=2) means the unpack failed.
+          & $sevenZip x "$($setup.FullName)" "-o$extractDir" -y | Out-Null
+          if ($LASTEXITCODE -ge 2) {
+            Write-Host "::error::7-Zip failed to unpack $($setup.Name) (exit $LASTEXITCODE)."
+            exit 1
+          }
+          $pluginDir = Join-Path $extractDir '$PLUGINSDIR'
+          if (-not (Test-Path $pluginDir)) {
+            # The recursive signature scan below is the real gate; this only
+            # flags that 7-Zip labelled the helper-DLL folder unexpectedly.
+            Write-Host "::warning::No `$PLUGINSDIR folder in the unpacked installer; helper DLLs will still be checked by the recursive scan (#2237)."
+          }
+          $bins = @(Get-ChildItem -Path $extractDir -Recurse -Include "*.exe","*.dll","*.node" -File)
+          Write-Host "Embedded binaries to verify: $($bins.Count)"
+          $unsigned = @()
+          foreach ($b in $bins) {
+            $sig = Get-AuthenticodeSignature -FilePath $b.FullName
+            if ($sig.Status -ne "Valid") {
+              $unsigned += [PSCustomObject]@{
+                Path = $b.FullName.Substring($extractDir.Length).TrimStart("/\")
+                Status = $sig.Status.ToString()
+              }
+            }
+          }
+          if ($unsigned.Count -gt 0) {
+            Write-Host "::error::Unsigned/invalid binaries inside the installer ($($unsigned.Count) of $($bins.Count)) — Smart App Control will prompt on these:"
+            $unsigned | Format-Table -AutoSize | Out-String | Write-Host
+            exit 1
+          }
+          Write-Host "All $($bins.Count) embedded installer binaries (incl. `$PLUGINSDIR helper DLLs) are validly signed."
+          Remove-Item -Path $extractDir -Recurse -Force
 
       # Scan the Tauri-generated NSI / NSH output for unresolved ${...}
       # placeholders. #2230 showed "${product_name} is running" rendering

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -113,6 +113,54 @@ Convert to base64:
 base64 -i certificate.pfx
 ```
 
+## Windows Signing Coverage (What Smart App Control Evaluates)
+
+A signed outer setup `.exe` is not enough. Smart App Control / Defender
+evaluates **every** executable and library that is actually loaded on the
+user's machine, including binaries extracted from the installer at runtime.
+The Windows release path therefore signs three distinct surfaces, each before
+the artifact that embeds it is produced:
+
+1. **Embedded runtime payload** (`#2235`) — `node.exe`, the Git-for-Windows
+   portable tree, the bundled Python DLLs/`.pyd`, sidecars under
+   `embedded-runtime/`, and `mcp-servers/**/*.node`. These are signed *before*
+   `tauri build` so the signatures land inside both the NSIS installer and the
+   `.nsis.zip` updater bundle. Files are flattened into one staging directory
+   (`scripts/flatten-windows-signables.mjs`) and signed in a single SSL.com
+   `batch_sign` to avoid the per-file TOTP throttle, then copied back via the
+   manifest (`scripts/restore-windows-signables.mjs`).
+
+2. **NSIS helper DLLs** (`#2237`) — `System.dll`, `nsExec.dll`, `nsDialogs.dll`,
+   and `nsis_tauri_utils.dll` ship inside the `tauri-bundler` NSIS cache
+   (`%LOCALAPPDATA%\tauri\NSIS\Plugins`) and `makensis` compiles them *into* the
+   setup `.exe`; at install they are extracted to `%TEMP%\nsXXXX.tmp` and loaded.
+   We do not depend on an upstream tauri change: the first `tauri build`
+   populates the cache, we sign those DLLs in place (reusing the same
+   flatten/restore scripts), and a second `tauri build` (with
+   `SEREN_TAURI_SKIP_PREP=1`, so the already-signed runtime is untouched and
+   cargo reuses its target dir) recompiles the installer with the signed copies.
+
+3. **Outer setup `.exe` and `.nsis.zip`** — the setup `.exe` is signed
+   post-build with SSL.com eSigner. Because Tauri builds the `.nsis.zip` from
+   the *unsigned* setup `.exe` during the build, the updater bundle is re-packed
+   from the signed `.exe` and its `.nsis.zip.sig` re-signed with the Tauri
+   updater key (`#2236`).
+
+### Verification gates (release CI, hard-fail)
+
+- Loose `.exe`/`.dll` under `bundle/` are all `Valid` (`#2235`).
+- Every `.exe`/`.dll` extracted from `.nsis.zip` is `Valid` (`#2236`).
+- The setup `.exe` is unpacked with 7-Zip and **every** embedded
+  `.exe`/`.dll`/`.node` — including the `$PLUGINSDIR` helper DLLs — is `Valid`
+  (`#2237`). This is the closest CI proxy for what Smart App Control sees.
+
+### SEREN_TAURI_SKIP_PREP
+
+`build/prepare-tauri-build.ts` honours `SEREN_TAURI_SKIP_PREP=1` by skipping
+runtime preparation entirely. The release workflow sets it on every
+`tauri build` that runs **after** the embedded runtime has been staged and
+signed, so the build cannot re-download and clobber the signed binaries.
+
 ## Testing Locally
 
 ### macOS


### PR DESCRIPTION
## Summary

Closes #2237 (follow-up to #2230 / #2234, builds on #2235 + #2236).

The NSIS helper DLLs (`System.dll`, `nsExec.dll`, `nsDialogs.dll`, `nsis_tauri_utils.dll`) ship inside the `tauri-bundler` NSIS cache and `makensis` compiles them **into** the setup `.exe`. At install they are extracted to `%TEMP%\nsXXXX.tmp` and loaded, so Smart App Control blocks them when unsigned — regardless of the outer installer's signature.

**The original ticket said "file an upstream tauri issue and wait."** That blocks deployment on a team that won't prioritize it. This is the fix we own instead.

## What changed (`release.yml`, Windows path)

1. **Sign the cached plugin DLLs** — the first `tauri build` (from #2235) populates `%LOCALAPPDATA%\tauri\NSIS\Plugins`. Flatten those DLLs (reusing #2235's `flatten-windows-signables.mjs`), one SSL.com `batch_sign`, restore in place. Asserts DLLs were actually found (no silent no-op).
2. **Rebuild** with `SEREN_TAURI_SKIP_PREP=1` so `makensis` recompiles the installer embedding the signed DLLs — cargo reuses the pass-1 target dir and the already-signed embedded runtime is untouched, so it is a fast re-bundle.
3. **Deepest verification gate** — 7-Zip unpacks the finished setup `.exe` and **every** embedded `.exe`/`.dll`/`.node` (the `$PLUGINSDIR` helper DLLs **and** the whole embedded runtime) must report `Valid`. This is the closest CI proxy for what a user's Smart App Control evaluates — it sees inside the compressed installer, which #2235/#2236's checks cannot.

Plus `docs/code-signing.md`: documents all three signing surfaces and the hard-fail verification gates.

## Why two-pass (not pre-staging the cache)

Pre-downloading the NSIS toolchain would couple us to tauri 2.11.2's exact NSIS version and silently break (re-download → unsigned) on upgrade. Two-pass lets tauri fetch whatever it wants; we sign in place. The extra pass is a re-bundle only (cargo cached, prep skipped), and the dominant cost — signing the Git-for-Windows tree — happens once.

## Tests

No new unit test: reuses the already-tested flatten/restore scripts; the rest is CI orchestration of 7-Zip / `Get-AuthenticodeSignature` (testing it would mean asserting mocked shell behavior). Validated by YAML parse; the 11 flatten/restore tests still pass.

## Validation status

⚠️ Executes only on a Windows release tag. The 7z deep-verify is the real end-to-end gate and runs on the release. ⚠️ Watch wall-clock: two builds + signing the Git-for-Windows tree may approach the 45-min budget; if so, the follow-up is MinGit or an HSM `signtool` path.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
