### PR TITLE
fix(updater): block macOS updates from mounted DMGs

### DIFF
--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -2,9 +2,9 @@
 // ABOUTME: Drains Seren-owned child processes, blocks new spawns, and waits for Windows file handles to release.
 
 use serde::Serialize;
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(target_os = "windows")]
 use std::time::Duration;
 use std::time::Instant;
@@ -45,6 +45,102 @@ pub struct PreInstallReport {
     pub handle_released: bool,
     pub locked_node_path: Option<String>,
     pub elapsed_ms: u128,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallPreflightReport {
+    pub install_ready: bool,
+    pub current_app_path: Option<String>,
+    pub reason: Option<String>,
+    pub remediation: Option<String>,
+}
+
+const MACOS_DMG_REASON: &str = "SerenDesktop is running from a mounted installer volume.";
+const MACOS_DMG_REMEDIATION: &str = "Move SerenDesktop to /Applications, eject the installer disk image, reopen Seren, then install the update.";
+
+/// Check whether the updater can safely replace the running app bundle before
+/// downloading the update payload. On macOS, running directly from a mounted
+/// DMG makes Tauri's bundle swap hit `EXDEV` because the current app is under
+/// `/Volumes/*` and the updater's temp backup is on the system data volume.
+#[tauri::command]
+pub async fn updater_install_preflight() -> Result<InstallPreflightReport, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let exe_path = std::env::current_exe()
+            .map_err(|e| format!("failed to resolve current executable: {e}"))?;
+        return Ok(macos_install_preflight_for_exe_path(&exe_path));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(InstallPreflightReport::ready(None))
+    }
+}
+
+impl InstallPreflightReport {
+    fn ready(current_app_path: Option<String>) -> Self {
+        Self {
+            install_ready: true,
+            current_app_path,
+            reason: None,
+            remediation: None,
+        }
+    }
+
+    fn blocked(
+        current_app_path: Option<String>,
+        reason: impl Into<String>,
+        remediation: impl Into<String>,
+    ) -> Self {
+        Self {
+            install_ready: false,
+            current_app_path,
+            reason: Some(reason.into()),
+            remediation: Some(remediation.into()),
+        }
+    }
+}
+
+fn macos_install_preflight_for_exe_path(exe_path: &Path) -> InstallPreflightReport {
+    let current_app_path = app_bundle_path_from_exe_path(exe_path);
+
+    if current_app_path
+        .as_ref()
+        .is_some_and(|path| is_mounted_macos_volume_path(path))
+    {
+        return InstallPreflightReport::blocked(
+            current_app_path.clone(),
+            MACOS_DMG_REASON,
+            MACOS_DMG_REMEDIATION,
+        );
+    }
+
+    InstallPreflightReport::ready(current_app_path)
+}
+
+fn app_bundle_path_from_exe_path(exe_path: &Path) -> Option<String> {
+    let normalized = exe_path.to_string_lossy().replace('\\', "/");
+    let mut search_start = 0;
+    let mut app_bundle_path = None;
+
+    while let Some(relative_index) = normalized[search_start..].find(".app") {
+        let app_end = search_start + relative_index + ".app".len();
+        let ends_component = normalized
+            .as_bytes()
+            .get(app_end)
+            .is_none_or(|byte| *byte == b'/');
+        if ends_component {
+            app_bundle_path = Some(normalized[..app_end].to_string());
+        }
+        search_start = app_end;
+    }
+
+    app_bundle_path
+}
+
+fn is_mounted_macos_volume_path(path: &str) -> bool {
+    path == "/Volumes" || path.starts_with("/Volumes/")
 }
 
 /// Drain every Seren-owned child process tree and wait until the bundled
@@ -237,5 +333,47 @@ mod tests {
         // Re-engaging after release works (a second update attempt).
         guard.engage();
         assert!(guard.is_engaged());
+    }
+
+    #[test]
+    fn macos_install_preflight_blocks_mounted_dmg_bundle() {
+        let report = macos_install_preflight_for_exe_path(Path::new(
+            "/Volumes/SerenDesktop/SerenDesktop.app/Contents/MacOS/Seren",
+        ));
+
+        assert!(!report.install_ready);
+        assert_eq!(
+            report.current_app_path.as_deref(),
+            Some("/Volumes/SerenDesktop/SerenDesktop.app")
+        );
+        assert_eq!(report.reason.as_deref(), Some(MACOS_DMG_REASON));
+        assert_eq!(report.remediation.as_deref(), Some(MACOS_DMG_REMEDIATION));
+    }
+
+    #[test]
+    fn macos_install_preflight_allows_applications_bundle() {
+        let report = macos_install_preflight_for_exe_path(Path::new(
+            "/Applications/SerenDesktop.app/Contents/MacOS/Seren",
+        ));
+
+        assert!(report.install_ready);
+        assert_eq!(
+            report.current_app_path.as_deref(),
+            Some("/Applications/SerenDesktop.app")
+        );
+        assert!(report.reason.is_none());
+        assert!(report.remediation.is_none());
+    }
+
+    #[test]
+    fn app_bundle_path_resolves_from_nested_resource_paths() {
+        let path = app_bundle_path_from_exe_path(Path::new(
+            "/Volumes/SerenDesktop/SerenDesktop.app/Contents/Resources/embedded-runtime/darwin-arm64/node/bin/node",
+        ));
+
+        assert_eq!(
+            path.as_deref(),
+            Some("/Volumes/SerenDesktop/SerenDesktop.app")
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -901,6 +901,7 @@ pub fn run() {
             embedded_runtime::get_embedded_runtime_info,
             provider_runtime::provider_runtime_get_config,
             provider_runtime::provider_runtime_stop,
+            commands::updater::updater_install_preflight,
             commands::updater::updater_pre_install,
             commands::updater::updater_pre_install_release,
             // CLI installer commands

--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -80,8 +80,10 @@ async function initUpdater(): Promise<void> {
   // without it users see "app stopped, nothing happens" and assume failure.
   // OK is the only choice: skipped upgrades mean users on old broken builds.
   if (state.status === "available") {
-    await acknowledgeAutoInstall(state.availableVersion);
-    await installAvailableUpdate();
+    if (await installPreflight()) {
+      await acknowledgeAutoInstall(state.availableVersion);
+      await installAvailableUpdate({ preflightAlreadyPassed: true });
+    }
   }
 
   // Re-check every 15 minutes so the badge appears without requiring a restart
@@ -186,6 +188,69 @@ interface PreInstallReport {
   elapsedMs: number;
 }
 
+interface InstallPreflightReport {
+  installReady: boolean;
+  currentAppPath: string | null;
+  reason: string | null;
+  remediation: string | null;
+}
+
+const MACOS_DMG_UPDATE_REMEDIATION =
+  "Move SerenDesktop to /Applications, eject the installer disk image, reopen Seren, then install the update.";
+
+async function installPreflight(): Promise<boolean> {
+  if (!isTauriRuntime()) return false;
+
+  try {
+    const report = await invoke<InstallPreflightReport>(
+      "updater_install_preflight",
+    );
+    if (report.installReady) return true;
+
+    const remediation = report.remediation ?? MACOS_DMG_UPDATE_REMEDIATION;
+    const reason =
+      report.reason ??
+      "SerenDesktop cannot install updates from this app location.";
+    console.error("[Updater] Install blocked by preflight:", reason);
+    telemetry.captureError(new Error(reason), {
+      type: "updater",
+      phase: "install_preflight",
+      currentAppPath: report.currentAppPath ?? "unknown",
+    });
+    setState({
+      status: "error",
+      error: remediation,
+      downloadedBytes: 0,
+      totalBytes: 0,
+      progressPercent: 0,
+    });
+
+    try {
+      await message(remediation, {
+        title: "Move Seren to Applications",
+        kind: "warning",
+        okLabel: "OK",
+      });
+    } catch (dialogError) {
+      const err =
+        dialogError instanceof Error
+          ? dialogError
+          : new Error(String(dialogError));
+      console.warn("[Updater] Preflight dialog failed:", err.message);
+    }
+
+    return false;
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.warn("[Updater] Install preflight failed:", err.message);
+    telemetry.captureError(err, {
+      type: "updater",
+      phase: "install_preflight",
+    });
+    return true;
+  }
+}
+
 /** Drain Seren-owned child processes before handing control to the NSIS
  *  installer / macOS updater. Failure to drain on Windows is the root cause
  *  of #2230's "Error opening file for writing: node.exe" — a stale bundled
@@ -227,7 +292,13 @@ async function preInstallShutdown(): Promise<PreInstallReport | null> {
   }
 }
 
-async function installAvailableUpdate(): Promise<void> {
+interface InstallOptions {
+  preflightAlreadyPassed?: boolean;
+}
+
+async function installAvailableUpdate(
+  options: InstallOptions = {},
+): Promise<void> {
   if (!isTauriRuntime()) {
     console.warn("[Updater] Install skipped: not Tauri runtime");
     return;
@@ -238,6 +309,10 @@ async function installAvailableUpdate(): Promise<void> {
       status: "error",
       error: "No pending update found. Try checking again.",
     });
+    return;
+  }
+
+  if (!options.preflightAlreadyPassed && !(await installPreflight())) {
     return;
   }
 

--- a/tests/unit/updater-store.test.ts
+++ b/tests/unit/updater-store.test.ts
@@ -11,6 +11,7 @@ const {
   clearAllBrowsingDataMock,
   captureErrorMock,
   invokeMock,
+  messageMock,
 } = vi.hoisted(() => ({
   mockStoreState: {} as Record<string, unknown>,
   isTauriRuntimeMock: vi.fn<() => boolean>(),
@@ -19,6 +20,7 @@ const {
   clearAllBrowsingDataMock: vi.fn(),
   captureErrorMock: vi.fn(),
   invokeMock: vi.fn(),
+  messageMock: vi.fn(),
 }));
 
 vi.mock("solid-js/store", () => ({
@@ -37,6 +39,10 @@ vi.mock("@/lib/tauri-bridge", () => ({
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: invokeMock,
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  message: messageMock,
 }));
 
 vi.mock("@tauri-apps/plugin-updater", () => ({
@@ -69,14 +75,29 @@ describe("updaterStore install flow", () => {
     clearAllBrowsingDataMock.mockReset();
     captureErrorMock.mockReset();
     invokeMock.mockReset();
-    invokeMock.mockResolvedValue({
-      mcpDrained: true,
-      terminalsDrained: true,
-      providerRuntimeDrained: true,
-      claudeMemoryDrained: true,
-      handleReleased: true,
-      lockedNodePath: null,
-      elapsedMs: 10,
+    messageMock.mockReset();
+    messageMock.mockResolvedValue(undefined);
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "updater_install_preflight") {
+        return {
+          installReady: true,
+          currentAppPath: "/Applications/SerenDesktop.app",
+          reason: null,
+          remediation: null,
+        };
+      }
+      if (command === "updater_pre_install") {
+        return {
+          mcpDrained: true,
+          terminalsDrained: true,
+          providerRuntimeDrained: true,
+          claudeMemoryDrained: true,
+          handleReleased: true,
+          lockedNodePath: null,
+          elapsedMs: 10,
+        };
+      }
+      return undefined;
     });
     // Vitest sets import.meta.env.DEV=true; the prod-only code paths under
     // test would otherwise short-circuit through isDevRuntime().
@@ -161,11 +182,52 @@ describe("updaterStore install flow", () => {
     await updaterStore.checkForUpdates();
     await updaterStore.installAvailableUpdate();
 
+    expect(invokeMock).toHaveBeenCalledWith("updater_install_preflight");
     expect(invokeMock).toHaveBeenCalledWith("updater_pre_install");
     expect(downloadAndInstallMock).toHaveBeenCalledOnce();
-    expect(invokeMock.mock.invocationCallOrder[0]).toBeLessThan(
+    const preInstallCallIndex = invokeMock.mock.calls.findIndex(
+      (call) => call[0] === "updater_pre_install",
+    );
+    expect(invokeMock.mock.invocationCallOrder[preInstallCallIndex]).toBeLessThan(
       downloadAndInstallMock.mock.invocationCallOrder[0],
     );
+  });
+
+  it("blocks macOS updater installs when running from a mounted DMG (#2273)", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const downloadAndInstallMock = vi.fn(async () => {});
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "updater_install_preflight") {
+        return {
+          installReady: false,
+          currentAppPath: "/Volumes/SerenDesktop/SerenDesktop.app",
+          reason: "SerenDesktop is running from a mounted installer volume.",
+          remediation:
+            "Move SerenDesktop to /Applications, eject the installer disk image, reopen Seren, then install the update.",
+        };
+      }
+      throw new Error(`unexpected invoke: ${command}`);
+    });
+    checkMock.mockResolvedValue({
+      version: "3.51.7",
+      downloadAndInstall: downloadAndInstallMock,
+    });
+
+    const { updaterStore } = await import("@/stores/updater.store");
+
+    await updaterStore.checkForUpdates();
+    await updaterStore.installAvailableUpdate();
+
+    expect(downloadAndInstallMock).not.toHaveBeenCalled();
+    expect(invokeMock).toHaveBeenCalledOnce();
+    expect(invokeMock).toHaveBeenCalledWith("updater_install_preflight");
+    expect(mockStoreState.status).toBe("error");
+    expect(mockStoreState.error).toContain("/Applications");
+    expect(captureErrorMock).toHaveBeenCalledWith(expect.any(Error), {
+      type: "updater",
+      phase: "install_preflight",
+      currentAppPath: "/Volumes/SerenDesktop/SerenDesktop.app",
+    });
   });
 
   it("continues install when pre-install handle release times out", async () => {
@@ -175,14 +237,24 @@ describe("updaterStore install flow", () => {
     // may still succeed if the kernel flushes the handle by the time NSIS
     // gets there.
     isTauriRuntimeMock.mockReturnValue(true);
-    invokeMock.mockResolvedValue({
-      mcpDrained: true,
-      terminalsDrained: true,
-      providerRuntimeDrained: true,
-      claudeMemoryDrained: true,
-      handleReleased: false,
-      lockedNodePath: "C:\\Users\\u\\AppData\\Local\\SerenDesktop\\embedded-runtime\\win32-x64\\node\\node.exe",
-      elapsedMs: 15000,
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "updater_install_preflight") {
+        return {
+          installReady: true,
+          currentAppPath: null,
+          reason: null,
+          remediation: null,
+        };
+      }
+      return {
+        mcpDrained: true,
+        terminalsDrained: true,
+        providerRuntimeDrained: true,
+        claudeMemoryDrained: true,
+        handleReleased: false,
+        lockedNodePath: "C:\\Users\\u\\AppData\\Local\\SerenDesktop\\embedded-runtime\\win32-x64\\node\\node.exe",
+        elapsedMs: 15000,
+      };
     });
     const downloadAndInstallMock = vi.fn(async () => {});
     checkMock.mockResolvedValue({


### PR DESCRIPTION
## Summary

Fixes #2273.

Cristin's log showed the updater repeatedly downloaded v3.51.7 and failed during install with `Cross-device link (os error 18)` while SerenDesktop was running from `/Volumes/SerenDesktop/SerenDesktop.app`. Tauri's macOS updater moves the current `.app` bundle into a temp backup before swapping in the downloaded update; that move cannot cross from a mounted DMG volume to the system temp volume.

This PR adds a shared install preflight:

- Native command `updater_install_preflight` detects macOS `.app` bundles under `/Volumes/*`.
- Startup auto-install and manual install both call the preflight before any update download starts.
- Mounted-DMG installs are blocked with an actionable `/Applications` remediation and telemetry.
- Windows pre-install drain behavior remains unchanged.

## Verification

- `pnpm vitest run tests/unit/updater-store.test.ts`
- `cargo test --lib commands::updater`
- `rustfmt --edition 2024 --check src-tauri/src/commands/updater.rs`
- `pnpm exec biome check src/stores/updater.store.ts`
- `pnpm build` (passes; existing Rolldown PURE annotation and chunk-size warnings remain)

## Audit notes

- Failure path: `src/stores/updater.store.ts -> pendingUpdate.downloadAndInstall()` called Tauri updater while app path was `/Volumes/SerenDesktop/SerenDesktop.app`.
- Fix path: `installPreflight()` now runs before download/child-drain; blocked macOS DMG installs never call `downloadAndInstall()`.
- Impact: macOS DMG launches stop retrying failed installs; installed `/Applications/*.app` path and Windows updater drain still proceed.
