### PR TITLE
Fix Windows Codex MCP config shell launch

### DIFF
--- a/bin/browser-local/mcp-config.mjs
+++ b/bin/browser-local/mcp-config.mjs
@@ -95,25 +95,43 @@ function dedupeServers(servers) {
   return Array.from(deduped.values());
 }
 
+function encodeTomlString(value) {
+  const raw = String(value);
+  if (!raw.includes("'") && !/[\r\n]/.test(raw)) {
+    return `'${raw}'`;
+  }
+  if (!raw.includes("'''") && !/[\r\n]/.test(raw)) {
+    return `'''${raw}'''`;
+  }
+  return JSON.stringify(raw);
+}
+
+function encodeTomlKey(key) {
+  if (/^[A-Za-z0-9_-]+$/.test(key)) {
+    return key;
+  }
+  return encodeTomlString(key);
+}
+
 function encodeTomlValue(value) {
   if (typeof value === "string") {
-    return JSON.stringify(value);
+    return encodeTomlString(value);
   }
   if (typeof value === "number") {
-    return Number.isFinite(value) ? String(value) : JSON.stringify(String(value));
+    return Number.isFinite(value) ? String(value) : encodeTomlString(value);
   }
   if (typeof value === "boolean") {
     return value ? "true" : "false";
   }
   if (Array.isArray(value)) {
-    return `[${value.map((item) => encodeTomlValue(item)).join(", ")}]`;
+    return `[${value.map((item) => encodeTomlValue(item)).join(",")}]`;
   }
   if (value && typeof value === "object") {
     return `{${Object.entries(value)
-      .map(([key, child]) => `${JSON.stringify(key)}=${encodeTomlValue(child)}`)
-      .join(", ")}}`;
+      .map(([key, child]) => `${encodeTomlKey(key)}=${encodeTomlValue(child)}`)
+      .join(",")}}`;
   }
-  return '""';
+  return "''";
 }
 
 function buildClaudeMcpConfig(servers) {

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -256,11 +256,21 @@ function buildInitializeParams() {
   };
 }
 
+function quoteWindowsShellArg(arg) {
+  return `"${String(arg).replace(/"/g, '\\"')}"`;
+}
+
 function spawnCodexProcess(cwd, { apiKey, mcpServers } = {}) {
   const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
+  const useWindowsShell = process.platform === "win32";
   const args = ["app-server"];
   if (mcpConfig.codexMcpConfigOverride) {
-    args.push("-c", mcpConfig.codexMcpConfigOverride);
+    args.push(
+      "-c",
+      useWindowsShell
+        ? quoteWindowsShellArg(mcpConfig.codexMcpConfigOverride)
+        : mcpConfig.codexMcpConfigOverride,
+    );
   }
 
   // Use the absolute-path resolver instead of bare `"codex"` so GUI-launched
@@ -274,7 +284,7 @@ function spawnCodexProcess(cwd, { apiKey, mcpServers } = {}) {
       ...mcpConfig.childEnv,
     },
     stdio: ["pipe", "pipe", "pipe"],
-    shell: process.platform === "win32",
+    shell: useWindowsShell,
   });
 }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1047,6 +1047,22 @@ export function agentDisplayName(agentType?: string): string {
   }
 }
 
+function agentInitializationFailureMessage(agentType?: string): string {
+  const agentName = agentDisplayName(agentType);
+  const remediation =
+    agentType === "codex"
+      ? "Codex is installed and signed in"
+      : agentType === "gemini"
+        ? "Gemini is installed and signed in"
+        : agentType === "lmstudio"
+          ? "LM Studio is running and reachable"
+          : agentType === "claude-codex"
+            ? "Claude Code and Codex are installed and signed in"
+            : `${agentName} is installed and authenticated`;
+
+  return `Agent session terminated before initialization completed. Check that ${remediation}.`;
+}
+
 function truncateBootstrapText(content: string): string {
   return content.length > FORK_BOOTSTRAP_MAX_MSG_CHARS
     ? `${content.slice(0, FORK_BOOTSTRAP_MAX_MSG_CHARS)}... [truncated]`
@@ -2947,11 +2963,11 @@ export const agentStore = {
                 "Agent session failed during initialization.";
               rejectReady(new Error(sessionError));
             } else if (data.status === "terminated" && rejectReady) {
-              // Claude process exited before reaching "ready" — typically an
-              // auth failure or binary-not-found on Windows.
+              // The provider process exited before reaching "ready" — typically
+              // an auth failure or binary-not-found on Windows.
               const sessionError =
                 state.sessions[data.sessionId]?.error ??
-                "Agent session terminated before initialization completed. Check that Claude Code is installed and authenticated.";
+                agentInitializationFailureMessage(resolvedAgentType);
               rejectReady(new Error(sessionError));
             }
           },
@@ -3333,7 +3349,7 @@ export const agentStore = {
               );
               initFailure =
                 sessionState?.error ??
-                "Agent session terminated before initialization completed. Check that Claude Code is installed and authenticated.";
+                agentInitializationFailureMessage(resolvedAgentType);
             } else {
               console.warn(
                 "[AgentStore] Timeout waiting for ready, proceeding anyway",

--- a/tests/fixtures/argv-printer.mjs
+++ b/tests/fixtures/argv-printer.mjs
@@ -1,0 +1,1 @@
+console.log(JSON.stringify(process.argv.slice(2)));

--- a/tests/unit/agent-spawn-guard.test.ts
+++ b/tests/unit/agent-spawn-guard.test.ts
@@ -53,3 +53,18 @@ describe("Codex spawnSession dead-process guard", () => {
     );
   });
 });
+
+describe("agent initialization failure copy", () => {
+  const agentStoreSource = readFileSync(
+    resolve("src/stores/agent.store.ts"),
+    "utf-8",
+  );
+
+  it("uses provider-specific fallback remediation instead of a Claude-only message", () => {
+    expect(agentStoreSource).toContain("agentInitializationFailureMessage");
+    expect(agentStoreSource).toContain("Codex is installed and signed in");
+    expect(agentStoreSource).not.toContain(
+      "Agent session terminated before initialization completed. Check that Claude Code is installed and authenticated.",
+    );
+  });
+});

--- a/tests/unit/mcp-config-codex.test.ts
+++ b/tests/unit/mcp-config-codex.test.ts
@@ -1,0 +1,75 @@
+// ABOUTME: Regression guard for Windows Codex app-server MCP config argv handling.
+// ABOUTME: Pins TOML literal-string output so cmd.exe cannot split or strip needed quotes.
+
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const MODULE_PATH = "../../bin/browser-local/mcp-config.mjs";
+const EMBEDDED_NODE = String.raw`C:\Program Files\Seren Desktop\embedded-runtime\win32-x64\node\node.exe`;
+const PLAYWRIGHT_SCRIPT = String.raw`C:\Users\rebec\AppData\Local\Seren Desktop\mcp-servers\playwright-stealth\dist\index.js`;
+
+const PLAYWRIGHT_SERVER = {
+  name: "playwright-stealth",
+  type: "local",
+  enabled: true,
+  command: "node",
+  args: [PLAYWRIGHT_SCRIPT],
+  env: {},
+};
+
+async function loadModule() {
+  vi.resetModules();
+  return await import(MODULE_PATH);
+}
+
+describe("Codex MCP config override", () => {
+  const originalEmbeddedNode = process.env.SEREN_EMBEDDED_NODE_BIN;
+
+  beforeEach(() => {
+    process.env.SEREN_EMBEDDED_NODE_BIN = EMBEDDED_NODE;
+  });
+
+  afterEach(() => {
+    if (originalEmbeddedNode === undefined) {
+      delete process.env.SEREN_EMBEDDED_NODE_BIN;
+    } else {
+      process.env.SEREN_EMBEDDED_NODE_BIN = originalEmbeddedNode;
+    }
+  });
+
+  it("uses shell-stable TOML literal strings for Windows paths with spaces", async () => {
+    const { buildProviderMcpConfig } = await loadModule();
+
+    const { codexMcpConfigOverride } = buildProviderMcpConfig({
+      apiKey: null,
+      mcpServers: [PLAYWRIGHT_SERVER],
+    });
+
+    expect(codexMcpConfigOverride).toBe(
+      `mcp_servers={playwright-stealth={command='${EMBEDDED_NODE}',args=['${PLAYWRIGHT_SCRIPT}']}}`,
+    );
+  });
+
+  it("survives shell=true argv construction when wrapped as one Windows shell arg", async () => {
+    const { buildProviderMcpConfig } = await loadModule();
+    const { codexMcpConfigOverride } = buildProviderMcpConfig({
+      apiKey: null,
+      mcpServers: [PLAYWRIGHT_SERVER],
+    });
+    const wrappedForWindowsShell = `"${codexMcpConfigOverride}"`;
+
+    const probe = spawnSync(
+      process.execPath,
+      [resolve("tests/fixtures/argv-printer.mjs"), "app-server", "-c", wrappedForWindowsShell],
+      { encoding: "utf8", shell: true },
+    );
+
+    expect(probe.status).toBe(0);
+    expect(JSON.parse(probe.stdout)).toEqual([
+      "app-server",
+      "-c",
+      codexMcpConfigOverride,
+    ]);
+  });
+});

--- a/tests/unit/mcp-config-node-resolve.test.ts
+++ b/tests/unit/mcp-config-node-resolve.test.ts
@@ -100,7 +100,7 @@ describe("#1883 — mcp-config resolves bare 'node' to embedded node binary", ()
       mcpServers: [PLAYWRIGHT_SERVER],
     });
 
-    expect(codexMcpConfigOverride).toContain(`"command"=${JSON.stringify(EMBEDDED_NODE)}`);
-    expect(codexMcpConfigOverride).not.toContain(`"command"="node"`);
+    expect(codexMcpConfigOverride).toContain(`command='${EMBEDDED_NODE}'`);
+    expect(codexMcpConfigOverride).not.toContain("command='node'");
   });
 });


### PR DESCRIPTION
## Summary
- Fixes the Windows Codex `.cmd` launch path so the MCP `-c` override is preserved as one shell argument and remains valid TOML.
- Emits Codex MCP inline TOML with literal strings and compact tables to avoid `cmd.exe` stripping TOML double quotes.
- Replaces the Claude-only initialization fallback with provider-specific remediation copy.

## Audit
Log evidence from:
- `~/Downloads/Logs/tauri.localhost-1781810354465.log`
- `~/Downloads/Logs/tauri.localhost-1781810426931.log`

P0 signature:
- `codex app-server` exits with `unrecognized subcommand 'args=[\\\\?\\C:\\Users\\rebec\\...\\playwright-stealth\\dist\\index.js]}}'` because Windows shell splitting turns the MCP config into extra argv.

P1 signature:
- Codex spawn fallback tells the user to check Claude Code installation/authentication.

Audited code paths:
- `bin/browser-local/mcp-config.mjs`
- `bin/browser-local/providers.mjs`
- `src/stores/agent.store.ts`

Closes #2565

## Validation
- `pnpm vitest run tests/unit/mcp-config-codex.test.ts tests/unit/mcp-config-gemini.test.ts tests/unit/mcp-config-node-resolve.test.ts tests/unit/agent-spawn-guard.test.ts`
- `pnpm build`
- direct local Codex parser smoke for `app-server -c <patched override> --listen off`
- AWS Windows SSM `.cmd` argv preservation probe on `seren-sandbox`
- AWS Windows SSM temp Codex CLI parser smoke on `seren-sandbox`
- `pnpm test:runtime-smoke`
- `pnpm exec tsc --noEmit`
