### PR TITLE
fix(skills): make skill preview manifest-first (#2617)

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -689,8 +689,11 @@ async function downloadSkillBundleManifest(
   }
   const apiResultFailure = findApiResultFailure(data);
   if (apiResultFailure) {
+    const message = apiResultFailure.message
+      ? ` (${apiResultFailure.message})`
+      : "";
     throw new SkillsApiError(
-      `Failed to download manifest for skill ${slug}: ${apiResultFailure.status}`,
+      `Failed to download manifest for skill ${slug}: ${apiResultFailure.status}${message}`,
       apiResultFailure.status,
     );
   }
@@ -864,23 +867,6 @@ async function downloadSkillBundle(
         manifest.files?.reduce((sum, meta) => sum + meta.size_bytes, 0) ?? 0,
       files,
     };
-  }
-}
-
-/**
- * Bundle metadata for callers that never read file bodies (content
- * preview, sync-state revision checks). On the oversized-bundle fallback
- * this stops at the manifest, so previewing a 50 MiB skill costs one
- * metadata request instead of the full payload fan-out (#2296).
- */
-async function downloadSkillBundleMetadata(
-  slug: string,
-): Promise<SkillBundle | SkillBundleManifest> {
-  try {
-    return await downloadSkillBundleSingleShot(slug);
-  } catch (error) {
-    if (!isOversizedBundleError(error)) throw error;
-    return downloadSkillBundleManifest(slug);
   }
 }
 
@@ -1719,7 +1705,10 @@ export const skills = {
     }
 
     log.info("[Skills] Fetching content for", slug);
-    return (await downloadSkillBundleMetadata(slug)).skill_md;
+    // Preview only needs skill_md, which the manifest carries. Query it
+    // directly so previewing a large skill never pulls the full bundle
+    // (which the metered gateway buffers and rejects with 500). #2617
+    return (await downloadSkillBundleManifest(slug)).skill_md;
   },
 
   /**

--- a/tests/unit/skills-index-api.test.ts
+++ b/tests/unit/skills-index-api.test.ts
@@ -5,11 +5,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockListSkills = vi.hoisted(() => vi.fn());
 const mockDownloadSkill = vi.hoisted(() => vi.fn());
+const mockDownloadSkillManifest = vi.hoisted(() => vi.fn());
 let storage: Map<string, string>;
 
 vi.mock("@/api/seren-skills", () => ({
   createOrgFolder: vi.fn(),
   downloadSkill: mockDownloadSkill,
+  downloadSkillManifest: mockDownloadSkillManifest,
   getAuthorIdentity: vi.fn(),
   getOrgFolder: vi.fn(),
   listSkills: mockListSkills,
@@ -210,7 +212,7 @@ describe("skills.fetchIndex via Seren Skills API", () => {
   });
 });
 
-describe("skills.fetchContent via downloadSkillBundle", () => {
+describe("skills.fetchContent via downloadSkillBundleManifest", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
@@ -228,7 +230,7 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
   }
 
   it("unwraps a bundle response wrapped in nested data envelopes", async () => {
-    mockDownloadSkill.mockResolvedValueOnce({
+    mockDownloadSkillManifest.mockResolvedValueOnce({
       data: { data: { data: bundle("alpha") } },
     });
 
@@ -247,7 +249,7 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
   });
 
   it("returns the bundle markdown when the response is unwrapped", async () => {
-    mockDownloadSkill.mockResolvedValueOnce({ data: bundle("beta") });
+    mockDownloadSkillManifest.mockResolvedValueOnce({ data: bundle("beta") });
 
     const { skills } = await import("@/services/skills");
     const content = await skills.fetchContent({
@@ -264,7 +266,7 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
   });
 
   it("throws when the bundle response cannot be normalized", async () => {
-    mockDownloadSkill.mockResolvedValueOnce({
+    mockDownloadSkillManifest.mockResolvedValueOnce({
       data: { content_hash: "abc" },
     });
 
@@ -279,7 +281,7 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
         sourceUrl: "seren-skills:gamma",
         tags: [],
       }),
-    ).rejects.toThrow("Unexpected seren-skills bundle response for gamma");
+    ).rejects.toThrow("Unexpected seren-skills manifest response for gamma");
   });
 
   it("includes inner envelope keys when a wrapped bundle response cannot be normalized", async () => {
@@ -287,7 +289,7 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
     // and the inner envelope is missing the bundle fields. The error must
     // surface BOTH outer and inner keys so we can root-cause without
     // redeploying the desktop client.
-    mockDownloadSkill.mockResolvedValueOnce({
+    mockDownloadSkillManifest.mockResolvedValueOnce({
       data: { data: { content_hash: "abc" } },
     });
 
@@ -306,7 +308,7 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
   });
 
   it("surfaces server error envelopes when the bundle body carries an error payload", async () => {
-    mockDownloadSkill.mockResolvedValueOnce({
+    mockDownloadSkillManifest.mockResolvedValueOnce({
       data: {
         data: {
           body: {
@@ -331,7 +333,7 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
   });
 
   it("treats publisher ApiResultResponse failures as failed downloads", async () => {
-    mockDownloadSkill.mockResolvedValueOnce({
+    mockDownloadSkillManifest.mockResolvedValueOnce({
       data: {
         data: {
           status: 404,
@@ -356,12 +358,12 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
         tags: [],
       }),
     ).rejects.toThrow(
-      "Failed to download skill curve-gauge-yield-trader: 404 (skill not found)",
+      "Failed to download manifest for skill curve-gauge-yield-trader: 404 (skill not found)",
     );
   });
 
   it("throws when the API returns an error", async () => {
-    mockDownloadSkill.mockResolvedValueOnce({
+    mockDownloadSkillManifest.mockResolvedValueOnce({
       error: { message: "not found" },
       response: { status: 404 },
     });
@@ -377,6 +379,6 @@ describe("skills.fetchContent via downloadSkillBundle", () => {
         sourceUrl: "seren-skills:delta",
         tags: [],
       }),
-    ).rejects.toThrow("Failed to download skill delta: 404");
+    ).rejects.toThrow("Failed to download manifest for skill delta: 404");
   });
 });

--- a/tests/unit/skills-split-download.test.ts
+++ b/tests/unit/skills-split-download.test.ts
@@ -233,7 +233,9 @@ describe("split-download fallback (#2296)", () => {
       response: { status: 403 },
     });
 
-    await expect(skills.fetchContent(catalogSkill)).rejects.toThrow(/403/);
+    await expect(
+      skills.install(catalogSkill, "", "seren", null),
+    ).rejects.toThrow(/403/);
     expect(mockDownloadSkillManifest).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Closes #2617.

## Problem
`skills.fetchContent` (skill markdown preview for a not-yet-installed catalog skill) fetched `skill_md` via `downloadSkillBundleMetadata`, which went single-shot-first. For an oversized skill (`glide-affinity-proposals`, 78 MB of PPTX templates) this pulled the full bundle, the metered gateway rejected it with 500, and only then fell back to the 22 KB manifest. The manifest already carries `skill_md`.

This completes the manifest-first work from #2611/#2612, which scoped the revision-check path but deliberately left `fetchContent` out.

## Changes (`src/services/skills.ts`)
- `fetchContent` queries `downloadSkillBundleManifest` directly; removed the now single-caller `downloadSkillBundleMetadata` wrapper.
- The **install** path (`downloadSkillBundle`) keeps single-shot-first + the oversized-500 split-download fallback (#2296) unchanged.
- Manifest download error now includes the publisher error message, matching the single-shot path.

## Impact
No skill path pulls the full bundle just to read metadata. Verified during the #2612 audit that `/download` and `/download/manifest` return an identical `content_hash`, so preview/normalization behavior is unchanged.

## Tests (critical only)
- `skills-index-api.test.ts`: the fetchContent block now drives the manifest endpoint (envelope-unwrap + error-normalization coverage preserved; error messages updated to the manifest path).
- `skills-split-download.test.ts`: the "does not fall back on non-500" #2296 contract test re-pointed to the **install** path, which still implements single-shot-first + 500-only split.
- Full suite green (2048 tests); `tsc` clean; Biome clean on `src/`.
