### PR TITLE
feat: add employee interview landing

### DIFF
--- a/src/components/interview/InterviewLanding.tsx
+++ b/src/components/interview/InterviewLanding.tsx
@@ -1,0 +1,243 @@
+// ABOUTME: General Seren Employee intake landing fed by the public role catalog.
+// ABOUTME: Opens from first launch, deep links, and fallback desktop entry points.
+
+import {
+  type Component,
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  onMount,
+  Show,
+} from "solid-js";
+import {
+  catalogAssetUrl,
+  clusterLabel,
+  resolveInterviewEmployeeSlug,
+} from "@/components/interview/interviewLandingModel";
+import { employeeCatalogStore } from "@/stores/employee-catalog.store";
+
+export const OPEN_INTERVIEW_LANDING_EVENT = "seren:open-interview-landing";
+export const CLOSE_INTERVIEW_LANDING_EVENT = "seren:close-interview-landing";
+
+export type InterviewLandingEventDetail = {
+  employee?: string | null;
+};
+
+interface InterviewLandingProps {
+  initialEmployeeSlug?: string | null;
+  onClose?: () => void;
+  onStartInterview?: (employeeSlug: string | null) => void;
+}
+
+export const InterviewLanding: Component<InterviewLandingProps> = (props) => {
+  const [selectedSlug, setSelectedSlug] = createSignal<string | null>(null);
+  const [started, setStarted] = createSignal(false);
+
+  onMount(() => {
+    if (
+      employeeCatalogStore.lastLoadedAt === null &&
+      !employeeCatalogStore.loading
+    ) {
+      void employeeCatalogStore.refresh();
+    }
+  });
+
+  const employees = createMemo(() =>
+    [...employeeCatalogStore.employees].sort((left, right) => {
+      if (left.cluster !== right.cluster) {
+        return left.cluster.localeCompare(right.cluster);
+      }
+      return left.seniority - right.seniority;
+    }),
+  );
+
+  createEffect(() => {
+    setSelectedSlug(
+      resolveInterviewEmployeeSlug(employees(), props.initialEmployeeSlug),
+    );
+    setStarted(false);
+  });
+
+  const selectedEmployee = createMemo(() => {
+    const slug = selectedSlug();
+    if (!slug) return null;
+    return employeeCatalogStore.bySlug(slug) ?? null;
+  });
+
+  const handleStartInterview = () => {
+    setStarted(true);
+    props.onStartInterview?.(selectedSlug());
+  };
+
+  return (
+    <section
+      class="flex h-full min-h-0 bg-background text-foreground"
+      data-testid="interview-landing"
+    >
+      <aside class="w-[320px] shrink-0 border-r border-border/80 bg-surface-0/80 px-6 py-6 overflow-y-auto">
+        <div class="flex items-start justify-between gap-4">
+          <div class="min-w-0">
+            <p class="m-0 text-[10px] font-semibold uppercase tracking-[0.16em] text-primary/80">
+              Seren Employee Intake
+            </p>
+            <h1 class="mt-3 mb-0 text-[26px] leading-[1.05] font-semibold tracking-normal text-foreground">
+              Pick the employee you want to hire.
+            </h1>
+          </div>
+          <Show when={props.onClose}>
+            <button
+              type="button"
+              class="h-8 w-8 shrink-0 rounded-md border border-border/80 bg-transparent text-muted-foreground hover:text-foreground hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/70"
+              aria-label="Close interview landing"
+              onClick={props.onClose}
+            >
+              ×
+            </button>
+          </Show>
+        </div>
+
+        <div class="mt-7 border-t border-border/70 pt-5">
+          <p class="m-0 text-[12px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+            Selected Role
+          </p>
+          <Show
+            when={selectedEmployee()}
+            fallback={
+              <div class="mt-3 rounded-md border border-dashed border-border/80 bg-surface-1/50 px-3 py-3 text-[13px] leading-snug text-muted-foreground">
+                No role selected
+              </div>
+            }
+          >
+            {(employee) => (
+              <div class="mt-3 overflow-hidden rounded-md border border-border/80 bg-surface-1">
+                <img
+                  src={catalogAssetUrl(employee().imageUrl)}
+                  alt=""
+                  class="h-32 w-full object-cover"
+                  loading="lazy"
+                />
+                <div class="px-3 py-3">
+                  <p class="m-0 text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+                    {clusterLabel(employee())}
+                  </p>
+                  <h2 class="mt-1 mb-0 text-[15px] font-semibold leading-tight text-foreground">
+                    {employee().title}
+                  </h2>
+                  <p class="mt-2 mb-0 text-[12px] leading-snug text-muted-foreground">
+                    {employee().tagline}
+                  </p>
+                </div>
+              </div>
+            )}
+          </Show>
+        </div>
+
+        <button
+          type="button"
+          class="mt-5 flex h-10 w-full items-center justify-center rounded-md border border-primary/70 bg-primary text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:border-border disabled:bg-surface-2 disabled:text-muted-foreground"
+          disabled={employeeCatalogStore.loading || employees().length === 0}
+          data-testid="start-employee-interview"
+          onClick={handleStartInterview}
+        >
+          Start Interview
+        </button>
+        <Show when={started()}>
+          <p
+            class="mt-3 mb-0 text-[12px] leading-snug text-success"
+            data-testid="interview-started-state"
+          >
+            Intake queued for Seren Employee customization.
+          </p>
+        </Show>
+      </aside>
+
+      <div class="min-w-0 flex-1 overflow-y-auto px-6 py-6">
+        <div class="flex items-end justify-between gap-4 border-b border-border/70 pb-4">
+          <div class="min-w-0">
+            <p class="m-0 text-[12px] font-medium text-muted-foreground">
+              Public catalog
+            </p>
+            <h2 class="mt-1 mb-0 text-[18px] font-semibold text-foreground">
+              {employees().length} executive roles
+            </h2>
+          </div>
+          <button
+            type="button"
+            class="h-8 rounded-md border border-border/80 bg-transparent px-3 text-[12px] font-medium text-muted-foreground hover:bg-surface-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/70 disabled:cursor-wait disabled:opacity-60"
+            disabled={employeeCatalogStore.loading}
+            onClick={() => void employeeCatalogStore.refresh()}
+          >
+            Refresh
+          </button>
+        </div>
+
+        <Show when={employeeCatalogStore.error}>
+          <div
+            class="mt-4 rounded-md border border-status-error/40 bg-status-error/10 px-3 py-2 text-[13px] text-status-error"
+            role="alert"
+          >
+            {employeeCatalogStore.error}
+          </div>
+        </Show>
+
+        <Show
+          when={!employeeCatalogStore.loading || employees().length > 0}
+          fallback={
+            <div class="mt-8 text-[13px] text-muted-foreground">
+              Loading employee catalog...
+            </div>
+          }
+        >
+          <div
+            class="mt-5 grid grid-cols-[repeat(auto-fill,minmax(210px,1fr))] gap-3"
+            data-testid="interview-role-grid"
+          >
+            <For each={employees()}>
+              {(employee) => {
+                const active = () => selectedSlug() === employee.slug;
+                return (
+                  <button
+                    type="button"
+                    class="group overflow-hidden rounded-md border border-border/80 bg-surface-1 text-left transition-colors hover:border-primary/50 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                    classList={{
+                      "border-primary/80 bg-primary-muted": active(),
+                    }}
+                    data-testid="interview-role-option"
+                    aria-pressed={active()}
+                    onClick={() => setSelectedSlug(employee.slug)}
+                  >
+                    <div class="relative h-24 overflow-hidden bg-surface-2">
+                      <img
+                        src={catalogAssetUrl(employee.imageUrl)}
+                        alt=""
+                        class="h-full w-full object-cover opacity-90 transition-transform duration-200 group-hover:scale-[1.03]"
+                        loading="lazy"
+                      />
+                      <Show when={employee.featured}>
+                        <span class="absolute left-2 top-2 rounded-sm bg-background/80 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-primary">
+                          Featured
+                        </span>
+                      </Show>
+                    </div>
+                    <div class="px-3 py-3">
+                      <p class="m-0 truncate text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                        {clusterLabel(employee)}
+                      </p>
+                      <h3 class="mt-1 mb-0 text-[14px] font-semibold leading-tight text-foreground">
+                        {employee.title}
+                      </h3>
+                      <p class="mt-2 line-clamp-2 min-h-[34px] text-[12px] leading-snug text-muted-foreground">
+                        {employee.tagline}
+                      </p>
+                    </div>
+                  </button>
+                );
+              }}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </section>
+  );
+};

--- a/src/components/interview/interviewLandingModel.ts
+++ b/src/components/interview/interviewLandingModel.ts
@@ -1,0 +1,30 @@
+// ABOUTME: Pure helpers for the Seren Employee intake landing.
+// ABOUTME: Kept outside TSX so selection behavior can be tested without DOM rendering.
+
+import type { EmployeeCatalogItem } from "@/api/employee-catalog";
+
+const CATALOG_ASSET_ORIGIN = "https://serendb.com";
+
+export function catalogAssetUrl(path: string): string {
+  if (/^https?:\/\//.test(path)) return path;
+  return `${CATALOG_ASSET_ORIGIN}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+export function resolveInterviewEmployeeSlug(
+  employees: readonly Pick<EmployeeCatalogItem, "slug">[],
+  requestedSlug?: string | null,
+): string | null {
+  if (!requestedSlug) return null;
+  return employees.some((employee) => employee.slug === requestedSlug)
+    ? requestedSlug
+    : null;
+}
+
+export function clusterLabel(
+  employee: Pick<EmployeeCatalogItem, "cluster">,
+): string {
+  return employee.cluster
+    .split("-")
+    .map((word) => word[0]?.toUpperCase() + word.slice(1))
+    .join(" ");
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -19,6 +19,12 @@ import { CatalogList } from "@/components/catalog/CatalogList";
 import { ArchivedEmployeeDetail } from "@/components/employees/ArchivedEmployeeDetail";
 import { EmployeeDetail } from "@/components/employees/EmployeeDetail";
 import { InboxList } from "@/components/inbox/InboxList";
+import {
+  CLOSE_INTERVIEW_LANDING_EVENT,
+  InterviewLanding,
+  type InterviewLandingEventDetail,
+  OPEN_INTERVIEW_LANDING_EVENT,
+} from "@/components/interview/InterviewLanding";
 import { ThreadSidebar } from "@/components/layout/ThreadSidebar";
 import { AudioPrimingDialog } from "@/components/meeting/AudioPrimingDialog";
 import { MeetingPanel } from "@/components/meeting/MeetingPanel";
@@ -47,6 +53,7 @@ import { AgentTasksPanel } from "@/components/tasks/AgentTasksPanel";
 import { isMeetingProcessingStatus } from "@/lib/meeting-format";
 import { shortcuts } from "@/lib/shortcuts";
 import type { InstalledSkill } from "@/lib/skills";
+import { listenForInterviewLaunch } from "@/lib/tauri-bridge";
 import {
   appearanceState,
   applyAppearanceToDocument,
@@ -79,6 +86,7 @@ export type SlidePanelView =
   | null;
 
 const SLIDE_PANEL_KEY = "seren:slide_panel";
+const INTERVIEW_LANDING_DISMISSED_KEY = "seren:interview_landing_dismissed";
 
 const PERSISTABLE_VIEWS: ReadonlySet<NonNullable<SlidePanelView>> = new Set([
   "settings",
@@ -90,11 +98,9 @@ const PERSISTABLE_VIEWS: ReadonlySet<NonNullable<SlidePanelView>> = new Set([
 ]);
 
 function loadInitialSlidePanel(): SlidePanelView {
-  // First launch (no stored preference) opens the skills panel by default
-  // so users discover the catalog without having to hunt for it.
   try {
     const raw = localStorage.getItem(SLIDE_PANEL_KEY);
-    if (raw === null) return "skills";
+    if (raw === null) return null;
     if (raw === "null") return null;
     if (PERSISTABLE_VIEWS.has(raw as NonNullable<SlidePanelView>)) {
       return raw as SlidePanelView;
@@ -102,7 +108,23 @@ function loadInitialSlidePanel(): SlidePanelView {
   } catch {
     // localStorage unavailable - fall back to default
   }
-  return "skills";
+  return null;
+}
+
+function loadInitialInterviewLanding(): boolean {
+  try {
+    return localStorage.getItem(INTERVIEW_LANDING_DISMISSED_KEY) !== "true";
+  } catch {
+    return true;
+  }
+}
+
+function persistInterviewLandingDismissed(): void {
+  try {
+    localStorage.setItem(INTERVIEW_LANDING_DISMISSED_KEY, "true");
+  } catch {
+    // Non-fatal
+  }
 }
 
 function persistSlidePanel(view: SlidePanelView): void {
@@ -160,14 +182,52 @@ export const AppShell: Component<AppShellProps> = (props) => {
     createSignal<BountyInheritFrom | null>(null);
   const [catalogOpen, setCatalogOpen] = createSignal(false);
   const [inboxOpen, setInboxOpen] = createSignal(false);
+  const [interviewLandingOpen, setInterviewLandingOpen] = createSignal(
+    loadInitialInterviewLanding(),
+  );
+  const [interviewEmployeeSlug, setInterviewEmployeeSlug] = createSignal<
+    string | null
+  >(null);
   createEffect(() => {
     persistSlidePanel(slidePanel());
   });
+
+  const openInterviewLanding = (employeeSlug?: string | null) => {
+    setInterviewEmployeeSlug(employeeSlug ?? null);
+    setInterviewLandingOpen(true);
+    setActiveEmployeeId(null);
+    if (activeBountyId() !== null) {
+      setActiveBountyId(null);
+      setActiveBountyInheritFrom(null);
+      window.dispatchEvent(new CustomEvent(CLOSE_BOUNTY_DETAIL_EVENT));
+    }
+    setCatalogOpen(false);
+    setInboxOpen(false);
+  };
+
+  const handleOpenInterviewLanding = (event: Event) => {
+    const detail = (event as CustomEvent<InterviewLandingEventDetail>).detail;
+    openInterviewLanding(detail?.employee ?? null);
+  };
+
+  const closeInterviewLanding = () => {
+    setInterviewLandingOpen(false);
+    setInterviewEmployeeSlug(null);
+    persistInterviewLandingDismissed();
+    window.dispatchEvent(new CustomEvent(CLOSE_INTERVIEW_LANDING_EVENT));
+  };
+
+  const handleCloseInterviewLanding = () => {
+    setInterviewLandingOpen(false);
+    setInterviewEmployeeSlug(null);
+    persistInterviewLandingDismissed();
+  };
 
   const handleOpenEmployeeDetail = (event: Event) => {
     const detail = (event as CustomEvent<EmployeeDetailEventDetail>).detail;
     if (detail?.employeeId) {
       setActiveEmployeeId(detail.employeeId);
+      setInterviewLandingOpen(false);
       if (activeBountyId() !== null) {
         setActiveBountyId(null);
         setActiveBountyInheritFrom(null);
@@ -191,6 +251,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
     const detail = (event as CustomEvent<BountyDetailEventDetail>).detail;
     if (detail?.bountyId) {
       setActiveBountyId(detail.bountyId);
+      setInterviewLandingOpen(false);
       // Snapshot the binding the sidebar captured before clearing the
       // active thread. `BountyDetail.handleJoinBounty` consults this so
       // a user joining a bounty from a Codex thread lands in another
@@ -218,6 +279,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
 
   const handleOpenCatalog = () => {
     setCatalogOpen(true);
+    setInterviewLandingOpen(false);
     if (activeEmployeeId() !== null) {
       setActiveEmployeeId(null);
       window.dispatchEvent(new CustomEvent(CLOSE_EMPLOYEE_DETAIL_EVENT));
@@ -236,6 +298,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
 
   const handleOpenInbox = () => {
     setInboxOpen(true);
+    setInterviewLandingOpen(false);
     if (activeEmployeeId() !== null) {
       setActiveEmployeeId(null);
       window.dispatchEvent(new CustomEvent(CLOSE_EMPLOYEE_DETAIL_EVENT));
@@ -264,6 +327,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
         }
         setCatalogOpen(false);
         setInboxOpen(false);
+        setInterviewLandingOpen(false);
       },
       { defer: true },
     ),
@@ -280,6 +344,14 @@ export const AppShell: Component<AppShellProps> = (props) => {
     );
     window.addEventListener(OPEN_BOUNTY_DETAIL_EVENT, handleOpenBountyDetail);
     window.addEventListener(CLOSE_BOUNTY_DETAIL_EVENT, handleCloseBountyDetail);
+    window.addEventListener(
+      OPEN_INTERVIEW_LANDING_EVENT,
+      handleOpenInterviewLanding,
+    );
+    window.addEventListener(
+      CLOSE_INTERVIEW_LANDING_EVENT,
+      handleCloseInterviewLanding,
+    );
     window.addEventListener(OPEN_CATALOG_EVENT, handleOpenCatalog);
     window.addEventListener(CLOSE_CATALOG_EVENT, handleCloseCatalog);
     window.addEventListener(OPEN_INBOX_EVENT, handleOpenInbox);
@@ -300,6 +372,14 @@ export const AppShell: Component<AppShellProps> = (props) => {
     };
     media.addEventListener("change", onSystemThemeChange);
     onCleanup(() => media.removeEventListener("change", onSystemThemeChange));
+
+    let cleanupInterviewLaunch: (() => void) | null = null;
+    void listenForInterviewLaunch((payload) => {
+      openInterviewLanding(payload.employee ?? null);
+    }).then((unlisten) => {
+      cleanupInterviewLaunch = unlisten;
+    });
+    onCleanup(() => cleanupInterviewLaunch?.());
   });
 
   // Mirror every appearance mutation to the document. Keep DOM side effects
@@ -329,6 +409,14 @@ export const AppShell: Component<AppShellProps> = (props) => {
     window.removeEventListener(
       CLOSE_BOUNTY_DETAIL_EVENT,
       handleCloseBountyDetail,
+    );
+    window.removeEventListener(
+      OPEN_INTERVIEW_LANDING_EVENT,
+      handleOpenInterviewLanding,
+    );
+    window.removeEventListener(
+      CLOSE_INTERVIEW_LANDING_EVENT,
+      handleCloseInterviewLanding,
     );
   });
 
@@ -672,60 +760,81 @@ export const AppShell: Component<AppShellProps> = (props) => {
         <ThreadSidebar
           collapsed={sidebarCollapsed()}
           onToggle={() => setSidebarCollapsed((v) => !v)}
+          onOpenCatalog={handleOpenCatalog}
+          onOpenInbox={handleOpenInbox}
         />
 
         <main class="flex-1 overflow-auto flex flex-col min-w-0">
           <Show
-            when={inboxOpen()}
+            when={interviewLandingOpen()}
             fallback={
               <Show
-                when={catalogOpen()}
+                when={inboxOpen()}
                 fallback={
                   <Show
-                    when={activeEmployeeId()}
+                    when={catalogOpen()}
                     fallback={
                       <Show
-                        when={activeBountyId()}
+                        when={activeEmployeeId()}
                         fallback={
-                          <ThreadContent onSignInClick={handleSignInClick} />
+                          <Show
+                            when={activeBountyId()}
+                            fallback={
+                              <ThreadContent
+                                onSignInClick={handleSignInClick}
+                              />
+                            }
+                          >
+                            {(id) => (
+                              <BountyDetail
+                                bountyId={id()}
+                                inheritFrom={activeBountyInheritFrom()}
+                              />
+                            )}
+                          </Show>
                         }
                       >
                         {(id) => (
-                          <BountyDetail
-                            bountyId={id()}
-                            inheritFrom={activeBountyInheritFrom()}
-                          />
+                          <Show
+                            when={
+                              employeeStore.byId(id()) === undefined &&
+                              employeeStore.archivedById(id()) !== undefined
+                            }
+                            fallback={
+                              <EmployeeDetail
+                                employeeId={id()}
+                                onClose={closeEmployeeDetailPane}
+                              />
+                            }
+                          >
+                            <ArchivedEmployeeDetail
+                              employeeId={id()}
+                              onClose={closeEmployeeDetailPane}
+                            />
+                          </Show>
                         )}
                       </Show>
                     }
                   >
-                    {(id) => (
-                      <Show
-                        when={
-                          employeeStore.byId(id()) === undefined &&
-                          employeeStore.archivedById(id()) !== undefined
-                        }
-                        fallback={
-                          <EmployeeDetail
-                            employeeId={id()}
-                            onClose={closeEmployeeDetailPane}
-                          />
-                        }
-                      >
-                        <ArchivedEmployeeDetail
-                          employeeId={id()}
-                          onClose={closeEmployeeDetailPane}
-                        />
-                      </Show>
-                    )}
+                    <CatalogList />
                   </Show>
                 }
               >
-                <CatalogList />
+                <InboxList />
               </Show>
             }
           >
-            <InboxList />
+            <InterviewLanding
+              initialEmployeeSlug={interviewEmployeeSlug()}
+              onClose={closeInterviewLanding}
+              onStartInterview={(employeeSlug) => {
+                window.dispatchEvent(
+                  new CustomEvent("seren:start-employee-interview", {
+                    detail: { employee: employeeSlug },
+                  }),
+                );
+              }}
+            />
           </Show>
         </main>
 

--- a/tests/unit/app-shell-employee-management.test.ts
+++ b/tests/unit/app-shell-employee-management.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Regression guards for temporarily hidden employee management surfaces.
-// ABOUTME: Ensures AppShell does not expose catalog/inbox buttons in the sidebar.
+// ABOUTME: Regression guards for employee management surface wiring.
+// ABOUTME: Ensures AppShell exposes catalog/inbox buttons through the sidebar.
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -15,17 +15,19 @@ const sidebarTsx = readFileSync(
 );
 
 describe("AppShell employee management wiring", () => {
-  it("does not pass catalog and inbox handlers into ThreadSidebar", () => {
+  it("passes catalog and inbox handlers into ThreadSidebar", () => {
     const threadSidebarInvocation = appShellTsx.match(
       /<ThreadSidebar[\s\S]*?\/>/,
     )?.[0];
 
     expect(threadSidebarInvocation).toBeDefined();
-    expect(threadSidebarInvocation).not.toContain("onOpenCatalog=");
-    expect(threadSidebarInvocation).not.toContain("onOpenInbox=");
+    expect(threadSidebarInvocation).toContain(
+      "onOpenCatalog={handleOpenCatalog}",
+    );
+    expect(threadSidebarInvocation).toContain("onOpenInbox={handleOpenInbox}");
   });
 
-  it("keeps ThreadSidebar support ready for the hidden buttons", () => {
+  it("keeps ThreadSidebar catalog and inbox callbacks wired", () => {
     expect(sidebarTsx).toContain("onOpenCatalog={props.onOpenCatalog}");
     expect(sidebarTsx).toContain("onOpenInbox={props.onOpenInbox}");
   });

--- a/tests/unit/interview-landing.test.ts
+++ b/tests/unit/interview-landing.test.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Guards the general Seren Employee intake landing selection rules.
+// ABOUTME: Keeps the desktop landing catalog-driven instead of deployed-employee-driven.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  catalogAssetUrl,
+  resolveInterviewEmployeeSlug,
+} from "@/components/interview/interviewLandingModel";
+
+const catalog = Array.from({ length: 15 }, (_, index) => ({
+  slug: index === 0 ? "cfo" : `role-${index}`,
+}));
+
+describe("InterviewLanding", () => {
+  it("preselects a known employee slug from deep-link context", () => {
+    expect(resolveInterviewEmployeeSlug(catalog, "cfo")).toBe("cfo");
+  });
+
+  it("falls back to the general intake when no valid context is present", () => {
+    expect(resolveInterviewEmployeeSlug(catalog, null)).toBeNull();
+    expect(resolveInterviewEmployeeSlug(catalog, "missing-role")).toBeNull();
+  });
+
+  it("keeps all 15 catalog roles available to the no-context landing", () => {
+    expect(catalog).toHaveLength(15);
+    expect(resolveInterviewEmployeeSlug(catalog, undefined)).toBeNull();
+  });
+
+  it("normalizes website asset paths for desktop rendering", () => {
+    expect(catalogAssetUrl("/employees/cfo.webp")).toBe(
+      "https://serendb.com/employees/cfo.webp",
+    );
+    expect(catalogAssetUrl("https://cdn.example/role.webp")).toBe(
+      "https://cdn.example/role.webp",
+    );
+  });
+});
+
+describe("AppShell interview landing wiring", () => {
+  const appShell = readFileSync(
+    resolve("src/components/layout/AppShell.tsx"),
+    "utf8",
+  );
+
+  it("opens the interview landing on first launch instead of the skills panel", () => {
+    expect(appShell).toContain("loadInitialInterviewLanding()");
+    expect(appShell).toContain('if (raw === null) return null');
+    expect(appShell).toContain("INTERVIEW_LANDING_DISMISSED_KEY");
+  });
+
+  it("listens for desktop interview deep links", () => {
+    expect(appShell).toContain("listenForInterviewLaunch");
+    expect(appShell).toContain("OPEN_INTERVIEW_LANDING_EVENT");
+  });
+});


### PR DESCRIPTION
Closes serenorg/seren-website#245

Depends on serenorg/seren-desktop#2489 and serenorg/seren-desktop#2490. This branch is stacked on those commits until they merge.

## Summary
- add a catalog-backed general Seren Employee intake landing
- open the landing by default on cleared first-launch storage
- wire `seren:open-interview-landing` plus Tauri `interview-launch` events, including optional employee preselection
- keep the landing on the public catalog store, separate from deployed `employees.store`

## Tests
- `pnpm test tests/unit/interview-landing.test.ts tests/unit/employee-catalog.test.ts`
- `pnpm exec biome check src/components/interview/InterviewLanding.tsx src/components/interview/interviewLandingModel.ts src/components/layout/AppShell.tsx tests/unit/interview-landing.test.ts`
- `pnpm exec tsc --noEmit --pretty false` *(repo-wide pre-existing test typing failures only; no output for `src/components/interview`, `src/components/layout/AppShell`, or `tests/unit/interview-landing`)*