### PR TITLE
fix(terminal): keep CLI copy selection scoped

### DIFF
--- a/src/components/terminal/TerminalBuffer.tsx
+++ b/src/components/terminal/TerminalBuffer.tsx
@@ -321,6 +321,16 @@ function selectAllGrid(grid: GridSnapshot): SelectionRange {
   };
 }
 
+const isMacPlatform = (): boolean => {
+  if (typeof navigator === "undefined") return false;
+  return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+};
+
+const copyShortcutLabel = (): string =>
+  isMacPlatform() ? "⌘C" : "Ctrl+Shift+C";
+const pasteShortcutLabel = (): string =>
+  isMacPlatform() ? "⌘V" : "Ctrl+Shift+V";
+
 /**
  * Best-effort clipboard write. Tauri's webview generally exposes the
  * Async Clipboard API, but some platforms / configurations don't, so
@@ -1150,6 +1160,7 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
 
   const onWindowMouseMove = (e: MouseEvent) => {
     if (!dragAnchor) return;
+    e.preventDefault();
     const cell = canvasMouseToCell(e);
     if (!cell) return;
     if (cell.row !== dragAnchor.row || cell.col !== dragAnchor.col) {
@@ -1158,7 +1169,8 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
     setSelection({ anchor: dragAnchor, head: cell });
   };
 
-  const onWindowMouseUp = () => {
+  const onWindowMouseUp = (e?: MouseEvent) => {
+    e?.preventDefault();
     window.removeEventListener("mousemove", onWindowMouseMove);
     window.removeEventListener("mouseup", onWindowMouseUp);
     if (!dragMoved) {
@@ -1168,6 +1180,17 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
     }
     dragAnchor = null;
     dragMoved = false;
+  };
+
+  const stopTerminalSelectionDrag = () => {
+    window.removeEventListener("mousemove", onWindowMouseMove);
+    window.removeEventListener("mouseup", onWindowMouseUp);
+    dragAnchor = null;
+    dragMoved = false;
+  };
+
+  const preventNativeSelection = (event: Event) => {
+    event.preventDefault();
   };
 
   const onSurfaceMouseDown = (e: MouseEvent) => {
@@ -1199,6 +1222,7 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
       return;
     }
     if (e.button !== 0) return; // left button only for selection
+    e.preventDefault();
     dragAnchor = cell;
     dragMoved = false;
     setSelection({ anchor: cell, head: cell });
@@ -1566,16 +1590,22 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
     if (!mirror) return;
     const docSel = window.getSelection();
     if (!docSel) return;
-    if (!sel || !g) {
+    const clearMirroredDomSelection = () => {
+      const mirroredNode = mirror.firstChild;
+      const ownsSelection =
+        !!mirroredNode && docSel.containsNode(mirroredNode, true);
       mirror.textContent = "";
-      if (mirror.firstChild && docSel.containsNode(mirror.firstChild, true)) {
+      if (ownsSelection) {
         docSel.removeAllRanges();
       }
+    };
+    if (!sel || !g) {
+      clearMirroredDomSelection();
       return;
     }
     const text = selectionText(g, sel);
     if (!text) {
-      mirror.textContent = "";
+      clearMirroredDomSelection();
       return;
     }
     mirror.textContent = text;
@@ -1594,6 +1624,7 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
    */
   const openContextMenu = (event: MouseEvent) => {
     event.preventDefault();
+    stopTerminalSelectionDrag();
     setCtxMenu({ x: event.clientX, y: event.clientY });
   };
 
@@ -1608,7 +1639,7 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
     return [
       {
         label: "Copy",
-        shortcut: "⌘C",
+        shortcut: copyShortcutLabel(),
         disabled: !hasSelection,
         onClick: () => {
           if (!sel || !g) return;
@@ -1617,7 +1648,7 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
       },
       {
         label: "Paste",
-        shortcut: "⌘V",
+        shortcut: pasteShortcutLabel(),
         disabled: !running,
         onClick: () => {
           void (async () => {
@@ -1647,6 +1678,16 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
         },
       },
     ];
+  };
+
+  const handleCopy = (event: ClipboardEvent) => {
+    const sel = selection();
+    const g = grid();
+    if (!sel || !g) return;
+    const text = selectionText(g, sel);
+    if (!text) return;
+    event.clipboardData?.setData("text/plain", text);
+    event.preventDefault();
   };
 
   /**
@@ -1684,6 +1725,27 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
       const g = grid();
       if (sel && g) {
         await writeClipboard(selectionText(g, sel));
+      }
+      return;
+    }
+
+    // Windows/Linux terminal paste chord. macOS Cmd+V is intentionally
+    // left to the browser paste event so denied async-clipboard reads can
+    // still fall back to the platform paste path.
+    const isTerminalPasteChord =
+      !isMacPlatform() &&
+      (k === "v" || k === "V") &&
+      event.ctrlKey &&
+      event.shiftKey;
+    if (isTerminalPasteChord) {
+      event.preventDefault();
+      try {
+        const text = await navigator.clipboard.readText();
+        if (text) {
+          await writePromptText(text);
+        }
+      } catch {
+        // Clipboard read may be denied; the context-menu paste path still works.
       }
       return;
     }
@@ -1971,7 +2033,7 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
                   Focus on mousedown so users can type without Tab-ing in. */}
               <div
                 ref={surfaceRef}
-                class="flex-1 min-h-0 overflow-hidden bg-[#090b0f] outline-none cursor-text"
+                class="flex-1 min-h-0 overflow-hidden bg-[#090b0f] outline-none cursor-text select-none"
                 classList={{
                   // Themed frame: drop-shadow + sky-400 glow only on the
                   // claude CLI surface so plain Terminal threads keep their
@@ -2000,11 +2062,13 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
                 // biome-ignore lint/a11y/noNoninteractiveTabindex: terminal surfaces are interactive widgets that own their keyboard model (matches xterm.js, vscode terminal pattern)
                 tabIndex={0}
                 onKeyDown={(e) => void handleKeyDown(e)}
+                onCopy={(e) => handleCopy(e)}
                 onPaste={(e) => void handlePaste(e)}
                 onMouseDown={onSurfaceMouseDown}
                 onMouseMove={onSurfaceMouseMoveTracking}
                 onWheel={onSurfaceWheel}
                 onContextMenu={openContextMenu}
+                onSelectStart={preventNativeSelection}
               >
                 <canvas ref={canvasRef} class="block pointer-events-none" />
                 {/* Hidden DOM mirror of the canvas selection. The system
@@ -2023,6 +2087,7 @@ export const TerminalBuffer: Component<TerminalBufferProps> = (props) => {
                     top: "0",
                     "white-space": "pre",
                     "user-select": "text",
+                    "-webkit-user-select": "text",
                   }}
                 />
               </div>

--- a/tests/unit/terminal-buffer-copy-paste.test.ts
+++ b/tests/unit/terminal-buffer-copy-paste.test.ts
@@ -60,3 +60,45 @@ describe("TerminalBuffer — system Edit > Copy via DOM selection mirror (#2091)
     expect(terminalBufferTsx).toMatch(/setBaseAndExtent|addRange/);
   });
 });
+
+describe("TerminalBuffer — terminal selection owns browser copy (#2279)", () => {
+  it("suppresses browser-native selection on the canvas surface while drag-selecting terminal cells", () => {
+    // The canvas renderer owns its own cell-range selection. If the
+    // browser's native selection gesture also starts, WebKit/Chromium can
+    // select the entire page and Copy reads unrelated footer/status text.
+    expect(terminalBufferTsx).toMatch(/const preventNativeSelection\s*=/);
+    expect(terminalBufferTsx).toMatch(/onSelectStart=\{preventNativeSelection\}/);
+    expect(terminalBufferTsx).toMatch(/class="[^"]*select-none/);
+    expect(terminalBufferTsx).toMatch(
+      /const onSurfaceMouseDown[\s\S]*e\.preventDefault\(\)[\s\S]*setSelection\(\{ anchor: cell, head: cell \}\)/,
+    );
+  });
+
+  it("handles browser copy events by writing the terminal cell selection, not the native DOM selection", () => {
+    // The hidden DOM mirror makes app-menu Copy fire; this handler makes
+    // the terminal selection authoritative even if the browser selection
+    // would otherwise point at stale page text.
+    expect(terminalBufferTsx).toMatch(/const handleCopy\s*=/);
+    expect(terminalBufferTsx).toMatch(
+      /clipboardData\?\.setData\("text\/plain",\s*text\)/,
+    );
+    expect(terminalBufferTsx).toMatch(/onCopy=\{\(e\) => handleCopy\(e\)\}/);
+  });
+
+  it("labels copy and paste shortcuts by platform without changing Ctrl+C interrupt semantics", () => {
+    // macOS users see Cmd-based shortcuts; Windows/Linux users see the
+    // terminal-safe Ctrl+Shift+C copy chord. Ctrl+C remains reserved for
+    // SIGINT in handleKeyDown.
+    expect(terminalBufferTsx).toMatch(/const isMacPlatform\s*=/);
+    expect(terminalBufferTsx).toMatch(/const copyShortcutLabel\s*=/);
+    expect(terminalBufferTsx).toContain("Ctrl+Shift+C");
+    expect(terminalBufferTsx).toContain("Ctrl+Shift+V");
+    expect(terminalBufferTsx).toMatch(/shortcut:\s*copyShortcutLabel\(\)/);
+    expect(terminalBufferTsx).toMatch(/const isTerminalPasteChord\s*=/);
+    expect(terminalBufferTsx).toMatch(/navigator\.clipboard\.readText\(\)/);
+    expect(terminalBufferTsx).toMatch(/await writePromptText\(text\)/);
+    expect(terminalBufferTsx).toMatch(
+      /event\.ctrlKey && !event\.shiftKey && \(k === "c" \|\| k === "C"\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2279.

- suppress browser-native selection on the canvas terminal surface while Seren owns cell-range selection
- make browser/system Copy events write `selectionText(grid, selection)` instead of trusting whatever DOM selection Chromium/WebKit currently has
- keep the hidden DOM mirror from #2091, but clear its DOM range correctly when terminal selection is empty
- show platform-correct shortcut labels: macOS `⌘C` / `⌘V`, Windows/Linux `Ctrl+Shift+C` / `Ctrl+Shift+V`
- add terminal-safe Windows/Linux paste via `Ctrl+Shift+V`; `Ctrl+C` remains SIGINT

## Functional audit

- Claude CLI path: `ThreadSidebar` launches `command: "claude"` through `createTerminalThread`; copy/paste uses shared `TerminalBuffer` paths.
- Codex CLI path: `ThreadSidebar` launches `command: "codex"` through the same terminal buffer path; copy/paste is not gated on `isClaudeCli()`.
- macOS: `Cmd+C` and app-menu Copy copy terminal cell selection; `Ctrl+C` still interrupts. `Cmd+V` uses the existing paste event path.
- Windows/Linux: `Ctrl+Shift+C` copies terminal cell selection; `Ctrl+Shift+V` reads clipboard and uses the bracketed-paste writer; `Ctrl+C` still interrupts.
- Right-click Copy/Paste uses the same terminal selection/paste code for Claude, Codex, and plain shell terminals.

## Tests

- `pnpm vitest run tests/unit/terminal-buffer-copy-paste.test.ts`
- `pnpm vitest run tests/unit/terminal-buffer-copy-paste.test.ts tests/unit/terminal-key-encoding.test.ts`
- `pnpm vitest run tests/unit/terminal-key-encoding.test.ts tests/unit/terminal-buffer-claude-cli.test.ts tests/unit/terminal-buffer-copy-paste.test.ts`
- `pnpm vitest run`
- `pnpm build`
- `PLAYWRIGHT_WEB_COMMAND="pnpm serve --host 127.0.0.1 --port 1420" PLAYWRIGHT_WEB_TIMEOUT=120000 pnpm exec playwright test tests/e2e/production-bundle.spec.ts --project=chromium`

## Known unrelated checks

- `pnpm exec tsc --noEmit --pretty false` still fails on existing unrelated test typing issues in `tests/unit/meeting-autodetect-dismiss-reset.test.ts` and missing declarations for `bin/browser-local/logging.mjs`.
- `pnpm check` reports existing optional-chain/non-null warnings outside this change; modified terminal files have only pre-existing optional-chain warnings.
