### PR TITLE
fix: audit follow-ups — calendar cloud-sync + auto-record desync (#2685, #2686)

### DIFF
--- a/src-tauri/src/audio/lifecycle.rs
+++ b/src-tauri/src/audio/lifecycle.rs
@@ -120,6 +120,16 @@ impl LifecycleController {
         self.suppress_until_gate_closes = true;
     }
 
+    /// The wiring failed to start the proposed capture (createMeeting / capture
+    /// start threw). Reset to `Idle` so the next tick can re-propose — no
+    /// suppression, since this was not a user-initiated stop.
+    pub fn note_start_failed(&mut self) {
+        self.state = LifecycleState::Idle;
+        self.recording_since = None;
+        self.app_release_since = None;
+        self.gate_open_since = None;
+    }
+
     /// Advance the state machine by one observation, returning the side effect to
     /// perform (at most one per tick).
     pub fn evaluate(&mut self, signal: &LifecycleSignal) -> Option<LifecycleAction> {

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -242,9 +242,10 @@ pub async fn run_capture_stream(
 ) {
     let mut chunker = StreamingChunker::new(cfg);
     while let Some(frame) = frames.recv().await {
-        // Paused: drop the frame before chunking so no segments are produced and
-        // no Them audio is buffered. The chunker treats the absence as a gap
-        // (already handled); resume simply lets frames flow again.
+        // Paused: drop frames at this worker before chunking, so paused audio
+        // produces no segments and isn't buffered. A few frames already queued
+        // upstream when pause flips may still be processed once; the chunker
+        // treats the absence as a gap. Resume simply lets frames flow again.
         if stats.is_paused() {
             continue;
         }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1196,6 +1196,19 @@ pub fn meeting_lifecycle_note_manual_stop(
     Ok(())
 }
 
+/// The frontend failed to start an auto-proposed capture — reset the controller
+/// to Idle so it can re-propose (no suppression).
+#[tauri::command]
+pub fn meeting_lifecycle_note_start_failed(
+    lifecycle: State<'_, std::sync::Mutex<LifecycleController>>,
+) -> Result<(), String> {
+    lifecycle
+        .lock()
+        .map_err(|err| err.to_string())?
+        .note_start_failed();
+    Ok(())
+}
+
 // --- Dictation (shares the transcribe + cleanup engines with Meeting Mode) --
 
 /// Transcribe a single dictation chunk; returns "" for silence rather than erroring.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -945,6 +945,7 @@ pub fn run() {
             commands::audio::meeting_autodetect,
             commands::audio::meeting_lifecycle_tick,
             commands::audio::meeting_lifecycle_note_manual_stop,
+            commands::audio::meeting_lifecycle_note_start_failed,
             // Dictation commands
             commands::audio::transcribe_pcm,
             commands::audio::cleanup_dictation_text,

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -1099,7 +1099,8 @@ fn load_meeting(conn: &Connection, id: &str) -> rusqlite::Result<Option<MeetingR
                 routed_skill_slug, agent_conversation_id, notes_markdown, notes_struct_json,
                 CASE WHEN deleted_at IS NULL THEN NULL ELSE deleted_at END, deleted_at,
                 created_at, updated_at, row_version, failure_reason, capture_diagnostics_json,
-                seren_notes_id
+                seren_notes_id, trigger_source, calendar_event_id, calendar_provider,
+                attendees_json
          FROM meetings
          WHERE id = ?1",
         params![id],
@@ -1109,6 +1110,10 @@ fn load_meeting(conn: &Connection, id: &str) -> rusqlite::Result<Option<MeetingR
                 "failure_reason": row.get::<_, Option<String>>(16)?,
                 "capture_diagnostics_json": parse_json_opt(row.get::<_, Option<String>>(17)?),
                 "seren_notes_id": row.get::<_, Option<String>>(18)?,
+                "trigger_source": row.get::<_, Option<String>>(19)?,
+                "calendar_event_id": row.get::<_, Option<String>>(20)?,
+                "calendar_provider": row.get::<_, Option<String>>(21)?,
+                "attendees_json": row.get::<_, Option<String>>(22)?,
             }))
             .map_err(to_sqlite_invalid)?;
             Ok(MeetingRow {
@@ -1536,9 +1541,10 @@ fn apply_remote_meeting(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
             id, title, source_app, started_at, ended_at, status, template_id,
             routed_skill_slug, agent_conversation_id, notes_markdown,
             notes_struct_json, failure_reason, capture_diagnostics_json,
-            seren_notes_id, created_at, updated_at, row_version, synced_at, deleted_at
+            seren_notes_id, created_at, updated_at, row_version, synced_at, deleted_at,
+            trigger_source, calendar_event_id, calendar_provider, attendees_json
          )
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, NULL)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, NULL, ?19, ?20, ?21, ?22)
          ON CONFLICT(id) DO UPDATE SET
             title = excluded.title,
             source_app = excluded.source_app,
@@ -1552,6 +1558,10 @@ fn apply_remote_meeting(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
             failure_reason = excluded.failure_reason,
             capture_diagnostics_json = excluded.capture_diagnostics_json,
             seren_notes_id = excluded.seren_notes_id,
+            trigger_source = excluded.trigger_source,
+            calendar_event_id = excluded.calendar_event_id,
+            calendar_provider = excluded.calendar_provider,
+            attendees_json = excluded.attendees_json,
             updated_at = excluded.updated_at,
             row_version = excluded.row_version,
             synced_at = excluded.synced_at,
@@ -1576,6 +1586,10 @@ fn apply_remote_meeting(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
             pg_get::<i64>(&row, "updated_at")?,
             pg_get::<i64>(&row, "row_version")?,
             now_ms(),
+            value_opt_str(&payload, "trigger_source"),
+            value_opt_str(&payload, "calendar_event_id"),
+            value_opt_str(&payload, "calendar_provider"),
+            value_opt_str(&payload, "attendees_json"),
         ],
     )?;
     Ok(())

--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -135,7 +135,7 @@ export function MeetingPanel() {
     if (!desktopRuntime || !meeting || stopping()) return;
     setStopping(true);
     try {
-      await meetingStore.stopAndProcess(meeting);
+      await meetingStore.stopByUser(meeting);
       meetingStore.resetAutoDetectDismissal();
     } finally {
       setStopping(false);

--- a/src/components/meeting/RecordingIndicator.tsx
+++ b/src/components/meeting/RecordingIndicator.tsx
@@ -50,7 +50,7 @@ export function RecordingIndicator() {
 
   const onStop = () => {
     const meeting = active();
-    if (meeting) void meetingStore.stopAndProcess(meeting);
+    if (meeting) void meetingStore.stopByUser(meeting);
   };
 
   const onTogglePause = () => {

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -53,16 +53,25 @@ function eventTimeMs(
 }
 
 function videoLinkFor(event: RawGoogleEvent): string | null {
-  if (event.hangoutLink) return event.hangoutLink;
-  const video = event.conferenceData?.entryPoints?.find(
-    (entry) => entry.entryPointType === "video" && entry.uri,
-  );
-  if (video?.uri) return video.uri;
-  // Zoom/Meet links sometimes live only in the location field.
-  const match = (event.location ?? "").match(
-    /https?:\/\/\S*(zoom\.us|meet\.google\.com)\S*/i,
-  );
-  return match ? match[0] : null;
+  const candidate =
+    event.hangoutLink ??
+    event.conferenceData?.entryPoints?.find(
+      (entry) => entry.entryPointType === "video" && entry.uri,
+    )?.uri ??
+    // Zoom/Meet links sometimes live only in the location field; stop at the
+    // first whitespace/delimiter so trailing text isn't captured.
+    (event.location ?? "").match(
+      /https?:\/\/[^\s,;]*(?:zoom\.us|meet\.google\.com)[^\s,;]*/i,
+    )?.[0] ??
+    null;
+  if (!candidate) return null;
+  // Only trust a well-formed https URL (location text comes from third-party invites).
+  try {
+    const url = new URL(candidate);
+    return url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
 }
 
 /** Normalize a raw Google event, dropping cancelled/non-meeting entries. */
@@ -71,6 +80,9 @@ export function normalizeEvent(event: RawGoogleEvent): CalendarEvent | null {
   if (event.eventType && NON_MEETING_EVENT_TYPES.has(event.eventType)) {
     return null;
   }
+  // All-day events (date, not dateTime) span 24h+ and aren't recordable
+  // meetings — exclude them so they can't hijack the recording match.
+  if (!event.start?.dateTime || !event.end?.dateTime) return null;
   const startMs = eventTimeMs(event.start);
   const endMs = eventTimeMs(event.end);
   if (startMs === null || endMs === null) return null;
@@ -103,25 +115,23 @@ export async function getUpcomingEvents(
     maxResults: "20",
   });
   const url = `${apiBase}/publishers/${PUBLISHER_SLUG}/events?${params.toString()}`;
-  const headers: Record<string, string> = {};
-  if (!shouldUseRustGatewayAuth(url)) {
-    const token = await getToken();
-    if (!token) return [];
-    headers.Authorization = `Bearer ${token}`;
-  }
-
   try {
+    const headers: Record<string, string> = {};
+    if (!shouldUseRustGatewayAuth(url)) {
+      const token = await getToken();
+      if (!token) return [];
+      headers.Authorization = `Bearer ${token}`;
+    }
     const response = await appFetch(url, { method: "GET", headers });
     if (!response.ok) return [];
     const result = await response.json();
-    if (publisherStatus(result) === 200 || publisherStatus(result) === null) {
-      const body = unwrapPublisherBody(result) as { items?: RawGoogleEvent[] };
-      return (body?.items ?? [])
-        .map(normalizeEvent)
-        .filter((event): event is CalendarEvent => event !== null)
-        .sort((a, b) => a.startMs - b.startMs);
-    }
-    return [];
+    const status = publisherStatus(result);
+    if (status !== undefined && (status < 200 || status >= 300)) return [];
+    const body = unwrapPublisherBody(result) as { items?: RawGoogleEvent[] };
+    return (body?.items ?? [])
+      .map(normalizeEvent)
+      .filter((event): event is CalendarEvent => event !== null)
+      .sort((a, b) => a.startMs - b.startMs);
   } catch {
     return [];
   }

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -347,6 +347,11 @@ export function meetingLifecycleNoteManualStop(): Promise<void> {
   return invoke("meeting_lifecycle_note_manual_stop");
 }
 
+/** Tell the lifecycle the wiring failed to start a proposed capture. */
+export function meetingLifecycleNoteStartFailed(): Promise<void> {
+  return invoke("meeting_lifecycle_note_start_failed");
+}
+
 /** Pause a live capture without ending it. Resolves false if none is active. */
 export function pauseMeetingCapture(meetingId: string): Promise<boolean> {
   return invoke("pause_meeting_capture", { meetingId });

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -29,6 +29,7 @@ import {
   type MeetingTemplate,
   meetingAutodetect,
   meetingLifecycleNoteManualStop,
+  meetingLifecycleNoteStartFailed,
   meetingLifecycleTick,
   pauseMeetingCapture,
   reconcileMeetingSpeakers,
@@ -690,7 +691,7 @@ async function toggleCaptureFromTray(): Promise<void> {
     (meeting) => meeting.status === "capturing",
   );
   if (active) {
-    await stopAndProcess(active);
+    await stopByUser(active);
     return;
   }
   if (isStarting || meetingState.primingRequest) return;
@@ -1099,23 +1100,32 @@ async function pollAutoDetect(): Promise<void> {
   ).catch(() => null);
   if (action?.kind === "start_capture") {
     if (!isCapturing()) {
-      const now = Date.now();
-      const event = matchActiveEvent(cachedUpcomingEvents, now);
-      const meeting = await createMeeting({
-        title: event?.title ?? `Meeting ${formatTime(now)}`,
-        sourceApp: action.sourceApp ?? "Auto-detect",
-        templateId: settingsStore.get("meetingTemplateId"),
-        triggerSource: "auto_mic",
-        calendarEventId: event?.id ?? null,
-        calendarProvider: event ? "google" : null,
-        attendeesJson:
-          event && event.attendees.length > 0
-            ? JSON.stringify(event.attendees)
-            : null,
-      });
-      lifecycleMeetingId = meeting.id;
-      lifecycleEventEndMs = event?.endMs ?? null;
-      await requestCaptureStart(meeting);
+      try {
+        const now = Date.now();
+        const event = matchActiveEvent(cachedUpcomingEvents, now);
+        const meeting = await createMeeting({
+          title: event?.title ?? `Meeting ${formatTime(now)}`,
+          sourceApp: action.sourceApp ?? "Auto-detect",
+          templateId: settingsStore.get("meetingTemplateId"),
+          triggerSource: "auto_mic",
+          calendarEventId: event?.id ?? null,
+          calendarProvider: event ? "google" : null,
+          attendeesJson:
+            event && event.attendees.length > 0
+              ? JSON.stringify(event.attendees)
+              : null,
+        });
+        lifecycleMeetingId = meeting.id;
+        lifecycleEventEndMs = event?.endMs ?? null;
+        await requestCaptureStart(meeting);
+      } catch {
+        // Start failed — reset the controller so it can re-propose, and clear
+        // the dangling id so a wedged "Recording" controller can't block all
+        // future auto-records for this call.
+        lifecycleMeetingId = null;
+        lifecycleEventEndMs = null;
+        await meetingLifecycleNoteStartFailed().catch(() => {});
+      }
     }
     return;
   }
@@ -1217,6 +1227,15 @@ async function startFromCalendarEvent(event: CalendarEvent): Promise<void> {
   await requestCaptureStart(meeting);
 }
 
+// A user-initiated stop. Suppresses lifecycle auto-restart until the call ends
+// (covers manually-started captures too) and clears lifecycle tracking.
+async function stopByUser(meeting: Meeting): Promise<void> {
+  await meetingLifecycleNoteManualStop().catch(() => {});
+  lifecycleMeetingId = null;
+  lifecycleEventEndMs = null;
+  await stopAndProcess(meeting);
+}
+
 export const meetingStore = {
   get state(): MeetingState {
     return meetingState;
@@ -1233,6 +1252,7 @@ export const meetingStore = {
   reconcileStaleCaptures,
   stopCapture,
   stopAndProcess,
+  stopByUser,
   pauseCapture,
   resumeCapture,
   getMeetingSkillCandidates,


### PR DESCRIPTION
## Audit follow-up fixes — calendar (#2686) + auto-record (#2685)

Closes #2686, #2685. Fixes from the adversarial pre-review audit of the three shipped meeting features. (Search P0/P1s were fixed in #2684 before that merge; #2687 tracks the remaining search P2s.)

### Calendar (#2686)
- **P1 — cloud-sync gap (data loss across devices):** `history_sync.rs` now carries `trigger_source`, `calendar_event_id`, `calendar_provider`, `attendees_json` through the `payload` jsonb on push **and** apply (mirroring `seren_notes_id`), so calendar metadata round-trips to cloud + a second device. (The #2659 PR claimed this already worked — it didn't; corrected.)
- **P2 — all-day events could hijack/mis-stamp a recording:** `normalizeEvent` now drops all-day events (`date`, no `dateTime`) from match candidates, removing the 24h-window match and the UTC day-bleed.
- **P2 — location video-link regex** tightened (stops at whitespace/`,;`) and the result is validated as an https `URL` before use (location text comes from third-party invites).
- **P2 — dead `publisherStatus === null` check** → accept any 2xx; auth moved inside the try.

### Auto-record (#2685)
- **P1 — controller↔frontend desync:** new `meeting_lifecycle_note_start_failed` command + a catch around the auto-start side-effect, so a failed `createMeeting`/capture-start no longer leaves the controller wedged in `Recording` (which silently disabled auto-record for the rest of the call).
- **P1 — manual-stop suppression for manual captures:** user-initiated stops (indicator, panel, tray) now route through `stopByUser` → `meetingLifecycleNoteManualStop`, so a manual stop suppresses auto-restart even when the capture wasn't lifecycle-started (previously the lifecycle could auto-record over a call the user just stopped).
- **P2 — pause-gate comment** corrected to not over-claim the in-flight-frame guarantee.

### Verification
- `cargo test --lib`: **872 pass, 0 fail** (incl. history_sync + lifecycle).
- Frontend: `tsc` + `biome` clean; **19** meeting/calendar unit tests pass.
- Live caveats unchanged: real-call auto-record behavior and the cloud-sync round-trip need a human / connected account to confirm end-to-end.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
