### PR TITLE
ci(release): build x86_64 Linux on ubuntu-24.04 for xcap PipeWire

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,9 @@ jobs:
             target: x86_64-pc-windows-msvc
             name: Windows-x64
             updater_platform: windows-x86_64
-          - os: ubuntu-22.04
+          # 24.04 ships the newer PipeWire that xcap's libspa 0.9.2 needs
+          # (spa_video_info_raw.flags); 22.04's headers are too old to compile.
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             name: Linux-x64
             updater_platform: linux-x86_64


### PR DESCRIPTION
release.yml built x86_64 Linux on `ubuntu-22.04`, whose PipeWire headers are too old for xcap's `libspa 0.9.2` (`spa_video_info_raw` has no field `flags`), failing the v3.59.0 release build. aarch64 already builds on `ubuntu-24.04` and passed. Move x86_64 to `ubuntu-24.04` too.

Trade-off: the x86_64 `.deb`/`.AppImage` now requires glibc 2.39+ (built on 24.04), dropping support for older distros — consistent with the aarch64 build, which already uses 24.04. Found during the v3.59.0 release loop; release.yml is only exercised by a tag, so the re-tag is the validation.