### PR TITLE
feat: calendar-driven meeting metadata + upcoming peek (#2659)

### DIFF
--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -154,6 +154,14 @@ pub struct Meeting {
     pub seren_notes_id: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
+    /// How the recording started: "manual", "auto_mic", or "calendar".
+    pub trigger_source: Option<String>,
+    /// Matched calendar event id, when a calendar event was associated.
+    pub calendar_event_id: Option<String>,
+    /// Calendar provider for the matched event (e.g. "google").
+    pub calendar_provider: Option<String>,
+    /// JSON array of attendee names/emails from the matched calendar event.
+    pub attendees_json: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -33,6 +33,10 @@ pub async fn create_meeting(
     source_app: Option<String>,
     started_at: Option<i64>,
     template_id: Option<String>,
+    trigger_source: Option<String>,
+    calendar_event_id: Option<String>,
+    calendar_provider: Option<String>,
+    attendees_json: Option<String>,
 ) -> Result<Meeting, String> {
     let now = now_ms();
     let meeting = NewMeeting {
@@ -41,6 +45,10 @@ pub async fn create_meeting(
         source_app,
         started_at: started_at.unwrap_or(now),
         template_id,
+        trigger_source,
+        calendar_event_id,
+        calendar_provider,
+        attendees_json,
         now,
     };
 
@@ -1326,6 +1334,10 @@ pub struct NewMeeting {
     pub source_app: Option<String>,
     pub started_at: i64,
     pub template_id: Option<String>,
+    pub trigger_source: Option<String>,
+    pub calendar_event_id: Option<String>,
+    pub calendar_provider: Option<String>,
+    pub attendees_json: Option<String>,
     pub now: i64,
 }
 
@@ -1350,9 +1362,10 @@ pub fn insert_meeting(conn: &Connection, meeting: NewMeeting) -> Result<Meeting>
             id, title, source_app, started_at, ended_at, status, template_id,
             routed_skill_slug, agent_conversation_id, notes_markdown,
             notes_struct_json, failure_reason, capture_diagnostics_json,
-            seren_notes_id, created_at, updated_at
+            seren_notes_id, created_at, updated_at,
+            trigger_source, calendar_event_id, calendar_provider, attendees_json
          )
-         VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?7, ?7)",
+         VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?7, ?7, ?8, ?9, ?10, ?11)",
         params![
             meeting.id,
             meeting.title,
@@ -1360,7 +1373,11 @@ pub fn insert_meeting(conn: &Connection, meeting: NewMeeting) -> Result<Meeting>
             meeting.started_at,
             MeetingStatus::PendingCapture.as_str(),
             meeting.template_id,
-            meeting.now
+            meeting.now,
+            meeting.trigger_source,
+            meeting.calendar_event_id,
+            meeting.calendar_provider,
+            meeting.attendees_json
         ],
     )?;
     mark_sync_upsert(conn, "meetings", &meeting.id)?;
@@ -1373,7 +1390,8 @@ pub fn select_meeting(conn: &Connection, id: &str) -> Result<Option<Meeting>> {
         "SELECT id, title, source_app, started_at, ended_at, status, template_id,
                 routed_skill_slug, agent_conversation_id, notes_markdown,
                 notes_struct_json, failure_reason, capture_diagnostics_json,
-                seren_notes_id, created_at, updated_at
+                seren_notes_id, created_at, updated_at,
+                trigger_source, calendar_event_id, calendar_provider, attendees_json
          FROM meetings
          WHERE id = ?1",
         params![id],
@@ -1387,7 +1405,8 @@ pub fn select_meetings(conn: &Connection, limit: i32) -> Result<Vec<Meeting>> {
         "SELECT id, title, source_app, started_at, ended_at, status, template_id,
                 routed_skill_slug, agent_conversation_id, notes_markdown,
                 notes_struct_json, failure_reason, capture_diagnostics_json,
-                seren_notes_id, created_at, updated_at
+                seren_notes_id, created_at, updated_at,
+                trigger_source, calendar_event_id, calendar_provider, attendees_json
          FROM meetings
          ORDER BY started_at DESC
          LIMIT ?1",
@@ -1579,6 +1598,10 @@ fn row_to_meeting(row: &rusqlite::Row<'_>) -> Result<Meeting> {
         seren_notes_id: row.get(13)?,
         created_at: row.get(14)?,
         updated_at: row.get(15)?,
+        trigger_source: row.get(16)?,
+        calendar_event_id: row.get(17)?,
+        calendar_provider: row.get(18)?,
+        attendees_json: row.get(19)?,
     })
 }
 
@@ -1726,6 +1749,10 @@ mod tests {
             source_app: Some("Zoom".to_string()),
             started_at: 10,
             template_id: Some("discovery".to_string()),
+            trigger_source: None,
+            calendar_event_id: None,
+            calendar_provider: None,
+            attendees_json: None,
             now: 20,
         }
     }

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -492,6 +492,10 @@ fn setup_history_sync_schema(conn: &Connection) -> Result<()> {
     add_column_if_missing(conn, "meetings", "deleted_at", "INTEGER")?;
     add_column_if_missing(conn, "meetings", "synced_at", "INTEGER")?;
     add_column_if_missing(conn, "meetings", "updated_at", "INTEGER")?;
+    add_column_if_missing(conn, "meetings", "trigger_source", "TEXT")?;
+    add_column_if_missing(conn, "meetings", "calendar_event_id", "TEXT")?;
+    add_column_if_missing(conn, "meetings", "calendar_provider", "TEXT")?;
+    add_column_if_missing(conn, "meetings", "attendees_json", "TEXT")?;
     conn.execute(
         "UPDATE meetings
          SET updated_at = created_at

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -5,6 +5,7 @@ import { createMemo, createSignal, For, onMount, Show } from "solid-js";
 import { ConfirmDialog } from "@/components/catalog/ConfirmDialog";
 import { MeetingDetail } from "@/components/meeting/MeetingDetail";
 import { MeetingSettings } from "@/components/meeting/MeetingSettings";
+import { UpcomingMeetings } from "@/components/meeting/UpcomingMeetings";
 import { createMeetingDurationClock } from "@/lib/meeting-duration-clock";
 import {
   formatDuration,
@@ -328,6 +329,10 @@ export function MeetingPanel() {
 
       {/* Auto-detect now surfaces app-wide via RecordPrompt (titlebar); the
           in-panel banner was a dead spot (only visible with this panel open). */}
+
+      <Show when={!showSettings()}>
+        <UpcomingMeetings />
+      </Show>
 
       <Show when={!showSettings()} fallback={<MeetingSettings />}>
         <div class="min-h-0 flex-1 grid grid-cols-[220px_1fr]">

--- a/src/components/meeting/UpcomingMeetings.tsx
+++ b/src/components/meeting/UpcomingMeetings.tsx
@@ -1,0 +1,54 @@
+// ABOUTME: Compact upcoming-meetings peek from the connected Google Calendar.
+// ABOUTME: Shows the next events and offers one-tap recording with metadata.
+
+import { For, Show } from "solid-js";
+import { formatTime } from "@/lib/meeting-format";
+import { meetingStore } from "@/stores/meeting.store";
+
+export function UpcomingMeetings() {
+  const upcoming = () =>
+    meetingStore.state.upcomingEvents
+      .filter((event) => event.endMs > Date.now())
+      .slice(0, 4);
+
+  return (
+    <Show when={upcoming().length > 0}>
+      <div class="px-4 py-3 border-b border-border bg-surface-0/40">
+        <div class="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          Upcoming
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <For each={upcoming()}>
+            {(event) => (
+              <div class="flex min-w-0 items-center gap-2">
+                <div class="min-w-0 flex-1">
+                  <div class="truncate text-[12px] font-medium text-foreground">
+                    {event.title}
+                  </div>
+                  <div class="truncate text-[10px] text-muted-foreground">
+                    {formatTime(event.startMs)}
+                    {event.attendees.length > 0
+                      ? ` · ${event.attendees.length} attendee${
+                          event.attendees.length === 1 ? "" : "s"
+                        }`
+                      : ""}
+                    {event.meetingUrl ? " · video" : ""}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  class="h-6 shrink-0 rounded-md border border-border bg-surface-2 px-2 text-[10px] font-medium text-foreground transition-colors hover:bg-surface-3"
+                  onClick={() =>
+                    void meetingStore.startFromCalendarEvent(event)
+                  }
+                >
+                  Record
+                </button>
+              </div>
+            )}
+          </For>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -1,0 +1,151 @@
+// ABOUTME: Google Calendar read client for meeting metadata + pre-arm.
+// ABOUTME: Lists windowed upcoming events via the Gateway publisher and matches them to recordings.
+
+import { apiBase } from "@/lib/config";
+import { appFetch } from "@/lib/fetch";
+import { publisherStatus, unwrapPublisherBody } from "@/lib/publisher-response";
+import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
+import { getToken } from "@/services/auth";
+
+const PUBLISHER_SLUG = "google-calendar";
+
+/** A normalized upcoming calendar event for meeting matching + pre-arm. */
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  startMs: number;
+  endMs: number;
+  /** Attendee display names (falling back to email). */
+  attendees: string[];
+  /** Video-conferencing join link, when the event has one. */
+  meetingUrl: string | null;
+}
+
+// Google `eventType`s that are not real meetings.
+const NON_MEETING_EVENT_TYPES = new Set([
+  "workingLocation",
+  "outOfOffice",
+  "focusTime",
+]);
+
+interface RawGoogleEvent {
+  id?: string;
+  summary?: string;
+  status?: string;
+  eventType?: string;
+  start?: { dateTime?: string; date?: string };
+  end?: { dateTime?: string; date?: string };
+  attendees?: Array<{ displayName?: string; email?: string }>;
+  hangoutLink?: string;
+  location?: string;
+  conferenceData?: {
+    entryPoints?: Array<{ entryPointType?: string; uri?: string }>;
+  };
+}
+
+function eventTimeMs(
+  slot: { dateTime?: string; date?: string } | undefined,
+): number | null {
+  const raw = slot?.dateTime ?? slot?.date;
+  if (!raw) return null;
+  const ms = Date.parse(raw);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function videoLinkFor(event: RawGoogleEvent): string | null {
+  if (event.hangoutLink) return event.hangoutLink;
+  const video = event.conferenceData?.entryPoints?.find(
+    (entry) => entry.entryPointType === "video" && entry.uri,
+  );
+  if (video?.uri) return video.uri;
+  // Zoom/Meet links sometimes live only in the location field.
+  const match = (event.location ?? "").match(
+    /https?:\/\/\S*(zoom\.us|meet\.google\.com)\S*/i,
+  );
+  return match ? match[0] : null;
+}
+
+/** Normalize a raw Google event, dropping cancelled/non-meeting entries. */
+export function normalizeEvent(event: RawGoogleEvent): CalendarEvent | null {
+  if (event.status === "cancelled") return null;
+  if (event.eventType && NON_MEETING_EVENT_TYPES.has(event.eventType)) {
+    return null;
+  }
+  const startMs = eventTimeMs(event.start);
+  const endMs = eventTimeMs(event.end);
+  if (startMs === null || endMs === null) return null;
+  return {
+    id: event.id ?? "",
+    title: event.summary?.trim() || "Untitled event",
+    startMs,
+    endMs,
+    attendees: (event.attendees ?? [])
+      .map((attendee) => attendee.displayName?.trim() || attendee.email?.trim())
+      .filter((name): name is string => Boolean(name)),
+    meetingUrl: videoLinkFor(event),
+  };
+}
+
+/**
+ * Fetch upcoming events from the user's primary Google calendar, windowed
+ * `[now, now + aheadMs]`. Returns `[]` on any failure (not connected, offline,
+ * upstream error) so callers degrade gracefully.
+ */
+export async function getUpcomingEvents(
+  aheadMs = 12 * 60 * 60_000,
+): Promise<CalendarEvent[]> {
+  const now = Date.now();
+  const params = new URLSearchParams({
+    timeMin: new Date(now).toISOString(),
+    timeMax: new Date(now + aheadMs).toISOString(),
+    singleEvents: "true",
+    orderBy: "startTime",
+    maxResults: "20",
+  });
+  const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/events?${params.toString()}`;
+  const headers: Record<string, string> = {};
+  if (!shouldUseRustGatewayAuth(url)) {
+    const token = await getToken();
+    if (!token) return [];
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  try {
+    const response = await appFetch(url, { method: "GET", headers });
+    if (!response.ok) return [];
+    const result = await response.json();
+    if (publisherStatus(result) === 200 || publisherStatus(result) === null) {
+      const body = unwrapPublisherBody(result) as { items?: RawGoogleEvent[] };
+      return (body?.items ?? [])
+        .map(normalizeEvent)
+        .filter((event): event is CalendarEvent => event !== null)
+        .sort((a, b) => a.startMs - b.startMs);
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Pick the calendar event a recording starting at `nowMs` belongs to: the one
+ * whose window contains now (with a small lead-in), preferring events that have
+ * a video-conferencing link. Returns null when nothing matches.
+ */
+export function matchActiveEvent(
+  events: CalendarEvent[],
+  nowMs: number,
+  leadMs = 5 * 60_000,
+): CalendarEvent | null {
+  const candidates = events.filter(
+    (event) => nowMs >= event.startMs - leadMs && nowMs <= event.endMs,
+  );
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => {
+    const linkDelta =
+      Number(Boolean(b.meetingUrl)) - Number(Boolean(a.meetingUrl));
+    if (linkDelta !== 0) return linkDelta;
+    return Math.abs(nowMs - a.startMs) - Math.abs(nowMs - b.startMs);
+  });
+  return candidates[0];
+}

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -31,6 +31,14 @@ export interface Meeting {
   captureDiagnosticsJson?: string | null;
   /** UUID of the auto-published seren-notes entry, when one exists. */
   serenNotesId?: string | null;
+  /** How the recording started: "manual", "auto_mic", or "calendar". */
+  triggerSource?: string | null;
+  /** Matched calendar event id, when associated with a calendar event. */
+  calendarEventId?: string | null;
+  /** Calendar provider for the matched event (e.g. "google"). */
+  calendarProvider?: string | null;
+  /** JSON array of attendee names/emails from the matched calendar event. */
+  attendeesJson?: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -58,6 +66,10 @@ export interface CreateMeetingInput {
   sourceApp?: string | null;
   startedAt?: number | null;
   templateId?: string | null;
+  triggerSource?: string | null;
+  calendarEventId?: string | null;
+  calendarProvider?: string | null;
+  attendeesJson?: string | null;
 }
 
 export interface AppendTranscriptSegmentInput {
@@ -76,6 +88,10 @@ export function createMeeting(input: CreateMeetingInput): Promise<Meeting> {
     sourceApp: input.sourceApp ?? null,
     startedAt: input.startedAt ?? null,
     templateId: input.templateId ?? null,
+    triggerSource: input.triggerSource ?? null,
+    calendarEventId: input.calendarEventId ?? null,
+    calendarProvider: input.calendarProvider ?? null,
+    attendeesJson: input.attendeesJson ?? null,
   });
 }
 

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -11,6 +11,11 @@ import {
 import { captureSupportError } from "@/lib/support/hook";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 import {
+  type CalendarEvent,
+  getUpcomingEvents,
+  matchActiveEvent,
+} from "@/services/calendar";
+import {
   type CaptureStopOutcome,
   createMeeting,
   deleteMeeting as deleteMeetingRecord,
@@ -52,6 +57,8 @@ interface MeetingState {
   captureLevel: number;
   /** True while the active capture is paused (frame ingestion suspended). */
   capturePaused: boolean;
+  /** Upcoming calendar events (empty unless Google Calendar is connected). */
+  upcomingEvents: CalendarEvent[];
   /**
    * True while the native mic is disconnected mid-capture and the backend is
    * re-acquiring it. The panel shows a "microphone disconnected — reconnecting…"
@@ -83,6 +90,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   liveSegments: [],
   captureLevel: 0,
   capturePaused: false,
+  upcomingEvents: [],
   micCaptureLost: false,
   isLoading: false,
   error: null,
@@ -115,6 +123,15 @@ const AUTO_DETECT_POLL_MS = 5_000;
 // The meeting the auto-record lifecycle started, if any. Tracked so each tick
 // passes the silence anchor and so a manual stop can suppress auto-restart.
 let lifecycleMeetingId: string | null = null;
+
+// The matched calendar event's end for the active lifecycle recording, fed to
+// the lifecycle tick so it can auto-stop at scheduled-end + tail.
+let lifecycleEventEndMs: number | null = null;
+
+// Upcoming calendar events, refreshed lazily (~5 min) and matched to recordings.
+let cachedUpcomingEvents: CalendarEvent[] = [];
+let lastCalendarFetchMs = 0;
+const CALENDAR_REFRESH_MS = 5 * 60_000;
 
 // Quit guard: confirm-on-quit while a capture is live. `quitConfirmed` lets a
 // second close request pass through even if window.destroy() is unavailable,
@@ -1031,6 +1048,17 @@ function isCapturing(ignoreMeetingId?: string): boolean {
 // Opt-in poll: while "auto-detect meetings" is on and nothing is capturing,
 // probe for active input and surface an arm prompt. The user still presses
 // start; capture is never auto-armed without consent.
+// Refresh the upcoming-events cache at most every CALENDAR_REFRESH_MS. Failures
+// (not connected, offline) leave the cache empty so matching degrades to no
+// calendar metadata. Fire-and-forget so it never blocks a poll.
+async function refreshUpcomingEventsIfStale(): Promise<void> {
+  const now = Date.now();
+  if (now - lastCalendarFetchMs < CALENDAR_REFRESH_MS) return;
+  lastCalendarFetchMs = now;
+  cachedUpcomingEvents = await getUpcomingEvents();
+  setMeetingState("upcomingEvents", cachedUpcomingEvents);
+}
+
 async function pollAutoDetect(): Promise<void> {
   if (!isTauriRuntime()) return;
   if (!settingsStore.get("meetingAutoDetectEnabled")) {
@@ -1039,11 +1067,14 @@ async function pollAutoDetect(): Promise<void> {
     return;
   }
 
+  void refreshUpcomingEventsIfStale();
+
   // A lifecycle recording that stopped outside the lifecycle (user hit Stop, or
   // priming was canceled): suppress auto-restart until the call's mic ends.
   if (lifecycleMeetingId !== null && !isCapturing()) {
     await meetingLifecycleNoteManualStop().catch(() => {});
     lifecycleMeetingId = null;
+    lifecycleEventEndMs = null;
   }
 
   // Don't interfere with a capture the lifecycle didn't start.
@@ -1054,18 +1085,30 @@ async function pollAutoDetect(): Promise<void> {
   }
 
   // 1) Lifecycle auto start/stop for known call apps. A tick failure degrades
-  //    to null so the unrecognized-app prompt below still runs.
-  const action = await meetingLifecycleTick(lifecycleMeetingId).catch(
-    () => null,
-  );
+  //    to null so the unrecognized-app prompt below still runs. The matched
+  //    calendar event's end feeds the tick's scheduled-end auto-stop.
+  const action = await meetingLifecycleTick(
+    lifecycleMeetingId,
+    lifecycleEventEndMs,
+  ).catch(() => null);
   if (action?.kind === "start_capture") {
     if (!isCapturing()) {
+      const now = Date.now();
+      const event = matchActiveEvent(cachedUpcomingEvents, now);
       const meeting = await createMeeting({
-        title: `Meeting ${formatTime(Date.now())}`,
+        title: event?.title ?? `Meeting ${formatTime(now)}`,
         sourceApp: action.sourceApp ?? "Auto-detect",
         templateId: settingsStore.get("meetingTemplateId"),
+        triggerSource: "auto_mic",
+        calendarEventId: event?.id ?? null,
+        calendarProvider: event ? "google" : null,
+        attendeesJson:
+          event && event.attendees.length > 0
+            ? JSON.stringify(event.attendees)
+            : null,
       });
       lifecycleMeetingId = meeting.id;
+      lifecycleEventEndMs = event?.endMs ?? null;
       await requestCaptureStart(meeting);
     }
     return;
@@ -1073,6 +1116,7 @@ async function pollAutoDetect(): Promise<void> {
   if (action?.kind === "stop_capture") {
     const id = lifecycleMeetingId;
     lifecycleMeetingId = null;
+    lifecycleEventEndMs = null;
     const meeting =
       id === null
         ? undefined

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -1192,6 +1192,25 @@ function acknowledgeReviewReady(meetingId?: string): void {
   }
 }
 
+// Start a recording from an upcoming calendar event (one-tap from the Upcoming
+// panel): stamps the event's title + attendees + id, then starts through the
+// shared priming gate. Treated as a manual capture, so the user stops it.
+async function startFromCalendarEvent(event: CalendarEvent): Promise<void> {
+  if (!isTauriRuntime() || isStarting || meetingState.primingRequest) return;
+  if (isCapturing()) return;
+  const meeting = await createMeeting({
+    title: event.title,
+    sourceApp: "Calendar",
+    templateId: settingsStore.get("meetingTemplateId"),
+    triggerSource: "calendar",
+    calendarEventId: event.id,
+    calendarProvider: "google",
+    attendeesJson:
+      event.attendees.length > 0 ? JSON.stringify(event.attendees) : null,
+  });
+  await requestCaptureStart(meeting);
+}
+
 export const meetingStore = {
   get state(): MeetingState {
     return meetingState;
@@ -1221,6 +1240,7 @@ export const meetingStore = {
   startAutoDetect,
   stopAutoDetect,
   acceptAutoDetect,
+  startFromCalendarEvent,
   dismissAutoDetect,
   resetAutoDetectDismissal,
   acknowledgeReviewReady,

--- a/tests/unit/calendar-match.test.ts
+++ b/tests/unit/calendar-match.test.ts
@@ -1,0 +1,99 @@
+// ABOUTME: Critical-path coverage for calendar event normalization + recording match.
+// ABOUTME: Pure logic that decides a recording's title/attendees and pre-arm window.
+
+import { describe, expect, it } from "vitest";
+import {
+  type CalendarEvent,
+  matchActiveEvent,
+  normalizeEvent,
+} from "@/services/calendar";
+
+describe("calendar normalizeEvent", () => {
+  it("parses a timed meeting with attendees and a hangout link", () => {
+    const event = normalizeEvent({
+      id: "e1",
+      summary: "Sync",
+      status: "confirmed",
+      eventType: "default",
+      start: { dateTime: "2026-06-26T10:00:00-07:00" },
+      end: { dateTime: "2026-06-26T10:30:00-07:00" },
+      attendees: [
+        { displayName: "Taariq Lewis", email: "t@x.com" },
+        { email: "a@b.com" },
+      ],
+      hangoutLink: "https://meet.google.com/abc",
+    });
+    expect(event?.title).toBe("Sync");
+    expect(event?.attendees).toEqual(["Taariq Lewis", "a@b.com"]);
+    expect(event?.meetingUrl).toBe("https://meet.google.com/abc");
+    expect(event?.startMs).toBe(Date.parse("2026-06-26T10:00:00-07:00"));
+  });
+
+  it("drops cancelled and non-meeting event types", () => {
+    expect(
+      normalizeEvent({
+        status: "cancelled",
+        start: { date: "2026-06-26" },
+        end: { date: "2026-06-27" },
+      }),
+    ).toBeNull();
+    expect(
+      normalizeEvent({
+        eventType: "outOfOffice",
+        start: { dateTime: "2026-06-26T10:00:00Z" },
+        end: { dateTime: "2026-06-26T11:00:00Z" },
+      }),
+    ).toBeNull();
+  });
+
+  it("extracts a zoom link from the location field", () => {
+    const event = normalizeEvent({
+      summary: "Call",
+      eventType: "default",
+      start: { dateTime: "2026-06-26T10:00:00Z" },
+      end: { dateTime: "2026-06-26T11:00:00Z" },
+      location: "Zoom: https://us02web.zoom.us/j/123",
+    });
+    expect(event?.meetingUrl).toBe("https://us02web.zoom.us/j/123");
+  });
+});
+
+describe("calendar matchActiveEvent", () => {
+  const event = (over: Partial<CalendarEvent>): CalendarEvent => ({
+    id: "x",
+    title: "T",
+    startMs: 0,
+    endMs: 0,
+    attendees: [],
+    meetingUrl: null,
+    ...over,
+  });
+
+  it("matches an in-window event and prefers one with a join link", () => {
+    const now = 1_000_000;
+    const noLink = event({ id: "no", startMs: now - 1000, endMs: now + 60_000 });
+    const withLink = event({
+      id: "yes",
+      startMs: now - 1000,
+      endMs: now + 60_000,
+      meetingUrl: "https://meet.google.com/x",
+    });
+    expect(matchActiveEvent([noLink, withLink], now)?.id).toBe("yes");
+  });
+
+  it("matches during the lead-in, and returns null outside any window", () => {
+    const now = 1_000_000;
+    const soon = event({
+      id: "soon",
+      startMs: now + 2 * 60_000,
+      endMs: now + 30 * 60_000,
+    });
+    expect(matchActiveEvent([soon], now)?.id).toBe("soon");
+    const later = event({
+      id: "later",
+      startMs: now + 60 * 60_000,
+      endMs: now + 90 * 60_000,
+    });
+    expect(matchActiveEvent([later], now)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Calendar-driven meeting context (#2659)

Closes #2659. Adds **Google Calendar metadata** to the (now automatic) recorder: auto-started recordings are matched to the concurrent calendar event and stamped with its **title + attendees**, the matched event's scheduled end drives the lifecycle's calendar auto-stop, and an **Upcoming-meetings** peek surfaces the next events with one-tap record. Builds on the auto-record lifecycle (#2670).

### What's in this PR
- **Data model** — nullable `meetings` columns `trigger_source`, `calendar_event_id`, `calendar_provider`, `attendees_json` via the additive `add_column_if_missing` migration, threaded through `Meeting`/`NewMeeting`, insert, both selects, the row mapper, `create_meeting`, and the TS `Meeting`/`CreateMeetingInput`. Backward-compatible; cloud mirror rides the existing `payload jsonb`.
- **`calendar.ts`** — windowed `getUpcomingEvents()` over the Gateway HTTP path (`GET /publishers/google-calendar/events?timeMin&timeMax&singleEvents&orderBy`), normalizing title / start-end / attendees / video link (`hangoutLink` → `conferenceData` → `location` zoom/meet), dropping cancelled + non-meeting `eventType`s. `matchActiveEvent()` picks the event a recording belongs to (prefers one with a join link). Degrades to `[]` when Google isn't connected.
- **Wiring** — the auto-detect poll lazily refreshes a windowed event cache (~5 min, fire-and-forget), feeds the matched event end to the lifecycle tick (`calendarEndMs`, the hook plumbed in #2670), and stamps metadata + `trigger_source=auto_mic` on auto-start.
- **UI** — `UpcomingMeetings` peek in the meeting panel (title, time, attendee count, video flag) with one-tap **Record** (stamps `trigger_source=calendar`). Self-hides when no events. Google connect reuses the existing `OAuthLogins` settings — no new connect flow.

### Verification
- `cargo test --lib commands::audio`: **16 passed** (incl. persistence round-trip + schema-migration idempotency).
- Frontend: `calendar-match` (5) + meeting suites (auto-detect, ui-regressions, priming-cancel, native-capture-lifecycle, rename-and-indicator, record-prompt, concurrent-stop) all green; `tsc` + `biome` clean on changed files.

### Notable findings / caveats
- The MCP `get_events` **tool drops query params** (returns all history); the **HTTP path windows correctly** — verified live against the connected account. That's why `calendar.ts` uses `appFetch` (like `seren-whisper.ts`), not `callGatewayTool`.
- **Live behavior not auto-tested here:** real calendar match-on-a-call needs a human with a live meeting. The parse + match logic is unit-tested against the verified event shape.
- **Follow-up (not in scope):** device pre-warming (a Rust `Armed` state ~1–2 min before a scheduled meeting) — a cold-start-latency optimization; mic-activity auto-start already covers starting, and Outlook/Exchange calendar needs a new publisher.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
