### PR TITLE
fix(ci): allow NSIS macro params in placeholder scan (#2310)

### DIFF
--- a/scripts/scan-nsis-placeholders.mjs
+++ b/scripts/scan-nsis-placeholders.mjs
@@ -37,12 +37,26 @@ function scan(file) {
   const text = readFileSync(file, "utf8");
   const findings = [];
   const lines = text.split(/\r?\n/);
+  // Inside `!macro name param1 param2` ... `!macroend`, NSIS references the
+  // declared parameters as ${param1} — lowercase tokens that are correct NSIS,
+  // not missed bundler substitutions. tauri-bundler ships utils.nsh verbatim
+  // with such macros (SetShortcutTarget shortcut target, ...), so declared
+  // parameters must not be flagged within their macro body (#2310).
+  let macroParams = null;
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i];
-    if (line.trimStart().startsWith(";")) continue;
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith(";")) continue;
+    const macroStart = trimmed.match(/^!macro\s+\S+\s*(.*)$/i);
+    if (macroStart) {
+      macroParams = new Set(macroStart[1].split(/\s+/).filter(Boolean));
+    } else if (/^!macroend\b/i.test(trimmed)) {
+      macroParams = null;
+    }
     for (const match of line.matchAll(SUSPECT_PATTERN)) {
       const token = match[0];
       if (ALLOWED_UNRESOLVED.has(token)) continue;
+      if (macroParams?.has(token.slice(2, -1))) continue;
       findings.push({ line: i + 1, token, context: line.trim() });
     }
   }

--- a/tests/unit/scan-nsis-placeholders.test.ts
+++ b/tests/unit/scan-nsis-placeholders.test.ts
@@ -80,4 +80,59 @@ describe("scan-nsis-placeholders", () => {
 
     expect(result.status).toBe(0);
   });
+
+  it("allows declared macro parameters inside the macro body (#2310)", () => {
+    // tauri-bundler ships utils.nsh verbatim (never handlebars-rendered);
+    // its macros reference declared params as ${param} — legitimate NSIS.
+    writeFileSync(
+      join(tmp, "utils.nsh"),
+      [
+        "!macro SetShortcutTarget shortcut target",
+        "  ${IPersistFile::Load} $1 '(\"${shortcut}\", ${STGM_READWRITE})'",
+        '  ${IShellLink::SetPath} $0 \'(w "${target}")\'',
+        '  ${IPersistFile::Save} $1 \'("${shortcut}",1)\'',
+        "!macroend",
+        "!macro UnpinShortcut shortcut",
+        "  ${IPersistFile::Load} $1 '(\"${shortcut}\", ${STGM_READ})'",
+        "!macroend",
+      ].join("\n"),
+    );
+
+    const result = runScanner(tmp);
+
+    expect(result.status).toBe(0);
+  });
+
+  it("still fails on undeclared lowercase tokens inside a macro body", () => {
+    writeFileSync(
+      join(tmp, "utils.nsh"),
+      [
+        "!macro CheckIfAppIsRunning executableName productName",
+        'MessageBox MB_OK "${product_name} is running! Click OK to kill it"',
+        "!macroend",
+      ].join("\n"),
+    );
+
+    const result = runScanner(tmp);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("${product_name}");
+  });
+
+  it("stops allowing macro parameters after !macroend", () => {
+    writeFileSync(
+      join(tmp, "utils.nsh"),
+      [
+        "!macro UnpinShortcut shortcut",
+        '  Pin::Unpin "${shortcut}"',
+        "!macroend",
+        'Run "${shortcut}"',
+      ].join("\n"),
+    );
+
+    const result = runScanner(tmp);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("line 4");
+  });
 });


### PR DESCRIPTION
Closes #2310.

## Problem

The v3.52.8 release run ([27305733985](https://github.com/serenorg/seren-desktop/actions/runs/27305733985)) was the first ever to clear the Windows signing gates (#2300 works — all 715 embedded binaries verified signed), which let the "Scan NSIS template for unresolved placeholders" gate run for the first time. It false-positived on 8 tokens in `utils.nsh`:

```
${shortcut} (x6), ${target} (x2)
```

`utils.nsh` is written **verbatim** by tauri-bundler (`include_bytes!` — never handlebars-rendered), and every flagged token is a declared NSIS macro parameter (`!macro SetShortcutTarget shortcut target`, `!macro UnpinShortcut shortcut`, ...). Inside a `!macro` body, `${param}` is correct NSIS — not the #2230 leak shape the scanner hunts.

The gate was added in #2234 after v3.51.7 shipped; every v3.52.x run died earlier at signing, so this latent bug was unreachable until now.

## Fix

The scanner tracks `!macro <name> <params...>` … `!macroend` regions and allows the declared parameter names within their macro body. Everything else still fails the scan, so genuine unrendered tokens (literal `${product_name}` shown to users, #2230) stay caught.

## Testing

- Three new unit tests (subprocess invocation, real `utils.nsh` shapes): declared params pass, undeclared lowercase tokens inside a macro still fail, params stop being allowed after `!macroend`. 7/7 pass.
- Ran the fixed scanner against the **exact** `utils.nsh` tauri-cli 2.11.2 ships (the file from the failed run): exits 0.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
