### PR TITLE
Fix transcript semantic search embedding publisher

### DIFF
--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1886,8 +1886,8 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
               Semantic Code Indexing
             </h3>
             <p class="m-0 mb-6 text-muted-foreground leading-normal">
-              Enable semantic search across your codebase. Powered by
-              SerenEmbed.
+              Enable semantic search across your codebase. Powered by OpenAI
+              Embeddings.
             </p>
 
             <div class="flex items-start justify-start gap-4 py-3 border-b border-border">
@@ -1909,8 +1909,9 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                   </span>
                   <span class="text-[0.8rem] text-muted-foreground">
                     Index your codebase for AI-powered semantic code search.
-                    Embeddings are generated via SerenEmbed (paid via
-                    SerenBucks) and stored locally for instant retrieval.
+                    Embeddings are generated via the OpenAI Embeddings publisher
+                    (charged through Seren Gateway) and stored locally for
+                    instant retrieval.
                   </span>
                 </span>
               </label>
@@ -1923,7 +1924,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
               <ul class="m-0 pl-4 text-[0.8rem] text-muted-foreground space-y-2">
                 <li>Your code is chunked at function/class boundaries</li>
                 <li>
-                  SerenEmbed generates embeddings (charged via SerenBucks)
+                  OpenAI Embeddings generates vectors through Seren Gateway
                 </li>
                 <li>
                   Embeddings are stored locally in sqlite-vec for instant search

--- a/src/lib/indexing/orchestrator.ts
+++ b/src/lib/indexing/orchestrator.ts
@@ -104,7 +104,7 @@ export async function runIndexing(
         const batch = chunked.chunks.slice(j, j + BATCH_SIZE);
         const texts = batch.map((c: { content: string }) => c.content);
 
-        // Generate embeddings via SerenEmbed
+        // Generate embeddings via the shared publisher client.
         const embeddingResponse = await embedTexts(texts);
         totalTokens += embeddingResponse.usage.total_tokens;
 
@@ -204,7 +204,7 @@ export async function reindexFile(
       return;
     }
 
-    // Generate embeddings
+    // Generate embeddings via the shared publisher client.
     const texts = chunked.chunks.map((c: FileChunk) => c.content);
     const embeddingResponse = await embedTexts(texts);
 

--- a/src/services/indexing.ts
+++ b/src/services/indexing.ts
@@ -171,7 +171,7 @@ export async function deleteFileIndex(
 
 /**
  * Index a batch of code chunks.
- * Generates embeddings via SerenEmbed and stores in local vector db.
+ * Generates embeddings via the embedding publisher and stores in local vector db.
  */
 export async function indexChunks(
   projectPath: string,

--- a/src/services/seren-embed.ts
+++ b/src/services/seren-embed.ts
@@ -1,4 +1,4 @@
-// ABOUTME: SerenEmbed API client for generating text embeddings.
+// ABOUTME: Publisher API client for generating text embeddings.
 // ABOUTME: Uses SerenBucks via /publishers endpoint for paid embedding generation.
 
 import { apiBase } from "@/lib/config";
@@ -7,7 +7,7 @@ import { publisherStatus, unwrapPublisherBody } from "@/lib/publisher-response";
 import { shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 import { getToken } from "@/services/auth";
 
-const PUBLISHER_SLUG = "seren-embed";
+const PUBLISHER_SLUG = "openai-embeddings";
 
 /** Default model for embeddings */
 const DEFAULT_MODEL = "text-embedding-3-small";
@@ -38,7 +38,7 @@ interface EmbeddingResponse {
 
 /**
  * Generate embeddings for a single text string.
- * Uses SerenEmbed publisher via Seren Gateway.
+ * Uses the direct OpenAI Embeddings publisher via Seren Gateway.
  */
 export async function embedText(
   text: string,
@@ -81,14 +81,16 @@ export async function embedTexts(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`SerenEmbed API error: ${response.status} - ${errorText}`);
+    throw new Error(
+      `Embedding publisher API error: ${response.status} - ${errorText}`,
+    );
   }
 
   const result = await response.json();
 
   const status = publisherStatus(result);
   if (status && status !== 200) {
-    throw new Error(`SerenEmbed upstream error: ${status}`);
+    throw new Error(`Embedding publisher upstream error: ${status}`);
   }
 
   return unwrapPublisherBody<EmbeddingResponse>(result) as EmbeddingResponse;

--- a/src/services/transcript-search.ts
+++ b/src/services/transcript-search.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Semantic transcript search — chunk, embed, index, and query meeting transcripts.
-// ABOUTME: Embeddings come from seren-embed; vectors are stored locally via Tauri commands.
+// ABOUTME: Embeddings come from the shared publisher client; vectors are stored locally via Tauri commands.
 
 import { invoke } from "@tauri-apps/api/core";
 import {
@@ -85,8 +85,9 @@ export function chunkTranscript(
 }
 
 /**
- * (Re)index one meeting's transcript: chunk it, embed the chunks via seren-embed,
- * and replace the meeting's stored vectors. Returns the number of chunks indexed.
+ * (Re)index one meeting's transcript: chunk it, embed the chunks via the
+ * embedding publisher, and replace the meeting's stored vectors. Returns the
+ * number of chunks indexed.
  */
 const indexing = new Set<string>();
 
@@ -151,7 +152,7 @@ export async function searchTranscripts(
       limit,
     });
   } catch {
-    // Offline / unauthenticated / out of balance / seren-embed down.
+    // Offline / unauthenticated / out of balance / embedding publisher down.
     semanticUnavailable = true;
   }
 
@@ -185,7 +186,7 @@ export async function deleteMeetingIndex(meetingId: string): Promise<void> {
 }
 
 // Per-meeting failed-attempt counter so a meeting that embeds (a paid
-// seren-embed call) but then fails to persist isn't re-embedded on every
+// publisher call) but then fails to persist isn't re-embedded on every
 // loadMeetings(). Bounded retries cap the wasted spend; resets on app restart.
 const MAX_BACKFILL_ATTEMPTS = 3;
 const backfillAttempts = new Map<string, number>();

--- a/tests/unit/seren-embed.test.ts
+++ b/tests/unit/seren-embed.test.ts
@@ -1,0 +1,70 @@
+// ABOUTME: Critical endpoint-contract coverage for the shared semantic search embedding client.
+// ABOUTME: Guards transcript/code search from drifting back to the SerenEmbed pipeline publisher.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  appFetch: vi.fn<typeof globalThis.fetch>(),
+  shouldUseRustGatewayAuth: vi.fn<(input: RequestInfo | URL) => boolean>(),
+  getToken: vi.fn<() => Promise<string | null>>(),
+}));
+
+vi.mock("@/lib/fetch", () => ({
+  appFetch: mocks.appFetch,
+}));
+
+vi.mock("@/lib/tauri-fetch", () => ({
+  shouldUseRustGatewayAuth: mocks.shouldUseRustGatewayAuth,
+}));
+
+vi.mock("@/services/auth", () => ({
+  getToken: mocks.getToken,
+}));
+
+describe("seren embedding client", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.shouldUseRustGatewayAuth.mockReturnValue(false);
+    mocks.getToken.mockResolvedValue("access-token");
+  });
+
+  it("calls the direct OpenAI embeddings publisher and unwraps gateway envelopes", async () => {
+    const embedding = Array.from({ length: 1536 }, (_, index) => index / 1536);
+    mocks.appFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            status: 200,
+            body: {
+              object: "list",
+              data: [{ object: "embedding", embedding, index: 0 }],
+              model: "text-embedding-3-small",
+              usage: { prompt_tokens: 1, total_tokens: 1 },
+            },
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const { embedTexts } = await import("@/services/seren-embed");
+    const result = await embedTexts(["reconciliation"]);
+
+    expect(mocks.appFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mocks.appFetch.mock.calls[0] ?? [];
+    expect(url).toBe(
+      "https://api.serendb.com/publishers/openai-embeddings/embeddings",
+    );
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer access-token",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      input: ["reconciliation"],
+      model: "text-embedding-3-small",
+    });
+    expect(result.data[0].embedding).toEqual(embedding);
+  });
+});


### PR DESCRIPTION
Fixes #2728

## Summary
- route the shared embedding client to the live direct `openai-embeddings` publisher at `/embeddings`
- keep publisher gateway envelope unwrapping intact for embedding responses
- update semantic indexing copy/comments that still named the old SerenEmbed pipeline service
- add a focused regression test for the publisher slug/path and envelope unwrap

## Verification
- `pnpm test tests/unit/seren-embed.test.ts`
- `pnpm test tests/unit/transcript-chunk.test.ts tests/unit/seren-embed.test.ts`
- `pnpm exec biome check src/services/seren-embed.ts src/services/transcript-search.ts src/services/indexing.ts src/lib/indexing/orchestrator.ts src/components/settings/SettingsPanel.tsx`
- `git diff --check`

## Audit
- Live publisher metadata shows `seren-embed` exposes pipeline job endpoints, not synchronous `POST /embeddings`.
- Live publisher call to `seren-embed /embeddings` returned `404`.
- Live publisher call to `openai-embeddings /embeddings` returned a valid `text-embedding-3-small` embedding.
- Transcript search and code semantic search both use `src/services/seren-embed.ts`, so the fix restores both Mac and Windows frontend paths.