### PR TITLE
fix(ci): -LiteralPath for all Authenticode checks (#2291)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -729,7 +729,7 @@ jobs:
           }
           foreach ($file in $nsisFiles) {
             Write-Host "Checking signature for: $($file.FullName)"
-            $sig = Get-AuthenticodeSignature -FilePath $file.FullName
+            $sig = Get-AuthenticodeSignature -LiteralPath $file.FullName
             if ($sig.Status -eq "Valid") {
               Write-Host "  Valid signature: $($sig.SignerCertificate.Subject)"
             } else {
@@ -762,7 +762,7 @@ jobs:
             exit 1
           }
           # The setup .exe must already be EV-signed (verified in the step above).
-          $sig = Get-AuthenticodeSignature -FilePath $setup.FullName
+          $sig = Get-AuthenticodeSignature -LiteralPath $setup.FullName
           if ($sig.Status -ne "Valid") {
             Write-Host "::error::Refusing to pack an unsigned setup .exe into the updater bundle: $($sig.Status)"
             exit 1
@@ -805,7 +805,7 @@ jobs:
           }
           $unsigned = @()
           foreach ($f in $files) {
-            $sig = Get-AuthenticodeSignature -FilePath $f.FullName
+            $sig = Get-AuthenticodeSignature -LiteralPath $f.FullName
             if ($sig.Status -eq "Valid") {
               Write-Host "  Valid: $($f.Name)"
             } else {
@@ -853,7 +853,7 @@ jobs:
           $unsignedFiles = @()
           $validFiles = @()
           Get-ChildItem -Path $bundleRoot -Recurse -Include "*.exe","*.dll" -File | ForEach-Object {
-            $sig = Get-AuthenticodeSignature -FilePath $_.FullName
+            $sig = Get-AuthenticodeSignature -LiteralPath $_.FullName
             if ($sig.Status -eq "Valid") {
               $validFiles += $_.FullName
             } else {
@@ -911,7 +911,7 @@ jobs:
           Write-Host "Embedded binaries to verify: $($bins.Count)"
           $unsigned = @()
           foreach ($b in $bins) {
-            $sig = Get-AuthenticodeSignature -FilePath $b.FullName
+            $sig = Get-AuthenticodeSignature -LiteralPath $b.FullName
             if ($sig.Status -ne "Valid") {
               $unsigned += [PSCustomObject]@{
                 Path = $b.FullName.Substring($extractDir.Length).TrimStart("/\")

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -34,7 +34,7 @@ function Require-ValidSignature([string]$Path, [string]$Label) {
   if (-not (Test-Path -LiteralPath $Path)) {
     Fail "$Label not found: $Path"
   }
-  $signature = Get-AuthenticodeSignature -FilePath $Path
+  $signature = Get-AuthenticodeSignature -LiteralPath $Path
   if ($signature.Status -ne "Valid") {
     Fail "$Label is not validly Authenticode signed. Status=$($signature.Status) Subject=$($signature.SignerCertificate.Subject)"
   }


### PR DESCRIPTION
Closes #2291. Completes the #2287 fix: sweeps the 5 remaining `Get-AuthenticodeSignature -FilePath` calls in release.yml inline steps + the 1 in windows-e2e-app.ps1 to `-LiteralPath`. The deepest gate — "Verify embedded installer payload signatures" — 7-Zip-extracts the installer (which contains the Git toolchain's `[.exe`) and crashed on the wildcard glob. Verified: 0 `-FilePath` remain, YAML valid, ps1 parses. Windows-only cmdlet, so validated by parse + the tagged release reaching these steps.