### PR TITLE
feat(history-sync): sync desktop history to SerenDB

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1541,6 +1541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,7 +2045,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -2148,7 +2154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -2160,6 +2166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
 ]
@@ -2557,6 +2564,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -4266,13 +4279,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.7.0",
+ "plain",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -4428,6 +4442,16 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "md5"
@@ -4983,6 +5007,15 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -5562,6 +5595,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plist"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5659,6 +5698,63 @@ dependencies = [
  "shell-words",
  "winapi",
  "winreg 0.10.1",
+]
+
+[[package]]
+name = "postgres"
+version = "0.19.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacf632d0554ff75f58183694f41dc8999c8a3a43a386994d0ec2d034f1dfbe1"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-native-tls"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
+dependencies = [
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.13.0",
+ "md-5",
+ "memchr",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]
@@ -6186,9 +6282,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -6532,7 +6628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
 dependencies = [
  "bitflags 2.10.0",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -7182,10 +7278,13 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "native-tls",
  "notify",
  "objc2",
  "objc2-foundation",
  "portable-pty",
+ "postgres",
+ "postgres-native-tls",
  "rand 0.10.1",
  "rand_distr",
  "regex",
@@ -7757,6 +7856,17 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -8749,6 +8859,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf 0.13.1",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.1",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9267,10 +9403,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -9675,6 +9832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9690,6 +9856,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -10088,6 +10263,19 @@ dependencies = [
  "tokio",
  "ureq",
  "wacore",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,6 +59,9 @@ sha2 = "0.10"
 base64 = "0.22"
 libc = "0.2"
 reqwest = { version = "0.13", features = ["json", "stream"] }
+postgres = { version = "0.19", features = ["with-serde_json-1"] }
+postgres-native-tls = "0.5"
+native-tls = "0.2"
 seren-memory-sdk = { git = "https://github.com/serenorg/seren-memory-sdk.git", branch = "main" }
 rmcp = { version = "1.2", features = [
     "client",

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -19,7 +19,7 @@ use crate::audio::types::{
     Meeting, MeetingStatus, SegmentStatus, Speaker, SpeakerSource, TranscriptSegment,
 };
 use crate::orchestrator::types::SkillRef;
-use crate::services::database::DbPool;
+use crate::services::database::{DbPool, enqueue_sync_tombstone, mark_sync_upsert};
 use rusqlite::{Connection, OptionalExtension, Result, params};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -135,6 +135,7 @@ fn set_meeting_notes_record(
             id
         ],
     )?;
+    mark_sync_upsert(conn, "meetings", id)?;
     Ok(())
 }
 
@@ -153,6 +154,7 @@ pub async fn set_meeting_routed_skill(
              WHERE id = ?4",
             params![routed_skill_slug, agent_conversation_id, now_ms(), id],
         )?;
+        mark_sync_upsert(conn, "meetings", &id)?;
         Ok(())
     })
     .await?;
@@ -786,6 +788,7 @@ pub fn insert_meeting(conn: &Connection, meeting: NewMeeting) -> Result<Meeting>
             meeting.now
         ],
     )?;
+    mark_sync_upsert(conn, "meetings", &meeting.id)?;
 
     select_meeting(conn, &meeting.id)?.ok_or(rusqlite::Error::QueryReturnedNoRows)
 }
@@ -821,6 +824,15 @@ pub fn select_meetings(conn: &Connection, limit: i32) -> Result<Vec<Meeting>> {
 
 pub fn delete_meeting_record(conn: &Connection, id: &str) -> Result<usize> {
     let tx = conn.unchecked_transaction()?;
+    let mut stmt = tx.prepare("SELECT id FROM transcript_segments WHERE meeting_id = ?1")?;
+    let segment_ids = stmt
+        .query_map(params![id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(stmt);
+    for segment_id in &segment_ids {
+        enqueue_sync_tombstone(&tx, "transcript_segments", segment_id)?;
+    }
+    enqueue_sync_tombstone(&tx, "meetings", id)?;
     tx.execute(
         "DELETE FROM transcript_segments WHERE meeting_id = ?1",
         params![id],
@@ -892,6 +904,7 @@ pub fn update_meeting_status_record_with_failure_reason_and_diagnostics(
             id
         ],
     )?;
+    mark_sync_upsert(conn, "meetings", id)?;
     Ok(())
 }
 
@@ -919,6 +932,7 @@ pub fn insert_transcript_segment(
             segment.created_at
         ],
     )?;
+    mark_sync_upsert(conn, "transcript_segments", &segment.id)?;
 
     Ok(TranscriptSegment {
         id: segment.id,
@@ -961,6 +975,7 @@ pub fn update_transcript_segment_speaker(conn: &Connection, id: &str, label: &st
          WHERE id = ?3",
         params![label, SpeakerSource::Diarization.as_str(), id],
     )?;
+    mark_sync_upsert(conn, "transcript_segments", id)?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -2,7 +2,10 @@
 // ABOUTME: Handles CRUD operations for conversations and messages in SQLite.
 
 use crate::commands::provider_runtime::DERIVED_KIND_CASE_SQL;
-use crate::services::database::{DbPool, PersistedMessage, init_db, save_message_record};
+use crate::services::database::{
+    DbPool, PersistedMessage, enqueue_sync_tombstone, init_db, mark_sync_upsert,
+    save_message_record,
+};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -15,6 +18,25 @@ pub(crate) fn delete_conversation_records(
     let tx = conn.unchecked_transaction()?;
     let mut deleted = 0;
     for id in conversation_ids {
+        let mut event_stmt =
+            tx.prepare("SELECT id FROM message_events WHERE conversation_id = ?1")?;
+        let event_ids = event_stmt
+            .query_map(params![id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(event_stmt);
+        let mut message_stmt = tx.prepare("SELECT id FROM messages WHERE conversation_id = ?1")?;
+        let message_ids = message_stmt
+            .query_map(params![id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(message_stmt);
+        for event_id in &event_ids {
+            enqueue_sync_tombstone(&tx, "message_events", event_id)?;
+        }
+        for message_id in &message_ids {
+            enqueue_sync_tombstone(&tx, "messages", message_id)?;
+        }
+        enqueue_sync_tombstone(&tx, "thread_drafts", id)?;
+        enqueue_sync_tombstone(&tx, "conversations", id)?;
         tx.execute(
             "DELETE FROM eval_signals
              WHERE message_id IN (
@@ -54,6 +76,10 @@ pub(crate) fn delete_conversation_records(
         )?;
         tx.execute(
             "DELETE FROM runtime_sessions WHERE thread_id = ?1",
+            params![id],
+        )?;
+        tx.execute(
+            "DELETE FROM message_events WHERE conversation_id = ?1",
             params![id],
         )?;
         tx.execute(
@@ -187,6 +213,7 @@ pub async fn create_conversation(
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, 'chat', ?7)",
             params![id, title, created_at, selected_model, selected_provider, normalized_project_root, employee_id],
         )?;
+        mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
     .await?;
@@ -276,29 +303,26 @@ pub async fn list_conversations(
         let mut stmt = conn.prepare(&sql)?;
 
         let rows = stmt
-            .query_map(
-                params![kind, raw, normalized, effective_limit],
-                |row| {
-                    Ok(UnifiedConversationRow {
-                        id: row.get(0)?,
-                        title: row.get(1)?,
-                        created_at: row.get(2)?,
-                        kind: row.get(3)?,
-                        project_root: row.get(4)?,
-                        is_archived: row.get::<_, i32>(5)? != 0,
-                        selected_provider: row.get(6)?,
-                        selected_model: row.get(7)?,
-                        employee_id: row.get(8)?,
-                        agent_type: row.get(9)?,
-                        agent_session_id: row.get(10)?,
-                        agent_cwd: row.get(11)?,
-                        agent_model_id: row.get(12)?,
-                        agent_permission_mode: row.get(13)?,
-                        agent_metadata: row.get(14)?,
-                        project_id: row.get(15)?,
-                    })
-                },
-            )?
+            .query_map(params![kind, raw, normalized, effective_limit], |row| {
+                Ok(UnifiedConversationRow {
+                    id: row.get(0)?,
+                    title: row.get(1)?,
+                    created_at: row.get(2)?,
+                    kind: row.get(3)?,
+                    project_root: row.get(4)?,
+                    is_archived: row.get::<_, i32>(5)? != 0,
+                    selected_provider: row.get(6)?,
+                    selected_model: row.get(7)?,
+                    employee_id: row.get(8)?,
+                    agent_type: row.get(9)?,
+                    agent_session_id: row.get(10)?,
+                    agent_cwd: row.get(11)?,
+                    agent_model_id: row.get(12)?,
+                    agent_permission_mode: row.get(13)?,
+                    agent_metadata: row.get(14)?,
+                    project_id: row.get(15)?,
+                })
+            })?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(rows)
@@ -360,18 +384,21 @@ pub async fn update_conversation(
                 "UPDATE conversations SET title = ?1 WHERE id = ?2",
                 params![t, id],
             )?;
+            mark_sync_upsert(conn, "conversations", &id)?;
         }
         if let Some(m) = selected_model {
             conn.execute(
                 "UPDATE conversations SET selected_model = ?1 WHERE id = ?2",
                 params![m, id],
             )?;
+            mark_sync_upsert(conn, "conversations", &id)?;
         }
         if let Some(p) = selected_provider {
             conn.execute(
                 "UPDATE conversations SET selected_provider = ?1 WHERE id = ?2",
                 params![p, id],
             )?;
+            mark_sync_upsert(conn, "conversations", &id)?;
         }
         Ok(())
     })
@@ -385,6 +412,7 @@ pub async fn archive_conversation(app: AppHandle, id: String) -> Result<(), Stri
             "UPDATE conversations SET is_archived = 1 WHERE id = ?1",
             params![id],
         )?;
+        mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
     .await
@@ -492,6 +520,7 @@ pub async fn create_agent_conversation(
                 normalized_project_root
             ],
         )?;
+        mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
     .await?;
@@ -559,6 +588,7 @@ pub async fn set_agent_conversation_session_id(
             "UPDATE conversations SET agent_session_id = ?1 WHERE id = ?2 AND kind = 'agent'",
             params![agent_session_id, id],
         )?;
+        mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
     .await
@@ -575,6 +605,7 @@ pub async fn set_agent_conversation_title(
             "UPDATE conversations SET title = ?1 WHERE id = ?2 AND kind = 'agent'",
             params![title, id],
         )?;
+        mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
     .await
@@ -591,6 +622,7 @@ pub async fn set_agent_conversation_model_id(
             "UPDATE conversations SET agent_model_id = ?1 WHERE id = ?2 AND kind = 'agent'",
             params![agent_model_id, id],
         )?;
+        mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
     .await
@@ -607,6 +639,7 @@ pub async fn set_agent_conversation_permission_mode(
             "UPDATE conversations SET agent_permission_mode = ?1 WHERE id = ?2 AND kind = 'agent'",
             params![agent_permission_mode, id],
         )?;
+        mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
     .await
@@ -615,10 +648,7 @@ pub async fn set_agent_conversation_permission_mode(
 /// Fetch the persisted composer draft for a thread (#1631).
 /// Survives force-quit so the user never loses unsent text.
 #[tauri::command]
-pub async fn get_thread_draft(
-    app: AppHandle,
-    thread_id: String,
-) -> Result<String, String> {
+pub async fn get_thread_draft(app: AppHandle, thread_id: String) -> Result<String, String> {
     run_db(app, move |conn| {
         let draft: Option<String> = conn
             .query_row(
@@ -646,6 +676,7 @@ pub async fn set_thread_draft(
             "UPDATE conversations SET draft = ?1 WHERE id = ?2",
             params![draft, thread_id],
         )?;
+        mark_sync_upsert(conn, "thread_drafts", &thread_id)?;
         Ok(())
     })
     .await
@@ -719,6 +750,7 @@ pub async fn set_agent_conversation_metadata(
             "UPDATE conversations SET agent_metadata = ?1 WHERE id = ?2 AND kind = 'agent'",
             params![agent_metadata, id],
         )?;
+        mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
     .await
@@ -731,6 +763,7 @@ pub async fn archive_agent_conversation(app: AppHandle, id: String) -> Result<()
             "UPDATE conversations SET is_archived = 1 WHERE id = ?1 AND kind = 'agent'",
             params![id],
         )?;
+        mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
     .await
@@ -814,6 +847,28 @@ pub async fn clear_conversation_history(
     conversation_id: String,
 ) -> Result<(), String> {
     run_db(app, move |conn| {
+        let mut event_stmt =
+            conn.prepare("SELECT id FROM message_events WHERE conversation_id = ?1")?;
+        let event_ids = event_stmt
+            .query_map(params![conversation_id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(event_stmt);
+        let mut message_stmt =
+            conn.prepare("SELECT id FROM messages WHERE conversation_id = ?1")?;
+        let message_ids = message_stmt
+            .query_map(params![conversation_id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(message_stmt);
+        for event_id in &event_ids {
+            enqueue_sync_tombstone(conn, "message_events", event_id)?;
+        }
+        for message_id in &message_ids {
+            enqueue_sync_tombstone(conn, "messages", message_id)?;
+        }
+        conn.execute(
+            "DELETE FROM message_events WHERE conversation_id = ?1",
+            params![conversation_id],
+        )?;
         conn.execute(
             "DELETE FROM messages WHERE conversation_id = ?1",
             params![conversation_id],
@@ -826,6 +881,29 @@ pub async fn clear_conversation_history(
 #[tauri::command]
 pub async fn clear_all_history(app: AppHandle) -> Result<(), String> {
     run_db(app, move |conn| {
+        let conversation_ids = conn
+            .prepare("SELECT id FROM conversations")?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        for id in &conversation_ids {
+            enqueue_sync_tombstone(conn, "thread_drafts", id)?;
+            enqueue_sync_tombstone(conn, "conversations", id)?;
+        }
+        let event_ids = conn
+            .prepare("SELECT id FROM message_events")?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        for id in &event_ids {
+            enqueue_sync_tombstone(conn, "message_events", id)?;
+        }
+        let message_ids = conn
+            .prepare("SELECT id FROM messages")?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        for id in &message_ids {
+            enqueue_sync_tombstone(conn, "messages", id)?;
+        }
+        conn.execute("DELETE FROM message_events", [])?;
         conn.execute("DELETE FROM messages", [])?;
         conn.execute("DELETE FROM conversations", [])?;
         Ok(())
@@ -929,7 +1007,12 @@ mod tests {
         let effective_limit = limit.unwrap_or(-1);
         let mut stmt = conn.prepare(&sql).unwrap();
         stmt.query_map(
-            params![kind, raw_project_root, normalized_project_root, effective_limit],
+            params![
+                kind,
+                raw_project_root,
+                normalized_project_root,
+                effective_limit
+            ],
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )
         .unwrap()
@@ -1029,14 +1112,29 @@ mod tests {
         let rows = list_for_test_full(&conn, None, Some("/tmp/proj"), None, None);
         let ids: Vec<&str> = rows.iter().map(|r| r.0.as_str()).collect();
         // chat-pr, agent-pid, agent-cwd match by the requested project.
-        assert!(ids.contains(&"chat-pr"), "chat-pr should match by project_root");
-        assert!(ids.contains(&"agent-pid"), "agent-pid should match by project_id");
-        assert!(ids.contains(&"agent-cwd"), "agent-cwd should match by agent_cwd");
+        assert!(
+            ids.contains(&"chat-pr"),
+            "chat-pr should match by project_root"
+        );
+        assert!(
+            ids.contains(&"agent-pid"),
+            "agent-pid should match by project_id"
+        );
+        assert!(
+            ids.contains(&"agent-cwd"),
+            "agent-cwd should match by agent_cwd"
+        );
         // chat-null is included because the chat bucket always surfaces
         // unscoped chat rows.
-        assert!(ids.contains(&"chat-null"), "chat with NULL project_root should surface");
+        assert!(
+            ids.contains(&"chat-null"),
+            "chat with NULL project_root should surface"
+        );
         // chat-other is in a different project and must be excluded.
-        assert!(!ids.contains(&"chat-other"), "chat in other project must be filtered out");
+        assert!(
+            !ids.contains(&"chat-other"),
+            "chat in other project must be filtered out"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/history_sync.rs
+++ b/src-tauri/src/commands/history_sync.rs
@@ -1,0 +1,45 @@
+// ABOUTME: Tauri commands for SerenDB chat and meeting history sync.
+// ABOUTME: Thin command layer over services::history_sync.
+
+use crate::services::history_sync::{
+    HistorySyncConfig, HistorySyncSummary, run_history_sync_once, wipe_remote_history,
+};
+use tauri::AppHandle;
+
+#[tauri::command]
+pub async fn history_sync_run_now(
+    app: AppHandle,
+    project_id: String,
+    branch_id: String,
+    database_name: String,
+) -> Result<HistorySyncSummary, String> {
+    run_history_sync_once(
+        app,
+        HistorySyncConfig {
+            project_id,
+            branch_id,
+            database_name,
+        },
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn history_sync_wipe_remote(
+    app: AppHandle,
+    project_id: String,
+    branch_id: String,
+    database_name: String,
+    confirmation: String,
+) -> Result<(), String> {
+    wipe_remote_history(
+        app,
+        HistorySyncConfig {
+            project_id,
+            branch_id,
+            database_name,
+        },
+        confirmation,
+    )
+    .await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ pub mod commands {
     pub mod context_intelligence;
     pub mod employees_archive;
     pub mod gateway_http;
+    pub mod history_sync;
     pub mod indexing;
     pub mod memory;
     pub mod model_context_cache;
@@ -29,6 +30,7 @@ pub mod services {
     pub mod chunker;
     pub mod context_intelligence;
     pub mod database;
+    pub mod history_sync;
     pub mod indexer;
     pub mod vector_store;
 }
@@ -796,6 +798,8 @@ pub fn run() {
             // Rust-backed Gateway API bridge
             commands::gateway_http::gateway_http_start,
             commands::gateway_http::gateway_http_cancel,
+            commands::history_sync::history_sync_run_now,
+            commands::history_sync::history_sync_wipe_remote,
             // Meeting Mode persistence commands
             commands::audio::create_meeting,
             commands::audio::get_meeting,

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -11,6 +11,14 @@ use tauri::{AppHandle, Manager};
 use uuid::Uuid;
 
 pub const MAX_MESSAGES_PER_CONVERSATION: i32 = 1000;
+pub const HISTORY_SYNC_TABLES: &[&str] = &[
+    "conversations",
+    "messages",
+    "message_events",
+    "thread_drafts",
+    "meetings",
+    "transcript_segments",
+];
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PersistedMessage {
@@ -123,6 +131,115 @@ pub fn checkpoint_managed_db(app: &AppHandle, reason: &str) {
     }
 }
 
+pub fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+pub fn enqueue_sync_outbox(
+    conn: &Connection,
+    table_name: &str,
+    row_id: &str,
+    op: &str,
+) -> Result<()> {
+    if !HISTORY_SYNC_TABLES.contains(&table_name) {
+        return Err(rusqlite::Error::InvalidParameterName(format!(
+            "unknown sync table: {table_name}"
+        )));
+    }
+    if op != "upsert" && op != "tombstone" {
+        return Err(rusqlite::Error::InvalidParameterName(format!(
+            "unknown sync operation: {op}"
+        )));
+    }
+    conn.execute(
+        "INSERT INTO sync_outbox (table_name, row_id, op, enqueued_at)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(table_name, row_id) DO UPDATE SET
+             op = excluded.op,
+             enqueued_at = excluded.enqueued_at",
+        rusqlite::params![table_name, row_id, op, now_ms()],
+    )?;
+    Ok(())
+}
+
+pub fn enqueue_sync_tombstone(conn: &Connection, table_name: &str, row_id: &str) -> Result<()> {
+    enqueue_sync_outbox(conn, table_name, row_id, "tombstone")
+}
+
+pub fn mark_sync_upsert(conn: &Connection, table_name: &str, row_id: &str) -> Result<()> {
+    let updated_at = now_ms();
+    match table_name {
+        "conversations" => {
+            conn.execute(
+                "UPDATE conversations
+                 SET row_version = COALESCE(row_version, 1) + 1,
+                     updated_at = ?1,
+                     deleted_at = NULL
+                 WHERE id = ?2",
+                rusqlite::params![updated_at, row_id],
+            )?;
+        }
+        "messages" => {
+            conn.execute(
+                "UPDATE messages
+                 SET row_version = COALESCE(row_version, 1) + 1,
+                     updated_at = ?1,
+                     deleted_at = NULL
+                 WHERE id = ?2",
+                rusqlite::params![updated_at, row_id],
+            )?;
+        }
+        "message_events" => {
+            conn.execute(
+                "UPDATE message_events
+                 SET row_version = COALESCE(row_version, 1) + 1,
+                     updated_at = ?1,
+                     deleted_at = NULL
+                 WHERE id = ?2",
+                rusqlite::params![updated_at, row_id],
+            )?;
+        }
+        "meetings" => {
+            conn.execute(
+                "UPDATE meetings
+                 SET row_version = COALESCE(row_version, 1) + 1,
+                     deleted_at = NULL
+                 WHERE id = ?1",
+                rusqlite::params![row_id],
+            )?;
+        }
+        "transcript_segments" => {
+            conn.execute(
+                "UPDATE transcript_segments
+                 SET row_version = COALESCE(row_version, 1) + 1,
+                     updated_at = ?1,
+                     deleted_at = NULL
+                 WHERE id = ?2",
+                rusqlite::params![updated_at, row_id],
+            )?;
+        }
+        "thread_drafts" => {
+            conn.execute(
+                "UPDATE conversations
+                 SET row_version = COALESCE(row_version, 1) + 1,
+                     updated_at = ?1,
+                     deleted_at = NULL
+                 WHERE id = ?2",
+                rusqlite::params![updated_at, row_id],
+            )?;
+        }
+        _ => {
+            return Err(rusqlite::Error::InvalidParameterName(format!(
+                "unknown sync table: {table_name}"
+            )));
+        }
+    }
+    enqueue_sync_outbox(conn, table_name, row_id, "upsert")
+}
+
 pub fn start_wal_checkpoint_task(app: &AppHandle) {
     let app_handle = app.clone();
     let handle = tauri::async_runtime::spawn(async move {
@@ -143,8 +260,22 @@ pub fn start_wal_checkpoint_task(app: &AppHandle) {
 
 pub fn save_message_record(conn: &Connection, message: &PersistedMessage) -> Result<()> {
     if let Err(err) = conn.execute(
-        "INSERT OR REPLACE INTO messages (id, conversation_id, role, content, model, timestamp, metadata, provider)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        "INSERT INTO messages (
+            id, conversation_id, role, content, model, timestamp, metadata,
+            provider, row_version, updated_at, deleted_at
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, ?6, NULL)
+         ON CONFLICT(id) DO UPDATE SET
+            conversation_id = excluded.conversation_id,
+            role = excluded.role,
+            content = excluded.content,
+            model = excluded.model,
+            timestamp = excluded.timestamp,
+            metadata = excluded.metadata,
+            provider = excluded.provider,
+            row_version = COALESCE(messages.row_version, 1) + 1,
+            updated_at = excluded.updated_at,
+            deleted_at = NULL",
         rusqlite::params![
             message.id,
             message.conversation_id,
@@ -171,17 +302,24 @@ pub fn save_message_record(conn: &Connection, message: &PersistedMessage) -> Res
         message.conversation_id
     );
 
+    enqueue_sync_outbox(conn, "messages", &message.id, "upsert")?;
+
+    let event_id = Uuid::new_v4().to_string();
     conn.execute(
-        "INSERT INTO message_events (id, conversation_id, message_id, event_type, status, metadata, created_at)
-         VALUES (?1, ?2, ?3, 'message_persisted', 'completed', ?4, ?5)",
+        "INSERT INTO message_events (
+            id, conversation_id, message_id, event_type, status, metadata,
+            created_at, row_version, updated_at, deleted_at
+         )
+         VALUES (?1, ?2, ?3, 'message_persisted', 'completed', ?4, ?5, 1, ?5, NULL)",
         rusqlite::params![
-            Uuid::new_v4().to_string(),
+            event_id,
             message.conversation_id,
             message.id,
             message.metadata,
             message.timestamp
         ],
     )?;
+    enqueue_sync_outbox(conn, "message_events", &event_id, "upsert")?;
 
     let count: i32 = conn.query_row(
         "SELECT COUNT(*) FROM messages WHERE conversation_id = ?1",
@@ -189,6 +327,37 @@ pub fn save_message_record(conn: &Connection, message: &PersistedMessage) -> Res
         |row| row.get(0),
     )?;
     if count > MAX_MESSAGES_PER_CONVERSATION {
+        let mut stmt = conn.prepare(
+            "SELECT id FROM messages WHERE conversation_id = ?1 AND id NOT IN (
+                SELECT id FROM messages WHERE conversation_id = ?1 ORDER BY timestamp DESC LIMIT ?2
+            )",
+        )?;
+        let stale_ids = stmt
+            .query_map(
+                rusqlite::params![message.conversation_id, MAX_MESSAGES_PER_CONVERSATION],
+                |row| row.get::<_, String>(0),
+            )?
+            .collect::<Result<Vec<_>>>()?;
+        drop(stmt);
+        let mut event_stmt = conn.prepare("SELECT id FROM message_events WHERE message_id = ?1")?;
+        for stale_id in &stale_ids {
+            let event_ids = event_stmt
+                .query_map(rusqlite::params![stale_id], |row| row.get::<_, String>(0))?
+                .collect::<Result<Vec<_>>>()?;
+            for event_id in event_ids {
+                enqueue_sync_tombstone(conn, "message_events", &event_id)?;
+            }
+            enqueue_sync_tombstone(conn, "messages", stale_id)?;
+        }
+        drop(event_stmt);
+        conn.execute(
+            "DELETE FROM message_events WHERE message_id IN (
+                SELECT id FROM messages WHERE conversation_id = ?1 AND id NOT IN (
+                    SELECT id FROM messages WHERE conversation_id = ?1 ORDER BY timestamp DESC LIMIT ?2
+                )
+            )",
+            rusqlite::params![message.conversation_id, MAX_MESSAGES_PER_CONVERSATION],
+        )?;
         conn.execute(
             "DELETE FROM messages WHERE conversation_id = ?1 AND id NOT IN (
                 SELECT id FROM messages WHERE conversation_id = ?1 ORDER BY timestamp DESC LIMIT ?2
@@ -240,6 +409,142 @@ pub fn init_db(app: &AppHandle) -> Result<Connection> {
     checkpoint_wal(&conn, WalCheckpointMode::Restart)?;
     checkpoint_wal(&conn, WalCheckpointMode::Truncate)?;
     Ok(conn)
+}
+
+fn column_exists(conn: &Connection, table: &str, column: &str) -> bool {
+    conn.prepare(&format!("SELECT {column} FROM {table} LIMIT 1"))
+        .is_ok()
+}
+
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    definition: &str,
+) -> Result<()> {
+    if !column_exists(conn, table, column) {
+        conn.execute(
+            &format!("ALTER TABLE {table} ADD COLUMN {column} {definition}"),
+            [],
+        )?;
+    }
+    Ok(())
+}
+
+fn setup_history_sync_schema(conn: &Connection) -> Result<()> {
+    add_column_if_missing(
+        conn,
+        "conversations",
+        "row_version",
+        "INTEGER NOT NULL DEFAULT 1",
+    )?;
+    add_column_if_missing(conn, "conversations", "deleted_at", "INTEGER")?;
+    add_column_if_missing(conn, "conversations", "synced_at", "INTEGER")?;
+    add_column_if_missing(conn, "conversations", "updated_at", "INTEGER")?;
+    conn.execute(
+        "UPDATE conversations
+         SET updated_at = created_at
+         WHERE updated_at IS NULL OR updated_at = 0",
+        [],
+    )
+    .ok();
+
+    add_column_if_missing(
+        conn,
+        "messages",
+        "row_version",
+        "INTEGER NOT NULL DEFAULT 1",
+    )?;
+    add_column_if_missing(conn, "messages", "deleted_at", "INTEGER")?;
+    add_column_if_missing(conn, "messages", "synced_at", "INTEGER")?;
+    add_column_if_missing(conn, "messages", "updated_at", "INTEGER")?;
+    conn.execute(
+        "UPDATE messages
+         SET updated_at = timestamp
+         WHERE updated_at IS NULL OR updated_at = 0",
+        [],
+    )
+    .ok();
+
+    add_column_if_missing(
+        conn,
+        "message_events",
+        "row_version",
+        "INTEGER NOT NULL DEFAULT 1",
+    )?;
+    add_column_if_missing(conn, "message_events", "deleted_at", "INTEGER")?;
+    add_column_if_missing(conn, "message_events", "synced_at", "INTEGER")?;
+    add_column_if_missing(conn, "message_events", "updated_at", "INTEGER")?;
+    conn.execute(
+        "UPDATE message_events
+         SET updated_at = created_at
+         WHERE updated_at IS NULL OR updated_at = 0",
+        [],
+    )
+    .ok();
+
+    add_column_if_missing(
+        conn,
+        "meetings",
+        "row_version",
+        "INTEGER NOT NULL DEFAULT 1",
+    )?;
+    add_column_if_missing(conn, "meetings", "deleted_at", "INTEGER")?;
+    add_column_if_missing(conn, "meetings", "synced_at", "INTEGER")?;
+    add_column_if_missing(conn, "meetings", "updated_at", "INTEGER")?;
+    conn.execute(
+        "UPDATE meetings
+         SET updated_at = created_at
+         WHERE updated_at IS NULL OR updated_at = 0",
+        [],
+    )
+    .ok();
+
+    add_column_if_missing(
+        conn,
+        "transcript_segments",
+        "row_version",
+        "INTEGER NOT NULL DEFAULT 1",
+    )?;
+    add_column_if_missing(conn, "transcript_segments", "deleted_at", "INTEGER")?;
+    add_column_if_missing(conn, "transcript_segments", "synced_at", "INTEGER")?;
+    add_column_if_missing(conn, "transcript_segments", "updated_at", "INTEGER")?;
+    conn.execute(
+        "UPDATE transcript_segments
+         SET updated_at = created_at
+         WHERE updated_at IS NULL OR updated_at = 0",
+        [],
+    )
+    .ok();
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS sync_outbox (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            table_name TEXT NOT NULL,
+            row_id TEXT NOT NULL,
+            op TEXT NOT NULL,
+            enqueued_at INTEGER NOT NULL,
+            conflict INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(table_name, row_id)
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sync_outbox_order
+         ON sync_outbox(id ASC)",
+        [],
+    )
+    .ok();
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS history_sync_state (
+            table_name TEXT PRIMARY KEY,
+            last_pulled_version INTEGER NOT NULL DEFAULT 0,
+            first_backfill_completed INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL
+        )",
+        [],
+    )?;
+    Ok(())
 }
 
 /// Create tables and run migrations on a connection.
@@ -768,6 +1073,8 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
     )
     .ok();
 
+    setup_history_sync_schema(conn)?;
+
     // Persisted context-window observations keyed by (provider, model_id).
     // Populated from CLI prompt-completion metadata so the catalog does not
     // need to be edited every time a new model ships.
@@ -907,8 +1214,8 @@ fn migrate_orphan_messages(conn: &Connection) -> Result<()> {
             .as_millis() as i64;
 
         conn.execute(
-            "INSERT OR IGNORE INTO conversations (id, title, created_at, is_archived)
-             VALUES (?1, ?2, ?3, 0)",
+            "INSERT OR IGNORE INTO conversations (id, title, created_at, is_archived, updated_at)
+             VALUES (?1, ?2, ?3, 0, ?3)",
             rusqlite::params![default_id, "Previous Chat", now],
         )?;
 
@@ -979,6 +1286,93 @@ mod tests {
             )
             .unwrap();
         assert_eq!(event_count, 2);
+    }
+
+    #[test]
+    fn save_message_record_prune_tombstones_message_events() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at) VALUES ('c1', 'Chat', 1000)",
+            [],
+        )
+        .unwrap();
+
+        for idx in 0..=MAX_MESSAGES_PER_CONVERSATION {
+            save_message_record(
+                &conn,
+                &PersistedMessage {
+                    id: format!("m{idx}"),
+                    conversation_id: "c1".to_string(),
+                    role: "user".to_string(),
+                    content: format!("message {idx}"),
+                    model: None,
+                    timestamp: 2000 + i64::from(idx),
+                    metadata: None,
+                    provider: None,
+                },
+            )
+            .unwrap();
+        }
+
+        let stale_message_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM messages WHERE id = 'm0'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        let stale_event_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM message_events WHERE message_id = 'm0'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let event_tombstones: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sync_outbox
+                 WHERE table_name = 'message_events' AND op = 'tombstone'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(stale_message_count, 0);
+        assert_eq!(stale_event_count, 0);
+        assert!(event_tombstones >= 1);
+    }
+
+    #[test]
+    fn mark_sync_upsert_thread_draft_refreshes_snapshot_version() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, updated_at, row_version)
+             VALUES ('c1', 'Chat', 1000, 1000, 1)",
+            [],
+        )
+        .unwrap();
+
+        mark_sync_upsert(&conn, "thread_drafts", "c1").unwrap();
+
+        let (row_version, updated_at): (i64, i64) = conn
+            .query_row(
+                "SELECT row_version, updated_at FROM conversations WHERE id = 'c1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        let outbox_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sync_outbox
+                 WHERE table_name = 'thread_drafts' AND row_id = 'c1' AND op = 'upsert'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(row_version, 2);
+        assert!(updated_at >= 1000);
+        assert_eq!(outbox_count, 1);
     }
 
     #[test]

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -1,0 +1,1603 @@
+// ABOUTME: Bidirectional chat and meeting history sync to the user's SerenDB branch.
+// ABOUTME: Keeps local SQLite as the fast path and mirrors durable text rows to Postgres.
+
+use postgres::{Client as PgClient, Row as PgRow};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tauri::{AppHandle, Manager};
+use tauri_plugin_store::StoreExt;
+
+use crate::auth;
+use crate::services::database::{DbPool, HISTORY_SYNC_TABLES, now_ms};
+
+const GATEWAY_BASE_URL: &str = "https://api.serendb.com/publishers/seren-db";
+const HISTORY_SYNC_STORE: &str = "history_sync.json";
+const CONNECTION_STRING_KEY: &str = "connection_string";
+const CONNECTION_STRING_CACHED_AT_KEY: &str = "connection_string_cached_at";
+const CONNECTION_TTL_MS: i64 = 24 * 60 * 60 * 1000;
+const MAX_SYNC_PAYLOAD_BYTES: usize = 2 * 1024 * 1024;
+
+const PULL_ORDER: &[&str] = &[
+    "conversations",
+    "messages",
+    "message_events",
+    "thread_drafts",
+    "meetings",
+    "transcript_segments",
+];
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HistorySyncConfig {
+    pub project_id: String,
+    pub branch_id: String,
+    pub database_name: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HistorySyncSummary {
+    pub pushed: usize,
+    pub pulled: usize,
+    pub backfilled: usize,
+    pub queued: usize,
+    pub conflicts: usize,
+}
+
+#[derive(Debug)]
+struct OutboxItem {
+    id: i64,
+    table_name: String,
+    row_id: String,
+    op: String,
+    enqueued_at: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct DataEnvelope<T> {
+    data: T,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConnectionStringData {
+    connection_string: String,
+}
+
+pub fn remote_schema_sql() -> &'static [&'static str] {
+    &[
+        "CREATE SCHEMA IF NOT EXISTS seren_desktop",
+        "CREATE TABLE IF NOT EXISTS seren_desktop.conversations (
+            id              text PRIMARY KEY,
+            title           text NOT NULL,
+            created_at      bigint NOT NULL,
+            updated_at      bigint NOT NULL,
+            archived_at     bigint,
+            deleted_at      bigint,
+            payload         jsonb NOT NULL,
+            row_version     bigint NOT NULL DEFAULT 1
+        )",
+        "CREATE TABLE IF NOT EXISTS seren_desktop.messages (
+            id              text PRIMARY KEY,
+            conversation_id text NOT NULL REFERENCES seren_desktop.conversations(id) ON DELETE CASCADE,
+            seq             bigint NOT NULL,
+            role            text NOT NULL,
+            content         text,
+            created_at      bigint NOT NULL,
+            updated_at      bigint NOT NULL,
+            deleted_at      bigint,
+            payload         jsonb NOT NULL,
+            row_version     bigint NOT NULL DEFAULT 1,
+            UNIQUE (conversation_id, seq)
+        )",
+        "CREATE TABLE IF NOT EXISTS seren_desktop.message_events (
+            id              text PRIMARY KEY,
+            conversation_id text NOT NULL REFERENCES seren_desktop.conversations(id) ON DELETE CASCADE,
+            message_id      text NOT NULL REFERENCES seren_desktop.messages(id) ON DELETE CASCADE,
+            event_type      text NOT NULL,
+            status          text NOT NULL,
+            payload         jsonb NOT NULL,
+            created_at      bigint NOT NULL,
+            updated_at      bigint NOT NULL,
+            deleted_at      bigint,
+            row_version     bigint NOT NULL DEFAULT 1
+        )",
+        "CREATE TABLE IF NOT EXISTS seren_desktop.thread_drafts (
+            conversation_id text PRIMARY KEY REFERENCES seren_desktop.conversations(id) ON DELETE CASCADE,
+            text            text NOT NULL,
+            updated_at      bigint NOT NULL,
+            row_version     bigint NOT NULL DEFAULT 1
+        )",
+        "CREATE TABLE IF NOT EXISTS seren_desktop.meetings (
+            id                      text PRIMARY KEY,
+            title                   text NOT NULL,
+            source_app              text,
+            started_at              bigint NOT NULL,
+            ended_at                bigint,
+            status                  text NOT NULL,
+            template_id             text,
+            routed_skill_slug       text,
+            agent_conversation_id   text REFERENCES seren_desktop.conversations(id) ON DELETE SET NULL,
+            notes_markdown          text,
+            notes_struct_json       jsonb,
+            archived_at             bigint,
+            deleted_at              bigint,
+            created_at              bigint NOT NULL,
+            updated_at              bigint NOT NULL,
+            payload                 jsonb NOT NULL DEFAULT '{}'::jsonb,
+            row_version             bigint NOT NULL DEFAULT 1
+        )",
+        "CREATE TABLE IF NOT EXISTS seren_desktop.transcript_segments (
+            id              text PRIMARY KEY,
+            meeting_id      text NOT NULL REFERENCES seren_desktop.meetings(id) ON DELETE CASCADE,
+            seq             bigint NOT NULL,
+            speaker         text NOT NULL,
+            text            text NOT NULL,
+            start_ms        bigint NOT NULL,
+            end_ms          bigint NOT NULL,
+            status          text NOT NULL,
+            created_at      bigint NOT NULL,
+            updated_at      bigint NOT NULL,
+            deleted_at      bigint,
+            payload         jsonb NOT NULL,
+            row_version     bigint NOT NULL DEFAULT 1,
+            UNIQUE (meeting_id, seq)
+        )",
+        "CREATE TABLE IF NOT EXISTS seren_desktop.sync_state (
+            table_name      text NOT NULL,
+            device_id       text NOT NULL,
+            last_pulled_at  bigint NOT NULL,
+            PRIMARY KEY (table_name, device_id)
+        )",
+        "CREATE INDEX IF NOT EXISTS idx_seren_desktop_messages_conversation
+            ON seren_desktop.messages(conversation_id, seq)",
+        "CREATE INDEX IF NOT EXISTS idx_seren_desktop_message_events_message
+            ON seren_desktop.message_events(message_id, created_at)",
+        "CREATE INDEX IF NOT EXISTS idx_seren_desktop_segments_meeting
+            ON seren_desktop.transcript_segments(meeting_id, seq)",
+    ]
+}
+
+pub async fn run_history_sync_once(
+    app: AppHandle,
+    config: HistorySyncConfig,
+) -> Result<HistorySyncSummary, String> {
+    let mut client = open_remote_client(&app, &config).await?;
+    ensure_remote_schema(&mut client)?;
+
+    let backfilled = with_local_db(&app, enqueue_initial_backfill)?;
+    let pushed = push_outbox(&app, &mut client)?;
+    let pulled = pull_remote(&app, &mut client)?;
+    let (queued, conflicts) = with_local_db(&app, |conn| {
+        Ok((
+            conn.query_row("SELECT COUNT(*) FROM sync_outbox", [], |row| {
+                row.get::<_, i64>(0)
+            })? as usize,
+            conn.query_row(
+                "SELECT COUNT(*) FROM sync_outbox WHERE conflict = 1",
+                [],
+                |row| row.get::<_, i64>(0),
+            )? as usize,
+        ))
+    })?;
+
+    Ok(HistorySyncSummary {
+        pushed,
+        pulled,
+        backfilled,
+        queued,
+        conflicts,
+    })
+}
+
+pub async fn wipe_remote_history(
+    app: AppHandle,
+    config: HistorySyncConfig,
+    confirmation: String,
+) -> Result<(), String> {
+    if confirmation != config.database_name {
+        return Err(format!(
+            "Type {name} to wipe the remote history copy",
+            name = config.database_name
+        ));
+    }
+    let mut client = open_remote_client(&app, &config).await?;
+    client
+        .execute("DROP SCHEMA IF EXISTS seren_desktop CASCADE", &[])
+        .map_err(|err| err.to_string())?;
+    ensure_remote_schema(&mut client)?;
+    Ok(())
+}
+
+fn ensure_remote_schema(client: &mut PgClient) -> Result<(), String> {
+    for statement in remote_schema_sql() {
+        client
+            .execute(*statement, &[])
+            .map_err(|err| format!("failed to apply history sync schema: {err}"))?;
+    }
+    Ok(())
+}
+
+async fn open_remote_client(
+    app: &AppHandle,
+    config: &HistorySyncConfig,
+) -> Result<PgClient, String> {
+    let connection = get_connection_string(app, config, false).await?;
+    match connect_client(&connection) {
+        Ok(client) => Ok(client),
+        Err(err) if is_refreshable_postgres_error_text(&err) => {
+            let refreshed = get_connection_string(app, config, true).await?;
+            connect_client(&refreshed)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn connect_client(connection_string: &str) -> Result<PgClient, String> {
+    let tls = native_tls::TlsConnector::builder()
+        .build()
+        .map_err(|err| err.to_string())?;
+    let tls = postgres_native_tls::MakeTlsConnector::new(tls);
+    PgClient::connect(connection_string, tls).map_err(|err| err.to_string())
+}
+
+fn is_refreshable_postgres_error_text(err: &str) -> bool {
+    let lower = err.to_lowercase();
+    err.contains("28P01")
+        || err.contains("57P03")
+        || lower.contains("password")
+        || lower.contains("authentication")
+}
+
+async fn get_connection_string(
+    app: &AppHandle,
+    config: &HistorySyncConfig,
+    force_refresh: bool,
+) -> Result<String, String> {
+    let store = app
+        .store(HISTORY_SYNC_STORE)
+        .map_err(|err| format!("failed to open history sync store: {err}"))?;
+    let now = now_ms();
+    if !force_refresh {
+        let cached_at = store
+            .get(CONNECTION_STRING_CACHED_AT_KEY)
+            .and_then(|value| value.as_i64())
+            .unwrap_or(0);
+        if now.saturating_sub(cached_at) < CONNECTION_TTL_MS {
+            if let Some(connection) = store
+                .get(CONNECTION_STRING_KEY)
+                .and_then(|value| value.as_str().map(str::to_string))
+            {
+                return Ok(connection);
+            }
+        }
+    }
+
+    let client = reqwest::Client::new();
+    let url = format!(
+        "{base}/projects/{project}/branches/{branch}/connection-string?pooled=true",
+        base = GATEWAY_BASE_URL,
+        project = config.project_id,
+        branch = config.branch_id
+    );
+    let response = auth::authenticated_request(app, &client, |client, token| {
+        client.get(&url).bearer_auth(token)
+    })
+    .await?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "connection string request failed: HTTP {}",
+            response.status()
+        ));
+    }
+    let envelope: DataEnvelope<ConnectionStringData> = response
+        .json()
+        .await
+        .map_err(|err| format!("connection string response parse failed: {err}"))?;
+    store.set(
+        CONNECTION_STRING_KEY,
+        serde_json::Value::String(envelope.data.connection_string.clone()),
+    );
+    store.set(
+        CONNECTION_STRING_CACHED_AT_KEY,
+        serde_json::Value::Number(now.into()),
+    );
+    store
+        .save()
+        .map_err(|err| format!("failed to save history sync connection cache: {err}"))?;
+    Ok(envelope.data.connection_string)
+}
+
+fn with_local_db<T>(
+    app: &AppHandle,
+    task: impl FnOnce(&Connection) -> rusqlite::Result<T>,
+) -> Result<T, String> {
+    let pool = app.state::<DbPool>();
+    pool.with_connection(task)
+}
+
+fn enqueue_initial_backfill(conn: &Connection) -> rusqlite::Result<usize> {
+    let completed: i64 = conn
+        .query_row(
+            "SELECT MAX(first_backfill_completed) FROM history_sync_state",
+            [],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()?
+        .flatten()
+        .unwrap_or(0);
+    if completed != 0 {
+        return Ok(0);
+    }
+
+    let mut count = 0usize;
+    for table in HISTORY_SYNC_TABLES {
+        match *table {
+            "thread_drafts" => {
+                count += enqueue_rows(
+                    conn,
+                    table,
+                    "SELECT id FROM conversations WHERE draft IS NOT NULL AND draft <> ''",
+                )?;
+            }
+            _ => {
+                count += enqueue_rows(conn, table, &format!("SELECT id FROM {table}"))?;
+            }
+        }
+    }
+    for table in HISTORY_SYNC_TABLES {
+        conn.execute(
+            "INSERT INTO history_sync_state
+                (table_name, last_pulled_version, first_backfill_completed, updated_at)
+             VALUES (?1, 0, 1, ?2)
+             ON CONFLICT(table_name) DO UPDATE SET
+                first_backfill_completed = 1,
+                updated_at = excluded.updated_at",
+            params![table, now_ms()],
+        )?;
+    }
+    Ok(count)
+}
+
+fn enqueue_rows(conn: &Connection, table_name: &str, query: &str) -> rusqlite::Result<usize> {
+    let mut stmt = conn.prepare(query)?;
+    let ids = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(stmt);
+    for id in &ids {
+        crate::services::database::enqueue_sync_outbox(conn, table_name, id, "upsert")?;
+    }
+    Ok(ids.len())
+}
+
+fn push_outbox(app: &AppHandle, client: &mut PgClient) -> Result<usize, String> {
+    let mut pushed = 0usize;
+    loop {
+        let batch = with_local_db(app, read_outbox_batch)?;
+        if batch.is_empty() {
+            break;
+        }
+        for item in batch {
+            if item.op == "tombstone" {
+                push_tombstone(client, &item)?;
+                clear_outbox_item(app, item.id)?;
+                pushed += 1;
+                continue;
+            }
+
+            let pushed_row = match item.table_name.as_str() {
+                "conversations" => {
+                    if let Some(row) =
+                        with_local_db(app, |conn| load_conversation(conn, &item.row_id))?
+                    {
+                        push_conversation(client, row)?;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                "messages" => {
+                    if let Some(row) = with_local_db(app, |conn| load_message(conn, &item.row_id))?
+                    {
+                        push_message(client, row)?;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                "message_events" => {
+                    if let Some(row) =
+                        with_local_db(app, |conn| load_message_event(conn, &item.row_id))?
+                    {
+                        push_message_event(client, row)?;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                "thread_drafts" => {
+                    if let Some(row) =
+                        with_local_db(app, |conn| load_thread_draft(conn, &item.row_id))?
+                    {
+                        push_thread_draft(client, row)?;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                "meetings" => {
+                    if let Some(row) = with_local_db(app, |conn| load_meeting(conn, &item.row_id))?
+                    {
+                        push_meeting(client, row)?;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                "transcript_segments" => {
+                    if let Some(row) =
+                        with_local_db(app, |conn| load_transcript_segment(conn, &item.row_id))?
+                    {
+                        push_transcript_segment(client, row)?;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            };
+            clear_outbox_item(app, item.id)?;
+            if pushed_row {
+                mark_synced(app, &item.table_name, &item.row_id)?;
+                pushed += 1;
+            }
+        }
+    }
+    Ok(pushed)
+}
+
+fn read_outbox_batch(conn: &Connection) -> rusqlite::Result<Vec<OutboxItem>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, table_name, row_id, op, enqueued_at
+         FROM sync_outbox
+         ORDER BY id ASC
+         LIMIT 500",
+    )?;
+    stmt.query_map([], |row| {
+        Ok(OutboxItem {
+            id: row.get(0)?,
+            table_name: row.get(1)?,
+            row_id: row.get(2)?,
+            op: row.get(3)?,
+            enqueued_at: row.get(4)?,
+        })
+    })?
+    .collect()
+}
+
+fn clear_outbox_item(app: &AppHandle, id: i64) -> Result<(), String> {
+    with_local_db(app, |conn| {
+        conn.execute("DELETE FROM sync_outbox WHERE id = ?1", params![id])?;
+        Ok(())
+    })
+}
+
+fn mark_synced(app: &AppHandle, table_name: &str, row_id: &str) -> Result<(), String> {
+    with_local_db(app, |conn| {
+        let sql = match table_name {
+            "conversations" => "UPDATE conversations SET synced_at = ?1 WHERE id = ?2",
+            "messages" => "UPDATE messages SET synced_at = ?1 WHERE id = ?2",
+            "message_events" => "UPDATE message_events SET synced_at = ?1 WHERE id = ?2",
+            "meetings" => "UPDATE meetings SET synced_at = ?1 WHERE id = ?2",
+            "transcript_segments" => "UPDATE transcript_segments SET synced_at = ?1 WHERE id = ?2",
+            "thread_drafts" => "UPDATE conversations SET synced_at = ?1 WHERE id = ?2",
+            _ => return Ok(()),
+        };
+        conn.execute(sql, params![now_ms(), row_id])?;
+        Ok(())
+    })
+}
+
+fn push_tombstone(client: &mut PgClient, item: &OutboxItem) -> Result<(), String> {
+    let deleted_at = item.enqueued_at;
+    match item.table_name.as_str() {
+        "conversations" => {
+            client
+                .execute(
+                    "UPDATE seren_desktop.conversations
+                     SET deleted_at = $2, row_version = row_version + 1
+                     WHERE id = $1",
+                    &[&item.row_id, &deleted_at],
+                )
+                .map_err(|err| err.to_string())?;
+            client
+                .execute(
+                    "UPDATE seren_desktop.messages
+                     SET deleted_at = $2, row_version = row_version + 1
+                     WHERE conversation_id = $1",
+                    &[&item.row_id, &deleted_at],
+                )
+                .map_err(|err| err.to_string())?;
+            client
+                .execute(
+                    "UPDATE seren_desktop.message_events
+                     SET deleted_at = $2, row_version = row_version + 1
+                     WHERE conversation_id = $1",
+                    &[&item.row_id, &deleted_at],
+                )
+                .map_err(|err| err.to_string())?;
+            client
+                .execute(
+                    "DELETE FROM seren_desktop.thread_drafts WHERE conversation_id = $1",
+                    &[&item.row_id],
+                )
+                .map_err(|err| err.to_string())?;
+        }
+        "messages" => {
+            update_deleted_at(client, "messages", &item.row_id, deleted_at)?;
+            client
+                .execute(
+                    "UPDATE seren_desktop.message_events
+                     SET deleted_at = $2, row_version = row_version + 1
+                     WHERE message_id = $1",
+                    &[&item.row_id, &deleted_at],
+                )
+                .map_err(|err| err.to_string())?;
+        }
+        "meetings" => {
+            update_deleted_at(client, "meetings", &item.row_id, deleted_at)?;
+            client
+                .execute(
+                    "UPDATE seren_desktop.transcript_segments
+                     SET deleted_at = $2, row_version = row_version + 1
+                     WHERE meeting_id = $1",
+                    &[&item.row_id, &deleted_at],
+                )
+                .map_err(|err| err.to_string())?;
+        }
+        "thread_drafts" => {
+            client
+                .execute(
+                    "DELETE FROM seren_desktop.thread_drafts WHERE conversation_id = $1",
+                    &[&item.row_id],
+                )
+                .map_err(|err| err.to_string())?;
+        }
+        "message_events" | "transcript_segments" => {
+            update_deleted_at(client, &item.table_name, &item.row_id, deleted_at)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn update_deleted_at(
+    client: &mut PgClient,
+    table_name: &str,
+    row_id: &str,
+    deleted_at: i64,
+) -> Result<(), String> {
+    let sql = format!(
+        "UPDATE seren_desktop.{table_name}
+         SET deleted_at = $2, row_version = row_version + 1
+         WHERE id = $1"
+    );
+    client
+        .execute(&sql, &[&row_id, &deleted_at])
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ConversationRow {
+    id: String,
+    title: String,
+    created_at: i64,
+    updated_at: i64,
+    archived_at: Option<i64>,
+    deleted_at: Option<i64>,
+    payload: Value,
+    row_version: i64,
+}
+
+fn load_conversation(conn: &Connection, id: &str) -> rusqlite::Result<Option<ConversationRow>> {
+    conn.query_row(
+        "SELECT id, title, created_at, COALESCE(updated_at, created_at),
+                CASE WHEN is_archived = 1 THEN COALESCE(updated_at, created_at) ELSE NULL END,
+                deleted_at, row_version, selected_model, selected_provider, project_root,
+                is_archived, kind, agent_type, agent_session_id, agent_cwd, agent_model_id,
+                agent_permission_mode, agent_metadata, project_id, employee_id, draft
+         FROM conversations
+         WHERE id = ?1",
+        params![id],
+        |row| {
+            let payload = checked_payload(json!({
+                "selected_model": row.get::<_, Option<String>>(7)?,
+                "selected_provider": row.get::<_, Option<String>>(8)?,
+                "project_root": row.get::<_, Option<String>>(9)?,
+                "is_archived": row.get::<_, i64>(10)? != 0,
+                "kind": row.get::<_, String>(11)?,
+                "agent_type": row.get::<_, Option<String>>(12)?,
+                "agent_session_id": row.get::<_, Option<String>>(13)?,
+                "agent_cwd": row.get::<_, Option<String>>(14)?,
+                "agent_model_id": row.get::<_, Option<String>>(15)?,
+                "agent_permission_mode": row.get::<_, Option<String>>(16)?,
+                "agent_metadata": parse_json_opt(row.get::<_, Option<String>>(17)?),
+                "project_id": row.get::<_, Option<String>>(18)?,
+                "employee_id": row.get::<_, Option<String>>(19)?,
+                "draft": row.get::<_, Option<String>>(20)?,
+            }))
+            .map_err(to_sqlite_invalid)?;
+            Ok(ConversationRow {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                created_at: row.get(2)?,
+                updated_at: row.get(3)?,
+                archived_at: row.get(4)?,
+                deleted_at: row.get(5)?,
+                row_version: row.get(6)?,
+                payload,
+            })
+        },
+    )
+    .optional()
+}
+
+fn push_conversation(client: &mut PgClient, row: ConversationRow) -> Result<(), String> {
+    client
+        .execute(
+            "INSERT INTO seren_desktop.conversations
+            (id, title, created_at, updated_at, archived_at, deleted_at, payload, row_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         ON CONFLICT(id) DO UPDATE SET
+            title = excluded.title,
+            updated_at = excluded.updated_at,
+            archived_at = excluded.archived_at,
+            deleted_at = excluded.deleted_at,
+            payload = excluded.payload,
+            row_version = excluded.row_version
+         WHERE excluded.row_version >= seren_desktop.conversations.row_version",
+            &[
+                &row.id,
+                &row.title,
+                &row.created_at,
+                &row.updated_at,
+                &row.archived_at,
+                &row.deleted_at,
+                &row.payload,
+                &row.row_version,
+            ],
+        )
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct MessageRow {
+    id: String,
+    conversation_id: String,
+    seq: i64,
+    role: String,
+    content: String,
+    created_at: i64,
+    updated_at: i64,
+    deleted_at: Option<i64>,
+    payload: Value,
+    row_version: i64,
+}
+
+fn load_message(conn: &Connection, id: &str) -> rusqlite::Result<Option<MessageRow>> {
+    conn.query_row(
+        "WITH ordered AS (
+            SELECT id,
+                   ROW_NUMBER() OVER (PARTITION BY conversation_id ORDER BY timestamp ASC, id ASC) AS seq
+            FROM messages
+            WHERE conversation_id = (SELECT conversation_id FROM messages WHERE id = ?1)
+        )
+         SELECT m.id, m.conversation_id, o.seq, m.role, m.content, m.timestamp,
+                COALESCE(m.updated_at, m.timestamp), m.deleted_at, m.row_version,
+                m.model, m.metadata, m.provider
+         FROM messages m
+         JOIN ordered o ON o.id = m.id
+         WHERE m.id = ?1",
+        params![id],
+        |row| {
+            let payload = checked_payload(json!({
+                "model": row.get::<_, Option<String>>(9)?,
+                "metadata": parse_json_opt(row.get::<_, Option<String>>(10)?),
+                "provider": row.get::<_, Option<String>>(11)?,
+            }))
+            .map_err(to_sqlite_invalid)?;
+            Ok(MessageRow {
+                id: row.get(0)?,
+                conversation_id: row.get(1)?,
+                seq: row.get(2)?,
+                role: row.get(3)?,
+                content: row.get(4)?,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+                deleted_at: row.get(7)?,
+                row_version: row.get(8)?,
+                payload,
+            })
+        },
+    )
+    .optional()
+}
+
+fn push_message(client: &mut PgClient, row: MessageRow) -> Result<(), String> {
+    client
+        .execute(
+        "INSERT INTO seren_desktop.messages
+            (id, conversation_id, seq, role, content, created_at, updated_at, deleted_at, payload, row_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         ON CONFLICT(id) DO UPDATE SET
+            conversation_id = excluded.conversation_id,
+            seq = excluded.seq,
+            role = excluded.role,
+            content = excluded.content,
+            updated_at = excluded.updated_at,
+            deleted_at = excluded.deleted_at,
+            payload = excluded.payload,
+            row_version = excluded.row_version
+         WHERE excluded.row_version >= seren_desktop.messages.row_version",
+            &[
+                &row.id,
+                &row.conversation_id,
+                &row.seq,
+                &row.role,
+                &row.content,
+                &row.created_at,
+                &row.updated_at,
+                &row.deleted_at,
+                &row.payload,
+                &row.row_version,
+            ],
+        )
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct MessageEventRow {
+    id: String,
+    conversation_id: String,
+    message_id: String,
+    event_type: String,
+    status: String,
+    payload: Value,
+    created_at: i64,
+    updated_at: i64,
+    deleted_at: Option<i64>,
+    row_version: i64,
+}
+
+fn load_message_event(conn: &Connection, id: &str) -> rusqlite::Result<Option<MessageEventRow>> {
+    conn.query_row(
+        "SELECT id, conversation_id, message_id, event_type, status, metadata,
+                created_at, COALESCE(updated_at, created_at), deleted_at, row_version
+         FROM message_events
+         WHERE id = ?1",
+        params![id],
+        |row| {
+            let payload = checked_payload(json!({
+                "metadata": parse_json_opt(row.get::<_, Option<String>>(5)?),
+            }))
+            .map_err(to_sqlite_invalid)?;
+            Ok(MessageEventRow {
+                id: row.get(0)?,
+                conversation_id: row.get(1)?,
+                message_id: row.get(2)?,
+                event_type: row.get(3)?,
+                status: row.get(4)?,
+                payload,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+                deleted_at: row.get(8)?,
+                row_version: row.get(9)?,
+            })
+        },
+    )
+    .optional()
+}
+
+fn push_message_event(client: &mut PgClient, row: MessageEventRow) -> Result<(), String> {
+    client
+        .execute(
+        "INSERT INTO seren_desktop.message_events
+            (id, conversation_id, message_id, event_type, status, payload, created_at, updated_at, deleted_at, row_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         ON CONFLICT(id) DO UPDATE SET
+            conversation_id = excluded.conversation_id,
+            message_id = excluded.message_id,
+            event_type = excluded.event_type,
+            status = excluded.status,
+            payload = excluded.payload,
+            updated_at = excluded.updated_at,
+            deleted_at = excluded.deleted_at,
+            row_version = excluded.row_version
+         WHERE excluded.row_version >= seren_desktop.message_events.row_version",
+            &[
+                &row.id,
+                &row.conversation_id,
+                &row.message_id,
+                &row.event_type,
+                &row.status,
+                &row.payload,
+                &row.created_at,
+                &row.updated_at,
+                &row.deleted_at,
+                &row.row_version,
+            ],
+        )
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ThreadDraftRow {
+    conversation_id: String,
+    text: String,
+    updated_at: i64,
+    row_version: i64,
+}
+
+fn load_thread_draft(conn: &Connection, id: &str) -> rusqlite::Result<Option<ThreadDraftRow>> {
+    conn.query_row(
+        "SELECT id, draft, COALESCE(updated_at, created_at), row_version
+         FROM conversations
+         WHERE id = ?1 AND draft IS NOT NULL AND draft <> ''",
+        params![id],
+        |row| {
+            Ok(ThreadDraftRow {
+                conversation_id: row.get(0)?,
+                text: row.get(1)?,
+                updated_at: row.get(2)?,
+                row_version: row.get(3)?,
+            })
+        },
+    )
+    .optional()
+}
+
+fn push_thread_draft(client: &mut PgClient, row: ThreadDraftRow) -> Result<(), String> {
+    client
+        .execute(
+            "INSERT INTO seren_desktop.thread_drafts
+            (conversation_id, text, updated_at, row_version)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT(conversation_id) DO UPDATE SET
+            text = excluded.text,
+            updated_at = excluded.updated_at,
+            row_version = excluded.row_version
+         WHERE excluded.updated_at >= seren_desktop.thread_drafts.updated_at",
+            &[
+                &row.conversation_id,
+                &row.text,
+                &row.updated_at,
+                &row.row_version,
+            ],
+        )
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct MeetingRow {
+    id: String,
+    title: String,
+    source_app: Option<String>,
+    started_at: i64,
+    ended_at: Option<i64>,
+    status: String,
+    template_id: Option<String>,
+    routed_skill_slug: Option<String>,
+    agent_conversation_id: Option<String>,
+    notes_markdown: Option<String>,
+    notes_struct_json: Option<Value>,
+    archived_at: Option<i64>,
+    deleted_at: Option<i64>,
+    created_at: i64,
+    updated_at: i64,
+    payload: Value,
+    row_version: i64,
+}
+
+fn load_meeting(conn: &Connection, id: &str) -> rusqlite::Result<Option<MeetingRow>> {
+    conn.query_row(
+        "SELECT id, title, source_app, started_at, ended_at, status, template_id,
+                routed_skill_slug, agent_conversation_id, notes_markdown, notes_struct_json,
+                CASE WHEN deleted_at IS NULL THEN NULL ELSE deleted_at END, deleted_at,
+                created_at, updated_at, row_version, failure_reason, capture_diagnostics_json
+         FROM meetings
+         WHERE id = ?1",
+        params![id],
+        |row| {
+            let notes_struct_json = parse_json_opt(row.get::<_, Option<String>>(10)?);
+            let payload = checked_payload(json!({
+                "failure_reason": row.get::<_, Option<String>>(16)?,
+                "capture_diagnostics_json": parse_json_opt(row.get::<_, Option<String>>(17)?),
+            }))
+            .map_err(to_sqlite_invalid)?;
+            Ok(MeetingRow {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                source_app: row.get(2)?,
+                started_at: row.get(3)?,
+                ended_at: row.get(4)?,
+                status: row.get(5)?,
+                template_id: row.get(6)?,
+                routed_skill_slug: row.get(7)?,
+                agent_conversation_id: row.get(8)?,
+                notes_markdown: row.get(9)?,
+                notes_struct_json: if notes_struct_json.is_null() {
+                    None
+                } else {
+                    Some(notes_struct_json)
+                },
+                archived_at: row.get(11)?,
+                deleted_at: row.get(12)?,
+                created_at: row.get(13)?,
+                updated_at: row.get(14)?,
+                row_version: row.get(15)?,
+                payload,
+            })
+        },
+    )
+    .optional()
+}
+
+fn push_meeting(client: &mut PgClient, row: MeetingRow) -> Result<(), String> {
+    client
+        .execute(
+            "INSERT INTO seren_desktop.meetings
+            (id, title, source_app, started_at, ended_at, status, template_id,
+             routed_skill_slug, agent_conversation_id, notes_markdown, notes_struct_json,
+             archived_at, deleted_at, created_at, updated_at, payload, row_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+         ON CONFLICT(id) DO UPDATE SET
+            title = excluded.title,
+            source_app = excluded.source_app,
+            ended_at = excluded.ended_at,
+            status = excluded.status,
+            template_id = excluded.template_id,
+            routed_skill_slug = excluded.routed_skill_slug,
+            agent_conversation_id = excluded.agent_conversation_id,
+            notes_markdown = excluded.notes_markdown,
+            notes_struct_json = excluded.notes_struct_json,
+            archived_at = excluded.archived_at,
+            deleted_at = excluded.deleted_at,
+            updated_at = excluded.updated_at,
+            payload = excluded.payload,
+            row_version = excluded.row_version
+         WHERE excluded.row_version >= seren_desktop.meetings.row_version",
+            &[
+                &row.id,
+                &row.title,
+                &row.source_app,
+                &row.started_at,
+                &row.ended_at,
+                &row.status,
+                &row.template_id,
+                &row.routed_skill_slug,
+                &row.agent_conversation_id,
+                &row.notes_markdown,
+                &row.notes_struct_json,
+                &row.archived_at,
+                &row.deleted_at,
+                &row.created_at,
+                &row.updated_at,
+                &row.payload,
+                &row.row_version,
+            ],
+        )
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct TranscriptSegmentRow {
+    id: String,
+    meeting_id: String,
+    seq: i64,
+    speaker: String,
+    text: String,
+    start_ms: i64,
+    end_ms: i64,
+    status: String,
+    created_at: i64,
+    updated_at: i64,
+    deleted_at: Option<i64>,
+    payload: Value,
+    row_version: i64,
+}
+
+fn load_transcript_segment(
+    conn: &Connection,
+    id: &str,
+) -> rusqlite::Result<Option<TranscriptSegmentRow>> {
+    conn.query_row(
+        "SELECT id, meeting_id, seq, speaker, text, start_ms, end_ms, status,
+                created_at, COALESCE(updated_at, created_at), deleted_at, row_version,
+                speaker_label, speaker_source
+         FROM transcript_segments
+         WHERE id = ?1",
+        params![id],
+        |row| {
+            let payload = checked_payload(json!({
+                "speaker_label": row.get::<_, Option<String>>(12)?,
+                "speaker_source": row.get::<_, Option<String>>(13)?,
+            }))
+            .map_err(to_sqlite_invalid)?;
+            Ok(TranscriptSegmentRow {
+                id: row.get(0)?,
+                meeting_id: row.get(1)?,
+                seq: row.get(2)?,
+                speaker: row.get(3)?,
+                text: row.get(4)?,
+                start_ms: row.get(5)?,
+                end_ms: row.get(6)?,
+                status: row.get(7)?,
+                created_at: row.get(8)?,
+                updated_at: row.get(9)?,
+                deleted_at: row.get(10)?,
+                row_version: row.get(11)?,
+                payload,
+            })
+        },
+    )
+    .optional()
+}
+
+fn push_transcript_segment(client: &mut PgClient, row: TranscriptSegmentRow) -> Result<(), String> {
+    client
+        .execute(
+            "INSERT INTO seren_desktop.transcript_segments
+            (id, meeting_id, seq, speaker, text, start_ms, end_ms, status,
+             created_at, updated_at, deleted_at, payload, row_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+         ON CONFLICT(id) DO UPDATE SET
+            meeting_id = excluded.meeting_id,
+            seq = excluded.seq,
+            speaker = excluded.speaker,
+            text = excluded.text,
+            start_ms = excluded.start_ms,
+            end_ms = excluded.end_ms,
+            status = excluded.status,
+            updated_at = excluded.updated_at,
+            deleted_at = excluded.deleted_at,
+            payload = excluded.payload,
+            row_version = excluded.row_version
+         WHERE excluded.row_version >= seren_desktop.transcript_segments.row_version",
+            &[
+                &row.id,
+                &row.meeting_id,
+                &row.seq,
+                &row.speaker,
+                &row.text,
+                &row.start_ms,
+                &row.end_ms,
+                &row.status,
+                &row.created_at,
+                &row.updated_at,
+                &row.deleted_at,
+                &row.payload,
+                &row.row_version,
+            ],
+        )
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+fn pull_remote(app: &AppHandle, client: &mut PgClient) -> Result<usize, String> {
+    let mut pulled = 0usize;
+    for table_name in PULL_ORDER {
+        let since = local_last_pulled(app, table_name)?;
+        let sql = format!(
+            "SELECT * FROM seren_desktop.{table_name}
+             WHERE row_version > $1
+             ORDER BY row_version ASC"
+        );
+        let rows = client
+            .query(&sql, &[&since])
+            .map_err(|err| err.to_string())?;
+        let mut max_version = since;
+        for row in rows {
+            let version: i64 = row.try_get("row_version").map_err(|err| err.to_string())?;
+            max_version = max_version.max(version);
+            apply_remote_row(app, table_name, row)?;
+            pulled += 1;
+        }
+        if max_version > since {
+            set_local_last_pulled(app, table_name, max_version)?;
+        }
+    }
+    Ok(pulled)
+}
+
+fn local_last_pulled(app: &AppHandle, table_name: &str) -> Result<i64, String> {
+    with_local_db(app, |conn| {
+        Ok(conn
+            .query_row(
+                "SELECT last_pulled_version FROM history_sync_state WHERE table_name = ?1",
+                params![table_name],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?
+            .unwrap_or(0))
+    })
+}
+
+fn set_local_last_pulled(app: &AppHandle, table_name: &str, version: i64) -> Result<(), String> {
+    with_local_db(app, |conn| {
+        conn.execute(
+            "INSERT INTO history_sync_state
+                (table_name, last_pulled_version, first_backfill_completed, updated_at)
+             VALUES (?1, ?2, 1, ?3)
+             ON CONFLICT(table_name) DO UPDATE SET
+                last_pulled_version = excluded.last_pulled_version,
+                first_backfill_completed = 1,
+                updated_at = excluded.updated_at",
+            params![table_name, version, now_ms()],
+        )?;
+        Ok(())
+    })
+}
+
+fn apply_remote_row(app: &AppHandle, table_name: &str, row: PgRow) -> Result<(), String> {
+    with_local_db(app, |conn| match table_name {
+        "conversations" => apply_remote_conversation(conn, row),
+        "messages" => apply_remote_message(conn, row),
+        "message_events" => apply_remote_message_event(conn, row),
+        "thread_drafts" => apply_remote_thread_draft(conn, row),
+        "meetings" => apply_remote_meeting(conn, row),
+        "transcript_segments" => apply_remote_transcript_segment(conn, row),
+        _ => Ok(()),
+    })
+}
+
+fn apply_remote_conversation(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
+    let id: String = pg_get(&row, "id")?;
+    let deleted_at: Option<i64> = pg_get(&row, "deleted_at")?;
+    if deleted_at.is_some() {
+        delete_conversation_local(conn, &id)?;
+        return Ok(());
+    }
+    let payload: Value = pg_get(&row, "payload")?;
+    conn.execute(
+        "INSERT INTO conversations (
+            id, title, created_at, is_archived, kind, selected_model,
+            selected_provider, project_root, agent_type, agent_session_id,
+            agent_cwd, agent_model_id, agent_permission_mode, agent_metadata,
+            project_id, employee_id, draft, row_version, updated_at, synced_at, deleted_at
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, NULL)
+         ON CONFLICT(id) DO UPDATE SET
+            title = excluded.title,
+            is_archived = excluded.is_archived,
+            kind = excluded.kind,
+            selected_model = excluded.selected_model,
+            selected_provider = excluded.selected_provider,
+            project_root = excluded.project_root,
+            agent_type = excluded.agent_type,
+            agent_session_id = excluded.agent_session_id,
+            agent_cwd = excluded.agent_cwd,
+            agent_model_id = excluded.agent_model_id,
+            agent_permission_mode = excluded.agent_permission_mode,
+            agent_metadata = excluded.agent_metadata,
+            project_id = excluded.project_id,
+            employee_id = excluded.employee_id,
+            draft = COALESCE(conversations.draft, excluded.draft),
+            row_version = excluded.row_version,
+            updated_at = excluded.updated_at,
+            synced_at = excluded.synced_at,
+            deleted_at = NULL
+         WHERE COALESCE(conversations.row_version, 0) <= excluded.row_version",
+        params![
+            id,
+            pg_get::<String>(&row, "title")?,
+            pg_get::<i64>(&row, "created_at")?,
+            value_bool(&payload, "is_archived") as i64,
+            value_str(&payload, "kind").unwrap_or_else(|| "chat".to_string()),
+            value_opt_str(&payload, "selected_model"),
+            value_opt_str(&payload, "selected_provider"),
+            value_opt_str(&payload, "project_root"),
+            value_opt_str(&payload, "agent_type"),
+            value_opt_str(&payload, "agent_session_id"),
+            value_opt_str(&payload, "agent_cwd"),
+            value_opt_str(&payload, "agent_model_id"),
+            value_opt_str(&payload, "agent_permission_mode"),
+            value_to_string_opt(payload.get("agent_metadata")),
+            value_opt_str(&payload, "project_id"),
+            value_opt_str(&payload, "employee_id"),
+            value_opt_str(&payload, "draft"),
+            pg_get::<i64>(&row, "row_version")?,
+            pg_get::<i64>(&row, "updated_at")?,
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_remote_message(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
+    let id: String = pg_get(&row, "id")?;
+    if pg_get::<Option<i64>>(&row, "deleted_at")?.is_some() {
+        conn.execute(
+            "DELETE FROM message_events WHERE message_id = ?1",
+            params![id],
+        )?;
+        conn.execute("DELETE FROM messages WHERE id = ?1", params![id])?;
+        return Ok(());
+    }
+    let payload: Value = pg_get(&row, "payload")?;
+    conn.execute(
+        "INSERT INTO messages (
+            id, conversation_id, role, content, model, timestamp, metadata,
+            provider, row_version, updated_at, synced_at, deleted_at
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, NULL)
+         ON CONFLICT(id) DO UPDATE SET
+            conversation_id = excluded.conversation_id,
+            role = excluded.role,
+            content = excluded.content,
+            model = excluded.model,
+            timestamp = excluded.timestamp,
+            metadata = excluded.metadata,
+            provider = excluded.provider,
+            row_version = excluded.row_version,
+            updated_at = excluded.updated_at,
+            synced_at = excluded.synced_at,
+            deleted_at = NULL
+         WHERE COALESCE(messages.row_version, 0) <= excluded.row_version",
+        params![
+            id,
+            pg_get::<String>(&row, "conversation_id")?,
+            pg_get::<String>(&row, "role")?,
+            pg_get::<Option<String>>(&row, "content")?.unwrap_or_default(),
+            value_opt_str(&payload, "model"),
+            pg_get::<i64>(&row, "created_at")?,
+            value_to_string_opt(payload.get("metadata")),
+            value_opt_str(&payload, "provider"),
+            pg_get::<i64>(&row, "row_version")?,
+            pg_get::<i64>(&row, "updated_at")?,
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_remote_message_event(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
+    let id: String = pg_get(&row, "id")?;
+    if pg_get::<Option<i64>>(&row, "deleted_at")?.is_some() {
+        conn.execute("DELETE FROM message_events WHERE id = ?1", params![id])?;
+        return Ok(());
+    }
+    let payload: Value = pg_get(&row, "payload")?;
+    conn.execute(
+        "INSERT INTO message_events (
+            id, conversation_id, message_id, event_type, status, metadata,
+            created_at, row_version, updated_at, synced_at, deleted_at
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL)
+         ON CONFLICT(id) DO UPDATE SET
+            conversation_id = excluded.conversation_id,
+            message_id = excluded.message_id,
+            event_type = excluded.event_type,
+            status = excluded.status,
+            metadata = excluded.metadata,
+            row_version = excluded.row_version,
+            updated_at = excluded.updated_at,
+            synced_at = excluded.synced_at,
+            deleted_at = NULL
+         WHERE COALESCE(message_events.row_version, 0) <= excluded.row_version",
+        params![
+            id,
+            pg_get::<String>(&row, "conversation_id")?,
+            pg_get::<String>(&row, "message_id")?,
+            pg_get::<String>(&row, "event_type")?,
+            pg_get::<String>(&row, "status")?,
+            value_to_string_opt(payload.get("metadata")),
+            pg_get::<i64>(&row, "created_at")?,
+            pg_get::<i64>(&row, "row_version")?,
+            pg_get::<i64>(&row, "updated_at")?,
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_remote_thread_draft(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE conversations
+         SET draft = ?1,
+             updated_at = ?2,
+             row_version = MAX(COALESCE(row_version, 1), ?3),
+             synced_at = ?4
+         WHERE id = ?5",
+        params![
+            pg_get::<String>(&row, "text")?,
+            pg_get::<i64>(&row, "updated_at")?,
+            pg_get::<i64>(&row, "row_version")?,
+            now_ms(),
+            pg_get::<String>(&row, "conversation_id")?,
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_remote_meeting(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
+    let id: String = pg_get(&row, "id")?;
+    if pg_get::<Option<i64>>(&row, "deleted_at")?.is_some() {
+        delete_meeting_local(conn, &id)?;
+        return Ok(());
+    }
+    let payload: Value = pg_get(&row, "payload")?;
+    conn.execute(
+        "INSERT INTO meetings (
+            id, title, source_app, started_at, ended_at, status, template_id,
+            routed_skill_slug, agent_conversation_id, notes_markdown,
+            notes_struct_json, failure_reason, capture_diagnostics_json,
+            created_at, updated_at, row_version, synced_at, deleted_at
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, NULL)
+         ON CONFLICT(id) DO UPDATE SET
+            title = excluded.title,
+            source_app = excluded.source_app,
+            ended_at = excluded.ended_at,
+            status = excluded.status,
+            template_id = excluded.template_id,
+            routed_skill_slug = excluded.routed_skill_slug,
+            agent_conversation_id = excluded.agent_conversation_id,
+            notes_markdown = excluded.notes_markdown,
+            notes_struct_json = excluded.notes_struct_json,
+            failure_reason = excluded.failure_reason,
+            capture_diagnostics_json = excluded.capture_diagnostics_json,
+            updated_at = excluded.updated_at,
+            row_version = excluded.row_version,
+            synced_at = excluded.synced_at,
+            deleted_at = NULL
+         WHERE COALESCE(meetings.row_version, 0) <= excluded.row_version",
+        params![
+            id,
+            pg_get::<String>(&row, "title")?,
+            pg_get::<Option<String>>(&row, "source_app")?,
+            pg_get::<i64>(&row, "started_at")?,
+            pg_get::<Option<i64>>(&row, "ended_at")?,
+            pg_get::<String>(&row, "status")?,
+            pg_get::<Option<String>>(&row, "template_id")?,
+            pg_get::<Option<String>>(&row, "routed_skill_slug")?,
+            pg_get::<Option<String>>(&row, "agent_conversation_id")?,
+            pg_get::<Option<String>>(&row, "notes_markdown")?,
+            value_to_string_opt(pg_get::<Option<Value>>(&row, "notes_struct_json")?.as_ref()),
+            value_opt_str(&payload, "failure_reason"),
+            value_to_string_opt(payload.get("capture_diagnostics_json")),
+            pg_get::<i64>(&row, "created_at")?,
+            pg_get::<i64>(&row, "updated_at")?,
+            pg_get::<i64>(&row, "row_version")?,
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_remote_transcript_segment(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
+    let id: String = pg_get(&row, "id")?;
+    if pg_get::<Option<i64>>(&row, "deleted_at")?.is_some() {
+        conn.execute("DELETE FROM transcript_segments WHERE id = ?1", params![id])?;
+        return Ok(());
+    }
+    let payload: Value = pg_get(&row, "payload")?;
+    conn.execute(
+        "INSERT INTO transcript_segments (
+            id, meeting_id, seq, speaker, text, start_ms, end_ms, status,
+            speaker_label, speaker_source, created_at, row_version, updated_at,
+            synced_at, deleted_at
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, NULL)
+         ON CONFLICT(id) DO UPDATE SET
+            meeting_id = excluded.meeting_id,
+            seq = excluded.seq,
+            speaker = excluded.speaker,
+            text = excluded.text,
+            start_ms = excluded.start_ms,
+            end_ms = excluded.end_ms,
+            status = excluded.status,
+            speaker_label = excluded.speaker_label,
+            speaker_source = excluded.speaker_source,
+            row_version = excluded.row_version,
+            updated_at = excluded.updated_at,
+            synced_at = excluded.synced_at,
+            deleted_at = NULL
+         WHERE COALESCE(transcript_segments.row_version, 0) <= excluded.row_version",
+        params![
+            id,
+            pg_get::<String>(&row, "meeting_id")?,
+            pg_get::<i64>(&row, "seq")?,
+            pg_get::<String>(&row, "speaker")?,
+            pg_get::<String>(&row, "text")?,
+            pg_get::<i64>(&row, "start_ms")?,
+            pg_get::<i64>(&row, "end_ms")?,
+            pg_get::<String>(&row, "status")?,
+            value_opt_str(&payload, "speaker_label"),
+            value_opt_str(&payload, "speaker_source"),
+            pg_get::<i64>(&row, "created_at")?,
+            pg_get::<i64>(&row, "row_version")?,
+            pg_get::<i64>(&row, "updated_at")?,
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn delete_conversation_local(conn: &Connection, id: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "DELETE FROM message_events WHERE conversation_id = ?1",
+        params![id],
+    )?;
+    conn.execute(
+        "DELETE FROM messages WHERE conversation_id = ?1",
+        params![id],
+    )?;
+    conn.execute("DELETE FROM conversations WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+fn delete_meeting_local(conn: &Connection, id: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "DELETE FROM transcript_segments WHERE meeting_id = ?1",
+        params![id],
+    )?;
+    conn.execute("DELETE FROM meetings WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+fn checked_payload(value: Value) -> Result<Value, String> {
+    let size = serde_json::to_vec(&value)
+        .map_err(|err| err.to_string())?
+        .len();
+    if size > MAX_SYNC_PAYLOAD_BYTES {
+        return Err(format!(
+            "history sync payload is too large: {size} bytes exceeds {MAX_SYNC_PAYLOAD_BYTES}"
+        ));
+    }
+    Ok(value)
+}
+
+fn parse_json_opt(value: Option<String>) -> Value {
+    match value {
+        Some(raw) => serde_json::from_str(&raw).unwrap_or(Value::String(raw)),
+        None => Value::Null,
+    }
+}
+
+fn value_opt_str(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+fn value_str(value: &Value, key: &str) -> Option<String> {
+    value_opt_str(value, key)
+}
+
+fn value_bool(value: &Value, key: &str) -> bool {
+    value.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
+fn value_to_string_opt(value: Option<&Value>) -> Option<String> {
+    match value {
+        Some(Value::Null) | None => None,
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(other) => Some(other.to_string()),
+    }
+}
+
+fn to_sqlite_invalid(err: String) -> rusqlite::Error {
+    rusqlite::Error::ToSqlConversionFailure(Box::new(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        err,
+    )))
+}
+
+fn pg_get<T>(row: &PgRow, column: &str) -> rusqlite::Result<T>
+where
+    T: postgres::types::FromSqlOwned,
+{
+    row.try_get(column).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(err))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::database::{PersistedMessage, save_message_record, setup_schema};
+
+    #[test]
+    fn remote_schema_has_no_audio_binary_columns() {
+        let ddl = remote_schema_sql().join("\n").to_lowercase();
+        for forbidden in ["bytea", " blob", "raw_audio", "audio_chunk", "pcm_frames"] {
+            assert!(
+                !ddl.contains(forbidden),
+                "history sync schema must not contain {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn message_snapshot_preserves_tool_event_metadata_json() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind)
+             VALUES ('c1', 'Chat', 1000, 'chat')",
+            [],
+        )
+        .unwrap();
+        save_message_record(
+            &conn,
+            &PersistedMessage {
+                id: "m1".to_string(),
+                conversation_id: "c1".to_string(),
+                role: "assistant".to_string(),
+                content: "Used a tool".to_string(),
+                model: Some("model".to_string()),
+                timestamp: 2000,
+                metadata: Some(
+                    r#"{"tool_call":{"name":"search","args":{"q":"seren"}}}"#.to_string(),
+                ),
+                provider: Some("seren".to_string()),
+            },
+        )
+        .unwrap();
+
+        let event_id: String = conn
+            .query_row(
+                "SELECT id FROM message_events WHERE message_id = 'm1' LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let event = load_message_event(&conn, &event_id).unwrap().unwrap();
+        assert_eq!(
+            event.payload["metadata"]["tool_call"]["args"]["q"].as_str(),
+            Some("seren")
+        );
+    }
+
+    #[test]
+    fn initial_backfill_enqueues_each_durable_row_once() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind, draft)
+             VALUES ('c1', 'Chat', 1000, 'chat', 'draft')",
+            [],
+        )
+        .unwrap();
+        save_message_record(
+            &conn,
+            &PersistedMessage {
+                id: "m1".to_string(),
+                conversation_id: "c1".to_string(),
+                role: "user".to_string(),
+                content: "hello".to_string(),
+                model: None,
+                timestamp: 1100,
+                metadata: None,
+                provider: None,
+            },
+        )
+        .unwrap();
+
+        conn.execute("DELETE FROM sync_outbox", []).unwrap();
+        let first = enqueue_initial_backfill(&conn).unwrap();
+        let second = enqueue_initial_backfill(&conn).unwrap();
+        let queued: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sync_outbox", [], |row| row.get(0))
+            .unwrap();
+
+        assert!(first >= 3);
+        assert_eq!(second, 0);
+        assert_eq!(queued, first as i64);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ import { autocompleteStore } from "@/stores/autocomplete.store";
 import { chatStore } from "@/stores/chat.store";
 import { fileTreeState, initDefaultRootIfNeeded } from "@/stores/fileTree";
 import { providerStore } from "@/stores/provider.store";
-import { loadAllSettings } from "@/stores/settings.store";
+import { loadAllSettings, settingsState } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
 import { threadStore } from "@/stores/thread.store";
 import {
@@ -223,6 +223,28 @@ function App() {
 
     return isAuth;
   }, authStore.isAuthenticated);
+
+  let historySyncStartedForAuth: string | null = null;
+  createEffect(() => {
+    const isAuth = authStore.isAuthenticated;
+    const settingsLoaded = !settingsState.isLoading;
+    const enabled = settingsState.app.historySyncEnabled;
+
+    untrack(async () => {
+      const { startHistorySync, stopHistorySync } = await import(
+        "@/services/historySync"
+      );
+      if (!settingsLoaded || !isAuth || !enabled) {
+        historySyncStartedForAuth = null;
+        stopHistorySync();
+        return;
+      }
+      const key = "auth-session";
+      if (historySyncStartedForAuth === key) return;
+      historySyncStartedForAuth = key;
+      startHistorySync();
+    });
+  });
 
   // Claude Code auto-memory interceptor — start only after the user is
   // authenticated. The interceptor auto-provisions its own SerenDB project

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -17,6 +17,13 @@ import {
   startClaudeMemoryInterceptor,
   stopClaudeMemoryInterceptor,
 } from "@/services/claudeMemory";
+import {
+  type HistorySyncSummary,
+  runHistorySyncNow,
+  startHistorySync,
+  stopHistorySync,
+  wipeHistorySyncRemote,
+} from "@/services/historySync";
 import { allowsSerenPublicModels } from "@/services/organization-policy";
 import {
   appearanceState,
@@ -55,6 +62,7 @@ type SettingsSection =
   | "agent"
   | "providers"
   | "logins"
+  | "sync"
   | "keys"
   | "toolsets"
   | "editor"
@@ -89,6 +97,13 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
   const [claudeMemoryMessage, setClaudeMemoryMessage] = createSignal<
     string | null
   >(null);
+  const [historySyncBusy, setHistorySyncBusy] = createSignal(false);
+  const [historySyncMessage, setHistorySyncMessage] = createSignal<
+    string | null
+  >(null);
+  const [historySyncSummary, setHistorySyncSummary] =
+    createSignal<HistorySyncSummary | null>(null);
+  const [historySyncWipeConfirm, setHistorySyncWipeConfirm] = createSignal("");
 
   const refreshClaudeMemoryStatus = async () => {
     try {
@@ -159,6 +174,62 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
 
   const handleBooleanChange = (key: keyof Settings, checked: boolean) => {
     settingsStore.set(key, checked as Settings[typeof key]);
+  };
+
+  const historySyncDatabaseName = () =>
+    settingsState.app.historySyncDatabaseName ?? "seren_desktop_history";
+
+  const formatHistorySyncLastSynced = () => {
+    const value = settingsState.app.historySyncLastSyncedAt;
+    if (!value) return "Not synced yet.";
+    return new Date(value).toLocaleString();
+  };
+
+  const describeHistorySyncSummary = (summary: HistorySyncSummary) =>
+    `Pushed ${summary.pushed}, pulled ${summary.pulled}, backfilled ${summary.backfilled}, queued ${summary.queued}.`;
+
+  const handleHistorySyncNow = async () => {
+    setHistorySyncBusy(true);
+    setHistorySyncMessage(null);
+    try {
+      const summary = await runHistorySyncNow();
+      setHistorySyncSummary(summary);
+      setHistorySyncMessage(describeHistorySyncSummary(summary));
+    } catch (err) {
+      setHistorySyncMessage(`Sync failed: ${err}`);
+      console.error("[HistorySync] manual sync failed", err);
+    } finally {
+      setHistorySyncBusy(false);
+    }
+  };
+
+  const handleHistorySyncToggle = async (enabled: boolean) => {
+    handleBooleanChange("historySyncEnabled", enabled);
+    setHistorySyncMessage(null);
+    if (!enabled) {
+      stopHistorySync();
+      return;
+    }
+    startHistorySync();
+    await handleHistorySyncNow();
+  };
+
+  const handleHistorySyncWipe = async () => {
+    setHistorySyncBusy(true);
+    setHistorySyncMessage(null);
+    try {
+      await wipeHistorySyncRemote(historySyncWipeConfirm());
+      handleBooleanChange("historySyncEnabled", false);
+      stopHistorySync();
+      setHistorySyncSummary(null);
+      setHistorySyncWipeConfirm("");
+      setHistorySyncMessage("Remote history copy wiped. Cloud sync is off.");
+    } catch (err) {
+      setHistorySyncMessage(`Remote wipe failed: ${err}`);
+      console.error("[HistorySync] remote wipe failed", err);
+    } finally {
+      setHistorySyncBusy(false);
+    }
   };
 
   const handleThemeChange = (value: Theme) => {
@@ -291,6 +362,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
     { id: "agent", label: "Agent", icon: "🛡️" },
     { id: "providers", label: "AI Providers", icon: "🤖" },
     { id: "logins", label: "Logins", icon: "🔐" },
+    { id: "sync", label: "Cloud Sync", icon: "☁️" },
     { id: "keys", label: "Keys", icon: "🔑" },
     { id: "toolsets", label: "Toolsets", icon: "📦" },
     { id: "editor", label: "Editor", icon: "📝" },
@@ -1975,6 +2047,129 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
             <Show when={claudeMemoryMessage()}>
               <p class="m-0 mt-2 text-[0.78rem] text-muted-foreground">
                 {claudeMemoryMessage()}
+              </p>
+            </Show>
+          </section>
+        </Show>
+
+        <Show when={activeSection() === "sync"}>
+          <section>
+            <h3 class="m-0 mb-2 text-[1.3rem] font-semibold">Cloud Sync</h3>
+            <p class="m-0 mb-6 text-muted-foreground leading-normal">
+              Keep durable chat and meeting history mirrored to SerenDB.
+            </p>
+
+            <div class="flex items-start justify-between gap-4 py-3 border-b border-border">
+              <label class="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={settingsState.app.historySyncEnabled}
+                  disabled={historySyncBusy()}
+                  onChange={(e) =>
+                    handleHistorySyncToggle(e.currentTarget.checked)
+                  }
+                  class="w-[18px] h-[18px] mt-0.5 accent-accent cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                />
+                <span class="flex flex-col gap-0.5">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Sync Chat & Meeting History
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Uses the default SerenDB project named{" "}
+                    <code class="px-1 py-0.5 rounded bg-border/40 text-[0.78rem]">
+                      speech-text
+                    </code>{" "}
+                    and database{" "}
+                    <code class="px-1 py-0.5 rounded bg-border/40 text-[0.78rem]">
+                      {historySyncDatabaseName()}
+                    </code>
+                    .
+                  </span>
+                </span>
+              </label>
+              <button
+                type="button"
+                disabled={
+                  historySyncBusy() || !settingsState.app.historySyncEnabled
+                }
+                class="shrink-0 px-3 py-1.5 text-[0.8rem] rounded-md border border-border-strong bg-transparent hover:bg-border text-foreground cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={handleHistorySyncNow}
+              >
+                {historySyncBusy() ? "Syncing..." : "Sync Now"}
+              </button>
+            </div>
+
+            <div class="flex items-center justify-between gap-4 py-3 border-b border-border">
+              <div class="flex flex-col gap-0.5 min-w-0">
+                <span class="text-[0.85rem] font-medium text-foreground">
+                  Status
+                </span>
+                <span class="text-[0.78rem] text-muted-foreground">
+                  Last synced: {formatHistorySyncLastSynced()}
+                </span>
+                <Show when={historySyncSummary()}>
+                  {(summary) => (
+                    <span class="text-[0.78rem] text-muted-foreground">
+                      Conflicts waiting: {summary().conflicts}
+                    </span>
+                  )}
+                </Show>
+              </div>
+              <div class="text-right text-[0.78rem] text-muted-foreground min-w-[11rem]">
+                <div class="truncate">
+                  Project:{" "}
+                  {settingsState.app.historySyncProjectId ?? "Not provisioned"}
+                </div>
+                <div class="truncate">
+                  Branch:{" "}
+                  {settingsState.app.historySyncBranchId ?? "Not provisioned"}
+                </div>
+              </div>
+            </div>
+
+            <div class="py-3 border-b border-border">
+              <div class="flex items-start justify-between gap-4">
+                <div class="flex flex-col gap-0.5 flex-1">
+                  <span class="text-[0.95rem] font-medium text-foreground">
+                    Wipe Remote Copy
+                  </span>
+                  <span class="text-[0.8rem] text-muted-foreground">
+                    Type{" "}
+                    <code class="px-1 py-0.5 rounded bg-border/40 text-[0.78rem]">
+                      {historySyncDatabaseName()}
+                    </code>{" "}
+                    to remove the remote mirror. Local SQLite history is not
+                    deleted.
+                  </span>
+                </div>
+                <div class="flex items-center gap-2 shrink-0">
+                  <input
+                    type="text"
+                    value={historySyncWipeConfirm()}
+                    onInput={(e) =>
+                      setHistorySyncWipeConfirm(e.currentTarget.value)
+                    }
+                    placeholder={historySyncDatabaseName()}
+                    class="w-[14rem] px-2.5 py-1.5 rounded-md border border-border bg-surface text-[0.82rem] text-foreground outline-none focus:border-accent"
+                  />
+                  <button
+                    type="button"
+                    disabled={
+                      historySyncBusy() ||
+                      historySyncWipeConfirm() !== historySyncDatabaseName()
+                    }
+                    class="px-3 py-1.5 text-[0.8rem] rounded-md border border-destructive/60 bg-destructive/10 text-destructive hover:bg-destructive/15 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                    onClick={handleHistorySyncWipe}
+                  >
+                    Wipe
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <Show when={historySyncMessage()}>
+              <p class="m-0 mt-3 text-[0.78rem] text-muted-foreground">
+                {historySyncMessage()}
               </p>
             </Show>
           </section>

--- a/src/services/databases.ts
+++ b/src/services/databases.ts
@@ -9,6 +9,7 @@ import {
   type Organization,
 } from "@/api";
 import {
+  serenDbCreateBranch as apiCreateBranch,
   serenDbCreateDatabase as apiCreateDatabase,
   serenDbCreateProject as apiCreateProject,
   serenDbDeleteProject as apiDeleteProject,
@@ -118,6 +119,23 @@ export const databases = {
     const branches = data?.data || [];
     console.log("[Databases] Found", branches.length, "branches");
     return branches;
+  },
+
+  /**
+   * Create a new branch in a project.
+   */
+  async createBranch(projectId: string, name: string): Promise<Branch> {
+    console.log("[Databases] Creating branch:", name, "in project:", projectId);
+    const { data, error } = await apiCreateBranch({
+      path: { id: projectId },
+      body: { name, add_endpoint: true },
+      throwOnError: false,
+    });
+    if (error || !data?.data?.branch) {
+      console.error("[Databases] Error creating branch:", error);
+      throw new Error("Failed to create branch");
+    }
+    return this.getBranch(projectId, data.data.branch.id);
   },
 
   /**

--- a/src/services/historySync.ts
+++ b/src/services/historySync.ts
@@ -1,0 +1,191 @@
+// ABOUTME: Frontend orchestration for SerenDB chat and meeting history sync.
+// ABOUTME: Auto-provisions speech-text storage and schedules foreground sync ticks.
+
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+import { waitForDatabaseReady } from "@/services/claudeMemory";
+import { type Branch, databases } from "@/services/databases";
+import { settingsStore } from "@/stores/settings.store";
+
+const HISTORY_SYNC_PROJECT_NAME = "speech-text";
+const HISTORY_SYNC_BRANCH_NAME = "production";
+const HISTORY_SYNC_DATABASE_NAME = "seren_desktop_history";
+const FOREGROUND_SYNC_MS = 15_000;
+const BACKGROUND_SYNC_MS = 60_000;
+
+export interface HistorySyncProvisioning {
+  projectId: string;
+  branchId: string;
+  databaseName: string;
+}
+
+export interface HistorySyncSummary {
+  pushed: number;
+  pulled: number;
+  backfilled: number;
+  queued: number;
+  conflicts: number;
+}
+
+let syncTimer: number | null = null;
+let syncInFlight = false;
+
+function resolveBranch(
+  branches: Branch[],
+  defaultBranchId: string | null | undefined,
+): Branch | undefined {
+  return (
+    branches.find((branch) => branch.name === HISTORY_SYNC_BRANCH_NAME) ??
+    branches.find((branch) => branch.is_default) ??
+    branches.find((branch) => branch.id === defaultBranchId) ??
+    branches[0]
+  );
+}
+
+function syncDelayMs(): number {
+  return document.visibilityState === "hidden"
+    ? BACKGROUND_SYNC_MS
+    : FOREGROUND_SYNC_MS;
+}
+
+function scheduleNextSync(): void {
+  if (syncTimer !== null) {
+    window.clearTimeout(syncTimer);
+  }
+  syncTimer = window.setTimeout(() => {
+    syncTimer = null;
+    void runScheduledSync();
+  }, syncDelayMs());
+}
+
+async function runScheduledSync(): Promise<void> {
+  if (!settingsStore.get("historySyncEnabled")) {
+    stopHistorySync();
+    return;
+  }
+  try {
+    await runHistorySyncNow();
+  } catch (err) {
+    console.warn("[HistorySync] scheduled sync failed", err);
+  } finally {
+    if (settingsStore.get("historySyncEnabled")) {
+      scheduleNextSync();
+    }
+  }
+}
+
+/**
+ * Resolve the SerenDB project + branch + database that stores durable local
+ * history. Idempotent and safe to call before every manual or scheduled sync.
+ */
+export async function ensureHistorySyncProvisioned(): Promise<HistorySyncProvisioning> {
+  const persistedProject = settingsStore.get("historySyncProjectId");
+  const persistedBranch = settingsStore.get("historySyncBranchId");
+  const persistedDb = settingsStore.get("historySyncDatabaseName");
+  if (persistedProject && persistedBranch && persistedDb) {
+    return {
+      projectId: persistedProject,
+      branchId: persistedBranch,
+      databaseName: persistedDb,
+    };
+  }
+
+  const allProjects = await databases.listProjects();
+  let project = allProjects.find((p) => p.name === HISTORY_SYNC_PROJECT_NAME);
+  if (!project) {
+    console.info(
+      `[HistorySync] auto-provisioning SerenDB project "${HISTORY_SYNC_PROJECT_NAME}"`,
+    );
+    project = await databases.createProject(HISTORY_SYNC_PROJECT_NAME);
+  }
+
+  let branches = await databases.listBranches(project.id);
+  let branch = resolveBranch(branches, project.default_branch_id);
+  if (!branch) {
+    console.info(
+      `[HistorySync] auto-provisioning SerenDB branch "${HISTORY_SYNC_BRANCH_NAME}"`,
+    );
+    branch = await databases.createBranch(project.id, HISTORY_SYNC_BRANCH_NAME);
+    branches = await databases.listBranches(project.id);
+    branch = resolveBranch(branches, project.default_branch_id) ?? branch;
+  }
+
+  const allDatabases = await databases.listDatabases(project.id, branch.id);
+  const database = allDatabases.find(
+    (d) => d.name === HISTORY_SYNC_DATABASE_NAME,
+  );
+  if (!database) {
+    console.info(
+      `[HistorySync] auto-provisioning SerenDB database "${HISTORY_SYNC_DATABASE_NAME}"`,
+    );
+    await databases.createDatabase(
+      project.id,
+      branch.id,
+      HISTORY_SYNC_DATABASE_NAME,
+    );
+  }
+
+  await waitForDatabaseReady(project.id, branch.id, HISTORY_SYNC_DATABASE_NAME);
+
+  settingsStore.update({
+    historySyncProjectId: project.id,
+    historySyncBranchId: branch.id,
+    historySyncDatabaseName: HISTORY_SYNC_DATABASE_NAME,
+  });
+
+  return {
+    projectId: project.id,
+    branchId: branch.id,
+    databaseName: HISTORY_SYNC_DATABASE_NAME,
+  };
+}
+
+export async function runHistorySyncNow(): Promise<HistorySyncSummary> {
+  if (!isTauriRuntime()) {
+    return { pushed: 0, pulled: 0, backfilled: 0, queued: 0, conflicts: 0 };
+  }
+  if (syncInFlight) {
+    return { pushed: 0, pulled: 0, backfilled: 0, queued: 0, conflicts: 0 };
+  }
+  syncInFlight = true;
+  try {
+    const provisioning = await ensureHistorySyncProvisioned();
+    const summary = await invoke<HistorySyncSummary>("history_sync_run_now", {
+      projectId: provisioning.projectId,
+      branchId: provisioning.branchId,
+      databaseName: provisioning.databaseName,
+    });
+    settingsStore.set("historySyncLastSyncedAt", Date.now());
+    return summary;
+  } finally {
+    syncInFlight = false;
+  }
+}
+
+export function startHistorySync(): void {
+  if (!isTauriRuntime()) return;
+  if (!settingsStore.get("historySyncEnabled")) return;
+  if (syncTimer !== null || syncInFlight) return;
+  void runScheduledSync();
+}
+
+export function stopHistorySync(): void {
+  if (syncTimer !== null) {
+    window.clearTimeout(syncTimer);
+    syncTimer = null;
+  }
+}
+
+export async function wipeHistorySyncRemote(
+  confirmation: string,
+): Promise<void> {
+  if (!isTauriRuntime()) return;
+  const provisioning = await ensureHistorySyncProvisioned();
+  await invoke("history_sync_wipe_remote", {
+    projectId: provisioning.projectId,
+    branchId: provisioning.branchId,
+    databaseName: provisioning.databaseName,
+    confirmation,
+  });
+  settingsStore.set("historySyncLastSyncedAt", null);
+}

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -138,6 +138,17 @@ export interface Settings {
    */
   claudeMemoryDatabaseName: string | null;
 
+  /**
+   * Sync durable chat and meeting history to the user's SerenDB branch.
+   * Auto-provisions the dedicated "speech-text" project and
+   * "seren_desktop_history" database on first authenticated run.
+   */
+  historySyncEnabled: boolean;
+  historySyncProjectId: string | null;
+  historySyncBranchId: string | null;
+  historySyncDatabaseName: string | null;
+  historySyncLastSyncedAt: number | null;
+
   // Agent settings
   agentSandboxMode: "read-only" | "workspace-write" | "full-access";
   agentApprovalPolicy: "untrusted" | "on-failure" | "on-request" | "never";
@@ -257,6 +268,11 @@ const DEFAULT_SETTINGS: Settings = {
   claudeMemoryProjectId: null,
   claudeMemoryBranchId: null,
   claudeMemoryDatabaseName: null,
+  historySyncEnabled: true,
+  historySyncProjectId: null,
+  historySyncBranchId: null,
+  historySyncDatabaseName: null,
+  historySyncLastSyncedAt: null,
   // Agent
   agentSandboxMode: "workspace-write",
   agentApprovalPolicy: "on-request",


### PR DESCRIPTION
## Summary
- Adds bidirectional SerenDB history sync for durable chat, message event, draft, meeting, and transcript rows.
- Auto-provisions the `speech-text` project and `seren_desktop_history` database, with 24h connection-string caching and refresh-on-auth failure.
- Adds Settings → Cloud Sync controls for enable/disable, manual sync, status, and typed remote wipe confirmation.
- Preserves tool-call/message-event JSON payloads for replay and keeps raw/binary audio out of the remote schema.

## Audit notes
- Verified against `docs/plans/20260607_SerenDB_Sync_Design.md`.
- Intentional plan-compatible drift: remote IDs are `text` instead of UUID so legacy local IDs like `default-conversation` round-trip instead of being dropped.
- Functional audit fixed stale message pruning so message events are tombstoned/deleted with pruned messages, and draft updates now refresh the snapshot version used for sync.

## Tests
- `cargo test --manifest-path src-tauri/Cargo.toml --lib history_sync`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib save_message_record_is_idempotent_and_audited`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib save_message_record_prune_tombstones_message_events`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib mark_sync_upsert_thread_draft_refreshes_snapshot_version`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib meeting_persistence_round_trips_status_and_fields`
- `pnpm exec biome check src/services/historySync.ts src/services/databases.ts src/stores/settings.store.ts src/App.tsx src/components/settings/SettingsPanel.tsx`
- `pnpm build`
- `git diff --check`

## Notes
- `pnpm exec tsc --noEmit` still fails on unrelated existing test-only issues in `tests/unit/meeting-autodetect-dismiss-reset.test.ts`, `tests/unit/provider-runtime-log-prefix.test.ts`, and `tests/unit/windows-signables.test.ts`.

Closes #2136
