### PR TITLE
fix(agent): guard paired selector render state

### DIFF
--- a/src-tauri/src/validation/control_server.rs
+++ b/src-tauri/src/validation/control_server.rs
@@ -92,6 +92,8 @@ struct ControlCommand {
     #[serde(default)]
     value: Option<String>,
     #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
     route: Option<String>,
     #[serde(default)]
     key: Option<String>,
@@ -109,6 +111,8 @@ struct IncomingCommand {
     selector: Option<String>,
     #[serde(default)]
     value: Option<String>,
+    #[serde(default)]
+    path: Option<String>,
     #[serde(default)]
     route: Option<String>,
     #[serde(default)]
@@ -246,6 +250,7 @@ fn handle_request(
         command: incoming.command,
         selector: incoming.selector,
         value: incoming.value,
+        path: incoming.path,
         route: incoming.route,
         key: incoming.key,
         timeout_ms: incoming.timeout_ms,
@@ -290,7 +295,14 @@ fn handle_request(
 fn is_allowed_command(command: &str) -> bool {
     matches!(
         command,
-        "navigate" | "click" | "fill" | "press" | "waitFor" | "dumpText" | "screenshot"
+        "navigate"
+            | "click"
+            | "fill"
+            | "press"
+            | "waitFor"
+            | "dumpText"
+            | "screenshot"
+            | "setRootPath"
     )
 }
 

--- a/src/components/chat/AgentEffortSelector.tsx
+++ b/src/components/chat/AgentEffortSelector.tsx
@@ -19,10 +19,15 @@ export const AgentEffortSelector: Component<Props> = (props) => {
       (o) => o.id === "reasoning_effort" && o.type === "select",
     ) ?? null;
 
+  const optionValues = () => {
+    const values = option()?.options;
+    return Array.isArray(values) ? values : [];
+  };
+
   const currentLabel = () => {
     const opt = option();
     if (!opt) return null;
-    const current = opt.options.find((v) => v.value === opt.currentValue);
+    const current = optionValues().find((v) => v.value === opt.currentValue);
     return current?.name ?? opt.currentValue;
   };
 
@@ -88,7 +93,7 @@ export const AgentEffortSelector: Component<Props> = (props) => {
           <div class="px-3 py-2 border-b border-surface-2 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
             Reasoning Effort
           </div>
-          <For each={option()?.options ?? []}>
+          <For each={optionValues()}>
             {(opt) => (
               <button
                 type="button"

--- a/src/components/chat/AgentModelSelector.tsx
+++ b/src/components/chat/AgentModelSelector.tsx
@@ -18,7 +18,10 @@ export const AgentModelSelector: Component<Props> = (props) => {
   const [isOpen, setIsOpen] = createSignal(false);
   let dropdownRef: HTMLDivElement | undefined;
 
-  const availableModels = () => props.session?.availableModels ?? [];
+  const availableModels = () => {
+    const models = props.session?.availableModels;
+    return Array.isArray(models) ? models : [];
+  };
   const currentModelId = () => props.session?.currentModelId;
   const userSelectedModelId = () => props.session?.userSelectedModelId;
 

--- a/src/components/chat/PairedEffortSelector.tsx
+++ b/src/components/chat/PairedEffortSelector.tsx
@@ -28,10 +28,15 @@ export const PairedEffortSelector: Component<Props> = (props) => {
       (o) => o.id === "reasoning_effort" && o.type === "select",
     ) ?? null;
 
+  const optionValues = () => {
+    const values = option()?.options;
+    return Array.isArray(values) ? values : [];
+  };
+
   const currentLabel = () => {
     const opt = option();
     if (!opt) return null;
-    const current = opt.options.find((v) => v.value === opt.currentValue);
+    const current = optionValues().find((v) => v.value === opt.currentValue);
     return current?.name ?? opt.currentValue;
   };
 
@@ -88,7 +93,7 @@ export const PairedEffortSelector: Component<Props> = (props) => {
               Applies from the next planning session Claude spawns.
             </div>
           </Show>
-          <For each={option()?.options ?? []}>
+          <For each={optionValues()}>
             {(opt) => (
               <button
                 type="button"

--- a/src/components/chat/PairedModelSelector.tsx
+++ b/src/components/chat/PairedModelSelector.tsx
@@ -22,7 +22,10 @@ export const PairedModelSelector: Component<Props> = (props) => {
   let dropdownRef: HTMLDivElement | undefined;
 
   const roleStatus = () => props.session?.paired?.[props.pairedRole] ?? null;
-  const availableModels = () => roleStatus()?.models?.availableModels ?? [];
+  const availableModels = () => {
+    const models = roleStatus()?.models?.availableModels;
+    return Array.isArray(models) ? models : [];
+  };
   const currentModelId = () => roleStatus()?.models?.currentModelId;
 
   const currentModelName = () => {

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -180,6 +180,11 @@ const ShellRecoveryFallback: Component<ShellRecoveryFallbackProps> = (
 );
 
 function reportShellBoundaryError(surface: string, error: unknown): void {
+  const detail =
+    error instanceof Error ? (error.stack ?? error.message) : String(error);
+  console.warn(
+    `[AppShell] ${surface} surface recovered after error: ${detail}`,
+  );
   telemetry.reportError(
     error instanceof Error ? error : new Error(String(error)),
     { surface: `app_shell_${surface}` },

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -191,6 +191,14 @@ export async function connectPublisher(
  */
 export async function listConnectedPublishers(): Promise<OAuthConnection[]> {
   console.log("[PublisherOAuth] Fetching connected OAuth providers");
+  const token = await getToken();
+  if (!token) {
+    console.log(
+      "[PublisherOAuth] No auth token available; treating connections as empty",
+    );
+    return [];
+  }
+
   const { data, error } = await listConnections({ throwOnError: false });
 
   if (error) {

--- a/src/services/validation-control.ts
+++ b/src/services/validation-control.ts
@@ -5,12 +5,14 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 import { getValidationRuntimeInfo } from "@/services/oauth-callback";
+import { setRootPath } from "@/stores/fileTree";
 
 interface ValidationCommand {
   id: string;
   command: string;
   selector?: string;
   value?: string;
+  path?: string;
   route?: string;
   key?: string;
   timeoutMs?: number;
@@ -114,9 +116,17 @@ async function handleCommand(command: ValidationCommand): Promise<unknown> {
       return dumpText(command.selector);
     case "screenshot":
       return screenshot(command.selector, command.native === true);
+    case "setRootPath":
+      return setValidationRootPath(command.path ?? command.value);
     default:
       throw new Error(`Unsupported validation command: ${command.command}`);
   }
+}
+
+function setValidationRootPath(path: string | undefined): { rootPath: string } {
+  if (!path) throw new Error("setRootPath requires path");
+  setRootPath(path);
+  return { rootPath: path };
 }
 
 function navigate(route: string | undefined): { route: string } {

--- a/tests/unit/agent-selector-partial-status.test.ts
+++ b/tests/unit/agent-selector-partial-status.test.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Guards #2862 against render crashes from partial agent status frames.
+// ABOUTME: Paired/direct selectors must tolerate missing arrays during runtime startup.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function source(path: string): string {
+  return readFileSync(resolve(path), "utf-8");
+}
+
+describe("agent selector partial-status guards (#2862)", () => {
+  const agentEffort = source("src/components/chat/AgentEffortSelector.tsx");
+  const pairedEffort = source("src/components/chat/PairedEffortSelector.tsx");
+  const agentModel = source("src/components/chat/AgentModelSelector.tsx");
+  const pairedModel = source("src/components/chat/PairedModelSelector.tsx");
+
+  it("does not dereference config option arrays directly in effort selectors", () => {
+    for (const selector of [agentEffort, pairedEffort]) {
+      expect(selector).toContain("const optionValues = () =>");
+      expect(selector).toContain("Array.isArray(values) ? values : []");
+      expect(selector).toContain("<For each={optionValues()}>");
+      expect(selector).not.toContain("opt.options.find");
+      expect(selector).not.toContain("option()?.options ?? []");
+    }
+  });
+
+  it("normalizes model lists before rendering selector menus", () => {
+    for (const selector of [agentModel, pairedModel]) {
+      expect(selector).toContain("Array.isArray(models) ? models : []");
+    }
+  });
+});

--- a/tests/unit/app-shell-error-boundaries.test.ts
+++ b/tests/unit/app-shell-error-boundaries.test.ts
@@ -51,4 +51,10 @@ describe("AppShell scoped error recovery (#2797)", () => {
       expect(appShell).toContain(marker);
     }
   });
+
+  it("logs the caught error detail locally before reporting telemetry (#2862)", () => {
+    expect(appShell).toContain("surface recovered after error");
+    expect(appShell).toContain("error.stack ?? error.message");
+    expect(appShell).toContain("telemetry.reportError");
+  });
 });

--- a/tests/unit/publisher-oauth-reconnect.test.ts
+++ b/tests/unit/publisher-oauth-reconnect.test.ts
@@ -137,6 +137,17 @@ describe("publisher OAuth reconnect", () => {
     expect(mocks.openUrl).toHaveBeenCalledTimes(1);
   });
 
+  it("treats signed-out OAuth connection listing as empty without hitting the API (#2865)", async () => {
+    mocks.getToken.mockResolvedValue(null);
+    const { listConnectedPublishers } = await import(
+      "@/services/publisher-oauth"
+    );
+
+    await expect(listConnectedPublishers()).resolves.toEqual([]);
+
+    expect(mocks.listConnections).not.toHaveBeenCalled();
+  });
+
   it("continues reconnect when the stale connection was already gone", async () => {
     mocks.listConnections.mockResolvedValue({
       data: {

--- a/tests/validation/scenarios/paired-agent-recovery.ts
+++ b/tests/validation/scenarios/paired-agent-recovery.ts
@@ -1,0 +1,68 @@
+// ABOUTME: Replays the #2862 paired-agent launch path in the real validation app.
+// ABOUTME: Captures evidence that the workspace recovery fallback is not shown.
+
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+
+interface DumpTextResult {
+  text?: string;
+}
+
+const RECOVERY_TEXT = "Workspace is recovering.";
+
+function dumpTextValue(value: unknown): string {
+  return typeof (value as DumpTextResult)?.text === "string"
+    ? ((value as DumpTextResult).text as string)
+    : JSON.stringify(value);
+}
+
+async function assertNoWorkspaceRecovery(
+  ctx: ScenarioContext,
+  stage: string,
+): Promise<void> {
+  const text = await ctx.client.dumpText("body");
+  const bodyText = dumpTextValue(text);
+  await ctx.writeArtifact(`${stage}-text.json`, text);
+  if (bodyText.includes(RECOVERY_TEXT)) {
+    await ctx.writeArtifact(
+      `${stage}-recovery-screenshot.json`,
+      await ctx.client.screenshot("body"),
+    );
+    throw new Error(`${RECOVERY_TEXT} appeared during ${stage}`);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  await ctx.client.command({
+    command: "setRootPath",
+    path: process.cwd(),
+  });
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 30_000);
+  await assertNoWorkspaceRecovery(ctx, "initial");
+
+  await ctx.client.click("[data-testid='new-thread-button']");
+  await ctx.client.waitFor("[data-testid='new-claude-codex-agent']", 10_000);
+  await ctx.client.click("[data-testid='new-claude-codex-agent']");
+
+  await ctx.client.waitFor("[data-testid='paired-thread-header']", 60_000);
+  await ctx.client.waitFor(".chat-composer-form textarea", 60_000);
+  await assertNoWorkspaceRecovery(ctx, "paired-created");
+
+  await ctx.client.fill(
+    ".chat-composer-form textarea",
+    "What models are you using?",
+  );
+  await ctx.client.click(".chat-composer-form button[type='submit']");
+
+  await sleep(15_000);
+  await ctx.client.waitFor("[data-testid='paired-thread-header']", 60_000);
+  await assertNoWorkspaceRecovery(ctx, "paired-after-prompt");
+
+  await ctx.writeArtifact(
+    "paired-after-prompt-screenshot.json",
+    await ctx.client.screenshot("body"),
+  );
+}


### PR DESCRIPTION
Fixes #2862
Fixes #2865

## Summary
- Guard direct and paired agent model/effort selectors against partial runtime status frames before rendering dropdown state.
- Log shell recovery boundary error details locally before telemetry so future recoveries include the concrete stack in app logs.
- Treat signed-out OAuth connection listing as empty instead of calling `GET /oauth/connections` without a bearer token and throwing into the main workspace boundary.
- Add a validation-only `setRootPath` control command and a paired-agent validation walkthrough scenario so the crash path can be reproduced in an isolated real app.

## Audited code paths
- `ThreadSidebar` / `ThreadTabBar` launcher actions for Claude + Codex agent threads.
- `ThreadContent` -> `AgentChat` paired-thread rendering.
- `AgentModelSelector`, `AgentEffortSelector`, `PairedModelSelector`, `PairedEffortSelector` runtime status rendering.
- `agent.store` paired session hydration/status update handling.
- `paired-runtime.mjs` paired status emission for planner/executor model/config metadata.
- `AppShell` scoped shell recovery boundary.
- `OAuthAccountSwitcher` -> `listConnectedPublishers()` signed-out render path.
- Validation bridge frontend and Rust loopback control server command allowlist.

## Network/API path audit
- Original #2862 selector crash path: no Seren publisher/API slug is involved. The affected path is local UI state -> Tauri provider runtime -> local Claude/Codex child processes; no outbound Seren publisher method/path is invoked by selector rendering.
- Follow-up #2865 signed-out OAuth crash path: no Seren publisher slug is invoked. The failing first-party API path was `GET /oauth/connections`, verified in generated Seren Core API metadata at `src/api/generated/seren-core/sdk.gen.ts`.
- The live Seren publisher list was queried during audit before making unavailable/publisher-path determinations.

## Validation
- `pnpm vitest run tests/unit/agent-selector-partial-status.test.ts tests/unit/app-shell-error-boundaries.test.ts`
- `pnpm vitest run tests/unit/paired-runtime.test.ts tests/unit/launcher-redesign.test.ts tests/unit/composer-toolbar-layout.test.ts tests/unit/picker-sticky-model.test.ts`
- `pnpm vitest run tests/unit/publisher-oauth-reconnect.test.ts tests/unit/agent-selector-partial-status.test.ts tests/unit/app-shell-error-boundaries.test.ts`
- `pnpm biome check src/components/chat/AgentEffortSelector.tsx src/components/chat/AgentModelSelector.tsx src/components/chat/PairedEffortSelector.tsx src/components/chat/PairedModelSelector.tsx src/components/layout/AppShell.tsx tests/unit/agent-selector-partial-status.test.ts tests/unit/app-shell-error-boundaries.test.ts tests/validation/scenarios/paired-agent-recovery.ts`
- `pnpm biome check src/services/publisher-oauth.ts src/services/validation-control.ts tests/unit/publisher-oauth-reconnect.test.ts tests/validation/scenarios/paired-agent-recovery.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml --features validation validation`
- `pnpm build`
- `pnpm verify:frontend-build`
- `pnpm validate:walkthrough paired-agent-recovery` -> pass, `artifacts/validation-walkthrough/result.json` shows `ok: true`; captured `paired-created-text.json` and `paired-after-prompt-text.json` contain the paired header/composer and no `Workspace is recovering.` text.

## Discovery loop classification
- P1 #2865: signed-out OAuth connection fetch tripped the main workspace boundary during the post-PR walkthrough. Fixed in this PR with targeted unit coverage.
- Non-blocking: startup `web content process terminated`, signed-out support-report submission warnings, Solid cleanup warnings, and a transient `ConversationIndex database is locked` warning. The walkthrough completed, transcript UI rendered, and no new user-visible P0/P1/P2 failure was found after the #2865 fix.
