### PR TITLE
fix(ci): throttle Windows signing under SSL.com rate limit (#2282)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,11 @@ permissions:
   contents: write
   id-token: write
 
-# Prevent multiple releases from running simultaneously
+# Serialize ALL release runs (constant group, not per-tag) so two tags cannot
+# sign in parallel and stack signing bursts on the shared SSL.com credential,
+# which trips its per-minute rate limit (#2282). Queued runs wait, never cancel.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 env:
@@ -386,13 +388,21 @@ jobs:
           CARGO_BUILD_TARGET: ${{ matrix.target }}
         run: pnpm prepare:tauri-build
 
+      # Discover the signable set with the tested cross-platform selector, then
+      # sign it throttled to stay under SSL.com's per-minute rate limit (#2282).
+      # The embedded runtime is the only large payload, so it carries the throttle;
+      # the per-file installer/helper signings below stay unthrottled (tiny sets).
       - name: Sign embedded runtime (Windows)
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
         shell: pwsh
         run: |
+          pnpm tsx scripts/windows-signables.ts `
+            src-tauri/embedded-runtime src-tauri/mcp-servers > sign-targets.txt
           ./scripts/sign-windows-payload.ps1 `
             -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT `
-            -Root src-tauri/embedded-runtime, src-tauri/mcp-servers
+            -ListFile sign-targets.txt `
+            -BatchSize 10 `
+            -DelaySeconds 30
 
       # Build the app (with signing for macOS when certificates available)
       # Note: APPLE_ID/PASSWORD/TEAM_ID removed to prevent Tauri's internal notarization

--- a/scripts/sign-windows-payload.ps1
+++ b/scripts/sign-windows-payload.ps1
@@ -1,5 +1,5 @@
 # ABOUTME: Signs Windows PE binaries in place with signtool using the eSigner CKA-loaded EV cert (#2276).
-# ABOUTME: Replaces CodeSignTool batch_sign (100-file/batch cap); enumerates signables under roots, signs in batches, fails loud if any file is left unsigned.
+# ABOUTME: Takes signables from -Root/-File/-ListFile, skips already-signed, signs in throttled batches (#2282), fails loud if any file is left unsigned.
 
 [CmdletBinding()]
 param(
@@ -9,9 +9,16 @@ param(
   [string[]]$Root = @(),
   # Explicit files to sign (in addition to anything found under -Root).
   [string[]]$File = @(),
+  # Newline-delimited file produced by scripts/windows-signables.ts — the
+  # discovered embedded-runtime signable set. Each non-empty line is a path.
+  [string]$ListFile = "",
   # Files per signtool invocation — amortizes process startup while staying well
   # under the Windows command-line length limit.
   [int]$BatchSize = 50,
+  # Seconds to pause between batches. Each signtool call signs one cloud hash per
+  # file, so bursting the whole payload trips SSL.com's per-minute rate limit
+  # (#2282). Pausing between batches holds the request rate under that ceiling.
+  [int]$DelaySeconds = 0,
   [int]$MaxRetries = 3
 )
 
@@ -52,13 +59,44 @@ foreach ($r in $Root) {
     if ($signableExt -contains $_.Extension.ToLower()) { $targets.Add($_.FullName) }
   }
 }
+if ($ListFile) {
+  if (-not (Test-Path -LiteralPath $ListFile)) {
+    Write-Host "::error::ListFile not found: $ListFile"
+    exit 1
+  }
+  Get-Content -LiteralPath $ListFile | ForEach-Object {
+    $line = $_.Trim()
+    if (-not $line) { return }
+    if (-not (Test-Path -LiteralPath $line)) {
+      Write-Host "::error::Listed signable not found: $line"
+      exit 1
+    }
+    $targets.Add((Resolve-Path -LiteralPath $line).Path)
+  }
+}
 
 $targets = @($targets | Sort-Object -Unique)
 if ($targets.Count -eq 0) {
-  Write-Host "::error::No signable files found under roots [$($Root -join ', ')] / files [$($File -join ', ')]."
+  Write-Host "::error::No signable files found under roots [$($Root -join ', ')] / files [$($File -join ', ')] / list [$ListFile]."
   exit 1
 }
-Write-Host "Signing $($targets.Count) file(s) in batches of $BatchSize..."
+
+# Skip files that already carry a valid Authenticode signature — Smart App
+# Control honors any valid signature regardless of publisher, so re-signing
+# them only burns cloud signatures against the rate limit (#2282).
+$discovered = $targets.Count
+$targets = @($targets | Where-Object {
+  (Get-AuthenticodeSignature -FilePath $_).Status -ne "Valid"
+})
+$skipped = $discovered - $targets.Count
+if ($skipped -gt 0) {
+  Write-Host "Skipping $skipped already-validly-signed file(s)."
+}
+if ($targets.Count -eq 0) {
+  Write-Host "All $discovered discovered file(s) already validly signed; nothing to do."
+  exit 0
+}
+Write-Host "Signing $($targets.Count) file(s) in batches of $BatchSize (delay ${DelaySeconds}s between batches)..."
 
 # signtool signs each file by sending only its hash to the SSL.com cloud (one op
 # per file). Retry each batch for transient cloud/timestamp failures.
@@ -79,6 +117,10 @@ for ($i = 0; $i -lt $targets.Count; $i += $BatchSize) {
     Start-Sleep -Seconds (5 * $attempt)
   }
   Write-Host "  signed $([Math]::Min($i + $BatchSize, $targets.Count))/$($targets.Count)"
+  # Throttle between batches (not after the last) to stay under the rate limit.
+  if ($DelaySeconds -gt 0 -and ($i + $BatchSize) -lt $targets.Count) {
+    Start-Sleep -Seconds $DelaySeconds
+  }
 }
 
 # Fail loud if the signer silently dropped any file (the #2223 guarantee): every

--- a/scripts/windows-signables.ts
+++ b/scripts/windows-signables.ts
@@ -1,0 +1,65 @@
+// ABOUTME: Cross-platform discovery of Windows PE files that must be EV-signed before release.
+// ABOUTME: Single source of truth for the embedded-runtime signable set; bounds signtool volume to stay under SSL.com's rate limit (#2282).
+
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+// Authenticode-signable PE extensions. .pyd/.node are ordinary DLLs that
+// signtool signs in place by content.
+export const SIGNABLE_EXTENSIONS = new Set([".exe", ".dll", ".node", ".pyd"]);
+
+export interface CollectOptions {
+  /** Override the set of signable extensions (lower-case, leading dot). */
+  signableExtensions?: Set<string>;
+  /** Skip any path whose POSIX-normalized form matches one of these patterns. */
+  exclude?: RegExp[];
+}
+
+function walk(dir: string, exts: Set<string>, exclude: RegExp[], out: Set<string>): void {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    // Missing or unreadable root — skip (mirrors the signer's "Skipping missing root").
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    const posix = full.split(path.sep).join("/");
+    if (exclude.some((re) => re.test(posix))) continue;
+    // Use real directory entries only; do not follow symlinked dirs (avoids loops).
+    if (entry.isDirectory()) {
+      walk(full, exts, exclude, out);
+    } else if (entry.isFile() && exts.has(path.extname(entry.name).toLowerCase())) {
+      out.add(full);
+    }
+  }
+}
+
+/**
+ * Recursively collect every signable PE file under the given roots.
+ * Deduplicates across overlapping roots and returns a sorted, deterministic list.
+ */
+export function collectSignables(roots: string[], opts: CollectOptions = {}): string[] {
+  const exts = opts.signableExtensions ?? SIGNABLE_EXTENSIONS;
+  const exclude = opts.exclude ?? [];
+  const out = new Set<string>();
+  for (const root of roots) {
+    walk(root, exts, exclude, out);
+  }
+  return [...out].sort();
+}
+
+// CLI: `tsx scripts/windows-signables.ts <root> [<root> ...]`
+// Prints one absolute path per line for the release signer to consume via -ListFile.
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.url.replace(/^file:\/\//, ""));
+if (isMain) {
+  const roots = process.argv.slice(2);
+  if (roots.length === 0) {
+    console.error("usage: windows-signables.ts <root> [<root> ...]");
+    process.exit(2);
+  }
+  const files = collectSignables(roots);
+  process.stdout.write(files.join("\n") + (files.length ? "\n" : ""));
+}

--- a/tests/unit/windows-signables.test.ts
+++ b/tests/unit/windows-signables.test.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Tests for cross-platform Windows signable-file discovery used by the release signer.
+// ABOUTME: Real temp-filesystem trees (no mocks) covering extension filtering, recursion, dedupe, exclusion, and missing roots.
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { collectSignables } from "../../scripts/windows-signables";
+
+let root: string;
+
+function touch(rel: string): string {
+  const full = path.join(root, rel);
+  mkdirSync(path.dirname(full), { recursive: true });
+  writeFileSync(full, "x");
+  return full;
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "signables-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("collectSignables", () => {
+  it("selects only PE-signable extensions and ignores the rest", () => {
+    const exe = touch("node.exe");
+    const dll = touch("lib/libssl.dll");
+    const node = touch("native/addon.node");
+    const pyd = touch("py/_ssl.pyd");
+    touch("readme.txt");
+    touch("data/config.json");
+    touch("LICENSE");
+
+    const got = collectSignables([root]);
+
+    expect(got).toEqual([dll, node, pyd, exe].sort());
+  });
+
+  it("recurses into nested directories", () => {
+    const deep = touch("a/b/c/d/deep.dll");
+    expect(collectSignables([root])).toEqual([deep]);
+  });
+
+  it("matches extensions case-insensitively", () => {
+    const a = touch("A.DLL");
+    const b = touch("B.Exe");
+    expect(collectSignables([root]).sort()).toEqual([a, b].sort());
+  });
+
+  it("dedupes a file reachable through overlapping roots", () => {
+    const dll = touch("sub/x.dll");
+    const got = collectSignables([root, path.join(root, "sub")]);
+    expect(got).toEqual([dll]);
+  });
+
+  it("skips a missing root without throwing and still scans valid ones", () => {
+    const dll = touch("real.dll");
+    const missing = path.join(root, "does-not-exist");
+    expect(() => collectSignables([missing, root])).not.toThrow();
+    expect(collectSignables([missing, root])).toEqual([dll]);
+  });
+
+  it("applies exclusion patterns against POSIX-normalized paths", () => {
+    const keep = touch("bin/node.exe");
+    touch("git/mingw64/bin/libgmp-10.dll");
+    const got = collectSignables([root], { exclude: [/\/mingw64\//] });
+    expect(got).toEqual([keep]);
+  });
+
+  it("does not follow symlinked directories (avoids recursion loops)", () => {
+    const real = touch("real/x.dll");
+    // Symlink that points back at the tree root would loop a naive walker.
+    symlinkSync(root, path.join(root, "real", "loop"), "dir");
+    const got = collectSignables([root]);
+    expect(got).toEqual([real]);
+  });
+
+  it("returns a sorted, deterministic list", () => {
+    touch("z.dll");
+    touch("a.dll");
+    touch("m.exe");
+    const got = collectSignables([root]);
+    expect(got).toEqual([...got].sort());
+  });
+});


### PR DESCRIPTION
Closes #2282.

## Problem

Windows release builds fail at **Sign embedded runtime (Windows)** with `0x80090003` / "Signing credentials not configured" partway through the payload (first ~50 files sign, the rest fail). Audited from the SSL.com signing-logs export: this is the eSigner **per-minute rate limit**, not a monthly quota and not the malware blocker.

- Metering is per-file (`SIGN_HASH`). 101 signatures *succeeded* on Jun 9 — so a "20/month" cap is not the gate.
- The 101 were a burst: **95 in ~3 minutes (~30/min)** vs a baseline of median 3/day.
- Amplified by the per-tag `concurrency.group`, which let two tags sign in parallel and stack their bursts on the shared credential.

## Fix

1. **Serialize releases** — constant `concurrency.group: release` so two tags queue instead of stacking signing bursts.
2. **Throttle** `sign-windows-payload.ps1` — new `-DelaySeconds` + smaller batches; the embedded-runtime step uses `-BatchSize 10 -DelaySeconds 30` (~12 sig/min, well under the ~30/min that tripped it).
3. **Skip already-validly-signed files** — SAC honors any valid signature regardless of publisher, so re-signing pre-signed node/python/.NET binaries only burns rate-limited cloud signatures.
4. **Tested selector** — `scripts/windows-signables.ts` is the single, cross-platform source of truth for the signable set, consumed via `-ListFile`.

## Out of scope (separate ticket)

Aggressively cutting the signable set by category (e.g. dropping the Git mingw64 DLLs) risks Smart App Control blocking them on users' machines (#2235) and can't be verified locally — it must be validated on a real SAC-enforced Windows box.

## Tests

- `tests/unit/windows-signables.test.ts` — 8 tests against real temp-filesystem trees (extension filtering, recursion, case-insensitivity, dedupe across overlapping roots, missing-root tolerance, exclusion patterns, symlink-loop avoidance, deterministic order). All green.
- `sign-windows-payload.ps1` passes a PowerShell AST parse check.
- CLI smoke-tested: emits clean path-only stdout (no banner contamination), correct extension filtering.

## Verification limits

The `signtool` signing path runs only in CI against SSL.com. It is **not** validated by repeated tagged releases (those re-spend the metered signatures we are conserving); CI's existing loud post-sign verifier confirms full signature coverage at release time.
