### PR TITLE
feat: automatic recording lifecycle — mic auto-start/stop, indicator, pause/resume (#2670)

### DIFF
--- a/docs/design/auto-record-and-search.md
+++ b/docs/design/auto-record-and-search.md
@@ -1,0 +1,75 @@
+<!--
+ABOUTME: Design + spec for automatic recording lifecycle and semantic transcript search.
+ABOUTME: Covers mic-activity auto-start/stop, calendar metadata, and seren-embed search.
+-->
+
+# Auto-record lifecycle + semantic transcript search — design & spec
+
+_Design review 2026-06-26. Issues: #2670 (auto-record lifecycle), #2659 (calendar metadata + pre-arm), #2658 (semantic search). #2660 (action-item lifecycle) is explicitly out of scope._
+
+## Motivation
+
+Recording is **passive** today: `audio/detect.rs` probes mic activity and pops a manual "Call detected" prompt; the user must remember to start *and* stop. A real user forgot to stop and left a **209-minute** recording running after the calls closed. We make recording start automatically when a meeting app takes the mic and stop automatically when it's released, and we make transcripts searchable.
+
+## Decisions (locked)
+
+| Area | Decision |
+| --- | --- |
+| Auto-start gate | Rising edge of *(mic `input_active` AND a `KNOWN_CALL_APPS` process running)*, ~3s debounce. Manual prompt stays as fallback. |
+| Auto-stop | Multi-signal, earliest of: app-release sustained **90s**; **15 min** no new transcript; matched calendar `scheduled_end + 5 min`. |
+| Start UX | Silent start + loud indicator (tray/menubar + draggable floating pill + in-app banner), one-click Stop + Delete. |
+| Delete | Reuse existing `delete_meeting_record` cascade. No new delete code. |
+| Pause/Resume | Net-new pipeline capability + indicator controls; marks transcript `Gap`. |
+| Calendar | Google Calendar (read-only publisher) — metadata match + pre-arm. Outlook/Exchange + Zoom = fast-follow (no publisher today; Zoom/Meet events ride the user's Google calendar). |
+| Search engine | Semantic via existing `seren-embed` + `sqlite-vec` (reuse code-search infra). `LIKE` exact-match pass alongside / offline fallback. Requires connectivity (relaxes #2658's original offline criterion). |
+| Default | Auto-record **ON**; Settings toggle + editable app list. |
+| Consent v1 | First-run explainer + copyable disclosure snippet. Auto-post-to-chat = fast-follow. |
+
+## Architecture
+
+Both features attach to the existing capture/transcript subsystem; neither rebuilds it.
+
+### Auto-record engine (`src-tauri/src/audio/lifecycle.rs`)
+State machine `Idle → Armed → Recording → Stopping → Stopped`, driven by a ~2s poll of `probe_audio_activity()` plus last-transcript-segment time and (optional) calendar windows. Calls the existing `start_meeting_capture` / `stop_meeting_capture`; emits lifecycle events to the frontend. Never touches the capture pipeline internals.
+
+- **Start:** debounced rising edge of the gate.
+- **Stop:** multi-signal; if a stop signal reverses inside its grace window, cancel and return to `Recording`.
+- **Manual-stop suppression:** a manual Stop disarms auto-start until the next `Idle` transition (so a still-live call can't instantly re-record).
+- **Merge prevention:** each `Recording` cycle is its own meeting record; a stop is a hard boundary, never appended.
+- **Pre-arm:** ~1–2 min before a matched calendar event, enter `Armed` and pre-warm the device; disarm ~15 min after scheduled start if no mic activity.
+
+### Pause/Resume
+New `pause_meeting_capture` / `resume_meeting_capture` commands suspend/resume frame ingestion without ending the session; the gap is recorded via the existing `Gap` segment status; the elapsed timer pauses.
+
+### Calendar (`src/services/calendar.ts`)
+One-time Google Calendar connect (OAuth passthrough) → `events.list` windowed, polled ~5 min, cached locally. On auto-start, match the concurrent event (time overlap + meeting link/app) and stamp `title`, `attendees_json`, `calendar_event_id` onto the meeting. Pure enrichment — everything works if unconnected.
+
+### Search
+On capture-complete, chunk the transcript into overlapping windows of consecutive segments (~3–6 turns / ≤~512 tokens, speaker-aware), embed via `seren-embed` (text-embedding-3-small, 1536-dim) into a new local-only `transcript_embeddings` vec0 table; also embed notes. Backfill existing meetings. Query = semantic `search_similar` merged with a `LIKE` sweep over transcript text + titles + attendees; rank = semantic + exact-match boost. Surfaces: ⌘K palette, library search field, in-transcript find. Results: snippet + surrounding turns + speaker labels + jump-to-source; filters by speaker / date / attendee.
+
+## Data model
+
+- `meetings` += `trigger_source` (`manual｜auto_mic｜calendar`), `calendar_event_id`, `calendar_provider`, `attendees_json`. One rusqlite migration; cloud mirror rides existing `payload jsonb`.
+- New local-only `transcript_embeddings` vec0 (`chunk_id, meeting_id, seq_start, seq_end, vector[1536]`) — derived, not synced.
+- `transcript_segments` unchanged; Pause writes a `Gap` segment.
+- Settings (`tauri-plugin-store`): `auto_record_enabled=true`, editable known-call-app list, calendar connection, consent prefs.
+
+## Privacy
+
+Raw audio is never persisted (existing design) — only transcripts. ON-by-default is covered by the loud indicator + first-run consent explainer; Delete is one-click and tombstones the synced copy. Attendee PII stays local + synced as meeting metadata and is scrubbed from error reports. Two-party-consent exposure flagged; v1 = explainer + copyable snippet.
+
+## Implementation plan
+
+Each phase = worktree → PR(s) → merge → cleanup. Critical-path tests only (no TDD, no duplicate tests).
+
+- **Phase 0** — verify transcript persistence end-to-end (search depends on it).
+- **Phase 1** — auto-record lifecycle (`lifecycle.rs` + settings + quit/sleep guard + pause/resume). [#2670]
+- **Phase 2** — recording indicator UI (tray/pill/banner + first-run consent).
+- **Phase 3** — calendar metadata + pre-arm. [#2659]
+- **Phase 4** — semantic search. [#2658]
+
+Order: 0 → 1 → 2, then 3 and 4 in parallel. Phase 1 alone kills the runaway.
+
+## Post-implementation
+
+Functional walk-through audit (macOS + Windows via AWS SSM for build/detection/logic; live-audio behavior flagged where only a human on a real call can confirm). New P0/P1 findings → tickets assigned to `taariq`, labeled bug, fixed via the same workflow; loop until green.

--- a/src-tauri/src/audio/lifecycle.rs
+++ b/src-tauri/src/audio/lifecycle.rs
@@ -1,0 +1,289 @@
+// ABOUTME: Auto-record lifecycle decision core — when to auto-start and auto-stop capture.
+// ABOUTME: Pure state machine over mic-activity, known-call-app, transcript, and calendar signals.
+
+use serde::Serialize;
+
+/// Tunable thresholds for the auto-record lifecycle. Defaults reflect the design
+/// review: 3s start debounce so a mic blip can't trigger; 90s app-release grace
+/// so mute/unmute and device switches don't end a live meeting; 15min silence
+/// backstop as the hard runaway guard; 5min tail past a matched calendar end
+/// (deliberately shorter than the in-window grace).
+#[derive(Debug, Clone, Copy)]
+pub struct LifecycleConfig {
+    pub start_debounce_ms: i64,
+    pub app_release_grace_ms: i64,
+    pub silence_timeout_ms: i64,
+    pub calendar_end_tail_ms: i64,
+}
+
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        Self {
+            start_debounce_ms: 3_000,
+            app_release_grace_ms: 90_000,
+            silence_timeout_ms: 15 * 60_000,
+            calendar_end_tail_ms: 5 * 60_000,
+        }
+    }
+}
+
+/// One observation of the world, sampled by the poll task (~every 2s). `gate_open`
+/// is the auto-start gate: mic input is active AND a known conferencing app is
+/// running. `source_app` carries the detected app name for the meeting record.
+#[derive(Debug, Clone, Default)]
+pub struct LifecycleSignal {
+    pub now_ms: i64,
+    pub gate_open: bool,
+    pub source_app: Option<String>,
+    /// Timestamp of the most recent persisted transcript segment, if any.
+    pub last_segment_ms: Option<i64>,
+    /// Scheduled end of the matched calendar event, if any.
+    pub calendar_end_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleState {
+    Idle,
+    Recording,
+}
+
+/// Why an auto-started recording was stopped. Surfaced to the frontend so the
+/// indicator can explain the stop, and recorded for diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopReason {
+    AppReleased,
+    Silence,
+    CalendarEnd,
+}
+
+/// The single side effect the controller asks the wiring layer to perform on a
+/// given tick. The wiring creates a fresh meeting per `StartCapture` (so each
+/// call is its own record — no back-to-back merge) and stops capture on
+/// `StopCapture`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LifecycleAction {
+    StartCapture { source_app: Option<String> },
+    StopCapture { reason: StopReason },
+}
+
+/// Pure auto-record decision engine. Holds no I/O — the wiring layer feeds it a
+/// `LifecycleSignal` each tick and performs the returned `LifecycleAction`.
+#[derive(Debug)]
+pub struct LifecycleController {
+    config: LifecycleConfig,
+    state: LifecycleState,
+    /// Since when the start gate has been continuously open (start debounce).
+    gate_open_since: Option<i64>,
+    /// Since when the meeting app has continuously released the mic (stop grace).
+    app_release_since: Option<i64>,
+    /// When the current recording started — silence is measured from here until
+    /// the first transcript segment lands.
+    recording_since: Option<i64>,
+    /// After a manual stop, suppress auto-start until the gate fully closes, so
+    /// stopping a recording while the call is still live can't instantly
+    /// re-record it.
+    suppress_until_gate_closes: bool,
+}
+
+impl LifecycleController {
+    pub fn new(config: LifecycleConfig) -> Self {
+        Self {
+            config,
+            state: LifecycleState::Idle,
+            gate_open_since: None,
+            app_release_since: None,
+            recording_since: None,
+            suppress_until_gate_closes: false,
+        }
+    }
+
+    pub fn state(&self) -> LifecycleState {
+        self.state
+    }
+
+    /// Record that the user manually stopped the active recording (via the
+    /// indicator). Returns to `Idle` and suppresses auto-start until the call's
+    /// mic session ends.
+    pub fn note_manual_stop(&mut self) {
+        self.state = LifecycleState::Idle;
+        self.recording_since = None;
+        self.app_release_since = None;
+        self.gate_open_since = None;
+        self.suppress_until_gate_closes = true;
+    }
+
+    /// Advance the state machine by one observation, returning the side effect to
+    /// perform (at most one per tick).
+    pub fn evaluate(&mut self, signal: &LifecycleSignal) -> Option<LifecycleAction> {
+        match self.state {
+            LifecycleState::Idle => self.evaluate_idle(signal),
+            LifecycleState::Recording => self.evaluate_recording(signal),
+        }
+    }
+
+    fn evaluate_idle(&mut self, signal: &LifecycleSignal) -> Option<LifecycleAction> {
+        // Manual-stop suppression: hold off auto-start until the gate has fully
+        // closed (the call actually ended), then re-arm normally.
+        if self.suppress_until_gate_closes {
+            if !signal.gate_open {
+                self.suppress_until_gate_closes = false;
+                self.gate_open_since = None;
+            }
+            return None;
+        }
+
+        if signal.gate_open {
+            let opened_at = *self.gate_open_since.get_or_insert(signal.now_ms);
+            if signal.now_ms - opened_at >= self.config.start_debounce_ms {
+                self.state = LifecycleState::Recording;
+                self.recording_since = Some(signal.now_ms);
+                self.gate_open_since = None;
+                self.app_release_since = None;
+                return Some(LifecycleAction::StartCapture {
+                    source_app: signal.source_app.clone(),
+                });
+            }
+        } else {
+            self.gate_open_since = None;
+        }
+        None
+    }
+
+    fn evaluate_recording(&mut self, signal: &LifecycleSignal) -> Option<LifecycleAction> {
+        // 1) App-release grace. If the gate reopens inside the window, cancel the
+        //    pending stop and keep recording.
+        if !signal.gate_open {
+            let released_at = *self.app_release_since.get_or_insert(signal.now_ms);
+            if signal.now_ms - released_at >= self.config.app_release_grace_ms {
+                return Some(self.stop(StopReason::AppReleased));
+            }
+        } else {
+            self.app_release_since = None;
+        }
+
+        // 2) Silence backstop — the hard runaway guard. Measure from the last
+        //    persisted segment, or from recording start if none has landed yet.
+        let silence_anchor = signal.last_segment_ms.or(self.recording_since);
+        if let Some(anchor) = silence_anchor {
+            if signal.now_ms - anchor >= self.config.silence_timeout_ms {
+                return Some(self.stop(StopReason::Silence));
+            }
+        }
+
+        // 3) Matched calendar end + tail.
+        if let Some(end) = signal.calendar_end_ms {
+            if signal.now_ms >= end + self.config.calendar_end_tail_ms {
+                return Some(self.stop(StopReason::CalendarEnd));
+            }
+        }
+
+        None
+    }
+
+    fn stop(&mut self, reason: StopReason) -> LifecycleAction {
+        self.state = LifecycleState::Idle;
+        self.recording_since = None;
+        self.app_release_since = None;
+        self.gate_open_since = None;
+        LifecycleAction::StopCapture { reason }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CFG: LifecycleConfig = LifecycleConfig {
+        start_debounce_ms: 3_000,
+        app_release_grace_ms: 90_000,
+        silence_timeout_ms: 900_000,
+        calendar_end_tail_ms: 300_000,
+    };
+
+    fn gate(now_ms: i64, open: bool) -> LifecycleSignal {
+        LifecycleSignal {
+            now_ms,
+            gate_open: open,
+            source_app: open.then(|| "Zoom".to_string()),
+            last_segment_ms: None,
+            calendar_end_ms: None,
+        }
+    }
+
+    /// The critical auto-record behaviors in one pass: debounced start,
+    /// app-release grace with mid-window reversal, the silence backstop, and
+    /// manual-stop suppression. These are the runaway-fix correctness guarantees.
+    #[test]
+    fn auto_record_decision_core() {
+        let mut c = LifecycleController::new(CFG);
+
+        // Start does not fire before the debounce elapses...
+        assert_eq!(c.evaluate(&gate(0, true)), None);
+        assert_eq!(c.evaluate(&gate(2_000, true)), None);
+        // ...and fires once the gate has stayed open past it.
+        assert_eq!(
+            c.evaluate(&gate(3_000, true)),
+            Some(LifecycleAction::StartCapture {
+                source_app: Some("Zoom".to_string())
+            })
+        );
+        assert_eq!(c.state(), LifecycleState::Recording);
+
+        // App releases the mic: no stop inside the grace window...
+        assert_eq!(c.evaluate(&gate(10_000, false)), None);
+        // ...and a reversal inside the window cancels the pending stop.
+        assert_eq!(c.evaluate(&gate(20_000, true)), None);
+        assert_eq!(c.state(), LifecycleState::Recording);
+        // Sustained release past the grace window stops with AppReleased.
+        assert_eq!(c.evaluate(&gate(30_000, false)), None);
+        assert_eq!(
+            c.evaluate(&gate(30_000 + CFG.app_release_grace_ms, false)),
+            Some(LifecycleAction::StopCapture {
+                reason: StopReason::AppReleased
+            })
+        );
+        assert_eq!(c.state(), LifecycleState::Idle);
+
+        // Silence backstop: with the gate held open but no transcript segments,
+        // recording auto-stops after the silence timeout (the runaway guard).
+        let mut c = LifecycleController::new(CFG);
+        c.evaluate(&gate(0, true));
+        assert_eq!(
+            c.evaluate(&gate(CFG.start_debounce_ms, true)),
+            Some(LifecycleAction::StartCapture {
+                source_app: Some("Zoom".to_string())
+            })
+        );
+        assert_eq!(c.evaluate(&gate(CFG.start_debounce_ms + 60_000, true)), None);
+        assert_eq!(
+            c.evaluate(&gate(CFG.start_debounce_ms + CFG.silence_timeout_ms, true)),
+            Some(LifecycleAction::StopCapture {
+                reason: StopReason::Silence
+            })
+        );
+
+        // Manual-stop suppression: after a manual stop while the call is still
+        // live (gate open), auto-start must not re-fire until the gate closes.
+        let mut c = LifecycleController::new(CFG);
+        c.evaluate(&gate(0, true));
+        c.evaluate(&gate(CFG.start_debounce_ms, true));
+        assert_eq!(c.state(), LifecycleState::Recording);
+        c.note_manual_stop();
+        assert_eq!(c.state(), LifecycleState::Idle);
+        // Gate still open across many ticks → still suppressed, no restart.
+        assert_eq!(c.evaluate(&gate(100_000, true)), None);
+        assert_eq!(c.evaluate(&gate(200_000, true)), None);
+        // Call ends (gate closes) → suppression lifts.
+        assert_eq!(c.evaluate(&gate(210_000, false)), None);
+        // A fresh call re-arms and auto-starts again.
+        c.evaluate(&gate(300_000, true));
+        assert_eq!(
+            c.evaluate(&gate(300_000 + CFG.start_debounce_ms, true)),
+            Some(LifecycleAction::StartCapture {
+                source_app: Some("Zoom".to_string())
+            })
+        );
+    }
+}

--- a/src-tauri/src/audio/lifecycle.rs
+++ b/src-tauri/src/audio/lifecycle.rs
@@ -62,10 +62,16 @@ pub enum StopReason {
 /// given tick. The wiring creates a fresh meeting per `StartCapture` (so each
 /// call is its own record — no back-to-back merge) and stops capture on
 /// `StopCapture`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum LifecycleAction {
-    StartCapture { source_app: Option<String> },
-    StopCapture { reason: StopReason },
+    StartCapture {
+        #[serde(rename = "sourceApp")]
+        source_app: Option<String>,
+    },
+    StopCapture {
+        reason: StopReason,
+    },
 }
 
 /// Pure auto-record decision engine. Holds no I/O — the wiring layer feeds it a

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -6,6 +6,7 @@ pub mod capture;
 pub mod chunker;
 pub mod cleanup;
 pub mod detect;
+pub mod lifecycle;
 pub mod llm;
 pub mod merge;
 pub mod notes;

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -92,6 +92,9 @@ pub struct CaptureStreamStats {
     emitted_gap_count: AtomicU64,
     transport_failure_count: AtomicU64,
     last_transport_error: StdMutex<Option<String>>,
+    // Pause gate. While set, the capture workers drop frames (no segments, no
+    // buffered Them audio) without tearing down the session.
+    paused: AtomicBool,
 }
 
 #[derive(Default)]
@@ -128,6 +131,14 @@ impl CaptureStreamStats {
 
     fn record_chunk(&self) {
         self.chunk_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn set_paused(&self, paused: bool) {
+        self.paused.store(paused, Ordering::Relaxed);
+    }
+
+    fn is_paused(&self) -> bool {
+        self.paused.load(Ordering::Relaxed)
     }
 
     fn record_ok_segment(&self) {
@@ -231,6 +242,12 @@ pub async fn run_capture_stream(
 ) {
     let mut chunker = StreamingChunker::new(cfg);
     while let Some(frame) = frames.recv().await {
+        // Paused: drop the frame before chunking so no segments are produced and
+        // no Them audio is buffered. The chunker treats the absence as a gap
+        // (already handled); resume simply lets frames flow again.
+        if stats.is_paused() {
+            continue;
+        }
         stats.record_frame(&frame.samples, cfg.rms_threshold);
         if let Some(buffer) = them_buffer.as_ref() {
             buffer_them_samples(buffer, &frame.samples);
@@ -942,6 +959,18 @@ impl CaptureRegistry {
             self.active.lock().unwrap().get(meeting_id),
             Some(CaptureSlot::Active(_))
         )
+    }
+
+    /// Pause or resume frame ingestion for a live capture without ending it.
+    /// Returns false when no active capture exists for `meeting_id`.
+    pub fn set_paused(&self, meeting_id: &str, paused: bool) -> bool {
+        match self.active.lock().unwrap().get(meeting_id) {
+            Some(CaptureSlot::Active(capture)) => {
+                capture.stats.set_paused(paused);
+                true
+            }
+            _ => false,
+        }
     }
 
     /// Whether the registry slot for `meeting_id` is taken (live or draining).

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -5,6 +5,7 @@ use crate::audio::capture::{TARGET_SAMPLE_RATE, to_mono_16k};
 use crate::audio::chunker::{Chunk, ChunkCfg, chunk as chunk_pcm};
 use crate::audio::cleanup::{build_cleanup_prompt, build_transform_prompt};
 use crate::audio::detect::{MeetingAutodetectResult, meeting_detection, probe_audio_activity};
+use crate::audio::lifecycle::{LifecycleAction, LifecycleController, LifecycleSignal};
 use crate::audio::llm::{CompletionRequest, complete};
 use crate::audio::merge::merge_segments;
 use crate::audio::notes::{ParsedNotes, generate_notes};
@@ -1107,6 +1108,70 @@ pub fn list_meeting_templates() -> Vec<MeetingTemplate> {
 pub fn meeting_autodetect() -> MeetingAutodetectResult {
     let activity = probe_audio_activity();
     meeting_detection(activity)
+}
+
+/// Timestamp of the most recently persisted transcript segment for a meeting —
+/// the silence-backstop anchor. `None` when nothing has landed yet.
+fn select_last_segment_ms(conn: &Connection, meeting_id: &str) -> Result<Option<i64>> {
+    conn.query_row(
+        "SELECT MAX(created_at) FROM transcript_segments WHERE meeting_id = ?1",
+        params![meeting_id],
+        |row| row.get::<_, Option<i64>>(0),
+    )
+    .optional()
+    .map(Option::flatten)
+}
+
+/// Advance the auto-record lifecycle by one tick and return the action to
+/// perform, if any. The frontend poll drives this while auto-detect is enabled;
+/// the controller lives in Tauri-managed state so it persists across ticks.
+/// Signals: the live mic-activity probe (gate + source app), the active
+/// meeting's last-segment time (silence backstop), and an optional matched
+/// calendar end.
+#[tauri::command]
+pub async fn meeting_lifecycle_tick(
+    app: AppHandle,
+    lifecycle: State<'_, std::sync::Mutex<LifecycleController>>,
+    active_meeting_id: Option<String>,
+    calendar_end_ms: Option<i64>,
+) -> Result<Option<LifecycleAction>, String> {
+    let activity = probe_audio_activity();
+    let source_app = activity.source_app;
+    // Gate A: mic active AND a known conferencing app. `source_app` is populated
+    // only when both hold, so its presence is the gate.
+    let gate_open = source_app.is_some();
+
+    let last_segment_ms = match active_meeting_id {
+        Some(id) => run_db(app, move |conn| select_last_segment_ms(conn, &id)).await?,
+        None => None,
+    };
+
+    let signal = LifecycleSignal {
+        now_ms: now_ms(),
+        gate_open,
+        source_app,
+        last_segment_ms,
+        calendar_end_ms,
+    };
+
+    let action = lifecycle
+        .lock()
+        .map_err(|err| err.to_string())?
+        .evaluate(&signal);
+    Ok(action)
+}
+
+/// Record that the user manually stopped the active recording, so auto-start
+/// stays suppressed until the call's mic session ends.
+#[tauri::command]
+pub fn meeting_lifecycle_note_manual_stop(
+    lifecycle: State<'_, std::sync::Mutex<LifecycleController>>,
+) -> Result<(), String> {
+    lifecycle
+        .lock()
+        .map_err(|err| err.to_string())?
+        .note_manual_stop();
+    Ok(())
 }
 
 // --- Dictation (shares the transcribe + cleanup engines with Meeting Mode) --

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -638,6 +638,20 @@ pub fn is_meeting_capture_active(registry: State<'_, CaptureRegistry>, meeting_i
     registry.is_active(&meeting_id)
 }
 
+/// Pause a live capture: workers drop frames (no segments) without ending the
+/// session. Returns false when no active capture exists for the meeting.
+#[tauri::command]
+pub fn pause_meeting_capture(registry: State<'_, CaptureRegistry>, meeting_id: String) -> bool {
+    registry.set_paused(&meeting_id, true)
+}
+
+/// Resume a paused capture: frames flow again. Returns false when no active
+/// capture exists for the meeting.
+#[tauri::command]
+pub fn resume_meeting_capture(registry: State<'_, CaptureRegistry>, meeting_id: String) -> bool {
+    registry.set_paused(&meeting_id, false)
+}
+
 #[tauri::command]
 pub async fn stop_meeting_capture(
     app: AppHandle,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -584,6 +584,9 @@ pub fn run() {
         .manage(mcp::HttpMcpState::new())
         .manage(orchestrator::service::OrchestratorState::new())
         .manage(audio::pipeline::CaptureRegistry::default())
+        .manage(std::sync::Mutex::new(
+            audio::lifecycle::LifecycleController::new(audio::lifecycle::LifecycleConfig::default()),
+        ))
         .manage(orchestrator::eval::EvalState::new())
         .manage(orchestrator::tool_bridge::ToolResultBridge::new())
         .manage(provider_runtime::ProviderRuntimeState::new())
@@ -936,6 +939,8 @@ pub fn run() {
             commands::audio::select_meeting_skills,
             commands::audio::list_meeting_templates,
             commands::audio::meeting_autodetect,
+            commands::audio::meeting_lifecycle_tick,
+            commands::audio::meeting_lifecycle_note_manual_stop,
             // Dictation commands
             commands::audio::transcribe_pcm,
             commands::audio::cleanup_dictation_text,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -930,6 +930,8 @@ pub fn run() {
             // Meeting Mode capture + intelligence commands
             commands::audio::start_meeting_capture,
             commands::audio::is_meeting_capture_active,
+            commands::audio::pause_meeting_capture,
+            commands::audio::resume_meeting_capture,
             commands::audio::stop_meeting_capture,
             commands::audio::e2e_inject_meeting_capture_audio,
             commands::audio::reconcile_meeting_speakers,

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -29,6 +29,7 @@ import {
 import { ThreadSidebar } from "@/components/layout/ThreadSidebar";
 import { AudioPrimingDialog } from "@/components/meeting/AudioPrimingDialog";
 import { MeetingPanel } from "@/components/meeting/MeetingPanel";
+import { RecordingIndicator } from "@/components/meeting/RecordingIndicator";
 import { SessionPanel } from "@/components/session/SessionPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import {
@@ -1087,6 +1088,10 @@ export const AppShell: Component<AppShellProps> = (props) => {
           onCancel={() => void meetingStore.cancelPriming()}
         />
       </Show>
+
+      {/* Always-visible recording indicator while a capture is live (auto- or
+          manually-started): elapsed time + Stop / Pause / Resume / Delete. */}
+      <RecordingIndicator />
 
       {/* Layout-level blocking sign-in modal — fires on mid-session expiry,
           refresh-token failure, and the /login slash command. Distinct from

--- a/src/components/meeting/AudioPrimingDialog.tsx
+++ b/src/components/meeting/AudioPrimingDialog.tsx
@@ -97,6 +97,12 @@ export const AudioPrimingDialog: Component<AudioPrimingDialogProps> = (
           </div>
         </div>
 
+        <p class="px-5 pb-4 text-[11px] text-muted-foreground leading-relaxed">
+          Recording happens locally — other participants aren't automatically
+          notified. Please let them know you're taking notes; some regions
+          require everyone's consent.
+        </p>
+
         <div class="flex justify-end gap-2 px-5 py-4 border-t border-border">
           <button
             type="button"

--- a/src/components/meeting/RecordingIndicator.tsx
+++ b/src/components/meeting/RecordingIndicator.tsx
@@ -1,0 +1,109 @@
+// ABOUTME: Floating always-visible indicator shown while a meeting is recording.
+// ABOUTME: Surfaces Stop / Pause / Resume / Delete so an auto-started capture is never silent.
+
+import { createEffect, createSignal, onCleanup, onMount, Show } from "solid-js";
+import { meetingStore } from "@/stores/meeting.store";
+
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+const CONTROL_CLASS =
+  "h-6 rounded-md px-2 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-accent/15 hover:text-foreground";
+
+export function RecordingIndicator() {
+  const [now, setNow] = createSignal(Date.now());
+  const [confirmingDelete, setConfirmingDelete] = createSignal(false);
+
+  let timer: number | undefined;
+  onMount(() => {
+    timer = window.setInterval(() => setNow(Date.now()), 1000);
+  });
+  onCleanup(() => {
+    if (timer !== undefined) window.clearInterval(timer);
+  });
+
+  const active = () =>
+    meetingStore.state.meetings.find(
+      (meeting) => meeting.status === "capturing",
+    ) ?? null;
+  const paused = () => meetingStore.state.capturePaused;
+
+  // Drop a stale delete confirmation if the recording ends.
+  createEffect(() => {
+    if (active() === null && confirmingDelete()) setConfirmingDelete(false);
+  });
+
+  const elapsed = () => {
+    const meeting = active();
+    return meeting ? formatElapsed(now() - meeting.startedAt) : "0:00";
+  };
+
+  const onStop = () => {
+    const meeting = active();
+    if (meeting) void meetingStore.stopAndProcess(meeting);
+  };
+
+  const onTogglePause = () => {
+    const meeting = active();
+    if (!meeting) return;
+    if (paused()) void meetingStore.resumeCapture(meeting.id);
+    else void meetingStore.pauseCapture(meeting.id);
+  };
+
+  const onDelete = () => {
+    const meeting = active();
+    if (!meeting) return;
+    if (!confirmingDelete()) {
+      setConfirmingDelete(true);
+      return;
+    }
+    setConfirmingDelete(false);
+    void meetingStore.deleteMeeting(meeting);
+  };
+
+  return (
+    <Show when={active()}>
+      <div
+        class="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border border-destructive/40 bg-popover/95 px-3 py-1.5 shadow-[0_8px_24px_rgba(0,0,0,0.32)] backdrop-blur-sm animate-[fadeIn_200ms_ease]"
+        aria-label="Recording in progress"
+      >
+        <span class="relative flex h-2.5 w-2.5 shrink-0 items-center justify-center">
+          <Show
+            when={!paused()}
+            fallback={
+              <span class="h-2.5 w-2.5 rounded-full bg-muted-foreground" />
+            }
+          >
+            <span class="absolute h-2.5 w-2.5 rounded-full bg-destructive/70 animate-[voicePulse_1.4s_ease-in-out_infinite]" />
+            <span class="h-2.5 w-2.5 rounded-full bg-destructive" />
+          </Show>
+        </span>
+        <span class="text-[11px] font-medium tabular-nums text-foreground">
+          {paused() ? "Paused" : "Rec"} {elapsed()}
+        </span>
+        <Show when={meetingStore.state.micCaptureLost}>
+          <span class="text-[10px] font-medium text-destructive">mic lost</span>
+        </Show>
+        <div class="ml-1 flex shrink-0 items-center gap-1">
+          <button type="button" class={CONTROL_CLASS} onClick={onTogglePause}>
+            {paused() ? "Resume" : "Pause"}
+          </button>
+          <button
+            type="button"
+            class="h-6 rounded-md border border-destructive/40 px-2 text-[10px] font-medium text-destructive transition-colors hover:bg-destructive hover:text-destructive-foreground"
+            onClick={onStop}
+          >
+            Stop
+          </button>
+          <button type="button" class={CONTROL_CLASS} onClick={onDelete}>
+            {confirmingDelete() ? "Confirm?" : "Delete"}
+          </button>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/src/components/meeting/RecordingIndicator.tsx
+++ b/src/components/meeting/RecordingIndicator.tsx
@@ -14,9 +14,15 @@ function formatElapsed(ms: number): string {
 const CONTROL_CLASS =
   "h-6 rounded-md px-2 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-accent/15 hover:text-foreground";
 
+// Copyable participant disclosure — local capture gives others no automatic
+// signal, so this lets the user paste a heads-up into the meeting chat.
+const DISCLOSURE =
+  "Heads up — I'm using an AI assistant to take notes on this call.";
+
 export function RecordingIndicator() {
   const [now, setNow] = createSignal(Date.now());
   const [confirmingDelete, setConfirmingDelete] = createSignal(false);
+  const [copied, setCopied] = createSignal(false);
 
   let timer: number | undefined;
   onMount(() => {
@@ -54,6 +60,16 @@ export function RecordingIndicator() {
     else void meetingStore.pauseCapture(meeting.id);
   };
 
+  const onNotify = () => {
+    void navigator.clipboard
+      .writeText(DISCLOSURE)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
+  };
+
   const onDelete = () => {
     const meeting = active();
     if (!meeting) return;
@@ -89,6 +105,14 @@ export function RecordingIndicator() {
           <span class="text-[10px] font-medium text-destructive">mic lost</span>
         </Show>
         <div class="ml-1 flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            class={CONTROL_CLASS}
+            onClick={onNotify}
+            title="Copy a recording disclosure to paste into the meeting chat"
+          >
+            {copied() ? "Copied" : "Notify"}
+          </button>
           <button type="button" class={CONTROL_CLASS} onClick={onTogglePause}>
             {paused() ? "Resume" : "Pause"}
           </button>

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -330,3 +330,13 @@ export function meetingLifecycleTick(
 export function meetingLifecycleNoteManualStop(): Promise<void> {
   return invoke("meeting_lifecycle_note_manual_stop");
 }
+
+/** Pause a live capture without ending it. Resolves false if none is active. */
+export function pauseMeetingCapture(meetingId: string): Promise<boolean> {
+  return invoke("pause_meeting_capture", { meetingId });
+}
+
+/** Resume a paused capture. Resolves false if none is active. */
+export function resumeMeetingCapture(meetingId: string): Promise<boolean> {
+  return invoke("resume_meeting_capture", { meetingId });
+}

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -301,3 +301,32 @@ export interface MeetingAutodetectResult {
 export function meetingAutodetect(): Promise<MeetingAutodetectResult> {
   return invoke("meeting_autodetect");
 }
+
+/**
+ * One auto-record lifecycle action returned by `meetingLifecycleTick`. The Rust
+ * decision core owns the state machine; the frontend executes the action with
+ * the existing start/stop paths.
+ */
+export type MeetingLifecycleAction =
+  | { kind: "start_capture"; sourceApp: string | null }
+  | {
+      kind: "stop_capture";
+      reason: "app_released" | "silence" | "calendar_end";
+    };
+
+/**
+ * Advance the auto-record lifecycle one tick. Pass the currently-recording
+ * meeting id (for the silence backstop) and an optional matched calendar end.
+ * Returns the action to perform, or `null` when nothing changes this tick.
+ */
+export function meetingLifecycleTick(
+  activeMeetingId: string | null,
+  calendarEndMs: number | null = null,
+): Promise<MeetingLifecycleAction | null> {
+  return invoke("meeting_lifecycle_tick", { activeMeetingId, calendarEndMs });
+}
+
+/** Tell the lifecycle the user manually stopped capture (suppress auto-restart). */
+export function meetingLifecycleNoteManualStop(): Promise<void> {
+  return invoke("meeting_lifecycle_note_manual_stop");
+}

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -25,8 +25,10 @@ import {
   meetingAutodetect,
   meetingLifecycleNoteManualStop,
   meetingLifecycleTick,
+  pauseMeetingCapture,
   reconcileMeetingSpeakers,
   republishMeetingToSerenNotes,
+  resumeMeetingCapture,
   selectMeetingSkills,
   setMeetingRoutedSkill,
   startMeetingCapture as startBackendCapture,
@@ -48,6 +50,8 @@ interface MeetingState {
   activeMeeting: Meeting | null;
   liveSegments: TranscriptSegment[];
   captureLevel: number;
+  /** True while the active capture is paused (frame ingestion suspended). */
+  capturePaused: boolean;
   /**
    * True while the native mic is disconnected mid-capture and the backend is
    * re-acquiring it. The panel shows a "microphone disconnected — reconnecting…"
@@ -78,6 +82,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   activeMeeting: null,
   liveSegments: [],
   captureLevel: 0,
+  capturePaused: false,
   micCaptureLost: false,
   isLoading: false,
   error: null,
@@ -463,6 +468,7 @@ async function beginCapture(meeting: Meeting): Promise<void> {
   try {
     const started = await startCapture(meeting);
     if (!started) return;
+    setMeetingState("capturePaused", false);
     await loadMeetings();
     await setActiveMeeting(
       meetingState.meetings.find((item) => item.id === meeting.id) ?? meeting,
@@ -505,6 +511,21 @@ async function cancelPriming(): Promise<void> {
     meeting.id,
     "Capture was canceled before audio permissions were requested.",
   );
+}
+
+// Pause the active capture: backend workers drop frames (a transcript gap)
+// while the session stays alive. No-op if no capture is active.
+async function pauseCapture(meetingId: string): Promise<void> {
+  if (!isTauriRuntime()) return;
+  const ok = await pauseMeetingCapture(meetingId).catch(() => false);
+  if (ok) setMeetingState("capturePaused", true);
+}
+
+// Resume a paused capture: frames flow again.
+async function resumeCapture(meetingId: string): Promise<void> {
+  if (!isTauriRuntime()) return;
+  const ok = await resumeMeetingCapture(meetingId).catch(() => false);
+  if (ok) setMeetingState("capturePaused", false);
 }
 
 // At startup, backend capture may still be active even though the renderer
@@ -1095,6 +1116,8 @@ export const meetingStore = {
   reconcileStaleCaptures,
   stopCapture,
   stopAndProcess,
+  pauseCapture,
+  resumeCapture,
   getMeetingSkillCandidates,
   routeMeetingToSkill,
   regenerateNotes,

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -116,6 +116,12 @@ const AUTO_DETECT_POLL_MS = 5_000;
 // passes the silence anchor and so a manual stop can suppress auto-restart.
 let lifecycleMeetingId: string | null = null;
 
+// Quit guard: confirm-on-quit while a capture is live. `quitConfirmed` lets a
+// second close request pass through even if window.destroy() is unavailable,
+// so the guard can never wedge app-quit.
+let closeGuardUnlisten: UnlistenFn | null = null;
+let quitConfirmed = false;
+
 // Shared in-flight guard across every start caller (panel, tray, auto-detect)
 // so a double-trigger can't launch two mic streams for the same session.
 let isStarting = false;
@@ -286,6 +292,8 @@ async function startMeetingEventListeners(): Promise<void> {
   stopMeetingEventListeners();
   if (!isTauriRuntime()) return;
 
+  void registerQuitGuard();
+
   transcriptUnlisten = await listen<TranscriptSegment>(
     "meeting://transcript-chunk",
     (event) => {
@@ -419,6 +427,7 @@ function stopMeetingEventListeners(): void {
   notesPublishedUnlisten?.();
   micStatusUnlisten?.();
   trayToggleUnlisten?.();
+  closeGuardUnlisten?.();
   transcriptUnlisten = null;
   statusUnlisten = null;
   levelUnlisten = null;
@@ -427,6 +436,44 @@ function stopMeetingEventListeners(): void {
   notesPublishedUnlisten = null;
   micStatusUnlisten = null;
   trayToggleUnlisten = null;
+  closeGuardUnlisten = null;
+}
+
+// Confirm-on-quit while a capture is live, so a recording is never lost or left
+// running on exit. Built to never block quit: after the user confirms (or on any
+// error) `quitConfirmed` is set, so a second close request passes straight
+// through even if window.destroy() is denied.
+async function registerQuitGuard(): Promise<void> {
+  if (!isTauriRuntime() || closeGuardUnlisten) return;
+  try {
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    const { confirm } = await import("@tauri-apps/plugin-dialog");
+    const appWindow = getCurrentWindow();
+    closeGuardUnlisten = await appWindow.onCloseRequested(async (event) => {
+      if (quitConfirmed || !isCapturing()) return;
+      event.preventDefault();
+      let stopAndQuit = false;
+      try {
+        stopAndQuit = await confirm(
+          "A meeting is still recording. Stop and save it before quitting?",
+          { title: "Recording in progress", kind: "warning" },
+        );
+      } catch {
+        quitConfirmed = true;
+        await appWindow.destroy().catch(() => {});
+        return;
+      }
+      if (!stopAndQuit) return; // user canceled the quit; keep recording
+      const meeting = meetingState.meetings.find(
+        (item) => item.status === "capturing",
+      );
+      if (meeting) await stopAndProcess(meeting).catch(() => {});
+      quitConfirmed = true;
+      await appWindow.destroy().catch(() => {});
+    });
+  } catch {
+    // Window API unavailable (e.g. browser-local) — no guard, nothing blocked.
+  }
 }
 
 async function startCapture(meeting: Meeting): Promise<boolean> {

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -23,6 +23,8 @@ import {
   type Meeting,
   type MeetingTemplate,
   meetingAutodetect,
+  meetingLifecycleNoteManualStop,
+  meetingLifecycleTick,
   reconcileMeetingSpeakers,
   republishMeetingToSerenNotes,
   selectMeetingSkills,
@@ -104,6 +106,10 @@ const PUBLISH_FAILED_BANNER =
 let autoDetectTimer: number | null = null;
 let autoDetectDismissed = false;
 const AUTO_DETECT_POLL_MS = 5_000;
+
+// The meeting the auto-record lifecycle started, if any. Tracked so each tick
+// passes the silence anchor and so a manual stop can suppress auto-restart.
+let lifecycleMeetingId: string | null = null;
 
 // Shared in-flight guard across every start caller (panel, tray, auto-detect)
 // so a double-trigger can't launch two mic streams for the same session.
@@ -964,24 +970,60 @@ async function pollAutoDetect(): Promise<void> {
     setMeetingState("autoDetectSourceApp", null);
     return;
   }
-  if (isCapturing()) {
+
+  // A lifecycle recording that stopped outside the lifecycle (user hit Stop, or
+  // priming was canceled): suppress auto-restart until the call's mic ends.
+  if (lifecycleMeetingId !== null && !isCapturing()) {
+    await meetingLifecycleNoteManualStop().catch(() => {});
+    lifecycleMeetingId = null;
+  }
+
+  // Don't interfere with a capture the lifecycle didn't start.
+  if (lifecycleMeetingId === null && isCapturing()) {
     setMeetingState("autoDetectSuggested", false);
     setMeetingState("autoDetectSourceApp", null);
     return;
   }
 
   try {
-    const detection = await meetingAutodetect();
-    if (!detection.detected) {
-      autoDetectDismissed = false;
-      setMeetingState("autoDetectSuggested", false);
-      setMeetingState("autoDetectSourceApp", null);
+    const action = await meetingLifecycleTick(lifecycleMeetingId);
+    if (action?.kind === "start_capture") {
+      if (isCapturing()) return;
+      const meeting = await createMeeting({
+        title: `Meeting ${formatTime(Date.now())}`,
+        sourceApp: action.sourceApp ?? "Auto-detect",
+        templateId: settingsStore.get("meetingTemplateId"),
+      });
+      lifecycleMeetingId = meeting.id;
+      await requestCaptureStart(meeting);
       return;
     }
-    setMeetingState("autoDetectSourceApp", detection.sourceApp);
-    setMeetingState("autoDetectSuggested", !autoDetectDismissed);
+    if (action?.kind === "stop_capture") {
+      const id = lifecycleMeetingId;
+      lifecycleMeetingId = null;
+      const meeting =
+        id === null
+          ? undefined
+          : meetingState.meetings.find((item) => item.id === id);
+      if (meeting) await stopAndProcess(meeting);
+      return;
+    }
+
+    // No lifecycle action and nothing recording: surface the arm prompt only
+    // for an unrecognized app (the lifecycle auto-handles known call apps).
+    if (lifecycleMeetingId === null && !isCapturing()) {
+      const detection = await meetingAutodetect();
+      if (detection.detected && !detection.sourceApp) {
+        setMeetingState("autoDetectSourceApp", detection.sourceApp);
+        setMeetingState("autoDetectSuggested", !autoDetectDismissed);
+      } else {
+        autoDetectDismissed = false;
+        setMeetingState("autoDetectSuggested", false);
+        setMeetingState("autoDetectSourceApp", null);
+      }
+    }
   } catch {
-    // Probe failures are non-fatal; leave the prompt as-is.
+    // Probe/tick failures are non-fatal; leave state as-is.
   }
 }
 

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -1053,10 +1053,13 @@ async function pollAutoDetect(): Promise<void> {
     return;
   }
 
-  try {
-    const action = await meetingLifecycleTick(lifecycleMeetingId);
-    if (action?.kind === "start_capture") {
-      if (isCapturing()) return;
+  // 1) Lifecycle auto start/stop for known call apps. A tick failure degrades
+  //    to null so the unrecognized-app prompt below still runs.
+  const action = await meetingLifecycleTick(lifecycleMeetingId).catch(
+    () => null,
+  );
+  if (action?.kind === "start_capture") {
+    if (!isCapturing()) {
       const meeting = await createMeeting({
         title: `Meeting ${formatTime(Date.now())}`,
         sourceApp: action.sourceApp ?? "Auto-detect",
@@ -1064,34 +1067,32 @@ async function pollAutoDetect(): Promise<void> {
       });
       lifecycleMeetingId = meeting.id;
       await requestCaptureStart(meeting);
-      return;
     }
-    if (action?.kind === "stop_capture") {
-      const id = lifecycleMeetingId;
-      lifecycleMeetingId = null;
-      const meeting =
-        id === null
-          ? undefined
-          : meetingState.meetings.find((item) => item.id === id);
-      if (meeting) await stopAndProcess(meeting);
-      return;
-    }
+    return;
+  }
+  if (action?.kind === "stop_capture") {
+    const id = lifecycleMeetingId;
+    lifecycleMeetingId = null;
+    const meeting =
+      id === null
+        ? undefined
+        : meetingState.meetings.find((item) => item.id === id);
+    if (meeting) await stopAndProcess(meeting);
+    return;
+  }
 
-    // No lifecycle action and nothing recording: surface the arm prompt only
-    // for an unrecognized app (the lifecycle auto-handles known call apps).
-    if (lifecycleMeetingId === null && !isCapturing()) {
-      const detection = await meetingAutodetect();
-      if (detection.detected && !detection.sourceApp) {
-        setMeetingState("autoDetectSourceApp", detection.sourceApp);
-        setMeetingState("autoDetectSuggested", !autoDetectDismissed);
-      } else {
-        autoDetectDismissed = false;
-        setMeetingState("autoDetectSuggested", false);
-        setMeetingState("autoDetectSourceApp", null);
-      }
+  // 2) Fallback arm prompt for an unrecognized app the lifecycle won't
+  //    auto-handle. Known apps auto-start above and never reach here.
+  if (lifecycleMeetingId === null && !isCapturing()) {
+    const detection = await meetingAutodetect().catch(() => null);
+    if (detection?.detected && !detection.sourceApp) {
+      setMeetingState("autoDetectSourceApp", detection.sourceApp);
+      setMeetingState("autoDetectSuggested", !autoDetectDismissed);
+    } else {
+      autoDetectDismissed = false;
+      setMeetingState("autoDetectSuggested", false);
+      setMeetingState("autoDetectSourceApp", null);
     }
-  } catch {
-    // Probe/tick failures are non-fatal; leave state as-is.
   }
 }
 

--- a/tests/unit/meeting-autodetect-dismiss-reset.test.ts
+++ b/tests/unit/meeting-autodetect-dismiss-reset.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Regression coverage for #2209 — dismissed auto-record prompts must re-arm after calls end.
-// ABOUTME: The poll must still probe while dismissed so a later call can prompt again.
+// ABOUTME: Known apps now auto-start via the lifecycle; the prompt is for unrecognized apps, and must still re-arm.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -8,6 +8,9 @@ const m = vi.hoisted(() => ({
     detected: false,
     sourceApp: null,
   })),
+  // The lifecycle takes no action for an unrecognized app, so the poll falls
+  // through to the arm prompt — the path this regression guards.
+  meetingLifecycleTick: vi.fn(async (): Promise<null> => null),
   listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
 }));
 
@@ -18,6 +21,7 @@ vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
 vi.mock("@/services/meetings", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/services/meetings")>()),
   meetingAutodetect: m.meetingAutodetect,
+  meetingLifecycleTick: m.meetingLifecycleTick,
   listMeetings: m.listMeetings,
 }));
 vi.mock("@/stores/settings.store", () => ({
@@ -33,6 +37,11 @@ vi.mock("@/stores/settings.store", () => ({
 import type { Meeting, MeetingAutodetectResult } from "@/services/meetings";
 import { meetingStore } from "@/stores/meeting.store";
 
+// Flush the microtasks of one poll (lifecycle tick + autodetect + state set).
+async function flushPoll(): Promise<void> {
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+}
+
 describe("meeting auto-detect dismissal reset (#2209)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -41,6 +50,8 @@ describe("meeting auto-detect dismissal reset (#2209)", () => {
       clearInterval: globalThis.clearInterval,
     });
     m.meetingAutodetect.mockReset();
+    m.meetingLifecycleTick.mockReset();
+    m.meetingLifecycleTick.mockResolvedValue(null);
     m.listMeetings.mockResolvedValue([]);
     meetingStore.stopAutoDetect();
     meetingStore.resetAutoDetectDismissal();
@@ -52,19 +63,20 @@ describe("meeting auto-detect dismissal reset (#2209)", () => {
     vi.useRealTimers();
   });
 
-  it("re-arms the record prompt after the previously dismissed call app disappears", async () => {
+  it("re-arms the record prompt after a dismissed unrecognized call disappears", async () => {
+    // An unrecognized call app (no known source) the lifecycle won't auto-start.
     m.meetingAutodetect.mockResolvedValueOnce({
       detected: true,
-      sourceApp: "Discord",
+      sourceApp: null,
     });
     meetingStore.startAutoDetect();
-    await Promise.resolve();
+    await flushPoll();
 
     expect(meetingStore.state.autoDetectSuggested).toBe(true);
-    expect(meetingStore.state.autoDetectSourceApp).toBe("Discord");
     meetingStore.dismissAutoDetect();
     expect(meetingStore.state.autoDetectSuggested).toBe(false);
 
+    // Call ends: while dismissed, the poll keeps probing and clears the dismissal.
     m.meetingAutodetect.mockResolvedValueOnce({
       detected: false,
       sourceApp: null,
@@ -73,14 +85,14 @@ describe("meeting auto-detect dismissal reset (#2209)", () => {
     expect(meetingStore.state.autoDetectSuggested).toBe(false);
     expect(meetingStore.state.autoDetectSourceApp).toBeNull();
 
+    // A later unrecognized call re-arms the prompt.
     m.meetingAutodetect.mockResolvedValueOnce({
       detected: true,
-      sourceApp: "Zoom",
+      sourceApp: null,
     });
     await vi.advanceTimersByTimeAsync(5_000);
 
     expect(m.meetingAutodetect).toHaveBeenCalledTimes(3);
     expect(meetingStore.state.autoDetectSuggested).toBe(true);
-    expect(meetingStore.state.autoDetectSourceApp).toBe("Zoom");
   });
 });


### PR DESCRIPTION
## Automatic recording lifecycle (#2670)

Closes #2670. Turns Seren's **passive** meeting detection into an **automatic** recorder: capture auto-starts when a known conferencing app takes the mic and auto-stops (multi-signal) when the call ends — fixing the 209-minute runaway, and the "I forgot to start" gap. Design: `docs/design/auto-record-and-search.md`.

### What's in this PR

**Rust decision core + wiring**
- `audio/lifecycle.rs` — pure state machine: debounced auto-start on the *(mic-active AND known-call-app)* gate; multi-signal auto-stop (app-release 90s grace / 15-min silence backstop / matched calendar end + 5-min tail); manual-stop suppression; back-to-back merge prevention. **One critical unit test** covers these transitions.
- `meeting_lifecycle_tick` / `meeting_lifecycle_note_manual_stop` commands expose the controller (held in Tauri-managed state) to the frontend poll. `select_last_segment_ms` is the silence anchor.
- Pause/resume: a pause gate on the shared `CaptureStreamStats` (no worker-signature churn) so workers drop frames while paused — no segments, no buffered audio — without ending the session. `pause_meeting_capture` / `resume_meeting_capture`.

**Frontend**
- The existing auto-detect poll now drives the lifecycle: auto-creates + starts a meeting on a known app (reusing the existing priming / in-flight-guard / `stopAndProcess` paths), never interferes with a manually-started capture, and suppresses auto-restart after a manual stop. The arm prompt now shows only for an *unrecognized* app the lifecycle won't auto-handle.
- `RecordingIndicator` — always-visible floating pill (elapsed time, pulsing rec dot, mic-lost notice) with one-click Pause/Resume, Stop, Delete, and a copyable participant disclosure ("Notify"). Mounted globally in `AppShell`.
- First-run priming dialog gains a local-recording/consent note.
- Confirm-on-quit guard while recording (built to never block quit).
- Auto-record is ON by default (`meetingAutoDetectEnabled` already defaults true).

### Verification
- `cargo test --lib`: **870 passed, 0 failed** (incl. the lifecycle decision test).
- Frontend meeting suites: **26 passed** (auto-detect dismiss/reset updated to the new design, priming-cancel, native-capture-lifecycle, ui-regressions, rename-and-indicator, concurrent-stop, record-prompt-placement, settings-copy).
- `tsc --noEmit` and `biome check` clean on all changed files.

### Honest caveats
- **Live behavior not auto-tested here:** a real "Zoom call → auto-start, then end → auto-stop", plus pause/resume and the quit-confirm, need a human on an actual call (no live audio in CI). The decision logic is unit-tested; the wiring is glue over existing, tested paths.
- **Sleep guard:** the explicit confirm-on-quit is included; system *sleep* is covered defense-in-depth by the auto-stop signals (sleep → mic released → 90s grace, with the 15-min silence backstop behind it).

Companion work: #2659 (calendar metadata + pre-arm) and #2658 (semantic search) follow as separate PRs.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
