### PR TITLE
fix(oauth): route Gateway tool calls to the owning run's account

### DIFF
--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -1483,6 +1483,7 @@ created if missing.",
     /// call `submit_tool_result` with the result.
     async fn execute_frontend_tool(
         app: &tauri::AppHandle,
+        conversation_id: &str,
         tool_call_id: &str,
         name: &str,
         arguments: &str,
@@ -1501,8 +1502,12 @@ created if missing.",
             tool_call_id
         );
 
-        // Emit a tool execution request to the frontend
+        // Emit a tool execution request to the frontend. The owning conversation
+        // id lets the frontend resolve per-thread state (e.g. the selected OAuth
+        // account) against the run that issued the call, not whichever chat the
+        // user happens to be viewing when a background run reaches a tool.
         let payload = serde_json::json!({
+            "conversation_id": conversation_id,
             "tool_call_id": tool_call_id,
             "name": name,
             "arguments": arguments,
@@ -1550,7 +1555,7 @@ impl Worker for ChatModelWorker {
 
     async fn execute(
         &self,
-        _conversation_id: &str,
+        conversation_id: &str,
         prompt: &str,
         conversation_context: &[serde_json::Value],
         routing: &RoutingDecision,
@@ -1874,7 +1879,14 @@ impl Worker for ChatModelWorker {
                         } else {
                             // Route non-local tools (gateway__, mcp__)
                             // to the frontend for execution via the tool bridge.
-                            Self::execute_frontend_tool(app, &tc.id, &tc.name, &tc.arguments).await
+                            Self::execute_frontend_tool(
+                                app,
+                                conversation_id,
+                                &tc.id,
+                                &tc.name,
+                                &tc.arguments,
+                            )
+                            .await
                         };
 
                         // Emit ToolResult event to frontend

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -141,6 +141,7 @@ async function requestGatewayApproval(
   publisherSlug: string,
   toolName: string,
   args: Record<string, unknown>,
+  conversationId: string | null,
 ): Promise<GatewayApprovalResult> {
   const approvalId = `gateway-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const requirement = getApprovalRequirement(publisherSlug, toolName);
@@ -156,7 +157,7 @@ async function requestGatewayApproval(
       publisherSlug,
       toolName,
       args,
-      threadId: conversationStore.activeConversationId,
+      threadId: conversationId ?? conversationStore.activeConversationId,
       description: requirement?.description || "Execute operation",
       isDestructive: requirement?.isDestructive || false,
     });
@@ -204,6 +205,7 @@ async function resolveGatewayOAuthConnectionArgs(
   publisherSlug: string,
   toolName: string,
   args: Record<string, unknown>,
+  conversationId: string | null,
 ): Promise<GatewayConnectionArgsResult> {
   if (typeof args.connection_id === "string" && args.connection_id.length > 0) {
     return { args };
@@ -220,7 +222,7 @@ async function resolveGatewayOAuthConnectionArgs(
     );
     if (providerConnections.length === 0) return { args };
 
-    const threadId = conversationStore.activeConversationId;
+    const threadId = conversationId ?? conversationStore.activeConversationId;
     const selected = resolveThreadOAuthConnection(
       threadId,
       provider.providerSlug,
@@ -316,7 +318,10 @@ async function requestShellApproval(
  * Execute a single tool call and return the result.
  * Routes to MCP servers or file tools based on prefix.
  */
-export async function executeTool(toolCall: ToolCall): Promise<ToolResult> {
+export async function executeTool(
+  toolCall: ToolCall,
+  conversationId: string | null = null,
+): Promise<ToolResult> {
   const { name, arguments: argsJson } = toolCall.function;
 
   try {
@@ -348,6 +353,7 @@ export async function executeTool(toolCall: ToolCall): Promise<ToolResult> {
         gatewayInfo.publisherSlug,
         gatewayInfo.toolName,
         args,
+        conversationId,
       );
     }
 
@@ -659,6 +665,7 @@ async function executeGatewayTool(
   publisherSlug: string,
   toolName: string,
   args: Record<string, unknown>,
+  conversationId: string | null,
 ): Promise<ToolResult> {
   try {
     let callArgs = args;
@@ -672,6 +679,7 @@ async function executeGatewayTool(
         publisherSlug,
         toolName,
         args,
+        conversationId,
       );
 
       if (!approval.approved) {
@@ -694,6 +702,7 @@ async function executeGatewayTool(
       publisherSlug,
       toolName,
       callArgs,
+      conversationId,
     );
     if (resolvedArgs.error) {
       return {

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -139,6 +139,7 @@ interface SkillRef {
 
 /** Tool execution request emitted by the Rust ChatModelWorker for non-local tools. */
 interface ToolExecutionRequest {
+  conversation_id: string;
   tool_call_id: string;
   name: string;
   arguments: string;
@@ -1131,14 +1132,17 @@ async function handleToolRequest(request: ToolExecutionRequest): Promise<void> {
   );
 
   try {
-    const result = await executeTool({
-      id: request.tool_call_id,
-      type: "function",
-      function: {
-        name: request.name,
-        arguments: request.arguments,
+    const result = await executeTool(
+      {
+        id: request.tool_call_id,
+        type: "function",
+        function: {
+          name: request.name,
+          arguments: request.arguments,
+        },
       },
-    });
+      request.conversation_id,
+    );
 
     await invoke("submit_tool_result", {
       toolCallId: result.tool_call_id,

--- a/tests/unit/tool-executor-oauth-account.test.ts
+++ b/tests/unit/tool-executor-oauth-account.test.ts
@@ -77,6 +77,7 @@ describe("tool executor OAuth account routing", () => {
       "@/stores/oauth-account.store"
     );
     setThreadOAuthConnectionId("thread-1", "google", null);
+    setThreadOAuthConnectionId("thread-2", "google", null);
     mocks.resolveOAuthProviderForPublisher.mockResolvedValue({
       publisherSlug: "gmail",
       providerSlug: "google",
@@ -109,6 +110,36 @@ describe("tool executor OAuth account routing", () => {
         arguments: JSON.stringify({ q: "from:example" }),
       },
     });
+
+    expect(result.is_error).toBe(false);
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith("gmail", "messages", {
+      q: "from:example",
+      connection_id: "conn-google-personal",
+    });
+  });
+
+  it("resolves the owning run's OAuth account, not the chat the user is viewing", async () => {
+    const [{ executeTool }, { setThreadOAuthConnectionId }] =
+      await Promise.all([
+        import("@/lib/tools/executor"),
+        import("@/stores/oauth-account.store"),
+      ]);
+    // The user is viewing thread-1 (active) with the work account selected,
+    // while a background run in thread-2 selected the personal account.
+    setThreadOAuthConnectionId("thread-1", "google", "conn-google-work");
+    setThreadOAuthConnectionId("thread-2", "google", "conn-google-personal");
+
+    const result = await executeTool(
+      {
+        id: "tool-call-owning",
+        type: "function",
+        function: {
+          name: "gateway__gmail__messages",
+          arguments: JSON.stringify({ q: "from:example" }),
+        },
+      },
+      "thread-2",
+    );
 
     expect(result.is_error).toBe(false);
     expect(mocks.callGatewayTool).toHaveBeenCalledWith("gmail", "messages", {


### PR DESCRIPTION
## Summary

Fixes #2795 (CRITICAL, blocks v3.67.0).

The multi-account publisher routing shipped in #2791 resolved the OAuth account for a Gateway tool call from `conversationStore.activeConversationId` — the chat the user is *currently viewing* — instead of the conversation that *owns the running tool call*. During a background agent run that overlaps a chat switch, a tool call could execute under the **wrong connected account's token** (e.g. read/send from the wrong Gmail account). It was silent for read tools; for approval tools the dialog also preselected the wrong account.

## Root cause

`orchestrator://tool-request` events carried no owning conversation id, so the frontend had to fall back to the globally-active chat. `activeStreams` is keyed by conversationId (concurrent per-conversation runs are supported), and `setActiveConversation` does not cancel a running orchestration — so the active id legitimately diverges from the run that issued a tool call.

## Fix

Thread the owning `conversation_id` end-to-end:

- **Rust** (`chat_model_worker.rs`): include `conversation_id` in the tool-request payload, using the (previously unused) `conversation_id` param already on `Worker::execute`.
- **Frontend** (`orchestrator.ts`): add `conversation_id` to `ToolExecutionRequest`; `handleToolRequest` forwards it to `executeTool`.
- **Frontend** (`executor.ts`): `executeTool`/`executeGatewayTool` pass an owning-conversation id into `requestGatewayApproval` and `resolveGatewayOAuthConnectionArgs`, which use it instead of the active id. Falls back to `activeConversationId` when unset, preserving behavior for other callers.

## Tests

- New regression test in `tool-executor-oauth-account.test.ts`: a tool call owned by `thread-2` resolves thread-2's account even when the active chat (`thread-1`) has a different account selected. Fails without the fix.
- Full suite green: 2166 frontend unit tests pass; `cargo check` clean.
