### PR TITLE
fix(meeting): reduced-motion + status semantics + draggable indicator

### DIFF
--- a/src/components/meeting/RecordingIndicator.tsx
+++ b/src/components/meeting/RecordingIndicator.tsx
@@ -19,11 +19,37 @@ const CONTROL_CLASS =
 const DISCLOSURE =
   "Heads up — I'm using an AI assistant to take notes on this call.";
 
+// Persisted drag position so a user who moved the indicator off their controls
+// keeps it there across reopens. UI-only; not sensitive.
+const POSITION_KEY = "seren.recordingIndicator.position";
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+function loadPosition(): Position | null {
+  try {
+    const raw = localStorage.getItem(POSITION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.x === "number" && typeof parsed?.y === "number") {
+      return { x: parsed.x, y: parsed.y };
+    }
+  } catch {
+    // Ignore malformed storage; fall back to the default corner.
+  }
+  return null;
+}
+
 export function RecordingIndicator() {
   const [now, setNow] = createSignal(Date.now());
   const [confirmingDelete, setConfirmingDelete] = createSignal(false);
   const [deleting, setDeleting] = createSignal(false);
   const [copied, setCopied] = createSignal(false);
+  const [position, setPosition] = createSignal<Position | null>(loadPosition());
+  let containerRef: HTMLDivElement | undefined;
+  let drag: { px: number; py: number; ox: number; oy: number } | null = null;
 
   let timer: number | undefined;
   onMount(() => {
@@ -44,6 +70,16 @@ export function RecordingIndicator() {
     if (active() === null && confirmingDelete()) setConfirmingDelete(false);
   });
 
+  // Discrete recording state for assistive tech — announced on change (start,
+  // pause, mic loss), unlike the per-second elapsed timer which would spam a
+  // live region.
+  const statusText = () => {
+    const base = paused() ? "Recording paused" : "Recording in progress";
+    return meetingStore.state.micCaptureLost
+      ? `${base}, microphone disconnected`
+      : base;
+  };
+
   // Elapsed excludes paused spans and freezes while paused: the anchor is the
   // pause-start timestamp when paused, otherwise the live clock, minus the time
   // already accumulated across completed pauses.
@@ -55,6 +91,54 @@ export function RecordingIndicator() {
     return formatElapsed(
       anchor - meeting.startedAt - state.capturePausedAccumMs,
     );
+  };
+
+  // Keep the indicator fully on-screen when dragged or the window resizes.
+  const clampToViewport = (x: number, y: number): Position => {
+    const width = containerRef?.offsetWidth ?? 0;
+    const height = containerRef?.offsetHeight ?? 0;
+    const maxX = Math.max(0, window.innerWidth - width);
+    const maxY = Math.max(0, window.innerHeight - height);
+    return {
+      x: Math.min(Math.max(0, x), maxX),
+      y: Math.min(Math.max(0, y), maxY),
+    };
+  };
+
+  const onDragStart = (event: PointerEvent) => {
+    if (!containerRef) return;
+    const rect = containerRef.getBoundingClientRect();
+    drag = {
+      px: event.clientX,
+      py: event.clientY,
+      ox: rect.left,
+      oy: rect.top,
+    };
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    event.preventDefault();
+  };
+
+  const onDragMove = (event: PointerEvent) => {
+    if (!drag) return;
+    setPosition(
+      clampToViewport(
+        drag.ox + (event.clientX - drag.px),
+        drag.oy + (event.clientY - drag.py),
+      ),
+    );
+  };
+
+  const onDragEnd = () => {
+    if (!drag) return;
+    drag = null;
+    const current = position();
+    if (current) {
+      try {
+        localStorage.setItem(POSITION_KEY, JSON.stringify(current));
+      } catch {
+        // Non-fatal: position just won't persist across reloads.
+      }
+    }
   };
 
   const onStop = () => {
@@ -97,33 +181,61 @@ export function RecordingIndicator() {
   return (
     <Show when={active()}>
       <div
+        ref={containerRef}
         class="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border border-destructive/40 bg-popover/95 px-3 py-1.5 shadow-[0_8px_24px_rgba(0,0,0,0.32)] backdrop-blur-sm animate-[fadeIn_200ms_ease]"
-        aria-label="Recording in progress"
+        style={
+          position()
+            ? {
+                left: `${position()?.x}px`,
+                top: `${position()?.y}px`,
+                right: "auto",
+                bottom: "auto",
+              }
+            : undefined
+        }
+        aria-label={statusText()}
       >
-        <span class="relative flex h-2.5 w-2.5 shrink-0 items-center justify-center">
-          <Show
-            when={!paused()}
-            fallback={
-              <span class="h-2.5 w-2.5 rounded-full bg-muted-foreground" />
-            }
-          >
-            <span class="absolute h-2.5 w-2.5 rounded-full bg-destructive/70 animate-[voicePulse_1.4s_ease-in-out_infinite]" />
-            <span class="h-2.5 w-2.5 rounded-full bg-destructive" />
-          </Show>
+        {/* Off-screen live region: announces state changes (start/pause/mic
+            loss) without reading the ticking timer every second. */}
+        <span class="sr-only" role="status" aria-live="polite">
+          {statusText()}
         </span>
-        <span class="text-[11px] font-medium tabular-nums text-foreground">
-          {paused() ? "Paused" : "Rec"} {elapsed()}
-        </span>
-        <Show when={meetingStore.state.micCaptureLost}>
-          <span class="text-[10px] font-medium text-destructive">mic lost</span>
-        </Show>
-        <Show when={meetingStore.state.error}>
-          {(message) => (
-            <span class="max-w-[200px] truncate text-[10px] font-medium text-destructive">
-              {message()}
+        {/* Drag handle: the timer/label area moves the pill so it never traps
+            bottom-right controls. The buttons stay outside the handle. */}
+        <div
+          class="flex cursor-grab touch-none select-none items-center gap-2"
+          onPointerDown={onDragStart}
+          onPointerMove={onDragMove}
+          onPointerUp={onDragEnd}
+          onPointerCancel={onDragEnd}
+        >
+          <span class="relative flex h-2.5 w-2.5 shrink-0 items-center justify-center">
+            <Show
+              when={!paused()}
+              fallback={
+                <span class="h-2.5 w-2.5 rounded-full bg-muted-foreground" />
+              }
+            >
+              <span class="absolute h-2.5 w-2.5 rounded-full bg-destructive/70 animate-[voicePulse_1.4s_ease-in-out_infinite]" />
+              <span class="h-2.5 w-2.5 rounded-full bg-destructive" />
+            </Show>
+          </span>
+          <span class="text-[11px] font-medium tabular-nums text-foreground">
+            {paused() ? "Paused" : "Rec"} {elapsed()}
+          </span>
+          <Show when={meetingStore.state.micCaptureLost}>
+            <span class="text-[10px] font-medium text-destructive">
+              mic lost
             </span>
-          )}
-        </Show>
+          </Show>
+          <Show when={meetingStore.state.error}>
+            {(message) => (
+              <span class="max-w-[200px] truncate text-[10px] font-medium text-destructive">
+                {message()}
+              </span>
+            )}
+          </Show>
+        </div>
         <div class="ml-1 flex shrink-0 items-center gap-1">
           <button
             type="button"

--- a/src/styles.css
+++ b/src/styles.css
@@ -791,8 +791,9 @@ footer.status-bar {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .recording-card-enter {
-    animation: none;
+  .recording-card-enter,
+  .meeting-recording-glow,
+  [class*="animate-[voicePulse"] {
+    animation: none !important;
   }
 }
-


### PR DESCRIPTION
## Summary
Two accessibility / UX fixes from the meeting-features release audit.

### AUD-016 — reduced-motion + status semantics (#2707)
The sole `prefers-reduced-motion` block only disabled `.recording-card-enter`, so the **infinite** `voicePulse` dot (recording indicator, record prompt, voice button) and the titlebar `meeting-recording-glow` kept animating for reduced-motion users.
- Extends the reduced-motion block to neutralize `.meeting-recording-glow` and any `animate-[voicePulse…]` element.
- The indicator had only a static `aria-label`. Adds an off-screen `role="status" aria-live="polite"` region carrying the discrete state (**recording / paused / microphone disconnected**) so state changes are announced — without spamming the per-second elapsed timer — and makes the `aria-label` reflect that state.

### AUD-017 — draggable indicator (#2708)
The floating indicator was hard-pinned at `bottom-4 right-4` and could trap bottom-right app controls behind it. The timer/label area is now a **drag handle**: pointer-drag, viewport-clamped, with the position persisted to `localStorage`. The control buttons sit outside the handle, so dragging never fires Stop/Pause/Delete.

## Verification
- `biome check` clean; `tsc --noEmit` no errors in changed files; `vite build` ✓.
- Reduced-motion selector confirmed intact after formatting.

Closes #2707
Closes #2708

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
