### PR TITLE
fix(e2e): provision agent CLIs before Windows release probes

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -542,6 +542,7 @@ const PAIRED_PROMPT_TIMEOUT_MS = 600_000;
 const PROVIDER_CONFIG_TIMEOUT_MS = 30_000;
 const PROVIDER_WS_OPEN_TIMEOUT_MS = 30_000;
 const PROVIDER_RPC_TIMEOUT_MS = 60_000;
+const PROVIDER_ENSURE_CLI_TIMEOUT_MS = 600_000;
 const PROVIDER_SPAWN_TIMEOUT_MS = 150_000;
 const PROVIDER_TERMINATE_TIMEOUT_MS = 15_000;
 
@@ -564,6 +565,9 @@ const AUTH_FAILURE_PATTERNS = [
 
 const AGENT_PROCESS_EXIT_PATTERNS = [
   "app server stopped before request completed",
+  "cli not found",
+  "failed to install",
+  "not recognized as the name",
   "worker thread dropped while prompt was active",
 ];
 
@@ -593,8 +597,9 @@ function authError(journey, detail) {
 
 function provisioningError(journey, detail) {
   return new AgentProvisioningError(
-    `${journey} CLI exited before completing the Windows e2e prompt. Verify ` +
-      `the scheduled-task user received agent credentials via ` +
+    `${journey} CLI could not be installed, launched, or kept alive long ` +
+      `enough to complete the Windows e2e prompt. Verify the scheduled-task ` +
+      `user can resolve the CLI binary and received agent credentials via ` +
       `SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI or ` +
       `SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64, and check provider-runtime logs ` +
       `for a real process crash. Detail: ${detail}`,
@@ -655,6 +660,23 @@ function summarizeProviderRuntimeEvents(buffer, marker, sessionIds) {
   return events.length > 0 ? events.join(" | ") : "<no provider runtime events captured>";
 }
 
+async function ensureAgentCli(ws, agentType) {
+  try {
+    logStage(`${agentType} ensuring provider CLI`);
+    const resolved = await rpcWithTimeout(
+      ws,
+      "provider_ensure_agent_cli",
+      { agentType },
+      PROVIDER_ENSURE_CLI_TIMEOUT_MS,
+      `${agentType} CLI install`,
+    );
+    logStage(`${agentType} provider CLI ready: ${String(resolved || "<unknown>")}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw provisioningError(agentType, message);
+  }
+}
+
 // A raw spawn/prompt failure carries a generic message; the runtime also emits
 // a provider://error with the auth text. Promote either signal to a distinct
 // AgentAuthError so the job names the credential gap, not a timeout (#2375).
@@ -700,6 +722,7 @@ async function runSingleAgentJourney(ws, buffer, agentType) {
   let session;
   try {
     logStage(`${agentType} journey starting`);
+    await ensureAgentCli(ws, agentType);
     logStage(`${agentType} checking provider availability`);
     const available = await rpcWithTimeout(
       ws,
@@ -806,6 +829,7 @@ async function runPairedJourney(ws, buffer) {
   let session;
   try {
     logStage(`${PAIRED_AGENT_TYPE} journey starting`);
+    await ensureAgentCli(ws, PAIRED_AGENT_TYPE);
     logStage(`${PAIRED_AGENT_TYPE} checking provider availability`);
     const available = await rpcWithTimeout(
       ws,

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -240,6 +240,7 @@ describe("Windows production e2e release gate", () => {
       "PROVIDER_CONFIG_TIMEOUT_MS",
       "PROVIDER_WS_OPEN_TIMEOUT_MS",
       "PROVIDER_RPC_TIMEOUT_MS",
+      "PROVIDER_ENSURE_CLI_TIMEOUT_MS",
       "PROVIDER_SPAWN_TIMEOUT_MS",
       "PROVIDER_TERMINATE_TIMEOUT_MS",
       "rpcWithTimeout",
@@ -253,6 +254,30 @@ describe("Windows production e2e release gate", () => {
     ]) {
       expect(probe).toContain(required);
     }
+  });
+
+  it("provisions agent CLIs before checking release-gate availability (#2481)", () => {
+    // A Bedrock-backed Claude run still needs a launchable local Claude Code
+    // binary. The release probe must use the same install contract as the
+    // desktop spawn path before it asks whether the provider can launch.
+    expect(probe).toContain("provider_ensure_agent_cli");
+    expect(probe).toContain("ensureAgentCli");
+    expect(probe).toContain("ensuring provider CLI");
+    expect(probe).toContain("provider CLI ready");
+
+    const singleJourneyStart = probe.indexOf("async function runSingleAgentJourney");
+    const pairedJourneyStart = probe.indexOf("async function runPairedJourney");
+    expect(singleJourneyStart).toBeGreaterThanOrEqual(0);
+    expect(pairedJourneyStart).toBeGreaterThanOrEqual(0);
+
+    const singleJourney = probe.slice(singleJourneyStart, pairedJourneyStart);
+    const pairedJourney = probe.slice(pairedJourneyStart);
+    expect(singleJourney.indexOf("ensureAgentCli")).toBeLessThan(
+      singleJourney.indexOf("provider_check_agent_available"),
+    );
+    expect(pairedJourney.indexOf("ensureAgentCli")).toBeLessThan(
+      pairedJourney.indexOf("provider_check_agent_available"),
+    );
   });
 
   it("certifies every shipped agent journey, not one env-selected type (#2375)", () => {


### PR DESCRIPTION
## Summary

Fixes #2481.

The v3.55.10 Windows release e2e reached the provider-runtime journey and then failed because the harness checked `claude-code` availability/authentication but never invoked the provider CLI provisioning contract. Bedrock auth removes the Claude login-file requirement, but the runtime still needs a launchable local `claude` binary.

This PR makes the release probe call `provider_ensure_agent_cli` before `provider_check_agent_available` for both single-agent and paired journeys, with a dedicated 10-minute timeout and provisioning-specific error text. That matches the desktop spawn path, which already ensures CLIs before `provider_spawn`.

## Audit

Issue confirmed from SSM/on-box logs for release run `27641549131`, job `81756728914`: the probe progressed through sign-in, provider runtime config/health/ws auth, and then timed out at `claude-code` spawn with `Claude Code CLI not found at "claude"`.

Changed code paths:
- `scripts/windows-e2e-app.mjs`: release probe CLI provisioning order, timeout, and diagnostics.
- `tests/unit/windows-e2e-release-gate.test.ts`: source guard that install/provisioning precedes availability checks.

Expected impact:
- Fresh Windows e2e users can install/provision Claude/Codex CLIs before spawn.
- If provisioning fails, release logs name the CLI provisioning failure instead of waiting for a spawn timeout.
- Existing desktop UI first-run install behavior is unchanged.

## Tests

- `node --check scripts/windows-e2e-app.mjs`
- `pnpm vitest run tests/unit/windows-e2e-release-gate.test.ts`
- `git diff --check`
- `pnpm exec biome check scripts/windows-e2e-app.mjs tests/unit/windows-e2e-release-gate.test.ts` *(repo Biome config ignores both files)*
