### PR TITLE
fix(meeting): surface seren-notes publish failures + republish CTA (#2343)

### DIFF
--- a/src-tauri/src/audio/seren_notes_publish.rs
+++ b/src-tauri/src/audio/seren_notes_publish.rs
@@ -4,9 +4,43 @@
 use crate::auth::{authenticated_request, has_stored_credentials};
 use reqwest::Client;
 use serde_json::Value;
+use std::time::Duration;
 use tauri::AppHandle;
 
 const PUBLISH_URL: &str = "https://api.serendb.com/publishers/seren-notes/notes";
+// seren-notes is scale-to-zero — the first 5xx on a cold publisher is almost
+// always cold-start warm-up, not a real failure. Two retries with widening
+// backoff (2s, then 4s) give the worker time to come up before we declare a
+// real outage and route the user to the support pipeline. Keep this in sync
+// with the `Publish to Seren Notes` button copy in MeetingDetail. #2343.
+const RETRY_BACKOFFS: [Duration; 2] = [Duration::from_secs(2), Duration::from_secs(4)];
+
+/// Outcome of a publish attempt. Distinguishes a missing-credentials skip
+/// (silent — UI shows the Login CTA) from a terminal server failure that
+/// should be surfaced to the user and routed through the support pipeline
+/// for a serenorg/seren-desktop bug ticket. #2343.
+#[derive(Debug)]
+pub enum PublishError {
+    NotAuthenticated,
+    /// The Gateway returned a 5xx (or the second attempt did). `status` is
+    /// the HTTP status code from the final attempt; `body` is the response
+    /// body, truncated by the caller before going into telemetry.
+    Server { status: u16, body: String },
+    /// Any other failure — network drop, malformed response, missing id.
+    Other(String),
+}
+
+impl PublishError {
+    pub fn into_message(self) -> String {
+        match self {
+            PublishError::NotAuthenticated => "not authenticated".to_string(),
+            PublishError::Server { status, body } => {
+                format!("seren-notes publish returned {status}: {body}")
+            }
+            PublishError::Other(msg) => msg,
+        }
+    }
+}
 
 /// Assemble the single markdown body posted to seren-notes. Always carries
 /// notes, action items, and the per-speaker transcript, in that order, so the
@@ -97,13 +131,19 @@ fn is_uuid(s: &str) -> bool {
 /// using the user's existing access token. Short-circuits with a clear error
 /// when no credentials are stored — callers handle that case by skipping the
 /// publish silently and letting the UI render the "Login to SerenDB" CTA.
+///
+/// On a 5xx the attempt is retried up to `RETRY_BACKOFFS.len()` times with
+/// widening backoff to absorb scale-to-zero cold starts. A 5xx surviving
+/// every retry returns `PublishError::Server`, which the caller surfaces to
+/// the UI (toast + republish CTA) and emits as a captureSupportError so the
+/// support pipeline opens a serenorg/seren-desktop bug ticket. #2343.
 pub async fn publish_meeting_notes(
     app: &AppHandle,
     title: &str,
     content: &str,
-) -> Result<String, String> {
+) -> Result<String, PublishError> {
     if !has_stored_credentials(app) {
-        return Err("not authenticated".to_string());
+        return Err(PublishError::NotAuthenticated);
     }
     let client = Client::new();
     let body = serde_json::json!({
@@ -112,24 +152,65 @@ pub async fn publish_meeting_notes(
         "format": "markdown",
     })
     .to_string();
-    let response = authenticated_request(app, &client, |c, token| {
+
+    let mut last_server: Option<(u16, String)> = None;
+    let attempts = RETRY_BACKOFFS.len() + 1;
+    for attempt in 0..attempts {
+        match attempt_publish(app, &client, &body).await {
+            Ok(id) => return Ok(id),
+            Err(PublishError::Server { status, body: srv }) => {
+                last_server = Some((status, srv));
+                if let Some(delay) = RETRY_BACKOFFS.get(attempt).copied() {
+                    log::warn!(
+                        "[meeting] seren-notes publish 5xx={status} (attempt {}/{attempts}); retrying in {:?} (cold-start expected)",
+                        attempt + 1,
+                        delay,
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    let (status, body) = last_server
+        .expect("retry loop only exits via Ok, non-Server Err, or after surfacing a Server status");
+    Err(PublishError::Server { status, body })
+}
+
+async fn attempt_publish(
+    app: &AppHandle,
+    client: &Client,
+    body: &str,
+) -> Result<String, PublishError> {
+    let response = authenticated_request(app, client, |c, token| {
         c.post(PUBLISH_URL)
             .header("Content-Type", "application/json")
             .bearer_auth(token)
-            .body(body.clone())
+            .body(body.to_string())
     })
-    .await?;
+    .await
+    .map_err(PublishError::Other)?;
     let status = response.status();
     let text = response
         .text()
         .await
-        .map_err(|err| format!("seren-notes read body failed: {err}"))?;
+        .map_err(|err| PublishError::Other(format!("seren-notes read body failed: {err}")))?;
+    if status.is_server_error() {
+        return Err(PublishError::Server {
+            status: status.as_u16(),
+            body: text,
+        });
+    }
     if !status.is_success() {
-        return Err(format!("seren-notes publish returned {status}: {text}"));
+        return Err(PublishError::Other(format!(
+            "seren-notes publish returned {status}: {text}"
+        )));
     }
     let value: Value = serde_json::from_str(&text)
-        .map_err(|err| format!("seren-notes response was not JSON: {err}"))?;
-    extract_note_id(&value).ok_or_else(|| "seren-notes response missing note id".to_string())
+        .map_err(|err| PublishError::Other(format!("seren-notes response was not JSON: {err}")))?;
+    extract_note_id(&value)
+        .ok_or_else(|| PublishError::Other("seren-notes response missing note id".to_string()))
 }
 
 #[cfg(test)]
@@ -230,5 +311,34 @@ mod tests {
     fn extract_note_id_returns_none_when_id_missing() {
         let value = json!({"data": {"title": "n", "content": "c"}});
         assert_eq!(extract_note_id(&value), None);
+    }
+
+    // The captureSupportError telemetry payload echoes the publish error's
+    // message verbatim; this test pins the wire shape so a future refactor
+    // can't quietly break the support pipeline's signature dedupe. #2343.
+    #[test]
+    fn publish_error_server_into_message_includes_status_for_support_signature() {
+        let err = PublishError::Server {
+            status: 503,
+            body: "upstream cold start".to_string(),
+        };
+        let msg = err.into_message();
+        assert!(msg.contains("503"), "expected status in message: {msg}");
+        assert!(
+            msg.contains("upstream cold start"),
+            "expected body in message: {msg}"
+        );
+    }
+
+    // Cold-start absorption requires *more than one* retry — a single retry
+    // is not enough to reach a warm worker. Pin the minimum retry count so a
+    // tuning revert can't quietly drop the budget back to one. #2343.
+    #[test]
+    fn retry_budget_is_at_least_two_attempts_for_cold_start() {
+        assert!(
+            RETRY_BACKOFFS.len() >= 2,
+            "scale-to-zero seren-notes needs at least two retries before declaring a real outage; got {}",
+            RETRY_BACKOFFS.len()
+        );
     }
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -186,12 +186,45 @@ fn claim_publish_slot(meeting_id: &str) -> Option<PublishGuard> {
     Some(PublishGuard(meeting_id.to_string()))
 }
 
+// Body bodies can be megabytes; cap before they ride into telemetry.
+const PUBLISH_FAIL_BODY_LIMIT: usize = 2_048;
+
+// Emit a structured "publish failed" event the frontend listens for to call
+// captureSupportError, which opens a serenorg/seren-desktop bug ticket from
+// the existing support telemetry pipeline. #2343.
+fn emit_notes_publish_failed(
+    app: &AppHandle,
+    meeting_id: &str,
+    status: Option<u16>,
+    body: &str,
+) {
+    let trimmed = if body.len() > PUBLISH_FAIL_BODY_LIMIT {
+        &body[..PUBLISH_FAIL_BODY_LIMIT]
+    } else {
+        body
+    };
+    if let Err(err) = app.emit(
+        "meeting://notes-publish-failed",
+        serde_json::json!({
+            "meetingId": meeting_id,
+            "status": status,
+            "body": trimmed,
+        }),
+    ) {
+        log::warn!("[meeting] emit notes-publish-failed for {meeting_id}: {err}");
+    }
+}
+
 // Auto-publish the finalized meeting (notes + action items + transcript) to
 // seren-notes so the UI can render a "Chat with meeting notes" link. Runs in
 // its own task so a slow gateway never blocks notes-ready from rendering.
 // Always re-publishes — a Regenerate-after-publish overwrites the link to
 // point at the new content. Skips silently when the user isn't signed in;
 // the local UI shows the login CTA based on authStore.
+//
+// Emits `meeting://notes-publish-failed` (status + body) on a terminal
+// failure so the frontend can route it through captureSupportError and open
+// a bug ticket automatically. #2343.
 async fn spawn_seren_notes_publish(
     app: AppHandle,
     meeting_id: String,
@@ -229,12 +262,29 @@ async fn spawn_seren_notes_publish(
     .await
     {
         Ok(id) => id,
-        Err(err) => {
+        Err(crate::audio::seren_notes_publish::PublishError::NotAuthenticated) => {
+            // UI surfaces this via the existing "Login to SerenDB" CTA.
             log::info!(
-                "[meeting] seren-notes publish skipped or failed for {}: {}",
-                meeting_id,
-                err
+                "[meeting] seren-notes publish skipped for {} (not authenticated)",
+                meeting_id
             );
+            return;
+        }
+        Err(crate::audio::seren_notes_publish::PublishError::Server { status, body }) => {
+            log::warn!(
+                "[meeting] seren-notes publish failed for {} with {status} after retries",
+                meeting_id
+            );
+            emit_notes_publish_failed(&app, &meeting_id, Some(status), &body);
+            return;
+        }
+        Err(crate::audio::seren_notes_publish::PublishError::Other(msg)) => {
+            log::warn!(
+                "[meeting] seren-notes publish failed for {}: {}",
+                meeting_id,
+                msg
+            );
+            emit_notes_publish_failed(&app, &meeting_id, None, &msg);
             return;
         }
     };
@@ -266,6 +316,55 @@ async fn spawn_seren_notes_publish(
             err
         );
     }
+}
+
+// User-triggered republish: re-runs the same publish path the auto-flow
+// uses when notes finalize. Idempotent under PublishGuard — if a publish is
+// already in flight for this meeting, the spawned call no-ops without
+// double-posting. The frontend `Publish to Seren Notes` button calls this
+// after a 5xx-after-retry left the meeting without a `seren_notes_id`. #2343.
+#[tauri::command]
+pub async fn republish_meeting_to_seren_notes(
+    app: AppHandle,
+    meeting_id: String,
+) -> Result<(), String> {
+    let lookup = meeting_id.clone();
+    let meeting = run_db(app.clone(), move |conn| select_meeting(conn, &lookup))
+        .await?
+        .ok_or_else(|| "meeting not found".to_string())?;
+    if meeting.notes_markdown.is_none() {
+        return Err("meeting has no notes yet".to_string());
+    }
+    let notes_markdown = meeting.notes_markdown.clone().unwrap_or_default();
+    let action_items: Vec<String> = meeting
+        .notes_struct_json
+        .as_deref()
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
+        .and_then(|v| {
+            v.get("action_items")
+                .or_else(|| v.get("actionItems"))
+                .cloned()
+        })
+        .and_then(|v| serde_json::from_value::<Vec<String>>(v).ok())
+        .unwrap_or_default();
+    let transcript_app = app.clone();
+    let transcript_id = meeting_id.clone();
+    let segments = run_db(transcript_app, move |conn| {
+        select_transcript_segments(conn, &transcript_id)
+    })
+    .await?;
+    let transcript = assemble_transcript(segments);
+    tauri::async_runtime::spawn(async move {
+        spawn_seren_notes_publish(
+            app,
+            meeting_id,
+            notes_markdown,
+            action_items,
+            transcript,
+        )
+        .await;
+    });
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -818,6 +818,7 @@ pub fn run() {
             commands::audio::stop_meeting_capture,
             commands::audio::reconcile_meeting_speakers,
             commands::audio::generate_meeting_notes,
+            commands::audio::republish_meeting_to_seren_notes,
             commands::audio::get_meeting_transcript_text,
             commands::audio::select_meeting_skills,
             commands::audio::list_meeting_templates,

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -122,6 +122,7 @@ export function MeetingDetail(props: MeetingDetailProps) {
     props.meeting.templateId ?? settingsStore.get("meetingTemplateId"),
   );
   const [regenerating, setRegenerating] = createSignal(false);
+  const [republishing, setRepublishing] = createSignal(false);
   const [highlightedSeq, setHighlightedSeq] = createSignal<number | null>(null);
   const [editingTitle, setEditingTitle] = createSignal(false);
   const [titleDraft, setTitleDraft] = createSignal("");
@@ -240,6 +241,19 @@ export function MeetingDetail(props: MeetingDetailProps) {
       await meetingStore.routeMeetingToSkill(props.meeting, slug);
     } finally {
       setRouting(false);
+    }
+  };
+
+  // Manual republish for #2343. The backend uses PublishGuard so a
+  // double-click can't double-post; the button is also disabled while a
+  // call is in flight to keep the surface honest.
+  const republish = async () => {
+    if (republishing()) return;
+    setRepublishing(true);
+    try {
+      await meetingStore.republishToSerenNotes(props.meeting);
+    } finally {
+      setRepublishing(false);
     }
   };
 
@@ -417,14 +431,32 @@ export function MeetingDetail(props: MeetingDetailProps) {
           <Show
             when={props.meeting.serenNotesId}
             fallback={
-              <Show when={!authStore.isAuthenticated}>
-                <div class="mt-2 text-[12px] text-muted-foreground">
+              <Show
+                when={authStore.isAuthenticated}
+                fallback={
+                  <div class="mt-2 text-[12px] text-muted-foreground">
+                    <button
+                      type="button"
+                      class="text-primary hover:underline focus:outline-none focus:underline"
+                      onClick={() => requestSignInModal()}
+                    >
+                      Login to SerenDB to chat with your meeting notes
+                    </button>
+                  </div>
+                }
+              >
+                {/* Authenticated but no published id — the auto-publish
+                  hit a 5xx after retry, the prior session was offline, or
+                  the user signed in after notes finalized. Manual retry. */}
+                <div class="mt-2 flex items-center gap-2">
                   <button
                     type="button"
-                    class="text-primary hover:underline focus:outline-none focus:underline"
-                    onClick={() => requestSignInModal()}
+                    class="h-7 px-2.5 rounded-md border border-primary/40 bg-primary/10 text-[12px] text-primary hover:bg-primary/15 disabled:opacity-60"
+                    onClick={republish}
+                    disabled={republishing() || !isTauriRuntime()}
+                    title="Publish these notes to notes.serendb.com"
                   >
-                    Login to SerenDB to chat with your meeting notes
+                    {republishing() ? "Publishing…" : "Publish to Seren Notes"}
                   </button>
                 </div>
               </Show>

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -254,6 +254,17 @@ export function getMeetingTranscriptText(meetingId: string): Promise<string> {
   return invoke("get_meeting_transcript_text", { meetingId });
 }
 
+/**
+ * Re-run the seren-notes publish for a meeting whose previous publish failed
+ * (5xx after the backend retry budget) or never ran (auto-publish dropped
+ * before the link landed). Idempotent under the per-meeting PublishGuard:
+ * if a publish is already in flight, this no-ops on the backend without
+ * double-posting. #2343.
+ */
+export function republishMeetingToSerenNotes(meetingId: string): Promise<void> {
+  return invoke("republish_meeting_to_seren_notes", { meetingId });
+}
+
 export function selectMeetingSkills(skills: SkillRef[]): Promise<string[]> {
   return invoke("select_meeting_skills", { skills });
 }

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -4,6 +4,7 @@
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createStore } from "solid-js/store";
 import { formatTime } from "@/lib/meeting-format";
+import { captureSupportError } from "@/lib/support/hook";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 import {
   type CaptureStopOutcome,
@@ -19,6 +20,7 @@ import {
   type MeetingTemplate,
   meetingAutodetect,
   reconcileMeetingSpeakers,
+  republishMeetingToSerenNotes,
   selectMeetingSkills,
   setMeetingRoutedSkill,
   startMeetingCapture as startBackendCapture,
@@ -72,6 +74,7 @@ let transcriptUnlisten: UnlistenFn | null = null;
 let statusUnlisten: UnlistenFn | null = null;
 let levelUnlisten: UnlistenFn | null = null;
 let segmentsUpdatedUnlisten: UnlistenFn | null = null;
+let notesPublishFailedUnlisten: UnlistenFn | null = null;
 let trayToggleUnlisten: (() => void) | null = null;
 
 let autoDetectTimer: number | null = null;
@@ -290,6 +293,33 @@ async function startMeetingEventListeners(): Promise<void> {
     },
   );
 
+  // A terminal seren-notes publish failure (5xx after the backend retry
+  // budget) lands here. Surface a banner so the user can republish, and
+  // route the same failure through captureSupportError so the existing
+  // support telemetry pipeline opens a serenorg/seren-desktop bug ticket
+  // (per `feedback_support_pipeline.md` — console.warn is local-only). #2343.
+  notesPublishFailedUnlisten = await listen<{
+    meetingId: string;
+    status: number | null;
+    body: string;
+  }>("meeting://notes-publish-failed", (event) => {
+    const { meetingId, status, body } = event.payload;
+    setMeetingState(
+      "error",
+      "Couldn't publish meeting notes to Seren Notes. Use the Publish to Seren Notes button to try again.",
+    );
+    void captureSupportError({
+      kind: "seren_notes_publish_failed",
+      message: `seren-notes publish failed for meeting ${meetingId}${status !== null ? ` with HTTP ${status}` : ""}`,
+      http: {
+        method: "POST",
+        url: "https://api.serendb.com/publishers/seren-notes/notes",
+        ...(status !== null ? { status } : {}),
+        body,
+      },
+    });
+  });
+
   // The tray menu's Start/Stop action toggles capture through the same flow.
   trayToggleUnlisten = await onTrayToggleCapture(() => {
     void toggleCaptureFromTray();
@@ -301,11 +331,13 @@ function stopMeetingEventListeners(): void {
   statusUnlisten?.();
   levelUnlisten?.();
   segmentsUpdatedUnlisten?.();
+  notesPublishFailedUnlisten?.();
   trayToggleUnlisten?.();
   transcriptUnlisten = null;
   statusUnlisten = null;
   levelUnlisten = null;
   segmentsUpdatedUnlisten = null;
+  notesPublishFailedUnlisten = null;
   trayToggleUnlisten = null;
 }
 
@@ -692,6 +724,25 @@ function clearError(): void {
   setMeetingState("error", null);
 }
 
+// Manual retry path for a publish that failed after the backend retry
+// budget. Calls the backend command (idempotent under PublishGuard); a
+// `meeting://notes-published` or `meeting://notes-publish-failed` event
+// reconciles the UI. #2343.
+async function republishToSerenNotes(meeting: Meeting): Promise<void> {
+  if (!isTauriRuntime()) return;
+  setMeetingState("error", null);
+  try {
+    await republishMeetingToSerenNotes(meeting.id);
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error
+        ? error.message
+        : "Failed to republish meeting notes",
+    );
+  }
+}
+
 // Rename a saved meeting. Persists the new title, then updates the list row and
 // the active selection so the change shows immediately; the backend also emits
 // meeting://status, which reconciles any other surface.
@@ -850,6 +901,7 @@ export const meetingStore = {
   getMeetingSkillCandidates,
   routeMeetingToSkill,
   regenerateNotes,
+  republishToSerenNotes,
   renameMeeting,
   deleteMeeting,
   clearError,


### PR DESCRIPTION
Closes #2343.

## Summary

- Auto-publish to seren-notes now retries 5xx twice (2s, 4s) to absorb scale-to-zero cold starts, then emits a structured failure event when the 5xx survives the retry budget.
- The frontend listens for that event and calls `captureSupportError` so the existing support pipeline opens a `serenorg/seren-desktop` bug ticket automatically.
- A new `Publish to Seren Notes` button under the notes block lets an authenticated user retry on demand. The backend `republish_meeting_to_seren_notes` command honors the existing `PublishGuard`, so double-click + race-with-auto-flow are safe.

## Repro vs fix

Before (audited #2337 / PR #2338 / commit 78b50f94, `src-tauri/src/commands/audio.rs:232-239`):
1. Sign in, capture, finalize notes.
2. Force a 5xx (or drop network).
3. Backend logs `log::info!` and returns. UI shows neither the Login CTA nor the chat link nor any error.

After:
1. Backend retries (2s, then 4s) — covers cold start.
2. If it still 5xx, emits `meeting://notes-publish-failed` with status + body.
3. Frontend shows a banner + the `Publish to Seren Notes` button; `captureSupportError` fires with the HTTP context, which opens a bug ticket via the existing telemetry pipeline.

## Files

- `src-tauri/src/audio/seren_notes_publish.rs` — `PublishError` enum (NotAuthenticated / Server / Other), retry loop with `[2s, 4s]` backoff budget.
- `src-tauri/src/commands/audio.rs` — `spawn_seren_notes_publish` routes each variant; emits `meeting://notes-publish-failed` on terminal failure. New `republish_meeting_to_seren_notes` Tauri command.
- `src-tauri/src/lib.rs` — registers the new command.
- `src/services/meetings.ts` — `republishMeetingToSerenNotes(meetingId)`.
- `src/stores/meeting.store.ts` — listener calls `captureSupportError` + sets `error` banner; `republishToSerenNotes(meeting)` action.
- `src/components/meeting/MeetingDetail.tsx` — `Publish to Seren Notes` button in the previously-empty authenticated-but-unpublished state.

## Tests (critical only per CLAUDE.md)

- `PublishError::Server::into_message` includes the HTTP status (pins the wire shape `captureSupportError`'s signature dedupe depends on).
- `RETRY_BACKOFFS.len() >= 2` (cold-start absorption contract).
- All 100 existing `audio` module tests still pass; biome + tsc green for changed files.

## Test plan

- [ ] Signed in, force seren-notes to 5xx (or unplug network during publish): banner appears, `Publish to Seren Notes` button renders, captureSupportError fires, a bug ticket is created via the support pipeline.
- [ ] Click `Publish to Seren Notes` after the failure: re-runs the publish; on success the banner clears and the `Chat with meeting notes:` link replaces the button.
- [ ] Double-click the button: PublishGuard prevents two POSTs; only one note is created.
- [ ] Signed out: the existing `Login to SerenDB to chat with your meeting notes` CTA still renders (no regression).
- [ ] Cold-start path: a single 5xx followed by 200 succeeds inside the retry budget — no failure event, no bug ticket noise.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
