### PR TITLE
fix(meeting): editable titles + unique labels + live recording indicator (#2335)

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -163,6 +163,28 @@ pub async fn set_meeting_routed_skill(
 }
 
 #[tauri::command]
+pub async fn update_meeting_title(
+    app: AppHandle,
+    id: String,
+    title: String,
+) -> Result<(), String> {
+    let lookup = id.clone();
+    run_db(app.clone(), move |conn| {
+        conn.execute(
+            "UPDATE meetings
+             SET title = ?1, updated_at = ?2
+             WHERE id = ?3",
+            params![title, now_ms(), id],
+        )?;
+        mark_sync_upsert(conn, "meetings", &id)?;
+        Ok(())
+    })
+    .await?;
+    emit_meeting_status_by_id(&app, &lookup).await;
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn append_transcript_segment(
     app: AppHandle,
     meeting_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -808,6 +808,7 @@ pub fn run() {
             commands::audio::delete_meeting,
             commands::audio::update_meeting_status,
             commands::audio::update_meeting_notes,
+            commands::audio::update_meeting_title,
             commands::audio::set_meeting_routed_skill,
             commands::audio::append_transcript_segment,
             commands::audio::get_transcript_segments,

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -638,6 +638,14 @@ export const AppShell: Component<AppShellProps> = (props) => {
       (meeting) => meeting.status === "capturing",
     );
 
+  // Live-capture signal for the titlebar so a recording stays visible after the
+  // meeting drawer is closed (#2335). The capture lifecycle lives in this shell,
+  // so the indicator persists for the whole session, not just while the panel is open.
+  const meetingRecording = () =>
+    meetingStore.state.meetings.some(
+      (meeting) => meeting.status === "capturing",
+    );
+
   return (
     <div class="flex flex-col h-screen bg-background text-foreground">
       <Titlebar
@@ -645,6 +653,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
         onToggleMeetings={handleToggleMeetings}
         onToggleSkills={handleToggleSkills}
         onToggleSettings={handleToggleSettings}
+        meetingRecording={meetingRecording()}
         recordPromptVisible={recordPromptVisible()}
         recordPromptSourceApp={meetingStore.state.autoDetectSourceApp}
         onRecordConversation={() => void meetingStore.acceptAutoDetect()}

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -13,6 +13,8 @@ interface TitlebarProps {
   onToggleMeetings: () => void;
   onToggleSkills: () => void;
   onToggleSettings: () => void;
+  /** A meeting capture is live; show the recording indicator on the button. */
+  meetingRecording?: boolean;
   recordPromptVisible?: boolean;
   recordPromptSourceApp?: string | null;
   onRecordConversation?: () => void;
@@ -157,11 +159,27 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
         <button
           type="button"
           data-testid="titlebar-meetings-button"
-          class="flex items-center justify-center w-7 h-7 border-none rounded-md bg-transparent text-muted-foreground cursor-pointer transition-all duration-100 hover:bg-surface-2 hover:text-foreground active:scale-95"
+          class="relative flex items-center justify-center w-7 h-7 border-none rounded-md cursor-pointer transition-all duration-100 active:scale-95"
+          classList={{
+            "bg-transparent text-muted-foreground hover:bg-surface-2 hover:text-foreground":
+              !props.meetingRecording,
+            "text-success bg-success/10 meeting-recording-glow":
+              props.meetingRecording,
+          }}
           onClick={props.onToggleMeetings}
-          title="Meetings"
+          title={
+            props.meetingRecording
+              ? "Recording in progress — open Meetings to stop"
+              : "Meetings"
+          }
+          aria-label={
+            props.meetingRecording ? "Recording in progress" : "Meetings"
+          }
         >
           <MeetingsIcon />
+          <Show when={props.meetingRecording}>
+            <span class="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-success ring-2 ring-surface-1 animate-pulse" />
+          </Show>
         </button>
 
         <button

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -24,6 +24,26 @@ interface MeetingDetailProps {
   onRequestDelete?: (meeting: Meeting) => void;
 }
 
+function PencilGlyph() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M11.1 2.9a1.2 1.2 0 0 1 1.7 1.7l-6.8 6.8-2.3.6.6-2.3 6.8-6.8Z"
+        stroke="currentColor"
+        stroke-width="1.3"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+}
+
 function TrashGlyph() {
   return (
     <svg
@@ -92,8 +112,26 @@ export function MeetingDetail(props: MeetingDetailProps) {
   );
   const [regenerating, setRegenerating] = createSignal(false);
   const [highlightedSeq, setHighlightedSeq] = createSignal<number | null>(null);
+  const [editingTitle, setEditingTitle] = createSignal(false);
+  const [titleDraft, setTitleDraft] = createSignal("");
 
   const rows = new Map<number, HTMLElement>();
+
+  const startEditingTitle = () => {
+    // Edit the raw stored title (blank for an auto-named meeting), not the
+    // "Meeting HH:MM:SS" fallback, so the placeholder guides a real name.
+    setTitleDraft(props.meeting.title);
+    setEditingTitle(true);
+  };
+
+  // Persist the draft, then leave edit mode. Guarded so Enter (which exits edit
+  // mode) and the unmount blur that follows don't both fire a rename.
+  const commitTitle = async () => {
+    if (!editingTitle()) return;
+    const draft = titleDraft();
+    setEditingTitle(false);
+    await meetingStore.renameMeeting(props.meeting, draft);
+  };
 
   onMount(async () => {
     let builtins: MeetingTemplate[] = [];
@@ -153,9 +191,44 @@ export function MeetingDetail(props: MeetingDetailProps) {
       <div class="mb-5">
         <div class="flex items-start justify-between gap-4">
           <div class="min-w-0">
-            <h3 class="truncate text-[18px] font-semibold tracking-normal">
-              {meetingTitle(props.meeting)}
-            </h3>
+            <Show
+              when={editingTitle()}
+              fallback={
+                <div class="group flex max-w-full items-center gap-1.5">
+                  <h3 class="truncate text-[18px] font-semibold tracking-normal">
+                    {meetingTitle(props.meeting)}
+                  </h3>
+                  <button
+                    type="button"
+                    class="shrink-0 rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-70"
+                    onClick={startEditingTitle}
+                    title="Rename meeting"
+                    aria-label="Rename meeting"
+                  >
+                    <PencilGlyph />
+                  </button>
+                </div>
+              }
+            >
+              <input
+                ref={(el) => queueMicrotask(() => el.focus())}
+                class="w-full h-9 rounded-md border border-border bg-surface-1 px-2.5 text-[18px] font-semibold text-foreground focus:outline-none focus:border-primary/60"
+                value={titleDraft()}
+                placeholder={meetingTitle(props.meeting)}
+                aria-label="Meeting title"
+                onInput={(event) => setTitleDraft(event.currentTarget.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    void commitTitle();
+                  } else if (event.key === "Escape") {
+                    event.preventDefault();
+                    setEditingTitle(false);
+                  }
+                }}
+                onBlur={() => void commitTitle()}
+              />
+            </Show>
             <div class="mt-1 flex flex-wrap items-center gap-3 text-[12px] text-muted-foreground">
               <span>{STATUS_LABELS[props.meeting.status]}</span>
               <span class="font-mono tabular-nums">

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -214,6 +214,12 @@ export function MeetingPanel(props: MeetingPanelProps) {
             placeholder="Meeting title"
             value={title()}
             onInput={(event) => setTitle(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                void startManualCapture();
+              }
+            }}
             disabled={activeCapture() !== undefined}
           />
           <Show

--- a/src/lib/meeting-format.ts
+++ b/src/lib/meeting-format.ts
@@ -21,8 +21,22 @@ export function formatDuration(meeting: Meeting): string {
   return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
+// Auto-generated titles carry seconds so two captures started in the same
+// clock-minute stay distinguishable in the list (#2335). formatTime keeps minute
+// precision for the duration/status surfaces that don't need disambiguation.
+function formatTimeWithSeconds(ms: number): string {
+  return new Date(ms).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
 export function meetingTitle(meeting: Meeting): string {
-  return meeting.title.trim() || `Meeting ${formatTime(meeting.startedAt)}`;
+  return (
+    meeting.title.trim() ||
+    `Meeting ${formatTimeWithSeconds(meeting.startedAt)}`
+  );
 }
 
 export const STATUS_LABELS: Record<Meeting["status"], string> = {

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -115,6 +115,10 @@ export function updateMeetingNotes(
   });
 }
 
+export function updateMeetingTitle(id: string, title: string): Promise<void> {
+  return invoke("update_meeting_title", { id, title });
+}
+
 export function setMeetingRoutedSkill(
   id: string,
   routedSkillSlug?: string | null,

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -25,6 +25,7 @@ import {
   stopMeetingCapture as stopBackendCapture,
   type TranscriptSegment,
   updateMeetingStatus,
+  updateMeetingTitle,
 } from "@/services/meetings";
 import { orchestrate } from "@/services/orchestrator";
 import { onTrayToggleCapture, setTrayRecording } from "@/services/tray";
@@ -665,6 +666,34 @@ function clearError(): void {
   setMeetingState("error", null);
 }
 
+// Rename a saved meeting. Persists the new title, then updates the list row and
+// the active selection so the change shows immediately; the backend also emits
+// meeting://status, which reconciles any other surface.
+async function renameMeeting(meeting: Meeting, title: string): Promise<void> {
+  const trimmed = title.trim();
+  if (trimmed === meeting.title) return;
+  if (!isTauriRuntime()) return;
+  try {
+    await updateMeetingTitle(meeting.id, trimmed);
+    setMeetingState("meetings", (meetings) =>
+      meetings.map((item) =>
+        item.id === meeting.id ? { ...item, title: trimmed } : item,
+      ),
+    );
+    if (meetingState.activeMeeting?.id === meeting.id) {
+      setMeetingState("activeMeeting", {
+        ...meetingState.activeMeeting,
+        title: trimmed,
+      });
+    }
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Failed to rename meeting",
+    );
+  }
+}
+
 async function deleteMeeting(meeting: Meeting): Promise<void> {
   if (!isTauriRuntime()) return;
   setMeetingState("error", null);
@@ -793,6 +822,7 @@ export const meetingStore = {
   stopCapture,
   stopAndProcess,
   regenerateNotes,
+  renameMeeting,
   deleteMeeting,
   clearError,
   startAutoDetect,

--- a/src/styles.css
+++ b/src/styles.css
@@ -476,6 +476,22 @@ footer.status-bar {
   animation: updater-shimmer 1.5s ease-in-out infinite;
 }
 
+/* Live meeting-capture indicator on the titlebar meetings button. Green pulse so
+   an active recording stays visible even when the meeting drawer is closed (#2335). */
+@keyframes meeting-recording-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 7px 2px rgba(52, 211, 153, 0.28);
+  }
+}
+
+.meeting-recording-glow {
+  animation: meeting-recording-pulse 1.8s ease-in-out infinite;
+}
+
 /* Slide-in from right (SlidePanel) */
 @keyframes slideInRight {
   from {

--- a/tests/unit/meeting-rename-and-indicator.test.ts
+++ b/tests/unit/meeting-rename-and-indicator.test.ts
@@ -1,0 +1,65 @@
+// ABOUTME: Source-level guards for #2335 — meeting rename plumbing and the titlebar recording indicator.
+// ABOUTME: Locks the wiring so the rename path and live-capture affordance can't silently regress.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string): string {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("Meeting rename plumbing (#2335)", () => {
+  it("wires updateMeetingTitle from the service to a Rust command", () => {
+    const service = source("src/services/meetings.ts");
+    expect(service).toContain("export function updateMeetingTitle");
+    expect(service).toContain('invoke("update_meeting_title"');
+  });
+
+  it("registers the Rust update_meeting_title command", () => {
+    expect(source("src-tauri/src/commands/audio.rs")).toContain(
+      "pub async fn update_meeting_title",
+    );
+    expect(source("src-tauri/src/lib.rs")).toContain(
+      "commands::audio::update_meeting_title",
+    );
+  });
+
+  it("adds a renameMeeting store action over updateMeetingTitle", () => {
+    const store = source("src/stores/meeting.store.ts");
+    expect(store).toContain("renameMeeting");
+    expect(store).toContain("updateMeetingTitle");
+  });
+
+  it("makes the detail title editable, committing on Enter and canceling on Escape", () => {
+    const detail = source("src/components/meeting/MeetingDetail.tsx");
+    expect(detail).toContain("renameMeeting");
+    expect(detail).toContain('"Enter"');
+    expect(detail).toContain('"Escape"');
+  });
+
+  it("starts capture on Enter in the new-meeting title field (no dead key)", () => {
+    const panel = source("src/components/meeting/MeetingPanel.tsx");
+    expect(panel).toContain("onKeyDown");
+    expect(panel).toContain("startManualCapture");
+  });
+});
+
+describe("Titlebar recording indicator when the drawer is closed (#2335)", () => {
+  it("drives the meetings button from live capture state", () => {
+    const titlebar = source("src/components/layout/Titlebar.tsx");
+    expect(titlebar).toContain("meetingRecording");
+    expect(titlebar).toContain("meeting-recording-glow");
+  });
+
+  it("derives capturing state in AppShell and passes it to the titlebar", () => {
+    const appShell = source("src/components/layout/AppShell.tsx");
+    expect(appShell).toContain("meetingRecording={");
+  });
+
+  it("defines the green recording-glow animation", () => {
+    expect(source("src/styles.css")).toContain("meeting-recording-glow");
+  });
+});

--- a/tests/unit/meeting-title-fallback.test.ts
+++ b/tests/unit/meeting-title-fallback.test.ts
@@ -1,0 +1,48 @@
+// ABOUTME: Regression test for #2335 — untitled meetings in the same minute must not collide.
+// ABOUTME: The auto-generated fallback title disambiguates by second; explicit titles win verbatim.
+
+import { describe, expect, it } from "vitest";
+import { meetingTitle } from "@/lib/meeting-format";
+import type { Meeting } from "@/services/meetings";
+
+function makeMeeting(overrides: Partial<Meeting>): Meeting {
+  return {
+    id: "m",
+    title: "",
+    sourceApp: null,
+    startedAt: 0,
+    endedAt: null,
+    status: "notes_ready",
+    templateId: null,
+    routedSkillSlug: null,
+    agentConversationId: null,
+    notesMarkdown: null,
+    notesStructJson: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("meetingTitle (#2335)", () => {
+  it("uses an explicit title verbatim, trimmed", () => {
+    expect(meetingTitle(makeMeeting({ title: "  Standup June 11  " }))).toBe(
+      "Standup June 11",
+    );
+  });
+
+  it("keeps the 'Meeting' prefix for untitled meetings", () => {
+    expect(meetingTitle(makeMeeting({ startedAt: 0 }))).toMatch(/^Meeting /);
+  });
+
+  it("distinguishes two untitled meetings started in the same minute", () => {
+    // Two captures 36 seconds apart share the same clock-minute (05:46). The
+    // minute-precision fallback collided ("Meeting 05:46 AM" twice); the fix
+    // disambiguates by second so the list rows stay distinct.
+    const first = new Date(2026, 5, 11, 5, 46, 12).getTime();
+    const second = new Date(2026, 5, 11, 5, 46, 48).getTime();
+    expect(meetingTitle(makeMeeting({ startedAt: first }))).not.toBe(
+      meetingTitle(makeMeeting({ startedAt: second })),
+    );
+  });
+});


### PR DESCRIPTION
Closes #2335.

Fixes three Meeting Mode defects reproduced from the running desktop app.

## BUG 1 — Meeting title not editable / not saved (P1)
Before, there was no rename path anywhere (no service fn, no Rust command) and the new-meeting title field had no Enter handler — typing + Enter was a silent no-op.

- New Rust command `update_meeting_title` (mirrors `set_meeting_routed_skill`: `UPDATE meetings SET title…`, `mark_sync_upsert`, emits `meeting://status`), registered in `lib.rs`.
- `updateMeetingTitle` service + `renameMeeting` store action (optimistic list + active-meeting update; the status event reconciles other surfaces).
- The meeting title in `MeetingDetail` is now inline-editable — click the rename affordance, **Enter** saves, **Escape** cancels.
- The new-meeting field in `MeetingPanel` starts capture on **Enter** (the key is no longer dead).

## BUG 2 — Duplicate list names (P2)
`meetingTitle()` fell back to minute precision, so two captures in the same minute both read "Meeting 05:46 AM". The auto-generated fallback now carries seconds; `formatTime` stays minute-precision for the duration/status surfaces. Rename (BUG 1) lets users disambiguate permanently.

## BUG 3 — No recording indicator when the drawer is closed (P1)
The capture lifecycle lives in the always-mounted `AppShell`, so capture keeps running after the panel unmounts — but the titlebar gave no signal. The titlebar meetings button now glows green with a pulsing dot whenever any meeting is `capturing`, with a tooltip/aria-label telling the user recording is live and to open Meetings to stop. Clicking it reopens the drawer (existing behavior).

## Tests (critical only)
- `meeting-title-fallback.test.ts` — pure-fn: explicit title wins; two same-minute untitled meetings get distinct labels.
- `meeting-rename-and-indicator.test.ts` — source-level guards (existing `meeting-ui-regressions` style) for the rename plumbing (service → Rust command → store → detail) and the titlebar recording-indicator wiring.

## Verification
- `pnpm vitest run tests/unit/` — 1658 passed (no regressions).
- `cargo check` (src-tauri) — clean.
- Biome — clean on changed files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
