### PR TITLE
fix(interview): allow apex serendb.com for catalog + telemetry (#2511)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -26,6 +26,7 @@
     {
       "identifier": "http:default",
       "allow": [
+        { "url": "https://serendb.com/**" },
         { "url": "https://api.serendb.com/**" },
         { "url": "https://mcp.serendb.com/**" },
         { "url": "https://openrouter.ai/**" },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc://localhost http://ipc.localhost ws://127.0.0.1:* http://127.0.0.1:* https://api.serendb.com https://api.github.com https://raw.githubusercontent.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai https://*.thirdweb.com https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org https://*.base.org https://pub-714fe894394345a0a8a102fbac2b208f.r2.dev; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' asset: https: data:; font-src 'self' data: https://fonts.gstatic.com; frame-src http://127.0.0.1:* http://localhost:*",
+      "csp": "default-src 'self'; connect-src 'self' ipc://localhost http://ipc.localhost ws://127.0.0.1:* http://127.0.0.1:* https://serendb.com https://api.serendb.com https://api.github.com https://raw.githubusercontent.com https://api.openai.com https://auth.openai.com https://accounts.google.com https://oauth2.googleapis.com https://generativelanguage.googleapis.com https://openrouter.ai https://*.thirdweb.com https://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org https://*.base.org https://pub-714fe894394345a0a8a102fbac2b208f.r2.dev; script-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' asset: https: data:; font-src 'self' data: https://fonts.gstatic.com; frame-src http://127.0.0.1:* http://localhost:*",
       "assetProtocol": {
         "enable": true,
         "scope": [


### PR DESCRIPTION
## What
Allow the apex `serendb.com` origin in the Tauri HTTP plugin scope and the webview CSP so the employee catalog and interview interest telemetry work in the packaged desktop app.

Closes #2511.

## Why (verified root cause)
- `src/api/employee-catalog.ts:54-56` fetches `https://serendb.com/api/employees`; `src/services/telemetry.ts:50,168` POSTs to `https://serendb.com/api/telemetry/employee-interest`. No `.env`/CI override, so production uses these apex URLs.
- `src/lib/tauri-fetch.ts` routes only the `api.serendb.com` origin through the Rust gateway bridge; apex `serendb.com` falls to `@tauri-apps/plugin-http`, which enforces the capability scope.
- `capabilities/default.json` `http:default` and `tauri.conf.json` CSP `connect-src` listed `api.serendb.com` but not the apex → fetch denied in the packaged app → interview landing (forced startup surface) shows zero roles; telemetry silently dropped. Browser-local/vitest use `globalThis.fetch` (no scope) so they passed.
- Endpoint reality: `GET https://serendb.com/api/employees` → 200; `api.serendb.com` → 404. The endpoint lives on the apex, so allowing the apex is the correct fix (not changing the URL).

## Changes
- `capabilities/default.json`: add `{ "url": "https://serendb.com/**" }` to `http:default`.
- `tauri.conf.json`: add `https://serendb.com` to CSP `connect-src`.

## Verification
JSON validated; apex present in both scope and CSP. Behavioral verification: `pnpm tauri dev` on macOS confirms the interview landing populates roles and interest telemetry POSTs succeed (run post-merge as part of the walk-through). The change is platform-agnostic config, so the packaged Windows build uses the identical scope/CSP.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
