### PR TITLE
fix(editor): open clicked PDFs in the in-app viewer (#2449)

### DIFF
--- a/src/components/editor/PdfViewer.tsx
+++ b/src/components/editor/PdfViewer.tsx
@@ -8,6 +8,7 @@ import {
   createSignal,
   onCleanup,
 } from "solid-js";
+import { readFileBytes } from "@/lib/files/service";
 
 // Set up the worker
 pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
@@ -63,9 +64,11 @@ export const PdfViewer: Component<PdfViewerProps> = (props) => {
       }
       pdfDoc = null;
 
-      // Load PDF using a file:// URL (v6 getDocument takes init parameters).
-      const url = `file://${path}`;
-      loadingTask = pdfjsLib.getDocument({ url });
+      // Read the bytes through the bridge (resolves `~`, reads binary safely)
+      // and hand them to pdf.js directly. A hand-built `file://` URL does not
+      // expand `~` and is malformed for Windows drive paths.
+      const data = await readFileBytes(path);
+      loadingTask = pdfjsLib.getDocument({ data });
       pdfDoc = await loadingTask.promise;
 
       setTotalPages(pdfDoc.numPages);

--- a/src/lib/files/file-types.ts
+++ b/src/lib/files/file-types.ts
@@ -1,0 +1,10 @@
+// ABOUTME: Pure file-type predicates for routing files to editor viewers.
+// ABOUTME: Free of I/O so it is safe to import where the files service is mocked.
+
+/**
+ * Whether a path is a PDF rendered by the in-app PDF viewer rather than the
+ * text editor.
+ */
+export function isPdfFile(path: string): boolean {
+  return path.toLowerCase().endsWith(".pdf");
+}

--- a/src/lib/files/service.ts
+++ b/src/lib/files/service.ts
@@ -5,6 +5,7 @@ import {
   isBrowserLocalRuntime,
   runtimeInvoke,
 } from "@/lib/browser-local-runtime";
+import { isPdfFile } from "@/lib/files/file-types";
 import { imageMimeType, isSupportedImageFile } from "@/lib/images/file-types";
 import { createSkillsSymlink } from "@/lib/skills/paths";
 import {
@@ -128,6 +129,21 @@ export async function readImageAsDataUrl(path: string): Promise<string> {
   const base64 = await readFileBase64Bridge(path);
   const mime = imageMimeType(path) ?? "application/octet-stream";
   return `data:${mime};base64,${base64}`;
+}
+
+/**
+ * Read a file as raw bytes for binary viewers. Goes through the base64 bridge
+ * (which resolves `~` and reads binary safely on every platform) and decodes
+ * client-side, so the viewer never depends on `file://`/asset path formats.
+ */
+export async function readFileBytes(path: string): Promise<Uint8Array> {
+  const base64 = await readFileBase64Bridge(path);
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
 }
 
 async function openDialog(
@@ -281,10 +297,11 @@ export async function openFileInTab(
   // Non-greedy + end-anchor preserves Windows drive letters like C:\foo.md.
   const path = stripLineAnchor(rawPath);
   const cwd = (options.cwd ?? fileDirname(path)).replace(/\/+$/, "") || "/";
-  // Image files are rendered by ImageViewer, which loads their bytes itself.
-  // They are binary, so reading them as UTF-8 text here throws and the tab
-  // would never open — clicking an image link would silently do nothing.
-  if (isSupportedImageFile(path)) {
+  // Image and PDF files are rendered by dedicated viewers that load their
+  // bytes themselves. They are binary, so reading them as UTF-8 text here
+  // throws and the tab would never open — clicking the link would silently
+  // do nothing.
+  if (isSupportedImageFile(path) || isPdfFile(path)) {
     openTab(path, "", cwd);
     return;
   }

--- a/src/stores/editor.sessions.ts
+++ b/src/stores/editor.sessions.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Sessions surface in the project-rooted thread sidebar as kind="editor" entries.
 
 import { createEffect, untrack } from "solid-js";
+import { isPdfFile } from "@/lib/files/file-types";
 import { pathExists, readFile } from "@/lib/files/service";
 import { isSupportedImageFile } from "@/lib/images/file-types";
 import { log } from "@/lib/logger";
@@ -304,10 +305,10 @@ export async function restoreEditorSessions(): Promise<void> {
 
   for (const tab of persisted.tabs) {
     try {
-      // Image tabs are binary; reading them as text would throw. The viewer
-      // loads the file itself, so reopen with empty content when it still
-      // exists (matching the drop-if-missing behavior of the text path).
-      if (isSupportedImageFile(tab.filePath)) {
+      // Image and PDF tabs are binary; reading them as text would throw. The
+      // viewer loads the file itself, so reopen with empty content when it
+      // still exists (matching the drop-if-missing behavior of the text path).
+      if (isSupportedImageFile(tab.filePath) || isPdfFile(tab.filePath)) {
         if (await pathExists(tab.filePath)) {
           openTab(tab.filePath, "", tab.cwd);
         }

--- a/tests/unit/image-file-opening.test.ts
+++ b/tests/unit/image-file-opening.test.ts
@@ -1,12 +1,14 @@
-// ABOUTME: Critical tests for opening image files in the OS default viewer.
-// ABOUTME: Guards shared image extension support and default-app bridge delegation.
+// ABOUTME: Critical tests for opening image and PDF files in the editor viewers.
+// ABOUTME: Guards binary tabs opening without a text read and bridge delegation.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { isPdfFile } from "@/lib/files/file-types";
 import {
   openFileInTab,
   openImageInDefaultViewer,
+  readFileBytes,
   readImageAsDataUrl,
 } from "@/lib/files/service";
 import {
@@ -122,5 +124,38 @@ describe("image file opening", () => {
     expect(desktopSource).toContain(
       'registerHandler("open_path_with_default_app", openPathWithDefaultApp)',
     );
+  });
+});
+
+describe("pdf file opening", () => {
+  it("detects pdf paths case-insensitively", () => {
+    expect(isPdfFile("/Users/me/docs/report.pdf")).toBe(true);
+    expect(isPdfFile("C:\\Users\\me\\Report.PDF")).toBe(true);
+    expect(isPdfFile("/Users/me/notes/readme.md")).toBe(false);
+  });
+
+  it("opens pdf tabs without reading them as text (would throw on binary)", async () => {
+    vi.mocked(readFile).mockRejectedValue(
+      new Error("stream did not contain valid UTF-8"),
+    );
+
+    await expect(
+      openFileInTab("/Users/me/docs/report.pdf"),
+    ).resolves.toBeUndefined();
+
+    expect(readFile).not.toHaveBeenCalled();
+    expect(
+      tabsState.tabs.some((t) => t.filePath === "/Users/me/docs/report.pdf"),
+    ).toBe(true);
+  });
+
+  it("reads file bytes from base64 for binary viewers", async () => {
+    // "ABC" -> base64 "QUJD"
+    vi.mocked(readFileBase64).mockResolvedValue("QUJD");
+
+    const bytes = await readFileBytes("/Users/me/docs/report.pdf");
+
+    expect(readFileBase64).toHaveBeenCalledWith("/Users/me/docs/report.pdf");
+    expect(Array.from(bytes)).toEqual([65, 66, 67]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2449. Discovered during the #2369 / #2448 functional code-path audit: **PDFs never opened in the in-app viewer** — same class of defect as the image bug, plus a second platform defect in `PdfViewer`.

## Root cause

1. **Binary read before the tab opens.** `openFileInTab` read every file as UTF-8 text via `read_file` → Rust `fs::read_to_string`, which fails on binary PDF bytes. The promise rejected before `openTab` ran, so the tab and `PdfViewer` never mounted. In chat the rejection was swallowed by `.catch(console.warn)`. Affected every entry point (chat link, file tree, skills explorer). (#2448 fixed this for images and intentionally left PDFs for this ticket.)
2. **`file://` URL wrong for `~` and Windows.** `PdfViewer.loadPdf` built `` `file://${path}` ``, which does not expand `~` and is malformed for Windows drive paths (`file://C:\…`).

## Fix

- `openFileInTab` skips the UTF-8 text read for PDFs (alongside images) and opens the tab with empty content — the viewer loads the bytes itself.
- `PdfViewer` reads bytes through the base64 bridge (`readFileBytes`) and passes them to `pdfjsLib.getDocument({ data })` instead of a hand-built `file://` URL. The bridge resolves `~` and reads binary safely on macOS and Windows, removing the tilde/Windows path-format dependency. CSP unchanged.
- Session restore (`editor.sessions.ts`) reopens PDF tabs without a text read.
- `isPdfFile` moved to a pure `src/lib/files/file-types.ts` so it is safe to import where the files service is mocked (mirrors `images/file-types.ts`). This also fixes a latent fragility: importing predicates from the I/O service breaks any test that mocks that service wholesale.

## Tests

- `tests/unit/image-file-opening.test.ts`: `isPdfFile` detection, `openFileInTab` does **not** read PDFs as text (regression), `readFileBytes` decodes base64 → bytes.
- Affected suites green: `image-file-opening`, `editor-sessions`, `file-link-anchor`, `tabs` (26 tests). Biome clean; `tsc` adds zero new errors.

## Manual verification plan (macOS + Windows)

- Click a `~/…/doc.pdf` chat link → opens in the in-app PDF viewer.
- Open a PDF from the file tree → renders; page nav + zoom work.
- Load failure surfaces as "Failed to load PDF file" in the viewer.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
