### PR TITLE
fix: paired turn status lifecycle and terminate event leak

### DIFF
--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -214,6 +214,9 @@ export function createPairedRuntime({ emit, inner }) {
     if (!route) return false;
     const paired = pairedSessions.get(route.pairedId);
     if (!paired) return false;
+    // Teardown in flight: swallow every inner emission so raw inner session
+    // ids never reach the frontend during terminate (#2373).
+    if (paired.terminating) return true;
     const roleState = paired.roles[route.role];
 
     switch (channel) {
@@ -442,14 +445,18 @@ export function createPairedRuntime({ emit, inner }) {
       };
     } catch (error) {
       paired.terminating = true;
+      // Terminate before dropping the route entries so teardown emissions
+      // from the inner runtimes stay intercepted (#2373).
       for (const role of Object.values(paired.roles)) {
         if (!role.innerSessionId) continue;
-        innerToPaired.delete(role.innerSessionId);
         try {
           await inner.terminateSession({ sessionId: role.innerSessionId });
         } catch {
           // Best-effort teardown — the inner spawn may never have registered.
         }
+      }
+      for (const role of Object.values(paired.roles)) {
+        if (role.innerSessionId) innerToPaired.delete(role.innerSessionId);
       }
       pairedSessions.delete(pairedId);
       const message = error instanceof Error ? error.message : String(error);
@@ -495,6 +502,11 @@ export function createPairedRuntime({ emit, inner }) {
 
     paired.cancelRequested = false;
     paired.currentPrompt = {};
+    // The whole pipeline is one turn from the frontend's perspective. The
+    // composer's Send gate reads info.status, so every status frame emitted
+    // during a phase must carry "prompting" — a mid-turn "ready" re-enables
+    // Send and the second submit collides with this turn (#2372).
+    paired.status = "prompting";
     const usage = { input_tokens: 0, output_tokens: 0 };
     let contextWindow;
 
@@ -512,7 +524,6 @@ export function createPairedRuntime({ emit, inner }) {
       }
 
       setPhase(paired, "planning", "planner");
-      emitPairedStatus(paired, "prompting");
       const planText = await runRoleTurn(
         paired,
         "planner",
@@ -546,6 +557,7 @@ export function createPairedRuntime({ emit, inner }) {
       collectMeta("planner");
 
       paired.currentPrompt = null;
+      paired.status = "ready";
       setPhase(paired, "idle", null);
       emit("provider://prompt-complete", {
         sessionId: paired.id,
@@ -561,6 +573,7 @@ export function createPairedRuntime({ emit, inner }) {
       const message = error instanceof Error ? error.message : String(error);
       const wasCancelled =
         paired.cancelRequested || message.includes("Task cancelled");
+      paired.status = "ready";
       paired.state = "idle";
       paired.activeRole = null;
       if (wasCancelled) {
@@ -589,6 +602,7 @@ export function createPairedRuntime({ emit, inner }) {
       }
     }
 
+    paired.status = "ready";
     paired.state = "idle";
     paired.activeRole = null;
     emit("provider://error", {
@@ -601,17 +615,24 @@ export function createPairedRuntime({ emit, inner }) {
   async function terminateSession({ sessionId }) {
     const paired = requirePaired(sessionId);
     paired.terminating = true;
-    pairedSessions.delete(sessionId);
 
+    // Inner runtimes emit their own terminated statuses while teardown is
+    // in flight. Keep the route entries (and the paired record) alive until
+    // both inner sessions are down so those emits stay intercepted — the
+    // terminating flag swallows them (#2373).
     for (const role of Object.values(paired.roles)) {
       if (!role.innerSessionId) continue;
-      innerToPaired.delete(role.innerSessionId);
       try {
         await inner.terminateSession({ sessionId: role.innerSessionId });
       } catch {
         // Best-effort: one inner session may already be gone.
       }
     }
+
+    for (const role of Object.values(paired.roles)) {
+      if (role.innerSessionId) innerToPaired.delete(role.innerSessionId);
+    }
+    pairedSessions.delete(sessionId);
 
     emit("provider://session-status", {
       sessionId: paired.id,

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -349,6 +349,32 @@ describe("paired runtime — prompt pipeline", () => {
     expect(dedup).toEqual(["planning", "executing", "reviewing", "idle"]);
   });
 
+  it("keeps status 'prompting' for the whole pipeline so the composer stays frozen (#2372)", async () => {
+    await h.paired.sendPrompt({ sessionId: "paired-1", prompt: "do it" });
+    const frames = eventsFor(h.emitted, "provider://session-status").map(
+      (e) => ({
+        status: e.payload.status as string,
+        state:
+          (e.payload as { paired?: { state?: string } }).paired?.state ?? null,
+      }),
+    );
+    // Every frame emitted while a phase is active must carry "prompting" —
+    // a mid-turn "ready" re-enables Send (#2372).
+    for (const frame of frames) {
+      if (
+        frame.state === "planning" ||
+        frame.state === "executing" ||
+        frame.state === "reviewing"
+      ) {
+        expect(frame, JSON.stringify(frame)).toMatchObject({
+          status: "prompting",
+        });
+      }
+    }
+    // The turn must end on a ready frame.
+    expect(frames[frames.length - 1].status).toBe("ready");
+  });
+
   it("suppresses replayed inner history chunks (DB transcript is authoritative)", async () => {
     h.wrappedEmit("provider://message-chunk", {
       sessionId: h.inner.spawnSession.mock.calls[0][0].localSessionId,
@@ -579,5 +605,36 @@ describe("paired runtime — terminate", () => {
     expect(statuses.length).toBe(1);
     expect(statuses[0].payload.status).toBe("terminated");
     expect(h.paired.hasSession("paired-1")).toBe(false);
+  });
+
+  it("never leaks inner session ids when inner terminations emit during teardown (#2373)", async () => {
+    const h = createHarness();
+    await spawnPaired(h);
+    h.emitted.length = 0;
+
+    // Real runtimes emit a terminated status for each inner session while
+    // terminateSession is in flight — those must stay intercepted.
+    h.inner.terminateSession.mockImplementation(
+      async ({ sessionId }: { sessionId: string }) => {
+        h.wrappedEmit("provider://session-status", {
+          sessionId,
+          status: "terminated",
+        });
+        h.innerSessions.delete(sessionId);
+      },
+    );
+
+    await h.paired.terminateSession({ sessionId: "paired-1" });
+    const leaked = h.emitted.filter(
+      (e) =>
+        typeof e.payload.sessionId === "string" &&
+        e.payload.sessionId !== "paired-1",
+    );
+    expect(leaked).toEqual([]);
+    // Exactly one terminated status reaches the frontend: the paired one.
+    const terminated = eventsFor(h.emitted, "provider://session-status").filter(
+      (e) => e.payload.status === "terminated",
+    );
+    expect(terminated.length).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #2372
Closes #2373

## What

Two defects found in the #2368 post-merge functional walk-through audit (live paired smoke against real CLIs):

1. **#2372 (P1)** — `paired.status` never flipped to `prompting` for the pipeline, so each phase-transition status frame carried `ready`, re-enabling the composer Send button mid-turn. Now `prompting` is held from turn start through the final review, restored to `ready` on completion, cancel, and error.
2. **#2373 (P2)** — `terminateSession` dropped the inner-session route entries before terminating the inner sessions, so their teardown `terminated` events leaked raw inner session ids to the frontend. Routes (and the paired record) now stay alive through teardown, with a `terminating` swallow in the interceptor; spawn-failure cleanup uses the same ordering.

## Verification

- TDD: two new tests pinning the status walk and the terminate-leak contract (red before fix, green after); 27/27 paired runtime tests, 1745/1745 unit tests.
- Live functional smoke (real Claude + Codex CLIs): status walk now `prompting/planning → prompting/executing → prompting/reviewing → ready/idle`, exactly one terminated event, SMOKE PASS.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com