### PR TITLE
ci(windows): embed modern manifest for cargo tests (#2251)

### DIFF
--- a/scripts/test-windows-cargo.ps1
+++ b/scripts/test-windows-cargo.ps1
@@ -44,6 +44,22 @@ function Invoke-Checked {
   }
 }
 
+function Remove-AppLocalApiSetForwarders {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $Directory
+  )
+
+  if (-not (Test-Path $Directory)) {
+    return
+  }
+
+  # API-set DLLs are OS contracts. App-local downlevel copies can shadow
+  # KernelBase-backed implementations and break modern Windows test binaries.
+  Get-ChildItem -Path $Directory -Filter "api-ms-win-*.dll" -File -ErrorAction SilentlyContinue |
+    Remove-Item -Force
+}
+
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 $tauriDir = Join-Path $repoRoot "src-tauri"
 $cargoManifest = Join-Path $tauriDir "Cargo.toml"
@@ -58,9 +74,19 @@ try {
     throw "Cargo did not produce the expected target deps directory: $targetDeps"
   }
 
+  Remove-AppLocalApiSetForwarders $targetDeps
+
   @"
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+    </application>
+  </compatibility>
   <dependency>
     <dependentAssembly>
       <assemblyIdentity


### PR DESCRIPTION
## Summary

- removes stale app-local `api-ms-win-*.dll` forwarders from the Windows cargo test deps directory
- embeds a manifest that declares modern Windows compatibility in addition to Common Controls v6

## Audit

Fixes #2251. The AWS Windows Server 2022 validation failed with `STATUS_ENTRYPOINT_NOT_FOUND` before the Rust test harness could start. A compatibility-aware manifest proof on the same host allowed the harness to enumerate tests.

## Tests

- `pwsh` script parse check
- AWS Windows Server 2022 proof: embedded modern manifest into `seren_desktop_lib-*.exe`, then `--list` enumerated the Rust test harness