### PR TITLE
fix: move meeting notes link above the note body (#2584)

### DIFF
--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -442,6 +442,63 @@ export function MeetingDetail(props: MeetingDetailProps) {
         <div class="mb-2 text-[12px] font-medium text-muted-foreground">
           Notes
         </div>
+        {/* Link/CTA renders above the note body so it's reachable without
+          scrolling past the full markdown (#2584). */}
+        <Show when={props.meeting.notesMarkdown}>
+          <Show
+            when={props.meeting.serenNotesId}
+            fallback={
+              <Show
+                when={authStore.isAuthenticated}
+                fallback={
+                  <div class="mb-2 text-[12px] text-muted-foreground">
+                    <button
+                      type="button"
+                      class="text-primary hover:underline focus:outline-none focus:underline"
+                      onClick={() => requestSignInModal()}
+                    >
+                      Login to SerenDB to chat with your meeting notes
+                    </button>
+                  </div>
+                }
+              >
+                {/* Authenticated but no published id — the auto-publish
+                  hit a 5xx after retry, the prior session was offline, or
+                  the user signed in after notes finalized. Manual retry. */}
+                <div class="mb-2 flex items-center gap-2">
+                  <button
+                    type="button"
+                    class="h-7 px-2.5 rounded-md border border-primary/40 bg-primary/10 text-[12px] text-primary hover:bg-primary/15 disabled:opacity-60"
+                    onClick={republish}
+                    disabled={republishing() || !isTauriRuntime()}
+                    title="Publish these notes to notes.serendb.com"
+                  >
+                    {republishing() ? "Publishing…" : "Publish to Seren Notes"}
+                  </button>
+                </div>
+              </Show>
+            }
+          >
+            {(serenNotesId) => {
+              const url = `https://notes.serendb.com/notes/${serenNotesId()}`;
+              return (
+                <div class="mb-2 text-[12px] text-muted-foreground">
+                  Chat with meeting notes:{" "}
+                  <button
+                    type="button"
+                    class="text-primary hover:underline focus:outline-none focus:underline break-all"
+                    onClick={() => {
+                      void openExternalLink(url);
+                    }}
+                    title="Open this meeting on notes.serendb.com"
+                  >
+                    {url}
+                  </button>
+                </div>
+              );
+            }}
+          </Show>
+        </Show>
         <Show
           when={props.meeting.notesMarkdown}
           fallback={
@@ -465,61 +522,6 @@ export function MeetingDetail(props: MeetingDetailProps) {
               innerHTML={renderMarkdown(markdown())}
             />
           )}
-        </Show>
-        <Show when={props.meeting.notesMarkdown}>
-          <Show
-            when={props.meeting.serenNotesId}
-            fallback={
-              <Show
-                when={authStore.isAuthenticated}
-                fallback={
-                  <div class="mt-2 text-[12px] text-muted-foreground">
-                    <button
-                      type="button"
-                      class="text-primary hover:underline focus:outline-none focus:underline"
-                      onClick={() => requestSignInModal()}
-                    >
-                      Login to SerenDB to chat with your meeting notes
-                    </button>
-                  </div>
-                }
-              >
-                {/* Authenticated but no published id — the auto-publish
-                  hit a 5xx after retry, the prior session was offline, or
-                  the user signed in after notes finalized. Manual retry. */}
-                <div class="mt-2 flex items-center gap-2">
-                  <button
-                    type="button"
-                    class="h-7 px-2.5 rounded-md border border-primary/40 bg-primary/10 text-[12px] text-primary hover:bg-primary/15 disabled:opacity-60"
-                    onClick={republish}
-                    disabled={republishing() || !isTauriRuntime()}
-                    title="Publish these notes to notes.serendb.com"
-                  >
-                    {republishing() ? "Publishing…" : "Publish to Seren Notes"}
-                  </button>
-                </div>
-              </Show>
-            }
-          >
-            {(serenNotesId) => {
-              const url = `https://notes.serendb.com/notes/${serenNotesId()}`;
-              return (
-                <div class="mt-2 text-[12px] text-muted-foreground">
-                  Chat with meeting notes:{" "}
-                  <button
-                    type="button"
-                    class="text-primary hover:underline focus:outline-none focus:underline break-all"
-                    onClick={() => {
-                      void openExternalLink(url);
-                    }}
-                    title="Open this meeting on notes.serendb.com"
-                  >
-                    {url}
-                  </button>
-                </div>
-              );
-            }}
-          </Show>
         </Show>
       </section>
 


### PR DESCRIPTION
Closes #2584.

## Problem

When notes are generated from a recorded meeting, the "Chat with meeting notes" link rendered at the **bottom** of the notes body, forcing the user to scroll past the entire markdown note to reach it.

## Fix

Reorder the Notes `<section>` in `MeetingDetail.tsx` so the link/CTA `<Show>` block (the `notes.serendb.com` link, and the sign-in / "Publish to Seren Notes" fallbacks that share that slot) renders **above** the markdown body, directly under the "Notes" header. Margins flip from `mt-2` to `mb-2` so the spacing reads correctly at the top.

Presentation-only — no behavior or data changes. Conditional logic is preserved: with no markdown the body fallback ("Notes will appear here…") still shows and the link block renders nothing.

## Validation

- `tsc --noEmit` — clean
- `biome check` on the changed file — clean

No tests added: UI-only reorder, which the repo guidance excludes from TDD.

## Affected code paths

- `src/components/meeting/MeetingDetail.tsx`

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
