### PR TITLE
fix(windows): fast-detect finished e2e scheduled task (#2431)

### DIFF
--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -161,7 +161,6 @@ $password = New-TemporaryPassword
 $taskScriptPath = Join-Path $resolvedWorkDir "windows-e2e-task.ps1"
 $taskLogPath = Join-Path $resolvedWorkDir "windows-e2e-task.log"
 $e2eInstallDir = Join-Path $env:SystemDrive "SerenDesktopE2E"
-$startedAt = Get-Date
 
 try {
   Write-Stage "Creating temporary Windows user $qualifiedUserName"
@@ -475,16 +474,31 @@ try {
   Start-ScheduledTask -TaskName $taskName
   $deadline = (Get-Date).AddSeconds($TaskTimeoutSeconds + 60)
   $lastStatus = ""
+  # LastTaskResult of a task that has not yet produced a run result. Once the
+  # action runs to completion this becomes the action's exit code, so it is the
+  # reliable "the task finished" signal. LastRunTime is not: it lags and can sit
+  # at its own sentinel after a fast run, which previously let the loop spin to
+  # the full deadline on a task that had already failed in seconds.
+  $taskNeverRanResult = 267011  # SCHED_S_TASK_HAS_NOT_RUN (0x00041303)
+  $observedRunning = $false
   do {
     Start-Sleep -Seconds 5
     $task = Get-ScheduledTask -TaskName $taskName
     $taskInfo = Get-ScheduledTaskInfo -TaskName $taskName
+    if ($task.State -eq "Running") {
+      $observedRunning = $true
+    }
     $status = "state=$($task.State) lastResult=$($taskInfo.LastTaskResult)"
     if ($status -ne $lastStatus) {
       Write-Stage "Scheduled task $status"
       $lastStatus = $status
     }
-    if ($taskInfo.LastRunTime -gt $startedAt.AddSeconds(-10) -and $task.State -ne "Running") {
+    # Done once the task is no longer Running and we have evidence it actually
+    # ran — either we caught it in the Running state, or it has recorded a run
+    # result other than the never-ran sentinel.
+    $taskFinished = $task.State -ne "Running" -and
+      ($observedRunning -or $taskInfo.LastTaskResult -ne $taskNeverRanResult)
+    if ($taskFinished) {
       break
     }
   } while ((Get-Date) -lt $deadline)

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -140,6 +140,20 @@ describe("Windows production e2e release gate", () => {
     expect(taskUserRunner).toContain("1200");
   });
 
+  it("detects a finished scheduled task immediately instead of spinning to the deadline (#2431)", () => {
+    // A fast-failed task must surface in ~seconds, not burn the full SSM/runner
+    // budget. The completion check must not depend on Get-ScheduledTaskInfo
+    // LastRunTime updating (it lags and can sit at its sentinel after a quick
+    // run); it latches on the Running state and the never-ran result sentinel.
+    expect(taskUserRunner).toContain("267011");
+    expect(taskUserRunner).toContain("SCHED_S_TASK_HAS_NOT_RUN");
+    expect(taskUserRunner).toContain("observedRunning");
+    expect(taskUserRunner).toContain("taskFinished");
+    // The brittle LastRunTime-vs-startedAt break condition is gone.
+    expect(taskUserRunner).not.toContain("LastRunTime -gt");
+    expect(taskUserRunner).not.toContain("$startedAt");
+  });
+
   it("keeps unsigned PR artifact mode explicit and forbidden for release runs", () => {
     expect(runner).toContain("[switch]$AllowUnsignedPrArtifact");
     expect(runner).toContain("SEREN_E2E_UNSIGNED_PR_RUN");


### PR DESCRIPTION
Closes #2431.

## Problem
The on-box scheduled-task wait loop in `scripts/windows-e2e-task-user.ps1` broke only when `Get-ScheduledTaskInfo.LastRunTime` advanced past the script start time. That value lags and can sit at its sentinel after a fast run, so a task that **failed in seconds** left the loop spinning to its full deadline — and the SSM `AWS-RunPowerShellScript` 3600s execution cap killed the process first, masking the real failure as a generic timeout.

Evidence (v3.55.3 release run `27529321367`): the box task failed at **08:08:27** with `::error:: Missing Windows e2e agent credential archive`, yet the SSM command ended `TimedOut` at **exactly 3600s** (`PT1H0.596S`).

## Fix
Break as soon as the task leaves the `Running` state **and** we have evidence it ran — either we observed the `Running` state (an `observedRunning` latch), or `LastTaskResult` is no longer the never-ran sentinel `SCHED_S_TASK_HAS_NOT_RUN` (`267011`). The brittle `LastRunTime`-vs-start-time comparison (and the now-unused start-time variable) are removed. Post-loop timeout/result handling is unchanged, so a genuinely stuck task still fails as a timeout.

## Verification
- `pnpm vitest run tests/unit/windows-e2e-release-gate.test.ts` → 11/11 pass (new assertion guards the robust completion check).
- `pwsh` `Parser::ParseFile` on the edited script → PARSE OK.
- Real on-box behavior is validated in the follow-up functional walk-through (paired with #2432 preflight/timeout and #2433 Bedrock).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
