### PR TITLE
fix: surface SerenDB memory provisioning failures (#2497)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -309,8 +309,11 @@ function App() {
         }
         claudeMemoryStartedForAuth = key;
 
-        const { startClaudeMemoryInterceptor, migrateExistingClaudeMemory } =
-          await import("@/services/claudeMemory");
+        const {
+          startClaudeMemoryInterceptor,
+          migrateExistingClaudeMemory,
+          classifyMemoryStartFailure,
+        } = await import("@/services/claudeMemory");
         const { message: showMessageDialog } = await import(
           "@tauri-apps/plugin-dialog"
         );
@@ -362,10 +365,11 @@ function App() {
           const errMessage = err instanceof Error ? err.message : String(err);
           const errStack =
             err instanceof Error && err.stack ? err.stack.split("\n") : [];
-          const httpStatusMatch = /returned HTTP (\d{3})/i.exec(errMessage);
-          const httpStatusCode = httpStatusMatch?.[1]
-            ? Number.parseInt(httpStatusMatch[1], 10)
-            : undefined;
+          // Classify the failure once: `notice.status` drives telemetry and
+          // `notice.message` is the body-free, actionable dialog copy. The raw
+          // server body still flows to telemetry (below) but is NEVER shown to
+          // the user — a 401/403 can carry a permission payload. #2497 Defect 3.
+          const notice = classifyMemoryStartFailure(err);
           try {
             const { captureSupportError } = await import("@/lib/support/hook");
             void captureSupportError({
@@ -375,7 +379,7 @@ function App() {
               http: {
                 method: "POST",
                 url: "https://api.serendb.com/publishers/seren-db/query",
-                status: httpStatusCode,
+                status: notice.status,
                 body: errMessage,
               },
             });
@@ -385,9 +389,7 @@ function App() {
               `[ClaudeMemory] captureSupportError unavailable: ${captureErr}`,
             );
           }
-          await notifyUser(
-            `The Claude memory interceptor could not start: ${err}. You can try again by toggling it off and on in Settings → Code Indexing → Claude Code Auto-Memory.`,
-          );
+          await notifyUser(notice.message);
         }
       } catch (error) {
         console.error(`[ClaudeMemory] reactive start crashed: ${error}`);

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -11,6 +11,7 @@ import {
   Show,
 } from "solid-js";
 import { isBuiltinServer, isLocalServer } from "@/lib/mcp/types";
+import { type BuildInfo, getBuildInfo } from "@/services/buildInfo";
 import {
   getClaudeMemoryStatus,
   migrateExistingClaudeMemory,
@@ -89,6 +90,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
 
   // Claude Code auto-memory interceptor state. The watcher lives in Rust;
   // the panel only reflects its current status and exposes the controls.
+  const [buildInfo, setBuildInfo] = createSignal<BuildInfo | null>(null);
   const [claudeMemoryRunning, setClaudeMemoryRunning] = createSignal(false);
   const [claudeMemoryWatchingRoot, setClaudeMemoryWatchingRoot] = createSignal<
     string | null
@@ -422,6 +424,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
       handleOpenSection as EventListener,
     );
     void refreshClaudeMemoryStatus();
+    void getBuildInfo().then(setBuildInfo);
   });
 
   onCleanup(() => {
@@ -2188,6 +2191,25 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
             <p class="m-0 mb-6 text-muted-foreground leading-normal">
               Configure application behavior and privacy options.
             </p>
+
+            <Show when={buildInfo()}>
+              {(info) => (
+                <div class="flex items-center justify-between py-3 border-b border-border">
+                  <span class="flex flex-col gap-0.5">
+                    <span class="text-[0.95rem] font-medium text-foreground">
+                      Version
+                    </span>
+                    <span class="text-[0.8rem] text-muted-foreground">
+                      The Seren build currently running — include this when
+                      reporting an issue
+                    </span>
+                  </span>
+                  <span class="text-[0.85rem] font-mono text-muted-foreground text-right break-all">
+                    {info().app_version}
+                  </span>
+                </div>
+              )}
+            </Show>
 
             <div class="flex items-start justify-start gap-4 py-3 border-b border-border">
               <label class="flex items-start gap-3 cursor-pointer">

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -276,11 +276,26 @@ export { getToken };
 const DESKTOP_API_KEY_NAME = "Seren Desktop";
 
 /**
+ * Thrown when provisioning the SerenDB desktop API key fails. Carries the HTTP
+ * `status` so the auth store can distinguish a non-transient auth/permission
+ * failure (401/403 → re-sign-in) from a retryable one (5xx/network → keep the
+ * session, chat still works on the JWT). See #2497.
+ */
+export class ApiKeyProvisioningError extends Error {
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "ApiKeyProvisioningError";
+    this.status = status;
+  }
+}
+
+/**
  * Create a new API key for MCP authentication.
  * Uses POST /organizations/default/api-keys, which resolves "default" to
  * the user's first organization.
  * @returns API key (seren_xxx_yyy format)
- * @throws Error if not authenticated or request fails
+ * @throws ApiKeyProvisioningError if not authenticated or the request fails
  */
 export async function createApiKey(): Promise<string> {
   const { data, error, response } = await createDefaultOrgApiKey({
@@ -289,6 +304,7 @@ export async function createApiKey(): Promise<string> {
   });
 
   if (error || !data?.data) {
+    const status = response?.status;
     let message = "Failed to create API key";
     try {
       const parsed = (await response?.clone().json()) as Partial<AuthError>;
@@ -298,7 +314,14 @@ export async function createApiKey(): Promise<string> {
     } catch {
       // Non-JSON body — fall back to default message.
     }
-    throw new Error(message);
+    // Carry the HTTP status both as a property (so callers can branch on
+    // 401/403 vs 5xx without regex) and in the message via the same
+    // `returned HTTP <status>` marker App.tsx already parses. Without this,
+    // downstream telemetry/dialogs can't tell a non-transient auth/permission
+    // failure from a retryable one. #2497.
+    const statusSuffix =
+      typeof status === "number" ? ` (returned HTTP ${status})` : "";
+    throw new ApiKeyProvisioningError(`${message}${statusSuffix}`, status);
   }
 
   return data.data.api_key;

--- a/src/services/buildInfo.ts
+++ b/src/services/buildInfo.ts
@@ -1,0 +1,35 @@
+// ABOUTME: Service wrapper for the native build/version info Tauri command.
+// ABOUTME: Lets UI surface the app version without calling invoke directly.
+
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+
+export interface BuildInfo {
+  app_version: string;
+  release_tag: string;
+  commit: string;
+  build_date: string;
+  build_type: string;
+  tauri_version: string;
+  webview: string;
+  rust_version: string;
+  os: string;
+}
+
+/**
+ * Read the native build info (version, release tag, commit, …). Returns null in
+ * the browser fallback runtime, where the `get_build_info` Tauri command does
+ * not exist. See #2497 — exposes the version in Settings → General so users can
+ * report which build they are on.
+ */
+export async function getBuildInfo(): Promise<BuildInfo | null> {
+  if (!isTauriRuntime()) {
+    return null;
+  }
+  try {
+    return await invoke<BuildInfo>("get_build_info");
+  } catch (error) {
+    console.warn("[BuildInfo] Failed to read build info:", error);
+    return null;
+  }
+}

--- a/src/services/claudeMemory.ts
+++ b/src/services/claudeMemory.ts
@@ -227,6 +227,61 @@ export interface InterceptFailureEvent {
 }
 
 /**
+ * A user-facing notice for a failed interceptor start. `status` is the parsed
+ * HTTP status (for telemetry); `message` is body-free copy safe to show in a
+ * dialog.
+ */
+export interface MemoryStartFailureNotice {
+  status: number | undefined;
+  message: string;
+}
+
+/**
+ * Map a Claude-memory interceptor start failure to an actionable, body-free
+ * user notice. Branches on the failure class so a non-transient auth/permission
+ * failure (401/403) reads differently from a retryable one, and so the dialog
+ * never echoes raw server bodies (which can include an HTTP 403 payload). The
+ * status is parsed from the `returned HTTP <status>` marker that both the Rust
+ * `run_sql` formatter and the seren-db service errors emit. #2497 Defect 3.
+ */
+export function classifyMemoryStartFailure(
+  error: unknown,
+): MemoryStartFailureNotice {
+  const raw = error instanceof Error ? error.message : String(error);
+  const statusMatch = /returned HTTP (\d{3})/i.exec(raw);
+  const status = statusMatch?.[1]
+    ? Number.parseInt(statusMatch[1], 10)
+    : undefined;
+
+  // Auth/permission failure — not transient. "Toggle it off and on" won't help.
+  if (status === 401 || status === 403) {
+    return {
+      status,
+      message:
+        "Seren couldn't authorize memory storage for your account. This usually means your account is still finishing setup. Sign out and back in, or try again in a few minutes. If it keeps happening, contact support.",
+    };
+  }
+
+  // The desktop API key hasn't landed yet — a transient provisioning failure
+  // upstream kept the session but left no key. Re-authenticating re-mints it.
+  if (/api key not available/i.test(raw)) {
+    return {
+      status,
+      message:
+        "Seren is still finishing your account setup, so memory storage isn't ready yet. Sign out and back in, or try again shortly.",
+    };
+  }
+
+  // Everything else (5xx, 408, gateway timeout, network, cold-start exhaustion)
+  // is transient and self-heals on the next memory write.
+  return {
+    status,
+    message:
+      "Seren couldn't reach memory storage just now. It will retry automatically on the next memory write — you can also retry from Settings → Code Indexing → Claude Code Auto-Memory.",
+  };
+}
+
+/**
  * Resolve the SerenDB project + branch + database the Claude memory
  * interceptor should write to. Auto-creates anything missing on first run
  * and persists the resolved IDs to settings so subsequent runs reuse them.

--- a/src/services/databases.ts
+++ b/src/services/databases.ts
@@ -33,6 +33,39 @@ export type Database = DatabaseWithOwner;
 export type { Branch, Organization, Project };
 
 /**
+ * Format a seren-db management-call failure so it carries the HTTP status (and
+ * any short server detail) using the same `returned HTTP <status>` marker the
+ * Rust SQL client emits. Without this, a 403 on the seren-db management path
+ * (most likely on `createProject` for a brand-new user) reaches the Claude
+ * memory interceptor as an opaque "Failed to X" — defeating the App.tsx dialog
+ * classifier and the support telemetry that seren-core#187 needs to correlate
+ * the 403. The status drives downstream classification; raw bodies are never
+ * shown to the user. #2497 (NEW P1-b).
+ */
+function describeSerenDbError(
+  action: string,
+  error: unknown,
+  response: { status?: number } | undefined,
+): string {
+  const status = response?.status;
+  let detail = "";
+  if (error && typeof error === "object") {
+    const candidate =
+      "message" in error
+        ? (error as { message?: unknown }).message
+        : "error" in error
+          ? (error as { error?: unknown }).error
+          : undefined;
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      detail = `: ${candidate.trim().slice(0, 200)}`;
+    }
+  }
+  return typeof status === "number"
+    ? `Failed to ${action}: returned HTTP ${status}${detail}`
+    : `Failed to ${action}${detail}`;
+}
+
+/**
  * Database service for Seren API operations.
  * Uses generated SDK with full type safety.
  */
@@ -57,10 +90,12 @@ export const databases = {
    */
   async listProjects(): Promise<Project[]> {
     console.log("[Databases] Fetching projects");
-    const { data, error } = await apiListProjects({ throwOnError: false });
+    const { data, error, response } = await apiListProjects({
+      throwOnError: false,
+    });
     if (error) {
       console.error("[Databases] Error fetching projects:", error);
-      throw new Error("Failed to list projects");
+      throw new Error(describeSerenDbError("list projects", error, response));
     }
     const projects = data?.data || [];
     console.log("[Databases] Found", projects.length, "projects");
@@ -76,13 +111,13 @@ export const databases = {
     _organizationId?: string,
   ): Promise<Project> {
     console.log("[Databases] Creating project:", name);
-    const { data, error } = await apiCreateProject({
+    const { data, error, response } = await apiCreateProject({
       body: { name, region: "aws-us-east-2" },
       throwOnError: false,
     });
     if (error || !data?.data) {
       console.error("[Databases] Error creating project:", error);
-      throw new Error("Failed to create project");
+      throw new Error(describeSerenDbError("create project", error, response));
     }
     // Fetch full project details (create returns ProjectCreated, not full Project)
     return this.getProject(data.data.id);
@@ -108,13 +143,13 @@ export const databases = {
    */
   async listBranches(projectId: string): Promise<Branch[]> {
     console.log("[Databases] Fetching branches for project:", projectId);
-    const { data, error } = await apiListBranches({
+    const { data, error, response } = await apiListBranches({
       path: { id: projectId },
       throwOnError: false,
     });
     if (error) {
       console.error("[Databases] Error fetching branches:", error);
-      throw new Error("Failed to list branches");
+      throw new Error(describeSerenDbError("list branches", error, response));
     }
     const branches = data?.data || [];
     console.log("[Databases] Found", branches.length, "branches");
@@ -166,13 +201,13 @@ export const databases = {
     branchId: string,
   ): Promise<Database[]> {
     console.log("[Databases] Fetching databases for branch:", branchId);
-    const { data, error } = await apiListDatabases({
+    const { data, error, response } = await apiListDatabases({
       path: { id: projectId, bid: branchId },
       throwOnError: false,
     });
     if (error) {
       console.error("[Databases] Error fetching databases:", error);
-      throw new Error("Failed to list databases");
+      throw new Error(describeSerenDbError("list databases", error, response));
     }
     const dbs = data?.data || [];
     console.log("[Databases] Found", dbs.length, "databases");
@@ -197,14 +232,14 @@ export const databases = {
       "branch:",
       branchId,
     );
-    const { data, error } = await apiCreateDatabase({
+    const { data, error, response } = await apiCreateDatabase({
       path: { id: projectId, bid: branchId },
       body: { name, owner_name: ownerName ?? null },
       throwOnError: false,
     });
     if (error || !data?.data) {
       console.error("[Databases] Error creating database:", error);
-      throw new Error("Failed to create database");
+      throw new Error(describeSerenDbError("create database", error, response));
     }
     return {
       id: data.data.id,
@@ -255,12 +290,12 @@ export const databases = {
    * Get a single project by ID.
    */
   async getProject(projectId: string): Promise<Project> {
-    const { data, error } = await apiGetProject({
+    const { data, error, response } = await apiGetProject({
       path: { id: projectId },
       throwOnError: false,
     });
     if (error || !data?.data) {
-      throw new Error("Failed to get project");
+      throw new Error(describeSerenDbError("get project", error, response));
     }
     return data.data;
   },

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -61,16 +61,25 @@ let authBindingsInitialized = false;
 let authEpoch = 0;
 
 /**
+ * Outcome of [`ensureApiKey`]. On failure we carry the HTTP `status` (when the
+ * server gave one) so the caller can tell a non-transient auth/permission
+ * failure (401/403) apart from a retryable one (5xx/network). See #2497.
+ */
+type EnsureApiKeyResult =
+  | { ok: true }
+  | { ok: false; status: number | undefined; error: unknown };
+
+/**
  * Ensure we have a Seren API key for MCP authentication.
  * Checks local storage first, only creates a new key if none stored.
  */
-async function ensureApiKey(): Promise<boolean> {
+async function ensureApiKey(): Promise<EnsureApiKeyResult> {
   try {
     // Check if we already have a stored API key
     const existingKey = await getSerenApiKey();
     if (existingKey) {
       verboseRuntimeConsole.debug("[Auth Store] Using existing stored API key");
-      return true;
+      return { ok: true };
     }
 
     // No stored key - create a new one
@@ -82,10 +91,44 @@ async function ensureApiKey(): Promise<boolean> {
     verboseRuntimeConsole.debug(
       "[Auth Store] API key created and stored successfully",
     );
-    return true;
+    return { ok: true };
   } catch (error) {
     console.error("[Auth Store] Failed to ensure API key:", error);
-    return false;
+    const status =
+      typeof (error as { status?: unknown })?.status === "number"
+        ? (error as { status: number }).status
+        : undefined;
+    return { ok: false, status, error };
+  }
+}
+
+/**
+ * Report an API-key provisioning failure to the support pipeline so persistent
+ * failures open a serenorg/seren-core ticket instead of dying in a console log.
+ * Non-blocking and best-effort — telemetry must never gate sign-in. #2497.
+ */
+async function reportApiKeyFailure(
+  status: number | undefined,
+  error: unknown,
+): Promise<void> {
+  try {
+    const { captureSupportError } = await import("@/lib/support/hook");
+    const message = error instanceof Error ? error.message : String(error);
+    const stack =
+      error instanceof Error && error.stack ? error.stack.split("\n") : [];
+    void captureSupportError({
+      kind: "auth.api_key_provisioning_failure",
+      message,
+      stack,
+      http: {
+        method: "POST",
+        url: "https://api.serendb.com/organizations/default/api-keys",
+        status,
+        body: message,
+      },
+    });
+  } catch (captureErr) {
+    console.warn(`[Auth Store] captureSupportError unavailable: ${captureErr}`);
   }
 }
 
@@ -152,13 +195,35 @@ async function activateAuthenticatedSession(
     return false;
   }
 
-  const hasApiKey = await ensureApiKey();
+  const apiKey = await ensureApiKey();
   if (authEpochChanged(expectedEpoch)) {
     return false;
   }
 
-  if (!hasApiKey) {
-    console.warn("[Auth Store] Could not ensure API key - MCP may not work");
+  if (!apiKey.ok) {
+    void reportApiKeyFailure(apiKey.status, apiKey.error);
+
+    // A 401/403 means the server rejected us for auth/permission reasons — the
+    // JWT itself is no good (or this account can't provision a key), so we must
+    // NOT present a logged-in shell. Clear the session and surface the blocking
+    // sign-in modal: that IS the actionable error + retry. #2497.
+    if (apiKey.status === 401 || apiKey.status === 403) {
+      clearAuthState();
+      requestSignInModal();
+      return false;
+    }
+
+    // Any other failure (network, 5xx, unknown) is transient: the JWT is still
+    // valid and the SerenDB key is only needed by MCP tools + the Claude memory
+    // interceptor — NOT by the primary chat path, which goes direct to the
+    // provider CLI on the JWT. Blocking the whole session here would break chat
+    // for an otherwise-valid user, and (because this runs on auth:token-refreshed)
+    // would spuriously force-logout mid-refresh. Keep the session; ensureApiKey
+    // re-runs on the next refresh and self-heals, and the interceptor surfaces
+    // the now-classified failure. #2497 (NEW P1-a).
+    console.warn(
+      "[Auth Store] API key provisioning failed transiently; keeping session, MCP + Claude memory will retry on next refresh",
+    );
   }
 
   setState({

--- a/tests/services/claudeMemory.test.ts
+++ b/tests/services/claudeMemory.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/stores/settings.store", () => ({
 }));
 
 import {
+  classifyMemoryStartFailure,
   ensureClaudeMemoryProvisioned,
   getClaudeMemoryStatus,
   migrateExistingClaudeMemory,
@@ -483,5 +484,48 @@ describe("startClaudeMemoryInterceptor wiring", () => {
     });
     expect(invokeMock).not.toHaveBeenCalled();
     expect(databasesMock.listProjects).not.toHaveBeenCalled();
+  });
+});
+
+describe("classifyMemoryStartFailure (#2497 Defect 3)", () => {
+  it("treats 401/403 as a non-transient auth/permission failure", () => {
+    for (const status of [401, 403]) {
+      const notice = classifyMemoryStartFailure(
+        new Error(`serendb SELECT failed: SerenDB query returned HTTP ${status}: {"message":"forbidden"}`),
+      );
+      expect(notice.status).toBe(status);
+      expect(notice.message.toLowerCase()).toContain("authorize");
+      // Never echoes the raw server body or the toggle-off-and-on advice.
+      expect(notice.message).not.toContain("forbidden");
+      expect(notice.message).not.toMatch(/toggling it off and on/i);
+    }
+  });
+
+  it("explains that the desktop key is still provisioning when it is absent", () => {
+    const notice = classifyMemoryStartFailure(
+      new Error(
+        "SerenDB API key not available — log in to Seren Desktop so the key is provisioned",
+      ),
+    );
+    expect(notice.status).toBeUndefined();
+    expect(notice.message.toLowerCase()).toContain("finishing");
+    expect(notice.message).not.toContain("log in to Seren Desktop so the key");
+  });
+
+  it("treats 5xx / gateway timeouts as transient and retryable", () => {
+    for (const status of [408, 500, 502, 503, 504]) {
+      const notice = classifyMemoryStartFailure(
+        new Error(`SerenDB query returned HTTP ${status}: upstream`),
+      );
+      expect(notice.status).toBe(status);
+      expect(notice.message.toLowerCase()).toContain("retry");
+      expect(notice.message).not.toContain("upstream");
+    }
+  });
+
+  it("defaults to the transient notice for status-less errors", () => {
+    const notice = classifyMemoryStartFailure(new Error("network unreachable"));
+    expect(notice.status).toBeUndefined();
+    expect(notice.message.toLowerCase()).toContain("retry");
   });
 });

--- a/tests/unit/auth-create-apikey-status.test.ts
+++ b/tests/unit/auth-create-apikey-status.test.ts
@@ -1,0 +1,93 @@
+// ABOUTME: #2497 Defect 1 — createApiKey() must carry the HTTP status so the
+// ABOUTME: auth store can tell a non-transient 401/403 from a retryable 5xx.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createDefaultOrgApiKeyMock } = vi.hoisted(() => ({
+  createDefaultOrgApiKeyMock: vi.fn(),
+}));
+
+vi.mock("@/api", () => ({
+  createDefaultOrgApiKey: createDefaultOrgApiKeyMock,
+  getCurrentUser: vi.fn(),
+  login: vi.fn(),
+  refreshToken: vi.fn(),
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  clearDefaultOrganizationId: vi.fn(),
+  clearRefreshToken: vi.fn(),
+  clearToken: vi.fn(),
+  getRefreshToken: vi.fn(),
+  getToken: vi.fn(),
+  isTauriRuntime: vi.fn(() => false),
+  storeDefaultOrganizationId: vi.fn(),
+  storeRefreshToken: vi.fn(),
+  storeToken: vi.fn(),
+}));
+
+// Break the auth.ts <-> auth.store circular import for this focused test.
+vi.mock("@/stores/auth.store", () => ({
+  clearAuthState: vi.fn(),
+  requestSignInModal: vi.fn(),
+}));
+
+import { ApiKeyProvisioningError, createApiKey } from "@/services/auth";
+
+function errorResult(status: number, body: unknown) {
+  return {
+    data: undefined,
+    error: { message: typeof body === "string" ? body : undefined },
+    response: {
+      status,
+      clone: () => ({ json: async () => body }),
+    },
+  };
+}
+
+describe("createApiKey HTTP status (#2497 Defect 1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the api_key on success", async () => {
+    createDefaultOrgApiKeyMock.mockResolvedValueOnce({
+      data: { data: { api_key: "seren_live_abc" } },
+      error: undefined,
+      response: { status: 201 },
+    });
+    await expect(createApiKey()).resolves.toBe("seren_live_abc");
+  });
+
+  for (const status of [401, 403, 500]) {
+    it(`throws an ApiKeyProvisioningError carrying status ${status}`, async () => {
+      createDefaultOrgApiKeyMock.mockResolvedValueOnce(
+        errorResult(status, { message: "denied" }),
+      );
+
+      const err = await createApiKey().then(
+        () => {
+          throw new Error("expected createApiKey to reject");
+        },
+        (e) => e as ApiKeyProvisioningError,
+      );
+
+      expect(err).toBeInstanceOf(ApiKeyProvisioningError);
+      expect(err.status).toBe(status);
+      // Also reachable by the App.tsx `returned HTTP <status>` regex.
+      expect(err.message).toMatch(new RegExp(`returned HTTP ${status}`));
+    });
+  }
+
+  it("is an ApiKeyProvisioningError instance even when no status is present", async () => {
+    createDefaultOrgApiKeyMock.mockResolvedValueOnce({
+      data: undefined,
+      error: { message: "boom" },
+      response: undefined,
+    });
+    await createApiKey().catch((err) => {
+      expect(err).toBeInstanceOf(ApiKeyProvisioningError);
+      expect(err.status).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/auth-store-apikey-ordering.test.ts
+++ b/tests/unit/auth-store-apikey-ordering.test.ts
@@ -88,6 +88,12 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: listenMock,
 }));
 
+// reportApiKeyFailure dynamically imports this on the failure path; stub it so
+// the tests stay deterministic and the output stays pristine.
+vi.mock("@/lib/support/hook", () => ({
+  captureSupportError: vi.fn(),
+}));
+
 import {
   authStore,
   checkAuth,
@@ -222,6 +228,66 @@ describe("auth.store #1613 — API key before isAuthenticated flips", () => {
     expect(storeSerenApiKeyMock).toHaveBeenCalledTimes(1);
     expect(createApiKeyMock).toHaveBeenCalledTimes(1);
     expect(authAtStoreTime).toBe(false);
+    expect(authStore.isAuthenticated).toBe(true);
+    expect(authStore.signInModalRequested).toBe(false);
+  });
+});
+
+describe("auth.store #2497 — API key provisioning failure handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventListeners.clear();
+    isTauriRuntimeMock.mockReturnValue(false);
+    hasStoredTokenMock.mockResolvedValue(true);
+    isLoggedInMock.mockResolvedValue(true);
+    runtimeHasCapabilityMock.mockReturnValue(false);
+    resetAuthStore();
+  });
+
+  for (const status of [401, 403]) {
+    it(`HTTP ${status} key failure does NOT flip isAuthenticated and raises the sign-in modal`, async () => {
+      storedKeyRef.value = null;
+      createApiKeyMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Forbidden (returned HTTP ${status})`), {
+          status,
+        }),
+      );
+
+      await setAuthenticated({ id: "u1", email: "u@test", name: "U" });
+
+      // Genuine auth/permission failure: the logged-in shell must NOT appear,
+      // the key must not be stored, and the user must be told to sign in again.
+      expect(authStore.isAuthenticated).toBe(false);
+      expect(authStore.signInModalRequested).toBe(true);
+      expect(storeSerenApiKeyMock).not.toHaveBeenCalled();
+    });
+  }
+
+  for (const status of [500, 503]) {
+    it(`HTTP ${status} key failure KEEPS the session so chat still works (no forced sign-in)`, async () => {
+      storedKeyRef.value = null;
+      createApiKeyMock.mockRejectedValueOnce(
+        Object.assign(new Error(`Server error (returned HTTP ${status})`), {
+          status,
+        }),
+      );
+
+      await setAuthenticated({ id: "u1", email: "u@test", name: "U" });
+
+      // The JWT is still valid; the SerenDB key is only needed by MCP tools +
+      // the Claude memory interceptor, not the primary chat path. Blocking the
+      // whole session here would break chat for an otherwise-valid user.
+      expect(authStore.isAuthenticated).toBe(true);
+      expect(authStore.signInModalRequested).toBe(false);
+    });
+  }
+
+  it("a status-less (network) key failure also keeps the session", async () => {
+    storedKeyRef.value = null;
+    createApiKeyMock.mockRejectedValueOnce(new Error("network unreachable"));
+
+    await setAuthenticated({ id: "u1", email: "u@test", name: "U" });
+
     expect(authStore.isAuthenticated).toBe(true);
     expect(authStore.signInModalRequested).toBe(false);
   });

--- a/tests/unit/claude-memory-user-scoped-auth.test.ts
+++ b/tests/unit/claude-memory-user-scoped-auth.test.ts
@@ -1,0 +1,51 @@
+// ABOUTME: #2497 Defect 2 — prove the seren-db memory path authenticates with
+// ABOUTME: the user-scoped desktop key / user JWT, never an agent/gateway key.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const rustWatcher = readFileSync(
+  resolve("src-tauri/src/claude_memory.rs"),
+  "utf-8",
+);
+const databasesService = readFileSync(
+  resolve("src/services/databases.ts"),
+  "utf-8",
+);
+const tauriBridge = readFileSync(resolve("src/lib/tauri-bridge.ts"), "utf-8");
+const setupAuth = readFileSync(resolve("src/api/setup-auth.ts"), "utf-8");
+
+describe("seren-db memory path uses the user-scoped credential (#2497 Defect 2)", () => {
+  it("the Rust watcher bears the SerenDB API key read from the user's store entry", () => {
+    // The /publishers/seren-db/query call must bearer the API key field…
+    expect(rustWatcher).toMatch(/\.bearer_auth\(&self\.api_key\)/);
+    // …and that key is read from the same store entry the desktop key lands in.
+    expect(rustWatcher).toMatch(/const SEREN_API_KEY_KEY: &str = "seren_api_key"/);
+    expect(rustWatcher).toMatch(/fn read_seren_api_key/);
+    expect(rustWatcher).toMatch(/\.get\(SEREN_API_KEY_KEY\)/);
+  });
+
+  it("the desktop stores the minted user key under that same `seren_api_key` entry", () => {
+    expect(tauriBridge).toMatch(/export async function storeSerenApiKey/);
+    expect(tauriBridge).toMatch(/key: "seren_api_key"/);
+  });
+
+  it("databases.runSql goes through the Rust user-key client, not the MCP gateway", () => {
+    // The /query leg must use the Rust command (user-scoped API key) rather than
+    // the seren-mcp gateway (agent-scoped keys). The Rust command name is the
+    // load-bearing invariant.
+    expect(databasesService).toMatch(
+      /invoke<QueryResult>\("claude_memory_run_sql"/,
+    );
+  });
+
+  it("the seren-db management SDK attaches the user JWT, not an agent key", () => {
+    // setup-auth is the only interceptor on the seren-db client: it attaches the
+    // user's OAuth token (or defers to the Rust gateway bridge, which also uses
+    // the user JWT via authenticated_request). No agent/gateway key here.
+    expect(setupAuth).toMatch(/getToken\(\)/);
+    expect(setupAuth).toMatch(/Authorization.*Bearer \$\{token\}/);
+    expect(setupAuth).not.toMatch(/api[_-]?key/i);
+  });
+});

--- a/tests/unit/databases-error-status.test.ts
+++ b/tests/unit/databases-error-status.test.ts
@@ -1,0 +1,93 @@
+// ABOUTME: #2497 NEW P1-b — seren-db management helpers must carry the HTTP
+// ABOUTME: status so a new-user 403 on createProject/listProjects is classifiable.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdk = vi.hoisted(() => ({
+  serenDbListProjects: vi.fn(),
+  serenDbCreateProject: vi.fn(),
+  serenDbGetProject: vi.fn(),
+  serenDbListBranches: vi.fn(),
+  serenDbListDatabases: vi.fn(),
+  serenDbCreateDatabase: vi.fn(),
+  serenDbCreateBranch: vi.fn(),
+  serenDbDeleteProject: vi.fn(),
+  serenDbGetBranch: vi.fn(),
+  serenDbConnectionUri: vi.fn(),
+  serenDbGetDatabase: vi.fn(),
+  listOrganizations: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock("@/api/seren-db", () => ({
+  serenDbListProjects: sdk.serenDbListProjects,
+  serenDbCreateProject: sdk.serenDbCreateProject,
+  serenDbGetProject: sdk.serenDbGetProject,
+  serenDbListBranches: sdk.serenDbListBranches,
+  serenDbListDatabases: sdk.serenDbListDatabases,
+  serenDbCreateDatabase: sdk.serenDbCreateDatabase,
+  serenDbCreateBranch: sdk.serenDbCreateBranch,
+  serenDbDeleteProject: sdk.serenDbDeleteProject,
+  serenDbGetBranch: sdk.serenDbGetBranch,
+  serenDbConnectionUri: sdk.serenDbConnectionUri,
+  serenDbGetDatabase: sdk.serenDbGetDatabase,
+}));
+
+vi.mock("@/api", () => ({
+  listOrganizations: sdk.listOrganizations,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: sdk.invoke,
+}));
+
+import { databases } from "@/services/databases";
+
+const forbidden = {
+  data: undefined,
+  error: { error: "Database management requires a user-scoped API key or JWT." },
+  response: { status: 403 },
+};
+
+describe("seren-db management error status (#2497 NEW P1-b)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("listProjects surfaces a 403 with the `returned HTTP 403` marker", async () => {
+    sdk.serenDbListProjects.mockResolvedValueOnce(forbidden);
+    await expect(databases.listProjects()).rejects.toThrow(/returned HTTP 403/);
+  });
+
+  it("createProject surfaces a 403 with the `returned HTTP 403` marker", async () => {
+    sdk.serenDbCreateProject.mockResolvedValueOnce(forbidden);
+    await expect(databases.createProject("claude-agent-prefs")).rejects.toThrow(
+      /returned HTTP 403/,
+    );
+    // Must fail before attempting to fetch full details.
+    expect(sdk.serenDbGetProject).not.toHaveBeenCalled();
+  });
+
+  it("createDatabase surfaces a 403 with the `returned HTTP 403` marker", async () => {
+    sdk.serenDbCreateDatabase.mockResolvedValueOnce(forbidden);
+    await expect(
+      databases.createDatabase("p1", "b1", "claude_agent_prefs"),
+    ).rejects.toThrow(/returned HTTP 403/);
+  });
+
+  it("falls back to a status-less message when the server gave no response", async () => {
+    sdk.serenDbListProjects.mockResolvedValue({
+      data: undefined,
+      error: { message: "network down" },
+      response: undefined,
+    });
+    const err = await databases.listProjects().then(
+      () => {
+        throw new Error("expected listProjects to reject");
+      },
+      (e) => e as Error,
+    );
+    expect(err.message).toMatch(/Failed to list projects/);
+    expect(err.message).not.toMatch(/returned HTTP/);
+  });
+});


### PR DESCRIPTION
Closes #2497.

Fixes the first-run failure where a new user (Srini, `nikihana@gmail.com`) hit a server-side 403 on the SerenDB memory path and the desktop **swallowed it** — flipping `isAuthenticated: true` with no API key, then throwing a raw `HTTP 403: <body>` info dialog.

## What changed

### Defect 1 (P0) — failed key provisioning no longer silently flips `isAuthenticated`
- `services/auth.ts`: `createApiKey()` now throws a typed `ApiKeyProvisioningError` carrying the **HTTP status** (and a `returned HTTP <status>` marker), so downstream telemetry/dialogs can classify 401/403 vs 5xx.
- `stores/auth.store.ts`: `ensureApiKey()` returns a classified result; `activateAuthenticatedSession()` branches on it (see NEW P1-a).

### Defect 3 (P1) — actionable dialog, no raw server bodies
- `services/claudeMemory.ts`: new pure `classifyMemoryStartFailure()` maps the error to body-free, actionable copy — 401/403 → "couldn't authorize / account still provisioning", missing-key → "still finishing setup", 5xx/timeout → "temporary, will retry".
- `App.tsx`: the interceptor catch uses it; the raw server body still flows to telemetry but is **never** shown to the user.

### Defect 2 (P1) — verified + locked
Traced every leg: `/publishers/seren-db/query` → Rust `claude_memory_run_sql` → `bearer_auth(read_seren_api_key)` = **user-scoped desktop key**; seren-db management → generated SDK → `gateway_http` → `authenticated_request` = **user JWT**. Neither sends an agent/gateway key. Added a source-guard regression test.

### Minor — Version row
- `services/buildInfo.ts` (new) + `SettingsPanel`: read-only **Version** row in Settings → General sourced from `get_build_info`.

## New P1s found during the audit (documented on #2497, fixed here)

- **NEW P1-a** — naive "don't flip `isAuthenticated` on key failure" would **lock valid-JWT users out of chat** (chat goes direct to the provider CLI on the JWT; the SerenDB key is only needed by MCP tools + the memory interceptor) and would **force-logout mid token refresh**. Fix: only **401/403** clears the session + raises the sign-in modal; **transient** keeps the session and self-heals on the next refresh. Emits classified support telemetry.
- **NEW P1-b** — seren-db **management** helpers in `databases.ts` discarded the HTTP status (`throw "Failed to create project"`). For a new user the 403 most likely fires on `createProject`, so the error reaching `App.tsx` had no status → Defect 3's classifier and seren-core#187's telemetry correlation both failed. Fix: thread `response.status` + short body into those errors with a `returned HTTP <status>` marker.

## Acceptance criteria (#2497)
- [x] Failed API-key provisioning no longer silently flips `isAuthenticated: true`; user gets an actionable error + retry.
- [x] `createApiKey()` error includes HTTP status.
- [x] Test proving `/publishers/seren-db/*` calls use the user-scoped key.
- [x] Interceptor dialog distinguishes auth/permission (401/403) from transient (5xx/timeout); no raw server bodies.
- [x] App version shown in Settings → General.

## Tests (critical only)
`vitest` full suite green (**271 files / 1864 tests**). Added/extended:
- `auth-store-apikey-ordering.test.ts` — 401/403 → no flip + sign-in modal; 5xx/network → session kept.
- `auth-create-apikey-status.test.ts` — `createApiKey` carries status.
- `claudeMemory.test.ts` — `classifyMemoryStartFailure` branching + no raw bodies.
- `databases-error-status.test.ts` — management-path 403 carries `returned HTTP 403`.
- `claude-memory-user-scoped-auth.test.ts` — user-scoped-key / user-JWT invariant.

## Platform
All changes are platform-agnostic TS (no Rust changes); macOS/Windows behave identically. Companion server-side 403 root cause: serenorg/seren-core#187.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
