### PR TITLE
fix(agent): skip re-attach for paired threads to preserve PairedStatus (#2672)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3614,6 +3614,14 @@ export const agentStore = {
       return false;
     }
 
+    // Paired (claude-codex) threads are a two-inner-session structure whose
+    // PairedStatus the runtime's flat session info does not expose. Re-adopting
+    // one would drop the paired UI, so leave paired resumes on the existing
+    // terminate+respawn path (which reseeds pairedConfig from metadata). #2672
+    if (liveInfo.agentType === "claude-codex") {
+      return false;
+    }
+
     // Restore the persisted transcript for display. The live session already
     // streamed these turns while connected; re-attach renders them from SQLite
     // rather than replaying from a fresh process.

--- a/tests/unit/resume-reattach-live-session-2669.test.ts
+++ b/tests/unit/resume-reattach-live-session-2669.test.ts
@@ -73,4 +73,10 @@ describe("#2669 — resume re-attaches to a live session instead of reaping it",
     expect(reattachBody).toContain('liveInfo.status === "error"');
     expect(reattachBody).toContain("return false");
   });
+
+  it("reattach skips paired (claude-codex) threads to preserve their UI", () => {
+    // Paired threads carry a two-inner-session PairedStatus the flat runtime
+    // info cannot reconstruct; they must take the respawn path instead. #2672
+    expect(reattachBody).toContain('liveInfo.agentType === "claude-codex"');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2672 — follow-up to #2669/#2671.

`reattachLiveSession` (added in #2671) rebuilds an `ActiveSession` from the runtime's flat `AgentSessionInfo`, which does not expose paired (claude-codex) inner-session structure. Adopting a paired thread that way drops its `PairedStatus` and degrades the planner/executor UI until the thread is restarted.

## Fix

Return `false` from `reattachLiveSession` when `liveInfo.agentType === "claude-codex"`, so paired resumes take the existing terminate+respawn path that reseeds `pairedConfig` from conversation metadata. Single-session agents (claude-code, codex, gemini, lmstudio) are unaffected and still re-attach.

## Testing

- Extends `tests/unit/resume-reattach-live-session-2669.test.ts` with a case asserting the paired guard is present (5/5 pass).
- `biome check` clean on changed files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com