### PR TITLE
fix(meetings): stop stale calendar matches and manual runaways

### DIFF
--- a/src-tauri/src/audio/lifecycle.rs
+++ b/src-tauri/src/audio/lifecycle.rs
@@ -91,6 +91,12 @@ pub struct LifecycleController {
     /// stopping a recording while the call is still live can't instantly
     /// re-record it.
     suppress_until_gate_closes: bool,
+    /// Whether app-release should auto-stop the current capture. Auto-started
+    /// captures begin with this enabled. Externally-started captures begin with
+    /// it disabled so a user can press Record before the call app opens without
+    /// getting stopped after the release grace; the first observed gate-open
+    /// tick enables it for the remainder of that capture.
+    app_release_stop_enabled: bool,
 }
 
 impl LifecycleController {
@@ -102,6 +108,7 @@ impl LifecycleController {
             app_release_since: None,
             recording_since: None,
             suppress_until_gate_closes: false,
+            app_release_stop_enabled: true,
         }
     }
 
@@ -118,6 +125,20 @@ impl LifecycleController {
         self.app_release_since = None;
         self.gate_open_since = None;
         self.suppress_until_gate_closes = true;
+        self.app_release_stop_enabled = true;
+    }
+
+    /// Record that capture was started outside the lifecycle auto-start path
+    /// (manual button / tray / calendar one-tap). This lets the same auto-stop
+    /// signals protect every active Meeting capture, while avoiding a premature
+    /// AppReleased stop before a call app has ever taken the mic.
+    pub fn note_capture_started(&mut self, now_ms: i64, app_release_stop_enabled: bool) {
+        self.state = LifecycleState::Recording;
+        self.recording_since = Some(now_ms);
+        self.app_release_since = None;
+        self.gate_open_since = None;
+        self.suppress_until_gate_closes = false;
+        self.app_release_stop_enabled = app_release_stop_enabled;
     }
 
     /// The wiring failed to start the proposed capture (createMeeting / capture
@@ -128,6 +149,7 @@ impl LifecycleController {
         self.recording_since = None;
         self.app_release_since = None;
         self.gate_open_since = None;
+        self.app_release_stop_enabled = true;
     }
 
     /// Advance the state machine by one observation, returning the side effect to
@@ -157,6 +179,7 @@ impl LifecycleController {
                 self.recording_since = Some(signal.now_ms);
                 self.gate_open_since = None;
                 self.app_release_since = None;
+                self.app_release_stop_enabled = true;
                 return Some(LifecycleAction::StartCapture {
                     source_app: signal.source_app.clone(),
                 });
@@ -170,7 +193,10 @@ impl LifecycleController {
     fn evaluate_recording(&mut self, signal: &LifecycleSignal) -> Option<LifecycleAction> {
         // 1) App-release grace. If the gate reopens inside the window, cancel the
         //    pending stop and keep recording.
-        if !signal.gate_open {
+        if signal.gate_open {
+            self.app_release_stop_enabled = true;
+            self.app_release_since = None;
+        } else if self.app_release_stop_enabled {
             let released_at = *self.app_release_since.get_or_insert(signal.now_ms);
             if signal.now_ms - released_at >= self.config.app_release_grace_ms {
                 return Some(self.stop(StopReason::AppReleased));
@@ -203,6 +229,7 @@ impl LifecycleController {
         self.recording_since = None;
         self.app_release_since = None;
         self.gate_open_since = None;
+        self.app_release_stop_enabled = true;
         // A stop that fires while the call is still live must not instantly
         // re-record. The silence backstop and calendar-end stop both trigger
         // with the gate (mic + known app) still open, so without suppression the
@@ -282,7 +309,10 @@ mod tests {
                 source_app: Some("Zoom".to_string())
             })
         );
-        assert_eq!(c.evaluate(&gate(CFG.start_debounce_ms + 60_000, true)), None);
+        assert_eq!(
+            c.evaluate(&gate(CFG.start_debounce_ms + 60_000, true)),
+            None
+        );
         assert_eq!(
             c.evaluate(&gate(CFG.start_debounce_ms + CFG.silence_timeout_ms, true)),
             Some(LifecycleAction::StopCapture {
@@ -340,11 +370,20 @@ mod tests {
         assert_eq!(c.state(), LifecycleState::Idle);
         // Gate stays open well past another full debounce + silence window:
         // without suppression this would emit a second StartCapture. It must not.
-        assert_eq!(c.evaluate(&gate(stop_at + CFG.start_debounce_ms, true)), None);
-        assert_eq!(c.evaluate(&gate(stop_at + CFG.silence_timeout_ms, true)), None);
+        assert_eq!(
+            c.evaluate(&gate(stop_at + CFG.start_debounce_ms, true)),
+            None
+        );
+        assert_eq!(
+            c.evaluate(&gate(stop_at + CFG.silence_timeout_ms, true)),
+            None
+        );
         assert_eq!(c.state(), LifecycleState::Idle);
         // The call ends (gate closes) → suppression lifts...
-        assert_eq!(c.evaluate(&gate(stop_at + CFG.silence_timeout_ms, false)), None);
+        assert_eq!(
+            c.evaluate(&gate(stop_at + CFG.silence_timeout_ms, false)),
+            None
+        );
         // ...and a genuinely new call re-arms and records again.
         c.evaluate(&gate(stop_at + CFG.silence_timeout_ms + 10_000, true));
         assert_eq!(
@@ -382,5 +421,39 @@ mod tests {
         later.calendar_end_ms = Some(end_ms);
         assert_eq!(c.evaluate(&later), None);
         assert_eq!(c.state(), LifecycleState::Idle);
+    }
+
+    /// Manual/calendar one-tap captures are started outside evaluate_idle().
+    /// They still need the silence backstop, but must not AppReleased-stop after
+    /// 90s if the user pressed Record before the call app took the mic.
+    #[test]
+    fn external_capture_uses_silence_backstop_without_premature_app_release() {
+        let mut c = LifecycleController::new(CFG);
+        c.note_capture_started(0, false);
+
+        assert_eq!(c.evaluate(&gate(CFG.app_release_grace_ms, false)), None);
+        assert_eq!(
+            c.evaluate(&gate(CFG.silence_timeout_ms, false)),
+            Some(LifecycleAction::StopCapture {
+                reason: StopReason::Silence
+            })
+        );
+    }
+
+    /// Once an externally-started capture observes a real call gate, app-release
+    /// stop is safe and should protect the user when the meeting ends.
+    #[test]
+    fn external_capture_enables_app_release_after_gate_is_seen() {
+        let mut c = LifecycleController::new(CFG);
+        c.note_capture_started(0, false);
+
+        assert_eq!(c.evaluate(&gate(10_000, true)), None);
+        assert_eq!(c.evaluate(&gate(20_000, false)), None);
+        assert_eq!(
+            c.evaluate(&gate(20_000 + CFG.app_release_grace_ms, false)),
+            Some(LifecycleAction::StopCapture {
+                reason: StopReason::AppReleased
+            })
+        );
     }
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1311,6 +1311,23 @@ pub fn meeting_lifecycle_note_manual_stop(
     Ok(())
 }
 
+/// Record that capture started outside the lifecycle auto-start path (manual
+/// button, tray, or calendar one-tap) so the existing auto-stop signals still
+/// protect it. `app_release_stop_enabled=false` defers AppReleased until a
+/// real gate-open tick is observed, avoiding premature stops before a call app
+/// has actually taken the mic.
+#[tauri::command]
+pub fn meeting_lifecycle_note_capture_started(
+    lifecycle: State<'_, std::sync::Mutex<LifecycleController>>,
+    app_release_stop_enabled: bool,
+) -> Result<(), String> {
+    lifecycle
+        .lock()
+        .map_err(|err| err.to_string())?
+        .note_capture_started(now_ms(), app_release_stop_enabled);
+    Ok(())
+}
+
 /// The frontend failed to start an auto-proposed capture — reset the controller
 /// to Idle so it can re-propose (no suppression).
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -949,6 +949,7 @@ pub fn run() {
             commands::audio::meeting_autodetect,
             commands::audio::meeting_lifecycle_tick,
             commands::audio::meeting_lifecycle_note_manual_stop,
+            commands::audio::meeting_lifecycle_note_capture_started,
             commands::audio::meeting_lifecycle_note_start_failed,
             // Dictation commands
             commands::audio::transcribe_pcm,

--- a/src/components/meeting/UpcomingMeetings.tsx
+++ b/src/components/meeting/UpcomingMeetings.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Shows the next events and offers one-tap recording with metadata.
 
 import { For, Show } from "solid-js";
+import { TrashIcon } from "@/components/recording/icons";
 import { formatTime } from "@/lib/meeting-format";
 import { meetingStore } from "@/stores/meeting.store";
 
@@ -59,6 +60,15 @@ export function UpcomingMeetings() {
                     }
                   >
                     Record
+                  </button>
+                  <button
+                    type="button"
+                    class="grid h-6 w-6 shrink-0 place-items-center rounded-md border border-border bg-surface-1 text-muted-foreground transition-colors hover:bg-surface-3 hover:text-foreground"
+                    aria-label={`Remove ${event.title} from upcoming recordings`}
+                    title="Remove from upcoming recordings"
+                    onClick={() => meetingStore.skipUpcomingEvent(event)}
+                  >
+                    <TrashIcon />
                   </button>
                 </div>
               )}

--- a/src/services/meetings.ts
+++ b/src/services/meetings.ts
@@ -474,6 +474,18 @@ export function meetingLifecycleNoteManualStop(): Promise<void> {
   return invoke("meeting_lifecycle_note_manual_stop");
 }
 
+/**
+ * Tell the lifecycle a capture was started outside auto-start (manual/tray/
+ * calendar), so auto-stop still protects it.
+ */
+export function meetingLifecycleNoteCaptureStarted(
+  appReleaseStopEnabled = false,
+): Promise<void> {
+  return invoke("meeting_lifecycle_note_capture_started", {
+    appReleaseStopEnabled,
+  });
+}
+
 /** Tell the lifecycle the wiring failed to start a proposed capture. */
 export function meetingLifecycleNoteStartFailed(): Promise<void> {
   return invoke("meeting_lifecycle_note_start_failed");

--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -34,6 +34,7 @@ import {
   type MeetingSpeakerAssignment,
   type MeetingTemplate,
   meetingAutodetect,
+  meetingLifecycleNoteCaptureStarted,
   meetingLifecycleNoteManualStop,
   meetingLifecycleNoteStartFailed,
   meetingLifecycleTick,
@@ -170,6 +171,20 @@ let lifecycleEventEndMs: number | null = null;
 let cachedUpcomingEvents: CalendarEvent[] = [];
 let lastCalendarFetchMs = 0;
 const CALENDAR_REFRESH_MS = 5 * 60_000;
+const DEFAULT_CALENDAR_SUPPRESS_MS = 2 * 60 * 60_000;
+
+interface LifecycleCaptureOptions {
+  appReleaseStopEnabled: boolean;
+  calendarEndMs?: number | null;
+}
+
+const DEFAULT_LIFECYCLE_CAPTURE_OPTIONS: LifecycleCaptureOptions = {
+  appReleaseStopEnabled: false,
+  calendarEndMs: null,
+};
+
+let primingLifecycleOptions: LifecycleCaptureOptions | null = null;
+const calendarEventEndByMeetingId = new Map<string, number>();
 
 // Quit guard: confirm-on-quit while a capture is live. `quitConfirmed` lets a
 // second close request pass through even if window.destroy() is unavailable,
@@ -233,6 +248,103 @@ function captureStartupFailureReason(error: unknown): string {
     return "Microphone capture is unavailable in this desktop WebView. Restart Seren and try capture again.";
   }
   return `Meeting capture could not start: ${meetingErrorMessage(error)}`;
+}
+
+function skippedCalendarEvents(): { id: string; untilMs: number }[] {
+  const skipped = settingsStore.get("meetingSkippedCalendarEvents");
+  return Array.isArray(skipped) ? skipped : [];
+}
+
+function pruneSkippedCalendarEvents(now = Date.now()): Set<string> {
+  const skipped = skippedCalendarEvents();
+  const active = skipped.filter((item) => item.untilMs > now);
+  if (active.length !== skipped.length) {
+    settingsStore.set("meetingSkippedCalendarEvents", active);
+  }
+  return new Set(active.map((item) => item.id));
+}
+
+function recordableCalendarEvents(
+  events: readonly CalendarEvent[] = cachedUpcomingEvents,
+  now = Date.now(),
+): CalendarEvent[] {
+  const skipped = pruneSkippedCalendarEvents(now);
+  return events.filter((event) => !skipped.has(event.id));
+}
+
+function setUpcomingEvents(events: readonly CalendarEvent[]): void {
+  setMeetingState("upcomingEvents", recordableCalendarEvents(events));
+}
+
+function skipUpcomingEvent(event: CalendarEvent): void {
+  const untilMs = Math.max(event.endMs, Date.now() + 60_000);
+  const existing = skippedCalendarEvents();
+  const kept = existing.filter(
+    (item) => item.untilMs > Date.now() && item.id !== event.id,
+  );
+  settingsStore.set("meetingSkippedCalendarEvents", [
+    ...kept,
+    { id: event.id, untilMs },
+  ]);
+  cachedUpcomingEvents = cachedUpcomingEvents.filter(
+    (item) => item.id !== event.id,
+  );
+  setUpcomingEvents(cachedUpcomingEvents);
+}
+
+function rememberMeetingCalendarEnd(
+  meetingId: string,
+  endMs: number | null | undefined,
+): void {
+  if (typeof endMs === "number" && Number.isFinite(endMs)) {
+    calendarEventEndByMeetingId.set(meetingId, endMs);
+  }
+}
+
+function calendarEndForMeeting(meeting: Meeting): number | null {
+  const remembered = calendarEventEndByMeetingId.get(meeting.id);
+  if (remembered !== undefined) return remembered;
+  if (!meeting.calendarEventId) return null;
+  return (
+    cachedUpcomingEvents.find((event) => event.id === meeting.calendarEventId)
+      ?.endMs ?? null
+  );
+}
+
+function suppressMeetingCalendarEvent(meeting: Meeting): void {
+  const eventId = meeting.calendarEventId;
+  if (!eventId) return;
+  const endMs =
+    calendarEndForMeeting(meeting) ??
+    (meeting.id === lifecycleMeetingId ? lifecycleEventEndMs : null);
+  const now = Date.now();
+  if (endMs !== null && now >= endMs) return;
+  const untilMs = endMs !== null ? endMs : now + DEFAULT_CALENDAR_SUPPRESS_MS;
+  const existing = skippedCalendarEvents();
+  const kept = existing.filter(
+    (item) => item.untilMs > now && item.id !== eventId,
+  );
+  settingsStore.set("meetingSkippedCalendarEvents", [
+    ...kept,
+    { id: eventId, untilMs },
+  ]);
+  cachedUpcomingEvents = cachedUpcomingEvents.filter(
+    (event) => event.id !== eventId,
+  );
+  setUpcomingEvents(cachedUpcomingEvents);
+  calendarEventEndByMeetingId.delete(meeting.id);
+}
+
+async function armLifecycleForCapture(
+  meeting: Meeting,
+  options: LifecycleCaptureOptions = DEFAULT_LIFECYCLE_CAPTURE_OPTIONS,
+): Promise<void> {
+  lifecycleMeetingId = meeting.id;
+  lifecycleEventEndMs = options.calendarEndMs ?? calendarEndForMeeting(meeting);
+  rememberMeetingCalendarEnd(meeting.id, lifecycleEventEndMs);
+  await meetingLifecycleNoteCaptureStarted(options.appReleaseStopEnabled).catch(
+    () => {},
+  );
 }
 
 function notesFailureReason(error: unknown): string {
@@ -604,7 +716,10 @@ async function startCapture(meeting: Meeting): Promise<boolean> {
 // Start a freshly-created meeting and surface it as the active one. Shared by
 // every start caller (panel, tray, auto-detect) behind a single in-flight guard
 // so a double-trigger can't launch two mic streams.
-async function beginCapture(meeting: Meeting): Promise<void> {
+async function beginCapture(
+  meeting: Meeting,
+  lifecycleOptions: LifecycleCaptureOptions = DEFAULT_LIFECYCLE_CAPTURE_OPTIONS,
+): Promise<void> {
   if (!isTauriRuntime() || isStarting) return;
   if (isCapturing(meeting.id)) return;
   isStarting = true;
@@ -614,6 +729,7 @@ async function beginCapture(meeting: Meeting): Promise<void> {
     setMeetingState("capturePaused", false);
     setMeetingState("capturePausedAt", null);
     setMeetingState("capturePausedAccumMs", 0);
+    await armLifecycleForCapture(meeting, lifecycleOptions);
     await loadMeetings();
     await setActiveMeeting(
       meetingState.meetings.find((item) => item.id === meeting.id) ?? meeting,
@@ -626,12 +742,16 @@ async function beginCapture(meeting: Meeting): Promise<void> {
 // First-run gate shared by every start path. If the user has already
 // acknowledged the audio-permission explainer, start immediately; otherwise
 // stash the meeting and let the app-wide priming dialog drive the decision.
-async function requestCaptureStart(meeting: Meeting): Promise<void> {
+async function requestCaptureStart(
+  meeting: Meeting,
+  lifecycleOptions: LifecycleCaptureOptions = DEFAULT_LIFECYCLE_CAPTURE_OPTIONS,
+): Promise<void> {
   if (!isTauriRuntime()) return;
   if (settingsStore.get("meetingAudioPrimed")) {
-    await beginCapture(meeting);
+    await beginCapture(meeting, lifecycleOptions);
     return;
   }
+  primingLifecycleOptions = lifecycleOptions;
   setMeetingState("primingRequest", meeting);
 }
 
@@ -639,10 +759,13 @@ async function requestCaptureStart(meeting: Meeting): Promise<void> {
 // and clear the request.
 async function confirmPriming(): Promise<void> {
   const meeting = meetingState.primingRequest;
+  const lifecycleOptions =
+    primingLifecycleOptions ?? DEFAULT_LIFECYCLE_CAPTURE_OPTIONS;
+  primingLifecycleOptions = null;
   setMeetingState("primingRequest", null);
   if (!meeting) return;
   settingsStore.set("meetingAudioPrimed", true);
-  await beginCapture(meeting);
+  await beginCapture(meeting, lifecycleOptions);
 }
 
 // User dismissed the explainer: abort the pending start. The meeting row was
@@ -650,6 +773,7 @@ async function confirmPriming(): Promise<void> {
 // isCapturing() stays true forever and blocks every future capture.
 async function cancelPriming(): Promise<void> {
   const meeting = meetingState.primingRequest;
+  primingLifecycleOptions = null;
   setMeetingState("primingRequest", null);
   if (!meeting || !isTauriRuntime()) return;
   await failMeeting(
@@ -725,6 +849,10 @@ async function reconcileStaleCaptures(): Promise<void> {
           setMeetingState("capturePaused", backendPaused);
           setMeetingState("capturePausedAt", backendPaused ? Date.now() : null);
           setMeetingState("capturePausedAccumMs", 0);
+          await armLifecycleForCapture(meeting, {
+            appReleaseStopEnabled: meeting.triggerSource === "auto_mic",
+            calendarEndMs: calendarEndForMeeting(meeting),
+          });
           if (!meetingState.activeMeeting) {
             await setActiveMeeting(meeting);
           }
@@ -828,6 +956,7 @@ async function stopAndProcess(meeting: Meeting): Promise<void> {
   if (processingMeetings.has(meeting.id)) return;
   processingMeetings.add(meeting.id);
   try {
+    suppressMeetingCalendarEvent(meeting);
     const stopOutcome = await stopCapture(meeting.id);
     await loadMeetings();
     if (!isTauriRuntime()) return;
@@ -906,6 +1035,7 @@ async function stopAndProcess(meeting: Meeting): Promise<void> {
       meetingState.meetings.find((m) => m.id === meeting.id) ?? null;
     await setActiveMeeting(refreshed);
   } finally {
+    calendarEventEndByMeetingId.delete(meeting.id);
     processingMeetings.delete(meeting.id);
   }
 }
@@ -1231,7 +1361,7 @@ async function refreshUpcomingEventsIfStale(): Promise<void> {
   lastCalendarFetchMs = now;
   const result = await getUpcomingEvents();
   cachedUpcomingEvents = result.events;
-  setMeetingState("upcomingEvents", result.events);
+  setUpcomingEvents(result.events);
   setMeetingState("upcomingStatus", result.status);
 }
 
@@ -1272,7 +1402,7 @@ async function pollAutoDetect(): Promise<void> {
       try {
         const now = Date.now();
         const event = matchActiveEvent(
-          cachedUpcomingEvents,
+          recordableCalendarEvents(cachedUpcomingEvents, now),
           now,
           action.sourceApp,
         );
@@ -1290,7 +1420,11 @@ async function pollAutoDetect(): Promise<void> {
         });
         lifecycleMeetingId = meeting.id;
         lifecycleEventEndMs = event?.endMs ?? null;
-        await requestCaptureStart(meeting);
+        rememberMeetingCalendarEnd(meeting.id, lifecycleEventEndMs);
+        await requestCaptureStart(meeting, {
+          appReleaseStopEnabled: true,
+          calendarEndMs: lifecycleEventEndMs,
+        });
       } catch {
         // Start failed — reset the controller so it can re-propose, and clear
         // the dangling id so a wedged "Recording" controller can't block all
@@ -1397,13 +1531,18 @@ async function startFromCalendarEvent(event: CalendarEvent): Promise<void> {
     attendeesJson:
       event.attendees.length > 0 ? JSON.stringify(event.attendees) : null,
   });
-  await requestCaptureStart(meeting);
+  rememberMeetingCalendarEnd(meeting.id, event.endMs);
+  await requestCaptureStart(meeting, {
+    appReleaseStopEnabled: false,
+    calendarEndMs: event.endMs,
+  });
 }
 
 // A user-initiated stop. Suppresses lifecycle auto-restart until the call ends
 // (covers manually-started captures too) and clears lifecycle tracking.
 async function stopByUser(meeting: Meeting): Promise<void> {
   await meetingLifecycleNoteManualStop().catch(() => {});
+  suppressMeetingCalendarEvent(meeting);
   lifecycleMeetingId = null;
   lifecycleEventEndMs = null;
   await stopAndProcess(meeting);
@@ -1426,6 +1565,7 @@ async function stopAndDelete(meeting: Meeting): Promise<void> {
   processingMeetings.add(meeting.id);
   setMeetingState("error", null);
   await meetingLifecycleNoteManualStop().catch(() => {});
+  suppressMeetingCalendarEvent(meeting);
   lifecycleMeetingId = null;
   lifecycleEventEndMs = null;
   try {
@@ -1518,6 +1658,7 @@ export const meetingStore = {
   stopAutoDetect,
   acceptAutoDetect,
   startFromCalendarEvent,
+  skipUpcomingEvent,
   dismissAutoDetect,
   resetAutoDetectDismissal,
   acknowledgeReviewReady,

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -175,6 +175,8 @@ export interface Settings {
   meetingAutoDetectEnabled: boolean;
   meetingTemplateId: string;
   meetingCustomTemplates: { id: string; name: string; prompt: string }[];
+  /** Calendar events locally skipped from Upcoming and auto-match until end. */
+  meetingSkippedCalendarEvents: { id: string; untilMs: number }[];
   /**
    * Run the post-call Them diarization pass that stamps meeting-stable speaker
    * labels. Default off because it re-transcribes Them audio and no current UI
@@ -293,6 +295,7 @@ const DEFAULT_SETTINGS: Settings = {
   meetingAutoDetectEnabled: true,
   meetingTemplateId: "discovery",
   meetingCustomTemplates: [],
+  meetingSkippedCalendarEvents: [],
   meetingStableSpeakers: false,
   meetingAudioPrimed: false,
   // General

--- a/tests/unit/meeting-native-capture-lifecycle.test.ts
+++ b/tests/unit/meeting-native-capture-lifecycle.test.ts
@@ -61,6 +61,7 @@ const m = vi.hoisted(() => ({
     captureDiagnosticsJson: "{}",
     failureReason: null,
   })),
+  meetingLifecycleNoteCaptureStarted: vi.fn(async () => {}),
   updateMeetingStatus: vi.fn(async () => {}),
   listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
   getTranscriptSegments: vi.fn(async () => []),
@@ -91,6 +92,7 @@ vi.mock("@/services/meetings", async (importOriginal) => ({
   createMeeting: m.createMeeting,
   startMeetingCapture: m.startMeetingCapture,
   stopMeetingCapture: m.stopMeetingCapture,
+  meetingLifecycleNoteCaptureStarted: m.meetingLifecycleNoteCaptureStarted,
   updateMeetingStatus: m.updateMeetingStatus,
   listMeetings: m.listMeetings,
   getTranscriptSegments: m.getTranscriptSegments,
@@ -161,6 +163,7 @@ describe("meetingStore native capture lifecycle (#2225)", () => {
     await meetingStore.requestCaptureStart(meeting());
 
     expect(m.startMeetingCapture).toHaveBeenCalledWith("m1");
+    expect(m.meetingLifecycleNoteCaptureStarted).toHaveBeenCalledWith(false);
     expect(m.setTrayRecording).toHaveBeenCalledWith(true);
   });
 
@@ -193,6 +196,7 @@ describe("meetingStore native capture lifecycle (#2225)", () => {
 
     expect(m.isMeetingCaptureActive).toHaveBeenCalledWith("active");
     expect(m.setTrayRecording).toHaveBeenCalledWith(true);
+    expect(m.meetingLifecycleNoteCaptureStarted).toHaveBeenCalledWith(false);
     expect(m.updateMeetingStatus).not.toHaveBeenCalledWith(
       "active",
       "failed",

--- a/tests/unit/meeting-ui-regressions.test.ts
+++ b/tests/unit/meeting-ui-regressions.test.ts
@@ -116,3 +116,22 @@ describe("Meeting pending capture ownership (#2745)", () => {
     expect(store).toContain("if (isCapturing()) return;");
   });
 });
+
+describe("Meeting upcoming recording removal (#2780)", () => {
+  it("wires the Upcoming delete button to calendar skip state and auto-match filtering", () => {
+    const upcoming = source("src/components/meeting/UpcomingMeetings.tsx");
+    const store = source("src/stores/meeting.store.ts");
+    const settings = source("src/stores/settings.store.ts");
+
+    expect(upcoming).toContain("TrashIcon");
+    expect(upcoming).toContain("skipUpcomingEvent(event)");
+    expect(upcoming).toContain(
+      "Remove ${event.title} from upcoming recordings",
+    );
+    expect(settings).toContain("meetingSkippedCalendarEvents");
+    expect(store).toContain("function skipUpcomingEvent");
+    expect(store).toContain("recordableCalendarEvents(cachedUpcomingEvents, now)");
+    expect(store).toContain("suppressMeetingCalendarEvent(meeting)");
+    expect(store).toContain("meetingLifecycleNoteCaptureStarted");
+  });
+});

--- a/tests/unit/meeting-upcoming-skip.test.ts
+++ b/tests/unit/meeting-upcoming-skip.test.ts
@@ -1,0 +1,174 @@
+// ABOUTME: Regression coverage for skipped calendar events hijacking later auto-record titles.
+// ABOUTME: Skipped upcoming entries must disappear from UI state and from auto-match.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const settings = vi.hoisted(() => ({
+  values: new Map<string, unknown>(),
+  set: vi.fn((key: string, value: unknown) => {
+    settings.values.set(key, value);
+  }),
+}));
+
+const m = vi.hoisted(() => ({
+  createMeeting: vi.fn(async (input: Record<string, unknown>) => ({
+    id: "created",
+    title: input.title,
+    sourceApp: input.sourceApp ?? null,
+    startedAt: Date.now(),
+    endedAt: null,
+    status: "pending_capture",
+    templateId: input.templateId ?? null,
+    routedSkillSlug: null,
+    agentConversationId: null,
+    notesMarkdown: null,
+    notesStructJson: null,
+    failureReason: null,
+    triggerSource: input.triggerSource ?? null,
+    calendarEventId: input.calendarEventId ?? null,
+    calendarProvider: input.calendarProvider ?? null,
+    attendeesJson: input.attendeesJson ?? null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  })),
+  getUpcomingEvents: vi.fn(async (): Promise<unknown> => ({
+    status: "connected",
+    events: [],
+  })),
+  getTranscriptSegments: vi.fn(async () => []),
+  listMeetings: vi.fn(async () => []),
+  meetingAutodetect: vi.fn(async (): Promise<unknown> => ({
+    detected: false,
+    sourceApp: null,
+  })),
+  meetingLifecycleNoteCaptureStarted: vi.fn(async () => {}),
+  meetingLifecycleNoteManualStop: vi.fn(async () => {}),
+  meetingLifecycleNoteStartFailed: vi.fn(async () => {}),
+  meetingLifecycleTick: vi.fn(async (): Promise<unknown> => null),
+  setTrayRecording: vi.fn(),
+  startMeetingCapture: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tauri-bridge")>()),
+  isTauriRuntime: () => true,
+}));
+vi.mock("@/services/calendar", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/calendar")>()),
+  getUpcomingEvents: m.getUpcomingEvents,
+}));
+vi.mock("@/services/meetings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/meetings")>()),
+  createMeeting: m.createMeeting,
+  getTranscriptSegments: m.getTranscriptSegments,
+  listMeetings: m.listMeetings,
+  meetingAutodetect: m.meetingAutodetect,
+  meetingLifecycleNoteCaptureStarted: m.meetingLifecycleNoteCaptureStarted,
+  meetingLifecycleNoteManualStop: m.meetingLifecycleNoteManualStop,
+  meetingLifecycleNoteStartFailed: m.meetingLifecycleNoteStartFailed,
+  meetingLifecycleTick: m.meetingLifecycleTick,
+  startMeetingCapture: m.startMeetingCapture,
+}));
+vi.mock("@/services/orchestrator", () => ({ orchestrate: vi.fn() }));
+vi.mock("@/services/tray", () => ({
+  setTrayRecording: m.setTrayRecording,
+  onTrayToggleCapture: vi.fn(() => () => {}),
+}));
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: (key: string) => settings.values.get(key),
+    set: settings.set,
+  },
+}));
+vi.mock("@/stores/conversation.store", () => ({
+  conversationStore: {
+    createConversationWithModel: vi.fn(async () => ({ id: "c1" })),
+    setActiveConversation: vi.fn(),
+  },
+}));
+vi.mock("@/stores/provider.store", () => ({
+  providerStore: { resolvedModel: () => "model", activeModel: "model" },
+}));
+vi.mock("@/stores/skills.store", () => ({
+  skillsStore: { enabledSkills: [] },
+}));
+
+import type { CalendarEvent } from "@/services/calendar";
+import { meetingStore } from "@/stores/meeting.store";
+
+async function flushPoll(): Promise<void> {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+}
+
+describe("meeting upcoming calendar skip", () => {
+  const now = Date.parse("2026-06-30T10:00:00-07:00");
+  const peterEvent: CalendarEvent = {
+    id: "peter",
+    title: "2026 Tues Meetings w/ Peter Bernhardt",
+    startMs: now - 5 * 60_000,
+    endMs: now + 25 * 60_000,
+    attendees: ["Peter Bernhardt"],
+    meetingUrl: "https://us02web.zoom.us/j/123",
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    vi.stubGlobal("window", {
+      setInterval: globalThis.setInterval,
+      clearInterval: globalThis.clearInterval,
+    });
+    settings.values.clear();
+    settings.values.set("meetingAutoDetectEnabled", true);
+    settings.values.set("meetingAudioPrimed", true);
+    settings.values.set("meetingCustomTemplates", []);
+    settings.values.set("meetingSkippedCalendarEvents", []);
+    settings.set.mockClear();
+    for (const fn of Object.values(m)) fn.mockClear();
+    m.getUpcomingEvents.mockResolvedValue({
+      status: "connected",
+      events: [peterEvent],
+    });
+    m.meetingLifecycleTick.mockResolvedValue(null);
+    m.listMeetings.mockResolvedValue([]);
+    meetingStore.stopAutoDetect();
+    meetingStore.resetAutoDetectDismissal();
+  });
+
+  afterEach(() => {
+    meetingStore.stopAutoDetect();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("removes a skipped event from Upcoming and excludes it from auto-match", async () => {
+    meetingStore.startAutoDetect();
+    await flushPoll();
+
+    expect(meetingStore.state.upcomingEvents.map((event) => event.id)).toEqual([
+      "peter",
+    ]);
+
+    meetingStore.skipUpcomingEvent(peterEvent);
+
+    expect(meetingStore.state.upcomingEvents).toEqual([]);
+    expect(settings.values.get("meetingSkippedCalendarEvents")).toEqual([
+      { id: "peter", untilMs: peterEvent.endMs },
+    ]);
+
+    m.meetingLifecycleTick.mockResolvedValueOnce({
+      kind: "start_capture",
+      sourceApp: "Zoom",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushPoll();
+
+    expect(m.createMeeting).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calendarEventId: null,
+        title: expect.not.stringContaining("Peter Bernhardt"),
+      }),
+    );
+    expect(m.meetingLifecycleNoteCaptureStarted).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
Fixes #2780

## Summary
- arm Meeting lifecycle auto-stop for manual, tray, and calendar one-tap captures, while deferring AppReleased stops until a real call gate is observed for externally started captures
- suppress consumed/skipped calendar events until their end time so early-ended events cannot hijack later auto-recording titles
- add an Upcoming Meetings remove button for scheduled events that should not activate recording

## Audit
- audited prior meeting lifecycle/calendar PRs and commits: #2679, #2681, #2709, #2710, #2716, #2724/#2725, #2746
- inspected production evidence for `20260630 Bryan Colligan`: manual Meeting capture ran from 2026-06-30 13:22:32 PDT to 16:30:19 PDT, about 187.8 minutes
- inspected user screenshots at `~/Desktop/peter.png` and `~/Desktop/family.png`; both showed stale scheduled titles taking over active recording UI
- traced changed code paths through `src/stores/meeting.store.ts`, `src/components/meeting/UpcomingMeetings.tsx`, `src/services/meetings.ts`, `src-tauri/src/audio/lifecycle.rs`, and `src-tauri/src/commands/audio.rs`

## Networked feature paths
No new networked path is added by this change. Existing affected paths were traced and checked against the live Seren publisher list / metadata:
- `google-calendar`: `GET /events` via `src/services/calendar.ts` for upcoming-event metadata
- `seren-whisper`: `POST /audio/transcriptions` during stop/transcription flow
- `seren-notes`: `POST /notes` and `PATCH /notes/{note_id}` during notes publication

## Validation
- `pnpm exec biome format --write src/stores/meeting.store.ts src/components/meeting/UpcomingMeetings.tsx tests/unit/meeting-native-capture-lifecycle.test.ts tests/unit/meeting-upcoming-skip.test.ts tests/unit/meeting-ui-regressions.test.ts`
- `pnpm test -- tests/unit/meeting-native-capture-lifecycle.test.ts tests/unit/meeting-upcoming-skip.test.ts tests/unit/meeting-ui-regressions.test.ts` (repo script ran full Vitest suite: 302 files / 2145 tests passed)
- `pnpm prepare:mcp-servers`
- `cargo test lifecycle --lib`
- `pnpm check`
- `pnpm lint`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm build`
- `git diff --check`
- isolated dev launch with bundle id `com.serendb.desktop.fix2780`; screenshot evidence: `/tmp/seren-fix2780-front2.png`
- browser Meetings panel walkthrough on Vite dev server; screenshot evidence: `/tmp/seren-fix2780-browser-meetings.png`