### PR TITLE
fix(meeting): restore indicator pause state on capture reattach

### DIFF
--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -1045,6 +1045,16 @@ impl CaptureRegistry {
         }
     }
 
+    /// Whether the live capture for `meeting_id` is currently paused. `None` when
+    /// no active capture exists. The backend pause flag outlives a renderer
+    /// reload, so the indicator queries this on reattach to restore its state.
+    pub fn is_paused(&self, meeting_id: &str) -> Option<bool> {
+        match self.active.lock().unwrap().get(meeting_id) {
+            Some(CaptureSlot::Active(capture)) => Some(capture.stats.is_paused()),
+            _ => None,
+        }
+    }
+
     /// Whether the registry slot for `meeting_id` is taken (live or draining).
     /// This is the predicate `start` guards on, so a draining slot blocks a
     /// new capture for the same id until the drain completes.

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -660,6 +660,13 @@ pub fn is_meeting_capture_active(registry: State<'_, CaptureRegistry>, meeting_i
     registry.is_active(&meeting_id)
 }
 
+/// Whether the live capture for the meeting is currently paused. False when no
+/// active capture exists. Used on reattach to restore the indicator pause state.
+#[tauri::command]
+pub fn is_meeting_capture_paused(registry: State<'_, CaptureRegistry>, meeting_id: String) -> bool {
+    registry.is_paused(&meeting_id).unwrap_or(false)
+}
+
 /// Pause a live capture: workers drop frames (no segments) without ending the
 /// session. Returns false when no active capture exists for the meeting.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -932,6 +932,7 @@ pub fn run() {
             // Meeting Mode capture + intelligence commands
             commands::audio::start_meeting_capture,
             commands::audio::is_meeting_capture_active,
+            commands::audio::is_meeting_capture_paused,
             commands::audio::pause_meeting_capture,
             commands::audio::resume_meeting_capture,
             commands::audio::stop_meeting_capture,

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -209,6 +209,10 @@ export function isMeetingCaptureActive(meetingId: string): Promise<boolean> {
   return invoke("is_meeting_capture_active", { meetingId });
 }
 
+export function isMeetingCapturePaused(meetingId: string): Promise<boolean> {
+  return invoke("is_meeting_capture_paused", { meetingId });
+}
+
 export interface CaptureStopOutcome {
   hadCapture: boolean;
   nativeMicReady: boolean;

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -24,6 +24,7 @@ import {
   getMeetingTranscriptText,
   getTranscriptSegments,
   isMeetingCaptureActive,
+  isMeetingCapturePaused,
   listMeetings,
   listMeetingTemplates,
   type Meeting,
@@ -684,6 +685,16 @@ async function reconcileStaleCaptures(): Promise<void> {
         if (active) {
           void setTrayRecording(true);
           reattached = true;
+          // The backend pause flag survives a renderer reload but the store's
+          // pause fields reset to defaults, so the indicator would show a live
+          // "Rec" with a running timer while the backend is actually paused.
+          // Restore pause state from the backend on reattach.
+          const backendPaused = await isMeetingCapturePaused(meeting.id).catch(
+            () => false,
+          );
+          setMeetingState("capturePaused", backendPaused);
+          setMeetingState("capturePausedAt", backendPaused ? Date.now() : null);
+          setMeetingState("capturePausedAccumMs", 0);
           if (!meetingState.activeMeeting) {
             await setActiveMeeting(meeting);
           }


### PR DESCRIPTION
FW-6 (#2723): the backend pause flag lives in an AtomicBool on the in-process CaptureRegistry and survives a webview/renderer reload, but the store pause fields reset to defaults. After a renderer reload while paused, the indicator showed a live red dot + "Rec" with a running timer while the backend was actually paused and dropping frames.

- Adds `CaptureRegistry::is_paused` (mirrors `is_active`) exposed via the `is_meeting_capture_paused` command + `isMeetingCapturePaused` service.
- `reconcileStaleCaptures` restores `capturePaused`/`capturePausedAt` from the backend when reattaching a live capture.

Verification: cargo check OK; biome clean; tsc clean for changed files; pnpm test green; vite build OK.

Closes #2723

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com