### PR TITLE
fix(meeting): republish surfaces collisions + clears banner on success (#2358 #2359)

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -186,6 +186,17 @@ fn claim_publish_slot(meeting_id: &str) -> Option<PublishGuard> {
     Some(PublishGuard(meeting_id.to_string()))
 }
 
+/// Non-claiming peek used by the user-triggered republish to return a
+/// friendly error instead of silently dropping when an auto-publish is
+/// still in flight for this meeting. #2358.
+fn publish_slot_is_held(meeting_id: &str) -> bool {
+    publishing_meetings()
+        .lock()
+        .ok()
+        .map(|set| set.contains(meeting_id))
+        .unwrap_or(false)
+}
+
 // Body bodies can be megabytes; cap before they ride into telemetry.
 const PUBLISH_FAIL_BODY_LIMIT: usize = 2_048;
 
@@ -319,15 +330,22 @@ async fn spawn_seren_notes_publish(
 }
 
 // User-triggered republish: re-runs the same publish path the auto-flow
-// uses when notes finalize. Idempotent under PublishGuard — if a publish is
-// already in flight for this meeting, the spawned call no-ops without
-// double-posting. The frontend `Publish to Seren Notes` button calls this
-// after a 5xx-after-retry left the meeting without a `seren_notes_id`. #2343.
+// uses when notes finalize. Surfaces a clear Err when an auto-publish for
+// the same meeting is still mid-retry (otherwise `spawn_seren_notes_publish`
+// would silently drop the click — #2358). The frontend `Publish to Seren
+// Notes` button calls this after a 5xx-after-retry left the meeting
+// without a `seren_notes_id`. #2343.
 #[tauri::command]
 pub async fn republish_meeting_to_seren_notes(
     app: AppHandle,
     meeting_id: String,
 ) -> Result<(), String> {
+    if publish_slot_is_held(&meeting_id) {
+        return Err(
+            "A publish is already in progress for this meeting. Hold on a moment and try again."
+                .to_string(),
+        );
+    }
     let lookup = meeting_id.clone();
     let meeting = run_db(app.clone(), move |conn| select_meeting(conn, &lookup))
         .await?
@@ -1385,6 +1403,31 @@ mod tests {
         assert!(
             claim_publish_slot("meeting-publish-slot-a").is_some(),
             "claim succeeds again after the guard drops — regenerate can re-publish"
+        );
+    }
+
+    // The user-triggered republish path's protection against silent drops
+    // when an auto-publish is mid-retry hinges on `publish_slot_is_held`
+    // observing the same set the guard mutates, *without* consuming the
+    // slot. Pin both the observation and the non-consumption. #2358.
+    #[test]
+    fn publish_slot_peek_reports_held_without_consuming_it() {
+        let key = "meeting-slot-peek";
+        assert!(!publish_slot_is_held(key), "free at start");
+        let guard = claim_publish_slot(key).expect("first claim");
+        assert!(
+            publish_slot_is_held(key),
+            "peek must see the live guard so republish can error out"
+        );
+        // Peeking must NOT consume the slot — the auto-publish still holds it.
+        assert!(
+            publish_slot_is_held(key),
+            "peek is non-consuming; the guard still owns the slot"
+        );
+        drop(guard);
+        assert!(
+            !publish_slot_is_held(key),
+            "peek reports free after the guard drops"
         );
     }
 

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -75,7 +75,15 @@ let statusUnlisten: UnlistenFn | null = null;
 let levelUnlisten: UnlistenFn | null = null;
 let segmentsUpdatedUnlisten: UnlistenFn | null = null;
 let notesPublishFailedUnlisten: UnlistenFn | null = null;
+let notesPublishedUnlisten: UnlistenFn | null = null;
 let trayToggleUnlisten: (() => void) | null = null;
+
+// Substring marker on the publish-failed banner so the published-success
+// listener clears only the banner it set, never a concurrent error from a
+// different surface (e.g. notes generation failure). #2359.
+const PUBLISH_FAILED_BANNER_MARKER = "Publish to Seren Notes";
+const PUBLISH_FAILED_BANNER =
+  "Couldn't publish meeting notes to Seren Notes. Use the Publish to Seren Notes button to try again.";
 
 let autoDetectTimer: number | null = null;
 let autoDetectDismissed = false;
@@ -304,10 +312,7 @@ async function startMeetingEventListeners(): Promise<void> {
     body: string;
   }>("meeting://notes-publish-failed", (event) => {
     const { meetingId, status, body } = event.payload;
-    setMeetingState(
-      "error",
-      "Couldn't publish meeting notes to Seren Notes. Use the Publish to Seren Notes button to try again.",
-    );
+    setMeetingState("error", PUBLISH_FAILED_BANNER);
     void captureSupportError({
       kind: "seren_notes_publish_failed",
       message: `seren-notes publish failed for meeting ${meetingId}${status !== null ? ` with HTTP ${status}` : ""}`,
@@ -318,6 +323,20 @@ async function startMeetingEventListeners(): Promise<void> {
         body,
       },
     });
+  });
+
+  // Successful (re)publish clears the failed-banner we set above, so the
+  // user doesn't see "couldn't publish" lingering after the manual retry
+  // worked. Substring check on the marker keeps us from clearing a banner
+  // that came from a different surface (e.g. notes generation). #2359.
+  notesPublishedUnlisten = await listen<{
+    meetingId: string;
+    serenNotesId: string;
+  }>("meeting://notes-published", () => {
+    const current = meetingState.error;
+    if (current?.includes(PUBLISH_FAILED_BANNER_MARKER)) {
+      setMeetingState("error", null);
+    }
   });
 
   // The tray menu's Start/Stop action toggles capture through the same flow.
@@ -332,12 +351,14 @@ function stopMeetingEventListeners(): void {
   levelUnlisten?.();
   segmentsUpdatedUnlisten?.();
   notesPublishFailedUnlisten?.();
+  notesPublishedUnlisten?.();
   trayToggleUnlisten?.();
   transcriptUnlisten = null;
   statusUnlisten = null;
   levelUnlisten = null;
   segmentsUpdatedUnlisten = null;
   notesPublishFailedUnlisten = null;
+  notesPublishedUnlisten = null;
   trayToggleUnlisten = null;
 }
 


### PR DESCRIPTION
Closes #2358. Closes #2359.

## Summary

Two P0s found in the functional walk-through audit of #2357 (the #2343 fix):

1. **Silent click on collision (#2358).** When the auto-publish was still inside its `[2s, 4s]` cold-start retry budget, the new `Publish to Seren Notes` button hit `claim_publish_slot`, returned None, and the spawned task silently exited. Tauri command resolved `Ok(())`, the spinner stopped, and nothing happened — recreating the exact silent-failure UX #2343 was meant to kill.
2. **Banner persists after fix (#2359).** After the failure banner was set, a successful manual republish emitted `meeting://notes-published` but nothing cleared `meetingState.error`. The "Couldn't publish" copy lingered above the freshly-rendered "Chat with meeting notes:" link.

## Files

- `src-tauri/src/commands/audio.rs` — `publish_slot_is_held(meeting_id)` non-consuming peek + early-Err in `republish_meeting_to_seren_notes`. New unit test pins the contract.
- `src/stores/meeting.store.ts` — `meeting://notes-published` listener clears the failure banner when the substring marker matches.

## Tests (critical only per CLAUDE.md)

- `publish_slot_peek_reports_held_without_consuming_it` — pins the observation + non-consumption contract the republish gate relies on (a slot peek that consumed the slot would let the auto-publish silently fail).
- All 100 existing audio module tests still pass; biome clean for changed files.

## Test plan

- [ ] Force 5xx + cold-start delay. While auto-publish is mid-retry (within 6s), click `Publish to Seren Notes`. The banner now says `A publish is already in progress for this meeting. Hold on a moment and try again.` instead of going silent.
- [ ] Let the auto-publish exhaust its retry, banner appears, click `Publish to Seren Notes`, succeed. Banner clears as the chat link appears. No more contradictory "couldn't publish" above the success state.
- [ ] Concurrent error banner from a different surface (e.g. a notes-generation failure that includes the phrase "Publish to Seren Notes"? — note we use a hard-coded marker on our own banner; other banners that don't contain that exact substring are not touched).
- [ ] Pre-existing path: regenerate auto-publishes a new note, succeeds, the chat link updates. No regression.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
