### PR TITLE
fix(memory): don't block agent spawn on cold SerenDB index (#2460)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -501,7 +501,11 @@ let claudeMemoryInterceptedListener: Promise<UnlistenFn> | null = null;
 
 let sessionResetGeneration = 0;
 const CLAUDE_MEMORY_EVIDENCE_LIMIT = 20;
-const CLAUDE_MEMORY_RENDER_BEFORE_SPAWN_TIMEOUT_MS = 15_000;
+// Warm fast-path window for refreshing the Claude memory index before spawn.
+// A responsive SerenDB renders the index well under this budget; a cold
+// (scaled-to-zero) database takes far longer, so we cap the spawn wait here
+// and let the render finish in the background instead of stalling the spawn.
+const CLAUDE_MEMORY_RENDER_BEFORE_SPAWN_TIMEOUT_MS = 4_000;
 
 function disposeTauriListener(
   listener: Promise<UnlistenFn> | null,
@@ -1190,41 +1194,43 @@ async function refreshClaudeMemoryMdBeforeSpawn(
   if (!hasSerenApiKey) return;
   if (!settingsStore.get("claudeMemoryInterceptEnabled")) return;
 
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  let timedOut = false;
-  const renderPromise = renderClaudeMemoryMd(cwd).catch((error) => {
-    if (timedOut) {
-      console.warn(
-        "[AgentStore] Claude memory index refresh failed after spawn-time timeout:",
-        error,
-      );
+  // The on-disk MEMORY.md is what the agent reads at startup, and the
+  // interceptor re-renders it after every local memory write, so it is already
+  // current for a single-device user. This pre-spawn render only pulls in
+  // cross-device / cross-session updates from SerenDB. We give it a short warm
+  // fast-path window so a responsive DB refreshes the index before the agent
+  // reads it, but we never stall the spawn on a cold SerenDB: the render keeps
+  // running in the background and refreshes MEMORY.md for the next spawn.
+  let settled = false;
+  const renderPromise = renderClaudeMemoryMd(cwd)
+    .then((result) => {
+      settled = true;
+      if (result) {
+        console.info("[AgentStore] Refreshed Claude memory index:", result);
+      }
+      return result;
+    })
+    .catch((error) => {
+      settled = true;
+      console.warn("[AgentStore] Claude memory index refresh failed:", error);
       return null;
-    }
-    throw error;
-  });
+    });
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<"timeout">((resolve) => {
-    timeoutId = setTimeout(() => {
-      timedOut = true;
-      resolve("timeout");
-    }, CLAUDE_MEMORY_RENDER_BEFORE_SPAWN_TIMEOUT_MS);
+    timeoutId = setTimeout(
+      () => resolve("timeout"),
+      CLAUDE_MEMORY_RENDER_BEFORE_SPAWN_TIMEOUT_MS,
+    );
   });
 
   try {
     const result = await Promise.race([renderPromise, timeoutPromise]);
-    if (result === "timeout") {
-      console.warn(
-        `[AgentStore] Claude memory index refresh timed out after ${CLAUDE_MEMORY_RENDER_BEFORE_SPAWN_TIMEOUT_MS}ms; spawning with existing MEMORY.md.`,
+    if (result === "timeout" && !settled) {
+      console.info(
+        `[AgentStore] Claude memory index still refreshing after ${CLAUDE_MEMORY_RENDER_BEFORE_SPAWN_TIMEOUT_MS}ms; spawning with on-disk MEMORY.md while the refresh finishes in the background.`,
       );
-      return;
     }
-    if (result) {
-      console.info("[AgentStore] Refreshed Claude memory index:", result);
-    }
-  } catch (error) {
-    console.warn(
-      "[AgentStore] Claude memory index refresh before spawn failed:",
-      error,
-    );
   } finally {
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId);


### PR DESCRIPTION
Fixes #2460.

## Problem
Spawning a Claude agent stalled with `[AgentStore] Claude memory index refresh timed out after 15000ms; spawning with existing MEMORY.md.` `refreshClaudeMemoryMdBeforeSpawn` blocks the spawn for up to 15s on a single SerenDB `SELECT`. When the `claude_agent_prefs` database is scaled-to-zero, that query exceeds 15s, so every cold-start spawn froze the full 15s and then fell back to the on-disk MEMORY.md anyway — the worst of both worlds.

## Fix
- The interceptor already re-renders MEMORY.md after **every** local memory write (`claude_memory.rs` `render_memory_md_from_db`), so the on-disk index is current for single-device users. The pre-spawn render only catches cross-device / cross-session updates.
- Cap the warm fast-path window at 4s: a responsive DB still refreshes the index before the agent reads it, and a cold DB no longer stalls the spawn.
- The render keeps running in the background and refreshes MEMORY.md for the next spawn (its result/error is now logged from the promise chain regardless of the race outcome). The expected fall-through is an `info` log, not a `warn`.

## Trade-off
- Single-device users: zero functionality change (on-disk MEMORY.md always fresh), large UX win (no 15s stall).
- Cross-device users on a cold DB: a brand-new cross-device memory lands one spawn later instead of after a multi-second stall.

## Tests
No new test. Per repo testing rules this is store glue (timeout race + logging), not critical-algorithm/security/billing logic, and testing it would mean mocking `renderClaudeMemoryMd` + timers (mocked behavior). Verified with Biome (clean) and `tsc --noEmit` (no new errors; the 23 pre-existing errors are all in `tests/` fixtures).

## Risk
Low. Same render call and graceful fallback; only the blocking budget and logging changed.
