### PR TITLE
fix(meeting): exact-match search fallback + transcript DB WAL config

### DIFF
--- a/src-tauri/src/commands/transcript_search.rs
+++ b/src-tauri/src/commands/transcript_search.rs
@@ -56,6 +56,20 @@ pub fn search_transcripts(
         .map_err(|err| err.to_string())
 }
 
+/// Local literal-substring search over indexed transcript text. The offline /
+/// unauthenticated fallback for semantic search, and the exact-match path for
+/// names, emails, and phrases.
+#[tauri::command]
+pub fn search_transcripts_like(
+    app: AppHandle,
+    query: String,
+    limit: Option<usize>,
+) -> Result<Vec<TranscriptHit>, String> {
+    let conn = open_transcript_db(&app).map_err(|err| err.to_string())?;
+    transcript_vectors::search_transcript_chunks_like(&conn, &query, limit.unwrap_or(20))
+        .map_err(|err| err.to_string())
+}
+
 /// Meeting ids that already have indexed transcript chunks (for backfill).
 #[tauri::command]
 pub fn indexed_transcript_meeting_ids(app: AppHandle) -> Result<Vec<String>, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1067,6 +1067,7 @@ pub fn run() {
             commands::indexing::get_embedding_dimension,
             commands::transcript_search::index_meeting_transcript,
             commands::transcript_search::search_transcripts,
+            commands::transcript_search::search_transcripts_like,
             commands::transcript_search::indexed_transcript_meeting_ids,
             commands::transcript_search::delete_meeting_transcript_index,
             commands::indexing::discover_project_files,

--- a/src-tauri/src/services/transcript_vectors.rs
+++ b/src-tauri/src/services/transcript_vectors.rs
@@ -66,6 +66,11 @@ pub fn open_transcript_db(app: &AppHandle) -> Result<Connection> {
         fs::create_dir_all(parent).ok();
     }
     let conn = Connection::open(path)?;
+    // Match the managed DB's connection config (busy_timeout + WAL +
+    // synchronous=NORMAL). Every index/search/delete command opens its own
+    // connection, so without this, concurrent backfill vs. search vs. delete
+    // hit "database is locked" — silently surfacing as "No matches".
+    crate::services::database::configure_connection(&conn)?;
     create_transcript_tables(&conn)?;
     Ok(conn)
 }
@@ -153,6 +158,45 @@ pub fn search_transcript_chunks(
     Ok(hits)
 }
 
+/// Escape the LIKE metacharacters so a user query is matched literally.
+fn escape_like(query: &str) -> String {
+    query
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+/// Literal substring search over indexed transcript text. This works offline /
+/// unauthenticated / when seren-embed is down, and surfaces exact names, emails,
+/// and phrases that vector search ranks poorly. Returned hits carry distance 0.
+pub fn search_transcript_chunks_like(
+    conn: &Connection,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<TranscriptHit>> {
+    let pattern = format!("%{}%", escape_like(query));
+    let mut stmt = conn.prepare(
+        "SELECT meeting_id, seq_start, seq_end, text
+         FROM transcript_chunks
+         WHERE text LIKE ?1 ESCAPE '\\'
+         ORDER BY indexed_at DESC
+         LIMIT ?2",
+    )?;
+    let hits = stmt
+        .query_map(params![pattern, limit as i64], |row| {
+            Ok(TranscriptHit {
+                meeting_id: row.get(0)?,
+                seq_start: row.get(1)?,
+                seq_end: row.get(2)?,
+                text: row.get(3)?,
+                distance: 0.0,
+            })
+        })?
+        .filter_map(|row| row.ok())
+        .collect();
+    Ok(hits)
+}
+
 /// Meeting ids that already have indexed chunks (used to skip backfill work).
 pub fn indexed_meeting_ids(conn: &Connection) -> Result<Vec<String>> {
     let mut stmt = conn.prepare("SELECT DISTINCT meeting_id FROM transcript_chunks")?;
@@ -196,5 +240,31 @@ mod tests {
         delete_meeting_chunks(&conn, "m1").unwrap();
         assert!(search_transcript_chunks(&conn, &query, 5).unwrap().is_empty());
         assert!(indexed_meeting_ids(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn like_search_matches_literal_substrings_and_escapes_wildcards() {
+        init_sqlite_vec();
+        let conn = Connection::open_in_memory().unwrap();
+        create_transcript_tables(&conn).unwrap();
+
+        insert_transcript_chunk(&conn, "m1", 0, 2, "Me: email is bob@acme.io", &unit_vec(0), 1)
+            .unwrap();
+        insert_transcript_chunk(&conn, "m1", 3, 5, "Them: 50% off the budget", &unit_vec(1), 2)
+            .unwrap();
+
+        // Literal substring (case-insensitive via SQLite LIKE) hits one chunk.
+        let hits = search_transcript_chunks_like(&conn, "bob@acme.io", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].seq_start, 0);
+        assert_eq!(hits[0].distance, 0.0);
+
+        // `%` is matched literally, not as a wildcard: "50%" matches, "xx" does not.
+        assert_eq!(search_transcript_chunks_like(&conn, "50%", 10).unwrap().len(), 1);
+        assert!(search_transcript_chunks_like(&conn, "%", 10)
+            .unwrap()
+            .iter()
+            .all(|hit| hit.text.contains('%')));
+        assert!(search_transcript_chunks_like(&conn, "nope", 10).unwrap().is_empty());
     }
 }

--- a/src/components/meeting/TranscriptSearch.tsx
+++ b/src/components/meeting/TranscriptSearch.tsx
@@ -13,6 +13,7 @@ export function TranscriptSearch() {
   const [hits, setHits] = createSignal<TranscriptHit[]>([]);
   const [searching, setSearching] = createSignal(false);
   const [searched, setSearched] = createSignal(false);
+  const [semanticUnavailable, setSemanticUnavailable] = createSignal(false);
 
   const run = async () => {
     const trimmed = query().trim();
@@ -22,14 +23,11 @@ export function TranscriptSearch() {
       return;
     }
     setSearching(true);
-    try {
-      setHits(await searchTranscripts(trimmed, 20));
-    } catch {
-      setHits([]);
-    } finally {
-      setSearching(false);
-      setSearched(true);
-    }
+    const result = await searchTranscripts(trimmed, 20);
+    setHits(result.hits);
+    setSemanticUnavailable(result.semanticUnavailable);
+    setSearching(false);
+    setSearched(true);
   };
 
   const meetingTitleFor = (meetingId: string) =>
@@ -68,6 +66,11 @@ export function TranscriptSearch() {
       </Show>
 
       <Show when={searched() && !searching()}>
+        <Show when={semanticUnavailable()}>
+          <div class="mt-2 text-[11px] text-warning">
+            Semantic search unavailable — showing exact matches.
+          </div>
+        </Show>
         <Show
           when={hits().length > 0}
           fallback={

--- a/src/services/transcript-search.ts
+++ b/src/services/transcript-search.ts
@@ -116,15 +116,58 @@ export async function indexMeeting(meetingId: string): Promise<number> {
   }
 }
 
-/** Semantic search across all indexed transcripts. Empty query → no results. */
+export interface TranscriptSearchResult {
+  hits: TranscriptHit[];
+  /** True when semantic search failed (offline/unauthenticated/embed down) and
+   *  only the local exact-match results are shown. */
+  semanticUnavailable: boolean;
+}
+
+/**
+ * Search transcripts, combining semantic (vector) hits with a local exact-text
+ * pass. The exact pass always runs (it works offline / unauthenticated), so an
+ * embedding failure degrades to exact matches rather than an empty result. Never
+ * throws: callers distinguish "no matches" from "semantic unavailable" via the
+ * returned flag.
+ */
 export async function searchTranscripts(
   query: string,
   limit = 20,
-): Promise<TranscriptHit[]> {
+): Promise<TranscriptSearchResult> {
   const trimmed = query.trim();
-  if (!trimmed) return [];
-  const queryEmbedding = await embedText(trimmed);
-  return invoke("search_transcripts", { queryEmbedding, limit });
+  if (!trimmed) return { hits: [], semanticUnavailable: false };
+
+  const exact = await invoke<TranscriptHit[]>("search_transcripts_like", {
+    query: trimmed,
+    limit,
+  }).catch(() => [] as TranscriptHit[]);
+
+  let semantic: TranscriptHit[] = [];
+  let semanticUnavailable = false;
+  try {
+    const queryEmbedding = await embedText(trimmed);
+    semantic = await invoke<TranscriptHit[]>("search_transcripts", {
+      queryEmbedding,
+      limit,
+    });
+  } catch {
+    // Offline / unauthenticated / out of balance / seren-embed down.
+    semanticUnavailable = true;
+  }
+
+  // Semantic hits rank first; append exact hits not already covered.
+  const seen = new Set(
+    semantic.map((hit) => `${hit.meetingId}:${hit.seqStart}`),
+  );
+  const merged = [...semantic];
+  for (const hit of exact) {
+    const key = `${hit.meetingId}:${hit.seqStart}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      merged.push(hit);
+    }
+  }
+  return { hits: merged.slice(0, limit), semanticUnavailable };
 }
 
 /** Drop a meeting's transcript vectors (best-effort; called on delete). */


### PR DESCRIPTION
## Summary
Two search **robustness** fixes from the meeting-features release audit.

### AUD-006 — no exact/offline fallback, errors hidden as "No matches" (#2697)
Search always embedded then ran vector KNN, with no local fallback, and the UI caught every error → "No matches." So search was unusable offline / unauthenticated / out of balance / when seren-embed was down, and exact names/emails/literal phrases failed silently.
- New Rust command `search_transcripts_like` runs a local `LIKE` substring query over `transcript_chunks.text`, with `%`/`_`/`\` escaping so user input matches literally.
- `searchTranscripts` always runs the exact pass and merges it with semantic hits (semantic ranked first, exact appended). It never throws; an embedding failure degrades to exact matches and sets a flag.
- The UI surfaces **"Semantic search unavailable — showing exact matches."** instead of a blank result.

### AUD-007 — transcript DB lock risk (#2698)
`open_transcript_db` set no `busy_timeout` / `journal_mode=WAL` / `synchronous=NORMAL`, and every index/search/delete opens its own connection — so concurrent backfill vs. search vs. delete hit `database is locked`, surfacing (silently) as "No matches." It now reuses `database::configure_connection` (busy_timeout 5s + WAL + synchronous=NORMAL), matching the managed DB.

## Verification
- `cargo test --lib transcript_vectors` — 2 passed (incl. new `like_search_matches_literal_substrings_and_escapes_wildcards`); full lib compiles (new command + lib.rs registration).
- `biome check` clean; `tsc --noEmit` no errors in changed files; `vite build` ✓.

Closes #2697
Closes #2698

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
