### PR TITLE
fix(e2e): accept successful Windows probe with blank exit code

### DIFF
--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -163,8 +163,19 @@ function Invoke-ProcessWithTimeout([string]$FilePath, [string[]]$ArgumentList, [
     Write-FileTail $StderrPath 200
     Fail "$Label timed out after ${TimeoutSeconds}s and was killed."
   }
-  Write-Stage "${Label} exited with code $($process.ExitCode)"
-  return $process.ExitCode
+  try {
+    $process.WaitForExit()
+    $process.Refresh()
+  } catch {
+    Write-Host "::warning::Unable to refresh ${Label} process exit status: $($_.Exception.Message)"
+  }
+  if ($null -eq $process.ExitCode) {
+    Write-Stage "${Label} exited without reporting an exit code"
+    return $null
+  }
+  $exitCode = [int]$process.ExitCode
+  Write-Stage "${Label} exited with code $exitCode"
+  return $exitCode
 }
 
 function Write-FileTail([string]$Path, [int]$Tail = 200) {
@@ -382,6 +393,13 @@ try {
   Write-Stage "Running Node app e2e probe"
   $probeExitCode = Invoke-ProcessWithTimeout "node" @("$PSScriptRoot/windows-e2e-app.mjs") $ProbeTimeoutSeconds "Windows app e2e probe" -NoNewWindow -StdoutPath $probeStdoutPath -StderrPath $probeStderrPath -OnTimeout {
     Write-ProbeTimeoutDiagnostics $app
+  }
+  if ($null -eq $probeExitCode -and (Test-Path -LiteralPath $probeStdoutPath)) {
+    $probePassed = Select-String -LiteralPath $probeStdoutPath -SimpleMatch "[windows-e2e] full Windows production e2e passed" -Quiet
+    if ($probePassed) {
+      Write-Stage "Windows app e2e probe exit code was blank but success sentinel was observed"
+      $probeExitCode = 0
+    }
   }
   if ($probeExitCode -ne 0) {
     Write-FileTail $probeStdoutPath 200

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -146,6 +146,21 @@ describe("Windows production e2e release gate", () => {
     expect(stopAt).toBeGreaterThan(injectAt);
   });
 
+  it("does not fail a successful Windows probe solely because PowerShell reported a blank exit code (#2559)", () => {
+    expect(runner).toContain("$process.Refresh()");
+    expect(runner).toContain(
+      'Select-String -LiteralPath $probeStdoutPath -SimpleMatch "[windows-e2e] full Windows production e2e passed" -Quiet',
+    );
+    expect(runner).toContain(
+      "Windows app e2e probe exit code was blank but success sentinel was observed",
+    );
+
+    const fallbackAt = runner.indexOf("$null -eq $probeExitCode");
+    const failureAt = runner.indexOf("Windows app e2e script failed with exit code");
+    expect(fallbackAt).toBeGreaterThanOrEqual(0);
+    expect(failureAt).toBeGreaterThan(fallbackAt);
+  });
+
   it("fails eSigner CKA login/load commands at their native failure point (#2483)", () => {
     const buildJob = workflowJob("build");
     expect(buildJob).toContain("function Invoke-EsignerCka");


### PR DESCRIPTION
## Summary
- refresh process state before reading exit codes in the Windows e2e harness
- handle the observed Windows PowerShell null/blank probe exit code only when the probe stdout includes the explicit full-success sentinel
- keep normal failure handling for nonzero or blank probe exits without the sentinel

Closes #2559

## Validation
- git diff --check
- node --check scripts/windows-e2e-app.mjs
- pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts
- pwsh parse check for scripts/windows-e2e-app.ps1

## Audit
- The #2558 AWS walkthrough completed all product checks and Meeting capture passed with system=3 frames, but the harness failed on a blank process exit code.
- This patch only relaxes the blank-exit path when the probe emitted `[windows-e2e] full Windows production e2e passed`; real probe failures still tail stdout/stderr and fail.