### PR TITLE
fix(shortcuts): restore Cmd/Ctrl+Shift+Arrow selection in chat (#2624)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1184,9 +1184,15 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       }
     }
 
+    // Prompt-history recall only fires on a plain arrow. When a modifier is
+    // held the arrow is a text-selection / caret chord (Shift+Arrow,
+    // Cmd/Ctrl+Shift+Arrow, Option+Shift+Arrow) and must reach the textarea.
+    const isPlainArrow =
+      !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey;
+
     // Up arrow: navigate to older prompts
     const history = userMessageHistory();
-    if (event.key === "ArrowUp" && history.length > 0) {
+    if (event.key === "ArrowUp" && isPlainArrow && history.length > 0) {
       const textarea = event.currentTarget as HTMLTextAreaElement;
       if (textarea.selectionStart === 0 || input() === "") {
         event.preventDefault();
@@ -1206,7 +1212,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
 
     // Down arrow: navigate to newer prompts
-    if (event.key === "ArrowDown" && historyIndex() >= 0) {
+    if (event.key === "ArrowDown" && isPlainArrow && historyIndex() >= 0) {
       const textarea = event.currentTarget as HTMLTextAreaElement;
       if (textarea.selectionStart === textarea.value.length) {
         event.preventDefault();

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -1999,8 +1999,22 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
 
                   const history = userMessageHistory();
 
+                  // Prompt-history recall only fires on a plain arrow. When a
+                  // modifier is held the arrow is a text-selection / caret
+                  // chord (Shift+Arrow, Cmd/Ctrl+Shift+Arrow,
+                  // Option+Shift+Arrow) and must reach the textarea.
+                  const isPlainArrow =
+                    !event.shiftKey &&
+                    !event.metaKey &&
+                    !event.ctrlKey &&
+                    !event.altKey;
+
                   // Up arrow: navigate to older message
-                  if (event.key === "ArrowUp" && history.length > 0) {
+                  if (
+                    event.key === "ArrowUp" &&
+                    isPlainArrow &&
+                    history.length > 0
+                  ) {
                     const textarea = event.currentTarget;
                     if (textarea.selectionStart === 0 || input() === "") {
                       event.preventDefault();
@@ -2025,7 +2039,11 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                   }
 
                   // Down arrow: navigate to newer message
-                  if (event.key === "ArrowDown" && historyIndex() >= 0) {
+                  if (
+                    event.key === "ArrowDown" &&
+                    isPlainArrow &&
+                    historyIndex() >= 0
+                  ) {
                     const textarea = event.currentTarget;
                     if (textarea.selectionStart === textarea.value.length) {
                       event.preventDefault();

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -53,7 +53,7 @@ import { SkillsExplorer } from "@/components/sidebar/SkillsExplorer";
 import { AgentTasksPanel } from "@/components/tasks/AgentTasksPanel";
 import { openFolder } from "@/lib/files/service";
 import { isMeetingProcessingStatus } from "@/lib/meeting-format";
-import { shortcuts } from "@/lib/shortcuts";
+import { isNativeTextEditingKey, shortcuts } from "@/lib/shortcuts";
 import type { InstalledSkill } from "@/lib/skills";
 import { listenForInterviewLaunch } from "@/lib/tauri-bridge";
 import { telemetry } from "@/services/telemetry";
@@ -579,6 +579,16 @@ export const AppShell: Component<AppShellProps> = (props) => {
       target instanceof HTMLElement &&
       target.closest("[data-keybinding-recorder='true']")
     ) {
+      return;
+    }
+
+    // Inside a text field, caret-movement keys must perform native cursor
+    // movement and selection (e.g. Cmd/Ctrl+Shift+Arrow). The arrow-based
+    // pane keybindings collide with that chord, so never let this capture-phase
+    // handler swallow them. Terminal surfaces are non-editable, so pane resize
+    // still works there.
+    if (isNativeTextEditingKey(e)) {
+      workspaceKeybindingMatcher.clear();
       return;
     }
 

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -40,6 +40,41 @@ const GLOBAL_SHORTCUT_ACTIONS: readonly ShortcutAction[] = [
   "global.newTerminal",
 ];
 
+/**
+ * Keys that move or extend the text caret inside an editable field. Inside a
+ * text input these must always perform native cursor movement / selection
+ * (e.g. Cmd/Ctrl+Shift+Arrow) and never be consumed by an app shortcut.
+ */
+export const CARET_MOVEMENT_KEYS: ReadonlySet<string> = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+]);
+
+/** True when the event originates from a text-editing element. */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    (target.tagName === "INPUT" ||
+      target.tagName === "TEXTAREA" ||
+      target.isContentEditable)
+  );
+}
+
+/**
+ * True when a keydown must be left to the browser's native text editing
+ * (caret movement / selection) rather than consumed by an app shortcut —
+ * i.e. a caret-movement key fired while focus is in an editable field.
+ */
+export function isNativeTextEditingKey(event: KeyboardEvent): boolean {
+  return CARET_MOVEMENT_KEYS.has(event.key) && isEditableTarget(event.target);
+}
+
 class ShortcutManager {
   private handlers: Map<ShortcutAction, ShortcutCallback> = new Map();
   private enabled = true;
@@ -106,11 +141,7 @@ class ShortcutManager {
     const result = this.matcher.handleEvent(e);
     if (result.kind === "none") return;
 
-    const target = e.target as HTMLElement;
-    const isInputField =
-      target.tagName === "INPUT" ||
-      target.tagName === "TEXTAREA" ||
-      target.isContentEditable;
+    const isInputField = isEditableTarget(e.target);
 
     if (result.kind === "pending") {
       if (!isInputField) e.preventDefault();


### PR DESCRIPTION
## What

Restores keyboard text selection in the agent chat composer. **Cmd+Shift+Arrow** (macOS) / **Ctrl+Shift+Arrow** (Windows/Linux) — and other selection chords — now highlight/select text again.

Fixes #2624.

## Root cause (regression)

`8d7bb518 feat(shortcuts): add configurable keybindings` (2026-06-21) added arrow-key pane-resize bindings (`mod+shift+Arrow`) that collide with the OS-standard text-selection chord. Two paths broke selection:

1. **AppShell global handler** — the window-level keydown listener runs in the **capture phase** and called `e.preventDefault()` on any matched binding *without checking whether focus was in a text field* (`AppShell.tsx:588`). So the composer textarea never saw the chord and native selection died.
2. **Composer history-nav** — `AgentChat`/`ChatContent` ArrowUp/Down prompt-history recall called `preventDefault()` at text boundaries *without checking modifier keys*, hijacking `Shift+Arrow` / `Cmd+Shift+Arrow` into history navigation.

## Fix

- **AppShell.tsx** — bail out of the workspace keybinding handler for caret-movement keys (`Arrow*`, `Home`, `End`, `PageUp`, `PageDown`) when focus is in an editable element, so native cursor movement / selection wins. Terminal panes render a non-editable `<div role="application">` over a `<canvas>`, so i3-style `mod+shift+Arrow` pane resize **still works** there.
- **AgentChat.tsx / ChatContent.tsx** — prompt-history recall now only fires on a *plain* arrow (no `shift`/`meta`/`ctrl`/`alt`).
- **shortcuts.ts** — extract shared `isEditableTarget` / `isNativeTextEditingKey` helpers; reuse them in the existing input-field guard (DRY with the older shortcut system).

## Selection matrix (after fix)

| Chord | macOS | Win/Linux | Path |
| ----- | ----- | --------- | ---- |
| Shift+Arrow | ✅ char/line | ✅ char/line | composer guard |
| Cmd/Ctrl+Shift+Left/Right | ✅ line/word | ✅ word | AppShell guard |
| Cmd/Ctrl+Shift+Up/Down | ✅ doc | ✅ block | AppShell + composer guard |
| Option/Ctrl+Shift+Arrow (word) | ✅ | ✅ | composer guard |
| Pane resize in terminal | ✅ unaffected | ✅ unaffected | terminal is non-editable |
| Workspace switch while typing (Cmd+1) | ✅ unaffected | ✅ unaffected | non-caret key |

## Testing

- `biome check` clean on changed files (pre-existing warnings only).
- `tsc --noEmit` clean for the changed files.
- No unit test added: this is UI keyboard handling (CLAUDE.md "DO NOT test: UI components"), the helper is DOM-dependent, and the vitest env is `node` with no jsdom/happy-dom — testing it would require either a new dependency (disallowed) or mocked DOM (disallowed). Verified via code-path audit + functional walk-through instead.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
