### PR TITLE
fix(auth): serialize desktop token refresh

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -14,8 +14,49 @@ const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
 /// Global mutex to prevent concurrent refresh attempts from multiple workers.
 static REFRESH_LOCK: OnceLock<TokioMutex<()>> = OnceLock::new();
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RefreshLockDecision {
+    UseStoredAccessToken,
+    RefreshWithToken,
+    MissingRefreshToken,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RefreshUnauthorizedDecision {
+    UseStoredAccessToken,
+    ExpireSession,
+}
+
 fn refresh_mutex() -> &'static TokioMutex<()> {
     REFRESH_LOCK.get_or_init(|| TokioMutex::new(()))
+}
+
+pub(crate) fn decide_after_refresh_lock(
+    requested_refresh_token: Option<&str>,
+    stored_refresh_token: Option<&str>,
+    stored_access_token: Option<&str>,
+) -> RefreshLockDecision {
+    if requested_refresh_token != stored_refresh_token && stored_access_token.is_some() {
+        return RefreshLockDecision::UseStoredAccessToken;
+    }
+
+    if stored_refresh_token.is_some() {
+        return RefreshLockDecision::RefreshWithToken;
+    }
+
+    RefreshLockDecision::MissingRefreshToken
+}
+
+pub(crate) fn decide_after_refresh_unauthorized(
+    posted_refresh_token: &str,
+    stored_refresh_token: Option<&str>,
+    stored_access_token: Option<&str>,
+) -> RefreshUnauthorizedDecision {
+    if stored_refresh_token != Some(posted_refresh_token) && stored_access_token.is_some() {
+        return RefreshUnauthorizedDecision::UseStoredAccessToken;
+    }
+
+    RefreshUnauthorizedDecision::ExpireSession
 }
 
 /// Read the current access token from the encrypted store.
@@ -81,16 +122,21 @@ fn clear_tokens(app: &tauri::AppHandle) -> Result<(), String> {
 ///
 /// Uses a global mutex to prevent concurrent refresh storms from multiple workers.
 pub async fn refresh_access_token(app: &tauri::AppHandle) -> Result<String, String> {
+    let requested_refresh_token = get_refresh_token(app)?;
     let _guard = refresh_mutex().lock().await;
 
-    // After acquiring the lock, check if another caller already refreshed.
-    // If the token in the store is different from what the caller used,
-    // the refresh already happened — just return the new token.
-    // (Callers should compare with their stale token if they want to skip.)
-
-    let refresh_token = match get_refresh_token(app)? {
-        Some(rt) => rt,
-        None => {
+    let stored_refresh_token = get_refresh_token(app)?;
+    let stored_access_token = get_access_token(app).ok();
+    match decide_after_refresh_lock(
+        requested_refresh_token.as_deref(),
+        stored_refresh_token.as_deref(),
+        stored_access_token.as_deref(),
+    ) {
+        RefreshLockDecision::UseStoredAccessToken => {
+            log::debug!("[auth] Refresh token already rotated; reusing stored access token");
+            return Ok(stored_access_token.expect("decision requires stored access token"));
+        }
+        RefreshLockDecision::MissingRefreshToken => {
             // No refresh token means never-signed-in or already-logged-out,
             // not session expiry. Emitting auth:session-expired here turned
             // every signed-out Gateway call into a spurious sign-in-modal
@@ -98,7 +144,10 @@ pub async fn refresh_access_token(app: &tauri::AppHandle) -> Result<String, Stri
             let _ = clear_tokens(app);
             return Err("No refresh token available".to_string());
         }
-    };
+        RefreshLockDecision::RefreshWithToken => {}
+    }
+
+    let refresh_token = stored_refresh_token.expect("decision requires stored refresh token");
 
     let client = reqwest::Client::new();
     let response = client
@@ -110,6 +159,20 @@ pub async fn refresh_access_token(app: &tauri::AppHandle) -> Result<String, Stri
         .map_err(|e| format!("Token refresh network error: {}", e))?;
 
     if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+        let latest_refresh_token = get_refresh_token(app)?;
+        let latest_access_token = get_access_token(app).ok();
+        if decide_after_refresh_unauthorized(
+            &refresh_token,
+            latest_refresh_token.as_deref(),
+            latest_access_token.as_deref(),
+        ) == RefreshUnauthorizedDecision::UseStoredAccessToken
+        {
+            log::debug!(
+                "[auth] Refresh endpoint rejected stale refresh token after another refresh won"
+            );
+            return Ok(latest_access_token.expect("decision requires stored access token"));
+        }
+
         let _ = clear_tokens(app);
         let _ = app.emit("auth:session-expired", ());
         return Err("Session expired — please sign in again".to_string());
@@ -140,6 +203,62 @@ pub async fn refresh_access_token(app: &tauri::AppHandle) -> Result<String, Stri
 
     log::debug!("[auth] Token refreshed successfully");
     Ok(new_access_token.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RefreshLockDecision, RefreshUnauthorizedDecision, decide_after_refresh_lock,
+        decide_after_refresh_unauthorized,
+    };
+
+    #[test]
+    fn lock_decision_reuses_access_token_after_refresh_token_rotation() {
+        assert_eq!(
+            decide_after_refresh_lock(
+                Some("refresh-token-before-lock"),
+                Some("refresh-token-after-lock"),
+                Some("fresh-access-token"),
+            ),
+            RefreshLockDecision::UseStoredAccessToken,
+        );
+    }
+
+    #[test]
+    fn lock_decision_posts_when_refresh_token_is_unchanged() {
+        assert_eq!(
+            decide_after_refresh_lock(
+                Some("refresh-token-before-lock"),
+                Some("refresh-token-before-lock"),
+                Some("stale-access-token"),
+            ),
+            RefreshLockDecision::RefreshWithToken,
+        );
+    }
+
+    #[test]
+    fn unauthorized_decision_preserves_session_after_losing_external_race() {
+        assert_eq!(
+            decide_after_refresh_unauthorized(
+                "posted-refresh-token",
+                Some("newer-refresh-token"),
+                Some("fresh-access-token"),
+            ),
+            RefreshUnauthorizedDecision::UseStoredAccessToken,
+        );
+    }
+
+    #[test]
+    fn unauthorized_decision_expires_session_for_unchanged_refresh_token() {
+        assert_eq!(
+            decide_after_refresh_unauthorized(
+                "posted-refresh-token",
+                Some("posted-refresh-token"),
+                Some("stale-access-token"),
+            ),
+            RefreshUnauthorizedDecision::ExpireSession,
+        );
+    }
 }
 
 /// Make an authenticated HTTP request with automatic 401 refresh and retry.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,19 @@ fn clear_refresh_token(app: tauri::AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
+async fn refresh_session(app: tauri::AppHandle) -> Result<bool, String> {
+    match auth::refresh_access_token(&app).await {
+        Ok(_) => Ok(true),
+        Err(error)
+            if error == "No refresh token available" || error.starts_with("Session expired") =>
+        {
+            Ok(false)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[tauri::command]
 fn get_setting(
     app: tauri::AppHandle,
     store: String,
@@ -762,6 +775,7 @@ pub fn run() {
             store_refresh_token,
             get_refresh_token,
             clear_refresh_token,
+            refresh_session,
             get_setting,
             set_setting,
             store_provider_key,

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -14,6 +14,7 @@ import {
   clearToken,
   getRefreshToken,
   getToken,
+  isTauriRuntime,
   storeDefaultOrganizationId,
   storeRefreshToken,
   storeToken,
@@ -30,6 +31,14 @@ export interface AuthError {
 interface RefreshAccessTokenOptions {
   promptOnFailure?: boolean;
 }
+
+type RefreshAccessTokenOutcome =
+  | "success"
+  | "terminal-failure"
+  | "transient-failure";
+
+let refreshAccessTokenInFlight: Promise<RefreshAccessTokenOutcome> | null =
+  null;
 
 // Client-side login rate limiting (exponential backoff)
 const loginRateLimit = {
@@ -134,13 +143,38 @@ export async function refreshAccessToken(
   options: RefreshAccessTokenOptions = {},
 ): Promise<boolean> {
   const { promptOnFailure = true } = options;
-  const refreshToken = await getRefreshToken();
-  if (!refreshToken) {
+  if (!refreshAccessTokenInFlight) {
+    refreshAccessTokenInFlight = performRefreshAccessToken().finally(() => {
+      refreshAccessTokenInFlight = null;
+    });
+  }
+
+  const outcome = await refreshAccessTokenInFlight;
+  if (outcome === "terminal-failure") {
     clearAuthState();
     if (promptOnFailure) {
       requestSignInModal();
     }
-    return false;
+  }
+
+  return outcome === "success";
+}
+
+async function performRefreshAccessToken(): Promise<RefreshAccessTokenOutcome> {
+  if (isTauriRuntime()) {
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      const refreshed = await invoke<boolean>("refresh_session");
+      return refreshed ? "success" : "terminal-failure";
+    } catch {
+      // Network/IPC errors should not clear credentials or force a sign-in.
+      return "transient-failure";
+    }
+  }
+
+  const refreshToken = await getRefreshToken();
+  if (!refreshToken) {
+    return "terminal-failure";
   }
 
   try {
@@ -154,22 +188,19 @@ export async function refreshAccessToken(
       if (response?.status === 401) {
         await clearToken();
         await clearRefreshToken();
-        clearAuthState();
-        if (promptOnFailure) {
-          requestSignInModal();
-        }
+        return "terminal-failure";
       }
-      return false;
+      return "transient-failure";
     }
 
     await storeToken(data.data.access_token);
     if (data.data.refresh_token) {
       await storeRefreshToken(data.data.refresh_token);
     }
-    return true;
+    return "success";
   } catch {
     // Network error - don't clear tokens, don't prompt login
-    return false;
+    return "transient-failure";
   }
 }
 

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -14,6 +14,7 @@ import {
 import {
   logout as authLogout,
   createApiKey,
+  hasStoredToken,
   isLoggedIn,
 } from "@/services/auth";
 import { initializeGateway, resetGateway } from "@/services/mcp-gateway";
@@ -57,6 +58,7 @@ const [state, setState] = createStore<AuthState>({
 });
 
 let authBindingsInitialized = false;
+let authEpoch = 0;
 
 /**
  * Ensure we have a Seren API key for MCP authentication.
@@ -128,20 +130,33 @@ async function initializeMcpInBackground(): Promise<void> {
   }
 }
 
-async function loadPrivateChatPolicy(): Promise<void> {
+async function loadPrivateChatPolicy(): Promise<OrganizationPrivateChatPolicy | null> {
   try {
-    const policy = await getDefaultOrganizationPrivateChatPolicy();
-    setState("privateChatPolicy", policy);
+    return await getDefaultOrganizationPrivateChatPolicy();
   } catch (error) {
     console.warn("[Auth Store] Failed to load private chat policy:", error);
-    setState("privateChatPolicy", null);
+    return null;
   }
 }
 
-async function activateAuthenticatedSession(user?: User): Promise<void> {
-  await loadPrivateChatPolicy();
+function authEpochChanged(expectedEpoch: number | undefined): boolean {
+  return expectedEpoch !== undefined && expectedEpoch !== authEpoch;
+}
+
+async function activateAuthenticatedSession(
+  user?: User,
+  expectedEpoch?: number,
+): Promise<boolean> {
+  const privateChatPolicy = await loadPrivateChatPolicy();
+  if (authEpochChanged(expectedEpoch)) {
+    return false;
+  }
 
   const hasApiKey = await ensureApiKey();
+  if (authEpochChanged(expectedEpoch)) {
+    return false;
+  }
+
   if (!hasApiKey) {
     console.warn("[Auth Store] Could not ensure API key - MCP may not work");
   }
@@ -149,15 +164,23 @@ async function activateAuthenticatedSession(user?: User): Promise<void> {
   setState({
     ...(user !== undefined ? { user } : {}),
     isAuthenticated: true,
+    privateChatPolicy,
     signInModalRequested: false,
   });
 
   // Initialize MCP Gateway in background (non-blocking)
   void initializeMcpInBackground();
+  return true;
 }
 
-export async function restoreAuthenticatedSession(): Promise<void> {
-  await activateAuthenticatedSession();
+export async function restoreAuthenticatedSession(
+  expectedEpoch: number = authEpoch,
+): Promise<boolean> {
+  if (!(await hasStoredToken())) {
+    return false;
+  }
+
+  return activateAuthenticatedSession(undefined, expectedEpoch);
 }
 
 async function resetSkillsCatalog(): Promise<void> {
@@ -213,6 +236,8 @@ export async function setAuthenticated(user: User): Promise<void> {
  * Cleans up MCP Gateway state and stored credentials.
  */
 export async function logout(): Promise<void> {
+  authEpoch += 1;
+
   // Reset MCP Gateway state
   await resetGateway();
 
@@ -248,6 +273,7 @@ export async function logout(): Promise<void> {
  * see #1661).
  */
 export function clearAuthState(): void {
+  authEpoch += 1;
   void resetSkillsCatalog();
   setState({
     isAuthenticated: false,
@@ -294,8 +320,9 @@ export async function initAuthRuntimeBindings(): Promise<void> {
     verboseRuntimeConsole.debug(
       "[Auth Store] Token refreshed event from backend",
     );
+    const restoreEpoch = authEpoch;
     try {
-      await restoreAuthenticatedSession();
+      await restoreAuthenticatedSession(restoreEpoch);
     } catch (error) {
       console.warn(
         "[Auth Store] Failed to restore auth state after backend refresh:",

--- a/tests/unit/auth-service-refresh-login.test.ts
+++ b/tests/unit/auth-service-refresh-login.test.ts
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   clearToken: vi.fn<() => Promise<void>>(),
   clearRefreshToken: vi.fn<() => Promise<void>>(),
   clearDefaultOrganizationId: vi.fn<() => Promise<void>>(),
+  isTauriRuntime: vi.fn<() => boolean>(),
+  invoke: vi.fn(),
   clearAuthState: vi.fn<() => void>(),
   requestSignInModal: vi.fn<() => void>(),
 }));
@@ -32,6 +34,7 @@ vi.mock("@/lib/tauri-bridge", () => ({
   clearToken: mocks.clearToken,
   clearRefreshToken: mocks.clearRefreshToken,
   clearDefaultOrganizationId: mocks.clearDefaultOrganizationId,
+  isTauriRuntime: mocks.isTauriRuntime,
 }));
 
 vi.mock("@/stores/auth.store", () => ({
@@ -39,10 +42,25 @@ vi.mock("@/stores/auth.store", () => ({
   requestSignInModal: mocks.requestSignInModal,
 }));
 
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("auth service refresh during login validation", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mocks.isTauriRuntime.mockReturnValue(false);
   });
 
   it("uses a valid refresh token before declaring the user signed out", async () => {
@@ -77,6 +95,34 @@ describe("auth service refresh during login validation", () => {
     expect(mocks.storeRefreshToken).toHaveBeenCalledWith("fresh-refresh-token");
     expect(mocks.getCurrentUser).toHaveBeenCalledTimes(2);
     expect(mocks.clearToken).not.toHaveBeenCalled();
+    expect(mocks.clearAuthState).not.toHaveBeenCalled();
+    expect(mocks.requestSignInModal).not.toHaveBeenCalled();
+  });
+
+  it("shares concurrent Tauri refresh calls through one backend invoke", async () => {
+    mocks.isTauriRuntime.mockReturnValue(true);
+    const refresh = deferred<boolean>();
+    mocks.invoke.mockReturnValue(refresh.promise);
+
+    const { refreshAccessToken } = await import("@/services/auth");
+
+    const callers = [
+      refreshAccessToken(),
+      refreshAccessToken({ promptOnFailure: false }),
+      refreshAccessToken(),
+    ];
+    await vi.waitFor(() => {
+      expect(mocks.invoke).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mocks.invoke).toHaveBeenCalledTimes(1);
+    expect(mocks.invoke).toHaveBeenCalledWith("refresh_session");
+
+    refresh.resolve(true);
+
+    await expect(Promise.all(callers)).resolves.toEqual([true, true, true]);
+    expect(mocks.getRefreshToken).not.toHaveBeenCalled();
+    expect(mocks.refreshToken).not.toHaveBeenCalled();
     expect(mocks.clearAuthState).not.toHaveBeenCalled();
     expect(mocks.requestSignInModal).not.toHaveBeenCalled();
   });

--- a/tests/unit/auth-store-apikey-ordering.test.ts
+++ b/tests/unit/auth-store-apikey-ordering.test.ts
@@ -9,6 +9,7 @@ const {
   clearSerenApiKeyMock,
   isTauriRuntimeMock,
   isLoggedInMock,
+  hasStoredTokenMock,
   createApiKeyMock,
   authLogoutMock,
   initializeGatewayMock,
@@ -34,6 +35,7 @@ const {
     }),
     isTauriRuntimeMock: vi.fn(() => false),
     isLoggedInMock: vi.fn(async () => true),
+    hasStoredTokenMock: vi.fn(async () => true),
     createApiKeyMock: vi.fn(async () => "seren-api-key-fresh"),
     authLogoutMock: vi.fn(async () => {}),
     initializeGatewayMock: vi.fn(async () => {}),
@@ -59,6 +61,7 @@ vi.mock("@/lib/tauri-bridge", () => ({
 
 vi.mock("@/services/auth", () => ({
   isLoggedIn: isLoggedInMock,
+  hasStoredToken: hasStoredTokenMock,
   createApiKey: createApiKeyMock,
   logout: authLogoutMock,
 }));
@@ -117,6 +120,7 @@ describe("auth.store #1613 — API key before isAuthenticated flips", () => {
     vi.clearAllMocks();
     eventListeners.clear();
     isTauriRuntimeMock.mockReturnValue(false);
+    hasStoredTokenMock.mockResolvedValue(true);
     runtimeHasCapabilityMock.mockReturnValue(false);
     resetAuthStore();
   });

--- a/tests/unit/auth-store-refresh-epoch.test.ts
+++ b/tests/unit/auth-store-refresh-epoch.test.ts
@@ -1,0 +1,124 @@
+// ABOUTME: Regression coverage for backend auth event ordering.
+// ABOUTME: Ensures late token-refreshed handlers cannot undo session-expired state.
+
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const listeners = new Map<string, (event?: unknown) => unknown>();
+  return {
+    clearSerenApiKey: vi.fn(async () => {}),
+    getSerenApiKey: vi.fn(async () => "seren-api-key"),
+    storeSerenApiKey: vi.fn(async () => {}),
+    isTauriRuntime: vi.fn(() => true),
+    isLoggedIn: vi.fn(async () => true),
+    hasStoredToken: vi.fn(async () => true),
+    createApiKey: vi.fn(async () => "seren-api-key-fresh"),
+    authLogout: vi.fn(async () => {}),
+    initializeGateway: vi.fn(async () => {}),
+    resetGateway: vi.fn(async () => {}),
+    addSerenDbServer: vi.fn(async () => {}),
+    removeSerenDbServer: vi.fn(async () => {}),
+    runtimeHasCapability: vi.fn(() => false),
+    getPolicy: vi.fn(),
+    resetRemoteCatalog: vi.fn(),
+    eventListeners: listeners,
+    listen: vi.fn(async (event: string, handler: (event?: unknown) => unknown) => {
+      listeners.set(event, handler);
+      return vi.fn();
+    }),
+  };
+});
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  clearSerenApiKey: mocks.clearSerenApiKey,
+  getSerenApiKey: mocks.getSerenApiKey,
+  storeSerenApiKey: mocks.storeSerenApiKey,
+  isTauriRuntime: mocks.isTauriRuntime,
+}));
+
+vi.mock("@/services/auth", () => ({
+  isLoggedIn: mocks.isLoggedIn,
+  hasStoredToken: mocks.hasStoredToken,
+  createApiKey: mocks.createApiKey,
+  logout: mocks.authLogout,
+}));
+
+vi.mock("@/services/mcp-gateway", () => ({
+  initializeGateway: mocks.initializeGateway,
+  resetGateway: mocks.resetGateway,
+}));
+
+vi.mock("@/lib/mcp/serendb", () => ({
+  addSerenDbServer: mocks.addSerenDbServer,
+  removeSerenDbServer: mocks.removeSerenDbServer,
+}));
+
+vi.mock("@/lib/runtime", () => ({
+  runtimeHasCapability: mocks.runtimeHasCapability,
+}));
+
+vi.mock("@/services/organization-policy", () => ({
+  getDefaultOrganizationPrivateChatPolicy: mocks.getPolicy,
+}));
+
+vi.mock("@/stores/skills.store", () => ({
+  skillsStore: { resetRemoteCatalog: mocks.resetRemoteCatalog },
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("auth.store backend refresh event ordering", () => {
+  it("keeps session-expired state when token-refreshed resolves late", async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.eventListeners.clear();
+    mocks.isTauriRuntime.mockReturnValue(true);
+    mocks.hasStoredToken.mockResolvedValue(true);
+    mocks.runtimeHasCapability.mockReturnValue(false);
+
+    const policy = deferred<null>();
+    mocks.getPolicy.mockReturnValue(policy.promise);
+
+    const { authStore, initAuthRuntimeBindings } = await import(
+      "@/stores/auth.store"
+    );
+    (authStore as unknown as { isAuthenticated: boolean }).isAuthenticated =
+      true;
+    (
+      authStore as unknown as { signInModalRequested: boolean }
+    ).signInModalRequested = false;
+
+    await initAuthRuntimeBindings();
+
+    const onTokenRefreshed = mocks.eventListeners.get("auth:token-refreshed");
+    const onSessionExpired = mocks.eventListeners.get("auth:session-expired");
+    expect(onTokenRefreshed).toBeTypeOf("function");
+    expect(onSessionExpired).toBeTypeOf("function");
+
+    const tokenRefreshedPromise = onTokenRefreshed?.() as Promise<void>;
+    await Promise.resolve();
+
+    onSessionExpired?.();
+    expect(authStore.isAuthenticated).toBe(false);
+    expect(authStore.signInModalRequested).toBe(true);
+
+    policy.resolve(null);
+    await tokenRefreshedPromise;
+
+    expect(mocks.createApiKey).not.toHaveBeenCalled();
+    expect(authStore.isAuthenticated).toBe(false);
+    expect(authStore.signInModalRequested).toBe(true);
+  });
+});

--- a/tests/unit/compaction-auth-gate.test.ts
+++ b/tests/unit/compaction-auth-gate.test.ts
@@ -98,30 +98,40 @@ describe("#1639 — refreshAccessToken pairs clearAuthState + requestSignInModal
     );
   });
 
-  it("clears auth state AND requests the sign-in modal when no refresh token is available", () => {
+  it("maps missing refresh token to terminal failure", () => {
     const noTokenIdx = authServiceSource.indexOf("if (!refreshToken)");
     expect(noTokenIdx).toBeGreaterThan(0);
     const blockAfter = authServiceSource.slice(noTokenIdx, noTokenIdx + 200);
-    expect(blockAfter).toContain("clearAuthState()");
-    expect(blockAfter).toContain("requestSignInModal()");
+    expect(blockAfter).toContain('return "terminal-failure"');
   });
 
-  it("clears auth state AND requests the sign-in modal on 401 from refresh endpoint", () => {
+  it("maps 401 from refresh endpoint to terminal failure", () => {
     const refreshFnIdx = authServiceSource.indexOf(
-      "async function refreshAccessToken",
+      "async function performRefreshAccessToken",
     );
     const fnBody = authServiceSource.slice(refreshFnIdx, refreshFnIdx + 1400);
     const clear401Match = /response\??\.status === 401/.exec(fnBody);
     const clear401Idx = clear401Match?.index ?? -1;
     expect(clear401Idx).toBeGreaterThan(0);
     const afterClear = fnBody.slice(clear401Idx, clear401Idx + 300);
-    expect(afterClear).toContain("clearAuthState()");
-    expect(afterClear).toContain("requestSignInModal()");
+    expect(afterClear).toContain('return "terminal-failure"');
+  });
+
+  it("clears auth state AND requests the sign-in modal for terminal refresh failures", () => {
+    const refreshFnIdx = authServiceSource.indexOf(
+      "async function refreshAccessToken",
+    );
+    const fnBody = authServiceSource.slice(refreshFnIdx, refreshFnIdx + 900);
+    const terminalIdx = fnBody.indexOf('outcome === "terminal-failure"');
+    expect(terminalIdx).toBeGreaterThan(0);
+    const terminalBlock = fnBody.slice(terminalIdx, terminalIdx + 220);
+    expect(terminalBlock).toContain("clearAuthState()");
+    expect(terminalBlock).toContain("requestSignInModal()");
   });
 
   it("does NOT trigger the modal on network errors (user may be offline)", () => {
     const refreshFnIdx = authServiceSource.indexOf(
-      "async function refreshAccessToken",
+      "async function performRefreshAccessToken",
     );
     const fnBody = authServiceSource.slice(refreshFnIdx, refreshFnIdx + 1400);
     const catchBlock = fnBody.indexOf("} catch {");


### PR DESCRIPTION
Fixes #2380.

Summary:
- Serialize Tauri refresh through Rust and reuse a stored access token when another caller already rotated the refresh token.
- Route frontend refreshes through a single-flight refresh_session IPC path in Tauri, keeping SDK refresh only for the browser harness.
- Add an auth epoch guard so late auth:token-refreshed handlers cannot undo session-expired state.
- Update the existing compaction/auth source guard for the new terminal-failure flow.

Tests:
- pnpm check
- pnpm vitest run tests/unit/auth-service-refresh-login.test.ts tests/unit/auth-store-apikey-ordering.test.ts tests/unit/auth-store-refresh-epoch.test.ts
- pnpm vitest run tests/unit/compaction-auth-gate.test.ts
- pnpm test
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml auth
- cargo test --manifest-path src-tauri/Cargo.toml