### PR TITLE
fix(agent): log silent force-kill skips for diagnosability (#2316)

### DIFF
--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -570,10 +570,19 @@ fn parent_pid(pid: u32) -> Option<u32> {
     #[cfg(unix)]
     {
         // `ps -o ppid= -p <pid>` prints just the parent PID (macOS + Linux).
-        let output = std::process::Command::new("ps")
+        let output = match std::process::Command::new("ps")
             .args(["-o", "ppid=", "-p", &pid.to_string()])
             .output()
-            .ok()?;
+        {
+            Ok(output) => output,
+            // A failure to run `ps` (not merely empty output for a dead PID)
+            // means the ancestry guard can't verify and will refuse the kill —
+            // log it so a silently-unstoppable agent is diagnosable. #2316
+            Err(err) => {
+                log::warn!("[ProviderRuntime] parent_pid: `ps` failed for pid={pid}: {err}");
+                return None;
+            }
+        };
         String::from_utf8_lossy(&output.stdout)
             .trim()
             .parse::<u32>()
@@ -587,11 +596,19 @@ fn parent_pid(pid: u32) -> Option<u32> {
             "(Get-CimInstance Win32_Process -Filter 'ProcessId={}').ParentProcessId",
             pid
         );
-        let output = std::process::Command::new("powershell")
+        let output = match std::process::Command::new("powershell")
             .args(["-NoProfile", "-NonInteractive", "-Command", &script])
             .creation_flags(0x08000000) // CREATE_NO_WINDOW
             .output()
-            .ok()?;
+        {
+            Ok(output) => output,
+            Err(err) => {
+                log::warn!(
+                    "[ProviderRuntime] parent_pid: `powershell` failed for pid={pid}: {err}"
+                );
+                return None;
+            }
+        };
         String::from_utf8_lossy(&output.stdout)
             .trim()
             .parse::<u32>()

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -4776,6 +4776,13 @@ export const agentStore = {
                 `[AgentStore] abortTurn force-killed agent pid=${pid}`,
               );
             }
+          } else {
+            // Runtime is unreachable AND we have no PID to fall back on, so the
+            // agent cannot be force-killed. Surface it so the rare
+            // unstoppable-agent case is diagnosable rather than silent. #2316
+            console.warn(
+              "[AgentStore] abortTurn: runtime unreachable and no agent PID available; cannot force-kill this session",
+            );
           }
         }
         // If we force-killed the agent, the provider_terminate RPC would only


### PR DESCRIPTION
Closes #2316. Adds diagnostic logging for the two rare cases where the #2313 per-session force-kill is skipped without a breadcrumb: `abortTurn` reaching the unreachable-runtime branch with no session PID, and `parent_pid`'s `ps`/`powershell` lookup failing to execute (making the descendant guard refuse). No behavior change. Post-audit follow-up — the audit found no surviving P0/P1 in #2313; the Windows `.cmd`-wrapper functional verification remains tracked in #2316.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com