### PR TITLE
fix(meeting): autodetect across all input devices (#2364)

### DIFF
--- a/src-tauri/src/audio/detect.rs
+++ b/src-tauri/src/audio/detect.rs
@@ -27,6 +27,16 @@ pub fn should_start_capture(activity: AudioActivity) -> bool {
     activity.input_active
 }
 
+/// Pure decision for "is any input device currently engaged" — used by both
+/// platform probes after they enumerate input devices. Today's default-input
+/// gate misses every external mic (USB headset, audio interface, AirPods)
+/// that isn't set as System Settings → Sound → Input default; this seam ORs
+/// the per-device states so the prompt fires regardless of which input the
+/// conferencing app picked. #2364.
+pub fn any_input_device_running(states: impl IntoIterator<Item = bool>) -> bool {
+    states.into_iter().any(|running| running)
+}
+
 pub fn meeting_detection(activity: AudioActivity) -> MeetingAutodetectResult {
     if should_start_capture(activity.clone()) {
         return MeetingAutodetectResult {
@@ -112,9 +122,13 @@ mod platform_audio {
     const NO_ERR: OSStatus = 0;
     const K_AUDIO_OBJECT_SYSTEM_OBJECT: AudioObjectID = 1;
     const K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL: AudioObjectPropertyScope = fourcc(b"glob");
+    const K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT: AudioObjectPropertyScope = fourcc(b"inpt");
     const K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN: AudioObjectPropertyElement = 0;
     const K_AUDIO_HARDWARE_PROPERTY_DEFAULT_INPUT_DEVICE: AudioObjectPropertySelector =
         fourcc(b"dIn ");
+    const K_AUDIO_HARDWARE_PROPERTY_DEVICES: AudioObjectPropertySelector = fourcc(b"dev#");
+    const K_AUDIO_DEVICE_PROPERTY_STREAM_CONFIGURATION: AudioObjectPropertySelector =
+        fourcc(b"slay");
     const K_AUDIO_DEVICE_PROPERTY_DEVICE_IS_RUNNING_SOMEWHERE: AudioObjectPropertySelector =
         fourcc(b"gone");
 
@@ -136,10 +150,18 @@ mod platform_audio {
             io_data_size: *mut u32,
             out_data: *mut c_void,
         ) -> OSStatus;
+
+        fn AudioObjectGetPropertyDataSize(
+            in_object_id: AudioObjectID,
+            in_address: *const AudioObjectPropertyAddress,
+            in_qualifier_data_size: u32,
+            in_qualifier_data: *const c_void,
+            out_data_size: *mut u32,
+        ) -> OSStatus;
     }
 
     pub(super) fn probe_audio_activity() -> AudioActivity {
-        let input_active = default_input_device_is_running();
+        let input_active = any_input_device_is_running();
         AudioActivity {
             input_active,
             source_app: input_active
@@ -153,6 +175,30 @@ mod platform_audio {
             | ((code[1] as u32) << 16)
             | ((code[2] as u32) << 8)
             | (code[3] as u32)
+    }
+
+    /// OR `IsRunningSomewhere` across every input-capable device, not just the
+    /// default. Fixes #2364 where Zoom/etc. on a non-default mic (USB
+    /// headset, audio interface, AirPods) never tripped the prompt. Falls
+    /// back to the default-only path if device enumeration fails so the
+    /// probe is never worse than the prior behavior.
+    fn any_input_device_is_running() -> bool {
+        let devices = list_all_audio_device_ids();
+        if devices.is_empty() {
+            return default_input_device_is_running();
+        }
+        super::any_input_device_running(devices.into_iter().filter_map(|device_id| {
+            if !device_has_input_streams(device_id) {
+                return None;
+            }
+            Some(
+                audio_object_u32(
+                    device_id,
+                    K_AUDIO_DEVICE_PROPERTY_DEVICE_IS_RUNNING_SOMEWHERE,
+                )
+                .is_some_and(|running| running != 0),
+            )
+        }))
     }
 
     fn default_input_device_is_running() -> bool {
@@ -171,6 +217,118 @@ mod platform_audio {
             K_AUDIO_DEVICE_PROPERTY_DEVICE_IS_RUNNING_SOMEWHERE,
         )
         .is_some_and(|running| running != 0)
+    }
+
+    fn list_all_audio_device_ids() -> Vec<AudioObjectID> {
+        let address = AudioObjectPropertyAddress {
+            selector: K_AUDIO_HARDWARE_PROPERTY_DEVICES,
+            scope: K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL,
+            element: K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+        };
+        let mut size: u32 = 0;
+        // SAFETY: read-only CoreAudio size query; all pointers reference live
+        // stack values for the duration of the call.
+        let status = unsafe {
+            AudioObjectGetPropertyDataSize(
+                K_AUDIO_OBJECT_SYSTEM_OBJECT,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut size,
+            )
+        };
+        if status != NO_ERR || size == 0 {
+            return Vec::new();
+        }
+        let count = size as usize / std::mem::size_of::<AudioObjectID>();
+        let mut buffer: Vec<AudioObjectID> = vec![0; count];
+        let mut io_size = size;
+        // SAFETY: buffer is sized to exactly `size` bytes, matching the size
+        // CoreAudio just reported. Pointer is exclusive to this call.
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                K_AUDIO_OBJECT_SYSTEM_OBJECT,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut io_size,
+                buffer.as_mut_ptr() as *mut c_void,
+            )
+        };
+        if status != NO_ERR {
+            return Vec::new();
+        }
+        buffer.truncate(io_size as usize / std::mem::size_of::<AudioObjectID>());
+        buffer
+    }
+
+    /// Returns true when the device exposes at least one input buffer with at
+    /// least one channel. Used to skip output-only endpoints (HDMI, speakers,
+    /// AirPlay) — otherwise an active speaker would flip `IsRunningSomewhere`
+    /// and surface a fake record prompt.
+    fn device_has_input_streams(device_id: AudioObjectID) -> bool {
+        let address = AudioObjectPropertyAddress {
+            selector: K_AUDIO_DEVICE_PROPERTY_STREAM_CONFIGURATION,
+            scope: K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT,
+            element: K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+        };
+        let mut size: u32 = 0;
+        // SAFETY: read-only CoreAudio size query against the device id.
+        let status = unsafe {
+            AudioObjectGetPropertyDataSize(
+                device_id,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut size,
+            )
+        };
+        if status != NO_ERR || (size as usize) < std::mem::size_of::<u32>() {
+            return false;
+        }
+        let mut buffer: Vec<u8> = vec![0; size as usize];
+        let mut io_size = size;
+        // SAFETY: buffer is sized to exactly `size`; CoreAudio fills the
+        // `AudioBufferList` layout described in the Apple docs.
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                device_id,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut io_size,
+                buffer.as_mut_ptr() as *mut c_void,
+            )
+        };
+        if status != NO_ERR {
+            return false;
+        }
+        // AudioBufferList: u32 mNumberBuffers, followed by mNumberBuffers
+        // AudioBuffer structs { u32 mNumberChannels; u32 mDataByteSize;
+        // *mut c_void mData; }. We only need to know if any buffer has at
+        // least one channel, so reach into the first u32 of each entry.
+        let m_number_buffers = u32::from_ne_bytes(
+            buffer
+                .get(..4)
+                .and_then(|s| s.try_into().ok())
+                .unwrap_or([0, 0, 0, 0]),
+        );
+        if m_number_buffers == 0 {
+            return false;
+        }
+        let buffer_struct_size = std::mem::size_of::<u32>() * 2 + std::mem::size_of::<*mut c_void>();
+        for i in 0..m_number_buffers as usize {
+            let offset = std::mem::size_of::<u32>() + i * buffer_struct_size;
+            let Some(slice) = buffer.get(offset..offset + 4) else {
+                break;
+            };
+            let channels =
+                u32::from_ne_bytes(slice.try_into().unwrap_or([0, 0, 0, 0]));
+            if channels > 0 {
+                return true;
+            }
+        }
+        false
     }
 
     fn audio_object_u32(
@@ -211,13 +369,13 @@ mod platform_audio {
     use super::{AudioActivity, known_call_app_from_system_processes};
     use wasapi::initialize_mta;
     use windows::Win32::Media::Audio::{
-        AudioSessionStateActive, IAudioSessionManager2, IMMDeviceEnumerator, MMDeviceEnumerator,
-        eCapture, eCommunications,
+        AudioSessionStateActive, DEVICE_STATE_ACTIVE, IAudioSessionManager2, IMMDevice,
+        IMMDeviceEnumerator, MMDeviceEnumerator, eCapture,
     };
     use windows::Win32::System::Com::{CLSCTX_ALL, CoCreateInstance};
 
     pub(super) fn probe_audio_activity() -> AudioActivity {
-        let input_active = default_capture_session_is_active();
+        let input_active = any_capture_session_is_active();
         AudioActivity {
             input_active,
             source_app: input_active
@@ -226,7 +384,10 @@ mod platform_audio {
         }
     }
 
-    fn default_capture_session_is_active() -> bool {
+    /// Walk every active capture endpoint, not just the default
+    /// communications one. Fixes #2364 where Zoom/etc. on a non-default mic
+    /// (USB headset, dock mic, virtual driver) never tripped the prompt.
+    fn any_capture_session_is_active() -> bool {
         if initialize_mta().ok().is_err() {
             return false;
         }
@@ -236,10 +397,22 @@ mod platform_audio {
                 Ok(enumerator) => enumerator,
                 Err(_) => return false,
             };
-        let Ok(device) = (unsafe { enumerator.GetDefaultAudioEndpoint(eCapture, eCommunications) })
+        let Ok(endpoints) =
+            (unsafe { enumerator.EnumAudioEndpoints(eCapture, DEVICE_STATE_ACTIVE) })
         else {
             return false;
         };
+        let Ok(endpoint_count) = (unsafe { endpoints.GetCount() }) else {
+            return false;
+        };
+
+        super::any_input_device_running((0..endpoint_count).filter_map(|index| {
+            let device = unsafe { endpoints.Item(index) }.ok()?;
+            Some(endpoint_has_active_session(&device))
+        }))
+    }
+
+    fn endpoint_has_active_session(device: &IMMDevice) -> bool {
         let Ok(manager) = (unsafe { device.Activate::<IAudioSessionManager2>(CLSCTX_ALL, None) })
         else {
             return false;
@@ -329,5 +502,29 @@ mod tests {
             known_call_app_from_process_list(processes).as_deref(),
             Some("Discord")
         );
+    }
+
+    #[test]
+    fn any_input_device_running_fires_when_a_non_default_input_is_engaged() {
+        // The exact scenario from #2364: the system-default input (built-in
+        // mic) is idle, the USB headset Zoom is using is running. Before this
+        // seam, the probe only inspected the default and returned false.
+        let default_built_in_mic_idle = false;
+        let usb_headset_used_by_zoom = true;
+        assert!(any_input_device_running([
+            default_built_in_mic_idle,
+            usb_headset_used_by_zoom
+        ]));
+    }
+
+    #[test]
+    fn any_input_device_running_is_false_when_every_input_is_idle() {
+        assert!(!any_input_device_running([false, false, false]));
+    }
+
+    #[test]
+    fn any_input_device_running_is_false_for_an_empty_device_list() {
+        let empty: [bool; 0] = [];
+        assert!(!any_input_device_running(empty));
     }
 }


### PR DESCRIPTION
Closes #2364.

## Root cause

`src-tauri/src/audio/detect.rs` probed only the **default** input device on both platforms. Zoom (or any conferencing app) routed through a non-default mic — USB headset, audio interface, AirPods, dock mic, virtual driver — silently lost the record prompt.

Confirmed live today: Discord on the system-default built-in mic surfaced the prompt three times; the same-day Zoom call on a USB device only triggered after the user fiddled with the camera, which forced macOS to re-evaluate the audio chain.

## Fix

- **Pure seam** `any_input_device_running` (top of `detect.rs`) ORs per-device running states. Unit-testable without CoreAudio / WASAPI mocking.
- **macOS**: enumerate `kAudioHardwarePropertyDevices`, filter to input-capable via `kAudioDevicePropertyStreamConfiguration` (input scope), OR `IsRunningSomewhere`. Falls back to the prior default-only path if enumeration fails so the probe is never worse than before.
- **Windows**: `EnumAudioEndpoints(eCapture, DEVICE_STATE_ACTIVE)` to walk every active capture endpoint instead of just the default communications one; per-endpoint session-state check unchanged.

Filtering input-capable devices on macOS is necessary so output devices (HDMI, speakers, AirPlay) playing audio don't flip `IsRunningSomewhere` and surface a fake prompt.

## Critical tests

- `any_input_device_running_fires_when_a_non_default_input_is_engaged` — exact #2364 shape: default idle, non-default running.
- `any_input_device_running_is_false_when_every_input_is_idle` — boundary.
- `any_input_device_running_is_false_for_an_empty_device_list` — boundary.
- 110 existing audio tests still green.

## Test plan

- [ ] macOS: with a USB mic that is **not** the System Settings → Sound → Input default, join a Zoom/Discord/Teams call. Prompt fires within ~5s.
- [ ] macOS: plug in a USB headset, set it as Default Input, join a call. Prompt still fires (regression guard for the previous-default path).
- [ ] macOS: stop the call. Prompt disappears within ~5s once the mic goes idle.
- [ ] macOS: enable an output-only device (AirPlay / HDMI) and play music with no mic engaged. Prompt does NOT fire (regression guard for the input-capable filter).
- [ ] Windows: same as #1 with a USB capture device or audio interface routed to Teams/Zoom.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
