### PR TITLE
fix(employees): update run stream error copy tests

### DIFF
--- a/tests/unit/employees-core-run-stream.test.ts
+++ b/tests/unit/employees-core-run-stream.test.ts
@@ -118,7 +118,7 @@ describe("employees-core sequenced run stream", () => {
       'LLM error: LLM publisher returned 400: Provider returned error - {"error":{"code":400,"message":"Provider returned error","metadata":{"previous_errors":[{"provider_name":"OpenAI","raw":"{\\n \\"error\\": {\\n \\"message\\": \\"No tool call found for function call output with call_id call_123.\\",\\n \\"type\\": \\"invalid_request_error\\"\\n }\\n}"}],"provider_name":"Azure"}}}';
 
     expect(sanitizeEmployeeErrorText(rawError)).toBe(
-      "The employee could not complete this request because the model provider rejected the tool response.",
+      "The configured model route could not process the tool response. Change this employee to a tool-capable model route in employee settings.",
     );
 
     expect(
@@ -130,7 +130,7 @@ describe("employees-core sequenced run stream", () => {
         },
       }),
     ).toBe(
-      "The employee could not complete this request because the model provider rejected the tool response.",
+      "The configured model route could not process the tool response. Change this employee to a tool-capable model route in employee settings.",
     );
   });
 
@@ -146,7 +146,7 @@ describe("employees-core sequenced run stream", () => {
         "Error: seren client unavailable for publisher request tool",
       ),
     ).toBe(
-      "The employee is not configured to use the required tool. Enable live data or publisher tools for this employee to allow this request.",
+      "The required tool is not enabled for this employee. Enable live data or publisher tools in employee settings.",
     );
   });
 
@@ -156,7 +156,7 @@ describe("employees-core sequenced run stream", () => {
         "publisher operation is not allowed by allowed_publisher_operations",
       ),
     ).toBe(
-      "The employee is not allowed to use the required publisher operation. Enable the needed publisher permission for this employee.",
+      "This employee is not allowed to use that publisher operation. Update tool permissions in employee settings.",
     );
   });
 


### PR DESCRIPTION
Fixes #2787

## Summary
- update `employees-core-run-stream` expectations to match the clarified employee error messages introduced by `7e83b323`
- no runtime behavior change; this fixes stale test copy that blocks frontend CI

## Audit
- CI failure came from PR #2786 `test-frontend`, run `28534705336`, job `84592977904`
- audited implementation constants in `packages/employees-core/src/index.ts`
- audited stale assertions in `tests/unit/employees-core-run-stream.test.ts`
- confirmed commit `7e83b323 feat(employees): clarify tool capabilities and failures` intentionally changed the canonical copy but left expectations stale

## Networked feature paths
No networked feature path is touched by this test-only change.

## Validation
- `pnpm test -- tests/unit/employees-core-run-stream.test.ts` (repo script ran full Vitest suite: 302 files / 2150 tests passed)
- `git diff --check`
