### PR TITLE
fix(meeting): stop-and-delete, pause-aware timer, honest auto-record copy

### DIFF
--- a/src/components/meeting/MeetingSettings.tsx
+++ b/src/components/meeting/MeetingSettings.tsx
@@ -200,7 +200,7 @@ export function MeetingSettings() {
 
       <section>
         <label class="flex items-center justify-between gap-3 cursor-pointer">
-          <FieldLabel hint="Show the titlebar prompt when active microphone input is detected. Capture still waits for you to press Record.">
+          <FieldLabel hint="Recognized call apps (Zoom, Meet, Teams, Discord, …) auto-start recording after your one-time audio-permission acknowledgment. Other detected microphone activity only shows a titlebar prompt — you choose whether to record.">
             Auto-detect meetings
           </FieldLabel>
           <input

--- a/src/components/meeting/RecordingIndicator.tsx
+++ b/src/components/meeting/RecordingIndicator.tsx
@@ -22,6 +22,7 @@ const DISCLOSURE =
 export function RecordingIndicator() {
   const [now, setNow] = createSignal(Date.now());
   const [confirmingDelete, setConfirmingDelete] = createSignal(false);
+  const [deleting, setDeleting] = createSignal(false);
   const [copied, setCopied] = createSignal(false);
 
   let timer: number | undefined;
@@ -43,9 +44,17 @@ export function RecordingIndicator() {
     if (active() === null && confirmingDelete()) setConfirmingDelete(false);
   });
 
+  // Elapsed excludes paused spans and freezes while paused: the anchor is the
+  // pause-start timestamp when paused, otherwise the live clock, minus the time
+  // already accumulated across completed pauses.
   const elapsed = () => {
     const meeting = active();
-    return meeting ? formatElapsed(now() - meeting.startedAt) : "0:00";
+    if (!meeting) return "0:00";
+    const state = meetingStore.state;
+    const anchor = state.capturePausedAt ?? now();
+    return formatElapsed(
+      anchor - meeting.startedAt - state.capturePausedAccumMs,
+    );
   };
 
   const onStop = () => {
@@ -70,15 +79,19 @@ export function RecordingIndicator() {
       .catch(() => {});
   };
 
+  // Discard an unwanted recording: first click asks to confirm, second click
+  // stops the live capture and deletes it. deleteMeeting() refuses active
+  // captures, so this routes through stopAndDelete instead.
   const onDelete = () => {
     const meeting = active();
-    if (!meeting) return;
+    if (!meeting || deleting()) return;
     if (!confirmingDelete()) {
       setConfirmingDelete(true);
       return;
     }
     setConfirmingDelete(false);
-    void meetingStore.deleteMeeting(meeting);
+    setDeleting(true);
+    void meetingStore.stopAndDelete(meeting).finally(() => setDeleting(false));
   };
 
   return (
@@ -104,6 +117,13 @@ export function RecordingIndicator() {
         <Show when={meetingStore.state.micCaptureLost}>
           <span class="text-[10px] font-medium text-destructive">mic lost</span>
         </Show>
+        <Show when={meetingStore.state.error}>
+          {(message) => (
+            <span class="max-w-[200px] truncate text-[10px] font-medium text-destructive">
+              {message()}
+            </span>
+          )}
+        </Show>
         <div class="ml-1 flex shrink-0 items-center gap-1">
           <button
             type="button"
@@ -123,8 +143,17 @@ export function RecordingIndicator() {
           >
             Stop
           </button>
-          <button type="button" class={CONTROL_CLASS} onClick={onDelete}>
-            {confirmingDelete() ? "Confirm?" : "Delete"}
+          <button
+            type="button"
+            class={CONTROL_CLASS}
+            onClick={onDelete}
+            disabled={deleting()}
+          >
+            {deleting()
+              ? "Deleting…"
+              : confirmingDelete()
+                ? "Confirm?"
+                : "Delete"}
           </button>
         </div>
       </div>

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -62,6 +62,14 @@ interface MeetingState {
   captureLevel: number;
   /** True while the active capture is paused (frame ingestion suspended). */
   capturePaused: boolean;
+  /**
+   * Timestamp (ms) the current pause began, or null when not paused. Used to
+   * freeze the displayed elapsed time and exclude paused spans from it, matching
+   * the backend transcript gap.
+   */
+  capturePausedAt: number | null;
+  /** Total paused duration (ms) accumulated across completed pauses this capture. */
+  capturePausedAccumMs: number;
   /** Upcoming calendar events (empty unless Google Calendar is connected). */
   upcomingEvents: CalendarEvent[];
   /**
@@ -97,6 +105,8 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   liveSegments: [],
   captureLevel: 0,
   capturePaused: false,
+  capturePausedAt: null,
+  capturePausedAccumMs: 0,
   upcomingEvents: [],
   micCaptureLost: false,
   isLoading: false,
@@ -542,6 +552,8 @@ async function beginCapture(meeting: Meeting): Promise<void> {
     const started = await startCapture(meeting);
     if (!started) return;
     setMeetingState("capturePaused", false);
+    setMeetingState("capturePausedAt", null);
+    setMeetingState("capturePausedAccumMs", 0);
     await loadMeetings();
     await setActiveMeeting(
       meetingState.meetings.find((item) => item.id === meeting.id) ?? meeting,
@@ -591,14 +603,28 @@ async function cancelPriming(): Promise<void> {
 async function pauseCapture(meetingId: string): Promise<void> {
   if (!isTauriRuntime()) return;
   const ok = await pauseMeetingCapture(meetingId).catch(() => false);
-  if (ok) setMeetingState("capturePaused", true);
+  if (ok) {
+    setMeetingState("capturePaused", true);
+    setMeetingState("capturePausedAt", Date.now());
+  }
 }
 
-// Resume a paused capture: frames flow again.
+// Resume a paused capture: frames flow again. Fold the just-ended pause span into
+// the accumulator so elapsed time continues to exclude paused time.
 async function resumeCapture(meetingId: string): Promise<void> {
   if (!isTauriRuntime()) return;
   const ok = await resumeMeetingCapture(meetingId).catch(() => false);
-  if (ok) setMeetingState("capturePaused", false);
+  if (ok) {
+    const pausedAt = meetingState.capturePausedAt;
+    if (pausedAt !== null) {
+      setMeetingState(
+        "capturePausedAccumMs",
+        meetingState.capturePausedAccumMs + Math.max(0, Date.now() - pausedAt),
+      );
+    }
+    setMeetingState("capturePausedAt", null);
+    setMeetingState("capturePaused", false);
+  }
 }
 
 // At startup, backend capture may still be active even though the renderer
@@ -1239,6 +1265,44 @@ async function stopByUser(meeting: Meeting): Promise<void> {
   await stopAndProcess(meeting);
 }
 
+// Discard an in-progress recording from the floating indicator: stop the live
+// backend capture immediately (frames stop, mic released), then hard-delete the
+// meeting and its transcript/index WITHOUT running the notes pipeline. This is
+// the privacy escape hatch for an unwanted auto-record — deleteMeeting() refuses
+// active captures, so the indicator routes here instead. Suppresses lifecycle
+// auto-restart so the same live call can't instantly re-record.
+async function stopAndDelete(meeting: Meeting): Promise<void> {
+  if (!isTauriRuntime()) return;
+  setMeetingState("error", null);
+  await meetingLifecycleNoteManualStop().catch(() => {});
+  lifecycleMeetingId = null;
+  lifecycleEventEndMs = null;
+  // Stop the live capture first so no further frames land, then delete. We
+  // intentionally bypass stopAndProcess so the discarded audio is never
+  // transcribed or routed to the support pipeline.
+  await stopCapture(meeting.id).catch(() => {});
+  try {
+    await deleteMeetingRecord(meeting.id);
+    void deleteMeetingIndex(meeting.id);
+    const remaining = meetingState.meetings.filter(
+      (item) => item.id !== meeting.id,
+    );
+    setMeetingState("meetings", remaining);
+    if (meetingState.activeMeeting?.id === meeting.id) {
+      await setActiveMeeting(remaining[0] ?? null);
+    }
+    setMeetingState("capturePaused", false);
+    setMeetingState("capturePausedAt", null);
+    setMeetingState("capturePausedAccumMs", 0);
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Failed to delete recording",
+    );
+    await loadMeetings();
+  }
+}
+
 // A search hit asks the transcript view to scroll/highlight a segment; the
 // MeetingDetail effect consumes the target once that meeting's segments load.
 function requestSegmentScroll(meetingId: string, seq: number): void {
@@ -1266,6 +1330,7 @@ export const meetingStore = {
   stopCapture,
   stopAndProcess,
   stopByUser,
+  stopAndDelete,
   pauseCapture,
   resumeCapture,
   getMeetingSkillCandidates,


### PR DESCRIPTION
## Summary
Three meeting-indicator / consent fixes from the meeting-features release audit (frontend-only).

### AUD-002 — floating Delete is a dead privacy escape hatch (#2693)
The floating indicator's `Delete` called `deleteMeeting()`, which refuses `capturing` meetings ("Stop or finish this meeting before deleting it."). Confirm silently no-op'd and the recording continued; the rejection error was only visible in the meeting panel, never the indicator.
- Adds `meetingStore.stopAndDelete()`: stops the live capture first (mic released), then hard-deletes the meeting + transcript + index **without** running the notes pipeline (so discarded audio is never transcribed or routed to support). Suppresses lifecycle re-arm.
- Indicator routes `Delete` through it, shows a `Deleting…` state, and now surfaces `state.error` so a failed delete is visible.

### AUD-012 — pause timer kept running (#2703)
Elapsed was `now - startedAt`, so it climbed while "Paused" and counted paused time. Store now tracks `capturePausedAt` + `capturePausedAccumMs`; the indicator freezes elapsed while paused and excludes paused spans, matching the design's "elapsed timer pauses." State resets on each capture start so it can't leak across captures.

### AUD-010 — misleading consent copy (#2701)
The auto-detect hint claimed "Capture still waits for you to press Record," but recognized call apps auto-start after the one-time priming ack. Copy now accurately states recognized apps auto-start vs. other detected audio only prompting.

## Verification
- `biome check` clean on all changed files.
- `tsc --noEmit`: no errors in changed files (pre-existing errors confined to `packages/recording-ui` + tests).
- `vite build` ✓.

Closes #2693
Closes #2701
Closes #2703

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com