### PR TITLE
fix(meeting): functional walk-through follow-ups (test, privacy, search, indicator)

### DIFF
--- a/src/components/meeting/MeetingSettings.tsx
+++ b/src/components/meeting/MeetingSettings.tsx
@@ -200,7 +200,7 @@ export function MeetingSettings() {
 
       <section>
         <label class="flex items-center justify-between gap-3 cursor-pointer">
-          <FieldLabel hint="Recognized call apps (Zoom, Meet, Teams, Discord, …) auto-start recording after your one-time audio-permission acknowledgment. Other detected microphone activity only shows a titlebar prompt — you choose whether to record.">
+          <FieldLabel hint="Recognized call apps (Zoom, Meet, Teams, Discord, …) auto-start recording on active microphone input, after your one-time audio-permission acknowledgment. Other active microphone input only shows a titlebar prompt — you choose whether to record.">
             Auto-detect meetings
           </FieldLabel>
           <input

--- a/src/components/meeting/RecordingIndicator.tsx
+++ b/src/components/meeting/RecordingIndicator.tsx
@@ -105,6 +105,28 @@ export function RecordingIndicator() {
     };
   };
 
+  // Clamping otherwise only runs mid-drag, so a position restored at a smaller
+  // window size — or a window shrunk after dragging — could strand the pill
+  // off-screen (and the drag handle out of reach). Re-clamp on window resize and
+  // whenever the indicator becomes visible.
+  const onResize = () => {
+    const current = position();
+    if (current) setPosition(clampToViewport(current.x, current.y));
+  };
+  onMount(() => {
+    window.addEventListener("resize", onResize);
+    onCleanup(() => window.removeEventListener("resize", onResize));
+  });
+  createEffect(() => {
+    if (!active()) return;
+    const current = position();
+    if (!current || !containerRef) return;
+    const clamped = clampToViewport(current.x, current.y);
+    if (clamped.x !== current.x || clamped.y !== current.y) {
+      setPosition(clamped);
+    }
+  });
+
   const onDragStart = (event: PointerEvent) => {
     if (!containerRef) return;
     const rect = containerRef.getBoundingClientRect();

--- a/src/services/transcript-search.ts
+++ b/src/services/transcript-search.ts
@@ -155,19 +155,26 @@ export async function searchTranscripts(
     semanticUnavailable = true;
   }
 
-  // Semantic hits rank first; append exact hits not already covered.
-  const seen = new Set(
-    semantic.map((hit) => `${hit.meetingId}:${hit.seqStart}`),
-  );
-  const merged = [...semantic];
-  for (const hit of exact) {
-    const key = `${hit.meetingId}:${hit.seqStart}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      merged.push(hit);
-    }
+  // Merge semantic + exact, guaranteeing exact matches aren't truncated away
+  // when semantic saturates the limit (a literal email/name match must surface
+  // even with 20 fuzzy semantic hits). Reserve up to half the slots for exact
+  // hits, fill the rest with semantic, then top up from whichever side has more.
+  const key = (hit: TranscriptHit) => `${hit.meetingId}:${hit.seqStart}`;
+  const seen = new Set(semantic.map(key));
+  const exactUnique = exact.filter((hit) => !seen.has(key(hit)));
+  const reserve = Math.min(exactUnique.length, Math.floor(limit / 2));
+  const merged = [
+    ...semantic.slice(0, limit - reserve),
+    ...exactUnique.slice(0, reserve),
+  ];
+  for (const hit of [
+    ...semantic.slice(limit - reserve),
+    ...exactUnique.slice(reserve),
+  ]) {
+    if (merged.length >= limit) break;
+    merged.push(hit);
   }
-  return { hits: merged.slice(0, limit), semanticUnavailable };
+  return { hits: merged, semanticUnavailable };
 }
 
 /** Drop a meeting's transcript vectors (best-effort; called on delete). */

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -49,7 +49,6 @@ import { orchestrate } from "@/services/orchestrator";
 import {
   backfillTranscriptIndex,
   deleteMeetingIndex,
-  indexMeeting,
 } from "@/services/transcript-search";
 import { onTrayToggleCapture, setTrayRecording } from "@/services/tray";
 import { conversationStore } from "@/stores/conversation.store";
@@ -365,11 +364,12 @@ async function startMeetingEventListeners(): Promise<void> {
 
   statusUnlisten = await listen<Meeting>("meeting://status", (event) => {
     trackReadyTransition(event.payload);
-    // The transcript is finalized at transcript_ready — (re)index it now so the
-    // final content replaces any earlier partial chunks. index_meeting_transcript
-    // does an atomic delete-then-insert, so this is safe to call once per ready.
+    // The transcript is finalized at transcript_ready — index it now. Route
+    // through backfillTranscriptIndex so this shares the bounded retry budget;
+    // a transcript_ready that re-fires (notes-failure fallback, stale-reconcile)
+    // can't trigger unbounded paid re-embeds.
     if (event.payload.status === "transcript_ready") {
-      void indexMeeting(event.payload.id).catch(() => {});
+      void backfillTranscriptIndex([event.payload.id]);
     }
     setMeetingState("meetings", (meetings) => {
       const next = meetings.some((meeting) => meeting.id === event.payload.id)
@@ -1308,15 +1308,22 @@ async function stopByUser(meeting: Meeting): Promise<void> {
 // auto-restart so the same live call can't instantly re-record.
 async function stopAndDelete(meeting: Meeting): Promise<void> {
   if (!isTauriRuntime()) return;
+  // Claim the meeting in the processing guard *synchronously* (before any await)
+  // so a stopAndProcess that hasn't started yet — the lifecycle auto-stop, or a
+  // Stop click — sees the claim and no-ops, never transcribing or publishing the
+  // recording the user is discarding. If stopAndProcess already owns the claim
+  // we still delete (the user asked to); we just don't release its claim here.
+  const ownedByProcessing = processingMeetings.has(meeting.id);
+  processingMeetings.add(meeting.id);
   setMeetingState("error", null);
   await meetingLifecycleNoteManualStop().catch(() => {});
   lifecycleMeetingId = null;
   lifecycleEventEndMs = null;
-  // Stop the live capture first so no further frames land, then delete. We
-  // intentionally bypass stopAndProcess so the discarded audio is never
-  // transcribed or routed to the support pipeline.
-  await stopCapture(meeting.id).catch(() => {});
   try {
+    // Stop the live capture first so no further frames land, then delete. We
+    // intentionally bypass stopAndProcess so the discarded audio is never
+    // transcribed or routed to the support pipeline.
+    await stopCapture(meeting.id).catch(() => {});
     await deleteMeetingRecord(meeting.id);
     void deleteMeetingIndex(meeting.id);
     const remaining = meetingState.meetings.filter(
@@ -1335,6 +1342,8 @@ async function stopAndDelete(meeting: Meeting): Promise<void> {
       error instanceof Error ? error.message : "Failed to delete recording",
     );
     await loadMeetings();
+  } finally {
+    if (!ownedByProcessing) processingMeetings.delete(meeting.id);
   }
 }
 


### PR DESCRIPTION
Post-merge functional walk-through audit follow-ups (frontend).

- **FW-1 (#2718)**: honest-copy rewrite (#2710) dropped `active microphone input` that a regression test guards → `pnpm test` was red. Restored the phrase in the hint while keeping the honest auto-start wording.
- **FW-2 (#2719, privacy)**: `stopAndDelete` now claims the `processingMeetings` guard synchronously so a lifecycle/Stop-driven `stopAndProcess` no-ops and a discarded recording is never transcribed/published.
- **FW-3 (#2720)**: `searchTranscripts` reserves up to half the result slots for exact matches so they aren't truncated away when semantic saturates the limit.
- **FW-4 (#2721)**: the draggable indicator re-clamps on window resize and on becoming visible, so a restored/oversized position can't strand it off-screen.
- **FW-5 (#2722, cost)**: the `transcript_ready` listener routes through the capped `backfillTranscriptIndex` instead of `indexMeeting`, so a re-fired `transcript_ready` can't unbounded-embed.

Verification: biome clean; tsc clean for changed files; **pnpm test 2095 passed (0 failed)**; vite build OK.

Closes #2718
Closes #2719
Closes #2720
Closes #2721
Closes #2722

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com