### PR TITLE
fix(employees): fail-soft tool-groups fetch in employee detail (#2829)

### DIFF
--- a/src/components/employees/EmployeeDetail.tsx
+++ b/src/components/employees/EmployeeDetail.tsx
@@ -231,7 +231,18 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
       if (!employee || employee.visibility === "opaque") return undefined;
       return employee.id;
     },
-    async (id) => svc.listToolGroups(id),
+    async (id) => {
+      try {
+        return await svc.listToolGroups(id);
+      } catch (error) {
+        // Tool groups are a secondary panel. A transient fetch failure must
+        // not re-throw through the render graph and collapse the whole
+        // EmployeeDetail pane via ShellSurfaceBoundary. Degrade to an empty
+        // list, matching the fail-soft contract of the primary detail resource.
+        console.warn(`Failed to load tool groups for employee ${id}:`, error);
+        return [];
+      }
+    },
   );
   const capabilityBadges = createMemo(() => {
     const employee = detail();


### PR DESCRIPTION
Closes #2829 (P1, pre-release audit for v3.68.0).

## Problem
The `toolGroups` `createResource` fetcher rethrew on any `listToolGroups` API error. A rejected SolidJS resource **rethrows on read**, so `capabilityGroups()` threw during render. Because `EmployeeDetail` renders inside `ShellSurfaceBoundary`, a transient 401/403/404/500/network drop on the **secondary** tool-groups endpoint collapsed the **entire** detail pane (status, suspend/wake, conversations — all healthy) into the recovery screen.

## Fix
Catch inside the fetcher and degrade to an empty list, matching the fail-soft contract of the primary `detail` resource (`employees.store` `loadDetail`). The panel renders nothing on error; the rest of the pane stays healthy.

## Verification
Biome clean on the file; `tsc --noEmit` introduces zero new errors referencing `EmployeeDetail.tsx`. Per CLAUDE.md, UI components are not unit-tested.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com