### PR TITLE
feat: report employee interview telemetry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { AboutDialog } from "@/components/common/AboutDialog";
 import { LowBalanceModal } from "@/components/common/LowBalanceWarning";
 import { OrganizationOtpModal } from "@/components/common/OrganizationOtpModal";
 import { GatewayToolApproval } from "@/components/gateway/GatewayToolApproval";
+import { OPEN_INTERVIEW_LANDING_EVENT } from "@/components/interview/interviewLandingEvents";
 import { AppShell } from "@/components/layout/AppShell";
 import { X402PaymentApproval } from "@/components/mcp/X402PaymentApproval";
 import { ShellApproval } from "@/components/shell/ShellApproval";
@@ -53,8 +54,31 @@ import {
 } from "@/stores/wallet.store";
 import "./styles.css";
 
+const FIRST_AUTH_INTERVIEW_LANDING_KEY =
+  "seren:employee_intake_first_authenticated_launch";
+
 // Initialize telemetry early to capture startup errors
 telemetry.init();
+
+function claimFirstAuthenticatedInterviewLaunch(): boolean {
+  try {
+    if (localStorage.getItem(FIRST_AUTH_INTERVIEW_LANDING_KEY) === "true") {
+      return false;
+    }
+    localStorage.setItem(FIRST_AUTH_INTERVIEW_LANDING_KEY, "true");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function openFirstAuthenticatedInterviewLanding(): void {
+  window.dispatchEvent(
+    new CustomEvent(OPEN_INTERVIEW_LANDING_EVENT, {
+      detail: { source: "desktop-first-auth-launch" },
+    }),
+  );
+}
 
 function App() {
   if (shouldRenderPhase3Playground()) {
@@ -183,6 +207,9 @@ function App() {
 
       // Use untrack to prevent reactive dependencies
       untrack(() => {
+        if (claimFirstAuthenticatedInterviewLaunch()) {
+          queueMicrotask(openFirstAuthenticatedInterviewLanding);
+        }
         startAutoRefresh();
         autocompleteStore.enable();
         // Store cleanup to prevent effect accumulation

--- a/src/components/interview/InterviewLanding.tsx
+++ b/src/components/interview/InterviewLanding.tsx
@@ -15,18 +15,19 @@ import {
   clusterLabel,
   resolveInterviewEmployeeSlug,
 } from "@/components/interview/interviewLandingModel";
+
+export {
+  CLOSE_INTERVIEW_LANDING_EVENT,
+  type InterviewLandingEventDetail,
+  OPEN_INTERVIEW_LANDING_EVENT,
+} from "@/components/interview/interviewLandingEvents";
+
 import { employeeCatalogStore } from "@/stores/employee-catalog.store";
-
-export const OPEN_INTERVIEW_LANDING_EVENT = "seren:open-interview-landing";
-export const CLOSE_INTERVIEW_LANDING_EVENT = "seren:close-interview-landing";
-
-export type InterviewLandingEventDetail = {
-  employee?: string | null;
-};
 
 interface InterviewLandingProps {
   initialEmployeeSlug?: string | null;
   onClose?: () => void;
+  onSelectEmployee?: (employeeSlug: string) => void;
   onStartInterview?: (employeeSlug: string | null) => void;
 }
 
@@ -205,7 +206,10 @@ export const InterviewLanding: Component<InterviewLandingProps> = (props) => {
                     }}
                     data-testid="interview-role-option"
                     aria-pressed={active()}
-                    onClick={() => setSelectedSlug(employee.slug)}
+                    onClick={() => {
+                      setSelectedSlug(employee.slug);
+                      props.onSelectEmployee?.(employee.slug);
+                    }}
                   >
                     <div class="relative h-24 overflow-hidden bg-surface-2">
                       <img

--- a/src/components/interview/interviewLandingEvents.ts
+++ b/src/components/interview/interviewLandingEvents.ts
@@ -1,0 +1,10 @@
+// ABOUTME: Shared event names for the general Seren Employee intake landing.
+// ABOUTME: Lets startup and shell wiring open the landing without importing TSX.
+
+export const OPEN_INTERVIEW_LANDING_EVENT = "seren:open-interview-landing";
+export const CLOSE_INTERVIEW_LANDING_EVENT = "seren:close-interview-landing";
+
+export type InterviewLandingEventDetail = {
+  employee?: string | null;
+  source?: string;
+};

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -19,12 +19,12 @@ import { CatalogList } from "@/components/catalog/CatalogList";
 import { ArchivedEmployeeDetail } from "@/components/employees/ArchivedEmployeeDetail";
 import { EmployeeDetail } from "@/components/employees/EmployeeDetail";
 import { InboxList } from "@/components/inbox/InboxList";
+import { InterviewLanding } from "@/components/interview/InterviewLanding";
 import {
   CLOSE_INTERVIEW_LANDING_EVENT,
-  InterviewLanding,
   type InterviewLandingEventDetail,
   OPEN_INTERVIEW_LANDING_EVENT,
-} from "@/components/interview/InterviewLanding";
+} from "@/components/interview/interviewLandingEvents";
 import { ThreadSidebar } from "@/components/layout/ThreadSidebar";
 import { AudioPrimingDialog } from "@/components/meeting/AudioPrimingDialog";
 import { MeetingPanel } from "@/components/meeting/MeetingPanel";
@@ -54,6 +54,7 @@ import { isMeetingProcessingStatus } from "@/lib/meeting-format";
 import { shortcuts } from "@/lib/shortcuts";
 import type { InstalledSkill } from "@/lib/skills";
 import { listenForInterviewLaunch } from "@/lib/tauri-bridge";
+import { telemetry } from "@/services/telemetry";
 import {
   appearanceState,
   applyAppearanceToDocument,
@@ -192,7 +193,22 @@ export const AppShell: Component<AppShellProps> = (props) => {
     persistSlidePanel(slidePanel());
   });
 
-  const openInterviewLanding = (employeeSlug?: string | null) => {
+  const reportInterviewInterest = (
+    employeeSlug: string | null,
+    source: string,
+    event = "interview-launched",
+  ) => {
+    void telemetry.recordEmployeeInterest({
+      employeeSlug,
+      event,
+      source,
+    });
+  };
+
+  const openInterviewLanding = (
+    employeeSlug?: string | null,
+    source?: string,
+  ) => {
     setInterviewEmployeeSlug(employeeSlug ?? null);
     setInterviewLandingOpen(true);
     setActiveEmployeeId(null);
@@ -203,11 +219,14 @@ export const AppShell: Component<AppShellProps> = (props) => {
     }
     setCatalogOpen(false);
     setInboxOpen(false);
+    if (source) {
+      reportInterviewInterest(employeeSlug ?? null, source);
+    }
   };
 
   const handleOpenInterviewLanding = (event: Event) => {
     const detail = (event as CustomEvent<InterviewLandingEventDetail>).detail;
-    openInterviewLanding(detail?.employee ?? null);
+    openInterviewLanding(detail?.employee ?? null, detail?.source);
   };
 
   const closeInterviewLanding = () => {
@@ -375,7 +394,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
 
     let cleanupInterviewLaunch: (() => void) | null = null;
     void listenForInterviewLaunch((payload) => {
-      openInterviewLanding(payload.employee ?? null);
+      openInterviewLanding(payload.employee ?? null, "desktop-deep-link");
     }).then((unlisten) => {
       cleanupInterviewLaunch = unlisten;
     });
@@ -827,7 +846,19 @@ export const AppShell: Component<AppShellProps> = (props) => {
             <InterviewLanding
               initialEmployeeSlug={interviewEmployeeSlug()}
               onClose={closeInterviewLanding}
+              onSelectEmployee={(employeeSlug) => {
+                reportInterviewInterest(
+                  employeeSlug,
+                  "desktop-role-selection",
+                  "role-selected",
+                );
+              }}
               onStartInterview={(employeeSlug) => {
+                reportInterviewInterest(
+                  employeeSlug,
+                  "desktop-interview-start",
+                  "interview-started",
+                );
                 window.dispatchEvent(
                   new CustomEvent("seren:start-employee-interview", {
                     detail: { employee: employeeSlug },

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -33,6 +33,40 @@ const DEFAULT_CONFIG: TelemetryConfig = {
   maxBatchSize: 20,
 };
 
+export interface EmployeeInterestTelemetryInput {
+  employeeSlug?: string | null;
+  event?: string;
+  source: string;
+}
+
+export interface EmployeeInterestTelemetryPayload {
+  selected_employee_slug: string | null;
+  event: string;
+  source: string;
+  occurred_at: string;
+}
+
+const SEREN_WEBSITE_ORIGIN =
+  import.meta.env.VITE_SEREN_WEBSITE_URL ?? "https://serendb.com";
+
+export function websiteApiUrl(path: string): string {
+  return `${SEREN_WEBSITE_ORIGIN.replace(/\/$/, "")}${
+    path.startsWith("/") ? path : `/${path}`
+  }`;
+}
+
+export function buildEmployeeInterestTelemetryPayload(
+  input: EmployeeInterestTelemetryInput,
+  now = new Date(),
+): EmployeeInterestTelemetryPayload {
+  return {
+    selected_employee_slug: input.employeeSlug ?? null,
+    event: input.event ?? "interview-launched",
+    source: input.source,
+    occurred_at: now.toISOString(),
+  };
+}
+
 class TelemetryService {
   private config: TelemetryConfig;
   private rateLimiter: RateLimiter;
@@ -115,6 +149,30 @@ class TelemetryService {
    */
   reportError(error: Error, context?: Record<string, unknown>): void {
     this.captureError(error, context);
+  }
+
+  async recordEmployeeInterest(
+    input: EmployeeInterestTelemetryInput,
+  ): Promise<void> {
+    if (!this.config.enabled) return;
+
+    try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      const token = await getToken();
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+
+      await appFetch(websiteApiUrl("/api/telemetry/employee-interest"), {
+        method: "POST",
+        headers,
+        body: JSON.stringify(buildEmployeeInterestTelemetryPayload(input)),
+      });
+    } catch {
+      // Product telemetry is best-effort and must never block the intake.
+    }
   }
 
   /**

--- a/tests/unit/employee-interview-telemetry.test.ts
+++ b/tests/unit/employee-interview-telemetry.test.ts
@@ -1,0 +1,55 @@
+// ABOUTME: Tests general Seren Employee intake telemetry payloads.
+// ABOUTME: Guards against reintroducing per-employee interview-intent state.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildEmployeeInterestTelemetryPayload,
+  websiteApiUrl,
+} from "@/services/telemetry";
+
+describe("employee interview telemetry", () => {
+  it("builds a general interview-launched payload with optional role context", () => {
+    expect(
+      buildEmployeeInterestTelemetryPayload(
+        {
+          employeeSlug: "ciso",
+          source: "desktop-deep-link",
+        },
+        new Date("2026-06-17T01:00:00.000Z"),
+      ),
+    ).toEqual({
+      selected_employee_slug: "ciso",
+      event: "interview-launched",
+      source: "desktop-deep-link",
+      occurred_at: "2026-06-17T01:00:00.000Z",
+    });
+  });
+
+  it("keeps no-context launches general", () => {
+    expect(
+      buildEmployeeInterestTelemetryPayload({
+        employeeSlug: null,
+        event: "role-selected",
+        source: "desktop-role-selection",
+      }).selected_employee_slug,
+    ).toBeNull();
+  });
+
+  it("targets the website telemetry API", () => {
+    expect(websiteApiUrl("/api/telemetry/employee-interest")).toBe(
+      "https://serendb.com/api/telemetry/employee-interest",
+    );
+  });
+
+  it("does not add interview-intent fetch wiring", () => {
+    const app = readFileSync(resolve("src/App.tsx"), "utf8");
+    const shell = readFileSync(resolve("src/components/layout/AppShell.tsx"), "utf8");
+
+    expect(app).not.toContain("interview-intent");
+    expect(shell).not.toContain("interview-intent");
+    expect(app).toContain("OPEN_INTERVIEW_LANDING_EVENT");
+    expect(shell).toContain("recordEmployeeInterest");
+  });
+});


### PR DESCRIPTION
Closes serenorg/seren-website#247

Depends on serenorg/seren-desktop#2491. This branch is stacked until #243/#244/#245 land.

## Summary
- open the general interview landing once on first authenticated launch
- report best-effort employee-interest telemetry for deep-link opens, role selection, and interview start
- target the website telemetry API without adding per-employee `interview-intent` fetch/state

## Tests
- `pnpm test tests/unit/interview-landing.test.ts tests/unit/employee-catalog.test.ts tests/unit/employee-interview-telemetry.test.ts`
- `pnpm exec biome check src/App.tsx src/components/interview/InterviewLanding.tsx src/components/interview/interviewLandingEvents.ts src/components/interview/interviewLandingModel.ts src/components/layout/AppShell.tsx src/services/telemetry.ts tests/unit/interview-landing.test.ts tests/unit/employee-interview-telemetry.test.ts`
- TypeScript audit: `pnpm exec tsc --noEmit --pretty false ... | rg <new-file-patterns>` produced no output; full `tsc` still has unrelated pre-existing test typing failures.