### PR TITLE
feat(oauth): add multi-account publisher routing

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -108,6 +108,7 @@ import {
 } from "./composerToolbarClasses";
 import { DiffCard } from "./DiffCard";
 import { ImageAttachmentBar } from "./ImageAttachmentBar";
+import { OAuthAccountSwitcher } from "./OAuthAccountSwitcher";
 import { PairedEffortSelector } from "./PairedEffortSelector";
 import { PairedModelSelector } from "./PairedModelSelector";
 import { PlanHeader } from "./PlanHeader";
@@ -1728,6 +1729,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           >
             Clear
           </button>
+          <OAuthAccountSwitcher threadId={props.threadId} />
         </div>
       </Show>
 

--- a/src/components/chat/OAuthAccountSwitcher.tsx
+++ b/src/components/chat/OAuthAccountSwitcher.tsx
@@ -1,0 +1,236 @@
+// ABOUTME: Compact chat-header OAuth account switcher.
+// ABOUTME: Persists active provider account choices per thread.
+
+import {
+  type Component,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import { humanizeOAuthProviderSlug } from "@/lib/oauth-provider-resolution";
+import {
+  connectPublisher,
+  listConnectedPublishers,
+} from "@/services/publisher-oauth";
+import {
+  formatOAuthConnectionLabel,
+  getOAuthConnectionsForProvider,
+  type OAuthConnection,
+  oauthConnectionsRevision,
+  resolveThreadOAuthConnection,
+  setThreadOAuthConnectionId,
+} from "@/stores/oauth-account.store";
+
+interface OAuthAccountSwitcherProps {
+  threadId?: string | null;
+}
+
+interface ProviderAccountGroup {
+  providerSlug: string;
+  connections: OAuthConnection[];
+  selected: OAuthConnection | null;
+}
+
+function providerSortKey(providerSlug: string): number {
+  if (providerSlug === "google") return 0;
+  if (providerSlug === "microsoft") return 1;
+  return 10;
+}
+
+export const OAuthAccountSwitcher: Component<OAuthAccountSwitcherProps> = (
+  props,
+) => {
+  const [open, setOpen] = createSignal(false);
+  const [connectingProvider, setConnectingProvider] = createSignal<
+    string | null
+  >(null);
+  const [connectError, setConnectError] = createSignal<string | null>(null);
+  let rootRef: HTMLDivElement | undefined;
+  const [connections] = createResource(oauthConnectionsRevision, async () =>
+    listConnectedPublishers(),
+  );
+
+  onMount(() => {
+    const close = (event: MouseEvent) => {
+      if (
+        rootRef &&
+        event.target instanceof Node &&
+        rootRef.contains(event.target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    document.addEventListener("click", close);
+    onCleanup(() => document.removeEventListener("click", close));
+  });
+
+  const groups = createMemo<ProviderAccountGroup[]>(() => {
+    const allConnections = connections() ?? [];
+    const providerSlugs = Array.from(
+      new Set(
+        allConnections
+          .filter((connection) => connection.is_valid)
+          .map((connection) => connection.provider_slug),
+      ),
+    ).sort(
+      (a, b) => providerSortKey(a) - providerSortKey(b) || a.localeCompare(b),
+    );
+
+    return providerSlugs
+      .map((providerSlug) => {
+        const providerConnections = getOAuthConnectionsForProvider(
+          allConnections,
+          providerSlug,
+        );
+        return {
+          providerSlug,
+          connections: providerConnections,
+          selected: resolveThreadOAuthConnection(
+            props.threadId,
+            providerSlug,
+            allConnections,
+          ),
+        };
+      })
+      .filter((group) => group.connections.length > 0);
+  });
+
+  const primaryGroup = createMemo(
+    () => groups().find((group) => group.connections.length > 1) ?? groups()[0],
+  );
+
+  const primaryConnection = createMemo(() => {
+    const group = primaryGroup();
+    if (!group) return null;
+    return group.selected ?? group.connections[0] ?? null;
+  });
+
+  const chooseConnection = (
+    providerSlug: string,
+    connection: OAuthConnection,
+  ) => {
+    setThreadOAuthConnectionId(props.threadId, providerSlug, connection.id);
+    setOpen(false);
+  };
+
+  const addAccount = async (providerSlug: string) => {
+    if (connectingProvider()) return;
+    setConnectingProvider(providerSlug);
+    setConnectError(null);
+    try {
+      await connectPublisher(providerSlug);
+    } catch (err) {
+      setConnectError(
+        err instanceof Error ? err.message : "Failed to start OAuth flow",
+      );
+    } finally {
+      setConnectingProvider(null);
+    }
+  };
+
+  return (
+    <Show when={primaryConnection()}>
+      {(connection) => (
+        <div ref={rootRef} class="relative">
+          <button
+            type="button"
+            class="h-7 min-w-7 px-1.5 rounded-full border border-border bg-transparent text-muted-foreground hover:bg-surface-2 hover:text-foreground transition-colors flex items-center gap-1.5"
+            title={`Active account: ${formatOAuthConnectionLabel(connection())}`}
+            aria-label="Switch active account"
+            aria-expanded={open()}
+            data-testid="oauth-account-switcher"
+            onClick={() => setOpen((value) => !value)}
+          >
+            <span class="w-5 h-5 rounded-full bg-surface-2 border border-border flex items-center justify-center text-[10px] font-semibold text-foreground">
+              {formatOAuthConnectionLabel(connection()).charAt(0).toUpperCase()}
+            </span>
+          </button>
+
+          <Show when={open()}>
+            <div
+              class="absolute right-0 top-9 w-[280px] max-w-[calc(100vw-2rem)] bg-background border border-border rounded-lg shadow-[var(--shadow-lg)] z-50 overflow-hidden"
+              role="menu"
+            >
+              <For each={groups()}>
+                {(group) => (
+                  <div class="py-2 border-b border-border/60 last:border-b-0">
+                    <div class="px-3 pb-1 text-[0.7rem] uppercase tracking-wider text-muted-foreground/75">
+                      {humanizeOAuthProviderSlug(group.providerSlug)}
+                    </div>
+                    <For each={group.connections}>
+                      {(item) => {
+                        const selected = () =>
+                          group.selected?.id === item.id ||
+                          (!group.selected && item.is_default);
+
+                        return (
+                          <button
+                            type="button"
+                            class={`w-full text-left px-3 py-2 flex items-center justify-between gap-3 hover:bg-surface-2 transition-colors ${
+                              selected()
+                                ? "text-foreground"
+                                : "text-muted-foreground"
+                            }`}
+                            role="menuitem"
+                            onClick={() =>
+                              chooseConnection(group.providerSlug, item)
+                            }
+                          >
+                            <span class="min-w-0">
+                              <span class="block text-[0.85rem] truncate">
+                                {formatOAuthConnectionLabel(item)}
+                              </span>
+                              <Show when={item.is_default}>
+                                <span class="block text-[0.7rem] text-success">
+                                  Default
+                                </span>
+                              </Show>
+                            </span>
+                            <Show when={selected()}>
+                              <span class="text-success text-xs font-semibold">
+                                Active
+                              </span>
+                            </Show>
+                          </button>
+                        );
+                      }}
+                    </For>
+                    <button
+                      type="button"
+                      class="w-full text-left px-3 py-2.5 flex items-center gap-3 text-muted-foreground hover:bg-surface-2 hover:text-foreground transition-colors border-t border-border/60 disabled:opacity-50 disabled:cursor-not-allowed"
+                      onClick={() => addAccount(group.providerSlug)}
+                      disabled={Boolean(connectingProvider())}
+                    >
+                      <span class="w-6 h-6 rounded-full border border-dashed border-muted-foreground/50 flex items-center justify-center text-sm">
+                        +
+                      </span>
+                      <span class="text-[0.85rem]">
+                        {connectingProvider() === group.providerSlug
+                          ? "Opening..."
+                          : "Add account"}
+                      </span>
+                    </button>
+                  </div>
+                )}
+              </For>
+              <Show when={connectError()}>
+                {(message) => (
+                  <div class="px-3 py-2 border-t border-destructive/30 text-[0.75rem] text-destructive">
+                    {message()}
+                  </div>
+                )}
+              </Show>
+            </div>
+          </Show>
+        </div>
+      )}
+    </Show>
+  );
+};
+
+export default OAuthAccountSwitcher;

--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -4,12 +4,29 @@
 import { emit, listen } from "@tauri-apps/api/event";
 import {
   type Component,
+  createEffect,
+  createMemo,
+  createResource,
   createSignal,
+  For,
   onCleanup,
   onMount,
   Show,
 } from "solid-js";
+import {
+  listConnectedPublishers,
+  resolveOAuthProviderForPublisher,
+} from "@/services/publisher-oauth";
 import { conversationStore } from "@/stores/conversation.store";
+import {
+  formatOAuthConnectionLabel,
+  getDefaultOAuthConnection,
+  getOAuthConnectionsForProvider,
+  type OAuthConnection,
+  oauthConnectionsRevision,
+  resolveThreadOAuthConnection,
+  setThreadOAuthConnectionId,
+} from "@/stores/oauth-account.store";
 import type { UnifiedMessage } from "@/types/conversation";
 
 interface ApprovalRequest {
@@ -17,6 +34,7 @@ interface ApprovalRequest {
   publisherSlug: string;
   toolName: string;
   args: Record<string, unknown>;
+  threadId?: string | null;
   description: string;
   isDestructive: boolean;
 }
@@ -70,6 +88,20 @@ export const GatewayToolApproval: Component = () => {
   const [request, setRequest] = createSignal<ApprovalRequest | null>(null);
   const [isProcessing, setIsProcessing] = createSignal(false);
   const [provenance, setProvenance] = createSignal<Provenance | null>(null);
+  const [selectedConnectionId, setSelectedConnectionId] = createSignal<
+    string | null
+  >(null);
+
+  const [providerResolution] = createResource(
+    () => request()?.publisherSlug ?? null,
+    async (publisherSlug) =>
+      publisherSlug ? resolveOAuthProviderForPublisher(publisherSlug) : null,
+  );
+
+  const [connections] = createResource(
+    () => [request()?.approvalId ?? null, oauthConnectionsRevision()] as const,
+    async ([approvalId]) => (approvalId ? listConnectedPublishers() : []),
+  );
 
   onMount(async () => {
     const unlisten = await listen<ApprovalRequest>(
@@ -81,6 +113,7 @@ export const GatewayToolApproval: Component = () => {
         );
         // Snapshot provenance at the moment the request arrives
         setProvenance(deriveProvenance(conversationStore.messages));
+        setSelectedConnectionId(null);
         setRequest(event.payload);
         setIsProcessing(false);
       },
@@ -91,9 +124,89 @@ export const GatewayToolApproval: Component = () => {
     });
   });
 
+  const approvalThreadId = () =>
+    request()?.threadId ?? conversationStore.activeConversationId;
+
+  const providerSlug = createMemo(
+    () => providerResolution()?.providerSlug ?? null,
+  );
+
+  const validConnections = createMemo(() => {
+    const slug = providerSlug();
+    if (!slug) return [];
+    return getOAuthConnectionsForProvider(connections() ?? [], slug);
+  });
+
+  createEffect(() => {
+    const req = request();
+    const slug = providerSlug();
+    if (!req || !slug) return;
+
+    const current = selectedConnectionId();
+    if (
+      current &&
+      validConnections().some((connection) => connection.id === current)
+    ) {
+      return;
+    }
+
+    const resolved = resolveThreadOAuthConnection(
+      approvalThreadId(),
+      slug,
+      connections() ?? [],
+    );
+    setSelectedConnectionId(resolved?.id ?? null);
+  });
+
+  const selectedConnection = createMemo(() => {
+    const id = selectedConnectionId();
+    if (!id) return null;
+    return (
+      validConnections().find((connection) => connection.id === id) ?? null
+    );
+  });
+
+  const hasDefaultConnection = createMemo(() =>
+    Boolean(getDefaultOAuthConnection(validConnections())),
+  );
+
+  const shouldRenderAccountChoices = createMemo(
+    () => validConnections().length > 1 && !hasDefaultConnection(),
+  );
+
+  const needsConnectionChoice = createMemo(() => {
+    if (!providerSlug() || selectedConnection()) return false;
+    return shouldRenderAccountChoices();
+  });
+
+  const handleConnectionChange = (connectionId: string) => {
+    const slug = providerSlug();
+    if (!slug) return;
+    const connection = validConnections().find(
+      (item) => item.id === connectionId,
+    );
+    if (!connection) return;
+    setThreadOAuthConnectionId(approvalThreadId(), slug, connection.id);
+    setSelectedConnectionId(connection.id);
+  };
+
+  const connectionInitial = (connection: OAuthConnection) =>
+    formatOAuthConnectionLabel(connection).charAt(0).toUpperCase();
+
+  const approveLabel = createMemo(() => {
+    if (needsConnectionChoice()) return "Choose account";
+    if (isProcessing()) return "Processing...";
+    const connection = selectedConnection();
+    if (shouldRenderAccountChoices() && connection) {
+      return `Approve & send from ${formatOAuthConnectionLabel(connection)}`;
+    }
+    return "Approve";
+  });
+
   const handleApprove = async () => {
     const req = request();
     if (!req || isProcessing()) return;
+    if (needsConnectionChoice()) return;
 
     setIsProcessing(true);
     console.log("[GatewayToolApproval] Approving operation:", req.approvalId);
@@ -102,9 +215,11 @@ export const GatewayToolApproval: Component = () => {
       await emit("gateway-tool-approval-response", {
         id: req.approvalId,
         approved: true,
+        connectionId: selectedConnection()?.id ?? null,
       });
       setRequest(null);
       setProvenance(null);
+      setSelectedConnectionId(null);
     } catch (err) {
       console.error("[GatewayToolApproval] Failed to emit approval:", err);
       setIsProcessing(false);
@@ -125,6 +240,7 @@ export const GatewayToolApproval: Component = () => {
       });
       setRequest(null);
       setProvenance(null);
+      setSelectedConnectionId(null);
     } catch (err) {
       console.error("[GatewayToolApproval] Failed to emit denial:", err);
       setIsProcessing(false);
@@ -180,6 +296,140 @@ export const GatewayToolApproval: Component = () => {
                   {req().description}
                 </span>
               </div>
+
+              <Show when={validConnections().length > 0}>
+                <div class="flex flex-col gap-1.5 mb-4">
+                  <span class="text-sm font-medium text-muted-foreground uppercase tracking-[0.5px]">
+                    {shouldRenderAccountChoices()
+                      ? "From - choose an account to send from:"
+                      : "From:"}
+                  </span>
+                  <Show
+                    when={shouldRenderAccountChoices()}
+                    fallback={
+                      <Show
+                        when={
+                          validConnections().length === 1
+                            ? validConnections()[0]
+                            : null
+                        }
+                        keyed
+                        fallback={
+                          <div class="relative">
+                            <div class="flex items-center gap-3 text-base text-foreground bg-surface-1 px-3 py-2 rounded-md border border-border min-h-[46px]">
+                              <Show when={selectedConnection()}>
+                                {(connection) => (
+                                  <span class="w-7 h-7 rounded-full bg-accent text-primary-foreground flex items-center justify-center text-xs font-semibold shrink-0">
+                                    {connectionInitial(connection())}
+                                  </span>
+                                )}
+                              </Show>
+                              <span class="truncate">
+                                {selectedConnection()
+                                  ? formatOAuthConnectionLabel(
+                                      selectedConnection() as OAuthConnection,
+                                    )
+                                  : "Choose account"}
+                              </span>
+                              <span class="ml-auto text-muted-foreground">
+                                ⌄
+                              </span>
+                            </div>
+                            <select
+                              class="absolute inset-0 h-full w-full opacity-0 cursor-pointer"
+                              value={selectedConnectionId() ?? ""}
+                              onChange={(event) =>
+                                handleConnectionChange(
+                                  event.currentTarget.value,
+                                )
+                              }
+                              disabled={isProcessing()}
+                              aria-label="Choose OAuth account"
+                            >
+                              <option value="" disabled>
+                                Choose account
+                              </option>
+                              <For each={validConnections()}>
+                                {(connection) => (
+                                  <option value={connection.id}>
+                                    {formatOAuthConnectionLabel(connection)}
+                                    {connection.is_default ? " (default)" : ""}
+                                  </option>
+                                )}
+                              </For>
+                            </select>
+                          </div>
+                        }
+                      >
+                        {(connection) => (
+                          <span class="flex items-center gap-3 text-base text-foreground bg-surface-1 px-3 py-2 rounded-md border border-border min-h-[46px]">
+                            <span class="w-7 h-7 rounded-full bg-accent text-primary-foreground flex items-center justify-center text-xs font-semibold shrink-0">
+                              {connectionInitial(connection())}
+                            </span>
+                            <span class="truncate">
+                              {formatOAuthConnectionLabel(connection())}
+                            </span>
+                          </span>
+                        )}
+                      </Show>
+                    }
+                  >
+                    <div class="flex flex-col gap-2">
+                      <span class="text-[0.8rem] text-warning/90">
+                        {validConnections().length}{" "}
+                        {providerResolution()?.providerName ?? "OAuth"} accounts
+                        are connected and no default is set.
+                      </span>
+                      <For each={validConnections()}>
+                        {(connection) => {
+                          const selected = () =>
+                            selectedConnectionId() === connection.id;
+                          return (
+                            <button
+                              type="button"
+                              class={`w-full text-left flex items-center gap-3 px-3 py-3 rounded-lg border transition-colors ${
+                                selected()
+                                  ? "border-accent bg-accent/10 text-foreground"
+                                  : "border-border bg-surface-1 text-muted-foreground hover:bg-surface-2 hover:text-foreground"
+                              }`}
+                              onClick={() =>
+                                handleConnectionChange(connection.id)
+                              }
+                              disabled={isProcessing()}
+                            >
+                              <span
+                                class={`w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 ${
+                                  selected()
+                                    ? "border-accent"
+                                    : "border-muted-foreground/40"
+                                }`}
+                                aria-hidden="true"
+                              >
+                                <Show when={selected()}>
+                                  <span class="w-2 h-2 rounded-full bg-accent" />
+                                </Show>
+                              </span>
+                              <span class="w-7 h-7 rounded-full bg-accent text-primary-foreground flex items-center justify-center text-xs font-semibold shrink-0">
+                                {connectionInitial(connection)}
+                              </span>
+                              <span class="min-w-0">
+                                <span class="block text-[0.95rem] truncate">
+                                  {formatOAuthConnectionLabel(connection)}
+                                </span>
+                                <span class="block text-[0.8rem] text-muted-foreground truncate">
+                                  {providerResolution()?.providerName ??
+                                    "OAuth"}{" "}
+                                  account
+                                </span>
+                              </span>
+                            </button>
+                          );
+                        }}
+                      </For>
+                    </div>
+                  </Show>
+                </div>
+              </Show>
 
               <div class="flex flex-col gap-1.5 mb-4">
                 <span class="text-sm font-medium text-muted-foreground uppercase tracking-[0.5px]">
@@ -251,9 +501,9 @@ export const GatewayToolApproval: Component = () => {
                 type="button"
                 class="px-6 py-2.5 text-[0.95rem] font-medium border-none rounded-md cursor-pointer transition-all duration-150 bg-accent text-primary-foreground hover:bg-primary/85 hover:shadow-[var(--glow-primary)]"
                 onClick={handleApprove}
-                disabled={isProcessing()}
+                disabled={isProcessing() || needsConnectionChoice()}
               >
-                {isProcessing() ? "Processing..." : "Approve"}
+                {approveLabel()}
               </button>
             </div>
           </div>

--- a/src/components/settings/OAuthLogins.tsx
+++ b/src/components/settings/OAuthLogins.tsx
@@ -16,7 +16,6 @@ import {
   listProviders,
   listStorePublishers,
   type PublisherOAuthProviderResponse,
-  type UserOAuthConnectionResponse,
 } from "@/api";
 import attioLogo from "@/assets/oauth-logos/attio.svg";
 import githubLogo from "@/assets/oauth-logos/github.svg";
@@ -30,9 +29,16 @@ import {
 import { listenForOAuthCallback } from "@/lib/tauri-bridge";
 import {
   connectPublisher,
-  disconnectPublisher,
+  disconnectOAuthConnection,
+  setDefaultOAuthConnection,
 } from "@/services/publisher-oauth";
 import { authStore } from "@/stores/auth.store";
+import {
+  formatOAuthConnectionLabel,
+  getOAuthConnectionsForProvider,
+  markOAuthConnectionsChanged,
+  type OAuthConnection,
+} from "@/stores/oauth-account.store";
 
 /** Local fallback logos for OAuth providers */
 const LOCAL_PROVIDER_LOGOS: Record<string, string> = {
@@ -71,7 +77,10 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
   const [connectingProvider, setConnectingProvider] = createSignal<
     string | null
   >(null);
-  const [disconnectingProvider, setDisconnectingProvider] = createSignal<
+  const [disconnectingConnection, setDisconnectingConnection] = createSignal<
+    string | null
+  >(null);
+  const [settingDefaultConnection, setSettingDefaultConnection] = createSignal<
     string | null
   >(null);
   const [error, setError] = createSignal<string | null>(null);
@@ -144,7 +153,7 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
         console.error("[OAuthLogins] Error fetching connections:", error);
         return [];
       }
-      return data?.connections || [];
+      return (data?.connections || []) as OAuthConnection[];
     },
   );
 
@@ -214,6 +223,7 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
           "[OAuthLogins] Refreshing connections after successful OAuth",
         );
         await refetchConnections();
+        markOAuthConnectionsChanged();
         console.log("[OAuthLogins] Connections refreshed successfully");
         // Clear expired status for this provider since they just reconnected
         const currentProvider = connectingProvider();
@@ -237,12 +247,8 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
     });
   });
 
-  const isConnected = (
-    providerSlug: string,
-  ): UserOAuthConnectionResponse | undefined => {
-    return connections()?.find(
-      (c) => c.provider_slug === providerSlug && c.is_valid,
-    );
+  const providerConnections = (providerSlug: string): OAuthConnection[] => {
+    return getOAuthConnectionsForProvider(connections() ?? [], providerSlug);
   };
 
   const isExpired = (providerSlug: string, providerId: string): boolean => {
@@ -306,22 +312,40 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
     }
   };
 
-  const handleDisconnect = async (providerSlug: string) => {
+  const handleDisconnectConnection = async (
+    connection: OAuthConnection,
+  ): Promise<void> => {
     const confirmDisconnect = window.confirm(
-      `Disconnect from ${providerSlug}? You'll need to reconnect to use publishers that require this authentication.`,
+      `Disconnect ${formatOAuthConnectionLabel(connection)} from ${connection.provider_slug}? You'll need to reconnect to use publishers that require this authentication.`,
     );
     if (!confirmDisconnect) return;
 
     setError(null);
-    setDisconnectingProvider(providerSlug);
+    setDisconnectingConnection(connection.id);
 
     try {
-      await disconnectPublisher(providerSlug);
+      await disconnectOAuthConnection(connection.id);
       await refetchConnections();
-      setDisconnectingProvider(null);
+      setDisconnectingConnection(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to disconnect");
-      setDisconnectingProvider(null);
+      setDisconnectingConnection(null);
+    }
+  };
+
+  const handleSetDefaultConnection = async (
+    connection: OAuthConnection,
+  ): Promise<void> => {
+    setError(null);
+    setSettingDefaultConnection(connection.id);
+
+    try {
+      await setDefaultOAuthConnection(connection.id);
+      await refetchConnections();
+      setSettingDefaultConnection(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to set default");
+      setSettingDefaultConnection(null);
     }
   };
 
@@ -397,18 +421,17 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
         <div class="flex flex-col gap-2">
           <For each={providers()}>
             {(provider) => {
-              const connection = () => isConnected(provider.slug);
+              const providerAccounts = () => providerConnections(provider.slug);
+              const hasConnection = () => providerAccounts().length > 0;
               const expired = () => isExpired(provider.slug, provider.id);
               const isConnecting = () => connectingProvider() === provider.slug;
-              const isDisconnecting = () =>
-                disconnectingProvider() === provider.slug;
 
               // Determine card border/background based on state
               const cardClasses = () => {
                 if (expired()) {
                   return "border-warning/50 bg-warning/[0.08]";
                 }
-                if (connection()) {
+                if (hasConnection()) {
                   return "border-success/30 bg-success/5";
                 }
                 return "border-border-hover";
@@ -469,7 +492,7 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
                               Expired
                             </span>
                           </Show>
-                          <Show when={connection() && !expired()}>
+                          <Show when={hasConnection() && !expired()}>
                             <span class="text-[11px] px-1.5 py-0.5 rounded font-medium bg-success/20 text-success">
                               Connected
                             </span>
@@ -486,14 +509,12 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
                             this service
                           </span>
                         </Show>
-                        <Show when={!expired() && connection()}>
-                          {(conn) => (
-                            <span class="text-[0.75rem] text-muted-foreground">
-                              {conn().provider_email
-                                ? `Connected as ${conn().provider_email}`
-                                : `Last used: ${formatDate(conn().last_used_at)}`}
-                            </span>
-                          )}
+                        <Show when={!expired() && hasConnection()}>
+                          <span class="text-[0.75rem] text-muted-foreground">
+                            {providerAccounts().length === 1
+                              ? `1 account connected`
+                              : `${providerAccounts().length} accounts connected`}
+                          </span>
                         </Show>
                       </div>
                     </div>
@@ -509,19 +530,17 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
                           {isConnecting() ? "Reconnecting..." : "Reconnect"}
                         </button>
                       </Show>
-                      <Show when={connection() && !expired()}>
+                      <Show when={hasConnection() && !expired()}>
                         <button
                           type="button"
-                          class="px-4 py-2 bg-transparent border border-destructive/50 rounded-md text-destructive text-[0.9rem] cursor-pointer transition-all duration-150 hover:not-disabled:bg-destructive/10 hover:not-disabled:border-destructive disabled:opacity-50 disabled:cursor-not-allowed"
-                          onClick={() => handleDisconnect(provider.slug)}
-                          disabled={isDisconnecting()}
+                          class="px-4 py-2 bg-transparent border border-border rounded-md text-foreground text-[0.9rem] cursor-pointer transition-all duration-150 hover:not-disabled:bg-surface-2 hover:not-disabled:border-muted-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+                          onClick={() => handleConnect(provider)}
+                          disabled={isConnecting()}
                         >
-                          {isDisconnecting()
-                            ? "Disconnecting..."
-                            : "Disconnect"}
+                          {isConnecting() ? "Adding..." : "Add account"}
                         </button>
                       </Show>
-                      <Show when={!connection() && !expired()}>
+                      <Show when={!hasConnection() && !expired()}>
                         <button
                           type="button"
                           class="px-4 py-2 bg-accent border-none rounded-md text-white text-[0.9rem] font-medium cursor-pointer transition-all duration-150 hover:not-disabled:bg-primary/85 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -534,11 +553,92 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
                     </div>
                   </div>
 
+                  {/* Connected account rows */}
+                  <Show when={hasConnection() && !expired()}>
+                    <div class="px-4 pb-3 pt-0 border-t border-border/50">
+                      <span class="block text-[0.7rem] text-muted-foreground/70 uppercase tracking-wider pt-3 pb-1.5">
+                        Accounts
+                      </span>
+                      <div class="flex flex-col divide-y divide-border/50">
+                        <For each={providerAccounts()}>
+                          {(connection) => {
+                            const label = () =>
+                              formatOAuthConnectionLabel(connection);
+                            const isDefault = () =>
+                              Boolean(connection.is_default);
+                            const isDisconnecting = () =>
+                              disconnectingConnection() === connection.id;
+                            const isSettingDefault = () =>
+                              settingDefaultConnection() === connection.id;
+
+                            return (
+                              <div
+                                class="flex items-center justify-between gap-3 py-2.5"
+                                data-testid="oauth-account-row"
+                              >
+                                <div class="flex items-center gap-3 min-w-0">
+                                  <div class="w-8 h-8 rounded-full bg-surface-2 border border-border flex items-center justify-center text-xs font-semibold text-foreground shrink-0">
+                                    {label().charAt(0).toUpperCase()}
+                                  </div>
+                                  <div class="min-w-0">
+                                    <div class="flex items-center gap-2 min-w-0">
+                                      <span class="text-[0.9rem] text-foreground truncate">
+                                        {label()}
+                                      </span>
+                                      <Show when={isDefault()}>
+                                        <span class="text-[11px] text-success font-medium shrink-0">
+                                          Default
+                                        </span>
+                                      </Show>
+                                    </div>
+                                    <span class="block text-[0.75rem] text-muted-foreground truncate">
+                                      Last used:{" "}
+                                      {formatDate(connection.last_used_at)}
+                                    </span>
+                                  </div>
+                                </div>
+
+                                <div class="flex items-center gap-2 shrink-0">
+                                  <Show when={!isDefault()}>
+                                    <button
+                                      type="button"
+                                      class="px-3 py-1.5 bg-transparent border border-border rounded-md text-[0.8rem] text-muted-foreground cursor-pointer transition-all duration-150 hover:not-disabled:bg-surface-2 hover:not-disabled:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+                                      onClick={() =>
+                                        handleSetDefaultConnection(connection)
+                                      }
+                                      disabled={isSettingDefault()}
+                                    >
+                                      {isSettingDefault()
+                                        ? "Setting..."
+                                        : "Set default"}
+                                    </button>
+                                  </Show>
+                                  <button
+                                    type="button"
+                                    class="px-3 py-1.5 bg-transparent border border-destructive/50 rounded-md text-[0.8rem] text-destructive cursor-pointer transition-all duration-150 hover:not-disabled:bg-destructive/10 hover:not-disabled:border-destructive disabled:opacity-50 disabled:cursor-not-allowed"
+                                    onClick={() =>
+                                      handleDisconnectConnection(connection)
+                                    }
+                                    disabled={isDisconnecting()}
+                                  >
+                                    {isDisconnecting()
+                                      ? "Disconnecting..."
+                                      : "Disconnect"}
+                                  </button>
+                                </div>
+                              </div>
+                            );
+                          }}
+                        </For>
+                      </div>
+                    </div>
+                  </Show>
+
                   {/* Linked publishers sub-list */}
-                  <Show when={linked().length > 1}>
+                  <Show when={hasConnection() && linked().length > 0}>
                     <div class="px-4 pb-3 pt-0 border-t border-border/50 mt-0">
                       <span class="block text-[0.7rem] text-muted-foreground/70 uppercase tracking-wider pt-2.5 pb-1.5">
-                        Services using this connection
+                        Services using the default account
                       </span>
                       <div class="flex flex-col gap-1.5">
                         <For each={linked()}>

--- a/src/lib/oauth-provider-resolution.ts
+++ b/src/lib/oauth-provider-resolution.ts
@@ -25,6 +25,11 @@ const KNOWN_OAUTH_PROVIDER_BY_PUBLISHER: Record<string, KnownOAuthProvider> = {
   "google-meet": { providerSlug: "google", providerName: "Google" },
   googlecalendar: { providerSlug: "google", providerName: "Google" },
   googlemeet: { providerSlug: "google", providerName: "Google" },
+  "microsoft-outlook": {
+    providerSlug: "microsoft",
+    providerName: "Microsoft",
+  },
+  outlook: { providerSlug: "microsoft", providerName: "Microsoft" },
 };
 
 const DISPLAY_NAME_OVERRIDES: Record<string, string> = {
@@ -32,7 +37,9 @@ const DISPLAY_NAME_OVERRIDES: Record<string, string> = {
   github: "GitHub",
   gmail: "Gmail",
   google: "Google",
+  microsoft: "Microsoft",
   oauth: "OAuth",
+  outlook: "Outlook",
 };
 
 function uniqueNonEmpty(values: Array<string | null | undefined>): string[] {

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -12,8 +12,18 @@ import {
   callSerenTool,
   type PaymentProxyInfo,
 } from "@/services/mcp-gateway";
+import {
+  listConnectedPublishers,
+  resolveOAuthProviderForPublisher,
+} from "@/services/publisher-oauth";
 import { startShellProgressListener } from "@/services/shell-progress";
 import { x402Service } from "@/services/x402";
+import { conversationStore } from "@/stores/conversation.store";
+import {
+  getOAuthConnectionsForProvider,
+  hasAmbiguousOAuthConnections,
+  resolveThreadOAuthConnection,
+} from "@/stores/oauth-account.store";
 import { getApprovalRequirement, requiresApproval } from "./approval-config";
 import { parseGatewayToolName, parseMcpToolName } from "./definitions";
 
@@ -30,6 +40,16 @@ const GATEWAY_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const SHELL_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_RESULT_SIZE = 50_000; // 50KB cap
 const MAX_ARRAY_ITEMS = 25;
+
+interface GatewayApprovalResult {
+  approved: boolean;
+  connectionId?: string | null;
+}
+
+interface GatewayConnectionArgsResult {
+  args: Record<string, unknown>;
+  error?: string;
+}
 
 /**
  * Emit an event to notify the UI that an OAuth connection has expired.
@@ -121,7 +141,7 @@ async function requestGatewayApproval(
   publisherSlug: string,
   toolName: string,
   args: Record<string, unknown>,
-): Promise<boolean> {
+): Promise<GatewayApprovalResult> {
   const approvalId = `gateway-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const requirement = getApprovalRequirement(publisherSlug, toolName);
 
@@ -136,12 +156,13 @@ async function requestGatewayApproval(
       publisherSlug,
       toolName,
       args,
+      threadId: conversationStore.activeConversationId,
       description: requirement?.description || "Execute operation",
       isDestructive: requirement?.isDestructive || false,
     });
   } catch (err) {
     console.error("[Tool Executor] Failed to emit approval request:", err);
-    return false;
+    return { approved: false };
   }
 
   // Wait for approval response
@@ -150,10 +171,10 @@ async function requestGatewayApproval(
     const timeout = setTimeout(() => {
       console.log(`[Tool Executor] Approval timeout for ${approvalId}`);
       unlisten?.();
-      resolve(false);
+      resolve({ approved: false });
     }, GATEWAY_APPROVAL_TIMEOUT_MS);
 
-    listen<{ id: string; approved: boolean }>(
+    listen<{ id: string; approved: boolean; connectionId?: string | null }>(
       "gateway-tool-approval-response",
       (event) => {
         if (event.payload.id !== approvalId) return;
@@ -162,7 +183,10 @@ async function requestGatewayApproval(
         );
         clearTimeout(timeout);
         unlisten?.();
-        resolve(event.payload.approved);
+        resolve({
+          approved: event.payload.approved,
+          connectionId: event.payload.connectionId ?? null,
+        });
       },
     )
       .then((fn) => {
@@ -171,9 +195,59 @@ async function requestGatewayApproval(
       .catch((err) => {
         console.error("[Tool Executor] Failed to listen for approval:", err);
         clearTimeout(timeout);
-        resolve(false);
+        resolve({ approved: false });
       });
   });
+}
+
+async function resolveGatewayOAuthConnectionArgs(
+  publisherSlug: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<GatewayConnectionArgsResult> {
+  if (typeof args.connection_id === "string" && args.connection_id.length > 0) {
+    return { args };
+  }
+
+  try {
+    const [provider, connections] = await Promise.all([
+      resolveOAuthProviderForPublisher(publisherSlug),
+      listConnectedPublishers(),
+    ]);
+    const providerConnections = getOAuthConnectionsForProvider(
+      connections,
+      provider.providerSlug,
+    );
+    if (providerConnections.length === 0) return { args };
+
+    const threadId = conversationStore.activeConversationId;
+    const selected = resolveThreadOAuthConnection(
+      threadId,
+      provider.providerSlug,
+      connections,
+    );
+
+    if (selected) {
+      return { args: { ...args, connection_id: selected.id } };
+    }
+
+    if (
+      hasAmbiguousOAuthConnections(threadId, provider.providerSlug, connections)
+    ) {
+      return {
+        args,
+        error: `Multiple ${provider.providerName} accounts are connected. Choose an active account for this chat before running ${publisherSlug}/${toolName}.`,
+      };
+    }
+
+    return { args };
+  } catch (err) {
+    console.warn(
+      `[Tool Executor] Failed to resolve OAuth connection for ${publisherSlug}:`,
+      err,
+    );
+    return { args };
+  }
 }
 
 /**
@@ -587,18 +661,20 @@ async function executeGatewayTool(
   args: Record<string, unknown>,
 ): Promise<ToolResult> {
   try {
+    let callArgs = args;
+
     // Check if this operation requires user approval
     if (requiresApproval(publisherSlug, toolName)) {
       console.log(
         `[Tool Executor] Operation requires approval: ${publisherSlug}/${toolName}`,
       );
-      const approved = await requestGatewayApproval(
+      const approval = await requestGatewayApproval(
         publisherSlug,
         toolName,
         args,
       );
 
-      if (!approved) {
+      if (!approval.approved) {
         console.log("[Tool Executor] Operation denied by user");
         return {
           tool_call_id: toolCallId,
@@ -608,9 +684,27 @@ async function executeGatewayTool(
       }
 
       console.log("[Tool Executor] Operation approved by user");
+
+      if (approval.connectionId) {
+        callArgs = { ...args, connection_id: approval.connectionId };
+      }
     }
 
-    const response = await callGatewayTool(publisherSlug, toolName, args);
+    const resolvedArgs = await resolveGatewayOAuthConnectionArgs(
+      publisherSlug,
+      toolName,
+      callArgs,
+    );
+    if (resolvedArgs.error) {
+      return {
+        tool_call_id: toolCallId,
+        content: resolvedArgs.error,
+        is_error: true,
+      };
+    }
+    callArgs = resolvedArgs.args;
+
+    const response = await callGatewayTool(publisherSlug, toolName, callArgs);
 
     // Check if this is a payment proxy response (requires client-side signing)
     if (response.is_error && response.payment_proxy) {
@@ -648,7 +742,7 @@ async function executeGatewayTool(
         console.log("[Tool Executor] Retrying with signed payment...");
 
         const retryArgs = {
-          ...args,
+          ...callArgs,
           _x402_payment: paymentResult.paymentHeader,
         };
 
@@ -684,7 +778,7 @@ async function executeGatewayTool(
         const retryResponse = await callGatewayTool(
           publisherSlug,
           toolName,
-          args,
+          callArgs,
         );
 
         const retryContent =

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -646,8 +646,8 @@ export async function callGatewayTool(
   const startTime = Date.now();
 
   try {
-    // Separate x402 payment from tool args (call_publisher accepts it at top level)
-    const { _x402_payment, ...toolArgs } = args;
+    // Separate gateway metadata from publisher tool args.
+    const { _x402_payment, connection_id, ...toolArgs } = args;
 
     // Check if this is a first-class MCP tool on the gateway.
     // Native tools (from the gateway's list_tools response) are called directly
@@ -670,6 +670,9 @@ export async function callGatewayTool(
       };
       if (_x402_payment !== undefined) {
         dispatchArgs._x402_payment = _x402_payment;
+      }
+      if (typeof connection_id === "string" && connection_id.length > 0) {
+        dispatchArgs.connection_id = connection_id;
       }
 
       result = await mcpClient.callToolHttp(SEREN_MCP_SERVER_NAME, {

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -7,6 +7,7 @@ import {
   listProviders,
   listStorePublishers,
   revokeConnectionById,
+  setDefaultConnection,
   type UserOAuthConnectionResponse,
 } from "@/api";
 import { apiBase } from "@/lib/config";
@@ -19,6 +20,10 @@ import {
   getDesktopOAuthCallbackUrl,
   getValidationRuntimeInfo,
 } from "@/services/oauth-callback";
+import {
+  markOAuthConnectionsChanged,
+  type OAuthConnection,
+} from "@/stores/oauth-account.store";
 
 export interface PublisherOAuthProviderResolution {
   publisherSlug: string;
@@ -184,9 +189,7 @@ export async function connectPublisher(
 /**
  * List user's connected OAuth providers.
  */
-export async function listConnectedPublishers(): Promise<
-  UserOAuthConnectionResponse[]
-> {
+export async function listConnectedPublishers(): Promise<OAuthConnection[]> {
   console.log("[PublisherOAuth] Fetching connected OAuth providers");
   const { data, error } = await listConnections({ throwOnError: false });
 
@@ -195,7 +198,7 @@ export async function listConnectedPublishers(): Promise<
     throw new Error(`Failed to list connections: ${error}`);
   }
 
-  const connections = data?.connections || [];
+  const connections = (data?.connections || []) as OAuthConnection[];
   console.log(
     `[PublisherOAuth] Found ${connections.length} connected providers`,
   );
@@ -208,7 +211,63 @@ export async function listConnectedPublishers(): Promise<
 export async function disconnectPublisher(providerSlug: string): Promise<void> {
   console.log(`[PublisherOAuth] Disconnecting ${providerSlug}`);
   await revokePublisherConnection(providerSlug);
+  markOAuthConnectionsChanged();
   console.log(`[PublisherOAuth] Successfully disconnected ${providerSlug}`);
+}
+
+/**
+ * Disconnect one OAuth account row.
+ */
+export async function disconnectOAuthConnection(
+  connectionId: string,
+): Promise<void> {
+  console.log(
+    `[PublisherOAuth] Disconnecting OAuth connection ${connectionId}`,
+  );
+
+  const { error } = await revokeConnectionById({
+    path: { connection_id: connectionId },
+    throwOnError: false,
+  });
+
+  if (error) {
+    console.error(
+      `[PublisherOAuth] Error disconnecting OAuth connection ${connectionId}:`,
+      error,
+    );
+    throw new Error(`Failed to revoke connection: ${formatOAuthError(error)}`);
+  }
+
+  markOAuthConnectionsChanged();
+}
+
+/**
+ * Make one OAuth account the provider default.
+ */
+export async function setDefaultOAuthConnection(
+  connectionId: string,
+): Promise<OAuthConnection> {
+  console.log(
+    `[PublisherOAuth] Setting default OAuth connection ${connectionId}`,
+  );
+
+  const { data, error } = await setDefaultConnection({
+    path: { connection_id: connectionId },
+    throwOnError: false,
+  });
+
+  if (error) {
+    console.error(
+      `[PublisherOAuth] Error setting default OAuth connection ${connectionId}:`,
+      error,
+    );
+    throw new Error(
+      `Failed to set default connection: ${formatOAuthError(error)}`,
+    );
+  }
+
+  markOAuthConnectionsChanged();
+  return data.connection as OAuthConnection;
 }
 
 async function revokePublisherConnection(

--- a/src/stores/oauth-account.store.ts
+++ b/src/stores/oauth-account.store.ts
@@ -1,0 +1,173 @@
+// ABOUTME: Per-thread OAuth account selection for multi-account publishers.
+// ABOUTME: Keeps Settings, chat header, approvals, and gateway dispatch in sync.
+
+import { createSignal } from "solid-js";
+import type { UserOAuthConnectionResponse } from "@/api";
+
+export type OAuthConnection = UserOAuthConnectionResponse & {
+  is_default?: boolean;
+};
+
+type ThreadConnectionSelections = Record<string, Record<string, string>>;
+
+const STORAGE_KEY = "seren.oauth.thread-connection-selections.v1";
+
+function getStorage(): Storage | null {
+  if (typeof globalThis === "undefined") return null;
+  try {
+    return "localStorage" in globalThis ? globalThis.localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+function readSelections(): ThreadConnectionSelections {
+  const storage = getStorage();
+  if (!storage) return {};
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed as ThreadConnectionSelections;
+  } catch {
+    return {};
+  }
+}
+
+function writeSelections(selections: ThreadConnectionSelections): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(selections));
+  } catch {
+    // Ignore storage quota/private-mode failures; current session state still works.
+  }
+}
+
+function normalizeProviderSlug(providerSlug: string): string {
+  return providerSlug.trim().toLowerCase();
+}
+
+function normalizeThreadId(threadId: string | null | undefined): string | null {
+  const trimmed = threadId?.trim();
+  return trimmed ? trimmed : null;
+}
+
+const [selections, setSelections] = createSignal<ThreadConnectionSelections>(
+  readSelections(),
+);
+const [connectionsRevision, setConnectionsRevision] = createSignal(0);
+
+export const oauthConnectionsRevision = connectionsRevision;
+
+export function markOAuthConnectionsChanged(): void {
+  setConnectionsRevision((revision) => revision + 1);
+}
+
+export function getOAuthConnectionsForProvider(
+  connections: OAuthConnection[],
+  providerSlug: string,
+): OAuthConnection[] {
+  const normalizedProvider = normalizeProviderSlug(providerSlug);
+  return connections
+    .filter(
+      (connection) =>
+        connection.provider_slug.toLowerCase() === normalizedProvider &&
+        connection.is_valid,
+    )
+    .sort(
+      (a, b) => Number(Boolean(b.is_default)) - Number(Boolean(a.is_default)),
+    );
+}
+
+export function getDefaultOAuthConnection(
+  connections: OAuthConnection[],
+): OAuthConnection | null {
+  return connections.find((connection) => connection.is_default) ?? null;
+}
+
+export function getThreadOAuthConnectionId(
+  threadId: string | null | undefined,
+  providerSlug: string,
+): string | null {
+  const normalizedThreadId = normalizeThreadId(threadId);
+  if (!normalizedThreadId) return null;
+  return (
+    selections()[normalizedThreadId]?.[normalizeProviderSlug(providerSlug)] ??
+    null
+  );
+}
+
+export function setThreadOAuthConnectionId(
+  threadId: string | null | undefined,
+  providerSlug: string,
+  connectionId: string | null,
+): void {
+  const normalizedThreadId = normalizeThreadId(threadId);
+  if (!normalizedThreadId) return;
+
+  const normalizedProvider = normalizeProviderSlug(providerSlug);
+  const next: ThreadConnectionSelections = {
+    ...selections(),
+    [normalizedThreadId]: {
+      ...(selections()[normalizedThreadId] ?? {}),
+    },
+  };
+
+  if (connectionId) {
+    next[normalizedThreadId][normalizedProvider] = connectionId;
+  } else {
+    delete next[normalizedThreadId][normalizedProvider];
+    if (Object.keys(next[normalizedThreadId]).length === 0) {
+      delete next[normalizedThreadId];
+    }
+  }
+
+  setSelections(next);
+  writeSelections(next);
+}
+
+export function resolveThreadOAuthConnection(
+  threadId: string | null | undefined,
+  providerSlug: string,
+  allConnections: OAuthConnection[],
+): OAuthConnection | null {
+  const validConnections = getOAuthConnectionsForProvider(
+    allConnections,
+    providerSlug,
+  );
+  const selectedId = getThreadOAuthConnectionId(threadId, providerSlug);
+  const selected = selectedId
+    ? validConnections.find((connection) => connection.id === selectedId)
+    : null;
+  if (selected) return selected;
+
+  const defaultConnection = getDefaultOAuthConnection(validConnections);
+  if (defaultConnection) return defaultConnection;
+
+  return validConnections.length === 1 ? validConnections[0] : null;
+}
+
+export function hasAmbiguousOAuthConnections(
+  threadId: string | null | undefined,
+  providerSlug: string,
+  allConnections: OAuthConnection[],
+): boolean {
+  const validConnections = getOAuthConnectionsForProvider(
+    allConnections,
+    providerSlug,
+  );
+  if (validConnections.length <= 1) return false;
+  return !resolveThreadOAuthConnection(threadId, providerSlug, allConnections);
+}
+
+export function formatOAuthConnectionLabel(
+  connection: OAuthConnection,
+): string {
+  return (
+    connection.provider_email ||
+    connection.provider_user_id ||
+    `${connection.provider_slug} account`
+  );
+}

--- a/tests/services/mcp-gateway.test.ts
+++ b/tests/services/mcp-gateway.test.ts
@@ -332,6 +332,81 @@ describe("MCP Gateway Native Tool Routing (#1329)", () => {
     expect(result.is_error).toBe(false);
   });
 
+  it("should pass connection_id as call_publisher metadata for REST publisher tools", async () => {
+    const { mcpClient } = await import("@/lib/mcp/client");
+    const callToolMock = vi.mocked(mcpClient.callToolHttp);
+
+    callToolMock.mockImplementation(async (_server, request) => {
+      if (request.name === "list_agent_publishers") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                publishers: [{ slug: "gmail", name: "Gmail" }],
+              }),
+            },
+          ],
+          isError: false,
+        };
+      }
+      if (
+        request.name === "list_mcp_tools" &&
+        request.arguments?.publisher === "gmail"
+      ) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                tools: [
+                  {
+                    name: "post_messages_send",
+                    description: "Send email",
+                    inputSchema: { type: "object", properties: {} },
+                  },
+                ],
+              }),
+            },
+          ],
+          isError: false,
+        };
+      }
+      return { content: [], isError: true };
+    });
+
+    const { initializeGateway, callGatewayTool } = await import(
+      "@/services/mcp-gateway"
+    );
+
+    await initializeGateway();
+    callToolMock.mockClear();
+    callToolMock.mockResolvedValue({
+      content: [{ type: "text", text: "sent" }],
+      isError: false,
+    });
+
+    const result = await callGatewayTool("gmail", "post_messages_send", {
+      connection_id: "conn_google_1",
+      to: "user@example.com",
+      subject: "Hello",
+    });
+
+    expect(callToolMock).toHaveBeenCalledWith("seren-gateway", {
+      name: "call_publisher",
+      arguments: {
+        publisher: "gmail",
+        tool: "post_messages_send",
+        connection_id: "conn_google_1",
+        tool_args: {
+          to: "user@example.com",
+          subject: "Hello",
+        },
+      },
+    });
+    expect(result.is_error).toBe(false);
+  });
+
   it("should track native tools and clear them on reset", async () => {
     const { initializeGateway, isNativeMcpTool, resetGateway } = await import(
       "@/services/mcp-gateway"

--- a/tests/unit/publisher-oauth-reconnect.test.ts
+++ b/tests/unit/publisher-oauth-reconnect.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   listConnections: vi.fn(),
   openUrl: vi.fn<() => Promise<void>>(),
   revokeConnectionById: vi.fn(),
+  setDefaultConnection: vi.fn(),
 }));
 
 vi.mock("@/api", () => ({
@@ -16,6 +17,7 @@ vi.mock("@/api", () => ({
   listProviders: vi.fn(),
   listStorePublishers: vi.fn(),
   revokeConnectionById: mocks.revokeConnectionById,
+  setDefaultConnection: mocks.setDefaultConnection,
 }));
 
 vi.mock("@/lib/config", () => ({
@@ -72,6 +74,21 @@ describe("publisher OAuth reconnect", () => {
     });
     mocks.revokeConnectionById.mockResolvedValue({
       data: {},
+      response: new Response(null, { status: 200 }),
+    });
+    mocks.setDefaultConnection.mockResolvedValue({
+      data: {
+        connection: {
+          id: "conn_google_1",
+          provider_slug: "google",
+          provider_email: "user@example.com",
+          provider_user_id: "user-1",
+          is_valid: true,
+          is_default: true,
+          connected_at: "2026-01-01T00:00:00Z",
+          last_used_at: null,
+        },
+      },
       response: new Response(null, { status: 200 }),
     });
   });
@@ -194,5 +211,32 @@ describe("publisher OAuth reconnect", () => {
       bearerToken: "access-token",
       url: "https://api.serendb.com/oauth/google/authorize?redirect_uri=http%3A%2F%2F127.0.0.1%3A49152%2Foauth%2Fcallback",
     });
+  });
+
+  it("disconnects a single OAuth account row by connection id", async () => {
+    const { disconnectOAuthConnection } = await import(
+      "@/services/publisher-oauth"
+    );
+
+    await disconnectOAuthConnection("conn_google_1");
+
+    expect(mocks.revokeConnectionById).toHaveBeenCalledWith({
+      path: { connection_id: "conn_google_1" },
+      throwOnError: false,
+    });
+  });
+
+  it("sets a single OAuth account row as provider default", async () => {
+    const { setDefaultOAuthConnection } = await import(
+      "@/services/publisher-oauth"
+    );
+
+    const connection = await setDefaultOAuthConnection("conn_google_1");
+
+    expect(mocks.setDefaultConnection).toHaveBeenCalledWith({
+      path: { connection_id: "conn_google_1" },
+      throwOnError: false,
+    });
+    expect(connection.is_default).toBe(true);
   });
 });

--- a/tests/unit/tool-executor-oauth-account.test.ts
+++ b/tests/unit/tool-executor-oauth-account.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  callGatewayTool: vi.fn(),
+  callSerenTool: vi.fn(),
+  listConnectedPublishers: vi.fn(),
+  resolveOAuthProviderForPublisher: vi.fn(),
+  emit: vi.fn(),
+  listen: vi.fn(),
+  invoke: vi.fn(),
+  startShellProgressListener: vi.fn(),
+  handlePaymentRequired: vi.fn(),
+}));
+
+vi.mock("@/services/mcp-gateway", () => ({
+  callGatewayTool: mocks.callGatewayTool,
+  callSerenTool: mocks.callSerenTool,
+}));
+
+vi.mock("@/services/publisher-oauth", () => ({
+  listConnectedPublishers: mocks.listConnectedPublishers,
+  resolveOAuthProviderForPublisher: mocks.resolveOAuthProviderForPublisher,
+}));
+
+vi.mock("@/stores/conversation.store", () => ({
+  conversationStore: {
+    activeConversationId: "thread-1",
+  },
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: mocks.emit,
+  listen: mocks.listen,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@/services/shell-progress", () => ({
+  startShellProgressListener: mocks.startShellProgressListener,
+}));
+
+vi.mock("@/services/x402", () => ({
+  x402Service: {
+    handlePaymentRequired: mocks.handlePaymentRequired,
+  },
+}));
+
+const googleConnections = [
+  {
+    id: "conn-google-work",
+    provider_slug: "google",
+    provider_email: "work@example.com",
+    provider_user_id: "work",
+    is_valid: true,
+    is_default: false,
+    connected_at: "2026-06-01T00:00:00Z",
+    last_used_at: null,
+  },
+  {
+    id: "conn-google-personal",
+    provider_slug: "google",
+    provider_email: "personal@example.com",
+    provider_user_id: "personal",
+    is_valid: true,
+    is_default: false,
+    connected_at: "2026-06-15T00:00:00Z",
+    last_used_at: null,
+  },
+];
+
+describe("tool executor OAuth account routing", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { setThreadOAuthConnectionId } = await import(
+      "@/stores/oauth-account.store"
+    );
+    setThreadOAuthConnectionId("thread-1", "google", null);
+    mocks.resolveOAuthProviderForPublisher.mockResolvedValue({
+      publisherSlug: "gmail",
+      providerSlug: "google",
+      providerName: "Google",
+    });
+    mocks.listConnectedPublishers.mockResolvedValue(googleConnections);
+    mocks.callGatewayTool.mockResolvedValue({
+      result: "ok",
+      is_error: false,
+    });
+  });
+
+  it("attaches the active chat OAuth connection before dispatching a Gateway publisher tool", async () => {
+    const [{ executeTool }, { setThreadOAuthConnectionId }] =
+      await Promise.all([
+        import("@/lib/tools/executor"),
+        import("@/stores/oauth-account.store"),
+      ]);
+    setThreadOAuthConnectionId(
+      "thread-1",
+      "google",
+      "conn-google-personal",
+    );
+
+    const result = await executeTool({
+      id: "tool-call-1",
+      type: "function",
+      function: {
+        name: "gateway__gmail__messages",
+        arguments: JSON.stringify({ q: "from:example" }),
+      },
+    });
+
+    expect(result.is_error).toBe(false);
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith("gmail", "messages", {
+      q: "from:example",
+      connection_id: "conn-google-personal",
+    });
+  });
+
+  it("fails closed before dispatch when multiple accounts have no default or chat selection", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+
+    const result = await executeTool({
+      id: "tool-call-2",
+      type: "function",
+      function: {
+        name: "gateway__gmail__messages",
+        arguments: JSON.stringify({ q: "from:example" }),
+      },
+    });
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("Multiple Google accounts are connected");
+    expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #2790

## Summary
- Adds per-thread OAuth account selection keyed by provider, initialized from server default/single-account state.
- Updates Settings > Logins to show all connected accounts as rows with Add account, Set default, and per-account Disconnect.
- Adds a quiet chat-header OAuth account switcher and an approval-card From row, including fail-closed inline choices when multiple accounts have no default.
- Routes selected `connection_id` as top-level `call_publisher` metadata and strips it from publisher `tool_args`.

## Audit / Contract Notes
- Mock source confirmed at `/tmp/seren-multi-account-mocks` (`s1`-`s4`, `screen1`-`screen4`, `index.html`).
- Existing desktop code collapsed OAuth connections in `OAuthLogins.tsx` and did not pass account selection through `mcp-gateway.ts`.
- Live OpenAPI verified:
  - `GET /oauth/connections` returns connection rows with `is_default`.
  - `PUT /oauth/connections/{connection_id}/default` sets provider default.
  - `DELETE /oauth/connections/{connection_id}` revokes a single connection row.
- Live Seren publisher metadata verified for `gmail`, `google-calendar`, and `microsoft-outlook`; Google publishers share `google`, Outlook uses `microsoft`.
- Networked path: chat tool call -> `executeGatewayTool` -> `callGatewayTool` -> Seren MCP `call_publisher` with `{ publisher, tool, connection_id, tool_args }`. Native MCP tools are not changed by this PR.

## Validation
- `pnpm exec biome check src/stores/oauth-account.store.ts src/components/chat/OAuthAccountSwitcher.tsx src/components/gateway/GatewayToolApproval.tsx src/components/settings/OAuthLogins.tsx src/services/publisher-oauth.ts src/services/mcp-gateway.ts src/lib/oauth-provider-resolution.ts src/lib/tools/executor.ts`
- `pnpm test -- tests/services/mcp-gateway.test.ts tests/unit/publisher-oauth-reconnect.test.ts tests/unit/tool-executor-oauth-account.test.ts`
- `git diff --check`
- `pnpm build`

Build exits successfully; existing Rolldown pure-annotation and dynamic-import warnings remain from dependencies/app chunking.

## Functional Walkthrough Evidence
Controlled Playwright walkthrough against the Vite app at `http://127.0.0.1:4179/` with mocked live OAuth fixtures:
- `/tmp/issue-2790-settings-logins-multi-account.png`
- `/tmp/issue-2790-chat-account-switcher.png`
- `/tmp/issue-2790-approval-from-selector.png`
- `/tmp/issue-2790-approval-ambiguity-chooser.png`

Walkthrough confirmed Settings rows, header switcher + Add account, approval From selector, and fail-closed no-default chooser with Approve disabled until account selection.
