### PR TITLE
fix(e2e): use spoken Windows meeting audio stimulus

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -1299,13 +1299,39 @@ async function exerciseHistorySync(page, token) {
   await runHistorySync(page, destination, "after-wipe-resync");
 }
 
+function powerShellSingleQuoted(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
 function playWindowsAudio() {
+  const speechText = powerShellSingleQuoted(
+    "Seren Windows end to end meeting capture test. This spoken system audio should be recorded and transcribed.",
+  );
+  const stimulusSeconds = Math.max(6, CAPTURE_SECONDS - 1);
   const command = [
-    "[Console]::Beep(880, 1200)",
-    "Start-Sleep -Milliseconds 250",
-    "[Console]::Beep(660, 1200)",
-    "Start-Sleep -Milliseconds 250",
-    "[Console]::Beep(990, 1200)",
+    "$ErrorActionPreference = 'Continue'",
+    `$deadline = (Get-Date).AddSeconds(${stimulusSeconds})`,
+    "$playedSpeech = $false",
+    "try {",
+    "  $voice = New-Object -ComObject SAPI.SpVoice",
+    "  $voice.Volume = 100",
+    "  $voice.Rate = -1",
+    "  while ((Get-Date) -lt $deadline) {",
+    `    [void]$voice.Speak(${speechText}, 0)`,
+    "    $playedSpeech = $true",
+    "    Start-Sleep -Milliseconds 150",
+    "  }",
+    "} catch {",
+    "  $playedSpeech = $false",
+    "}",
+    "if (-not $playedSpeech) {",
+    "  while ((Get-Date) -lt $deadline) {",
+    "    [Console]::Beep(880, 800)",
+    "    Start-Sleep -Milliseconds 150",
+    "    [Console]::Beep(660, 800)",
+    "    Start-Sleep -Milliseconds 150",
+    "  }",
+    "}",
   ].join("; ");
   return spawn("powershell.exe", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command], {
     stdio: "ignore",

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -115,6 +115,24 @@ describe("Windows production e2e release gate", () => {
     );
   });
 
+  it("uses spoken system audio for the Windows Meeting capture stimulus (#2555)", () => {
+    expect(probe).toContain("powerShellSingleQuoted");
+    expect(probe).toContain("SAPI.SpVoice");
+    expect(probe).toContain("$voice.Speak");
+    expect(probe).toContain("spoken system audio");
+    expect(probe).toContain("$playedSpeech");
+    expect(probe).toContain("[Console]::Beep");
+
+    const stimulusStart = probe.indexOf("function playWindowsAudio");
+    const captureStart = probe.indexOf("async function exerciseMeetingCapture");
+    expect(stimulusStart).toBeGreaterThanOrEqual(0);
+    expect(captureStart).toBeGreaterThan(stimulusStart);
+    const stimulus = probe.slice(stimulusStart, captureStart);
+    expect(stimulus.indexOf("SAPI.SpVoice")).toBeLessThan(
+      stimulus.indexOf("[Console]::Beep"),
+    );
+  });
+
   it("fails eSigner CKA login/load commands at their native failure point (#2483)", () => {
     const buildJob = workflowJob("build");
     expect(buildJob).toContain("function Invoke-EsignerCka");


### PR DESCRIPTION
## Summary
- replace the Windows Meeting capture e2e audio stimulus with repeated SAPI spoken system audio
- keep a beep fallback only when SAPI speech cannot be constructed
- add a release-gate guard so the walkthrough cannot drift back to tone-only audio

## Audit
The AWS Windows walkthrough for #2551/#2553 confirmed the app now starts system-audio-only capture when no default mic exists, but `Console.Beep` produced zero loopback frames on the host. Meeting capture stop also requires speech/transcribable audio, so the e2e stimulus must be spoken audio rather than tones.

Closes #2555

## Tests
- `node --check scripts/windows-e2e-app.mjs`
- `pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts`
- `git diff --check`
