### PR TITLE
fix(agent): persist streamed assistant drafts

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -799,6 +799,8 @@ export interface ActiveSession {
   streamingContentReplay?: boolean;
   /** Stable replay assistant message id for chunk/message boundaries. */
   streamingContentMessageId?: string;
+  /** Stable SQLite row id for the in-flight assistant draft for this turn. */
+  assistantDraftMessageId?: string;
   /** Timestamp for current streaming thinking chunk buffer (ms epoch). */
   streamingThinkingTimestamp?: number;
   /** Buffered replay user text that may arrive as multiple chunks. */
@@ -1195,17 +1197,63 @@ function persistAgentMessage(
   // never stamped with producer provenance.
   const provider =
     msg.type === "user" ? null : (msg.provider ?? sessionAgentType);
-  saveMessage(
-    msg.id,
-    conversationId,
-    msg.type === "user" ? "user" : "assistant",
-    msg.content,
-    null,
-    msg.timestamp,
-    serializeAgentMessageMetadata(msg),
-    provider,
-  ).catch((error) =>
-    console.warn("[AgentStore] Failed to persist agent message:", error),
+  const queueKey = `${conversationId}:${msg.id}`;
+  const previous = messagePersistQueues.get(queueKey) ?? Promise.resolve();
+  const next = previous
+    .catch(() => undefined)
+    .then(() =>
+      saveMessage(
+        msg.id,
+        conversationId,
+        msg.type === "user" ? "user" : "assistant",
+        msg.content,
+        null,
+        msg.timestamp,
+        serializeAgentMessageMetadata(msg),
+        provider,
+      ),
+    );
+  messagePersistQueues.set(queueKey, next);
+  next
+    .catch((error) =>
+      console.warn("[AgentStore] Failed to persist agent message:", error),
+    )
+    .finally(() => {
+      if (messagePersistQueues.get(queueKey) === next) {
+        messagePersistQueues.delete(queueKey);
+      }
+    });
+}
+
+function persistStreamingAssistantDraft(sessionId: string): void {
+  const session = state.sessions[sessionId];
+  if (!session?.conversationId || !session.streamingContent) return;
+  if (session.streamingContentReplay === true) return;
+
+  const draftContent = scrubAgentMarkup(session.streamingContent);
+  if (
+    draftContent.length === 0 ||
+    isGeneratedPromptPrimer(draftContent) ||
+    session.isSkippingSkillContext
+  ) {
+    return;
+  }
+
+  const draftMessageId = session.assistantDraftMessageId ?? crypto.randomUUID();
+  if (!session.assistantDraftMessageId) {
+    setState("sessions", sessionId, "assistantDraftMessageId", draftMessageId);
+  }
+
+  persistAgentMessage(
+    session.conversationId,
+    {
+      id: draftMessageId,
+      type: "assistant",
+      content: draftContent,
+      timestamp: session.streamingContentTimestamp ?? Date.now(),
+      provider: session.info.agentType,
+    },
+    session.info.agentType,
   );
 }
 
@@ -1386,6 +1434,7 @@ const pendingSessionEvents = new Map<string, AgentEvent[]>();
 /** Guard against concurrent auto-recovery spawns in sendPrompt (per-session). */
 const recoveryInFlightMap = new Map<string, Promise<string | null>>();
 const LEGACY_CLAUDE_LOCAL_SESSION_ID_RE = /^session-\d+$/;
+const messagePersistQueues = new Map<string, Promise<void>>();
 
 // Chunk accumulation buffers — plain JS, not reactive.
 // Flushed to the SolidJS store at CHUNK_FLUSH_MS intervals to reduce
@@ -1481,6 +1530,7 @@ function flushChunkBuf(sessionId: string): void {
         buf.content,
       ),
     );
+    persistStreamingAssistantDraft(sessionId);
     buf.content = "";
   }
   if (buf.thinking) {
@@ -5101,6 +5151,7 @@ export const agentStore = {
     setState("sessions", sessionId, "streamingContentTimestamp", undefined);
     setState("sessions", sessionId, "streamingContentReplay", undefined);
     setState("sessions", sessionId, "streamingContentMessageId", undefined);
+    setState("sessions", sessionId, "assistantDraftMessageId", undefined);
     setState("sessions", sessionId, "streamingThinking", "");
     setState("sessions", sessionId, "streamingThinkingTimestamp", undefined);
     setState("sessions", sessionId, "pendingUserMessage", "");
@@ -5748,6 +5799,7 @@ export const agentStore = {
         }
         this.flushPendingUserMessage(sessionId);
         this.finalizeStreamingContent(sessionId, { isReplay: isHistoryReplay });
+        setState("sessions", sessionId, "assistantDraftMessageId", undefined);
 
         // Turn finalized successfully → clear the thread's in-flight signal,
         // the inline error state (if any), and the restart timer. #1631.
@@ -6967,6 +7019,7 @@ export const agentStore = {
         setState("sessions", sessionId, "streamingContentTimestamp", undefined);
         setState("sessions", sessionId, "streamingContentReplay", undefined);
         setState("sessions", sessionId, "streamingContentMessageId", undefined);
+        setState("sessions", sessionId, "assistantDraftMessageId", undefined);
         setState("sessions", sessionId, "promptStartTime", undefined);
         return;
       }
@@ -6983,6 +7036,7 @@ export const agentStore = {
         setState("sessions", sessionId, "streamingContentTimestamp", undefined);
         setState("sessions", sessionId, "streamingContentReplay", undefined);
         setState("sessions", sessionId, "streamingContentMessageId", undefined);
+        setState("sessions", sessionId, "assistantDraftMessageId", undefined);
         setState("sessions", sessionId, "promptStartTime", undefined);
         return;
       }
@@ -6998,7 +7052,10 @@ export const agentStore = {
       const safeContent = finalOutputValidation.safeDisplayText;
 
       const message: AgentMessage = {
-        id: session.streamingContentMessageId ?? crypto.randomUUID(),
+        id:
+          session.assistantDraftMessageId ??
+          session.streamingContentMessageId ??
+          crypto.randomUUID(),
         type: "assistant",
         content: safeContent,
         timestamp: session.streamingContentTimestamp ?? Date.now(),
@@ -7057,6 +7114,7 @@ export const agentStore = {
       setState("sessions", sessionId, "streamingContentTimestamp", undefined);
       setState("sessions", sessionId, "streamingContentReplay", undefined);
       setState("sessions", sessionId, "streamingContentMessageId", undefined);
+      setState("sessions", sessionId, "assistantDraftMessageId", undefined);
       // Clear the start time
       setState("sessions", sessionId, "promptStartTime", undefined);
     }

--- a/tests/unit/agent-history-persistence.test.ts
+++ b/tests/unit/agent-history-persistence.test.ts
@@ -113,8 +113,8 @@ describe("agent message persistence guards", () => {
       finalizeIdx,
       agentStoreSource.indexOf("async forkConversation(", finalizeIdx),
     );
-    expect(finalizeBody).toContain(
-      "id: session.streamingContentMessageId ?? crypto.randomUUID()",
+    expect(finalizeBody).toMatch(
+      /id:\s*session\.assistantDraftMessageId\s*\?\?\s*session\.streamingContentMessageId\s*\?\?\s*crypto\.randomUUID\(\)/,
     );
   });
 

--- a/tests/unit/agent-streaming-draft-persistence.test.ts
+++ b/tests/unit/agent-streaming-draft-persistence.test.ts
@@ -1,0 +1,69 @@
+// ABOUTME: Regression tests for #2333 — visible streamed assistant text must survive reload.
+// ABOUTME: Pins the agent-store contract that checkpoints live assistant chunks before promptComplete.
+
+import { describe, expect, it } from "vitest";
+import { readSource } from "./source-text";
+
+const agentStoreSource = readSource("src/stores/agent.store.ts");
+
+describe("#2333 — live assistant stream drafts are recoverable after reload", () => {
+  it("flushChunkBuf checkpoints visible live assistant text to SQLite", () => {
+    const flushIdx = agentStoreSource.indexOf(
+      "function flushChunkBuf(sessionId: string)",
+    );
+    expect(flushIdx).toBeGreaterThan(0);
+    const flushBody = agentStoreSource.slice(flushIdx, flushIdx + 1400);
+
+    expect(flushBody).toContain("persistStreamingAssistantDraft(sessionId)");
+    expect(flushBody).toContain("consumeAgentThinkingMarkupChunk(");
+
+    const checkpointIdx = flushBody.indexOf(
+      "persistStreamingAssistantDraft(sessionId)",
+    );
+    const visibleAppendIdx = flushBody.indexOf(
+      "consumeAgentThinkingMarkupChunk(",
+    );
+    expect(checkpointIdx).toBeGreaterThan(visibleAppendIdx);
+  });
+
+  it("draft persistence skips replay/primer text and reuses the final assistant message id", () => {
+    const helperIdx = agentStoreSource.indexOf(
+      "function persistStreamingAssistantDraft(",
+    );
+    expect(helperIdx).toBeGreaterThan(0);
+    const helperBody = agentStoreSource.slice(helperIdx, helperIdx + 2200);
+
+    expect(helperBody).toContain("session.streamingContentReplay === true");
+    expect(helperBody).toContain("isGeneratedPromptPrimer(draftContent)");
+    expect(helperBody).toContain("session.assistantDraftMessageId");
+    expect(helperBody).toContain('type: "assistant"');
+    expect(helperBody).toContain("persistAgentMessage(");
+
+    const finalizeIdx = agentStoreSource.indexOf(
+      "finalizeStreamingContent(sessionId: string",
+    );
+    expect(finalizeIdx).toBeGreaterThan(0);
+    const finalizeBody = agentStoreSource.slice(finalizeIdx, finalizeIdx + 4200);
+    expect(finalizeBody).toMatch(
+      /id:\s*session\.assistantDraftMessageId\s*\?\?\s*session\.streamingContentMessageId\s*\?\?\s*crypto\.randomUUID\(\)/,
+    );
+  });
+
+  it("serializes draft and final saves for the same assistant message id", () => {
+    expect(agentStoreSource).toContain(
+      "const messagePersistQueues = new Map<string, Promise<void>>()",
+    );
+
+    const persistIdx = agentStoreSource.indexOf(
+      "function persistAgentMessage(",
+    );
+    expect(persistIdx).toBeGreaterThan(0);
+    const persistBody = agentStoreSource.slice(persistIdx, persistIdx + 2600);
+
+    expect(persistBody).toContain('const queueKey = `${conversationId}:${msg.id}`');
+    expect(persistBody).toContain("messagePersistQueues.get(queueKey)");
+    expect(persistBody).toContain(".catch(() => undefined)");
+    expect(persistBody).toContain(".then(() =>");
+    expect(persistBody).toContain("messagePersistQueues.set(queueKey, next)");
+  });
+});


### PR DESCRIPTION
Closes #2333

## Summary
- checkpoint visible live assistant streaming text into SQLite before promptComplete
- reuse a stable in-flight assistant draft id so final completion overwrites the draft row
- serialize saves per conversation/message id so older draft writes cannot race and overwrite final text
- keep replay, generated prompt primers, and tool-boundary UI flushes from creating duplicate persisted assistant rows

## Functional audit
- Live stream then reload: draft row is persisted and restored by loadPersistedAgentHistory.
- Live stream then normal completion: final assistant message uses the same draft id and overwrites the draft.
- Tool-call boundary flush: UI can still split assistant text around tool cards; SQLite keeps a single recoverable draft/final row.
- History replay: streamingContentReplay skips draft persistence and still honors provider message ids.
- Generated primer / skill context: draft and final discard paths clear the draft id without persisting primer text.
- MacOS/Windows: change is frontend store + existing SQLite save_message bridge, no platform-specific branch.

## Tests
- pnpm vitest run tests/unit/agent-streaming-draft-persistence.test.ts tests/unit/agent-history-persistence.test.ts tests/unit/agent-skills-priming.test.ts tests/unit/agent-scrub-wiring.test.ts
- pnpm test
- pnpm build

## Notes
- pnpm build exits 0 with existing Rolldown node_modules PURE annotation warnings and chunk-size warnings.
- pnpm check exits 0 with existing lint warnings in unrelated files.