### PR TITLE
fix(support): log real error name+message on boundary crashes (#2877)

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -59,7 +59,7 @@ import { openFolder } from "@/lib/files/service";
 import { isMeetingProcessingStatus } from "@/lib/meeting-format";
 import { isNativeTextEditingKey, shortcuts } from "@/lib/shortcuts";
 import type { InstalledSkill } from "@/lib/skills";
-import { captureUnknownError } from "@/lib/support/hook";
+import { captureUnknownError, formatErrorForLog } from "@/lib/support/hook";
 import { listenForInterviewLaunch } from "@/lib/tauri-bridge";
 import {
   backfillConversationFts,
@@ -181,8 +181,10 @@ const ShellRecoveryFallback: Component<ShellRecoveryFallbackProps> = (
 );
 
 function reportShellBoundaryError(surface: string, error: unknown): void {
-  const detail =
-    error instanceof Error ? (error.stack ?? error.message) : String(error);
+  // Lead with name + message (formatErrorForLog), then frames. A bare
+  // `error.stack` is frames-only on WebKit/JSC, which is why these crashes
+  // logged an anonymous stack with no error text.
+  const detail = formatErrorForLog(error);
   console.warn(
     `[AppShell] ${surface} surface recovered after error: ${detail}`,
   );

--- a/src/lib/support/hook.ts
+++ b/src/lib/support/hook.ts
@@ -81,6 +81,18 @@ function normalizeError(error: unknown): {
   }
 }
 
+/**
+ * Build a log-safe one-string detail from an error, name and message first.
+ * WebKit/JSC `Error.stack` is frames-only — it omits the name and message — so
+ * logging a bare `error.stack` hides what actually threw. Always lead with
+ * `kind: message`, then the frames.
+ */
+export function formatErrorForLog(error: unknown): string {
+  const { kind, message, stack } = normalizeError(error);
+  const head = `${kind}: ${message}`;
+  return stack.length > 0 ? `${head}\n${stack.join("\n")}` : head;
+}
+
 function inferOs(raw: string): SupportReportPayload["os"] {
   const value = raw.toLowerCase();
   if (value.includes("windows") || value.includes("win32")) return "windows";

--- a/tests/unit/app-shell-error-boundaries.test.ts
+++ b/tests/unit/app-shell-error-boundaries.test.ts
@@ -54,7 +54,11 @@ describe("AppShell scoped error recovery (#2797)", () => {
 
   it("logs the caught error detail locally before reporting telemetry (#2862)", () => {
     expect(appShell).toContain("surface recovered after error");
-    expect(appShell).toContain("error.stack ?? error.message");
+    // formatErrorForLog leads with name+message so WebKit/JSC's frames-only
+    // stack no longer hides what threw (#2877). It replaced the old
+    // `error.stack ?? error.message`, which dropped the message entirely.
+    expect(appShell).toContain("formatErrorForLog(error)");
+    expect(appShell).not.toContain("error.stack ?? error.message");
     expect(appShell).toContain("telemetry.reportError");
   });
 
@@ -63,8 +67,8 @@ describe("AppShell scoped error recovery (#2797)", () => {
     // neither reaches /support/report. The boundary reporter must ALSO route
     // through captureUnknownError so a user-visible workspace-recovery crash
     // auto-files a ticket.
-    expect(appShell).toContain(
-      'import { captureUnknownError } from "@/lib/support/hook";',
+    expect(appShell).toMatch(
+      /import \{[^}]*\bcaptureUnknownError\b[^}]*\} from "@\/lib\/support\/hook";/,
     );
     const idx = appShell.indexOf("function reportShellBoundaryError");
     expect(idx).toBeGreaterThan(0);

--- a/tests/unit/support-reporting.test.ts
+++ b/tests/unit/support-reporting.test.ts
@@ -8,6 +8,7 @@ import {
   __supportReportingTestHooks,
   benignConsoleError,
   captureSupportError,
+  formatErrorForLog,
   installSupportReporting,
   isBenignReloadCallbackWarning,
   reportError,
@@ -419,5 +420,39 @@ describe("benign Tauri reload callback-id warning (#2873)", () => {
     ).toBe(false);
     expect(isBenignReloadCallbackWarning([new Error(NOISE)])).toBe(false);
     expect(isBenignReloadCallbackWarning([])).toBe(false);
+  });
+});
+
+describe("formatErrorForLog (#2877)", () => {
+  it("leads with name and message even when the stack omits them (WebKit/JSC)", () => {
+    const error = new Error("configOptions.find is not a function");
+    error.name = "TypeError";
+    // JSC's Error.stack is frames-only: no name, no message.
+    Object.defineProperty(error, "stack", {
+      value: "renderMessage@app.js:1:2\nsendPrompt@stores.js:3:4",
+      configurable: true,
+    });
+
+    const detail = formatErrorForLog(error);
+
+    expect(detail).toContain("TypeError: configOptions.find is not a function");
+    expect(detail).toContain("renderMessage@app.js:1:2");
+    // The message must precede the frames, not be lost behind them.
+    expect(detail.indexOf("TypeError:")).toBeLessThan(
+      detail.indexOf("renderMessage@app.js"),
+    );
+  });
+
+  it("falls back to a message when there is no stack", () => {
+    const error = new Error("boom");
+    error.name = "ReferenceError";
+    Object.defineProperty(error, "stack", { value: "", configurable: true });
+    expect(formatErrorForLog(error)).toBe("ReferenceError: boom");
+  });
+
+  it("stringifies non-Error throws", () => {
+    expect(formatErrorForLog("plain string throw")).toContain(
+      "plain string throw",
+    );
   });
 });


### PR DESCRIPTION
Closes #2877.

## Problem
The main-surface recovery boundary reporter logged:
```ts
const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
```
On WebKit/JSC (the desktop runtime), `Error.stack` is **frames-only** — it omits the name and message — and because the stack is truthy, the `?? error.message` branch never ran. So every "Workspace is recovering." crash logged an **anonymous stack with no error text**. That is the direct reason #2875 needed a debugger break (and five prior PRs) to root-cause: the actual `ReferenceError`/`TypeError` was invisible in logs and screenshots.

## Fix
- Add `formatErrorForLog(error)` in `src/lib/support/hook.ts` (built on the existing `normalizeError`): leads with `name: message`, then the frames.
- Use it in `reportShellBoundaryError` (`src/components/layout/AppShell.tsx`).
- Tests: 3 new cases for `formatErrorForLog` (message survives a frames-only JSC stack; message-only fallback; non-Error throws), plus the existing `app-shell-error-boundaries` source guards updated to assert the new formatter and forbid the old `error.stack ?? error.message`.

The support payload already carried the message via `captureUnknownError`; this fixes the **local log/console** that operators and users actually read.

## Scope note (the "no ticket" half of #2877)
I verified the native `/support/report` submit path is **robust**, not a silent no-op: `submit_support_report` (`src-tauri/src/support.rs`) reads `seren_api_key` from the **same `auth.json` store** the app writes on login (`src/lib/tauri-bridge.ts`), authenticates with a bearer token, and on transient failure **persists the report for a next-launch sweep**. So a signed-in user's boundary crash does submit an authenticated, deduped, redacted report. Whether that report becomes a GitHub issue is decided by the backend at `api.serendb.com`, which is outside this repo — so I did not change the submit path and can't assert its behavior here. Flagging for a backend check.

The browser-only `no-api-key` path is expected (the browser harness has no auth) and already `console.warn`s the failure; left unchanged.

## Validation
- Full vitest suite: **314 files / 2261 tests passed**.
- Biome check on changed files: clean.

## Networked paths
No new path. Existing: `captureSupportError` → `submit_support_report` (Tauri) → `POST https://api.serendb.com/support/report`. No slug/method/path added.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
