### PR TITLE
fix(skills): manifest-first revision check + transient 5xx retry (#2611)

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -577,13 +577,46 @@ function normalizeSkillBundle(value: unknown): SkillBundle | null {
   });
 }
 
+/** Gateway statuses worth a bounded retry on idempotent skill GETs (#2611). */
+const TRANSIENT_GATEWAY_STATUSES = new Set([502, 503, 504]);
+/** Backoff before each retry; length is the number of extra attempts. */
+const TRANSIENT_RETRY_DELAYS_MS = [250, 1000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Retry an idempotent seren-skills download GET on transient gateway
+ * failures (502/503/504). The gateway intermittently 502s across publisher
+ * endpoints while the upstream publisher pod is briefly unavailable
+ * (serenorg/seren-core#189); a bounded retry rides through the blip instead
+ * of surfacing a hard error. Non-transient statuses — including the
+ * oversized-bundle 500 that triggers the split-download fallback — return on
+ * the first attempt, so their existing handling is unchanged.
+ */
+async function withTransientGatewayRetry<
+  T extends { error?: unknown; response?: { status?: number } },
+>(call: () => Promise<T>): Promise<T> {
+  let result = await call();
+  for (const delayMs of TRANSIENT_RETRY_DELAYS_MS) {
+    if (!result.error) return result;
+    const status = result.response?.status;
+    if (status === undefined || !TRANSIENT_GATEWAY_STATUSES.has(status)) {
+      return result;
+    }
+    await sleep(delayMs);
+    result = await call();
+  }
+  return result;
+}
+
 async function downloadSkillBundleSingleShot(
   slug: string,
 ): Promise<SkillBundle> {
-  const { data, error, response } = await downloadSkill({
-    path: { slug },
-    throwOnError: false,
-  });
+  const { data, error, response } = await withTransientGatewayRetry(() =>
+    downloadSkill({ path: { slug }, throwOnError: false }),
+  );
   if (error || !data) {
     const status = response ? `: ${response.status}` : "";
     throw new SkillsApiError(
@@ -644,10 +677,9 @@ function normalizeSkillBundleManifest(
 async function downloadSkillBundleManifest(
   slug: string,
 ): Promise<SkillBundleManifest> {
-  const { data, error, response } = await downloadSkillManifest({
-    path: { slug },
-    throwOnError: false,
-  });
+  const { data, error, response } = await withTransientGatewayRetry(() =>
+    downloadSkillManifest({ path: { slug }, throwOnError: false }),
+  );
   if (error || !data) {
     const status = response ? `: ${response.status}` : "";
     throw new SkillsApiError(
@@ -687,11 +719,9 @@ async function downloadSkillBundleFilePayload(
   slug: string,
   path: string,
 ): Promise<SkillBundleFileDownload> {
-  const { data, error, response } = await downloadSkillFile({
-    path: { slug },
-    query: { path },
-    throwOnError: false,
-  });
+  const { data, error, response } = await withTransientGatewayRetry(() =>
+    downloadSkillFile({ path: { slug }, query: { path }, throwOnError: false }),
+  );
   if (error || !data) {
     const status = response ? `: ${response.status}` : "";
     throw new SkillsApiError(
@@ -1099,7 +1129,11 @@ async function fetchRemoteSkillRevision(
 ): Promise<RemoteSkillRevision | null> {
   const slug = skillSlugFromSourceUrl(sourceUrl);
   if (!slug) return null;
-  return remoteRevisionFromBundle(await downloadSkillBundleMetadata(slug));
+  // A revision check only needs content_hash/version/updated_at, all of which
+  // the manifest carries. Query it directly instead of single-shot-first so a
+  // large skill's refresh never pulls the full bundle (and never depends on
+  // the gateway's oversized-bundle 500 to fall back). #2611
+  return remoteRevisionFromBundle(await downloadSkillBundleManifest(slug));
 }
 
 /**

--- a/tests/unit/skills-binary-payload.test.ts
+++ b/tests/unit/skills-binary-payload.test.ts
@@ -7,6 +7,7 @@ import type { InstalledSkill, Skill } from "@/lib/skills";
 
 const mockInvoke = vi.hoisted(() => vi.fn());
 const mockDownloadSkill = vi.hoisted(() => vi.fn());
+const mockDownloadSkillManifest = vi.hoisted(() => vi.fn());
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: mockInvoke,
@@ -30,6 +31,7 @@ vi.mock("@/api/seren-skills", () => ({
   createVersion: vi.fn(),
   deleteSkill: vi.fn(),
   downloadSkill: mockDownloadSkill,
+  downloadSkillManifest: mockDownloadSkillManifest,
   getAuthorIdentity: vi.fn(),
   getOrgFolder: vi.fn(),
   listSkills: vi.fn(),
@@ -82,7 +84,15 @@ const catalogSkill: Skill = {
 beforeEach(() => {
   mockInvoke.mockReset();
   mockDownloadSkill.mockReset();
+  mockDownloadSkillManifest.mockReset();
   mockDownloadSkill.mockResolvedValue({
+    data: bundle,
+    error: undefined,
+    response: { status: 200 },
+  });
+  // The revision check (inspectSyncStatus) is manifest-first; the manifest
+  // carries the same content_hash/files the bundle does.
+  mockDownloadSkillManifest.mockResolvedValue({
     data: bundle,
     error: undefined,
     response: { status: 200 },

--- a/tests/unit/skills-split-download.test.ts
+++ b/tests/unit/skills-split-download.test.ts
@@ -237,6 +237,28 @@ describe("split-download fallback (#2296)", () => {
     expect(mockDownloadSkillManifest).not.toHaveBeenCalled();
   });
 
+  it("retries a transient 502 from the manifest endpoint and succeeds", async () => {
+    vi.useFakeTimers();
+    mockDownloadSkillManifest
+      .mockResolvedValueOnce({
+        data: undefined,
+        error: { error: "BadGateway" },
+        response: { status: 502 },
+      })
+      .mockResolvedValueOnce({
+        data: manifest,
+        error: undefined,
+        response: { status: 200 },
+      });
+
+    const pending = skills.fetchContent(catalogSkill);
+    await vi.runAllTimersAsync();
+
+    await expect(pending).resolves.toBe(SKILL_MD);
+    expect(mockDownloadSkillManifest).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
   it("rejects the install when a file was republished mid-download", async () => {
     mockDownloadSkillFile.mockImplementation(
       async (options: { query: { path: string } }) => ({

--- a/tests/unit/skills-sync-status.test.ts
+++ b/tests/unit/skills-sync-status.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockDownloadSkill = vi.hoisted(() => vi.fn());
+const mockDownloadSkillManifest = vi.hoisted(() => vi.fn());
 
 vi.mock("@/api/seren-skills", () => ({
   createOrgFolder: vi.fn(),
   downloadSkill: mockDownloadSkill,
+  downloadSkillManifest: mockDownloadSkillManifest,
   getAuthorIdentity: vi.fn(),
   getOrgFolder: vi.fn(),
   upsertAuthorIdentity: vi.fn(),
@@ -27,7 +29,7 @@ describe("skills.inspectSyncStatus", () => {
     const skillSourceUrl = "seren-skills:polymarket-maker-rebate-bot";
     const lastModified = "2026-03-18T00:00:00Z";
 
-    mockDownloadSkill.mockResolvedValue({
+    mockDownloadSkillManifest.mockResolvedValue({
       data: {
         content_hash: lastModified,
         files: [],
@@ -107,7 +109,7 @@ describe("skills.inspectSyncStatus", () => {
 
   it("keeps legacy serenorg repo sync state refreshable through the Seren Skills API", async () => {
     const lastModified = "2026-03-19T00:00:00Z";
-    mockDownloadSkill.mockResolvedValue({
+    mockDownloadSkillManifest.mockResolvedValue({
       data: {
         content_hash: lastModified,
         files: [],
@@ -175,10 +177,12 @@ describe("skills.inspectSyncStatus", () => {
       },
     });
 
-    expect(mockDownloadSkill).toHaveBeenCalledWith({
+    expect(mockDownloadSkillManifest).toHaveBeenCalledWith({
       path: { slug: "polymarket-maker-rebate-bot" },
       throwOnError: false,
     });
+    // The revision check is manifest-first: it must not pull the full bundle.
+    expect(mockDownloadSkill).not.toHaveBeenCalled();
     expect(status).toMatchObject({
       state: "update-available",
       updateAvailable: true,
@@ -219,5 +223,6 @@ describe("skills.inspectSyncStatus", () => {
 
     expect(status).toBeNull();
     expect(mockDownloadSkill).not.toHaveBeenCalled();
+    expect(mockDownloadSkillManifest).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #2611.

## Problem
Refreshing an installed large skill (`glide-affinity-proposals` — 78 MB of PPTX templates) fails with `Failed to download skill glide-affinity-proposals: 502` / `Failed to download manifest ... : 502`.

The 502 itself is server-side gateway/publisher instability (tracked in serenorg/seren-core#189). This PR fixes two client-side weaknesses that make the desktop brittle against it.

## Changes (`src/services/skills.ts`)
1. **Manifest-first revision check.** `fetchRemoteSkillRevision` now calls `downloadSkillBundleManifest` directly instead of single-shot-first. `remoteRevisionFromBundle` only needs `content_hash`/`version`/`updated_at`, all present in the 22 KB manifest — so a refresh no longer pulls the full 78 MB bundle (which the metered gateway buffers and rejects with 500) on every app start. Scoped to the revision-check path; `fetchContent` preview and the catalog list are unchanged.
2. **Bounded transient-5xx retry.** The three skill download GETs (`downloadSkill`, `downloadSkillManifest`, `downloadSkillFile`) retry `502/503/504` with backoff (`[250ms, 1000ms]`). The oversized-bundle **500 is not transient**, so the split-download fallback (#2296) is untouched; catalog `listSkills` keeps its existing cache-fallback model.

## Impact
- Eliminates the guaranteed 78 MB→500 round trip on every refresh of a large skill.
- Rides through intermittent gateway 502/503/504 on skill downloads instead of surfacing a hard error.

## Tests (critical only)
- `skills-sync-status.test.ts` migrated to assert the revision check uses the **manifest** endpoint and never the full single-shot bundle.
- `skills-split-download.test.ts` adds one test: a transient 502 on the manifest is retried and succeeds.
- Full suite green; `tsc` clean; Biome clean on `src/`.

## Out of scope (follow-up, assessed in functional audit)
- `fetchContent` preview still single-shot-first for oversized skills.
- Catalog list (`/skills`) 502s rely on cache fallback only.
