### PR TITLE
fix(lmstudio): reply when a model's chat template rejects tools (#2463)

### DIFF
--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -23,6 +23,8 @@ const DEFAULT_MCP_GATEWAY_URL =
   process.env.SEREN_MCP_GATEWAY_URL ?? "https://mcp.serendb.com/mcp";
 const LMSTUDIO_AGENT_TYPE = "lmstudio";
 const MAX_TOOL_ITERATIONS = 25;
+const TOOLS_UNSUPPORTED_NOTICE =
+  "_This model doesn't support tool calls, so local file access and Seren tools are off for this chat._\n\n";
 
 const FILE_TOOLS = [
   {
@@ -625,6 +627,37 @@ export function normalizeToolCalls(accumulator) {
     .filter((call) => call.function.name);
 }
 
+function throwIfErrorPayload(payload) {
+  if (payload?.error == null) return;
+  const detail = payload.error?.message ?? payload.error;
+  throw new Error(
+    typeof detail === "string" ? detail : JSON.stringify(detail),
+  );
+}
+
+/**
+ * True when an LM Studio failure means the loaded model can't accept tool
+ * definitions. Tool support is a property of the specific GGUF's Jinja chat
+ * template, not the model family — community "obliterated"/abliterated builds
+ * routinely ship a template that throws when `tools` are present, while the
+ * official build of the same model handles them. We can't know up front, so
+ * the caller degrades reactively on these signatures.
+ */
+export function isToolIncompatibilityError(message) {
+  const lower = String(message ?? "").toLowerCase();
+  return (
+    lower.includes("jinja") ||
+    lower.includes("does not support tool") ||
+    lower.includes("doesn't support tool") ||
+    lower.includes("not support tools") ||
+    lower.includes("tool use is not supported") ||
+    lower.includes("tools are not supported") ||
+    lower.includes("tool calling is not supported") ||
+    lower.includes("function calling is not supported") ||
+    lower.includes("tool_choice")
+  );
+}
+
 async function streamOpenAiResponse({ session, body, signal, onContent }) {
   const response = await fetch(`${openAiBaseUrl(session.baseUrl)}/chat/completions`, {
     method: "POST",
@@ -644,6 +677,7 @@ async function streamOpenAiResponse({ session, body, signal, onContent }) {
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.includes("text/event-stream")) {
     const payload = await response.json();
+    throwIfErrorPayload(payload);
     const message = payload?.choices?.[0]?.message ?? {};
     if (message.content) onContent(message.content);
     return {
@@ -659,6 +693,34 @@ async function streamOpenAiResponse({ session, body, signal, onContent }) {
   let content = "";
   let stopReason = "stop";
 
+  const processEvent = (event) => {
+    const data = event
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim())
+      .join("\n");
+    if (!data || data === "[DONE]") return;
+
+    const payload = safeJsonParse(data, null);
+    // LM Studio reports server/model failures (e.g. a chat template that can't
+    // render tool definitions) as a 200 OK SSE `event: error` frame with no
+    // `choices`. Surface it instead of silently returning an empty completion.
+    throwIfErrorPayload(payload);
+    const choice = payload?.choices?.[0];
+    if (!choice) return;
+    if (choice.finish_reason) stopReason = choice.finish_reason;
+    const delta = choice.delta ?? {};
+    if (typeof delta.content === "string" && delta.content.length > 0) {
+      content += delta.content;
+      onContent(delta.content);
+    }
+    if (Array.isArray(delta.tool_calls)) {
+      for (const toolCall of delta.tool_calls) {
+        appendToolDelta(toolAccumulator, toolCall);
+      }
+    }
+  };
+
   for await (const chunk of response.body) {
     buffer += decoder.decode(chunk, { stream: true });
     let boundary = buffer.indexOf("\n\n");
@@ -666,29 +728,13 @@ async function streamOpenAiResponse({ session, body, signal, onContent }) {
       const event = buffer.slice(0, boundary);
       buffer = buffer.slice(boundary + 2);
       boundary = buffer.indexOf("\n\n");
-
-      const data = event
-        .split(/\r?\n/)
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice(5).trim())
-        .join("\n");
-      if (!data || data === "[DONE]") continue;
-
-      const payload = safeJsonParse(data, null);
-      const choice = payload?.choices?.[0];
-      if (!choice) continue;
-      if (choice.finish_reason) stopReason = choice.finish_reason;
-      const delta = choice.delta ?? {};
-      if (typeof delta.content === "string" && delta.content.length > 0) {
-        content += delta.content;
-        onContent(delta.content);
-      }
-      if (Array.isArray(delta.tool_calls)) {
-        for (const toolCall of delta.tool_calls) {
-          appendToolDelta(toolAccumulator, toolCall);
-        }
-      }
+      processEvent(event);
     }
+  }
+  // Flush a trailing event the server emitted without a closing blank line —
+  // otherwise a final error frame can be dropped and surface as an empty reply.
+  if (buffer.trim().length > 0) {
+    processEvent(buffer);
   }
 
   return {
@@ -696,6 +742,50 @@ async function streamOpenAiResponse({ session, body, signal, onContent }) {
     toolCalls: normalizeToolCalls(toolAccumulator),
     stopReason,
   };
+}
+
+/**
+ * Run one chat completion, degrading gracefully when the loaded model rejects
+ * tool definitions. Tool-capable models keep full tool calling; models whose
+ * chat template can't render tools (common for community local builds) drop
+ * tools for the rest of the session and retry, so the user always gets a reply
+ * instead of a silent empty response.
+ */
+async function runChatCompletion({ session, tools, signal, onContent }) {
+  const useTools = tools.length > 0 && !session.toolsDisabled;
+  const baseBody = {
+    model: session.currentModelId,
+    messages: session.messages,
+    stream: true,
+  };
+
+  try {
+    return await streamOpenAiResponse({
+      session,
+      signal,
+      onContent,
+      body: useTools ? { ...baseBody, tools, tool_choice: "auto" } : baseBody,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (
+      !useTools ||
+      error?.name === "AbortError" ||
+      !isToolIncompatibilityError(message)
+    ) {
+      throw error;
+    }
+
+    session.toolsDisabled = true;
+    console.warn(
+      `${session.logPrefix} model "${session.currentModelId}" rejected tool definitions (${message}); retrying without tools for this session.`,
+    );
+    // One-time, honest notice so the user understands why tools are inactive.
+    // Emitted to the UI only (not pushed into session.messages), so it never
+    // re-enters the model's context on later turns.
+    onContent(TOOLS_UNSUPPORTED_NOTICE);
+    return streamOpenAiResponse({ session, signal, onContent, body: baseBody });
+  }
 }
 
 async function requestPermission(session, toolCall, args) {
@@ -852,15 +942,10 @@ async function sendPromptToLmStudio(session, prompt, context) {
 
     for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration += 1) {
       const { tools, handlers } = await buildToolCatalog(session);
-      const result = await streamOpenAiResponse({
+      const result = await runChatCompletion({
         session,
+        tools,
         signal: abortController.signal,
-        body: {
-          model: session.currentModelId,
-          messages: session.messages,
-          stream: true,
-          ...(tools.length > 0 ? { tools, tool_choice: "auto" } : {}),
-        },
         onContent: (text) => {
           session.emit("provider://message-chunk", {
             sessionId: session.id,
@@ -974,6 +1059,7 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
       pendingPermissions: new Map(),
       approvedForSession: new Set(),
       messages: [],
+      toolsDisabled: false,
       loadedModelKey: null,
       loadedModelIdentifier: null,
       loadedBySession: false,

--- a/tests/unit/lmstudio-runtime.test.ts
+++ b/tests/unit/lmstudio-runtime.test.ts
@@ -9,6 +9,7 @@ import * as lmStudioRuntime from "../../bin/browser-local/lmstudio-runtime.mjs";
 const {
   buildLmsExecInvocation,
   isLoopbackLmStudioBaseUrl,
+  isToolIncompatibilityError,
   lmStudioHttpBaseUrl,
   lmStudioWsBaseUrl,
   normalizeLmStudioBaseUrl,
@@ -21,6 +22,7 @@ const {
     platform?: NodeJS.Platform,
   ) => { command: string; args: string[] };
   isLoopbackLmStudioBaseUrl: (value: string) => boolean;
+  isToolIncompatibilityError: (message: unknown) => boolean;
   lmStudioHttpBaseUrl: (value: string) => string;
   lmStudioWsBaseUrl: (value: string) => string;
   normalizeLmStudioBaseUrl: (value: string) => string;
@@ -84,6 +86,24 @@ describe("LM Studio runtime helpers", () => {
     ]);
   });
 
+  it("detects tool-incompatibility failures and ignores unrelated errors", () => {
+    // The obliterated-Gemma signature reproduced live against LM Studio.
+    expect(
+      isToolIncompatibilityError(
+        'Error rendering prompt with jinja template: "Cannot call something that is not a function: got UndefinedValue".',
+      ),
+    ).toBe(true);
+    expect(isToolIncompatibilityError("This model does not support tools")).toBe(
+      true,
+    );
+    expect(isToolIncompatibilityError("Invalid tool_choice value")).toBe(true);
+    // Unrelated failures must NOT trigger a silent no-tools degrade.
+    expect(isToolIncompatibilityError("Context length exceeded")).toBe(false);
+    expect(isToolIncompatibilityError("Model is still loading")).toBe(false);
+    expect(isToolIncompatibilityError("")).toBe(false);
+    expect(isToolIncompatibilityError(null)).toBe(false);
+  });
+
   it("runs Windows lms command shims through cmd.exe", () => {
     expect(
       buildLmsExecInvocation("C:\\Users\\me\\.lmstudio\\bin\\lms.cmd", [
@@ -133,5 +153,13 @@ describe("LM Studio runtime wiring", () => {
     expect(providersSource).toContain('agentType === "lmstudio"');
     const fallbacks = providersSource.match(/lmStudioRuntime\.hasSession/g) ?? [];
     expect(fallbacks.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("surfaces streamed error frames and degrades tools instead of replying empty", () => {
+    // Streamed `event: error` frames must throw, not be swallowed into an empty
+    // completion; tool-incompatible models must drop tools and retry.
+    expect(runtimeSource).toContain("throwIfErrorPayload");
+    expect(runtimeSource).toContain("session.toolsDisabled = true");
+    expect(runtimeSource).toContain("runChatCompletion");
   });
 });


### PR DESCRIPTION
Fixes #2463.

## Problem

Selecting an LM Studio model whose chat template can't render tool definitions (e.g. the "obliterated"/abliterated community Gemma builds) produced **no response at all** — the chat silently completed with an empty assistant message.

The runtime always attached the local file tools (+ Seren MCP tools) to every `/v1/chat/completions` call. Against such a model, LM Studio returns **HTTP 200 + `text/event-stream`** and then streams a single `event: error` frame (jinja template can't render `tools`). That frame has no `choices`, so `streamOpenAiResponse` skipped it and returned empty content → silent "no response".

Tool support is a property of the **specific GGUF's Jinja chat template**, not the model family. Verified live: `gemma-4-12b-obliterated` ❌ tools, `google/gemma-4-e4b` (official) ✅ tools, `qwen/qwen3.5-9b` ✅ tools — so a blanket "Gemma = no tools" rule would be wrong. The correct design is a reactive fallback.

## Fix (`bin/browser-local/lmstudio-runtime.mjs`)

- **P1 — surface errors:** `throwIfErrorPayload` raises on any streamed/JSON `error` payload (so genuine failures reach `provider://error` instead of an empty reply), and the trailing SSE buffer is flushed so a closing error frame isn't dropped.
- **P0 — graceful degrade:** `runChatCompletion` retries without tools when a tool-incompatibility error is detected (`isToolIncompatibilityError`), sets `session.toolsDisabled`, and emits a one-time, honest notice via the existing `message-chunk` channel. Tool-capable models keep full tool calling.

No Rust/UI plumbing changes — degraded replies and surfaced errors both flow through existing `message-chunk` / `error` channels.

## Verification (live, against local LM Studio)

- `gemma-4-12b-obliterated` + "Hello good ser" → tools rejected → dropped → one-time notice → **streamed reply** (`errors: 0`, `prompt-complete: 1`). PASS.
- `qwen/qwen3.5-9b` → tools retained, normal reply, no notice, no fallback. PASS (no regression).
- `pnpm vitest run tests/unit/lmstudio-runtime.test.ts tests/unit/provider-runtime-agent-isolation.test.ts` → 15/15 pass.

## Tests

- Unit test pins `isToolIncompatibilityError` against the reproduced jinja signature and confirms unrelated errors (context-length, loading) do **not** trigger a silent no-tools degrade.
- Source-text guard for the error-surfacing + tool-degrade wiring.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
