### PR TITLE
fix(chat): guard cold-start against duplicate spawn sends (#2525)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -798,6 +798,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         console.warn("[AgentChat] sendMessage aborted: no open folder");
         return;
       }
+      // A Send/Enter while the cold-start spawn is still running would call
+      // spawnSession again; the store rejects the duplicate (returns null),
+      // which the failure branch below would misread as spawn_failed and tear
+      // down the in-flight spawn. Ignore the extra submit until it's ready.
+      if (agentStore.isSpawning(thread.id)) return;
       agentStore.setTurnInFlight(thread.id, true);
       agentStore.armRestartTimer(thread.id, 60_000, "spawn_failed");
       try {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2105,6 +2105,13 @@ export const agentStore = {
     return state.threadStates[threadId]?.turnInFlight === true;
   },
 
+  /** True while a spawn for this conversation is in flight. Backed by the
+   *  spawnSession dedup guard (added before spawn, removed in finally), so it
+   *  is never stale — used to reject duplicate cold-start sends (#2525). */
+  isSpawning(conversationId: string): boolean {
+    return spawningConversations.has(conversationId);
+  },
+
   getTurnError(threadId: string): TurnError | null {
     return state.threadStates[threadId]?.turnError ?? null;
   },


### PR DESCRIPTION
## Problem

Found in the post-merge functional walk-through of #2517. On a thread with no live session (fresh / just-switched / idle-reclaimed), a **second Send/Enter during the cold-start spawn** showed a spurious red "spawn failed" error, **terminated the session that was spawning**, and dropped the prompt.

#2517 made the composer interactive during cold-start (button stays "Send", input not cleared until `AgentChat.tsx:1003`, `isPrompting()` still false), so a double submit re-enters the cold-start path.

## Race

1. Send #1 → `setTurnInFlight(true)` → `await spawnSession({localSessionId: thread.id})` (adds to `spawningConversations`).
2. Send #2 during the await → `spawnSession` returns **`null`** (duplicate, `agent.store.ts:2771-2777`).
3. Send #2 reads `null` as failure → `setTurnError("spawn_failed")` → flips `turnInFlight=false` (`agent.store.ts:2198`).
4. Send #1 resolves, hits `if (!isTurnInFlight(thread.id))` (`AgentChat.tsx:813`) → true → **terminates its own freshly-spawned session**.

## Fix

- `agent.store.ts`: expose `isSpawning(conversationId)` over the existing `spawningConversations` dedup Set (added before spawn, removed in `finally` → never stale).
- `AgentChat.tsx`: in the cold-start block, before `setTurnInFlight(true)`, `if (agentStore.isSpawning(thread.id)) return;`.

The first send still cold-starts and dispatches; extra submits during the spawn are ignored until the session is ready, after which normal send/queue applies. Warm path unchanged.

## Verification

- `biome check` clean · `tsc --noEmit` clean
- chat regression tests green (`chat-send-thread-provider`, `agent-chat-memo-order`, `chat-queue-serial-drain`, `chat-store-reset`)
- Pure frontend; behaviour identical on macOS and Windows.

Closes #2525

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
