### PR TITLE
Fix recording indicator overlap with chat composer controls

### DIFF
--- a/src/components/meeting/RecordingIndicator.tsx
+++ b/src/components/meeting/RecordingIndicator.tsx
@@ -3,6 +3,13 @@
 
 import { createEffect, createSignal, onCleanup, onMount, Show } from "solid-js";
 import { meetingStore } from "@/stores/meeting.store";
+import {
+  DEFAULT_COMPOSER_GAP,
+  DEFAULT_EDGE_INSET,
+  DEFAULT_TITLEBAR_HEIGHT,
+  defaultRecordingIndicatorPosition,
+  type Position,
+} from "./recordingIndicatorPlacement";
 
 function formatElapsed(ms: number): string {
   const total = Math.max(0, Math.floor(ms / 1000));
@@ -22,11 +29,6 @@ const DISCLOSURE =
 // Persisted drag position so a user who moved the indicator off their controls
 // keeps it there across reopens. UI-only; not sensitive.
 const POSITION_KEY = "seren.recordingIndicator.position";
-
-interface Position {
-  x: number;
-  y: number;
-}
 
 function loadPosition(): Position | null {
   try {
@@ -48,8 +50,12 @@ export function RecordingIndicator() {
   const [deleting, setDeleting] = createSignal(false);
   const [copied, setCopied] = createSignal(false);
   const [position, setPosition] = createSignal<Position | null>(loadPosition());
+  const [defaultPosition, setDefaultPosition] = createSignal<Position | null>(
+    null,
+  );
   let containerRef: HTMLDivElement | undefined;
   let drag: { px: number; py: number; ox: number; oy: number } | null = null;
+  let defaultPositionFrame: number | null = null;
 
   let timer: number | undefined;
   onMount(() => {
@@ -64,6 +70,7 @@ export function RecordingIndicator() {
       (meeting) => meeting.status === "capturing",
     ) ?? null;
   const paused = () => meetingStore.state.capturePaused;
+  const displayedPosition = () => position() ?? defaultPosition();
 
   // Drop a stale delete confirmation if the recording ends.
   createEffect(() => {
@@ -105,6 +112,55 @@ export function RecordingIndicator() {
     };
   };
 
+  const titlebarHeight = (): number => {
+    const raw = getComputedStyle(document.documentElement)
+      .getPropertyValue("--titlebar-height")
+      .trim();
+    const parsed = Number.parseFloat(raw);
+    return Number.isFinite(parsed) ? parsed : DEFAULT_TITLEBAR_HEIGHT;
+  };
+
+  const visibleComposerTop = (): number | null => {
+    const composers = Array.from(
+      document.querySelectorAll<HTMLElement>(".chat-composer-form"),
+    );
+    const visibleComposers = composers
+      .map((composer) => composer.getBoundingClientRect())
+      .filter(
+        (rect) =>
+          rect.width > 0 &&
+          rect.height > 0 &&
+          rect.bottom > 0 &&
+          rect.top < window.innerHeight,
+      )
+      .sort((a, b) => b.bottom - a.bottom);
+
+    return visibleComposers[0]?.top ?? null;
+  };
+
+  const updateDefaultPosition = () => {
+    if (!active() || position() || !containerRef) return;
+    const next = defaultRecordingIndicatorPosition({
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      indicatorWidth: containerRef.offsetWidth,
+      indicatorHeight: containerRef.offsetHeight,
+      composerTop: visibleComposerTop(),
+      titlebarHeight: titlebarHeight(),
+    });
+    setDefaultPosition((current) =>
+      current?.x === next.x && current.y === next.y ? current : next,
+    );
+  };
+
+  const scheduleDefaultPositionUpdate = () => {
+    if (defaultPositionFrame !== null) return;
+    defaultPositionFrame = window.requestAnimationFrame(() => {
+      defaultPositionFrame = null;
+      updateDefaultPosition();
+    });
+  };
+
   // Clamping otherwise only runs mid-drag, so a position restored at a smaller
   // window size — or a window shrunk after dragging — could strand the pill
   // off-screen (and the drag handle out of reach). Re-clamp on window resize and
@@ -112,15 +168,39 @@ export function RecordingIndicator() {
   const onResize = () => {
     const current = position();
     if (current) setPosition(clampToViewport(current.x, current.y));
+    else scheduleDefaultPositionUpdate();
   };
   onMount(() => {
     window.addEventListener("resize", onResize);
-    onCleanup(() => window.removeEventListener("resize", onResize));
+    const layoutObserver = new MutationObserver(() => {
+      if (active() && !position()) scheduleDefaultPositionUpdate();
+    });
+    layoutObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["aria-hidden", "class", "hidden", "style"],
+    });
+    onCleanup(() => {
+      window.removeEventListener("resize", onResize);
+      layoutObserver.disconnect();
+      if (defaultPositionFrame !== null) {
+        window.cancelAnimationFrame(defaultPositionFrame);
+      }
+    });
   });
   createEffect(() => {
-    if (!active()) return;
+    if (!active()) {
+      setDefaultPosition(null);
+      return;
+    }
     const current = position();
-    if (!current || !containerRef) return;
+    if (!current) {
+      scheduleDefaultPositionUpdate();
+      return;
+    }
+    if (!containerRef) return;
+    setDefaultPosition(null);
     const clamped = clampToViewport(current.x, current.y);
     if (clamped.x !== current.x || clamped.y !== current.y) {
       setPosition(clamped);
@@ -204,16 +284,20 @@ export function RecordingIndicator() {
     <Show when={active()}>
       <div
         ref={containerRef}
-        class="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border border-destructive/40 bg-popover/95 px-3 py-1.5 shadow-[0_8px_24px_rgba(0,0,0,0.32)] backdrop-blur-sm animate-[fadeIn_200ms_ease]"
+        class="fixed z-50 flex items-center gap-2 rounded-full border border-destructive/40 bg-popover/95 px-3 py-1.5 shadow-[0_8px_24px_rgba(0,0,0,0.32)] backdrop-blur-sm animate-[fadeIn_200ms_ease]"
         style={
-          position()
+          displayedPosition()
             ? {
-                left: `${position()?.x}px`,
-                top: `${position()?.y}px`,
+                left: `${displayedPosition()?.x}px`,
+                top: `${displayedPosition()?.y}px`,
                 right: "auto",
                 bottom: "auto",
               }
-            : undefined
+            : {
+                right: `${DEFAULT_EDGE_INSET}px`,
+                top: `calc(var(--titlebar-height, ${DEFAULT_TITLEBAR_HEIGHT}px) + ${DEFAULT_COMPOSER_GAP}px)`,
+                bottom: "auto",
+              }
         }
         aria-label={statusText()}
       >

--- a/src/components/meeting/recordingIndicatorPlacement.ts
+++ b/src/components/meeting/recordingIndicatorPlacement.ts
@@ -1,0 +1,48 @@
+// ABOUTME: Pure positioning helper for the floating meeting recording controls.
+// ABOUTME: Keeps default placement testable without importing Solid TSX.
+
+export const DEFAULT_EDGE_INSET = 16;
+export const DEFAULT_COMPOSER_GAP = 12;
+export const DEFAULT_TITLEBAR_HEIGHT = 40;
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface RecordingIndicatorPlacementInput {
+  viewportWidth: number;
+  viewportHeight: number;
+  indicatorWidth: number;
+  indicatorHeight: number;
+  composerTop: number | null;
+  titlebarHeight?: number;
+}
+
+export function defaultRecordingIndicatorPosition(
+  input: RecordingIndicatorPlacementInput,
+): Position {
+  const safeTop =
+    (input.titlebarHeight ?? DEFAULT_TITLEBAR_HEIGHT) + DEFAULT_COMPOSER_GAP;
+  const maxX = Math.max(0, input.viewportWidth - input.indicatorWidth);
+  const maxY = Math.max(0, input.viewportHeight - input.indicatorHeight);
+  const preferredX =
+    input.viewportWidth - input.indicatorWidth - DEFAULT_EDGE_INSET;
+  const bottomRightY =
+    input.viewportHeight - input.indicatorHeight - DEFAULT_EDGE_INSET;
+  const composerSafeY =
+    input.composerTop === null
+      ? null
+      : input.composerTop - input.indicatorHeight - DEFAULT_COMPOSER_GAP;
+  const preferredY =
+    composerSafeY !== null && composerSafeY >= safeTop
+      ? composerSafeY
+      : input.composerTop !== null
+        ? safeTop
+        : bottomRightY;
+
+  return {
+    x: Math.min(Math.max(DEFAULT_EDGE_INSET, preferredX), maxX),
+    y: Math.min(Math.max(0, preferredY), maxY),
+  };
+}

--- a/tests/unit/recording-indicator-placement.test.ts
+++ b/tests/unit/recording-indicator-placement.test.ts
@@ -1,0 +1,34 @@
+// ABOUTME: Regression coverage for #2806 recording indicator default placement.
+// ABOUTME: Ensures the first-run pill clears the chat composer controls.
+
+import { describe, expect, it } from "vitest";
+import { defaultRecordingIndicatorPosition } from "@/components/meeting/recordingIndicatorPlacement";
+
+describe("recording indicator placement (#2806)", () => {
+  it("places the default indicator above a visible chat composer", () => {
+    const position = defaultRecordingIndicatorPosition({
+      viewportWidth: 1440,
+      viewportHeight: 900,
+      indicatorWidth: 320,
+      indicatorHeight: 40,
+      composerTop: 720,
+      titlebarHeight: 40,
+    });
+
+    expect(position.x).toBe(1104);
+    expect(position.y + 40).toBeLessThanOrEqual(708);
+  });
+
+  it("keeps the old bottom-right default when no chat composer is visible", () => {
+    const position = defaultRecordingIndicatorPosition({
+      viewportWidth: 1440,
+      viewportHeight: 900,
+      indicatorWidth: 320,
+      indicatorHeight: 40,
+      composerTop: null,
+      titlebarHeight: 40,
+    });
+
+    expect(position).toEqual({ x: 1104, y: 844 });
+  });
+});


### PR DESCRIPTION
Closes #2806

## Summary
- default the floating meeting recording indicator above a visible chat composer instead of the bottom-right composer controls
- keep dragged/persisted indicator positions intact and clamp them as before
- add a pure placement helper plus focused regression coverage for composer-present and no-composer defaults

## Audit
- Code path: `AppShell` mounts `RecordingIndicator`; `RecordingIndicator` reads active captures from `meetingStore`; chat composer bounds come from `.chat-composer-form` in `AgentChat` / `ChatContent`.
- Prior work reviewed: release audit `AUD-017`, #2708/#2717 draggable indicator work, #2211/#2214 titlebar recorder relocation, and #2679 automatic capture lifecycle.
- Networked path: none for this UI placement change. No outbound publisher/API slug, method, or path exists in the changed feature path.

## Validation
- `pnpm exec vitest run tests/unit/recording-indicator-placement.test.ts tests/unit/record-prompt-placement.test.ts tests/unit/meeting-rename-and-indicator.test.ts tests/unit/composer-toolbar-layout.test.ts`
- `pnpm exec biome check src/components/meeting/RecordingIndicator.tsx src/components/meeting/recordingIndicatorPlacement.ts tests/unit/recording-indicator-placement.test.ts`
- `pnpm build` passed with existing Rolldown/node_modules and chunk-size warnings
- Real-app validation in the Tauri validation harness started meeting capture and captured the chat composer with the recording indicator above the composer controls. Later clean-profile reruns reached the native capture path but timed out while native mic initialization was blocked in the local environment.
