### PR TITLE
fix(windows): preflight e2e fails open on SSM permission gap (#2442)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1072,11 +1072,14 @@ jobs:
       - name: Preflight Windows e2e box prerequisites
         shell: bash
         run: |
-          # Not 'set -e': this is a best-effort early check. If the runner's role
-          # cannot read Parameter Store (the box uses its own role), we must fail
-          # OPEN — skip with a warning, never block the release on the preflight's
-          # own permission gap.
+          # This is a best-effort early check. If the runner's role cannot read
+          # Parameter Store (the box uses its own role), we must fail OPEN — skip
+          # with a warning, never block the release on the preflight's own
+          # permission gap. GitHub's default 'shell: bash' runs with -e already
+          # set, so 'set +e' is required: otherwise a non-zero SSM probe (e.g.
+          # AccessDenied, exit 254) aborts the step before the fail-open below.
           set -uo pipefail
+          set +e
           prefix="${WINDOWS_E2E_SECRET_PARAMETER_PREFIX%/}"
           required=(
             SEREN_E2E_EMAIL SEREN_E2E_PASSWORD


### PR DESCRIPTION
Closes #2442.

## Problem

`windows-app-e2e`'s **Preflight Windows e2e box prerequisites** step is meant to **fail open** when the runner OIDC role can't read SSM Parameter Store (the e2e box uses its *own* role) — warn and skip, never block the release. It declared `set -uo pipefail`, intentionally omitting `set -e`. But GitHub's default `shell: bash` already invokes `bash --noprofile --norc -e -o pipefail`, so `-e` is active and omitting it does nothing.

When `aws ssm get-parameters` returns **254** (service error — the runner role lacks `ssm:GetParameters`), the active `-e` aborts the step at the assignment, *before* the `if [ -z "$json" ]` fail-open check. `2>/dev/null` hides the AWS error, so the log shows only a bare exit 254.

**Impact:** v3.55.4 built green on all 5 platforms, then this gate killed it in 16s; `publish-release` was skipped. Shipped via the manual-publish override (#2323). This has been forcing the override for multiple consecutive releases.

## Fix

Add `set +e` so the fail-open actually runs, and correct the now-misleading "Not 'set -e'" comment.

## Verification

Local repro of GitHub's `-e` shell:
```
BEFORE (set -uo pipefail only): step exit 254  — fail-open never runs (the bug)
AFTER  (set +e added):          step exit 0    — fail-open warning fires (fixed)
```

## Follow-up (not in this PR)

The runner role genuinely can't read SSM, so the preflight will always warn-and-skip. To make it actually validate prereqs, grant the runner role `ssm:GetParameters` on `WINDOWS_E2E_SECRET_PARAMETER_PREFIX/*`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com