### PR TITLE
fix(recording): move screen recorder to titlebar + video icon (#2609)

### DIFF
--- a/packages/recording-ui/src/index.tsx
+++ b/packages/recording-ui/src/index.tsx
@@ -90,10 +90,15 @@ function RecordIcon() {
       width="16"
       height="16"
       viewBox="0 0 16 16"
-      fill="currentColor"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.4"
+      stroke-linecap="round"
+      stroke-linejoin="round"
       aria-hidden="true"
     >
-      <circle cx="8" cy="8" r="5" />
+      <rect x="1.75" y="4.25" width="8.5" height="7.5" rx="1.75" />
+      <path d="M10.25 7 14 5v6l-3.75-2z" />
     </svg>
   );
 }

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -2,7 +2,6 @@
 // ABOUTME: Handles agent session lifecycle and message streaming.
 
 import type { RecordingSession } from "@seren/recording-core";
-import { RecordButton } from "@seren/recording-ui";
 import { confirm } from "@tauri-apps/plugin-dialog";
 import type { Component } from "solid-js";
 import {
@@ -22,7 +21,6 @@ import { DiffProposalDialog } from "@/components/agent/DiffProposalDialog";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { RecordedSessionCard } from "@/components/recording/RecordedSessionCard";
-import { desktopRecordingAdapter } from "@/features/recording/desktopRecordingAdapter";
 import { appendRecordingSkillDraftPrompt } from "@/features/recording/recordingComposer";
 import { extractAgentThinkingMarkup } from "@/lib/agent-thinking-markup";
 import { isAuthError, isLikelyAuthError } from "@/lib/auth-errors";
@@ -188,6 +186,18 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       const len = inputRef?.value.length ?? 0;
       inputRef?.setSelectionRange(len, len);
     });
+  };
+  // The screen recorder lives in the titlebar; route its stopped session into
+  // the focused composer. Only the active pane handles the event, and the
+  // _handled flag prevents the sibling composer from double-processing it.
+  const onRecordingSessionStop = (event: Event) => {
+    if (!isPaneActive()) return;
+    const custom = event as CustomEvent<RecordingSession | null> & {
+      _handled?: boolean;
+    };
+    if (custom._handled) return;
+    custom._handled = true;
+    handleRecordingSessionStop(custom.detail);
   };
   markdownWorker.onmessage = (
     e: MessageEvent<{ id: string; html: string; error?: boolean }>,
@@ -428,6 +438,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   onMount(() => {
     window.addEventListener("seren:pick-images", onPickImages);
     window.addEventListener("seren:set-chat-input", onSetChatInput);
+    window.addEventListener(
+      "seren:recording-session-stop",
+      onRecordingSessionStop,
+    );
     if (isPaneActive() && fileTreeState.rootPath) {
       void agentStore.refreshRemoteSessions(
         fileTreeState.rootPath,
@@ -438,6 +452,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   onCleanup(() => {
     window.removeEventListener("seren:pick-images", onPickImages);
     window.removeEventListener("seren:set-chat-input", onSetChatInput);
+    window.removeEventListener(
+      "seren:recording-session-stop",
+      onRecordingSessionStop,
+    );
   });
 
   // Resolve the session for the currently-viewed thread, not the global
@@ -2184,10 +2202,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 </Show>
               </div>
               <div class={COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES}>
-                <RecordButton
-                  adapter={desktopRecordingAdapter}
-                  onSessionStop={handleRecordingSessionStop}
-                />
                 <VoiceInputButton
                   mode="agent"
                   onTranscript={(text) => {

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -2,7 +2,6 @@
 // ABOUTME: Shows chat messages, input, and model selector.
 
 import type { RecordingSession } from "@seren/recording-core";
-import { RecordButton } from "@seren/recording-ui";
 import { confirm } from "@tauri-apps/plugin-dialog";
 /* eslint-disable solid/no-innerhtml */
 import type { Component } from "solid-js";
@@ -23,7 +22,6 @@ import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { SlidePanel } from "@/components/layout/SlidePanel";
 import { RecordedSessionCard } from "@/components/recording/RecordedSessionCard";
 import { DepositModal } from "@/components/wallet/DepositModal";
-import { desktopRecordingAdapter } from "@/features/recording/desktopRecordingAdapter";
 import { appendRecordingSkillDraftPrompt } from "@/features/recording/recordingComposer";
 import { isAuthError, isContextOverflowError } from "@/lib/auth-errors";
 import {
@@ -219,6 +217,18 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       const len = inputRef?.value.length ?? 0;
       inputRef?.setSelectionRange(len, len);
     });
+  };
+  // The screen recorder lives in the titlebar; route its stopped session into
+  // the focused composer. Only the active pane handles the event, and the
+  // _handled flag prevents the sibling composer from double-processing it.
+  const onRecordingSessionStop = (event: Event) => {
+    if (!isPaneActive()) return;
+    const custom = event as CustomEvent<RecordingSession | null> & {
+      _handled?: boolean;
+    };
+    if (custom._handled) return;
+    custom._handled = true;
+    handleRecordingSessionStop(custom.detail);
   };
   const activeThreadProvider = (): ProviderId => {
     const id = conversationId();
@@ -607,6 +617,10 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     // Listen for slash command events
     window.addEventListener("seren:pick-images", handlePickImages);
     window.addEventListener("seren:set-chat-input", handleSetChatInput);
+    window.addEventListener(
+      "seren:recording-session-stop",
+      onRecordingSessionStop,
+    );
     window.addEventListener(RUN_SKILL_EVENT, handleRunSkillEvent);
 
     try {
@@ -661,6 +675,10 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     window.removeEventListener(
       "seren:set-chat-input",
       handleSetChatInput as EventListener,
+    );
+    window.removeEventListener(
+      "seren:recording-session-stop",
+      onRecordingSessionStop,
     );
     window.removeEventListener(RUN_SKILL_EVENT, handleRunSkillEvent);
 
@@ -2062,10 +2080,6 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                 </Show>
               </div>
               <div class={COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES}>
-                <RecordButton
-                  adapter={desktopRecordingAdapter}
-                  onSessionStop={handleRecordingSessionStop}
-                />
                 <VoiceInputButton
                   onTranscript={(text) => {
                     setInput((prev) => (prev ? `${prev} ${text}` : text));

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -1,10 +1,12 @@
 // ABOUTME: Compact titlebar with workspace switcher, balance, and window actions.
 // ABOUTME: Project folder lives in the sidebar header, not duplicated here.
 
+import { RecordButton } from "@seren/recording-ui";
 import { type Component, Show } from "solid-js";
 import { BalanceDisplay } from "@/components/common/BalanceDisplay";
 import { WorkspaceBar } from "@/components/layout/WorkspaceBar";
 import { RecordPrompt } from "@/components/meeting/RecordPrompt";
+import { desktopRecordingAdapter } from "@/features/recording/desktopRecordingAdapter";
 import { authStore } from "@/stores/auth.store";
 import { updaterStore } from "@/stores/updater.store";
 
@@ -172,6 +174,22 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
         <Show when={authStore.isAuthenticated}>
           <BalanceDisplay />
         </Show>
+
+        {/* Screen/workflow recorder lives beside the meeting recorder — both
+            are capture controls. The active composer picks up the stopped
+            session via the seren:recording-session-stop event. */}
+        <RecordButton
+          adapter={desktopRecordingAdapter}
+          class="relative flex items-center justify-center w-7 h-7 border-none rounded-md bg-transparent text-rec-fg-muted cursor-pointer transition-all duration-100 hover:bg-surface-2 hover:text-foreground active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
+          classNames={{ toolbar: "absolute right-0 top-full z-50 mt-1" }}
+          onSessionStop={(session) =>
+            window.dispatchEvent(
+              new CustomEvent("seren:recording-session-stop", {
+                detail: session,
+              }),
+            )
+          }
+        />
 
         <button
           type="button"

--- a/tests/unit/recording-packages.test.ts
+++ b/tests/unit/recording-packages.test.ts
@@ -54,6 +54,7 @@ const recordingComposerSource = source(
 );
 const agentChatSource = source("src/components/chat/AgentChat.tsx");
 const chatContentSource = source("src/components/chat/ChatContent.tsx");
+const titlebarSource = source("src/components/layout/Titlebar.tsx");
 const tauriLibSource = source("src-tauri/src/lib.rs");
 
 function tarString(bytes: Uint8Array, offset: number, length: number): string {
@@ -719,14 +720,13 @@ describe("recording packages", () => {
       appendRecordingSkillDraftPrompt("Existing instruction  \n", session),
     ).toMatch(/^Existing instruction\n\nCreate a Seren skill draft/);
     expect(recordingComposerSource).toContain("buildRecordingSkillDraftPrompt");
-    expect(agentChatSource).toContain("handleRecordingSessionStop");
-    expect(agentChatSource).toContain(
-      "onSessionStop={handleRecordingSessionStop}",
-    );
-    expect(chatContentSource).toContain("handleRecordingSessionStop");
-    expect(chatContentSource).toContain(
-      "onSessionStop={handleRecordingSessionStop}",
-    );
+    // The composers still build the draft prompt from a stopped session, but
+    // now receive it over the titlebar's recording-session-stop event rather
+    // than a direct onSessionStop prop. (#2609)
+    for (const composer of [agentChatSource, chatContentSource]) {
+      expect(composer).toContain("handleRecordingSessionStop");
+      expect(composer).toContain('"seren:recording-session-stop"');
+    }
   });
 
   it("builds a correction prompt from an existing draft review", () => {
@@ -2373,20 +2373,32 @@ describe("recording packages", () => {
     expect(recordingMarkerForShortcutCode("Numpad1")).toBeNull();
   });
 
-  it("wires desktop through an adapter and places record before mic", () => {
+  it("wires desktop through an adapter and places the screen recorder in the titlebar (#2609)", () => {
     expect(desktopAdapterSource).toContain("@tauri-apps/api/core");
     expect(desktopAdapterSource).toContain("recording_list_targets");
     expect(desktopAdapterSource).toContain("recording_check_permissions");
     expect(desktopAdapterSource).toContain("recording_request_permission");
     expect(desktopAdapterSource).toContain("recording_start");
 
+    // The screen recorder is a capture control: it sits in the titlebar
+    // immediately before the meeting recorder, not beside the dictation mic.
+    expect(titlebarSource).toContain('from "@seren/recording-ui"');
+    expect(titlebarSource).toContain("desktopRecordingAdapter");
+    expect(titlebarSource).toContain("<RecordButton");
+    expect(titlebarSource.indexOf("<RecordButton")).toBeLessThan(
+      titlebarSource.indexOf('data-testid="titlebar-meetings-button"'),
+    );
+
+    // It must not render in either composer toolbar, and the active composer
+    // receives stopped sessions over the window event instead.
     for (const composer of [agentChatSource, chatContentSource]) {
-      expect(composer).toContain('from "@seren/recording-ui"');
-      expect(composer).toContain("desktopRecordingAdapter");
-      expect(composer.indexOf("<RecordButton")).toBeLessThan(
-        composer.indexOf("<VoiceInputButton"),
-      );
+      expect(composer).not.toContain("<RecordButton");
+      expect(composer).toContain("seren:recording-session-stop");
     }
+    expect(titlebarSource).toContain("seren:recording-session-stop");
+
+    // The trigger glyph reads as "record video", never the ambiguous dot.
+    expect(uiSource).not.toContain('<circle cx="8" cy="8" r="5" />');
   });
 
   it("registers the desktop recording command surface", () => {


### PR DESCRIPTION
Closes #2609.

## Problem

The screen/workflow recorder (`RecordButton` from `@seren/recording-ui`) shipped as an **unlabeled gray dot (`●`)** in the chat composer, directly to the **left of the voice-input mic**. Two UX defects:

1. It sat beside *voice dictation*, conflating screen capture with prompting-by-voice.
2. A bare dot gives no signal that clicking it **films your screen**.

## Fix

- **Relocated** the `RecordButton` out of both composer toolbars (`AgentChat.tsx`, `ChatContent.tsx`) into the **titlebar, immediately left of the meeting recorder** (`titlebar-meetings-button`) — grouped with the other capture control. Sized `w-7 h-7` to match the titlebar buttons.
- **New icon**: replaced the dot with an outline **video-camera** glyph (matches the meetings/settings/skills stroke style). The active state still shows the stop square.
- **Preserved the skill-draft flow**: the titlebar button's `onSessionStop` dispatches a `seren:recording-session-stop` window event; the focused composer listens and runs the existing `handleRecordingSessionStop`, reusing the established `isPaneActive()` + `_handled` dedup (same pattern as `seren:set-chat-input`). The recorded-session card and draft prompt still land in the active chat.
- **Stable titlebar layout**: the inline recording toolbar renders as a floating popover (`classNames.toolbar`) instead of expanding the titlebar inline.
- Updated the placement regression test in `tests/unit/recording-packages.test.ts`.

## Verification

- `tsc --noEmit`: 0 errors.
- Biome `check` on changed files: clean (only 2 pre-existing `useOptionalChain` warnings outside this diff).
- Full unit suite: **2034 passed / 285 files**, including the updated placement assertions.
- Confirmed `onSessionStop` fires on both the normal `stop()` and OS external-stop paths, so the event route fully replaces the old prop coupling.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
