### PR TITLE
fix(windows): authenticate e2e claude-code via Bedrock (#2433)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -233,7 +233,21 @@ function hasAnyCredentialPath(paths) {
   });
 }
 
+function isClaudeBedrockConfigured() {
+  const value = process.env.CLAUDE_CODE_USE_BEDROCK;
+  if (value == null) {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(String(value).trim().toLowerCase());
+}
+
 function hasClaudeCredentials() {
+  // Bedrock authenticates the Claude Code CLI through the AWS credential chain
+  // (instance role / AWS_* env), not a login file. When CLAUDE_CODE_USE_BEDROCK
+  // is set, treat Claude as authenticated rather than looking for a profile.
+  if (isClaudeBedrockConfigured()) {
+    return true;
+  }
   const home = os.homedir();
   const appData = process.env.APPDATA;
   return hasAnyCredentialPath([

--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -30,6 +30,10 @@ const AGENT_JOURNEYS = (
   .map((value) => value.trim())
   .filter(Boolean);
 const AGENT_CWD = process.env.SEREN_E2E_AGENT_CWD ?? process.cwd();
+// Pin the spawn model when set (e.g. a Bedrock inference-profile id for the
+// Bedrock-backed claude-code journey). The runtime always forwards --model, so
+// this is the only lever that reaches the CLI; unset means runtime default.
+const AGENT_MODEL = process.env.SEREN_E2E_AGENT_MODEL?.trim() || null;
 const PROMPT_TEXT =
   process.env.SEREN_E2E_AGENT_PROMPT ??
   "Reply with exactly SEREN_WINDOWS_E2E_OK and no other text.";
@@ -565,6 +569,7 @@ async function runSingleAgentJourney(ws, buffer, agentType) {
       searchEnabled: false,
       networkEnabled: true,
       timeoutSecs: 120,
+      initialModelId: AGENT_MODEL ?? undefined,
     });
     assert(session?.id, `${agentType} provider_spawn did not return a local session id`);
     // The prompt RPC resolves only when the turn completes (or rejects on an

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -395,7 +395,11 @@ try {
     "SEREN_E2E_AGENT_PROMPT",
     "SEREN_E2E_AGENT_CREDENTIALS_REQUIRED",
     "SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI",
-    "SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64"
+    "SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64",
+    "SEREN_E2E_AGENT_MODEL",
+    "SEREN_E2E_AGENT_USE_BEDROCK",
+    "SEREN_E2E_AGENT_BEDROCK_REGION",
+    "SEREN_E2E_AGENT_SMALL_FAST_MODEL"
   )
   foreach (`$name in `$secretNames) {
     `$parameterName = "`$secretPrefix/`$name"
@@ -412,6 +416,27 @@ try {
   }
   if (`$allowMissingAgentCredentials) {
     [Environment]::SetEnvironmentVariable("SEREN_E2E_AGENT_CREDENTIALS_REQUIRED", "0", "Process")
+  }
+  # Bedrock-backed agent journeys (claude-code): authenticate via the EC2
+  # instance role instead of a stored login file. The runtime always forwards
+  # --model, so the spawned model id (SEREN_E2E_AGENT_MODEL, read by the probe)
+  # must be a Bedrock inference-profile id; ANTHROPIC_SMALL_FAST_MODEL covers the
+  # CLI's background small-model calls, which --model does not override.
+  if (Convert-EnvFlag (Get-EnvValue "SEREN_E2E_AGENT_USE_BEDROCK") `$true) {
+    `$bedrockRegion = Get-EnvValue "SEREN_E2E_AGENT_BEDROCK_REGION"
+    if ([string]::IsNullOrWhiteSpace(`$bedrockRegion)) { `$bedrockRegion = "us-east-1" }
+    `$bedrockModel = Get-EnvValue "SEREN_E2E_AGENT_MODEL"
+    if ([string]::IsNullOrWhiteSpace(`$bedrockModel)) { `$bedrockModel = "us.anthropic.claude-opus-4-6-v1" }
+    `$bedrockSmallModel = Get-EnvValue "SEREN_E2E_AGENT_SMALL_FAST_MODEL"
+    if ([string]::IsNullOrWhiteSpace(`$bedrockSmallModel)) { `$bedrockSmallModel = "us.anthropic.claude-haiku-4-5-20251001-v1:0" }
+    [Environment]::SetEnvironmentVariable("CLAUDE_CODE_USE_BEDROCK", "1", "Process")
+    [Environment]::SetEnvironmentVariable("AWS_REGION", `$bedrockRegion, "Process")
+    [Environment]::SetEnvironmentVariable("ANTHROPIC_MODEL", `$bedrockModel, "Process")
+    [Environment]::SetEnvironmentVariable("ANTHROPIC_SMALL_FAST_MODEL", `$bedrockSmallModel, "Process")
+    [Environment]::SetEnvironmentVariable("SEREN_E2E_AGENT_MODEL", `$bedrockModel, "Process")
+    # Bedrock uses the AWS credential chain; no Claude login file is required.
+    [Environment]::SetEnvironmentVariable("SEREN_E2E_AGENT_CREDENTIALS_REQUIRED", "0", "Process")
+    Write-TaskLog "Configured Bedrock agent backend: region=`$bedrockRegion model=`$bedrockModel small=`$bedrockSmallModel"
   }
   Import-AgentCredentialArchive
 

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -23,6 +23,10 @@ const taskUserRunner = readFileSync(
   "utf8",
 );
 const probe = readFileSync(join(root, "scripts/windows-e2e-app.mjs"), "utf8");
+const agentRegistry = readFileSync(
+  join(root, "bin/browser-local/agent-registry.mjs"),
+  "utf8",
+);
 
 function workflowJob(name: string): string {
   const start = releaseWorkflow.indexOf(`  ${name}:`);
@@ -152,6 +156,22 @@ describe("Windows production e2e release gate", () => {
     // The brittle LastRunTime-vs-startedAt break condition is gone.
     expect(taskUserRunner).not.toContain("LastRunTime -gt");
     expect(taskUserRunner).not.toContain("$startedAt");
+  });
+
+  it("authenticates the claude-code journey via Bedrock without a login file (#2433)", () => {
+    // Bedrock authenticates the Claude Code CLI through the AWS credential chain,
+    // so the auth gate must treat Claude as authenticated when
+    // CLAUDE_CODE_USE_BEDROCK is set, rather than requiring a login file.
+    expect(agentRegistry).toContain("CLAUDE_CODE_USE_BEDROCK");
+    expect(agentRegistry).toContain("isClaudeBedrockConfigured");
+    // The harness configures the Bedrock backend (region + models) and the probe
+    // forwards the model id as the spawn --model (the runtime always passes
+    // --model, which overrides ANTHROPIC_MODEL).
+    expect(taskUserRunner).toContain("CLAUDE_CODE_USE_BEDROCK");
+    expect(taskUserRunner).toContain("ANTHROPIC_SMALL_FAST_MODEL");
+    expect(taskUserRunner).toContain("SEREN_E2E_AGENT_USE_BEDROCK");
+    expect(probe).toContain("SEREN_E2E_AGENT_MODEL");
+    expect(probe).toContain("initialModelId");
   });
 
   it("keeps unsigned PR artifact mode explicit and forbidden for release runs", () => {


### PR DESCRIPTION
Closes #2433.

## Problem
The Windows app e2e agent journey required a stored agent credential archive (`SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_*`) that is **not** in Parameter Store, so v3.55.3 failed at `::error:: Missing Windows e2e agent credential archive`. Per decision, authenticate the **claude-code** journey via **AWS Bedrock — Opus 4.6** using the box instance role, with no stored login file. Codex/paired journeys are deferred (Bedrock hosts no GPT‑5.x, only `gpt-oss`).

## Why it was more than a config flip
- The agent child inherits `process.env`, but the runtime **always** passes `--model preferredModel` (default Anthropic alias `claude-opus-4-7[1m]`), which overrides `ANTHROPIC_MODEL` — so the spawned model id must itself be a Bedrock id.
- `provider_check_agent_authenticated` → `hasClaudeCredentials()` only checked login files, so under Bedrock the journey threw an auth error before spawning.

## Changes
1. **`bin/browser-local/agent-registry.mjs`** — `hasClaudeCredentials()` returns `true` when `CLAUDE_CODE_USE_BEDROCK` is set (Bedrock authenticates via the AWS credential chain). Env-gated; non-Bedrock behavior unchanged.
2. **`scripts/windows-e2e-app.mjs`** — forward `SEREN_E2E_AGENT_MODEL` as the spawn `initialModelId` (→ `--model`); unset leaves the runtime default.
3. **`scripts/windows-e2e-task-user.ps1`** — when `SEREN_E2E_AGENT_USE_BEDROCK` is truthy (default), set `CLAUDE_CODE_USE_BEDROCK`, `AWS_REGION`, `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, and clear the credential requirement before the archive check.
4. **Gate test** — assert the Bedrock auth short-circuit + model passthrough are wired.

## Infra (set in SSM, not code)
`/seren-desktop/windows-e2e/prod/`: `SEREN_E2E_AGENT_JOURNEYS=claude-code`, `SEREN_E2E_AGENT_USE_BEDROCK=1`, `SEREN_E2E_AGENT_MODEL=us.anthropic.claude-opus-4-6-v1`, `SEREN_E2E_AGENT_BEDROCK_REGION=us-east-1`, `SEREN_E2E_AGENT_SMALL_FAST_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0`, `SEREN_E2E_AGENT_CREDENTIALS_REQUIRED=0`. Journey narrowing lives in SSM so the harness still certifies whatever journeys it is asked to run.

## Verification
- `pnpm vitest run tests/unit/windows-e2e-release-gate.test.ts` → 12/12.
- `pwsh Parser::ParseFile` (outer) + parse of the un-escaped **generated** here-string → both OK; Bedrock block survives as runnable code.
- Bedrock ids verified live (us-east-1, acct 232501868299): `us.anthropic.claude-opus-4-6-v1` and `us.anthropic.claude-haiku-4-5-20251001-v1:0` exist; box role `seren-sandbox-ec2-role` has `SerenE2EBedrockInvoke`.
- End-to-end on-box validation is the follow-up functional walk-through.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
