### PR TITLE
feat(meeting): auto-publish to seren-notes with chat link (#2337)

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -11,6 +11,7 @@ pub mod merge;
 pub mod notes;
 pub mod pipeline;
 pub mod reconcile;
+pub mod seren_notes_publish;
 pub mod templates;
 pub mod transcribe;
 pub mod types;

--- a/src-tauri/src/audio/seren_notes_publish.rs
+++ b/src-tauri/src/audio/seren_notes_publish.rs
@@ -1,0 +1,234 @@
+// ABOUTME: Auto-publishes a finalized meeting (notes + action items + transcript) to seren-notes.
+// ABOUTME: Returns the created note UUID so the client can link "Chat with meeting notes".
+
+use crate::auth::{authenticated_request, has_stored_credentials};
+use reqwest::Client;
+use serde_json::Value;
+use tauri::AppHandle;
+
+const PUBLISH_URL: &str = "https://api.serendb.com/publishers/seren-notes/notes";
+
+/// Assemble the single markdown body posted to seren-notes. Always carries
+/// notes, action items, and the per-speaker transcript, in that order, so the
+/// published page mirrors what the user sees locally.
+pub fn build_publish_content(
+    notes_markdown: &str,
+    action_items: &[String],
+    transcript: &str,
+) -> String {
+    let mut out = String::new();
+    out.push_str("## Notes\n\n");
+    out.push_str(notes_markdown.trim());
+    out.push_str("\n\n## Action items\n\n");
+    if action_items.is_empty() {
+        out.push_str("_None captured._\n");
+    } else {
+        for item in action_items {
+            let trimmed = item.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            out.push_str("- ");
+            out.push_str(trimmed);
+            out.push('\n');
+        }
+    }
+    out.push_str("\n## Transcript\n\n");
+    out.push_str(transcript.trim());
+    out.push('\n');
+    out
+}
+
+/// Walk an arbitrary seren-notes response shape (raw, NoteDataResponse, or the
+/// Gateway publisher-proxy envelope `{data:{status,body,cost}}` with a body
+/// that may be JSON-encoded) and return the first UUID-shaped `id` found.
+/// Mirrors `extractNoteId` in `src/lib/save-to-notes.ts` so both surfaces
+/// tolerate the same envelope drift.
+pub fn extract_note_id(value: &Value) -> Option<String> {
+    let mut queue: Vec<Value> = vec![value.clone()];
+    while let Some(node) = queue.pop() {
+        match node {
+            Value::String(s) => {
+                if s.starts_with('{') || s.starts_with('[') {
+                    if let Ok(parsed) = serde_json::from_str::<Value>(&s) {
+                        queue.push(parsed);
+                    }
+                }
+            }
+            Value::Object(map) => {
+                if let Some(Value::String(id)) = map.get("id") {
+                    if is_uuid(id) {
+                        return Some(id.clone());
+                    }
+                }
+                for v in map.into_iter().map(|(_, v)| v) {
+                    queue.push(v);
+                }
+            }
+            Value::Array(items) => {
+                for v in items {
+                    queue.push(v);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn is_uuid(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('-').collect();
+    let expected = [8usize, 4, 4, 4, 12];
+    if parts.len() != expected.len() {
+        return false;
+    }
+    for (part, expected_len) in parts.iter().zip(expected.iter()) {
+        if part.len() != *expected_len {
+            return false;
+        }
+        if !part.chars().all(|c| c.is_ascii_hexdigit()) {
+            return false;
+        }
+    }
+    true
+}
+
+/// POST the assembled note to seren-notes via the Gateway publisher proxy
+/// using the user's existing access token. Short-circuits with a clear error
+/// when no credentials are stored — callers handle that case by skipping the
+/// publish silently and letting the UI render the "Login to SerenDB" CTA.
+pub async fn publish_meeting_notes(
+    app: &AppHandle,
+    title: &str,
+    content: &str,
+) -> Result<String, String> {
+    if !has_stored_credentials(app) {
+        return Err("not authenticated".to_string());
+    }
+    let client = Client::new();
+    let body = serde_json::json!({
+        "title": title,
+        "content": content,
+        "format": "markdown",
+    })
+    .to_string();
+    let response = authenticated_request(app, &client, |c, token| {
+        c.post(PUBLISH_URL)
+            .header("Content-Type", "application/json")
+            .bearer_auth(token)
+            .body(body.clone())
+    })
+    .await?;
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .map_err(|err| format!("seren-notes read body failed: {err}"))?;
+    if !status.is_success() {
+        return Err(format!("seren-notes publish returned {status}: {text}"));
+    }
+    let value: Value = serde_json::from_str(&text)
+        .map_err(|err| format!("seren-notes response was not JSON: {err}"))?;
+    extract_note_id(&value).ok_or_else(|| "seren-notes response missing note id".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn build_publish_content_contains_all_three_sections_in_order() {
+        let body = build_publish_content(
+            "# Summary\nWe agreed on Q3 launch.",
+            &["Send recap email".to_string(), "Book follow-up".to_string()],
+            "Me: Let's ship.\nThem: Agreed.",
+        );
+        let notes_idx = body.find("## Notes").expect("notes header");
+        let actions_idx = body.find("## Action items").expect("actions header");
+        let transcript_idx = body.find("## Transcript").expect("transcript header");
+        assert!(notes_idx < actions_idx);
+        assert!(actions_idx < transcript_idx);
+        assert!(body.contains("We agreed on Q3 launch."));
+        assert!(body.contains("- Send recap email"));
+        assert!(body.contains("- Book follow-up"));
+        assert!(body.contains("Me: Let's ship."));
+        assert!(body.contains("Them: Agreed."));
+    }
+
+    #[test]
+    fn build_publish_content_renders_placeholder_when_no_action_items() {
+        let body = build_publish_content("notes", &[], "transcript");
+        assert!(body.contains("## Action items\n\n_None captured._"));
+    }
+
+    #[test]
+    fn build_publish_content_skips_blank_action_items() {
+        let body = build_publish_content(
+            "notes",
+            &["   ".to_string(), "Real item".to_string()],
+            "transcript",
+        );
+        assert!(body.contains("- Real item"));
+        assert!(!body.contains("- \n"));
+    }
+
+    #[test]
+    fn extract_note_id_handles_raw_upstream_shape() {
+        let value = json!({"id": "276a4660-e16b-4934-97c6-a1ade2426653", "title": "n"});
+        assert_eq!(
+            extract_note_id(&value).as_deref(),
+            Some("276a4660-e16b-4934-97c6-a1ade2426653")
+        );
+    }
+
+    #[test]
+    fn extract_note_id_handles_note_data_response_shape() {
+        let value = json!({"data": {"id": "276a4660-e16b-4934-97c6-a1ade2426653"}});
+        assert_eq!(
+            extract_note_id(&value).as_deref(),
+            Some("276a4660-e16b-4934-97c6-a1ade2426653")
+        );
+    }
+
+    #[test]
+    fn extract_note_id_handles_publisher_proxy_with_parsed_body() {
+        let value = json!({
+            "data": {
+                "status": 200,
+                "body": {"data": {"id": "276a4660-e16b-4934-97c6-a1ade2426653"}},
+                "cost": 0
+            }
+        });
+        assert_eq!(
+            extract_note_id(&value).as_deref(),
+            Some("276a4660-e16b-4934-97c6-a1ade2426653")
+        );
+    }
+
+    #[test]
+    fn extract_note_id_handles_publisher_proxy_with_json_string_body() {
+        let value = json!({
+            "data": {
+                "status": 200,
+                "body": "{\"id\":\"276a4660-e16b-4934-97c6-a1ade2426653\"}"
+            }
+        });
+        assert_eq!(
+            extract_note_id(&value).as_deref(),
+            Some("276a4660-e16b-4934-97c6-a1ade2426653")
+        );
+    }
+
+    #[test]
+    fn extract_note_id_rejects_non_uuid_id_field() {
+        let value = json!({"id": "not-a-uuid", "data": {"id": "also-not"}});
+        assert_eq!(extract_note_id(&value), None);
+    }
+
+    #[test]
+    fn extract_note_id_returns_none_when_id_missing() {
+        let value = json!({"data": {"title": "n", "content": "c"}});
+        assert_eq!(extract_note_id(&value), None);
+    }
+}

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -151,6 +151,7 @@ pub struct Meeting {
     pub notes_struct_json: Option<String>,
     pub failure_reason: Option<String>,
     pub capture_diagnostics_json: Option<String>,
+    pub seren_notes_id: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -139,6 +139,103 @@ fn set_meeting_notes_record(
     Ok(())
 }
 
+fn set_meeting_seren_notes_id_record(
+    conn: &Connection,
+    id: &str,
+    seren_notes_id: &str,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE meetings
+         SET seren_notes_id = ?1,
+             updated_at = ?2
+         WHERE id = ?3",
+        params![seren_notes_id, now_ms(), id],
+    )?;
+    mark_sync_upsert(conn, "meetings", id)?;
+    Ok(())
+}
+
+// Auto-publish the finalized meeting (notes + action items + transcript) to
+// seren-notes so the UI can render a "Chat with meeting notes" link. Runs in
+// its own task so a slow gateway never blocks notes-ready from rendering.
+// Skips silently when the user isn't signed in or the meeting has already
+// been published — the local UI handles both states from authStore and
+// `meeting.serenNotesId`.
+async fn spawn_seren_notes_publish(
+    app: AppHandle,
+    meeting_id: String,
+    notes_markdown: String,
+    action_items: Vec<String>,
+    transcript: String,
+) {
+    let lookup_id = meeting_id.clone();
+    let meeting = match run_db(app.clone(), move |conn| select_meeting(conn, &lookup_id)).await {
+        Ok(Some(m)) => m,
+        Ok(None) => return,
+        Err(err) => {
+            log::warn!(
+                "[meeting] seren-notes publish skipped for {}: select_meeting failed: {}",
+                meeting_id,
+                err
+            );
+            return;
+        }
+    };
+    if meeting.seren_notes_id.is_some() {
+        return;
+    }
+    let content = crate::audio::seren_notes_publish::build_publish_content(
+        &notes_markdown,
+        &action_items,
+        &transcript,
+    );
+    let note_id = match crate::audio::seren_notes_publish::publish_meeting_notes(
+        &app,
+        &meeting.title,
+        &content,
+    )
+    .await
+    {
+        Ok(id) => id,
+        Err(err) => {
+            log::info!(
+                "[meeting] seren-notes publish skipped or failed for {}: {}",
+                meeting_id,
+                err
+            );
+            return;
+        }
+    };
+    let store_id = meeting_id.clone();
+    let stored_note_id = note_id.clone();
+    if let Err(err) = run_db(app.clone(), move |conn| {
+        set_meeting_seren_notes_id_record(conn, &store_id, &stored_note_id)
+    })
+    .await
+    {
+        log::warn!(
+            "[meeting] persist seren-notes id failed for {}: {}",
+            meeting_id,
+            err
+        );
+        return;
+    }
+    emit_meeting_status_by_id(&app, &meeting_id).await;
+    if let Err(err) = app.emit(
+        "meeting://notes-published",
+        serde_json::json!({
+            "meetingId": meeting_id,
+            "serenNotesId": note_id,
+        }),
+    ) {
+        log::warn!(
+            "[meeting] emit meeting://notes-published failed for {}: {}",
+            meeting_id,
+            err
+        );
+    }
+}
+
 #[tauri::command]
 pub async fn set_meeting_routed_skill(
     app: AppHandle,
@@ -635,6 +732,25 @@ pub async fn generate_meeting_notes(
     })
     .await?;
     emit_meeting_status_by_id(&app, &lookup).await;
+
+    // Fire-and-forget seren-notes auto-publish so the UI gets a
+    // "Chat with meeting notes" link without blocking notes-ready render.
+    let publish_app = app.clone();
+    let publish_id = lookup.clone();
+    let publish_markdown = parsed.markdown.clone();
+    let publish_action_items = parsed.structured.action_items.clone();
+    let publish_transcript = transcript.clone();
+    tauri::async_runtime::spawn(async move {
+        spawn_seren_notes_publish(
+            publish_app,
+            publish_id,
+            publish_markdown,
+            publish_action_items,
+            publish_transcript,
+        )
+        .await;
+    });
+
     Ok(parsed)
 }
 
@@ -797,9 +913,9 @@ pub fn insert_meeting(conn: &Connection, meeting: NewMeeting) -> Result<Meeting>
             id, title, source_app, started_at, ended_at, status, template_id,
             routed_skill_slug, agent_conversation_id, notes_markdown,
             notes_struct_json, failure_reason, capture_diagnostics_json,
-            created_at, updated_at
+            seren_notes_id, created_at, updated_at
          )
-         VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, NULL, NULL, NULL, NULL, NULL, NULL, ?7, ?7)",
+         VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?7, ?7)",
         params![
             meeting.id,
             meeting.title,
@@ -820,7 +936,7 @@ pub fn select_meeting(conn: &Connection, id: &str) -> Result<Option<Meeting>> {
         "SELECT id, title, source_app, started_at, ended_at, status, template_id,
                 routed_skill_slug, agent_conversation_id, notes_markdown,
                 notes_struct_json, failure_reason, capture_diagnostics_json,
-                created_at, updated_at
+                seren_notes_id, created_at, updated_at
          FROM meetings
          WHERE id = ?1",
         params![id],
@@ -834,7 +950,7 @@ pub fn select_meetings(conn: &Connection, limit: i32) -> Result<Vec<Meeting>> {
         "SELECT id, title, source_app, started_at, ended_at, status, template_id,
                 routed_skill_slug, agent_conversation_id, notes_markdown,
                 notes_struct_json, failure_reason, capture_diagnostics_json,
-                created_at, updated_at
+                seren_notes_id, created_at, updated_at
          FROM meetings
          ORDER BY started_at DESC
          LIMIT ?1",
@@ -1023,8 +1139,9 @@ fn row_to_meeting(row: &rusqlite::Row<'_>) -> Result<Meeting> {
         notes_struct_json: row.get(10)?,
         failure_reason: row.get(11)?,
         capture_diagnostics_json: row.get(12)?,
-        created_at: row.get(13)?,
-        updated_at: row.get(14)?,
+        seren_notes_id: row.get(13)?,
+        created_at: row.get(14)?,
+        updated_at: row.get(15)?,
     })
 }
 

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -650,6 +650,7 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             notes_struct_json TEXT,
             failure_reason TEXT,
             capture_diagnostics_json TEXT,
+            seren_notes_id TEXT,
             created_at INTEGER NOT NULL,
             updated_at INTEGER NOT NULL,
             FOREIGN KEY (agent_conversation_id) REFERENCES conversations(id)
@@ -726,6 +727,16 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
             [],
         )
         .ok();
+    }
+
+    // Migration: add seren-notes id link to meetings for existing DBs. Nullable
+    // so historical rows remain valid; populated only when auto-publish lands.
+    let has_seren_notes_id: bool = conn
+        .prepare("SELECT seren_notes_id FROM meetings LIMIT 1")
+        .is_ok();
+    if !has_seren_notes_id {
+        conn.execute("ALTER TABLE meetings ADD COLUMN seren_notes_id TEXT", [])
+            .ok();
     }
 
     // Migration: add agent conversation columns if they don't exist (for existing DBs)

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: AI notes render muted; transcript shows Me bright / Them muted with jump-to-source.
 
 import { createMemo, createSignal, For, onMount, Show } from "solid-js";
+import { openExternalLink } from "@/lib/external-link";
 import {
   formatDuration,
   meetingTitle,
@@ -16,6 +17,7 @@ import {
   type StructuredNotes,
   type TranscriptSegment,
 } from "@/services/meetings";
+import { authStore, requestSignInModal } from "@/stores/auth.store";
 import { meetingStore } from "@/stores/meeting.store";
 import { settingsStore } from "@/stores/settings.store";
 
@@ -309,6 +311,43 @@ export function MeetingDetail(props: MeetingDetailProps) {
               innerHTML={renderMarkdown(markdown())}
             />
           )}
+        </Show>
+        <Show when={props.meeting.notesMarkdown}>
+          <Show
+            when={props.meeting.serenNotesId}
+            fallback={
+              <Show when={!authStore.isAuthenticated}>
+                <div class="mt-2 text-[12px] text-muted-foreground">
+                  <button
+                    type="button"
+                    class="text-primary hover:underline focus:outline-none focus:underline"
+                    onClick={() => requestSignInModal()}
+                  >
+                    Login to SerenDB to chat with your meeting notes
+                  </button>
+                </div>
+              </Show>
+            }
+          >
+            {(serenNotesId) => {
+              const url = `https://notes.serendb.com/notes/${serenNotesId()}`;
+              return (
+                <div class="mt-2 text-[12px] text-muted-foreground">
+                  Chat with meeting notes:{" "}
+                  <button
+                    type="button"
+                    class="text-primary hover:underline focus:outline-none focus:underline break-all"
+                    onClick={() => {
+                      void openExternalLink(url);
+                    }}
+                    title="Open this meeting on notes.serendb.com"
+                  >
+                    {url}
+                  </button>
+                </div>
+              );
+            }}
+          </Show>
         </Show>
       </section>
 

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -29,6 +29,8 @@ export interface Meeting {
   notesStructJson: string | null;
   failureReason?: string | null;
   captureDiagnosticsJson?: string | null;
+  /** UUID of the auto-published seren-notes entry, when one exists. */
+  serenNotesId?: string | null;
   createdAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
Closes #2337.

## Summary

- Rust: after \`generate_meeting_notes\` finalizes a meeting, fire-and-forget POST to \`/publishers/seren-notes/notes\` with notes + action items + transcript. Persist the returned UUID on \`meetings.seren_notes_id\` and emit \`meeting://status\` so the UI re-renders.
- Frontend: \`MeetingDetail\` now shows \`Chat with meeting notes: https://notes.serendb.com/notes/<id>\` once the publish lands; when the user is not signed in, shows a \`Login to SerenDB to chat with your meeting notes\` button that opens the existing sign-in modal.
- DB: new nullable \`meetings.seren_notes_id TEXT\` column with the standard ALTER-TABLE migration alongside the existing failure/diagnostics migrations.

## Files

- \`src-tauri/src/audio/seren_notes_publish.rs\` (new) — pure \`build_publish_content\`, tolerant \`extract_note_id\` walker, and the \`publish_meeting_notes\` HTTP caller using \`authenticated_request\`.
- \`src-tauri/src/commands/audio.rs\` — \`set_meeting_seren_notes_id_record\`, \`spawn_seren_notes_publish\`, and the hook inside \`generate_meeting_notes\`. INSERT/SELECT/\`row_to_meeting\` updated for the new column.
- \`src-tauri/src/audio/types.rs\`, \`src-tauri/src/audio/mod.rs\`, \`src-tauri/src/services/database.rs\`.
- \`src/components/meeting/MeetingDetail.tsx\`, \`src/services/meetings.ts\`.

## Tests (critical only, per CLAUDE.md)

- 9 new Rust tests in \`audio::seren_notes_publish::tests\` covering payload assembly (section order, action-item placeholder, blank skipping) and UUID extraction across raw / NoteDataResponse / publisher-proxy parsed-body / publisher-proxy JSON-string-body envelopes.
- All 100 existing \`audio\` module tests still pass.
- \`pnpm tsc --noEmit\` clean for \`src/\`.

UI render is intentionally not Vitest-tested (CLAUDE.md "DO NOT test UI components"); the logic the link/CTA depends on is the auth flag and the \`serenNotesId\` field, both of which are exercised by Rust + tsc.

## Test plan

- [ ] Capture a meeting while signed in to SerenDB; after notes finalize, \`Chat with meeting notes:\` link appears under the Notes section and opens \`notes.serendb.com/notes/<uuid>\` in the browser.
- [ ] The published page shows ## Notes, ## Action items, ## Transcript in that order.
- [ ] Sign out, capture a meeting; after notes finalize, the CTA \`Login to SerenDB to chat with your meeting notes\` appears and clicking it raises the sign-in modal.
- [ ] Signed in but offline: notes still finalize, no link shown, no error toast.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com