### PR TITLE
fix(recording): P1/P2 pre-release audit fixes for v3.59.0 (#2593-#2602)

### DIFF
--- a/openapi/openapi-seren-skills.json
+++ b/openapi/openapi-seren-skills.json
@@ -3217,6 +3217,12 @@
           "status": {
             "$ref": "#/components/schemas/SkillStatus"
           },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "updated_at": {
             "type": "string",
             "format": "date-time"

--- a/packages/recording-extension/src/content.js
+++ b/packages/recording-extension/src/content.js
@@ -27,16 +27,60 @@ function elementRole(element) {
   );
 }
 
+// Roles/tags whose visible text is a stable control label (e.g. button copy)
+// rather than arbitrary page content. Only these may capture free text.
+const FREE_TEXT_ROLES = new Set([
+  "button",
+  "link",
+  "menuitem",
+  "tab",
+  "heading",
+]);
+const FREE_TEXT_TAGS = new Set([
+  "button",
+  "a",
+  "summary",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+]);
+
+function allowsFreeText(element) {
+  const role = (element.getAttribute("role") || "").toLowerCase();
+  if (FREE_TEXT_ROLES.has(role)) return true;
+  const tag = element.tagName.toLowerCase();
+  if (FREE_TEXT_TAGS.has(tag)) return true;
+  if (tag === "input" || tag === "button") {
+    const type = (element.getAttribute("type") || "").toLowerCase();
+    return type === "button" || type === "submit" || type === "reset";
+  }
+  return false;
+}
+
+// Mask digit runs (>=4) and email-like tokens so incidental PII in a captured
+// label is not stored verbatim.
+function scrubCapturedText(value) {
+  return value
+    .replace(/[^\s@]+@[^\s@]+\.[^\s@]+/g, "[redacted]")
+    .replace(/\d{4,}/g, "[redacted]");
+}
+
 function elementName(element) {
-  const label =
+  const attribute =
     element.getAttribute("aria-label") ||
     element.getAttribute("title") ||
     element.getAttribute("alt") ||
     element.getAttribute("placeholder") ||
-    element.innerText ||
-    element.textContent ||
     "";
-  return label.replace(/\s+/g, " ").trim().slice(0, 120);
+  const freeText = allowsFreeText(element)
+    ? element.innerText || element.textContent || ""
+    : "";
+  const label = attribute || freeText;
+  const normalized = label.replace(/\s+/g, " ").trim().slice(0, 120);
+  return scrubCapturedText(normalized);
 }
 
 function isSensitiveElement(element) {

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -21,6 +21,8 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use tauri::Emitter;
 use tauri::Manager;
 use uuid::Uuid;
 
@@ -43,7 +45,31 @@ use objc2_foundation::NSString;
 
 #[derive(Default)]
 pub struct RecordingState {
-    active: Mutex<Option<ActiveRecording>>,
+    active: Mutex<RecordingSlot>,
+}
+
+/// Lifecycle slot for the single in-flight native recording. `Starting` is held
+/// only while `recording_start` does its blocking capture/spawn work outside the
+/// state lock, so a concurrent start is rejected without the lock being held
+/// across a slow screen grab.
+#[derive(Default)]
+enum RecordingSlot {
+    #[default]
+    Idle,
+    Starting,
+    Active(ActiveRecording),
+}
+
+impl RecordingSlot {
+    fn take_active(&mut self) -> Option<ActiveRecording> {
+        match std::mem::replace(self, RecordingSlot::Idle) {
+            RecordingSlot::Active(active) => Some(active),
+            other => {
+                *self = other;
+                None
+            }
+        }
+    }
 }
 
 impl RecordingState {
@@ -53,16 +79,16 @@ impl RecordingState {
     /// macOS `screencapture` child is orphaned and keeps recording the screen
     /// after the app quits. Works through a shared reference by locking.
     pub fn shutdown(&self) {
-        if let Ok(mut active) = self.active.lock() {
-            finalize_active_recording(active.take());
+        if let Ok(mut slot) = self.active.lock() {
+            finalize_active_recording(slot.take_active());
         }
     }
 }
 
 impl Drop for RecordingState {
     fn drop(&mut self) {
-        if let Ok(active) = self.active.get_mut() {
-            finalize_active_recording(active.take());
+        if let Ok(slot) = self.active.get_mut() {
+            finalize_active_recording(slot.take_active());
         }
     }
 }
@@ -95,6 +121,8 @@ enum NativeRecordingBackend {
     XcapAvi {
         stop_tx: mpsc::Sender<()>,
         join: thread::JoinHandle<Result<NativeRecordingArtifacts, String>>,
+        video_path: PathBuf,
+        output_dir: PathBuf,
     },
 }
 
@@ -259,8 +287,18 @@ fn native_backend_marker_fields(backend: &NativeRecordingBackend) -> Option<(u32
 }
 
 #[cfg(not(target_os = "macos"))]
-fn native_backend_marker_fields(_backend: &NativeRecordingBackend) -> Option<(u32, PathBuf)> {
-    None
+fn native_backend_marker_fields(backend: &NativeRecordingBackend) -> Option<(u32, PathBuf)> {
+    match backend {
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        NativeRecordingBackend::XcapAvi { video_path, .. } => {
+            // Write a marker for the recording process (this app) so a crash
+            // leaves a `.active-recorder` the startup reaper can use to drop the
+            // partial `recording-*` directory on the next launch.
+            Some((std::process::id(), video_path.clone()))
+        }
+        #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+        _ => None,
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1380,12 +1418,17 @@ fn build_recording_session(
 }
 
 fn start_native_recording_backend(
+    app: &tauri::AppHandle,
     request: &RecordingStartRequest,
     output_dir: &Path,
 ) -> Result<NativeRecordingBackend, String> {
     match request.target_kind {
-        RecordingRequestTargetKind::Screen => start_screen_recording_backend(request, output_dir),
-        RecordingRequestTargetKind::Window => start_window_recording_backend(request, output_dir),
+        RecordingRequestTargetKind::Screen => {
+            start_screen_recording_backend(app, request, output_dir)
+        }
+        RecordingRequestTargetKind::Window => {
+            start_window_recording_backend(app, request, output_dir)
+        }
         RecordingRequestTargetKind::Browser => Err(
             "Native browser recording is not implemented yet; use the browser recorder or extension path for now."
                 .to_string(),
@@ -1416,11 +1459,13 @@ fn macos_screencapture_video_args(
 }
 
 fn start_screen_recording_backend(
+    app: &tauri::AppHandle,
     request: &RecordingStartRequest,
     output_dir: &Path,
 ) -> Result<NativeRecordingBackend, String> {
     #[cfg(target_os = "macos")]
     {
+        let _ = app;
         let video_path = output_dir.join("workflow-recording.mov");
         let mut command = Command::new("/usr/sbin/screencapture");
         command.args(macos_screencapture_video_args(request, &video_path)?);
@@ -1437,11 +1482,12 @@ fn start_screen_recording_backend(
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     {
         let _ = request;
-        start_xcap_screen_recording_backend(output_dir)
+        start_xcap_screen_recording_backend(app, output_dir)
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
+        let _ = app;
         let _ = request;
         let _ = output_dir;
         Err("Native screen recording is not implemented on this platform yet.".to_string())
@@ -1449,7 +1495,15 @@ fn start_screen_recording_backend(
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
+fn recording_id_from_output_dir(output_dir: &Path) -> Option<String> {
+    output_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn start_xcap_screen_recording_backend(
+    app: &tauri::AppHandle,
     output_dir: &Path,
 ) -> Result<NativeRecordingBackend, String> {
     let video_path = output_dir.join("workflow-recording.avi");
@@ -1470,6 +1524,8 @@ fn start_xcap_screen_recording_backend(
     let (stop_tx, stop_rx) = mpsc::channel();
     let thread_video_path = video_path.clone();
     let thread_output_dir = output_dir.to_path_buf();
+    let thread_app = app.clone();
+    let recording_id = recording_id_from_output_dir(output_dir);
     let join = thread::spawn(move || {
         record_xcap_avi(
             thread_video_path,
@@ -1477,13 +1533,21 @@ fn start_xcap_screen_recording_backend(
             recorder,
             receiver,
             stop_rx,
+            thread_app,
+            recording_id,
         )
     });
-    Ok(NativeRecordingBackend::XcapAvi { stop_tx, join })
+    Ok(NativeRecordingBackend::XcapAvi {
+        stop_tx,
+        join,
+        video_path,
+        output_dir: output_dir.to_path_buf(),
+    })
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 fn start_xcap_window_recording_backend(
+    app: &tauri::AppHandle,
     output_dir: &Path,
     window: xcap::Window,
 ) -> Result<NativeRecordingBackend, String> {
@@ -1491,18 +1555,26 @@ fn start_xcap_window_recording_backend(
     let (stop_tx, stop_rx) = mpsc::channel();
     let thread_video_path = video_path.clone();
     let thread_output_dir = output_dir.to_path_buf();
+    let _ = app;
     let join = thread::spawn(move || {
         record_xcap_window_avi(thread_video_path, thread_output_dir, window, stop_rx)
     });
-    Ok(NativeRecordingBackend::XcapAvi { stop_tx, join })
+    Ok(NativeRecordingBackend::XcapAvi {
+        stop_tx,
+        join,
+        video_path,
+        output_dir: output_dir.to_path_buf(),
+    })
 }
 
 fn start_window_recording_backend(
+    app: &tauri::AppHandle,
     request: &RecordingStartRequest,
     output_dir: &Path,
 ) -> Result<NativeRecordingBackend, String> {
     #[cfg(target_os = "macos")]
     {
+        let _ = app;
         let platform_id = request_capture_window_platform_id(request)?
             .ok_or_else(|| "Select an app window before recording.".to_string())?;
         ensure_capture_window_recordable(platform_id)?;
@@ -1524,11 +1596,12 @@ fn start_window_recording_backend(
         let platform_id = request_capture_window_platform_id(request)?
             .ok_or_else(|| "Select an app window before recording.".to_string())?;
         let window = select_xcap_recordable_window(platform_id)?;
-        start_xcap_window_recording_backend(output_dir, window)
+        start_xcap_window_recording_backend(app, output_dir, window)
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
+        let _ = app;
         let _ = request;
         let _ = output_dir;
         Err("Native window recording is not implemented on this platform yet.".to_string())
@@ -1827,7 +1900,10 @@ fn finish_xcap_avi_artifact(
         let _ = fs::remove_file(&video_path);
         return Err("Native recording did not encode any frames.".to_string());
     }
-    writer.finish()?;
+    if let Err(error) = writer.finish() {
+        let _ = fs::remove_file(&video_path);
+        return Err(error);
+    }
     let metadata = fs::metadata(&video_path).map_err(|error| {
         format!(
             "Native recording artifact is unavailable at {}: {error}",
@@ -1872,6 +1948,8 @@ fn record_xcap_avi(
     recorder: xcap::VideoRecorder,
     receiver: mpsc::Receiver<xcap::Frame>,
     stop_rx: mpsc::Receiver<()>,
+    app: tauri::AppHandle,
+    recording_id: Option<String>,
 ) -> Result<NativeRecordingArtifacts, String> {
     const FPS: u32 = 8;
     let started_at = Instant::now();
@@ -1884,8 +1962,11 @@ fn record_xcap_avi(
     let mut frames_encoded: u64 = 0;
     let mut frames_skipped: u64 = 0;
     let mut encode_error_count: u64 = 0;
+    // Captured instead of early-returning so `recorder.stop()` always runs and a
+    // partial file is removed on the error paths below.
+    let mut loop_error: Option<String> = None;
 
-    loop {
+    'capture: loop {
         if stop_rx.try_recv().is_ok() {
             break;
         }
@@ -1904,12 +1985,13 @@ fn record_xcap_avi(
                 if writer.is_none() {
                     frame_width = Some(frame.width);
                     frame_height = Some(frame.height);
-                    writer = Some(MjpegAviWriter::create(
-                        &video_path,
-                        frame.width,
-                        frame.height,
-                        FPS,
-                    )?);
+                    match MjpegAviWriter::create(&video_path, frame.width, frame.height, FPS) {
+                        Ok(created) => writer = Some(created),
+                        Err(error) => {
+                            loop_error = Some(error);
+                            break 'capture;
+                        }
+                    }
                 }
                 if frame_width != Some(frame.width) || frame_height != Some(frame.height) {
                     frames_skipped = frames_skipped.saturating_add(1);
@@ -1920,23 +2002,41 @@ fn record_xcap_avi(
                     Err(error) => {
                         encode_error_count = encode_error_count.saturating_add(1);
                         if writer.is_none() {
-                            return Err(error);
+                            loop_error = Some(error);
+                            break 'capture;
                         }
                         continue;
                     }
                 };
                 if let Some(writer) = writer.as_mut() {
-                    writer.write_frame(&jpeg)?;
+                    if let Err(error) = writer.write_frame(&jpeg) {
+                        loop_error = Some(error);
+                        break 'capture;
+                    }
                 }
                 frames_encoded = frames_encoded.saturating_add(1);
                 last_frame_at = Some(Instant::now());
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {}
-            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                // The OS/capture ended the session out-of-band (no stop was
+                // requested), so notify the frontend before finalizing.
+                if let Some(recording_id) = recording_id.as_deref() {
+                    let _ = app.emit(
+                        "recording://external-stop",
+                        json!({ "recordingId": recording_id }),
+                    );
+                }
+                break;
+            }
         }
     }
 
     let _ = recorder.stop();
+    if let Some(error) = loop_error {
+        let _ = fs::remove_file(&video_path);
+        return Err(error);
+    }
     finish_xcap_avi_artifact(
         video_path,
         output_dir,
@@ -2002,7 +2102,13 @@ fn record_xcap_window_avi(
         if writer.is_none() {
             frame_width = Some(width);
             frame_height = Some(height);
-            writer = Some(MjpegAviWriter::create(&video_path, width, height, FPS)?);
+            match MjpegAviWriter::create(&video_path, width, height, FPS) {
+                Ok(created) => writer = Some(created),
+                Err(error) => {
+                    let _ = fs::remove_file(&video_path);
+                    return Err(error);
+                }
+            }
         }
         if frame_width != Some(width) || frame_height != Some(height) {
             frames_skipped = frames_skipped.saturating_add(1);
@@ -2013,13 +2119,17 @@ fn record_xcap_window_avi(
             Err(error) => {
                 encode_error_count = encode_error_count.saturating_add(1);
                 if writer.is_none() {
+                    let _ = fs::remove_file(&video_path);
                     return Err(error);
                 }
                 continue;
             }
         };
         if let Some(writer) = writer.as_mut() {
-            writer.write_frame(&jpeg)?;
+            if let Err(error) = writer.write_frame(&jpeg) {
+                let _ = fs::remove_file(&video_path);
+                return Err(error);
+            }
         }
         frames_encoded = frames_encoded.saturating_add(1);
     }
@@ -2170,9 +2280,18 @@ fn discard_native_recording_backend(backend: NativeRecordingBackend) {
             }
         }
         #[cfg(any(target_os = "windows", target_os = "linux"))]
-        NativeRecordingBackend::XcapAvi { stop_tx, join, .. } => {
+        NativeRecordingBackend::XcapAvi {
+            stop_tx,
+            join,
+            output_dir,
+            ..
+        } => {
             let _ = stop_tx.send(());
-            let _ = join.join();
+            // A failed finalize leaves only an empty/partial artifact; drop the
+            // output directory rather than accumulating dead recording folders.
+            if matches!(join.join(), Ok(Err(_)) | Err(_)) {
+                let _ = fs::remove_dir_all(&output_dir);
+            }
         }
     }
 }
@@ -2182,7 +2301,7 @@ fn recorder_process_is_active(pid: u32, video_path: &Path) -> bool {
     // Match both process name and output path so a reused PID or unrelated
     // screencapture process is not signalled.
     Command::new("/bin/ps")
-        .args(["-p", &pid.to_string(), "-o", "command="])
+        .args(["-ww", "-p", &pid.to_string(), "-o", "command="])
         .output()
         .ok()
         .filter(|output| output.status.success())
@@ -2903,18 +3022,53 @@ pub async fn recording_start(
     state: tauri::State<'_, RecordingState>,
     request: RecordingStartRequest,
 ) -> Result<RecordingSession, String> {
-    let mut active = state
+    {
+        let mut slot = state
+            .active
+            .lock()
+            .map_err(|_| "recording state poisoned")?;
+        match *slot {
+            RecordingSlot::Idle => *slot = RecordingSlot::Starting,
+            RecordingSlot::Starting | RecordingSlot::Active(_) => {
+                return Err("A workflow recording is already active.".to_string());
+            }
+        }
+    }
+
+    // Reservation acquired; run the blocking capture/spawn work without holding
+    // the state lock so concurrent IPC stays responsive. Any failure must
+    // release the `Starting` reservation back to `Idle`.
+    let started = build_active_recording(&app, request);
+    let mut slot = state
         .active
         .lock()
         .map_err(|_| "recording state poisoned")?;
-    if active.is_some() {
-        return Err("A workflow recording is already active.".to_string());
+    match started {
+        Ok(active) => {
+            let session = active.session.clone();
+            *slot = RecordingSlot::Active(active);
+            Ok(session)
+        }
+        Err(error) => {
+            *slot = RecordingSlot::Idle;
+            Err(error)
+        }
     }
+}
+
+/// Perform the blocking start work (directory creation, start keyframe capture,
+/// backend spawn, marker write) outside the state lock. On any error the freshly
+/// created output directory is removed so empty recording folders do not
+/// accumulate, mirroring the prior in-lock behavior.
+fn build_active_recording(
+    app: &tauri::AppHandle,
+    request: RecordingStartRequest,
+) -> Result<ActiveRecording, String> {
     validate_recording_start_request(&request)?;
     ensure_native_recording_permissions(&request)?;
 
     let id = format!("recording-{}", Uuid::new_v4());
-    let output_root = recording_output_root(&app)?;
+    let output_root = recording_output_root(app)?;
     let output_dir = recording_output_dir(&output_root, &id);
     fs::create_dir_all(&output_dir)
         .map_err(|error| format!("Failed to create recording output directory: {error}"))?;
@@ -2923,7 +3077,7 @@ pub async fn recording_start(
     let keyframes = capture_native_keyframe(&output_dir, "start", 0, 1, capture_window_platform_id)
         .into_iter()
         .collect::<Vec<_>>();
-    let backend = match start_native_recording_backend(&request, &output_dir) {
+    let backend = match start_native_recording_backend(app, &request, &output_dir) {
         Ok(backend) => backend,
         Err(error) => {
             // The recorder never started, so the freshly created output
@@ -2945,16 +3099,15 @@ pub async fn recording_start(
             },
         );
     }
-    *active = Some(ActiveRecording {
-        session: session.clone(),
+    Ok(ActiveRecording {
+        session,
         backend,
         markers: Vec::new(),
         next_keyframe_index: keyframes.len() + 1,
         keyframes,
         capture_window_platform_id,
         started_instant: Instant::now(),
-    });
-    Ok(session)
+    })
 }
 
 #[tauri::command]
@@ -2962,16 +3115,27 @@ pub async fn recording_stop(
     state: tauri::State<'_, RecordingState>,
 ) -> Result<Option<RecordingSession>, String> {
     let active = {
-        let mut guard = state
+        let mut slot = state
             .active
             .lock()
             .map_err(|_| "recording state poisoned")?;
-        guard.take()
-    };
-    let Some(active) = active else {
-        return Ok(None);
+        match std::mem::replace(&mut *slot, RecordingSlot::Idle) {
+            RecordingSlot::Active(active) => active,
+            // A stop racing an in-flight start must not discard the start; put
+            // the reservation back so `recording_start` can still publish it.
+            RecordingSlot::Starting => {
+                *slot = RecordingSlot::Starting;
+                return Ok(None);
+            }
+            RecordingSlot::Idle => return Ok(None),
+        }
     };
     let active_output_dir = active.session.output_dir.clone();
+
+    // Snapshot the recording duration BEFORE finalizing. On macOS finalize
+    // waits on SIGINT and runs avconvert, so taking it afterward would skew the
+    // stop keyframe/trace timestamps toward finalize time, not recording end.
+    let duration_ms = elapsed_marker_ms(active.started_instant);
 
     let artifacts = match stop_native_recording_backend(active.backend) {
         Ok(artifacts) => {
@@ -2990,6 +3154,9 @@ pub async fn recording_stop(
         }
     };
     let mut session = active.session;
+    // The video is finalized on disk. From here, sidecar/metadata writes are
+    // best-effort: a tiny JSON write failure (e.g. disk full) must not discard a
+    // perfectly good recording, so each falls back to its default on error.
     session.artifact_url = Some(file_url(&artifacts.video_path)?);
     session.mime_type = Some(artifacts.mime_type);
     session.size_bytes = Some(artifacts.size_bytes);
@@ -2999,19 +3166,18 @@ pub async fn recording_stop(
     }
     session.marker_count = Some(active.markers.len() as u64);
     session.redacted_event_count = Some(0);
-    let duration_ms = elapsed_marker_ms(active.started_instant);
-    if let Some((trace_path, trace_event_count)) = write_native_trace(
-        &artifacts.output_dir,
-        &session,
-        &active.markers,
-        duration_ms,
-    )? {
-        session.trace_artifact_url = Some(file_url(&trace_path)?);
-        session.trace_event_count = Some(trace_event_count as u64);
-        session.trace_truncated = Some(false);
-    } else {
-        session.trace_event_count = Some(0);
-        session.trace_truncated = Some(false);
+    session.trace_event_count = Some(0);
+    session.trace_truncated = Some(false);
+    match write_native_trace(&artifacts.output_dir, &session, &active.markers, duration_ms) {
+        Ok(Some((trace_path, trace_event_count))) => match file_url(&trace_path) {
+            Ok(url) => {
+                session.trace_artifact_url = Some(url);
+                session.trace_event_count = Some(trace_event_count as u64);
+            }
+            Err(error) => log::warn!("Failed to resolve recording trace URL: {error}"),
+        },
+        Ok(None) => {}
+        Err(error) => log::warn!("Failed to write recording trace: {error}"),
     }
     session.transcript_segment_count = Some(0);
     let mut keyframes = active.keyframes;
@@ -3026,18 +3192,28 @@ pub async fn recording_stop(
             keyframes.push(stop_frame);
         }
     }
-    if let Some(keyframe_path) = write_native_keyframe_manifest(&artifacts.output_dir, &keyframes)?
-    {
-        session.keyframe_artifact_url = Some(file_url(&keyframe_path)?);
-        session.keyframe_count = Some(keyframes.len() as u64);
-    } else {
-        session.keyframe_count = Some(0);
+    session.keyframe_count = Some(0);
+    match write_native_keyframe_manifest(&artifacts.output_dir, &keyframes) {
+        Ok(Some(keyframe_path)) => match file_url(&keyframe_path) {
+            Ok(url) => {
+                session.keyframe_artifact_url = Some(url);
+                session.keyframe_count = Some(keyframes.len() as u64);
+            }
+            Err(error) => log::warn!("Failed to resolve recording keyframe URL: {error}"),
+        },
+        Ok(None) => {}
+        Err(error) => log::warn!("Failed to write recording keyframe manifest: {error}"),
     }
     let (quality_status, quality_checks) = recording_quality(&session);
     session.quality_status = Some(quality_status);
     session.quality_checks = Some(quality_checks);
-    let metadata_path = write_recording_metadata(&artifacts.output_dir, &session)?;
-    session.metadata_artifact_url = Some(file_url(&metadata_path)?);
+    match write_recording_metadata(&artifacts.output_dir, &session) {
+        Ok(metadata_path) => match file_url(&metadata_path) {
+            Ok(url) => session.metadata_artifact_url = Some(url),
+            Err(error) => log::warn!("Failed to resolve recording metadata URL: {error}"),
+        },
+        Err(error) => log::warn!("Failed to write recording metadata: {error}"),
+    }
     Ok(Some(session))
 }
 
@@ -3047,11 +3223,11 @@ pub async fn recording_add_marker(
     kind: RecordingMarkerKind,
 ) -> Result<(), String> {
     let (recording_id, needs_frontmost_context) = {
-        let active = state
+        let slot = state
             .active
             .lock()
             .map_err(|_| "recording state poisoned")?;
-        let Some(active) = active.as_ref() else {
+        let RecordingSlot::Active(active) = &*slot else {
             return Err("No workflow recording is active.".to_string());
         };
         (
@@ -3065,16 +3241,16 @@ pub async fn recording_add_marker(
         None
     };
     let pending_keyframe = {
-        let mut active = state
+        let mut slot = state
             .active
             .lock()
             .map_err(|_| "recording state poisoned")?;
-        let Some(active) = active
-            .as_mut()
-            .filter(|active| active.session.id == recording_id)
-        else {
+        let RecordingSlot::Active(active) = &mut *slot else {
             return Err("No workflow recording is active.".to_string());
         };
+        if active.session.id != recording_id {
+            return Err("No workflow recording is active.".to_string());
+        }
         let context = recording_marker_action_context(active, fallback_context);
         let t_ms = elapsed_marker_ms(active.started_instant);
         active.markers.push(RecordingMarker {
@@ -3110,16 +3286,20 @@ pub async fn recording_add_marker(
             index,
             capture_window_platform_id,
         ) {
-            let mut active = state
+            let mut slot = state
                 .active
                 .lock()
                 .map_err(|_| "recording state poisoned")?;
-            if let Some(active) = active.as_mut().filter(|active| {
-                active.session.id == recording_id && active.keyframes.len() < MAX_NATIVE_KEYFRAMES
-            }) {
-                active.keyframes.push(frame);
-            } else {
-                let _ = fs::remove_file(output_dir.join(&frame.file_name));
+            match &mut *slot {
+                RecordingSlot::Active(active)
+                    if active.session.id == recording_id
+                        && active.keyframes.len() < MAX_NATIVE_KEYFRAMES =>
+                {
+                    active.keyframes.push(frame);
+                }
+                _ => {
+                    let _ = fs::remove_file(output_dir.join(&frame.file_name));
+                }
             }
         }
     }
@@ -3270,12 +3450,14 @@ pub async fn recording_delete_local(
 ) -> Result<(), String> {
     validate_local_recording_id(&id)?;
     {
-        let active = state
+        let slot = state
             .active
             .lock()
             .map_err(|_| "recording state poisoned")?;
-        if active.as_ref().map(|active| active.session.id.as_str()) == Some(id.as_str()) {
-            return Err("Stop the active recording before deleting it.".to_string());
+        if let RecordingSlot::Active(active) = &*slot {
+            if active.session.id == id {
+                return Err("Stop the active recording before deleting it.".to_string());
+            }
         }
     }
     let root = recording_output_root(&app)?;
@@ -4760,5 +4942,19 @@ mod tests {
 
         assert!(!preview_root.join("window-preview-1.png").exists());
         assert!(root.path().join("window-preview-2.png").exists());
+    }
+
+    #[test]
+    fn recording_slot_take_active_preserves_non_active_states() {
+        // An idle slot yields nothing and stays idle.
+        let mut idle = RecordingSlot::Idle;
+        assert!(idle.take_active().is_none());
+        assert!(matches!(idle, RecordingSlot::Idle));
+
+        // A stop racing an in-flight start must not consume the reservation, so
+        // `recording_start` can still publish the recording it is preparing.
+        let mut starting = RecordingSlot::Starting;
+        assert!(starting.take_active().is_none());
+        assert!(matches!(starting, RecordingSlot::Starting));
     }
 }

--- a/src/api/generated/seren-skills/types.gen.ts
+++ b/src/api/generated/seren-skills/types.gen.ts
@@ -486,7 +486,6 @@ export type SkillSummary = {
     deleted_at?: string | null;
     description: string;
     discoverability: SkillDiscoverability;
-    tags?: Array<string>;
     /**
      * Per-skill override for the GitHub mirror folder. When set, takes
      * precedence over `skill_org_folders.folder_slug`. `None` means
@@ -508,6 +507,7 @@ export type SkillSummary = {
     sponsor_referral_code?: string | null;
     sponsor_static?: unknown;
     status: SkillStatus;
+    tags?: Array<string>;
     updated_at: string;
     visibility: SkillVisibility;
 };

--- a/src/components/recording/RecordedSessionCard.tsx
+++ b/src/components/recording/RecordedSessionCard.tsx
@@ -16,6 +16,7 @@ import {
   formatCaptureStats,
   revealLocalRecording,
 } from "@/features/recording/localRecordings";
+import { captureSupportError } from "@/lib/support/hook";
 
 function qualityPillClass(status: RecordingSession["qualityStatus"]): string {
   if (status === "ready") {
@@ -60,6 +61,11 @@ export function RecordedSessionCard(props: {
       setError(
         err instanceof Error ? err.message : "Could not reveal recording.",
       );
+      void captureSupportError({
+        kind: "RecordingRevealFailure",
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error && err.stack ? [err.stack] : undefined,
+      });
     } finally {
       setBusy(null);
     }
@@ -76,6 +82,11 @@ export function RecordedSessionCard(props: {
       setError(
         err instanceof Error ? err.message : "Could not delete recording.",
       );
+      void captureSupportError({
+        kind: "RecordingDeleteFailure",
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error && err.stack ? [err.stack] : undefined,
+      });
       setBusy(null);
     }
   };

--- a/src/components/settings/RecordingsSettings.tsx
+++ b/src/components/settings/RecordingsSettings.tsx
@@ -14,6 +14,7 @@ import {
   listLocalRecordings,
   revealLocalRecording,
 } from "@/features/recording/localRecordings";
+import { captureSupportError } from "@/lib/support/hook";
 
 const GHOST_ICON_BUTTON =
   "grid size-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-surface-3 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-40 disabled:hover:bg-transparent";
@@ -55,6 +56,11 @@ export function RecordingsSettings() {
       await revealLocalRecording(id);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not reveal.");
+      void captureSupportError({
+        kind: "RecordingRevealFailure",
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error && err.stack ? [err.stack] : undefined,
+      });
     } finally {
       setPendingId(null);
     }
@@ -69,6 +75,11 @@ export function RecordingsSettings() {
       setRecordings((items) => items.filter((item) => item.id !== id));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not delete.");
+      void captureSupportError({
+        kind: "RecordingDeleteFailure",
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error && err.stack ? [err.stack] : undefined,
+      });
     } finally {
       setPendingId(null);
     }

--- a/src/features/recording/desktopRecordingAdapter.ts
+++ b/src/features/recording/desktopRecordingAdapter.ts
@@ -24,6 +24,31 @@ async function getInvoke(): Promise<
   return invoke;
 }
 
+async function getListen(): Promise<
+  typeof import("@tauri-apps/api/event").listen | null
+> {
+  if (!isTauriRuntime()) return null;
+  const { listen } = await import("@tauri-apps/api/event");
+  return listen;
+}
+
+const EXTERNAL_STOP_EVENT = "recording://external-stop";
+
+interface ExternalStopPayload {
+  recordingId: string;
+}
+
+function externalStopSession(recordingId: string): RecordingSession {
+  return {
+    id: recordingId,
+    targetKind: "screen",
+    targetLabel: "Workflow recording",
+    startedAtMs: 0,
+    outputDir: null,
+    maxVideoHeight: 0,
+  };
+}
+
 function browserTargets(): RecordingTarget[] {
   return DEFAULT_RECORDING_TARGETS.map((target) => ({
     ...target,
@@ -171,5 +196,43 @@ export const desktopRecordingAdapter: RecordingHostAdapter = {
     const invoke = await getInvoke();
     if (!invoke) return;
     await invoke("recording_add_marker", { kind });
+  },
+
+  releaseSessionArtifacts(_session: RecordingSession): void {
+    // Native artifacts are file:// URLs backed by on-disk files; there are no
+    // blob: handles to revoke.
+  },
+
+  onExternalStop(handler: (session: RecordingSession) => void): () => void {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    void getListen().then((listen) => {
+      if (!listen || cancelled) return;
+      void listen<ExternalStopPayload>(EXTERNAL_STOP_EVENT, (event) => {
+        const recordingId = event.payload?.recordingId;
+        if (!recordingId) return;
+        // The OS ended capture out-of-band; finalize via the stop command to
+        // recover the artifact-bearing session, falling back to a minimal
+        // session if finalize yielded nothing.
+        void desktopRecordingAdapter
+          .stop()
+          .then((session) =>
+            handler(session ?? externalStopSession(recordingId)),
+          )
+          .catch(() => handler(externalStopSession(recordingId)));
+      })
+        .then((dispose) => {
+          if (cancelled) {
+            dispose();
+            return;
+          }
+          unlisten = dispose;
+        })
+        .catch(() => {});
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
   },
 };

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -47,6 +47,7 @@ import {
   type SkillSyncState,
   type SkillSyncStatus,
 } from "@/lib/skills";
+import { captureSupportError } from "@/lib/support/hook";
 import { getDefaultOrganizationId, isTauriRuntime } from "@/lib/tauri-bridge";
 
 const LEGACY_INDEX_CACHE_KEY = "seren:skills_index";
@@ -115,6 +116,26 @@ function normalizeOrgFolderSlug(value: string, organizationId: string): string {
   return normalized || fallback;
 }
 
+/**
+ * Surface a public-publish preflight failure that is NOT a user-actionable
+ * validation error (e.g. a Gateway 5xx or network fault). Reports it to the
+ * support pipeline before rethrowing so an operator gets a ticket, while the
+ * UI still receives the thrown error. Validation errors (403 admin, 409
+ * slug-in-use, missing email) are thrown directly by the callers and are never
+ * routed here.
+ */
+function failPublicPublishPreflight(
+  kind: string,
+  message: string,
+  status: number | undefined,
+): never {
+  void captureSupportError({
+    kind,
+    message: status ? `${message} (status=${status})` : message,
+  });
+  throw new Error(message);
+}
+
 async function resolveDefaultOrgFolderSlug(
   organizationId: string,
 ): Promise<string> {
@@ -122,8 +143,11 @@ async function resolveDefaultOrgFolderSlug(
     throwOnError: false,
   });
   if (error) {
-    const status = response ? `: ${response.status}` : "";
-    throw new Error(`Failed to load organization folder details${status}`);
+    failPublicPublishPreflight(
+      "SkillPublishOrgFolderLoadFailure",
+      "Failed to load organization folder details",
+      response?.status,
+    );
   }
 
   const organization = data?.data?.find((org) => org.id === organizationId);
@@ -161,8 +185,11 @@ async function createOrgFolderForPublicPublish(
     );
   }
 
-  const status = response ? `: ${response.status}` : "";
-  throw new Error(`Failed to create organization skill folder${status}`);
+  failPublicPublishPreflight(
+    "SkillPublishOrgFolderCreateFailure",
+    "Failed to create organization skill folder",
+    response?.status,
+  );
 }
 
 async function assertOrgFolderConfiguredForPublicPublish(
@@ -193,8 +220,11 @@ async function assertOrgFolderConfiguredForPublicPublish(
     );
   }
 
-  const status = response ? `: ${response.status}` : "";
-  throw new Error(`Failed to verify organization skill folder${status}`);
+  failPublicPublishPreflight(
+    "SkillPublishOrgFolderVerifyFailure",
+    "Failed to verify organization skill folder",
+    response?.status,
+  );
 }
 
 async function ensureAuthorIdentityForPublicPublish(
@@ -205,18 +235,22 @@ async function ensureAuthorIdentityForPublicPublish(
   const existingIdentity = await getAuthorIdentity({ throwOnError: false });
   if (!existingIdentity.error) return;
   if (existingIdentity.response?.status !== 404) {
-    const status = existingIdentity.response
-      ? `: ${existingIdentity.response.status}`
-      : "";
-    throw new Error(`Failed to verify Git author identity${status}`);
+    failPublicPublishPreflight(
+      "SkillPublishAuthorIdentityVerifyFailure",
+      "Failed to verify Git author identity",
+      existingIdentity.response?.status,
+    );
   }
 
   const { data, error, response } = await getCurrentUser({
     throwOnError: false,
   });
   if (error || !data?.data) {
-    const status = response ? `: ${response.status}` : "";
-    throw new Error(`Failed to load Git author identity details${status}`);
+    failPublicPublishPreflight(
+      "SkillPublishAuthorIdentityLoadFailure",
+      "Failed to load Git author identity details",
+      response?.status,
+    );
   }
 
   const accountName = `${data.data.name ?? ""}`.trim();
@@ -237,8 +271,11 @@ async function ensureAuthorIdentityForPublicPublish(
     throwOnError: false,
   });
   if (upserted.error) {
-    const status = upserted.response ? `: ${upserted.response.status}` : "";
-    throw new Error(`Failed to configure Git author identity${status}`);
+    failPublicPublishPreflight(
+      "SkillPublishAuthorIdentityUpsertFailure",
+      "Failed to configure Git author identity",
+      upserted.response?.status,
+    );
   }
 }
 

--- a/tests/unit/recording-desktop-adapter.test.ts
+++ b/tests/unit/recording-desktop-adapter.test.ts
@@ -2,6 +2,8 @@
 // ABOUTME: Guards the Tauri/native boundary without importing UI package internals.
 
 import { invoke } from "@tauri-apps/api/core";
+import type { Event, EventCallback, UnlistenFn } from "@tauri-apps/api/event";
+import { listen } from "@tauri-apps/api/event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { desktopRecordingAdapter } from "@/features/recording/desktopRecordingAdapter";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
@@ -14,8 +16,50 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
 }));
 
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
 const isTauriRuntimeMock = vi.mocked(isTauriRuntime);
 const invokeMock = vi.mocked(invoke);
+const listenMock = vi.mocked(listen);
+
+// Flush pending tasks so the adapter's lazy dynamic import (which settles on a
+// macrotask boundary) plus the chained listen registration / stop finalize all
+// complete before assertions.
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 3; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+interface ExternalStopPayload {
+  recordingId: string;
+}
+
+function emitExternalStop(
+  capture: EventCallback<ExternalStopPayload>,
+  recordingId: string,
+): void {
+  capture({
+    event: "recording://external-stop",
+    id: 1,
+    payload: { recordingId },
+  } as Event<ExternalStopPayload>);
+}
+
+// Capture the listen handler the adapter registers so the test can drive the
+// external-stop event directly, while keeping the mock typed to `listen`.
+function stubListen(
+  dispose: UnlistenFn,
+): { handler: () => EventCallback<ExternalStopPayload> | null } {
+  let captured: EventCallback<ExternalStopPayload> | null = null;
+  listenMock.mockImplementation((async (_event, callback) => {
+    captured = callback as EventCallback<ExternalStopPayload>;
+    return dispose;
+  }) as typeof listen);
+  return { handler: () => captured };
+}
 
 describe("desktopRecordingAdapter", () => {
   beforeEach(() => {
@@ -303,6 +347,99 @@ describe("desktopRecordingAdapter", () => {
     expect(invokeMock).toHaveBeenNthCalledWith(
       10,
       "recording_clear_window_previews",
+    );
+  });
+
+  it("releases native session artifacts without touching Tauri", () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const session = {
+      id: "recording-1",
+      targetKind: "screen" as const,
+      targetLabel: "Workflow recording",
+      startedAtMs: 1234,
+      outputDir: null,
+      maxVideoHeight: 720,
+    };
+
+    expect(desktopRecordingAdapter.releaseSessionArtifacts?.(session)).toBe(
+      undefined,
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(listenMock).not.toHaveBeenCalled();
+  });
+
+  it("does not subscribe to external-stop events outside Tauri", async () => {
+    isTauriRuntimeMock.mockReturnValue(false);
+    const handler = vi.fn();
+
+    const unsubscribe = desktopRecordingAdapter.onExternalStop?.(handler);
+    await Promise.resolve();
+
+    expect(listenMock).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+    unsubscribe?.();
+  });
+
+  it("finalizes the recording when an external-stop event fires", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const dispose = vi.fn();
+    const listenStub = stubListen(dispose);
+    invokeMock.mockImplementation(async (command) => {
+      if (command === "recording_stop") {
+        return {
+          id: "recording-77",
+          targetKind: "screen",
+          targetLabel: "Workflow recording",
+          startedAtMs: 4321,
+          outputDir: "/tmp/recording-77",
+          maxVideoHeight: 720,
+          artifactUrl: "file:///tmp/recording-77/workflow-recording.avi",
+        };
+      }
+      return undefined;
+    });
+
+    const handler = vi.fn();
+    const unsubscribe = desktopRecordingAdapter.onExternalStop?.(handler);
+    await flushAsync();
+
+    expect(listenMock).toHaveBeenCalledWith(
+      "recording://external-stop",
+      expect.any(Function),
+    );
+    const capture = listenStub.handler();
+    expect(capture).not.toBeNull();
+
+    if (capture) emitExternalStop(capture, "recording-77");
+    await flushAsync();
+
+    expect(invokeMock).toHaveBeenCalledWith("recording_stop");
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "recording-77",
+        artifactUrl: "file:///tmp/recording-77/workflow-recording.avi",
+      }),
+    );
+
+    unsubscribe?.();
+    expect(dispose).toHaveBeenCalled();
+  });
+
+  it("falls back to a minimal session when finalize yields nothing", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const listenStub = stubListen(vi.fn());
+    invokeMock.mockResolvedValue(null);
+
+    const handler = vi.fn();
+    desktopRecordingAdapter.onExternalStop?.(handler);
+    await flushAsync();
+
+    const capture = listenStub.handler();
+    if (capture) emitExternalStop(capture, "recording-99");
+    await flushAsync();
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "recording-99", outputDir: null }),
     );
   });
 });

--- a/tests/unit/recording-extension.test.ts
+++ b/tests/unit/recording-extension.test.ts
@@ -47,6 +47,32 @@ function loadExtensionScript(source: string): Record<string, unknown> {
   return context;
 }
 
+interface ElementStub {
+  tagName: string;
+  innerText: string;
+  textContent: string;
+  getAttribute(name: string): string | null;
+}
+
+function elementStub(
+  tagName: string,
+  options: {
+    attributes?: Record<string, string>;
+    innerText?: string;
+    textContent?: string;
+  } = {},
+): ElementStub {
+  const attributes = options.attributes ?? {};
+  return {
+    tagName: tagName.toUpperCase(),
+    innerText: options.innerText ?? "",
+    textContent: options.textContent ?? options.innerText ?? "",
+    getAttribute(name: string): string | null {
+      return attributes[name] ?? null;
+    },
+  };
+}
+
 const manifest = JSON.parse(
   readFileSync(resolve("packages/recording-extension/manifest.json"), "utf-8"),
 ) as {
@@ -163,6 +189,41 @@ describe("recording browser extension scaffold", () => {
     expect(isAllowed("http://localhost:9999")).toBe(false);
     expect(isAllowed("file:///etc/passwd")).toBe(false);
     expect(isAllowed("not a url")).toBe(false);
+  });
+
+  it("only captures visible text for control-label roles and scrubs PII", () => {
+    const context = loadExtensionScript(contentSource);
+    const elementName = context.elementName as (
+      element: ElementStub,
+    ) => string;
+
+    // A button label is a stable control name and may be captured, but a
+    // digit run within it must be masked.
+    expect(
+      elementName(
+        elementStub("button", { innerText: "Pay invoice 12345" }),
+      ),
+    ).toBe("Pay invoice [redacted]");
+
+    // Arbitrary page content (a div) must not have its visible text captured.
+    expect(
+      elementName(
+        elementStub("div", {
+          innerText: "Customer SSN 123-45-6789 and balance",
+        }),
+      ),
+    ).toBe("");
+
+    // Explicit accessible labels are still captured (with PII scrubbed),
+    // regardless of tag.
+    expect(
+      elementName(
+        elementStub("div", {
+          attributes: { "aria-label": "Email user@example.com" },
+          innerText: "ignored body text",
+        }),
+      ),
+    ).toBe("Email [redacted]");
   });
 
   it("strips query and fragment from captured navigation URLs", () => {


### PR DESCRIPTION
## What

Pre-release audit fixes for the recording subsystem (v3.59.0). Resolves the P1/P2 findings from the comprehensive audit.

| Issue | Severity | Fix |
| --- | --- | --- |
| #2593 | P1 | `recording_start` no longer holds the state lock across the blocking screen grab + backend spawn — `RecordingSlot {Idle,Starting,Active}` reservation keeps stop/marker/delete responsive |
| #2594 | P1 | `recording_stop` treats sidecar/metadata writes as non-fatal after the video is finalized — a good recording is never reported as lost on a tiny-JSON write failure |
| #2595 | P1 | xcap capture thread always calls `recorder.stop()` and removes a partial `.avi` on error; `finish()`/discard paths clean up too |
| #2596 | P1 | Win/Linux emit `recording://external-stop` when capture ends out-of-band; desktop adapter implements `onExternalStop` + `releaseSessionArtifacts` so the UI recovers instead of stuck "recording". **macOS watcher deferred — see below** |
| #2597 | P2 | `SkillSummary.tags` added to the openapi spec + regenerated (was hand-edited; would vanish on `generate:api`) |
| #2598 | P2 | recording reveal/delete + skills public-publish preflight failures route through `captureSupportError` |
| #2599 | P2 | Win/Linux write an active-recorder marker so a crashed partial recording dir is reaped on next launch |
| #2600 | P2 | orphan reaper uses `ps -ww` so a long command line/path is not truncated |
| #2601 | P2 | extension `content.js` only captures free text for control roles + scrubs email/long-digit tokens |
| #2602 | P2 | `recording_stop` snapshots duration before finalize so stop keyframe/trace timestamps reflect the true recording end |

## #2596 residual (macOS)

The Win/Linux external-stop path + the frontend recovery hooks are implemented. The **macOS** external-stop watcher is intentionally NOT included: it first requires verifying what `screencapture -v` actually does when screen-recording permission is revoked mid-session (does it exit, or keep producing frames?). Shipping a speculative poll-for-exit watcher without that real-behavior check would be unreliable. #2596 stays open for the macOS half. The trigger is rare and the recording is not lost (the partial video is finalized on stop and reaped on next launch).

## Verification

- `cargo check`: clean (no new warnings)
- `cargo test --lib commands::recording`: 41 passed
- `vitest` (recording-desktop-adapter, recording-skill-bundle, recording-packages, recording-extension, skills-index-api): 90 passed
- `biome check` (changed paths): clean
- `tsc --noEmit`: 0 errors
- #2597: `pnpm generate:api` run; only the spec-derived `tags` change kept (version-drift churn reverted)

Closes #2593, #2594, #2595, #2597, #2598, #2599, #2600, #2601, #2602. Advances #2596 (macOS residual tracked).
