### PR TITLE
fix(codex): require CLI upgrade for GPT-5.6 defaults

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -13,7 +13,12 @@ import {
 import os from "node:os";
 import path from "node:path";
 
-import { backgroundUpdateCli } from "./cli-updater.mjs";
+import {
+  backgroundUpdateCli,
+  CLI_MIN_VERSION_BASELINE,
+  isBelowBaseline,
+  runInstalledVersion,
+} from "./cli-updater.mjs";
 
 // LM Studio support is loaded lazily so a missing LM Studio dependency (e.g.
 // @lmstudio/sdk) never crashes the registry, which every agent relies on for
@@ -400,6 +405,77 @@ async function ensureGlobalNpmPackage({ emit, command, packageName, label }) {
   });
 
   return command;
+}
+
+function runCodexSelfUpdate(resolvedPath) {
+  const command =
+    typeof resolvedPath === "string" && resolvedPath.length > 0
+      ? resolvedPath
+      : "codex";
+  const shell =
+    process.platform === "win32" && command.toLowerCase().endsWith(".cmd");
+  return new Promise((resolvePromise, rejectPromise) => {
+    execFile(
+      command,
+      ["update"],
+      { timeout: 180_000, shell },
+      (error, stdout, stderr) => {
+        if (error) {
+          rejectPromise(new Error(stderr || error.message));
+          return;
+        }
+        resolvePromise(stdout.trim());
+      },
+    );
+  });
+}
+
+async function ensureCodexCliViaUpdater(emit) {
+  await ensureGlobalNpmPackage({
+    emit,
+    command: "codex",
+    packageName: "@openai/codex",
+    label: "Codex",
+  });
+
+  const baseline = CLI_MIN_VERSION_BASELINE["@openai/codex"];
+  let resolved = resolveInstalledCodexBinary();
+  const installed = await runInstalledVersion(resolved, "codex");
+  if (!isBelowBaseline(installed, baseline)) {
+    return resolved;
+  }
+
+  emit("provider://cli-install-progress", {
+    stage: "installing",
+    message: `Updating Codex CLI to ${baseline} or newer...`,
+  });
+
+  try {
+    await runCodexSelfUpdate(resolved !== "codex" ? resolved : "codex");
+  } catch (error) {
+    throw new Error(
+      `Codex CLI ${installed ?? "unknown"} is too old for Seren's GPT-5.6 ` +
+        `defaults and auto-update failed. Run "codex update" manually and ` +
+        `restart Seren. ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  resolved = resolveInstalledCodexBinary();
+  const updated = await runInstalledVersion(resolved, "codex");
+  if (isBelowBaseline(updated, baseline)) {
+    throw new Error(
+      `Codex CLI is still ${updated ?? "unknown"} after update; Seren requires ` +
+        `${baseline} or newer for GPT-5.6 defaults. Run "codex update" manually ` +
+        "and restart Seren.",
+    );
+  }
+
+  emit("provider://cli-install-progress", {
+    stage: "complete",
+    message: "Codex CLI updated successfully",
+  });
+
+  return resolved;
 }
 
 async function ensureClaudeCodeViaNativeInstaller(emit) {
@@ -798,12 +874,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         return true;
       },
       async ensureCli() {
-        return ensureGlobalNpmPackage({
-          emit,
-          command: "codex",
-          packageName: "@openai/codex",
-          label: "Codex",
-        });
+        return ensureCodexCliViaUpdater(emit);
       },
       launchLogin() {
         // Login MUST target the same binary that providers.spawnCodex

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -41,6 +41,10 @@ const SEMVER_EXTRACT_RE = /\d+\.\d+\.\d+[^\s]*/;
  * model ids), since the gate force-updates to `@latest`. 2.1.197 is verified
  * to ship the claude-opus-4-8 catalog. */
 export const CLI_MIN_VERSION_BASELINE = {
+  // 0.144.1 is verified to advertise the GPT-5.6 Codex catalog. 0.143.0
+  // accepts those ids at thread/start but fails at turn/start with "requires
+  // a newer version of Codex", breaking Seren's GPT-5.6 defaults. #2904.
+  "@openai/codex": "0.144.1",
   "@anthropic-ai/claude-code": "2.1.197",
 };
 
@@ -418,6 +422,7 @@ export async function backgroundUpdateCli({
   const installedVersionFn =
     _versionOverrides?.runInstalledVersion ?? runInstalledVersion;
   const npmViewFn = _versionOverrides?.runNpmView ?? runNpmView;
+  const selfUpdateFn = _versionOverrides?.tryCliSelfUpdate ?? tryCliSelfUpdate;
 
   // Compatibility: production runs may not pass `state` (callers were
   // written before the test seam). When state is omitted we manage
@@ -482,12 +487,27 @@ export async function backgroundUpdateCli({
     }
 
     if (installed && latest && isNewer(installed, latest)) {
+      if (packageName === "@openai/codex") {
+        const selfOk = await selfUpdateFn(resolvedPath);
+        if (selfOk) {
+          saveState(persisted);
+          onUpdated?.({
+            label,
+            bareCommand,
+            from: installed,
+            to: latest,
+            channel: "self",
+          });
+          return report("success", { from: installed, to: latest, channel: "self" });
+        }
+      }
+
       // Native installs are gated by the upstream's signed installer + their
       // own self-update mechanism; we don't have a tarball to scan. Keep
       // existing flow. npm channel updates are scanned per #1647.
       if (channel === "native") {
         try {
-          const selfOk = await tryCliSelfUpdate(resolvedPath);
+          const selfOk = await selfUpdateFn(resolvedPath);
           if (!selfOk) {
             await runClaudeNativeInstaller();
           }

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -210,6 +210,74 @@ describe("isBelowBaseline (#1761)", () => {
       "2.1.197",
     );
   });
+
+  it("Codex baseline ships the GPT-5.6 app-server catalog (#2904)", async () => {
+    expect(CLI_MIN_VERSION_BASELINE["@openai/codex"]).toBe("0.144.1");
+
+    const state = {
+      "lastUpdateCheck:codex": Date.now() - 1000,
+    };
+    const result = await backgroundUpdateCli({
+      label: "Codex",
+      bareCommand: "codex",
+      resolvedPath: "/opt/homebrew/bin/codex",
+      packageName: "@openai/codex",
+      state,
+      now: Date.now(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "0.143.0",
+        runNpmView: async () => null,
+      },
+    });
+
+    expect(result.skipped).not.toBe("ttl");
+    expect(result).toMatchObject({
+      outcome: "skipped:network",
+      installed: "0.143.0",
+    });
+  });
+
+  it("uses Codex self-update before npm tarball scanning (#2904)", async () => {
+    let selfUpdateCalls = 0;
+    let scanCalled = false;
+    const result = await backgroundUpdateCli({
+      label: "Codex",
+      bareCommand: "codex",
+      resolvedPath: "/opt/homebrew/bin/codex",
+      packageName: "@openai/codex",
+      state: {},
+      now: Date.now(),
+      _versionOverrides: {
+        runInstalledVersion: async () => "0.143.0",
+        runNpmView: async () => "0.144.1",
+        tryCliSelfUpdate: async () => {
+          selfUpdateCalls++;
+          return true;
+        },
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => {
+          throw new Error("must not pack when Codex self-update succeeds");
+        },
+        scanTarball: async () => {
+          scanCalled = true;
+          throw new Error("must not scan when Codex self-update succeeds");
+        },
+        runNpmInstallFromTarball: async () => {
+          throw new Error("must not install when Codex self-update succeeds");
+        },
+      },
+    });
+
+    expect(selfUpdateCalls).toBe(1);
+    expect(scanCalled).toBe(false);
+    expect(result).toMatchObject({
+      outcome: "success",
+      from: "0.143.0",
+      to: "0.144.1",
+      channel: "self",
+    });
+  });
 });
 
 describe("outcome logging (#1646)", () => {

--- a/tests/unit/codex-cli-upgrade-gate.test.ts
+++ b/tests/unit/codex-cli-upgrade-gate.test.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Focused guard for #2904 — Codex spawn must block on upgrading old CLIs.
+// ABOUTME: Prevents regressing to install-only ensureCli while GPT-5.6 defaults require a newer Codex.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const agentRegistrySource = readFileSync(
+  new URL("../../bin/browser-local/agent-registry.mjs", import.meta.url),
+  "utf8",
+);
+
+describe("#2904 Codex CLI upgrade gate", () => {
+  it("Codex ensureCli uses the blocking updater before provider spawn", () => {
+    const codexDefStart = agentRegistrySource.indexOf("codex: {");
+    const claudeDefStart = agentRegistrySource.indexOf('"claude-code": {');
+    const codexDefinition = agentRegistrySource.slice(
+      codexDefStart,
+      claudeDefStart,
+    );
+
+    expect(codexDefinition).toContain("async ensureCli()");
+    expect(codexDefinition).toContain("return ensureCodexCliViaUpdater(emit)");
+    expect(codexDefinition).not.toContain("return ensureGlobalNpmPackage({");
+  });
+
+  it("the Codex updater runs codex update and fails closed if still below baseline", () => {
+    const helperStart = agentRegistrySource.indexOf(
+      "async function ensureCodexCliViaUpdater",
+    );
+    const helperEnd = agentRegistrySource.indexOf(
+      "async function ensureClaudeCodeViaNativeInstaller",
+    );
+    const helper = agentRegistrySource.slice(helperStart, helperEnd);
+
+    expect(helper).toContain("CLI_MIN_VERSION_BASELINE");
+    expect(helper).toContain("isBelowBaseline");
+    expect(helper).toContain("runCodexSelfUpdate");
+    expect(helper).toContain('Run "codex update" manually');
+  });
+});


### PR DESCRIPTION
Closes #2904.

## Root cause
PR #2899 made Seren prefer GPT-5.6 Codex defaults, but the existing Codex `ensureCli()` path only installed Codex when missing and did not enforce the minimum CLI that can actually run those IDs. Live local evidence showed Codex CLI 0.143.0 could accept `gpt-5.6-sol` at `thread/start`, then failed `turn/start` with `400 Bad Request: The 'gpt-5.6-sol' model requires a newer version of Codex`.

## Fix
- Adds `@openai/codex` baseline `0.144.1`, verified live to advertise `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
- Makes Codex `ensureCli()` block on `codex update` before provider spawn when installed Codex is below the baseline.
- Fails closed with a clear manual `codex update` instruction if auto-update cannot bring Codex to the required version.
- Uses Codex self-update before npm tarball scanning in the background updater to avoid papering over native/Homebrew installs with an npm shadow.
- Keeps GPT-5.6 defaults intact rather than downgrading to synthetic fallback logic.

## Networked path audit
- Runtime feature path is local `codex app-server` stdio JSON-RPC: `initialize` -> `model/list` -> `thread/start` -> `turn/start`.
- Upgrade path is local `codex update`, which delegates to Codex's supported package-manager update flow.
- No Seren publisher/API request path exists for the changed runtime feature.
- GitHub tracking used live publisher `github-api`: `/repos/serenorg/seren-desktop/issues`, `/repos/serenorg/seren-desktop/issues/2904/comments`, and `/repos/serenorg/seren-desktop/pulls`.

## Validation
- `git diff --check`
- `node --check bin/browser-local/agent-registry.mjs`
- `node --check bin/browser-local/cli-updater.mjs`
- `pnpm vitest run tests/unit/cli-updater.test.ts tests/unit/codex-cli-upgrade-gate.test.ts tests/unit/codex-fast-mode-config.test.ts`
- Live before/after Codex CLI check: `codex-cli 0.143.0` failed GPT-5.6 turn; `codex update` installed `codex-cli 0.144.1`; live `model/list` then advertised GPT-5.6 records.
- Live no-mock app-server turns completed for direct `gpt-5.6-sol` and paired-executor `gpt-5.6-luna`.
- Real app walkthrough: `pnpm validate:walkthrough agent-send-recovery`, artifact `artifacts/validation-walkthrough/result.json` returned `{ "ok": true, "scenario": "agent-send-recovery" }`.

## Walkthrough findings
- P0/P1/P2: none found in the affected flow.
- Non-blocking pre-existing noise: validation app emitted support-report warnings because no Seren API key is configured in the validation profile; walkthrough still completed successfully.