### PR TITLE
fix(recording): close hardening backlog

### DIFF
--- a/packages/recording-core/src/index.ts
+++ b/packages/recording-core/src/index.ts
@@ -1758,9 +1758,10 @@ function writeTarHeader(
   mtimeSeconds: number,
 ): Uint8Array<ArrayBuffer> {
   const pathParts = path.split("/");
+  const pathBytes = new TextEncoder().encode(path);
   const pathUnsafe =
     path.length === 0 ||
-    path.length > 100 ||
+    pathBytes.length > 100 ||
     path.startsWith("/") ||
     path.includes("\\") ||
     pathParts.some((part) => part === "" || part === "." || part === "..");

--- a/packages/recording-ui/src/index.tsx
+++ b/packages/recording-ui/src/index.tsx
@@ -41,7 +41,10 @@ export interface RecordButtonProps {
   class?: string;
   classNames?: RecordingUiClassNames;
   onSessionStart?: (session: RecordingSession) => void;
-  onSessionStop?: (session: RecordingSession | null) => void;
+  onSessionStop?: (
+    session: RecordingSession | null,
+    releaseArtifacts?: () => void,
+  ) => void;
   onError?: (message: string) => void;
 }
 
@@ -232,6 +235,15 @@ export function RecordButton(props: RecordButtonProps) {
     props.onError?.(message);
   };
 
+  const releaseArtifactsFor = (session: RecordingSession) => {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      void props.adapter.releaseSessionArtifacts?.(session);
+    };
+  };
+
   let elapsedTimer: ReturnType<typeof setInterval> | undefined;
   const stopElapsedTimer = () => {
     if (!elapsedTimer) return;
@@ -254,7 +266,7 @@ export function RecordButton(props: RecordButtonProps) {
     setLastMarkerLabel(null);
     setStatus("idle");
     setError(null);
-    props.onSessionStop?.(session);
+    props.onSessionStop?.(session, releaseArtifactsFor(session));
   });
   onCleanup(() => externalStopCleanup?.());
   onCleanup(() => {
@@ -451,7 +463,10 @@ export function RecordButton(props: RecordButtonProps) {
       setMarkerCount(0);
       setLastMarkerLabel(null);
       setStatus("idle");
-      props.onSessionStop?.(session);
+      props.onSessionStop?.(
+        session,
+        session ? releaseArtifactsFor(session) : undefined,
+      );
     } catch (err) {
       fail(err, "recording");
     }

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -144,6 +144,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const [awaitingLogin, setAwaitingLogin] = createSignal<AgentType | null>(
     null,
   );
+  let releaseRecordedSessionArtifacts: (() => void) | undefined;
   let inputRef: HTMLTextAreaElement | undefined;
   let messagesRef: HTMLDivElement | undefined;
   let userHasScrolledUp = false;
@@ -178,10 +179,21 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     const len = inputRef?.value.length ?? 0;
     inputRef?.setSelectionRange(len, len);
   };
-  const handleRecordingSessionStop = (session: RecordingSession | null) => {
+  const clearRecordedSession = () => {
+    releaseRecordedSessionArtifacts?.();
+    releaseRecordedSessionArtifacts = undefined;
+    setRecordedSession(null);
+  };
+  onCleanup(clearRecordedSession);
+  const handleRecordingSessionStop = (
+    session: RecordingSession | null,
+    releaseArtifacts?: () => void,
+  ) => {
     if (!session) return;
+    clearRecordedSession();
+    releaseRecordedSessionArtifacts = releaseArtifacts;
     setInput((current) => appendRecordingSkillDraftPrompt(current, session));
-    if (session.outputDir) setRecordedSession(session);
+    setRecordedSession(session);
     queueMicrotask(() => {
       inputRef?.focus();
       const len = inputRef?.value.length ?? 0;
@@ -193,10 +205,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   // next gains focus), then clear so only one composer handles it. This keeps
   // the skill-draft flow alive even if recording stopped with no chat focused.
   createEffect(() => {
-    const pending = recordingHandoff.pending;
+    const pending = recordingHandoff.pendingEntry;
     if (!pending || !isPaneActive()) return;
     recordingHandoff.clear();
-    handleRecordingSessionStop(pending);
+    handleRecordingSessionStop(pending.session, pending.releaseArtifacts);
   });
   markdownWorker.onmessage = (
     e: MessageEvent<{ id: string; html: string; error?: boolean }>,
@@ -2088,7 +2100,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 {(session) => (
                   <RecordedSessionCard
                     session={session()}
-                    onDismiss={() => setRecordedSession(null)}
+                    onDismiss={clearRecordedSession}
                   />
                 )}
               </Show>

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -193,6 +193,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     if (!isPaneActive()) return;
     setAttachedImages((prev) => [...prev, ...files]);
   });
+  let releaseRecordedSessionArtifacts: (() => void) | undefined;
   let inputRef: HTMLTextAreaElement | undefined;
   let messagesRef: HTMLDivElement | undefined;
   let suggestionDebounceTimer: ReturnType<typeof setTimeout> | undefined;
@@ -217,10 +218,21 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
   );
   const conversationId = () =>
     props.threadId ?? conversationStore.activeConversationId;
-  const handleRecordingSessionStop = (session: RecordingSession | null) => {
+  const clearRecordedSession = () => {
+    releaseRecordedSessionArtifacts?.();
+    releaseRecordedSessionArtifacts = undefined;
+    setRecordedSession(null);
+  };
+  onCleanup(clearRecordedSession);
+  const handleRecordingSessionStop = (
+    session: RecordingSession | null,
+    releaseArtifacts?: () => void,
+  ) => {
     if (!session) return;
+    clearRecordedSession();
+    releaseRecordedSessionArtifacts = releaseArtifacts;
     setInput((current) => appendRecordingSkillDraftPrompt(current, session));
-    if (session.outputDir) setRecordedSession(session);
+    setRecordedSession(session);
     queueMicrotask(() => {
       inputRef?.focus();
       const len = inputRef?.value.length ?? 0;
@@ -232,10 +244,10 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
   // next gains focus), then clear so only one composer handles it. This keeps
   // the skill-draft flow alive even if recording stopped with no chat focused.
   createEffect(() => {
-    const pending = recordingHandoff.pending;
+    const pending = recordingHandoff.pendingEntry;
     if (!pending || !isPaneActive()) return;
     recordingHandoff.clear();
-    handleRecordingSessionStop(pending);
+    handleRecordingSessionStop(pending.session, pending.releaseArtifacts);
   });
   const activeThreadProvider = (): ProviderId => {
     const id = conversationId();
@@ -1919,7 +1931,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                 {(session) => (
                   <RecordedSessionCard
                     session={session()}
-                    onDismiss={() => setRecordedSession(null)}
+                    onDismiss={clearRecordedSession}
                   />
                 )}
               </Show>

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -184,7 +184,9 @@ export const Titlebar: Component<TitlebarProps> = (props) => {
           adapter={desktopRecordingAdapter}
           class="relative flex items-center justify-center w-7 h-7 border-none rounded-md bg-transparent text-rec-fg-muted cursor-pointer transition-all duration-100 hover:bg-surface-2 hover:text-foreground active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
           classNames={{ toolbar: "absolute right-0 top-full z-50 mt-1" }}
-          onSessionStop={(session) => recordingHandoff.offer(session)}
+          onSessionStop={(session, releaseArtifacts) =>
+            recordingHandoff.offer(session, releaseArtifacts)
+          }
         />
 
         <button

--- a/src/components/recording/RecordedSessionCard.tsx
+++ b/src/components/recording/RecordedSessionCard.tsx
@@ -50,6 +50,7 @@ export function RecordedSessionCard(props: {
   const markerCount = () => props.session.markerCount ?? 0;
   const captureStatsLabel = () =>
     formatCaptureStats(props.session.captureStats);
+  const hasLocalArtifacts = () => Boolean(props.session.outputDir);
 
   const reveal = async () => {
     if (busy()) return;
@@ -121,26 +122,28 @@ export function RecordedSessionCard(props: {
               <SparkIcon />
               {buildingSkill() ? "Hide draft" : "Build skill"}
             </button>
-            <button
-              type="button"
-              class={GHOST_ICON_BUTTON}
-              aria-label="Reveal recording in Finder"
-              title="Reveal in Finder"
-              disabled={busy() !== null}
-              onClick={() => void reveal()}
-            >
-              <RevealIcon />
-            </button>
-            <button
-              type="button"
-              class={`${GHOST_ICON_BUTTON} hover:bg-red-500/10 hover:text-red-600`}
-              aria-label="Delete recording"
-              title="Delete recording from disk"
-              disabled={busy() !== null}
-              onClick={() => void remove()}
-            >
-              <TrashIcon />
-            </button>
+            <Show when={hasLocalArtifacts()}>
+              <button
+                type="button"
+                class={GHOST_ICON_BUTTON}
+                aria-label="Reveal recording in Finder"
+                title="Reveal in Finder"
+                disabled={busy() !== null}
+                onClick={() => void reveal()}
+              >
+                <RevealIcon />
+              </button>
+              <button
+                type="button"
+                class={`${GHOST_ICON_BUTTON} hover:bg-red-500/10 hover:text-red-600`}
+                aria-label="Delete recording"
+                title="Delete recording from disk"
+                disabled={busy() !== null}
+                onClick={() => void remove()}
+              >
+                <TrashIcon />
+              </button>
+            </Show>
             <button
               type="button"
               class={GHOST_ICON_BUTTON}
@@ -178,14 +181,16 @@ export function RecordedSessionCard(props: {
             ·
           </span>
           <span class="uppercase tracking-wide text-muted-foreground/80">
-            local only
+            {hasLocalArtifacts() ? "local only" : "no local folder"}
           </span>
         </div>
 
         <p class="text-[11px] leading-snug text-muted-foreground">
           The skill-draft prompt was added to your message. Send it, then paste
           the reply into <span class="text-foreground/80">Build skill</span>.
-          The video stays on this device.
+          {hasLocalArtifacts()
+            ? " The video stays on this device."
+            : " This capture does not expose reveal or delete actions."}
         </p>
 
         <Show when={error()}>

--- a/src/features/recording/recordingHandoff.ts
+++ b/src/features/recording/recordingHandoff.ts
@@ -4,21 +4,31 @@
 import type { RecordingSession } from "@seren/recording-core";
 import { createSignal } from "solid-js";
 
-const [pendingSession, setPendingSession] =
-  createSignal<RecordingSession | null>(null);
+export interface RecordingHandoffEntry {
+  session: RecordingSession;
+  releaseArtifacts?: () => void;
+}
+
+const [pendingEntry, setPendingEntry] =
+  createSignal<RecordingHandoffEntry | null>(null);
 
 export const recordingHandoff = {
+  /** The stopped session and release callback awaiting a composer, or null. */
+  get pendingEntry(): RecordingHandoffEntry | null {
+    return pendingEntry();
+  },
   /** The stopped session awaiting a composer, or null. Tracked when read. */
   get pending(): RecordingSession | null {
-    return pendingSession();
+    return pendingEntry()?.session ?? null;
   },
   /** Offer a stopped session for the active composer to pick up. */
-  offer(session: RecordingSession | null): void {
+  offer(session: RecordingSession | null, releaseArtifacts?: () => void): void {
     if (!session) return;
-    setPendingSession(session);
+    pendingEntry()?.releaseArtifacts?.();
+    setPendingEntry({ session, releaseArtifacts });
   },
   /** Drop the pending session once a composer has taken it. */
   clear(): void {
-    setPendingSession(null);
+    setPendingEntry(null);
   },
 };

--- a/tests/unit/recording-handoff.test.ts
+++ b/tests/unit/recording-handoff.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Guards #2614 — a stopped session must survive until a composer takes it.
 
 import type { RecordingSession } from "@seren/recording-core";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { recordingHandoff } from "@/features/recording/recordingHandoff";
 
 function session(id: string): RecordingSession {
@@ -39,5 +39,33 @@ describe("recordingHandoff (#2614)", () => {
     recordingHandoff.offer(first);
     recordingHandoff.offer(second);
     expect(recordingHandoff.pending).toBe(second);
+  });
+
+  it("keeps the release callback with the pending session", () => {
+    const releaseArtifacts = vi.fn();
+    const stopped = session("with-release");
+
+    recordingHandoff.offer(stopped, releaseArtifacts);
+
+    expect(recordingHandoff.pendingEntry).toEqual({
+      session: stopped,
+      releaseArtifacts,
+    });
+    recordingHandoff.clear();
+    expect(releaseArtifacts).not.toHaveBeenCalled();
+  });
+
+  it("releases an unconsumed pending session when it is replaced", () => {
+    const releaseFirst = vi.fn();
+    const releaseSecond = vi.fn();
+    const first = session("first-release");
+    const second = session("second-release");
+
+    recordingHandoff.offer(first, releaseFirst);
+    recordingHandoff.offer(second, releaseSecond);
+
+    expect(releaseFirst).toHaveBeenCalledTimes(1);
+    expect(releaseSecond).not.toHaveBeenCalled();
+    expect(recordingHandoff.pendingEntry?.session).toBe(second);
   });
 });

--- a/tests/unit/recording-packages.test.ts
+++ b/tests/unit/recording-packages.test.ts
@@ -52,8 +52,14 @@ const desktopAdapterSource = source(
 const recordingComposerSource = source(
   "src/features/recording/recordingComposer.ts",
 );
+const recordingHandoffSource = source(
+  "src/features/recording/recordingHandoff.ts",
+);
 const agentChatSource = source("src/components/chat/AgentChat.tsx");
 const chatContentSource = source("src/components/chat/ChatContent.tsx");
+const recordedSessionCardSource = source(
+  "src/components/recording/RecordedSessionCard.tsx",
+);
 const titlebarSource = source("src/components/layout/Titlebar.tsx");
 const tauriLibSource = source("src-tauri/src/lib.rs");
 
@@ -517,6 +523,14 @@ describe("recording packages", () => {
 
   it("makes stopped-session artifact ownership explicit", () => {
     expect(coreSource).toContain("releaseSessionArtifacts?");
+    expect(uiSource).toContain("releaseArtifactsFor");
+    expect(uiSource).toContain(
+      "props.adapter.releaseSessionArtifacts?.(session)",
+    );
+    expect(titlebarSource).toContain(
+      "recordingHandoff.offer(session, releaseArtifacts)",
+    );
+    expect(recordingHandoffSource).toContain("releaseArtifacts?: () => void");
     const session: RecordingSession = {
       id: "session-urls",
       targetKind: "browser",
@@ -726,8 +740,15 @@ describe("recording packages", () => {
     // stopping with no chat focused. (#2614)
     for (const composer of [agentChatSource, chatContentSource]) {
       expect(composer).toContain("handleRecordingSessionStop");
-      expect(composer).toContain("recordingHandoff.pending");
+      expect(composer).toContain("recordingHandoff.pendingEntry");
+      expect(composer).toContain("releaseRecordedSessionArtifacts");
+      expect(composer).toContain("setRecordedSession(session)");
+      expect(composer).not.toContain(
+        "if (session.outputDir) setRecordedSession(session)",
+      );
     }
+    expect(recordedSessionCardSource).toContain("hasLocalArtifacts");
+    expect(recordedSessionCardSource).toContain("no local folder");
   });
 
   it("builds a correction prompt from an existing draft review", () => {
@@ -1591,6 +1612,12 @@ describe("recording packages", () => {
       buildRecordingSkillBundleTar({
         slug: "../unsafe",
         files: [{ path: "SKILL.md", content: "bad" }],
+      }),
+    ).toThrow("Recording skill bundle file path is not tar-safe");
+    expect(() =>
+      buildRecordingSkillBundleTar({
+        slug: "s",
+        files: [{ path: "é".repeat(50), content: "bad" }],
       }),
     ).toThrow("Recording skill bundle file path is not tar-safe");
   });


### PR DESCRIPTION
## Summary
- validate recording skill tar paths by UTF-8 byte length so non-ASCII names cannot be truncated mid-codepoint
- keep null-output stopped recording sessions visible in chat composers while hiding disk-only reveal/delete actions
- thread stopped-session artifact release callbacks through RecordButton, titlebar handoff, and composer dismissal/replacement

## Audit
- confirmed current main already has lazy Tauri recording imports, startup/dialog preview pruning, titlebar-only RecordButton usage, service-layer public publish acknowledgement checks, and AVI rcFrame i16 clamping
- no new P0/P1 product issues found in the post-fix Mac/Windows code-path walk-through

## Verification
- pnpm vitest run tests/unit/recording-packages.test.ts tests/unit/recording-desktop-adapter.test.ts tests/unit/recording-handoff.test.ts
- pnpm exec tsc --noEmit
- pnpm prepare:mcp-servers
- CARGO_BUILD_JOBS=1 cargo test --manifest-path src-tauri/Cargo.toml recording --lib
- pnpm build

Closes #2603