### PR TITLE
Fix active recording elapsed timers

### DIFF
--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -14,6 +14,7 @@ import {
   formatDuration,
   formatMeetingDate,
   formatTime,
+  isMeetingDurationLive,
   isMeetingProcessingStatus,
   isMeetingReadyStatus,
   meetingProcessingLabel,
@@ -36,6 +37,7 @@ import { settingsStore } from "@/stores/settings.store";
 
 interface MeetingDetailProps {
   meeting: Meeting;
+  durationNow?: number;
   onRequestDelete?: (meeting: Meeting) => void;
 }
 
@@ -171,6 +173,8 @@ export function MeetingDetail(props: MeetingDetailProps) {
   );
 
   const segments = () => meetingStore.state.liveSegments;
+  const durationNow = () =>
+    isMeetingDurationLive(props.meeting) ? props.durationNow : undefined;
   const processing = () => isMeetingProcessingStatus(props.meeting.status);
   const ready = () => isMeetingReadyStatus(props.meeting.status);
   const notesActionBusy = () =>
@@ -316,7 +320,7 @@ export function MeetingDetail(props: MeetingDetailProps) {
             <div class="mt-1 flex flex-wrap items-center gap-3 text-[12px] text-muted-foreground">
               <span>{STATUS_LABELS[props.meeting.status]}</span>
               <span class="font-mono tabular-nums">
-                {formatDuration(props.meeting)}
+                {formatDuration(props.meeting, durationNow())}
               </span>
               <span>
                 {formatMeetingDate(props.meeting.startedAt)} ·{" "}

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -5,10 +5,12 @@ import { createMemo, createSignal, For, onMount, Show } from "solid-js";
 import { ConfirmDialog } from "@/components/catalog/ConfirmDialog";
 import { MeetingDetail } from "@/components/meeting/MeetingDetail";
 import { MeetingSettings } from "@/components/meeting/MeetingSettings";
+import { createMeetingDurationClock } from "@/lib/meeting-duration-clock";
 import {
   formatDuration,
   formatMeetingDate,
   formatTime,
+  isMeetingDurationLive,
   isMeetingProcessingStatus,
   isMeetingReadyStatus,
   meetingProcessingLabel,
@@ -86,6 +88,11 @@ export function MeetingPanel() {
   });
 
   const activeMeeting = () => meetingStore.state.activeMeeting;
+  const durationNow = createMeetingDurationClock(() =>
+    [activeCapture(), activeMeeting()].some(
+      (meeting) => meeting != null && isMeetingDurationLive(meeting),
+    ),
+  );
   const template = () => settingsStore.get("meetingTemplateId");
   const desktopRuntime = isTauriRuntime();
   const deleteConfirmationMessage = () => {
@@ -251,7 +258,7 @@ export function MeetingPanel() {
             <div class="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
               <span class="w-1.5 h-1.5 rounded-full bg-destructive animate-pulse" />
               <span class="font-mono tabular-nums">
-                {formatDuration(meeting())}
+                {formatDuration(meeting(), durationNow())}
               </span>
               <span>{meetingTitle(meeting())}</span>
             </div>
@@ -391,6 +398,7 @@ export function MeetingPanel() {
               {(meeting) => (
                 <MeetingDetail
                   meeting={meeting()}
+                  durationNow={durationNow()}
                   onRequestDelete={(target) => setPendingDelete(target)}
                 />
               )}

--- a/src/lib/meeting-duration-clock.ts
+++ b/src/lib/meeting-duration-clock.ts
@@ -1,0 +1,25 @@
+// ABOUTME: Reactive clock for live Meeting Mode elapsed-time surfaces.
+// ABOUTME: Keeps active capture timers moving without polling completed rows.
+
+import { type Accessor, createEffect, createSignal, onCleanup } from "solid-js";
+
+const MEETING_DURATION_TICK_MS = 1_000;
+
+export function createMeetingDurationClock(
+  active: Accessor<boolean>,
+): Accessor<number> {
+  const [now, setNow] = createSignal(Date.now());
+
+  createEffect(() => {
+    if (!active()) return;
+
+    setNow(Date.now());
+    const timer = setInterval(
+      () => setNow(Date.now()),
+      MEETING_DURATION_TICK_MS,
+    );
+    onCleanup(() => clearInterval(timer));
+  });
+
+  return now;
+}

--- a/src/lib/meeting-format.ts
+++ b/src/lib/meeting-format.ts
@@ -42,8 +42,11 @@ export function formatMeetingDate(
   });
 }
 
-export function formatDuration(meeting: Meeting): string {
-  const end = meeting.endedAt ?? Date.now();
+export function formatDuration(
+  meeting: Meeting,
+  now: number = Date.now(),
+): string {
+  const end = meeting.endedAt ?? now;
   const totalSeconds = Math.max(
     0,
     Math.floor((end - meeting.startedAt) / 1000),
@@ -51,6 +54,13 @@ export function formatDuration(meeting: Meeting): string {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function isMeetingDurationLive(meeting: Meeting): boolean {
+  return (
+    (meeting.endedAt === null || meeting.endedAt === undefined) &&
+    (meeting.status === "pending_capture" || meeting.status === "capturing")
+  );
 }
 
 // Auto-generated titles carry seconds so two captures started in the same

--- a/tests/unit/meeting-duration-timers.test.ts
+++ b/tests/unit/meeting-duration-timers.test.ts
@@ -1,0 +1,80 @@
+// ABOUTME: Regression coverage for #2648 live Meeting Mode elapsed timers.
+// ABOUTME: Guards the explicit reactive clock dependency used by active captures.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  formatDuration,
+  isMeetingDurationLive,
+} from "@/lib/meeting-format";
+import type { Meeting } from "@/services/meetings";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string): string {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+function meeting(overrides: Partial<Meeting> = {}): Meeting {
+  return {
+    id: "meeting-1",
+    title: "Cristin Debrief",
+    sourceApp: "Zoom",
+    startedAt: 10_000,
+    endedAt: null,
+    status: "capturing",
+    templateId: null,
+    routedSkillSlug: null,
+    agentConversationId: null,
+    notesMarkdown: null,
+    notesStructJson: null,
+    createdAt: 10_000,
+    updatedAt: 10_000,
+    ...overrides,
+  };
+}
+
+describe("meeting duration timers (#2648)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("formats live durations from an explicit clock while ended meetings stay fixed", () => {
+    expect(formatDuration(meeting(), 43_000)).toBe("00:33");
+    expect(formatDuration(meeting({ endedAt: 22_000 }), 43_000)).toBe("00:12");
+  });
+
+  it("identifies only pending or active captures as live timers", () => {
+    expect(isMeetingDurationLive(meeting({ status: "pending_capture" }))).toBe(
+      true,
+    );
+    expect(isMeetingDurationLive(meeting({ status: "capturing" }))).toBe(true);
+    expect(
+      isMeetingDurationLive(meeting({ status: "transcribing" })),
+    ).toBe(false);
+    expect(
+      isMeetingDurationLive(meeting({ status: "capturing", endedAt: 22_000 })),
+    ).toBe(false);
+  });
+
+  it("wires the live duration clock into both active recording surfaces", () => {
+    const clock = source("src/lib/meeting-duration-clock.ts");
+    const panel = source("src/components/meeting/MeetingPanel.tsx");
+    const detail = source("src/components/meeting/MeetingDetail.tsx");
+
+    expect(clock).toContain("createEffect");
+    expect(clock).toContain("setInterval");
+    expect(clock).toContain("clearInterval");
+    expect(panel).toContain("createMeetingDurationClock");
+    expect(panel).toContain("isMeetingDurationLive");
+    expect(panel).toContain("formatDuration(meeting(), durationNow())");
+    expect(panel).toContain("durationNow={durationNow()}");
+    expect(detail).toContain("formatDuration(props.meeting, durationNow())");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #2648 by adding a live reactive duration clock for Meeting Mode active capture timers.
- Feeds the same clock into the active capture banner and selected meeting detail header.
- Keeps completed meeting durations fixed from `endedAt`.

## Audit
- Confirmed the stale timer path from `~/Downloads/Logs/20260625_recording_time.log`: both affected surfaces called `formatDuration(...)` without a reactive dependency.
- Audited Mac/Windows impact: this is frontend Solid rendering only; no Tauri, capture backend, or OS-specific audio code paths changed.

## Verification
- `pnpm biome check src/lib/meeting-format.ts src/lib/meeting-duration-clock.ts src/components/meeting/MeetingPanel.tsx src/components/meeting/MeetingDetail.tsx tests/unit/meeting-duration-timers.test.ts`
- `pnpm vitest run tests/unit/meeting-duration-timers.test.ts tests/unit/meeting-format-date.test.ts tests/unit/meeting-ui-regressions.test.ts tests/unit/meeting-rename-and-indicator.test.ts tests/unit/meeting-title-fallback.test.ts tests/unit/meeting-status-labels.test.ts`
- `pnpm build`