### PR TITLE
Fix live session re-attach state hydration

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -748,6 +748,51 @@ function buildPermissionToolCall(toolName, input, toolUseId) {
   };
 }
 
+function buildPermissionOptions() {
+  return [
+    {
+      optionId: "allow_once",
+      label: "Allow once",
+      description: "Allow this action one time.",
+    },
+    {
+      optionId: "allow_session",
+      label: "Allow session",
+      description: "Allow this tool for the rest of this session.",
+    },
+    {
+      optionId: "deny",
+      label: "Reject",
+      description: "Reject this action but keep the turn running.",
+    },
+    {
+      optionId: "cancel",
+      label: "Cancel turn",
+      description: "Reject this action and interrupt the turn.",
+    },
+  ];
+}
+
+function buildPermissionRequestEvent(session, requestId, pending) {
+  return {
+    sessionId: session.id,
+    requestId,
+    toolCall: buildPermissionToolCall(
+      pending.toolName,
+      pending.toolInput,
+      pending.toolUseId,
+    ),
+    options: buildPermissionOptions(),
+  };
+}
+
+function listPendingPermissions(session) {
+  return Array.from(session.pendingPermissions.entries()).map(
+    ([requestId, pending]) =>
+      buildPermissionRequestEvent(session, requestId, pending),
+  );
+}
+
 function stringifyToolResultContent(content) {
   if (typeof content === "string") {
     return content;
@@ -1596,33 +1641,14 @@ function handlePermissionRequest(emit, session, payload) {
     toolUseId,
   });
 
-  emit("provider://permission-request", {
-    sessionId: session.id,
-    requestId,
-    toolCall: buildPermissionToolCall(toolName, toolInput, toolUseId),
-    options: [
-      {
-        optionId: "allow_once",
-        label: "Allow once",
-        description: "Allow this action one time.",
-      },
-      {
-        optionId: "allow_session",
-        label: "Allow session",
-        description: "Allow this tool for the rest of this session.",
-      },
-      {
-        optionId: "deny",
-        label: "Reject",
-        description: "Reject this action but keep the turn running.",
-      },
-      {
-        optionId: "cancel",
-        label: "Cancel turn",
-        description: "Reject this action and interrupt the turn.",
-      },
-    ],
-  });
+  emit(
+    "provider://permission-request",
+    buildPermissionRequestEvent(session, requestId, {
+      toolName,
+      toolInput,
+      toolUseId,
+    }),
+  );
 }
 
 function handleSystemMessage(emit, session, payload) {
@@ -2476,6 +2502,9 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       createdAt: session.createdAt,
       agentSessionId: session.agentSessionId,
       timeoutSecs: session.timeoutSecs,
+      currentModelId: session.currentModelId,
+      currentModeId: session.currentModeId,
+      pendingPermissions: listPendingPermissions(session),
     }));
   }
 

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -505,16 +505,45 @@ function handleSessionUpdate(emit, session, params) {
  * Handle an inbound ACP request from the agent. Today the only one we expect
  * is `session/request_permission` for tool approvals.
  */
+function buildPermissionRequestEvent(session, requestId, params) {
+  return {
+    sessionId: session.id,
+    requestId,
+    toolCall: {
+      name: params.toolCall?.name ?? "tool",
+      title: params.toolCall?.title ?? "Tool call",
+      input: params.toolCall ?? {},
+    },
+    options: (params.options ?? []).map((opt) => ({
+      optionId: opt.optionId,
+      label: opt.name ?? opt.optionId,
+      description: opt.kind,
+    })),
+  };
+}
+
+function listPendingPermissions(session) {
+  return Array.from(session.pendingPermissions.values()).map(
+    (pending) => pending.permissionRequest,
+  );
+}
+
 function handleAgentRequest(emit, session, payload) {
   if (payload.method === "session/request_permission") {
     const params = payload.params ?? {};
     const requestId = randomUUID();
+    const permissionRequest = buildPermissionRequestEvent(
+      session,
+      requestId,
+      params,
+    );
     session.pendingPermissions.set(requestId, {
       requestId,
       jsonRpcId: payload.id,
       // Store the ACP option list verbatim so respondToPermission can map
       // a desktop optionId back to the agent's expected outcome.
       options: Array.isArray(params.options) ? params.options : [],
+      permissionRequest,
     });
 
     // Auto-approve in YOLO / auto_edit mode for non-destructive tools.
@@ -536,20 +565,7 @@ function handleAgentRequest(emit, session, payload) {
       return;
     }
 
-    emit("provider://permission-request", {
-      sessionId: session.id,
-      requestId,
-      toolCall: {
-        name: params.toolCall?.name ?? "tool",
-        title: params.toolCall?.title ?? "Tool call",
-        input: params.toolCall ?? {},
-      },
-      options: (params.options ?? []).map((opt) => ({
-        optionId: opt.optionId,
-        label: opt.name ?? opt.optionId,
-        description: opt.kind,
-      })),
-    });
+    emit("provider://permission-request", permissionRequest);
     return;
   }
 
@@ -950,6 +966,9 @@ export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) 
       createdAt: session.createdAt,
       agentSessionId: session.agentSessionId,
       timeoutSecs: session.timeoutSecs,
+      currentModelId: session.currentModelId,
+      currentModeId: session.currentModeId,
+      pendingPermissions: listPendingPermissions(session),
     }));
   }
 

--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -1231,6 +1231,45 @@ async function runChatCompletion({ session, tools, signal, onContent }) {
   }
 }
 
+function buildPermissionOptions() {
+  return [
+    {
+      optionId: "accept",
+      label: "Approve once",
+      description: "Run this tool call one time.",
+    },
+    {
+      optionId: "acceptForSession",
+      label: "Approve session",
+      description: "Allow this tool for the rest of the session.",
+    },
+    {
+      optionId: "decline",
+      label: "Deny",
+      description: "Return a denial to the model.",
+    },
+  ];
+}
+
+function buildPermissionRequestEvent(session, requestId, toolCall, args) {
+  return {
+    sessionId: session.id,
+    requestId,
+    toolCall: {
+      name: toolCall.function.name,
+      title: toolCall.function.name,
+      input: args,
+    },
+    options: buildPermissionOptions(),
+  };
+}
+
+function listPendingPermissions(session) {
+  return Array.from(session.pendingPermissions.values()).map(
+    (pending) => pending.permissionRequest,
+  );
+}
+
 async function requestPermission(session, toolCall, args) {
   if (
     session.currentModeId === "auto" ||
@@ -1240,36 +1279,21 @@ async function requestPermission(session, toolCall, args) {
   }
 
   const requestId = randomUUID();
+  const permissionRequest = buildPermissionRequestEvent(
+    session,
+    requestId,
+    toolCall,
+    args,
+  );
   const permission = new Promise((resolve) => {
-    session.pendingPermissions.set(requestId, { resolve, toolName: toolCall.function.name });
+    session.pendingPermissions.set(requestId, {
+      resolve,
+      toolName: toolCall.function.name,
+      permissionRequest,
+    });
   });
 
-  session.emit("provider://permission-request", {
-    sessionId: session.id,
-    requestId,
-    toolCall: {
-      name: toolCall.function.name,
-      title: toolCall.function.name,
-      input: args,
-    },
-    options: [
-      {
-        optionId: "accept",
-        label: "Approve once",
-        description: "Run this tool call one time.",
-      },
-      {
-        optionId: "acceptForSession",
-        label: "Approve session",
-        description: "Allow this tool for the rest of the session.",
-      },
-      {
-        optionId: "decline",
-        label: "Deny",
-        description: "Return a denial to the model.",
-      },
-    ],
-  });
+  session.emit("provider://permission-request", permissionRequest);
 
   return permission;
 }
@@ -1597,6 +1621,9 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
       createdAt: session.createdAt,
       agentSessionId: session.agentSessionId,
       timeoutSecs: session.timeoutSecs,
+      currentModelId: session.currentModelId,
+      currentModeId: session.currentModeId,
+      pendingPermissions: listPendingPermissions(session),
     }));
   }
 

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -694,6 +694,36 @@ function buildApprovalToolCall(method, params) {
   };
 }
 
+function buildApprovalOptions() {
+  return [
+    {
+      optionId: "accept",
+      label: "Approve once",
+      description: "Allow this action one time.",
+    },
+    {
+      optionId: "acceptForSession",
+      label: "Approve session",
+      description: "Allow similar actions for the rest of this session.",
+    },
+  ];
+}
+
+function buildPermissionRequestEvent(session, requestId, method, params) {
+  return {
+    sessionId: session.id,
+    requestId,
+    toolCall: buildApprovalToolCall(method, params),
+    options: buildApprovalOptions(),
+  };
+}
+
+function listPendingPermissions(session) {
+  return Array.from(session.pendingPermissions.values()).map(
+    (pending) => pending.permissionRequest,
+  );
+}
+
 function isRecoverableResumeError(message) {
   const lower = String(message).toLowerCase();
   return (
@@ -786,10 +816,17 @@ function handleResponse(session, payload) {
 function handleServerRequest(emit, session, payload) {
   const method = payload.method;
   const requestId = randomUUID();
+  const params = payload.params ?? {};
   const pendingPermission = {
     requestId,
     jsonRpcId: payload.id,
     method,
+    permissionRequest: buildPermissionRequestEvent(
+      session,
+      requestId,
+      method,
+      params,
+    ),
   };
 
   if (session.currentModeId === "auto") {
@@ -805,23 +842,7 @@ function handleServerRequest(emit, session, payload) {
 
   session.pendingPermissions.set(requestId, pendingPermission);
 
-  emit("provider://permission-request", {
-    sessionId: session.id,
-    requestId,
-    toolCall: buildApprovalToolCall(method, payload.params ?? {}),
-    options: [
-      {
-        optionId: "accept",
-        label: "Approve once",
-        description: "Allow this action one time.",
-      },
-      {
-        optionId: "acceptForSession",
-        label: "Approve session",
-        description: "Allow similar actions for the rest of this session.",
-      },
-    ],
-  });
+  emit("provider://permission-request", pendingPermission.permissionRequest);
 }
 
 function handleNotification(emit, session, payload) {
@@ -1504,6 +1525,9 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         createdAt: session.createdAt,
         agentSessionId: session.agentSessionId,
         timeoutSecs: session.timeoutSecs,
+        currentModelId: session.currentModelId,
+        currentModeId: session.currentModeId,
+        pendingPermissions: listPendingPermissions(session),
       })),
       ...(await claudeRuntime.listSessions()),
       ...(await geminiRuntime.listSessions()),

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -68,6 +68,12 @@ export interface AgentSessionInfo {
    * runtime could not report a PID. #2313
    */
   pid?: number | null;
+  /** Runtime-authoritative model id for a live session. */
+  currentModelId?: string | null;
+  /** Runtime-authoritative permission/mode id for a live session. */
+  currentModeId?: string | null;
+  /** Pending approval dialogs that must be re-surfaced after UI re-attach. */
+  pendingPermissions?: PermissionRequestEvent[];
 }
 
 export interface AgentInfo {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -52,6 +52,10 @@ const sessionReadyPromises = new Map<
  *  when selectThread fires twice before the first spawn registers the session. */
 const spawningConversations = new Set<string>();
 
+/** Conversations with a live-session re-attach currently in progress.
+ *  Multiple resume triggers can race before the adopted session reaches state. */
+const reattachingConversations = new Map<string, Promise<boolean>>();
+
 /** Session IDs that have been explicitly terminated. The global event subscriber
  *  drops events for these IDs to prevent stale errors from dead sessions leaking
  *  into new/live sessions. Cleared when the global subscriber is torn down. */
@@ -3591,132 +3595,175 @@ export const agentStore = {
    * usable live session and the caller should fall back to terminate+respawn.
    */
   async reattachLiveSession(conversationId: string): Promise<boolean> {
-    let liveInfo: AgentSessionInfo | undefined;
-    try {
-      const backendSessions = await providerService.listSessions();
-      liveInfo = backendSessions.find((s) => s.id === conversationId);
-    } catch (err) {
-      // If we cannot ask the runtime, fall back to the normal respawn path.
-      console.warn(
-        "[AgentStore] listSessions during re-attach probe failed:",
-        err,
-      );
-      return false;
+    const inFlight = reattachingConversations.get(conversationId);
+    if (inFlight) {
+      return inFlight;
     }
 
-    // No live session, or one the runtime already considers dead — let the
-    // caller terminate (a no-op for a missing session) and respawn fresh.
-    if (
-      !liveInfo ||
-      liveInfo.status === "terminated" ||
-      liveInfo.status === "error"
-    ) {
-      return false;
-    }
-
-    // Paired (claude-codex) threads are a two-inner-session structure whose
-    // PairedStatus the runtime's flat session info does not expose. Re-adopting
-    // one would drop the paired UI, so leave paired resumes on the existing
-    // terminate+respawn path (which reseeds pairedConfig from metadata). #2672
-    if (liveInfo.agentType === "claude-codex") {
-      return false;
-    }
-
-    // Restore the persisted transcript for display. The live session already
-    // streamed these turns while connected; re-attach renders them from SQLite
-    // rather than replaying from a fresh process.
-    const restored = await loadPersistedAgentHistory(conversationId);
-    let convo: DbAgentConversation | null = null;
-    try {
-      convo = await getAgentConversation(conversationId);
-    } catch {
-      // Non-fatal — the runtime is the source of truth for the live session.
-    }
-    const agentType = liveInfo.agentType;
-
-    // The webview reload that dropped our session handle also dropped the
-    // global event subscription. Re-install it so events from the live
-    // session (incl. background task completions) are routed again.
-    await this.ensureAgentEventSubscription();
-
-    // This id is alive again — clear any stale terminated marker so the global
-    // subscriber does not drop its events.
-    terminatedSessionIds.delete(conversationId);
-    spawnContextMap.delete(conversationId);
-
-    const hasRestoredMessages = restored.messages.length > 0;
-    // The live session may be mid-turn at re-attach time (e.g. a reload while
-    // the agent is answering). The runtime reports this as "prompting".
-    const liveTurnInFlight = liveInfo.status === "prompting";
-    const session: ActiveSession = {
-      info: liveInfo,
-      messages: restored.messages,
-      plan: [],
-      pendingToolCalls: new Map(),
-      streamingContent: "",
-      streamingThinking: "",
-      pendingUserMessage: "",
-      cwd: liveInfo.cwd,
-      conversationId,
-      agentSessionId: liveInfo.agentSessionId,
-      // Re-attach performs NO provider replay (it never respawns the CLI), so
-      // there are no replay events to suppress — only live ones. Setting
-      // skipHistoryReplay here would make every live event handler early-return
-      // and silently drop the entire in-flight turn (and its persistence).
-      // Leave it unset so live chunks/tool calls render; restored history won't
-      // duplicate because the live session only emits new forward events. #2674
-      skipHistoryReplay: undefined,
-      restoredMessageCount: hasRestoredMessages
-        ? restored.messages.length
-        : undefined,
-      // A mid-turn re-attach has no record of when the turn began; seed the
-      // elapsed-time clock now so the "Thinking…" indicator reflects reality.
-      promptStartTime: liveTurnInFlight ? Date.now() : undefined,
-      contextWindowSize: defaultContextWindowFor(
-        agentType,
-        convo?.agent_model_id ?? undefined,
-      ),
-      currentModelId: convo?.agent_model_id ?? undefined,
-      currentModeId: convo?.agent_permission_mode ?? undefined,
-      title: convo?.title,
-      pendingPrompts: [],
-      role: "serving",
-    };
-    setState("sessions", conversationId, session);
-    setState("activeSessionId", conversationId);
-
-    // Reflect an in-flight turn so the UI shows activity instead of looking
-    // idle while the re-attached agent is actually working. Cleared on the
-    // turn's promptComplete/cancel like any other turn. #2674
-    if (liveTurnInFlight) {
-      this.setTurnInFlight(conversationId, true);
-    }
-
-    // Drain events buffered by the global subscriber while no session record
-    // existed for this id.
-    const pendingEvents = pendingSessionEvents.get(conversationId);
-    if (pendingEvents?.length) {
-      for (const pendingEvent of pendingEvents) {
-        this.handleSessionEvent(conversationId, pendingEvent);
+    const attempt = (async () => {
+      let liveInfo: AgentSessionInfo | undefined;
+      try {
+        const backendSessions = await providerService.listSessions();
+        liveInfo = backendSessions.find((s) => s.id === conversationId);
+      } catch (err) {
+        // If we cannot ask the runtime, fall back to the normal respawn path.
+        console.warn(
+          "[AgentStore] listSessions during re-attach probe failed:",
+          err,
+        );
+        return false;
       }
-      pendingSessionEvents.delete(conversationId);
-    }
 
-    // The live session is already past initialization — unblock any sendPrompt
-    // that awaits a readiness gate keyed on this id.
-    const readyEntry = sessionReadyPromises.get(conversationId);
-    if (readyEntry) {
-      readyEntry.resolve();
-      sessionReadyPromises.delete(conversationId);
-    }
+      // No live session, or one the runtime already considers dead — let the
+      // caller terminate (a no-op for a missing session) and respawn fresh.
+      if (
+        !liveInfo ||
+        liveInfo.status === "terminated" ||
+        liveInfo.status === "error"
+      ) {
+        return false;
+      }
 
-    console.info(
-      "[AgentStore] Re-attached to live runtime session for conversation",
-      conversationId,
-      "status:",
-      liveInfo.status,
-    );
-    return true;
+      // Paired (claude-codex) threads are a two-inner-session structure whose
+      // PairedStatus the runtime's flat session info does not expose. Re-adopting
+      // one would drop the paired UI, so leave paired resumes on the existing
+      // terminate+respawn path (which reseeds pairedConfig from metadata). #2672
+      if (liveInfo.agentType === "claude-codex") {
+        return false;
+      }
+
+      // Restore the persisted transcript for display. The live session already
+      // streamed these turns while connected; re-attach renders them from SQLite
+      // rather than replaying from a fresh process.
+      const restored = await loadPersistedAgentHistory(conversationId);
+      let convo: DbAgentConversation | null = null;
+      try {
+        convo = await getAgentConversation(conversationId);
+      } catch {
+        // Non-fatal — the runtime is the source of truth for the live session.
+      }
+      const agentType = liveInfo.agentType;
+      const runtimeModelId =
+        liveInfo.currentModelId ?? convo?.agent_model_id ?? undefined;
+      const runtimeModeId =
+        liveInfo.currentModeId ?? convo?.agent_permission_mode ?? undefined;
+      const rehydratedPendingPermissions = (
+        liveInfo.pendingPermissions ?? []
+      ).filter(
+        (permission) =>
+          permission?.sessionId === conversationId &&
+          typeof permission.requestId === "string" &&
+          Array.isArray(permission.options),
+      );
+
+      // The webview reload that dropped our session handle also dropped the
+      // global event subscription. Re-install it so events from the live
+      // session (incl. background task completions) are routed again.
+      await this.ensureAgentEventSubscription();
+
+      // This id is alive again — clear any stale terminated marker so the global
+      // subscriber does not drop its events.
+      terminatedSessionIds.delete(conversationId);
+      spawnContextMap.delete(conversationId);
+
+      const hasRestoredMessages = restored.messages.length > 0;
+      // The live session may be mid-turn at re-attach time (e.g. a reload while
+      // the agent is answering). The runtime reports this as "prompting".
+      const liveTurnInFlight = liveInfo.status === "prompting";
+      const session: ActiveSession = {
+        info: liveInfo,
+        messages: restored.messages,
+        plan: [],
+        pendingToolCalls: new Map(),
+        streamingContent: "",
+        streamingThinking: "",
+        pendingUserMessage: "",
+        cwd: liveInfo.cwd,
+        conversationId,
+        agentSessionId: liveInfo.agentSessionId,
+        // Re-attach performs NO provider replay (it never respawns the CLI), so
+        // there are no replay events to suppress — only live ones. Setting
+        // skipHistoryReplay here would make every live event handler early-return
+        // and silently drop the entire in-flight turn (and its persistence).
+        // Leave it unset so live chunks/tool calls render; restored history won't
+        // duplicate because the live session only emits new forward events. #2674
+        skipHistoryReplay: undefined,
+        restoredMessageCount: hasRestoredMessages
+          ? restored.messages.length
+          : undefined,
+        // A mid-turn re-attach has no record of when the turn began; seed the
+        // elapsed-time clock now so the "Thinking…" indicator reflects reality.
+        promptStartTime: liveTurnInFlight ? Date.now() : undefined,
+        contextWindowSize: defaultContextWindowFor(
+          agentType,
+          runtimeModelId ?? undefined,
+        ),
+        currentModelId: runtimeModelId ?? undefined,
+        currentModeId: runtimeModeId ?? undefined,
+        title: convo?.title,
+        pendingPrompts: [],
+        role: "serving",
+      };
+      setState("sessions", conversationId, session);
+      setState("activeSessionId", conversationId);
+
+      if (rehydratedPendingPermissions.length > 0) {
+        const seenRequestIds = new Set(
+          state.pendingPermissions.map((permission) => permission.requestId),
+        );
+        const nextPendingPermissions = [...state.pendingPermissions];
+        for (const permission of rehydratedPendingPermissions) {
+          if (seenRequestIds.has(permission.requestId)) {
+            continue;
+          }
+          seenRequestIds.add(permission.requestId);
+          nextPendingPermissions.push(permission);
+        }
+        setState("pendingPermissions", nextPendingPermissions);
+      }
+
+      // Reflect an in-flight turn so the UI shows activity instead of looking
+      // idle while the re-attached agent is actually working. Cleared on the
+      // turn's promptComplete/cancel like any other turn. #2674
+      if (liveTurnInFlight) {
+        this.setTurnInFlight(conversationId, true);
+      }
+
+      // Drain events buffered by the global subscriber while no session record
+      // existed for this id.
+      const pendingEvents = pendingSessionEvents.get(conversationId);
+      if (pendingEvents?.length) {
+        for (const pendingEvent of pendingEvents) {
+          this.handleSessionEvent(conversationId, pendingEvent);
+        }
+        pendingSessionEvents.delete(conversationId);
+      }
+
+      // The live session is already past initialization — unblock any sendPrompt
+      // that awaits a readiness gate keyed on this id.
+      const readyEntry = sessionReadyPromises.get(conversationId);
+      if (readyEntry) {
+        readyEntry.resolve();
+        sessionReadyPromises.delete(conversationId);
+      }
+
+      console.info(
+        "[AgentStore] Re-attached to live runtime session for conversation",
+        conversationId,
+        "status:",
+        liveInfo.status,
+      );
+      return true;
+    })();
+
+    reattachingConversations.set(conversationId, attempt);
+    try {
+      return await attempt;
+    } finally {
+      if (reattachingConversations.get(conversationId) === attempt) {
+        reattachingConversations.delete(conversationId);
+      }
+    }
   },
 
   /**
@@ -6242,6 +6289,7 @@ export const agentStore = {
     sessionResetGeneration += 1;
     disposeAgentStoreRuntimeBindings();
     spawningConversations.clear();
+    reattachingConversations.clear();
     expectedTerminateSessionIds.clear();
     restartTimers.forEach((timer) => clearTimeout(timer));
     restartTimers.clear();
@@ -6958,6 +7006,13 @@ export const agentStore = {
                 "unknown",
             ),
         );
+        if (
+          state.pendingPermissions.some(
+            (permission) => permission.requestId === permEvent.requestId,
+          )
+        ) {
+          break;
+        }
         setState("pendingPermissions", [
           ...state.pendingPermissions,
           permEvent,

--- a/tests/unit/resume-reattach-live-session-2675.test.ts
+++ b/tests/unit/resume-reattach-live-session-2675.test.ts
@@ -1,0 +1,82 @@
+// ABOUTME: Regression checks for #2675 — re-attach must restore live runtime
+// ABOUTME: approval/model/mode state and serialize concurrent adoption.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const providerServiceSource = readFileSync(
+  resolve("src/services/providers.ts"),
+  "utf-8",
+);
+const runtimeSources = [
+  "bin/browser-local/claude-runtime.mjs",
+  "bin/browser-local/providers.mjs",
+  "bin/browser-local/gemini-runtime.mjs",
+  "bin/browser-local/lmstudio-runtime.mjs",
+].map((path) => [path, readFileSync(resolve(path), "utf-8")] as const);
+
+function extractMethodBody(name: string): string {
+  const start = agentStoreSource.indexOf(`async ${name}(`);
+  if (start < 0) return "";
+  const rest = agentStoreSource.slice(start + 1);
+  const nextAsync = rest.indexOf("\n  async ");
+  return nextAsync < 0 ? agentStoreSource.slice(start) : rest.slice(0, nextAsync);
+}
+
+describe("#2675 — live re-attach restores runtime state", () => {
+  const reattachBody = extractMethodBody("reattachLiveSession");
+
+  it("listSessions exposes the runtime state needed to rehydrate the UI", () => {
+    expect(providerServiceSource).toContain("currentModelId?: string | null");
+    expect(providerServiceSource).toContain("currentModeId?: string | null");
+    expect(providerServiceSource).toContain(
+      "pendingPermissions?: PermissionRequestEvent[]",
+    );
+  });
+
+  it("reattachLiveSession serializes concurrent adoption for one conversation", () => {
+    expect(agentStoreSource).toContain("const reattachingConversations");
+    expect(reattachBody).toContain(
+      "const inFlight = reattachingConversations.get(conversationId)",
+    );
+    expect(reattachBody).toContain("return inFlight");
+    expect(reattachBody).toContain(
+      "reattachingConversations.set(conversationId, attempt)",
+    );
+    expect(reattachBody).toContain(
+      "reattachingConversations.delete(conversationId)",
+    );
+  });
+
+  it("reattachLiveSession prefers live runtime model and mode over stale DB values", () => {
+    const runtimeModelAt = reattachBody.indexOf("liveInfo.currentModelId");
+    const runtimeModeAt = reattachBody.indexOf("liveInfo.currentModeId");
+    const sessionModelAt = reattachBody.indexOf("currentModelId: runtimeModelId");
+    const sessionModeAt = reattachBody.indexOf("currentModeId: runtimeModeId");
+
+    expect(runtimeModelAt).toBeGreaterThan(-1);
+    expect(runtimeModeAt).toBeGreaterThan(-1);
+    expect(sessionModelAt).toBeGreaterThan(runtimeModelAt);
+    expect(sessionModeAt).toBeGreaterThan(runtimeModeAt);
+  });
+
+  it("reattachLiveSession re-surfaces pending approvals without duplicates", () => {
+    expect(reattachBody).toContain("liveInfo.pendingPermissions");
+    expect(reattachBody).toContain('setState("pendingPermissions"');
+    expect(reattachBody).toContain("seenRequestIds");
+    expect(agentStoreSource).toContain("permission.requestId === permEvent.requestId");
+  });
+
+  it("browser-local runtimes snapshot pending approvals through listSessions", () => {
+    for (const [path, source] of runtimeSources) {
+      expect(source, path).toContain("pendingPermissions: listPendingPermissions(session)");
+      expect(source, path).toContain("currentModelId: session.currentModelId");
+      expect(source, path).toContain("currentModeId: session.currentModeId");
+    }
+  });
+});


### PR DESCRIPTION
Closes #2675

## Summary
- Expose runtime-authoritative `currentModelId`, `currentModeId`, and pending permission snapshots from `listSessions()` for Claude, Codex, Gemini, and LM Studio browser-local runtimes.
- Serialize `reattachLiveSession()` adoption per conversation so concurrent resume triggers share one adoption/drain path.
- Rehydrate pending approval dialogs from the live runtime and suppress duplicate permission dialogs by `requestId` when buffered events overlap rehydration.

## Audit
- Re-confirmed the broken paths from #2675: `listSessions()` did not carry approval/model/mode state, and `reattachLiveSession()` seeded picker state from the DB row while lacking a per-conversation re-attach guard.
- macOS and Windows use the same frontend store and provider-runtime `provider_list_sessions` contract for this flow; no platform-specific path differences were found.
- Functional walk-through audit found no new P0/P1 issue requiring a follow-up ticket. A duplicate permission-dialog risk introduced by rehydrating before draining buffered events was caught in audit and fixed in this PR.

## Verification
- `pnpm exec vitest run tests/unit/resume-reattach-live-session-2669.test.ts tests/unit/resume-reattach-live-session-2675.test.ts tests/unit/agent-spawn-guard.test.ts`
- `pnpm exec biome check src/services/providers.ts src/stores/agent.store.ts tests/unit/resume-reattach-live-session-2675.test.ts bin/browser-local/claude-runtime.mjs bin/browser-local/providers.mjs bin/browser-local/gemini-runtime.mjs bin/browser-local/lmstudio-runtime.mjs`
- `node --check bin/browser-local/claude-runtime.mjs`
- `node --check bin/browser-local/providers.mjs`
- `node --check bin/browser-local/gemini-runtime.mjs`
- `node --check bin/browser-local/lmstudio-runtime.mjs`
- `pnpm build`
- `pnpm build:provider-runtime`
- `pnpm test:runtime-smoke`

Note: `pnpm exec tsc --noEmit` still fails on an existing unrelated unit-test typing issue in `tests/unit/claude-workflow-history-replay.test.ts` (`Unused '@ts-expect-error'` and missing declaration for `../../bin/browser-local/claude-runtime.mjs`).
