### PR TITLE
fix(agent): pass paired context to Codex executor

### DIFF
--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -162,10 +162,23 @@ function buildPlannerPrompt(userPrompt) {
 
 function buildExecutorPrompt(userPrompt, planText) {
   return [
-    "You are the EXECUTOR in a paired workflow. Claude (the planner) reviewed",
-    "the user's request and produced the plan below. Implement it: make the",
-    "code edits, run the commands, and run the tests the plan calls for.",
-    "Report what you changed and any test results.",
+    "You are the EXECUTOR in a paired workflow. Claude's plan is approved",
+    "guidance, but the repository is the source of truth. Inspect the",
+    "relevant files, callers, tests, and config before editing. If the plan",
+    "conflicts with the code, adapt and report the deviation.",
+    "",
+    "Make the code changes needed to satisfy the user's request end-to-end.",
+    "Preserve unrelated user work and do not revert unrelated changes.",
+    "Run focused verification first, then broader impacted lint, typecheck,",
+    "build, and test checks when available. Diagnose and fix failures unless",
+    "blocked by missing secrets, unavailable external state, or evidence of a",
+    "pre-existing failure.",
+    "",
+    "If third-party services are relevant, use live MCP/publisher discovery",
+    "before assuming integrations are unavailable.",
+    "",
+    "Report only: changed files, verification commands/results, plan",
+    "deviations, and remaining risks/blockers.",
     "",
     "Original user request:",
     userPrompt,
@@ -664,6 +677,7 @@ export function createPairedRuntime({ emit, inner }) {
         paired,
         "executor",
         buildExecutorPrompt(prompt, planText),
+        context,
       );
       collectMeta("executor");
 

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -460,6 +460,28 @@ describe("paired runtime — prompt pipeline", () => {
     expect(String(codexCall.prompt)).toContain("rename the login button");
   });
 
+  it("passes original context through to the Codex executor turn (#2858)", async () => {
+    const context = [
+      { type: "text", text: "Selected file: src/components/LoginButton.tsx" },
+      { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+    ];
+    await h.paired.sendPrompt({
+      sessionId: "paired-1",
+      prompt: "rename the login button",
+      context,
+    });
+    const plannerCall = h.inner.sendPrompt.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    const executorCall = h.inner.sendPrompt.mock.calls[1][0] as Record<
+      string,
+      unknown
+    >;
+    expect(plannerCall.context).toBe(context);
+    expect(executorCall.context).toBe(context);
+  });
+
   it("hands the executor's output to the review prompt", async () => {
     await h.paired.sendPrompt({
       sessionId: "paired-1",
@@ -481,6 +503,19 @@ describe("paired runtime — prompt pipeline", () => {
     // reviewer framing that invites Fable to spend output tokens on it.
     expect(plannerPrompt).not.toContain("REVIEWER");
     expect(plannerPrompt).toContain("rename the login button");
+  });
+
+  it("sends an execution-focused executor prompt with verification guidance (#2858)", async () => {
+    await h.paired.sendPrompt({
+      sessionId: "paired-1",
+      prompt: "rename the login button",
+    });
+    const executorPrompt = String(h.inner.sendPrompt.mock.calls[1][0].prompt);
+    expect(executorPrompt).toContain("repository is the source of truth");
+    expect(executorPrompt).toContain("Preserve unrelated user work");
+    expect(executorPrompt).toContain("Run focused verification first");
+    expect(executorPrompt).toContain("live MCP/publisher discovery");
+    expect(executorPrompt).toContain("Report only: changed files");
   });
 
   it("emits inline handoff events between phases with source and destination", async () => {


### PR DESCRIPTION
Closes #2858

## Summary

- Pass the original paired prompt context into the Codex executor turn, not only the Claude planner turn.
- Strengthen the executor prompt so Codex treats Claude's plan as guidance while using the repo as source of truth, preserving unrelated work, verifying changes, using live MCP/publisher discovery when relevant, and reporting reviewer-ready results.
- Add focused regression coverage for executor context propagation and executor prompt requirements.

## Audit Notes

- UI path: `claude-codex` thread creation routes through the local agent store/provider runtime into `bin/browser-local/paired-runtime.mjs`.
- Runtime path: paired runtime spawns local Claude Code for planner/reviewer and local Codex app-server for executor.
- Codex input path: `providers.mjs` turns `context` into Codex app-server text/image input via `buildCodexTurnInput`; the broken path was the paired executor call omitting `context`.
- Networked path: no Seren publisher/API slug is invoked by this feature path. The changed behavior is local provider-runtime orchestration and local Codex app-server JSON-RPC.
- Generated runtime: `pnpm build:provider-runtime` was run; `src-tauri/embedded-runtime/provider-runtime` is ignored by repo config but the on-disk generated copy includes this change.

## Validation

- `pnpm vitest run tests/unit/paired-runtime.test.ts` passed: 43/43.
- `pnpm build:provider-runtime` passed.
- `pnpm test:runtime-smoke` passed.
- `pnpm test` passed: 312 files, 2223 tests.
- `pnpm check` exited 0 with existing unrelated Biome warnings in other files.
- `SEREN_VALIDATION_DISCOVERY_TIMEOUT_MS=900000 pnpm validate:walkthrough app-ready` passed; artifacts show `result.json` ok, validation app `com.serendb.desktop.validation`, generated embedded provider runtime launched from `src-tauri/target/debug/embedded-runtime/provider-runtime/provider-runtime.mjs`, DOM screenshot 1183x768, native screenshot 1200x800.

## Post-PR Walkthrough Classification

- P0/P1/P2 newly found regressions: none.
- Non-blocking: `SEREN_E2E_AGENTS=claude-codex SEREN_E2E_RUNTIMES=browser-local,desktop-native pnpm test:runtime-e2e` completed the live paired prompt path, then failed in the existing generic e2e harness because it treats paired `agentSessionId` as a single remote-session string even though `claude-codex` returns `{ planner, executor }`. This is test-harness coverage debt, not a product regression in the changed code path; Windows paired e2e already has a separate paired-specific journey.