### PR TITLE
fix(release): guard windows-app-e2e against nightly auto-stop (#2630)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1098,6 +1098,10 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
+      # EventBridge Scheduler that stops the shared e2e box nightly (23:00 ET).
+      # The release suspends it for the duration of the e2e run so the box is not
+      # killed mid-test (#2630), and restores it in an always() teardown.
+      WINDOWS_E2E_AUTO_STOP_SCHEDULE: seren-sandbox-auto-stop
     steps:
       - name: Checkout e2e scripts
         uses: actions/checkout@v7
@@ -1201,6 +1205,38 @@ jobs:
             exit 1
           fi
           echo "Windows e2e box prerequisites present."
+
+      # The nightly seren-sandbox-auto-stop schedule (23:00 ET) is a direct
+      # ec2:stopInstances with no awareness of in-flight releases, so a release
+      # that reaches e2e inside the stop window loses the box mid-command and the
+      # gate stalls for ~105 min (#2630). Suspend the schedule for the duration of
+      # this run; the always() teardown re-enables it. This runs BEFORE starting
+      # the box so a stop cannot fire during the up-to-10-min boot wait below.
+      # scheduler:UpdateSchedule is a full-definition replace, so round-trip the
+      # live definition through jq and only flip State to avoid corrupting the
+      # target. Fail OPEN: a missing scheduler permission must not block the
+      # release — the run then proceeds at the status-quo risk and the self-heal
+      # restart below recovers if the box is stopped anyway.
+      - name: Suspend nightly auto-stop during e2e
+        shell: bash
+        run: |
+          set -uo pipefail
+          set +e
+          def="$(aws scheduler get-schedule \
+            --name "$WINDOWS_E2E_AUTO_STOP_SCHEDULE" \
+            --region "$AWS_REGION" 2>/dev/null \
+            | jq 'del(.Arn,.CreationDate,.LastModificationDate) | .State="DISABLED"')"
+          if [ -z "$def" ] || [ "$def" = "null" ]; then
+            echo "::warning::Could not read schedule '$WINDOWS_E2E_AUTO_STOP_SCHEDULE' (missing or no permission); skipping suspend. The run proceeds unprotected; the self-heal restart recovers a mid-run stop."
+            exit 0
+          fi
+          if aws scheduler update-schedule \
+            --region "$AWS_REGION" \
+            --cli-input-json "$def" >/dev/null 2>&1; then
+            echo "Suspended nightly auto-stop '$WINDOWS_E2E_AUTO_STOP_SCHEDULE' for this run."
+          else
+            echo "::warning::Failed to suspend '$WINDOWS_E2E_AUTO_STOP_SCHEDULE' (no scheduler permission?); proceeding unprotected. The self-heal restart recovers a mid-run stop."
+          fi
 
       # The e2e host is a shared box that other tooling stops to save cost.
       # SendCommand against a stopped instance fails with InvalidInstanceId
@@ -1354,13 +1390,45 @@ jobs:
             JSON.stringify({ commands, executionTimeout: ["6000"] }, null, 2),
           );
           NODE
-          command_id="$(aws ssm send-command \
-            --instance-ids "$WINDOWS_E2E_INSTANCE_ID" \
-            --document-name "AWS-RunPowerShellScript" \
-            --comment "Seren Desktop release Windows production e2e ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
-            --parameters "file://$RUNNER_TEMP/windows-e2e-commands.json" \
-            --query "Command.CommandId" \
-            --output text)"
+          send_e2e_command() {
+            aws ssm send-command \
+              --instance-ids "$WINDOWS_E2E_INSTANCE_ID" \
+              --document-name "AWS-RunPowerShellScript" \
+              --comment "Seren Desktop release Windows production e2e ${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
+              --parameters "file://$RUNNER_TEMP/windows-e2e-commands.json" \
+              --query "Command.CommandId" \
+              --output text
+          }
+          # The shared box is stopped nightly by the seren-sandbox-auto-stop
+          # schedule (23:00 ET, #2630), with no awareness of in-flight runs. A
+          # release that reaches e2e inside that window loses the box mid-command:
+          # the on-box command can never complete and its SSM status stalls on
+          # Pending until the deadline, then fails the release. Restart the box
+          # and resend the command instead of burning the whole deadline on a
+          # command that is already dead. The schedule fires once per night, so a
+          # single restart is the normal case; the cap bounds a genuinely broken
+          # host.
+          restart_e2e_host() {
+            echo "::warning::Windows e2e host was stopped mid-run (likely the nightly auto-stop, #2630); restarting and resending the command."
+            aws ec2 wait instance-stopped --instance-ids "$WINDOWS_E2E_INSTANCE_ID" || true
+            aws ec2 start-instances --instance-ids "$WINDOWS_E2E_INSTANCE_ID" >/dev/null
+            aws ec2 wait instance-running --instance-ids "$WINDOWS_E2E_INSTANCE_ID"
+            online_deadline=$((SECONDS + 600))
+            until [ "$(aws ssm describe-instance-information \
+              --filters "Key=InstanceIds,Values=$WINDOWS_E2E_INSTANCE_ID" \
+              --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null)" = "Online" ]; do
+              if [ "$SECONDS" -gt "$online_deadline" ]; then
+                echo "::error::Windows e2e host did not return online after a mid-run stop."
+                exit 1
+              fi
+              echo "Waiting for SSM agent after restart..."
+              sleep 15
+            done
+            echo "Windows e2e host back online after restart."
+          }
+          max_restarts=2
+          restart_count=0
+          command_id="$(send_e2e_command)"
           echo "command_id=$command_id" >> "$GITHUB_OUTPUT"
           echo "SSM command: $command_id"
           # Poll past the SSM executionTimeout (6000s) so the on-box command, not
@@ -1384,6 +1452,27 @@ jobs:
                 exit 1
                 ;;
             esac
+            # A box stopped out from under the command never reaches a terminal
+            # SSM status, so detect it directly from EC2 state rather than waiting
+            # out the deadline. Treat a transient describe error (unknown) as
+            # "keep polling" so an API blip does not trigger a needless restart.
+            instance_state="$(aws ec2 describe-instances \
+              --instance-ids "$WINDOWS_E2E_INSTANCE_ID" \
+              --query 'Reservations[0].Instances[0].State.Name' \
+              --output text 2>/dev/null || echo unknown)"
+            if [ "$instance_state" != "running" ] && [ "$instance_state" != "unknown" ]; then
+              echo "Windows e2e host state is '$instance_state' while the command is still running."
+              if [ "$restart_count" -ge "$max_restarts" ]; then
+                echo "::error::Windows e2e host was stopped mid-run and the restart cap ($max_restarts) is exhausted."
+                exit 1
+              fi
+              restart_count=$((restart_count + 1))
+              restart_e2e_host
+              command_id="$(send_e2e_command)"
+              echo "SSM command (restart $restart_count/$max_restarts): $command_id"
+              deadline=$((SECONDS + 6300))
+              continue
+            fi
             if [ "$SECONDS" -gt "$deadline" ]; then
               echo "::error::Timed out waiting for Windows e2e SSM command $command_id"
               exit 1
@@ -1395,6 +1484,34 @@ jobs:
             --instance-id "$WINDOWS_E2E_INSTANCE_ID" \
             --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
             --output json
+
+      # Re-enable the nightly auto-stop regardless of the e2e outcome so a release
+      # never leaves the shared box pinned-on (cost leak). Idempotent: re-applies
+      # the live definition with State=ENABLED even if the suspend step did not run
+      # or already restored it. Fail OPEN here too — teardown cannot meaningfully
+      # block, and the Terraform-managed schedule's desired state (ENABLED) is the
+      # backstop that corrects a stuck-disabled schedule on the next apply (#2630).
+      - name: Restore nightly auto-stop
+        if: always()
+        shell: bash
+        run: |
+          set -uo pipefail
+          set +e
+          def="$(aws scheduler get-schedule \
+            --name "$WINDOWS_E2E_AUTO_STOP_SCHEDULE" \
+            --region "$AWS_REGION" 2>/dev/null \
+            | jq 'del(.Arn,.CreationDate,.LastModificationDate) | .State="ENABLED"')"
+          if [ -z "$def" ] || [ "$def" = "null" ]; then
+            echo "::warning::Could not read schedule '$WINDOWS_E2E_AUTO_STOP_SCHEDULE' to restore it; Terraform will re-enable it on the next apply."
+            exit 0
+          fi
+          if aws scheduler update-schedule \
+            --region "$AWS_REGION" \
+            --cli-input-json "$def" >/dev/null 2>&1; then
+            echo "Restored nightly auto-stop '$WINDOWS_E2E_AUTO_STOP_SCHEDULE'."
+          else
+            echo "::error::Failed to restore '$WINDOWS_E2E_AUTO_STOP_SCHEDULE' to ENABLED. The shared e2e box may stay running. Re-enable it manually or via the next Terraform apply."
+          fi
 
       - name: Download Windows e2e log bundle
         if: always()


### PR DESCRIPTION
Closes #2630

## Problem
The `seren-sandbox-auto-stop` EventBridge schedule (`cron(0 23 * * ? *)` America/New_York) is a **direct `ec2:stopInstances`** on the shared e2e box `i-0a575b70ba969fb6e` with **no awareness of in-flight releases**. The build matrix takes ~70 min, so any release tagged after ~21:50 ET reaches the e2e phase inside the 23:00 ET stop window. The box is powered off mid-command; the on-box SSM command can never complete; the poll loop hits its `|| echo Pending` fallback and prints `Windows e2e SSM status: Pending` every 30s until the ~105 min deadline, then fails `windows-app-e2e`. Because `publish-release` is gated on it, the release stalls ~105 min and needs the manual override (#2323). This recurred on v3.60.0.

## Fix — two complementary layers
**1. Primary (prevent the stop):** a new **Suspend nightly auto-stop during e2e** step (right after the host is confirmed online) sets the schedule to `DISABLED`; an `always()` **Restore nightly auto-stop** teardown re-enables it. `scheduler:UpdateSchedule` is a *full-definition replace*, so the live definition is round-tripped through `jq` with only `State` flipped — the target/cron/timezone/role/retry are preserved exactly. Both steps **fail open**: a missing scheduler permission emits a warning and proceeds, never blocking a release.

**2. Backstop (recover if the stop happens anyway):** the SSM poll loop now reads EC2 instance state and, if the box is stopped out from under the command, restarts it and resends the command (capped at 2 restarts) instead of burning the deadline. This covers the cases where the suspend failed open or a Terraform `apply` re-enabled the schedule mid-window. (Self-heal logic carried in from the parallel `fix/e2e-autostop-selfheal` draft so it is not lost.)

## Cost-leak safety
The schedule and box are Terraform-managed (`ManagedBy=terraform`). The Terraform desired state (`ENABLED`) is the backstop for the rare case where a hard runner crash skips the `always()` teardown and leaves the schedule disabled — the next `terraform apply` reverts the drift. The teardown is idempotent and itself fails open with a loud `::error::` if it cannot restore.

## IAM
Requires three additional permissions on the release OIDC role `SerenDesktopWindowsE2EReleaseRole` (agent-managed inline policy, `ManagedBy=codex`; trust policy restricts it to `refs/tags/v*`):
- `scheduler:GetSchedule`, `scheduler:UpdateSchedule` scoped to `arn:aws:scheduler:us-east-1:232501868299:schedule/default/seren-sandbox-auto-stop`
- `iam:PassRole` on `seren-sandbox-scheduler-role`, conditioned on `iam:PassedToService = scheduler.amazonaws.com`

These were applied live and verified with `iam simulate-principal-policy` (all `allowed`).

## Validation
Ran the exact step scripts against the **live** schedule:
- `ENABLED -> DISABLED -> ENABLED`, full definition preserved (target/cron/timezone/role/retry).
- Both fail-open paths (missing schedule / no permission) warn and exit 0, leaving the real schedule untouched.
- `release.yml` parses as valid YAML; new bash steps pass `bash -n`.

## Notes / not done here
The issue's preferred *durable* fix (option 1) is a tag-aware Lambda replacing the direct `stopInstances` target — that belongs in the Terraform infra repo, not seren-desktop. This PR is the recommended repo-only fix (option 2) hardened with the self-heal backstop (option 3).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
