### PR TITLE
fix: lock meeting note template selection to each meeting (#2583)

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -415,6 +415,28 @@ pub async fn update_meeting_title(app: AppHandle, id: String, title: String) -> 
 }
 
 #[tauri::command]
+pub async fn update_meeting_template(
+    app: AppHandle,
+    id: String,
+    template_id: Option<String>,
+) -> Result<(), String> {
+    let lookup = id.clone();
+    run_db(app.clone(), move |conn| {
+        conn.execute(
+            "UPDATE meetings
+             SET template_id = ?1, updated_at = ?2
+             WHERE id = ?3",
+            params![template_id, now_ms(), id],
+        )?;
+        mark_sync_upsert(conn, "meetings", &id)?;
+        Ok(())
+    })
+    .await?;
+    emit_meeting_status_by_id(&app, &lookup).await;
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn append_transcript_segment(
     app: AppHandle,
     meeting_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -892,6 +892,7 @@ pub fn run() {
             commands::audio::update_meeting_status,
             commands::audio::update_meeting_notes,
             commands::audio::update_meeting_title,
+            commands::audio::update_meeting_template,
             commands::audio::set_meeting_routed_skill,
             commands::audio::append_transcript_segment,
             commands::audio::get_transcript_segments,

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -122,9 +122,11 @@ function keywords(text: string): string[] {
 
 export function MeetingDetail(props: MeetingDetailProps) {
   const [templates, setTemplates] = createSignal<MeetingTemplate[]>([]);
-  const [selectedTemplate, setSelectedTemplate] = createSignal(
-    props.meeting.templateId ?? settingsStore.get("meetingTemplateId"),
-  );
+  // The selected template is derived from the meeting record (not local state)
+  // so it stays scoped to this meeting. A shared one-shot signal previously
+  // leaked the last selection across every meeting (#2583).
+  const selectedTemplate = () =>
+    props.meeting.templateId ?? settingsStore.get("meetingTemplateId");
   const [regenerating, setRegenerating] = createSignal(false);
   const [republishing, setRepublishing] = createSignal(false);
   const [highlightedSeq, setHighlightedSeq] = createSignal<number | null>(null);
@@ -372,7 +374,12 @@ export function MeetingDetail(props: MeetingDetailProps) {
         <select
           class="h-7 rounded-md border border-border bg-surface-1 px-2 text-[12px] text-foreground focus:outline-none focus:border-primary/60"
           value={selectedTemplate()}
-          onChange={(event) => setSelectedTemplate(event.currentTarget.value)}
+          onChange={(event) =>
+            void meetingStore.setMeetingTemplate(
+              props.meeting,
+              event.currentTarget.value,
+            )
+          }
         >
           <For each={templates()}>
             {(template) => <option value={template.id}>{template.name}</option>}

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -121,6 +121,13 @@ export function updateMeetingTitle(id: string, title: string): Promise<void> {
   return invoke("update_meeting_title", { id, title });
 }
 
+export function updateMeetingTemplate(
+  id: string,
+  templateId: string | null,
+): Promise<void> {
+  return invoke("update_meeting_template", { id, templateId });
+}
+
 export function setMeetingRoutedSkill(
   id: string,
   routedSkillSlug?: string | null,

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -31,6 +31,7 @@ import {
   stopMeetingCapture as stopBackendCapture,
   type TranscriptSegment,
   updateMeetingStatus,
+  updateMeetingTemplate,
   updateMeetingTitle,
 } from "@/services/meetings";
 import { orchestrate } from "@/services/orchestrator";
@@ -835,6 +836,37 @@ async function renameMeeting(meeting: Meeting, title: string): Promise<void> {
   }
 }
 
+// Persist a meeting's note template so the choice is locked to that meeting and
+// survives switching between meetings. Updates the list row and the active
+// selection immediately; the backend also emits meeting://status, which
+// reconciles any other surface.
+async function setMeetingTemplate(
+  meeting: Meeting,
+  templateId: string,
+): Promise<void> {
+  if (templateId === meeting.templateId) return;
+  if (!isTauriRuntime()) return;
+  try {
+    await updateMeetingTemplate(meeting.id, templateId);
+    setMeetingState("meetings", (meetings) =>
+      meetings.map((item) =>
+        item.id === meeting.id ? { ...item, templateId } : item,
+      ),
+    );
+    if (meetingState.activeMeeting?.id === meeting.id) {
+      setMeetingState("activeMeeting", {
+        ...meetingState.activeMeeting,
+        templateId,
+      });
+    }
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Failed to set meeting template",
+    );
+  }
+}
+
 async function deleteMeeting(meeting: Meeting): Promise<void> {
   if (!isTauriRuntime()) return;
   setMeetingState("error", null);
@@ -976,6 +1008,7 @@ export const meetingStore = {
   regenerateNotes,
   republishToSerenNotes,
   renameMeeting,
+  setMeetingTemplate,
   deleteMeeting,
   clearError,
   startAutoDetect,


### PR DESCRIPTION
Closes #2583.

## Problem

Selecting a note **Template** in one meeting's detail view flipped the Templates dropdown for **every other meeting**. Templates were not locked per meeting (chat).

## Root cause

`MeetingDetail.tsx` stored the selected template in a component-local signal initialized once. `MeetingPanel.tsx` renders the detail with a **non-keyed** `<Show>`, so switching the active meeting reused the same `MeetingDetail` instance — the `createSignal` initializer never re-ran and the value leaked across meetings. The selection was also never persisted to `meeting.templateId`.

## Fix

- Derive the dropdown value from `props.meeting.templateId` (reactive, per-meeting) instead of a shared local signal.
- Persist a chosen template per meeting so it is durably locked to that meeting:
  - `update_meeting_template` Tauri command (mirrors `update_meeting_title`) + `invoke_handler` registration
  - `updateMeetingTemplate` service wrapper
  - `meetingStore.setMeetingTemplate` optimistic-update action (updates list row + active meeting; backend emits `meeting://status` to reconcile other surfaces)

## Validation

- `cargo check` — clean (pre-existing dead-code warnings only)
- `tsc --noEmit` — clean
- `biome check` on changed files — clean

No tests added: this is UI + simple CRUD persistence, which the repo guidance excludes from TDD.

## Affected code paths

- `src/components/meeting/MeetingDetail.tsx`
- `src/stores/meeting.store.ts`
- `src/services/meetings.ts`
- `src-tauri/src/commands/audio.rs`
- `src-tauri/src/lib.rs`

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
