### PR TITLE
fix(agent): guard fast-mode selector against non-array models

### DIFF
--- a/src/components/chat/AgentFastModeSelector.tsx
+++ b/src/components/chat/AgentFastModeSelector.tsx
@@ -10,7 +10,10 @@ interface Props {
 }
 
 export const AgentFastModeSelector: Component<Props> = (props) => {
-  const availableModels = () => props.session?.availableModels ?? [];
+  const availableModels = () => {
+    const models = props.session?.availableModels;
+    return Array.isArray(models) ? models : [];
+  };
   const displayModelId = () =>
     props.session?.userSelectedModelId ?? props.session?.currentModelId;
 

--- a/tests/unit/agent-selector-partial-status.test.ts
+++ b/tests/unit/agent-selector-partial-status.test.ts
@@ -14,6 +14,7 @@ describe("agent selector partial-status guards (#2862)", () => {
   const pairedEffort = source("src/components/chat/PairedEffortSelector.tsx");
   const agentModel = source("src/components/chat/AgentModelSelector.tsx");
   const pairedModel = source("src/components/chat/PairedModelSelector.tsx");
+  const agentFastMode = source("src/components/chat/AgentFastModeSelector.tsx");
 
   it("does not dereference config option arrays directly in effort selectors", () => {
     for (const selector of [agentEffort, pairedEffort]) {
@@ -29,5 +30,15 @@ describe("agent selector partial-status guards (#2862)", () => {
     for (const selector of [agentModel, pairedModel]) {
       expect(selector).toContain("Array.isArray(models) ? models : []");
     }
+  });
+
+  it("normalizes availableModels before .find in the fast-mode selector (#2866)", () => {
+    // option() runs ungated inside <Show when={option()}> and calls
+    // availableModels().find(...), so a non-array availableModels must be
+    // normalized to [] rather than dereferenced.
+    expect(agentFastMode).toContain("Array.isArray(models) ? models : []");
+    expect(agentFastMode).not.toContain(
+      "props.session?.availableModels ?? []",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Closes #2866. Residual of #2862 / #2863.

`AgentFastModeSelector` evaluates `option()` **ungated** inside `<Show when={option()}>`, and `option()` calls `currentModelSupportsFastMode()`, which calls `availableModels().find(...)`. The `?? []` fallback only catches `null`/`undefined`, so a **non-array** `availableModels` (the same partial-status frame #2863 normalizes in the model selectors) reached `.find` and threw, tripping the main workspace `ShellSurfaceBoundary` ("Workspace is recovering. This view hit an error.").

PR #2863 guarded `AgentEffortSelector`, `PairedEffortSelector`, `AgentModelSelector`, and `PairedModelSelector` — but not this one. `AgentModeSelector` is already safe via its `availableModes().length > 0` gate.

## Change

- Normalize `availableModels` with `Array.isArray(...)` in `AgentFastModeSelector`, matching the pattern from #2863.
- Extend `tests/unit/agent-selector-partial-status.test.ts` with a fast-mode assertion.

## Verification

- `vitest run tests/unit/agent-selector-partial-status.test.ts` — 3/3 pass.
- `biome check` on changed files — clean.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
