### PR TITLE
fix(release): cap Windows signing volume

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ env:
   HAS_APPLE_SIGNING: ${{ secrets.APPLE_CERTIFICATE != '' }}
   # SSL.com eSigner cloud signing for Windows EV code signing
   HAS_WINDOWS_SIGNING: ${{ secrets.ES_USERNAME != '' }}
+  # Maximum billable SSL.com cloud hash-signing operations for one Windows
+  # release job. Bump only after auditing sign-targets.txt / signer telemetry.
+  MAX_SIGNATURES: ${{ vars.MAX_SIGNATURES || '850' }}
 
 jobs:
   create-release:
@@ -307,6 +310,21 @@ jobs:
           echo "::error::Either configure SSL.com eSigner secrets or push a non-v* tag for unsigned dev builds."
           exit 1
 
+      - name: Initialize Windows signing budget telemetry
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          [int]$max = 0
+          if (-not [int]::TryParse($env:MAX_SIGNATURES, [ref]$max) -or $max -lt 0) {
+            Write-Host "::error::MAX_SIGNATURES must be a non-negative integer, got '$env:MAX_SIGNATURES'."
+            exit 1
+          }
+          $telemetry = Join-Path $env:RUNNER_TEMP "windows-signing-telemetry.jsonl"
+          Remove-Item -LiteralPath $telemetry -Force -ErrorAction SilentlyContinue
+          "WINDOWS_SIGN_TELEMETRY_FILE=$telemetry" >> $env:GITHUB_ENV
+          Write-Host "Windows signing telemetry: $telemetry"
+          Write-Host "Windows signing MAX_SIGNATURES=$max"
+
       # macOS: Import certificates and setup keychain (skip if no certificate)
       - name: Import macOS certificates
         if: matrix.os == 'macos-latest' && env.HAS_APPLE_SIGNING == 'true'
@@ -495,6 +513,55 @@ jobs:
       - name: Build Tauri app (unsigned, macOS without signing)
         if: matrix.os == 'macos-latest' && env.HAS_APPLE_SIGNING != 'true'
         run: pnpm tauri build --target ${{ matrix.target }}
+
+      - name: Summarize Windows signing budget
+        if: always() && matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          $summary = $env:GITHUB_STEP_SUMMARY
+          $telemetry = $env:WINDOWS_SIGN_TELEMETRY_FILE
+          Add-Content -LiteralPath $summary -Value "## Windows signing budget"
+          Add-Content -LiteralPath $summary -Value ""
+          Add-Content -LiteralPath $summary -Value "- MAX_SIGNATURES: $env:MAX_SIGNATURES"
+          Add-Content -LiteralPath $summary -Value "- Telemetry: ``$telemetry``"
+          if (-not $telemetry -or -not (Test-Path -LiteralPath $telemetry)) {
+            Add-Content -LiteralPath $summary -Value "- Status: no signing telemetry was produced before the job stopped."
+            Write-Host "No Windows signing telemetry found at: $telemetry"
+            exit 0
+          }
+
+          $records = @()
+          foreach ($line in (Get-Content -LiteralPath $telemetry)) {
+            $trimmed = $line.Trim()
+            if (-not $trimmed) { continue }
+            $records += ($trimmed | ConvertFrom-Json)
+          }
+
+          [int]$discovered = 0
+          [int]$skipped = 0
+          [int]$wouldSign = 0
+          [int]$signed = 0
+          $blocked = $false
+          foreach ($record in $records) {
+            if ($null -ne $record.discovered) { $discovered += [int]$record.discovered }
+            if ($null -ne $record.skipped) { $skipped += [int]$record.skipped }
+            if ($null -ne $record.would_sign) { $wouldSign += [int]$record.would_sign }
+            if ($null -ne $record.signed) { $signed += [int]$record.signed }
+            if ($record.status -eq "blocked") { $blocked = $true }
+          }
+          $status = if ($blocked) { "blocked by budget gate" } else { "within budget" }
+          Add-Content -LiteralPath $summary -Value "- Status: $status"
+          Add-Content -LiteralPath $summary -Value "- Discovered: $discovered"
+          Add-Content -LiteralPath $summary -Value "- Skipped already valid: $skipped"
+          Add-Content -LiteralPath $summary -Value "- Cloud signatures spent: $signed"
+          Add-Content -LiteralPath $summary -Value ""
+          Add-Content -LiteralPath $summary -Value "| Status | Source | Discovered | Skipped | Would sign | Signed | Previous signed |"
+          Add-Content -LiteralPath $summary -Value "|---|---|---:|---:|---:|---:|---:|"
+          foreach ($record in $records) {
+            $source = ([string]$record.source).Replace("|", "\|")
+            Add-Content -LiteralPath $summary -Value "| $($record.status) | ``$source`` | $($record.discovered) | $($record.skipped) | $($record.would_sign) | $($record.signed) | $($record.previous_signed) |"
+          }
+          Write-Host "Windows signing budget summary: status=$status discovered=$discovered skipped=$skipped signed=$signed max=$env:MAX_SIGNATURES"
 
       # Verify dist/ contains current frontend code.
       # Catches stale dist/ bundles that bypass beforeBuildCommand.

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -36,8 +36,15 @@ Add these secrets to the repository settings (Settings → Secrets → Actions):
 
 | Secret | Description |
 |--------|-------------|
-| `WINDOWS_CERTIFICATE` | Code signing certificate (.pfx, base64 encoded) |
-| `WINDOWS_CERTIFICATE_PASSWORD` | Password for the .pfx file |
+| `ES_USERNAME` | SSL.com eSigner account username |
+| `ES_PASSWORD` | SSL.com eSigner account password |
+| `ES_TOTP_SECRET` | SSL.com eSigner TOTP seed used by the CKA login step |
+
+### Release Variables
+
+| Variable | Description |
+|----------|-------------|
+| `MAX_SIGNATURES` | Maximum SSL.com cloud hash-signing operations allowed in one Windows release job. Defaults to `850` in `release.yml`; raise only after reviewing `sign-targets.txt` and the Windows signing job summary. |
 
 ## Certificate Setup
 
@@ -98,20 +105,11 @@ Update `src-tauri/tauri.conf.json` with the public key:
 
 ### Step 3: Windows Code Signing Certificate
 
-**Option A: DigiCert (Recommended)**
-1. https://www.digicert.com/signing/code-signing-certificates
-2. Choose Standard or EV Code Signing
-3. Complete verification (1-3 days for EV)
-4. Download .pfx file
-
-**Option B: Other Providers**
-- Sectigo: https://sectigo.com/code-signing-certificates
-- GlobalSign: https://www.globalsign.com/code-signing
-
-Convert to base64:
-```bash
-base64 -i certificate.pfx
-```
+Production Windows signing uses SSL.com eSigner CKA (Cloud Key Adapter), not a
+checked-in or CI-imported `.pfx`. The release workflow installs the CKA client,
+logs in with the `ES_*` secrets, loads the EV code-signing certificate into
+`Cert:\CurrentUser\My`, and exports `WINDOWS_SIGN_THUMBPRINT` for the signer
+wrapper and Tauri `signCommand` overlay.
 
 ## Windows Signing Coverage (What Smart App Control Evaluates)
 
@@ -128,7 +126,8 @@ the artifact that embeds it is produced:
    `.nsis.zip` updater bundle. The signable set is discovered by
    `scripts/print-windows-signables.ts` and signed in place by
    `scripts/sign-windows-payload.ps1` (signtool + eSigner CKA, throttled
-   batches under SSL.com's rate limit, `#2282`).
+   batches under SSL.com's rate limit, `#2282`, with the `MAX_SIGNATURES`
+   budget gate from `#2818`).
 
 2. **NSIS stock plugin DLLs** (`#2237`, `#2299`) — `System.dll`, `nsExec.dll`,
    `StartMenu.dll`, and `nsDialogs.dll` ship inside the `tauri-bundler` NSIS
@@ -157,11 +156,22 @@ the artifact that embeds it is produced:
 
 ### Verification gates (release CI, hard-fail)
 
+- The cumulative signer telemetry cannot exceed `MAX_SIGNATURES` (`#2818`).
+  Recent Windows signing audits found roughly 715-729 embedded-runtime
+  signables, plus the NSIS/tooling and Tauri wrapper signings. The default
+  ceiling is `850`, leaving limited headroom for normal drift while stopping a
+  runaway release before it spends hundreds or thousands of unexpected SSL.com
+  cloud signatures.
 - Loose `.exe`/`.dll` under `bundle/` are all `Valid` (`#2235`).
 - Every `.exe`/`.dll` extracted from `.nsis.zip` is `Valid` (`#2236`).
 - The setup `.exe` is unpacked with 7-Zip and **every** embedded
   `.exe`/`.dll`/`.node` — including the `$PLUGINSDIR` helper DLLs — is `Valid`
   (`#2237`). This is the closest CI proxy for what Smart App Control sees.
+
+Each Windows release writes a **Windows signing budget** section to the GitHub
+job summary. Review the discovered, skipped, and cloud-signatures-spent counts
+before changing `MAX_SIGNATURES`; a ceiling bump should be paired with an audit
+of the added files and why they must be signed.
 
 ### SEREN_TAURI_SKIP_PREP
 

--- a/scripts/sign-windows-payload.ps1
+++ b/scripts/sign-windows-payload.ps1
@@ -1,5 +1,6 @@
 # ABOUTME: Signs Windows PE binaries in place with signtool using the eSigner CKA-loaded EV cert (#2276).
 # ABOUTME: Takes signables from -Root/-File/-ListFile, skips already-signed, signs in throttled batches (#2282), fails loud if any file is left unsigned.
+# ABOUTME: Enforces the Windows release signature budget and writes per-invocation telemetry (#2818).
 
 [CmdletBinding()]
 param(
@@ -21,10 +22,84 @@ param(
   # file, so bursting the whole payload trips SSL.com's per-minute rate limit
   # (#2282). Pausing between batches holds the request rate under that ceiling.
   [int]$DelaySeconds = 0,
+  # Maximum cumulative cloud hash-signing operations allowed for this release job.
+  # Defaults from MAX_SIGNATURES; unset/-1 disables the gate for local ad-hoc use.
+  [int]$MaxSignatures = -1,
+  # JSONL telemetry file shared across signer invocations in one release job.
+  # Defaults from WINDOWS_SIGN_TELEMETRY_FILE.
+  [string]$TelemetryFile = "",
   [int]$MaxRetries = 3
 )
 
 $ErrorActionPreference = "Stop"
+
+function Resolve-MaxSignatureBudget {
+  param([int]$Explicit)
+  if ($Explicit -ge 0) { return $Explicit }
+  $raw = $env:MAX_SIGNATURES
+  if (-not $raw) { return -1 }
+  [int]$parsed = 0
+  if (-not [int]::TryParse($raw, [ref]$parsed) -or $parsed -lt 0) {
+    Write-Host "::error::MAX_SIGNATURES must be a non-negative integer, got '$raw'."
+    exit 1
+  }
+  return $parsed
+}
+
+function Get-SigningSource {
+  if ($ListFile) { return "list:$ListFile" }
+  if ($File.Count -gt 0 -and $Root.Count -eq 0) { return "file" }
+  if ($Root.Count -gt 0 -and $File.Count -eq 0) { return "root" }
+  return "mixed"
+}
+
+function Read-PreviousSignedCount {
+  param([string]$Path)
+  if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return 0 }
+  [int]$total = 0
+  foreach ($line in (Get-Content -LiteralPath $Path)) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed) { continue }
+    try {
+      $record = $trimmed | ConvertFrom-Json
+      if ($null -ne $record.signed) { $total += [int]$record.signed }
+    } catch {
+      Write-Host "::warning::Ignoring malformed Windows signing telemetry line in ${Path}: $trimmed"
+    }
+  }
+  return $total
+}
+
+function Write-SigningTelemetry {
+  param(
+    [string]$Path,
+    [string]$Status,
+    [string]$Source,
+    [int]$Discovered,
+    [int]$Skipped,
+    [int]$WouldSign,
+    [int]$Signed,
+    [int]$PreviousSigned,
+    [int]$Max
+  )
+  if (-not $Path) { return }
+  $dir = Split-Path -Parent $Path
+  if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+  }
+  $record = [PSCustomObject]@{
+    timestamp = (Get-Date).ToUniversalTime().ToString("o")
+    status = $Status
+    source = $Source
+    discovered = $Discovered
+    skipped = $Skipped
+    would_sign = $WouldSign
+    signed = $Signed
+    previous_signed = $PreviousSigned
+    max_signatures = if ($Max -ge 0) { $Max } else { $null }
+  }
+  ($record | ConvertTo-Json -Compress) | Add-Content -LiteralPath $Path
+}
 
 # Resolve the thumbprint before anything else so a missing credential fails
 # fast with an actionable error instead of a confusing signtool failure.
@@ -33,23 +108,14 @@ if (-not $Thumbprint) {
   Write-Host "::error::No certificate thumbprint: pass -Thumbprint or set WINDOWS_SIGN_THUMBPRINT (exported by the eSigner CKA setup step)."
   exit 1
 }
+$maxSignatureBudget = Resolve-MaxSignatureBudget -Explicit $MaxSignatures
+if (-not $TelemetryFile) { $TelemetryFile = $env:WINDOWS_SIGN_TELEMETRY_FILE }
+$signingSource = Get-SigningSource
 
 # Authenticode-signable PE extensions. .pyd/.node are ordinary DLLs; signtool
 # signs them in place by content, so (unlike CodeSignTool) no extension rewrite
 # is needed.
 $signableExt = @(".exe", ".dll", ".node", ".pyd")
-
-# Discover the newest x64 signtool.exe from the installed Windows 10 SDK rather
-# than hardcoding an SDK version that drifts on the hosted runner.
-$signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter "signtool.exe" -ErrorAction SilentlyContinue |
-  Where-Object { $_.FullName -match "\\x64\\" } |
-  Sort-Object FullName -Descending |
-  Select-Object -First 1
-if (-not $signtool) {
-  Write-Host "::error::Could not locate an x64 signtool.exe under the Windows 10 SDK."
-  exit 1
-}
-Write-Host "Using signtool: $($signtool.FullName)"
 
 # Build the target set: explicit files + every signable under each root.
 $targets = [System.Collections.Generic.List[string]]::new()
@@ -106,9 +172,34 @@ if ($skipped -gt 0) {
 }
 if ($targets.Count -eq 0) {
   Write-Host "All $discovered discovered file(s) already validly signed; nothing to do."
+  $previousSigned = Read-PreviousSignedCount -Path $TelemetryFile
+  Write-SigningTelemetry -Path $TelemetryFile -Status "success" -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign 0 -Signed 0 -PreviousSigned $previousSigned -Max $maxSignatureBudget
   exit 0
 }
+$previousSigned = Read-PreviousSignedCount -Path $TelemetryFile
+$projectedSigned = $previousSigned + $targets.Count
+if ($maxSignatureBudget -ge 0) {
+  Write-Host "Windows signing budget: $previousSigned already signed, this invocation would sign $($targets.Count), max $maxSignatureBudget."
+  if ($projectedSigned -gt $maxSignatureBudget) {
+    Write-Host "::error::Windows signing budget exceeded: signing $($targets.Count) more file(s) would bring this release to $projectedSigned cloud signature(s), above MAX_SIGNATURES=$maxSignatureBudget."
+    Write-Host "::error::Audit sign-targets.txt / Windows signing telemetry and raise MAX_SIGNATURES through review only if this release intentionally needs the extra signatures."
+    Write-SigningTelemetry -Path $TelemetryFile -Status "blocked" -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign $targets.Count -Signed 0 -PreviousSigned $previousSigned -Max $maxSignatureBudget
+    exit 1
+  }
+}
 Write-Host "Signing $($targets.Count) file(s) in batches of $BatchSize (delay ${DelaySeconds}s between batches)..."
+
+# Discover the newest x64 signtool.exe from the installed Windows 10 SDK rather
+# than hardcoding an SDK version that drifts on the hosted runner.
+$signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter "signtool.exe" -ErrorAction SilentlyContinue |
+  Where-Object { $_.FullName -match "\\x64\\" } |
+  Sort-Object FullName -Descending |
+  Select-Object -First 1
+if (-not $signtool) {
+  Write-Host "::error::Could not locate an x64 signtool.exe under the Windows 10 SDK."
+  exit 1
+}
+Write-Host "Using signtool: $($signtool.FullName)"
 
 # signtool signs each file by sending only its hash to the SSL.com cloud (one op
 # per file). Retry each batch for transient cloud/timestamp failures.
@@ -147,4 +238,5 @@ if ($unsigned.Count -gt 0) {
   $unsigned | ForEach-Object { Write-Host "    $_" }
   exit 1
 }
+Write-SigningTelemetry -Path $TelemetryFile -Status "success" -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign $targets.Count -Signed $targets.Count -PreviousSigned $previousSigned -Max $maxSignatureBudget
 Write-Host "All $($targets.Count) file(s) carry a Valid Authenticode signature."

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -17,6 +17,10 @@ function runCli(args: string[]): { stdout: string; stderr: string; status: numbe
   return { stdout: r.stdout ?? "", stderr: r.stderr ?? "", status: r.status ?? 1 };
 }
 
+function psSingleQuoted(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
 describe("print-windows-sign-overlay CLI", () => {
   it("emits a minimal signCommand overlay wired to the payload signer", () => {
     const { stdout, status } = runCli([repoRoot]);
@@ -124,6 +128,31 @@ describe("release workflow contract", () => {
     expect(workflow).toContain("Verify embedded installer payload signatures (Windows)");
     expect(workflow).toContain("Audit Windows payload signature coverage");
   });
+
+  it("caps Windows signing volume and reports budget telemetry (#2818)", () => {
+    const signer = readFileSync(signerScript, "utf8");
+
+    expect(workflow).toContain("MAX_SIGNATURES");
+    expect(workflow).toContain("vars.MAX_SIGNATURES");
+    expect(workflow).toContain("Initialize Windows signing budget telemetry");
+    expect(workflow).toContain("WINDOWS_SIGN_TELEMETRY_FILE");
+    expect(workflow).toContain("Summarize Windows signing budget");
+    expect(workflow).toContain("Cloud signatures spent");
+
+    const initAt = workflow.indexOf("Initialize Windows signing budget telemetry");
+    const signAt = workflow.indexOf("Sign embedded runtime (Windows)");
+    const buildAt = workflow.indexOf("Build Tauri app (signed, Windows)");
+    const summaryAt = workflow.indexOf("Summarize Windows signing budget");
+    expect(initAt).toBeGreaterThanOrEqual(0);
+    expect(signAt).toBeGreaterThan(initAt);
+    expect(summaryAt).toBeGreaterThan(buildAt);
+
+    expect(signer).toContain("Resolve-MaxSignatureBudget");
+    expect(signer).toContain("Read-PreviousSignedCount");
+    expect(signer).toContain("Write-SigningTelemetry");
+    expect(signer).toContain("Windows signing budget exceeded");
+    expect(signer).toContain("MAX_SIGNATURES");
+  });
 });
 
 describe("sign-windows-payload.ps1 thumbprint resolution", () => {
@@ -175,11 +204,64 @@ describe("sign-windows-payload.ps1 thumbprint resolution", () => {
     "accepts the thumbprint from WINDOWS_SIGN_THUMBPRINT (signCommand passes no -Thumbprint)",
     () => {
       const { out, status } = runSigner({ WINDOWS_SIGN_THUMBPRINT: "933C679D86D0ACAF531B37A4D12C0B360EB4815C" });
-      // Proceeds past validation; on non-Windows it then fails at signtool
-      // discovery — proving the env thumbprint was accepted.
+      // Proceeds past validation into Windows-only signing work — proving the
+      // env thumbprint was accepted.
       expect(status).toBe(1);
-      expect(out).toContain("signtool");
+      expect(out).toMatch(/Get-AuthenticodeSignature|signtool/);
       expect(out).not.toContain("WINDOWS_SIGN_THUMBPRINT");
+    },
+    pwshTimeout,
+  );
+
+  it.runIf(hasPwsh)(
+    "blocks over-budget signing before signtool and records telemetry (#2818)",
+    () => {
+      const telemetry = path.join(dummy, "telemetry.jsonl");
+      writeFileSync(
+        telemetry,
+        `${JSON.stringify({
+          status: "success",
+          source: "previous",
+          discovered: 2,
+          skipped: 0,
+          would_sign: 2,
+          signed: 2,
+          previous_signed: 0,
+          max_signatures: 2,
+        })}\n`,
+      );
+
+      const script = `
+function Get-AuthenticodeSignature {
+  param([string]$LiteralPath)
+  [PSCustomObject]@{ Status = "NotSigned" }
+}
+& ${psSingleQuoted(signerScript)} -Thumbprint "933C679D86D0ACAF531B37A4D12C0B360EB4815C" -File ${psSingleQuoted(path.join(dummy, "a.exe"))} -MaxSignatures 2 -TelemetryFile ${psSingleQuoted(telemetry)}
+exit $LASTEXITCODE
+`;
+      const r = spawnSync("pwsh", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script], {
+        encoding: "utf8",
+      });
+      const out = `${r.stdout}\n${r.stderr}`;
+
+      expect(r.status).toBe(1);
+      expect(out).toContain("Windows signing budget exceeded");
+      expect(out).not.toContain("signtool");
+
+      const records = readFileSync(telemetry, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(records).toHaveLength(2);
+      expect(records[1]).toMatchObject({
+        status: "blocked",
+        discovered: 1,
+        skipped: 0,
+        would_sign: 1,
+        signed: 0,
+        previous_signed: 2,
+        max_signatures: 2,
+      });
     },
     pwshTimeout,
   );


### PR DESCRIPTION
Closes #2818.

## Audit

The broken path is the Windows release signing path:

1. `.github/workflows/release.yml` stages the embedded runtime on the Windows matrix leg.
2. `scripts/print-windows-signables.ts src-tauri/embedded-runtime src-tauri/mcp-servers > sign-targets.txt` emits the signable PE list.
3. `scripts/sign-windows-payload.ps1 -ListFile sign-targets.txt -BatchSize 10 -DelaySeconds 30` signs every unsigned target with `signtool` through SSL.com eSigner CKA.
4. `scripts/stage-signed-nsis-toolset.ps1` invokes the same signer for stock NSIS plugin DLLs.
5. Tauri `bundle.windows.signCommand` invokes the same signer per app/installer helper file.

Prior history reviewed: #2276, #2282/#2283, #2284/#2285, #2286/#2287/#2292, #2289/#2290, #2294/#2295, #2299/#2300, #2479/#2480, and #2483/#2484. #2282 fixed rate limiting and release serialization but explicitly did not add a total per-release cloud-signing budget.

## Fix

- Adds a `MAX_SIGNATURES` release control, defaulting to `850` unless overridden by repo variable.
- Makes `sign-windows-payload.ps1` enforce the cumulative budget across all signer invocations in the Windows release job by reading/writing shared JSONL telemetry.
- Fails before invoking `signtool` if the next invocation would exceed the budget, so an over-budget release does not spend additional SSL.com signatures.
- Adds an `always()` Windows signing budget job-summary step with discovered, skipped, would-sign, and spent signature counts.
- Documents the expected current signing volume and the `MAX_SIGNATURES` audit/bump process.

## Networked path

No Seren publisher/API path is changed by this fix. There is no UI action and no outbound Seren publisher slug/method/path in this code path. The affected networked release path remains GitHub Actions on `windows-latest` invoking local PowerShell and Windows `signtool`, which talks to the already-configured SSL.com eSigner CKA cloud credential and timestamp endpoint.

## Validation

- `pnpm vitest run tests/unit/windows-sign-overlay.test.ts tests/unit/windows-e2e-release-gate.test.ts tests/unit/windows-signables.test.ts tests/unit/print-windows-signables.test.ts` — 48 passed.
- `pwsh` AST parse for `scripts/sign-windows-payload.ps1` — passed.
- `git diff --check` — passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml` — passed.
- Functional signer walkthrough, mocked Authenticode `NotSigned`: previous signed count 2 + one new target with `MAX_SIGNATURES=2` exits 1 before `signtool` and writes a `blocked` telemetry record.
- Functional signer walkthrough, mocked Authenticode `Valid`: one already-signed target with `MAX_SIGNATURES=0` exits 0, skips signing, and writes `signed=0` telemetry.

Notes: `biome format --write tests/unit/windows-sign-overlay.test.ts` reports the path is ignored by repo config. Ruby YAML parsing could not run locally because this machine's Ruby is missing `libgmp.10.dylib`; actionlint covered the workflow syntax instead.
