### PR TITLE
fix(release): cache Windows embedded-runtime signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,21 +436,47 @@ jobs:
           CARGO_BUILD_TARGET: ${{ matrix.target }}
         run: pnpm prepare:tauri-build
 
+      - name: Restore Windows signature cache
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        uses: actions/cache@v4
+        with:
+          path: .sig-cache/windows-authenticode
+          # Unique primary key + broad restore key: restore the newest prior
+          # content-addressed store, then save this run's newly signed misses.
+          key: win-sigcache-${{ github.run_id }}
+          restore-keys: |
+            win-sigcache-
+
       # Discover the signable set with the tested cross-platform selector, then
       # sign it throttled to stay under SSL.com's per-minute rate limit (#2282).
       # The embedded runtime is the only large payload, so it carries the throttle;
       # the per-file installer/helper signings below stay unthrottled (tiny sets).
+      # A content-addressed signature cache restores unchanged binaries before
+      # signing, so steady-state releases only spend signatures on changed files
+      # while the signer keeps its existing Valid-signature skip and telemetry.
       - name: Sign embedded runtime (Windows)
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
         shell: pwsh
         run: |
           pnpm tsx scripts/print-windows-signables.ts `
             src-tauri/embedded-runtime src-tauri/mcp-servers > sign-targets.txt
+          ./scripts/windows-signature-cache.ps1 `
+            -Mode restore `
+            -ListFile sign-targets.txt `
+            -CacheDir .sig-cache/windows-authenticode `
+            -Manifest windows-signature-cache-manifest.tsv `
+            -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT
           ./scripts/sign-windows-payload.ps1 `
             -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT `
             -ListFile sign-targets.txt `
             -BatchSize 10 `
             -DelaySeconds 30
+          ./scripts/windows-signature-cache.ps1 `
+            -Mode save `
+            -ListFile sign-targets.txt `
+            -CacheDir .sig-cache/windows-authenticode `
+            -Manifest windows-signature-cache-manifest.tsv `
+            -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT
 
       # makensis embeds the stock NSIS plugins ($PLUGINSDIR: System.dll,
       # nsExec.dll, StartMenu.dll, nsDialogs.dll) from the bundler's NSIS

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -128,6 +128,12 @@ the artifact that embeds it is produced:
    `scripts/sign-windows-payload.ps1` (signtool + eSigner CKA, throttled
    batches under SSL.com's rate limit, `#2282`, with `MAX_SIGNATURES`
    budget telemetry from `#2818`/`#2821`).
+   `scripts/windows-signature-cache.ps1` wraps this large payload signing with
+   a content-addressed Authenticode cache (`#2823`): before signing, unchanged
+   files are restored from cache only when the cached blob has a `Valid`
+   signature from the expected certificate thumbprint; after signing, newly
+   signed cache misses are saved by their pre-sign SHA-256. The signer still
+   owns the actual skip/sign/budget telemetry behavior.
 
 2. **NSIS stock plugin DLLs** (`#2237`, `#2299`) — `System.dll`, `nsExec.dll`,
    `StartMenu.dll`, and `nsDialogs.dll` ship inside the `tauri-bundler` NSIS
@@ -164,6 +170,12 @@ growth visible without blocking a production release. Review the discovered,
 skipped, and cloud-signatures-spent counts before changing `MAX_SIGNATURES`; a
 threshold bump should be paired with an audit of the added files and why they
 must be signed.
+
+The embedded-runtime signature cache should make the second release with an
+unchanged runtime report most of that large payload as skipped already valid,
+because cached signed binaries are restored before `sign-windows-payload.ps1`
+runs. A cold cache should behave the same as the pre-cache path, then populate
+the cache for later releases.
 
 ### Verification gates (release CI, hard-fail)
 

--- a/scripts/windows-signature-cache.ps1
+++ b/scripts/windows-signature-cache.ps1
@@ -1,0 +1,92 @@
+# ABOUTME: Content-addressed cache for Windows Authenticode signatures so unchanged release payload binaries are signed once.
+# ABOUTME: Restores only valid, trusted cached signatures before the existing signer runs, then saves newly signed cache misses.
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][ValidateSet("restore", "save")][string]$Mode,
+  # Newline-delimited signable set produced by scripts/print-windows-signables.ts.
+  [Parameter(Mandatory = $true)][string]$ListFile,
+  # Persistent cache directory restored/saved by actions/cache.
+  [Parameter(Mandatory = $true)][string]$CacheDir,
+  # Pre-sign hash manifest written by restore and consumed by save.
+  [Parameter(Mandatory = $true)][string]$Manifest,
+  # Only trust cached signatures produced by this certificate. Defaults from CI.
+  [string]$Thumbprint = ""
+)
+
+$ErrorActionPreference = "Stop"
+if (-not $Thumbprint) { $Thumbprint = $env:WINDOWS_SIGN_THUMBPRINT }
+$trustedThumbprint = if ($Thumbprint) { $Thumbprint.Replace(" ", "").ToUpperInvariant() } else { "" }
+
+function Get-Signables {
+  param([string]$Path)
+  if (-not (Test-Path -LiteralPath $Path)) { throw "ListFile not found: $Path" }
+  Get-Content -LiteralPath $Path | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+}
+
+function Test-TrustedSignature {
+  param([string]$Path)
+  $sig = Get-AuthenticodeSignature -LiteralPath $Path
+  if ($sig.Status -ne "Valid" -or -not $sig.SignerCertificate) { return $false }
+  if ($trustedThumbprint) {
+    $actual = ([string]$sig.SignerCertificate.Thumbprint).Replace(" ", "").ToUpperInvariant()
+    if ($actual -ne $trustedThumbprint) { return $false }
+  }
+  return $true
+}
+
+New-Item -ItemType Directory -Force -Path $CacheDir | Out-Null
+$manifestDir = Split-Path -Parent $Manifest
+if ($manifestDir -and -not (Test-Path -LiteralPath $manifestDir)) {
+  New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
+}
+
+if ($Mode -eq "restore") {
+  $lines = [System.Collections.Generic.List[string]]::new()
+  [int]$restored = 0
+  [int]$total = 0
+
+  foreach ($raw in Get-Signables $ListFile) {
+    if (-not (Test-Path -LiteralPath $raw)) { throw "Listed signable not found: $raw" }
+    $file = (Resolve-Path -LiteralPath $raw).Path
+    $total++
+
+    $hash = (Get-FileHash -LiteralPath $file -Algorithm SHA256).Hash.ToUpperInvariant()
+    $lines.Add("$hash`t$file")
+    $blob = Join-Path $CacheDir "$hash.signed"
+    if (-not (Test-Path -LiteralPath $blob)) { continue }
+
+    $tmp = "$file.sigcache.tmp"
+    Copy-Item -LiteralPath $blob -Destination $tmp -Force
+    if (Test-TrustedSignature $tmp) {
+      Move-Item -LiteralPath $tmp -Destination $file -Force
+      $restored++
+    } else {
+      Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+      Remove-Item -LiteralPath $blob -Force -ErrorAction SilentlyContinue
+      Write-Host "::warning::Discarded untrusted Windows signature-cache entry for $([IO.Path]::GetFileName($file))."
+    }
+  }
+
+  Set-Content -LiteralPath $Manifest -Value $lines
+  Write-Host "Windows signature cache: restored $restored of $total signable(s)."
+} elseif ($Mode -eq "save") {
+  if (-not (Test-Path -LiteralPath $Manifest)) { throw "Manifest not found: $Manifest" }
+
+  [int]$saved = 0
+  foreach ($line in Get-Content -LiteralPath $Manifest) {
+    $parts = $line -split "`t", 2
+    if ($parts.Count -ne 2) { continue }
+    $hash = $parts[0]
+    $file = $parts[1]
+    $blob = Join-Path $CacheDir "$hash.signed"
+    if (Test-Path -LiteralPath $blob) { continue }
+    if (-not (Test-Path -LiteralPath $file)) { continue }
+    if (-not (Test-TrustedSignature $file)) { continue }
+
+    Copy-Item -LiteralPath $file -Destination $blob -Force
+    $saved++
+  }
+
+  Write-Host "Windows signature cache: saved $saved newly signed blob(s)."
+}

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -129,6 +129,27 @@ describe("release workflow contract", () => {
     expect(workflow).toContain("Audit Windows payload signature coverage");
   });
 
+  it("wraps the embedded-runtime signer with the Windows signature cache (#2823)", () => {
+    expect(workflow).toContain("Restore Windows signature cache");
+    expect(workflow).toContain("uses: actions/cache@v4");
+    expect(workflow).toContain(".sig-cache/windows-authenticode");
+    expect(workflow).toContain("key: win-sigcache-${{ github.run_id }}");
+    expect(workflow).toContain("win-sigcache-");
+    expect(workflow).toContain("windows-signature-cache.ps1");
+
+    const cacheActionAt = workflow.indexOf("Restore Windows signature cache");
+    const signStepAt = workflow.indexOf("Sign embedded runtime (Windows)");
+    const cacheRestoreAt = workflow.indexOf("-Mode restore", signStepAt);
+    const signerAt = workflow.indexOf("sign-windows-payload.ps1", cacheRestoreAt);
+    const cacheSaveAt = workflow.indexOf("-Mode save", signerAt);
+
+    expect(cacheActionAt).toBeGreaterThanOrEqual(0);
+    expect(signStepAt).toBeGreaterThan(cacheActionAt);
+    expect(cacheRestoreAt).toBeGreaterThan(signStepAt);
+    expect(signerAt).toBeGreaterThan(cacheRestoreAt);
+    expect(cacheSaveAt).toBeGreaterThan(signerAt);
+  });
+
   it("reports Windows signing budget telemetry as warning-only (#2818/#2821)", () => {
     const signer = readFileSync(signerScript, "utf8");
 

--- a/tests/unit/windows-signature-cache.test.ts
+++ b/tests/unit/windows-signature-cache.test.ts
@@ -1,0 +1,180 @@
+// ABOUTME: Functional tests for the Windows Authenticode signature cache helper (#2823).
+// ABOUTME: Uses mocked PowerShell signature checks so cache trust and manifest behavior are covered without a Windows signer.
+
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const cacheScript = path.join(repoRoot, "scripts", "windows-signature-cache.ps1");
+const pwshCheck = spawnSync("pwsh", ["-NoProfile", "-Command", "$PSVersionTable.PSVersion.Major"], {
+  encoding: "utf8",
+});
+const hasPwsh = pwshCheck.status === 0;
+
+let root: string;
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex").toUpperCase();
+}
+
+function psSingleQuoted(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function runCacheScript(args: string[], signatureMock: string): { out: string; status: number } {
+  const command = `
+$ErrorActionPreference = "Stop"
+${signatureMock}
+& ${psSingleQuoted(cacheScript)} ${args.join(" ")}
+if ($?) { exit 0 } else { exit 1 }
+`;
+  const r = spawnSync("pwsh", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command], {
+    encoding: "utf8",
+  });
+  return { out: `${r.stdout}\n${r.stderr}`, status: r.status ?? 1 };
+}
+
+function validSignatureMock(thumbprint: string): string {
+  return `
+function global:Get-AuthenticodeSignature {
+  param([string]$LiteralPath)
+  [PSCustomObject]@{
+    Status = "Valid"
+    SignerCertificate = [PSCustomObject]@{ Thumbprint = ${psSingleQuoted(thumbprint)} }
+  }
+}
+`;
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "win-sig-cache-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("windows-signature-cache.ps1", () => {
+  const pwshTimeout = 30_000;
+
+  it.runIf(hasPwsh)(
+    "restores a valid cached signature by the pre-sign content hash",
+    () => {
+      const payload = path.join(root, "payload.exe");
+      const list = path.join(root, "sign-targets.txt");
+      const cache = path.join(root, "cache");
+      const manifest = path.join(root, "manifest.tsv");
+      const unsigned = "unsigned bytes";
+      const signed = "signed bytes";
+      const hash = sha256(unsigned);
+
+      mkdirSync(cache, { recursive: true });
+      writeFileSync(payload, unsigned);
+      writeFileSync(list, `${payload}\n`);
+      writeFileSync(path.join(cache, `${hash}.signed`), signed);
+
+      const { out, status } = runCacheScript(
+        [
+          "-Mode restore",
+          "-ListFile",
+          psSingleQuoted(list),
+          "-CacheDir",
+          psSingleQuoted(cache),
+          "-Manifest",
+          psSingleQuoted(manifest),
+          "-Thumbprint",
+          psSingleQuoted("ABC123"),
+        ],
+        validSignatureMock("ABC123"),
+      );
+
+      expect(status).toBe(0);
+      expect(out).toContain("restored 1 of 1");
+      expect(readFileSync(payload, "utf8")).toBe(signed);
+      expect(readFileSync(manifest, "utf8").trim()).toBe(`${hash}\t${payload}`);
+    },
+    pwshTimeout,
+  );
+
+  it.runIf(hasPwsh)(
+    "discards a wrong-thumbprint cache entry before overwriting the payload",
+    () => {
+      const payload = path.join(root, "payload.exe");
+      const list = path.join(root, "sign-targets.txt");
+      const cache = path.join(root, "cache");
+      const manifest = path.join(root, "manifest.tsv");
+      const unsigned = "unsigned bytes";
+      const hash = sha256(unsigned);
+      const blob = path.join(cache, `${hash}.signed`);
+
+      mkdirSync(cache, { recursive: true });
+      writeFileSync(payload, unsigned);
+      writeFileSync(list, `${payload}\n`);
+      writeFileSync(blob, "foreign signed bytes");
+
+      const { out, status } = runCacheScript(
+        [
+          "-Mode restore",
+          "-ListFile",
+          psSingleQuoted(list),
+          "-CacheDir",
+          psSingleQuoted(cache),
+          "-Manifest",
+          psSingleQuoted(manifest),
+          "-Thumbprint",
+          psSingleQuoted("ABC123"),
+        ],
+        validSignatureMock("DEF456"),
+      );
+
+      expect(status).toBe(0);
+      expect(out).toContain("Discarded untrusted Windows signature-cache entry");
+      expect(out).toContain("restored 0 of 1");
+      expect(readFileSync(payload, "utf8")).toBe(unsigned);
+      expect(() => readFileSync(blob, "utf8")).toThrow();
+      expect(readFileSync(manifest, "utf8").trim()).toBe(`${hash}\t${payload}`);
+    },
+    pwshTimeout,
+  );
+
+  it.runIf(hasPwsh)(
+    "saves a newly signed file under the manifest's original pre-sign hash",
+    () => {
+      const payload = path.join(root, "payload.exe");
+      const list = path.join(root, "sign-targets.txt");
+      const cache = path.join(root, "cache");
+      const manifest = path.join(root, "manifest.tsv");
+      const originalHash = sha256("unsigned bytes");
+      const signed = "signed bytes";
+
+      mkdirSync(cache, { recursive: true });
+      writeFileSync(payload, signed);
+      writeFileSync(list, `${payload}\n`);
+      writeFileSync(manifest, `${originalHash}\t${payload}\n`);
+
+      const { out, status } = runCacheScript(
+        [
+          "-Mode save",
+          "-ListFile",
+          psSingleQuoted(list),
+          "-CacheDir",
+          psSingleQuoted(cache),
+          "-Manifest",
+          psSingleQuoted(manifest),
+          "-Thumbprint",
+          psSingleQuoted("ABC123"),
+        ],
+        validSignatureMock("ABC123"),
+      );
+
+      expect(status).toBe(0);
+      expect(out).toContain("saved 1 newly signed");
+      expect(readFileSync(path.join(cache, `${originalHash}.signed`), "utf8")).toBe(signed);
+    },
+    pwshTimeout,
+  );
+});


### PR DESCRIPTION
Closes #2823.

## Audit

The broken path is the Windows release signing path introduced and refined by #2818/#2820/#2821/#2822:

1. `.github/workflows/release.yml` stages `src-tauri/embedded-runtime` and `src-tauri/mcp-servers` on the Windows release leg.
2. `scripts/print-windows-signables.ts src-tauri/embedded-runtime src-tauri/mcp-servers > sign-targets.txt` emits the large PE signable set.
3. `scripts/sign-windows-payload.ps1 -ListFile sign-targets.txt -BatchSize 10 -DelaySeconds 30` skips `Valid` files, signs remaining `.exe/.dll/.node/.pyd` files through SSL.com eSigner CKA, and records budget telemetry.
4. Fresh CI runners re-stage the embedded runtime as unsigned bytes on every release, so unchanged runtime binaries are signed again every release. #2820/#2822 make this visible/warning-only but do not reduce steady-state signature volume.

Prior issues/PRs/docs reviewed: #2818, #2820, #2821/#2822, #2282/#2283, #2235, `docs/code-signing.md`, `.github/workflows/release.yml`, `scripts/sign-windows-payload.ps1`, `scripts/windows-signables.ts`, `scripts/print-windows-signables.ts`, and `scripts/stage-signed-nsis-toolset.ps1`.

## Fix

- Adds `scripts/windows-signature-cache.ps1`, a content-addressed Authenticode cache helper.
- Restore mode hashes each staged unsigned signable, records a pre-sign hash manifest, verifies any cached blob is `Valid` and signed by the expected thumbprint, then restores trusted blobs before the signer runs.
- Save mode reads the pre-sign manifest and saves newly signed valid own-cert files under `<pre-sign-sha256>.signed`.
- Wraps only the large embedded-runtime signing step with `actions/cache@v4` plus restore -> existing signer -> save.
- Leaves `sign-windows-payload.ps1` unchanged, so existing valid-signature skips, warnings, telemetry, and hard signature verification behavior remain in force.
- Documents the cache in `docs/code-signing.md`.

## Networked path

No Seren publisher/API path is changed. There is no UI action and no outbound Seren publisher slug/method/path in this release feature. The affected path is GitHub Actions release CI on `windows-latest`.

Changed networked dependency: `.github/workflows/release.yml` now uses official `actions/cache@v4` with `path`, `key`, and `restore-keys`. I verified the official GitHub action metadata via `gh api -X GET repos/actions/cache/contents/action.yml --field ref=v4`; the `v4` tag resolves to `0057852bfaa89a56745cba8c7296529d2fc39830`, and `action.yml` defines restore as `main`, save as `post`, and the inputs used here. Existing outbound signing remains local PowerShell/Windows `signtool` through the already configured SSL.com eSigner CKA credential plus RFC 3161 timestamping at `http://ts.ssl.com`.

## Validation

- `pnpm vitest run tests/unit/windows-signature-cache.test.ts tests/unit/windows-sign-overlay.test.ts tests/unit/windows-signables.test.ts tests/unit/print-windows-signables.test.ts` — 28 passed.
- PowerShell AST parse for `scripts/windows-signature-cache.ps1` and `scripts/sign-windows-payload.ps1` — passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml` — passed.
- `git diff --check` — passed.
- `pnpm exec biome check tests/unit/windows-signature-cache.test.ts tests/unit/windows-sign-overlay.test.ts` — repo config ignores these test paths, so Biome processed 0 files.
- Functional release-cache walkthrough with mocked Authenticode: cold restore left the unsigned payload unchanged, save cached one newly signed blob, and warm restore replaced the same unsigned payload from cache.

No broad TDD was added; coverage is limited to the cache trust/manifest behavior and workflow ordering contract.