### PR TITLE
fix(ci): run signables via dedicated CLI entrypoint (#2284)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,7 +396,7 @@ jobs:
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
         shell: pwsh
         run: |
-          pnpm tsx scripts/windows-signables.ts `
+          pnpm tsx scripts/print-windows-signables.ts `
             src-tauri/embedded-runtime src-tauri/mcp-servers > sign-targets.txt
           ./scripts/sign-windows-payload.ps1 `
             -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT `

--- a/scripts/print-windows-signables.ts
+++ b/scripts/print-windows-signables.ts
@@ -1,0 +1,15 @@
+// ABOUTME: CLI entrypoint that prints the Windows signable set (one absolute path per line) for the release signer.
+// ABOUTME: Always executes — never imported — so there is no fragile entrypoint detection to misfire on Windows (#2284).
+
+import process from "node:process";
+
+import { collectSignables } from "./windows-signables";
+
+const roots = process.argv.slice(2);
+if (roots.length === 0) {
+  console.error("usage: print-windows-signables.ts <root> [<root> ...]");
+  process.exit(2);
+}
+
+const files = collectSignables(roots);
+process.stdout.write(files.join("\n") + (files.length ? "\n" : ""));

--- a/scripts/windows-signables.ts
+++ b/scripts/windows-signables.ts
@@ -3,7 +3,6 @@
 
 import { readdirSync } from "node:fs";
 import path from "node:path";
-import process from "node:process";
 
 // Authenticode-signable PE extensions. .pyd/.node are ordinary DLLs that
 // signtool signs in place by content.
@@ -49,17 +48,4 @@ export function collectSignables(roots: string[], opts: CollectOptions = {}): st
     walk(root, exts, exclude, out);
   }
   return [...out].sort();
-}
-
-// CLI: `tsx scripts/windows-signables.ts <root> [<root> ...]`
-// Prints one absolute path per line for the release signer to consume via -ListFile.
-const isMain = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.url.replace(/^file:\/\//, ""));
-if (isMain) {
-  const roots = process.argv.slice(2);
-  if (roots.length === 0) {
-    console.error("usage: windows-signables.ts <root> [<root> ...]");
-    process.exit(2);
-  }
-  const files = collectSignables(roots);
-  process.stdout.write(files.join("\n") + (files.length ? "\n" : ""));
 }

--- a/tests/unit/print-windows-signables.test.ts
+++ b/tests/unit/print-windows-signables.test.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Functional test for the print-windows-signables CLI entrypoint, spawned as a subprocess like the release step.
+// ABOUTME: Guards the regression where the CLI never executed and emitted an empty signing list (#2284).
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const tsxBin = path.join(repoRoot, "node_modules", ".bin", "tsx");
+const cli = path.join(repoRoot, "scripts", "print-windows-signables.ts");
+
+let root: string;
+
+function touch(rel: string): string {
+  const full = path.join(root, rel);
+  mkdirSync(path.dirname(full), { recursive: true });
+  writeFileSync(full, "x");
+  return full;
+}
+
+function runCli(args: string[]): { stdout: string; status: number } {
+  try {
+    const stdout = execFileSync(tsxBin, [cli, ...args], { encoding: "utf8" });
+    return { stdout, status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; status?: number };
+    return { stdout: e.stdout ?? "", status: e.status ?? 1 };
+  }
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "print-signables-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("print-windows-signables CLI", () => {
+  it("runs as a subprocess and prints the discovered signables, one per line", () => {
+    const exe = touch("node.exe");
+    const dll = touch("lib/libssl.dll");
+    touch("readme.txt");
+
+    const { stdout, status } = runCli([root]);
+
+    expect(status).toBe(0);
+    const lines = stdout.split("\n").filter((l) => l.length > 0);
+    // Only paths, no banner contamination; exactly the two signables.
+    expect(lines.sort()).toEqual([dll, exe].sort());
+  });
+
+  it("emits nothing (not an error) when no signables exist", () => {
+    touch("readme.txt");
+    const { stdout, status } = runCli([root]);
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("");
+  });
+
+  it("exits non-zero when invoked with no roots", () => {
+    const { status } = runCli([]);
+    expect(status).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #2284. Follow-up to #2283 — fixes a P0 found in that PR's post-merge functional audit.

## Bug

`scripts/windows-signables.ts` guarded its CLI with a hand-rolled `import.meta.url`-vs-`argv[1]` check. On the **Windows** runner (the only platform that runs this step) the check is always false:

```
file:///D:/a/.../windows-signables.ts  ->  /D:/a/...  ->  \D:\a\...   !=   D:\a\...  (argv[1])
```

So the CLI never executed, `sign-targets.txt` was empty, and `sign-windows-payload.ps1` failed with `No signable files found` — breaking the release. macOS/Linux matched by luck, so the unit tests missed it.

## Fix

Remove the fragile entrypoint detection entirely:

- `scripts/windows-signables.ts` — pure library (no top-level side effects; safe to import).
- `scripts/print-windows-signables.ts` — dedicated CLI entrypoint that always runs (never imported, no guard).
- `release.yml` calls the entrypoint.

## Tests

- `tests/unit/print-windows-signables.test.ts` spawns the entrypoint as a subprocess (the way the release step does) and asserts it prints the discovered paths, emits nothing for an empty set, and exits non-zero with no roots.
- Existing `windows-signables.test.ts` (8 library tests) still green. 11 total.
