### PR TITLE
Fix paired Codex executor permission mode

### DIFF
--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -566,7 +566,9 @@ export function createPairedRuntime({ emit, inner }) {
     const info = await inner.spawnSession({
       ...base,
       agentType: ROLE_DEFS.executor.agentType,
-      approvalPolicy: params.approvalPolicy,
+      // Match direct Codex sessions: paired executor work should start in
+      // Permission Mode: Auto, not inherit Claude's default on-request policy.
+      approvalPolicy: "on-failure",
       sandboxMode: params.sandboxMode,
       networkEnabled: params.networkEnabled,
     });

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -164,7 +164,11 @@ function modeFromApprovalPolicy(approvalPolicy) {
 }
 
 function sandboxFromMode(sandboxMode, networkEnabled) {
-  if (networkEnabled || sandboxMode === "danger-full-access") {
+  if (
+    networkEnabled ||
+    sandboxMode === "danger-full-access" ||
+    sandboxMode === "full-access"
+  ) {
     return "danger-full-access";
   }
   if (sandboxMode === "read-only") {
@@ -1864,3 +1868,9 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     stopLmStudioServer: lmStudioRuntime.stopServer,
   };
 }
+
+export {
+  codexApprovalPolicy as _codexApprovalPolicy,
+  modeFromApprovalPolicy as _modeFromApprovalPolicy,
+  sandboxFromMode as _sandboxFromMode,
+};

--- a/tests/unit/codex-runtime-permission-defaults.test.ts
+++ b/tests/unit/codex-runtime-permission-defaults.test.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Focused guards for Codex permission/sandbox mapping used by paired executor spawns.
+// ABOUTME: Pins #2886 so app settings values produce the intended Codex thread/start params.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/providers.mjs",
+  import.meta.url,
+).href;
+const {
+  _codexApprovalPolicy: codexApprovalPolicy,
+  _modeFromApprovalPolicy: modeFromApprovalPolicy,
+  _sandboxFromMode: sandboxFromMode,
+} = await import(/* @vite-ignore */ modulePath);
+
+describe("Codex permission defaults (#2886)", () => {
+  it("maps the paired executor policy to Permission Mode: Auto", () => {
+    expect(modeFromApprovalPolicy("on-failure")).toBe("auto");
+    expect(codexApprovalPolicy("auto")).toBe("never");
+  });
+
+  it("keeps explicitly ask-shaped policies on Suggest", () => {
+    expect(modeFromApprovalPolicy("on-request")).toBe("ask");
+    expect(modeFromApprovalPolicy("untrusted")).toBe("ask");
+    expect(codexApprovalPolicy("ask")).toBe("on-request");
+  });
+});
+
+describe("Codex sandbox mapping (#2886)", () => {
+  it("honors the app settings full-access value", () => {
+    expect(sandboxFromMode("full-access", false)).toBe("danger-full-access");
+  });
+
+  it("keeps legacy runtime full-access and network-enabled sessions full access", () => {
+    expect(sandboxFromMode("danger-full-access", false)).toBe(
+      "danger-full-access",
+    );
+    expect(sandboxFromMode("workspace-write", true)).toBe("danger-full-access");
+  });
+});

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -171,6 +171,24 @@ describe("paired runtime — spawn", () => {
     expect(spawnTypes).toContain("codex");
   });
 
+  it("starts the Codex executor in Auto while leaving Claude planner on its own policy (#2886)", async () => {
+    await spawnPaired(h, {
+      approvalPolicy: "on-request",
+      sandboxMode: "workspace-write",
+    });
+
+    const claudeSpawn = h.inner.spawnSession.mock.calls.find(
+      (c) => c[0].agentType === "claude-code",
+    )?.[0];
+    const codexSpawn = h.inner.spawnSession.mock.calls.find(
+      (c) => c[0].agentType === "codex",
+    )?.[0];
+
+    expect(claudeSpawn?.approvalPolicy).toBe("on-request");
+    expect(codexSpawn?.approvalPolicy).toBe("on-failure");
+    expect(codexSpawn?.sandboxMode).toBe("workspace-write");
+  });
+
   it("returns a composite agentSessionId carrying both inner remote ids", async () => {
     const info = await spawnPaired(h);
     const composite = JSON.parse(String(info.agentSessionId));


### PR DESCRIPTION
Fixes #2886

## Summary
- Start the Codex executor in Claude + Codex paired sessions with the same Auto permission policy used by direct Codex sessions.
- Preserve Claude planner/reviewer permission behavior instead of applying its on-request default to Codex.
- Treat the app settings `full-access` sandbox value as Codex `danger-full-access`.

## Audited code paths
- `src/stores/agent.store.ts` paired provider spawn settings
- `src/services/providers.ts` provider spawn RPC forwarding
- `bin/browser-local/paired-runtime.mjs` Claude/Codex inner session spawning
- `bin/browser-local/providers.mjs` Codex permission and sandbox mapping

## Networked feature path
No outbound publisher/API path exists for the changed app behavior. The UI action routes locally through provider runtime WebSocket RPC (`provider_spawn`) into local Claude/Codex runtime processes. GitHub publisher `github-api` was used only for issue/PR workflow via `POST /repos/serenorg/seren-desktop/pulls`.

## Validation
- `pnpm vitest run tests/unit/paired-runtime.test.ts tests/unit/codex-runtime-permission-defaults.test.ts tests/unit/claude-runtime-default-permission-mode.test.ts`
- `pnpm test`
- `pnpm build`
- Live provider-runtime smoke with real Claude + Codex CLIs: paired spawn with `approvalPolicy: on-request`, executor file write completed, `permissionEvents: 0`.
- Live Tauri validation walkthrough: `pnpm validate:walkthrough paired-agent-recovery` -> `ok: true`.