### PR TITLE
fix(e2e): submit GitHub 2FA via Verify button in Windows probe (#2509)

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -1,5 +1,6 @@
 import { randomUUID, createHmac } from "node:crypto";
 import { spawn } from "node:child_process";
+import { writeFile } from "node:fs/promises";
 import process from "node:process";
 import { setTimeout as sleep } from "node:timers/promises";
 import { chromium } from "@playwright/test";
@@ -306,7 +307,28 @@ function totp(secret, timestamp = Date.now()) {
   return String(code % 1_000_000).padStart(6, "0");
 }
 
-async function completeGithubAuthorization(authUrl) {
+// Persist a screenshot and page HTML when the GitHub OAuth flow stalls. The
+// SSM transport only echoes the run log, so without an on-disk artifact a
+// GitHub UI change surfaces as an opaque timeout (#2509). Files land in the
+// harness work dir and are retrievable from the e2e box.
+async function captureOAuthFailureArtifacts(page, label) {
+  const safe = label.replace(/[^a-z0-9-]/gi, "_");
+  const base = `github-oauth-failure-${safe}`;
+  try {
+    await page.screenshot({ path: `${base}.png`, fullPage: true });
+    logStage(`captured OAuth failure screenshot ${base}.png`);
+  } catch (error) {
+    logStage(`could not capture OAuth screenshot: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  try {
+    await writeFile(`${base}.html`, await page.content(), "utf8");
+    logStage(`captured OAuth failure HTML ${base}.html`);
+  } catch (error) {
+    logStage(`could not capture OAuth HTML: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function completeGithubAuthorization(authUrl, label) {
   const browser = await chromium.launch({ headless: false });
   const context = await browser.newContext();
   const page = await context.newPage();
@@ -320,14 +342,29 @@ async function completeGithubAuthorization(authUrl) {
       await page.getByRole("button", { name: /sign in/i }).click();
     }
 
-    const otpInput = page.locator("input[name='otp'], input#app_otp, input[autocomplete='one-time-code']").first();
-    if (await otpInput.isVisible({ timeout: 8_000 }).catch(() => false)) {
+    const otpInput = page
+      .locator(
+        "input[autocomplete='one-time-code'], input[name='otp'], input[name='app_otp'], input#app_totp, input#otp, input[inputmode='numeric']",
+      )
+      .first();
+    if (await otpInput.isVisible({ timeout: 20_000 }).catch(() => false)) {
       assert(
         GITHUB_TOTP_SECRET,
         "GitHub requested two-factor auth but SEREN_E2E_GITHUB_TOTP_SECRET is not configured",
       );
       await otpInput.fill(totp(GITHUB_TOTP_SECRET));
-      await page.keyboard.press("Enter");
+      // GitHub's 2FA app page renders an explicit Verify button and does not
+      // reliably submit on Enter (#2509); click it when present, else Enter.
+      const verifyButton = page
+        .getByRole("button", { name: /verify|confirm|continue|sign in/i })
+        .or(page.locator("button[type='submit']"))
+        .first();
+      if (await verifyButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        await verifyButton.click();
+      } else {
+        await page.keyboard.press("Enter");
+      }
+      await page.waitForLoadState("domcontentloaded").catch(() => {});
     }
 
     const authorizeButton = page
@@ -341,6 +378,7 @@ async function completeGithubAuthorization(authUrl) {
     await page.waitForURL(/localhost:8787\/oauth\/callback|127\.0\.0\.1:8787\/oauth\/callback|github\.com\/settings\/connections/, {
       timeout: 120_000,
     }).catch(async () => {
+      await captureOAuthFailureArtifacts(page, label);
       const body = await page.locator("body").innerText({ timeout: 5_000 }).catch(() => "");
       throw new Error(`GitHub OAuth did not reach the Seren callback. URL=${page.url()} Body=${body.slice(0, 500)}`);
     });
@@ -356,7 +394,7 @@ async function exerciseOAuthReconnect(page) {
 
   for (const phase of ["connect", "reconnect"]) {
     const authUrl = await startGatewayOAuth(page, token);
-    await completeGithubAuthorization(authUrl);
+    await completeGithubAuthorization(authUrl, phase);
     const connection = await assertOAuthConnected(token);
     console.log(`[windows-e2e] GitHub OAuth ${phase} valid for ${connection.provider_email ?? connection.provider_slug}`);
     await revokeOAuthConnection(token);


### PR DESCRIPTION
## What

Hardens the GitHub OAuth step (`completeGithubAuthorization`) in the Windows release e2e probe so it submits the 2FA code reliably, and adds failure diagnostics.

Closes #2509.

## Why

In v3.56.0 (release run 27673852005) `windows-app-e2e` reached stage 4 (`exerciseOAuthReconnect`) for the first time and stalled on GitHub's two-factor page:

```
Error: GitHub OAuth did not reach the Seren callback.
URL=https://github.com/sessions/two-factor/app
Body=...Two-factor authentication...Enter the verification code...Verify...
  at completeGithubAuthorization (scripts/windows-e2e-app.mjs:345)
```

The probe filled the TOTP and submitted with a bare `keyboard.press("Enter")`. GitHub's current 2FA app page renders an explicit **Verify** button and did not advance on Enter, so the 120s wait for the Seren callback timed out. Stages 1–3 (sign-in, claude-code via Bedrock, history sync) passed.

## Changes (`scripts/windows-e2e-app.mjs`)

- Click an explicit Verify/submit button after filling the OTP; fall back to Enter when none is present.
- Broaden OTP selectors (`one-time-code`, `otp`, `app_otp`, `app_totp`, `inputmode=numeric`) and raise the visibility wait 8s → 20s for the login→2FA transition.
- `waitForLoadState` after submit so the 2FA navigation settles before the authorize check.
- Capture a screenshot + page HTML to the work dir on callback-timeout (named per phase), retrievable from the e2e box — closes the diagnostic gap that required pulling the on-box log by hand.

## Blast radius

Harness-only. `windows-e2e-app.mjs` is not shipped in the app, not imported by product code, and run by no CI job except `windows-app-e2e`. The failure fallback is the original Enter-press, so there is no regression. The Seren-side OAuth calls are unchanged.

## Tests

No new unit test: this is Playwright automation against github.com's live UI with no extractable pure logic; a mock-based test would violate the repo's "never test mocked behavior" rule. `node --check` passes. Definitive verification is a live run of the patched probe against the installed build on the e2e box (tracked in the follow-up walk-through).

## Follow-up (infra, @taariq)

B-2 from #2509: provision a GitHub test account with 2FA disabled for `SEREN_E2E_GITHUB_*` to remove TOTP automation against github.com entirely. No code change needed — the OTP branch is already conditional.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
