### PR TITLE
chore(deps): fix biome 2.5.2 + cache-bump check fallout

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",
@@ -26,7 +26,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noExplicitAny": "error",
         "noAssignInExpressions": "off",
@@ -36,6 +36,7 @@
         "noNonNullAssertion": "warn"
       },
       "a11y": {
+        "noSvgWithoutTitle": "off",
         "noStaticElementInteractions": "off",
         "useKeyWithClickEvents": "off",
         "useButtonType": "off",

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -131,7 +131,7 @@ describe("release workflow contract", () => {
 
   it("wraps the embedded-runtime signer with the Windows signature cache (#2823)", () => {
     expect(workflow).toContain("Restore Windows signature cache");
-    expect(workflow).toContain("uses: actions/cache@v4");
+    expect(workflow).toContain("uses: actions/cache@v6");
     expect(workflow).toContain(".sig-cache/windows-authenticode");
     expect(workflow).toContain("key: win-sigcache-${{ github.run_id }}");
     expect(workflow).toContain("win-sigcache-");


### PR DESCRIPTION
Repairs two green-check breakages that surfaced after today's batch of Dependabot merges.

## What broke
- **#2840** (actions/cache 4→6) rewrote `release.yml`'s `cache@v4`→`@v6`, but the source-grep test `windows-sign-overlay.test.ts:134` pinned the literal `"uses: actions/cache@v4"` → test-frontend fails. (The bump itself is behaviorally fine.)
- **#2847** (dev-tools group) bumped the Biome CLI 2.4.16→2.5.2 → `biome.json` schema mismatch, and 2.5.2 newly flags `noSvgWithoutTitle` at **error** level on 6 static SVG assets (`logo.svg` + 5 oauth logos), turning `pnpm check` red.

## Fix (2 files, 4 lines)
- Sync the test's pinned action version to `@v6`.
- Migrate `biome.json` (schema→2.5.2, `recommended: true`→`preset: "recommended"`) and disable `noSvgWithoutTitle` — consistent with the 9 a11y rules already disabled for this desktop app; SVG assets aren't code to lint.

## Verification
`biome check` → exit 0 (48 pre-existing tolerated warnings unchanged). Full unit suite → **2219 pass**. `cargo check` was already green with the new `Cargo.lock`.

Follow-up to the Dependabot triage (15 merged, #2848 rmcp closed as breaking).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com