### PR TITLE
feat: add employee catalog client

### DIFF
--- a/src/api/employee-catalog.ts
+++ b/src/api/employee-catalog.ts
@@ -1,0 +1,140 @@
+// ABOUTME: Public Seren Employee catalog API client for desktop intake surfaces.
+// ABOUTME: Fetches role definitions from the website without touching deployed employees.
+
+import { appFetch } from "@/lib/fetch";
+
+export type EmployeeCatalogClusterKey =
+  | "office-of-the-ceo"
+  | "finance-investment"
+  | "revenue-market"
+  | "technology-security"
+  | "risk-legal-people";
+
+export interface EmployeeCatalogCluster {
+  key: EmployeeCatalogClusterKey;
+  label: string;
+}
+
+export interface EmployeeCatalogItem {
+  slug: string;
+  title: string;
+  cluster: EmployeeCatalogClusterKey;
+  seniority: number;
+  tagline: string;
+  featured: boolean;
+  imageUrl: string;
+  heroImageUrl: string;
+  skillSlug: string;
+}
+
+export interface EmployeeCatalog {
+  employees: EmployeeCatalogItem[];
+  clusters: EmployeeCatalogCluster[];
+  total: number;
+}
+
+type RawEmployeeCatalogItem = {
+  slug?: unknown;
+  title?: unknown;
+  cluster?: unknown;
+  seniority?: unknown;
+  tagline?: unknown;
+  featured?: unknown;
+  image_url?: unknown;
+  hero_image_url?: unknown;
+  skill_slug?: unknown;
+};
+
+type RawEmployeeCatalogResponse = {
+  employees?: unknown;
+  clusters?: unknown;
+  total?: unknown;
+};
+
+const CATALOG_URL =
+  import.meta.env.VITE_SEREN_EMPLOYEE_CATALOG_URL ??
+  "https://serendb.com/api/employees";
+
+function asString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `employee catalog field '${field}' must be a non-empty string`,
+    );
+  }
+  return value;
+}
+
+function asNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(
+      `employee catalog field '${field}' must be a finite number`,
+    );
+  }
+  return value;
+}
+
+function asBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`employee catalog field '${field}' must be a boolean`);
+  }
+  return value;
+}
+
+function normalizeEmployee(raw: RawEmployeeCatalogItem): EmployeeCatalogItem {
+  const slug = asString(raw.slug, "slug");
+  return {
+    slug,
+    title: asString(raw.title, "title"),
+    cluster: asString(raw.cluster, "cluster") as EmployeeCatalogClusterKey,
+    seniority: asNumber(raw.seniority, "seniority"),
+    tagline: asString(raw.tagline, "tagline"),
+    featured: asBoolean(raw.featured, "featured"),
+    imageUrl: asString(raw.image_url, "image_url"),
+    heroImageUrl: asString(raw.hero_image_url, "hero_image_url"),
+    skillSlug:
+      typeof raw.skill_slug === "string" && raw.skill_slug.length > 0
+        ? raw.skill_slug
+        : slug,
+  };
+}
+
+function normalizeCluster(raw: unknown): EmployeeCatalogCluster {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("employee catalog cluster must be an object");
+  }
+  const row = raw as { key?: unknown; label?: unknown };
+  return {
+    key: asString(row.key, "cluster.key") as EmployeeCatalogClusterKey,
+    label: asString(row.label, "cluster.label"),
+  };
+}
+
+export function normalizeEmployeeCatalogResponse(
+  raw: RawEmployeeCatalogResponse,
+): EmployeeCatalog {
+  if (!Array.isArray(raw.employees)) {
+    throw new Error("employee catalog response must include employees[]");
+  }
+  if (!Array.isArray(raw.clusters)) {
+    throw new Error("employee catalog response must include clusters[]");
+  }
+
+  const employees = raw.employees.map((item) =>
+    normalizeEmployee(item as RawEmployeeCatalogItem),
+  );
+  return {
+    employees,
+    clusters: raw.clusters.map(normalizeCluster),
+    total: typeof raw.total === "number" ? raw.total : employees.length,
+  };
+}
+
+export async function fetchEmployeeCatalog(): Promise<EmployeeCatalog> {
+  const response = await appFetch(CATALOG_URL);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch employee catalog: HTTP ${response.status}`,
+    );
+  }
+  return normalizeEmployeeCatalogResponse(await response.json());
+}

--- a/src/stores/employee-catalog.store.ts
+++ b/src/stores/employee-catalog.store.ts
@@ -1,0 +1,77 @@
+// ABOUTME: Reactive desktop store for the public Seren Employee role catalog.
+// ABOUTME: Separate from deployed employees.store, which tracks running agent instances.
+
+import { createStore } from "solid-js/store";
+import type {
+  EmployeeCatalogCluster,
+  EmployeeCatalogItem,
+} from "@/api/employee-catalog";
+import { fetchEmployeeCatalog } from "@/api/employee-catalog";
+
+interface EmployeeCatalogState {
+  employees: EmployeeCatalogItem[];
+  clusters: EmployeeCatalogCluster[];
+  loading: boolean;
+  error: string | null;
+  lastLoadedAt: number | null;
+}
+
+const [state, setState] = createStore<EmployeeCatalogState>({
+  employees: [],
+  clusters: [],
+  loading: false,
+  error: null,
+  lastLoadedAt: null,
+});
+
+export const employeeCatalogStore = {
+  get employees(): EmployeeCatalogItem[] {
+    return state.employees;
+  },
+
+  get clusters(): EmployeeCatalogCluster[] {
+    return state.clusters;
+  },
+
+  get loading(): boolean {
+    return state.loading;
+  },
+
+  get error(): string | null {
+    return state.error;
+  },
+
+  get lastLoadedAt(): number | null {
+    return state.lastLoadedAt;
+  },
+
+  bySlug(slug: string): EmployeeCatalogItem | undefined {
+    return state.employees.find((employee) => employee.slug === slug);
+  },
+
+  async refresh(): Promise<void> {
+    setState("loading", true);
+    setState("error", null);
+
+    try {
+      const catalog = await fetchEmployeeCatalog();
+      setState("employees", catalog.employees);
+      setState("clusters", catalog.clusters);
+      setState("lastLoadedAt", Date.now());
+    } catch (error) {
+      setState("error", error instanceof Error ? error.message : String(error));
+    } finally {
+      setState("loading", false);
+    }
+  },
+
+  reset(): void {
+    setState({
+      employees: [],
+      clusters: [],
+      loading: false,
+      error: null,
+      lastLoadedAt: null,
+    });
+  },
+};

--- a/tests/unit/employee-catalog.test.ts
+++ b/tests/unit/employee-catalog.test.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Tests public Seren Employee catalog response normalization.
+// ABOUTME: Guards the desktop intake catalog from deployed employee state coupling.
+
+import { describe, expect, it } from "vitest";
+import { normalizeEmployeeCatalogResponse } from "@/api/employee-catalog";
+
+describe("employee catalog API normalization", () => {
+  it("maps website catalog fields to desktop catalog items", () => {
+    const catalog = normalizeEmployeeCatalogResponse({
+      total: 1,
+      clusters: [{ key: "finance-investment", label: "Finance & Investment" }],
+      employees: [
+        {
+          slug: "cfo",
+          title: "Chief Financial Officer",
+          cluster: "finance-investment",
+          seniority: 1,
+          tagline: "A CFO for your CFO.",
+          featured: true,
+          image_url: "/employees/cfo.webp",
+          hero_image_url: "/employees/cfo-hero.webp",
+          skill_slug: "cfo",
+          status: "running",
+          mode: "always_on",
+        },
+      ],
+    });
+
+    expect(catalog.total).toBe(1);
+    expect(catalog.employees[0]).toEqual({
+      slug: "cfo",
+      title: "Chief Financial Officer",
+      cluster: "finance-investment",
+      seniority: 1,
+      tagline: "A CFO for your CFO.",
+      featured: true,
+      imageUrl: "/employees/cfo.webp",
+      heroImageUrl: "/employees/cfo-hero.webp",
+      skillSlug: "cfo",
+    });
+    expect(catalog.employees[0]).not.toHaveProperty("status");
+    expect(catalog.employees[0]).not.toHaveProperty("mode");
+  });
+
+  it("fails loudly when employees are missing", () => {
+    expect(() =>
+      normalizeEmployeeCatalogResponse({
+        clusters: [],
+      }),
+    ).toThrow("employees[]");
+  });
+});


### PR DESCRIPTION
Closes serenorg/seren-website#243

## Summary
- add a desktop API client for the public Seren Employee catalog endpoint
- add a separate employeeCatalogStore for interview landing surfaces
- keep deployed employees.store and the runnable skills pipeline untouched
- add a pure normalization test that strips deployed runtime fields from catalog items

## Tests
- pnpm exec biome check src/api/employee-catalog.ts src/stores/employee-catalog.store.ts tests/unit/employee-catalog.test.ts
- pnpm test tests/unit/employee-catalog.test.ts

## Note
- pnpm exec tsc --noEmit currently fails on pre-existing unrelated test typing issues in meeting-autodetect/provider-runtime/windows manifest tests; this branch's changed files pass Biome and targeted Vitest.