### PR TITLE
Fix Record Workflow app-window previews

### DIFF
--- a/packages/recording-ui/src/index.tsx
+++ b/packages/recording-ui/src/index.tsx
@@ -179,6 +179,16 @@ export function RecordButton(props: RecordButtonProps) {
     activeSession()?.context?.prep.successState.trim() || null;
   const supportsExecutableTrace = () =>
     Boolean(selectedTarget()?.capabilities.includes("action_trace"));
+  const preferredCaptureWindowId = (
+    windows: RecordingCaptureWindow[],
+    currentWindowId: string | null,
+  ) =>
+    windows.find(
+      (window) => window.id === currentWindowId && window.isRecordable,
+    )?.id ??
+    windows.find((window) => window.isFocused && window.isRecordable)?.id ??
+    windows.find((window) => window.isRecordable)?.id ??
+    null;
   const startRequest = (): RecordingStartRequest | null => {
     const target = selectedTarget();
     if (!target) return null;
@@ -303,22 +313,20 @@ export function RecordButton(props: RecordButtonProps) {
       setPermissionPreflight(nextPermissionPreflight);
       setBrowserExtensionReadiness(nextBrowserExtensionReadiness);
       setCaptureWindows(nextCaptureWindows);
-      if (
-        !nextCaptureWindows.some(
-          (window) => window.id === selectedCaptureWindowId(),
-        )
-      ) {
-        setSelectedCaptureWindowId(
-          nextCaptureWindows.find((window) => window.isFocused)?.id ??
-            nextCaptureWindows.find((window) => window.isRecordable)?.id ??
-            null,
-        );
-      }
+      const nextSelectedCaptureWindowId = preferredCaptureWindowId(
+        nextCaptureWindows,
+        selectedCaptureWindowId(),
+      );
+      setSelectedCaptureWindowId(nextSelectedCaptureWindowId);
       const initial = findInitialRecordingTarget(
         nextTargets,
         selectedTargetId(),
       );
+      const nextSelectedTargetId = initial?.id ?? selectedTargetId();
       if (initial) setSelectedTargetId(initial.id);
+      if (nextSelectedTargetId === "window" && nextSelectedCaptureWindowId) {
+        await previewCaptureWindow(nextSelectedCaptureWindowId);
+      }
       setStatus("idle");
     } catch (err) {
       fail(err);
@@ -332,17 +340,15 @@ export function RecordButton(props: RecordButtonProps) {
     try {
       const nextCaptureWindows = await props.adapter.listCaptureWindows();
       setCaptureWindows(nextCaptureWindows);
-      if (
-        !nextCaptureWindows.some(
-          (window) => window.id === selectedCaptureWindowId(),
-        )
-      ) {
-        setSelectedCaptureWindowId(
-          nextCaptureWindows.find((window) => window.isFocused)?.id ??
-            nextCaptureWindows.find((window) => window.isRecordable)?.id ??
-            null,
-        );
+      const nextSelectedCaptureWindowId = preferredCaptureWindowId(
+        nextCaptureWindows,
+        selectedCaptureWindowId(),
+      );
+      setSelectedCaptureWindowId(nextSelectedCaptureWindowId);
+      if (!nextSelectedCaptureWindowId) {
         setWindowPreview(null);
+      } else if (selectedTarget()?.kind === "window") {
+        await previewCaptureWindow(nextSelectedCaptureWindowId);
       }
     } catch (err) {
       setWindowPreviewError(formatRecordingError(err));
@@ -355,6 +361,10 @@ export function RecordButton(props: RecordButtonProps) {
     setSelectedTargetId(targetId);
     setWindowPreview(null);
     setWindowPreviewError(null);
+    const windowId = selectedCaptureWindowId();
+    if (targetId === "window" && windowId) {
+      void previewCaptureWindow(windowId);
+    }
   };
 
   const clearWindowPreviewState = () => {
@@ -383,6 +393,14 @@ export function RecordButton(props: RecordButtonProps) {
     } finally {
       setPreviewingWindowId(null);
     }
+  };
+
+  const handleWindowPreviewImageError = () => {
+    if (!windowPreview()) return;
+    setWindowPreview(null);
+    setWindowPreviewError(
+      "Window preview image could not be loaded. Refresh windows and try again.",
+    );
   };
 
   const start = async () => {
@@ -586,6 +604,7 @@ export function RecordButton(props: RecordButtonProps) {
           onClose={closeDialog}
           onSelectTarget={selectTarget}
           onPreviewWindow={(windowId) => void previewCaptureWindow(windowId)}
+          onPreviewImageError={handleWindowPreviewImageError}
           onRefreshWindows={() => void refreshCaptureWindows()}
           onPrepChange={updatePrep}
           onIncludeMicrophone={setIncludeMicrophone}
@@ -1203,6 +1222,7 @@ interface RecordingDialogProps {
   onClose: () => void;
   onSelectTarget: (targetId: string) => void;
   onPreviewWindow: (windowId: string) => void;
+  onPreviewImageError: () => void;
   onRefreshWindows: () => void;
   onPrepChange: <K extends keyof RecordingPrep>(
     key: K,
@@ -1518,6 +1538,7 @@ function WindowCapturePreviewPanel(props: {
   selectedWindowId: string | null;
   error: string | null;
   onPreviewWindow: (windowId: string) => void;
+  onPreviewImageError: () => void;
   onRefresh: () => void;
   classNames?: RecordingUiClassNames;
 }) {
@@ -1531,7 +1552,7 @@ function WindowCapturePreviewPanel(props: {
         }
         return left.appName.localeCompare(right.appName);
       })
-      .slice(0, 8);
+      .slice(0, 24);
 
   return (
     <div
@@ -1633,6 +1654,7 @@ function WindowCapturePreviewPanel(props: {
                   src={preview().artifactUrl}
                   alt="Window preview"
                   class="max-h-56 w-full object-contain"
+                  onError={props.onPreviewImageError}
                 />
               )}
             </Show>
@@ -1781,6 +1803,7 @@ function RecordingDialog(props: RecordingDialogProps) {
                 selectedWindowId={props.selectedCaptureWindowId}
                 error={props.windowPreviewError}
                 onPreviewWindow={props.onPreviewWindow}
+                onPreviewImageError={props.onPreviewImageError}
                 onRefresh={props.onRefreshWindows}
                 classNames={props.classNames}
               />
@@ -1789,7 +1812,8 @@ function RecordingDialog(props: RecordingDialogProps) {
             <Show
               when={
                 props.selectedTarget?.kind === "browser" &&
-                props.browserExtensionReadiness
+                props.browserExtensionReadiness &&
+                props.browserExtensionReadiness.status !== "unsupported"
               }
             >
               {(readiness) => (

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -669,13 +669,12 @@ fn recording_targets() -> Vec<RecordingTarget> {
             id: "browser".to_string(),
             kind: RecordingTargetKind::Browser,
             label: "Browser".to_string(),
-            detail: "Capture a browser workflow with the native recorder.".to_string(),
+            detail: "Capture browser workflows with native desktop recording.".to_string(),
             is_available: native_screen_video_available,
             capabilities: browser_capabilities,
             limitations: vec![
-                "Browser recording uses the native video and marker capture fallback.".to_string(),
-                "High-fidelity DOM tracing requires the Seren Workflow Recorder extension."
-                    .to_string(),
+                "Records browser activity with native video, cursor, microphone when available, and explicit markers.".to_string(),
+                "Use App window to pin one browser window, or Full screen for browser workflows that span windows.".to_string(),
             ],
         },
     ]
@@ -1209,6 +1208,33 @@ fn validate_capture_window_selection(
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+fn is_macos_system_capture_window(app_name: &str) -> bool {
+    const SYSTEM_OWNERS: &[&str] = &[
+        "Control Center",
+        "Dock",
+        "loginwindow",
+        "Notification Center",
+        "SystemUIServer",
+        "Window Server",
+    ];
+    SYSTEM_OWNERS
+        .iter()
+        .any(|owner| app_name.eq_ignore_ascii_case(owner))
+}
+
+fn is_capture_window_candidate(app_name: &str, width: u32, height: u32) -> bool {
+    let app_name = app_name.trim();
+    if app_name.is_empty() || width == 0 || height == 0 {
+        return false;
+    }
+    #[cfg(target_os = "macos")]
+    if is_macos_system_capture_window(app_name) {
+        return false;
+    }
+    true
+}
+
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn xcap_window_summary(window: &xcap::Window) -> Option<RecordingCaptureWindow> {
     let id = window.id().ok()?;
@@ -1221,7 +1247,7 @@ fn xcap_window_summary(window: &xcap::Window) -> Option<RecordingCaptureWindow> 
     let height = window.height().ok()?;
     let is_minimized = window.is_minimized().unwrap_or(false);
     let is_focused = window.is_focused().unwrap_or(false);
-    if app_name.is_empty() || width == 0 || height == 0 {
+    if !is_capture_window_candidate(&app_name, width, height) {
         return None;
     }
     Some(RecordingCaptureWindow {
@@ -3615,6 +3641,9 @@ mod tests {
                 .iter()
                 .any(|limitation| limitation.contains("native video"))
         );
+        assert!(!browser.limitations.iter().any(
+            |limitation| limitation.contains("DOM tracing") || limitation.contains("extension")
+        ));
         assert_eq!(
             window
                 .capabilities
@@ -3633,6 +3662,26 @@ mod tests {
                     .iter()
                     .any(|limitation| limitation.contains("frame capture backend"))
             );
+        }
+    }
+
+    #[test]
+    fn capture_window_candidates_exclude_non_app_system_windows() {
+        assert!(!is_capture_window_candidate("", 800, 600));
+        assert!(!is_capture_window_candidate("Preview App", 0, 600));
+        assert!(!is_capture_window_candidate("Preview App", 800, 0));
+        assert!(is_capture_window_candidate("Preview App", 800, 600));
+
+        if cfg!(target_os = "macos") {
+            assert!(!is_capture_window_candidate("Control Center", 120, 60));
+            assert!(!is_capture_window_candidate("loginwindow", 1728, 1117));
+            assert!(!is_capture_window_candidate(
+                "Notification Center",
+                320,
+                240
+            ));
+        } else {
+            assert!(is_capture_window_candidate("Control Center", 120, 60));
         }
     }
 

--- a/src/features/recording/desktopRecordingAdapter.ts
+++ b/src/features/recording/desktopRecordingAdapter.ts
@@ -143,13 +143,11 @@ function browserPermissionPreflight(): RecordingPermissionPreflight {
 
 function browserExtensionReadiness(): RecordingBrowserExtensionReadiness {
   return {
-    status: "unknown",
-    label: "Browser extension",
+    status: "unsupported",
+    label: "Native browser recording",
     message:
-      "High-fidelity DOM tracing requires the Seren Workflow Recorder extension and an attachable Chromium tab.",
-    canContinueWithFallback: true,
-    bannerDisclosure:
-      'Chrome may show a "Seren is debugging this browser" banner while DOM tracing is active.',
+      "Browser workflows record through Seren Desktop native video capture. Use App window to pin recording to one browser window.",
+    canContinueWithFallback: false,
   };
 }
 

--- a/tests/unit/recording-desktop-adapter.test.ts
+++ b/tests/unit/recording-desktop-adapter.test.ts
@@ -117,18 +117,16 @@ describe("desktopRecordingAdapter", () => {
     });
   });
 
-  it("surfaces browser extension readiness before capture", async () => {
+  it("surfaces browser recording readiness without extension-only UX", async () => {
     const readiness = await desktopRecordingAdapter.checkBrowserExtension?.();
 
     expect(invokeMock).not.toHaveBeenCalled();
     expect(readiness).toEqual({
-      status: "unknown",
-      label: "Browser extension",
+      status: "unsupported",
+      label: "Native browser recording",
       message:
-        "High-fidelity DOM tracing requires the Seren Workflow Recorder extension and an attachable Chromium tab.",
-      canContinueWithFallback: true,
-      bannerDisclosure:
-        'Chrome may show a "Seren is debugging this browser" banner while DOM tracing is active.',
+        "Browser workflows record through Seren Desktop native video capture. Use App window to pin recording to one browser window.",
+      canContinueWithFallback: false,
     });
   });
 

--- a/tests/unit/recording-packages.test.ts
+++ b/tests/unit/recording-packages.test.ts
@@ -2333,6 +2333,15 @@ describe("recording packages", () => {
     expect(uiSource).toContain("props.adapter.listCaptureWindows");
     expect(uiSource).toContain("props.adapter.captureWindowPreview");
     expect(uiSource).toContain("props.adapter.clearWindowPreviews");
+    expect(uiSource).toContain("preferredCaptureWindowId");
+    expect(uiSource).toContain(
+      "await previewCaptureWindow(nextSelectedCaptureWindowId)",
+    );
+    expect(uiSource).toContain(".slice(0, 24)");
+    expect(uiSource).toContain("props.onPreviewImageError");
+    expect(uiSource).toContain(
+      'props.browserExtensionReadiness.status !== "unsupported"',
+    );
     expect(uiSource).toContain("refreshCaptureWindows");
     expect(uiSource).toContain("onRefreshWindows");
     expect(uiSource).toContain("clearWindowPreviewState");


### PR DESCRIPTION
Closes #2690

## Summary
- Auto-preview the selected App window when the dialog opens, when the user switches to App window, and after refresh.
- Surface preview image load failures instead of leaving a broken image icon.
- Filter macOS system/pseudo windows from native app-window selections, including Control Center, Window Server, loginwindow, Dock, Notification Center, and SystemUIServer.
- Remove unsupported browser-extension/debugger UX from the default Browser target path and describe native desktop recording instead.

## Audit
- Verified xcap currently returns Window Server, loginwindow, and many Control Center menu-extra windows before SerenDesktop on macOS; the new filter removes those non-app owners.
- Checked Windows xcap path: it already filters invisible, tool, Program Manager, cloaked, and self-owned windows before Seren receives them.
- Checked official Loom docs: Loom Desktop treats browser workflows as native Full Screen/Window capture, while Chrome Extension adds Current Tab. The updated Browser copy follows that model.
- Live Seren publisher search found no AWS Windows desktop/session publisher available to this harness; PR CI provides the available Windows build validation path.

## Tests
- `pnpm vitest run tests/unit/recording-desktop-adapter.test.ts tests/unit/recording-packages.test.ts`
- `pnpm prepare:mcp-servers`
- `cargo test --manifest-path src-tauri/Cargo.toml commands::recording::tests:: --lib`
- `pnpm exec biome check packages/recording-ui/src/index.tsx src/features/recording/desktopRecordingAdapter.ts tests/unit/recording-desktop-adapter.test.ts tests/unit/recording-packages.test.ts`
- `pnpm build`
- `pnpm verify:frontend-build`