### PR TITLE
fix(support): file recovery-boundary crashes as tickets (#2870)

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -59,6 +59,7 @@ import { openFolder } from "@/lib/files/service";
 import { isMeetingProcessingStatus } from "@/lib/meeting-format";
 import { isNativeTextEditingKey, shortcuts } from "@/lib/shortcuts";
 import type { InstalledSkill } from "@/lib/skills";
+import { captureUnknownError } from "@/lib/support/hook";
 import { listenForInterviewLaunch } from "@/lib/tauri-bridge";
 import {
   backfillConversationFts,
@@ -189,6 +190,11 @@ function reportShellBoundaryError(surface: string, error: unknown): void {
     error instanceof Error ? error : new Error(String(error)),
     { surface: `app_shell_${surface}` },
   );
+  // A caught render-boundary error is a user-visible crash — route it to the
+  // support pipeline so it becomes a ticket, not just a local warn + telemetry
+  // event. captureUnknownError dedupes by signature, so a boundary that
+  // re-throws on Retry cannot spam /support/report. #2870.
+  captureUnknownError(`app_shell_${surface}`, error);
 }
 
 interface ShellSurfaceBoundaryProps {

--- a/tests/unit/app-shell-error-boundaries.test.ts
+++ b/tests/unit/app-shell-error-boundaries.test.ts
@@ -57,4 +57,18 @@ describe("AppShell scoped error recovery (#2797)", () => {
     expect(appShell).toContain("error.stack ?? error.message");
     expect(appShell).toContain("telemetry.reportError");
   });
+
+  it("routes the caught boundary error to the /support/report pipeline (#2870)", () => {
+    // console.warn is local-only and telemetry.reportError goes to analytics —
+    // neither reaches /support/report. The boundary reporter must ALSO route
+    // through captureUnknownError so a user-visible workspace-recovery crash
+    // auto-files a ticket.
+    expect(appShell).toContain(
+      'import { captureUnknownError } from "@/lib/support/hook";',
+    );
+    const idx = appShell.indexOf("function reportShellBoundaryError");
+    expect(idx).toBeGreaterThan(0);
+    const body = appShell.slice(idx, idx + 900);
+    expect(body).toContain("captureUnknownError(`app_shell_${surface}`, error)");
+  });
 });


### PR DESCRIPTION
Closes #2870.

## Problem
The `AppShell` `ShellSurfaceBoundary` — the "Workspace is recovering." fallback — is invisible to the `/support/report` GitHub-issue pipeline, so user-visible workspace crashes (#2862, #2869) never auto-file even after #2864/#2868 closed the other reportability gaps.

`reportShellBoundaryError` (`AppShell.tsx`) does two things, neither of which reaches `/support/report`:
- `console.warn(...)` — the support hook's `console.warn` wrapper only appends to the local log slice; it never calls `captureSupportError`.
- `telemetry.reportError(...)` → `telemetry.captureError` → PostHog analytics, gated + rate-limited.

And a SolidJS `<ErrorBoundary>` **catches** the render throw, so it never reaches `window.addEventListener("error")` or a reportable `console.error` — the two other triggers #2868 relies on.

## Fix
Route `reportShellBoundaryError` through `captureUnknownError` (`@/lib/support/hook`) in addition to the existing local warn + telemetry, so a caught boundary error reaches `/support/report`. `captureSupportError` dedupes by signature, so a boundary that re-throws on Retry cannot spam issues.

## Networked paths traced
Adds one already-existing outbound path: `captureUnknownError` → `captureSupportError` → `submit_support_report` (Tauri) → `POST https://api.serendb.com/support/report` (browser path: `POST {API_BASE}/support/report`). No new slug/method/path — identical to #2868.

## Validation
- Full vitest suite green: **2254/2254**.
- Extended `tests/unit/app-shell-error-boundaries.test.ts` (#2797/#2862 boundary test) with a #2870 assertion: the reporter imports and calls `captureUnknownError(\`app_shell_${surface}\`, error)`.
- Biome `pnpm lint`: exit 0, no new warnings.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
