### PR TITLE
feat(agent): pin Fable 5 for the Claude + Codex planner (#2825)

### DIFF
--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -5,6 +5,20 @@ import { randomUUID } from "node:crypto";
 
 export const PAIRED_AGENT_TYPE = "claude-codex";
 
+// Default Claude model for the paired agent's planner/reviewer role. The paired
+// agent pins the Claude role to Fable 5 unless the user has explicitly chosen a
+// planner model. Applied as a post-spawn model switch (see spawnRole) so an
+// unavailable id degrades to the Claude Code default with a notice instead of
+// failing the session. Fable's context is 1M-native, so the bare id is used
+// (no `[1m]` tier suffix). #2825.
+const PAIRED_PLANNER_MODEL_ID = "claude-fable-5";
+
+// Friendly labels for pinned model ids the Claude Code catalog may not report by
+// name, so the setup declaration reads "Fable 5" rather than a raw model id.
+const MODEL_DISPLAY_LABELS = {
+  "claude-fable-5": "Fable 5",
+};
+
 const ROLE_DEFS = {
   planner: {
     role: "planner",
@@ -38,7 +52,9 @@ function effortDisplayValue(roleState) {
 
 function describeRoleModel(roleState) {
   const base = roleState.pinnedModelId
-    ? (modelDisplayName(roleState) ?? roleState.pinnedModelId)
+    ? (modelDisplayName(roleState) ??
+        MODEL_DISPLAY_LABELS[roleState.pinnedModelId] ??
+        roleState.pinnedModelId)
     : ROLE_DEFS[roleState.role].defaultModelLabel;
   const current = modelDisplayName(roleState);
   return current && current !== base ? `${base} · currently ${current}` : base;
@@ -62,11 +78,16 @@ export function buildPairedDeclaration(paired) {
 
 function buildPlannerPrompt(userPrompt) {
   return [
-    "You are the PLANNER and REVIEWER in a paired workflow. A separate",
-    "executor agent (Codex) will make all code edits, run commands, and run",
-    "tests. Do NOT edit files or run state-changing commands yourself.",
-    "Read whatever you need, then reply with a short, concrete implementation",
-    "plan the executor can follow. Plain language; numbered steps.",
+    "You are the PLANNER in a paired workflow. A separate executor agent",
+    "(Codex) will make all code edits, run commands, and run tests — you do",
+    "not. Read only the files you need to write an accurate plan.",
+    "",
+    "Reply with the implementation plan and nothing else: numbered steps the",
+    "executor can follow, each naming the concrete file paths and functions to",
+    "change. Skip preamble, restating the request, rationale, alternatives you",
+    "weighed, and risk commentary — the executor needs the steps, not the",
+    "reasoning. If the request is already unambiguous, write the plan directly",
+    "rather than surveying options.",
     "",
     "User request:",
     userPrompt,
@@ -350,6 +371,25 @@ export function createPairedRuntime({ emit, inner }) {
         initialModelId: config.modelId ?? undefined,
       });
       roleState.agentSessionId = info?.agentSessionId ?? roleState.agentSessionId;
+
+      // Pin the planner/reviewer model — Fable 5 by default (#2825) unless the
+      // user has explicitly chosen a planner model. Switch after spawn: the
+      // spawn stays on the Claude Code default, so a model id the local CLI does
+      // not recognize degrades to a notice here instead of killing the planner
+      // process (an unknown spawn-time `--model` would). Mirrors the executor.
+      const plannerModelId = config.modelId ?? PAIRED_PLANNER_MODEL_ID;
+      if (plannerModelId) {
+        try {
+          await inner.setSessionModel({
+            sessionId: innerSessionId,
+            modelId: plannerModelId,
+          });
+          roleState.pinnedModelId = plannerModelId;
+        } catch {
+          roleState.pinnedModelId = null;
+          roleState.notice = `Pinned model ${plannerModelId} is unavailable in this Claude Code install. Using the Claude default instead.`;
+        }
+      }
       return info;
     }
 

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -229,8 +229,14 @@ describe("paired runtime — spawn", () => {
   });
 
   it("applies pinned executor model from spawn params, with fallback notice when unavailable", async () => {
-    h.inner.setSessionModel.mockRejectedValueOnce(
-      new Error("Unknown Codex model: gpt-retired"),
+    // The planner is pinned to Fable 5 first (#2825), so reject only the
+    // executor's model rather than the next call in order.
+    h.inner.setSessionModel.mockImplementation(
+      async ({ modelId }: { modelId: string }) => {
+        if (modelId === "gpt-retired") {
+          throw new Error("Unknown Codex model: gpt-retired");
+        }
+      },
     );
     await spawnPaired(h, {
       paired: { executor: { modelId: "gpt-retired" } },
@@ -245,6 +251,58 @@ describe("paired runtime — spawn", () => {
     >;
     expect(String(last.paired.executor.notice)).toContain("gpt-retired");
     expect(String(last.paired.executor.notice)).toMatch(/no longer available/i);
+  });
+
+  it("pins Fable 5 for the planner on spawn when no planner model is configured (#2825)", async () => {
+    await spawnPaired(h);
+    const plannerInnerId = String(
+      h.inner.spawnSession.mock.calls.find(
+        (c) => c[0].agentType === "claude-code",
+      )?.[0].localSessionId,
+    );
+    expect(h.inner.setSessionModel).toHaveBeenCalledWith({
+      sessionId: plannerInnerId,
+      modelId: "claude-fable-5",
+    });
+  });
+
+  it("respects an explicit planner model instead of the Fable default", async () => {
+    await spawnPaired(h, {
+      paired: { planner: { modelId: "claude-opus-4-6" } },
+    });
+    const plannerInnerId = String(
+      h.inner.spawnSession.mock.calls.find(
+        (c) => c[0].agentType === "claude-code",
+      )?.[0].localSessionId,
+    );
+    const plannerSets = h.inner.setSessionModel.mock.calls.filter(
+      (c) => c[0].sessionId === plannerInnerId,
+    );
+    expect(plannerSets.map((c) => c[0].modelId)).toEqual(["claude-opus-4-6"]);
+  });
+
+  it("keeps the paired session alive when the pinned planner model is unavailable", async () => {
+    // A planner model the local Claude Code install rejects must degrade to a
+    // notice, never fail the spawn — the whole point of the post-spawn switch.
+    h.inner.setSessionModel.mockImplementation(
+      async ({ modelId }: { modelId: string }) => {
+        if (modelId === "claude-fable-5") {
+          throw new Error("Unknown model: claude-fable-5");
+        }
+      },
+    );
+    const info = await spawnPaired(h);
+    expect(info.id).toBe("paired-1");
+    const statuses = eventsFor(h.emitted, "provider://session-status").filter(
+      (e) => e.payload.sessionId === "paired-1",
+    );
+    const last = statuses[statuses.length - 1].payload as Record<
+      string,
+      // biome-ignore lint/suspicious/noExplicitAny: test introspection
+      any
+    >;
+    expect(String(last.paired.planner.notice)).toContain("claude-fable-5");
+    expect(String(last.paired.planner.notice)).toMatch(/Claude default/i);
   });
 
   it("never forwards raw inner session ids to the frontend", async () => {
@@ -314,6 +372,20 @@ describe("paired runtime — prompt pipeline", () => {
     });
     const reviewCall = h.inner.sendPrompt.mock.calls[2][0];
     expect(String(reviewCall.prompt)).toContain("EXEC: renamed the button");
+  });
+
+  it("sends a plan-only planner prompt that omits reviewer framing (#2825)", async () => {
+    await h.paired.sendPrompt({
+      sessionId: "paired-1",
+      prompt: "rename the login button",
+    });
+    const plannerPrompt = String(h.inner.sendPrompt.mock.calls[0][0].prompt);
+    expect(plannerPrompt).toContain("You are the PLANNER");
+    expect(plannerPrompt).toContain("the implementation plan and nothing else");
+    // The review phase is a separate turn; the planner prompt must not carry
+    // reviewer framing that invites Fable to spend output tokens on it.
+    expect(plannerPrompt).not.toContain("REVIEWER");
+    expect(plannerPrompt).toContain("rename the login button");
   });
 
   it("emits inline handoff events between phases with source and destination", async () => {
@@ -494,6 +566,9 @@ describe("paired runtime — role-scoped model and effort", () => {
         (c) => c[0].agentType === "codex",
       )?.[0].localSessionId,
     );
+    // Drop the spawn-time planner Fable pin (#2825) so these tests count only
+    // their own explicit setSessionModel calls.
+    h.inner.setSessionModel.mockClear();
     h.emitted.length = 0;
   });
 


### PR DESCRIPTION
Closes #2825

## What
Pin **Fable 5** (`claude-fable-5`) as the planner/reviewer (Claude) model for the paired **Claude + Codex** agent, and Fable-tune the planner prompt to cut wasted output tokens. Executor (Codex) role unchanged.

Timely: Fable is included in subscriber weekly limits through **July 7** (usage-credits after) — https://www.anthropic.com/news/redeploying-fable-5.

## Changes (`bin/browser-local/paired-runtime.mjs`)
- **Planner pin (defensive):** default the planner to `claude-fable-5` unless the user has explicitly chosen a planner model (`params.paired.planner.modelId`). Applied as a **post-spawn `setSessionModel`**, not a spawn-time `--model`: the planner spawns on the Claude Code default, then switches — so a model id the local CLI rejects **degrades to a notice** rather than killing the planner process. Mirrors the existing executor pin.
- **`buildPlannerPrompt` rewrite:** plan-only (dropped "REVIEWER" framing — review is a separate turn), bounded reading, "the plan and nothing else" (no preamble/rationale/alternatives/risk), concrete file paths + functions (the plan is Codex's input, so this also cuts the executor's re-discovery), and skip option-surveying when the request is unambiguous.
- Friendly label so the setup declaration reads "Fable 5", not a raw id.

## Tests (`tests/unit/paired-runtime.test.ts`) — critical coverage only
- Planner pins Fable 5 on spawn when no planner model is configured.
- Explicit planner model overrides the Fable default.
- **Graceful fallback:** an unavailable pinned model degrades to a notice, session still spawns (the safety-critical case).
- Planner prompt is plan-only and omits reviewer framing.
- Updated one existing test for the new spawn-time set-model ordering; added `mockClear` to the role-scoped `beforeEach`.

Result: `paired-runtime` 31/31; full unit suite **2205/2205** pass.

## Networked-path analysis
None. The planner is the local `claude` CLI spawned as a child process; the pin only changes its `--model` and it talks **direct to Anthropic** — `api.serendb.com` is not in this path. No Seren publisher/API slugs to verify.

## ⚠️ Validation gate — DRAFT until in-app walkthrough passes
I could **not** validate in the real app: the `claude` CLI is not installed on the dev machine and Fable needs an authenticated account, so I cannot observe the planner loading Fable. The defensive design means a wrong model string fails safe (falls back to the Claude default + notice), but the happy path is unverified.

**To validate (machine with Claude Code + Fable access):**
1. `pnpm build:provider-runtime` (regenerate the bundled runtime from `bin/`), then start the app (`pnpm tauri dev`).
2. Start a **Claude + Codex** agent → the setup declaration should read the planner as **Fable 5**.
3. Send a prompt; confirm the plan turn runs on Fable and the plan is plan-only.
4. Negative check: temporarily set the pin to a bad id and confirm the fallback notice appears and the session still runs.

Please run this (or point me at a box with the CLI + Fable) before merge.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com