### PR TITLE
Fix org-owned skill folder alias manifest downloads

### DIFF
--- a/src/lib/skills/display.ts
+++ b/src/lib/skills/display.ts
@@ -96,6 +96,7 @@ export function skillsShareCommandAlias(
  * 1. catalog.slug === installed.slug                  (default case)
  * 2. catalog.slug === installed.dirName               (local slug drift)
  * 3. catalog.skillFolderName === installed.dirName    (org-namespaced)
+ * 4. catalog.skillFolderName === installed.slug       (parsed local slug)
  */
 export function catalogSkillMatchesInstalled(
   candidate: Skill,
@@ -105,7 +106,8 @@ export function catalogSkillMatchesInstalled(
   if (candidate.slug === installed.dirName) return true;
   if (
     candidate.skillFolderName &&
-    candidate.skillFolderName === installed.dirName
+    (candidate.skillFolderName === installed.dirName ||
+      candidate.skillFolderName === installed.slug)
   ) {
     return true;
   }

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -93,6 +93,12 @@ export interface Skill {
    * when the slug diverges from the install directory.
    */
   skillFolderName?: string;
+  /**
+   * Catalog mirror folder when the publisher exposes it. Combined with
+   * `skillFolderName`, this identifies legacy raw GitHub paths whose API slug
+   * is now org-namespaced.
+   */
+  folderSlug?: string | null;
   /** Slug-based name (used for lookups) */
   name: string;
   /** Human-readable display name from frontmatter */

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -29,6 +29,7 @@ import {
 import { log } from "@/lib/logger";
 import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import {
+  catalogSkillMatchesInstalled,
   computeBytesHash,
   computeContentHash,
   getSkillPath,
@@ -310,6 +311,7 @@ function skillSummaryToSkill(summary: SkillSummary): Skill {
     id: `seren:${summary.slug}`,
     slug: summary.slug,
     skillFolderName: summary.skill_folder_name,
+    folderSlug: summary.folder_slug ?? null,
     name: humanizeSkillName(summary.name, summary.slug),
     description: summary.description,
     source: "seren",
@@ -342,6 +344,7 @@ function skillToCacheEntry(skill: Skill): Skill {
     id: skill.id,
     slug: skill.slug,
     skillFolderName: skill.skillFolderName,
+    folderSlug: skill.folderSlug,
     name: skill.name,
     displayName: skill.displayName,
     description: skill.description,
@@ -1222,8 +1225,9 @@ async function fetchUpstreamSkillBundle(
   options?: SkillInstallOptions,
 ): Promise<UpstreamSkillBundle | null> {
   const slug =
+    (skill.sourceUrl ? skillSlugFromSourceUrl(skill.sourceUrl) : null) ??
     skill.slug ??
-    (skill.sourceUrl ? skillSlugFromSourceUrl(skill.sourceUrl) : null);
+    null;
   if (!slug) return null;
   const bundle = await downloadSkillBundle(slug, options);
   return {
@@ -1270,6 +1274,55 @@ function isManagedFileMap(value: unknown): value is Record<string, string> {
   return Object.entries(value).every(
     ([path, hash]) => typeof path === "string" && typeof hash === "string",
   );
+}
+
+function normalizeSkillMatchText(value: string | null | undefined): string {
+  return (value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function installedSkillNameMatchesCatalog(
+  installed: InstalledSkill,
+  candidate: Skill,
+): boolean {
+  const installedNames = new Set(
+    [installed.displayName, installed.name]
+      .map(normalizeSkillMatchText)
+      .filter((value) => value.length > 0),
+  );
+  if (installedNames.size === 0) return false;
+  return [candidate.displayName, candidate.name]
+    .map(normalizeSkillMatchText)
+    .some((value) => value.length > 0 && installedNames.has(value));
+}
+
+function findCatalogBackfillMatch(
+  installed: InstalledSkill,
+  available: Skill[],
+): Skill | null {
+  const candidates = available.filter(
+    (candidate) =>
+      candidate.source === "seren" &&
+      Boolean(candidate.sourceUrl) &&
+      catalogSkillMatchesInstalled(candidate, installed),
+  );
+  if (candidates.length === 0) return null;
+
+  const direct = candidates.find(
+    (candidate) =>
+      candidate.slug === installed.slug || candidate.slug === installed.dirName,
+  );
+  if (direct) return direct;
+
+  const nameMatches = candidates.filter((candidate) =>
+    installedSkillNameMatchesCatalog(installed, candidate),
+  );
+  if (nameMatches.length === 1) return nameMatches[0];
+
+  return candidates.length === 1 ? candidates[0] : null;
 }
 
 function parseInstalledSyncState(
@@ -2417,9 +2470,12 @@ export const skills = {
 
   /**
    * Backfill sync state for installed skills that were installed before the
-   * sync feature existed (pre-v2.3.16). Matches installed skills missing
-   * sync state to available Seren Skills by slug, then writes a minimal
-   * .seren-sync.json so the upstream refresh flow can detect updates.
+   * sync feature existed (pre-v2.3.16), and repair early sync states that
+   * stored the install folder (`grant-intake`) instead of the canonical
+   * publisher slug (`chief-grants-officer-grant-intake`). Matches installed
+   * skills to available Seren Skills by slug or by org-owned
+   * `skill_folder_name` with name disambiguation, then writes .seren-sync.json
+   * so the upstream refresh flow can detect updates.
    */
   async backfillSyncState(
     installed: InstalledSkill[],
@@ -2427,26 +2483,42 @@ export const skills = {
   ): Promise<number> {
     if (!isTauriRuntime()) return 0;
 
-    const remoteSkillsBySlug = new Map<string, Skill>();
-    for (const skill of available) {
-      if (skill.source === "seren" && skill.sourceUrl) {
-        remoteSkillsBySlug.set(skill.slug, skill);
-      }
-    }
-
     let backfilled = 0;
 
     for (const skill of installed) {
-      // Skip skills that already have sync state
-      if (skill.syncState) continue;
-
-      // Try matching by slug first, then fall back to dirName (which always
-      // equals the marketplace slug even when resolveSkillSlug() derives a
-      // different slug from SKILL.md frontmatter name).
-      const match =
-        remoteSkillsBySlug.get(skill.slug) ??
-        remoteSkillsBySlug.get(skill.dirName);
+      const match = findCatalogBackfillMatch(skill, available);
       if (!match?.sourceUrl) {
+        continue;
+      }
+
+      if (skill.syncState) {
+        if (skill.syncState.upstreamSourceUrl === match.sourceUrl) {
+          continue;
+        }
+
+        const repairedSyncState: SkillSyncState = {
+          ...skill.syncState,
+          upstreamSource: "seren",
+          upstreamSourceUrl: match.sourceUrl,
+          upstreamDeleted: undefined,
+        };
+
+        try {
+          await invoke("write_skill_sync_state", {
+            skillsDir: skill.skillsDir,
+            slug: skill.dirName,
+            stateJson: JSON.stringify(repairedSyncState),
+          });
+          backfilled++;
+          log.info(
+            "[Skills] Repaired sync state for",
+            skill.slug,
+            "→",
+            match.sourceUrl,
+          );
+        } catch (err) {
+          log.warn("[Skills] Failed to repair sync state for", skill.slug, err);
+        }
         continue;
       }
 

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -9,6 +9,7 @@ import { log } from "@/lib/logger";
 import { queryClient } from "@/lib/query-client";
 import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import {
+  catalogSkillMatchesInstalled,
   filterHostCompatibleCatalog,
   type InstalledSkill,
   isSkillCompatibleWithHost,
@@ -115,6 +116,26 @@ function makeProjectConfig(enabled: string[]): ProjectSkillsConfig {
 
 function skillRef(skill: Pick<InstalledSkill, "scope" | "slug">): string {
   return `${skill.scope}:${skill.slug}`;
+}
+
+function normalizeSkillIdentityText(value: string | null | undefined): string {
+  return (value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function skillNamesMatch(candidate: Skill, installed: InstalledSkill): boolean {
+  const candidateNames = new Set(
+    [candidate.displayName, candidate.name]
+      .map(normalizeSkillIdentityText)
+      .filter((value) => value.length > 0),
+  );
+  if (candidateNames.size === 0) return false;
+  return [installed.displayName, installed.name]
+    .map(normalizeSkillIdentityText)
+    .some((value) => value.length > 0 && candidateNames.has(value));
 }
 
 function applyAvailableCatalog(all: Skill[]): void {
@@ -378,12 +399,27 @@ export const skillsStore = {
     const skill = state.available.find((s) => s.id === skillId);
     if (!skill) return false;
     return state.installed.some((s) => {
-      if (s.slug !== skill.slug) return false;
-      // dirName matches slug — genuine install
-      if (s.dirName === s.slug) return true;
-      // dirName differs but has upstream sync state linking to this source — genuine install
-      if (s.syncState && s.upstreamSourceUrl) return true;
-      // dirName differs, no sync state — stale skill with coincidental slug collision
+      if (s.slug === skill.slug) {
+        if (s.dirName === s.slug) return true;
+        if (skill.sourceUrl && s.upstreamSourceUrl === skill.sourceUrl) {
+          return true;
+        }
+        return false;
+      }
+      if (s.dirName === skill.slug) return true;
+      if (
+        !skill.skillFolderName ||
+        (skill.skillFolderName !== s.dirName &&
+          skill.skillFolderName !== s.slug)
+      ) {
+        return false;
+      }
+      if (skill.sourceUrl && s.upstreamSourceUrl === skill.sourceUrl) {
+        return true;
+      }
+      // Folder names are not globally unique across org-owned skills, so an
+      // unsynced local folder also needs the human skill name to line up.
+      if (skillNamesMatch(skill, s)) return true;
       return false;
     });
   },
@@ -950,13 +986,13 @@ export const skillsStore = {
 
     // Backfill sync state for skills installed before the sync feature
     // existed (pre-v2.3.16). Non-blocking: failures are logged and skipped.
-    const needsBackfill = state.installed.some(
-      (s) =>
-        !s.syncState &&
-        state.available.some(
-          (a) =>
-            (a.slug === s.slug || a.slug === s.dirName) && a.source === "seren",
-        ),
+    const needsBackfill = state.installed.some((s) =>
+      state.available.some(
+        (a) =>
+          a.source === "seren" &&
+          catalogSkillMatchesInstalled(a, s) &&
+          (!s.syncState || s.upstreamSourceUrl !== a.sourceUrl),
+      ),
     );
     if (needsBackfill) {
       const count = await skills.backfillSyncState(

--- a/tests/unit/skills-auto-sync.test.ts
+++ b/tests/unit/skills-auto-sync.test.ts
@@ -483,6 +483,113 @@ describe("backfill triggers for slug/dirName mismatch (#1558)", () => {
 
     expect(mockSkillsService.backfillSyncState).toHaveBeenCalled();
   });
+
+  it("triggers backfill when an org-owned catalog folder name matches the install dir", async () => {
+    const installedSkill = {
+      slug: "grant-intake",
+      dirName: "grant-intake",
+      scope: "seren" as const,
+      source: "seren",
+      path: "/skills/grant-intake/SKILL.md",
+      syncState: undefined,
+    };
+    const catalogEntry = {
+      slug: "chief-grants-officer-grant-intake",
+      skillFolderName: "grant-intake",
+      source: "seren",
+      sourceUrl: "seren-skills:chief-grants-officer-grant-intake",
+    };
+
+    mockSkillsService.fetchAllSkills.mockResolvedValue([catalogEntry]);
+    mockSkillsService.listAllInstalled.mockResolvedValue([installedSkill]);
+    mockSkillsService.backfillSyncState.mockResolvedValue(1);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refresh();
+
+    expect(mockSkillsService.backfillSyncState).toHaveBeenCalled();
+  });
+
+  it("triggers backfill when sync state points at a stale folder alias", async () => {
+    const installedSkill = {
+      slug: "grant-intake",
+      dirName: "grant-intake",
+      scope: "seren" as const,
+      source: "seren",
+      path: "/skills/grant-intake/SKILL.md",
+      upstreamSourceUrl: "seren-skills:grant-intake",
+      syncState: {
+        upstreamSource: "seren",
+        upstreamSourceUrl: "seren-skills:grant-intake",
+        syncedRevision: "old",
+        syncedAt: 1,
+        managedFiles: {},
+      },
+    };
+    const catalogEntry = {
+      slug: "chief-grants-officer-grant-intake",
+      skillFolderName: "grant-intake",
+      source: "seren",
+      sourceUrl: "seren-skills:chief-grants-officer-grant-intake",
+    };
+
+    mockSkillsService.fetchAllSkills.mockResolvedValue([catalogEntry]);
+    mockSkillsService.listAllInstalled.mockResolvedValue([installedSkill]);
+    mockSkillsService.backfillSyncState.mockResolvedValue(1);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    await skillsStore.refresh();
+
+    expect(mockSkillsService.backfillSyncState).toHaveBeenCalled();
+  });
+});
+
+describe("isInstalled with org-owned folder aliases (#2676)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("does not mark sibling catalog rows installed when a folder alias is ambiguous", async () => {
+    const installedSkill = {
+      slug: "grant-intake",
+      dirName: "grant-intake",
+      name: "Chief Grants Officer - Grant Intake",
+      scope: "seren" as const,
+      source: "local",
+      path: "/skills/grant-intake/SKILL.md",
+      syncState: undefined,
+    };
+    const chief = {
+      id: "seren:chief-grants-officer-grant-intake",
+      slug: "chief-grants-officer-grant-intake",
+      skillFolderName: "grant-intake",
+      name: "Chief Grants Officer - Grant Intake",
+      description: "",
+      source: "seren" as const,
+      sourceUrl: "seren-skills:chief-grants-officer-grant-intake",
+      tags: [],
+    };
+    const egeria = {
+      id: "seren:egeria-grant-intake",
+      slug: "egeria-grant-intake",
+      skillFolderName: "grant-intake",
+      name: "Egeria Grant Intake",
+      description: "",
+      source: "seren" as const,
+      sourceUrl: "seren-skills:egeria-grant-intake",
+      tags: [],
+    };
+
+    mockSkillsService.listAllInstalled.mockResolvedValue([installedSkill]);
+
+    const { skillsStore } = await import("@/stores/skills.store");
+    skillsStore.setAvailableCatalog([chief, egeria]);
+    await skillsStore.refreshInstalled();
+
+    expect(skillsStore.isInstalled(chief.id)).toBe(true);
+    expect(skillsStore.isInstalled(egeria.id)).toBe(false);
+  });
 });
 
 describe("silent skill refresh contract (#1891)", () => {

--- a/tests/unit/skills-index-api.test.ts
+++ b/tests/unit/skills-index-api.test.ts
@@ -35,7 +35,10 @@ function skillSummary(slug: string, tags: string[] = []) {
     deleted_at: null,
     description: "Skill description",
     discoverability: "public",
+    folder_slug: null,
+    github_mirror_health: "ok",
     id: `skill-${slug}`,
+    install_count: 0,
     name: "Test Skill",
     owner_kind: "user",
     owner_organization_id: "org-1",
@@ -128,6 +131,7 @@ describe("skills.fetchIndex via Seren Skills API", () => {
         skills: [
           {
             ...skillSummary("pk-lead-intelligence"),
+            folder_slug: "autumn",
             slug: "autumn-pk-lead-intelligence",
             skill_folder_name: "pk-lead-intelligence",
           },
@@ -143,6 +147,7 @@ describe("skills.fetchIndex via Seren Skills API", () => {
     expect(result[0]).toMatchObject({
       slug: "autumn-pk-lead-intelligence",
       skillFolderName: "pk-lead-intelligence",
+      folderSlug: "autumn",
     });
   });
 

--- a/tests/unit/skills-split-download.test.ts
+++ b/tests/unit/skills-split-download.test.ts
@@ -239,6 +239,41 @@ describe("split-download fallback (#2296)", () => {
     expect(mockDownloadSkillManifest).not.toHaveBeenCalled();
   });
 
+  it("uses sourceUrl as the canonical download slug when local slug is a folder alias", async () => {
+    mockDownloadSkill.mockResolvedValueOnce({
+      data: {
+        ...manifest,
+        skill: {
+          ...manifest.skill,
+          slug: "chief-grants-officer-grant-intake",
+          name: "Chief Grants Officer - Grant Intake",
+        },
+        files: [],
+      },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    await skills.install(
+      {
+        ...catalogSkill,
+        id: "seren:chief-grants-officer-grant-intake",
+        slug: "grant-intake",
+        name: "Chief Grants Officer - Grant Intake",
+        sourceUrl: "seren-skills:chief-grants-officer-grant-intake",
+      },
+      "",
+      "seren",
+      null,
+    );
+
+    expect(mockDownloadSkill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { slug: "chief-grants-officer-grant-intake" },
+      }),
+    );
+  });
+
   it("retries a transient 502 from the manifest endpoint and succeeds", async () => {
     vi.useFakeTimers();
     mockDownloadSkillManifest
@@ -276,5 +311,146 @@ describe("split-download fallback (#2296)", () => {
     await expect(
       skills.install(catalogSkill, "", "seren", null),
     ).rejects.toThrow(/republished|version/i);
+  });
+
+  it("backfills org-owned installs through skillFolderName with name disambiguation", async () => {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      switch (cmd) {
+        case "read_skill_content":
+          return "# Chief Grants Officer - Grant Intake\n";
+        case "write_skill_sync_state":
+          return null;
+        default:
+          return null;
+      }
+    });
+
+    const count = await skills.backfillSyncState(
+      [
+        {
+          id: "local:grant-intake",
+          slug: "grant-intake",
+          name: "Chief Grants Officer - Grant Intake",
+          description: "",
+          source: "local",
+          tags: [],
+          scope: "seren",
+          skillsDir: "/skills",
+          dirName: "grant-intake",
+          path: "/skills/grant-intake/SKILL.md",
+          installedAt: 1,
+          enabled: true,
+          contentHash: "local-hash",
+        },
+      ],
+      [
+        {
+          id: "seren:egeria-grant-intake",
+          slug: "egeria-grant-intake",
+          skillFolderName: "grant-intake",
+          name: "Egeria Grant Intake",
+          description: "",
+          source: "seren",
+          sourceUrl: "seren-skills:egeria-grant-intake",
+          tags: [],
+        },
+        {
+          id: "seren:chief-grants-officer-grant-intake",
+          slug: "chief-grants-officer-grant-intake",
+          skillFolderName: "grant-intake",
+          name: "Chief Grants Officer - Grant Intake",
+          description: "",
+          source: "seren",
+          sourceUrl: "seren-skills:chief-grants-officer-grant-intake",
+          tags: [],
+        },
+      ],
+    );
+
+    const writeCall = mockInvoke.mock.calls.find(
+      (call) => call[0] === "write_skill_sync_state",
+    );
+    const stateJson = JSON.parse(writeCall?.[1].stateJson);
+
+    expect(count).toBe(1);
+    expect(stateJson.upstreamSourceUrl).toBe(
+      "seren-skills:chief-grants-officer-grant-intake",
+    );
+  });
+
+  it("repairs stale folder-alias sync state to the canonical publisher slug", async () => {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      switch (cmd) {
+        case "write_skill_sync_state":
+          return null;
+        default:
+          return null;
+      }
+    });
+
+    const count = await skills.backfillSyncState(
+      [
+        {
+          id: "local:grant-intake",
+          slug: "grant-intake",
+          name: "Chief Grants Officer - Grant Intake",
+          description: "",
+          source: "local",
+          tags: [],
+          scope: "seren",
+          skillsDir: "/skills",
+          dirName: "grant-intake",
+          path: "/skills/grant-intake/SKILL.md",
+          installedAt: 1,
+          enabled: true,
+          contentHash: "local-hash",
+          upstreamSource: "seren",
+          upstreamSourceUrl: "seren-skills:grant-intake",
+          syncState: {
+            version: 1,
+            upstreamSource: "seren",
+            upstreamSourceUrl: "seren-skills:grant-intake",
+            syncedRevision: "old-revision",
+            syncedAt: 1,
+            managedFiles: { "SKILL.md": "old-hash" },
+            upstreamDeleted: true,
+          },
+        },
+      ],
+      [
+        {
+          id: "seren:egeria-grant-intake",
+          slug: "egeria-grant-intake",
+          skillFolderName: "grant-intake",
+          name: "Egeria Grant Intake",
+          description: "",
+          source: "seren",
+          sourceUrl: "seren-skills:egeria-grant-intake",
+          tags: [],
+        },
+        {
+          id: "seren:chief-grants-officer-grant-intake",
+          slug: "chief-grants-officer-grant-intake",
+          skillFolderName: "grant-intake",
+          name: "Chief Grants Officer - Grant Intake",
+          description: "",
+          source: "seren",
+          sourceUrl: "seren-skills:chief-grants-officer-grant-intake",
+          tags: [],
+        },
+      ],
+    );
+
+    const writeCall = mockInvoke.mock.calls.find(
+      (call) => call[0] === "write_skill_sync_state",
+    );
+    const stateJson = JSON.parse(writeCall?.[1].stateJson);
+
+    expect(count).toBe(1);
+    expect(stateJson.upstreamSourceUrl).toBe(
+      "seren-skills:chief-grants-officer-grant-intake",
+    );
+    expect(stateJson.syncedRevision).toBe("old-revision");
+    expect(stateJson.upstreamDeleted).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- prefer canonical `seren-skills:{publisher_slug}` source URLs when downloading upstream skill bundles
- repair stale sync state that stored an org-owned folder alias like `seren-skills:grant-intake` instead of the public publisher slug
- backfill org-owned installs by `skill_folder_name` with display-name disambiguation so ambiguous aliases do not map to the wrong skill
- keep installed-state checks from marking sibling catalog rows installed when they share the same folder name

## Audit
Live Seren Skills audit confirmed:
- `GET /skills/grant-intake/download/manifest` returns 404 `skill not found`
- `GET /skills/chief-grants-officer-grant-intake/download/manifest` returns 200 and is public
- public catalog has at least two rows with `skill_folder_name=grant-intake`, so folder-only aliases must not be guessed without local name/source context

## Tests
- `pnpm test tests/unit/skills-index-api.test.ts tests/unit/skills-split-download.test.ts tests/unit/skills-auto-sync.test.ts tests/unit/skills-display.test.ts`
- `pnpm exec biome check src/lib/skills/display.ts src/lib/skills/types.ts src/services/skills.ts src/stores/skills.store.ts tests/unit/skills-auto-sync.test.ts tests/unit/skills-index-api.test.ts tests/unit/skills-split-download.test.ts`
- `pnpm build` (passes with existing Rolldown pure-annotation/chunk-size/dynamic-import warnings from dependencies)

Closes #2676