### PR TITLE
fix(meeting): surface + log transcription backend failures instead of silent "Transcript gap" (#2606)

### DIFF
--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -18,7 +18,7 @@ use crate::audio::apm::{ApmDiagnostics, MeetingAudioProcessor};
 use crate::audio::capture::{AudioCaptureSource, CaptureError, PcmFrame, TARGET_SAMPLE_RATE};
 use crate::audio::chunker::{Chunk, ChunkCfg, StreamingChunker};
 use crate::audio::transcribe::{
-    ChunkTranscriber, GatewayTranscriber, RetryConfig, TranscriptionMode,
+    ChunkTranscriber, GatewayTranscriber, RetryConfig, TranscribeError, TranscriptionMode,
     transcribe_chunk_with_retry,
 };
 use crate::audio::types::{SegmentStatus, Speaker, SpeakerSource, TranscriptSegment};
@@ -58,6 +58,12 @@ pub struct CaptureStopSummary {
     pub chunk_count: u64,
     pub emitted_segment_count: u64,
     pub emitted_gap_count: u64,
+    /// The most recent transport-level transcription failure (e.g. an upstream
+    /// `429 insufficient_quota`) seen during the capture, if any. `None` when no
+    /// chunk hit a backend error — an empty transcript was genuine silence, not
+    /// a service outage. Lets the stop path name the real cause instead of a
+    /// generic "no words transcribed" guess.
+    pub transcription_error: Option<String>,
     pub apm: ApmDiagnostics,
 }
 
@@ -77,6 +83,8 @@ pub struct CaptureStreamStats {
     chunk_count: AtomicU64,
     emitted_segment_count: AtomicU64,
     emitted_gap_count: AtomicU64,
+    transport_failure_count: AtomicU64,
+    last_transport_error: StdMutex<Option<String>>,
 }
 
 #[derive(Default)]
@@ -124,6 +132,25 @@ impl CaptureStreamStats {
         self.emitted_gap_count.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Record a chunk's transcription failure. Only transport-level errors
+    /// (network/auth/quota/5xx) are kept as the surfaced cause; a terminal
+    /// `Empty` is genuine silence, not a service outage, so it stays a plain
+    /// gap. The first transport failure of a capture logs once at WARN; the
+    /// rest update the stored cause without spamming the log (a sustained
+    /// outage can fail every chunk).
+    fn record_transcription_failure(&self, err: &TranscribeError) {
+        let TranscribeError::Transport(detail) = err else {
+            return;
+        };
+        let first = self.transport_failure_count.fetch_add(1, Ordering::Relaxed) == 0;
+        *self.last_transport_error.lock().unwrap() = Some(detail.clone());
+        if first {
+            log::warn!(
+                "[meeting] transcription transport error (further errors this capture are counted but not re-logged): {detail}"
+            );
+        }
+    }
+
     fn summary(
         &self,
         had_capture: bool,
@@ -152,6 +179,7 @@ impl CaptureStreamStats {
             chunk_count: self.chunk_count.load(Ordering::Relaxed),
             emitted_segment_count: self.emitted_segment_count.load(Ordering::Relaxed),
             emitted_gap_count: self.emitted_gap_count.load(Ordering::Relaxed),
+            transcription_error: self.last_transport_error.lock().unwrap().clone(),
             apm,
         }
     }
@@ -281,9 +309,12 @@ async fn emit_segment(
                 stats.record_ok_segment();
             }
         }
-        Err(_) => {
+        Err(err) => {
             // A failed window becomes a single Gap spanning the chunk so audio is
-            // never silently dropped.
+            // never silently dropped. Record the cause so a backend outage
+            // (quota/auth/5xx) surfaces in the stop summary instead of looking
+            // like silence.
+            stats.record_transcription_failure(&err);
             let segment = TranscriptSegment {
                 id: Uuid::new_v4().to_string(),
                 meeting_id: meeting_id.to_string(),
@@ -1013,7 +1044,7 @@ impl CaptureRegistry {
             apm,
         );
         log::info!(
-            "[meeting] capture stop summary for {meeting_id}: native_mic_ready={} system_audio_ready={} apm_ready={} mic_source_frames={} system_source_frames={} push_frames={} accepted_push_frames={} dropped_push_frames={} dropped_push_samples={} frames={} speech_frames={} chunks={} emitted_segments={} emitted_gaps={}",
+            "[meeting] capture stop summary for {meeting_id}: native_mic_ready={} system_audio_ready={} apm_ready={} mic_source_frames={} system_source_frames={} push_frames={} accepted_push_frames={} dropped_push_frames={} dropped_push_samples={} frames={} speech_frames={} chunks={} emitted_segments={} emitted_gaps={} transcription_error={:?}",
             summary.native_mic_ready,
             summary.system_audio_ready,
             summary.apm_ready,
@@ -1027,7 +1058,8 @@ impl CaptureRegistry {
             summary.speech_frame_count,
             summary.chunk_count,
             summary.emitted_segment_count,
-            summary.emitted_gap_count
+            summary.emitted_gap_count,
+            summary.transcription_error
         );
         // The workers have flushed: take the buffered Them PCM out of the capture
         // (before it drops) and hand it to the post-call diarization pass. Done
@@ -1248,6 +1280,43 @@ mod tests {
         assert_eq!(summary.chunk_count, 1);
         assert_eq!(summary.emitted_segment_count, 1);
         assert_eq!(summary.emitted_gap_count, 1);
+        // Empty is genuine silence, not a service outage: no surfaced cause.
+        assert_eq!(summary.transcription_error, None);
+    }
+
+    #[test]
+    fn transport_failure_surfaces_in_summary_but_empty_does_not() {
+        // #2606: a terminal Empty stays a plain gap (real silence), but a
+        // transport failure (quota/auth/5xx) is the actionable cause and must
+        // surface so the stop path can name it instead of blaming the user.
+        let stats = CaptureStreamStats::default();
+
+        stats.record_transcription_failure(&TranscribeError::Empty);
+        let summary = stats.summary(
+            true,
+            CaptureIngressSummary::default(),
+            &CaptureSourceStats::default(),
+            true,
+            false,
+            ApmDiagnostics::default(),
+        );
+        assert_eq!(summary.transcription_error, None);
+
+        stats.record_transcription_failure(&TranscribeError::Transport(
+            "whisper upstream 429: insufficient_quota".to_string(),
+        ));
+        let summary = stats.summary(
+            true,
+            CaptureIngressSummary::default(),
+            &CaptureSourceStats::default(),
+            true,
+            false,
+            ApmDiagnostics::default(),
+        );
+        assert_eq!(
+            summary.transcription_error.as_deref(),
+            Some("whisper upstream 429: insufficient_quota")
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -614,6 +614,7 @@ pub async fn stop_meeting_capture(
         apm: summary.apm.clone(),
         capture_diagnostics_json: capture_diagnostics_json.clone(),
         failure_reason: failure_reason.clone(),
+        transcription_error: summary.transcription_error.clone(),
     };
     if preserve_existing_failure {
         return Ok(outcome);
@@ -730,6 +731,10 @@ pub struct StopMeetingCaptureOutcome {
     pub apm: crate::audio::apm::ApmDiagnostics,
     pub capture_diagnostics_json: String,
     pub failure_reason: Option<String>,
+    /// The most recent transport-level transcription failure (quota/auth/5xx),
+    /// if any. Present only on a genuine backend outage; the frontend opens a
+    /// support ticket when it is set, and never for benign empty captures.
+    pub transcription_error: Option<String>,
 }
 
 fn capture_start_diagnostics_json(started: bool, error: Option<&str>) -> String {
@@ -778,6 +783,7 @@ fn capture_stop_diagnostics_json(
         "persistedSegmentCount": persisted_segment_count,
         "persistedTextSegmentCount": persisted_text_segment_count,
         "failureReason": failure_reason,
+        "transcriptionError": summary.transcription_error,
         "apm": summary.apm,
         "updatedAt": now_ms(),
     })
@@ -833,6 +839,11 @@ fn stop_capture_failure_reason(
             "Audio reached Meeting capture, but it was too short or quiet to transcribe. Speak for a few seconds, then start capture again."
                 .to_string(),
         );
+    }
+    if let Some(cause) = summary.transcription_error.as_deref() {
+        return Some(format!(
+            "Audio reached transcription, but the speech-to-text service kept returning an error ({cause}). This is a service-side problem, not your audio. Try again once the service recovers."
+        ));
     }
     if persisted_segment_count == 0 {
         return Some(
@@ -1797,6 +1808,32 @@ mod tests {
         };
 
         assert_eq!(stop_capture_failure_reason(&summary, 1, 1), None);
+    }
+
+    #[test]
+    fn stop_capture_failure_reason_names_backend_transcription_error() {
+        // Every chunk failed transcription (the #2606 quota outage): chunks were
+        // produced but no text persisted, and a transport error was recorded.
+        // The reason must name the service cause, not blame the user's audio.
+        let summary = crate::audio::pipeline::CaptureStopSummary {
+            had_capture: true,
+            frame_count: 18_207,
+            sample_count: 18_207 * 320,
+            speech_frame_count: 4_336,
+            chunk_count: 44,
+            emitted_segment_count: 44,
+            emitted_gap_count: 44,
+            transcription_error: Some(
+                "transcription transport failed: whisper upstream 429: insufficient_quota"
+                    .to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let reason = stop_capture_failure_reason(&summary, 0, 0).unwrap();
+
+        assert!(reason.contains("service-side problem"));
+        assert!(reason.contains("insufficient_quota"));
     }
 
     #[test]

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -225,6 +225,9 @@ export interface CaptureStopOutcome {
   };
   captureDiagnosticsJson: string;
   failureReason?: string | null;
+  // Set only when a transport-level transcription failure (quota/auth/5xx) was
+  // seen during capture. Drives the support ticket; absent for benign silence.
+  transcriptionError?: string | null;
 }
 
 export function stopMeetingCapture(

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -605,6 +605,22 @@ async function stopAndProcess(meeting: Meeting): Promise<void> {
         meetingId: meeting.id,
         outcome: stopOutcome,
       });
+      // A transport-level transcription failure (quota/auth/5xx) is a
+      // service-side outage, not a benign empty capture — route it through the
+      // support pipeline so a serenorg/seren-desktop ticket opens. console.error
+      // is local-only (per `feedback_support_pipeline.md`); only a real backend
+      // error reaches here, never plain silence. #2606.
+      if (stopOutcome.transcriptionError) {
+        void captureSupportError({
+          kind: "meeting_transcription_failed",
+          message: `meeting transcription backend failed for ${meeting.id}: ${stopOutcome.transcriptionError}`,
+          http: {
+            method: "POST",
+            url: "https://api.serendb.com/publishers/seren-whisper/audio/transcriptions",
+            body: stopOutcome.transcriptionError,
+          },
+        });
+      }
       await failMeeting(meeting.id, stopOutcome.failureReason, null);
       return;
     }


### PR DESCRIPTION
Closes #2606.

## What

When the meeting-transcription backend (`seren-whisper` → OpenAI) fails for **every** chunk, Seren Desktop rendered an endless wall of **"Transcript gap"** with **no logged cause, a misleading failure reason, and no support ticket**. A recoverable backend outage (quota / auth / capacity / 5xx) became a silent, undiagnosable, data-losing experience.

This was the real story behind the 2026-06-23 "headset → nothing recorded" report: capture was healthy the whole time; transcription returned `429 insufficient_quota` for 100% of chunks because the upstream OpenAI account behind `seren-whisper` was out of quota. The desktop gave zero signal about why. (Root incident resolved by rotating the publisher key; this PR fixes the desktop-side observability/UX defect that made it invisible.)

## Evidence

`SerenDesktop.log` stop summaries showed a clean before/after — `emitted_segments == chunks == emitted_gaps` (every chunk → one Gap = transcription `Err`):

| Time (Jun 2026) | chunks | segments | gaps | verdict |
|---|---|---|---|---|
| 21 14:54 | 1314 | 1387 | 3 | ✅ working |
| 23 00:50 | 1385 | 2423 | 153 | ✅ working |
| 23 18:43 | 1210 | 1210 | **1210** | ❌ 100% gap |
| 23 20:31 | 44 | 44 | **44** | ❌ 100% gap |

Capture was healthy in every one of those summaries (`mic_source_frames`, `system_source_frames`, `speech_frames`, `chunks` all non-zero). The failure was 100% in transcription. Live probe of the exact code path returned `429 insufficient_quota` for both `whisper-1` (Me) and `gpt-4o-transcribe-diarize` (Them).

## Changes

- **`pipeline.rs`** — `emit_segment` now binds the `TranscribeError` and records it via `CaptureStreamStats::record_transcription_failure`. Only `Transport` (network/auth/quota/5xx) is kept as the surfaced cause; a terminal `Empty` stays a benign gap (genuine silence). One `WARN` on the first transport failure per capture — no 1210-line spam. The cause flows into `CaptureStopSummary.transcription_error` and the `capture stop summary` log line.
- **`commands/audio.rs`** — `StopMeetingCaptureOutcome.transcription_error` + capture diagnostics JSON. `stop_capture_failure_reason` names the real service cause ("…the speech-to-text service kept returning an error (…). This is a service-side problem, not your audio.") when chunks were produced but no text persisted.
- **`services/meetings.ts` / `meeting.store.ts`** — surfaces `transcriptionError`; opens a `captureSupportError` ticket on a backend transcription failure (gated on a real `Transport` cause — never for benign empty/silent captures).

## Tests (critical only)

- `pipeline.rs::transport_failure_surfaces_in_summary_but_empty_does_not` — `Transport` surfaces in the summary; `Empty` does not.
- `commands/audio.rs::stop_capture_failure_reason_names_backend_transcription_error` — the stop reason names the backend cause instead of "check input levels".
- Existing `pipeline_marks_failed_windows_as_gaps` extended to assert `Empty` does not surface.

## Verification

- `cargo check` ✅ (only pre-existing dead-code warnings)
- `cargo test` audio modules ✅ — 13 pipeline + 6 failure-reason, 0 failed
- `biome check` ✅ on changed TS
- `tsc --noEmit` ✅ (exit 0)

## Scope

Platform-agnostic (shared pipeline) — macOS and Windows benefit identically. The upstream OpenAI quota itself is ops/billing, out of scope here.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
