### PR TITLE
Show skill install progress

### DIFF
--- a/src/components/sidebar/SkillsExplorer.tsx
+++ b/src/components/sidebar/SkillsExplorer.tsx
@@ -27,6 +27,7 @@ import {
 import type {
   InstalledSkill,
   Skill,
+  SkillInstallProgress,
   SkillScope,
   SkillSyncStatus,
 } from "@/lib/skills";
@@ -109,6 +110,75 @@ const SettingsIcon: Component = () => (
   </svg>
 );
 
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), 3);
+  return `${(bytes / k ** index).toFixed(1)} ${sizes[index]}`;
+}
+
+const SkillInstallProgressBar: Component<{
+  progress: SkillInstallProgress;
+  compact?: boolean;
+}> = (props) => {
+  const determinate = () => props.progress.totalBytes > 0;
+  const statusLabel = () => {
+    if (props.progress.stage === "installing") return "Installing";
+    if (!determinate()) return "Downloading";
+    return `${formatBytes(props.progress.downloadedBytes)} / ${formatBytes(
+      props.progress.totalBytes,
+    )}`;
+  };
+
+  return (
+    <div
+      class={
+        props.compact
+          ? "flex flex-col gap-1 min-w-[120px]"
+          : "flex flex-col gap-1 w-full min-w-[120px]"
+      }
+    >
+      <div class="flex items-center justify-between gap-2 text-[10px] text-muted-foreground">
+        <span class="truncate">{props.progress.message}</span>
+        <span class="shrink-0">
+          {determinate() ? `${props.progress.progressPercent}%` : statusLabel()}
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label="Skill install progress"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow={
+          determinate() ? props.progress.progressPercent : undefined
+        }
+        class="w-full h-[4px] bg-white/10 rounded-full overflow-hidden"
+        title={
+          determinate()
+            ? `${formatBytes(props.progress.downloadedBytes)} / ${formatBytes(
+                props.progress.totalBytes,
+              )}`
+            : props.progress.message
+        }
+      >
+        <div
+          class={`${
+            props.progress.stage === "installing"
+              ? "updater-bar-installing"
+              : "updater-bar-downloading"
+          } h-full rounded-full transition-all duration-300`}
+          style={{
+            width: determinate()
+              ? `${props.progress.progressPercent}%`
+              : "100%",
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
 export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
   const [activeFilter, setActiveFilter] = createSignal<Filter>("all");
   const [searchQuery, setSearchQuery] = createSignal("");
@@ -127,6 +197,9 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
   const [actionInProgress, setActionInProgress] = createSignal<string | null>(
     null,
   );
+  const [installProgressBySkill, setInstallProgressBySkill] = createSignal<
+    Record<string, SkillInstallProgress | undefined>
+  >({});
   const [refreshStatus, setRefreshStatus] = createSignal<string | null>(null);
   const [installWarning, setInstallWarning] = createSignal<{
     slug: string;
@@ -304,6 +377,34 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
     status: SkillSyncStatus | null | undefined,
   ) => {
     setSyncStatuses((current) => ({ ...current, [path]: status }));
+  };
+
+  const installProgressFor = (skillId: string) =>
+    installProgressBySkill()[skillId] ?? null;
+
+  const setInstallProgressFor = (
+    skillId: string,
+    progress: SkillInstallProgress,
+  ) => {
+    setInstallProgressBySkill((current) => ({
+      ...current,
+      [skillId]: progress,
+    }));
+  };
+
+  const clearInstallProgressFor = (skillId: string) => {
+    setInstallProgressBySkill((current) => {
+      const next = { ...current };
+      delete next[skillId];
+      return next;
+    });
+  };
+
+  const installButtonLabel = (skillId: string): string => {
+    if (actionInProgress() !== skillId) return "Install";
+    return installProgressFor(skillId)?.stage === "downloading"
+      ? "Downloading..."
+      : "Installing...";
   };
 
   const loadSyncStatus = async (skill: InstalledSkill) => {
@@ -600,6 +701,15 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
     scope: SkillScope = "seren",
   ) => {
     setActionInProgress(skill.id);
+    setInstallProgressFor(skill.id, {
+      stage: "downloading",
+      downloadedBytes: 0,
+      totalBytes: 0,
+      progressPercent: 0,
+      filesCompleted: 0,
+      filesTotal: 0,
+      message: "Preparing skill download",
+    });
     setInstallWarning(null);
     setInstallError(null);
     try {
@@ -607,7 +717,9 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
       if (!content) {
         throw new Error(`No SKILL.md content available for ${skill.slug}`);
       }
-      const installed = await skillsStore.install(skill, content, scope);
+      const installed = await skillsStore.install(skill, content, scope, {
+        onProgress: (progress) => setInstallProgressFor(skill.id, progress),
+      });
       await loadSyncStatus(installed);
       // Catalog install used to auto-attach the skill to the active thread
       // here. We removed that side effect: skills are tools-on-demand, not
@@ -630,6 +742,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
       });
     } finally {
       setActionInProgress(null);
+      clearInstallProgressFor(skill.id);
     }
   };
 
@@ -1589,6 +1702,16 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                             </span>
                           </Show>
                         </div>
+                        <Show when={installProgressFor(skill.id)}>
+                          {(progress) => (
+                            <div class="mt-2 max-w-[260px]">
+                              <SkillInstallProgressBar
+                                progress={progress()}
+                                compact
+                              />
+                            </div>
+                          )}
+                        </Show>
                       </div>
 
                       {/* Install button */}
@@ -1603,7 +1726,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                           disabled={installing()}
                           title="Install this skill locally"
                         >
-                          {installing() ? "Installing..." : "Install"}
+                          {installButtonLabel(skill.id)}
                         </button>
                       </div>
                     </div>
@@ -1651,6 +1774,15 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                           </Show>
 
                           <div class="mt-2.5 flex items-center gap-2 flex-wrap">
+                            <Show when={installProgressFor(skill.id)}>
+                              {(progress) => (
+                                <div class="basis-full">
+                                  <SkillInstallProgressBar
+                                    progress={progress()}
+                                  />
+                                </div>
+                              )}
+                            </Show>
                             <button
                               type="button"
                               class="px-3 py-1 bg-primary text-primary-foreground rounded-md text-[12px] font-medium cursor-pointer transition-colors hover:bg-primary/80 disabled:opacity-40 disabled:cursor-default"
@@ -1658,7 +1790,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                               disabled={installing()}
                               title="Install this skill locally"
                             >
-                              {installing() ? "Installing..." : "Install"}
+                              {installButtonLabel(skill.id)}
                             </button>
                             <Show when={ownsSkill(skill)}>
                               <button

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -169,6 +169,23 @@ export interface SkillSyncStatus {
   error?: string;
 }
 
+export type SkillInstallProgressStage = "downloading" | "installing";
+
+export interface SkillInstallProgress {
+  stage: SkillInstallProgressStage;
+  downloadedBytes: number;
+  totalBytes: number;
+  progressPercent: number;
+  filesCompleted: number;
+  filesTotal: number;
+  currentFile?: string;
+  message: string;
+}
+
+export interface SkillInstallOptions {
+  onProgress?: (progress: SkillInstallProgress) => void;
+}
+
 /**
  * Scope where a skill is installed.
  */

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -32,6 +32,8 @@ import {
   resolveSkillDisplayName,
   resolveSkillSlug,
   type Skill,
+  type SkillInstallOptions,
+  type SkillInstallProgress,
   type SkillScope,
   type SkillSource,
   type SkillSyncState,
@@ -79,8 +81,13 @@ interface ExtraFile {
 interface UpstreamSkillBundle {
   skillMd: string;
   payloadFiles: ExtraFile[];
+  payloadTotalBytes: number;
   remoteRevision: RemoteSkillRevision | null;
 }
+
+type DownloadedSkillBundle = SkillBundle & {
+  payloadTotalBytes?: number;
+};
 
 export interface InstallResult {
   installed: InstalledSkill;
@@ -515,6 +522,18 @@ async function downloadSkillBundleFilePayload(
 /** Per-file fetch fan-out cap for the split download flow. */
 const SPLIT_DOWNLOAD_CONCURRENCY = 4;
 
+function progressPercent(downloadedBytes: number, totalBytes: number): number {
+  if (totalBytes <= 0) return 0;
+  return Math.min(Math.round((downloadedBytes / totalBytes) * 100), 100);
+}
+
+function emitInstallProgress(
+  options: SkillInstallOptions | undefined,
+  progress: SkillInstallProgress,
+): void {
+  options?.onProgress?.(progress);
+}
+
 /**
  * Fetch every manifest file body with bounded concurrency and assemble
  * the `SkillBundle.files` shape the install pipeline consumes. Each file
@@ -525,10 +544,48 @@ const SPLIT_DOWNLOAD_CONCURRENCY = 4;
 async function fetchManifestFiles(
   slug: string,
   manifest: SkillBundleManifest,
+  options?: SkillInstallOptions,
 ): Promise<SkillBundleFile[]> {
   const metas = manifest.files ?? [];
   const files: SkillBundleFile[] = new Array(metas.length);
+  const totalBytes = metas.reduce((sum, meta) => sum + meta.size_bytes, 0);
+  const completedByIndex = new Set<number>();
+  let downloadedBytes = 0;
+  let filesCompleted = 0;
+  let nextProgressIndex = 0;
   let next = 0;
+
+  emitInstallProgress(options, {
+    stage: "downloading",
+    downloadedBytes: 0,
+    totalBytes,
+    progressPercent: 0,
+    filesCompleted: 0,
+    filesTotal: metas.length,
+    message:
+      totalBytes > 0
+        ? `Downloading 0 of ${metas.length} payload files`
+        : "Downloading skill payload files",
+  });
+
+  const emitContiguousCompletedProgress = (currentFile?: string) => {
+    while (completedByIndex.has(nextProgressIndex)) {
+      const meta = metas[nextProgressIndex];
+      downloadedBytes += meta.size_bytes;
+      filesCompleted += 1;
+      nextProgressIndex += 1;
+      emitInstallProgress(options, {
+        stage: "downloading",
+        downloadedBytes,
+        totalBytes,
+        progressPercent: progressPercent(downloadedBytes, totalBytes),
+        filesCompleted,
+        filesTotal: metas.length,
+        currentFile,
+        message: `Downloading ${filesCompleted} of ${metas.length} payload files`,
+      });
+    }
+  };
 
   const workers = Array.from(
     { length: Math.min(SPLIT_DOWNLOAD_CONCURRENCY, metas.length) },
@@ -549,6 +606,8 @@ async function fetchManifestFiles(
           mode: payload.mode,
           is_binary: payload.is_binary,
         };
+        completedByIndex.add(index);
+        emitContiguousCompletedProgress(payload.path);
       }
     },
   );
@@ -556,7 +615,10 @@ async function fetchManifestFiles(
   return files;
 }
 
-async function downloadSkillBundle(slug: string): Promise<SkillBundle> {
+async function downloadSkillBundle(
+  slug: string,
+  options?: SkillInstallOptions,
+): Promise<DownloadedSkillBundle> {
   try {
     return await downloadSkillBundleSingleShot(slug);
   } catch (error) {
@@ -565,13 +627,15 @@ async function downloadSkillBundle(slug: string): Promise<SkillBundle> {
       `[Skills] Single-shot download of ${slug} failed with 500; using split download fallback`,
     );
     const manifest = await downloadSkillBundleManifest(slug);
-    const files = await fetchManifestFiles(slug, manifest);
+    const files = await fetchManifestFiles(slug, manifest, options);
     return {
       skill: manifest.skill,
       version: manifest.version,
       skill_md: manifest.skill_md,
       manifest: manifest.manifest,
       content_hash: manifest.content_hash,
+      payloadTotalBytes:
+        manifest.files?.reduce((sum, meta) => sum + meta.size_bytes, 0) ?? 0,
       files,
     };
   }
@@ -934,18 +998,22 @@ async function logInstallFailure(
   }
 }
 
-async function fetchUpstreamSkillBundle(skill: {
-  sourceUrl?: string;
-  slug?: string;
-}): Promise<UpstreamSkillBundle | null> {
+async function fetchUpstreamSkillBundle(
+  skill: {
+    sourceUrl?: string;
+    slug?: string;
+  },
+  options?: SkillInstallOptions,
+): Promise<UpstreamSkillBundle | null> {
   const slug =
     skill.slug ??
     (skill.sourceUrl ? skillSlugFromSourceUrl(skill.sourceUrl) : null);
   if (!slug) return null;
-  const bundle = await downloadSkillBundle(slug);
+  const bundle = await downloadSkillBundle(slug, options);
   return {
     skillMd: bundle.skill_md,
     payloadFiles: bundleFilesToExtraFiles(bundle.files),
+    payloadTotalBytes: bundle.payloadTotalBytes ?? 0,
     remoteRevision: remoteRevisionFromBundle(bundle),
   };
 }
@@ -1434,6 +1502,7 @@ export const skills = {
     content: string,
     scope: SkillScope,
     projectRoot: string | null,
+    options?: SkillInstallOptions,
   ): Promise<InstalledSkill> {
     if (!isTauriRuntime()) {
       throw new Error("Skills can only be installed in the desktop app");
@@ -1455,14 +1524,16 @@ export const skills = {
     let installContent = content;
     let extraFiles: ExtraFile[] = [];
     let extraFilesJson: string | undefined;
+    let payloadTotalBytes = 0;
     let syncState: SkillSyncState | null = null;
     if (skill.source === "seren" && skill.sourceUrl) {
-      const bundle = await fetchUpstreamSkillBundle(skill);
+      const bundle = await fetchUpstreamSkillBundle(skill, options);
       if (!bundle) {
         throw new Error("Unable to fetch upstream skill content");
       }
       installContent = bundle.skillMd;
       extraFiles = bundle.payloadFiles;
+      payloadTotalBytes = bundle.payloadTotalBytes;
       if (extraFiles.length > 0) {
         extraFilesJson = JSON.stringify(extraFiles);
         log.info(
@@ -1480,6 +1551,16 @@ export const skills = {
         extraFiles,
       );
     }
+
+    emitInstallProgress(options, {
+      stage: "installing",
+      downloadedBytes: payloadTotalBytes,
+      totalBytes: payloadTotalBytes,
+      progressPercent: payloadTotalBytes > 0 ? 100 : 0,
+      filesCompleted: extraFiles.length,
+      filesTotal: extraFiles.length,
+      message: "Installing skill files",
+    });
 
     const path = await invoke<string>("install_skill", {
       skillsDir,

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -12,6 +12,7 @@ import {
   type InstalledSkill,
   isSkillCompatibleWithHost,
   type Skill,
+  type SkillInstallOptions,
   type SkillScope,
   type SkillsState,
 } from "@/lib/skills";
@@ -968,6 +969,7 @@ export const skillsStore = {
     skill: Skill,
     content: string,
     scope: SkillScope,
+    options?: SkillInstallOptions,
   ): Promise<InstalledSkill> {
     const key = `${scope}:${skill.slug}`;
     const inflight = activeInstallPromises.get(key);
@@ -982,6 +984,7 @@ export const skillsStore = {
         content,
         scope,
         projectRoot,
+        options,
       );
 
       // Drop any prior entry sharing the install path before appending so a

--- a/tests/unit/skills-install-progress-ui.test.ts
+++ b/tests/unit/skills-install-progress-ui.test.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Pins #2328 skill install progress UI to an accessible progress bar.
+// ABOUTME: Large payload installs must show byte-aware progress, not only a static Installing label.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  resolve("src/components/sidebar/SkillsExplorer.tsx"),
+  "utf-8",
+);
+
+describe("SkillsExplorer install progress UI (#2328)", () => {
+  it("renders an accessible install progress bar for active catalog installs", () => {
+    expect(source).toContain("SkillInstallProgressBar");
+    expect(source).toContain('role="progressbar"');
+    expect(source).toContain("aria-valuenow");
+    expect(source).toContain("installProgressFor(skill.id)");
+  });
+});

--- a/tests/unit/skills-split-download.test.ts
+++ b/tests/unit/skills-split-download.test.ts
@@ -181,6 +181,40 @@ describe("split-download fallback (#2296)", () => {
     );
   });
 
+  it("reports byte-aware progress while split-downloading payload files", async () => {
+    const onProgress = vi.fn();
+
+    await skills.install(catalogSkill, "", "seren", null, { onProgress });
+
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: "downloading",
+        downloadedBytes: 0,
+        totalBytes: PPTX_BYTES.length + SCRIPT_TEXT.length,
+        progressPercent: 0,
+        filesCompleted: 0,
+        filesTotal: 2,
+      }),
+    );
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: "downloading",
+        downloadedBytes: PPTX_BYTES.length,
+        totalBytes: PPTX_BYTES.length + SCRIPT_TEXT.length,
+        filesCompleted: 1,
+        filesTotal: 2,
+      }),
+    );
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: "installing",
+        downloadedBytes: PPTX_BYTES.length + SCRIPT_TEXT.length,
+        totalBytes: PPTX_BYTES.length + SCRIPT_TEXT.length,
+        progressPercent: 100,
+      }),
+    );
+  });
+
   it("serves content preview from the manifest without fetching file bodies", async () => {
     const content = await skills.fetchContent(catalogSkill);
     expect(content).toBe(SKILL_MD);


### PR DESCRIPTION
## Summary

Fixes #2328.

- Adds byte-aware progress events to the Seren Skills split-download install path.
- Shows an accessible progress bar in the Skills panel list row and expanded detail while a catalog skill installs.
- Reuses the updater progress shimmer classes for determinate download and indeterminate install states.

## Code-path audit

- `src/services/skills.ts`: split-download manifest totals drive progress callbacks; file completion remains ordered even with concurrent fetches.
- `src/stores/skills.store.ts`: progress callback is optional and preserves all existing install callers.
- `src/components/sidebar/SkillsExplorer.tsx`: catalog install initializes progress immediately, disables install controls, renders progress in row/detail, then clears state on completion/error.

## Verification

- `pnpm vitest run tests/unit/skills-split-download.test.ts tests/unit/skills-install-progress-ui.test.ts`
- `pnpm test`
- `pnpm build`
- `pnpm exec biome check src/components/sidebar/SkillsExplorer.tsx src/lib/skills/types.ts src/services/skills.ts src/stores/skills.store.ts tests/unit/skills-split-download.test.ts tests/unit/skills-install-progress-ui.test.ts`

## Notes

- Full `pnpm check` is currently blocked by existing unrelated Biome diagnostics in session/employee UI files.
- Full `tsc -p tsconfig.json --noEmit` is currently blocked by existing unrelated test declaration/type issues.
- AWS Windows host testing could not be run from this environment because no AWS/SSM/Windows runner credentials are present locally, and the live publisher list does not expose a Windows desktop test endpoint.