### PR TITLE
fix(meeting): re-publish on regenerate + sync round-trip (#2339, #2340)

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -155,12 +155,43 @@ fn set_meeting_seren_notes_id_record(
     Ok(())
 }
 
+// Tracks meetings that have a publish task in flight so a Regenerate
+// triggered before the first publish lands cannot interleave: a second
+// publish racing the first would write its id, then the first would
+// overwrite with a different (now-stale) id pointing at orphaned content.
+// Per-meeting serialization — short-lived; drops on task end via PublishGuard.
+fn publishing_meetings() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
+    static SET: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+        std::sync::OnceLock::new();
+    SET.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+struct PublishGuard(String);
+
+impl Drop for PublishGuard {
+    fn drop(&mut self) {
+        if let Ok(mut set) = publishing_meetings().lock() {
+            set.remove(&self.0);
+        }
+    }
+}
+
+/// Try to claim the publish slot for a meeting id. Returns the guard on
+/// success; None if a publish is already in flight for the same id.
+fn claim_publish_slot(meeting_id: &str) -> Option<PublishGuard> {
+    let mut set = publishing_meetings().lock().ok()?;
+    if !set.insert(meeting_id.to_string()) {
+        return None;
+    }
+    Some(PublishGuard(meeting_id.to_string()))
+}
+
 // Auto-publish the finalized meeting (notes + action items + transcript) to
 // seren-notes so the UI can render a "Chat with meeting notes" link. Runs in
 // its own task so a slow gateway never blocks notes-ready from rendering.
-// Skips silently when the user isn't signed in or the meeting has already
-// been published — the local UI handles both states from authStore and
-// `meeting.serenNotesId`.
+// Always re-publishes — a Regenerate-after-publish overwrites the link to
+// point at the new content. Skips silently when the user isn't signed in;
+// the local UI shows the login CTA based on authStore.
 async fn spawn_seren_notes_publish(
     app: AppHandle,
     meeting_id: String,
@@ -168,6 +199,10 @@ async fn spawn_seren_notes_publish(
     action_items: Vec<String>,
     transcript: String,
 ) {
+    let _slot = match claim_publish_slot(&meeting_id) {
+        Some(slot) => slot,
+        None => return,
+    };
     let lookup_id = meeting_id.clone();
     let meeting = match run_db(app.clone(), move |conn| select_meeting(conn, &lookup_id)).await {
         Ok(Some(m)) => m,
@@ -181,9 +216,6 @@ async fn spawn_seren_notes_publish(
             return;
         }
     };
-    if meeting.seren_notes_id.is_some() {
-        return;
-    }
     let content = crate::audio::seren_notes_publish::build_publish_content(
         &notes_markdown,
         &action_items,
@@ -1239,6 +1271,22 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         setup_schema(&conn).unwrap();
         conn
+    }
+
+    #[test]
+    fn publish_slot_blocks_overlapping_claims_for_same_meeting() {
+        let slot = claim_publish_slot("meeting-publish-slot-a").expect("first claim");
+        assert!(
+            claim_publish_slot("meeting-publish-slot-a").is_none(),
+            "second claim for the same meeting must fail while the first guard lives"
+        );
+        let other = claim_publish_slot("meeting-publish-slot-b").expect("other meeting still free");
+        drop(other);
+        drop(slot);
+        assert!(
+            claim_publish_slot("meeting-publish-slot-a").is_some(),
+            "claim succeeds again after the guard drops — regenerate can re-publish"
+        );
     }
 
     fn meeting(id: &str) -> NewMeeting {

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -1015,12 +1015,21 @@ struct MeetingRow {
     row_version: i64,
 }
 
+/// Extract the optional seren-notes id stashed in a meeting sync payload. The
+/// id lives inside the JSONB payload because adding it as a first-class
+/// column on the cloud Postgres requires a separate seren-core deploy. Pure
+/// helper so the carry-through is unit-testable without a Postgres mock.
+pub fn seren_notes_id_from_payload(payload: &Value) -> Option<String> {
+    payload.get("seren_notes_id")?.as_str().map(str::to_string)
+}
+
 fn load_meeting(conn: &Connection, id: &str) -> rusqlite::Result<Option<MeetingRow>> {
     conn.query_row(
         "SELECT id, title, source_app, started_at, ended_at, status, template_id,
                 routed_skill_slug, agent_conversation_id, notes_markdown, notes_struct_json,
                 CASE WHEN deleted_at IS NULL THEN NULL ELSE deleted_at END, deleted_at,
-                created_at, updated_at, row_version, failure_reason, capture_diagnostics_json
+                created_at, updated_at, row_version, failure_reason, capture_diagnostics_json,
+                seren_notes_id
          FROM meetings
          WHERE id = ?1",
         params![id],
@@ -1029,6 +1038,7 @@ fn load_meeting(conn: &Connection, id: &str) -> rusqlite::Result<Option<MeetingR
             let payload = checked_payload(json!({
                 "failure_reason": row.get::<_, Option<String>>(16)?,
                 "capture_diagnostics_json": parse_json_opt(row.get::<_, Option<String>>(17)?),
+                "seren_notes_id": row.get::<_, Option<String>>(18)?,
             }))
             .map_err(to_sqlite_invalid)?;
             Ok(MeetingRow {
@@ -1449,9 +1459,9 @@ fn apply_remote_meeting(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
             id, title, source_app, started_at, ended_at, status, template_id,
             routed_skill_slug, agent_conversation_id, notes_markdown,
             notes_struct_json, failure_reason, capture_diagnostics_json,
-            created_at, updated_at, row_version, synced_at, deleted_at
+            seren_notes_id, created_at, updated_at, row_version, synced_at, deleted_at
          )
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, NULL)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, NULL)
          ON CONFLICT(id) DO UPDATE SET
             title = excluded.title,
             source_app = excluded.source_app,
@@ -1464,6 +1474,7 @@ fn apply_remote_meeting(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
             notes_struct_json = excluded.notes_struct_json,
             failure_reason = excluded.failure_reason,
             capture_diagnostics_json = excluded.capture_diagnostics_json,
+            seren_notes_id = excluded.seren_notes_id,
             updated_at = excluded.updated_at,
             row_version = excluded.row_version,
             synced_at = excluded.synced_at,
@@ -1483,6 +1494,7 @@ fn apply_remote_meeting(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
             value_to_string_opt(pg_get::<Option<Value>>(&row, "notes_struct_json")?.as_ref()),
             value_opt_str(&payload, "failure_reason"),
             value_to_string_opt(payload.get("capture_diagnostics_json")),
+            seren_notes_id_from_payload(&payload),
             pg_get::<i64>(&row, "created_at")?,
             pg_get::<i64>(&row, "updated_at")?,
             pg_get::<i64>(&row, "row_version")?,
@@ -1633,6 +1645,34 @@ mod tests {
                 "history sync schema must not contain {forbidden}"
             );
         }
+    }
+
+    #[test]
+    fn seren_notes_id_round_trips_through_payload() {
+        let payload = json!({
+            "failure_reason": null,
+            "capture_diagnostics_json": null,
+            "seren_notes_id": "276a4660-e16b-4934-97c6-a1ade2426653",
+        });
+        assert_eq!(
+            seren_notes_id_from_payload(&payload).as_deref(),
+            Some("276a4660-e16b-4934-97c6-a1ade2426653")
+        );
+    }
+
+    #[test]
+    fn seren_notes_id_absent_payload_returns_none() {
+        let payload = json!({
+            "failure_reason": "boom",
+            "capture_diagnostics_json": null,
+        });
+        assert!(seren_notes_id_from_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn seren_notes_id_null_payload_field_returns_none() {
+        let payload = json!({ "seren_notes_id": null });
+        assert!(seren_notes_id_from_payload(&payload).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Closes #2339 and #2340 — both surfaced in the functional audit of #2337 (PR #2338).

## #2339 — Regenerate now re-publishes

Before: `spawn_seren_notes_publish` short-circuited with `if meeting.seren_notes_id.is_some() { return; }`. On a Regenerate-with-new-template, the in-app link kept pointing at the old cloud note — content the user just abandoned.

After: drop the early-return, always re-publish. Race-safe via a per-meeting `PublishGuard` (Mutex<HashSet<String>>) so a fast double-trigger can't have two POSTs interleave and leave a stale id sticking. Old cloud note gets orphaned; acceptable tradeoff vs a silently-wrong link.

## #2340 — `seren_notes_id` round-trips through sync

Before: `meetings.seren_notes_id` was local-only. After `/login` on a new device, the desktop UI showed no "Chat with meeting notes" link even though the cloud note still existed.

After: `load_meeting` stashes `seren_notes_id` inside the existing `payload` JSONB on push; `apply_remote_meeting` adds the field to its INSERT column list and ON CONFLICT UPDATE, reading the value from the payload via the new pure `seren_notes_id_from_payload` helper. No seren-core schema change required.

## Critical tests

- `publish_slot_blocks_overlapping_claims_for_same_meeting` — the mutex guards the race.
- `seren_notes_id_round_trips_through_payload` — JSONB carry-through preserves the id.
- `seren_notes_id_absent_payload_returns_none` and `..._null_payload_field_returns_none` — boundary behavior.
- 112 audio + history_sync tests still green.

## Test plan

- [ ] Capture a meeting; let notes finalize → link appears.
- [ ] Pick a different template; click Regenerate → after notes re-finalize, link URL updates to a new UUID. Click it; remote shows the new template's output.
- [ ] Sign out and back in on a second device; previously published meetings show the link again after the next sync round-trip.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
