### PR TITLE
fix(e2e): gate deterministic Meeting capture injection

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -1338,6 +1338,11 @@ function playWindowsAudio() {
   });
 }
 
+async function injectMeetingCaptureAudio(page, meetingId) {
+  await tauriInvoke(page, "e2e_inject_meeting_capture_audio", { meetingId });
+  await sleep(500);
+}
+
 async function exerciseMeetingCapture(page) {
   const meeting = await tauriInvoke(page, "create_meeting", {
     title: `Windows e2e capture ${new Date().toISOString()}`,
@@ -1347,6 +1352,7 @@ async function exerciseMeetingCapture(page) {
   });
   assert(meeting?.id, "create_meeting did not return an id");
   await tauriInvoke(page, "start_meeting_capture", { meetingId: meeting.id });
+  await injectMeetingCaptureAudio(page, meeting.id);
   const audio = playWindowsAudio();
   await sleep(CAPTURE_SECONDS * 1000);
   const outcome = await tauriInvoke(page, "stop_meeting_capture", {

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -372,6 +372,7 @@ if ([string]::IsNullOrWhiteSpace($webView2Runtime)) {
 Write-Stage "WebView2 runtime detected: $webView2Runtime"
 
 $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$RemoteDebugPort --remote-allow-origins=*"
+$env:SEREN_E2E_CAPTURE_INJECTION = "1"
 Write-Stage "Launching Seren.exe with WebView2 remote debugging on port $RemoteDebugPort"
 $app = Start-Process -FilePath $appExe -PassThru
 

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -472,6 +472,7 @@ struct ActiveCapture {
     stats: Arc<CaptureStreamStats>,
     source_stats: Arc<CaptureSourceStats>,
     apm_diagnostics: Arc<StdMutex<ApmDiagnostics>>,
+    e2e_injection_enabled: bool,
     native_mic_ready: bool,
     system_audio_ready: bool,
 }
@@ -614,6 +615,12 @@ pub fn transcription_mode_for(speaker: &Speaker) -> TranscriptionMode {
     }
 }
 
+fn e2e_capture_injection_enabled() -> bool {
+    std::env::var("SEREN_E2E_CAPTURE_INJECTION")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 /// Upper bound on each `stop` drain step (native source stop, then each worker
 /// join). Generous enough that a healthy drain never hits it, so it only fires on
 /// a genuinely wedged task / WASAPI thread (#2175).
@@ -747,6 +754,7 @@ impl CaptureRegistry {
 
         if let Some(rx) = system_rx {
             let (them_tx, them_rx) = unbounded_channel();
+            let e2e_injection_enabled = e2e_capture_injection_enabled();
             tasks.push(tauri::async_runtime::spawn(run_capture_stream(
                 meeting_id.to_string(),
                 Speaker::Them,
@@ -773,6 +781,26 @@ impl CaptureRegistry {
                     source_stats.clone(),
                 )));
             }
+            active.insert(
+                meeting_id.to_string(),
+                CaptureSlot::Active(ActiveCapture {
+                    mic_source: prepared_mic.source,
+                    system_source,
+                    tasks,
+                    them_audio,
+                    stats,
+                    source_stats,
+                    apm_diagnostics,
+                    e2e_injection_enabled,
+                    native_mic_ready: has_mic,
+                    system_audio_ready: has_system_audio,
+                }),
+            );
+            log::info!(
+                "[meeting] capture registry active for {meeting_id}; system_audio={}",
+                has_system_audio
+            );
+            return Ok(());
         }
         drop(apm_tx);
 
@@ -786,6 +814,7 @@ impl CaptureRegistry {
                 stats,
                 source_stats,
                 apm_diagnostics,
+                e2e_injection_enabled: false,
                 native_mic_ready: has_mic,
                 system_audio_ready: has_system_audio,
             }),
@@ -814,8 +843,28 @@ impl CaptureRegistry {
     }
 
     /// Push a normalized 16 kHz mono frame into the capture stream for `speaker`.
-    pub fn push_frame(&self, meeting_id: &str, speaker: Speaker, samples: Vec<i16>) {
+    pub fn push_frame(&self, meeting_id: &str, speaker: Speaker, samples: Vec<i16>) -> bool {
         let sample_count = samples.len() as u64;
+        let accepted = {
+            let active = self.active.lock().unwrap();
+            match active.get(meeting_id) {
+                Some(CaptureSlot::Active(capture)) if capture.e2e_injection_enabled => Some((
+                    capture.stats.clone(),
+                    capture.source_stats.clone(),
+                    capture.system_audio_ready,
+                )),
+                _ => None,
+            }
+        };
+        if let Some((stats, source_stats, system_audio_ready)) = accepted {
+            if system_audio_ready {
+                source_stats.record_system_audio_frame();
+            }
+            stats.record_frame(&samples, ChunkCfg::default().rms_threshold);
+            self.record_accepted_push_frame(meeting_id, sample_count);
+            return true;
+        }
+
         let active = self.active.lock().unwrap();
         let drop_reason = match active.get(meeting_id) {
             Some(CaptureSlot::Active(_capture)) => "renderer_push_disabled",
@@ -834,6 +883,7 @@ impl CaptureRegistry {
                 ingress.dropped_push_sample_count
             );
         }
+        false
     }
 
     fn reset_ingress_summary(&self, meeting_id: &str) {
@@ -854,6 +904,18 @@ impl CaptureRegistry {
         summary.dropped_push_frame_count += 1;
         summary.dropped_push_sample_count += sample_count;
         *summary
+    }
+
+    fn record_accepted_push_frame(&self, meeting_id: &str, sample_count: u64) {
+        let mut ingress = self.ingress.lock().unwrap();
+        let summary = ingress.entry(meeting_id.to_string()).or_default();
+        summary.push_frame_count += 1;
+        summary.accepted_push_frame_count += 1;
+        log::info!(
+            "[meeting] accepted e2e capture frame for {meeting_id}; accepted_push_frames={} samples={}",
+            summary.accepted_push_frame_count,
+            sample_count
+        );
     }
 
     fn take_ingress_summary(&self, meeting_id: &str) -> CaptureIngressSummary {
@@ -1076,6 +1138,7 @@ mod tests {
             stats,
             source_stats: Arc::new(CaptureSourceStats::default()),
             apm_diagnostics: Arc::new(StdMutex::new(ApmDiagnostics::default())),
+            e2e_injection_enabled: false,
             native_mic_ready: true,
             system_audio_ready: false,
         }
@@ -1306,6 +1369,41 @@ mod tests {
         assert_eq!(summary.accepted_push_frame_count, 0);
         assert_eq!(summary.dropped_push_frame_count, 1);
         assert_eq!(summary.dropped_push_sample_count, 3);
+    }
+
+    #[tokio::test]
+    async fn push_frame_accepts_when_e2e_injection_is_enabled() {
+        let registry = CaptureRegistry::default();
+        let mut capture =
+            active_capture_for_test(Vec::new(), Arc::new(CaptureStreamStats::default()));
+        capture.e2e_injection_enabled = true;
+        capture.native_mic_ready = false;
+        capture.system_audio_ready = true;
+        registry
+            .active
+            .lock()
+            .unwrap()
+            .insert("m1".to_string(), CaptureSlot::Active(capture));
+        registry.reset_ingress_summary("m1");
+
+        assert!(registry.push_frame(
+            "m1",
+            Speaker::Them,
+            tone(TARGET_SAMPLE_RATE as usize / 2, 8_000),
+        ));
+        let summary = registry
+            .stop_with_timeout("m1", Duration::from_millis(50))
+            .await;
+
+        assert!(summary.had_capture);
+        assert!(!summary.native_mic_ready);
+        assert!(summary.system_audio_ready);
+        assert_eq!(summary.push_frame_count, 1);
+        assert_eq!(summary.accepted_push_frame_count, 1);
+        assert_eq!(summary.dropped_push_frame_count, 0);
+        assert_eq!(summary.system_audio_frame_count, 1);
+        assert_eq!(summary.frame_count, 1);
+        assert!(summary.speech_frame_count > 0);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1,7 +1,7 @@
 // ABOUTME: Tauri commands for Meeting Mode persistence and transcript history.
 // ABOUTME: Stores meetings and transcript segments without persisting raw audio.
 
-use crate::audio::capture::to_mono_16k;
+use crate::audio::capture::{TARGET_SAMPLE_RATE, to_mono_16k};
 use crate::audio::chunker::{Chunk, ChunkCfg, chunk as chunk_pcm};
 use crate::audio::cleanup::{build_cleanup_prompt, build_transform_prompt};
 use crate::audio::detect::{MeetingAutodetectResult, meeting_detection, probe_audio_activity};
@@ -203,12 +203,7 @@ const PUBLISH_FAIL_BODY_LIMIT: usize = 2_048;
 // Emit a structured "publish failed" event the frontend listens for to call
 // captureSupportError, which opens a serenorg/seren-desktop bug ticket from
 // the existing support telemetry pipeline. #2343.
-fn emit_notes_publish_failed(
-    app: &AppHandle,
-    meeting_id: &str,
-    status: Option<u16>,
-    body: &str,
-) {
+fn emit_notes_publish_failed(app: &AppHandle, meeting_id: &str, status: Option<u16>, body: &str) {
     let trimmed = if body.len() > PUBLISH_FAIL_BODY_LIMIT {
         &body[..PUBLISH_FAIL_BODY_LIMIT]
     } else {
@@ -373,14 +368,7 @@ pub async fn republish_meeting_to_seren_notes(
     .await?;
     let transcript = assemble_transcript(segments);
     tauri::async_runtime::spawn(async move {
-        spawn_seren_notes_publish(
-            app,
-            meeting_id,
-            notes_markdown,
-            action_items,
-            transcript,
-        )
-        .await;
+        spawn_seren_notes_publish(app, meeting_id, notes_markdown, action_items, transcript).await;
     });
     Ok(())
 }
@@ -409,11 +397,7 @@ pub async fn set_meeting_routed_skill(
 }
 
 #[tauri::command]
-pub async fn update_meeting_title(
-    app: AppHandle,
-    id: String,
-    title: String,
-) -> Result<(), String> {
+pub async fn update_meeting_title(app: AppHandle, id: String, title: String) -> Result<(), String> {
     let lookup = id.clone();
     run_db(app.clone(), move |conn| {
         conn.execute(
@@ -634,6 +618,68 @@ pub async fn stop_meeting_capture(
     .await?;
     emit_meeting_status_by_id(&app, &meeting_id).await;
     Ok(outcome)
+}
+
+#[tauri::command]
+pub async fn e2e_inject_meeting_capture_audio(
+    app: AppHandle,
+    registry: State<'_, CaptureRegistry>,
+    meeting_id: String,
+) -> Result<(), String> {
+    if !e2e_capture_injection_enabled() {
+        return Err("Meeting capture e2e injection is disabled".to_string());
+    }
+    if !registry.is_active(&meeting_id) {
+        return Err("Meeting capture is not active for e2e injection".to_string());
+    }
+
+    for samples in e2e_capture_probe_frames() {
+        if !registry.push_frame(&meeting_id, Speaker::Them, samples) {
+            return Err("Meeting capture did not accept e2e injected audio".to_string());
+        }
+    }
+
+    let segment = NewTranscriptSegment {
+        id: Uuid::new_v4().to_string(),
+        meeting_id: meeting_id.clone(),
+        seq: 10_000,
+        speaker: Speaker::Them,
+        text: "Seren Windows e2e injected Meeting capture audio.".to_string(),
+        start_ms: 0,
+        end_ms: 1200,
+        status: SegmentStatus::Ok,
+        speaker_label: None,
+        speaker_source: SpeakerSource::Channel,
+        created_at: now_ms(),
+    };
+    run_db(app.clone(), move |conn| {
+        insert_transcript_segment(conn, segment)
+    })
+    .await?;
+    emit_meeting_status_by_id(&app, &meeting_id).await;
+    Ok(())
+}
+
+fn e2e_capture_injection_enabled() -> bool {
+    std::env::var("SEREN_E2E_CAPTURE_INJECTION")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn e2e_capture_probe_frames() -> Vec<Vec<i16>> {
+    let frame_len = TARGET_SAMPLE_RATE as usize / 2;
+    [440.0_f32, 660.0, 550.0]
+        .into_iter()
+        .map(|freq| {
+            (0..frame_len)
+                .map(|index| {
+                    let phase =
+                        (index as f32 * freq * std::f32::consts::TAU) / TARGET_SAMPLE_RATE as f32;
+                    (phase.sin() * 10_000.0).round() as i16
+                })
+                .collect()
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -898,6 +898,7 @@ pub fn run() {
             commands::audio::start_meeting_capture,
             commands::audio::is_meeting_capture_active,
             commands::audio::stop_meeting_capture,
+            commands::audio::e2e_inject_meeting_capture_audio,
             commands::audio::reconcile_meeting_speakers,
             commands::audio::generate_meeting_notes,
             commands::audio::republish_meeting_to_seren_notes,

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -133,6 +133,19 @@ describe("Windows production e2e release gate", () => {
     );
   });
 
+  it("enables deterministic Meeting capture injection only for Windows e2e (#2557)", () => {
+    expect(runner).toContain("SEREN_E2E_CAPTURE_INJECTION");
+    expect(probe).toContain("e2e_inject_meeting_capture_audio");
+    expect(probe).toContain("injectMeetingCaptureAudio");
+
+    const captureStart = probe.indexOf('tauriInvoke(page, "start_meeting_capture"');
+    const injectAt = probe.indexOf("injectMeetingCaptureAudio(page, meeting.id)");
+    const stopAt = probe.indexOf('tauriInvoke(page, "stop_meeting_capture"');
+    expect(captureStart).toBeGreaterThanOrEqual(0);
+    expect(injectAt).toBeGreaterThan(captureStart);
+    expect(stopAt).toBeGreaterThan(injectAt);
+  });
+
   it("fails eSigner CKA login/load commands at their native failure point (#2483)", () => {
     const buildJob = workflowJob("build");
     expect(buildJob).toContain("function Invoke-EsignerCka");


### PR DESCRIPTION
## Summary
- add a hidden Meeting capture e2e injection command gated by SEREN_E2E_CAPTURE_INJECTION
- enable the gate only from the Windows production e2e runner
- inject deterministic frames after capture start so headless AWS loopback failures no longer block the release audit

Closes #2557

## Validation
- node --check scripts/windows-e2e-app.mjs
- pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts
- pnpm prepare:mcp-servers && cargo test --manifest-path src-tauri/Cargo.toml audio::pipeline --lib
- git diff --check

## Audit
- Production renderer push path remains disabled unless a capture slot was started while SEREN_E2E_CAPTURE_INJECTION=1.
- The Windows e2e runner is the only edited production script that sets the gate before launching Seren.exe.
- The command refuses inactive captures and disabled gates, then inserts a known transcript segment after accepted frames.