### PR TITLE
fix(passwords): succeed when session locks during vault create (#2831)

### DIFF
--- a/src-tauri/src/passwords.rs
+++ b/src-tauri/src/passwords.rs
@@ -776,7 +776,15 @@ async fn create_passwords_vault_inner(
 
     let mut stored = passwords_session().lock().await;
     let Some(session) = stored.as_mut() else {
-        return Err(anyhow::anyhow!("Unlock Seren Passwords first"));
+        // The vault was created and the MCP agent granted server-side above; the
+        // session was locked during the network round-trip, so there is no
+        // in-memory state to update. Report success — the vault persists and
+        // reappears on the next unlock — instead of a misleading "unlock first"
+        // error for an operation that actually completed. #2831
+        return Ok(UnlockPasswordsVaultResponse {
+            vaults: Vec::new(),
+            mcp_agent_identity_id: mcp_agent.as_ref().map(|agent| agent.identity_id),
+        });
     };
     if session.mcp_agent.is_none() {
         session.mcp_agent = mcp_agent;


### PR DESCRIPTION
Closes #2831 (P2, pre-release audit follow-up).

## Problem
`create_passwords_vault_inner` drops the session lock during the network round-trip (create vault → provision MCP agent → POST grant), then re-acquires it to cache the new vault. If a concurrent `lock_passwords_vault` cleared the session in that window, the re-acquire found `None` and returned `"Unlock Seren Passwords first"` — a **misleading failure for a vault that was already created and granted server-side**, which the frontend (`KeysSettings`) surfaces as "Could not create vault."

## Fix
Treat the re-acquire miss as success: the vault persists server-side and reappears on the next unlock, and there's no in-memory state to update while locked. Return an empty vault list (the honest locked-session view) plus the provisioned agent id, instead of an error.

## Verification
`cargo test` passwords module: 38/38 pass, clean compile, no unused-variable warnings. The race is inherently mock-dependent to reproduce (HTTP + mutex timing), which CLAUDE.md's "never test mocked behavior" rule excludes; relying on compile + the existing passwords suite, consistent with the module's pure-function test style.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com