### PR TITLE
fix(skills): binary-safe payload install via base64

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -960,6 +960,7 @@ pub fn run() {
             skills::remove_skill,
             skills::read_skill_content,
             skills::read_skill_file,
+            skills::read_skill_file_b64,
             skills::list_skill_payload_files,
             skills::read_skill_sync_state,
             skills::write_skill_sync_state,

--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -391,7 +391,7 @@ fn write_skill_tree(
                 .map_err(|e| format!("Failed to create directory for {}: {}", file.path, e))?;
         }
 
-        fs::write(&target, &file.content)
+        fs::write(&target, file.bytes()?)
             .map_err(|e| format!("Failed to write {}: {}", file.path, e))?;
 
         #[cfg(unix)]
@@ -1194,9 +1194,28 @@ pub fn rename_skill_dir(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct ExtraFile {
     path: String,
-    content: String,
+    /// Plain-text content. Legacy field; lossy for non-UTF-8 bytes.
+    #[serde(default)]
+    content: Option<String>,
+    /// Base64 of the raw file bytes. Binary-safe; preferred over `content`.
+    #[serde(default)]
+    content_b64: Option<String>,
+}
+
+impl ExtraFile {
+    fn bytes(&self) -> Result<Vec<u8>, String> {
+        use base64::{Engine, engine::general_purpose::STANDARD};
+        match (&self.content_b64, &self.content) {
+            (Some(encoded), _) => STANDARD
+                .decode(encoded)
+                .map_err(|e| format!("Invalid base64 content for {}: {}", self.path, e)),
+            (None, Some(text)) => Ok(text.as_bytes().to_vec()),
+            (None, None) => Err(format!("Bundle file {} has no content", self.path)),
+        }
+    }
 }
 
 /// Extract file paths referenced in SKILL.md content.
@@ -1477,6 +1496,33 @@ pub fn read_skill_file(
     Ok(Some(content))
 }
 
+/// Read a relative file from a skill directory as base64 of its raw bytes.
+/// Binary-safe counterpart of `read_skill_file` for sync-state hashing (#2297).
+#[tauri::command]
+pub fn read_skill_file_b64(
+    skills_dir: String,
+    slug: String,
+    relative_path: String,
+) -> Result<Option<String>, String> {
+    use base64::{Engine, engine::general_purpose::STANDARD};
+
+    let dir_path = PathBuf::from(&skills_dir);
+    let skill_dir = match resolve_skill_dir_path(&dir_path, &slug) {
+        Some(path) => path,
+        None => return Ok(None),
+    };
+
+    let target = resolve_relative_skill_path(&skill_dir, &relative_path)?;
+    if !target.exists() {
+        return Ok(None);
+    }
+    let target = canonicalize_within_skill_dir(&skill_dir, &target)?;
+
+    let bytes =
+        fs::read(&target).map_err(|e| format!("Failed to read {}: {}", relative_path, e))?;
+    Ok(Some(STANDARD.encode(&bytes)))
+}
+
 /// Read the persisted sync state for a skill if present.
 #[tauri::command]
 pub fn read_skill_sync_state(skills_dir: String, slug: String) -> Result<Option<String>, String> {
@@ -1645,6 +1691,78 @@ See [section](#overview) and [email](mailto:test@example.com).
             fs::read_to_string(skill_dir.join("scripts/agent.py")).unwrap(),
             "print('hello')"
         );
+    }
+
+    #[test]
+    fn install_skill_writes_binary_extra_file_byte_identical() {
+        use base64::{Engine, engine::general_purpose::STANDARD};
+
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().to_string_lossy().to_string();
+
+        // zip/pptx magic followed by bytes that are not valid UTF-8. A text
+        // round-trip would replace them with U+FFFD (#2297).
+        let payload: Vec<u8> = vec![
+            0x50, 0x4B, 0x03, 0x04, 0xFF, 0xFE, 0x00, 0x80, 0xC3, 0x28, 0xA0, 0xA1,
+        ];
+        let extras = serde_json::json!([
+            {"path": "assets/template.pptx", "contentB64": STANDARD.encode(&payload)},
+        ]);
+
+        install_skill(
+            skills_dir.clone(),
+            "test-skill".to_string(),
+            "# Test\n".to_string(),
+            Some(extras.to_string()),
+            None,
+        )
+        .unwrap();
+
+        let written = fs::read(tmp.path().join("test-skill/assets/template.pptx")).unwrap();
+        assert_eq!(written, payload, "binary payload must be byte-identical");
+    }
+
+    #[test]
+    fn install_skill_rejects_extra_file_without_content() {
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().to_string_lossy().to_string();
+
+        let extras = serde_json::json!([
+            {"path": "assets/empty.bin"},
+        ]);
+
+        let result = install_skill(
+            skills_dir,
+            "test-skill".to_string(),
+            "# Test\n".to_string(),
+            Some(extras.to_string()),
+            None,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("no content"));
+    }
+
+    #[test]
+    fn read_skill_file_b64_returns_raw_bytes() {
+        use base64::{Engine, engine::general_purpose::STANDARD};
+
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().to_string_lossy().to_string();
+        let skill_dir = tmp.path().join("test-skill");
+        fs::create_dir_all(skill_dir.join("assets")).unwrap();
+        fs::write(skill_dir.join("SKILL.md"), "# Test\n").unwrap();
+
+        let payload: Vec<u8> = vec![0x50, 0x4B, 0x03, 0x04, 0xFF, 0xFE, 0x00, 0x80];
+        fs::write(skill_dir.join("assets/template.pptx"), &payload).unwrap();
+
+        let encoded = read_skill_file_b64(
+            skills_dir,
+            "test-skill".to_string(),
+            "assets/template.pptx".to_string(),
+        )
+        .unwrap()
+        .expect("file should be found");
+        assert_eq!(STANDARD.decode(encoded).unwrap(), payload);
     }
 
     #[test]
@@ -2430,27 +2548,17 @@ Run [agent](scripts/agent.py) — it writes to `state/session_cache.json` lazily
         // tries, `bundle_managed_paths` strips them so `preserve_user_files`
         // keeps the backup copy and `write_skill_tree` refuses to lay down
         // the contaminated bundle file.
+        let extra = |path: &str, content: &str| ExtraFile {
+            path: path.to_string(),
+            content: Some(content.to_string()),
+            content_b64: None,
+        };
         let extras = vec![
-            ExtraFile {
-                path: "scripts/agent.py".to_string(),
-                content: "print('ok')\n".to_string(),
-            },
-            ExtraFile {
-                path: ".env".to_string(),
-                content: "SEREN_API_KEY=leaked\n".to_string(),
-            },
-            ExtraFile {
-                path: "state/session.json".to_string(),
-                content: "{}\n".to_string(),
-            },
-            ExtraFile {
-                path: "logs/old.jsonl".to_string(),
-                content: "".to_string(),
-            },
-            ExtraFile {
-                path: ".env.example".to_string(),
-                content: "SEREN_API_KEY=\n".to_string(),
-            },
+            extra("scripts/agent.py", "print('ok')\n"),
+            extra(".env", "SEREN_API_KEY=leaked\n"),
+            extra("state/session.json", "{}\n"),
+            extra("logs/old.jsonl", ""),
+            extra(".env.example", "SEREN_API_KEY=\n"),
         ];
         let paths = bundle_managed_paths(&extras, true);
         assert!(paths.contains("SKILL.md"));

--- a/src/lib/skills/parser.ts
+++ b/src/lib/skills/parser.ts
@@ -335,9 +335,18 @@ function extractDescriptionFromContent(content: string): string | null {
  * Compute SHA-256 hash of content for change detection.
  */
 export async function computeContentHash(content: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(content);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return computeBytesHash(new TextEncoder().encode(content));
+}
+
+/**
+ * Compute SHA-256 hash of raw bytes. Binary-safe counterpart of
+ * computeContentHash; for valid UTF-8 text the two agree (#2297).
+ */
+export async function computeBytesHash(bytes: Uint8Array): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest(
+    "SHA-256",
+    bytes as BufferSource,
+  );
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 }

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -17,6 +17,7 @@ import {
 import { log } from "@/lib/logger";
 import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import {
+  computeBytesHash,
   computeContentHash,
   getSkillPath,
   humanizeSkillName,
@@ -64,7 +65,11 @@ export function isAuthStatus(status: number | undefined): boolean {
 
 interface ExtraFile {
   path: string;
-  content: string;
+  /**
+   * Base64 of the raw file bytes. Carried end-to-end so binary payload
+   * files survive install without a lossy UTF-8 round-trip (#2297).
+   */
+  contentB64: string;
 }
 
 interface UpstreamSkillBundle {
@@ -154,10 +159,9 @@ function remoteRevisionFromBundle(bundle: SkillBundle): RemoteSkillRevision {
   };
 }
 
-function decodeBase64Text(value: string): string {
+function base64ToBytes(value: string): Uint8Array {
   const binary = atob(value);
-  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
 }
 
 /**
@@ -183,7 +187,7 @@ async function collectPayloadFiles(
 function bundleFilesToExtraFiles(files: SkillBundleFile[] = []): ExtraFile[] {
   return files.map((file) => ({
     path: file.path,
-    content: decodeBase64Text(file.content_b64),
+    contentB64: file.content_b64,
   }));
 }
 
@@ -516,16 +520,14 @@ async function fetchSerenSkills(skipCache = false): Promise<Skill[]> {
 
 function buildManagedFileMap(
   skillMdHash: string,
-  payloadFiles: Array<{ path: string; content: string; hash?: string }>,
+  payloadFiles: Array<{ path: string; hash: string }>,
 ): Record<string, string> {
   const managedFiles: Record<string, string> = {
     "SKILL.md": skillMdHash,
   };
 
   for (const file of payloadFiles) {
-    if (file.hash) {
-      managedFiles[file.path] = file.hash;
-    }
+    managedFiles[file.path] = file.hash;
   }
 
   return managedFiles;
@@ -757,11 +759,13 @@ async function computeUpstreamSyncState(
   payloadFiles: ExtraFile[],
 ): Promise<SkillSyncState> {
   const skillMdHash = await computeContentHash(skillMd);
+  // Hash the decoded bytes, not a text round-trip: for valid UTF-8 the
+  // digest is identical, and binary payload files get a faithful hash
+  // instead of one built on U+FFFD-mangled content (#2297).
   const payloadWithHashes = await Promise.all(
     payloadFiles.map(async (file) => ({
       path: file.path,
-      content: file.content,
-      hash: await computeContentHash(file.content),
+      hash: await computeBytesHash(base64ToBytes(file.contentB64)),
     })),
   );
 
@@ -1432,6 +1436,25 @@ export const skills = {
   },
 
   /**
+   * Read a relative file from an installed skill directory as base64 of
+   * its raw bytes. Binary-safe counterpart of readFile (#2297).
+   */
+  async readFileB64(
+    skill: InstalledSkill,
+    relativePath: string,
+  ): Promise<string | null> {
+    if (!isTauriRuntime()) {
+      return null;
+    }
+
+    return invoke<string | null>("read_skill_file_b64", {
+      skillsDir: skill.skillsDir,
+      slug: skill.dirName,
+      relativePath,
+    });
+  },
+
+  /**
    * Determine the sync status for an upstream-managed installed skill.
    */
   async inspectSyncStatus(
@@ -1448,26 +1471,38 @@ export const skills = {
       const managedPaths = Object.keys(skill.syncState?.managedFiles ?? {});
 
       if (skill.syncState) {
+        // Payload files are hashed from raw bytes: a text read would fail
+        // outright (or mangle) binary files like pptx templates (#2297).
         const results = await Promise.all(
           managedPaths.map(async (path) => {
-            const content =
-              path === "SKILL.md"
-                ? await this.readContent(skill)
-                : await this.readFile(skill, path);
-            return { path, content };
+            if (path === "SKILL.md") {
+              const content = await this.readContent(skill);
+              return {
+                path,
+                hash:
+                  content === null ? null : await computeContentHash(content),
+              };
+            }
+            const contentB64 = await this.readFileB64(skill, path);
+            return {
+              path,
+              hash:
+                contentB64 === null
+                  ? null
+                  : await computeBytesHash(base64ToBytes(contentB64)),
+            };
           }),
         );
 
-        for (const { path, content } of results) {
-          if (content === null) {
+        for (const { path, hash } of results) {
+          if (hash === null) {
             localManagedState[path] = null;
             missingManagedFiles.push(path);
             continue;
           }
 
-          const contentHash = await computeContentHash(content);
-          localManagedState[path] = contentHash;
-          if (contentHash !== skill.syncState.managedFiles[path]) {
+          localManagedState[path] = hash;
+          if (hash !== skill.syncState.managedFiles[path]) {
             changedLocalFiles.push(path);
           }
         }

--- a/tests/unit/skills-binary-payload.test.ts
+++ b/tests/unit/skills-binary-payload.test.ts
@@ -1,0 +1,183 @@
+// ABOUTME: Regression tests for binary-safe skill payload installs (#2297).
+// ABOUTME: Verifies base64 is carried end-to-end and sync hashes use raw bytes.
+
+import { createHash } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InstalledSkill, Skill } from "@/lib/skills";
+
+const mockInvoke = vi.hoisted(() => vi.fn());
+const mockDownloadSkill = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  isTauriRuntime: () => true,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/lib/runtime-console", () => ({
+  verboseRuntimeConsole: { debug: vi.fn() },
+}));
+
+vi.mock("@/api/seren-skills", () => ({
+  createSkill: vi.fn(),
+  createVersion: vi.fn(),
+  deleteSkill: vi.fn(),
+  downloadSkill: mockDownloadSkill,
+  listSkills: vi.fn(),
+  updateSkill: vi.fn(),
+}));
+
+import { skills } from "@/services/skills";
+
+// pptx/zip magic followed by sequences that are NOT valid UTF-8. A text
+// round-trip (atob + TextDecoder) mangles these into U+FFFD replacements.
+const BINARY_BYTES = new Uint8Array([
+  0x50, 0x4b, 0x03, 0x04, 0xff, 0xfe, 0x00, 0x80, 0xc3, 0x28, 0xa0, 0xa1,
+]);
+const BINARY_B64 = Buffer.from(BINARY_BYTES).toString("base64");
+const SKILL_MD = "# Glide Affinity Proposals\n\nTemplates included.\n";
+
+function sha256Hex(data: Uint8Array | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+const bundle = {
+  skill: {
+    slug: "glide-affinity-proposals",
+    name: "Glide Affinity Proposals",
+    updated_at: "2026-06-10T00:00:00Z",
+  },
+  version: "1.0.0",
+  skill_md: SKILL_MD,
+  content_hash: "remote-hash-1",
+  files: [
+    {
+      path: "assets/template.pptx",
+      content_b64: BINARY_B64,
+      is_binary: true,
+    },
+  ],
+};
+
+const catalogSkill: Skill = {
+  id: "seren:glide-affinity-proposals",
+  slug: "glide-affinity-proposals",
+  name: "Glide Affinity Proposals",
+  description: "Builds proposals",
+  source: "seren",
+  sourceUrl: "seren-skills:glide-affinity-proposals",
+  tags: [],
+};
+
+beforeEach(() => {
+  mockInvoke.mockReset();
+  mockDownloadSkill.mockReset();
+  mockDownloadSkill.mockResolvedValue({
+    data: bundle,
+    error: undefined,
+    response: { status: 200 },
+  });
+  mockInvoke.mockImplementation(async (cmd: string) => {
+    switch (cmd) {
+      case "get_seren_skills_dir":
+        return "/tmp/seren-skills";
+      case "install_skill":
+        return "/tmp/seren-skills/glide-affinity-proposals/SKILL.md";
+      case "validate_skill_payload":
+        return [];
+      default:
+        return null;
+    }
+  });
+});
+
+describe("binary-safe skill installs (#2297)", () => {
+  it("passes payload base64 to install_skill untouched (no UTF-8 round-trip)", async () => {
+    await skills.install(catalogSkill, "", "seren", null);
+
+    const installCall = mockInvoke.mock.calls.find(
+      (call) => call[0] === "install_skill",
+    );
+    expect(installCall).toBeDefined();
+    const args = installCall?.[1] as { extraFiles: string };
+    const extraFiles = JSON.parse(args.extraFiles) as Array<{
+      path: string;
+      contentB64: string;
+    }>;
+    expect(extraFiles).toEqual([
+      { path: "assets/template.pptx", contentB64: BINARY_B64 },
+    ]);
+  });
+
+  it("hashes raw payload bytes (not a text round-trip) into sync state", async () => {
+    await skills.install(catalogSkill, "", "seren", null);
+
+    const installCall = mockInvoke.mock.calls.find(
+      (call) => call[0] === "install_skill",
+    );
+    const args = installCall?.[1] as { syncStateJson: string };
+    const syncState = JSON.parse(args.syncStateJson) as {
+      managedFiles: Record<string, string>;
+    };
+    expect(syncState.managedFiles["assets/template.pptx"]).toBe(
+      sha256Hex(BINARY_BYTES),
+    );
+    expect(syncState.managedFiles["SKILL.md"]).toBe(sha256Hex(SKILL_MD));
+  });
+
+  it("does not flag an unmodified binary payload file as locally changed", async () => {
+    const installed = {
+      id: "local:glide-affinity-proposals",
+      slug: "glide-affinity-proposals",
+      name: "Glide Affinity Proposals",
+      description: "Builds proposals",
+      source: "local",
+      tags: [],
+      scope: "seren",
+      skillsDir: "/tmp/seren-skills",
+      dirName: "glide-affinity-proposals",
+      path: "/tmp/seren-skills/glide-affinity-proposals/SKILL.md",
+      installedAt: Date.now(),
+      enabled: true,
+      contentHash: sha256Hex(SKILL_MD),
+      upstreamSource: "seren",
+      upstreamSourceUrl: "seren-skills:glide-affinity-proposals",
+      syncState: {
+        version: 1,
+        upstreamSource: "seren",
+        upstreamSourceUrl: "seren-skills:glide-affinity-proposals",
+        syncedRevision: "remote-hash-1",
+        syncedAt: Date.now(),
+        managedFiles: {
+          "SKILL.md": sha256Hex(SKILL_MD),
+          "assets/template.pptx": sha256Hex(BINARY_BYTES),
+        },
+      },
+    } as InstalledSkill;
+
+    mockInvoke.mockImplementation(async (cmd: string, params?: unknown) => {
+      switch (cmd) {
+        case "read_skill_content":
+          return SKILL_MD;
+        case "read_skill_file_b64": {
+          const { relativePath } = params as { relativePath: string };
+          return relativePath === "assets/template.pptx" ? BINARY_B64 : null;
+        }
+        default:
+          return null;
+      }
+    });
+
+    const status = await skills.inspectSyncStatus(installed);
+    expect(status).not.toBeNull();
+    expect(status?.state).toBe("current");
+    expect(status?.changedLocalFiles).toEqual([]);
+    expect(status?.missingManagedFiles).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #2297

## Problem

Every bundle file was forced through a UTF-8 text round-trip on install: `bundleFilesToExtraFiles` decoded `content_b64` with `atob` + `TextDecoder` for all files, ignoring the bundle's `is_binary` flag. Invalid UTF-8 sequences were replaced with U+FFFD — irreversible corruption for binary payloads like the glide-affinity-proposals pptx templates. Sync-state hashing hashed the mangled text, and `inspectSyncStatus` hard-errored on binary payloads because `read_skill_file` uses `fs::read_to_string`.

## Fix

- Webview → Rust `ExtraFile` contract now carries `contentB64`; Rust decodes base64 to raw bytes at the filesystem boundary (`write_skill_tree`). The legacy `content` field is still accepted, per the issue spec.
- `computeUpstreamSyncState` hashes the decoded bytes. For valid UTF-8 the digest is unchanged, so existing sync states stay valid; binary files now get faithful hashes.
- New `read_skill_file_b64` Tauri command (same path-safety guards as `read_skill_file`); `inspectSyncStatus` hashes payload files from raw bytes, so unmodified binary files are no longer flagged or errored.

## Tests

- Rust: non-UTF-8 payload (zip/pptx magic + 0xFF bytes) is byte-identical on disk after `install_skill`; missing-content rejection; `read_skill_file_b64` raw-bytes round-trip. Full suite: 683 passed.
- TS: install passes base64 through untouched; sync state hashes raw bytes; `inspectSyncStatus` reports `current` for unmodified binary payloads. Full suite: 1656 passed (245 files).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com