### PR TITLE
fix(agent): clean up cancel-path edges from #2302 (#2306)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -2074,9 +2074,19 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       // roundtrip, or its stdout reader stalled). A cooperative cancel that
       // is silently swallowed leaves the agent running past a "successful"
       // cancel. Hard-kill the child tree so the cancel actually stops the
-      // agent, mirroring terminateSession. The session is no longer reusable
-      // afterward; the child's exit listener tears it down. #2301.
+      // agent, mirroring terminateSession. #2301
+      //
+      // The child is now dead: its exit listener emits the authoritative
+      // "terminated" status and deletes the session, so don't emit a
+      // misleading "ready" here (the session is not reusable). Reject the
+      // pending prompt and return. #2306
       killChildTree(session.process);
+      emit("provider://error", {
+        sessionId,
+        error: "Task cancelled",
+      });
+      rejectCurrentPrompt(session, new Error("Task cancelled"));
+      return;
     }
 
     session.status = "ready";

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -4738,18 +4738,23 @@ export const agentStore = {
       try {
         await providerService.cancelPrompt(session.info.id);
       } catch (err) {
-        // Cooperative cancel did not reach/stop the agent — the provider_cancel
-        // RPC failed or timed out, which means the runtime socket is likely
-        // stale or the runtime is unresponsive. Drop the socket so the
-        // escalation reconnects fresh, then hard-terminate: provider_terminate
-        // unconditionally kills the child process tree, so the user's Stop
-        // actually stops the agent instead of leaving it running behind an
-        // idle-looking UI. #2301.
+        // Cooperative cancel did not reach/stop the agent. Escalate to a hard
+        // terminate: provider_terminate unconditionally kills the child process
+        // tree, so the user's Stop actually stops the agent instead of leaving
+        // it running behind an idle-looking UI. #2301.
+        const message = err instanceof Error ? err.message : String(err);
         console.warn(
           "[AgentStore] abortTurn cancelPrompt failed; escalating to terminate:",
           err,
         );
-        disconnectLocalProviderRuntime();
+        // Only drop the socket when the failure looks like an unresponsive
+        // runtime (RPC timeout / dead socket) — a stale socket must be
+        // replaced before the terminate can land. For a logical error (e.g.
+        // "Session not found") the socket is healthy, so dropping it would
+        // needlessly reject other sessions' in-flight RPCs. #2306
+        if (/timed out|not connected|disconnected/i.test(message)) {
+          disconnectLocalProviderRuntime();
+        }
         await this.terminateSession(session.info.id).catch((termErr) => {
           console.error(
             "[AgentStore] abortTurn terminate escalation failed:",


### PR DESCRIPTION
Fixes #2306. Two P2 edges from #2302: (1) claude-runtime cancelPrompt no longer emits a misleading `ready` in the hard-kill branch — it rejects + returns and lets the child exit listener own the `terminated` emit/teardown; (2) abortTurn only drops the runtime socket on timeout/connection-type failures, so a logical cancel error on a healthy socket no longer rejects other sessions' in-flight RPCs. Existing #2302 regression test still passes; full suite 1671 green.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com