### PR TITLE
fix(auth): allow trusted console CLI social redirect

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -7,6 +7,8 @@ use url::Url;
 
 const CLIENT_ID: &str = "seren-desktop";
 const REDIRECT_URI: &str = "http://127.0.0.1:8787/auth/callback";
+const CONSOLE_HOST: &str = "console.serendb.com";
+const CONSOLE_CLI_LOGIN_PATH: &str = "/login/cli";
 
 #[tauri::command]
 pub async fn start_social_login(
@@ -34,7 +36,7 @@ fn validate_authorize_url(auth_url: &str, provider: &str) -> Result<Url, String>
     if !is_secure {
         return Err("Social login URL must use HTTPS".to_string());
     }
-    if url.host_str() == Some("console.serendb.com") {
+    if url.host_str() == Some(CONSOLE_HOST) {
         return Err("Social login must not route through console.serendb.com".to_string());
     }
 
@@ -95,15 +97,106 @@ async fn resolve_provider_redirect(auth_url: &Url) -> Result<Option<String>, Str
         .and_then(|value| value.to_str().ok())
         .ok_or("Social login redirect missing Location header")?;
 
-    if location.contains("console.serendb.com") {
-        return Err("Social login unexpectedly routed through console.serendb.com".to_string());
-    }
+    Ok(Some(validate_provider_redirect(auth_url, location)?))
+}
 
+fn validate_provider_redirect(auth_url: &Url, location: &str) -> Result<String, String> {
     let location_url =
         Url::parse(location).map_err(|e| format!("Invalid social login redirect: {}", e))?;
     if location_url.scheme() != "https" {
         return Err("Unexpected social login redirect scheme".to_string());
     }
 
-    Ok(Some(location.to_string()))
+    if location_url.host_str() == Some(CONSOLE_HOST) {
+        validate_console_cli_redirect(auth_url, &location_url)?;
+    }
+
+    Ok(location.to_string())
+}
+
+fn validate_console_cli_redirect(auth_url: &Url, location_url: &Url) -> Result<(), String> {
+    if location_url.path() != CONSOLE_CLI_LOGIN_PATH {
+        return Err("Social login unexpectedly routed through console.serendb.com".to_string());
+    }
+
+    require_matching_query_param(auth_url, location_url, "state")?;
+    require_matching_query_param(auth_url, location_url, "redirect_uri")?;
+    require_matching_query_param(auth_url, location_url, "code_challenge")?;
+    require_matching_query_param(auth_url, location_url, "client_id")?;
+    Ok(())
+}
+
+fn require_matching_query_param(
+    source_url: &Url,
+    redirect_url: &Url,
+    key: &str,
+) -> Result<(), String> {
+    let source_value =
+        query_param(source_url, key).ok_or_else(|| format!("Social login URL missing {}", key))?;
+    let redirect_value = query_param(redirect_url, key)
+        .ok_or_else(|| format!("Social login redirect missing {}", key))?;
+
+    if redirect_value != source_value {
+        return Err(format!("Social login redirect {} mismatch", key));
+    }
+
+    Ok(())
+}
+
+fn query_param(url: &Url, key: &str) -> Option<String> {
+    url.query_pairs()
+        .find_map(|(name, value)| (name == key).then(|| value.into_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_authorize_url() -> Url {
+        validate_authorize_url(
+            "https://api.serendb.com/oauth2/authorize?client_id=seren-desktop&response_type=code&redirect_uri=http%3A%2F%2F127.0.0.1%3A8787%2Fauth%2Fcallback&state=audit-state&code_challenge=audit-challenge&code_challenge_method=S256&provider=google",
+            "google",
+        )
+        .expect("valid authorize URL")
+    }
+
+    #[test]
+    fn allows_trusted_console_cli_redirect_that_preserves_pkce_params() {
+        let auth_url = valid_authorize_url();
+        let redirect = "https://console.serendb.com/login/cli?state=audit-state&redirect_uri=http%3A%2F%2F127.0.0.1%3A8787%2Fauth%2Fcallback&code_challenge=audit-challenge&client_id=seren-desktop";
+
+        assert_eq!(
+            validate_provider_redirect(&auth_url, redirect).expect("trusted redirect"),
+            redirect
+        );
+    }
+
+    #[test]
+    fn rejects_console_redirects_outside_cli_login() {
+        let auth_url = valid_authorize_url();
+
+        let error = validate_provider_redirect(
+            &auth_url,
+            "https://console.serendb.com/login?state=audit-state&redirect_uri=http%3A%2F%2F127.0.0.1%3A8787%2Fauth%2Fcallback&code_challenge=audit-challenge&client_id=seren-desktop",
+        )
+        .expect_err("unexpected console path must be rejected");
+
+        assert_eq!(
+            error,
+            "Social login unexpectedly routed through console.serendb.com"
+        );
+    }
+
+    #[test]
+    fn rejects_console_cli_redirect_with_mismatched_state() {
+        let auth_url = valid_authorize_url();
+
+        let error = validate_provider_redirect(
+            &auth_url,
+            "https://console.serendb.com/login/cli?state=other-state&redirect_uri=http%3A%2F%2F127.0.0.1%3A8787%2Fauth%2Fcallback&code_challenge=audit-challenge&client_id=seren-desktop",
+        )
+        .expect_err("state mismatch must be rejected");
+
+        assert_eq!(error, "Social login redirect state mismatch");
+    }
 }

--- a/src/components/auth/SignIn.tsx
+++ b/src/components/auth/SignIn.tsx
@@ -29,6 +29,16 @@ interface SignInProps {
   onSuccess: () => Promise<void> | void;
 }
 
+// Tauri `invoke` rejects with the raw `Err` string payload, not an `Error`, so
+// surface string rejections too instead of collapsing every failure into the
+// generic fallback. Keeping the real cause visible is what makes social/login
+// failures diagnosable.
+function authErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message) return err.message;
+  if (typeof err === "string" && err.trim()) return err;
+  return fallback;
+}
+
 export const SignIn: Component<SignInProps> = (props) => {
   const [email, setEmail] = createSignal("");
   const [password, setPassword] = createSignal("");
@@ -45,7 +55,7 @@ export const SignIn: Component<SignInProps> = (props) => {
     try {
       await props.onSuccess();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Sign-in setup failed");
+      setError(authErrorMessage(err, "Sign-in setup failed"));
       setPhase("credentials");
     }
   };
@@ -57,7 +67,7 @@ export const SignIn: Component<SignInProps> = (props) => {
     try {
       await startSocialLogin(provider);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Social sign-in failed");
+      setError(authErrorMessage(err, "Social sign-in failed"));
       setPhase("credentials");
       return;
     }
@@ -84,7 +94,7 @@ export const SignIn: Component<SignInProps> = (props) => {
     try {
       await login(email(), password());
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Login failed");
+      setError(authErrorMessage(err, "Login failed"));
       setPhase("credentials");
       return;
     }

--- a/src/services/social-login.ts
+++ b/src/services/social-login.ts
@@ -39,6 +39,10 @@ const CLIENT_ID = "seren-desktop";
 const REDIRECT_URI = "http://127.0.0.1:8787/auth/callback";
 const CODE_VERIFIER_LENGTH = 64;
 const STATE_LENGTH = 32;
+// Stop waiting on the loopback callback after this long so an abandoned or
+// failed browser flow can't leave the sign-in UI stuck in a loading phase
+// with no way to recover short of restarting the app.
+const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
 
 function generateRandomString(length: number): string {
   const chars =
@@ -214,9 +218,20 @@ export async function startSocialLogin(
     callbackWaiter.handler,
   );
 
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   try {
     await invoke("start_social_login", { provider, authUrl });
-    const callback = await callbackWaiter.promise;
+
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(
+          new Error(
+            "Social sign-in timed out. Close the browser tab and try again.",
+          ),
+        );
+      }, CALLBACK_TIMEOUT_MS);
+    });
+    const callback = await Promise.race([callbackWaiter.promise, timeout]);
 
     const tokenPayload = await exchangeCodeForTokens(
       callback.code ?? "",
@@ -234,6 +249,9 @@ export async function startSocialLogin(
       default_organization_id: defaultOrganizationId,
     };
   } finally {
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
     unlisten();
   }
 }

--- a/tests/services/social-login.test.ts
+++ b/tests/services/social-login.test.ts
@@ -187,4 +187,55 @@ describe("social login", () => {
     expect(storeDefaultOrganizationIdMock).not.toHaveBeenCalled();
     expect(unlisten).toHaveBeenCalledTimes(1);
   });
+
+  it("times out abandoned browser flows and unregisters the callback listener", async () => {
+    const unlisten = vi.fn();
+    let resolveInvoke: (() => void) | undefined;
+    listenMock.mockResolvedValue(unlisten);
+    invokeMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInvoke = resolve;
+        }),
+    );
+
+    const promise = startSocialLogin("google");
+    await waitForInvoke();
+
+    vi.useFakeTimers();
+    try {
+      resolveInvoke?.();
+      const assertion = expect(promise).rejects.toThrow(
+        "Social sign-in timed out. Close the browser tab and try again.",
+      );
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(appFetchMock).not.toHaveBeenCalled();
+    expect(storeTokenMock).not.toHaveBeenCalled();
+    expect(storeRefreshTokenMock).not.toHaveBeenCalled();
+    expect(storeDefaultOrganizationIdMock).not.toHaveBeenCalled();
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates native string failures and unregisters the callback listener", async () => {
+    const unlisten = vi.fn();
+    listenMock.mockResolvedValue(unlisten);
+    invokeMock.mockRejectedValue(
+      "Social login unexpectedly routed through console.serendb.com",
+    );
+
+    await expect(startSocialLogin("google")).rejects.toBe(
+      "Social login unexpectedly routed through console.serendb.com",
+    );
+
+    expect(appFetchMock).not.toHaveBeenCalled();
+    expect(storeTokenMock).not.toHaveBeenCalled();
+    expect(storeRefreshTokenMock).not.toHaveBeenCalled();
+    expect(storeDefaultOrganizationIdMock).not.toHaveBeenCalled();
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/signin-auth-completion.test.ts
+++ b/tests/unit/signin-auth-completion.test.ts
@@ -21,6 +21,15 @@ describe("SignIn auth completion", () => {
     expect(source).toContain('setPhase("credentials")');
   });
 
+  it("surfaces raw Tauri string errors instead of only Error instances", () => {
+    const source = readSource("src/components/auth/SignIn.tsx");
+
+    expect(source).toContain('typeof err === "string"');
+    expect(source).toContain('authErrorMessage(err, "Social sign-in failed")');
+    expect(source).toContain('authErrorMessage(err, "Login failed")');
+    expect(source).toContain('authErrorMessage(err, "Sign-in setup failed")');
+  });
+
   it("main account sign-in waits for authStore activation before closing", () => {
     const appSource = readSource("src/App.tsx");
     const shellSource = readSource("src/components/layout/AppShell.tsx");


### PR DESCRIPTION
Closes #2472.
Closes #2474.

## Summary
- Allow desktop social sign-in to open the trusted `https://console.serendb.com/login/cli` OAuth handoff returned by `api.serendb.com/oauth2/authorize`.
- Preserve rejection for arbitrary console redirects, non-HTTPS redirects, and tampered state/redirect URI/client ID/PKCE challenge values.
- Surface Tauri native string errors in the SignIn modal instead of collapsing them to generic failures.
- Bound abandoned browser/callback waits with a five-minute timeout and always unregister the callback listener.
- Add focused Rust and frontend regression coverage for the trusted redirect, rejection cases, timeout cleanup, and error surfacing.

## Audit
- Customer email report reviewed: Google social signup succeeded in console, desktop login failed.
- Local logs and code paths reviewed across `SignIn.tsx`, `social-login.ts`, `auth.rs`, and the OAuth callback server.
- Live endpoint probe confirmed a fresh desktop authorize request returns `307` to `https://console.serendb.com/login/cli?...` with preserved state, redirect URI, PKCE challenge, and client ID.
- The primary root cause is in `seren-desktop`, not `seren-core`: desktop rejected the valid trusted handoff before opening the browser.
- Follow-up P1 audit found the same flow hid native string errors and could leave the UI loading indefinitely if the callback never arrived.

## Tests
- `pnpm exec vitest run tests/services/social-login.test.ts tests/unit/signin-auth-completion.test.ts`
- `pnpm exec vitest run tests/services/social-login.test.ts`
- `pnpm build` (passes with existing Rolldown annotation/chunk warnings)
- `pnpm exec biome lint src/components/auth/SignIn.tsx src/services/social-login.ts tests/services/social-login.test.ts tests/unit/signin-auth-completion.test.ts`
- `pnpm prepare:mcp-servers`
- `cargo test --manifest-path src-tauri/Cargo.toml commands::auth`