### PR TITLE
fix(e2e): reap stale SerenE2E temp accounts at startup (#2468)

### DIFF
--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -147,6 +147,40 @@ function Remove-LocalE2EUser([string]$UserName) {
     -TimeoutSeconds 30
 }
 
+function Remove-StaleE2EUsers() {
+  # A cancelled/superseded release run (or a killed SSM step) skips the finally
+  # teardown, leaking its temporary SerenE2E* admin account and profile dir.
+  # Reap every existing SerenE2E* account and orphaned profile dir before this
+  # run creates its user, so leaks self-heal instead of accumulating.
+  # windows-app-e2e is serialized (group: release), so no concurrent run owns
+  # one of these accounts. #2468
+  try {
+    foreach ($staleUser in @(Get-LocalUser -Name "SerenE2E*" -ErrorAction SilentlyContinue)) {
+      Write-Stage "Reaping stale e2e user $($staleUser.Name)"
+      Remove-LocalE2EUser $staleUser.Name
+    }
+    Get-ChildItem -LiteralPath "C:\Users" -Directory -Filter "SerenE2E*" -ErrorAction SilentlyContinue |
+      ForEach-Object {
+        $orphanPath = $_.FullName
+        Invoke-CleanupWithTimeout `
+          -Label "Remove orphaned e2e profile directory $orphanPath" `
+          -ScriptBlock {
+            param($Path)
+            Get-CimInstance Win32_UserProfile -ErrorAction SilentlyContinue |
+              Where-Object { $_.LocalPath -eq $Path } |
+              Remove-CimInstance -ErrorAction SilentlyContinue
+            if (Test-Path -LiteralPath $Path) {
+              Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
+            }
+          } `
+          -ArgumentList @($orphanPath) `
+          -TimeoutSeconds 30
+      }
+  } catch {
+    Write-Host "::warning::Stale e2e user reap failed: $($_.Exception.Message)"
+  }
+}
+
 $resolvedInstaller = (Resolve-Path -LiteralPath $InstallerPath).Path
 $resolvedWorkDir = (Resolve-Path -LiteralPath $WorkDir).Path
 $runnerPath = Join-Path $resolvedWorkDir "scripts\windows-e2e-app.ps1"
@@ -163,6 +197,7 @@ $taskLogPath = Join-Path $resolvedWorkDir "windows-e2e-task.log"
 $e2eInstallDir = Join-Path $env:SystemDrive "SerenDesktopE2E"
 
 try {
+  Remove-StaleE2EUsers
   Write-Stage "Creating temporary Windows user $qualifiedUserName"
   Remove-LocalE2EUser $userName
   & net user $userName $password /add /Y | Out-Null


### PR DESCRIPTION
## What

Fixes #2468 — the windows-app-e2e harness leaks its temporary `SerenE2E<guid>` admin account and `C:\Users\SerenE2E<guid>` profile dir.

## Root cause

`windows-e2e-task-user.ps1` deletes the temp account in a `finally` block. When a release run is cancelled/superseded (common) or its SSM step is killed/times out, the `finally` never runs → account + profile dir survive. Each run uses a fresh GUID name, so nothing ever removes a prior run's leak. On the box: **9 leaked accounts + 19 profile dirs**.

## Fix

Add a `Remove-StaleE2EUsers` startup reaper that removes every existing `SerenE2E*` account and orphaned `C:\Users\SerenE2E*` profile dir before this run creates its user — making the leak self-healing regardless of why a prior teardown didn't run. windows-app-e2e is serialized via `group: release`, so no concurrent run owns one of these accounts.

In steady state the reaper sees 0–1 stale entries (fast); the current 19-dir backlog was cleaned one-time on the box as part of this fix.

## Verification

Ran the reap logic on the e2e box (`i-0a575b70ba969fb6e`): it enumerated the 9 leaked accounts + 19 profile dirs, deleted all 9 accounts, and cleared the orphaned dirs. PowerShell parse-checked clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
