### PR TITLE
fix(meeting): make auto-detect poll single-flight (#2814)

### DIFF
--- a/src/stores/meeting.store.ts
+++ b/src/stores/meeting.store.ts
@@ -196,6 +196,16 @@ let quitConfirmed = false;
 // so a double-trigger can't launch two mic streams for the same session.
 let isStarting = false;
 
+// Single-flight guard for the auto-detect poll. `setInterval` fires the poll
+// every AUTO_DETECT_POLL_MS regardless of whether the prior tick has finished,
+// and a tick that auto-starts a capture parks on `requestCaptureStart` while
+// native mic init runs (seconds to minutes). Without this guard, overlapping
+// ticks fire `meetingLifecycleNoteManualStop` against the in-flight start (the
+// new pending_capture row isn't in the store yet, so `isCapturing()` reads
+// false) and spawn orphaned pending_capture meetings that wedge the panel in
+// "Starting". The auto-detect loop is single-flight by design.
+let pollInFlight = false;
+
 // Stops in flight, keyed by meeting id. Two stop sources (tray + panel) can
 // fire near-simultaneously and both pass the status check, double-running notes
 // + the agent handoff. This guard makes the second a no-op (#2162).
@@ -1365,7 +1375,20 @@ async function refreshUpcomingEventsIfStale(): Promise<void> {
   setMeetingState("upcomingStatus", result.status);
 }
 
+// Serialize the poll: skip a tick while a prior one is still running (including
+// its awaited capture start/stop), so overlapping ticks can't desync the
+// lifecycle or orphan a pending_capture meeting mid-start.
 async function pollAutoDetect(): Promise<void> {
+  if (pollInFlight) return;
+  pollInFlight = true;
+  try {
+    await runAutoDetectPollOnce();
+  } finally {
+    pollInFlight = false;
+  }
+}
+
+async function runAutoDetectPollOnce(): Promise<void> {
   if (!isTauriRuntime()) return;
   if (!settingsStore.get("meetingAutoDetectEnabled")) {
     setMeetingState("autoDetectSuggested", false);

--- a/tests/unit/meeting-autodetect-poll-reentrancy.test.ts
+++ b/tests/unit/meeting-autodetect-poll-reentrancy.test.ts
@@ -1,0 +1,152 @@
+// ABOUTME: Regression coverage for #2814 — the auto-detect poll is single-flight.
+// ABOUTME: Overlapping ticks during an in-flight capture start must not desync the lifecycle or orphan meetings.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const m = vi.hoisted(() => ({
+  meetingLifecycleTick: vi.fn(async () => ({
+    kind: "start_capture" as const,
+    sourceApp: "Teams",
+  })),
+  meetingLifecycleNoteManualStop: vi.fn(async () => {}),
+  meetingLifecycleNoteCaptureStarted: vi.fn(async () => {}),
+  meetingLifecycleNoteStartFailed: vi.fn(async () => {}),
+  meetingAutodetect: vi.fn(async () => ({ detected: false, sourceApp: null })),
+  createMeeting: vi.fn(),
+  startMeetingCapture: vi.fn(),
+  listMeetings: vi.fn(async (): Promise<Meeting[]> => []),
+  getUpcomingEvents: vi.fn(async () => ({
+    events: [],
+    status: "connected" as const,
+  })),
+  setTrayRecording: vi.fn(),
+}));
+
+vi.mock("@/lib/tauri-bridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tauri-bridge")>()),
+  isTauriRuntime: () => true,
+}));
+vi.mock("@/services/meetings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/meetings")>()),
+  meetingLifecycleTick: m.meetingLifecycleTick,
+  meetingLifecycleNoteManualStop: m.meetingLifecycleNoteManualStop,
+  meetingLifecycleNoteCaptureStarted: m.meetingLifecycleNoteCaptureStarted,
+  meetingLifecycleNoteStartFailed: m.meetingLifecycleNoteStartFailed,
+  meetingAutodetect: m.meetingAutodetect,
+  createMeeting: m.createMeeting,
+  startMeetingCapture: m.startMeetingCapture,
+  listMeetings: m.listMeetings,
+}));
+vi.mock("@/services/calendar", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/calendar")>()),
+  getUpcomingEvents: m.getUpcomingEvents,
+}));
+vi.mock("@/services/transcript-search", () => ({
+  backfillTranscriptIndex: vi.fn(),
+  deleteMeetingIndex: vi.fn(),
+  indexMeeting: vi.fn(async () => {}),
+}));
+vi.mock("@/services/orchestrator", () => ({ orchestrate: vi.fn() }));
+vi.mock("@/services/tray", () => ({
+  setTrayRecording: m.setTrayRecording,
+  onTrayToggleCapture: vi.fn(() => () => {}),
+}));
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: (key: string) =>
+      key === "meetingAutoDetectEnabled" || key === "meetingAudioPrimed"
+        ? true
+        : null,
+    set: vi.fn(),
+  },
+}));
+vi.mock("@/stores/conversation.store", () => ({
+  conversationStore: {
+    createConversationWithModel: vi.fn(async () => ({ id: "c1" })),
+    setActiveConversation: vi.fn(),
+  },
+}));
+vi.mock("@/stores/provider.store", () => ({
+  providerStore: { resolvedModel: () => "model", activeModel: "model" },
+}));
+vi.mock("@/stores/skills.store", () => ({
+  skillsStore: { enabledSkills: [] },
+}));
+
+import type { Meeting } from "@/services/meetings";
+import { meetingStore } from "@/stores/meeting.store";
+
+const AUTO_DETECT_POLL_MS = 5_000;
+
+function meeting(overrides: Partial<Meeting> = {}): Meeting {
+  return {
+    id: "auto-1",
+    title: "Meeting",
+    sourceApp: "Teams",
+    startedAt: 0,
+    endedAt: null,
+    status: "pending_capture",
+    templateId: null,
+    routedSkillSlug: null,
+    agentConversationId: null,
+    notesMarkdown: null,
+    notesStructJson: null,
+    failureReason: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("auto-detect poll re-entrancy (#2814)", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(m)) fn.mockClear();
+    m.createMeeting.mockResolvedValue(meeting());
+    m.listMeetings.mockResolvedValue([]);
+    m.meetingLifecycleTick.mockResolvedValue({
+      kind: "start_capture",
+      sourceApp: "Teams",
+    });
+  });
+
+  it("skips ticks while a capture start is in flight, never orphaning meetings or faking a manual stop", async () => {
+    vi.useFakeTimers();
+    // startAutoDetect drives the poll off window.setInterval; in the node test
+    // env, point window at globalThis so it resolves to the fake-timer globals.
+    const hadWindow = "window" in globalThis;
+    if (!hadWindow) {
+      (globalThis as { window?: typeof globalThis }).window = globalThis;
+    }
+    // The auto-started capture parks on native mic init: startMeetingCapture stays
+    // pending for the whole window, exactly like the ~4-minute block in the report.
+    let releaseStart: () => void = () => {};
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    m.startMeetingCapture.mockReturnValue(startGate);
+
+    try {
+      // First tick fires synchronously and parks inside requestCaptureStart.
+      meetingStore.startAutoDetect();
+      await vi.advanceTimersByTimeAsync(1);
+
+      // Three more interval ticks fire while the start is still in flight.
+      await vi.advanceTimersByTimeAsync(AUTO_DETECT_POLL_MS * 3);
+
+      // Exactly one capture was created and started; the overlapping ticks were
+      // skipped rather than churning new pending_capture rows.
+      expect(m.createMeeting).toHaveBeenCalledTimes(1);
+      expect(m.startMeetingCapture).toHaveBeenCalledTimes(1);
+      // The in-flight start must never be mistaken for a manual stop.
+      expect(m.meetingLifecycleNoteManualStop).not.toHaveBeenCalled();
+    } finally {
+      releaseStart();
+      await vi.advanceTimersByTimeAsync(1);
+      meetingStore.stopAutoDetect();
+      vi.useRealTimers();
+      if (!hadWindow) {
+        (globalThis as { window?: typeof globalThis }).window = undefined;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

Fixes #2814 — a meeting perpetually stuck in **"Starting"** with an auto-record start/stop loop and no in-app recovery.

## Root cause (audited)

`pollAutoDetect()` in `src/stores/meeting.store.ts` is driven by `setInterval(() => void pollAutoDetect(), 5s)` with **no re-entrancy guard**. When a tick auto-starts a capture it `await`s `requestCaptureStart` → `startBackendCapture`, which blocks on native mic/CoreAudio init — **~4 minutes** in the reported log. During that window:

- The new `pending_capture` meeting is created via a pure service call and is **not yet in `meetingState.meetings`** (the store is only refreshed by `loadMeetings()` *after* the start resolves), so `isCapturing()` reads **false**.
- Overlapping interval ticks therefore (a) fire `meetingLifecycleNoteManualStop()` against the in-flight start, desyncing the Rust lifecycle controller, and (b) re-enter the `start_capture` branch and `createMeeting()` more `pending_capture` rows whose `beginCapture()` immediately no-ops on the `isStarting` guard — **orphans** stuck in `pending_capture`.

An orphaned `pending_capture` meeting becomes `captureOwner()`, which disables Start, hides Stop (shown only for `status === "capturing"`), and blocks delete — the perpetual "Starting" wedge.

## Fix

Make `pollAutoDetect` **single-flight**: skip a tick while a prior one (including its awaited capture start/stop) is still running. The auto-detect loop is a single-flight state machine by design; overlapping ticks are never valid. Minimal change — the poll body is unchanged, wrapped by a `pollInFlight` guard with try/finally.

## Networked path

Frontend-only. The change touches the local auto-detect loop (`meeting_lifecycle_tick`, `meeting_autodetect`, `createMeeting` → local SQLite; all local Tauri IPC). **No Gateway/publisher (`api.serendb.com` / `mcp.serendb.com`) request path is added or altered.**

## Tests

- New `tests/unit/meeting-autodetect-poll-reentrancy.test.ts`: with `startMeetingCapture` held pending (simulating the mic-init block), three overlapping interval ticks must not create extra meetings or fake a manual stop. **Fails pre-fix** (`createMeeting` called 4×, orphans) and **passes after**.
- Full unit suite green: **2192 passed**. `tsc --noEmit` clean. Biome clean.

## Verification note

Manual in-app walkthrough on macOS (auto-detect on, join/leave a Teams call, confirm no stuck "Starting" and no start/stop churn) is the remaining functional check; the deterministic regression test reproduces the exact overlapping-tick condition that produced the wedge in the field log.
