### PR TITLE
fix(e2e): ignore transient provider ws startup error

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -70,6 +70,28 @@ function logStage(message) {
   console.log(`[windows-e2e] ${message}`);
 }
 
+function isTransientProviderRuntimeStartupError(message) {
+  return /^WebSocket connection to 'ws:\/\/127\.0\.0\.1:\d+\/?' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED$/.test(
+    message,
+  );
+}
+
+function assertNoUnexpectedBrowserErrors(browserErrors) {
+  const unexpectedErrors = browserErrors.filter(
+    (message) => !isTransientProviderRuntimeStartupError(message),
+  );
+  const ignoredCount = browserErrors.length - unexpectedErrors.length;
+  if (ignoredCount > 0) {
+    console.log(
+      `[windows-e2e] ignored ${ignoredCount} transient provider runtime startup WebSocket error(s) after runtime auth succeeded`,
+    );
+  }
+  assert(
+    unexpectedErrors.length === 0,
+    `WebView console/page errors: ${unexpectedErrors.join("\n")}`,
+  );
+}
+
 async function waitUntil(label, fn, { timeoutMs = 60_000, intervalMs = 500 } = {}) {
   const deadline = Date.now() + timeoutMs;
   let lastError;
@@ -1384,7 +1406,7 @@ async function main() {
     await exerciseHistorySync(page, token);
     await validateGithubPat();
     await exerciseMeetingCapture(page);
-    assert(browserErrors.length === 0, `WebView console/page errors: ${browserErrors.join("\n")}`);
+    assertNoUnexpectedBrowserErrors(browserErrors);
     console.log("[windows-e2e] full Windows production e2e passed");
   } finally {
     await browser.close();

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -161,6 +161,29 @@ describe("Windows production e2e release gate", () => {
     expect(failureAt).toBeGreaterThan(fallbackAt);
   });
 
+  it("ignores only transient provider runtime startup WebSocket console noise after successful auth (#2561)", () => {
+    expect(probe).toContain("isTransientProviderRuntimeStartupError");
+    expect(probe).toContain("assertNoUnexpectedBrowserErrors");
+    expect(probe).toContain("net::ERR_CONNECTION_REFUSED");
+    expect(probe).toContain(
+      "transient provider runtime startup WebSocket error(s) after runtime auth succeeded",
+    );
+    expect(probe).toContain("unexpectedErrors.length === 0");
+    expect(probe).not.toContain("browserErrors.length === 0");
+
+    const mainAt = probe.indexOf("async function main()");
+    const agentRuntimeAt = probe.indexOf("await exerciseAgentRuntime(page);", mainAt);
+    const meetingCaptureAt = probe.indexOf("await exerciseMeetingCapture(page);", mainAt);
+    const auditAt = probe.indexOf(
+      "assertNoUnexpectedBrowserErrors(browserErrors);",
+      mainAt,
+    );
+    expect(mainAt).toBeGreaterThanOrEqual(0);
+    expect(agentRuntimeAt).toBeGreaterThan(mainAt);
+    expect(meetingCaptureAt).toBeGreaterThan(agentRuntimeAt);
+    expect(auditAt).toBeGreaterThan(meetingCaptureAt);
+  });
+
   it("fails eSigner CKA login/load commands at their native failure point (#2483)", () => {
     const buildJob = workflowJob("build");
     expect(buildJob).toContain("function Invoke-EsignerCka");


### PR DESCRIPTION
## Summary\n- filters only the known transient localhost provider-runtime WebSocket connection-refused console error after the provider runtime has already authenticated and the Windows probe reaches the final audit\n- keeps all other WebView console/page errors fatal\n- adds a focused release-gate guard for the #2561 regression\n\nFixes #2561\n\n## Validation\n- git diff --check\n- node --check scripts/windows-e2e-app.mjs\n- pnpm exec vitest run tests/unit/windows-e2e-release-gate.test.ts\n- pnpm lint (passes; reports existing unrelated warnings in UI files)\n