### PR TITLE
fix(release): hard-gate unchanged Windows signing cache misses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ env:
   # Warning threshold for billable SSL.com cloud hash-signing operations in one
   # Windows release job. Bump only after auditing sign-targets.txt / signer telemetry.
   MAX_SIGNATURES: ${{ vars.MAX_SIGNATURES || '850' }}
+  # Hard gate for unchanged embedded-runtime releases: if the manifest matches
+  # the previous release, a working signature cache should make this near zero.
+  WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED: ${{ vars.WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED || '25' }}
 
 jobs:
   create-release:
@@ -436,6 +439,61 @@ jobs:
           CARGO_BUILD_TARGET: ${{ matrix.target }}
         run: pnpm prepare:tauri-build
 
+      - name: Fetch previous Windows signing cache state
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tagName = '${{ github.ref_name }}';
+            const stateAssetName = 'windows-signing-cache-state.json';
+            const outputPath = 'windows-signing-cache-previous-state.json';
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 50,
+            });
+            const previous = releases.find((release) => !release.draft && release.tag_name !== tagName);
+            if (!previous) {
+              core.notice('No previous published release found for Windows signing cache comparison.');
+              return;
+            }
+
+            const assets = await github.paginate(github.rest.repos.listReleaseAssets, {
+              owner,
+              repo,
+              release_id: previous.id,
+              per_page: 100,
+            });
+            const stateAsset = assets.find((asset) => asset.name === stateAssetName);
+            if (!stateAsset) {
+              core.notice(`Previous release ${previous.tag_name} has no ${stateAssetName}; first gated release will write it.`);
+              return;
+            }
+
+            const response = await github.request('GET /repos/{owner}/{repo}/releases/assets/{asset_id}', {
+              owner,
+              repo,
+              asset_id: stateAsset.id,
+              headers: {
+                accept: 'application/octet-stream',
+              },
+            });
+            const raw = typeof response.data === 'string'
+              ? response.data
+              : Buffer.isBuffer(response.data)
+                ? response.data.toString('utf8')
+                : response.data instanceof ArrayBuffer
+                  ? Buffer.from(response.data).toString('utf8')
+                  : JSON.stringify(response.data);
+            JSON.parse(raw);
+            fs.writeFileSync(outputPath, raw);
+            core.notice(`Downloaded Windows signing cache state from ${previous.tag_name} to ${outputPath}.`);
+
       - name: Restore Windows signature cache
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
         uses: actions/cache@v6
@@ -477,6 +535,17 @@ jobs:
             -CacheDir .sig-cache/windows-authenticode `
             -Manifest windows-signature-cache-manifest.tsv `
             -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT
+
+      - name: Assert Windows signature cache hit budget
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        run: |
+          ./scripts/assert-windows-signature-cache.ps1 `
+            -ListFile sign-targets.txt `
+            -Manifest windows-signature-cache-manifest.tsv `
+            -PreviousState windows-signing-cache-previous-state.json `
+            -OutputState windows-signing-cache-state.json `
+            -MaxSignedWhenUnchanged $env:WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED
 
       # makensis embeds the stock NSIS plugins ($PLUGINSDIR: System.dll,
       # nsExec.dll, StartMenu.dll, nsDialogs.dll) from the bundler's NSIS
@@ -1169,6 +1238,14 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.nsis.zip
             src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.nsis.zip.sig
           if-no-files-found: warn
+
+      - name: Upload Windows signing cache state
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-signing-cache-state
+          path: windows-signing-cache-state.json
+          if-no-files-found: error
 
       - name: Upload Linux updater bundle
         if: startsWith(matrix.os, 'ubuntu')

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -45,6 +45,7 @@ Add these secrets to the repository settings (Settings → Secrets → Actions):
 | Variable | Description |
 |----------|-------------|
 | `MAX_SIGNATURES` | Warning threshold for SSL.com cloud hash-signing operations in one Windows release job. Defaults to `850` in `release.yml`; raise only after reviewing `sign-targets.txt` and the Windows signing job summary. |
+| `WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED` | Hard-fail threshold for fresh embedded-runtime signatures when the signable manifest matches the previous release. Defaults to `25`; keep this low so a broken signature cache fails before release artifacts publish. |
 
 ## Certificate Setup
 
@@ -177,8 +178,28 @@ because cached signed binaries are restored before `sign-windows-payload.ps1`
 runs. A cold cache should behave the same as the pre-cache path, then populate
 the cache for later releases.
 
+### Signature cache hit gate (release CI, hard-fail)
+
+The release job persists `windows-signing-cache-state.json` as a GitHub release
+asset. On the next Windows release, the workflow downloads that state from the
+previous published release, computes a stable hash of the current
+embedded-runtime signable manifest (`windows-signature-cache-manifest.tsv`),
+and runs `scripts/assert-windows-signature-cache.ps1` against the real signer
+telemetry.
+
+If the manifest hash matches the previous release, the embedded-runtime set is
+unchanged. In that case, the cache must restore almost all previously signed
+binaries before the signer runs. Fresh embedded-runtime signatures above
+`WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED` fail the Windows build with an
+explicit cache-regression error. If no previous state exists yet, or the
+manifest hash changed because the runtime genuinely changed, the gate writes
+the current state and skips the assertion for that release.
+
 ### Verification gates (release CI, hard-fail)
 
+- Unchanged embedded-runtime releases cannot freshly sign more than
+  `WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED` files; this catches broken
+  cross-release signature-cache restores before artifacts are uploaded.
 - Loose `.exe`/`.dll` under `bundle/` are all `Valid` (`#2235`).
 - Every `.exe`/`.dll` extracted from `.nsis.zip` is `Valid` (`#2236`).
 - The setup `.exe` is unpacked with 7-Zip and **every** embedded

--- a/scripts/assert-windows-signature-cache.ps1
+++ b/scripts/assert-windows-signature-cache.ps1
@@ -1,0 +1,240 @@
+# ABOUTME: Hard-gates Windows release signing when an unchanged embedded-runtime manifest re-signs too many files.
+# ABOUTME: Persists the manifest hash as a release asset so cache-restore regressions do not hide the comparison state.
+
+[CmdletBinding()]
+param(
+  # Newline-delimited signable set produced by scripts/print-windows-signables.ts.
+  [Parameter(Mandatory = $true)][string]$ListFile,
+  # Pre-sign hash manifest written by scripts/windows-signature-cache.ps1 restore mode.
+  [Parameter(Mandatory = $true)][string]$Manifest,
+  # JSONL telemetry written by scripts/sign-windows-payload.ps1.
+  [string]$TelemetryFile = "",
+  # Previous release state downloaded from the GitHub release asset, when present.
+  [string]$PreviousState = "",
+  # State to upload with this release for the next release's comparison.
+  [Parameter(Mandatory = $true)][string]$OutputState,
+  # Maximum fresh embedded-runtime signatures allowed when the manifest is unchanged.
+  # Defaults from WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED, then 25.
+  [int]$MaxSignedWhenUnchanged = -1,
+  # Stable base for turning absolute manifest paths into release-invariant paths.
+  [string]$Workspace = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-NonNegativeInt {
+  param(
+    [string]$Raw,
+    [string]$Name,
+    [int]$Default
+  )
+  if (-not $Raw) { return $Default }
+  [int]$parsed = 0
+  if (-not [int]::TryParse($Raw, [ref]$parsed) -or $parsed -lt 0) {
+    Write-Host "::error::$Name must be a non-negative integer, got '$Raw'."
+    exit 1
+  }
+  return $parsed
+}
+
+function Get-StableManifestPath {
+  param(
+    [string]$Path,
+    [string]$WorkspaceRoot
+  )
+
+  $full = [IO.Path]::GetFullPath($Path)
+  if ($WorkspaceRoot) {
+    $root = [IO.Path]::GetFullPath($WorkspaceRoot)
+    $separators = [char[]]@([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+    $root = $root.TrimEnd($separators)
+    if ($full.Equals($root, [System.StringComparison]::OrdinalIgnoreCase)) {
+      return "."
+    }
+    $rootWithSeparator = "$root$([IO.Path]::DirectorySeparatorChar)"
+    $rootWithAltSeparator = "$root$([IO.Path]::AltDirectorySeparatorChar)"
+    if (
+      $full.StartsWith($rootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase) -or
+      $full.StartsWith($rootWithAltSeparator, [System.StringComparison]::OrdinalIgnoreCase)
+    ) {
+      return ([IO.Path]::GetRelativePath($root, $full)).Replace("\", "/")
+    }
+  }
+  return $full.Replace("\", "/")
+}
+
+function Get-Sha256Hex {
+  param([string]$Value)
+  $sha = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($Value)
+    return ([BitConverter]::ToString($sha.ComputeHash($bytes))).Replace("-", "").ToUpperInvariant()
+  } finally {
+    $sha.Dispose()
+  }
+}
+
+function Read-ManifestSummary {
+  param(
+    [string]$Path,
+    [string]$WorkspaceRoot
+  )
+
+  if (-not (Test-Path -LiteralPath $Path)) { throw "Manifest not found: $Path" }
+  $entries = [System.Collections.Generic.List[string]]::new()
+  foreach ($line in Get-Content -LiteralPath $Path) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed) { continue }
+    $parts = $trimmed -split "`t", 2
+    if ($parts.Count -ne 2 -or -not $parts[0] -or -not $parts[1]) {
+      throw "Malformed Windows signature cache manifest line: $trimmed"
+    }
+    $hash = $parts[0].Trim().ToUpperInvariant()
+    $stablePath = Get-StableManifestPath -Path $parts[1].Trim() -WorkspaceRoot $WorkspaceRoot
+    $entries.Add("$hash`t$stablePath")
+  }
+  if ($entries.Count -eq 0) { throw "Manifest has no signable entries: $Path" }
+  $sorted = @($entries | Sort-Object)
+  $payload = $sorted -join "`n"
+  [PSCustomObject]@{
+    hash = Get-Sha256Hex -Value $payload
+    entries = $sorted.Count
+  }
+}
+
+function Read-TelemetrySummary {
+  param([string]$Path)
+
+  if (-not $Path) { throw "TelemetryFile is required for the Windows signature cache gate." }
+  if (-not (Test-Path -LiteralPath $Path)) { throw "TelemetryFile not found: $Path" }
+
+  [int]$totalSigned = 0
+  [int]$embeddedDiscovered = 0
+  [int]$embeddedSkipped = 0
+  [int]$embeddedWouldSign = 0
+  [int]$embeddedSigned = 0
+  [int]$embeddedRecords = 0
+
+  foreach ($line in Get-Content -LiteralPath $Path) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed) { continue }
+    try {
+      $record = $trimmed | ConvertFrom-Json
+    } catch {
+      throw "Malformed Windows signing telemetry line in ${Path}: $trimmed"
+    }
+    if ($null -ne $record.signed) { $totalSigned += [int]$record.signed }
+    $source = [string]$record.source
+    if ($source.StartsWith("list:", [System.StringComparison]::OrdinalIgnoreCase)) {
+      $embeddedRecords++
+      if ($null -ne $record.discovered) { $embeddedDiscovered += [int]$record.discovered }
+      if ($null -ne $record.skipped) { $embeddedSkipped += [int]$record.skipped }
+      if ($null -ne $record.would_sign) { $embeddedWouldSign += [int]$record.would_sign }
+      if ($null -ne $record.signed) { $embeddedSigned += [int]$record.signed }
+    }
+  }
+
+  if ($embeddedRecords -eq 0) {
+    throw "No embedded-runtime list telemetry found in $Path."
+  }
+
+  [PSCustomObject]@{
+    total_signed = $totalSigned
+    embedded_records = $embeddedRecords
+    embedded_discovered = $embeddedDiscovered
+    embedded_skipped = $embeddedSkipped
+    embedded_would_sign = $embeddedWouldSign
+    embedded_signed = $embeddedSigned
+  }
+}
+
+function Read-PreviousState {
+  param([string]$Path)
+  if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return $null }
+  try {
+    return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json)
+  } catch {
+    Write-Host "::warning::Ignoring malformed previous Windows signing cache state at ${Path}: $($_.Exception.Message)"
+    return $null
+  }
+}
+
+function Write-CurrentState {
+  param(
+    [string]$Path,
+    [object]$State
+  )
+  $dir = Split-Path -Parent $Path
+  if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+  }
+  ($State | ConvertTo-Json -Depth 5) | Set-Content -LiteralPath $Path
+}
+
+if (-not $TelemetryFile) { $TelemetryFile = $env:WINDOWS_SIGN_TELEMETRY_FILE }
+if (-not $Workspace) { $Workspace = $env:GITHUB_WORKSPACE }
+if (-not $Workspace) { $Workspace = (Get-Location).Path }
+if ($MaxSignedWhenUnchanged -lt 0) {
+  $MaxSignedWhenUnchanged = Resolve-NonNegativeInt `
+    -Raw $env:WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED `
+    -Name "WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED" `
+    -Default 25
+}
+
+if (-not (Test-Path -LiteralPath $ListFile)) { throw "ListFile not found: $ListFile" }
+$manifestSummary = Read-ManifestSummary -Path $Manifest -WorkspaceRoot $Workspace
+$telemetrySummary = Read-TelemetrySummary -Path $TelemetryFile
+$previous = Read-PreviousState -Path $PreviousState
+
+$previousHash = if ($previous -and $previous.manifest_hash) {
+  ([string]$previous.manifest_hash).ToUpperInvariant()
+} else {
+  ""
+}
+
+$status = "skipped_no_previous_state"
+$currentHash = [string]$manifestSummary.hash
+if ($previousHash) {
+  if ($previousHash -eq $currentHash) {
+    $status = "passed_unchanged_manifest"
+    if ($telemetrySummary.embedded_signed -gt $MaxSignedWhenUnchanged) {
+      $status = "failed_unchanged_manifest_over_floor"
+    }
+  } else {
+    $status = "skipped_changed_manifest"
+  }
+}
+
+$state = [PSCustomObject]@{
+  schema_version = 1
+  created_at = (Get-Date).ToUniversalTime().ToString("o")
+  github_ref = $env:GITHUB_REF
+  github_sha = $env:GITHUB_SHA
+  github_run_id = $env:GITHUB_RUN_ID
+  manifest_hash = $currentHash
+  manifest_entries = [int]$manifestSummary.entries
+  previous_manifest_hash = if ($previousHash) { $previousHash } else { $null }
+  cache_gate_status = $status
+  max_signed_when_unchanged = $MaxSignedWhenUnchanged
+  embedded_runtime_discovered = [int]$telemetrySummary.embedded_discovered
+  embedded_runtime_skipped = [int]$telemetrySummary.embedded_skipped
+  embedded_runtime_would_sign = [int]$telemetrySummary.embedded_would_sign
+  embedded_runtime_signed = [int]$telemetrySummary.embedded_signed
+  total_signed_so_far = [int]$telemetrySummary.total_signed
+}
+Write-CurrentState -Path $OutputState -State $state
+
+if ($status -eq "failed_unchanged_manifest_over_floor") {
+  Write-Host "::error::Windows signature cache regression: embedded-runtime manifest hash $currentHash matches the previous release, but $($telemetrySummary.embedded_signed) embedded-runtime file(s) were freshly signed; expected <= $MaxSignedWhenUnchanged."
+  Write-Host "::error::Inspect telemetry '$TelemetryFile', cache manifest '$Manifest', previous state '$PreviousState', and current state '$OutputState'. The actions/cache restore may be broken or returning an empty cache."
+  exit 1
+}
+
+if ($status -eq "passed_unchanged_manifest") {
+  Write-Host "Windows signature cache gate passed: unchanged embedded-runtime manifest $currentHash signed $($telemetrySummary.embedded_signed) file(s), max $MaxSignedWhenUnchanged."
+} elseif ($status -eq "skipped_changed_manifest") {
+  Write-Host "Windows signature cache gate skipped: embedded-runtime manifest changed from $previousHash to $currentHash."
+} else {
+  Write-Host "Windows signature cache gate skipped: no previous release state was available."
+}
+Write-Host "Windows signature cache state written: $OutputState"

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -150,6 +150,33 @@ describe("release workflow contract", () => {
     expect(cacheSaveAt).toBeGreaterThan(signerAt);
   });
 
+  it("hard-gates unchanged embedded-runtime signature cache misses before Windows artifacts upload (#2882)", () => {
+    expect(workflow).toContain("WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED");
+    expect(workflow).toContain("Fetch previous Windows signing cache state");
+    expect(workflow).toContain("windows-signing-cache-previous-state.json");
+    expect(workflow).toContain("Assert Windows signature cache hit budget");
+    expect(workflow).toContain("assert-windows-signature-cache.ps1");
+    expect(workflow).toContain("windows-signing-cache-state.json");
+    expect(workflow).toContain("Upload Windows signing cache state");
+
+    const stageAt = workflow.indexOf("Stage embedded runtime for signing (Windows)");
+    const fetchStateAt = workflow.indexOf("Fetch previous Windows signing cache state");
+    const cacheRestoreAt = workflow.indexOf("Restore Windows signature cache");
+    const signAt = workflow.indexOf("Sign embedded runtime (Windows)");
+    const assertAt = workflow.indexOf("Assert Windows signature cache hit budget");
+    const buildAt = workflow.indexOf("Build Tauri app (signed, Windows)");
+    const uploadWindowsAt = workflow.indexOf("Upload Windows NSIS");
+    const uploadStateAt = workflow.indexOf("Upload Windows signing cache state");
+
+    expect(stageAt).toBeGreaterThanOrEqual(0);
+    expect(fetchStateAt).toBeGreaterThan(stageAt);
+    expect(cacheRestoreAt).toBeGreaterThan(fetchStateAt);
+    expect(signAt).toBeGreaterThan(cacheRestoreAt);
+    expect(assertAt).toBeGreaterThan(signAt);
+    expect(assertAt).toBeLessThan(buildAt);
+    expect(uploadStateAt).toBeGreaterThan(uploadWindowsAt);
+  });
+
   it("reports Windows signing budget telemetry as warning-only (#2818/#2821)", () => {
     const signer = readFileSync(signerScript, "utf8");
 

--- a/tests/unit/windows-signature-cache-gate.test.ts
+++ b/tests/unit/windows-signature-cache-gate.test.ts
@@ -1,0 +1,175 @@
+// ABOUTME: Regression tests for the Windows signature-cache hard gate (#2882).
+// ABOUTME: Uses real telemetry and manifest files; no signer mocking is needed for this release assertion.
+
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const gateScript = path.join(repoRoot, "scripts", "assert-windows-signature-cache.ps1");
+const pwshCheck = spawnSync("pwsh", ["-NoProfile", "-Command", "$PSVersionTable.PSVersion.Major"], {
+  encoding: "utf8",
+});
+const hasPwsh = pwshCheck.status === 0;
+
+let root: string;
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex").toUpperCase();
+}
+
+function writeArtifacts(contentHash: string, signed: number): { list: string; manifest: string; telemetry: string } {
+  const payload = path.join(root, "src-tauri", "embedded-runtime", "bin", "payload.exe");
+  const list = path.join(root, "sign-targets.txt");
+  const manifest = path.join(root, "windows-signature-cache-manifest.tsv");
+  const telemetry = path.join(root, "windows-signing-telemetry.jsonl");
+
+  mkdirSync(path.dirname(payload), { recursive: true });
+  writeFileSync(payload, "unsigned payload");
+  writeFileSync(list, `${payload}\n`);
+  writeFileSync(manifest, `${contentHash}\t${payload}\n`);
+  writeFileSync(
+    telemetry,
+    `${JSON.stringify({
+      status: "success",
+      source: "list:sign-targets.txt",
+      discovered: 729,
+      skipped: 195,
+      would_sign: signed,
+      signed,
+      previous_signed: 0,
+      max_signatures: 850,
+    })}\n`,
+  );
+
+  return { list, manifest, telemetry };
+}
+
+function runGate(args: string[]): { out: string; status: number } {
+  const r = spawnSync(
+    "pwsh",
+    ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", gateScript, ...args],
+    { encoding: "utf8" },
+  );
+  return { out: `${r.stdout}\n${r.stderr}`, status: r.status ?? 1 };
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "win-sig-cache-gate-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("assert-windows-signature-cache.ps1", () => {
+  const pwshTimeout = 30_000;
+
+  it.runIf(hasPwsh)(
+    "fails when an unchanged embedded-runtime manifest freshly signs over the cache-hit floor",
+    () => {
+      const artifacts = writeArtifacts(sha256("unsigned payload"), 534);
+      const previousState = path.join(root, "previous-state.json");
+      const currentState = path.join(root, "current-state.json");
+
+      const first = runGate([
+        "-ListFile",
+        artifacts.list,
+        "-Manifest",
+        artifacts.manifest,
+        "-TelemetryFile",
+        artifacts.telemetry,
+        "-OutputState",
+        previousState,
+        "-Workspace",
+        root,
+        "-MaxSignedWhenUnchanged",
+        "25",
+      ]);
+      expect(first.status).toBe(0);
+      expect(first.out).toContain("no previous release state");
+
+      const second = runGate([
+        "-ListFile",
+        artifacts.list,
+        "-Manifest",
+        artifacts.manifest,
+        "-TelemetryFile",
+        artifacts.telemetry,
+        "-PreviousState",
+        previousState,
+        "-OutputState",
+        currentState,
+        "-Workspace",
+        root,
+        "-MaxSignedWhenUnchanged",
+        "25",
+      ]);
+
+      expect(second.status).toBe(1);
+      expect(second.out).toContain("Windows signature cache regression");
+      expect(second.out).toContain("expected <= 25");
+
+      const state = JSON.parse(readFileSync(currentState, "utf8"));
+      expect(state.cache_gate_status).toBe("failed_unchanged_manifest_over_floor");
+      expect(state.embedded_runtime_signed).toBe(534);
+      expect(state.previous_manifest_hash).toBe(state.manifest_hash);
+    },
+    pwshTimeout,
+  );
+
+  it.runIf(hasPwsh)(
+    "skips the hard gate when the embedded-runtime manifest changed",
+    () => {
+      const firstArtifacts = writeArtifacts(sha256("unsigned payload v1"), 534);
+      const previousState = path.join(root, "previous-state.json");
+      const currentState = path.join(root, "current-state.json");
+
+      expect(
+        runGate([
+          "-ListFile",
+          firstArtifacts.list,
+          "-Manifest",
+          firstArtifacts.manifest,
+          "-TelemetryFile",
+          firstArtifacts.telemetry,
+          "-OutputState",
+          previousState,
+          "-Workspace",
+          root,
+          "-MaxSignedWhenUnchanged",
+          "25",
+        ]).status,
+      ).toBe(0);
+
+      const changedArtifacts = writeArtifacts(sha256("unsigned payload v2"), 534);
+      const changed = runGate([
+        "-ListFile",
+        changedArtifacts.list,
+        "-Manifest",
+        changedArtifacts.manifest,
+        "-TelemetryFile",
+        changedArtifacts.telemetry,
+        "-PreviousState",
+        previousState,
+        "-OutputState",
+        currentState,
+        "-Workspace",
+        root,
+        "-MaxSignedWhenUnchanged",
+        "25",
+      ]);
+
+      expect(changed.status).toBe(0);
+      expect(changed.out).toContain("manifest changed");
+
+      const state = JSON.parse(readFileSync(currentState, "utf8"));
+      expect(state.cache_gate_status).toBe("skipped_changed_manifest");
+      expect(state.previous_manifest_hash).not.toBe(state.manifest_hash);
+    },
+    pwshTimeout,
+  );
+});


### PR DESCRIPTION
Closes #2882.

## Audit

The broken path is the Windows tag-release signing path:

1. `.github/workflows/release.yml` stages `src-tauri/embedded-runtime` / `src-tauri/mcp-servers` on the Windows matrix leg.
2. `scripts/print-windows-signables.ts ... > sign-targets.txt` emits the embedded-runtime PE signable set.
3. `scripts/windows-signature-cache.ps1 -Mode restore` writes `windows-signature-cache-manifest.tsv` and restores cached signed blobs from `.sig-cache/windows-authenticode`.
4. `scripts/sign-windows-payload.ps1 -ListFile sign-targets.txt` skips valid files, signs cache misses with SSL.com eSigner CKA, and appends JSONL telemetry to `WINDOWS_SIGN_TELEMETRY_FILE`.
5. `scripts/windows-signature-cache.ps1 -Mode save` saves newly signed blobs by pre-sign content hash.
6. The existing "Summarize Windows signing budget" step only reports telemetry and exits 0, so a broken cross-release cache can still publish a release.

Prior issues/PRs/docs reviewed: #2818, #2820, #2821/#2822, #2823/#2824, #2235/#2241, #2294/#2295, #2299/#2300, `docs/code-signing.md`, `.github/workflows/release.yml`, `scripts/sign-windows-payload.ps1`, `scripts/windows-signature-cache.ps1`, `scripts/print-windows-signables.ts`, and `scripts/stage-signed-nsis-toolset.ps1`.

## Fix

- Adds `scripts/assert-windows-signature-cache.ps1`.
- Persists `windows-signing-cache-state.json` as a GitHub release asset so comparison state does not depend on `actions/cache` working.
- Downloads the previous published release's state before the Windows cache restore.
- Computes a stable manifest hash from `windows-signature-cache-manifest.tsv` using pre-sign content hashes plus workspace-relative paths.
- Immediately after embedded-runtime signing, fails the Windows build if the manifest matches the previous release but fresh embedded-runtime signatures exceed `WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED` (default `25`).
- Uploads the current state artifact with the release for the next release's comparison.
- Leaves `MAX_SIGNATURES` warning-only, so #2821's release-continuity behavior is preserved.

## Networked path

No Seren publisher/API path is changed; this is release CI, not a UI feature.

Changed outbound GitHub API path in `.github/workflows/release.yml`:

- `GET /repos/{owner}/{repo}/releases` via `github.rest.repos.listReleases` to find the previous published release.
- `GET /repos/{owner}/{repo}/releases/{release_id}/assets` via `github.rest.repos.listReleaseAssets` to find `windows-signing-cache-state.json`.
- `GET /repos/{owner}/{repo}/releases/assets/{asset_id}` with `Accept: application/octet-stream` via `github.request` to download the prior state.

Live verification performed against `serenorg/seren-desktop`: latest published release `v3.68.5` resolves by tag, release asset listing works, and an asset download with `Accept: application/octet-stream` returned `latest.json` content. Action tags verified live: `actions/cache@v6`, `actions/github-script@v9`, `actions/upload-artifact@v7`, and `actions/download-artifact@v8` all resolve.

Publish safety: the new state artifact is uploaded as `windows-signing-cache-state`, so the existing publish job uploads `windows-signing-cache-state.json` to the GitHub release. R2/updater steps only read `artifacts/update-*` and installer extension globs, so the state JSON does not enter updater metadata or R2 installer uploads.

## Validation

- `pnpm vitest run tests/unit/windows-signature-cache-gate.test.ts tests/unit/windows-signature-cache.test.ts tests/unit/windows-sign-overlay.test.ts` — 20 passed.
- PowerShell AST parse for `scripts/assert-windows-signature-cache.ps1`, `scripts/windows-signature-cache.ps1`, and `scripts/sign-windows-payload.ps1` — passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml` — passed.
- `git diff --check` and `git diff --cached --check` — passed.
- `pnpm exec biome check tests/unit/windows-signature-cache-gate.test.ts tests/unit/windows-sign-overlay.test.ts` — repo config ignored both paths and processed 0 files.

Functional walkthrough: exercised the cache gate against real local telemetry and manifest artifacts, with no mocked signer. The first run without previous state writes state and skips; a second run with the same manifest and `signed=534` fails with the explicit cache-regression error; a changed manifest with the same signed count skips the hard gate as expected.
