### PR TITLE
fix(oauth): surface reconnect prompt for token-refresh failures

### DIFF
--- a/src/lib/oauth-tool-errors.ts
+++ b/src/lib/oauth-tool-errors.ts
@@ -57,12 +57,20 @@ export function isOAuthConnectionRequiredError(message: string): boolean {
 }
 
 /**
+ * Check if an error message indicates a previously-valid token that expired or
+ * was revoked, so the gateway could not refresh it on the user's behalf.
+ */
+export function isOAuthRefreshError(message: string): boolean {
+  return includesAny(message, OAUTH_REFRESH_ERROR_MARKERS);
+}
+
+/**
  * Check if an error message indicates an OAuth token issue.
  * These errors mean the user's OAuth connection needs to be refreshed.
  */
 export function isOAuthTokenError(message: string): boolean {
   return (
-    includesAny(message, OAUTH_REFRESH_ERROR_MARKERS) ||
+    isOAuthRefreshError(message) ||
     isOAuthConnectionRequiredError(message) ||
     isOAuthScopeError(message)
   );
@@ -86,7 +94,10 @@ export function getOAuthConnectActionForToolError(
   const publisherSlug = parseGatewayPublisherSlug(toolName);
   if (!publisherSlug) return null;
 
-  if (isOAuthConnectionRequiredError(errorMessage)) {
+  if (
+    isOAuthConnectionRequiredError(errorMessage) ||
+    isOAuthRefreshError(errorMessage)
+  ) {
     return { publisherSlug, reason: "connection_required" };
   }
   if (isOAuthScopeError(errorMessage)) {

--- a/tests/unit/oauth-tool-errors.test.ts
+++ b/tests/unit/oauth-tool-errors.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   getOAuthConnectActionForToolError,
   isOAuthConnectionRequiredError,
+  isOAuthRefreshError,
   isOAuthScopeError,
   isOAuthTokenError,
 } from "@/lib/oauth-tool-errors";
@@ -36,6 +37,29 @@ describe("BYOC OAuth tool errors", () => {
   it("classifies canonical scope markers directly", () => {
     expect(isOAuthScopeError("insufficient authentication scopes")).toBe(true);
     expect(isOAuthScopeError("access_token_scope_insufficient")).toBe(true);
+  });
+
+  it("classifies expired-token refresh failures as reconnect-worthy", () => {
+    expect(isOAuthRefreshError("OAuth token refresh failed")).toBe(true);
+    expect(isOAuthRefreshError('{"error":"invalid_grant"}')).toBe(true);
+    expect(isOAuthRefreshError("refresh token expired")).toBe(true);
+    expect(isOAuthRefreshError("403 Forbidden: quota exceeded")).toBe(false);
+  });
+
+  it("surfaces an inline reconnect action when a previously-valid token expires", () => {
+    for (const message of [
+      "OAuth token refresh failed",
+      "Provider error during token refresh",
+      '{"error":"invalid_grant","error_description":"Token has been expired or revoked."}',
+      "refresh token expired",
+    ]) {
+      expect(
+        getOAuthConnectActionForToolError(
+          "gateway__gmail__get_messages",
+          message,
+        ),
+      ).toEqual({ publisherSlug: "gmail", reason: "connection_required" });
+    }
   });
 
   it("returns an inline action only for actionable gateway OAuth failures", () => {


### PR DESCRIPTION
## Summary

`getOAuthConnectActionForToolError` only branched on connection-required and scope-insufficient errors. The most common BYOC OAuth case — a token that was valid yesterday and just expired/was revoked (`invalid_grant`, `"OAuth token refresh failed"`) — fell through to `null`, so no inline reconnect prompt rendered in the chat even though `executor.ts` still emitted `oauth-connection-expired` to Settings.

- Extract `isOAuthRefreshError` (mirrors `isOAuthScopeError` / `isOAuthConnectionRequiredError`; `isOAuthTokenError` now reuses it).
- Branch on it in `getOAuthConnectActionForToolError` with `reason: "connection_required"` — the user action is identical (reconnect the account).

Fixes #2259.

## Test plan

- [x] `pnpm vitest run tests/unit/oauth-tool-errors.test.ts` — 6/6 pass (2 new cases: `isOAuthRefreshError` classification + inline action for all four refresh markers against `gateway__gmail__get_messages`).
- [x] Wrote the tests first (red → green).
- [x] `pnpm check` on changed files — clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
