### PR TITLE
fix(windows): bound app e2e probe runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1161,8 +1161,10 @@ jobs:
             `$work = Join-Path $env:TEMP '${workName}'`,
             "if (Test-Path $work) { Remove-Item -LiteralPath $work -Recurse -Force }",
             "New-Item -ItemType Directory -Force -Path $work | Out-Null",
+            "Write-Host '[windows-e2e:ssm] Downloading staged installer and payload'",
             `Invoke-WebRequest -Uri ${psString(env.INSTALLER_URL)} -OutFile (Join-Path $work 'SerenDesktop-setup.exe')`,
             `Invoke-WebRequest -Uri ${psString(env.PAYLOAD_URL)} -OutFile (Join-Path $work 'windows-e2e-payload.zip')`,
+            "Write-Host '[windows-e2e:ssm] Expanding e2e payload'",
             "Expand-Archive -LiteralPath (Join-Path $work 'windows-e2e-payload.zip') -DestinationPath $work -Force",
             `$secretNames = @(${secretNames.map((name) => `'${name}'`).join(",")})`,
             // The aws call runs under Windows PowerShell 5.1, where native
@@ -1171,16 +1173,21 @@ jobs:
             // whole script before the guard ran (#2320). Scope EAP=Continue
             // around the call so missing parameters degrade to the guarded
             // skip they were designed for.
+            "Write-Host '[windows-e2e:ssm] Hydrating e2e secrets from SSM Parameter Store'",
             `foreach ($name in $secretNames) { $parameterName = '${env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX}/' + $name; $value = & { $ErrorActionPreference = 'Continue'; aws ssm get-parameter --with-decryption --name $parameterName --query 'Parameter.Value' --output text 2>$null }; if ($LASTEXITCODE -eq 0 -and $value -and $value -ne 'None') { [Environment]::SetEnvironmentVariable($name, $value, 'Process') } }`,
             "[Environment]::SetEnvironmentVariable('SEREN_E2E_API_BASE', 'https://api.serendb.com', 'Process')",
             "[Environment]::SetEnvironmentVariable('SEREN_E2E_RELEASE_RUN', '1', 'Process')",
             "Set-Location $work",
+            "Write-Host '[windows-e2e:ssm] Enabling Corepack'",
             "corepack enable",
             "corepack prepare pnpm@9 --activate",
+            "Write-Host '[windows-e2e:ssm] Installing npm dependencies'",
             "pnpm install --frozen-lockfile",
+            "Write-Host '[windows-e2e:ssm] Installing Playwright Chromium'",
             "pnpm exec playwright install chromium",
-            "powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-app.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe')",
-          ];
+            "Write-Host '[windows-e2e:ssm] Running Windows app harness'",
+            "powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-app.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe') -ProbeTimeoutSeconds 1800",
+            ];
           process.stdout.write(JSON.stringify({ commands }, null, 2));
           NODE
           command_id="$(aws ssm send-command \

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -10,7 +10,9 @@ param(
 
   [int]$StartupTimeoutSeconds = 120,
 
-  [int]$InstallerTimeoutSeconds = 180
+  [int]$InstallerTimeoutSeconds = 180,
+
+  [int]$ProbeTimeoutSeconds = 1800
 )
 
 $ErrorActionPreference = "Stop"
@@ -19,6 +21,11 @@ Set-StrictMode -Version Latest
 function Fail([string]$Message) {
   Write-Host "::error::$Message"
   exit 1
+}
+
+function Write-Stage([string]$Message) {
+  $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  Write-Host "[windows-e2e] $timestamp $Message"
 }
 
 function Require-Env([string[]]$Names) {
@@ -90,13 +97,23 @@ function Clear-DownloadMarksUnder([string]$Root) {
   }
 }
 
-function Invoke-ProcessWithTimeout([string]$FilePath, [string[]]$ArgumentList, [int]$TimeoutSeconds, [string]$Label) {
-  $process = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -PassThru
+function Invoke-ProcessWithTimeout([string]$FilePath, [string[]]$ArgumentList, [int]$TimeoutSeconds, [string]$Label, [switch]$NoNewWindow) {
+  Write-Stage "Starting ${Label} with ${TimeoutSeconds}s timeout"
+  $startArgs = @{
+    FilePath = $FilePath
+    ArgumentList = $ArgumentList
+    PassThru = $true
+  }
+  if ($NoNewWindow) {
+    $startArgs.NoNewWindow = $true
+  }
+  $process = Start-Process @startArgs
   $timeoutMs = [int]([Math]::Min([int]::MaxValue, [int64]$TimeoutSeconds * 1000))
   if (-not $process.WaitForExit($timeoutMs)) {
     Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
     Fail "$Label timed out after ${TimeoutSeconds}s and was killed."
   }
+  Write-Stage "${Label} exited with code $($process.ExitCode)"
   return $process.ExitCode
 }
 
@@ -139,6 +156,7 @@ function Find-RequiredFile([string]$Root, [string]$Filter, [string]$Label) {
   return $match.FullName
 }
 
+Write-Stage "Validating required production e2e environment"
 Require-Env @(
   "SEREN_E2E_EMAIL",
   "SEREN_E2E_PASSWORD",
@@ -156,17 +174,19 @@ if (-not [string]::IsNullOrWhiteSpace($env:SEREN_E2E_API_BASE) -and $env:SEREN_E
 $env:SEREN_E2E_API_BASE = "https://api.serendb.com"
 $env:SEREN_E2E_CDP_ENDPOINT = "http://127.0.0.1:$RemoteDebugPort"
 
+Write-Stage "Preparing installer artifact"
 $resolvedInstaller = (Resolve-Path -LiteralPath $InstallerPath).Path
 Clear-DownloadMark $resolvedInstaller "Windows NSIS installer"
 Require-SignedOrExplicitPrArtifact $resolvedInstaller "Windows NSIS installer"
 
+Write-Stage "Cleaning existing Seren processes and install directory"
 Get-Process -Name "Seren" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 if (Test-Path -LiteralPath $InstallDir) {
   Remove-Item -LiteralPath $InstallDir -Recurse -Force
 }
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
-Write-Host "Installing SerenDesktop into $InstallDir"
+Write-Stage "Installing SerenDesktop into $InstallDir"
 $installArgs = @("/S", "/D=$InstallDir")
 $installExitCode = Invoke-ProcessWithTimeout $resolvedInstaller $installArgs $InstallerTimeoutSeconds "NSIS installer"
 if ($installExitCode -ne 0) {
@@ -176,6 +196,7 @@ if ($AllowUnsignedPrArtifact) {
   Clear-DownloadMarksUnder $InstallDir
 }
 
+Write-Stage "Validating installed app payload"
 $appExe = Join-Path $InstallDir "Seren.exe"
 if (-not (Test-Path -LiteralPath $appExe)) {
   Write-DirectorySnapshot $InstallDir
@@ -187,6 +208,7 @@ $runtimeRoot = Join-Path $InstallDir "embedded-runtime"
 if (-not (Test-Path -LiteralPath $runtimeRoot)) {
   Fail "Installed app is missing embedded-runtime at $runtimeRoot"
 }
+Write-Stage "Validating bundled runtime"
 $nodeExe = Find-RequiredFile $runtimeRoot "node.exe" "bundled node.exe"
 $npmCmd = Find-RequiredFile $runtimeRoot "npm.cmd" "bundled npm.cmd"
 $providerRuntime = Find-RequiredFile $runtimeRoot "provider-runtime.mjs" "provider-runtime.mjs"
@@ -202,16 +224,19 @@ if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($npmVersion)) {
 Write-Host "Bundled runtime verified: node=$nodeVersion npm=$npmVersion providerRuntime=$providerRuntime"
 
 $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$RemoteDebugPort --remote-allow-origins=*"
-Write-Host "Launching Seren.exe with WebView2 remote debugging on port $RemoteDebugPort"
+Write-Stage "Launching Seren.exe with WebView2 remote debugging on port $RemoteDebugPort"
 $app = Start-Process -FilePath $appExe -PassThru
 
 try {
+  Write-Stage "Waiting for WebView2 CDP endpoint"
   Wait-ForCdp -Port $RemoteDebugPort -TimeoutSeconds $StartupTimeoutSeconds
-  node "$PSScriptRoot/windows-e2e-app.mjs"
-  if ($LASTEXITCODE -ne 0) {
-    Fail "Windows app e2e script failed with exit code $LASTEXITCODE"
+  Write-Stage "Running Node app e2e probe"
+  $probeExitCode = Invoke-ProcessWithTimeout "node" @("$PSScriptRoot/windows-e2e-app.mjs") $ProbeTimeoutSeconds "Windows app e2e probe" -NoNewWindow
+  if ($probeExitCode -ne 0) {
+    Fail "Windows app e2e script failed with exit code $probeExitCode"
   }
 } finally {
+  Write-Stage "Cleaning up Seren processes"
   if ($null -ne $app -and -not $app.HasExited) {
     Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
   }

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -70,7 +70,10 @@ describe("Windows production e2e release gate", () => {
     expect(runner).toContain("/S");
     expect(runner).toContain("Unblock-File");
     expect(runner).toContain("InstallerTimeoutSeconds");
+    expect(runner).toContain("ProbeTimeoutSeconds");
     expect(runner).toContain("WaitForExit");
+    expect(runner).toContain("Write-Stage");
+    expect(runner).toContain("Windows app e2e probe");
     expect(runner).toContain("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS");
     expect(runner).toContain("node.exe");
     expect(runner).toContain("npm.cmd");
@@ -89,6 +92,9 @@ describe("Windows production e2e release gate", () => {
     expect(releaseGate).toContain("aws s3 presign");
     expect(releaseGate).toContain("Invoke-WebRequest -Uri");
     expect(releaseGate).toContain("SEREN_E2E_RELEASE_RUN");
+    expect(releaseGate).toContain("[windows-e2e:ssm] Installing npm dependencies");
+    expect(releaseGate).toContain("[windows-e2e:ssm] Running Windows app harness");
+    expect(releaseGate).toContain("-ProbeTimeoutSeconds 1800");
     expect(releaseGate).not.toContain("-AllowUnsignedPrArtifact");
     expect(releaseGate).not.toContain("SEREN_E2E_UNSIGNED_PR_RUN");
   });


### PR DESCRIPTION
## Summary

Closes #2405.

Functional audit after #2382 / PR #2387 found that a Windows AWS e2e run can remain `InProgress` for over an hour with no stage output. This PR makes the harness fail with actionable stage context instead of silently consuming the outer SSM timeout.

Changes:

- Add timestamped `[windows-e2e]` stage markers through `scripts/windows-e2e-app.ps1`.
- Add `-ProbeTimeoutSeconds` and run `windows-e2e-app.mjs` through the existing process timeout wrapper.
- Add `[windows-e2e:ssm]` setup markers in the release workflow SSM command.
- Keep release signature behavior and unsigned-PR gating unchanged.

## Tests

- `pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts`
- `pwsh` parser check for `scripts/windows-e2e-app.ps1`
- `python3` YAML parse of `.github/workflows/release.yml`
- `git diff --check`

## Audit note

The #2387 CI matrix passed on macOS, Linux, and Windows. The follow-up AWS walk-through was cancelled after remaining `InProgress` for more than an hour with empty SSM stdout/stderr, which is the P1 addressed here.
