### PR TITLE
fix(agent): isolate agent runtime loads so one can't crash all (#2457)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -14,12 +14,14 @@ import os from "node:os";
 import path from "node:path";
 
 import { backgroundUpdateCli } from "./cli-updater.mjs";
-import {
-  checkLmStudioAuthenticated,
-  checkLmStudioAvailable,
-  ensureLmStudioCli,
-  launchLmStudioDownload,
-} from "./lmstudio-runtime.mjs";
+
+// LM Studio support is loaded lazily so a missing LM Studio dependency (e.g.
+// @lmstudio/sdk) never crashes the registry, which every agent relies on for
+// install/login/availability metadata (#2457). It is imported on demand only
+// when the LM Studio agent is queried.
+function loadLmStudioRuntime() {
+  return import("./lmstudio-runtime.mjs");
+}
 
 /**
  * Map a binary file's CPU architecture to Node's `process.arch` taxonomy.
@@ -954,8 +956,23 @@ export function createBrowserLocalAgentRegistry({ emit }) {
       description: "Local LM Studio server via OpenAI-compatible HTTP",
       command: "lms",
       async getAvailability() {
-        const serverReady = await checkLmStudioAuthenticated();
-        const canStart = await checkLmStudioAvailable();
+        let lmStudio;
+        try {
+          lmStudio = await loadLmStudioRuntime();
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : String(error);
+          return {
+            type: "lmstudio",
+            name: "LM Studio",
+            description: "Local LM Studio server via OpenAI-compatible HTTP",
+            command: "lms",
+            available: false,
+            authenticated: false,
+            unavailableReason: `LM Studio support failed to load: ${reason}`,
+          };
+        }
+        const serverReady = await lmStudio.checkLmStudioAuthenticated();
+        const canStart = await lmStudio.checkLmStudioAvailable();
         return {
           type: "lmstudio",
           name: "LM Studio",
@@ -975,13 +992,16 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         return true;
       },
       async checkAuthenticated() {
-        return checkLmStudioAuthenticated();
+        const lmStudio = await loadLmStudioRuntime();
+        return lmStudio.checkLmStudioAuthenticated();
       },
       async ensureCli() {
-        return ensureLmStudioCli();
+        const lmStudio = await loadLmStudioRuntime();
+        return lmStudio.ensureLmStudioCli();
       },
-      launchLogin() {
-        launchLmStudioDownload();
+      async launchLogin() {
+        const lmStudio = await loadLmStudioRuntime();
+        lmStudio.launchLmStudioDownload();
       },
     },
   };

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -8,12 +8,99 @@ import {
   createBrowserLocalAgentRegistry,
   resolveInstalledCodexBinary,
 } from "./agent-registry.mjs";
-import { createClaudeRuntime } from "./claude-runtime.mjs";
-import { createGeminiRuntime } from "./gemini-runtime.mjs";
-import { createLmStudioRuntime } from "./lmstudio-runtime.mjs";
 import { providerLogPrefix } from "./logging.mjs";
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
-import { createPairedRuntime, PAIRED_AGENT_TYPE } from "./paired-runtime.mjs";
+
+// Agent runtimes are loaded in isolation (#2457). Each runtime module is
+// imported dynamically inside try/catch so that one agent failing to load — a
+// missing optional dependency, a broken native binding, a throwing module —
+// cannot crash the provider runtime or disable the other agents. A runtime that
+// fails to load or instantiate is replaced with an unavailable stub that owns
+// no sessions and throws a clear, per-agent error only when that agent is used.
+async function loadAgentRuntimeModule(label, importer) {
+  try {
+    return { module: await importer(), error: null };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.error(`[provider-runtime] ${label} runtime failed to load: ${reason}`);
+    return { module: null, error: reason };
+  }
+}
+
+const claudeRuntimeModule = await loadAgentRuntimeModule(
+  "claude-code",
+  () => import("./claude-runtime.mjs"),
+);
+const geminiRuntimeModule = await loadAgentRuntimeModule(
+  "gemini",
+  () => import("./gemini-runtime.mjs"),
+);
+const lmStudioRuntimeModule = await loadAgentRuntimeModule(
+  "lmstudio",
+  () => import("./lmstudio-runtime.mjs"),
+);
+const pairedRuntimeModule = await loadAgentRuntimeModule(
+  "claude-codex",
+  () => import("./paired-runtime.mjs"),
+);
+
+// Needed for synchronous dispatch before the paired runtime is instantiated;
+// fall back to the known identifier if the module failed to load so dispatch
+// still recognizes the type and routes it to the unavailable stub.
+const PAIRED_AGENT_TYPE =
+  pairedRuntimeModule.module?.PAIRED_AGENT_TYPE ?? "claude-codex";
+
+export function createUnavailableRuntime(label, reason) {
+  const detail = reason ? `: ${reason}` : "";
+  const unavailable = async () => {
+    throw new Error(`The ${label} agent is unavailable${detail}`);
+  };
+  return {
+    // Sync predicates must never force a load: an unavailable runtime owns no
+    // sessions, so routing skips it and the other agents are unaffected.
+    hasSession: () => false,
+    interceptEmit: () => false,
+    listSessions: async () => [],
+    spawnSession: unavailable,
+    sendPrompt: unavailable,
+    cancelPrompt: unavailable,
+    terminateSession: unavailable,
+    setPermissionMode: unavailable,
+    respondToPermission: unavailable,
+    listRemoteSessions: unavailable,
+    setModel: unavailable,
+    setSessionModel: unavailable,
+    setConfigOption: unavailable,
+    updateSessionConfigOption: unavailable,
+    forkSession: unavailable,
+    buildSyntheticTranscript: unavailable,
+    testConnection: unavailable,
+    startServer: unavailable,
+    stopServer: unavailable,
+  };
+}
+
+function instantiateAgentRuntime(label, loaded, factoryName, args) {
+  if (!loaded.module) {
+    return createUnavailableRuntime(label, loaded.error);
+  }
+  const factory = loaded.module[factoryName];
+  if (typeof factory !== "function") {
+    return createUnavailableRuntime(
+      label,
+      `${factoryName} export missing from ${label} runtime`,
+    );
+  }
+  try {
+    return factory(args);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.error(
+      `[provider-runtime] ${label} runtime failed to initialize: ${reason}`,
+    );
+    return createUnavailableRuntime(label, reason);
+  }
+}
 
 function isAuthError(message) {
   const lower = String(message).toLowerCase();
@@ -994,9 +1081,24 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
   };
   const codexLogPrefix = providerLogPrefix("codex", runtimeMode);
   const agentRegistry = createBrowserLocalAgentRegistry({ emit });
-  const claudeRuntime = createClaudeRuntime({ emit, runtimeMode });
-  const geminiRuntime = createGeminiRuntime({ emit, runtimeMode });
-  const lmStudioRuntime = createLmStudioRuntime({ emit, runtimeMode });
+  const claudeRuntime = instantiateAgentRuntime(
+    "claude-code",
+    claudeRuntimeModule,
+    "createClaudeRuntime",
+    { emit, runtimeMode },
+  );
+  const geminiRuntime = instantiateAgentRuntime(
+    "gemini",
+    geminiRuntimeModule,
+    "createGeminiRuntime",
+    { emit, runtimeMode },
+  );
+  const lmStudioRuntime = instantiateAgentRuntime(
+    "lmstudio",
+    lmStudioRuntimeModule,
+    "createLmStudioRuntime",
+    { emit, runtimeMode },
+  );
 
   async function withTemporaryCodexSession(cwd, callback) {
     const processHandle = spawnCodexProcess(cwd);
@@ -1668,19 +1770,24 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
   // Created last so the paired coordinator can drive the handler functions
   // above as its inner runtime (hoisted declarations). It receives the RAW
   // emit — its own events must not re-enter the interceptor.
-  pairedRuntime = createPairedRuntime({
-    emit: rawEmit,
-    inner: {
-      spawnSession,
-      sendPrompt,
-      cancelPrompt,
-      terminateSession,
-      setSessionModel,
-      updateSessionConfigOption,
-      setPermissionMode,
-      respondToPermission,
+  pairedRuntime = instantiateAgentRuntime(
+    "claude-codex",
+    pairedRuntimeModule,
+    "createPairedRuntime",
+    {
+      emit: rawEmit,
+      inner: {
+        spawnSession,
+        sendPrompt,
+        cancelPrompt,
+        terminateSession,
+        setSessionModel,
+        updateSessionConfigOption,
+        setPermissionMode,
+        respondToPermission,
+      },
     },
-  });
+  );
 
   return {
     spawnSession,

--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -63,6 +63,11 @@ function main(): void {
     readFileSync(path.join(repoRoot, "package.json"), "utf8"),
   ) as { dependencies?: Record<string, string> };
   const wsVersion = rootPackageJson.dependencies?.ws ?? "^8.19.0";
+  // lmstudio-runtime.mjs statically imports @lmstudio/sdk at provider-runtime
+  // startup (provider-runtime.mjs -> providers.mjs -> lmstudio-runtime.mjs), so
+  // the package must be present in the bundle or the runtime exits before it
+  // becomes ready (#2456).
+  const lmstudioSdkVersion = rootPackageJson.dependencies?.["@lmstudio/sdk"] ?? "1.5.0";
 
   rmSync(destDir, { recursive: true, force: true });
   mkdirSync(destDir, { recursive: true });
@@ -84,6 +89,7 @@ function main(): void {
         version: "0.1.0",
         type: "module",
         dependencies: {
+          "@lmstudio/sdk": lmstudioSdkVersion,
           ws: wsVersion,
         },
       },
@@ -108,6 +114,7 @@ function main(): void {
       {
         builtAt: new Date().toISOString(),
         dependencies: {
+          "@lmstudio/sdk": lmstudioSdkVersion,
           ws: wsVersion,
         },
       },

--- a/tests/unit/provider-runtime-agent-isolation.test.ts
+++ b/tests/unit/provider-runtime-agent-isolation.test.ts
@@ -1,0 +1,74 @@
+// ABOUTME: Regression tests for #2457/#2456 — one agent runtime's load failure
+// ABOUTME: must not crash the provider runtime or disable the other agents.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createUnavailableRuntime } from "../../bin/browser-local/providers.mjs";
+
+const providersSource = readFileSync(
+  resolve("bin/browser-local/providers.mjs"),
+  "utf-8",
+);
+const registrySource = readFileSync(
+  resolve("bin/browser-local/agent-registry.mjs"),
+  "utf-8",
+);
+const bundlerSource = readFileSync(
+  resolve("scripts/build-provider-runtime.ts"),
+  "utf-8",
+);
+
+describe("#2457 — unavailable agent runtime is isolated", () => {
+  it("owns no sessions and never forces a load via sync predicates", () => {
+    const runtime = createUnavailableRuntime("lmstudio", "boom");
+    expect(runtime.hasSession("any-session")).toBe(false);
+    expect(runtime.interceptEmit("provider://event", {})).toBe(false);
+  });
+
+  it("lists no sessions so aggregation across runtimes still works", async () => {
+    const runtime = createUnavailableRuntime("lmstudio", "boom");
+    await expect(runtime.listSessions()).resolves.toEqual([]);
+  });
+
+  it("throws a clear per-agent error only when the agent is invoked", async () => {
+    const runtime = createUnavailableRuntime("lmstudio", "missing dep");
+    await expect(runtime.spawnSession({})).rejects.toThrow(
+      /The lmstudio agent is unavailable: missing dep/,
+    );
+    await expect(runtime.testConnection()).rejects.toThrow(/unavailable/);
+  });
+});
+
+describe("#2457 — agent runtimes are not statically imported at startup", () => {
+  it("providers.mjs loads each agent runtime via dynamic import, not a top-level static import", () => {
+    for (const mod of [
+      "claude-runtime.mjs",
+      "gemini-runtime.mjs",
+      "lmstudio-runtime.mjs",
+      "paired-runtime.mjs",
+    ]) {
+      expect(
+        providersSource,
+        `${mod} must not be statically imported at top level`,
+      ).not.toMatch(new RegExp(`^import\\s.*from\\s+"\\./${mod.replace(".", "\\.")}"`, "m"));
+      expect(
+        providersSource,
+        `${mod} must be loaded via dynamic import()`,
+      ).toContain(`import("./${mod}")`);
+    }
+  });
+
+  it("agent-registry.mjs does not statically import lmstudio-runtime (it is needed by every agent)", () => {
+    expect(registrySource).not.toMatch(
+      /^import\s[\s\S]*?from\s+"\.\/lmstudio-runtime\.mjs"/m,
+    );
+    expect(registrySource).toContain('import("./lmstudio-runtime.mjs")');
+  });
+});
+
+describe("#2456 — LM Studio SDK is bundled into the packaged provider runtime", () => {
+  it("build-provider-runtime.ts ships @lmstudio/sdk in the embedded bundle deps", () => {
+    expect(bundlerSource).toContain('"@lmstudio/sdk": lmstudioSdkVersion');
+  });
+});


### PR DESCRIPTION
## Why
v3.55.7's windows-app-e2e failed and gated the release. Root cause (verified on the real packaged Windows build, AWS e2e box): the provider runtime crashed at startup with `ERR_MODULE_NOT_FOUND: @lmstudio/sdk` and exited 1 before becoming ready — so **every** agent journey (claude-code, codex, gemini, claude-codex) failed, even though LM Studio was unrelated.

This is the architectural defect in **#2457**: the provider runtime loaded every agent runtime at startup via static, top-level ESM imports and instantiated them eagerly. A static import cannot be guarded, so any one agent throwing at module evaluation kills the whole runtime. **#2456** (missing bundle dep) was the immediate trigger.

`#2454`'s initialize-timeout widening did nothing here because the runtime crashes at startup, long before the handshake it touched. Dev/CI missed it because they run from the full repo `node_modules` where the dep resolves; only the packaged minimal bundle omits it.

## What changed
**Architectural fix — no agent failure may cascade:**
- `bin/browser-local/providers.mjs` — each agent runtime is loaded via dynamic `import()` in try/catch, and eager instantiation is guarded. A runtime that fails to load/init becomes an **unavailable stub**: owns no sessions, lists none, and throws a clear per-agent error only when that agent is invoked. Routing skips unavailable runtimes, so the others keep working.
- `bin/browser-local/agent-registry.mjs` — the registry (needed by every agent) now loads `lmstudio-runtime.mjs` lazily inside the LM Studio definition instead of at module top level, and degrades to an unavailable result if the import fails.

**Make the LM Studio feature work in the package (#2456):**
- `scripts/build-provider-runtime.ts` bundles `@lmstudio/sdk` into the embedded provider runtime (derived from root `package.json` like `ws`). With the isolation fix this is no longer load-bearing for the runtime — it just enables the feature.

## Verification
- **Reproduced the exact packaged bundle without `@lmstudio/sdk`:** `providers.mjs` imports cleanly, `createProviderHandlers` works, `getAvailableAgents` lists all 5, claude/codex/gemini stay usable, and LM Studio degrades to an isolated `available=false` / "unavailable" rejection. Process exits 0.
- **With `@lmstudio/sdk` bundled:** LM Studio loads `available=true` — feature not regressed.
- **Tests:** new `tests/unit/provider-runtime-agent-isolation.test.ts` (isolation contract + source-inspection regression guards). Full unit suite green (**1802 tests**). Related provider/runtime/lmstudio suites green (96).

## Follow-ups (tracked in #2457, separate)
- Harden `test:runtime-smoke` (or a build-time check) to import the **packaged bundle** and assert it boots — would have caught #2456.
- Derive the bundle dependency list from the actual import graph so new top-level provider-runtime deps can't silently break the package.

Closes #2457. Fixes #2456.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
