### PR TITLE
fix(meetings): stop Discord recordings after remote silence

### DIFF
--- a/src-tauri/src/audio/lifecycle.rs
+++ b/src-tauri/src/audio/lifecycle.rs
@@ -37,6 +37,10 @@ pub struct LifecycleSignal {
     pub source_app: Option<String>,
     /// Timestamp of the most recent persisted transcript segment, if any.
     pub last_segment_ms: Option<i64>,
+    /// Timestamp of the most recent persisted remote/system transcript segment.
+    /// This protects call recordings when local mic noise keeps producing
+    /// bogus "Me" segments after the other side has gone quiet.
+    pub last_remote_segment_ms: Option<i64>,
     /// Scheduled end of the matched calendar event, if any.
     pub calendar_end_ms: Option<i64>,
 }
@@ -214,7 +218,17 @@ impl LifecycleController {
             }
         }
 
-        // 3) Matched calendar end + tail.
+        // 3) Remote stream backstop. The generic silence guard above can be
+        // defeated when a quiet room produces local mic hallucinations, while
+        // the call app process keeps the gate open. Once the remote/system
+        // channel has existed, it must keep advancing too.
+        if let Some(anchor) = signal.last_remote_segment_ms {
+            if signal.now_ms - anchor >= self.config.silence_timeout_ms {
+                return Some(self.stop(StopReason::Silence));
+            }
+        }
+
+        // 4) Matched calendar end + tail.
         if let Some(end) = signal.calendar_end_ms {
             if signal.now_ms >= end + self.config.calendar_end_tail_ms {
                 return Some(self.stop(StopReason::CalendarEnd));
@@ -261,6 +275,7 @@ mod tests {
             gate_open: open,
             source_app: open.then(|| "Zoom".to_string()),
             last_segment_ms: None,
+            last_remote_segment_ms: None,
             calendar_end_ms: None,
         }
     }
@@ -395,6 +410,40 @@ mod tests {
                 source_app: Some("Zoom".to_string())
             })
         );
+    }
+
+    /// Discord can remain open after a call, and Seren's own active mic capture
+    /// can keep the input-device gate looking open. If local mic noise keeps
+    /// producing bogus "Me" transcript segments after the remote side stops,
+    /// the remote-channel backstop must still end the recording.
+    #[test]
+    fn remote_silence_stops_when_local_segments_keep_advancing() {
+        let mut c = LifecycleController::new(CFG);
+        c.evaluate(&gate(0, true));
+        assert_eq!(
+            c.evaluate(&gate(CFG.start_debounce_ms, true)),
+            Some(LifecycleAction::StartCapture {
+                source_app: Some("Zoom".to_string())
+            })
+        );
+
+        let last_remote = 10 * 60_000;
+        let stop_at = last_remote + CFG.silence_timeout_ms;
+        let mut active_local = gate(stop_at - 1, true);
+        active_local.last_segment_ms = Some(stop_at - 1);
+        active_local.last_remote_segment_ms = Some(last_remote);
+        assert_eq!(c.evaluate(&active_local), None);
+
+        let mut remote_stale = gate(stop_at, true);
+        remote_stale.last_segment_ms = Some(stop_at);
+        remote_stale.last_remote_segment_ms = Some(last_remote);
+        assert_eq!(
+            c.evaluate(&remote_stale),
+            Some(LifecycleAction::StopCapture {
+                reason: StopReason::Silence
+            })
+        );
+        assert_eq!(c.state(), LifecycleState::Idle);
     }
 
     /// A calendar-end stop likewise fires while the call is still live (the

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1247,16 +1247,36 @@ pub fn meeting_autodetect() -> MeetingAutodetectResult {
     meeting_detection(activity)
 }
 
-/// Timestamp of the most recently persisted transcript segment for a meeting —
-/// the silence-backstop anchor. `None` when nothing has landed yet.
-fn select_last_segment_ms(conn: &Connection, meeting_id: &str) -> Result<Option<i64>> {
+#[derive(Debug, Clone, Copy, Default)]
+struct LifecycleSegmentTimes {
+    last_segment_ms: Option<i64>,
+    last_remote_segment_ms: Option<i64>,
+}
+
+/// Timestamps for lifecycle silence guards. `last_segment_ms` covers fully
+/// silent recordings; `last_remote_segment_ms` catches call-end runaways where
+/// local mic noise keeps producing "Me" transcript segments after the remote
+/// system channel has stopped.
+fn select_lifecycle_segment_times(
+    conn: &Connection,
+    meeting_id: &str,
+) -> Result<LifecycleSegmentTimes> {
     conn.query_row(
-        "SELECT MAX(created_at) FROM transcript_segments WHERE meeting_id = ?1",
-        params![meeting_id],
-        |row| row.get::<_, Option<i64>>(0),
+        "SELECT
+            MAX(created_at) AS last_segment_ms,
+            MAX(CASE WHEN speaker = ?2 THEN created_at END) AS last_remote_segment_ms
+         FROM transcript_segments
+         WHERE meeting_id = ?1",
+        params![meeting_id, Speaker::Them.as_str()],
+        |row| {
+            Ok(LifecycleSegmentTimes {
+                last_segment_ms: row.get::<_, Option<i64>>(0)?,
+                last_remote_segment_ms: row.get::<_, Option<i64>>(1)?,
+            })
+        },
     )
     .optional()
-    .map(Option::flatten)
+    .map(|times| times.unwrap_or_default())
 }
 
 /// Advance the auto-record lifecycle by one tick and return the action to
@@ -1278,16 +1298,17 @@ pub async fn meeting_lifecycle_tick(
     // only when both hold, so its presence is the gate.
     let gate_open = source_app.is_some();
 
-    let last_segment_ms = match active_meeting_id {
-        Some(id) => run_db(app, move |conn| select_last_segment_ms(conn, &id)).await?,
-        None => None,
+    let segment_times = match active_meeting_id {
+        Some(id) => run_db(app, move |conn| select_lifecycle_segment_times(conn, &id)).await?,
+        None => LifecycleSegmentTimes::default(),
     };
 
     let signal = LifecycleSignal {
         now_ms: now_ms(),
         gate_open,
         source_app,
-        last_segment_ms,
+        last_segment_ms: segment_times.last_segment_ms,
+        last_remote_segment_ms: segment_times.last_remote_segment_ms,
         calendar_end_ms,
     };
 
@@ -2374,6 +2395,42 @@ mod tests {
         assert_eq!(segments[0].speaker_label, None);
         assert_eq!(segments[0].speaker_source, SpeakerSource::Channel);
         assert_eq!(segments[2].status, SegmentStatus::Gap);
+    }
+
+    #[test]
+    fn lifecycle_segment_times_keep_remote_anchor_separate() {
+        let conn = setup();
+        insert_meeting(&conn, meeting("meeting-1")).unwrap();
+
+        for (seq, speaker, created_at) in [
+            (0, Speaker::Them, 10),
+            (1, Speaker::Me, 20),
+            (2, Speaker::Them, 30),
+            (3, Speaker::Me, 40),
+        ] {
+            insert_transcript_segment(
+                &conn,
+                NewTranscriptSegment {
+                    id: format!("segment-{seq}"),
+                    meeting_id: "meeting-1".to_string(),
+                    seq,
+                    speaker,
+                    text: format!("text {seq}"),
+                    start_ms: seq * 100,
+                    end_ms: seq * 100 + 50,
+                    status: SegmentStatus::Ok,
+                    speaker_label: None,
+                    speaker_source: SpeakerSource::Channel,
+                    created_at,
+                },
+            )
+            .unwrap();
+        }
+
+        let times = select_lifecycle_segment_times(&conn, "meeting-1").unwrap();
+
+        assert_eq!(times.last_segment_ms, Some(40));
+        assert_eq!(times.last_remote_segment_ms, Some(30));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2785

## Summary
- add a remote/system-channel lifecycle timestamp so auto-recordings stop when the remote meeting stream goes stale, even if local mic noise keeps producing `Me` transcript segments
- keep the existing `Silence` stop reason and re-arm suppression behavior so the UI contract stays unchanged
- add focused Rust coverage for the lifecycle decision and the SQLite aggregate that separates newest-any segment from newest-remote segment

## Audit
- inspected user evidence:
  - `~/Desktop/long.png` showed a Discord-sourced Meeting recording at about `144:09`
  - `~/Desktop/auto.png` confirmed `Auto-detect meetings` was ON
- inspected local settings: `meetingAutoDetectEnabled=true`
- inspected local meeting row `64688ac1-4d7a-40de-bc11-77dfb3c7b774`: `source_app=Discord`, `trigger_source=auto_mic`, no `calendar_event_id`, duration about `144.2` minutes
- inspected transcript segments for the same row: `them` stopped around minute `82.3`; `me` continued until minute `143.4` with obvious silence/noise hallucinations such as repeated `Bye` / `Thank you`
- audited relevant code paths in `src/stores/meeting.store.ts`, `src-tauri/src/audio/detect.rs`, `src-tauri/src/audio/lifecycle.rs`, and `src-tauri/src/commands/audio.rs`
- audited prior lifecycle issues/PRs: #2670/#2679, #2709, #2710, #2712, #2724/#2725, and #2780/#2781

## Networked feature paths
No new networked path is added by this change. Existing affected paths were traced and checked against the live Seren publisher list / metadata:
- `google-calendar`: `GET /events` via `src/services/calendar.ts` for optional calendar metadata
- `seren-whisper`: `POST /audio/transcriptions` via `src/services/seren-whisper.ts` during transcription
- `seren-notes`: `POST /notes` and `PATCH /notes/{note_id}` during notes publication

## Validation
- `pnpm prepare:mcp-servers`
- `rustfmt --edition 2024 src-tauri/src/audio/lifecycle.rs src-tauri/src/commands/audio.rs`
- `git diff --check`
- `cargo test --manifest-path src-tauri/Cargo.toml lifecycle --lib` (7 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` (895 passed, 2 ignored)
- `pnpm check` currently fails on unrelated pre-existing Biome diagnostics outside this diff, including `biome.json`, `src/components/chat/ChatContent.tsx`, `src/components/employees/EmployeeRunDetailModal.tsx`, and `src/components/session/SessionContent.tsx`
