### PR TITLE
Fix playwright-stealth CDP attach mode

### DIFF
--- a/mcp-servers/playwright-stealth/README.md
+++ b/mcp-servers/playwright-stealth/README.md
@@ -42,6 +42,8 @@ This MCP server is automatically configured in Seren Desktop. It provides the sa
 - `playwright_press` - Press keyboard keys
 - `playwright_close` - Close browser
 - `playwright_reset` - Reset page
+- `playwright_list_pages` - List open pages/tabs in the active browser context
+- `playwright_select_page` - Select the active page/tab by id, index, URL substring, or title substring
 - `playwright_list_browsers` - List all installed browsers available for automation
 - `playwright_set_browser` - Switch to a different installed browser at runtime
 - `playwright_get_cookie` - Read a cookie value (including HttpOnly cookies) from the active page's origin
@@ -97,6 +99,33 @@ of evasion names. When the variable is unset, `iframe.contentWindow` and
 list replaces the default disabled set; set it to an empty string to opt back
 into all stealth evasions except `chrome.app`, which is always disabled for
 macOS notarization compatibility.
+
+### CDP Attach Mode for Human Login
+
+Skills that need human-in-the-loop authentication can launch a visible Chrome
+or Edge profile with remote debugging enabled, then point this MCP at that
+browser instead of allowing the MCP to launch its own fresh profile:
+
+```bash
+PLAYWRIGHT_MCP_CONNECT_CDP_URL=http://127.0.0.1:9222 node dist/index.js
+
+# Equivalent CLI form:
+node dist/index.js --cdp-url http://127.0.0.1:9222
+```
+
+In CDP mode the MCP calls `chromium.connectOverCDP`, uses the attached
+browser's existing default context, and reuses an existing tab when available.
+Call `playwright_list_pages` after the user signs in, then
+`playwright_select_page` with the returned `id`, `index`, `urlContains`, or
+`titleContains` to bind automation to the authenticated tab.
+
+CDP attach mode uses the attached browser's profile, cookies, extensions, and
+launch flags. The `playwright-extra` stealth plugin and launch-only Chromium
+arguments apply only when this MCP launches the browser itself; context and
+page init scripts still apply to future navigations where Playwright supports
+them. `playwright_reset` only unbinds the active page in CDP mode, and
+`playwright_close` disconnects from the remote browser instead of closing the
+user's visible browser.
 
 ### In Seren Desktop
 

--- a/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/browser.test.ts
@@ -1,18 +1,22 @@
 // ABOUTME: Unit tests for multi-browser selection, detection, and configuration.
 // ABOUTME: Validates parseBrowserType, isChromiumBased, resolveBrowserName, and listInstalledBrowsers.
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { InstalledBrowser } from "../browser.js";
 import {
   addPageInitPatchIfEnabled,
   applyStealthPluginIfEnabled,
+  CONNECT_CDP_URL_ENV,
   createSafeStealthPlugin,
   detectDefaultBrowser,
+  getConfiguredCdpUrl,
+  getDefaultBrowserContext,
   isChromiumBased,
   launchBrowserWithFallback,
   listInstalledBrowsers,
   parseBrowserType,
   resolveBrowserName,
+  resolveBrowserStartupMode,
 } from "../browser.js";
 
 const TEST_INSTALLED_BROWSERS: InstalledBrowser[] = [
@@ -46,11 +50,18 @@ const CONTROLLED_ENV_KEYS = [
   "SEREN_PLAYWRIGHT_DISABLE_STEALTH",
   "SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE",
   "SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH",
+  "PLAYWRIGHT_MCP_CONNECT_CDP_URL",
 ] as const;
 
 const ORIGINAL_ENV = new Map(
   CONTROLLED_ENV_KEYS.map((key) => [key, process.env[key]]),
 );
+
+beforeEach(() => {
+  for (const key of CONTROLLED_ENV_KEYS) {
+    delete process.env[key];
+  }
+});
 
 afterEach(() => {
   for (const key of CONTROLLED_ENV_KEYS) {
@@ -162,6 +173,61 @@ describe("parseBrowserType", () => {
     expect(parseBrowserType("msedge-beta")).toBe("msedge-beta");
     expect(parseBrowserType("msedge-dev")).toBe("msedge-dev");
     expect(parseBrowserType("moz-firefox")).toBe("moz-firefox");
+  });
+});
+
+describe("CDP attach startup mode", () => {
+  it("uses PLAYWRIGHT_MCP_CONNECT_CDP_URL when configured", () => {
+    const env = {
+      [CONNECT_CDP_URL_ENV]: " http://127.0.0.1:9222 ",
+    } as NodeJS.ProcessEnv;
+
+    expect(getConfiguredCdpUrl(env, ["node", "index.js"])).toBe(
+      "http://127.0.0.1:9222",
+    );
+    expect(resolveBrowserStartupMode(env, ["node", "index.js"])).toEqual({
+      mode: "cdp",
+      cdpUrl: "http://127.0.0.1:9222",
+    });
+  });
+
+  it("uses --cdp-url when the env var is not set", () => {
+    expect(
+      resolveBrowserStartupMode({}, [
+        "node",
+        "index.js",
+        "--cdp-url",
+        "http://127.0.0.1:9223",
+      ]),
+    ).toEqual({
+      mode: "cdp",
+      cdpUrl: "http://127.0.0.1:9223",
+    });
+  });
+
+  it("falls back to launch mode when no CDP endpoint is configured", () => {
+    expect(resolveBrowserStartupMode({}, ["node", "index.js"])).toEqual({
+      mode: "launch",
+    });
+  });
+
+  it("selects the attached browser default context", () => {
+    const defaultContext = {};
+    const attachedBrowser = {
+      contexts: () => [defaultContext],
+    };
+
+    expect(getDefaultBrowserContext(attachedBrowser as never)).toBe(
+      defaultContext,
+    );
+  });
+
+  it("fails closed when an attached browser has no default context", () => {
+    const attachedBrowser = { contexts: () => [] };
+
+    expect(() => getDefaultBrowserContext(attachedBrowser as never)).toThrow(
+      "Attached CDP browser has no default context",
+    );
   });
 });
 

--- a/mcp-servers/playwright-stealth/src/__tests__/navigate.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/navigate.test.ts
@@ -15,8 +15,10 @@ vi.mock("../browser.js", () => ({
   getActiveBrowserType: vi.fn(() => "chrome"),
   getContext: vi.fn(),
   getPage: mocks.getPage,
+  listPages: vi.fn(),
   listInstalledBrowsers: vi.fn(() => []),
   resetPage: vi.fn(),
+  selectPage: vi.fn(),
   setBrowser: vi.fn(),
 }));
 

--- a/mcp-servers/playwright-stealth/src/__tests__/page_targets.test.ts
+++ b/mcp-servers/playwright-stealth/src/__tests__/page_targets.test.ts
@@ -1,0 +1,68 @@
+// ABOUTME: Tests for page target listing and selection tool wrappers.
+// ABOUTME: Guards CDP attach workflows that bind to a user's authenticated tab.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listPages, selectPage } from "../tools.js";
+
+const mocks = vi.hoisted(() => ({
+  listPages: vi.fn(),
+  selectPage: vi.fn(),
+}));
+
+vi.mock("../browser.js", () => ({
+  closeBrowser: vi.fn(),
+  getActiveBrowserType: vi.fn(() => "chromium-cdp"),
+  getContext: vi.fn(),
+  getPage: vi.fn(),
+  listPages: mocks.listPages,
+  listInstalledBrowsers: vi.fn(() => []),
+  resetPage: vi.fn(),
+  selectPage: mocks.selectPage,
+  setBrowser: vi.fn(),
+}));
+
+describe("page target tools", () => {
+  beforeEach(() => {
+    mocks.listPages.mockReset();
+    mocks.selectPage.mockReset();
+  });
+
+  it("serializes open page targets", async () => {
+    mocks.listPages.mockResolvedValue([
+      {
+        id: "page-1",
+        index: 0,
+        url: "https://bank.example/accounts",
+        title: "Accounts",
+        isActive: true,
+      },
+    ]);
+
+    await expect(listPages()).resolves.toBe(
+      JSON.stringify(
+        [
+          {
+            id: "page-1",
+            index: 0,
+            url: "https://bank.example/accounts",
+            title: "Accounts",
+            isActive: true,
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+  });
+
+  it("selects a page target and reports its URL", async () => {
+    mocks.selectPage.mockResolvedValue({
+      url: () => "https://bank.example/statements",
+    });
+
+    await expect(selectPage({ id: "page-2" })).resolves.toBe(
+      "Selected page: https://bank.example/statements",
+    );
+    expect(mocks.selectPage).toHaveBeenCalledWith({ id: "page-2" });
+  });
+});

--- a/mcp-servers/playwright-stealth/src/browser.ts
+++ b/mcp-servers/playwright-stealth/src/browser.ts
@@ -62,10 +62,12 @@ export const STEALTH_EVASIONS_DISABLE_ENV =
   "SEREN_PLAYWRIGHT_STEALTH_EVASIONS_DISABLE";
 export const DISABLE_PAGE_INIT_PATCH_ENV =
   "SEREN_PLAYWRIGHT_DISABLE_PAGE_INIT_PATCH";
+export const CONNECT_CDP_URL_ENV = "PLAYWRIGHT_MCP_CONNECT_CDP_URL";
 const DEFAULT_DISABLED_STEALTH_EVASIONS = [
   "iframe.contentWindow",
   "navigator.permissions",
 ];
+const CDP_CONNECT_TIMEOUT_MS = 120_000;
 
 // ── Browser Detection ──────────────────────────────────────────────────────────
 
@@ -443,17 +445,78 @@ export async function launchBrowserWithFallback(
 // Lazy: probing installed browser paths during module load can outrun the MCP
 // stdio `initialize` handshake on slow disks. Resolve on first read instead
 // (#1921).
+type BrowserConnectionMode = "launch" | "cdp";
+
 let activeBrowserName: string | null = null;
 let browser: Browser | null = null;
 let context: BrowserContext | null = null;
 let page: Page | null = null;
+let browserConnectionMode: BrowserConnectionMode | null = null;
 let stealthApplied = false;
+let nextPageId = 1;
+const pageIds = new WeakMap<Page, string>();
+
+export interface BrowserPageInfo {
+  id: string;
+  index: number;
+  url: string;
+  title: string;
+  isActive: boolean;
+}
+
+export type PageSelector = {
+  id?: string;
+  index?: number;
+  urlContains?: string;
+  titleContains?: string;
+};
+
+export type BrowserStartupMode =
+  | { mode: "cdp"; cdpUrl: string }
+  | { mode: "launch" };
 
 // ── Public API ─────────────────────────────────────────────────────────────────
 
+export function getConfiguredCdpUrl(
+  env: NodeJS.ProcessEnv = process.env,
+  argv: string[] = process.argv,
+): string | null {
+  const envUrl = env[CONNECT_CDP_URL_ENV]?.trim();
+  if (envUrl) return envUrl;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--cdp-url" || arg === "--connect-cdp-url") {
+      const value = argv[i + 1]?.trim();
+      if (value && !value.startsWith("--")) return value;
+      continue;
+    }
+
+    for (const prefix of ["--cdp-url=", "--connect-cdp-url="]) {
+      if (arg.startsWith(prefix)) {
+        const value = arg.slice(prefix.length).trim();
+        return value || null;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function resolveBrowserStartupMode(
+  env: NodeJS.ProcessEnv = process.env,
+  argv: string[] = process.argv,
+): BrowserStartupMode {
+  const cdpUrl = getConfiguredCdpUrl(env, argv);
+  return cdpUrl ? { mode: "cdp", cdpUrl } : { mode: "launch" };
+}
+
 export function getActiveBrowserType(): string {
   if (activeBrowserName === null) {
-    activeBrowserName = parseBrowserType(process.env.BROWSER_TYPE);
+    activeBrowserName =
+      resolveBrowserStartupMode().mode === "cdp"
+        ? "chromium-cdp"
+        : parseBrowserType(process.env.BROWSER_TYPE);
   }
   return activeBrowserName;
 }
@@ -462,6 +525,12 @@ export function getActiveBrowserType(): string {
 export async function setBrowser(
   name: string,
 ): Promise<{ name: string; browserName: string; stealthSupported: boolean }> {
+  if (resolveBrowserStartupMode().mode === "cdp") {
+    throw new Error(
+      `Cannot switch browsers while ${CONNECT_CDP_URL_ENV} or --cdp-url is set. CDP attach mode uses the already-running Chromium browser.`,
+    );
+  }
+
   const normalized = parseBrowserType(name);
 
   const installed = listInstalledBrowsers();
@@ -584,8 +653,25 @@ export async function addPageInitPatchIfEnabled(
 
 export async function getBrowser(): Promise<Browser> {
   if (!browser) {
-    const installed = listInstalledBrowsers();
+    const startupMode = resolveBrowserStartupMode();
 
+    if (startupMode.mode === "cdp") {
+      try {
+        browser = await chromium.connectOverCDP(startupMode.cdpUrl, {
+          timeout: CDP_CONNECT_TIMEOUT_MS,
+        });
+        browserConnectionMode = "cdp";
+        activeBrowserName = "chromium-cdp";
+        return browser;
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Failed to connect to Chromium over CDP at ${startupMode.cdpUrl}: ${msg}. Ensure the browser was launched with --remote-debugging-port and the endpoint is reachable.`,
+        );
+      }
+    }
+
+    const installed = listInstalledBrowsers();
     try {
       const launched = await launchBrowserWithFallback(
         getActiveBrowserType(),
@@ -606,6 +692,7 @@ export async function getBrowser(): Promise<Browser> {
         },
       );
       browser = launched.browser;
+      browserConnectionMode = "launch";
       activeBrowserName = launched.browserName;
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -617,9 +704,24 @@ export async function getBrowser(): Promise<Browser> {
   return browser;
 }
 
+export function getDefaultBrowserContext(b: Browser): BrowserContext {
+  const [defaultContext] = b.contexts();
+  if (!defaultContext) {
+    throw new Error(
+      "Attached CDP browser has no default context. Launch Chrome or Edge with a normal profile and --remote-debugging-port, then retry.",
+    );
+  }
+  return defaultContext;
+}
+
 export async function getContext(): Promise<BrowserContext> {
   if (!context) {
     const b = await getBrowser();
+    if (browserConnectionMode === "cdp") {
+      context = getDefaultBrowserContext(b);
+      return context;
+    }
+
     const engine = resolveBrowserName(getActiveBrowserType());
     context = await b.newContext({
       userAgent: DEFAULT_USER_AGENTS[engine],
@@ -631,10 +733,37 @@ export async function getContext(): Promise<BrowserContext> {
   return context;
 }
 
+function reusablePages(ctx: BrowserContext): Page[] {
+  return ctx.pages().filter((candidate) => !candidate.isClosed());
+}
+
+function idForPage(targetPage: Page): string {
+  const existing = pageIds.get(targetPage);
+  if (existing) return existing;
+
+  const id = `page-${nextPageId}`;
+  nextPageId += 1;
+  pageIds.set(targetPage, id);
+  return id;
+}
+
+async function safePageTitle(targetPage: Page): Promise<string> {
+  try {
+    return await targetPage.title();
+  } catch {
+    return "";
+  }
+}
+
 export async function getPage(): Promise<Page> {
+  if (page?.isClosed()) {
+    page = null;
+  }
+
   if (!page) {
     const ctx = await getContext();
-    page = await ctx.newPage();
+    const existingPage = reusablePages(ctx)[0];
+    page = existingPage ?? (await ctx.newPage());
 
     const engine = resolveBrowserName(getActiveBrowserType());
     await addPageInitPatchIfEnabled(page, engine);
@@ -642,7 +771,95 @@ export async function getPage(): Promise<Page> {
   return page;
 }
 
+export async function listPages(): Promise<BrowserPageInfo[]> {
+  const ctx = await getContext();
+  const pages = reusablePages(ctx);
+
+  return Promise.all(
+    pages.map(async (targetPage, index) => ({
+      id: idForPage(targetPage),
+      index,
+      url: targetPage.url(),
+      title: await safePageTitle(targetPage),
+      isActive: targetPage === page,
+    })),
+  );
+}
+
+export async function selectPage(selector: PageSelector): Promise<Page> {
+  const hasSelector =
+    selector.id !== undefined ||
+    selector.index !== undefined ||
+    selector.urlContains !== undefined ||
+    selector.titleContains !== undefined;
+
+  if (!hasSelector) {
+    throw new Error(
+      "Select a page by id, index, urlContains, or titleContains. Use playwright_list_pages first.",
+    );
+  }
+
+  const ctx = await getContext();
+  const pages = reusablePages(ctx);
+  const pageInfos = await Promise.all(
+    pages.map(async (targetPage, index) => ({
+      targetPage,
+      info: {
+        id: idForPage(targetPage),
+        index,
+        url: targetPage.url(),
+        title: await safePageTitle(targetPage),
+      },
+    })),
+  );
+
+  const match = pageInfos.find(({ info }) => {
+    if (selector.id !== undefined) return info.id === selector.id;
+    if (selector.index !== undefined) return info.index === selector.index;
+    if (selector.urlContains !== undefined)
+      return info.url.includes(selector.urlContains);
+    if (selector.titleContains !== undefined)
+      return info.title.includes(selector.titleContains);
+    return false;
+  });
+
+  if (!match) {
+    throw new Error(
+      `No matching page found. Available pages: ${pageInfos
+        .map(({ info }) => `${info.id}[${info.index}] ${info.url}`)
+        .join("; ")}`,
+    );
+  }
+
+  page = match.targetPage;
+  await page.bringToFront().catch(() => undefined);
+
+  const engine = resolveBrowserName(getActiveBrowserType());
+  await addPageInitPatchIfEnabled(page, engine);
+
+  return page;
+}
+
 export async function closeBrowser(): Promise<void> {
+  if (browserConnectionMode === "cdp") {
+    if (browser) {
+      const remoteBrowser = browser as Browser & {
+        disconnect?: () => Promise<void> | void;
+      };
+      if (typeof remoteBrowser.disconnect === "function") {
+        await remoteBrowser.disconnect();
+      } else {
+        await browser.close();
+      }
+    }
+    page = null;
+    context = null;
+    browser = null;
+    browserConnectionMode = null;
+    activeBrowserName = null;
+    return;
+  }
+
   if (page) {
     await page.close();
     page = null;
@@ -655,11 +872,14 @@ export async function closeBrowser(): Promise<void> {
     await browser.close();
     browser = null;
   }
+  browserConnectionMode = null;
 }
 
 export async function resetPage(): Promise<void> {
   if (page) {
-    await page.close();
+    if (browserConnectionMode !== "cdp") {
+      await page.close();
+    }
     page = null;
   }
 }

--- a/mcp-servers/playwright-stealth/src/index.ts
+++ b/mcp-servers/playwright-stealth/src/index.ts
@@ -190,6 +190,44 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: "playwright_list_pages",
+        description:
+          "List open pages/tabs in the active browser context. In CDP attach mode this lists the attached browser's existing tabs so the agent can bind to the user's authenticated tab.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "playwright_select_page",
+        description:
+          "Select the active page/tab by id, index, URL substring, or title substring. Use playwright_list_pages first to inspect available targets.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              description:
+                "Stable page id returned by playwright_list_pages, such as page-1.",
+            },
+            index: {
+              type: "number",
+              description:
+                "Zero-based index returned by playwright_list_pages.",
+            },
+            urlContains: {
+              type: "string",
+              description: "Select the first page whose URL contains this text.",
+            },
+            titleContains: {
+              type: "string",
+              description:
+                "Select the first page whose title contains this text.",
+            },
+          },
+        },
+      },
+      {
         name: "playwright_list_browsers",
         description:
           "List all browsers installed on this system that can be used for automation. Returns name, engine, executable path, stealth support, and which browser is currently active.",
@@ -370,6 +408,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         break;
       case "playwright_reset":
         result = await tools.reset();
+        break;
+      case "playwright_list_pages":
+        result = await tools.listPages();
+        break;
+      case "playwright_select_page":
+        result = await tools.selectPage({
+          id: args.id as string | undefined,
+          index: args.index as number | undefined,
+          urlContains: args.urlContains as string | undefined,
+          titleContains: args.titleContains as string | undefined,
+        });
         break;
       case "playwright_list_browsers":
         result = tools.listBrowsers();

--- a/mcp-servers/playwright-stealth/src/tools.ts
+++ b/mcp-servers/playwright-stealth/src/tools.ts
@@ -7,10 +7,13 @@ import {
   getActiveBrowserType,
   getContext,
   getPage,
+  listPages as listBrowserPages,
   listInstalledBrowsers,
   resetPage,
+  selectPage as selectBrowserPage,
   setBrowser,
 } from "./browser.js";
+import type { PageSelector } from "./browser.js";
 import type { NavigateOptions } from "./tool_definitions.js";
 
 type CookieInput = Parameters<BrowserContext["addCookies"]>[0][number];
@@ -157,6 +160,16 @@ export function listBrowsers(): string {
     isActive: b.name === active,
   }));
   return JSON.stringify(result, null, 2);
+}
+
+export async function listPages(): Promise<string> {
+  const pages = await listBrowserPages();
+  return JSON.stringify(pages, null, 2);
+}
+
+export async function selectPage(selector: PageSelector): Promise<string> {
+  const page = await selectBrowserPage(selector);
+  return `Selected page: ${page.url()}`;
 }
 
 export async function switchBrowser(browser: string): Promise<string> {


### PR DESCRIPTION
Closes #2570

## Summary
- Add `PLAYWRIGHT_MCP_CONNECT_CDP_URL` / `--cdp-url` CDP attach mode using `chromium.connectOverCDP` with the existing default browser context.
- Reuse attached browser pages and add `playwright_list_pages` / `playwright_select_page` so agents can bind to the user-authenticated tab.
- Keep launched-browser behavior intact, while making CDP reset/close avoid closing the human-owned tab/browser.
- Document the CDP profile/stealth behavior tradeoff.

## Tests
- `npm run build` in `mcp-servers/playwright-stealth`
- `npm test` in `mcp-servers/playwright-stealth`
- `pnpm prepare:mcp-servers`
- Functional CDP smoke: launched Chrome with `--remote-debugging-port`, attached via rebuilt MCP `dist`, listed/selected existing tab, verified `resetPage()` preserved the tab, verified `closeBrowser()` disconnected while Chrome stayed alive, verified no `playwright_chromiumdev_profile` process.

## Audit
- Confirmed issue path: previous MCP only launched new browser/context/page, so CDP URL was ignored.
- Confirmed fixed path: CDP mode bypasses launch fallback and resolves `getContext()` to `browser.contexts()[0]`.
- Confirmed impact: human login session stays in the same browser profile/page the agent observes and drives.
- Windows note: CDP attach code is OS-independent and mirrors existing Windows E2E `chromium.connectOverCDP(..., { timeout: 120_000 })` precedent; full Windows bundle validation runs in PR CI matrix.