### PR TITLE
chore: make `pnpm check` green (closes #2727)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
       "**/vite.config.ts",
       "!**/.worktrees/**/*",
       "!**/src/api/generated/**/*",
-      "!**/src-tauri/target/**/*"
+      "!**/src-tauri/target/**/*",
+      "!**/mcp-servers/**"
     ]
   },
   "formatter": {

--- a/src/lib/employees/import.ts
+++ b/src/lib/employees/import.ts
@@ -32,10 +32,15 @@ export function normalizeResourcePath(path: string): string | null {
     const trimmed = part.trim();
     if (!trimmed || trimmed === ".") continue;
     if (trimmed === "..") return null;
-    if (trimmed.startsWith(".") && !(index === 0 && trimmed.toLowerCase() === ".skills")) {
+    if (
+      trimmed.startsWith(".") &&
+      !(index === 0 && trimmed.toLowerCase() === ".skills")
+    ) {
       return null;
     }
-    parts.push(index === 0 && trimmed.toLowerCase() === ".skills" ? ".skills" : trimmed);
+    parts.push(
+      index === 0 && trimmed.toLowerCase() === ".skills" ? ".skills" : trimmed,
+    );
   }
 
   return parts.length > 0 ? parts.join("/") : null;


### PR DESCRIPTION
Closes #2727.

## What

`pnpm check` (`biome check`) exited **1** with **5 errors** + 48 warnings. The 5 errors were all in the `format` / `assist/source/organizeImports` category (not lint rules) and pre-existing — none in any recent release diff.

| File | Rule | Fix |
| ---- | ---- | --- |
| `mcp-servers/playwright-stealth/src/index.ts` | `format` | excluded (vendored) |
| `mcp-servers/playwright-stealth/src/tools.ts` | `organizeImports` | excluded (vendored) |
| `src-tauri/mcp-servers/playwright-stealth/src/index.ts` | `format` | excluded (gitignored staged copy) |
| `src-tauri/mcp-servers/playwright-stealth/src/tools.ts` | `organizeImports` | excluded (gitignored staged copy) |
| `src/lib/employees/import.ts` | `format` | wrapped two over-width lines |

## How

- **`biome.json`** — add `!**/mcp-servers/**` to `files.includes`. `mcp-servers/` holds only vendored MCP servers (currently just `playwright-stealth`); our Biome config shouldn't format/organize third-party code. One pattern covers both the tracked root copy and the gitignored `src-tauri/mcp-servers/` staged copy (and any future vendored servers).
- **`src/lib/employees/import.ts`** — our own code; applied Biome's line-wrapping for two over-width statements. Pure formatting, no behavior change.

## Verification

Ran the repo's Biome binary against the worktree (including a faithful reproduction of the gitignored `src-tauri/mcp-servers/` staged copy):

```
biome check → exit 0   (was: 5 errors, exit 1)
Found 49 warnings.      (non-fatal; biome check has no --error-on-warnings)
```

The `noNonNullAssertion` / `useOptionalChain` **warnings** are intentionally left as-is — they don't affect exit code and are out of scope for "make check green."

## Not done (deliberate)

The issue suggests *optionally* swapping `pnpm lint` → `pnpm check` in CI (`.github/workflows/ci.yml`). Leaving that as a separate decision — it's a CI gate change, not a hygiene fix. `pnpm lint` (the current gate) was already green and is unchanged by this PR.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
