### PR TITLE
fix(history-sync): serialize sync runs against remote wipe

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -526,6 +526,7 @@ pub fn run() {
             commands::updater::ShutdownGuard::default(),
         ))
         .manage(services::database::WalCheckpointTask::default())
+        .manage(services::history_sync::HistorySyncLock::default())
         .manage(messaging::MessagingState::new())
         .manage(std::sync::Arc::new(tokio::sync::Mutex::new(None))
             as polymarket::commands::PolymarketWsState);

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -36,6 +36,18 @@ pub struct HistorySyncConfig {
     pub database_name: String,
 }
 
+/// Serializes a history sync run against a remote wipe so the two never
+/// interleave on the shared local database and leave the cloud mirror in a
+/// stuck or divergent state.
+#[derive(Default)]
+pub struct HistorySyncLock(std::sync::Arc<tokio::sync::Mutex<()>>);
+
+impl HistorySyncLock {
+    fn handle(app: &AppHandle) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+        app.state::<HistorySyncLock>().0.clone()
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HistorySyncSummary {
@@ -163,6 +175,8 @@ pub async fn run_history_sync_once(
     app: AppHandle,
     config: HistorySyncConfig,
 ) -> Result<HistorySyncSummary, String> {
+    let lock = HistorySyncLock::handle(&app);
+    let _guard = lock.lock().await;
     let mut client = open_remote_client(&app, &config).await?;
     ensure_remote_schema(&mut client)?;
 
@@ -202,6 +216,8 @@ pub async fn wipe_remote_history(
             name = config.database_name
         ));
     }
+    let lock = HistorySyncLock::handle(&app);
+    let _guard = lock.lock().await;
     let mut client = open_remote_client(&app, &config).await?;
     client
         .execute("DROP SCHEMA IF EXISTS seren_desktop CASCADE", &[])

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -217,10 +217,13 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
   const handleHistorySyncWipe = async () => {
     setHistorySyncBusy(true);
     setHistorySyncMessage(null);
+    // Stop scheduled ticks before wiping so no new sync dispatches mid-wipe.
+    // The Rust-side lock still serializes an already-running sync against the
+    // wipe; this just avoids queuing more work to wait behind it.
+    handleBooleanChange("historySyncEnabled", false);
+    stopHistorySync();
     try {
       await wipeHistorySyncRemote(historySyncWipeConfirm());
-      handleBooleanChange("historySyncEnabled", false);
-      stopHistorySync();
       setHistorySyncSummary(null);
       setHistorySyncWipeConfirm("");
       setHistorySyncMessage(


### PR DESCRIPTION
## Summary

`run_history_sync_once` and `wipe_remote_history` were independent async Tauri commands sharing only the per-statement `DbPool` mutex (`Mutex<Connection>`, locked per `with_connection`), so a scheduled sync tick could interleave with a manual wipe:

- a concurrent `enqueue_initial_backfill` could flip `first_backfill_completed` back to `1` after the wipe reset it to `0` → cloud mirror stuck empty (the #2258 symptom, via a race);
- an in-flight `push_outbox` could write rows into the schema moments before `DROP SCHEMA` and stamp them `synced_at` locally → permanent local-only divergence.

### Fix

- Add `HistorySyncLock` (`Arc<tokio::sync::Mutex<()>>`) as managed state; both `run_history_sync_once` and `wipe_remote_history` acquire it for their full duration → mutually exclusive end to end (not per-statement).
- Reorder `handleHistorySyncWipe` to disable sync + `stopHistorySync()` **before** awaiting the wipe, so no new tick queues behind the lock. The Rust lock remains the load-bearing guard for a tick already dispatched.

Fixes #2262.

## Why no new unit test

This is a concurrency guard. A meaningful test needs a full `AppHandle` + managed state + live Postgres integration harness (tracked in #2265, the Windows/e2e harness ticket); a service-level test would only assert `tokio::sync::Mutex` itself, which CLAUDE.md's "never test mocked/framework behavior" rule excludes. The existing safety nets still hold:

- [x] `cargo test --lib services::history_sync::tests` — 7/7 pass.
- [x] `cargo check` — clean.
- [x] `pnpm test` — 1631/1631 pass.
- [x] `pnpm check` on changed files — clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
