### PR TITLE
Explain transcript semantic search fallback

### DIFF
--- a/src/components/meeting/TranscriptSearch.tsx
+++ b/src/components/meeting/TranscriptSearch.tsx
@@ -14,6 +14,8 @@ export function TranscriptSearch() {
   const [searching, setSearching] = createSignal(false);
   const [searched, setSearched] = createSignal(false);
   const [semanticUnavailable, setSemanticUnavailable] = createSignal(false);
+  const [semanticUnavailableReason, setSemanticUnavailableReason] =
+    createSignal<string | null>(null);
   let inputRef: HTMLInputElement | undefined;
 
   // The global "Search transcripts" shortcut opens this panel and asks the input
@@ -32,12 +34,15 @@ export function TranscriptSearch() {
     if (!trimmed) {
       setHits([]);
       setSearched(false);
+      setSemanticUnavailable(false);
+      setSemanticUnavailableReason(null);
       return;
     }
     setSearching(true);
     const result = await searchTranscripts(trimmed, 20);
     setHits(result.hits);
     setSemanticUnavailable(result.semanticUnavailable);
+    setSemanticUnavailableReason(result.semanticUnavailableReason ?? null);
     setSearching(false);
     setSearched(true);
   };
@@ -81,7 +86,9 @@ export function TranscriptSearch() {
       <Show when={searched() && !searching()}>
         <Show when={semanticUnavailable()}>
           <div class="mt-2 text-[11px] text-warning">
-            Semantic search unavailable — showing exact matches.
+            {semanticUnavailableReason()
+              ? `Semantic search unavailable: ${semanticUnavailableReason()} — showing exact matches.`
+              : "Semantic search unavailable — showing exact matches."}
           </div>
         </Show>
         <Show

--- a/src/services/transcript-search.ts
+++ b/src/services/transcript-search.ts
@@ -122,6 +122,46 @@ export interface TranscriptSearchResult {
   /** True when semantic search failed (offline/unauthenticated/embed down) and
    *  only the local exact-match results are shown. */
   semanticUnavailable: boolean;
+  semanticUnavailableReason?: string;
+}
+
+function describeSemanticSearchFailure(error: unknown): string {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  const lower = message.toLowerCase();
+
+  if (
+    lower.includes("not authenticated") ||
+    lower.includes("unauthorized") ||
+    lower.includes("401")
+  ) {
+    return "sign in is required";
+  }
+  if (
+    lower.includes("402") ||
+    lower.includes("balance") ||
+    lower.includes("payment") ||
+    lower.includes("out of balance") ||
+    lower.includes("insufficient")
+  ) {
+    return "embedding publisher needs payment or balance";
+  }
+  if (lower.includes("404") || lower.includes("not found")) {
+    return "embedding endpoint was not found";
+  }
+  if (
+    lower.includes("timeout") ||
+    lower.includes("network") ||
+    lower.includes("failed to fetch")
+  ) {
+    return "could not reach the embedding publisher";
+  }
+
+  return "embedding request failed";
 }
 
 /**
@@ -145,15 +185,17 @@ export async function searchTranscripts(
 
   let semantic: TranscriptHit[] = [];
   let semanticUnavailable = false;
+  let semanticUnavailableReason: string | undefined;
   try {
     const queryEmbedding = await embedText(trimmed);
     semantic = await invoke<TranscriptHit[]>("search_transcripts", {
       queryEmbedding,
       limit,
     });
-  } catch {
+  } catch (error) {
     // Offline / unauthenticated / out of balance / embedding publisher down.
     semanticUnavailable = true;
+    semanticUnavailableReason = describeSemanticSearchFailure(error);
   }
 
   // Merge semantic + exact, guaranteeing exact matches aren't truncated away
@@ -175,7 +217,7 @@ export async function searchTranscripts(
     if (merged.length >= limit) break;
     merged.push(hit);
   }
-  return { hits: merged, semanticUnavailable };
+  return { hits: merged, semanticUnavailable, semanticUnavailableReason };
 }
 
 /** Drop a meeting's transcript vectors (best-effort; called on delete). */

--- a/tests/unit/transcript-search-fallback.test.ts
+++ b/tests/unit/transcript-search-fallback.test.ts
@@ -1,0 +1,54 @@
+// ABOUTME: Critical fallback coverage for transcript semantic search failures.
+// ABOUTME: Ensures exact matches remain visible while the UI gets an actionable reason.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  embedText: vi.fn<(text: string) => Promise<number[]>>(),
+  embedTexts: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@/services/seren-embed", () => ({
+  embedText: mocks.embedText,
+  embedTexts: mocks.embedTexts,
+}));
+
+describe("searchTranscripts fallback reason", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("keeps exact matches and returns a concise reason when semantic embedding fails", async () => {
+    const exactHit = {
+      meetingId: "meeting-1",
+      seqStart: 1,
+      seqEnd: 2,
+      text: "Me: reconciliation plan",
+      distance: 0,
+    };
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "search_transcripts_like") {
+        return Promise.resolve([exactHit]);
+      }
+      throw new Error(`unexpected invoke: ${command}`);
+    });
+    mocks.embedText.mockRejectedValue(
+      new Error("Embedding publisher upstream error: 402"),
+    );
+
+    const { searchTranscripts } = await import("@/services/transcript-search");
+    const result = await searchTranscripts("reconciliation", 20);
+
+    expect(result.hits).toEqual([exactHit]);
+    expect(result.semanticUnavailable).toBe(true);
+    expect(result.semanticUnavailableReason).toBe(
+      "embedding publisher needs payment or balance",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2730

## Summary
- return a concise semantic fallback reason from `searchTranscripts()`
- keep exact-match fallback behavior unchanged
- render the reason in the transcript search warning when available
- add focused fallback coverage for payment/balance-style embedding failures

## Verification
- `pnpm test tests/unit/transcript-search-fallback.test.ts tests/unit/transcript-chunk.test.ts tests/unit/seren-embed.test.ts`
- `pnpm exec biome check src/services/transcript-search.ts src/components/meeting/TranscriptSearch.tsx`
- `git diff --check`

## Audit
- Exact search still runs before semantic embedding, so offline fallback remains available.
- Mac and Windows Tauri users share the same frontend service path and Rust gateway bridge; this fix is platform-neutral.
- The UI no longer collapses all semantic failures into a reasonless message.