### PR TITLE
fix(audio): capacity-aware one-shot fallback to SerenModels (#2397)

### DIFF
--- a/src-tauri/src/audio/llm.rs
+++ b/src-tauri/src/audio/llm.rs
@@ -63,9 +63,9 @@ pub async fn complete(app: &AppHandle, request: CompletionRequest) -> Result<Str
             .await
             {
                 Ok(content) => Ok(content),
-                Err(err) if is_provider_auth_error(&err) => {
+                Err(err) if is_provider_fallback_error(&err) => {
                     log::warn!(
-                        "[audio-llm] provider one-shot auth failed; retrying via SerenModels fallback: {err}"
+                        "[audio-llm] provider one-shot unavailable (auth/capacity); retrying via SerenModels fallback: {err}"
                     );
                     complete_via_seren_models(
                         app,
@@ -265,6 +265,18 @@ fn seren_models_fallback_model(requested_model: &str) -> String {
     SEREN_MODELS_SUMMARIZATION_MODEL.to_string()
 }
 
+/// A provider one-shot error that should retry on the wallet-billed SerenModels
+/// fallback instead of failing the prompt. Covers two classes:
+/// the provider isn't authenticated, or the provider's subscription has no
+/// remaining capacity (quota/rate-limit). A long meeting that exhausts the
+/// user's Claude/Codex/Gemini subscription mid-pass must still produce notes,
+/// and must not keep hammering a throttled subscription that also serves the
+/// user's interactive chat. Non-capacity safety errors (e.g. a tool-call abort)
+/// are deliberately excluded so they still fail closed. #2397.
+fn is_provider_fallback_error(error: &str) -> bool {
+    is_provider_auth_error(error) || is_provider_capacity_error(error)
+}
+
 fn is_provider_auth_error(error: &str) -> bool {
     let lower = error.to_ascii_lowercase();
     lower.contains("authentication required")
@@ -273,6 +285,26 @@ fn is_provider_auth_error(error: &str) -> bool {
         || lower.contains("login required")
         || lower.contains("not logged in")
         || lower.contains("please run /login")
+}
+
+/// Detect provider subscription quota/rate-limit/capacity exhaustion. The
+/// underlying CLIs surface these as free-form strings, so match on the
+/// substrings the major providers use for HTTP 429 / usage-limit conditions.
+fn is_provider_capacity_error(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("rate limit")
+        || lower.contains("rate-limit")
+        || lower.contains("ratelimit")
+        || lower.contains("too many requests")
+        || lower.contains("quota")
+        || lower.contains("usage limit")
+        || lower.contains("usage_limit")
+        || lower.contains("insufficient_quota")
+        || lower.contains("resource exhausted")
+        || lower.contains("resource_exhausted")
+        || lower.contains("overloaded")
+        || lower.contains("capacity")
+        || lower.contains("429")
 }
 
 #[cfg(test)]
@@ -354,5 +386,50 @@ mod tests {
             "provider one-shot attempted a tool call; toolless completion aborted"
         ));
         assert!(!is_provider_auth_error("Provider runtime socket closed before prompt completed."));
+    }
+
+    #[test]
+    fn provider_capacity_error_detection_covers_common_quota_shapes() {
+        for error in [
+            "Rate limit exceeded. Please try again later.",
+            "429 Too Many Requests",
+            "You have hit your usage limit for this model",
+            "insufficient_quota: you exceeded your current quota",
+            "RESOURCE_EXHAUSTED: Quota exceeded for gemini",
+            "Anthropic API error: overloaded_error",
+            "Server is at capacity, retry shortly",
+        ] {
+            assert!(
+                is_provider_capacity_error(error),
+                "expected capacity error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_capacity_error_does_not_match_safety_or_transport_errors() {
+        // A tool-call/permission abort is a non-capacity safety error and MUST
+        // fail closed, never fall back. Transport closes are not capacity.
+        assert!(!is_provider_capacity_error(
+            "provider one-shot attempted a tool call; toolless completion aborted"
+        ));
+        assert!(!is_provider_capacity_error(
+            "Provider runtime socket closed before prompt completed."
+        ));
+        assert!(!is_provider_capacity_error("provider one-shot returned no content"));
+    }
+
+    #[test]
+    fn fallback_predicate_covers_auth_and_capacity_but_not_safety() {
+        assert!(is_provider_fallback_error("not logged in"));
+        assert!(is_provider_fallback_error("429 Too Many Requests"));
+        assert!(is_provider_fallback_error("usage limit reached"));
+        // Safety / transport failures fail closed (no SerenModels fallback).
+        assert!(!is_provider_fallback_error(
+            "provider one-shot attempted a tool call; toolless completion aborted"
+        ));
+        assert!(!is_provider_fallback_error(
+            "Provider runtime socket closed before prompt completed."
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Closes #2397. Makes long-meeting provider one-shots capacity-aware: when the user's Claude/Codex/Gemini CLI subscription rate-limits or reports no remaining capacity, the notes/dictation/edit-by-voice one-shot now falls back to the wallet-billed SerenModels path instead of failing the prompt and degrading interactive chat.

## What changed

`src-tauri/src/audio/llm.rs`
- Add `is_provider_capacity_error()` — classifies quota / rate-limit / 429 / too-many-requests / usage-limit / overloaded / resource-exhausted / insufficient_quota.
- Add `is_provider_fallback_error()` = auth **OR** capacity; `complete()` now falls back to SerenModels on either.
- Non-capacity safety errors (the `provider://tool-call` / permission abort) still **fail closed** — no fallback — per the AC.

## Why this is the whole fix

Audit (see issue thread) confirmed the rest of the AC is already satisfied by current code:
- single prompt when the transcript fits `TRANSCRIPT_CHAR_BUDGET` (`notes.rs:142`),
- sequential map-reduce (`notes.rs:149`, `notes.rs:243`),
- per-prompt fallback without losing partials (`collect_resilient_partials`),
- ephemeral session, no live-chat mutation.

The only gap was the fallback classifier ignoring capacity errors.

## Tests

`cargo test ... audio::llm` — 8/8 pass (4 new):
- capacity detection across 7 common quota shapes,
- capacity classifier does **not** match tool-abort / socket-close / no-content,
- fallback predicate covers auth+capacity but not safety/transport errors.

## Not verified here

Exact provider-CLI rate-limit strings can't be exercised against live authenticated CLIs in this environment; the classifier uses a broad substring set. Meeting-level "stop re-trying a throttled provider for the rest of the meeting" is a deferred optimization (AC specifies per-prompt).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
