### PR TITLE
fix(release): self-prune Windows e2e scratch + resolve real CDP port

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1652,8 +1652,20 @@ jobs:
             `$work = Join-Path $env:TEMP '${workName}'`,
             `$logsS3Uri = ${psString(logsS3Uri)}`,
             `$logsUploadUrl = ${psString(env.LOGS_UPLOAD_URL)}`,
-            "if (Test-Path $work) { Remove-Item -LiteralPath $work -Recurse -Force }",
+            // Prune leaked scratch dirs from prior runs (#2901). A crash before
+            // the finally-cleanup below leaves one 'seren-release-windows-e2e-*'
+            // dir per run; 99 of them filled the box C: drive to 96.9% free=6.26GB
+            // and slowed the NSIS install to 7+ min. Delete ALL of them (not just
+            // this run-id) so the drive self-heals even after a prior crash.
+            "$stale = @(Get-ChildItem -LiteralPath $env:TEMP -Directory -Filter 'seren-release-windows-e2e-*' -ErrorAction SilentlyContinue)",
+            "if ($stale.Count -gt 0) { Write-Host \"[windows-e2e:ssm] Pruning $($stale.Count) leaked scratch dir(s) from prior runs\"; $stale | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue } }",
+            "$sysDrive = if ([string]::IsNullOrWhiteSpace($env:SystemDrive)) { 'C:' } else { $env:SystemDrive }",
+            "$freeGb = [math]::Round((Get-PSDrive -Name $sysDrive.TrimEnd(':')).Free / 1GB, 2)",
+            "if ($freeGb -lt 15) { Write-Host \"::warning::[windows-e2e:ssm] Low disk: $sysDrive has $freeGb GB free (<15 GB); WebView2 CDP startup may stall (see #2901/#2902)\" } else { Write-Host \"[windows-e2e:ssm] $sysDrive free space: $freeGb GB\" }",
             "New-Item -ItemType Directory -Force -Path $work | Out-Null",
+            // The download -> run -> upload sequence removes $work in the finally
+            // below on BOTH success and failure, so the scratch never leaks (#2901).
+            "try {",
             "Write-Host '[windows-e2e:ssm] Downloading staged installer and payload'",
             `Invoke-WebRequest -Uri ${psString(env.INSTALLER_URL)} -OutFile (Join-Path $work 'SerenDesktop-setup.exe')`,
             `Invoke-WebRequest -Uri ${psString(env.PAYLOAD_URL)} -OutFile (Join-Path $work 'windows-e2e-payload.zip')`,
@@ -1672,6 +1684,11 @@ jobs:
             "try { Invoke-WebRequest -Uri $logsUploadUrl -Method Put -InFile $logBundle -UseBasicParsing | Out-Null } catch { throw \"Failed to upload Windows app harness logs to $logsS3Uri via presigned URL: $($_.Exception.Message)\" }",
             "Write-Host \"[windows-e2e:ssm] Uploaded Windows app harness logs to $logsS3Uri\"",
             "if ($harnessExitCode -ne 0) { throw \"Windows app scheduled-task harness failed with exit code $harnessExitCode\" }",
+            // Remove this run's scratch dir on BOTH success and failure, AFTER the
+            // logs are uploaded above, so the box drive can't trend downward across
+            // runs (#2901). Runs even when the try body throws. Set-Location out of
+            // $work first: Windows cannot delete a process's current directory.
+            "} finally { Set-Location -LiteralPath $env:TEMP; Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue; Write-Host '[windows-e2e:ssm] Removed scratch work dir' }",
             ];
           // executionTimeout bounds the whole on-box command. It must exceed the
           // harness's own budget: the scheduled-task wait (TaskTimeoutSeconds + 60

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -269,30 +269,98 @@ function Copy-E2EAppLogs([string]$DestinationDir) {
   }
 }
 
-function Wait-ForCdp([int]$Port, [int]$TimeoutSeconds, [System.Diagnostics.Process]$AppProcess) {
+function Get-WebView2UserDataDirs() {
+  # WebView2 stores its profile (including DevToolsActivePort) under the app's
+  # bundle-identifier folder. Mirror the roots Copy-E2EAppLogs already trusts.
+  $dirs = @()
+  foreach ($base in @($env:LOCALAPPDATA, $env:APPDATA)) {
+    if ([string]::IsNullOrWhiteSpace($base)) {
+      continue
+    }
+    $dirs += (Join-Path $base "com.serendb.desktop\EBWebView")
+  }
+  return @($dirs | Select-Object -Unique)
+}
+
+function Get-DevToolsActivePort([string[]]$UserDataDirs) {
+  # WebView2/Chromium writes the actually-bound remote-debugging port into
+  # <user-data-dir>\DevToolsActivePort (first line). Returns 0 when no readable
+  # port file exists yet.
+  foreach ($dir in $UserDataDirs) {
+    $portFile = Join-Path $dir "DevToolsActivePort"
+    if (-not (Test-Path -LiteralPath $portFile)) {
+      continue
+    }
+    try {
+      $firstLine = Get-Content -LiteralPath $portFile -TotalCount 1 -ErrorAction Stop | Select-Object -First 1
+      $parsed = 0
+      if (-not [string]::IsNullOrWhiteSpace($firstLine) -and [int]::TryParse($firstLine.Trim(), [ref]$parsed) -and $parsed -gt 0) {
+        return $parsed
+      }
+    } catch {
+      Write-Host "::warning::Unable to read DevToolsActivePort at ${portFile}: $($_.Exception.Message)"
+    }
+  }
+  return 0
+}
+
+function Write-DevToolsActivePortDiagnostics([string[]]$UserDataDirs) {
+  Write-Host "DevToolsActivePort probe:"
+  foreach ($dir in $UserDataDirs) {
+    $portFile = Join-Path $dir "DevToolsActivePort"
+    if (Test-Path -LiteralPath $portFile) {
+      $contents = (Get-Content -LiteralPath $portFile -ErrorAction SilentlyContinue) -join " | "
+      Write-Host "  present: $portFile -> [$contents]"
+    } else {
+      Write-Host "  missing: $portFile"
+    }
+  }
+}
+
+function Wait-ForCdp([int]$Port, [int]$TimeoutSeconds, [System.Diagnostics.Process]$AppProcess, [string[]]$UserDataDirs) {
   $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
-  $url = "http://127.0.0.1:$Port/json/version"
+  $portsTried = [System.Collections.Generic.List[int]]::new()
+  $portsTried.Add($Port)
   do {
     if ($null -ne $AppProcess) {
       $AppProcess.Refresh()
       if ($AppProcess.HasExited) {
         Write-WindowsLaunchDiagnostics $AppProcess
+        Write-DevToolsActivePortDiagnostics $UserDataDirs
         Fail "Seren.exe exited before WebView2 CDP became available. ExitCode=$($AppProcess.ExitCode)"
       }
     }
-    try {
-      $response = Invoke-RestMethod -Uri $url -Method Get -TimeoutSec 2
-      if ($response.webSocketDebuggerUrl) {
-        return
-      }
-    } catch {
-      Start-Sleep -Milliseconds 500
+
+    # Prefer the port WebView2 actually bound. If it declined the requested port
+    # (busy, ephemeral fallback, or a version-specific behavior change like the
+    # Evergreen 149->150 bump in #2902), DevToolsActivePort names the real one;
+    # poll it too instead of the fixed 9222 forever.
+    $filePort = Get-DevToolsActivePort $UserDataDirs
+    if ($filePort -gt 0 -and -not $portsTried.Contains($filePort)) {
+      Write-Stage "DevToolsActivePort reports WebView2 bound port $filePort (requested $Port); adding it to the CDP probe set"
+      $portsTried.Add($filePort)
     }
+
+    foreach ($candidate in $portsTried) {
+      try {
+        $response = Invoke-RestMethod -Uri "http://127.0.0.1:$candidate/json/version" -Method Get -TimeoutSec 2
+        if ($response.webSocketDebuggerUrl) {
+          if ($candidate -ne $Port) {
+            Write-Stage "WebView2 CDP came up on port $candidate (requested $Port)"
+          }
+          return $candidate
+        }
+      } catch {
+        # endpoint not ready yet; retry every candidate until the deadline
+      }
+    }
+    Start-Sleep -Milliseconds 500
   } while ((Get-Date) -lt $deadline)
 
   $webViewCount = @(Get-Process -Name "msedgewebview2" -ErrorAction SilentlyContinue).Count
   Write-WindowsLaunchDiagnostics $AppProcess
-  Fail "Timed out waiting for WebView2 remote debugging endpoint at $url. msedgewebview2 process count=$webViewCount"
+  Write-DevToolsActivePortDiagnostics $UserDataDirs
+  Fail "Timed out waiting for WebView2 remote debugging endpoint on port(s) $($portsTried -join ', '). msedgewebview2 process count=$webViewCount"
 }
 
 function Find-RequiredFile([string]$Root, [string]$Filter, [string]$Label) {
@@ -382,14 +450,23 @@ if ([string]::IsNullOrWhiteSpace($webView2Runtime)) {
 }
 Write-Stage "WebView2 runtime detected: $webView2Runtime"
 
+# --remote-allow-origins stays a wildcard: it only gates the WebSocket upgrade,
+# not the /json/version HTTP discovery that timed out in #2902, and an explicit
+# fixed-port origin would reject the very non-9222 fallback the DevToolsActivePort
+# resolution below is designed to attach to.
 $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$RemoteDebugPort --remote-allow-origins=*"
 $env:SEREN_E2E_CAPTURE_INJECTION = "1"
+$webViewUserDataDirs = Get-WebView2UserDataDirs
 Write-Stage "Launching Seren.exe with WebView2 remote debugging on port $RemoteDebugPort"
 $app = Start-Process -FilePath $appExe -PassThru
 
 try {
   Write-Stage "Waiting for WebView2 CDP endpoint"
-  Wait-ForCdp -Port $RemoteDebugPort -TimeoutSeconds $StartupTimeoutSeconds -AppProcess $app
+  $cdpPort = Wait-ForCdp -Port $RemoteDebugPort -TimeoutSeconds $StartupTimeoutSeconds -AppProcess $app -UserDataDirs $webViewUserDataDirs
+  # Thread the port WebView2 actually bound through to the probe (#2902); it may
+  # differ from $RemoteDebugPort when DevToolsActivePort resolved a fallback.
+  $env:SEREN_E2E_CDP_ENDPOINT = "http://127.0.0.1:$cdpPort"
+  Write-Stage "Using CDP endpoint $env:SEREN_E2E_CDP_ENDPOINT for the Windows app e2e probe"
   Write-Stage "Running Node app e2e probe"
   $probeExitCode = Invoke-ProcessWithTimeout "node" @("$PSScriptRoot/windows-e2e-app.mjs") $ProbeTimeoutSeconds "Windows app e2e probe" -NoNewWindow -StdoutPath $probeStdoutPath -StderrPath $probeStderrPath -OnTimeout {
     Write-ProbeTimeoutDiagnostics $app

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -512,4 +512,47 @@ describe("Windows production e2e release gate", () => {
     expect(manualPublishWorkflow).toContain("latest.json");
     expect(manualPublishWorkflow).not.toContain("windows-app-e2e");
   });
+
+  it("self-prunes leaked on-box scratch dirs and removes this run's on both paths (#2901)", () => {
+    const job = workflowJob("windows-app-e2e");
+    // Prune ALL prior scratch dirs (not just this run-id), so a crash before the
+    // finally-cleanup can't silently fill the box drive across runs.
+    expect(job).toContain(
+      "Get-ChildItem -LiteralPath $env:TEMP -Directory -Filter 'seren-release-windows-e2e-*'",
+    );
+    expect(job).toContain(
+      "$stale | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }",
+    );
+    // The leaky start-only, same-run-id-only cleanup must not come back.
+    expect(job).not.toContain(
+      "if (Test-Path $work) { Remove-Item -LiteralPath $work -Recurse -Force }",
+    );
+    // Scratch is removed on success AND failure, after logs upload; Set-Location
+    // out of $work first because Windows can't delete a process's CWD.
+    expect(job).toContain(
+      "} finally { Set-Location -LiteralPath $env:TEMP; Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue;",
+    );
+    // Disk pressure surfaces explicitly instead of as a mystery CDP timeout.
+    expect(job).toContain("Low disk:");
+  });
+
+  it("resolves the real WebView2 CDP port via DevToolsActivePort (#2902)", () => {
+    // The gate must not hard-code 9222 forever: when WebView2 binds a different
+    // port (busy/ephemeral/Evergreen bump), DevToolsActivePort names the real one.
+    expect(runner).toContain("function Get-DevToolsActivePort");
+    expect(runner).toContain("function Get-WebView2UserDataDirs");
+    expect(runner).toContain("com.serendb.desktop\\EBWebView");
+    expect(runner).toContain("DevToolsActivePort");
+    expect(runner).toContain("-UserDataDirs $webViewUserDataDirs");
+    // The resolved port is threaded through to the Node probe.
+    expect(runner).toContain(
+      '$env:SEREN_E2E_CDP_ENDPOINT = "http://127.0.0.1:$cdpPort"',
+    );
+    // Timeout must state whether DevToolsActivePort existed and what it named.
+    expect(runner).toContain("function Write-DevToolsActivePortDiagnostics");
+    expect(runner).toContain("Write-DevToolsActivePortDiagnostics $UserDataDirs");
+    // Origin stays a wildcard: it only gates the WS upgrade, not /json/version,
+    // and a fixed-port origin would reject the non-9222 fallback we attach to.
+    expect(runner).toContain("--remote-allow-origins=*");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the two-part `windows-app-e2e` gate incident from release **v3.68.7**. Both fixes live in the release harness; neither touches product code.

Fixes #2901
Fixes #2902

### #2901 — leaked per-run scratch dirs filled the box C: drive
`.github/workflows/release.yml` (on-box SSM command):
- **Prune at start** — delete *all* pre-existing `seren-release-windows-e2e-*` dirs under `%TEMP%` (not just this run-id), so a crash before cleanup self-heals across runs. 99 leaked dirs had filled C: to 96.9% (6.26 GB free) and slowed the NSIS install to 7+ min.
- **Remove at end** — wrap download → run → upload in `try { … } finally { … }` and remove this run's scratch on **both** success and failure, *after* logs upload to S3. `Set-Location` out of `$work` first because Windows can't delete a process's current directory.
- **Explicit disk signal** — report drive free space and `::warning::` below 15 GB, so disk pressure shows up as a log line instead of a mysterious CDP timeout.

### #2902 — harness hard-coded CDP port 9222 with no fallback
`scripts/windows-e2e-app.ps1`:
- **`DevToolsActivePort` as source of truth** — new `Get-DevToolsActivePort` / `Get-WebView2UserDataDirs` read the port WebView2 actually bound from `…\com.serendb.desktop\EBWebView\DevToolsActivePort`. `Wait-ForCdp` now polls both the requested port and the resolved fallback, returns the working port, and the launcher threads it to the probe via `SEREN_E2E_CDP_ENDPOINT`. A non-9222 bind (busy/ephemeral/Evergreen 149→150 bump) no longer hangs forever.
- **Timeout diagnostics** — `Write-DevToolsActivePortDiagnostics` dumps whether the file existed and what port it named on every CDP failure path.

**Deliberately NOT changed — issue #2902 item 2 (`--remote-allow-origins` explicit).** Kept as `*`. `--remote-allow-origins` only gates the **WebSocket** upgrade Origin header, not the `/json/version` **HTTP GET** that actually timed out in this incident (6 `msedgewebview2` processes were running; the HTTP discovery endpoint never answered — a port-binding/timing failure, not an origin rejection). Verified via web search that `*` is still the supported wildcard (in place since Dec 2022, not removed). An explicit fixed-port origin would also **reject the very non-9222 fallback** the DevToolsActivePort resolution is built to attach to. Flagging for your call, @taariq — happy to add explicit origins if you want it regardless.

## Tests
- Added two guardrails to `tests/unit/windows-e2e-release-gate.test.ts` (prune-all + finally-cleanup + disk signal; DevToolsActivePort resolution + port threading + timeout diagnostics + retained wildcard). Full file: **26/26 pass**.

## Validation & limitations (no-mocks honesty)
- ✅ `release.yml` valid YAML (yq); the embedded Node generator emits 31 well-formed commands.
- ✅ Guardrail suite green.
- ⚠️ **PowerShell was not executed locally** — `pwsh` 7.5.4 is corrupted in this environment (aborts on startup with a `System.Runtime.Serialization.Formatters` assembly-load fault). Balance/logic verified by manual review. Per #2902's own acceptance criteria and the repo's no-mocks rule, **this layer can only be validated end-to-end by the next real release run** — the DevToolsActivePort path and cross-run drive self-heal must be confirmed against the live Windows box on the next tag. Do not treat this PR as validated until that run's logs show: prune count, `… free space: … GB`, and the CDP endpoint line.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com