### PR TITLE
ci: add eSigner CKA auth preflight

### DIFF
--- a/.github/workflows/esigner-cka-preflight.yml
+++ b/.github/workflows/esigner-cka-preflight.yml
@@ -1,0 +1,102 @@
+# ABOUTME: Manual SSL.com eSigner CKA auth preflight for Windows release signing.
+# ABOUTME: Validates signing auth without creating releases, artifacts, or updater manifests.
+
+name: eSigner CKA Preflight
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  esigner-cka-preflight:
+    runs-on: windows-latest
+    env:
+      HAS_WINDOWS_SIGNING: ${{ secrets.ES_USERNAME != '' && secrets.ES_PASSWORD != '' && secrets.ES_TOTP_SECRET != '' }}
+      ES_USERNAME: ${{ secrets.ES_USERNAME }}
+      ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
+      ES_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
+    steps:
+      - name: Validate eSigner secret presence
+        shell: pwsh
+        run: |
+          if ($env:HAS_WINDOWS_SIGNING -ne "true") {
+            Write-Host "::error::Missing one or more eSigner secrets: ES_USERNAME, ES_PASSWORD, ES_TOTP_SECRET."
+            exit 1
+          }
+          Write-Host "eSigner secrets are present; running CKA auth preflight."
+
+      - name: Install and authenticate eSigner CKA
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installDir = Join-Path $env:USERPROFILE "eSignerCKA"
+          $masterKey = Join-Path $installDir "master.key"
+
+          Write-Host "Downloading SSL.com eSigner CKA installer"
+          Invoke-WebRequest -Uri "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.8/SSL.COM-eSigner-CKA_1.0.8.zip" -OutFile eSigner_CKA_Setup.zip
+          Expand-Archive -Force eSigner_CKA_Setup.zip
+          Remove-Item eSigner_CKA_Setup.zip
+          Move-Item -Destination "eSigner_CKA_Installer.exe" -Path "eSigner_CKA_Setup\*.exe"
+
+          New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+          Write-Host "Installing eSigner CKA into $installDir"
+          Start-Process ".\eSigner_CKA_Installer.exe" -ArgumentList '/CURRENTUSER','/VERYSILENT','/SUPPRESSMSGBOXES',"/DIR=$installDir" -Wait
+
+          if (Test-Path ".\setup\vc_redist.x64.exe") {
+            Write-Host "Installing bundled Visual C++ redistributables"
+            Start-Process ".\setup\vc_redist.x86.exe" -ArgumentList "/install","/q" -Wait
+            Start-Process ".\setup\vc_redist.x64.exe" -ArgumentList "/install","/q" -Wait
+          }
+
+          $registerKsp = Get-ChildItem -Path $installDir -Recurse -Filter "RegisterKSP.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $registerKsp) {
+            Write-Host "::error::RegisterKSP.exe not found under $installDir; eSigner KSP cannot be registered."
+            exit 1
+          }
+          Write-Host "Registering eSigner KSP"
+          & $registerKsp.FullName | Out-Null
+
+          $cspConfig = Get-ChildItem -Path $installDir -Recurse -Filter "eSignerCSP.Config.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($cspConfig) {
+            Write-Host "Running eSigner CSP configuration"
+            & $cspConfig.FullName | Out-Null
+          }
+
+          $cka = Join-Path $installDir "eSignerCKATool.exe"
+          if (-not (Test-Path -LiteralPath $cka)) {
+            Write-Host "::error::eSignerCKATool.exe not found at $cka; eSigner CKA cannot load certificates."
+            exit 1
+          }
+          Write-Host "Resolved eSignerCKATool.exe at $cka"
+
+          function Invoke-EsignerCka {
+            param(
+              [Parameter(Mandatory = $true)][string]$Step,
+              [Parameter(Mandatory = $true)][string[]]$Arguments
+            )
+            Write-Host "Running eSigner CKA $Step"
+            & $cka @Arguments
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -ne 0) {
+              if ($Step -eq "config/login") {
+                Write-Host "::error::eSigner CKA config/login failed with exit code $exitCode. Validate SSL.com account status, cooldown/lockout, ES_USERNAME, ES_PASSWORD, and ES_TOTP_SECRET before rotating secrets."
+              } else {
+                Write-Host "::error::eSigner CKA $Step failed with exit code $exitCode."
+              }
+              exit $exitCode
+            }
+          }
+
+          Invoke-EsignerCka "config/login" @("config", "-mode", "PRODUCTION", "-user", "$env:ES_USERNAME", "-pass", "$env:ES_PASSWORD", "-totp", "$env:ES_TOTP_SECRET", "-key", "$masterKey", "-r")
+          Invoke-EsignerCka "unload" @("unload")
+          Invoke-EsignerCka "load" @("load")
+
+          $cert = Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert | Select-Object -First 1
+          if (-not $cert) {
+            Write-Host "::error::eSigner CKA authenticated but did not load a code-signing certificate into Cert:\CurrentUser\My."
+            exit 1
+          }
+
+          Write-Host "eSigner CKA preflight loaded code-signing certificate: $($cert.Subject) [$($cert.Thumbprint)]"

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -10,12 +10,19 @@ const manualPublishWorkflowPath = join(
   root,
   ".github/workflows/publish-release-manual.yml",
 );
+const esignerPreflightWorkflowPath = join(
+  root,
+  ".github/workflows/esigner-cka-preflight.yml",
+);
 const releaseWorkflow = readFileSync(
   join(root, ".github/workflows/release.yml"),
   "utf8",
 );
 const manualPublishWorkflow = existsSync(manualPublishWorkflowPath)
   ? readFileSync(manualPublishWorkflowPath, "utf8")
+  : "";
+const esignerPreflightWorkflow = existsSync(esignerPreflightWorkflowPath)
+  ? readFileSync(esignerPreflightWorkflowPath, "utf8")
   : "";
 const runner = readFileSync(join(root, "scripts/windows-e2e-app.ps1"), "utf8");
 const taskUserRunner = readFileSync(
@@ -111,6 +118,27 @@ describe("Windows production e2e release gate", () => {
     expect(unloadAt).toBeGreaterThan(configAt);
     expect(loadAt).toBeGreaterThan(unloadAt);
     expect(certCheckAt).toBeGreaterThan(loadAt);
+  });
+
+  it("keeps the eSigner CKA auth preflight manual and side-effect free (#2485)", () => {
+    expect(existsSync(esignerPreflightWorkflowPath)).toBe(true);
+    expect(esignerPreflightWorkflow).toContain("workflow_dispatch:");
+    expect(esignerPreflightWorkflow).toContain("runs-on: windows-latest");
+    expect(esignerPreflightWorkflow).toContain("ES_USERNAME");
+    expect(esignerPreflightWorkflow).toContain("ES_PASSWORD");
+    expect(esignerPreflightWorkflow).toContain("ES_TOTP_SECRET");
+    expect(esignerPreflightWorkflow).toContain("eSignerCKATool.exe");
+    expect(esignerPreflightWorkflow).toContain('Invoke-EsignerCka "config/login"');
+    expect(esignerPreflightWorkflow).toContain('Invoke-EsignerCka "unload"');
+    expect(esignerPreflightWorkflow).toContain('Invoke-EsignerCka "load"');
+    expect(esignerPreflightWorkflow).toContain("Cert:\\CurrentUser\\My");
+    expect(esignerPreflightWorkflow).toContain("code-signing certificate");
+    expect(esignerPreflightWorkflow).not.toContain("actions/checkout");
+    expect(esignerPreflightWorkflow).not.toContain("softprops/action-gh-release");
+    expect(esignerPreflightWorkflow).not.toContain("aws s3 cp");
+    expect(esignerPreflightWorkflow).not.toContain("R2_BUCKET");
+    expect(esignerPreflightWorkflow).not.toContain("latest.json");
+    expect(esignerPreflightWorkflow).not.toContain("tauri build");
   });
 
   it("installs and probes the signed Windows app instead of running a browser mock", () => {


### PR DESCRIPTION
## Summary

Refs #2485.

Adds a permanent manual `eSigner CKA Preflight` workflow so release operators can validate SSL.com eSigner auth on a hosted Windows runner without cutting a production tag or publishing artifacts.

## Code paths

- `.github/workflows/esigner-cka-preflight.yml`
  - `workflow_dispatch` only.
  - Runs on `windows-latest`.
  - Validates `ES_USERNAME`, `ES_PASSWORD`, and `ES_TOTP_SECRET` are present.
  - Downloads and installs SSL.com eSigner CKA v1.0.8.
  - Registers KSP and runs optional CSP config if present.
  - Runs the production auth path: `config/login`, `unload`, `load`.
  - Checks `Cert:\CurrentUser\My -CodeSigningCert`.
  - Does not checkout, build, sign app payloads, upload artifacts, publish releases, touch R2, or generate `latest.json`.

- `tests/unit/windows-e2e-release-gate.test.ts`
  - Adds one critical source guard for the new workflow: manual-only, Windows runner, required secrets, auth command sequence, cert-store check, and no publishing/uploading code paths.

## Audit

Issue re-confirmed: #2485 needs a direct confirmation path because the previous release failure proved only that SSL.com rejected one login attempt. It did not prove permanent credential invalidity, and a full release tag is too expensive and side-effectful for auth confirmation.

Fix impact: operators can now run a side-effect-free auth preflight. A green preflight supports cutting the next production tag; a red preflight gives a precise auth/load stage before any release build work starts.

Permanent or temporary: permanent operator diagnostic. It has no automatic triggers.

## Tests

- `pnpm vitest run tests/unit/windows-e2e-release-gate.test.ts`
- `git diff --check`
- `git diff HEAD^ --check`

Notes:
- `pnpm exec biome check .github/workflows/esigner-cka-preflight.yml tests/unit/windows-e2e-release-gate.test.ts` reports both files are ignored by repo config.
