### PR TITLE
Gate releases on Windows production app e2e

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@ on:
       - 'v*'
 
 permissions:
+  actions: read
   contents: write
+  id-token: write
 
 # Prevent multiple releases from running simultaneously
 concurrency:
@@ -1056,8 +1058,169 @@ jobs:
         run: |
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
 
+  windows-app-e2e:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      WINDOWS_E2E_INSTANCE_ID: ${{ secrets.WINDOWS_E2E_INSTANCE_ID }}
+      WINDOWS_E2E_S3_BUCKET: ${{ secrets.WINDOWS_E2E_S3_BUCKET }}
+      WINDOWS_E2E_SECRET_PARAMETER_PREFIX: ${{ secrets.WINDOWS_E2E_SECRET_PARAMETER_PREFIX }}
+      WINDOWS_E2E_AWS_ROLE_ARN: ${{ secrets.WINDOWS_E2E_AWS_ROLE_ARN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+    steps:
+      - name: Checkout e2e scripts
+        uses: actions/checkout@v6
+
+      - name: Download signed Windows installer
+        uses: actions/download-artifact@v8
+        with:
+          name: Seren-Desktop-Windows-x64.exe
+          path: windows-artifact
+
+      - name: Validate Windows e2e AWS configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in WINDOWS_E2E_INSTANCE_ID WINDOWS_E2E_S3_BUCKET WINDOWS_E2E_SECRET_PARAMETER_PREFIX AWS_REGION; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ -z "${WINDOWS_E2E_AWS_ROLE_ARN:-}" ] && { [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; }; then
+            missing+=("WINDOWS_E2E_AWS_ROLE_ARN or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY")
+          fi
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf '::error::Missing required Windows e2e secret(s): %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials with OIDC role
+        if: env.WINDOWS_E2E_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ env.WINDOWS_E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Configure AWS credentials with access keys
+        if: env.WINDOWS_E2E_AWS_ROLE_ARN == ''
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Stage Windows e2e payload in S3
+        id: stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          installer="$(find windows-artifact -type f -name '*.exe' | head -n 1)"
+          if [ -z "$installer" ]; then
+            echo "::error::No signed Windows installer artifact found"
+            exit 1
+          fi
+          payload="$RUNNER_TEMP/windows-e2e-payload.zip"
+          zip -q -r "$payload" \
+            package.json \
+            pnpm-lock.yaml \
+            scripts/windows-e2e-app.ps1 \
+            scripts/windows-e2e-app.mjs
+          prefix="release-windows-e2e/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
+          aws s3 cp "$installer" "s3://${WINDOWS_E2E_S3_BUCKET}/${prefix}/SerenDesktop-setup.exe"
+          aws s3 cp "$payload" "s3://${WINDOWS_E2E_S3_BUCKET}/${prefix}/windows-e2e-payload.zip"
+          echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
+
+      - name: Run full Windows app e2e on AWS host
+        id: ssm
+        shell: bash
+        env:
+          S3_PREFIX: ${{ steps.stage.outputs.prefix }}
+        run: |
+          set -euo pipefail
+          node <<'NODE' > "$RUNNER_TEMP/windows-e2e-commands.json"
+          const env = process.env;
+          const secretNames = [
+            "SEREN_E2E_EMAIL",
+            "SEREN_E2E_PASSWORD",
+            "SEREN_E2E_HISTORY_PROJECT_ID",
+            "SEREN_E2E_HISTORY_BRANCH_ID",
+            "SEREN_E2E_HISTORY_DATABASE_NAME",
+            "SEREN_E2E_GITHUB_USERNAME",
+            "SEREN_E2E_GITHUB_PASSWORD",
+            "SEREN_E2E_GITHUB_PAT",
+            "SEREN_E2E_GITHUB_TOTP_SECRET",
+            "SEREN_E2E_AGENT_TYPE",
+            "SEREN_E2E_AGENT_CWD",
+          ];
+          const workName = `seren-release-windows-e2e-${env.GITHUB_RUN_ID}-${env.GITHUB_RUN_ATTEMPT}`;
+          const installerS3 = `s3://${env.WINDOWS_E2E_S3_BUCKET}/${env.S3_PREFIX}/SerenDesktop-setup.exe`;
+          const payloadS3 = `s3://${env.WINDOWS_E2E_S3_BUCKET}/${env.S3_PREFIX}/windows-e2e-payload.zip`;
+          const commands = [
+            "$ErrorActionPreference = 'Stop'",
+            "$ProgressPreference = 'SilentlyContinue'",
+            `$work = Join-Path $env:TEMP '${workName}'`,
+            "if (Test-Path $work) { Remove-Item -LiteralPath $work -Recurse -Force }",
+            "New-Item -ItemType Directory -Force -Path $work | Out-Null",
+            `aws s3 cp '${installerS3}' (Join-Path $work 'SerenDesktop-setup.exe')`,
+            `aws s3 cp '${payloadS3}' (Join-Path $work 'windows-e2e-payload.zip')`,
+            "Expand-Archive -LiteralPath (Join-Path $work 'windows-e2e-payload.zip') -DestinationPath $work -Force",
+            `$secretNames = @(${secretNames.map((name) => `'${name}'`).join(",")})`,
+            `foreach ($name in $secretNames) { $parameterName = '${env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX}/' + $name; $value = aws ssm get-parameter --with-decryption --name $parameterName --query 'Parameter.Value' --output text 2>$null; if ($LASTEXITCODE -eq 0 -and $value -and $value -ne 'None') { [Environment]::SetEnvironmentVariable($name, $value, 'Process') } }`,
+            "[Environment]::SetEnvironmentVariable('SEREN_E2E_API_BASE', 'https://api.serendb.com', 'Process')",
+            "Set-Location $work",
+            "corepack enable",
+            "corepack prepare pnpm@9 --activate",
+            "pnpm install --frozen-lockfile",
+            "pnpm exec playwright install chromium",
+            "powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-app.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe')",
+          ];
+          process.stdout.write(JSON.stringify({ commands }, null, 2));
+          NODE
+          command_id="$(aws ssm send-command \
+            --instance-ids "$WINDOWS_E2E_INSTANCE_ID" \
+            --document-name "AWS-RunPowerShellScript" \
+            --comment "Seren Desktop release Windows production e2e ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
+            --parameters "file://$RUNNER_TEMP/windows-e2e-commands.json" \
+            --query "Command.CommandId" \
+            --output text)"
+          echo "command_id=$command_id" >> "$GITHUB_OUTPUT"
+          echo "SSM command: $command_id"
+          deadline=$((SECONDS + 3600))
+          while true; do
+            status="$(aws ssm get-command-invocation \
+              --command-id "$command_id" \
+              --instance-id "$WINDOWS_E2E_INSTANCE_ID" \
+              --query "Status" \
+              --output text 2>/dev/null || echo Pending)"
+            echo "Windows e2e SSM status: $status"
+            case "$status" in
+              Success) break ;;
+              Failed|Cancelled|TimedOut|Cancelling)
+                aws ssm get-command-invocation \
+                  --command-id "$command_id" \
+                  --instance-id "$WINDOWS_E2E_INSTANCE_ID" \
+                  --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
+                  --output json
+                exit 1
+                ;;
+            esac
+            if [ "$SECONDS" -gt "$deadline" ]; then
+              echo "::error::Timed out waiting for Windows e2e SSM command $command_id"
+              exit 1
+            fi
+            sleep 30
+          done
+          aws ssm get-command-invocation \
+            --command-id "$command_id" \
+            --instance-id "$WINDOWS_E2E_INSTANCE_ID" \
+            --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
+            --output json
+
   publish-release:
-    needs: [create-release, build]
+    needs: [create-release, build, windows-app-e2e]
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts

--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -1,0 +1,558 @@
+import { randomUUID, createHmac } from "node:crypto";
+import { spawn } from "node:child_process";
+import process from "node:process";
+import { setTimeout as sleep } from "node:timers/promises";
+import { chromium } from "@playwright/test";
+import { WebSocket } from "ws";
+
+const API_BASE = requiredEnv("SEREN_E2E_API_BASE", "https://api.serendb.com").replace(/\/$/, "");
+const CDP_ENDPOINT = requiredEnv("SEREN_E2E_CDP_ENDPOINT");
+const EMAIL = requiredEnv("SEREN_E2E_EMAIL");
+const PASSWORD = requiredEnv("SEREN_E2E_PASSWORD");
+const HISTORY_PROJECT_ID = requiredEnv("SEREN_E2E_HISTORY_PROJECT_ID");
+const HISTORY_BRANCH_ID = requiredEnv("SEREN_E2E_HISTORY_BRANCH_ID");
+const HISTORY_DATABASE_NAME = requiredEnv("SEREN_E2E_HISTORY_DATABASE_NAME");
+const GITHUB_USERNAME = requiredEnv("SEREN_E2E_GITHUB_USERNAME");
+const GITHUB_PASSWORD = requiredEnv("SEREN_E2E_GITHUB_PASSWORD");
+const GITHUB_PAT = requiredEnv("SEREN_E2E_GITHUB_PAT");
+const GITHUB_TOTP_SECRET = process.env.SEREN_E2E_GITHUB_TOTP_SECRET ?? "";
+const OAUTH_PROVIDER = process.env.SEREN_E2E_OAUTH_PROVIDER ?? "github";
+const AGENT_TYPE = process.env.SEREN_E2E_AGENT_TYPE ?? "codex";
+const AGENT_CWD = process.env.SEREN_E2E_AGENT_CWD ?? process.cwd();
+const PROMPT_TEXT =
+  process.env.SEREN_E2E_AGENT_PROMPT ??
+  "Reply with exactly SEREN_WINDOWS_E2E_OK and no other text.";
+const CAPTURE_SECONDS = Number(process.env.SEREN_E2E_MEETING_CAPTURE_SECONDS ?? "8");
+
+function requiredEnv(name, fallback) {
+  const value = process.env[name] ?? fallback;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function waitUntil(label, fn, { timeoutMs = 60_000, intervalMs = 500 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const value = await fn();
+      if (value) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(
+    `Timed out waiting for ${label}${lastError ? `: ${lastError.message}` : ""}`,
+  );
+}
+
+async function tauriInvoke(page, command, args = {}) {
+  return page.evaluate(
+    async ({ command: cmd, args: invokeArgs }) => {
+      const internals = window.__TAURI_INTERNALS__;
+      if (!internals?.invoke) {
+        throw new Error("Tauri invoke bridge is not available in the WebView");
+      }
+      return await internals.invoke(cmd, invokeArgs);
+    },
+    { command, args },
+  );
+}
+
+async function findSerenPage(browser) {
+  return waitUntil(
+    "Seren WebView page",
+    async () => {
+      for (const context of browser.contexts()) {
+        for (const page of context.pages()) {
+          const url = page.url();
+          if (!url.startsWith("devtools://") && !url.includes("/json/list")) {
+            return page;
+          }
+        }
+      }
+      return null;
+    },
+    { timeoutMs: 45_000 },
+  );
+}
+
+async function connectToApp() {
+  const browser = await chromium.connectOverCDP(CDP_ENDPOINT);
+  const page = await findSerenPage(browser);
+  const browserErrors = [];
+  page.on("pageerror", (error) => browserErrors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      browserErrors.push(message.text());
+    }
+  });
+  await page.waitForLoadState("domcontentloaded");
+  return { browser, page, browserErrors };
+}
+
+async function signIn(page) {
+  await tauriInvoke(page, "clear_token").catch(() => {});
+  await tauriInvoke(page, "clear_refresh_token").catch(() => {});
+
+  const emailInput = page.getByLabel("Email");
+  if (!(await emailInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+    const signInButton = page.getByRole("button", { name: /^Sign In$/ }).first();
+    await signInButton.click({ timeout: 10_000 });
+  }
+
+  await page.getByLabel("Email").fill(EMAIL);
+  await page.getByLabel("Password").fill(PASSWORD);
+  await page.getByRole("button", { name: /^Sign In$/ }).last().click();
+
+  const token = await waitUntil(
+    "stored production auth token",
+    async () => {
+      const value = await tauriInvoke(page, "get_token").catch(() => null);
+      return typeof value === "string" && value.length > 20 ? value : null;
+    },
+    { timeoutMs: 45_000 },
+  );
+  await validateSerenSession(token);
+}
+
+async function validateSerenSession(token) {
+  const response = await fetch(`${API_BASE}/auth/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assert(response.ok, `Production /auth/me failed after sign-in: HTTP ${response.status}`);
+  const payload = await response.json();
+  assert(payload?.data?.email, "Production /auth/me response did not include a user email");
+  console.log(`[windows-e2e] Signed in to production as ${payload.data.email}`);
+}
+
+async function validateGithubPat() {
+  const response = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${GITHUB_PAT}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "seren-desktop-windows-e2e",
+    },
+  });
+  assert(response.ok, `GitHub PAT validation failed: HTTP ${response.status}`);
+  const body = await response.json();
+  assert(body?.login, "GitHub PAT validation did not return a login");
+  console.log(`[windows-e2e] GitHub PAT validated for ${body.login}`);
+}
+
+async function apiRequest(path, token, options = {}) {
+  return fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      ...(options.headers ?? {}),
+    },
+  });
+}
+
+async function revokeOAuthConnection(token, provider = OAUTH_PROVIDER) {
+  const response = await apiRequest(`/oauth/connections/${encodeURIComponent(provider)}`, token, {
+    method: "DELETE",
+  });
+  if (!response.ok && response.status !== 404) {
+    throw new Error(`Failed to revoke ${provider} OAuth connection: HTTP ${response.status}`);
+  }
+}
+
+async function assertOAuthConnected(token, provider = OAUTH_PROVIDER) {
+  return waitUntil(
+    `${provider} OAuth connection`,
+    async () => {
+      const response = await apiRequest("/oauth/connections", token);
+      if (!response.ok) {
+        throw new Error(`list connections returned HTTP ${response.status}`);
+      }
+      const payload = await response.json();
+      const connections = payload.connections ?? payload.data?.connections ?? [];
+      return connections.find(
+        (connection) =>
+          connection.provider_slug === provider &&
+          connection.is_valid !== false,
+      );
+    },
+    { timeoutMs: 45_000 },
+  );
+}
+
+async function startGatewayOAuth(page, token, provider = OAUTH_PROVIDER) {
+  const redirectUri = "http://localhost:8787/oauth/callback";
+  const authUrl = `${API_BASE}/oauth/${provider}/authorize?redirect_uri=${encodeURIComponent(
+    redirectUri,
+  )}`;
+  const location = await tauriInvoke(page, "get_oauth_redirect_url", {
+    url: authUrl,
+    bearerToken: token,
+  });
+  assert(
+    typeof location === "string" && location.startsWith("https://"),
+    `Gateway returned invalid OAuth redirect URL for ${provider}`,
+  );
+  return location;
+}
+
+function base32Decode(input) {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  let bits = "";
+  const bytes = [];
+  for (const char of input.replace(/\s+/g, "").replace(/=+$/, "").toUpperCase()) {
+    const value = alphabet.indexOf(char);
+    if (value < 0) throw new Error("Invalid base32 character in TOTP secret");
+    bits += value.toString(2).padStart(5, "0");
+    while (bits.length >= 8) {
+      bytes.push(Number.parseInt(bits.slice(0, 8), 2));
+      bits = bits.slice(8);
+    }
+  }
+  return Buffer.from(bytes);
+}
+
+function totp(secret, timestamp = Date.now()) {
+  const counter = Math.floor(timestamp / 1000 / 30);
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64BE(BigInt(counter));
+  const digest = createHmac("sha1", base32Decode(secret)).update(buffer).digest();
+  const offset = digest[digest.length - 1] & 0xf;
+  const code =
+    ((digest[offset] & 0x7f) << 24) |
+    ((digest[offset + 1] & 0xff) << 16) |
+    ((digest[offset + 2] & 0xff) << 8) |
+    (digest[offset + 3] & 0xff);
+  return String(code % 1_000_000).padStart(6, "0");
+}
+
+async function completeGithubAuthorization(authUrl) {
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  try {
+    await page.goto(authUrl, { waitUntil: "domcontentloaded", timeout: 60_000 });
+
+    const login = page.locator("#login_field, input[name='login']").first();
+    if (await login.isVisible({ timeout: 10_000 }).catch(() => false)) {
+      await login.fill(GITHUB_USERNAME);
+      await page.locator("#password, input[name='password']").first().fill(GITHUB_PASSWORD);
+      await page.getByRole("button", { name: /sign in/i }).click();
+    }
+
+    const otpInput = page.locator("input[name='otp'], input#app_otp, input[autocomplete='one-time-code']").first();
+    if (await otpInput.isVisible({ timeout: 8_000 }).catch(() => false)) {
+      assert(
+        GITHUB_TOTP_SECRET,
+        "GitHub requested two-factor auth but SEREN_E2E_GITHUB_TOTP_SECRET is not configured",
+      );
+      await otpInput.fill(totp(GITHUB_TOTP_SECRET));
+      await page.keyboard.press("Enter");
+    }
+
+    const authorizeButton = page
+      .getByRole("button", { name: /authorize|continue|grant/i })
+      .or(page.locator("button[name='authorize'], input[name='authorize']"))
+      .first();
+    if (await authorizeButton.isVisible({ timeout: 15_000 }).catch(() => false)) {
+      await authorizeButton.click();
+    }
+
+    await page.waitForURL(/localhost:8787\/oauth\/callback|127\.0\.0\.1:8787\/oauth\/callback|github\.com\/settings\/connections/, {
+      timeout: 120_000,
+    }).catch(async () => {
+      const body = await page.locator("body").innerText({ timeout: 5_000 }).catch(() => "");
+      throw new Error(`GitHub OAuth did not reach the Seren callback. URL=${page.url()} Body=${body.slice(0, 500)}`);
+    });
+  } finally {
+    await browser.close();
+  }
+}
+
+async function exerciseOAuthReconnect(page) {
+  const token = await tauriInvoke(page, "get_token");
+  await validateGithubPat();
+  await revokeOAuthConnection(token);
+
+  for (const phase of ["connect", "reconnect"]) {
+    const authUrl = await startGatewayOAuth(page, token);
+    await completeGithubAuthorization(authUrl);
+    const connection = await assertOAuthConnected(token);
+    console.log(`[windows-e2e] GitHub OAuth ${phase} valid for ${connection.provider_email ?? connection.provider_slug}`);
+    await revokeOAuthConnection(token);
+  }
+}
+
+function createRuntimeBuffer(ws) {
+  const messages = [];
+  const waiters = new Set();
+  ws.on("message", (raw) => {
+    let message;
+    try {
+      message = JSON.parse(String(raw));
+    } catch {
+      return;
+    }
+    if (!message?.method) return;
+    messages.push(message);
+    for (const waiter of [...waiters]) {
+      if (waiter.predicate(message)) {
+        clearTimeout(waiter.timeout);
+        waiters.delete(waiter);
+        waiter.resolve(message);
+      }
+    }
+  });
+  return {
+    mark: () => messages.length,
+    slice: (from) => messages.slice(from),
+    waitFor(predicate, timeoutMs, from = 0) {
+      const existing = messages.slice(from).find(predicate);
+      if (existing) return Promise.resolve(existing);
+      return new Promise((resolve, reject) => {
+        const waiter = {
+          predicate,
+          resolve,
+          reject,
+          timeout: setTimeout(() => {
+            waiters.delete(waiter);
+            reject(new Error("Timed out waiting for provider runtime event"));
+          }, timeoutMs),
+        };
+        waiters.add(waiter);
+      });
+    },
+  };
+}
+
+function rpc(ws, method, params = {}) {
+  const id = Math.floor(Math.random() * 1_000_000_000);
+  return new Promise((resolve, reject) => {
+    const onMessage = (raw) => {
+      let message;
+      try {
+        message = JSON.parse(String(raw));
+      } catch (error) {
+        ws.off("message", onMessage);
+        reject(error);
+        return;
+      }
+      if (message.id !== id) return;
+      ws.off("message", onMessage);
+      if (message.error) {
+        reject(new Error(String(message.error.message ?? "Provider runtime RPC failed")));
+        return;
+      }
+      resolve(message.result);
+    };
+    ws.on("message", onMessage);
+    ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+  });
+}
+
+async function connectProviderRuntime(config) {
+  const health = await waitUntil(
+    "provider runtime health",
+    async () => {
+      const response = await fetch(`${config.apiBaseUrl}/__seren/health`);
+      return response.ok ? response.json() : null;
+    },
+    { timeoutMs: 45_000 },
+  );
+  assert(health.mode === "desktop-native", `Unexpected provider runtime mode: ${health.mode}`);
+  const ws = new WebSocket(config.wsBaseUrl);
+  await new Promise((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  await rpc(ws, "auth", { token: config.token });
+  return ws;
+}
+
+function assistantText(buffer, marker, sessionId) {
+  return buffer
+    .slice(marker)
+    .filter(
+      (message) =>
+        message.method === "provider://message-chunk" &&
+        message.params?.sessionId === sessionId &&
+        message.params?.isThought !== true,
+    )
+    .map((message) => String(message.params?.text ?? ""))
+    .join("");
+}
+
+async function exerciseAgentRuntime(page) {
+  const config = await tauriInvoke(page, "provider_runtime_get_config");
+  assert(config?.apiBaseUrl && config?.wsBaseUrl && config?.token, "provider runtime config missing fields");
+  const ws = await connectProviderRuntime(config);
+  const buffer = createRuntimeBuffer(ws);
+  let session;
+  try {
+    const available = await rpc(ws, "provider_check_agent_available", { agentType: AGENT_TYPE });
+    assert(available === true, `${AGENT_TYPE} is not available on the Windows e2e host`);
+    session = await rpc(ws, "provider_spawn", {
+      agentType: AGENT_TYPE,
+      cwd: AGENT_CWD,
+      localSessionId: randomUUID(),
+      resumeAgentSessionId: null,
+      sandboxMode: "workspace-write",
+      apiKey: null,
+      approvalPolicy: AGENT_TYPE === "codex" ? "never" : "on-request",
+      searchEnabled: false,
+      networkEnabled: true,
+      timeoutSecs: 120,
+    });
+    assert(session?.id, "provider_spawn did not return a local session id");
+    const marker = buffer.mark();
+    await rpc(ws, "provider_prompt", {
+      sessionId: session.id,
+      prompt: PROMPT_TEXT,
+      context: null,
+    });
+    await buffer.waitFor(
+      (message) =>
+        message.method === "provider://prompt-complete" &&
+        message.params?.sessionId === session.id &&
+        message.params?.historyReplay !== true,
+      240_000,
+      marker,
+    );
+    const text = assistantText(buffer, marker, session.id);
+    assert(
+      text.includes("SEREN_WINDOWS_E2E_OK"),
+      `Agent response did not include expected marker. Text=${text.slice(0, 500)}`,
+    );
+    console.log(`[windows-e2e] ${AGENT_TYPE} stream-json runtime prompt completed`);
+  } finally {
+    if (session?.id) {
+      await rpc(ws, "provider_terminate", { sessionId: session.id }).catch(() => {});
+    }
+    ws.close();
+  }
+}
+
+async function createConversationWithMessage(page, label) {
+  const conversationId = `windows-e2e-${label}-${randomUUID()}`;
+  const timestamp = Date.now();
+  await tauriInvoke(page, "create_conversation", {
+    id: conversationId,
+    title: `Windows e2e ${label}`,
+    selectedModel: null,
+    selectedProvider: "seren",
+    projectRoot: null,
+    employeeId: null,
+  });
+  await tauriInvoke(page, "save_message", {
+    id: randomUUID(),
+    conversationId,
+    role: "user",
+    content: `history-sync ${label} ${timestamp}`,
+    model: null,
+    timestamp,
+    metadata: null,
+    provider: "seren",
+  });
+  return conversationId;
+}
+
+async function runHistorySync(page, label) {
+  const summary = await tauriInvoke(page, "history_sync_run_now", {
+    projectId: HISTORY_PROJECT_ID,
+    branchId: HISTORY_BRANCH_ID,
+    databaseName: HISTORY_DATABASE_NAME,
+  });
+  assert(summary.conflicts === 0, `${label} history sync reported conflicts`);
+  assert(summary.queued === 0, `${label} history sync left queued rows`);
+  assert(summary.pushed > 0 || summary.pulled > 0 || summary.backfilled > 0, `${label} history sync moved no rows`);
+  console.log(`[windows-e2e] history sync ${label}: ${JSON.stringify(summary)}`);
+  return summary;
+}
+
+async function exerciseHistorySync(page) {
+  await createConversationWithMessage(page, "before-wipe");
+  await runHistorySync(page, "initial");
+  await tauriInvoke(page, "history_sync_wipe_remote", {
+    projectId: HISTORY_PROJECT_ID,
+    branchId: HISTORY_BRANCH_ID,
+    databaseName: HISTORY_DATABASE_NAME,
+    confirmation: HISTORY_DATABASE_NAME,
+  });
+  await createConversationWithMessage(page, "after-wipe");
+  await runHistorySync(page, "after-wipe-resync");
+}
+
+function playWindowsAudio() {
+  const command = [
+    "[Console]::Beep(880, 1200)",
+    "Start-Sleep -Milliseconds 250",
+    "[Console]::Beep(660, 1200)",
+    "Start-Sleep -Milliseconds 250",
+    "[Console]::Beep(990, 1200)",
+  ].join("; ");
+  return spawn("powershell.exe", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command], {
+    stdio: "ignore",
+  });
+}
+
+async function exerciseMeetingCapture(page) {
+  const meeting = await tauriInvoke(page, "create_meeting", {
+    title: `Windows e2e capture ${new Date().toISOString()}`,
+    sourceApp: "windows-e2e",
+    startedAt: Date.now(),
+    templateId: null,
+  });
+  assert(meeting?.id, "create_meeting did not return an id");
+  await tauriInvoke(page, "start_meeting_capture", { meetingId: meeting.id });
+  const audio = playWindowsAudio();
+  await sleep(CAPTURE_SECONDS * 1000);
+  const outcome = await tauriInvoke(page, "stop_meeting_capture", {
+    meetingId: meeting.id,
+  });
+  audio.kill();
+  assert(outcome.hadCapture === true, "meeting capture reported hadCapture=false");
+  assert(
+    outcome.nativeMicReady === true || outcome.systemAudioReady === true,
+    `meeting capture had no native mic or system audio ready: ${JSON.stringify(outcome)}`,
+  );
+  assert(
+    outcome.nativeMicFrameCount > 0 ||
+      outcome.systemAudioFrameCount > 0 ||
+      outcome.frameCount > 0,
+    `meeting capture recorded no frames: ${JSON.stringify(outcome)}`,
+  );
+  assert(!outcome.failureReason, `meeting capture failed: ${outcome.failureReason}`);
+  console.log(
+    `[windows-e2e] meeting capture frames mic=${outcome.nativeMicFrameCount} system=${outcome.systemAudioFrameCount}`,
+  );
+}
+
+async function main() {
+  const { browser, page, browserErrors } = await connectToApp();
+  try {
+    await signIn(page);
+    await exerciseAgentRuntime(page);
+    await exerciseHistorySync(page);
+    await exerciseOAuthReconnect(page);
+    await exerciseMeetingCapture(page);
+    assert(browserErrors.length === 0, `WebView console/page errors: ${browserErrors.join("\n")}`);
+    console.log("[windows-e2e] full Windows production e2e passed");
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -1,0 +1,142 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$InstallerPath,
+
+  [int]$RemoteDebugPort = 9222,
+
+  [string]$InstallDir = (Join-Path $env:LOCALAPPDATA "SerenDesktopE2E"),
+
+  [int]$StartupTimeoutSeconds = 120
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Fail([string]$Message) {
+  Write-Host "::error::$Message"
+  exit 1
+}
+
+function Require-Env([string[]]$Names) {
+  $missing = @()
+  foreach ($name in $Names) {
+    $value = [Environment]::GetEnvironmentVariable($name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+      $missing += $name
+    }
+  }
+  if ($missing.Count -gt 0) {
+    Fail "Missing required Windows e2e secret(s): $($missing -join ', ')"
+  }
+}
+
+function Require-ValidSignature([string]$Path, [string]$Label) {
+  if (-not (Test-Path -LiteralPath $Path)) {
+    Fail "$Label not found: $Path"
+  }
+  $signature = Get-AuthenticodeSignature -FilePath $Path
+  if ($signature.Status -ne "Valid") {
+    Fail "$Label is not validly Authenticode signed. Status=$($signature.Status) Subject=$($signature.SignerCertificate.Subject)"
+  }
+  Write-Host "$Label signature valid: $Path"
+}
+
+function Wait-ForCdp([int]$Port, [int]$TimeoutSeconds) {
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  $url = "http://127.0.0.1:$Port/json/version"
+  do {
+    try {
+      $response = Invoke-RestMethod -Uri $url -Method Get -TimeoutSec 2
+      if ($response.webSocketDebuggerUrl) {
+        return
+      }
+    } catch {
+      Start-Sleep -Milliseconds 500
+    }
+  } while ((Get-Date) -lt $deadline)
+
+  Fail "Timed out waiting for WebView2 remote debugging endpoint at $url"
+}
+
+function Find-RequiredFile([string]$Root, [string]$Filter, [string]$Label) {
+  $match = Get-ChildItem -Path $Root -Filter $Filter -Recurse -File -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+  if (-not $match) {
+    Fail "Installed app is missing $Label under $Root"
+  }
+  return $match.FullName
+}
+
+Require-Env @(
+  "SEREN_E2E_EMAIL",
+  "SEREN_E2E_PASSWORD",
+  "SEREN_E2E_HISTORY_PROJECT_ID",
+  "SEREN_E2E_HISTORY_BRANCH_ID",
+  "SEREN_E2E_HISTORY_DATABASE_NAME",
+  "SEREN_E2E_GITHUB_USERNAME",
+  "SEREN_E2E_GITHUB_PASSWORD",
+  "SEREN_E2E_GITHUB_PAT"
+)
+
+if (-not [string]::IsNullOrWhiteSpace($env:SEREN_E2E_API_BASE) -and $env:SEREN_E2E_API_BASE.TrimEnd("/") -ne "https://api.serendb.com") {
+  Fail "Windows e2e must run against production. SEREN_E2E_API_BASE=$env:SEREN_E2E_API_BASE"
+}
+$env:SEREN_E2E_API_BASE = "https://api.serendb.com"
+$env:SEREN_E2E_CDP_ENDPOINT = "http://127.0.0.1:$RemoteDebugPort"
+
+$resolvedInstaller = (Resolve-Path -LiteralPath $InstallerPath).Path
+Require-ValidSignature $resolvedInstaller "Windows NSIS installer"
+
+Get-Process -Name "Seren" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+if (Test-Path -LiteralPath $InstallDir) {
+  Remove-Item -LiteralPath $InstallDir -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+Write-Host "Installing SerenDesktop into $InstallDir"
+$installArgs = @("/S", "/D=$InstallDir")
+$install = Start-Process -FilePath $resolvedInstaller -ArgumentList $installArgs -Wait -PassThru
+if ($install.ExitCode -ne 0) {
+  Fail "NSIS installer exited with $($install.ExitCode)"
+}
+
+$appExe = Join-Path $InstallDir "Seren.exe"
+if (-not (Test-Path -LiteralPath $appExe)) {
+  $appExe = Find-RequiredFile $InstallDir "Seren.exe" "Seren.exe"
+}
+Require-ValidSignature $appExe "Installed Seren.exe"
+
+$runtimeRoot = Join-Path $InstallDir "embedded-runtime"
+if (-not (Test-Path -LiteralPath $runtimeRoot)) {
+  Fail "Installed app is missing embedded-runtime at $runtimeRoot"
+}
+$nodeExe = Find-RequiredFile $runtimeRoot "node.exe" "bundled node.exe"
+$npmCmd = Find-RequiredFile $runtimeRoot "npm.cmd" "bundled npm.cmd"
+$providerRuntime = Find-RequiredFile $runtimeRoot "provider-runtime.mjs" "provider-runtime.mjs"
+
+$nodeVersion = & $nodeExe --version
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($nodeVersion)) {
+  Fail "Bundled node.exe did not execute successfully"
+}
+$npmVersion = & $npmCmd --version
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($npmVersion)) {
+  Fail "Bundled npm.cmd did not execute successfully"
+}
+Write-Host "Bundled runtime verified: node=$nodeVersion npm=$npmVersion providerRuntime=$providerRuntime"
+
+$env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$RemoteDebugPort --remote-allow-origins=*"
+Write-Host "Launching Seren.exe with WebView2 remote debugging on port $RemoteDebugPort"
+$app = Start-Process -FilePath $appExe -PassThru
+
+try {
+  Wait-ForCdp -Port $RemoteDebugPort -TimeoutSeconds $StartupTimeoutSeconds
+  node "$PSScriptRoot/windows-e2e-app.mjs"
+  if ($LASTEXITCODE -ne 0) {
+    Fail "Windows app e2e script failed with exit code $LASTEXITCODE"
+  }
+} finally {
+  if ($null -ne $app -and -not $app.HasExited) {
+    Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
+  }
+  Get-Process -Name "Seren" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+}

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Guardrail for the Windows release gate added for #2265.
+// ABOUTME: Prevents the release workflow from drifting back to build-only certification.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const releaseWorkflow = readFileSync(
+  join(root, ".github/workflows/release.yml"),
+  "utf8",
+);
+const runner = readFileSync(join(root, "scripts/windows-e2e-app.ps1"), "utf8");
+const probe = readFileSync(join(root, "scripts/windows-e2e-app.mjs"), "utf8");
+
+function workflowJob(name: string): string {
+  const start = releaseWorkflow.indexOf(`  ${name}:`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const next = releaseWorkflow
+    .slice(start + 1)
+    .search(/\n  [a-zA-Z0-9_-]+:\n/);
+  return next === -1
+    ? releaseWorkflow.slice(start)
+    : releaseWorkflow.slice(start, start + 1 + next);
+}
+
+describe("Windows production e2e release gate", () => {
+  it("blocks release publishing on the AWS Windows e2e job", () => {
+    expect(releaseWorkflow).toContain("windows-app-e2e:");
+    expect(releaseWorkflow).toContain("needs: build");
+    expect(releaseWorkflow).toContain("aws ssm send-command");
+    expect(releaseWorkflow).toContain("aws ssm get-command-invocation");
+    expect(releaseWorkflow).toContain("WINDOWS_E2E_INSTANCE_ID");
+    expect(releaseWorkflow).toContain("WINDOWS_E2E_S3_BUCKET");
+    expect(releaseWorkflow).toMatch(
+      /publish-release:\s*\n\s*needs:\s*\[create-release, build, windows-app-e2e\]/,
+    );
+    expect(workflowJob("windows-app-e2e")).not.toContain(
+      "continue-on-error: true",
+    );
+  });
+
+  it("requires real production credentials and a live history-sync tenant", () => {
+    for (const required of [
+      "SEREN_E2E_EMAIL",
+      "SEREN_E2E_PASSWORD",
+      "SEREN_E2E_HISTORY_PROJECT_ID",
+      "SEREN_E2E_HISTORY_BRANCH_ID",
+      "SEREN_E2E_HISTORY_DATABASE_NAME",
+      "SEREN_E2E_GITHUB_USERNAME",
+      "SEREN_E2E_GITHUB_PASSWORD",
+      "SEREN_E2E_GITHUB_PAT",
+    ]) {
+      expect(runner).toContain(required);
+      expect(probe).toContain(required);
+    }
+    expect(runner).toContain("https://api.serendb.com");
+    expect(probe).toContain("https://api.serendb.com");
+  });
+
+  it("installs and probes the signed Windows app instead of running a browser mock", () => {
+    expect(runner).toContain("Get-AuthenticodeSignature");
+    expect(runner).toContain("/S");
+    expect(runner).toContain("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS");
+    expect(runner).toContain("node.exe");
+    expect(runner).toContain("npm.cmd");
+    expect(runner).toContain("windows-e2e-app.mjs");
+    expect(probe).toContain("connectOverCDP");
+    expect(probe).toContain("__TAURI_INTERNALS__");
+  });
+
+  it("covers the required production journeys", () => {
+    for (const required of [
+      "provider_runtime_get_config",
+      "provider_spawn",
+      "provider_prompt",
+      "history_sync_run_now",
+      "history_sync_wipe_remote",
+      "get_oauth_redirect_url",
+      "/oauth/connections",
+      "create_meeting",
+      "start_meeting_capture",
+      "stop_meeting_capture",
+    ]) {
+      expect(probe).toContain(required);
+    }
+    expect(probe).toContain("SEREN_WINDOWS_E2E_OK");
+  });
+});


### PR DESCRIPTION
Fixes #2265

## Summary
- add a Windows app e2e runner that installs the signed NSIS artifact, verifies signatures and bundled node/npm, then drives production journeys through Playwright CDP
- cover fresh production sign-in, provider runtime prompt, live history-sync wipe/resync, GitHub OAuth connect/reconnect, and meeting capture with real credentials from SSM Parameter Store
- add a release workflow job that runs the full Windows e2e on the AWS Windows host before publish-release can run
- add a focused guard test so the release gate cannot drift back to build-only certification

## Tests
- pnpm vitest run tests/unit/windows-e2e-release-gate.test.ts
- node --check scripts/windows-e2e-app.mjs
- pwsh parser check for scripts/windows-e2e-app.ps1

## Notes
- The actual production Windows e2e requires the signed release artifact, AWS SSM host, and SSM Parameter Store credentials; the workflow fails closed if they are missing.