### PR TITLE
Fix Windows e2e scheduled-task app harness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1107,6 +1107,7 @@ jobs:
           zip -q -r "$payload" \
             package.json \
             pnpm-lock.yaml \
+            scripts/windows-e2e-task-user.ps1 \
             scripts/windows-e2e-app.ps1 \
             scripts/windows-e2e-app.mjs
           prefix="release-windows-e2e/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
@@ -1138,19 +1139,6 @@ jobs:
           node <<'NODE' > "$RUNNER_TEMP/windows-e2e-commands.json"
           const env = process.env;
           const psString = (value) => `'${String(value).replaceAll("'", "''")}'`;
-          const secretNames = [
-            "SEREN_E2E_EMAIL",
-            "SEREN_E2E_PASSWORD",
-            "SEREN_E2E_HISTORY_PROJECT_ID",
-            "SEREN_E2E_HISTORY_BRANCH_ID",
-            "SEREN_E2E_HISTORY_DATABASE_NAME",
-            "SEREN_E2E_GITHUB_USERNAME",
-            "SEREN_E2E_GITHUB_PASSWORD",
-            "SEREN_E2E_GITHUB_PAT",
-            "SEREN_E2E_GITHUB_TOTP_SECRET",
-            "SEREN_E2E_AGENT_TYPE",
-            "SEREN_E2E_AGENT_CWD",
-          ];
           if (!env.INSTALLER_URL || !env.PAYLOAD_URL) {
             throw new Error("Missing presigned Windows e2e payload URL(s)");
           }
@@ -1166,28 +1154,10 @@ jobs:
             `Invoke-WebRequest -Uri ${psString(env.PAYLOAD_URL)} -OutFile (Join-Path $work 'windows-e2e-payload.zip')`,
             "Write-Host '[windows-e2e:ssm] Expanding e2e payload'",
             "Expand-Archive -LiteralPath (Join-Path $work 'windows-e2e-payload.zip') -DestinationPath $work -Force",
-            `$secretNames = @(${secretNames.map((name) => `'${name}'`).join(",")})`,
-            // The aws call runs under Windows PowerShell 5.1, where native
-            // stderr through a 2>$null redirect becomes a NativeCommandError
-            // that EAP=Stop turns terminating — a missing parameter killed the
-            // whole script before the guard ran (#2320). Scope EAP=Continue
-            // around the call so missing parameters degrade to the guarded
-            // skip they were designed for.
-            "Write-Host '[windows-e2e:ssm] Hydrating e2e secrets from SSM Parameter Store'",
-            `foreach ($name in $secretNames) { $parameterName = '${env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX}/' + $name; $value = & { $ErrorActionPreference = 'Continue'; aws ssm get-parameter --with-decryption --name $parameterName --query 'Parameter.Value' --output text 2>$null }; if ($LASTEXITCODE -eq 0 -and $value -and $value -ne 'None') { [Environment]::SetEnvironmentVariable($name, $value, 'Process') } }`,
-            "[Environment]::SetEnvironmentVariable('SEREN_E2E_API_BASE', 'https://api.serendb.com', 'Process')",
-            "[Environment]::SetEnvironmentVariable('SEREN_E2E_RELEASE_RUN', '1', 'Process')",
             "Set-Location $work",
-            "Write-Host '[windows-e2e:ssm] Enabling Corepack'",
-            "corepack enable",
-            "corepack prepare pnpm@9 --activate",
-            "Write-Host '[windows-e2e:ssm] Installing npm dependencies'",
-            "pnpm install --frozen-lockfile",
-            "Write-Host '[windows-e2e:ssm] Installing Playwright Chromium'",
-            "pnpm exec playwright install chromium",
-            "Write-Host '[windows-e2e:ssm] Running Windows app harness'",
-            "powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-app.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe') -ProbeTimeoutSeconds 1800",
-            "if ($LASTEXITCODE -ne 0) { throw \"Windows app harness failed with exit code $LASTEXITCODE\" }",
+            "Write-Host '[windows-e2e:ssm] Running Windows app harness as scheduled task user'",
+            `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-task-user.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe') -WorkDir $work -SecretParameterPrefix ${psString(env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX)} -ProbeTimeoutSeconds 1800 -TaskTimeoutSeconds 3600`,
+            "if ($LASTEXITCODE -ne 0) { throw \"Windows app scheduled-task harness failed with exit code $LASTEXITCODE\" }",
             ];
           process.stdout.write(JSON.stringify({ commands }, null, 2));
           NODE

--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -97,8 +97,39 @@ async function findSerenPage(browser) {
   );
 }
 
+async function resolveCdpEndpoint(endpoint) {
+  const versionUrl = `${endpoint.replace(/\/$/, "")}/json/version`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch(versionUrl, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const version = await response.json();
+    if (
+      typeof version.webSocketDebuggerUrl === "string" &&
+      version.webSocketDebuggerUrl.trim() !== ""
+    ) {
+      console.log(`[windows-e2e] resolved CDP websocket endpoint from ${versionUrl}`);
+      return version.webSocketDebuggerUrl;
+    }
+    throw new Error("missing webSocketDebuggerUrl");
+  } catch (error) {
+    console.warn(
+      `[windows-e2e] unable to resolve CDP websocket endpoint from ${versionUrl}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return endpoint;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 async function connectToApp() {
-  const browser = await chromium.connectOverCDP(CDP_ENDPOINT);
+  const cdpEndpoint = await resolveCdpEndpoint(CDP_ENDPOINT);
+  const browser = await chromium.connectOverCDP(cdpEndpoint, { timeout: 120_000 });
   const page = await findSerenPage(browser);
   const browserErrors = [];
   page.on("pageerror", (error) => browserErrors.push(error.message));
@@ -425,18 +456,42 @@ const AUTH_FAILURE_PATTERNS = [
   "invalid api key",
 ];
 
+const AGENT_PROCESS_EXIT_PATTERNS = [
+  "app server stopped before request completed",
+  "worker thread dropped while prompt was active",
+];
+
 function isAuthFailureMessage(message) {
   const lower = String(message ?? "").toLowerCase();
   return AUTH_FAILURE_PATTERNS.some((pattern) => lower.includes(pattern));
 }
 
+function isAgentProcessExitMessage(message) {
+  const lower = String(message ?? "").toLowerCase();
+  return AGENT_PROCESS_EXIT_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
 class AgentAuthError extends Error {}
+class AgentProvisioningError extends Error {}
 
 function authError(journey, detail) {
   return new AgentAuthError(
     `${journey} CLI is installed but not authenticated on the Windows e2e host ` +
       `(login expired or never provisioned). Refresh the credential via the ` +
-      `WINDOWS_E2E_SECRET_PARAMETER_PREFIX SSM mechanism. Detail: ${detail}`,
+      `WINDOWS_E2E_SECRET_PARAMETER_PREFIX SSM mechanism. If the harness runs ` +
+      `as a scheduled-task user, ensure SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI ` +
+      `or SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64 hydrates that temporary profile. ` +
+      `Detail: ${detail}`,
+  );
+}
+
+function provisioningError(journey, detail) {
+  return new AgentProvisioningError(
+    `${journey} CLI exited before completing the Windows e2e prompt. Verify ` +
+      `the scheduled-task user received agent credentials via ` +
+      `SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI or ` +
+      `SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64, and check provider-runtime logs ` +
+      `for a real process crash. Detail: ${detail}`,
   );
 }
 
@@ -456,18 +511,28 @@ function withTimeout(promise, ms, label) {
 // AgentAuthError so the job names the credential gap, not a timeout (#2375).
 function classifyJourneyError(journey, error, buffer, marker, sessionIds) {
   if (error instanceof AgentAuthError) return error;
+  if (error instanceof AgentProvisioningError) return error;
   const message = error instanceof Error ? error.message : String(error);
   if (isAuthFailureMessage(message)) return authError(journey, message);
+  if (isAgentProcessExitMessage(message)) return provisioningError(journey, message);
   const ids = sessionIds.filter(Boolean);
-  const authEvent = buffer
+  const journeyEvents = buffer
     .slice(marker)
-    .find(
+    .filter(
       (event) =>
         event.method === "provider://error" &&
-        ids.includes(event.params?.sessionId) &&
-        isAuthFailureMessage(event.params?.error),
+        ids.includes(event.params?.sessionId),
     );
+  const authEvent = journeyEvents.find((event) =>
+    isAuthFailureMessage(event.params?.error),
+  );
   if (authEvent) return authError(journey, String(authEvent.params.error));
+  const processExitEvent = journeyEvents.find((event) =>
+    isAgentProcessExitMessage(event.params?.error),
+  );
+  if (processExitEvent) {
+    return provisioningError(journey, String(processExitEvent.params.error));
+  }
   return error instanceof Error ? error : new Error(message);
 }
 

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -81,6 +81,29 @@ function Require-SignedOrExplicitPrArtifact([string]$Path, [string]$Label) {
   Write-Host "::warning::$Label Authenticode validation skipped for explicit unsigned PR artifact run: $Path"
 }
 
+function Get-WebView2RuntimeVersion() {
+  $runtimeClientId = "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
+  $candidatePaths = @(
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\$runtimeClientId",
+    "HKCU:\Software\Microsoft\EdgeUpdate\Clients\$runtimeClientId",
+    "HKLM:\SOFTWARE\Microsoft\EdgeUpdate\Clients\$runtimeClientId"
+  )
+  foreach ($path in $candidatePaths) {
+    try {
+      if (-not (Test-Path -LiteralPath $path)) {
+        continue
+      }
+      $runtime = Get-ItemProperty -LiteralPath $path -ErrorAction Stop
+      if (-not [string]::IsNullOrWhiteSpace($runtime.pv) -and $runtime.pv -ne "0.0.0.0") {
+        return "$($runtime.pv) ($path)"
+      }
+    } catch {
+      Write-Host "::warning::Unable to inspect WebView2 runtime registry key ${path}: $($_.Exception.Message)"
+    }
+  }
+  return $null
+}
+
 function Clear-DownloadMark([string]$Path, [string]$Label) {
   if (-not (Test-Path -LiteralPath $Path)) {
     Fail "$Label not found: $Path"
@@ -271,6 +294,12 @@ if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($npmVersion)) {
   Fail "Bundled npm.cmd did not execute successfully"
 }
 Write-Host "Bundled runtime verified: node=$nodeVersion npm=$npmVersion providerRuntime=$providerRuntime"
+
+$webView2Runtime = Get-WebView2RuntimeVersion
+if ([string]::IsNullOrWhiteSpace($webView2Runtime)) {
+  Fail "Microsoft Edge WebView2 Runtime is not installed. The Windows app cannot create a WebView2/CDP endpoint without the Evergreen Runtime."
+}
+Write-Stage "WebView2 runtime detected: $webView2Runtime"
 
 $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$RemoteDebugPort --remote-allow-origins=*"
 Write-Stage "Launching Seren.exe with WebView2 remote debugging on port $RemoteDebugPort"

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -1,0 +1,443 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$InstallerPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$WorkDir,
+
+  [Parameter(Mandatory = $true)]
+  [string]$SecretParameterPrefix,
+
+  [int]$RemoteDebugPort = 9222,
+
+  [int]$StartupTimeoutSeconds = 120,
+
+  [int]$InstallerTimeoutSeconds = 600,
+
+  [int]$ProbeTimeoutSeconds = 1800,
+
+  [int]$TaskTimeoutSeconds = 3600,
+
+  [switch]$AllowUnsignedPrArtifact,
+
+  [switch]$AllowMissingAgentCredentials
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Fail([string]$Message) {
+  Write-Host "::error::$Message"
+  exit 1
+}
+
+function Write-Stage([string]$Message) {
+  $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  Write-Host "[windows-e2e:task-user] $timestamp $Message"
+}
+
+function Convert-ToSingleQuotedPowerShellString([string]$Value) {
+  return "'$($Value.Replace("'", "''"))'"
+}
+
+function New-TemporaryPassword() {
+  $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+  try {
+    do {
+      $bytes = New-Object byte[] 18
+      $rng.GetBytes($bytes)
+      $token = ([Convert]::ToBase64String($bytes) -replace "[^A-Za-z0-9]", "")
+    } while ($token.Length -lt 16)
+    return "S3ren-$($token.Substring(0, 16))!9a"
+  } finally {
+    $rng.Dispose()
+  }
+}
+
+function Invoke-CleanupWithTimeout {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Label,
+
+    [Parameter(Mandatory = $true)]
+    [scriptblock]$ScriptBlock,
+
+    [object[]]$ArgumentList = @(),
+
+    [int]$TimeoutSeconds = 30
+  )
+
+  $job = $null
+  try {
+    $job = Start-Job -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList
+    $completed = Wait-Job -Job $job -Timeout $TimeoutSeconds
+    if (-not $completed) {
+      Write-Host "::warning::$Label timed out after ${TimeoutSeconds}s; continuing cleanup"
+      Stop-Job -Job $job -ErrorAction SilentlyContinue
+      return
+    }
+    Receive-Job -Job $job -ErrorAction Continue | Out-Host
+  } catch {
+    Write-Host "::warning::$Label failed: $($_.Exception.Message)"
+  } finally {
+    if ($job) {
+      Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+    }
+  }
+}
+
+function Stop-E2EProcessTree {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$InstallDir
+  )
+
+  $normalizedInstallDir = $InstallDir.TrimEnd("\")
+  try {
+    Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+      Where-Object {
+        $name = [string]$_.Name
+        $path = [string]$_.ExecutablePath
+        $commandLine = [string]$_.CommandLine
+        $inInstallDir =
+          $path.StartsWith($normalizedInstallDir, [StringComparison]::OrdinalIgnoreCase) -or
+          ($commandLine.IndexOf($normalizedInstallDir, [StringComparison]::OrdinalIgnoreCase) -ge 0)
+        $isAppProcess = @("Seren.exe", "msedgewebview2.exe") -contains $name
+        $isRuntimeNode = $name -eq "node.exe" -and $inInstallDir
+        $isAppProcess -or $isRuntimeNode
+      } |
+      ForEach-Object {
+        Write-Stage "Stopping leftover e2e process $($_.Name) pid=$($_.ProcessId)"
+        Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+      }
+  } catch {
+    Write-Host "::warning::Unable to stop leftover e2e process tree: $($_.Exception.Message)"
+  }
+}
+
+function Remove-LocalE2EUser([string]$UserName) {
+  if ([string]::IsNullOrWhiteSpace($UserName)) {
+    return
+  }
+  $profilePath = Join-Path "C:\Users" $UserName
+  Invoke-CleanupWithTimeout `
+    -Label "Delete temporary Windows user $UserName" `
+    -ScriptBlock { param($Name) & net user $Name /delete 2>$null | Out-Null } `
+    -ArgumentList @($UserName) `
+    -TimeoutSeconds 15
+  Invoke-CleanupWithTimeout `
+    -Label "Remove temporary Windows profile registration $profilePath" `
+    -ScriptBlock {
+      param($Path)
+      Get-CimInstance Win32_UserProfile -ErrorAction SilentlyContinue |
+        Where-Object { $_.LocalPath -eq $Path } |
+        Remove-CimInstance -ErrorAction SilentlyContinue
+    } `
+    -ArgumentList @($profilePath) `
+    -TimeoutSeconds 30
+  Invoke-CleanupWithTimeout `
+    -Label "Remove temporary Windows profile directory $profilePath" `
+    -ScriptBlock {
+      param($Path)
+      if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
+      }
+    } `
+    -ArgumentList @($profilePath) `
+    -TimeoutSeconds 30
+}
+
+$resolvedInstaller = (Resolve-Path -LiteralPath $InstallerPath).Path
+$resolvedWorkDir = (Resolve-Path -LiteralPath $WorkDir).Path
+$runnerPath = Join-Path $resolvedWorkDir "scripts\windows-e2e-app.ps1"
+if (-not (Test-Path -LiteralPath $runnerPath)) {
+  Fail "Windows app harness missing from e2e payload: $runnerPath"
+}
+
+$taskName = "SerenDesktopE2E-$([Guid]::NewGuid().ToString("N").Substring(0, 8))"
+$userName = "SerenE2E$([Guid]::NewGuid().ToString("N").Substring(0, 6))"
+$qualifiedUserName = "$env:COMPUTERNAME\$userName"
+$password = New-TemporaryPassword
+$taskScriptPath = Join-Path $resolvedWorkDir "windows-e2e-task.ps1"
+$taskLogPath = Join-Path $resolvedWorkDir "windows-e2e-task.log"
+$e2eInstallDir = Join-Path $env:SystemDrive "SerenDesktopE2E"
+$startedAt = Get-Date
+
+try {
+  Write-Stage "Creating temporary Windows user $qualifiedUserName"
+  Remove-LocalE2EUser $userName
+  & net user $userName $password /add /Y | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    Fail "Failed to create temporary Windows e2e user $qualifiedUserName"
+  }
+  & net localgroup Administrators $userName /add | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    Fail "Failed to grant Administrators membership to $qualifiedUserName"
+  }
+
+  Write-Stage "Granting temporary user access to $resolvedWorkDir"
+  $grant = "$($env:COMPUTERNAME)\$($userName):(OI)(CI)M"
+  & icacls $resolvedWorkDir /grant $grant /T | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    Fail "Failed to grant $qualifiedUserName access to $resolvedWorkDir"
+  }
+
+  $psWorkDir = Convert-ToSingleQuotedPowerShellString $resolvedWorkDir
+  $psInstaller = Convert-ToSingleQuotedPowerShellString $resolvedInstaller
+  $psSecretPrefix = Convert-ToSingleQuotedPowerShellString $SecretParameterPrefix.TrimEnd("/")
+  $psTaskLog = Convert-ToSingleQuotedPowerShellString $taskLogPath
+  $psAllowUnsignedPrArtifact = if ($AllowUnsignedPrArtifact) { "`$true" } else { "`$false" }
+  $psAllowMissingAgentCredentials = if ($AllowMissingAgentCredentials) { "`$true" } else { "`$false" }
+  $taskScript = @"
+`$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+`$ProgressPreference = "SilentlyContinue"
+`$work = $psWorkDir
+`$installerPath = $psInstaller
+`$secretPrefix = $psSecretPrefix
+`$taskLog = $psTaskLog
+`$remoteDebugPort = $RemoteDebugPort
+`$startupTimeoutSeconds = $StartupTimeoutSeconds
+`$probeTimeoutSeconds = $ProbeTimeoutSeconds
+`$allowUnsignedPrArtifact = $psAllowUnsignedPrArtifact
+`$allowMissingAgentCredentials = $psAllowMissingAgentCredentials
+`$installDir = Join-Path `$env:SystemDrive "SerenDesktopE2E"
+`$installerTimeoutSeconds = $InstallerTimeoutSeconds
+`$awsCliTimeoutArgs = @("--cli-connect-timeout", "10", "--cli-read-timeout", "30")
+
+function Write-TaskLog([string]`$Message) {
+  `$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  Add-Content -LiteralPath `$taskLog -Value "[windows-e2e:task] `$timestamp `$Message"
+}
+
+function Invoke-LoggedNative([string]`$Label, [string]`$FilePath, [string[]]`$ArgumentList, [int]`$TimeoutSeconds = 600) {
+  Write-TaskLog "Starting `$Label"
+  `$job = `$null
+  try {
+    `$workingDirectory = (Get-Location).Path
+    `$job = Start-Job -ScriptBlock {
+      param([string]`$Command, [string[]]`$CommandArgs, [string]`$WorkingDirectory)
+      try {
+        Set-Location `$WorkingDirectory
+        `$output = & `$Command @CommandArgs 2>&1
+        `$exitCode = if (`$null -eq `$LASTEXITCODE) { 0 } else { [int]`$LASTEXITCODE }
+      } catch {
+        `$output = @(`$_.Exception.Message)
+        `$exitCode = 1
+      }
+      foreach (`$line in `$output) {
+        [pscustomobject]@{ Kind = "output"; Value = [string]`$line }
+      }
+      [pscustomobject]@{ Kind = "exit"; Value = [string]`$exitCode }
+    } -ArgumentList `$FilePath, `$ArgumentList, `$workingDirectory
+
+    `$completed = Wait-Job -Job `$job -Timeout `$TimeoutSeconds
+    if (-not `$completed) {
+      Receive-Job -Job `$job -Keep -ErrorAction SilentlyContinue | Where-Object { `$_.Kind -eq "output" } | ForEach-Object {
+        Add-Content -LiteralPath `$taskLog -Value ([string]`$_.Value)
+      }
+      Stop-Job -Job `$job -ErrorAction SilentlyContinue
+      throw "`$Label timed out after `$TimeoutSeconds seconds"
+    }
+    `$records = @(Receive-Job -Job `$job -ErrorAction SilentlyContinue)
+    `$records | Where-Object { `$_.Kind -eq "output" } | ForEach-Object {
+      Add-Content -LiteralPath `$taskLog -Value ([string]`$_.Value)
+    }
+    `$exitRecord = `$records | Where-Object { `$_.Kind -eq "exit" } | Select-Object -Last 1
+    `$exitCode = if (`$exitRecord) { [int]`$exitRecord.Value } else { 1 }
+    if (`$exitCode -ne 0) {
+      throw "`$Label failed with exit code `$exitCode"
+    }
+  } finally {
+    if (`$job) {
+      Remove-Job -Job `$job -Force -ErrorAction SilentlyContinue
+    }
+  }
+  Write-TaskLog "`$Label completed"
+}
+
+function Get-EnvValue([string]`$Name) {
+  return [Environment]::GetEnvironmentVariable(`$Name, "Process")
+}
+
+function Convert-EnvFlag([string]`$Value, [bool]`$Default) {
+  if ([string]::IsNullOrWhiteSpace(`$Value)) {
+    return `$Default
+  }
+  return @("1", "true", "yes", "on") -contains `$Value.Trim().ToLowerInvariant()
+}
+
+function Import-AgentCredentialArchive() {
+  `$archiveS3Uri = Get-EnvValue "SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI"
+  `$archiveB64 = Get-EnvValue "SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64"
+  `$credentialsRequired = Convert-EnvFlag (Get-EnvValue "SEREN_E2E_AGENT_CREDENTIALS_REQUIRED") `$true
+
+  if ([string]::IsNullOrWhiteSpace(`$archiveS3Uri) -and [string]::IsNullOrWhiteSpace(`$archiveB64)) {
+    if (`$credentialsRequired) {
+      throw "Missing Windows e2e agent credential archive. Store a profile-root zip at `$secretPrefix/SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI or `$secretPrefix/SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64 before running agent journeys."
+    }
+    Write-TaskLog "Agent credential archive not configured; continuing because SEREN_E2E_AGENT_CREDENTIALS_REQUIRED is false"
+    return
+  }
+
+  `$archivePath = Join-Path `$env:TEMP "seren-agent-credentials.zip"
+  Remove-Item -LiteralPath `$archivePath -Force -ErrorAction SilentlyContinue
+  if (-not [string]::IsNullOrWhiteSpace(`$archiveS3Uri)) {
+    Invoke-LoggedNative "Agent credential archive download" "aws" (@("s3", "cp", `$archiveS3Uri, `$archivePath, "--only-show-errors") + `$awsCliTimeoutArgs) 300
+  } else {
+    Write-TaskLog "Decoding agent credential archive from SSM"
+    [System.IO.File]::WriteAllBytes(`$archivePath, [Convert]::FromBase64String(`$archiveB64))
+  }
+
+  Write-TaskLog "Expanding agent credential archive into temporary user profile"
+  Expand-Archive -LiteralPath `$archivePath -DestinationPath `$env:USERPROFILE -Force
+  Remove-Item -LiteralPath `$archivePath -Force -ErrorAction SilentlyContinue
+  Write-TaskLog "Imported agent credential archive into temporary user profile"
+}
+
+try {
+  Set-Content -LiteralPath `$taskLog -Value "[windows-e2e:task] `$((Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")) task-user=`$(whoami)"
+  [Environment]::SetEnvironmentVariable("AWS_METADATA_SERVICE_TIMEOUT", "2", "Process")
+  [Environment]::SetEnvironmentVariable("AWS_METADATA_SERVICE_NUM_ATTEMPTS", "2", "Process")
+  Write-TaskLog "Hydrating e2e secrets from SSM Parameter Store"
+  `$secretNames = @(
+    "SEREN_E2E_EMAIL",
+    "SEREN_E2E_PASSWORD",
+    "SEREN_E2E_HISTORY_PROJECT_ID",
+    "SEREN_E2E_HISTORY_BRANCH_ID",
+    "SEREN_E2E_HISTORY_DATABASE_NAME",
+    "SEREN_E2E_GITHUB_USERNAME",
+    "SEREN_E2E_GITHUB_PASSWORD",
+    "SEREN_E2E_GITHUB_PAT",
+    "SEREN_E2E_GITHUB_TOTP_SECRET",
+    "SEREN_E2E_AGENT_TYPE",
+    "SEREN_E2E_AGENT_CWD",
+    "SEREN_E2E_AGENT_JOURNEYS",
+    "SEREN_E2E_AGENT_PROMPT",
+    "SEREN_E2E_AGENT_CREDENTIALS_REQUIRED",
+    "SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI",
+    "SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64"
+  )
+  foreach (`$name in `$secretNames) {
+    `$parameterName = "`$secretPrefix/`$name"
+    `$value = & { `$ErrorActionPreference = "Continue"; aws ssm get-parameter --with-decryption --name `$parameterName --query "Parameter.Value" --output text @awsCliTimeoutArgs 2>`$null }
+    if (`$LASTEXITCODE -eq 0 -and `$value -and `$value -ne "None") {
+      [Environment]::SetEnvironmentVariable(`$name, `$value, "Process")
+    }
+  }
+  [Environment]::SetEnvironmentVariable("SEREN_E2E_API_BASE", "https://api.serendb.com", "Process")
+  if (`$allowUnsignedPrArtifact) {
+    [Environment]::SetEnvironmentVariable("SEREN_E2E_UNSIGNED_PR_RUN", "1", "Process")
+  } else {
+    [Environment]::SetEnvironmentVariable("SEREN_E2E_RELEASE_RUN", "1", "Process")
+  }
+  if (`$allowMissingAgentCredentials) {
+    [Environment]::SetEnvironmentVariable("SEREN_E2E_AGENT_CREDENTIALS_REQUIRED", "0", "Process")
+  }
+  Import-AgentCredentialArchive
+
+  Set-Location `$work
+  Write-TaskLog "Using install directory `$installDir"
+  Invoke-LoggedNative "Corepack enable" "corepack" @("enable") 120
+  Invoke-LoggedNative "Corepack prepare pnpm" "corepack" @("prepare", "pnpm@9", "--activate") 180
+  Invoke-LoggedNative "pnpm install" "pnpm" @("install", "--frozen-lockfile") 1200
+  Invoke-LoggedNative "Playwright Chromium install" "pnpm" @("exec", "playwright", "install", "chromium") 600
+  `$harnessArgs = @(
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    ".\scripts\windows-e2e-app.ps1",
+    "-InstallerPath",
+    `$installerPath,
+    "-InstallDir",
+    `$installDir,
+    "-InstallerTimeoutSeconds",
+    [string]`$installerTimeoutSeconds,
+    "-RemoteDebugPort",
+    [string]`$remoteDebugPort,
+    "-StartupTimeoutSeconds",
+    [string]`$startupTimeoutSeconds,
+    "-ProbeTimeoutSeconds",
+    [string]`$probeTimeoutSeconds
+  )
+  if (`$allowUnsignedPrArtifact) {
+    `$harnessArgs += "-AllowUnsignedPrArtifact"
+  }
+  `$harnessTimeoutSeconds = [Math]::Max(600, `$installerTimeoutSeconds + `$probeTimeoutSeconds + 300)
+  Invoke-LoggedNative "Windows app harness" "powershell" `$harnessArgs `$harnessTimeoutSeconds
+  Write-TaskLog "Windows app scheduled-task harness completed"
+} catch {
+  Write-TaskLog "::error::`$(`$_.Exception.Message)"
+  exit 1
+}
+"@
+  Set-Content -LiteralPath $taskScriptPath -Value $taskScript -Encoding UTF8
+
+  Write-Stage "Registering scheduled task $taskName"
+  $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$taskScriptPath`""
+  $settings = New-ScheduledTaskSettingsSet `
+    -ExecutionTimeLimit (New-TimeSpan -Seconds $TaskTimeoutSeconds) `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable
+  Register-ScheduledTask `
+    -TaskName $taskName `
+    -Action $action `
+    -Settings $settings `
+    -User $qualifiedUserName `
+    -Password $password `
+    -RunLevel Highest `
+    -Force |
+    Out-Null
+
+  Write-Stage "Starting scheduled task $taskName"
+  Start-ScheduledTask -TaskName $taskName
+  $deadline = (Get-Date).AddSeconds($TaskTimeoutSeconds + 60)
+  $lastStatus = ""
+  do {
+    Start-Sleep -Seconds 5
+    $task = Get-ScheduledTask -TaskName $taskName
+    $taskInfo = Get-ScheduledTaskInfo -TaskName $taskName
+    $status = "state=$($task.State) lastResult=$($taskInfo.LastTaskResult)"
+    if ($status -ne $lastStatus) {
+      Write-Stage "Scheduled task $status"
+      $lastStatus = $status
+    }
+    if ($taskInfo.LastRunTime -gt $startedAt.AddSeconds(-10) -and $task.State -ne "Running") {
+      break
+    }
+  } while ((Get-Date) -lt $deadline)
+
+  $task = Get-ScheduledTask -TaskName $taskName
+  $taskInfo = Get-ScheduledTaskInfo -TaskName $taskName
+  if ($task.State -eq "Running") {
+    Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+    Fail "Windows app scheduled-task harness timed out after ${TaskTimeoutSeconds}s"
+  }
+
+  Write-Stage "Scheduled task log follows"
+  if (Test-Path -LiteralPath $taskLogPath) {
+    Get-Content -LiteralPath $taskLogPath -Tail 800 | Write-Host
+  } else {
+    Write-Host "::warning::Scheduled task log was not created: $taskLogPath"
+  }
+
+  if ($taskInfo.LastTaskResult -ne 0) {
+    Fail "Windows app scheduled-task harness failed with result $($taskInfo.LastTaskResult)"
+  }
+  Write-Stage "Windows app scheduled-task harness passed"
+} finally {
+  Write-Stage "Cleaning up scheduled task, temporary user, and app processes"
+  try {
+    Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+  } catch {
+  }
+  try {
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+  } catch {
+  }
+  Stop-E2EProcessTree -InstallDir $e2eInstallDir
+  Remove-Item -LiteralPath $taskScriptPath -Force -ErrorAction SilentlyContinue
+  Remove-LocalE2EUser $userName
+}

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -18,6 +18,10 @@ const manualPublishWorkflow = existsSync(manualPublishWorkflowPath)
   ? readFileSync(manualPublishWorkflowPath, "utf8")
   : "";
 const runner = readFileSync(join(root, "scripts/windows-e2e-app.ps1"), "utf8");
+const taskUserRunner = readFileSync(
+  join(root, "scripts/windows-e2e-task-user.ps1"),
+  "utf8",
+);
 const probe = readFileSync(join(root, "scripts/windows-e2e-app.mjs"), "utf8");
 
 function workflowJob(name: string): string {
@@ -82,11 +86,53 @@ describe("Windows production e2e release gate", () => {
     expect(runner).toContain("msedgewebview2.exe");
     expect(runner).toContain("query session");
     expect(runner).toContain("quser");
+    expect(runner).toContain("{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}");
+    expect(runner).toContain("WebView2 runtime detected");
     expect(runner).toContain("node.exe");
     expect(runner).toContain("npm.cmd");
     expect(runner).toContain("windows-e2e-app.mjs");
     expect(probe).toContain("connectOverCDP");
+    expect(probe).toContain("webSocketDebuggerUrl");
+    expect(probe).toContain("120_000");
     expect(probe).toContain("__TAURI_INTERNALS__");
+  });
+
+  it("runs the Windows app harness as a temporary scheduled-task user", () => {
+    expect(releaseWorkflow).toContain("scripts/windows-e2e-task-user.ps1");
+    expect(releaseWorkflow).toContain(
+      "[windows-e2e:ssm] Running Windows app harness as scheduled task user",
+    );
+    expect(taskUserRunner).toContain("Register-ScheduledTask");
+    expect(taskUserRunner).toContain("Start-ScheduledTask");
+    expect(taskUserRunner).toContain("Get-ScheduledTaskInfo");
+    expect(taskUserRunner).toContain("Unregister-ScheduledTask");
+    expect(taskUserRunner).toContain("net user");
+    expect(taskUserRunner).toContain("Administrators");
+    expect(taskUserRunner).toContain("SEREN_E2E_RELEASE_RUN");
+    expect(taskUserRunner).toContain("AllowUnsignedPrArtifact");
+    expect(taskUserRunner).toContain("AllowMissingAgentCredentials");
+    expect(taskUserRunner).toContain("SEREN_E2E_UNSIGNED_PR_RUN");
+    expect(taskUserRunner).toContain("SerenDesktopE2E");
+    expect(taskUserRunner).toContain("-InstallDir");
+    expect(taskUserRunner).toContain("InstallerTimeoutSeconds = 600");
+    expect(taskUserRunner).toContain("windows-e2e-app.ps1");
+    expect(taskUserRunner).toContain("Windows app scheduled-task harness failed");
+    expect(taskUserRunner).toContain("Stop-E2EProcessTree");
+    expect(taskUserRunner).toContain("node.exe");
+    expect(taskUserRunner).toContain("Invoke-CleanupWithTimeout");
+    expect(taskUserRunner).toContain("Start-Job");
+    expect(taskUserRunner).toContain("SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI");
+    expect(taskUserRunner).toContain("SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64");
+    expect(taskUserRunner).toContain("SEREN_E2E_AGENT_CREDENTIALS_REQUIRED");
+    expect(taskUserRunner).toContain("Expand-Archive");
+    expect(taskUserRunner).toContain("AWS_METADATA_SERVICE_TIMEOUT");
+    expect(taskUserRunner).toContain("--cli-connect-timeout");
+    expect(taskUserRunner).toContain("--cli-read-timeout");
+    expect(taskUserRunner).toContain("Start-Job");
+    expect(taskUserRunner).toContain("Wait-Job");
+    expect(taskUserRunner).toContain("Stop-Job");
+    expect(taskUserRunner).toContain("pnpm install");
+    expect(taskUserRunner).toContain("1200");
   });
 
   it("keeps unsigned PR artifact mode explicit and forbidden for release runs", () => {
@@ -98,13 +144,16 @@ describe("Windows production e2e release gate", () => {
     const releaseGate = workflowJob("windows-app-e2e");
     expect(releaseGate).toContain("aws s3 presign");
     expect(releaseGate).toContain("Invoke-WebRequest -Uri");
-    expect(releaseGate).toContain("SEREN_E2E_RELEASE_RUN");
-    expect(releaseGate).toContain("[windows-e2e:ssm] Installing npm dependencies");
-    expect(releaseGate).toContain("[windows-e2e:ssm] Running Windows app harness");
+    expect(releaseGate).toContain(
+      "[windows-e2e:ssm] Running Windows app harness as scheduled task user",
+    );
     expect(releaseGate).toContain("-ProbeTimeoutSeconds 1800");
     expect(releaseGate).toContain("$LASTEXITCODE");
-    expect(releaseGate).toContain("Windows app harness failed with exit code");
+    expect(releaseGate).toContain(
+      "Windows app scheduled-task harness failed with exit code",
+    );
     expect(releaseGate).not.toContain("-AllowUnsignedPrArtifact");
+    expect(releaseGate).not.toContain("-AllowMissingAgentCredentials");
     expect(releaseGate).not.toContain("SEREN_E2E_UNSIGNED_PR_RUN");
   });
 
@@ -155,8 +204,11 @@ describe("Windows production e2e release gate", () => {
     // An expired or unprovisioned credential must read as a login problem, not
     // a generic spawn/timeout failure.
     expect(probe).toContain("AgentAuthError");
+    expect(probe).toContain("AgentProvisioningError");
     expect(probe).toContain("not authenticated");
     expect(probe).toContain("provider://error");
+    expect(probe).toContain("app server stopped before request completed");
+    expect(probe).toContain("SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI");
   });
 
   it("has a manual publish override for already-built release artifacts", () => {


### PR DESCRIPTION
## Summary
- run the Windows app e2e harness as a temporary scheduled-task user so WebView2/CDP can start outside SSM LocalSystem
- add WebView2 runtime detection, CDP websocket endpoint resolution, and clearer agent provisioning failures
- move SSM secret hydration/setup into the task-user wrapper with bounded AWS CLI/native command steps and cleanup of app/provider-runtime processes

## Audit results
- AWS host `i-0a575b70ba969fb6e` confirmed the original LocalSystem path starts `Seren.exe` without WebView2/CDP.
- Scheduled-task user launch reached WebView2/CDP and production sign-in in earlier manual run `aaf90bcd-e3f5-4113-9b74-85e8d7aeed37`.
- Follow-up audits found and addressed cleanup hangs, unbounded AWS CLI hydration, and unbounded setup command execution.
- Full agent journey remains blocked by missing agent CLI credential archive in `/seren-desktop/windows-e2e/prod`; tracked in #2413 and intentionally not closed here.

## Validation
- `pwsh` parser: `scripts/windows-e2e-task-user.ps1`
- `pwsh` parser: `scripts/windows-e2e-app.ps1`
- `node --check scripts/windows-e2e-app.mjs`
- `pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts`
- `git diff --check`

Closes #2409
Closes #2412
Closes #2414
Closes #2415
Refs #2413