### PR TITLE
fix(release): reproducible pip launchers stop re-signing (#2926)

### DIFF
--- a/build/win32/prepare-python-runtime.ts
+++ b/build/win32/prepare-python-runtime.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Bundles Python with the Tauri installer so skills work without a system install.
 
 import { execSync } from "child_process";
+import { createHash } from "node:crypto";
 import * as fs from "fs";
 import * as https from "https";
 import * as path from "path";
@@ -29,6 +30,95 @@ function downloadConfig(arch: "x64" | "arm64"): DownloadConfig {
 }
 
 const GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py";
+
+// Pinned pip so the launcher-generating input never floats. get-pip bundles a
+// pip wheel, but we install this exact version explicitly so a silent upstream
+// bump cannot change the launcher bytes. Bump alongside PIP_SOURCE_DATE_EPOCH
+// when intentionally reseeding the embedded runtime (an explicit +1 signing op).
+const PIP_VERSION = "26.1.2";
+
+// Fixed source epoch for reproducible launcher bytes (#2926). pip's vendored
+// distlib ScriptMaker stamps SOURCE_DATE_EPOCH — or the current time when unset
+// — into each Windows console launcher's embedded ZIP. Unset, two clean builds
+// at different times produce different pip.exe/pip3.exe/pip3.12.exe hashes even
+// with identical pip and build path, so the content-addressed signature cache
+// always misses them and re-signs three files every release. A fixed value
+// makes the launchers byte-identical across builds and cacheable. Bump on any
+// intentional Python/pip upgrade so the reseed is explicit.
+const PIP_SOURCE_DATE_EPOCH = 1735689600; // 2025-01-01T00:00:00Z
+
+// Optional integrity pin for the floating get-pip.py bootstrap. When
+// GET_PIP_SHA256 is set, a mismatch fails closed before executing the
+// downloaded script; otherwise the observed digest is recorded in the manifest
+// for auditing.
+const GET_PIP_SHA256 = process.env.GET_PIP_SHA256 ?? "";
+
+/**
+ * Build the pip bootstrap command. Installs the exact pinned pip so the
+ * launcher generator is deterministic. Exported for unit testing.
+ */
+export function buildPipBootstrapCommand(
+	pythonExe: string,
+	getPipPath: string,
+	pipVersion: string,
+): string {
+	return `"${pythonExe}" "${getPipPath}" "pip==${pipVersion}" --no-warn-script-location --disable-pip-version-check`;
+}
+
+/**
+ * Environment for the pip bootstrap subprocess, forcing a fixed
+ * SOURCE_DATE_EPOCH so distlib produces reproducible launcher ZIPs (#2926).
+ * Exported for unit testing.
+ */
+export function pipBootstrapEnv(
+	baseEnv: NodeJS.ProcessEnv,
+	sourceDateEpoch: number,
+): NodeJS.ProcessEnv {
+	return { ...baseEnv, SOURCE_DATE_EPOCH: String(sourceDateEpoch) };
+}
+
+// The three console-script launchers pip generates are byte-identical to each
+// other within a build. A divergence means a launcher-generating input drifted.
+const PIP_LAUNCHERS = ["pip.exe", "pip3.exe", "pip3.12.exe"];
+
+function sha256File(filePath: string): string {
+	return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+/**
+ * Fail closed when the pip launchers are not reproducible (#2926 §5): they must
+ * all share one unsigned hash. Returns that shared hash. Exported for testing.
+ */
+export function assertLaunchersReproducible(
+	hashes: Array<{ name: string; sha256: string }>,
+): string {
+	const unique = new Set(hashes.map((h) => h.sha256.toLowerCase()));
+	if (unique.size !== 1) {
+		const detail = hashes.map((h) => `${h.name}=${h.sha256}`).join(", ");
+		throw new Error(
+			`pip launchers are not reproducible (expected one shared hash, got ${unique.size}): ${detail}. ` +
+				"A launcher-generating input drifted; reseed with a bumped PIP_SOURCE_DATE_EPOCH.",
+		);
+	}
+	return [...unique][0];
+}
+
+/**
+ * Fail closed when a pinned get-pip digest is configured and does not match the
+ * downloaded bootstrap. An empty expected digest records-only (no gate).
+ * Exported for unit testing.
+ */
+export function assertGetPipIntegrity(
+	actualSha256: string,
+	expectedSha256: string,
+): void {
+	if (expectedSha256 && expectedSha256.toLowerCase() !== actualSha256.toLowerCase()) {
+		throw new Error(
+			`get-pip.py integrity check failed: expected ${expectedSha256}, got ${actualSha256}. ` +
+				"Audit the new bootstrap and update GET_PIP_SHA256 before proceeding.",
+		);
+	}
+}
 
 interface PrepareOptions {
 	arch: "x64" | "arm64";
@@ -100,28 +190,57 @@ export function enableSitePackages(pthContents: string): string {
 	return rewritten.join("\n");
 }
 
-async function installPip(pythonDir: string): Promise<void> {
-	console.log(`Bootstrapping pip in ${pythonDir}...`);
+interface PipBootstrapResult {
+	getPipSha256: string;
+	pipLauncherSha256: string | null;
+}
+
+async function installPip(pythonDir: string): Promise<PipBootstrapResult> {
+	console.log(`Bootstrapping pip ${PIP_VERSION} in ${pythonDir}...`);
 	const getPipPath = path.join(pythonDir, "get-pip.py");
 	await downloadFile(GET_PIP_URL, getPipPath);
 
+	const getPipSha256 = sha256File(getPipPath);
+	try {
+		assertGetPipIntegrity(getPipSha256, GET_PIP_SHA256);
+	} catch (err) {
+		fs.unlinkSync(getPipPath);
+		throw err;
+	}
+
 	const pythonExe = path.join(pythonDir, "python.exe");
-	execSync(
-		`"${pythonExe}" "${getPipPath}" --no-warn-script-location --disable-pip-version-check`,
-		{ stdio: "inherit" },
-	);
+	// SOURCE_DATE_EPOCH makes the pip-generated launchers reproducible so the
+	// signature cache restores them instead of re-signing three files (#2926).
+	execSync(buildPipBootstrapCommand(pythonExe, getPipPath, PIP_VERSION), {
+		stdio: "inherit",
+		env: pipBootstrapEnv(process.env, PIP_SOURCE_DATE_EPOCH),
+	});
 
 	fs.unlinkSync(getPipPath);
+
+	// #2926 §5: the launchers must be reproducible. Assert they share one hash
+	// and record it, so a launcher-generating drift is caught (and the recorded
+	// hash lets a future release compare against the prior runtime state).
+	const scriptsDir = path.join(pythonDir, "Scripts");
+	const launcherHashes = PIP_LAUNCHERS.map((name) => path.join(scriptsDir, name))
+		.filter((p) => fs.existsSync(p))
+		.map((p) => ({ name: path.basename(p), sha256: sha256File(p) }));
+	const pipLauncherSha256 =
+		launcherHashes.length > 0 ? assertLaunchersReproducible(launcherHashes) : null;
+
+	return { getPipSha256, pipLauncherSha256 };
 }
 
-async function preparePython(options: PrepareOptions): Promise<string> {
+async function preparePython(
+	options: PrepareOptions,
+): Promise<{ pythonDir: string; getPipSha256: string | null; pipLauncherSha256: string | null }> {
 	const { arch, outputDir } = options;
 	const cfg = downloadConfig(arch);
 	const pythonDir = path.join(outputDir, "python");
 
 	if (fs.existsSync(pythonDir)) {
 		console.log(`Python directory already exists at ${pythonDir}, skipping...`);
-		return pythonDir;
+		return { pythonDir, getPipSha256: null, pipLauncherSha256: null };
 	}
 
 	fs.mkdirSync(pythonDir, { recursive: true });
@@ -157,8 +276,10 @@ async function preparePython(options: PrepareOptions): Promise<string> {
 	// Only run pip install when the build host can execute the downloaded
 	// python.exe — i.e. the host is Windows. Cross-platform CI prepares
 	// the zip extraction only; pip install happens on the Windows runner.
+	let getPipSha256: string | null = null;
+	let pipLauncherSha256: string | null = null;
 	if (process.platform === "win32") {
-		await installPip(pythonDir);
+		({ getPipSha256, pipLauncherSha256 } = await installPip(pythonDir));
 	} else {
 		console.log(
 			"[prepare-python-runtime] Skipping pip bootstrap on non-Windows host — " +
@@ -170,7 +291,7 @@ async function preparePython(options: PrepareOptions): Promise<string> {
 	fs.unlinkSync(zipPath);
 
 	console.log(`Python prepared at ${pythonDir}`);
-	return pythonDir;
+	return { pythonDir, getPipSha256, pipLauncherSha256 };
 }
 
 export async function preparePythonRuntime(
@@ -180,11 +301,18 @@ export async function preparePythonRuntime(
 	console.log(`Preparing embedded Python runtime for Windows ${arch}...`);
 
 	fs.mkdirSync(outputDir, { recursive: true });
-	const pythonDir = await preparePython({ arch, outputDir });
+	const { pythonDir, getPipSha256, pipLauncherSha256 } = await preparePython({
+		arch,
+		outputDir,
+	});
 
 	const manifestPath = path.join(outputDir, "embedded-python.json");
 	const manifest = {
 		python: PYTHON_VERSION,
+		pip: PIP_VERSION,
+		pipSourceDateEpoch: PIP_SOURCE_DATE_EPOCH,
+		getPipSha256,
+		pipLauncherSha256,
 		arch,
 		platform: "win32",
 		preparedAt: new Date().toISOString(),
@@ -233,4 +361,4 @@ if (isInvokedAsCli(import.meta.url, process.argv[1])) {
 		});
 }
 
-export { PYTHON_VERSION };
+export { PYTHON_VERSION, PIP_VERSION, PIP_SOURCE_DATE_EPOCH };

--- a/scripts/sign-windows-payload.ps1
+++ b/scripts/sign-windows-payload.ps1
@@ -80,7 +80,9 @@ function Write-SigningTelemetry {
     [int]$WouldSign,
     [int]$Signed,
     [int]$PreviousSigned,
-    [int]$Max
+    [int]$Max,
+    [int]$UniqueHashes = 0,
+    [int]$AliasesRestored = 0
   )
   if (-not $Path) { return }
   $dir = Split-Path -Parent $Path
@@ -95,6 +97,8 @@ function Write-SigningTelemetry {
     skipped = $Skipped
     would_sign = $WouldSign
     signed = $Signed
+    unique_hashes = $UniqueHashes
+    aliases_restored = $AliasesRestored
     previous_signed = $PreviousSigned
     max_signatures = if ($Max -ge 0) { $Max } else { $null }
   }
@@ -176,18 +180,29 @@ if ($targets.Count -eq 0) {
   Write-SigningTelemetry -Path $TelemetryFile -Status "success" -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign 0 -Signed 0 -PreviousSigned $previousSigned -Max $maxSignatureBudget
   exit 0
 }
+# Deduplicate identical unsigned files by content hash so byte-identical targets
+# (e.g. the three reproducible pip launchers, #2926) spend one cloud signature,
+# not one each. The signed representative is propagated to its aliases after
+# signing; every alias is verified below.
+$hashGroups = @($targets | Group-Object -Property { (Get-FileHash -LiteralPath $_ -Algorithm SHA256).Hash })
+$representatives = @($hashGroups | ForEach-Object { $_.Group[0] })
+$aliasesRestored = $targets.Count - $representatives.Count
+if ($aliasesRestored -gt 0) {
+  Write-Host "Deduplicated $($targets.Count) unsigned file(s) to $($representatives.Count) unique hash(es); $aliasesRestored alias(es) will reuse a signed representative."
+}
+
 $previousSigned = Read-PreviousSignedCount -Path $TelemetryFile
-$projectedSigned = $previousSigned + $targets.Count
+$projectedSigned = $previousSigned + $representatives.Count
 $telemetryStatus = "success"
 if ($maxSignatureBudget -ge 0) {
-  Write-Host "Windows signing budget: $previousSigned already signed, this invocation would sign $($targets.Count), max $maxSignatureBudget."
+  Write-Host "Windows signing budget: $previousSigned already signed, this invocation would sign $($representatives.Count), max $maxSignatureBudget."
   if ($projectedSigned -gt $maxSignatureBudget) {
-    Write-Host "::warning::Windows signing budget exceeded: signing $($targets.Count) more file(s) would bring this release to $projectedSigned cloud signature(s), above MAX_SIGNATURES=$maxSignatureBudget."
+    Write-Host "::warning::Windows signing budget exceeded: signing $($representatives.Count) more file(s) would bring this release to $projectedSigned cloud signature(s), above MAX_SIGNATURES=$maxSignatureBudget."
     Write-Host "::warning::Release signing will continue. Audit sign-targets.txt / Windows signing telemetry and raise MAX_SIGNATURES if this release intentionally needs the extra signatures."
     $telemetryStatus = "over_budget"
   }
 }
-Write-Host "Signing $($targets.Count) file(s) in batches of $BatchSize (delay ${DelaySeconds}s between batches)..."
+Write-Host "Signing $($representatives.Count) unique file(s) in batches of $BatchSize (delay ${DelaySeconds}s between batches)..."
 
 # Discover the newest x64 signtool.exe from the installed Windows 10 SDK rather
 # than hardcoding an SDK version that drifts on the hosted runner.
@@ -204,9 +219,9 @@ Write-Host "Using signtool: $($signtool.FullName)"
 # signtool signs each file by sending only its hash to the SSL.com cloud (one op
 # per file). Retry each batch for transient cloud/timestamp failures.
 $ts = "http://ts.ssl.com"
-for ($i = 0; $i -lt $targets.Count; $i += $BatchSize) {
-  $end = [Math]::Min($i + $BatchSize - 1, $targets.Count - 1)
-  $batch = @($targets[$i..$end])
+for ($i = 0; $i -lt $representatives.Count; $i += $BatchSize) {
+  $end = [Math]::Min($i + $BatchSize - 1, $representatives.Count - 1)
+  $batch = @($representatives[$i..$end])
   $attempt = 0
   while ($true) {
     $attempt++
@@ -219,10 +234,21 @@ for ($i = 0; $i -lt $targets.Count; $i += $BatchSize) {
     Write-Host "signtool batch failed (exit $LASTEXITCODE); retry $attempt/$MaxRetries after backoff..."
     Start-Sleep -Seconds (5 * $attempt)
   }
-  Write-Host "  signed $([Math]::Min($i + $BatchSize, $targets.Count))/$($targets.Count)"
+  Write-Host "  signed $([Math]::Min($i + $BatchSize, $representatives.Count))/$($representatives.Count)"
   # Throttle between batches (not after the last) to stay under the rate limit.
-  if ($DelaySeconds -gt 0 -and ($i + $BatchSize) -lt $targets.Count) {
+  if ($DelaySeconds -gt 0 -and ($i + $BatchSize) -lt $representatives.Count) {
     Start-Sleep -Seconds $DelaySeconds
+  }
+}
+
+# Propagate each signed representative to its byte-identical aliases. They had
+# the same unsigned content, so the representative's Authenticode signature is
+# valid for them too (signtool binds to content, not filename). Every alias is
+# verified in the loop below.
+foreach ($group in $hashGroups) {
+  $rep = $group.Group[0]
+  foreach ($alias in @($group.Group | Select-Object -Skip 1)) {
+    Copy-Item -LiteralPath $rep -Destination $alias -Force
   }
 }
 
@@ -238,5 +264,5 @@ if ($unsigned.Count -gt 0) {
   $unsigned | ForEach-Object { Write-Host "    $_" }
   exit 1
 }
-Write-SigningTelemetry -Path $TelemetryFile -Status $telemetryStatus -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign $targets.Count -Signed $targets.Count -PreviousSigned $previousSigned -Max $maxSignatureBudget
-Write-Host "All $($targets.Count) file(s) carry a Valid Authenticode signature."
+Write-SigningTelemetry -Path $TelemetryFile -Status $telemetryStatus -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign $representatives.Count -Signed $representatives.Count -UniqueHashes $representatives.Count -AliasesRestored $aliasesRestored -PreviousSigned $previousSigned -Max $maxSignatureBudget
+Write-Host "All $($targets.Count) file(s) carry a Valid Authenticode signature ($($representatives.Count) cloud signature(s), $aliasesRestored alias(es) reused)."

--- a/tests/unit/prepare-python-reproducible.test.ts
+++ b/tests/unit/prepare-python-reproducible.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Guards the reproducible pip-launcher bootstrap so unchanged inputs stop re-signing pip*.exe (#2926).
+// ABOUTME: Unit-level only — the byte-identical-launcher proof is a Windows release-time observation.
+
+import { describe, expect, it } from "vitest";
+import {
+  assertGetPipIntegrity,
+  assertLaunchersReproducible,
+  buildPipBootstrapCommand,
+  PIP_SOURCE_DATE_EPOCH,
+  PIP_VERSION,
+  pipBootstrapEnv,
+} from "../../build/win32/prepare-python-runtime";
+
+describe("reproducible pip bootstrap (#2926)", () => {
+  it("forces a fixed SOURCE_DATE_EPOCH so distlib launcher ZIPs are deterministic", () => {
+    const env = pipBootstrapEnv({ PATH: "/usr/bin" }, PIP_SOURCE_DATE_EPOCH);
+    // The launcher timestamp non-determinism is the whole bug: the subprocess
+    // MUST carry the fixed epoch, and the base env must survive.
+    expect(env.SOURCE_DATE_EPOCH).toBe(String(PIP_SOURCE_DATE_EPOCH));
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  it("pins the exact pip version in the bootstrap command", () => {
+    const cmd = buildPipBootstrapCommand("C:/py/python.exe", "C:/py/get-pip.py", PIP_VERSION);
+    expect(cmd).toContain(`"pip==${PIP_VERSION}"`);
+    expect(cmd).toContain("--disable-pip-version-check");
+  });
+
+  it("uses explicit, valid pinned config", () => {
+    expect(PIP_VERSION).toMatch(/^\d+\.\d+(\.\d+)?$/);
+    expect(Number.isInteger(PIP_SOURCE_DATE_EPOCH)).toBe(true);
+    expect(PIP_SOURCE_DATE_EPOCH).toBeGreaterThan(0);
+  });
+
+  it("fails closed when a pinned get-pip digest does not match", () => {
+    expect(() => assertGetPipIntegrity("aaaa", "bbbb")).toThrow(/integrity check failed/i);
+  });
+
+  it("passes a matching digest (case-insensitive) and is record-only when unpinned", () => {
+    expect(() => assertGetPipIntegrity("ABCDEF", "abcdef")).not.toThrow();
+    expect(() => assertGetPipIntegrity("anything", "")).not.toThrow();
+  });
+
+  it("returns the shared hash when all pip launchers are reproducible", () => {
+    const shared = assertLaunchersReproducible([
+      { name: "pip.exe", sha256: "DEAD" },
+      { name: "pip3.exe", sha256: "dead" },
+      { name: "pip3.12.exe", sha256: "dead" },
+    ]);
+    expect(shared).toBe("dead");
+  });
+
+  it("fails closed when the pip launchers diverge (#2926 §5)", () => {
+    expect(() =>
+      assertLaunchersReproducible([
+        { name: "pip.exe", sha256: "aaa" },
+        { name: "pip3.exe", sha256: "bbb" },
+        { name: "pip3.12.exe", sha256: "aaa" },
+      ]),
+    ).toThrow(/not reproducible/i);
+  });
+});


### PR DESCRIPTION
Closes #2926. Closes #2927.

Implements #2926 (make the pip launchers reproducible so they stop re-signing every release) and supersedes #2927's pip optimization by keeping the launchers signed and functional rather than excluding them.

## Root cause

`build/win32/prepare-python-runtime.ts` ran `get-pip.py` **without `SOURCE_DATE_EPOCH`**, so pip's vendored distlib stamped the current time into each Windows console-launcher's embedded ZIP. Two clean builds at different times produced different `pip.exe`/`pip3.exe`/`pip3.12.exe` hashes even with identical pip (26.1.2) and build path — so the content-addressed R2 cache always missed them and re-signed **3 files every release** (confirmed across v3.68.9 and v3.69.0).

## Changes

**`build/win32/prepare-python-runtime.ts` (#2926 §1, §5)**
- Pin `PIP_VERSION` and install it explicitly.
- Set a fixed `PIP_SOURCE_DATE_EPOCH` on the bootstrap subprocess → reproducible launcher bytes → cacheable.
- Record `pip`, `pipSourceDateEpoch`, `getPipSha256`, `pipLauncherSha256` in `embedded-python.json`.
- `assertGetPipIntegrity` fails closed when `GET_PIP_SHA256` is pinned (record-only otherwise).
- `assertLaunchersReproducible` fails closed if the three launchers don't share one hash (§5 intra-build reproducibility gate).

**`scripts/sign-windows-payload.ps1` (#2926 §3)**
- Deduplicate identical unsigned targets by SHA-256 before signing: sign one representative per unique hash, propagate its signature to same-hash aliases, verify **every** file, and report `unique_hashes` / `aliases_restored` in telemetry.
- Bounds a reseed build to **1** launcher operation instead of 3; steady-state builds restore all three from cache (**0** operations).

**§4** reuses the existing content-addressed cache — no second cache system. Independent of the #2922 cache-health gate (they gate different failures).

## Tests

`tests/unit/prepare-python-reproducible.test.ts` (runs locally): SOURCE_DATE_EPOCH is forced on the bootstrap env, pip version is pinned, get-pip integrity fails closed / is record-only when unpinned, and the launcher-reproducibility assertion returns the shared hash / fails closed on divergence. Full unit suite green (2294 passed).

## Validation constraints (explicit)

The pip bootstrap and signer only run on Windows, so the **op-reduction proof is a release-time observation**, per this ticket's own acceptance ("two consecutive green releases"): first post-rollout release ≤1 launcher op, next unchanged release 0. The signer change has no local test harness (needs signtool); it is validated by the next Windows release signing telemetry — which will show `unique_hashes` / `aliases_restored` and the launcher ops dropping. Cutting a release right after merge is the intended verification.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
