### PR TITLE
fix(agent): recover Claude workflow results during replay

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1049,6 +1049,249 @@ function replayMetaFromHistoryEntry(entry) {
   };
 }
 
+function historyEntryAssistantText(entry) {
+  if (entry?.type !== "assistant") {
+    return "";
+  }
+
+  const blocks = Array.isArray(entry?.message?.content) ? entry.message.content : [];
+  return blocks
+    .filter((block) => block?.type === "text" && typeof block.text === "string")
+    .map((block) => block.text)
+    .join("\n");
+}
+
+function parseReplayTimestamp(value) {
+  const timestamp =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.length > 0
+        ? Date.parse(value)
+        : undefined;
+  return typeof timestamp === "number" && Number.isFinite(timestamp)
+    ? timestamp
+    : undefined;
+}
+
+function workflowScalarToText(value) {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value && typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+function workflowSourcesToText(sources) {
+  if (!Array.isArray(sources) || sources.length === 0) {
+    return "";
+  }
+
+  return sources
+    .map((source) => {
+      if (typeof source === "string") {
+        return source.trim();
+      }
+      if (!source || typeof source !== "object") {
+        return "";
+      }
+      const url = workflowScalarToText(source.url);
+      const title = workflowScalarToText(source.title);
+      if (title && url) {
+        return `${title} (${url})`;
+      }
+      return url || title || workflowScalarToText(source);
+    })
+    .filter(Boolean)
+    .join(", ");
+}
+
+function workflowFindingToText(finding, index) {
+  if (typeof finding === "string") {
+    return `${index + 1}. ${finding.trim()}`;
+  }
+
+  if (!finding || typeof finding !== "object") {
+    return "";
+  }
+
+  const claim =
+    workflowScalarToText(finding.claim) ||
+    workflowScalarToText(finding.title) ||
+    workflowScalarToText(finding.finding) ||
+    workflowScalarToText(finding);
+  if (!claim) {
+    return "";
+  }
+
+  const lines = [`${index + 1}. ${claim}`];
+  const confidence = workflowScalarToText(finding.confidence);
+  if (confidence) {
+    lines.push(`   Confidence: ${confidence}`);
+  }
+  const evidence = workflowScalarToText(finding.evidence);
+  if (evidence) {
+    lines.push(`   Evidence: ${evidence}`);
+  }
+  const vote = workflowScalarToText(finding.vote);
+  if (vote) {
+    lines.push(`   Vote: ${vote}`);
+  }
+  const sources = workflowSourcesToText(finding.sources);
+  if (sources) {
+    lines.push(`   Sources: ${sources}`);
+  }
+  return lines.join("\n");
+}
+
+function workflowArraySection(title, values, formatter) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return "";
+  }
+
+  const body = values
+    .map((value, index) => formatter(value, index))
+    .filter((line) => typeof line === "string" && line.trim().length > 0)
+    .join("\n");
+  return body ? `#### ${title}\n${body}` : "";
+}
+
+export function formatClaudeWorkflowResultForReplay(workflow) {
+  const result = workflow?.result;
+  if (typeof result === "string") {
+    return result.trim();
+  }
+  if (!result || typeof result !== "object") {
+    return "";
+  }
+
+  const workflowName =
+    typeof workflow?.workflowName === "string" && workflow.workflowName.trim()
+      ? workflow.workflowName.trim()
+      : "Claude workflow";
+  const sections = [`### ${workflowName} result`];
+
+  const summary = workflowScalarToText(result.summary);
+  if (summary) {
+    sections.push(summary);
+  }
+
+  const findings = workflowArraySection(
+    "Findings",
+    result.findings,
+    workflowFindingToText,
+  );
+  if (findings) {
+    sections.push(findings);
+  }
+
+  const caveats = workflowScalarToText(result.caveats);
+  if (caveats) {
+    sections.push(`#### Caveats\n${caveats}`);
+  }
+
+  const openQuestions = workflowArraySection(
+    "Open questions",
+    result.openQuestions,
+    (question, index) => {
+      const text = workflowScalarToText(question);
+      return text ? `${index + 1}. ${text}` : "";
+    },
+  );
+  if (openQuestions) {
+    sections.push(openQuestions);
+  }
+
+  if (sections.length === 1) {
+    try {
+      return JSON.stringify(result, null, 2);
+    } catch {
+      return "";
+    }
+  }
+
+  return sections.join("\n\n").trim();
+}
+
+function workflowResultAlreadyInParentHistory(parentAssistantText, replayText) {
+  if (!parentAssistantText || !replayText) {
+    return false;
+  }
+
+  const normalizedParent = parentAssistantText.replace(/\s+/g, " ");
+  const candidates = [
+    replayText,
+    replayText.replace(/^### [^\n]+\n+/, ""),
+  ];
+  return candidates.some((candidate) => {
+    const fingerprint = candidate.replace(/\s+/g, " ").trim().slice(0, 160);
+    return fingerprint.length >= 80 && normalizedParent.includes(fingerprint);
+  });
+}
+
+export async function readClaudeWorkflowReplayMessages(
+  historyPath,
+  sessionId,
+  parentAssistantText = "",
+) {
+  const workflowDir = path.join(path.dirname(historyPath), sessionId, "workflows");
+  let entries;
+  try {
+    entries = await fs.readdir(workflowDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const messages = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+
+    const workflowPath = path.join(workflowDir, entry.name);
+    let workflow;
+    try {
+      workflow = await readJson(workflowPath);
+    } catch {
+      continue;
+    }
+
+    const status =
+      typeof workflow?.status === "string"
+        ? workflow.status.toLowerCase()
+        : "";
+    if (status && !["completed", "done", "success", "succeeded"].includes(status)) {
+      continue;
+    }
+
+    const text = formatClaudeWorkflowResultForReplay(workflow);
+    if (!text || workflowResultAlreadyInParentHistory(parentAssistantText, text)) {
+      continue;
+    }
+
+    const runId =
+      typeof workflow?.runId === "string" && workflow.runId.trim()
+        ? workflow.runId.trim()
+        : path.basename(entry.name, ".json");
+    messages.push({
+      messageId: `claude-workflow-result:${runId}`,
+      text,
+      timestamp: parseReplayTimestamp(workflow?.timestamp ?? workflow?.startTime),
+    });
+  }
+
+  messages.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
+  return messages;
+}
+
 function replayClaudeHistoryEntry(emit, session, entry) {
   const type = entry?.type;
   if (type !== "user" && type !== "assistant") {
@@ -1149,6 +1392,7 @@ async function replayClaudeHistoryBestEffort(emit, session, cwd, sessionId) {
     return;
   }
 
+  const parentAssistantText = [];
   for (const line of bytes.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) {
@@ -1162,7 +1406,27 @@ async function replayClaudeHistoryBestEffort(emit, session, cwd, sessionId) {
       continue;
     }
 
+    const assistantText = historyEntryAssistantText(entry);
+    if (assistantText) {
+      parentAssistantText.push(assistantText);
+    }
     replayClaudeHistoryEntry(emit, session, entry);
+  }
+
+  const workflowMessages = await readClaudeWorkflowReplayMessages(
+    historyPath,
+    sessionId,
+    parentAssistantText.join("\n"),
+  );
+  for (const message of workflowMessages) {
+    emit("provider://message-chunk", {
+      sessionId: session.id,
+      text: message.text,
+      messageId: message.messageId,
+      timestamp: message.timestamp,
+      replay: true,
+      recoveryReplay: true,
+    });
   }
 
   emit("provider://prompt-complete", {

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -117,6 +117,8 @@ export interface MessageChunkEvent {
   timestamp?: number;
   /** True when this chunk was emitted from session history replay. */
   replay?: boolean;
+  /** True when replay repairs output recovered from provider sidecar history. */
+  recoveryReplay?: boolean;
   /** Producing agent inside a paired thread (claude-code | codex). */
   agentProvider?: string;
 }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -6134,6 +6134,7 @@ export const agentStore = {
           {
             replay: event.data.replay === true,
             messageId: event.data.messageId,
+            recoveryReplay: event.data.recoveryReplay === true,
             agentProvider: event.data.agentProvider,
           },
         );
@@ -6899,13 +6900,29 @@ export const agentStore = {
     text: string,
     isThought?: boolean,
     timestamp?: number,
-    meta?: { replay?: boolean; messageId?: string; agentProvider?: string },
+    meta?: {
+      replay?: boolean;
+      messageId?: string;
+      recoveryReplay?: boolean;
+      agentProvider?: string;
+    },
   ) {
     let session = state.sessions[sessionId];
     if (!session) return;
 
-    // Skip replay assistant/thought chunks when we have restored messages.
-    if (session.skipHistoryReplay) return;
+    const recoveryMessageId =
+      meta?.recoveryReplay === true ? meta?.messageId?.trim() : undefined;
+    if (
+      recoveryMessageId &&
+      session.messages.some((message) => message.id === recoveryMessageId)
+    ) {
+      return;
+    }
+
+    // Skip normal replay assistant/thought chunks when we have restored
+    // messages. Recovered provider sidecar outputs are allowed through only
+    // when their stable message id is absent from restored SQLite history.
+    if (session.skipHistoryReplay && !recoveryMessageId) return;
 
     // Paired threads interleave Claude and Codex output in one stream. A
     // producer change is a message boundary: land the previous agent's

--- a/tests/unit/agent-history-persistence.test.ts
+++ b/tests/unit/agent-history-persistence.test.ts
@@ -84,6 +84,9 @@ describe("agent message persistence guards", () => {
 
     expect(caseBody).toContain("replay: event.data.replay === true");
     expect(caseBody).toContain("messageId: event.data.messageId");
+    expect(caseBody).toContain(
+      "recoveryReplay: event.data.recoveryReplay === true",
+    );
   });
 
   it("handleMessageChunk uses replay message ids as assistant boundaries", () => {
@@ -97,6 +100,23 @@ describe("agent message persistence guards", () => {
     expect(handlerBody).toContain("streamingContentMessageId");
     expect(handlerBody).toContain(
       "this.finalizeStreamingContent(sessionId, { isReplay: true })",
+    );
+  });
+
+  it("recovered provider sidecar chunks can repair missing SQLite history", () => {
+    const handlerIdx = agentStoreSource.indexOf("\n  handleMessageChunk(");
+    expect(handlerIdx).toBeGreaterThan(0);
+    const handlerBody = agentStoreSource.slice(
+      handlerIdx,
+      agentStoreSource.indexOf("enqueueToolEvent(", handlerIdx),
+    );
+
+    expect(handlerBody).toContain("meta?.recoveryReplay === true");
+    expect(handlerBody).toContain(
+      "session.messages.some((message) => message.id === recoveryMessageId)",
+    );
+    expect(handlerBody).toContain(
+      "if (session.skipHistoryReplay && !recoveryMessageId) return",
     );
   });
 

--- a/tests/unit/claude-workflow-history-replay.test.ts
+++ b/tests/unit/claude-workflow-history-replay.test.ts
@@ -1,0 +1,121 @@
+// ABOUTME: Regression guard for #2666 - completed Claude workflow sidecar
+// ABOUTME: results must replay into restored Seren agent thread history.
+
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error - .mjs source is JS; type info isn't generated.
+import {
+  formatClaudeWorkflowResultForReplay,
+  readClaudeWorkflowReplayMessages,
+} from "../../bin/browser-local/claude-runtime.mjs";
+
+describe("#2666 - Claude workflow sidecar history replay", () => {
+  it("formats completed workflow result metadata as visible assistant text", () => {
+    const text = formatClaudeWorkflowResultForReplay({
+      workflowName: "deep-research",
+      result: {
+        summary: "No authoritative CCO-signable playbook exists.",
+        findings: [
+          {
+            claim: "The field is fragmented.",
+            confidence: "high",
+            evidence: "SEC and FINRA materials do not publish a standard.",
+            sources: ["https://example.com/sec", "https://example.com/finra"],
+          },
+        ],
+        caveats: "Paywalled vendor docs were not inspected.",
+        openQuestions: ["Whether COMPLY has an unpublished template."],
+      },
+    });
+
+    expect(text).toContain("### deep-research result");
+    expect(text).toContain("No authoritative CCO-signable playbook exists.");
+    expect(text).toContain("1. The field is fragmented.");
+    expect(text).toContain("Confidence: high");
+    expect(text).toContain("Sources: https://example.com/sec");
+    expect(text).toContain("#### Caveats");
+    expect(text).toContain("#### Open questions");
+  });
+
+  it("reads completed sidecar workflows next to the Claude session jsonl", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "claude-workflow-replay-"));
+    const sessionId = "session-123";
+    const projectDir = path.join(root, "project");
+    const workflowDir = path.join(projectDir, sessionId, "workflows");
+    await mkdir(workflowDir, { recursive: true });
+
+    const historyPath = path.join(projectDir, `${sessionId}.jsonl`);
+    await writeFile(historyPath, "", "utf8");
+    await writeFile(
+      path.join(workflowDir, "wf_done.json"),
+      JSON.stringify({
+        runId: "wf_done",
+        status: "completed",
+        timestamp: "2026-06-26T08:15:23.853Z",
+        workflowName: "deep-research",
+        result: {
+          summary: "Recovered sidecar result.",
+          findings: [{ claim: "The missing output exists." }],
+        },
+      }),
+      "utf8",
+    );
+    await writeFile(
+      path.join(workflowDir, "wf_running.json"),
+      JSON.stringify({
+        runId: "wf_running",
+        status: "running",
+        result: { summary: "Do not replay in-progress output." },
+      }),
+      "utf8",
+    );
+
+    const messages = await readClaudeWorkflowReplayMessages(
+      historyPath,
+      sessionId,
+      "",
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      messageId: "claude-workflow-result:wf_done",
+      text: expect.stringContaining("Recovered sidecar result."),
+      timestamp: Date.parse("2026-06-26T08:15:23.853Z"),
+    });
+  });
+
+  it("skips sidecar output already present in parent assistant history", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "claude-workflow-replay-"));
+    const sessionId = "session-456";
+    const projectDir = path.join(root, "project");
+    const workflowDir = path.join(projectDir, sessionId, "workflows");
+    await mkdir(workflowDir, { recursive: true });
+
+    const historyPath = path.join(projectDir, `${sessionId}.jsonl`);
+    await writeFile(historyPath, "", "utf8");
+    await writeFile(
+      path.join(workflowDir, "wf_done.json"),
+      JSON.stringify({
+        runId: "wf_done",
+        status: "completed",
+        workflowName: "deep-research",
+        result: {
+          summary:
+            "This exact completed workflow result was already written into the parent assistant transcript and should not replay twice.",
+        },
+      }),
+      "utf8",
+    );
+
+    const messages = await readClaudeWorkflowReplayMessages(
+      historyPath,
+      sessionId,
+      "This exact completed workflow result was already written into the parent assistant transcript and should not replay twice.",
+    );
+
+    expect(messages).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Replays completed Claude Code workflow sidecar results during Claude history restoration.
- Formats workflow result metadata into visible assistant text with a stable `claude-workflow-result:<workflow-run-id>` message id.
- Allows only missing recovered sidecar chunks through the restored-history replay skip guard, so existing SQLite messages still prevent duplicate parent transcript replay.

Closes #2666.

## Verification
- `pnpm vitest run tests/unit/claude-workflow-history-replay.test.ts tests/unit/agent-history-persistence.test.ts tests/unit/claude-spawn-replay-deferred.test.ts`
- `pnpm build:provider-runtime`
- `pnpm test:runtime-smoke`
- Functional audit: verified the new replay reader recovers a completed workflow result from the Claude Code sidecar transcript layout without requiring private local paths, usernames, transcript IDs, or prompt contents.

## Privacy
- Public issue and PR text intentionally use generic transcript path shapes only.
- No private local paths, usernames, transcript UUIDs, or user prompt contents are included.
