### PR TITLE
fix(agent): add Codex fast mode service tier

### DIFF
--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -281,6 +281,7 @@ export function createPairedRuntime({ emit, inner }) {
       configOptions: undefined,
       pinnedModelId: null,
       pinnedEffort: null,
+      pinnedServiceTier: null,
       notice: null,
       turnText: "",
       lastTurnMeta: null,
@@ -306,6 +307,7 @@ export function createPairedRuntime({ emit, inner }) {
       configOptions: roleState.configOptions,
       pinnedModelId: roleState.pinnedModelId,
       pinnedEffort: roleState.pinnedEffort,
+      pinnedServiceTier: roleState.pinnedServiceTier,
       notice: roleState.notice,
     };
   }
@@ -595,6 +597,19 @@ export function createPairedRuntime({ emit, inner }) {
       } catch {
         roleState.pinnedEffort = null;
         roleState.notice = `Pinned effort ${config.effort} is not supported by the selected Codex model. Using its default effort instead.`;
+      }
+    }
+    if (config.serviceTier) {
+      try {
+        await inner.updateSessionConfigOption({
+          sessionId: innerSessionId,
+          configId: "fast_mode",
+          valueId: "on",
+        });
+        roleState.pinnedServiceTier = config.serviceTier;
+      } catch {
+        roleState.pinnedServiceTier = null;
+        roleState.notice = `Pinned Codex service tier ${config.serviceTier} is not supported by the selected model. Using its default speed instead.`;
       }
     }
     return info;
@@ -955,6 +970,13 @@ export function createPairedRuntime({ emit, inner }) {
       // selector responsive until the runtime echo lands.
       const option = (roleState.configOptions ?? []).find(
         (o) => o.id === "reasoning_effort",
+      );
+      if (option) option.currentValue = valueId;
+    }
+    if (configId === "fast_mode") {
+      roleState.pinnedServiceTier = valueId === "on" ? "fast" : null;
+      const option = (roleState.configOptions ?? []).find(
+        (o) => o.id === "fast_mode",
       );
       if (option) option.currentValue = valueId;
     }

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -323,33 +323,87 @@ function createCodexSessionRecord({
     currentModelId: null,
     currentModeId,
     reasoningEffort: "medium",
+    serviceTier: null,
     latestTurnUsage: undefined,
   };
+}
+
+function normalizeServiceTier(value) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function normalizeServiceTiers(record) {
+  const tiers = [];
+  const seen = new Set();
+  const addTier = (id, name, description) => {
+    if (typeof id !== "string" || id.length === 0 || seen.has(id)) {
+      return;
+    }
+    seen.add(id);
+    tiers.push({
+      id,
+      name: typeof name === "string" && name.length > 0 ? name : id,
+      description:
+        typeof description === "string" && description.length > 0
+          ? description
+          : null,
+    });
+  };
+
+  if (Array.isArray(record?.serviceTiers)) {
+    for (const tier of record.serviceTiers) {
+      addTier(tier?.id, tier?.name, tier?.description);
+    }
+  }
+
+  if (Array.isArray(record?.additionalSpeedTiers)) {
+    for (const tier of record.additionalSpeedTiers) {
+      addTier(tier, tier, null);
+    }
+  }
+
+  return tiers;
+}
+
+function getFastServiceTier(modelRecord) {
+  return (
+    modelRecord?.serviceTiers?.find((tier) => tier.id === "fast") ?? null
+  );
 }
 
 function normalizeModelRecords(result) {
   const data = Array.isArray(result?.data) ? result.data : [];
   return data
     .filter((record) => record && record.hidden !== true)
-    .map((record) => ({
-      modelId: record.id ?? record.model,
-      name: record.displayName ?? record.id ?? record.model ?? "Unknown model",
-      description: record.description ?? undefined,
-      defaultReasoningEffort:
-        record.defaultReasoningEffort ??
-        record.default_reasoning_effort ??
-        "medium",
-      supportedReasoningEfforts: Array.isArray(record.supportedReasoningEfforts)
-        ? record.supportedReasoningEfforts
-            .map((effort) => ({
-              value: effort.reasoningEffort,
-              name: effort.reasoningEffort,
-              description: effort.description ?? undefined,
-            }))
-            .filter((effort) => typeof effort.value === "string")
-        : [],
-      isDefault: record.isDefault === true,
-    }))
+    .map((record) => {
+      const serviceTiers = normalizeServiceTiers(record);
+      return {
+        modelId: record.id ?? record.model,
+        name:
+          record.displayName ?? record.id ?? record.model ?? "Unknown model",
+        description: record.description ?? undefined,
+        defaultReasoningEffort:
+          record.defaultReasoningEffort ??
+          record.default_reasoning_effort ??
+          "medium",
+        supportedReasoningEfforts: Array.isArray(
+          record.supportedReasoningEfforts,
+        )
+          ? record.supportedReasoningEfforts
+              .map((effort) => ({
+                value: effort.reasoningEffort,
+                name: effort.reasoningEffort,
+                description: effort.description ?? undefined,
+              }))
+              .filter((effort) => typeof effort.value === "string")
+          : [],
+        defaultServiceTier: normalizeServiceTier(
+          record.defaultServiceTier ?? record.default_service_tier,
+        ),
+        serviceTiers,
+        isDefault: record.isDefault === true,
+      };
+    })
     .filter((record) => typeof record.modelId === "string");
 }
 
@@ -369,10 +423,11 @@ function buildAvailableModels(session) {
     modelId: record.modelId,
     name: record.name,
     description: record.description,
+    supportsFastMode: getFastServiceTier(record) !== null,
   }));
 }
 
-function buildConfigOptions(session) {
+function buildReasoningEffortConfigOption(session) {
   const modelRecord = getSelectedModelRecord(session);
   const efforts =
     modelRecord?.supportedReasoningEfforts?.length > 0
@@ -385,7 +440,7 @@ function buildConfigOptions(session) {
         ];
 
   if (efforts.length === 0) {
-    return [];
+    return null;
   }
 
   const currentValue = efforts.some(
@@ -396,20 +451,84 @@ function buildConfigOptions(session) {
 
   session.reasoningEffort = currentValue;
 
-  return [
-    {
-      id: "reasoning_effort",
-      name: "Reasoning Effort",
-      description: "Controls how much reasoning Codex uses on future turns.",
-      type: "select",
-      currentValue,
-      options: efforts.map((option) => ({
-        value: option.value,
-        name: option.name,
-        description: option.description ?? null,
-      })),
-    },
-  ];
+  return {
+    id: "reasoning_effort",
+    name: "Reasoning Effort",
+    description: "Controls how much reasoning Codex uses on future turns.",
+    type: "select",
+    currentValue,
+    options: efforts.map((option) => ({
+      value: option.value,
+      name: option.name,
+      description: option.description ?? null,
+    })),
+  };
+}
+
+function buildFastModeConfigOption(session) {
+  const fastTier = getFastServiceTier(getSelectedModelRecord(session));
+  if (!fastTier) {
+    return null;
+  }
+
+  return {
+    id: "fast_mode",
+    name: "Fast Mode",
+    description: "Uses the Codex Fast service tier for future turns.",
+    type: "select",
+    currentValue: session.serviceTier === fastTier.id ? "on" : "off",
+    options: [
+      {
+        value: "on",
+        name: "On",
+        description: fastTier.description,
+      },
+      {
+        value: "off",
+        name: "Off",
+        description: "Use the model's standard service tier.",
+      },
+    ],
+  };
+}
+
+function buildConfigOptions(session) {
+  const options = [];
+  const reasoningEffortOption = buildReasoningEffortConfigOption(session);
+  if (reasoningEffortOption) {
+    options.push(reasoningEffortOption);
+  }
+  const fastModeOption = buildFastModeConfigOption(session);
+  if (fastModeOption) {
+    options.push(fastModeOption);
+  }
+  return options;
+}
+
+function codexServiceTierFromFastModeValue(valueId, session) {
+  switch (valueId) {
+    case "on": {
+      const fastTier = getFastServiceTier(getSelectedModelRecord(session));
+      if (!fastTier) {
+        throw new Error("Fast mode is not supported by the selected Codex model.");
+      }
+      return fastTier.id;
+    }
+    case "off":
+      return null;
+    default:
+      throw new Error(`Unsupported fast mode value: ${valueId}`);
+  }
+}
+
+function buildCodexTurnStartParams(session, prompt, context) {
+  return {
+    threadId: session.agentSessionId,
+    input: buildCodexTurnInput(prompt, context),
+    ...(session.currentModelId ? { model: session.currentModelId } : {}),
+    ...(session.reasoningEffort ? { effort: session.reasoningEffort } : {}),
+    ...(session.serviceTier ? { serviceTier: session.serviceTier } : {}),
+  };
 }
 
 function buildSessionStatus(session, status = session.status) {
@@ -1256,6 +1375,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         approvalPolicy: codexApprovalPolicy(resolvedMode),
         sandbox: resolvedSandbox,
         experimentalRawEvents: false,
+        ...(session.serviceTier ? { serviceTier: session.serviceTier } : {}),
       };
 
       let threadResult;
@@ -1321,6 +1441,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         threadResult?.reasoningEffort ??
         getSelectedModelRecord(session)?.defaultReasoningEffort ??
         "medium";
+      session.serviceTier = normalizeServiceTier(threadResult?.serviceTier);
 
       if (resumedExistingThread && session.agentSessionId) {
         let replayThread = threadResult?.thread;
@@ -1409,14 +1530,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       const response = await sendRequest(
         session,
         "turn/start",
-        {
-          threadId: session.agentSessionId,
-          input: buildCodexTurnInput(prompt, context),
-          ...(session.currentModelId ? { model: session.currentModelId } : {}),
-          ...(session.reasoningEffort
-            ? { effort: session.reasoningEffort }
-            : {}),
-        },
+        buildCodexTurnStartParams(session, prompt, context),
         20_000,
       );
 
@@ -1745,6 +1859,23 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     }
 
     session.currentModelId = targetModel.modelId;
+    if (
+      session.serviceTier &&
+      !targetModel.serviceTiers.some((tier) => tier.id === session.serviceTier)
+    ) {
+      if (session.agentSessionId) {
+        await sendRequest(
+          session,
+          "thread/settings/update",
+          {
+            threadId: session.agentSessionId,
+            serviceTier: null,
+          },
+          10_000,
+        );
+      }
+      session.serviceTier = null;
+    }
     const supportsCurrentEffort = targetModel.supportedReasoningEfforts.some(
       (option) => option.value === session.reasoningEffort,
     );
@@ -1800,11 +1931,35 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       }
       return claudeRuntime.setConfigOption({ sessionId, configId, valueId });
     }
+
+    if (configId === "fast_mode") {
+      const serviceTier = codexServiceTierFromFastModeValue(valueId, session);
+      if (session.agentSessionId) {
+        await sendRequest(
+          session,
+          "thread/settings/update",
+          {
+            threadId: session.agentSessionId,
+            serviceTier,
+          },
+          10_000,
+        );
+      }
+      session.serviceTier = serviceTier;
+      emit("provider://config-options-update", {
+        sessionId,
+        configOptions: buildConfigOptions(session),
+      });
+      return null;
+    }
+
     if (configId !== "reasoning_effort") {
       return null;
     }
 
-    const configOption = buildConfigOptions(session)[0];
+    const configOption = buildConfigOptions(session).find(
+      (option) => option.id === "reasoning_effort",
+    );
     if (
       !configOption ||
       !configOption.options.some((option) => option.value === valueId)
@@ -1870,7 +2025,11 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
 }
 
 export {
+  buildCodexTurnStartParams as _buildCodexTurnStartParams,
+  buildSessionStatus as _buildCodexSessionStatus,
+  codexServiceTierFromFastModeValue as _codexServiceTierFromFastModeValue,
   codexApprovalPolicy as _codexApprovalPolicy,
   modeFromApprovalPolicy as _modeFromApprovalPolicy,
+  normalizeModelRecords as _normalizeCodexModelRecords,
   sandboxFromMode as _sandboxFromMode,
 };

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -111,6 +111,7 @@ import { DiffCard } from "./DiffCard";
 import { ImageAttachmentBar } from "./ImageAttachmentBar";
 import { OAuthAccountSwitcher } from "./OAuthAccountSwitcher";
 import { PairedEffortSelector } from "./PairedEffortSelector";
+import { PairedFastModeSelector } from "./PairedFastModeSelector";
 import { PairedModelSelector } from "./PairedModelSelector";
 import { PlanHeader } from "./PlanHeader";
 import { SkillsButton } from "./SkillsButton";
@@ -2249,6 +2250,10 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                     pairedRole="planner"
                   />
                   <PairedEffortSelector
+                    session={threadSession()}
+                    pairedRole="executor"
+                  />
+                  <PairedFastModeSelector
                     session={threadSession()}
                     pairedRole="executor"
                   />

--- a/src/components/chat/PairedFastModeSelector.tsx
+++ b/src/components/chat/PairedFastModeSelector.tsx
@@ -1,24 +1,31 @@
-// ABOUTME: Toggle for agent fast mode when the active model supports it.
-// ABOUTME: Uses the generic provider config-option bridge.
+// ABOUTME: Role-scoped fast-mode toggle for paired Claude + Codex threads.
+// ABOUTME: Renders only when that role reports a fast_mode option and model support.
 
 import type { Component } from "solid-js";
 import { Show } from "solid-js";
+import type { PairedRole } from "@/services/providers";
 import { type ActiveSession, agentStore } from "@/stores/agent.store";
 
 interface Props {
   session: ActiveSession | null;
+  pairedRole: PairedRole;
 }
 
-export const AgentFastModeSelector: Component<Props> = (props) => {
+const ROLE_LABELS: Record<PairedRole, string> = {
+  planner: "Planner fast",
+  executor: "Executor fast",
+};
+
+export const PairedFastModeSelector: Component<Props> = (props) => {
+  const roleStatus = () => props.session?.paired?.[props.pairedRole] ?? null;
+
   const availableModels = () => {
-    const models = props.session?.availableModels;
+    const models = roleStatus()?.models?.availableModels;
     return Array.isArray(models) ? models : [];
   };
-  const displayModelId = () =>
-    props.session?.userSelectedModelId ?? props.session?.currentModelId;
 
   const currentModelSupportsFastMode = () => {
-    const id = displayModelId();
+    const id = roleStatus()?.models?.currentModelId;
     if (!id) return false;
     return (
       availableModels().find((model) => model.modelId === id)
@@ -27,7 +34,7 @@ export const AgentFastModeSelector: Component<Props> = (props) => {
   };
 
   const configOptions = () => {
-    const options = props.session?.configOptions;
+    const options = roleStatus()?.configOptions;
     return Array.isArray(options) ? options : [];
   };
 
@@ -45,7 +52,8 @@ export const AgentFastModeSelector: Component<Props> = (props) => {
 
   const toggleFastMode = () => {
     if (!option()) return;
-    agentStore.setConfigOption(
+    void agentStore.setPairedConfigOption(
+      props.pairedRole,
       "fast_mode",
       isOn() ? "off" : "on",
       props.session?.info.id,
@@ -80,7 +88,7 @@ export const AgentFastModeSelector: Component<Props> = (props) => {
             d="M13 3L4 14h7l-1 7 9-11h-7l1-7z"
           />
         </svg>
-        <span class="font-medium">Fast</span>
+        <span class="font-medium">{ROLE_LABELS[props.pairedRole]}</span>
       </button>
     </Show>
   );

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -245,12 +245,16 @@ export interface PairedRoleStatus {
       modelId: string;
       name: string;
       description?: string;
+      supportsFastMode?: boolean;
+      supportsAutoMode?: boolean;
+      supportsAdaptiveThinking?: boolean;
     }>;
   };
   configOptions?: SessionConfigOption[];
   /** Explicit user pick; null while floating on the provider default. */
   pinnedModelId?: string | null;
   pinnedEffort?: string | null;
+  pinnedServiceTier?: string | null;
   /** Inline status, e.g. pinned-model fallback or next-session effort timing. */
   notice?: string | null;
 }
@@ -276,8 +280,8 @@ export interface PairedTranscriptEvent {
 
 /** Per-role spawn configuration restored from the conversation row. */
 export interface PairedSpawnConfig {
-  planner?: { modelId?: string; effort?: string };
-  executor?: { modelId?: string; effort?: string };
+  planner?: { modelId?: string; effort?: string; serviceTier?: string };
+  executor?: { modelId?: string; effort?: string; serviceTier?: string };
 }
 
 export interface SessionStatusEvent {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -6190,10 +6190,15 @@ export const agentStore = {
 
     const roleConfig = (
       role: PairedStatus["planner"],
-    ): { modelId?: string; effort?: string } | undefined => {
+    ):
+      | { modelId?: string; effort?: string; serviceTier?: string }
+      | undefined => {
       const config = {
         ...(role.pinnedModelId ? { modelId: role.pinnedModelId } : {}),
         ...(role.pinnedEffort ? { effort: role.pinnedEffort } : {}),
+        ...(role.pinnedServiceTier
+          ? { serviceTier: role.pinnedServiceTier }
+          : {}),
       };
       return Object.keys(config).length > 0 ? config : undefined;
     };

--- a/tests/unit/agent-model-capability-badges.test.ts
+++ b/tests/unit/agent-model-capability-badges.test.ts
@@ -13,6 +13,10 @@ const fastSelectorSource = readFileSync(
   resolve("src/components/chat/AgentFastModeSelector.tsx"),
   "utf-8",
 );
+const pairedFastSelectorSource = readFileSync(
+  resolve("src/components/chat/PairedFastModeSelector.tsx"),
+  "utf-8",
+);
 const chatSource = readFileSync(
   resolve("src/components/chat/AgentChat.tsx"),
   "utf-8",
@@ -34,5 +38,11 @@ describe("#2058 agent model capability UI", () => {
     expect(fastSelectorSource).toContain('id === "fast_mode"');
     expect(fastSelectorSource).toContain("supportsFastMode");
     expect(fastSelectorSource).toMatch(/setConfigOption\(\s*"fast_mode"/);
+    expect(chatSource).toContain("PairedFastModeSelector");
+    expect(pairedFastSelectorSource).toContain('id === "fast_mode"');
+    expect(pairedFastSelectorSource).toContain("supportsFastMode");
+    expect(pairedFastSelectorSource).toMatch(
+      /setPairedConfigOption\(\s*props\.pairedRole,\s*"fast_mode"/,
+    );
   });
 });

--- a/tests/unit/agent-selector-partial-status.test.ts
+++ b/tests/unit/agent-selector-partial-status.test.ts
@@ -15,6 +15,9 @@ describe("agent selector partial-status guards (#2862)", () => {
   const agentModel = source("src/components/chat/AgentModelSelector.tsx");
   const pairedModel = source("src/components/chat/PairedModelSelector.tsx");
   const agentFastMode = source("src/components/chat/AgentFastModeSelector.tsx");
+  const pairedFastMode = source(
+    "src/components/chat/PairedFastModeSelector.tsx",
+  );
 
   it("does not dereference config option arrays directly in effort selectors", () => {
     for (const selector of [agentEffort, pairedEffort]) {
@@ -40,6 +43,7 @@ describe("agent selector partial-status guards (#2862)", () => {
     expect(agentFastMode).not.toContain(
       "props.session?.availableModels ?? []",
     );
+    expect(pairedFastMode).toContain("Array.isArray(models) ? models : []");
   });
 });
 
@@ -47,13 +51,21 @@ describe("configOptions non-array guards (#2869)", () => {
   const agentEffort = source("src/components/chat/AgentEffortSelector.tsx");
   const agentFastMode = source("src/components/chat/AgentFastModeSelector.tsx");
   const pairedEffort = source("src/components/chat/PairedEffortSelector.tsx");
+  const pairedFastMode = source(
+    "src/components/chat/PairedFastModeSelector.tsx",
+  );
   const agentStore = source("src/stores/agent.store.ts");
 
   it("normalizes configOptions before .find in every effort/fast-mode selector", () => {
     // `configOptions?.find(...)` only guards null/undefined; a truthy
     // non-array partial frame reaches `.find` and throws, tripping the
     // workspace-recovery boundary. Each reader must normalize to [] first.
-    for (const selector of [agentEffort, agentFastMode, pairedEffort]) {
+    for (const selector of [
+      agentEffort,
+      agentFastMode,
+      pairedEffort,
+      pairedFastMode,
+    ]) {
       expect(selector).toContain("Array.isArray(options) ? options : []");
       expect(selector).toContain("configOptions().find");
       expect(selector).not.toContain("configOptions?.find");

--- a/tests/unit/codex-fast-mode-config.test.ts
+++ b/tests/unit/codex-fast-mode-config.test.ts
@@ -1,0 +1,131 @@
+// ABOUTME: Critical guards for #2888 — Codex Fast Mode maps to app-server serviceTier.
+// ABOUTME: Keeps model service-tier metadata, config options, and turn payloads wired.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/providers.mjs",
+  import.meta.url,
+).href;
+const {
+  _buildCodexSessionStatus: buildCodexSessionStatus,
+  _buildCodexTurnStartParams: buildCodexTurnStartParams,
+  _codexServiceTierFromFastModeValue: codexServiceTierFromFastModeValue,
+  _normalizeCodexModelRecords: normalizeCodexModelRecords,
+} = await import(/* @vite-ignore */ modulePath);
+
+function modelListResult() {
+  return {
+    data: [
+      {
+        id: "gpt-5.5",
+        displayName: "GPT-5.5",
+        description: "Full Codex model",
+        hidden: false,
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "medium", description: "Balanced" },
+          { reasoningEffort: "high", description: "More depth" },
+        ],
+        defaultServiceTier: null,
+        serviceTiers: [
+          {
+            id: "priority",
+            name: "Fast",
+            description: "Higher-throughput Fast tier",
+          },
+        ],
+        additionalSpeedTiers: ["fast"],
+        isDefault: true,
+      },
+      {
+        id: "gpt-5.4-mini",
+        displayName: "GPT-5.4 Mini",
+        description: "Mini model",
+        hidden: false,
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [],
+        defaultServiceTier: null,
+        serviceTiers: [],
+        isDefault: false,
+      },
+    ],
+  };
+}
+
+function session(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "session-1",
+    status: "ready",
+    agentSessionId: "thread-1",
+    availableModelRecords: normalizeCodexModelRecords(modelListResult()),
+    currentModelId: "gpt-5.5",
+    currentModeId: "auto",
+    reasoningEffort: "medium",
+    serviceTier: null,
+    ...overrides,
+  };
+}
+
+describe("#2888 Codex fast mode config", () => {
+  it("exposes Fast support from Codex service-tier metadata and emits a fast_mode option", () => {
+    const status = buildCodexSessionStatus(session());
+
+    expect(status.models.availableModels[0]).toMatchObject({
+      modelId: "gpt-5.5",
+      supportsFastMode: true,
+    });
+    expect(status.models.availableModels[1]).toMatchObject({
+      modelId: "gpt-5.4-mini",
+      supportsFastMode: false,
+    });
+    expect(
+      status.configOptions.find(
+        (option: { id: string }) => option.id === "fast_mode",
+      ),
+    ).toMatchObject({
+      id: "fast_mode",
+      type: "select",
+      currentValue: "off",
+      options: [
+        { value: "on", name: "On" },
+        { value: "off", name: "Off" },
+      ],
+    });
+  });
+
+  it("hides fast_mode for a Codex model without a Fast service tier", () => {
+    const status = buildCodexSessionStatus(
+      session({ currentModelId: "gpt-5.4-mini" }),
+    );
+
+    expect(
+      status.configOptions.some(
+        (option: { id: string }) => option.id === "fast_mode",
+      ),
+    ).toBe(false);
+  });
+
+  it("maps fast_mode values to app-server serviceTier values", () => {
+    expect(codexServiceTierFromFastModeValue("on", session())).toBe("fast");
+    expect(codexServiceTierFromFastModeValue("off", session())).toBeNull();
+    expect(() =>
+      codexServiceTierFromFastModeValue("enabled", session()),
+    ).toThrow("Unsupported fast mode value");
+  });
+
+  it("adds serviceTier to future Codex turn/start params when Fast is selected", () => {
+    const params = buildCodexTurnStartParams(
+      session({ serviceTier: "fast" }),
+      "hello",
+      [],
+    );
+
+    expect(params).toMatchObject({
+      threadId: "thread-1",
+      model: "gpt-5.5",
+      effort: "medium",
+      serviceTier: "fast",
+    });
+  });
+});

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -52,8 +52,16 @@ function createHarness() {
   const codexModels = {
     currentModelId: "gpt-5.5-codex",
     availableModels: [
-      { modelId: "gpt-5.5-codex", name: "GPT-5.5 Codex" },
-      { modelId: "gpt-5.1-codex-mini", name: "GPT-5.1 Codex Mini" },
+      {
+        modelId: "gpt-5.5-codex",
+        name: "GPT-5.5 Codex",
+        supportsFastMode: true,
+      },
+      {
+        modelId: "gpt-5.1-codex-mini",
+        name: "GPT-5.1 Codex Mini",
+        supportsFastMode: false,
+      },
     ],
   };
   const claudeEffort = {
@@ -77,6 +85,16 @@ function createHarness() {
       { value: "high", name: "high" },
     ],
   };
+  const codexFastMode = {
+    id: "fast_mode",
+    name: "Fast Mode",
+    type: "select",
+    currentValue: "off",
+    options: [
+      { value: "on", name: "On" },
+      { value: "off", name: "Off" },
+    ],
+  };
 
   const inner = {
     spawnSession: vi.fn(async (params: Record<string, unknown>) => {
@@ -89,7 +107,9 @@ function createHarness() {
         status: "ready",
         agentSessionId: `${agentType}-remote-${id}`,
         models: isClaude ? claudeModels : codexModels,
-        configOptions: [isClaude ? { ...claudeEffort } : { ...codexEffort }],
+        configOptions: isClaude
+          ? [{ ...claudeEffort }]
+          : [{ ...codexEffort }, { ...codexFastMode }],
       });
       return {
         id,
@@ -914,6 +934,31 @@ describe("paired runtime — role-scoped model and effort", () => {
       configId: "reasoning_effort",
       valueId: "high",
     });
+  });
+
+  it("executor fast mode change routes to Codex and updates paired status", async () => {
+    await h.paired.updateSessionConfigOption({
+      sessionId: "paired-1",
+      configId: "fast_mode",
+      valueId: "on",
+      role: "executor",
+    });
+    expect(h.inner.updateSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: executorInnerId,
+      configId: "fast_mode",
+      valueId: "on",
+    });
+    const statuses = eventsFor(h.emitted, "provider://session-status");
+    const last = statuses[statuses.length - 1].payload as {
+      // biome-ignore lint/suspicious/noExplicitAny: test introspection
+      paired?: Record<string, any>;
+    };
+    expect(last.paired?.executor.pinnedServiceTier).toBe("fast");
+    expect(
+      last.paired?.executor.configOptions.find(
+        (option: { id: string }) => option.id === "fast_mode",
+      )?.currentValue,
+    ).toBe("on");
   });
 
   it("surfaces unsupported effort values instead of silently applying them", async () => {


### PR DESCRIPTION
## Summary
- Adds Codex Fast Mode as a `fast_mode` config option backed by app-server `serviceTier`.
- Preserves live Codex model metadata, including `additionalSpeedTiers: ["fast"]`, as `supportsFastMode` for the UI.
- Wires direct Codex and paired Claude+Codex executor UI/runtime selection, persistence, and future `turn/start` payloads.
- Adds focused regression guards for model metadata, config-option exposure, app-server request payloads, paired-agent config routing, and selector partial-status safety.

Closes #2888

## Audit
- Reviewed issue #2888 and related prior work: #2058/#2059, #2866/#2869, #2368.
- Checked current official Codex docs/manual for Fast Mode: `/fast`, `service_tier = "fast"`, `[features].fast_mode = true`.
- Generated live local app-server schemas and verified `ModelListResponse.serviceTiers`, `ModelListResponse.additionalSpeedTiers`, `ThreadStartParams.serviceTier`, `ThreadResumeParams.serviceTier`, `TurnStartParams.serviceTier`, and `ThreadSettingsUpdateParams.serviceTier`.
- Network path: no Seren publisher/API slug is involved. The changed path is local UI -> provider service -> local browser-local/desktop-native provider runtime -> `codex app-server` over stdio JSON-RPC (`model/list`, `thread/start`, `thread/resume`, `turn/start`, `thread/settings/update`).

## Validation
- `pnpm vitest run tests/unit/codex-fast-mode-config.test.ts tests/unit/paired-runtime.test.ts tests/unit/agent-model-capability-badges.test.ts tests/unit/agent-selector-partial-status.test.ts tests/unit/codex-runtime-permission-defaults.test.ts` (64 passed)
- `pnpm check` (passed; existing warnings only)
- `pnpm test` (2269 passed, 8 skipped)
- `pnpm build` (passed; existing Vite/Rolldown warnings only)
- `pnpm verify:frontend-build` (passed)
- Live Codex app-server probe: 4 visible models; `gpt-5.5` and `gpt-5.4` expose Fast via `additionalSpeedTiers: ["fast"]`.
- Live browser-local provider-runtime probe: spawned real Codex session on `gpt-5.5`; toggled `provider_update_session_config_option fast_mode` off -> on -> off and observed `provider://config-options-update` transitions.
- Real macOS validation app walkthrough: `pnpm validate:walkthrough codex-fast-mode` with a temporary scenario; result artifact `ok: true`, Codex UI showed `GPT-5.5` + `Fast`, and the scenario waited for `button[title='Disable fast mode']` after clicking.
