### PR TITLE
ci: harden cargo against transient crates.io download flakes (#2665)

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -8,6 +8,14 @@ on:
   issues:
     types: [labeled]
 
+env:
+  # Harden cargo against transient crates.io download flakes (curl error 56,
+  # connection reset mid-stream). Cargo's default net.retry is 3 and does not
+  # always recover an in-flight reset; bump retries and disable HTTP/2
+  # multiplexing so a dropped connection cannot fail the agent's cargo build/check.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
+
 jobs:
   fix:
     # Only run when the agent-task label is applied

--- a/.github/workflows/build-publisher-sidecars.yml
+++ b/.github/workflows/build-publisher-sidecars.yml
@@ -18,6 +18,14 @@ concurrency:
   group: build-publisher-sidecars-${{ github.event.inputs.publisher_version }}
   cancel-in-progress: false
 
+env:
+  # Harden cargo against transient crates.io download flakes (curl error 56,
+  # connection reset mid-stream). Cargo's default net.retry is 3 and does not
+  # always recover an in-flight reset; bump retries and disable HTTP/2
+  # multiplexing so one dropped connection cannot fail a sidecar build.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Harden cargo against transient crates.io download flakes (curl error 56,
+  # connection reset mid-stream). Cargo's default net.retry is 3 and does not
+  # always recover an in-flight reset; bump retries and disable HTTP/2
+  # multiplexing so one dropped connection cannot fail the Rust test or build job.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
+
 jobs:
   check-commit-subjects:
     # Validates each non-merge commit subject in the PR diff against

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  # Harden cargo against transient crates.io download flakes (curl error 56,
+  # connection reset mid-stream). Cargo's default net.retry is 3 and does not
+  # always recover an in-flight reset; bump retries and disable HTTP/2
+  # multiplexing so one dropped connection cannot fail a whole platform's build.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
   TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
   # Signing availability flags (for conditional steps)


### PR DESCRIPTION
## Summary

Fixes #2665. Release and CI Rust builds could die when a single crates.io download was reset mid-stream (`curl error 56: connection reset by peer`). Cargo's default `net.retry` is **3** and does not reliably recover an in-flight connection reset, so one dropped connection failed a whole platform's release artifacts and forced a manual re-run (the `v3.61.1` Linux-arm64 job).

## Fix

Set workflow-level cargo network hardening in **every workflow that compiles Rust**:

```yaml
env:
  CARGO_NET_RETRY: "10"
  CARGO_HTTP_MULTIPLEXING: "false"   # avoid HTTP/2 multiplexing resets on flaky links
```

| Workflow | Cargo exposure hardened |
|---|---|
| `release.yml` | 5-platform `pnpm tauri build` matrix (the failing run) |
| `ci.yml` | `cargo test` + `pnpm tauri build` |
| `build-publisher-sidecars.yml` | `cargo build --release` |
| `agent-fix.yml` | autonomous agent runs `cargo build`/`check` |

The issue named release.yml + the CI build workflow; the other two share the **identical** crates.io exposure (Rust toolchain + `Swatinem/rust-cache` + cargo invocation) and the fix is identical, additive, and harmless, so they're hardened in the same pass.

## Why workflow-level `env:`

GitHub Actions merges env across levels (workflow -> job -> step) rather than replacing, and no job/step overrides `CARGO_NET_RETRY` or `CARGO_HTTP_MULTIPLEXING` in any of these files — so **all matrix platforms inherit the hardening** from one place. Disabling HTTP/2 multiplexing forces HTTP/1.1 with separate connections, which sidesteps the stream-reset failure mode the issue hit.

## Audit / verification

- Confirmed **no** existing `CARGO_NET_RETRY`/`CARGO_HTTP_MULTIPLEXING` anywhere in `.github/workflows/` before this change (the root cause).
- Confirmed `publish-release-manual.yml`, `retry-notarization.yml`, `esigner-cka-preflight.yml`, and the R2 prune/restore workflows do **not** compile Rust — no exposure, intentionally untouched.
- Validated all four edited YAML files parse cleanly.
- Verified cargo accepts both env vars as valid typed config (`CARGO_NET_RETRY=10 CARGO_HTTP_MULTIPLEXING=false cargo --version` -> exit 0).

## Acceptance criteria

- [x] `CARGO_NET_RETRY` (+ `CARGO_HTTP_MULTIPLEXING=false`) set for release builds across all 5 matrix platforms
- [x] Transient crates.io download resets are retried automatically rather than failing the job
- [x] No change to signing, notarization, or artifact upload behavior

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
