### PR TITLE
fix(windows): preflight e2e agent credentials

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -545,6 +545,15 @@ async function runSingleAgentJourney(ws, buffer, agentType) {
       agentType,
     });
     assert(available === true, `${agentType} is not available on the Windows e2e host`);
+    const authenticated = await rpc(ws, "provider_check_agent_authenticated", {
+      agentType,
+    });
+    if (authenticated !== true) {
+      throw authError(
+        agentType,
+        "provider_check_agent_authenticated returned false before prompt",
+      );
+    }
     session = await rpc(ws, "provider_spawn", {
       agentType,
       cwd: AGENT_CWD,
@@ -604,6 +613,15 @@ async function runPairedJourney(ws, buffer) {
       agentType: PAIRED_AGENT_TYPE,
     });
     assert(available === true, `${PAIRED_AGENT_TYPE} is not available on the Windows e2e host`);
+    const authenticated = await rpc(ws, "provider_check_agent_authenticated", {
+      agentType: PAIRED_AGENT_TYPE,
+    });
+    if (authenticated !== true) {
+      throw authError(
+        PAIRED_AGENT_TYPE,
+        "provider_check_agent_authenticated returned false before prompt",
+      );
+    }
     session = await rpc(ws, "provider_spawn", {
       agentType: PAIRED_AGENT_TYPE,
       cwd: AGENT_CWD,

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -267,6 +267,85 @@ function Convert-EnvFlag([string]`$Value, [bool]`$Default) {
   return @("1", "true", "yes", "on") -contains `$Value.Trim().ToLowerInvariant()
 }
 
+function Test-AnyCredentialPath([string[]]`$Paths) {
+  foreach (`$candidate in `$Paths) {
+    if (-not [string]::IsNullOrWhiteSpace(`$candidate) -and (Test-Path -LiteralPath `$candidate -PathType Leaf)) {
+      return `$true
+    }
+  }
+  return `$false
+}
+
+function Get-ConfiguredAgentJourneys() {
+  `$configured = Get-EnvValue "SEREN_E2E_AGENT_JOURNEYS"
+  if ([string]::IsNullOrWhiteSpace(`$configured)) {
+    return @("codex", "claude-code", "claude-codex")
+  }
+  return @(
+    `$configured.Split(",") |
+      ForEach-Object { `$_.Trim().ToLowerInvariant() } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace(`$_) } |
+      Select-Object -Unique
+  )
+}
+
+function Get-MissingAgentCredentialNames() {
+  `$journeys = @(Get-ConfiguredAgentJourneys)
+  `$requiresClaude = `$journeys -contains "claude-code" -or `$journeys -contains "claude-codex"
+  `$requiresCodex = `$journeys -contains "codex" -or `$journeys -contains "claude-codex"
+  `$home = [Environment]::GetEnvironmentVariable("USERPROFILE")
+  `$appData = [Environment]::GetEnvironmentVariable("APPDATA")
+  `$missing = @()
+
+  if (`$requiresClaude) {
+    `$claudePaths = @(
+      (Join-Path `$home ".claude\.credentials.json"),
+      (Join-Path `$home ".claude.json")
+    )
+    if (-not [string]::IsNullOrWhiteSpace(`$appData)) {
+      `$claudePaths += @(
+        (Join-Path `$appData "Claude\.credentials.json"),
+        (Join-Path `$appData "Claude\credentials.json")
+      )
+    }
+    if (-not (Test-AnyCredentialPath `$claudePaths)) {
+      `$missing += "Claude Code (.claude/.credentials.json or equivalent)"
+    }
+  }
+
+  if (`$requiresCodex) {
+    `$codexHasEnvKey = -not [string]::IsNullOrWhiteSpace((Get-EnvValue "OPENAI_API_KEY"))
+    `$codexPaths = @(
+      (Join-Path `$home ".codex\auth.json"),
+      (Join-Path `$home ".codex\credentials.json")
+    )
+    if (-not [string]::IsNullOrWhiteSpace(`$appData)) {
+      `$codexPaths += @(
+        (Join-Path `$appData "Codex\auth.json"),
+        (Join-Path `$appData "OpenAI\Codex\auth.json")
+      )
+    }
+    if (-not `$codexHasEnvKey -and -not (Test-AnyCredentialPath `$codexPaths)) {
+      `$missing += "Codex (.codex/auth.json or equivalent)"
+    }
+  }
+
+  return `$missing
+}
+
+function Assert-AgentCredentialsPresent() {
+  `$credentialsRequired = Convert-EnvFlag (Get-EnvValue "SEREN_E2E_AGENT_CREDENTIALS_REQUIRED") `$true
+  if (-not `$credentialsRequired) {
+    Write-TaskLog "Skipping agent credential validation because SEREN_E2E_AGENT_CREDENTIALS_REQUIRED is false"
+    return
+  }
+  `$missing = @(Get-MissingAgentCredentialNames)
+  if (`$missing.Count -gt 0) {
+    throw "Windows e2e agent credential archive did not provision required CLI credential file(s): `$(`$missing -join ', '). Store a profile-root zip at `$secretPrefix/SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI or `$secretPrefix/SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64. The archive should expand directly into USERPROFILE without an extra top-level folder."
+  }
+  Write-TaskLog "Validated agent CLI credentials for configured journey(s)"
+}
+
 function Import-AgentCredentialArchive() {
   `$archiveS3Uri = Get-EnvValue "SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI"
   `$archiveB64 = Get-EnvValue "SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64"
@@ -293,6 +372,7 @@ function Import-AgentCredentialArchive() {
   Expand-Archive -LiteralPath `$archivePath -DestinationPath `$env:USERPROFILE -Force
   Remove-Item -LiteralPath `$archivePath -Force -ErrorAction SilentlyContinue
   Write-TaskLog "Imported agent credential archive into temporary user profile"
+  Assert-AgentCredentialsPresent
 }
 
 try {

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -124,6 +124,11 @@ describe("Windows production e2e release gate", () => {
     expect(taskUserRunner).toContain("SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI");
     expect(taskUserRunner).toContain("SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64");
     expect(taskUserRunner).toContain("SEREN_E2E_AGENT_CREDENTIALS_REQUIRED");
+    expect(taskUserRunner).toContain("Assert-AgentCredentialsPresent");
+    expect(taskUserRunner).toContain("did not provision required CLI credential file");
+    expect(taskUserRunner).toContain("without an extra top-level folder");
+    expect(taskUserRunner).toContain(".codex\\auth.json");
+    expect(taskUserRunner).toContain(".claude\\.credentials.json");
     expect(taskUserRunner).toContain("Expand-Archive");
     expect(taskUserRunner).toContain("AWS_METADATA_SERVICE_TIMEOUT");
     expect(taskUserRunner).toContain("--cli-connect-timeout");
@@ -205,6 +210,10 @@ describe("Windows production e2e release gate", () => {
     // a generic spawn/timeout failure.
     expect(probe).toContain("AgentAuthError");
     expect(probe).toContain("AgentProvisioningError");
+    expect(probe).toContain("provider_check_agent_authenticated");
+    expect(probe).toContain(
+      "provider_check_agent_authenticated returned false before prompt",
+    );
     expect(probe).toContain("not authenticated");
     expect(probe).toContain("provider://error");
     expect(probe).toContain("app server stopped before request completed");


### PR DESCRIPTION
## Summary
- validate the scheduled-task user's hydrated agent credential archive before launching Seren
- fail with a precise, non-secret credential provisioning message when the archive is missing or has the wrong zip layout
- preflight `provider_check_agent_authenticated` in the Windows app probe before spawning/prompting Codex, Claude, or the paired journey

## Audit
- Issue #2413 is confirmed as a P1 Windows release-gate bug: the task-user profile can sign in to Seren but lacks Claude/Codex CLI credentials.
- Existing code already downloaded and expanded a credential archive, but did not verify that `.codex/auth.json` or `.claude/.credentials.json` actually landed in the temporary profile.
- No P0s found. P1 hardening added for malformed/partial archives and probe-level auth preflight.
- Mac release/user paths are unaffected; touched code is Windows e2e release harness only.

## Tests
- `pnpm vitest run tests/unit/windows-e2e-release-gate.test.ts`
- `pnpm vitest run tests/unit/provider-agent-auth-status.test.ts`
- `node --check scripts/windows-e2e-app.mjs`
- PowerShell parser check for `scripts/windows-e2e-task-user.ps1`
- `git diff --check`

Closes #2413
