### PR TITLE
Fix BYOC OAuth reconnect and first-connect prompts

### DIFF
--- a/src/components/chat/ToolCallCard.tsx
+++ b/src/components/chat/ToolCallCard.tsx
@@ -2,12 +2,20 @@
 // ABOUTME: Shows tool summary, status indicator, and expandable details.
 
 import type { Component } from "solid-js";
-import { createEffect, createSignal, Show } from "solid-js";
+import { createEffect, createResource, createSignal, Show } from "solid-js";
 import {
   isDirectoryListing,
   summarizeDirectoryListing,
 } from "@/lib/directory-listing";
+import {
+  getOAuthConnectActionForToolError,
+  type OAuthConnectAction,
+} from "@/lib/oauth-tool-errors";
 import type { ToolCallEvent } from "@/services/providers";
+import {
+  connectPublisher,
+  resolveOAuthProviderForPublisher,
+} from "@/services/publisher-oauth";
 
 interface ToolCallCardProps {
   toolCall: ToolCallEvent;
@@ -120,6 +128,94 @@ function extractSummary(toolCall: ToolCallEvent): string {
   return "No description available";
 }
 
+const OAuthToolConnectPrompt: Component<{
+  action: OAuthConnectAction;
+}> = (props) => {
+  const [connecting, setConnecting] = createSignal(false);
+  const [opened, setOpened] = createSignal(false);
+  const [connectError, setConnectError] = createSignal<string | null>(null);
+  const [provider] = createResource(
+    () => props.action.publisherSlug,
+    resolveOAuthProviderForPublisher,
+  );
+
+  const providerName = () => provider()?.providerName ?? "account";
+  const buttonLabel = () =>
+    props.action.reason === "scope_insufficient"
+      ? `Reconnect ${providerName()}`
+      : `Connect ${providerName()}`;
+  const message = () =>
+    props.action.reason === "scope_insufficient"
+      ? `${providerName()} needs updated permissions for this tool.`
+      : `${providerName()} is required before this tool can run.`;
+
+  const handleConnect = async (event: MouseEvent) => {
+    event.stopPropagation();
+    if (connecting()) return;
+    setConnecting(true);
+    setOpened(false);
+    setConnectError(null);
+    try {
+      const resolved = await resolveOAuthProviderForPublisher(
+        props.action.publisherSlug,
+      );
+      await connectPublisher(resolved.providerSlug);
+      setOpened(true);
+    } catch (err) {
+      setConnectError(
+        err instanceof Error ? err.message : "Failed to start OAuth flow",
+      );
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  return (
+    <div class="flex items-center gap-3 border-t border-warning/30 bg-warning/[0.07] px-3 py-2.5">
+      <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-warning/15 text-warning">
+        <svg
+          class="h-4 w-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          role="img"
+          aria-label="OAuth"
+        >
+          <path d="M15 7a5 5 0 1 0-4 4" />
+          <path d="M21 2l-9.6 9.6" />
+          <path d="M15 2h6v6" />
+        </svg>
+      </div>
+      <div class="min-w-0 flex-1">
+        <div class="text-xs font-medium text-foreground">{message()}</div>
+        <Show when={opened()}>
+          <div class="mt-0.5 text-[11px] text-muted-foreground">
+            Authorization opened in your browser.
+          </div>
+        </Show>
+        <Show when={connectError()}>
+          {(error) => (
+            <div class="mt-0.5 break-words text-[11px] text-destructive">
+              {error()}
+            </div>
+          )}
+        </Show>
+      </div>
+      <button
+        type="button"
+        class="shrink-0 whitespace-nowrap rounded-md border border-warning/50 bg-warning/90 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:not-disabled:bg-warning/75 disabled:cursor-not-allowed disabled:opacity-55"
+        onClick={handleConnect}
+        disabled={connecting() || provider.loading}
+      >
+        {connecting() || provider.loading ? "Opening..." : buttonLabel()}
+      </button>
+    </div>
+  );
+};
+
 export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
   const [isExpanded, setIsExpanded] = createSignal(false);
   const [isResultExpanded, setIsResultExpanded] = createSignal(false);
@@ -190,6 +286,11 @@ export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
   };
 
   const summary = () => extractSummary(props.toolCall);
+  const oauthConnectAction = () =>
+    getOAuthConnectActionForToolError(
+      props.toolCall.name ?? props.toolCall.title,
+      props.toolCall.error,
+    );
 
   const statusInfo = () => {
     const status = props.toolCall.status.toLowerCase();
@@ -463,6 +564,10 @@ export const ToolCallCard: Component<ToolCallCardProps> = (props) => {
           />
         </svg>
       </button>
+
+      <Show when={oauthConnectAction()}>
+        {(action) => <OAuthToolConnectPrompt action={action()} />}
+      </Show>
 
       {/* Details */}
       <Show when={isOpen()}>

--- a/src/components/settings/OAuthLogins.tsx
+++ b/src/components/settings/OAuthLogins.tsx
@@ -23,6 +23,10 @@ import githubLogo from "@/assets/oauth-logos/github.svg";
 import googleLogo from "@/assets/oauth-logos/google.svg";
 import linearLogo from "@/assets/oauth-logos/linear.svg";
 import { apiBase } from "@/lib/config";
+import {
+  getExpiredOAuthProviderSlugs,
+  isOAuthProviderExpired,
+} from "@/lib/oauth-provider-resolution";
 import { listenForOAuthCallback } from "@/lib/tauri-bridge";
 import {
   connectPublisher,
@@ -159,6 +163,13 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
         setExpiredProviders((prev) => {
           const next = new Set(prev);
           next.add(publisherSlug);
+          for (const providerSlug of getExpiredOAuthProviderSlugs(
+            publisherSlug,
+            providers() ?? [],
+            publisherData()?.byProvider ?? {},
+          )) {
+            next.add(providerSlug);
+          }
           return next;
         });
       },
@@ -234,14 +245,26 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
     );
   };
 
-  const isExpired = (providerSlug: string): boolean => {
-    return expiredProviders().has(providerSlug);
+  const isExpired = (providerSlug: string, providerId: string): boolean => {
+    return isOAuthProviderExpired(
+      providerSlug,
+      providerId,
+      publisherData()?.byProvider ?? {},
+      expiredProviders(),
+    );
   };
 
   const clearExpiredStatus = (providerSlug: string) => {
     setExpiredProviders((prev) => {
       const next = new Set(prev);
       next.delete(providerSlug);
+      const provider = providers()?.find((item) => item.slug === providerSlug);
+      const linkedPublishers = provider
+        ? (publisherData()?.byProvider[provider.id] ?? [])
+        : [];
+      for (const publisher of linkedPublishers) {
+        next.delete(publisher.slug);
+      }
       return next;
     });
   };
@@ -375,7 +398,7 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
           <For each={providers()}>
             {(provider) => {
               const connection = () => isConnected(provider.slug);
-              const expired = () => isExpired(provider.slug);
+              const expired = () => isExpired(provider.slug, provider.id);
               const isConnecting = () => connectingProvider() === provider.slug;
               const isDisconnecting = () =>
                 disconnectingProvider() === provider.slug;

--- a/src/lib/group-tool-calls.ts
+++ b/src/lib/group-tool-calls.ts
@@ -35,6 +35,7 @@ export function toToolCallEvent(data: ToolCallData): ToolCallEvent {
     sessionId: "",
     toolCallId: data.toolCallId,
     title: data.title || data.name || "Tool",
+    name: data.name,
     kind: data.kind,
     status: data.status,
     parameters: params,

--- a/src/lib/oauth-provider-resolution.ts
+++ b/src/lib/oauth-provider-resolution.ts
@@ -1,0 +1,100 @@
+// ABOUTME: Helpers for resolving BYOC gateway publishers to OAuth providers.
+// ABOUTME: Keeps chat connect prompts and Settings reconnect state aligned.
+
+export interface OAuthProviderRef {
+  id?: string | null;
+  slug?: string | null;
+  name?: string | null;
+}
+
+export interface LinkedOAuthPublisherRef {
+  slug: string;
+  name?: string | null;
+}
+
+export interface KnownOAuthProvider {
+  providerSlug: string;
+  providerName: string;
+}
+
+const KNOWN_OAUTH_PROVIDER_BY_PUBLISHER: Record<string, KnownOAuthProvider> = {
+  calendar: { providerSlug: "google", providerName: "Google" },
+  "github-api": { providerSlug: "github", providerName: "GitHub" },
+  gmail: { providerSlug: "google", providerName: "Google" },
+  "google-calendar": { providerSlug: "google", providerName: "Google" },
+  "google-meet": { providerSlug: "google", providerName: "Google" },
+  googlecalendar: { providerSlug: "google", providerName: "Google" },
+  googlemeet: { providerSlug: "google", providerName: "Google" },
+};
+
+const DISPLAY_NAME_OVERRIDES: Record<string, string> = {
+  api: "API",
+  github: "GitHub",
+  gmail: "Gmail",
+  google: "Google",
+  oauth: "OAuth",
+};
+
+function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.filter((v): v is string => Boolean(v))));
+}
+
+export function humanizeOAuthProviderSlug(slug: string): string {
+  return slug
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((part) => {
+      const lower = part.toLowerCase();
+      return (
+        DISPLAY_NAME_OVERRIDES[lower] ??
+        `${lower.charAt(0).toUpperCase()}${lower.slice(1)}`
+      );
+    })
+    .join(" ");
+}
+
+export function getKnownOAuthProviderForPublisher(
+  publisherSlug: string,
+): KnownOAuthProvider | null {
+  return KNOWN_OAUTH_PROVIDER_BY_PUBLISHER[publisherSlug.toLowerCase()] ?? null;
+}
+
+export function getExpiredOAuthProviderSlugs(
+  publisherSlug: string,
+  providers: OAuthProviderRef[],
+  byProvider: Record<string, LinkedOAuthPublisherRef[]>,
+): string[] {
+  const directProviderSlug = providers.find(
+    (provider) => provider.slug === publisherSlug,
+  )?.slug;
+  const slugs = [directProviderSlug];
+
+  for (const [providerId, linkedPublishers] of Object.entries(byProvider)) {
+    if (
+      !linkedPublishers.some((publisher) => publisher.slug === publisherSlug)
+    ) {
+      continue;
+    }
+    const provider = providers.find((item) => item.id === providerId);
+    slugs.push(provider?.slug);
+  }
+
+  const known = getKnownOAuthProviderForPublisher(publisherSlug);
+  slugs.push(known?.providerSlug);
+
+  return uniqueNonEmpty(slugs).length > 0
+    ? uniqueNonEmpty(slugs)
+    : [publisherSlug];
+}
+
+export function isOAuthProviderExpired(
+  providerSlug: string,
+  providerId: string,
+  byProvider: Record<string, LinkedOAuthPublisherRef[]>,
+  expiredSlugs: Iterable<string>,
+): boolean {
+  const expired = new Set(expiredSlugs);
+  if (expired.has(providerSlug)) return true;
+  const linkedPublishers = byProvider[providerId] ?? [];
+  return linkedPublishers.some((publisher) => expired.has(publisher.slug));
+}

--- a/src/lib/oauth-tool-errors.ts
+++ b/src/lib/oauth-tool-errors.ts
@@ -1,0 +1,96 @@
+// ABOUTME: Classifies gateway publisher OAuth failures for reconnect and connect UX.
+// ABOUTME: Covers refresh failures, missing first connections, and Google scope 403s.
+
+export type OAuthConnectActionReason =
+  | "connection_required"
+  | "scope_insufficient";
+
+export interface OAuthConnectAction {
+  publisherSlug: string;
+  reason: OAuthConnectActionReason;
+}
+
+const OAUTH_REFRESH_ERROR_MARKERS = [
+  "oauth token refresh failed",
+  "token refresh failed",
+  "provider error during token refresh",
+  "invalid_grant",
+  "refresh token expired",
+];
+
+const OAUTH_CONNECTION_REQUIRED_MARKERS = [
+  "oauth authentication required",
+  "oauth connection required",
+  "requires oauth",
+  "requires user oauth",
+  "user oauth required",
+  "missing oauth connection",
+  "no oauth connection",
+  "not connected to oauth",
+  "connect your account",
+];
+
+const OAUTH_SCOPE_ERROR_MARKERS = [
+  "access_token_scope_insufficient",
+  "insufficient authentication scopes",
+  "insufficient oauth scopes",
+  "insufficient_scope",
+  "missing required scope",
+  "missing oauth scope",
+];
+
+function normalizeMessage(message: string): string {
+  return message.toLowerCase();
+}
+
+function includesAny(message: string, markers: readonly string[]): boolean {
+  const lowerMessage = normalizeMessage(message);
+  return markers.some((marker) => lowerMessage.includes(marker));
+}
+
+export function isOAuthScopeError(message: string): boolean {
+  return includesAny(message, OAUTH_SCOPE_ERROR_MARKERS);
+}
+
+export function isOAuthConnectionRequiredError(message: string): boolean {
+  return includesAny(message, OAUTH_CONNECTION_REQUIRED_MARKERS);
+}
+
+/**
+ * Check if an error message indicates an OAuth token issue.
+ * These errors mean the user's OAuth connection needs to be refreshed.
+ */
+export function isOAuthTokenError(message: string): boolean {
+  return (
+    includesAny(message, OAUTH_REFRESH_ERROR_MARKERS) ||
+    isOAuthConnectionRequiredError(message) ||
+    isOAuthScopeError(message)
+  );
+}
+
+export function parseGatewayPublisherSlug(
+  toolName: string | null | undefined,
+): string | null {
+  if (!toolName?.startsWith("gateway__")) return null;
+  const rest = toolName.slice("gateway__".length);
+  const separatorIndex = rest.indexOf("__");
+  if (separatorIndex === -1) return null;
+  return rest.slice(0, separatorIndex) || null;
+}
+
+export function getOAuthConnectActionForToolError(
+  toolName: string | null | undefined,
+  errorMessage: string | null | undefined,
+): OAuthConnectAction | null {
+  if (!errorMessage) return null;
+  const publisherSlug = parseGatewayPublisherSlug(toolName);
+  if (!publisherSlug) return null;
+
+  if (isOAuthConnectionRequiredError(errorMessage)) {
+    return { publisherSlug, reason: "connection_required" };
+  }
+  if (isOAuthScopeError(errorMessage)) {
+    return { publisherSlug, reason: "scope_insufficient" };
+  }
+  return null;
+}

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -4,6 +4,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { mcpClient } from "@/lib/mcp/client";
+import { isOAuthTokenError } from "@/lib/oauth-tool-errors";
 import type { ToolCall, ToolResult } from "@/lib/providers/types";
 import { type PaymentRequirements, parsePaymentRequirements } from "@/lib/x402";
 import {
@@ -29,22 +30,6 @@ const GATEWAY_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const SHELL_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_RESULT_SIZE = 50_000; // 50KB cap
 const MAX_ARRAY_ITEMS = 25;
-
-/**
- * Check if an error message indicates an OAuth token issue.
- * These errors mean the user's OAuth connection needs to be refreshed.
- */
-function isOAuthTokenError(message: string): boolean {
-  const lowerMessage = message.toLowerCase();
-  return (
-    lowerMessage.includes("oauth token refresh failed") ||
-    lowerMessage.includes("token refresh failed") ||
-    lowerMessage.includes("provider error during token refresh") ||
-    lowerMessage.includes("oauth authentication required") ||
-    lowerMessage.includes("invalid_grant") ||
-    lowerMessage.includes("refresh token expired")
-  );
-}
 
 /**
  * Emit an event to notify the UI that an OAuth connection has expired.
@@ -650,7 +635,7 @@ async function executeGatewayTool(
         new Error(JSON.stringify(response.payment_proxy)),
       );
 
-      if (!paymentResult || !paymentResult.success) {
+      if (!paymentResult?.success) {
         return {
           tool_call_id: toolCallId,
           content: paymentResult?.error || "Payment was cancelled or failed",

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -91,6 +91,8 @@ export interface ToolCallEvent {
   sessionId: string;
   toolCallId: string;
   title: string;
+  /** Raw provider/runtime tool name, e.g. gateway__gmail__get_messages. */
+  name?: string;
   kind: string;
   status: string;
   parameters?: Record<string, unknown>;

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -4,11 +4,116 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   listConnections,
+  listProviders,
+  listStorePublishers,
   revokeConnection,
   type UserOAuthConnectionResponse,
 } from "@/api";
 import { apiBase } from "@/lib/config";
+import {
+  getKnownOAuthProviderForPublisher,
+  humanizeOAuthProviderSlug,
+} from "@/lib/oauth-provider-resolution";
 import { getToken } from "@/lib/tauri-bridge";
+
+export interface PublisherOAuthProviderResolution {
+  publisherSlug: string;
+  providerSlug: string;
+  providerName: string;
+}
+
+let providerLookupPromise: Promise<
+  Map<string, PublisherOAuthProviderResolution>
+> | null = null;
+
+function fallbackOAuthProviderForPublisher(
+  publisherSlug: string,
+): PublisherOAuthProviderResolution {
+  const known = getKnownOAuthProviderForPublisher(publisherSlug);
+  const providerSlug = known?.providerSlug ?? publisherSlug;
+  return {
+    publisherSlug,
+    providerSlug,
+    providerName:
+      known?.providerName ?? humanizeOAuthProviderSlug(providerSlug),
+  };
+}
+
+async function loadPublisherOAuthProviderLookup(): Promise<
+  Map<string, PublisherOAuthProviderResolution>
+> {
+  const [providerResult, publisherResult] = await Promise.all([
+    listProviders({ throwOnError: false }),
+    listStorePublishers({
+      query: { limit: 100 },
+      throwOnError: false,
+    }),
+  ]);
+
+  const providers = providerResult.data?.providers ?? [];
+  const publishers = publisherResult.data?.data ?? [];
+  const providersById = new Map(
+    providers.map((provider) => [provider.id, provider]),
+  );
+  const lookup = new Map<string, PublisherOAuthProviderResolution>();
+
+  for (const provider of providers) {
+    lookup.set(provider.slug, {
+      publisherSlug: provider.slug,
+      providerSlug: provider.slug,
+      providerName: provider.name,
+    });
+  }
+
+  for (const publisher of publishers) {
+    const provider = publisher.oauth_provider_id
+      ? providersById.get(publisher.oauth_provider_id)
+      : null;
+    if (!provider) continue;
+    lookup.set(publisher.slug, {
+      publisherSlug: publisher.slug,
+      providerSlug: provider.slug,
+      providerName: provider.name,
+    });
+  }
+
+  for (const publisher of publishers) {
+    const known = getKnownOAuthProviderForPublisher(publisher.slug);
+    if (!known || lookup.has(publisher.slug)) continue;
+    lookup.set(publisher.slug, {
+      publisherSlug: publisher.slug,
+      providerSlug: known.providerSlug,
+      providerName: known.providerName,
+    });
+  }
+
+  return lookup;
+}
+
+/**
+ * Resolve a Gateway publisher slug (e.g. "gmail") to the OAuth provider slug
+ * accepted by connectPublisher() (e.g. "google").
+ */
+export async function resolveOAuthProviderForPublisher(
+  publisherSlug: string,
+): Promise<PublisherOAuthProviderResolution> {
+  providerLookupPromise ??= loadPublisherOAuthProviderLookup();
+
+  try {
+    const lookup = await providerLookupPromise;
+    return (
+      lookup.get(publisherSlug) ??
+      fallbackOAuthProviderForPublisher(publisherSlug)
+    );
+  } catch (err) {
+    console.warn(
+      `[PublisherOAuth] Failed to resolve OAuth provider for ${publisherSlug}:`,
+      err,
+    );
+    providerLookupPromise = null;
+    return fallbackOAuthProviderForPublisher(publisherSlug);
+  }
+}
 
 /**
  * Start OAuth flow for a publisher provider.

--- a/tests/unit/oauth-provider-resolution.test.ts
+++ b/tests/unit/oauth-provider-resolution.test.ts
@@ -1,0 +1,71 @@
+// ABOUTME: Regression tests for mapping gateway publisher slugs to OAuth providers.
+// ABOUTME: Ensures Google publisher failures can mark the Google login as expired.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getExpiredOAuthProviderSlugs,
+  getKnownOAuthProviderForPublisher,
+  humanizeOAuthProviderSlug,
+  isOAuthProviderExpired,
+} from "@/lib/oauth-provider-resolution";
+
+describe("OAuth publisher/provider resolution", () => {
+  const providers = [
+    { id: "provider-google", slug: "google", name: "Google" },
+    { id: "provider-github", slug: "github", name: "GitHub" },
+  ];
+  const byProvider = {
+    "provider-google": [
+      { slug: "gmail", name: "Gmail" },
+      { slug: "google-calendar", name: "Google Calendar" },
+    ],
+    "provider-github": [{ slug: "github-api", name: "GitHub" }],
+  };
+
+  it("resolves linked publisher slugs to their OAuth provider slug", () => {
+    expect(
+      getExpiredOAuthProviderSlugs("gmail", providers, byProvider),
+    ).toEqual(["google"]);
+    expect(
+      getExpiredOAuthProviderSlugs("github-api", providers, byProvider),
+    ).toEqual(["github"]);
+  });
+
+  it("falls back to the raw slug when publisher metadata has not loaded", () => {
+    expect(getExpiredOAuthProviderSlugs("gmail", [], {})).toEqual(["google"]);
+    expect(getExpiredOAuthProviderSlugs("custom-pub", [], {})).toEqual([
+      "custom-pub",
+    ]);
+  });
+
+  it("marks a provider expired when either its slug or a linked publisher slug expires", () => {
+    expect(
+      isOAuthProviderExpired("google", "provider-google", byProvider, [
+        "gmail",
+      ]),
+    ).toBe(true);
+    expect(
+      isOAuthProviderExpired("google", "provider-google", byProvider, [
+        "google",
+      ]),
+    ).toBe(true);
+    expect(
+      isOAuthProviderExpired("github", "provider-github", byProvider, [
+        "gmail",
+      ]),
+    ).toBe(false);
+  });
+
+  it("knows Google BYOC publisher aliases for first-connect prompts", () => {
+    expect(getKnownOAuthProviderForPublisher("google-meet")).toEqual({
+      providerSlug: "google",
+      providerName: "Google",
+    });
+    expect(getKnownOAuthProviderForPublisher("github-api")).toEqual({
+      providerSlug: "github",
+      providerName: "GitHub",
+    });
+    expect(humanizeOAuthProviderSlug("github-api")).toBe("GitHub API");
+  });
+});

--- a/tests/unit/oauth-tool-errors.test.ts
+++ b/tests/unit/oauth-tool-errors.test.ts
@@ -1,0 +1,72 @@
+// ABOUTME: Regression tests for BYOC OAuth tool-error classification.
+// ABOUTME: Pins inline connect/reconnect affordance triggers for gateway tools.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getOAuthConnectActionForToolError,
+  isOAuthConnectionRequiredError,
+  isOAuthScopeError,
+  isOAuthTokenError,
+} from "@/lib/oauth-tool-errors";
+
+describe("BYOC OAuth tool errors", () => {
+  it("treats Google insufficient-scope 403s as reconnect-worthy OAuth errors", () => {
+    expect(
+      isOAuthTokenError(
+        "403 Forbidden: Request had insufficient authentication scopes.",
+      ),
+    ).toBe(true);
+    expect(
+      isOAuthTokenError(
+        '{"error":"access_token_scope_insufficient","message":"Missing scope"}',
+      ),
+    ).toBe(true);
+  });
+
+  it("distinguishes first-connect OAuth failures from generic forbidden errors", () => {
+    expect(isOAuthConnectionRequiredError("OAuth authentication required")).toBe(
+      true,
+    );
+    expect(
+      isOAuthConnectionRequiredError("403 Forbidden: quota exceeded"),
+    ).toBe(false);
+  });
+
+  it("classifies canonical scope markers directly", () => {
+    expect(isOAuthScopeError("insufficient authentication scopes")).toBe(true);
+    expect(isOAuthScopeError("access_token_scope_insufficient")).toBe(true);
+  });
+
+  it("returns an inline action only for actionable gateway OAuth failures", () => {
+    expect(
+      getOAuthConnectActionForToolError(
+        "gateway__gmail__get_messages",
+        "OAuth authentication required",
+      ),
+    ).toEqual({ publisherSlug: "gmail", reason: "connection_required" });
+
+    expect(
+      getOAuthConnectActionForToolError(
+        "gateway__google-meet__create_meeting",
+        "403: access_token_scope_insufficient",
+      ),
+    ).toEqual({
+      publisherSlug: "google-meet",
+      reason: "scope_insufficient",
+    });
+
+    expect(
+      getOAuthConnectActionForToolError(
+        "read_file",
+        "OAuth authentication required",
+      ),
+    ).toBeNull();
+    expect(
+      getOAuthConnectActionForToolError(
+        "gateway__gmail__get_messages",
+        "403 Forbidden: quota exceeded",
+      ),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- classify BYOC OAuth scope-403 errors as reconnect-worthy token errors
- map gateway publisher slugs like gmail/google-meet/github-api back to OAuth provider slugs for Settings reconnect state
- add inline chat Connect/Reconnect action for actionable gateway OAuth tool failures

## Tests
- pnpm vitest run tests/unit/oauth-tool-errors.test.ts tests/unit/oauth-provider-resolution.test.ts
- pnpm vitest run tests/unit/oauth-tool-errors.test.ts tests/unit/oauth-provider-resolution.test.ts tests/unit/group-tool-calls.test.ts tests/services/mcp-gateway.test.ts
- pnpm test
- pnpm exec biome check src/lib/oauth-tool-errors.ts src/lib/oauth-provider-resolution.ts src/lib/tools/executor.ts src/services/publisher-oauth.ts src/components/settings/OAuthLogins.tsx src/services/providers.ts src/lib/group-tool-calls.ts src/components/chat/ToolCallCard.tsx tests/unit/oauth-tool-errors.test.ts tests/unit/oauth-provider-resolution.test.ts
- pnpm check (passes with existing warnings in unrelated session components)
- pnpm build (passes with existing Vite/Rolldown dependency warnings)

## Functional Audit
- Scope 403 path: gateway tool error -> shared OAuth classifier -> oauth-connection-expired event -> OAuth Logins resolves publisher slug to provider card -> reconnect affordance.
- First-connect path: failed gateway tool result -> tool card receives raw tool name -> inline Connect/Reconnect action resolves publisher to provider -> connectPublisher(providerSlug).
- macOS/Windows parity: inline action uses the existing connectPublisher service, preserving seren:// callback on macOS/Linux and localhost callback on Windows.
- P0/P1 follow-up tickets: none found in this audit.

Fixes #2248