### PR TITLE
Fix Windows e2e sign-in submit flake

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -177,6 +177,26 @@ async function dismissSessionExpiredModal(page) {
   }
 }
 
+async function submitSignInForm(form) {
+  const submitButton = form.getByRole("button", { name: /^Sign In$/ });
+  await waitUntil(
+    "enabled sign-in submit button",
+    async () => ((await submitButton.isEnabled().catch(() => false)) ? true : null),
+    { timeoutMs: 10_000 },
+  );
+  await submitButton.evaluate((button) => {
+    const form = button.closest("form");
+    if (!form) {
+      throw new Error("Sign-in submit button is not inside a form");
+    }
+    if (typeof form.requestSubmit === "function") {
+      form.requestSubmit(button);
+      return;
+    }
+    button.click();
+  });
+}
+
 async function signIn(page) {
   await tauriInvoke(page, "clear_token").catch(() => {});
   await tauriInvoke(page, "clear_refresh_token").catch(() => {});
@@ -195,7 +215,7 @@ async function signIn(page) {
   const form = page.locator("form").filter({ has: page.getByLabel("Email") });
   await form.getByLabel("Email").fill(EMAIL);
   await form.getByLabel("Password").fill(PASSWORD);
-  await form.getByRole("button", { name: /^Sign In$/ }).click();
+  await submitSignInForm(form);
 
   const token = await waitUntil(
     "stored production auth token",

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -106,6 +106,15 @@ describe("Windows production e2e release gate", () => {
     expect(probe).toContain("https://api.serendb.com");
   });
 
+  it("submits Windows sign-in without relying on WebView2 pointer click completion (#2553)", () => {
+    expect(probe).toContain("submitSignInForm");
+    expect(probe).toContain("enabled sign-in submit button");
+    expect(probe).toContain("form.requestSubmit(button)");
+    expect(probe).not.toContain(
+      'form.getByRole("button", { name: /^Sign In$/ }).click();',
+    );
+  });
+
   it("fails eSigner CKA login/load commands at their native failure point (#2483)", () => {
     const buildJob = workflowJob("build");
     expect(buildJob).toContain("function Invoke-EsignerCka");


### PR DESCRIPTION
Closes #2553

## Summary
- Submit the scoped Windows e2e sign-in form via DOM `requestSubmit()` instead of a WebView2/CDP pointer click.
- Keep the existing field/form scoping and token wait behavior.
- Add a release-gate guard so the submit path does not regress to a raw button click.

## Audit
- The failed AWS run showed the button visible/enabled/stable, but `locator.click()` timed out while performing the click and no auth request reached the app.
- `requestSubmit(button)` preserves normal form submit semantics without relying on pointer action completion in WebView2 remote debugging.

## Tests
- node --check scripts/windows-e2e-app.mjs
- pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts
- git diff --check