### PR TITLE
fix(windows): use global Opus 4.6 Bedrock profile for e2e (#2437)

### DIFF
--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -425,10 +425,15 @@ try {
   if (Convert-EnvFlag (Get-EnvValue "SEREN_E2E_AGENT_USE_BEDROCK") `$true) {
     `$bedrockRegion = Get-EnvValue "SEREN_E2E_AGENT_BEDROCK_REGION"
     if ([string]::IsNullOrWhiteSpace(`$bedrockRegion)) { `$bedrockRegion = "us-east-1" }
+    # Only the global Opus 4.6 inference profile carries Bedrock quota in this
+    # account (4.32B tokens/day); the us.* profiles and every Haiku/Sonnet
+    # profile are provisioned at 0 and throttle on the first call. Use the
+    # global profile for both the main and small-fast model - the e2e is one
+    # short prompt, so the small-fast model just needs a quota-bearing id.
     `$bedrockModel = Get-EnvValue "SEREN_E2E_AGENT_MODEL"
-    if ([string]::IsNullOrWhiteSpace(`$bedrockModel)) { `$bedrockModel = "us.anthropic.claude-opus-4-6-v1" }
+    if ([string]::IsNullOrWhiteSpace(`$bedrockModel)) { `$bedrockModel = "global.anthropic.claude-opus-4-6-v1" }
     `$bedrockSmallModel = Get-EnvValue "SEREN_E2E_AGENT_SMALL_FAST_MODEL"
-    if ([string]::IsNullOrWhiteSpace(`$bedrockSmallModel)) { `$bedrockSmallModel = "us.anthropic.claude-haiku-4-5-20251001-v1:0" }
+    if ([string]::IsNullOrWhiteSpace(`$bedrockSmallModel)) { `$bedrockSmallModel = "global.anthropic.claude-opus-4-6-v1" }
     [Environment]::SetEnvironmentVariable("CLAUDE_CODE_USE_BEDROCK", "1", "Process")
     [Environment]::SetEnvironmentVariable("AWS_REGION", `$bedrockRegion, "Process")
     [Environment]::SetEnvironmentVariable("ANTHROPIC_MODEL", `$bedrockModel, "Process")


### PR DESCRIPTION
Closes #2437.

## Problem
A pre-tag probe from the box instance role (`seren-sandbox-ec2-role`) found the `us.` cross-region inference profile has **zero** Bedrock quota in this account: a ~10-token `aws bedrock-runtime converse` on `us.anthropic.claude-opus-4-6-v1` (and Haiku 4.5) throws `ThrottlingException: Too many tokens per day` on the **first** call. Service Quotas (us-east-1) confirm: `us.` Opus 4.6 TPM = 0, every Haiku/Sonnet profile = 0; the **only** Anthropic model with quota is the **global** Opus 4.6 profile (4,320,000,000 tokens/day). `global.anthropic.claude-opus-4-6-v1` converse **succeeds** from the box.

## Fix
Default both the main and small-fast model to `global.anthropic.claude-opus-4-6-v1`. The e2e is one short prompt, so the small-fast model only needs a quota-bearing id, and no other Anthropic model has quota. The SSM params (`SEREN_E2E_AGENT_MODEL`, `SEREN_E2E_AGENT_SMALL_FAST_MODEL`) are already updated to the global profile; this aligns the code default.

## Verification
- `aws bedrock-runtime converse` from the box: `us.` Opus/Haiku → throttle; `global.` Opus → returned the marker (exit 0).
- gate test 13/13; outer + generated PowerShell parse OK; no `us.`/Haiku ids remain in the harness.

Found by the v3.55.4 pre-release pipeline walkthrough — prevented a guaranteed-red Bedrock journey.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
