### PR TITLE
fix(agent): gate respawn error listener (#2470)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1894,8 +1894,22 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         });
       }
 
+      // Declared before the error listener so the listener can identity-check
+      // against this launch's session; assigned below once the record exists.
+      let launchedSession;
+
       // Catch spawn errors (e.g. ENOENT, EBADARCH) to prevent crashing the provider runtime.
       processHandle.on("error", (spawnError) => {
+        // A respawn (#2452) reuses this sessionId on a fresh process while the
+        // old killed handle keeps its listeners. Only act when THIS launch's
+        // session is still the registered one, so a late error from an orphaned
+        // handle can't delete or terminate the live session. #2470
+        if (sessions.get(sessionId) !== launchedSession) {
+          console.error(
+            `${claudeLogPrefix} ignoring spawn error from a replaced process: ${spawnError.message}`,
+          );
+          return;
+        }
         console.error(`${claudeLogPrefix} Spawn error: ${spawnError.message}`);
         sessions.delete(sessionId);
         // macOS surfaces a wrong-arch binary as `errno: -86` / "Bad CPU type in
@@ -1929,7 +1943,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         });
       });
 
-      const launchedSession = createSessionRecord({
+      launchedSession = createSessionRecord({
         sessionId,
         cwd,
         processHandle,
@@ -1976,6 +1990,9 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
           // control-request rejection against the fresh session). Then wait for
           // its exit cleanup to release the session id before relaunching.
           sessions.delete(sessionId);
+          // Close the wedged session's readline so its stdout reader is torn
+          // down with it, mirroring terminateSession's cleanup.
+          session.output.close();
           const pendingExit = exitPromises.get(sessionId);
           killChildTree(processHandle);
           if (pendingExit) await pendingExit;

--- a/tests/unit/claude-initialize-timeout.test.ts
+++ b/tests/unit/claude-initialize-timeout.test.ts
@@ -43,13 +43,23 @@ describe("#2452 — a wedged initialize handshake recovers by respawning, not re
 
     const start = runtimeSource.indexOf("let initResult;");
     expect(start, "initialize loop must exist").toBeGreaterThan(0);
-    const body = runtimeSource.slice(start, start + 1200);
+    const body = runtimeSource.slice(start, start + 1600);
     expect(body).toContain("await sendInitialize(session)");
     expect(body).toMatch(/attempt\s*>=\s*INITIALIZE_MAX_ATTEMPTS/);
     // On timeout: detach the wedged session, kill its tree, relaunch fresh.
     expect(body).toContain("sessions.delete(sessionId)");
     expect(body).toContain("killChildTree(processHandle)");
     expect(body).toContain("launchClaudeProcess()");
+  });
+
+  it("gates the spawn error listener so an orphaned handle can't clobber the live session (#2470)", () => {
+    const start = runtimeSource.indexOf('processHandle.on("error"');
+    expect(start, "spawn error listener must exist").toBeGreaterThan(0);
+    const body = runtimeSource.slice(start, start + 800);
+    // The listener must early-return unless its own launch's session is still
+    // the registered one, so a late error from a respawned-over handle is inert.
+    expect(body).toMatch(/sessions\.get\(sessionId\)\s*!==\s*launchedSession/);
+    expect(body).toMatch(/return;/);
   });
 
   it("does not drive initialize through a bare 20s control request", () => {


### PR DESCRIPTION
## What

Fixes #2470 — audit follow-up to #2452 / PR #2467. The kill+respawn path reused the same `sessionId` across two live `ChildProcess` handles without detaching the old handle's listeners. The `exit` handler is safe (gated on `wasTracked` via `sessions.delete` before kill), but the **spawn `error` handler was un-gated**.

## P1 — un-gated error listener could clobber the new session

A Node `ChildProcess` can emit `error` after `exit`. On respawn, the old killed handle keeps its `error` listener, which unconditionally did `sessions.delete(sessionId)` + emitted `provider://session-status: terminated` for the bare `sessionId` — so a late `error` from the orphaned handle would delete the **live new** session and surface a spurious termination.

**Fix:** gate the error listener with an identity check — it acts only when this launch's session is still the registered one (`if (sessions.get(sessionId) !== launchedSession) { ...; return; }`). Genuine first-launch spawn errors (ENOENT/EBADARCH) still surface; orphaned-handle errors are logged and ignored.

## P2 — readline not closed on respawn

Close the wedged session's `readline` (`session.output.close()`) before relaunch, mirroring `terminateSession`.

## How found

Independent adversarial review of the #2452 diff (the other five ordering-sensitive failure modes were verified closed; this was the one real hole).

## Tests

`tests/unit/claude-initialize-timeout.test.ts` gains a regression assertion for the error-listener identity guard. Full claude-runtime/spawn suite green (57 tests).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
