### PR TITLE
fix(agent): force-provision Seren API key at spawn (#2655)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -475,7 +475,11 @@ import type {
   ToolCallEvent,
 } from "@/services/providers";
 import * as providerService from "@/services/providers";
-import { authStore, requestSignInModal } from "@/stores/auth.store";
+import {
+  authStore,
+  ensureApiKey,
+  requestSignInModal,
+} from "@/stores/auth.store";
 
 /** Set once we've subscribed to `provider-runtime://ready` so repeated
  *  initialize() calls don't stack listeners. */
@@ -3104,18 +3108,17 @@ export const agentStore = {
           setState("installStatus", null);
         }
 
-        // Get Seren API key to enable MCP tools for the agent.
-        // If null, auth may still be initializing — wait briefly and retry
-        // so the agent gets publisher access on cold start.
+        // Get the Seren API key that authorizes the agent's Seren MCP server.
+        // Without it the MCP config silently omits Seren entirely, so the agent
+        // launches with no publisher tools for the whole session.
+        // getSerenApiKey() only READS storage — if the key isn't there yet
+        // (cold start, or a transient provisioning failure that kept the
+        // session alive without a key, #2497), force-provision it now rather
+        // than spawning without publisher access. See #2655.
         let apiKey = await getSerenApiKey();
-        if (!apiKey) {
-          await new Promise((r) => setTimeout(r, 3000));
+        if (!apiKey && authStore.isAuthenticated) {
+          await ensureApiKey();
           apiKey = await getSerenApiKey();
-          if (apiKey) {
-            console.info(
-              "[AgentStore] API key became available after waiting for auth",
-            );
-          }
         }
         const enabledMcpServers = getEnabledMcpServers();
 

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -72,7 +72,7 @@ type EnsureApiKeyResult =
  * Ensure we have a Seren API key for MCP authentication.
  * Checks local storage first, only creates a new key if none stored.
  */
-async function ensureApiKey(): Promise<EnsureApiKeyResult> {
+export async function ensureApiKey(): Promise<EnsureApiKeyResult> {
   try {
     // Check if we already have a stored API key
     const existingKey = await getSerenApiKey();

--- a/tests/unit/compaction-auth-gate.test.ts
+++ b/tests/unit/compaction-auth-gate.test.ts
@@ -17,8 +17,10 @@ const authServiceSource = readFileSync(
 
 describe("#1639 — auto-compact auth gate", () => {
   it("imports authStore and the modal-trigger from auth.store (#1661 renamed promptLogin)", () => {
-    expect(agentStoreSource).toContain(
-      'import { authStore, requestSignInModal } from "@/stores/auth.store"',
+    // Match the import regardless of single- vs multi-line formatting or other
+    // co-imported symbols, so adding an import here doesn't trip the guard.
+    expect(agentStoreSource).toMatch(
+      /import\s*\{[^}]*\bauthStore\b[^}]*\brequestSignInModal\b[^}]*\}\s*from\s*["']@\/stores\/auth\.store["']/,
     );
   });
 


### PR DESCRIPTION
Closes #2655.

## Problem

The spawned Claude Code / Codex agent's Seren MCP server is synthesized **purely from the Seren API key** — `createRemoteSerenServer(apiKey)` returns `null` when the key is falsy and `buildProviderMcpConfig` silently drops it. No key ⇒ no Seren MCP, silently, for the whole session (unrecoverable under `--strict-mcp-config`).

The spawn path (`agent.store.ts`) only **re-read** storage after a blind 3-second wait:

```ts
let apiKey = await getSerenApiKey();   // READS only
if (!apiKey) { await sleep(3000); apiKey = await getSerenApiKey(); }
```

`getSerenApiKey()` never **creates** a key. So the #2497 case — where login deliberately keeps the session alive without a key after a transient (5xx/network) provisioning failure — leaves the agent permanently without Seren MCP, because nothing re-attempts key creation until the next token refresh, and a 3s re-read can't help.

## Fix

When the key is absent **and** the user is authenticated, force-provision it before building the MCP config:

```ts
let apiKey = await getSerenApiKey();
if (!apiKey && authStore.isAuthenticated) {
  await ensureApiKey();          // exported from auth.store; no-op if a key exists
  apiKey = await getSerenApiKey();
}
```

`ensureApiKey()` checks storage first (instant no-op when present), only creating a key when missing, and raises no sign-in modal of its own. This also removes the 3-second stall on the happy path. Unauthenticated runs (browser-local) skip the attempt, so no spurious `createApiKey` 401s.

A deeper follow-up — session-scoped re-injection so a key arriving mid-session recovers a *live* agent — is intentionally out of scope.

## Test

No new unit test: the change is a 4-line guard inside the large spawn function, and `ensureApiKey`'s behavior is already covered by `auth-store-apikey-ordering`. Updated the #1661 import guard in `compaction-auth-gate.test.ts` from an exact single-line string match to a format-robust regex (still asserts `authStore` + `requestSignInModal` are imported from `@/stores/auth.store`), since the added import is now wrapped multi-line by Biome.

## Verification

- `tsc --noEmit` clean; Biome clean on changed files.
- Full unit suite green: **2057 tests / 289 files passed.**

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
