### PR TITLE
fix(gateway): retry init after a failed connect (#2654)

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -391,8 +391,15 @@ export async function initializeGateway(): Promise<void> {
     }
   })();
 
-  await loadingPromise;
-  loadingPromise = null;
+  // Clear the in-flight slot whether the connect succeeded or threw. A failed
+  // attempt must not leave a rejected promise cached here, or every later
+  // initializeGateway() call short-circuits on it and the gateway stays dead
+  // for the whole session (recoverable only by logout). See #2654.
+  try {
+    await loadingPromise;
+  } finally {
+    loadingPromise = null;
+  }
 }
 
 /**

--- a/tests/services/mcp-gateway.test.ts
+++ b/tests/services/mcp-gateway.test.ts
@@ -378,3 +378,44 @@ describe("MCP Gateway Native Tool Routing (#1329)", () => {
     });
   });
 });
+
+describe("MCP Gateway init recovery (#2654)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("retries connecting after a transient failure instead of caching the rejection", async () => {
+    const { mcpClient } = await import("@/lib/mcp/client");
+    const connectMock = vi.mocked(mcpClient.connectHttp);
+    // First connect attempt fails transiently; the second succeeds.
+    connectMock
+      .mockRejectedValueOnce(new Error("transient connect failure"))
+      .mockResolvedValue(undefined);
+
+    const { initializeGateway, isGatewayInitInFlight, isGatewayInitialized } =
+      await import("@/services/mcp-gateway");
+
+    // Suppress the expected "[MCP Gateway] Failed to connect" log so output
+    // stays pristine; assert it fired to document the failure path.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // First attempt rejects.
+    await expect(initializeGateway()).rejects.toThrow(
+      "transient connect failure",
+    );
+
+    // The in-flight slot must be cleared — never left holding a rejected
+    // promise, or every later call short-circuits on it (gateway dead until
+    // logout).
+    expect(isGatewayInitInFlight()).toBe(false);
+
+    // A subsequent attempt must re-enter the connect path and succeed.
+    await expect(initializeGateway()).resolves.toBeUndefined();
+    expect(connectMock).toHaveBeenCalledTimes(2);
+    expect(isGatewayInitialized()).toBe(true);
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #2654.

## Problem

`initializeGateway()` cached a **rejected** promise after a transient connect failure. The reset to `null` sat on the line *after* `await loadingPromise`, so it never ran on the throw path:

```ts
await loadingPromise;   // re-throws on failure
loadingPromise = null;  // never reached when the above throws
```

`loadingPromise` is reset only here (success) and in `resetGateway` (logout-only). So one transient `connectHttp` failure during the post-login window left every subsequent `initializeGateway()` short-circuiting on `if (loadingPromise) return loadingPromise` — returning the stuck rejected promise forever. The in-app Seren gateway and the **entire publisher tool catalog** (`callGatewayTool`/`getGatewayTools`) stayed dead for the whole session; only logout recovered it (a token refresh did not).

## Fix

Wrap the await in `try/finally` so the in-flight slot always clears:

```ts
try {
  await loadingPromise;
} finally {
  loadingPromise = null;
}
```

Caller error semantics are unchanged — `initializeMcpInBackground`'s try/catch and `waitForGatewayReady`'s `.catch` already absorb the rejection.

## Test

Added a regression test in `tests/services/mcp-gateway.test.ts`: the first `connectHttp` rejects, then resolves. It asserts (a) `isGatewayInitInFlight()` returns to `false` after the failed attempt settles, (b) the next `initializeGateway()` re-enters the connect path (`connectHttp` called twice) and succeeds. **Verified the test FAILS on the pre-fix code** and passes with the fix.

## Verification

- `tsc --noEmit` clean; Biome clean on changed files.
- `tests/services/mcp-gateway.test.ts`: 10/10 pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
