### PR TITLE
feat(editor): open clicked images in default viewer

### DIFF
--- a/bin/browser-local/dialogs.mjs
+++ b/bin/browser-local/dialogs.mjs
@@ -2,6 +2,7 @@
 // ABOUTME: Uses platform CLI tools so the local browser mode stays dependency-light.
 
 import { execFile } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
 import { platform } from "node:os";
 import { dirname } from "node:path";
 
@@ -21,6 +22,30 @@ function exec(command, args) {
       resolve(stdout.trim());
     });
   });
+}
+
+function execStrict(command, args) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { timeout: 60_000 }, (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+function assertOpenableFile(path) {
+  if (!path || typeof path !== "string") {
+    throw new Error("Path is required");
+  }
+  if (!existsSync(path)) {
+    throw new Error(`Path does not exist: ${path}`);
+  }
+  if (!statSync(path).isFile()) {
+    throw new Error(`Path is not a file: ${path}`);
+  }
 }
 
 export async function openFolderDialog() {
@@ -125,6 +150,32 @@ export async function revealInFileManager({ path }) {
 
   if (os === "win32") {
     await exec("explorer", [`/select,${path}`]);
+    return;
+  }
+
+  throw new Error(`Unsupported platform: ${os}`);
+}
+
+export async function openPathWithDefaultApp({ path }) {
+  assertOpenableFile(path);
+
+  if (os === "darwin") {
+    await execStrict("open", [path]);
+    return;
+  }
+
+  if (os === "linux") {
+    await execStrict("xdg-open", [path]);
+    return;
+  }
+
+  if (os === "win32") {
+    await execStrict("powershell", [
+      "-NoProfile",
+      "-Command",
+      "Start-Process -LiteralPath $args[0]",
+      path,
+    ]);
     return;
   }
 

--- a/bin/seren-desktop.mjs
+++ b/bin/seren-desktop.mjs
@@ -11,6 +11,7 @@ import { createProviderHandlers } from "./browser-local/providers.mjs";
 import {
   openFileDialog,
   openFolderDialog,
+  openPathWithDefaultApp,
   revealInFileManager,
   saveFileDialog,
 } from "./browser-local/dialogs.mjs";
@@ -230,6 +231,7 @@ function registerBrowserLocalHandlers() {
   registerHandler("open_file_dialog", openFileDialog);
   registerHandler("save_file_dialog", saveFileDialog);
   registerHandler("reveal_in_file_manager", revealInFileManager);
+  registerHandler("open_path_with_default_app", openPathWithDefaultApp);
 
   const providerHandlers = createProviderHandlers({
     emit,

--- a/src-tauri/src/files.rs
+++ b/src-tauri/src/files.rs
@@ -167,6 +167,24 @@ pub fn reveal_in_file_manager(app: tauri::AppHandle, path: String) -> Result<(),
         .map_err(|e| format!("Failed to reveal in file manager: {}", e))
 }
 
+/// Open a file with the operating system's default application.
+#[tauri::command]
+pub fn open_path_with_default_app(app: tauri::AppHandle, path: String) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+    let resolved = expand_tilde(&path)?;
+
+    if !resolved.exists() {
+        return Err(format!("Path does not exist: {}", path));
+    }
+    if resolved.is_dir() {
+        return Err(format!("Path is a directory: {}", path));
+    }
+
+    app.opener()
+        .open_path(resolved.to_string_lossy().to_string(), None::<&str>)
+        .map_err(|e| format!("Failed to open file with default app: {}", e))
+}
+
 /// Defence-in-depth guard (GH #1584): reject writes whose resolved path
 /// still contains a literal `~` segment. Before GH #1583 landed, an
 /// unexpanded `~/foo` would fall back to `Path::new("~/foo")` and resolve

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -779,6 +779,7 @@ pub fn run() {
             files::delete_path,
             files::rename_path,
             files::reveal_in_file_manager,
+            files::open_path_with_default_app,
             // Shell command execution (requires frontend approval)
             shell::execute_shell_command,
             shell::execute_shell_command_streaming,

--- a/src/components/editor/EditorContent.tsx
+++ b/src/components/editor/EditorContent.tsx
@@ -17,6 +17,7 @@ import {
   setInlineEditHandler,
 } from "@/lib/editor";
 import { saveTab } from "@/lib/files/service";
+import { isSupportedImageFile } from "@/lib/images/file-types";
 import { authStore } from "@/stores/auth.store";
 import { editorStore } from "@/stores/editor.store";
 import { setSelectedPath } from "@/stores/fileTree";
@@ -172,11 +173,7 @@ export const EditorContent: Component<EditorContentProps> = (props) => {
   // Check if current file is an image
   const isImageFile = createMemo(() => {
     const path = activeFilePath();
-    if (!path) return false;
-    const ext = path.toLowerCase().split(".").pop();
-    return ["png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "ico"].includes(
-      ext || "",
-    );
+    return path ? isSupportedImageFile(path) : false;
   });
 
   // Check if current file is a PDF

--- a/src/components/editor/EditorPanel.tsx
+++ b/src/components/editor/EditorPanel.tsx
@@ -24,6 +24,7 @@ import {
   openFolder,
   saveTab,
 } from "@/lib/files/service";
+import { isSupportedImageFile } from "@/lib/images/file-types";
 import { editorStore } from "@/stores/editor.store";
 import { fileTreeState, setNodes, setSelectedPath } from "@/stores/fileTree";
 import {
@@ -142,11 +143,7 @@ export const EditorPanel: Component = () => {
   // Check if current file is an image
   const isImageFile = createMemo(() => {
     const path = activeFilePath();
-    if (!path) return false;
-    const ext = path.toLowerCase().split(".").pop();
-    return ["png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "ico"].includes(
-      ext || "",
-    );
+    return path ? isSupportedImageFile(path) : false;
   });
 
   // Check if current file is a PDF

--- a/src/components/editor/ImageViewer.tsx
+++ b/src/components/editor/ImageViewer.tsx
@@ -9,6 +9,7 @@ import {
   onCleanup,
   Show,
 } from "solid-js";
+import { openImageInDefaultViewer } from "@/lib/files/service";
 
 interface ImageViewerProps {
   filePath: string;
@@ -22,9 +23,12 @@ export const ImageViewer: Component<ImageViewerProps> = (props) => {
     height: number;
   } | null>(null);
   const [error, setError] = createSignal<string | null>(null);
+  const [openError, setOpenError] = createSignal<string | null>(null);
   const [isDragging, setIsDragging] = createSignal(false);
+  const [hasDragged, setHasDragged] = createSignal(false);
   const [position, setPosition] = createSignal({ x: 0, y: 0 });
   const [dragStart, setDragStart] = createSignal({ x: 0, y: 0 });
+  const [pointerStart, setPointerStart] = createSignal({ x: 0, y: 0 });
 
   // Load image when file path changes
   createEffect(() => {
@@ -35,6 +39,7 @@ export const ImageViewer: Component<ImageViewerProps> = (props) => {
     const url = convertFileSrc(path);
     setImageUrl(url);
     setError(null);
+    setOpenError(null);
     setZoom(100);
     setPosition({ x: 0, y: 0 });
   });
@@ -73,11 +78,20 @@ export const ImageViewer: Component<ImageViewerProps> = (props) => {
   function handleMouseDown(e: MouseEvent) {
     if (e.button !== 0) return;
     setIsDragging(true);
+    setHasDragged(false);
+    setPointerStart({ x: e.clientX, y: e.clientY });
     setDragStart({ x: e.clientX - position().x, y: e.clientY - position().y });
   }
 
   function handleMouseMove(e: MouseEvent) {
     if (!isDragging()) return;
+    const start = pointerStart();
+    if (
+      Math.abs(e.clientX - start.x) > 4 ||
+      Math.abs(e.clientY - start.y) > 4
+    ) {
+      setHasDragged(true);
+    }
     setPosition({
       x: e.clientX - dragStart().x,
       y: e.clientY - dragStart().y,
@@ -104,6 +118,25 @@ export const ImageViewer: Component<ImageViewerProps> = (props) => {
     const parts = props.filePath.split("/");
     return parts[parts.length - 1];
   };
+
+  async function openInDefaultViewer() {
+    setOpenError(null);
+    try {
+      await openImageInDefaultViewer(props.filePath);
+    } catch (error) {
+      setOpenError(
+        error instanceof Error
+          ? error.message
+          : "Failed to open image in default viewer",
+      );
+    }
+  }
+
+  function handleImageClick(e: MouseEvent) {
+    e.stopPropagation();
+    if (hasDragged()) return;
+    void openInDefaultViewer();
+  }
 
   return (
     <div class="flex flex-col h-full bg-card">
@@ -144,6 +177,14 @@ export const ImageViewer: Component<ImageViewerProps> = (props) => {
           >
             ⟳
           </button>
+          <button
+            type="button"
+            class="bg-transparent border border-border-strong text-foreground h-8 rounded px-2 flex items-center justify-center text-xs font-medium cursor-pointer transition-all hover:bg-border-medium hover:border-muted-foreground/40"
+            onClick={() => void openInDefaultViewer()}
+            title="Open in default image viewer"
+          >
+            Open
+          </button>
         </div>
       </div>
 
@@ -171,11 +212,20 @@ export const ImageViewer: Component<ImageViewerProps> = (props) => {
                 }}
                 onLoad={handleImageLoad}
                 onError={handleImageError}
+                onClick={handleImageClick}
                 draggable={false}
+                title="Open in default image viewer"
               />
             )}
           </Show>
         )}
+        <Show when={openError()}>
+          {(message) => (
+            <div class="absolute bottom-3 left-1/2 z-10 max-w-[calc(100%-2rem)] -translate-x-1/2 rounded border border-destructive/50 bg-background px-3 py-2 text-xs text-destructive shadow">
+              {message()}
+            </div>
+          )}
+        </Show>
       </div>
     </div>
   );

--- a/src/lib/files/service.ts
+++ b/src/lib/files/service.ts
@@ -13,6 +13,7 @@ import {
   isDirectory as isDirectoryBridge,
   isTauriRuntime,
   listDirectory as listDirectoryBridge,
+  openPathWithDefaultApp as openPathWithDefaultAppBridge,
   pathExists as pathExistsBridge,
   readFile as readFileBridge,
   renamePath as renamePathBridge,
@@ -107,6 +108,13 @@ export async function renamePath(
  */
 export async function revealInFileManager(path: string): Promise<void> {
   return revealInFileManagerBridge(path);
+}
+
+/**
+ * Open an image file with the operating system's default image viewer.
+ */
+export async function openImageInDefaultViewer(path: string): Promise<void> {
+  return openPathWithDefaultAppBridge(path);
 }
 
 async function openDialog(

--- a/src/lib/images/file-types.ts
+++ b/src/lib/images/file-types.ts
@@ -1,0 +1,43 @@
+// ABOUTME: Shared image file type detection for editor image previews.
+// ABOUTME: Keeps image tab routing consistent across editor surfaces.
+
+export const SUPPORTED_IMAGE_EXTENSIONS = [
+  "png",
+  "jpg",
+  "jpeg",
+  "jpe",
+  "jfif",
+  "gif",
+  "svg",
+  "webp",
+  "bmp",
+  "dib",
+  "ico",
+  "cur",
+  "tif",
+  "tiff",
+  "heic",
+  "heif",
+  "avif",
+] as const;
+
+const SUPPORTED_IMAGE_EXTENSION_SET = new Set<string>(
+  SUPPORTED_IMAGE_EXTENSIONS,
+);
+
+function fileNameFromPath(path: string): string {
+  const lastSlash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
+}
+
+export function imageFileExtension(path: string): string | null {
+  const fileName = fileNameFromPath(path);
+  const dot = fileName.lastIndexOf(".");
+  if (dot <= 0 || dot === fileName.length - 1) return null;
+  return fileName.slice(dot + 1).toLowerCase();
+}
+
+export function isSupportedImageFile(path: string): boolean {
+  const extension = imageFileExtension(path);
+  return extension !== null && SUPPORTED_IMAGE_EXTENSION_SET.has(extension);
+}

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -464,6 +464,22 @@ export async function revealInFileManager(path: string): Promise<void> {
   throw new Error("File system operations require a local runtime");
 }
 
+/**
+ * Open a file with the operating system's default application.
+ */
+export async function openPathWithDefaultApp(path: string): Promise<void> {
+  const invoke = await getInvoke();
+  if (invoke) {
+    await invoke("open_path_with_default_app", { path });
+    return;
+  }
+  if (isBrowserLocalRuntime()) {
+    await runtimeInvoke("open_path_with_default_app", { path });
+    return;
+  }
+  throw new Error("File system operations require a local runtime");
+}
+
 // ============================================================================
 // Provider API Key Management
 // ============================================================================

--- a/tests/unit/image-file-opening.test.ts
+++ b/tests/unit/image-file-opening.test.ts
@@ -1,0 +1,37 @@
+// ABOUTME: Critical tests for opening image files in the OS default viewer.
+// ABOUTME: Guards shared image extension support and default-app bridge delegation.
+
+import { describe, expect, it, vi } from "vitest";
+import { openImageInDefaultViewer } from "@/lib/files/service";
+import { isSupportedImageFile } from "@/lib/images/file-types";
+import { openPathWithDefaultApp } from "@/lib/tauri-bridge";
+
+vi.mock("@/lib/tauri-bridge", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/tauri-bridge")>(
+    "@/lib/tauri-bridge",
+  );
+  return {
+    ...actual,
+    openPathWithDefaultApp: vi.fn(),
+  };
+});
+
+describe("image file opening", () => {
+  it("recognizes common default image viewer file types", () => {
+    expect(isSupportedImageFile("/Users/me/photo.PNG")).toBe(true);
+    expect(isSupportedImageFile("C:\\Users\\me\\Pictures\\scan.tiff")).toBe(
+      true,
+    );
+    expect(isSupportedImageFile("/Users/me/Downloads/live.heic")).toBe(true);
+    expect(isSupportedImageFile("/Users/me/Downloads/modern.avif")).toBe(true);
+    expect(isSupportedImageFile("/Users/me/notes/image-readme.md")).toBe(false);
+  });
+
+  it("delegates image opening to the default-app bridge", async () => {
+    await openImageInDefaultViewer("/Users/me/Pictures/photo.jpg");
+
+    expect(openPathWithDefaultApp).toHaveBeenCalledWith(
+      "/Users/me/Pictures/photo.jpg",
+    );
+  });
+});

--- a/tests/unit/image-file-opening.test.ts
+++ b/tests/unit/image-file-opening.test.ts
@@ -2,6 +2,8 @@
 // ABOUTME: Guards shared image extension support and default-app bridge delegation.
 
 import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { openImageInDefaultViewer } from "@/lib/files/service";
 import { isSupportedImageFile } from "@/lib/images/file-types";
 import { openPathWithDefaultApp } from "@/lib/tauri-bridge";
@@ -32,6 +34,27 @@ describe("image file opening", () => {
 
     expect(openPathWithDefaultApp).toHaveBeenCalledWith(
       "/Users/me/Pictures/photo.jpg",
+    );
+  });
+
+  it("registers the browser-local default-app opener fallback", () => {
+    const dialogsSource = readFileSync(
+      resolve("bin/browser-local/dialogs.mjs"),
+      "utf-8",
+    );
+    const desktopSource = readFileSync(
+      resolve("bin/seren-desktop.mjs"),
+      "utf-8",
+    );
+
+    expect(dialogsSource).toContain(
+      "export async function openPathWithDefaultApp",
+    );
+    expect(dialogsSource).toContain('execStrict("open", [path])');
+    expect(dialogsSource).toContain('execStrict("xdg-open", [path])');
+    expect(dialogsSource).toContain("Start-Process -LiteralPath $args[0]");
+    expect(desktopSource).toContain(
+      'registerHandler("open_path_with_default_app", openPathWithDefaultApp)',
     );
   });
 });


### PR DESCRIPTION
Fixes #2369

## Summary
- Added a Tauri command and frontend bridge/service wrapper to open local files with the OS default app.
- Wired image clicks and an explicit Open control in ImageViewer while preserving drag-to-pan and wheel zoom.
- Centralized image extension detection and expanded common default-viewer formats including TIFF, HEIC/HEIF, AVIF, JFIF, DIB, and CUR.

## Code-path audit
- src/components/editor/EditorContent.tsx and src/components/editor/EditorPanel.tsx now share isSupportedImageFile.
- src/components/editor/ImageViewer.tsx is the single UI path for image tabs in both editor surfaces.
- src/lib/files/service.ts and src/lib/tauri-bridge.ts expose the default-app open boundary.
- src-tauri/src/files.rs resolves and validates the file, then delegates to tauri_plugin_opener::open_path for macOS/Windows/Linux default app behavior.

## Verification
- pnpm vitest run tests/unit/image-file-opening.test.ts
- pnpm test
- pnpm check (existing unrelated warnings only)
- pnpm build
- pnpm prepare:mcp-servers
- cargo check