### PR TITLE
feat(meeting): global Search transcripts shortcut (Cmd/Ctrl+Shift+F)

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -825,6 +825,10 @@ export const AppShell: Component<AppShellProps> = (props) => {
       setSlidePanel(null);
       void threadStore.createTerminalThread({ title: "Terminal" });
     });
+    shortcuts.register("global.searchMeetings", () => {
+      setSlidePanel("meetings");
+      meetingStore.requestSearchFocus();
+    });
   });
 
   onCleanup(() => {
@@ -849,6 +853,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
     shortcuts.unregister("global.openFiles");
     shortcuts.unregister("global.newChat");
     shortcuts.unregister("global.newTerminal");
+    shortcuts.unregister("global.searchMeetings");
   });
 
   const recordPromptVisible = () =>

--- a/src/components/meeting/TranscriptSearch.tsx
+++ b/src/components/meeting/TranscriptSearch.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Semantic search field over meeting transcripts with jump-to-meeting results.
 // ABOUTME: Calls the transcript-search service; clicking a hit opens its meeting.
 
-import { createSignal, For, Show } from "solid-js";
+import { createEffect, createSignal, For, Show } from "solid-js";
 import {
   searchTranscripts,
   type TranscriptHit,
@@ -14,6 +14,18 @@ export function TranscriptSearch() {
   const [searching, setSearching] = createSignal(false);
   const [searched, setSearched] = createSignal(false);
   const [semanticUnavailable, setSemanticUnavailable] = createSignal(false);
+  let inputRef: HTMLInputElement | undefined;
+
+  // The global "Search transcripts" shortcut opens this panel and asks the input
+  // to focus. Consume the request whether the panel was already open (this effect
+  // re-runs) or just mounted (it runs once with the flag already set), then clear
+  // it so reopening the panel later never steals focus.
+  createEffect(() => {
+    if (meetingStore.state.pendingSearchFocus) {
+      inputRef?.focus();
+      meetingStore.clearSearchFocus();
+    }
+  });
 
   const run = async () => {
     const trimmed = query().trim();
@@ -53,6 +65,7 @@ export function TranscriptSearch() {
         }}
       >
         <input
+          ref={inputRef}
           type="search"
           value={query()}
           onInput={(event) => setQuery(event.currentTarget.value)}

--- a/src/components/settings/KeybindingsSettings.tsx
+++ b/src/components/settings/KeybindingsSettings.tsx
@@ -56,6 +56,7 @@ const SHORTCUT_SECTIONS: ShortcutSectionConfig[] = [
       "global.openFiles",
       "global.newChat",
       "global.newTerminal",
+      "global.searchMeetings",
     ],
   },
   {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -15,7 +15,8 @@ export type ShortcutAction =
   | "global.focusEditor"
   | "global.openFiles"
   | "global.newChat"
-  | "global.newTerminal";
+  | "global.newTerminal"
+  | "global.searchMeetings";
 
 /**
  * A shortcut handler may return `false` to signal it did not consume the key,
@@ -38,6 +39,7 @@ const GLOBAL_SHORTCUT_ACTIONS: readonly ShortcutAction[] = [
   "global.openFiles",
   "global.newChat",
   "global.newTerminal",
+  "global.searchMeetings",
 ];
 
 /**

--- a/src/stores/keybindings.store.ts
+++ b/src/stores/keybindings.store.ts
@@ -27,6 +27,7 @@ export type KeybindingActionId =
   | "global.openFiles"
   | "global.newChat"
   | "global.newTerminal"
+  | "global.searchMeetings"
   | "workspace.next"
   | "workspace.previous"
   | "workspace.switch1"
@@ -161,6 +162,13 @@ const keybindingDefinitions = [
     label: "New terminal",
     description: "Open a new terminal thread.",
     defaults: [{ sequence: [{ mod: true, key: "t" }] }],
+  },
+  {
+    id: "global.searchMeetings",
+    group: "Global",
+    label: "Search transcripts",
+    description: "Open the meetings panel and focus transcript search.",
+    defaults: [{ sequence: [{ mod: true, shift: true, key: "f" }] }],
   },
   {
     id: "workspace.next",

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -98,6 +98,8 @@ interface MeetingState {
   reviewReadyMeetingId: string | null;
   /** A search hit asked to scroll the transcript to a segment (meeting + seq). */
   searchScrollTarget: { meetingId: string; seq: number } | null;
+  /** Set by the global search shortcut so TranscriptSearch focuses its input. */
+  pendingSearchFocus: boolean;
 }
 
 const [meetingState, setMeetingState] = createStore<MeetingState>({
@@ -117,6 +119,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   primingRequest: null,
   reviewReadyMeetingId: null,
   searchScrollTarget: null,
+  pendingSearchFocus: false,
 });
 
 let transcriptUnlisten: UnlistenFn | null = null;
@@ -1335,6 +1338,17 @@ function clearSegmentScroll(): void {
   setMeetingState("searchScrollTarget", null);
 }
 
+// The global search shortcut requests focus; TranscriptSearch consumes and
+// clears it once its input is focused (works whether the panel was already
+// open or is opening in the same gesture).
+function requestSearchFocus(): void {
+  setMeetingState("pendingSearchFocus", true);
+}
+
+function clearSearchFocus(): void {
+  setMeetingState("pendingSearchFocus", false);
+}
+
 export const meetingStore = {
   get state(): MeetingState {
     return meetingState;
@@ -1372,4 +1386,6 @@ export const meetingStore = {
   acknowledgeReviewReady,
   requestSegmentScroll,
   clearSegmentScroll,
+  requestSearchFocus,
+  clearSearchFocus,
 };


### PR DESCRIPTION
## Summary
AUD-015 (#2706): transcript search was only reachable inside the meetings panel — no global entry, low discoverability. Adds a global keybinding (default **Cmd/Ctrl+Shift+F**, configurable in Keybindings settings) that opens the meetings panel and focuses the transcript search input.

- New `global.searchMeetings` action in the keybinding registry (`keybindings.store.ts`) + shortcut dispatcher (`lib/shortcuts.ts`), surfaced in Keybindings settings.
- `AppShell` registers it: opens the meetings slide-panel + requests search focus.
- `meeting.store` exposes a `pendingSearchFocus` flag; `TranscriptSearch` consumes it (via a `createEffect`) to focus its input whether the panel was already open or is opening in the same gesture, then clears it so reopening later never steals focus.

No collision with existing bindings (verified). Global shortcuts are ignored while focus is in an editable field, so the editor/Monaco find is unaffected.

## Verification
biome clean; tsc no errors in changed files; vite build OK.

Closes #2706

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com