### PR TITLE
fix(windows): diagnose e2e CDP launch failures

### DIFF
--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -139,10 +139,43 @@ function Write-DirectorySnapshot([string]$Root) {
     Write-Host
 }
 
-function Wait-ForCdp([int]$Port, [int]$TimeoutSeconds) {
+function Write-WindowsLaunchDiagnostics([System.Diagnostics.Process]$AppProcess) {
+  Write-Stage "Collecting Windows launch diagnostics"
+  if ($null -ne $AppProcess) {
+    try {
+      $AppProcess.Refresh()
+      Write-Host "Seren process: pid=$($AppProcess.Id) exited=$($AppProcess.HasExited) exitCode=$(if ($AppProcess.HasExited) { $AppProcess.ExitCode } else { '<running>' })"
+    } catch {
+      Write-Host "::warning::Unable to refresh Seren process state: $($_.Exception.Message)"
+    }
+  }
+
+  Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -in @("Seren.exe", "msedgewebview2.exe") } |
+    Select-Object ProcessId, ParentProcessId, SessionId, Name, CommandLine |
+    Format-List |
+    Out-String |
+    Write-Host
+
+  Write-Host "Windows identity:"
+  & { $ErrorActionPreference = "Continue"; whoami 2>&1 } | Out-String | Write-Host
+  Write-Host "Windows sessions:"
+  & { $ErrorActionPreference = "Continue"; query session 2>&1 } | Out-String | Write-Host
+  Write-Host "Logged-on users:"
+  & { $ErrorActionPreference = "Continue"; quser 2>&1 } | Out-String | Write-Host
+}
+
+function Wait-ForCdp([int]$Port, [int]$TimeoutSeconds, [System.Diagnostics.Process]$AppProcess) {
   $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
   $url = "http://127.0.0.1:$Port/json/version"
   do {
+    if ($null -ne $AppProcess) {
+      $AppProcess.Refresh()
+      if ($AppProcess.HasExited) {
+        Write-WindowsLaunchDiagnostics $AppProcess
+        Fail "Seren.exe exited before WebView2 CDP became available. ExitCode=$($AppProcess.ExitCode)"
+      }
+    }
     try {
       $response = Invoke-RestMethod -Uri $url -Method Get -TimeoutSec 2
       if ($response.webSocketDebuggerUrl) {
@@ -153,7 +186,9 @@ function Wait-ForCdp([int]$Port, [int]$TimeoutSeconds) {
     }
   } while ((Get-Date) -lt $deadline)
 
-  Fail "Timed out waiting for WebView2 remote debugging endpoint at $url"
+  $webViewCount = @(Get-Process -Name "msedgewebview2" -ErrorAction SilentlyContinue).Count
+  Write-WindowsLaunchDiagnostics $AppProcess
+  Fail "Timed out waiting for WebView2 remote debugging endpoint at $url. msedgewebview2 process count=$webViewCount"
 }
 
 function Find-RequiredFile([string]$Root, [string]$Filter, [string]$Label) {
@@ -243,7 +278,7 @@ $app = Start-Process -FilePath $appExe -PassThru
 
 try {
   Write-Stage "Waiting for WebView2 CDP endpoint"
-  Wait-ForCdp -Port $RemoteDebugPort -TimeoutSeconds $StartupTimeoutSeconds
+  Wait-ForCdp -Port $RemoteDebugPort -TimeoutSeconds $StartupTimeoutSeconds -AppProcess $app
   Write-Stage "Running Node app e2e probe"
   $probeExitCode = Invoke-ProcessWithTimeout "node" @("$PSScriptRoot/windows-e2e-app.mjs") $ProbeTimeoutSeconds "Windows app e2e probe" -NoNewWindow
   if ($probeExitCode -ne 0) {

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -78,6 +78,10 @@ describe("Windows production e2e release gate", () => {
     expect(runner).toContain("Write-Stage");
     expect(runner).toContain("Windows app e2e probe");
     expect(runner).toContain("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS");
+    expect(runner).toContain("Write-WindowsLaunchDiagnostics");
+    expect(runner).toContain("msedgewebview2.exe");
+    expect(runner).toContain("query session");
+    expect(runner).toContain("quser");
     expect(runner).toContain("node.exe");
     expect(runner).toContain("npm.cmd");
     expect(runner).toContain("windows-e2e-app.mjs");


### PR DESCRIPTION
Refs #2409.

## Audit
- Final AWS walkthrough after #2408 installed to `C:\SerenDesktopE2E` and verified the bundled runtime.
- SSM command `fc37f9de-19a9-4111-ba4a-b8f2794665b8` failed at CDP startup with no WebView2 endpoint.
- Process audits showed `Seren.exe` stayed alive under SSM LocalSystem but no `msedgewebview2.exe` child was created.
- Session audit showed no logged-in Windows user on the AWS host.

## Fix
- On CDP timeout or early app exit, the harness now prints explicit launch diagnostics: Seren process state, WebView2 process list, current identity, Windows sessions, and logged-on users.
- The timeout error includes the WebView2 process count so the next AWS run distinguishes app exit, missing WebView2 child, and CDP-only failures.

## Scope
- This is the diagnostic slice for #2409. The remaining P1 work is to provision or select a Windows test path with an interactive logged-in desktop/session capable of starting WebView2/CDP.

## Tests
- `pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts`
- PowerShell parser check for `scripts/windows-e2e-app.ps1`
- `git diff --check`
