### PR TITLE
Fix OAuth reconnect refresh-token recovery

### DIFF
--- a/src/components/chat/ToolCallCard.tsx
+++ b/src/components/chat/ToolCallCard.tsx
@@ -159,7 +159,9 @@ const OAuthToolConnectPrompt: Component<{
       const resolved = await resolveOAuthProviderForPublisher(
         props.action.publisherSlug,
       );
-      await connectPublisher(resolved.providerSlug);
+      await connectPublisher(resolved.providerSlug, {
+        revokeBeforeConnect: props.action.revokeBeforeConnect,
+      });
       setOpened(true);
     } catch (err) {
       setConnectError(

--- a/src/lib/oauth-tool-errors.ts
+++ b/src/lib/oauth-tool-errors.ts
@@ -8,6 +8,7 @@ export type OAuthConnectActionReason =
 export interface OAuthConnectAction {
   publisherSlug: string;
   reason: OAuthConnectActionReason;
+  revokeBeforeConnect?: boolean;
 }
 
 const OAUTH_REFRESH_ERROR_MARKERS = [
@@ -94,10 +95,14 @@ export function getOAuthConnectActionForToolError(
   const publisherSlug = parseGatewayPublisherSlug(toolName);
   if (!publisherSlug) return null;
 
-  if (
-    isOAuthConnectionRequiredError(errorMessage) ||
-    isOAuthRefreshError(errorMessage)
-  ) {
+  if (isOAuthRefreshError(errorMessage)) {
+    return {
+      publisherSlug,
+      reason: "connection_required",
+      revokeBeforeConnect: true,
+    };
+  }
+  if (isOAuthConnectionRequiredError(errorMessage)) {
     return { publisherSlug, reason: "connection_required" };
   }
   if (isOAuthScopeError(errorMessage)) {

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -22,6 +22,15 @@ export interface PublisherOAuthProviderResolution {
   providerName: string;
 }
 
+export interface ConnectPublisherOptions {
+  /**
+   * Used for refresh-token failures where the gateway still has a stale
+   * provider grant. Revoking first forces providers like Google through fresh
+   * consent so a new refresh token can be minted.
+   */
+  revokeBeforeConnect?: boolean;
+}
+
 let providerLookupPromise: Promise<
   Map<string, PublisherOAuthProviderResolution>
 > | null = null;
@@ -122,12 +131,19 @@ export async function resolveOAuthProviderForPublisher(
  *
  * In dev mode, uses localhost redirect for easier testing without deep link conflicts.
  */
-export async function connectPublisher(providerSlug: string): Promise<void> {
+export async function connectPublisher(
+  providerSlug: string,
+  options: ConnectPublisherOptions = {},
+): Promise<void> {
   console.log(`[PublisherOAuth] Starting OAuth flow for ${providerSlug}`);
 
   const token = await getToken();
   if (!token) {
     throw new Error("Not authenticated. Please log in first.");
+  }
+
+  if (options.revokeBeforeConnect) {
+    await revokePublisherConnection(providerSlug, { ignoreNotFound: true });
   }
 
   // Use deep links on macOS/Linux where seren:// URL scheme is registered.
@@ -184,20 +200,41 @@ export async function listConnectedPublishers(): Promise<
  */
 export async function disconnectPublisher(providerSlug: string): Promise<void> {
   console.log(`[PublisherOAuth] Disconnecting ${providerSlug}`);
-  const { error } = await revokeConnection({
+  await revokePublisherConnection(providerSlug);
+  console.log(`[PublisherOAuth] Successfully disconnected ${providerSlug}`);
+}
+
+async function revokePublisherConnection(
+  providerSlug: string,
+  options: { ignoreNotFound?: boolean } = {},
+): Promise<void> {
+  const { error, response } = await revokeConnection({
     path: { provider: providerSlug },
     throwOnError: false,
   });
 
   if (error) {
+    if (options.ignoreNotFound && response?.status === 404) {
+      console.log(
+        `[PublisherOAuth] No existing ${providerSlug} connection to revoke`,
+      );
+      return;
+    }
     console.error(
       `[PublisherOAuth] Error disconnecting ${providerSlug}:`,
       error,
     );
-    throw new Error(`Failed to revoke connection: ${error}`);
+    throw new Error(`Failed to revoke connection: ${formatOAuthError(error)}`);
   }
+}
 
-  console.log(`[PublisherOAuth] Successfully disconnected ${providerSlug}`);
+function formatOAuthError(error: unknown): string {
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return JSON.stringify(error) ?? String(error);
 }
 
 /**

--- a/tests/unit/oauth-tool-errors.test.ts
+++ b/tests/unit/oauth-tool-errors.test.ts
@@ -58,7 +58,11 @@ describe("BYOC OAuth tool errors", () => {
           "gateway__gmail__get_messages",
           message,
         ),
-      ).toEqual({ publisherSlug: "gmail", reason: "connection_required" });
+      ).toEqual({
+        publisherSlug: "gmail",
+        reason: "connection_required",
+        revokeBeforeConnect: true,
+      });
     }
   });
 

--- a/tests/unit/publisher-oauth-reconnect.test.ts
+++ b/tests/unit/publisher-oauth-reconnect.test.ts
@@ -1,0 +1,102 @@
+// ABOUTME: Regression tests for publisher OAuth reconnect refresh-token repair.
+// ABOUTME: Ensures stale provider grants are revoked before fresh authorization.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getToken: vi.fn<() => Promise<string | null>>(),
+  invoke: vi.fn<() => Promise<string>>(),
+  openUrl: vi.fn<() => Promise<void>>(),
+  revokeConnection: vi.fn(),
+}));
+
+vi.mock("@/api", () => ({
+  listConnections: vi.fn(),
+  listProviders: vi.fn(),
+  listStorePublishers: vi.fn(),
+  revokeConnection: mocks.revokeConnection,
+}));
+
+vi.mock("@/lib/config", () => ({
+  apiBase: "https://api.serendb.com",
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  getToken: mocks.getToken,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: mocks.openUrl,
+}));
+
+describe("publisher OAuth reconnect", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: { userAgent: "Macintosh" },
+    });
+    mocks.getToken.mockResolvedValue("access-token");
+    mocks.invoke.mockResolvedValue("https://accounts.example.test/oauth");
+    mocks.openUrl.mockResolvedValue(undefined);
+    mocks.revokeConnection.mockResolvedValue({
+      data: {},
+      response: new Response(null, { status: 200 }),
+    });
+  });
+
+  it("revokes the stale provider connection before opening refresh-failure reconnect", async () => {
+    const { connectPublisher } = await import("@/services/publisher-oauth");
+
+    await connectPublisher("google", { revokeBeforeConnect: true });
+
+    expect(mocks.revokeConnection).toHaveBeenCalledWith({
+      path: { provider: "google" },
+      throwOnError: false,
+    });
+    expect(mocks.invoke).toHaveBeenCalledWith("get_oauth_redirect_url", {
+      bearerToken: "access-token",
+      url: "https://api.serendb.com/oauth/google/authorize?redirect_uri=seren%3A%2F%2Foauth%2Fcallback",
+    });
+    expect(mocks.openUrl).toHaveBeenCalledWith(
+      "https://accounts.example.test/oauth",
+    );
+
+    expect(
+      mocks.revokeConnection.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.invoke.mock.invocationCallOrder[0]);
+    expect(mocks.invoke.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.openUrl.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not revoke before a normal first-connect authorization", async () => {
+    const { connectPublisher } = await import("@/services/publisher-oauth");
+
+    await connectPublisher("google");
+
+    expect(mocks.revokeConnection).not.toHaveBeenCalled();
+    expect(mocks.invoke).toHaveBeenCalledTimes(1);
+    expect(mocks.openUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues reconnect when the stale connection was already gone", async () => {
+    mocks.revokeConnection.mockResolvedValue({
+      error: { message: "Connection not found" },
+      response: new Response(null, { status: 404 }),
+    });
+    const { connectPublisher } = await import("@/services/publisher-oauth");
+
+    await connectPublisher("google", { revokeBeforeConnect: true });
+
+    expect(mocks.invoke).toHaveBeenCalledTimes(1);
+    expect(mocks.openUrl).toHaveBeenCalledWith(
+      "https://accounts.example.test/oauth",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2264

## Summary
- mark refresh-failure OAuth actions as revoke-before-connect
- revoke stale publisher connections before reconnecting while tolerating missing stale records
- add focused unit coverage for refresh-failure actions and reconnect ordering

## Tests
- pnpm vitest run tests/unit/oauth-tool-errors.test.ts tests/unit/publisher-oauth-reconnect.test.ts
- pnpm biome check src/lib/oauth-tool-errors.ts src/services/publisher-oauth.ts src/components/chat/ToolCallCard.tsx tests/unit/oauth-tool-errors.test.ts tests/unit/publisher-oauth-reconnect.test.ts