### PR TITLE
fix(agent): detect paired-planner Fable via 1M-tier catalog id (#2859)

### DIFF
--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -10,15 +10,44 @@ export const PAIRED_AGENT_TYPE = "claude-codex";
 // planner model. When the account cannot switch to Fable, the planner falls back
 // to the newest Opus (#2827) rather than silently running the Claude default.
 // Applied as a post-spawn model switch (see spawnRole), resolved against the
-// session's real switchable catalog. Fable's context is 1M-native, so the bare
-// id is used (no `[1m]` tier suffix). #2825.
-const PAIRED_PLANNER_MODEL_ID = "claude-fable-5";
+// session's real switchable catalog.
+//
+// Match on the base id, NOT an exact literal: the Claude Code CLI reports Fable
+// in its switchable catalog as `claude-fable-5[1m]` (1M-tier suffix, the same
+// shape as its Opus/Sonnet 1M entries), and future builds may date-stamp it. An
+// exact bare-id compare silently missed the real `[1m]` entry and demoted every
+// Fable-capable account to the Opus fallback with a false "unavailable" notice
+// (#2859). Resolve against the normalized base and pin whichever concrete id the
+// catalog actually exposes. #2825.
+const PAIRED_PLANNER_BASE_MODEL_ID = "claude-fable-5";
 
 // Friendly labels for pinned model ids the Claude Code catalog may not report by
 // name, so the setup declaration reads "Fable 5" rather than a raw model id.
 const MODEL_DISPLAY_LABELS = {
   "claude-fable-5": "Fable 5",
+  "claude-fable-5[1m]": "Fable 5",
 };
+
+// Normalize a catalog model id to its base for family matching: drop the 1M-tier
+// `[1m]` suffix and any trailing `-YYYYMMDD` date stamp. Mirrors the stripping in
+// claude-runtime.mjs's inferClaudeContextWindow so `claude-fable-5[1m]` and a
+// dated `claude-fable-5-20260601` both resolve to `claude-fable-5`.
+function normalizeBaseModelId(modelId) {
+  return typeof modelId === "string"
+    ? modelId.replace(/\[1m\]$/i, "").replace(/-\d{8}$/, "")
+    : "";
+}
+
+// Find the account's switchable Fable entry regardless of tier/date suffix.
+// Prefer the 1M-tier variant when the catalog lists more than one, so the pin
+// lands on Fable's native 1M context.
+function findFableModel(availableModels) {
+  const fable = availableModels.filter(
+    (m) => normalizeBaseModelId(m.modelId) === PAIRED_PLANNER_BASE_MODEL_ID,
+  );
+  if (fable.length === 0) return null;
+  return fable.find((m) => /\[1m\]$/i.test(m.modelId)) ?? fable[0];
+}
 
 // When Fable 5 isn't available on the account, the planner falls back to Opus.
 // The Claude catalog is sorted opus-first, newest version first, so the first
@@ -45,8 +74,9 @@ export function resolvePlannerModel(explicitModelId, availableModels) {
     return { modelId: explicitModelId, reason: "explicit", name: null };
   }
   const models = Array.isArray(availableModels) ? availableModels : [];
-  if (models.some((m) => m.modelId === PAIRED_PLANNER_MODEL_ID)) {
-    return { modelId: PAIRED_PLANNER_MODEL_ID, reason: "fable", name: null };
+  const fable = findFableModel(models);
+  if (fable) {
+    return { modelId: fable.modelId, reason: "fable", name: fable.name ?? null };
   }
   const opus = findFallbackOpus(models);
   if (opus) {

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -40,11 +40,13 @@ function createHarness() {
 
   const innerSessions = new Map<string, FakeInnerSession>();
 
+  // Mirrors the live Claude Code catalog: the CLI reports Fable with the 1M-tier
+  // suffix (`claude-fable-5[1m]`), never the bare id (#2859).
   const claudeModels = {
     currentModelId: "claude-opus-4-7[1m]",
     availableModels: [
       { modelId: "claude-opus-4-7[1m]", name: "Opus 4.7 (1M)" },
-      { modelId: "claude-fable-5", name: "Fable 5" },
+      { modelId: "claude-fable-5[1m]", name: "Fable" },
     ],
   };
   const codexModels = {
@@ -264,17 +266,32 @@ describe("paired runtime — spawn", () => {
     expect(String(last.paired.executor.notice)).toMatch(/no longer available/i);
   });
 
-  it("pins Fable 5 for the planner on spawn when no planner model is configured (#2825)", async () => {
+  it("pins Fable 5 for the planner on spawn when no planner model is configured (#2825, #2859)", async () => {
     await spawnPaired(h);
     const plannerInnerId = String(
       h.inner.spawnSession.mock.calls.find(
         (c) => c[0].agentType === "claude-code",
       )?.[0].localSessionId,
     );
+    // Pins the concrete catalog id the CLI actually exposes for Fable — the
+    // 1M-tier `[1m]` variant, not the bare id (#2859).
     expect(h.inner.setSessionModel).toHaveBeenCalledWith({
       sessionId: plannerInnerId,
-      modelId: "claude-fable-5",
+      modelId: "claude-fable-5[1m]",
     });
+
+    // No fallback fired, so the planner carries no "unavailable" notice and is
+    // pinned to Fable — the exact regression from #2859.
+    const statuses = eventsFor(h.emitted, "provider://session-status").filter(
+      (e) => e.payload.sessionId === "paired-1",
+    );
+    const last = statuses[statuses.length - 1].payload as Record<
+      string,
+      // biome-ignore lint/suspicious/noExplicitAny: test introspection
+      any
+    >;
+    expect(last.paired.planner.pinnedModelId).toBe("claude-fable-5[1m]");
+    expect(last.paired.planner.notice).toBeNull();
   });
 
   it("respects an explicit planner model instead of the Fable default", async () => {
@@ -297,8 +314,8 @@ describe("paired runtime — spawn", () => {
     // notice, never fail the spawn — the whole point of the post-spawn switch.
     h.inner.setSessionModel.mockImplementation(
       async ({ modelId }: { modelId: string }) => {
-        if (modelId === "claude-fable-5") {
-          throw new Error("Unknown model: claude-fable-5");
+        if (modelId === "claude-fable-5[1m]") {
+          throw new Error("Unknown model: claude-fable-5[1m]");
         }
       },
     );
@@ -312,7 +329,7 @@ describe("paired runtime — spawn", () => {
       // biome-ignore lint/suspicious/noExplicitAny: test introspection
       any
     >;
-    expect(String(last.paired.planner.notice)).toContain("claude-fable-5");
+    expect(String(last.paired.planner.notice)).toContain("claude-fable-5[1m]");
     expect(String(last.paired.planner.notice)).toMatch(/Claude default/i);
   });
 
@@ -806,6 +823,26 @@ describe("resolvePlannerModel (#2827)", () => {
         { modelId: "claude-fable-5", name: "Fable 5" },
       ]),
     ).toMatchObject({ modelId: "claude-fable-5", reason: "fable" });
+  });
+
+  it("matches the live catalog's 1M-tier Fable id, not just the bare id (#2859)", () => {
+    // The real CLI reports `claude-fable-5[1m]`; an exact bare-id compare missed
+    // it and demoted every Fable account to the Opus fallback.
+    expect(
+      resolvePlannerModel(null, [
+        { modelId: "claude-opus-4-8[1m]", name: "Opus 4.8 (1M context)" },
+        { modelId: "claude-fable-5[1m]", name: "Fable" },
+      ]),
+    ).toMatchObject({ modelId: "claude-fable-5[1m]", reason: "fable" });
+  });
+
+  it("prefers the 1M-tier Fable variant when the catalog lists both", () => {
+    expect(
+      resolvePlannerModel(null, [
+        { modelId: "claude-fable-5", name: "Fable 5" },
+        { modelId: "claude-fable-5[1m]", name: "Fable" },
+      ]),
+    ).toMatchObject({ modelId: "claude-fable-5[1m]", reason: "fable" });
   });
 
   it("falls back to the newest Opus 1M tier when Fable is absent", () => {


### PR DESCRIPTION
## What

Fixes the paired **Claude + Codex** planner falsely reporting *"Fable 5 is unavailable on this account; planning with Opus 4.8 (1M context) instead"* on accounts that **do** have Fable access.

Closes #2859.

## Root cause (verified against the live CLI)

`resolvePlannerModel` pinned Fable by an exact compare against the bare id `claude-fable-5`. The real Claude Code CLI reports Fable in its switchable `initialize` catalog with the 1M-tier suffix — `claude-fable-5[1m]` — the same shape as its Opus/Sonnet 1M entries. The compare never matched, so the planner fell through to the Opus fallback: it pinned Opus 4.8, emitted the false "unavailable" notice, and the setup declaration read `Planner: Opus 4.8 (1M context)` instead of `Planner: Fable`.

Driving the installed CLI (`~/.local/bin/claude`, v2.1.201) through the same stream-json `initialize` handshake the runtime uses confirms the id:

```
value="default"            display="Default (recommended)"
value="opus[1m]"           display="Opus"
value="claude-fable-5[1m]" display="Fable"
value="sonnet"             display="Sonnet"
value="haiku"              display="Haiku"
```

## Fix

- Match Fable by its **normalized base id** — strip a trailing `[1m]` and any `-YYYYMMDD` date stamp — and pin whichever concrete id the catalog actually exposes, preferring the `[1m]` variant. Robust to the bare id, the `[1m]` id, and future date-stamped ids; mirrors the existing `[1m]`-aware stripping in `claude-runtime.mjs`.
- Once Fable matches, the planner pins Fable, emits no notice, and the declaration reads `Planner: Fable`.

## Validation

- `pnpm vitest run tests/unit/paired-runtime.test.ts` → **41 passed**.
- Exercised the **real** fixed resolver against the **live CLI catalog** (captured above): resolves `{ modelId: "claude-fable-5[1m]", reason: "fable" }`; an Opus-only account still falls back to `opus-fallback`.
- End-to-end paired spawn (inner emits the model-change status like the real `claudeRuntime.setModel`): setup declaration reads `Planner: Fable · high effort.` with no "unavailable" notice.
- Corrected the test harness catalog to the real `[1m]` id (it used the fictitious bare `claude-fable-5`) and added resolver + spawn coverage for the 1M-tier form.

## Networked-path note

Fully local — the paired planner switches models via the local Claude Code CLI child process over stdio control protocol (`initialize` / `set_model`). No `api.serendb.com` / publisher slug is involved.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
