### PR TITLE
test(meeting): isolate Windows vitest imports

### DIFF
--- a/tests/unit/meeting-capture-start-failure.test.ts
+++ b/tests/unit/meeting-capture-start-failure.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/services/meetings", async (importOriginal) => ({
   listMeetings: m.listMeetings,
   getTranscriptSegments: m.getTranscriptSegments,
 }));
+vi.mock("@/services/orchestrator", () => ({ orchestrate: vi.fn() }));
 vi.mock("@/services/tray", () => ({
   setTrayRecording: m.setTrayRecording,
   onTrayToggleCapture: vi.fn(() => () => {}),
@@ -32,6 +33,12 @@ vi.mock("@/stores/settings.store", () => ({
   settingsStore: {
     get: (key: string) => key === "meetingAudioPrimed",
     set: vi.fn(),
+  },
+}));
+vi.mock("@/stores/conversation.store", () => ({
+  conversationStore: {
+    createConversationWithModel: vi.fn(async () => ({ id: "c1" })),
+    setActiveConversation: vi.fn(),
   },
 }));
 vi.mock("@/stores/provider.store", () => ({

--- a/tests/unit/meeting-native-capture-lifecycle.test.ts
+++ b/tests/unit/meeting-native-capture-lifecycle.test.ts
@@ -69,6 +69,7 @@ vi.mock("@/services/meetings", async (importOriginal) => ({
   getTranscriptSegments: m.getTranscriptSegments,
   isMeetingCaptureActive: m.isMeetingCaptureActive,
 }));
+vi.mock("@/services/orchestrator", () => ({ orchestrate: vi.fn() }));
 vi.mock("@/services/tray", () => ({
   setTrayRecording: m.setTrayRecording,
   onTrayToggleCapture: vi.fn(() => () => {}),
@@ -77,6 +78,12 @@ vi.mock("@/stores/settings.store", () => ({
   settingsStore: {
     get: (key: string) => key === "meetingAudioPrimed",
     set: vi.fn(),
+  },
+}));
+vi.mock("@/stores/conversation.store", () => ({
+  conversationStore: {
+    createConversationWithModel: vi.fn(async () => ({ id: "c1" })),
+    setActiveConversation: vi.fn(),
   },
 }));
 vi.mock("@/stores/provider.store", () => ({


### PR DESCRIPTION
Closes #2330.

## Summary

- Mock `@/services/orchestrator` in the two Meeting Mode tests that only exercise capture startup/lifecycle behavior.
- Mock `@/stores/conversation.store` in the same tests so importing `meeting.store` does not load unrelated conversation/tooling modules.
- Keeps the handoff behavior covered by the dedicated handoff tests that already mock these boundaries.

## Audit / Repro

AWS Windows Server 2022 host `seren-sandbox` reproduced the issue at `250870b6d47522b997f471ffc4793dd80cf8b5b0`:

```powershell
pnpm vitest run tests/unit/meeting-native-capture-lifecycle.test.ts tests/unit/meeting-capture-start-failure.test.ts --reporter verbose
```

Before: 2 failed suites, 0 tests collected, `ERR_MODULE_NOT_FOUND` resolving `@walletconnect/sign-client` through `thirdweb`.

After applying this patch in the same Windows checkout: 2 files, 6 tests passed.

## Verification

- `pnpm vitest run tests/unit/meeting-native-capture-lifecycle.test.ts tests/unit/meeting-capture-start-failure.test.ts`
- `pnpm vitest run tests/unit/meeting-ui-regressions.test.ts tests/unit/meeting-native-capture-lifecycle.test.ts tests/unit/meeting-capture-start-failure.test.ts tests/unit/meeting-concurrent-stop.test.ts tests/unit/meeting-notes-failure-gate.test.ts tests/unit/meeting-handoff-terminal.test.ts tests/unit/meeting-speaker-reconcile-gate.test.ts`
- `pnpm check`
- `pnpm build`
- AWS Windows SSM verification: `51886b63-9405-4663-bb5e-9e1c939e2224`
