### PR TITLE
fix(skills): restore frontmatter tag merge clobbered by stale-base employee API sync

### DIFF
--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -305,6 +305,7 @@ export interface EnabledSkillsContentOptions {
  * specific SKILL.md is missing display metadata.
  */
 function skillSummaryToSkill(summary: SkillSummary): Skill {
+  const frontmatterTags = (summary.tags ?? []).filter((tag) => tag.length > 0);
   return {
     id: `seren:${summary.slug}`,
     slug: summary.slug,
@@ -315,6 +316,7 @@ function skillSummaryToSkill(summary: SkillSummary): Skill {
     sourceUrl: `seren-skills:${summary.slug}`,
     tags: [
       ...new Set([
+        ...frontmatterTags,
         summary.visibility,
         summary.discoverability,
         summary.status,


### PR DESCRIPTION
## Problem

`tests/unit/skills-index-api.test.ts:112` ("preserves frontmatter tags from catalog summaries") fails **deterministically** on `main`, blocking `test-frontend` and therefore the entire CI pipeline (downstream `E2E (production bundle)` + `build` jobs skipped). Observed in run https://github.com/serenorg/seren-desktop/actions/runs/28170936966:

```
AssertionError: expected [ 'public', 'published' ] to deeply equal ArrayContaining{…}
- ArrayContaining [ "recorded", "unverified", "public", "published" ]
+ [ "public", "published" ]
 ❯ tests/unit/skills-index-api.test.ts:112:29
```

## Root cause

`0ea608d3` added a frontmatter-tag merge to `skillSummaryToSkill`. Commit `c6970fda` ("chore(api): sync employee secret delegation clients") — a stale-base parallel-session merge whose branch predated `0ea608d3` — silently reverted those two lines while committing an otherwise legitimate generated-API sync. The companion test survived, so it now fails on main. Blast radius is exactly these two lines (`git diff <prev>..<head> -- src/services/skills.ts` = `2 --`, nothing else).

## Impact (functional, not just the test)

Recorded/published skills lose their frontmatter tags (e.g. `recorded`, `unverified`) in the catalog adapter — the desktop UI can no longer filter/identify them by those tags.

## Fix

Restore the `frontmatterTags` const and its spread. The result is **byte-identical** to the pre-regression code in `b8cdffe7` (`git diff b8cdffe7 -- src/services/skills.ts` is empty after this change).

## Verification

- `vitest run tests/unit/skills-index-api.test.ts` → 14/14 pass.
- `biome check src/services/skills.ts` → clean.

Closes #2645

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
