### PR TITLE
fix(e2e): disambiguate GitHub login submit from passkey button (#2527)

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -339,7 +339,14 @@ async function completeGithubAuthorization(authUrl, label) {
     if (await login.isVisible({ timeout: 10_000 }).catch(() => false)) {
       await login.fill(GITHUB_USERNAME);
       await page.locator("#password, input[name='password']").first().fill(GITHUB_PASSWORD);
-      await page.getByRole("button", { name: /sign in/i }).click();
+      // Target the password form's submit, not a name regex: GitHub now also
+      // renders a "Sign in with a passkey" <button>, so /sign in/i matched two
+      // elements and tripped Playwright strict mode (#2527). The passkey is a
+      // type="button", so the submit selector can't collide with it.
+      await page
+        .locator("input[type='submit'][name='commit'], button[type='submit']")
+        .first()
+        .click();
     }
 
     const otpInput = page
@@ -378,10 +385,17 @@ async function completeGithubAuthorization(authUrl, label) {
     await page.waitForURL(/localhost:8787\/oauth\/callback|127\.0\.0\.1:8787\/oauth\/callback|github\.com\/settings\/connections/, {
       timeout: 120_000,
     }).catch(async () => {
-      await captureOAuthFailureArtifacts(page, label);
       const body = await page.locator("body").innerText({ timeout: 5_000 }).catch(() => "");
       throw new Error(`GitHub OAuth did not reach the Seren callback. URL=${page.url()} Body=${body.slice(0, 500)}`);
     });
+  } catch (error) {
+    // Any failure in the GitHub flow — login, 2FA, authorize, or callback —
+    // leaves a screenshot + page HTML in the work dir so the next github.com
+    // UI change is a quick fix, not a hand-pulled on-box log (#2527). The
+    // earlier login-button failure produced no artifact because capture was
+    // scoped only to the callback timeout.
+    await captureOAuthFailureArtifacts(page, label);
+    throw error;
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
## What
Fix the release e2e GitHub OAuth-reconnect stage, which broke at the **login** step on v3.56.1.

Closes #2527.

## Why (verified from the on-box log, run 27697057462)
The probe now clears sign-in, the claude-code Bedrock journey, history sync, and PAT validation, then fails in `completeGithubAuthorization`:
```
locator.click: strict mode violation: getByRole('button', { name: /sign in/i }) resolved to 2 elements:
  1) <input type="submit" name="commit" value="Sign in" class="js-sign-in-button">
  2) <button ...webauthn...> "Sign in with a passkey"
```
GitHub added a **"Sign in with a passkey"** button; `/sign in/i` matches both → Playwright strict mode throws. The #2509 fix targeted the *2FA* submit; this is one step earlier, at the password login.

## Changes (`scripts/windows-e2e-app.mjs`)
- Click the password form's submit `input[type='submit'][name='commit'], button[type='submit']` instead of a name regex. The passkey is a `type="button"`, so the submit selector can't collide with it (and it's immune to label/casing changes).
- Capture screenshot + page HTML on **any** failure in the GitHub flow, not just the callback timeout — this login failure left no artifact and had to be diagnosed from the on-box log.

## Tests
No unit test: Playwright automation of github.com's live UI, no extractable pure logic (same rationale as #2509). `node --check` passes. Real verification is the next Windows release-build e2e.

## Structural recommendation (separate, @taariq)
This is the **2nd release in a row** the OAuth-reconnect gate broke on a different github.com login element (v3.56.0: 2FA submit; v3.56.1: login passkey). The sub-test can only validate Seren's OAuth by automating GitHub's ever-changing login UI. Recommend making OAuth-reconnect **non-blocking** (run it, surface failures as warnings + the screenshot artifact, but don't gate releases on github.com UI churn) so the gate blocks only on Seren's own functionality. Filed in #2527 for your decision.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
