### PR TITLE
fix(agent): keep mid-turn re-attached sessions rendering (#2674)

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3645,6 +3645,9 @@ export const agentStore = {
     spawnContextMap.delete(conversationId);
 
     const hasRestoredMessages = restored.messages.length > 0;
+    // The live session may be mid-turn at re-attach time (e.g. a reload while
+    // the agent is answering). The runtime reports this as "prompting".
+    const liveTurnInFlight = liveInfo.status === "prompting";
     const session: ActiveSession = {
       info: liveInfo,
       messages: restored.messages,
@@ -3656,10 +3659,19 @@ export const agentStore = {
       cwd: liveInfo.cwd,
       conversationId,
       agentSessionId: liveInfo.agentSessionId,
-      skipHistoryReplay: hasRestoredMessages ? true : undefined,
+      // Re-attach performs NO provider replay (it never respawns the CLI), so
+      // there are no replay events to suppress — only live ones. Setting
+      // skipHistoryReplay here would make every live event handler early-return
+      // and silently drop the entire in-flight turn (and its persistence).
+      // Leave it unset so live chunks/tool calls render; restored history won't
+      // duplicate because the live session only emits new forward events. #2674
+      skipHistoryReplay: undefined,
       restoredMessageCount: hasRestoredMessages
         ? restored.messages.length
         : undefined,
+      // A mid-turn re-attach has no record of when the turn began; seed the
+      // elapsed-time clock now so the "Thinking…" indicator reflects reality.
+      promptStartTime: liveTurnInFlight ? Date.now() : undefined,
       contextWindowSize: defaultContextWindowFor(
         agentType,
         convo?.agent_model_id ?? undefined,
@@ -3672,6 +3684,13 @@ export const agentStore = {
     };
     setState("sessions", conversationId, session);
     setState("activeSessionId", conversationId);
+
+    // Reflect an in-flight turn so the UI shows activity instead of looking
+    // idle while the re-attached agent is actually working. Cleared on the
+    // turn's promptComplete/cancel like any other turn. #2674
+    if (liveTurnInFlight) {
+      this.setTurnInFlight(conversationId, true);
+    }
 
     // Drain events buffered by the global subscriber while no session record
     // existed for this id.

--- a/tests/unit/resume-reattach-live-session-2669.test.ts
+++ b/tests/unit/resume-reattach-live-session-2669.test.ts
@@ -79,4 +79,17 @@ describe("#2669 — resume re-attaches to a live session instead of reaping it",
     // info cannot reconstruct; they must take the respawn path instead. #2672
     expect(reattachBody).toContain('liveInfo.agentType === "claude-codex"');
   });
+
+  it("reattach never sets skipHistoryReplay (no replay occurs on re-attach)", () => {
+    // Re-attach does not respawn, so there are no replay events to suppress.
+    // Setting skipHistoryReplay would drop the entire live in-flight turn. #2674
+    expect(reattachBody).toContain("skipHistoryReplay: undefined");
+    expect(reattachBody).not.toContain("skipHistoryReplay: hasRestoredMessages");
+  });
+
+  it("reattach reflects an in-flight turn when the live session is prompting", () => {
+    // A mid-turn re-attach must show activity, not look idle. #2674
+    expect(reattachBody).toContain('liveInfo.status === "prompting"');
+    expect(reattachBody).toContain("setTurnInFlight(conversationId, true)");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2674 — follow-up to #2669/#2671, found in a self-audit of the re-attach path.

When `reattachLiveSession` adopts a session that is **mid-turn** at reload (`status === "prompting"`):

1. **The in-flight turn was silently dropped.** Re-attach copied `skipHistoryReplay: true` from the spawn path, where it suppresses the `--resume` replay. But re-attach performs **no** replay (it never respawns the CLI), so the flag had nothing to suppress and instead made every live event handler (`handleMessageChunk`/`handleToolCall`/`handleToolResult`) early-return — dropping the entire turn and its SQLite persistence. The user saw their prompt with no answer.
2. **No activity indicator.** `setTurnInFlight(true)` is only called inside `sendPrompt`; re-attach never set it, so the UI looked idle while the agent worked.

## Fix

- Leave `skipHistoryReplay` unset on re-attach so live events render and persist. Restored SQLite history cannot duplicate — the live session only emits new forward events; `restoredMessageCount` is still kept for the compaction math.
- When `liveInfo.status === "prompting"`, mark the turn in-flight and seed `promptStartTime` so the Thinking indicator reflects reality. Cleared by the turn’s normal promptComplete/cancel.

Common #2669 case (main turn done, background subagent running, session `ready`) is unaffected; paired threads already bail out (#2672).

## Testing

- Extends `tests/unit/resume-reattach-live-session-2669.test.ts` (now 7/7): asserts re-attach never sets `skipHistoryReplay` and marks the turn in-flight when prompting.
- `biome check` clean; lifecycle test subset green.

P2 edges (pending-approval re-hydration, concurrent-resume dedup, stale model/mode) tracked separately in #2675.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com