### PR TITLE
fix(agent): pin newest Opus when paired planner lacks Fable 5 (#2827)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -2863,6 +2863,11 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     });
   }
 
+  function listSessionModels(sessionId) {
+    const session = sessions.get(sessionId);
+    return session ? buildAvailableModels(session) : [];
+  }
+
   async function setModel({ sessionId, modelId }) {
     const session = sessions.get(sessionId);
     if (!session) {
@@ -3053,6 +3058,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     setPermissionMode,
     respondToPermission,
     setModel,
+    listSessionModels,
     setConfigOption,
     forkSession,
     buildSyntheticTranscript,

--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -7,10 +7,11 @@ export const PAIRED_AGENT_TYPE = "claude-codex";
 
 // Default Claude model for the paired agent's planner/reviewer role. The paired
 // agent pins the Claude role to Fable 5 unless the user has explicitly chosen a
-// planner model. Applied as a post-spawn model switch (see spawnRole) so an
-// unavailable id degrades to the Claude Code default with a notice instead of
-// failing the session. Fable's context is 1M-native, so the bare id is used
-// (no `[1m]` tier suffix). #2825.
+// planner model. When the account cannot switch to Fable, the planner falls back
+// to the newest Opus (#2827) rather than silently running the Claude default.
+// Applied as a post-spawn model switch (see spawnRole), resolved against the
+// session's real switchable catalog. Fable's context is 1M-native, so the bare
+// id is used (no `[1m]` tier suffix). #2825.
 const PAIRED_PLANNER_MODEL_ID = "claude-fable-5";
 
 // Friendly labels for pinned model ids the Claude Code catalog may not report by
@@ -18,6 +19,41 @@ const PAIRED_PLANNER_MODEL_ID = "claude-fable-5";
 const MODEL_DISPLAY_LABELS = {
   "claude-fable-5": "Fable 5",
 };
+
+// When Fable 5 isn't available on the account, the planner falls back to Opus.
+// The Claude catalog is sorted opus-first, newest version first, so the first
+// Opus entry is the latest; prefer its 1M-context tier (the app default, #2810).
+function findFallbackOpus(availableModels) {
+  const opus = availableModels.filter(
+    (m) => typeof m.modelId === "string" && m.modelId.startsWith("claude-opus-"),
+  );
+  if (opus.length === 0) return null;
+  const newestBaseId = opus[0].modelId.replace(/\[1m\]$/, "");
+  return (
+    opus.find((m) => m.modelId === `${newestBaseId}[1m]`) ??
+    opus.find((m) => m.modelId === newestBaseId) ??
+    opus[0]
+  );
+}
+
+// Resolve which model to pin for the planner given the account's switchable
+// catalog. Prefer an explicit user choice, then Fable 5, then the newest Opus.
+// Returns a null modelId when none apply so the caller keeps the Claude default.
+// The `reason` drives the notice/label so a fallback never claims to be Fable.
+export function resolvePlannerModel(explicitModelId, availableModels) {
+  if (explicitModelId) {
+    return { modelId: explicitModelId, reason: "explicit", name: null };
+  }
+  const models = Array.isArray(availableModels) ? availableModels : [];
+  if (models.some((m) => m.modelId === PAIRED_PLANNER_MODEL_ID)) {
+    return { modelId: PAIRED_PLANNER_MODEL_ID, reason: "fable", name: null };
+  }
+  const opus = findFallbackOpus(models);
+  if (opus) {
+    return { modelId: opus.modelId, reason: "opus-fallback", name: opus.name };
+  }
+  return { modelId: null, reason: "default", name: null };
+}
 
 const ROLE_DEFS = {
   planner: {
@@ -372,23 +408,38 @@ export function createPairedRuntime({ emit, inner }) {
       });
       roleState.agentSessionId = info?.agentSessionId ?? roleState.agentSessionId;
 
-      // Pin the planner/reviewer model — Fable 5 by default (#2825) unless the
-      // user has explicitly chosen a planner model. Switch after spawn: the
-      // spawn stays on the Claude Code default, so a model id the local CLI does
-      // not recognize degrades to a notice here instead of killing the planner
-      // process (an unknown spawn-time `--model` would). Mirrors the executor.
-      const plannerModelId = config.modelId ?? PAIRED_PLANNER_MODEL_ID;
-      if (plannerModelId) {
+      // Pin the planner/reviewer model. Prefer the user's explicit choice, then
+      // Fable 5 (#2825), then the newest Opus when the account has no Fable
+      // access (#2827). Resolve against the session's real switchable catalog
+      // instead of assuming setSessionModel throws on a miss — the Claude path
+      // does not throw for an unavailable id, so a blind pin would silently run
+      // the wrong model while claiming Fable. Switch after spawn so the process
+      // stays on the Claude default first; pinnedModelId/notice always reflect
+      // the model actually pinned, never a Fable claim while running Opus.
+      const availableModels =
+        typeof inner.listSessionModels === "function"
+          ? (inner.listSessionModels(innerSessionId) ?? [])
+          : [];
+      const target = resolvePlannerModel(config.modelId, availableModels);
+      if (target.modelId) {
         try {
           await inner.setSessionModel({
             sessionId: innerSessionId,
-            modelId: plannerModelId,
+            modelId: target.modelId,
           });
-          roleState.pinnedModelId = plannerModelId;
+          roleState.pinnedModelId = target.modelId;
+          roleState.notice =
+            target.reason === "opus-fallback"
+              ? `Fable 5 is unavailable on this account; planning with ${target.name ?? "Opus"} instead.`
+              : null;
         } catch {
           roleState.pinnedModelId = null;
-          roleState.notice = `Pinned model ${plannerModelId} is unavailable in this Claude Code install. Using the Claude default instead.`;
+          roleState.notice = `Pinned model ${target.modelId} is unavailable in this Claude Code install. Using the Claude default instead.`;
         }
+      } else {
+        roleState.pinnedModelId = null;
+        roleState.notice =
+          "Neither Fable 5 nor an Opus model is available on this account. Using the Claude default instead.";
       }
       return info;
     }

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -1755,6 +1755,18 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     });
   }
 
+  // Read the switchable model catalog for a session. The paired coordinator uses
+  // it to resolve the planner pin (Fable 5, else newest Opus) against what the
+  // account can actually switch to. Codex sessions live in the local `sessions`
+  // map; a Claude planner session is owned by claudeRuntime.
+  function listSessionModels(sessionId) {
+    const session = sessions.get(sessionId);
+    if (session) {
+      return buildAvailableModels(session);
+    }
+    return claudeRuntime.listSessionModels(sessionId);
+  }
+
   async function setSessionMode({ sessionId, mode }) {
     return setPermissionMode({ sessionId, mode });
   }
@@ -1819,6 +1831,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         cancelPrompt,
         terminateSession,
         setSessionModel,
+        listSessionModels,
         updateSessionConfigOption,
         setPermissionMode,
         respondToPermission,

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -3,7 +3,11 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 // @ts-expect-error — plain-JS runtime module without type declarations.
-import { createPairedRuntime, PAIRED_AGENT_TYPE } from "../../bin/browser-local/paired-runtime.mjs";
+import {
+  createPairedRuntime,
+  PAIRED_AGENT_TYPE,
+  resolvePlannerModel,
+} from "../../bin/browser-local/paired-runtime.mjs";
 
 interface Emitted {
   channel: string;
@@ -113,6 +117,13 @@ function createHarness() {
       innerSessions.delete(sessionId);
     }),
     setSessionModel: vi.fn(async () => {}),
+    listSessionModels: vi.fn((sessionId: string) => {
+      const session = innerSessions.get(sessionId);
+      if (!session) return [];
+      return session.agentType === "claude-code"
+        ? claudeModels.availableModels
+        : codexModels.availableModels;
+    }),
     updateSessionConfigOption: vi.fn(async () => null),
     setPermissionMode: vi.fn(async () => {}),
     respondToPermission: vi.fn(async () => {}),
@@ -303,6 +314,73 @@ describe("paired runtime — spawn", () => {
     >;
     expect(String(last.paired.planner.notice)).toContain("claude-fable-5");
     expect(String(last.paired.planner.notice)).toMatch(/Claude default/i);
+  });
+
+  it("falls back to the newest Opus and pins Opus, not Fable, when Fable 5 is unavailable (#2827)", async () => {
+    // Account without Fable access: the switchable catalog carries only Opus.
+    h.inner.listSessionModels.mockImplementation((sessionId: string) => {
+      const session = h.innerSessions.get(sessionId);
+      if (!session || session.agentType !== "claude-code") return [];
+      return [
+        { modelId: "claude-opus-4-8[1m]", name: "Opus 4.8 (1M context)" },
+        { modelId: "claude-opus-4-8", name: "Opus 4.8" },
+        { modelId: "claude-opus-4-7[1m]", name: "Opus 4.7 (1M context)" },
+      ];
+    });
+    await spawnPaired(h);
+    const plannerInnerId = String(
+      h.inner.spawnSession.mock.calls.find(
+        (c) => c[0].agentType === "claude-code",
+      )?.[0].localSessionId,
+    );
+    const plannerSets = h.inner.setSessionModel.mock.calls.filter(
+      (c) => c[0].sessionId === plannerInnerId,
+    );
+    // Newest Opus, 1M tier — never claude-fable-5.
+    expect(plannerSets.map((c) => c[0].modelId)).toEqual(["claude-opus-4-8[1m]"]);
+
+    const statuses = eventsFor(h.emitted, "provider://session-status").filter(
+      (e) => e.payload.sessionId === "paired-1",
+    );
+    const last = statuses[statuses.length - 1].payload as Record<
+      string,
+      // biome-ignore lint/suspicious/noExplicitAny: test introspection
+      any
+    >;
+    expect(last.paired.planner.pinnedModelId).toBe("claude-opus-4-8[1m]");
+    expect(String(last.paired.planner.notice)).toMatch(/Fable 5 is unavailable/i);
+    expect(String(last.paired.planner.notice)).toContain("Opus");
+  });
+
+  it("keeps the Claude default with a notice when neither Fable nor Opus is available (#2827)", async () => {
+    h.inner.listSessionModels.mockImplementation((sessionId: string) => {
+      const session = h.innerSessions.get(sessionId);
+      if (!session || session.agentType !== "claude-code") return [];
+      return [{ modelId: "claude-sonnet-4-5", name: "Sonnet 4.5" }];
+    });
+    await spawnPaired(h);
+    const plannerInnerId = String(
+      h.inner.spawnSession.mock.calls.find(
+        (c) => c[0].agentType === "claude-code",
+      )?.[0].localSessionId,
+    );
+    const plannerSets = h.inner.setSessionModel.mock.calls.filter(
+      (c) => c[0].sessionId === plannerInnerId,
+    );
+    expect(plannerSets).toHaveLength(0);
+
+    const statuses = eventsFor(h.emitted, "provider://session-status").filter(
+      (e) => e.payload.sessionId === "paired-1",
+    );
+    const last = statuses[statuses.length - 1].payload as Record<
+      string,
+      // biome-ignore lint/suspicious/noExplicitAny: test introspection
+      any
+    >;
+    expect(last.paired.planner.pinnedModelId).toBeNull();
+    expect(String(last.paired.planner.notice)).toMatch(
+      /Neither Fable 5 nor an Opus/i,
+    );
   });
 
   it("never forwards raw inner session ids to the frontend", async () => {
@@ -711,5 +789,51 @@ describe("paired runtime — terminate", () => {
       (e) => e.payload.status === "terminated",
     );
     expect(terminated.length).toBe(1);
+  });
+});
+
+describe("resolvePlannerModel (#2827)", () => {
+  it("respects an explicit user model over Fable", () => {
+    expect(
+      resolvePlannerModel("claude-opus-4-6", [{ modelId: "claude-fable-5" }]),
+    ).toMatchObject({ modelId: "claude-opus-4-6", reason: "explicit" });
+  });
+
+  it("prefers Fable 5 when the account can switch to it", () => {
+    expect(
+      resolvePlannerModel(null, [
+        { modelId: "claude-opus-4-8[1m]", name: "Opus 4.8 (1M context)" },
+        { modelId: "claude-fable-5", name: "Fable 5" },
+      ]),
+    ).toMatchObject({ modelId: "claude-fable-5", reason: "fable" });
+  });
+
+  it("falls back to the newest Opus 1M tier when Fable is absent", () => {
+    expect(
+      resolvePlannerModel(null, [
+        { modelId: "claude-opus-4-8", name: "Opus 4.8" },
+        { modelId: "claude-opus-4-8[1m]", name: "Opus 4.8 (1M context)" },
+        { modelId: "claude-opus-4-7[1m]", name: "Opus 4.7 (1M context)" },
+      ]),
+    ).toMatchObject({ modelId: "claude-opus-4-8[1m]", reason: "opus-fallback" });
+  });
+
+  it("uses the bare Opus tier when no 1M variant is listed", () => {
+    expect(
+      resolvePlannerModel(null, [{ modelId: "claude-opus-4-8", name: "Opus 4.8" }]),
+    ).toMatchObject({ modelId: "claude-opus-4-8", reason: "opus-fallback" });
+  });
+
+  it("returns a null pin when neither Fable nor Opus is available", () => {
+    expect(
+      resolvePlannerModel(null, [{ modelId: "claude-sonnet-4-5" }]),
+    ).toMatchObject({ modelId: null, reason: "default" });
+  });
+
+  it("tolerates an empty or missing catalog", () => {
+    expect(resolvePlannerModel(null, [])).toMatchObject({ reason: "default" });
+    expect(resolvePlannerModel(null, undefined)).toMatchObject({
+      reason: "default",
+    });
   });
 });


### PR DESCRIPTION
Closes #2827 (P1, pre-release audit for v3.68.0).

## Problem
The paired planner pinned Fable 5 via a post-spawn `setSessionModel` and treated a **throw** as "model unavailable → degrade to a notice." But the Claude path (`claudeRuntime.setModel`) does **not** throw on a catalog miss — it passes the id through to the CLI and records it as current. So on an account **without Fable access**, the planner silently ran the Claude default while the setup declaration still declared **"Fable 5."**

## Fix (per Taariq's spec: fall back to Opus 4.8 / newest Opus, and say Opus — not Fable)
Resolve the planner model against the session's **real switchable catalog** instead of inferring from a throw:
1. explicit user model → 2. Fable 5 → 3. **newest Opus** (its 1M tier, matching the app default #2810) → 4. none → keep Claude default + notice.

The pin, the label, and the notice always reflect the model **actually** selected — a fallback reads **"Opus"**, never "Fable" — with a notice explaining the substitution.

## Plumbing
Adds `listSessionModels` to the Claude runtime and the provider facade, wired into the paired coordinator's `inner`, so the planner can read the catalog synchronously after spawn. The shared `claudeRuntime.setModel` throw semantics are **untouched** (the predictive-standby `restoreSessionSettings` constraint is preserved).

## Tests
- `resolvePlannerModel` unit tests: explicit / Fable / newest-Opus-1M / bare-Opus / none / empty-catalog.
- Integration: planner falls back to `claude-opus-4-8[1m]` (not Fable) with an Opus notice; keeps the Claude default + notice when neither is available; existing Fable-default and explicit-model paths still hold.
- Full suite: **2219 pass** (312 files). `node --check` clean on all three runtime modules.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com