### PR TITLE
fix(agent): guarantee Cancel stops the agent (#2301)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -2055,15 +2055,29 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       return;
     }
 
-    await sendControlRequest(
-      session,
-      {
-        subtype: "interrupt",
-      },
-      10_000,
-    ).catch(() => {
-      // Best-effort interrupt only.
-    });
+    let interrupted = false;
+    try {
+      await sendControlRequest(
+        session,
+        {
+          subtype: "interrupt",
+        },
+        10_000,
+      );
+      interrupted = true;
+    } catch {
+      // Cooperative interrupt was not acknowledged — escalate below.
+    }
+
+    if (!interrupted) {
+      // The CLI did not honor the interrupt (hung, blocked on a tool/MCP
+      // roundtrip, or its stdout reader stalled). A cooperative cancel that
+      // is silently swallowed leaves the agent running past a "successful"
+      // cancel. Hard-kill the child tree so the cancel actually stops the
+      // agent, mirroring terminateSession. The session is no longer reusable
+      // afterward; the child's exit listener tears it down. #2301.
+      killChildTree(session.process);
+    }
 
     session.status = "ready";
     emit("provider://error", {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/agent-output-validation";
 import { shouldLogAgentRuntimeEvent } from "@/lib/agent-runtime-debug";
 import {
+  disconnectLocalProviderRuntime,
   isLocalProviderRuntime,
   onRuntimeEvent,
 } from "@/lib/browser-local-runtime";
@@ -4737,7 +4738,24 @@ export const agentStore = {
       try {
         await providerService.cancelPrompt(session.info.id);
       } catch (err) {
-        console.warn("[AgentStore] abortTurn cancelPrompt failed:", err);
+        // Cooperative cancel did not reach/stop the agent — the provider_cancel
+        // RPC failed or timed out, which means the runtime socket is likely
+        // stale or the runtime is unresponsive. Drop the socket so the
+        // escalation reconnects fresh, then hard-terminate: provider_terminate
+        // unconditionally kills the child process tree, so the user's Stop
+        // actually stops the agent instead of leaving it running behind an
+        // idle-looking UI. #2301.
+        console.warn(
+          "[AgentStore] abortTurn cancelPrompt failed; escalating to terminate:",
+          err,
+        );
+        disconnectLocalProviderRuntime();
+        await this.terminateSession(session.info.id).catch((termErr) => {
+          console.error(
+            "[AgentStore] abortTurn terminate escalation failed:",
+            termErr,
+          );
+        });
       }
     }
     this.setTurnInFlight(threadId, false);

--- a/tests/unit/agent-predictive-compaction.test.ts
+++ b/tests/unit/agent-predictive-compaction.test.ts
@@ -130,7 +130,11 @@ describe("#1631 — abortTurn wired for user cancel", () => {
   it("abortTurn symbol exists and does NOT set turnError", () => {
     const idx = agentStoreSource.indexOf("async abortTurn(");
     expect(idx).toBeGreaterThan(0);
-    const body = agentStoreSource.slice(idx, idx + 1200);
+    // Bound the slice to the actual method body (next method declaration)
+    // rather than a fixed-width window, so it stays accurate as abortTurn
+    // grows (e.g. the #2301 terminate-escalation path).
+    const end = agentStoreSource.indexOf("focusProjectSession(", idx);
+    const body = agentStoreSource.slice(idx, end > idx ? end : idx + 2000);
     expect(body).toContain("this.setTurnInFlight(threadId, false)");
     expect(body).not.toContain("this.setTurnError(");
   });

--- a/tests/unit/cancel-guaranteed-stop.test.ts
+++ b/tests/unit/cancel-guaranteed-stop.test.ts
@@ -1,0 +1,116 @@
+// ABOUTME: Regression test for #2301 — Cancel/Stop must GUARANTEE the Claude
+// ABOUTME: agent stops; cooperative interrupt failures must escalate to a hard kill.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const claudeRuntimeSource = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+
+/**
+ * Slice the body of the inner `async function cancelPrompt(...)` defined inside
+ * createClaudeRuntime. Sibling closure methods share indent-2, so the next
+ * `\n  async function ` declaration (terminateSession) bounds the slice.
+ */
+function extractCancelPromptBody(): string {
+  const start = claudeRuntimeSource.indexOf(
+    "async function cancelPrompt({ sessionId })",
+  );
+  if (start < 0) return "";
+  const after = claudeRuntimeSource.indexOf("\n  async function ", start + 1);
+  return after < 0
+    ? claudeRuntimeSource.slice(start)
+    : claudeRuntimeSource.slice(start, after);
+}
+
+/**
+ * Slice the body of the `async abortTurn(threadId: string)` store method.
+ * The next method declaration (`focusProjectSession(`) bounds the slice.
+ */
+function extractAbortTurnBody(): string {
+  const start = agentStoreSource.indexOf(
+    "async abortTurn(threadId: string): Promise<void> {",
+  );
+  if (start < 0) return "";
+  const after = agentStoreSource.indexOf("focusProjectSession(", start);
+  return after < 0
+    ? agentStoreSource.slice(start)
+    : agentStoreSource.slice(start, after);
+}
+
+describe("#2301 — runtime cancelPrompt escalates to a hard kill when interrupt fails", () => {
+  const body = extractCancelPromptBody();
+
+  it("body extraction succeeds (guard against refactor breakage)", () => {
+    expect(body, "cancelPrompt body must be non-empty").not.toBe("");
+    // Still attempts the cooperative interrupt first.
+    expect(body).toContain("sendControlRequest");
+    expect(body).toContain("interrupt");
+  });
+
+  it("escalates to killChildTree so the agent is guaranteed to stop", () => {
+    // The bug: cancelPrompt swallowed a failed/timed-out interrupt and marked
+    // the session "ready" WITHOUT killing the child, so the agent kept
+    // running. Cancel must hard-kill when the cooperative interrupt does not
+    // succeed — mirroring terminateSession's killChildTree.
+    expect(
+      body,
+      "cancelPrompt must call killChildTree as an escalation when the interrupt is not honored.",
+    ).toContain("killChildTree");
+  });
+
+  it("hard-kill is an escalation AFTER the cooperative interrupt, not unconditional", () => {
+    const interruptIdx = body.indexOf("sendControlRequest");
+    const killIdx = body.indexOf("killChildTree");
+    expect(interruptIdx).toBeGreaterThan(-1);
+    expect(killIdx).toBeGreaterThan(interruptIdx);
+  });
+
+  it("the hard-kill is gated on interrupt failure (not run on success)", () => {
+    // A conditional/flag must guard the kill so a cooperative interrupt that
+    // DID succeed leaves the session reusable. Accept either a boolean flag or
+    // a catch-driven escalation.
+    const hasFlag = /interrupted/.test(body);
+    const hasCatchEscalation = /catch[\s\S]*killChildTree/.test(body);
+    expect(
+      hasFlag || hasCatchEscalation,
+      "killChildTree must be guarded by interrupt-failure (a flag like `interrupted` or a catch path), not called unconditionally.",
+    ).toBe(true);
+  });
+});
+
+describe("#2301 — frontend abortTurn escalates to a hard stop when cancel RPC fails", () => {
+  const body = extractAbortTurnBody();
+
+  it("body extraction succeeds (guard against refactor breakage)", () => {
+    expect(body, "abortTurn body must be non-empty").not.toBe("");
+    // Still attempts the cooperative cancel first.
+    expect(body).toContain("providerService.cancelPrompt");
+  });
+
+  it("escalates to terminateSession when cancelPrompt fails/times out", () => {
+    // The bug: abortTurn caught a timed-out provider_cancel RPC, logged a
+    // warning, and flipped the UI idle WITHOUT stopping the agent. On failure
+    // it must escalate to terminateSession, whose runtime handler
+    // unconditionally hard-kills the child via a distinct RPC.
+    const cancelIdx = body.indexOf("providerService.cancelPrompt");
+    expect(cancelIdx, "abortTurn must call providerService.cancelPrompt").toBeGreaterThan(0);
+    const catchIdx = body.indexOf("catch", cancelIdx);
+    expect(
+      catchIdx,
+      "abortTurn must have a catch around cancelPrompt",
+    ).toBeGreaterThan(cancelIdx);
+    const afterCancelCatch = body.slice(catchIdx);
+    expect(
+      afterCancelCatch,
+      "the cancelPrompt failure path must escalate to terminateSession so the agent actually stops.",
+    ).toContain("terminateSession");
+  });
+});


### PR DESCRIPTION
## What

Make **Cancel / Stop guarantee the Claude agent stops.** Fixes #2301.

## Why

Cancel was best-effort cooperative with no guaranteed termination (logs `20260610_cancel_fail.log`, `20260610_cancel_fail_two.log`):

- **Runtime** (`bin/browser-local/claude-runtime.mjs` `cancelPrompt`): sent a `control_request: interrupt`, **swallowed any failure** with `.catch(() => {})`, then marked the session `"ready"` and emitted `Task cancelled` — **without killing the child**. A CLI that ignored the interrupt (hung, blocked on a tool/MCP roundtrip, stalled stdout reader) kept running past a "successful" cancel.
- **Frontend** (`src/stores/agent.store.ts` `abortTurn`): caught a timed-out `provider_cancel` RPC, logged `[AgentStore] abortTurn cancelPrompt failed`, flipped the UI idle, and cleared the turn — **without ever stopping the agent**. Exactly the logged behavior (5× `Runtime RPC timed out: provider_cancel`).

## How

- **Runtime:** escalate to `killChildTree(session.process)` when the cooperative `interrupt` is not acknowledged (rejects/times out), mirroring `terminateSession`. A cooperative interrupt that *does* succeed leaves the session reusable (unchanged behavior).
- **Frontend:** when the cancel RPC fails/times out, drop the possibly-stale runtime WebSocket (`disconnectLocalProviderRuntime()`) so the escalation reconnects fresh, then call `terminateSession` — a distinct `provider_terminate` RPC whose runtime handler **unconditionally** hard-kills the child tree.

These compose: a healthy-runtime-but-uncooperative-CLI is stopped by the runtime kill (cancel RPC then returns success); a stale/unresponsive socket is stopped by the frontend terminate escalation over a fresh connection.

## Tests

- `tests/unit/cancel-guaranteed-stop.test.ts` (new, TDD): asserts the runtime escalates to `killChildTree` only on interrupt failure, and the frontend escalates to `terminateSession` in the cancel-failure path. Source-level regression style, matching the existing runtime/store test convention (#1889, #1708).
- Re-anchored the #1631 `abortTurn` slice test in `agent-predictive-compaction.test.ts` to the method boundary (the fixed-width window no longer captured the still-present `setTurnInFlight` after the function grew).
- Full unit suite green: **1662 passed**.

## Residual (tracked for the post-merge functional audit)

If the runtime's Node event loop is genuinely blocked (synchronous CPU work) **or** the socket is dead and no `provider-runtime://restarted` ever fires (the Rust monitor in `provider_runtime.rs` detects only process *exit*, not unresponsiveness), then even the fresh-socket `terminate` can't be processed — only a Rust process-level kill / liveness watchdog would stop the agent. The exact upstream trigger for full runtime unresponsiveness is not deterministically identifiable from the logs. To be covered by the follow-up walk-through audit as a separate P1 if it survives this fix.

Scope: no Rust changes; `bin/` is the source of truth and is bundled into dev and release builds via `build:provider-runtime`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
