### PR TITLE
fix(agent): default new Claude threads to Opus 4.8 1M + bypass (#2810)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -594,9 +594,35 @@ const ONE_M_TIER_RECORDS = [
 ];
 
 // Default model for fresh sessions. Chosen so users land on the 1M-tier
-// experience without needing picker discovery; the cli-updater baseline at
-// 2.1.120 (#1761) guarantees every running CLI knows this id. #1763.
-const DEFAULT_PREFERRED_MODEL = "claude-opus-4-7[1m]";
+// experience without needing picker discovery; the cli-updater baseline
+// (see CLI_MIN_VERSION_BASELINE) guarantees every running CLI knows this id.
+// Opus 4.8 was prewired in #2060; #2810 promotes it to the out-of-box default.
+// #1763.
+const DEFAULT_PREFERRED_MODEL = "claude-opus-4-8[1m]";
+
+// Out-of-box permission mode for fresh Claude threads. Users land on
+// bypassPermissions so they are not re-selecting it every session — the
+// composer Permission Mode selector is the source of truth, and per-thread
+// changes persist per-conversation (#1597). See claudeModeFromApprovalPolicy
+// for how an explicitly stricter approval policy still downgrades the seed.
+// #2810.
+const DEFAULT_PREFERRED_MODE = "bypassPermissions";
+
+// Maps the persisted agent approval policy to the permission mode a fresh
+// Claude thread spawns in. The default and on-request policies land on the
+// out-of-box DEFAULT_PREFERRED_MODE; only an explicitly stricter policy
+// (untrusted / on-failure) downgrades to acceptEdits. Runs against the stored
+// setting at every spawn, so it governs the composer default without mutating
+// the saved value. #2810.
+function claudeModeFromApprovalPolicy(approvalPolicy) {
+  switch (approvalPolicy) {
+    case "untrusted":
+    case "on-failure":
+      return "acceptEdits";
+    default:
+      return DEFAULT_PREFERRED_MODE;
+  }
+}
 
 // Picker order (top → bottom): the active default first, then by family
 // (opus → sonnet → haiku → other), then by version descending (4-7 → 4-6 →
@@ -2265,19 +2291,6 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     };
   }
 
-  function claudeModeFromApprovalPolicy(approvalPolicy) {
-    switch (approvalPolicy) {
-      case "on-request":
-      case "untrusted":
-      case "on-failure":
-        return "acceptEdits";
-      case "never":
-        return "bypassPermissions";
-      default:
-        return "acceptEdits";
-    }
-  }
-
   async function spawnSession(params) {
     const {
       cwd,
@@ -2998,6 +3011,8 @@ export {
   augmentWithLegacyOpus as _augmentWithLegacyOpus,
   ONE_M_TIER_RECORDS as _ONE_M_TIER_RECORDS,
   DEFAULT_PREFERRED_MODEL as _DEFAULT_PREFERRED_MODEL,
+  DEFAULT_PREFERRED_MODE as _DEFAULT_PREFERRED_MODE,
+  claudeModeFromApprovalPolicy as _claudeModeFromApprovalPolicy,
   comparePickerEntries as _comparePickerEntries,
   resolveSpawnShell as _resolveSpawnShell,
   buildClaudeArgs as _buildClaudeArgs,

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -35,10 +35,13 @@ const SEMVER_EXTRACT_RE = /\d+\.\d+\.\d+[^\s]*/;
  * the baseline we ignore the 24h TTL and force an update on the next launch.
  * This unsticks installs that were poisoned by an old `cli-tools/package.json`
  * caret pin (e.g. `^2.1.30`) or by a transient registry failure that the TTL
- * then masked for months. Bumped together with #1761 so users gain access to
- * the JS→native migration boundary at 2.1.120 and the Opus 4.7 catalog. */
+ * then masked for months. #1761 set this to 2.1.120 for the JS→native
+ * migration boundary and the Opus 4.7 catalog; #2810 raises it so a stuck
+ * install cannot spawn on the new Opus 4.8 default (the CLI rejects unknown
+ * model ids), since the gate force-updates to `@latest`. 2.1.197 is verified
+ * to ship the claude-opus-4-8 catalog. */
 export const CLI_MIN_VERSION_BASELINE = {
-  "@anthropic-ai/claude-code": "2.1.120",
+  "@anthropic-ai/claude-code": "2.1.197",
 };
 
 /** Returns true when `installed` is a clean semver below `baseline`. */

--- a/tests/unit/claude-runtime-1m-tier-postinit.test.ts
+++ b/tests/unit/claude-runtime-1m-tier-postinit.test.ts
@@ -50,13 +50,13 @@ describe("#1776 — post-init currentModelId resolution preserves [1m]", () => {
     expect(fnBody).not.toContain("chooseUpdatedModelId(");
   });
 
-  it("DEFAULT_PREFERRED_MODEL is the [1m]-tier Opus 4.7 id", () => {
+  it("DEFAULT_PREFERRED_MODEL is the [1m]-tier Opus 4.8 id (#2810)", () => {
     // The fresh-thread fallback must default to the 1M-tier variant so the
     // picker shows it as the default selection out of the box. Combined with
     // the chooseUpdatedModelId reuse above, this gives fresh threads a 1M
     // window without requiring picker discovery.
     expect(claudeRuntimeSource).toContain(
-      'const DEFAULT_PREFERRED_MODEL = "claude-opus-4-7[1m]";',
+      'const DEFAULT_PREFERRED_MODEL = "claude-opus-4-8[1m]";',
     );
   });
 });

--- a/tests/unit/claude-runtime-1m-tier.test.ts
+++ b/tests/unit/claude-runtime-1m-tier.test.ts
@@ -233,9 +233,9 @@ describe("comparePickerEntries — default first, newest descending (#1763)", ()
   });
 });
 
-describe("DEFAULT_PREFERRED_MODEL — fresh-session out-of-box default (#1763)", () => {
-  it("is the Opus 4.7 1M-tier id so new users get the wider window without picker discovery", () => {
-    expect(DEFAULT_PREFERRED_MODEL).toBe("claude-opus-4-7[1m]");
+describe("DEFAULT_PREFERRED_MODEL — fresh-session out-of-box default (#1763, #2810)", () => {
+  it("is the Opus 4.8 1M-tier id so new users get the newest model + wider window without picker discovery", () => {
+    expect(DEFAULT_PREFERRED_MODEL).toBe("claude-opus-4-8[1m]");
   });
 });
 

--- a/tests/unit/claude-runtime-default-permission-mode.test.ts
+++ b/tests/unit/claude-runtime-default-permission-mode.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Critical guard for #2810 — fresh Claude threads default to Bypass Permissions.
+// ABOUTME: Verifies the approval-policy → permission-mode seed so new threads land on bypass.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const {
+  _DEFAULT_PREFERRED_MODE: DEFAULT_PREFERRED_MODE,
+  _claudeModeFromApprovalPolicy: claudeModeFromApprovalPolicy,
+} = await import(/* @vite-ignore */ modulePath);
+
+describe("DEFAULT_PREFERRED_MODE — fresh-session out-of-box permission mode (#2810)", () => {
+  it("is bypassPermissions so new Claude threads auto-approve without re-selection", () => {
+    expect(DEFAULT_PREFERRED_MODE).toBe("bypassPermissions");
+  });
+});
+
+describe("claudeModeFromApprovalPolicy — fresh-session seed (#2810)", () => {
+  it("lands the default 'on-request' policy on bypassPermissions", () => {
+    // 'on-request' is the shipped default agentApprovalPolicy; running the
+    // stored value through the mapping at spawn is what fixes existing installs
+    // without mutating the saved setting.
+    expect(claudeModeFromApprovalPolicy("on-request")).toBe("bypassPermissions");
+  });
+
+  it("keeps 'never' on bypassPermissions", () => {
+    expect(claudeModeFromApprovalPolicy("never")).toBe("bypassPermissions");
+  });
+
+  it("falls back to bypassPermissions for unknown / unset policies", () => {
+    expect(claudeModeFromApprovalPolicy(undefined)).toBe("bypassPermissions");
+    expect(claudeModeFromApprovalPolicy("something-else")).toBe(
+      "bypassPermissions",
+    );
+  });
+
+  it("honors an explicitly stricter policy by downgrading to acceptEdits", () => {
+    expect(claudeModeFromApprovalPolicy("untrusted")).toBe("acceptEdits");
+    expect(claudeModeFromApprovalPolicy("on-failure")).toBe("acceptEdits");
+  });
+});

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -173,7 +173,7 @@ describe("backgroundUpdateCli TTL gate", () => {
       state,
       now: Date.now(),
       _versionOverrides: {
-        runInstalledVersion: async () => "2.1.123",
+        runInstalledVersion: async () => "2.1.199",
         runNpmView: async () => null,
       },
     });
@@ -200,12 +200,14 @@ describe("isBelowBaseline (#1761)", () => {
     expect(isBelowBaseline("2.1.30", "")).toBe(false);
   });
 
-  it("Claude Code baseline is at the JS→native migration boundary", () => {
-    // 2.1.120 is the first native-binary release. Below this, users miss
-    // the Opus 4.7 catalog and the binary structure the install detection
-    // expects. The baseline must not regress without explicit reasoning.
+  it("Claude Code baseline ships the Opus 4.8 catalog (#2810)", () => {
+    // #1761 set this to 2.1.120 (JS→native boundary + Opus 4.7 catalog).
+    // #2810 raised it to 2.1.197 so a stuck install can't spawn on the new
+    // Opus 4.8 default — the CLI rejects unknown model ids, and the baseline
+    // gate force-updates to @latest. 2.1.197 is verified to ship
+    // claude-opus-4-8. The baseline must not regress without explicit reasoning.
     expect(CLI_MIN_VERSION_BASELINE["@anthropic-ai/claude-code"]).toBe(
-      "2.1.120",
+      "2.1.197",
     );
   });
 });


### PR DESCRIPTION
Closes #2810.

## What

Fresh Claude Code (subscription/CLI) threads landed on the wrong out-of-box defaults, forcing users to re-select both controls every new thread:

- **Model** defaulted to Opus 4.7 (1M) even though Opus 4.8 (1M) was prewired months ago (#2060).
- **Permission Mode** (composer toolbar) defaulted to Accept Edits, not Bypass Permissions.

## Changes (Node provider runtime — no Rust/SolidJS)

- `claude-runtime.mjs`: `DEFAULT_PREFERRED_MODEL` → `claude-opus-4-8[1m]`.
- `cli-updater.mjs`: `CLI_MIN_VERSION_BASELINE` → `2.1.197`. The CLI rejects unknown model ids, so a stuck install must force-update to a binary that recognizes `claude-opus-4-8`; the baseline gate installs `@latest`. 2.1.197 verified to ship the opus-4-8 catalog.
- `claude-runtime.mjs`: remap the fresh-session seed so `on-request`/default → `bypassPermissions`, keeping explicit `untrusted`/`on-failure` → `acceptEdits`. Runs against the **stored** setting at spawn, so it fixes existing installs without mutating the saved Agent Approval Policy value.

## Tests

- New: `claude-runtime-default-permission-mode.test.ts` (fresh-session seed → bypass; stricter policy → acceptEdits).
- Updated the guarding tests for the model default (`claude-runtime-1m-tier*.test.ts`) and the CLI baseline (`cli-updater.test.ts`). Full suite green (2191/2191).

## Functional validation (live CLI, macOS)

Drove the real `spawnSession` against the logged-in `claude` 2.1.199:

- Permission mode: fresh session with saved `on-request` → session-status `currentModeId: "bypassPermissions"`. ✅
- Model: session runs `claude-opus-4-8[1m]` on the genuine 1M tier — direct CLI turn reports `modelUsage: claude-opus-4-8[1m]`, and the runtime emits `contextWindow: 1000000`, so the compaction denominator is correctly 1M (no premature compaction). ✅

## Known limitation (accepted, self-resolving)

On subscriptions whose CLI `initialize` catalog does not yet advertise `claude-opus-4-8`, the model **label** lags: the composer shows the newest catalog Opus (e.g. "Opus 4.6") before the first message, then the bare 4.8 id after — even though the session runs 4.8 on the 1M tier. Root cause is Anthropic-side: the CLI's advisory catalog omits 4.8 for the account (it accepts 4.7 when requested but drops 4.8), so Seren falls back to its newest named Opus. This clears automatically once the account's CLI catalog advertises 4.8. Shipping ahead of that rollout per product decision.

## Networked paths

No Seren publisher/gateway slug involved. External calls unchanged in mechanism: (a) local Claude CLI → Anthropic API with the existing `context-1m-2025-08-07` beta header (newer model id only); (b) `npm install -g @anthropic-ai/claude-code@latest` via the embedded runtime for the baseline force-update.

## Security note

New Claude threads now auto-approve every tool by default (bypassPermissions). Intentional per request.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
