### PR TITLE
fix: surface DocReader and Windows Codex errors

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -10,6 +10,7 @@ import {
 } from "./agent-registry.mjs";
 import { providerLogPrefix } from "./logging.mjs";
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
+import { composeWindowsShellCommand } from "./windows-shell-args.mjs";
 
 // Agent runtimes are loaded in isolation (#2457). Each runtime module is
 // imported dynamically inside try/catch so that one agent failing to load — a
@@ -256,35 +257,37 @@ function buildInitializeParams() {
   };
 }
 
-function quoteWindowsShellArg(arg) {
-  return `"${String(arg).replace(/"/g, '\\"')}"`;
-}
-
 function spawnCodexProcess(cwd, { apiKey, mcpServers } = {}) {
   const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
   const useWindowsShell = process.platform === "win32";
   const args = ["app-server"];
   if (mcpConfig.codexMcpConfigOverride) {
-    args.push(
-      "-c",
-      useWindowsShell
-        ? quoteWindowsShellArg(mcpConfig.codexMcpConfigOverride)
-        : mcpConfig.codexMcpConfigOverride,
-    );
+    args.push("-c", mcpConfig.codexMcpConfigOverride);
   }
 
   // Use the absolute-path resolver instead of bare `"codex"` so GUI-launched
   // instances don't depend on shell PATH — addresses the same class of
   // Windows regressions we hit for Claude (#876, #928, #1297, #1409).
   const codexBinary = resolveInstalledCodexBinary();
+  const spawnEnv = {
+    ...process.env,
+    ...mcpConfig.childEnv,
+  };
+
+  if (useWindowsShell) {
+    return spawn(composeWindowsShellCommand(codexBinary, args), {
+      cwd,
+      env: spawnEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: true,
+      windowsVerbatimArguments: true,
+    });
+  }
+
   return spawn(codexBinary, args, {
     cwd,
-    env: {
-      ...process.env,
-      ...mcpConfig.childEnv,
-    },
+    env: spawnEnv,
     stdio: ["pipe", "pipe", "pipe"],
-    shell: useWindowsShell,
   });
 }
 

--- a/bin/browser-local/windows-shell-args.mjs
+++ b/bin/browser-local/windows-shell-args.mjs
@@ -1,0 +1,15 @@
+// ABOUTME: Windows cmd.exe argument quoting helpers for provider-runtime child processes.
+// ABOUTME: Keeps shell=true process launches from splitting structured config args.
+
+export function quoteWindowsShellArg(arg) {
+  const value = String(arg);
+  if (value.length === 0) return '""';
+
+  return `"${value
+    .replace(/(\\*)"/g, '$1$1\\"')
+    .replace(/(\\+)$/g, "$1$1")}"`;
+}
+
+export function composeWindowsShellCommand(command, args = []) {
+  return [command, ...args].map((arg) => quoteWindowsShellArg(arg)).join(" ");
+}

--- a/src/services/docreader.ts
+++ b/src/services/docreader.ts
@@ -4,7 +4,7 @@
 import { apiBase } from "@/lib/config";
 import { appFetch } from "@/lib/fetch";
 import type { Attachment } from "@/lib/providers/types";
-import { unwrapPublisherBody } from "@/lib/publisher-response";
+import { publisherStatus, unwrapPublisherBody } from "@/lib/publisher-response";
 import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 import { updateBalanceFromError } from "@/stores/wallet.store";
@@ -49,6 +49,65 @@ function extractText(payload: DocReaderResponseBody): string | undefined {
     if (joined.trim()) return joined;
   }
   return undefined;
+}
+
+function updateBalanceFromPublisherError(payload: unknown): void {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return;
+  const balanceAtomic = (payload as Record<string, unknown>)
+    .availableBalanceAtomic;
+  if (typeof balanceAtomic !== "string" && typeof balanceAtomic !== "number") {
+    return;
+  }
+  const parsed =
+    typeof balanceAtomic === "number"
+      ? balanceAtomic
+      : Number.parseInt(balanceAtomic, 10);
+  if (!Number.isNaN(parsed)) {
+    updateBalanceFromError(parsed);
+  }
+}
+
+function publisherErrorMessage(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+  if (typeof record.message === "string" && record.message.trim()) {
+    return record.message.trim();
+  }
+  if (typeof record.error === "string" && record.error.trim()) {
+    return record.error.trim();
+  }
+  const error = record.error;
+  if (error && typeof error === "object" && !Array.isArray(error)) {
+    const message = (error as Record<string, unknown>).message;
+    if (typeof message === "string" && message.trim()) {
+      return message.trim();
+    }
+  }
+  return null;
+}
+
+function docReaderStatusError(status: number, payload: unknown): Error {
+  if (status === 402) {
+    updateBalanceFromPublisherError(payload);
+    return new Error(
+      "Insufficient SerenBucks balance. Add funds to process documents.",
+    );
+  }
+  if (status === 401) {
+    return new Error(
+      "Document processing requires a Seren account. Sign in to continue.",
+    );
+  }
+
+  const message = publisherErrorMessage(payload);
+  return new Error(
+    message
+      ? `DocReader service failed (${status}): ${message}`
+      : `DocReader service failed (${status}). Try again later.`,
+  );
 }
 
 /**
@@ -127,6 +186,17 @@ export async function readDocument(attachment: Attachment): Promise<string> {
 
   const data = await response.json();
   console.log("[DocReader] Response payload keys:", Object.keys(data));
+  const innerStatus = publisherStatus(data);
+  if (innerStatus !== undefined && innerStatus >= 400) {
+    const payload = unwrapPublisherBody<unknown>(data);
+    console.error(
+      "[DocReader] Publisher error:",
+      innerStatus,
+      JSON.stringify(payload).slice(0, 500),
+    );
+    throw docReaderStatusError(innerStatus, payload);
+  }
+
   const payload = unwrapPublisherBody<DocReaderResponseBody>(
     data,
   ) as DocReaderResponseBody;

--- a/tests/unit/docreader.test.ts
+++ b/tests/unit/docreader.test.ts
@@ -1,0 +1,67 @@
+// ABOUTME: Critical DocReader envelope tests for Gateway transport-200 publisher failures.
+// ABOUTME: Prevents upstream 5xx responses from being misreported as empty documents.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Attachment } from "@/lib/providers/types";
+
+const mockAppFetch = vi.hoisted(() => vi.fn());
+const mockGetToken = vi.hoisted(() => vi.fn());
+const mockShouldUseRustGatewayAuth = vi.hoisted(() => vi.fn());
+const mockUpdateBalanceFromError = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/fetch", () => ({ appFetch: mockAppFetch }));
+vi.mock("@/services/auth", () => ({ getToken: mockGetToken }));
+vi.mock("@/lib/tauri-fetch", () => ({
+  shouldUseRustGatewayAuth: mockShouldUseRustGatewayAuth,
+}));
+vi.mock("@/stores/wallet.store", () => ({
+  updateBalanceFromError: mockUpdateBalanceFromError,
+}));
+vi.mock("@/lib/config", () => ({ apiBase: "https://api.serendb.com" }));
+
+function makeJsonResponse(payload: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => payload,
+  } as unknown as Response;
+}
+
+const attachment: Attachment = {
+  name: "resume.docx",
+  mimeType:
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  base64: "ZmFrZQ==",
+};
+
+describe("readDocument", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockGetToken.mockResolvedValue("test-token");
+    mockShouldUseRustGatewayAuth.mockReturnValue(false);
+  });
+
+  it("surfaces publisher-inner 5xx errors before trying to extract text", async () => {
+    mockAppFetch.mockResolvedValueOnce(
+      makeJsonResponse({
+        data: {
+          status: 500,
+          body: { message: "Internal Server Error" },
+          response_bytes: 35,
+          execution_time_ms: 104,
+          cost: "0",
+          asset_symbol: "USDC",
+          payment_source: "prepaid_balance",
+        },
+      }),
+    );
+
+    const { readDocument } = await import("@/services/docreader");
+
+    await expect(readDocument(attachment)).rejects.toThrow(
+      "DocReader service failed (500): Internal Server Error",
+    );
+  });
+});

--- a/tests/unit/mcp-config-codex.test.ts
+++ b/tests/unit/mcp-config-codex.test.ts
@@ -6,6 +6,8 @@ import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const MODULE_PATH = "../../bin/browser-local/mcp-config.mjs";
+const WINDOWS_SHELL_ARGS_MODULE =
+  "../../bin/browser-local/windows-shell-args.mjs";
 const EMBEDDED_NODE = String.raw`C:\Program Files\Seren Desktop\embedded-runtime\win32-x64\node\node.exe`;
 const PLAYWRIGHT_SCRIPT = String.raw`C:\Users\rebec\AppData\Local\Seren Desktop\mcp-servers\playwright-stealth\dist\index.js`;
 
@@ -51,19 +53,23 @@ describe("Codex MCP config override", () => {
     );
   });
 
-  it("survives shell=true argv construction when wrapped as one Windows shell arg", async () => {
+  it("survives shell=true command-line construction as one config arg", async () => {
     const { buildProviderMcpConfig } = await loadModule();
+    const { composeWindowsShellCommand } = await import(
+      WINDOWS_SHELL_ARGS_MODULE
+    );
     const { codexMcpConfigOverride } = buildProviderMcpConfig({
       apiKey: null,
       mcpServers: [PLAYWRIGHT_SERVER],
     });
-    const wrappedForWindowsShell = `"${codexMcpConfigOverride}"`;
+    const commandLine = composeWindowsShellCommand(process.execPath, [
+      resolve("tests/fixtures/argv-printer.mjs"),
+      "app-server",
+      "-c",
+      codexMcpConfigOverride,
+    ]);
 
-    const probe = spawnSync(
-      process.execPath,
-      [resolve("tests/fixtures/argv-printer.mjs"), "app-server", "-c", wrappedForWindowsShell],
-      { encoding: "utf8", shell: true },
-    );
+    const probe = spawnSync(commandLine, { encoding: "utf8", shell: true });
 
     expect(probe.status).toBe(0);
     expect(JSON.parse(probe.stdout)).toEqual([


### PR DESCRIPTION
Closes #2567
Closes #2569

## Audit
- Source log: `~/Downloads/Logs/tauri.localhost-1781812476284.log`
- Confirmed the original logged Windows Codex MCP config corruption is already fixed on `main` by #2566.
- New P1: DocReader received Gateway transport `200 OK` while the publisher envelope carried inner `status: 500`, then misreported it as an empty document.
- New P1 found during required AWS Windows walkthrough: Windows `shell: true` spawn quoting split the Codex `-c` MCP override on actual Windows Server 2022.

## Fix
- Check `publisherStatus(data)` before DocReader text extraction.
- Surface inner 401/402 with existing user-facing copy, preserve wallet balance refresh for inner 402 envelopes, and surface inner 5xx as `DocReader service failed (<status>): <message>`.
- Compose a single explicitly quoted Windows command line for Codex shell launches instead of relying on Node's `shell: true` command+args concatenation.
- Add focused regression coverage for the exact logged DocReader envelope and actual Windows shell argv behavior.

## Verification
- Local: `pnpm vitest run tests/unit/docreader.test.ts tests/unit/mcp-config-codex.test.ts tests/unit/mcp-config-node-resolve.test.ts`
- Local: `pnpm biome check src/services/docreader.ts tests/unit/docreader.test.ts bin/browser-local/providers.mjs bin/browser-local/windows-shell-args.mjs tests/unit/mcp-config-codex.test.ts`
- Local: `pnpm exec tsc --noEmit --pretty false`
- Local: `git diff --check`
- Local: `pnpm build`
- AWS Windows Server 2022 SSM command `00533f65-40ab-4b13-a137-2c8fc763d163`: focused Vitest, typecheck, and Biome passed with `core.autocrlf=false`.
- GitHub Actions CI run `27788207884`: green across lint, frontend tests, Rust tests, production E2E, macOS build, Windows build, and Ubuntu build.