### PR TITLE
fix(windows): embed Common Controls manifest at build time

### DIFF
--- a/scripts/test-windows-cargo.ps1
+++ b/scripts/test-windows-cargo.ps1
@@ -6,30 +6,6 @@ if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
   throw "scripts/test-windows-cargo.ps1 must be run on Windows."
 }
 
-function Resolve-MtExe {
-  $existing = Get-Command "mt.exe" -ErrorAction SilentlyContinue
-  if ($existing) {
-    return $existing.Source
-  }
-
-  $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}) | Where-Object { $_ }
-  $candidates = @()
-  foreach ($root in $roots) {
-    $sdkBin = Join-Path $root "Windows Kits\10\bin"
-    if (Test-Path $sdkBin) {
-      $candidates += Get-ChildItem -Path $sdkBin -Recurse -Filter "mt.exe" -ErrorAction SilentlyContinue |
-        Where-Object { $_.FullName -match "\\x64\\mt\.exe$" }
-    }
-  }
-
-  $selected = $candidates | Sort-Object FullName -Descending | Select-Object -First 1
-  if (-not $selected) {
-    throw "mt.exe was not found. Install the Windows SDK with Visual Studio Build Tools."
-  }
-
-  return $selected.FullName
-}
-
 function Invoke-Checked {
   param(
     [Parameter(Mandatory = $true)]
@@ -64,7 +40,6 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 $tauriDir = Join-Path $repoRoot "src-tauri"
 $cargoManifest = Join-Path $tauriDir "Cargo.toml"
 $targetDeps = Join-Path $tauriDir "target\debug\deps"
-$commonControlsManifest = Join-Path $targetDeps "common-controls-v6.manifest"
 
 Push-Location $repoRoot
 try {
@@ -75,41 +50,6 @@ try {
   }
 
   Remove-AppLocalApiSetForwarders $targetDeps
-
-  @"
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-    <application>
-      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
-      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
-    </application>
-  </compatibility>
-  <dependency>
-    <dependentAssembly>
-      <assemblyIdentity
-        type="win32"
-        name="Microsoft.Windows.Common-Controls"
-        version="6.0.0.0"
-        processorArchitecture="*"
-        publicKeyToken="6595b64144ccf1df"
-        language="*" />
-    </dependentAssembly>
-  </dependency>
-</assembly>
-"@ | Set-Content -Path $commonControlsManifest -Encoding ASCII
-
-  $mt = Resolve-MtExe
-  $testExecutables = Get-ChildItem -Path $targetDeps -Filter "*.exe" -File
-  if (-not $testExecutables) {
-    throw "Cargo did not produce any Windows test executables in $targetDeps."
-  }
-
-  foreach ($testExecutable in $testExecutables) {
-    Invoke-Checked $mt "-manifest" $commonControlsManifest "-outputresource:$($testExecutable.FullName);#1"
-  }
 
   Invoke-Checked "cargo" "test" "--manifest-path" $cargoManifest
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,4 +1,6 @@
 fn main() {
+    embed_windows_common_controls_manifest();
+
     // Pass the target triple to the compiled code for sidecar binary discovery
     println!(
         "cargo:rustc-env=TARGET={}",
@@ -53,5 +55,34 @@ fn main() {
         println!("cargo:rustc-env=BUILT_RUST_VERSION=unknown");
     }
 
-    tauri_build::build()
+    run_tauri_build()
+}
+
+fn embed_windows_common_controls_manifest() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os != "windows" || target_env != "msvc" {
+        return;
+    }
+
+    let manifest_path =
+        std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .join("common-controls-v6.manifest");
+    let manifest = manifest_path.display();
+
+    println!("cargo:rerun-if-changed={manifest}");
+    println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+    println!("cargo:rustc-link-arg=/MANIFESTINPUT:{manifest}");
+}
+
+fn run_tauri_build() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "windows" && target_env == "msvc" {
+        let windows = tauri_build::WindowsAttributes::new_without_app_manifest();
+        let attributes = tauri_build::Attributes::new().windows_attributes(windows);
+        tauri_build::try_build(attributes).expect("failed to run Tauri build script");
+    } else {
+        tauri_build::build();
+    }
 }

--- a/src-tauri/common-controls-v6.manifest
+++ b/src-tauri/common-controls-v6.manifest
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+    </application>
+  </compatibility>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/tests/unit/windows-cargo-manifest.test.ts
+++ b/tests/unit/windows-cargo-manifest.test.ts
@@ -1,0 +1,48 @@
+// ABOUTME: Guards Windows Rust test harness manifest embedding.
+// ABOUTME: Plain cargo test must link Common Controls v6 without wrapper mutation.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = process.cwd();
+const tauriDir = join(repoRoot, "src-tauri");
+
+describe("Windows cargo test manifest embedding", () => {
+  it("links every MSVC test executable with the checked-in Common Controls v6 manifest", () => {
+    const buildScriptPath = join(tauriDir, "build.rs");
+    const manifestPath = join(tauriDir, "common-controls-v6.manifest");
+
+    expect(existsSync(buildScriptPath)).toBe(true);
+    expect(existsSync(manifestPath)).toBe(true);
+
+    const buildScript = readFileSync(buildScriptPath, "utf8");
+    expect(buildScript).toContain('std::env::var("CARGO_MANIFEST_DIR")');
+    expect(buildScript).toContain("cargo:rustc-link-arg=/MANIFEST:EMBED");
+    expect(buildScript).toContain(
+      "cargo:rustc-link-arg=/MANIFESTINPUT:{manifest}",
+    );
+    expect(buildScript).not.toContain("rustc-link-arg-tests");
+    expect(buildScript).toContain("WindowsAttributes::new_without_app_manifest");
+    expect(buildScript).toContain("common-controls-v6.manifest");
+
+    const manifest = readFileSync(manifestPath, "utf8");
+    expect(manifest).toContain("Microsoft.Windows.Common-Controls");
+    expect(manifest).toContain('version="6.0.0.0"');
+    expect(manifest).toContain(
+      'supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"',
+    );
+  });
+
+  it("keeps the Windows wrapper from post-build manifest patching", () => {
+    const script = readFileSync(
+      join(repoRoot, "scripts", "test-windows-cargo.ps1"),
+      "utf8",
+    );
+
+    expect(script).toContain("Remove-AppLocalApiSetForwarders $targetDeps");
+    expect(script).not.toContain("Resolve-MtExe");
+    expect(script).not.toContain("mt.exe");
+    expect(script).not.toContain("-outputresource:");
+    expect(script).not.toContain("common-controls-v6.manifest");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2312.
Fixes #2324.

- checks in a Windows Common Controls v6 application manifest for `src-tauri`
- emits MSVC link-time manifest args from `src-tauri/build.rs` so plain `cargo test --manifest-path src-tauri/Cargo.toml ...` test harnesses receive the manifest
- disables Tauri's duplicate Windows app-manifest resource on the same MSVC path, because Tauri's default manifest is app-bin-only and collides with the build-time manifest when both are present
- removes the Windows cargo wrapper's post-build `mt.exe` mutation path; it now only preserves the API-set forwarder cleanup before running cargo tests

## Audit

The original comment suggested `src-tauri/.cargo/config.toml`, but a repo-root `cargo test --manifest-path src-tauri/Cargo.toml ...` does not read `src-tauri/.cargo/config.toml`. The fix therefore lives in `build.rs`, uses `CARGO_MANIFEST_DIR` for an absolute manifest path, and covers the exact failing plain-cargo invocation.

Windows validation also found two implementation traps before merge:

- `cargo:rustc-link-arg-tests` is invalid for this package because there is no explicit Cargo `[[test]]` target, even though Cargo creates unit-test harnesses.
- generic `cargo:rustc-link-arg` initially duplicated Tauri's app manifest resource for the `Seren` bin test target; the final code disables Tauri's app manifest resource only on Windows MSVC and supplies the manifest once via link args.

Optional dependency attribution: `tauri-plugin-dialog v2.7.1` pulls `rfd v0.16.0`, whose Windows backend imports `TaskDialogIndirect`. `tauri-runtime-wry` and `muda` also reference that API. The manifest fix resolves the loader binding regardless of which dependency first contributes the import.

## Tests

- `pnpm vitest run tests/unit/windows-cargo-manifest.test.ts`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --no-run`
- AWS Windows Server 2022 SSM `f7baf113-a6b2-4014-90fa-f2e951b96fa0` on `i-0a575b70ba969fb6e`:
  - `pnpm vitest run tests/unit/windows-cargo-manifest.test.ts` passed
  - `cargo test --quiet --manifest-path src-tauri/Cargo.toml skills:: -- --list` launched and enumerated `skills::` tests without `0xc0000139`
  - `cargo test --quiet --manifest-path src-tauri/Cargo.toml install_skill_writes_manifest_only_when_no_extras -- --nocapture` passed

## Impact

Plain Windows cargo test binaries now get the Common Controls v6 activation manifest at link time instead of relying on `scripts/test-windows-cargo.ps1` post-build mutation. Linux/macOS builds skip the Windows link args and keep the existing Tauri build path.
