### PR TITLE
fix(ci): use -LiteralPath in signer so '[.exe' doesn't glob (#2286)

### DIFF
--- a/scripts/sign-windows-payload.ps1
+++ b/scripts/sign-windows-payload.ps1
@@ -84,9 +84,11 @@ if ($targets.Count -eq 0) {
 # Skip files that already carry a valid Authenticode signature — Smart App
 # Control honors any valid signature regardless of publisher, so re-signing
 # them only burns cloud signatures against the rate limit (#2282).
+# -LiteralPath, not -FilePath: the runtime ships binaries like "[.exe" whose
+# brackets -FilePath would mis-parse as a wildcard pattern (#2286).
 $discovered = $targets.Count
 $targets = @($targets | Where-Object {
-  (Get-AuthenticodeSignature -FilePath $_).Status -ne "Valid"
+  (Get-AuthenticodeSignature -LiteralPath $_).Status -ne "Valid"
 })
 $skipped = $discovered - $targets.Count
 if ($skipped -gt 0) {
@@ -127,7 +129,7 @@ for ($i = 0; $i -lt $targets.Count; $i += $BatchSize) {
 # target must carry a Valid Authenticode signature before we proceed.
 $unsigned = @()
 foreach ($t in $targets) {
-  $sig = Get-AuthenticodeSignature -FilePath $t
+  $sig = Get-AuthenticodeSignature -LiteralPath $t
   if ($sig.Status -ne "Valid") { $unsigned += "$t : $($sig.Status)" }
 }
 if ($unsigned.Count -gt 0) {


### PR DESCRIPTION
Closes #2286.

## Bug

The Windows "Sign embedded runtime" step crashed **before signing anything**:

```
Get-AuthenticodeSignature: scripts/sign-windows-payload.ps1:89
  | The specified wildcard character pattern is not valid: [.exe
```

`Get-AuthenticodeSignature -FilePath` treats its argument as a **wildcard pattern**. The bundled Git-for-Windows toolchain ships a real binary literally named `[.exe` (the POSIX `[`/`test` command), whose `[` is an invalid wildcard → crash, exit 1.

## Fix

Switch both call sites to `-LiteralPath` (literal, no globbing):
- the skip-already-signed pre-filter (added in #2283)
- the post-sign verifier loop (pre-existing latent bug — would have crashed on `[.exe` after signing regardless)

Audited the rest of the script: every other path access already uses `-LiteralPath` / literal native args.

## Notes

- **No signatures were spent** — the crash is before `signtool` runs, so no SSL.com rate-limit/quota cost.
- `Get-AuthenticodeSignature` is Windows-only (absent from macOS/Linux pwsh), so this can't be unit-tested without a Windows runner. Validated by pwsh AST parse check + the live release.
- This is the first fix that lets a run actually reach the throttled `signtool` signing (prior runs crashed before it).
