### PR TITLE
fix(release): persist Windows signature cache in R2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ env:
   # Hard gate for unchanged embedded-runtime releases: if the manifest matches
   # the previous release, a working signature cache should make this near zero.
   WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED: ${{ vars.WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED || '25' }}
+  # R2 prefix for the content-addressed signed Windows embedded-runtime blobs.
+  WINDOWS_SIGNATURE_CACHE_R2_PREFIX: windows-signature-cache/authenticode
 
 jobs:
   create-release:
@@ -494,16 +496,53 @@ jobs:
             fs.writeFileSync(outputPath, raw);
             core.notice(`Downloaded Windows signing cache state from ${previous.tag_name} to ${outputPath}.`);
 
-      - name: Restore Windows signature cache
+      - name: Setup AWS CLI for Windows signature cache
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
-        uses: actions/cache@v6
-        with:
-          path: .sig-cache/windows-authenticode
-          # Unique primary key + broad restore key: restore the newest prior
-          # content-addressed store, then save this run's newly signed misses.
-          key: win-sigcache-${{ github.run_id }}
-          restore-keys: |
-            win-sigcache-
+        shell: pwsh
+        run: |
+          $aws = Get-Command aws -ErrorAction SilentlyContinue
+          if (-not $aws) {
+            python -m pip install --user awscli
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "::error::Failed to install awscli for Windows signature cache restore/save."
+              exit $LASTEXITCODE
+            }
+            $scriptsDir = python -c "import os, site; print(os.path.join(site.USER_BASE, 'Scripts'))"
+            $env:PATH = "$scriptsDir;$env:PATH"
+            Add-Content -LiteralPath $env:GITHUB_PATH -Value $scriptsDir
+          }
+          aws --version
+
+      - name: Restore Windows signature cache from R2
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET_NAME }}
+        run: |
+          if (-not $env:AWS_ACCESS_KEY_ID -or -not $env:AWS_SECRET_ACCESS_KEY -or -not $env:AWS_ENDPOINT_URL -or -not $env:R2_BUCKET) {
+            Write-Host "::error::R2 credentials are required for the Windows signature cache."
+            exit 1
+          }
+          $cacheDir = ".sig-cache/windows-authenticode"
+          New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+          $source = "s3://$env:R2_BUCKET/$env:WINDOWS_SIGNATURE_CACHE_R2_PREFIX"
+          Write-Host "Restoring Windows signature cache from $source"
+          aws s3 sync $source $cacheDir `
+            --endpoint-url="$env:AWS_ENDPOINT_URL" `
+            --exclude "*" `
+            --include "*.signed" `
+            --no-progress `
+            --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::Failed to restore Windows signature cache from R2."
+            exit $LASTEXITCODE
+          }
+          $count = @(Get-ChildItem -LiteralPath $cacheDir -Filter "*.signed" -File -ErrorAction SilentlyContinue).Count
+          Write-Host "Windows signature cache: restored $count signed blob(s) from R2."
 
       # Discover the signable set with the tested cross-platform selector, then
       # sign it throttled to stay under SSL.com's per-minute rate limit (#2282).
@@ -535,6 +574,41 @@ jobs:
             -CacheDir .sig-cache/windows-authenticode `
             -Manifest windows-signature-cache-manifest.tsv `
             -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT
+
+      - name: Save Windows signature cache to R2
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET_NAME }}
+        run: |
+          if (-not $env:AWS_ACCESS_KEY_ID -or -not $env:AWS_SECRET_ACCESS_KEY -or -not $env:AWS_ENDPOINT_URL -or -not $env:R2_BUCKET) {
+            Write-Host "::error::R2 credentials are required for the Windows signature cache."
+            exit 1
+          }
+          $cacheDir = ".sig-cache/windows-authenticode"
+          $count = @(Get-ChildItem -LiteralPath $cacheDir -Filter "*.signed" -File -ErrorAction SilentlyContinue).Count
+          if ($count -eq 0) {
+            Write-Host "::warning::No Windows signature cache blobs exist to upload to R2."
+            exit 0
+          }
+          $target = "s3://$env:R2_BUCKET/$env:WINDOWS_SIGNATURE_CACHE_R2_PREFIX"
+          Write-Host "Saving $count Windows signature cache blob(s) to $target"
+          aws s3 sync $cacheDir $target `
+            --endpoint-url="$env:AWS_ENDPOINT_URL" `
+            --exclude "*" `
+            --include "*.signed" `
+            --size-only `
+            --no-progress `
+            --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::Failed to save Windows signature cache to R2."
+            exit $LASTEXITCODE
+          }
+          Write-Host "Windows signature cache: R2 save completed."
 
       - name: Assert Windows signature cache hit budget
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -39,6 +39,10 @@ Add these secrets to the repository settings (Settings → Secrets → Actions):
 | `ES_USERNAME` | SSL.com eSigner account username |
 | `ES_PASSWORD` | SSL.com eSigner account password |
 | `ES_TOTP_SECRET` | SSL.com eSigner TOTP seed used by the CKA login step |
+| `R2_ACCESS_KEY_ID` | Cloudflare R2 access key used by the release workflow to restore/save the Windows signature cache and publish release artifacts |
+| `R2_SECRET_ACCESS_KEY` | Cloudflare R2 secret key used with `R2_ACCESS_KEY_ID` |
+| `R2_ENDPOINT` | Cloudflare R2 S3-compatible endpoint used by AWS CLI |
+| `R2_BUCKET_NAME` | Cloudflare R2 bucket used for release artifacts and the Windows signature cache |
 
 ### Release Variables
 
@@ -133,8 +137,12 @@ the artifact that embeds it is produced:
    a content-addressed Authenticode cache (`#2823`): before signing, unchanged
    files are restored from cache only when the cached blob has a `Valid`
    signature from the expected certificate thumbprint; after signing, newly
-   signed cache misses are saved by their pre-sign SHA-256. The signer still
-   owns the actual skip/sign/budget telemetry behavior.
+   signed cache misses are saved by their pre-sign SHA-256. The signed blob
+   store lives in Cloudflare R2 under
+   `windows-signature-cache/authenticode/`, not `actions/cache`, because
+   GitHub Actions caches created on one release tag cannot be restored by the
+   next release tag. The signer still owns the actual skip/sign/budget
+   telemetry behavior.
 
 2. **NSIS stock plugin DLLs** (`#2237`, `#2299`) — `System.dll`, `nsExec.dll`,
    `StartMenu.dll`, and `nsDialogs.dll` ship inside the `tauri-bundler` NSIS
@@ -176,7 +184,15 @@ The embedded-runtime signature cache should make the second release with an
 unchanged runtime report most of that large payload as skipped already valid,
 because cached signed binaries are restored before `sign-windows-payload.ps1`
 runs. A cold cache should behave the same as the pre-cache path, then populate
-the cache for later releases.
+the R2 cache for later releases.
+
+The workflow installs AWS CLI on the Windows runner only when needed, syncs
+`*.signed` blobs from `s3://$R2_BUCKET_NAME/windows-signature-cache/authenticode`
+before the PowerShell cache restore, and syncs the content-addressed cache back
+to the same R2 prefix after signing using `AWS_DEFAULT_REGION=auto`.
+`scripts/windows-signature-cache.ps1` still verifies every restored blob with
+`Get-AuthenticodeSignature` and the loaded eSigner certificate thumbprint
+before overwriting staged runtime files.
 
 ### Signature cache hit gate (release CI, hard-fail)
 

--- a/scripts/assert-windows-signature-cache.ps1
+++ b/scripts/assert-windows-signature-cache.ps1
@@ -226,7 +226,7 @@ Write-CurrentState -Path $OutputState -State $state
 
 if ($status -eq "failed_unchanged_manifest_over_floor") {
   Write-Host "::error::Windows signature cache regression: embedded-runtime manifest hash $currentHash matches the previous release, but $($telemetrySummary.embedded_signed) embedded-runtime file(s) were freshly signed; expected <= $MaxSignedWhenUnchanged."
-  Write-Host "::error::Inspect telemetry '$TelemetryFile', cache manifest '$Manifest', previous state '$PreviousState', and current state '$OutputState'. The actions/cache restore may be broken or returning an empty cache."
+  Write-Host "::error::Inspect telemetry '$TelemetryFile', cache manifest '$Manifest', previous state '$PreviousState', and current state '$OutputState'. The R2 signature-cache restore may be broken or returning an empty cache."
   exit 1
 }
 

--- a/scripts/windows-signature-cache.ps1
+++ b/scripts/windows-signature-cache.ps1
@@ -6,7 +6,7 @@ param(
   [Parameter(Mandatory = $true)][ValidateSet("restore", "save")][string]$Mode,
   # Newline-delimited signable set produced by scripts/print-windows-signables.ts.
   [Parameter(Mandatory = $true)][string]$ListFile,
-  # Persistent cache directory restored/saved by actions/cache.
+  # Persistent cache directory restored/saved by the release workflow's R2 sync.
   [Parameter(Mandatory = $true)][string]$CacheDir,
   # Pre-sign hash manifest written by restore and consumed by save.
   [Parameter(Mandatory = $true)][string]$Manifest,

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -129,25 +129,34 @@ describe("release workflow contract", () => {
     expect(workflow).toContain("Audit Windows payload signature coverage");
   });
 
-  it("wraps the embedded-runtime signer with the Windows signature cache (#2823)", () => {
-    expect(workflow).toContain("Restore Windows signature cache");
-    expect(workflow).toContain("uses: actions/cache@v6");
+  it("wraps the embedded-runtime signer with the R2-backed Windows signature cache (#2823/#2883)", () => {
+    expect(workflow).toContain("WINDOWS_SIGNATURE_CACHE_R2_PREFIX");
+    expect(workflow).toContain("windows-signature-cache/authenticode");
+    expect(workflow).toContain("Setup AWS CLI for Windows signature cache");
+    expect(workflow).toContain("Restore Windows signature cache from R2");
+    expect(workflow).toContain("Save Windows signature cache to R2");
     expect(workflow).toContain(".sig-cache/windows-authenticode");
-    expect(workflow).toContain("key: win-sigcache-${{ github.run_id }}");
-    expect(workflow).toContain("win-sigcache-");
+    expect(workflow).toContain("aws s3 sync");
+    expect(workflow).toContain("--size-only");
     expect(workflow).toContain("windows-signature-cache.ps1");
+    expect(workflow).not.toContain("key: win-sigcache-${{ github.run_id }}");
+    expect(workflow).not.toContain("win-sigcache-");
 
-    const cacheActionAt = workflow.indexOf("Restore Windows signature cache");
+    const awsCliAt = workflow.indexOf("Setup AWS CLI for Windows signature cache");
+    const r2RestoreAt = workflow.indexOf("Restore Windows signature cache from R2");
     const signStepAt = workflow.indexOf("Sign embedded runtime (Windows)");
     const cacheRestoreAt = workflow.indexOf("-Mode restore", signStepAt);
     const signerAt = workflow.indexOf("sign-windows-payload.ps1", cacheRestoreAt);
     const cacheSaveAt = workflow.indexOf("-Mode save", signerAt);
+    const r2SaveAt = workflow.indexOf("Save Windows signature cache to R2");
 
-    expect(cacheActionAt).toBeGreaterThanOrEqual(0);
-    expect(signStepAt).toBeGreaterThan(cacheActionAt);
+    expect(awsCliAt).toBeGreaterThanOrEqual(0);
+    expect(r2RestoreAt).toBeGreaterThan(awsCliAt);
+    expect(signStepAt).toBeGreaterThan(r2RestoreAt);
     expect(cacheRestoreAt).toBeGreaterThan(signStepAt);
     expect(signerAt).toBeGreaterThan(cacheRestoreAt);
     expect(cacheSaveAt).toBeGreaterThan(signerAt);
+    expect(r2SaveAt).toBeGreaterThan(cacheSaveAt);
   });
 
   it("hard-gates unchanged embedded-runtime signature cache misses before Windows artifacts upload (#2882)", () => {
@@ -161,8 +170,9 @@ describe("release workflow contract", () => {
 
     const stageAt = workflow.indexOf("Stage embedded runtime for signing (Windows)");
     const fetchStateAt = workflow.indexOf("Fetch previous Windows signing cache state");
-    const cacheRestoreAt = workflow.indexOf("Restore Windows signature cache");
+    const cacheRestoreAt = workflow.indexOf("Restore Windows signature cache from R2");
     const signAt = workflow.indexOf("Sign embedded runtime (Windows)");
+    const cacheSaveAt = workflow.indexOf("Save Windows signature cache to R2");
     const assertAt = workflow.indexOf("Assert Windows signature cache hit budget");
     const buildAt = workflow.indexOf("Build Tauri app (signed, Windows)");
     const uploadWindowsAt = workflow.indexOf("Upload Windows NSIS");
@@ -172,7 +182,8 @@ describe("release workflow contract", () => {
     expect(fetchStateAt).toBeGreaterThan(stageAt);
     expect(cacheRestoreAt).toBeGreaterThan(fetchStateAt);
     expect(signAt).toBeGreaterThan(cacheRestoreAt);
-    expect(assertAt).toBeGreaterThan(signAt);
+    expect(cacheSaveAt).toBeGreaterThan(signAt);
+    expect(assertAt).toBeGreaterThan(cacheSaveAt);
     expect(assertAt).toBeLessThan(buildAt);
     expect(uploadStateAt).toBeGreaterThan(uploadWindowsAt);
   });


### PR DESCRIPTION
Closes #2883.

## Audit

The broken path is the Windows tag-release signing cache introduced by #2824 and guarded by #2882:

1. `.github/workflows/release.yml` stages `src-tauri/embedded-runtime` and `src-tauri/mcp-servers` on the Windows release leg.
2. `scripts/print-windows-signables.ts ... > sign-targets.txt` emits the embedded-runtime PE signable set.
3. `scripts/windows-signature-cache.ps1 -Mode restore` computes the pre-sign content manifest and restores any trusted signed blobs already present under `.sig-cache/windows-authenticode`.
4. `scripts/sign-windows-payload.ps1 -ListFile sign-targets.txt` skips restored valid files, signs misses through SSL.com eSigner CKA, and writes JSONL telemetry.
5. `scripts/windows-signature-cache.ps1 -Mode save` writes newly signed blobs under their pre-sign SHA-256.
6. Before this PR, the only cross-run persistence for those blobs was `actions/cache@v6` with `key: win-sigcache-${{ github.run_id }}` and `restore-keys: win-sigcache-`.

GitHub's official cache documentation says cache restore searches the current branch/tag and then the default branch, subject to scope restrictions, and specifically states caches created for one tag are not accessible to another tag. That matches the production evidence in #2883: every release tag restored `0 of 729` and re-signed ~534 files despite prior successful cache saves.

Prior issues/PRs/docs reviewed: #2818, #2820, #2821/#2822, #2823/#2824, #2882/#2884, #2235/#2241, #2294/#2295, #2299/#2300, `.github/workflows/release.yml`, `docs/code-signing.md`, `scripts/windows-signature-cache.ps1`, `scripts/assert-windows-signature-cache.ps1`, `scripts/sign-windows-payload.ps1`, and GitHub's dependency-cache reference.

## Fix

- Removes the tag-scoped `actions/cache` persistence from the Windows signature cache path.
- Adds `WINDOWS_SIGNATURE_CACHE_R2_PREFIX=windows-signature-cache/authenticode`.
- Installs AWS CLI on the Windows runner only when needed.
- Restores `*.signed` blobs from `s3://$R2_BUCKET_NAME/windows-signature-cache/authenticode` before running the existing PowerShell cache restore.
- Keeps `scripts/windows-signature-cache.ps1` as the trust boundary: every restored blob must still be `Valid` and signed by the expected thumbprint before it overwrites staged runtime bytes.
- Saves the post-sign content-addressed cache back to the same R2 prefix with `aws s3 sync --size-only` after newly signed misses are cached locally.
- Leaves the #2882 hard gate in place after the R2 save, so unchanged-runtime cache misses still fail before Windows artifacts build/publish.
- Avoids adding a giant cache archive to GitHub release assets, so the existing publish-release traversal and updater/R2 artifact publishing are not inflated by the signature cache.

## Networked path

No Seren publisher/API path is changed; this is release CI, not a UI feature.

Changed outbound path:

- `aws s3 sync s3://$R2_BUCKET_NAME/$WINDOWS_SIGNATURE_CACHE_R2_PREFIX .sig-cache/windows-authenticode --endpoint-url=$R2_ENDPOINT ...` on the Windows build leg before signing.
- `aws s3 sync .sig-cache/windows-authenticode s3://$R2_BUCKET_NAME/$WINDOWS_SIGNATURE_CACHE_R2_PREFIX --endpoint-url=$R2_ENDPOINT --size-only ...` after signing.

This uses Cloudflare R2's S3-compatible API through AWS CLI. Official Cloudflare docs confirm AWS CLI works with R2 via a custom `--endpoint-url` and `region=auto`; official Cloudflare S3 API compatibility docs confirm R2 implements the S3 API. No R2 credentials are available in local dev, so live R2 read/write proof must happen in the release workflow.

Existing GitHub API paths from #2882 remain unchanged: the workflow still downloads the previous release's `windows-signing-cache-state.json` and uploads the current one as a GitHub release asset.

Publish safety: this PR does not add any new GitHub release artifact for cache blobs. The cache lives in R2 under its own prefix. The existing publish job still uploads normal release artifacts and updater manifests from `artifacts/update-*` and installer extension globs.

## Validation

- `HOME=$(mktemp -d) pnpm vitest run tests/unit/windows-sign-overlay.test.ts tests/unit/windows-signature-cache.test.ts tests/unit/windows-signature-cache-gate.test.ts` — 20 passed.
- `HOME=$(mktemp -d) pwsh -NoProfile` AST parse for `scripts/assert-windows-signature-cache.ps1`, `scripts/windows-signature-cache.ps1`, and `scripts/sign-windows-payload.ps1` — passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml` — passed.
- `git diff --check` and `git diff --cached --check` — passed.
- `pnpm exec biome check tests/unit/windows-sign-overlay.test.ts tests/unit/windows-signature-cache.test.ts tests/unit/windows-signature-cache-gate.test.ts` — repo config ignored these paths and processed 0 files.

Local note: the default local PowerShell home currently crashes before script execution with a .NET `FileLoadException`; running with a clean temporary `HOME` executes the PowerShell tests and parser successfully. CI Windows should not inherit that local machine state.

## Required production proof after merge

#2883's acceptance criteria require two real consecutive release tags. The expected proof is:

- Release N: cold or partially warm R2 cache restores the available blobs, signs misses, and saves `.signed` blobs to R2.
- Release N+1 with unchanged embedded-runtime manifest: `scripts/windows-signature-cache.ps1` restores most/all embedded-runtime blobs from R2, `scripts/sign-windows-payload.ps1` reports embedded-runtime `signed` near zero, and the #2882 gate passes without raising `WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED`.
