### PR TITLE
fix(release): sign stock NSIS plugins in toolset cache (#2299)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,6 +404,20 @@ jobs:
             -BatchSize 10 `
             -DelaySeconds 30
 
+      # makensis embeds the stock NSIS plugins ($PLUGINSDIR: System.dll,
+      # nsExec.dll, StartMenu.dll, nsDialogs.dll) from the bundler's NSIS
+      # toolset cache, NOT from the signed build-local copies — the copy is
+      # only on the plugin search path for additional/nsis_tauri_utils.dll
+      # (tauri#14147; fixed upstream in tauri#15422 but unreleased, and
+      # upstream's sign list misses nsExec.dll, which installer-hooks.nsh
+      # uses). Seed the cache exactly as the bundler would and EV-sign the
+      # stock plugin DLLs in place; they are not hash-pinned, so the
+      # signatures survive the build (#2299).
+      - name: Stage signed NSIS toolset (Windows)
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: ./scripts/stage-signed-nsis-toolset.ps1
+
       # Build the app (with signing for macOS when certificates available)
       # Note: APPLE_ID/PASSWORD/TEAM_ID removed to prevent Tauri's internal notarization
       # Notarization is handled separately with polling in the "Notarize macOS app" step
@@ -422,13 +436,14 @@ jobs:
           NO_STRIP: "true"
         run: pnpm tauri build --verbose --target ${{ matrix.target }} --bundles deb,appimage
       # Single signed Windows build. The signCommand overlay makes the bundler
-      # itself sign at the only correct points in its pipeline (#2294):
-      # Seren.exe AFTER bundle-type patching, the NSIS plugin DLLs (incl.
-      # nsis_tauri_utils.dll) on build-local COPIES so the hash-pinned cache
-      # stays pristine, the uninstaller via the !uninstfinalize hook, and the
-      # setup .exe after makensis. The previous build->sign->rebuild dance
-      # could never work: every rebuild re-patched the exe (stripping its
-      # signature) and restored the mis-hashed plugin cache from upstream.
+      # itself sign at the correct points in its pipeline (#2294): Seren.exe
+      # AFTER bundle-type patching, nsis_tauri_utils.dll on the build-local
+      # plugin copy (the only plugin makensis takes from that copy — the stock
+      # plugins come from the pre-signed toolset cache staged above, #2299),
+      # the uninstaller via the !uninstfinalize hook, and the setup .exe after
+      # makensis. The previous build->sign->rebuild dance could never work:
+      # every rebuild re-patched the exe (stripping its signature) and
+      # restored the mis-hashed plugin cache from upstream.
       # The overlay lives outside tauri.conf.json so contributor Windows
       # builds never attempt to sign. The wrapper reads WINDOWS_SIGN_THUMBPRINT
       # from the eSigner CKA step via GITHUB_ENV.

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -125,26 +125,35 @@ the artifact that embeds it is produced:
    portable tree, the bundled Python DLLs/`.pyd`, sidecars under
    `embedded-runtime/`, and `mcp-servers/**/*.node`. These are signed *before*
    `tauri build` so the signatures land inside both the NSIS installer and the
-   `.nsis.zip` updater bundle. Files are flattened into one staging directory
-   (`scripts/flatten-windows-signables.mjs`) and signed in a single SSL.com
-   `batch_sign` to avoid the per-file TOTP throttle, then copied back via the
-   manifest (`scripts/restore-windows-signables.mjs`).
+   `.nsis.zip` updater bundle. The signable set is discovered by
+   `scripts/print-windows-signables.ts` and signed in place by
+   `scripts/sign-windows-payload.ps1` (signtool + eSigner CKA, throttled
+   batches under SSL.com's rate limit, `#2282`).
 
-2. **NSIS helper DLLs** (`#2237`) — `System.dll`, `nsExec.dll`, `nsDialogs.dll`,
-   and `nsis_tauri_utils.dll` ship inside the `tauri-bundler` NSIS cache
-   (`%LOCALAPPDATA%\tauri\NSIS\Plugins`) and `makensis` compiles them *into* the
-   setup `.exe`; at install they are extracted to `%TEMP%\nsXXXX.tmp` and loaded.
-   We do not depend on an upstream tauri change: the first `tauri build`
-   populates the cache, we sign those DLLs in place (reusing the same
-   flatten/restore scripts), and a second `tauri build` (with
-   `SEREN_TAURI_SKIP_PREP=1`, so the already-signed runtime is untouched and
-   cargo reuses its target dir) recompiles the installer with the signed copies.
+2. **NSIS stock plugin DLLs** (`#2237`, `#2299`) — `System.dll`, `nsExec.dll`,
+   `StartMenu.dll`, and `nsDialogs.dll` ship inside the `tauri-bundler` NSIS
+   toolset cache (`%LOCALAPPDATA%\tauri\NSIS\Plugins`) and `makensis` compiles
+   them *into* the setup `.exe`; at install they are extracted to
+   `%TEMP%\nsXXXX.tmp` and loaded. The bundler's own `signCommand` pipeline
+   signs build-local *copies* of these, but makensis never reads stock plugins
+   from that copy (tauri#14147 — fixed upstream in tauri#15422, unreleased, and
+   upstream's sign list misses `nsExec.dll`, which `installer-hooks.nsh` uses).
+   `scripts/stage-signed-nsis-toolset.ps1` therefore seeds the toolset cache
+   exactly as the bundler would (same pinned URL/SHA1, including the
+   hash-pinned `nsis_tauri_utils.dll`, which stays unsigned in the cache so the
+   bundler does not re-download it) and EV-signs the stock plugin DLLs in
+   place before the build. `nsis_tauri_utils.dll` itself is signed by the
+   bundler on the build-local copy, the one plugin dir makensis does take from
+   the copy.
 
-3. **Outer setup `.exe` and `.nsis.zip`** — the setup `.exe` is signed
-   post-build with SSL.com eSigner. Because Tauri builds the `.nsis.zip` from
-   the *unsigned* setup `.exe` during the build, the updater bundle is re-packed
-   from the signed `.exe` and its `.nsis.zip.sig` re-signed with the Tauri
-   updater key (`#2236`).
+3. **Seren.exe, the uninstaller, and the setup `.exe`** (`#2294`) — signed by
+   the bundler itself via a CI-only `signCommand` config overlay
+   (`scripts/print-windows-sign-overlay.ts`) at the only correct points in its
+   pipeline: the main exe after bundle-type patching, the uninstaller via the
+   `!uninstfinalize` hook, and the setup `.exe` after makensis. Because Tauri
+   builds the `.nsis.zip` updater bundle during the same pipeline, the bundle
+   is re-packed from the signed `.exe` and its `.nsis.zip.sig` re-signed with
+   the Tauri updater key (`#2236`).
 
 ### Verification gates (release CI, hard-fail)
 

--- a/scripts/stage-signed-nsis-toolset.ps1
+++ b/scripts/stage-signed-nsis-toolset.ps1
@@ -1,0 +1,79 @@
+# ABOUTME: Pre-seeds the tauri-bundler NSIS cache and EV-signs the stock plugin DLLs in place (#2299).
+# ABOUTME: makensis embeds stock plugins from the cache, not the bundler's signed copies (tauri#14147, fix unreleased), so the cache must carry the signatures.
+
+[CmdletBinding()]
+param(
+  # Pinned to the tauri-bundler constants shipped in @tauri-apps/cli 2.11.2
+  # (crates/tauri-bundler/src/bundle/windows/nsis/mod.rs). If a CLI bump changes
+  # the NSIS version, the bundler recreates the cache with unsigned DLLs and the
+  # "Verify embedded installer payload signatures" gate fails with the exact
+  # DLL names — update these constants alongside the CLI.
+  [string]$NsisUrl = "https://github.com/tauri-apps/binary-releases/releases/download/nsis-3.11/nsis-3.11.zip",
+  [string]$NsisSha1 = "EF7FF767E5CBD9EDD22ADD3A32C9B8F4500BB10D",
+  [string]$NsisZipRoot = "nsis-3.11",
+  # Hash-pinned by the bundler: must match byte-for-byte or the bundler
+  # re-downloads it (which is also why this one is NOT signed here — it gets
+  # signed on the bundler's build-local copy, which IS on the plugin search
+  # path for additional/).
+  [string]$UtilsUrl = "https://github.com/tauri-apps/nsis-tauri-utils/releases/download/nsis_tauri_utils-v0.5.3/nsis_tauri_utils.dll",
+  [string]$UtilsSha1 = "75197FEE3C6A814FE035788D1C34EAD39349B860"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-VerifiedDownload {
+  param([string]$Url, [string]$Sha1, [string]$OutFile)
+  Invoke-WebRequest -Uri $Url -OutFile $OutFile
+  $hash = (Get-FileHash -LiteralPath $OutFile -Algorithm SHA1).Hash
+  if ($hash -ine $Sha1) {
+    Write-Host "::error::SHA1 mismatch for ${Url}: expected $Sha1, got $hash."
+    exit 1
+  }
+}
+
+$toolsDir = Join-Path $env:LOCALAPPDATA "tauri"
+$nsisDir = Join-Path $toolsDir "NSIS"
+
+if (Test-Path -LiteralPath $nsisDir) {
+  Write-Host "NSIS cache already present at $nsisDir; skipping seed."
+} else {
+  New-Item -ItemType Directory -Force -Path $toolsDir | Out-Null
+  $zip = Join-Path $env:RUNNER_TEMP "nsis-toolset.zip"
+  Get-VerifiedDownload -Url $NsisUrl -Sha1 $NsisSha1 -OutFile $zip
+  Expand-Archive -LiteralPath $zip -DestinationPath $toolsDir
+  Rename-Item -LiteralPath (Join-Path $toolsDir $NsisZipRoot) -NewName "NSIS"
+  Write-Host "Seeded NSIS toolset cache at $nsisDir."
+}
+
+# The bundler treats additional/nsis_tauri_utils.dll as a required file: if it
+# is missing it deletes and re-extracts the WHOLE cache, clobbering the
+# signatures below. Seed it with the exact pinned bytes so the cache survives.
+$additionalDir = Join-Path $nsisDir "Plugins/x86-unicode/additional"
+$utilsDll = Join-Path $additionalDir "nsis_tauri_utils.dll"
+if (-not (Test-Path -LiteralPath $utilsDll)) {
+  New-Item -ItemType Directory -Force -Path $additionalDir | Out-Null
+  Get-VerifiedDownload -Url $UtilsUrl -Sha1 $UtilsSha1 -OutFile $utilsDll
+  Write-Host "Seeded nsis_tauri_utils.dll (hash-pinned, left unsigned on purpose)."
+}
+
+# Sign every stock plugin DLL the compiler could embed into $PLUGINSDIR
+# (top level only — additional/ stays pristine, see above). Smart App Control
+# evaluates these after the installer extracts them to %TEMP% (#2237).
+$pluginDir = Join-Path $nsisDir "Plugins/x86-unicode"
+$stock = @(Get-ChildItem -LiteralPath $pluginDir -Filter "*.dll" -File)
+if ($stock.Count -eq 0) {
+  Write-Host "::error::No stock plugin DLLs found under $pluginDir — NSIS zip layout changed?"
+  exit 1
+}
+# The four our installer is known to embed (template + installer-hooks.nsh)
+# must be in the set, or the seeded toolset cannot produce a clean installer.
+$required = @("System.dll", "nsExec.dll", "StartMenu.dll", "nsDialogs.dll")
+$missing = @($required | Where-Object { $_ -notin $stock.Name })
+if ($missing.Count -gt 0) {
+  Write-Host "::error::Stock plugin set is missing: $($missing -join ', ')."
+  exit 1
+}
+Write-Host "Signing $($stock.Count) stock NSIS plugin DLL(s) in the toolset cache..."
+& (Join-Path $PSScriptRoot "sign-windows-payload.ps1") -File @($stock | ForEach-Object { $_.FullName })
+# The signer's `exit` only ends its own script scope — propagate it.
+exit $LASTEXITCODE


### PR DESCRIPTION
Closes #2299.

## Problem

v3.52.7's Windows release failed the **Verify embedded installer payload signatures** gate: `$PLUGINSDIR\System.dll`, `nsExec.dll`, `StartMenu.dll`, and `nsDialogs.dll` ship unsigned inside the setup `.exe` (run [27299690183](https://github.com/serenorg/seren-desktop/actions/runs/27299690183/job/80641850969)).

The #2295 `signCommand` overlay does make the bundler sign build-local copies of the stock plugins — but makensis never reads stock plugins from that copy. The installer template only `!addplugindir`s the `additional/` subdir (which is why `nsis_tauri_utils.dll` came out signed), and the `NSISPLUGINS` env var the bundler sets does not exist anywhere in the NSIS source. makensis falls back to `${NSISDIR}\Plugins\x86-unicode` — the unsigned toolset cache. This is tauri-apps/tauri#14147; the upstream fix (tauri-apps/tauri#15422) is merged but unreleased (CLI 2.11.2 predates it), and upstream's sign list misses `nsExec.dll` either way — that plugin is pulled in by our own `nsis/installer-hooks.nsh`.

## Fix

New `scripts/stage-signed-nsis-toolset.ps1`, run before the signed Windows build:

- Seeds `%LOCALAPPDATA%\tauri\NSIS` exactly as tauri-bundler 2.11.2 would: same pinned `nsis-3.11.zip` URL + SHA1, same extract/rename, plus the hash-pinned `nsis_tauri_utils.dll` (left unsigned in the cache on purpose — the bundler hash-verifies it and would re-download a signed copy; it gets signed on the build-local copy, the one dir makensis does take from the copy).
- EV-signs all 16 stock plugin DLLs in the cache via the existing `sign-windows-payload.ps1` (signtool + eSigner CKA, skip-already-signed). The stock DLLs are existence-checked only — never hash-pinned — so the signatures survive the build and makensis embeds the signed copies.
- Fails loud if the four plugins our installer is known to embed are missing from the seeded set.

Self-policing on CLI bumps: if a future `@tauri-apps/cli` changes the NSIS version, the bundler deletes and recreates the cache with unsigned DLLs, and the existing deep installer verifier fails with the exact DLL names.

Also updates the stale Windows coverage section in `docs/code-signing.md` (it still described the pre-#2295 two-build dance and the old `batch_sign` flow).

## Testing

Functionally tested on macOS with sandboxed `LOCALAPPDATA`/`RUNNER_TEMP`, up to the signtool handoff:

- Real download of both artifacts; SHA1s match the bundler's pins; zip root really is `nsis-3.11`; resulting layout matches what the bundler expects (16 stock DLLs + `additional/nsis_tauri_utils.dll`).
- Required-plugin sanity check passes; idempotent re-run skips the seed and goes straight to signing.
- Caught and fixed during testing: the signer's `exit 1` did not propagate out of the `&` invocation — the script now exits with `$LASTEXITCODE` explicitly.

signtool itself only exists on Windows; the live release tag is the end-to-end test, gated by the existing deep verifier.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
