### PR TITLE
fix(bounties): pause join while verifier is failing

### DIFF
--- a/src/components/bounties/BountyDetail.tsx
+++ b/src/components/bounties/BountyDetail.tsx
@@ -355,6 +355,12 @@ function statusTone(status: string): string {
   return "bg-muted-foreground/15 text-muted-foreground border-border";
 }
 
+function isVerifierDegraded(bounty: BountyView): boolean {
+  return (
+    bounty.health_status !== "healthy" || bounty.verifier_failure_count > 0
+  );
+}
+
 function earningStatusTone(status: string): string {
   if (status === "paid")
     return "bg-emerald-500/10 text-emerald-700 border-emerald-600/25 dark:bg-emerald-500/15 dark:text-emerald-300 dark:border-emerald-500/30";
@@ -629,13 +635,26 @@ export const BountyDetail: Component<BountyDetailProps> = (props) => {
     return "Bounty unavailable.";
   });
 
-  const canJoinBounty = createMemo(() => {
+  const showJoinBounty = createMemo(() => {
     const b = bounty();
     if (!b) return false;
     // Joining only makes sense on bounties that can actually pay out.
     // Funding/draft are pre-open; exhausted/expired/cancelled are dead.
     return b.status === "open";
   });
+
+  const joinDisabledReason = createMemo(() => {
+    const b = bounty();
+    if (!b || !showJoinBounty()) return null;
+    if (isVerifierDegraded(b)) {
+      return "Bounty verifier is currently failing; joining is paused until it recovers.";
+    }
+    return null;
+  });
+
+  const canJoinBounty = createMemo(
+    () => showJoinBounty() && !joinDisabledReason(),
+  );
 
   const [joining, setJoining] = createSignal(false);
   const [joinError, setJoinError] = createSignal<string | null>(null);
@@ -734,7 +753,7 @@ export const BountyDetail: Component<BountyDetailProps> = (props) => {
 
   const handleJoinBounty = async () => {
     const b = bounty();
-    if (!b || joining()) return;
+    if (!b || joining() || !canJoinBounty()) return;
     setJoining(true);
     setJoinError(null);
     try {
@@ -885,22 +904,35 @@ export const BountyDetail: Component<BountyDetailProps> = (props) => {
             )}
           </Show>
         </div>
-        <Show when={canJoinBounty()}>
+        <Show when={showJoinBounty()}>
           <button
             type="button"
             class="group inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary/15 border border-primary/40 text-primary text-[13px] font-medium hover:bg-primary/25 hover:border-primary/60 active:bg-primary/30 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background"
             onClick={handleJoinBounty}
-            disabled={joining()}
+            disabled={joining() || !canJoinBounty()}
             aria-busy={joining()}
-            title="Join this bounty and open a chat seeded with its context"
+            title={
+              joinDisabledReason() ??
+              "Join this bounty and open a chat seeded with its context"
+            }
           >
             <Show
-              when={!joining()}
+              when={!joining() && canJoinBounty()}
               fallback={
-                <span
-                  class="w-3 h-3 border-2 border-primary/30 border-t-primary rounded-full animate-spin"
-                  aria-hidden="true"
-                />
+                <Show
+                  when={!joining()}
+                  fallback={
+                    <span
+                      class="w-3 h-3 border-2 border-primary/30 border-t-primary rounded-full animate-spin"
+                      aria-hidden="true"
+                    />
+                  }
+                >
+                  <span
+                    class="w-3 h-3 rounded-full border border-amber-500/50 bg-amber-500/20"
+                    aria-hidden="true"
+                  />
+                </Show>
               }
             >
               <svg
@@ -920,7 +952,13 @@ export const BountyDetail: Component<BountyDetailProps> = (props) => {
                 />
               </svg>
             </Show>
-            <span>{joining() ? "Joining..." : "Join the bounty"}</span>
+            <span>
+              {joining()
+                ? "Joining..."
+                : joinDisabledReason()
+                  ? "Verifier unavailable"
+                  : "Join the bounty"}
+            </span>
           </button>
         </Show>
       </header>

--- a/tests/unit/bounties-wiring.test.ts
+++ b/tests/unit/bounties-wiring.test.ts
@@ -13,6 +13,14 @@ const bountyDetailTsx = readFileSync(
   resolve("src/components/bounties/BountyDetail.tsx"),
   "utf-8",
 );
+const bountyClientGenTs = readFileSync(
+  resolve("src/api/generated/seren-bounty/client.gen.ts"),
+  "utf-8",
+);
+const bountySdkGenTs = readFileSync(
+  resolve("src/api/generated/seren-bounty/sdk.gen.ts"),
+  "utf-8",
+);
 const bountiesSectionTsx = readFileSync(
   resolve("src/components/sidebar/BountiesSection.tsx"),
   "utf-8",
@@ -54,6 +62,33 @@ describe("Seren Bounties wiring", () => {
   it("only reuses the Seren-scoped bounty skill installation", () => {
     expect(bountyDetailTsx).toMatch(
       /s\.scope === "seren" &&\s+s\.slug === SEREN_BOUNTY_SLUG/,
+    );
+  });
+
+  it("pauses bounty join while the verifier is degraded", () => {
+    expect(bountyDetailTsx).toContain("function isVerifierDegraded");
+    expect(bountyDetailTsx).toContain("bounty.verifier_failure_count > 0");
+    expect(bountyDetailTsx).toContain("joinDisabledReason");
+    expect(bountyDetailTsx).toContain("!canJoinBounty()");
+    expect(bountyDetailTsx).toContain("Verifier unavailable");
+  });
+
+  it("keeps seren-bounty production paths aligned to the live publisher contract", () => {
+    // Verified against the live Seren MCP publisher metadata on 2026-06-28.
+    expect(bountyClientGenTs).toContain(
+      "baseUrl: '/publishers/seren-bounty'",
+    );
+    expect(bountySdkGenTs).toMatch(
+      /listBounties[\s\S]*\.get<[\s\S]*url: '\/bounties'/,
+    );
+    expect(bountySdkGenTs).toMatch(
+      /getBountyStats[\s\S]*\.get<[\s\S]*url: '\/bounties\/\{id\}\/stats'/,
+    );
+    expect(bountySdkGenTs).toMatch(
+      /getBountyLeaderboard[\s\S]*\.get<[\s\S]*url: '\/bounties\/\{id\}\/leaderboard'/,
+    );
+    expect(bountySdkGenTs).toMatch(
+      /joinBounty[\s\S]*\.post<[\s\S]*url: '\/bounties\/\{id\}\/join'/,
     );
   });
 


### PR DESCRIPTION
Closes #2739.

## Audit
- Confirmed live Seren MCP publisher `seren-bounty` exposes `GET /bounties`, `GET /bounties/{id}/stats`, `GET /bounties/{id}/leaderboard`, and `POST /bounties/{id}/join`.
- Confirmed live bounty `29d54db4-213c-4f16-810c-d8de1bf7d338` is `open` while reporting `verifier_failure_count: 2` and the screenshot DNS failure.
- Fixed `BountyDetail` so open bounties with degraded verifier health keep the status/error visible but disable the Join path, including the handler guard.

## Tests
- `pnpm vitest run tests/unit/bounties-wiring.test.ts tests/unit/publisher-response.test.ts`
- `pnpm exec biome check src/components/bounties/BountyDetail.tsx tests/unit/bounties-wiring.test.ts --write`
- `git diff --check`