### PR TITLE
fix(release): gate Windows signing on cache restore rate (#2922)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ env:
   # Hard gate for unchanged embedded-runtime releases: if the manifest matches
   # the previous release, a working signature cache should make this near zero.
   WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED: ${{ vars.WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED || '25' }}
+  # Hard gate when the embedded-runtime manifest changed: the per-file R2 cache
+  # must still restore at least this percent of signables, or the release fails
+  # instead of silently re-signing (and billing) the unchanged files (#2922).
+  # Lower this only for a release that intentionally overhauls the runtime.
+  WINDOWS_EMBEDDED_RUNTIME_CACHE_MIN_RESTORE_RATE: ${{ vars.WINDOWS_EMBEDDED_RUNTIME_CACHE_MIN_RESTORE_RATE || '75' }}
   # R2 prefix for the content-addressed signed Windows embedded-runtime blobs.
   WINDOWS_SIGNATURE_CACHE_R2_PREFIX: windows-signature-cache/authenticode
 
@@ -619,7 +624,8 @@ jobs:
             -Manifest windows-signature-cache-manifest.tsv `
             -PreviousState windows-signing-cache-previous-state.json `
             -OutputState windows-signing-cache-state.json `
-            -MaxSignedWhenUnchanged $env:WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED
+            -MaxSignedWhenUnchanged $env:WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED `
+            -MinRestoreRateWhenChanged $env:WINDOWS_EMBEDDED_RUNTIME_CACHE_MIN_RESTORE_RATE
 
       # makensis embeds the stock NSIS plugins ($PLUGINSDIR: System.dll,
       # nsExec.dll, StartMenu.dll, nsDialogs.dll) from the bundler's NSIS

--- a/scripts/assert-windows-signature-cache.ps1
+++ b/scripts/assert-windows-signature-cache.ps1
@@ -16,6 +16,11 @@ param(
   # Maximum fresh embedded-runtime signatures allowed when the manifest is unchanged.
   # Defaults from WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED, then 25.
   [int]$MaxSignedWhenUnchanged = -1,
+  # Minimum percent of embedded-runtime signables that must restore from the
+  # per-file cache when the manifest changed. Below this, the R2 cache is
+  # treated as collapsed and the release fails (#2922). Defaults from
+  # WINDOWS_EMBEDDED_RUNTIME_CACHE_MIN_RESTORE_RATE, then 75.
+  [int]$MinRestoreRateWhenChanged = -1,
   # Stable base for turning absolute manifest paths into release-invariant paths.
   [string]$Workspace = ""
 )
@@ -180,6 +185,12 @@ if ($MaxSignedWhenUnchanged -lt 0) {
     -Name "WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED" `
     -Default 25
 }
+if ($MinRestoreRateWhenChanged -lt 0) {
+  $MinRestoreRateWhenChanged = Resolve-NonNegativeInt `
+    -Raw $env:WINDOWS_EMBEDDED_RUNTIME_CACHE_MIN_RESTORE_RATE `
+    -Name "WINDOWS_EMBEDDED_RUNTIME_CACHE_MIN_RESTORE_RATE" `
+    -Default 75
+}
 
 if (-not (Test-Path -LiteralPath $ListFile)) { throw "ListFile not found: $ListFile" }
 $manifestSummary = Read-ManifestSummary -Path $Manifest -WorkspaceRoot $Workspace
@@ -194,6 +205,11 @@ $previousHash = if ($previous -and $previous.manifest_hash) {
 
 $status = "skipped_no_previous_state"
 $currentHash = [string]$manifestSummary.hash
+$restoreRate = if ($telemetrySummary.embedded_discovered -gt 0) {
+  [math]::Round(100.0 * $telemetrySummary.embedded_skipped / $telemetrySummary.embedded_discovered, 2)
+} else {
+  100.0
+}
 if ($previousHash) {
   if ($previousHash -eq $currentHash) {
     $status = "passed_unchanged_manifest"
@@ -201,7 +217,15 @@ if ($previousHash) {
       $status = "failed_unchanged_manifest_over_floor"
     }
   } else {
-    $status = "skipped_changed_manifest"
+    # The manifest changed, but a previous release means the per-file R2 cache
+    # should still restore the ~99% of embedded-runtime files that did not
+    # change. A collapsed restore rate is the silent-overage signal (#2922):
+    # the aggregate hash changing every release must not disable the guard.
+    if ($telemetrySummary.embedded_discovered -gt 0 -and $restoreRate -lt $MinRestoreRateWhenChanged) {
+      $status = "failed_changed_manifest_restore_collapsed"
+    } else {
+      $status = "passed_changed_manifest"
+    }
   }
 }
 
@@ -216,10 +240,12 @@ $state = [PSCustomObject]@{
   previous_manifest_hash = if ($previousHash) { $previousHash } else { $null }
   cache_gate_status = $status
   max_signed_when_unchanged = $MaxSignedWhenUnchanged
+  min_restore_rate_when_changed = $MinRestoreRateWhenChanged
   embedded_runtime_discovered = [int]$telemetrySummary.embedded_discovered
   embedded_runtime_skipped = [int]$telemetrySummary.embedded_skipped
   embedded_runtime_would_sign = [int]$telemetrySummary.embedded_would_sign
   embedded_runtime_signed = [int]$telemetrySummary.embedded_signed
+  embedded_runtime_restore_rate = $restoreRate
   total_signed_so_far = [int]$telemetrySummary.total_signed
 }
 Write-CurrentState -Path $OutputState -State $state
@@ -230,10 +256,16 @@ if ($status -eq "failed_unchanged_manifest_over_floor") {
   exit 1
 }
 
+if ($status -eq "failed_changed_manifest_restore_collapsed") {
+  Write-Host "::error::Windows signature cache regression: embedded-runtime manifest changed, but only $($telemetrySummary.embedded_skipped)/$($telemetrySummary.embedded_discovered) ($restoreRate%) signable(s) restored from the per-file cache; below the $MinRestoreRateWhenChanged% floor. This release would freshly sign $($telemetrySummary.embedded_signed) file(s) and silently bill SSL.com (#2922)."
+  Write-Host "::error::Inspect telemetry '$TelemetryFile', cache manifest '$Manifest', and the R2 signature-cache restore. If this release intentionally overhauls the embedded runtime, lower WINDOWS_EMBEDDED_RUNTIME_CACHE_MIN_RESTORE_RATE for this run."
+  exit 1
+}
+
 if ($status -eq "passed_unchanged_manifest") {
   Write-Host "Windows signature cache gate passed: unchanged embedded-runtime manifest $currentHash signed $($telemetrySummary.embedded_signed) file(s), max $MaxSignedWhenUnchanged."
-} elseif ($status -eq "skipped_changed_manifest") {
-  Write-Host "Windows signature cache gate skipped: embedded-runtime manifest changed from $previousHash to $currentHash."
+} elseif ($status -eq "passed_changed_manifest") {
+  Write-Host "Windows signature cache gate passed: embedded-runtime manifest changed from $previousHash to $currentHash, but $restoreRate% of signables restored from cache (min $MinRestoreRateWhenChanged%); signed $($telemetrySummary.embedded_signed) file(s)."
 } else {
   Write-Host "Windows signature cache gate skipped: no previous release state was available."
 }

--- a/tests/unit/windows-signature-cache-gate.test.ts
+++ b/tests/unit/windows-signature-cache-gate.test.ts
@@ -21,7 +21,11 @@ function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex").toUpperCase();
 }
 
-function writeArtifacts(contentHash: string, signed: number): { list: string; manifest: string; telemetry: string } {
+function writeArtifacts(
+  contentHash: string,
+  signed: number,
+  skipped = 195,
+): { list: string; manifest: string; telemetry: string } {
   const payload = path.join(root, "src-tauri", "embedded-runtime", "bin", "payload.exe");
   const list = path.join(root, "sign-targets.txt");
   const manifest = path.join(root, "windows-signature-cache-manifest.tsv");
@@ -37,7 +41,7 @@ function writeArtifacts(contentHash: string, signed: number): { list: string; ma
       status: "success",
       source: "list:sign-targets.txt",
       discovered: 729,
-      skipped: 195,
+      skipped,
       would_sign: signed,
       signed,
       previous_signed: 0,
@@ -121,31 +125,39 @@ describe("assert-windows-signature-cache.ps1", () => {
     pwshTimeout,
   );
 
+  // Bootstrap a previous-release state whose manifest hash differs from the
+  // follow-up run, so the follow-up exercises the changed-manifest path.
+  function bootstrapPreviousState(previousState: string): void {
+    const first = writeArtifacts(sha256("unsigned payload v1"), 3, 726);
+    expect(
+      runGate([
+        "-ListFile",
+        first.list,
+        "-Manifest",
+        first.manifest,
+        "-TelemetryFile",
+        first.telemetry,
+        "-OutputState",
+        previousState,
+        "-Workspace",
+        root,
+        "-MaxSignedWhenUnchanged",
+        "25",
+        "-MinRestoreRateWhenChanged",
+        "75",
+      ]).status,
+    ).toBe(0);
+  }
+
   it.runIf(hasPwsh)(
-    "skips the hard gate when the embedded-runtime manifest changed",
+    "passes when the manifest changed but the per-file cache still restored",
     () => {
-      const firstArtifacts = writeArtifacts(sha256("unsigned payload v1"), 534);
       const previousState = path.join(root, "previous-state.json");
       const currentState = path.join(root, "current-state.json");
+      bootstrapPreviousState(previousState);
 
-      expect(
-        runGate([
-          "-ListFile",
-          firstArtifacts.list,
-          "-Manifest",
-          firstArtifacts.manifest,
-          "-TelemetryFile",
-          firstArtifacts.telemetry,
-          "-OutputState",
-          previousState,
-          "-Workspace",
-          root,
-          "-MaxSignedWhenUnchanged",
-          "25",
-        ]).status,
-      ).toBe(0);
-
-      const changedArtifacts = writeArtifacts(sha256("unsigned payload v2"), 534);
+      // Healthy steady state: 726/729 restored (99.6%), only 3 freshly signed.
+      const changedArtifacts = writeArtifacts(sha256("unsigned payload v2"), 3, 726);
       const changed = runGate([
         "-ListFile",
         changedArtifacts.list,
@@ -161,13 +173,54 @@ describe("assert-windows-signature-cache.ps1", () => {
         root,
         "-MaxSignedWhenUnchanged",
         "25",
+        "-MinRestoreRateWhenChanged",
+        "75",
       ]);
 
       expect(changed.status).toBe(0);
-      expect(changed.out).toContain("manifest changed");
+      const state = JSON.parse(readFileSync(currentState, "utf8"));
+      expect(state.cache_gate_status).toBe("passed_changed_manifest");
+      expect(state.previous_manifest_hash).not.toBe(state.manifest_hash);
+    },
+    pwshTimeout,
+  );
+
+  it.runIf(hasPwsh)(
+    "fails when the manifest changed and the per-file cache restore collapsed (#2922)",
+    () => {
+      const previousState = path.join(root, "previous-state.json");
+      const currentState = path.join(root, "current-state.json");
+      bootstrapPreviousState(previousState);
+
+      // Broken cache: only 195/729 restored (26.7%), 534 freshly signed — the
+      // silent-overage regression that a changed manifest must no longer hide.
+      const changedArtifacts = writeArtifacts(sha256("unsigned payload v2"), 534, 195);
+      const changed = runGate([
+        "-ListFile",
+        changedArtifacts.list,
+        "-Manifest",
+        changedArtifacts.manifest,
+        "-TelemetryFile",
+        changedArtifacts.telemetry,
+        "-PreviousState",
+        previousState,
+        "-OutputState",
+        currentState,
+        "-Workspace",
+        root,
+        "-MaxSignedWhenUnchanged",
+        "25",
+        "-MinRestoreRateWhenChanged",
+        "75",
+      ]);
+
+      expect(changed.status).toBe(1);
+      expect(changed.out).toContain("Windows signature cache regression");
+      expect(changed.out).toContain("restore");
 
       const state = JSON.parse(readFileSync(currentState, "utf8"));
-      expect(state.cache_gate_status).toBe("skipped_changed_manifest");
+      expect(state.cache_gate_status).toBe("failed_changed_manifest_restore_collapsed");
+      expect(state.embedded_runtime_signed).toBe(534);
       expect(state.previous_manifest_hash).not.toBe(state.manifest_hash);
     },
     pwshTimeout,


### PR DESCRIPTION
Closes #2922.

## Problem

The Windows signing regression hard-gate (`assert-windows-signature-cache.ps1`, #2882) only fails the release on its **unchanged-manifest** path. The aggregate embedded-runtime manifest hash changes on **every** release (any 1 of ~729 files differs), so the gate always took the `skipped_changed_manifest` branch and asserted nothing — **skipped on 100% of releases (v3.68.6 → v3.69.0)**. A silent per-file cache regression would re-sign ~534 files — under the 850 `MAX_SIGNATURES` cap and with a "changed" manifest — so the release would go green and bill SSL.com overage with no signal. That is the exact #2883 failure mode #2882 was created to stop.

## Fix (narrow)

Assert on the **per-file cache restore rate** on the changed-manifest path too, decoupled from aggregate manifest identity:

- New `-MinRestoreRateWhenChanged` (default **75%**, env `WINDOWS_EMBEDDED_RUNTIME_CACHE_MIN_RESTORE_RATE`). When the manifest changed but a previous release exists, fail if `embedded_skipped / embedded_discovered < floor`.
- Calibrated from real release-asset telemetry (embedded set = 729 files): healthy releases restore **99.6%** (sign 3); a broken/cold cache restores **26.7%** (signs 534). 75% sits with huge margin between them and won't false-fail moderate legit runtime changes.
- Overridable (lower the var) for a release that intentionally overhauls the embedded runtime; the failure message says so.
- New states persisted to the release asset: `passed_changed_manifest` / `failed_changed_manifest_restore_collapsed`, plus `embedded_runtime_restore_rate` and `min_restore_rate_when_changed`.

Files: `scripts/assert-windows-signature-cache.ps1`, `.github/workflows/release.yml` (env + param wiring, mirroring the existing `HIT_MAX_SIGNED` pattern), `tests/unit/windows-signature-cache-gate.test.ts`.

## Tests (live, no mocks)

The existing test **encoded the bug** (changed manifest + 534 signed → `status === 0`). Replaced with two cases that run the **real** `pwsh` gate script via `spawnSync` (no reimplementation, no mock):
- changed manifest that still restores 99.6% → **passes** (`passed_changed_manifest`)
- changed manifest whose restore collapses to 26.7% → **fails** (`failed_changed_manifest_restore_collapsed`)

Kept the original unchanged-manifest floor test. No broad TDD added.

## Validation

- Local `pwsh` is broken in this environment (x86_64/Rosetta .NET crash), so the pwsh-dependent tests **skip locally** — I did not fake a local pass. Full unit suite otherwise green (2287 passed).
- **Live validation runs in CI**: `test-frontend` (ubuntu-latest, working pwsh) executes these tests against the real gate script — the existing file already ran there (2 tests, green) in prior CI; this PR makes it 3. That green is the live evidence.
- **Ultimate validation** is the next Windows release run, where the gate runs against real signing telemetry.

## Networked path

None. CI-side PowerShell + workflow config + a vitest that runs the real script. No UI action, publisher slug, or outbound request.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
