### PR TITLE
Fix AppShell recovery blanking chat threads

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -6,6 +6,7 @@ import {
   createEffect,
   createSignal,
   ErrorBoundary,
+  type JSX,
   Match,
   on,
   onCleanup,
@@ -140,6 +141,90 @@ const PERSISTABLE_VIEWS: ReadonlySet<NonNullable<SlidePanelView>> = new Set([
   "meetings",
   "skills",
 ]);
+
+interface ShellRecoveryFallbackProps {
+  title: string;
+  message: string;
+  compact?: boolean;
+  className?: string;
+  onRetry?: () => void;
+}
+
+const ShellRecoveryFallback: Component<ShellRecoveryFallbackProps> = (
+  props,
+) => (
+  <div
+    role="alert"
+    class={[
+      "flex flex-col items-center justify-center gap-3 p-4 text-center",
+      props.compact
+        ? "min-h-[var(--titlebar-height,40px)]"
+        : "h-full min-h-[220px]",
+      props.className ?? "",
+    ].join(" ")}
+  >
+    <div class="text-sm font-semibold text-foreground">{props.title}</div>
+    <div class="max-w-md text-[13px] text-muted-foreground">
+      {props.message}
+    </div>
+    <Show when={props.onRetry}>
+      <button
+        type="button"
+        class="rounded border border-border bg-card px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-surface-2"
+        onClick={() => props.onRetry?.()}
+      >
+        Retry
+      </button>
+    </Show>
+  </div>
+);
+
+function reportShellBoundaryError(surface: string, error: unknown): void {
+  telemetry.reportError(
+    error instanceof Error ? error : new Error(String(error)),
+    { surface: `app_shell_${surface}` },
+  );
+}
+
+interface ShellSurfaceBoundaryProps {
+  surface: string;
+  title: string;
+  message: string;
+  compact?: boolean;
+  children: JSX.Element;
+}
+
+const ShellSurfaceBoundary: Component<ShellSurfaceBoundaryProps> = (props) => (
+  <ErrorBoundary
+    fallback={(error, reset) => {
+      reportShellBoundaryError(props.surface, error);
+      return (
+        <ShellRecoveryFallback
+          title={props.title}
+          message={props.message}
+          compact={props.compact}
+          onRetry={reset}
+        />
+      );
+    }}
+  >
+    {props.children}
+  </ErrorBoundary>
+);
+
+const ShellSilentBoundary: Component<{
+  surface: string;
+  children: JSX.Element;
+}> = (props) => (
+  <ErrorBoundary
+    fallback={(error) => {
+      reportShellBoundaryError(props.surface, error);
+      return null;
+    }}
+  >
+    {props.children}
+  </ErrorBoundary>
+);
 
 function loadInitialSlidePanel(): SlidePanelView {
   try {
@@ -919,143 +1004,180 @@ export const AppShell: Component<AppShellProps> = (props) => {
 
   return (
     <div class="flex flex-col h-screen bg-background text-foreground">
-      <Titlebar
-        onSignInClick={handleSignInClick}
-        onToggleMeetings={handleToggleMeetings}
-        onToggleSkills={handleToggleSkills}
-        onToggleSettings={handleToggleSettings}
-        meetingRecording={meetingRecording()}
-        meetingProcessing={meetingProcessing()}
-        meetingReady={meetingReady()}
-        recordPromptVisible={recordPromptVisible()}
-        recordPromptSourceApp={meetingStore.state.autoDetectSourceApp}
-        onRecordConversation={() => void meetingStore.acceptAutoDetect()}
-        onDismissRecordPrompt={() => meetingStore.dismissAutoDetect()}
-      />
+      <ShellSurfaceBoundary
+        surface="titlebar"
+        title="Titlebar is recovering."
+        message="Workspace controls hit an error, but chats remain available."
+        compact
+      >
+        <Titlebar
+          onSignInClick={handleSignInClick}
+          onToggleMeetings={handleToggleMeetings}
+          onToggleSkills={handleToggleSkills}
+          onToggleSettings={handleToggleSettings}
+          meetingRecording={meetingRecording()}
+          meetingProcessing={meetingProcessing()}
+          meetingReady={meetingReady()}
+          recordPromptVisible={recordPromptVisible()}
+          recordPromptSourceApp={meetingStore.state.autoDetectSourceApp}
+          onRecordConversation={() => void meetingStore.acceptAutoDetect()}
+          onDismissRecordPrompt={() => meetingStore.dismissAutoDetect()}
+        />
+      </ShellSurfaceBoundary>
 
       <div class="flex flex-1 overflow-hidden relative">
-        <ThreadSidebar
-          collapsed={sidebarCollapsed()}
-          onToggle={() => setSidebarCollapsed((v) => !v)}
-          onOpenCatalog={handleOpenCatalog}
-          onOpenInbox={handleOpenInbox}
-        />
+        <ErrorBoundary
+          fallback={(error, reset) => {
+            reportShellBoundaryError("thread_sidebar", error);
+            return (
+              <aside
+                data-testid="thread-sidebar-recovery"
+                class="thread-list-surface flex flex-col bg-card border-r border-border overflow-hidden"
+                classList={{
+                  "w-[var(--sidebar-width)] min-w-[var(--sidebar-width)]":
+                    !sidebarCollapsed(),
+                  "w-9 min-w-9": sidebarCollapsed(),
+                }}
+              >
+                <ShellRecoveryFallback
+                  title="Threads are recovering."
+                  message="Thread navigation hit an error. The workspace is still running."
+                  onRetry={reset}
+                />
+              </aside>
+            );
+          }}
+        >
+          <ThreadSidebar
+            collapsed={sidebarCollapsed()}
+            onToggle={() => setSidebarCollapsed((v) => !v)}
+            onOpenCatalog={handleOpenCatalog}
+            onOpenInbox={handleOpenInbox}
+          />
+        </ErrorBoundary>
 
         <main class="flex-1 overflow-auto flex flex-col min-w-0">
-          <Show
-            when={conversationSearchStore.state.mode === "full"}
-            fallback={
-              <Show
-                when={interviewLandingOpen()}
-                fallback={
-                  <Show
-                    when={inboxOpen()}
-                    fallback={
-                      <Show
-                        when={catalogOpen()}
-                        fallback={
-                          <Show
-                            when={activeEmployeeId()}
-                            fallback={
-                              <Show
-                                when={activeBountyId()}
-                                fallback={
-                                  <ThreadContent
-                                    onSignInClick={handleSignInClick}
-                                  />
-                                }
-                              >
-                                {(id) => (
-                                  <BountyDetail
-                                    bountyId={id()}
-                                    inheritFrom={activeBountyInheritFrom()}
-                                  />
-                                )}
-                              </Show>
-                            }
-                          >
-                            {(id) => (
-                              <Show
-                                when={
-                                  employeeStore.byId(id()) === undefined &&
-                                  employeeStore.archivedById(id()) !== undefined
-                                }
-                                fallback={
-                                  <EmployeeDetail
+          <ShellSurfaceBoundary
+            surface="main"
+            title="Workspace is recovering."
+            message="This view hit an error. Threads and navigation remain available."
+          >
+            <Show
+              when={conversationSearchStore.state.mode === "full"}
+              fallback={
+                <Show
+                  when={interviewLandingOpen()}
+                  fallback={
+                    <Show
+                      when={inboxOpen()}
+                      fallback={
+                        <Show
+                          when={catalogOpen()}
+                          fallback={
+                            <Show
+                              when={activeEmployeeId()}
+                              fallback={
+                                <Show
+                                  when={activeBountyId()}
+                                  fallback={
+                                    <ThreadContent
+                                      onSignInClick={handleSignInClick}
+                                    />
+                                  }
+                                >
+                                  {(id) => (
+                                    <BountyDetail
+                                      bountyId={id()}
+                                      inheritFrom={activeBountyInheritFrom()}
+                                    />
+                                  )}
+                                </Show>
+                              }
+                            >
+                              {(id) => (
+                                <Show
+                                  when={
+                                    employeeStore.byId(id()) === undefined &&
+                                    employeeStore.archivedById(id()) !==
+                                      undefined
+                                  }
+                                  fallback={
+                                    <EmployeeDetail
+                                      employeeId={id()}
+                                      onClose={closeEmployeeDetailPane}
+                                    />
+                                  }
+                                >
+                                  <ArchivedEmployeeDetail
                                     employeeId={id()}
                                     onClose={closeEmployeeDetailPane}
                                   />
-                                }
-                              >
-                                <ArchivedEmployeeDetail
-                                  employeeId={id()}
-                                  onClose={closeEmployeeDetailPane}
-                                />
-                              </Show>
-                            )}
-                          </Show>
-                        }
-                      >
-                        <ErrorBoundary
-                          fallback={(error) => {
-                            telemetry.reportError(
-                              error instanceof Error
-                                ? error
-                                : new Error(String(error)),
-                              { surface: "agent_catalog" },
-                            );
-                            return (
-                              <div class="flex h-full min-h-[320px] flex-col items-center justify-center gap-3 p-6 text-center">
-                                <div class="text-sm font-semibold text-foreground">
-                                  Agent catalog is recovering.
-                                </div>
-                                <div class="max-w-md text-[13px] text-muted-foreground">
-                                  The catalog view hit an unexpected entry, but
-                                  the rest of Seren is still available.
-                                </div>
-                                <button
-                                  type="button"
-                                  class="rounded border border-border bg-card px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-surface-2"
-                                  onClick={handleCloseCatalog}
-                                >
-                                  Back to workspace
-                                </button>
-                              </div>
-                            );
-                          }}
+                                </Show>
+                              )}
+                            </Show>
+                          }
                         >
-                          <CatalogList />
-                        </ErrorBoundary>
-                      </Show>
-                    }
-                  >
-                    <InboxList />
-                  </Show>
-                }
-              >
-                <InterviewLanding
-                  initialEmployeeSlug={interviewEmployeeSlug()}
-                  onClose={closeInterviewLanding}
-                  onSelectEmployee={(employeeSlug) => {
-                    reportInterviewInterest(
-                      employeeSlug,
-                      "desktop-role-selection",
-                      "role-selected",
-                    );
-                  }}
-                  onStartInterview={(employeeSlug) => {
-                    reportInterviewInterest(
-                      employeeSlug,
-                      "desktop-interview-start",
-                      "interview-started",
-                    );
-                  }}
-                />
-              </Show>
-            }
-          >
-            <ConversationSearchResults />
-          </Show>
+                          <ErrorBoundary
+                            fallback={(error) => {
+                              telemetry.reportError(
+                                error instanceof Error
+                                  ? error
+                                  : new Error(String(error)),
+                                { surface: "agent_catalog" },
+                              );
+                              return (
+                                <div class="flex h-full min-h-[320px] flex-col items-center justify-center gap-3 p-6 text-center">
+                                  <div class="text-sm font-semibold text-foreground">
+                                    Agent catalog is recovering.
+                                  </div>
+                                  <div class="max-w-md text-[13px] text-muted-foreground">
+                                    The catalog view hit an unexpected entry,
+                                    but the rest of Seren is still available.
+                                  </div>
+                                  <button
+                                    type="button"
+                                    class="rounded border border-border bg-card px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-surface-2"
+                                    onClick={handleCloseCatalog}
+                                  >
+                                    Back to workspace
+                                  </button>
+                                </div>
+                              );
+                            }}
+                          >
+                            <CatalogList />
+                          </ErrorBoundary>
+                        </Show>
+                      }
+                    >
+                      <InboxList />
+                    </Show>
+                  }
+                >
+                  <InterviewLanding
+                    initialEmployeeSlug={interviewEmployeeSlug()}
+                    onClose={closeInterviewLanding}
+                    onSelectEmployee={(employeeSlug) => {
+                      reportInterviewInterest(
+                        employeeSlug,
+                        "desktop-role-selection",
+                        "role-selected",
+                      );
+                    }}
+                    onStartInterview={(employeeSlug) => {
+                      reportInterviewInterest(
+                        employeeSlug,
+                        "desktop-interview-start",
+                        "interview-started",
+                      );
+                    }}
+                  />
+                </Show>
+              }
+            >
+              <ConversationSearchResults />
+            </Show>
+          </ShellSurfaceBoundary>
         </main>
 
         <SlidePanel
@@ -1065,94 +1187,104 @@ export const AppShell: Component<AppShellProps> = (props) => {
           reader={slidePanel() === "meetings"}
           wide={slidePanel() === "settings"}
         >
-          <Switch>
-            <Match when={slidePanel() === "settings"}>
-              <SettingsPanel
-                onSignInClick={handleSignInClick}
-                onLogout={props.onLogout}
-              />
-            </Match>
-            <Match when={slidePanel() === "database"}>
-              <DatabasePanel />
-            </Match>
-            <Match when={slidePanel() === "tasks"}>
-              <AgentTasksPanel />
-            </Match>
-            <Match when={slidePanel() === "sessions"}>
-              <SessionPanel />
-            </Match>
-            <Match when={slidePanel() === "meetings"}>
-              <MeetingPanel />
-            </Match>
-            <Match when={slidePanel() === "skills"}>
-              <SkillsExplorer panelMode />
-            </Match>
-            <Match when={slidePanel() === "account"}>
-              <SignIn onSuccess={handleLoginSuccess} />
-            </Match>
-          </Switch>
+          <ShellSurfaceBoundary
+            surface="slide_panel"
+            title="Panel is recovering."
+            message="This side panel hit an error. Your workspace remains available."
+          >
+            <Switch>
+              <Match when={slidePanel() === "settings"}>
+                <SettingsPanel
+                  onSignInClick={handleSignInClick}
+                  onLogout={props.onLogout}
+                />
+              </Match>
+              <Match when={slidePanel() === "database"}>
+                <DatabasePanel />
+              </Match>
+              <Match when={slidePanel() === "tasks"}>
+                <AgentTasksPanel />
+              </Match>
+              <Match when={slidePanel() === "sessions"}>
+                <SessionPanel />
+              </Match>
+              <Match when={slidePanel() === "meetings"}>
+                <MeetingPanel />
+              </Match>
+              <Match when={slidePanel() === "skills"}>
+                <SkillsExplorer panelMode />
+              </Match>
+              <Match when={slidePanel() === "account"}>
+                <SignIn onSuccess={handleLoginSuccess} />
+              </Match>
+            </Switch>
+          </ShellSurfaceBoundary>
         </SlidePanel>
       </div>
 
-      <Show when={skillPublishStore.firstPublishPath}>
-        {(path) => {
-          const target = () => publishTargetForPath(path());
-          return (
-            <Show when={target()}>
-              {(skill) => (
-                <PublishSkillModal
-                  skill={skill()}
-                  onClose={() => skillPublishStore.clearFirstPublish()}
-                  onPublished={() => void handleSkillPublishComplete()}
-                />
-              )}
-            </Show>
-          );
-        }}
-      </Show>
-      <Show when={skillPublishStore.versionPublishPath}>
-        {(path) => {
-          const target = () => publishTargetForPath(path());
-          const catalogVersion = (slug: string) =>
-            skillsStore.available.find((s) => s.slug === slug)?.version;
-          return (
-            <Show when={target()}>
-              {(skill) => (
-                <PublishVersionModal
-                  skill={skill()}
-                  currentVersion={
-                    catalogVersion(skill().slug) ?? skill().version
-                  }
-                  onClose={() => skillPublishStore.clearVersionPublish()}
-                  onPublished={() => void handleSkillPublishComplete()}
-                />
-              )}
-            </Show>
-          );
-        }}
-      </Show>
+      <ShellSilentBoundary surface="publish_modals">
+        <Show when={skillPublishStore.firstPublishPath}>
+          {(path) => {
+            const target = () => publishTargetForPath(path());
+            return (
+              <Show when={target()}>
+                {(skill) => (
+                  <PublishSkillModal
+                    skill={skill()}
+                    onClose={() => skillPublishStore.clearFirstPublish()}
+                    onPublished={() => void handleSkillPublishComplete()}
+                  />
+                )}
+              </Show>
+            );
+          }}
+        </Show>
+        <Show when={skillPublishStore.versionPublishPath}>
+          {(path) => {
+            const target = () => publishTargetForPath(path());
+            const catalogVersion = (slug: string) =>
+              skillsStore.available.find((s) => s.slug === slug)?.version;
+            return (
+              <Show when={target()}>
+                {(skill) => (
+                  <PublishVersionModal
+                    skill={skill()}
+                    currentVersion={
+                      catalogVersion(skill().slug) ?? skill().version
+                    }
+                    onClose={() => skillPublishStore.clearVersionPublish()}
+                    onPublished={() => void handleSkillPublishComplete()}
+                  />
+                )}
+              </Show>
+            );
+          }}
+        </Show>
+      </ShellSilentBoundary>
 
       {/* First-run audio-permission explainer, surfaced app-wide so non-panel
           start paths (tray, auto-detect) gate on it too. Driven by the meeting
           store's pending priming request. */}
-      <Show when={meetingStore.state.primingRequest}>
-        <AudioPrimingDialog
-          onContinue={() => void meetingStore.confirmPriming()}
-          onCancel={() => void meetingStore.cancelPriming()}
-        />
-      </Show>
+      <ShellSilentBoundary surface="global_overlays">
+        <Show when={meetingStore.state.primingRequest}>
+          <AudioPrimingDialog
+            onContinue={() => void meetingStore.confirmPriming()}
+            onCancel={() => void meetingStore.cancelPriming()}
+          />
+        </Show>
 
-      {/* Always-visible recording indicator while a capture is live (auto- or
-          manually-started): elapsed time + Stop / Pause / Resume / Delete. */}
-      <RecordingIndicator />
+        {/* Always-visible recording indicator while a capture is live (auto- or
+            manually-started): elapsed time + Stop / Pause / Resume / Delete. */}
+        <RecordingIndicator />
 
-      <ConversationSearchOverlay />
+        <ConversationSearchOverlay />
 
-      {/* Layout-level blocking sign-in modal — fires on mid-session expiry,
-          refresh-token failure, and the /login slash command. Distinct from
-          the passive titlebar Sign In button (always-on when unauthenticated)
-          and from ChatContent's local pre-send gate. See #1661. */}
-      <SessionExpiredModal />
+        {/* Layout-level blocking sign-in modal — fires on mid-session expiry,
+            refresh-token failure, and the /login slash command. Distinct from
+            the passive titlebar Sign In button (always-on when unauthenticated)
+            and from ChatContent's local pre-send gate. See #1661. */}
+        <SessionExpiredModal />
+      </ShellSilentBoundary>
     </div>
   );
 };

--- a/tests/unit/app-shell-error-boundaries.test.ts
+++ b/tests/unit/app-shell-error-boundaries.test.ts
@@ -1,0 +1,54 @@
+// ABOUTME: Guards #2797 so recoverable shell errors do not blank chat threads.
+// ABOUTME: Keeps the root fallback as last resort while AppShell owns scoped recovery.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+function source(path: string): string {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("AppShell scoped error recovery (#2797)", () => {
+  const appShell = source("src/components/layout/AppShell.tsx");
+  const app = source("src/App.tsx");
+
+  it("keeps the app-wide recovery screen as a last-resort boundary only", () => {
+    expect(app).toContain("Something went wrong. Seren is recovering.");
+    expect(appShell).toContain("ShellSurfaceBoundary");
+    expect(appShell).toContain("ShellSilentBoundary");
+  });
+
+  it("wraps major shell surfaces in local boundaries so ThreadSidebar survives main view faults", () => {
+    const sidebarIndex = appShell.indexOf("<ThreadSidebar");
+    const mainIndex = appShell.indexOf(
+      '<main class="flex-1 overflow-auto flex flex-col min-w-0">',
+    );
+    const mainBoundaryIndex = appShell.indexOf('surface="main"', mainIndex);
+    const threadContentIndex = appShell.indexOf("<ThreadContent", mainIndex);
+
+    expect(sidebarIndex).toBeGreaterThan(0);
+    expect(mainIndex).toBeGreaterThan(sidebarIndex);
+    expect(mainBoundaryIndex).toBeGreaterThan(mainIndex);
+    expect(threadContentIndex).toBeGreaterThan(mainBoundaryIndex);
+  });
+
+  it("defines recovery fallbacks for titlebar, threads, workspace, panels, and overlays", () => {
+    for (const marker of [
+      'surface="titlebar"',
+      'reportShellBoundaryError("thread_sidebar"',
+      'surface="main"',
+      'surface="slide_panel"',
+      'surface="publish_modals"',
+      'surface="global_overlays"',
+      "Titlebar is recovering.",
+      "Threads are recovering.",
+      "Workspace is recovering.",
+      "Panel is recovering.",
+    ]) {
+      expect(appShell).toContain(marker);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add AppShell-scoped error boundaries around titlebar, thread sidebar, main routed content, slide panels, publish modals, and global overlays.
- Keep the root `src/App.tsx` full-window recovery boundary as last resort only.
- Add a focused source-level regression guard for shell recovery containment.

Fixes #2797

## Audited code paths
- `src/App.tsx` root Solid `ErrorBoundary`
- `src/components/layout/AppShell.tsx`
- Prior related fix: #2534 / #2536 Agent Catalog-only crash containment
- Failure evidence: `/Users/taariqlewis/Downloads/Logs/20260702_wrong.log` and `/Users/taariqlewis/Desktop/wrong.png`

## Networked path audit
No networked publisher/API request path is changed by this fix. The broken behavior is render containment in the desktop shell.

Verified live/noisy paths from the log:
- `seren-skills` publisher slug is live; `GET /skills` is the catalog/owned-skills path used by `src/services/skills.ts`.
- Seren Core wallet balance: `GET /wallet/balance`.
- Seren Core OAuth connections: `GET /oauth/connections`.
- Tauri updater endpoints remain configured in `src-tauri/tauri.conf.json`.

## Verification
- `pnpm vitest run tests/unit/app-shell-error-boundaries.test.ts`
- `pnpm vitest run tests/unit/app-shell-error-boundaries.test.ts tests/unit/app-shell-employee-management.test.ts tests/unit/meeting-ui-regressions.test.ts tests/unit/meeting-rename-and-indicator.test.ts`
- `pnpm exec biome check src/components/layout/AppShell.tsx tests/unit/app-shell-error-boundaries.test.ts --max-diagnostics=50`
- `pnpm test` (306 files / 2169 tests passed)
- `pnpm lint` (exited 0; existing warnings in unrelated files)
- `pnpm build`
- `PLAYWRIGHT_WEB_COMMAND='pnpm exec vite preview --port 1420' PLAYWRIGHT_WEB_TIMEOUT=30000 PLAYWRIGHT_PORT=1420 CI=true pnpm exec playwright test tests/e2e/production-bundle.spec.ts tests/e2e/thread-lifecycle.spec.ts tests/e2e/session-panel.spec.ts` (11 passed / 3 skipped)

Notes:
- `pnpm exec tsc --noEmit --pretty false` still fails on existing unrelated baseline errors in `GatewayToolApproval.tsx`, `src/lib/tools/executor.ts`, `organization-otp.ts`, and `publisher-oauth.ts`; this repo CI does not run `tsc`.