### PR TITLE
fix: complete employee intake handoff

### DIFF
--- a/src/components/interview/InterviewLanding.tsx
+++ b/src/components/interview/InterviewLanding.tsx
@@ -17,6 +17,11 @@ import {
   nextInterviewSelection,
   resolveInterviewEmployeeSlug,
 } from "@/components/interview/interviewLandingModel";
+import { openExternalLink } from "@/lib/external-link";
+import {
+  EMPLOYEE_INTAKE_CALENDLY_URL,
+  submitGeneralEmployeeIntake,
+} from "@/services/employee-intake";
 
 export {
   CLOSE_INTERVIEW_LANDING_EVENT,
@@ -35,7 +40,15 @@ interface InterviewLandingProps {
 
 export const InterviewLanding: Component<InterviewLandingProps> = (props) => {
   const [selectedSlug, setSelectedSlug] = createSignal<string | null>(null);
-  const [started, setStarted] = createSignal(false);
+  const [step, setStep] = createSignal<"select" | "questions" | "complete">(
+    "select",
+  );
+  const [goals, setGoals] = createSignal("");
+  const [requirements, setRequirements] = createSignal("");
+  const [tools, setTools] = createSignal("");
+  const [discussionNotes, setDiscussionNotes] = createSignal("");
+  const [submitting, setSubmitting] = createSignal(false);
+  const [submitError, setSubmitError] = createSignal<string | null>(null);
 
   onMount(() => {
     if (
@@ -62,7 +75,8 @@ export const InterviewLanding: Component<InterviewLandingProps> = (props) => {
       () => props.initialEmployeeSlug,
       (requested) => {
         setSelectedSlug(resolveInterviewEmployeeSlug(employees(), requested));
-        setStarted(false);
+        setStep("select");
+        setSubmitError(null);
       },
       { defer: true },
     ),
@@ -80,7 +94,8 @@ export const InterviewLanding: Component<InterviewLandingProps> = (props) => {
       );
       if (next !== current) {
         setSelectedSlug(next);
-        setStarted(false);
+        setStep("select");
+        setSubmitError(null);
       }
     }),
   );
@@ -91,9 +106,47 @@ export const InterviewLanding: Component<InterviewLandingProps> = (props) => {
     return employeeCatalogStore.bySlug(slug) ?? null;
   });
 
+  const isComplete = createMemo(
+    () =>
+      !!selectedSlug() &&
+      goals().trim().length > 0 &&
+      requirements().trim().length > 0 &&
+      tools().trim().length > 0 &&
+      discussionNotes().trim().length > 0,
+  );
+
   const handleStartInterview = () => {
-    setStarted(true);
+    if (!selectedSlug()) {
+      setSubmitError("Choose a Seren employee before starting the intake.");
+      return;
+    }
+    setStep("questions");
+    setSubmitError(null);
     props.onStartInterview?.(selectedSlug());
+  };
+
+  const handleSubmitIntake = async () => {
+    if (!isComplete()) {
+      setSubmitError("Complete each intake field before scheduling.");
+      return;
+    }
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await submitGeneralEmployeeIntake({
+        selectedEmployeeSlug: selectedSlug(),
+        goals: goals(),
+        requirements: requirements(),
+        tools: tools(),
+        discussionNotes: discussionNotes(),
+      });
+      setStep("complete");
+      await openExternalLink(EMPLOYEE_INTAKE_CALENDLY_URL);
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -159,22 +212,124 @@ export const InterviewLanding: Component<InterviewLandingProps> = (props) => {
           </Show>
         </div>
 
-        <button
-          type="button"
-          class="mt-5 flex h-10 w-full items-center justify-center rounded-md border border-primary/70 bg-primary text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:border-border disabled:bg-surface-2 disabled:text-muted-foreground"
-          disabled={employeeCatalogStore.loading || employees().length === 0}
-          data-testid="start-employee-interview"
-          onClick={handleStartInterview}
+        <Show
+          when={step() === "questions"}
+          fallback={
+            <Show
+              when={step() === "complete"}
+              fallback={
+                <button
+                  type="button"
+                  class="mt-5 flex h-10 w-full items-center justify-center rounded-md border border-primary/70 bg-primary text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:border-border disabled:bg-surface-2 disabled:text-muted-foreground"
+                  disabled={
+                    employeeCatalogStore.loading ||
+                    employees().length === 0 ||
+                    !selectedSlug()
+                  }
+                  data-testid="start-employee-interview"
+                  onClick={handleStartInterview}
+                >
+                  Start Interview
+                </button>
+              }
+            >
+              <div
+                class="mt-5 rounded-md border border-success/40 bg-success/10 px-3 py-3"
+                data-testid="interview-complete-state"
+              >
+                <p class="m-0 text-[13px] font-semibold text-success">
+                  Intake sent to Seren.
+                </p>
+                <p class="mt-1 mb-0 text-[12px] leading-snug text-muted-foreground">
+                  Calendly is open for your follow-up call.
+                </p>
+                <button
+                  type="button"
+                  class="mt-3 h-9 w-full rounded-md border border-border/80 bg-surface-1 text-[12px] font-medium text-foreground hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/70"
+                  onClick={() =>
+                    void openExternalLink(EMPLOYEE_INTAKE_CALENDLY_URL)
+                  }
+                >
+                  Open Calendly
+                </button>
+              </div>
+            </Show>
+          }
         >
-          Start Interview
-        </button>
-        <Show when={started()}>
-          <p
-            class="mt-3 mb-0 text-[12px] leading-snug text-success"
-            data-testid="interview-started-state"
-          >
-            Intake queued for Seren Employee customization.
-          </p>
+          <div class="mt-5 space-y-3" data-testid="employee-intake-form">
+            <label class="block">
+              <span class="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                Goals
+              </span>
+              <textarea
+                class="mt-1 min-h-20 w-full resize-y rounded-md border border-border/80 bg-surface-1 px-3 py-2 text-[13px] leading-snug text-foreground outline-none focus:border-primary/70"
+                value={goals()}
+                onInput={(event) => setGoals(event.currentTarget.value)}
+              />
+            </label>
+            <label class="block">
+              <span class="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                Requirements
+              </span>
+              <textarea
+                class="mt-1 min-h-20 w-full resize-y rounded-md border border-border/80 bg-surface-1 px-3 py-2 text-[13px] leading-snug text-foreground outline-none focus:border-primary/70"
+                value={requirements()}
+                onInput={(event) => setRequirements(event.currentTarget.value)}
+              />
+            </label>
+            <label class="block">
+              <span class="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                Tools
+              </span>
+              <textarea
+                class="mt-1 min-h-16 w-full resize-y rounded-md border border-border/80 bg-surface-1 px-3 py-2 text-[13px] leading-snug text-foreground outline-none focus:border-primary/70"
+                value={tools()}
+                onInput={(event) => setTools(event.currentTarget.value)}
+              />
+            </label>
+            <label class="block">
+              <span class="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                Discuss with Seren
+              </span>
+              <textarea
+                class="mt-1 min-h-20 w-full resize-y rounded-md border border-border/80 bg-surface-1 px-3 py-2 text-[13px] leading-snug text-foreground outline-none focus:border-primary/70"
+                value={discussionNotes()}
+                onInput={(event) =>
+                  setDiscussionNotes(event.currentTarget.value)
+                }
+              />
+            </label>
+            <div class="flex gap-2">
+              <button
+                type="button"
+                class="h-10 flex-1 rounded-md border border-primary/70 bg-primary text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-not-allowed disabled:border-border disabled:bg-surface-2 disabled:text-muted-foreground"
+                disabled={submitting() || !isComplete()}
+                data-testid="submit-employee-intake"
+                onClick={() => void handleSubmitIntake()}
+              >
+                {submitting() ? "Sending..." : "Send and Schedule"}
+              </button>
+              <button
+                type="button"
+                class="h-10 rounded-md border border-border/80 bg-transparent px-3 text-[12px] font-medium text-muted-foreground hover:bg-surface-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/70"
+                disabled={submitting()}
+                onClick={() => setStep("select")}
+              >
+                Back
+              </button>
+            </div>
+          </div>
+        </Show>
+        <Show when={submitError()}>
+          {(message) => (
+            <p
+              class="mt-3 mb-0 text-[12px] leading-snug text-status-error"
+              role="alert"
+              data-testid="interview-submit-error"
+            >
+              {message()}
+            </p>
+          )}
         </Show>
       </aside>
 

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -848,11 +848,6 @@ export const AppShell: Component<AppShellProps> = (props) => {
                   "desktop-interview-start",
                   "interview-started",
                 );
-                window.dispatchEvent(
-                  new CustomEvent("seren:start-employee-interview", {
-                    detail: { employee: employeeSlug },
-                  }),
-                );
               }}
             />
           </Show>

--- a/src/services/employee-intake.ts
+++ b/src/services/employee-intake.ts
@@ -1,0 +1,74 @@
+// ABOUTME: Website handoff client for completed Seren Employee intake notes.
+// ABOUTME: Persists the general intake and carries the Calendly scheduling URL.
+
+import { appFetch } from "@/lib/fetch";
+import { getToken } from "@/lib/tauri-bridge";
+import { websiteApiUrl } from "@/services/telemetry";
+
+export const EMPLOYEE_INTAKE_CALENDLY_URL = "https://calendly.com/taariq/30min";
+
+export interface GeneralEmployeeIntakeInput {
+  selectedEmployeeSlug: string | null;
+  goals: string;
+  requirements: string;
+  tools: string;
+  discussionNotes: string;
+}
+
+export interface GeneralEmployeeIntakePayload {
+  selected_employee_slug: string | null;
+  goals: string;
+  requirements: string;
+  tools: string;
+  discussion_notes: string;
+  calendly_url: string;
+}
+
+export function buildGeneralEmployeeIntakePayload(
+  input: GeneralEmployeeIntakeInput,
+): GeneralEmployeeIntakePayload {
+  return {
+    selected_employee_slug: input.selectedEmployeeSlug,
+    goals: input.goals.trim(),
+    requirements: input.requirements.trim(),
+    tools: input.tools.trim(),
+    discussion_notes: input.discussionNotes.trim(),
+    calendly_url: EMPLOYEE_INTAKE_CALENDLY_URL,
+  };
+}
+
+export async function submitGeneralEmployeeIntake(
+  input: GeneralEmployeeIntakeInput,
+): Promise<void> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  const token = await getToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await appFetch(
+    websiteApiUrl("/api/general-interview-submissions"),
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(buildGeneralEmployeeIntakePayload(input)),
+    },
+  );
+
+  if (!response.ok) {
+    let message = `Failed to submit intake: HTTP ${response.status}`;
+    try {
+      const body = await response.json();
+      if (typeof body?.error === "string") {
+        message = body.error;
+      } else if (typeof body?.message === "string") {
+        message = body.message;
+      }
+    } catch {
+      // Keep the HTTP status fallback.
+    }
+    throw new Error(message);
+  }
+}

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -40,7 +40,7 @@ export interface EmployeeInterestTelemetryInput {
 }
 
 export interface EmployeeInterestTelemetryPayload {
-  selected_employee_slug: string | null;
+  employee_slug: string;
   event: string;
   source: string;
   occurred_at: string;
@@ -58,9 +58,10 @@ export function websiteApiUrl(path: string): string {
 export function buildEmployeeInterestTelemetryPayload(
   input: EmployeeInterestTelemetryInput,
   now = new Date(),
-): EmployeeInterestTelemetryPayload {
+): EmployeeInterestTelemetryPayload | null {
+  if (!input.employeeSlug) return null;
   return {
-    selected_employee_slug: input.employeeSlug ?? null,
+    employee_slug: input.employeeSlug,
     event: input.event ?? "interview-launched",
     source: input.source,
     occurred_at: now.toISOString(),
@@ -155,6 +156,8 @@ class TelemetryService {
     input: EmployeeInterestTelemetryInput,
   ): Promise<void> {
     if (!this.config.enabled) return;
+    const payload = buildEmployeeInterestTelemetryPayload(input);
+    if (!payload) return;
 
     try {
       const headers: Record<string, string> = {
@@ -168,7 +171,7 @@ class TelemetryService {
       await appFetch(websiteApiUrl("/api/telemetry/employee-interest"), {
         method: "POST",
         headers,
-        body: JSON.stringify(buildEmployeeInterestTelemetryPayload(input)),
+        body: JSON.stringify(payload),
       });
     } catch {
       // Product telemetry is best-effort and must never block the intake.

--- a/tests/unit/employee-intake-service.test.ts
+++ b/tests/unit/employee-intake-service.test.ts
@@ -1,0 +1,29 @@
+// ABOUTME: Regression coverage for the desktop-to-website employee intake handoff.
+// ABOUTME: Verifies the payload shape expected by the website submission API.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildGeneralEmployeeIntakePayload,
+  EMPLOYEE_INTAKE_CALENDLY_URL,
+} from "@/services/employee-intake";
+
+describe("employee intake service", () => {
+  it("builds the general interview submission payload expected by the website", () => {
+    expect(
+      buildGeneralEmployeeIntakePayload({
+        selectedEmployeeSlug: "cfo",
+        goals: "  weekly cash visibility  ",
+        requirements: " board-ready controls ",
+        tools: " NetSuite, Excel ",
+        discussionNotes: " implementation timeline ",
+      }),
+    ).toEqual({
+      selected_employee_slug: "cfo",
+      goals: "weekly cash visibility",
+      requirements: "board-ready controls",
+      tools: "NetSuite, Excel",
+      discussion_notes: "implementation timeline",
+      calendly_url: EMPLOYEE_INTAKE_CALENDLY_URL,
+    });
+  });
+});

--- a/tests/unit/employee-interview-telemetry.test.ts
+++ b/tests/unit/employee-interview-telemetry.test.ts
@@ -20,7 +20,7 @@ describe("employee interview telemetry", () => {
         new Date("2026-06-17T01:00:00.000Z"),
       ),
     ).toEqual({
-      selected_employee_slug: "ciso",
+      employee_slug: "ciso",
       event: "interview-launched",
       source: "desktop-deep-link",
       occurred_at: "2026-06-17T01:00:00.000Z",
@@ -33,7 +33,7 @@ describe("employee interview telemetry", () => {
         employeeSlug: null,
         event: "role-selected",
         source: "desktop-role-selection",
-      }).selected_employee_slug,
+      }),
     ).toBeNull();
   });
 
@@ -49,6 +49,7 @@ describe("employee interview telemetry", () => {
 
     expect(app).not.toContain("interview-intent");
     expect(shell).not.toContain("interview-intent");
+    expect(shell).not.toContain("seren:start-employee-interview");
     expect(app).toContain("OPEN_INTERVIEW_LANDING_EVENT");
     expect(shell).toContain("recordEmployeeInterest");
   });

--- a/tests/unit/interview-landing.test.ts
+++ b/tests/unit/interview-landing.test.ts
@@ -67,6 +67,18 @@ describe("AppShell interview landing wiring", () => {
     expect(appShell).not.toContain("persistInterviewLandingDismissed");
   });
 
+  it("submits the desktop intake instead of dispatching an unhandled queued event", () => {
+    const landing = readFileSync(
+      resolve("src/components/interview/InterviewLanding.tsx"),
+      "utf8",
+    );
+
+    expect(landing).toContain("submitGeneralEmployeeIntake");
+    expect(landing).toContain("EMPLOYEE_INTAKE_CALENDLY_URL");
+    expect(landing).not.toContain("Intake queued for Seren Employee customization");
+    expect(appShell).not.toContain("seren:start-employee-interview");
+  });
+
   it("listens for desktop interview deep links", () => {
     expect(appShell).toContain("listenForInterviewLaunch");
     expect(appShell).toContain("OPEN_INTERVIEW_LANDING_EVENT");


### PR DESCRIPTION
Closes #2531.

## Audit result
- Fixed P1 desktop intake blocker from `~/Downloads/Logs/20260617_intake.log` and `~/Desktop/intake.png`.
- Replaced the inert queued state with a general intake form that captures role, goals, requirements, tools, and discussion notes.
- Posts completed intake notes to `/api/general-interview-submissions` and opens `https://calendly.com/taariq/30min` after a successful handoff.
- Corrected employee-interest telemetry to send `employee_slug`, matching the website endpoint.
- Removed the unhandled `seren:start-employee-interview` event dispatch.

## Audited code paths
- `src/components/interview/InterviewLanding.tsx`
- `src/components/layout/AppShell.tsx`
- `src/services/telemetry.ts`
- `src/services/employee-intake.ts`
- `tests/unit/interview-landing.test.ts`
- `tests/unit/employee-interview-telemetry.test.ts`
- `tests/unit/employee-intake-service.test.ts`

## Verification
- `pnpm exec biome check src/services/employee-intake.ts src/services/telemetry.ts src/components/interview/InterviewLanding.tsx src/components/layout/AppShell.tsx tests/unit/interview-landing.test.ts tests/unit/employee-interview-telemetry.test.ts tests/unit/employee-intake-service.test.ts`
- `pnpm test -- tests/unit/interview-landing.test.ts tests/unit/employee-interview-telemetry.test.ts tests/unit/employee-intake-service.test.ts` (repo ran 272 files / 1875 tests)
- `pnpm exec tsc --noEmit`
- Browser walkthrough at `http://localhost:1420/` with mocked catalog/submission endpoints: role select -> Start Interview -> intake form -> submit -> expected payload -> Calendly popup
- `pnpm build`
- `pnpm verify:frontend-build`
- Windows static unit subset: `pnpm test -- tests/unit/windows-e2e-release-gate.test.ts tests/unit/windows-cargo-manifest.test.ts tests/unit/windows-signables.test.ts tests/unit/print-windows-signables.test.ts tests/unit/windows-sign-overlay.test.ts` (repo ran 272 files / 1875 tests)