### PR TITLE
fix(meeting): show date on list rows + detail header (#2344)

### DIFF
--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -5,6 +5,8 @@ import { createMemo, createSignal, For, onMount, Show } from "solid-js";
 import { openExternalLink } from "@/lib/external-link";
 import {
   formatDuration,
+  formatMeetingDate,
+  formatTime,
   meetingTitle,
   STATUS_LABELS,
 } from "@/lib/meeting-format";
@@ -235,6 +237,10 @@ export function MeetingDetail(props: MeetingDetailProps) {
               <span>{STATUS_LABELS[props.meeting.status]}</span>
               <span class="font-mono tabular-nums">
                 {formatDuration(props.meeting)}
+              </span>
+              <span>
+                {formatMeetingDate(props.meeting.startedAt)} ·{" "}
+                {formatTime(props.meeting.startedAt)}
               </span>
               <span>{props.meeting.sourceApp ?? "Desktop"}</span>
             </div>

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -7,6 +7,7 @@ import { MeetingDetail } from "@/components/meeting/MeetingDetail";
 import { MeetingSettings } from "@/components/meeting/MeetingSettings";
 import {
   formatDuration,
+  formatMeetingDate,
   formatTime,
   meetingTitle,
   STATUS_LABELS,
@@ -313,7 +314,10 @@ export function MeetingPanel(props: MeetingPanelProps) {
                         {meetingTitle(meeting)}
                       </div>
                       <div class="mt-1 flex items-center justify-between gap-2 text-[11px]">
-                        <span>{formatTime(meeting.startedAt)}</span>
+                        <span>
+                          {formatMeetingDate(meeting.startedAt)} ·{" "}
+                          {formatTime(meeting.startedAt)}
+                        </span>
                         <span>{STATUS_LABELS[meeting.status]}</span>
                       </div>
                     </button>

--- a/src/lib/meeting-format.ts
+++ b/src/lib/meeting-format.ts
@@ -10,6 +10,38 @@ export function formatTime(ms: number): string {
   });
 }
 
+// Compact date label for list rows and the detail meta row. Recent meetings
+// collapse to Today/Yesterday so the row stays scannable; older ones get a
+// calendar date, including the year when it differs from the current year so a
+// January meeting from last year is not mistaken for this year (#2344).
+export function formatMeetingDate(
+  ms: number,
+  now: number = Date.now(),
+): string {
+  const day = new Date(ms);
+  const today = new Date(now);
+  const sameDay =
+    day.getFullYear() === today.getFullYear() &&
+    day.getMonth() === today.getMonth() &&
+    day.getDate() === today.getDate();
+  if (sameDay) return "Today";
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  if (
+    day.getFullYear() === yesterday.getFullYear() &&
+    day.getMonth() === yesterday.getMonth() &&
+    day.getDate() === yesterday.getDate()
+  ) {
+    return "Yesterday";
+  }
+  const sameYear = day.getFullYear() === today.getFullYear();
+  return day.toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    year: sameYear ? undefined : "numeric",
+  });
+}
+
 export function formatDuration(meeting: Meeting): string {
   const end = meeting.endedAt ?? Date.now();
   const totalSeconds = Math.max(

--- a/tests/unit/meeting-format-date.test.ts
+++ b/tests/unit/meeting-format-date.test.ts
@@ -1,0 +1,35 @@
+// ABOUTME: Coverage for #2344 — meeting list/detail must show a date, not just time.
+// ABOUTME: formatMeetingDate maps recent dates to Today/Yesterday and falls back to a calendar date.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatMeetingDate } from "@/lib/meeting-format";
+
+function at(year: number, month: number, day: number, h = 12, m = 0): number {
+  return new Date(year, month - 1, day, h, m).getTime();
+}
+
+describe("formatMeetingDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 11, 9, 0));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns Today for a meeting started earlier the same day", () => {
+    expect(formatMeetingDate(at(2026, 6, 11, 7, 35))).toBe("Today");
+  });
+
+  it("returns Yesterday for a meeting started the previous calendar day", () => {
+    expect(formatMeetingDate(at(2026, 6, 10, 23, 59))).toBe("Yesterday");
+  });
+
+  it("returns a same-year calendar date for older meetings", () => {
+    expect(formatMeetingDate(at(2026, 1, 4))).toMatch(/Jan\b.*\b4\b/);
+  });
+
+  it("includes the year when the meeting is from a previous year", () => {
+    expect(formatMeetingDate(at(2024, 12, 30))).toMatch(/2024/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `formatMeetingDate(ms)` to `meeting-format.ts` that returns `Today` / `Yesterday` / `Mon D` (or `Mon D, YYYY` for prior years).
- Renders date + time in `MeetingPanel` list rows and the `MeetingDetail` meta row.
- Unit tests cover the four branches: today, yesterday, same-year date, prior-year date.

Closes #2344.

## Test plan
- [x] `pnpm vitest run tests/unit/meeting-format-date.test.ts` — 4/4 green.
- [x] `pnpm exec biome check src/lib/meeting-format.ts ...` — clean.
- [ ] Manual verify in `pnpm tauri dev`: open the Meeting panel, confirm rows show "Today · 7:35 AM" / "Yesterday · 7:35 AM" / "Jun 4 · 7:35 AM".