### PR TITLE
Fix stuck agent turn after provider send failures

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2214,6 +2214,49 @@ export const agentStore = {
     setState("threadStates", threadId, "turnError", null);
   },
 
+  failTurnForSession(
+    sessionId: string,
+    message: string,
+    kind: ErrorKind = "crash_ceiling",
+  ): void {
+    const session = state.sessions[sessionId];
+    const threadId = session?.conversationId;
+    if (!threadId) return;
+
+    const turnIsActive =
+      this.isTurnInFlight(threadId) || session.info.status === "prompting";
+    if (!turnIsActive) return;
+
+    const existing = state.threadStates[threadId]?.turnError;
+    if (
+      existing?.kind === kind &&
+      existing.message === message &&
+      !this.isTurnInFlight(threadId)
+    ) {
+      if (state.sessions[sessionId]?.info.status === "prompting") {
+        setState(
+          "sessions",
+          sessionId,
+          "info",
+          "status",
+          "ready" as SessionStatus,
+        );
+      }
+      return;
+    }
+
+    this.setTurnError(threadId, kind, message);
+    if (state.sessions[sessionId]?.info.status === "prompting") {
+      setState(
+        "sessions",
+        sessionId,
+        "info",
+        "status",
+        "ready" as SessionStatus,
+      );
+    }
+  },
+
   async recoverDroppedPrompt(
     sessionId: string,
     reason: string,
@@ -5516,10 +5559,15 @@ export const agentStore = {
             "[AgentStore] sendPrompt: waiting for in-flight compaction to complete",
           );
           await compactPromise;
+        } else {
+          this.addErrorMessage(sessionId, message);
+          this.failTurnForSession(sessionId, message);
         }
-        // Don't add error message — compactAndRetry handles fallback
+        // If compactAndRetry is active it owns the terminal fallback. Without
+        // that promise this catch path is the only terminal failure signal.
       } else if (!message.includes("Task cancelled")) {
         this.addErrorMessage(sessionId, message);
+        this.failTurnForSession(sessionId, message);
       }
 
       // Ensure the session is not stuck in "prompting" after any error —
@@ -6604,6 +6652,7 @@ export const agentStore = {
                 );
                 setState("sessions", sessionId, "promptTooLong", true);
                 this.addErrorMessage(sessionId, event.data.error);
+                this.failTurnForSession(sessionId, String(event.data.error));
                 this.acceptRateLimitFallback().catch((err) => {
                   console.error("[AgentStore] Auto-failover failed:", err);
                 });
@@ -6618,10 +6667,10 @@ export const agentStore = {
                 console.warn(
                   "[AgentStore] Compaction skipped (nothing to compact). Session is too small to compact — surfacing error to user without Chat fallback.",
                 );
-                this.addErrorMessage(
-                  sessionId,
-                  "This thread is too full for the model's context window and there is nothing left to compact. Start a new thread to continue.",
-                );
+                const terminalMessage =
+                  "This thread is too full for the model's context window and there is nothing left to compact. Start a new thread to continue.";
+                this.addErrorMessage(sessionId, terminalMessage);
+                this.failTurnForSession(sessionId, terminalMessage);
               }
               return outcome;
             },
@@ -6699,6 +6748,7 @@ export const agentStore = {
             void this.recoverDroppedPrompt(sessionId, errStr);
           } else {
             this.addErrorMessage(sessionId, event.data.error);
+            this.failTurnForSession(sessionId, errStr);
           }
         }
         break;
@@ -7726,18 +7776,24 @@ export const agentStore = {
     const session = state.sessions[sessionId];
     const agentLabel = agentDisplayName(session?.info.agentType);
     const prefixedError = `[${agentLabel}] ${error}`;
+    const lastMessage = session?.messages.at(-1);
 
-    const message: AgentMessage = {
-      id: crypto.randomUUID(),
-      type: "error",
-      content: prefixedError,
-      timestamp: Date.now(),
-    };
+    if (
+      lastMessage?.type !== "error" ||
+      lastMessage.content !== prefixedError
+    ) {
+      const message: AgentMessage = {
+        id: crypto.randomUUID(),
+        type: "error",
+        content: prefixedError,
+        timestamp: Date.now(),
+      };
 
-    setState("sessions", sessionId, "messages", (msgs) => [...msgs, message]);
-    const errConvoId = session?.conversationId;
-    const errAgentType = session?.info.agentType ?? null;
-    if (errConvoId) persistAgentMessage(errConvoId, message, errAgentType);
+      setState("sessions", sessionId, "messages", (msgs) => [...msgs, message]);
+      const errConvoId = session?.conversationId;
+      const errAgentType = session?.info.agentType ?? null;
+      if (errConvoId) persistAgentMessage(errConvoId, message, errAgentType);
+    }
     // Set session-specific error instead of global error
     setState("sessions", sessionId, "error", prefixedError);
   },

--- a/tests/unit/agent-terminal-send-failure.test.ts
+++ b/tests/unit/agent-terminal-send-failure.test.ts
@@ -1,0 +1,85 @@
+// ABOUTME: Regression coverage for #2537 — provider send failures must not
+// ABOUTME: leave agent turns stuck in-flight or duplicate adjacent error rows.
+
+import { describe, expect, it } from "vitest";
+import { readSource } from "./source-text";
+
+const agentStoreSource = readSource("src/stores/agent.store.ts");
+
+const failTurnStart = agentStoreSource.indexOf("failTurnForSession(");
+const failTurnBody = agentStoreSource.slice(failTurnStart, failTurnStart + 2200);
+
+const sendPromptCatchStart = agentStoreSource.indexOf(
+  "console.error(`[AgentStore] sendPrompt error",
+);
+const sendPromptCatchBody = agentStoreSource.slice(
+  sendPromptCatchStart,
+  sendPromptCatchStart + 1800,
+);
+
+const genericProviderErrorStart = agentStoreSource.indexOf(
+  "this.addErrorMessage(sessionId, event.data.error);\n            this.failTurnForSession(sessionId, errStr);",
+);
+const genericProviderErrorBody = agentStoreSource.slice(
+  genericProviderErrorStart - 500,
+  genericProviderErrorStart + 500,
+);
+
+const promptTooLongFallbackStart = agentStoreSource.indexOf(
+  "Compaction failed catastrophically",
+);
+const promptTooLongFallbackBody = agentStoreSource.slice(
+  promptTooLongFallbackStart,
+  promptTooLongFallbackStart + 2200,
+);
+
+const addErrorStart = agentStoreSource.indexOf("addErrorMessage(sessionId: string");
+const addErrorBody = agentStoreSource.slice(addErrorStart, addErrorStart + 1500);
+
+describe("#2537 — terminal provider send failures restore UI turn state", () => {
+  it("has a helper that maps session failures back to the conversation turn", () => {
+    expect(failTurnStart).toBeGreaterThan(0);
+    expect(failTurnBody).toContain("const threadId = session?.conversationId");
+    expect(failTurnBody).toContain("this.isTurnInFlight(threadId)");
+    expect(failTurnBody).toContain('session.info.status === "prompting"');
+    expect(failTurnBody).toContain("this.setTurnError(threadId, kind, message)");
+    expect(failTurnBody).toContain('"ready" as SessionStatus');
+  });
+
+  it("direct sendPrompt failures add one error row and clear the in-flight turn", () => {
+    expect(sendPromptCatchStart).toBeGreaterThan(0);
+    expect(sendPromptCatchBody).toContain("this.addErrorMessage(sessionId, message)");
+    expect(sendPromptCatchBody).toContain("this.failTurnForSession(sessionId, message)");
+  });
+
+  it("prompt-too-long rejections without an event-side compact promise terminalize the turn", () => {
+    expect(sendPromptCatchBody).toContain("if (compactPromise)");
+    expect(sendPromptCatchBody).toContain("} else {\n          this.addErrorMessage(sessionId, message);\n          this.failTurnForSession(sessionId, message);");
+  });
+
+  it("generic provider error events terminalize active turns instead of relying on sendPrompt catch", () => {
+    expect(genericProviderErrorStart).toBeGreaterThan(0);
+    expect(genericProviderErrorBody).toContain("this.addErrorMessage(sessionId, event.data.error)");
+    expect(genericProviderErrorBody).toContain("this.failTurnForSession(sessionId, errStr)");
+  });
+
+  it("terminal prompt-too-long compaction outcomes clear the thinking indicator", () => {
+    expect(promptTooLongFallbackStart).toBeGreaterThan(0);
+    expect(promptTooLongFallbackBody).toContain(
+      "this.failTurnForSession(sessionId, String(event.data.error))",
+    );
+    expect(promptTooLongFallbackBody).toContain("const terminalMessage");
+    expect(promptTooLongFallbackBody).toContain(
+      "this.failTurnForSession(sessionId, terminalMessage)",
+    );
+  });
+
+  it("adjacent duplicate error messages are suppressed while keeping the banner current", () => {
+    expect(addErrorStart).toBeGreaterThan(0);
+    expect(addErrorBody).toContain("const lastMessage = session?.messages.at(-1)");
+    expect(addErrorBody).toMatch(
+      /lastMessage\?\.type\s*!==\s*"error"\s*\|\|\s*lastMessage\.content\s*!==\s*prefixedError/,
+    );
+    expect(addErrorBody).toContain('setState("sessions", sessionId, "error", prefixedError)');
+  });
+});


### PR DESCRIPTION
## Summary
- terminalize active agent turns when provider send failures cannot recover
- avoid duplicate adjacent provider error bubbles while keeping the session error banner current
- clear prompt-too-long terminal compaction outcomes through the existing retryable turn-error path

Fixes #2537

## Audited code paths
- `src/stores/agent.store.ts`
  - `sendPrompt` catch path
  - provider `case "error"` event path
  - prompt-too-long `compactAndRetry` terminal outcomes
  - `addErrorMessage` duplicate suppression
- `src/components/chat/AgentChat.tsx` impact path via `agentStore.isTurnInFlight(thread.id)`

## Verification
- `pnpm exec vitest run tests/unit/agent-terminal-send-failure.test.ts tests/unit/agent-turn-error.test.ts tests/unit/graceful-cancel-clears-turn-in-flight.test.ts tests/unit/agent-session-died-mid-prompt.test.ts tests/unit/agent-turn-in-flight.test.ts tests/unit/agent-predictive-compaction.test.ts tests/unit/predictive-compact-race.test.ts tests/unit/predictive-compact-failure-drain.test.ts tests/unit/agent-provider-runtime-restart.test.ts tests/unit/agent-session-events.test.ts tests/unit/provider-bindings.test.ts tests/unit/agent-spawn-guard.test.ts`
- `pnpm exec biome check src/stores/agent.store.ts tests/unit/agent-terminal-send-failure.test.ts`
- `pnpm test:runtime-smoke`
- `pnpm verify:frontend-build`
- `pnpm exec vitest run tests/unit/windows-cargo-manifest.test.ts tests/unit/windows-e2e-release-gate.test.ts tests/unit/windows-sign-overlay.test.ts tests/unit/windows-signables.test.ts tests/unit/print-windows-signables.test.ts tests/unit/scan-nsis-placeholders.test.ts`
- `pnpm build`

Note: full `pnpm check` is currently blocked by unrelated pre-existing Biome diagnostics in `src/components/session/SessionContent.tsx`, `src/components/session/SessionTimeline.tsx`, and `src/components/employees/EmployeeRunDetailModal.tsx`.