### PR TITLE
fix(agent): recover Codex over-budget tail compaction

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -20,6 +20,7 @@ import { isGeneratedPromptPrimer } from "@/lib/chat-history-export";
 import {
   type PrunableMessage,
   pruneCompactedHistory,
+  relieveOverBudgetTail,
 } from "@/lib/compaction/prune";
 import {
   buildDeterministicFallbackSummary,
@@ -334,6 +335,88 @@ function consumeCompactionPrepend(sessionId: string, prompt: string): string {
   if (!prepend) return prompt;
   setState("sessions", sessionId, "pendingCompactionPrepend", undefined);
   return `[Auto-compaction restored prior context]\n${prepend}\n\n---\n\n${prompt}`;
+}
+
+function prunableAgentMessage(m: AgentMessage): PrunableMessage {
+  return {
+    id: m.id,
+    role:
+      m.type === "user" || m.type === "assistant" || m.type === "tool"
+        ? m.type
+        : "other",
+    content: m.content,
+    toolResult: m.toolCall?.result,
+    toolName: m.toolCall?.title,
+    toolArgs: m.toolCall?.parameters
+      ? JSON.stringify(m.toolCall.parameters)
+      : undefined,
+  };
+}
+
+function applyPrunedAgentMessages(
+  messages: AgentMessage[],
+  pruned: PrunableMessage[],
+): AgentMessage[] {
+  return messages.map((m, i) => {
+    const p = pruned[i];
+    if (!p) return m;
+    const next: AgentMessage = { ...m, content: p.content };
+    if (m.toolCall) {
+      let parameters = m.toolCall.parameters;
+      if (p.toolArgs !== undefined) {
+        try {
+          parameters = JSON.parse(p.toolArgs) as Record<string, unknown>;
+        } catch {
+          parameters = m.toolCall.parameters;
+        }
+      }
+      next.toolCall = {
+        ...m.toolCall,
+        parameters,
+        ...(p.toolResult !== undefined ? { result: p.toolResult } : {}),
+      };
+    }
+    return next;
+  });
+}
+
+function buildAgentCompactionPrepend(
+  summary: string,
+  toPreserve: AgentMessage[],
+): string {
+  // Tool messages can be enormous file contents / JSON dumps; user and
+  // assistant text keep the original ceiling used by the long-standing
+  // post-compaction prepend path.
+  const MAX_MSG_CHARS = 2000;
+  const MAX_TOOL_CHARS = 500;
+  const preservedContext = toPreserve
+    .map((m) => {
+      if (m.type === "user" || m.type === "assistant") {
+        const content =
+          m.content.length > MAX_MSG_CHARS
+            ? `${m.content.slice(0, MAX_MSG_CHARS)}... [truncated]`
+            : m.content;
+        if (m.type === "user") {
+          return `<prior_user>${content}</prior_user>`;
+        }
+        return `<prior_assistant>${content}</prior_assistant>`;
+      }
+      if (m.type === "tool" && m.toolCall?.result) {
+        const title = (m.toolCall.title || "tool").replace(/"/g, "'");
+        const result = m.toolCall.result;
+        const trimmed =
+          result.length > MAX_TOOL_CHARS
+            ? `${result.slice(0, MAX_TOOL_CHARS)}... [truncated]`
+            : result;
+        return `<prior_tool name="${title}">${trimmed}</prior_tool>`;
+      }
+      return null;
+    })
+    .filter((s): s is string => s !== null)
+    .join("\n\n");
+  return preservedContext
+    ? `Prior work summary:\n${summary}\n\n<prior_messages>\n${preservedContext}\n</prior_messages>`
+    : `Prior work summary:\n${summary}`;
 }
 
 /**
@@ -4485,18 +4568,123 @@ export const agentStore = {
       targetTailRatio: opts?.tailRatio,
     });
     const toCompact = messages.slice(0, tailWindow.cutIndex);
-    const toPreserve = messages.slice(tailWindow.cutIndex);
+    let toPreserve = messages.slice(tailWindow.cutIndex);
     if (toCompact.length === 0) {
       if (tailWindow.overBudget) {
-        // Soft-ceiling (#2113): the anchored tail alone exceeds the budget and
-        // there is no older prefix to summarize. The serving transcript is left
-        // intact — the agent runtime manages its own context window, and the
-        // post-compaction prepend is already per-message bounded on the normal
-        // path — but surface the condition so a stuck context gauge is visible
-        // instead of being reported as plain "nothing to compact".
-        console.warn(
-          `[AgentStore] over-budget tail with no compactable prefix (tail ${tailWindow.tailTokens} > budget ${tailWindow.tailBudget}); serving transcript left intact`,
+        const relief = relieveOverBudgetTail(
+          toPreserve.map(prunableAgentMessage),
+          tailWindow.tailBudget,
         );
+        toPreserve = applyPrunedAgentMessages(toPreserve, relief.messages);
+        console.warn(
+          `[AgentStore] over-budget tail with no compactable prefix pruned ${relief.tailTokensBefore}->${relief.tailTokensAfter} tokens`,
+        );
+        if (
+          mode === "reactive" &&
+          relief.tailTokensAfter < relief.tailTokensBefore
+        ) {
+          // The agent runtime owns its own transcript, so mutating Solid state is
+          // not enough to relieve Codex/Claude context pressure. Respawn a clean
+          // session and queue the pruned, bounded tail as the one-shot prepend;
+          // compactAndRetry will resend the failed user prompt on that session.
+          const fullTranscript = toPreserve;
+          const cwd = session.cwd;
+          const agentType = session.info.agentType;
+          const conversationId = session.conversationId;
+          const priorModelId = session.currentModelId;
+          const queuedPrompts = session.pendingPrompts ?? [];
+          const tailReliefSummary = relief.stillOverBudget
+            ? "No older transcript prefix was available to summarize. Reducible tool payloads in the preserved tail were pruned, but the retained context may still be close to the model limit."
+            : "No older transcript prefix was available to summarize. Reducible tool payloads in the preserved tail were pruned before retrying the failed request.";
+          const prependText = buildAgentCompactionPrepend(
+            `${tailReliefSummary}\n\nVERIFY-BEFORE-ACTING: Files, projects, and databases mentioned above may not exist on disk. Re-read the workspace, list .worktrees/, and resolve SerenDB projects/tables before acting on any claim.`,
+            toPreserve,
+          );
+
+          try {
+            setState("sessions", sessionId, "isCompacting", true);
+            await this.terminateSession(sessionId);
+            const reliefSessionId = await this.spawnSession(cwd, agentType, {
+              localSessionId: conversationId,
+              initialModelId: priorModelId,
+            });
+            if (!reliefSessionId) {
+              throw new Error(
+                "CompactionFailure: tail-relief respawn returned null",
+              );
+            }
+            if (!state.sessions[reliefSessionId]) {
+              throw new Error(
+                "CompactionFailure: tail-relief respawn was removed before settings could be restored",
+              );
+            }
+            setState("sessions", reliefSessionId, "messages", fullTranscript);
+            setState(
+              "sessions",
+              reliefSessionId,
+              "restoredMessageCount",
+              fullTranscript.length,
+            );
+            if (queuedPrompts.length > 0) {
+              setState(
+                "sessions",
+                reliefSessionId,
+                "pendingPrompts",
+                queuedPrompts,
+              );
+            }
+            await waitForSessionReady(reliefSessionId);
+            await this.restoreSessionSettings(session, reliefSessionId);
+            setState(
+              "sessions",
+              reliefSessionId,
+              "pendingCompactionPrepend",
+              prependText,
+            );
+            console.info(
+              `[AgentStore] over-budget tail relief respawned ${reliefSessionId} after pruning ${relief.tailTokensBefore}->${relief.tailTokensAfter} tokens`,
+            );
+            return { outcome: "succeeded", newSessionId: reliefSessionId };
+          } catch (error) {
+            console.error(
+              "[AgentStore] Tail-relief respawn failed (catastrophic):",
+              error,
+            );
+            if (state.sessions[sessionId]) {
+              setState("sessions", sessionId, "isCompacting", false);
+            } else if (fullTranscript.length > 0) {
+              console.warn(
+                `[AgentStore] Tail-relief recovery — restoring ${fullTranscript.length} pruned messages to a new session`,
+              );
+              try {
+                const recoveryId = await this.spawnSession(cwd, agentType, {
+                  localSessionId: conversationId,
+                  initialModelId: priorModelId,
+                });
+                if (recoveryId) {
+                  setState("sessions", recoveryId, "messages", fullTranscript);
+                  setState(
+                    "sessions",
+                    recoveryId,
+                    "restoredMessageCount",
+                    fullTranscript.length,
+                  );
+                }
+              } catch (recoveryErr) {
+                console.error(
+                  "[AgentStore] Tail-relief recovery spawn also failed:",
+                  recoveryErr,
+                );
+              }
+            }
+            return { outcome: "failed_catastrophic" };
+          }
+        }
+        if (relief.stillOverBudget) {
+          console.warn(
+            "[AgentStore] over-budget tail still exceeds budget after pruning (irreducible content)",
+          );
+        }
       } else {
         console.info(
           "[AgentStore] Token budget preserves the whole tail — nothing to compact",
@@ -4547,19 +4735,7 @@ export const agentStore = {
       // bound oversized tool-call arguments. This both shrinks the summarizer
       // input and lets the summary capture tool outcomes (previously dropped,
       // since only message content was fed in). #2105.
-      const prunable: PrunableMessage[] = toCompact.map((m) => ({
-        id: m.id,
-        role:
-          m.type === "user" || m.type === "assistant" || m.type === "tool"
-            ? m.type
-            : "other",
-        content: m.content,
-        toolResult: m.toolCall?.result,
-        toolName: m.toolCall?.title,
-        toolArgs: m.toolCall?.parameters
-          ? JSON.stringify(m.toolCall.parameters)
-          : undefined,
-      }));
+      const prunable: PrunableMessage[] = toCompact.map(prunableAgentMessage);
       const pruned = pruneCompactedHistory(prunable, {
         protectedFromIndex: prunable.length,
       });
@@ -4685,36 +4861,7 @@ export const agentStore = {
       // the transcript inside its assistant content instead of treating
       // the block as quoted context, bleeding the prepend into the chat
       // and starving the Thinking budget. #1941.
-      const MAX_MSG_CHARS = 2000;
-      const MAX_TOOL_CHARS = 500;
-      const preservedContext = toPreserve
-        .map((m) => {
-          if (m.type === "user" || m.type === "assistant") {
-            const content =
-              m.content.length > MAX_MSG_CHARS
-                ? `${m.content.slice(0, MAX_MSG_CHARS)}... [truncated]`
-                : m.content;
-            if (m.type === "user") {
-              return `<prior_user>${content}</prior_user>`;
-            }
-            return `<prior_assistant>${content}</prior_assistant>`;
-          }
-          if (m.type === "tool" && m.toolCall?.result) {
-            const title = (m.toolCall.title || "tool").replace(/"/g, "'");
-            const result = m.toolCall.result;
-            const trimmed =
-              result.length > MAX_TOOL_CHARS
-                ? `${result.slice(0, MAX_TOOL_CHARS)}... [truncated]`
-                : result;
-            return `<prior_tool name="${title}">${trimmed}</prior_tool>`;
-          }
-          return null;
-        })
-        .filter((s): s is string => s !== null)
-        .join("\n\n");
-      const prependText = preservedContext
-        ? `Prior work summary:\n${summary}\n\n<prior_messages>\n${preservedContext}\n</prior_messages>`
-        : `Prior work summary:\n${summary}`;
+      const prependText = buildAgentCompactionPrepend(summary, toPreserve);
 
       // The synthetic-transcript builder interprets this as a count of REAL
       // user turns to keep from the parent JSONL (findCutIndex in

--- a/tests/unit/compaction-window-wiring.test.ts
+++ b/tests/unit/compaction-window-wiring.test.ts
@@ -43,7 +43,13 @@ describe("#2113 compaction acts on the over-budget tail flag", () => {
     expect(chatStore).toContain("relieveOverBudgetTail(");
   });
 
-  it("agent surfaces an over-budget tail with no compactable prefix", () => {
+  it("agent prunes and respawns an over-budget tail with no compactable prefix", () => {
     expect(agentStore).toContain("tailWindow.overBudget");
+    expect(agentStore).toContain("relieveOverBudgetTail(");
+    expect(agentStore).toContain("over-budget tail relief respawned");
+    expect(agentStore).toContain(
+      'return { outcome: "succeeded", newSessionId: reliefSessionId }',
+    );
+    expect(agentStore).not.toContain("serving transcript left intact");
   });
 });

--- a/tests/unit/predictive-drain-not-blocked.test.ts
+++ b/tests/unit/predictive-drain-not-blocked.test.ts
@@ -22,28 +22,27 @@ describe("#1673 — predictive compaction does not block drain", () => {
     );
     const fnBody = agentStoreSource.slice(fnStart, fnEnd);
 
-    // Exactly one true-flip on isCompacting in this function.
-    const flips = fnBody.match(
+    // Every true-flip on isCompacting in this function must be reactive-gated.
+    // Tail-relief compaction has a second reactive-only respawn path; predictive
+    // mode still must not signal teardown on the serving session.
+    const flips = [...fnBody.matchAll(
       /setState\("sessions",\s*sessionId,\s*"isCompacting",\s*true\)/g,
+    )];
+    expect(flips.length, "at least one isCompacting=true flip").toBeGreaterThan(
+      0,
     );
-    expect(flips, "exactly one isCompacting=true flip").toHaveLength(1);
-
-    // That flip must be reactive-gated. We assert by string adjacency: the
-    // `if (mode === "reactive") {` opener must precede the flip with no
-    // intervening close-brace at the same scope.
-    const reactiveGateIdx = fnBody.indexOf('if (mode === "reactive")');
-    const flipIdx = fnBody.indexOf(
-      'setState("sessions", sessionId, "isCompacting", true)',
-    );
-    expect(reactiveGateIdx, "reactive gate must exist").toBeGreaterThan(0);
-    expect(flipIdx).toBeGreaterThan(reactiveGateIdx);
-
-    // The slice between gate and flip must contain only whitespace + "{".
-    const between = fnBody.slice(
-      reactiveGateIdx + 'if (mode === "reactive")'.length,
-      flipIdx,
-    );
-    expect(between.trim()).toBe("{");
+    for (const flip of flips) {
+      const flipIdx = flip.index ?? 0;
+      const reactiveGateIdx = fnBody.lastIndexOf(
+        'mode === "reactive"',
+        flipIdx,
+      );
+      const predictiveBranchIdx = fnBody.lastIndexOf(
+        'if (mode === "predictive")',
+        flipIdx,
+      );
+      expect(reactiveGateIdx).toBeGreaterThan(predictiveBranchIdx);
+    }
   });
 
   it("predictive branch does not write isCompacting on the serving session", () => {

--- a/tests/unit/setmodel-context-window-and-prepend-tool-results.test.ts
+++ b/tests/unit/setmodel-context-window-and-prepend-tool-results.test.ts
@@ -73,12 +73,11 @@ describe("#1858 Defect 2 — passive prepend preserves tool-result content", () 
   // resource-id slot, so opaque handles got summarized away and the user had
   // to re-supply them post-compaction.
 
-  // Anchor on the unique "Build the structured prepend up-front" comment that
-  // introduces the prepend-builder block in compactAgentConversation. This
-  // keeps assertions inside the prepend region only — not the toCompact
-  // serialization above it nor the post-prepend spawn flows below.
+  // Anchor on the shared prepend helper. This keeps assertions inside the
+  // prepend formatting region only — not the toCompact serialization nor the
+  // post-prepend spawn flows below.
   const prependRegion = () =>
-    regionAfter("Build the structured prepend up-front", 2500);
+    regionAfter("function buildAgentCompactionPrepend", 2500);
 
   it("prepend builder includes m.type === \"tool\" alongside user/assistant", () => {
     // The filter must allow tool messages through. Pre-fix shape was a literal


### PR DESCRIPTION
Closes #2817.

## Summary

Fixes the Codex reactive-compaction dead end shown in `~/Downloads/Logs/20260703_Codex.log`:

```text
Token budget preserves the whole tail — nothing to compact
compactAndRetry: configured count left nothing to compact (82 messages); retrying with a tighter tail budget (ratio=0.15)
over-budget tail with no compactable prefix (tail 336002 > budget 150000); serving transcript left intact
Compaction skipped (nothing to compact)
```

The bug was that the agent path only logged `tailWindow.overBudget && toCompact.length === 0`. That left Codex's own runtime transcript untouched and returned `skipped_nothing_to_compact`, so the user saw the context-window failure after prior fixes had already attempted compaction.

## Fix

- Reuses the existing `relieveOverBudgetTail` helper in the agent no-prefix branch.
- Applies the pruned tool result / tool arg payloads back to agent messages.
- When reactive relief actually reduces accounted tokens, terminates the overfull runtime, spawns a clean session, queues a bounded prior-context prepend, and returns `succeeded` so `compactAndRetry` retries the failed prompt on the clean session.
- Keeps irreducible user text unchanged; if pruning cannot reduce the tail, the path still returns `skipped_nothing_to_compact`.
- Adds recovery if the tail-relief respawn fails after termination, restoring the pruned transcript into a new session.
- Extracts the agent prepend formatter so the normal compaction path and tail-relief path use the same XML-style bounded prior-message frame.

## Audit

Prior fixes reviewed before patching:

- #1757 / PR #1759: Codex `compactAndRetry` false-fail and retry dispatch.
- #1758 / PR #1760: Codex context-window metadata for predictive compaction.
- #2031 / PR #2032: aggressive reactive retry for short-but-token-heavy sessions.
- #2104 / PR #2108: token-budgeted tail selection.
- #2113 / PR #2114: over-budget flag handling; this explicitly left the agent no-prefix branch as log-only, which the 2026-07-03 Codex log proves insufficient.

Networked path trace:

- UI submit path is local app state -> `agentStore.sendPrompt` -> Tauri provider runtime command `provider_prompt`.
- This fix adds no new publisher/API slug, method, or path.
- Existing normal summary compaction still uses `sendProviderMessage("seren", buildChatRequest(...))`; the fixed no-prefix tail-relief branch intentionally does not add a summarizer network request.

## Test plan

- [x] `pnpm exec vitest run tests/unit/compaction-window-wiring.test.ts tests/unit/compaction-prune.test.ts tests/unit/compact-retry-aggressive-fallback.test.ts tests/unit/compact-retry-codex.test.ts tests/unit/prompt-too-long-streamed-content-removed.test.ts tests/unit/agent-terminal-send-failure.test.ts tests/unit/setmodel-context-window-and-prepend-tool-results.test.ts tests/unit/predictive-drain-not-blocked.test.ts tests/unit/compaction-session-removal-guard.test.ts` — 9 files / 50 tests pass
- [x] `pnpm exec vitest run` — 311 files / 2195 tests pass
- [x] `pnpm exec biome check src/stores/agent.store.ts` — pass
- [x] `git diff --check` — pass
- [!] `pnpm exec tsc --noEmit` — fails on pre-existing unrelated errors in `GatewayToolApproval.tsx`, `executor.ts`, `organization-otp.ts`, `publisher-oauth.ts`, and `claude-runtime-seren-mcp-audit.test.ts`.
