### PR TITLE
feat: show employee intake on startup without auto-opening bounties

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -87,7 +87,6 @@ export type SlidePanelView =
   | null;
 
 const SLIDE_PANEL_KEY = "seren:slide_panel";
-const INTERVIEW_LANDING_DISMISSED_KEY = "seren:interview_landing_dismissed";
 
 const PERSISTABLE_VIEWS: ReadonlySet<NonNullable<SlidePanelView>> = new Set([
   "settings",
@@ -112,20 +111,12 @@ function loadInitialSlidePanel(): SlidePanelView {
   return null;
 }
 
+// Strong startup default: the Seren Employee intake landing is the canonical
+// startup surface. Closing it is session-only — the next launch shows it
+// again. This intentionally ignores the legacy
+// `seren:interview_landing_dismissed` key.
 function loadInitialInterviewLanding(): boolean {
-  try {
-    return localStorage.getItem(INTERVIEW_LANDING_DISMISSED_KEY) !== "true";
-  } catch {
-    return true;
-  }
-}
-
-function persistInterviewLandingDismissed(): void {
-  try {
-    localStorage.setItem(INTERVIEW_LANDING_DISMISSED_KEY, "true");
-  } catch {
-    // Non-fatal
-  }
+  return true;
 }
 
 function persistSlidePanel(view: SlidePanelView): void {
@@ -232,14 +223,12 @@ export const AppShell: Component<AppShellProps> = (props) => {
   const closeInterviewLanding = () => {
     setInterviewLandingOpen(false);
     setInterviewEmployeeSlug(null);
-    persistInterviewLandingDismissed();
     window.dispatchEvent(new CustomEvent(CLOSE_INTERVIEW_LANDING_EVENT));
   };
 
   const handleCloseInterviewLanding = () => {
     setInterviewLandingOpen(false);
     setInterviewEmployeeSlug(null);
-    persistInterviewLandingDismissed();
   };
 
   const handleOpenEmployeeDetail = (event: Event) => {

--- a/src/components/sidebar/BountiesSection.tsx
+++ b/src/components/sidebar/BountiesSection.tsx
@@ -4,7 +4,6 @@
 import { createQuery } from "@tanstack/solid-query";
 import {
   type Component,
-  createEffect,
   createMemo,
   createSignal,
   For,
@@ -172,7 +171,6 @@ const BountyRow: Component<{
 export const BountiesSection: Component = () => {
   const [collapsed, setCollapsed] = createSignal(false);
   const [activeId, setActiveId] = createSignal<string | null>(null);
-  const [autoOpenedDefault, setAutoOpenedDefault] = createSignal(false);
 
   const handleSelectBounty = (bountyId: string) => {
     // Snapshot the active thread's binding BEFORE clearing the active
@@ -261,13 +259,6 @@ export const BountiesSection: Component = () => {
       .sort((a, b) => createdAtTime(b.createdAt) - createdAtTime(a.createdAt)),
   );
 
-  createEffect(() => {
-    if (autoOpenedDefault() || activeId() || threadStore.activeThreadId) return;
-    const bounty = activeBounties()[0];
-    if (!bounty) return;
-    setAutoOpenedDefault(true);
-    handleSelectBounty(bounty.id);
-  });
   const errorMessage = createMemo(() =>
     bountiesQuery.error instanceof Error
       ? bountiesQuery.error.message

--- a/tests/unit/bounties-wiring.test.ts
+++ b/tests/unit/bounties-wiring.test.ts
@@ -13,6 +13,14 @@ const bountyDetailTsx = readFileSync(
   resolve("src/components/bounties/BountyDetail.tsx"),
   "utf-8",
 );
+const bountiesSectionTsx = readFileSync(
+  resolve("src/components/sidebar/BountiesSection.tsx"),
+  "utf-8",
+);
+const threadSidebarTsx = readFileSync(
+  resolve("src/components/layout/ThreadSidebar.tsx"),
+  "utf-8",
+);
 
 function functionBody(name: string, source: string): string {
   const match = source.match(
@@ -47,5 +55,24 @@ describe("Seren Bounties wiring", () => {
     expect(bountyDetailTsx).toMatch(
       /s\.scope === "seren" &&\s+s\.slug === SEREN_BOUNTY_SLUG/,
     );
+  });
+
+  it("does not auto-dispatch OPEN_BOUNTY_DETAIL_EVENT on load", () => {
+    // The sidebar must not auto-open the newest active bounty on startup.
+    // Strong startup default is the Seren Employee intake landing; explicit
+    // user selection is the only path to opening a bounty.
+    expect(bountiesSectionTsx).not.toContain("autoOpenedDefault");
+    expect(bountiesSectionTsx).not.toContain("setAutoOpenedDefault");
+    // Guard: the only place dispatching OPEN_BOUNTY_DETAIL_EVENT must be
+    // `handleSelectBounty`, which is only reachable via user click.
+    expect(bountiesSectionTsx).not.toMatch(/createEffect\([^)]*handleSelectBounty/);
+  });
+
+  it("renders EmployeesSection before BountiesSection in the sidebar", () => {
+    const employeesIdx = threadSidebarTsx.indexOf("<EmployeesSection");
+    const bountiesIdx = threadSidebarTsx.indexOf("<BountiesSection");
+    expect(employeesIdx).toBeGreaterThanOrEqual(0);
+    expect(bountiesIdx).toBeGreaterThanOrEqual(0);
+    expect(employeesIdx).toBeLessThan(bountiesIdx);
   });
 });

--- a/tests/unit/interview-landing.test.ts
+++ b/tests/unit/interview-landing.test.ts
@@ -44,10 +44,15 @@ describe("AppShell interview landing wiring", () => {
     "utf8",
   );
 
-  it("opens the interview landing on first launch instead of the skills panel", () => {
+  it("uses a strong startup default for the interview landing", () => {
     expect(appShell).toContain("loadInitialInterviewLanding()");
-    expect(appShell).toContain('if (raw === null) return null');
-    expect(appShell).toContain("INTERVIEW_LANDING_DISMISSED_KEY");
+    // Strong default: the loader returns `true` unconditionally and does not
+    // consult the legacy persistent-dismissal key. Closing is session-only.
+    expect(appShell).toMatch(
+      /function loadInitialInterviewLanding\(\): boolean \{[\s\S]*?return true;[\s\S]*?\}/,
+    );
+    expect(appShell).not.toContain("INTERVIEW_LANDING_DISMISSED_KEY");
+    expect(appShell).not.toContain("persistInterviewLandingDismissed");
   });
 
   it("listens for desktop interview deep links", () => {


### PR DESCRIPTION
## Summary
Closes #2495.

- Disables the Bounties auto-open on startup: removed the `createEffect` in `BountiesSection` that selected `activeBounties()[0]` and dispatched `OPEN_BOUNTY_DETAIL_EVENT`. Bounties are still rendered in the sidebar; explicit user click remains the only path to `BountyDetail`.
- Makes Seren Employee intake the strong startup default: `loadInitialInterviewLanding()` now always returns `true`. Dropped the legacy `seren:interview_landing_dismissed` key and the `persistInterviewLandingDismissed()` helper so closing the landing is session-only — the next launch shows it again.
- Mutual-exclusion behavior in `AppShell` is unchanged: opening employee detail/catalog/inbox still closes bounty detail; opening a bounty still closes interview landing + employee detail/catalog/inbox.

## P0/P1 audit on the proposed fix
- **P0**: the issue's proposed strong default would have regressed on the first close if we only flipped `loadInitialInterviewLanding`. The two close handlers still wrote `seren:interview_landing_dismissed=true` via `persistInterviewLandingDismissed()`, and the legacy load path would honor it on next launch. Removed both the helper and the constant to make session-only close real and to remove dead code.
- **P1**: existing `interview-landing.test.ts` asserted `INTERVIEW_LANDING_DISMISSED_KEY` was still present in `AppShell.tsx`. Updated the assertion set to match the new shape (strong startup default + no persistent-dismissal references).

## Test plan
- [x] `npx vitest run` — 1842 / 1842 pass
- [x] `npx tsc --noEmit` — no new errors in changed files (pre-existing TS errors in unrelated test files only)
- [x] `npx biome check` on changed files — clean
- [x] Unit guards added: `BountiesSection` does not auto-dispatch `OPEN_BOUNTY_DETAIL_EVENT`; `ThreadSidebar` renders `EmployeesSection` before `BountiesSection`

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
