### PR TITLE
fix(ci): absorb pwsh cold-start in windows-sign-overlay tests (#2362)

### DIFF
--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -155,20 +155,32 @@ describe("sign-windows-payload.ps1 thumbprint resolution", () => {
     return { out: `${r.stdout}\n${r.stderr}`, status: r.status ?? 1 };
   }
 
-  it.runIf(runnable)("fails fast with a clear error when no thumbprint is provided", () => {
-    const { out, status } = runSigner({});
-    expect(status).toBe(1);
-    expect(out).toContain("WINDOWS_SIGN_THUMBPRINT");
-    // Must fail on input validation, not deep in signtool discovery.
-    expect(out).not.toContain("signtool");
-  });
+  // Per-test timeout absorbs pwsh cold-start on CI runners (~5–7s on a fresh
+  // Linux runner vs ~400ms once warm). Default vitest 5s ceiling tripped #2362.
+  const pwshTimeout = 30_000;
 
-  it.runIf(runnable)("accepts the thumbprint from WINDOWS_SIGN_THUMBPRINT (signCommand passes no -Thumbprint)", () => {
-    const { out, status } = runSigner({ WINDOWS_SIGN_THUMBPRINT: "933C679D86D0ACAF531B37A4D12C0B360EB4815C" });
-    // Proceeds past validation; on non-Windows it then fails at signtool
-    // discovery — proving the env thumbprint was accepted.
-    expect(status).toBe(1);
-    expect(out).toContain("signtool");
-    expect(out).not.toContain("WINDOWS_SIGN_THUMBPRINT");
-  });
+  it.runIf(runnable)(
+    "fails fast with a clear error when no thumbprint is provided",
+    () => {
+      const { out, status } = runSigner({});
+      expect(status).toBe(1);
+      expect(out).toContain("WINDOWS_SIGN_THUMBPRINT");
+      // Must fail on input validation, not deep in signtool discovery.
+      expect(out).not.toContain("signtool");
+    },
+    pwshTimeout,
+  );
+
+  it.runIf(runnable)(
+    "accepts the thumbprint from WINDOWS_SIGN_THUMBPRINT (signCommand passes no -Thumbprint)",
+    () => {
+      const { out, status } = runSigner({ WINDOWS_SIGN_THUMBPRINT: "933C679D86D0ACAF531B37A4D12C0B360EB4815C" });
+      // Proceeds past validation; on non-Windows it then fails at signtool
+      // discovery — proving the env thumbprint was accepted.
+      expect(status).toBe(1);
+      expect(out).toContain("signtool");
+      expect(out).not.toContain("WINDOWS_SIGN_THUMBPRINT");
+    },
+    pwshTimeout,
+  );
 });


### PR DESCRIPTION
## Summary

Closes #2362.

CI run [27359643449](https://github.com/serenorg/seren-desktop/actions/runs/27359643449) on main failed with:

```
FAIL tests/unit/windows-sign-overlay.test.ts > sign-windows-payload.ps1 thumbprint resolution > fails fast with a clear error when no thumbprint is provided
Error: Test timed out in 5000ms.
```

Both `it.runIf(runnable)` tests in this file `spawnSync` `pwsh` to execute the signer `.ps1`. On a warm Linux runner that costs ~400ms; on a cold runner the first `pwsh` invocation costs 5–7 s before any user code runs. The failing test took 5408 ms — 408 ms over vitest's default 5000 ms timeout.

Bumping the per-test timeout to 30 s on both `runIf` tests so cold-start variance cannot flake CI again. Warm-path duration is unchanged.

## Test plan

- [x] `pnpm vitest run tests/unit/windows-sign-overlay.test.ts` → 11/11 pass in 3.24s locally
- [ ] CI green on the PR
