### PR TITLE
fix(agent): verify publisher absence; bound ledger memory (#2918 #2919)

### DIFF
--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -703,6 +703,16 @@ export function createPairedRuntime({ emit, inner }) {
       checkpoint: null,
     };
     paired.ledger.phases.push(phase);
+    // Bound in-memory ledger growth the same way persistence does — keep only
+    // the most recent phases. The active phase is always last, and older
+    // terminal phases are history whose spend already lives in totalSpend
+    // (#2919).
+    if (paired.ledger.phases.length > MAX_PERSISTED_PHASES) {
+      paired.ledger.phases.splice(
+        0,
+        paired.ledger.phases.length - MAX_PERSISTED_PHASES,
+      );
+    }
     return phase;
   }
 

--- a/src/lib/agent-output-validation/validateFinalOutput.ts
+++ b/src/lib/agent-output-validation/validateFinalOutput.ts
@@ -228,13 +228,14 @@ function matchesTool(tool: ToolEvidence, pattern: RegExp): boolean {
 }
 
 function isSuccessfulPublisherAbsenceVerification(tool: ToolEvidence): boolean {
-  return (
-    !isFailedTool(tool) &&
-    matchesTool(tool, /list_agent_publishers/i) &&
-    /publisher[^\n]*(not found|absent)|no matching publisher/i.test(
-      tool.result ?? "",
-    )
-  );
+  // A successful no-argument list_agent_publishers call is the live catalog
+  // evidence the agent is instructed to gather; the absence determination is
+  // its client-side filter over that list. The real tool returns the catalog
+  // as JSON ({"publishers":[...]}), never prose like "not found", so requiring
+  // absence phrasing in the result made this unsatisfiable (#2918). A failed or
+  // malformed lookup is still excluded so it can never stand in for real
+  // evidence (#2910).
+  return !isFailedTool(tool) && matchesTool(tool, /list_agent_publishers/i);
 }
 
 function isFailedTool(tool: ToolEvidence): boolean {

--- a/tests/unit/agent-output-validation.test.ts
+++ b/tests/unit/agent-output-validation.test.ts
@@ -210,6 +210,9 @@ describe("#1987 Verified Agent Output", () => {
       evidenceToolCallIds: [],
     });
 
+    // The real list_agent_publishers tool returns the catalog as JSON, never
+    // prose like "not found" — a successful live list that omits GitHub is the
+    // evidence, and the absence is the agent's client-side filter (#2918).
     const unavailableWithFreshAbsence = validateFinalOutput({
       finalText: "GitHub is unavailable in this session.",
       evidence: extractEvidenceFromUnifiedMessages([
@@ -221,7 +224,8 @@ describe("#1987 Verified Agent Output", () => {
             kind: "seren-mcp",
             name: "mcp__seren_mcp__list_agent_publishers",
             status: "completed",
-            result: "Fresh publisher list: no matching publisher found",
+            result:
+              '{"publishers":[{"slug":"seren-notes"},{"slug":"seren-whisper"}]}',
           },
         }),
       ]),


### PR DESCRIPTION
v3.69.0 pre-release audit follow-ups. Closes #2918, closes #2919.

## #2918 (P1 bug) — publisher-absence verifier was unsatisfiable by real output

`isSuccessfulPublisherAbsenceVerification` only credited a `publisher_unavailable` claim when the `list_agent_publishers` result matched `/publisher[^\n]*(not found|absent)|no matching publisher/i`. The real tool returns the catalog as JSON (`{"publishers":[...]}`) and never that prose, so **no absence claim could ever be verified** — every correct "X is unavailable" conclusion was rewritten to a hedge and blocked from memory.

Fix: accept a **successful** `list_agent_publishers` call as the evidence — the live no-arg catalog is what the agent is instructed to gather, and the absence is its client-side filter over that list. A failed/malformed lookup is still excluded via `!isFailedTool`, so the #2910 false-negative case stays closed.

The masking test (`unavailableWithFreshAbsence`) fed a fabricated `"no matching publisher found"` string the tool never emits. It now feeds real JSON output — and **fails on the old verifier** (`verified`→`unverified`), passes with the fix.

## #2919 (P2) — ledger robustness

- **2a** (budget crash on corrupt resume token): already shipped in #2920.
- **2b** (unbounded in-memory phases): `createLedgerPhase` now caps `ledger.phases` to `MAX_PERSISTED_PHASES`, mirroring persistence. The active phase is always last; older terminal phases are history whose spend already lives in `totalSpend`. No behavioral change through the public interface (persisted output already sliced to 8), so no new test — full suite confirms no regression.
- **2c** (resume-into-reviewing double-count): **not a real defect.** `setPhase` persists the `reviewing` snapshot *before* the review's `collectMeta` runs, and no persist happens in the one-statement window between `collectMeta` and the terminal status — so a resumed review is counted exactly once. Left as intended recovery behavior.

## Verification

Full unit suite green (2287 passed, 8 skipped). Biome clean on `validateFinalOutput.ts`. #2918 fix proven fail-before/pass-after against the real JSON tool output.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
