### PR TITLE
fix(ci): use commit SHA for manual-publish target_commitish

### DIFF
--- a/.github/workflows/publish-release-manual.yml
+++ b/.github/workflows/publish-release-manual.yml
@@ -50,7 +50,11 @@ jobs:
             const repo = context.repo.repo;
             const tagName = '${{ inputs.tag }}';
             const artifactsDir = 'artifacts';
-            const targetCommitish = tagName;
+            // target_commitish must be a branch or commit SHA, never a tag name —
+            // GitHub rejects a tag-named commitish with HTTP 422 on undraft. The
+            // tag already exists at this point, so this value is only validated,
+            // not used to move the tag. Mirror release.yml, which uses context.sha.
+            const targetCommitish = context.sha;
 
             const findReleaseForTag = async () => {
               try {


### PR DESCRIPTION
## Problem

The manual-publish override (`publish-release-manual.yml`, the #2323 lever) failed at the **Publish release** step with:

```
HttpError: Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"} (HTTP 422)
```

It set `target_commitish` to the **tag name** (`v3.55.2`) when undrafting the release. GitHub requires `target_commitish` to be a **branch or commit SHA**, never a tag name, and rejects it with 422.

This blocked the manual publish of v3.55.2, whose builds were all green and EV-signed — only the `windows-app-e2e` gate failed because the AWS e2e box was being upgraded (NSIS installer timed out at 180s).

## Fix

Mirror `release.yml`'s proven approach and pass `context.sha`. The git tag already exists at publish time, so this value is only validated, never used to move the tag.

## Validation

Re-dispatched the corrected workflow against the green build run (`27482625454`) for tag `v3.55.2` — publish + R2 mirror + `latest.json` succeeded.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
