### PR TITLE
fix(skills): use org-prefixed catalog slugs for auto-install (#2486)

### DIFF
--- a/src/components/bounties/BountyDetail.tsx
+++ b/src/components/bounties/BountyDetail.tsx
@@ -47,7 +47,10 @@ import { fileTreeState } from "@/stores/fileTree";
 import { skillsStore } from "@/stores/skills.store";
 import { threadStore } from "@/stores/thread.store";
 
-const SEREN_BOUNTY_SLUG = "seren-bounty";
+// Catalog slugs are `${org}-${skillName}`, so the seren-org skill at
+// seren/seren-bounty/SKILL.md is published as `seren-seren-bounty`. The bare
+// folder name 404s against the gateway — keep the org prefix (seren-desktop#2486).
+const SEREN_BOUNTY_SLUG = "seren-seren-bounty";
 const SEREN_BOUNTY_SOURCE_URL = `seren-skills:${SEREN_BOUNTY_SLUG}`;
 
 interface BountyDetailProps {

--- a/src/components/sidebar/SkillsExplorer.tsx
+++ b/src/components/sidebar/SkillsExplorer.tsx
@@ -57,7 +57,10 @@ interface SkillsExplorerProps {
 
 type Filter = "all" | "installed" | "needs-sync";
 
-const SKILL_CREATOR_SLUG = "skill-creator";
+// Catalog slugs are `${org}-${skillName}`, so the seren-org skill at
+// seren/skill-creator/SKILL.md is published as `seren-skill-creator`. The bare
+// folder name 404s against the gateway — keep the org prefix (seren-desktop#2486).
+const SKILL_CREATOR_SLUG = "seren-skill-creator";
 const SKILL_CREATOR_SOURCE_URL = `seren-skills:${SKILL_CREATOR_SLUG}`;
 
 const PlayIcon: Component = () => (


### PR DESCRIPTION
Fixes #2486.

## Problem

`skill-creator` and `seren-bounty` auto-installs fail with `404 (skill not found)` for all users (seen in `20260616_erik.log`, `20260609_Cristin.log`).

## Root cause (verified against the live gateway)

The catalog derives slugs as `${org}-${skillName}` (`serenorg/seren-skills` `scripts/build-index.mjs`), so seren-org skills carry a `seren-` prefix. The client hardcoded the bare folder names:

| Client constant | Bare slug | `/skills/{slug}/download` | Correct slug | Result |
| --- | --- | --- | --- | --- |
| `SkillsExplorer.tsx` `SKILL_CREATOR_SLUG` | `skill-creator` | **404** | `seren-skill-creator` | **200** |
| `BountyDetail.tsx` `SEREN_BOUNTY_SLUG` | `seren-bounty` | **404** | `seren-seren-bounty` | **200** |

Both skills have lived under `seren/` since April 2026; the constants were never updated when the catalog moved to the org/skill layout. **Not** related to `serenorg/seren-skills` going private — the gateway serves both org-prefixed slugs at 200 right now.

## Fix

Point both constants at the real catalog slugs and add a comment documenting the `${org}-${skillName}` convention. No migration needed: the old slugs never installed, so no stale records exist. Installed-state detection is by slug, and catalog installs already use the org-prefixed slug, so the now-correct constants match.

## Verification

- Live gateway: bare slugs → 404, org-prefixed → 200 (both skills).
- Biome clean on both files; no remaining bare-slug literals in `src/`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
