### PR TITLE
fix(windows): don't block the UI thread killing children on quit (#2508)

### DIFF
--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -215,11 +215,16 @@ impl ProviderRuntimeState {
                         // kill_on_drop only terminates the immediate child, leaving
                         // grandchild node.exe processes (claude CLI) orphaned and
                         // holding file locks that block the next NSIS install.
+                        // Spawn detached instead of .status(): this runs in the
+                        // RunEvent::Exit handler on the UI thread, and waiting on
+                        // taskkill there freezes "Quit Seren" until the whole tree
+                        // dies (#2508). /F /T is fire-and-forget — taskkill keeps
+                        // running and reaps the tree after we exit.
                         use std::os::windows::process::CommandExt;
                         let _ = std::process::Command::new("taskkill")
                             .args(["/F", "/T", "/PID", &pid.to_string()])
                             .creation_flags(0x08000000) // CREATE_NO_WINDOW
-                            .status();
+                            .spawn();
                     }
                 }
             }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -102,11 +102,16 @@ impl TerminalState {
 
             #[cfg(windows)]
             if let Some(pid) = pid {
+                // Spawn detached instead of .status(): kill_all runs in the
+                // RunEvent::Exit handler on the UI thread, and waiting on
+                // taskkill there freezes "Quit Seren" until the tree dies
+                // (#2508). /F /T is fire-and-forget — taskkill keeps running
+                // and reaps the tree after we exit.
                 use std::os::windows::process::CommandExt;
                 let _ = std::process::Command::new("taskkill")
                     .args(["/F", "/T", "/PID", &pid.to_string()])
                     .creation_flags(0x08000000) // CREATE_NO_WINDOW
-                    .status();
+                    .spawn();
             }
             #[cfg(not(windows))]
             let _ = pid;


### PR DESCRIPTION
## What
Stop "Quit Seren" from freezing the app on Windows.

Closes #2508.

## Why (verified root cause — static analysis through the pinned crate sources)
`PredefinedMenuItem::quit` (lib.rs / tray.rs) posts `WM_QUIT` on Windows → tao's message pump emits `LoopDestroyed` → tauri-runtime-wry maps it to `RunEvent::Exit`, run **synchronously on the UI/message-pump thread**. Our exit cleanup (`lib.rs` ~1111-1130) then calls, on that thread:
- `provider_runtime::kill_sync` → `taskkill /F /T /PID … .status()` (provider_runtime.rs:219)
- `terminal::kill_all` → `taskkill /F /T /PID … .status()` (terminal.rs:106)

`.status()` **blocks** until taskkill terminates the entire descendant tree (provider node → claude/codex/gemini CLI → MCP grandchildren). That pins the UI thread, so the window never closes → "freezes and doesn't close." macOS/Linux use non-blocking `libc::kill(SIGKILL)` and are unaffected — which is why this is Windows-only.

(Investigation also noted a cross-platform amplifier: the WAL `checkpoint_managed_db` at exit can stall ~5s under a held DB lock. That's not the Windows-specific freeze and is left as a separate follow-up.)

## Fix
Spawn taskkill **detached** (`.spawn()` instead of `.status()`) in both Windows kill paths. `taskkill /F /T` is fire-and-forget — once spawned it keeps reaping the tree independently after our process exits, so the exit handler returns immediately and the window closes. Both edits are inside `#[cfg(windows)]` blocks; no macOS/Linux behavior changes.

## Verification — honest status
- `rustfmt --check` parses both files; the change is a swap between two `std::process::Command` methods (both `io::Result<_>`, used with `let _ =`, no new imports) — minimal compile risk.
- I could **not** fully cross-compile-check from macOS: the `x86_64-pc-windows-gnu` check fails in a transitive C dep (`aws-lc-sys` needs `x86_64-w64-mingw32-gcc`), not in this code. Native Windows compilation is covered by release CI.
- Behavioral confirmation (quit closes cleanly) requires a Windows build carrying this fix; pending the next Windows release build. The current `windows-app-e2e` probe does not exercise menu-quit, so it won't cover this.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
