### PR TITLE
Fix skill sync alert surfacing in agent chat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,7 +181,7 @@ function App() {
   createEffect((prevRoot: string | null | undefined) => {
     const root = fileTreeState.rootPath;
     if (root === prevRoot) return root;
-    void skillsStore.refreshInstalled();
+    void skillsStore.refreshInstalled({ inspectSyncStatuses: true });
     void skillsStore.loadProjectConfig(root);
     return root;
   }, fileTreeState.rootPath);

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -2,7 +2,10 @@
 // ABOUTME: Handles agent session lifecycle and message streaming.
 
 import type { RecordingSession } from "@seren/recording-core";
-import { confirm } from "@tauri-apps/plugin-dialog";
+import {
+  confirm,
+  message as showMessageDialog,
+} from "@tauri-apps/plugin-dialog";
 import type { Component } from "solid-js";
 import {
   createEffect,
@@ -61,7 +64,11 @@ import {
   setCurrentSkillDragPayload,
   skillDragPayload,
 } from "@/lib/skill-drag";
-import { skillCommandAliases, skillMatchesCommandAlias } from "@/lib/skills";
+import {
+  type InstalledSkill,
+  skillCommandAliases,
+  skillMatchesCommandAlias,
+} from "@/lib/skills";
 import {
   buildSkillInvocationDirective,
   buildSkillInvocationDisplay,
@@ -106,6 +113,7 @@ import { PairedModelSelector } from "./PairedModelSelector";
 import { PlanHeader } from "./PlanHeader";
 import { SkillsButton } from "./SkillsButton";
 import { SlashCommandPopup } from "./SlashCommandPopup";
+import { SyncSkillButton } from "./SyncSkillButton";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { ThinkingStatus } from "./ThinkingStatus";
 import { ThreadProviderSwitcher } from "./ThreadProviderSwitcher";
@@ -321,6 +329,39 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
     return null;
   });
+  // Inspect the active skill's sync status once so agent chat gets the same
+  // composer Sync affordance as Seren chat without opening the Skills panel.
+  createEffect(() => {
+    const skill = recentSkill();
+    if (!skill) return;
+    if (skillsStore.syncStatusFor(skill.path) !== undefined) return;
+    void skillsStore.loadSyncStatus(skill).catch(() => undefined);
+  });
+  const activeSkillNeedsSync = () => {
+    const skill = recentSkill();
+    return skill ? skillsStore.skillNeedsSync(skill) : false;
+  };
+  const handleSyncActiveSkill = async (skill: InstalledSkill) => {
+    try {
+      const result = await skillsStore.syncInstalledSkill(skill);
+      if (
+        (result.outcome === "untracked" || result.outcome === "error") &&
+        result.message
+      ) {
+        await showMessageDialog(result.message, {
+          title: "Sync skill",
+          kind: result.outcome === "error" ? "error" : "warning",
+        });
+      }
+    } catch (err) {
+      await showMessageDialog(
+        `Could not sync ${skill.name}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { title: "Sync skill", kind: "error" },
+      );
+    }
+  };
 
   // Get streaming content for THIS thread's conversation ID
   const threadStreamingContent = createMemo(() => {
@@ -2192,6 +2233,14 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                     inputRef?.setSelectionRange(len, len);
                   }}
                 />
+                <Show when={activeSkillNeedsSync() && recentSkill()}>
+                  {(skill) => (
+                    <SyncSkillButton
+                      skill={skill()}
+                      onSync={() => void handleSyncActiveSkill(skill())}
+                    />
+                  )}
+                </Show>
 
                 <Show when={messageQueue().length > 0}>
                   <span class="flex items-center gap-2 px-2 py-1 bg-surface-2 border border-border rounded text-xs text-muted-foreground">

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -41,6 +41,15 @@ export interface RefreshSummary {
   failed: number;
 }
 
+export interface RefreshInstalledOptions {
+  /**
+   * Also inspect upstream sync status after the installed inventory has been
+   * re-read. This is intentionally opt-in because the full refresh path already
+   * performs its own auto-sync sweep.
+   */
+  inspectSyncStatuses?: boolean;
+}
+
 /** Concurrency guard: in-flight refresh promise so concurrent calls coalesce. */
 let activeRefreshPromise: Promise<RefreshSummary> | null = null;
 
@@ -853,7 +862,7 @@ export const skillsStore = {
   /**
    * Refresh installed skills from the file system.
    */
-  async refreshInstalled(): Promise<void> {
+  async refreshInstalled(options: RefreshInstalledOptions = {}): Promise<void> {
     setState("isLoading", true);
     setState("error", null);
 
@@ -888,6 +897,9 @@ export const skillsStore = {
         installed.length,
         "installed skills",
       );
+      if (options.inspectSyncStatuses) {
+        await this.refreshAllSyncStatuses();
+      }
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to load installed skills";

--- a/tests/unit/agent-skill-sync-composer.test.ts
+++ b/tests/unit/agent-skill-sync-composer.test.ts
@@ -1,0 +1,24 @@
+// ABOUTME: Guards #2649 — agent chat must surface skill sync actions like Seren chat.
+// ABOUTME: Source-level because mounting AgentChat requires the full agent runtime harness.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentChatSource = readFileSync(
+  resolve("src/components/chat/AgentChat.tsx"),
+  "utf-8",
+);
+
+describe("agent chat skill sync composer affordance (#2649)", () => {
+  it("loads recent skill sync status without opening the Skills panel", () => {
+    expect(agentChatSource).toContain("skillsStore.loadSyncStatus(skill)");
+    expect(agentChatSource).toContain("skillsStore.syncStatusFor(skill.path)");
+  });
+
+  it("renders the shared SyncSkillButton and sync action for stale recent skills", () => {
+    expect(agentChatSource).toContain("SyncSkillButton");
+    expect(agentChatSource).toContain("activeSkillNeedsSync() && recentSkill()");
+    expect(agentChatSource).toContain("skillsStore.syncInstalledSkill(skill)");
+  });
+});

--- a/tests/unit/skills-sync-action.test.ts
+++ b/tests/unit/skills-sync-action.test.ts
@@ -172,6 +172,21 @@ describe("skillNeedsSync decides whether the composer Sync button shows (#2613)"
     expect(mockSkillsService.inspectSyncStatus).not.toHaveBeenCalled();
     expect(skillsStore.skillNeedsSync(skill)).toBe(false);
   });
+
+  it("hydrates sync status when installed inventory refresh requests inspection", async () => {
+    const skill = installedSkill("demo");
+    mockSkillsService.listAllInstalled.mockResolvedValue([skill]);
+    mockSkillsService.isUpstreamManagedSkill.mockReturnValue(true);
+    mockSkillsService.inspectSyncStatus.mockResolvedValue(
+      status({ state: "local-changes", hasLocalChanges: true }),
+    );
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refreshInstalled({ inspectSyncStatuses: true });
+
+    expect(mockSkillsService.inspectSyncStatus).toHaveBeenCalledWith(skill);
+    expect(skillsStore.skillNeedsSync(skill)).toBe(true);
+  });
 });
 
 describe("syncInstalledSkill gates every overwrite on confirmation (#2613)", () => {


### PR DESCRIPTION
## Summary
- Hydrates installed skill sync statuses when the app refreshes installed inventory after project-root changes, so chat surfaces do not depend on opening the Skills panel first.
- Adds Agent chat parity with Seren chat for stale recent skills: inspect sync status, render `SyncSkillButton`, and use the existing confirmation/overwrite gate.
- Adds focused regression coverage for installed-inventory sync-status hydration and Agent chat composer parity.

Fixes #2649

## Tests
- `pnpm vitest run tests/unit/skills-sync-action.test.ts tests/unit/agent-skill-sync-composer.test.ts`
- `pnpm vitest run tests/unit/skills-auto-sync.test.ts`
- `pnpm exec biome check src/App.tsx src/components/chat/AgentChat.tsx src/stores/skills.store.ts tests/unit/skills-sync-action.test.ts tests/unit/agent-skill-sync-composer.test.ts`
- `pnpm build`

## Functional Walkthrough Audit
- Reviewed screenshots `~/Desktop/sync1.png` and `~/Desktop/sync2.png`: sync state was only visible in the Skills panel.
- Verified audited code path: `SkillsExplorer` panel mount was the only Agent-visible path that populated and exposed sync attention; Agent chat did not render `SyncSkillButton`.
- Browser-local walkthrough on `http://127.0.0.1:5179/`: Seren chat toolbar rendered normally; unauthenticated browser-local runtime blocked full Agent thread creation, so Agent parity is covered by build/source regression tests.
- No new P0/P1 issue was identified in this change path. Existing unauthenticated browser-local warnings were unrelated to this patch.
