### PR TITLE
feat(agent): per-session force-kill to stop one runaway agent (#2313)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1993,6 +1993,9 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         createdAt: session.createdAt,
         agentSessionId: session.agentSessionId,
         timeoutSecs: session.timeoutSecs,
+        // OS PID of the agent child, so Rust can force-kill this one session
+        // when the cooperative cancel/terminate RPCs are unreachable. #2313
+        pid: session.process?.pid ?? null,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -763,6 +763,9 @@ export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) 
         createdAt: session.createdAt,
         agentSessionId: session.agentSessionId,
         timeoutSecs: session.timeoutSecs,
+        // OS PID of the agent child, so Rust can force-kill this one session
+        // when the cooperative cancel/terminate RPCs are unreachable. #2313
+        pid: session.process?.pid ?? null,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -1194,6 +1194,9 @@ export function createProviderHandlers({ emit, runtimeMode = "provider-runtime" 
         createdAt: session.createdAt,
         agentSessionId: session.agentSessionId,
         timeoutSecs: session.timeoutSecs,
+        // OS PID of the agent child, so Rust can force-kill this one session
+        // when the cooperative cancel/terminate RPCs are unreachable. #2313
+        pid: session.process?.pid ?? null,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -901,6 +901,7 @@ pub fn run() {
             embedded_runtime::get_embedded_runtime_info,
             provider_runtime::provider_runtime_get_config,
             provider_runtime::provider_runtime_stop,
+            provider_runtime::provider_force_kill_session,
             commands::updater::updater_install_preflight,
             commands::updater::updater_pre_install,
             commands::updater::updater_pre_install_release,

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -562,10 +562,173 @@ pub async fn provider_runtime_stop(state: State<'_, ProviderRuntimeState>) -> Re
     }
 }
 
+/// Look up the parent PID of `pid` via the OS, or `None` if it can't be
+/// determined (the process is gone or the query failed). Implemented with a
+/// subprocess on every platform so the same code compiles and is testable
+/// everywhere — this only runs on the rare force-kill escalation path.
+fn parent_pid(pid: u32) -> Option<u32> {
+    #[cfg(unix)]
+    {
+        // `ps -o ppid= -p <pid>` prints just the parent PID (macOS + Linux).
+        let output = std::process::Command::new("ps")
+            .args(["-o", "ppid=", "-p", &pid.to_string()])
+            .output()
+            .ok()?;
+        String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<u32>()
+            .ok()
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // Win32_Process.ParentProcessId is the reliable parent-PID source.
+        let script = format!(
+            "(Get-CimInstance Win32_Process -Filter 'ProcessId={}').ParentProcessId",
+            pid
+        );
+        let output = std::process::Command::new("powershell")
+            .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+            .creation_flags(0x08000000) // CREATE_NO_WINDOW
+            .output()
+            .ok()?;
+        String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<u32>()
+            .ok()
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
+/// True if `target` is a (proper) descendant of `ancestor`, found by walking
+/// `target`'s parent chain. The walk is bounded to defend against PID-reuse
+/// cycles, and stops at the kernel/init roots (PID 0/1).
+fn is_descendant_of(target: u32, ancestor: u32) -> bool {
+    let mut current = target;
+    for _ in 0..64 {
+        match parent_pid(current) {
+            Some(parent) => {
+                if parent == ancestor {
+                    return true;
+                }
+                if parent == 0 || parent == 1 || parent == current {
+                    return false;
+                }
+                current = parent;
+            }
+            None => return false,
+        }
+    }
+    false
+}
+
+/// Force-kill the process tree rooted at `pid`. On Windows `taskkill /T` reaps
+/// the whole tree; on unix we SIGKILL the agent process (its stdio children
+/// exit on the closed pipes), matching `kill_sync`'s behavior.
+fn force_kill_pid_tree(pid: u32) {
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as i32, libc::SIGKILL);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        let _ = std::process::Command::new("taskkill")
+            .args(["/F", "/T", "/PID", &pid.to_string()])
+            .creation_flags(0x08000000) // CREATE_NO_WINDOW
+            .status();
+    }
+}
+
+/// Force-kill a single agent session's child process by PID, as the last-resort
+/// escalation when the runtime's cooperative cancel/terminate RPCs are
+/// unreachable. Returns `true` if the process was killed, `false` if the kill
+/// was refused by the PID-reuse guard.
+///
+/// PID-reuse guard: the target must be a descendant of the managed provider
+/// runtime. If the agent already exited and the OS reused its PID for an
+/// unrelated process, that process is not under our runtime and is left
+/// untouched. The runtime process itself is never a valid target.
+#[tauri::command]
+pub async fn provider_force_kill_session(
+    state: State<'_, ProviderRuntimeState>,
+    pid: u32,
+) -> Result<bool, String> {
+    let runtime_pid = {
+        let guard = state.process.lock().await;
+        guard.as_ref().and_then(|process| process.child.id())
+    };
+    let Some(runtime_pid) = runtime_pid else {
+        log::warn!("[ProviderRuntime] force-kill refused for pid={pid}: runtime not running");
+        return Ok(false);
+    };
+
+    if pid == runtime_pid {
+        log::warn!(
+            "[ProviderRuntime] force-kill refused: pid={pid} is the provider runtime itself"
+        );
+        return Ok(false);
+    }
+
+    if !is_descendant_of(pid, runtime_pid) {
+        log::warn!(
+            "[ProviderRuntime] force-kill refused: pid={pid} is not a descendant of provider runtime pid={runtime_pid} (possible PID reuse)"
+        );
+        return Ok(false);
+    }
+
+    log::info!(
+        "[ProviderRuntime] force-killing agent session pid={pid} (runtime pid={runtime_pid})"
+    );
+    force_kill_pid_tree(pid);
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use tokio::process::Command as TokioCommand;
+
+    #[test]
+    fn force_kill_guard_only_matches_descendants() {
+        let me = std::process::id();
+        // Spawn a real, short-lived child of this test process.
+        #[cfg(unix)]
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn child");
+        #[cfg(windows)]
+        let mut child = std::process::Command::new("cmd")
+            .args(["/C", "ping", "-n", "30", "127.0.0.1"])
+            .spawn()
+            .expect("spawn child");
+        let child_pid = child.id();
+
+        // The spawned child's parent is this test process, so it is a
+        // descendant of it — the guard would permit killing it.
+        assert_eq!(parent_pid(child_pid), Some(me));
+        assert!(
+            is_descendant_of(child_pid, me),
+            "spawned child must be a descendant of this process"
+        );
+        // An unrelated root process (init/launchd, PID 1) is NOT our
+        // descendant — the guard must refuse it.
+        assert!(
+            !is_descendant_of(1, me),
+            "PID 1 must not be a descendant of the test process"
+        );
+        // A process is not a descendant of itself, so the runtime PID can
+        // never be force-killed as if it were one of its own sessions.
+        assert!(!is_descendant_of(me, me));
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
 
     /// Build a stub child process that exits instantly with the requested
     /// code/signal so `wait_for_provider_runtime_with_deadline` can exercise

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Provider runtime service for spawning and communicating with coding agents.
 // ABOUTME: Resolves the active runtime transport dynamically so browser modes can degrade cleanly.
 
+import { invoke } from "@tauri-apps/api/core";
 import {
   isLocalProviderRuntime,
   onRuntimeEvent,
@@ -8,6 +9,7 @@ import {
 } from "@/lib/browser-local-runtime";
 import type { McpServerConfig } from "@/lib/mcp/types";
 import { runtimeHasCapability } from "@/lib/runtime";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
 
 // ============================================================================
 // Types
@@ -50,6 +52,12 @@ export interface AgentSessionInfo {
   agentSessionId?: string;
   /** Prompt timeout in seconds. Undefined means unlimited (no timeout). */
   timeoutSecs?: number;
+  /**
+   * OS PID of the agent child process. Lets the Rust core force-kill this one
+   * session when the provider-runtime WebSocket is unreachable. Null when the
+   * runtime could not report a PID. #2313
+   */
+  pid?: number | null;
 }
 
 export interface AgentInfo {
@@ -367,6 +375,19 @@ export async function cancelPrompt(sessionId: string): Promise<void> {
  */
 export async function terminateSession(sessionId: string): Promise<void> {
   return invokeProvider("provider_terminate", { sessionId });
+}
+
+/**
+ * Force-kill a single agent session's child process by PID via the Rust core,
+ * bypassing the (possibly unreachable) provider-runtime WebSocket. This is the
+ * last-resort Stop escalation: it is the only path that lands when the runtime
+ * itself can no longer process RPCs. Rust applies a descendant-of-runtime guard
+ * so a stale/reused PID is never killed. Returns true if the process was
+ * killed, false if refused or unavailable. No-op outside the native runtime.
+ */
+export async function forceKillSession(pid: number): Promise<boolean> {
+  if (!isTauriRuntime()) return false;
+  return invoke<boolean>("provider_force_kill_session", { pid });
 }
 
 /**

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -4752,10 +4752,38 @@ export const agentStore = {
         // replaced before the terminate can land. For a logical error (e.g.
         // "Session not found") the socket is healthy, so dropping it would
         // needlessly reject other sessions' in-flight RPCs. #2306
+        let forceKilled = false;
         if (/timed out|not connected|disconnected/i.test(message)) {
           disconnectLocalProviderRuntime();
+          // The runtime WS is unreachable, so the terminate RPC below cannot
+          // land either. Force-kill the agent's process directly via Rust —
+          // the only escalation that works when the runtime can't process
+          // RPCs. The Rust descendant-of-runtime guard keeps this safe even if
+          // the PID is stale, and only the targeted session dies. #2313
+          const pid = session.info.pid;
+          if (pid != null) {
+            forceKilled = await providerService
+              .forceKillSession(pid)
+              .catch((killErr) => {
+                console.error(
+                  "[AgentStore] abortTurn force-kill failed:",
+                  killErr,
+                );
+                return false;
+              });
+            if (forceKilled) {
+              console.warn(
+                `[AgentStore] abortTurn force-killed agent pid=${pid}`,
+              );
+            }
+          }
         }
-        await this.terminateSession(session.info.id).catch((termErr) => {
+        // If we force-killed the agent, the provider_terminate RPC would only
+        // time out against the wedged runtime — skip it and clean up local
+        // state only. Otherwise attempt the normal cooperative terminate. #2313
+        await this.terminateSession(session.info.id, {
+          skipProviderKill: forceKilled,
+        }).catch((termErr) => {
           console.error(
             "[AgentStore] abortTurn terminate escalation failed:",
             termErr,

--- a/tests/unit/per-session-force-kill.test.ts
+++ b/tests/unit/per-session-force-kill.test.ts
@@ -1,0 +1,73 @@
+// ABOUTME: Regression test for #2313 — per-session force-kill wiring: runtime
+// ABOUTME: emits the child PID, and abortTurn escalates to provider_force_kill_session.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const providersSource = readFileSync(
+  resolve("src/services/providers.ts"),
+  "utf-8",
+);
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const claudeRuntimeSource = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+
+describe("#2313 — runtime spawn response carries the agent child PID", () => {
+  it("each provider's spawn return includes pid from session.process", () => {
+    // The frontend can only force-kill a session if it knows the child PID.
+    for (const file of [
+      "bin/browser-local/claude-runtime.mjs",
+      "bin/browser-local/providers.mjs",
+      "bin/browser-local/gemini-runtime.mjs",
+    ]) {
+      const src = readFileSync(resolve(file), "utf-8");
+      expect(src, `${file} must report the child pid`).toContain(
+        "pid: session.process?.pid",
+      );
+    }
+    // Sanity: the claude spawn return (not just a comment) carries it.
+    expect(claudeRuntimeSource).toContain("pid: session.process?.pid ?? null");
+  });
+});
+
+describe("#2313 — forceKillSession service is native-guarded and invokes the command", () => {
+  const start = providersSource.indexOf("export async function forceKillSession");
+  const body = providersSource.slice(start, start + 400);
+
+  it("exists and is exported", () => {
+    expect(start, "forceKillSession must be exported").toBeGreaterThan(0);
+  });
+
+  it("no-ops outside the native runtime and invokes provider_force_kill_session", () => {
+    // Browser-local mode has no Rust core — guard so invoke() never runs there.
+    expect(body).toContain("isTauriRuntime()");
+    expect(body).toContain('invoke<boolean>("provider_force_kill_session"');
+  });
+});
+
+describe("#2313 — abortTurn escalates to force-kill when the runtime is unreachable", () => {
+  const start = agentStoreSource.indexOf(
+    "async abortTurn(threadId: string): Promise<void> {",
+  );
+  const end = agentStoreSource.indexOf("focusProjectSession(", start);
+  const body = agentStoreSource.slice(start, end > start ? end : start + 3000);
+
+  it("calls forceKillSession only inside the unreachable-runtime branch", () => {
+    // The force-kill lives after the timeout/disconnect guard, so a healthy
+    // socket (logical cancel error) does not trigger a process kill.
+    const guardIdx = body.indexOf("disconnectLocalProviderRuntime()");
+    const killIdx = body.indexOf("forceKillSession(");
+    expect(guardIdx, "disconnect guard must exist").toBeGreaterThan(0);
+    expect(killIdx, "abortTurn must escalate to forceKillSession").toBeGreaterThan(
+      guardIdx,
+    );
+    // It targets the session's reported PID.
+    expect(body).toContain("session.info.pid");
+  });
+});


### PR DESCRIPTION
Closes #2313. Surgical Stop: when the provider-runtime WS is wedged, force-kill **one** agent's child process via Rust instead of nuking the whole runtime.

- Runtime (claude/codex/gemini): emit agent child `pid` in the spawn response.
- Frontend: `providers.forceKillSession` (native-guarded); `abortTurn` force-kills the PID as the final escalation when the cancel RPC is unreachable, then skips the doomed terminate RPC.
- Rust `provider_force_kill_session(pid)`: **descendant-of-runtime PID-reuse guard** (never kills a reused/unrelated PID, never the runtime itself), then SIGKILL (unix) / `taskkill /F /T` (windows). Parent-PID via `ps -o ppid=` / `Get-CimInstance` so it compiles + is testable on all platforms.

**Tests:** Rust unit test for the kill guard (spawns a real child: child IS a descendant, PID 1 is NOT, self is NOT) — passes on macOS. Frontend wiring regression test. Full suite green (1674). Windows `taskkill /T` tree-kill already verified live; ancestry walk being verified on the AWS Windows box.

**Residual:** sibling-agent PID reuse under the same runtime (narrow; blast radius = one of the user's own agents) — for the follow-up audit.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com