### PR TITLE
fix(windows): support unsigned PR app e2e runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1110,19 +1110,34 @@ jobs:
             scripts/windows-e2e-app.ps1 \
             scripts/windows-e2e-app.mjs
           prefix="release-windows-e2e/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
-          aws s3 cp "$installer" "s3://${WINDOWS_E2E_S3_BUCKET}/${prefix}/SerenDesktop-setup.exe"
-          aws s3 cp "$payload" "s3://${WINDOWS_E2E_S3_BUCKET}/${prefix}/windows-e2e-payload.zip"
+          installer_s3="s3://${WINDOWS_E2E_S3_BUCKET}/${prefix}/SerenDesktop-setup.exe"
+          payload_s3="s3://${WINDOWS_E2E_S3_BUCKET}/${prefix}/windows-e2e-payload.zip"
+          aws s3 cp "$installer" "$installer_s3"
+          aws s3 cp "$payload" "$payload_s3"
+          installer_url="$(aws s3 presign "$installer_s3" --expires-in 7200)"
+          payload_url="$(aws s3 presign "$payload_s3" --expires-in 7200)"
           echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
+          {
+            echo "installer_url<<EOF"
+            echo "$installer_url"
+            echo "EOF"
+            echo "payload_url<<EOF"
+            echo "$payload_url"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run full Windows app e2e on AWS host
         id: ssm
         shell: bash
         env:
           S3_PREFIX: ${{ steps.stage.outputs.prefix }}
+          INSTALLER_URL: ${{ steps.stage.outputs.installer_url }}
+          PAYLOAD_URL: ${{ steps.stage.outputs.payload_url }}
         run: |
           set -euo pipefail
           node <<'NODE' > "$RUNNER_TEMP/windows-e2e-commands.json"
           const env = process.env;
+          const psString = (value) => `'${String(value).replaceAll("'", "''")}'`;
           const secretNames = [
             "SEREN_E2E_EMAIL",
             "SEREN_E2E_PASSWORD",
@@ -1136,17 +1151,18 @@ jobs:
             "SEREN_E2E_AGENT_TYPE",
             "SEREN_E2E_AGENT_CWD",
           ];
+          if (!env.INSTALLER_URL || !env.PAYLOAD_URL) {
+            throw new Error("Missing presigned Windows e2e payload URL(s)");
+          }
           const workName = `seren-release-windows-e2e-${env.GITHUB_RUN_ID}-${env.GITHUB_RUN_ATTEMPT}`;
-          const installerS3 = `s3://${env.WINDOWS_E2E_S3_BUCKET}/${env.S3_PREFIX}/SerenDesktop-setup.exe`;
-          const payloadS3 = `s3://${env.WINDOWS_E2E_S3_BUCKET}/${env.S3_PREFIX}/windows-e2e-payload.zip`;
           const commands = [
             "$ErrorActionPreference = 'Stop'",
             "$ProgressPreference = 'SilentlyContinue'",
             `$work = Join-Path $env:TEMP '${workName}'`,
             "if (Test-Path $work) { Remove-Item -LiteralPath $work -Recurse -Force }",
             "New-Item -ItemType Directory -Force -Path $work | Out-Null",
-            `aws s3 cp '${installerS3}' (Join-Path $work 'SerenDesktop-setup.exe')`,
-            `aws s3 cp '${payloadS3}' (Join-Path $work 'windows-e2e-payload.zip')`,
+            `Invoke-WebRequest -Uri ${psString(env.INSTALLER_URL)} -OutFile (Join-Path $work 'SerenDesktop-setup.exe')`,
+            `Invoke-WebRequest -Uri ${psString(env.PAYLOAD_URL)} -OutFile (Join-Path $work 'windows-e2e-payload.zip')`,
             "Expand-Archive -LiteralPath (Join-Path $work 'windows-e2e-payload.zip') -DestinationPath $work -Force",
             `$secretNames = @(${secretNames.map((name) => `'${name}'`).join(",")})`,
             // The aws call runs under Windows PowerShell 5.1, where native
@@ -1157,6 +1173,7 @@ jobs:
             // skip they were designed for.
             `foreach ($name in $secretNames) { $parameterName = '${env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX}/' + $name; $value = & { $ErrorActionPreference = 'Continue'; aws ssm get-parameter --with-decryption --name $parameterName --query 'Parameter.Value' --output text 2>$null }; if ($LASTEXITCODE -eq 0 -and $value -and $value -ne 'None') { [Environment]::SetEnvironmentVariable($name, $value, 'Process') } }`,
             "[Environment]::SetEnvironmentVariable('SEREN_E2E_API_BASE', 'https://api.serendb.com', 'Process')",
+            "[Environment]::SetEnvironmentVariable('SEREN_E2E_RELEASE_RUN', '1', 'Process')",
             "Set-Location $work",
             "corepack enable",
             "corepack prepare pnpm@9 --activate",

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -2,11 +2,15 @@ param(
   [Parameter(Mandatory = $true)]
   [string]$InstallerPath,
 
+  [switch]$AllowUnsignedPrArtifact,
+
   [int]$RemoteDebugPort = 9222,
 
   [string]$InstallDir = (Join-Path $env:LOCALAPPDATA "SerenDesktopE2E"),
 
-  [int]$StartupTimeoutSeconds = 120
+  [int]$StartupTimeoutSeconds = 120,
+
+  [int]$InstallerTimeoutSeconds = 180
 )
 
 $ErrorActionPreference = "Stop"
@@ -36,9 +40,77 @@ function Require-ValidSignature([string]$Path, [string]$Label) {
   }
   $signature = Get-AuthenticodeSignature -LiteralPath $Path
   if ($signature.Status -ne "Valid") {
-    Fail "$Label is not validly Authenticode signed. Status=$($signature.Status) Subject=$($signature.SignerCertificate.Subject)"
+    $subject = if ($null -ne $signature.SignerCertificate) { $signature.SignerCertificate.Subject } else { "<none>" }
+    Fail "$Label is not validly Authenticode signed. Status=$($signature.Status) Subject=$subject"
   }
   Write-Host "$Label signature valid: $Path"
+}
+
+function Require-SignedOrExplicitPrArtifact([string]$Path, [string]$Label) {
+  if (-not $AllowUnsignedPrArtifact) {
+    Require-ValidSignature $Path $Label
+    return
+  }
+
+  if ($env:SEREN_E2E_UNSIGNED_PR_RUN -ne "1") {
+    Fail "-AllowUnsignedPrArtifact requires SEREN_E2E_UNSIGNED_PR_RUN=1 so release signature checks cannot be bypassed accidentally."
+  }
+  if ($env:SEREN_E2E_RELEASE_RUN -eq "1" -or $env:GITHUB_REF -like "refs/tags/v*") {
+    Fail "-AllowUnsignedPrArtifact is forbidden for release Windows e2e runs."
+  }
+  if (-not (Test-Path -LiteralPath $Path)) {
+    Fail "$Label not found: $Path"
+  }
+
+  Write-Host "::warning::$Label Authenticode validation skipped for explicit unsigned PR artifact run: $Path"
+}
+
+function Clear-DownloadMark([string]$Path, [string]$Label) {
+  if (-not (Test-Path -LiteralPath $Path)) {
+    Fail "$Label not found: $Path"
+  }
+  try {
+    Unblock-File -LiteralPath $Path -ErrorAction Stop
+    Write-Host "Cleared download mark for ${Label}: $Path"
+  } catch {
+    Write-Host "::warning::Unable to clear download mark for ${Label}: $($_.Exception.Message)"
+  }
+}
+
+function Clear-DownloadMarksUnder([string]$Root) {
+  if (-not (Test-Path -LiteralPath $Root)) {
+    return
+  }
+  Get-ChildItem -Path $Root -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
+    try {
+      Unblock-File -LiteralPath $_.FullName -ErrorAction Stop
+    } catch {
+      Write-Host "::warning::Unable to clear download mark for installed file $($_.FullName): $($_.Exception.Message)"
+    }
+  }
+}
+
+function Invoke-ProcessWithTimeout([string]$FilePath, [string[]]$ArgumentList, [int]$TimeoutSeconds, [string]$Label) {
+  $process = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -PassThru
+  $timeoutMs = [int]([Math]::Min([int]::MaxValue, [int64]$TimeoutSeconds * 1000))
+  if (-not $process.WaitForExit($timeoutMs)) {
+    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+    Fail "$Label timed out after ${TimeoutSeconds}s and was killed."
+  }
+  return $process.ExitCode
+}
+
+function Write-DirectorySnapshot([string]$Root) {
+  if (-not (Test-Path -LiteralPath $Root)) {
+    Write-Host "Install directory does not exist: $Root"
+    return
+  }
+  Write-Host "Install directory snapshot for ${Root}:"
+  Get-ChildItem -Path $Root -Recurse -Force -ErrorAction SilentlyContinue |
+    Select-Object -First 80 FullName, Length, LastWriteTime |
+    Format-Table -AutoSize |
+    Out-String |
+    Write-Host
 }
 
 function Wait-ForCdp([int]$Port, [int]$TimeoutSeconds) {
@@ -85,7 +157,8 @@ $env:SEREN_E2E_API_BASE = "https://api.serendb.com"
 $env:SEREN_E2E_CDP_ENDPOINT = "http://127.0.0.1:$RemoteDebugPort"
 
 $resolvedInstaller = (Resolve-Path -LiteralPath $InstallerPath).Path
-Require-ValidSignature $resolvedInstaller "Windows NSIS installer"
+Clear-DownloadMark $resolvedInstaller "Windows NSIS installer"
+Require-SignedOrExplicitPrArtifact $resolvedInstaller "Windows NSIS installer"
 
 Get-Process -Name "Seren" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 if (Test-Path -LiteralPath $InstallDir) {
@@ -95,16 +168,20 @@ New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
 Write-Host "Installing SerenDesktop into $InstallDir"
 $installArgs = @("/S", "/D=$InstallDir")
-$install = Start-Process -FilePath $resolvedInstaller -ArgumentList $installArgs -Wait -PassThru
-if ($install.ExitCode -ne 0) {
-  Fail "NSIS installer exited with $($install.ExitCode)"
+$installExitCode = Invoke-ProcessWithTimeout $resolvedInstaller $installArgs $InstallerTimeoutSeconds "NSIS installer"
+if ($installExitCode -ne 0) {
+  Fail "NSIS installer exited with $installExitCode"
+}
+if ($AllowUnsignedPrArtifact) {
+  Clear-DownloadMarksUnder $InstallDir
 }
 
 $appExe = Join-Path $InstallDir "Seren.exe"
 if (-not (Test-Path -LiteralPath $appExe)) {
+  Write-DirectorySnapshot $InstallDir
   $appExe = Find-RequiredFile $InstallDir "Seren.exe" "Seren.exe"
 }
-Require-ValidSignature $appExe "Installed Seren.exe"
+Require-SignedOrExplicitPrArtifact $appExe "Installed Seren.exe"
 
 $runtimeRoot = Join-Path $InstallDir "embedded-runtime"
 if (-not (Test-Path -LiteralPath $runtimeRoot)) {

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -68,12 +68,29 @@ describe("Windows production e2e release gate", () => {
   it("installs and probes the signed Windows app instead of running a browser mock", () => {
     expect(runner).toContain("Get-AuthenticodeSignature");
     expect(runner).toContain("/S");
+    expect(runner).toContain("Unblock-File");
+    expect(runner).toContain("InstallerTimeoutSeconds");
+    expect(runner).toContain("WaitForExit");
     expect(runner).toContain("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS");
     expect(runner).toContain("node.exe");
     expect(runner).toContain("npm.cmd");
     expect(runner).toContain("windows-e2e-app.mjs");
     expect(probe).toContain("connectOverCDP");
     expect(probe).toContain("__TAURI_INTERNALS__");
+  });
+
+  it("keeps unsigned PR artifact mode explicit and forbidden for release runs", () => {
+    expect(runner).toContain("[switch]$AllowUnsignedPrArtifact");
+    expect(runner).toContain("SEREN_E2E_UNSIGNED_PR_RUN");
+    expect(runner).toContain("SEREN_E2E_RELEASE_RUN");
+    expect(runner).toContain("is forbidden for release Windows e2e runs");
+
+    const releaseGate = workflowJob("windows-app-e2e");
+    expect(releaseGate).toContain("aws s3 presign");
+    expect(releaseGate).toContain("Invoke-WebRequest -Uri");
+    expect(releaseGate).toContain("SEREN_E2E_RELEASE_RUN");
+    expect(releaseGate).not.toContain("-AllowUnsignedPrArtifact");
+    expect(releaseGate).not.toContain("SEREN_E2E_UNSIGNED_PR_RUN");
   });
 
   it("covers the required production journeys", () => {


### PR DESCRIPTION
## Summary

Closes #2382.

Audit found two P1 blockers in the Windows app e2e path:

- Unsigned PR artifacts could only be tested by patching out Authenticode assertions, which risked weakening the signed-release gate.
- The AWS host downloaded staged payloads with direct `aws s3 cp`, but the issue's manual run already observed `403` from the instance role.

This PR keeps release validation signed by default, adds an explicit unsigned-PR mode guarded by `SEREN_E2E_UNSIGNED_PR_RUN=1`, rejects that mode for release runs, clears MOTW/download marks before install and launch, adds an NSIS install timeout with diagnostics, and switches release SSM staging to presigned payload URLs.

## Tests

- `pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts`
- `pwsh -NoProfile -Command '[System.Management.Automation.Language.Parser]::ParseFile(...)'`
- `python3` YAML parse of `.github/workflows/release.yml`
- `git diff --check`

## Follow-up validation

After CI produces the unsigned Windows PR artifact, run the AWS Windows host walk-through with `-AllowUnsignedPrArtifact` and `SEREN_E2E_UNSIGNED_PR_RUN=1`.
