### PR TITLE
fix(auth): no session-expired modal for signed-out users (#2445)

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -146,19 +146,39 @@ async function connectToApp() {
   return { browser, page, browserErrors };
 }
 
+// The app exposes the same "Sign In" text/labels on three surfaces: the
+// titlebar button, the account slide-panel form, and the session-expired
+// modal form (z-1000, rendered last). Global `getByLabel`/`.last()` selectors
+// race across all three, so bind every interaction to a single form (#2445).
+async function dismissSessionExpiredModal(page) {
+  const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+  if (await dialog.isVisible().catch(() => false)) {
+    await dialog
+      .getByRole("button", { name: /^Dismiss$/ })
+      .click({ timeout: 5_000 })
+      .catch(() => {});
+  }
+}
+
 async function signIn(page) {
   await tauriInvoke(page, "clear_token").catch(() => {});
   await tauriInvoke(page, "clear_refresh_token").catch(() => {});
 
+  // A signed-out session must not surface the "session expired" modal (#2445);
+  // dismiss it if a prior build still does so the panel form is the only one.
+  await dismissSessionExpiredModal(page);
+
   const emailInput = page.getByLabel("Email");
-  if (!(await emailInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+  if (!(await emailInput.isVisible().catch(() => false))) {
     const signInButton = page.getByRole("button", { name: /^Sign In$/ }).first();
     await signInButton.click({ timeout: 10_000 });
   }
 
-  await page.getByLabel("Email").fill(EMAIL);
-  await page.getByLabel("Password").fill(PASSWORD);
-  await page.getByRole("button", { name: /^Sign In$/ }).last().click();
+  // Scope to the one sign-in form so the submit is unambiguous.
+  const form = page.locator("form").filter({ has: page.getByLabel("Email") });
+  await form.getByLabel("Email").fill(EMAIL);
+  await form.getByLabel("Password").fill(PASSWORD);
+  await form.getByRole("button", { name: /^Sign In$/ }).click();
 
   const token = await waitUntil(
     "stored production auth token",

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -35,7 +35,8 @@ interface RefreshAccessTokenOptions {
 type RefreshAccessTokenOutcome =
   | "success"
   | "terminal-failure"
-  | "transient-failure";
+  | "transient-failure"
+  | "unauthenticated";
 
 let refreshAccessTokenInFlight: Promise<RefreshAccessTokenOutcome> | null =
   null;
@@ -151,16 +152,32 @@ export async function refreshAccessToken(
 
   const outcome = await refreshAccessTokenInFlight;
   if (outcome === "terminal-failure") {
+    // A real session existed and the refresh token was rejected — escalate.
     clearAuthState();
     if (promptOnFailure) {
       requestSignInModal();
     }
+  } else if (outcome === "unauthenticated") {
+    // No refresh token means never-signed-in or already-logged-out, not
+    // session expiry. Clear any stale frontend state but NEVER raise the
+    // "session expired" modal — otherwise every signed-out Gateway 401 pops a
+    // spurious sign-in prompt. Mirrors the Rust-side guard in auth.rs (#1860).
+    clearAuthState();
   }
 
   return outcome === "success";
 }
 
 async function performRefreshAccessToken(): Promise<RefreshAccessTokenOutcome> {
+  // With no refresh token there is no session to refresh — this is
+  // never-signed-in or already-logged-out, not an expired session. Surface it
+  // distinctly so the caller never raises the "session expired" modal for a
+  // signed-out user (the Rust side already makes this distinction; see #1860).
+  const refreshToken = await getRefreshToken();
+  if (!refreshToken) {
+    return "unauthenticated";
+  }
+
   if (isTauriRuntime()) {
     try {
       const { invoke } = await import("@tauri-apps/api/core");
@@ -170,11 +187,6 @@ async function performRefreshAccessToken(): Promise<RefreshAccessTokenOutcome> {
       // Network/IPC errors should not clear credentials or force a sign-in.
       return "transient-failure";
     }
-  }
-
-  const refreshToken = await getRefreshToken();
-  if (!refreshToken) {
-    return "terminal-failure";
   }
 
   try {

--- a/tests/unit/auth-service-refresh-login.test.ts
+++ b/tests/unit/auth-service-refresh-login.test.ts
@@ -101,6 +101,7 @@ describe("auth service refresh during login validation", () => {
 
   it("shares concurrent Tauri refresh calls through one backend invoke", async () => {
     mocks.isTauriRuntime.mockReturnValue(true);
+    mocks.getRefreshToken.mockResolvedValue("valid-refresh-token");
     const refresh = deferred<boolean>();
     mocks.invoke.mockReturnValue(refresh.promise);
 
@@ -121,9 +122,67 @@ describe("auth service refresh during login validation", () => {
     refresh.resolve(true);
 
     await expect(Promise.all(callers)).resolves.toEqual([true, true, true]);
-    expect(mocks.getRefreshToken).not.toHaveBeenCalled();
+    // The token-presence gate runs once for the deduped in-flight refresh.
+    expect(mocks.getRefreshToken).toHaveBeenCalledTimes(1);
     expect(mocks.refreshToken).not.toHaveBeenCalled();
     expect(mocks.clearAuthState).not.toHaveBeenCalled();
+    expect(mocks.requestSignInModal).not.toHaveBeenCalled();
+  });
+
+  it("never raises the sign-in modal for a signed-out user (Tauri, no refresh token)", async () => {
+    mocks.isTauriRuntime.mockReturnValue(true);
+    mocks.getRefreshToken.mockResolvedValue(null);
+
+    const { refreshAccessToken } = await import("@/services/auth");
+
+    await expect(refreshAccessToken()).resolves.toBe(false);
+
+    // No session to refresh: the backend is never invoked and the
+    // "session expired" modal must stay closed.
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    expect(mocks.requestSignInModal).not.toHaveBeenCalled();
+    expect(mocks.clearAuthState).toHaveBeenCalledTimes(1);
+  });
+
+  it("never raises the sign-in modal for a signed-out user (browser, no refresh token)", async () => {
+    mocks.isTauriRuntime.mockReturnValue(false);
+    mocks.getRefreshToken.mockResolvedValue(null);
+
+    const { refreshAccessToken } = await import("@/services/auth");
+
+    await expect(refreshAccessToken()).resolves.toBe(false);
+
+    expect(mocks.refreshToken).not.toHaveBeenCalled();
+    expect(mocks.requestSignInModal).not.toHaveBeenCalled();
+    expect(mocks.clearAuthState).toHaveBeenCalledTimes(1);
+  });
+
+  it("raises the sign-in modal when a present refresh token is rejected (genuine expiry)", async () => {
+    mocks.isTauriRuntime.mockReturnValue(true);
+    mocks.getRefreshToken.mockResolvedValue("expired-refresh-token");
+    mocks.invoke.mockResolvedValue(false);
+
+    const { refreshAccessToken } = await import("@/services/auth");
+
+    await expect(refreshAccessToken()).resolves.toBe(false);
+
+    expect(mocks.invoke).toHaveBeenCalledWith("refresh_session");
+    expect(mocks.clearAuthState).toHaveBeenCalledTimes(1);
+    expect(mocks.requestSignInModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not raise the modal on genuine expiry when prompting is disabled", async () => {
+    mocks.isTauriRuntime.mockReturnValue(true);
+    mocks.getRefreshToken.mockResolvedValue("expired-refresh-token");
+    mocks.invoke.mockResolvedValue(false);
+
+    const { refreshAccessToken } = await import("@/services/auth");
+
+    await expect(
+      refreshAccessToken({ promptOnFailure: false }),
+    ).resolves.toBe(false);
+
+    expect(mocks.clearAuthState).toHaveBeenCalledTimes(1);
     expect(mocks.requestSignInModal).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/compaction-auth-gate.test.ts
+++ b/tests/unit/compaction-auth-gate.test.ts
@@ -98,11 +98,23 @@ describe("#1639 — refreshAccessToken pairs clearAuthState + requestSignInModal
     );
   });
 
-  it("maps missing refresh token to terminal failure", () => {
+  it("maps a missing refresh token to unauthenticated, not session expiry (#2445)", () => {
     const noTokenIdx = authServiceSource.indexOf("if (!refreshToken)");
     expect(noTokenIdx).toBeGreaterThan(0);
     const blockAfter = authServiceSource.slice(noTokenIdx, noTokenIdx + 200);
-    expect(blockAfter).toContain('return "terminal-failure"');
+    expect(blockAfter).toContain('return "unauthenticated"');
+  });
+
+  it("never raises the sign-in modal for the unauthenticated outcome (#2445)", () => {
+    const refreshFnIdx = authServiceSource.indexOf(
+      "async function refreshAccessToken",
+    );
+    const fnBody = authServiceSource.slice(refreshFnIdx, refreshFnIdx + 1300);
+    const unauthIdx = fnBody.indexOf('outcome === "unauthenticated"');
+    expect(unauthIdx).toBeGreaterThan(0);
+    const unauthBlock = fnBody.slice(unauthIdx, unauthIdx + 400);
+    expect(unauthBlock).toContain("clearAuthState()");
+    expect(unauthBlock).not.toContain("requestSignInModal()");
   });
 
   it("maps 401 from refresh endpoint to terminal failure", () => {


### PR DESCRIPTION
Fixes #2445. Unblocks the windows-app-e2e release gate (v3.55.5 failure, run 27573787446).

## Root cause

The v3.55.5 release passed all 5 platform builds but `windows-app-e2e` timed out (30s) clicking **Sign In** in the app probe — the first release where the preflight fail-open (#2442/#2443) let the harness reach the actual app. The button resolved **enabled**, so the actionability failure was *stable*/*receives-events*, not *enabled*.

The app exposes three sign-in surfaces with identical text/labels: the titlebar button, the `account` slide-panel form, and the **`SessionExpiredModal` form** (`fixed inset-0 z-[1000]`, rendered last in DOM). On the e2e box the user is signed out (fresh temp user, no token); a boot-time authenticated Gateway call returns **401** → `appFetch`/generated-client 401 handler → `refreshAccessToken()` (default `promptOnFailure=true`) → no refresh token → `requestSignInModal()` → the *"Your Seren session has expired"* modal pops as a third surface that races/covers the probe's panel flow.

That modal is itself a bug: it's the **same case #1860 fixed on the Rust side** (`auth.rs`: a missing refresh token means never-signed-in / logged-out, not session expiry). The frontend never got the equivalent guard.

## Fix

1. **`src/services/auth.ts` (root cause):** `refreshAccessToken` now distinguishes `unauthenticated` (no refresh token) from genuine `terminal-failure` (refresh token rejected). Only genuine expiry raises the sign-in modal; expiry still also arrives via the backend `auth:session-expired` event. A signed-out 401 no longer pops a spurious "session expired" modal.
2. **`scripts/windows-e2e-app.mjs` (defense in depth):** `signIn()` binds to a single sign-in form (no global `.last()`/`getByLabel`) and dismisses the session-expired modal if present.

## Verification

- **Local reproduction (browser-local harness):**
  - No modal → original probe sequence succeeds at every viewport (1200×800 → 640×480).
  - Forcing a 401 (`page.route` → 401) reproduces the modal (`modalPresent: true`) — the box condition browser-local normally misses (CORS, not 401).
  - Hardened `signIn()` succeeds in **both** no-modal and forced-modal cases across viewports (1200×800, 1200×760, 1000×620).
- **Unit tests:** auth suite green — 31 tests across `auth-service-refresh-login`, `compaction-auth-gate`, `auth-clear-state`, `auth-rust-events`, `fetch-retry`, `skills-refresh-signed-out`, `signin-auth-completion`. New cases cover: no modal for signed-out (Tauri + browser), modal still raised on genuine expiry, and `promptOnFailure=false` honored.

## Notes / not covered

The exact actionability reason on the box was unrecoverable (SSM `Get-Content -Tail 800` + 24KB cap truncated the Playwright call log). The modal is the only confirmed difference between the failing box and a passing local run; the headless local harness could not reproduce the *failure* itself (headless Chromium scroll/stability differs from WebView2). Both changes independently harden the flow, so the gate should pass regardless of the precise micro-mechanism. Final end-to-end validation requires the next release tag (windows-app-e2e runs only on tags).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
