### PR TITLE
feat(search): searchable chat & agent conversation history (⌘⇧H)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,7 @@
       "!**/.worktrees/**/*",
       "!**/src/api/generated/**/*",
       "!**/src-tauri/target/**/*",
-      "!**/mcp-servers/**"
+      "!**/mcp-servers"
     ]
   },
   "formatter": {

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -6,10 +6,97 @@ use crate::services::database::{
     DbPool, PersistedMessage, enqueue_sync_tombstone, init_db, mark_sync_upsert,
     save_message_record,
 };
+use crate::services::conversation_index::{self, IndexableMessage, open_index_db};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
+
+fn load_indexable_message_meta(
+    conn: &Connection,
+    conversation_id: &str,
+) -> rusqlite::Result<Option<(String, Option<String>, Option<String>, Option<String>, bool)>> {
+    let sql = format!(
+        "SELECT {case} AS derived_kind,
+                c.title,
+                CASE WHEN ({case}) = 'agent'
+                     THEN COALESCE(c.agent_type, psr.provider)
+                     ELSE c.agent_type END AS agent_type,
+                COALESCE(c.project_root, c.agent_cwd, c.project_id) AS project_root,
+                c.is_archived
+         FROM conversations c
+         LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+         WHERE c.id = ?1",
+        case = DERIVED_KIND_CASE_SQL,
+    );
+    conn.query_row(&sql, params![conversation_id], |row| {
+        Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get::<_, i32>(4)? != 0,
+        ))
+    })
+    .optional()
+}
+
+fn index_message_best_effort(app: &AppHandle, message: &IndexableMessage) {
+    match open_index_db(app).and_then(|conn| conversation_index::reindex_message(&conn, message)) {
+        Ok(_) => {}
+        Err(err) => log::warn!(
+            "[ConversationIndex] Failed to index message {}: {}",
+            message.message_id,
+            err
+        ),
+    }
+}
+
+fn delete_conversation_index_best_effort(app: &AppHandle, conversation_id: &str) {
+    match open_index_db(app)
+        .and_then(|conn| conversation_index::delete_conversation_chunks(&conn, conversation_id))
+    {
+        Ok(_) => {}
+        Err(err) => log::warn!(
+            "[ConversationIndex] Failed to delete index for conversation {}: {}",
+            conversation_id,
+            err
+        ),
+    }
+}
+
+fn clear_conversation_index_best_effort(app: &AppHandle) {
+    match open_index_db(app).and_then(|conn| conversation_index::clear_all_chunks(&conn)) {
+        Ok(_) => {}
+        Err(err) => log::warn!(
+            "[ConversationIndex] Failed to clear conversation index: {}",
+            err
+        ),
+    }
+}
+
+async fn refresh_conversation_index_meta_best_effort(
+    app: AppHandle,
+    conversation_id: String,
+    title: Option<String>,
+    is_archived: Option<bool>,
+) {
+    match open_index_db(&app).and_then(|conn| {
+        conversation_index::update_conversation_meta(
+            &conn,
+            &conversation_id,
+            title.as_deref(),
+            is_archived,
+        )
+    }) {
+        Ok(_) => {}
+        Err(err) => log::warn!(
+            "[ConversationIndex] Failed to refresh index metadata for conversation {}: {}",
+            conversation_id,
+            err
+        ),
+    }
+}
 
 pub(crate) fn delete_conversation_records(
     conn: &Connection,
@@ -378,7 +465,9 @@ pub async fn update_conversation(
     selected_model: Option<String>,
     selected_provider: Option<String>,
 ) -> Result<(), String> {
-    run_db(app, move |conn| {
+    let index_id = id.clone();
+    let index_title = title.clone();
+    run_db(app.clone(), move |conn| {
         if let Some(t) = title {
             conn.execute(
                 "UPDATE conversations SET title = ?1 WHERE id = ?2",
@@ -402,12 +491,15 @@ pub async fn update_conversation(
         }
         Ok(())
     })
-    .await
+    .await?;
+    refresh_conversation_index_meta_best_effort(app, index_id, index_title, None).await;
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn archive_conversation(app: AppHandle, id: String) -> Result<(), String> {
-    run_db(app, move |conn| {
+    let index_id = id.clone();
+    run_db(app.clone(), move |conn| {
         conn.execute(
             "UPDATE conversations SET is_archived = 1 WHERE id = ?1",
             params![id],
@@ -415,16 +507,21 @@ pub async fn archive_conversation(app: AppHandle, id: String) -> Result<(), Stri
         mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
-    .await
+    .await?;
+    refresh_conversation_index_meta_best_effort(app, index_id, None, Some(true)).await;
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn delete_conversation(app: AppHandle, id: String) -> Result<(), String> {
-    run_db(app, move |conn| {
+    let index_id = id.clone();
+    run_db(app.clone(), move |conn| {
         delete_conversation_records(conn, &[id])?;
         Ok(())
     })
-    .await
+    .await?;
+    delete_conversation_index_best_effort(&app, &index_id);
+    Ok(())
 }
 
 #[tauri::command]
@@ -432,16 +529,20 @@ pub async fn delete_conversations_by_employee(
     app: AppHandle,
     employee_id: String,
 ) -> Result<i64, String> {
-    run_db(app, move |conn| {
+    let (deleted, conversation_ids) = run_db(app.clone(), move |conn| {
         let mut stmt = conn.prepare("SELECT id FROM conversations WHERE employee_id = ?1")?;
         let conversation_ids = stmt
             .query_map(params![employee_id], |row| row.get::<_, String>(0))?
             .collect::<rusqlite::Result<Vec<_>>>()?;
         drop(stmt);
         let deleted = delete_conversation_records(conn, &conversation_ids)?;
-        Ok(deleted as i64)
+        Ok((deleted as i64, conversation_ids))
     })
-    .await
+    .await?;
+    for conversation_id in &conversation_ids {
+        delete_conversation_index_best_effort(&app, conversation_id);
+    }
+    Ok(deleted)
 }
 
 // ============================================================================
@@ -600,7 +701,9 @@ pub async fn set_agent_conversation_title(
     id: String,
     title: String,
 ) -> Result<(), String> {
-    run_db(app, move |conn| {
+    let index_id = id.clone();
+    let index_title = title.clone();
+    run_db(app.clone(), move |conn| {
         conn.execute(
             "UPDATE conversations SET title = ?1 WHERE id = ?2 AND kind = 'agent'",
             params![title, id],
@@ -608,7 +711,9 @@ pub async fn set_agent_conversation_title(
         mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
-    .await
+    .await?;
+    refresh_conversation_index_meta_best_effort(app, index_id, Some(index_title), None).await;
+    Ok(())
 }
 
 #[tauri::command]
@@ -758,7 +863,8 @@ pub async fn set_agent_conversation_metadata(
 
 #[tauri::command]
 pub async fn archive_agent_conversation(app: AppHandle, id: String) -> Result<(), String> {
-    run_db(app, move |conn| {
+    let index_id = id.clone();
+    run_db(app.clone(), move |conn| {
         conn.execute(
             "UPDATE conversations SET is_archived = 1 WHERE id = ?1 AND kind = 'agent'",
             params![id],
@@ -766,7 +872,9 @@ pub async fn archive_agent_conversation(app: AppHandle, id: String) -> Result<()
         mark_sync_upsert(conn, "conversations", &id)?;
         Ok(())
     })
-    .await
+    .await?;
+    refresh_conversation_index_meta_best_effort(app, index_id, None, Some(true)).await;
+    Ok(())
 }
 
 // ============================================================================
@@ -785,22 +893,39 @@ pub async fn save_message(
     metadata: Option<String>,
     provider: Option<String>,
 ) -> Result<(), String> {
-    run_db(app, move |conn| {
-        save_message_record(
-            conn,
-            &PersistedMessage {
-                id,
-                conversation_id,
-                role,
-                content,
-                model,
-                timestamp,
-                metadata,
-                provider,
-            },
-        )
+    let indexable = run_db(app.clone(), move |conn| {
+        let message = PersistedMessage {
+            id,
+            conversation_id,
+            role,
+            content,
+            model,
+            timestamp,
+            metadata,
+            provider,
+        };
+        save_message_record(conn, &message)?;
+        let meta = load_indexable_message_meta(conn, &message.conversation_id)?;
+        Ok(meta.map(|(kind, title, agent_type, project_root, is_archived)| {
+            IndexableMessage {
+                message_id: message.id,
+                conversation_id: message.conversation_id,
+                kind,
+                role: message.role,
+                title,
+                agent_type,
+                project_root,
+                is_archived,
+                timestamp: message.timestamp,
+                content: message.content,
+            }
+        }))
     })
-    .await
+    .await?;
+    if let Some(message) = indexable {
+        index_message_best_effort(&app, &message);
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -846,7 +971,8 @@ pub async fn clear_conversation_history(
     app: AppHandle,
     conversation_id: String,
 ) -> Result<(), String> {
-    run_db(app, move |conn| {
+    let index_id = conversation_id.clone();
+    run_db(app.clone(), move |conn| {
         let mut event_stmt =
             conn.prepare("SELECT id FROM message_events WHERE conversation_id = ?1")?;
         let event_ids = event_stmt
@@ -875,12 +1001,14 @@ pub async fn clear_conversation_history(
         )?;
         Ok(())
     })
-    .await
+    .await?;
+    delete_conversation_index_best_effort(&app, &index_id);
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn clear_all_history(app: AppHandle) -> Result<(), String> {
-    run_db(app, move |conn| {
+    run_db(app.clone(), move |conn| {
         let conversation_ids = conn
             .prepare("SELECT id FROM conversations")?
             .query_map([], |row| row.get::<_, String>(0))?
@@ -908,14 +1036,16 @@ pub async fn clear_all_history(app: AppHandle) -> Result<(), String> {
         conn.execute("DELETE FROM conversations", [])?;
         Ok(())
     })
-    .await
+    .await?;
+    clear_conversation_index_best_effort(&app);
+    Ok(())
 }
 
 // ============================================================================
 // Helper
 // ============================================================================
 
-async fn run_db<T>(
+pub(crate) async fn run_db<T>(
     app: AppHandle,
     task: impl FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
 ) -> Result<T, String>

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -2,11 +2,11 @@
 // ABOUTME: Handles CRUD operations for conversations and messages in SQLite.
 
 use crate::commands::provider_runtime::DERIVED_KIND_CASE_SQL;
+use crate::services::conversation_index::{self, IndexableMessage, open_index_db};
 use crate::services::database::{
     DbPool, PersistedMessage, enqueue_sync_tombstone, init_db, mark_sync_upsert,
     save_message_record,
 };
-use crate::services::conversation_index::{self, IndexableMessage, open_index_db};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -906,8 +906,8 @@ pub async fn save_message(
         };
         save_message_record(conn, &message)?;
         let meta = load_indexable_message_meta(conn, &message.conversation_id)?;
-        Ok(meta.map(|(kind, title, agent_type, project_root, is_archived)| {
-            IndexableMessage {
+        Ok(meta.map(
+            |(kind, title, agent_type, project_root, is_archived)| IndexableMessage {
                 message_id: message.id,
                 conversation_id: message.conversation_id,
                 kind,
@@ -918,8 +918,8 @@ pub async fn save_message(
                 is_archived,
                 timestamp: message.timestamp,
                 content: message.content,
-            }
-        }))
+            },
+        ))
     })
     .await?;
     if let Some(message) = indexable {

--- a/src-tauri/src/commands/conversation_search.rs
+++ b/src-tauri/src/commands/conversation_search.rs
@@ -71,8 +71,7 @@ pub fn index_conversation_embeddings(
     embedding: Vec<f32>,
 ) -> Result<(), String> {
     let conn = open_index_db(&app).map_err(|err| err.to_string())?;
-    conversation_index::insert_embedding(&conn, chunk_id, &embedding)
-        .map_err(|err| err.to_string())
+    conversation_index::insert_embedding(&conn, chunk_id, &embedding).map_err(|err| err.to_string())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/conversation_search.rs
+++ b/src-tauri/src/commands/conversation_search.rs
@@ -1,0 +1,172 @@
+// ABOUTME: Tauri commands for indexed chat/agent conversation history search.
+// ABOUTME: Opens the local conversation index DB and maps search/backfill errors to strings.
+
+use crate::commands::chat::run_db;
+use crate::commands::provider_runtime::DERIVED_KIND_CASE_SQL;
+use crate::services::conversation_index::{
+    self, ConversationHit, IndexableMessage, SearchFilters, open_index_db,
+};
+use rusqlite::{OptionalExtension, params};
+use serde::Serialize;
+use std::collections::HashSet;
+use tauri::AppHandle;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnembeddedConversationChunk {
+    pub chunk_id: i64,
+    pub text: String,
+}
+
+fn load_conversation_meta(
+    conn: &rusqlite::Connection,
+    conversation_id: &str,
+) -> rusqlite::Result<Option<(Option<String>, bool)>> {
+    conn.query_row(
+        "SELECT title, is_archived FROM conversations WHERE id = ?1",
+        params![conversation_id],
+        |row| Ok((row.get(0)?, row.get::<_, i32>(1)? != 0)),
+    )
+    .optional()
+}
+
+#[tauri::command]
+pub fn search_conversations_fts(
+    app: AppHandle,
+    query: String,
+    filters: Option<SearchFilters>,
+    limit: Option<usize>,
+) -> Result<Vec<ConversationHit>, String> {
+    let conn = open_index_db(&app).map_err(|err| err.to_string())?;
+    conversation_index::search_fts(
+        &conn,
+        &query,
+        &filters.unwrap_or_default(),
+        limit.unwrap_or(20),
+    )
+    .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub fn search_conversations(
+    app: AppHandle,
+    query_embedding: Vec<f32>,
+    filters: Option<SearchFilters>,
+    limit: Option<usize>,
+) -> Result<Vec<ConversationHit>, String> {
+    let conn = open_index_db(&app).map_err(|err| err.to_string())?;
+    conversation_index::search_semantic(
+        &conn,
+        &query_embedding,
+        &filters.unwrap_or_default(),
+        limit.unwrap_or(20),
+    )
+    .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub fn index_conversation_embeddings(
+    app: AppHandle,
+    chunk_id: i64,
+    embedding: Vec<f32>,
+) -> Result<(), String> {
+    let conn = open_index_db(&app).map_err(|err| err.to_string())?;
+    conversation_index::insert_embedding(&conn, chunk_id, &embedding)
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub fn unembedded_conversation_chunks(
+    app: AppHandle,
+    limit: Option<usize>,
+) -> Result<Vec<UnembeddedConversationChunk>, String> {
+    let conn = open_index_db(&app).map_err(|err| err.to_string())?;
+    let rows = conversation_index::unembedded_chunk_batch(&conn, limit.unwrap_or(20))
+        .map_err(|err| err.to_string())?;
+    Ok(rows
+        .into_iter()
+        .map(|(chunk_id, text)| UnembeddedConversationChunk { chunk_id, text })
+        .collect())
+}
+
+#[tauri::command]
+pub fn delete_conversation_index(app: AppHandle, conversation_id: String) -> Result<(), String> {
+    let conn = open_index_db(&app).map_err(|err| err.to_string())?;
+    conversation_index::delete_conversation_chunks(&conn, &conversation_id)
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn update_conversation_index_meta(
+    app: AppHandle,
+    conversation_id: String,
+) -> Result<(), String> {
+    let meta = run_db(app.clone(), {
+        let id = conversation_id.clone();
+        move |conn| load_conversation_meta(conn, &id)
+    })
+    .await?
+    .ok_or_else(|| "conversation not found".to_string())?;
+    let conn = open_index_db(&app).map_err(|err| err.to_string())?;
+    conversation_index::update_conversation_meta(
+        &conn,
+        &conversation_id,
+        meta.0.as_deref(),
+        Some(meta.1),
+    )
+    .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn backfill_conversation_fts(app: AppHandle) -> Result<usize, String> {
+    let index_conn = open_index_db(&app).map_err(|err| err.to_string())?;
+    let indexed = conversation_index::indexed_message_ids(&index_conn)
+        .map_err(|err| err.to_string())?
+        .into_iter()
+        .collect::<HashSet<_>>();
+
+    let messages = run_db(app.clone(), move |conn| {
+        let sql = format!(
+            "SELECT m.id, m.conversation_id, {case} AS derived_kind, m.role,
+                    c.title,
+                    CASE WHEN ({case}) = 'agent'
+                         THEN COALESCE(c.agent_type, psr.provider)
+                         ELSE c.agent_type END AS agent_type,
+                    COALESCE(c.project_root, c.agent_cwd, c.project_id) AS project_root,
+                    c.is_archived, m.timestamp, m.content
+             FROM messages m
+             JOIN conversations c ON c.id = m.conversation_id
+             LEFT JOIN provider_session_runtime psr ON psr.thread_id = c.id
+             ORDER BY m.timestamp ASC",
+            case = DERIVED_KIND_CASE_SQL,
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        stmt.query_map([], |row| {
+            Ok(IndexableMessage {
+                message_id: row.get(0)?,
+                conversation_id: row.get(1)?,
+                kind: row.get(2)?,
+                role: row.get(3)?,
+                title: row.get(4)?,
+                agent_type: row.get(5)?,
+                project_root: row.get(6)?,
+                is_archived: row.get::<_, i32>(7)? != 0,
+                timestamp: row.get(8)?,
+                content: row.get(9)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()
+    })
+    .await?;
+
+    let mut count = 0;
+    for message in messages {
+        if indexed.contains(&message.message_id) {
+            continue;
+        }
+        conversation_index::reindex_message(&index_conn, &message)
+            .map_err(|err| err.to_string())?;
+        count += 1;
+    }
+    Ok(count)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ pub mod commands {
 pub mod services {
     pub mod chunker;
     pub mod context_intelligence;
+    pub mod conversation_index;
     pub mod database;
     pub mod history_sync;
     pub mod indexer;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,8 +12,8 @@ pub mod commands {
     pub mod chat;
     pub mod claude_memory;
     pub mod cli_installer;
-    pub mod conversation_search;
     pub mod context_intelligence;
+    pub mod conversation_search;
     pub mod employees_archive;
     pub mod gateway_http;
     pub mod history_sync;
@@ -608,25 +608,28 @@ pub fn run() {
         builder = builder.plugin(tauri_plugin_deep_link::init());
     }
 
-    builder = builder
-        .manage(mcp::McpState::new())
-        .manage(mcp::HttpMcpState::new())
-        .manage(orchestrator::service::OrchestratorState::new())
-        .manage(audio::pipeline::CaptureRegistry::default())
-        .manage(std::sync::Mutex::new(
-            audio::lifecycle::LifecycleController::new(audio::lifecycle::LifecycleConfig::default()),
-        ))
-        .manage(orchestrator::eval::EvalState::new())
-        .manage(orchestrator::tool_bridge::ToolResultBridge::new())
-        .manage(provider_runtime::ProviderRuntimeState::new())
-        .manage(std::sync::Arc::new(
-            commands::updater::ShutdownGuard::default(),
-        ))
-        .manage(services::database::WalCheckpointTask::default())
-        .manage(services::history_sync::HistorySyncLock::default())
-        .manage(messaging::MessagingState::new())
-        .manage(std::sync::Arc::new(tokio::sync::Mutex::new(None))
-            as polymarket::commands::PolymarketWsState);
+    builder =
+        builder
+            .manage(mcp::McpState::new())
+            .manage(mcp::HttpMcpState::new())
+            .manage(orchestrator::service::OrchestratorState::new())
+            .manage(audio::pipeline::CaptureRegistry::default())
+            .manage(std::sync::Mutex::new(
+                audio::lifecycle::LifecycleController::new(
+                    audio::lifecycle::LifecycleConfig::default(),
+                ),
+            ))
+            .manage(orchestrator::eval::EvalState::new())
+            .manage(orchestrator::tool_bridge::ToolResultBridge::new())
+            .manage(provider_runtime::ProviderRuntimeState::new())
+            .manage(std::sync::Arc::new(
+                commands::updater::ShutdownGuard::default(),
+            ))
+            .manage(services::database::WalCheckpointTask::default())
+            .manage(services::history_sync::HistorySyncLock::default())
+            .manage(messaging::MessagingState::new())
+            .manage(std::sync::Arc::new(tokio::sync::Mutex::new(None))
+                as polymarket::commands::PolymarketWsState);
 
     builder
         .on_menu_event(|app, event| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ pub mod commands {
     pub mod chat;
     pub mod claude_memory;
     pub mod cli_installer;
+    pub mod conversation_search;
     pub mod context_intelligence;
     pub mod employees_archive;
     pub mod gateway_http;
@@ -1129,6 +1130,13 @@ pub fn run() {
             commands::transcript_search::search_transcripts_like,
             commands::transcript_search::indexed_transcript_meeting_ids,
             commands::transcript_search::delete_meeting_transcript_index,
+            commands::conversation_search::search_conversations_fts,
+            commands::conversation_search::search_conversations,
+            commands::conversation_search::index_conversation_embeddings,
+            commands::conversation_search::unembedded_conversation_chunks,
+            commands::conversation_search::delete_conversation_index,
+            commands::conversation_search::update_conversation_index_meta,
+            commands::conversation_search::backfill_conversation_fts,
             commands::indexing::discover_project_files,
             commands::indexing::chunk_file,
             commands::indexing::estimate_indexing,

--- a/src-tauri/src/services/conversation_index.rs
+++ b/src-tauri/src/services/conversation_index.rs
@@ -126,7 +126,10 @@ fn create_tables(conn: &Connection) -> Result<()> {
     // Exact path. A plain (non-external-content) FTS5 table whose rowid mirrors
     // conv_chunks.id — supports INSERT with an explicit rowid and DELETE by rowid,
     // avoiding the external-content sync footguns.
-    conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS conv_fts USING fts5(text)", [])?;
+    conn.execute(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS conv_fts USING fts5(text)",
+        [],
+    )?;
     // Semantic path (dim reuses EMBEDDING_DIM = 1536, same as transcript/code index).
     conn.execute(
         &format!(
@@ -157,7 +160,10 @@ pub fn open_index_db(app: &AppHandle) -> Result<Connection> {
 }
 
 fn embedding_to_blob(embedding: &[f32]) -> Vec<u8> {
-    embedding.iter().flat_map(|value| value.to_le_bytes()).collect()
+    embedding
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
 }
 
 fn fts_document(title: Option<&str>, text: &str) -> String {
@@ -200,7 +206,11 @@ pub fn chunk_message(content: &str) -> Vec<ChunkInput> {
                 }
             }
         }
-        let text: String = chars[start..end].iter().collect::<String>().trim().to_string();
+        let text: String = chars[start..end]
+            .iter()
+            .collect::<String>()
+            .trim()
+            .to_string();
         if !text.is_empty() {
             chunks.push(ChunkInput { seq, text });
             seq += 1;
@@ -219,9 +229,15 @@ fn delete_message_chunks_tx(tx: &Connection, message_id: &str) -> Result<()> {
     };
     for id in &ids {
         tx.execute("DELETE FROM conv_fts WHERE rowid = ?1", params![id])?;
-        tx.execute("DELETE FROM conv_embeddings WHERE chunk_id = ?1", params![id])?;
+        tx.execute(
+            "DELETE FROM conv_embeddings WHERE chunk_id = ?1",
+            params![id],
+        )?;
     }
-    tx.execute("DELETE FROM conv_chunks WHERE message_id = ?1", params![message_id])?;
+    tx.execute(
+        "DELETE FROM conv_chunks WHERE message_id = ?1",
+        params![message_id],
+    )?;
     Ok(())
 }
 
@@ -282,7 +298,10 @@ pub fn delete_conversation_chunks(conn: &Connection, conversation_id: &str) -> R
     };
     for id in &ids {
         tx.execute("DELETE FROM conv_fts WHERE rowid = ?1", params![id])?;
-        tx.execute("DELETE FROM conv_embeddings WHERE chunk_id = ?1", params![id])?;
+        tx.execute(
+            "DELETE FROM conv_embeddings WHERE chunk_id = ?1",
+            params![id],
+        )?;
     }
     tx.execute(
         "DELETE FROM conv_chunks WHERE conversation_id = ?1",
@@ -317,9 +336,11 @@ pub fn update_conversation_meta(
         let rows: Vec<(i64, String)> = {
             let mut stmt =
                 conn.prepare("SELECT id, text FROM conv_chunks WHERE conversation_id = ?1")?;
-            stmt.query_map(params![conversation_id], |row| Ok((row.get(0)?, row.get(1)?)))?
-                .filter_map(|row| row.ok())
-                .collect()
+            stmt.query_map(params![conversation_id], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })?
+            .filter_map(|row| row.ok())
+            .collect()
         };
         for (chunk_id, text) in rows {
             conn.execute(
@@ -384,7 +405,12 @@ fn build_filter_clause(filters: &SearchFilters) -> (String, Vec<Value>) {
     let mut clause = String::new();
     let mut vals: Vec<Value> = Vec::new();
     if !filters.kinds.is_empty() {
-        let placeholders = filters.kinds.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let placeholders = filters
+            .kinds
+            .iter()
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(",");
         clause.push_str(&format!(" AND c.kind IN ({placeholders})"));
         for kind in &filters.kinds {
             vals.push(Value::Text(kind.clone()));
@@ -527,7 +553,11 @@ mod tests {
             kind: kind.to_string(),
             role: role.to_string(),
             title: Some(format!("title-{conv}")),
-            agent_type: if kind == "agent" { Some("claude-code".into()) } else { None },
+            agent_type: if kind == "agent" {
+                Some("claude-code".into())
+            } else {
+                None
+            },
             project_root: Some("/repo".into()),
             is_archived: false,
             timestamp: 1000,
@@ -562,8 +592,16 @@ mod tests {
     #[test]
     fn fts_ranks_and_matches_words() {
         let conn = test_conn();
-        reindex_message(&conn, &msg("m1", "c1", "chat", "user", "the updater signing failed")).unwrap();
-        reindex_message(&conn, &msg("m2", "c2", "chat", "user", "weather chatter today")).unwrap();
+        reindex_message(
+            &conn,
+            &msg("m1", "c1", "chat", "user", "the updater signing failed"),
+        )
+        .unwrap();
+        reindex_message(
+            &conn,
+            &msg("m2", "c2", "chat", "user", "weather chatter today"),
+        )
+        .unwrap();
 
         let hits = search_fts(&conn, "signing", &SearchFilters::default(), 10).unwrap();
         assert_eq!(hits.len(), 1);
@@ -588,7 +626,13 @@ mod tests {
         let conn = test_conn();
         reindex_message(
             &conn,
-            &msg("m1", "c1", "chat", "assistant", r#"set createUpdaterArtifacts: true AND ship"#),
+            &msg(
+                "m1",
+                "c1",
+                "chat",
+                "assistant",
+                r#"set createUpdaterArtifacts: true AND ship"#,
+            ),
         )
         .unwrap();
 
@@ -606,11 +650,20 @@ mod tests {
         }
         // A term that is present matches; one that is absent does not.
         assert_eq!(
-            search_fts(&conn, "createUpdaterArtifacts", &SearchFilters::default(), 10).unwrap().len(),
+            search_fts(
+                &conn,
+                "createUpdaterArtifacts",
+                &SearchFilters::default(),
+                10
+            )
+            .unwrap()
+            .len(),
             1
         );
         assert_eq!(
-            search_fts(&conn, "nonexistentterm", &SearchFilters::default(), 10).unwrap().len(),
+            search_fts(&conn, "nonexistentterm", &SearchFilters::default(), 10)
+                .unwrap()
+                .len(),
             0
         );
     }
@@ -656,10 +709,16 @@ mod tests {
         let query = unit_vec(0);
 
         let run = |f: &SearchFilters| {
-            let mut fts: Vec<String> =
-                search_fts(&conn, "alpha", f, 50).unwrap().into_iter().map(|h| h.message_id).collect();
-            let mut sem: Vec<String> =
-                search_semantic(&conn, &query, f, 50).unwrap().into_iter().map(|h| h.message_id).collect();
+            let mut fts: Vec<String> = search_fts(&conn, "alpha", f, 50)
+                .unwrap()
+                .into_iter()
+                .map(|h| h.message_id)
+                .collect();
+            let mut sem: Vec<String> = search_semantic(&conn, &query, f, 50)
+                .unwrap()
+                .into_iter()
+                .map(|h| h.message_id)
+                .collect();
             fts.sort();
             sem.sort();
             (fts, sem)
@@ -671,17 +730,26 @@ mod tests {
         assert_eq!(sem, vec!["m1", "m2"]);
 
         // kind = chat only → m1 (m3 archived).
-        let (fts, sem) = run(&SearchFilters { kinds: vec!["chat".into()], ..Default::default() });
+        let (fts, sem) = run(&SearchFilters {
+            kinds: vec!["chat".into()],
+            ..Default::default()
+        });
         assert_eq!(fts, vec!["m1"]);
         assert_eq!(sem, vec!["m1"]);
 
         // project = /repoB → m2.
-        let (fts, sem) = run(&SearchFilters { project_root: Some("/repoB".into()), ..Default::default() });
+        let (fts, sem) = run(&SearchFilters {
+            project_root: Some("/repoB".into()),
+            ..Default::default()
+        });
         assert_eq!(fts, vec!["m2"]);
         assert_eq!(sem, vec!["m2"]);
 
         // include archived → m1, m2, m3.
-        let (fts, sem) = run(&SearchFilters { include_archived: true, ..Default::default() });
+        let (fts, sem) = run(&SearchFilters {
+            include_archived: true,
+            ..Default::default()
+        });
         assert_eq!(fts, vec!["m1", "m2", "m3"]);
         assert_eq!(sem, vec!["m1", "m2", "m3"]);
     }
@@ -689,22 +757,52 @@ mod tests {
     #[test]
     fn delete_and_reindex_cascade() {
         let conn = test_conn();
-        reindex_message(&conn, &msg("m1", "c1", "chat", "user", "original signing text")).unwrap();
+        reindex_message(
+            &conn,
+            &msg("m1", "c1", "chat", "user", "original signing text"),
+        )
+        .unwrap();
         insert_embedding(&conn, chunk_id_for(&conn, "m1"), &unit_vec(0)).unwrap();
 
         // Edit (upsert): reindex replaces text; the old text is gone.
-        reindex_message(&conn, &msg("m1", "c1", "chat", "user", "revised deployment text")).unwrap();
-        assert_eq!(search_fts(&conn, "signing", &SearchFilters::default(), 10).unwrap().len(), 0);
-        assert_eq!(search_fts(&conn, "deployment", &SearchFilters::default(), 10).unwrap().len(), 1);
+        reindex_message(
+            &conn,
+            &msg("m1", "c1", "chat", "user", "revised deployment text"),
+        )
+        .unwrap();
+        assert_eq!(
+            search_fts(&conn, "signing", &SearchFilters::default(), 10)
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            search_fts(&conn, "deployment", &SearchFilters::default(), 10)
+                .unwrap()
+                .len(),
+            1
+        );
         // Reindex dropped the stale embedding too (chunk is unembedded again).
-        assert!(unembedded_chunk_batch(&conn, 10).unwrap().iter().any(|(_, t)| t.contains("deployment")));
+        assert!(
+            unembedded_chunk_batch(&conn, 10)
+                .unwrap()
+                .iter()
+                .any(|(_, t)| t.contains("deployment"))
+        );
 
         // Delete by message: chunks + fts + embeddings all gone.
         insert_embedding(&conn, chunk_id_for(&conn, "m1"), &unit_vec(0)).unwrap();
         delete_message_chunks(&conn, "m1").unwrap();
-        assert_eq!(search_fts(&conn, "deployment", &SearchFilters::default(), 10).unwrap().len(), 0);
+        assert_eq!(
+            search_fts(&conn, "deployment", &SearchFilters::default(), 10)
+                .unwrap()
+                .len(),
+            0
+        );
         assert!(indexed_message_ids(&conn).unwrap().is_empty());
-        let count: i64 = conn.query_row("SELECT COUNT(*) FROM conv_embeddings", [], |r| r.get(0)).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM conv_embeddings", [], |r| r.get(0))
+            .unwrap();
         assert_eq!(count, 0);
     }
 
@@ -712,7 +810,11 @@ mod tests {
     fn delete_conversation_and_clear_all() {
         let conn = test_conn();
         reindex_message(&conn, &msg("m1", "c1", "chat", "user", "one signing")).unwrap();
-        reindex_message(&conn, &msg("m2", "c1", "assistant", "assistant", "two signing")).unwrap();
+        reindex_message(
+            &conn,
+            &msg("m2", "c1", "assistant", "assistant", "two signing"),
+        )
+        .unwrap();
         reindex_message(&conn, &msg("m3", "c2", "chat", "user", "three signing")).unwrap();
 
         delete_conversation_chunks(&conn, "c1").unwrap();
@@ -733,14 +835,22 @@ mod tests {
         let hits = search_fts(
             &conn,
             "signing",
-            &SearchFilters { include_archived: true, ..Default::default() },
+            &SearchFilters {
+                include_archived: true,
+                ..Default::default()
+            },
             10,
         )
         .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].title.as_deref(), Some("Renamed"));
         // Now archived → excluded by the default filter.
-        assert_eq!(search_fts(&conn, "signing", &SearchFilters::default(), 10).unwrap().len(), 0);
+        assert_eq!(
+            search_fts(&conn, "signing", &SearchFilters::default(), 10)
+                .unwrap()
+                .len(),
+            0
+        );
     }
 
     #[test]
@@ -754,6 +864,9 @@ mod tests {
         let giant = "word ".repeat(CHUNK_CHAR_BUDGET * MAX_CHUNKS_PER_MESSAGE);
         let chunks = chunk_message(&giant);
         assert_eq!(chunks.len(), MAX_CHUNKS_PER_MESSAGE);
-        assert_eq!(chunks.last().unwrap().seq, (MAX_CHUNKS_PER_MESSAGE - 1) as i64);
+        assert_eq!(
+            chunks.last().unwrap().seq,
+            (MAX_CHUNKS_PER_MESSAGE - 1) as i64
+        );
     }
 }

--- a/src-tauri/src/services/conversation_index.rs
+++ b/src-tauri/src/services/conversation_index.rs
@@ -160,6 +160,13 @@ fn embedding_to_blob(embedding: &[f32]) -> Vec<u8> {
     embedding.iter().flat_map(|value| value.to_le_bytes()).collect()
 }
 
+fn fts_document(title: Option<&str>, text: &str) -> String {
+    match title.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(title) => format!("{title}\n{text}"),
+        None => text.to_string(),
+    }
+}
+
 /// Split a message into embeddable chunks on a character budget, breaking on
 /// whitespace where possible. Capped at `MAX_CHUNKS_PER_MESSAGE`; only the head
 /// of a giant message is indexed. Empty/whitespace-only content yields no chunks.
@@ -250,7 +257,7 @@ pub fn reindex_message(conn: &Connection, msg: &IndexableMessage) -> Result<()> 
         let chunk_id = tx.last_insert_rowid();
         tx.execute(
             "INSERT INTO conv_fts (rowid, text) VALUES (?1, ?2)",
-            params![chunk_id, chunk.text],
+            params![chunk_id, fts_document(msg.title.as_deref(), &chunk.text)],
         )?;
     }
     tx.commit()?;
@@ -307,6 +314,19 @@ pub fn update_conversation_meta(
             "UPDATE conv_chunks SET title = ?1 WHERE conversation_id = ?2",
             params![title, conversation_id],
         )?;
+        let rows: Vec<(i64, String)> = {
+            let mut stmt =
+                conn.prepare("SELECT id, text FROM conv_chunks WHERE conversation_id = ?1")?;
+            stmt.query_map(params![conversation_id], |row| Ok((row.get(0)?, row.get(1)?)))?
+                .filter_map(|row| row.ok())
+                .collect()
+        };
+        for (chunk_id, text) in rows {
+            conn.execute(
+                "UPDATE conv_fts SET text = ?1 WHERE rowid = ?2",
+                params![fts_document(Some(title), &text), chunk_id],
+            )?;
+        }
     }
     if let Some(is_archived) = is_archived {
         conn.execute(
@@ -320,6 +340,12 @@ pub fn update_conversation_meta(
 /// Attach an embedding to an existing chunk (upsert by chunk id). The caller must
 /// validate `embedding.len() == EMBEDDING_DIM`.
 pub fn insert_embedding(conn: &Connection, chunk_id: i64, embedding: &[f32]) -> Result<()> {
+    if embedding.len() != EMBEDDING_DIM {
+        return Err(rusqlite::Error::InvalidParameterName(format!(
+            "expected embedding dim {EMBEDDING_DIM}, got {}",
+            embedding.len()
+        )));
+    }
     conn.execute(
         "INSERT OR REPLACE INTO conv_embeddings (chunk_id, embedding) VALUES (?1, ?2)",
         params![chunk_id, embedding_to_blob(embedding)],
@@ -543,6 +569,18 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].message_id, "m1");
         assert_eq!(hits[0].distance, 0.0);
+    }
+
+    #[test]
+    fn fts_matches_conversation_titles() {
+        let conn = test_conn();
+        let mut message = msg("m1", "c1", "chat", "user", "body does not contain the term");
+        message.title = Some("Release signing notes".to_string());
+        reindex_message(&conn, &message).unwrap();
+
+        let hits = search_fts(&conn, "release", &SearchFilters::default(), 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].message_id, "m1");
     }
 
     #[test]

--- a/src-tauri/src/services/conversation_index.rs
+++ b/src-tauri/src/services/conversation_index.rs
@@ -1,0 +1,721 @@
+// ABOUTME: Local index for chat/agent conversation search — FTS5 (exact) + sqlite-vec (semantic).
+// ABOUTME: Chunks message content into a dedicated indexes/conversations.db, mirroring the transcript stack.
+
+use crate::services::vector_store::{EMBEDDING_DIM, init_sqlite_vec};
+use rusqlite::{Connection, Result, params, params_from_iter, types::Value};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+/// Target characters per chunk (mirrors the transcript chunker's CHUNK_CHAR_BUDGET).
+const CHUNK_CHAR_BUDGET: usize = 1500;
+/// Max chunks indexed per message. Real history has a single 11.7M-char message;
+/// without a cap one row would explode index size, embedding cost, and latency.
+/// We index a bounded head and skip the tail.
+const MAX_CHUNKS_PER_MESSAGE: usize = 12;
+
+/// A conversation search hit: the matched chunk's location, denormalized display
+/// attributes, text, and distance. FTS hits carry distance 0.0; semantic hits
+/// carry the vector distance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationHit {
+    pub message_id: String,
+    pub conversation_id: String,
+    pub kind: String,
+    pub role: String,
+    pub title: Option<String>,
+    pub agent_type: Option<String>,
+    pub project_root: Option<String>,
+    pub timestamp: i64,
+    pub seq: i64,
+    pub text: String,
+    pub distance: f32,
+}
+
+/// A message ready to be (re)indexed. Carries the denormalized attributes so both
+/// search paths filter/display against `conv_chunks` alone — no cross-database join
+/// back to the managed `chat.db`.
+#[derive(Debug, Clone)]
+pub struct IndexableMessage {
+    pub message_id: String,
+    pub conversation_id: String,
+    pub kind: String,
+    pub role: String,
+    pub title: Option<String>,
+    pub agent_type: Option<String>,
+    pub project_root: Option<String>,
+    pub is_archived: bool,
+    pub timestamp: i64,
+    pub content: String,
+}
+
+/// Filters pushed into SQL `WHERE` (not post-filtered in JS) so counts/paging stay
+/// correct at scale. Empty `kinds` means "all kinds".
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchFilters {
+    #[serde(default)]
+    pub kinds: Vec<String>,
+    #[serde(default)]
+    pub project_root: Option<String>,
+    #[serde(default)]
+    pub after_ms: Option<i64>,
+    #[serde(default)]
+    pub before_ms: Option<i64>,
+    #[serde(default)]
+    pub include_archived: bool,
+}
+
+/// A chunk of a single message, in order.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChunkInput {
+    pub seq: i64,
+    pub text: String,
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+fn conversation_index_db_path(app: &AppHandle) -> PathBuf {
+    app.path()
+        .app_data_dir()
+        .expect("app data dir")
+        .join("indexes")
+        .join("conversations.db")
+}
+
+/// Create the conversation index tables on a connection that already has the
+/// sqlite-vec extension loaded.
+fn create_tables(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS conv_chunks (
+            id              INTEGER PRIMARY KEY,
+            message_id      TEXT    NOT NULL,
+            conversation_id TEXT    NOT NULL,
+            kind            TEXT    NOT NULL,
+            role            TEXT    NOT NULL,
+            title           TEXT,
+            agent_type      TEXT,
+            project_root    TEXT,
+            is_archived     INTEGER NOT NULL DEFAULT 0,
+            timestamp       INTEGER NOT NULL,
+            seq             INTEGER NOT NULL,
+            text            TEXT    NOT NULL,
+            indexed_at      INTEGER NOT NULL
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_conv_chunks_message ON conv_chunks(message_id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_conv_chunks_conversation ON conv_chunks(conversation_id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_conv_chunks_ts ON conv_chunks(timestamp DESC)",
+        [],
+    )?;
+    // Exact path. A plain (non-external-content) FTS5 table whose rowid mirrors
+    // conv_chunks.id — supports INSERT with an explicit rowid and DELETE by rowid,
+    // avoiding the external-content sync footguns.
+    conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS conv_fts USING fts5(text)", [])?;
+    // Semantic path (dim reuses EMBEDDING_DIM = 1536, same as transcript/code index).
+    conn.execute(
+        &format!(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS conv_embeddings USING vec0(
+                chunk_id INTEGER PRIMARY KEY,
+                embedding float[{EMBEDDING_DIM}]
+            )"
+        ),
+        [],
+    )?;
+    Ok(())
+}
+
+/// Open (creating if needed) the conversation index DB with sqlite-vec loaded.
+/// Uses `configure_connection` (WAL + busy_timeout) — mandatory, since backfill,
+/// search, and index-on-write all touch this file concurrently; without it they
+/// hit "database is locked", surfacing as spurious "No matches".
+pub fn open_index_db(app: &AppHandle) -> Result<Connection> {
+    init_sqlite_vec();
+    let path = conversation_index_db_path(app);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).ok();
+    }
+    let conn = Connection::open(path)?;
+    crate::services::database::configure_connection(&conn)?;
+    create_tables(&conn)?;
+    Ok(conn)
+}
+
+fn embedding_to_blob(embedding: &[f32]) -> Vec<u8> {
+    embedding.iter().flat_map(|value| value.to_le_bytes()).collect()
+}
+
+/// Split a message into embeddable chunks on a character budget, breaking on
+/// whitespace where possible. Capped at `MAX_CHUNKS_PER_MESSAGE`; only the head
+/// of a giant message is indexed. Empty/whitespace-only content yields no chunks.
+pub fn chunk_message(content: &str) -> Vec<ChunkInput> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    // Bound work and memory: only the head is ever indexed for giant messages,
+    // so never materialize more than the cap's worth of characters.
+    let cap_chars = MAX_CHUNKS_PER_MESSAGE * CHUNK_CHAR_BUDGET;
+    let mut chars: Vec<char> = trimmed.chars().take(cap_chars + 1).collect();
+    let truncated = chars.len() > cap_chars;
+    if truncated {
+        chars.truncate(cap_chars);
+        log::warn!("conversation_index: message exceeded {cap_chars} chars; indexing head only");
+    }
+
+    let mut chunks = Vec::new();
+    let mut start = 0usize;
+    let mut seq = 0i64;
+    while start < chars.len() && chunks.len() < MAX_CHUNKS_PER_MESSAGE {
+        let mut end = (start + CHUNK_CHAR_BUDGET).min(chars.len());
+        // Prefer to break at a whitespace boundary near the budget (look back up
+        // to 200 chars) so words/lines aren't split mid-token.
+        if end < chars.len() {
+            let lookback = end.saturating_sub(200);
+            if let Some(ws) = (lookback..end).rev().find(|&i| chars[i].is_whitespace()) {
+                if ws > start {
+                    end = ws + 1;
+                }
+            }
+        }
+        let text: String = chars[start..end].iter().collect::<String>().trim().to_string();
+        if !text.is_empty() {
+            chunks.push(ChunkInput { seq, text });
+            seq += 1;
+        }
+        start = end;
+    }
+    chunks
+}
+
+fn delete_message_chunks_tx(tx: &Connection, message_id: &str) -> Result<()> {
+    let ids: Vec<i64> = {
+        let mut stmt = tx.prepare("SELECT id FROM conv_chunks WHERE message_id = ?1")?;
+        stmt.query_map(params![message_id], |row| row.get(0))?
+            .filter_map(|row| row.ok())
+            .collect()
+    };
+    for id in &ids {
+        tx.execute("DELETE FROM conv_fts WHERE rowid = ?1", params![id])?;
+        tx.execute("DELETE FROM conv_embeddings WHERE chunk_id = ?1", params![id])?;
+    }
+    tx.execute("DELETE FROM conv_chunks WHERE message_id = ?1", params![message_id])?;
+    Ok(())
+}
+
+/// Re-index one message: drop its existing chunks (+ FTS + embeddings) and write
+/// fresh chunk rows. Embeddings are NOT computed here — they attach later, async.
+/// Handles edits/upserts (delete-then-insert keyed by `message_id`).
+pub fn reindex_message(conn: &Connection, msg: &IndexableMessage) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    delete_message_chunks_tx(&tx, &msg.message_id)?;
+    let chunks = chunk_message(&msg.content);
+    let now = now_ms();
+    for chunk in &chunks {
+        tx.execute(
+            "INSERT INTO conv_chunks
+                (message_id, conversation_id, kind, role, title, agent_type,
+                 project_root, is_archived, timestamp, seq, text, indexed_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                msg.message_id,
+                msg.conversation_id,
+                msg.kind,
+                msg.role,
+                msg.title,
+                msg.agent_type,
+                msg.project_root,
+                msg.is_archived,
+                msg.timestamp,
+                chunk.seq,
+                chunk.text,
+                now,
+            ],
+        )?;
+        let chunk_id = tx.last_insert_rowid();
+        tx.execute(
+            "INSERT INTO conv_fts (rowid, text) VALUES (?1, ?2)",
+            params![chunk_id, chunk.text],
+        )?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+/// Drop all chunks (+ FTS + embeddings) for a single message.
+pub fn delete_message_chunks(conn: &Connection, message_id: &str) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    delete_message_chunks_tx(&tx, message_id)?;
+    tx.commit()
+}
+
+/// Drop all chunks (+ FTS + embeddings) for a whole conversation.
+pub fn delete_conversation_chunks(conn: &Connection, conversation_id: &str) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    let ids: Vec<i64> = {
+        let mut stmt = tx.prepare("SELECT id FROM conv_chunks WHERE conversation_id = ?1")?;
+        stmt.query_map(params![conversation_id], |row| row.get(0))?
+            .filter_map(|row| row.ok())
+            .collect()
+    };
+    for id in &ids {
+        tx.execute("DELETE FROM conv_fts WHERE rowid = ?1", params![id])?;
+        tx.execute("DELETE FROM conv_embeddings WHERE chunk_id = ?1", params![id])?;
+    }
+    tx.execute(
+        "DELETE FROM conv_chunks WHERE conversation_id = ?1",
+        params![conversation_id],
+    )?;
+    tx.commit()
+}
+
+/// Clear the entire index (called from "clear all history").
+pub fn clear_all_chunks(conn: &Connection) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute("DELETE FROM conv_embeddings", [])?;
+    tx.execute("DELETE FROM conv_fts", [])?;
+    tx.execute("DELETE FROM conv_chunks", [])?;
+    tx.commit()
+}
+
+/// Update the denormalized display/filter columns for a conversation's chunks,
+/// without re-chunking. Called from archive/rename paths so filters and labels
+/// stay correct. Any `None` argument leaves that column unchanged.
+pub fn update_conversation_meta(
+    conn: &Connection,
+    conversation_id: &str,
+    title: Option<&str>,
+    is_archived: Option<bool>,
+) -> Result<()> {
+    if let Some(title) = title {
+        conn.execute(
+            "UPDATE conv_chunks SET title = ?1 WHERE conversation_id = ?2",
+            params![title, conversation_id],
+        )?;
+    }
+    if let Some(is_archived) = is_archived {
+        conn.execute(
+            "UPDATE conv_chunks SET is_archived = ?1 WHERE conversation_id = ?2",
+            params![is_archived, conversation_id],
+        )?;
+    }
+    Ok(())
+}
+
+/// Attach an embedding to an existing chunk (upsert by chunk id). The caller must
+/// validate `embedding.len() == EMBEDDING_DIM`.
+pub fn insert_embedding(conn: &Connection, chunk_id: i64, embedding: &[f32]) -> Result<()> {
+    conn.execute(
+        "INSERT OR REPLACE INTO conv_embeddings (chunk_id, embedding) VALUES (?1, ?2)",
+        params![chunk_id, embedding_to_blob(embedding)],
+    )?;
+    Ok(())
+}
+
+/// The next batch of chunks with no embedding yet (for the async backfill).
+pub fn unembedded_chunk_batch(conn: &Connection, limit: usize) -> Result<Vec<(i64, String)>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, text FROM conv_chunks
+         WHERE id NOT IN (SELECT chunk_id FROM conv_embeddings)
+         ORDER BY id
+         LIMIT ?1",
+    )?;
+    let rows = stmt
+        .query_map(params![limit as i64], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .filter_map(|row| row.ok())
+        .collect();
+    Ok(rows)
+}
+
+/// Message ids that already have indexed chunks (so the FTS backfill can diff).
+pub fn indexed_message_ids(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare("SELECT DISTINCT message_id FROM conv_chunks")?;
+    let ids = stmt
+        .query_map([], |row| row.get(0))?
+        .filter_map(|row| row.ok())
+        .collect();
+    Ok(ids)
+}
+
+/// Build the shared filter `WHERE` fragment (leading " AND ...") plus its params,
+/// so both search paths filter identically in SQL.
+fn build_filter_clause(filters: &SearchFilters) -> (String, Vec<Value>) {
+    let mut clause = String::new();
+    let mut vals: Vec<Value> = Vec::new();
+    if !filters.kinds.is_empty() {
+        let placeholders = filters.kinds.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        clause.push_str(&format!(" AND c.kind IN ({placeholders})"));
+        for kind in &filters.kinds {
+            vals.push(Value::Text(kind.clone()));
+        }
+    }
+    if let Some(project_root) = &filters.project_root {
+        clause.push_str(" AND c.project_root = ?");
+        vals.push(Value::Text(project_root.clone()));
+    }
+    if let Some(after) = filters.after_ms {
+        clause.push_str(" AND c.timestamp >= ?");
+        vals.push(Value::Integer(after));
+    }
+    if let Some(before) = filters.before_ms {
+        clause.push_str(" AND c.timestamp <= ?");
+        vals.push(Value::Integer(before));
+    }
+    if !filters.include_archived {
+        clause.push_str(" AND c.is_archived = 0");
+    }
+    (clause, vals)
+}
+
+/// Turn raw user input into a phrase-safe FTS5 MATCH string: wrap each
+/// whitespace-separated term in double quotes (escaping embedded quotes) so FTS5
+/// operators (AND/OR/NOT/NEAR, `*`, `"`, `:`, `-`, parens) are matched literally
+/// and never error on hostile input. Empty input yields an empty string.
+fn fts_query(raw: &str) -> String {
+    raw.split_whitespace()
+        .filter(|term| !term.is_empty())
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn row_to_hit(row: &rusqlite::Row) -> rusqlite::Result<ConversationHit> {
+    Ok(ConversationHit {
+        message_id: row.get(0)?,
+        conversation_id: row.get(1)?,
+        kind: row.get(2)?,
+        role: row.get(3)?,
+        title: row.get(4)?,
+        agent_type: row.get(5)?,
+        project_root: row.get(6)?,
+        timestamp: row.get(7)?,
+        seq: row.get(8)?,
+        text: row.get(9)?,
+        distance: row.get(10)?,
+    })
+}
+
+const HIT_COLUMNS: &str = "c.message_id, c.conversation_id, c.kind, c.role, c.title, \
+     c.agent_type, c.project_root, c.timestamp, c.seq, c.text";
+
+/// Exact full-text search over indexed chunks, bm25-ranked. Offline/unauthenticated.
+/// Returns hits with distance 0.0.
+pub fn search_fts(
+    conn: &Connection,
+    query: &str,
+    filters: &SearchFilters,
+    limit: usize,
+) -> Result<Vec<ConversationHit>> {
+    let match_query = fts_query(query);
+    if match_query.is_empty() {
+        return Ok(Vec::new());
+    }
+    let (clause, filter_vals) = build_filter_clause(filters);
+    let sql = format!(
+        "SELECT {HIT_COLUMNS}, 0.0 AS distance
+         FROM conv_fts f JOIN conv_chunks c ON c.id = f.rowid
+         WHERE conv_fts MATCH ?{clause}
+         ORDER BY bm25(conv_fts)
+         LIMIT ?"
+    );
+    let mut binds: Vec<Value> = Vec::with_capacity(filter_vals.len() + 2);
+    binds.push(Value::Text(match_query));
+    binds.extend(filter_vals);
+    binds.push(Value::Integer(limit as i64));
+
+    let mut stmt = conn.prepare(&sql)?;
+    let hits = stmt
+        .query_map(params_from_iter(binds), row_to_hit)?
+        .filter_map(|row| row.ok())
+        .collect();
+    Ok(hits)
+}
+
+/// Semantic KNN search over embedded chunks. The KNN runs in an isolated subquery
+/// (vec0 requires the MATCH + `k` together on the vtable and nothing else), then
+/// the joined metadata is filtered and re-limited. We over-fetch so filtering
+/// still yields up to `limit` rows.
+pub fn search_semantic(
+    conn: &Connection,
+    query_embedding: &[f32],
+    filters: &SearchFilters,
+    limit: usize,
+) -> Result<Vec<ConversationHit>> {
+    let (clause, filter_vals) = build_filter_clause(filters);
+    let over_fetch = ((limit * 5).max(50)).min(500) as i64;
+    let sql = format!(
+        "SELECT {HIT_COLUMNS}, knn.distance
+         FROM (
+            SELECT chunk_id, distance FROM conv_embeddings
+            WHERE embedding MATCH ? AND k = ?
+         ) knn
+         JOIN conv_chunks c ON c.id = knn.chunk_id
+         WHERE 1=1{clause}
+         ORDER BY knn.distance
+         LIMIT ?"
+    );
+    let mut binds: Vec<Value> = Vec::with_capacity(filter_vals.len() + 3);
+    binds.push(Value::Blob(embedding_to_blob(query_embedding)));
+    binds.push(Value::Integer(over_fetch));
+    binds.extend(filter_vals);
+    binds.push(Value::Integer(limit as i64));
+
+    let mut stmt = conn.prepare(&sql)?;
+    let hits = stmt
+        .query_map(params_from_iter(binds), row_to_hit)?
+        .filter_map(|row| row.ok())
+        .collect();
+    Ok(hits)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_conn() -> Connection {
+        init_sqlite_vec();
+        let conn = Connection::open_in_memory().unwrap();
+        create_tables(&conn).unwrap();
+        conn
+    }
+
+    fn msg(id: &str, conv: &str, kind: &str, role: &str, content: &str) -> IndexableMessage {
+        IndexableMessage {
+            message_id: id.to_string(),
+            conversation_id: conv.to_string(),
+            kind: kind.to_string(),
+            role: role.to_string(),
+            title: Some(format!("title-{conv}")),
+            agent_type: if kind == "agent" { Some("claude-code".into()) } else { None },
+            project_root: Some("/repo".into()),
+            is_archived: false,
+            timestamp: 1000,
+            content: content.to_string(),
+        }
+    }
+
+    fn unit_vec(index: usize) -> Vec<f32> {
+        let mut embedding = vec![0.0f32; EMBEDDING_DIM];
+        embedding[index] = 1.0;
+        embedding
+    }
+
+    fn chunk_id_for(conn: &Connection, message_id: &str) -> i64 {
+        conn.query_row(
+            "SELECT id FROM conv_chunks WHERE message_id = ?1 ORDER BY seq LIMIT 1",
+            params![message_id],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    // T0.2: the whole exact-path design assumes FTS5 is compiled into the bundled
+    // sqlite. Prove it rather than trust the docs.
+    #[test]
+    fn fts5_is_available() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE VIRTUAL TABLE t USING fts5(x)", [])
+            .expect("fts5 must be available in bundled sqlite");
+    }
+
+    #[test]
+    fn fts_ranks_and_matches_words() {
+        let conn = test_conn();
+        reindex_message(&conn, &msg("m1", "c1", "chat", "user", "the updater signing failed")).unwrap();
+        reindex_message(&conn, &msg("m2", "c2", "chat", "user", "weather chatter today")).unwrap();
+
+        let hits = search_fts(&conn, "signing", &SearchFilters::default(), 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].message_id, "m1");
+        assert_eq!(hits[0].distance, 0.0);
+    }
+
+    #[test]
+    fn fts_query_is_injection_safe() {
+        let conn = test_conn();
+        reindex_message(
+            &conn,
+            &msg("m1", "c1", "chat", "assistant", r#"set createUpdaterArtifacts: true AND ship"#),
+        )
+        .unwrap();
+
+        // Queries containing FTS operators / metacharacters must not error.
+        for query in [
+            r#"createUpdaterArtifacts"#,
+            r#"AND"#,
+            r#"true*"#,
+            r#"foo"bar"#,
+            r#"( OR )"#,
+            r#"NEAR("#,
+        ] {
+            let hits = search_fts(&conn, query, &SearchFilters::default(), 10);
+            assert!(hits.is_ok(), "query {query:?} must not error");
+        }
+        // A term that is present matches; one that is absent does not.
+        assert_eq!(
+            search_fts(&conn, "createUpdaterArtifacts", &SearchFilters::default(), 10).unwrap().len(),
+            1
+        );
+        assert_eq!(
+            search_fts(&conn, "nonexistentterm", &SearchFilters::default(), 10).unwrap().len(),
+            0
+        );
+    }
+
+    #[test]
+    fn semantic_ranks_nearest_first() {
+        let conn = test_conn();
+        reindex_message(&conn, &msg("m1", "c1", "chat", "user", "budget decision")).unwrap();
+        reindex_message(&conn, &msg("m2", "c2", "chat", "user", "weather chatter")).unwrap();
+        insert_embedding(&conn, chunk_id_for(&conn, "m1"), &unit_vec(0)).unwrap();
+        insert_embedding(&conn, chunk_id_for(&conn, "m2"), &unit_vec(1)).unwrap();
+
+        let mut query = vec![0.0f32; EMBEDDING_DIM];
+        query[0] = 0.9;
+        query[1] = 0.1;
+        let hits = search_semantic(&conn, &query, &SearchFilters::default(), 10).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].message_id, "m1");
+        assert!(hits[0].distance <= hits[1].distance);
+    }
+
+    #[test]
+    fn filters_apply() {
+        let conn = test_conn();
+        // chat / agent, two projects, one archived — exercised on BOTH paths.
+        let mut chat = msg("m1", "c1", "chat", "user", "alpha signing token");
+        chat.project_root = Some("/repoA".into());
+        reindex_message(&conn, &chat).unwrap();
+
+        let mut agent = msg("m2", "c2", "agent", "assistant", "alpha signing token");
+        agent.project_root = Some("/repoB".into());
+        reindex_message(&conn, &agent).unwrap();
+
+        let mut archived = msg("m3", "c3", "chat", "user", "alpha signing token");
+        archived.is_archived = true;
+        archived.project_root = Some("/repoA".into());
+        reindex_message(&conn, &archived).unwrap();
+
+        // Attach embeddings so the semantic path returns the same population.
+        insert_embedding(&conn, chunk_id_for(&conn, "m1"), &unit_vec(0)).unwrap();
+        insert_embedding(&conn, chunk_id_for(&conn, "m2"), &unit_vec(0)).unwrap();
+        insert_embedding(&conn, chunk_id_for(&conn, "m3"), &unit_vec(0)).unwrap();
+        let query = unit_vec(0);
+
+        let run = |f: &SearchFilters| {
+            let mut fts: Vec<String> =
+                search_fts(&conn, "alpha", f, 50).unwrap().into_iter().map(|h| h.message_id).collect();
+            let mut sem: Vec<String> =
+                search_semantic(&conn, &query, f, 50).unwrap().into_iter().map(|h| h.message_id).collect();
+            fts.sort();
+            sem.sort();
+            (fts, sem)
+        };
+
+        // Default: archived excluded → m1, m2.
+        let (fts, sem) = run(&SearchFilters::default());
+        assert_eq!(fts, vec!["m1", "m2"]);
+        assert_eq!(sem, vec!["m1", "m2"]);
+
+        // kind = chat only → m1 (m3 archived).
+        let (fts, sem) = run(&SearchFilters { kinds: vec!["chat".into()], ..Default::default() });
+        assert_eq!(fts, vec!["m1"]);
+        assert_eq!(sem, vec!["m1"]);
+
+        // project = /repoB → m2.
+        let (fts, sem) = run(&SearchFilters { project_root: Some("/repoB".into()), ..Default::default() });
+        assert_eq!(fts, vec!["m2"]);
+        assert_eq!(sem, vec!["m2"]);
+
+        // include archived → m1, m2, m3.
+        let (fts, sem) = run(&SearchFilters { include_archived: true, ..Default::default() });
+        assert_eq!(fts, vec!["m1", "m2", "m3"]);
+        assert_eq!(sem, vec!["m1", "m2", "m3"]);
+    }
+
+    #[test]
+    fn delete_and_reindex_cascade() {
+        let conn = test_conn();
+        reindex_message(&conn, &msg("m1", "c1", "chat", "user", "original signing text")).unwrap();
+        insert_embedding(&conn, chunk_id_for(&conn, "m1"), &unit_vec(0)).unwrap();
+
+        // Edit (upsert): reindex replaces text; the old text is gone.
+        reindex_message(&conn, &msg("m1", "c1", "chat", "user", "revised deployment text")).unwrap();
+        assert_eq!(search_fts(&conn, "signing", &SearchFilters::default(), 10).unwrap().len(), 0);
+        assert_eq!(search_fts(&conn, "deployment", &SearchFilters::default(), 10).unwrap().len(), 1);
+        // Reindex dropped the stale embedding too (chunk is unembedded again).
+        assert!(unembedded_chunk_batch(&conn, 10).unwrap().iter().any(|(_, t)| t.contains("deployment")));
+
+        // Delete by message: chunks + fts + embeddings all gone.
+        insert_embedding(&conn, chunk_id_for(&conn, "m1"), &unit_vec(0)).unwrap();
+        delete_message_chunks(&conn, "m1").unwrap();
+        assert_eq!(search_fts(&conn, "deployment", &SearchFilters::default(), 10).unwrap().len(), 0);
+        assert!(indexed_message_ids(&conn).unwrap().is_empty());
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM conv_embeddings", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn delete_conversation_and_clear_all() {
+        let conn = test_conn();
+        reindex_message(&conn, &msg("m1", "c1", "chat", "user", "one signing")).unwrap();
+        reindex_message(&conn, &msg("m2", "c1", "assistant", "assistant", "two signing")).unwrap();
+        reindex_message(&conn, &msg("m3", "c2", "chat", "user", "three signing")).unwrap();
+
+        delete_conversation_chunks(&conn, "c1").unwrap();
+        let remaining: Vec<String> = indexed_message_ids(&conn).unwrap();
+        assert_eq!(remaining, vec!["m3"]);
+
+        clear_all_chunks(&conn).unwrap();
+        assert!(indexed_message_ids(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn update_meta_reflects_in_filters_and_hits() {
+        let conn = test_conn();
+        reindex_message(&conn, &msg("m1", "c1", "chat", "user", "signing thread")).unwrap();
+
+        update_conversation_meta(&conn, "c1", Some("Renamed"), Some(true)).unwrap();
+        // Title reflected on hits (archived, so include_archived to see it).
+        let hits = search_fts(
+            &conn,
+            "signing",
+            &SearchFilters { include_archived: true, ..Default::default() },
+            10,
+        )
+        .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title.as_deref(), Some("Renamed"));
+        // Now archived → excluded by the default filter.
+        assert_eq!(search_fts(&conn, "signing", &SearchFilters::default(), 10).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn chunking_caps_and_skips_empty() {
+        assert!(chunk_message("   \n  ").is_empty());
+        let one = chunk_message("hello world");
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].seq, 0);
+
+        // A message far larger than the cap yields exactly MAX_CHUNKS_PER_MESSAGE.
+        let giant = "word ".repeat(CHUNK_CHAR_BUDGET * MAX_CHUNKS_PER_MESSAGE);
+        let chunks = chunk_message(&giant);
+        assert_eq!(chunks.len(), MAX_CHUNKS_PER_MESSAGE);
+        assert_eq!(chunks.last().unwrap().seq, (MAX_CHUNKS_PER_MESSAGE - 1) as i64);
+    }
+}

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -50,6 +50,7 @@ import {
   isDocreaderMime,
   pickAndReadAttachments,
 } from "@/lib/images/attachments";
+import { scrollMessageIntoView } from "@/lib/message-scroll";
 import type { Attachment } from "@/lib/providers/types";
 import {
   getModelDisplayName,
@@ -658,6 +659,20 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     agentStore.pendingPermissions;
     agentStore.pendingDiffProposals;
     requestAnimationFrame(scrollToBottom);
+  });
+
+  createEffect(() => {
+    if (!isPaneActive()) return;
+    const target = threadStore.pendingMessageScroll;
+    const thread = activeAgentThread();
+    if (!target || target.conversationId !== thread?.id) return;
+
+    void threadMessages().length;
+    requestAnimationFrame(() => {
+      if (scrollMessageIntoView(messagesRef, target.messageId)) {
+        threadStore.clearMessageScroll();
+      }
+    });
   });
 
   // Clear "awaiting login" banner once a session starts
@@ -1356,6 +1371,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           <article
             class="chat-message-row group/msg relative px-5 py-4 bg-surface-1 border-b border-surface-2 [contain:layout]"
             classList={{ "border-l-2 border-l-destructive": showTurnError() }}
+            data-message-id={message.id}
           >
             <Show when={message.docNames?.length}>
               <div class="flex flex-wrap gap-1.5 mb-2">
@@ -1444,7 +1460,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           }
         };
         return (
-          <article class="chat-message-row group/msg relative px-5 py-4 border-b border-surface-2 [contain:layout]">
+          <article
+            class="chat-message-row group/msg relative px-5 py-4 border-b border-surface-2 [contain:layout]"
+            data-message-id={message.id}
+          >
             <Show when={pairedAttribution()}>
               <div
                 class="mb-1.5 text-[11px] font-semibold uppercase tracking-[0.04em] text-muted-foreground"
@@ -1540,21 +1559,24 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
       case "thought":
         return (
-          <article class="chat-message-row px-5 py-3 border-b border-surface-2">
+          <article
+            class="chat-message-row px-5 py-3 border-b border-surface-2"
+            data-message-id={message.id}
+          >
             <ThinkingBlock thinking={message.content} />
           </article>
         );
 
       case "tool":
         return message.toolCall ? (
-          <div class="chat-tool-row px-5 py-2">
+          <div class="chat-tool-row px-5 py-2" data-message-id={message.id}>
             <ToolCallCard toolCall={message.toolCall} />
           </div>
         ) : null;
 
       case "diff":
         return message.diff ? (
-          <div class="chat-tool-row px-5 py-2">
+          <div class="chat-tool-row px-5 py-2" data-message-id={message.id}>
             <DiffCard diff={message.diff} onViewInEditor={props.onViewDiff} />
           </div>
         ) : null;
@@ -1566,6 +1588,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           <div
             class="chat-message-row px-5 py-2 border-b border-surface-2 flex items-center gap-2"
             data-testid="paired-handoff"
+            data-message-id={message.id}
           >
             <span class="text-[12px]" aria-hidden="true">
               {"\u{1F91D}"}
@@ -1578,7 +1601,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
       case "error":
         return (
-          <article class="chat-message-row px-5 py-3 border-b border-surface-2">
+          <article
+            class="chat-message-row px-5 py-3 border-b border-surface-2"
+            data-message-id={message.id}
+          >
             <div
               class={`px-3 py-2 border rounded-md text-sm ${
                 isAuthError(message.content)
@@ -1818,11 +1844,22 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 index() === groupConsecutiveToolCalls().length - 1;
               if (item.type === "tool_group") {
                 return (
-                  <ToolCallGroup
-                    groupId={item.id}
-                    toolCalls={item.toolCalls}
-                    isComplete={true}
-                  />
+                  <>
+                    <For each={item.messages}>
+                      {(groupMessage) => (
+                        <span
+                          aria-hidden="true"
+                          class="block h-0 overflow-hidden"
+                          data-message-id={groupMessage.id}
+                        />
+                      )}
+                    </For>
+                    <ToolCallGroup
+                      groupId={item.id}
+                      toolCalls={item.toolCalls}
+                      isComplete={true}
+                    />
+                  </>
                 );
               }
               return renderMessage(item.message, isLast());

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -48,6 +48,7 @@ import {
   toToolCallEvent,
 } from "@/lib/group-tool-calls";
 import { pickAndReadAttachments } from "@/lib/images/attachments";
+import { scrollMessageIntoView } from "@/lib/message-scroll";
 import { isPaymentError } from "@/lib/payment-errors";
 import {
   computeProviderBoundaries,
@@ -103,6 +104,7 @@ import { fileTreeState } from "@/stores/fileTree";
 import { providerStore } from "@/stores/provider.store";
 import { settingsStore } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
+import { threadStore } from "@/stores/thread.store";
 import { workspaceStore } from "@/stores/workspace.store";
 import {
   isRetryableWorker,
@@ -712,6 +714,20 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
     void streamingThinking();
     void Object.keys(htmlCache).length;
     requestAnimationFrame(scrollToBottom);
+  });
+
+  createEffect(() => {
+    if (!isPaneActive()) return;
+    const target = threadStore.pendingMessageScroll;
+    const id = conversationId();
+    if (!target || target.conversationId !== id) return;
+
+    void conversationMessages().length;
+    requestAnimationFrame(() => {
+      if (scrollMessageIntoView(messagesRef, target.messageId)) {
+        threadStore.clearMessageScroll();
+      }
+    });
   });
 
   onCleanup(() => {
@@ -1516,11 +1532,22 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                 // Render grouped tool calls
                 if (item.type === "tool_group") {
                   return (
-                    <ToolCallGroup
-                      groupId={item.id}
-                      toolCalls={item.toolCalls}
-                      isComplete={true}
-                    />
+                    <>
+                      <For each={item.messages}>
+                        {(groupMessage) => (
+                          <span
+                            aria-hidden="true"
+                            class="block h-0 overflow-hidden"
+                            data-message-id={groupMessage.id}
+                          />
+                        )}
+                      </For>
+                      <ToolCallGroup
+                        groupId={item.id}
+                        toolCalls={item.toolCalls}
+                        isComplete={true}
+                      />
+                    </>
                   );
                 }
 
@@ -1533,7 +1560,10 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                 // Render individual tool call card (for 1-2 tool calls)
                 if (message.type === "tool_call" && message.toolCall) {
                   return (
-                    <div class="chat-tool-row px-5 py-2">
+                    <div
+                      class="chat-tool-row px-5 py-2"
+                      data-message-id={message.id}
+                    >
                       <ToolCallCard
                         toolCall={toToolCallEvent(message.toolCall)}
                       />
@@ -1589,6 +1619,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                     </Show>
                     <article
                       class={`chat-message-row group/msg px-5 py-4 border-b border-surface-2 last:border-b-0 [contain:layout] ${message.role === "user" ? "bg-surface-1" : "bg-transparent"}`}
+                      data-message-id={message.id}
                     >
                       <Show when={message.images && message.images.length > 0}>
                         <MessageImages images={message.images ?? []} />

--- a/src/components/chat/RerouteAnnouncement.tsx
+++ b/src/components/chat/RerouteAnnouncement.tsx
@@ -12,7 +12,10 @@ export const RerouteAnnouncement: Component<RerouteAnnouncementProps> = (
   props,
 ) => {
   return (
-    <div class="flex items-center gap-2 px-3 py-1.5 border-l-2 border-warning text-warning text-xs leading-normal animate-[fadeInUp_300ms_ease-in]">
+    <div
+      class="flex items-center gap-2 px-3 py-1.5 border-l-2 border-warning text-warning text-xs leading-normal animate-[fadeInUp_300ms_ease-in]"
+      data-message-id={props.message.id}
+    >
       <span class="font-semibold whitespace-nowrap">Rerouted</span>
       <span class="text-muted-foreground">{props.message.content}</span>
     </div>

--- a/src/components/chat/TransitionAnnouncement.tsx
+++ b/src/components/chat/TransitionAnnouncement.tsx
@@ -12,7 +12,10 @@ export const TransitionAnnouncement: Component<TransitionAnnouncementProps> = (
   props,
 ) => {
   return (
-    <div class="flex items-center gap-2 px-3 py-1.5 border-l-2 border-primary text-muted-foreground text-xs leading-normal animate-[fadeInUp_300ms_ease-in]">
+    <div
+      class="flex items-center gap-2 px-3 py-1.5 border-l-2 border-primary text-muted-foreground text-xs leading-normal animate-[fadeInUp_300ms_ease-in]"
+      data-message-id={props.message.id}
+    >
       {props.message.content}
     </div>
   );

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -30,6 +30,8 @@ import { ThreadSidebar } from "@/components/layout/ThreadSidebar";
 import { AudioPrimingDialog } from "@/components/meeting/AudioPrimingDialog";
 import { MeetingPanel } from "@/components/meeting/MeetingPanel";
 import { RecordingIndicator } from "@/components/meeting/RecordingIndicator";
+import { ConversationSearchOverlay } from "@/components/search/ConversationSearchOverlay";
+import { ConversationSearchResults } from "@/components/search/ConversationSearchResults";
 import { SessionPanel } from "@/components/session/SessionPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import {
@@ -57,12 +59,18 @@ import { isMeetingProcessingStatus } from "@/lib/meeting-format";
 import { isNativeTextEditingKey, shortcuts } from "@/lib/shortcuts";
 import type { InstalledSkill } from "@/lib/skills";
 import { listenForInterviewLaunch } from "@/lib/tauri-bridge";
+import {
+  backfillConversationFts,
+  backfillConversationIndex,
+} from "@/services/conversation-search";
 import { telemetry } from "@/services/telemetry";
 import {
   appearanceState,
   applyAppearanceToDocument,
   loadAppearance,
 } from "@/stores/appearance.store";
+import { authStore } from "@/stores/auth.store";
+import { conversationSearchStore } from "@/stores/conversation-search.store";
 import {
   initEditorSessionPersistence,
   pickEditorSessionForContext,
@@ -216,8 +224,22 @@ export const AppShell: Component<AppShellProps> = (props) => {
   const [interviewEmployeeSlug, setInterviewEmployeeSlug] = createSignal<
     string | null
   >(null);
+  const [conversationFtsReady, setConversationFtsReady] = createSignal(false);
+  let conversationEmbeddingBackfillStarted = false;
+
+  const startConversationEmbeddingBackfill = () => {
+    if (conversationEmbeddingBackfillStarted) return;
+    conversationEmbeddingBackfillStarted = true;
+    void backfillConversationIndex();
+  };
+
   createEffect(() => {
     persistSlidePanel(slidePanel());
+  });
+
+  createEffect(() => {
+    if (!conversationFtsReady() || !authStore.isAuthenticated) return;
+    startConversationEmbeddingBackfill();
   });
 
   const reportInterviewInterest = (
@@ -799,6 +821,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
     // every future capture (#2160).
     void meetingStore.reconcileStaleCaptures();
     meetingStore.startAutoDetect();
+    void backfillConversationFts().finally(() => setConversationFtsReady(true));
 
     window.addEventListener("seren:open-panel", handleOpenPanel);
     window.addEventListener(
@@ -838,6 +861,10 @@ export const AppShell: Component<AppShellProps> = (props) => {
       setSlidePanel("meetings");
       meetingStore.requestSearchFocus();
     });
+    shortcuts.register("global.searchHistory", () => {
+      setSlidePanel(null);
+      conversationSearchStore.openOverlay();
+    });
   });
 
   onCleanup(() => {
@@ -867,6 +894,7 @@ export const AppShell: Component<AppShellProps> = (props) => {
     shortcuts.unregister("global.newChat");
     shortcuts.unregister("global.newTerminal");
     shortcuts.unregister("global.searchMeetings");
+    shortcuts.unregister("global.searchHistory");
   });
 
   const recordPromptVisible = () =>
@@ -915,111 +943,118 @@ export const AppShell: Component<AppShellProps> = (props) => {
 
         <main class="flex-1 overflow-auto flex flex-col min-w-0">
           <Show
-            when={interviewLandingOpen()}
+            when={conversationSearchStore.state.mode === "full"}
             fallback={
               <Show
-                when={inboxOpen()}
+                when={interviewLandingOpen()}
                 fallback={
                   <Show
-                    when={catalogOpen()}
+                    when={inboxOpen()}
                     fallback={
                       <Show
-                        when={activeEmployeeId()}
+                        when={catalogOpen()}
                         fallback={
                           <Show
-                            when={activeBountyId()}
+                            when={activeEmployeeId()}
                             fallback={
-                              <ThreadContent
-                                onSignInClick={handleSignInClick}
-                              />
+                              <Show
+                                when={activeBountyId()}
+                                fallback={
+                                  <ThreadContent
+                                    onSignInClick={handleSignInClick}
+                                  />
+                                }
+                              >
+                                {(id) => (
+                                  <BountyDetail
+                                    bountyId={id()}
+                                    inheritFrom={activeBountyInheritFrom()}
+                                  />
+                                )}
+                              </Show>
                             }
                           >
                             {(id) => (
-                              <BountyDetail
-                                bountyId={id()}
-                                inheritFrom={activeBountyInheritFrom()}
-                              />
+                              <Show
+                                when={
+                                  employeeStore.byId(id()) === undefined &&
+                                  employeeStore.archivedById(id()) !== undefined
+                                }
+                                fallback={
+                                  <EmployeeDetail
+                                    employeeId={id()}
+                                    onClose={closeEmployeeDetailPane}
+                                  />
+                                }
+                              >
+                                <ArchivedEmployeeDetail
+                                  employeeId={id()}
+                                  onClose={closeEmployeeDetailPane}
+                                />
+                              </Show>
                             )}
                           </Show>
                         }
                       >
-                        {(id) => (
-                          <Show
-                            when={
-                              employeeStore.byId(id()) === undefined &&
-                              employeeStore.archivedById(id()) !== undefined
-                            }
-                            fallback={
-                              <EmployeeDetail
-                                employeeId={id()}
-                                onClose={closeEmployeeDetailPane}
-                              />
-                            }
-                          >
-                            <ArchivedEmployeeDetail
-                              employeeId={id()}
-                              onClose={closeEmployeeDetailPane}
-                            />
-                          </Show>
-                        )}
+                        <ErrorBoundary
+                          fallback={(error) => {
+                            telemetry.reportError(
+                              error instanceof Error
+                                ? error
+                                : new Error(String(error)),
+                              { surface: "agent_catalog" },
+                            );
+                            return (
+                              <div class="flex h-full min-h-[320px] flex-col items-center justify-center gap-3 p-6 text-center">
+                                <div class="text-sm font-semibold text-foreground">
+                                  Agent catalog is recovering.
+                                </div>
+                                <div class="max-w-md text-[13px] text-muted-foreground">
+                                  The catalog view hit an unexpected entry, but
+                                  the rest of Seren is still available.
+                                </div>
+                                <button
+                                  type="button"
+                                  class="rounded border border-border bg-card px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-surface-2"
+                                  onClick={handleCloseCatalog}
+                                >
+                                  Back to workspace
+                                </button>
+                              </div>
+                            );
+                          }}
+                        >
+                          <CatalogList />
+                        </ErrorBoundary>
                       </Show>
                     }
                   >
-                    <ErrorBoundary
-                      fallback={(error) => {
-                        telemetry.reportError(
-                          error instanceof Error
-                            ? error
-                            : new Error(String(error)),
-                          { surface: "agent_catalog" },
-                        );
-                        return (
-                          <div class="flex h-full min-h-[320px] flex-col items-center justify-center gap-3 p-6 text-center">
-                            <div class="text-sm font-semibold text-foreground">
-                              Agent catalog is recovering.
-                            </div>
-                            <div class="max-w-md text-[13px] text-muted-foreground">
-                              The catalog view hit an unexpected entry, but the
-                              rest of Seren is still available.
-                            </div>
-                            <button
-                              type="button"
-                              class="rounded border border-border bg-card px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-surface-2"
-                              onClick={handleCloseCatalog}
-                            >
-                              Back to workspace
-                            </button>
-                          </div>
-                        );
-                      }}
-                    >
-                      <CatalogList />
-                    </ErrorBoundary>
+                    <InboxList />
                   </Show>
                 }
               >
-                <InboxList />
+                <InterviewLanding
+                  initialEmployeeSlug={interviewEmployeeSlug()}
+                  onClose={closeInterviewLanding}
+                  onSelectEmployee={(employeeSlug) => {
+                    reportInterviewInterest(
+                      employeeSlug,
+                      "desktop-role-selection",
+                      "role-selected",
+                    );
+                  }}
+                  onStartInterview={(employeeSlug) => {
+                    reportInterviewInterest(
+                      employeeSlug,
+                      "desktop-interview-start",
+                      "interview-started",
+                    );
+                  }}
+                />
               </Show>
             }
           >
-            <InterviewLanding
-              initialEmployeeSlug={interviewEmployeeSlug()}
-              onClose={closeInterviewLanding}
-              onSelectEmployee={(employeeSlug) => {
-                reportInterviewInterest(
-                  employeeSlug,
-                  "desktop-role-selection",
-                  "role-selected",
-                );
-              }}
-              onStartInterview={(employeeSlug) => {
-                reportInterviewInterest(
-                  employeeSlug,
-                  "desktop-interview-start",
-                  "interview-started",
-                );
-              }}
-            />
+            <ConversationSearchResults />
           </Show>
         </main>
 
@@ -1110,6 +1145,8 @@ export const AppShell: Component<AppShellProps> = (props) => {
       {/* Always-visible recording indicator while a capture is live (auto- or
           manually-started): elapsed time + Stop / Pause / Resume / Delete. */}
       <RecordingIndicator />
+
+      <ConversationSearchOverlay />
 
       {/* Layout-level blocking sign-in modal — fires on mid-session expiry,
           refresh-token failure, and the /login slash command. Distinct from

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -21,6 +21,7 @@ import {
   OPEN_EMPLOYEE_DETAIL_EVENT,
 } from "@/components/sidebar/EmployeesSection";
 import { openFolder } from "@/lib/files/service";
+import { getShortcutLabel } from "@/lib/shortcuts";
 import {
   encodeThreadDragPayload,
   encodeThreadDragText,
@@ -38,6 +39,7 @@ import {
 import type { AgentType } from "@/services/providers";
 import { agentStore } from "@/stores/agent.store";
 import { authStore, refreshPrivateChatPolicy } from "@/stores/auth.store";
+import { conversationSearchStore } from "@/stores/conversation-search.store";
 import { editorSessionStore } from "@/stores/editor.sessions";
 import { fileTreeState } from "@/stores/fileTree";
 import type {
@@ -116,6 +118,25 @@ const EditorIcon: Component<{ size?: number; strokeWidth?: number }> = (
   >
     <path d="M9.5 2.5H4a1.5 1.5 0 0 0-1.5 1.5v8A1.5 1.5 0 0 0 4 13.5h8A1.5 1.5 0 0 0 13.5 12V6" />
     <path d="M11 2.5l2.5 2.5-5.5 5.5H5.5V8L11 2.5z" />
+  </svg>
+);
+
+const SearchIcon: Component<{ size?: number; strokeWidth?: number }> = (
+  iconProps,
+) => (
+  <svg
+    width={iconProps.size ?? 14}
+    height={iconProps.size ?? 14}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    stroke-width={iconProps.strokeWidth ?? 1.4}
+    stroke-linecap="round"
+    role="img"
+    aria-label="Search"
+  >
+    <circle cx="7" cy="7" r="4.25" />
+    <path d="m10.25 10.25 3 3" />
   </svg>
 );
 
@@ -231,6 +252,11 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
     } finally {
       setSpawning(false);
     }
+  };
+
+  const handleSearchHistory = () => {
+    setShowLauncher(false);
+    conversationSearchStore.openOverlay();
   };
 
   const toggleLauncher = () => {
@@ -822,6 +848,21 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
               </button>
             </div>
           </Show>
+        </div>
+
+        <div class="px-3 pb-2 shrink-0">
+          <button
+            type="button"
+            data-testid="search-history-button"
+            class="flex h-8 w-full items-center gap-2 rounded-md border border-transparent bg-transparent px-2.5 text-left text-[12px] text-muted-foreground transition-colors hover:border-border hover:bg-surface-2 hover:text-foreground"
+            onClick={handleSearchHistory}
+          >
+            <SearchIcon size={13} />
+            <span class="min-w-0 flex-1 truncate">Search history</span>
+            <kbd class="shrink-0 rounded border border-border bg-surface-3 px-1.5 py-px font-mono text-[10px] text-muted-foreground">
+              {getShortcutLabel("global.searchHistory")}
+            </kbd>
+          </button>
         </div>
 
         {/* Thread list grouped by project */}

--- a/src/components/search/ConversationSearchOverlay.tsx
+++ b/src/components/search/ConversationSearchOverlay.tsx
@@ -1,0 +1,443 @@
+// ABOUTME: Spotlight overlay for searching chat and agent conversation history.
+// ABOUTME: Renders exact and semantic hits with keyboard navigation and safe highlights.
+
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  onCleanup,
+  Show,
+} from "solid-js";
+import { type HighlightSegment, highlightTerms } from "@/lib/highlight";
+import type { ConversationHit } from "@/services/conversation-search";
+import {
+  type ConversationKindFilter,
+  conversationSearchStore,
+} from "@/stores/conversation-search.store";
+import { threadStore } from "@/stores/thread.store";
+
+function titleFor(hit: ConversationHit): string {
+  return hit.title?.trim() || "Untitled conversation";
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const delta = Date.now() - timestamp;
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (delta < hour) return `${Math.max(1, Math.round(delta / minute))}m ago`;
+  if (delta < day) return `${Math.round(delta / hour)}h ago`;
+  if (delta < 14 * day) return `${Math.round(delta / day)}d ago`;
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function roleLabel(hit: ConversationHit): string {
+  if (hit.role === "user") return "You";
+  return hit.agentType || "Assistant";
+}
+
+function projectLabel(projectRoot: string | null): string {
+  if (!projectRoot) return "No project";
+  return projectRoot.split("/").filter(Boolean).at(-1) || projectRoot;
+}
+
+function KindIcon(props: { kind: "chat" | "agent" }) {
+  return (
+    <svg
+      class={`h-4 w-4 shrink-0 ${props.kind === "agent" ? "text-violet-300" : "text-muted-foreground"}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.7"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <Show
+        when={props.kind === "agent"}
+        fallback={
+          <path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z" />
+        }
+      >
+        <path d="m12 2 8 4.7v10.6L12 22l-8-4.7V6.7z" />
+      </Show>
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      class="h-5 w-5 shrink-0 text-muted-foreground"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m20 20-3.2-3.2" />
+    </svg>
+  );
+}
+
+function HighlightedText(props: { text: string; query: string }) {
+  const segments = createMemo(() => highlightTerms(props.text, props.query));
+  return (
+    <For each={segments()}>
+      {(segment: HighlightSegment) =>
+        typeof segment === "string" ? (
+          segment
+        ) : (
+          <mark class="rounded bg-primary/15 px-0.5 font-semibold text-primary">
+            {segment.mark}
+          </mark>
+        )
+      }
+    </For>
+  );
+}
+
+function ResultRow(props: {
+  hit: ConversationHit;
+  selected: boolean;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      class={`relative w-full rounded-[7px] border px-3 py-2 text-left transition-colors ${props.selected ? "border-border bg-surface-2 before:absolute before:left-0 before:top-2 before:bottom-2 before:w-0.5 before:rounded before:bg-primary" : "border-transparent hover:bg-surface-0"}`}
+      onClick={props.onOpen}
+    >
+      <div class="flex min-w-0 items-center gap-2">
+        <KindIcon kind={props.hit.kind} />
+        <div class="min-w-0 truncate text-[13px] font-semibold text-foreground">
+          {titleFor(props.hit)}
+        </div>
+        <div class="ml-auto shrink-0 text-[11px] text-muted-foreground">
+          {formatRelativeTime(props.hit.timestamp)}
+        </div>
+      </div>
+      <div class="ml-6 mt-0.5 flex min-w-0 items-center gap-1.5 truncate text-[11px] text-muted-foreground">
+        <span>{props.hit.kind === "agent" ? "Agent" : "Chat"}</span>
+        <Show when={props.hit.agentType}>
+          {(agent) => (
+            <>
+              <span>·</span>
+              <span>{agent()}</span>
+            </>
+          )}
+        </Show>
+        <span>·</span>
+        <span>{projectLabel(props.hit.projectRoot)}</span>
+        <Show when={props.hit.matchType === "semantic"}>
+          <span>·</span>
+          <span class="text-primary">semantic match</span>
+        </Show>
+      </div>
+      <div class="ml-6 mt-1 line-clamp-2 text-[12px] leading-5 text-secondary-foreground">
+        <span class="font-semibold text-muted-foreground">
+          {roleLabel(props.hit)}:
+        </span>{" "}
+        <HighlightedText
+          text={props.hit.text}
+          query={conversationSearchStore.state.query}
+        />
+      </div>
+    </button>
+  );
+}
+
+function SearchFilters() {
+  const projects = createMemo(() => {
+    const values = new Set<string>();
+    for (const thread of threadStore.allConversations) {
+      if (thread.projectRoot) values.add(thread.projectRoot);
+    }
+    return [...values].sort((left, right) => left.localeCompare(right));
+  });
+
+  return (
+    <div class="flex flex-wrap items-center gap-2 border-b border-border/60 bg-surface-0 px-3 py-2">
+      <div class="inline-flex overflow-hidden rounded-[7px] border border-border">
+        <For each={["all", "chat", "agent"] as ConversationKindFilter[]}>
+          {(kind) => (
+            <button
+              type="button"
+              class={`h-7 px-3 text-[12px] capitalize transition-colors ${conversationSearchStore.state.filters.kind === kind ? "bg-surface-2 text-foreground" : "text-muted-foreground hover:bg-surface-1 hover:text-foreground"}`}
+              onClick={() => conversationSearchStore.setKind(kind)}
+            >
+              {kind}
+            </button>
+          )}
+        </For>
+      </div>
+      <select
+        aria-label="Project"
+        value={conversationSearchStore.state.filters.projectRoot ?? ""}
+        onChange={(event) =>
+          conversationSearchStore.setProjectRoot(
+            event.currentTarget.value || null,
+          )
+        }
+        class="h-7 rounded-[7px] border border-border bg-surface-0 px-2 text-[12px] text-secondary-foreground outline-none focus:border-primary/50"
+      >
+        <option value="">All projects</option>
+        <For each={projects()}>
+          {(project) => (
+            <option value={project}>{projectLabel(project)}</option>
+          )}
+        </For>
+      </select>
+      <input
+        type="date"
+        aria-label="From date"
+        value={conversationSearchStore.state.filters.fromDate}
+        onInput={(event) =>
+          conversationSearchStore.setFromDate(event.currentTarget.value)
+        }
+        class="h-7 rounded-[7px] border border-border bg-surface-0 px-2 text-[12px] text-secondary-foreground outline-none focus:border-primary/50"
+      />
+      <input
+        type="date"
+        aria-label="To date"
+        value={conversationSearchStore.state.filters.toDate}
+        onInput={(event) =>
+          conversationSearchStore.setToDate(event.currentTarget.value)
+        }
+        class="h-7 rounded-[7px] border border-border bg-surface-0 px-2 text-[12px] text-secondary-foreground outline-none focus:border-primary/50"
+      />
+      <label class="ml-auto flex h-7 items-center gap-2 text-[12px] text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={conversationSearchStore.state.filters.includeArchived}
+          onChange={(event) =>
+            conversationSearchStore.setIncludeArchived(
+              event.currentTarget.checked,
+            )
+          }
+          class="h-3.5 w-3.5 accent-primary"
+        />
+        Include archived
+      </label>
+    </div>
+  );
+}
+
+export function ConversationSearchOverlay() {
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+  let inputRef: HTMLInputElement | undefined;
+  let debounce: ReturnType<typeof setTimeout> | undefined;
+
+  const visibleResults = createMemo(() =>
+    conversationSearchStore.state.results.slice(0, 8),
+  );
+  const exactResults = createMemo(() =>
+    visibleResults().filter((hit) => hit.matchType === "exact"),
+  );
+  const semanticResults = createMemo(() =>
+    visibleResults().filter((hit) => hit.matchType === "semantic"),
+  );
+  const selectableCount = () =>
+    visibleResults().length +
+    (conversationSearchStore.state.results.length > 0 ? 1 : 0);
+
+  createEffect(() => {
+    if (!conversationSearchStore.state.open) return;
+    conversationSearchStore.state.query;
+    const filters = conversationSearchStore.state.filters;
+    filters.kind;
+    filters.projectRoot;
+    filters.fromDate;
+    filters.toDate;
+    filters.includeArchived;
+    clearTimeout(debounce);
+    debounce = setTimeout(() => void conversationSearchStore.runSearch(), 150);
+  });
+
+  createEffect(() => {
+    if (
+      conversationSearchStore.state.open &&
+      conversationSearchStore.state.pendingFocus
+    ) {
+      queueMicrotask(() => inputRef?.focus());
+      conversationSearchStore.consumeFocusRequest();
+    }
+  });
+
+  createEffect(() => {
+    if (selectedIndex() >= selectableCount()) setSelectedIndex(0);
+  });
+
+  onCleanup(() => clearTimeout(debounce));
+
+  const openSelected = () => {
+    const selected = selectedIndex();
+    if (selected < visibleResults().length) {
+      conversationSearchStore.openHit(visibleResults()[selected]);
+    } else if (conversationSearchStore.state.results.length > 0) {
+      conversationSearchStore.expandToFull();
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      conversationSearchStore.close();
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setSelectedIndex((value) => (value + 1) % Math.max(selectableCount(), 1));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setSelectedIndex(
+        (value) =>
+          (value - 1 + Math.max(selectableCount(), 1)) %
+          Math.max(selectableCount(), 1),
+      );
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      openSelected();
+    }
+  };
+
+  return (
+    <Show when={conversationSearchStore.state.open}>
+      <div
+        class="fixed inset-0 z-50 bg-background/70 backdrop-blur-[2px]"
+        onMouseDown={(event) => {
+          if (event.target === event.currentTarget)
+            conversationSearchStore.close();
+        }}
+      >
+        <section
+          role="dialog"
+          aria-label="Search conversation history"
+          data-testid="conversation-search-overlay"
+          class="absolute left-1/2 top-[11vh] flex max-h-[74vh] w-[680px] max-w-[calc(100vw-40px)] -translate-x-1/2 flex-col overflow-hidden rounded-[12px] border border-border-strong bg-surface-1 shadow-[0_24px_70px_rgba(0,0,0,0.62),0_4px_14px_rgba(0,0,0,0.45)]"
+          onKeyDown={handleKeyDown}
+        >
+          <div class="flex items-center gap-3 border-b border-border px-4 py-3.5">
+            <SearchIcon />
+            <input
+              ref={inputRef}
+              type="search"
+              spellcheck={false}
+              value={conversationSearchStore.state.query}
+              onInput={(event) =>
+                conversationSearchStore.setQuery(event.currentTarget.value)
+              }
+              placeholder="Search history"
+              data-testid="conversation-search-input"
+              class="min-w-0 flex-1 bg-transparent text-[17px] text-foreground outline-none placeholder:text-muted-foreground"
+            />
+            <kbd class="rounded border border-border bg-surface-2 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+              Esc
+            </kbd>
+          </div>
+          <SearchFilters />
+          <Show when={conversationSearchStore.state.semanticUnavailable}>
+            <div class="mx-3 mt-3 rounded-[8px] border border-warning/30 bg-warning/10 px-3 py-2 text-[12px] text-warning">
+              {conversationSearchStore.state.semanticUnavailableReason
+                ? `Semantic search unavailable: ${conversationSearchStore.state.semanticUnavailableReason}. Showing exact matches.`
+                : "Semantic search unavailable. Showing exact matches."}
+            </div>
+          </Show>
+          <div class="min-h-[160px] overflow-auto px-1.5 py-2">
+            <Show
+              when={conversationSearchStore.state.query.trim()}
+              fallback={
+                <div class="px-3 py-10 text-center text-[13px] text-muted-foreground">
+                  Search titles, prompts, assistant replies, and agent output.
+                </div>
+              }
+            >
+              <Show
+                when={
+                  conversationSearchStore.state.loading ||
+                  conversationSearchStore.state.results.length > 0
+                }
+                fallback={
+                  <div class="px-3 py-10 text-center text-[13px] text-muted-foreground">
+                    {conversationSearchStore.state.searched
+                      ? "No matches."
+                      : "Type to search history."}
+                  </div>
+                }
+              >
+                <Show when={conversationSearchStore.state.loading}>
+                  <div class="px-3 pb-2 text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+                    Searching
+                  </div>
+                </Show>
+                <Show when={exactResults().length > 0}>
+                  <div class="px-3 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                    {conversationSearchStore.state.results.length} results
+                  </div>
+                  <For each={exactResults()}>
+                    {(hit, index) => (
+                      <ResultRow
+                        hit={hit}
+                        selected={selectedIndex() === index()}
+                        onOpen={() => conversationSearchStore.openHit(hit)}
+                      />
+                    )}
+                  </For>
+                </Show>
+                <Show when={semanticResults().length > 0}>
+                  <div class="px-3 pb-1 pt-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                    Related by meaning
+                  </div>
+                  <For each={semanticResults()}>
+                    {(hit, index) => (
+                      <ResultRow
+                        hit={hit}
+                        selected={
+                          selectedIndex() === exactResults().length + index()
+                        }
+                        onOpen={() => conversationSearchStore.openHit(hit)}
+                      />
+                    )}
+                  </For>
+                </Show>
+                <Show when={conversationSearchStore.state.results.length > 0}>
+                  <button
+                    type="button"
+                    class={`mt-1 flex h-9 w-full items-center justify-between rounded-[7px] px-3 text-left text-[12px] transition-colors ${selectedIndex() === visibleResults().length ? "bg-surface-2 text-foreground" : "text-muted-foreground hover:bg-surface-0 hover:text-foreground"}`}
+                    onClick={() => conversationSearchStore.expandToFull()}
+                  >
+                    <span>
+                      See all {conversationSearchStore.state.results.length}{" "}
+                      results
+                    </span>
+                    <span aria-hidden="true">→</span>
+                  </button>
+                </Show>
+              </Show>
+            </Show>
+          </div>
+          <div class="flex items-center gap-4 border-t border-border bg-surface-0 px-3 py-2 text-[11px] text-muted-foreground">
+            <span>↑↓ Navigate</span>
+            <span>↵ Open</span>
+            <span>Esc Close</span>
+            <span class="ml-auto">
+              {conversationSearchStore.state.semanticUnavailable
+                ? "Exact only"
+                : "Exact + semantic"}
+            </span>
+          </div>
+        </section>
+      </div>
+    </Show>
+  );
+}

--- a/src/components/search/ConversationSearchResults.tsx
+++ b/src/components/search/ConversationSearchResults.tsx
@@ -1,0 +1,360 @@
+// ABOUTME: Full-pane grouped results view for conversation history search.
+// ABOUTME: Shares query/filter state with the spotlight overlay and opens hits in-place.
+
+import { createEffect, createMemo, For, onCleanup, Show } from "solid-js";
+import { type HighlightSegment, highlightTerms } from "@/lib/highlight";
+import type { ConversationHit } from "@/services/conversation-search";
+import { conversationSearchStore } from "@/stores/conversation-search.store";
+import { threadStore } from "@/stores/thread.store";
+
+function titleFor(hit: Pick<ConversationHit, "title">): string {
+  return hit.title?.trim() || "Untitled conversation";
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const delta = Date.now() - timestamp;
+  const day = 86_400_000;
+  if (delta < day) return "today";
+  if (delta < 14 * day) return `${Math.round(delta / day)}d ago`;
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function roleLabel(hit: ConversationHit): string {
+  if (hit.role === "user") return "You";
+  return hit.agentType || "Assistant";
+}
+
+function projectLabel(projectRoot: string | null): string {
+  if (!projectRoot) return "No project";
+  return projectRoot.split("/").filter(Boolean).at(-1) || projectRoot;
+}
+
+function KindIcon(props: { kind: "chat" | "agent" }) {
+  return (
+    <svg
+      class={`h-4 w-4 shrink-0 ${props.kind === "agent" ? "text-violet-300" : "text-muted-foreground"}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.7"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <Show
+        when={props.kind === "agent"}
+        fallback={
+          <path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z" />
+        }
+      >
+        <path d="m12 2 8 4.7v10.6L12 22l-8-4.7V6.7z" />
+      </Show>
+    </svg>
+  );
+}
+
+function HighlightedText(props: { text: string; query: string }) {
+  const segments = createMemo(() => highlightTerms(props.text, props.query));
+  return (
+    <For each={segments()}>
+      {(segment: HighlightSegment) =>
+        typeof segment === "string" ? (
+          segment
+        ) : (
+          <mark class="rounded bg-primary/15 px-0.5 font-semibold text-primary">
+            {segment.mark}
+          </mark>
+        )
+      }
+    </For>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      class="h-5 w-5 shrink-0 text-muted-foreground"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m20 20-3.2-3.2" />
+    </svg>
+  );
+}
+
+function FiltersBar() {
+  const projects = createMemo(() => {
+    const values = new Set<string>();
+    for (const thread of threadStore.allConversations) {
+      if (thread.projectRoot) values.add(thread.projectRoot);
+    }
+    return [...values].sort((left, right) => left.localeCompare(right));
+  });
+
+  return (
+    <div class="mt-3 flex flex-wrap items-center gap-2">
+      <div class="inline-flex overflow-hidden rounded-[7px] border border-border">
+        <For each={["all", "chat", "agent"] as const}>
+          {(kind) => (
+            <button
+              type="button"
+              class={`h-7 px-3 text-[12px] capitalize ${conversationSearchStore.state.filters.kind === kind ? "bg-surface-2 text-foreground" : "text-muted-foreground hover:bg-surface-1 hover:text-foreground"}`}
+              onClick={() => conversationSearchStore.setKind(kind)}
+            >
+              {kind}
+            </button>
+          )}
+        </For>
+      </div>
+      <select
+        aria-label="Project"
+        value={conversationSearchStore.state.filters.projectRoot ?? ""}
+        onChange={(event) =>
+          conversationSearchStore.setProjectRoot(
+            event.currentTarget.value || null,
+          )
+        }
+        class="h-7 rounded-[7px] border border-border bg-background px-2 text-[12px] text-secondary-foreground outline-none focus:border-primary/50"
+      >
+        <option value="">All projects</option>
+        <For each={projects()}>
+          {(project) => (
+            <option value={project}>{projectLabel(project)}</option>
+          )}
+        </For>
+      </select>
+      <input
+        type="date"
+        aria-label="From date"
+        value={conversationSearchStore.state.filters.fromDate}
+        onInput={(event) =>
+          conversationSearchStore.setFromDate(event.currentTarget.value)
+        }
+        class="h-7 rounded-[7px] border border-border bg-background px-2 text-[12px] text-secondary-foreground outline-none focus:border-primary/50"
+      />
+      <input
+        type="date"
+        aria-label="To date"
+        value={conversationSearchStore.state.filters.toDate}
+        onInput={(event) =>
+          conversationSearchStore.setToDate(event.currentTarget.value)
+        }
+        class="h-7 rounded-[7px] border border-border bg-background px-2 text-[12px] text-secondary-foreground outline-none focus:border-primary/50"
+      />
+      <label class="flex h-7 items-center gap-2 text-[12px] text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={conversationSearchStore.state.filters.includeArchived}
+          onChange={(event) =>
+            conversationSearchStore.setIncludeArchived(
+              event.currentTarget.checked,
+            )
+          }
+          class="h-3.5 w-3.5 accent-primary"
+        />
+        Include archived
+      </label>
+    </div>
+  );
+}
+
+interface ResultGroup {
+  conversationId: string;
+  title: string;
+  kind: "chat" | "agent";
+  agentType: string | null;
+  projectRoot: string | null;
+  timestamp: number;
+  hits: ConversationHit[];
+}
+
+export function ConversationSearchResults() {
+  let inputRef: HTMLInputElement | undefined;
+  let debounce: ReturnType<typeof setTimeout> | undefined;
+
+  const groups = createMemo(() => {
+    const byId = new Map<string, ResultGroup>();
+    for (const hit of conversationSearchStore.state.results) {
+      const existing = byId.get(hit.conversationId);
+      if (existing) {
+        existing.hits.push(hit);
+        existing.timestamp = Math.max(existing.timestamp, hit.timestamp);
+      } else {
+        byId.set(hit.conversationId, {
+          conversationId: hit.conversationId,
+          title: titleFor(hit),
+          kind: hit.kind,
+          agentType: hit.agentType,
+          projectRoot: hit.projectRoot,
+          timestamp: hit.timestamp,
+          hits: [hit],
+        });
+      }
+    }
+    return [...byId.values()];
+  });
+
+  createEffect(() => {
+    if (conversationSearchStore.state.mode !== "full") return;
+    conversationSearchStore.state.query;
+    const filters = conversationSearchStore.state.filters;
+    filters.kind;
+    filters.projectRoot;
+    filters.fromDate;
+    filters.toDate;
+    filters.includeArchived;
+    clearTimeout(debounce);
+    debounce = setTimeout(() => void conversationSearchStore.runSearch(), 150);
+  });
+
+  createEffect(() => {
+    if (
+      conversationSearchStore.state.mode === "full" &&
+      conversationSearchStore.state.pendingFocus
+    ) {
+      queueMicrotask(() => inputRef?.focus());
+      conversationSearchStore.consumeFocusRequest();
+    }
+  });
+
+  onCleanup(() => clearTimeout(debounce));
+
+  return (
+    <section
+      class="flex h-full min-h-0 flex-col bg-background"
+      data-testid="conversation-search-results"
+    >
+      <div class="shrink-0 border-b border-border px-6 py-4">
+        <div class="flex items-center gap-3 rounded-[10px] border border-border-medium bg-surface-1 px-4 py-3 shadow-[0_0_0_3px_rgba(56,189,248,0.08)]">
+          <SearchIcon />
+          <input
+            ref={inputRef}
+            type="search"
+            spellcheck={false}
+            value={conversationSearchStore.state.query}
+            onInput={(event) =>
+              conversationSearchStore.setQuery(event.currentTarget.value)
+            }
+            placeholder="Search history"
+            class="min-w-0 flex-1 bg-transparent text-[18px] text-foreground outline-none placeholder:text-muted-foreground"
+          />
+          <button
+            type="button"
+            class="rounded p-1 text-muted-foreground hover:bg-surface-2 hover:text-foreground"
+            aria-label="Close search"
+            onClick={() => conversationSearchStore.close()}
+          >
+            ×
+          </button>
+        </div>
+        <div class="flex items-start gap-3">
+          <FiltersBar />
+          <div class="ml-auto mt-4 shrink-0 font-mono text-[12px] text-muted-foreground">
+            {conversationSearchStore.state.results.length} matches ·{" "}
+            {groups().length} conversations
+          </div>
+        </div>
+      </div>
+      <Show when={conversationSearchStore.state.semanticUnavailable}>
+        <div class="mx-6 mt-4 flex items-center gap-2 rounded-[8px] border border-warning/30 bg-warning/10 px-3 py-2 text-[12px] text-warning">
+          <span aria-hidden="true">△</span>
+          <span>
+            {conversationSearchStore.state.semanticUnavailableReason
+              ? `Semantic search is unavailable: ${conversationSearchStore.state.semanticUnavailableReason}. Showing exact matches only.`
+              : "Semantic search is unavailable. Showing exact matches only."}
+          </span>
+        </div>
+      </Show>
+      <div class="min-h-0 flex-1 overflow-auto px-6 pb-8 pt-3">
+        <Show
+          when={conversationSearchStore.state.results.length > 0}
+          fallback={
+            <div class="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+              {conversationSearchStore.state.query.trim()
+                ? "No matches."
+                : "Search titles, prompts, assistant replies, and agent output."}
+            </div>
+          }
+        >
+          <For each={groups()}>
+            {(group) => (
+              <section class="mt-4">
+                <div class="flex min-w-0 items-center gap-2 border-b border-border/60 px-1 pb-2">
+                  <KindIcon kind={group.kind} />
+                  <button
+                    type="button"
+                    class="min-w-0 truncate text-left text-[14px] font-semibold text-foreground hover:text-primary"
+                    onClick={() =>
+                      conversationSearchStore.openHit(group.hits[0])
+                    }
+                  >
+                    {group.title}
+                  </button>
+                  <span class="truncate text-[12px] text-muted-foreground">
+                    · {group.kind === "agent" ? "Agent" : "Chat"}
+                    <Show when={group.agentType}>
+                      {(agent) => <> · {agent()}</>}
+                    </Show>
+                    {" · "}
+                    {projectLabel(group.projectRoot)} ·{" "}
+                    {formatRelativeTime(group.timestamp)}
+                  </span>
+                  <span class="ml-auto shrink-0 font-mono text-[11px] text-muted-foreground">
+                    {group.hits.length}{" "}
+                    {group.hits.length === 1 ? "match" : "matches"}
+                  </span>
+                  <button
+                    type="button"
+                    class="shrink-0 text-[12px] font-medium text-primary hover:text-primary-hover"
+                    onClick={() =>
+                      conversationSearchStore.openHit(group.hits[0])
+                    }
+                  >
+                    Open →
+                  </button>
+                </div>
+                <div class="py-1">
+                  <For each={group.hits}>
+                    {(hit) => (
+                      <button
+                        type="button"
+                        class="flex w-full gap-3 rounded-[8px] px-2 py-2 text-left hover:bg-surface-1"
+                        onClick={() => conversationSearchStore.openHit(hit)}
+                      >
+                        <div class="w-24 shrink-0 pt-0.5 text-right text-[11px] leading-4 text-muted-foreground">
+                          <span class="block font-semibold text-secondary-foreground">
+                            {roleLabel(hit)}
+                          </span>
+                          {formatRelativeTime(hit.timestamp)}
+                        </div>
+                        <div class="min-w-0 flex-1 text-[13px] leading-6 text-secondary-foreground">
+                          <HighlightedText
+                            text={hit.text}
+                            query={conversationSearchStore.state.query}
+                          />
+                          <Show when={hit.matchType === "semantic"}>
+                            <span class="ml-2 text-[11px] text-primary">
+                              semantic match
+                            </span>
+                          </Show>
+                        </div>
+                      </button>
+                    )}
+                  </For>
+                </div>
+              </section>
+            )}
+          </For>
+        </Show>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Safe text highlighting helper that returns renderable segments.
+// ABOUTME: Avoids innerHTML when marking query terms in search results.
+
+export type HighlightSegment = string | { mark: string };
+
+function uniqueTerms(query: string): string[] {
+  const seen = new Set<string>();
+  const terms: string[] = [];
+  for (const raw of query.split(/\s+/)) {
+    const term = raw.trim();
+    if (!term) continue;
+    const key = term.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    terms.push(term);
+  }
+  return terms;
+}
+
+export function highlightTerms(
+  text: string,
+  query: string,
+): HighlightSegment[] {
+  const terms = uniqueTerms(query);
+  if (terms.length === 0 || text.length === 0) return [text];
+
+  const lowerText = text.toLowerCase();
+  const spans: Array<{ start: number; end: number }> = [];
+  for (const term of terms) {
+    const lowerTerm = term.toLowerCase();
+    let start = 0;
+    while (start < lowerText.length) {
+      const index = lowerText.indexOf(lowerTerm, start);
+      if (index === -1) break;
+      spans.push({ start: index, end: index + lowerTerm.length });
+      start = index + Math.max(lowerTerm.length, 1);
+    }
+  }
+
+  if (spans.length === 0) return [text];
+
+  spans.sort((left, right) =>
+    left.start === right.start
+      ? left.end - right.end
+      : left.start - right.start,
+  );
+  const merged: Array<{ start: number; end: number }> = [];
+  for (const span of spans) {
+    const previous = merged[merged.length - 1];
+    if (previous && span.start <= previous.end) {
+      previous.end = Math.max(previous.end, span.end);
+    } else {
+      merged.push({ ...span });
+    }
+  }
+
+  const out: HighlightSegment[] = [];
+  let cursor = 0;
+  for (const span of merged) {
+    if (span.start > cursor) out.push(text.slice(cursor, span.start));
+    out.push({ mark: text.slice(span.start, span.end) });
+    cursor = span.end;
+  }
+  if (cursor < text.length) out.push(text.slice(cursor));
+  return out;
+}

--- a/src/lib/message-scroll.ts
+++ b/src/lib/message-scroll.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Helpers for scrolling persisted chat/agent message rows into view.
+// ABOUTME: Used by conversation history search hit navigation.
+
+function messageSelector(messageId: string): string {
+  const escaped =
+    typeof CSS !== "undefined" && typeof CSS.escape === "function"
+      ? CSS.escape(messageId)
+      : messageId.replace(/["\\]/g, "\\$&");
+  return `[data-message-id="${escaped}"]`;
+}
+
+export function scrollMessageIntoView(
+  container: HTMLElement | undefined,
+  messageId: string,
+): boolean {
+  const element = container?.querySelector<HTMLElement>(
+    messageSelector(messageId),
+  );
+  if (!element) return false;
+
+  element.scrollIntoView({ behavior: "smooth", block: "center" });
+  element.classList.add(
+    "ring-1",
+    "ring-primary/70",
+    "bg-primary/5",
+    "transition-colors",
+    "duration-300",
+  );
+  window.setTimeout(() => {
+    element.classList.remove(
+      "ring-1",
+      "ring-primary/70",
+      "bg-primary/5",
+      "transition-colors",
+      "duration-300",
+    );
+  }, 1600);
+
+  return true;
+}

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -16,7 +16,8 @@ export type ShortcutAction =
   | "global.openFiles"
   | "global.newChat"
   | "global.newTerminal"
-  | "global.searchMeetings";
+  | "global.searchMeetings"
+  | "global.searchHistory";
 
 /**
  * A shortcut handler may return `false` to signal it did not consume the key,
@@ -40,6 +41,7 @@ const GLOBAL_SHORTCUT_ACTIONS: readonly ShortcutAction[] = [
   "global.newChat",
   "global.newTerminal",
   "global.searchMeetings",
+  "global.searchHistory",
 ];
 
 /**
@@ -150,7 +152,11 @@ class ShortcutManager {
       return;
     }
 
-    if (isInputField && result.action !== "global.closePanel") {
+    if (
+      isInputField &&
+      result.action !== "global.closePanel" &&
+      result.action !== "global.searchHistory"
+    ) {
       return;
     }
 

--- a/src/services/conversation-search.ts
+++ b/src/services/conversation-search.ts
@@ -1,0 +1,232 @@
+// ABOUTME: Conversation history search service combining exact FTS and semantic hits.
+// ABOUTME: Owns all IPC and embedding calls for chat/agent history search UI.
+
+import { invoke } from "@tauri-apps/api/core";
+import { embedText, embedTexts } from "@/services/seren-embed";
+
+export type ConversationKind = "chat" | "agent";
+export type ConversationMatchType = "exact" | "semantic";
+
+interface RawConversationHit {
+  messageId: string;
+  conversationId: string;
+  kind: ConversationKind;
+  role: string;
+  title: string | null;
+  agentType: string | null;
+  projectRoot: string | null;
+  timestamp: number;
+  seq: number;
+  text: string;
+  distance: number;
+}
+
+export interface ConversationHit extends RawConversationHit {
+  matchType: ConversationMatchType;
+}
+
+export interface ConversationSearchFilters {
+  kinds?: ConversationKind[];
+  projectRoot?: string | null;
+  afterMs?: number | null;
+  beforeMs?: number | null;
+  includeArchived?: boolean;
+}
+
+export interface ConversationSearchOptions {
+  limit?: number;
+  filters?: ConversationSearchFilters;
+}
+
+export interface ConversationSearchResult {
+  hits: ConversationHit[];
+  semanticUnavailable: boolean;
+  semanticUnavailableReason?: string;
+}
+
+interface UnembeddedConversationChunk {
+  chunkId: number;
+  text: string;
+}
+
+function normalizeFilters(
+  filters: ConversationSearchFilters | undefined,
+): ConversationSearchFilters {
+  return {
+    kinds: filters?.kinds ?? [],
+    projectRoot: filters?.projectRoot?.trim() || null,
+    afterMs: filters?.afterMs ?? null,
+    beforeMs: filters?.beforeMs ?? null,
+    includeArchived: filters?.includeArchived ?? false,
+  };
+}
+
+function describeSemanticSearchFailure(error: unknown): string {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  const lower = message.toLowerCase();
+
+  if (
+    lower.includes("not authenticated") ||
+    lower.includes("unauthorized") ||
+    lower.includes("401")
+  ) {
+    return "sign in is required";
+  }
+  if (
+    lower.includes("402") ||
+    lower.includes("balance") ||
+    lower.includes("payment") ||
+    lower.includes("out of balance") ||
+    lower.includes("insufficient")
+  ) {
+    return "embedding publisher needs payment or balance";
+  }
+  if (lower.includes("404") || lower.includes("not found")) {
+    return "embedding endpoint was not found";
+  }
+  if (
+    lower.includes("timeout") ||
+    lower.includes("network") ||
+    lower.includes("failed to fetch")
+  ) {
+    return "could not reach the embedding publisher";
+  }
+
+  return "embedding request failed";
+}
+
+function withMatchType(
+  hits: RawConversationHit[],
+  matchType: ConversationMatchType,
+): ConversationHit[] {
+  return hits.map((hit) => ({ ...hit, matchType }));
+}
+
+function hitKey(hit: ConversationHit): string {
+  return `${hit.messageId}:${hit.seq}`;
+}
+
+function mergeHits(
+  exact: ConversationHit[],
+  semantic: ConversationHit[],
+  limit: number,
+): ConversationHit[] {
+  const out = exact.slice(0, limit);
+  const seen = new Set(out.map(hitKey));
+  for (const hit of semantic) {
+    if (out.length >= limit) break;
+    const key = hitKey(hit);
+    if (seen.has(key)) continue;
+    out.push(hit);
+    seen.add(key);
+  }
+  return out;
+}
+
+export async function searchConversations(
+  query: string,
+  options: ConversationSearchOptions = {},
+): Promise<ConversationSearchResult> {
+  const trimmed = query.trim();
+  if (!trimmed) return { hits: [], semanticUnavailable: false };
+
+  const limit = options.limit ?? 20;
+  const filters = normalizeFilters(options.filters);
+  const exactRaw = await invoke<RawConversationHit[]>(
+    "search_conversations_fts",
+    {
+      query: trimmed,
+      filters,
+      limit,
+    },
+  ).catch(() => [] as RawConversationHit[]);
+  const exact = withMatchType(exactRaw, "exact");
+
+  let semantic: ConversationHit[] = [];
+  let semanticUnavailable = false;
+  let semanticUnavailableReason: string | undefined;
+  try {
+    const queryEmbedding = await embedText(trimmed);
+    const semanticRaw = await invoke<RawConversationHit[]>(
+      "search_conversations",
+      {
+        queryEmbedding,
+        filters,
+        limit,
+      },
+    );
+    semantic = withMatchType(semanticRaw, "semantic");
+  } catch (error) {
+    semanticUnavailable = true;
+    semanticUnavailableReason = describeSemanticSearchFailure(error);
+  }
+
+  return {
+    hits: mergeHits(exact, semantic, limit),
+    semanticUnavailable,
+    semanticUnavailableReason,
+  };
+}
+
+export async function backfillConversationFts(): Promise<number> {
+  return invoke<number>("backfill_conversation_fts").catch(() => 0);
+}
+
+export async function deleteConversationIndex(
+  conversationId: string,
+): Promise<void> {
+  await invoke("delete_conversation_index", { conversationId }).catch(() => {});
+}
+
+const BATCH_SIZE = 20;
+const MAX_BACKFILL_ATTEMPTS = 3;
+const backfillAttempts = new Map<number, number>();
+
+export async function backfillConversationIndex(): Promise<void> {
+  while (true) {
+    const pending = await invoke<UnembeddedConversationChunk[]>(
+      "unembedded_conversation_chunks",
+      { limit: BATCH_SIZE },
+    ).catch(() => [] as UnembeddedConversationChunk[]);
+    if (pending.length === 0) return;
+
+    const eligible = pending.filter(
+      (chunk) =>
+        (backfillAttempts.get(chunk.chunkId) ?? 0) < MAX_BACKFILL_ATTEMPTS,
+    );
+    if (eligible.length === 0) return;
+
+    let embeddings: Awaited<ReturnType<typeof embedTexts>>;
+    try {
+      embeddings = await embedTexts(eligible.map((chunk) => chunk.text));
+    } catch {
+      for (const chunk of eligible) {
+        backfillAttempts.set(
+          chunk.chunkId,
+          (backfillAttempts.get(chunk.chunkId) ?? 0) + 1,
+        );
+      }
+      return;
+    }
+
+    for (const [index, chunk] of eligible.entries()) {
+      try {
+        await invoke("index_conversation_embeddings", {
+          chunkId: chunk.chunkId,
+          embedding: embeddings.data[index].embedding,
+        });
+        backfillAttempts.delete(chunk.chunkId);
+      } catch {
+        backfillAttempts.set(
+          chunk.chunkId,
+          (backfillAttempts.get(chunk.chunkId) ?? 0) + 1,
+        );
+      }
+    }
+  }
+}

--- a/src/services/conversation-search.ts
+++ b/src/services/conversation-search.ts
@@ -215,10 +215,18 @@ export async function backfillConversationIndex(): Promise<void> {
     }
 
     for (const [index, chunk] of eligible.entries()) {
+      const embedding = embeddings.data[index]?.embedding;
+      if (!embedding) {
+        backfillAttempts.set(
+          chunk.chunkId,
+          (backfillAttempts.get(chunk.chunkId) ?? 0) + 1,
+        );
+        continue;
+      }
       try {
         await invoke("index_conversation_embeddings", {
           chunkId: chunk.chunkId,
-          embedding: embeddings.data[index].embedding,
+          embedding,
         });
         backfillAttempts.delete(chunk.chunkId);
       } catch {

--- a/src/services/validation-control.ts
+++ b/src/services/validation-control.ts
@@ -74,7 +74,8 @@ export function installValidationControlBridge(): void {
             reply.result = await handleCommand(command);
           } catch (error) {
             reply.ok = false;
-            reply.error = error instanceof Error ? error.message : String(error);
+            reply.error =
+              error instanceof Error ? error.message : String(error);
           }
 
           try {
@@ -274,7 +275,9 @@ async function nativeScreenshot(): Promise<unknown> {
   try {
     const runtime = await getValidationRuntimeInfo();
     if (!runtime.isValidation || runtime.processId <= 0) {
-      throw new Error("Native validation capture requires validation runtime info.");
+      throw new Error(
+        "Native validation capture requires validation runtime info.",
+      );
     }
 
     const windows = await invoke<NativeCaptureWindow[]>(

--- a/src/stores/conversation-search.store.ts
+++ b/src/stores/conversation-search.store.ts
@@ -1,0 +1,187 @@
+// ABOUTME: UI state and actions for conversation history search.
+// ABOUTME: Shares one result set between the spotlight overlay and full-pane view.
+
+import { createStore } from "solid-js/store";
+import {
+  type ConversationHit,
+  type ConversationKind,
+  type ConversationSearchFilters,
+  searchConversations,
+} from "@/services/conversation-search";
+import { threadStore } from "@/stores/thread.store";
+
+export type ConversationSearchMode = "overlay" | "full";
+export type ConversationKindFilter = "all" | ConversationKind;
+
+export interface ConversationSearchUiFilters {
+  kind: ConversationKindFilter;
+  projectRoot: string | null;
+  fromDate: string;
+  toDate: string;
+  includeArchived: boolean;
+}
+
+interface ConversationSearchState {
+  open: boolean;
+  mode: ConversationSearchMode;
+  pendingFocus: boolean;
+  query: string;
+  filters: ConversationSearchUiFilters;
+  results: ConversationHit[];
+  loading: boolean;
+  searched: boolean;
+  semanticUnavailable: boolean;
+  semanticUnavailableReason: string | null;
+}
+
+const [state, setState] = createStore<ConversationSearchState>({
+  open: false,
+  mode: "overlay",
+  pendingFocus: false,
+  query: "",
+  filters: {
+    kind: "all",
+    projectRoot: null,
+    fromDate: "",
+    toDate: "",
+    includeArchived: false,
+  },
+  results: [],
+  loading: false,
+  searched: false,
+  semanticUnavailable: false,
+  semanticUnavailableReason: null,
+});
+
+let searchRequest = 0;
+
+function dayStartMs(value: string): number | null {
+  if (!value) return null;
+  const parsed = new Date(`${value}T00:00:00`);
+  const time = parsed.getTime();
+  return Number.isFinite(time) ? time : null;
+}
+
+function dayEndMs(value: string): number | null {
+  if (!value) return null;
+  const parsed = new Date(`${value}T23:59:59.999`);
+  const time = parsed.getTime();
+  return Number.isFinite(time) ? time : null;
+}
+
+function serviceFilters(): ConversationSearchFilters {
+  const filters = state.filters;
+  return {
+    kinds: filters.kind === "all" ? [] : [filters.kind],
+    projectRoot: filters.projectRoot,
+    afterMs: dayStartMs(filters.fromDate),
+    beforeMs: dayEndMs(filters.toDate),
+    includeArchived: filters.includeArchived,
+  };
+}
+
+function setEmptySearchState() {
+  setState({
+    results: [],
+    loading: false,
+    searched: false,
+    semanticUnavailable: false,
+    semanticUnavailableReason: null,
+  });
+}
+
+export const conversationSearchStore = {
+  state,
+
+  openOverlay(prefill?: string) {
+    setState({
+      open: true,
+      mode: "overlay",
+      pendingFocus: true,
+    });
+    if (prefill !== undefined) setState("query", prefill);
+  },
+
+  close() {
+    setState({
+      open: false,
+      mode: "overlay",
+      pendingFocus: false,
+    });
+  },
+
+  expandToFull() {
+    setState({
+      open: false,
+      mode: "full",
+      pendingFocus: true,
+    });
+  },
+
+  consumeFocusRequest() {
+    setState("pendingFocus", false);
+  },
+
+  setQuery(query: string) {
+    setState("query", query);
+  },
+
+  setKind(kind: ConversationKindFilter) {
+    setState("filters", "kind", kind);
+  },
+
+  setProjectRoot(projectRoot: string | null) {
+    setState("filters", "projectRoot", projectRoot);
+  },
+
+  setFromDate(value: string) {
+    setState("filters", "fromDate", value);
+  },
+
+  setToDate(value: string) {
+    setState("filters", "toDate", value);
+  },
+
+  setIncludeArchived(value: boolean) {
+    setState("filters", "includeArchived", value);
+  },
+
+  clearFilters() {
+    setState("filters", {
+      kind: "all",
+      projectRoot: null,
+      fromDate: "",
+      toDate: "",
+      includeArchived: false,
+    });
+  },
+
+  async runSearch(limit = 80) {
+    const query = state.query.trim();
+    const request = ++searchRequest;
+    if (!query) {
+      setEmptySearchState();
+      return;
+    }
+
+    setState("loading", true);
+    const result = await searchConversations(query, {
+      limit,
+      filters: serviceFilters(),
+    });
+    if (request !== searchRequest) return;
+    setState({
+      results: result.hits,
+      loading: false,
+      searched: true,
+      semanticUnavailable: result.semanticUnavailable,
+      semanticUnavailableReason: result.semanticUnavailableReason ?? null,
+    });
+  },
+
+  openHit(hit: ConversationHit) {
+    threadStore.selectThread(hit.conversationId, hit.kind);
+    threadStore.requestMessageScroll(hit.conversationId, hit.messageId);
+    this.close();
+  },
+};

--- a/src/stores/keybindings.store.ts
+++ b/src/stores/keybindings.store.ts
@@ -28,6 +28,7 @@ export type KeybindingActionId =
   | "global.newChat"
   | "global.newTerminal"
   | "global.searchMeetings"
+  | "global.searchHistory"
   | "workspace.next"
   | "workspace.previous"
   | "workspace.switch1"
@@ -169,6 +170,13 @@ const keybindingDefinitions = [
     label: "Search transcripts",
     description: "Open the meetings panel and focus transcript search.",
     defaults: [{ sequence: [{ mod: true, shift: true, key: "f" }] }],
+  },
+  {
+    id: "global.searchHistory",
+    group: "Global",
+    label: "Search history",
+    description: "Open the conversation history search overlay.",
+    defaults: [{ sequence: [{ mod: true, shift: true, key: "h" }] }],
   },
   {
     id: "workspace.next",

--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -155,6 +155,7 @@ export interface ThreadGroup {
 interface ThreadState {
   activeThreadId: string | null;
   activeThreadKind: ThreadKind | null;
+  pendingMessageScroll: { conversationId: string; messageId: string } | null;
   /** When true, new threads prefer Seren Chat over any available agent. */
   preferChat: boolean;
   /**
@@ -187,6 +188,7 @@ export interface SkillLaunchOptions {
 const [state, setState] = createStore<ThreadState>({
   activeThreadId: null,
   activeThreadKind: null,
+  pendingMessageScroll: null,
   preferChat: false,
   projectOrder: loadProjectOrder(),
   folderLastActivity: loadFolderLastActivity(),
@@ -397,6 +399,21 @@ export const threadStore = {
 
   get activeThreadKind(): ThreadKind | null {
     return state.activeThreadKind;
+  },
+
+  get pendingMessageScroll(): {
+    conversationId: string;
+    messageId: string;
+  } | null {
+    return state.pendingMessageScroll;
+  },
+
+  requestMessageScroll(conversationId: string, messageId: string): void {
+    setState("pendingMessageScroll", { conversationId, messageId });
+  },
+
+  clearMessageScroll(): void {
+    setState("pendingMessageScroll", null);
   },
 
   get preferChat(): boolean {

--- a/tests/e2e/conversation-search.spec.ts
+++ b/tests/e2e/conversation-search.spec.ts
@@ -1,0 +1,62 @@
+// ABOUTME: E2e for the conversation history search overlay — wiring and graceful degrade.
+// ABOUTME: Browser mode has no local SQLite index, so this asserts UI wiring + no-crash, not hits.
+
+import { expect, test } from "@playwright/test";
+
+test.describe("Conversation history search", () => {
+  test.beforeEach(async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    await page.goto("/");
+    await page.waitForLoadState("load");
+    (page as unknown as { __errors: string[] }).__errors = errors;
+  });
+
+  test("sidebar Search history entry opens the overlay and focuses the input", async ({
+    page,
+  }) => {
+    const button = page.getByTestId("search-history-button");
+    await expect(button).toBeVisible({ timeout: 10_000 });
+    await button.click();
+
+    await expect(
+      page.getByTestId("conversation-search-overlay"),
+    ).toBeVisible();
+    await expect(page.getByTestId("conversation-search-input")).toBeFocused();
+  });
+
+  test("typing a query degrades gracefully to a no-results state without crashing", async ({
+    page,
+  }) => {
+    await page.getByTestId("search-history-button").click();
+    const input = page.getByTestId("conversation-search-input");
+    await input.fill("updater signing");
+
+    // Browser mode has no local index, so the service returns empty results
+    // (never throwing). The overlay shows its no-results state.
+    await expect(page.getByText("No matches.")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const errors = (page as unknown as { __errors: string[] }).__errors;
+    const initErrors = errors.filter(
+      (error) =>
+        (error.includes("Cannot access") &&
+          error.includes("before initialization")) ||
+        error.includes("SyntaxError"),
+    );
+    expect(initErrors).toEqual([]);
+  });
+
+  test("Escape closes the overlay", async ({ page }) => {
+    await page.getByTestId("search-history-button").click();
+    await expect(
+      page.getByTestId("conversation-search-overlay"),
+    ).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(
+      page.getByTestId("conversation-search-overlay"),
+    ).toBeHidden();
+  });
+});

--- a/tests/unit/conversation-search-service.test.ts
+++ b/tests/unit/conversation-search-service.test.ts
@@ -1,0 +1,98 @@
+// ABOUTME: Tests for conversation search service merge/degrade behavior.
+// ABOUTME: Mocks IPC and embeddings to keep coverage focused on local logic.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invokeMock, embedTextMock, embedTextsMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  embedTextMock: vi.fn(),
+  embedTextsMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@/services/seren-embed", () => ({
+  embedText: embedTextMock,
+  embedTexts: embedTextsMock,
+}));
+
+import {
+  searchConversations,
+  type ConversationHit,
+} from "@/services/conversation-search";
+
+function hit(messageId: string): Omit<ConversationHit, "matchType"> {
+  return {
+    messageId,
+    conversationId: "c1",
+    title: "Thread",
+    kind: "chat",
+    role: "assistant",
+    agentType: null,
+    projectRoot: "/tmp/project",
+    timestamp: 1000,
+    seq: 0,
+    text: `text ${messageId}`,
+    distance: 0,
+  };
+}
+
+describe("searchConversations", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    embedTextMock.mockReset();
+    embedTextsMock.mockReset();
+  });
+
+  it("returns exact hits with a semantic-unavailable flag when embedding fails", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "search_conversations_fts") {
+        return Promise.resolve([hit("m1")]);
+      }
+      return Promise.resolve([]);
+    });
+    embedTextMock.mockRejectedValue(new Error("Not authenticated"));
+
+    const result = await searchConversations("updater", { limit: 10 });
+
+    expect(result.hits.map((item) => item.messageId)).toEqual(["m1"]);
+    expect(result.hits[0].matchType).toBe("exact");
+    expect(result.semanticUnavailable).toBe(true);
+    expect(result.semanticUnavailableReason).toBe("sign in is required");
+  });
+
+  it("does not let semantic hits crowd out exact matches", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "search_conversations_fts") {
+        return Promise.resolve([hit("m1"), hit("m2")]);
+      }
+      return Promise.resolve([hit("m3"), hit("m4")]);
+    });
+    embedTextMock.mockResolvedValue([0.1, 0.2]);
+
+    const result = await searchConversations("updater", { limit: 2 });
+
+    expect(result.hits.map((item) => item.messageId)).toEqual(["m1", "m2"]);
+    expect(result.semanticUnavailable).toBe(false);
+  });
+
+  it("dedupes the same chunk returned by exact and semantic paths", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "search_conversations_fts") {
+        return Promise.resolve([hit("m1")]);
+      }
+      return Promise.resolve([hit("m1"), hit("m2")]);
+    });
+    embedTextMock.mockResolvedValue([0.1, 0.2]);
+
+    const result = await searchConversations("updater", { limit: 10 });
+
+    expect(result.hits.map((item) => item.messageId)).toEqual(["m1", "m2"]);
+    expect(result.hits.map((item) => item.matchType)).toEqual([
+      "exact",
+      "semantic",
+    ]);
+  });
+});

--- a/tests/unit/highlight.test.ts
+++ b/tests/unit/highlight.test.ts
@@ -1,0 +1,43 @@
+// ABOUTME: Tests for safe search-result highlighting.
+// ABOUTME: Verifies literal query handling without innerHTML.
+
+import { describe, expect, it } from "vitest";
+import { highlightTerms } from "@/lib/highlight";
+
+describe("highlightTerms", () => {
+  it("returns plain text for an empty query", () => {
+    expect(highlightTerms("hello world", "")).toEqual(["hello world"]);
+  });
+
+  it("wraps a single matching term", () => {
+    expect(highlightTerms("hello world", "world")).toEqual([
+      "hello ",
+      { mark: "world" },
+    ]);
+  });
+
+  it("matches case-insensitively while preserving source case", () => {
+    expect(highlightTerms("Updater Signing", "signing")).toEqual([
+      "Updater ",
+      { mark: "Signing" },
+    ]);
+  });
+
+  it("treats regex metacharacters literally", () => {
+    expect(highlightTerms("call foo.*(bar) now", "foo.*(bar)")).toEqual([
+      "call ",
+      { mark: "foo.*(bar)" },
+      " now",
+    ]);
+  });
+
+  it("returns the whole string when there is no match", () => {
+    expect(highlightTerms("hello world", "missing")).toEqual(["hello world"]);
+  });
+
+  it("merges overlapping and adjacent matches", () => {
+    expect(highlightTerms("signing", "sign signing")).toEqual([
+      { mark: "signing" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds first-class **content search over chat + agent conversation history**, reachable in one keystroke (`⌘⇧H`), matching a hit anywhere in the full exchange — prompts, assistant/agent output, and conversation titles. Two retrieval paths run together: **exact** (SQLite FTS5, bm25-ranked, works offline/unauthenticated) and **semantic** (sqlite-vec KNN over `text-embedding-3-small`, degrading to exact when embeddings/auth are down). Clicking a hit opens the thread and scrolls to (and briefly highlights) the matching message.

Closes #2789. Design: `docs/plans/20260701_Conversation_History_Search_Design.md`; plan: `docs/plans/20260701_Conversation_History_Search.md`.

## What's included

**Rust — local index (`indexes/conversations.db`, mirrors the transcript vector stack):**
- `services/conversation_index.rs` — `conv_chunks` (denormalized `kind`/`role`/`title`/`agent_type`/`project_root`/`is_archived`/`timestamp` so both paths filter + display in SQL), `conv_fts` (plain FTS5, `rowid == chunk id`), `conv_embeddings` (`vec0` float[1536]). Rust-only chunker with a per-message chunk **cap** (bounds cost — real history has an 11.7M-char message). Title folded into the FTS document so title-only matches work. FTS query sanitizer wraps terms as phrases so operators (`AND`/`*`/`"`/`NEAR(`) are literal and never error.
- `commands/conversation_search.rs` — `search_conversations_fts`, `search_conversations` (KNN), `index_conversation_embeddings`, `unembedded_conversation_chunks`, `delete_conversation_index`, `update_conversation_index_meta`, `backfill_conversation_fts`. Registered in `lib.rs`.
- Index-on-write in `save_message` (reads the **derived** kind via `provider_session_runtime` so it matches the sidebar; index write runs best-effort **outside** the DB pool lock so a failure never fails a save). Delete/clear/archive/rename hooks keep the index in sync. Historical backfill is idempotent.

**Frontend:**
- `services/conversation-search.ts` — runs exact (always) + semantic, merges exact-first + dedupes by `messageId:seq`, degrades with a classified reason, never throws. Retry-capped embedding backfill.
- `stores/conversation-search.store.ts` — one store backs both surfaces; debounced search with a stale-request guard.
- `components/search/ConversationSearchOverlay.tsx` (spotlight, `⌘⇧H`) + `ConversationSearchResults.tsx` (grouped full pane via "See all results"). `lib/highlight.ts` returns renderable segments (no `innerHTML`). No pill/chip look.
- `⌘⇧H` registered in `keybindings.store`/`shortcuts` (user-remappable; fires even while a text input is focused). Sidebar "Search history" entry. `data-message-id` anchors + a scroll effect that re-fires as messages hydrate after the thread loads.

## Verification

- `cargo check`: clean (only pre-existing warnings). `cargo test`: 10/10 conversation-index tests (FTS5 availability, bm25 ranking, injection-safe query, title match, semantic ranking, filters on both paths, delete/reindex cascade, meta update, chunk cap).
- `pnpm test`: **2165 passing** (incl. new highlight + service merge/degrade/dedupe suites). `tsc`: no new errors. `biome check`: clean on all touched files.
- **E2E** (`tests/e2e/conversation-search.spec.ts`, 3/3 against the vite frontend): sidebar/keybinding opens the overlay + focuses input, a query degrades gracefully to a no-results state with no crash (browser-fallback contract), Esc closes.

## Networked path

Semantic search POSTs the query embedding to `${apiBase}/publishers/openai-embeddings/embeddings` (via `services/seren-embed.ts`) — the same paid publisher the shipped meetings transcript search already uses; verified from code and by that production feature. (Live publisher-list confirmation via the Seren MCP could not run this session — the `seren-mcp` server did not finish connecting.)

## Caveats / follow-ups

- The full-Tauri happy path (real SQLite index → highlighted hits → click-to-scroll) was **not** run headlessly here; it's covered by the Rust/service/highlight unit tests and the browser-mode E2E. Recommend a manual `pnpm tauri dev` pass on a populated DB.
- Scroll-to-message no-ops gracefully when the target is older than the loaded window (chat caps at 1000, agent at 200; `getMessages` has no offset — load-around is out of scope).
- A crate-wide `cargo fmt` (30+ unrelated files) was intentionally **excluded** from this PR to keep it focused.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
