### PR TITLE
feat(meeting): per-transcript Route button (#2346)

### DIFF
--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -1,7 +1,14 @@
 // ABOUTME: Meeting detail "notes canvas": rendered notes, template picker, regenerate, transcript.
 // ABOUTME: AI notes render muted; transcript shows Me bright / Them muted with jump-to-source.
 
-import { createMemo, createSignal, For, onMount, Show } from "solid-js";
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  onMount,
+  Show,
+} from "solid-js";
 import { openExternalLink } from "@/lib/external-link";
 import {
   formatDuration,
@@ -118,6 +125,11 @@ export function MeetingDetail(props: MeetingDetailProps) {
   const [highlightedSeq, setHighlightedSeq] = createSignal<number | null>(null);
   const [editingTitle, setEditingTitle] = createSignal(false);
   const [titleDraft, setTitleDraft] = createSignal("");
+  const [skillCandidates, setSkillCandidates] = createSignal<
+    { slug: string; name: string }[]
+  >([]);
+  const [selectedSkillSlug, setSelectedSkillSlug] = createSignal("");
+  const [routing, setRouting] = createSignal(false);
 
   const rows = new Map<number, HTMLElement>();
 
@@ -187,6 +199,47 @@ export function MeetingDetail(props: MeetingDetailProps) {
       await meetingStore.regenerateNotes(props.meeting, selectedTemplate());
     } finally {
       setRegenerating(false);
+    }
+  };
+
+  // Re-resolve skill candidates whenever notes settle on a new meeting so the
+  // picker stays accurate as the user switches between rows (#2346). The
+  // classifier needs the transcript text, which only exists after notes_ready.
+  createEffect(() => {
+    const status = props.meeting.status;
+    if (status !== "notes_ready" && status !== "done" && status !== "failed") {
+      setSkillCandidates([]);
+      setSelectedSkillSlug("");
+      return;
+    }
+    const meeting = props.meeting;
+    void (async () => {
+      const candidates = await meetingStore.getMeetingSkillCandidates(meeting);
+      setSkillCandidates(
+        candidates.map((c) => ({ slug: c.slug, name: c.name })),
+      );
+      const previous = selectedSkillSlug();
+      if (!candidates.some((c) => c.slug === previous)) {
+        setSelectedSkillSlug(candidates[0]?.slug ?? "");
+      }
+    })();
+  });
+
+  const routeDisabled = () =>
+    routing() ||
+    !isTauriRuntime() ||
+    !selectedSkillSlug() ||
+    !props.meeting.notesMarkdown ||
+    props.meeting.status === "agent_running";
+
+  const routeTranscript = async () => {
+    const slug = selectedSkillSlug();
+    if (!slug || routing()) return;
+    setRouting(true);
+    try {
+      await meetingStore.routeMeetingToSkill(props.meeting, slug);
+    } finally {
+      setRouting(false);
     }
   };
 
@@ -298,6 +351,48 @@ export function MeetingDetail(props: MeetingDetailProps) {
           {regenerating() ? "Regenerating…" : "Regenerate"}
         </button>
       </div>
+
+      <Show when={props.meeting.notesMarkdown}>
+        <div class="mb-4 flex items-center gap-2">
+          <span class="text-[12px] text-muted-foreground">Route to skill</span>
+          <Show
+            when={skillCandidates().length > 0}
+            fallback={
+              <span class="text-[12px] text-muted-foreground italic">
+                No matching meeting skill installed.
+              </span>
+            }
+          >
+            <select
+              class="h-7 rounded-md border border-border bg-surface-1 px-2 text-[12px] text-foreground focus:outline-none focus:border-primary/60"
+              value={selectedSkillSlug()}
+              onChange={(event) =>
+                setSelectedSkillSlug(event.currentTarget.value)
+              }
+            >
+              <For each={skillCandidates()}>
+                {(skill) => <option value={skill.slug}>{skill.name}</option>}
+              </For>
+            </select>
+            <button
+              type="button"
+              class="h-7 px-2.5 rounded-md border border-primary/40 bg-primary/10 text-[12px] text-primary hover:bg-primary/15 disabled:opacity-60"
+              onClick={routeTranscript}
+              disabled={routeDisabled()}
+              title="Process this transcript through the selected skill"
+            >
+              {routing() ? "Routing…" : "Route transcript"}
+            </button>
+          </Show>
+          <Show when={props.meeting.routedSkillSlug}>
+            {(slug) => (
+              <span class="text-[11px] text-muted-foreground">
+                Routed to {slug()}
+              </span>
+            )}
+          </Show>
+        </div>
+      </Show>
 
       <section class="mb-6">
         <div class="mb-2 text-[12px] font-medium text-muted-foreground">

--- a/src/components/meeting/MeetingSettings.tsx
+++ b/src/components/meeting/MeetingSettings.tsx
@@ -180,20 +180,6 @@ export function MeetingSettings() {
       </section>
 
       <section>
-        <FieldLabel hint="Slug of the installed meeting skill to use when several match.">
-          Default routing skill
-        </FieldLabel>
-        <input
-          class="h-8 w-full rounded-md border border-border bg-surface-1 px-2.5 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary/60"
-          placeholder="e.g. glide/affinity-proposals (blank = first match)"
-          value={settingsStore.get("meetingDefaultSkill")}
-          onInput={(event) =>
-            settingsStore.set("meetingDefaultSkill", event.currentTarget.value)
-          }
-        />
-      </section>
-
-      <section>
         <label class="flex items-center justify-between gap-3 cursor-pointer">
           <FieldLabel hint="Clean up filler and punctuation in notes and dictation.">
             AI cleanup

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -561,19 +561,27 @@ async function stopAndProcess(meeting: Meeting): Promise<void> {
     const refreshed =
       meetingState.meetings.find((m) => m.id === meeting.id) ?? null;
     await setActiveMeeting(refreshed);
-
-    await runHandoff(meeting);
   } finally {
     processingMeetings.delete(meeting.id);
   }
 }
 
-async function runHandoff(meeting: Meeting): Promise<void> {
-  // No transcript means nothing to hand off — guards a notes/transcribe failure
-  // from auto-invoking a skill with an empty prompt (#2159).
-  const transcript = await getMeetingTranscriptText(meeting.id).catch(() => "");
-  if (!transcript.trim()) return;
+interface MeetingSkillCandidate {
+  slug: string;
+  name: string;
+  description: string;
+  tags: string[];
+}
 
+// Match the current transcript + notes against installed meeting skills. The
+// detail view uses this to populate the per-transcript "Route to skill" picker
+// once notes are ready (#2346). Returns an empty list on classifier failure so
+// the UI can fall back to "no matching skills" instead of breaking.
+async function getMeetingSkillCandidates(
+  meeting: Meeting,
+): Promise<MeetingSkillCandidate[]> {
+  const transcript = await getMeetingTranscriptText(meeting.id).catch(() => "");
+  if (!transcript.trim()) return [];
   const skillRefs = skillsStore.enabledSkills.map((skill) => ({
     slug: skill.slug,
     name: skill.name,
@@ -581,23 +589,41 @@ async function runHandoff(meeting: Meeting): Promise<void> {
     tags: skill.tags ?? [],
     path: skill.path,
   }));
-
   let meetingSlugs: string[] = [];
   try {
     meetingSlugs = await selectMeetingSkills(skillRefs);
   } catch {
     meetingSlugs = [];
   }
-  if (meetingSlugs.length === 0) return;
+  return meetingSlugs
+    .map((slug) => skillRefs.find((skill) => skill.slug === slug))
+    .filter((skill): skill is (typeof skillRefs)[number] => skill !== undefined)
+    .map((skill) => ({
+      slug: skill.slug,
+      name: skill.name,
+      description: skill.description,
+      tags: skill.tags,
+    }));
+}
 
-  const defaultSlug = settingsStore.get("meetingDefaultSkill");
-  const chosenSlug =
-    defaultSlug && meetingSlugs.includes(defaultSlug)
-      ? defaultSlug
-      : meetingSlugs[0];
-  const chosen = skillRefs.find((skill) => skill.slug === chosenSlug);
-  if (!chosen) return;
-
+// User-triggered handoff. Creates the chat conversation, marks the meeting as
+// routed, and orchestrates the transcript through the chosen skill. Replaces
+// the previous auto-handoff so the user controls when (and to which skill) a
+// transcript becomes a conversation (#2346).
+async function routeMeetingToSkill(
+  meeting: Meeting,
+  slug: string,
+): Promise<void> {
+  const transcript = await getMeetingTranscriptText(meeting.id).catch(() => "");
+  if (!transcript.trim()) {
+    setMeetingState("error", "No transcript available to route.");
+    return;
+  }
+  const chosen = skillsStore.enabledSkills.find((skill) => skill.slug === slug);
+  if (!chosen) {
+    setMeetingState("error", `Skill ${slug} is not installed.`);
+    return;
+  }
   const notes =
     meetingState.meetings.find((m) => m.id === meeting.id)?.notesMarkdown ?? "";
 
@@ -605,13 +631,14 @@ async function runHandoff(meeting: Meeting): Promise<void> {
     `Meeting: ${meeting.title}`.slice(0, 80),
     providerStore.activeModel,
   );
-  await setMeetingRoutedSkill(meeting.id, chosenSlug, conversation.id);
+  await setMeetingRoutedSkill(meeting.id, slug, conversation.id);
   await updateMeetingStatus(meeting.id, "agent_running");
   await loadMeetings();
 
+  const tags = chosen.tags ?? [];
   const prompt = [
     `Process this completed meeting using the ${chosen.name} meeting skill` +
-      (chosen.tags.length ? ` (tags: ${chosen.tags.join(", ")})` : "") +
+      (tags.length ? ` (tags: ${tags.join(", ")})` : "") +
       ".",
     notes ? `Meeting notes:\n${notes}` : "",
     transcript ? `Transcript:\n${transcript}` : "",
@@ -622,10 +649,9 @@ async function runHandoff(meeting: Meeting): Promise<void> {
   conversationStore.setActiveConversation(conversation.id);
   try {
     await orchestrate(conversation.id, prompt);
-    // The agent finished: drive the status machine to a terminal state so the
-    // meeting doesn't sit at `agent_running` forever (#2158). Pass no ended_at
-    // so the capture-end timestamp set at stop survives instead of being
-    // overwritten with the agent-finish time (#2174).
+    // Drive the status to a terminal state so the meeting doesn't sit at
+    // `agent_running` forever (#2158). Pass no ended_at so the capture-end
+    // timestamp set at stop survives instead of being overwritten (#2174).
     await updateMeetingStatus(meeting.id, "done");
   } catch (error) {
     const reason = `Agent handoff failed: ${meetingErrorMessage(error)}`;
@@ -821,6 +847,8 @@ export const meetingStore = {
   reconcileStaleCaptures,
   stopCapture,
   stopAndProcess,
+  getMeetingSkillCandidates,
+  routeMeetingToSkill,
   regenerateNotes,
   renameMeeting,
   deleteMeeting,

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -171,7 +171,6 @@ export interface Settings {
   meetingAutoDetectEnabled: boolean;
   meetingTemplateId: string;
   meetingCustomTemplates: { id: string; name: string; prompt: string }[];
-  meetingDefaultSkill: string;
   /**
    * Run the post-call Them diarization pass that stamps meeting-stable speaker
    * labels. Default off because it re-transcribes Them audio and no current UI
@@ -288,7 +287,6 @@ const DEFAULT_SETTINGS: Settings = {
   meetingAutoDetectEnabled: true,
   meetingTemplateId: "discovery",
   meetingCustomTemplates: [],
-  meetingDefaultSkill: "",
   meetingStableSpeakers: false,
   meetingAudioPrimed: false,
   // General

--- a/tests/unit/meeting-concurrent-stop.test.ts
+++ b/tests/unit/meeting-concurrent-stop.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Regression test for #2162 — concurrent stop sources must not double-run notes + agent handoff.
-// ABOUTME: Two near-simultaneous stops (tray/panel) for one meeting should process it once.
+// ABOUTME: Regression test for #2162 — concurrent stop sources must not double-run notes generation.
+// ABOUTME: Two near-simultaneous stops (tray/panel) for one meeting should process it once. Routing is user-triggered (#2346).
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -102,7 +102,8 @@ describe("meetingStore concurrent stop guard (#2162)", () => {
     ]);
 
     expect(m.generateMeetingNotes).toHaveBeenCalledTimes(1);
-    expect(m.orchestrate).toHaveBeenCalledTimes(1);
+    // Routing is now user-triggered, so a stop does not invoke the agent (#2346).
+    expect(m.orchestrate).not.toHaveBeenCalled();
   });
 
   it("allows a fresh stop after the first one finishes", async () => {
@@ -110,6 +111,6 @@ describe("meetingStore concurrent stop guard (#2162)", () => {
     await meetingStore.stopAndProcess(meeting());
 
     expect(m.generateMeetingNotes).toHaveBeenCalledTimes(2);
-    expect(m.orchestrate).toHaveBeenCalledTimes(2);
+    expect(m.orchestrate).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/meeting-handoff-terminal.test.ts
+++ b/tests/unit/meeting-handoff-terminal.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Regression test for #2158 — a handed-off meeting must reach done/failed, not sit at agent_running forever.
-// ABOUTME: Drives the real stopAndProcess -> runHandoff flow with the agent run mocked.
+// ABOUTME: Drives user-triggered routeMeetingToSkill (#2346) with the agent run mocked.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -97,7 +97,10 @@ describe("meetingStore handoff terminal status (#2158)", () => {
   it("sets done after the agent run resolves", async () => {
     m.orchestrate.mockResolvedValueOnce(undefined);
 
-    await meetingStore.stopAndProcess(meeting());
+    await meetingStore.routeMeetingToSkill(
+      meeting({ status: "notes_ready" }),
+      "s",
+    );
 
     expect(m.orchestrate).toHaveBeenCalledTimes(1);
     // Terminal transition carries no ended_at so the capture-end time survives (#2174).
@@ -107,7 +110,10 @@ describe("meetingStore handoff terminal status (#2158)", () => {
   it("sets failed when the agent run rejects", async () => {
     m.orchestrate.mockRejectedValueOnce(new Error("boom"));
 
-    await meetingStore.stopAndProcess(meeting());
+    await meetingStore.routeMeetingToSkill(
+      meeting({ status: "notes_ready" }),
+      "s",
+    );
 
     expect(m.updateMeetingStatus).toHaveBeenCalledWith(
       "m1",

--- a/tests/unit/meeting-route-to-skill.test.ts
+++ b/tests/unit/meeting-route-to-skill.test.ts
@@ -1,0 +1,137 @@
+// ABOUTME: Coverage for #2346 — meetings only hand off to a skill on user action.
+// ABOUTME: routeMeetingToSkill is the single entry point; empty transcript / unknown slug abort safely.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const m = vi.hoisted(() => ({
+  getMeetingTranscriptText: vi.fn(async () => "speaker: hello there"),
+  selectMeetingSkills: vi.fn(async () => ["glide/affinity-proposals"]),
+  setMeetingRoutedSkill: vi.fn(async () => {}),
+  updateMeetingStatus: vi.fn(async () => {}),
+  listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
+  createConversationWithModel: vi.fn(async () => ({ id: "conv-1" })),
+  setActiveConversation: vi.fn(),
+  orchestrate: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tauri-bridge")>()),
+  isTauriRuntime: () => true,
+}));
+vi.mock("@/services/meetings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/meetings")>()),
+  getMeetingTranscriptText: m.getMeetingTranscriptText,
+  selectMeetingSkills: m.selectMeetingSkills,
+  setMeetingRoutedSkill: m.setMeetingRoutedSkill,
+  updateMeetingStatus: m.updateMeetingStatus,
+  listMeetings: m.listMeetings,
+}));
+vi.mock("@/services/orchestrator", () => ({ orchestrate: m.orchestrate }));
+vi.mock("@/services/tray", () => ({
+  setTrayRecording: vi.fn(),
+  onTrayToggleCapture: vi.fn(() => () => {}),
+}));
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: () => undefined,
+    set: vi.fn(),
+  },
+}));
+vi.mock("@/stores/conversation.store", () => ({
+  conversationStore: {
+    createConversationWithModel: m.createConversationWithModel,
+    setActiveConversation: m.setActiveConversation,
+  },
+}));
+vi.mock("@/stores/provider.store", () => ({
+  providerStore: { resolvedModel: () => "model", activeModel: "model" },
+}));
+vi.mock("@/stores/skills.store", () => ({
+  skillsStore: {
+    enabledSkills: [
+      {
+        slug: "glide/affinity-proposals",
+        name: "Glide Affinity Proposals",
+        description: "",
+        tags: ["meeting"],
+        path: "/skills/glide",
+      },
+    ],
+  },
+}));
+
+import type { Meeting } from "@/services/meetings";
+import { meetingStore } from "@/stores/meeting.store";
+
+function meeting(overrides: Partial<Meeting> = {}): Meeting {
+  return {
+    id: "m1",
+    title: "Discovery sync",
+    sourceApp: "Manual",
+    startedAt: 0,
+    endedAt: 100,
+    status: "notes_ready",
+    templateId: null,
+    routedSkillSlug: null,
+    agentConversationId: null,
+    notesMarkdown: "# Notes",
+    notesStructJson: null,
+    failureReason: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("meetingStore.routeMeetingToSkill (#2346)", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(m)) {
+      if ("mockClear" in fn) fn.mockClear();
+    }
+    m.getMeetingTranscriptText.mockResolvedValue("speaker: hello there");
+    meetingStore.clearError();
+  });
+
+  it("creates a conversation, marks routed, and orchestrates the chosen skill", async () => {
+    await meetingStore.routeMeetingToSkill(
+      meeting(),
+      "glide/affinity-proposals",
+    );
+
+    expect(m.createConversationWithModel).toHaveBeenCalledTimes(1);
+    expect(m.setMeetingRoutedSkill).toHaveBeenCalledWith(
+      "m1",
+      "glide/affinity-proposals",
+      "conv-1",
+    );
+    expect(m.orchestrate).toHaveBeenCalledWith(
+      "conv-1",
+      expect.stringContaining("Glide Affinity Proposals"),
+    );
+    expect(m.setActiveConversation).toHaveBeenCalledWith("conv-1");
+    expect(m.updateMeetingStatus).toHaveBeenCalledWith("m1", "done");
+  });
+
+  it("aborts safely when the transcript is empty", async () => {
+    m.getMeetingTranscriptText.mockResolvedValueOnce("");
+
+    await meetingStore.routeMeetingToSkill(
+      meeting(),
+      "glide/affinity-proposals",
+    );
+
+    expect(m.createConversationWithModel).not.toHaveBeenCalled();
+    expect(m.setMeetingRoutedSkill).not.toHaveBeenCalled();
+    expect(m.orchestrate).not.toHaveBeenCalled();
+    expect(meetingStore.state.error).toMatch(/transcript/i);
+  });
+
+  it("aborts safely when the slug is not installed", async () => {
+    await meetingStore.routeMeetingToSkill(meeting(), "unknown/skill");
+
+    expect(m.createConversationWithModel).not.toHaveBeenCalled();
+    expect(m.setMeetingRoutedSkill).not.toHaveBeenCalled();
+    expect(m.orchestrate).not.toHaveBeenCalled();
+    expect(meetingStore.state.error).toMatch(/not installed/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Removes the global `Default routing skill` field from `MeetingSettings` and its `meetingDefaultSkill` setting.
- Stops auto-routing meetings after `stopAndProcess` finishes; meeting settles at `notes_ready`.
- Adds `meetingStore.getMeetingSkillCandidates(meeting)` + `meetingStore.routeMeetingToSkill(meeting, slug)` so the UI can populate a per-transcript picker and trigger handoff on demand.
- Adds the picker + "Route transcript" button to `MeetingDetail.tsx`, shown once notes are ready. Disabled until a skill is selected and notes exist.
- Preserves the `#2158` done/failed terminal-status guarantee — it now applies to the new `routeMeetingToSkill` entry point.

Closes #2346.

## Test plan
- [x] `pnpm vitest run tests/unit/meeting` — 47/47 green (15 files).
- [x] New critical test `meeting-route-to-skill.test.ts`: happy path + empty-transcript abort + unknown-slug abort.
- [x] Updated `meeting-handoff-terminal.test.ts` + `meeting-concurrent-stop.test.ts` to exercise the new user-triggered entry point.
- [ ] Manual: capture a meeting, wait for notes, confirm picker appears with matched skills, click "Route transcript" → chat opens routed conversation.
- [ ] Manual: with no installed meeting skill, picker shows "No matching meeting skill installed.".
