### PR TITLE
fix(interview): keep role selection across catalog refresh (#2512)

### DIFF
--- a/src/components/interview/InterviewLanding.tsx
+++ b/src/components/interview/InterviewLanding.tsx
@@ -7,12 +7,14 @@ import {
   createMemo,
   createSignal,
   For,
+  on,
   onMount,
   Show,
 } from "solid-js";
 import {
   catalogAssetUrl,
   clusterLabel,
+  nextInterviewSelection,
   resolveInterviewEmployeeSlug,
 } from "@/components/interview/interviewLandingModel";
 
@@ -53,12 +55,35 @@ export const InterviewLanding: Component<InterviewLandingProps> = (props) => {
     }),
   );
 
-  createEffect(() => {
-    setSelectedSlug(
-      resolveInterviewEmployeeSlug(employees(), props.initialEmployeeSlug),
-    );
-    setStarted(false);
-  });
+  // A deep link (including an in-place re-open) targets a specific role and
+  // should win, resetting the queued state for the new context.
+  createEffect(
+    on(
+      () => props.initialEmployeeSlug,
+      (requested) => {
+        setSelectedSlug(resolveInterviewEmployeeSlug(employees(), requested));
+        setStarted(false);
+      },
+      { defer: true },
+    ),
+  );
+
+  // Seed the selection from the catalog, but preserve a still-valid manual
+  // selection across catalog refreshes instead of discarding it (#2512).
+  createEffect(
+    on(employees, (list) => {
+      const current = selectedSlug();
+      const next = nextInterviewSelection(
+        current,
+        list,
+        props.initialEmployeeSlug,
+      );
+      if (next !== current) {
+        setSelectedSlug(next);
+        setStarted(false);
+      }
+    }),
+  );
 
   const selectedEmployee = createMemo(() => {
     const slug = selectedSlug();

--- a/src/components/interview/interviewLandingModel.ts
+++ b/src/components/interview/interviewLandingModel.ts
@@ -20,6 +20,22 @@ export function resolveInterviewEmployeeSlug(
     : null;
 }
 
+// Keep a still-valid manual selection when the catalog list is replaced (e.g.
+// a Refresh or a background reload), otherwise fall back to the deep-link slug.
+export function nextInterviewSelection(
+  currentSlug: string | null,
+  employees: readonly Pick<EmployeeCatalogItem, "slug">[],
+  requestedSlug?: string | null,
+): string | null {
+  if (
+    currentSlug &&
+    employees.some((employee) => employee.slug === currentSlug)
+  ) {
+    return currentSlug;
+  }
+  return resolveInterviewEmployeeSlug(employees, requestedSlug);
+}
+
 export function clusterLabel(
   employee: Pick<EmployeeCatalogItem, "cluster">,
 ): string {

--- a/tests/unit/interview-landing.test.ts
+++ b/tests/unit/interview-landing.test.ts
@@ -6,6 +6,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   catalogAssetUrl,
+  nextInterviewSelection,
   resolveInterviewEmployeeSlug,
 } from "@/components/interview/interviewLandingModel";
 
@@ -35,6 +36,17 @@ describe("InterviewLanding", () => {
     expect(catalogAssetUrl("https://cdn.example/role.webp")).toBe(
       "https://cdn.example/role.webp",
     );
+  });
+
+  it("preserves a still-valid manual selection across a catalog refresh", () => {
+    expect(nextInterviewSelection("role-3", catalog, "cfo")).toBe("role-3");
+    expect(nextInterviewSelection("role-3", catalog, null)).toBe("role-3");
+  });
+
+  it("re-seeds from the deep-link slug when the selection is gone or absent", () => {
+    expect(nextInterviewSelection(null, catalog, "cfo")).toBe("cfo");
+    expect(nextInterviewSelection("removed-role", catalog, "cfo")).toBe("cfo");
+    expect(nextInterviewSelection("removed-role", catalog, null)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What
Stop the interview landing from discarding a manual role selection when the catalog list is replaced (Refresh button or a background reload).

Closes #2512.

## Why (verified root cause)
`InterviewLanding.tsx` reset `selectedSlug` in a single `createEffect` that tracked the `employees()` memo. `employeeCatalogStore.refresh()` assigns a new array, so the effect re-ran and unconditionally reset the selection to the deep-link slug (or null). The visible "Refresh" button reproduced it on demand.

## Fix
- New pure helper `nextInterviewSelection(current, employees, requestedSlug)` in `interviewLandingModel.ts`: keep a still-valid current selection, else fall back to `resolveInterviewEmployeeSlug`.
- Split the component reaction into two `on()` effects:
  - deferred effect on `props.initialEmployeeSlug` — a deep link (incl. in-place re-open) still wins and resets the queued state;
  - effect on `employees` — re-seed only when there isn't already a valid selection, preserving manual picks across refreshes.

## Verification
- `tests/unit/interview-landing.test.ts`: added cases for preservation and re-seed; full file 8/8 green.
- `tsc --noEmit`: clean. `biome check`: clean.
- Platform-agnostic SolidJS logic (applies to macOS and Windows). Behavioral check via `pnpm tauri dev` post-merge.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
