### PR TITLE
fix(release): recover Windows e2e from nightly auto-stop (#2630)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1354,13 +1354,45 @@ jobs:
             JSON.stringify({ commands, executionTimeout: ["6000"] }, null, 2),
           );
           NODE
-          command_id="$(aws ssm send-command \
-            --instance-ids "$WINDOWS_E2E_INSTANCE_ID" \
-            --document-name "AWS-RunPowerShellScript" \
-            --comment "Seren Desktop release Windows production e2e ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
-            --parameters "file://$RUNNER_TEMP/windows-e2e-commands.json" \
-            --query "Command.CommandId" \
-            --output text)"
+          send_e2e_command() {
+            aws ssm send-command \
+              --instance-ids "$WINDOWS_E2E_INSTANCE_ID" \
+              --document-name "AWS-RunPowerShellScript" \
+              --comment "Seren Desktop release Windows production e2e ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
+              --parameters "file://$RUNNER_TEMP/windows-e2e-commands.json" \
+              --query "Command.CommandId" \
+              --output text
+          }
+          # The shared box is stopped nightly by the seren-sandbox-auto-stop
+          # schedule (23:00 ET, #2630), with no awareness of in-flight runs. A
+          # release that reaches e2e inside that window loses the box mid-command:
+          # the on-box command can never complete and its SSM status stalls on
+          # Pending until the deadline, then fails the release. Restart the box
+          # and resend the command instead of burning the whole deadline on a
+          # command that is already dead. The schedule fires once per night, so a
+          # single restart is the normal case; the cap bounds a genuinely broken
+          # host.
+          restart_e2e_host() {
+            echo "::warning::Windows e2e host was stopped mid-run (likely the nightly auto-stop, #2630); restarting and resending the command."
+            aws ec2 wait instance-stopped --instance-ids "$WINDOWS_E2E_INSTANCE_ID" || true
+            aws ec2 start-instances --instance-ids "$WINDOWS_E2E_INSTANCE_ID" >/dev/null
+            aws ec2 wait instance-running --instance-ids "$WINDOWS_E2E_INSTANCE_ID"
+            online_deadline=$((SECONDS + 600))
+            until [ "$(aws ssm describe-instance-information \
+              --filters "Key=InstanceIds,Values=$WINDOWS_E2E_INSTANCE_ID" \
+              --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null)" = "Online" ]; do
+              if [ "$SECONDS" -gt "$online_deadline" ]; then
+                echo "::error::Windows e2e host did not return online after a mid-run stop."
+                exit 1
+              fi
+              echo "Waiting for SSM agent after restart..."
+              sleep 15
+            done
+            echo "Windows e2e host back online after restart."
+          }
+          max_restarts=2
+          restart_count=0
+          command_id="$(send_e2e_command)"
           echo "command_id=$command_id" >> "$GITHUB_OUTPUT"
           echo "SSM command: $command_id"
           # Poll past the SSM executionTimeout (6000s) so the on-box command, not
@@ -1384,6 +1416,27 @@ jobs:
                 exit 1
                 ;;
             esac
+            # A box stopped out from under the command never reaches a terminal
+            # SSM status, so detect it directly from EC2 state rather than waiting
+            # out the deadline. Treat a transient describe error (unknown) as
+            # "keep polling" so an API blip does not trigger a needless restart.
+            instance_state="$(aws ec2 describe-instances \
+              --instance-ids "$WINDOWS_E2E_INSTANCE_ID" \
+              --query 'Reservations[0].Instances[0].State.Name' \
+              --output text 2>/dev/null || echo unknown)"
+            if [ "$instance_state" != "running" ] && [ "$instance_state" != "unknown" ]; then
+              echo "Windows e2e host state is '$instance_state' while the command is still running."
+              if [ "$restart_count" -ge "$max_restarts" ]; then
+                echo "::error::Windows e2e host was stopped mid-run and the restart cap ($max_restarts) is exhausted."
+                exit 1
+              fi
+              restart_count=$((restart_count + 1))
+              restart_e2e_host
+              command_id="$(send_e2e_command)"
+              echo "SSM command (restart $restart_count/$max_restarts): $command_id"
+              deadline=$((SECONDS + 6300))
+              continue
+            fi
             if [ "$SECONDS" -gt "$deadline" ]; then
               echo "::error::Timed out waiting for Windows e2e SSM command $command_id"
               exit 1


### PR DESCRIPTION
## Closes #2630

### Problem (confirmed against live AWS)
The EventBridge schedule `seren-sandbox-auto-stop` is a blind `ec2:stopInstances` on the hardcoded e2e box `i-0a575b70ba969fb6e`:

```
State: ENABLED  Cron: cron(0 23 * * ? *)  TZ: America/New_York  (= 03:00 UTC)
Target: arn:aws:scheduler:::aws-sdk:ec2:stopInstances  Input: {"InstanceIds":["i-0a575b70ba969fb6e"]}
```

It has **no awareness of in-flight release runs**. The build matrix is ~70 min, so any release tagged after ~21:50 ET reaches `windows-app-e2e` inside the 23:00 ET stop window and the box is killed mid-test (v3.60.0 hit this at 02:57 UTC, stopped 03:00 UTC, ~2.5 min in). The orphaned on-box SSM command never reaches a terminal status; the poll loop prints `Windows e2e SSM status: Pending` every 30s until its 6300s (~105 min) deadline, then fails. Since `publish` is gated on `windows-app-e2e`, the release stalls ~105 min and falls back to the manual-publish override (#2323).

### Fix (repo-only, this PR)
In the SSM poll loop, read EC2 instance state alongside the SSM status. A box that is **not running** (excluding a transient `unknown` describe error) means it was stopped out from under the command, so:
1. wait-stopped → `start-instances` → wait-running → wait for the SSM agent `Online`, then
2. resend the same staged command and reset the poll deadline.

Bounded to **two restarts**. The nightly schedule fires once, so a single restart yields a clean completing run; the cap fails fast on a genuinely broken host. Genuine test failures (SSM `Failed`/`TimedOut`/`Cancelled`) are **not** retried — only a stopped box is.

### Why this approach
The issue lists three options. Only this one is fully repo-contained:
- **Lambda tag-guard (durable, recommended)** — pure AWS infra (no IaC exists in this repo); a production EventBridge/Lambda change I won't make unilaterally. **Recommended infra follow-up** — it eliminates the interruption entirely.
- **Disable/re-enable the schedule** — needs a new `scheduler:Get/UpdateSchedule` IAM grant on the OIDC role + fragile full-schedule replacement, and carries a cost-leak risk if a runner dies before re-enable.
- **Workflow self-heal (this PR)** — uses only `ec2`/`ssm` APIs the job already calls. **No new IAM, no schedule mutation, no cost-leak.** Strictly better than the status quo in every case.

Honest tradeoff: the in-progress test restarts from scratch (the issue's "symptom-only" note). Cost ≈ one extra ~100 min e2e in the rare collision case — far cheaper than today's fail + manual override + manual re-run.

### Verification
- YAML parses (Ruby `YAML.load_file`)
- `bash -n` clean on every `run:` block in `windows-app-e2e`
- `actionlint` 1.7.12 — 0 findings
- `shellcheck` 0.10.0 on the edited step — 0 findings (no exclusions)

The on-box harness already wipes `$work` at start (`Remove-Item ... -Recurse`), so a resent command runs cleanly from scratch; the restart path is idempotent.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
