### PR TITLE
fix(agent): respawn claude on a wedged initialize handshake (#2452)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -860,26 +860,25 @@ function sendControlRequest(session, request, timeoutMs = 30_000) {
   });
 }
 
-// A brand-new user's first-ever claude invocation does one-time init (fresh
-// profile, fetching the dynamic command/plugin catalog over the network) that
-// runs several times slower than a warm run — measured up to ~9s on a cold
-// Windows host versus ~2s warm. The default per-request window was too tight
-// for that cold path and timed out the spawn (#2452/#2454), so the initialize
-// handshake gets a wider budget and one retry before the session is abandoned.
+// A brand-new profile's first-ever claude invocation does one-time init (fresh
+// profile, fetching the dynamic command/plugin catalog and feature gates over
+// the network) that runs several times slower than a warm run — measured up to
+// ~9s on a cold Windows host versus ~2s warm — and can occasionally wedge so
+// the CLI never answers the handshake at all. Each attempt gets a wide budget;
+// if it still times out, spawnSession kills the wedged process and hands the
+// handshake to a fresh one rather than re-asking the stuck child, whose warm
+// second invocation answers in ~2s. #2452/#2454
 const INITIALIZE_TIMEOUT_MS = 60_000;
+// Total initialize attempts (initial spawn + respawns) before the session is
+// abandoned. Each attempt runs against a fresh process. #2452
+const INITIALIZE_MAX_ATTEMPTS = 2;
 
-async function sendInitializeWithRetry(session) {
-  const request = { subtype: "initialize", hooks: null };
-  try {
-    return await sendControlRequest(session, request, INITIALIZE_TIMEOUT_MS);
-  } catch (error) {
-    console.error(
-      `${session.logPrefix ?? "[claude]"} initialize handshake timed out after ${
-        INITIALIZE_TIMEOUT_MS / 1000
-      }s; retrying once: ${error.message}`,
-    );
-    return sendControlRequest(session, request, INITIALIZE_TIMEOUT_MS);
-  }
+function sendInitialize(session) {
+  return sendControlRequest(
+    session,
+    { subtype: "initialize", hooks: null },
+    INITIALIZE_TIMEOUT_MS,
+  );
 }
 
 function buildClaudeArgs({
@@ -1851,90 +1850,138 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     // only the latter made the Claude spawn line
     // useless when correlating with [AgentRuntime] Event received logs
     // in the renderer console. #1889
-    console.error(
-      `${claudeLogPrefix} spawn sessionId=${sessionId} ` +
-        `agentSessionId=${remoteSessionId} preferredModel="${preferredModel}"`,
-    );
-    const processHandle = spawn(
-      claudeBin,
-      claudeArgs,
-      {
-        cwd,
-        env: {
-          ...process.env,
-          ...mcpConfig.childEnv,
-          PATH: extendedPath,
-        },
-        stdio: ["pipe", "pipe", "pipe"],
-        shell: resolveSpawnShell(claudeBin),
-      },
-    );
-
-    // Clean up MCP config temp file when the process exits
-    if (claudeArgs._mcpTempFile) {
-      const tempFile = claudeArgs._mcpTempFile;
-      processHandle.on("exit", () => {
-        try { unlinkSync(tempFile); } catch {}
-      });
-    }
-
-    // Catch spawn errors (e.g. ENOENT, EBADARCH) to prevent crashing the provider runtime.
-    processHandle.on("error", (spawnError) => {
-      console.error(`${claudeLogPrefix} Spawn error: ${spawnError.message}`);
-      sessions.delete(sessionId);
-      // macOS surfaces a wrong-arch binary as `errno: -86` / "Bad CPU type in
-      // executable" (EBADARCH). It hits when a prior install dropped the wrong
-      // slice (e.g. x86_64 claude on an arm64 Mac without Rosetta) and our
-      // resolver couldn't see that path was unusable. Surface a specific,
-      // actionable error so the user doesn't see "spawn Unknown system error -86". #1862
-      const isBadArch =
-        spawnError.errno === -86 ||
-        spawnError.code === "EBADARCH" ||
-        /bad cpu type in executable/i.test(spawnError.message ?? "");
-      let errorMessage;
-      if (spawnError.code === "ENOENT") {
-        errorMessage = `Claude Code CLI not found at "${claudeBin}". Install it from https://claude.ai/download`;
-      } else if (isBadArch) {
-        errorMessage =
-          `Claude Code CLI at "${claudeBin}" is the wrong CPU type for this Mac ` +
-          `(host arch: ${process.arch}). Install Rosetta 2 with ` +
-          `'softwareupdate --install-rosetta --agree-to-license', or delete that ` +
-          `binary and let Seren reinstall via npm on next launch.`;
-      } else {
-        errorMessage = `Failed to start Claude Code: ${spawnError.message}`;
-      }
-      emit("provider://error", {
-        sessionId,
-        error: errorMessage,
-      });
-      emit("provider://session-status", {
-        sessionId,
-        status: "terminated",
-      });
-    });
-
     const resolvedMode = claudeModeFromApprovalPolicy(approvalPolicy);
-    const session = createSessionRecord({
-      sessionId,
-      cwd,
-      processHandle,
-      timeoutSecs,
-      agentSessionId: remoteSessionId,
-      // Seed currentModelId with what we spawned on so the first session-status
-      // event reflects reality; assistant messages then refresh it from
-      // message.model on every turn (#1635).
-      currentModelId: preferredModel,
-      currentModeId: "default",
-      mcpConfigJson: mcpConfig.claudeMcpConfigJson,
-      spawnEnv: mcpConfig.childEnv,
-      reasoningEffort: effectiveEffort,
-    });
 
-    sessions.set(sessionId, session);
-    attachProcessListeners(emit, sessions, session, exitPromises);
+    // Spawn the CLI, wire its listeners, and register the session. Returns the
+    // process handle and session record so the initialize handshake can hand
+    // off to a fresh process if the first one wedges. #2452
+    const launchClaudeProcess = () => {
+      console.error(
+        `${claudeLogPrefix} spawn sessionId=${sessionId} ` +
+          `agentSessionId=${remoteSessionId} preferredModel="${preferredModel}"`,
+      );
+
+      // The MCP config temp file is consumed at CLI startup and unlinked when
+      // the process exits, so a respawn must rematerialize it before launching.
+      if (claudeArgs._mcpTempFile && mcpConfig.claudeMcpConfigJson) {
+        writeFileSync(
+          claudeArgs._mcpTempFile,
+          mcpConfig.claudeMcpConfigJson,
+          "utf-8",
+        );
+      }
+
+      const processHandle = spawn(
+        claudeBin,
+        claudeArgs,
+        {
+          cwd,
+          env: {
+            ...process.env,
+            ...mcpConfig.childEnv,
+            PATH: extendedPath,
+          },
+          stdio: ["pipe", "pipe", "pipe"],
+          shell: resolveSpawnShell(claudeBin),
+        },
+      );
+
+      // Clean up MCP config temp file when the process exits
+      if (claudeArgs._mcpTempFile) {
+        const tempFile = claudeArgs._mcpTempFile;
+        processHandle.on("exit", () => {
+          try { unlinkSync(tempFile); } catch {}
+        });
+      }
+
+      // Catch spawn errors (e.g. ENOENT, EBADARCH) to prevent crashing the provider runtime.
+      processHandle.on("error", (spawnError) => {
+        console.error(`${claudeLogPrefix} Spawn error: ${spawnError.message}`);
+        sessions.delete(sessionId);
+        // macOS surfaces a wrong-arch binary as `errno: -86` / "Bad CPU type in
+        // executable" (EBADARCH). It hits when a prior install dropped the wrong
+        // slice (e.g. x86_64 claude on an arm64 Mac without Rosetta) and our
+        // resolver couldn't see that path was unusable. Surface a specific,
+        // actionable error so the user doesn't see "spawn Unknown system error -86". #1862
+        const isBadArch =
+          spawnError.errno === -86 ||
+          spawnError.code === "EBADARCH" ||
+          /bad cpu type in executable/i.test(spawnError.message ?? "");
+        let errorMessage;
+        if (spawnError.code === "ENOENT") {
+          errorMessage = `Claude Code CLI not found at "${claudeBin}". Install it from https://claude.ai/download`;
+        } else if (isBadArch) {
+          errorMessage =
+            `Claude Code CLI at "${claudeBin}" is the wrong CPU type for this Mac ` +
+            `(host arch: ${process.arch}). Install Rosetta 2 with ` +
+            `'softwareupdate --install-rosetta --agree-to-license', or delete that ` +
+            `binary and let Seren reinstall via npm on next launch.`;
+        } else {
+          errorMessage = `Failed to start Claude Code: ${spawnError.message}`;
+        }
+        emit("provider://error", {
+          sessionId,
+          error: errorMessage,
+        });
+        emit("provider://session-status", {
+          sessionId,
+          status: "terminated",
+        });
+      });
+
+      const launchedSession = createSessionRecord({
+        sessionId,
+        cwd,
+        processHandle,
+        timeoutSecs,
+        agentSessionId: remoteSessionId,
+        // Seed currentModelId with what we spawned on so the first session-status
+        // event reflects reality; assistant messages then refresh it from
+        // message.model on every turn (#1635).
+        currentModelId: preferredModel,
+        currentModeId: "default",
+        mcpConfigJson: mcpConfig.claudeMcpConfigJson,
+        spawnEnv: mcpConfig.childEnv,
+        reasoningEffort: effectiveEffort,
+      });
+
+      sessions.set(sessionId, launchedSession);
+      attachProcessListeners(emit, sessions, launchedSession, exitPromises);
+      return { processHandle, session: launchedSession };
+    };
+
+    let { processHandle, session } = launchClaudeProcess();
 
     try {
-      const initResult = await sendInitializeWithRetry(session);
+      // Initialize handshake with kill+respawn. A first-run stall can wedge the
+      // CLI so it never answers the request; re-asking the SAME process can't
+      // recover (it's already stuck), so on timeout we kill it and hand the
+      // handshake to a fresh process. The previous same-process retry just
+      // doubled the wait. #2452
+      let initResult;
+      for (let attempt = 1; ; attempt += 1) {
+        try {
+          initResult = await sendInitialize(session);
+          break;
+        } catch (initError) {
+          if (attempt >= INITIALIZE_MAX_ATTEMPTS) throw initError;
+          console.error(
+            `${session.logPrefix ?? claudeLogPrefix} initialize handshake timed ` +
+              `out after ${INITIALIZE_TIMEOUT_MS / 1000}s ` +
+              `(attempt ${attempt}/${INITIALIZE_MAX_ATTEMPTS}); killing the wedged ` +
+              `process and respawning: ${initError.message}`,
+          );
+          // Detach the wedged session before killing so its exit handler sees
+          // wasTracked=false and stays silent (no spurious terminated emit, no
+          // control-request rejection against the fresh session). Then wait for
+          // its exit cleanup to release the session id before relaunching.
+          sessions.delete(sessionId);
+          const pendingExit = exitPromises.get(sessionId);
+          killChildTree(processHandle);
+          if (pendingExit) await pendingExit;
+          ({ processHandle, session } = launchClaudeProcess());
+        }
+      }
 
       session.availableModelRecords = augmentWithLegacyOpus(
         normalizeModelRecords(initResult),

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -441,6 +441,13 @@ try {
     [Environment]::SetEnvironmentVariable("SEREN_E2E_AGENT_MODEL", `$bedrockModel, "Process")
     # Bedrock uses the AWS credential chain; no Claude login file is required.
     [Environment]::SetEnvironmentVariable("SEREN_E2E_AGENT_CREDENTIALS_REQUIRED", "0", "Process")
+    # A brand-new profile's first claude-code run on the e2e host fetches the
+    # autoupdater/telemetry/feature-gate catalog over the network at startup;
+    # any of those stalling can wedge the stream-json initialize handshake on a
+    # cold box. Disable that non-essential startup traffic so the handshake only
+    # depends on the local catalog. The runtime still kills+respawns a wedged
+    # process as a backstop. #2452
+    [Environment]::SetEnvironmentVariable("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1", "Process")
     Write-TaskLog "Configured Bedrock agent backend: region=`$bedrockRegion model=`$bedrockModel small=`$bedrockSmallModel"
   }
   Import-AgentCredentialArchive

--- a/tests/unit/claude-initialize-timeout.test.ts
+++ b/tests/unit/claude-initialize-timeout.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Regression test for #2454 — claude-code initialize handshake must
-// ABOUTME: tolerate cold first-run latency (wide timeout + one retry) and resolve .local\bin.
+// ABOUTME: Regression test for #2452/#2454 — claude-code initialize handshake uses a wide
+// ABOUTME: timeout and recovers a wedged spawn by killing+respawning, not a same-process retry.
 
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
@@ -17,21 +17,42 @@ describe("#2454 — claude initialize handshake tolerates cold first-run", () =>
     const ms = Number((match?.[1] ?? "0").replaceAll("_", ""));
     expect(ms).toBeGreaterThanOrEqual(60_000);
   });
+});
 
-  it("retries the initialize handshake once before abandoning the spawn", () => {
-    const start = runtimeSource.indexOf("async function sendInitializeWithRetry");
-    expect(start, "sendInitializeWithRetry must exist").toBeGreaterThan(0);
-    const body = runtimeSource.slice(start, start + 700);
-    // Two sendControlRequest calls = initial attempt + one retry.
-    const calls = body.match(/sendControlRequest\(/g) ?? [];
-    expect(calls.length, "must call sendControlRequest twice (attempt + retry)").toBe(2);
-    expect(body).toContain("subtype: \"initialize\"");
-    expect(body).toMatch(/catch\s*\(/);
+describe("#2452 — a wedged initialize handshake recovers by respawning, not re-asking", () => {
+  it("sends initialize as a single-attempt request (no same-process retry helper)", () => {
+    expect(
+      runtimeSource.includes("function sendInitialize("),
+      "sendInitialize helper must exist",
+    ).toBe(true);
+    expect(
+      runtimeSource.includes("sendInitializeWithRetry"),
+      "the same-process retry helper must be gone",
+    ).toBe(false);
+    const start = runtimeSource.indexOf("function sendInitialize(");
+    const body = runtimeSource.slice(start, start + 300);
+    // Exactly one control request — recovery now respawns a fresh process.
+    expect((body.match(/sendControlRequest\(/g) ?? []).length).toBe(1);
+    expect(body).toContain('subtype: "initialize"');
   });
 
-  it("spawn drives initialize through the retry helper, not a bare 20s control request", () => {
-    expect(runtimeSource).toContain("await sendInitializeWithRetry(session)");
-    // The old tight inline initialize timeout must be gone.
+  it("bounds the attempts and kills+respawns a fresh process on timeout", () => {
+    const max = runtimeSource.match(/INITIALIZE_MAX_ATTEMPTS\s*=\s*([0-9_]+)/);
+    expect(max, "INITIALIZE_MAX_ATTEMPTS constant must exist").not.toBeNull();
+    expect(Number((max?.[1] ?? "0").replaceAll("_", ""))).toBeGreaterThanOrEqual(2);
+
+    const start = runtimeSource.indexOf("let initResult;");
+    expect(start, "initialize loop must exist").toBeGreaterThan(0);
+    const body = runtimeSource.slice(start, start + 1200);
+    expect(body).toContain("await sendInitialize(session)");
+    expect(body).toMatch(/attempt\s*>=\s*INITIALIZE_MAX_ATTEMPTS/);
+    // On timeout: detach the wedged session, kill its tree, relaunch fresh.
+    expect(body).toContain("sessions.delete(sessionId)");
+    expect(body).toContain("killChildTree(processHandle)");
+    expect(body).toContain("launchClaudeProcess()");
+  });
+
+  it("does not drive initialize through a bare 20s control request", () => {
     expect(runtimeSource).not.toMatch(/subtype:\s*"initialize"[\s\S]{0,80}20_000/);
   });
 });


### PR DESCRIPTION
## What

Fixes #2452 — windows-app-e2e claude-code Bedrock journey times out on the stream-json `initialize` handshake (~130s).

## Root cause (validated on-box, claude 2.1.178)

The `initialize` handshake completes in **≤9s under every reproducible condition** (warm, cold profile, +Bedrock, even a dead/stalled Bedrock endpoint — that call is self-bounded at ~8s). The 130s no-response is a **non-deterministic first-run stall** (brand-new admin user, Session 0, fresh install, release-time load) that does not reproduce in isolation.

The one provable defect: `sendInitializeWithRetry` re-sent `initialize` to the **same already-wedged process**. Whatever stalls the first handshake, re-asking the stuck child can't recover — so #2454's 60s+retry produced 60s + 60s ≈ 130s instead of fixing it.

(An earlier theory blamed an uncapped Bedrock call governed by `API_TIMEOUT_MS`; on-box validation refuted it — see the issue thread. `API_TIMEOUT_MS` is a no-op here.)

## Fix

1. **Product runtime (`claude-runtime.mjs`):** on `initialize` timeout, **kill the wedged process and respawn a fresh one**, then re-handshake — instead of retrying the same child. The session is detached before the kill so the old process's exit handler stays silent (`wasTracked=false`: no spurious `terminated` emit, no control-request rejection against the fresh session), and its exit cleanup is awaited before relaunch so it can't clobber the new session id. The MCP config temp file is rematerialized per launch so a respawn still finds it. Capped at 2 attempts.
2. **E2e harness (`windows-e2e-task-user.ps1`):** set `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` for the Bedrock journey so the handshake doesn't depend on autoupdate/telemetry/feature-gate startup network — a plausible first-wedge source. (`kill+respawn` is the backstop.)

**Pre-warm was intentionally dropped** — it's redundant with kill+respawn (the respawn *is* the warm second invocation, well within the 240s prompt / 3600s task budget) and carries an install-timing complication (claude is installed by the app mid-journey, so there's no clean pre-journey hook).

## Impact

- Happy path unchanged (single attempt, success).
- Wedged first attempt → fresh respawn recovers (~2s warm handshake).
- Both attempts wedged → clean failure, no leak.
- Real subscription users unaffected (handshake was never their problem); real Bedrock users get the same recovery.

## Tests

Updated `tests/unit/claude-initialize-timeout.test.ts` to guard the new kill+respawn shape. Full claude-runtime/spawn suite green (53 tests). No mock-based tests added (per repo testing rules).

**Honest caveat:** the 130s won't reproduce on-box, so no fix is provably *eliminating*; this fixes the one demonstrable defect and removes the most likely first-wedge source. Definitive validation is the next release-tag windows-app-e2e run.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
