### PR TITLE
fix(lmstudio): scope tool fallback by model

### DIFF
--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -24,7 +24,7 @@ const DEFAULT_MCP_GATEWAY_URL =
 const LMSTUDIO_AGENT_TYPE = "lmstudio";
 const MAX_TOOL_ITERATIONS = 25;
 const TOOLS_UNSUPPORTED_NOTICE =
-  "_This model doesn't support tool calls, so local file access and Seren tools are off for this chat._\n\n";
+  "_This LM Studio model doesn't support tool calls, so local file access and Seren tools are off for this model._\n\n";
 
 const FILE_TOOLS = [
   {
@@ -481,6 +481,35 @@ export function normalizeOpenAiToolName(name) {
     .slice(0, 64) || "tool";
 }
 
+function toolIncompatibleModelIds(session) {
+  if (!(session.toolIncompatibleModelIds instanceof Set)) {
+    session.toolIncompatibleModelIds = new Set();
+  }
+  return session.toolIncompatibleModelIds;
+}
+
+function modelToolStateKey(modelId) {
+  return typeof modelId === "string" ? modelId.trim() : "";
+}
+
+export function isLmStudioModelToolIncompatible(
+  session,
+  modelId = session.currentModelId,
+) {
+  const key = modelToolStateKey(modelId);
+  return key.length > 0 && toolIncompatibleModelIds(session).has(key);
+}
+
+export function markLmStudioModelToolIncompatible(
+  session,
+  modelId = session.currentModelId,
+) {
+  const key = modelToolStateKey(modelId);
+  if (key.length > 0) {
+    toolIncompatibleModelIds(session).add(key);
+  }
+}
+
 function uniqueToolName(name, used) {
   const base = normalizeOpenAiToolName(name);
   let candidate = base;
@@ -771,13 +800,16 @@ async function streamOpenAiResponse({ session, body, signal, onContent }) {
  * Run one chat completion, degrading gracefully when the loaded model rejects
  * tool definitions. Tool-capable models keep full tool calling; models whose
  * chat template can't render tools (common for community local builds) drop
- * tools for the rest of the session and retry, so the user always gets a reply
- * instead of a silent empty response.
+ * tools for that model and retry, so the user always gets a reply instead of a
+ * silent empty response.
  */
 async function runChatCompletion({ session, tools, signal, onContent }) {
-  const useTools = tools.length > 0 && !session.toolsDisabled;
+  const requestModelId = session.currentModelId;
+  const useTools =
+    tools.length > 0 &&
+    !isLmStudioModelToolIncompatible(session, requestModelId);
   const baseBody = {
-    model: session.currentModelId,
+    model: requestModelId,
     messages: session.messages,
     stream: true,
   };
@@ -799,9 +831,9 @@ async function runChatCompletion({ session, tools, signal, onContent }) {
       throw error;
     }
 
-    session.toolsDisabled = true;
+    markLmStudioModelToolIncompatible(session, requestModelId);
     console.warn(
-      `${session.logPrefix} model "${session.currentModelId}" rejected tool definitions (${message}); retrying without tools for this session.`,
+      `${session.logPrefix} model "${requestModelId}" rejected tool definitions (${message}); retrying without tools for this model.`,
     );
     // One-time, honest notice so the user understands why tools are inactive.
     // Emitted to the UI only (not pushed into session.messages), so it never
@@ -1083,7 +1115,7 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
       pendingPermissions: new Map(),
       approvedForSession: new Set(),
       messages: [],
-      toolsDisabled: false,
+      toolIncompatibleModelIds: new Set(),
       loadedModelKey: null,
       loadedModelIdentifier: null,
       loadedBySession: false,

--- a/tests/unit/lmstudio-runtime.test.ts
+++ b/tests/unit/lmstudio-runtime.test.ts
@@ -8,10 +8,12 @@ import * as lmStudioRuntime from "../../bin/browser-local/lmstudio-runtime.mjs";
 
 const {
   buildLmsExecInvocation,
+  isLmStudioModelToolIncompatible,
   isLoopbackLmStudioBaseUrl,
   isToolIncompatibilityError,
   lmStudioHttpBaseUrl,
   lmStudioWsBaseUrl,
+  markLmStudioModelToolIncompatible,
   normalizeLmStudioBaseUrl,
   normalizeOpenAiToolName,
   normalizeToolCalls,
@@ -22,8 +24,22 @@ const {
     args: string[],
     platform?: NodeJS.Platform,
   ) => { command: string; args: string[] };
+  isLmStudioModelToolIncompatible: (
+    session: {
+      currentModelId?: string;
+      toolIncompatibleModelIds?: Set<string>;
+    },
+    modelId?: string,
+  ) => boolean;
   isLoopbackLmStudioBaseUrl: (value: string) => boolean;
   isToolIncompatibilityError: (message: unknown) => boolean;
+  markLmStudioModelToolIncompatible: (
+    session: {
+      currentModelId?: string;
+      toolIncompatibleModelIds?: Set<string>;
+    },
+    modelId?: string,
+  ) => void;
   reasoningTextFromDelta: (delta: unknown) => string;
   lmStudioHttpBaseUrl: (value: string) => string;
   lmStudioWsBaseUrl: (value: string) => string;
@@ -118,6 +134,31 @@ describe("LM Studio runtime helpers", () => {
     expect(isToolIncompatibilityError(null)).toBe(false);
   });
 
+  it("scopes tool incompatibility to the selected LM Studio model", () => {
+    const session = {
+      currentModelId: "gemma-4-12b-obliterated",
+      toolIncompatibleModelIds: new Set<string>(),
+    };
+
+    expect(isLmStudioModelToolIncompatible(session)).toBe(false);
+    markLmStudioModelToolIncompatible(session);
+    expect(isLmStudioModelToolIncompatible(session)).toBe(true);
+
+    session.currentModelId = "qwen/qwen3.5-9b";
+    expect(isLmStudioModelToolIncompatible(session)).toBe(false);
+    markLmStudioModelToolIncompatible(session);
+    expect(isLmStudioModelToolIncompatible(session)).toBe(true);
+
+    session.currentModelId = "mistral/tool-capable";
+    markLmStudioModelToolIncompatible(session, "gemma-4-12b-obliterated");
+    expect(isLmStudioModelToolIncompatible(session)).toBe(false);
+
+    session.currentModelId = "gemma-4-12b-obliterated";
+    expect(
+      isLmStudioModelToolIncompatible(session, "gemma-4-12b-obliterated"),
+    ).toBe(true);
+  });
+
   it("runs Windows lms command shims through cmd.exe", () => {
     expect(
       buildLmsExecInvocation("C:\\Users\\me\\.lmstudio\\bin\\lms.cmd", [
@@ -173,7 +214,13 @@ describe("LM Studio runtime wiring", () => {
     // Streamed `event: error` frames must throw, not be swallowed into an empty
     // completion; tool-incompatible models must drop tools and retry.
     expect(runtimeSource).toContain("throwIfErrorPayload");
-    expect(runtimeSource).toContain("session.toolsDisabled = true");
+    expect(runtimeSource).toContain(
+      "markLmStudioModelToolIncompatible(session, requestModelId)",
+    );
+    expect(runtimeSource).toContain(
+      "const requestModelId = session.currentModelId",
+    );
+    expect(runtimeSource).toContain("toolIncompatibleModelIds: new Set()");
     expect(runtimeSource).toContain("runChatCompletion");
   });
 


### PR DESCRIPTION
Closes #2477.

## Audit
- Reviewed ~/Downloads/Logs/20260617_qwen.log: an LM Studio model rejected tool definitions, then the session retried without tools before Qwen was loaded.
- Confirmed the runtime stored tool incompatibility at session scope, so one broken model template could disable Seren MCP tools for later model selections in the same LM Studio session.
- Audited the proposed fix for an in-flight model-switch edge case and captured the request model ID before streaming.

## Fix
- Store LM Studio tool-template incompatibility by model ID instead of a session-wide flag.
- Retry without tools only for the model that rejected tool definitions.
- Keep later model selections eligible for Seren MCP tools, including list_agent_publishers/call_publisher.
- Update the user notice to say tools are off for the current model, not the entire chat.

## Verification
- pnpm vitest run tests/unit/lmstudio-runtime.test.ts
- node --check bin/browser-local/lmstudio-runtime.mjs
- git diff --check
- pnpm build:provider-runtime
- pnpm test:runtime-smoke

## Functional walkthrough audit
- macOS local-provider path: provider-runtime bundle and smoke passed.
- Windows user path: covered in code by platform-neutral runtime state plus existing Windows lms command shim test in the same focused suite; no Windows host is available in this environment for native Tauri e2e.