### PR TITLE
feat: semantic transcript search via seren-embed + sqlite-vec (#2658)

### DIFF
--- a/src-tauri/src/commands/transcript_search.rs
+++ b/src-tauri/src/commands/transcript_search.rs
@@ -1,0 +1,74 @@
+// ABOUTME: Tauri commands for semantic transcript search over meeting embeddings.
+// ABOUTME: Indexes pre-embedded chunks and runs KNN queries via the transcript vector DB.
+
+use crate::services::transcript_vectors::{self, TranscriptHit, open_transcript_db};
+use serde::Deserialize;
+use tauri::AppHandle;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranscriptChunkInput {
+    pub seq_start: i64,
+    pub seq_end: i64,
+    pub text: String,
+    pub embedding: Vec<f32>,
+}
+
+/// Re-index a meeting's transcript: replace its chunks with the supplied
+/// pre-embedded chunks. Embeddings are generated on the frontend via seren-embed.
+#[tauri::command]
+pub fn index_meeting_transcript(
+    app: AppHandle,
+    meeting_id: String,
+    chunks: Vec<TranscriptChunkInput>,
+) -> Result<usize, String> {
+    let conn = open_transcript_db(&app).map_err(|err| err.to_string())?;
+    transcript_vectors::delete_meeting_chunks(&conn, &meeting_id)
+        .map_err(|err| err.to_string())?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    for chunk in &chunks {
+        transcript_vectors::insert_transcript_chunk(
+            &conn,
+            &meeting_id,
+            chunk.seq_start,
+            chunk.seq_end,
+            &chunk.text,
+            &chunk.embedding,
+            now,
+        )
+        .map_err(|err| err.to_string())?;
+    }
+    Ok(chunks.len())
+}
+
+/// Semantic KNN search over indexed transcripts using a query embedding.
+#[tauri::command]
+pub fn search_transcripts(
+    app: AppHandle,
+    query_embedding: Vec<f32>,
+    limit: Option<usize>,
+) -> Result<Vec<TranscriptHit>, String> {
+    let conn = open_transcript_db(&app).map_err(|err| err.to_string())?;
+    transcript_vectors::search_transcript_chunks(&conn, &query_embedding, limit.unwrap_or(20))
+        .map_err(|err| err.to_string())
+}
+
+/// Meeting ids that already have indexed transcript chunks (for backfill).
+#[tauri::command]
+pub fn indexed_transcript_meeting_ids(app: AppHandle) -> Result<Vec<String>, String> {
+    let conn = open_transcript_db(&app).map_err(|err| err.to_string())?;
+    transcript_vectors::indexed_meeting_ids(&conn).map_err(|err| err.to_string())
+}
+
+/// Drop a meeting's transcript index (called when a meeting is deleted).
+#[tauri::command]
+pub fn delete_meeting_transcript_index(
+    app: AppHandle,
+    meeting_id: String,
+) -> Result<(), String> {
+    let conn = open_transcript_db(&app).map_err(|err| err.to_string())?;
+    transcript_vectors::delete_meeting_chunks(&conn, &meeting_id).map_err(|err| err.to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub mod commands {
     pub mod provider_runtime;
     pub mod recording;
     pub mod session;
+    pub mod transcript_search;
     pub mod updater;
     pub mod web;
 }
@@ -33,6 +34,7 @@ pub mod services {
     pub mod database;
     pub mod history_sync;
     pub mod indexer;
+    pub mod transcript_vectors;
     pub mod vector_store;
 }
 
@@ -1062,6 +1064,10 @@ pub fn run() {
             commands::indexing::file_needs_reindex,
             commands::indexing::search_codebase,
             commands::indexing::get_embedding_dimension,
+            commands::transcript_search::index_meeting_transcript,
+            commands::transcript_search::search_transcripts,
+            commands::transcript_search::indexed_transcript_meeting_ids,
+            commands::transcript_search::delete_meeting_transcript_index,
             commands::indexing::discover_project_files,
             commands::indexing::chunk_file,
             commands::indexing::estimate_indexing,

--- a/src-tauri/src/services/transcript_vectors.rs
+++ b/src-tauri/src/services/transcript_vectors.rs
@@ -1,0 +1,200 @@
+// ABOUTME: Local vector storage for semantic transcript search using sqlite-vec.
+// ABOUTME: Stores meeting transcript chunk embeddings in a dedicated index DB.
+
+use crate::services::vector_store::{EMBEDDING_DIM, init_sqlite_vec};
+use rusqlite::{Connection, Result, params};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+/// A transcript search hit: a matched chunk's location, text, and distance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranscriptHit {
+    pub meeting_id: String,
+    pub seq_start: i64,
+    pub seq_end: i64,
+    pub text: String,
+    pub distance: f32,
+}
+
+fn transcript_db_path(app: &AppHandle) -> PathBuf {
+    app.path()
+        .app_data_dir()
+        .expect("app data dir")
+        .join("indexes")
+        .join("transcripts.db")
+}
+
+/// Create the transcript chunk + embedding tables on a connection that already
+/// has the sqlite-vec extension loaded.
+fn create_transcript_tables(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS transcript_chunks (
+            id INTEGER PRIMARY KEY,
+            meeting_id TEXT NOT NULL,
+            seq_start INTEGER NOT NULL,
+            seq_end INTEGER NOT NULL,
+            text TEXT NOT NULL,
+            indexed_at INTEGER NOT NULL
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_transcript_chunks_meeting
+         ON transcript_chunks (meeting_id)",
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS transcript_embeddings USING vec0(
+                chunk_id INTEGER PRIMARY KEY,
+                embedding float[{EMBEDDING_DIM}]
+            )"
+        ),
+        [],
+    )?;
+    Ok(())
+}
+
+/// Open (creating if needed) the transcript vector DB with sqlite-vec loaded.
+pub fn open_transcript_db(app: &AppHandle) -> Result<Connection> {
+    init_sqlite_vec();
+    let path = transcript_db_path(app);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).ok();
+    }
+    let conn = Connection::open(path)?;
+    create_transcript_tables(&conn)?;
+    Ok(conn)
+}
+
+fn embedding_to_blob(embedding: &[f32]) -> Vec<u8> {
+    embedding.iter().flat_map(|value| value.to_le_bytes()).collect()
+}
+
+/// Remove all indexed chunks for a meeting (before re-indexing or on delete).
+pub fn delete_meeting_chunks(conn: &Connection, meeting_id: &str) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    {
+        let mut stmt =
+            tx.prepare("SELECT id FROM transcript_chunks WHERE meeting_id = ?1")?;
+        let ids: Vec<i64> = stmt
+            .query_map(params![meeting_id], |row| row.get(0))?
+            .filter_map(|row| row.ok())
+            .collect();
+        for id in ids {
+            tx.execute(
+                "DELETE FROM transcript_embeddings WHERE chunk_id = ?1",
+                params![id],
+            )?;
+        }
+    }
+    tx.execute(
+        "DELETE FROM transcript_chunks WHERE meeting_id = ?1",
+        params![meeting_id],
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Insert one transcript chunk and its embedding, returning the chunk id.
+pub fn insert_transcript_chunk(
+    conn: &Connection,
+    meeting_id: &str,
+    seq_start: i64,
+    seq_end: i64,
+    text: &str,
+    embedding: &[f32],
+    now: i64,
+) -> Result<i64> {
+    conn.execute(
+        "INSERT INTO transcript_chunks (meeting_id, seq_start, seq_end, text, indexed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![meeting_id, seq_start, seq_end, text, now],
+    )?;
+    let chunk_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO transcript_embeddings (chunk_id, embedding) VALUES (?1, ?2)",
+        params![chunk_id, embedding_to_blob(embedding)],
+    )?;
+    Ok(chunk_id)
+}
+
+/// K-nearest-neighbor search over indexed transcript chunks.
+pub fn search_transcript_chunks(
+    conn: &Connection,
+    query_embedding: &[f32],
+    limit: usize,
+) -> Result<Vec<TranscriptHit>> {
+    let mut stmt = conn.prepare(
+        "SELECT c.meeting_id, c.seq_start, c.seq_end, c.text, e.distance
+         FROM transcript_embeddings e
+         JOIN transcript_chunks c ON c.id = e.chunk_id
+         WHERE e.embedding MATCH ?1 AND k = ?2
+         ORDER BY e.distance",
+    )?;
+    let hits = stmt
+        .query_map(
+            params![embedding_to_blob(query_embedding), limit as i64],
+            |row| {
+                Ok(TranscriptHit {
+                    meeting_id: row.get(0)?,
+                    seq_start: row.get(1)?,
+                    seq_end: row.get(2)?,
+                    text: row.get(3)?,
+                    distance: row.get(4)?,
+                })
+            },
+        )?
+        .filter_map(|row| row.ok())
+        .collect();
+    Ok(hits)
+}
+
+/// Meeting ids that already have indexed chunks (used to skip backfill work).
+pub fn indexed_meeting_ids(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare("SELECT DISTINCT meeting_id FROM transcript_chunks")?;
+    let ids = stmt
+        .query_map([], |row| row.get(0))?
+        .filter_map(|row| row.ok())
+        .collect();
+    Ok(ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unit_vec(index: usize) -> Vec<f32> {
+        let mut embedding = vec![0.0f32; EMBEDDING_DIM];
+        embedding[index] = 1.0;
+        embedding
+    }
+
+    #[test]
+    fn search_ranks_nearest_chunk_first_and_delete_clears() {
+        init_sqlite_vec();
+        let conn = Connection::open_in_memory().unwrap();
+        create_transcript_tables(&conn).unwrap();
+
+        insert_transcript_chunk(&conn, "m1", 0, 2, "budget decision", &unit_vec(0), 1)
+            .unwrap();
+        insert_transcript_chunk(&conn, "m1", 3, 5, "weather chatter", &unit_vec(1), 1)
+            .unwrap();
+
+        // Query closest to the first chunk's direction.
+        let mut query = vec![0.0f32; EMBEDDING_DIM];
+        query[0] = 0.9;
+        query[1] = 0.1;
+        let hits = search_transcript_chunks(&conn, &query, 5).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].seq_start, 0);
+        assert_eq!(hits[0].text, "budget decision");
+
+        delete_meeting_chunks(&conn, "m1").unwrap();
+        assert!(search_transcript_chunks(&conn, &query, 5).unwrap().is_empty());
+        assert!(indexed_meeting_ids(&conn).unwrap().is_empty());
+    }
+}

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -5,6 +5,7 @@ import { createMemo, createSignal, For, onMount, Show } from "solid-js";
 import { ConfirmDialog } from "@/components/catalog/ConfirmDialog";
 import { MeetingDetail } from "@/components/meeting/MeetingDetail";
 import { MeetingSettings } from "@/components/meeting/MeetingSettings";
+import { TranscriptSearch } from "@/components/meeting/TranscriptSearch";
 import { UpcomingMeetings } from "@/components/meeting/UpcomingMeetings";
 import { createMeetingDurationClock } from "@/lib/meeting-duration-clock";
 import {
@@ -331,6 +332,7 @@ export function MeetingPanel() {
           in-panel banner was a dead spot (only visible with this panel open). */}
 
       <Show when={!showSettings()}>
+        <TranscriptSearch />
         <UpcomingMeetings />
       </Show>
 

--- a/src/components/meeting/TranscriptSearch.tsx
+++ b/src/components/meeting/TranscriptSearch.tsx
@@ -1,0 +1,98 @@
+// ABOUTME: Semantic search field over meeting transcripts with jump-to-meeting results.
+// ABOUTME: Calls the transcript-search service; clicking a hit opens its meeting.
+
+import { createSignal, For, Show } from "solid-js";
+import {
+  searchTranscripts,
+  type TranscriptHit,
+} from "@/services/transcript-search";
+import { meetingStore } from "@/stores/meeting.store";
+
+export function TranscriptSearch() {
+  const [query, setQuery] = createSignal("");
+  const [hits, setHits] = createSignal<TranscriptHit[]>([]);
+  const [searching, setSearching] = createSignal(false);
+  const [searched, setSearched] = createSignal(false);
+
+  const run = async () => {
+    const trimmed = query().trim();
+    if (!trimmed) {
+      setHits([]);
+      setSearched(false);
+      return;
+    }
+    setSearching(true);
+    try {
+      setHits(await searchTranscripts(trimmed, 20));
+    } catch {
+      setHits([]);
+    } finally {
+      setSearching(false);
+      setSearched(true);
+    }
+  };
+
+  const meetingTitleFor = (meetingId: string) =>
+    meetingStore.state.meetings.find((meeting) => meeting.id === meetingId)
+      ?.title ?? "Meeting";
+
+  const openHit = (hit: TranscriptHit) => {
+    const meeting = meetingStore.state.meetings.find(
+      (item) => item.id === hit.meetingId,
+    );
+    if (meeting) void meetingStore.setActiveMeeting(meeting);
+  };
+
+  return (
+    <div class="border-b border-border bg-surface-0/40 px-4 py-3">
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          void run();
+        }}
+      >
+        <input
+          type="search"
+          value={query()}
+          onInput={(event) => setQuery(event.currentTarget.value)}
+          placeholder="Search transcripts…"
+          class="h-8 w-full rounded-md border border-border bg-surface-1 px-2.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:outline-none"
+        />
+      </form>
+
+      <Show when={searching()}>
+        <div class="mt-2 text-[11px] text-muted-foreground">Searching…</div>
+      </Show>
+
+      <Show when={searched() && !searching()}>
+        <Show
+          when={hits().length > 0}
+          fallback={
+            <div class="mt-2 text-[11px] text-muted-foreground">
+              No matches.
+            </div>
+          }
+        >
+          <div class="mt-2 flex max-h-48 flex-col gap-1.5 overflow-auto">
+            <For each={hits()}>
+              {(hit) => (
+                <button
+                  type="button"
+                  onClick={() => openHit(hit)}
+                  class="rounded-md border border-border bg-surface-1 px-2.5 py-1.5 text-left transition-colors hover:bg-surface-2"
+                >
+                  <div class="truncate text-[11px] font-medium text-foreground">
+                    {meetingTitleFor(hit.meetingId)}
+                  </div>
+                  <div class="line-clamp-2 whitespace-pre-line text-[11px] text-muted-foreground">
+                    {hit.text}
+                  </div>
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+      </Show>
+    </div>
+  );
+}

--- a/src/services/transcript-search.ts
+++ b/src/services/transcript-search.ts
@@ -1,0 +1,120 @@
+// ABOUTME: Semantic transcript search — chunk, embed, index, and query meeting transcripts.
+// ABOUTME: Embeddings come from seren-embed; vectors are stored locally via Tauri commands.
+
+import { invoke } from "@tauri-apps/api/core";
+import {
+  getTranscriptSegments,
+  type TranscriptSegment,
+} from "@/services/meetings";
+import { embedText, embedTexts } from "@/services/seren-embed";
+
+// Window transcript segments into chunks small enough to embed but large enough
+// to carry context. Non-overlapping; bounded by chars and segment count.
+const CHUNK_CHAR_BUDGET = 1500;
+const CHUNK_MAX_SEGMENTS = 8;
+
+export interface TranscriptChunk {
+  seqStart: number;
+  seqEnd: number;
+  text: string;
+}
+
+/** A semantic search hit returned by the vector store. */
+export interface TranscriptHit {
+  meetingId: string;
+  seqStart: number;
+  seqEnd: number;
+  text: string;
+  distance: number;
+}
+
+function speakerLabel(speaker: TranscriptSegment["speaker"]): string {
+  return speaker === "me" ? "Me" : "Them";
+}
+
+/**
+ * Split a transcript into embeddable chunks, preserving speaker turns and the
+ * source seq range so a hit can jump back to the exact segment.
+ */
+export function chunkTranscript(
+  segments: TranscriptSegment[],
+): TranscriptChunk[] {
+  const usable = segments.filter(
+    (segment) => segment.status === "ok" && segment.text.trim().length > 0,
+  );
+  const chunks: TranscriptChunk[] = [];
+  let current: TranscriptSegment[] = [];
+  let chars = 0;
+
+  const flush = () => {
+    if (current.length === 0) return;
+    chunks.push({
+      seqStart: current[0].seq,
+      seqEnd: current[current.length - 1].seq,
+      text: current
+        .map(
+          (segment) =>
+            `${speakerLabel(segment.speaker)}: ${segment.text.trim()}`,
+        )
+        .join("\n"),
+    });
+    current = [];
+    chars = 0;
+  };
+
+  for (const segment of usable) {
+    current.push(segment);
+    chars += segment.text.length;
+    if (current.length >= CHUNK_MAX_SEGMENTS || chars >= CHUNK_CHAR_BUDGET) {
+      flush();
+    }
+  }
+  flush();
+  return chunks;
+}
+
+/**
+ * (Re)index one meeting's transcript: chunk it, embed the chunks via seren-embed,
+ * and replace the meeting's stored vectors. Returns the number of chunks indexed.
+ */
+export async function indexMeeting(meetingId: string): Promise<number> {
+  const segments = await getTranscriptSegments(meetingId);
+  const chunks = chunkTranscript(segments);
+  if (chunks.length === 0) {
+    await invoke("delete_meeting_transcript_index", { meetingId });
+    return 0;
+  }
+  const embeddings = await embedTexts(chunks.map((chunk) => chunk.text));
+  const payload = chunks.map((chunk, index) => ({
+    seqStart: chunk.seqStart,
+    seqEnd: chunk.seqEnd,
+    text: chunk.text,
+    embedding: embeddings.data[index].embedding,
+  }));
+  return invoke("index_meeting_transcript", { meetingId, chunks: payload });
+}
+
+/** Semantic search across all indexed transcripts. Empty query → no results. */
+export async function searchTranscripts(
+  query: string,
+  limit = 20,
+): Promise<TranscriptHit[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+  const queryEmbedding = await embedText(trimmed);
+  return invoke("search_transcripts", { queryEmbedding, limit });
+}
+
+/** Index any of the given meetings that aren't already indexed (best-effort). */
+export async function backfillTranscriptIndex(
+  meetingIds: string[],
+): Promise<void> {
+  const indexed = new Set(
+    await invoke<string[]>("indexed_transcript_meeting_ids").catch(() => []),
+  );
+  for (const meetingId of meetingIds) {
+    if (!indexed.has(meetingId)) {
+      await indexMeeting(meetingId).catch(() => {});
+    }
+  }
+}

--- a/src/services/transcript-search.ts
+++ b/src/services/transcript-search.ts
@@ -77,21 +77,32 @@ export function chunkTranscript(
  * (Re)index one meeting's transcript: chunk it, embed the chunks via seren-embed,
  * and replace the meeting's stored vectors. Returns the number of chunks indexed.
  */
+const indexing = new Set<string>();
+
 export async function indexMeeting(meetingId: string): Promise<number> {
-  const segments = await getTranscriptSegments(meetingId);
-  const chunks = chunkTranscript(segments);
-  if (chunks.length === 0) {
-    await invoke("delete_meeting_transcript_index", { meetingId });
-    return 0;
+  if (indexing.has(meetingId)) return 0;
+  indexing.add(meetingId);
+  try {
+    const segments = await getTranscriptSegments(meetingId);
+    const chunks = chunkTranscript(segments);
+    if (chunks.length === 0) {
+      await invoke("delete_meeting_transcript_index", { meetingId });
+      return 0;
+    }
+    const embeddings = await embedTexts(chunks.map((chunk) => chunk.text));
+    const payload = chunks.map((chunk, index) => ({
+      seqStart: chunk.seqStart,
+      seqEnd: chunk.seqEnd,
+      text: chunk.text,
+      embedding: embeddings.data[index].embedding,
+    }));
+    return await invoke("index_meeting_transcript", {
+      meetingId,
+      chunks: payload,
+    });
+  } finally {
+    indexing.delete(meetingId);
   }
-  const embeddings = await embedTexts(chunks.map((chunk) => chunk.text));
-  const payload = chunks.map((chunk, index) => ({
-    seqStart: chunk.seqStart,
-    seqEnd: chunk.seqEnd,
-    text: chunk.text,
-    embedding: embeddings.data[index].embedding,
-  }));
-  return invoke("index_meeting_transcript", { meetingId, chunks: payload });
 }
 
 /** Semantic search across all indexed transcripts. Empty query → no results. */
@@ -103,6 +114,13 @@ export async function searchTranscripts(
   if (!trimmed) return [];
   const queryEmbedding = await embedText(trimmed);
   return invoke("search_transcripts", { queryEmbedding, limit });
+}
+
+/** Drop a meeting's transcript vectors (best-effort; called on delete). */
+export async function deleteMeetingIndex(meetingId: string): Promise<void> {
+  await invoke("delete_meeting_transcript_index", { meetingId }).catch(
+    () => {},
+  );
 }
 
 /** Index any of the given meetings that aren't already indexed (best-effort). */

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -44,6 +44,10 @@ import {
   updateMeetingTitle,
 } from "@/services/meetings";
 import { orchestrate } from "@/services/orchestrator";
+import {
+  backfillTranscriptIndex,
+  deleteMeetingIndex,
+} from "@/services/transcript-search";
 import { onTrayToggleCapture, setTrayRecording } from "@/services/tray";
 import { conversationStore } from "@/stores/conversation.store";
 import { providerStore } from "@/stores/provider.store";
@@ -235,6 +239,7 @@ async function loadMeetings(): Promise<void> {
   try {
     const meetings = await listMeetings();
     setMeetingState("meetings", meetings);
+    void backfillTranscriptIndex(meetings.map((item) => item.id));
   } catch (error) {
     setMeetingState(
       "error",
@@ -1022,6 +1027,7 @@ async function deleteMeeting(meeting: Meeting): Promise<void> {
   }
   try {
     await deleteMeetingRecord(meeting.id);
+    void deleteMeetingIndex(meeting.id);
     const remaining = meetingState.meetings.filter(
       (item) => item.id !== meeting.id,
     );

--- a/tests/unit/transcript-chunk.test.ts
+++ b/tests/unit/transcript-chunk.test.ts
@@ -1,0 +1,48 @@
+// ABOUTME: Critical-path coverage for transcript chunking used by semantic search.
+// ABOUTME: Chunks must drop gaps/empties and preserve the seq range for jump-to-source.
+
+import { describe, expect, it } from "vitest";
+import type { TranscriptSegment } from "@/services/meetings";
+import { chunkTranscript } from "@/services/transcript-search";
+
+const seg = (
+  seq: number,
+  text: string,
+  over: Partial<TranscriptSegment> = {},
+): TranscriptSegment => ({
+  id: `s${seq}`,
+  meetingId: "m",
+  seq,
+  speaker: "me",
+  text,
+  startMs: 0,
+  endMs: 0,
+  status: "ok",
+  createdAt: 0,
+  ...over,
+});
+
+describe("chunkTranscript", () => {
+  it("drops gaps/empties and preserves seq range + speaker labels", () => {
+    const chunks = chunkTranscript([
+      seg(0, "hello", { speaker: "me" }),
+      seg(1, "   ", { status: "ok" }),
+      seg(2, "world", { speaker: "them", status: "gap" }),
+      seg(3, "again", { speaker: "them" }),
+    ]);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].seqStart).toBe(0);
+    expect(chunks[0].seqEnd).toBe(3);
+    expect(chunks[0].text).toBe("Me: hello\nThem: again");
+  });
+
+  it("splits into contiguous, non-overlapping chunks past the segment cap", () => {
+    const many = Array.from({ length: 20 }, (_, index) =>
+      seg(index, `turn ${index}`),
+    );
+    const chunks = chunkTranscript(many);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks[0].seqStart).toBe(0);
+    expect(chunks[1].seqStart).toBe(chunks[0].seqEnd + 1);
+  });
+});


### PR DESCRIPTION
## Semantic transcript search (#2658)

Adds **semantic search over meeting transcripts** via the existing `seren-embed` + `sqlite-vec` path (per the design decision to reuse the maintained vector infra rather than stand up FTS5). A search field in the meeting panel returns ranked, speaker-labeled snippets; clicking a hit opens its meeting.

### What's in this PR
- **Rust vector store** — `services/transcript_vectors.rs`: a dedicated `transcripts.db` index (`transcript_chunks` + `transcript_embeddings` vec0[1536]) mirroring the code-search store, with insert / delete / KNN-search / indexed-ids. KNN uses the `k = ?` constraint sqlite-vec requires (a plain JOIN'd `LIMIT` errors). Commands `index_meeting_transcript` / `search_transcripts` / `indexed_transcript_meeting_ids` / `delete_meeting_transcript_index`.
- **Frontend service** — `transcript-search.ts`: `chunkTranscript()` windows segments (speaker-aware, bounded by chars/segments, drops gaps+empties, keeps the seq range for jump-to-source), `indexMeeting()` chunks + embeds via `seren-embed` and stores vectors (with an in-flight guard), `searchTranscripts()` embeds the query and runs the KNN command, plus a best-effort backfill.
- **Indexing triggers** — backfill un-indexed meetings on library load; drop a meeting's vectors on delete.
- **UI** — `TranscriptSearch` field in the meeting panel: semantic query → ranked snippets (with `Me:`/`Them:` speaker labels) → click opens the meeting.

### Verification
- `cargo test --lib transcript_vectors`: **1 passed** (insert → KNN rank-nearest → delete-clears round-trip on a real sqlite-vec DB).
- Frontend: `transcript-chunk` (2) + meeting suites (auto-detect, ui-regressions, native-capture-lifecycle, concurrent-stop) green; `tsc` + `biome` clean on changed files.

### Honest scope note — what's deferred (not silently cut)
This ships the **semantic core**. The following from #2658's acceptance criteria are **documented follow-ups**, not in this PR — flagging so you can decide priority:
- **`LIKE` exact-match pass** (semantic-only here; exact name/ID lookups would benefit from the planned `LIKE` over `transcript_segments.text`).
- **⌘K command palette** entry and **in-transcript find** (the library search field is in; these are additional surfaces).
- **Precise jump-to-segment scroll** (clicking a hit currently opens the meeting; the seq range is stored, so wiring the existing jump-to-source anchoring is the next step) and **date/attendee filters**.

Live caveat: semantic quality + the live embed path need a connected account against real transcripts; the chunk + KNN logic is unit-tested, and indexing requires connectivity (the design intentionally relaxed the original "offline" criterion to semantic-via-seren-embed).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
