### PR TITLE
fix(agent): widen claude-code initialize timeout + retry (#2454)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -55,7 +55,9 @@ function resolveClaudeBinary() {
     const appData = process.env.APPDATA ?? "";
     const nodeDir = path.dirname(process.execPath);
     const candidates = [
-      // Native installer (install.ps1) places binary here
+      // Native installer (install.ps1) places the binary here
+      path.join(home, ".local", "bin", "claude.exe"),
+      // Older native installer location
       path.join(home, ".claude", "bin", "claude.exe"),
       // Legacy/alternate location
       ...(appData ? [path.join(appData, "Claude", "claude.exe")] : []),
@@ -856,6 +858,28 @@ function sendControlRequest(session, request, timeoutMs = 30_000) {
       request,
     });
   });
+}
+
+// A brand-new user's first-ever claude invocation does one-time init (fresh
+// profile, fetching the dynamic command/plugin catalog over the network) that
+// runs several times slower than a warm run — measured up to ~9s on a cold
+// Windows host versus ~2s warm. The default per-request window was too tight
+// for that cold path and timed out the spawn (#2452/#2454), so the initialize
+// handshake gets a wider budget and one retry before the session is abandoned.
+const INITIALIZE_TIMEOUT_MS = 60_000;
+
+async function sendInitializeWithRetry(session) {
+  const request = { subtype: "initialize", hooks: null };
+  try {
+    return await sendControlRequest(session, request, INITIALIZE_TIMEOUT_MS);
+  } catch (error) {
+    console.error(
+      `${session.logPrefix ?? "[claude]"} initialize handshake timed out after ${
+        INITIALIZE_TIMEOUT_MS / 1000
+      }s; retrying once: ${error.message}`,
+    );
+    return sendControlRequest(session, request, INITIALIZE_TIMEOUT_MS);
+  }
 }
 
 function buildClaudeArgs({
@@ -1910,14 +1934,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     attachProcessListeners(emit, sessions, session, exitPromises);
 
     try {
-      const initResult = await sendControlRequest(
-        session,
-        {
-          subtype: "initialize",
-          hooks: null,
-        },
-        20_000,
-      );
+      const initResult = await sendInitializeWithRetry(session);
 
       session.availableModelRecords = augmentWithLegacyOpus(
         normalizeModelRecords(initResult),

--- a/tests/unit/claude-initialize-timeout.test.ts
+++ b/tests/unit/claude-initialize-timeout.test.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Regression test for #2454 — claude-code initialize handshake must
+// ABOUTME: tolerate cold first-run latency (wide timeout + one retry) and resolve .local\bin.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const runtimeSource = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf-8",
+);
+
+describe("#2454 — claude initialize handshake tolerates cold first-run", () => {
+  it("defines a wide initialize timeout (>= 60s, not the old 20s)", () => {
+    const match = runtimeSource.match(/INITIALIZE_TIMEOUT_MS\s*=\s*([0-9_]+)/);
+    expect(match, "INITIALIZE_TIMEOUT_MS constant must exist").not.toBeNull();
+    const ms = Number((match?.[1] ?? "0").replaceAll("_", ""));
+    expect(ms).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it("retries the initialize handshake once before abandoning the spawn", () => {
+    const start = runtimeSource.indexOf("async function sendInitializeWithRetry");
+    expect(start, "sendInitializeWithRetry must exist").toBeGreaterThan(0);
+    const body = runtimeSource.slice(start, start + 700);
+    // Two sendControlRequest calls = initial attempt + one retry.
+    const calls = body.match(/sendControlRequest\(/g) ?? [];
+    expect(calls.length, "must call sendControlRequest twice (attempt + retry)").toBe(2);
+    expect(body).toContain("subtype: \"initialize\"");
+    expect(body).toMatch(/catch\s*\(/);
+  });
+
+  it("spawn drives initialize through the retry helper, not a bare 20s control request", () => {
+    expect(runtimeSource).toContain("await sendInitializeWithRetry(session)");
+    // The old tight inline initialize timeout must be gone.
+    expect(runtimeSource).not.toMatch(/subtype:\s*"initialize"[\s\S]{0,80}20_000/);
+  });
+});
+
+describe("#2454 — resolveClaudeBinary finds the native installer location", () => {
+  it("includes %USERPROFILE%\\.local\\bin\\claude.exe in the Windows candidates", () => {
+    const start = runtimeSource.indexOf("function resolveClaudeBinary");
+    const body = runtimeSource.slice(start, start + 700);
+    expect(body).toMatch(/\.join\(home,\s*"\.local",\s*"bin",\s*"claude\.exe"\)/);
+  });
+});


### PR DESCRIPTION
Fixes #2454. Implements the fix for the root cause investigated in #2452.

## Root cause (from on-box investigation, #2452)
The provider runtime caps the claude-code stream-json `initialize` control_request at **20s** (`bin/browser-local/claude-runtime.mjs`). Reproduced on the e2e box with the same claude version (2.1.178): the handshake takes ~2.2s warm but **~8.7s for a brand-new user's first-ever invocation** (one-time per-user init that fetches the dynamic command/plugin catalog over the network). In the v3.55.6 release run (freshly-installed claude + first-ever invocation + box load/network) it exceeded 20s → `windows-app-e2e` timeout → release shipped via manual override.

Ruled out: Bedrock access (raw converse 3.7s), MCP config (none in the default spawn), version drift (ran the same 2.1.178), flags, and the handshake protocol itself.

## Changes
- **`sendInitializeWithRetry`**: raise the initialize budget to **60s** and **retry once**. Benefits real users too — a first cold agent spawn on a slow network shouldn't fail at 20s.
- **`resolveClaudeBinary`**: add `%USERPROFILE%\.local\bin\claude.exe` (where the current native installer places the binary; previously resolved only via the `where claude` PATH fallback).

## Tests
- New source-inspection test (`claude-initialize-timeout.test.ts`) guards the 60s timeout, the retry, the spawn wiring, and the `.local\bin` candidate.
- Existing claude-runtime tests stay green (29 tests across 5 files run locally).

## Validation note
The fix targets the proven latency cause. I could not reproduce a clean >20s locally (peaked at 8.7s; n=1 on the real failure), so #2452 stays open until a release tag runs `windows-app-e2e` green without the manual-publish override — that's the real end-to-end proof.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
