### PR TITLE
fix(passwords): edit restored login fields

### DIFF
--- a/src-tauri/src/passwords.rs
+++ b/src-tauri/src/passwords.rs
@@ -15,10 +15,10 @@ use seren_secrets_crypto::keys::{
 use seren_secrets_crypto::protocol::account::{AccountSecrets, account_setup, unlock_account};
 use seren_secrets_crypto::protocol::item::{
     ApiCredentialContent, ApiCredentialKind, CustomField, CustomFieldKind, DecryptedItemContent,
-    FieldPurpose, ItemContent, LoginContent, decrypt_item_with_content_key, decrypt_metadata_json,
-    decrypt_tags, decrypt_title, encrypt_item_with_content_key, encrypt_metadata_json,
-    encrypt_tags, encrypt_title, generate_item_content_key, unwrap_item_content_key,
-    wrap_item_content_key,
+    FieldPurpose, ItemContent, LoginContent, LoginUrl, TotpAlgorithm, TotpConfig,
+    decrypt_item_with_content_key, decrypt_metadata_json, decrypt_tags, decrypt_title,
+    encrypt_item_with_content_key, encrypt_metadata_json, encrypt_tags, encrypt_title,
+    generate_item_content_key, unwrap_item_content_key, wrap_item_content_key,
 };
 use seren_secrets_crypto::protocol::vault::{
     decrypt_vault_name, encrypt_vault_description, encrypt_vault_name, generate_vault_key,
@@ -329,11 +329,12 @@ struct ItemListMetadata {
     reprompt: bool,
 }
 
-struct ExistingApiCredentialState {
+struct ExistingItemState {
     metadata: ItemListMetadata,
     content_key: ItemContentKey,
     content_key_wrap: String,
     tags_ciphertext: Option<String>,
+    content: DecryptedItemContent,
 }
 
 fn default_item_kind() -> String {
@@ -454,10 +455,10 @@ pub async fn save_passwords_api_credential(
         Some(value) if !value.trim().is_empty() => Some(parse_uuid(value, "item_id")?),
         _ => None,
     };
-    let mut fields = sanitize_fields(request.fields)?;
+    let mut fields = request.fields;
     let title = sanitize_title(&request.title, &request.service_name);
 
-    let result = save_passwords_api_credential_inner(&app, vault_id, item_id, &title, &fields)
+    let result = save_passwords_api_credential_inner(&app, vault_id, item_id, &title, &mut fields)
         .await
         .map_err(|err| err.to_string());
 
@@ -717,7 +718,7 @@ async fn save_passwords_api_credential_inner(
     vault_id: Uuid,
     item_id: Option<Uuid>,
     title: &str,
-    fields: &[PasswordsSecretFieldInput],
+    fields: &mut [PasswordsSecretFieldInput],
 ) -> anyhow::Result<CreatePasswordsApiCredentialResponse> {
     let vault = unlocked_vault(vault_id).await?;
     if !vault.writable {
@@ -727,17 +728,35 @@ async fn save_passwords_api_credential_inner(
     let update_existing = item_id.is_some();
     let item_id = item_id.unwrap_or_else(Uuid::new_v4);
     let client = reqwest::Client::new();
-    let mut content = build_secret_reference_content(fields);
     let existing_state = if update_existing {
-        match merge_existing_item(app, &client, &vault, item_id, &mut content).await {
-            Ok(state) => Some(state),
-            Err(err) => {
-                zeroize_item_content(&mut content);
-                return Err(err);
-            }
-        }
+        Some(load_existing_item_state(app, &client, &vault, item_id).await?)
     } else {
         None
+    };
+    let mut existing_state = existing_state;
+    let mut content = match existing_state.as_mut() {
+        Some(state) => match state.metadata.item_kind.as_str() {
+            "api_credential" => {
+                sanitize_fields_in_place(fields).map_err(anyhow::Error::msg)?;
+                let mut content = build_secret_reference_content(fields);
+                merge_api_credential_content(&mut content, state.content.as_mut());
+                content
+            }
+            "login" => {
+                sanitize_password_item_fields_in_place(fields).map_err(anyhow::Error::msg)?;
+                merge_login_content_fields(state.content.as_mut(), fields)?;
+                state.content.as_ref().clone()
+            }
+            item_kind => {
+                return Err(anyhow::anyhow!(
+                    "Existing entry is a {item_kind} item; only login and API credential entries can be edited here"
+                ));
+            }
+        },
+        None => {
+            sanitize_fields_in_place(fields).map_err(anyhow::Error::msg)?;
+            build_secret_reference_content(fields)
+        }
     };
     let body = match existing_state.as_ref() {
         Some(state) => {
@@ -801,16 +820,13 @@ async fn save_passwords_api_credential_inner(
 
 /// Fetches and decrypts the item being updated so the new request preserves
 /// what the editor does not model: the stored metadata (item kind, favorite,
-/// sensitive, reprompt) and the content fields the editor never surfaces.
-/// Refuses to overwrite items that are not API credentials, since the editor
-/// only submits API-credential content and would destroy any other kind.
-async fn merge_existing_item(
+/// sensitive, reprompt), the item content key, tags, and hidden content fields.
+async fn load_existing_item_state(
     app: &AppHandle,
     client: &reqwest::Client,
     vault: &UnlockedVault,
     item_id: Uuid,
-    content: &mut ItemContent,
-) -> anyhow::Result<ExistingApiCredentialState> {
+) -> anyhow::Result<ExistingItemState> {
     let record = get_item_record(app, client, vault.vault_id, item_id).await?;
     let metadata_json = decrypt_metadata_json(
         &vault.vault_key,
@@ -819,19 +835,13 @@ async fn merge_existing_item(
     )?;
     let metadata: ItemListMetadata = serde_json::from_str(&metadata_json)
         .map_err(|err| anyhow::anyhow!("Existing item metadata is malformed: {err}"))?;
-    if metadata.item_kind != "api_credential" {
-        return Err(anyhow::anyhow!(
-            "Existing entry is a {} item; only API credential entries can be edited here",
-            metadata.item_kind
-        ));
-    }
-    let (content_key, mut existing) = decrypt_item_content(&vault.vault_key, &record)?;
-    merge_api_credential_content(content, &mut existing);
-    Ok(ExistingApiCredentialState {
+    let (content_key, content) = decrypt_item_content(&vault.vault_key, &record)?;
+    Ok(ExistingItemState {
         metadata,
         content_key,
         content_key_wrap: record.content_key_wrap,
         tags_ciphertext: record.tags_ciphertext,
+        content,
     })
 }
 
@@ -879,6 +889,107 @@ fn editor_surfaced_alias(existing: &ApiCredentialContent, alias: ApiCredentialAl
         .custom_fields
         .iter()
         .any(|field| api_credential_alias(&field.name) == Some(alias))
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LoginFieldAlias {
+    Username,
+    Password,
+    Url,
+    Totp,
+    Notes,
+}
+
+fn login_field_alias(name: &str) -> Option<LoginFieldAlias> {
+    match name.trim().to_ascii_lowercase().as_str() {
+        "username" | "user" | "login" => Some(LoginFieldAlias::Username),
+        "password" | "pass" => Some(LoginFieldAlias::Password),
+        "url" | "uri" | "website" | "site" => Some(LoginFieldAlias::Url),
+        "totp" | "otp" | "one_time_password" | "one-time password" => Some(LoginFieldAlias::Totp),
+        "notes" | "note" => Some(LoginFieldAlias::Notes),
+        _ => None,
+    }
+}
+
+fn merge_login_content_fields(
+    content: &mut ItemContent,
+    fields: &[PasswordsSecretFieldInput],
+) -> anyhow::Result<()> {
+    let ItemContent::Login(login) = content else {
+        return Err(anyhow::anyhow!("Existing item content is not a login"));
+    };
+
+    let mut username: Option<String> = None;
+    let mut password: Option<String> = None;
+    let mut url: Option<String> = None;
+    let mut totp: Option<String> = None;
+    let mut notes: Option<String> = None;
+    let mut custom_fields = Vec::new();
+    let mut existing_custom = std::mem::take(&mut login.custom_fields)
+        .into_iter()
+        .map(|field| (field.name.to_ascii_lowercase(), field))
+        .collect::<BTreeMap<_, _>>();
+
+    for field in fields {
+        match login_field_alias(&field.name) {
+            Some(LoginFieldAlias::Username) => username = Some(field.value.clone()),
+            Some(LoginFieldAlias::Password) => password = Some(field.value.clone()),
+            Some(LoginFieldAlias::Url) => url = Some(field.value.clone()),
+            Some(LoginFieldAlias::Totp) => totp = Some(field.value.clone()),
+            Some(LoginFieldAlias::Notes) => notes = Some(field.value.clone()),
+            None => {
+                let key = field.name.to_ascii_lowercase();
+                let mut custom = existing_custom.remove(&key).unwrap_or_else(|| CustomField {
+                    name: field.name.clone(),
+                    kind: CustomFieldKind::Concealed,
+                    value: String::new(),
+                    purpose: field_purpose_for_name(&field.name),
+                    section_id: None,
+                });
+                custom.name = field.name.clone();
+                custom.value = field.value.clone();
+                if custom.purpose.is_none() {
+                    custom.purpose = field_purpose_for_name(&field.name);
+                }
+                custom_fields.push(custom);
+            }
+        }
+    }
+
+    login.username = username.unwrap_or_default();
+    login.password = password.unwrap_or_default();
+    match url {
+        Some(value) => {
+            if let Some(first) = login.urls.first_mut() {
+                first.url = value;
+            } else {
+                login.urls.push(LoginUrl::plain(value));
+            }
+        }
+        None => {
+            if !login.urls.is_empty() {
+                login.urls.remove(0);
+            }
+        }
+    }
+    if let Some(secret_base32) = totp {
+        let mut existing = login.totp.take().unwrap_or(TotpConfig {
+            secret_base32: String::new(),
+            algorithm: TotpAlgorithm::Sha1,
+            digits: 6,
+            period_seconds: 30,
+        });
+        existing.secret_base32 = secret_base32;
+        login.totp = Some(existing);
+    } else {
+        login.totp = None;
+    }
+    let notes = notes.unwrap_or_default();
+    let (notes_doc, notes_text) = seren_secrets_crypto::prose::from_plaintext(&notes);
+    login.notes = notes_doc;
+    login.notes_text = notes_text;
+    login.custom_fields = custom_fields;
+    Ok(())
 }
 
 fn passwords_url(path: &str) -> String {
@@ -1730,6 +1841,41 @@ fn sanitize_fields_in_place(fields: &mut [PasswordsSecretFieldInput]) -> Result<
     Ok(())
 }
 
+fn sanitize_password_item_fields_in_place(
+    fields: &mut [PasswordsSecretFieldInput],
+) -> Result<(), String> {
+    if fields.is_empty() {
+        return Err("Add at least one field to store in Seren Passwords".to_string());
+    }
+    if fields.len() > MAX_SECRET_FIELDS {
+        return Err(format!(
+            "At most {MAX_SECRET_FIELDS} fields can be saved at once"
+        ));
+    }
+
+    let mut names = BTreeSet::new();
+    for field in fields.iter_mut() {
+        field.name = field.name.trim().to_string();
+        if field.name.is_empty() {
+            return Err("Each field name must have a label".to_string());
+        }
+        if field.name.len() > MAX_FIELD_NAME_LEN {
+            return Err("Field names are too long".to_string());
+        }
+        if field.value.is_empty() {
+            return Err(format!("{} is empty", field.name));
+        }
+        if field.value.len() > MAX_FIELD_VALUE_LEN {
+            return Err(format!("{} is too large", field.name));
+        }
+        let normalized = field.name.to_ascii_lowercase();
+        if !names.insert(normalized) {
+            return Err(format!("{} is duplicated", field.name));
+        }
+    }
+    Ok(())
+}
+
 fn is_valid_env_name(name: &str) -> bool {
     let mut chars = name.chars();
     matches!(chars.next(), Some('_' | 'A'..='Z'))
@@ -1971,6 +2117,32 @@ mod tests {
             ])
             .is_err()
         );
+    }
+
+    #[test]
+    fn sanitizes_password_item_fields_without_env_name_rules() {
+        let mut fields = vec![
+            PasswordsSecretFieldInput {
+                name: " username ".into(),
+                value: "taariq@example.com".into(),
+            },
+            PasswordsSecretFieldInput {
+                name: "workspace".into(),
+                value: "Glide".into(),
+            },
+        ];
+
+        sanitize_password_item_fields_in_place(&mut fields).unwrap();
+
+        assert_eq!(fields[0].name, "username");
+        assert_eq!(fields[1].name, "workspace");
+
+        fields.push(PasswordsSecretFieldInput {
+            name: "WORKSPACE".into(),
+            value: "duplicate".into(),
+        });
+        let err = sanitize_password_item_fields_in_place(&mut fields).unwrap_err();
+        assert!(err.contains("duplicated"));
     }
 
     #[test]
@@ -2756,5 +2928,92 @@ mod tests {
         assert!(merged.notes.plain_text().is_empty());
         // SECRET was never surfaced, so the stored value survives.
         assert_eq!(merged.secondary_value, "foreign-secondary");
+    }
+
+    #[test]
+    fn merge_login_content_fields_updates_visible_fields_only() {
+        let (notes, notes_text) = seren_secrets_crypto::prose::from_plaintext("old note");
+        let mut content = ItemContent::Login(LoginContent {
+            username: "old-user".to_string(),
+            password: "old-password".to_string(),
+            urls: vec![
+                LoginUrl::plain("https://old.example.com"),
+                LoginUrl::plain("https://secondary.example.com"),
+            ],
+            totp: Some(TotpConfig {
+                secret_base32: "OLDTOTP".to_string(),
+                algorithm: TotpAlgorithm::Sha256,
+                digits: 8,
+                period_seconds: 45,
+            }),
+            notes,
+            notes_text,
+            custom_fields: vec![CustomField {
+                name: "workspace".to_string(),
+                kind: CustomFieldKind::String,
+                value: "Old".to_string(),
+                purpose: None,
+                section_id: Some("details".to_string()),
+            }],
+            autofill_on_page_load: Some(true),
+            ..Default::default()
+        });
+        let mut fields = vec![
+            PasswordsSecretFieldInput {
+                name: "username".into(),
+                value: "new-user".into(),
+            },
+            PasswordsSecretFieldInput {
+                name: "password".into(),
+                value: "new-password".into(),
+            },
+            PasswordsSecretFieldInput {
+                name: "url".into(),
+                value: "https://new.example.com".into(),
+            },
+            PasswordsSecretFieldInput {
+                name: "totp".into(),
+                value: "NEWTOTP".into(),
+            },
+            PasswordsSecretFieldInput {
+                name: "notes".into(),
+                value: "new note".into(),
+            },
+            PasswordsSecretFieldInput {
+                name: "workspace".into(),
+                value: "Glide".into(),
+            },
+            PasswordsSecretFieldInput {
+                name: "team secret".into(),
+                value: "shared".into(),
+            },
+        ];
+        sanitize_password_item_fields_in_place(&mut fields).unwrap();
+
+        merge_login_content_fields(&mut content, &fields).unwrap();
+
+        let ItemContent::Login(login) = content else {
+            panic!("expected login content");
+        };
+        assert_eq!(login.username, "new-user");
+        assert_eq!(login.password, "new-password");
+        assert_eq!(login.urls[0].url, "https://new.example.com");
+        assert_eq!(login.urls[1].url, "https://secondary.example.com");
+        let totp = login.totp.unwrap();
+        assert_eq!(totp.secret_base32, "NEWTOTP");
+        assert_eq!(totp.algorithm, TotpAlgorithm::Sha256);
+        assert_eq!(totp.digits, 8);
+        assert_eq!(totp.period_seconds, 45);
+        assert_eq!(login.notes_text, "new note");
+        assert_eq!(login.autofill_on_page_load, Some(true));
+        assert_eq!(login.custom_fields.len(), 2);
+        assert_eq!(login.custom_fields[0].name, "workspace");
+        assert_eq!(login.custom_fields[0].kind, CustomFieldKind::String);
+        assert_eq!(
+            login.custom_fields[0].section_id.as_deref(),
+            Some("details")
+        );
+        assert_eq!(login.custom_fields[1].name, "team secret");
+        assert_eq!(login.custom_fields[1].kind, CustomFieldKind::Concealed);
     }
 }

--- a/src/components/settings/KeysSettings.tsx
+++ b/src/components/settings/KeysSettings.tsx
@@ -72,7 +72,10 @@ const MIN_MASTER_PASSWORD_BITS = 60;
 const PASSWORDS_IDLE_LOCK_HOURS = 4;
 const PASSWORDS_IDLE_LOCK_MS = PASSWORDS_IDLE_LOCK_HOURS * 60 * 60 * 1000;
 const PASSWORD_FIELD_ROW_GRID_CLASS =
-  "grid grid-cols-[minmax(6rem,0.85fr)_minmax(0,1fr)_2rem] items-center gap-2";
+  "grid grid-cols-[minmax(5.5rem,10rem)_minmax(0,1fr)_2rem] items-start gap-2";
+const PASSWORD_VALUE_INPUT_CLASS =
+  "min-w-0 rounded-md border border-border-strong bg-surface-3/80 px-3 py-2 font-mono text-[0.82rem] leading-relaxed text-foreground focus:border-accent focus:outline-none";
+const PASSWORD_VALUE_TEXTAREA_MAX_HEIGHT = 160;
 const DECISION_LABELS: Record<SecretAuditEvent["decision"], string> = {
   approved_by_user: "Approved by you",
   auto_approved: "Auto-approved",
@@ -177,13 +180,24 @@ function estimateMasterPasswordBits(password: string): number {
   );
 }
 
+function resizePasswordValueTextarea(textarea: HTMLTextAreaElement): void {
+  requestAnimationFrame(() => {
+    textarea.style.height = "auto";
+    const height = Math.min(
+      textarea.scrollHeight,
+      PASSWORD_VALUE_TEXTAREA_MAX_HEIGHT,
+    );
+    textarea.style.height = `${height}px`;
+    textarea.style.overflowY =
+      textarea.scrollHeight > PASSWORD_VALUE_TEXTAREA_MAX_HEIGHT
+        ? "auto"
+        : "hidden";
+  });
+}
+
 export const KeysSettings: Component = () => {
   const [tab, setTab] = createSignal<KeysTab>("stored");
   const [showAddForm, setShowAddForm] = createSignal(false);
-  const [prefillCredential, setPrefillCredential] = createSignal<{
-    vaultId: string;
-    itemId: string;
-  } | null>(null);
   const [selectedServiceId, setSelectedServiceId] =
     createSignal(DEFAULT_SERVICE_ID);
   const [selectedSkillId, setSelectedSkillId] = createSignal(DEFAULT_SKILL_ID);
@@ -339,7 +353,6 @@ export const KeysSettings: Component = () => {
       setRecoveryKeyDisplay(null);
       // Granting needs an unlocked vault, so close any open create flow.
       setShowAddForm(false);
-      setPrefillCredential(null);
     } finally {
       setVaultBusy(false);
     }
@@ -540,6 +553,7 @@ export const KeysSettings: Component = () => {
 
   const handleSaveVaultItem = async (input: {
     itemId?: string | null;
+    itemKind?: string | null;
     title: string;
     fields: { name: string; value: string }[];
   }) => {
@@ -656,20 +670,11 @@ export const KeysSettings: Component = () => {
         `Granted ${input.agentLabel || input.agentId} access to ${input.serviceName}.`,
       );
       setShowAddForm(false);
-      setPrefillCredential(null);
       await refetchBindings();
       await refetchAudit();
     } catch (error) {
       setSaveMessage(`Could not grant access: ${String(error)}`);
     }
-  };
-
-  const handleUseSelectedVaultItem = () => {
-    const detail = selectedVaultItem();
-    if (!detail) return;
-    setPrefillCredential({ vaultId: detail.vaultId, itemId: detail.itemId });
-    setShowAddForm(true);
-    setSaveMessage("Choose an agent to grant access to this credential.");
   };
 
   const openGrantAccessForm = (serviceId = selectedServiceId()) => {
@@ -679,7 +684,6 @@ export const KeysSettings: Component = () => {
         .map((name) => `${name}=`)
         .join("\n"),
     );
-    setPrefillCredential(null);
     setShowAddForm(true);
   };
 
@@ -740,7 +744,6 @@ export const KeysSettings: Component = () => {
     setReferenceLines(
       binding.variableNames.map((name) => `${name}=`).join("\n"),
     );
-    setPrefillCredential(null);
     setShowAddForm(true);
     setSaveMessage(
       `Re-select a credential to update ${binding.skillName}'s access, or use Advanced to edit the raw references.`,
@@ -793,7 +796,6 @@ export const KeysSettings: Component = () => {
         onSelectVault={(vaultId) => void handleSelectVault(vaultId)}
         onSelectItem={(item) => void handleSelectVaultItem(item)}
         onSaveItem={(input) => void handleSaveVaultItem(input)}
-        onUseForBinding={handleUseSelectedVaultItem}
       />
 
       <Show when={tab() === "stored"}>
@@ -870,13 +872,11 @@ export const KeysSettings: Component = () => {
             agents={agents()}
             entries={credentialEntries()}
             vaultUnlocked={vaults().length > 0}
-            prefill={prefillCredential()}
             loadEntryFields={loadEntryFields}
             findBinding={findBindingFor}
             onGrant={(input) => void handleGrantAccess(input)}
             onCancel={() => {
               setShowAddForm(false);
-              setPrefillCredential(null);
             }}
           >
             <AddKeyForm
@@ -899,7 +899,6 @@ export const KeysSettings: Component = () => {
               }}
               onCancel={() => {
                 setShowAddForm(false);
-                setPrefillCredential(null);
               }}
               onSave={handleSaveKey}
             />
@@ -1134,12 +1133,6 @@ const IconEyeOff = (props: IconProps) => (
   </Svg>
 );
 
-const IconArrowRight = (props: IconProps) => (
-  <Svg {...props}>
-    <path d="M5 12h14M13 6l6 6-6 6" />
-  </Svg>
-);
-
 const PasswordsVaultEditor: Component<{
   vaults: PasswordsVaultSummary[];
   selectedVaultId: string;
@@ -1162,10 +1155,10 @@ const PasswordsVaultEditor: Component<{
   onSelectItem: (item: PasswordsItemSummary) => void;
   onSaveItem: (input: {
     itemId?: string | null;
+    itemKind?: string | null;
     title: string;
     fields: { name: string; value: string }[];
   }) => void;
-  onUseForBinding: () => void;
 }> = (props) => {
   const [masterPassword, setMasterPassword] = createSignal("");
   const [confirmPassword, setConfirmPassword] = createSignal("");
@@ -1189,23 +1182,36 @@ const PasswordsVaultEditor: Component<{
   const [newVaultDescription, setNewVaultDescription] = createSignal("");
   const unlocked = () => props.vaults.length > 0;
   const writable = () => props.selectedVault?.writable === true;
+  const editingItemKind = () =>
+    editingItemId() ? props.selectedItem?.itemKind : "api_credential";
   const editableEntry = () =>
     editingItemId() === null ||
-    props.selectedItem?.itemKind === "api_credential";
+    editingItemKind() === "api_credential" ||
+    editingItemKind() === "login";
   const namedRows = () => fieldRows().filter((row) => row.name.trim());
+  const editingApiCredential = () =>
+    editingItemId() === null || editingItemKind() === "api_credential";
+  const normalizedFieldName = (name: string) =>
+    editingApiCredential() ? name.trim().toUpperCase() : name.trim();
   const masterPasswordBits = () => estimateMasterPasswordBits(masterPassword());
   const saveDisabledReason = createMemo(() => {
     if (!unlocked()) return "Unlock your vault first";
     if (!writable()) return "Select a writable vault";
     if (props.busy) return "Vault is busy";
     if (!editableEntry())
-      return "Only API credential entries can be edited here";
+      return "Only login and API credential entries can be edited here";
     if (!entryTitle().trim()) return "Add a title";
     const named = namedRows();
     if (named.length === 0) return "Add at least one field";
-    if (named.some((row) => !isEnvVarName(row.name)))
+    if (
+      editingApiCredential() &&
+      named.some((row) => !isEnvVarName(row.name))
+    ) {
       return "Field names must be valid env vars";
-    const names = named.map((row) => row.name.trim().toUpperCase());
+    }
+    const names = named.map((row) =>
+      normalizedFieldName(row.name).toLowerCase(),
+    );
     if (new Set(names).size !== names.length)
       return "Field names must be unique";
     if (named.some((row) => !row.value.trim()))
@@ -1358,9 +1364,10 @@ const PasswordsVaultEditor: Component<{
     if (saveDisabledReason()) return;
     props.onSaveItem({
       itemId: editingItemId(),
+      itemKind: editingItemKind(),
       title: entryTitle().trim() || "Credential",
       fields: namedRows().map((row) => ({
-        name: row.name.trim().toUpperCase(),
+        name: normalizedFieldName(row.name),
         value: row.value,
       })),
     });
@@ -1854,7 +1861,7 @@ const PasswordsVaultEditor: Component<{
               }
             >
               <div class="p-5">
-                <div class="mb-5 flex items-start justify-between gap-4">
+                <div class="mb-5">
                   <div>
                     <h4 class="m-0 mb-1 text-[1.1rem] font-semibold text-foreground">
                       {editingItemId() ? "Edit vault entry" : "New vault entry"}
@@ -1864,17 +1871,6 @@ const PasswordsVaultEditor: Component<{
                       {props.selectedVault?.name ?? "your vault"}.
                     </p>
                   </div>
-                  <Show when={editingItemId()}>
-                    <button
-                      type="button"
-                      class="inline-flex items-center gap-1.5 rounded-md border border-accent/50 bg-accent/10 px-3 py-2 text-[0.85rem] font-medium text-accent transition hover:bg-accent/15 disabled:opacity-60"
-                      disabled={(props.selectedItem?.fields.length ?? 0) === 0}
-                      onClick={props.onUseForBinding}
-                    >
-                      Use for binding
-                      <IconArrowRight size={14} />
-                    </button>
-                  </Show>
                 </div>
 
                 <label class="mb-4 flex flex-col gap-2">
@@ -1943,8 +1939,10 @@ const PasswordsVaultEditor: Component<{
                     {(row, index) => (
                       <div class={PASSWORD_FIELD_ROW_GRID_CLASS}>
                         <input
-                          class="min-w-0 rounded-md border border-border-strong bg-surface-3/80 px-3 py-2 font-mono text-[0.82rem] uppercase text-foreground focus:border-accent focus:outline-none"
-                          placeholder="ENV_NAME"
+                          class={`min-w-0 rounded-md border border-border-strong bg-surface-3/80 px-3 py-2 font-mono text-[0.82rem] text-foreground focus:border-accent focus:outline-none ${editingApiCredential() ? "uppercase" : ""}`}
+                          placeholder={
+                            editingApiCredential() ? "ENV_NAME" : "field name"
+                          }
                           value={row.name}
                           readOnly={!editableEntry()}
                           onInput={(event) =>
@@ -1953,19 +1951,41 @@ const PasswordsVaultEditor: Component<{
                             })
                           }
                         />
-                        <input
-                          type={showValues() ? "text" : "password"}
-                          autocomplete="off"
-                          class="min-w-0 rounded-md border border-border-strong bg-surface-3/80 px-3 py-2 font-mono text-[0.82rem] text-foreground focus:border-accent focus:outline-none"
-                          placeholder="value"
-                          value={row.value}
-                          readOnly={!editableEntry()}
-                          onInput={(event) =>
-                            updateFieldRow(index(), {
-                              value: event.currentTarget.value,
-                            })
+                        <Show
+                          when={showValues()}
+                          fallback={
+                            <input
+                              type="password"
+                              autocomplete="off"
+                              class={PASSWORD_VALUE_INPUT_CLASS}
+                              placeholder="value"
+                              value={row.value}
+                              readOnly={!editableEntry()}
+                              onInput={(event) =>
+                                updateFieldRow(index(), {
+                                  value: event.currentTarget.value,
+                                })
+                              }
+                            />
                           }
-                        />
+                        >
+                          <textarea
+                            autocomplete="off"
+                            class={`${PASSWORD_VALUE_INPUT_CLASS} min-h-[2.5rem] resize-y overflow-hidden whitespace-pre-wrap break-all`}
+                            ref={resizePasswordValueTextarea}
+                            rows={1}
+                            spellcheck={false}
+                            placeholder="value"
+                            value={row.value}
+                            readOnly={!editableEntry()}
+                            onInput={(event) => {
+                              updateFieldRow(index(), {
+                                value: event.currentTarget.value,
+                              });
+                              resizePasswordValueTextarea(event.currentTarget);
+                            }}
+                          />
+                        </Show>
                         <button
                           type="button"
                           class="grid h-8 w-8 shrink-0 place-items-center rounded-md text-muted-foreground hover:text-destructive disabled:opacity-40"
@@ -2030,7 +2050,6 @@ const GrantAccessForm: Component<{
   agents: GrantTargetChoice[];
   entries: { vaultId: string; itemId: string; title: string }[];
   vaultUnlocked: boolean;
-  prefill: { vaultId: string; itemId: string } | null;
   loadEntryFields: (vaultId: string, itemId: string) => Promise<string[]>;
   findBinding: (
     serviceId: string,
@@ -2066,9 +2085,6 @@ const GrantAccessForm: Component<{
   const [checked, setChecked] = createSignal<Record<string, boolean>>({});
   const [loadingFields, setLoadingFields] = createSignal(false);
   const [serviceOverride, setServiceOverride] = createSignal("");
-  const [appliedPrefillKey, setAppliedPrefillKey] = createSignal<string | null>(
-    null,
-  );
 
   const entryKey = (entry: { vaultId: string; itemId: string }) =>
     `${entry.vaultId}::${entry.itemId}`;
@@ -2114,21 +2130,6 @@ const GrantAccessForm: Component<{
       setChecked({});
     }
   };
-
-  // Apply a "Use for binding" prefill once the entry is in the list. Guarded by
-  // the applied key so a later reactive update does not override a manual pick.
-  createEffect(() => {
-    const pre = props.prefill;
-    if (!pre) return;
-    const key = entryKey(pre);
-    if (
-      appliedPrefillKey() !== key &&
-      props.entries.some((entry) => entryKey(entry) === key)
-    ) {
-      setAppliedPrefillKey(key);
-      selectCredential(key);
-    }
-  });
 
   const disabledReason = () => {
     if (!agentId().trim()) return "Choose an agent";

--- a/tests/unit/keys-settings-ui.test.ts
+++ b/tests/unit/keys-settings-ui.test.ts
@@ -46,7 +46,7 @@ describe("KeysSettings Seren Passwords contract (#1823)", () => {
     expect(keysSettings).toContain("Save your recovery key");
     expect(keysSettings).toContain("New vault entry");
     expect(keysSettings).toContain("Edit vault entry");
-    expect(keysSettings).toContain("Use for binding");
+    expect(keysSettings).not.toContain("Use for binding");
   });
 
   it("requires acknowledging the recovery key and states local-only derivation", () => {
@@ -84,10 +84,16 @@ describe("KeysSettings Seren Passwords contract (#1823)", () => {
     expect(keysSettings).toContain("selectedVaultId() !== item.vaultId");
   });
 
-  it("keeps restored password field variable labels readable", () => {
+  it("keeps restored password fields editable and readable", () => {
     expect(keysSettings).toContain(
-      "grid-cols-[minmax(6rem,0.85fr)_minmax(0,1fr)_2rem]",
+      "grid-cols-[minmax(5.5rem,10rem)_minmax(0,1fr)_2rem]",
     );
-    expect(keysSettings).toContain("min-w-0 rounded-md border");
+    expect(keysSettings).toContain(
+      'editingItemKind() === "api_credential" ||',
+    );
+    expect(keysSettings).toContain('editingItemKind() === "login"');
+    expect(keysSettings).toContain("Only login and API credential entries");
+    expect(keysSettings).toContain("<textarea");
+    expect(keysSettings).toContain("break-all");
   });
 });


### PR DESCRIPTION
## Summary
- make restored `login` vault entries editable in Seren Passwords instead of read-only
- preserve login-specific field names and hidden login metadata when saving existing entries
- replace clipped value inputs with capped, wrapping textareas when values are shown
- remove the non-functional `Use for binding` button from the vault editor

Closes #2752

## Code Path Audit
- UI edit path: `SettingsPanel` -> `KeysSettings` -> `PasswordsVaultEditor` -> `handleSaveVaultItem` -> `savePasswordsApiCredential`
- IPC command: `save_passwords_api_credential`
- Existing item save path: `src-tauri/src/passwords.rs` -> `save_passwords_api_credential_inner`
- Existing login entries now use `sanitize_password_item_fields_in_place` + `merge_login_content_fields`, preserving stored URLs, TOTP config, custom field metadata, tags, and content key wrapping.
- Existing API credentials keep the env-var validation/uppercase behavior.

## Live Publisher Contract
- Called `list_agent_publishers` with no args; live list includes `seren-passwords`.
- `get_agent_publisher(slug: "seren-passwords")` confirms:
  - `GET /vaults/{vault_id}/items`
  - `GET /vaults/{vault_id}/items/{item_id}`
  - `POST /vaults/{vault_id}/items`
  - `PATCH /vaults/{vault_id}/items/{item_id}`
- Dummy live route checks:
  - `GET /vaults/00000000-0000-0000-0000-000000000000/items/00000000-0000-0000-0000-000000000000` returned `404 item not found`, proving route reachability.
  - `PATCH /vaults/00000000-0000-0000-0000-000000000000/items/00000000-0000-0000-0000-000000000000` with an empty body returned `422 invalid request body`, proving method/path reachability.

## Functional Walkthrough
- Vite app smoke: opened Settings -> Passwords in browser mode and confirmed the removed `Use for binding` button is absent.
- Mocked Tauri browser walkthrough: unlocked a mocked `Glide` vault, opened `Linkedin Taariq` login item, clicked `Show values`, edited the password textarea, saved, and confirmed the UI submitted `save_passwords_api_credential` with preserved login field names.
- Live Seren Passwords helper check listed the current `Glide` vault items including `Canva`, `Linkedin Taariq`, Microsoft logins, and `affinity-crm`.

## Tests
- `pnpm exec biome check src/components/settings/KeysSettings.tsx tests/unit/keys-settings-ui.test.ts`
- `pnpm vitest run tests/unit/keys-settings-ui.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml passwords::tests::`
- `pnpm build`
- one-off Playwright browser smoke against `http://127.0.0.1:5177/` for the mocked login edit/save path

## Notes
- `pnpm build` still emits existing Rolldown PURE annotation/chunk warnings from dependencies; build exits successfully.
