### PR TITLE
fix(session): drop duplicate Close X (#2352)

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -742,7 +742,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
               <AgentTasksPanel onClose={handleCloseSlidePanel} />
             </Match>
             <Match when={slidePanel() === "sessions"}>
-              <SessionPanel onClose={handleCloseSlidePanel} />
+              <SessionPanel />
             </Match>
             <Match when={slidePanel() === "meetings"}>
               <MeetingPanel />

--- a/src/components/session/SessionPanel.tsx
+++ b/src/components/session/SessionPanel.tsx
@@ -15,11 +15,8 @@ import type { SessionEnvironment } from "@/types/session";
 import { SessionStatusBadge } from "./SessionStatusBadge";
 import { SessionTimeline } from "./SessionTimeline";
 
-interface SessionPanelProps {
-  onClose?: () => void;
-}
-
-export const SessionPanel: Component<SessionPanelProps> = (props) => {
+// SlidePanel chrome owns Close + backdrop dismissal — no SessionPanel props (#2352).
+export const SessionPanel: Component = () => {
   const [showCreate, setShowCreate] = createSignal(false);
   const [newTitle, setNewTitle] = createSignal("");
   const [newEnv, setNewEnv] = createSignal<SessionEnvironment>("browser");
@@ -91,30 +88,6 @@ export const SessionPanel: Component<SessionPanelProps> = (props) => {
           >
             {showCreate() ? "Cancel" : "+ New"}
           </button>
-          <Show when={props.onClose}>
-            <button
-              type="button"
-              class="p-1 text-muted-foreground hover:text-foreground transition-colors rounded"
-              onClick={props.onClose}
-              title="Close panel"
-            >
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 16 16"
-                fill="none"
-                role="img"
-                aria-label="Close"
-              >
-                <path
-                  d="M4 4l8 8M12 4l-8 8"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </Show>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Audit finding from #2345 (MeetingPanel duplicate close): `SessionPanel` had the same pattern.
- Drop the local Close X + the now-unused `onClose` prop; AppShell call-site simplified.
- SlidePanel chrome's Close X + backdrop click continue to own dismissal.

Closes #2352.

## Test plan
- [x] `pnpm exec biome check src/components/session/SessionPanel.tsx src/components/layout/AppShell.tsx` clean.
- [x] All 47 meeting unit tests still green (cross-check that the SlidePanel chrome is still intact).
- [ ] `pnpm tauri dev` → open Sessions slide-panel → confirm one Close X visible, click closes; backdrop click closes; "+ New" still works.
