### PR TITLE
fix(release): hard-stop Windows signing over budget (#2929)

### DIFF
--- a/.github/workflows/publish-release-manual.yml
+++ b/.github/workflows/publish-release-manual.yml
@@ -148,13 +148,16 @@ jobs:
                 if (!fs.statSync(dir).isDirectory()) return false;
                 return fs.readdirSync(dir).some((f) => f.endsWith('-setup.exe'));
               });
-            const windowsSignedClaim = isProductionTag && hasWindowsArtifact
+            const budgetStatePath = path.join(artifactsDir, 'windows-signing-budget-state', 'windows-signing-budget-state.json');
+            const windowsSigningBlocked = fs.existsSync(budgetStatePath)
+              && JSON.parse(fs.readFileSync(budgetStatePath, 'utf8')).blocked === true;
+            const windowsSignedClaim = isProductionTag && hasWindowsArtifact && !windowsSigningBlocked
               ? 'Windows builds are EV code signed. If you still see a SmartScreen warning, click "More info" -> "Run anyway"; reputation builds with installs.'
               : 'Windows artifacts in this release are NOT EV code signed.';
             const noteMarker = '<!-- WINDOWS_SIGNING_NOTE -->';
             if (publishTarget.body && publishTarget.body.includes(noteMarker)) {
               const updatedBody = publishTarget.body.replace(noteMarker, windowsSignedClaim);
-              console.log(`Resolving Windows signing note: tag=${tagName} hasWindowsArtifact=${hasWindowsArtifact}`);
+              console.log(`Resolving Windows signing note: tag=${tagName} hasWindowsArtifact=${hasWindowsArtifact} budgetBlocked=${windowsSigningBlocked}`);
               await github.rest.repos.updateRelease({
                 owner,
                 repo,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,10 @@ env:
   HAS_APPLE_SIGNING: ${{ secrets.APPLE_CERTIFICATE != '' }}
   # SSL.com eSigner cloud signing for Windows EV code signing
   HAS_WINDOWS_SIGNING: ${{ secrets.ES_USERNAME != '' }}
-  # Warning threshold for billable SSL.com cloud hash-signing operations in one
-  # Windows release job. Bump only after auditing sign-targets.txt / signer telemetry.
-  MAX_SIGNATURES: ${{ vars.MAX_SIGNATURES || '850' }}
+  # Fail-closed ceiling for billable SSL.com cloud hash-signing operations in one
+  # Windows release job. Normal releases spend roughly 0-10; 100 leaves ample
+  # drift while a cold/full cache reseed requires an explicit audited repo override.
+  MAX_SIGNATURES: ${{ vars.MAX_SIGNATURES || '100' }}
   # Hard gate for unchanged embedded-runtime releases: if the manifest matches
   # the previous release, a working signature cache should make this near zero.
   WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED: ${{ vars.WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED || '25' }}
@@ -305,12 +306,14 @@ jobs:
             seren-desktop-publishers \
             seren-desktop-mcp
 
-      # Windows: gate v* tag releases on signing being available.
+      # Windows: gate v* tag releases on signing credentials being available.
       # Without this, a misconfigured secret causes us to ship an unsigned
       # Windows binary that Smart App Control immediately blocks (#2230 audit
       # P1 "Release workflow can claim EV signing even when Windows signing
       # is skipped"). For tag pushes that ARE production releases, refuse to
-      # proceed rather than ship unsigned.
+      # proceed rather than silently ship unsigned. A runtime MAX_SIGNATURES
+      # block is distinct: the signer records it and the release intentionally
+      # continues with the transparently unsigned fallback required by #2929.
       - name: Require Windows signing for tag releases
         if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/v') && env.HAS_WINDOWS_SIGNING != 'true'
         shell: bash
@@ -330,9 +333,14 @@ jobs:
             exit 1
           }
           $telemetry = Join-Path $env:RUNNER_TEMP "windows-signing-telemetry.jsonl"
+          $blockFile = Join-Path $env:RUNNER_TEMP "windows-signing-budget-block.json"
           Remove-Item -LiteralPath $telemetry -Force -ErrorAction SilentlyContinue
+          Remove-Item -LiteralPath $blockFile -Force -ErrorAction SilentlyContinue
           "WINDOWS_SIGN_TELEMETRY_FILE=$telemetry" >> $env:GITHUB_ENV
+          "WINDOWS_SIGNING_BLOCK_FILE=$blockFile" >> $env:GITHUB_ENV
+          "WINDOWS_SIGNING_BLOCKED=false" >> $env:GITHUB_ENV
           Write-Host "Windows signing telemetry: $telemetry"
+          Write-Host "Windows signing block state: $blockFile"
           Write-Host "Windows signing MAX_SIGNATURES=$max"
 
       # macOS: Import certificates and setup keychain (skip if no certificate)
@@ -571,6 +579,7 @@ jobs:
           ./scripts/sign-windows-payload.ps1 `
             -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT `
             -ListFile sign-targets.txt `
+            -SigningSource "embedded-runtime-and-mcp" `
             -BatchSize 10 `
             -DelaySeconds 30
           ./scripts/windows-signature-cache.ps1 `
@@ -581,7 +590,7 @@ jobs:
             -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT
 
       - name: Save Windows signature cache to R2
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -616,7 +625,7 @@ jobs:
           Write-Host "Windows signature cache: R2 save completed."
 
       - name: Assert Windows signature cache hit budget
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         run: |
           ./scripts/assert-windows-signature-cache.ps1 `
@@ -650,7 +659,7 @@ jobs:
             -Thumbprint $env:WINDOWS_SIGN_THUMBPRINT
 
       - name: Save NSIS signature cache to R2
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -713,7 +722,7 @@ jobs:
       # The overlay lives outside tauri.conf.json so contributor Windows
       # builds never attempt to sign. The wrapper reads WINDOWS_SIGN_THUMBPRINT
       # from the eSigner CKA step via GITHUB_ENV.
-      - name: Build Tauri app (signed, Windows)
+      - name: Build Tauri app (budget-aware, Windows)
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
         env:
           # The embedded runtime was already staged and EV-signed above; skip
@@ -743,9 +752,7 @@ jobs:
           Add-Content -LiteralPath $summary -Value "- MAX_SIGNATURES: $env:MAX_SIGNATURES"
           Add-Content -LiteralPath $summary -Value "- Telemetry: ``$telemetry``"
           if (-not $telemetry -or -not (Test-Path -LiteralPath $telemetry)) {
-            Add-Content -LiteralPath $summary -Value "- Status: no signing telemetry was produced before the job stopped."
-            Write-Host "No Windows signing telemetry found at: $telemetry"
-            exit 0
+            throw "No Windows signing telemetry found at: $telemetry"
           }
 
           $records = @()
@@ -759,19 +766,21 @@ jobs:
           [int]$skipped = 0
           [int]$wouldSign = 0
           [int]$signed = 0
-          $overBudget = $false
+          $blocked = $false
           foreach ($record in $records) {
             if ($null -ne $record.discovered) { $discovered += [int]$record.discovered }
             if ($null -ne $record.skipped) { $skipped += [int]$record.skipped }
             if ($null -ne $record.would_sign) { $wouldSign += [int]$record.would_sign }
             if ($null -ne $record.signed) { $signed += [int]$record.signed }
-            if ($record.status -eq "over_budget") { $overBudget = $true }
+            if ($record.status -eq "blocked_over_budget" -or $record.status -eq "skipped_budget_blocked") { $blocked = $true }
           }
-          $status = if ($overBudget) { "over budget warning" } else { "within budget" }
+          $status = if ($blocked) { "blocked_over_budget" } else { "within_budget" }
           Add-Content -LiteralPath $summary -Value "- Status: $status"
+          Add-Content -LiteralPath $summary -Value "- Projected cloud signatures: $wouldSign"
           Add-Content -LiteralPath $summary -Value "- Discovered: $discovered"
           Add-Content -LiteralPath $summary -Value "- Skipped already valid: $skipped"
-          Add-Content -LiteralPath $summary -Value "- Cloud signatures spent: $signed"
+          Add-Content -LiteralPath $summary -Value "- Actual cloud signatures spent: $signed"
+          Add-Content -LiteralPath $summary -Value "- Signing blocked: $($blocked.ToString().ToLowerInvariant())"
           Add-Content -LiteralPath $summary -Value ""
           Add-Content -LiteralPath $summary -Value "| Status | Source | Discovered | Skipped | Would sign | Signed | Previous signed |"
           Add-Content -LiteralPath $summary -Value "|---|---|---:|---:|---:|---:|---:|"
@@ -779,7 +788,17 @@ jobs:
             $source = ([string]$record.source).Replace("|", "\|")
             Add-Content -LiteralPath $summary -Value "| $($record.status) | ``$source`` | $($record.discovered) | $($record.skipped) | $($record.would_sign) | $($record.signed) | $($record.previous_signed) |"
           }
-          Write-Host "Windows signing budget summary: status=$status discovered=$discovered skipped=$skipped signed=$signed max=$env:MAX_SIGNATURES"
+          $state = [PSCustomObject]@{
+            schema_version = 1
+            status = $status
+            blocked = $blocked
+            max_signatures = [int]$env:MAX_SIGNATURES
+            projected_total = $wouldSign
+            actual_signed = $signed
+            sources = @($records)
+          }
+          ($state | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath "windows-signing-budget-state.json"
+          Write-Host "Windows signing budget summary: status=$status projected=$wouldSign signed=$signed max=$env:MAX_SIGNATURES"
 
       # Verify dist/ contains current frontend code.
       # Catches stale dist/ bundles that bypass beforeBuildCommand.
@@ -1011,7 +1030,7 @@ jobs:
       # users' machines (#2230 audit P0/P1 #1).
       - name: Verify Windows code signing (NSIS setup .exe)
         id: verify_windows_setup
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         run: |
           Write-Host "Verifying NSIS setup .exe signatures..."
@@ -1039,7 +1058,7 @@ jobs:
       # as a guarantee until a green release proves it redundant (#2294). It
       # mirrors the macOS .app.tar.gz re-pack/re-sign pattern above (#2236).
       - name: Re-pack and re-sign .nsis.zip updater bundle (Windows)
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         run: |
           $nsisDir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis"
@@ -1085,7 +1104,7 @@ jobs:
       # by Tauri repacking artifacts and losing signatures (#2236) and by a
       # Deflate re-pack the updater cannot extract (#2479), so this is a hard gate.
       - name: Verify .nsis.zip updater bundle signatures (Windows)
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         run: |
           $nsisDir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis"
@@ -1191,7 +1210,7 @@ jobs:
       # (.nsis.zip) and #2237 ($PLUGINSDIR helper DLLs).
       - name: Audit Windows payload signature coverage
         id: audit_windows_payload
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         run: |
           $bundleRoot = "src-tauri/target/${{ matrix.target }}/release/bundle"
@@ -1224,7 +1243,7 @@ jobs:
       # Valid Authenticode signature. This is what a user's Smart App Control
       # actually evaluates, so a failure here means a real publisher prompt.
       - name: Verify embedded installer payload signatures (Windows)
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         shell: pwsh
         run: |
           $nsisDir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis"
@@ -1271,6 +1290,23 @@ jobs:
           }
           Write-Host "All $($bins.Count) embedded installer binaries (incl. `$PLUGINSDIR helper DLLs) are validly signed."
           Remove-Item -Path $extractDir -Recurse -Force
+
+      - name: Verify budget-blocked Windows fallback is unsigned
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED == 'true'
+        shell: pwsh
+        run: |
+          $nsisDir = "src-tauri/target/${{ matrix.target }}/release/bundle/nsis"
+          $setup = Get-ChildItem -Path $nsisDir -Filter "*-setup.exe" | Select-Object -First 1
+          if (-not $setup) {
+            Write-Host "::error::Budget-blocked build produced no Windows setup artifact."
+            exit 1
+          }
+          $sig = Get-AuthenticodeSignature -LiteralPath $setup.FullName
+          if ($sig.Status -eq "Valid") {
+            Write-Host "::error::Budget-blocked fallback unexpectedly produced a validly Authenticode-signed setup artifact."
+            exit 1
+          }
+          Write-Host "Budget-blocked Windows fallback is present and not EV signed: $($setup.Name) status=$($sig.Status)."
 
       # Scan the Tauri-generated NSI / NSH output for unresolved ${...}
       # placeholders. #2230 showed "${product_name} is running" rendering
@@ -1363,11 +1399,19 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload Windows signing cache state
-        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true' && env.WINDOWS_SIGNING_BLOCKED != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: windows-signing-cache-state
           path: windows-signing-cache-state.json
+          if-no-files-found: error
+
+      - name: Upload Windows signing budget state
+        if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-signing-budget-state
+          path: windows-signing-budget-state.json
           if-no-files-found: error
 
       - name: Upload Linux updater bundle
@@ -1410,6 +1454,12 @@ jobs:
         with:
           name: Seren-Desktop-Windows-x64.exe
           path: windows-artifact
+
+      - name: Download Windows signing budget state
+        uses: actions/download-artifact@v8
+        with:
+          name: windows-signing-budget-state
+          path: windows-signing-budget-state
 
       - name: Validate Windows e2e AWS configuration
         shell: bash
@@ -1573,9 +1623,15 @@ jobs:
           set -euo pipefail
           installer="$(find windows-artifact -type f -name '*.exe' | head -n 1)"
           if [ -z "$installer" ]; then
-            echo "::error::No signed Windows installer artifact found"
+            echo "::error::No Windows installer artifact found"
             exit 1
           fi
+          budget_state="windows-signing-budget-state/windows-signing-budget-state.json"
+          if [ ! -f "$budget_state" ]; then
+            echo "::error::Windows signing budget state artifact is missing"
+            exit 1
+          fi
+          signing_blocked="$(jq -r 'if .blocked == true then "true" else "false" end' "$budget_state")"
           payload="$RUNNER_TEMP/windows-e2e-payload.zip"
           zip -q -r "$payload" \
             package.json \
@@ -1622,6 +1678,7 @@ jobs:
           PY
           )"
           echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
+          echo "signing_blocked=$signing_blocked" >> "$GITHUB_OUTPUT"
           {
             echo "installer_url<<EOF"
             echo "$installer_url"
@@ -1642,6 +1699,7 @@ jobs:
           INSTALLER_URL: ${{ steps.stage.outputs.installer_url }}
           PAYLOAD_URL: ${{ steps.stage.outputs.payload_url }}
           LOGS_UPLOAD_URL: ${{ steps.stage.outputs.logs_upload_url }}
+          WINDOWS_SIGNING_BLOCKED: ${{ steps.stage.outputs.signing_blocked }}
         run: |
           set -euo pipefail
           node <<'NODE' > "$RUNNER_TEMP/windows-e2e-commands.json"
@@ -1652,6 +1710,9 @@ jobs:
           }
           const workName = `seren-release-windows-e2e-${env.GITHUB_RUN_ID}-${env.GITHUB_RUN_ATTEMPT}`;
           const logsS3Uri = `s3://${env.WINDOWS_E2E_S3_BUCKET}/${env.S3_PREFIX}/windows-e2e-logs.zip`;
+          const unsignedBudgetArg = env.WINDOWS_SIGNING_BLOCKED === 'true'
+            ? ' -AllowUnsignedBudgetBlockedArtifact'
+            : '';
           const commands = [
             "$ErrorActionPreference = 'Stop'",
             "$ProgressPreference = 'SilentlyContinue'",
@@ -1679,7 +1740,7 @@ jobs:
             "Expand-Archive -LiteralPath (Join-Path $work 'windows-e2e-payload.zip') -DestinationPath $work -Force",
             "Set-Location $work",
             "Write-Host '[windows-e2e:ssm] Running Windows app harness as scheduled task user'",
-            `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-task-user.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe') -WorkDir $work -SecretParameterPrefix ${psString(env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX)} -ProbeTimeoutSeconds 1800 -TaskTimeoutSeconds 3600`,
+            `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-task-user.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe') -WorkDir $work -SecretParameterPrefix ${psString(env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX)} -ProbeTimeoutSeconds 1800 -TaskTimeoutSeconds 3600${unsignedBudgetArg}`,
             "$harnessExitCode = $LASTEXITCODE",
             "Write-Host '[windows-e2e:ssm] Bundling Windows app harness logs'",
             "$logPaths = @((Join-Path $work 'windows-e2e-task.log'), (Join-Path $work 'windows-e2e-logs')) | Where-Object { Test-Path -LiteralPath $_ }",
@@ -1989,13 +2050,16 @@ jobs:
                 if (!fs.statSync(dir).isDirectory()) return false;
                 return fs.readdirSync(dir).some((f) => f.endsWith('-setup.exe'));
               });
-            const windowsSignedClaim = isProductionTag && hasWindowsArtifact
+            const budgetStatePath = path.join(artifactsDir, 'windows-signing-budget-state', 'windows-signing-budget-state.json');
+            const windowsSigningBlocked = fs.existsSync(budgetStatePath)
+              && JSON.parse(fs.readFileSync(budgetStatePath, 'utf8')).blocked === true;
+            const windowsSignedClaim = isProductionTag && hasWindowsArtifact && !windowsSigningBlocked
               ? 'Windows builds are EV code signed. If you still see a SmartScreen warning, click "More info" → "Run anyway"; reputation builds with installs.'
               : 'Windows artifacts in this release are NOT EV code signed.';
             const noteMarker = '<!-- WINDOWS_SIGNING_NOTE -->';
             if (publishTarget.body && publishTarget.body.includes(noteMarker)) {
               const updatedBody = publishTarget.body.replace(noteMarker, windowsSignedClaim);
-              console.log(`Resolving Windows signing note: tag=${tagName} hasWindowsArtifact=${hasWindowsArtifact}`);
+              console.log(`Resolving Windows signing note: tag=${tagName} hasWindowsArtifact=${hasWindowsArtifact} budgetBlocked=${windowsSigningBlocked}`);
               await github.rest.repos.updateRelease({
                 owner,
                 repo,

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -48,7 +48,7 @@ Add these secrets to the repository settings (Settings → Secrets → Actions):
 
 | Variable | Description |
 |----------|-------------|
-| `MAX_SIGNATURES` | Warning threshold for SSL.com cloud hash-signing operations in one Windows release job. Defaults to `850` in `release.yml`; raise only after reviewing `sign-targets.txt` and the Windows signing job summary. |
+| `MAX_SIGNATURES` | Fail-closed ceiling for SSL.com cloud hash-signing operations in one Windows release job. Defaults to `100` in `release.yml`; an intentional cold/full cache reseed above that ceiling requires an explicit repository-variable override after reviewing the signable inventory. |
 | `WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED` | Hard-fail threshold for fresh embedded-runtime signatures when the signable manifest matches the previous release. Defaults to `25`; keep this low so a broken signature cache fails before release artifacts publish. |
 
 ## Certificate Setup
@@ -169,16 +169,30 @@ the artifact that embeds it is produced:
    is re-packed from the signed `.exe` and its `.nsis.zip.sig` re-signed with
    the Tauri updater key (`#2236`).
 
-### Budget telemetry (release CI, warning-only)
+### Signing budget barrier (release CI, fail-closed)
 
 Each Windows release writes a **Windows signing budget** section to the GitHub
 job summary. Recent audits found roughly 715-729 embedded-runtime signables,
-plus the NSIS/tooling and Tauri wrapper signings. The default warning threshold
-is `850`, leaving limited headroom for normal drift while making unexpected
-growth visible without blocking a production release. Review the discovered,
-skipped, and cloud-signatures-spent counts before changing `MAX_SIGNATURES`; a
-threshold bump should be paired with an audit of the added files and why they
-must be signed.
+but healthy cache-backed releases spend roughly 0-10 fresh cloud signatures.
+The default ceiling is `100`: enough for ordinary drift, but low enough to stop
+a collapsed cache or unexpected signing source. A deliberate cold/full cache
+reseed can exceed that value only through an explicit audited `MAX_SIGNATURES`
+repository-variable override.
+
+Every signer invocation contributes to one shared JSONL ledger, including the
+embedded runtime and MCP binaries, NSIS stock plugins, Seren.exe, helper DLLs,
+the uninstaller, and the setup executable. Before `signtool` is discovered or
+called, the signer checks `actual signed so far + this source's unique unsigned
+hashes`. Exceeding the ceiling writes `blocked_over_budget`, persists a block
+state, and makes every later signing source record-and-skip without contacting
+SSL.com. Malformed telemetry or a missing/invalid `MAX_SIGNATURES` fails the run
+as CI misconfiguration instead of disabling the barrier.
+
+A runtime budget block protects spend, not availability. The Windows build and
+real AWS-hosted app walkthrough continue, signature-only verification gates are
+skipped, and CI asserts that the resulting setup executable is not EV signed.
+The installer and updater artifacts still publish, while release notes are
+resolved to **NOT EV code signed** from the uploaded budget-state artifact.
 
 The embedded-runtime signature cache should make the second release with an
 unchanged runtime report most of that large payload as skipped already valid,
@@ -204,12 +218,13 @@ and runs `scripts/assert-windows-signature-cache.ps1` against the real signer
 telemetry.
 
 If the manifest hash matches the previous release, the embedded-runtime set is
-unchanged. In that case, the cache must restore almost all previously signed
-binaries before the signer runs. Fresh embedded-runtime signatures above
-`WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED` fail the Windows build with an
-explicit cache-regression error. If no previous state exists yet, or the
-manifest hash changed because the runtime genuinely changed, the gate writes
-the current state and skips the assertion for that release.
+unchanged. In that case, fresh embedded-runtime signatures above
+`WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED` fail the Windows build. If the
+manifest changed, the cache must still restore at least
+`WINDOWS_EMBEDDED_RUNTIME_CACHE_MIN_RESTORE_RATE` percent of the per-file set.
+The cache-health gate remains independent of the release-wide budget barrier;
+on a budget-blocked unsigned fallback it does not attempt to certify signed
+output or upload a signed-cache state for the next release.
 
 ### Verification gates (release CI, hard-fail)
 

--- a/scripts/sign-windows-payload.ps1
+++ b/scripts/sign-windows-payload.ps1
@@ -1,6 +1,6 @@
 # ABOUTME: Signs Windows PE binaries in place with signtool using the eSigner CKA-loaded EV cert (#2276).
 # ABOUTME: Takes signables from -Root/-File/-ListFile, skips already-signed, signs in throttled batches (#2282), fails loud if any file is left unsigned.
-# ABOUTME: Reports the Windows release signature budget and writes per-invocation telemetry (#2818/#2821).
+# ABOUTME: Hard-stops before signtool when the cumulative release budget would be exceeded and records per-source telemetry.
 
 [CmdletBinding()]
 param(
@@ -22,22 +22,26 @@ param(
   # file, so bursting the whole payload trips SSL.com's per-minute rate limit
   # (#2282). Pausing between batches holds the request rate under that ceiling.
   [int]$DelaySeconds = 0,
-  # Maximum cumulative cloud hash-signing operations expected for this release job.
-  # Defaults from MAX_SIGNATURES; unset/-1 disables the warning for local ad-hoc use.
+  # Maximum cumulative cloud hash-signing operations allowed for this release job.
+  # Defaults from the required MAX_SIGNATURES environment variable.
   [int]$MaxSignatures = -1,
   # JSONL telemetry file shared across signer invocations in one release job.
   # Defaults from WINDOWS_SIGN_TELEMETRY_FILE.
   [string]$TelemetryFile = "",
+  # Human-readable source shown in budget telemetry.
+  [string]$SigningSource = "",
   [int]$MaxRetries = 3
 )
 
 $ErrorActionPreference = "Stop"
 
-function Resolve-MaxSignatureBudget {
-  param([int]$Explicit)
+function Resolve-MaxSignatureBudget([int]$Explicit) {
   if ($Explicit -ge 0) { return $Explicit }
   $raw = $env:MAX_SIGNATURES
-  if (-not $raw) { return -1 }
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    Write-Host "::error::MAX_SIGNATURES is required and must be a non-negative integer."
+    exit 1
+  }
   [int]$parsed = 0
   if (-not [int]::TryParse($raw, [ref]$parsed) -or $parsed -lt 0) {
     Write-Host "::error::MAX_SIGNATURES must be a non-negative integer, got '$raw'."
@@ -47,27 +51,12 @@ function Resolve-MaxSignatureBudget {
 }
 
 function Get-SigningSource {
+  if ($SigningSource) { return $SigningSource }
   if ($ListFile) { return "list:$ListFile" }
-  if ($File.Count -gt 0 -and $Root.Count -eq 0) { return "file" }
+  if ($File.Count -eq 1 -and $Root.Count -eq 0) { return "file:$([IO.Path]::GetFileName($File[0]))" }
+  if ($File.Count -gt 1 -and $Root.Count -eq 0) { return "files:$($File.Count)" }
   if ($Root.Count -gt 0 -and $File.Count -eq 0) { return "root" }
   return "mixed"
-}
-
-function Read-PreviousSignedCount {
-  param([string]$Path)
-  if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return 0 }
-  [int]$total = 0
-  foreach ($line in (Get-Content -LiteralPath $Path)) {
-    $trimmed = $line.Trim()
-    if (-not $trimmed) { continue }
-    try {
-      $record = $trimmed | ConvertFrom-Json
-      if ($null -ne $record.signed) { $total += [int]$record.signed }
-    } catch {
-      Write-Host "::warning::Ignoring malformed Windows signing telemetry line in ${Path}: $trimmed"
-    }
-  }
-  return $total
 }
 
 function Write-SigningTelemetry {
@@ -81,6 +70,7 @@ function Write-SigningTelemetry {
     [int]$Signed,
     [int]$PreviousSigned,
     [int]$Max,
+    [int]$ProjectedTotal,
     [int]$UniqueHashes = 0,
     [int]$AliasesRestored = 0
   )
@@ -100,7 +90,9 @@ function Write-SigningTelemetry {
     unique_hashes = $UniqueHashes
     aliases_restored = $AliasesRestored
     previous_signed = $PreviousSigned
-    max_signatures = if ($Max -ge 0) { $Max } else { $null }
+    max_signatures = $Max
+    projected_total = $ProjectedTotal
+    blocked = $false
   }
   ($record | ConvertTo-Json -Compress) | Add-Content -LiteralPath $Path
 }
@@ -112,7 +104,7 @@ if (-not $Thumbprint) {
   Write-Host "::error::No certificate thumbprint: pass -Thumbprint or set WINDOWS_SIGN_THUMBPRINT (exported by the eSigner CKA setup step)."
   exit 1
 }
-$maxSignatureBudget = Resolve-MaxSignatureBudget -Explicit $MaxSignatures
+$maxSignatureBudget = Resolve-MaxSignatureBudget $MaxSignatures
 if (-not $TelemetryFile) { $TelemetryFile = $env:WINDOWS_SIGN_TELEMETRY_FILE }
 $signingSource = Get-SigningSource
 
@@ -176,31 +168,51 @@ if ($skipped -gt 0) {
 }
 if ($targets.Count -eq 0) {
   Write-Host "All $discovered discovered file(s) already validly signed; nothing to do."
-  $previousSigned = Read-PreviousSignedCount -Path $TelemetryFile
-  Write-SigningTelemetry -Path $TelemetryFile -Status "success" -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign 0 -Signed 0 -PreviousSigned $previousSigned -Max $maxSignatureBudget
-  exit 0
-}
-# Deduplicate identical unsigned files by content hash so byte-identical targets
-# (e.g. the three reproducible pip launchers, #2926) spend one cloud signature,
-# not one each. The signed representative is propagated to its aliases after
-# signing; every alias is verified below.
-$hashGroups = @($targets | Group-Object -Property { (Get-FileHash -LiteralPath $_ -Algorithm SHA256).Hash })
-$representatives = @($hashGroups | ForEach-Object { $_.Group[0] })
-$aliasesRestored = $targets.Count - $representatives.Count
-if ($aliasesRestored -gt 0) {
-  Write-Host "Deduplicated $($targets.Count) unsigned file(s) to $($representatives.Count) unique hash(es); $aliasesRestored alias(es) will reuse a signed representative."
+  $representatives = @()
+  $aliasesRestored = 0
+} else {
+  # Deduplicate identical unsigned files by content hash so byte-identical targets
+  # (e.g. the three reproducible pip launchers, #2926) spend one cloud signature,
+  # not one each. The signed representative is propagated to its aliases after
+  # signing; every alias is verified below.
+  $hashGroups = @($targets | Group-Object -Property { (Get-FileHash -LiteralPath $_ -Algorithm SHA256).Hash })
+  $representatives = @($hashGroups | ForEach-Object { $_.Group[0] })
+  $aliasesRestored = $targets.Count - $representatives.Count
+  if ($aliasesRestored -gt 0) {
+    Write-Host "Deduplicated $($targets.Count) unsigned file(s) to $($representatives.Count) unique hash(es); $aliasesRestored alias(es) will reuse a signed representative."
+  }
 }
 
-$previousSigned = Read-PreviousSignedCount -Path $TelemetryFile
-$projectedSigned = $previousSigned + $representatives.Count
-$telemetryStatus = "success"
-if ($maxSignatureBudget -ge 0) {
-  Write-Host "Windows signing budget: $previousSigned already signed, this invocation would sign $($representatives.Count), max $maxSignatureBudget."
-  if ($projectedSigned -gt $maxSignatureBudget) {
-    Write-Host "::warning::Windows signing budget exceeded: signing $($representatives.Count) more file(s) would bring this release to $projectedSigned cloud signature(s), above MAX_SIGNATURES=$maxSignatureBudget."
-    Write-Host "::warning::Release signing will continue. Audit sign-targets.txt / Windows signing telemetry and raise MAX_SIGNATURES if this release intentionally needs the extra signatures."
-    $telemetryStatus = "over_budget"
+$budgetScript = Join-Path $PSScriptRoot "windows-signing-budget.ps1"
+& $budgetScript `
+  -Source $signingSource `
+  -Discovered $discovered `
+  -Skipped $skipped `
+  -WouldSign $representatives.Count `
+  -UniqueHashes $representatives.Count `
+  -AliasesRestored $aliasesRestored `
+  -MaxSignatures $maxSignatureBudget `
+  -TelemetryFile $TelemetryFile
+$budgetExit = $LASTEXITCODE
+if ($budgetExit -eq 2) {
+  Write-Host "Skipping source '$signingSource' because the Windows signing budget is blocked."
+  exit 0
+}
+if ($budgetExit -ne 0) { exit $budgetExit }
+
+$previousSigned = 0
+if (Test-Path -LiteralPath $TelemetryFile) {
+  foreach ($line in (Get-Content -LiteralPath $TelemetryFile)) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed) { continue }
+    $record = $trimmed | ConvertFrom-Json
+    $previousSigned += [int]$record.signed
   }
+}
+$projectedSigned = $previousSigned + $representatives.Count
+if ($representatives.Count -eq 0) {
+  Write-SigningTelemetry -Path $TelemetryFile -Status "success" -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign 0 -Signed 0 -PreviousSigned $previousSigned -Max $maxSignatureBudget -ProjectedTotal $projectedSigned
+  exit 0
 }
 Write-Host "Signing $($representatives.Count) unique file(s) in batches of $BatchSize (delay ${DelaySeconds}s between batches)..."
 
@@ -264,5 +276,5 @@ if ($unsigned.Count -gt 0) {
   $unsigned | ForEach-Object { Write-Host "    $_" }
   exit 1
 }
-Write-SigningTelemetry -Path $TelemetryFile -Status $telemetryStatus -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign $representatives.Count -Signed $representatives.Count -UniqueHashes $representatives.Count -AliasesRestored $aliasesRestored -PreviousSigned $previousSigned -Max $maxSignatureBudget
+Write-SigningTelemetry -Path $TelemetryFile -Status "success" -Source $signingSource -Discovered $discovered -Skipped $skipped -WouldSign $representatives.Count -Signed $representatives.Count -UniqueHashes $representatives.Count -AliasesRestored $aliasesRestored -PreviousSigned $previousSigned -Max $maxSignatureBudget -ProjectedTotal $projectedSigned
 Write-Host "All $($targets.Count) file(s) carry a Valid Authenticode signature ($($representatives.Count) cloud signature(s), $aliasesRestored alias(es) reused)."

--- a/scripts/stage-signed-nsis-toolset.ps1
+++ b/scripts/stage-signed-nsis-toolset.ps1
@@ -99,7 +99,7 @@ if ($CacheDir) {
 }
 
 Write-Host "Signing $($stock.Count) stock NSIS plugin DLL(s) in the toolset cache..."
-& (Join-Path $PSScriptRoot "sign-windows-payload.ps1") -File $pluginPaths
+& (Join-Path $PSScriptRoot "sign-windows-payload.ps1") -File $pluginPaths -SigningSource "nsis-stock-plugins"
 $signExit = $LASTEXITCODE
 if ($signExit -ne 0) { exit $signExit }
 

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -4,6 +4,8 @@ param(
 
   [switch]$AllowUnsignedPrArtifact,
 
+  [switch]$AllowUnsignedBudgetBlockedArtifact,
+
   [int]$RemoteDebugPort = 9222,
 
   [string]$InstallDir = "",
@@ -63,8 +65,19 @@ function Require-ValidSignature([string]$Path, [string]$Label) {
 }
 
 function Require-SignedOrExplicitPrArtifact([string]$Path, [string]$Label) {
-  if (-not $AllowUnsignedPrArtifact) {
+  if (-not $AllowUnsignedPrArtifact -and -not $AllowUnsignedBudgetBlockedArtifact) {
     Require-ValidSignature $Path $Label
+    return
+  }
+
+  if ($AllowUnsignedBudgetBlockedArtifact) {
+    if ($env:SEREN_E2E_RELEASE_RUN -ne "1" -or $env:SEREN_E2E_WINDOWS_SIGNING_BLOCKED -ne "1") {
+      Fail "-AllowUnsignedBudgetBlockedArtifact requires an explicit budget-blocked release run."
+    }
+    if (-not (Test-Path -LiteralPath $Path)) {
+      Fail "$Label not found: $Path"
+    }
+    Write-Host "::warning::$Label Authenticode validation skipped for explicit MAX_SIGNATURES-blocked release: $Path"
     return
   }
 
@@ -413,7 +426,7 @@ $installExitCode = Invoke-ProcessWithTimeout $resolvedInstaller $installArgs $In
 if ($installExitCode -ne 0) {
   Fail "NSIS installer exited with $installExitCode"
 }
-if ($AllowUnsignedPrArtifact) {
+if ($AllowUnsignedPrArtifact -or $AllowUnsignedBudgetBlockedArtifact) {
   Clear-DownloadMarksUnder $InstallDir
 }
 

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -20,6 +20,8 @@ param(
 
   [switch]$AllowUnsignedPrArtifact,
 
+  [switch]$AllowUnsignedBudgetBlockedArtifact,
+
   [switch]$AllowMissingAgentCredentials
 )
 
@@ -221,6 +223,7 @@ try {
   $psSecretPrefix = Convert-ToSingleQuotedPowerShellString $SecretParameterPrefix.TrimEnd("/")
   $psTaskLog = Convert-ToSingleQuotedPowerShellString $taskLogPath
   $psAllowUnsignedPrArtifact = if ($AllowUnsignedPrArtifact) { "`$true" } else { "`$false" }
+  $psAllowUnsignedBudgetBlockedArtifact = if ($AllowUnsignedBudgetBlockedArtifact) { "`$true" } else { "`$false" }
   $psAllowMissingAgentCredentials = if ($AllowMissingAgentCredentials) { "`$true" } else { "`$false" }
   $taskScript = @"
 `$ErrorActionPreference = "Stop"
@@ -234,6 +237,7 @@ Set-StrictMode -Version Latest
 `$startupTimeoutSeconds = $StartupTimeoutSeconds
 `$probeTimeoutSeconds = $ProbeTimeoutSeconds
 `$allowUnsignedPrArtifact = $psAllowUnsignedPrArtifact
+`$allowUnsignedBudgetBlockedArtifact = $psAllowUnsignedBudgetBlockedArtifact
 `$allowMissingAgentCredentials = $psAllowMissingAgentCredentials
 `$installDir = Join-Path `$env:SystemDrive "SerenDesktopE2E"
 `$installerTimeoutSeconds = $InstallerTimeoutSeconds
@@ -441,7 +445,10 @@ try {
     }
   }
   [Environment]::SetEnvironmentVariable("SEREN_E2E_API_BASE", "https://api.serendb.com", "Process")
-  if (`$allowUnsignedPrArtifact) {
+  if (`$allowUnsignedBudgetBlockedArtifact) {
+    [Environment]::SetEnvironmentVariable("SEREN_E2E_RELEASE_RUN", "1", "Process")
+    [Environment]::SetEnvironmentVariable("SEREN_E2E_WINDOWS_SIGNING_BLOCKED", "1", "Process")
+  } elseif (`$allowUnsignedPrArtifact) {
     [Environment]::SetEnvironmentVariable("SEREN_E2E_UNSIGNED_PR_RUN", "1", "Process")
   } else {
     [Environment]::SetEnvironmentVariable("SEREN_E2E_RELEASE_RUN", "1", "Process")
@@ -511,6 +518,9 @@ try {
   )
   if (`$allowUnsignedPrArtifact) {
     `$harnessArgs += "-AllowUnsignedPrArtifact"
+  }
+  if (`$allowUnsignedBudgetBlockedArtifact) {
+    `$harnessArgs += "-AllowUnsignedBudgetBlockedArtifact"
   }
   `$harnessTimeoutSeconds = [Math]::Max(600, `$installerTimeoutSeconds + `$probeTimeoutSeconds + 300)
   Invoke-LoggedNative "Windows app harness" "powershell" `$harnessArgs `$harnessTimeoutSeconds

--- a/scripts/windows-signing-budget.ps1
+++ b/scripts/windows-signing-budget.ps1
@@ -1,0 +1,127 @@
+# ABOUTME: Enforces the cumulative per-release Windows cloud-signing budget before signtool can run.
+# ABOUTME: Persists fail-closed block telemetry so later signing sources skip while the unsigned release remains buildable.
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$Source,
+  [Parameter(Mandatory = $true)][int]$Discovered,
+  [Parameter(Mandatory = $true)][int]$Skipped,
+  [Parameter(Mandatory = $true)][int]$WouldSign,
+  [int]$UniqueHashes = 0,
+  [int]$AliasesRestored = 0,
+  [int]$MaxSignatures = -1,
+  [string]$TelemetryFile = "",
+  [string]$BlockFile = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$Message) {
+  Write-Host "::error::$Message"
+  exit 1
+}
+
+function Resolve-MaxSignatures([int]$Explicit) {
+  if ($Explicit -ge 0) { return $Explicit }
+  $raw = $env:MAX_SIGNATURES
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    Fail "MAX_SIGNATURES is required and must be a non-negative integer."
+  }
+  [int]$parsed = 0
+  if (-not [int]::TryParse($raw, [ref]$parsed) -or $parsed -lt 0) {
+    Fail "MAX_SIGNATURES must be a non-negative integer, got '$raw'."
+  }
+  return $parsed
+}
+
+function Read-PreviousSignedCount([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path)) { return 0 }
+  [int]$total = 0
+  foreach ($line in (Get-Content -LiteralPath $Path)) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed) { continue }
+    try {
+      $record = $trimmed | ConvertFrom-Json
+    } catch {
+      Fail "Malformed Windows signing telemetry line in ${Path}: $trimmed"
+    }
+    if ($null -eq $record.signed) {
+      Fail "Windows signing telemetry line has no signed count in ${Path}: $trimmed"
+    }
+    $total += [int]$record.signed
+  }
+  return $total
+}
+
+function Write-Telemetry(
+  [string]$Path,
+  [string]$Status,
+  [int]$PreviousSigned,
+  [int]$Max,
+  [int]$ProjectedTotal
+) {
+  $dir = Split-Path -Parent $Path
+  if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+  }
+  $record = [PSCustomObject]@{
+    timestamp = (Get-Date).ToUniversalTime().ToString("o")
+    status = $Status
+    source = $Source
+    discovered = $Discovered
+    skipped = $Skipped
+    would_sign = $WouldSign
+    signed = 0
+    unique_hashes = $UniqueHashes
+    aliases_restored = $AliasesRestored
+    previous_signed = $PreviousSigned
+    max_signatures = $Max
+    projected_total = $ProjectedTotal
+    blocked = $true
+  }
+  ($record | ConvertTo-Json -Compress) | Add-Content -LiteralPath $Path
+}
+
+$max = Resolve-MaxSignatures $MaxSignatures
+if (-not $TelemetryFile) { $TelemetryFile = $env:WINDOWS_SIGN_TELEMETRY_FILE }
+if ([string]::IsNullOrWhiteSpace($TelemetryFile)) {
+  Fail "WINDOWS_SIGN_TELEMETRY_FILE is required for fail-closed signing-budget enforcement."
+}
+if (-not $BlockFile) { $BlockFile = $env:WINDOWS_SIGNING_BLOCK_FILE }
+if ([string]::IsNullOrWhiteSpace($BlockFile)) {
+  Fail "WINDOWS_SIGNING_BLOCK_FILE is required for fail-closed signing-budget enforcement."
+}
+
+$previousSigned = Read-PreviousSignedCount $TelemetryFile
+$projectedTotal = $previousSigned + $WouldSign
+
+if (Test-Path -LiteralPath $BlockFile) {
+  Write-Telemetry $TelemetryFile "skipped_budget_blocked" $previousSigned $max $projectedTotal
+  Write-Host "Windows signing remains blocked; source '$Source' will not invoke signtool."
+  exit 2
+}
+
+Write-Host "Windows signing budget: source='$Source' previous=$previousSigned would_sign=$WouldSign projected=$projectedTotal max=$max."
+if ($projectedTotal -le $max) { exit 0 }
+
+Write-Telemetry $TelemetryFile "blocked_over_budget" $previousSigned $max $projectedTotal
+$blockDir = Split-Path -Parent $BlockFile
+if ($blockDir -and -not (Test-Path -LiteralPath $blockDir)) {
+  New-Item -ItemType Directory -Force -Path $blockDir | Out-Null
+}
+$state = [PSCustomObject]@{
+  schema_version = 1
+  created_at = (Get-Date).ToUniversalTime().ToString("o")
+  status = "blocked_over_budget"
+  source = $Source
+  previous_signed = $previousSigned
+  would_sign = $WouldSign
+  projected_total = $projectedTotal
+  max_signatures = $max
+}
+($state | ConvertTo-Json -Depth 4) | Set-Content -LiteralPath $BlockFile
+if ($env:GITHUB_ENV) {
+  "WINDOWS_SIGNING_BLOCKED=true" | Add-Content -LiteralPath $env:GITHUB_ENV
+}
+Write-Host "::error::Windows signing blocked before signtool: source '$Source' would bring this release to $projectedTotal cloud signature(s), above MAX_SIGNATURES=$max. The release will continue with a transparently unsigned Windows artifact."
+exit 2

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -331,13 +331,19 @@ describe("Windows production e2e release gate", () => {
     expect(probe).toContain("initialModelId");
   });
 
-  it("keeps unsigned PR artifact mode explicit and forbidden for release runs", () => {
+  it("allows unsigned release walkthroughs only for an explicit MAX_SIGNATURES block", () => {
     expect(runner).toContain("[switch]$AllowUnsignedPrArtifact");
+    expect(runner).toContain("[switch]$AllowUnsignedBudgetBlockedArtifact");
     expect(runner).toContain("SEREN_E2E_UNSIGNED_PR_RUN");
     expect(runner).toContain("SEREN_E2E_RELEASE_RUN");
+    expect(runner).toContain("SEREN_E2E_WINDOWS_SIGNING_BLOCKED");
     expect(runner).toContain("is forbidden for release Windows e2e runs");
+    expect(runner).toContain("requires an explicit budget-blocked release run");
+    expect(taskUserRunner).toContain("AllowUnsignedBudgetBlockedArtifact");
 
     const releaseGate = workflowJob("windows-app-e2e");
+    expect(releaseGate).toContain("Download Windows signing budget state");
+    expect(releaseGate).toContain("windows-signing-budget-state.json");
     expect(releaseGate).toContain("aws s3 presign");
     expect(releaseGate).toContain("Invoke-WebRequest -Uri");
     expect(releaseGate).toContain(
@@ -349,6 +355,7 @@ describe("Windows production e2e release gate", () => {
       "Windows app scheduled-task harness failed with exit code",
     );
     expect(releaseGate).not.toContain("-AllowUnsignedPrArtifact");
+    expect(releaseGate).toContain("-AllowUnsignedBudgetBlockedArtifact");
     expect(releaseGate).not.toContain("-AllowMissingAgentCredentials");
     expect(releaseGate).not.toContain("SEREN_E2E_UNSIGNED_PR_RUN");
   });
@@ -509,6 +516,8 @@ describe("Windows production e2e release gate", () => {
       "github-token: ${{ secrets.GITHUB_TOKEN }}",
     );
     expect(manualPublishWorkflow).toContain("WINDOWS_SIGNING_NOTE");
+    expect(manualPublishWorkflow).toContain("windows-signing-budget-state.json");
+    expect(manualPublishWorkflow).toContain("windowsSigningBlocked");
     expect(manualPublishWorkflow).toContain("latest.json");
     expect(manualPublishWorkflow).not.toContain("windows-app-e2e");
   });

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Guards the regression class where Windows installers shipped unsigned Seren.exe / nsis_tauri_utils.dll (v3.52.4-6).
 
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -15,10 +15,6 @@ const signerScript = path.join(repoRoot, "scripts", "sign-windows-payload.ps1");
 function runCli(args: string[]): { stdout: string; stderr: string; status: number } {
   const r = spawnSync(tsxBin, [cli, ...args], { encoding: "utf8" });
   return { stdout: r.stdout ?? "", stderr: r.stderr ?? "", status: r.status ?? 1 };
-}
-
-function psSingleQuoted(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
 }
 
 describe("print-windows-sign-overlay CLI", () => {
@@ -174,7 +170,7 @@ describe("release workflow contract", () => {
     const signAt = workflow.indexOf("Sign embedded runtime (Windows)");
     const cacheSaveAt = workflow.indexOf("Save Windows signature cache to R2");
     const assertAt = workflow.indexOf("Assert Windows signature cache hit budget");
-    const buildAt = workflow.indexOf("Build Tauri app (signed, Windows)");
+    const buildAt = workflow.indexOf("Build Tauri app (budget-aware, Windows)");
     const uploadWindowsAt = workflow.indexOf("Upload Windows NSIS");
     const uploadStateAt = workflow.indexOf("Upload Windows signing cache state");
 
@@ -188,29 +184,37 @@ describe("release workflow contract", () => {
     expect(uploadStateAt).toBeGreaterThan(uploadWindowsAt);
   });
 
-  it("reports Windows signing budget telemetry as warning-only (#2818/#2821)", () => {
+  it("hard-blocks Windows signing before signtool and preserves the unsigned fallback (#2929)", () => {
     const signer = readFileSync(signerScript, "utf8");
+    const budget = readFileSync(path.join(repoRoot, "scripts", "windows-signing-budget.ps1"), "utf8");
 
     expect(workflow).toContain("MAX_SIGNATURES");
     expect(workflow).toContain("vars.MAX_SIGNATURES");
     expect(workflow).toContain("Initialize Windows signing budget telemetry");
     expect(workflow).toContain("WINDOWS_SIGN_TELEMETRY_FILE");
+    expect(workflow).toContain("WINDOWS_SIGNING_BLOCK_FILE");
     expect(workflow).toContain("Summarize Windows signing budget");
-    expect(workflow).toContain("Cloud signatures spent");
+    expect(workflow).toContain("Projected cloud signatures");
+    expect(workflow).toContain("Actual cloud signatures spent");
+    expect(workflow).toContain("Verify budget-blocked Windows fallback is unsigned");
+    expect(workflow).toContain("windows-signing-budget-state.json");
+    expect(workflow).toContain("Windows artifacts in this release are NOT EV code signed.");
 
     const initAt = workflow.indexOf("Initialize Windows signing budget telemetry");
     const signAt = workflow.indexOf("Sign embedded runtime (Windows)");
-    const buildAt = workflow.indexOf("Build Tauri app (signed, Windows)");
+    const buildAt = workflow.indexOf("Build Tauri app (budget-aware, Windows)");
     const summaryAt = workflow.indexOf("Summarize Windows signing budget");
     expect(initAt).toBeGreaterThanOrEqual(0);
     expect(signAt).toBeGreaterThan(initAt);
     expect(summaryAt).toBeGreaterThan(buildAt);
 
     expect(signer).toContain("Resolve-MaxSignatureBudget");
-    expect(signer).toContain("Read-PreviousSignedCount");
     expect(signer).toContain("Write-SigningTelemetry");
-    expect(signer).toContain("Windows signing budget exceeded");
-    expect(signer).toContain("over_budget");
+    expect(signer).toContain("windows-signing-budget.ps1");
+    expect(signer.indexOf("windows-signing-budget.ps1")).toBeLessThan(signer.indexOf("signtool.exe"));
+    expect(budget).toContain("blocked_over_budget");
+    expect(budget).toContain("exit 2");
+    expect(budget).not.toContain("::warning::Windows signing budget exceeded");
     expect(signer).toContain("MAX_SIGNATURES");
   });
 });
@@ -239,7 +243,17 @@ describe("sign-windows-payload.ps1 thumbprint resolution", () => {
     const r = spawnSync(
       "pwsh",
       ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", signerScript, "-File", path.join(dummy, "a.exe")],
-      { encoding: "utf8", env: { ...process.env, WINDOWS_SIGN_THUMBPRINT: undefined, ...env } },
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          WINDOWS_SIGN_THUMBPRINT: undefined,
+          MAX_SIGNATURES: "100",
+          WINDOWS_SIGN_TELEMETRY_FILE: path.join(dummy, "telemetry.jsonl"),
+          WINDOWS_SIGNING_BLOCK_FILE: path.join(dummy, "blocked.json"),
+          ...env,
+        },
+      },
     );
     return { out: `${r.stdout}\n${r.stderr}`, status: r.status ?? 1 };
   }
@@ -273,78 +287,4 @@ describe("sign-windows-payload.ps1 thumbprint resolution", () => {
     pwshTimeout,
   );
 
-  it.runIf(runnable)(
-    "warns over-budget signing, continues to signtool, and records telemetry (#2821)",
-    () => {
-      const telemetry = path.join(dummy, "telemetry.jsonl");
-      const fakeSigntool = path.join(dummy, "kit\\x64\\signtool.exe");
-      writeFileSync(fakeSigntool, "#!/bin/sh\nexit 0\n");
-      chmodSync(fakeSigntool, 0o755);
-      writeFileSync(
-        telemetry,
-        `${JSON.stringify({
-          status: "success",
-          source: "previous",
-          discovered: 2,
-          skipped: 0,
-          would_sign: 2,
-          signed: 2,
-          previous_signed: 0,
-          max_signatures: 2,
-        })}\n`,
-      );
-
-      const script = `
-$global:sigChecks = 0
-function global:Get-AuthenticodeSignature {
-  param([string]$LiteralPath)
-  $global:sigChecks++
-  if ($global:sigChecks -eq 1) {
-    [PSCustomObject]@{ Status = "NotSigned" }
-  } else {
-    [PSCustomObject]@{ Status = "Valid" }
-  }
-}
-function global:Get-ChildItem {
-  param(
-    [string]$Path,
-    [switch]$Recurse,
-    [string]$Filter,
-    [object]$ErrorAction
-  )
-  if ($Filter -eq "signtool.exe") {
-    [PSCustomObject]@{ FullName = ${psSingleQuoted(fakeSigntool)} }
-    return
-  }
-  Microsoft.PowerShell.Management\\Get-ChildItem @PSBoundParameters
-}
-& ${psSingleQuoted(signerScript)} -Thumbprint "933C679D86D0ACAF531B37A4D12C0B360EB4815C" -File ${psSingleQuoted(path.join(dummy, "a.exe"))} -MaxSignatures 2 -TelemetryFile ${psSingleQuoted(telemetry)}
-exit $LASTEXITCODE
-`;
-      const r = spawnSync("pwsh", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script], {
-        encoding: "utf8",
-      });
-      const out = `${r.stdout}\n${r.stderr}`;
-
-      expect(r.status).toBe(0);
-      expect(out).toContain("Windows signing budget exceeded");
-      expect(out).toContain(`Using signtool: ${fakeSigntool}`);
-
-      const records = readFileSync(telemetry, "utf8")
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line));
-      expect(records).toHaveLength(2);
-      expect(records[1]).toMatchObject({
-        status: "over_budget",
-        discovered: 1,
-        skipped: 0,
-        would_sign: 1,
-        signed: 1,
-        previous_signed: 2,
-        max_signatures: 2,
-      });
-    },
-    pwshTimeout,
-  );
 });

--- a/tests/unit/windows-signing-budget.test.ts
+++ b/tests/unit/windows-signing-budget.test.ts
@@ -1,0 +1,145 @@
+// ABOUTME: Runs the real Windows signing-budget barrier against temporary telemetry and block-state files.
+// ABOUTME: Covers under-cap passage, cumulative over-cap blocking, persisted skips, and fail-closed bad configuration.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "..", "..");
+const barrier = path.join(root, "scripts", "windows-signing-budget.ps1");
+const pwshCheck = spawnSync("pwsh", ["-NoProfile", "-Command", "$PSVersionTable.PSVersion.Major"], {
+  encoding: "utf8",
+});
+const runnable = pwshCheck.status === 0;
+
+let dir: string;
+let telemetry: string;
+let blockFile: string;
+
+function successRecord(signed: number): string {
+  return `${JSON.stringify({
+    status: "success",
+    source: `prior-${signed}`,
+    discovered: signed,
+    skipped: 0,
+    would_sign: signed,
+    signed,
+    previous_signed: 0,
+    max_signatures: 100,
+  })}\n`;
+}
+
+function runBarrier(max: string | undefined, wouldSign = 1) {
+  return spawnSync(
+    "pwsh",
+    [
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      barrier,
+      "-Source",
+      "test-source",
+      "-Discovered",
+      String(wouldSign),
+      "-Skipped",
+      "0",
+      "-WouldSign",
+      String(wouldSign),
+      "-TelemetryFile",
+      telemetry,
+      "-BlockFile",
+      blockFile,
+    ],
+    {
+      encoding: "utf8",
+      env: { ...process.env, MAX_SIGNATURES: max },
+    },
+  );
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "windows-signing-budget-"));
+  telemetry = path.join(dir, "telemetry.jsonl");
+  blockFile = path.join(dir, "blocked.json");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe.runIf(runnable)("Windows signing budget barrier", () => {
+  it("allows an under-cap signing source without mutating the ledger", () => {
+    writeFileSync(telemetry, successRecord(2));
+    const result = runBarrier("3", 1);
+
+    expect(result.status).toBe(0);
+    expect(existsSync(blockFile)).toBe(false);
+    expect(readFileSync(telemetry, "utf8")).toBe(successRecord(2));
+  });
+
+  it("aggregates prior invocations and blocks before the next source can sign", () => {
+    writeFileSync(telemetry, successRecord(2) + successRecord(1));
+    const result = runBarrier("4", 2);
+
+    expect(result.status).toBe(2);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("blocked before signtool");
+    const records = readFileSync(telemetry, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(records.at(-1)).toMatchObject({
+      status: "blocked_over_budget",
+      previous_signed: 3,
+      would_sign: 2,
+      signed: 0,
+      projected_total: 5,
+      max_signatures: 4,
+      blocked: true,
+    });
+    expect(JSON.parse(readFileSync(blockFile, "utf8"))).toMatchObject({
+      status: "blocked_over_budget",
+      projected_total: 5,
+    });
+  });
+
+  it("keeps later signing sources blocked and records their breakdown", () => {
+    writeFileSync(telemetry, successRecord(2));
+    writeFileSync(blockFile, JSON.stringify({ status: "blocked_over_budget" }));
+    const result = runBarrier("100", 4);
+
+    expect(result.status).toBe(2);
+    const records = readFileSync(telemetry, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(records.at(-1)).toMatchObject({
+      status: "skipped_budget_blocked",
+      source: "test-source",
+      would_sign: 4,
+      signed: 0,
+    });
+  });
+
+  it.each([
+    [undefined, "MAX_SIGNATURES is required"],
+    ["invalid", "must be a non-negative integer"],
+    ["-1", "must be a non-negative integer"],
+  ])("fails closed for missing or invalid MAX_SIGNATURES (%s)", (max, message) => {
+    const result = runBarrier(max);
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(message);
+    expect(existsSync(blockFile)).toBe(false);
+  });
+
+  it("fails closed on malformed cumulative telemetry", () => {
+    writeFileSync(telemetry, "not-json\n");
+    const result = runBarrier("100");
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("Malformed Windows signing telemetry");
+    expect(existsSync(blockFile)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2929.

## Root cause

`scripts/sign-windows-payload.ps1` calculated the cumulative per-release total before every signtool invocation, but deliberately emitted a warning and kept signing when the projection exceeded `MAX_SIGNATURES`. The workflow then assumed every tag artifact was signed: signature gates were unconditional, the AWS Windows walkthrough rejected unsigned release artifacts, and the release-note resolver inferred signing from setup-file presence alone.

## Fix

- Add a fail-closed budget barrier that runs before signtool discovery/invocation.
- Aggregate actual signed counts across embedded runtime/MCP, NSIS plugins, app/helper, uninstaller, and setup signer calls.
- On the first over-cap source, write `blocked_over_budget`, persist a shared block state, emit a GitHub Actions error, and return before signtool.
- Enumerate later sources into the same telemetry as `skipped_budget_blocked` without contacting SSL.com.
- Lower the default from 850 to 100. Normal releases are ~0-10 operations; an intentional cold/full reseed now requires an explicit audited repository-variable override.
- Keep availability: finish and upload the unsigned Windows installer/updater, assert the setup is not EV signed, route the real AWS-hosted walkthrough through an explicit budget-blocked allowance, and resolve release notes from the budget-state artifact to “NOT EV code signed.”
- Fail loudly on missing/invalid `MAX_SIGNATURES` or malformed cumulative telemetry.
- Preserve the independent signature-cache gate on signed releases; budget-blocked unsigned releases do not publish a signed-cache state.

## Critical coverage

- Real `windows-signing-budget.ps1` process: under-cap passage, cumulative multi-invocation block, persistent later-source block, missing/invalid cap, and malformed state.
- Workflow contracts: barrier precedes signtool, unsigned artifact/state/release-note path remains present, and AWS walkthrough bypass is restricted to an explicit budget-blocked release.
- Existing cache-health gate coverage remains unchanged.

## Local validation

- `pnpm test` — 317 files passed, 2,294 tests passed; PowerShell-dependent files skipped because this host's x86 pwsh crashes under Rosetta before startup.
- `pnpm vitest run tests/unit/windows-signing-budget.test.ts tests/unit/windows-sign-overlay.test.ts tests/unit/windows-e2e-release-gate.test.ts tests/unit/windows-signature-cache-gate.test.ts` — 40 passed; 12 PowerShell-host-dependent tests skipped for the same host crash.
- `pnpm build`
- `pnpm verify:frontend-build`
- YAML parse for release and manual-publish workflows.
- `git diff --check`
- `pnpm check` exits 0 with the repository's pre-existing warnings.

CI is the required live PowerShell evidence; no local mock is claimed as functional validation.

## Networked path

No Seren publisher/API or user-facing outbound network path is added or changed. This is release-CI orchestration around existing GitHub artifact, Cloudflare R2 cache, SSL.com signtool, and AWS Windows e2e paths. The changed path has no UI action or Seren publisher slug.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com