### PR TITLE
fix(agent): guard non-array configOptions render crash (#2869)

### DIFF
--- a/src/components/chat/AgentEffortSelector.tsx
+++ b/src/components/chat/AgentEffortSelector.tsx
@@ -14,8 +14,13 @@ export const AgentEffortSelector: Component<Props> = (props) => {
   const [isOpen, setIsOpen] = createSignal(false);
   let dropdownRef: HTMLDivElement | undefined;
 
+  const configOptions = () => {
+    const options = props.session?.configOptions;
+    return Array.isArray(options) ? options : [];
+  };
+
   const option = () =>
-    props.session?.configOptions?.find(
+    configOptions().find(
       (o) => o.id === "reasoning_effort" && o.type === "select",
     ) ?? null;
 

--- a/src/components/chat/AgentFastModeSelector.tsx
+++ b/src/components/chat/AgentFastModeSelector.tsx
@@ -26,9 +26,14 @@ export const AgentFastModeSelector: Component<Props> = (props) => {
     );
   };
 
+  const configOptions = () => {
+    const options = props.session?.configOptions;
+    return Array.isArray(options) ? options : [];
+  };
+
   const option = () => {
     const fastModeOption =
-      props.session?.configOptions?.find(
+      configOptions().find(
         (config) => config.id === "fast_mode" && config.type === "select",
       ) ?? null;
     return fastModeOption && currentModelSupportsFastMode()

--- a/src/components/chat/PairedEffortSelector.tsx
+++ b/src/components/chat/PairedEffortSelector.tsx
@@ -23,8 +23,13 @@ export const PairedEffortSelector: Component<Props> = (props) => {
 
   const roleStatus = () => props.session?.paired?.[props.pairedRole] ?? null;
 
+  const configOptions = () => {
+    const options = roleStatus()?.configOptions;
+    return Array.isArray(options) ? options : [];
+  };
+
   const option = () =>
-    roleStatus()?.configOptions?.find(
+    configOptions().find(
       (o) => o.id === "reasoning_effort" && o.type === "select",
     ) ?? null;
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -6884,6 +6884,10 @@ export const agentStore = {
       case "configOptionsUpdate": {
         const restore = state.sessions[sessionId]?.pendingConfigRestore;
         const incoming = event.data.configOptions;
+        // Ignore a malformed frame whose configOptions is not an array — both
+        // the `.map` below and the selector `.find` readers would throw on it,
+        // tripping the workspace-recovery boundary. #2869.
+        if (!Array.isArray(incoming)) break;
         const merged = restore
           ? incoming.map((opt) =>
               opt.type === "select" && restore[opt.id]
@@ -7871,12 +7875,19 @@ export const agentStore = {
           setState("sessions", sessionId, "pendingModelId", undefined);
         }
       }
-      setState(
-        "sessions",
-        sessionId,
-        "availableModels",
-        models.availableModels,
-      );
+      // A partial/malformed status frame can carry these list fields as a
+      // non-array shape (#2862). Only accept arrays so no downstream render
+      // ever dereferences a non-array with `.find`/`.map`; a later clean frame
+      // restores the real list. Ignoring (vs. coercing to []) keeps a prior
+      // good list intact through a transient bad frame. #2869.
+      if (Array.isArray(models.availableModels)) {
+        setState(
+          "sessions",
+          sessionId,
+          "availableModels",
+          models.availableModels,
+        );
+      }
     }
 
     // Extract mode state from session status events (e.g. ready with modes,
@@ -7887,12 +7898,12 @@ export const agentStore = {
         availableModes?: AgentModeInfo[];
       };
       setState("sessions", sessionId, "currentModeId", modes.currentModeId);
-      if (modes.availableModes) {
+      if (Array.isArray(modes.availableModes)) {
         setState("sessions", sessionId, "availableModes", modes.availableModes);
       }
     }
 
-    if (data?.configOptions) {
+    if (Array.isArray(data?.configOptions)) {
       setState("sessions", sessionId, "configOptions", data.configOptions);
     }
 

--- a/tests/unit/agent-selector-partial-status.test.ts
+++ b/tests/unit/agent-selector-partial-status.test.ts
@@ -42,3 +42,39 @@ describe("agent selector partial-status guards (#2862)", () => {
     );
   });
 });
+
+describe("configOptions non-array guards (#2869)", () => {
+  const agentEffort = source("src/components/chat/AgentEffortSelector.tsx");
+  const agentFastMode = source("src/components/chat/AgentFastModeSelector.tsx");
+  const pairedEffort = source("src/components/chat/PairedEffortSelector.tsx");
+  const agentStore = source("src/stores/agent.store.ts");
+
+  it("normalizes configOptions before .find in every effort/fast-mode selector", () => {
+    // `configOptions?.find(...)` only guards null/undefined; a truthy
+    // non-array partial frame reaches `.find` and throws, tripping the
+    // workspace-recovery boundary. Each reader must normalize to [] first.
+    for (const selector of [agentEffort, agentFastMode, pairedEffort]) {
+      expect(selector).toContain("Array.isArray(options) ? options : []");
+      expect(selector).toContain("configOptions().find");
+      expect(selector).not.toContain("configOptions?.find");
+    }
+  });
+
+  it("only writes array-shaped status list fields into session state", () => {
+    // Root cause: handleStatusChange stored whatever the frame carried. The
+    // write must be gated on Array.isArray so no reader ever sees a non-array.
+    expect(agentStore).toContain("Array.isArray(data?.configOptions)");
+    expect(agentStore).toContain("Array.isArray(models.availableModels)");
+    expect(agentStore).toContain("Array.isArray(modes.availableModes)");
+    // The bare unguarded write-gate must be gone.
+    expect(agentStore).not.toContain("if (data?.configOptions) {");
+  });
+
+  it("ignores a configOptionsUpdate frame whose configOptions is not an array", () => {
+    // incoming.map(...) throws on a non-array before it can even be stored.
+    const idx = agentStore.indexOf('case "configOptionsUpdate":');
+    expect(idx).toBeGreaterThan(0);
+    const body = agentStore.slice(idx, idx + 700);
+    expect(body).toContain("if (!Array.isArray(incoming)) break;");
+  });
+});

--- a/tests/validation/scenarios/agent-send-recovery.ts
+++ b/tests/validation/scenarios/agent-send-recovery.ts
@@ -1,0 +1,74 @@
+// ABOUTME: Reproduces the single-agent Send -> "Workspace is recovering" crash.
+// ABOUTME: Provider-agnostic: exercises both Claude Code and Codex send paths.
+
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+
+interface DumpTextResult {
+  text?: string;
+}
+
+const RECOVERY_TEXT = "Workspace is recovering.";
+
+function dumpTextValue(value: unknown): string {
+  return typeof (value as DumpTextResult)?.text === "string"
+    ? ((value as DumpTextResult).text as string)
+    : JSON.stringify(value);
+}
+
+async function assertNoWorkspaceRecovery(
+  ctx: ScenarioContext,
+  stage: string,
+): Promise<void> {
+  const text = await ctx.client.dumpText("body");
+  const bodyText = dumpTextValue(text);
+  await ctx.writeArtifact(`${stage}-text.json`, text);
+  if (bodyText.includes(RECOVERY_TEXT)) {
+    await ctx.writeArtifact(
+      `${stage}-recovery-screenshot.json`,
+      await ctx.client.screenshot("body"),
+    );
+    throw new Error(`${RECOVERY_TEXT} appeared during ${stage}`);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function exerciseAgent(
+  ctx: ScenarioContext,
+  newAgentTestId: string,
+  label: string,
+): Promise<void> {
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 30_000);
+  await ctx.client.click("[data-testid='new-thread-button']");
+  await ctx.client.waitFor(`[data-testid='${newAgentTestId}']`, 10_000);
+  await ctx.client.click(`[data-testid='${newAgentTestId}']`);
+
+  await ctx.client.waitFor(".chat-composer-form textarea", 60_000);
+  await assertNoWorkspaceRecovery(ctx, `${label}-created`);
+
+  await ctx.client.fill(".chat-composer-form textarea", "Hello world!");
+  await ctx.client.click(".chat-composer-form button[type='submit']");
+
+  // The crash fires on the turnInFlight flip and again as status frames stream
+  // in during the turn. Poll across the whole active-turn window.
+  for (let i = 0; i < 12; i += 1) {
+    await sleep(2_500);
+    await assertNoWorkspaceRecovery(ctx, `${label}-turn-${i}`);
+  }
+
+  await ctx.writeArtifact(
+    `${label}-after-prompt-screenshot.json`,
+    await ctx.client.screenshot("body"),
+  );
+}
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  await ctx.client.command({ command: "setRootPath", path: process.cwd() });
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 30_000);
+  await assertNoWorkspaceRecovery(ctx, "initial");
+
+  await exerciseAgent(ctx, "new-claude-agent", "claude");
+  await exerciseAgent(ctx, "new-codex-agent", "codex");
+}


### PR DESCRIPTION
Closes #2869.

## Problem
Sending a prompt on a **single-agent** thread (Claude Code **or** Codex) can trip the main-workspace `ShellSurfaceBoundary` — "Workspace is recovering. This view hit an error." — and **Retry only recovers once the agent stops its task**. Reported on v3.68.2 (`35c62230`), which already has #2863/#2867/#2868.

## Root cause
The same non-array partial-status bug class as #2862, on the one field the earlier fixes never guarded: `configOptions`.

- `AgentEffortSelector.tsx` and `AgentFastModeSelector.tsx` (and the paired `PairedEffortSelector.tsx`) run `props.session?.configOptions?.find(...)`. `?.` guards only null/undefined; a truthy **non-array** `configOptions` reaches `.find` and throws. `option()` runs on every render inside `<Show when={option()}>`, so it throws synchronously in the `sendPrompt` re-render cascade. Both single-agent selectors mount for Claude **and** Codex → provider-agnostic.
- The runtime can emit a partial frame with a non-array here (established by #2862 for the sibling `availableModels`), and the store wrote it unvalidated (`handleStatusChange` `agent.store.ts:7896`; `configOptionsUpdate` `:6886/6894`, whose `incoming.map` also throws).
- Turn-scoped because the clean "ready" frame after the turn restores an array, so Retry works only after the agent stops.
- #2863/#2867 guarded `availableModels`/`option().options` with `Array.isArray` but never `configOptions` — which is why it survived multiple PRs.

## Approach
1. **Root cause — normalize at the store write site.** `handleStatusChange` now only writes `configOptions`/`availableModels`/`availableModes` when they are arrays; `configOptionsUpdate` ignores a non-array frame before `.map`. A malformed frame is skipped (keeping a prior good list) rather than coerced to `[]`, so a transient bad frame doesn't blank the composer. No downstream reader — present or future — can observe a non-array.
2. **Defense in depth.** The three `configOptions` readers normalize with `Array.isArray` (matching the established pattern the same files already use for `availableModels`/`option().options`), which also covers the paired reader whose upstream data this PR does not walk.

## Networked paths traced
No Seren publisher slug or first-party API path is on the changed feature path. Status/config frames flow local UI ← local Tauri provider runtime ← local Claude Code/Codex child (stream-json/ACP). Verified `SessionStatusEvent.configOptions` typing (`src/services/providers.ts:283-289`) and the browser-local emitter `buildConfigOptions` (`bin/browser-local/providers.mjs`). No outbound slug/method/path added.

## Validation
- **Full vitest suite green: 2253/2253** (313 files).
- Extended `tests/unit/agent-selector-partial-status.test.ts` (#2862/#2866 regression file) with #2869 assertions: the three readers normalize before `.find`, and the store write sites gate on `Array.isArray`.
- Biome `pnpm lint`: exit 0, no new warnings (48 pre-existing, identical to `main`).
- `tsc`: changed files clean (repo has 20 pre-existing unrelated errors on `main`; `tsc` is not a CI gate — CI runs `pnpm lint` + `pnpm test`).
- Added `tests/validation/scenarios/agent-send-recovery.ts` (Claude + Codex send "Hello world!", assert no "Workspace is recovering") mirroring #2862's `paired-agent-recovery.ts` for the validation harness.

## Scope note
The reportability gap that let this crash go un-ticketed (the recovery boundary routes to `console.warn` + telemetry, never `/support/report`) is filed separately as #2870 and will be a follow-up PR.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
