### PR TITLE
fix(oauth): resolve chat-header switcher add-account callback (#2803)

### DIFF
--- a/src/components/chat/OAuthAccountSwitcher.tsx
+++ b/src/components/chat/OAuthAccountSwitcher.tsx
@@ -11,7 +11,9 @@ import {
   onMount,
   Show,
 } from "solid-js";
+import { describeOAuthCallbackError } from "@/lib/oauth-callback";
 import { humanizeOAuthProviderSlug } from "@/lib/oauth-provider-resolution";
+import { listenForOAuthCallback } from "@/lib/tauri-bridge";
 import {
   connectPublisher,
   listConnectedPublishers,
@@ -19,6 +21,7 @@ import {
 import {
   formatOAuthConnectionLabel,
   getOAuthConnectionsForProvider,
+  markOAuthConnectionsChanged,
   type OAuthConnection,
   oauthConnectionsRevision,
   resolveThreadOAuthConnection,
@@ -50,6 +53,7 @@ export const OAuthAccountSwitcher: Component<OAuthAccountSwitcherProps> = (
   >(null);
   const [connectError, setConnectError] = createSignal<string | null>(null);
   let rootRef: HTMLDivElement | undefined;
+  let connectTimeout: ReturnType<typeof setTimeout> | null = null;
   const [connections] = createResource(oauthConnectionsRevision, async () =>
     listConnectedPublishers(),
   );
@@ -67,6 +71,30 @@ export const OAuthAccountSwitcher: Component<OAuthAccountSwitcherProps> = (
     };
     document.addEventListener("click", close);
     onCleanup(() => document.removeEventListener("click", close));
+  });
+
+  // Resolve a switcher-initiated add-account flow when its OAuth callback lands.
+  // Without this, add-account errors are never shown here and a successful add
+  // never refreshes the list.
+  onMount(async () => {
+    const unlisten = await listenForOAuthCallback((url) => {
+      if (!connectingProvider()) return;
+      if (connectTimeout) clearTimeout(connectTimeout);
+      const callbackError = describeOAuthCallbackError(url);
+      if (callbackError) {
+        setConnectError(callbackError);
+        setConnectingProvider(null);
+        return;
+      }
+      // Success — refresh every account list bound to the revision signal.
+      markOAuthConnectionsChanged();
+      setConnectError(null);
+      setConnectingProvider(null);
+    });
+    onCleanup(() => {
+      unlisten();
+      if (connectTimeout) clearTimeout(connectTimeout);
+    });
   });
 
   const groups = createMemo<ProviderAccountGroup[]>(() => {
@@ -122,13 +150,25 @@ export const OAuthAccountSwitcher: Component<OAuthAccountSwitcherProps> = (
     if (connectingProvider()) return;
     setConnectingProvider(providerSlug);
     setConnectError(null);
+
+    // Reset if the OAuth callback never arrives (e.g. the user cancels in the
+    // browser). The listener above clears this on a real callback.
+    if (connectTimeout) clearTimeout(connectTimeout);
+    connectTimeout = setTimeout(() => {
+      if (connectingProvider()) {
+        setConnectingProvider(null);
+        setConnectError("Connection timed out. Please try again.");
+      }
+    }, 120_000);
+
     try {
       await connectPublisher(providerSlug);
+      // Flow continues via the OAuth callback listener.
     } catch (err) {
+      if (connectTimeout) clearTimeout(connectTimeout);
       setConnectError(
         err instanceof Error ? err.message : "Failed to start OAuth flow",
       );
-    } finally {
       setConnectingProvider(null);
     }
   };


### PR DESCRIPTION
## What

Fixes #2803 — the chat-header account switcher's "Add account" swallowed the OAuth result. Follow-up to #2801 (same silent-failure class, different surface).

## Root cause

`src/components/chat/OAuthAccountSwitcher.tsx`:
- `addAccount` cleared connecting state in a `finally` that ran immediately after `connectPublisher` resolved (right after the browser opened), and
- the component registered **no** `oauth-callback` listener.

So an add-account error was never surfaced in the switcher, and a successful add never bumped `oauthConnectionsRevision`, leaving the switcher list stale until something else refreshed it.

## Change

- Add an `oauth-callback` listener (via `listenForOAuthCallback`) that, while a switcher-initiated flow is active (`connectingProvider()` set), reuses `describeOAuthCallbackError(url)` (added in #2801) to surface errors through `connectError`, and calls `markOAuthConnectionsChanged()` on success so every revision-bound account list refreshes.
- Hold the connecting state until the callback resolves; clear it on a synchronous throw; add a 2-minute timeout safeguard (mirrors `OAuthLogins.tsx`).

## Tests

- Parsing logic reused from #2801 is covered by `tests/unit/oauth-callback.test.ts` (5/5). The rest is UI wiring; per repo policy UI components are not unit-tested.
- Biome clean on the changed file; `tsc --noEmit` adds **0** errors in touched files (pre-existing errors on `main` are unrelated).

## Not fixed here

The upstream Gateway scope-config root cause (missing `openid/email/profile` → "did not return a stable account identifier") remains out of scope — see #2800.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
