### PR TITLE
fix(audio): keep raw transcript when dictation cleanup fails (#2403)

### DIFF
--- a/src/lib/audio/useVoiceInput.ts
+++ b/src/lib/audio/useVoiceInput.ts
@@ -125,13 +125,29 @@ export function useVoiceInput(
         return;
       }
 
-      const transcript = settingsStore.get("voiceCleanupEnabled")
-        ? await cleanupDictationText(
+      // Cleanup only polishes already-captured speech. If the LLM cleanup
+      // throws (empty provider completion, a fail-closed tool/permission abort
+      // on Codex/Gemini, or transport failure) or returns nothing, fall back to
+      // the raw transcript — never discard the user's words because the polish
+      // step failed. #2403.
+      let transcript = trimmed;
+      if (settingsStore.get("voiceCleanupEnabled")) {
+        try {
+          const cleaned = await cleanupDictationText(
             trimmed,
             providerStore.resolvedModel(),
             settingsStore.get("voiceCustomVocabulary"),
-          )
-        : trimmed;
+          );
+          if (cleaned.trim()) {
+            transcript = cleaned;
+          }
+        } catch (err) {
+          console.warn(
+            "[VoiceInput] cleanup failed; inserting raw transcript:",
+            err,
+          );
+        }
+      }
 
       if (transcript.trim()) {
         onTranscript(transcript.trim());

--- a/tests/unit/voice-input-cleanup-failure.test.ts
+++ b/tests/unit/voice-input-cleanup-failure.test.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Regression test for #2403 — a failed LLM cleanup must not discard captured dictation.
+// ABOUTME: Drives the real useVoiceInput hook with cleanup enabled and a throwing cleanup call.
+
+import { createRoot } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => {
+  const stopSpy = vi.fn(async () => "um hello there");
+  const startMock = vi.fn(async () => ({ stop: stopSpy, level: () => 0 }));
+  const cleanupMock = vi.fn(async () => {
+    throw new Error("provider one-shot returned no content");
+  });
+  return { stopSpy, startMock, cleanupMock };
+});
+
+vi.mock("@/lib/audio/dictationCapture", () => ({
+  startDictationCapture: h.startMock,
+}));
+vi.mock("@/services/dictation", () => ({
+  cleanupDictationText: h.cleanupMock,
+  transformSelection: vi.fn(),
+  transcribePcm: vi.fn(),
+}));
+vi.mock("@/stores/provider.store", () => ({
+  providerStore: { resolvedModel: () => "model" },
+}));
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: (key: string) =>
+      key === "voiceCleanupEnabled"
+        ? true
+        : key === "voiceCustomVocabulary"
+          ? []
+          : false,
+  },
+}));
+
+import { useVoiceInput } from "@/lib/audio/useVoiceInput";
+
+describe("useVoiceInput cleanup failure (#2403)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn() },
+      platform: "MacIntel",
+    });
+    h.startMock.mockClear();
+    h.stopSpy.mockClear();
+    h.cleanupMock.mockClear();
+  });
+
+  it("inserts the raw transcript when LLM cleanup throws", async () => {
+    await createRoot(async (dispose) => {
+      const inserted: string[] = [];
+      const voice = useVoiceInput((text) => inserted.push(text));
+
+      await voice.startRecording();
+      await voice.stopRecording();
+
+      // Cleanup was attempted and threw, yet the captured speech survives.
+      expect(h.cleanupMock).toHaveBeenCalledTimes(1);
+      expect(inserted).toEqual(["um hello there"]);
+      expect(voice.voiceState()).toBe("idle");
+      dispose();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2403. Found during the functional walk-through audit of #2397/#2398/#2399. With voice cleanup enabled, a failed LLM cleanup discarded the user's already-captured dictation.

## The defect

`src/lib/audio/useVoiceInput.ts` wrapped **both** transcription and the LLM cleanup call in one `try/catch`. Transcription succeeds (`trimmed` is non-empty), but if `cleanupDictationText` throws, the `catch` sets an error state and the captured speech is never inserted — silent data loss.

The provider one-shot behind cleanup throws on:
- empty provider completions (documented as common, #2366),
- a fail-closed tool/permission abort on Codex (`ask`) / Gemini (`plan`) — #2398 correctly stopped these from hanging, which *raised* the cleanup-throw rate for non-Claude users,
- transport/socket errors.

(#2397 already removed auth/capacity as throw causes — those now fall back to SerenModels.)

## Fix

Isolate cleanup in its own `try/catch` and fall back to the raw transcript on throw **or** empty result. Transcription failures (`handle.stop()`) still surface as errors. The user never loses their words because the polish step failed — at worst they get unpolished text.

## Tests

`vitest run` (3 files, 5 tests) pass, including the new `voice-input-cleanup-failure.test.ts`: drives the real hook with cleanup enabled and a throwing `cleanupDictationText`, asserts the raw transcript is still inserted and state returns to `idle`. Existing tap-race and dictation-cleanup tests unaffected. Biome clean.

Platform-independent (TypeScript), so it holds for macOS and Windows.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
