### PR TITLE
fix(windows): fail e2e on harness errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1187,6 +1187,7 @@ jobs:
             "pnpm exec playwright install chromium",
             "Write-Host '[windows-e2e:ssm] Running Windows app harness'",
             "powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-app.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe') -ProbeTimeoutSeconds 1800",
+            "if ($LASTEXITCODE -ne 0) { throw \"Windows app harness failed with exit code $LASTEXITCODE\" }",
             ];
           process.stdout.write(JSON.stringify({ commands }, null, 2));
           NODE

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -6,7 +6,7 @@ param(
 
   [int]$RemoteDebugPort = 9222,
 
-  [string]$InstallDir = (Join-Path $env:LOCALAPPDATA "SerenDesktopE2E"),
+  [string]$InstallDir = "",
 
   [int]$StartupTimeoutSeconds = 120,
 
@@ -26,6 +26,15 @@ function Fail([string]$Message) {
 function Write-Stage([string]$Message) {
   $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
   Write-Host "[windows-e2e] $timestamp $Message"
+}
+
+function Get-DefaultInstallDir() {
+  $localAppData = [Environment]::GetEnvironmentVariable("LOCALAPPDATA")
+  $systemDrive = if ([string]::IsNullOrWhiteSpace($env:SystemDrive)) { "C:" } else { $env:SystemDrive }
+  if ([string]::IsNullOrWhiteSpace($localAppData) -or $localAppData -like "*\Windows\system32\config\systemprofile\AppData\Local") {
+    return (Join-Path $systemDrive "SerenDesktopE2E")
+  }
+  return (Join-Path $localAppData "SerenDesktopE2E")
 }
 
 function Require-Env([string[]]$Names) {
@@ -173,6 +182,11 @@ if (-not [string]::IsNullOrWhiteSpace($env:SEREN_E2E_API_BASE) -and $env:SEREN_E
 }
 $env:SEREN_E2E_API_BASE = "https://api.serendb.com"
 $env:SEREN_E2E_CDP_ENDPOINT = "http://127.0.0.1:$RemoteDebugPort"
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+  $InstallDir = Get-DefaultInstallDir
+}
+Write-Stage "Using Windows e2e install directory $InstallDir"
 
 Write-Stage "Preparing installer artifact"
 $resolvedInstaller = (Resolve-Path -LiteralPath $InstallerPath).Path

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -71,6 +71,9 @@ describe("Windows production e2e release gate", () => {
     expect(runner).toContain("Unblock-File");
     expect(runner).toContain("InstallerTimeoutSeconds");
     expect(runner).toContain("ProbeTimeoutSeconds");
+    expect(runner).toContain("Get-DefaultInstallDir");
+    expect(runner).toContain("systemprofile");
+    expect(runner).toContain("SerenDesktopE2E");
     expect(runner).toContain("WaitForExit");
     expect(runner).toContain("Write-Stage");
     expect(runner).toContain("Windows app e2e probe");
@@ -95,6 +98,8 @@ describe("Windows production e2e release gate", () => {
     expect(releaseGate).toContain("[windows-e2e:ssm] Installing npm dependencies");
     expect(releaseGate).toContain("[windows-e2e:ssm] Running Windows app harness");
     expect(releaseGate).toContain("-ProbeTimeoutSeconds 1800");
+    expect(releaseGate).toContain("$LASTEXITCODE");
+    expect(releaseGate).toContain("Windows app harness failed with exit code");
     expect(releaseGate).not.toContain("-AllowUnsignedPrArtifact");
     expect(releaseGate).not.toContain("SEREN_E2E_UNSIGNED_PR_RUN");
   });


### PR DESCRIPTION
Closes #2407.\n\n## Audit\n- Reproduced on AWS Windows host i-0a575b70ba969fb6e with merged #2406 artifact.\n- SSM command b58e1d49-19bc-4a18-9cf4-1d1fa7f0423e returned Success while the nested harness emitted `::error::Installed app is missing Seren.exe`.\n- Follow-up install audit showed the systemprofile LocalAppData target was empty while `C:\SerenDesktopE2E` materialized `Seren.exe` from the same installer.\n\n## Fix\n- Default the Windows e2e install dir to `%SystemDrive%\SerenDesktopE2E` when running under the LocalSystem/systemprofile SSM context; normal users still default to LocalAppData.\n- Make the release SSM command throw when the nested harness exits non-zero, so SSM cannot pass after a failed app probe.\n- Add focused guard coverage for the LocalSystem install-dir branch and `` propagation.\n\n## Tests\n- `pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts`\n- PowerShell parser check for `scripts/windows-e2e-app.ps1`\n- YAML parse for `.github/workflows/release.yml`\n- `git diff --check`\n