### PR TITLE
fix(agent): default Codex to GPT-5.6 models

### DIFF
--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -573,6 +573,9 @@ export function createPairedRuntime({ emit, inner }) {
       approvalPolicy: "on-failure",
       sandboxMode: params.sandboxMode,
       networkEnabled: params.networkEnabled,
+      initialModelId: config.modelId ?? undefined,
+      reasoningEffort: config.effort ?? undefined,
+      codexDefaultIntent: "paired-executor",
     });
     roleState.agentSessionId = info?.agentSessionId ?? roleState.agentSessionId;
 

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -51,6 +51,58 @@ const pairedRuntimeModule = await loadAgentRuntimeModule(
 const PAIRED_AGENT_TYPE =
   pairedRuntimeModule.module?.PAIRED_AGENT_TYPE ?? "claude-codex";
 
+const CODEX_DEFAULT_INTENTS = new Set(["direct", "paired-executor"]);
+const CODEX_DIRECT_PREFERRED_MODELS = ["gpt-5.6-sol", "gpt-5.6"];
+const CODEX_PAIRED_EXECUTOR_PREFERRED_MODELS = [
+  "gpt-5.6-luna",
+  "gpt-5.6-terra",
+];
+const CODEX_KNOWN_GPT56_MODELS = new Map([
+  [
+    "gpt-5.6-sol",
+    {
+      name: "GPT-5.6 Sol",
+      description: "Flagship GPT-5.6 model for Codex.",
+      defaultReasoningEffort: "medium",
+    },
+  ],
+  [
+    "gpt-5.6",
+    {
+      name: "GPT-5.6",
+      description: "GPT-5.6 alias that routes to Sol.",
+      defaultReasoningEffort: "medium",
+    },
+  ],
+  [
+    "gpt-5.6-luna",
+    {
+      name: "GPT-5.6 Luna",
+      description: "Fast, lower-cost GPT-5.6 model for Codex.",
+      defaultReasoningEffort: "low",
+    },
+  ],
+  [
+    "gpt-5.6-terra",
+    {
+      name: "GPT-5.6 Terra",
+      description: "Balanced GPT-5.6 model for Codex.",
+      defaultReasoningEffort: "medium",
+    },
+  ],
+]);
+const CODEX_KNOWN_MODEL_PICKER_ORDER = [
+  "gpt-5.6-sol",
+  "gpt-5.6-luna",
+  "gpt-5.6-terra",
+];
+const CODEX_GPT56_REASONING_EFFORTS = [
+  { value: "low", name: "low" },
+  { value: "medium", name: "medium" },
+  { value: "high", name: "high" },
+  { value: "xhigh", name: "xhigh" },
+];
+
 export function createUnavailableRuntime(label, reason) {
   const detail = reason ? `: ${reason}` : "";
   const unavailable = async () => {
@@ -407,14 +459,100 @@ function normalizeModelRecords(result) {
     .filter((record) => typeof record.modelId === "string");
 }
 
+function codexKnownModelRecord(modelId) {
+  const known = CODEX_KNOWN_GPT56_MODELS.get(modelId);
+  if (!known) return null;
+  return {
+    modelId,
+    name: known.name,
+    description: known.description,
+    defaultReasoningEffort: known.defaultReasoningEffort,
+    supportedReasoningEfforts: CODEX_GPT56_REASONING_EFFORTS,
+    defaultServiceTier: null,
+    serviceTiers: [],
+    isDefault: false,
+  };
+}
+
+function withKnownCodexModelRecords(records) {
+  const catalog = Array.isArray(records) ? records : [];
+  const seen = new Set(catalog.map((record) => record.modelId));
+  const known = CODEX_KNOWN_MODEL_PICKER_ORDER
+    .filter((modelId) => !seen.has(modelId))
+    .map(codexKnownModelRecord)
+    .filter(Boolean);
+  return [...catalog, ...known];
+}
+
+function normalizeCodexDefaultIntent(value) {
+  return CODEX_DEFAULT_INTENTS.has(value) ? value : "direct";
+}
+
+function findModelRecord(records, modelId) {
+  return (
+    records.find((record) => record.modelId === modelId) ??
+    null
+  );
+}
+
+function getCatalogDefaultModelRecord(records) {
+  return records.find((record) => record.isDefault) ?? records[0] ?? null;
+}
+
+function resolveCodexPreferredModelRecord(
+  records,
+  { intent = "direct", explicitModelId = null } = {},
+) {
+  const catalog = Array.isArray(records) ? records : [];
+  if (typeof explicitModelId === "string" && explicitModelId.length > 0) {
+    const explicit =
+      findModelRecord(catalog, explicitModelId) ??
+      codexKnownModelRecord(explicitModelId);
+    if (explicit) return explicit;
+  }
+
+  const preferred =
+    normalizeCodexDefaultIntent(intent) === "paired-executor"
+      ? CODEX_PAIRED_EXECUTOR_PREFERRED_MODELS
+      : CODEX_DIRECT_PREFERRED_MODELS;
+  for (const modelId of preferred) {
+    const record =
+      findModelRecord(catalog, modelId) ?? codexKnownModelRecord(modelId);
+    if (record) return record;
+  }
+
+  return getCatalogDefaultModelRecord(catalog);
+}
+
+function resolveCodexInitialReasoningEffort(
+  modelRecord,
+  { intent = "direct", explicitEffort = null } = {},
+) {
+  const supported = Array.isArray(modelRecord?.supportedReasoningEfforts)
+    ? modelRecord.supportedReasoningEfforts
+        .map((option) => option?.value)
+        .filter((value) => typeof value === "string" && value.length > 0)
+    : [];
+  const supports = (value) => supported.length === 0 || supported.includes(value);
+  const preferred =
+    typeof explicitEffort === "string" && explicitEffort.length > 0
+      ? explicitEffort
+      : normalizeCodexDefaultIntent(intent) === "paired-executor"
+        ? "low"
+        : (modelRecord?.defaultReasoningEffort ?? "medium");
+
+  if (supports(preferred)) return preferred;
+  const modelDefault = modelRecord?.defaultReasoningEffort ?? null;
+  if (modelDefault && supports(modelDefault)) return modelDefault;
+  return supported[0] ?? "medium";
+}
+
 function getSelectedModelRecord(session) {
   return (
     session.availableModelRecords.find(
       (record) => record.modelId === session.currentModelId,
     ) ??
-    session.availableModelRecords.find((record) => record.isDefault) ??
-    session.availableModelRecords[0] ??
-    null
+    getCatalogDefaultModelRecord(session.availableModelRecords)
   );
 }
 
@@ -519,6 +657,22 @@ function codexServiceTierFromFastModeValue(valueId, session) {
     default:
       throw new Error(`Unsupported fast mode value: ${valueId}`);
   }
+}
+
+function buildCodexThreadStartParams(
+  session,
+  cwd,
+  resolvedMode,
+  resolvedSandbox,
+) {
+  return {
+    cwd,
+    approvalPolicy: codexApprovalPolicy(resolvedMode),
+    sandbox: resolvedSandbox,
+    experimentalRawEvents: false,
+    ...(session.currentModelId ? { model: session.currentModelId } : {}),
+    ...(session.serviceTier ? { serviceTier: session.serviceTier } : {}),
+  };
 }
 
 function buildCodexTurnStartParams(session, prompt, context) {
@@ -1305,6 +1459,9 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       sandboxMode,
       networkEnabled,
       timeoutSecs,
+      initialModelId,
+      reasoningEffort,
+      codexDefaultIntent,
     } = params;
 
     if (agentType === PAIRED_AGENT_TYPE) {
@@ -1368,7 +1525,25 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         throw new Error("Codex session was terminated during initialization.");
       }
 
-      session.availableModelRecords = normalizeModelRecords(modelListResult);
+      session.availableModelRecords = withKnownCodexModelRecords(
+        normalizeModelRecords(modelListResult),
+      );
+      const defaultIntent = normalizeCodexDefaultIntent(codexDefaultIntent);
+      const preferredModelRecord = resolveCodexPreferredModelRecord(
+        session.availableModelRecords,
+        {
+          intent: defaultIntent,
+          explicitModelId: initialModelId,
+        },
+      );
+      session.currentModelId = preferredModelRecord?.modelId ?? null;
+      session.reasoningEffort = resolveCodexInitialReasoningEffort(
+        preferredModelRecord,
+        {
+          intent: defaultIntent,
+          explicitEffort: reasoningEffort,
+        },
+      );
 
       const threadParams = {
         cwd,
@@ -1377,6 +1552,12 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         experimentalRawEvents: false,
         ...(session.serviceTier ? { serviceTier: session.serviceTier } : {}),
       };
+      const threadStartParams = buildCodexThreadStartParams(
+        session,
+        cwd,
+        resolvedMode,
+        resolvedSandbox,
+      );
 
       let threadResult;
       let resumedExistingThread = false;
@@ -1399,7 +1580,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
           threadResult = await sendRequest(
             session,
             "thread/start",
-            threadParams,
+            threadStartParams,
             20_000,
           );
         }
@@ -1407,7 +1588,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         threadResult = await sendRequest(
           session,
           "thread/start",
-          threadParams,
+          threadStartParams,
           20_000,
         );
       }
@@ -1435,12 +1616,24 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
           `${codexLogPrefix} threadResult.model: requested=${requestedModelId}, served=${servedModelId}`,
         );
       }
-      session.currentModelId =
-        servedModelId ?? requestedModelId ?? null;
-      session.reasoningEffort =
-        threadResult?.reasoningEffort ??
-        getSelectedModelRecord(session)?.defaultReasoningEffort ??
-        "medium";
+      session.currentModelId = resumedExistingThread
+        ? (servedModelId ?? requestedModelId ?? null)
+        : (requestedModelId ?? servedModelId ?? null);
+      if (resumedExistingThread) {
+        session.reasoningEffort =
+          threadResult?.reasoningEffort ??
+          getSelectedModelRecord(session)?.defaultReasoningEffort ??
+          session.reasoningEffort ??
+          "medium";
+      } else {
+        session.reasoningEffort = resolveCodexInitialReasoningEffort(
+          getSelectedModelRecord(session),
+          {
+            intent: defaultIntent,
+            explicitEffort: reasoningEffort,
+          },
+        );
+      }
       session.serviceTier = normalizeServiceTier(threadResult?.serviceTier);
 
       if (resumedExistingThread && session.agentSessionId) {
@@ -2025,11 +2218,14 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
 }
 
 export {
+  buildCodexThreadStartParams as _buildCodexThreadStartParams,
   buildCodexTurnStartParams as _buildCodexTurnStartParams,
   buildSessionStatus as _buildCodexSessionStatus,
   codexServiceTierFromFastModeValue as _codexServiceTierFromFastModeValue,
   codexApprovalPolicy as _codexApprovalPolicy,
   modeFromApprovalPolicy as _modeFromApprovalPolicy,
   normalizeModelRecords as _normalizeCodexModelRecords,
+  resolveCodexInitialReasoningEffort as _resolveCodexInitialReasoningEffort,
+  resolveCodexPreferredModelRecord as _resolveCodexPreferredModelRecord,
   sandboxFromMode as _sandboxFromMode,
 };

--- a/tests/unit/codex-fast-mode-config.test.ts
+++ b/tests/unit/codex-fast-mode-config.test.ts
@@ -9,9 +9,12 @@ const modulePath = new URL(
 ).href;
 const {
   _buildCodexSessionStatus: buildCodexSessionStatus,
+  _buildCodexThreadStartParams: buildCodexThreadStartParams,
   _buildCodexTurnStartParams: buildCodexTurnStartParams,
   _codexServiceTierFromFastModeValue: codexServiceTierFromFastModeValue,
   _normalizeCodexModelRecords: normalizeCodexModelRecords,
+  _resolveCodexInitialReasoningEffort: resolveCodexInitialReasoningEffort,
+  _resolveCodexPreferredModelRecord: resolveCodexPreferredModelRecord,
 } = await import(/* @vite-ignore */ modulePath);
 
 function modelListResult() {
@@ -66,6 +69,62 @@ function session(overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+describe("#2890 Codex GPT-5.6 defaults", () => {
+  it("prefers GPT-5.6 Sol for direct Codex even when model/list is stale", () => {
+    const records = normalizeCodexModelRecords(modelListResult());
+    const preferred = resolveCodexPreferredModelRecord(records, {
+      intent: "direct",
+    });
+
+    expect(preferred?.modelId).toBe("gpt-5.6-sol");
+    expect(preferred?.name).toBe("GPT-5.6 Sol");
+    expect(
+      resolveCodexInitialReasoningEffort(preferred, { intent: "direct" }),
+    ).toBe("medium");
+  });
+
+  it("prefers GPT-5.6 Luna with low effort for the paired Claude + Codex executor even when model/list is stale", () => {
+    const records = normalizeCodexModelRecords(modelListResult());
+    const preferred = resolveCodexPreferredModelRecord(records, {
+      intent: "paired-executor",
+    });
+
+    expect(preferred?.modelId).toBe("gpt-5.6-luna");
+    expect(preferred?.name).toBe("GPT-5.6 Luna");
+    expect(
+      resolveCodexInitialReasoningEffort(preferred, {
+        intent: "paired-executor",
+      }),
+    ).toBe("low");
+  });
+
+  it("preserves an explicit Codex model over preferred defaults", () => {
+    const records = normalizeCodexModelRecords(modelListResult());
+    const preferred = resolveCodexPreferredModelRecord(records, {
+      intent: "direct",
+      explicitModelId: "gpt-5.6-luna",
+    });
+
+    expect(preferred?.modelId).toBe("gpt-5.6-luna");
+  });
+
+  it("passes the resolved model to Codex thread/start", () => {
+    const params = buildCodexThreadStartParams(
+      session({ currentModelId: "gpt-5.6-sol" }),
+      "/repo",
+      "auto",
+      "danger-full-access",
+    );
+
+    expect(params).toMatchObject({
+      cwd: "/repo",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+      model: "gpt-5.6-sol",
+    });
+  });
+});
 
 describe("#2888 Codex fast mode config", () => {
   it("exposes Fast support from Codex service-tier metadata and emits a fast_mode option", () => {

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -49,21 +49,28 @@ function createHarness() {
       { modelId: "claude-fable-5[1m]", name: "Fable" },
     ],
   };
-  const codexModels = {
-    currentModelId: "gpt-5.5-codex",
-    availableModels: [
-      {
-        modelId: "gpt-5.5-codex",
-        name: "GPT-5.5 Codex",
-        supportsFastMode: true,
-      },
-      {
-        modelId: "gpt-5.1-codex-mini",
-        name: "GPT-5.1 Codex Mini",
-        supportsFastMode: false,
-      },
-    ],
-  };
+  const codexAvailableModels = [
+    {
+      modelId: "gpt-5.6-sol",
+      name: "GPT-5.6 Sol",
+      supportsFastMode: true,
+    },
+    {
+      modelId: "gpt-5.6-luna",
+      name: "GPT-5.6 Luna",
+      supportsFastMode: true,
+    },
+    {
+      modelId: "gpt-5.6-terra",
+      name: "GPT-5.6 Terra",
+      supportsFastMode: true,
+    },
+    {
+      modelId: "gpt-5.5-codex",
+      name: "GPT-5.5 Codex",
+      supportsFastMode: true,
+    },
+  ];
   const claudeEffort = {
     id: "reasoning_effort",
     name: "Reasoning Effort",
@@ -79,8 +86,9 @@ function createHarness() {
     id: "reasoning_effort",
     name: "Reasoning Effort",
     type: "select",
-    currentValue: "medium",
+    currentValue: "low",
     options: [
+      { value: "low", name: "low" },
       { value: "medium", name: "medium" },
       { value: "high", name: "high" },
     ],
@@ -102,6 +110,25 @@ function createHarness() {
       const agentType = String(params.agentType);
       innerSessions.set(id, { id, agentType, scriptedTurnText: [] });
       const isClaude = agentType === "claude-code";
+      const codexInitialModelId =
+        typeof params.initialModelId === "string" &&
+        codexAvailableModels.some(
+          (model) => model.modelId === params.initialModelId,
+        )
+          ? params.initialModelId
+          : params.codexDefaultIntent === "paired-executor"
+            ? "gpt-5.6-luna"
+            : "gpt-5.6-sol";
+      const codexModels = {
+        currentModelId: codexInitialModelId,
+        availableModels: codexAvailableModels,
+      };
+      const codexReasoningEffort =
+        typeof params.reasoningEffort === "string"
+          ? params.reasoningEffort
+          : params.codexDefaultIntent === "paired-executor"
+            ? "low"
+            : "medium";
       wrappedEmit("provider://session-status", {
         sessionId: id,
         status: "ready",
@@ -109,7 +136,10 @@ function createHarness() {
         models: isClaude ? claudeModels : codexModels,
         configOptions: isClaude
           ? [{ ...claudeEffort }]
-          : [{ ...codexEffort }, { ...codexFastMode }],
+          : [
+              { ...codexEffort, currentValue: codexReasoningEffort },
+              { ...codexFastMode },
+            ],
       });
       return {
         id,
@@ -144,7 +174,7 @@ function createHarness() {
       if (!session) return [];
       return session.agentType === "claude-code"
         ? claudeModels.availableModels
-        : codexModels.availableModels;
+        : codexAvailableModels;
     }),
     updateSessionConfigOption: vi.fn(async () => null),
     setPermissionMode: vi.fn(async () => {}),
@@ -207,6 +237,7 @@ describe("paired runtime — spawn", () => {
     expect(claudeSpawn?.approvalPolicy).toBe("on-request");
     expect(codexSpawn?.approvalPolicy).toBe("on-failure");
     expect(codexSpawn?.sandboxMode).toBe("workspace-write");
+    expect(codexSpawn?.codexDefaultIntent).toBe("paired-executor");
   });
 
   it("returns a composite agentSessionId carrying both inner remote ids", async () => {
@@ -228,7 +259,8 @@ describe("paired runtime — spawn", () => {
     expect(text).toContain("Handoffs appear inline");
     // Declares resolved models and efforts in plain language.
     expect(text).toContain("Opus 4.7 (1M)");
-    expect(text).toContain("GPT-5.5 Codex");
+    expect(text).toContain("GPT-5.6 Luna");
+    expect(text).toContain("low");
     expect(text).toContain("medium");
     expect(declarations[0].payload.sessionId).toBe("paired-1");
   });
@@ -273,9 +305,10 @@ describe("paired runtime — spawn", () => {
     expect(last.paired.planner.models.currentModelId).toBe(
       "claude-opus-4-7[1m]",
     );
-    expect(last.paired.executor.models.currentModelId).toBe("gpt-5.5-codex");
+    expect(last.paired.executor.models.currentModelId).toBe("gpt-5.6-luna");
     expect(last.paired.planner.configOptions[0].id).toBe("reasoning_effort");
     expect(last.paired.executor.configOptions[0].id).toBe("reasoning_effort");
+    expect(last.paired.executor.configOptions[0].currentValue).toBe("low");
     expect(last.paired.state).toBe("idle");
   });
 
@@ -292,6 +325,9 @@ describe("paired runtime — spawn", () => {
     await spawnPaired(h, {
       paired: { executor: { modelId: "gpt-retired" } },
     });
+    const codexSpawn = h.inner.spawnSession.mock.calls.find(
+      (c) => c[0].agentType === "codex",
+    )?.[0];
     const statuses = eventsFor(h.emitted, "provider://session-status").filter(
       (e) => e.payload.sessionId === "paired-1",
     );
@@ -300,6 +336,8 @@ describe("paired runtime — spawn", () => {
       // biome-ignore lint/suspicious/noExplicitAny: test introspection
       any
     >;
+    expect(codexSpawn?.initialModelId).toBe("gpt-retired");
+    expect(codexSpawn?.codexDefaultIntent).toBe("paired-executor");
     expect(String(last.paired.executor.notice)).toContain("gpt-retired");
     expect(String(last.paired.executor.notice)).toMatch(/no longer available/i);
   });


### PR DESCRIPTION
Closes #2890

## Summary
- Default direct Codex sessions to `gpt-5.6-sol` with medium reasoning.
- Default Claude + Codex executor sessions to `gpt-5.6-luna` with low reasoning.
- Add official GPT-5.6 Codex records when `model/list` is stale, and pass the selected model into Codex `thread/start`.

## Audit
- Direct Codex path: UI -> `agent.store.spawnSession` -> provider runtime -> local `codex app-server` JSON-RPC (`initialize`, `model/list`, `thread/start`, later `turn/start`). No outbound Seren publisher/API path exists for the changed feature.
- Paired path: UI -> `new-claude-codex-agent` -> `paired-runtime` planner/executor spawns -> executor delegates to the same Codex provider path with `codexDefaultIntent: paired-executor`.
- Live metadata verified: `seren-models` publisher exposes `GET /models` and includes `openai/gpt-5.6-sol`, `openai/gpt-5.6-luna`, and `openai/gpt-5.6-terra`. Official OpenAI docs identify Sol as the flagship/best model and Luna as the fast, lower-cost model.
- Local probe verified Codex app-server 0.143.0 accepts `thread/start` model IDs `gpt-5.6-sol`, `gpt-5.6-luna`, and `gpt-5.6-terra` even when `model/list` only returns GPT-5.5-era entries.

## Validation
- `pnpm test -- tests/unit/codex-fast-mode-config.test.ts tests/unit/paired-runtime.test.ts tests/unit/setmodel-context-window-and-prepend-tool-results.test.ts tests/unit/codex-runtime-permission-defaults.test.ts tests/unit/agent-model-observability.test.ts` (Vitest ran the repo suite: 317 files, 2,273 passed, 8 skipped).
- `node --check bin/browser-local/providers.mjs && node --check bin/browser-local/paired-runtime.mjs`.
- `git diff --check`.
- Real validation app walkthrough: `pnpm validate:walkthrough gh2890-codex-default-models` using a temporary uncommitted scenario. Evidence captured direct Codex rendering `GPT-5.6 Sol` + `medium`, and Claude+Codex executor rendering `GPT-5.6 Luna` + `Executor effort · low`.

## Notes
- `pnpm check` is still red on existing unrelated `src/**` Biome warnings; changed runtime/test paths are outside the current Biome include set.
