### PR TITLE
fix(recording): stop native recorder on exit (#2590) + fix Linux xcap build (#2592)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev libgbm-dev
       - uses: pnpm/action-setup@v5
         with:
           version: 9
@@ -229,7 +229,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev libgbm-dev
       - run: pnpm install --frozen-lockfile
       - name: Build (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev libxdo-dev patchelf libfuse2 xdg-utils
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev libxdo-dev patchelf libfuse2 xdg-utils pkg-config libclang-dev libxcb1-dev libxrandr-dev libdbus-1-dev libpipewire-0.3-dev libwayland-dev libegl-dev libgbm-dev
 
       - name: Install frontend dependencies
         run: pnpm install

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -46,14 +46,31 @@ pub struct RecordingState {
     active: Mutex<Option<ActiveRecording>>,
 }
 
+impl RecordingState {
+    /// Stop any in-progress native recording, releasing its capture process.
+    /// Called from `RunEvent::Exit` because Tauri terminates via
+    /// `std::process::exit`, which never runs `Drop` — without this an active
+    /// macOS `screencapture` child is orphaned and keeps recording the screen
+    /// after the app quits. Works through a shared reference by locking.
+    pub fn shutdown(&self) {
+        if let Ok(mut active) = self.active.lock() {
+            finalize_active_recording(active.take());
+        }
+    }
+}
+
 impl Drop for RecordingState {
     fn drop(&mut self) {
         if let Ok(active) = self.active.get_mut() {
-            if let Some(active) = active.take() {
-                clear_active_recorder_marker_for_output_dir(active.session.output_dir.as_deref());
-                discard_native_recording_backend(active.backend);
-            }
+            finalize_active_recording(active.take());
         }
+    }
+}
+
+fn finalize_active_recording(active: Option<ActiveRecording>) {
+    if let Some(active) = active {
+        clear_active_recorder_marker_for_output_dir(active.session.output_dir.as_deref());
+        discard_native_recording_backend(active.backend);
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1165,6 +1165,12 @@ pub fn run() {
                 if let Some(rt_state) = app.try_state::<provider_runtime::ProviderRuntimeState>() {
                     rt_state.kill_sync();
                 }
+                // Stop an in-progress native recorder so a screen-capture child
+                // process is not orphaned and left recording the screen after
+                // quit (Tauri exits via process::exit, which skips Drop).
+                if let Some(rec_state) = app.try_state::<commands::recording::RecordingState>() {
+                    rec_state.shutdown();
+                }
             }
             _ => {}
         });


### PR DESCRIPTION
## What

Stop an in-progress native recording when the app quits, so the macOS `screencapture` child process is not orphaned and left recording the screen.

Fixes #2590.

## Why

`RecordingState`'s only cleanup was its `Drop` impl, but Tauri's `app.run()` terminates the process via `std::process::exit`, which never runs destructors. The `RunEvent::Exit` handler already kills every other child process (MCP, terminal PTYs, provider runtime) but omitted the recorder. On macOS, a spawned `screencapture -v` child is not killed when its GUI parent exits (no controlling terminal -> no SIGHUP), so quitting mid-recording left it capturing the entire screen to disk indefinitely until the next launch's reaper SIGINTed it via the on-disk marker — a privacy issue and an unbounded resource leak.

## How

- `recording.rs`: extract the active-recording teardown into a shared `finalize_active_recording` helper, and add `RecordingState::shutdown()` that takes + finalizes the active recording through a lock (so it works from a shared `&self`, unlike `Drop`'s `&mut self`). `Drop` now delegates to the same helper.
- `lib.rs`: call `rec_state.shutdown()` in the `RunEvent::Exit` handler, alongside the existing MCP/terminal/provider-runtime cleanup.

The on-disk marker + next-launch `reap_orphaned_recordings` reaper remains as the crash/force-quit backstop; this fix makes a clean quit stop the recorder immediately.

## Testing

- `cargo check` passes.
- Reuses the already-tested `discard_native_recording_backend` teardown path (SIGINT -> wait -> kill).

Caught during the pre-release audit for v3.59.0 (recording subsystem). This was the sole CRITICAL finding across the recording Rust module, skills-publishing changes, and the frontend/extension surface.

---

## Also fixes #2592 — Linux build break

The recording feature's `xcap` dependency pulls in `libspa-sys`/PipeWire on Linux, but neither ci.yml nor release.yml installed the PipeWire/libclang system packages — so `main`'s Linux build was already red. Added `libpipewire-0.3-dev` + `libclang-dev` to the Ubuntu deps in ci.yml (test-rust + build) and release.yml. This PR's green `build` matrix (incl. Linux) is the verification.