### PR TITLE
fix(support): drop benign Tauri reload callback-id console noise (#2873)

### DIFF
--- a/src/lib/support/hook.ts
+++ b/src/lib/support/hook.ts
@@ -465,6 +465,23 @@ export async function safeInvoke<T>(
   }
 }
 
+/**
+ * Tauri's injected IPC core logs `[TAURI] Couldn't find callback id <n>. This
+ * might happen when the app is reloaded while Rust is running an asynchronous
+ * operation.` whenever a callback id is missing because the webview reloaded
+ * mid async op. It is expected and non-actionable, and repeats many times per
+ * reload — so the console.warn wrapper drops it instead of printing/logging it.
+ * Matched apostrophe-agnostically; unrelated `[TAURI]` warnings pass through.
+ */
+export function isBenignReloadCallbackWarning(args: unknown[]): boolean {
+  const first = args[0];
+  return (
+    typeof first === "string" &&
+    first.includes("[TAURI]") &&
+    first.includes("find callback id")
+  );
+}
+
 export function installSupportReporting(): void {
   if (installed || typeof window === "undefined") return;
   const supportGlobal = supportReportingGlobal();
@@ -512,6 +529,9 @@ export function installSupportReporting(): void {
   };
 
   console.warn = (...args: unknown[]) => {
+    // Drop the benign Tauri reload callback-id warning entirely — it is
+    // non-actionable and floods both the console and the support log. #2873.
+    if (isBenignReloadCallbackWarning(args)) return;
     originalWarn(...args);
     appendSupportLog("WARN", "console", args.map(String).join(" "));
   };

--- a/tests/unit/support-reporting.test.ts
+++ b/tests/unit/support-reporting.test.ts
@@ -9,6 +9,7 @@ import {
   benignConsoleError,
   captureSupportError,
   installSupportReporting,
+  isBenignReloadCallbackWarning,
   reportError,
 } from "@/lib/support/hook";
 import {
@@ -398,5 +399,25 @@ describe("#1630 agent-store support reporting", () => {
     expect(source).toContain("captureSupportError({");
     expect(source).toContain("tool_calls: toolCalls");
     expect(source).not.toContain("TODO(#1630)");
+  });
+});
+
+describe("benign Tauri reload callback-id warning (#2873)", () => {
+  const NOISE =
+    "[TAURI] Couldn't find callback id 838612930. This might happen when the app is reloaded while Rust is running an asynchronous operation.";
+
+  it("flags the reload callback-id warning for suppression", () => {
+    expect(isBenignReloadCallbackWarning([NOISE])).toBe(true);
+  });
+
+  it("leaves unrelated warnings (including other [TAURI] warnings) untouched", () => {
+    expect(isBenignReloadCallbackWarning(["some unrelated warning"])).toBe(
+      false,
+    );
+    expect(
+      isBenignReloadCallbackWarning(["[TAURI] plugin failed to initialize"]),
+    ).toBe(false);
+    expect(isBenignReloadCallbackWarning([new Error(NOISE)])).toBe(false);
+    expect(isBenignReloadCallbackWarning([])).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #2873.

## Problem
The console and the support WARN log slice are flooded with a benign, non-actionable warning:

```
[TAURI] Couldn't find callback id 838612930. This might happen when the app is reloaded while Rust is running an asynchronous operation.
```

Tauri's injected IPC core (`window.__TAURI_INTERNALS__`) emits it whenever a callback id is missing because the webview reloaded while a Rust async op was in flight — expected, and it repeats many times per reload (~70 in `~/Downloads/Logs/20260706_retry.log`). We don't call `mockIPC`; the source is Tauri's Rust-injected core, so we can't remove it upstream.

## Fix
`installSupportReporting()` (`src/lib/support/hook.ts`, wired at `src/index.tsx:43`) already wraps `console.warn`. Add an apostrophe-agnostic predicate `isBenignReloadCallbackWarning` (matches `[TAURI]` + `find callback id`) and early-return from the wrapper before printing/logging when it matches. Unrelated `[TAURI]` warnings and all other warnings pass through unchanged.

## Networked paths traced
None — client-only console-interception change in `src/lib/support/hook.ts`. No publisher slug or API call.

## Validation
- Full vitest suite green: **2256/2256**.
- Added focused tests in `tests/unit/support-reporting.test.ts`: the reload callback-id string is flagged; unrelated warnings (including other `[TAURI]` warnings, an `Error`, and empty args) are not.
- Biome `pnpm lint`: exit 0, no new warnings.

## Release
Not in v3.68.3 (already tagged) — targets the next release.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
