### PR TITLE
chore(rust): eliminate 7 dead_code warnings in src-tauri (#2792)

### DIFF
--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -2935,6 +2935,7 @@ fn clean_native_context_text(value: &str, max_chars: usize) -> Option<String> {
     (!cleaned.is_empty()).then(|| cleaned.to_string())
 }
 
+#[cfg(any(target_os = "windows", test))]
 fn app_name_from_process_path(path: &str) -> Option<String> {
     let file_name = path
         .rsplit(['\\', '/'])

--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -1,6 +1,7 @@
 // ABOUTME: Configures embedded Node.js and Git runtime paths at application startup.
 // ABOUTME: Stores bundled runtime directories for injection into child process environments.
 
+#[cfg(any(target_os = "windows", test))]
 use serde::Serialize;
 use std::env;
 use std::path::PathBuf;
@@ -24,6 +25,7 @@ pub struct EmbeddedRuntimePaths {
     pub python_dir: Option<PathBuf>,
 }
 
+#[cfg(any(target_os = "windows", test))]
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RuntimeHealthIssue {
     pub component: String,
@@ -31,6 +33,7 @@ pub struct RuntimeHealthIssue {
     pub remediation: String,
 }
 
+#[cfg(any(target_os = "windows", test))]
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RuntimeHealthReport {
     pub ok: bool,
@@ -38,6 +41,7 @@ pub struct RuntimeHealthReport {
     pub issues: Vec<RuntimeHealthIssue>,
 }
 
+#[cfg(any(target_os = "windows", test))]
 impl RuntimeHealthReport {
     pub fn to_error_message(&self) -> String {
         if self.ok {
@@ -67,6 +71,7 @@ impl RuntimeHealthReport {
 /// debugging from inside the user's paid turn. Windows is intentionally
 /// fail-closed because it does not have reliable system Python/Node fallback
 /// semantics for skill execution.
+#[cfg(any(target_os = "windows", test))]
 pub fn runtime_health_report_for_os(
     platform: &str,
     paths: &EmbeddedRuntimePaths,

--- a/src-tauri/src/orchestrator/trust.rs
+++ b/src-tauri/src/orchestrator/trust.rs
@@ -116,58 +116,6 @@ pub(crate) struct ModelStats {
     cost_count: u32,
 }
 
-/// Compute Thompson sampling rankings for available models given a task type.
-///
-/// For each model:
-/// 1. Query time-decayed positive/negative counts from eval_signals
-/// 2. Sample from Beta(positive + 1, negative + 1)
-/// 3. Apply cost penalty: score = sample - (cost_weight * normalized_cost)
-///
-/// Models with no data get Beta(1,1) = uniform random [0,1] (exploration).
-/// Returns rankings sorted by score descending.
-pub fn get_model_rankings<R: Rng>(
-    conn: &Connection,
-    rng: &mut R,
-    task_type: &str,
-    available_models: &[String],
-    cost_weight: f64,
-) -> Vec<ModelRanking> {
-    if available_models.is_empty() {
-        return vec![];
-    }
-
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as i64;
-
-    let stats = load_model_stats_at(conn, task_type, available_models, now);
-    sample_model_rankings(rng, available_models, &stats, None, cost_weight)
-}
-
-/// Compute Thompson sampling rankings with best-effort community priors.
-pub fn get_model_rankings_with_community_priors<R: Rng>(
-    conn: &Connection,
-    rng: &mut R,
-    task_type: &str,
-    available_models: &[String],
-    community_priors: &HashMap<String, CommunityPrior>,
-    cost_weight: f64,
-) -> Vec<ModelRanking> {
-    if available_models.is_empty() {
-        return vec![];
-    }
-
-    let stats = load_model_stats(conn, task_type, available_models);
-    sample_model_rankings(
-        rng,
-        available_models,
-        &stats,
-        Some(community_priors),
-        cost_weight,
-    )
-}
-
 /// Load time-decayed local stats from SQLite for the ranking sampler.
 pub(crate) fn load_model_stats(
     conn: &Connection,
@@ -575,7 +523,8 @@ mod tests {
     }
 
     // =========================================================================
-    // Thompson Sampling — get_model_rankings
+    // Thompson Sampling — load_model_stats + sample_model_rankings
+    // (the live production composition used in orchestrator::service)
     // =========================================================================
 
     #[test]
@@ -584,7 +533,8 @@ mod tests {
         let mut rng = seeded_rng();
         let models = vec!["model-a".to_string(), "model-b".to_string()];
 
-        let rankings = get_model_rankings(&conn, &mut rng, "general_chat", &models, 0.1);
+        let stats = load_model_stats(&conn, "general_chat", &models);
+        let rankings = sample_model_rankings(&mut rng, &models, &stats, None, 0.1);
         assert_eq!(rankings.len(), 2);
         // Both should have scores (from Beta(1,1) uniform sampling)
         for r in &rankings {
@@ -596,7 +546,9 @@ mod tests {
     fn ranking_empty_models_returns_empty() {
         let conn = setup_test_db();
         let mut rng = seeded_rng();
-        let rankings = get_model_rankings(&conn, &mut rng, "general_chat", &[], 0.1);
+        let models: Vec<String> = vec![];
+        let stats = load_model_stats(&conn, "general_chat", &models);
+        let rankings = sample_model_rankings(&mut rng, &models, &stats, None, 0.1);
         assert!(rankings.is_empty());
     }
 
@@ -637,7 +589,8 @@ mod tests {
         let mut good_first_count = 0;
         for seed in 0..20 {
             let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-            let rankings = get_model_rankings(&conn, &mut rng, "code_generation", &models, 0.0);
+            let stats = load_model_stats(&conn, "code_generation", &models);
+            let rankings = sample_model_rankings(&mut rng, &models, &stats, None, 0.0);
             if rankings[0].model_id == "model-good" {
                 good_first_count += 1;
             }
@@ -688,7 +641,8 @@ mod tests {
         let mut recent_first = 0;
         for seed in 0..30 {
             let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-            let rankings = get_model_rankings(&conn, &mut rng, "general_chat", &models, 0.0);
+            let stats = load_model_stats(&conn, "general_chat", &models);
+            let rankings = sample_model_rankings(&mut rng, &models, &stats, None, 0.0);
             if rankings[0].model_id == "model-recent" {
                 recent_first += 1;
             }
@@ -736,7 +690,8 @@ mod tests {
         let mut cheap_first = 0;
         for seed in 0..30 {
             let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-            let rankings = get_model_rankings(&conn, &mut rng, "general_chat", &models, 0.1);
+            let stats = load_model_stats(&conn, "general_chat", &models);
+            let rankings = sample_model_rankings(&mut rng, &models, &stats, None, 0.1);
             if rankings[0].model_id == "model-cheap" {
                 cheap_first += 1;
             }
@@ -800,24 +755,24 @@ mod tests {
             prior(1000.0, 1.0, 50),
         );
 
+        let stats = load_model_stats(&conn, "general_chat", &models);
         let mut local_first_without_prior = 0;
         let mut community_first_with_prior = 0;
 
         for seed in 0..20 {
             let mut local_rng = rand::rngs::StdRng::seed_from_u64(seed);
             let local_rankings =
-                get_model_rankings(&conn, &mut local_rng, "general_chat", &models, 0.0);
+                sample_model_rankings(&mut local_rng, &models, &stats, None, 0.0);
             if local_rankings[0].model_id == "model-local-favorite" {
                 local_first_without_prior += 1;
             }
 
             let mut blended_rng = rand::rngs::StdRng::seed_from_u64(seed);
-            let blended_rankings = get_model_rankings_with_community_priors(
-                &conn,
+            let blended_rankings = sample_model_rankings(
                 &mut blended_rng,
-                "general_chat",
                 &models,
-                &community_priors,
+                &stats,
+                Some(&community_priors),
                 0.0,
             );
             if blended_rankings[0].model_id == "model-community-favorite" {
@@ -843,16 +798,16 @@ mod tests {
         // the same rankings as the local-only path given the same local stats
         // and the same RNG state.
         //
-        // The earlier shape of this test compared two top-level wrappers —
-        // `get_model_rankings` and `get_model_rankings_with_community_priors`
-        // — which each capture their own `SystemTime::now()` inside
-        // `load_model_stats[_at]`. The two `now` values drift by microseconds
-        // between calls; the resulting decay-weighted alpha/beta drift too,
-        // producing different Beta-distribution samples from otherwise
-        // identical seeded RNGs. That made the test flaky in CI (#2033).
+        // The earlier shape of this test compared two top-level ranking
+        // wrappers (since removed) that each captured their own
+        // `SystemTime::now()` inside `load_model_stats[_at]`. The two `now`
+        // values drift by microseconds between calls; the resulting
+        // decay-weighted alpha/beta drift too, producing different
+        // Beta-distribution samples from otherwise identical seeded RNGs. That
+        // made the test flaky in CI (#2033).
         //
-        // The fallback contract lives at the sampler, not at the wrappers, so
-        // assert it there with identical stats and identical seeded RNG state.
+        // The fallback contract lives at the sampler, so assert it there with
+        // identical stats and identical seeded RNG state.
         let mut stats: HashMap<String, ModelStats> = HashMap::new();
         stats.insert(
             "model-good".to_string(),


### PR DESCRIPTION
## Summary

Eliminates the **7 `dead_code` warnings** `cargo check` emits from the `seren-desktop` lib crate on `main`. The 7 warnings came from **three distinct causes**, each fixed at its real root rather than by blanket deletion.

Closes #2792.

### Group A — Windows-only caller not `cfg`-gated (`recording.rs`, warning #1)
`app_name_from_process_path` is **live on Windows** — its only caller, `windows_process_app_name`, is `#[cfg(target_os = "windows")]`. On macOS/Linux the caller compiles out, so the ungated helper looked dead. Gated it to `#[cfg(any(target_os = "windows", test))]` so it compiles exactly where it's used (Windows runtime + cross-platform tests).

### Group B — Windows-only health-check API not `cfg`-gated (`embedded_runtime.rs`, warnings #2–#5)
`RuntimeHealthIssue` / `RuntimeHealthReport` / `to_error_message` / `runtime_health_report_for_os` are consumed only inside the `#[cfg(target_os = "windows")]` block of `runtime_health_error_for_chat` (`chat_model_worker.rs`) — the intentional Windows fail-closed runtime gate. Applied the same `#[cfg(any(target_os = "windows", test))]` gate to all four items **and** to the `serde::Serialize` import they alone use (otherwise the import becomes newly-unused on non-Windows). Windows behavior and the tests are unchanged.

### Group C — genuinely dead redundant wrappers (`trust.rs`, warnings #6–#7)
`get_model_rankings` and `get_model_rankings_with_community_priors` have **no production callers** — the orchestrator composes `trust::load_model_stats` + `trust::sample_model_rankings` directly (`service.rs:225` / `:254`). Removed both wrappers.

**Test handling (deviates from the issue, with Taariq's explicit approval):** the issue proposed deleting the wrapper tests. But 3 of them (`ranking_prefers_high_satisfaction_model`, `ranking_applies_time_decay`, `ranking_penalizes_expensive_model`) cover live, billing-relevant ranking-algorithm behavior that runs through `sample_model_rankings` — the wrapper was just the entry point they happened to call. Rather than delete and lose that coverage, they're **repointed to the live `load_model_stats` + `sample_model_rankings` composition** (the same path `service.rs` uses). This mirrors the #2033 move that put the fallback contract on the sampler. The 2 trivial guard tests and the community-prior-shift test were repointed the same way. Net: dead wrappers gone, coverage preserved.

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml` → **0 warnings** (was 7).
- `cargo test` (macOS host): `trust::` 17 passed, `embedded_runtime::` 6 passed (incl. both `windows_runtime_health_*` tests via the `cfg(test)` gate), `recording::` 46 passed (incl. `process_paths_map_to_app_names`).
- **Windows safety of the `cfg` gates:** the gates are `any(target_os = "windows", test)`, i.e. a no-op superset on Windows — Groups A/B compile byte-for-byte as before on Windows and their Windows callers are intact, so Windows warnings can only *decrease* (the two Group C wrapper warnings, which were dead on Windows too, go away). Empirical Windows confirmation via the CI Windows job on this PR.

## Networked path

**Not applicable.** The changed symbols (`app_name_from_process_path`, the runtime-health structs/fns, the ranking sampler composition) touch only local OS calls, local filesystem paths, and local SQLite reads — no publisher/API slug, method, or path is involved. Verified by grepping the changed regions for any HTTP/reqwest/gateway/publisher/IPC surface (none).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
