### PR TITLE
fix(agent): guarantee Cancel stops Gemini and Codex agents (#2304)

### DIFF
--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -330,6 +330,27 @@ function resolveCurrentPrompt(session) {
   pending.resolve();
 }
 
+// Resolve true once `pendingPrompt` is no longer the session's active prompt
+// (the agent settled the turn — resolve or reject clears currentPrompt), or
+// false if `timeoutMs` elapses first. Used to detect whether a cooperative
+// cancel actually stopped the turn before escalating to a hard kill.
+function waitForPromptToClear(session, pendingPrompt, timeoutMs) {
+  if (session.currentPrompt !== pendingPrompt) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const deadline = setTimeout(() => {
+      clearInterval(poll);
+      resolve(false);
+    }, timeoutMs);
+    const poll = setInterval(() => {
+      if (session.currentPrompt !== pendingPrompt) {
+        clearInterval(poll);
+        clearTimeout(deadline);
+        resolve(true);
+      }
+    }, 100);
+  });
+}
+
 function handleResponse(session, payload) {
   const pending = session.pendingRequests.get(String(payload.id));
   if (!pending) return;
@@ -865,12 +886,26 @@ export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) 
       throw new Error(`No Gemini session: ${sessionId}`);
     }
 
+    const pendingPrompt = session.currentPrompt;
+
     // ACP `session/cancel` is a notification (no id, no response).
     writeMessage(session, {
       jsonrpc: "2.0",
       method: "session/cancel",
       params: { sessionId: session.agentSessionId ?? sessionId },
     });
+
+    // The notification has no acknowledgement. Give the agent a short grace
+    // window to actually stop — its own turn-end clears currentPrompt. If the
+    // turn is still active after the window the agent ignored the cancel, so
+    // hard-kill the child tree to guarantee it stops, mirroring the Claude and
+    // Codex cancel paths. #2304.
+    if (pendingPrompt) {
+      const settled = await waitForPromptToClear(session, pendingPrompt, 10_000);
+      if (!settled) {
+        killChildTree(session.process);
+      }
+    }
 
     session.status = "ready";
     emit("provider://error", { sessionId, error: "Task cancelled" });

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -1281,17 +1281,28 @@ export function createProviderHandlers({ emit, runtimeMode = "provider-runtime" 
       const interruptTurnId = session.activeTurnId;
       session.activeTurnId = null;
 
-      await sendRequest(
-        session,
-        "turn/interrupt",
-        {
-          threadId: session.agentSessionId,
-          turnId: interruptTurnId,
-        },
-        10_000,
-      ).catch(() => {
-        // Best-effort interrupt only.
-      });
+      let interrupted = false;
+      try {
+        await sendRequest(
+          session,
+          "turn/interrupt",
+          {
+            threadId: session.agentSessionId,
+            turnId: interruptTurnId,
+          },
+          10_000,
+        );
+        interrupted = true;
+      } catch {
+        // Interrupt not acknowledged — escalate below.
+      }
+
+      if (!interrupted) {
+        // turn/interrupt was not honored (Codex hung or unresponsive). Hard-
+        // kill the child tree so the cancel actually stops the agent, mirroring
+        // terminateSession and the Claude cancel path. #2304.
+        killChildTree(session.process);
+      }
     }
 
     session.status = "ready";

--- a/tests/unit/provider-cancel-parity.test.ts
+++ b/tests/unit/provider-cancel-parity.test.ts
@@ -1,0 +1,77 @@
+// ABOUTME: Regression test for #2304 — Gemini and Codex cancel must GUARANTEE
+// ABOUTME: the agent stops, escalating to killChildTree when cooperative cancel fails.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const codexSource = readFileSync(
+  resolve("bin/browser-local/providers.mjs"),
+  "utf-8",
+);
+const geminiSource = readFileSync(
+  resolve("bin/browser-local/gemini-runtime.mjs"),
+  "utf-8",
+);
+
+/** Slice a top-level `async function <name>(` body, bounded by the next
+ * `\n  async function ` (sibling closure methods share indent-2). */
+function sliceAsyncFn(source: string, signature: string): string {
+  const start = source.indexOf(signature);
+  if (start < 0) return "";
+  const after = source.indexOf("\n  async function ", start + 1);
+  return after < 0 ? source.slice(start) : source.slice(start, after);
+}
+
+describe("#2304 — Codex cancelPrompt escalates to a hard kill when interrupt fails", () => {
+  const body = sliceAsyncFn(codexSource, "async function cancelPrompt({ sessionId })");
+
+  it("body extraction succeeds and still attempts the cooperative interrupt", () => {
+    expect(body, "Codex cancelPrompt body must be non-empty").not.toBe("");
+    expect(body).toContain("turn/interrupt");
+  });
+
+  it("escalates to killChildTree on interrupt failure (no longer a silent swallow)", () => {
+    expect(
+      body,
+      "Codex cancelPrompt must hard-kill the child when turn/interrupt is not acknowledged.",
+    ).toContain("killChildTree");
+    const interruptIdx = body.indexOf("turn/interrupt");
+    const killIdx = body.indexOf("killChildTree");
+    expect(killIdx, "kill must be an escalation after the interrupt").toBeGreaterThan(
+      interruptIdx,
+    );
+  });
+
+  it("the hard-kill is gated on interrupt failure, not unconditional", () => {
+    const hasFlag = /interrupted|interruptOk|stopped/.test(body);
+    const hasCatchEscalation = /catch[\s\S]*killChildTree/.test(body);
+    expect(
+      hasFlag || hasCatchEscalation,
+      "killChildTree must be guarded by interrupt-failure (a flag or catch path).",
+    ).toBe(true);
+  });
+});
+
+describe("#2304 — Gemini cancelPrompt escalates to a hard kill when the agent does not stop", () => {
+  const body = sliceAsyncFn(geminiSource, "async function cancelPrompt({ sessionId })");
+
+  it("body extraction succeeds and still sends the cooperative cancel", () => {
+    expect(body, "Gemini cancelPrompt body must be non-empty").not.toBe("");
+    expect(body).toContain("session/cancel");
+  });
+
+  it("escalates to killChildTree when the cooperative cancel does not settle the turn", () => {
+    // session/cancel is a fire-and-forget notification; if the agent ignores
+    // it, only a hard kill stops the child. The kill must be gated on the
+    // turn still being active after a grace window (currentPrompt not cleared).
+    expect(
+      body,
+      "Gemini cancelPrompt must hard-kill the child when the cooperative cancel is not honored.",
+    ).toContain("killChildTree");
+    expect(
+      body,
+      "the kill must be gated on the turn not settling (currentPrompt liveness).",
+    ).toContain("currentPrompt");
+  });
+});


### PR DESCRIPTION
## What

Extend the #2302 guaranteed-stop cancel to the **Gemini** and **Codex** providers. Fixes #2304.

## Why

#2302 fixed Claude. The audit found the same cooperative-only bug in the other two providers:
- **Codex** (`bin/browser-local/providers.mjs`): `turn/interrupt` failure was swallowed (`.catch(() => {})`) and the child was never killed.
- **Gemini** (`bin/browser-local/gemini-runtime.mjs`): `session/cancel` is a fire-and-forget notification with no acknowledgement and no fallback.

## How

- **Codex:** track `turn/interrupt` success; on rejection/timeout escalate to `killChildTree(session.process)`.
- **Gemini:** after sending `session/cancel`, wait a grace window for the agent to settle the turn (its turn-end clears `currentPrompt` via `resolveCurrentPrompt`); if the turn is still active after the window, escalate to `killChildTree`. New `waitForPromptToClear` helper keyed on `currentPrompt` liveness.

Both mirror the Claude path: a cooperative cancel that succeeds leaves the session reusable; only an unhonored cancel hard-kills.

## Tests

- `tests/unit/provider-cancel-parity.test.ts` (TDD): asserts each provider's `cancelPrompt` escalates to `killChildTree` only on cancel-failure. Source-level regression, matching `cancel-guaranteed-stop.test.ts`.
- Full unit suite green: **1671 passed**.

## Note

Gemini's grace-then-kill path could not be exercised against a live Gemini ACP session locally; the source-regression test covers the escalation wiring. Functional verification against a live Gemini agent is recommended.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
