### PR TITLE
fix(agent): dedupe solid-js to stop workspace-recovery crash on send (#2875)

### DIFF
--- a/packages/chat-ui/src/index.tsx
+++ b/packages/chat-ui/src/index.tsx
@@ -242,6 +242,12 @@ export function ChatThinkingStatus(props: ChatThinkingStatusProps) {
   let wordTimer: ReturnType<typeof setInterval> | undefined;
   let tickTimer: ReturnType<typeof setInterval> | undefined;
 
+  // Declared before onMount because onMount reads it. When a mismatched
+  // solid-js instance runs onMount synchronously during render (instead of
+  // deferring), a declaration placed after onMount lands in the temporal dead
+  // zone and throws a ReferenceError that takes down the whole surface.
+  const showElapsedAfterMs = () => props.showElapsedAfterMs ?? 5000;
+
   onMount(() => {
     setIndex(Math.floor(Math.random() * words().length));
     wordTimer = setInterval(() => {
@@ -260,8 +266,6 @@ export function ChatThinkingStatus(props: ChatThinkingStatusProps) {
     if (wordTimer) clearInterval(wordTimer);
     if (tickTimer) clearInterval(tickTimer);
   });
-
-  const showElapsedAfterMs = () => props.showElapsedAfterMs ?? 5000;
 
   return (
     <span class={cx(props.class, props.classNames?.root)}>

--- a/tests/unit/thinking-status-tdz.test.ts
+++ b/tests/unit/thinking-status-tdz.test.ts
@@ -1,0 +1,37 @@
+// ABOUTME: Guards #2875 — the ChatThinkingStatus TDZ that crashed the main surface.
+// ABOUTME: showElapsedAfterMs must precede onMount, and solid-js must be deduped.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function source(path: string): string {
+  return readFileSync(resolve(path), "utf-8");
+}
+
+describe("ChatThinkingStatus TDZ guard (#2875)", () => {
+  const chatUi = source("packages/chat-ui/src/index.tsx");
+  const fnStart = chatUi.indexOf("export function ChatThinkingStatus");
+  const body = chatUi.slice(fnStart);
+
+  it("declares showElapsedAfterMs before the onMount that reads it", () => {
+    // A duplicate solid-js runtime (version skew + no dedupe) can run onMount
+    // synchronously during render. If showElapsedAfterMs is declared after
+    // onMount, that synchronous read lands in the temporal dead zone and throws
+    // a ReferenceError that trips the main-surface recovery boundary.
+    const declIndex = body.indexOf("const showElapsedAfterMs =");
+    const onMountIndex = body.indexOf("onMount(");
+    expect(fnStart).toBeGreaterThan(-1);
+    expect(declIndex).toBeGreaterThan(-1);
+    expect(onMountIndex).toBeGreaterThan(-1);
+    expect(declIndex).toBeLessThan(onMountIndex);
+  });
+});
+
+describe("solid-js dedupe guard (#2875)", () => {
+  const viteConfig = source("vite.config.ts");
+
+  it("forces a single solid-js runtime so onMount cannot run in an ownerless second copy", () => {
+    expect(viteConfig).toMatch(/dedupe:\s*\[\s*["']solid-js["']/);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -80,6 +80,13 @@ export default defineConfig(async () => ({
 
   // Path aliases
   resolve: {
+    // Force a single solid-js instance across the app and every workspace
+    // package (e.g. @seren/chat-ui, which pins it as a peer dependency).
+    // Without this, a version skew — such as the app on 1.9.14 while a
+    // workspace peer resolves to 1.9.13 — ships two reactive runtimes, and a
+    // component's onMount can run in an ownerless second runtime synchronously
+    // during render, tripping temporal-dead-zone crashes.
+    dedupe: ["solid-js"],
     alias: [
       { find: "@", replacement: resolve(__dirname, "src") },
       {


### PR DESCRIPTION
Closes #2875.

## Problem
Sending a prompt trips the `AppShell` `ShellSurfaceBoundary(surface="main")` fallback ("Workspace is recovering.") on every single-agent thread — Claude **and** Codex. Survived five prior PRs (#2863/#2867/#2871) that guarded non-array selector readers, which were never the cause.

## Root cause (from a debugger break, not inferred)
The throwing frame is **`ChatThinkingStatus`** (the thinking-dots/elapsed animation in workspace package `@seren/chat-ui`). Pause reason: **`ReferenceError`**; scope showed `wordTimer` already set (i.e. inside `onMount`) and `showElapsedAfterMs` uninitialized — a **temporal-dead-zone** read.

`ChatThinkingStatus.onMount` reads `showElapsedAfterMs()` before that `const` is declared. That is only safe if `onMount` defers. It ran **synchronously** because the build shipped **two Solid runtimes**:

- Dependabot **#2853** (`86172d33`) bumped **`solid-js` 1.9.13 → 1.9.14**.
- `@seren/chat-ui` pins `solid-js` as a **peer dependency**, resolved to **1.9.13**, while the app root moved to **1.9.14**.
- `vite.config.ts` had **no `resolve.dedupe: ['solid-js']`**, so both copies bundled. `ChatThinkingStatus`'s `onMount` (1.9.13, no active owner in the app's 1.9.14 render) ran eagerly → TDZ.

**Verified at the build level:** Solid's core `"Stale read"` marker appears **2x** in the bundle without dedupe, **1x** with it.

Symptoms all follow: turn-scoped (the animation only mounts while thinking, so "retry works after thinking completes"), provider-agnostic, and synchronous in the `sendPrompt` status→"prompting" setState cascade.

## Fix
1. **Root cause:** add `resolve.dedupe: ['solid-js']` in `vite.config.ts` → one Solid runtime → `onMount` defers as before the bump.
2. **Hardening:** move `const showElapsedAfterMs` above `onMount` in `ChatThinkingStatus` so a future dep skew can't resurface this TDZ.
3. **Regression test** (`tests/unit/thinking-status-tdz.test.ts`): asserts the declaration precedes `onMount` and that solid-js is deduped. Both assertions fail on `main` and pass here.

## Validation
- Full vitest suite: **314 files / 2258 tests passed**.
- Biome check on changed files: clean.
- Build-level dedupe proof: `"Stale read"` 2x → 1x.
- Manual in-app confirmation on a dev build: pending (@taariq).

## Networked paths
None. `ChatThinkingStatus` is a pure render component; the fix is entirely local build/runtime. No publisher slug, first-party API path, method, or outbound request is on the changed path.

## Credit
@taariq correctly hypothesized last session that the thinking animation was failing due to that day's dependabot upgrades; this PR confirms and fixes exactly that.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
