### PR TITLE
fix(meeting): treat pending capture as startup owner

### DIFF
--- a/src/components/meeting/MeetingPanel.tsx
+++ b/src/components/meeting/MeetingPanel.tsx
@@ -78,6 +78,13 @@ export function MeetingPanel() {
       (meeting) => meeting.status === "capturing",
     ),
   );
+  const captureOwner = createMemo(
+    () =>
+      activeCapture() ??
+      meetingStore.state.meetings.find(
+        (meeting) => meeting.status === "pending_capture",
+      ),
+  );
   const activeProcessing = createMemo(() =>
     meetingStore.state.meetings.find((meeting) =>
       isMeetingProcessingStatus(meeting.status),
@@ -91,7 +98,7 @@ export function MeetingPanel() {
 
   const activeMeeting = () => meetingStore.state.activeMeeting;
   const durationNow = createMeetingDurationClock(() =>
-    [activeCapture(), activeMeeting()].some(
+    [captureOwner(), activeMeeting()].some(
       (meeting) => meeting != null && isMeetingDurationLive(meeting),
     ),
   );
@@ -115,6 +122,8 @@ export function MeetingPanel() {
     if (!desktopRuntime || starting()) return;
     // A priming dialog is already pending a start; don't create a second one.
     if (meetingStore.state.primingRequest) return;
+    // `pending_capture` already owns the start path while native audio spins up.
+    if (captureOwner()) return;
     setStarting(true);
     try {
       const meeting = await createMeeting({
@@ -224,10 +233,10 @@ export function MeetingPanel() {
                 void startManualCapture();
               }
             }}
-            disabled={activeCapture() !== undefined}
+            disabled={captureOwner() !== undefined}
           />
           <Show
-            when={activeCapture()}
+            when={captureOwner()}
             fallback={
               <button
                 type="button"
@@ -242,23 +251,50 @@ export function MeetingPanel() {
               </button>
             }
           >
-            <button
-              type="button"
-              class="h-8 w-9 flex items-center justify-center rounded-md border border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/15 disabled:opacity-60"
-              onClick={stopManualCapture}
-              disabled={stopping() || !desktopRuntime}
-              title={
-                desktopRuntime ? "Stop capture" : "Desktop runtime required"
-              }
-            >
-              <StopGlyph />
-            </button>
+            {(meeting) => (
+              <Show
+                when={meeting().status === "capturing"}
+                fallback={
+                  <button
+                    type="button"
+                    class="h-8 w-9 flex items-center justify-center rounded-md border border-warning/40 bg-warning/10 text-warning disabled:opacity-70"
+                    disabled
+                    title="Starting capture"
+                  >
+                    <MicGlyph />
+                  </button>
+                }
+              >
+                <button
+                  type="button"
+                  class="h-8 w-9 flex items-center justify-center rounded-md border border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/15 disabled:opacity-60"
+                  onClick={stopManualCapture}
+                  disabled={stopping() || !desktopRuntime}
+                  title={
+                    desktopRuntime ? "Stop capture" : "Desktop runtime required"
+                  }
+                >
+                  <StopGlyph />
+                </button>
+              </Show>
+            )}
           </Show>
         </div>
-        <Show when={activeCapture()}>
+        <Show when={captureOwner()}>
           {(meeting) => (
             <div class="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
-              <span class="w-1.5 h-1.5 rounded-full bg-destructive animate-pulse" />
+              <span
+                class="w-1.5 h-1.5 rounded-full animate-pulse"
+                classList={{
+                  "bg-destructive": meeting().status === "capturing",
+                  "bg-warning": meeting().status === "pending_capture",
+                }}
+              />
+              <span>
+                {meeting().status === "pending_capture"
+                  ? "Starting capture"
+                  : "Recording"}
+              </span>
               <span class="font-mono tabular-nums">
                 {formatDuration(meeting(), durationNow())}
               </span>

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -766,6 +766,7 @@ async function toggleCaptureFromTray(): Promise<void> {
     await stopByUser(active);
     return;
   }
+  if (isCapturing()) return;
   if (isStarting || meetingState.primingRequest) return;
   const meeting = await createMeeting({
     title: `Meeting ${formatTime(Date.now())}`,

--- a/tests/unit/meeting-native-capture-lifecycle.test.ts
+++ b/tests/unit/meeting-native-capture-lifecycle.test.ts
@@ -7,7 +7,27 @@ const eventBus = vi.hoisted(() => ({
   listeners: new Map<string, (event: { payload: unknown }) => void>(),
 }));
 
+const tray = vi.hoisted(() => ({
+  handler: null as (() => void) | null,
+}));
+
 const m = vi.hoisted(() => ({
+  createMeeting: vi.fn(async (): Promise<Meeting> => ({
+    id: "created-from-tray",
+    title: "Tray",
+    sourceApp: "Tray",
+    startedAt: 0,
+    endedAt: null,
+    status: "pending_capture",
+    templateId: null,
+    routedSkillSlug: null,
+    agentConversationId: null,
+    notesMarkdown: null,
+    notesStructJson: null,
+    failureReason: null,
+    createdAt: 0,
+    updatedAt: 0,
+  })),
   startMeetingCapture: vi.fn(async () => {}),
   stopMeetingCapture: vi.fn(async () => ({
     hadCapture: true,
@@ -46,6 +66,12 @@ const m = vi.hoisted(() => ({
   getTranscriptSegments: vi.fn(async () => []),
   isMeetingCaptureActive: vi.fn(async () => false),
   setTrayRecording: vi.fn(),
+  onTrayToggleCapture: vi.fn((handler: () => void) => {
+    tray.handler = handler;
+    return () => {
+      tray.handler = null;
+    };
+  }),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -62,6 +88,7 @@ vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
 }));
 vi.mock("@/services/meetings", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/services/meetings")>()),
+  createMeeting: m.createMeeting,
   startMeetingCapture: m.startMeetingCapture,
   stopMeetingCapture: m.stopMeetingCapture,
   updateMeetingStatus: m.updateMeetingStatus,
@@ -72,7 +99,7 @@ vi.mock("@/services/meetings", async (importOriginal) => ({
 vi.mock("@/services/orchestrator", () => ({ orchestrate: vi.fn() }));
 vi.mock("@/services/tray", () => ({
   setTrayRecording: m.setTrayRecording,
-  onTrayToggleCapture: vi.fn(() => () => {}),
+  onTrayToggleCapture: m.onTrayToggleCapture,
 }));
 vi.mock("@/stores/settings.store", () => ({
   settingsStore: {
@@ -120,6 +147,7 @@ describe("meetingStore native capture lifecycle (#2225)", () => {
   beforeEach(async () => {
     for (const fn of Object.values(m)) fn.mockClear();
     eventBus.listeners.clear();
+    tray.handler = null;
     m.listMeetings.mockResolvedValue([]);
     m.isMeetingCaptureActive.mockResolvedValue(false);
     await meetingStore.loadMeetings();
@@ -171,5 +199,17 @@ describe("meetingStore native capture lifecycle (#2225)", () => {
       expect.anything(),
       expect.anything(),
     );
+  });
+
+  it("does not create a second meeting from the tray while startup is pending", async () => {
+    m.listMeetings.mockResolvedValue([meeting({ status: "pending_capture" })]);
+
+    await meetingStore.loadMeetings();
+    await meetingStore.startMeetingEventListeners();
+    tray.handler?.();
+
+    expect(m.createMeeting).not.toHaveBeenCalled();
+    expect(m.startMeetingCapture).not.toHaveBeenCalled();
+    meetingStore.stopMeetingEventListeners();
   });
 });

--- a/tests/unit/meeting-ui-regressions.test.ts
+++ b/tests/unit/meeting-ui-regressions.test.ts
@@ -101,3 +101,18 @@ describe("Meeting delete affordance (#2231)", () => {
     expect(lib).toContain("commands::audio::delete_meeting");
   });
 });
+
+describe("Meeting pending capture ownership (#2745)", () => {
+  it("treats pending capture as owning the start controls without exposing stop", () => {
+    const panel = source("src/components/meeting/MeetingPanel.tsx");
+    const store = source("src/stores/meeting.store.ts");
+
+    expect(panel).toContain("const captureOwner = createMemo");
+    expect(panel).toContain('meeting.status === "pending_capture"');
+    expect(panel).toContain("if (captureOwner()) return;");
+    expect(panel).toContain("disabled={captureOwner() !== undefined}");
+    expect(panel).toContain('title="Starting capture"');
+    expect(panel).toContain('meeting().status === "capturing"');
+    expect(store).toContain("if (isCapturing()) return;");
+  });
+});


### PR DESCRIPTION
## Summary
- Treat `pending_capture` as the Meeting panel capture owner while native audio startup is in progress.
- Keep Stop scoped to actual `capturing` rows, and show a disabled `Starting capture` state for pending rows.
- Prevent tray Start from creating a second pending meeting while any pending/capturing row already owns capture.

Closes #2745

## Tests
- `pnpm exec vitest run tests/unit/meeting-native-capture-lifecycle.test.ts tests/unit/meeting-concurrent-stop.test.ts tests/unit/meeting-ui-regressions.test.ts`
- `pnpm exec biome check src/components/meeting/MeetingPanel.tsx src/stores/meeting.store.ts tests/unit/meeting-ui-regressions.test.ts tests/unit/meeting-native-capture-lifecycle.test.ts`
- `pnpm test`
- `pnpm check` (passes with existing warnings outside this change)
- `pnpm build` (passes with existing Rolldown/dependency/chunk warnings)
- `pnpm prepare:mcp-servers`
- `cargo test --manifest-path src-tauri/Cargo.toml`

## Functional Audit
- Code path: `create_meeting` emits `pending_capture`; `start_meeting_capture` transitions to `capturing` only after `CaptureRegistry::start` returns.
- Fixed UI path: `MeetingPanel` now disables title/start for `pending_capture` and only exposes Stop for `capturing`.
- Fixed tray path: `toggleCaptureFromTray` now no-ops while `isCapturing()` reports pending/capturing ownership.
- Networked app feature paths changed: none. No publisher/API request path is introduced or modified by this PR.

## Live Contract Verification
- Seren publisher list queried live with no arguments.
- GitHub publisher enumerated live as `github-api`.
- Repo probe verified: `GET /repos/serenorg/seren-desktop`.
- Issue creation verified: `POST /repos/serenorg/seren-desktop/issues`.
- PR creation path used here: `POST /repos/serenorg/seren-desktop/pulls`.