### PR TITLE
fix(oauth): surface publisher OAuth callback errors reliably (#2800)

### DIFF
--- a/src/components/settings/OAuthLogins.tsx
+++ b/src/components/settings/OAuthLogins.tsx
@@ -22,6 +22,7 @@ import githubLogo from "@/assets/oauth-logos/github.svg";
 import googleLogo from "@/assets/oauth-logos/google.svg";
 import linearLogo from "@/assets/oauth-logos/linear.svg";
 import { apiBase } from "@/lib/config";
+import { describeOAuthCallbackError } from "@/lib/oauth-callback";
 import {
   getExpiredOAuthProviderSlugs,
   isOAuthProviderExpired,
@@ -193,35 +194,28 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
   onMount(async () => {
     console.log("[OAuthLogins] Setting up OAuth callback listener");
     const unlisten = await listenForOAuthCallback(async (url) => {
-      // Only process if we initiated a publisher OAuth flow
+      console.log("[OAuthLogins] Received OAuth callback URL:", url);
+
+      // Surface Gateway/provider errors even if the webview reloaded mid-flow
+      // (which resets connectingProvider) or the connect timeout already fired.
+      // Otherwise a failed "Add account" looks like a silent no-op.
+      const callbackError = describeOAuthCallbackError(url);
+      if (callbackError) {
+        console.log("[OAuthLogins] OAuth error received:", callbackError);
+        if (connectTimeout) clearTimeout(connectTimeout);
+        setError(callbackError);
+        setConnectingProvider(null);
+        return;
+      }
+
+      // Success: only refresh if this panel initiated the flow.
       if (!connectingProvider()) return;
 
-      console.log("[OAuthLogins] Received OAuth callback URL:", url);
+      // The Gateway handles token exchange, we just need to refresh.
+      console.log(
+        "[OAuthLogins] Refreshing connections after successful OAuth",
+      );
       try {
-        const urlObj = new URL(url);
-        console.log(
-          "[OAuthLogins] Parsed URL - origin:",
-          urlObj.origin,
-          "pathname:",
-          urlObj.pathname,
-          "search:",
-          urlObj.search,
-        );
-        const errorParam = urlObj.searchParams.get("error");
-
-        if (errorParam) {
-          console.log("[OAuthLogins] OAuth error received:", errorParam);
-          if (connectTimeout) clearTimeout(connectTimeout);
-          setError(`OAuth error: ${errorParam}`);
-          setConnectingProvider(null);
-          return;
-        }
-
-        // Refresh connections after successful OAuth callback
-        // The Gateway handles token exchange, we just need to refresh
-        console.log(
-          "[OAuthLogins] Refreshing connections after successful OAuth",
-        );
         await refetchConnections();
         markOAuthConnectionsChanged();
         console.log("[OAuthLogins] Connections refreshed successfully");
@@ -230,13 +224,12 @@ export const OAuthLogins: Component<OAuthLoginsProps> = (props) => {
         if (currentProvider) {
           clearExpiredStatus(currentProvider);
         }
-        if (connectTimeout) clearTimeout(connectTimeout);
-        setConnectingProvider(null);
         setError(null);
       } catch (err) {
         console.error("[OAuthLogins] Error processing OAuth callback:", err);
-        if (connectTimeout) clearTimeout(connectTimeout);
         setError(err instanceof Error ? err.message : "OAuth callback failed");
+      } finally {
+        if (connectTimeout) clearTimeout(connectTimeout);
         setConnectingProvider(null);
       }
     });

--- a/src/lib/oauth-callback.ts
+++ b/src/lib/oauth-callback.ts
@@ -1,0 +1,28 @@
+// ABOUTME: Parses publisher OAuth deep-link callback URLs (seren://oauth/callback or loopback).
+// ABOUTME: Extracts a user-facing error message, preferring the Gateway's error_description.
+
+/**
+ * Inspect an OAuth callback URL and return a user-facing error message when the
+ * Gateway reported a failure, or null when the callback is a success (or cannot
+ * be parsed).
+ *
+ * The Gateway's `GET /oauth/{provider}/callback` redirects back with `error`
+ * plus a human-readable `error_description` on failure. We prefer the
+ * description so the user learns *why* the connection failed (e.g. "OAuth
+ * provider did not return a stable account identifier") instead of an opaque
+ * `callback_failed` code.
+ */
+export function describeOAuthCallbackError(url: string): string | null {
+  let params: URLSearchParams;
+  try {
+    params = new URL(url).searchParams;
+  } catch {
+    return null;
+  }
+  const error = params.get("error");
+  if (!error) return null;
+  const description = params.get("error_description")?.trim();
+  return description
+    ? `Connection failed: ${description}`
+    : `OAuth error: ${error}`;
+}

--- a/tests/unit/oauth-callback.test.ts
+++ b/tests/unit/oauth-callback.test.ts
@@ -1,0 +1,48 @@
+// ABOUTME: Regression tests for parsing publisher OAuth deep-link callback errors.
+// ABOUTME: Protects surfacing the Gateway's error_description instead of an opaque code.
+
+import { describe, expect, it } from "vitest";
+
+import { describeOAuthCallbackError } from "@/lib/oauth-callback";
+
+describe("describeOAuthCallbackError", () => {
+  it("returns null for a successful callback (no error param)", () => {
+    expect(
+      describeOAuthCallbackError(
+        "seren://oauth/callback?code=abc123&state=xyz",
+      ),
+    ).toBeNull();
+  });
+
+  it("prefers the Gateway error_description over the opaque error code", () => {
+    // The exact failure captured in ~/Downloads/Logs/20260703_oauth.log
+    const url =
+      "seren://oauth/callback?error=callback_failed&error_description=" +
+      encodeURIComponent(
+        "Bad request: OAuth provider did not return a stable account identifier",
+      );
+    expect(describeOAuthCallbackError(url)).toBe(
+      "Connection failed: Bad request: OAuth provider did not return a stable account identifier",
+    );
+  });
+
+  it("falls back to the error code when no description is present", () => {
+    expect(
+      describeOAuthCallbackError("seren://oauth/callback?error=access_denied"),
+    ).toBe("OAuth error: access_denied");
+  });
+
+  it("parses the loopback callback variant used on Windows/validation builds", () => {
+    const url =
+      "http://127.0.0.1:8765/oauth/callback?error=callback_failed" +
+      "&error_description=" +
+      encodeURIComponent("Provider rejected the request");
+    expect(describeOAuthCallbackError(url)).toBe(
+      "Connection failed: Provider rejected the request",
+    );
+  });
+
+  it("returns null for an unparseable callback string", () => {
+    expect(describeOAuthCallbackError("not a url")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Fixes #2800 — a failed **Settings → Logins → Google → "Add account"** looked successful because the desktop client swallowed/obscured the Gateway's OAuth callback error.

## Root cause (Layer 1, in-repo)

In `OAuthLogins.tsx` the OAuth callback handler:
- gated **all** processing on `if (!connectingProvider()) return;`. The log (`~/Downloads/Logs/20260703_oauth.log`) shows the webview reloading mid-flow, which resets `connectingProvider` to `null`; the fresh listener then **silently drops** the `error=callback_failed` callback. The 2-minute timeout resetting `connectingProvider` first has the same effect.
- surfaced only the opaque `error` code and **discarded `error_description`** ("OAuth provider did not return a stable account identifier").

## Change

- New pure helper `src/lib/oauth-callback.ts` → `describeOAuthCallbackError(url)`, which prefers `error_description` over the opaque code and returns `null` for success/unparseable URLs.
- `OAuthLogins.tsx`: handle the error branch **before** the `connectingProvider()` gate (so errors are always surfaced), and use the helper. Success handling is unchanged — it still only refreshes when this panel initiated the flow.

## Not fixed here (Layer 2, Gateway — see #2800)

This makes the failure **visible and explained**; it does **not** make a second Google account addable. The `google` provider's authorize URL requests no `openid/email/profile` scope, so the Gateway cannot derive a stable account identifier. That is a Gateway OAuth-provider scope-config change on `api.serendb.com`, not in this repo.

## Networked path (verified)

`connectPublisher("google")` → `GET /oauth/google/authorize?redirect_uri=seren://oauth/callback` (via Rust `get_oauth_redirect_url`) → Gateway 302 to Google → `GET /oauth/google/callback` → 302 `seren://oauth/callback?error=…` → Rust deep-link emits `oauth-callback` → this handler. Slugs/paths verified against `openapi/openapi.json` (`initiate_oauth`, `oauth_callback`, `list_connections`) and the live authorize URL in the log. Scopes are server-owned (`update_org_oauth_provider`).

## Tests

- New `tests/unit/oauth-callback.test.ts` (5 cases): success → null; `error_description` preference (the exact captured failure); opaque-code fallback; loopback callback variant; unparseable → null. **5/5 pass.**
- Existing OAuth suites unchanged and green: `oauth-provider-resolution`, `publisher-oauth-reconnect`, `oauth-tool-errors`, `tool-executor-oauth-account` (20/20).
- Biome clean on changed source; `tsc --noEmit` introduces **0** new errors (5 pre-existing on `main`, unrelated files).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
