### PR TITLE
Fix agent catalog crash on malformed rows

### DIFF
--- a/src/components/catalog/CatalogEntryModal.tsx
+++ b/src/components/catalog/CatalogEntryModal.tsx
@@ -44,6 +44,16 @@ function parseJsonOrFallback(value: string, fallback: unknown): unknown {
   }
 }
 
+function stringifyJsonOrFallback(value: unknown, fallback: unknown): string {
+  const candidate = value ?? fallback;
+  try {
+    const json = JSON.stringify(candidate, null, 2);
+    return typeof json === "string" ? json : JSON.stringify(fallback, null, 2);
+  } catch {
+    return JSON.stringify(fallback, null, 2);
+  }
+}
+
 export const CatalogEntryModal: Component<CatalogEntryModalProps> = (props) => {
   const mode = (): Mode => (props.entry ? "edit" : "create");
 
@@ -64,11 +74,11 @@ export const CatalogEntryModal: Component<CatalogEntryModalProps> = (props) => {
     props.entry?.deprecated ?? false,
   );
   const [labelsText, setLabelsText] = createSignal(
-    props.entry ? JSON.stringify(props.entry.labels, null, 2) : "{}",
+    props.entry ? stringifyJsonOrFallback(props.entry.labels, {}) : "{}",
   );
   const [sourceText, setSourceText] = createSignal(
     props.entry
-      ? JSON.stringify(props.entry.source, null, 2)
+      ? stringifyJsonOrFallback(props.entry.source, { type: "inline" })
       : '{"type": "inline"}',
   );
 

--- a/src/components/catalog/CatalogList.tsx
+++ b/src/components/catalog/CatalogList.tsx
@@ -16,6 +16,7 @@ import {
   agentCatalog,
   type CatalogEntry,
   type CatalogEntryKind,
+  normalizeAgentCatalogEntries,
 } from "@/services/agent-catalog";
 
 const KIND_LABEL: Record<CatalogEntryKind, string> = {
@@ -71,8 +72,12 @@ export const CatalogList: Component = () => {
     },
   );
 
+  const safeEntries = createMemo(() =>
+    normalizeAgentCatalogEntries(entries() ?? []),
+  );
+
   const grouped = createMemo(() => {
-    const list = entries() ?? [];
+    const list = safeEntries();
     const byKind = new Map<CatalogEntryKind, CatalogEntry[]>();
     for (const entry of list) {
       const bucket = byKind.get(entry.kind) ?? [];
@@ -178,9 +183,7 @@ export const CatalogList: Component = () => {
         </div>
       </Show>
       <Show
-        when={
-          !entries.loading && !entries.error && (entries() ?? []).length === 0
-        }
+        when={!entries.loading && !entries.error && safeEntries().length === 0}
       >
         <div class="text-[13px] text-muted-foreground">
           No catalog entries yet.

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import {
   type Component,
   createEffect,
   createSignal,
+  ErrorBoundary,
   Match,
   on,
   onCleanup,
@@ -824,7 +825,36 @@ export const AppShell: Component<AppShellProps> = (props) => {
                       </Show>
                     }
                   >
-                    <CatalogList />
+                    <ErrorBoundary
+                      fallback={(error) => {
+                        telemetry.reportError(
+                          error instanceof Error
+                            ? error
+                            : new Error(String(error)),
+                          { surface: "agent_catalog" },
+                        );
+                        return (
+                          <div class="flex h-full min-h-[320px] flex-col items-center justify-center gap-3 p-6 text-center">
+                            <div class="text-sm font-semibold text-foreground">
+                              Agent catalog is recovering.
+                            </div>
+                            <div class="max-w-md text-[13px] text-muted-foreground">
+                              The catalog view hit an unexpected entry, but the
+                              rest of Seren is still available.
+                            </div>
+                            <button
+                              type="button"
+                              class="rounded border border-border bg-card px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-surface-2"
+                              onClick={handleCloseCatalog}
+                            >
+                              Back to workspace
+                            </button>
+                          </div>
+                        );
+                      }}
+                    >
+                      <CatalogList />
+                    </ErrorBoundary>
                   </Show>
                 }
               >

--- a/src/services/agent-catalog.ts
+++ b/src/services/agent-catalog.ts
@@ -28,6 +28,94 @@ export type CatalogListQuery = {
   includeDeprecated?: boolean;
 };
 
+const CATALOG_ENTRY_KINDS: CatalogEntryKind[] = [
+  "agent",
+  "skill",
+  "mcp_server",
+  "prompt",
+  "runtime_policy",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function stringField(obj: Record<string, unknown>, key: string): string | null {
+  const value = obj[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function optionalStringField(
+  obj: Record<string, unknown>,
+  key: string,
+): string | null | undefined {
+  const value = obj[key];
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return typeof value === "string" ? value : undefined;
+}
+
+function catalogKind(value: unknown): CatalogEntryKind | null {
+  return typeof value === "string" &&
+    CATALOG_ENTRY_KINDS.includes(value as CatalogEntryKind)
+    ? (value as CatalogEntryKind)
+    : null;
+}
+
+export function normalizeAgentCatalogEntry(
+  value: unknown,
+): CatalogEntry | null {
+  if (!isRecord(value)) return null;
+
+  const id = stringField(value, "id");
+  const name = stringField(value, "name");
+  const version = stringField(value, "version");
+  const kind = catalogKind(value.kind);
+
+  if (!id || !name || !version || !kind) {
+    return null;
+  }
+
+  return {
+    annotations: value.annotations ?? {},
+    category: optionalStringField(value, "category") ?? null,
+    created_at: stringField(value, "created_at") ?? "",
+    created_by_user_id: optionalStringField(value, "created_by_user_id"),
+    deprecated: value.deprecated === true,
+    description: typeof value.description === "string" ? value.description : "",
+    id,
+    kind,
+    labels: value.labels ?? {},
+    name,
+    namespace: stringField(value, "namespace") ?? "default",
+    organization_id: stringField(value, "organization_id") ?? "",
+    requires: isRecord(value.requires)
+      ? (value.requires as CatalogEntry["requires"])
+      : undefined,
+    source: value.source ?? { type: "inline" },
+    tag: optionalStringField(value, "tag") ?? null,
+    trust: value.trust ?? {},
+    updated_at: stringField(value, "updated_at") ?? "",
+    version,
+  };
+}
+
+export function normalizeAgentCatalogEntries(value: unknown): CatalogEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const normalized = normalizeAgentCatalogEntry(entry);
+    return normalized ? [normalized] : [];
+  });
+}
+
+function requireCatalogEntry(value: unknown, action: string): CatalogEntry {
+  const entry = normalizeAgentCatalogEntry(value);
+  if (!entry) {
+    throw new Error(`Catalog ${action} response did not include a valid entry`);
+  }
+  return entry;
+}
+
 export const agentCatalog = {
   async list(
     organizationId: string,
@@ -49,7 +137,7 @@ export const agentCatalog = {
         `Failed to list catalog entries: ${formatApiError(error, response, "")}`,
       );
     }
-    return data?.data?.data ?? [];
+    return normalizeAgentCatalogEntries(data?.data?.data);
   },
 
   async get(organizationId: string, entryId: string): Promise<CatalogEntry> {
@@ -62,10 +150,7 @@ export const agentCatalog = {
         `Failed to load catalog entry: ${formatApiError(error, response, "")}`,
       );
     }
-    if (!data?.data) {
-      throw new Error("Catalog entry response did not include a body");
-    }
-    return data.data;
+    return requireCatalogEntry(data?.data, "load");
   },
 
   async resolveTag(
@@ -88,10 +173,7 @@ export const agentCatalog = {
         `Failed to resolve catalog tag: ${formatApiError(error, response, "")}`,
       );
     }
-    if (!data?.data) {
-      throw new Error("Catalog tag-resolution response did not include a body");
-    }
-    return data.data;
+    return requireCatalogEntry(data?.data, "tag-resolution");
   },
 
   async create(
@@ -108,10 +190,7 @@ export const agentCatalog = {
         `Failed to create catalog entry: ${formatApiError(error, response, "")}`,
       );
     }
-    if (!data?.data) {
-      throw new Error("Catalog create response did not include a body");
-    }
-    return data.data;
+    return requireCatalogEntry(data?.data, "create");
   },
 
   async update(
@@ -129,10 +208,7 @@ export const agentCatalog = {
         `Failed to update catalog entry: ${formatApiError(error, response, "")}`,
       );
     }
-    if (!data?.data) {
-      throw new Error("Catalog update response did not include a body");
-    }
-    return data.data;
+    return requireCatalogEntry(data?.data, "update");
   },
 
   async delete(organizationId: string, entryId: string): Promise<void> {

--- a/tests/unit/agent-catalog-normalization.test.ts
+++ b/tests/unit/agent-catalog-normalization.test.ts
@@ -1,0 +1,73 @@
+// ABOUTME: Regression coverage for malformed Agent Catalog rows.
+// ABOUTME: Keeps catalog data drift from crashing the desktop shell.
+
+import { describe, expect, it } from "vitest";
+import {
+  normalizeAgentCatalogEntries,
+  normalizeAgentCatalogEntry,
+} from "@/services/agent-catalog";
+
+describe("agent catalog normalization", () => {
+  it("normalizes nullable display fields without throwing", () => {
+    const entry = normalizeAgentCatalogEntry({
+      id: "entry-1",
+      kind: "agent",
+      name: "triage-agent",
+      namespace: null,
+      version: "1.0.0",
+      description: null,
+      deprecated: null,
+      labels: null,
+      source: undefined,
+      updated_at: null,
+    });
+
+    expect(entry).toMatchObject({
+      id: "entry-1",
+      kind: "agent",
+      name: "triage-agent",
+      namespace: "default",
+      version: "1.0.0",
+      description: "",
+      deprecated: false,
+      labels: {},
+      source: { type: "inline" },
+      updated_at: "",
+    });
+  });
+
+  it("drops rows that cannot render or support actions safely", () => {
+    const entries = normalizeAgentCatalogEntries([
+      {
+        id: "valid",
+        kind: "prompt",
+        name: "brief",
+        namespace: "default",
+        version: "2026.06.17",
+        updated_at: "2026-06-17T18:04:13.000Z",
+      },
+      {
+        id: "missing-kind",
+        name: "bad-row",
+        namespace: "default",
+        version: "1.0.0",
+      },
+      {
+        id: "unknown-kind",
+        kind: "future_kind",
+        name: "future-row",
+        namespace: "default",
+        version: "1.0.0",
+      },
+      {
+        kind: "agent",
+        name: "missing-id",
+        namespace: "default",
+        version: "1.0.0",
+      },
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.id).toBe("valid");
+  });
+});


### PR DESCRIPTION
## Summary
- Normalizes Agent Catalog API rows before list/detail consumers use them.
- Drops rows missing required render/action identity instead of letting the catalog view throw.
- Adds a catalog-local `ErrorBoundary` so future catalog-only render defects do not collapse the full desktop shell.
- Hardens edit modal JSON textarea initialization for missing `labels` / `source` fields.

Fixes #2534

## Audited code paths
- `src/services/agent-catalog.ts`
- `src/components/catalog/CatalogList.tsx`
- `src/components/catalog/CatalogEntryModal.tsx`
- `src/components/layout/AppShell.tsx`
- `src/App.tsx` root `ErrorBoundary` behavior from crash log

## Verification
- `pnpm vitest run tests/unit/agent-catalog-normalization.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec biome check src/services/agent-catalog.ts src/components/catalog/CatalogList.tsx src/components/catalog/CatalogEntryModal.tsx src/components/layout/AppShell.tsx tests/unit/agent-catalog-normalization.test.ts`
- Final audit confirmed the remaining `localeCompare` calls consume normalized string fields.
