### PR TITLE
fix(recording): hand off stopped recording to active composer (#2614)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -22,6 +22,7 @@ import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { RecordedSessionCard } from "@/components/recording/RecordedSessionCard";
 import { appendRecordingSkillDraftPrompt } from "@/features/recording/recordingComposer";
+import { recordingHandoff } from "@/features/recording/recordingHandoff";
 import { extractAgentThinkingMarkup } from "@/lib/agent-thinking-markup";
 import { isAuthError, isLikelyAuthError } from "@/lib/auth-errors";
 import { collapseBuildOutput } from "@/lib/build-output";
@@ -187,18 +188,16 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       inputRef?.setSelectionRange(len, len);
     });
   };
-  // The screen recorder lives in the titlebar; route its stopped session into
-  // the focused composer. Only the active pane handles the event, and the
-  // _handled flag prevents the sibling composer from double-processing it.
-  const onRecordingSessionStop = (event: Event) => {
-    if (!isPaneActive()) return;
-    const custom = event as CustomEvent<RecordingSession | null> & {
-      _handled?: boolean;
-    };
-    if (custom._handled) return;
-    custom._handled = true;
-    handleRecordingSessionStop(custom.detail);
-  };
+  // The screen recorder lives in the titlebar; it offers a stopped session to
+  // the handoff store. Consume it once this is the active pane (now or when it
+  // next gains focus), then clear so only one composer handles it. This keeps
+  // the skill-draft flow alive even if recording stopped with no chat focused.
+  createEffect(() => {
+    const pending = recordingHandoff.pending;
+    if (!pending || !isPaneActive()) return;
+    recordingHandoff.clear();
+    handleRecordingSessionStop(pending);
+  });
   markdownWorker.onmessage = (
     e: MessageEvent<{ id: string; html: string; error?: boolean }>,
   ) => {
@@ -438,10 +437,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   onMount(() => {
     window.addEventListener("seren:pick-images", onPickImages);
     window.addEventListener("seren:set-chat-input", onSetChatInput);
-    window.addEventListener(
-      "seren:recording-session-stop",
-      onRecordingSessionStop,
-    );
     if (isPaneActive() && fileTreeState.rootPath) {
       void agentStore.refreshRemoteSessions(
         fileTreeState.rootPath,
@@ -452,10 +447,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   onCleanup(() => {
     window.removeEventListener("seren:pick-images", onPickImages);
     window.removeEventListener("seren:set-chat-input", onSetChatInput);
-    window.removeEventListener(
-      "seren:recording-session-stop",
-      onRecordingSessionStop,
-    );
   });
 
   // Resolve the session for the currently-viewed thread, not the global

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -23,6 +23,7 @@ import { SlidePanel } from "@/components/layout/SlidePanel";
 import { RecordedSessionCard } from "@/components/recording/RecordedSessionCard";
 import { DepositModal } from "@/components/wallet/DepositModal";
 import { appendRecordingSkillDraftPrompt } from "@/features/recording/recordingComposer";
+import { recordingHandoff } from "@/features/recording/recordingHandoff";
 import { isAuthError, isContextOverflowError } from "@/lib/auth-errors";
 import {
   formatChatHistoryMarkdown,
@@ -218,18 +219,16 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       inputRef?.setSelectionRange(len, len);
     });
   };
-  // The screen recorder lives in the titlebar; route its stopped session into
-  // the focused composer. Only the active pane handles the event, and the
-  // _handled flag prevents the sibling composer from double-processing it.
-  const onRecordingSessionStop = (event: Event) => {
-    if (!isPaneActive()) return;
-    const custom = event as CustomEvent<RecordingSession | null> & {
-      _handled?: boolean;
-    };
-    if (custom._handled) return;
-    custom._handled = true;
-    handleRecordingSessionStop(custom.detail);
-  };
+  // The screen recorder lives in the titlebar; it offers a stopped session to
+  // the handoff store. Consume it once this is the active pane (now or when it
+  // next gains focus), then clear so only one composer handles it. This keeps
+  // the skill-draft flow alive even if recording stopped with no chat focused.
+  createEffect(() => {
+    const pending = recordingHandoff.pending;
+    if (!pending || !isPaneActive()) return;
+    recordingHandoff.clear();
+    handleRecordingSessionStop(pending);
+  });
   const activeThreadProvider = (): ProviderId => {
     const id = conversationId();
     const selectedProvider = id
@@ -617,10 +616,6 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     // Listen for slash command events
     window.addEventListener("seren:pick-images", handlePickImages);
     window.addEventListener("seren:set-chat-input", handleSetChatInput);
-    window.addEventListener(
-      "seren:recording-session-stop",
-      onRecordingSessionStop,
-    );
     window.addEventListener(RUN_SKILL_EVENT, handleRunSkillEvent);
 
     try {
@@ -675,10 +670,6 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     window.removeEventListener(
       "seren:set-chat-input",
       handleSetChatInput as EventListener,
-    );
-    window.removeEventListener(
-      "seren:recording-session-stop",
-      onRecordingSessionStop,
     );
     window.removeEventListener(RUN_SKILL_EVENT, handleRunSkillEvent);
 

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -7,6 +7,7 @@ import { BalanceDisplay } from "@/components/common/BalanceDisplay";
 import { WorkspaceBar } from "@/components/layout/WorkspaceBar";
 import { RecordPrompt } from "@/components/meeting/RecordPrompt";
 import { desktopRecordingAdapter } from "@/features/recording/desktopRecordingAdapter";
+import { recordingHandoff } from "@/features/recording/recordingHandoff";
 import { authStore } from "@/stores/auth.store";
 import { updaterStore } from "@/stores/updater.store";
 
@@ -176,19 +177,14 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
         </Show>
 
         {/* Screen/workflow recorder lives beside the meeting recorder — both
-            are capture controls. The active composer picks up the stopped
-            session via the seren:recording-session-stop event. */}
+            are capture controls. A stopped session is offered to the handoff
+            store; the active chat composer consumes it when ready, so the
+            skill-draft flow survives stopping with no composer focused. */}
         <RecordButton
           adapter={desktopRecordingAdapter}
           class="relative flex items-center justify-center w-7 h-7 border-none rounded-md bg-transparent text-rec-fg-muted cursor-pointer transition-all duration-100 hover:bg-surface-2 hover:text-foreground active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
           classNames={{ toolbar: "absolute right-0 top-full z-50 mt-1" }}
-          onSessionStop={(session) =>
-            window.dispatchEvent(
-              new CustomEvent("seren:recording-session-stop", {
-                detail: session,
-              }),
-            )
-          }
+          onSessionStop={(session) => recordingHandoff.offer(session)}
         />
 
         <button

--- a/src/components/settings/RecordingsSettings.tsx
+++ b/src/components/settings/RecordingsSettings.tsx
@@ -136,8 +136,8 @@ export function RecordingsSettings() {
             <FilmIcon />
           </span>
           <p class="m-0 text-[12px] text-muted-foreground">
-            No recordings yet. Use the record button in chat to capture a
-            workflow.
+            No recordings yet. Use the record button in the titlebar to capture
+            a workflow.
           </p>
         </div>
       </Show>

--- a/src/features/recording/recordingHandoff.ts
+++ b/src/features/recording/recordingHandoff.ts
@@ -1,0 +1,24 @@
+// ABOUTME: Reactive handoff for a screen recording stopped from the titlebar.
+// ABOUTME: The titlebar offers the session; the active chat composer consumes it.
+
+import type { RecordingSession } from "@seren/recording-core";
+import { createSignal } from "solid-js";
+
+const [pendingSession, setPendingSession] =
+  createSignal<RecordingSession | null>(null);
+
+export const recordingHandoff = {
+  /** The stopped session awaiting a composer, or null. Tracked when read. */
+  get pending(): RecordingSession | null {
+    return pendingSession();
+  },
+  /** Offer a stopped session for the active composer to pick up. */
+  offer(session: RecordingSession | null): void {
+    if (!session) return;
+    setPendingSession(session);
+  },
+  /** Drop the pending session once a composer has taken it. */
+  clear(): void {
+    setPendingSession(null);
+  },
+};

--- a/tests/unit/recording-handoff.test.ts
+++ b/tests/unit/recording-handoff.test.ts
@@ -1,0 +1,43 @@
+// ABOUTME: Contract tests for the titlebar→composer recording handoff store.
+// ABOUTME: Guards #2614 — a stopped session must survive until a composer takes it.
+
+import type { RecordingSession } from "@seren/recording-core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { recordingHandoff } from "@/features/recording/recordingHandoff";
+
+function session(id: string): RecordingSession {
+  return {
+    id,
+    targetKind: "screen",
+    targetLabel: "Workflow recording",
+    startedAtMs: 0,
+    outputDir: "/tmp/rec",
+    maxVideoHeight: 720,
+  };
+}
+
+describe("recordingHandoff (#2614)", () => {
+  beforeEach(() => recordingHandoff.clear());
+
+  it("holds an offered session until it is cleared", () => {
+    expect(recordingHandoff.pending).toBeNull();
+    const stopped = session("a");
+    recordingHandoff.offer(stopped);
+    expect(recordingHandoff.pending).toBe(stopped);
+    recordingHandoff.clear();
+    expect(recordingHandoff.pending).toBeNull();
+  });
+
+  it("ignores a null offer so a no-op stop never sets a phantom session", () => {
+    recordingHandoff.offer(null);
+    expect(recordingHandoff.pending).toBeNull();
+  });
+
+  it("retains the latest offered session, replacing an unconsumed one", () => {
+    const first = session("first");
+    const second = session("second");
+    recordingHandoff.offer(first);
+    recordingHandoff.offer(second);
+    expect(recordingHandoff.pending).toBe(second);
+  });
+});

--- a/tests/unit/recording-packages.test.ts
+++ b/tests/unit/recording-packages.test.ts
@@ -721,11 +721,12 @@ describe("recording packages", () => {
     ).toMatch(/^Existing instruction\n\nCreate a Seren skill draft/);
     expect(recordingComposerSource).toContain("buildRecordingSkillDraftPrompt");
     // The composers still build the draft prompt from a stopped session, but
-    // now receive it over the titlebar's recording-session-stop event rather
-    // than a direct onSessionStop prop. (#2609)
+    // now consume it from the recordingHandoff store when the pane is active
+    // rather than a fire-and-forget window event, so the draft survives
+    // stopping with no chat focused. (#2614)
     for (const composer of [agentChatSource, chatContentSource]) {
       expect(composer).toContain("handleRecordingSessionStop");
-      expect(composer).toContain('"seren:recording-session-stop"');
+      expect(composer).toContain("recordingHandoff.pending");
     }
   });
 
@@ -2389,13 +2390,13 @@ describe("recording packages", () => {
       titlebarSource.indexOf('data-testid="titlebar-meetings-button"'),
     );
 
-    // It must not render in either composer toolbar, and the active composer
-    // receives stopped sessions over the window event instead.
+    // It must not render in either composer toolbar; the titlebar offers the
+    // stopped session to the handoff store and the active composer consumes it.
+    expect(titlebarSource).toContain("recordingHandoff.offer");
     for (const composer of [agentChatSource, chatContentSource]) {
       expect(composer).not.toContain("<RecordButton");
-      expect(composer).toContain("seren:recording-session-stop");
+      expect(composer).toContain("recordingHandoff.pending");
     }
-    expect(titlebarSource).toContain("seren:recording-session-stop");
 
     // The trigger glyph reads as "record video", never the ambiguous dot.
     expect(uiSource).not.toContain('<circle cx="8" cy="8" r="5" />');


### PR DESCRIPTION
Closes #2614. Follow-up to #2609 / #2610.

## Problem (P1 regression introduced by #2609)

Moving the screen recorder into the always-mounted titlebar made it possible to **stop a recording while no chat composer is active** — Catalog/Inbox/Employee/Bounty open (these replace `ThreadContent`), zero open threads, or a focused terminal/editor pane. The titlebar dispatched a fire-and-forget `seren:recording-session-stop` window event that only the composers handled, gated on `isPaneActive()`. With no active composer, the event was dropped: the skill-draft prompt and `RecordedSessionCard` silently never appeared. The video file was still saved, but Settings → Recordings only offers Reveal/Delete, so the skill-generation flow — the feature's whole point — was unrecoverable for that recording.

Found by the post-merge functional walk-through audit of #2609.

## Fix

- **`recordingHandoff` store** (`src/features/recording/recordingHandoff.ts`): a tiny reactive signal holding the stopped session awaiting a composer.
- **Titlebar** offers the stopped session (`recordingHandoff.offer(session)`) instead of firing a window event.
- **Both composers** consume it via a `createEffect`: when there is a pending session **and** this is the active pane (now, or the moment it next gains focus), it takes the session, clears the store (so only one composer handles it), and runs the existing `handleRecordingSessionStop`. Nothing is dropped regardless of view state. The effect is owner-scoped, so the manual `onMount`/`onCleanup` listener registration is gone.
- Fixed the now-stale empty-state copy ("use the record button in chat" → "in the titlebar").

## Why a store, not the event

A `window` CustomEvent is fire-and-forget — if no listener is mounted/active at dispatch time, it is lost. A reactive store retains the session until a composer becomes active, which is exactly the missing guarantee.

## Verification

- New `tests/unit/recording-handoff.test.ts`: store contract — offer/clear, `offer(null)` no-op (guards the no-op-stop path), replace-latest.
- Updated `tests/unit/recording-packages.test.ts` to assert the handoff wiring.
- `tsc --noEmit`: 0 errors. Biome: clean (only pre-existing warnings outside this diff).
- Full unit suite: **2038 passed / 286 files**.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
