### PR TITLE
Fix GLM chat turns stuck in Thinking

### DIFF
--- a/src/services/orchestrator-watchdog.ts
+++ b/src/services/orchestrator-watchdog.ts
@@ -1,0 +1,127 @@
+// ABOUTME: Progress watchdog for frontend orchestrator turns.
+// ABOUTME: Prevents chat turns from leaving the composer blocked forever.
+
+export const ORCHESTRATOR_STALL_THRESHOLD_MS = 30_000;
+export const ORCHESTRATOR_NO_PROGRESS_TIMEOUT_MS = 5 * 60_000;
+export const ORCHESTRATOR_WATCHDOG_TICK_MS = 5_000;
+
+export class OrchestratorNoProgressTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OrchestratorNoProgressTimeoutError";
+  }
+}
+
+export interface OrchestratorProgressWatchdog {
+  markProgress: () => void;
+  pause: () => void;
+  resume: () => void;
+  stop: () => void;
+  waitForTimeout: () => Promise<never>;
+  timedOut: () => boolean;
+}
+
+interface WatchdogOptions {
+  conversationId: string;
+  stallThresholdMs?: number;
+  noProgressTimeoutMs?: number;
+  tickMs?: number;
+  now?: () => number;
+  onStallChange: (stalled: boolean, conversationId: string) => void;
+  onTimeout?: (conversationId: string) => void | Promise<void>;
+  onTimeoutError?: (error: unknown, conversationId: string) => void;
+}
+
+function timeoutMessage(timeoutMs: number): string {
+  const minutes = Math.max(1, Math.round(timeoutMs / 60_000));
+  return (
+    `The model stopped sending progress for ${minutes} minutes, so Seren ` +
+    "stopped this turn and made the chat usable again. Please retry or switch models."
+  );
+}
+
+export function createOrchestratorProgressWatchdog({
+  conversationId,
+  stallThresholdMs = ORCHESTRATOR_STALL_THRESHOLD_MS,
+  noProgressTimeoutMs = ORCHESTRATOR_NO_PROGRESS_TIMEOUT_MS,
+  tickMs = ORCHESTRATOR_WATCHDOG_TICK_MS,
+  now = () => Date.now(),
+  onStallChange,
+  onTimeout,
+  onTimeoutError,
+}: WatchdogOptions): OrchestratorProgressWatchdog {
+  let stopped = false;
+  let paused = false;
+  let stalled = false;
+  let didTimeOut = false;
+  let lastProgressAt = now();
+  let rejectTimeout: (error: OrchestratorNoProgressTimeoutError) => void = () =>
+    undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    rejectTimeout = reject;
+  });
+
+  const clearStall = () => {
+    if (!stalled) return;
+    stalled = false;
+    onStallChange(false, conversationId);
+  };
+
+  const timer = setInterval(() => {
+    if (stopped || paused) return;
+
+    const quietMs = now() - lastProgressAt;
+    if (quietMs >= noProgressTimeoutMs) {
+      stopped = true;
+      didTimeOut = true;
+      clearInterval(timer);
+      clearStall();
+      void Promise.resolve(onTimeout?.(conversationId)).catch((error) => {
+        onTimeoutError?.(error, conversationId);
+      });
+      rejectTimeout(
+        new OrchestratorNoProgressTimeoutError(
+          timeoutMessage(noProgressTimeoutMs),
+        ),
+      );
+      return;
+    }
+
+    if (!stalled && quietMs >= stallThresholdMs) {
+      stalled = true;
+      onStallChange(true, conversationId);
+    }
+  }, tickMs);
+
+  return {
+    markProgress() {
+      if (stopped) return;
+      lastProgressAt = now();
+      clearStall();
+    },
+    pause() {
+      if (stopped) return;
+      paused = true;
+      clearStall();
+    },
+    resume() {
+      if (stopped) return;
+      paused = false;
+      lastProgressAt = now();
+      clearStall();
+    },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(timer);
+      clearStall();
+    },
+    waitForTimeout() {
+      return timeoutPromise;
+    },
+    timedOut() {
+      return didTimeOut;
+    },
+  };
+}

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -28,6 +28,11 @@ import {
 } from "@/services/memory";
 import { serializeHistory } from "@/services/orchestrator-history";
 import {
+  createOrchestratorProgressWatchdog,
+  OrchestratorNoProgressTimeoutError,
+  type OrchestratorProgressWatchdog,
+} from "@/services/orchestrator-watchdog";
+import {
   allowsClaudeAgent,
   allowsCodexAgent,
   allowsSerenPrivateAgent,
@@ -265,12 +270,33 @@ export async function orchestrate(
   let unlistenTransition: UnlistenFn | null = null;
   let unlistenEvent: UnlistenFn | null = null;
   let unlistenToolRequest: UnlistenFn | null = null;
+  let watchdog: OrchestratorProgressWatchdog | null = null;
 
   try {
+    watchdog = createOrchestratorProgressWatchdog({
+      conversationId,
+      onStallChange: (stalled, id) =>
+        conversationStore.setStreamingStalled(stalled, id),
+      onTimeout: async (id) => {
+        try {
+          await invoke("cancel_orchestration", { conversationId: id });
+        } catch (error) {
+          console.warn("[orchestrator] Watchdog cancel failed:", error);
+        }
+      },
+      onTimeoutError: (error, id) => {
+        console.warn(
+          `[orchestrator] Watchdog timeout cleanup failed for ${id}:`,
+          error,
+        );
+      },
+    });
+
     unlistenTransition = await listen<TransitionEvent>(
       "orchestrator://transition",
       (event) => {
         if (event.payload.conversation_id === conversationId) {
+          watchdog?.markProgress();
           handleTransition(event.payload);
         }
       },
@@ -280,6 +306,7 @@ export async function orchestrate(
       "orchestrator://event",
       (event) => {
         if (event.payload.conversation_id === conversationId) {
+          watchdog?.markProgress();
           handleWorkerEvent(event.payload);
         }
       },
@@ -287,7 +314,12 @@ export async function orchestrate(
 
     unlistenToolRequest = await listen<ToolExecutionRequest>(
       "orchestrator://tool-request",
-      (event) => handleToolRequest(event.payload),
+      (event) => {
+        watchdog?.pause();
+        void handleToolRequest(event.payload).finally(() => {
+          watchdog?.resume();
+        });
+      },
     );
 
     // 5. Invoke the Rust orchestrator (auth token read from store on Rust side)
@@ -296,18 +328,32 @@ export async function orchestrate(
       mime_type: img.mimeType,
       base64: img.base64,
     }));
-    await invoke("orchestrate", {
-      conversationId,
-      assistantMessageId: stream.messageId,
-      prompt,
-      history,
-      capabilities,
-      images: imagePayload,
-    });
+    await Promise.race([
+      invoke("orchestrate", {
+        conversationId,
+        assistantMessageId: stream.messageId,
+        prompt,
+        history,
+        capabilities,
+        images: imagePayload,
+      }),
+      watchdog.waitForTimeout(),
+    ]);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    handleError(message, conversationId);
+    const completedTurn =
+      error instanceof OrchestratorNoProgressTimeoutError &&
+      conversationStore.getMessagesFor(conversationId).some((msg) => {
+        if (msg.id !== stream.messageId || msg.status !== "complete") {
+          return false;
+        }
+        return Boolean(msg.content.trim() || msg.thinking?.trim());
+      });
+    if (!completedTurn) {
+      handleError(message, conversationId);
+    }
   } finally {
+    watchdog?.stop();
     unlistenTransition?.();
     unlistenEvent?.();
     unlistenToolRequest?.();

--- a/tests/unit/orchestrator-watchdog.test.ts
+++ b/tests/unit/orchestrator-watchdog.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Critical regression tests for stalled chat-model turn recovery.
+// ABOUTME: Keeps the normal orchestrator path from leaving chat stuck loading.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  createOrchestratorProgressWatchdog,
+  OrchestratorNoProgressTimeoutError,
+} from "@/services/orchestrator-watchdog";
+
+describe("orchestrator progress watchdog", () => {
+  it("marks stalls, clears on progress, pauses for tool approval, and times out", async () => {
+    vi.useFakeTimers();
+    let now = 0;
+    const stalls: boolean[] = [];
+    const onTimeout = vi.fn();
+
+    const watchdog = createOrchestratorProgressWatchdog({
+      conversationId: "conv-2661",
+      stallThresholdMs: 100,
+      noProgressTimeoutMs: 300,
+      tickMs: 50,
+      now: () => now,
+      onStallChange: (stalled) => stalls.push(stalled),
+      onTimeout,
+    });
+
+    now = 100;
+    await vi.advanceTimersByTimeAsync(50);
+    expect(stalls).toEqual([true]);
+
+    watchdog.markProgress();
+    expect(stalls).toEqual([true, false]);
+
+    watchdog.pause();
+    now = 10_000;
+    await vi.advanceTimersByTimeAsync(500);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    watchdog.resume();
+    now = 10_300;
+    const timeoutPromise = watchdog.waitForTimeout();
+    const timeoutExpectation = expect(timeoutPromise).rejects.toBeInstanceOf(
+      OrchestratorNoProgressTimeoutError,
+    );
+    await vi.advanceTimersByTimeAsync(50);
+
+    await timeoutExpectation;
+    expect(onTimeout).toHaveBeenCalledWith("conv-2661");
+    expect(watchdog.timedOut()).toBe(true);
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a frontend orchestrator progress watchdog for normal chat-model turns.
- Surface the existing stalled streaming hint after quiet periods.
- Cancel and terminally error a turn if no progress arrives within the recovery window, while pausing the watchdog during frontend tool-request approval/execution.

Fixes #2661

## Audit
- Confirmed affected path: `src/services/orchestrator.ts` normal chat-model turns set loading true and only cleared after `invoke("orchestrate")` resolved.
- Employee cloud-agent path already had a stall detector; normal chat-model path did not.
- The chat UI renders Thinking while `conversationStore.loading` stays true with empty streaming content.

## Verification
- `pnpm exec biome check src/services/orchestrator.ts src/services/orchestrator-watchdog.ts tests/unit/orchestrator-watchdog.test.ts`
- `pnpm exec vitest run tests/unit/orchestrator-watchdog.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run`
- `git diff --check`
- `pnpm build` (passed with existing Vite/Rolldown dependency annotation and chunk-size warnings)