### PR TITLE
fix(shortcuts): slash popup yields Shift+Arrow selection (#2627)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1148,17 +1148,23 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   });
 
   const handleKeyDown = (event: KeyboardEvent) => {
+    // Arrow keys only drive popup / history navigation on a plain arrow. When a
+    // modifier is held the arrow is a text-selection / caret chord (Shift+Arrow,
+    // Cmd/Ctrl+Shift+Arrow, Option+Shift+Arrow) and must reach the textarea.
+    const isPlainArrow =
+      !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey;
+
     // Slash command popup keyboard navigation
     const isSlashInput = input().startsWith("/") && !input().includes(" ");
     if (isSlashInput) {
       const matches = getCompletions(input(), "agent");
       if (matches.length > 0) {
-        if (event.key === "ArrowUp") {
+        if (event.key === "ArrowUp" && isPlainArrow) {
           event.preventDefault();
           setCommandPopupIndex((i) => (i > 0 ? i - 1 : matches.length - 1));
           return;
         }
-        if (event.key === "ArrowDown") {
+        if (event.key === "ArrowDown" && isPlainArrow) {
           event.preventDefault();
           setCommandPopupIndex((i) => (i < matches.length - 1 ? i + 1 : 0));
           return;
@@ -1183,12 +1189,6 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         }
       }
     }
-
-    // Prompt-history recall only fires on a plain arrow. When a modifier is
-    // held the arrow is a text-selection / caret chord (Shift+Arrow,
-    // Cmd/Ctrl+Shift+Arrow, Option+Shift+Arrow) and must reach the textarea.
-    const isPlainArrow =
-      !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey;
 
     // Up arrow: navigate to older prompts
     const history = userMessageHistory();

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -1953,20 +1953,30 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                 onDragOver={handleSkillDragOver}
                 onDrop={(event) => void handleSkillDrop(event)}
                 onKeyDown={(event) => {
+                  // Arrow keys only drive popup / history navigation on a plain
+                  // arrow. When a modifier is held the arrow is a text-selection
+                  // / caret chord (Shift+Arrow, Cmd/Ctrl+Shift+Arrow,
+                  // Option+Shift+Arrow) and must reach the textarea.
+                  const isPlainArrow =
+                    !event.shiftKey &&
+                    !event.metaKey &&
+                    !event.ctrlKey &&
+                    !event.altKey;
+
                   // Slash command popup keyboard navigation
                   const isSlashInput =
                     input().startsWith("/") && !input().includes(" ");
                   if (isSlashInput) {
                     const matches = getCompletions(input(), "chat");
                     if (matches.length > 0) {
-                      if (event.key === "ArrowUp") {
+                      if (event.key === "ArrowUp" && isPlainArrow) {
                         event.preventDefault();
                         setCommandPopupIndex((i) =>
                           i > 0 ? i - 1 : matches.length - 1,
                         );
                         return;
                       }
-                      if (event.key === "ArrowDown") {
+                      if (event.key === "ArrowDown" && isPlainArrow) {
                         event.preventDefault();
                         setCommandPopupIndex((i) =>
                           i < matches.length - 1 ? i + 1 : 0,
@@ -1998,16 +2008,6 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                   }
 
                   const history = userMessageHistory();
-
-                  // Prompt-history recall only fires on a plain arrow. When a
-                  // modifier is held the arrow is a text-selection / caret
-                  // chord (Shift+Arrow, Cmd/Ctrl+Shift+Arrow,
-                  // Option+Shift+Arrow) and must reach the textarea.
-                  const isPlainArrow =
-                    !event.shiftKey &&
-                    !event.metaKey &&
-                    !event.ctrlKey &&
-                    !event.altKey;
 
                   // Up arrow: navigate to older message
                   if (


### PR DESCRIPTION
## What

Follow-up to #2625, found during the post-merge functional walk-through. Restores `Shift+Arrow` / `Cmd/Ctrl+Shift+Arrow` / `Option/Alt+Shift+Arrow` text selection while the slash-command completion popup is open.

Fixes #2627.

## Root cause

The slash-command popup handler in both composers called `event.preventDefault()` on `ArrowUp`/`ArrowDown` **without checking modifiers**, so while a `/token` input had matches, modified arrows were hijacked into popup navigation instead of extending the selection. This sat directly above the history-nav block that #2625 already guarded — making the same handler self-inconsistent.

## Fix

Hoist the existing `isPlainArrow` check to the top of each handler and reuse it for both the slash-popup arrows and prompt-history recall (no duplication). Modified arrows now fall through to native text selection; plain arrows still navigate the popup; `Tab`/`Enter`/`Escape` popup actions are unchanged.

- `src/components/chat/AgentChat.tsx`
- `src/components/chat/ChatContent.tsx`

## Testing

- `biome check` clean on changed files (pre-existing warnings only).
- `tsc --noEmit` clean for the changed files.
- No unit test: UI keyboard handling (CLAUDE.md "DO NOT test: UI components"); verified via code-path audit + walk-through.

## Selection matrix after this + #2625

| State | Shift+Arrow | Cmd/Ctrl+Shift+Arrow | Plain Arrow |
| ----- | ----------- | -------------------- | ----------- |
| Normal composer | ✅ select | ✅ select | caret move / history |
| Slash popup open | ✅ select | ✅ select | popup nav |

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
