### PR TITLE
fix(release): fail fast on eSigner login errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -364,9 +364,31 @@ jobs:
           $cspConfig = Get-ChildItem -Path $installDir -Recurse -Filter "eSignerCSP.Config.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
           if ($cspConfig) { & $cspConfig.FullName | Out-Null }
           $cka = Join-Path $installDir "eSignerCKATool.exe"
-          & $cka config -mode "PRODUCTION" -user "$env:ES_USERNAME" -pass "$env:ES_PASSWORD" -totp "$env:ES_TOTP_SECRET" -key "$masterKey" -r
-          & $cka unload
-          & $cka load
+          if (-not (Test-Path -LiteralPath $cka)) {
+            Write-Host "::error::eSignerCKATool.exe not found at $cka — eSigner CKA cannot load certificates."
+            exit 1
+          }
+
+          function Invoke-EsignerCka {
+            param(
+              [Parameter(Mandatory = $true)][string]$Step,
+              [Parameter(Mandatory = $true)][string[]]$Arguments
+            )
+            & $cka @Arguments
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -ne 0) {
+              if ($Step -eq "config/login") {
+                Write-Host "::error::eSigner CKA config/login failed with exit code $exitCode. Validate or rotate ES_USERNAME, ES_PASSWORD, and ES_TOTP_SECRET."
+              } else {
+                Write-Host "::error::eSigner CKA $Step failed with exit code $exitCode."
+              }
+              exit $exitCode
+            }
+          }
+
+          Invoke-EsignerCka "config/login" @("config", "-mode", "PRODUCTION", "-user", "$env:ES_USERNAME", "-pass", "$env:ES_PASSWORD", "-totp", "$env:ES_TOTP_SECRET", "-key", "$masterKey", "-r")
+          Invoke-EsignerCka "unload" @("unload")
+          Invoke-EsignerCka "load" @("load")
           $cert = Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert | Select-Object -First 1
           if (-not $cert) {
             Write-Host "::error::eSigner CKA did not load a code-signing certificate into the store."

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -91,6 +91,28 @@ describe("Windows production e2e release gate", () => {
     expect(probe).toContain("https://api.serendb.com");
   });
 
+  it("fails eSigner CKA login/load commands at their native failure point (#2483)", () => {
+    const buildJob = workflowJob("build");
+    expect(buildJob).toContain("function Invoke-EsignerCka");
+    expect(buildJob).toContain("eSignerCKATool.exe not found");
+    expect(buildJob).toContain("eSigner CKA config/login failed");
+    expect(buildJob).toContain(
+      "Validate or rotate ES_USERNAME, ES_PASSWORD, and ES_TOTP_SECRET",
+    );
+    expect(buildJob).toContain('Invoke-EsignerCka "config/login"');
+    expect(buildJob).toContain('Invoke-EsignerCka "unload"');
+    expect(buildJob).toContain('Invoke-EsignerCka "load"');
+
+    const configAt = buildJob.indexOf('Invoke-EsignerCka "config/login"');
+    const unloadAt = buildJob.indexOf('Invoke-EsignerCka "unload"');
+    const loadAt = buildJob.indexOf('Invoke-EsignerCka "load"');
+    const certCheckAt = buildJob.indexOf("eSigner CKA did not load");
+    expect(configAt).toBeGreaterThanOrEqual(0);
+    expect(unloadAt).toBeGreaterThan(configAt);
+    expect(loadAt).toBeGreaterThan(unloadAt);
+    expect(certCheckAt).toBeGreaterThan(loadAt);
+  });
+
   it("installs and probes the signed Windows app instead of running a browser mock", () => {
     expect(runner).toContain("Get-AuthenticodeSignature");
     expect(runner).toContain("/S");


### PR DESCRIPTION
## Summary

Fixes #2483.

The `v3.55.11` release failed in `Setup eSigner CKA (Windows)` because SSL.com rejected the configured username/password/TOTP. The workflow continued after the native `eSignerCKATool.exe config` failure and finally reported only the generic missing-certificate check.

This PR wraps the CKA `config/login`, `unload`, and `load` calls with explicit `$LASTEXITCODE` checks so the release log stops at the command that actually failed. For the observed failure, the error now says to validate or rotate `ES_USERNAME`, `ES_PASSWORD`, and `ES_TOTP_SECRET`.

## Audit

Observed failure from run `27647224845`, job `81762104749`:

```text
Could not validate a username and password. Error: Login failed
UnloadAllCertificate: Unload all certificates from Window-MY with csp eSignerKSP
LoadAllCertToStore: Load all certificates to Window-MY with csp eSignerKSP
::error::eSigner CKA did not load a code-signing certificate into the store.
```

Manual override was run separately for already-built `v3.55.10` artifacts: https://github.com/serenorg/seren-desktop/actions/runs/27647480813. The GitHub release is published and R2 updater/installer uploads completed.

## Tests

- `pnpm vitest run tests/unit/windows-e2e-release-gate.test.ts`
- `git diff --check`

Notes:
- `pnpm exec biome check .github/workflows/release.yml tests/unit/windows-e2e-release-gate.test.ts` reports both files are ignored by repo config.
- Ruby YAML parse sanity check could not run locally because the installed Ruby is missing `libgmp.10.dylib`; the release workflow guard test covers the changed source.

## Remaining operator action

This PR improves diagnostics only. Future signed Windows releases still require valid SSL.com eSigner secrets in GitHub: `ES_USERNAME`, `ES_PASSWORD`, and `ES_TOTP_SECRET`.
