### PR TITLE
fix(release): sign NSIS stock plugins on cold signature cache (#2900)

### DIFF
--- a/scripts/stage-signed-nsis-toolset.ps1
+++ b/scripts/stage-signed-nsis-toolset.ps1
@@ -92,7 +92,10 @@ if ($CacheDir) {
   $listFile = Join-Path ([IO.Path]::GetTempPath()) "nsis-signables.txt"
   Set-Content -LiteralPath $listFile -Value $pluginPaths
   & $cacheScript -Mode restore -ListFile $listFile -CacheDir $CacheDir -Manifest $Manifest -Thumbprint $Thumbprint
-  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  # Null-safe: only a non-zero code is a failure. `-ne 0` alone would fire on a
+  # $null $LASTEXITCODE ($null -ne 0 is $true in PowerShell) and silently skip
+  # signing with exit 0, shipping unsigned stock plugins (#2900).
+  if ($LASTEXITCODE) { exit $LASTEXITCODE }
 }
 
 Write-Host "Signing $($stock.Count) stock NSIS plugin DLL(s) in the toolset cache..."
@@ -103,6 +106,6 @@ if ($signExit -ne 0) { exit $signExit }
 # Persist newly signed plugins into the cache for the next release to restore.
 if ($CacheDir) {
   & $cacheScript -Mode save -ListFile $listFile -CacheDir $CacheDir -Manifest $Manifest -Thumbprint $Thumbprint
-  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  if ($LASTEXITCODE) { exit $LASTEXITCODE }
 }
 exit 0

--- a/scripts/windows-signature-cache.ps1
+++ b/scripts/windows-signature-cache.ps1
@@ -90,3 +90,10 @@ if ($Mode -eq "restore") {
 
   Write-Host "Windows signature cache: saved $saved newly signed blob(s)."
 }
+
+# Exit 0 explicitly on success. This script runs only cmdlets (no native command
+# sets $LASTEXITCODE), so without this a caller invoking it with `&` inherits a
+# stale/`$null` $LASTEXITCODE. `$null -ne 0` is $true in PowerShell, so a caller
+# guard `if ($LASTEXITCODE -ne 0) { exit }` would fire on a clean run. Real
+# failures throw (ErrorActionPreference=Stop) and never reach this line.
+exit 0

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -581,4 +581,25 @@ describe("Windows production e2e release gate", () => {
     );
     expect(tauriConf).toContain('"create": false');
   });
+
+  it("signs stock NSIS plugins on a cold cache instead of exiting 0 on a null $LASTEXITCODE (#2900)", () => {
+    // windows-signature-cache.ps1 runs only cmdlets, so it must exit with a
+    // deterministic code — otherwise a `&`-invoking caller inherits a $null
+    // $LASTEXITCODE, and `$null -ne 0` ($true in PowerShell) trips its failure
+    // guard, exiting 0 before signing and shipping an unsigned nsExec.dll.
+    const cacheScript = readFileSync(
+      join(root, "scripts/windows-signature-cache.ps1"),
+      "utf8",
+    );
+    expect(cacheScript.trimEnd().endsWith("exit 0")).toBe(true);
+
+    // The stage script's cache guards must be null-safe (`if ($LASTEXITCODE)`),
+    // never the `-ne 0` form that fires on a clean run.
+    const stage = readFileSync(
+      join(root, "scripts/stage-signed-nsis-toolset.ps1"),
+      "utf8",
+    );
+    expect(stage).toContain("if ($LASTEXITCODE) { exit $LASTEXITCODE }");
+    expect(stage).not.toContain("if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }");
+  });
 });


### PR DESCRIPTION
## Summary

The v3.68.8 Windows release build fails the **Verify embedded installer payload signatures** gate with `$PLUGINSDIR\nsExec.dll NotSigned` (1 of 716) — twice, identically. It's a **regression from #2903** (the NSIS-toolset R2 signature cache), and it's a PowerShell `$LASTEXITCODE` bug.

## Root cause

`stage-signed-nsis-toolset.ps1` (post-#2903) does:

```powershell
& $cacheScript -Mode restore ...
if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }   # <-- bug
Write-Host "Signing $($stock.Count) stock NSIS plugin DLL(s)..."
& sign-windows-payload.ps1 -File $pluginPaths
```

`windows-signature-cache.ps1` runs **only cmdlets** (`Get-FileHash`, `Get-AuthenticodeSignature`, `Copy-Item`, `Set-Content`) and never calls `exit`, so invoking it with `&` leaves the caller's `$LASTEXITCODE` unchanged. On a clean run no native command has run yet, so `$LASTEXITCODE` is **`$null`** — and in PowerShell **`$null -ne 0` is `$true`**. The guard therefore runs `exit $null` (which exits 0), so the step **returns success but skips signing every stock plugin**. `makensis` then embeds an unsigned `nsExec.dll` — the other stock plugins are covered by the tauri bundler's own signing, but `nsExec.dll` is only covered by this toolset step.

The v3.68.8 log confirms it — the step ends at:

```
Windows signature cache: restored 0 of 16 signable(s).
```

with **no** subsequent "Signing 16 stock NSIS plugin DLL..." line. This would fail every release with the cache enabled, cold or warm (the restore path invokes no native command in either case).

## Fix

- **`windows-signature-cache.ps1`** — end with an explicit `exit 0` on success, so a `&`-invoking caller gets a deterministic code (real failures still throw under `ErrorActionPreference=Stop`).
- **`stage-signed-nsis-toolset.ps1`** — make both cache guards null-safe: `if ($LASTEXITCODE) { exit $LASTEXITCODE }` (false for `$null` and `0`, true only for a real non-zero code).
- **`windows-e2e-release-gate.test.ts`** — guardrail asserting the `exit 0` and the null-safe guards.

## Validation

- `pnpm vitest run tests/unit/windows-e2e-release-gate.test.ts` — **28 passed** (incl. the new guardrail).
- pwsh can't be exercised on the build host (signtool/eSigner are Windows-cloud only), so per the no-mocks rule this is **validated by the next Windows release**: the payload-signature gate is the confirm signal, and a green Windows build means `nsExec.dll` is signed.

Once this and #2907 are in, the next tag should build Windows cleanly and finally run `windows-app-e2e` (validating the WebView2 fix too).

Refs #2900, #2903

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
