### PR TITLE
fix(chat): paint composer with history on thread switch (#2517)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -2013,7 +2013,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       </Show>
 
       {/* Input Area */}
-      <Show when={hasSession()}>
+      {/* Gate on the active agent thread, not on a live session, so the
+          composer paints in the same frame as the hydrated history instead of
+          waiting for the async spawn. sendMessage()'s cold-start path spawns
+          the session on first send when none exists yet (#1631, #2517). */}
+      <Show when={activeAgentThread()}>
         <div class="shrink-0 border-t border-surface-2 bg-surface-1">
           <form
             class="chat-composer-form flex flex-col gap-2 px-4 pb-4 pt-1.5"
@@ -2044,7 +2048,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 }}
               />
               <ResizableTextarea
-                workspaceDefaultFocus={hasSession()}
+                workspaceDefaultFocus={!!activeAgentThread()}
                 ref={(el) => (inputRef = el)}
                 value={input() ?? ""}
                 placeholder={
@@ -2062,7 +2066,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 onDragOver={handleSkillDragOver}
                 onDrop={(event) => void handleSkillDrop(event)}
                 onKeyDown={handleKeyDown}
-                disabled={!hasSession()}
               />
             </div>
             <Show when={commandStatus()}>
@@ -2168,11 +2171,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                     <button
                       type="submit"
                       class="px-4 py-1.5 bg-success text-white rounded-md text-[13px] font-medium hover:bg-emerald-700 transition-colors disabled:bg-surface-2 disabled:text-muted-foreground disabled:cursor-not-allowed"
-                      disabled={
-                        !hasSession() ||
-                        !(input() ?? "").trim() ||
-                        isProcessingDocs()
-                      }
+                      disabled={!(input() ?? "").trim() || isProcessingDocs()}
                     >
                       Send
                     </button>


### PR DESCRIPTION
## Problem

From the `20260617_load.log` audit: switching agent threads showed the chat history immediately but the composer/input box a beat later — the panel looked half-loaded (`~/Desktop/delay.png`).

## Root cause

History and composer used different readiness gates:
- **History** hydrates from SQLite on switch, independent of any live session (`AgentChat.tsx:449-456`, #2499).
- **Composer** was gated on `hasSession()` (`AgentChat.tsx:2016`), which is `null` until the session finishes spawning. The spawn is fire-and-forget (`thread.store.ts:828`), so the box waited for it.

## Fix

Gate the composer on `activeAgentThread()` (synchronously available on switch) instead of `hasSession()`, so it paints in the same frame as the history. The `!hasSession()` terms on the textarea and Send button are dropped so the box is usable during the brief cold-start window.

This is safe:
- `sendMessage()` already spawns the session on first send when none exists (cold-start path, `AgentChat.tsx:786-836`, #1631).
- The toolbar selectors already accept `session: ActiveSession | null` and render a default state for null.
- The warm path (session present) is unchanged.

## Verification

- `biome check` clean
- `tsc --noEmit` clean
- composer/chat unit tests green (`composer-toolbar-layout`, `composer-no-skill-chips`, `agent-chat-memo-order`, `chat-send-thread-provider`)

Closes #2517

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
