### PR TITLE
fix(agent): recover seren-mcp sessions with zero tools (#2802)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -918,6 +918,30 @@ const INITIALIZE_TIMEOUT_MS = 60_000;
 // abandoned. Each attempt runs against a fresh process. #2452
 const INITIALIZE_MAX_ATTEMPTS = 2;
 
+// The Seren MCP gateway can complete its MCP `initialize` handshake — so its
+// instruction block loads into the prompt — while its `tools/list` call fails,
+// leaving the session "connected" with ZERO seren-mcp tools for its whole
+// lifetime. Claude Code does NOT downgrade the client to "failed" on a
+// tools/list miss, so the connection status reads healthy while every publisher
+// action fails against tools that were never registered. The only reliable
+// signal is the tool COUNT, and the first streamed `system init` message is the
+// earliest point that count is fully resolved. We audit it there and recover in
+// place with the `mcp_reconnect` control request (single-server reconnect +
+// tools re-fetch, no process restart) before surfacing a degraded state. #2802
+const SEREN_MCP_SERVER_NAME = "seren-mcp";
+const SEREN_MCP_TOOL_PREFIX = `mcp__${SEREN_MCP_SERVER_NAME}__`;
+// The remote HTTP gateway's connect + tools/list races in the background and is
+// often still `pending` when the first `system init` fires, so a bare "0 tools
+// at init" is NOT yet a failure. Give the connection this long to register its
+// tools naturally (cheap local `mcp_status` polls, no gateway round-trips)
+// before treating it as degraded — otherwise a healthy-but-slow gateway would
+// be needlessly reconnected on every spawn.
+const SEREN_MCP_SETTLE_TIMEOUT_MS = 10_000;
+const SEREN_MCP_SETTLE_POLL_INTERVAL_MS = 500;
+const SEREN_MCP_RECONNECT_MAX_ATTEMPTS = 3;
+const SEREN_MCP_RECONNECT_BASE_DELAY_MS = 500;
+const SEREN_MCP_CONTROL_TIMEOUT_MS = 15_000;
+
 function sendInitialize(session) {
   return sendControlRequest(
     session,
@@ -1667,6 +1691,10 @@ function handleSystemMessage(emit, session, payload) {
         session.currentModelId ??
         inferCurrentModelId(payload.model, session.availableModelRecords);
       emit("provider://session-status", buildSessionStatus(session));
+      // The `system init` message is the first point Claude Code's tool
+      // registry is fully resolved, so it is where we can tell whether the
+      // Seren gateway actually registered its tools. #2802
+      maybeAuditSerenMcpTools(emit, session, payload);
       return;
     }
 
@@ -1688,6 +1716,173 @@ function handleSystemMessage(emit, session, payload) {
     default:
       return;
   }
+}
+
+/** Count the seren-mcp tools in a streamed `system init` `tools` array. */
+function countSerenMcpTools(tools) {
+  if (!Array.isArray(tools)) {
+    return 0;
+  }
+  return tools.filter(
+    (name) => typeof name === "string" && name.startsWith(SEREN_MCP_TOOL_PREFIX),
+  ).length;
+}
+
+/**
+ * Audit the first `system init` for missing Seren gateway tools and kick off
+ * settle-then-recover when the gateway did not register any tools. Runs at most
+ * once per session, and only when the session was spawned with the gateway
+ * configured (an API key was present). #2802
+ */
+function maybeAuditSerenMcpTools(emit, session, payload) {
+  if (!session.serenMcpConfigured || session.serenMcpToolsChecked) {
+    return;
+  }
+  session.serenMcpToolsChecked = true;
+
+  // Fast path: the gateway already registered its tools by the time the first
+  // `system init` fired, so there is nothing to do and no control traffic.
+  if (countSerenMcpTools(payload.tools) > 0) {
+    return;
+  }
+
+  // Zero tools at init can just mean the remote gateway is still connecting, so
+  // don't judge it yet — let it settle, then recover only if it stays toolless.
+  void settleAndRecoverSerenMcpTools(emit, session);
+}
+
+/**
+ * Read the live seren-mcp status + tool count via the `mcp_status` control
+ * request. Returns `{ status, toolCount }`, or `null` when `mcp_status` is
+ * unsupported (older CLI) or the session is gone.
+ */
+async function serenMcpStatus(session) {
+  let response;
+  try {
+    response = await sendControlRequest(
+      session,
+      { subtype: "mcp_status" },
+      SEREN_MCP_CONTROL_TIMEOUT_MS,
+    );
+  } catch {
+    return null;
+  }
+  const servers = Array.isArray(response?.mcpServers) ? response.mcpServers : [];
+  const seren = servers.find((server) => server?.name === SEREN_MCP_SERVER_NAME);
+  return {
+    status: seren?.status ?? "absent",
+    toolCount: Array.isArray(seren?.tools) ? seren.tools.length : 0,
+  };
+}
+
+/**
+ * Wait for the remote gateway to finish connecting before judging it. The
+ * connect + tools/list race in the background, so poll the cheap in-process
+ * `mcp_status` until the gateway either registers tools (healthy — was just
+ * slow) or the settle window elapses with it still toolless. Only then hand off
+ * to reconnect recovery. Never reconnects a merely-still-connecting gateway. #2802
+ */
+async function settleAndRecoverSerenMcpTools(emit, session) {
+  const settleDeadline = Date.now() + SEREN_MCP_SETTLE_TIMEOUT_MS;
+  let lastStatus = "pending";
+  for (;;) {
+    if (session.process?.exitCode != null || session.process?.killed) {
+      return;
+    }
+    const status = await serenMcpStatus(session);
+    if (status === null) {
+      // `mcp_status` unsupported — we cannot distinguish "still connecting" from
+      // "genuinely toolless", so do nothing rather than risk a false alarm.
+      return;
+    }
+    lastStatus = status.status;
+    if (status.toolCount > 0) {
+      return; // healthy — the gateway registered its tools on its own
+    }
+    if (Date.now() >= settleDeadline) {
+      break; // still toolless after the settle window — treat as degraded
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, SEREN_MCP_SETTLE_POLL_INTERVAL_MS),
+    );
+  }
+
+  console.warn(
+    `${session.logPrefix ?? providerLogPrefix("claude")} seren-mcp registered ` +
+      `0 tools after ${Math.round(SEREN_MCP_SETTLE_TIMEOUT_MS / 1000)}s ` +
+      `(server status: ${lastStatus}); attempting in-place reconnect recovery.`,
+  );
+  await recoverSerenMcpTools(emit, session);
+}
+
+/**
+ * Reconnect the seren-mcp server in place (no process restart) with bounded
+ * retries and backoff, re-checking the tool count after each attempt. When the
+ * underlying failure is a server-side `tools/list` transient, a reconnect
+ * re-fetches the tool list and repopulates the live registry for the rest of
+ * the session. Surfaces a degraded state only after every attempt is
+ * exhausted. #2802
+ */
+async function recoverSerenMcpTools(emit, session) {
+  for (
+    let attempt = 1;
+    attempt <= SEREN_MCP_RECONNECT_MAX_ATTEMPTS;
+    attempt += 1
+  ) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, SEREN_MCP_RECONNECT_BASE_DELAY_MS * attempt),
+    );
+
+    // Stop if the CLI process has since exited or been killed — reconnecting a
+    // dead session is pointless and would spuriously surface a degraded state.
+    if (session.process?.exitCode != null || session.process?.killed) {
+      return;
+    }
+
+    try {
+      await sendControlRequest(
+        session,
+        { subtype: "mcp_reconnect", serverName: SEREN_MCP_SERVER_NAME },
+        SEREN_MCP_CONTROL_TIMEOUT_MS,
+      );
+    } catch (error) {
+      console.warn(
+        `${session.logPrefix ?? providerLogPrefix("claude")} seren-mcp ` +
+          `reconnect attempt ${attempt}/${SEREN_MCP_RECONNECT_MAX_ATTEMPTS} ` +
+          `failed: ${error.message}`,
+      );
+      continue;
+    }
+
+    const status = await serenMcpStatus(session);
+    if (status === null) {
+      // Reconnect was acknowledged but the count cannot be verified (older CLI
+      // without `mcp_status`, or the session ended). Best effort — stop here.
+      console.warn(
+        `${session.logPrefix ?? providerLogPrefix("claude")} seren-mcp ` +
+          `reconnected (tool count unverifiable); stopping recovery.`,
+      );
+      return;
+    }
+    if (status.toolCount > 0) {
+      console.warn(
+        `${session.logPrefix ?? providerLogPrefix("claude")} seren-mcp tools ` +
+          `recovered: ${status.toolCount} tools after reconnect attempt ` +
+          `${attempt}.`,
+      );
+      return;
+    }
+  }
+
+  console.error(
+    `${session.logPrefix ?? providerLogPrefix("claude")} seren-mcp tools ` +
+      `failed to register after ${SEREN_MCP_RECONNECT_MAX_ATTEMPTS} reconnect ` +
+      `attempts; surfacing degraded state.`,
+  );
+  emit("provider://mcp-degraded", {
+    sessionId: session.id,
+    serverName: SEREN_MCP_SERVER_NAME,
+  });
 }
 
 function handleAssistantMessage(emit, session, payload) {
@@ -2029,6 +2224,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     mcpConfigJson = null,
     spawnEnv = {},
     reasoningEffort = DEFAULT_CLAUDE_EFFORT,
+    serenMcpConfigured = false,
   }) {
     return {
       id: sessionId,
@@ -2061,6 +2257,11 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       // Peak per-turn input tokens across the current prompt's tool-call
       // iterations. Reset at handleResult. See #1611.
       peakInputTokens: 0,
+      // Whether this session was spawned with the Seren MCP gateway configured
+      // (an API key was present), and whether its post-spawn tool-registration
+      // audit has already run. See maybeAuditSerenMcpTools / #2802.
+      serenMcpConfigured,
+      serenMcpToolsChecked: false,
     };
   }
 
@@ -2102,6 +2303,11 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
 
     const remoteSessionId = resumeAgentSessionId ?? randomUUID();
     const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
+    // The Seren gateway is only in the MCP config when an API key is present
+    // (see createRemoteSerenServer). Mirror that check so the post-spawn tool
+    // audit only runs for sessions that actually expect gateway tools. #2802
+    const serenMcpConfigured =
+      typeof apiKey === "string" && apiKey.trim().length > 0;
     const claudeBin = resolveClaudeBinary();
     const extendedPath = buildExtendedPath();
     const effectiveEffort =
@@ -2247,6 +2453,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         mcpConfigJson: mcpConfig.claudeMcpConfigJson,
         spawnEnv: mcpConfig.childEnv,
         reasoningEffort: effectiveEffort,
+        serenMcpConfigured,
       });
 
       sessions.set(sessionId, launchedSession);
@@ -2799,4 +3006,6 @@ export {
   buildFastModeFlagSettings as _buildFastModeFlagSettings,
   handleAssistantMessage as _handleAssistantMessage,
   handleStreamEvent as _handleStreamEvent,
+  countSerenMcpTools as _countSerenMcpTools,
+  SEREN_MCP_TOOL_PREFIX as _SEREN_MCP_TOOL_PREFIX,
 };

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -356,6 +356,18 @@ export interface LoginRequiredEvent {
   reason: string;
 }
 
+/**
+ * Emitted by an agent runtime when the Seren MCP gateway was configured for a
+ * session but failed to register any tools after bounded in-place reconnect
+ * attempts (the gateway connected — its instructions loaded — but its
+ * `tools/list` kept failing). Lets the desktop surface a degraded state instead
+ * of letting the session run instruction-only and silently. (#2802)
+ */
+export interface McpDegradedEvent {
+  sessionId: string;
+  serverName: string;
+}
+
 // Union type for all provider runtime events
 export type AgentEvent =
   | { type: "pairedEvent"; data: PairedTranscriptEvent }
@@ -371,7 +383,8 @@ export type AgentEvent =
   | { type: "sessionStatus"; data: SessionStatusEvent }
   | { type: "userMessage"; data: UserMessageEvent }
   | { type: "error"; data: ErrorEvent }
-  | { type: "loginRequired"; data: LoginRequiredEvent };
+  | { type: "loginRequired"; data: LoginRequiredEvent }
+  | { type: "mcpDegraded"; data: McpDegradedEvent };
 
 async function invokeProvider<T>(
   command: string,
@@ -757,6 +770,7 @@ const EVENT_SUFFIXES = {
   userMessage: "user-message",
   error: "error",
   loginRequired: "login-required",
+  mcpDegraded: "mcp-degraded",
 } as const;
 
 type EventType = keyof typeof EVENT_SUFFIXES;
@@ -907,6 +921,12 @@ export async function subscribeToSession(
       "error",
       createHandler<{ type: "error"; data: ErrorEvent }>("error"),
     ),
+    subscribeToEvent<McpDegradedEvent>(
+      "mcpDegraded",
+      createHandler<{ type: "mcpDegraded"; data: McpDegradedEvent }>(
+        "mcpDegraded",
+      ),
+    ),
   ]);
 }
 
@@ -959,6 +979,9 @@ export async function subscribeToAllEvents(
     ),
     subscribeToEvent<LoginRequiredEvent>("loginRequired", (data) =>
       callback({ type: "loginRequired", data }),
+    ),
+    subscribeToEvent<McpDegradedEvent>("mcpDegraded", (data) =>
+      callback({ type: "mcpDegraded", data }),
     ),
   ]);
 }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -6738,6 +6738,59 @@ export const agentStore = {
         this.handleStatusChange(sessionId, event.data.status, event.data);
         break;
 
+      case "mcpDegraded": {
+        // The Seren gateway connected for this session (its instructions
+        // loaded) but never registered its tools, and the runtime exhausted
+        // its in-place reconnect attempts. Surface a calm, non-fatal notice —
+        // the thread still works for non-publisher tasks, so this must NOT set
+        // the persistent session error banner or freeze the composer — and
+        // route it to the support pipeline so a persistent gateway
+        // `tools/list` failure becomes ticketable rather than silent. #2802
+        const degradedSession = state.sessions[sessionId];
+        if (!degradedSession) {
+          break;
+        }
+        const degradedNotice =
+          "Seren publisher tools could not be loaded for this thread — the " +
+          "Seren gateway was reachable but its tool list stayed unavailable " +
+          "after several retries. Publisher actions may fail here; start a " +
+          "new thread to try again.";
+        const lastDegradedMessage = degradedSession.messages.at(-1);
+        if (
+          lastDegradedMessage?.type !== "error" ||
+          lastDegradedMessage.content !== degradedNotice
+        ) {
+          const noticeMessage: AgentMessage = {
+            id: crypto.randomUUID(),
+            type: "error",
+            content: degradedNotice,
+            timestamp: Date.now(),
+          };
+          setState("sessions", sessionId, "messages", (msgs) => [
+            ...msgs,
+            noticeMessage,
+          ]);
+          const degradedConvoId = degradedSession.conversationId;
+          if (degradedConvoId) {
+            persistAgentMessage(
+              degradedConvoId,
+              noticeMessage,
+              degradedSession.info.agentType ?? null,
+            );
+          }
+        }
+        void captureSupportError({
+          kind: "agent.seren_mcp_tools_unavailable",
+          message: `seren-mcp registered 0 tools after reconnect recovery (server: ${event.data.serverName})`,
+          agentContext: {
+            model: degradedSession.currentModelId,
+            provider: degradedSession.info.agentType,
+            tool_calls: [],
+          },
+        });
+        break;
+      }
+
       case "error": {
         // Graceful "Task cancelled" is a system/user-initiated cancel
         // (predictive-compaction promotion teardown, Stop button, etc.) and

--- a/tests/services/providers.test.ts
+++ b/tests/services/providers.test.ts
@@ -55,10 +55,10 @@ describe("provider runtime event subscriptions", () => {
     const unlisteners = mockRuntimeSubscriptions();
 
     const dispose = await subscribeToSession("session-1", vi.fn());
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(13);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(14);
 
     dispose();
-    expect(unlisteners).toHaveLength(13);
+    expect(unlisteners).toHaveLength(14);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -69,8 +69,8 @@ describe("provider runtime event subscriptions", () => {
 
     await expectAggregateError(subscribeToSession("session-1", vi.fn()));
 
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(13);
-    expect(unlisteners).toHaveLength(12);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(14);
+    expect(unlisteners).toHaveLength(13);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -80,10 +80,10 @@ describe("provider runtime event subscriptions", () => {
     const unlisteners = mockRuntimeSubscriptions();
 
     const dispose = await subscribeToAllEvents(vi.fn());
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(14);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(15);
 
     dispose();
-    expect(unlisteners).toHaveLength(14);
+    expect(unlisteners).toHaveLength(15);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -94,8 +94,8 @@ describe("provider runtime event subscriptions", () => {
 
     await expectAggregateError(subscribeToAllEvents(vi.fn()));
 
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(14);
-    expect(unlisteners).toHaveLength(13);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(15);
+    expect(unlisteners).toHaveLength(14);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }

--- a/tests/unit/claude-runtime-seren-mcp-audit.test.ts
+++ b/tests/unit/claude-runtime-seren-mcp-audit.test.ts
@@ -1,0 +1,138 @@
+// ABOUTME: Critical guard for #2802 — detecting a Seren gateway that connected
+// ABOUTME: but registered zero tools, and locking in the in-place reconnect recovery.
+
+import { readSource } from "./source-text";
+import { describe, expect, it } from "vitest";
+import {
+  _countSerenMcpTools as countSerenMcpTools,
+  _SEREN_MCP_TOOL_PREFIX as SEREN_MCP_TOOL_PREFIX,
+} from "../../bin/browser-local/claude-runtime.mjs";
+
+const claudeRuntimeSource = readSource("bin/browser-local/claude-runtime.mjs");
+
+// A realistic `system init` `tools` array with built-ins + a healthy playwright
+// stdio server + the Seren gateway's publisher meta-tools registered.
+const HEALTHY_TOOLS = [
+  "Task",
+  "Bash",
+  "Read",
+  "mcp__playwright__playwright_navigate",
+  "mcp__playwright__playwright_click",
+  "mcp__seren-mcp__list_agent_publishers",
+  "mcp__seren-mcp__call_publisher",
+];
+
+// The #2802 failure: the gateway completed its MCP `initialize` (so its
+// instructions loaded) but its `tools/list` failed, so NOT ONE
+// `mcp__seren-mcp__*` tool is present even though other servers registered.
+const DEGRADED_TOOLS = [
+  "Task",
+  "Bash",
+  "Read",
+  "mcp__playwright__playwright_navigate",
+  "mcp__playwright__playwright_click",
+];
+
+describe("#2802 — seren-mcp zero-tool detection", () => {
+  it("uses the exact hyphen-preserving gateway tool prefix", () => {
+    // Claude Code sanitizes MCP server names with /[^a-zA-Z0-9_-]/ → "_",
+    // which PRESERVES hyphens, so "seren-mcp" tools register as
+    // `mcp__seren-mcp__*` (NOT `mcp__seren_mcp__*`). Getting this wrong makes
+    // every tool miss the filter and reports a permanent false degradation.
+    expect(SEREN_MCP_TOOL_PREFIX).toBe("mcp__seren-mcp__");
+  });
+
+  it("counts the gateway tools when the gateway registered them", () => {
+    expect(countSerenMcpTools(HEALTHY_TOOLS)).toBe(2);
+  });
+
+  it("returns 0 when the gateway connected but registered no tools", () => {
+    // This is the state the whole fix hinges on: other servers registered,
+    // seren-mcp did not. It must read as zero so recovery fires.
+    expect(countSerenMcpTools(DEGRADED_TOOLS)).toBe(0);
+  });
+
+  it("never counts another server's tools as the gateway's", () => {
+    expect(
+      countSerenMcpTools([
+        "mcp__playwright__playwright_navigate",
+        "mcp__seren-mcp-other__x",
+        "mcp__notseren-mcp__y",
+      ]),
+    ).toBe(0);
+  });
+
+  it("treats a missing or malformed tools list as zero, not a crash", () => {
+    expect(countSerenMcpTools(undefined)).toBe(0);
+    expect(countSerenMcpTools(null)).toBe(0);
+    expect(countSerenMcpTools("not-an-array")).toBe(0);
+    expect(countSerenMcpTools([undefined, 42, { name: "x" }])).toBe(0);
+  });
+});
+
+describe("#2802 — audit is wired into spawn and recovery flow", () => {
+  it("audits the gateway on the first streamed `system init`", () => {
+    // The tool registry is only fully resolved at the first `system init`, so
+    // that is the one place the audit can run. A pre-prompt probe can read a
+    // still-connecting registry and false-trigger.
+    const initCase = claudeRuntimeSource.slice(
+      claudeRuntimeSource.indexOf('case "init": {'),
+      claudeRuntimeSource.indexOf('case "status":'),
+    );
+    expect(initCase).toContain("maybeAuditSerenMcpTools(emit, session, payload)");
+  });
+
+  it("only audits sessions spawned with the gateway configured, exactly once", () => {
+    const fnStart = claudeRuntimeSource.indexOf(
+      "function maybeAuditSerenMcpTools(",
+    );
+    expect(fnStart).toBeGreaterThan(0);
+    const fnBody = claudeRuntimeSource.slice(fnStart, fnStart + 900);
+    expect(fnBody).toContain(
+      "if (!session.serenMcpConfigured || session.serenMcpToolsChecked)",
+    );
+    expect(fnBody).toContain("session.serenMcpToolsChecked = true");
+  });
+
+  it("lets a still-connecting gateway settle before judging it degraded", () => {
+    // The remote gateway is often still `pending` at the first `system init`,
+    // so it must be given a settle window (cheap mcp_status polls) to register
+    // tools before any reconnect — otherwise healthy-but-slow gateways get
+    // needlessly reconnected on every spawn.
+    const fnStart = claudeRuntimeSource.indexOf(
+      "async function settleAndRecoverSerenMcpTools(",
+    );
+    expect(fnStart).toBeGreaterThan(0);
+    const fnBody = claudeRuntimeSource.slice(fnStart, fnStart + 1400);
+    expect(fnBody).toContain("SEREN_MCP_SETTLE_TIMEOUT_MS");
+    // A gateway that registers tools during the settle window is healthy — no
+    // reconnect churn.
+    expect(fnBody).toContain("if (status.toolCount > 0)");
+    expect(fnBody).toContain("return; // healthy");
+    expect(fnBody).toContain("recoverSerenMcpTools(emit, session)");
+  });
+
+  it("recovers in place via bounded mcp_reconnect + mcp_status re-check", () => {
+    const fnStart = claudeRuntimeSource.indexOf(
+      "async function recoverSerenMcpTools(",
+    );
+    expect(fnStart).toBeGreaterThan(0);
+    const fnBody = claudeRuntimeSource.slice(fnStart, fnStart + 2000);
+    // Single-server reconnect (no full-process respawn) with a bounded loop.
+    expect(fnBody).toContain('subtype: "mcp_reconnect"');
+    expect(fnBody).toContain("serverName: SEREN_MCP_SERVER_NAME");
+    expect(fnBody).toContain("attempt <= SEREN_MCP_RECONNECT_MAX_ATTEMPTS");
+    // Verifies the reconnect actually restored tools before declaring success —
+    // a reconnect ACK means "connected", not "tools present".
+    expect(fnBody).toContain("serenMcpStatus(session)");
+    expect(fnBody).toContain("status.toolCount > 0");
+  });
+
+  it("surfaces a degraded state only after recovery is exhausted", () => {
+    const fnStart = claudeRuntimeSource.indexOf(
+      "async function recoverSerenMcpTools(",
+    );
+    const fnBody = claudeRuntimeSource.slice(fnStart, fnStart + 2000);
+    expect(fnBody).toContain('emit("provider://mcp-degraded"');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2802. Spawned agent sessions could run their **entire lifetime with the Seren MCP gateway's instructions in the prompt but none of its tools registered**. The gateway completes its MCP `initialize` handshake (so the instruction block loads) while its `tools/list` keeps failing, and the agent CLI leaves the client marked **`connected` with zero tools**. The appended primer tells the model to call `list_agent_publishers` / `call_publisher`, but those tools never exist in the session — so every publisher action fails or falls back to raw-HTTP workarounds, silently, for the whole session, with no detection or recovery.

## Root cause & mechanism (verified against the bundled agent CLI 2.1.199 binary)

- A failed/empty `tools/list` does **not** downgrade the MCP client from `connected` to `failed`, so connection status reads healthy while the tool set is empty. Detection must key on the **tool count**, not the status.
- The `initialize` control response carries no MCP/tool info; the first streamed `system init` message does (`tools` + `mcp_servers`).
- The remote HTTP gateway's connect + `tools/list` **race in the background** and are often still `pending` when the first `system init` fires — so a bare "0 tools at init" is not yet a failure.
- The CLI exposes `mcp_status` (per-server status + tools) and `mcp_reconnect` (single-server reconnect + tools re-fetch, **no process restart**) control requests. Unknown subtypes reject cleanly, so older CLIs degrade gracefully.

## Fix

**Runtime (`bin/browser-local/claude-runtime.mjs`)** — on the first `system init` of a gateway-configured session (API key present), audit the registered tool list:

1. Fast path: tools already present -> nothing to do, zero control traffic.
2. Otherwise **settle**: poll the cheap in-process `mcp_status` for up to 10s. If the gateway registers tools on its own (it was just slow to connect), stop — no reconnect churn on healthy-but-slow gateways.
3. If it stays toolless, **recover in place** via `mcp_reconnect` with bounded retries + backoff, re-checking the tool count after each attempt.
4. Only if recovery is exhausted, emit a new `provider://mcp-degraded` event.

**Frontend (`providers.ts`, `agent.store.ts`)** — forward `provider://mcp-degraded` and render a calm, non-fatal in-thread notice (the thread still works for non-publisher tasks — no error banner, no frozen composer) and route it through `captureSupportError` so a persistent gateway `tools/list` failure is ticketable instead of silent.

## Networked path

The only outbound path is the agent CLI's own MCP client -> `https://mcp.serendb.com/mcp` (streamable-HTTP, `Authorization: Bearer ${SEREN_API_KEY}`), configured via `--mcp-config`. This PR adds **no new outbound requests** — it uses the CLI's local `mcp_status` / `mcp_reconnect` control channel over stdio. Verified the seren-mcp slug/URL against the live config builder (`mcp-config.mjs`).

## Validation

- **Live functional test** against the actual gateway using the real runtime code (`createClaudeRuntime`) + the real agent CLI: reproduced an **active occurrence** of the bug — seren-mcp reached `status=connected` but returned `tools=0` for 30s+ straight (the model even fell back to `ToolSearch` hunting for the missing tools). The fix's settle -> detect -> 3x reconnect -> `provider://mcp-degraded` sequence fired end to end. **The gateway's streamable-HTTP `tools/list` is currently broken** — see companion **serenorg/seren#188** for the server-side root cause.
- `pnpm vitest run` — **2184 passed**. New `tests/unit/claude-runtime-seren-mcp-audit.test.ts` covers the detection predicate behaviorally (healthy / degraded / other-server / malformed) and locks in the settle + reconnect wiring; updated `providers.test.ts` listener counts for the new event.
- `tsc --noEmit` clean for changed files; `biome check` clean.

## Notes / follow-ups

- The **root cause is server-side** (serenorg/seren#188); this desktop change is the belt-and-suspenders detection + recovery + visibility layer.
- Scope is the Claude Code spawn path (the reported surface). Codex/Gemini use different MCP plumbing and would need separate handling if the same failure appears there.
- The secondary in-app-chat/orchestrator bugs listed in #2802 (gateway pagination, `waitForGatewayReady` on the agent path, connected-but-toolless gateway) are a different surface and out of scope here.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
