### PR TITLE
fix(ci): drop unshipped nsis-updater byproduct before audit (#2289)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -820,6 +820,23 @@ jobs:
           Write-Host "All binaries inside the .nsis.zip updater bundle are validly signed."
           Remove-Item -Path $extractDir -Recurse -Force
 
+      # createUpdaterArtifacts emits a second, duplicate installer copy under
+      # bundle/nsis-updater/ that nothing ships — the installer uploads from
+      # bundle/nsis/*.exe and the updater from bundle/nsis/*.nsis.zip. That copy
+      # is never EV-signed, so drop it before the coverage audit rather than
+      # spend a signature on a dead artifact (#2289).
+      - name: Drop unshipped nsis-updater byproduct (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          $dir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis-updater"
+          if (Test-Path -LiteralPath $dir) {
+            Write-Host "Removing unshipped Tauri byproduct: $dir"
+            Remove-Item -LiteralPath $dir -Recurse -Force
+          } else {
+            Write-Host "No nsis-updater directory present; nothing to drop."
+          }
+
       # Recursive Authenticode check over every loose .exe/.dll the Tauri build
       # emits under bundle/. Now that the embedded runtime is EV-signed pre-build
       # (#2235), any unsigned/invalid file here is a real regression — a missed


### PR DESCRIPTION
Closes #2289.

## Problem

The first run where Windows signing fully succeeded (v3.52.4) failed the post-signing **coverage audit** on exactly one file:

```
Unsigned/invalid files in bundle: 1
...bundle\nsis-updater\SerenDesktop_3.52.4_x64-setup.exe   NotSigned
```

## Root cause

`createUpdaterArtifacts: "v1Compatible"` makes the Tauri NSIS bundler emit a **duplicate, unshipped** installer copy under `bundle/nsis-updater/`. Our pipeline signs and ships only `bundle/nsis/`:
- installer upload → `bundle/nsis/*.exe`
- updater upload → `bundle/nsis/*.nsis.zip` (+ `.sig`, re-packed & re-signed)

`grep -r nsis-updater` over `.github/`, `scripts/`, `build/`, `tauri.conf.json` returns nothing — that copy is never referenced, uploaded, or pushed to R2. It just never gets EV-signed, and the recursive coverage audit (#2235) trips on it. This gate was unreachable until signing got this far (#2282/#2284/#2286).

## Fix

Drop `bundle/nsis-updater/` right before the coverage audit. Safe (nothing ships from it) and avoids spending a signature on a dead artifact. All shipped artifacts remain signed/verified/uploaded unchanged.

## Validation

`pwsh` parse-check of the embedded script + YAML validated. The signing/audit path is Windows + SSL.com-credential bound, so end-to-end validation is the tagged release reaching the audit step.
