### PR TITLE
Fix Windows e2e log upload permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1250,10 +1250,41 @@ jobs:
           prefix="release-windows-e2e/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
           installer_s3="s3://${WINDOWS_E2E_S3_BUCKET}/${prefix}/SerenDesktop-setup.exe"
           payload_s3="s3://${WINDOWS_E2E_S3_BUCKET}/${prefix}/windows-e2e-payload.zip"
+          logs_key="${prefix}/windows-e2e-logs.zip"
           aws s3 cp "$installer" "$installer_s3"
           aws s3 cp "$payload" "$payload_s3"
           installer_url="$(aws s3 presign "$installer_s3" --expires-in 7200)"
           payload_url="$(aws s3 presign "$payload_s3" --expires-in 7200)"
+          logs_upload_url="$(
+            WINDOWS_E2E_LOG_BUCKET="$WINDOWS_E2E_S3_BUCKET" \
+            WINDOWS_E2E_LOG_KEY="$logs_key" \
+            python3 <<'PY'
+import os
+import subprocess
+import sys
+
+try:
+    import boto3
+except ModuleNotFoundError:
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--quiet", "boto3"],
+        stdout=subprocess.DEVNULL,
+    )
+    import boto3
+
+bucket = os.environ["WINDOWS_E2E_LOG_BUCKET"]
+key = os.environ["WINDOWS_E2E_LOG_KEY"]
+client = boto3.client("s3", region_name=os.environ.get("AWS_REGION"))
+print(
+    client.generate_presigned_url(
+        "put_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=7200,
+        HttpMethod="PUT",
+    )
+)
+PY
+          )"
           echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
           {
             echo "installer_url<<EOF"
@@ -1261,6 +1292,9 @@ jobs:
             echo "EOF"
             echo "payload_url<<EOF"
             echo "$payload_url"
+            echo "EOF"
+            echo "logs_upload_url<<EOF"
+            echo "$logs_upload_url"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -1271,12 +1305,13 @@ jobs:
           S3_PREFIX: ${{ steps.stage.outputs.prefix }}
           INSTALLER_URL: ${{ steps.stage.outputs.installer_url }}
           PAYLOAD_URL: ${{ steps.stage.outputs.payload_url }}
+          LOGS_UPLOAD_URL: ${{ steps.stage.outputs.logs_upload_url }}
         run: |
           set -euo pipefail
           node <<'NODE' > "$RUNNER_TEMP/windows-e2e-commands.json"
           const env = process.env;
           const psString = (value) => `'${String(value).replaceAll("'", "''")}'`;
-          if (!env.INSTALLER_URL || !env.PAYLOAD_URL) {
+          if (!env.INSTALLER_URL || !env.PAYLOAD_URL || !env.LOGS_UPLOAD_URL) {
             throw new Error("Missing presigned Windows e2e payload URL(s)");
           }
           const workName = `seren-release-windows-e2e-${env.GITHUB_RUN_ID}-${env.GITHUB_RUN_ATTEMPT}`;
@@ -1286,6 +1321,7 @@ jobs:
             "$ProgressPreference = 'SilentlyContinue'",
             `$work = Join-Path $env:TEMP '${workName}'`,
             `$logsS3Uri = ${psString(logsS3Uri)}`,
+            `$logsUploadUrl = ${psString(env.LOGS_UPLOAD_URL)}`,
             "if (Test-Path $work) { Remove-Item -LiteralPath $work -Recurse -Force }",
             "New-Item -ItemType Directory -Force -Path $work | Out-Null",
             "Write-Host '[windows-e2e:ssm] Downloading staged installer and payload'",
@@ -1303,8 +1339,7 @@ jobs:
             "$logBundle = Join-Path $work 'windows-e2e-logs.zip'",
             "Remove-Item -LiteralPath $logBundle -Force -ErrorAction SilentlyContinue",
             "Compress-Archive -Path $logPaths -DestinationPath $logBundle -Force",
-            "aws s3 cp $logBundle $logsS3Uri",
-            "if ($LASTEXITCODE -ne 0) { throw \"Failed to upload Windows app harness logs to $logsS3Uri\" }",
+            "try { Invoke-WebRequest -Uri $logsUploadUrl -Method Put -InFile $logBundle -UseBasicParsing | Out-Null } catch { throw \"Failed to upload Windows app harness logs to $logsS3Uri via presigned URL: $($_.Exception.Message)\" }",
             "Write-Host \"[windows-e2e:ssm] Uploaded Windows app harness logs to $logsS3Uri\"",
             "if ($harnessExitCode -ne 0) { throw \"Windows app scheduled-task harness failed with exit code $harnessExitCode\" }",
             ];

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -333,6 +333,11 @@ describe("Windows production e2e release gate", () => {
 
     expect(releaseWorkflow).toContain("windows-e2e-logs.zip");
     expect(releaseWorkflow).toContain("Bundling Windows app harness logs");
+    expect(releaseWorkflow).toContain("logs_upload_url");
+    expect(releaseWorkflow).toContain("generate_presigned_url");
+    expect(releaseWorkflow).toContain("put_object");
+    expect(releaseWorkflow).toContain("Invoke-WebRequest -Uri $logsUploadUrl -Method Put");
+    expect(releaseWorkflow).not.toContain("aws s3 cp $logBundle $logsS3Uri");
     expect(releaseWorkflow).toContain("Download Windows e2e log bundle");
     expect(releaseWorkflow).toContain("Upload Windows e2e logs");
     expect(releaseWorkflow).toContain("windows-app-e2e-logs");


### PR DESCRIPTION
## Summary
- generate a presigned S3 PUT URL for the Windows e2e log bundle on the GitHub runner
- upload the on-box log zip with Invoke-WebRequest instead of requiring the EC2 role to have s3:PutObject
- extend the release-gate guard test for the presigned upload path

Fixes #2543

## Tests
- pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts
- git diff --check