### PR TITLE
fix(history-sync): reset local state on wipe so re-sync re-uploads

### DIFF
--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -207,6 +207,28 @@ pub async fn wipe_remote_history(
         .execute("DROP SCHEMA IF EXISTS seren_desktop CASCADE", &[])
         .map_err(|err| err.to_string())?;
     ensure_remote_schema(&mut client)?;
+    with_local_db(&app, |conn| reset_local_sync_state(conn))?;
+    Ok(())
+}
+
+/// Clear local sync bookkeeping after the remote copy is wiped so the next sync
+/// performs a fresh full backfill instead of short-circuiting on stale state.
+fn reset_local_sync_state(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE history_sync_state
+         SET last_pulled_version = 0,
+             first_backfill_completed = 0,
+             updated_at = ?1",
+        params![now_ms()],
+    )?;
+    for table in HISTORY_SYNC_TABLES {
+        // Drafts live on the conversations row, not a table of their own.
+        if *table == "thread_drafts" {
+            continue;
+        }
+        conn.execute(&format!("UPDATE {table} SET synced_at = NULL"), [])?;
+    }
+    conn.execute("DELETE FROM sync_outbox", [])?;
     Ok(())
 }
 
@@ -1739,5 +1761,74 @@ mod tests {
             )
             .unwrap();
         assert_eq!(stored.chars().count(), 500);
+    }
+
+    #[test]
+    fn wipe_resets_local_state_so_backfill_reenqueues() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind)
+             VALUES ('c1', 'Chat', 1000, 'chat')",
+            [],
+        )
+        .unwrap();
+        save_message_record(
+            &conn,
+            &PersistedMessage {
+                id: "m1".to_string(),
+                conversation_id: "c1".to_string(),
+                role: "user".to_string(),
+                content: "hello".to_string(),
+                model: None,
+                timestamp: 1100,
+                metadata: None,
+                provider: None,
+            },
+        )
+        .unwrap();
+
+        // First sync: backfill everything, then simulate a successful push that
+        // drains the outbox and stamps rows as synced.
+        let first = enqueue_initial_backfill(&conn).unwrap();
+        assert!(first >= 2);
+        conn.execute("DELETE FROM sync_outbox", []).unwrap();
+        conn.execute("UPDATE conversations SET synced_at = 123", [])
+            .unwrap();
+        conn.execute("UPDATE messages SET synced_at = 123", [])
+            .unwrap();
+
+        // Without a reset, a re-sync short-circuits and uploads nothing — the bug.
+        assert_eq!(enqueue_initial_backfill(&conn).unwrap(), 0);
+
+        // Wiping the remote must reset local state so the next sync re-uploads.
+        reset_local_sync_state(&conn).unwrap();
+
+        let completed: i64 = conn
+            .query_row(
+                "SELECT MAX(first_backfill_completed) FROM history_sync_state",
+                [],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .unwrap()
+            .unwrap_or(0);
+        assert_eq!(completed, 0, "backfill flag must be cleared");
+
+        let still_synced: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE synced_at IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(still_synced, 0, "synced_at must be cleared");
+
+        let outbox: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sync_outbox", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(outbox, 0, "stale outbox rows must be cleared");
+
+        // The next backfill re-enqueues the full history.
+        assert_eq!(enqueue_initial_backfill(&conn).unwrap(), first);
     }
 }

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -223,7 +223,9 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
       stopHistorySync();
       setHistorySyncSummary(null);
       setHistorySyncWipeConfirm("");
-      setHistorySyncMessage("Remote history copy wiped. Cloud sync is off.");
+      setHistorySyncMessage(
+        "Remote history copy wiped. Cloud sync is off — re-enable it to upload a fresh copy.",
+      );
     } catch (err) {
       setHistorySyncMessage(`Remote wipe failed: ${err}`);
       console.error("[HistorySync] remote wipe failed", err);


### PR DESCRIPTION
## Summary

`wipe_remote_history` dropped/recreated the remote `seren_desktop` schema but left local sync bookkeeping intact: `history_sync_state.first_backfill_completed=1`, `synced_at` stamps on every row, and any stale `sync_outbox` rows. A user who wiped to recover from a corrupt remote and then re-enabled sync hit `enqueue_initial_backfill`'s short-circuit (`if completed != 0 return Ok(0)`), so **nothing re-uploaded** — the Settings panel reported "synced" against an empty remote. Silent data-loss-equivalent.

- Add `reset_local_sync_state(conn)`: clears `first_backfill_completed` + `last_pulled_version`, nulls `synced_at` on the five durable tables (drafts are tracked on `conversations`, so skipped), and deletes stale `sync_outbox` rows.
- Call it from `wipe_remote_history` after the remote schema is recreated.
- Clarify the Settings wipe confirmation message so the user knows re-enabling sync uploads a fresh copy.

Fixes #2258.

## Test plan

- [x] Wrote the test first (red → green): `wipe_resets_local_state_so_backfill_reenqueues` proves the pre-fix short-circuit (`enqueue_initial_backfill == 0`), then asserts that after `reset_local_sync_state` the flag/synced_at/outbox are cleared and the next backfill re-enqueues the **full** original row count.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib services::history_sync::tests` — 7/7 pass.
- [x] `cargo check` — clean.
- [x] `pnpm check` on changed files — clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
