### PR TITLE
Fix provider runtime restart port stranding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1280,10 +1280,12 @@ jobs:
             throw new Error("Missing presigned Windows e2e payload URL(s)");
           }
           const workName = `seren-release-windows-e2e-${env.GITHUB_RUN_ID}-${env.GITHUB_RUN_ATTEMPT}`;
+          const logsS3Uri = `s3://${env.WINDOWS_E2E_S3_BUCKET}/${env.S3_PREFIX}/windows-e2e-logs.zip`;
           const commands = [
             "$ErrorActionPreference = 'Stop'",
             "$ProgressPreference = 'SilentlyContinue'",
             `$work = Join-Path $env:TEMP '${workName}'`,
+            `$logsS3Uri = ${psString(logsS3Uri)}`,
             "if (Test-Path $work) { Remove-Item -LiteralPath $work -Recurse -Force }",
             "New-Item -ItemType Directory -Force -Path $work | Out-Null",
             "Write-Host '[windows-e2e:ssm] Downloading staged installer and payload'",
@@ -1294,7 +1296,17 @@ jobs:
             "Set-Location $work",
             "Write-Host '[windows-e2e:ssm] Running Windows app harness as scheduled task user'",
             `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-task-user.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe') -WorkDir $work -SecretParameterPrefix ${psString(env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX)} -ProbeTimeoutSeconds 1800 -TaskTimeoutSeconds 3600`,
-            "if ($LASTEXITCODE -ne 0) { throw \"Windows app scheduled-task harness failed with exit code $LASTEXITCODE\" }",
+            "$harnessExitCode = $LASTEXITCODE",
+            "Write-Host '[windows-e2e:ssm] Bundling Windows app harness logs'",
+            "$logPaths = @((Join-Path $work 'windows-e2e-task.log'), (Join-Path $work 'windows-e2e-logs')) | Where-Object { Test-Path -LiteralPath $_ }",
+            "if (@($logPaths).Count -eq 0) { Set-Content -LiteralPath (Join-Path $work 'windows-e2e-log-missing.txt') -Value 'No Windows e2e logs were produced.'; $logPaths = @((Join-Path $work 'windows-e2e-log-missing.txt')) }",
+            "$logBundle = Join-Path $work 'windows-e2e-logs.zip'",
+            "Remove-Item -LiteralPath $logBundle -Force -ErrorAction SilentlyContinue",
+            "Compress-Archive -Path $logPaths -DestinationPath $logBundle -Force",
+            "aws s3 cp $logBundle $logsS3Uri",
+            "if ($LASTEXITCODE -ne 0) { throw \"Failed to upload Windows app harness logs to $logsS3Uri\" }",
+            "Write-Host \"[windows-e2e:ssm] Uploaded Windows app harness logs to $logsS3Uri\"",
+            "if ($harnessExitCode -ne 0) { throw \"Windows app scheduled-task harness failed with exit code $harnessExitCode\" }",
             ];
           // executionTimeout bounds the whole on-box command. It must exceed the
           // harness's own budget: the scheduled-task wait (TaskTimeoutSeconds + 60
@@ -1347,6 +1359,30 @@ jobs:
             --instance-id "$WINDOWS_E2E_INSTANCE_ID" \
             --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
             --output json
+
+      - name: Download Windows e2e log bundle
+        if: always()
+        shell: bash
+        env:
+          S3_PREFIX: ${{ steps.stage.outputs.prefix }}
+        run: |
+          set -uo pipefail
+          mkdir -p windows-e2e-logs
+          if [ -z "${S3_PREFIX:-}" ]; then
+            echo "::warning::Windows e2e S3 prefix was not produced; skipping log download."
+            exit 0
+          fi
+          if ! aws s3 cp "s3://${WINDOWS_E2E_S3_BUCKET}/${S3_PREFIX}/windows-e2e-logs.zip" windows-e2e-logs/windows-e2e-logs.zip; then
+            echo "::warning::Windows e2e log bundle was not available in S3."
+          fi
+
+      - name: Upload Windows e2e logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-app-e2e-logs
+          path: windows-e2e-logs/
+          if-no-files-found: warn
 
   publish-release:
     needs: [create-release, build, windows-app-e2e]

--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -215,6 +215,15 @@ function startServer(config) {
     });
   });
 
+  server.on("error", (error) => {
+    console.error(
+      `[provider-runtime] listen failed on ${config.host}:${config.port}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    process.exit(1);
+  });
+
   server.listen(config.port, config.host, () => {
     const address = server.address();
     const port = typeof address === "object" && address ? address.port : config.port;

--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -349,15 +349,82 @@ function waitForWebSocketOpen(ws) {
   });
 }
 
-async function connectProviderRuntime(config) {
+function validateProviderRuntimeConfig(config, label = "provider runtime config") {
+  assert(
+    config?.apiBaseUrl && config?.wsBaseUrl && config?.token,
+    `${label} missing fields`,
+  );
+  return config;
+}
+
+async function resolveProviderRuntimeConfig(
+  page,
+  { timeoutMs = PROVIDER_CONFIG_TIMEOUT_MS, label = "provider runtime config" } = {},
+) {
+  return validateProviderRuntimeConfig(
+    await withTimeout(tauriInvoke(page, "provider_runtime_get_config"), timeoutMs, label),
+    label,
+  );
+}
+
+async function fetchProviderRuntimeHealth(config) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PROVIDER_HEALTH_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${config.apiBaseUrl}/__seren/health`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const health = await response.json();
+    if (health?.ok !== true) {
+      throw new Error(`health ok=${String(health?.ok)}`);
+    }
+    return health;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function refreshProviderRuntimeConfig(page, previousConfig) {
+  const nextConfig = await resolveProviderRuntimeConfig(page, {
+    timeoutMs: PROVIDER_CONFIG_REFRESH_TIMEOUT_MS,
+    label: "provider runtime config refresh",
+  });
+  if (
+    nextConfig.apiBaseUrl !== previousConfig.apiBaseUrl ||
+    nextConfig.wsBaseUrl !== previousConfig.wsBaseUrl ||
+    nextConfig.token !== previousConfig.token
+  ) {
+    logStage(
+      `Provider runtime config refreshed: api=${redactUrl(nextConfig.apiBaseUrl)} ws=${redactUrl(nextConfig.wsBaseUrl)}`,
+    );
+  }
+  return nextConfig;
+}
+
+async function connectProviderRuntime(page, initialConfig) {
+  let config = validateProviderRuntimeConfig(initialConfig);
+  let failedHealthAttempts = 0;
   logStage(`Waiting for provider runtime health at ${config.apiBaseUrl}`);
   const health = await waitUntil(
     "provider runtime health",
     async () => {
-      const response = await fetch(`${config.apiBaseUrl}/__seren/health`);
-      return response.ok ? response.json() : null;
+      try {
+        return await fetchProviderRuntimeHealth(config);
+      } catch (error) {
+        failedHealthAttempts += 1;
+        if (failedHealthAttempts <= 3 || failedHealthAttempts % 10 === 0) {
+          logStage(
+            `Provider runtime health miss at ${redactUrl(config.apiBaseUrl)}; refreshing config (${error instanceof Error ? error.message : String(error)})`,
+          );
+        }
+        config = await refreshProviderRuntimeConfig(page, config);
+        return null;
+      }
     },
-    { timeoutMs: 45_000 },
+    { timeoutMs: PROVIDER_HEALTH_TIMEOUT_MS },
   );
   assert(health.mode === "desktop-native", `Unexpected provider runtime mode: ${health.mode}`);
   logStage("Provider runtime health OK; connecting WebSocket");
@@ -393,6 +460,9 @@ const SINGLE_PROMPT_TIMEOUT_MS = 240_000;
 // needs a wider ceiling than a single prompt.
 const PAIRED_PROMPT_TIMEOUT_MS = 600_000;
 const PROVIDER_CONFIG_TIMEOUT_MS = 30_000;
+const PROVIDER_CONFIG_REFRESH_TIMEOUT_MS = 5_000;
+const PROVIDER_HEALTH_TIMEOUT_MS = 45_000;
+const PROVIDER_HEALTH_REQUEST_TIMEOUT_MS = 2_000;
 const PROVIDER_WS_OPEN_TIMEOUT_MS = 30_000;
 const PROVIDER_RPC_TIMEOUT_MS = 60_000;
 const PROVIDER_ENSURE_CLI_TIMEOUT_MS = 600_000;
@@ -849,16 +919,11 @@ async function runPairedJourney(ws, buffer) {
 
 async function exerciseAgentRuntime(page) {
   logStage("Resolving provider runtime config");
-  const config = await withTimeout(
-    tauriInvoke(page, "provider_runtime_get_config"),
-    PROVIDER_CONFIG_TIMEOUT_MS,
-    "provider runtime config",
-  );
-  assert(config?.apiBaseUrl && config?.wsBaseUrl && config?.token, "provider runtime config missing fields");
+  const config = await resolveProviderRuntimeConfig(page);
   logStage(
     `Provider runtime config resolved: api=${redactUrl(config.apiBaseUrl)} ws=${redactUrl(config.wsBaseUrl)}`,
   );
-  const ws = await connectProviderRuntime(config);
+  const ws = await connectProviderRuntime(page, config);
   const buffer = createRuntimeBuffer(ws);
   try {
     for (const journey of AGENT_JOURNEYS) {

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -129,7 +129,7 @@ function Clear-DownloadMarksUnder([string]$Root) {
   }
 }
 
-function Invoke-ProcessWithTimeout([string]$FilePath, [string[]]$ArgumentList, [int]$TimeoutSeconds, [string]$Label, [switch]$NoNewWindow, [scriptblock]$OnTimeout = $null) {
+function Invoke-ProcessWithTimeout([string]$FilePath, [string[]]$ArgumentList, [int]$TimeoutSeconds, [string]$Label, [switch]$NoNewWindow, [scriptblock]$OnTimeout = $null, [string]$StdoutPath = "", [string]$StderrPath = "") {
   Write-Stage "Starting ${Label} with ${TimeoutSeconds}s timeout"
   $startArgs = @{
     FilePath = $FilePath
@@ -138,6 +138,14 @@ function Invoke-ProcessWithTimeout([string]$FilePath, [string[]]$ArgumentList, [
   }
   if ($NoNewWindow) {
     $startArgs.NoNewWindow = $true
+  }
+  if (-not [string]::IsNullOrWhiteSpace($StdoutPath)) {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $StdoutPath) | Out-Null
+    $startArgs.RedirectStandardOutput = $StdoutPath
+  }
+  if (-not [string]::IsNullOrWhiteSpace($StderrPath)) {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $StderrPath) | Out-Null
+    $startArgs.RedirectStandardError = $StderrPath
   }
   $process = Start-Process @startArgs
   $timeoutMs = [int]([Math]::Min([int]::MaxValue, [int64]$TimeoutSeconds * 1000))
@@ -151,10 +159,20 @@ function Invoke-ProcessWithTimeout([string]$FilePath, [string[]]$ArgumentList, [
       }
     }
     Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+    Write-FileTail $StdoutPath 200
+    Write-FileTail $StderrPath 200
     Fail "$Label timed out after ${TimeoutSeconds}s and was killed."
   }
   Write-Stage "${Label} exited with code $($process.ExitCode)"
   return $process.ExitCode
+}
+
+function Write-FileTail([string]$Path, [int]$Tail = 200) {
+  if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path)) {
+    return
+  }
+  Write-Host "Tail of ${Path}:"
+  Get-Content -LiteralPath $Path -Tail $Tail -ErrorAction SilentlyContinue | Write-Host
 }
 
 function Write-DirectorySnapshot([string]$Root) {
@@ -210,6 +228,36 @@ function Write-ProbeTimeoutDiagnostics([System.Diagnostics.Process]$AppProcess) 
     Write-Host
 }
 
+function Copy-E2EAppLogs([string]$DestinationDir) {
+  New-Item -ItemType Directory -Force -Path $DestinationDir | Out-Null
+  $roots = @()
+  foreach ($base in @($env:APPDATA, $env:LOCALAPPDATA)) {
+    if ([string]::IsNullOrWhiteSpace($base)) {
+      continue
+    }
+    $roots += @(
+      (Join-Path $base "com.serendb.desktop\logs"),
+      (Join-Path $base "SerenDesktop\logs"),
+      (Join-Path $base "Seren\logs")
+    )
+  }
+
+  foreach ($root in ($roots | Select-Object -Unique)) {
+    if (-not (Test-Path -LiteralPath $root)) {
+      continue
+    }
+    try {
+      $safeName = ($root -replace "[:\\\/]+", "_").Trim("_")
+      $target = Join-Path $DestinationDir "app-logs-$safeName"
+      New-Item -ItemType Directory -Force -Path $target | Out-Null
+      Copy-Item -Path (Join-Path $root "*") -Destination $target -Recurse -Force -ErrorAction Stop
+      Write-Stage "Copied app logs from $root to $target"
+    } catch {
+      Write-Host "::warning::Unable to copy app logs from ${root}: $($_.Exception.Message)"
+    }
+  }
+}
+
 function Wait-ForCdp([int]$Port, [int]$TimeoutSeconds, [System.Diagnostics.Process]$AppProcess) {
   $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
   $url = "http://127.0.0.1:$Port/json/version"
@@ -244,6 +292,11 @@ function Find-RequiredFile([string]$Root, [string]$Filter, [string]$Label) {
   }
   return $match.FullName
 }
+
+$e2eLogDir = Join-Path (Split-Path -Parent $PSScriptRoot) "windows-e2e-logs"
+New-Item -ItemType Directory -Force -Path $e2eLogDir | Out-Null
+$probeStdoutPath = Join-Path $e2eLogDir "windows-e2e-probe.stdout.log"
+$probeStderrPath = Join-Path $e2eLogDir "windows-e2e-probe.stderr.log"
 
 Write-Stage "Validating required production e2e environment"
 Require-Env @(
@@ -329,16 +382,20 @@ try {
   Write-Stage "Waiting for WebView2 CDP endpoint"
   Wait-ForCdp -Port $RemoteDebugPort -TimeoutSeconds $StartupTimeoutSeconds -AppProcess $app
   Write-Stage "Running Node app e2e probe"
-  $probeExitCode = Invoke-ProcessWithTimeout "node" @("$PSScriptRoot/windows-e2e-app.mjs") $ProbeTimeoutSeconds "Windows app e2e probe" -NoNewWindow -OnTimeout {
+  $probeExitCode = Invoke-ProcessWithTimeout "node" @("$PSScriptRoot/windows-e2e-app.mjs") $ProbeTimeoutSeconds "Windows app e2e probe" -NoNewWindow -StdoutPath $probeStdoutPath -StderrPath $probeStderrPath -OnTimeout {
     Write-ProbeTimeoutDiagnostics $app
   }
   if ($probeExitCode -ne 0) {
+    Write-FileTail $probeStdoutPath 200
+    Write-FileTail $probeStderrPath 200
     Fail "Windows app e2e script failed with exit code $probeExitCode"
   }
 } finally {
+  Copy-E2EAppLogs $e2eLogDir
   Write-Stage "Cleaning up Seren processes"
   if ($null -ne $app -and -not $app.HasExited) {
     Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
   }
   Get-Process -Name "Seren" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+  Copy-E2EAppLogs $e2eLogDir
 }

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -44,6 +44,7 @@ struct ProviderRuntimeProcess {
 pub struct ProviderRuntimeState {
     process: Mutex<Option<ProviderRuntimeProcess>>,
     monitor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    last_config: Mutex<Option<ProviderRuntimeConfig>>,
 }
 
 impl ProviderRuntimeState {
@@ -51,6 +52,7 @@ impl ProviderRuntimeState {
         Self {
             process: Mutex::new(None),
             monitor_handle: Mutex::new(None),
+            last_config: Mutex::new(None),
         }
     }
 
@@ -66,11 +68,23 @@ impl ProviderRuntimeState {
             return Err("Update in progress — provider runtime spawn refused".to_string());
         }
 
+        let mut preferred_config = self.last_config.lock().await.clone();
         let mut guard = self.process.lock().await;
 
         if let Some(process) = guard.as_mut() {
+            preferred_config = Some(process.config.clone());
             match process.child.try_wait() {
-                Ok(None) => return Ok(process.config.clone()),
+                Ok(None) => {
+                    if check_provider_runtime_health_once(&process.config).await {
+                        return Ok(process.config.clone());
+                    }
+                    log::warn!(
+                        "[ProviderRuntime] Existing process pid={} failed cached health check; restarting on pinned port {}",
+                        process.child.id().unwrap_or(0),
+                        process.config.port
+                    );
+                    let _ = process.child.start_kill();
+                }
                 Ok(Some(status)) => {
                     log::warn!(
                         "[ProviderRuntime] Existing process exited before reuse: {}",
@@ -89,7 +103,7 @@ impl ProviderRuntimeState {
         }
 
         let host = "127.0.0.1".to_string();
-        let token = generate_auth_token();
+        let config = startup_config_for_host(&host, preferred_config.as_ref())?;
         let node_bin = resolve_node_binary(app);
         let runtime_entry = find_provider_runtime_mjs()?;
 
@@ -100,16 +114,14 @@ impl ProviderRuntimeState {
         let mut attempt_errors: Vec<String> = Vec::with_capacity(STARTUP_ATTEMPT_BUDGETS.len());
         for (attempt_idx, deadline) in STARTUP_ATTEMPT_BUDGETS.iter().enumerate() {
             let attempt_num = attempt_idx + 1;
-            let port = find_available_port()?;
-            let config = ProviderRuntimeConfig {
-                api_base_url: format!("http://{}:{}", host, port),
-                ws_base_url: format!("ws://{}:{}", host, port),
-                host: host.clone(),
-                port,
-                token: token.clone(),
-            };
 
-            let mut child = spawn_node_process(&node_bin, &runtime_entry, &host, port, &token)?;
+            let mut child = spawn_node_process(
+                &node_bin,
+                &runtime_entry,
+                &config.host,
+                config.port,
+                &config.token,
+            )?;
 
             log::info!(
                 "[ProviderRuntime] Attempt {}/{} — spawned node={} pid={} port={} deadline={}s",
@@ -117,7 +129,7 @@ impl ProviderRuntimeState {
                 STARTUP_ATTEMPT_BUDGETS.len(),
                 node_bin.display(),
                 child.id().unwrap_or(0),
-                port,
+                config.port,
                 deadline.as_secs(),
             );
 
@@ -130,6 +142,7 @@ impl ProviderRuntimeState {
                         config: config.clone(),
                     });
                     drop(guard);
+                    *self.last_config.lock().await = Some(config.clone());
 
                     // Abort any previous crash monitor before starting a new one
                     if let Some(old_handle) = self.monitor_handle.lock().await.take() {
@@ -154,7 +167,7 @@ impl ProviderRuntimeState {
                         STARTUP_ATTEMPT_BUDGETS.len(),
                         attempt_err,
                         if attempt_num < STARTUP_ATTEMPT_BUDGETS.len() {
-                            "retrying with fresh process"
+                            "retrying on pinned port"
                         } else {
                             "giving up"
                         },
@@ -255,6 +268,34 @@ fn find_available_port() -> Result<u16, String> {
         .local_addr()
         .map(|addr| addr.port())
         .map_err(|err| format!("Failed to read provider runtime port: {}", err))
+}
+
+fn build_provider_runtime_config(host: String, port: u16, token: String) -> ProviderRuntimeConfig {
+    ProviderRuntimeConfig {
+        api_base_url: format!("http://{}:{}", host, port),
+        ws_base_url: format!("ws://{}:{}", host, port),
+        host,
+        port,
+        token,
+    }
+}
+
+fn startup_config_for_host(
+    host: &str,
+    preferred: Option<&ProviderRuntimeConfig>,
+) -> Result<ProviderRuntimeConfig, String> {
+    match preferred {
+        Some(config) => Ok(build_provider_runtime_config(
+            host.to_string(),
+            config.port,
+            config.token.clone(),
+        )),
+        None => Ok(build_provider_runtime_config(
+            host.to_string(),
+            find_available_port()?,
+            generate_auth_token(),
+        )),
+    }
 }
 
 fn generate_auth_token() -> String {
@@ -457,6 +498,23 @@ async fn wait_for_provider_runtime_with_deadline(
         }
 
         tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+
+async fn check_provider_runtime_health_once(config: &ProviderRuntimeConfig) -> bool {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(750))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+    let health_url = format!("{}/__seren/health", config.api_base_url);
+    match client.get(&health_url).send().await {
+        Ok(response) if response.status().is_success() => response
+            .json::<serde_json::Value>()
+            .await
+            .ok()
+            .and_then(|body| body.get("ok").and_then(|value| value.as_bool()))
+            .unwrap_or(false),
+        _ => false,
     }
 }
 
@@ -811,6 +869,31 @@ mod tests {
             api_base_url: "http://127.0.0.1:1".to_string(),
             ws_base_url: "ws://127.0.0.1:1".to_string(),
         }
+    }
+
+    #[test]
+    fn startup_config_reuses_existing_port_and_token() {
+        let existing = build_provider_runtime_config(
+            "127.0.0.1".to_string(),
+            51908,
+            "existing-token".to_string(),
+        );
+
+        let reused = startup_config_for_host("127.0.0.1", Some(&existing)).expect("reused config");
+
+        assert_eq!(reused.port, existing.port);
+        assert_eq!(reused.token, existing.token);
+        assert_eq!(reused.api_base_url, "http://127.0.0.1:51908");
+        assert_eq!(reused.ws_base_url, "ws://127.0.0.1:51908");
+    }
+
+    #[tokio::test]
+    async fn cached_health_check_rejects_dead_port() {
+        let config = dummy_config();
+        assert!(
+            !check_provider_runtime_health_once(&config).await,
+            "a cached config for a dead port must not be reused"
+        );
     }
 
     /// GH #1587: a child that exits (e.g. SIGKILL, signal 9) before binding

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -285,6 +285,9 @@ describe("Windows production e2e release gate", () => {
   it("bounds provider runtime waits and preserves diagnostic breadcrumbs (#2475)", () => {
     for (const required of [
       "PROVIDER_CONFIG_TIMEOUT_MS",
+      "PROVIDER_CONFIG_REFRESH_TIMEOUT_MS",
+      "PROVIDER_HEALTH_TIMEOUT_MS",
+      "PROVIDER_HEALTH_REQUEST_TIMEOUT_MS",
       "PROVIDER_WS_OPEN_TIMEOUT_MS",
       "PROVIDER_RPC_TIMEOUT_MS",
       "PROVIDER_ENSURE_CLI_TIMEOUT_MS",
@@ -301,6 +304,38 @@ describe("Windows production e2e release gate", () => {
     ]) {
       expect(probe).toContain(required);
     }
+  });
+
+  it("refreshes provider-runtime config while waiting for health (#2539)", () => {
+    expect(probe).toContain("resolveProviderRuntimeConfig");
+    expect(probe).toContain("fetchProviderRuntimeHealth");
+    expect(probe).toContain("refreshProviderRuntimeConfig");
+    expect(probe).toContain("Provider runtime health miss");
+    expect(probe).toContain("provider runtime config refresh");
+    expect(probe).toContain("connectProviderRuntime(page, config)");
+
+    const connectStart = probe.indexOf("async function connectProviderRuntime");
+    expect(connectStart).toBeGreaterThanOrEqual(0);
+    const connectBody = probe.slice(connectStart, probe.indexOf("function assistantText"));
+    expect(connectBody.indexOf("fetchProviderRuntimeHealth")).toBeLessThan(
+      connectBody.indexOf("refreshProviderRuntimeConfig"),
+    );
+  });
+
+  it("uploads complete Windows e2e probe and runtime logs (#2539)", () => {
+    expect(runner).toContain("windows-e2e-logs");
+    expect(runner).toContain("windows-e2e-probe.stdout.log");
+    expect(runner).toContain("windows-e2e-probe.stderr.log");
+    expect(runner).toContain("RedirectStandardOutput");
+    expect(runner).toContain("RedirectStandardError");
+    expect(runner).toContain("Copy-E2EAppLogs");
+    expect(runner).toContain("com.serendb.desktop\\logs");
+
+    expect(releaseWorkflow).toContain("windows-e2e-logs.zip");
+    expect(releaseWorkflow).toContain("Bundling Windows app harness logs");
+    expect(releaseWorkflow).toContain("Download Windows e2e log bundle");
+    expect(releaseWorkflow).toContain("Upload Windows e2e logs");
+    expect(releaseWorkflow).toContain("windows-app-e2e-logs");
   });
 
   it("provisions agent CLIs before checking release-gate availability (#2481)", () => {


### PR DESCRIPTION
## Summary
- Pin provider-runtime port/token across supervisor restarts by retaining the last successful config
- Revalidate cached runtime health before returning reused config, respawning on the pinned port when unhealthy
- Harden the Windows e2e probe to refresh provider_runtime_get_config after health misses
- Upload full Windows e2e probe/app runtime logs as a release-gate artifact

Fixes #2539

## Tests
- node --check scripts/windows-e2e-app.mjs
- node --check bin/provider-runtime.mjs
- pwsh PSParser check for scripts/windows-e2e-app.ps1
- pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts
- cargo test --manifest-path src-tauri/Cargo.toml provider_runtime --lib

## Audit
- Rechecked the issue failure path: consumers no longer get stranded by a restarted runtime moving to a new random port.
- No new P0/P1 issues found in the changed code paths during local audit.