### PR TITLE
fix(ci): bump configure-aws-credentials to v6 for Node 24 (#2376)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1051,14 +1051,14 @@ jobs:
 
       - name: Configure AWS credentials with OIDC role
         if: env.WINDOWS_E2E_AWS_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.WINDOWS_E2E_AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Configure AWS credentials with access keys
         if: env.WINDOWS_E2E_AWS_ROLE_ARN == ''
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

Bumps both `aws-actions/configure-aws-credentials` call sites in `release.yml` from `@v5` to `@v6`.

## Why

- v5 declares `runs.using: node20`; GitHub force-migrates all actions to Node 24 on **2026-06-16**.
- v6 (v6.2.0 current) is the Node 24-native major. Verified its only breaking change is the runtime requirement (runner >= v2.327.1 — GitHub-hosted runners already exceed this).
- Verified our inputs (`role-to-assume`, `aws-region`, `aws-access-key-id`, `aws-secret-access-key`) are unchanged between v5 and v6.
- This was the flagged pipeline risk after v3.54.0; must land before tagging v3.55.0.

Closes #2376

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com