### PR TITLE
fix(agent): let paired planner hold the turn instead of forcing Codex handoff (#2880)

### DIFF
--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -142,18 +142,75 @@ export function buildPairedDeclaration(paired) {
   ].join("\n");
 }
 
+// A planner turn ends with this control token when the plan is NOT ready to
+// hand to the executor — the user asked to keep discussing or designing first,
+// asked to withhold execution, or the request needs a clarifying question. When
+// present, the coordinator returns control to the user instead of handing off
+// to Codex (#2880). The token is stripped from the streamed planner text so it
+// never renders to the user.
+const PLANNER_HOLD_SENTINEL = "[[PAIRED:AWAIT_USER]]";
+
+// Streaming-safe removal of a fixed control token from a text stream. The token
+// can arrive split across chunks, so each push() emits everything that cannot
+// be part of the token and holds back a trailing prefix until later text
+// decides it. `found` flips true once a complete token has been seen.
+function createSentinelFilter(sentinel) {
+  let pending = "";
+  let found = false;
+  const heldPrefixLen = () => {
+    const max = Math.min(pending.length, sentinel.length - 1);
+    for (let n = max; n > 0; n--) {
+      if (sentinel.startsWith(pending.slice(pending.length - n))) return n;
+    }
+    return 0;
+  };
+  return {
+    push(text) {
+      pending += text ?? "";
+      let idx = pending.indexOf(sentinel);
+      while (idx !== -1) {
+        found = true;
+        pending = pending.slice(0, idx) + pending.slice(idx + sentinel.length);
+        idx = pending.indexOf(sentinel);
+      }
+      const keep = pending.length - heldPrefixLen();
+      const out = pending.slice(0, keep);
+      pending = pending.slice(keep);
+      return out;
+    },
+    flush() {
+      const out = pending;
+      pending = "";
+      return out;
+    },
+    get found() {
+      return found;
+    },
+  };
+}
+
 function buildPlannerPrompt(userPrompt) {
   return [
     "You are the PLANNER in a paired workflow. A separate executor agent",
     "(Codex) will make all code edits, run commands, and run tests — you do",
     "not. Read only the files you need to write an accurate plan.",
     "",
-    "Reply with the implementation plan and nothing else: numbered steps the",
-    "executor can follow, each naming the concrete file paths and functions to",
-    "change. Skip preamble, restating the request, rationale, alternatives you",
-    "weighed, and risk commentary — the executor needs the steps, not the",
-    "reasoning. If the request is already unambiguous, write the plan directly",
-    "rather than surveying options.",
+    "If the user is not ready for execution — they asked you to discuss,",
+    "design, or scope the work before any code changes, asked you to hold off",
+    "handing to the executor, or the request needs a clarifying question — then",
+    "do NOT write an implementation plan. Respond to the user directly (ask",
+    "your question or share the discussion, one point at a time when they ask",
+    "for that), and end your entire message with this exact control line on its",
+    `own line: ${PLANNER_HOLD_SENTINEL}`,
+    "The control line keeps ownership with you so the executor never starts;",
+    "the user does not see it. Use it every turn you need to keep talking.",
+    "",
+    "Otherwise the request is ready to build. Reply with the implementation plan and nothing else:",
+    "numbered steps the executor can follow, each naming the concrete file",
+    "paths and functions to change. Skip preamble, restating the request,",
+    "rationale, alternatives you weighed, and risk commentary — the executor",
+    "needs the steps, not the reasoning. Do not include the control line when",
+    "you hand off a plan.",
     "",
     "User request:",
     userPrompt,
@@ -227,6 +284,8 @@ export function createPairedRuntime({ emit, inner }) {
       notice: null,
       turnText: "",
       lastTurnMeta: null,
+      holdRequested: false,
+      sentinelFilter: null,
     };
   }
 
@@ -366,6 +425,23 @@ export function createPairedRuntime({ emit, inner }) {
 
       case "provider://message-chunk": {
         if (payload.replay === true) return true;
+        const filter = roleState.sentinelFilter;
+        if (filter && !payload.isThought) {
+          // Planner visible text: strip the hold control token before it
+          // streams so the user never sees it (#2880). Thoughts bypass the
+          // filter — the token only appears in the final answer.
+          const visible = filter.push(payload.text ?? "");
+          roleState.turnText += visible;
+          if (visible) {
+            emit(channel, {
+              ...payload,
+              text: visible,
+              sessionId: paired.id,
+              agentProvider: roleState.agentType,
+            });
+          }
+          return true;
+        }
         if (!payload.isThought) {
           roleState.turnText += payload.text ?? "";
         }
@@ -619,11 +695,35 @@ export function createPairedRuntime({ emit, inner }) {
     const roleState = paired.roles[role];
     roleState.turnText = "";
     roleState.lastTurnMeta = null;
-    await inner.sendPrompt({
-      sessionId: roleState.innerSessionId,
-      prompt,
-      context,
-    });
+    roleState.holdRequested = false;
+    // Only the planner can hold the turn for the user; its control token is
+    // stripped from the streamed text as chunks arrive (#2880).
+    roleState.sentinelFilter =
+      role === "planner" ? createSentinelFilter(PLANNER_HOLD_SENTINEL) : null;
+    try {
+      await inner.sendPrompt({
+        sessionId: roleState.innerSessionId,
+        prompt,
+        context,
+      });
+    } finally {
+      const filter = roleState.sentinelFilter;
+      roleState.sentinelFilter = null;
+      if (filter) {
+        // Emit any held-back tail (a partial token that never completed) so the
+        // last visible characters still reach the UI.
+        const tail = filter.flush();
+        if (tail && !paired.cancelRequested) {
+          roleState.turnText += tail;
+          emit("provider://message-chunk", {
+            sessionId: paired.id,
+            text: tail,
+            agentProvider: roleState.agentType,
+          });
+        }
+        roleState.holdRequested = filter.found;
+      }
+    }
     throwIfCancelled(paired);
     return roleState.turnText;
   }
@@ -665,6 +765,25 @@ export function createPairedRuntime({ emit, inner }) {
         context,
       );
       collectMeta("planner");
+
+      // The planner can hold the turn for the user — a design/discussion phase
+      // or a clarifying question — instead of handing off. Skip execution and
+      // review and return control so the user can reply (#2880).
+      if (paired.roles.planner.holdRequested) {
+        paired.currentPrompt = null;
+        paired.status = "ready";
+        setPhase(paired, "idle", null);
+        emit("provider://prompt-complete", {
+          sessionId: paired.id,
+          stopReason: "end_turn",
+          meta: {
+            usage,
+            ...(contextWindow ? { contextWindow } : {}),
+          },
+        });
+        emitPairedStatus(paired, "ready");
+        return;
+      }
 
       emitHandoff(
         paired,

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -619,6 +619,121 @@ describe("paired runtime — prompt pipeline", () => {
   });
 });
 
+describe("paired runtime — planner hold (#2880)", () => {
+  let h: ReturnType<typeof createHarness>;
+  beforeEach(async () => {
+    h = createHarness();
+    await spawnPaired(h);
+    h.emitted.length = 0;
+  });
+
+  it("holds the turn for the user instead of handing off when the planner emits the sentinel", async () => {
+    for (const s of h.innerSessions.values()) {
+      if (s.agentType === "claude-code") {
+        s.scriptedTurnText = ["What should the skill be named?\n[[PAIRED:AWAIT_USER]]"];
+      }
+    }
+
+    await h.paired.sendPrompt({
+      sessionId: "paired-1",
+      prompt: "help me design a private grant skill, ask me questions first",
+    });
+
+    // Only the planner ran — Codex was never prompted, and there is no review.
+    const order = h.inner.sendPrompt.mock.calls.map((c) => {
+      const sid = String(c[0].sessionId);
+      return h.innerSessions.get(sid)?.agentType ?? sid;
+    });
+    expect(order).toEqual(["claude-code"]);
+
+    // No handoff events fired.
+    const handoffs = eventsFor(h.emitted, "provider://paired-event").filter(
+      (e) => e.payload.kind === "handoff",
+    );
+    expect(handoffs.length).toBe(0);
+
+    // Exactly one paired prompt-complete closes the turn.
+    const completes = eventsFor(h.emitted, "provider://prompt-complete").filter(
+      (e) => e.payload.sessionId === "paired-1",
+    );
+    expect(completes.length).toBe(1);
+
+    // The control token never reaches the frontend; the question does.
+    const visible = eventsFor(h.emitted, "provider://message-chunk")
+      .map((e) => String(e.payload.text))
+      .join("");
+    expect(visible).toContain("What should the skill be named?");
+    expect(visible).not.toContain("AWAIT_USER");
+    expect(visible).not.toContain("[[PAIRED");
+
+    // The turn ends idle, ownership released back to the user.
+    const states = eventsFor(h.emitted, "provider://session-status")
+      .map(
+        (e) =>
+          (e.payload as { paired?: { state?: string } }).paired?.state ?? null,
+      )
+      .filter(Boolean);
+    expect(states[states.length - 1]).toBe("idle");
+  });
+
+  it("strips the sentinel even when it splits across streamed chunks", async () => {
+    h.inner.sendPrompt.mockImplementation(
+      async ({ sessionId }: { sessionId: string }) => {
+        const session = h.innerSessions.get(sessionId);
+        if (session?.agentType === "claude-code") {
+          h.wrappedEmit("provider://message-chunk", {
+            sessionId,
+            text: "Question part [[PAIRED:AW",
+          });
+          h.wrappedEmit("provider://message-chunk", {
+            sessionId,
+            text: "AIT_USER]]",
+          });
+        }
+        h.wrappedEmit("provider://prompt-complete", {
+          sessionId,
+          stopReason: "end_turn",
+          meta: { usage: { input_tokens: 10, output_tokens: 5 } },
+        });
+      },
+    );
+
+    await h.paired.sendPrompt({ sessionId: "paired-1", prompt: "discuss first" });
+
+    // Held even though the token was split — Codex never ran.
+    const order = h.inner.sendPrompt.mock.calls.map((c) => {
+      const sid = String(c[0].sessionId);
+      return h.innerSessions.get(sid)?.agentType ?? sid;
+    });
+    expect(order).toEqual(["claude-code"]);
+
+    // No fragment of the token leaks through the chunk boundary.
+    const visible = eventsFor(h.emitted, "provider://message-chunk")
+      .map((e) => String(e.payload.text))
+      .join("");
+    expect(visible).toBe("Question part ");
+    expect(visible).not.toContain("[[PAIRED");
+    expect(visible).not.toContain("AW");
+  });
+
+  it("runs the full plan → execute → review pipeline when no sentinel is present", async () => {
+    for (const s of h.innerSessions.values()) {
+      s.scriptedTurnText =
+        s.agentType === "claude-code"
+          ? ["PLAN: do the thing", "REVIEW: looks good"]
+          : ["EXEC: did the thing"];
+    }
+
+    await h.paired.sendPrompt({ sessionId: "paired-1", prompt: "build it now" });
+
+    const order = h.inner.sendPrompt.mock.calls.map((c) => {
+      const sid = String(c[0].sessionId);
+      return h.innerSessions.get(sid)?.agentType ?? sid;
+    });
+    expect(order).toEqual(["claude-code", "codex", "claude-code"]);
+  });
+});
+
 describe("paired runtime — approvals", () => {
   let h: ReturnType<typeof createHarness>;
   let executorInnerId: string;


### PR DESCRIPTION
## What

Fixes #2880. In a **Claude + Codex** paired thread, the planner can now **hold the turn** for a design/discussion phase instead of being forced to hand off to Codex.

## Root cause

`bin/browser-local/paired-runtime.mjs` — `sendPrompt()` ran an unconditional `plan → execute → review` pipeline on every user turn. After the planner produced any output, it *always* emitted `Claude handed off to Codex…` and ran the executor. There was no way for the planner to keep talking to the user — so a prompt like *"ask me questions one at a time, don't hand off to Codex until the design is complete"* was structurally impossible. (Reported from `~/Downloads/Logs/20260708_fable_fail.log`.)

## Change

- **Hold control token.** `buildPlannerPrompt()` now instructs the planner to respond directly and end its message with `[[PAIRED:AWAIT_USER]]` when the user wants to discuss/design first, withheld execution, or a clarifying question is needed.
- **Skip execution on hold.** When the planner turn signals hold (`holdRequested`), `sendPrompt()` completes the turn planner-only — no executor, no review — returning control to the user.
- **Streaming-safe stripping.** `createSentinelFilter()` removes the token from the streamed planner text even when it splits across chunk boundaries, so it never renders in the UI.
- **Default unchanged.** With no token, the existing `plan → execute → review` pipeline runs exactly as before.

## Tests

`tests/unit/paired-runtime.test.ts` — added a `planner hold (#2880)` block:
- holds the turn (Codex never prompted, no handoff, one `prompt-complete`, token stripped, ends `idle`)
- strips the token when it splits across streamed chunks
- still runs the full pipeline when no token is present

All 46 tests pass (`vitest run tests/unit/paired-runtime.test.ts`).

## Scope / transport note

The paired coordinator only relays events from two local child-process runtimes — Claude Code (stream-json, **not ACP**) and Codex (JSON-RPC 2.0 over stdio) — each talking directly to its own provider. **No Seren publisher/API slug is on this handoff path**, so there is no networked path to verify. The edited module is bundled into the embedded runtime by `scripts/build-provider-runtime.ts` (gitignored artifact; CI regenerates it), so this ships to the native app.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
