### PR TITLE
fix(editor): open clicked images in the in-app viewer (#2369)

### DIFF
--- a/src/components/editor/ImageViewer.tsx
+++ b/src/components/editor/ImageViewer.tsx
@@ -1,7 +1,6 @@
 // ABOUTME: Image viewer component for displaying image files.
 // ABOUTME: Supports zoom, pan, and displays image metadata.
 
-import { convertFileSrc } from "@tauri-apps/api/core";
 import {
   type Component,
   createEffect,
@@ -9,7 +8,10 @@ import {
   onCleanup,
   Show,
 } from "solid-js";
-import { openImageInDefaultViewer } from "@/lib/files/service";
+import {
+  openImageInDefaultViewer,
+  readImageAsDataUrl,
+} from "@/lib/files/service";
 
 interface ImageViewerProps {
   filePath: string;
@@ -30,18 +32,31 @@ export const ImageViewer: Component<ImageViewerProps> = (props) => {
   const [dragStart, setDragStart] = createSignal({ x: 0, y: 0 });
   const [pointerStart, setPointerStart] = createSignal({ x: 0, y: 0 });
 
-  // Load image when file path changes
+  // Load image when file path changes. The bytes are read through the bridge
+  // (which resolves `~` and reads binary safely) and shown as a data URL, so
+  // the viewer works for absolute, tilde, and Windows paths alike.
   createEffect(() => {
     const path = props.filePath;
     if (!path) return;
 
-    // Convert file path to URL using Tauri's asset protocol
-    const url = convertFileSrc(path);
-    setImageUrl(url);
+    setImageUrl(null);
+    setDimensions(null);
     setError(null);
     setOpenError(null);
     setZoom(100);
     setPosition({ x: 0, y: 0 });
+
+    let cancelled = false;
+    onCleanup(() => {
+      cancelled = true;
+    });
+    readImageAsDataUrl(path)
+      .then((url) => {
+        if (!cancelled) setImageUrl(url);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Failed to load image");
+      });
   });
 
   function handleImageLoad(e: Event) {

--- a/src/lib/files/service.ts
+++ b/src/lib/files/service.ts
@@ -5,6 +5,7 @@ import {
   isBrowserLocalRuntime,
   runtimeInvoke,
 } from "@/lib/browser-local-runtime";
+import { imageMimeType, isSupportedImageFile } from "@/lib/images/file-types";
 import { createSkillsSymlink } from "@/lib/skills/paths";
 import {
   createDirectory as createDirectoryBridge,
@@ -15,6 +16,7 @@ import {
   listDirectory as listDirectoryBridge,
   openPathWithDefaultApp as openPathWithDefaultAppBridge,
   pathExists as pathExistsBridge,
+  readFileBase64 as readFileBase64Bridge,
   readFile as readFileBridge,
   renamePath as renamePathBridge,
   revealInFileManager as revealInFileManagerBridge,
@@ -115,6 +117,17 @@ export async function revealInFileManager(path: string): Promise<void> {
  */
 export async function openImageInDefaultViewer(path: string): Promise<void> {
   return openPathWithDefaultAppBridge(path);
+}
+
+/**
+ * Read an image file as a `data:` URL for in-app preview. Reads the bytes via
+ * the base64 bridge (which resolves `~` and reads binary safely on every
+ * platform) so the viewer never depends on asset-protocol path resolution.
+ */
+export async function readImageAsDataUrl(path: string): Promise<string> {
+  const base64 = await readFileBase64Bridge(path);
+  const mime = imageMimeType(path) ?? "application/octet-stream";
+  return `data:${mime};base64,${base64}`;
 }
 
 async function openDialog(
@@ -268,6 +281,13 @@ export async function openFileInTab(
   // Non-greedy + end-anchor preserves Windows drive letters like C:\foo.md.
   const path = stripLineAnchor(rawPath);
   const cwd = (options.cwd ?? fileDirname(path)).replace(/\/+$/, "") || "/";
+  // Image files are rendered by ImageViewer, which loads their bytes itself.
+  // They are binary, so reading them as UTF-8 text here throws and the tab
+  // would never open — clicking an image link would silently do nothing.
+  if (isSupportedImageFile(path)) {
+    openTab(path, "", cwd);
+    return;
+  }
   const content = await readFile(path);
   openTab(path, content, cwd);
 }

--- a/src/lib/images/file-types.ts
+++ b/src/lib/images/file-types.ts
@@ -41,3 +41,33 @@ export function isSupportedImageFile(path: string): boolean {
   const extension = imageFileExtension(path);
   return extension !== null && SUPPORTED_IMAGE_EXTENSION_SET.has(extension);
 }
+
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  jpe: "image/jpeg",
+  jfif: "image/jpeg",
+  gif: "image/gif",
+  svg: "image/svg+xml",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  dib: "image/bmp",
+  ico: "image/x-icon",
+  cur: "image/x-icon",
+  tif: "image/tiff",
+  tiff: "image/tiff",
+  heic: "image/heic",
+  heif: "image/heif",
+  avif: "image/avif",
+};
+
+/**
+ * Resolve the MIME type used to build a `data:` URL for an image preview.
+ * Returns null for paths that are not supported image files.
+ */
+export function imageMimeType(path: string): string | null {
+  const extension = imageFileExtension(path);
+  if (extension === null) return null;
+  return IMAGE_MIME_BY_EXTENSION[extension] ?? null;
+}

--- a/src/stores/editor.sessions.ts
+++ b/src/stores/editor.sessions.ts
@@ -2,7 +2,8 @@
 // ABOUTME: Sessions surface in the project-rooted thread sidebar as kind="editor" entries.
 
 import { createEffect, untrack } from "solid-js";
-import { readFile } from "@/lib/files/service";
+import { pathExists, readFile } from "@/lib/files/service";
+import { isSupportedImageFile } from "@/lib/images/file-types";
 import { log } from "@/lib/logger";
 import {
   bumpSessionActiveAt,
@@ -303,6 +304,15 @@ export async function restoreEditorSessions(): Promise<void> {
 
   for (const tab of persisted.tabs) {
     try {
+      // Image tabs are binary; reading them as text would throw. The viewer
+      // loads the file itself, so reopen with empty content when it still
+      // exists (matching the drop-if-missing behavior of the text path).
+      if (isSupportedImageFile(tab.filePath)) {
+        if (await pathExists(tab.filePath)) {
+          openTab(tab.filePath, "", tab.cwd);
+        }
+        continue;
+      }
       const content = await readFile(tab.filePath);
       openTab(tab.filePath, content, tab.cwd);
     } catch (err) {

--- a/tests/unit/image-file-opening.test.ts
+++ b/tests/unit/image-file-opening.test.ts
@@ -1,12 +1,24 @@
 // ABOUTME: Critical tests for opening image files in the OS default viewer.
 // ABOUTME: Guards shared image extension support and default-app bridge delegation.
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { openImageInDefaultViewer } from "@/lib/files/service";
-import { isSupportedImageFile } from "@/lib/images/file-types";
-import { openPathWithDefaultApp } from "@/lib/tauri-bridge";
+import {
+  openFileInTab,
+  openImageInDefaultViewer,
+  readImageAsDataUrl,
+} from "@/lib/files/service";
+import {
+  imageMimeType,
+  isSupportedImageFile,
+} from "@/lib/images/file-types";
+import {
+  openPathWithDefaultApp,
+  readFile,
+  readFileBase64,
+} from "@/lib/tauri-bridge";
+import { closeAllTabs, tabsState } from "@/stores/tabs";
 
 vi.mock("@/lib/tauri-bridge", async () => {
   const actual = await vi.importActual<typeof import("@/lib/tauri-bridge")>(
@@ -15,7 +27,14 @@ vi.mock("@/lib/tauri-bridge", async () => {
   return {
     ...actual,
     openPathWithDefaultApp: vi.fn(),
+    readFile: vi.fn(),
+    readFileBase64: vi.fn(),
   };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  closeAllTabs();
 });
 
 describe("image file opening", () => {
@@ -35,6 +54,53 @@ describe("image file opening", () => {
     expect(openPathWithDefaultApp).toHaveBeenCalledWith(
       "/Users/me/Pictures/photo.jpg",
     );
+  });
+
+  it("maps supported image extensions to data-URL MIME types", () => {
+    expect(imageMimeType("/Users/me/photo.PNG")).toBe("image/png");
+    expect(imageMimeType("/Users/me/photo.jpeg")).toBe("image/jpeg");
+    expect(imageMimeType("/Users/me/photo.jpe")).toBe("image/jpeg");
+    expect(imageMimeType("/Users/me/icon.svg")).toBe("image/svg+xml");
+    expect(imageMimeType("C:\\Users\\me\\live.HEIC")).toBe("image/heic");
+    expect(imageMimeType("/Users/me/notes/readme.md")).toBeNull();
+  });
+
+  it("builds a data URL for an image from its base64 bytes", async () => {
+    vi.mocked(readFileBase64).mockResolvedValue("QUJD");
+
+    const url = await readImageAsDataUrl("/Users/me/Pictures/photo.png");
+
+    expect(readFileBase64).toHaveBeenCalledWith("/Users/me/Pictures/photo.png");
+    expect(url).toBe("data:image/png;base64,QUJD");
+  });
+
+  it("opens image tabs without reading them as text (would throw on binary)", async () => {
+    // read_file does a UTF-8 read and throws on binary data; the fix must not
+    // call it, or the tab never opens and the click silently does nothing.
+    vi.mocked(readFile).mockRejectedValue(
+      new Error("stream did not contain valid UTF-8"),
+    );
+
+    await expect(
+      openFileInTab("/Users/me/Pictures/photo.png"),
+    ).resolves.toBeUndefined();
+
+    expect(readFile).not.toHaveBeenCalled();
+    expect(
+      tabsState.tabs.some((t) => t.filePath === "/Users/me/Pictures/photo.png"),
+    ).toBe(true);
+  });
+
+  it("reads non-image files as text content", async () => {
+    vi.mocked(readFile).mockResolvedValue("hello world");
+
+    await openFileInTab("/Users/me/notes/readme.md");
+
+    expect(readFile).toHaveBeenCalledWith("/Users/me/notes/readme.md");
+    const tab = tabsState.tabs.find(
+      (t) => t.filePath === "/Users/me/notes/readme.md",
+    );
+    expect(tab?.content).toBe("hello world");
   });
 
   it("registers the browser-local default-app opener fallback", () => {


### PR DESCRIPTION
## Summary

Fixes #2369. Clicking an image link such as `~/Desktop/desk.png` did nothing — no tab, no error, no image in the viewer. The #2370 "Open in default viewer" feature was unreachable because the `ImageViewer` never mounted.

## Root cause (two coupled defects)

1. **Binary read before the tab opens (P0).** `openFileInTab` (`src/lib/files/service.ts`) always did `const content = await readFile(path)` → Rust `read_file` → `fs::read_to_string`, which fails on binary image bytes (*"stream did not contain valid UTF-8"*). The promise rejected before `openTab` ran, so the tab and `ImageViewer` never appeared. The chat link handlers (`ChatContent.tsx`, `AgentChat.tsx`) swallow that rejection with `.catch(console.warn)` → the reported "no reaction, no error." This hit **every** entry point (chat link, file tree, skills explorer).

2. **Unresolved `~` in the viewer (P1).** Even once a tab opened, `ImageViewer` used `convertFileSrc(path)`; the asset protocol does not expand `~`, so `~/Desktop/desk.png` never resolved.

## Fix

- `openFileInTab` skips the UTF-8 text read for image files and opens the tab with empty content — the viewer loads the bytes itself.
- `ImageViewer` now loads via `read_file_base64` → `data:` URL (`readImageAsDataUrl`). The base64 bridge resolves `~` and reads binary safely in Rust, so absolute, tilde, and Windows paths all work with no asset-protocol path dependency (`data:` is already allowed by the CSP `img-src`).
- Session restore (`editor.sessions.ts`) reopens image tabs without a text read (with a `pathExists` guard to keep drop-if-missing behavior).
- Load failures now surface as **"Failed to load image"** in the viewer instead of doing nothing.

Centralizing the fix in `openFileInTab` covers both chat surfaces and the file tree at once.

## Why it shipped broken before

Existing tests only covered extension detection and the default-app bridge delegation — they never exercised tab-open/render. This PR adds regression tests that `openFileInTab` does **not** read images as text and that `readImageAsDataUrl` builds the correct data URL.

## Tests

- `tests/unit/image-file-opening.test.ts`: image MIME mapping, `readImageAsDataUrl` data URL, `openFileInTab` does not read images as text (regression), text files still read as content.
- Affected suites green: `image-file-opening`, `editor-sessions`, `file-link-anchor`, `tabs` (23 tests). Biome clean; `tsc` adds zero new errors.

## Manual verification plan (macOS + Windows)

- Click a `~/Desktop/desk.png` chat link → image opens in the in-app viewer.
- Open an image from the file tree → renders.
- Drag/pan does not trigger the external open; wheel zoom + zoom buttons work.
- "Open" button launches the OS default viewer.
- A `.heic`/`.tiff` path routes to `ImageViewer`; if the WebView can't decode it, the viewer shows the error and the "Open" button still works.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
