### PR TITLE
fix(memory): refresh Claude auto-memory index

### DIFF
--- a/src-tauri/src/claude_memory.rs
+++ b/src-tauri/src/claude_memory.rs
@@ -2,7 +2,7 @@
 // ABOUTME: Watches ~/.claude/projects/*/memory/ and INSERTs each file as a row in
 // ABOUTME: claude_agent_preferences. Storage is a separate SerenDB project from user memory.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -86,6 +86,8 @@ pub struct InterceptSuccessEvent {
     pub path: String,
     pub name: Option<String>,
     pub memory_type: String,
+    pub rendered_memory_md: Option<String>,
+    pub render_error: Option<String>,
 }
 
 /// Event emitted when the cloud write fails; the file is left on disk so the
@@ -156,7 +158,13 @@ pub fn encode_project_dir(cwd: &Path) -> String {
     let sanitized = resolved.trim_start_matches('/').replace(':', "");
     let normalized: String = sanitized
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect();
     format!("-{normalized}")
 }
@@ -351,7 +359,11 @@ pub fn parse_memory_file(contents: &str) -> ParsedMemoryFile {
         }
         if let Some((key, value)) = line.split_once(':') {
             let key = key.trim().to_lowercase();
-            let value = value.trim().trim_matches('"').trim_matches('\'').to_string();
+            let value = value
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string();
             if !value.is_empty() {
                 map.insert(key, value);
             }
@@ -444,7 +456,7 @@ pub fn build_select_preferences_sql(project_path: &str) -> String {
 // MEMORY.md rendering
 // ---------------------------------------------------------------------------
 
-/// Atomically refresh `MEMORY.md` so its auto-index reflects the latest
+/// Atomically refresh `memory/MEMORY.md` so its auto-index reflects the latest
 /// SerenDB rows while preserving any hand-curated content the user wrote
 /// outside the marker block.
 ///
@@ -463,10 +475,11 @@ pub fn write_rendered_memory_md(
     claude_project_dir: &Path,
     auto_index_body: &str,
 ) -> Result<PathBuf, String> {
-    fs::create_dir_all(claude_project_dir)
-        .map_err(|e| format!("failed to create claude project dir: {e}"))?;
+    let memory_dir = claude_project_dir.join("memory");
+    fs::create_dir_all(&memory_dir)
+        .map_err(|e| format!("failed to create claude memory dir: {e}"))?;
 
-    let final_path = claude_project_dir.join(RENDERED_INDEX_FILENAME);
+    let final_path = memory_dir.join(RENDERED_INDEX_FILENAME);
     let block = format!(
         "{AUTO_INDEX_BEGIN}\n{}\n{AUTO_INDEX_END}",
         auto_index_body.trim_matches('\n')
@@ -477,11 +490,9 @@ pub fn write_rendered_memory_md(
         Err(_) => format!("# Claude Memory\n\n{block}\n"),
     };
 
-    let tmp_path = claude_project_dir.join(format!("{RENDERED_INDEX_FILENAME}.tmp"));
-    fs::write(&tmp_path, &merged)
-        .map_err(|e| format!("failed to write temp MEMORY.md: {e}"))?;
-    fs::rename(&tmp_path, &final_path)
-        .map_err(|e| format!("failed to finalize MEMORY.md: {e}"))?;
+    let tmp_path = memory_dir.join(format!("{RENDERED_INDEX_FILENAME}.tmp"));
+    fs::write(&tmp_path, &merged).map_err(|e| format!("failed to write temp MEMORY.md: {e}"))?;
+    fs::rename(&tmp_path, &final_path).map_err(|e| format!("failed to finalize MEMORY.md: {e}"))?;
     Ok(final_path)
 }
 
@@ -519,7 +530,10 @@ pub fn render_preferences_as_markdown(rows: &[Vec<serde_json::Value>]) -> String
     let mut sections: BTreeMap<String, Vec<(String, String, String)>> = BTreeMap::new();
     for row in rows {
         let pref_key = row.first().and_then(|v| v.as_str()).unwrap_or("");
-        let pref_type = row.get(1).and_then(|v| v.as_str()).unwrap_or("uncategorized");
+        let pref_type = row
+            .get(1)
+            .and_then(|v| v.as_str())
+            .unwrap_or("uncategorized");
         let description = row.get(2).and_then(|v| v.as_str()).unwrap_or("");
         let source_file = row
             .get(4)
@@ -527,10 +541,11 @@ pub fn render_preferences_as_markdown(rows: &[Vec<serde_json::Value>]) -> String
             .filter(|s| !s.is_empty())
             .map(String::from)
             .unwrap_or_else(|| format!("{pref_key}.md"));
-        sections
-            .entry(pref_type.to_string())
-            .or_default()
-            .push((pref_key.to_string(), source_file, description.to_string()));
+        sections.entry(pref_type.to_string()).or_default().push((
+            pref_key.to_string(),
+            source_file,
+            description.to_string(),
+        ));
     }
 
     let mut out = String::new();
@@ -545,7 +560,9 @@ pub fn render_preferences_as_markdown(rows: &[Vec<serde_json::Value>]) -> String
             if description.is_empty() {
                 out.push_str(&format!("- [{source_file}]({source_file})\n"));
             } else {
-                out.push_str(&format!("- [{source_file}]({source_file}) — {description}\n"));
+                out.push_str(&format!(
+                    "- [{source_file}]({source_file}) — {description}\n"
+                ));
             }
         }
     }
@@ -697,8 +714,8 @@ pub async fn process_memory_file(
         return Ok(ProcessOutcome::Skipped);
     }
 
-    let contents = fs::read_to_string(path)
-        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    let contents =
+        fs::read_to_string(path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
     if contents.trim().is_empty() {
         return Ok(ProcessOutcome::Skipped);
     }
@@ -744,7 +761,7 @@ pub async fn process_memory_file(
     })
 }
 
-/// Render `MEMORY.md` for a given Claude project directory by SELECTing all
+/// Render `memory/MEMORY.md` for a given Claude project directory by SELECTing all
 /// preference rows from SerenDB and formatting them as Markdown.
 pub async fn render_memory_md_from_db(
     client: &SerenDbSqlClient,
@@ -947,25 +964,34 @@ async fn handle_event(app: &AppHandle, path: PathBuf, config: &SerenDbConfig) {
                 path.display()
             );
 
+            let mut rendered_memory_md = None;
+            let mut render_error = None;
+
             // Refresh MEMORY.md so the agent that wrote this file can see
             // its entry appear in the index — closing the feedback gap that
             // caused the "memory write vanished" loop. Failures here MUST
             // NOT mask the successful intercept (the row is already in
             // SerenDB); we only log them.
             if let Some(claude_project_dir) = claude_project_dir_for_memory_file(&path) {
-                if let Err(e) =
-                    render_memory_md_from_db(&client, config, &claude_project_dir).await
-                {
-                    log::warn!(
-                        "[ClaudeMemory] persisted {} but MEMORY.md refresh failed: {e}",
-                        path.display()
-                    );
+                match render_memory_md_from_db(&client, config, &claude_project_dir).await {
+                    Ok(rendered_path) => {
+                        rendered_memory_md = Some(rendered_path.to_string_lossy().to_string());
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "[ClaudeMemory] persisted {} but MEMORY.md refresh failed: {e}",
+                            path.display()
+                        );
+                        render_error = Some(e);
+                    }
                 }
             } else {
-                log::warn!(
+                let message = format!(
                     "[ClaudeMemory] persisted {} but could not derive claude project dir for MEMORY.md refresh",
                     path.display()
                 );
+                log::warn!("{message}");
+                render_error = Some(message);
             }
 
             let _ = app.emit(
@@ -974,6 +1000,8 @@ async fn handle_event(app: &AppHandle, path: PathBuf, config: &SerenDbConfig) {
                     path: path.to_string_lossy().to_string(),
                     name,
                     memory_type,
+                    rendered_memory_md,
+                    render_error,
                 },
             );
         }
@@ -1014,8 +1042,9 @@ pub async fn migrate_existing_files(
     }
 
     let mut report = MigrationReport::default();
-    let project_dirs = fs::read_dir(&root)
-        .map_err(|e| format!("failed to read claude projects root: {e}"))?;
+    let mut projects_to_render = BTreeSet::new();
+    let project_dirs =
+        fs::read_dir(&root).map_err(|e| format!("failed to read claude projects root: {e}"))?;
 
     for entry in project_dirs.flatten() {
         let memory_dir = entry.path().join("memory");
@@ -1032,7 +1061,18 @@ pub async fn migrate_existing_files(
                 continue;
             }
             match process_memory_file(&path, &client, config).await {
-                Ok(ProcessOutcome::Persisted { .. }) => report.persisted += 1,
+                Ok(ProcessOutcome::Persisted { .. }) => {
+                    report.persisted += 1;
+                    if let Some(claude_project_dir) = claude_project_dir_for_memory_file(&path) {
+                        projects_to_render.insert(claude_project_dir);
+                    } else {
+                        report.render_failures += 1;
+                        log::warn!(
+                            "[ClaudeMemory] migration persisted {} but could not derive claude project dir for MEMORY.md refresh",
+                            path.display()
+                        );
+                    }
+                }
                 Ok(ProcessOutcome::Skipped) => {}
                 Err(e) => {
                     log::warn!(
@@ -1045,10 +1085,28 @@ pub async fn migrate_existing_files(
         }
     }
 
+    for claude_project_dir in projects_to_render {
+        match render_memory_md_from_db(&client, config, &claude_project_dir).await {
+            Ok(path) => {
+                report.rendered += 1;
+                log::info!("[ClaudeMemory] migration refreshed {}", path.display());
+            }
+            Err(e) => {
+                report.render_failures += 1;
+                log::warn!(
+                    "[ClaudeMemory] migration could not refresh MEMORY.md for {}: {e}",
+                    claude_project_dir.display()
+                );
+            }
+        }
+    }
+
     log::info!(
-        "[ClaudeMemory] migration finished: persisted={} failures={}",
+        "[ClaudeMemory] migration finished: persisted={} failures={} rendered={} render_failures={}",
         report.persisted,
-        report.failures
+        report.failures,
+        report.rendered,
+        report.render_failures
     );
     Ok(report)
 }
@@ -1057,6 +1115,8 @@ pub async fn migrate_existing_files(
 pub struct MigrationReport {
     pub persisted: usize,
     pub failures: usize,
+    pub rendered: usize,
+    pub render_failures: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -1227,7 +1287,10 @@ mod tests {
     #[test]
     fn derive_pref_key_strips_md_extension() {
         let path = Path::new("/some/dir/feedback_smoke_test.md");
-        assert_eq!(derive_pref_key(path), Some("feedback_smoke_test".to_string()));
+        assert_eq!(
+            derive_pref_key(path),
+            Some("feedback_smoke_test".to_string())
+        );
     }
 
     #[test]
@@ -1238,8 +1301,8 @@ mod tests {
         // refreshed; everything else (headings, notes, prose) survives.
         let tmp = TempDir::new().expect("tempdir");
         let dir = tmp.path().join("-proj");
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("MEMORY.md");
+        fs::create_dir_all(dir.join("memory")).unwrap();
+        let path = dir.join("memory").join("MEMORY.md");
         let existing = "# Seren Desktop Memory\n\n## Critical Lessons\n\
             - hand-written note that must survive a re-render\n\n\
             <!-- BEGIN AUTO-INDEX -->\nstale auto content\n<!-- END AUTO-INDEX -->\n\n\
@@ -1259,7 +1322,7 @@ mod tests {
             !merged.contains("stale auto content"),
             "stale content inside markers MUST be replaced"
         );
-        assert!(!dir.join("MEMORY.md.tmp").exists());
+        assert!(!dir.join("memory").join("MEMORY.md.tmp").exists());
     }
 
     #[test]
@@ -1270,8 +1333,8 @@ mod tests {
         // overwriting it.
         let tmp = TempDir::new().expect("tempdir");
         let dir = tmp.path().join("-proj");
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("MEMORY.md");
+        fs::create_dir_all(dir.join("memory")).unwrap();
+        let path = dir.join("memory").join("MEMORY.md");
         let existing = "# Seren Desktop Memory\n\n## Critical Lessons\n- must survive\n";
         fs::write(&path, existing).unwrap();
 
@@ -1292,13 +1355,44 @@ mod tests {
         // intercepted file path so it can call render_memory_md_from_db
         // without depending on outside state. The dir is always the file's
         // grandparent (parent is the `memory/` subdir).
-        let path =
-            Path::new("/home/a/.claude/projects/-Users-x-foo/memory/feedback_test.md");
+        let path = Path::new("/home/a/.claude/projects/-Users-x-foo/memory/feedback_test.md");
         assert_eq!(
             claude_project_dir_for_memory_file(path),
             Some(PathBuf::from("/home/a/.claude/projects/-Users-x-foo"))
         );
         assert_eq!(claude_project_dir_for_memory_file(Path::new("/")), None);
+    }
+
+    #[test]
+    fn write_rendered_memory_md_targets_memory_subdir_and_replaces_stale_index() {
+        let tmp = TempDir::new().expect("tempdir");
+        let dir = tmp.path().join("-proj");
+
+        let first = write_rendered_memory_md(
+            &dir,
+            "## Feedback\n- [stale.md](stale.md) — stale description\n",
+        )
+        .unwrap();
+        assert_eq!(first, dir.join("memory").join("MEMORY.md"));
+        let first_modified = fs::metadata(&first).unwrap().modified().unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        let second = write_rendered_memory_md(
+            &dir,
+            "## Feedback\n- [current.md](current.md) — current description\n",
+        )
+        .unwrap();
+        let second_modified = fs::metadata(&second).unwrap().modified().unwrap();
+        let rendered = fs::read_to_string(&second).unwrap();
+
+        assert!(rendered.contains("current description"));
+        assert!(!rendered.contains("stale description"));
+        assert!(
+            second_modified >= first_modified,
+            "MEMORY.md mtime must not go backwards after a refresh"
+        );
+        assert!(!dir.join("MEMORY.md").exists());
     }
 
     // ---- SQL builder tests (the heart of the #1509 storage rebuild) ------
@@ -1348,14 +1442,8 @@ mod tests {
 
     #[test]
     fn build_upsert_preference_sql_handles_null_description() {
-        let sql = build_upsert_preference_sql(
-            "-proj",
-            "no_desc",
-            "feedback",
-            None,
-            "body",
-            "no_desc.md",
-        );
+        let sql =
+            build_upsert_preference_sql("-proj", "no_desc", "feedback", None, "body", "no_desc.md");
         // None description must serialize as the literal NULL keyword,
         // not as a quoted empty string.
         assert!(sql.contains(", NULL,"));
@@ -1433,9 +1521,7 @@ mod integration {
     fn require_env(name: &str) -> String {
         match std::env::var(name) {
             Ok(v) if !v.trim().is_empty() => v,
-            _ => panic!(
-                "{name} is not set — SerenDB SQL roundtrip test requires live credentials"
-            ),
+            _ => panic!("{name} is not set — SerenDB SQL roundtrip test requires live credentials"),
         }
     }
 

--- a/src-tauri/src/commands/claude_memory.rs
+++ b/src-tauri/src/commands/claude_memory.rs
@@ -73,8 +73,7 @@ pub async fn claude_memory_start(
 ) -> Result<ClaudeMemoryStatus, String> {
     let config = build_config(project_id, branch_id, database_name)?;
 
-    let join =
-        tokio::task::spawn_blocking(move || claude_memory::start_watcher(app, config));
+    let join = tokio::task::spawn_blocking(move || claude_memory::start_watcher(app, config));
     let root = match tokio::time::timeout(CLAUDE_MEMORY_START_TIMEOUT, join).await {
         Ok(Ok(Ok(path))) => path,
         Ok(Ok(Err(e))) => return Err(e),
@@ -160,10 +159,7 @@ pub async fn claude_memory_migrate_existing(
 /// <id>` and surfaces a "Claude Code request failed" error event before the
 /// recovery fallback kicks in (#1657).
 #[tauri::command]
-pub fn claude_session_exists(
-    project_cwd: String,
-    session_id: String,
-) -> Result<bool, String> {
+pub fn claude_session_exists(project_cwd: String, session_id: String) -> Result<bool, String> {
     let root = claude_memory::claude_projects_root()?;
     Ok(claude_memory::session_jsonl_path(&root, Path::new(&project_cwd), &session_id).is_file())
 }
@@ -185,7 +181,7 @@ pub fn claude_memory_get_project_identity(
     })
 }
 
-/// Render `~/.claude/projects/<encoded(project_cwd)>/MEMORY.md` from the
+/// Render `~/.claude/projects/<encoded(project_cwd)>/memory/MEMORY.md` from the
 /// `claude_agent_preferences` table in SerenDB. The frontend calls this when
 /// a project is opened so Claude Code reads fresh content next session.
 #[tauri::command]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,7 +306,7 @@ function App() {
           if (settingsStore.get("claudeMemoryMigrateOnStartup")) {
             const report = await migrateExistingClaudeMemory();
             console.info(
-              `[ClaudeMemory] startup migration: persisted=${report.persisted} failures=${report.failures}`,
+              `[ClaudeMemory] startup migration: persisted=${report.persisted} failures=${report.failures} rendered=${report.rendered} render_failures=${report.render_failures}`,
             );
             if (report.failures > 0) {
               await notifyUser(
@@ -315,6 +315,13 @@ function App() {
                 } could not be pushed to SerenDB yet and ${
                   report.failures === 1 ? "was" : "were"
                 } left on disk. The interceptor will retry automatically on the next write, or you can retry now from Settings → Code Indexing → Claude Code Auto-Memory → Migrate Existing Files.`,
+              );
+            }
+            if (report.render_failures > 0) {
+              await notifyUser(
+                `${report.render_failures} Claude memory index refresh${
+                  report.render_failures === 1 ? "" : "es"
+                } failed after migration. The database write succeeded, but Claude Code may read stale MEMORY.md content until the next successful refresh.`,
               );
             }
           }

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -145,16 +145,16 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
     setClaudeMemoryMessage(null);
     try {
       const report = await migrateExistingClaudeMemory();
-      const { persisted, failures } = report;
-      if (persisted === 0 && failures === 0) {
+      const { persisted, failures, rendered, render_failures } = report;
+      if (persisted === 0 && failures === 0 && render_failures === 0) {
         setClaudeMemoryMessage("No plaintext memory files found.");
-      } else if (failures === 0) {
+      } else if (failures === 0 && render_failures === 0) {
         setClaudeMemoryMessage(
-          `Pushed ${persisted} file${persisted === 1 ? "" : "s"} to SerenDB.`,
+          `Pushed ${persisted} file${persisted === 1 ? "" : "s"} to SerenDB and refreshed ${rendered} MEMORY.md index${rendered === 1 ? "" : "es"}.`,
         );
       } else {
         setClaudeMemoryMessage(
-          `Pushed ${persisted}, left ${failures} on disk (cloud write failed — will retry).`,
+          `Pushed ${persisted}, left ${failures} on disk, and hit ${render_failures} MEMORY.md refresh failure${render_failures === 1 ? "" : "s"}.`,
         );
       }
     } catch (err) {

--- a/src/services/claudeMemory.ts
+++ b/src/services/claudeMemory.ts
@@ -197,6 +197,8 @@ export interface ClaudeMemoryStatus {
 export interface ClaudeMemoryMigrationReport {
   persisted: number;
   failures: number;
+  rendered: number;
+  render_failures: number;
 }
 
 export interface ClaudeMemoryProjectIdentity {
@@ -214,6 +216,8 @@ export interface InterceptSuccessEvent {
   path: string;
   name: string | null;
   memory_type: string;
+  rendered_memory_md: string | null;
+  render_error: string | null;
 }
 
 export interface InterceptFailureEvent {
@@ -369,14 +373,15 @@ export async function getClaudeMemoryStatus(): Promise<ClaudeMemoryStatus> {
 
 /**
  * Walk every existing Claude memory directory and push any pre-existing `.md`
- * files to SerenDB. Returns persisted + failures counts. Files whose cloud
- * write fails are left on disk so the live watcher can retry later.
+ * files to SerenDB. Returns persisted, cloud-write failures, refreshed
+ * MEMORY.md indexes, and refresh failures. Files whose cloud write fails are
+ * left on disk so the live watcher can retry later.
  *
  * Provisions the SerenDB project/database/table first if needed.
  */
 export async function migrateExistingClaudeMemory(): Promise<ClaudeMemoryMigrationReport> {
   if (!isTauriRuntime()) {
-    return { persisted: 0, failures: 0 };
+    return { persisted: 0, failures: 0, rendered: 0, render_failures: 0 };
   }
   const provisioning = await ensureClaudeMemoryProvisioned();
   return invoke<ClaudeMemoryMigrationReport>("claude_memory_migrate_existing", {
@@ -422,7 +427,7 @@ export async function claudeSessionExists(
 }
 
 /**
- * Render `~/.claude/projects/<encoded(projectCwd)>/MEMORY.md` from the
+ * Render `~/.claude/projects/<encoded(projectCwd)>/memory/MEMORY.md` from the
  * `claude_agent_preferences` SerenDB table, so Claude Code reads fresh
  * content at the start of its next session.
  */

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -5,7 +5,9 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createStore, produce } from "solid-js/store";
 import {
   extractEvidenceFromAgentMessages,
+  type FinalizationEvidence,
   type FinalOutputValidationReport,
+  type ToolEvidence,
   validateFinalOutput,
 } from "@/lib/agent-output-validation";
 import { shouldLogAgentRuntimeEvent } from "@/lib/agent-runtime-debug";
@@ -439,7 +441,11 @@ import {
   type UnifiedConversationRow,
 } from "@/lib/tauri-bridge";
 import { refreshAccessToken } from "@/services/auth";
-import { claudeSessionExists } from "@/services/claudeMemory";
+import {
+  type InterceptSuccessEvent as ClaudeMemoryInterceptSuccessEvent,
+  claudeSessionExists,
+  renderClaudeMemoryMd,
+} from "@/services/claudeMemory";
 import {
   bootstrapMemoryContext,
   processAssistantResponseMemory,
@@ -489,7 +495,12 @@ let cliScanRejectedUnsub: (() => void) | null = null;
  *  the schema is reconciled. #1829. */
 let syntheticSchemaDriftUnsub: (() => void) | null = null;
 
+/** Set once we've subscribed to Rust Claude memory intercept events. */
+let claudeMemoryInterceptedListener: Promise<UnlistenFn> | null = null;
+
 let sessionResetGeneration = 0;
+const CLAUDE_MEMORY_EVIDENCE_LIMIT = 20;
+const CLAUDE_MEMORY_RENDER_BEFORE_SPAWN_TIMEOUT_MS = 15_000;
 
 function disposeTauriListener(
   listener: Promise<UnlistenFn> | null,
@@ -517,6 +528,10 @@ function disposeAgentStoreSideChannelListeners(): void {
 
   syntheticSchemaDriftUnsub?.();
   syntheticSchemaDriftUnsub = null;
+
+  const claudeMemoryListener = claudeMemoryInterceptedListener;
+  claudeMemoryInterceptedListener = null;
+  disposeTauriListener(claudeMemoryListener, "claude-memory intercepted");
 }
 
 /** Commit an agent list into the store + settle the selected-agent fallback.
@@ -643,6 +658,47 @@ function subscribeToProviderRuntimeRestarted(): void {
             );
           }
         })();
+      }
+    },
+  );
+}
+
+function subscribeToClaudeMemoryIntercepts(): void {
+  if (claudeMemoryInterceptedListener) return;
+  claudeMemoryInterceptedListener = listen<ClaudeMemoryInterceptSuccessEvent>(
+    "claude-memory-intercepted",
+    (event) => {
+      const payload = event.payload;
+      if (!payload?.path) return;
+
+      for (const [sessionId, session] of Object.entries(state.sessions)) {
+        if (!usesClaudeMemory(session.info.agentType)) continue;
+        if (!isClaudeMemoryPathForCwd(payload.path, session.cwd)) continue;
+
+        const evidence: ToolEvidence = {
+          id: `claude-memory:${sessionId}:${Date.now()}:${payload.path}`,
+          name: "claude_memory_interceptor",
+          title: "Claude Memory Interceptor",
+          kind: "database",
+          status: "completed",
+          result: [
+            "Persisted Claude memory to claude_agent_preferences",
+            `source=${payload.path}`,
+            payload.rendered_memory_md
+              ? `memory_md=${payload.rendered_memory_md}`
+              : null,
+            payload.render_error
+              ? `render_error=${payload.render_error}`
+              : null,
+          ]
+            .filter((part): part is string => Boolean(part))
+            .join("; "),
+          isError: false,
+        };
+
+        setState("sessions", sessionId, "claudeMemoryWriteEvidence", (prev) =>
+          [...(prev ?? []), evidence].slice(-CLAUDE_MEMORY_EVIDENCE_LIMIT),
+        );
       }
     },
   );
@@ -938,6 +994,8 @@ export interface ActiveSession {
   /** Queued prompts awaiting dispatch when the session returns to ready.
    *  Lives in the store (not the component) so background threads still drain. */
   pendingPrompts: string[];
+  /** Scoped out-of-band DB write evidence from the Rust Claude memory watcher. */
+  claudeMemoryWriteEvidence?: ToolEvidence[];
   /**
    * Serving = the session the user is talking to. Standby = a warm
    * replacement session being seeded via predictive compaction — invisible
@@ -1084,6 +1142,91 @@ function filterDroppedPromptRecoveryMessages(
       !isSessionDeathMessage(message.content)
     );
   });
+}
+
+function usesClaudeMemory(agentType: AgentType): boolean {
+  return agentType === "claude-code" || agentType === "claude-codex";
+}
+
+function encodeClaudeProjectDirForPath(cwd: string): string {
+  const normalized = cwd
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/:/g, "");
+  return `-${normalized
+    .split("")
+    .map((char) => (/[A-Za-z0-9-]/.test(char) ? char : "-"))
+    .join("")}`;
+}
+
+function isClaudeMemoryPathForCwd(path: string, cwd: string): boolean {
+  const encoded = encodeClaudeProjectDirForPath(cwd);
+  return path.replace(/\\/g, "/").split("/").includes(encoded);
+}
+
+function buildAgentFinalizationEvidence(
+  session: ActiveSession,
+): FinalizationEvidence {
+  const evidence = extractEvidenceFromAgentMessages(session.messages);
+  const memoryEvidence = session.claudeMemoryWriteEvidence ?? [];
+  if (memoryEvidence.length === 0) {
+    return evidence;
+  }
+  return {
+    ...evidence,
+    tools: [...evidence.tools, ...memoryEvidence],
+  };
+}
+
+async function refreshClaudeMemoryMdBeforeSpawn(
+  cwd: string,
+  agentType: AgentType,
+  hasSerenApiKey: boolean,
+): Promise<void> {
+  if (!usesClaudeMemory(agentType)) return;
+  if (!hasSerenApiKey) return;
+  if (!settingsStore.get("claudeMemoryInterceptEnabled")) return;
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  const renderPromise = renderClaudeMemoryMd(cwd).catch((error) => {
+    if (timedOut) {
+      console.warn(
+        "[AgentStore] Claude memory index refresh failed after spawn-time timeout:",
+        error,
+      );
+      return null;
+    }
+    throw error;
+  });
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      resolve("timeout");
+    }, CLAUDE_MEMORY_RENDER_BEFORE_SPAWN_TIMEOUT_MS);
+  });
+
+  try {
+    const result = await Promise.race([renderPromise, timeoutPromise]);
+    if (result === "timeout") {
+      console.warn(
+        `[AgentStore] Claude memory index refresh timed out after ${CLAUDE_MEMORY_RENDER_BEFORE_SPAWN_TIMEOUT_MS}ms; spawning with existing MEMORY.md.`,
+      );
+      return;
+    }
+    if (result) {
+      console.info("[AgentStore] Refreshed Claude memory index:", result);
+    }
+  } catch (error) {
+    console.warn(
+      "[AgentStore] Claude memory index refresh before spawn failed:",
+      error,
+    );
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
 function mergeRecoveryMessages(
@@ -2381,6 +2524,7 @@ export const agentStore = {
     // at runtime. Pre-#1829 the runtime emitted this event but no consumer
     // existed in the TS layer, so the gate was one-way.
     subscribeToSyntheticTranscriptSchemaDrift();
+    subscribeToClaudeMemoryIntercepts();
 
     const backoffMs = [0, 1_000, 2_000, 4_000, 8_000];
     for (let attempt = 0; attempt < backoffMs.length; attempt++) {
@@ -2901,6 +3045,12 @@ export const agentStore = {
           resolvedAgentType === "claude-codex"
             ? settingsStore.settings.claudeReasoningEffort
             : undefined;
+
+        await refreshClaudeMemoryMdBeforeSpawn(
+          cwd,
+          resolvedAgentType,
+          Boolean(apiKey),
+        );
 
         console.log("[AgentStore] Spawning agent process...");
         const info = await providerService.spawnAgent(
@@ -5189,6 +5339,7 @@ export const agentStore = {
 
     // Track when the prompt started for duration calculation
     setState("sessions", sessionId, "promptStartTime", Date.now());
+    setState("sessions", sessionId, "claudeMemoryWriteEvidence", []);
     // Clear any prior cancel flag — user is submitting a new prompt.
     setState("sessions", sessionId, "cancelRequested", undefined);
     // Store the prompt so we can retry after compaction if needed
@@ -7298,7 +7449,7 @@ export const agentStore = {
         : undefined;
       const finalOutputValidation = validateFinalOutput({
         finalText: scrubbed,
-        evidence: extractEvidenceFromAgentMessages(session.messages),
+        evidence: buildAgentFinalizationEvidence(session),
       });
       const safeContent = finalOutputValidation.safeDisplayText;
 

--- a/tests/services/claudeMemory.test.ts
+++ b/tests/services/claudeMemory.test.ts
@@ -58,6 +58,7 @@ import {
   ensureClaudeMemoryProvisioned,
   getClaudeMemoryStatus,
   migrateExistingClaudeMemory,
+  renderClaudeMemoryMd,
   startClaudeMemoryInterceptor,
   stopClaudeMemoryInterceptor,
   waitForDatabaseReady,
@@ -426,11 +427,41 @@ describe("startClaudeMemoryInterceptor wiring", () => {
     settingsState.claudeMemoryProjectId = "p";
     settingsState.claudeMemoryBranchId = "b";
     settingsState.claudeMemoryDatabaseName = "d";
-    invokeMock.mockResolvedValue({ persisted: 7, failures: 2 });
+    invokeMock.mockResolvedValue({
+      persisted: 7,
+      failures: 2,
+      rendered: 3,
+      render_failures: 1,
+    });
 
     const report = await migrateExistingClaudeMemory();
-    expect(report).toEqual({ persisted: 7, failures: 2 });
+    expect(report).toEqual({
+      persisted: 7,
+      failures: 2,
+      rendered: 3,
+      render_failures: 1,
+    });
     expect(invokeMock).toHaveBeenCalledWith("claude_memory_migrate_existing", {
+      projectId: "p",
+      branchId: "b",
+      databaseName: "d",
+    });
+  });
+
+  it("render provisions then forwards the project cwd to the Tauri render command", async () => {
+    settingsState.claudeMemoryProjectId = "p";
+    settingsState.claudeMemoryBranchId = "b";
+    settingsState.claudeMemoryDatabaseName = "d";
+    invokeMock.mockResolvedValue(
+      "/home/a/.claude/projects/-home-a-proj/memory/MEMORY.md",
+    );
+
+    const path = await renderClaudeMemoryMd("/home/a/proj");
+    expect(path).toBe(
+      "/home/a/.claude/projects/-home-a-proj/memory/MEMORY.md",
+    );
+    expect(invokeMock).toHaveBeenCalledWith("claude_memory_render_memory_md", {
+      projectCwd: "/home/a/proj",
       projectId: "p",
       branchId: "b",
       databaseName: "d",
@@ -444,7 +475,12 @@ describe("startClaudeMemoryInterceptor wiring", () => {
     const migrated = await migrateExistingClaudeMemory();
     expect(started).toEqual({ running: false, watching_root: null });
     expect(status).toEqual({ running: false, watching_root: null });
-    expect(migrated).toEqual({ persisted: 0, failures: 0 });
+    expect(migrated).toEqual({
+      persisted: 0,
+      failures: 0,
+      rendered: 0,
+      render_failures: 0,
+    });
     expect(invokeMock).not.toHaveBeenCalled();
     expect(databasesMock.listProjects).not.toHaveBeenCalled();
   });

--- a/tests/unit/agent-output-validation.test.ts
+++ b/tests/unit/agent-output-validation.test.ts
@@ -211,6 +211,37 @@ describe("#1987 Verified Agent Output", () => {
     });
   });
 
+  it("credits Claude auto-memory intercepts as out-of-band database write evidence", () => {
+    const report = validateFinalOutput({
+      finalText: "I saved the memory record to the database.",
+      evidence: {
+        diffs: [],
+        tools: [
+          {
+            id: "claude-memory-1",
+            name: "claude_memory_interceptor",
+            title: "Claude Memory Interceptor",
+            kind: "database",
+            status: "completed",
+            result:
+              "Persisted Claude memory to claude_agent_preferences; memory_md=/Users/a/.claude/projects/-Users-a-proj/memory/MEMORY.md",
+            isError: false,
+          },
+        ],
+      },
+    });
+
+    expect(report.safeDisplayText).toBe(
+      "I saved the memory record to the database.",
+    );
+    expect(report.canStoreMemory).toBe(true);
+    expect(report.claims[0]).toMatchObject({
+      kind: "db_persisted",
+      status: "verified",
+      evidenceToolCallIds: ["claude-memory-1"],
+    });
+  });
+
   it("validates browser claims against browser-tool evidence", () => {
     const successReport = validateFinalOutput({
       finalText: "I took a screenshot of the website.",

--- a/tests/unit/agent-seren-memory-wiring.test.ts
+++ b/tests/unit/agent-seren-memory-wiring.test.ts
@@ -54,6 +54,25 @@ describe("#1625 — agent spawnSession bootstraps Seren memory context", () => {
     );
     expect(spawnWindow).toContain("memory bootstrap failed (non-fatal)");
   });
+
+  it("spawnSession refreshes Claude Code MEMORY.md before starting a Claude-backed session", () => {
+    expect(agentStoreSource).toContain("renderClaudeMemoryMd");
+    expect(agentStoreSource).toContain("refreshClaudeMemoryMdBeforeSpawn(");
+    const spawnSessionStart = agentStoreSource.indexOf("async spawnSession(");
+    const refreshCall = agentStoreSource.indexOf(
+      "await refreshClaudeMemoryMdBeforeSpawn(",
+      spawnSessionStart,
+    );
+    const providerSpawnCall = agentStoreSource.indexOf(
+      "const info = await providerService.spawnAgent(",
+      spawnSessionStart,
+    );
+    expect(refreshCall).toBeGreaterThan(spawnSessionStart);
+    expect(providerSpawnCall).toBeGreaterThan(refreshCall);
+    expect(agentStoreSource).toContain(
+      "CLAUDE_MEMORY_RENDER_BEFORE_SPAWN_TIMEOUT_MS",
+    );
+  });
 });
 
 describe("#1625 — finalizeStreamingContent extracts assistant turns to memory", () => {
@@ -80,6 +99,24 @@ describe("#1625 — finalizeStreamingContent extracts assistant turns to memory"
     expect(agentStoreSource).toContain(
       "this.finalizeStreamingContent(sessionId, { isReplay: isHistoryReplay })",
     );
+  });
+
+  it("final output validation includes scoped Claude auto-memory DB evidence", () => {
+    expect(agentStoreSource).toContain('listen<ClaudeMemoryInterceptSuccessEvent>(');
+    expect(agentStoreSource).toContain('"claude-memory-intercepted"');
+    expect(agentStoreSource).toContain("claudeMemoryWriteEvidence");
+    expect(agentStoreSource).toContain("buildAgentFinalizationEvidence(session)");
+    expect(agentStoreSource).toContain('name: "claude_memory_interceptor"');
+  });
+
+  it("Claude auto-memory event matching normalizes Windows paths", () => {
+    const helperStart = agentStoreSource.indexOf(
+      "function encodeClaudeProjectDirForPath(",
+    );
+    expect(helperStart).toBeGreaterThan(0);
+    const helperWindow = agentStoreSource.slice(helperStart, helperStart + 800);
+    expect(helperWindow).toContain('replace(/\\\\/g, "/")');
+    expect(helperWindow).toContain('replace(/:/g, "")');
   });
 });
 

--- a/tests/unit/claude-session-preflight.test.ts
+++ b/tests/unit/claude-session-preflight.test.ts
@@ -39,8 +39,8 @@ describe("#1657 — claudeSessionExists pre-flight before --resume", () => {
   });
 
   it("agent.store imports claudeSessionExists from the service module", () => {
-    expect(agentStoreSource).toContain(
-      'import { claudeSessionExists } from "@/services/claudeMemory"',
+    expect(agentStoreSource).toMatch(
+      /import\s*\{[\s\S]*?claudeSessionExists[\s\S]*?\}\s*from\s*"@\/services\/claudeMemory"/,
     );
   });
 


### PR DESCRIPTION
## Summary
- Write rendered Claude memory indexes to the actual Claude memory path: `~/.claude/projects/<encoded>/memory/MEMORY.md`.
- Refresh `MEMORY.md` after live intercepts, startup migration, and before Claude-backed session spawn.
- Credit scoped Claude auto-memory intercept events as out-of-band DB write evidence so valid memory saves are not rewritten as unverified database writes.

Closes #2394

## Audit
- P1 fixed: stale `MEMORY.md` came from writing the rendered index to the project dir instead of the `memory/` dir.
- P1 fixed: final-output validation had no session-scoped evidence for Rust watcher DB writes.
- No additional P0/P1 issues found in the functional Mac/Windows path audit.

## Tests
- `pnpm exec vitest run tests/unit/agent-output-validation.test.ts tests/unit/agent-seren-memory-wiring.test.ts tests/services/claudeMemory.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib claude_memory -- --nocapture`
- `pnpm exec biome check src/App.tsx src/components/settings/SettingsPanel.tsx src/services/claudeMemory.ts src/stores/agent.store.ts`

## Notes
- `pnpm exec tsc --noEmit` still fails on pre-existing unrelated repo-wide test typing issues, including `tests/unit/windows-cargo-manifest.test.ts` missing Vitest globals.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` still fails on pre-existing unrelated Rust formatting across the crate.