### PR TITLE
fix(chat): restore agent history when no live session (#2499)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -441,6 +441,20 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
   });
 
+  // Hydrate the durable transcript from SQLite whenever the viewed thread has
+  // no live session messages to show. Without this, reopening an agent thread
+  // before its session re-spawns (cold start, idle-reclaim, spawn thrash)
+  // leaves the panel blank even though the history is on disk. Re-runs on
+  // thread switch and on session presence change. #2499.
+  createEffect(() => {
+    const thread = activeAgentThread();
+    if (!thread) return;
+    const session = threadSession();
+    if (!session || session.messages.length === 0) {
+      void agentStore.hydratePersistedHistory(thread.id);
+    }
+  });
+
   const forkSupported = createMemo(() => {
     const session = threadSession();
     if (!session) return false;

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1543,6 +1543,15 @@ interface AgentState {
   sessions: Record<string, ActiveSession>;
   /** Per-thread runtime state keyed by conversationId (#1631). */
   threadStates: Record<string, ThreadRuntimeState>;
+  /**
+   * Durable transcript fallback keyed by conversationId, hydrated from the
+   * SQLite `messages` table when a thread is viewed without a live session.
+   * Lets an agent thread render its history on cold start, after an
+   * idle-reclaim, or mid-spawn instead of showing blank. Live
+   * `session.messages` take precedence once a session owns the transcript.
+   * #2499.
+   */
+  persistedMessages: Record<string, AgentMessage[]>;
   /** Currently focused session ID */
   activeSessionId: string | null;
   /** Selected agent type for new sessions */
@@ -1609,6 +1618,7 @@ const [state, setState] = createStore<AgentState>({
   availableAgents: [],
   sessions: {},
   threadStates: {},
+  persistedMessages: {},
   activeSessionId: null,
   selectedAgentType: "claude-code",
   recentAgentConversations: [],
@@ -1991,7 +2001,38 @@ export const agentStore = {
     const session = Object.values(state.sessions).find(
       (s) => s.conversationId === conversationId,
     );
-    return session?.messages ?? [];
+    if (session && session.messages.length > 0) {
+      return session.messages;
+    }
+    // No live session yet (cold start, idle-reclaim, mid-spawn) or it has not
+    // hydrated: fall back to the durable transcript so the thread never renders
+    // blank. Populated by hydratePersistedHistory. #2499.
+    return state.persistedMessages[conversationId] ?? [];
+  },
+
+  /**
+   * Load this thread's durable transcript from SQLite into the
+   * `persistedMessages` fallback when no live session owns it, so an agent
+   * thread renders its history immediately instead of blank. Reads fresh on
+   * every call where no session has messages, so the fallback cannot go stale
+   * after an idle-reclaim. No-op (and drops any stale fallback) once a live
+   * session has messages — that source is authoritative. #2499.
+   */
+  async hydratePersistedHistory(conversationId: string): Promise<void> {
+    const ownsTranscript = (id: string): boolean => {
+      const session = this.getSessionForConversation(id);
+      return !!session && session.messages.length > 0;
+    };
+    if (ownsTranscript(conversationId)) {
+      if (state.persistedMessages[conversationId]) {
+        setState("persistedMessages", conversationId, undefined as never);
+      }
+      return;
+    }
+    const { messages } = await loadPersistedAgentHistory(conversationId);
+    // A session may have hydrated while awaiting the read; don't clobber it.
+    if (ownsTranscript(conversationId)) return;
+    setState("persistedMessages", conversationId, messages);
   },
 
   /**

--- a/tests/unit/agent-history-persistence.test.ts
+++ b/tests/unit/agent-history-persistence.test.ts
@@ -10,6 +10,11 @@ const agentStoreSource = readFileSync(
   "utf-8",
 );
 
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
 describe("agent message persistence guards", () => {
   it("persistAgentMessage only stores user, assistant, and handoff types", () => {
     const fnStart = agentStoreSource.indexOf(
@@ -220,5 +225,55 @@ describe("#1663 — agent thread history must not be wiped on resume or send", (
     expect(slice).toContain(
       "clearConversationHistory(session.conversationId)",
     );
+  });
+});
+
+describe("#2499 — agent thread transcript must fall back to durable history when no live session", () => {
+  it("getMessagesForConversation falls back to the persistedMessages cache, not just live session.messages", () => {
+    const fnIdx = agentStoreSource.indexOf(
+      "getMessagesForConversation(conversationId: string): AgentMessage[]",
+    );
+    expect(fnIdx).toBeGreaterThan(0);
+    const fnBody = agentStoreSource.slice(fnIdx, fnIdx + 600);
+    // Live session wins when it owns the transcript...
+    expect(fnBody).toContain("session.messages.length > 0");
+    // ...otherwise the durable cache is the source so the panel is never blank.
+    expect(fnBody).toContain("state.persistedMessages[conversationId]");
+    // The old blank-prone implementation returned bare session messages.
+    expect(fnBody).not.toMatch(/return\s+session\?\.messages\s*\?\?\s*\[\];/);
+  });
+
+  it("persistedMessages is part of agent store state and initialized", () => {
+    expect(agentStoreSource).toContain(
+      "persistedMessages: Record<string, AgentMessage[]>;",
+    );
+    expect(agentStoreSource).toContain("persistedMessages: {},");
+  });
+
+  it("hydratePersistedHistory loads from SQLite, respects live-session precedence, and re-reads fresh", () => {
+    const fnIdx = agentStoreSource.indexOf(
+      "async hydratePersistedHistory(conversationId: string)",
+    );
+    expect(fnIdx).toBeGreaterThan(0);
+    const fnBody = agentStoreSource.slice(fnIdx, fnIdx + 900);
+    // Reads the durable transcript from SQLite.
+    expect(fnBody).toContain("loadPersistedAgentHistory(conversationId)");
+    // Writes into the fallback cache.
+    expect(fnBody).toContain('setState("persistedMessages", conversationId');
+    // Does not clobber a live session that already owns the transcript
+    // (guarded both before and after the awaited read).
+    expect(fnBody).toContain("ownsTranscript");
+  });
+
+  it("AgentChat hydrates the durable transcript when the viewed thread has no live session", () => {
+    expect(agentChatSource).toContain(
+      "agentStore.hydratePersistedHistory(thread.id)",
+    );
+    // The hydrate must trigger only when there is no live transcript to show.
+    const callIdx = agentChatSource.indexOf(
+      "agentStore.hydratePersistedHistory(thread.id)",
+    );
+    const window = agentChatSource.slice(callIdx - 220, callIdx);
+    expect(window).toContain("session.messages.length === 0");
   });
 });


### PR DESCRIPTION
## What

Fixes #2499 — agent threads rendered a **blank transcript** (perceived as lost chat history) whenever there was no live provider session for the thread: cold app start, after the "Reclaiming idle Claude session before spawn" SIGTERM reclaim (`code=143`), or during spawn thrash.

## Root cause

`AgentChat` reads its transcript from ephemeral live-session state only (`getMessagesForConversation` → `session?.messages ?? []`). Persisted history (the durable SQLite `messages` table) was only loaded into `session.messages` during a spawn, and there is no auto-resume on mount — so viewing a thread without a hydrated live session showed nothing, even though `get_messages` returns the rows fine.

## Fix (display layer, durable source of truth)

- `agent.store.ts`: new `persistedMessages` cache + `hydratePersistedHistory(conversationId)` that loads from the SQLite `messages` table when no live session owns the transcript (re-reads fresh so it can't go stale after a reclaim; drops stale cache once a live session owns the transcript).
- `getMessagesForConversation`: prefer non-empty live `session.messages`, else fall back to the persisted cache.
- `AgentChat.tsx`: hydrate the durable transcript whenever the viewed thread has no live session messages.

This deliberately does **not** touch `DERIVED_KIND_CASE_SQL` — cross-category provider routing (a chat thread bound to a CLI model rendering in the agent shell) is intended behavior. The bug was purely that the agent shell had no durable read path.

## Tests

`tests/unit/agent-history-persistence.test.ts` — 4 focused guard tests pinning the durable-fallback invariant (getter fallback, store state, hydrate semantics, AgentChat trigger). Full related suite green:

```
agent-history-persistence, agent-invisible-restart, conversation-store,
thread-store, chat-empties-after-login-2097 → 86 passed
```
Biome clean; typecheck clean for changed files (pre-existing unrelated test-file tsc baseline untouched).

## Impact / platforms

P0 core-flow regression. macOS + Windows (display-layer logic, platform-agnostic).
