### PR TITLE
fix: show the correct meeting template on first render (#2587)

### DIFF
--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -382,7 +382,17 @@ export function MeetingDetail(props: MeetingDetailProps) {
           }
         >
           <For each={templates()}>
-            {(template) => <option value={template.id}>{template.name}</option>}
+            {(template) => (
+              // `selected` lives on the option so it re-applies when the async
+              // template list populates; binding only `value` on the select
+              // leaves the dropdown on option[0] until the next switch (#2587).
+              <option
+                value={template.id}
+                selected={template.id === selectedTemplate()}
+              >
+                {template.name}
+              </option>
+            )}
           </For>
         </select>
         <button


### PR DESCRIPTION
Closes #2587. Found by the post-merge functional audit of #2583.

## Problem

The meeting "Templates" dropdown displayed the wrong template — always the first option, "Sales Call" — on the first render of a meeting on the default template ("Discovery"). The displayed template diverged from what **Regenerate** actually used.

## Root cause

`MeetingDetail.tsx` bound only `value={selectedTemplate()}` on the `<select>`, but the options render from an async-loaded `templates()` list. On first render the list is empty, so the `value` effect lands on `selectedIndex = -1`; when options arrive, the HTML selectedness-reset auto-selects option[0] (`sales_call`), and the `value` effect does not re-run (its dependency didn't change). The dropdown stayed on "Sales Call" until the next meeting switch.

## Fix

Bind `selected={template.id === selectedTemplate()}` on each `<option>` inside the `<For>`. The binding re-applies whenever the option list (re)populates and whenever `selectedTemplate()` changes, so the dropdown always reflects the meeting's real template.

## Validation

- `tsc --noEmit` — clean
- `biome check` on the changed file — clean

UI-only; excluded from TDD per repo guidance. Platform-agnostic (pure JSX).

## Affected code paths

- `src/components/meeting/MeetingDetail.tsx`

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
