### PR TITLE
fix(ci): survive missing SSM parameter in e2e secret loop (#2320)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1120,7 +1120,13 @@ jobs:
             `aws s3 cp '${payloadS3}' (Join-Path $work 'windows-e2e-payload.zip')`,
             "Expand-Archive -LiteralPath (Join-Path $work 'windows-e2e-payload.zip') -DestinationPath $work -Force",
             `$secretNames = @(${secretNames.map((name) => `'${name}'`).join(",")})`,
-            `foreach ($name in $secretNames) { $parameterName = '${env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX}/' + $name; $value = aws ssm get-parameter --with-decryption --name $parameterName --query 'Parameter.Value' --output text 2>$null; if ($LASTEXITCODE -eq 0 -and $value -and $value -ne 'None') { [Environment]::SetEnvironmentVariable($name, $value, 'Process') } }`,
+            // The aws call runs under Windows PowerShell 5.1, where native
+            // stderr through a 2>$null redirect becomes a NativeCommandError
+            // that EAP=Stop turns terminating — a missing parameter killed the
+            // whole script before the guard ran (#2320). Scope EAP=Continue
+            // around the call so missing parameters degrade to the guarded
+            // skip they were designed for.
+            `foreach ($name in $secretNames) { $parameterName = '${env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX}/' + $name; $value = & { $ErrorActionPreference = 'Continue'; aws ssm get-parameter --with-decryption --name $parameterName --query 'Parameter.Value' --output text 2>$null }; if ($LASTEXITCODE -eq 0 -and $value -and $value -ne 'None') { [Environment]::SetEnvironmentVariable($name, $value, 'Process') } }`,
             "[Environment]::SetEnvironmentVariable('SEREN_E2E_API_BASE', 'https://api.serendb.com', 'Process')",
             "Set-Location $work",
             "corepack enable",


### PR DESCRIPTION
Closes #2320.

v3.52.9 attempt 2's `windows-app-e2e` died in the SSM secret-fetch loop: under Windows PowerShell 5.1 (what AWS-RunPowerShellScript uses), a native command writing to a redirected stderr (`2>$null`) becomes a `NativeCommandError`, and the script-level `$ErrorActionPreference = 'Stop'` makes it terminating. The first missing parameter (`SEREN_E2E_AGENT_TYPE`) killed the script before the tolerant guard (`if ($LASTEXITCODE -eq 0 ...)`) ever ran.

## Fix

Scope `$ErrorActionPreference = 'Continue'` around the `aws ssm get-parameter` call in a script block, so missing/unreadable parameters degrade to the guarded skip they were designed for.

## Verification (live, on the e2e host, under EAP=Stop)

- Old loop shape with a missing name: terminates with `NativeCommandError` (reproduces the failure).
- New scoped-EAP shape with a deliberately missing name: `SET`/`SKIP` per name, completes — `SCOPED-EAP LOOP SURVIVED MISSING PARAM`.

Also staged the two previously missing parameters (`SEREN_E2E_AGENT_TYPE=codex` matching the script default; `SEREN_E2E_AGENT_CWD=None` sentinel so the script default still applies) — that's what unblocked the live v3.52.9 rerun, since reruns use the tag's workflow.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
