### PR TITLE
fix(search): jump-to-segment from hits + index cleanup on delete (#2687)

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -75,6 +75,20 @@ pub async fn delete_meeting(app: AppHandle, id: String) -> Result<(), String> {
         Ok(())
     })
     .await?;
+    // Drop the transcript search index for this meeting too, so a delete can't
+    // orphan its vectors. Best-effort: a missing index isn't a delete failure.
+    let app_for_index = app.clone();
+    let index_id = deleted_id.clone();
+    let _ = tauri::async_runtime::spawn_blocking(move || {
+        if let Ok(conn) =
+            crate::services::transcript_vectors::open_transcript_db(&app_for_index)
+        {
+            let _ = crate::services::transcript_vectors::delete_meeting_chunks(
+                &conn, &index_id,
+            );
+        }
+    })
+    .await;
     let _ = app.emit(
         "meeting://deleted",
         serde_json::json!({ "meetingId": deleted_id }),

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -210,6 +210,21 @@ export function MeetingDetail(props: MeetingDetailProps) {
     }
   };
 
+  // A search hit requested a jump to a specific segment — scroll + highlight it
+  // once this meeting's transcript has loaded, then consume the request.
+  createEffect(() => {
+    const target = meetingStore.state.searchScrollTarget;
+    if (!target || props.meeting.id !== target.meetingId) return;
+    if (!segments().some((segment) => segment.meetingId === target.meetingId)) {
+      return;
+    }
+    setHighlightedSeq(target.seq);
+    rows
+      .get(target.seq)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    meetingStore.clearSegmentScroll();
+  });
+
   const regenerate = async () => {
     if (regenerating()) return;
     setRegenerating(true);

--- a/src/components/meeting/TranscriptSearch.tsx
+++ b/src/components/meeting/TranscriptSearch.tsx
@@ -40,7 +40,10 @@ export function TranscriptSearch() {
     const meeting = meetingStore.state.meetings.find(
       (item) => item.id === hit.meetingId,
     );
-    if (meeting) void meetingStore.setActiveMeeting(meeting);
+    if (meeting) {
+      void meetingStore.setActiveMeeting(meeting);
+      meetingStore.requestSegmentScroll(hit.meetingId, hit.seqStart);
+    }
   };
 
   return (

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -87,6 +87,8 @@ interface MeetingState {
   primingRequest: Meeting | null;
   /** Most recent meeting that became reviewable while the user was elsewhere. */
   reviewReadyMeetingId: string | null;
+  /** A search hit asked to scroll the transcript to a segment (meeting + seq). */
+  searchScrollTarget: { meetingId: string; seq: number } | null;
 }
 
 const [meetingState, setMeetingState] = createStore<MeetingState>({
@@ -103,6 +105,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   autoDetectSourceApp: null,
   primingRequest: null,
   reviewReadyMeetingId: null,
+  searchScrollTarget: null,
 });
 
 let transcriptUnlisten: UnlistenFn | null = null;
@@ -1236,6 +1239,16 @@ async function stopByUser(meeting: Meeting): Promise<void> {
   await stopAndProcess(meeting);
 }
 
+// A search hit asks the transcript view to scroll/highlight a segment; the
+// MeetingDetail effect consumes the target once that meeting's segments load.
+function requestSegmentScroll(meetingId: string, seq: number): void {
+  setMeetingState("searchScrollTarget", { meetingId, seq });
+}
+
+function clearSegmentScroll(): void {
+  setMeetingState("searchScrollTarget", null);
+}
+
 export const meetingStore = {
   get state(): MeetingState {
     return meetingState;
@@ -1270,4 +1283,6 @@ export const meetingStore = {
   dismissAutoDetect,
   resetAutoDetectDismissal,
   acknowledgeReviewReady,
+  requestSegmentScroll,
+  clearSegmentScroll,
 };


### PR DESCRIPTION

Closes #2687.

Clicking a search hit now scrolls + highlights the exact transcript segment:
a store searchScrollTarget (meeting + seq) set by the hit, consumed by a
MeetingDetail effect once that meeting's segments load (reuses the existing
rows/scrollIntoView jump-to-source anchoring). And the Rust delete_meeting
command now drops the meeting's transcript vectors (best-effort, off-thread)
so a delete can no longer orphan the search index.

cargo --lib 872 pass; frontend tsc/biome clean; 17 meeting/search unit tests pass.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com