### PR TITLE
fix(release): enable WebView2 remote debugging via app browser args (#2902)

### DIFF
--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -450,10 +450,15 @@ if ([string]::IsNullOrWhiteSpace($webView2Runtime)) {
 }
 Write-Stage "WebView2 runtime detected: $webView2Runtime"
 
-# --remote-allow-origins stays a wildcard: it only gates the WebSocket upgrade,
-# not the /json/version HTTP discovery that timed out in #2902, and an explicit
-# fixed-port origin would reject the very non-9222 fallback the DevToolsActivePort
-# resolution below is designed to attach to.
+# SEREN_E2E_REMOTE_DEBUG_PORT is the primary switch: the app reads it at startup
+# and enables WebView2 remote debugging through its own AdditionalBrowserArguments.
+# WebView2 150 ignores the WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS env var once the
+# host app sets browser args, so that env var no longer reaches the browser
+# process (#2902). We keep setting it too as a fallback for WebView2 149-era
+# runtimes that still honor it. --remote-allow-origins stays a wildcard: it only
+# gates the WebSocket upgrade, not the /json/version HTTP discovery, and an
+# explicit fixed-port origin would reject the non-9222 DevToolsActivePort fallback.
+$env:SEREN_E2E_REMOTE_DEBUG_PORT = "$RemoteDebugPort"
 $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$RemoteDebugPort --remote-allow-origins=*"
 $env:SEREN_E2E_CAPTURE_INJECTION = "1"
 $webViewUserDataDirs = Get-WebView2UserDataDirs

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -638,6 +638,43 @@ pub fn run() {
             }
         })
         .setup(|app| {
+            // Create the configured windows here rather than letting Tauri
+            // auto-create them (the window is marked "create": false in
+            // tauri.conf.json) so the Windows e2e release gate can enable
+            // WebView2 remote debugging through the app's OWN
+            // AdditionalBrowserArguments. WebView2 150 stopped honoring the
+            // WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS environment variable once
+            // the host app sets browser args, so the harness env var never
+            // reaches the browser process (serenorg/seren-desktop#2902).
+            // Passing the flags programmatically is the channel WebView2 still
+            // honors.
+            //
+            // Gated on SEREN_E2E_REMOTE_DEBUG_PORT so a normal build never opens
+            // a debug port. The string mirrors wry's own default args
+            // (disable-features + autoplay-policy) because additional_browser_args
+            // REPLACES that default instead of extending it.
+            let e2e_remote_debug_args = std::env::var("SEREN_E2E_REMOTE_DEBUG_PORT")
+                .ok()
+                .and_then(|value| value.trim().parse::<u16>().ok())
+                .map(|port| {
+                    format!(
+                        "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --autoplay-policy=no-user-gesture-required --remote-debugging-port={port} --remote-allow-origins=*"
+                    )
+                });
+            let window_configs = app.config().app.windows.clone();
+            for window_config in &window_configs {
+                let mut window_builder =
+                    tauri::WebviewWindowBuilder::from_config(app.handle(), window_config)?;
+                if let Some(args) = &e2e_remote_debug_args {
+                    window_builder = window_builder.additional_browser_args(args);
+                    log::info!(
+                        "[e2e] WebView2 remote debugging enabled on window '{}'",
+                        window_config.label
+                    );
+                }
+                window_builder.build()?;
+            }
+
             let app_identifier = app.config().identifier.clone();
             let validation_instance = validation::is_validation_identifier(&app_identifier);
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,6 +14,8 @@
     "macOSPrivateApi": true,
     "windows": [
       {
+        "label": "main",
+        "create": false,
         "title": "Seren",
         "width": 1200,
         "height": 800,

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -555,4 +555,30 @@ describe("Windows production e2e release gate", () => {
     // and a fixed-port origin would reject the non-9222 fallback we attach to.
     expect(runner).toContain("--remote-allow-origins=*");
   });
+
+  it("enables WebView2 remote debugging via the app's own AdditionalBrowserArguments (#2902)", () => {
+    // WebView2 150 drops the WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS env var once
+    // the host app sets browser args, so --remote-debugging-port never reaches
+    // the browser process. The port must be injected through the app's own
+    // programmatic additional_browser_args, gated on an e2e-only env flag.
+    expect(runner).toContain("SEREN_E2E_REMOTE_DEBUG_PORT");
+
+    const libRs = readFileSync(join(root, "src-tauri/src/lib.rs"), "utf8");
+    expect(libRs).toContain("SEREN_E2E_REMOTE_DEBUG_PORT");
+    expect(libRs).toContain("additional_browser_args");
+    expect(libRs).toContain("WebviewWindowBuilder::from_config");
+    // additional_browser_args REPLACES wry's default, so the e2e string must
+    // reproduce it or the e2e webview would diverge from production.
+    expect(libRs).toContain(
+      "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection",
+    );
+    expect(libRs).toContain("--autoplay-policy=no-user-gesture-required");
+
+    // The window is created in the setup hook, so auto-creation must be off.
+    const tauriConf = readFileSync(
+      join(root, "src-tauri/tauri.conf.json"),
+      "utf8",
+    );
+    expect(tauriConf).toContain('"create": false');
+  });
 });


### PR DESCRIPTION
## Summary

Completes the fix for the `windows-app-e2e` gate failure that blocked v3.68.7. #2905 (merged) added a `DevToolsActivePort` CDP-port resolver, but that was necessary-not-sufficient: on WebView2 150 remote debugging never activates at all, so no port file is ever written. This PR makes the app actually enable remote debugging through the channel WebView2 150 honors.

## Root cause (confirmed against the real gate)

Reconstructed the full `msedgewebview2.exe` command lines from **both** failing runs (the v3.68.7 release run and a disk-cleaned diagnostic re-run). The main browser process on WebView2 `150.0.4078.48` carries Tauri/wry's programmatic args (`--disable-features=…`, `--autoplay-policy=…`) but **`--remote-debugging-port` is absent from every process**.

WebView2 150 applies the host app's *programmatic* `AdditionalBrowserArguments` and **ignores the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` env var** the harness set (149 honored it; 150 drops it). So `--remote-debugging-port` never reached the browser → no CDP server on :9222 → no `DevToolsActivePort` → gate timed out. A disk-cleaned diagnostic re-run (21 GB free) failed identically, ruling out disk pressure.

## Fix

- **`src-tauri/src/lib.rs`** — create the main window in the `setup` hook via `WebviewWindowBuilder::from_config`; when `SEREN_E2E_REMOTE_DEBUG_PORT` is set, add `additional_browser_args` with `--remote-debugging-port` + `--remote-allow-origins=*`. The string reproduces wry's default (`--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --autoplay-policy=no-user-gesture-required`) because `additional_browser_args` **replaces** that default. Gated on the env flag, so **production never opens a debug port**.
- **`src-tauri/tauri.conf.json`** — mark the main window `"create": false` so the setup hook owns creation (Tauri auto-creates only windows where `create == true`).
- **`scripts/windows-e2e-app.ps1`** — set `SEREN_E2E_REMOTE_DEBUG_PORT` before launching Seren (keeps the env var too as a WebView2-149 fallback).
- **`tests/unit/windows-e2e-release-gate.test.ts`** — guardrail asserting the env gate, the app-side `additional_browser_args`, the reproduced wry defaults, and `create:false`.

Complements #2905: with the port now actually bound, its `DevToolsActivePort` resolver becomes real insurance for future port-binding changes.

## Validation

- `cargo check` — passes (Rust compiles).
- `pnpm vitest run tests/unit/windows-e2e-release-gate.test.ts` — 27 passed (incl. new guardrail).
- **WebView2 CDP behavior can only be validated end-to-end on the real Windows e2e box / next release** — it cannot be unit-tested on the build host. #2905's `present/missing DevToolsActivePort` timeout diagnostic is the confirm signal if anything is still off.

Closes #2902

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com