### PR TITLE
fix(ci): start Windows e2e host before SSM send-command (#2318)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1064,6 +1064,35 @@ jobs:
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      # The e2e host is a shared box that other tooling stops to save cost.
+      # SendCommand against a stopped instance fails with InvalidInstanceId
+      # (v3.52.9, #2318) — start it if needed and wait for the SSM agent to
+      # report Online before staging work on it.
+      - name: Ensure Windows e2e host is running
+        shell: bash
+        run: |
+          set -euo pipefail
+          state="$(aws ec2 describe-instances --instance-ids "$WINDOWS_E2E_INSTANCE_ID" \
+            --query 'Reservations[0].Instances[0].State.Name' --output text)"
+          echo "Instance state: $state"
+          if [ "$state" != "running" ]; then
+            aws ec2 start-instances --instance-ids "$WINDOWS_E2E_INSTANCE_ID" >/dev/null
+            aws ec2 wait instance-running --instance-ids "$WINDOWS_E2E_INSTANCE_ID"
+            echo "Instance started."
+          fi
+          deadline=$((SECONDS + 600))
+          until [ "$(aws ssm describe-instance-information \
+            --filters "Key=InstanceIds,Values=$WINDOWS_E2E_INSTANCE_ID" \
+            --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null)" = "Online" ]; do
+            if [ "$SECONDS" -gt "$deadline" ]; then
+              echo "::error::Timed out waiting for the SSM agent to come online on the Windows e2e host."
+              exit 1
+            fi
+            echo "Waiting for SSM agent..."
+            sleep 15
+          done
+          echo "SSM agent online."
+
       - name: Stage Windows e2e payload in S3
         id: stage
         shell: bash


### PR DESCRIPTION
Closes #2318.

The windows-app-e2e job assumed the shared e2e EC2 host is always running and went straight to `ssm send-command` — v3.52.9 attempt 1 hit a stopped box (`InvalidInstanceId`; CloudTrail shows a StopInstances 42 minutes earlier from other tooling that cost-manages the box).

New step after AWS credential config: describe instance state → `ec2 start-instances` if not running → `aws ec2 wait instance-running` → poll `ssm describe-instance-information` until `PingStatus=Online` with a 10-minute deadline. The IAM role's inline policy gained `ec2:StartInstances` (scoped to the host), `ec2:DescribeInstances`, and `ssm:DescribeInstanceInformation` — already applied and verified.

Residual hazard stays documented in #2318: a stop or Seren process kill mid-e2e from other tooling still fails the run; a lease convention or dedicated host is the structural fix if collisions continue.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
