### PR TITLE
fix(release): warn on Windows signing budget overage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ env:
   HAS_APPLE_SIGNING: ${{ secrets.APPLE_CERTIFICATE != '' }}
   # SSL.com eSigner cloud signing for Windows EV code signing
   HAS_WINDOWS_SIGNING: ${{ secrets.ES_USERNAME != '' }}
-  # Maximum billable SSL.com cloud hash-signing operations for one Windows
-  # release job. Bump only after auditing sign-targets.txt / signer telemetry.
+  # Warning threshold for billable SSL.com cloud hash-signing operations in one
+  # Windows release job. Bump only after auditing sign-targets.txt / signer telemetry.
   MAX_SIGNATURES: ${{ vars.MAX_SIGNATURES || '850' }}
 
 jobs:
@@ -541,15 +541,15 @@ jobs:
           [int]$skipped = 0
           [int]$wouldSign = 0
           [int]$signed = 0
-          $blocked = $false
+          $overBudget = $false
           foreach ($record in $records) {
             if ($null -ne $record.discovered) { $discovered += [int]$record.discovered }
             if ($null -ne $record.skipped) { $skipped += [int]$record.skipped }
             if ($null -ne $record.would_sign) { $wouldSign += [int]$record.would_sign }
             if ($null -ne $record.signed) { $signed += [int]$record.signed }
-            if ($record.status -eq "blocked") { $blocked = $true }
+            if ($record.status -eq "over_budget") { $overBudget = $true }
           }
-          $status = if ($blocked) { "blocked by budget gate" } else { "within budget" }
+          $status = if ($overBudget) { "over budget warning" } else { "within budget" }
           Add-Content -LiteralPath $summary -Value "- Status: $status"
           Add-Content -LiteralPath $summary -Value "- Discovered: $discovered"
           Add-Content -LiteralPath $summary -Value "- Skipped already valid: $skipped"

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -44,7 +44,7 @@ Add these secrets to the repository settings (Settings → Secrets → Actions):
 
 | Variable | Description |
 |----------|-------------|
-| `MAX_SIGNATURES` | Maximum SSL.com cloud hash-signing operations allowed in one Windows release job. Defaults to `850` in `release.yml`; raise only after reviewing `sign-targets.txt` and the Windows signing job summary. |
+| `MAX_SIGNATURES` | Warning threshold for SSL.com cloud hash-signing operations in one Windows release job. Defaults to `850` in `release.yml`; raise only after reviewing `sign-targets.txt` and the Windows signing job summary. |
 
 ## Certificate Setup
 
@@ -126,8 +126,8 @@ the artifact that embeds it is produced:
    `.nsis.zip` updater bundle. The signable set is discovered by
    `scripts/print-windows-signables.ts` and signed in place by
    `scripts/sign-windows-payload.ps1` (signtool + eSigner CKA, throttled
-   batches under SSL.com's rate limit, `#2282`, with the `MAX_SIGNATURES`
-   budget gate from `#2818`).
+   batches under SSL.com's rate limit, `#2282`, with `MAX_SIGNATURES`
+   budget telemetry from `#2818`/`#2821`).
 
 2. **NSIS stock plugin DLLs** (`#2237`, `#2299`) — `System.dll`, `nsExec.dll`,
    `StartMenu.dll`, and `nsDialogs.dll` ship inside the `tauri-bundler` NSIS
@@ -154,24 +154,24 @@ the artifact that embeds it is produced:
    is re-packed from the signed `.exe` and its `.nsis.zip.sig` re-signed with
    the Tauri updater key (`#2236`).
 
+### Budget telemetry (release CI, warning-only)
+
+Each Windows release writes a **Windows signing budget** section to the GitHub
+job summary. Recent audits found roughly 715-729 embedded-runtime signables,
+plus the NSIS/tooling and Tauri wrapper signings. The default warning threshold
+is `850`, leaving limited headroom for normal drift while making unexpected
+growth visible without blocking a production release. Review the discovered,
+skipped, and cloud-signatures-spent counts before changing `MAX_SIGNATURES`; a
+threshold bump should be paired with an audit of the added files and why they
+must be signed.
+
 ### Verification gates (release CI, hard-fail)
 
-- The cumulative signer telemetry cannot exceed `MAX_SIGNATURES` (`#2818`).
-  Recent Windows signing audits found roughly 715-729 embedded-runtime
-  signables, plus the NSIS/tooling and Tauri wrapper signings. The default
-  ceiling is `850`, leaving limited headroom for normal drift while stopping a
-  runaway release before it spends hundreds or thousands of unexpected SSL.com
-  cloud signatures.
 - Loose `.exe`/`.dll` under `bundle/` are all `Valid` (`#2235`).
 - Every `.exe`/`.dll` extracted from `.nsis.zip` is `Valid` (`#2236`).
 - The setup `.exe` is unpacked with 7-Zip and **every** embedded
   `.exe`/`.dll`/`.node` — including the `$PLUGINSDIR` helper DLLs — is `Valid`
   (`#2237`). This is the closest CI proxy for what Smart App Control sees.
-
-Each Windows release writes a **Windows signing budget** section to the GitHub
-job summary. Review the discovered, skipped, and cloud-signatures-spent counts
-before changing `MAX_SIGNATURES`; a ceiling bump should be paired with an audit
-of the added files and why they must be signed.
 
 ### SEREN_TAURI_SKIP_PREP
 

--- a/scripts/sign-windows-payload.ps1
+++ b/scripts/sign-windows-payload.ps1
@@ -1,6 +1,6 @@
 # ABOUTME: Signs Windows PE binaries in place with signtool using the eSigner CKA-loaded EV cert (#2276).
 # ABOUTME: Takes signables from -Root/-File/-ListFile, skips already-signed, signs in throttled batches (#2282), fails loud if any file is left unsigned.
-# ABOUTME: Enforces the Windows release signature budget and writes per-invocation telemetry (#2818).
+# ABOUTME: Reports the Windows release signature budget and writes per-invocation telemetry (#2818/#2821).
 
 [CmdletBinding()]
 param(
@@ -22,8 +22,8 @@ param(
   # file, so bursting the whole payload trips SSL.com's per-minute rate limit
   # (#2282). Pausing between batches holds the request rate under that ceiling.
   [int]$DelaySeconds = 0,
-  # Maximum cumulative cloud hash-signing operations allowed for this release job.
-  # Defaults from MAX_SIGNATURES; unset/-1 disables the gate for local ad-hoc use.
+  # Maximum cumulative cloud hash-signing operations expected for this release job.
+  # Defaults from MAX_SIGNATURES; unset/-1 disables the warning for local ad-hoc use.
   [int]$MaxSignatures = -1,
   # JSONL telemetry file shared across signer invocations in one release job.
   # Defaults from WINDOWS_SIGN_TELEMETRY_FILE.
@@ -178,13 +178,13 @@ if ($targets.Count -eq 0) {
 }
 $previousSigned = Read-PreviousSignedCount -Path $TelemetryFile
 $projectedSigned = $previousSigned + $targets.Count
+$telemetryStatus = "success"
 if ($maxSignatureBudget -ge 0) {
   Write-Host "Windows signing budget: $previousSigned already signed, this invocation would sign $($targets.Count), max $maxSignatureBudget."
   if ($projectedSigned -gt $maxSignatureBudget) {
-    Write-Host "::error::Windows signing budget exceeded: signing $($targets.Count) more file(s) would bring this release to $projectedSigned cloud signature(s), above MAX_SIGNATURES=$maxSignatureBudget."
-    Write-Host "::error::Audit sign-targets.txt / Windows signing telemetry and raise MAX_SIGNATURES through review only if this release intentionally needs the extra signatures."
-    Write-SigningTelemetry -Path $TelemetryFile -Status "blocked" -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign $targets.Count -Signed 0 -PreviousSigned $previousSigned -Max $maxSignatureBudget
-    exit 1
+    Write-Host "::warning::Windows signing budget exceeded: signing $($targets.Count) more file(s) would bring this release to $projectedSigned cloud signature(s), above MAX_SIGNATURES=$maxSignatureBudget."
+    Write-Host "::warning::Release signing will continue. Audit sign-targets.txt / Windows signing telemetry and raise MAX_SIGNATURES if this release intentionally needs the extra signatures."
+    $telemetryStatus = "over_budget"
   }
 }
 Write-Host "Signing $($targets.Count) file(s) in batches of $BatchSize (delay ${DelaySeconds}s between batches)..."
@@ -238,5 +238,5 @@ if ($unsigned.Count -gt 0) {
   $unsigned | ForEach-Object { Write-Host "    $_" }
   exit 1
 }
-Write-SigningTelemetry -Path $TelemetryFile -Status "success" -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign $targets.Count -Signed $targets.Count -PreviousSigned $previousSigned -Max $maxSignatureBudget
+Write-SigningTelemetry -Path $TelemetryFile -Status $telemetryStatus -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign $targets.Count -Signed $targets.Count -PreviousSigned $previousSigned -Max $maxSignatureBudget
 Write-Host "All $($targets.Count) file(s) carry a Valid Authenticode signature."

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Guards the regression class where Windows installers shipped unsigned Seren.exe / nsis_tauri_utils.dll (v3.52.4-6).
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -129,7 +129,7 @@ describe("release workflow contract", () => {
     expect(workflow).toContain("Audit Windows payload signature coverage");
   });
 
-  it("caps Windows signing volume and reports budget telemetry (#2818)", () => {
+  it("reports Windows signing budget telemetry as warning-only (#2818/#2821)", () => {
     const signer = readFileSync(signerScript, "utf8");
 
     expect(workflow).toContain("MAX_SIGNATURES");
@@ -151,6 +151,7 @@ describe("release workflow contract", () => {
     expect(signer).toContain("Read-PreviousSignedCount");
     expect(signer).toContain("Write-SigningTelemetry");
     expect(signer).toContain("Windows signing budget exceeded");
+    expect(signer).toContain("over_budget");
     expect(signer).toContain("MAX_SIGNATURES");
   });
 });
@@ -213,10 +214,13 @@ describe("sign-windows-payload.ps1 thumbprint resolution", () => {
     pwshTimeout,
   );
 
-  it.runIf(hasPwsh)(
-    "blocks over-budget signing before signtool and records telemetry (#2818)",
+  it.runIf(runnable)(
+    "warns over-budget signing, continues to signtool, and records telemetry (#2821)",
     () => {
       const telemetry = path.join(dummy, "telemetry.jsonl");
+      const fakeSigntool = path.join(dummy, "kit\\x64\\signtool.exe");
+      writeFileSync(fakeSigntool, "#!/bin/sh\nexit 0\n");
+      chmodSync(fakeSigntool, 0o755);
       writeFileSync(
         telemetry,
         `${JSON.stringify({
@@ -232,9 +236,28 @@ describe("sign-windows-payload.ps1 thumbprint resolution", () => {
       );
 
       const script = `
-function Get-AuthenticodeSignature {
+$global:sigChecks = 0
+function global:Get-AuthenticodeSignature {
   param([string]$LiteralPath)
-  [PSCustomObject]@{ Status = "NotSigned" }
+  $global:sigChecks++
+  if ($global:sigChecks -eq 1) {
+    [PSCustomObject]@{ Status = "NotSigned" }
+  } else {
+    [PSCustomObject]@{ Status = "Valid" }
+  }
+}
+function global:Get-ChildItem {
+  param(
+    [string]$Path,
+    [switch]$Recurse,
+    [string]$Filter,
+    [object]$ErrorAction
+  )
+  if ($Filter -eq "signtool.exe") {
+    [PSCustomObject]@{ FullName = ${psSingleQuoted(fakeSigntool)} }
+    return
+  }
+  Microsoft.PowerShell.Management\\Get-ChildItem @PSBoundParameters
 }
 & ${psSingleQuoted(signerScript)} -Thumbprint "933C679D86D0ACAF531B37A4D12C0B360EB4815C" -File ${psSingleQuoted(path.join(dummy, "a.exe"))} -MaxSignatures 2 -TelemetryFile ${psSingleQuoted(telemetry)}
 exit $LASTEXITCODE
@@ -244,9 +267,9 @@ exit $LASTEXITCODE
       });
       const out = `${r.stdout}\n${r.stderr}`;
 
-      expect(r.status).toBe(1);
+      expect(r.status).toBe(0);
       expect(out).toContain("Windows signing budget exceeded");
-      expect(out).not.toContain("signtool");
+      expect(out).toContain(`Using signtool: ${fakeSigntool}`);
 
       const records = readFileSync(telemetry, "utf8")
         .trim()
@@ -254,11 +277,11 @@ exit $LASTEXITCODE
         .map((line) => JSON.parse(line));
       expect(records).toHaveLength(2);
       expect(records[1]).toMatchObject({
-        status: "blocked",
+        status: "over_budget",
         discovered: 1,
         skipped: 0,
         would_sign: 1,
-        signed: 0,
+        signed: 1,
         previous_signed: 2,
         max_signatures: 2,
       });


### PR DESCRIPTION
Closes #2821.

## Audit

The broken path is the Windows release signing budget added by #2820:

1. .github/workflows/release.yml sets MAX_SIGNATURES and initializes WINDOWS_SIGN_TELEMETRY_FILE on the Windows matrix leg.
2. scripts/print-windows-signables.ts writes sign-targets.txt for src-tauri/embedded-runtime and src-tauri/mcp-servers.
3. scripts/sign-windows-payload.ps1 reads prior signed count from shared JSONL telemetry, computes projectedSigned, and previously exited 1 when projectedSigned exceeded MAX_SIGNATURES.
4. scripts/stage-signed-nsis-toolset.ps1 invokes the same signer for stock NSIS plugin DLLs.
5. Tauri bundle.windows.signCommand invokes the same signer for app and installer helper files.
6. The always() summary step reported budget telemetry, but could not recover the failed job.

Prior history reviewed: #2818/#2820, #2276/#2283, #2282/#2283, #2284/#2285, #2286/#2287/#2292, #2289/#2290, #2294/#2295, #2299/#2300, #2479/#2480, and #2483/#2484. Those fixes preserve signing coverage, rate limiting, literal-path handling, correct Tauri signing points, NSIS plugin signing, updater packaging, and eSigner login errors; none require MAX_SIGNATURES to remain a hard release gate.

## Fix

- Treat MAX_SIGNATURES as a warning threshold instead of a hard release gate.
- On over-budget signing, emit GitHub Actions warnings, continue to signtool, and record status=over_budget with the actual signed count after successful signing.
- Update the Windows signing job summary to show over budget warning instead of blocked by budget gate.
- Move docs wording from a hard-fail verification gate to warning-only budget telemetry.
- Replace the regression test that asserted the bad hard-stop behavior with a mocked signer walkthrough proving over-budget signing reaches signtool and exits successfully.

## Networked path

No Seren publisher/API path is changed. There is no UI action and no outbound Seren publisher slug/method/path in this release feature. The affected release path is GitHub Actions on windows-latest invoking local PowerShell and Windows signtool, which uses the already-configured SSL.com eSigner CKA credential and timestamp endpoint.

## Validation

- pnpm vitest run tests/unit/windows-sign-overlay.test.ts — 13 passed.
- pnpm vitest run tests/unit/windows-sign-overlay.test.ts tests/unit/windows-e2e-release-gate.test.ts tests/unit/windows-signables.test.ts tests/unit/print-windows-signables.test.ts — 48 passed.
- pwsh AST parse for scripts/sign-windows-payload.ps1 — passed.
- git diff --check — passed.
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml — passed.

Note: pnpm exec biome check tests/unit/windows-sign-overlay.test.ts reports the path is ignored by repo config, so no Biome formatting ran for that file.
