### PR TITLE
fix(rust): silence INFO Postgres NOTICE log flood (#2500)

### DIFF
--- a/src-tauri/src/claude_memory.rs
+++ b/src-tauri/src/claude_memory.rs
@@ -778,7 +778,9 @@ pub async fn render_memory_md_from_db(
         .run_sql(config, &sql, /* read_only */ true)
         .await
         .map_err(|e| format!("serendb SELECT failed: {e}"))?;
-    log::info!(
+    // Routine per-refresh bookkeeping; only useful while debugging memory
+    // provisioning. Keep it out of the INFO console to reduce noise. #2500.
+    log::debug!(
         "[ClaudeMemory] SELECT returned {} preference rows for project {}",
         result.row_count,
         project_path

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -323,7 +323,20 @@ fn connect_client(connection_string: &str) -> Result<PgClient, String> {
         .build()
         .map_err(|err| err.to_string())?;
     let tls = postgres_native_tls::MakeTlsConnector::new(tls);
-    PgClient::connect(connection_string, tls).map_err(|err| err.to_string())
+    let mut client = PgClient::connect(connection_string, tls).map_err(|err| err.to_string())?;
+    // The idempotent history-sync DDL (CREATE ... IF NOT EXISTS) makes the
+    // server emit a NOTICE per already-existing object on every sync tick, and
+    // the sync `postgres` crate logs each at INFO (target `postgres::config`).
+    // These "already exists, skipping" notices carry no diagnostic value, so
+    // suppress them at the protocol source in normal builds — keeping them in
+    // debug builds only. WARNING/ERROR still flow through. Best-effort: a
+    // failure here must not break the sync. #2500.
+    if !cfg!(debug_assertions) {
+        if let Err(err) = client.batch_execute("SET client_min_messages = warning") {
+            log::debug!("[HistorySync] failed to set client_min_messages: {err}");
+        }
+    }
+    Ok(client)
 }
 
 fn is_refreshable_postgres_error_text(err: &str) -> bool {


### PR DESCRIPTION
## What

Fixes #2500 — the webview console / log files were flooded with INFO-level Postgres NOTICE lines (5,900+ in one session), e.g.:

```
[postgres::config][INFO] NOTICE: relation "messages" already exists, skipping
[postgres::config][INFO] NOTICE: schema "seren_desktop" already exists, skipping
```

## Root cause

`ensure_remote_schema` re-runs ~11 idempotent `CREATE … IF NOT EXISTS` statements on **every** 15s history-sync tick (`history_sync.rs` `run_history_sync_once`). The remote Postgres emits a NOTICE per already-existing object, and the sync `postgres` crate (v0.19) logs each at INFO via its default notice callback (target `postgres::config`). `RotationStrategy::KeepOne` means this noise also evicts useful history from disk.

## Fix

- `connect_client` (the single connect chokepoint): issue `SET client_min_messages = warning` in non-debug builds. These "already exists, skipping" notices carry no diagnostic value, so they're suppressed at the protocol source in normal use, while still available in debug builds (honoring "move to DEBUG only"). WARNING/ERROR continue to flow. Best-effort — a failure setting it cannot break the sync.
- `claude_memory.rs`: downgrade the per-refresh `[ClaudeMemory] SELECT returned N preference rows` bookkeeping from `info!` to `debug!` (same noise class, appears in the reported log).

No behavior change beyond logging/connection config.

## Tests

None warranted — logging/connection configuration, not business logic (repo TDD policy: do not test config/mocked behavior). Verified `postgres::Client::batch_execute` exists (v0.19.14) and `client_min_messages = warning` is the correct level (suppresses NOTICE, keeps WARNING/ERROR). Compilation validated by CI `test-rust` + `build (macos/ubuntu/windows)`.

## Impact / platforms

P1 observability/operability. macOS + Windows (release builds; the connection path is platform-agnostic).
