### PR TITLE
fix(agent): retire abandoned paired ledger phase on cancel/error (#2917)

### DIFF
--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -394,6 +394,19 @@ function normalizeSpend(raw) {
   };
 }
 
+function normalizeBudget(raw) {
+  return {
+    executorTokens: Math.min(
+      500_000,
+      Math.max(1, Number(raw?.executorTokens) || DEFAULT_EXECUTOR_TOKEN_BUDGET),
+    ),
+    maxAttempts: Math.min(
+      5,
+      Math.max(1, Number(raw?.maxAttempts) || DEFAULT_EXECUTOR_MAX_ATTEMPTS),
+    ),
+  };
+}
+
 function normalizeLedger(raw) {
   if (!raw || raw.version !== PAIRED_LEDGER_VERSION) return createLedger();
   return {
@@ -406,6 +419,7 @@ function normalizeLedger(raw) {
           attempts: Array.isArray(phase.attempts) ? phase.attempts : [],
           artifacts: Array.isArray(phase.artifacts) ? phase.artifacts : [],
           blockers: Array.isArray(phase.blockers) ? phase.blockers : [],
+          budget: normalizeBudget(phase.budget),
           spend: {
             planner: normalizeSpend(phase.spend?.planner),
             executor: normalizeSpend(phase.spend?.executor),
@@ -646,9 +660,24 @@ export function createPairedRuntime({ emit, inner }) {
   function activeLedgerPhase(paired) {
     for (let index = paired.ledger.phases.length - 1; index >= 0; index -= 1) {
       const phase = paired.ledger.phases[index];
-      if (!["completed", "blocked"].includes(phase.status)) return phase;
+      if (!["completed", "blocked", "interrupted"].includes(phase.status)) {
+        return phase;
+      }
     }
     return null;
+  }
+
+  // A resumable phase (executing/reviewing) that is abandoned by cancel or an
+  // in-process error must be retired, or the user's next prompt satisfies the
+  // resume gate and is silently swallowed as a re-run of the old task (#2917).
+  // Cross-process resume is unaffected: a hard crash never runs this path, so a
+  // persisted executing phase still resumes on the next spawn. Planning and
+  // awaiting-user phases are left intact so planner-hold continuation survives.
+  function markActivePhaseInterrupted(paired) {
+    const phase = activeLedgerPhase(paired);
+    if (phase && (phase.status === "executing" || phase.status === "reviewing")) {
+      phase.status = "interrupted";
+    }
   }
 
   function createLedgerPhase(paired, userPrompt) {
@@ -1400,6 +1429,7 @@ export function createPairedRuntime({ emit, inner }) {
       paired.status = "ready";
       paired.state = "idle";
       paired.activeRole = null;
+      markActivePhaseInterrupted(paired);
       if (wasCancelled) {
         // cancelPrompt already emitted the cancel error + ready status.
         // Reject like the single-session runtimes so the frontend's prompt
@@ -1429,6 +1459,7 @@ export function createPairedRuntime({ emit, inner }) {
     paired.status = "ready";
     paired.state = "idle";
     paired.activeRole = null;
+    markActivePhaseInterrupted(paired);
     emit("provider://error", {
       sessionId: paired.id,
       error: "Task cancelled",

--- a/tests/unit/paired-runtime.test.ts
+++ b/tests/unit/paired-runtime.test.ts
@@ -913,6 +913,63 @@ describe("paired runtime — prompt pipeline", () => {
     expect(cancelErrors.length).toBe(1);
     expect(eventsFor(h.emitted, "provider://prompt-complete").length).toBe(0);
   });
+
+  it("retires an abandoned executing phase so the next prompt is honored, not swallowed as a resume (#2917)", async () => {
+    const originalSendPrompt = h.inner.sendPrompt.getMockImplementation();
+    // First turn: the planner plans, then the executor turn throws in-process.
+    h.inner.sendPrompt.mockImplementation(
+      async (args: { sessionId: string; prompt: string }) => {
+        const session = h.innerSessions.get(String(args.sessionId));
+        if (session?.agentType === "codex") {
+          throw new Error("executor blew up mid-turn");
+        }
+        return originalSendPrompt?.(args);
+      },
+    );
+    await h.paired
+      .sendPrompt({ sessionId: "paired-1", prompt: "implement feature X" })
+      .catch(() => {});
+
+    // Second turn: executor healthy again; the user sends a DIFFERENT request.
+    h.inner.sendPrompt.mockImplementation(originalSendPrompt);
+    for (const session of h.innerSessions.values()) {
+      session.scriptedTurnText =
+        session.agentType === "codex"
+          ? ["PASS A1 — did Y"]
+          : ["PLAN: do Y\nASSERT A1: Y is done", "REVIEW: Y looks correct"];
+    }
+    h.inner.sendPrompt.mockClear();
+    h.emitted.length = 0;
+
+    await h.paired.sendPrompt({
+      sessionId: "paired-1",
+      prompt: "STOP — do Y instead",
+    });
+
+    // A fresh plan → execute → review must run — NOT a resume that routes the
+    // stale task straight to the executor and drops the new prompt.
+    const order = h.inner.sendPrompt.mock.calls.map(
+      (call) => h.innerSessions.get(String(call[0].sessionId))?.agentType,
+    );
+    expect(order).toEqual(["claude-code", "codex", "claude-code"]);
+    const plannerPrompt = String(h.inner.sendPrompt.mock.calls[0][0].prompt);
+    const executorPrompt = String(h.inner.sendPrompt.mock.calls[1][0].prompt);
+    expect(plannerPrompt).toContain("STOP — do Y instead");
+    expect(executorPrompt).toContain("STOP — do Y instead");
+    expect(plannerPrompt).not.toContain("implement feature X");
+    expect(executorPrompt).not.toContain("implement feature X");
+
+    // The ledger retires the abandoned phase and starts a fresh, completed one.
+    const persisted = JSON.parse(
+      String(
+        eventsFor(h.emitted, "provider://session-status").at(-1)?.payload
+          .agentSessionId,
+      ),
+    );
+    expect(persisted.ledger.phases).toHaveLength(2);
+    expect(persisted.ledger.phases[0].status).toBe("interrupted");
+    expect(persisted.ledger.phases[1].status).toBe("completed");
+  });
 });
 
 describe("paired runtime — planner hold (#2880)", () => {


### PR DESCRIPTION
## What

Fixes **#2917** (P0) — found during the v3.69.0 pre-release audit of the durable paired task ledger (#2916).

A paired turn that is **cancelled** or hits an **in-process error** during the executor/review stage left its ledger phase in `status: "executing"`/`"reviewing"` with `canonicalPlan` still set. The teardown paths reset the session but never the phase, so the user's **next** prompt satisfied the `resumable` gate and was **silently dropped** — the runtime re-ran the *old* (cancelled) task instead of the new request. Worst case: a user who cancels to *stop* a destructive/live-send action triggers a full re-run of that exact task on their next message.

## Fix

- `markActivePhaseInterrupted(paired)` retires a resumable (`executing`/`reviewing`) phase to a new terminal status `interrupted`, called from the `sendPrompt` catch (covers cancel + error) and `cancelPrompt` (covers an inner runtime that hangs after cancel).
- `activeLedgerPhase` treats `interrupted` as terminal, so the next prompt starts a fresh phase.
- **Cross-process resume is unaffected**: a hard crash never runs `catch`/`cancelPrompt`, so a persisted `executing` phase still resumes on the next spawn. `planning`/`awaiting-user` phases are left intact so planner-hold continuation survives.
- Also hardens `normalizeLedger` to clamp a resumed phase `budget` (partial fix for **#2919** item 2a), preventing a `TypeError` on `phase.budget.maxAttempts` from a corrupt-but-valid-JSON resume token.

## Test

Regression test added to `paired-runtime.test.ts`: the executor's first turn throws → phase left non-terminal → the next, **different** prompt must run a fresh plan → execute → review carrying the **new** prompt. Verified it **fails on the unfixed runtime** (`['codex','claude-code']` — resumes stale task) and **passes with the fix** (`['claude-code','codex','claude-code']`). Full unit suite green (2287 passed).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
