### PR TITLE
fix(meeting): recover Me track on mid-capture mic disconnect (#2608)

### DIFF
--- a/src-tauri/src/audio/capture/mic.rs
+++ b/src-tauri/src/audio/capture/mic.rs
@@ -201,10 +201,17 @@ fn acquire_stream(sink: &FrameSender) -> Result<LiveStream, CaptureError> {
 /// Re-acquire the default input device after a mid-capture loss, retrying with
 /// capped backoff until a device returns or a stop is requested. `None` means
 /// the capture was stopped before recovery.
+///
+/// The settle delay runs *before* every acquire attempt (including the first):
+/// a device that just dropped is often not immediately re-openable, and an
+/// always-on floor caps how fast a flapping device — one that builds and plays
+/// but re-fails within milliseconds — can churn rebuilds and inflate the
+/// disconnect count. A 250 ms first-recovery delay is imperceptible against a
+/// real reconnect, which takes seconds.
 fn recover_stream(stop: &AtomicBool, sink: &FrameSender) -> Option<LiveStream> {
     let mut backoff = RECOVERY_BACKOFF_START;
     loop {
-        if stop.load(Ordering::SeqCst) {
+        if !sleep_until_stop(stop, backoff) {
             return None;
         }
         match acquire_stream(sink) {
@@ -214,9 +221,6 @@ fn recover_stream(stop: &AtomicBool, sink: &FrameSender) -> Option<LiveStream> {
                     "[meeting] native mic re-acquire failed ({err}); retrying in {backoff:?}"
                 );
             }
-        }
-        if !sleep_until_stop(stop, backoff) {
-            return None;
         }
         backoff = (backoff * 2).min(RECOVERY_BACKOFF_MAX);
     }

--- a/src-tauri/src/audio/capture/mic.rs
+++ b/src-tauri/src/audio/capture/mic.rs
@@ -1,5 +1,5 @@
 // ABOUTME: CPAL-backed native microphone source for Meeting Mode's Me stream.
-// ABOUTME: Owns the platform stream on a worker thread and emits 16 kHz mono PCM.
+// ABOUTME: Owns the platform stream on a worker thread; self-heals on device loss.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -11,15 +11,22 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{ErrorKind, Sample, SampleFormat, StreamConfig};
 
 use super::{
-    AudioCaptureSource, CaptureError, FrameSender, PcmFrame, spawn_with_readiness, to_mono_16k,
+    AudioCaptureSource, CaptureError, FrameSender, MicHealth, PcmFrame, spawn_with_readiness,
+    to_mono_16k,
 };
 
 const IDLE_SLEEP: Duration = Duration::from_millis(50);
+/// First re-acquire delay after a mid-capture loss; doubles up to the cap.
+const RECOVERY_BACKOFF_START: Duration = Duration::from_millis(250);
+/// Ceiling on the re-acquire backoff so a permanently-gone device is retried at
+/// a steady, cheap cadence (the device may return at any time) until stop.
+const RECOVERY_BACKOFF_MAX: Duration = Duration::from_secs(2);
 
 /// Captures the default input device so Meeting Mode no longer depends on
 /// renderer-owned WebAudio frames for the local speaker ("Me").
 pub struct CpalMicSource {
     stop_flag: Arc<AtomicBool>,
+    health: Arc<MicHealth>,
     handle: Option<JoinHandle<()>>,
 }
 
@@ -27,6 +34,7 @@ impl CpalMicSource {
     pub fn new() -> Self {
         Self {
             stop_flag: Arc::new(AtomicBool::new(false)),
+            health: Arc::new(MicHealth::default()),
             handle: None,
         }
     }
@@ -42,8 +50,9 @@ impl AudioCaptureSource for CpalMicSource {
     fn start(&mut self, sink: FrameSender) -> Result<(), CaptureError> {
         self.stop_flag.store(false, Ordering::SeqCst);
         let stop = self.stop_flag.clone();
+        let health = self.health.clone();
         let handle = spawn_with_readiness(move |ready| {
-            run_input(&stop, sink, &ready);
+            run_input(&stop, sink, &health, &ready);
         })?;
         self.handle = Some(handle);
         Ok(())
@@ -55,6 +64,10 @@ impl AudioCaptureSource for CpalMicSource {
             let _ = handle.join();
         }
     }
+
+    fn mic_health(&self) -> Option<Arc<MicHealth>> {
+        Some(self.health.clone())
+    }
 }
 
 impl Drop for CpalMicSource {
@@ -63,22 +76,81 @@ impl Drop for CpalMicSource {
     }
 }
 
-fn run_input(stop: &AtomicBool, sink: FrameSender, ready: &SyncSender<Result<(), CaptureError>>) {
+/// A built, playing cpal input stream paired with the flag its error callback
+/// flips when the device dies. `run_input` polls `lost()` to drive recovery.
+struct LiveStream {
+    // Held to keep the platform stream playing; dropped to tear it down.
+    _stream: cpal::Stream,
+    lost: Arc<AtomicBool>,
+}
+
+impl LiveStream {
+    fn lost(&self) -> bool {
+        self.lost.load(Ordering::SeqCst)
+    }
+}
+
+/// Capture the default input device, re-acquiring it whenever the live stream is
+/// lost mid-capture (Bluetooth/USB drop, default-device switch) so the "Me"
+/// track self-heals instead of silently freezing for the rest of the meeting.
+fn run_input(
+    stop: &AtomicBool,
+    sink: FrameSender,
+    health: &MicHealth,
+    ready: &SyncSender<Result<(), CaptureError>>,
+) {
+    // The first acquisition is the readiness verdict. A startup failure is
+    // terminal and propagates so the UI surfaces the real permission/device
+    // cause rather than recording silence; recovery only covers *mid-capture*
+    // loss after a stream was once live.
+    let mut stream = match acquire_stream(&sink) {
+        Ok(stream) => stream,
+        Err(err) => {
+            let _ = ready.send(Err(err));
+            return;
+        }
+    };
+    health.mark_live();
+    let _ = ready.send(Ok(()));
+
+    loop {
+        // Hold the live stream until a stop is requested or the device drops.
+        while !stop.load(Ordering::SeqCst) && !stream.lost() {
+            std::thread::sleep(IDLE_SLEEP);
+        }
+        if stop.load(Ordering::SeqCst) {
+            return; // stream drops at scope end
+        }
+        // Mid-capture device loss. Surface it, tear the dead stream down, and
+        // self-heal onto whatever input device is now default (#2608).
+        let count = health.mark_lost();
+        log::warn!(
+            "[meeting] native mic lost mid-capture (disconnect #{count}); re-acquiring input device"
+        );
+        drop(stream);
+        match recover_stream(stop, &sink) {
+            Some(fresh) => {
+                health.mark_live();
+                log::info!("[meeting] native mic re-acquired after disconnect #{count}");
+                stream = fresh;
+            }
+            None => return, // stop requested before a device came back
+        }
+    }
+}
+
+/// Open the current default input device and start delivering frames into `sink`.
+fn acquire_stream(sink: &FrameSender) -> Result<LiveStream, CaptureError> {
     let host = cpal::default_host();
     let Some(device) = host.default_input_device() else {
-        let _ = ready.send(Err(CaptureError::Device(
+        return Err(CaptureError::Device(
             "no default input device is available".to_string(),
-        )));
-        return;
+        ));
     };
     let supported = match device.default_input_config() {
         Ok(config) => config,
         Err(err) => {
-            let _ = ready.send(Err(map_cpal_error(
-                "default input config unavailable",
-                &err,
-            )));
-            return;
+            return Err(map_cpal_error("default input config unavailable", &err));
         }
     };
     let sample_format = supported.sample_format();
@@ -86,32 +158,90 @@ fn run_input(stop: &AtomicBool, sink: FrameSender, ready: &SyncSender<Result<(),
     let sample_rate = supported.sample_rate();
     let config: StreamConfig = supported.into();
 
+    let lost = Arc::new(AtomicBool::new(false));
     let stream = match sample_format {
-        SampleFormat::F32 => build_stream::<f32>(&device, &config, channels, sample_rate, sink),
-        SampleFormat::I16 => build_stream::<i16>(&device, &config, channels, sample_rate, sink),
-        SampleFormat::U16 => build_stream::<u16>(&device, &config, channels, sample_rate, sink),
+        SampleFormat::F32 => build_stream::<f32>(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            sink.clone(),
+            lost.clone(),
+        ),
+        SampleFormat::I16 => build_stream::<i16>(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            sink.clone(),
+            lost.clone(),
+        ),
+        SampleFormat::U16 => build_stream::<u16>(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            sink.clone(),
+            lost.clone(),
+        ),
         other => Err(CaptureError::Unsupported(format!(
             "default input sample format {other} is not supported"
         ))),
-    };
-    let stream = match stream {
-        Ok(stream) => stream,
-        Err(err) => {
-            let _ = ready.send(Err(err));
-            return;
-        }
-    };
+    }?;
 
     if let Err(err) = stream.play() {
-        let _ = ready.send(Err(map_cpal_error("input stream could not start", &err)));
-        return;
+        return Err(map_cpal_error("input stream could not start", &err));
     }
+    Ok(LiveStream {
+        _stream: stream,
+        lost,
+    })
+}
 
-    let _ = ready.send(Ok(()));
-    while !stop.load(Ordering::SeqCst) {
-        std::thread::sleep(IDLE_SLEEP);
+/// Re-acquire the default input device after a mid-capture loss, retrying with
+/// capped backoff until a device returns or a stop is requested. `None` means
+/// the capture was stopped before recovery.
+fn recover_stream(stop: &AtomicBool, sink: &FrameSender) -> Option<LiveStream> {
+    let mut backoff = RECOVERY_BACKOFF_START;
+    loop {
+        if stop.load(Ordering::SeqCst) {
+            return None;
+        }
+        match acquire_stream(sink) {
+            Ok(stream) => return Some(stream),
+            Err(err) => {
+                log::debug!(
+                    "[meeting] native mic re-acquire failed ({err}); retrying in {backoff:?}"
+                );
+            }
+        }
+        if !sleep_until_stop(stop, backoff) {
+            return None;
+        }
+        backoff = (backoff * 2).min(RECOVERY_BACKOFF_MAX);
     }
-    drop(stream);
+}
+
+/// Sleep up to `dur` in short increments, returning `false` as soon as a stop is
+/// requested so a stopping capture never waits a full backoff to exit.
+fn sleep_until_stop(stop: &AtomicBool, dur: Duration) -> bool {
+    let mut waited = Duration::ZERO;
+    while waited < dur {
+        if stop.load(Ordering::SeqCst) {
+            return false;
+        }
+        let step = IDLE_SLEEP.min(dur - waited);
+        std::thread::sleep(step);
+        waited += step;
+    }
+    !stop.load(Ordering::SeqCst)
+}
+
+/// Whether a cpal stream error means the stream is dead and must be rebuilt. A
+/// `DeviceChanged` reroute leaves the current stream live, so it is not fatal;
+/// every other error (device gone, config invalidated) requires re-acquisition.
+fn is_fatal_stream_error(kind: ErrorKind) -> bool {
+    kind != ErrorKind::DeviceChanged
 }
 
 fn build_stream<T>(
@@ -120,13 +250,19 @@ fn build_stream<T>(
     channels: u16,
     sample_rate: u32,
     sink: FrameSender,
+    lost: Arc<AtomicBool>,
 ) -> Result<cpal::Stream, CaptureError>
 where
     T: cpal::Sample + cpal::SizedSample + Copy + Send + 'static,
     i16: cpal::FromSample<T>,
 {
-    let err_fn = |err| {
-        log::warn!("[meeting] native mic stream error: {err}");
+    let err_fn = move |err: cpal::Error| {
+        if is_fatal_stream_error(err.kind()) {
+            log::warn!("[meeting] native mic stream error: {err}");
+            lost.store(true, Ordering::SeqCst);
+        } else {
+            log::info!("[meeting] native mic route changed; staying on current stream: {err}");
+        }
     };
     device
         .build_input_stream(
@@ -212,5 +348,22 @@ mod tests {
             map_cpal_error("open mic", &err),
             CaptureError::Unsupported(_)
         ));
+    }
+
+    #[test]
+    fn only_device_changed_reroute_keeps_the_stream_alive() {
+        // A reroute must NOT tear down the live stream, but a real disconnect or
+        // an invalidated config must trigger re-acquisition (#2608).
+        assert!(!is_fatal_stream_error(ErrorKind::DeviceChanged));
+        assert!(is_fatal_stream_error(ErrorKind::DeviceNotAvailable));
+        assert!(is_fatal_stream_error(ErrorKind::StreamInvalidated));
+    }
+
+    #[test]
+    fn sleep_until_stop_returns_immediately_when_already_stopped() {
+        // Recovery backoff must not delay a stopping capture: an already-set stop
+        // flag returns false without sleeping the full duration.
+        let stop = AtomicBool::new(true);
+        assert!(!sleep_until_stop(&stop, Duration::from_secs(30)));
     }
 }

--- a/src-tauri/src/audio/capture/mod.rs
+++ b/src-tauri/src/audio/capture/mod.rs
@@ -12,6 +12,8 @@ pub mod macos;
 #[cfg(target_os = "windows")]
 pub mod windows;
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::SyncSender;
 use std::thread::JoinHandle;
 
@@ -40,6 +42,42 @@ pub enum CaptureError {
     Unsupported(String),
 }
 
+/// Live health of a native microphone capture, shared between the capture
+/// worker thread (the sole writer) and the pipeline (a reader). The worker
+/// flips `live` as the underlying device stream is lost and re-acquired
+/// mid-capture and bumps `disconnect_count` on every loss, so the pipeline can
+/// surface a user-visible notice and a truthful stop summary instead of the
+/// silent partial-loss the static start-time readiness flag produced (#2608).
+#[derive(Debug, Default)]
+pub struct MicHealth {
+    live: AtomicBool,
+    disconnect_count: AtomicU64,
+}
+
+impl MicHealth {
+    /// Whether the mic stream is currently delivering frames.
+    pub fn is_live(&self) -> bool {
+        self.live.load(Ordering::SeqCst)
+    }
+
+    /// Number of mid-capture disconnects observed so far.
+    pub fn disconnect_count(&self) -> u64 {
+        self.disconnect_count.load(Ordering::SeqCst)
+    }
+
+    /// Worker-only: mark the stream live (initial acquire or post-recovery).
+    pub(crate) fn mark_live(&self) {
+        self.live.store(true, Ordering::SeqCst);
+    }
+
+    /// Worker-only: mark the stream lost and count the disconnect, returning the
+    /// new disconnect count for logging.
+    pub(crate) fn mark_lost(&self) -> u64 {
+        self.live.store(false, Ordering::SeqCst);
+        self.disconnect_count.fetch_add(1, Ordering::SeqCst) + 1
+    }
+}
+
 /// A single capture stream (mic, system audio, …) normalized to 16 kHz mono PCM.
 ///
 /// `start` begins delivering frames into `sink` and returns once capture is live;
@@ -49,6 +87,14 @@ pub enum CaptureError {
 pub trait AudioCaptureSource: Send {
     fn start(&mut self, sink: FrameSender) -> Result<(), CaptureError>;
     fn stop(&mut self);
+
+    /// The live health handle for a native microphone source, or `None` for
+    /// sources that don't track mid-capture device loss (system audio, fakes).
+    /// Lets the pipeline watch for disconnect/recovery without the capture layer
+    /// depending on Tauri (#2608).
+    fn mic_health(&self) -> Option<Arc<MicHealth>> {
+        None
+    }
 }
 
 /// Spawn `worker` on a dedicated OS thread and block until it reports readiness.
@@ -169,6 +215,26 @@ mod tests {
         let err = spawn_with_readiness(|_ready| {})
             .expect_err("a silent worker exit must surface as an error");
         assert!(matches!(err, CaptureError::Device(_)));
+    }
+
+    #[test]
+    fn mic_health_tracks_liveness_and_disconnect_count() {
+        // The stop summary's truthfulness and the disconnect notice both read
+        // this handle, so its transitions are the contract under test (#2608).
+        let health = MicHealth::default();
+        assert!(!health.is_live());
+        assert_eq!(health.disconnect_count(), 0);
+
+        health.mark_live();
+        assert!(health.is_live());
+
+        assert_eq!(health.mark_lost(), 1);
+        assert!(!health.is_live());
+
+        health.mark_live();
+        assert_eq!(health.mark_lost(), 2);
+        assert_eq!(health.disconnect_count(), 2);
+        assert!(!health.is_live());
     }
 
     #[test]

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -15,7 +15,9 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use uuid::Uuid;
 
 use crate::audio::apm::{ApmDiagnostics, MeetingAudioProcessor};
-use crate::audio::capture::{AudioCaptureSource, CaptureError, PcmFrame, TARGET_SAMPLE_RATE};
+use crate::audio::capture::{
+    AudioCaptureSource, CaptureError, MicHealth, PcmFrame, TARGET_SAMPLE_RATE,
+};
 use crate::audio::chunker::{Chunk, ChunkCfg, StreamingChunker};
 use crate::audio::transcribe::{
     ChunkTranscriber, GatewayTranscriber, RetryConfig, TranscribeError, TranscriptionMode,
@@ -42,6 +44,11 @@ const MAX_THEM_BUFFER_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 60 * 90;
 pub struct CaptureStopSummary {
     pub had_capture: bool,
     pub native_mic_ready: bool,
+    /// Mid-capture mic disconnects observed during the capture. `0` is the
+    /// healthy case; any positive count means the "Me" track briefly dropped and
+    /// self-healed (or was still down at stop, in which case `native_mic_ready`
+    /// is also false) — surfaced so partial loss is never silent (#2608).
+    pub native_mic_disconnect_count: u64,
     pub system_audio_ready: bool,
     pub apm_ready: bool,
     pub apm_active: bool,
@@ -157,12 +164,14 @@ impl CaptureStreamStats {
         ingress: CaptureIngressSummary,
         source: &CaptureSourceStats,
         native_mic_ready: bool,
+        native_mic_disconnect_count: u64,
         system_audio_ready: bool,
         apm: ApmDiagnostics,
     ) -> CaptureStopSummary {
         CaptureStopSummary {
             had_capture,
             native_mic_ready,
+            native_mic_disconnect_count,
             system_audio_ready,
             apm_ready: apm.initialized,
             apm_active: apm.active,
@@ -380,6 +389,50 @@ pub struct CaptureLevelEvent {
     pub level: f32,
 }
 
+/// How often the mic-health watcher samples liveness. Fast enough that a real
+/// disconnect surfaces a banner promptly without busy-spinning.
+const MIC_HEALTH_POLL: Duration = Duration::from_millis(250);
+
+/// Notice that the native mic dropped or self-healed mid-capture. The UI turns
+/// `disconnected` into a "microphone disconnected — reconnecting…" banner and
+/// clears it on `recovered`, so a Bluetooth/USB drop is never silent (#2608).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MicStatusEvent {
+    meeting_id: String,
+    status: &'static str,
+    disconnect_count: u64,
+}
+
+/// Poll the shared mic health on a short interval and emit `meeting://mic-status`
+/// on each live/lost transition. Spawned only when a real mic source and an app
+/// handle exist; `stop` aborts it, and it owns no resources so an abort needs no
+/// cleanup (#2608).
+async fn watch_mic_health(app: AppHandle, meeting_id: String, health: Arc<MicHealth>) {
+    let mut last_live = health.is_live();
+    loop {
+        tokio::time::sleep(MIC_HEALTH_POLL).await;
+        let live = health.is_live();
+        if live == last_live {
+            continue;
+        }
+        last_live = live;
+        let status = if live { "recovered" } else { "disconnected" };
+        let disconnect_count = health.disconnect_count();
+        log::info!(
+            "[meeting] native mic {status} mid-capture for {meeting_id} (disconnects={disconnect_count})"
+        );
+        let _ = app.emit(
+            "meeting://mic-status",
+            MicStatusEvent {
+                meeting_id: meeting_id.clone(),
+                status,
+                disconnect_count,
+            },
+        );
+    }
+}
+
 enum ApmInput {
     Capture(PcmFrame),
     Render(PcmFrame),
@@ -504,7 +557,14 @@ struct ActiveCapture {
     source_stats: Arc<CaptureSourceStats>,
     apm_diagnostics: Arc<StdMutex<ApmDiagnostics>>,
     e2e_injection_enabled: bool,
+    // Whether a native mic source was established at start. Combined with
+    // `mic_health` at stop to decide the summary's `native_mic_ready` (#2608).
     native_mic_ready: bool,
+    // Live health of the native mic, present only for the real cpal source.
+    // `None` for fake/test sources, which have no mid-capture loss tracking.
+    mic_health: Option<Arc<MicHealth>>,
+    // The mic-health watcher task, aborted by `stop` before the drain.
+    mic_health_watcher: Option<JoinHandle<()>>,
     system_audio_ready: bool,
 }
 
@@ -731,6 +791,20 @@ impl CaptureRegistry {
         };
         let has_mic = prepared_mic.has_mic();
 
+        // The real cpal mic exposes a live health handle; fake/test sources don't.
+        // Watch it for mid-capture disconnect/recovery and surface a user notice
+        // (#2608). Spawned before `app` is moved into the APM stream below.
+        let mic_health = prepared_mic
+            .source
+            .as_ref()
+            .and_then(|source| source.mic_health());
+        let mic_health_watcher = match (app.clone(), mic_health.clone()) {
+            (Some(app_handle), Some(health)) => Some(tauri::async_runtime::spawn(
+                watch_mic_health(app_handle, meeting_id.to_string(), health),
+            )),
+            _ => None,
+        };
+
         // Me and Them share one sequence counter so segments order globally.
         let seq = Arc::new(AtomicI64::new(0));
         let stats = Arc::new(CaptureStreamStats::default());
@@ -824,6 +898,8 @@ impl CaptureRegistry {
                     apm_diagnostics,
                     e2e_injection_enabled,
                     native_mic_ready: has_mic,
+                    mic_health: mic_health.clone(),
+                    mic_health_watcher,
                     system_audio_ready: has_system_audio,
                 }),
             );
@@ -847,6 +923,8 @@ impl CaptureRegistry {
                 apm_diagnostics,
                 e2e_injection_enabled: false,
                 native_mic_ready: has_mic,
+                mic_health,
+                mic_health_watcher,
                 system_audio_ready: has_system_audio,
             }),
         );
@@ -1009,10 +1087,15 @@ impl CaptureRegistry {
                 ingress,
                 &CaptureSourceStats::default(),
                 false,
+                0,
                 false,
                 ApmDiagnostics::default(),
             );
         };
+        // Stop the disconnect watcher first so it can't emit a notice mid-drain.
+        if let Some(watcher) = capture.mic_health_watcher.take() {
+            watcher.abort();
+        }
         // Stop native sources first so their channels close and routers can exit.
         if let Some(mut source) = capture.mic_source.take() {
             let join = tauri::async_runtime::spawn_blocking(move || source.stop());
@@ -1035,17 +1118,30 @@ impl CaptureRegistry {
         }
         let ingress = self.take_ingress_summary(meeting_id);
         let apm = capture.apm_diagnostics.lock().unwrap().clone();
+        // A real mic source reports `native_mic_ready` as established-AND-still-live
+        // at stop, so a disconnect that never recovered reads false instead of the
+        // frozen-but-"ready" summary this used to produce. Sources without health
+        // (fakes) keep the established flag. `disconnect_count` surfaces a recovered
+        // drop too (#2608).
+        let native_mic_live = capture.mic_health.as_ref().map_or(true, |h| h.is_live());
+        let native_mic_ready = capture.native_mic_ready && native_mic_live;
+        let native_mic_disconnect_count = capture
+            .mic_health
+            .as_ref()
+            .map_or(0, |h| h.disconnect_count());
         let summary = capture.stats.summary(
             true,
             ingress,
             capture.source_stats.as_ref(),
-            capture.native_mic_ready,
+            native_mic_ready,
+            native_mic_disconnect_count,
             capture.system_audio_ready,
             apm,
         );
         log::info!(
-            "[meeting] capture stop summary for {meeting_id}: native_mic_ready={} system_audio_ready={} apm_ready={} mic_source_frames={} system_source_frames={} push_frames={} accepted_push_frames={} dropped_push_frames={} dropped_push_samples={} frames={} speech_frames={} chunks={} emitted_segments={} emitted_gaps={} transcription_error={:?}",
+            "[meeting] capture stop summary for {meeting_id}: native_mic_ready={} native_mic_disconnects={} system_audio_ready={} apm_ready={} mic_source_frames={} system_source_frames={} push_frames={} accepted_push_frames={} dropped_push_frames={} dropped_push_samples={} frames={} speech_frames={} chunks={} emitted_segments={} emitted_gaps={} transcription_error={:?}",
             summary.native_mic_ready,
+            summary.native_mic_disconnect_count,
             summary.system_audio_ready,
             summary.apm_ready,
             summary.native_mic_frame_count,
@@ -1172,6 +1268,8 @@ mod tests {
             apm_diagnostics: Arc::new(StdMutex::new(ApmDiagnostics::default())),
             e2e_injection_enabled: false,
             native_mic_ready: true,
+            mic_health: None,
+            mic_health_watcher: None,
             system_audio_ready: false,
         }
     }
@@ -1271,6 +1369,7 @@ mod tests {
             CaptureIngressSummary::default(),
             &CaptureSourceStats::default(),
             true,
+            0,
             false,
             ApmDiagnostics::default(),
         );
@@ -1297,6 +1396,7 @@ mod tests {
             CaptureIngressSummary::default(),
             &CaptureSourceStats::default(),
             true,
+            0,
             false,
             ApmDiagnostics::default(),
         );
@@ -1310,6 +1410,7 @@ mod tests {
             CaptureIngressSummary::default(),
             &CaptureSourceStats::default(),
             true,
+            0,
             false,
             ApmDiagnostics::default(),
         );
@@ -1604,6 +1705,74 @@ mod tests {
         }
 
         fn stop(&mut self) {}
+    }
+
+    /// A mic source that started, dropped mid-capture, and never recovered.
+    /// Exposes a `MicHealth` seeded as lost-with-one-disconnect so the pipeline's
+    /// health-aware stop summary can be exercised without real hardware (#2608).
+    struct LostMicSource {
+        health: Arc<MicHealth>,
+    }
+
+    impl LostMicSource {
+        fn still_disconnected() -> Self {
+            let health = Arc::new(MicHealth::default());
+            health.mark_live();
+            health.mark_lost();
+            Self { health }
+        }
+    }
+
+    impl AudioCaptureSource for LostMicSource {
+        fn start(&mut self, _sink: FrameSender) -> Result<(), CaptureError> {
+            // Dropping the sink ends the (empty) mic stream at once; the test only
+            // exercises how health flows into the stop summary.
+            Ok(())
+        }
+
+        fn stop(&mut self) {}
+
+        fn mic_health(&self) -> Option<Arc<MicHealth>> {
+            Some(self.health.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_summary_reports_a_still_disconnected_mic_as_not_ready() {
+        // #2608: a mic that dropped mid-capture and never came back must read
+        // native_mic_ready=false with a disconnect count, not the frozen-but-
+        // "ready" summary that told the user nothing.
+        let registry = CaptureRegistry::default();
+        let me_transcriber: Arc<dyn ChunkTranscriber + Send + Sync> =
+            Arc::new(SequenceTranscriber {
+                texts: Mutex::new(vec![]),
+            });
+        let them_transcriber: Arc<dyn ChunkTranscriber + Send + Sync> =
+            Arc::new(SequenceTranscriber {
+                texts: Mutex::new(vec![]),
+            });
+        let sink = Arc::new(CollectingSink::default());
+        let collected: Arc<dyn SegmentSink> = sink.clone();
+
+        registry
+            .start_with_sources(
+                None,
+                "m1",
+                Some(Box::new(LostMicSource::still_disconnected())),
+                None,
+                me_transcriber,
+                them_transcriber,
+                collected,
+            )
+            .expect("a mic source that starts should make the capture active");
+
+        let summary = registry
+            .stop_with_timeout("m1", Duration::from_secs(1))
+            .await;
+
+        assert!(summary.had_capture);
+        assert!(!summary.native_mic_ready);
+        assert_eq!(summary.native_mic_disconnect_count, 1);
     }
 
     #[test]

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -593,6 +593,7 @@ pub async fn stop_meeting_capture(
     let outcome = StopMeetingCaptureOutcome {
         had_capture: summary.had_capture,
         native_mic_ready: summary.native_mic_ready,
+        native_mic_disconnect_count: summary.native_mic_disconnect_count,
         system_audio_ready: summary.system_audio_ready,
         apm_ready: summary.apm_ready,
         apm_active: summary.apm_active,
@@ -710,6 +711,10 @@ fn e2e_capture_probe_frames() -> Vec<Vec<i16>> {
 pub struct StopMeetingCaptureOutcome {
     pub had_capture: bool,
     pub native_mic_ready: bool,
+    /// Mid-capture mic disconnects during this capture (#2608). `0` is healthy;
+    /// any positive value means the "Me" track briefly dropped and self-healed
+    /// (or stayed down at stop, where `native_mic_ready` is also false).
+    pub native_mic_disconnect_count: u64,
     pub system_audio_ready: bool,
     pub apm_ready: bool,
     pub apm_active: bool,
@@ -764,6 +769,7 @@ fn capture_stop_diagnostics_json(
         "rendererPushPath": "disabled",
         "hadCapture": summary.had_capture,
         "nativeMicReady": summary.native_mic_ready,
+        "nativeMicDisconnectCount": summary.native_mic_disconnect_count,
         "systemAudioReady": summary.system_audio_ready,
         "apmReady": summary.apm_ready,
         "apmActive": summary.apm_active,

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -257,6 +257,14 @@ export function MeetingPanel() {
             </div>
           )}
         </Show>
+        {/* Mid-capture mic loss: the backend is re-acquiring; surface it so the
+            user knows their side isn't recording right now (#2608). */}
+        <Show when={activeCapture() && meetingStore.state.micCaptureLost}>
+          <div class="mt-2 flex items-center gap-2 text-[11px] text-destructive">
+            <span class="w-1.5 h-1.5 rounded-full bg-destructive animate-pulse" />
+            <span>Microphone disconnected — reconnecting…</span>
+          </div>
+        </Show>
         <Show when={activeProcessing()}>
           {(meeting) => (
             <div class="mt-3 flex items-center gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[12px] text-warning">

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -196,6 +196,12 @@ export function isMeetingCaptureActive(meetingId: string): Promise<boolean> {
 export interface CaptureStopOutcome {
   hadCapture: boolean;
   nativeMicReady: boolean;
+  /**
+   * Mid-capture mic disconnects during this capture (#2608). `0` is healthy; a
+   * positive value means the "Me" track briefly dropped and self-healed (or
+   * stayed down at stop, where `nativeMicReady` is also false).
+   */
+  nativeMicDisconnectCount: number;
   systemAudioReady: boolean;
   apmReady: boolean;
   apmActive: boolean;

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -374,12 +374,22 @@ async function startMeetingEventListeners(): Promise<void> {
   // The native mic dropped or self-healed mid-capture. Flip a flag the panel
   // reads to show "microphone disconnected — reconnecting…" so a Bluetooth/USB
   // drop is never silent; "recovered" clears it (#2608).
+  //
+  // Key the guard to the *capturing* meeting, matching the panel's banner gate
+  // (`status === "capturing"`), NOT the selected/viewed `activeMeeting`: the two
+  // diverge when the user opens another meeting mid-capture, which would
+  // otherwise drop a real disconnect for the recording meeting (the silent loss
+  // this fixes) or strand a stale banner. After stop, no meeting is capturing,
+  // so a late event from the watcher's poll window is rejected, not re-set.
   micStatusUnlisten = await listen<{
     meetingId: string;
     status: "disconnected" | "recovered";
     disconnectCount: number;
   }>("meeting://mic-status", (event) => {
-    if (meetingState.activeMeeting?.id !== event.payload.meetingId) return;
+    const capturing = meetingState.meetings.find(
+      (meeting) => meeting.status === "capturing",
+    );
+    if (capturing?.id !== event.payload.meetingId) return;
     setMeetingState("micCaptureLost", event.payload.status === "disconnected");
   });
 

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -46,6 +46,12 @@ interface MeetingState {
   activeMeeting: Meeting | null;
   liveSegments: TranscriptSegment[];
   captureLevel: number;
+  /**
+   * True while the native mic is disconnected mid-capture and the backend is
+   * re-acquiring it. The panel shows a "microphone disconnected — reconnecting…"
+   * notice so the loss is never silent; cleared on recovery or stop (#2608).
+   */
+  micCaptureLost: boolean;
   isLoading: boolean;
   error: string | null;
   /**
@@ -70,6 +76,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   activeMeeting: null,
   liveSegments: [],
   captureLevel: 0,
+  micCaptureLost: false,
   isLoading: false,
   error: null,
   autoDetectSuggested: false,
@@ -84,6 +91,7 @@ let levelUnlisten: UnlistenFn | null = null;
 let segmentsUpdatedUnlisten: UnlistenFn | null = null;
 let notesPublishFailedUnlisten: UnlistenFn | null = null;
 let notesPublishedUnlisten: UnlistenFn | null = null;
+let micStatusUnlisten: UnlistenFn | null = null;
 let trayToggleUnlisten: (() => void) | null = null;
 
 // Substring marker on the publish-failed banner so the published-success
@@ -363,6 +371,18 @@ async function startMeetingEventListeners(): Promise<void> {
     }
   });
 
+  // The native mic dropped or self-healed mid-capture. Flip a flag the panel
+  // reads to show "microphone disconnected — reconnecting…" so a Bluetooth/USB
+  // drop is never silent; "recovered" clears it (#2608).
+  micStatusUnlisten = await listen<{
+    meetingId: string;
+    status: "disconnected" | "recovered";
+    disconnectCount: number;
+  }>("meeting://mic-status", (event) => {
+    if (meetingState.activeMeeting?.id !== event.payload.meetingId) return;
+    setMeetingState("micCaptureLost", event.payload.status === "disconnected");
+  });
+
   // The tray menu's Start/Stop action toggles capture through the same flow.
   trayToggleUnlisten = await onTrayToggleCapture(() => {
     void toggleCaptureFromTray();
@@ -376,6 +396,7 @@ function stopMeetingEventListeners(): void {
   segmentsUpdatedUnlisten?.();
   notesPublishFailedUnlisten?.();
   notesPublishedUnlisten?.();
+  micStatusUnlisten?.();
   trayToggleUnlisten?.();
   transcriptUnlisten = null;
   statusUnlisten = null;
@@ -383,6 +404,7 @@ function stopMeetingEventListeners(): void {
   segmentsUpdatedUnlisten = null;
   notesPublishFailedUnlisten = null;
   notesPublishedUnlisten = null;
+  micStatusUnlisten = null;
   trayToggleUnlisten = null;
 }
 
@@ -410,6 +432,7 @@ async function startCapture(meeting: Meeting): Promise<boolean> {
     return false;
   }
   setMeetingState("captureLevel", 0);
+  setMeetingState("micCaptureLost", false);
   void setTrayRecording(true);
   return true;
 }
@@ -544,6 +567,7 @@ async function stopCapture(
   meetingId: string,
 ): Promise<CaptureStopOutcome | null> {
   setMeetingState("captureLevel", 0);
+  setMeetingState("micCaptureLost", false);
   void setTrayRecording(false);
   if (isTauriRuntime()) {
     return await stopBackendCapture(meetingId);


### PR DESCRIPTION
Closes #2608. Also closes #2621 and #2622 — two issues the post-implementation walk-through audit of this change surfaced (a P1 banner-scoping bug I introduced and a P2 recovery flap floor), both fixed in the follow-up commit on this branch before merge.


## Problem

A mid-capture mic/headset disconnect (Bluetooth drop, USB glitch, default-device switch) silently killed the **Me** stream for the rest of the meeting. `mic.rs`'s cpal error callback only logged; `run_input` kept "running" while delivering zero frames; `native_mic_ready` stayed `true` with frozen frame counts. The user lost their own side of the transcript with **no notice and no recovery** (7 real occurrences of `native mic stream error: Device disconnected` in production logs).

## Fix (comprehensive — surface **and** self-heal)

**1. Self-healing recovery (`mic.rs`).** The capture worker now supervises the live stream. On a *fatal* stream error it tears the dead stream down and re-acquires the current default input device with capped backoff (250 ms → 2 s) until a device returns or the capture stops — the Me track self-heals onto whatever mic is now default. A `DeviceChanged` reroute is **not** fatal and keeps the current stream. A first-acquire failure stays terminal (so the UI still surfaces the real permission/device cause).

**2. Truthful liveness (`MicHealth`, `capture/mod.rs` + `pipeline.rs`).** A shared `MicHealth` handle (live flag + disconnect counter) is the single source of truth. The stop summary now reports `native_mic_ready` as *established-and-still-live* — a drop that never recovered reads **false** instead of the old frozen-but-"ready" summary — plus a new `native_mic_disconnect_count`, threaded through `StopMeetingCaptureOutcome` and the capture-stop diagnostics JSON.

**3. User-visible notice (`meeting://mic-status` → panel banner).** A watcher task emits `meeting://mic-status` on each disconnect/recover transition; the meeting store flips `micCaptureLost` and `MeetingPanel` shows **"Microphone disconnected — reconnecting…"** while down, cleared on recovery/start/stop. The watcher is aborted on stop (no leak, no drain timeout).

## Platform verification (cpal 0.18.1, both required)

Read the cpal source to confirm — not assumed:
- **macOS / CoreAudio:** a `kAudioDevicePropertyDeviceIsAlive` listener pauses the input stream and reports `DeviceNotAvailable` ("Device disconnected") through the error callback. There is **no** auto-reroute for *input* (only the default-**output** monitor auto-reroutes), so re-acquisition is required.
- **Windows / WASAPI:** `AUDCLNT_E_DEVICE_INVALIDATED` maps to `DeviceNotAvailable`, fires the error callback once, and the run loop exits. Re-acquisition is required.

Both deliver the disconnect through the same `err_fn`, so the shared `mic.rs` path handles both.

## Tests (critical-only, no mocked behavior, no real hardware needed)

- `MicHealth` liveness/disconnect-count transitions (summary-truthfulness contract).
- `is_fatal_stream_error`: `DeviceChanged` keeps the stream; `DeviceNotAvailable`/`StreamInvalidated` trigger re-acquire.
- `sleep_until_stop` returns immediately when already stopped (recovery never delays stop past the drain budget).
- Pipeline end-to-end: a still-disconnected mic at stop reports `native_mic_ready=false` with `native_mic_disconnect_count=1`.

## Verification run

- `cargo check` ✅ · `cargo test audio::` ✅ (139 passed, incl. new tests)
- `biome check` ✅ · `tsc --noEmit` ✅ on changed frontend files

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
