### PR TITLE
fix(agent): preserve Opus 4.8 1M label (#2812)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -701,6 +701,42 @@ function augmentWithLegacyOpus(records) {
   return merged.slice().sort(comparePickerEntries);
 }
 
+function makeFallbackModelRecord(modelId) {
+  return {
+    modelId,
+    name: modelId,
+    description: undefined,
+    supportsEffort: false,
+    supportsFastMode: false,
+    supportsAutoMode: false,
+    supportsAdaptiveThinking: false,
+    supportedEffortLevels: [],
+    isDefault: false,
+  };
+}
+
+function ensurePreferredModelRecord(records, preferredModel) {
+  if (typeof preferredModel !== "string" || preferredModel.length === 0) {
+    return records;
+  }
+
+  const existing = records.find((record) => record.modelId === preferredModel);
+  const preferredRecord =
+    existing ??
+    ONE_M_TIER_RECORDS.find((record) => record.modelId === preferredModel) ??
+    makeFallbackModelRecord(preferredModel);
+
+  const withoutPreferred = records.filter(
+    (record) => record.modelId !== preferredModel,
+  );
+  return [
+    { ...preferredRecord, isDefault: true },
+    ...withoutPreferred.map((record) =>
+      record.isDefault ? { ...record, isDefault: false } : record,
+    ),
+  ].sort(comparePickerEntries);
+}
+
 function combinePrompt(prompt, context) {
   const contextText = Array.isArray(context)
     ? context
@@ -2231,6 +2267,26 @@ function attachProcessListeners(emit, sessions, session, exitPromises) {
   });
 }
 
+function resolvePostInitCurrentModelId(
+  previousModelId,
+  initModel,
+  availableModelRecords,
+) {
+  const inferredFromInit =
+    typeof initModel === "string" && initModel.length > 0
+      ? inferCurrentModelId(initModel, availableModelRecords)
+      : null;
+  return (
+    chooseUpdatedModelId(
+      previousModelId,
+      inferredFromInit,
+      availableModelRecords,
+    ) ??
+    inferredFromInit ??
+    previousModelId
+  );
+}
+
 export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) {
   const sessions = new Map();
   const claudeLogPrefix = providerLogPrefix("claude", runtimeMode);
@@ -2327,10 +2383,10 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       normalizeEffort(reasoningEffort) ?? DEFAULT_CLAUDE_EFFORT;
     // Prefer the user's persisted choice (agent_model_id from the conversation
     // row) so a resumed thread spawns on the model the user actually picked.
-    // Falls back to Opus 4.7 with the 1M-tier suffix for fresh threads — that
+    // Falls back to Opus 4.8 with the 1M-tier suffix for fresh threads — that
     // is the out-of-box default users should land on so the wider window is
     // active without requiring picker discovery (#1763). The cli-updater
-    // baseline at 2.1.120 (#1761) ensures every running CLI knows this model.
+    // baseline at 2.1.197 (#2810) ensures every running CLI knows this model.
     // When the CLI adds/changes models, the picker stays authoritative; the
     // assistant message handler below then corrects session.currentModelId
     // from Anthropic's message.model ground truth on the first response,
@@ -2510,8 +2566,11 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         }
       }
 
-      session.availableModelRecords = augmentWithLegacyOpus(
-        normalizeModelRecords(initResult),
+      session.availableModelRecords = ensurePreferredModelRecord(
+        augmentWithLegacyOpus(
+          normalizeModelRecords(initResult),
+        ),
+        preferredModel,
       );
       // Route the inferred id through chooseUpdatedModelId so the `[1m]`
       // suffix from the spawn-time `--model` arg is preserved when the CLI
@@ -2519,18 +2578,15 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       // post-init clobber strips `[1m]` from every fresh `[1m]` thread,
       // poisoning the picker and the next setModel arg with the 200K-tier
       // bare id even though the session is actually running on 1M. #1776.
-      const inferredFromInit = inferCurrentModelId(
+      // A null initResult.model means the CLI has not reported a current
+      // model yet. Keep the spawn seed in that case instead of falling back
+      // to records[0], which may be the newest catalog model rather than the
+      // `--model` argument this session is actually running. #2812.
+      session.currentModelId = resolvePostInitCurrentModelId(
+        session.currentModelId,
         initResult?.model ?? null,
         session.availableModelRecords,
       );
-      session.currentModelId =
-        chooseUpdatedModelId(
-          session.currentModelId,
-          inferredFromInit,
-          session.availableModelRecords,
-        ) ??
-        inferredFromInit ??
-        session.currentModelId;
 
       // The launched session stays in its default permission flow until we
       // explicitly switch modes over the control channel.
@@ -3009,6 +3065,8 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
 export {
   inferClaudeContextWindow as _inferClaudeContextWindow,
   augmentWithLegacyOpus as _augmentWithLegacyOpus,
+  ensurePreferredModelRecord as _ensurePreferredModelRecord,
+  resolvePostInitCurrentModelId as _resolvePostInitCurrentModelId,
   ONE_M_TIER_RECORDS as _ONE_M_TIER_RECORDS,
   DEFAULT_PREFERRED_MODEL as _DEFAULT_PREFERRED_MODEL,
   DEFAULT_PREFERRED_MODE as _DEFAULT_PREFERRED_MODE,

--- a/tests/unit/claude-runtime-1m-tier-postinit.test.ts
+++ b/tests/unit/claude-runtime-1m-tier-postinit.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 const claudeRuntimeSource = readSource("bin/browser-local/claude-runtime.mjs");
 
 describe("#1776 — post-init currentModelId resolution preserves [1m]", () => {
-  it("spawnSession routes the inferred init.model through chooseUpdatedModelId", () => {
+  it("spawnSession advertises the spawned model and resolves init.model through the post-init helper", () => {
     // Anthropic echoes the bare resolved id (e.g. claude-opus-4-7) in
     // initResult.model even when the session was spawned with --model
     // claude-opus-4-7[1m]. Resolving the bare echo via inferCurrentModelId
@@ -16,14 +16,16 @@ describe("#1776 — post-init currentModelId resolution preserves [1m]", () => {
     // running on 1M. chooseUpdatedModelId carries the existing #1763
     // [1m]-preservation guard — reuse it here so spawn-time and per-message
     // resolution agree on the tier marker.
-    const spawnAnchor = "augmentWithLegacyOpus(\n        normalizeModelRecords(initResult),\n      );";
+    const spawnAnchor = "ensurePreferredModelRecord(\n        augmentWithLegacyOpus(";
     const idx = claudeRuntimeSource.indexOf(spawnAnchor);
     expect(idx, "spawnSession post-init block must exist").toBeGreaterThan(0);
 
     const block = claudeRuntimeSource.slice(idx, idx + 1200);
-    expect(block).toContain("chooseUpdatedModelId(");
+    expect(block).toContain("normalizeModelRecords(initResult)");
+    expect(block).toContain("preferredModel");
+    expect(block).toContain("resolvePostInitCurrentModelId(");
     expect(block).toContain("session.currentModelId,");
-    expect(block).toContain("inferredFromInit");
+    expect(block).toContain("initResult?.model ?? null");
   });
 
   it("forkSession delegates [1m] preservation to the next spawnSession boot — no temp init block", () => {

--- a/tests/unit/claude-runtime-1m-tier.test.ts
+++ b/tests/unit/claude-runtime-1m-tier.test.ts
@@ -12,6 +12,8 @@ const modulePath = new URL(
 const {
   _inferClaudeContextWindow: inferClaudeContextWindow,
   _augmentWithLegacyOpus: augmentWithLegacyOpus,
+  _ensurePreferredModelRecord: ensurePreferredModelRecord,
+  _resolvePostInitCurrentModelId: resolvePostInitCurrentModelId,
   _ONE_M_TIER_RECORDS: ONE_M_TIER_RECORDS,
   _DEFAULT_PREFERRED_MODEL: DEFAULT_PREFERRED_MODEL,
   _comparePickerEntries: comparePickerEntries,
@@ -206,6 +208,98 @@ describe("augmentWithLegacyOpus — picker exposes 1M-tier variants", () => {
     expect(augmented[0].isDefault).toBe(true);
     const bareOpus = augmented.find((r) => r.modelId === "claude-opus-4-7");
     expect(bareOpus?.isDefault).toBe(false);
+  });
+});
+
+describe("ensurePreferredModelRecord — spawned model stays advertised (#2812)", () => {
+  it("injects Opus 4.8 1M when the CLI initialize catalog omits it", () => {
+    const cliCatalog = [
+      {
+        modelId: "claude-opus-4-7",
+        name: "Opus 4.7",
+        description: "",
+        supportsEffort: false,
+        supportedEffortLevels: [],
+        isDefault: true,
+      },
+      {
+        modelId: "claude-sonnet-4-6",
+        name: "Sonnet 4.6",
+        description: "",
+        supportsEffort: false,
+        supportedEffortLevels: [],
+        isDefault: false,
+      },
+    ];
+
+    const augmented = augmentWithLegacyOpus(cliCatalog);
+    expect(augmented.map((r: { modelId: string }) => r.modelId)).not.toContain(
+      "claude-opus-4-8[1m]",
+    );
+
+    const withPreferred = ensurePreferredModelRecord(
+      augmented,
+      "claude-opus-4-8[1m]",
+    ) as Array<{ modelId: string; name: string; isDefault: boolean }>;
+
+    expect(withPreferred[0]).toMatchObject({
+      modelId: "claude-opus-4-8[1m]",
+      name: "Opus 4.8 (1M context)",
+      isDefault: true,
+    });
+    expect(
+      withPreferred.find((r) => r.modelId === "claude-opus-4-7[1m]")?.isDefault,
+    ).toBe(false);
+  });
+});
+
+describe("resolvePostInitCurrentModelId — null initialize model keeps spawn seed (#2812)", () => {
+  it("does not fall back to records[0] when initResult.model is null", () => {
+    const records = ensurePreferredModelRecord(
+      augmentWithLegacyOpus([
+        {
+          modelId: "claude-opus-4-7",
+          name: "Opus 4.7",
+          description: "",
+          supportsEffort: false,
+          supportedEffortLevels: [],
+          isDefault: true,
+        },
+      ]),
+      "claude-opus-4-8[1m]",
+    );
+
+    expect(
+      resolvePostInitCurrentModelId(
+        "claude-opus-4-8[1m]",
+        null,
+        records,
+      ),
+    ).toBe("claude-opus-4-8[1m]");
+  });
+
+  it("still preserves the 1M suffix when initialize echoes the bare model", () => {
+    const records = ensurePreferredModelRecord(
+      augmentWithLegacyOpus([
+        {
+          modelId: "claude-opus-4-7",
+          name: "Opus 4.7",
+          description: "",
+          supportsEffort: false,
+          supportedEffortLevels: [],
+          isDefault: true,
+        },
+      ]),
+      "claude-opus-4-8[1m]",
+    );
+
+    expect(
+      resolvePostInitCurrentModelId(
+        "claude-opus-4-8[1m]",
+        "claude-opus-4-8",
+        records,
+      ),
+    ).toBe("claude-opus-4-8[1m]");
   });
 });
 


### PR DESCRIPTION
Closes #2812.

## Summary
- Inject the spawned preferred model into post-init model records when the CLI initialize catalog omits it, using the existing 1M display record for `claude-opus-4-8[1m]`.
- Preserve the spawn-time current model when `initResult.model` is null instead of inferring `records[0]`.
- Keep `augmentWithLegacyOpus` honest as an isolated catalog helper; the softer advertisement applies only to the model this session actually spawned with.

## Audit
- Issue audit: #2812 is a P2 label-only follow-up from #2810 / #2811; existing issue is assigned to `taariq` and labeled `bug`, `audited code-paths`, `area: chat`, `area: agent`.
- Prior PRs/issues reviewed: #2811 / #2810, #2060, #1762 / #1761, #1764 / #1763, #1777 / #1776.
- Code path traced: `AgentModelSelector` label reads `session.currentModelId` against `availableModels`; runtime status comes from `buildSessionStatus` / `buildAvailableModels`; fresh spawn path is `bin/browser-local/providers.mjs` -> `bin/browser-local/claude-runtime.mjs` -> local CLI `initialize` + control channel.
- Root cause confirmed: when initialize returns `model: null`, `inferCurrentModelId(null, records)` fell back to `records[0]`; when the account catalog omitted `claude-opus-4-8`, `availableModels` also lacked a friendly 4.8 1M record.

## Networked paths
- No Seren publisher/gateway slug is used by this feature path. The app does not call `call_publisher` for this label/update flow.
- Live publisher audit was still performed: `list_agent_publishers` shows `anthropic-claude-api` exists with `https://api.anthropic.com/v1` endpoints including `POST /messages` and `GET /models`, plus `seren-models`; this code path bypasses those publishers and shells out to the local Claude CLI.
- Direct outbound API method/path remains opaque inside the local CLI. Seren code only passes `--model claude-opus-4-8[1m]` and reads the CLI initialize/message stream.

## Tests
- `pnpm vitest run tests/unit/claude-runtime-1m-tier.test.ts tests/unit/claude-runtime-1m-tier-postinit.test.ts tests/unit/claude-model-resolution.test.ts tests/unit/agent-model-observability.test.ts tests/unit/claude-runtime-cleanups.test.ts`
- `pnpm test` (311 files / 2195 tests)
- `pnpm build:provider-runtime`
- `git diff --check HEAD~1..HEAD`

## Functional validation
- Live CLI: `claude 2.1.199`. Fresh runtime spawn with no prompt emitted `currentModelId: claude-opus-4-8[1m]`, display name `Opus 4.8 (1M context)`, and `availableModels[0]: claude-opus-4-8[1m]`.
- Live one-turn walkthrough: prompt `Reply with exactly OK.` returned `OK`; after the assistant message, status still emitted `currentModelId: claude-opus-4-8[1m]`, display name `Opus 4.8 (1M context)`, and `promptComplete.meta.contextWindow: 1000000`.

## Regression classification
- No P0/P1/P2 regressions found in the affected walkthrough.
