### PR TITLE
fix(meeting): app-aware calendar match + upcoming connect/error states

### DIFF
--- a/src/components/meeting/UpcomingMeetings.tsx
+++ b/src/components/meeting/UpcomingMeetings.tsx
@@ -10,44 +10,61 @@ export function UpcomingMeetings() {
     meetingStore.state.upcomingEvents
       .filter((event) => event.endMs > Date.now())
       .slice(0, 4);
+  const status = () => meetingStore.state.upcomingStatus;
+  // Surface the panel when there are events, or when there's an actionable
+  // calendar problem to report. A connected-but-empty calendar stays quiet.
+  const visible = () => upcoming().length > 0 || status() !== "connected";
+  const statusMessage = () =>
+    status() === "disconnected"
+      ? "Connect Google Calendar to see upcoming meetings."
+      : "Couldn't load your calendar — it'll retry shortly.";
 
   return (
-    <Show when={upcoming().length > 0}>
+    <Show when={visible()}>
       <div class="px-4 py-3 border-b border-border bg-surface-0/40">
         <div class="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
           Upcoming
         </div>
-        <div class="flex flex-col gap-1.5">
-          <For each={upcoming()}>
-            {(event) => (
-              <div class="flex min-w-0 items-center gap-2">
-                <div class="min-w-0 flex-1">
-                  <div class="truncate text-[12px] font-medium text-foreground">
-                    {event.title}
+        <Show
+          when={upcoming().length > 0}
+          fallback={
+            <div class="text-[11px] text-muted-foreground">
+              {statusMessage()}
+            </div>
+          }
+        >
+          <div class="flex flex-col gap-1.5">
+            <For each={upcoming()}>
+              {(event) => (
+                <div class="flex min-w-0 items-center gap-2">
+                  <div class="min-w-0 flex-1">
+                    <div class="truncate text-[12px] font-medium text-foreground">
+                      {event.title}
+                    </div>
+                    <div class="truncate text-[10px] text-muted-foreground">
+                      {formatTime(event.startMs)}
+                      {event.attendees.length > 0
+                        ? ` · ${event.attendees.length} attendee${
+                            event.attendees.length === 1 ? "" : "s"
+                          }`
+                        : ""}
+                      {event.meetingUrl ? " · video" : ""}
+                    </div>
                   </div>
-                  <div class="truncate text-[10px] text-muted-foreground">
-                    {formatTime(event.startMs)}
-                    {event.attendees.length > 0
-                      ? ` · ${event.attendees.length} attendee${
-                          event.attendees.length === 1 ? "" : "s"
-                        }`
-                      : ""}
-                    {event.meetingUrl ? " · video" : ""}
-                  </div>
+                  <button
+                    type="button"
+                    class="h-6 shrink-0 rounded-md border border-border bg-surface-2 px-2 text-[10px] font-medium text-foreground transition-colors hover:bg-surface-3"
+                    onClick={() =>
+                      void meetingStore.startFromCalendarEvent(event)
+                    }
+                  >
+                    Record
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  class="h-6 shrink-0 rounded-md border border-border bg-surface-2 px-2 text-[10px] font-medium text-foreground transition-colors hover:bg-surface-3"
-                  onClick={() =>
-                    void meetingStore.startFromCalendarEvent(event)
-                  }
-                >
-                  Record
-                </button>
-              </div>
-            )}
-          </For>
-        </div>
+              )}
+            </For>
+          </div>
+        </Show>
       </div>
     </Show>
   );

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Google Calendar read client for meeting metadata + pre-arm.
+// ABOUTME: Google Calendar read client for meeting metadata.
 // ABOUTME: Lists windowed upcoming events via the Gateway publisher and matches them to recordings.
 
 import { apiBase } from "@/lib/config";
@@ -9,7 +9,7 @@ import { getToken } from "@/services/auth";
 
 const PUBLISHER_SLUG = "google-calendar";
 
-/** A normalized upcoming calendar event for meeting matching + pre-arm. */
+/** A normalized upcoming calendar event for meeting matching. */
 export interface CalendarEvent {
   id: string;
   title: string;
@@ -99,13 +99,31 @@ export function normalizeEvent(event: RawGoogleEvent): CalendarEvent | null {
 }
 
 /**
+ * Whether the calendar fetch reached a connected account. `disconnected` means
+ * no/expired Google authorization (connect it); `error` means a network or
+ * upstream failure (retry); `connected` means a successful read (events may be
+ * empty). Lets the UI distinguish "not connected" from "nothing scheduled".
+ */
+export type CalendarConnectionStatus = "connected" | "disconnected" | "error";
+
+export interface UpcomingEventsResult {
+  status: CalendarConnectionStatus;
+  events: CalendarEvent[];
+}
+
+function statusForCode(code: number): CalendarConnectionStatus {
+  return code === 401 || code === 403 ? "disconnected" : "error";
+}
+
+/**
  * Fetch upcoming events from the user's primary Google calendar, windowed
- * `[now, now + aheadMs]`. Returns `[]` on any failure (not connected, offline,
- * upstream error) so callers degrade gracefully.
+ * `[now, now + aheadMs]`. Never throws: failures map to a `disconnected` or
+ * `error` status with empty events so callers degrade gracefully while still
+ * being able to tell the states apart.
  */
 export async function getUpcomingEvents(
   aheadMs = 12 * 60 * 60_000,
-): Promise<CalendarEvent[]> {
+): Promise<UpcomingEventsResult> {
   const now = Date.now();
   const params = new URLSearchParams({
     timeMin: new Date(now).toISOString(),
@@ -119,43 +137,89 @@ export async function getUpcomingEvents(
     const headers: Record<string, string> = {};
     if (!shouldUseRustGatewayAuth(url)) {
       const token = await getToken();
-      if (!token) return [];
+      if (!token) return { status: "disconnected", events: [] };
       headers.Authorization = `Bearer ${token}`;
     }
     const response = await appFetch(url, { method: "GET", headers });
-    if (!response.ok) return [];
+    if (!response.ok) {
+      return { status: statusForCode(response.status), events: [] };
+    }
     const result = await response.json();
     const status = publisherStatus(result);
-    if (status !== undefined && (status < 200 || status >= 300)) return [];
+    if (status !== undefined && (status < 200 || status >= 300)) {
+      return { status: statusForCode(status), events: [] };
+    }
     const body = unwrapPublisherBody(result) as { items?: RawGoogleEvent[] };
-    return (body?.items ?? [])
+    const events = (body?.items ?? [])
       .map(normalizeEvent)
       .filter((event): event is CalendarEvent => event !== null)
       .sort((a, b) => a.startMs - b.startMs);
+    return { status: "connected", events };
   } catch {
-    return [];
+    return { status: "error", events: [] };
   }
+}
+
+// The detected call app → the meeting-link hostnames it owns. Used to pick the
+// right event among overlapping ones (a Zoom call should match the Zoom link,
+// not a coincidentally-overlapping Meet invite). Browser apps (Chrome) own no
+// hostname, so they fall through to the link/ambiguity rules below.
+const APP_URL_DOMAINS: ReadonlyArray<{ key: string; domains: string[] }> = [
+  { key: "zoom", domains: ["zoom.us"] },
+  { key: "teams", domains: ["teams.microsoft.com", "teams.live.com"] },
+  { key: "webex", domains: ["webex.com"] },
+  { key: "meet", domains: ["meet.google.com"] },
+];
+
+/** True when the event's join-link hostname belongs to the detected app. */
+function eventMatchesApp(event: CalendarEvent, sourceApp: string): boolean {
+  if (!event.meetingUrl) return false;
+  const app = sourceApp.toLowerCase();
+  let host: string;
+  try {
+    host = new URL(event.meetingUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return APP_URL_DOMAINS.some(
+    ({ key, domains }) =>
+      app.includes(key) && domains.some((domain) => host.includes(domain)),
+  );
 }
 
 /**
  * Pick the calendar event a recording starting at `nowMs` belongs to: the one
- * whose window contains now (with a small lead-in), preferring events that have
- * a video-conferencing link. Returns null when nothing matches.
+ * whose window contains now (with a small lead-in). With a single in-window
+ * event, use it. With several, disambiguate by the detected app's meeting-link
+ * domain; otherwise prefer the lone event with a join link. When still
+ * ambiguous (multiple plausible events), return null rather than stamp the
+ * wrong title/attendees (PII) onto the recording.
  */
 export function matchActiveEvent(
   events: CalendarEvent[],
   nowMs: number,
+  sourceApp: string | null = null,
   leadMs = 5 * 60_000,
 ): CalendarEvent | null {
   const candidates = events.filter(
     (event) => nowMs >= event.startMs - leadMs && nowMs <= event.endMs,
   );
   if (candidates.length === 0) return null;
-  candidates.sort((a, b) => {
-    const linkDelta =
-      Number(Boolean(b.meetingUrl)) - Number(Boolean(a.meetingUrl));
-    if (linkDelta !== 0) return linkDelta;
-    return Math.abs(nowMs - a.startMs) - Math.abs(nowMs - b.startMs);
-  });
-  return candidates[0];
+  if (candidates.length === 1) return candidates[0];
+
+  // Several overlapping events: the detected app's link domain uniquely
+  // identifies the active call when it matches exactly one.
+  if (sourceApp) {
+    const appMatches = candidates.filter((event) =>
+      eventMatchesApp(event, sourceApp),
+    );
+    if (appMatches.length === 1) return appMatches[0];
+    if (appMatches.length > 1) return null;
+  }
+
+  // No app signal: a real video call almost always carries a join link, so a
+  // lone linked candidate is the safe pick. Multiple linked candidates are too
+  // ambiguous to stamp attendee PII — leave the recording unmatched.
+  const linked = candidates.filter((event) => event.meetingUrl);
+  return linked.length === 1 ? linked[0] : null;
 }

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -11,6 +11,7 @@ import {
 import { captureSupportError } from "@/lib/support/hook";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 import {
+  type CalendarConnectionStatus,
   type CalendarEvent,
   getUpcomingEvents,
   matchActiveEvent,
@@ -73,6 +74,8 @@ interface MeetingState {
   capturePausedAccumMs: number;
   /** Upcoming calendar events (empty unless Google Calendar is connected). */
   upcomingEvents: CalendarEvent[];
+  /** Last calendar fetch outcome, so the peek can show connect/retry states. */
+  upcomingStatus: CalendarConnectionStatus;
   /**
    * True while the native mic is disconnected mid-capture and the backend is
    * re-acquiring it. The panel shows a "microphone disconnected — reconnecting…"
@@ -111,6 +114,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   capturePausedAt: null,
   capturePausedAccumMs: 0,
   upcomingEvents: [],
+  upcomingStatus: "connected",
   micCaptureLost: false,
   isLoading: false,
   error: null,
@@ -1116,8 +1120,10 @@ async function refreshUpcomingEventsIfStale(): Promise<void> {
   const now = Date.now();
   if (now - lastCalendarFetchMs < CALENDAR_REFRESH_MS) return;
   lastCalendarFetchMs = now;
-  cachedUpcomingEvents = await getUpcomingEvents();
-  setMeetingState("upcomingEvents", cachedUpcomingEvents);
+  const result = await getUpcomingEvents();
+  cachedUpcomingEvents = result.events;
+  setMeetingState("upcomingEvents", result.events);
+  setMeetingState("upcomingStatus", result.status);
 }
 
 async function pollAutoDetect(): Promise<void> {
@@ -1156,7 +1162,11 @@ async function pollAutoDetect(): Promise<void> {
     if (!isCapturing()) {
       try {
         const now = Date.now();
-        const event = matchActiveEvent(cachedUpcomingEvents, now);
+        const event = matchActiveEvent(
+          cachedUpcomingEvents,
+          now,
+          action.sourceApp,
+        );
         const meeting = await createMeeting({
           title: event?.title ?? `Meeting ${formatTime(now)}`,
           sourceApp: action.sourceApp ?? "Auto-detect",

--- a/tests/unit/calendar-match.test.ts
+++ b/tests/unit/calendar-match.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Critical-path coverage for calendar event normalization + recording match.
-// ABOUTME: Pure logic that decides a recording's title/attendees and pre-arm window.
+// ABOUTME: Pure logic that decides a recording's title/attendees from a calendar event.
 
 import { describe, expect, it } from "vitest";
 import {
@@ -95,5 +95,42 @@ describe("calendar matchActiveEvent", () => {
       endMs: now + 90 * 60_000,
     });
     expect(matchActiveEvent([later], now)).toBeNull();
+  });
+
+  it("disambiguates overlapping events by the detected app's link domain", () => {
+    const now = 1_000_000;
+    const zoom = event({
+      id: "zoom",
+      startMs: now - 1000,
+      endMs: now + 60_000,
+      meetingUrl: "https://us02web.zoom.us/j/123",
+    });
+    const meet = event({
+      id: "meet",
+      startMs: now - 1000,
+      endMs: now + 60_000,
+      meetingUrl: "https://meet.google.com/abc",
+    });
+    expect(matchActiveEvent([zoom, meet], now, "Zoom")?.id).toBe("zoom");
+    expect(matchActiveEvent([zoom, meet], now, "Google Chrome")).toBeNull();
+  });
+
+  it("returns null for multiple linked overlapping events with no app match", () => {
+    const now = 1_000_000;
+    const a = event({
+      id: "a",
+      startMs: now - 1000,
+      endMs: now + 60_000,
+      meetingUrl: "https://us02web.zoom.us/j/1",
+    });
+    const b = event({
+      id: "b",
+      startMs: now - 1000,
+      endMs: now + 60_000,
+      meetingUrl: "https://meet.google.com/2",
+    });
+    // No detected app → cannot tell which call is live → leave unmatched
+    // rather than stamp the wrong attendees.
+    expect(matchActiveEvent([a, b], now)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Three calendar fixes from the meeting-features release audit.

### AUD-009 — wrong attendees/title stamped on overlapping events (#2700)
`matchActiveEvent` filtered only by time, then preferred *any* video link, discarding the detected call app. Two overlapping meetings could stamp the wrong title + attendee PII (saved locally and synced to the cloud note).
- Now disambiguates overlapping events by the detected app's meeting-link **domain** (Zoom↔`zoom.us`, Teams↔`teams.microsoft.com`/`teams.live.com`, Webex, Meet).
- A single in-window event is used as-is; among several, an app-domain match wins; otherwise a lone linked event wins; **multiple plausible linked events with no app match return `null`** (unmatched) rather than guessing.
- The auto-detect call site threads `action.sourceApp` through (it was available but discarded).

### AUD-014 — UpcomingMeetings blank for all non-success states (#2705)
The peek rendered nothing whether disconnected, offline, errored, or empty. `getUpcomingEvents` now returns a discriminated `{ status, events }` (`connected | disconnected | error`), and the peek shows **"Connect Google Calendar"** (disconnected) or **"Couldn't load your calendar"** (error) instead of a blank panel — staying quiet only when connected-and-empty.

### AUD-013 — "pre-arm" over-claim (#2704)
There is no Armed/pre-warm state; shipped behavior is metadata + one-tap/auto record. Dropped the misleading "pre-arm" wording from `calendar.ts` and the test header.

## Verification
- `vitest tests/unit/calendar-match.test.ts` — 7 passed (incl. new app-disambiguation + multiple-linked-ambiguity cases; existing single-link-preference case still passes).
- `biome check` clean; `tsc --noEmit` no errors in changed files; `vite build` ✓.

Closes #2700
Closes #2704
Closes #2705

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
