### PR TITLE
Fix #2384: route audio one-shots through authenticated agents

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -223,6 +223,77 @@ async function isCommandAvailable(command) {
   }
 }
 
+function hasAnyCredentialPath(paths) {
+  return paths.some((candidate) => {
+    try {
+      return existsSync(candidate);
+    } catch {
+      return false;
+    }
+  });
+}
+
+function hasClaudeCredentials() {
+  const home = os.homedir();
+  const appData = process.env.APPDATA;
+  return hasAnyCredentialPath([
+    path.join(home, ".claude", ".credentials.json"),
+    path.join(home, ".claude.json"),
+    ...(appData
+      ? [
+          path.join(appData, "Claude", ".credentials.json"),
+          path.join(appData, "Claude", "credentials.json"),
+        ]
+      : []),
+  ]);
+}
+
+function hasCodexCredentials() {
+  const home = os.homedir();
+  const appData = process.env.APPDATA;
+  return Boolean(process.env.OPENAI_API_KEY) || hasAnyCredentialPath([
+    path.join(home, ".codex", "auth.json"),
+    path.join(home, ".codex", "credentials.json"),
+    ...(appData
+      ? [
+          path.join(appData, "Codex", "auth.json"),
+          path.join(appData, "OpenAI", "Codex", "auth.json"),
+        ]
+      : []),
+  ]);
+}
+
+function hasGeminiCredentials() {
+  const home = os.homedir();
+  const appData = process.env.APPDATA;
+  return Boolean(process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY) ||
+    hasAnyCredentialPath([
+      path.join(home, ".gemini", "oauth_creds.json"),
+      path.join(home, ".gemini", "credentials.json"),
+      ...(appData
+        ? [
+            path.join(appData, "gemini", "oauth_creds.json"),
+            path.join(appData, "Google", "Gemini", "oauth_creds.json"),
+          ]
+        : []),
+    ]);
+}
+
+function isAgentAuthenticated(agentType) {
+  switch (agentType) {
+    case "claude-code":
+      return hasClaudeCredentials();
+    case "codex":
+      return hasCodexCredentials();
+    case "gemini":
+      return hasGeminiCredentials();
+    case "claude-codex":
+      return hasClaudeCredentials() && hasCodexCredentials();
+    default:
+      return false;
+  }
+}
+
 /**
  * Resolve the path to npm-cli.js relative to the running Node.js binary.
  * This bypasses shell wrapper shims that break execFile() on macOS/Linux
@@ -690,6 +761,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
           description: "OpenAI Codex via direct App Server integration",
           command: "codex",
           available: true,
+          authenticated: isAgentAuthenticated("codex"),
           ...(installed
             ? {}
             : {
@@ -731,6 +803,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
           description: "Anthropic Claude Code via direct provider runtime",
           command: "claude",
           available: true,
+          authenticated: isAgentAuthenticated("claude-code"),
           ...(installed
             ? {}
             : {
@@ -775,6 +848,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             "Paired workflow — Claude plans and reviews, Codex executes",
           command: "claude",
           available: true,
+          authenticated: isAgentAuthenticated("claude-codex"),
           ...(missing.length === 0
             ? {}
             : {
@@ -818,6 +892,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
           description: "Google Gemini via gemini-cli (Agent Client Protocol)",
           command: "gemini",
           available: true,
+          authenticated: isAgentAuthenticated("gemini"),
           ...(installed
             ? {}
             : {
@@ -939,6 +1014,11 @@ export function createBrowserLocalAgentRegistry({ emit }) {
 
     async checkAgentAvailable(agentType) {
       return getDefinition(agentType).canSpawn();
+    },
+
+    async checkAgentAuthenticated(agentType) {
+      getDefinition(agentType);
+      return isAgentAuthenticated(agentType);
     },
 
     async ensureAgentCli(agentType) {

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -1440,6 +1440,10 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     return agentRegistry.checkAgentAvailable(agentType);
   }
 
+  async function checkAgentAuthenticated({ agentType }) {
+    return agentRegistry.checkAgentAuthenticated(agentType);
+  }
+
   async function ensureAgentCli({ agentType }) {
     return agentRegistry.ensureAgentCli(agentType);
   }
@@ -1648,6 +1652,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     respondToDiffProposal,
     getAvailableAgents,
     checkAgentAvailable,
+    checkAgentAuthenticated,
     ensureAgentCli,
     launchLogin,
     listRemoteSessions,

--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -103,6 +103,10 @@ function registerProviderHandlers() {
     "provider_check_agent_available",
     providerHandlers.checkAgentAvailable,
   );
+  registerHandler(
+    "provider_check_agent_authenticated",
+    providerHandlers.checkAgentAuthenticated,
+  );
   registerHandler("provider_ensure_agent_cli", providerHandlers.ensureAgentCli);
   registerHandler("provider_launch_login", providerHandlers.launchLogin);
   registerHandler(

--- a/src-tauri/src/audio/llm.rs
+++ b/src-tauri/src/audio/llm.rs
@@ -5,15 +5,31 @@ use serde_json::{Value, json};
 use tauri::AppHandle;
 
 use crate::orchestrator::gateway_envelope::{publisher_status, unwrap_publisher_body};
+use crate::orchestrator::provider_worker::{
+    ProviderAgentStatus, ProviderOneShotRequest, complete_oneshot, list_provider_agents,
+};
 
 const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
 const PUBLISHER_SLUG: &str = "seren-models";
+const AUTO_MODEL_ID: &str = "auto";
+const DEFAULT_SEREN_MODELS_MODEL: &str = "anthropic/claude-sonnet-4";
 
 /// A single chat-completion request routed through the user's selected model.
 pub struct CompletionRequest {
     pub model: String,
     pub system: Option<String>,
     pub prompt: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompletionRoute {
+    ProviderAgent {
+        agent_type: String,
+        model: Option<String>,
+    },
+    SerenModels {
+        model: String,
+    },
 }
 
 /// One bounded retry when the upstream returns HTTP 200 with empty content.
@@ -26,9 +42,41 @@ const COMPLETION_MAX_ATTEMPTS: u32 = 2;
 /// Run one prompt through the same Gateway chat path the app uses for chat and
 /// return the assistant's text. Non-streaming; reuses the authed Gateway bridge.
 pub async fn complete(app: &AppHandle, request: CompletionRequest) -> Result<String, String> {
-    if request.model.trim().is_empty() {
-        return Err("no model selected for completion".to_string());
+    if request.prompt.trim().is_empty() {
+        return Err("completion prompt is empty".to_string());
     }
+
+    match resolve_completion_route(app, &request.model).await {
+        CompletionRoute::ProviderAgent { agent_type, model } => {
+            complete_oneshot(
+                app,
+                ProviderOneShotRequest {
+                    agent_type,
+                    model,
+                    system: request.system,
+                    prompt: request.prompt,
+                },
+            )
+            .await
+        }
+        CompletionRoute::SerenModels { model } => {
+            complete_via_seren_models(
+                app,
+                CompletionRequest {
+                    model,
+                    system: request.system,
+                    prompt: request.prompt,
+                },
+            )
+            .await
+        }
+    }
+}
+
+async fn complete_via_seren_models(
+    app: &AppHandle,
+    request: CompletionRequest,
+) -> Result<String, String> {
     let client = reqwest::Client::new();
     let url = format!("{GATEWAY_BASE_URL}/publishers/{PUBLISHER_SLUG}/chat/completions");
 
@@ -94,4 +142,171 @@ pub async fn complete(app: &AppHandle, request: CompletionRequest) -> Result<Str
         }
     }
     Err("chat completion returned no content".to_string())
+}
+
+async fn resolve_completion_route(app: &AppHandle, requested_model: &str) -> CompletionRoute {
+    match list_provider_agents(app).await {
+        Ok(agents) => resolve_completion_route_from_agents(&agents, requested_model),
+        Err(err) => {
+            log::debug!(
+                "[audio-llm] provider agent status unavailable; using SerenModels fallback: {err}"
+            );
+            CompletionRoute::SerenModels {
+                model: seren_models_fallback_model(requested_model),
+            }
+        }
+    }
+}
+
+pub fn resolve_completion_route_from_agents(
+    agents: &[ProviderAgentStatus],
+    requested_model: &str,
+) -> CompletionRoute {
+    if let Some(agent_type) = choose_authenticated_agent(agents, requested_model) {
+        return CompletionRoute::ProviderAgent {
+            model: agent_model_for_request(&agent_type, requested_model),
+            agent_type,
+        };
+    }
+
+    CompletionRoute::SerenModels {
+        model: seren_models_fallback_model(requested_model),
+    }
+}
+
+fn choose_authenticated_agent(
+    agents: &[ProviderAgentStatus],
+    requested_model: &str,
+) -> Option<String> {
+    let is_authenticated = |agent_type: &str| {
+        agents
+            .iter()
+            .any(|agent| agent.agent_type == agent_type && agent.available && agent.authenticated)
+    };
+
+    if let Some(preferred) = preferred_agent_for_model(requested_model) {
+        if is_authenticated(preferred) {
+            return Some(preferred.to_string());
+        }
+    }
+
+    ["claude-code", "codex", "gemini"]
+        .into_iter()
+        .find(|agent_type| is_authenticated(agent_type))
+        .map(str::to_string)
+}
+
+fn preferred_agent_for_model(model: &str) -> Option<&'static str> {
+    let normalized = model.trim().to_ascii_lowercase();
+    let bare = normalized
+        .split_once('/')
+        .map(|(_, tail)| tail)
+        .unwrap_or(normalized.as_str());
+    if bare.starts_with("claude-") {
+        return Some("claude-code");
+    }
+    if bare.starts_with("gemini-") {
+        return Some("gemini");
+    }
+    if bare.starts_with("gpt-")
+        || bare.starts_with("o1")
+        || bare.starts_with("o3")
+        || bare.starts_with("o4")
+    {
+        return Some("codex");
+    }
+    None
+}
+
+fn agent_model_for_request(agent_type: &str, requested_model: &str) -> Option<String> {
+    let trimmed = requested_model.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case(AUTO_MODEL_ID) || trimmed.contains('/') {
+        return None;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let compatible = match agent_type {
+        "claude-code" => lower.starts_with("claude-"),
+        "codex" => {
+            lower.starts_with("gpt-")
+                || lower.starts_with("o1")
+                || lower.starts_with("o3")
+                || lower.starts_with("o4")
+        }
+        "gemini" => lower.starts_with("gemini-"),
+        _ => false,
+    };
+    compatible.then(|| trimmed.to_string())
+}
+
+fn seren_models_fallback_model(requested_model: &str) -> String {
+    let trimmed = requested_model.trim();
+    if is_seren_models_catalog_id(trimmed) {
+        trimmed.to_string()
+    } else {
+        DEFAULT_SEREN_MODELS_MODEL.to_string()
+    }
+}
+
+fn is_seren_models_catalog_id(model: &str) -> bool {
+    !model.is_empty() && !model.eq_ignore_ascii_case(AUTO_MODEL_ID) && model.contains('/')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(agent_type: &str, authenticated: bool) -> ProviderAgentStatus {
+        ProviderAgentStatus {
+            agent_type: agent_type.to_string(),
+            available: true,
+            authenticated,
+        }
+    }
+
+    #[test]
+    fn route_prefers_authenticated_matching_cli_agent() {
+        let agents = vec![agent("claude-code", true), agent("codex", true)];
+        assert_eq!(
+            resolve_completion_route_from_agents(&agents, "claude-opus-4-8"),
+            CompletionRoute::ProviderAgent {
+                agent_type: "claude-code".to_string(),
+                model: Some("claude-opus-4-8".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn route_falls_back_to_catalog_model_for_auto_and_cli_ids_without_auth() {
+        assert_eq!(
+            resolve_completion_route_from_agents(&[], AUTO_MODEL_ID),
+            CompletionRoute::SerenModels {
+                model: DEFAULT_SEREN_MODELS_MODEL.to_string(),
+            }
+        );
+        assert_eq!(
+            resolve_completion_route_from_agents(&[], "claude-opus-4-8"),
+            CompletionRoute::SerenModels {
+                model: DEFAULT_SEREN_MODELS_MODEL.to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn route_preserves_catalog_ids_only_on_gateway_fallback() {
+        assert_eq!(
+            resolve_completion_route_from_agents(&[], "openai/gpt-5"),
+            CompletionRoute::SerenModels {
+                model: "openai/gpt-5".to_string(),
+            }
+        );
+        let agents = vec![agent("codex", true)];
+        assert_eq!(
+            resolve_completion_route_from_agents(&agents, "openai/gpt-5"),
+            CompletionRoute::ProviderAgent {
+                agent_type: "codex".to_string(),
+                model: None,
+            }
+        );
+    }
 }

--- a/src-tauri/src/orchestrator/provider_worker.rs
+++ b/src-tauri/src/orchestrator/provider_worker.rs
@@ -3,11 +3,12 @@
 
 use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
+use serde::Deserialize;
 use serde_json::{Value, json};
 use std::sync::Arc;
 use tauri::{AppHandle, Manager};
 use tokio::sync::{Mutex, mpsc};
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message};
 
 use super::types::{ImageAttachment, RoutingDecision, WorkerEvent};
 use super::worker::Worker;
@@ -15,6 +16,29 @@ use super::worker::Worker;
 const AUTH_REQUEST_ID: i64 = 1;
 const PROMPT_REQUEST_ID: i64 = 2;
 const CANCEL_REQUEST_ID: i64 = 3;
+const LIST_AGENTS_REQUEST_ID: i64 = 4;
+const SPAWN_ONESHOT_REQUEST_ID: i64 = 5;
+const SET_MODEL_ONESHOT_REQUEST_ID: i64 = 6;
+const TERMINATE_ONESHOT_REQUEST_ID: i64 = 7;
+const SET_MODE_ONESHOT_REQUEST_ID: i64 = 8;
+
+type RuntimeSocket = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ProviderAgentStatus {
+    #[serde(rename = "type")]
+    pub agent_type: String,
+    pub available: bool,
+    #[serde(default)]
+    pub authenticated: bool,
+}
+
+pub struct ProviderOneShotRequest {
+    pub agent_type: String,
+    pub model: Option<String>,
+    pub system: Option<String>,
+    pub prompt: String,
+}
 
 pub struct ProviderRuntimeWorker {
     app: AppHandle,
@@ -56,29 +80,7 @@ impl Worker for ProviderRuntimeWorker {
 
         let state: tauri::State<'_, crate::provider_runtime::ProviderRuntimeState> =
             self.app.state();
-        let config = state.ensure_started(&self.app).await?;
-
-        let (mut socket, _response) = connect_async(config.ws_base_url.clone())
-            .await
-            .map_err(|err| format!("Failed to connect to provider runtime: {}", err))?;
-
-        socket
-            .send(Message::Text(
-                json!({
-                    "jsonrpc": "2.0",
-                    "id": AUTH_REQUEST_ID,
-                    "method": "auth",
-                    "params": { "token": config.token },
-                })
-                .to_string()
-                .into(),
-            ))
-            .await
-            .map_err(|err| format!("Failed to authenticate provider runtime socket: {}", err))?;
-
-        wait_for_response(&mut socket, AUTH_REQUEST_ID)
-            .await
-            .map(|_| ())?;
+        let mut socket = connect_authenticated_provider_socket(&self.app, &state).await?;
 
         let context = if skill_content.trim().is_empty() {
             None
@@ -201,27 +203,7 @@ impl Worker for ProviderRuntimeWorker {
 
         let state: tauri::State<'_, crate::provider_runtime::ProviderRuntimeState> =
             self.app.state();
-        let config = state.ensure_started(&self.app).await?;
-        let (mut socket, _response) = connect_async(config.ws_base_url.clone())
-            .await
-            .map_err(|err| format!("Failed to connect to provider runtime: {}", err))?;
-
-        socket
-            .send(Message::Text(
-                json!({
-                    "jsonrpc": "2.0",
-                    "id": AUTH_REQUEST_ID,
-                    "method": "auth",
-                    "params": { "token": config.token },
-                })
-                .to_string()
-                .into(),
-            ))
-            .await
-            .map_err(|err| format!("Failed to authenticate provider runtime socket: {}", err))?;
-        wait_for_response(&mut socket, AUTH_REQUEST_ID)
-            .await
-            .map(|_| ())?;
+        let mut socket = connect_authenticated_provider_socket(&self.app, &state).await?;
 
         socket
             .send(Message::Text(
@@ -245,12 +227,185 @@ impl Worker for ProviderRuntimeWorker {
     }
 }
 
-async fn wait_for_response(
-    socket: &mut tokio_tungstenite::WebSocketStream<
-        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-    >,
+pub async fn list_provider_agents(app: &AppHandle) -> Result<Vec<ProviderAgentStatus>, String> {
+    let state: tauri::State<'_, crate::provider_runtime::ProviderRuntimeState> = app.state();
+    let mut socket = connect_authenticated_provider_socket(app, &state).await?;
+    let result = provider_request(
+        &mut socket,
+        LIST_AGENTS_REQUEST_ID,
+        "provider_get_available_agents",
+        json!({}),
+    )
+    .await?;
+    serde_json::from_value(result).map_err(|err| format!("Invalid provider agent list: {err}"))
+}
+
+pub async fn complete_oneshot(
+    app: &AppHandle,
+    request: ProviderOneShotRequest,
+) -> Result<String, String> {
+    if request.agent_type.trim().is_empty() {
+        return Err("no provider agent selected for completion".to_string());
+    }
+    if request.prompt.trim().is_empty() {
+        return Err("completion prompt is empty".to_string());
+    }
+
+    let agent_type = request.agent_type.clone();
+    let state: tauri::State<'_, crate::provider_runtime::ProviderRuntimeState> = app.state();
+    let mut socket = connect_authenticated_provider_socket(app, &state).await?;
+    let local_session_id = format!("oneshot-{}", uuid::Uuid::new_v4());
+    let cwd = provider_oneshot_cwd(app)?;
+
+    let mut spawn_params = json!({
+        "agentType": agent_type,
+        "localSessionId": local_session_id,
+        "cwd": cwd,
+        "apiKey": Value::Null,
+        "mcpServers": [],
+        "approvalPolicy": "on-request",
+        "sandboxMode": "read-only",
+        "networkEnabled": false,
+        "timeoutSecs": 180,
+    });
+    if agent_type == "claude-code" {
+        if let Some(model) = request
+            .model
+            .as_deref()
+            .filter(|model| !model.trim().is_empty())
+        {
+            spawn_params["initialModelId"] = json!(model);
+        }
+    }
+
+    let spawn_result = provider_request(
+        &mut socket,
+        SPAWN_ONESHOT_REQUEST_ID,
+        "provider_spawn",
+        spawn_params,
+    )
+    .await?;
+    let session_id = spawn_result
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .ok_or_else(|| "provider one-shot spawn returned no session id".to_string())?
+        .to_string();
+
+    let completion_result = async {
+        provider_request(
+            &mut socket,
+            SET_MODE_ONESHOT_REQUEST_ID,
+            "provider_set_permission_mode",
+            json!({
+                "sessionId": session_id,
+                "mode": provider_oneshot_permission_mode(&agent_type),
+            }),
+        )
+        .await?;
+
+        if agent_type != "gemini" {
+            if let Some(model) = request
+                .model
+                .as_deref()
+                .filter(|model| !model.trim().is_empty())
+            {
+                provider_request(
+                    &mut socket,
+                    SET_MODEL_ONESHOT_REQUEST_ID,
+                    "provider_set_session_model",
+                    json!({
+                        "sessionId": session_id,
+                        "modelId": model,
+                    }),
+                )
+                .await?;
+            }
+        }
+
+        collect_provider_prompt(
+            &mut socket,
+            &session_id,
+            &build_provider_prompt(request.system.as_deref(), &request.prompt),
+        )
+        .await
+    }
+    .await;
+
+    if let Err(err) = provider_request(
+        &mut socket,
+        TERMINATE_ONESHOT_REQUEST_ID,
+        "provider_terminate",
+        json!({ "sessionId": session_id }),
+    )
+    .await
+    {
+        log::warn!("[provider-one-shot] failed to terminate ephemeral session: {err}");
+    }
+
+    let content = completion_result?;
+    if content.trim().is_empty() {
+        return Err("provider one-shot returned no content".to_string());
+    }
+    Ok(content)
+}
+
+async fn connect_authenticated_provider_socket(
+    app: &AppHandle,
+    state: &tauri::State<'_, crate::provider_runtime::ProviderRuntimeState>,
+) -> Result<RuntimeSocket, String> {
+    let config = state.ensure_started(app).await?;
+
+    let (mut socket, _response) = connect_async(config.ws_base_url.clone())
+        .await
+        .map_err(|err| format!("Failed to connect to provider runtime: {}", err))?;
+
+    socket
+        .send(Message::Text(
+            json!({
+                "jsonrpc": "2.0",
+                "id": AUTH_REQUEST_ID,
+                "method": "auth",
+                "params": { "token": config.token },
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .map_err(|err| format!("Failed to authenticate provider runtime socket: {}", err))?;
+
+    wait_for_response(&mut socket, AUTH_REQUEST_ID)
+        .await
+        .map(|_| ())?;
+    Ok(socket)
+}
+
+async fn provider_request(
+    socket: &mut RuntimeSocket,
     request_id: i64,
+    method: &str,
+    params: Value,
 ) -> Result<Value, String> {
+    socket
+        .send(Message::Text(
+            json!({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .map_err(|err| format!("Failed to send provider runtime request {method}: {err}"))?;
+
+    wait_for_response(socket, request_id)
+        .await
+        .map(|payload| payload.get("result").cloned().unwrap_or(Value::Null))
+}
+
+async fn wait_for_response(socket: &mut RuntimeSocket, request_id: i64) -> Result<Value, String> {
     while let Some(message) = socket.next().await {
         let message = message.map_err(|err| format!("Provider runtime socket error: {}", err))?;
         let Message::Text(text) = message else {
@@ -272,6 +427,123 @@ async fn wait_for_response(
     }
 
     Err("Provider runtime socket closed before response.".to_string())
+}
+
+async fn collect_provider_prompt(
+    socket: &mut RuntimeSocket,
+    session_id: &str,
+    prompt: &str,
+) -> Result<String, String> {
+    socket
+        .send(Message::Text(
+            json!({
+                "jsonrpc": "2.0",
+                "id": PROMPT_REQUEST_ID,
+                "method": "provider_prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": prompt,
+                    "context": Value::Null,
+                },
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .map_err(|err| format!("Failed to send provider prompt: {err}"))?;
+
+    let mut content = String::new();
+    while let Some(message) = socket.next().await {
+        let message = message.map_err(|err| format!("Provider runtime socket error: {}", err))?;
+        let Message::Text(text) = message else {
+            continue;
+        };
+        let payload: Value = serde_json::from_str(&text)
+            .map_err(|err| format!("Invalid provider runtime payload: {}", err))?;
+
+        if let Some(id) = payload.get("id").and_then(|value| value.as_i64()) {
+            if id != PROMPT_REQUEST_ID {
+                continue;
+            }
+            if let Some(error_message) = response_error_message(&payload) {
+                return Err(error_message);
+            }
+            return Ok(content);
+        }
+
+        if payload.get("id").is_some() || payload.get("method").is_none() {
+            continue;
+        }
+        let method = payload
+            .get("method")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if !method.starts_with("provider://") {
+            continue;
+        }
+        let params = payload.get("params").cloned().unwrap_or(Value::Null);
+        if event_session_id(&params) != Some(session_id) {
+            continue;
+        }
+
+        match method {
+            "provider://message-chunk" => {
+                if params
+                    .get("isThought")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                if let Some(text) = params.get("text").and_then(Value::as_str) {
+                    content.push_str(text);
+                }
+            }
+            "provider://prompt-complete" => {}
+            "provider://tool-call" => {
+                return Err(
+                    "provider one-shot attempted a tool call; toolless completion aborted"
+                        .to_string(),
+                );
+            }
+            "provider://error" => {
+                return Err(params
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Local provider runtime error.")
+                    .to_string());
+            }
+            _ => {}
+        }
+    }
+
+    Err("Provider runtime socket closed before prompt completed.".to_string())
+}
+
+fn build_provider_prompt(system: Option<&str>, prompt: &str) -> String {
+    match system.map(str::trim).filter(|system| !system.is_empty()) {
+        Some(system) => format!("{system}\n\n{prompt}"),
+        None => prompt.to_string(),
+    }
+}
+
+fn provider_oneshot_cwd(app: &AppHandle) -> Result<String, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|err| format!("Failed to resolve app data dir: {err}"))?
+        .join("provider-oneshot");
+    std::fs::create_dir_all(&dir)
+        .map_err(|err| format!("Failed to create provider one-shot dir: {err}"))?;
+    Ok(dir.to_string_lossy().to_string())
+}
+
+fn provider_oneshot_permission_mode(agent_type: &str) -> &'static str {
+    match agent_type {
+        "claude-code" | "gemini" => "plan",
+        "codex" => "ask",
+        _ => "ask",
+    }
 }
 
 fn response_error_message(payload: &Value) -> Option<String> {

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -71,6 +71,7 @@ export interface AgentInfo {
   description: string;
   command: string;
   available: boolean;
+  authenticated?: boolean;
   unavailableReason?: string;
 }
 
@@ -636,6 +637,17 @@ export async function checkAgentAvailable(
   agentType: AgentType,
 ): Promise<boolean> {
   return invokeProvider<boolean>("provider_check_agent_available", {
+    agentType,
+  });
+}
+
+/**
+ * Check whether a specific agent has local subscription credentials available.
+ */
+export async function checkAgentAuthenticated(
+  agentType: AgentType,
+): Promise<boolean> {
+  return invokeProvider<boolean>("provider_check_agent_authenticated", {
     agentType,
   });
 }

--- a/tests/unit/provider-agent-auth-status.test.ts
+++ b/tests/unit/provider-agent-auth-status.test.ts
@@ -1,0 +1,27 @@
+// ABOUTME: Guards the provider runtime auth-status surface used by backend one-shot routing.
+// ABOUTME: Prevents regressions where install availability is mistaken for CLI subscription login.
+
+import { readSource } from "./source-text";
+import { describe, expect, it } from "vitest";
+
+const registrySource = readSource("bin/browser-local/agent-registry.mjs");
+const runtimeSource = readSource("bin/provider-runtime.mjs");
+const providersSource = readSource("bin/browser-local/providers.mjs");
+const providerServiceSource = readSource("src/services/providers.ts");
+
+describe("provider agent authentication status", () => {
+  it("reports authenticated separately from availability", () => {
+    expect(registrySource).toContain("function isAgentAuthenticated(agentType)");
+    expect(registrySource).toContain("authenticated: isAgentAuthenticated");
+    expect(registrySource).toContain('path.join(home, ".claude", ".credentials.json")');
+    expect(registrySource).toContain('path.join(home, ".codex", "auth.json")');
+    expect(registrySource).toContain('path.join(home, ".gemini", "oauth_creds.json")');
+  });
+
+  it("exposes a provider_check_agent_authenticated RPC", () => {
+    expect(runtimeSource).toContain("provider_check_agent_authenticated");
+    expect(providersSource).toContain("checkAgentAuthenticated({ agentType })");
+    expect(providerServiceSource).toContain("authenticated?: boolean");
+    expect(providerServiceSource).toContain("provider_check_agent_authenticated");
+  });
+});


### PR DESCRIPTION
Fixes #2384.

Audit results:
- Confirmed the notes/dictation/edit-by-voice path shared `audio::llm::complete` and sent raw picker model IDs to `seren-models`.
- Added the missing auth-status signal so routing is based on local CLI credentials, not binary availability.
- Added a P1 safety fix discovered during implementation: backend one-shots now spawn without MCP credentials, use read-only/request permission modes, and abort if a tool call is attempted.

Implementation:
- Adds a provider-runtime one-shot primitive with authenticated websocket RPC, ephemeral session spawn, non-thought chunk accumulation, and best-effort termination.
- Routes completion requests to an authenticated Claude/Codex/Gemini CLI when available.
- Falls back to `seren-models` only with a catalog-style model ID; `auto` and bare CLI IDs are normalized to a known catalog model.

Verification:
- `cargo test --manifest-path src-tauri/Cargo.toml audio::llm --lib`
- `pnpm vitest run tests/unit/provider-agent-auth-status.test.ts`
- `node --check bin/provider-runtime.mjs && node --check bin/browser-local/providers.mjs && node --check bin/browser-local/agent-registry.mjs`
- Provider-runtime RPC smoke: `provider_get_available_agents` + `provider_check_agent_authenticated` returned expected shapes.
