### PR TITLE
feat: polish transcript search filters

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -559,6 +559,11 @@ export const AppShell: Component<AppShellProps> = (props) => {
     }
   }) as EventListener;
 
+  const handleSearchTranscripts = ((e: CustomEvent) => {
+    setSlidePanel("meetings");
+    meetingStore.requestSearchFocus(String(e.detail ?? ""));
+  }) as EventListener;
+
   const workspaceKeybindingMatcher = createKeybindingMatcher(
     WORKSPACE_KEYBINDING_ACTIONS,
     () => ({
@@ -796,6 +801,10 @@ export const AppShell: Component<AppShellProps> = (props) => {
     meetingStore.startAutoDetect();
 
     window.addEventListener("seren:open-panel", handleOpenPanel);
+    window.addEventListener(
+      "seren:search-transcripts",
+      handleSearchTranscripts,
+    );
     window.addEventListener("seren:open-settings", handleOpenSettings);
     document.addEventListener("focusin", handleFocusIn);
     // Capture phase so descendants calling stopPropagation (Monaco)
@@ -837,6 +846,10 @@ export const AppShell: Component<AppShellProps> = (props) => {
     meetingStore.stopMeetingEventListeners();
     meetingStore.stopAutoDetect();
     window.removeEventListener("seren:open-panel", handleOpenPanel);
+    window.removeEventListener(
+      "seren:search-transcripts",
+      handleSearchTranscripts,
+    );
     window.removeEventListener("seren:open-settings", handleOpenSettings);
     document.removeEventListener("focusin", handleFocusIn);
     window.removeEventListener("keydown", handleKeyDown, true);

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -14,6 +14,7 @@ import {
   formatDuration,
   formatMeetingDate,
   formatTime,
+  formatTranscriptSpeakerLabel,
   isMeetingDurationLive,
   isMeetingProcessingStatus,
   isMeetingReadyStatus,
@@ -598,19 +599,19 @@ export function MeetingDetail(props: MeetingDetailProps) {
               {(segment) => (
                 <div
                   ref={(el) => rows.set(segment.seq, el)}
-                  class="grid grid-cols-[64px_minmax(0,1fr)] gap-3 py-2 border-b border-border/50 last:border-b-0 transition-colors"
+                  class="grid grid-cols-[112px_minmax(0,1fr)] gap-3 py-2 border-b border-border/50 last:border-b-0 transition-colors"
                   classList={{
                     "bg-primary/10": highlightedSeq() === segment.seq,
                   }}
                 >
                   <div
-                    class="text-[11px] font-mono tabular-nums"
+                    class="truncate text-[11px] font-mono tabular-nums"
                     classList={{
                       "text-foreground": segment.speaker === "me",
                       "text-muted-foreground": segment.speaker === "them",
                     }}
                   >
-                    {segment.speaker === "me" ? "Me" : "Them"}
+                    {formatTranscriptSpeakerLabel(segment)}
                   </div>
                   <div
                     class="min-w-0 break-words text-[13px] leading-5"

--- a/src/components/meeting/TranscriptSearch.tsx
+++ b/src/components/meeting/TranscriptSearch.tsx
@@ -1,15 +1,46 @@
 // ABOUTME: Semantic search field over meeting transcripts with jump-to-meeting results.
 // ABOUTME: Calls the transcript-search service; clicking a hit opens its meeting.
 
-import { createEffect, createSignal, For, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import { formatMeetingDate, formatTime } from "@/lib/meeting-format";
 import {
   searchTranscripts,
   type TranscriptHit,
 } from "@/services/transcript-search";
 import { meetingStore } from "@/stores/meeting.store";
 
+function dayStartMs(value: string): number | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(`${value}T00:00:00`);
+  const time = parsed.getTime();
+  return Number.isFinite(time) ? time : undefined;
+}
+
+function dayEndMs(value: string): number | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(`${value}T23:59:59.999`);
+  const time = parsed.getTime();
+  return Number.isFinite(time) ? time : undefined;
+}
+
+function attendeesFor(json: string | null | undefined): string[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
 export function TranscriptSearch() {
   const [query, setQuery] = createSignal("");
+  const [speaker, setSpeaker] = createSignal<"all" | "me" | "them">("all");
+  const [fromDate, setFromDate] = createSignal("");
+  const [toDate, setToDate] = createSignal("");
+  const [attendee, setAttendee] = createSignal("");
   const [hits, setHits] = createSignal<TranscriptHit[]>([]);
   const [searching, setSearching] = createSignal(false);
   const [searched, setSearched] = createSignal(false);
@@ -18,19 +49,22 @@ export function TranscriptSearch() {
     createSignal<string | null>(null);
   let inputRef: HTMLInputElement | undefined;
 
-  // The global "Search transcripts" shortcut opens this panel and asks the input
-  // to focus. Consume the request whether the panel was already open (this effect
-  // re-runs) or just mounted (it runs once with the flag already set), then clear
-  // it so reopening the panel later never steals focus.
-  createEffect(() => {
-    if (meetingStore.state.pendingSearchFocus) {
-      inputRef?.focus();
-      meetingStore.clearSearchFocus();
+  const knownAttendees = createMemo(() => {
+    const values = new Set<string>();
+    for (const meeting of meetingStore.state.meetings) {
+      for (const item of attendeesFor(meeting.attendeesJson)) {
+        const trimmed = item.trim();
+        if (trimmed) values.add(trimmed);
+      }
     }
+    return [...values].sort((left, right) => left.localeCompare(right));
   });
 
-  const run = async () => {
-    const trimmed = query().trim();
+  const hasFilters = () =>
+    Boolean(speaker() !== "all" || fromDate() || toDate() || attendee().trim());
+
+  const run = async (nextQuery = query()) => {
+    const trimmed = nextQuery.trim();
     if (!trimmed) {
       setHits([]);
       setSearched(false);
@@ -39,7 +73,16 @@ export function TranscriptSearch() {
       return;
     }
     setSearching(true);
-    const result = await searchTranscripts(trimmed, 20);
+    const result = await searchTranscripts(trimmed, {
+      limit: 20,
+      meetings: meetingStore.state.meetings,
+      filters: {
+        speaker: speaker(),
+        startedAfterMs: dayStartMs(fromDate()),
+        startedBeforeMs: dayEndMs(toDate()),
+        attendee: attendee(),
+      },
+    });
     setHits(result.hits);
     setSemanticUnavailable(result.semanticUnavailable);
     setSemanticUnavailableReason(result.semanticUnavailableReason ?? null);
@@ -47,9 +90,35 @@ export function TranscriptSearch() {
     setSearched(true);
   };
 
+  // The global shortcut and `/transcripts` slash command open this panel and
+  // ask the input to focus. A slash command can also provide the initial query.
+  createEffect(() => {
+    const pendingQuery = meetingStore.state.pendingSearchQuery;
+    if (meetingStore.state.pendingSearchFocus) {
+      inputRef?.focus();
+      meetingStore.clearSearchFocus();
+    }
+    if (pendingQuery !== null) {
+      setQuery(pendingQuery);
+      meetingStore.clearSearchQuery();
+      if (pendingQuery.trim()) {
+        queueMicrotask(() => void run(pendingQuery));
+      }
+    }
+  });
+
+  const meetingFor = (meetingId: string) =>
+    meetingStore.state.meetings.find((meeting) => meeting.id === meetingId);
+
   const meetingTitleFor = (meetingId: string) =>
-    meetingStore.state.meetings.find((meeting) => meeting.id === meetingId)
-      ?.title ?? "Meeting";
+    meetingFor(meetingId)?.title ?? "Meeting";
+
+  const meetingDateFor = (meetingId: string) => {
+    const meeting = meetingFor(meetingId);
+    return meeting
+      ? `${formatMeetingDate(meeting.startedAt)} · ${formatTime(meeting.startedAt)}`
+      : "";
+  };
 
   const openHit = (hit: TranscriptHit) => {
     const meeting = meetingStore.state.meetings.find(
@@ -77,6 +146,70 @@ export function TranscriptSearch() {
           placeholder="Search transcripts…"
           class="h-8 w-full rounded-md border border-border bg-surface-1 px-2.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:outline-none"
         />
+
+        <div class="mt-2 flex flex-wrap items-center gap-2">
+          <select
+            aria-label="Speaker"
+            value={speaker()}
+            onChange={(event) =>
+              setSpeaker(event.currentTarget.value as "all" | "me" | "them")
+            }
+            class="h-7 rounded-md border border-border bg-surface-1 px-2 text-[11px] text-foreground focus:border-primary/50 focus:outline-none"
+          >
+            <option value="all">Any speaker</option>
+            <option value="me">Me</option>
+            <option value="them">Them</option>
+          </select>
+          <input
+            type="date"
+            aria-label="From date"
+            value={fromDate()}
+            onInput={(event) => setFromDate(event.currentTarget.value)}
+            class="h-7 rounded-md border border-border bg-surface-1 px-2 text-[11px] text-foreground focus:border-primary/50 focus:outline-none"
+          />
+          <input
+            type="date"
+            aria-label="To date"
+            value={toDate()}
+            onInput={(event) => setToDate(event.currentTarget.value)}
+            class="h-7 rounded-md border border-border bg-surface-1 px-2 text-[11px] text-foreground focus:border-primary/50 focus:outline-none"
+          />
+          <input
+            type="search"
+            aria-label="Attendee"
+            value={attendee()}
+            list="transcript-search-attendees"
+            onInput={(event) => setAttendee(event.currentTarget.value)}
+            placeholder="Attendee"
+            class="h-7 min-w-[130px] flex-1 rounded-md border border-border bg-surface-1 px-2 text-[11px] text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:outline-none"
+          />
+          <datalist id="transcript-search-attendees">
+            <For each={knownAttendees()}>
+              {(item) => <option value={item} />}
+            </For>
+          </datalist>
+          <button
+            type="submit"
+            class="h-7 rounded-md border border-primary/40 bg-primary/10 px-2.5 text-[11px] text-primary transition-colors hover:bg-primary/15 disabled:opacity-60"
+            disabled={searching()}
+          >
+            Search
+          </button>
+          <Show when={hasFilters()}>
+            <button
+              type="button"
+              class="h-7 rounded-md border border-border bg-surface-1 px-2 text-[11px] text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground"
+              onClick={() => {
+                setSpeaker("all");
+                setFromDate("");
+                setToDate("");
+                setAttendee("");
+              }}
+            >
+              Clear
+            </button>
+          </Show>
+        </div>
       </form>
 
       <Show when={searching()}>
@@ -95,7 +228,7 @@ export function TranscriptSearch() {
           when={hits().length > 0}
           fallback={
             <div class="mt-2 text-[11px] text-muted-foreground">
-              No matches.
+              {hasFilters() ? "No matches for these filters." : "No matches."}
             </div>
           }
         >
@@ -107,10 +240,15 @@ export function TranscriptSearch() {
                   onClick={() => openHit(hit)}
                   class="rounded-md border border-border bg-surface-1 px-2.5 py-1.5 text-left transition-colors hover:bg-surface-2"
                 >
-                  <div class="truncate text-[11px] font-medium text-foreground">
-                    {meetingTitleFor(hit.meetingId)}
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="truncate text-[11px] font-medium text-foreground">
+                      {meetingTitleFor(hit.meetingId)}
+                    </div>
+                    <div class="shrink-0 text-[10px] text-muted-foreground">
+                      {meetingDateFor(hit.meetingId)}
+                    </div>
                   </div>
-                  <div class="line-clamp-2 whitespace-pre-line text-[11px] text-muted-foreground">
+                  <div class="mt-1 line-clamp-4 whitespace-pre-line text-[11px] leading-4 text-muted-foreground">
                     {hit.text}
                   </div>
                 </button>

--- a/src/lib/commands/registry.ts
+++ b/src/lib/commands/registry.ts
@@ -208,6 +208,22 @@ registry.register({
   },
 });
 
+registry.register({
+  name: "transcripts",
+  description: "Search meeting transcripts",
+  argHint: "<query>",
+  panels: ["chat", "agent"],
+  execute: (ctx) => {
+    ctx.openPanel("meetings");
+    window.dispatchEvent(
+      new CustomEvent("seren:search-transcripts", { detail: ctx.args }),
+    );
+    ctx.clearInput();
+    if (!ctx.args) ctx.showStatus("Transcript search opened.");
+    return true;
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Tier 3: Power User Commands
 // ---------------------------------------------------------------------------

--- a/src/lib/meeting-format.ts
+++ b/src/lib/meeting-format.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Shared display formatting for Meeting Mode surfaces.
 // ABOUTME: Time, duration, title, and status labels used by the panel and detail view.
 
-import type { Meeting } from "@/services/meetings";
+import type { Meeting, TranscriptSegment } from "@/services/meetings";
 
 export function formatTime(ms: number): string {
   return new Date(ms).toLocaleTimeString([], {
@@ -114,4 +114,28 @@ export function meetingReadyLabel(status: Meeting["status"]): string {
   return status === "transcript_ready"
     ? "Transcript ready to view"
     : "Notes ready to view";
+}
+
+function normalizeDiarizedLabel(label: string | null | undefined): string {
+  const trimmed = label?.trim();
+  if (!trimmed) return "";
+  if (/^(me|them)$/i.test(trimmed)) return "";
+
+  const readable = trimmed
+    .replace(/^speaker[_\s-]*/i, "")
+    .replace(/[_-]+/g, " ")
+    .trim();
+  if (!readable) return "";
+
+  if (/^speaker\s+/i.test(trimmed)) return `Speaker ${readable}`;
+  if (/^[a-z0-9]{1,3}$/i.test(readable)) return `Speaker ${readable}`;
+  return readable;
+}
+
+export function formatTranscriptSpeakerLabel(
+  segment: Pick<TranscriptSegment, "speaker" | "speakerLabel">,
+): string {
+  const channel = segment.speaker === "me" ? "Me" : "Them";
+  const diarized = normalizeDiarizedLabel(segment.speakerLabel);
+  return diarized ? `${channel} · ${diarized}` : channel;
 }

--- a/src/services/transcript-search.ts
+++ b/src/services/transcript-search.ts
@@ -2,8 +2,11 @@
 // ABOUTME: Embeddings come from the shared publisher client; vectors are stored locally via Tauri commands.
 
 import { invoke } from "@tauri-apps/api/core";
+import { formatTranscriptSpeakerLabel } from "@/lib/meeting-format";
 import {
   getTranscriptSegments,
+  type Meeting,
+  type Speaker,
   type TranscriptSegment,
 } from "@/services/meetings";
 import { embedText, embedTexts } from "@/services/seren-embed";
@@ -28,8 +31,92 @@ export interface TranscriptHit {
   distance: number;
 }
 
-function speakerLabel(speaker: TranscriptSegment["speaker"]): string {
-  return speaker === "me" ? "Me" : "Them";
+export interface TranscriptSearchFilters {
+  speaker?: Speaker | "all" | "";
+  startedAfterMs?: number | null;
+  startedBeforeMs?: number | null;
+  attendee?: string | null;
+}
+
+export interface TranscriptSearchOptions {
+  limit?: number;
+  filters?: TranscriptSearchFilters;
+  meetings?: readonly Meeting[];
+}
+
+function hasActiveFilters(filters: TranscriptSearchFilters | undefined) {
+  if (!filters) return false;
+  return Boolean(
+    (filters.speaker && filters.speaker !== "all") ||
+      filters.startedAfterMs != null ||
+      filters.startedBeforeMs != null ||
+      filters.attendee?.trim(),
+  );
+}
+
+function parseAttendees(meeting: Pick<Meeting, "attendeesJson">): string[] {
+  if (!meeting.attendeesJson) return [];
+  try {
+    const parsed = JSON.parse(meeting.attendeesJson) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalized(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function hitHasSpeaker(hit: TranscriptHit, speaker: Speaker): boolean {
+  const expected = speaker === "me" ? "me" : "them";
+  return hit.text
+    .split("\n")
+    .some((line) => normalized(line).startsWith(expected));
+}
+
+export function transcriptHitMatchesFilters(
+  hit: TranscriptHit,
+  filters: TranscriptSearchFilters | undefined,
+  meetings: readonly Meeting[] = [],
+): boolean {
+  if (!hasActiveFilters(filters)) return true;
+
+  if (filters?.speaker && filters.speaker !== "all") {
+    if (!hitHasSpeaker(hit, filters.speaker)) return false;
+  }
+
+  const needsMeeting =
+    filters?.startedAfterMs != null ||
+    filters?.startedBeforeMs != null ||
+    Boolean(filters?.attendee?.trim());
+  if (!needsMeeting) return true;
+
+  const meeting = meetings.find((item) => item.id === hit.meetingId);
+  if (!meeting) return false;
+
+  if (
+    filters?.startedAfterMs != null &&
+    meeting.startedAt < filters.startedAfterMs
+  ) {
+    return false;
+  }
+  if (
+    filters?.startedBeforeMs != null &&
+    meeting.startedAt > filters.startedBeforeMs
+  ) {
+    return false;
+  }
+
+  const attendee = normalized(filters?.attendee ?? "");
+  if (attendee) {
+    const attendees = parseAttendees(meeting).map(normalized);
+    if (!attendees.some((item) => item.includes(attendee))) return false;
+  }
+
+  return true;
 }
 
 /**
@@ -65,7 +152,7 @@ export function chunkTranscript(
       text: current
         .map(
           (segment) =>
-            `${speakerLabel(segment.speaker)}: ${segment.text.trim()}`,
+            `${formatTranscriptSpeakerLabel(segment)}: ${segment.text.trim()}`,
         )
         .join("\n"),
     });
@@ -173,14 +260,22 @@ function describeSemanticSearchFailure(error: unknown): string {
  */
 export async function searchTranscripts(
   query: string,
-  limit = 20,
+  limitOrOptions: number | TranscriptSearchOptions = 20,
 ): Promise<TranscriptSearchResult> {
   const trimmed = query.trim();
   if (!trimmed) return { hits: [], semanticUnavailable: false };
+  const options =
+    typeof limitOrOptions === "number"
+      ? { limit: limitOrOptions }
+      : limitOrOptions;
+  const limit = options.limit ?? 20;
+  const fetchLimit = hasActiveFilters(options.filters)
+    ? Math.max(limit * 5, 100)
+    : limit;
 
   const exact = await invoke<TranscriptHit[]>("search_transcripts_like", {
     query: trimmed,
-    limit,
+    limit: fetchLimit,
   }).catch(() => [] as TranscriptHit[]);
 
   let semantic: TranscriptHit[] = [];
@@ -190,7 +285,7 @@ export async function searchTranscripts(
     const queryEmbedding = await embedText(trimmed);
     semantic = await invoke<TranscriptHit[]>("search_transcripts", {
       queryEmbedding,
-      limit,
+      limit: fetchLimit,
     });
   } catch (error) {
     // Offline / unauthenticated / out of balance / embedding publisher down.
@@ -205,19 +300,24 @@ export async function searchTranscripts(
   const key = (hit: TranscriptHit) => `${hit.meetingId}:${hit.seqStart}`;
   const seen = new Set(semantic.map(key));
   const exactUnique = exact.filter((hit) => !seen.has(key(hit)));
-  const reserve = Math.min(exactUnique.length, Math.floor(limit / 2));
+  const reserve = Math.min(exactUnique.length, Math.floor(fetchLimit / 2));
   const merged = [
-    ...semantic.slice(0, limit - reserve),
+    ...semantic.slice(0, fetchLimit - reserve),
     ...exactUnique.slice(0, reserve),
   ];
   for (const hit of [
-    ...semantic.slice(limit - reserve),
+    ...semantic.slice(fetchLimit - reserve),
     ...exactUnique.slice(reserve),
   ]) {
-    if (merged.length >= limit) break;
+    if (merged.length >= fetchLimit) break;
     merged.push(hit);
   }
-  return { hits: merged, semanticUnavailable, semanticUnavailableReason };
+  const filtered = merged
+    .filter((hit) =>
+      transcriptHitMatchesFilters(hit, options.filters, options.meetings),
+    )
+    .slice(0, limit);
+  return { hits: filtered, semanticUnavailable, semanticUnavailableReason };
 }
 
 /** Drop a meeting's transcript vectors (best-effort; called on delete). */

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -103,6 +103,8 @@ interface MeetingState {
   searchScrollTarget: { meetingId: string; seq: number } | null;
   /** Set by the global search shortcut so TranscriptSearch focuses its input. */
   pendingSearchFocus: boolean;
+  /** Optional initial query supplied by command surfaces that open search. */
+  pendingSearchQuery: string | null;
 }
 
 const [meetingState, setMeetingState] = createStore<MeetingState>({
@@ -124,6 +126,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   reviewReadyMeetingId: null,
   searchScrollTarget: null,
   pendingSearchFocus: false,
+  pendingSearchQuery: null,
 });
 
 let transcriptUnlisten: UnlistenFn | null = null;
@@ -1371,12 +1374,19 @@ function clearSegmentScroll(): void {
 // The global search shortcut requests focus; TranscriptSearch consumes and
 // clears it once its input is focused (works whether the panel was already
 // open or is opening in the same gesture).
-function requestSearchFocus(): void {
+function requestSearchFocus(query?: string): void {
   setMeetingState("pendingSearchFocus", true);
+  if (query !== undefined) {
+    setMeetingState("pendingSearchQuery", query);
+  }
 }
 
 function clearSearchFocus(): void {
   setMeetingState("pendingSearchFocus", false);
+}
+
+function clearSearchQuery(): void {
+  setMeetingState("pendingSearchQuery", null);
 }
 
 export const meetingStore = {
@@ -1418,4 +1428,5 @@ export const meetingStore = {
   clearSegmentScroll,
   requestSearchFocus,
   clearSearchFocus,
+  clearSearchQuery,
 };

--- a/tests/unit/commands-parser-skills.test.ts
+++ b/tests/unit/commands-parser-skills.test.ts
@@ -190,6 +190,48 @@ describe("slash command palette ordering and fuzzy ranking", () => {
     expect(skillIdx).toBeLessThan(builtinIdx);
   });
 
+  it("exposes transcript search from the slash command palette", async () => {
+    const { getCompletions } = await import("@/lib/commands/parser");
+    const results = getCompletions("/trans", "chat");
+
+    expect(results.map((r) => r.name)).toContain("transcripts");
+  });
+
+  it("executes transcript search by opening meetings with the query", async () => {
+    const { parseCommand } = await import("@/lib/commands/parser");
+    const parsed = parseCommand("/transcripts budget review", "chat");
+    const openPanel = vi.fn();
+    const clearInput = vi.fn();
+    const showStatus = vi.fn();
+    const eventTarget = new EventTarget();
+    const listener = vi.fn();
+    vi.stubGlobal("window", eventTarget);
+    eventTarget.addEventListener("seren:search-transcripts", listener);
+
+    try {
+      const handled = await parsed?.command.execute({
+        rawInput: "/transcripts budget review",
+        args: parsed.args,
+        panel: "chat",
+        openPanel,
+        clearInput,
+        showStatus,
+      });
+
+      expect(handled).toBe(true);
+      expect(openPanel).toHaveBeenCalledWith("meetings");
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect((listener.mock.calls[0]?.[0] as CustomEvent).detail).toBe(
+        "budget review",
+      );
+      expect(clearInput).toHaveBeenCalledOnce();
+      expect(showStatus).not.toHaveBeenCalled();
+    } finally {
+      eventTarget.removeEventListener("seren:search-transcripts", listener);
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("does not let a skill shadow a built-in with the same name", async () => {
     mockSkillsService.listAllInstalled.mockResolvedValue([
       installedSkill("clear"),

--- a/tests/unit/transcript-chunk.test.ts
+++ b/tests/unit/transcript-chunk.test.ts
@@ -36,6 +36,17 @@ describe("chunkTranscript", () => {
     expect(chunks[0].text).toBe("Me: hello\nThem: again");
   });
 
+  it("keeps diarized speaker labels with the channel prefix", () => {
+    const chunks = chunkTranscript([
+      seg(0, "roadmap update", {
+        speaker: "them",
+        speakerLabel: "speaker_0",
+      }),
+    ]);
+
+    expect(chunks[0].text).toBe("Them · Speaker 0: roadmap update");
+  });
+
   it("splits into contiguous, non-overlapping chunks past the segment cap", () => {
     const many = Array.from({ length: 20 }, (_, index) =>
       seg(index, `turn ${index}`),

--- a/tests/unit/transcript-search-fallback.test.ts
+++ b/tests/unit/transcript-search-fallback.test.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Ensures exact matches remain visible while the UI gets an actionable reason.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Meeting } from "@/services/meetings";
 
 const mocks = vi.hoisted(() => ({
   invoke: vi.fn(),
@@ -50,5 +51,82 @@ describe("searchTranscripts fallback reason", () => {
     expect(result.semanticUnavailableReason).toBe(
       "embedding publisher needs payment or balance",
     );
+  });
+
+  it("widens retrieval and applies speaker, date, and attendee filters", async () => {
+    const jan10 = new Date("2026-01-10T12:00:00").getTime();
+    const exactHits = [
+      {
+        meetingId: "wrong-speaker",
+        seqStart: 1,
+        seqEnd: 1,
+        text: "Me: budget plan",
+        distance: 0,
+      },
+      {
+        meetingId: "match",
+        seqStart: 2,
+        seqEnd: 3,
+        text: "Them · Speaker A: budget plan\nMe: follow up",
+        distance: 0,
+      },
+      {
+        meetingId: "wrong-attendee",
+        seqStart: 4,
+        seqEnd: 5,
+        text: "Them: budget plan",
+        distance: 0,
+      },
+    ];
+    const meeting = (
+      id: string,
+      startedAt: number,
+      attendees: string[],
+    ): Meeting => ({
+      id,
+      title: id,
+      sourceApp: null,
+      startedAt,
+      endedAt: startedAt + 1,
+      status: "done",
+      templateId: null,
+      routedSkillSlug: null,
+      agentConversationId: null,
+      notesMarkdown: null,
+      notesStructJson: null,
+      attendeesJson: JSON.stringify(attendees),
+      createdAt: startedAt,
+      updatedAt: startedAt,
+    });
+
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "search_transcripts_like") {
+        return Promise.resolve(exactHits);
+      }
+      throw new Error(`unexpected invoke: ${command}`);
+    });
+    mocks.embedText.mockRejectedValue(new Error("network"));
+
+    const { searchTranscripts } = await import("@/services/transcript-search");
+    const result = await searchTranscripts("budget", {
+      limit: 2,
+      meetings: [
+        meeting("wrong-speaker", jan10, ["Ada Lovelace"]),
+        meeting("match", jan10, ["Ada Lovelace"]),
+        meeting("wrong-attendee", jan10, ["Grace Hopper"]),
+      ],
+      filters: {
+        speaker: "them",
+        startedAfterMs: new Date("2026-01-10T00:00:00").getTime(),
+        startedBeforeMs: new Date("2026-01-10T23:59:59.999").getTime(),
+        attendee: "ada",
+      },
+    });
+
+    expect(mocks.invoke).toHaveBeenCalledWith("search_transcripts_like", {
+      query: "budget",
+      limit: 100,
+    });
+    expect(result.hits).toEqual([exactHits[1]]);
   });
 });


### PR DESCRIPTION
Closes #2734

## Summary
- Adds speaker, date-range, and attendee filters to transcript search while preserving diarized speaker labels in snippets and meeting detail.
- Adds a `/transcripts <query>` command path that opens the Meetings transcript search flow with the query.
- Keeps result selection on the existing open-meeting and jump-to-segment path.

## Network Contract Audit
- UI path: `TranscriptSearch.run()` -> `searchTranscripts()` -> `embedText()` -> `appFetch()`.
- Outbound path: slug `openai-embeddings`, method `POST`, gateway path `/publishers/openai-embeddings/embeddings`, upstream publisher endpoint `POST /embeddings`; local vector search then uses Tauri IPC `search_transcripts`.
- Live Seren publisher verified active/authenticated for `openai-embeddings` with endpoint `POST /embeddings`.
- `tests/unit/seren-embed.test.ts` pins the production URL, method, auth header, and `text-embedding-3-small` request body.

## Verification
- `pnpm test`
- `pnpm check` (passes with existing warnings)
- `pnpm build` (passes with existing build warnings)
- Browser-local walkthrough reached logged-out/no-Tauri state, so authenticated meeting-panel UI could not be visually asserted there.
- Windows helper script was checked earlier and enforces Windows-only execution on this macOS host.