### PR TITLE
chore(tests): clear tsc --noEmit type errors in test files (#2504)

### DIFF
--- a/tests/unit/meeting-autodetect-dismiss-reset.test.ts
+++ b/tests/unit/meeting-autodetect-dismiss-reset.test.ts
@@ -4,7 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const m = vi.hoisted(() => ({
-  meetingAutodetect: vi.fn(async () => ({
+  meetingAutodetect: vi.fn(async (): Promise<MeetingAutodetectResult> => ({
     detected: false,
     sourceApp: null,
   })),
@@ -30,7 +30,7 @@ vi.mock("@/stores/settings.store", () => ({
   },
 }));
 
-import type { Meeting } from "@/services/meetings";
+import type { Meeting, MeetingAutodetectResult } from "@/services/meetings";
 import { meetingStore } from "@/stores/meeting.store";
 
 describe("meeting auto-detect dismissal reset (#2209)", () => {

--- a/tests/unit/provider-runtime-agent-isolation.test.ts
+++ b/tests/unit/provider-runtime-agent-isolation.test.ts
@@ -4,6 +4,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+// @ts-expect-error - providers.mjs is a plain ESM harness without type declarations
 import { createUnavailableRuntime } from "../../bin/browser-local/providers.mjs";
 
 const providersSource = readFileSync(

--- a/tests/unit/provider-runtime-log-prefix.test.ts
+++ b/tests/unit/provider-runtime-log-prefix.test.ts
@@ -4,6 +4,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+// @ts-expect-error - logging.mjs is a plain ESM harness without type declarations
 import { providerLogPrefix } from "../../bin/browser-local/logging.mjs";
 
 const runtimeLogFiles = [

--- a/tests/unit/windows-cargo-manifest.test.ts
+++ b/tests/unit/windows-cargo-manifest.test.ts
@@ -3,6 +3,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { describe, expect, it } from "vitest";
 
 const repoRoot = process.cwd();
 const tauriDir = join(repoRoot, "src-tauri");


### PR DESCRIPTION
## What

`tsc --noEmit -p tsconfig.json` reported **23 type errors**, all confined to test files. They never failed CI (no workflow runs `tsc` — `check` is Biome, `build`/`test` use esbuild) but polluted local `tsc`/editor diagnostics and masked any future *real* type regression in tests. All 1864/1868 vitest tests already passed; this is type/IDE hygiene.

Each error was a **lone outlier** from an established codebase convention. Fixed to match the convention — test-file-only, **no product code**.

## Root causes & fixes (audited per category)

| Cat | Count | File(s) | Root cause | Fix |
|-----|-------|---------|-----------|-----|
| A | 19 | `windows-cargo-manifest.test.ts` | Only test file (1/269) using `describe/it/expect` without importing them | `import { describe, expect, it } from "vitest"` (268 files already do) |
| B | 2 | `provider-runtime-{agent-isolation,log-prefix}.test.ts` | Real ES-import of untyped `.mjs` → TS7016 implicit-any | `// @ts-expect-error` (matches `codex-agent-image-context.test.ts`) |
| C | 2 | `meeting-autodetect-dismiss-reset.test.ts` | `meetingAutodetect` mock inferred `sourceApp: null`; sibling `listMeetings` was already annotated | Annotate `Promise<MeetingAutodetectResult>` |

## Verification
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json` → **0 errors** (was 23). The `@ts-expect-error` directives are confirmed necessary (tsc flags unused ones).
- Full `vitest run` → **271 files, 1868 tests pass** (no regression).
- No new tests added (these *are* tests; correctness is validated by tsc→0 + suite still green), per the "critical/required tests only" constraint.

Closes #2504

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com