### PR TITLE
feat(skills): composer Sync Skill button for active chat skill (#2613)

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -2,7 +2,10 @@
 // ABOUTME: Shows chat messages, input, and model selector.
 
 import type { RecordingSession } from "@seren/recording-core";
-import { confirm } from "@tauri-apps/plugin-dialog";
+import {
+  confirm,
+  message as showMessageDialog,
+} from "@tauri-apps/plugin-dialog";
 /* eslint-disable solid/no-innerhtml */
 import type { Component } from "solid-js";
 import {
@@ -58,7 +61,11 @@ import {
   setCurrentSkillDragPayload,
   skillDragPayload,
 } from "@/lib/skill-drag";
-import { skillCommandAliases, skillMatchesCommandAlias } from "@/lib/skills";
+import {
+  type InstalledSkill,
+  skillCommandAliases,
+  skillMatchesCommandAlias,
+} from "@/lib/skills";
 import {
   buildSkillInvocationDirective,
   buildSkillInvocationDisplay,
@@ -118,6 +125,7 @@ import { RLMStepsBlock } from "./RLMStepsBlock";
 import { SatisfactionSignal } from "./SatisfactionSignal";
 import { SkillsButton } from "./SkillsButton";
 import { SlashCommandPopup } from "./SlashCommandPopup";
+import { SyncSkillButton } from "./SyncSkillButton";
 import { ThinkingStatus } from "./ThinkingStatus";
 import { ToolCallCard } from "./ToolCallCard";
 import { ToolCallGroup } from "./ToolCallGroup";
@@ -428,6 +436,40 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     }
     return null;
   });
+  // Inspect the active skill's sync status once so the composer can surface the
+  // Sync button without the user opening the catalog. The store caches the
+  // verdict; `undefined` means "not inspected yet" for this skill.
+  createEffect(() => {
+    const skill = recentSkill();
+    if (!skill) return;
+    if (skillsStore.syncStatusFor(skill.path) !== undefined) return;
+    void skillsStore.loadSyncStatus(skill).catch(() => undefined);
+  });
+  const activeSkillNeedsSync = () => {
+    const skill = recentSkill();
+    return skill ? skillsStore.skillNeedsSync(skill) : false;
+  };
+  const handleSyncActiveSkill = async (skill: InstalledSkill) => {
+    try {
+      const result = await skillsStore.syncInstalledSkill(skill);
+      if (
+        (result.outcome === "untracked" || result.outcome === "error") &&
+        result.message
+      ) {
+        await showMessageDialog(result.message, {
+          title: "Sync skill",
+          kind: result.outcome === "error" ? "error" : "warning",
+        });
+      }
+    } catch (err) {
+      await showMessageDialog(
+        `Could not sync ${skill.name}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { title: "Sync skill", kind: "error" },
+      );
+    }
+  };
   const conversationIsLoading = () => {
     const id = conversationId();
     return id ? conversationStore.getLoadingFor(id) : false;
@@ -2064,6 +2106,14 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                       inputRef?.setSelectionRange(len, len);
                     }}
                   />
+                  <Show when={activeSkillNeedsSync() && recentSkill()}>
+                    {(skill) => (
+                      <SyncSkillButton
+                        skill={skill()}
+                        onSync={() => void handleSyncActiveSkill(skill())}
+                      />
+                    )}
+                  </Show>
                 </Show>
                 <Show when={messageQueue().length > 0}>
                   <span class="flex items-center gap-2 px-2 py-1 bg-surface-2 border border-border rounded text-xs text-muted-foreground">

--- a/src/components/chat/SyncSkillButton.tsx
+++ b/src/components/chat/SyncSkillButton.tsx
@@ -1,0 +1,62 @@
+// ABOUTME: Composer button that syncs the chat's active skill to its latest
+// ABOUTME: upstream revision; the parent renders it only when a sync is needed.
+
+import { type Component, Show } from "solid-js";
+import type { InstalledSkill } from "@/lib/skills";
+import { skillsStore } from "@/stores/skills.store";
+
+interface SyncSkillButtonProps {
+  /** The chat's active skill, already determined to need a sync by the parent. */
+  skill: InstalledSkill;
+  /**
+   * Trigger the sync. The parent runs `skillsStore.syncInstalledSkill`, which
+   * shows the changes/confirmation popup before applying.
+   */
+  onSync: () => void;
+}
+
+function SyncGlyph(props: { class?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.85"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+      class={props.class}
+    >
+      <path d="M21 2v6h-6" />
+      <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+      <path d="M3 22v-6h6" />
+      <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+    </svg>
+  );
+}
+
+export const SyncSkillButton: Component<SyncSkillButtonProps> = (props) => {
+  const loading = () => skillsStore.isSyncLoading(props.skill.path);
+
+  return (
+    <button
+      type="button"
+      aria-label={`Sync /${props.skill.slug} to the latest version`}
+      title={`/${props.skill.slug} has an update available — click to review the changes and sync`}
+      disabled={loading()}
+      class="flex items-center gap-2 px-3 py-1.5 bg-warning/10 border border-warning/40 rounded-md text-sm font-medium text-warning cursor-pointer transition-colors hover:bg-warning/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset disabled:opacity-60 disabled:cursor-default"
+      onClick={(event) => {
+        event.preventDefault();
+        if (loading()) return;
+        props.onSync();
+      }}
+    >
+      <SyncGlyph class={loading() ? "animate-spin" : undefined} />
+      <Show when={loading()} fallback={<span>Sync Skill</span>}>
+        <span>Syncing…</span>
+      </Show>
+    </button>
+  );
+};

--- a/src/components/sidebar/SkillsExplorer.tsx
+++ b/src/components/sidebar/SkillsExplorer.tsx
@@ -2,7 +2,6 @@
 // ABOUTME: Renders inside SlidePanel with chip filters (All / Installed / Needs sync) and an inline detail accordion.
 
 import { createInfiniteQuery } from "@tanstack/solid-query";
-import { confirm } from "@tauri-apps/plugin-dialog";
 import {
   type Component,
   createEffect,
@@ -212,12 +211,6 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
     slug: string;
     message: string;
   } | null>(null);
-  const [syncStatuses, setSyncStatuses] = createSignal<
-    Record<string, SkillSyncStatus | null | undefined>
-  >({});
-  const [syncLoading, setSyncLoading] = createSignal<Record<string, boolean>>(
-    {},
-  );
   let contentRef: HTMLDivElement | undefined;
   let refreshStatusTimer: ReturnType<typeof setTimeout> | null = null;
   const availableSkillsQuery = createInfiniteQuery(() =>
@@ -226,17 +219,14 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
 
   // ── Derived values ──────────────────────────────
 
-  const syncStatusFor = (skill: InstalledSkill) => syncStatuses()[skill.path];
-
-  const skillNeedsSync = (skill: InstalledSkill): boolean => {
-    const status = syncStatusFor(skill);
-    if (!status) return false;
-    return (
-      status.updateAvailable ||
-      status.hasLocalChanges ||
-      status.state === "bootstrap-required"
-    );
-  };
+  // Sync status is owned by skillsStore so the catalog panel and the composer
+  // Sync button never disagree about whether a skill needs syncing.
+  const syncStatusFor = (skill: InstalledSkill) =>
+    skillsStore.syncStatusFor(skill.path);
+  const syncLoadingFor = (skill: InstalledSkill) =>
+    skillsStore.isSyncLoading(skill.path);
+  const skillNeedsSync = (skill: InstalledSkill): boolean =>
+    skillsStore.skillNeedsSync(skill);
 
   // Ownership is decided by the publisher record, which only exists on
   // catalog-side Skills. For installed rows we cross-reference by slug. The
@@ -371,17 +361,6 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
   // invocation surfaces; thread-attach is a separate concept that may or may
   // not come back as an explicit "persona" affordance later.
 
-  const setSyncLoadingFor = (path: string, isLoading: boolean) => {
-    setSyncLoading((current) => ({ ...current, [path]: isLoading }));
-  };
-
-  const setSyncStatusFor = (
-    path: string,
-    status: SkillSyncStatus | null | undefined,
-  ) => {
-    setSyncStatuses((current) => ({ ...current, [path]: status }));
-  };
-
   const installProgressFor = (skillId: string) =>
     installProgressBySkill()[skillId] ?? null;
 
@@ -410,26 +389,10 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
       : "Installing...";
   };
 
-  const loadSyncStatus = async (skill: InstalledSkill) => {
-    if (!isUpstreamManagedSkill(skill)) {
-      setSyncStatusFor(skill.path, null);
-      return;
-    }
+  const loadSyncStatus = (skill: InstalledSkill) =>
+    skillsStore.loadSyncStatus(skill);
 
-    setSyncLoadingFor(skill.path, true);
-    try {
-      const status = await skillsService.inspectSyncStatus(skill);
-      setSyncStatusFor(skill.path, status);
-    } finally {
-      setSyncLoadingFor(skill.path, false);
-    }
-  };
-
-  const refreshAllSyncStatuses = async () => {
-    await Promise.all(
-      skillsStore.installed.map((skill) => loadSyncStatus(skill)),
-    );
-  };
+  const refreshAllSyncStatuses = () => skillsStore.refreshAllSyncStatuses();
 
   const updateCount = () =>
     skillsStore.installed.filter((skill) => {
@@ -753,7 +716,6 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
     setActionInProgress(skill.id);
     try {
       await skillsStore.remove(skill);
-      setSyncStatusFor(skill.path, undefined);
       if (expandedSkillId() === skill.id) {
         setExpandedSkillId(null);
         setDetailContent(null);
@@ -809,58 +771,17 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
   });
 
   const handleRefreshInstalledSkill = async (skill: InstalledSkill) => {
-    const cachedStatus = syncStatusFor(skill);
-    const existingStatus =
-      cachedStatus && cachedStatus.state !== "error"
-        ? cachedStatus
-        : await skillsService.inspectSyncStatus(skill);
-    setSyncStatusFor(skill.path, existingStatus);
-
-    if (!existingStatus) {
-      window.alert(
-        `${skill.name} is not tracked against an upstream Seren skill revision, so Seren will not refresh it automatically.`,
-      );
-      return;
-    }
-
-    if (existingStatus.state === "error") {
-      window.alert(
-        existingStatus.error
-          ? `Seren could not verify the current sync state for ${skill.name}.\n\n${existingStatus.error}\n\nRefresh has been blocked to avoid overwriting local files without a verified baseline.`
-          : `Seren could not verify the current sync state for ${skill.name}. Refresh has been blocked to avoid overwriting local files without a verified baseline.`,
-      );
-      return;
-    }
-
-    if (existingStatus?.hasLocalChanges) {
-      const changed = [
-        ...existingStatus.changedLocalFiles,
-        ...existingStatus.missingManagedFiles,
-      ];
-      const confirmOverwrite = await confirm(
-        `Local changes were detected in ${skill.name}.\n\n${changed
-          .slice(0, 8)
-          .join(
-            "\n",
-          )}${changed.length > 8 ? `\n...and ${changed.length - 8} more` : ""}\n\nOverwrite local skill files with upstream?`,
-        {
-          title: "Overwrite local skill changes?",
-          kind: "warning",
-        },
-      );
-      if (!confirmOverwrite) return;
-    }
-
     setActionInProgress(skill.id);
     try {
-      const refreshed = await skillsService.refreshInstalledSkill(skill, {
-        expectedLocalManagedState: existingStatus.localManagedState,
-      });
-      skillsStore.replaceInstalled(refreshed.installed);
-      setSyncStatusFor(refreshed.installed.path, refreshed.syncStatus);
+      const result = await skillsStore.syncInstalledSkill(skill);
+      if (
+        (result.outcome === "untracked" || result.outcome === "error") &&
+        result.message
+      ) {
+        window.alert(result.message);
+      }
     } catch (err) {
       console.error("[SkillsExplorer] Failed to refresh installed skill:", err);
-      await loadSyncStatus(skill);
     } finally {
       setActionInProgress(null);
     }
@@ -1351,7 +1272,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                             Yours
                           </span>
                         </Show>
-                        <Show when={syncLoading()[skill.path]}>
+                        <Show when={syncLoadingFor(skill)}>
                           <span class="text-[10px] text-muted-foreground">
                             Checking...
                           </span>
@@ -1461,7 +1382,7 @@ export const SkillsExplorer: Component<SkillsExplorerProps> = (props) => {
                                 }
                                 disabled={
                                   actionInProgress() === skill.id ||
-                                  syncLoading()[skill.path]
+                                  syncLoadingFor(skill)
                                 }
                               >
                                 {actionInProgress() === skill.id

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Handles available skills, installed skills, and thread/project/global resolution.
 
 import { invoke } from "@tauri-apps/api/core";
+import { confirm } from "@tauri-apps/plugin-dialog";
 import { untrack } from "solid-js";
 import { createStore } from "solid-js/store";
 import { log } from "@/lib/logger";
@@ -14,6 +15,7 @@ import {
   type Skill,
   type SkillInstallOptions,
   type SkillScope,
+  type SkillSyncStatus,
   type SkillsState,
 } from "@/lib/skills";
 import {
@@ -215,6 +217,77 @@ const [projectConfigState, setProjectConfigState] = createStore<
 const [threadSkillsState, setThreadSkillsState] = createStore<
   Record<string, string[] | null | undefined>
 >({});
+
+/**
+ * Sync-status cache keyed by installed skill path. Single source of truth so
+ * every surface (the Skills catalog panel and the composer Sync button) reads
+ * the same verdict and never disagrees about whether a skill needs syncing.
+ * - `undefined`: not inspected yet
+ * - `null`: not upstream-managed (nothing to sync)
+ * - `SkillSyncStatus`: last inspected verdict
+ */
+const [syncStatusState, setSyncStatusState] = createStore<
+  Record<string, SkillSyncStatus | null | undefined>
+>({});
+
+/** Per-skill (by path) in-flight flag for a sync-status inspection or refresh. */
+const [syncLoadingState, setSyncLoadingState] = createStore<
+  Record<string, boolean>
+>({});
+
+/**
+ * Outcome of {@link skillsStore.syncInstalledSkill}. The action owns the
+ * overwrite confirmation popup; callers map the outcome to surface-specific
+ * messaging (an alert in the catalog, a silent button update in the composer).
+ */
+export interface SyncSkillResult {
+  outcome: "synced" | "cancelled" | "untracked" | "error";
+  syncStatus: SkillSyncStatus | null | undefined;
+  /** Human-readable detail for the `error`/`untracked` outcomes. */
+  message?: string;
+}
+
+/** Short revision label for confirmation copy; null collapses to "current". */
+function shortRevision(sha: string | null): string {
+  if (!sha) return "current";
+  return sha.length > 12 ? sha.slice(0, 12) : sha;
+}
+
+/**
+ * Confirmation body for {@link skillsStore.syncInstalledSkill}, adapted to the
+ * verdict so the user sees what will happen before they apply it:
+ * - local edits → list the diverging files and warn about the overwrite
+ * - update available → name the revision jump
+ * - first sync → explain the bootstrap download
+ */
+function syncConfirmationMessage(
+  skill: InstalledSkill,
+  status: SkillSyncStatus,
+): string {
+  if (status.hasLocalChanges) {
+    const changed = [
+      ...status.changedLocalFiles,
+      ...status.missingManagedFiles,
+    ];
+    const list = changed.slice(0, 8).join("\n");
+    const more =
+      changed.length > 8 ? `\n...and ${changed.length - 8} more` : "";
+    return `Local changes were detected in ${skill.name}.\n\n${list}${more}\n\nOverwrite local skill files with upstream?`;
+  }
+
+  if (status.state === "bootstrap-required") {
+    return `${skill.name} needs an initial sync to download its skill files. Sync now?`;
+  }
+
+  if (status.updateAvailable) {
+    const target = shortRevision(status.remoteRevision?.sha ?? null);
+    return `An update is available for ${skill.name} (${shortRevision(
+      status.syncedRevision,
+    )} → ${target}).\n\nSync now to update to the latest published version?`;
+  }
+
+  return `${skill.name} is already up to date. Re-download the latest skill files anyway?`;
+}
 
 /**
  * Skills store with reactive state and actions.
@@ -583,8 +656,10 @@ export const skillsStore = {
         const status = await skills.inspectSyncStatus(installed);
         // inspectSyncStatus may return null for non-upstream-managed skills;
         // the gate above guarantees it isn't, but the type is honest about it.
+        setSyncStatusState(installed.path, status);
         if (status?.updateAvailable) {
-          await skills.refreshInstalledSkill(installed);
+          const refreshed = await skills.refreshInstalledSkill(installed);
+          setSyncStatusState(refreshed.installed.path, refreshed.syncStatus);
           await this.refreshInstalled();
           log.info(
             "[SkillsStore] Refreshed stale skill on toggle-on:",
@@ -890,9 +965,13 @@ export const skillsStore = {
       if (skill.syncState?.upstreamDeleted) continue;
       try {
         const status = await skills.inspectSyncStatus(skill);
+        // Keep the shared cache coherent so the composer Sync button reflects
+        // this background sweep without re-inspecting.
+        setSyncStatusState(skill.path, status);
         if (!status || status.hasLocalChanges) continue;
         if (status.updateAvailable || status.state === "bootstrap-required") {
-          await skills.refreshInstalledSkill(skill);
+          const refreshed = await skills.refreshInstalledSkill(skill);
+          setSyncStatusState(refreshed.installed.path, refreshed.syncStatus);
           autoRefreshed++;
           summary.updated++;
           log.info("[SkillsStore] Auto-refreshed stale skill:", skill.slug);
@@ -1023,6 +1102,10 @@ export const skillsStore = {
       state.installed.filter((s) => s.path !== skill.path),
     );
 
+    // Drop the cached sync verdict so a reinstall re-inspects from scratch.
+    setSyncStatusState(skill.path, undefined);
+    setSyncLoadingState(skill.path, false);
+
     // Remove enabled state
     delete enabledState[skill.path];
     saveEnabledState(enabledState);
@@ -1074,6 +1157,143 @@ export const skillsStore = {
       skill.path === updated.path ? updated : skill,
     );
     setState("installed", next);
+  },
+
+  // --------------------------------------------------------------------------
+  // Sync status (shared by the Skills catalog panel and the composer button)
+  // --------------------------------------------------------------------------
+
+  /**
+   * Reactive sync-status verdict for an installed skill (by path).
+   */
+  syncStatusFor(path: string): SkillSyncStatus | null | undefined {
+    return syncStatusState[path];
+  },
+
+  /**
+   * Whether an inspection or refresh is currently running for this skill path.
+   */
+  isSyncLoading(path: string): boolean {
+    return syncLoadingState[path] === true;
+  },
+
+  /**
+   * True when the cached verdict says the skill is out of step with upstream:
+   * an update is available, the local files diverge, or the skill has never
+   * been bootstrapped. Returns false when the status is unknown, an inspection
+   * error, or `current`.
+   */
+  skillNeedsSync(skill: InstalledSkill): boolean {
+    const status = syncStatusState[skill.path];
+    if (!status) return false;
+    return (
+      status.updateAvailable ||
+      status.hasLocalChanges ||
+      status.state === "bootstrap-required"
+    );
+  },
+
+  /**
+   * Inspect (or re-inspect) a single skill's sync status and cache the result.
+   * Non-upstream-managed skills are cached as `null` without a network call.
+   */
+  async loadSyncStatus(
+    skill: InstalledSkill,
+  ): Promise<SkillSyncStatus | null | undefined> {
+    if (!isUpstreamManagedSkill(skill)) {
+      setSyncStatusState(skill.path, null);
+      return null;
+    }
+
+    setSyncLoadingState(skill.path, true);
+    try {
+      const status = await skills.inspectSyncStatus(skill);
+      setSyncStatusState(skill.path, status);
+      return status;
+    } finally {
+      setSyncLoadingState(skill.path, false);
+    }
+  },
+
+  /**
+   * Inspect sync status for every installed skill, populating the cache. Used
+   * by the catalog panel on open; failures for a single skill are isolated so
+   * one bad skill cannot abort the whole sweep.
+   */
+  async refreshAllSyncStatuses(): Promise<void> {
+    await Promise.all(
+      state.installed.map((skill) =>
+        this.loadSyncStatus(skill).catch((err) => {
+          log.warn(
+            "[SkillsStore] Sync-status inspection failed:",
+            skill.slug,
+            err,
+          );
+          return undefined;
+        }),
+      ),
+    );
+  },
+
+  /**
+   * Sync an installed skill to its upstream revision. Shows a confirmation
+   * popup describing what will change before applying, refreshes the files,
+   * and updates the cached sync status. The single sync gesture for both the
+   * catalog row and the composer Sync button.
+   */
+  async syncInstalledSkill(skill: InstalledSkill): Promise<SyncSkillResult> {
+    const cached = syncStatusState[skill.path];
+    const status =
+      cached && cached.state !== "error"
+        ? cached
+        : await skills.inspectSyncStatus(skill);
+    setSyncStatusState(skill.path, status);
+
+    if (!status) {
+      return {
+        outcome: "untracked",
+        syncStatus: status,
+        message: `${skill.name} is not tracked against an upstream Seren skill revision, so Seren will not refresh it automatically.`,
+      };
+    }
+
+    if (status.state === "error") {
+      return {
+        outcome: "error",
+        syncStatus: status,
+        message: status.error
+          ? `Seren could not verify the current sync state for ${skill.name}.\n\n${status.error}\n\nSync has been blocked to avoid overwriting local files without a verified baseline.`
+          : `Seren could not verify the current sync state for ${skill.name}. Sync has been blocked to avoid overwriting local files without a verified baseline.`,
+      };
+    }
+
+    const confirmed = await confirm(syncConfirmationMessage(skill, status), {
+      title: status.hasLocalChanges
+        ? "Overwrite local skill changes?"
+        : "Sync skill?",
+      kind: status.hasLocalChanges ? "warning" : "info",
+    });
+    if (!confirmed) {
+      return { outcome: "cancelled", syncStatus: status };
+    }
+
+    setSyncLoadingState(skill.path, true);
+    try {
+      const refreshed = await skills.refreshInstalledSkill(skill, {
+        expectedLocalManagedState: status.localManagedState,
+      });
+      this.replaceInstalled(refreshed.installed);
+      setSyncStatusState(refreshed.installed.path, refreshed.syncStatus);
+      log.info("[SkillsStore] Synced skill:", skill.slug);
+      return { outcome: "synced", syncStatus: refreshed.syncStatus };
+    } catch (err) {
+      // Re-inspect so the cached verdict reflects post-failure reality
+      // (the refresh aborts before writing when local state drifted).
+      await this.loadSyncStatus(skill).catch(() => undefined);
+      throw err;
+    } finally {
+      setSyncLoadingState(skill.path, false);
+    }
   },
 
   /**

--- a/tests/unit/skills-sync-action.test.ts
+++ b/tests/unit/skills-sync-action.test.ts
@@ -1,0 +1,243 @@
+// ABOUTME: Tests skillsStore sync-status decision + the syncInstalledSkill consent gate (#2613).
+// ABOUTME: The composer Sync button relies on skillNeedsSync; the confirm popup must gate every overwrite.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockConfirm = vi.hoisted(() => vi.fn().mockResolvedValue(true));
+
+const mockSkillsService = vi.hoisted(() => ({
+  fetchAllSkills: vi.fn().mockResolvedValue([]),
+  fetchOwnedSkills: vi.fn().mockResolvedValue([]),
+  listAllInstalled: vi.fn().mockResolvedValue([]),
+  backfillSyncState: vi.fn().mockResolvedValue(0),
+  inspectSyncStatus: vi.fn().mockResolvedValue(null),
+  refreshInstalledSkill: vi
+    .fn()
+    .mockResolvedValue({ installed: {}, syncStatus: null }),
+  isUpstreamManagedSkill: vi.fn().mockReturnValue(true),
+  renameSkillDir: vi.fn().mockResolvedValue("/skills/renamed/SKILL.md"),
+  clearCache: vi.fn(),
+  install: vi.fn(),
+  readProjectConfig: vi.fn().mockResolvedValue(null),
+  writeProjectConfig: vi.fn().mockResolvedValue(undefined),
+  clearProjectConfig: vi.fn().mockResolvedValue(undefined),
+  getThreadSkills: vi.fn().mockResolvedValue(null),
+  setThreadSkills: vi.fn().mockResolvedValue(undefined),
+  clearThreadSkills: vi.fn().mockResolvedValue(undefined),
+  getEnabledSkillsContent: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  confirm: mockConfirm,
+}));
+
+vi.mock("solid-js/store", () => ({
+  createStore: <T extends Record<string, unknown>>(initial: T) => {
+    const state = { ...initial } as Record<string, unknown>;
+    const setState = (key: string, value: unknown) => {
+      state[key] = value;
+    };
+    return [state, setState];
+  },
+}));
+
+vi.mock("@/stores/fileTree", () => ({
+  getFileTreeState: () => ({ rootPath: "/test/project" }),
+  get fileTreeState() {
+    return { rootPath: "/test/project" };
+  },
+}));
+
+vi.mock("@/stores/auth.store", () => ({
+  authStore: { isAuthenticated: true },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/services/skills", () => {
+  class SkillsApiError extends Error {
+    status?: number;
+    constructor(message: string, status?: number) {
+      super(message);
+      this.name = "SkillsApiError";
+      this.status = status;
+    }
+  }
+  return {
+    skills: {
+      fetchAllSkills: mockSkillsService.fetchAllSkills,
+      fetchOwnedSkills: mockSkillsService.fetchOwnedSkills,
+      listAllInstalled: mockSkillsService.listAllInstalled,
+      backfillSyncState: mockSkillsService.backfillSyncState,
+      inspectSyncStatus: mockSkillsService.inspectSyncStatus,
+      refreshInstalledSkill: mockSkillsService.refreshInstalledSkill,
+      renameSkillDir: mockSkillsService.renameSkillDir,
+      clearCache: mockSkillsService.clearCache,
+      install: mockSkillsService.install,
+      readProjectConfig: mockSkillsService.readProjectConfig,
+      writeProjectConfig: mockSkillsService.writeProjectConfig,
+      clearProjectConfig: mockSkillsService.clearProjectConfig,
+      getThreadSkills: mockSkillsService.getThreadSkills,
+      setThreadSkills: mockSkillsService.setThreadSkills,
+      clearThreadSkills: mockSkillsService.clearThreadSkills,
+      getEnabledSkillsContent: mockSkillsService.getEnabledSkillsContent,
+    },
+    isUpstreamManagedSkill: mockSkillsService.isUpstreamManagedSkill,
+    SkillsApiError,
+    isAuthStatus: (status: number | undefined) =>
+      status === 401 || status === 403,
+  };
+});
+
+function installedSkill(slug: string) {
+  return {
+    id: `local:${slug}`,
+    slug,
+    name: slug,
+    description: "",
+    source: "local" as const,
+    tags: [],
+    scope: "seren" as const,
+    skillsDir: "/skills",
+    dirName: slug,
+    path: `/skills/${slug}/SKILL.md`,
+    installedAt: 1,
+    enabled: true,
+    contentHash: "hash",
+  };
+}
+
+function status(overrides: Record<string, unknown>) {
+  return {
+    state: "current",
+    updateAvailable: false,
+    hasLocalChanges: false,
+    syncedRevision: "abc123",
+    remoteRevision: null,
+    changedLocalFiles: [],
+    localManagedState: {},
+    missingManagedFiles: [],
+    ...overrides,
+  };
+}
+
+describe("skillNeedsSync decides whether the composer Sync button shows (#2613)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it.each([
+    ["update-available", { state: "update-available", updateAvailable: true }],
+    ["local edits", { state: "local-changes", hasLocalChanges: true }],
+    ["bootstrap-required", { state: "bootstrap-required" }],
+  ])("returns true for %s", async (_label, overrides) => {
+    const skill = installedSkill("demo");
+    mockSkillsService.inspectSyncStatus.mockResolvedValue(status(overrides));
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.loadSyncStatus(skill);
+
+    expect(skillsStore.skillNeedsSync(skill)).toBe(true);
+  });
+
+  it("returns false for a current skill", async () => {
+    const skill = installedSkill("demo");
+    mockSkillsService.inspectSyncStatus.mockResolvedValue(
+      status({ state: "current" }),
+    );
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.loadSyncStatus(skill);
+
+    expect(skillsStore.skillNeedsSync(skill)).toBe(false);
+  });
+
+  it("returns false when the skill has never been inspected", async () => {
+    const skill = installedSkill("unseen");
+    const { skillsStore } = await import("@/stores/skills.store");
+
+    expect(skillsStore.skillNeedsSync(skill)).toBe(false);
+  });
+
+  it("caches null without a network call for non-upstream skills", async () => {
+    const skill = installedSkill("local-only");
+    mockSkillsService.isUpstreamManagedSkill.mockReturnValue(false);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.loadSyncStatus(skill);
+
+    expect(mockSkillsService.inspectSyncStatus).not.toHaveBeenCalled();
+    expect(skillsStore.skillNeedsSync(skill)).toBe(false);
+  });
+});
+
+describe("syncInstalledSkill gates every overwrite on confirmation (#2613)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockConfirm.mockResolvedValue(true);
+    mockSkillsService.isUpstreamManagedSkill.mockReturnValue(true);
+  });
+
+  it("refreshes after the user confirms, passing the verified baseline", async () => {
+    const skill = installedSkill("demo");
+    const synced = status({ state: "update-available", updateAvailable: true });
+    mockSkillsService.inspectSyncStatus.mockResolvedValue(synced);
+    mockSkillsService.refreshInstalledSkill.mockResolvedValue({
+      installed: skill,
+      syncStatus: status({ state: "current" }),
+    });
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    const result = await skillsStore.syncInstalledSkill(skill);
+
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    expect(mockSkillsService.refreshInstalledSkill).toHaveBeenCalledWith(skill, {
+      expectedLocalManagedState: synced.localManagedState,
+    });
+    expect(result.outcome).toBe("synced");
+  });
+
+  it("does NOT overwrite when the user cancels the confirmation", async () => {
+    const skill = installedSkill("demo");
+    mockSkillsService.inspectSyncStatus.mockResolvedValue(
+      status({ state: "local-changes", hasLocalChanges: true }),
+    );
+    mockConfirm.mockResolvedValue(false);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    const result = await skillsStore.syncInstalledSkill(skill);
+
+    expect(mockSkillsService.refreshInstalledSkill).not.toHaveBeenCalled();
+    expect(result.outcome).toBe("cancelled");
+  });
+
+  it("blocks the sync and reports untracked skills without a refresh", async () => {
+    const skill = installedSkill("demo");
+    mockSkillsService.inspectSyncStatus.mockResolvedValue(null);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    const result = await skillsStore.syncInstalledSkill(skill);
+
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockSkillsService.refreshInstalledSkill).not.toHaveBeenCalled();
+    expect(result.outcome).toBe("untracked");
+  });
+
+  it("blocks the sync when the sync state could not be verified", async () => {
+    const skill = installedSkill("demo");
+    mockSkillsService.inspectSyncStatus.mockResolvedValue(
+      status({ state: "error", error: "boom" }),
+    );
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    const result = await skillsStore.syncInstalledSkill(skill);
+
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockSkillsService.refreshInstalledSkill).not.toHaveBeenCalled();
+    expect(result.outcome).toBe("error");
+  });
+});


### PR DESCRIPTION
## What & why

Closes #2613.

A skill that needs resyncing was only discoverable **inside the Skills catalog drawer** — the yellow badge and the per-row "Refresh from upstream" button live in `SkillsExplorer`. A user chatting with an active skill had no signal it was stale and no way to sync without opening the catalog and hunting for the yellow button. This is especially painful for skills with local edits, which the silent auto-refresh deliberately skips to avoid overwriting.

This adds a yellow **"Sync Skill"** button to the composer toolbar, immediately to the right of the **Skills** button, shown **only** when the chat's active skill needs syncing. Clicking it shows a popup describing what will change, and syncs in place on confirm — no catalog visit required.

## How

- **`skills.store.ts` is now the single source of truth for sync status.** Added a reactive sync-status cache (keyed by skill path) plus `syncStatusFor` / `isSyncLoading` / `skillNeedsSync` / `loadSyncStatus` / `refreshAllSyncStatuses`, and a `syncInstalledSkill(skill)` action that:
  - reuses the cached verdict (re-inspecting only when missing or in `error`),
  - returns `untracked` / `error` outcomes without touching disk,
  - **gates every overwrite on a confirmation popup** whose copy adapts to the verdict (local-edits overwrite warning / update available `X → Y` / first-sync bootstrap / already-current re-download),
  - re-verifies the local baseline (`expectedLocalManagedState`) before writing, and updates the cache on success.
  The background auto-refresh paths (`refresh()`, `toggleThreadSkill`) and `remove()` now keep this cache coherent so the composer button reflects them.
- **`SkillsExplorer` refactored to consume the store** instead of its own component-local `syncStatuses`/`syncLoading` signals and duplicated refresh/confirm logic. Net **−100 lines** there; the two surfaces can no longer drift.
- **New `SyncSkillButton`** composer component (yellow `bg-warning/10 border-warning/40`, spin glyph while syncing) wired into `ChatContent`'s toolbar via the existing `recentSkill` memo. An effect inspects the active skill's status once so the button can appear without opening the catalog; the click syncs exactly the skill the button represents.

## Tests

- New `tests/unit/skills-sync-action.test.ts`: locks down the needs-sync decision (the button's gate) and — critically — that `syncInstalledSkill` **never overwrites without confirmation** (cancel → no refresh), blocks untracked/unverifiable skills, and passes the verified baseline on confirm.
- Full unit suite green (2044 tests), Biome clean, `tsc --noEmit` clean, `vite build` clean.

## Audit notes

- No changes to `src/services/skills.ts` (kept clear of in-flight #2611/#2612 which own that file).
- Composer toolbar edits are in the left group (near Skills), complementary to in-flight #2609's right-group/listener edits.
- Behavior change worth calling out: the catalog's per-row "Refresh from upstream" now also confirms before a clean update/re-download (previously only confirmed on local changes) — consistent with the new single sync gesture.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
