### PR TITLE
fix(release): cache NSIS toolset plugin signatures in R2 (part of #2900)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -630,10 +630,53 @@ jobs:
       # uses). Seed the cache exactly as the bundler would and EV-sign the
       # stock plugin DLLs in place; they are not hash-pinned, so the
       # signatures survive the build (#2299).
+      # The stock plugins are byte-identical across releases (pinned NsisSha1),
+      # so cache their signatures in the same R2 store the embedded runtime uses.
+      # The cache dir was already restored from R2 above; the save step below
+      # pushes any freshly signed plugins back for the next release to reuse.
       - name: Stage signed NSIS toolset (Windows)
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
         shell: pwsh
-        run: ./scripts/stage-signed-nsis-toolset.ps1
+        run: |
+          ./scripts/stage-signed-nsis-toolset.ps1 `
+            -CacheDir .sig-cache/windows-authenticode `
+            -Manifest windows-nsis-cache-manifest.tsv `
+            -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT
+
+      - name: Save NSIS signature cache to R2
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        shell: pwsh
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET_NAME }}
+        run: |
+          if (-not $env:AWS_ACCESS_KEY_ID -or -not $env:AWS_SECRET_ACCESS_KEY -or -not $env:AWS_ENDPOINT_URL -or -not $env:R2_BUCKET) {
+            Write-Host "::error::R2 credentials are required for the Windows signature cache."
+            exit 1
+          }
+          $cacheDir = ".sig-cache/windows-authenticode"
+          $count = @(Get-ChildItem -LiteralPath $cacheDir -Filter "*.signed" -File -ErrorAction SilentlyContinue).Count
+          if ($count -eq 0) {
+            Write-Host "::warning::No Windows signature cache blobs exist to upload to R2."
+            exit 0
+          }
+          $target = "s3://$env:R2_BUCKET/$env:WINDOWS_SIGNATURE_CACHE_R2_PREFIX"
+          Write-Host "Saving $count Windows signature cache blob(s) to $target"
+          aws s3 sync $cacheDir $target `
+            --endpoint-url="$env:AWS_ENDPOINT_URL" `
+            --exclude "*" `
+            --include "*.signed" `
+            --size-only `
+            --no-progress `
+            --only-show-errors
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::Failed to save NSIS signature cache to R2."
+            exit $LASTEXITCODE
+          }
+          Write-Host "NSIS signature cache: R2 save completed."
 
       # Build the app (with signing for macOS when certificates available)
       # Note: APPLE_ID/PASSWORD/TEAM_ID removed to prevent Tauri's internal notarization

--- a/scripts/stage-signed-nsis-toolset.ps1
+++ b/scripts/stage-signed-nsis-toolset.ps1
@@ -16,7 +16,16 @@ param(
   # signed on the bundler's build-local copy, which IS on the plugin search
   # path for additional/).
   [string]$UtilsUrl = "https://github.com/tauri-apps/nsis-tauri-utils/releases/download/nsis_tauri_utils-v0.5.3/nsis_tauri_utils.dll",
-  [string]$UtilsSha1 = "75197FEE3C6A814FE035788D1C34EAD39349B860"
+  [string]$UtilsSha1 = "75197FEE3C6A814FE035788D1C34EAD39349B860",
+  # Content-addressed signature cache directory (restored from R2 by the release
+  # workflow). When set, the stock plugins reuse a prior release's signatures
+  # instead of spending an SSL.com cloud signature each time — they are
+  # byte-identical across releases (pinned NsisSha1), so the cache hits ~always.
+  [string]$CacheDir = "",
+  # Pre-sign hash manifest for the cache restore/save round-trip.
+  [string]$Manifest = "windows-nsis-cache-manifest.tsv",
+  # EV cert thumbprint; only signatures from this cert are trusted on restore.
+  [string]$Thumbprint = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -73,7 +82,27 @@ if ($missing.Count -gt 0) {
   Write-Host "::error::Stock plugin set is missing: $($missing -join ', ')."
   exit 1
 }
+$pluginPaths = @($stock | ForEach-Object { $_.FullName })
+
+# Restore cached signatures before signing so unchanged plugins skip the cloud
+# signer. Uses the same content-addressed engine as the embedded runtime; the
+# signer's own valid-signature skip then avoids re-signing anything restored.
+$cacheScript = Join-Path $PSScriptRoot "windows-signature-cache.ps1"
+if ($CacheDir) {
+  $listFile = Join-Path ([IO.Path]::GetTempPath()) "nsis-signables.txt"
+  Set-Content -LiteralPath $listFile -Value $pluginPaths
+  & $cacheScript -Mode restore -ListFile $listFile -CacheDir $CacheDir -Manifest $Manifest -Thumbprint $Thumbprint
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
 Write-Host "Signing $($stock.Count) stock NSIS plugin DLL(s) in the toolset cache..."
-& (Join-Path $PSScriptRoot "sign-windows-payload.ps1") -File @($stock | ForEach-Object { $_.FullName })
-# The signer's `exit` only ends its own script scope — propagate it.
-exit $LASTEXITCODE
+& (Join-Path $PSScriptRoot "sign-windows-payload.ps1") -File $pluginPaths
+$signExit = $LASTEXITCODE
+if ($signExit -ne 0) { exit $signExit }
+
+# Persist newly signed plugins into the cache for the next release to restore.
+if ($CacheDir) {
+  & $cacheScript -Mode save -ListFile $listFile -CacheDir $CacheDir -Manifest $Manifest -Thumbprint $Thumbprint
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+exit 0


### PR DESCRIPTION
## What & why

Part of #2900. The R2 signature cache (#2885) only wrapped the **embedded-runtime** signer, so the **16 stock NSIS plugins** were re-signed on every release — ~16 billable SSL.com eSigner signatures each time — even though they come from a **SHA1-pinned download** (`NsisSha1`) and are byte-identical across releases. v3.68.7's ledger confirmed this: 26 signatures, of which 16 were these plugins.

This wires the **same proven content-addressed engine** (`windows-signature-cache.ps1`, already covered by `tests/unit/windows-signature-cache.test.ts`) into `stage-signed-nsis-toolset.ps1`.

## Change

- `stage-signed-nsis-toolset.ps1`: optional `-CacheDir` / `-Manifest` / `-Thumbprint`. When set, **restore** cached signatures before signing (the signer's existing valid-signature skip then avoids the cloud call) and **save** newly signed plugins after.
- `release.yml`: pass those args to the "Stage signed NSIS toolset" step, and add a "Save NSIS signature cache to R2" step that pushes new plugin blobs to the **same** R2 store/prefix the embedded cache uses.

Steady-state releases with an unchanged NSIS toolset now spend **0** signatures on these plugins (down from 16). Expected new per-release floor: ~10 (3 changed-embedded + ~7 version-stamped installer/uninstaller), vs 26 today.

## Scope (deliberately narrow)

Only the pinned stock plugins. **Follow-ups still open on #2900:** `Seren.exe` (content-addressable, cacheable when code unchanged) and the mid-build `signCommand` helpers. The two version-stamped `setup.exe`s + uninstaller are the intended irreducible floor and are left alone.

## Networked paths

Only outbound call added: `aws s3 sync` to the **existing** Cloudflare R2 store (`s3://$R2_BUCKET/windows-signature-cache/authenticode`, via `R2_ENDPOINT`) — same bucket/prefix/secrets as #2885. **No Seren publisher/`api.serendb.com` path is involved.** NSIS/utils download URLs unchanged.

## Validation

- YAML validated (`release.yml` parses).
- Existing `windows-signature-cache` engine tests unaffected (the engine is unchanged; this adds a second call site).
- **Per CLAUDE.md "NO MOCKS IN FUNCTIONAL TESTING":** the real proof is a Windows release — the SSL.com signing-log count for the next release must show the 16 plugins as cache **restores**, not fresh signs. Local pwsh cannot exercise signtool/eSigner, and I am **not** claiming a mocked substitute. Final sign-off requires reading the next real release's telemetry + ledger.

## No new test

The cache engine's restore/save logic — the only real logic here — is already covered. A new test for this wiring would have to stub `signtool`/`Get-AuthenticodeSignature` (the exact layer that must be trusted), i.e. a mock of the failing layer, which this repo forbids. Adding it would be duplicative and misleading rather than protective.
