### PR TITLE
fix(ci): sign .pyd/.node as .dll so CodeSignTool accepts them (#2272)

### DIFF
--- a/scripts/flatten-windows-signables.mjs
+++ b/scripts/flatten-windows-signables.mjs
@@ -10,6 +10,13 @@ import process from "node:process";
 // modules (.pyd are DLLs). Anything else (.cmd, .json, .txt, .py) is left alone.
 const SIGNABLE = new Set([".exe", ".dll", ".node", ".pyd"]);
 
+// SSL.com CodeSignTool dispatches on the file extension against a fixed allowlist
+// and rejects .pyd/.node with "Unsupported file format for signing", even though
+// both are ordinary PE DLLs. Stage those under a .dll name so the signer accepts
+// them; the Authenticode signature lives in the PE Certificate Table, so restoring
+// the signed bytes to the original .pyd/.node path leaves it validly signed.
+const SIGN_AS_DLL = new Set([".node", ".pyd"]);
+
 function walk(dir, out) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
@@ -53,9 +60,15 @@ mkdirSync(stagingDir, { recursive: true });
 const manifest = [];
 found.forEach((original, index) => {
   // Zero-padded index prefix keeps flat names unique even when basenames
-  // collide (Git for Windows ships many same-named DLLs). Original extension
-  // is preserved so the signer dispatches on file type correctly.
-  const flat = `${String(index + 1).padStart(5, "0")}__${basename(original)}`;
+  // collide (Git for Windows ships many same-named DLLs). The extension drives
+  // how the signer dispatches: keep it as-is for .exe/.dll, but rewrite the ones
+  // the signer rejects by extension (.pyd/.node) to .dll. Restore copies by the
+  // original path, so the signed bytes land back on the real .pyd/.node file.
+  const ext = extname(original).toLowerCase();
+  const flatBase = SIGN_AS_DLL.has(ext)
+    ? `${basename(original, ext)}.dll`
+    : basename(original);
+  const flat = `${String(index + 1).padStart(5, "0")}__${flatBase}`;
   copyFileSync(original, join(stagingDir, flat));
   manifest.push({ flat, original });
 });

--- a/tests/unit/windows-signables.test.ts
+++ b/tests/unit/windows-signables.test.ts
@@ -103,17 +103,23 @@ describe("flatten-windows-signables", () => {
     }
   });
 
-  it("flat names preserve the original extension so the signer recognizes file type", () => {
+  it("flat names use signer-supported extensions while preserving original manifest paths", () => {
     const root = join(tmp, "runtime");
     write(join(root, "node.exe"));
     write(join(root, "a.dll"));
     write(join(root, "b.node"));
+    write(join(root, "_ssl.pyd"));
 
     run(FLATTEN, [staging, manifestPath, root]);
 
-    for (const entry of readManifest()) {
-      expect(entry.flat.endsWith(entry.original.slice(entry.original.lastIndexOf(".")))).toBe(true);
-    }
+    const stagedByOriginal = new Map(
+      readManifest().map((entry) => [entry.original.slice(root.length + 1), entry.flat]),
+    );
+
+    expect(stagedByOriginal.get("node.exe")?.endsWith(".exe")).toBe(true);
+    expect(stagedByOriginal.get("a.dll")?.endsWith(".dll")).toBe(true);
+    expect(stagedByOriginal.get("b.node")?.endsWith(".dll")).toBe(true);
+    expect(stagedByOriginal.get("_ssl.pyd")?.endsWith(".dll")).toBe(true);
   });
 
   it("merges multiple roots into one staging dir", () => {


### PR DESCRIPTION
## Problem

The v3.52.0 Windows build failed at **Batch-sign embedded runtime (Windows)** ([run 27236559269](https://github.com/serenorg/seren-desktop/actions/runs/27236559269)):

```
Error: Unsupported file format for signing - pyd
##[error]Something Went Wrong. Please try again.
```

It died on the first Python extension module, `_asyncio.pyd`. In that run, all 680 `.dll` and 708 `.exe` files signed fine — only `.pyd` was rejected.

## Root cause

`scripts/flatten-windows-signables.mjs` (added in #2241) flags `.pyd` as signable on the premise that "`.pyd` are DLLs." True at the PE level, but **SSL.com's CodeSignTool dispatches on the file extension** against a fixed allowlist, and `sign_code` rejects `pyd` outright.

## Fix

Stage `.pyd` (and `.node`, the same failure class — a native Node addon would fail identically) under a `.dll`-extensioned flat name so the signer accepts them. The Authenticode signature is embedded in the PE Certificate Table, so `restore-windows-signables.mjs` — which copies by the original path — writes the signed bytes back to the real `.pyd`/`.node` file, leaving it validly signed. This keeps the Smart App Control coverage #2235 intended rather than dropping `.pyd` and shipping Python extension modules unsigned.

Verified locally: a fixture with `.exe`/`.dll`/`.pyd`/`.node`/`.py` flattens correctly — `.pyd`/`.node` get `.dll` staging names while the manifest points at the true originals; `.exe`/`.dll` are untouched; `.py` is skipped.

Closes #2272

---
Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
