### PR TITLE
fix(meetings): add speaker assignment corrections

### DIFF
--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -109,6 +109,34 @@ impl TryFrom<&str> for SpeakerSource {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+pub enum SpeakerAssignmentScope {
+    Meeting,
+    Segment,
+}
+
+impl SpeakerAssignmentScope {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Meeting => "meeting",
+            Self::Segment => "segment",
+        }
+    }
+}
+
+impl TryFrom<&str> for SpeakerAssignmentScope {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "meeting" => Ok(Self::Meeting),
+            "segment" => Ok(Self::Segment),
+            _ => Err(format!("Unknown speaker assignment scope: {}", value)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum SegmentStatus {
     Ok,
     Gap,
@@ -180,6 +208,21 @@ pub struct TranscriptSegment {
     /// Whether `speaker` was assigned by the capture channel or by diarization.
     pub speaker_source: SpeakerSource,
     pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MeetingSpeakerAssignment {
+    pub id: String,
+    pub meeting_id: String,
+    pub source: SpeakerSource,
+    pub source_key: String,
+    pub display_name: String,
+    pub attendee_email: Option<String>,
+    pub scope: SpeakerAssignmentScope,
+    pub segment_id: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -17,12 +17,13 @@ use crate::audio::transcribe::{
     transcribe_full_recording,
 };
 use crate::audio::types::{
-    Meeting, MeetingStatus, SegmentStatus, Speaker, SpeakerSource, TranscriptSegment,
+    Meeting, MeetingSpeakerAssignment, MeetingStatus, SegmentStatus, Speaker,
+    SpeakerAssignmentScope, SpeakerSource, TranscriptSegment,
 };
 use crate::orchestrator::types::SkillRef;
 use crate::services::database::{DbPool, enqueue_sync_tombstone, mark_sync_upsert};
 use rusqlite::{Connection, OptionalExtension, Result, params};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, State};
 use uuid::Uuid;
 
@@ -80,12 +81,8 @@ pub async fn delete_meeting(app: AppHandle, id: String) -> Result<(), String> {
     let app_for_index = app.clone();
     let index_id = deleted_id.clone();
     let _ = tauri::async_runtime::spawn_blocking(move || {
-        if let Ok(conn) =
-            crate::services::transcript_vectors::open_transcript_db(&app_for_index)
-        {
-            let _ = crate::services::transcript_vectors::delete_meeting_chunks(
-                &conn, &index_id,
-            );
+        if let Ok(conn) = crate::services::transcript_vectors::open_transcript_db(&app_for_index) {
+            let _ = crate::services::transcript_vectors::delete_meeting_chunks(&conn, &index_id);
         }
     })
     .await;
@@ -416,7 +413,12 @@ pub async fn republish_meeting_to_seren_notes(
         select_transcript_segments(conn, &transcript_id)
     })
     .await?;
-    let transcript = assemble_transcript(segments);
+    let assignment_lookup = meeting_id.clone();
+    let assignments = run_db(app.clone(), move |conn| {
+        select_meeting_speaker_assignments(conn, &assignment_lookup)
+    })
+    .await?;
+    let transcript = assemble_transcript(segments, &assignments);
     tauri::async_runtime::spawn(async move {
         spawn_seren_notes_publish(app, meeting_id, notes_markdown, action_items, transcript).await;
     });
@@ -587,6 +589,88 @@ pub async fn get_transcript_segments(
         select_transcript_segments(conn, &meeting_id)
     })
     .await
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpeakerAssignmentInput {
+    pub meeting_id: String,
+    pub source: SpeakerSource,
+    pub source_key: String,
+    pub display_name: String,
+    pub attendee_email: Option<String>,
+    pub scope: SpeakerAssignmentScope,
+    pub segment_id: Option<String>,
+}
+
+#[tauri::command]
+pub async fn list_meeting_speaker_assignments(
+    app: AppHandle,
+    meeting_id: String,
+) -> Result<Vec<MeetingSpeakerAssignment>, String> {
+    run_db(app, move |conn| {
+        select_meeting_speaker_assignments(conn, &meeting_id)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn upsert_meeting_speaker_assignment(
+    app: AppHandle,
+    input: SpeakerAssignmentInput,
+) -> Result<MeetingSpeakerAssignment, String> {
+    let display_name = input.display_name.trim().to_string();
+    if display_name.is_empty() {
+        return Err("speaker display name is required".to_string());
+    }
+    let source_key = input.source_key.trim().to_string();
+    if source_key.is_empty() {
+        return Err("speaker source key is required".to_string());
+    }
+    if input.scope == SpeakerAssignmentScope::Segment && input.segment_id.is_none() {
+        return Err("segment assignment requires a segment id".to_string());
+    }
+
+    let meeting_id = input.meeting_id.clone();
+    let attendee_email = input.attendee_email.as_ref().and_then(|email| {
+        let trimmed = email.trim().to_string();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    });
+    let normalized = SpeakerAssignmentInput {
+        meeting_id: input.meeting_id,
+        source: input.source,
+        source_key,
+        display_name,
+        attendee_email,
+        scope: input.scope,
+        segment_id: input.segment_id,
+    };
+    let assignment = run_db(app.clone(), move |conn| {
+        upsert_speaker_assignment_record(conn, normalized)
+    })
+    .await?;
+    let _ = app.emit(
+        "meeting://segments-updated",
+        serde_json::json!({ "meetingId": meeting_id }),
+    );
+    Ok(assignment)
+}
+
+#[tauri::command]
+pub async fn delete_meeting_speaker_assignment(app: AppHandle, id: String) -> Result<(), String> {
+    let meeting_id = run_db(app.clone(), move |conn| {
+        delete_speaker_assignment_record(conn, &id)
+    })
+    .await?;
+    let _ = app.emit(
+        "meeting://segments-updated",
+        serde_json::json!({ "meetingId": meeting_id }),
+    );
+    Ok(())
 }
 
 // --- Capture lifecycle + Tier-1 intelligence -------------------------------
@@ -1085,7 +1169,12 @@ pub async fn generate_meeting_notes(
         select_transcript_segments(conn, &lookup)
     })
     .await?;
-    let transcript = assemble_transcript(segments);
+    let assignment_lookup = meeting_id.clone();
+    let assignments = run_db(app.clone(), move |conn| {
+        select_meeting_speaker_assignments(conn, &assignment_lookup)
+    })
+    .await?;
+    let transcript = assemble_transcript(segments, &assignments);
     if transcript.trim().is_empty() {
         return Err("no transcript to summarize".to_string());
     }
@@ -1127,11 +1216,16 @@ pub async fn get_meeting_transcript_text(
     app: AppHandle,
     meeting_id: String,
 ) -> Result<String, String> {
-    let segments = run_db(app, move |conn| {
-        select_transcript_segments(conn, &meeting_id)
+    let segment_lookup = meeting_id.clone();
+    let segments = run_db(app.clone(), move |conn| {
+        select_transcript_segments(conn, &segment_lookup)
     })
     .await?;
-    Ok(assemble_transcript(segments))
+    let assignments = run_db(app, move |conn| {
+        select_meeting_speaker_assignments(conn, &meeting_id)
+    })
+    .await?;
+    Ok(assemble_transcript(segments, &assignments))
 }
 
 /// Return the slugs of installed skills tagged to handle meetings (0 / 1 / many).
@@ -1342,8 +1436,11 @@ pub async fn transform_selection(
     .await
 }
 
-/// Assemble persisted segments into a chronological "Me/Them" transcript.
-fn assemble_transcript(segments: Vec<TranscriptSegment>) -> String {
+/// Assemble persisted segments into a chronological per-speaker transcript.
+fn assemble_transcript(
+    segments: Vec<TranscriptSegment>,
+    assignments: &[MeetingSpeakerAssignment],
+) -> String {
     let (me, them): (Vec<_>, Vec<_>) = segments
         .into_iter()
         .partition(|segment| segment.speaker == Speaker::Me);
@@ -1351,14 +1448,107 @@ fn assemble_transcript(segments: Vec<TranscriptSegment>) -> String {
         .into_iter()
         .filter(|segment| segment.status == SegmentStatus::Ok && !segment.text.trim().is_empty())
         .map(|segment| {
-            let speaker = match segment.speaker {
-                Speaker::Me => "Me",
-                Speaker::Them => "Them",
-            };
+            let speaker = resolved_transcript_speaker_label(&segment, assignments);
             format!("{speaker}: {}", segment.text.trim())
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn raw_transcript_speaker_label(segment: &TranscriptSegment) -> String {
+    let channel = match segment.speaker {
+        Speaker::Me => "Me",
+        Speaker::Them => "Them",
+    };
+    let Some(label) = normalize_diarized_label(segment.speaker_label.as_deref()) else {
+        return channel.to_string();
+    };
+    format!("{channel} · {label}")
+}
+
+fn normalize_diarized_label(label: Option<&str>) -> Option<String> {
+    let trimmed = label?.trim();
+    if trimmed.is_empty()
+        || trimmed.eq_ignore_ascii_case("me")
+        || trimmed.eq_ignore_ascii_case("them")
+    {
+        return None;
+    }
+    let mut readable = trimmed.to_string();
+    let lower = readable.to_lowercase();
+    if lower.starts_with("speaker_") {
+        readable = readable[8..].to_string();
+    } else if lower.starts_with("speaker-") {
+        readable = readable[8..].to_string();
+    } else if lower.starts_with("speaker ") {
+        readable = readable[8..].to_string();
+    }
+    readable = readable.replace(['_', '-'], " ").trim().to_string();
+    if readable.is_empty() {
+        return None;
+    }
+    let compact = readable.chars().filter(|c| !c.is_whitespace()).count();
+    if lower.starts_with("speaker") || compact <= 3 {
+        return Some(format!("Speaker {readable}"));
+    }
+    Some(readable)
+}
+
+fn speaker_assignment_key(segment: &TranscriptSegment) -> (SpeakerSource, String) {
+    if let Some(label) = segment
+        .speaker_label
+        .as_deref()
+        .map(str::trim)
+        .filter(|label| !label.is_empty())
+    {
+        return (SpeakerSource::Diarization, label.to_string());
+    }
+    (SpeakerSource::Channel, segment.speaker.as_str().to_string())
+}
+
+fn matching_assignment<'a>(
+    segment: &TranscriptSegment,
+    assignments: &'a [MeetingSpeakerAssignment],
+) -> Option<&'a MeetingSpeakerAssignment> {
+    let segment_assignment = assignments.iter().find(|assignment| {
+        assignment.scope == SpeakerAssignmentScope::Segment
+            && assignment.segment_id.as_deref() == Some(segment.id.as_str())
+    });
+    if segment_assignment.is_some() {
+        return segment_assignment;
+    }
+
+    let (source, source_key) = speaker_assignment_key(segment);
+    let meeting_assignment = assignments.iter().find(|assignment| {
+        assignment.scope == SpeakerAssignmentScope::Meeting
+            && assignment.source == source
+            && assignment.source_key == source_key
+    });
+    if meeting_assignment.is_some() {
+        return meeting_assignment;
+    }
+
+    if source == SpeakerSource::Diarization {
+        let channel_key = segment.speaker.as_str();
+        return assignments.iter().find(|assignment| {
+            assignment.scope == SpeakerAssignmentScope::Meeting
+                && assignment.source == SpeakerSource::Channel
+                && assignment.source_key == channel_key
+        });
+    }
+
+    None
+}
+
+fn resolved_transcript_speaker_label(
+    segment: &TranscriptSegment,
+    assignments: &[MeetingSpeakerAssignment],
+) -> String {
+    matching_assignment(segment, assignments)
+        .map(|assignment| assignment.display_name.trim())
+        .filter(|display_name| !display_name.is_empty())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| raw_transcript_speaker_label(segment))
 }
 
 #[derive(Debug, Clone)]
@@ -1457,10 +1647,23 @@ pub fn delete_meeting_record(conn: &Connection, id: &str) -> Result<usize> {
         .query_map(params![id], |row| row.get::<_, String>(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     drop(stmt);
+    let mut stmt =
+        tx.prepare("SELECT id FROM meeting_speaker_assignments WHERE meeting_id = ?1")?;
+    let assignment_ids = stmt
+        .query_map(params![id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(stmt);
     for segment_id in &segment_ids {
         enqueue_sync_tombstone(&tx, "transcript_segments", segment_id)?;
     }
+    for assignment_id in &assignment_ids {
+        enqueue_sync_tombstone(&tx, "meeting_speaker_assignments", assignment_id)?;
+    }
     enqueue_sync_tombstone(&tx, "meetings", id)?;
+    tx.execute(
+        "DELETE FROM meeting_speaker_assignments WHERE meeting_id = ?1",
+        params![id],
+    )?;
     tx.execute(
         "DELETE FROM transcript_segments WHERE meeting_id = ?1",
         params![id],
@@ -1607,6 +1810,163 @@ pub fn update_transcript_segment_speaker(conn: &Connection, id: &str, label: &st
     Ok(())
 }
 
+pub fn select_meeting_speaker_assignments(
+    conn: &Connection,
+    meeting_id: &str,
+) -> Result<Vec<MeetingSpeakerAssignment>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, meeting_id, source, source_key, display_name, attendee_email,
+                scope, segment_id, created_at, updated_at
+         FROM meeting_speaker_assignments
+         WHERE meeting_id = ?1 AND deleted_at IS NULL
+         ORDER BY scope ASC, created_at ASC",
+    )?;
+
+    stmt.query_map(params![meeting_id], row_to_speaker_assignment)?
+        .collect::<Result<Vec<_>>>()
+}
+
+pub fn upsert_speaker_assignment_record(
+    conn: &Connection,
+    input: SpeakerAssignmentInput,
+) -> Result<MeetingSpeakerAssignment> {
+    if input.scope == SpeakerAssignmentScope::Segment {
+        let Some(segment_id) = input.segment_id.as_deref() else {
+            return Err(rusqlite::Error::InvalidParameterName(
+                "segment assignment requires segment id".to_string(),
+            ));
+        };
+        let belongs_to_meeting: bool = conn.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM transcript_segments
+                WHERE id = ?1 AND meeting_id = ?2
+             )",
+            params![segment_id, &input.meeting_id],
+            |row| row.get::<_, i64>(0).map(|value| value != 0),
+        )?;
+        if !belongs_to_meeting {
+            return Err(rusqlite::Error::InvalidParameterName(
+                "segment does not belong to meeting".to_string(),
+            ));
+        }
+    }
+
+    let existing_id: Option<String> = match &input.scope {
+        SpeakerAssignmentScope::Meeting => conn
+            .query_row(
+                "SELECT id FROM meeting_speaker_assignments
+                 WHERE meeting_id = ?1
+                   AND source = ?2
+                   AND source_key = ?3
+                   AND scope = 'meeting'
+                   AND deleted_at IS NULL
+                 LIMIT 1",
+                params![&input.meeting_id, input.source.as_str(), &input.source_key],
+                |row| row.get(0),
+            )
+            .optional()?,
+        SpeakerAssignmentScope::Segment => conn
+            .query_row(
+                "SELECT id FROM meeting_speaker_assignments
+                 WHERE meeting_id = ?1
+                   AND segment_id = ?2
+                   AND scope = 'segment'
+                   AND deleted_at IS NULL
+                 LIMIT 1",
+                params![&input.meeting_id, &input.segment_id],
+                |row| row.get(0),
+            )
+            .optional()?,
+    };
+
+    let now = now_ms();
+    let id = existing_id.unwrap_or_else(|| Uuid::new_v4().to_string());
+    if assignment_exists(conn, &id)? {
+        conn.execute(
+            "UPDATE meeting_speaker_assignments
+             SET source = ?1,
+                 source_key = ?2,
+                 display_name = ?3,
+                 attendee_email = ?4,
+                 scope = ?5,
+                 segment_id = ?6,
+                 updated_at = ?7
+             WHERE id = ?8",
+            params![
+                input.source.as_str(),
+                &input.source_key,
+                &input.display_name,
+                &input.attendee_email,
+                input.scope.as_str(),
+                &input.segment_id,
+                now,
+                &id
+            ],
+        )?;
+    } else {
+        conn.execute(
+            "INSERT INTO meeting_speaker_assignments (
+                id, meeting_id, source, source_key, display_name, attendee_email,
+                scope, segment_id, created_at, updated_at
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)",
+            params![
+                &id,
+                &input.meeting_id,
+                input.source.as_str(),
+                &input.source_key,
+                &input.display_name,
+                &input.attendee_email,
+                input.scope.as_str(),
+                &input.segment_id,
+                now
+            ],
+        )?;
+    }
+    mark_sync_upsert(conn, "meeting_speaker_assignments", &id)?;
+    select_speaker_assignment(conn, &id)?.ok_or(rusqlite::Error::QueryReturnedNoRows)
+}
+
+fn assignment_exists(conn: &Connection, id: &str) -> Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM meeting_speaker_assignments WHERE id = ?1
+         )",
+        params![id],
+        |row| row.get::<_, i64>(0).map(|value| value != 0),
+    )
+}
+
+fn select_speaker_assignment(
+    conn: &Connection,
+    id: &str,
+) -> Result<Option<MeetingSpeakerAssignment>> {
+    conn.query_row(
+        "SELECT id, meeting_id, source, source_key, display_name, attendee_email,
+                scope, segment_id, created_at, updated_at
+         FROM meeting_speaker_assignments
+         WHERE id = ?1 AND deleted_at IS NULL",
+        params![id],
+        row_to_speaker_assignment,
+    )
+    .optional()
+}
+
+pub fn delete_speaker_assignment_record(conn: &Connection, id: &str) -> Result<String> {
+    let meeting_id: String = conn.query_row(
+        "SELECT meeting_id FROM meeting_speaker_assignments
+         WHERE id = ?1 AND deleted_at IS NULL",
+        params![id],
+        |row| row.get(0),
+    )?;
+    enqueue_sync_tombstone(conn, "meeting_speaker_assignments", id)?;
+    conn.execute(
+        "DELETE FROM meeting_speaker_assignments WHERE id = ?1",
+        params![id],
+    )?;
+    Ok(meeting_id)
+}
+
 fn row_to_meeting(row: &rusqlite::Row<'_>) -> Result<Meeting> {
     let status: String = row.get(5)?;
     Ok(Meeting {
@@ -1636,6 +1996,35 @@ fn row_to_meeting(row: &rusqlite::Row<'_>) -> Result<Meeting> {
         calendar_event_id: row.get(17)?,
         calendar_provider: row.get(18)?,
         attendees_json: row.get(19)?,
+    })
+}
+
+fn row_to_speaker_assignment(row: &rusqlite::Row<'_>) -> Result<MeetingSpeakerAssignment> {
+    let source: String = row.get(2)?;
+    let scope: String = row.get(6)?;
+    Ok(MeetingSpeakerAssignment {
+        id: row.get(0)?,
+        meeting_id: row.get(1)?,
+        source: SpeakerSource::try_from(source.as_str()).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(
+                2,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
+            )
+        })?,
+        source_key: row.get(3)?,
+        display_name: row.get(4)?,
+        attendee_email: row.get(5)?,
+        scope: SpeakerAssignmentScope::try_from(scope.as_str()).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
+            )
+        })?,
+        segment_id: row.get(7)?,
+        created_at: row.get(8)?,
+        updated_at: row.get(9)?,
     })
 }
 
@@ -1971,6 +2360,158 @@ mod tests {
     }
 
     #[test]
+    fn speaker_assignments_upsert_and_delete_by_scope() {
+        let conn = setup();
+        insert_meeting(&conn, meeting("meeting-1")).unwrap();
+        insert_transcript_segment(
+            &conn,
+            NewTranscriptSegment {
+                id: "segment-1".to_string(),
+                meeting_id: "meeting-1".to_string(),
+                seq: 0,
+                speaker: Speaker::Them,
+                text: "hello".to_string(),
+                start_ms: 0,
+                end_ms: 100,
+                status: SegmentStatus::Ok,
+                speaker_label: Some("A".to_string()),
+                speaker_source: SpeakerSource::Diarization,
+                created_at: 30,
+            },
+        )
+        .unwrap();
+
+        let first = upsert_speaker_assignment_record(
+            &conn,
+            SpeakerAssignmentInput {
+                meeting_id: "meeting-1".to_string(),
+                source: SpeakerSource::Diarization,
+                source_key: "A".to_string(),
+                display_name: "Ada Lovelace".to_string(),
+                attendee_email: Some("ada@example.com".to_string()),
+                scope: SpeakerAssignmentScope::Meeting,
+                segment_id: None,
+            },
+        )
+        .unwrap();
+        let second = upsert_speaker_assignment_record(
+            &conn,
+            SpeakerAssignmentInput {
+                meeting_id: "meeting-1".to_string(),
+                source: SpeakerSource::Diarization,
+                source_key: "A".to_string(),
+                display_name: "Grace Hopper".to_string(),
+                attendee_email: None,
+                scope: SpeakerAssignmentScope::Meeting,
+                segment_id: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(first.id, second.id);
+        let assignments = select_meeting_speaker_assignments(&conn, "meeting-1").unwrap();
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(assignments[0].display_name, "Grace Hopper");
+        assert_eq!(
+            delete_speaker_assignment_record(&conn, &first.id).unwrap(),
+            "meeting-1"
+        );
+        assert!(
+            select_meeting_speaker_assignments(&conn, "meeting-1")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn assemble_transcript_prefers_segment_then_meeting_assignment() {
+        let segments = vec![
+            TranscriptSegment {
+                id: "segment-1".to_string(),
+                meeting_id: "meeting-1".to_string(),
+                seq: 0,
+                speaker: Speaker::Them,
+                text: "first".to_string(),
+                start_ms: 0,
+                end_ms: 100,
+                status: SegmentStatus::Ok,
+                speaker_label: Some("A".to_string()),
+                speaker_source: SpeakerSource::Diarization,
+                created_at: 30,
+            },
+            TranscriptSegment {
+                id: "segment-2".to_string(),
+                meeting_id: "meeting-1".to_string(),
+                seq: 1,
+                speaker: Speaker::Them,
+                text: "second".to_string(),
+                start_ms: 100,
+                end_ms: 200,
+                status: SegmentStatus::Ok,
+                speaker_label: Some("A".to_string()),
+                speaker_source: SpeakerSource::Diarization,
+                created_at: 31,
+            },
+            TranscriptSegment {
+                id: "segment-3".to_string(),
+                meeting_id: "meeting-1".to_string(),
+                seq: 2,
+                speaker: Speaker::Them,
+                text: "third".to_string(),
+                start_ms: 200,
+                end_ms: 300,
+                status: SegmentStatus::Ok,
+                speaker_label: Some("B".to_string()),
+                speaker_source: SpeakerSource::Diarization,
+                created_at: 32,
+            },
+        ];
+        let assignments = vec![
+            MeetingSpeakerAssignment {
+                id: "assignment-1".to_string(),
+                meeting_id: "meeting-1".to_string(),
+                source: SpeakerSource::Diarization,
+                source_key: "A".to_string(),
+                display_name: "Ada Lovelace".to_string(),
+                attendee_email: None,
+                scope: SpeakerAssignmentScope::Meeting,
+                segment_id: None,
+                created_at: 40,
+                updated_at: 40,
+            },
+            MeetingSpeakerAssignment {
+                id: "assignment-2".to_string(),
+                meeting_id: "meeting-1".to_string(),
+                source: SpeakerSource::Diarization,
+                source_key: "A".to_string(),
+                display_name: "Grace Hopper".to_string(),
+                attendee_email: None,
+                scope: SpeakerAssignmentScope::Segment,
+                segment_id: Some("segment-2".to_string()),
+                created_at: 41,
+                updated_at: 41,
+            },
+            MeetingSpeakerAssignment {
+                id: "assignment-3".to_string(),
+                meeting_id: "meeting-1".to_string(),
+                source: SpeakerSource::Channel,
+                source_key: "them".to_string(),
+                display_name: "Customer".to_string(),
+                attendee_email: None,
+                scope: SpeakerAssignmentScope::Meeting,
+                segment_id: None,
+                created_at: 42,
+                updated_at: 42,
+            },
+        ];
+
+        assert_eq!(
+            assemble_transcript(segments, &assignments),
+            "Ada Lovelace: first\nGrace Hopper: second\nCustomer: third"
+        );
+    }
+
+    #[test]
     fn delete_meeting_record_removes_notes_and_transcript_segments() {
         let conn = setup();
         insert_meeting(&conn, meeting("meeting-1")).unwrap();
@@ -1992,11 +2533,29 @@ mod tests {
             },
         )
         .unwrap();
+        upsert_speaker_assignment_record(
+            &conn,
+            SpeakerAssignmentInput {
+                meeting_id: "meeting-1".to_string(),
+                source: SpeakerSource::Channel,
+                source_key: "me".to_string(),
+                display_name: "Taariq".to_string(),
+                attendee_email: None,
+                scope: SpeakerAssignmentScope::Meeting,
+                segment_id: None,
+            },
+        )
+        .unwrap();
 
         assert_eq!(delete_meeting_record(&conn, "meeting-1").unwrap(), 1);
         assert!(select_meeting(&conn, "meeting-1").unwrap().is_none());
         assert!(
             select_transcript_segments(&conn, "meeting-1")
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            select_meeting_speaker_assignments(&conn, "meeting-1")
                 .unwrap()
                 .is_empty()
         );

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -929,6 +929,9 @@ pub fn run() {
             commands::audio::set_meeting_routed_skill,
             commands::audio::append_transcript_segment,
             commands::audio::get_transcript_segments,
+            commands::audio::list_meeting_speaker_assignments,
+            commands::audio::upsert_meeting_speaker_assignment,
+            commands::audio::delete_meeting_speaker_assignment,
             // Meeting Mode capture + intelligence commands
             commands::audio::start_meeting_capture,
             commands::audio::is_meeting_capture_active,

--- a/src-tauri/src/services/database.rs
+++ b/src-tauri/src/services/database.rs
@@ -18,6 +18,7 @@ pub const HISTORY_SYNC_TABLES: &[&str] = &[
     "thread_drafts",
     "meetings",
     "transcript_segments",
+    "meeting_speaker_assignments",
 ];
 
 #[derive(Debug, Clone, PartialEq)]
@@ -214,6 +215,16 @@ pub fn mark_sync_upsert(conn: &Connection, table_name: &str, row_id: &str) -> Re
         "transcript_segments" => {
             conn.execute(
                 "UPDATE transcript_segments
+                 SET row_version = COALESCE(row_version, 1) + 1,
+                     updated_at = ?1,
+                     deleted_at = NULL
+                 WHERE id = ?2",
+                rusqlite::params![updated_at, row_id],
+            )?;
+        }
+        "meeting_speaker_assignments" => {
+            conn.execute(
+                "UPDATE meeting_speaker_assignments
                  SET row_version = COALESCE(row_version, 1) + 1,
                      updated_at = ?1,
                      deleted_at = NULL
@@ -521,6 +532,23 @@ fn setup_history_sync_schema(conn: &Connection) -> Result<()> {
     )
     .ok();
 
+    add_column_if_missing(
+        conn,
+        "meeting_speaker_assignments",
+        "row_version",
+        "INTEGER NOT NULL DEFAULT 1",
+    )?;
+    add_column_if_missing(conn, "meeting_speaker_assignments", "deleted_at", "INTEGER")?;
+    add_column_if_missing(conn, "meeting_speaker_assignments", "synced_at", "INTEGER")?;
+    add_column_if_missing(conn, "meeting_speaker_assignments", "updated_at", "INTEGER")?;
+    conn.execute(
+        "UPDATE meeting_speaker_assignments
+         SET updated_at = created_at
+         WHERE updated_at IS NULL OR updated_at = 0",
+        [],
+    )
+    .ok();
+
     conn.execute(
         "CREATE TABLE IF NOT EXISTS sync_outbox (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -736,6 +764,45 @@ pub fn setup_schema(conn: &Connection) -> Result<()> {
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_segments_meeting
          ON transcript_segments(meeting_id, seq)",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS meeting_speaker_assignments (
+            id TEXT PRIMARY KEY,
+            meeting_id TEXT NOT NULL,
+            source TEXT NOT NULL,
+            source_key TEXT NOT NULL,
+            display_name TEXT NOT NULL,
+            attendee_email TEXT,
+            scope TEXT NOT NULL,
+            segment_id TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            row_version INTEGER NOT NULL DEFAULT 1,
+            deleted_at INTEGER,
+            synced_at INTEGER,
+            FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE,
+            FOREIGN KEY (segment_id) REFERENCES transcript_segments(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_speaker_assignments_meeting
+         ON meeting_speaker_assignments(meeting_id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_speaker_assignments_meeting_scope
+         ON meeting_speaker_assignments(meeting_id, source, source_key, scope)
+         WHERE scope = 'meeting' AND deleted_at IS NULL",
+        [],
+    )?;
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_speaker_assignments_segment_scope
+         ON meeting_speaker_assignments(meeting_id, segment_id, scope)
+         WHERE scope = 'segment' AND deleted_at IS NULL",
         [],
     )?;
 

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -26,6 +26,7 @@ const PULL_ORDER: &[&str] = &[
     "thread_drafts",
     "meetings",
     "transcript_segments",
+    "meeting_speaker_assignments",
 ];
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -156,6 +157,21 @@ pub fn remote_schema_sql() -> &'static [&'static str] {
             row_version     bigint NOT NULL DEFAULT 1,
             UNIQUE (meeting_id, seq)
         )",
+        "CREATE TABLE IF NOT EXISTS seren_desktop.meeting_speaker_assignments (
+            id              text PRIMARY KEY,
+            meeting_id      text NOT NULL REFERENCES seren_desktop.meetings(id) ON DELETE CASCADE,
+            source          text NOT NULL,
+            source_key      text NOT NULL,
+            display_name    text NOT NULL,
+            attendee_email  text,
+            scope           text NOT NULL,
+            segment_id      text REFERENCES seren_desktop.transcript_segments(id) ON DELETE CASCADE,
+            created_at      bigint NOT NULL,
+            updated_at      bigint NOT NULL,
+            deleted_at      bigint,
+            payload         jsonb NOT NULL DEFAULT '{}'::jsonb,
+            row_version     bigint NOT NULL DEFAULT 1
+        )",
         "CREATE TABLE IF NOT EXISTS seren_desktop.sync_state (
             table_name      text NOT NULL,
             device_id       text NOT NULL,
@@ -168,6 +184,8 @@ pub fn remote_schema_sql() -> &'static [&'static str] {
             ON seren_desktop.message_events(message_id, created_at)",
         "CREATE INDEX IF NOT EXISTS idx_seren_desktop_segments_meeting
             ON seren_desktop.transcript_segments(meeting_id, seq)",
+        "CREATE INDEX IF NOT EXISTS idx_seren_desktop_speaker_assignments_meeting
+            ON seren_desktop.meeting_speaker_assignments(meeting_id)",
     ]
 }
 
@@ -598,6 +616,16 @@ fn push_outbox_item(
                 false
             }
         }
+        "meeting_speaker_assignments" => {
+            if let Some(row) = with_local_db(app, |conn| {
+                load_meeting_speaker_assignment(conn, &item.row_id)
+            })? {
+                push_meeting_speaker_assignment(client, row)?;
+                true
+            } else {
+                false
+            }
+        }
         _ => false,
     };
     Ok(if pushed_row {
@@ -672,6 +700,9 @@ fn mark_synced(app: &AppHandle, table_name: &str, row_id: &str) -> Result<(), St
             "message_events" => "UPDATE message_events SET synced_at = ?1 WHERE id = ?2",
             "meetings" => "UPDATE meetings SET synced_at = ?1 WHERE id = ?2",
             "transcript_segments" => "UPDATE transcript_segments SET synced_at = ?1 WHERE id = ?2",
+            "meeting_speaker_assignments" => {
+                "UPDATE meeting_speaker_assignments SET synced_at = ?1 WHERE id = ?2"
+            }
             "thread_drafts" => "UPDATE conversations SET synced_at = ?1 WHERE id = ?2",
             _ => return Ok(()),
         };
@@ -736,6 +767,14 @@ fn push_tombstone(client: &mut PgClient, item: &OutboxItem) -> Result<(), String
                     &[&item.row_id, &deleted_at],
                 )
                 .map_err(|err| err.to_string())?;
+            client
+                .execute(
+                    "UPDATE seren_desktop.meeting_speaker_assignments
+                     SET deleted_at = $2, row_version = row_version + 1
+                     WHERE meeting_id = $1",
+                    &[&item.row_id, &deleted_at],
+                )
+                .map_err(|err| err.to_string())?;
         }
         "thread_drafts" => {
             client
@@ -745,7 +784,7 @@ fn push_tombstone(client: &mut PgClient, item: &OutboxItem) -> Result<(), String
                 )
                 .map_err(|err| err.to_string())?;
         }
-        "message_events" | "transcript_segments" => {
+        "message_events" | "transcript_segments" | "meeting_speaker_assignments" => {
             update_deleted_at(client, &item.table_name, &item.row_id, deleted_at)?;
         }
         _ => {}
@@ -1286,6 +1325,98 @@ fn push_transcript_segment(client: &mut PgClient, row: TranscriptSegmentRow) -> 
     Ok(())
 }
 
+#[derive(Debug)]
+struct MeetingSpeakerAssignmentRow {
+    id: String,
+    meeting_id: String,
+    source: String,
+    source_key: String,
+    display_name: String,
+    attendee_email: Option<String>,
+    scope: String,
+    segment_id: Option<String>,
+    created_at: i64,
+    updated_at: i64,
+    deleted_at: Option<i64>,
+    payload: Value,
+    row_version: i64,
+}
+
+fn load_meeting_speaker_assignment(
+    conn: &Connection,
+    id: &str,
+) -> rusqlite::Result<Option<MeetingSpeakerAssignmentRow>> {
+    conn.query_row(
+        "SELECT id, meeting_id, source, source_key, display_name, attendee_email,
+                scope, segment_id, created_at, COALESCE(updated_at, created_at),
+                deleted_at, row_version
+         FROM meeting_speaker_assignments
+         WHERE id = ?1",
+        params![id],
+        |row| {
+            Ok(MeetingSpeakerAssignmentRow {
+                id: row.get(0)?,
+                meeting_id: row.get(1)?,
+                source: row.get(2)?,
+                source_key: row.get(3)?,
+                display_name: row.get(4)?,
+                attendee_email: row.get(5)?,
+                scope: row.get(6)?,
+                segment_id: row.get(7)?,
+                created_at: row.get(8)?,
+                updated_at: row.get(9)?,
+                deleted_at: row.get(10)?,
+                row_version: row.get(11)?,
+                payload: checked_payload(json!({})).map_err(to_sqlite_invalid)?,
+            })
+        },
+    )
+    .optional()
+}
+
+fn push_meeting_speaker_assignment(
+    client: &mut PgClient,
+    row: MeetingSpeakerAssignmentRow,
+) -> Result<(), String> {
+    client
+        .execute(
+            "INSERT INTO seren_desktop.meeting_speaker_assignments
+            (id, meeting_id, source, source_key, display_name, attendee_email,
+             scope, segment_id, created_at, updated_at, deleted_at, payload, row_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+         ON CONFLICT(id) DO UPDATE SET
+            meeting_id = excluded.meeting_id,
+            source = excluded.source,
+            source_key = excluded.source_key,
+            display_name = excluded.display_name,
+            attendee_email = excluded.attendee_email,
+            scope = excluded.scope,
+            segment_id = excluded.segment_id,
+            updated_at = excluded.updated_at,
+            deleted_at = excluded.deleted_at,
+            payload = excluded.payload,
+            row_version = excluded.row_version
+         WHERE excluded.row_version >= seren_desktop.meeting_speaker_assignments.row_version",
+            &[
+                &row.id,
+                &row.meeting_id,
+                &row.source,
+                &row.source_key,
+                &row.display_name,
+                &row.attendee_email,
+                &row.scope,
+                &row.segment_id,
+                &row.created_at,
+                &row.updated_at,
+                &row.deleted_at,
+                &row.payload,
+                &row.row_version,
+            ],
+        )
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
 fn pull_remote(app: &AppHandle, client: &mut PgClient, sync_scope: &str) -> Result<usize, String> {
     let mut pulled = 0usize;
     for table_name in PULL_ORDER {
@@ -1356,6 +1487,7 @@ fn apply_remote_row(app: &AppHandle, table_name: &str, row: PgRow) -> Result<(),
         "thread_drafts" => apply_remote_thread_draft(conn, row),
         "meetings" => apply_remote_meeting(conn, row),
         "transcript_segments" => apply_remote_transcript_segment(conn, row),
+        "meeting_speaker_assignments" => apply_remote_meeting_speaker_assignment(conn, row),
         _ => Ok(()),
     })
 }
@@ -1644,6 +1776,53 @@ fn apply_remote_transcript_segment(conn: &Connection, row: PgRow) -> rusqlite::R
     Ok(())
 }
 
+fn apply_remote_meeting_speaker_assignment(conn: &Connection, row: PgRow) -> rusqlite::Result<()> {
+    let id: String = pg_get(&row, "id")?;
+    if pg_get::<Option<i64>>(&row, "deleted_at")?.is_some() {
+        conn.execute(
+            "DELETE FROM meeting_speaker_assignments WHERE id = ?1",
+            params![id],
+        )?;
+        return Ok(());
+    }
+    conn.execute(
+        "INSERT INTO meeting_speaker_assignments (
+            id, meeting_id, source, source_key, display_name, attendee_email,
+            scope, segment_id, created_at, row_version, updated_at, synced_at,
+            deleted_at
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, NULL)
+         ON CONFLICT(id) DO UPDATE SET
+            meeting_id = excluded.meeting_id,
+            source = excluded.source,
+            source_key = excluded.source_key,
+            display_name = excluded.display_name,
+            attendee_email = excluded.attendee_email,
+            scope = excluded.scope,
+            segment_id = excluded.segment_id,
+            row_version = excluded.row_version,
+            updated_at = excluded.updated_at,
+            synced_at = excluded.synced_at,
+            deleted_at = NULL
+         WHERE COALESCE(meeting_speaker_assignments.row_version, 0) <= excluded.row_version",
+        params![
+            id,
+            pg_get::<String>(&row, "meeting_id")?,
+            pg_get::<String>(&row, "source")?,
+            pg_get::<String>(&row, "source_key")?,
+            pg_get::<String>(&row, "display_name")?,
+            pg_get::<Option<String>>(&row, "attendee_email")?,
+            pg_get::<String>(&row, "scope")?,
+            pg_get::<Option<String>>(&row, "segment_id")?,
+            pg_get::<i64>(&row, "created_at")?,
+            pg_get::<i64>(&row, "row_version")?,
+            pg_get::<i64>(&row, "updated_at")?,
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
 fn delete_conversation_local(conn: &Connection, id: &str) -> rusqlite::Result<()> {
     conn.execute(
         "DELETE FROM message_events WHERE conversation_id = ?1",
@@ -1658,6 +1837,10 @@ fn delete_conversation_local(conn: &Connection, id: &str) -> rusqlite::Result<()
 }
 
 fn delete_meeting_local(conn: &Connection, id: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "DELETE FROM meeting_speaker_assignments WHERE meeting_id = ?1",
+        params![id],
+    )?;
     conn.execute(
         "DELETE FROM transcript_segments WHERE meeting_id = ?1",
         params![id],

--- a/src/components/meeting/MeetingDetail.tsx
+++ b/src/components/meeting/MeetingDetail.tsx
@@ -13,6 +13,7 @@ import { openExternalLink } from "@/lib/external-link";
 import {
   formatDuration,
   formatMeetingDate,
+  formatRawTranscriptSpeakerLabel,
   formatTime,
   formatTranscriptSpeakerLabel,
   isMeetingDurationLive,
@@ -40,6 +41,69 @@ interface MeetingDetailProps {
   meeting: Meeting;
   durationNow?: number;
   onRequestDelete?: (meeting: Meeting) => void;
+}
+
+interface AttendeeOption {
+  label: string;
+  name: string;
+  email: string | null;
+}
+
+interface SpeakerEditorState {
+  segmentId: string;
+  displayName: string;
+  attendeeEmail: string | null;
+  scope: "meeting" | "segment";
+}
+
+function parseAttendeeOption(value: unknown): AttendeeOption | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const match = trimmed.match(/^(.*?)\s*<([^>]+)>$/);
+    if (match) {
+      const name = (match[1] || match[2]).trim();
+      const email = match[2].trim();
+      return { label: `${name} <${email}>`, name, email };
+    }
+    const email = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed) ? trimmed : null;
+    return { label: trimmed, name: trimmed, email };
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const name =
+      typeof record.name === "string" ? record.name.trim() : undefined;
+    const email =
+      typeof record.email === "string" ? record.email.trim() : undefined;
+    const display = name || email;
+    if (!display) return null;
+    return {
+      label: email && name ? `${name} <${email}>` : display,
+      name: display,
+      email: email || null,
+    };
+  }
+  return null;
+}
+
+function parseAttendees(json: string | null | undefined): AttendeeOption[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const seen = new Set<string>();
+    return parsed
+      .map(parseAttendeeOption)
+      .filter((item): item is AttendeeOption => item !== null)
+      .filter((item) => {
+        const key = `${item.name}\n${item.email ?? ""}`.toLowerCase();
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+  } catch {
+    return [];
+  }
 }
 
 function PencilGlyph() {
@@ -140,6 +204,8 @@ export function MeetingDetail(props: MeetingDetailProps) {
   >([]);
   const [selectedSkillSlug, setSelectedSkillSlug] = createSignal("");
   const [routing, setRouting] = createSignal(false);
+  const [speakerEditor, setSpeakerEditor] =
+    createSignal<SpeakerEditorState | null>(null);
 
   const rows = new Map<number, HTMLElement>();
 
@@ -174,6 +240,12 @@ export function MeetingDetail(props: MeetingDetailProps) {
   );
 
   const segments = () => meetingStore.state.liveSegments;
+  const attendeeOptions = createMemo(() =>
+    parseAttendees(props.meeting.attendeesJson),
+  );
+  const attendeeDatalistId = createMemo(
+    () => `meeting-speaker-attendees-${props.meeting.id}`,
+  );
   const durationNow = () =>
     isMeetingDurationLive(props.meeting) ? props.durationNow : undefined;
   const processing = () => isMeetingProcessingStatus(props.meeting.status);
@@ -275,6 +347,63 @@ export function MeetingDetail(props: MeetingDetailProps) {
     } finally {
       setRouting(false);
     }
+  };
+
+  const startSpeakerEdit = (segment: TranscriptSegment) => {
+    setSpeakerEditor({
+      segmentId: segment.id,
+      displayName: segment.speakerDisplayName ?? "",
+      attendeeEmail: null,
+      scope: segment.speakerAssignmentScope ?? "meeting",
+    });
+  };
+
+  const speakerEditorFor = (segment: TranscriptSegment) => {
+    const editor = speakerEditor();
+    return editor?.segmentId === segment.id ? editor : null;
+  };
+
+  const updateSpeakerDraft = (value: string) => {
+    const editor = speakerEditor();
+    if (!editor) return;
+    const match = attendeeOptions().find(
+      (option) => option.label === value || option.name === value,
+    );
+    setSpeakerEditor({
+      ...editor,
+      displayName: match?.name ?? value,
+      attendeeEmail: match?.email ?? null,
+    });
+  };
+
+  const setSpeakerScope = (scope: "meeting" | "segment") => {
+    const editor = speakerEditor();
+    if (!editor) return;
+    setSpeakerEditor({ ...editor, scope });
+  };
+
+  const commitSpeakerEdit = async (segment: TranscriptSegment) => {
+    const editor = speakerEditor();
+    if (!editor || editor.segmentId !== segment.id) return;
+    const displayName = editor.displayName.trim();
+    if (!displayName) return;
+    await meetingStore.assignSpeakerName({
+      meeting: props.meeting,
+      segment,
+      displayName,
+      attendeeEmail: editor.attendeeEmail,
+      scope: editor.scope,
+    });
+    setSpeakerEditor(null);
+  };
+
+  const clearSpeakerEdit = async (segment: TranscriptSegment) => {
+    if (!segment.speakerAssignmentId) return;
+    await meetingStore.clearSpeakerAssignment(
+      props.meeting,
+      segment.speakerAssignmentId,
+    );
+    setSpeakerEditor(null);
   };
 
   // Manual republish for #2343. The backend uses PublishGuard so a
@@ -595,24 +724,38 @@ export function MeetingDetail(props: MeetingDetailProps) {
           }
         >
           <div class="rounded-md border border-border bg-surface-0/50 px-3">
+            <datalist id={attendeeDatalistId()}>
+              <For each={attendeeOptions()}>
+                {(attendee) => <option value={attendee.label} />}
+              </For>
+            </datalist>
             <For each={segments()}>
               {(segment) => (
                 <div
                   ref={(el) => rows.set(segment.seq, el)}
-                  class="grid grid-cols-[112px_minmax(0,1fr)] gap-3 py-2 border-b border-border/50 last:border-b-0 transition-colors"
+                  class="grid grid-cols-[160px_minmax(0,1fr)] gap-x-3 gap-y-2 py-2 border-b border-border/50 last:border-b-0 transition-colors"
                   classList={{
                     "bg-primary/10": highlightedSeq() === segment.seq,
                   }}
                 >
-                  <div
-                    class="truncate text-[11px] font-mono tabular-nums"
+                  <button
+                    type="button"
+                    class="group inline-flex min-w-0 max-w-full items-center gap-1 rounded border border-transparent px-1 py-0.5 text-left text-[11px] font-mono tabular-nums transition-colors hover:border-border hover:bg-surface-1 focus:outline-none focus:border-primary/60"
                     classList={{
                       "text-foreground": segment.speaker === "me",
                       "text-muted-foreground": segment.speaker === "them",
                     }}
+                    onClick={() => startSpeakerEdit(segment)}
+                    title={`Assign speaker: ${formatRawTranscriptSpeakerLabel(segment)}`}
+                    aria-label={`Assign speaker for ${formatRawTranscriptSpeakerLabel(segment)}`}
                   >
-                    {formatTranscriptSpeakerLabel(segment)}
-                  </div>
+                    <span class="min-w-0 truncate">
+                      {formatTranscriptSpeakerLabel(segment)}
+                    </span>
+                    <span class="shrink-0 opacity-0 transition-opacity group-hover:opacity-70 group-focus:opacity-70">
+                      <PencilGlyph />
+                    </span>
+                  </button>
                   <div
                     class="min-w-0 break-words text-[13px] leading-5"
                     classList={{
@@ -624,6 +767,100 @@ export function MeetingDetail(props: MeetingDetailProps) {
                       ? segment.text || "Transcript gap"
                       : segment.text}
                   </div>
+                  <Show when={speakerEditorFor(segment)}>
+                    {(editor) => (
+                      <div class="col-span-2 rounded-md border border-border bg-surface-1 p-2.5">
+                        <div class="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
+                          <input
+                            ref={(el) => queueMicrotask(() => el.focus())}
+                            class="h-8 min-w-0 rounded-md border border-border bg-surface-0 px-2.5 text-[13px] text-foreground focus:outline-none focus:border-primary/60"
+                            value={editor().displayName}
+                            list={attendeeDatalistId()}
+                            placeholder="Speaker name"
+                            aria-label="Speaker name"
+                            onInput={(event) =>
+                              updateSpeakerDraft(event.currentTarget.value)
+                            }
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter") {
+                                event.preventDefault();
+                                void commitSpeakerEdit(segment);
+                              } else if (event.key === "Escape") {
+                                event.preventDefault();
+                                setSpeakerEditor(null);
+                              }
+                            }}
+                          />
+                          <div
+                            class="inline-flex h-8 overflow-hidden rounded-md border border-border bg-surface-0"
+                            role="group"
+                            aria-label="Speaker assignment scope"
+                          >
+                            <button
+                              type="button"
+                              class="px-2.5 text-[12px] transition-colors"
+                              classList={{
+                                "bg-primary/15 text-primary":
+                                  editor().scope === "segment",
+                                "text-muted-foreground hover:text-foreground":
+                                  editor().scope !== "segment",
+                              }}
+                              onClick={() => setSpeakerScope("segment")}
+                            >
+                              One
+                            </button>
+                            <button
+                              type="button"
+                              class="border-l border-border px-2.5 text-[12px] transition-colors"
+                              classList={{
+                                "bg-primary/15 text-primary":
+                                  editor().scope === "meeting",
+                                "text-muted-foreground hover:text-foreground":
+                                  editor().scope !== "meeting",
+                              }}
+                              onClick={() => setSpeakerScope("meeting")}
+                            >
+                              All
+                            </button>
+                          </div>
+                        </div>
+                        <div class="mt-2 flex items-center justify-between gap-2">
+                          <span
+                            class="min-w-0 truncate text-[11px] text-muted-foreground"
+                            title={formatRawTranscriptSpeakerLabel(segment)}
+                          >
+                            {formatRawTranscriptSpeakerLabel(segment)}
+                          </span>
+                          <div class="flex shrink-0 items-center gap-2">
+                            <Show when={segment.speakerAssignmentId}>
+                              <button
+                                type="button"
+                                class="h-7 px-2 rounded-md border border-border text-[12px] text-muted-foreground hover:text-foreground"
+                                onClick={() => void clearSpeakerEdit(segment)}
+                              >
+                                Clear
+                              </button>
+                            </Show>
+                            <button
+                              type="button"
+                              class="h-7 px-2 rounded-md border border-border text-[12px] text-muted-foreground hover:text-foreground"
+                              onClick={() => setSpeakerEditor(null)}
+                            >
+                              Cancel
+                            </button>
+                            <button
+                              type="button"
+                              class="h-7 px-2.5 rounded-md border border-primary/40 bg-primary/10 text-[12px] text-primary hover:bg-primary/15 disabled:opacity-50"
+                              disabled={!editor().displayName.trim()}
+                              onClick={() => void commitSpeakerEdit(segment)}
+                            >
+                              Save
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </Show>
                 </div>
               )}
             </For>

--- a/src/lib/meeting-format.ts
+++ b/src/lib/meeting-format.ts
@@ -132,10 +132,20 @@ function normalizeDiarizedLabel(label: string | null | undefined): string {
   return readable;
 }
 
-export function formatTranscriptSpeakerLabel(
+export function formatRawTranscriptSpeakerLabel(
   segment: Pick<TranscriptSegment, "speaker" | "speakerLabel">,
 ): string {
   const channel = segment.speaker === "me" ? "Me" : "Them";
   const diarized = normalizeDiarizedLabel(segment.speakerLabel);
   return diarized ? `${channel} · ${diarized}` : channel;
+}
+
+export function formatTranscriptSpeakerLabel(
+  segment: Pick<
+    TranscriptSegment,
+    "speaker" | "speakerLabel" | "speakerDisplayName"
+  >,
+): string {
+  const corrected = segment.speakerDisplayName?.trim();
+  return corrected || formatRawTranscriptSpeakerLabel(segment);
 }

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -44,6 +44,20 @@ export interface Meeting {
 }
 
 export type SpeakerSource = "channel" | "diarization";
+export type SpeakerAssignmentScope = "meeting" | "segment";
+
+export interface MeetingSpeakerAssignment {
+  id: string;
+  meetingId: string;
+  source: SpeakerSource;
+  sourceKey: string;
+  displayName: string;
+  attendeeEmail?: string | null;
+  scope: SpeakerAssignmentScope;
+  segmentId?: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
 
 export interface TranscriptSegment {
   id: string;
@@ -58,6 +72,11 @@ export interface TranscriptSegment {
   speakerLabel?: string | null;
   /** Whether `speaker` came from the capture channel or model diarization. */
   speakerSource?: SpeakerSource;
+  /** User-corrected speaker name resolved from assignment state, if present. */
+  speakerDisplayName?: string | null;
+  /** Assignment that supplied `speakerDisplayName`, useful for undo/change UI. */
+  speakerAssignmentId?: string | null;
+  speakerAssignmentScope?: SpeakerAssignmentScope | null;
   createdAt: number;
 }
 
@@ -170,10 +189,114 @@ export function appendTranscriptSegment(
   });
 }
 
-export function getTranscriptSegments(
+export interface SegmentSpeakerKey {
+  source: SpeakerSource;
+  sourceKey: string;
+}
+
+export function segmentSpeakerKey(
+  segment: TranscriptSegment,
+): SegmentSpeakerKey {
+  const diarized = segment.speakerLabel?.trim();
+  if (diarized) {
+    return { source: "diarization", sourceKey: diarized };
+  }
+  return { source: "channel", sourceKey: segment.speaker };
+}
+
+export function resolveSpeakerAssignment(
+  segment: TranscriptSegment,
+  assignments: readonly MeetingSpeakerAssignment[],
+): MeetingSpeakerAssignment | null {
+  const segmentAssignment =
+    assignments.find(
+      (assignment) =>
+        assignment.scope === "segment" && assignment.segmentId === segment.id,
+    ) ?? null;
+  if (segmentAssignment) return segmentAssignment;
+
+  const key = segmentSpeakerKey(segment);
+  const meetingAssignment = assignments.find(
+    (assignment) =>
+      assignment.scope === "meeting" &&
+      assignment.source === key.source &&
+      assignment.sourceKey === key.sourceKey,
+  );
+  if (meetingAssignment) return meetingAssignment;
+
+  if (key.source === "diarization") {
+    return (
+      assignments.find(
+        (assignment) =>
+          assignment.scope === "meeting" &&
+          assignment.source === "channel" &&
+          assignment.sourceKey === segment.speaker,
+      ) ?? null
+    );
+  }
+
+  return null;
+}
+
+export function applySpeakerAssignmentsToSegments(
+  segments: readonly TranscriptSegment[],
+  assignments: readonly MeetingSpeakerAssignment[],
+): TranscriptSegment[] {
+  return segments.map((segment) => {
+    const assignment = resolveSpeakerAssignment(segment, assignments);
+    if (!assignment) {
+      return {
+        ...segment,
+        speakerDisplayName: null,
+        speakerAssignmentId: null,
+        speakerAssignmentScope: null,
+      };
+    }
+    return {
+      ...segment,
+      speakerDisplayName: assignment.displayName,
+      speakerAssignmentId: assignment.id,
+      speakerAssignmentScope: assignment.scope,
+    };
+  });
+}
+
+export function listMeetingSpeakerAssignments(
+  meetingId: string,
+): Promise<MeetingSpeakerAssignment[]> {
+  return invoke("list_meeting_speaker_assignments", { meetingId });
+}
+
+export interface UpsertMeetingSpeakerAssignmentInput {
+  meetingId: string;
+  source: SpeakerSource;
+  sourceKey: string;
+  displayName: string;
+  attendeeEmail?: string | null;
+  scope: SpeakerAssignmentScope;
+  segmentId?: string | null;
+}
+
+export function upsertMeetingSpeakerAssignment(
+  input: UpsertMeetingSpeakerAssignmentInput,
+): Promise<MeetingSpeakerAssignment> {
+  return invoke("upsert_meeting_speaker_assignment", { input });
+}
+
+export function deleteMeetingSpeakerAssignment(id: string): Promise<void> {
+  return invoke("delete_meeting_speaker_assignment", { id });
+}
+
+export async function getTranscriptSegments(
   meetingId: string,
 ): Promise<TranscriptSegment[]> {
-  return invoke("get_transcript_segments", { meetingId });
+  const [segments, assignments] = await Promise.all([
+    invoke<TranscriptSegment[]>("get_transcript_segments", { meetingId }),
+    listMeetingSpeakerAssignments(meetingId).catch(
+      () => [] as MeetingSpeakerAssignment[],
+    ),
+  ]);
+  return applySpeakerAssignmentsToSegments(segments, assignments);
 }
 
 export interface StructuredNotes {

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -17,17 +17,21 @@ import {
   matchActiveEvent,
 } from "@/services/calendar";
 import {
+  applySpeakerAssignmentsToSegments,
   type CaptureStopOutcome,
   createMeeting,
   deleteMeeting as deleteMeetingRecord,
+  deleteMeetingSpeakerAssignment,
   generateMeetingNotes,
   getMeetingTranscriptText,
   getTranscriptSegments,
   isMeetingCaptureActive,
   isMeetingCapturePaused,
+  listMeetingSpeakerAssignments,
   listMeetings,
   listMeetingTemplates,
   type Meeting,
+  type MeetingSpeakerAssignment,
   type MeetingTemplate,
   meetingAutodetect,
   meetingLifecycleNoteManualStop,
@@ -37,6 +41,7 @@ import {
   reconcileMeetingSpeakers,
   republishMeetingToSerenNotes,
   resumeMeetingCapture,
+  segmentSpeakerKey,
   selectMeetingSkills,
   setMeetingRoutedSkill,
   startMeetingCapture as startBackendCapture,
@@ -45,11 +50,13 @@ import {
   updateMeetingStatus,
   updateMeetingTemplate,
   updateMeetingTitle,
+  upsertMeetingSpeakerAssignment,
 } from "@/services/meetings";
 import { orchestrate } from "@/services/orchestrator";
 import {
   backfillTranscriptIndex,
   deleteMeetingIndex,
+  indexMeeting,
 } from "@/services/transcript-search";
 import { onTrayToggleCapture, setTrayRecording } from "@/services/tray";
 import { conversationStore } from "@/stores/conversation.store";
@@ -61,6 +68,7 @@ interface MeetingState {
   meetings: Meeting[];
   activeMeeting: Meeting | null;
   liveSegments: TranscriptSegment[];
+  speakerAssignments: MeetingSpeakerAssignment[];
   captureLevel: number;
   /** True while the active capture is paused (frame ingestion suspended). */
   capturePaused: boolean;
@@ -111,6 +119,7 @@ const [meetingState, setMeetingState] = createStore<MeetingState>({
   meetings: [],
   activeMeeting: null,
   liveSegments: [],
+  speakerAssignments: [],
   captureLevel: 0,
   capturePaused: false,
   capturePausedAt: null,
@@ -294,15 +303,23 @@ async function setActiveMeeting(meeting: Meeting | null): Promise<void> {
   setMeetingState("activeMeeting", meeting);
   if (!meeting) {
     setMeetingState("liveSegments", []);
+    setMeetingState("speakerAssignments", []);
     return;
   }
   if (!isTauriRuntime()) {
     setMeetingState("liveSegments", []);
+    setMeetingState("speakerAssignments", []);
     return;
   }
 
   try {
-    const segments = await getTranscriptSegments(meeting.id);
+    const [segments, assignments] = await Promise.all([
+      getTranscriptSegments(meeting.id),
+      listMeetingSpeakerAssignments(meeting.id).catch(
+        () => [] as MeetingSpeakerAssignment[],
+      ),
+    ]);
+    setMeetingState("speakerAssignments", assignments);
     setMeetingState("liveSegments", sortSegmentsByCapture(segments));
   } catch (error) {
     setMeetingState(
@@ -329,9 +346,13 @@ export function sortSegmentsByCapture(
 }
 
 function appendLiveSegment(segment: TranscriptSegment): void {
+  const [assigned] = applySpeakerAssignmentsToSegments(
+    [segment],
+    meetingState.speakerAssignments,
+  );
   setMeetingState("liveSegments", (segments) => {
-    const withoutDuplicate = segments.filter((item) => item.id !== segment.id);
-    return sortSegmentsByCapture([...withoutDuplicate, segment]);
+    const withoutDuplicate = segments.filter((item) => item.id !== assigned.id);
+    return sortSegmentsByCapture([...withoutDuplicate, assigned]);
   });
 }
 
@@ -411,10 +432,16 @@ async function startMeetingEventListeners(): Promise<void> {
     (event) => {
       const active = meetingState.activeMeeting;
       if (active?.id !== event.payload.meetingId) return;
-      void getTranscriptSegments(event.payload.meetingId)
-        .then((segments) =>
-          setMeetingState("liveSegments", sortSegmentsByCapture(segments)),
-        )
+      void Promise.all([
+        getTranscriptSegments(event.payload.meetingId),
+        listMeetingSpeakerAssignments(event.payload.meetingId).catch(
+          () => [] as MeetingSpeakerAssignment[],
+        ),
+      ])
+        .then(([segments, assignments]) => {
+          setMeetingState("speakerAssignments", assignments);
+          setMeetingState("liveSegments", sortSegmentsByCapture(segments));
+        })
         .catch(() => {
           // Non-fatal: the existing labels stay; a manual refresh will reload.
         });
@@ -1087,6 +1114,73 @@ async function setMeetingTemplate(
   }
 }
 
+async function refreshSpeakerAssignments(meetingId: string): Promise<void> {
+  const assignments = await listMeetingSpeakerAssignments(meetingId).catch(
+    () => [] as MeetingSpeakerAssignment[],
+  );
+  setMeetingState("speakerAssignments", assignments);
+  setMeetingState("liveSegments", (segments) =>
+    sortSegmentsByCapture(
+      applySpeakerAssignmentsToSegments(segments, assignments),
+    ),
+  );
+}
+
+async function assignSpeakerName(input: {
+  meeting: Meeting;
+  segment: TranscriptSegment;
+  displayName: string;
+  attendeeEmail?: string | null;
+  scope: "meeting" | "segment";
+}): Promise<void> {
+  if (!isTauriRuntime()) return;
+  const name = input.displayName.trim();
+  if (!name) {
+    setMeetingState("error", "Speaker name is required.");
+    return;
+  }
+  try {
+    const key = segmentSpeakerKey(input.segment);
+    await upsertMeetingSpeakerAssignment({
+      meetingId: input.meeting.id,
+      source: key.source,
+      sourceKey: key.sourceKey,
+      displayName: name,
+      attendeeEmail: input.attendeeEmail ?? null,
+      scope: input.scope,
+      segmentId: input.scope === "segment" ? input.segment.id : null,
+    });
+    await refreshSpeakerAssignments(input.meeting.id);
+    if (INDEXABLE_STATUSES.has(input.meeting.status)) {
+      void indexMeeting(input.meeting.id).catch(() => {});
+    }
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Failed to assign speaker",
+    );
+  }
+}
+
+async function clearSpeakerAssignment(
+  meeting: Meeting,
+  assignmentId: string,
+): Promise<void> {
+  if (!isTauriRuntime() || !assignmentId) return;
+  try {
+    await deleteMeetingSpeakerAssignment(assignmentId);
+    await refreshSpeakerAssignments(meeting.id);
+    if (INDEXABLE_STATUSES.has(meeting.status)) {
+      void indexMeeting(meeting.id).catch(() => {});
+    }
+  } catch (error) {
+    setMeetingState(
+      "error",
+      error instanceof Error ? error.message : "Failed to clear speaker",
+    );
+  }
+}
+
 async function deleteMeeting(meeting: Meeting): Promise<void> {
   if (!isTauriRuntime()) return;
   setMeetingState("error", null);
@@ -1416,6 +1510,8 @@ export const meetingStore = {
   republishToSerenNotes,
   renameMeeting,
   setMeetingTemplate,
+  assignSpeakerName,
+  clearSpeakerAssignment,
   deleteMeeting,
   clearError,
   startAutoDetect,

--- a/tests/unit/meeting-speaker-assignment.test.ts
+++ b/tests/unit/meeting-speaker-assignment.test.ts
@@ -1,0 +1,92 @@
+// ABOUTME: Critical speaker-assignment resolution coverage for Meeting Mode.
+// ABOUTME: Segment corrections must beat meeting-wide corrections without losing raw labels.
+
+import { describe, expect, it } from "vitest";
+import {
+  formatRawTranscriptSpeakerLabel,
+  formatTranscriptSpeakerLabel,
+} from "@/lib/meeting-format";
+import {
+  applySpeakerAssignmentsToSegments,
+  type MeetingSpeakerAssignment,
+  type TranscriptSegment,
+} from "@/services/meetings";
+
+function segment(over: Partial<TranscriptSegment> = {}): TranscriptSegment {
+  return {
+    id: "s1",
+    meetingId: "m1",
+    seq: 1,
+    speaker: "them",
+    text: "roadmap",
+    startMs: 0,
+    endMs: 100,
+    status: "ok",
+    speakerLabel: "A",
+    speakerSource: "diarization",
+    createdAt: 0,
+    ...over,
+  };
+}
+
+function assignment(
+  over: Partial<MeetingSpeakerAssignment> = {},
+): MeetingSpeakerAssignment {
+  return {
+    id: "a1",
+    meetingId: "m1",
+    source: "diarization",
+    sourceKey: "A",
+    displayName: "Ada Lovelace",
+    attendeeEmail: null,
+    scope: "meeting",
+    segmentId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...over,
+  };
+}
+
+describe("meeting speaker assignments", () => {
+  it("prefers segment assignment, then meeting assignment, then raw label", () => {
+    const raw = segment();
+    expect(formatTranscriptSpeakerLabel(raw)).toBe("Them · Speaker A");
+    expect(formatRawTranscriptSpeakerLabel(raw)).toBe("Them · Speaker A");
+
+    const meetingAssigned = applySpeakerAssignmentsToSegments(rawArray(raw), [
+      assignment(),
+    ])[0];
+    expect(formatTranscriptSpeakerLabel(meetingAssigned)).toBe("Ada Lovelace");
+
+    const segmentAssigned = applySpeakerAssignmentsToSegments(rawArray(raw), [
+      assignment(),
+      assignment({
+        id: "a2",
+        displayName: "Grace Hopper",
+        scope: "segment",
+        segmentId: "s1",
+      }),
+    ])[0];
+    expect(formatTranscriptSpeakerLabel(segmentAssigned)).toBe("Grace Hopper");
+    expect(formatRawTranscriptSpeakerLabel(segmentAssigned)).toBe(
+      "Them · Speaker A",
+    );
+  });
+
+  it("keeps channel-wide assignments after diarization labels arrive", () => {
+    const assigned = applySpeakerAssignmentsToSegments(rawArray(segment()), [
+      assignment({
+        source: "channel",
+        sourceKey: "them",
+        displayName: "Customer",
+      }),
+    ])[0];
+
+    expect(formatTranscriptSpeakerLabel(assigned)).toBe("Customer");
+    expect(formatRawTranscriptSpeakerLabel(assigned)).toBe("Them · Speaker A");
+  });
+});
+
+function rawArray(segment: TranscriptSegment): TranscriptSegment[] {
+  return [segment];
+}

--- a/tests/unit/save-to-notes-inner-408-retry.test.ts
+++ b/tests/unit/save-to-notes-inner-408-retry.test.ts
@@ -83,6 +83,18 @@ describe("saveToSerenNotes — publisher-inner 408 cold-start retry", () => {
     await promise;
 
     expect(mockAppFetch).toHaveBeenCalledTimes(2);
+    const [url, init] = mockAppFetch.mock.calls[0] ?? [];
+    expect(url).toBe("https://api.serendb.com/publishers/seren-notes/notes");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer test-token",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      title: "Chat History",
+      content: "# hi",
+      format: "markdown",
+    });
     expect(mockOpenExternalLink).toHaveBeenCalledWith(
       `https://notes.serendb.com/notes/${UUID}`,
     );

--- a/tests/unit/transcript-chunk.test.ts
+++ b/tests/unit/transcript-chunk.test.ts
@@ -47,6 +47,18 @@ describe("chunkTranscript", () => {
     expect(chunks[0].text).toBe("Them · Speaker 0: roadmap update");
   });
 
+  it("uses corrected speaker names when chunking for search snippets", () => {
+    const chunks = chunkTranscript([
+      seg(0, "roadmap update", {
+        speaker: "them",
+        speakerLabel: "speaker_0",
+        speakerDisplayName: "Ada Lovelace",
+      }),
+    ]);
+
+    expect(chunks[0].text).toBe("Ada Lovelace: roadmap update");
+  });
+
   it("splits into contiguous, non-overlapping chunks past the segment cap", () => {
     const many = Array.from({ length: 20 }, (_, index) =>
       seg(index, `turn ${index}`),


### PR DESCRIPTION
Fixes #2766
Fixes #2767

## Summary
- Adds durable meeting and segment speaker assignments with SQLite/history-sync persistence.
- Adds inline speaker correction controls in Meeting Detail, including attendee suggestions and one-vs-all scope.
- Applies corrected labels to transcript display, transcript text export, search indexing, notes generation, and Seren Notes republish.
- Preserves channel-wide assignments after post-call diarization labels arrive.
- Pins mocked publisher request contracts for OpenAI embeddings and Seren Notes against the live publisher metadata.

## Verification
- `pnpm test -- tests/unit/meeting-speaker-assignment.test.ts tests/unit/transcript-chunk.test.ts tests/unit/seren-embed.test.ts tests/unit/save-to-notes-inner-408-retry.test.ts`
- `cargo test assemble_transcript_prefers_segment_then_meeting_assignment --lib`
- `cargo test speaker_assignments_upsert_and_delete_by_scope --lib`
- `cargo test delete_meeting_record_removes_notes_and_transcript_segments --lib`
- `rustfmt --edition 2024 --check src-tauri/src/audio/types.rs src-tauri/src/commands/audio.rs src-tauri/src/services/database.rs src-tauri/src/services/history_sync.rs`
- `pnpm build`

## Publisher Contract Audit
- Speaker correction persistence is local Tauri/SQLite: `upsert_meeting_speaker_assignment`, `list_meeting_speaker_assignments`, `delete_meeting_speaker_assignment`.
- Search reindex path calls `openai-embeddings` via `POST /embeddings`; live publisher metadata verified on 2026-06-29.
- Notes publish path calls `seren-notes` via `POST /notes`; live publisher metadata verified on 2026-06-29.