### PR TITLE
fix: classify 402/404/400 memory errors as non-retryable (#2506)

### DIFF
--- a/src/services/claudeMemory.ts
+++ b/src/services/claudeMemory.ts
@@ -238,11 +238,14 @@ export interface MemoryStartFailureNotice {
 
 /**
  * Map a Claude-memory interceptor start failure to an actionable, body-free
- * user notice. Branches on the failure class so a non-transient auth/permission
- * failure (401/403) reads differently from a retryable one, and so the dialog
- * never echoes raw server bodies (which can include an HTTP 403 payload). The
- * status is parsed from the `returned HTTP <status>` marker that both the Rust
- * `run_sql` formatter and the seren-db service errors emit. #2497 Defect 3.
+ * user notice. Branches on the failure class — auth/permission (401/403),
+ * billing (402), still-provisioning (missing key), other non-retryable client
+ * errors (400/404/409/422), and retryable transients (408/429/5xx/network) —
+ * so each reads differently and only the genuinely-retryable bucket promises an
+ * automatic retry. The dialog never echoes raw server bodies (which can include
+ * an HTTP 403 payload). The status is parsed from the `returned HTTP <status>`
+ * marker that both the Rust `run_sql` formatter and the seren-db service errors
+ * emit. #2497 Defect 3; #2506.
  */
 export function classifyMemoryStartFailure(
   error: unknown,
@@ -262,6 +265,16 @@ export function classifyMemoryStartFailure(
     };
   }
 
+  // Quota exceeded / payment required — retrying never helps; the user must top
+  // up. seren-core returns 402 for this on the seren-db path. #2506.
+  if (status === 402) {
+    return {
+      status,
+      message:
+        "Seren memory storage needs an active plan or balance on your account. Add funds in Settings → Wallet, then retry from Settings → Code Indexing → Claude Code Auto-Memory.",
+    };
+  }
+
   // The desktop API key hasn't landed yet — a transient provisioning failure
   // upstream kept the session but left no key. Re-authenticating re-mints it.
   if (/api key not available/i.test(raw)) {
@@ -272,8 +285,19 @@ export function classifyMemoryStartFailure(
     };
   }
 
-  // Everything else (5xx, 408, gateway timeout, network, cold-start exhaustion)
-  // is transient and self-heals on the next memory write.
+  // Other non-retryable client errors — no organization (400), no active plan
+  // (404), conflict (409), unprocessable (422). These will NOT self-heal, so we
+  // must not promise an automatic retry. seren-core#187 documents 400/404 here.
+  if (status === 400 || status === 404 || status === 409 || status === 422) {
+    return {
+      status,
+      message:
+        "Seren couldn't set up memory storage for your account. Sign out and back in, and contact support if it keeps happening.",
+    };
+  }
+
+  // Everything else (5xx, 408, 429, gateway timeout, network, cold-start
+  // exhaustion) is transient and self-heals on the next memory write.
   return {
     status,
     message:

--- a/tests/services/claudeMemory.test.ts
+++ b/tests/services/claudeMemory.test.ts
@@ -512,20 +512,48 @@ describe("classifyMemoryStartFailure (#2497 Defect 3)", () => {
     expect(notice.message).not.toContain("log in to Seren Desktop so the key");
   });
 
-  it("treats 5xx / gateway timeouts as transient and retryable", () => {
-    for (const status of [408, 500, 502, 503, 504]) {
+  it("treats 408/429/5xx / gateway timeouts as transient with an auto-retry promise", () => {
+    for (const status of [408, 429, 500, 502, 503, 504]) {
       const notice = classifyMemoryStartFailure(
         new Error(`SerenDB query returned HTTP ${status}: upstream`),
       );
       expect(notice.status).toBe(status);
-      expect(notice.message.toLowerCase()).toContain("retry");
+      expect(notice.message.toLowerCase()).toContain("retry automatically");
       expect(notice.message).not.toContain("upstream");
     }
   });
 
-  it("defaults to the transient notice for status-less errors", () => {
+  it("defaults to the transient auto-retry notice for status-less errors", () => {
     const notice = classifyMemoryStartFailure(new Error("network unreachable"));
     expect(notice.status).toBeUndefined();
-    expect(notice.message.toLowerCase()).toContain("retry");
+    expect(notice.message.toLowerCase()).toContain("retry automatically");
+  });
+
+  it("treats 402 as a billing wall (top up), never an auto-retry (#2506)", () => {
+    const notice = classifyMemoryStartFailure(
+      new Error(
+        'Failed to create project: returned HTTP 402: {"error":"quota exceeded"}',
+      ),
+    );
+    expect(notice.status).toBe(402);
+    expect(notice.message.toLowerCase()).toContain("plan or balance");
+    expect(notice.message).toMatch(/Settings → Wallet/);
+    // Must NOT promise an automatic retry, and must not leak the raw body.
+    expect(notice.message).not.toContain("retry automatically");
+    expect(notice.message).not.toContain("quota exceeded");
+  });
+
+  it("treats 400/404/409/422 as non-retryable setup errors, never auto-retry (#2506)", () => {
+    for (const status of [400, 404, 409, 422]) {
+      const notice = classifyMemoryStartFailure(
+        new Error(
+          `Failed to create project: returned HTTP ${status}: {"error":"no active plan"}`,
+        ),
+      );
+      expect(notice.status).toBe(status);
+      expect(notice.message.toLowerCase()).toContain("set up memory storage");
+      expect(notice.message).not.toContain("retry automatically");
+      expect(notice.message).not.toContain("no active plan");
+    }
   });
 });


### PR DESCRIPTION
Closes #2506.

Post-merge walk-through finding from #2497 (PR #2502). `classifyMemoryStartFailure()` only special-cased 401/403, so every other status fell into the **"It will retry automatically on the next memory write"** bucket — including non-transient client errors that will **never** self-heal. This misdirects a billing/setup-blocked new user (the exact origin scenario of #2497, which involved a Low Balance warning) into waiting forever instead of topping up.

#2502's NEW P1-b fix (threading `returned HTTP <status>` through the seren-db management helpers) made these statuses reach the classifier live, so the gap is now active.

## Change (`src/services/claudeMemory.ts`)
- **402** (quota / payment required) → billing copy pointing at **Settings → Wallet**; no auto-retry promise.
- **400 / 404 / 409 / 422** (no org / no active plan / conflict / unprocessable) → neutral non-transient setup message ("couldn't set up memory storage… sign out/in or contact support"); no auto-retry promise.
- **408 / 429 / 5xx / network / no-status** → unchanged: transient "will retry automatically".
- Still never echoes raw server bodies.

Server-side statuses per serenorg/seren-core#187 (402 quota, 404 no-plan, 400 no-org on `/publishers/seren-db/*`).

## Acceptance criteria (#2506)
- [x] 402 → billing/top-up copy, not "will retry."
- [x] 404 (no plan) / 400 (no org) → non-transient setup message, not "will retry."
- [x] 408/429/5xx/network still transient.
- [x] Unit test covers 402, 404, 400, 429, 503 buckets; asserts no raw bodies leak.

## Tests
`vitest` full suite green (**271 files / 1870 tests**). Extended `claudeMemory.test.ts` classifier block with the 402 billing bucket, the 400/404/409/422 non-retryable bucket, and 429 in the transient set.

## Platform
Platform-agnostic TS; macOS/Windows identical.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
