### PR TITLE
fix(meeting): correct transcript indexing — terminal-only, capture-sorted, bounded retries

### DIFF
--- a/src/services/transcript-search.ts
+++ b/src/services/transcript-search.ts
@@ -39,9 +39,20 @@ function speakerLabel(speaker: TranscriptSegment["speaker"]): string {
 export function chunkTranscript(
   segments: TranscriptSegment[],
 ): TranscriptChunk[] {
-  const usable = segments.filter(
-    (segment) => segment.status === "ok" && segment.text.trim().length > 0,
-  );
+  // Order by capture time before windowing. `seq` is assigned when each chunk's
+  // transcription request returns, so the fast Me vs slow Them streams complete
+  // out of order; chunking in seq order would glue together turns that aren't
+  // chronologically adjacent. startMs is the capture offset; seq only breaks
+  // exact-start ties (mirrors sortSegmentsByCapture in the meeting store).
+  const usable = [...segments]
+    .sort((left, right) =>
+      left.startMs !== right.startMs
+        ? left.startMs - right.startMs
+        : left.seq - right.seq,
+    )
+    .filter(
+      (segment) => segment.status === "ok" && segment.text.trim().length > 0,
+    );
   const chunks: TranscriptChunk[] = [];
   let current: TranscriptSegment[] = [];
   let chars = 0;
@@ -123,6 +134,12 @@ export async function deleteMeetingIndex(meetingId: string): Promise<void> {
   );
 }
 
+// Per-meeting failed-attempt counter so a meeting that embeds (a paid
+// seren-embed call) but then fails to persist isn't re-embedded on every
+// loadMeetings(). Bounded retries cap the wasted spend; resets on app restart.
+const MAX_BACKFILL_ATTEMPTS = 3;
+const backfillAttempts = new Map<string, number>();
+
 /** Index any of the given meetings that aren't already indexed (best-effort). */
 export async function backfillTranscriptIndex(
   meetingIds: string[],
@@ -131,8 +148,17 @@ export async function backfillTranscriptIndex(
     await invoke<string[]>("indexed_transcript_meeting_ids").catch(() => []),
   );
   for (const meetingId of meetingIds) {
-    if (!indexed.has(meetingId)) {
-      await indexMeeting(meetingId).catch(() => {});
+    if (indexed.has(meetingId)) continue;
+    if ((backfillAttempts.get(meetingId) ?? 0) >= MAX_BACKFILL_ATTEMPTS)
+      continue;
+    try {
+      await indexMeeting(meetingId);
+      backfillAttempts.delete(meetingId);
+    } catch {
+      backfillAttempts.set(
+        meetingId,
+        (backfillAttempts.get(meetingId) ?? 0) + 1,
+      );
     }
   }
 }

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -48,6 +48,7 @@ import { orchestrate } from "@/services/orchestrator";
 import {
   backfillTranscriptIndex,
   deleteMeetingIndex,
+  indexMeeting,
 } from "@/services/transcript-search";
 import { onTrayToggleCapture, setTrayRecording } from "@/services/tray";
 import { conversationStore } from "@/stores/conversation.store";
@@ -240,6 +241,17 @@ async function failMeeting(
   }
 }
 
+// Only meetings whose transcript is finalized are worth indexing. Backfilling a
+// still-capturing/transcribing meeting would index a partial transcript and then
+// permanently skip it (it already has chunks), so search would miss the rest.
+// transcript_ready and later states all have a stable transcript.
+const INDEXABLE_STATUSES: ReadonlySet<Meeting["status"]> = new Set([
+  "transcript_ready",
+  "notes_ready",
+  "agent_running",
+  "done",
+]);
+
 async function loadMeetings(): Promise<void> {
   setMeetingState("isLoading", true);
   setMeetingState("error", null);
@@ -253,7 +265,11 @@ async function loadMeetings(): Promise<void> {
   try {
     const meetings = await listMeetings();
     setMeetingState("meetings", meetings);
-    void backfillTranscriptIndex(meetings.map((item) => item.id));
+    void backfillTranscriptIndex(
+      meetings
+        .filter((item) => INDEXABLE_STATUSES.has(item.status))
+        .map((item) => item.id),
+    );
   } catch (error) {
     setMeetingState(
       "error",
@@ -342,6 +358,12 @@ async function startMeetingEventListeners(): Promise<void> {
 
   statusUnlisten = await listen<Meeting>("meeting://status", (event) => {
     trackReadyTransition(event.payload);
+    // The transcript is finalized at transcript_ready — (re)index it now so the
+    // final content replaces any earlier partial chunks. index_meeting_transcript
+    // does an atomic delete-then-insert, so this is safe to call once per ready.
+    if (event.payload.status === "transcript_ready") {
+      void indexMeeting(event.payload.id).catch(() => {});
+    }
     setMeetingState("meetings", (meetings) => {
       const next = meetings.some((meeting) => meeting.id === event.payload.id)
         ? meetings.map((meeting) =>


### PR DESCRIPTION
## Summary
Three search-index **correctness** fixes from the meeting-features release audit (frontend-only).

### AUD-004 — stale/partial index (#2695)
`loadMeetings()` backfilled every listed meeting, including active captures. `backfillTranscriptIndex` skips any meeting already holding chunks, so a meeting indexed mid-capture (one early chunk) was never reindexed → search permanently missed the rest.
- Backfill now runs only for transcript-finalized statuses (`transcript_ready`, `notes_ready`, `agent_running`, `done`).
- A meeting is (re)indexed on the `meeting://status` → `transcript_ready` transition. `index_meeting_transcript` is an atomic delete-then-insert, so the final transcript replaces any earlier partial chunks.

### AUD-005 — scrambled chunks (#2696)
`chunkTranscript` windowed segments in `seq` (completion) order, so fast-Me / slow-Them turns were glued together out of chronological order — scrambling chunk text and embeddings. It now sorts by `(startMs, seq)` before windowing, matching `sortSegmentsByCapture`.

### AUD-008 — unbounded paid embedding retries (#2699)
A meeting that embedded (a paid seren-embed call) but then failed to persist was re-embedded on every `loadMeetings()`. Backfill now tracks a per-meeting attempt budget (3) so a persistent failure stops wasting spend.
- The first-run **consent/progress UX** for bulk-indexing existing history is a separate product decision (it conflicts with the no-gating preference), so it is flagged on #2699 rather than added here. The concrete repeated-charge harm is fixed by the retry budget.

## Verification
- `biome check` clean; `tsc --noEmit` no errors in changed files; `vite build` ✓.

Closes #2695
Closes #2696
Refs #2699 (retry-budget half fixed here; consent UX pending product decision)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
