### PR TITLE
fix(mcp): retry transient gateway transport-channel-closed drop

### DIFF
--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -115,7 +115,14 @@ function isRetryableGatewayConnectError(error: unknown): boolean {
     /Service Unavailable|server_error|Authentication backend unavailable/i.test(
       message,
     ) ||
-    /network|timeout|temporar|ECONN|ETIMEDOUT|ERR_/i.test(message)
+    /network|timeout|temporar|ECONN|ETIMEDOUT|ERR_/i.test(message) ||
+    // A dropped MCP transport stream mid-handshake (rmcp surfaces this as
+    // "Transport channel closed" while sending the initialize request or the
+    // initialized notification) is a transient connect race, not a hard
+    // gateway error — retry it like any other transient.
+    /Transport channel closed|channel closed|connection (?:closed|reset|aborted)|stream closed/i.test(
+      message,
+    )
   );
 }
 

--- a/tests/services/mcp-gateway.test.ts
+++ b/tests/services/mcp-gateway.test.ts
@@ -441,6 +441,47 @@ describe("MCP Gateway init recovery (#2654, #2743)", () => {
     warnSpy.mockRestore();
   });
 
+  it("retries a transient transport-channel-closed handshake drop (#2778)", async () => {
+    const { mcpClient } = await import("@/lib/mcp/client");
+    const connectMock = vi.mocked(mcpClient.connectHttp);
+    // rmcp surfaces a dropped MCP stream mid-handshake as "Transport channel
+    // closed" — here while sending the initialized notification. The first
+    // attempt drops transiently; the second succeeds.
+    connectMock
+      .mockRejectedValueOnce(
+        new Error(
+          "Failed to connect to MCP server: Send message error Transport [rmcp::transport::streamable_http_client::StreamableHttpClientWorker] error: Transport channel closed, when send initialized notification",
+        ),
+      )
+      .mockResolvedValue(undefined);
+
+    const { MCP_GATEWAY_URL } = await import("@/lib/config");
+    const { initializeGateway, isGatewayInitInFlight, isGatewayInitialized } =
+      await import("@/services/mcp-gateway");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const init = initializeGateway();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(init).resolves.toBeUndefined();
+    expect(connectMock).toHaveBeenCalledTimes(2);
+    expect(connectMock).toHaveBeenNthCalledWith(
+      2,
+      "seren-gateway",
+      MCP_GATEWAY_URL,
+      "test-api-key",
+    );
+    expect(isGatewayInitInFlight()).toBe(false);
+    expect(isGatewayInitialized()).toBe(true);
+    // A recovered transient must not leave a console.error — that is what the
+    // Windows e2e console gate fails the release on.
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
   it("does not retry non-transient MCP auth failures", async () => {
     const { mcpClient } = await import("@/lib/mcp/client");
     const connectMock = vi.mocked(mcpClient.connectHttp);


### PR DESCRIPTION
## What

Classify a transient MCP gateway **transport-channel-closed** disconnect as retryable so `connectGatewayWithRetry` retries it, instead of rethrowing on the first attempt and logging a `console.error` that fails the Windows production e2e release gate.

Closes #2778.

## Why

The v3.66.2 release `windows-app-e2e` gate failed after every core journey had already passed (sign-in, provider runtime, `claude-code`, history sync, GitHub PAT, meeting capture). The only failure was the final browser-console audit:

```
[MCP Gateway] Failed to connect: ... error: Transport channel closed, when send initialized notification
[Auth Store] Failed to initialize MCP: ... Transport channel closed, when send initialized notification
```

`isRetryableGatewayConnectError` matched retryable transients by `HTTP 5xx`, `Service Unavailable / server_error / Authentication backend unavailable`, and `network/timeout/ECONN/...`. The rmcp transport-stream drop `Transport channel closed` matched **none** of them. #2743 added retry only for `503`s raised "when send **initialize request**"; this is a stream close on the **initialized notification** (the next handshake step), so the retry classifier let it through, `initializeGateway` logged `console.error`, and the strict gate failed the release — even though the connect is recoverable (the #2654 in-flight-promise clearing lets a later attempt succeed, and the app worked end to end).

## Change

- `src/services/mcp-gateway.ts` — `isRetryableGatewayConnectError` now also treats transport disconnects (`Transport channel closed` / `connection closed/reset/aborted` / `stream closed`) as retryable. Non-retryable `401/403`/missing-key failures stay immediate; a genuinely-down gateway still exhausts retries and correctly fails the gate.
- `tests/services/mcp-gateway.test.ts` — adds a guard (in the #2654/#2743 block) that a `Transport channel closed` handshake drop is retried, recovers, and leaves no `console.error`. Preserves the live `POST https://mcp.serendb.com/mcp` initialize contract assertion.

This mirrors the #2743 remediation pattern: fix the product-side retry classification rather than allowlist the e2e console gate.

## Test

```
vitest run tests/services/mcp-gateway.test.ts  →  12 passed
biome check src/services/mcp-gateway.ts        →  clean
```

## Release note

v3.66.2 was already shipped via the manual publish override (build artifacts were all green and signed; this transient was the only gate failure).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
