### PR TITLE
fix(release): native tauri signCommand for Windows signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,13 +421,31 @@ jobs:
         env:
           NO_STRIP: "true"
         run: pnpm tauri build --verbose --target ${{ matrix.target }} --bundles deb,appimage
-      - name: Build Tauri app (unsigned, other)
-        if: matrix.os != 'macos-latest' && !startsWith(matrix.os, 'ubuntu')
+      # Single signed Windows build. The signCommand overlay makes the bundler
+      # itself sign at the only correct points in its pipeline (#2294):
+      # Seren.exe AFTER bundle-type patching, the NSIS plugin DLLs (incl.
+      # nsis_tauri_utils.dll) on build-local COPIES so the hash-pinned cache
+      # stays pristine, the uninstaller via the !uninstfinalize hook, and the
+      # setup .exe after makensis. The previous build->sign->rebuild dance
+      # could never work: every rebuild re-patched the exe (stripping its
+      # signature) and restored the mis-hashed plugin cache from upstream.
+      # The overlay lives outside tauri.conf.json so contributor Windows
+      # builds never attempt to sign. The wrapper reads WINDOWS_SIGN_THUMBPRINT
+      # from the eSigner CKA step via GITHUB_ENV.
+      - name: Build Tauri app (signed, Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
         env:
-          # On the Windows signing path the embedded runtime was already staged
-          # and EV-signed above; skip re-preparation so the build does not
-          # overwrite the signed binaries with fresh unsigned downloads (#2235).
-          SEREN_TAURI_SKIP_PREP: ${{ (matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true') && '1' || '' }}
+          # The embedded runtime was already staged and EV-signed above; skip
+          # re-preparation so the build does not overwrite the signed binaries
+          # with fresh unsigned downloads (#2235).
+          SEREN_TAURI_SKIP_PREP: "1"
+        shell: pwsh
+        run: |
+          pnpm tsx scripts/print-windows-sign-overlay.ts "$env:GITHUB_WORKSPACE" > sign-overlay.json
+          Get-Content sign-overlay.json
+          pnpm tauri build --target ${{ matrix.target }} --config sign-overlay.json
+      - name: Build Tauri app (unsigned, other)
+        if: matrix.os != 'macos-latest' && !startsWith(matrix.os, 'ubuntu') && !(matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true')
         run: pnpm tauri build --target ${{ matrix.target }}
       - name: Build Tauri app (unsigned, macOS without signing)
         if: matrix.os == 'macos-latest' && env.HAS_APPLE_SIGNING != 'true'
@@ -656,61 +674,6 @@ jobs:
           echo "Files in $BUNDLE_DIR:"
           ls -la "$BUNDLE_DIR/"
 
-      # makensis compiles the main Seren.exe AND the NSIS helper DLLs (System.dll,
-      # nsExec.dll, nsDialogs.dll, nsis_tauri_utils.dll) INTO the setup .exe. The
-      # helper DLLs live in the tauri-bundler NSIS cache and are extracted to
-      # %TEMP%\nsXXXX.tmp and loaded at install time, so Smart App Control blocks
-      # them when unsigned regardless of the outer installer's signature
-      # (#2237 / #2230). The main binary is likewise blocked if unsigned. The
-      # first `tauri build` above produced both; EV-sign the compiled Seren.exe
-      # and the cached helper DLLs in place, then rebuild so makensis embeds the
-      # signed copies.
-      - name: Sign app binary and NSIS helper DLLs (Windows)
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
-        shell: pwsh
-        run: |
-          $appExe  = "src-tauri/target/${{ matrix.target }}/release/Seren.exe"
-          $plugins = Join-Path $env:LOCALAPPDATA "tauri\NSIS\Plugins"
-          if (-not (Test-Path $appExe)) {
-            Write-Host "::error::Compiled app binary not found at $appExe."
-            exit 1
-          }
-          if (-not (Test-Path $plugins)) {
-            Write-Host "::error::Tauri NSIS plugins cache not found at $plugins after build — cannot sign helper DLLs (#2237)."
-            exit 1
-          }
-          ./scripts/sign-windows-payload.ps1 `
-            -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT `
-            -File $appExe `
-            -Root $plugins
-
-      # Rebuild so makensis recompiles the installer with the now-signed helper
-      # DLLs. Cargo reuses the pass-1 target dir and SEREN_TAURI_SKIP_PREP keeps
-      # the already-signed embedded runtime in place, so this pass only re-bundles.
-      - name: Rebuild with signed NSIS helper DLLs (Windows)
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
-        env:
-          SEREN_TAURI_SKIP_PREP: "1"
-        run: pnpm tauri build --target ${{ matrix.target }}
-
-      # EV-sign the NSIS setup .exe in place. signtool touches only the file we
-      # point it at, so the loose .nsis.zip / .sig updater artifacts in the same
-      # directory are left untouched — no move-aside/copy-back dance needed (the
-      # CodeSignTool batch_sign path signed a whole directory and required it).
-      - name: Sign Windows NSIS installer
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
-        shell: pwsh
-        run: |
-          $nsisDir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis"
-          $setup = Get-ChildItem -Path $nsisDir -Filter "*-setup.exe" | Select-Object -First 1
-          if (-not $setup) {
-            Write-Host "::error::No NSIS *-setup.exe found in $nsisDir to sign."
-            exit 1
-          }
-          ./scripts/sign-windows-payload.ps1 `
-            -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT `
-            -File $setup.FullName
-
       # Verify Windows code signing on the NSIS setup .exe AND every shipped
       # .exe inside the installed app payload. The prior check only validated
       # the outer setup .exe, which left bundled Seren.exe + sidecars unsigned
@@ -740,11 +703,10 @@ jobs:
           Write-Host "NSIS setup .exe is properly signed."
 
       # The .nsis.zip updater bundle is what pendingUpdate.downloadAndInstall()
-      # consumes — NOT the public setup .exe. Tauri builds the .nsis.zip during
-      # `tauri build`, zipping the setup .exe BEFORE our post-build EV signing
-      # runs, so the installer inside the bundle is unsigned even though the
-      # loose setup .exe got signed. Rebuild the bundle from the now-signed
-      # setup .exe and re-sign the .nsis.zip.sig with the Tauri updater key —
+      # consumes — NOT the public setup .exe. With signCommand the bundler signs
+      # the setup .exe before zipping, so the bundle should already contain the
+      # signed installer; this re-pack from the loose signed setup .exe is kept
+      # as a guarantee until a green release proves it redundant (#2294). It
       # mirrors the macOS .app.tar.gz re-pack/re-sign pattern above (#2236).
       - name: Re-pack and re-sign .nsis.zip updater bundle (Windows)
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'

--- a/scripts/print-windows-sign-overlay.ts
+++ b/scripts/print-windows-sign-overlay.ts
@@ -1,0 +1,42 @@
+// ABOUTME: CLI entrypoint that prints the tauri --config overlay enabling native Windows signing via signCommand (#2294).
+// ABOUTME: CI-only — keeps signCommand out of tauri.conf.json so contributor Windows builds never attempt to sign.
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.argv[2];
+if (!root || process.argv.length > 3) {
+  console.error("usage: print-windows-sign-overlay.ts <absolute-workspace-root>");
+  process.exit(2);
+}
+if (!path.isAbsolute(root)) {
+  console.error(`workspace root must be absolute, got: ${root}`);
+  process.exit(2);
+}
+
+// Absolute path is load-bearing: the bundler absolutizes relative args against
+// its own cwd, and makensis runs the !uninstfinalize sign hook from another
+// directory entirely.
+const signer = path.join(root, "scripts", "sign-windows-payload.ps1");
+if (!existsSync(signer)) {
+  console.error(`signer script not found: ${signer}`);
+  process.exit(1);
+}
+
+// Object notation (CustomSignCommandConfig): args are passed as argv tokens,
+// so paths with spaces survive. "%1" must stay a standalone token — the
+// bundler only substitutes exact-match args. The signer resolves its
+// thumbprint from WINDOWS_SIGN_THUMBPRINT, exported by the eSigner CKA step.
+const overlay = {
+  bundle: {
+    windows: {
+      signCommand: {
+        cmd: "pwsh",
+        args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", signer, "-File", "%1"],
+      },
+    },
+  },
+};
+
+process.stdout.write(`${JSON.stringify(overlay, null, 2)}\n`);

--- a/scripts/sign-windows-payload.ps1
+++ b/scripts/sign-windows-payload.ps1
@@ -4,7 +4,9 @@
 [CmdletBinding()]
 param(
   # Authenticode cert thumbprint loaded into Cert:\CurrentUser\My by eSigner CKA.
-  [Parameter(Mandatory = $true)][string]$Thumbprint,
+  # Defaults from WINDOWS_SIGN_THUMBPRINT so tauri's signCommand (static args,
+  # no secrets) can invoke this wrapper per file (#2294).
+  [string]$Thumbprint = "",
   # Directories to recurse for signable PE files.
   [string[]]$Root = @(),
   # Explicit files to sign (in addition to anything found under -Root).
@@ -23,6 +25,14 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+# Resolve the thumbprint before anything else so a missing credential fails
+# fast with an actionable error instead of a confusing signtool failure.
+if (-not $Thumbprint) { $Thumbprint = $env:WINDOWS_SIGN_THUMBPRINT }
+if (-not $Thumbprint) {
+  Write-Host "::error::No certificate thumbprint: pass -Thumbprint or set WINDOWS_SIGN_THUMBPRINT (exported by the eSigner CKA setup step)."
+  exit 1
+}
 
 # Authenticode-signable PE extensions. .pyd/.node are ordinary DLLs; signtool
 # signs them in place by content, so (unlike CodeSignTool) no extension rewrite

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -1,0 +1,174 @@
+// ABOUTME: Functional tests for the native-signCommand release pipeline (#2294): overlay CLI, signer fail-fast, and workflow contract.
+// ABOUTME: Guards the regression class where Windows installers shipped unsigned Seren.exe / nsis_tauri_utils.dll (v3.52.4-6).
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const tsxBin = path.join(repoRoot, "node_modules", ".bin", "tsx");
+const cli = path.join(repoRoot, "scripts", "print-windows-sign-overlay.ts");
+const signerScript = path.join(repoRoot, "scripts", "sign-windows-payload.ps1");
+
+function runCli(args: string[]): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(tsxBin, [cli, ...args], { encoding: "utf8" });
+  return { stdout: r.stdout ?? "", stderr: r.stderr ?? "", status: r.status ?? 1 };
+}
+
+describe("print-windows-sign-overlay CLI", () => {
+  it("emits a minimal signCommand overlay wired to the payload signer", () => {
+    const { stdout, status } = runCli([repoRoot]);
+
+    expect(status).toBe(0);
+    const overlay = JSON.parse(stdout);
+
+    // Minimal overlay: nothing but the sign command may be overridden at build
+    // time, so a stray key cannot silently change bundle behavior.
+    expect(Object.keys(overlay)).toEqual(["bundle"]);
+    expect(Object.keys(overlay.bundle)).toEqual(["windows"]);
+    expect(Object.keys(overlay.bundle.windows)).toEqual(["signCommand"]);
+
+    const signCommand = overlay.bundle.windows.signCommand;
+    expect(signCommand.cmd).toBe("pwsh");
+
+    // %1 must be a standalone argv token (sign_command_custom replaces the
+    // exact arg "%1"; embedded forms are the tauri-apps/tauri#11754 bug class)
+    // and must be the value of the script's -File parameter.
+    const args: string[] = signCommand.args;
+    expect(args.filter((a) => a.includes("%1"))).toEqual(["%1"]);
+    expect(args[args.length - 1]).toBe("%1");
+    expect(args[args.length - 2]).toBe("-File");
+
+    // The wrapper path must be absolute: the bundler absolutizes relative args
+    // against its own cwd, and the !uninstfinalize NSIS hook runs the command
+    // from a different directory entirely.
+    const scriptArg = args.find((a) => a.endsWith("sign-windows-payload.ps1"));
+    expect(scriptArg).toBe(path.join(repoRoot, "scripts", "sign-windows-payload.ps1"));
+    expect(path.isAbsolute(scriptArg as string)).toBe(true);
+
+    // pwsh contract: -File <script> must terminate pwsh's own parameters so
+    // the trailing "-File %1" binds to the script, not to pwsh.
+    expect(args[args.indexOf(scriptArg as string) - 1]).toBe("-File");
+  });
+
+  it("conforms to the installed tauri CLI's CustomSignCommandConfig schema (object notation)", () => {
+    const { stdout, status } = runCli([repoRoot]);
+    expect(status).toBe(0);
+    const signCommand = JSON.parse(stdout).bundle.windows.signCommand;
+
+    const schema = JSON.parse(
+      readFileSync(path.join(repoRoot, "node_modules", "@tauri-apps", "cli", "config.schema.json"), "utf8"),
+    );
+    const objectNotation = schema.definitions.CustomSignCommandConfig.anyOf.find(
+      (v: { type?: string }) => v.type === "object",
+    );
+    expect(objectNotation).toBeDefined();
+    for (const key of objectNotation.required) {
+      expect(signCommand[key]).toBeDefined();
+    }
+    expect(typeof signCommand.cmd).toBe("string");
+    expect(Array.isArray(signCommand.args)).toBe(true);
+    for (const arg of signCommand.args) {
+      expect(typeof arg).toBe("string");
+    }
+  });
+
+  it("rejects a missing workspace root with usage", () => {
+    const { status } = runCli([]);
+    expect(status).toBe(2);
+  });
+
+  it("rejects a relative workspace root", () => {
+    const { status, stderr } = runCli(["some/relative/dir"]);
+    expect(status).toBe(2);
+    expect(stderr).toContain("absolute");
+  });
+
+  it("fails loud when the signer script is missing under the root", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "sign-overlay-"));
+    try {
+      const { status, stderr } = runCli([root]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("sign-windows-payload.ps1");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("local build safety", () => {
+  it("tauri.conf.json does not enable signCommand (contributor Windows builds must stay unsigned)", () => {
+    const conf = JSON.parse(readFileSync(path.join(repoRoot, "src-tauri", "tauri.conf.json"), "utf8"));
+    expect(conf.bundle?.windows?.signCommand).toBeUndefined();
+  });
+});
+
+describe("release workflow contract", () => {
+  const workflow = readFileSync(path.join(repoRoot, ".github", "workflows", "release.yml"), "utf8");
+
+  it("no longer contains the self-defeating sign/rebuild steps (#2294 root cause)", () => {
+    expect(workflow).not.toContain("Sign app binary and NSIS helper DLLs");
+    expect(workflow).not.toContain("Rebuild with signed NSIS helper DLLs");
+    expect(workflow).not.toContain("name: Sign Windows NSIS installer");
+  });
+
+  it("builds Windows once, with the signCommand overlay", () => {
+    expect(workflow).toContain("print-windows-sign-overlay.ts");
+    expect(workflow).toMatch(/tauri build[^\n]*--config[^\n]*sign-overlay\.json/);
+  });
+
+  it("keeps the throttled embedded-runtime pre-sign and the payload verifiers", () => {
+    expect(workflow).toContain("Sign embedded runtime (Windows)");
+    expect(workflow).toContain("Verify embedded installer payload signatures (Windows)");
+    expect(workflow).toContain("Audit Windows payload signature coverage");
+  });
+});
+
+describe("sign-windows-payload.ps1 thumbprint resolution", () => {
+  const pwshCheck = spawnSync("pwsh", ["-NoProfile", "-Command", "$PSVersionTable.PSVersion.Major"], {
+    encoding: "utf8",
+  });
+  const hasPwsh = pwshCheck.status === 0;
+  // On a real Windows box a discovered signtool would try to sign the dummy
+  // file; these tests only exercise the cross-platform validation prefix.
+  const runnable = hasPwsh && process.platform !== "win32";
+
+  let dummy: string;
+
+  beforeEach(() => {
+    dummy = mkdtempSync(path.join(tmpdir(), "signer-"));
+    writeFileSync(path.join(dummy, "a.exe"), "x");
+  });
+
+  afterEach(() => {
+    rmSync(dummy, { recursive: true, force: true });
+  });
+
+  function runSigner(env: Record<string, string | undefined>): { out: string; status: number } {
+    const r = spawnSync(
+      "pwsh",
+      ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", signerScript, "-File", path.join(dummy, "a.exe")],
+      { encoding: "utf8", env: { ...process.env, WINDOWS_SIGN_THUMBPRINT: undefined, ...env } },
+    );
+    return { out: `${r.stdout}\n${r.stderr}`, status: r.status ?? 1 };
+  }
+
+  it.runIf(runnable)("fails fast with a clear error when no thumbprint is provided", () => {
+    const { out, status } = runSigner({});
+    expect(status).toBe(1);
+    expect(out).toContain("WINDOWS_SIGN_THUMBPRINT");
+    // Must fail on input validation, not deep in signtool discovery.
+    expect(out).not.toContain("signtool");
+  });
+
+  it.runIf(runnable)("accepts the thumbprint from WINDOWS_SIGN_THUMBPRINT (signCommand passes no -Thumbprint)", () => {
+    const { out, status } = runSigner({ WINDOWS_SIGN_THUMBPRINT: "933C679D86D0ACAF531B37A4D12C0B360EB4815C" });
+    // Proceeds past validation; on non-Windows it then fails at signtool
+    // discovery — proving the env thumbprint was accepted.
+    expect(status).toBe(1);
+    expect(out).toContain("signtool");
+    expect(out).not.toContain("WINDOWS_SIGN_THUMBPRINT");
+  });
+});


### PR DESCRIPTION
Closes #2294

## Root cause (from the v3.52.6 job log + tauri-bundler source @ CLI 2.11.2)

The `build → sign → rebuild` dance was structurally self-defeating:

1. The rebuild **re-patches Seren.exe** with NSIS bundle-type info ("Patching … bundle type information") — stripping the EV signature applied seconds earlier.
2. The rebuild detects the cached `nsis_tauri_utils.dll` we signed is **mis-hashed** against the bundler's pinned SHA1 (`NSIS_REQUIRED_FILES_HASH`) and **re-downloads the unsigned original by design**.

Result: v3.52.4–6 installers embedded an unsigned `Seren.exe` + `$PLUGINSDIR\nsis_tauri_utils.dll` (2 of 715 payload binaries), caught by the embedded-payload verifier once #2292 made it run.

## Fix

Use the bundler's native custom sign command (tauri-apps/tauri#11676, in our CLI 2.11.2), which signs at the only correct pipeline points in a **single build**: Seren.exe *after* patching, plugin DLLs on build-local *copies* (pinned cache untouched), the uninstaller via `!uninstfinalize`, and the setup .exe after makensis.

- `scripts/print-windows-sign-overlay.ts` — tested CLI entrypoint (#2284 lesson) emitting the CI-only `--config` overlay. **Not** in `tauri.conf.json`: `can_sign()` must stay false for contributor Windows builds.
- `scripts/sign-windows-payload.ps1` — `-Thumbprint` now defaults from `WINDOWS_SIGN_THUMBPRINT` (signCommand args are static); fails fast with an actionable error when absent.
- `release.yml` — one "Build Tauri app (signed, Windows)" step replaces the three-step sign/rebuild/sign dance (~15 min and one full makensis×2 pass removed). Throttled embedded-runtime pre-sign and all verifiers unchanged.

## Tests

`tests/unit/windows-sign-overlay.test.ts` (11 tests, all green; full suite 1653 passing):
- overlay shape, standalone-`%1`-last contract, absolute wrapper path, pwsh `-File` ordering
- conformance against the installed CLI's `CustomSignCommandConfig` schema
- `tauri.conf.json` must not enable signCommand
- workflow contract: dance steps gone, overlay wired, verifiers retained
- signer fail-fast without thumbprint / env pickup with it (real pwsh subprocess, no mocks)

## Validation plan

Next tag exercises the full path; the embedded-payload verifier (715-binary, 7-Zip extraction) is the acceptance gate.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com