### PR TITLE
fix(meeting): sync seren-notes title on rename (#2342)

### DIFF
--- a/src-tauri/src/audio/seren_notes_publish.rs
+++ b/src-tauri/src/audio/seren_notes_publish.rs
@@ -221,28 +221,55 @@ pub async fn publish_meeting_notes(
     publish_with_retry(&RETRY_BACKOFFS, || attempt_publish(app, &client, &body)).await
 }
 
-async fn publish_with_retry<F, Fut>(
+/// PATCH an existing seren-notes entry's title so a desktop rename keeps the
+/// cloud note in sync (the share link is preserved — no new note is created).
+/// Returns `NotAuthenticated` so the caller can skip silently when signed out,
+/// and reuses the same cold-start retry/backoff as the create path. #2342.
+pub async fn update_meeting_note_title(
+    app: &AppHandle,
+    note_id: &str,
+    title: &str,
+) -> Result<(), PublishError> {
+    if !has_stored_credentials(app) {
+        return Err(PublishError::NotAuthenticated);
+    }
+    if !is_uuid(note_id) {
+        return Err(PublishError::Other(format!(
+            "refusing to PATCH seren-notes with non-uuid note id: {note_id}"
+        )));
+    }
+    let client = Client::new();
+    let url = format!("{PUBLISH_URL}/{note_id}");
+    let body = serde_json::json!({ "title": title }).to_string();
+
+    publish_with_retry(&RETRY_BACKOFFS, || {
+        attempt_update_note_title(app, &client, &url, &body)
+    })
+    .await
+}
+
+async fn publish_with_retry<T, F, Fut>(
     backoffs: &[Duration],
-    mut attempt_publish: F,
-) -> Result<String, PublishError>
+    mut attempt: F,
+) -> Result<T, PublishError>
 where
     F: FnMut() -> Fut,
-    Fut: Future<Output = Result<String, PublishError>>,
+    Fut: Future<Output = Result<T, PublishError>>,
 {
     let mut last_server: Option<(u16, String)> = None;
     let attempts = backoffs.len() + 1;
-    for attempt in 0..attempts {
-        match attempt_publish().await {
-            Ok(id) => return Ok(id),
+    for attempt_idx in 0..attempts {
+        match attempt().await {
+            Ok(value) => return Ok(value),
             Err(PublishError::Server { status, body: srv }) => {
                 if !is_retryable_publish_status(status) {
                     return Err(PublishError::Server { status, body: srv });
                 }
                 last_server = Some((status, srv));
-                if let Some(delay) = backoffs.get(attempt).copied() {
+                if let Some(delay) = backoffs.get(attempt_idx).copied() {
                     log::warn!(
-                        "[meeting] seren-notes publish retryable status={status} (attempt {}/{attempts}); retrying in {:?} (cold-start expected)",
-                        attempt + 1,
+                        "[meeting] seren-notes request retryable status={status} (attempt {}/{attempts}); retrying in {:?} (cold-start expected)",
+                        attempt_idx + 1,
                         delay,
                     );
                     tokio::time::sleep(delay).await;
@@ -287,6 +314,63 @@ async fn attempt_publish(
         )));
     }
     parse_publish_response_body(&text)
+}
+
+async fn attempt_update_note_title(
+    app: &AppHandle,
+    client: &Client,
+    url: &str,
+    body: &str,
+) -> Result<(), PublishError> {
+    let response = authenticated_request(app, client, |c, token| {
+        c.patch(url)
+            .header("Content-Type", "application/json")
+            .bearer_auth(token)
+            .body(body.to_string())
+    })
+    .await
+    .map_err(PublishError::Other)?;
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .map_err(|err| PublishError::Other(format!("seren-notes read body failed: {err}")))?;
+    if status.as_u16() == 408 || status.is_server_error() {
+        return Err(PublishError::Server {
+            status: status.as_u16(),
+            body: text,
+        });
+    }
+    if !status.is_success() {
+        return Err(PublishError::Other(format!(
+            "seren-notes title update returned {status}: {text}"
+        )));
+    }
+    parse_update_response_body(&text)
+}
+
+/// A PATCH success returns the updated note (or an empty body); we only need
+/// to detect a terminal/retryable status hidden inside the Gateway envelope
+/// (e.g. a 5xx cold start, or a 404 if the note was deleted server-side). A
+/// 2xx-or-non-JSON body is treated as success — unlike create, we don't need a
+/// note id back. #2342.
+fn parse_update_response_body(text: &str) -> Result<(), PublishError> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+    let Ok(value) = serde_json::from_str::<Value>(trimmed) else {
+        return Ok(());
+    };
+    if let Some(status) = publisher_status(&value) {
+        if status >= 400 {
+            return Err(PublishError::Server {
+                status,
+                body: publisher_body_text(&value, text),
+            });
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -432,6 +516,59 @@ mod tests {
     }
 
     #[test]
+    fn parse_update_response_body_accepts_empty_body() {
+        assert!(parse_update_response_body("").is_ok());
+        assert!(parse_update_response_body("   ").is_ok());
+    }
+
+    #[test]
+    fn parse_update_response_body_accepts_2xx_envelope() {
+        let text = json!({
+            "data": {
+                "status": 200,
+                "body": {"data": {"id": "276a4660-e16b-4934-97c6-a1ade2426653", "title": "Renamed"}},
+                "cost": "0"
+            }
+        })
+        .to_string();
+        assert!(parse_update_response_body(&text).is_ok());
+    }
+
+    #[test]
+    fn parse_update_response_body_returns_retryable_server_for_inner_503() {
+        let text = json!({
+            "data": {"status": 503, "body": "upstream cold start", "cost": "0"}
+        })
+        .to_string();
+        match parse_update_response_body(&text) {
+            Err(PublishError::Server { status, body }) => {
+                assert_eq!(status, 503);
+                assert!(is_retryable_publish_status(status));
+                assert_eq!(body, "upstream cold start");
+            }
+            other => panic!("expected inner 503 server error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_update_response_body_returns_terminal_server_for_inner_404() {
+        // Note deleted server-side: 404 is a terminal (non-retryable) status so
+        // the retry loop surfaces it immediately rather than burning the budget.
+        let text = json!({
+            "data": {"status": 404, "body": "note not found", "cost": "0"}
+        })
+        .to_string();
+        match parse_update_response_body(&text) {
+            Err(PublishError::Server { status, body }) => {
+                assert_eq!(status, 404);
+                assert!(!is_retryable_publish_status(status));
+                assert_eq!(body, "note not found");
+            }
+            other => panic!("expected inner 404 server error, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parse_publish_response_body_extracts_note_id_for_2xx_envelope() {
         let text = json!({
             "data": {
@@ -450,7 +587,7 @@ mod tests {
         let backoffs = [Duration::ZERO; RETRY_BACKOFFS.len()];
         let attempts = Arc::new(AtomicUsize::new(0));
         let seen_attempts = attempts.clone();
-        let result = publish_with_retry(&backoffs, move || {
+        let result: Result<String, PublishError> = publish_with_retry(&backoffs, move || {
             let seen_attempts = seen_attempts.clone();
             async move {
                 seen_attempts.fetch_add(1, Ordering::SeqCst);
@@ -474,7 +611,7 @@ mod tests {
         let backoffs = [Duration::ZERO; RETRY_BACKOFFS.len()];
         let attempts = Arc::new(AtomicUsize::new(0));
         let seen_attempts = attempts.clone();
-        let result = publish_with_retry(&backoffs, move || {
+        let result: Result<String, PublishError> = publish_with_retry(&backoffs, move || {
             let seen_attempts = seen_attempts.clone();
             async move {
                 seen_attempts.fetch_add(1, Ordering::SeqCst);

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -139,6 +139,16 @@ fn set_meeting_notes_record(
     Ok(())
 }
 
+fn get_meeting_seren_notes_id(conn: &Connection, id: &str) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT seren_notes_id FROM meetings WHERE id = ?1",
+        params![id],
+        |row| row.get::<_, Option<String>>(0),
+    )
+    .optional()
+    .map(Option::flatten)
+}
+
 fn set_meeting_seren_notes_id_record(
     conn: &Connection,
     id: &str,
@@ -399,19 +409,54 @@ pub async fn set_meeting_routed_skill(
 #[tauri::command]
 pub async fn update_meeting_title(app: AppHandle, id: String, title: String) -> Result<(), String> {
     let lookup = id.clone();
-    run_db(app.clone(), move |conn| {
+    let db_id = id.clone();
+    let db_title = title.clone();
+    // Read back the published-note id inside the same closure so the rename and
+    // the lookup see one consistent row.
+    let seren_notes_id = run_db(app.clone(), move |conn| {
         conn.execute(
             "UPDATE meetings
              SET title = ?1, updated_at = ?2
              WHERE id = ?3",
-            params![title, now_ms(), id],
+            params![db_title, now_ms(), db_id],
         )?;
-        mark_sync_upsert(conn, "meetings", &id)?;
-        Ok(())
+        mark_sync_upsert(conn, "meetings", &db_id)?;
+        get_meeting_seren_notes_id(conn, &db_id)
     })
     .await?;
     emit_meeting_status_by_id(&app, &lookup).await;
+
+    // If this meeting already has a cloud note, keep its title in sync via a
+    // fire-and-forget PATCH so a slow/cold gateway never blocks the rename. The
+    // share link is preserved (no new note). When there is no note yet, the
+    // next (auto or manual) publish reads the fresh title from the DB. #2342.
+    if let Some(note_id) = seren_notes_id {
+        tauri::async_runtime::spawn(sync_seren_notes_title(app, id, note_id, title));
+    }
     Ok(())
+}
+
+// Push a renamed meeting's title to its existing seren-notes entry. Best-effort:
+// the local rename already succeeded, so a terminal failure is logged (not
+// surfaced via the `notes-publish-failed` banner, whose republish CTA would
+// POST a duplicate note). #2342.
+async fn sync_seren_notes_title(app: AppHandle, meeting_id: String, note_id: String, title: String) {
+    use crate::audio::seren_notes_publish::PublishError;
+    match crate::audio::seren_notes_publish::update_meeting_note_title(&app, &note_id, &title).await
+    {
+        Ok(()) => {}
+        Err(PublishError::NotAuthenticated) => {
+            log::info!(
+                "[meeting] seren-notes title sync skipped for {meeting_id} (not authenticated)"
+            );
+        }
+        Err(err) => {
+            log::warn!(
+                "[meeting] seren-notes title sync failed for {meeting_id}: {}",
+                err.into_message()
+            );
+        }
+    }
 }
 
 #[tauri::command]


### PR DESCRIPTION
Closes #2342.

## Problem

Renaming a meeting transcript (the pencil "Rename meeting" button) only updated `meetings.title` in the local SQLite row and emitted `meeting://status` to refresh the UI. The already-published seren-note at `notes.serendb.com/notes/<uuid>` kept its transcription-time title forever — open seren-notes and you see the stale title.

`#2342` was previously auto-closed against PR #2338, but **#2338 is the auto-publish feature that introduced this drift** (the ticket was found while auditing #2338); it was never fixed. A fresh code-path audit confirmed the bug is still live: `update_meeting_title` had no seren-notes propagation, and `publish_meeting_notes` only ever **POST**s (create) — the stored `seren_notes_id` was never used to update the cloud note.

## Capability check (live)

`get_agent_publisher(seren-notes)` confirms the publisher exposes `PATCH /notes/{note_id}` — *"Update a note title, content, parent, archive/pin status. Supports expected_version for concurrency."* So fix path **B** (the ticket's preferred option) is viable: update in place, preserve the share link, no orphaned note.

## Fix

- **`src-tauri/src/audio/seren_notes_publish.rs`** — new `update_meeting_note_title(app, note_id, title)` that `PATCH`es `…/notes/{note_id}` with `{ "title": title }`, reusing the existing `authenticated_request` + cold-start retry/backoff + Gateway-envelope status handling. `publish_with_retry` is generalized over its success type (no behavior change). Guards against a non-uuid note id before building the URL.
- **`src-tauri/src/commands/audio.rs`** — after the title `UPDATE`, `update_meeting_title` reads back `seren_notes_id` in the *same* DB closure and, if present, fire-and-forgets the PATCH so a slow/cold gateway never blocks the rename. When there is no note yet, the next (auto or manual) publish already reads the fresh title from the DB. Failures are logged — intentionally **not** routed through the `notes-publish-failed` banner, whose republish CTA would POST a duplicate note.

No new note is created and the share link is preserved across renames. Frontend is unchanged — the only rename path (`MeetingDetail → renameMeeting → updateMeetingTitle → invoke("update_meeting_title")`) is fixed at the command layer, covering all callers.

## Tests (critical only, per CLAUDE.md)

- 4 new Rust unit tests for `parse_update_response_body`: empty body, 2xx envelope, inner-503 (retryable), inner-404 (terminal — surfaced immediately, not retried).
- `cargo test seren_notes_publish` → 20 passed. `cargo test commands::audio` → 15 passed. Whole `lib` test crate compiles clean.

UI/IPC wiring is integration-level (needs an AppHandle + a mock HTTP server) and is intentionally not unit-tested per the "NEVER test mocked behavior" rule.

## Test plan

- [ ] Signed in, capture a meeting → notes finalize → `Chat with meeting notes` link appears.
- [ ] Rename via the pencil; reload `notes.serendb.com/notes/<uuid>` — title now reflects the rename, **same uuid/link**.
- [ ] Rename while signed out — local rename succeeds, no error toast, info log only.
- [ ] Rename a meeting that was never published (no `seren_notes_id`) — no PATCH attempted; a later publish carries the new title.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
