### PR TITLE
Fix release workflow presign heredoc YAML

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1259,31 +1259,31 @@ jobs:
             WINDOWS_E2E_LOG_BUCKET="$WINDOWS_E2E_S3_BUCKET" \
             WINDOWS_E2E_LOG_KEY="$logs_key" \
             python3 <<'PY'
-import os
-import subprocess
-import sys
+          import os
+          import subprocess
+          import sys
 
-try:
-    import boto3
-except ModuleNotFoundError:
-    subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "--quiet", "boto3"],
-        stdout=subprocess.DEVNULL,
-    )
-    import boto3
+          try:
+              import boto3
+          except ModuleNotFoundError:
+              subprocess.check_call(
+                  [sys.executable, "-m", "pip", "install", "--quiet", "boto3"],
+                  stdout=subprocess.DEVNULL,
+              )
+              import boto3
 
-bucket = os.environ["WINDOWS_E2E_LOG_BUCKET"]
-key = os.environ["WINDOWS_E2E_LOG_KEY"]
-client = boto3.client("s3", region_name=os.environ.get("AWS_REGION"))
-print(
-    client.generate_presigned_url(
-        "put_object",
-        Params={"Bucket": bucket, "Key": key},
-        ExpiresIn=7200,
-        HttpMethod="PUT",
-    )
-)
-PY
+          bucket = os.environ["WINDOWS_E2E_LOG_BUCKET"]
+          key = os.environ["WINDOWS_E2E_LOG_KEY"]
+          client = boto3.client("s3", region_name=os.environ.get("AWS_REGION"))
+          print(
+              client.generate_presigned_url(
+                  "put_object",
+                  Params={"Bucket": bucket, "Key": key},
+                  ExpiresIn=7200,
+                  HttpMethod="PUT",
+              )
+          )
+          PY
           )"
           echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
           {

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -337,6 +337,9 @@ describe("Windows production e2e release gate", () => {
     expect(releaseWorkflow).toContain("generate_presigned_url");
     expect(releaseWorkflow).toContain("put_object");
     expect(releaseWorkflow).toContain("Invoke-WebRequest -Uri $logsUploadUrl -Method Put");
+    expect(releaseWorkflow).toContain("          import os\n");
+    expect(releaseWorkflow).toContain("          PY\n");
+    expect(releaseWorkflow).not.toContain("\nimport os\nimport subprocess\n");
     expect(releaseWorkflow).not.toContain("aws s3 cp $logBundle $logsS3Uri");
     expect(releaseWorkflow).toContain("Download Windows e2e log bundle");
     expect(releaseWorkflow).toContain("Upload Windows e2e logs");


### PR DESCRIPTION
## Summary
- indent the Python heredoc used for Windows e2e presigned log uploads so release.yml parses as YAML
- add a focused release-gate guard against unindented heredoc drift

Fixes #2545

## Tests
- python3 - <<'PY'
import yaml
with open('.github/workflows/release.yml') as f:
    yaml.safe_load(f)
print('yaml ok')
PY
- pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts
- git diff --check