### PR TITLE
fix(lmstudio): surface reasoning thinking, not blank reply (#2465)

### DIFF
--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -627,6 +627,18 @@ export function normalizeToolCalls(accumulator) {
     .filter((call) => call.function.name);
 }
 
+/**
+ * Extract reasoning text from an OpenAI-compatible streaming delta (or a
+ * non-streamed message). LM Studio exposes a reasoning model's chain of thought
+ * as `reasoning_content`; some builds use `reasoning`. Returns "" when neither
+ * is present so non-reasoning models are unaffected.
+ */
+export function reasoningTextFromDelta(delta) {
+  if (typeof delta?.reasoning_content === "string") return delta.reasoning_content;
+  if (typeof delta?.reasoning === "string") return delta.reasoning;
+  return "";
+}
+
 function throwIfErrorPayload(payload) {
   if (payload?.error == null) return;
   const detail = payload.error?.message ?? payload.error;
@@ -679,6 +691,8 @@ async function streamOpenAiResponse({ session, body, signal, onContent }) {
     const payload = await response.json();
     throwIfErrorPayload(payload);
     const message = payload?.choices?.[0]?.message ?? {};
+    const reasoning = reasoningTextFromDelta(message);
+    if (reasoning.length > 0) onContent(reasoning, { isThought: true });
     if (message.content) onContent(message.content);
     return {
       content: message.content ?? "",
@@ -710,6 +724,15 @@ async function streamOpenAiResponse({ session, body, signal, onContent }) {
     if (!choice) return;
     if (choice.finish_reason) stopReason = choice.finish_reason;
     const delta = choice.delta ?? {};
+    // Reasoning models (Qwen3.5, DeepSeek-R1, gpt-oss) stream their chain of
+    // thought as `reasoning_content` before any `content`. Surface it as a
+    // thought chunk so the UI shows live "thinking…" instead of a blank,
+    // hung-looking reply. Reasoning is display-only — never added to `content`,
+    // so it does not re-enter the model's context on later turns.
+    const reasoning = reasoningTextFromDelta(delta);
+    if (reasoning.length > 0) {
+      onContent(reasoning, { isThought: true });
+    }
     if (typeof delta.content === "string" && delta.content.length > 0) {
       content += delta.content;
       onContent(delta.content);
@@ -946,10 +969,11 @@ async function sendPromptToLmStudio(session, prompt, context) {
         session,
         tools,
         signal: abortController.signal,
-        onContent: (text) => {
+        onContent: (text, options) => {
           session.emit("provider://message-chunk", {
             sessionId: session.id,
             text,
+            ...(options?.isThought ? { isThought: true } : {}),
           });
         },
       });

--- a/tests/unit/lmstudio-runtime.test.ts
+++ b/tests/unit/lmstudio-runtime.test.ts
@@ -15,6 +15,7 @@ const {
   normalizeLmStudioBaseUrl,
   normalizeOpenAiToolName,
   normalizeToolCalls,
+  reasoningTextFromDelta,
 } = lmStudioRuntime as {
   buildLmsExecInvocation: (
     command: string,
@@ -23,6 +24,7 @@ const {
   ) => { command: string; args: string[] };
   isLoopbackLmStudioBaseUrl: (value: string) => boolean;
   isToolIncompatibilityError: (message: unknown) => boolean;
+  reasoningTextFromDelta: (delta: unknown) => string;
   lmStudioHttpBaseUrl: (value: string) => string;
   lmStudioWsBaseUrl: (value: string) => string;
   normalizeLmStudioBaseUrl: (value: string) => string;
@@ -84,6 +86,18 @@ describe("LM Studio runtime helpers", () => {
       "read_file",
       "write_file",
     ]);
+  });
+
+  it("extracts reasoning-model thinking from streaming deltas", () => {
+    // Qwen3.5 / DeepSeek-R1 emit `reasoning_content`; some builds use `reasoning`.
+    expect(reasoningTextFromDelta({ reasoning_content: "thinking" })).toBe(
+      "thinking",
+    );
+    expect(reasoningTextFromDelta({ reasoning: "thinking" })).toBe("thinking");
+    // Non-reasoning deltas (plain content) yield no thinking text.
+    expect(reasoningTextFromDelta({ content: "hello" })).toBe("");
+    expect(reasoningTextFromDelta({})).toBe("");
+    expect(reasoningTextFromDelta(null)).toBe("");
   });
 
   it("detects tool-incompatibility failures and ignores unrelated errors", () => {
@@ -161,5 +175,10 @@ describe("LM Studio runtime wiring", () => {
     expect(runtimeSource).toContain("throwIfErrorPayload");
     expect(runtimeSource).toContain("session.toolsDisabled = true");
     expect(runtimeSource).toContain("runChatCompletion");
+  });
+
+  it("surfaces reasoning-model thinking as thought chunks", () => {
+    expect(runtimeSource).toContain("reasoningTextFromDelta");
+    expect(runtimeSource).toContain("isThought: true");
   });
 });


### PR DESCRIPTION
Fixes #2465.

## Problem

Reasoning models in LM Studio (`qwen/qwen3.5-9b`, DeepSeek-R1, gpt-oss) showed **no output during their thinking phase** — a stuck "running" badge with a blank reply — until the answer finally appeared. Reported: `Qwen3.5 9B`, Suggest mode, "What tools can you use?" (`~/Desktop/qwen.png`).

## Root cause (reproduced live)

`streamOpenAiResponse` only handled `delta.content` and **dropped `delta.reasoning_content`**. Reasoning models stream their entire chain of thought as `reasoning_content` first. For "What tools can you use?" the live server emitted **52 `reasoning_content` deltas before any `content`**; runtime-level repro on `main`: `thought chunks: 0`, `content chunks: 185`. Same silent-drop class as #2463, different field. Pre-existing — the #2464 no-regression check used a trivial prompt ("pong") with near-zero reasoning, so it missed this.

## Fix

Surface `reasoning_content`/`reasoning` deltas as **thought chunks** (`message-chunk` + `isThought: true`) — the same path Codex/Gemini use (`map_provider_event` → `WorkerEvent::Thinking`, collapsible thinking UI). Reasoning is display-only and is **not** appended to the assistant message, so it never re-enters model context. Extracted as the pure, unit-tested `reasoningTextFromDelta`.

## Verification (live)

- `qwen3.5-9b` "What tools can you use?": **165 thought chunks first streamed at ~257ms**, then 177 content chunks — thinking visible immediately, no blank/hung window.
- Obliterated-Gemma tool fallback unaffected: 0 thought chunks, notice + reply intact, 0 errors.
- `pnpm vitest run tests/unit/lmstudio-runtime.test.ts tests/unit/provider-runtime-agent-isolation.test.ts` → 17/17.

## Tests

- Unit test for `reasoningTextFromDelta` (`reasoning_content` and `reasoning` variants; plain content/empty/null → "").
- Source-text guard for the `isThought` wiring.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
