### PR TITLE
fix(meeting): surface generation and ready states

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -44,6 +44,7 @@ import { PublishSkillModal } from "@/components/sidebar/PublishSkillModal";
 import { PublishVersionModal } from "@/components/sidebar/PublishVersionModal";
 import { SkillsExplorer } from "@/components/sidebar/SkillsExplorer";
 import { AgentTasksPanel } from "@/components/tasks/AgentTasksPanel";
+import { isMeetingProcessingStatus } from "@/lib/meeting-format";
 import { shortcuts } from "@/lib/shortcuts";
 import type { InstalledSkill } from "@/lib/skills";
 import {
@@ -645,6 +646,11 @@ export const AppShell: Component<AppShellProps> = (props) => {
     meetingStore.state.meetings.some(
       (meeting) => meeting.status === "capturing",
     );
+  const meetingProcessing = () =>
+    meetingStore.state.meetings.some((meeting) =>
+      isMeetingProcessingStatus(meeting.status),
+    );
+  const meetingReady = () => meetingStore.state.reviewReadyMeetingId !== null;
 
   return (
     <div class="flex flex-col h-screen bg-background text-foreground">
@@ -654,6 +660,8 @@ export const AppShell: Component<AppShellProps> = (props) => {
         onToggleSkills={handleToggleSkills}
         onToggleSettings={handleToggleSettings}
         meetingRecording={meetingRecording()}
+        meetingProcessing={meetingProcessing()}
+        meetingReady={meetingReady()}
         recordPromptVisible={recordPromptVisible()}
         recordPromptSourceApp={meetingStore.state.autoDetectSourceApp}
         onRecordConversation={() => void meetingStore.acceptAutoDetect()}

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -15,6 +15,10 @@ interface TitlebarProps {
   onToggleSettings: () => void;
   /** A meeting capture is live; show the recording indicator on the button. */
   meetingRecording?: boolean;
+  /** A stopped meeting is generating transcript-derived notes or routing. */
+  meetingProcessing?: boolean;
+  /** A meeting finished processing and is ready for review. */
+  meetingReady?: boolean;
   recordPromptVisible?: boolean;
   recordPromptSourceApp?: string | null;
   onRecordConversation?: () => void;
@@ -66,6 +70,19 @@ function MeetingsIcon() {
 }
 
 export const Titlebar: Component<TitlebarProps> = (props) => {
+  const meetingButtonState = () => {
+    if (props.meetingRecording) return "Recording in progress";
+    if (props.meetingProcessing) return "Generating meeting notes";
+    if (props.meetingReady) return "Transcript ready to view";
+    return "Meetings";
+  };
+  const meetingButtonActive = () =>
+    props.meetingRecording || props.meetingProcessing || props.meetingReady;
+  const meetingButtonTitle = () =>
+    meetingButtonActive()
+      ? `${meetingButtonState()} — open Meetings`
+      : "Meetings";
+
   return (
     <div
       class="relative flex items-center justify-between h-[var(--titlebar-height,40px)] px-3 bg-surface-1 border-b border-border shrink-0 select-none"
@@ -162,23 +179,34 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
           class="relative flex items-center justify-center w-7 h-7 border-none rounded-md cursor-pointer transition-all duration-100 active:scale-95"
           classList={{
             "bg-transparent text-muted-foreground hover:bg-surface-2 hover:text-foreground":
-              !props.meetingRecording,
+              !meetingButtonActive(),
             "text-success bg-success/10 meeting-recording-glow":
               props.meetingRecording,
+            "text-warning bg-warning/10":
+              !props.meetingRecording && props.meetingProcessing,
+            "text-primary bg-primary/10":
+              !props.meetingRecording &&
+              !props.meetingProcessing &&
+              props.meetingReady,
           }}
           onClick={props.onToggleMeetings}
-          title={
-            props.meetingRecording
-              ? "Recording in progress — open Meetings to stop"
-              : "Meetings"
-          }
-          aria-label={
-            props.meetingRecording ? "Recording in progress" : "Meetings"
-          }
+          title={meetingButtonTitle()}
+          aria-label={meetingButtonState()}
         >
           <MeetingsIcon />
-          <Show when={props.meetingRecording}>
-            <span class="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-success ring-2 ring-surface-1 animate-pulse" />
+          <Show when={meetingButtonActive()}>
+            <span
+              class="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full ring-2 ring-surface-1"
+              classList={{
+                "bg-success animate-pulse": props.meetingRecording,
+                "bg-warning animate-pulse":
+                  !props.meetingRecording && props.meetingProcessing,
+                "bg-primary":
+                  !props.meetingRecording &&
+                  !props.meetingProcessing &&
+                  props.meetingReady,
+              }}
+            />
           </Show>
         </button>
 

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -14,6 +14,10 @@ import {
   formatDuration,
   formatMeetingDate,
   formatTime,
+  isMeetingProcessingStatus,
+  isMeetingReadyStatus,
+  meetingProcessingLabel,
+  meetingReadyLabel,
   meetingTitle,
   STATUS_LABELS,
 } from "@/lib/meeting-format";
@@ -165,6 +169,13 @@ export function MeetingDetail(props: MeetingDetailProps) {
   );
 
   const segments = () => meetingStore.state.liveSegments;
+  const processing = () => isMeetingProcessingStatus(props.meeting.status);
+  const ready = () => isMeetingReadyStatus(props.meeting.status);
+  const notesActionBusy = () =>
+    regenerating() ||
+    processing() ||
+    props.meeting.status === "pending_capture" ||
+    props.meeting.status === "capturing";
   const deleteDisabled = () =>
     props.meeting.status === "pending_capture" ||
     props.meeting.status === "capturing" ||
@@ -342,6 +353,18 @@ export function MeetingDetail(props: MeetingDetailProps) {
             </div>
           )}
         </Show>
+        <Show when={processing()}>
+          <div class="mt-3 flex items-center gap-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-[12px] leading-5 text-warning">
+            <span class="h-2 w-2 rounded-full bg-warning animate-pulse" />
+            <span>{meetingProcessingLabel(props.meeting.status)}.</span>
+          </div>
+        </Show>
+        <Show when={!processing() && ready()}>
+          <div class="mt-3 flex items-center gap-2 rounded-md border border-primary/30 bg-primary/10 p-3 text-[12px] leading-5 text-primary">
+            <span class="h-2 w-2 rounded-full bg-primary" />
+            <span>{meetingReadyLabel(props.meeting.status)}.</span>
+          </div>
+        </Show>
       </div>
 
       <div class="mb-4 flex items-center gap-2">
@@ -359,7 +382,7 @@ export function MeetingDetail(props: MeetingDetailProps) {
           type="button"
           class="h-7 px-2.5 rounded-md border border-primary/40 bg-primary/10 text-[12px] text-primary hover:bg-primary/15 disabled:opacity-60"
           onClick={regenerate}
-          disabled={regenerating() || !isTauriRuntime()}
+          disabled={notesActionBusy() || !isTauriRuntime()}
           title="Regenerate notes with the selected template"
         >
           {regenerating() ? "Regenerating…" : "Regenerate"}
@@ -416,7 +439,16 @@ export function MeetingDetail(props: MeetingDetailProps) {
           when={props.meeting.notesMarkdown}
           fallback={
             <div class="min-h-[88px] rounded-md border border-border bg-surface-0/50 p-3 text-[13px] text-muted-foreground">
-              Notes will appear here after capture.
+              <Show
+                when={processing()}
+                fallback={
+                  props.meeting.status === "transcript_ready"
+                    ? "Transcript is ready below. Regenerate notes when you want a notes summary."
+                    : "Notes will appear here after capture."
+                }
+              >
+                Generating notes from the saved transcript.
+              </Show>
             </div>
           }
         >
@@ -517,7 +549,9 @@ export function MeetingDetail(props: MeetingDetailProps) {
           when={segments().length > 0}
           fallback={
             <div class="rounded-md border border-border bg-surface-0/50 p-3 text-[13px] text-muted-foreground">
-              No transcript yet.
+              {processing()
+                ? "Transcript chunks will appear here as they finish."
+                : "No transcript yet."}
             </div>
           }
         >

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -9,6 +9,10 @@ import {
   formatDuration,
   formatMeetingDate,
   formatTime,
+  isMeetingProcessingStatus,
+  isMeetingReadyStatus,
+  meetingProcessingLabel,
+  meetingReadyLabel,
   meetingTitle,
   STATUS_LABELS,
 } from "@/lib/meeting-format";
@@ -70,6 +74,16 @@ export function MeetingPanel() {
       (meeting) => meeting.status === "capturing",
     ),
   );
+  const activeProcessing = createMemo(() =>
+    meetingStore.state.meetings.find((meeting) =>
+      isMeetingProcessingStatus(meeting.status),
+    ),
+  );
+  const reviewReadyMeeting = createMemo(() => {
+    const id = meetingStore.state.reviewReadyMeetingId;
+    if (!id) return undefined;
+    return meetingStore.state.meetings.find((meeting) => meeting.id === id);
+  });
 
   const activeMeeting = () => meetingStore.state.activeMeeting;
   const template = () => settingsStore.get("meetingTemplateId");
@@ -79,6 +93,10 @@ export function MeetingPanel() {
     return meeting
       ? `Delete "${meetingTitle(meeting)}"? Notes and transcript segments will be permanently removed.`
       : "";
+  };
+  const openMeeting = (meeting: Meeting) => {
+    meetingStore.acknowledgeReviewReady(meeting.id);
+    void meetingStore.setActiveMeeting(meeting);
   };
 
   // Create the meeting, then hand off to the store's gate. The store decides
@@ -239,6 +257,42 @@ export function MeetingPanel() {
             </div>
           )}
         </Show>
+        <Show when={activeProcessing()}>
+          {(meeting) => (
+            <div class="mt-3 flex items-center gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[12px] text-warning">
+              <span class="h-2 w-2 rounded-full bg-warning animate-pulse" />
+              <span class="min-w-0 flex-1 truncate">
+                {meetingProcessingLabel(meeting().status)} for{" "}
+                {meetingTitle(meeting())}
+              </span>
+              <button
+                type="button"
+                class="shrink-0 text-warning/90 hover:text-warning hover:underline"
+                onClick={() => openMeeting(meeting())}
+              >
+                View transcript
+              </button>
+            </div>
+          )}
+        </Show>
+        <Show when={!activeProcessing() && reviewReadyMeeting()}>
+          {(meeting) => (
+            <div class="mt-3 flex items-center gap-2 rounded-md border border-primary/30 bg-primary/10 px-3 py-2 text-[12px] text-primary">
+              <span class="h-2 w-2 rounded-full bg-primary" />
+              <span class="min-w-0 flex-1 truncate">
+                {meetingReadyLabel(meeting().status)} for{" "}
+                {meetingTitle(meeting())}
+              </span>
+              <button
+                type="button"
+                class="shrink-0 text-primary/90 hover:text-primary hover:underline"
+                onClick={() => openMeeting(meeting())}
+              >
+                Open
+              </button>
+            </div>
+          )}
+        </Show>
       </div>
 
       <Show when={meetingStore.state.error}>
@@ -282,9 +336,7 @@ export function MeetingPanel() {
                         "bg-surface-2 text-foreground": selected(),
                         "text-muted-foreground": !selected(),
                       }}
-                      onClick={() =>
-                        void meetingStore.setActiveMeeting(meeting)
-                      }
+                      onClick={() => openMeeting(meeting)}
                     >
                       <div class="text-[13px] font-medium truncate">
                         {meetingTitle(meeting)}
@@ -294,7 +346,23 @@ export function MeetingPanel() {
                           {formatMeetingDate(meeting.startedAt)} ·{" "}
                           {formatTime(meeting.startedAt)}
                         </span>
-                        <span>{STATUS_LABELS[meeting.status]}</span>
+                        <span
+                          class="shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-medium"
+                          classList={{
+                            "border-warning/30 bg-warning/10 text-warning":
+                              isMeetingProcessingStatus(meeting.status),
+                            "border-primary/30 bg-primary/10 text-primary":
+                              isMeetingReadyStatus(meeting.status),
+                            "border-destructive/30 bg-destructive/10 text-destructive":
+                              meeting.status === "failed",
+                            "border-border bg-surface-1 text-muted-foreground":
+                              !isMeetingProcessingStatus(meeting.status) &&
+                              !isMeetingReadyStatus(meeting.status) &&
+                              meeting.status !== "failed",
+                          }}
+                        >
+                          {STATUS_LABELS[meeting.status]}
+                        </span>
                       </div>
                     </button>
                   );

--- a/src/lib/meeting-format.ts
+++ b/src/lib/meeting-format.ts
@@ -74,10 +74,34 @@ export function meetingTitle(meeting: Meeting): string {
 export const STATUS_LABELS: Record<Meeting["status"], string> = {
   pending_capture: "Starting",
   capturing: "Capturing",
-  transcribing: "Transcribing",
+  transcribing: "Generating notes",
   transcript_ready: "Transcript ready",
   notes_ready: "Notes ready",
   agent_running: "Agent running",
   done: "Done",
   failed: "Failed",
 };
+
+export function isMeetingProcessingStatus(status: Meeting["status"]): boolean {
+  return status === "transcribing" || status === "agent_running";
+}
+
+export function isMeetingReadyStatus(status: Meeting["status"]): boolean {
+  return (
+    status === "transcript_ready" ||
+    status === "notes_ready" ||
+    status === "done"
+  );
+}
+
+export function meetingProcessingLabel(status: Meeting["status"]): string {
+  return status === "agent_running"
+    ? "Routing transcript through skill"
+    : "Generating notes from transcript";
+}
+
+export function meetingReadyLabel(status: Meeting["status"]): string {
+  return status === "transcript_ready"
+    ? "Transcript ready to view"
+    : "Notes ready to view";
+}

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -3,7 +3,11 @@
 
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createStore } from "solid-js/store";
-import { formatTime } from "@/lib/meeting-format";
+import {
+  formatTime,
+  isMeetingProcessingStatus,
+  isMeetingReadyStatus,
+} from "@/lib/meeting-format";
 import { captureSupportError } from "@/lib/support/hook";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 import {
@@ -56,6 +60,8 @@ interface MeetingState {
    * honors the gate, not just the panel button.
    */
   primingRequest: Meeting | null;
+  /** Most recent meeting that became reviewable while the user was elsewhere. */
+  reviewReadyMeetingId: string | null;
 }
 
 const [meetingState, setMeetingState] = createStore<MeetingState>({
@@ -68,6 +74,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   autoDetectSuggested: false,
   autoDetectSourceApp: null,
   primingRequest: null,
+  reviewReadyMeetingId: null,
 });
 
 let transcriptUnlisten: UnlistenFn | null = null;
@@ -240,6 +247,21 @@ function appendLiveSegment(segment: TranscriptSegment): void {
   });
 }
 
+function trackReadyTransition(next: Meeting): void {
+  const previous = meetingState.meetings.find(
+    (meeting) => meeting.id === next.id,
+  );
+  if (isMeetingReadyStatus(next.status)) {
+    if (previous && !isMeetingReadyStatus(previous.status)) {
+      setMeetingState("reviewReadyMeetingId", next.id);
+    }
+    return;
+  }
+  if (meetingState.reviewReadyMeetingId === next.id) {
+    setMeetingState("reviewReadyMeetingId", null);
+  }
+}
+
 async function startMeetingEventListeners(): Promise<void> {
   stopMeetingEventListeners();
   if (!isTauriRuntime()) return;
@@ -255,6 +277,7 @@ async function startMeetingEventListeners(): Promise<void> {
   );
 
   statusUnlisten = await listen<Meeting>("meeting://status", (event) => {
+    trackReadyTransition(event.payload);
     setMeetingState("meetings", (meetings) => {
       const next = meetings.some((meeting) => meeting.id === event.payload.id)
         ? meetings.map((meeting) =>
@@ -447,7 +470,7 @@ async function cancelPriming(): Promise<void> {
 // At startup, backend capture may still be active even though the renderer
 // reloaded. Reattach to that live capture; fail only rows whose backend registry
 // is gone or whose post-capture processing cannot survive restart.
-const STALE_STATUSES = new Set([
+const STALE_STATUSES = new Set<Meeting["status"]>([
   "pending_capture",
   "capturing",
   "transcribing",
@@ -479,6 +502,26 @@ async function reconcileStaleCaptures(): Promise<void> {
         }
       }
       changed = true;
+      if (isMeetingProcessingStatus(meeting.status)) {
+        if (meeting.notesMarkdown?.trim()) {
+          await updateMeetingStatus(meeting.id, "notes_ready", null).catch(
+            () => {},
+          );
+          continue;
+        }
+        const transcript = await getMeetingTranscriptText(meeting.id).catch(
+          () => "",
+        );
+        if (transcript.trim()) {
+          await updateMeetingStatus(
+            meeting.id,
+            "transcript_ready",
+            null,
+            "Seren restarted before meeting notes finished. Your transcript is ready to view.",
+          ).catch(() => {});
+          continue;
+        }
+      }
       await updateMeetingStatus(
         meeting.id,
         "failed",
@@ -903,6 +946,15 @@ function resetAutoDetectDismissal(): void {
   autoDetectDismissed = false;
 }
 
+function acknowledgeReviewReady(meetingId?: string): void {
+  if (
+    meetingId === undefined ||
+    meetingState.reviewReadyMeetingId === meetingId
+  ) {
+    setMeetingState("reviewReadyMeetingId", null);
+  }
+}
+
 export const meetingStore = {
   get state(): MeetingState {
     return meetingState;
@@ -931,4 +983,5 @@ export const meetingStore = {
   acceptAutoDetect,
   dismissAutoDetect,
   resetAutoDetectDismissal,
+  acknowledgeReviewReady,
 };

--- a/tests/unit/meeting-priming-cancel.test.ts
+++ b/tests/unit/meeting-priming-cancel.test.ts
@@ -7,6 +7,7 @@ const services = vi.hoisted(() => ({
   updateMeetingStatus: vi.fn(async () => {}),
   listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
   isMeetingCaptureActive: vi.fn(async () => false),
+  getMeetingTranscriptText: vi.fn(async (_id: string) => ""),
 }));
 
 vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
@@ -18,6 +19,7 @@ vi.mock("@/services/meetings", async (importOriginal) => ({
   updateMeetingStatus: services.updateMeetingStatus,
   listMeetings: services.listMeetings,
   isMeetingCaptureActive: services.isMeetingCaptureActive,
+  getMeetingTranscriptText: services.getMeetingTranscriptText,
 }));
 vi.mock("@/stores/settings.store", () => ({
   settingsStore: { get: () => false, set: vi.fn() },
@@ -50,8 +52,10 @@ describe("meetingStore priming cancel + reconcile (#2160)", () => {
     services.updateMeetingStatus.mockClear();
     services.listMeetings.mockReset();
     services.isMeetingCaptureActive.mockReset();
+    services.getMeetingTranscriptText.mockReset();
     services.listMeetings.mockResolvedValue([]);
     services.isMeetingCaptureActive.mockResolvedValue(false);
+    services.getMeetingTranscriptText.mockResolvedValue("");
   });
 
   it("cancelPriming marks the stashed pending meeting failed", async () => {
@@ -73,7 +77,7 @@ describe("meetingStore priming cancel + reconcile (#2160)", () => {
     expect(services.listMeetings).toHaveBeenCalled();
   });
 
-  it("reconcileStaleCaptures fails leftover mid-pipeline rows, leaves terminal ones", async () => {
+  it("reconcileStaleCaptures preserves usable transcripts and fails true zombies", async () => {
     services.listMeetings.mockResolvedValueOnce([
       meeting({ id: "pending", status: "pending_capture" }),
       meeting({ id: "cap", status: "capturing" }),
@@ -82,11 +86,15 @@ describe("meetingStore priming cancel + reconcile (#2160)", () => {
       meeting({ id: "done1", status: "done" }),
       meeting({ id: "notes", status: "notes_ready" }),
     ]);
+    services.getMeetingTranscriptText.mockImplementation(async (id: string) =>
+      id === "trans" ? "saved transcript" : "",
+    );
 
     await meetingStore.reconcileStaleCaptures();
 
-    // Fail every mid-pipeline zombie, with no ended_at so a captured row keeps
-    // its capture-end time (#2174).
+    // Fail true mid-pipeline zombies, with no ended_at so a captured row keeps
+    // its capture-end time (#2174). A stopped meeting with transcript text is
+    // reviewable even if notes generation was interrupted (#2440).
     expect(services.isMeetingCaptureActive).toHaveBeenCalledWith("cap");
     expect(services.updateMeetingStatus).toHaveBeenCalledWith(
       "cap",
@@ -94,7 +102,7 @@ describe("meetingStore priming cancel + reconcile (#2160)", () => {
       null,
       expect.stringContaining("without an active backend capture"),
     );
-    for (const id of ["pending", "trans", "agent"]) {
+    for (const id of ["pending", "agent"]) {
       expect(services.updateMeetingStatus).toHaveBeenCalledWith(
         id,
         "failed",
@@ -102,6 +110,12 @@ describe("meetingStore priming cancel + reconcile (#2160)", () => {
         expect.stringContaining("Seren restarted"),
       );
     }
+    expect(services.updateMeetingStatus).toHaveBeenCalledWith(
+      "trans",
+      "transcript_ready",
+      null,
+      expect.stringContaining("transcript is ready"),
+    );
     // Terminal/resting rows are left alone.
     for (const id of ["done1", "notes"]) {
       expect(services.updateMeetingStatus).not.toHaveBeenCalledWith(

--- a/tests/unit/meeting-rename-and-indicator.test.ts
+++ b/tests/unit/meeting-rename-and-indicator.test.ts
@@ -63,3 +63,28 @@ describe("Titlebar recording indicator when the drawer is closed (#2335)", () =>
     expect(source("src/styles.css")).toContain("meeting-recording-glow");
   });
 });
+
+describe("Meeting generation and ready indicators (#2439)", () => {
+  it("drives the titlebar through recording, processing, and ready states", () => {
+    const titlebar = source("src/components/layout/Titlebar.tsx");
+    const appShell = source("src/components/layout/AppShell.tsx");
+
+    expect(titlebar).toContain("meetingProcessing");
+    expect(titlebar).toContain("meetingReady");
+    expect(titlebar).toContain("Generating meeting notes");
+    expect(titlebar).toContain("Transcript ready to view");
+    expect(appShell).toContain("meetingProcessing={meetingProcessing()}");
+    expect(appShell).toContain("meetingReady={meetingReady()}");
+  });
+
+  it("surfaces generation and ready states inside the Meetings drawer", () => {
+    const panel = source("src/components/meeting/MeetingPanel.tsx");
+    const detail = source("src/components/meeting/MeetingDetail.tsx");
+
+    expect(panel).toContain("activeProcessing");
+    expect(panel).toContain("reviewReadyMeeting");
+    expect(panel).toContain("meetingProcessingLabel");
+    expect(detail).toContain("meetingReadyLabel");
+    expect(detail).toContain("Generating notes from the saved transcript.");
+  });
+});

--- a/tests/unit/meeting-status-labels.test.ts
+++ b/tests/unit/meeting-status-labels.test.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Regression guard for #2439 — Meeting Mode must expose generation and ready states.
+// ABOUTME: These helpers drive titlebar, drawer, list, and detail copy.
+
+import { describe, expect, it } from "vitest";
+import {
+  isMeetingProcessingStatus,
+  isMeetingReadyStatus,
+  meetingProcessingLabel,
+  meetingReadyLabel,
+  STATUS_LABELS,
+} from "@/lib/meeting-format";
+
+describe("meeting status generation labels (#2439)", () => {
+  it("classifies stopped-generation states as processing", () => {
+    expect(isMeetingProcessingStatus("transcribing")).toBe(true);
+    expect(isMeetingProcessingStatus("agent_running")).toBe(true);
+    expect(isMeetingProcessingStatus("capturing")).toBe(false);
+    expect(STATUS_LABELS.transcribing).toBe("Generating notes");
+    expect(meetingProcessingLabel("transcribing")).toBe(
+      "Generating notes from transcript",
+    );
+  });
+
+  it("classifies transcript and notes terminal states as ready to view", () => {
+    expect(isMeetingReadyStatus("transcript_ready")).toBe(true);
+    expect(isMeetingReadyStatus("notes_ready")).toBe(true);
+    expect(isMeetingReadyStatus("done")).toBe(true);
+    expect(isMeetingReadyStatus("failed")).toBe(false);
+    expect(meetingReadyLabel("transcript_ready")).toBe(
+      "Transcript ready to view",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds persistent Meeting Mode generation states after capture stop: titlebar badge, drawer strip, list-row pills, and detail callouts.
- Adds a ready-to-view state for completed transcript/notes so users know the transcription is available.
- Preserves usable transcripts on startup recovery by moving interrupted post-capture rows to `transcript_ready` when transcript text exists.

## Audit
- `stop_meeting_capture` already emits `transcribing` after stop and `generate_meeting_notes` emits `notes_ready`; the missing path was frontend visibility across titlebar, drawer, list, and detail.
- Startup reconciliation previously failed all `transcribing` / `agent_running` rows after renderer restart; this now checks persisted transcript/notes before deciding whether the row is genuinely failed.
- MacOS and Windows capture backends both flow through the shared Rust `stop_meeting_capture` command and shared frontend statuses, so the UI/recovery behavior is platform-neutral.

## Verification
- `pnpm exec vitest run tests/unit/meeting-priming-cancel.test.ts tests/unit/meeting-rename-and-indicator.test.ts tests/unit/meeting-status-labels.test.ts tests/unit/meeting-notes-failure-gate.test.ts`
- `pnpm exec biome check src/lib/meeting-format.ts src/stores/meeting.store.ts src/components/layout/AppShell.tsx src/components/layout/Titlebar.tsx src/components/meeting/MeetingPanel.tsx src/components/meeting/MeetingDetail.tsx tests/unit/meeting-priming-cancel.test.ts tests/unit/meeting-rename-and-indicator.test.ts tests/unit/meeting-status-labels.test.ts`
- `pnpm build`
- Playwright built-preview walkthrough: app booted, titlebar Meetings button rendered/clicked, Meetings drawer rendered empty state without blank screen.

Closes #2439
Closes #2440
