### PR TITLE
fix(release): enforce persistent monthly SSL.com budget (#2931)

### DIFF
--- a/.github/workflows/publish-release-manual.yml
+++ b/.github/workflows/publish-release-manual.yml
@@ -149,15 +149,18 @@ jobs:
                 return fs.readdirSync(dir).some((f) => f.endsWith('-setup.exe'));
               });
             const budgetStatePath = path.join(artifactsDir, 'windows-signing-budget-state', 'windows-signing-budget-state.json');
-            const windowsSigningBlocked = fs.existsSync(budgetStatePath)
-              && JSON.parse(fs.readFileSync(budgetStatePath, 'utf8')).blocked === true;
+            const budgetState = fs.existsSync(budgetStatePath)
+              ? JSON.parse(fs.readFileSync(budgetStatePath, 'utf8'))
+              : null;
+            const windowsSigningBlocked = budgetState?.blocked === true;
+            const windowsSigningStatus = budgetState?.status || 'unknown';
             const windowsSignedClaim = isProductionTag && hasWindowsArtifact && !windowsSigningBlocked
               ? 'Windows builds are EV code signed. If you still see a SmartScreen warning, click "More info" -> "Run anyway"; reputation builds with installs.'
               : 'Windows artifacts in this release are NOT EV code signed.';
             const noteMarker = '<!-- WINDOWS_SIGNING_NOTE -->';
             if (publishTarget.body && publishTarget.body.includes(noteMarker)) {
               const updatedBody = publishTarget.body.replace(noteMarker, windowsSignedClaim);
-              console.log(`Resolving Windows signing note: tag=${tagName} hasWindowsArtifact=${hasWindowsArtifact} budgetBlocked=${windowsSigningBlocked}`);
+              console.log(`Resolving Windows signing note: tag=${tagName} hasWindowsArtifact=${hasWindowsArtifact} budgetBlocked=${windowsSigningBlocked} budgetStatus=${windowsSigningStatus}`);
               await github.rest.repos.updateRelease({
                 owner,
                 repo,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,18 @@ env:
   # Windows release job. Normal releases spend roughly 0-10; 100 leaves ample
   # drift while a cold/full cache reseed requires an explicit audited repo override.
   MAX_SIGNATURES: ${{ vars.MAX_SIGNATURES || '100' }}
+  # Persistent Tier 1 monthly barrier (#2931). Currency is integer cents only;
+  # account/certificate and invoice boundary are explicit repository variables.
+  SSL_SIGNING_MONTHLY_BUDGET_CENTS: ${{ vars.SSL_SIGNING_MONTHLY_BUDGET_CENTS || '10000' }}
+  SSL_SIGNING_TIER_BASE_CENTS: ${{ vars.SSL_SIGNING_TIER_BASE_CENTS || '2000' }}
+  SSL_SIGNING_TIER_INCLUDED_OPERATIONS: ${{ vars.SSL_SIGNING_TIER_INCLUDED_OPERATIONS || '20' }}
+  SSL_SIGNING_TIER_OVERAGE_CENTS: ${{ vars.SSL_SIGNING_TIER_OVERAGE_CENTS || '100' }}
+  SSL_SIGNING_OTHER_FIXED_MONTHLY_CENTS: ${{ vars.SSL_SIGNING_OTHER_FIXED_MONTHLY_CENTS || '0' }}
+  SSL_SIGNING_BILLING_ANCHOR_DAY: ${{ vars.SSL_SIGNING_BILLING_ANCHOR_DAY }}
+  SSL_SIGNING_BILLING_TIMEZONE: ${{ vars.SSL_SIGNING_BILLING_TIMEZONE }}
+  SSL_SIGNING_ACCOUNT: ${{ vars.SSL_SIGNING_ACCOUNT }}
+  SSL_SIGNING_CERTIFICATE: ${{ vars.SSL_SIGNING_CERTIFICATE }}
+  SSL_SIGNING_LEDGER_R2_PREFIX: windows-signing-ledgers/v1
   # Hard gate for unchanged embedded-runtime releases: if the manifest matches
   # the previous release, a working signature cache should make this near zero.
   WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED: ${{ vars.WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED || '25' }}
@@ -326,6 +338,11 @@ jobs:
       - name: Initialize Windows signing budget telemetry
         if: matrix.os == 'windows-latest' && env.HAS_WINDOWS_SIGNING == 'true'
         shell: pwsh
+        env:
+          MONTHLY_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          MONTHLY_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          MONTHLY_R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          MONTHLY_R2_BUCKET: ${{ secrets.R2_BUCKET_NAME }}
         run: |
           [int]$max = 0
           if (-not [int]::TryParse($env:MAX_SIGNATURES, [ref]$max) -or $max -lt 0) {
@@ -334,11 +351,19 @@ jobs:
           }
           $telemetry = Join-Path $env:RUNNER_TEMP "windows-signing-telemetry.jsonl"
           $blockFile = Join-Path $env:RUNNER_TEMP "windows-signing-budget-block.json"
+          $monthlyState = Join-Path $env:RUNNER_TEMP "windows-signing-monthly-state.json"
           Remove-Item -LiteralPath $telemetry -Force -ErrorAction SilentlyContinue
           Remove-Item -LiteralPath $blockFile -Force -ErrorAction SilentlyContinue
           "WINDOWS_SIGN_TELEMETRY_FILE=$telemetry" >> $env:GITHUB_ENV
           "WINDOWS_SIGNING_BLOCK_FILE=$blockFile" >> $env:GITHUB_ENV
+          "WINDOWS_SIGNING_MONTHLY_STATE_FILE=$monthlyState" >> $env:GITHUB_ENV
           "WINDOWS_SIGNING_BLOCKED=false" >> $env:GITHUB_ENV
+          "WINDOWS_SIGNING_MONTHLY_BLOCKED=false" >> $env:GITHUB_ENV
+          "AWS_ACCESS_KEY_ID=$env:MONTHLY_R2_ACCESS_KEY_ID" >> $env:GITHUB_ENV
+          "AWS_SECRET_ACCESS_KEY=$env:MONTHLY_R2_SECRET_ACCESS_KEY" >> $env:GITHUB_ENV
+          "AWS_DEFAULT_REGION=auto" >> $env:GITHUB_ENV
+          "AWS_ENDPOINT_URL=$env:MONTHLY_R2_ENDPOINT" >> $env:GITHUB_ENV
+          "R2_BUCKET=$env:MONTHLY_R2_BUCKET" >> $env:GITHUB_ENV
           Write-Host "Windows signing telemetry: $telemetry"
           Write-Host "Windows signing block state: $blockFile"
           Write-Host "Windows signing MAX_SIGNATURES=$max"
@@ -772,15 +797,24 @@ jobs:
             if ($null -ne $record.skipped) { $skipped += [int]$record.skipped }
             if ($null -ne $record.would_sign) { $wouldSign += [int]$record.would_sign }
             if ($null -ne $record.signed) { $signed += [int]$record.signed }
-            if ($record.status -eq "blocked_over_budget" -or $record.status -eq "skipped_budget_blocked") { $blocked = $true }
+            if ($record.status -eq "blocked_over_budget" -or $record.status -eq "skipped_budget_blocked" -or $record.status -eq "blocked_monthly_budget") { $blocked = $true }
           }
-          $status = if ($blocked) { "blocked_over_budget" } else { "within_budget" }
+          $monthlyBlocked = $records.status -contains "blocked_monthly_budget"
+          $status = if ($monthlyBlocked) { "blocked_monthly_budget" } elseif ($blocked) { "blocked_over_budget" } else { "within_budget" }
           Add-Content -LiteralPath $summary -Value "- Status: $status"
           Add-Content -LiteralPath $summary -Value "- Projected cloud signatures: $wouldSign"
           Add-Content -LiteralPath $summary -Value "- Discovered: $discovered"
           Add-Content -LiteralPath $summary -Value "- Skipped already valid: $skipped"
           Add-Content -LiteralPath $summary -Value "- Actual cloud signatures spent: $signed"
           Add-Content -LiteralPath $summary -Value "- Signing blocked: $($blocked.ToString().ToLowerInvariant())"
+          if (Test-Path -LiteralPath $env:WINDOWS_SIGNING_MONTHLY_STATE_FILE) {
+            $monthly = Get-Content -Raw -LiteralPath $env:WINDOWS_SIGNING_MONTHLY_STATE_FILE | ConvertFrom-Json
+            Add-Content -LiteralPath $summary -Value "- Monthly cycle: $($monthly.billing_cycle) ($($monthly.cycle_starts_at) to $($monthly.cycle_ends_at))"
+            Add-Content -LiteralPath $summary -Value "- Monthly operations used/reserved: $($monthly.committed_or_reserved_operations)"
+            Add-Content -LiteralPath $summary -Value "- Monthly operations remaining at configured cost: $([Math]::Max(0, $monthly.configuration.included_operations + [Math]::Floor(($monthly.configuration.budget_cents - $monthly.configuration.base_cents - $monthly.configuration.other_fixed_monthly_cents) / $monthly.configuration.overage_cents) - $monthly.committed_or_reserved_operations))"
+            Add-Content -LiteralPath $summary -Value "- Monthly projected charge: `$$('{0:F2}' -f ($monthly.projected_cost_cents / 100))"
+            Add-Content -LiteralPath $summary -Value "- Monthly ledger version: $($monthly.version)"
+          }
           Add-Content -LiteralPath $summary -Value ""
           Add-Content -LiteralPath $summary -Value "| Status | Source | Discovered | Skipped | Would sign | Signed | Previous signed |"
           Add-Content -LiteralPath $summary -Value "|---|---|---:|---:|---:|---:|---:|"
@@ -795,6 +829,7 @@ jobs:
             max_signatures = [int]$env:MAX_SIGNATURES
             projected_total = $wouldSign
             actual_signed = $signed
+            monthly = if (Test-Path -LiteralPath $env:WINDOWS_SIGNING_MONTHLY_STATE_FILE) { Get-Content -Raw -LiteralPath $env:WINDOWS_SIGNING_MONTHLY_STATE_FILE | ConvertFrom-Json } else { $null }
             sources = @($records)
           }
           ($state | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath "windows-signing-budget-state.json"

--- a/.github/workflows/windows-signing-ledger.yml
+++ b/.github/workflows/windows-signing-ledger.yml
@@ -1,6 +1,14 @@
 name: Windows signing monthly ledger
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/windows-signing-monthly-budget.ps1'
+      - 'scripts/test-windows-signing-monthly-budget-live.ps1'
+      - 'scripts/sign-windows-payload.ps1'
+      - '.github/workflows/windows-signing-ledger.yml'
+      - '.github/workflows/release.yml'
   workflow_dispatch:
     inputs:
       operation:
@@ -60,43 +68,6 @@ jobs:
           ./scripts/windows-signing-monthly-budget.ps1 -Mode Bootstrap -BootstrapOperations $operations -BootstrapSource $env:BOOTSTRAP_SOURCE -BootstrapApprovedBy '${{ github.actor }}'
 
       - name: Live R2 CAS and persistence test
-        if: inputs.operation == 'live-test'
+        if: github.event_name == 'pull_request' || inputs.operation == 'live-test'
         shell: pwsh
-        run: |
-          $env:SSL_SIGNING_MONTHLY_BUDGET_CENTS = "10000"
-          $env:SSL_SIGNING_TIER_BASE_CENTS = "2000"
-          $env:SSL_SIGNING_TIER_INCLUDED_OPERATIONS = "20"
-          $env:SSL_SIGNING_TIER_OVERAGE_CENTS = "100"
-          $env:SSL_SIGNING_OTHER_FIXED_MONTHLY_CENTS = "0"
-          $env:SSL_SIGNING_BILLING_ANCHOR_DAY = "1"
-          $env:SSL_SIGNING_BILLING_TIMEZONE = "UTC"
-          $env:SSL_SIGNING_ACCOUNT = "live-cas-test"
-          $env:SSL_SIGNING_CERTIFICATE = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-sequential"
-          $env:SSL_SIGNING_LEDGER_R2_PREFIX = "windows-signing-ledgers/live-tests"
-          ./scripts/windows-signing-monthly-budget.ps1 -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow CAS test" -BootstrapApprovedBy '${{ github.actor }}'
-          foreach ($release in 1..14) {
-            ./scripts/windows-signing-monthly-budget.ps1 -Mode Reserve -Source "seven-operation-release-$release" -Invocation 1 -Operations 7
-            if ($LASTEXITCODE -ne 0) { throw "Sequential reservation $release should have been admitted." }
-          }
-          ./scripts/windows-signing-monthly-budget.ps1 -Mode Reserve -Source "seven-operation-release-15" -Invocation 1 -Operations 7
-          if ($LASTEXITCODE -ne 2) { throw "The fifteenth seven-operation release was not blocked." }
-
-          # Use another isolated real ledger for a simultaneous near-limit CAS.
-          $env:SSL_SIGNING_MONTHLY_BUDGET_CENTS = "2000"
-          $env:SSL_SIGNING_TIER_BASE_CENTS = "0"
-          $env:SSL_SIGNING_TIER_INCLUDED_OPERATIONS = "0"
-          $env:SSL_SIGNING_TIER_OVERAGE_CENTS = "2000"
-          $env:SSL_SIGNING_CERTIFICATE = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-concurrent"
-          ./scripts/windows-signing-monthly-budget.ps1 -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow concurrent CAS test" -BootstrapApprovedBy '${{ github.actor }}'
-          $script = (Resolve-Path ./scripts/windows-signing-monthly-budget.ps1).Path
-          $aOut = Join-Path $env:RUNNER_TEMP "a.out"; $aErr = Join-Path $env:RUNNER_TEMP "a.err"
-          $bOut = Join-Path $env:RUNNER_TEMP "b.out"; $bErr = Join-Path $env:RUNNER_TEMP "b.err"
-          $a = Start-Process pwsh -PassThru -ArgumentList @('-NoProfile','-File',$script,'-Mode','Reserve','-Source','concurrent-a','-Invocation','1','-Operations','1') -RedirectStandardOutput $aOut -RedirectStandardError $aErr
-          $b = Start-Process pwsh -PassThru -ArgumentList @('-NoProfile','-File',$script,'-Mode','Reserve','-Source','concurrent-b','-Invocation','1','-Operations','1') -RedirectStandardOutput $bOut -RedirectStandardError $bErr
-          $a.WaitForExit(); $b.WaitForExit()
-          Get-Content $aOut,$aErr,$bOut,$bErr -ErrorAction SilentlyContinue
-          $codes = @($a.ExitCode, $b.ExitCode) | Sort-Object
-          if (($codes -join ',') -ne '0,2') { throw "CAS test expected one admission and one budget block, got $($codes -join ',')." }
-          # A fresh process must observe the committed reservation (durability).
-          ./scripts/windows-signing-monthly-budget.ps1 -Mode Reserve -Source "persistence-check" -Invocation 1 -Operations 1
-          if ($LASTEXITCODE -ne 2) { throw "A separate process did not observe the persisted reservation." }
+        run: ./scripts/test-windows-signing-monthly-budget-live.ps1

--- a/.github/workflows/windows-signing-ledger.yml
+++ b/.github/workflows/windows-signing-ledger.yml
@@ -1,0 +1,102 @@
+name: Windows signing monthly ledger
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "live-test or bootstrap-active-cycle"
+        required: true
+        type: choice
+        options: [live-test, bootstrap-active-cycle]
+      authoritative_operations:
+        description: "SSL.com operations already billed in the active cycle (bootstrap only)"
+        required: false
+        default: ""
+      authoritative_source:
+        description: "Invoice/dashboard evidence and timestamp (bootstrap only)"
+        required: false
+        default: ""
+      approval:
+        description: "Type BOOTSTRAP MONTHLY SSL LEDGER (bootstrap only)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  ledger:
+    runs-on: windows-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET_NAME }}
+      SSL_SIGNING_MONTHLY_BUDGET_CENTS: ${{ vars.SSL_SIGNING_MONTHLY_BUDGET_CENTS || '10000' }}
+      SSL_SIGNING_TIER_BASE_CENTS: ${{ vars.SSL_SIGNING_TIER_BASE_CENTS || '2000' }}
+      SSL_SIGNING_TIER_INCLUDED_OPERATIONS: ${{ vars.SSL_SIGNING_TIER_INCLUDED_OPERATIONS || '20' }}
+      SSL_SIGNING_TIER_OVERAGE_CENTS: ${{ vars.SSL_SIGNING_TIER_OVERAGE_CENTS || '100' }}
+      SSL_SIGNING_OTHER_FIXED_MONTHLY_CENTS: ${{ vars.SSL_SIGNING_OTHER_FIXED_MONTHLY_CENTS || '0' }}
+      SSL_SIGNING_BILLING_ANCHOR_DAY: ${{ vars.SSL_SIGNING_BILLING_ANCHOR_DAY }}
+      SSL_SIGNING_BILLING_TIMEZONE: ${{ vars.SSL_SIGNING_BILLING_TIMEZONE }}
+      SSL_SIGNING_ACCOUNT: ${{ vars.SSL_SIGNING_ACCOUNT }}
+      SSL_SIGNING_CERTIFICATE: ${{ vars.SSL_SIGNING_CERTIFICATE }}
+      SSL_SIGNING_LEDGER_R2_PREFIX: windows-signing-ledgers/v1
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Bootstrap active billing cycle
+        if: inputs.operation == 'bootstrap-active-cycle'
+        shell: pwsh
+        env:
+          BOOTSTRAP_OPERATIONS: ${{ inputs.authoritative_operations }}
+          BOOTSTRAP_SOURCE: ${{ inputs.authoritative_source }}
+          BOOTSTRAP_APPROVAL: ${{ inputs.approval }}
+        run: |
+          if ($env:BOOTSTRAP_APPROVAL -cne "BOOTSTRAP MONTHLY SSL LEDGER") { throw "Exact audited approval phrase is required." }
+          [int]$operations = -1
+          if (-not [int]::TryParse($env:BOOTSTRAP_OPERATIONS, [ref]$operations) -or $operations -lt 0) { throw "authoritative_operations must be a non-negative integer." }
+          ./scripts/windows-signing-monthly-budget.ps1 -Mode Bootstrap -BootstrapOperations $operations -BootstrapSource $env:BOOTSTRAP_SOURCE -BootstrapApprovedBy '${{ github.actor }}'
+
+      - name: Live R2 CAS and persistence test
+        if: inputs.operation == 'live-test'
+        shell: pwsh
+        run: |
+          $env:SSL_SIGNING_MONTHLY_BUDGET_CENTS = "10000"
+          $env:SSL_SIGNING_TIER_BASE_CENTS = "2000"
+          $env:SSL_SIGNING_TIER_INCLUDED_OPERATIONS = "20"
+          $env:SSL_SIGNING_TIER_OVERAGE_CENTS = "100"
+          $env:SSL_SIGNING_OTHER_FIXED_MONTHLY_CENTS = "0"
+          $env:SSL_SIGNING_BILLING_ANCHOR_DAY = "1"
+          $env:SSL_SIGNING_BILLING_TIMEZONE = "UTC"
+          $env:SSL_SIGNING_ACCOUNT = "live-cas-test"
+          $env:SSL_SIGNING_CERTIFICATE = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-sequential"
+          $env:SSL_SIGNING_LEDGER_R2_PREFIX = "windows-signing-ledgers/live-tests"
+          ./scripts/windows-signing-monthly-budget.ps1 -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow CAS test" -BootstrapApprovedBy '${{ github.actor }}'
+          foreach ($release in 1..14) {
+            ./scripts/windows-signing-monthly-budget.ps1 -Mode Reserve -Source "seven-operation-release-$release" -Invocation 1 -Operations 7
+            if ($LASTEXITCODE -ne 0) { throw "Sequential reservation $release should have been admitted." }
+          }
+          ./scripts/windows-signing-monthly-budget.ps1 -Mode Reserve -Source "seven-operation-release-15" -Invocation 1 -Operations 7
+          if ($LASTEXITCODE -ne 2) { throw "The fifteenth seven-operation release was not blocked." }
+
+          # Use another isolated real ledger for a simultaneous near-limit CAS.
+          $env:SSL_SIGNING_MONTHLY_BUDGET_CENTS = "2000"
+          $env:SSL_SIGNING_TIER_BASE_CENTS = "0"
+          $env:SSL_SIGNING_TIER_INCLUDED_OPERATIONS = "0"
+          $env:SSL_SIGNING_TIER_OVERAGE_CENTS = "2000"
+          $env:SSL_SIGNING_CERTIFICATE = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-concurrent"
+          ./scripts/windows-signing-monthly-budget.ps1 -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow concurrent CAS test" -BootstrapApprovedBy '${{ github.actor }}'
+          $script = (Resolve-Path ./scripts/windows-signing-monthly-budget.ps1).Path
+          $aOut = Join-Path $env:RUNNER_TEMP "a.out"; $aErr = Join-Path $env:RUNNER_TEMP "a.err"
+          $bOut = Join-Path $env:RUNNER_TEMP "b.out"; $bErr = Join-Path $env:RUNNER_TEMP "b.err"
+          $a = Start-Process pwsh -PassThru -ArgumentList @('-NoProfile','-File',$script,'-Mode','Reserve','-Source','concurrent-a','-Invocation','1','-Operations','1') -RedirectStandardOutput $aOut -RedirectStandardError $aErr
+          $b = Start-Process pwsh -PassThru -ArgumentList @('-NoProfile','-File',$script,'-Mode','Reserve','-Source','concurrent-b','-Invocation','1','-Operations','1') -RedirectStandardOutput $bOut -RedirectStandardError $bErr
+          $a.WaitForExit(); $b.WaitForExit()
+          Get-Content $aOut,$aErr,$bOut,$bErr -ErrorAction SilentlyContinue
+          $codes = @($a.ExitCode, $b.ExitCode) | Sort-Object
+          if (($codes -join ',') -ne '0,2') { throw "CAS test expected one admission and one budget block, got $($codes -join ',')." }
+          # A fresh process must observe the committed reservation (durability).
+          ./scripts/windows-signing-monthly-budget.ps1 -Mode Reserve -Source "persistence-check" -Invocation 1 -Operations 1
+          if ($LASTEXITCODE -ne 2) { throw "A separate process did not observe the persisted reservation." }

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -49,6 +49,14 @@ Add these secrets to the repository settings (Settings → Secrets → Actions):
 | Variable | Description |
 |----------|-------------|
 | `MAX_SIGNATURES` | Fail-closed ceiling for SSL.com cloud hash-signing operations in one Windows release job. Defaults to `100` in `release.yml`; an intentional cold/full cache reseed above that ceiling requires an explicit repository-variable override after reviewing the signable inventory. |
+| `SSL_SIGNING_MONTHLY_BUDGET_CENTS` | Monthly controlled SSL.com budget in integer cents; default `10000`. |
+| `SSL_SIGNING_TIER_BASE_CENTS` | Tier 1 base charge in cents; default `2000`. |
+| `SSL_SIGNING_TIER_INCLUDED_OPERATIONS` | Operations included by Tier 1; default `20`. |
+| `SSL_SIGNING_TIER_OVERAGE_CENTS` | Per-operation overage in cents; default `100`. |
+| `SSL_SIGNING_OTHER_FIXED_MONTHLY_CENTS` | Other subscription/credential charges in cents; default `0`, and must be raised if SSL.com keeps another fixed fee active. |
+| `SSL_SIGNING_BILLING_ANCHOR_DAY` | Required invoice-cycle start day (`1`-`28`). No calendar-month assumption is made. |
+| `SSL_SIGNING_BILLING_TIMEZONE` | Required IANA/Windows timezone for the invoice boundary. |
+| `SSL_SIGNING_ACCOUNT` / `SSL_SIGNING_CERTIFICATE` | Required stable ledger identity for the SSL.com account and certificate. |
 | `WINDOWS_EMBEDDED_RUNTIME_CACHE_HIT_MAX_SIGNED` | Hard-fail threshold for fresh embedded-runtime signatures when the signable manifest matches the previous release. Defaults to `25`; keep this low so a broken signature cache fails before release artifacts publish. |
 
 ## Certificate Setup
@@ -193,6 +201,55 @@ real AWS-hosted app walkthrough continue, signature-only verification gates are
 skipped, and CI asserts that the resulting setup executable is not EV signed.
 The installer and updater artifacts still publish, while release notes are
 resolved to **NOT EV code signed** from the uploaded budget-state artifact.
+
+The per-release `MAX_SIGNATURES` barrier is independent of the persistent
+monthly barrier. Immediately before every real `signtool` batch—and again
+before every retry—`windows-signing-monthly-budget.ps1` conditionally updates a
+versioned R2 ledger. The compare-and-swap uses the object's ETag (`If-Match`),
+retries conflicts, and treats missing, corrupt, stale, conflicting, or
+unreachable state as a hard signing failure. A reservation remains spent when
+the cloud result is missing or ambiguous.
+
+Tier 1 projection uses integer cents:
+
+`base + other_fixed + max(0, operations - included) * overage`.
+
+The defaults (`2000 + 0 + max(0, operations - 20) * 100`) permit 100 operations
+at a `10000`-cent ceiling. Fourteen seven-operation releases reserve 98; a
+fifteenth is blocked before SSL.com. Additional fixed charges reduce that
+ceiling automatically. Job summaries report the cycle boundary, committed or
+reserved operations, remaining operations, projected dollars, and ledger
+version. Alerts should be configured from the same ledger at 50%, 75%, 90%,
+and 100%; the workflow summary exposes the authoritative values.
+
+#### Bootstrap, rollover, and reconciliation
+
+The first release in an active invoice cycle must never create a zero ledger.
+Run the manual **Windows signing monthly ledger** workflow with
+`bootstrap-active-cycle`, the authoritative operation count from SSL.com's
+dashboard/invoice, its evidence timestamp/source, and the exact approval
+phrase. The object is created with `If-None-Match: *`, records the approving
+GitHub actor, and cannot overwrite an existing cycle. If authoritative usage is
+unknown, leave signing blocked and bootstrap at the next configured boundary
+with a verified zero. A new cycle also requires this explicit bootstrap; prior
+cycle objects remain under `windows-signing-ledgers/v1/` for audit.
+
+Reconcile `committed_or_reserved_operations` and each run/source/invocation
+entry against the SSL.com invoice. Reservations may conservatively exceed the
+invoice after ambiguous failures, but the projected charge must never exceed
+the repository budget. Before changing pricing, fixed charges, account,
+certificate, anchor, or timezone, reconcile the current object and bootstrap
+the new identity/cycle rather than editing a ledger in place.
+
+For a live backend check, dispatch the same workflow with `live-test`. It uses
+real R2 conditional writes, launches two simultaneous near-limit reservations,
+requires exactly one admission, and verifies persistence from a fresh process;
+it uses no storage mock.
+
+An emergency override requires an operator-approved repository-variable change
+and an audited ledger bootstrap under a new certificate/account identity. Never
+edit or delete the current ledger to recover budget. If the budget is exhausted,
+allow the documented unsigned release path or intentionally defer the release.
 
 The embedded-runtime signature cache should make the second release with an
 unchanged runtime report most of that large payload as skipped already valid,

--- a/scripts/sign-windows-payload.ps1
+++ b/scripts/sign-windows-payload.ps1
@@ -200,6 +200,25 @@ if ($budgetExit -eq 2) {
 }
 if ($budgetExit -ne 0) { exit $budgetExit }
 
+function Block-MonthlySigning([string]$Source, [int]$Invocation, [int]$Operations) {
+  $monthlyScript = Join-Path $PSScriptRoot "windows-signing-monthly-budget.ps1"
+  $monthlyState = $env:WINDOWS_SIGNING_MONTHLY_STATE_FILE
+  & $monthlyScript -Mode Reserve -Source $Source -Invocation $Invocation -Operations $Operations -OutputFile $monthlyState
+  $monthlyExit = $LASTEXITCODE
+  if ($monthlyExit -eq 2) {
+    $state = [PSCustomObject]@{ schema_version=1; status="blocked_monthly_budget"; source=$Source; invocation=$Invocation; operations=$Operations; created_at=(Get-Date).ToUniversalTime().ToString("o") }
+    ($state | ConvertTo-Json -Depth 4) | Set-Content -LiteralPath $env:WINDOWS_SIGNING_BLOCK_FILE
+    if ($env:GITHUB_ENV) {
+      "WINDOWS_SIGNING_BLOCKED=true" | Add-Content -LiteralPath $env:GITHUB_ENV
+      "WINDOWS_SIGNING_MONTHLY_BLOCKED=true" | Add-Content -LiteralPath $env:GITHUB_ENV
+    }
+    Write-SigningTelemetry -Path $TelemetryFile -Status "blocked_monthly_budget" -Source $Source -Discovered $discovered -Skipped $skipped -WouldSign $Operations -Signed 0 -PreviousSigned $previousSigned -Max $maxSignatureBudget -ProjectedTotal $projectedSigned
+    return $true
+  }
+  if ($monthlyExit -ne 0) { exit $monthlyExit }
+  return $false
+}
+
 $previousSigned = 0
 if (Test-Path -LiteralPath $TelemetryFile) {
   foreach ($line in (Get-Content -LiteralPath $TelemetryFile)) {
@@ -237,6 +256,13 @@ for ($i = 0; $i -lt $representatives.Count; $i += $BatchSize) {
   $attempt = 0
   while ($true) {
     $attempt++
+    # A failed signtool call may still have reached SSL.com. Every real retry is
+    # therefore a distinct reservation, immediately before the cloud call.
+    $cloudInvocation = [int](($i / $BatchSize) * $MaxRetries) + $attempt
+    if (Block-MonthlySigning $signingSource $cloudInvocation $batch.Count) {
+      Write-Host "Skipping source '$signingSource' because the monthly SSL.com budget is exhausted."
+      exit 0
+    }
     & $signtool.FullName sign /fd sha256 /tr $ts /td sha256 /sha1 $Thumbprint $batch
     if ($LASTEXITCODE -eq 0) { break }
     if ($attempt -ge $MaxRetries) {

--- a/scripts/test-windows-signing-monthly-budget-live.ps1
+++ b/scripts/test-windows-signing-monthly-budget-live.ps1
@@ -43,3 +43,4 @@ if (($codes -join ',') -ne '0,2') { throw "CAS test expected one admission and o
 & $barrier -Mode Reserve -Source "persistence-check" -Invocation 1 -Operations 1
 if ($LASTEXITCODE -ne 2) { throw "A separate process did not observe the persisted reservation." }
 Write-Host "Live R2 monthly signing ledger validation passed without mocks."
+exit 0

--- a/scripts/test-windows-signing-monthly-budget-live.ps1
+++ b/scripts/test-windows-signing-monthly-budget-live.ps1
@@ -1,0 +1,45 @@
+# ABOUTME: Runs the monthly SSL.com budget barrier against real R2 conditional writes; no storage mock is used.
+# ABOUTME: Verifies 14x7 admission, the fifteenth block, concurrent near-limit exclusion, and cross-process persistence.
+
+$ErrorActionPreference = "Stop"
+$barrier = (Resolve-Path (Join-Path $PSScriptRoot "windows-signing-monthly-budget.ps1")).Path
+$env:SSL_SIGNING_MONTHLY_BUDGET_CENTS = "10000"
+$env:SSL_SIGNING_TIER_BASE_CENTS = "2000"
+$env:SSL_SIGNING_TIER_INCLUDED_OPERATIONS = "20"
+$env:SSL_SIGNING_TIER_OVERAGE_CENTS = "100"
+$env:SSL_SIGNING_OTHER_FIXED_MONTHLY_CENTS = "0"
+$env:SSL_SIGNING_BILLING_ANCHOR_DAY = "1"
+$env:SSL_SIGNING_BILLING_TIMEZONE = "UTC"
+$env:SSL_SIGNING_ACCOUNT = "live-cas-test"
+$env:SSL_SIGNING_CERTIFICATE = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-sequential"
+$env:SSL_SIGNING_LEDGER_R2_PREFIX = "windows-signing-ledgers/live-tests"
+
+& $barrier -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow sequential budget test" -BootstrapApprovedBy $env:GITHUB_ACTOR
+if ($LASTEXITCODE -ne 0) { throw "Could not bootstrap the isolated sequential live-test ledger." }
+foreach ($release in 1..14) {
+  & $barrier -Mode Reserve -Source "seven-operation-release-$release" -Invocation 1 -Operations 7
+  if ($LASTEXITCODE -ne 0) { throw "Sequential reservation $release should have been admitted." }
+}
+& $barrier -Mode Reserve -Source "seven-operation-release-15" -Invocation 1 -Operations 7
+if ($LASTEXITCODE -ne 2) { throw "The fifteenth seven-operation release was not blocked." }
+
+$env:SSL_SIGNING_MONTHLY_BUDGET_CENTS = "2000"
+$env:SSL_SIGNING_TIER_BASE_CENTS = "0"
+$env:SSL_SIGNING_TIER_INCLUDED_OPERATIONS = "0"
+$env:SSL_SIGNING_TIER_OVERAGE_CENTS = "2000"
+$env:SSL_SIGNING_CERTIFICATE = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-concurrent"
+& $barrier -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow concurrent CAS test" -BootstrapApprovedBy $env:GITHUB_ACTOR
+if ($LASTEXITCODE -ne 0) { throw "Could not bootstrap the isolated concurrent live-test ledger." }
+
+$aOut = Join-Path $env:RUNNER_TEMP "a.out"; $aErr = Join-Path $env:RUNNER_TEMP "a.err"
+$bOut = Join-Path $env:RUNNER_TEMP "b.out"; $bErr = Join-Path $env:RUNNER_TEMP "b.err"
+$a = Start-Process pwsh -PassThru -ArgumentList @('-NoProfile','-File',$barrier,'-Mode','Reserve','-Source','concurrent-a','-Invocation','1','-Operations','1') -RedirectStandardOutput $aOut -RedirectStandardError $aErr
+$b = Start-Process pwsh -PassThru -ArgumentList @('-NoProfile','-File',$barrier,'-Mode','Reserve','-Source','concurrent-b','-Invocation','1','-Operations','1') -RedirectStandardOutput $bOut -RedirectStandardError $bErr
+$a.WaitForExit(); $b.WaitForExit()
+Get-Content $aOut,$aErr,$bOut,$bErr -ErrorAction SilentlyContinue
+$codes = @($a.ExitCode, $b.ExitCode) | Sort-Object
+if (($codes -join ',') -ne '0,2') { throw "CAS test expected one admission and one budget block, got $($codes -join ',')." }
+
+& $barrier -Mode Reserve -Source "persistence-check" -Invocation 1 -Operations 1
+if ($LASTEXITCODE -ne 2) { throw "A separate process did not observe the persisted reservation." }
+Write-Host "Live R2 monthly signing ledger validation passed without mocks."

--- a/scripts/windows-signing-monthly-budget.ps1
+++ b/scripts/windows-signing-monthly-budget.ps1
@@ -67,8 +67,17 @@ function Project-Cost([int64]$ProjectedOperations, [int64]$Base, [int64]$Include
 }
 
 function Invoke-Aws([string[]]$Arguments, [switch]$AllowFailure) {
-  $output = & aws @Arguments 2>&1 | Out-String
-  $code = $LASTEXITCODE
+  $output = ""
+  $code = 1
+  foreach ($transportAttempt in 1..5) {
+    $output = & aws @Arguments 2>&1 | Out-String
+    $code = $LASTEXITCODE
+    if ($code -eq 0) { break }
+    $transient = $output -match "Too Many Requests|\(429\)|status code: 429|\(50[0-9]\)|status code: 50[0-9]"
+    if (-not $transient -or $transportAttempt -eq 5) { break }
+    Write-Host "::warning::Transient R2 response on attempt $transportAttempt/5; retrying without permitting a signing call."
+    Start-Sleep -Milliseconds (250 * [Math]::Pow(2, $transportAttempt - 1))
+  }
   if ($code -ne 0 -and -not $AllowFailure) { Fail "R2 ledger request failed (aws $($Arguments[0..1] -join ' ')): $($output.Trim())" }
   return [PSCustomObject]@{ code = $code; output = $output.Trim() }
 }

--- a/scripts/windows-signing-monthly-budget.ps1
+++ b/scripts/windows-signing-monthly-budget.ps1
@@ -1,0 +1,181 @@
+# ABOUTME: Atomically reserves SSL.com operations in a billing-cycle R2 ledger before every cloud-signing call.
+# ABOUTME: Uses conditional PutObject requests so concurrent release jobs cannot overspend the configured monthly budget.
+
+[CmdletBinding()]
+param(
+  [ValidateSet("Reserve", "Bootstrap")][string]$Mode = "Reserve",
+  [string]$Source = "",
+  [int]$Invocation = 0,
+  [int]$Operations = 0,
+  [int]$BootstrapOperations = -1,
+  [string]$BootstrapSource = "",
+  [string]$BootstrapApprovedBy = "",
+  [string]$OutputFile = "",
+  [int]$MaxCasAttempts = 8
+)
+
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$Message) {
+  Write-Host "::error::$Message"
+  exit 1
+}
+
+function Require-Text([string]$Name) {
+  $value = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($value)) { Fail "$Name is required for monthly signing-budget enforcement." }
+  return $value.Trim()
+}
+
+function Require-NonNegativeInt([string]$Name) {
+  $raw = Require-Text $Name
+  [int64]$value = 0
+  if (-not [int64]::TryParse($raw, [ref]$value) -or $value -lt 0) {
+    Fail "$Name must be a non-negative integer, got '$raw'."
+  }
+  return $value
+}
+
+function Get-Cycle([datetimeoffset]$Now, [int]$AnchorDay, [string]$TimeZoneId) {
+  try { $zone = [TimeZoneInfo]::FindSystemTimeZoneById($TimeZoneId) } catch { Fail "Invalid SSL_SIGNING_BILLING_TIMEZONE '$TimeZoneId': $($_.Exception.Message)" }
+  $local = [TimeZoneInfo]::ConvertTime($Now, $zone)
+  $monthStart = [datetime]::new($local.Year, $local.Month, 1, 0, 0, 0, [DateTimeKind]::Unspecified)
+  $days = [DateTime]::DaysInMonth($monthStart.Year, $monthStart.Month)
+  if ($AnchorDay -gt $days) { Fail "SSL_SIGNING_BILLING_ANCHOR_DAY=$AnchorDay does not exist in $($monthStart.ToString('yyyy-MM'))." }
+  $boundary = $monthStart.AddDays($AnchorDay - 1)
+  if ($local.DateTime -lt $boundary) {
+    $monthStart = $monthStart.AddMonths(-1)
+    $days = [DateTime]::DaysInMonth($monthStart.Year, $monthStart.Month)
+    if ($AnchorDay -gt $days) { Fail "SSL_SIGNING_BILLING_ANCHOR_DAY=$AnchorDay does not exist in $($monthStart.ToString('yyyy-MM'))." }
+    $boundary = $monthStart.AddDays($AnchorDay - 1)
+  }
+  $nextMonth = $monthStart.AddMonths(1)
+  $nextDays = [DateTime]::DaysInMonth($nextMonth.Year, $nextMonth.Month)
+  if ($AnchorDay -gt $nextDays) { Fail "SSL_SIGNING_BILLING_ANCHOR_DAY=$AnchorDay does not exist in $($nextMonth.ToString('yyyy-MM'))." }
+  $nextBoundary = $nextMonth.AddDays($AnchorDay - 1)
+  return [PSCustomObject]@{
+    id = $boundary.ToString("yyyy-MM-dd")
+    starts_at = ([TimeZoneInfo]::ConvertTimeToUtc($boundary, $zone)).ToString("o")
+    ends_at = ([TimeZoneInfo]::ConvertTimeToUtc($nextBoundary, $zone)).ToString("o")
+    timezone = $TimeZoneId
+    anchor_day = $AnchorDay
+  }
+}
+
+function Project-Cost([int64]$ProjectedOperations, [int64]$Base, [int64]$Included, [int64]$Overage, [int64]$Fixed) {
+  return $Base + $Fixed + ([Math]::Max([int64]0, $ProjectedOperations - $Included) * $Overage)
+}
+
+function Invoke-Aws([string[]]$Arguments, [switch]$AllowFailure) {
+  $output = & aws @Arguments 2>&1 | Out-String
+  $code = $LASTEXITCODE
+  if ($code -ne 0 -and -not $AllowFailure) { Fail "R2 ledger request failed (aws $($Arguments[0..1] -join ' ')): $($output.Trim())" }
+  return [PSCustomObject]@{ code = $code; output = $output.Trim() }
+}
+
+$budget = Require-NonNegativeInt "SSL_SIGNING_MONTHLY_BUDGET_CENTS"
+$base = Require-NonNegativeInt "SSL_SIGNING_TIER_BASE_CENTS"
+$included = Require-NonNegativeInt "SSL_SIGNING_TIER_INCLUDED_OPERATIONS"
+$overage = Require-NonNegativeInt "SSL_SIGNING_TIER_OVERAGE_CENTS"
+$fixed = Require-NonNegativeInt "SSL_SIGNING_OTHER_FIXED_MONTHLY_CENTS"
+$anchorRaw = Require-Text "SSL_SIGNING_BILLING_ANCHOR_DAY"
+[int]$anchor = 0
+if (-not [int]::TryParse($anchorRaw, [ref]$anchor) -or $anchor -lt 1 -or $anchor -gt 28) { Fail "SSL_SIGNING_BILLING_ANCHOR_DAY must be an integer from 1 through 28, got '$anchorRaw'." }
+$timezone = Require-Text "SSL_SIGNING_BILLING_TIMEZONE"
+$account = Require-Text "SSL_SIGNING_ACCOUNT"
+$certificate = Require-Text "SSL_SIGNING_CERTIFICATE"
+$bucket = Require-Text "R2_BUCKET"
+$endpoint = Require-Text "AWS_ENDPOINT_URL"
+$prefix = Require-Text "SSL_SIGNING_LEDGER_R2_PREFIX"
+if ($base + $fixed -gt $budget) { Fail "Fixed Tier 1 costs ($($base + $fixed) cents) already exceed SSL_SIGNING_MONTHLY_BUDGET_CENTS=$budget." }
+if ($overage -eq 0) { Fail "SSL_SIGNING_TIER_OVERAGE_CENTS must be greater than zero so the operation ceiling is finite." }
+
+$cycle = Get-Cycle ([DateTimeOffset]::UtcNow) $anchor $timezone
+$safeAccount = ($account -replace '[^A-Za-z0-9._-]', '_')
+$safeCertificate = ($certificate -replace '[^A-Za-z0-9._-]', '_')
+$key = "$($prefix.Trim('/'))/$safeAccount/$safeCertificate/$($cycle.id).json"
+$uri = "s3://$bucket/$key"
+$configuration = [ordered]@{ budget_cents=$budget; base_cents=$base; included_operations=$included; overage_cents=$overage; other_fixed_monthly_cents=$fixed }
+
+if ($Mode -eq "Bootstrap") {
+  if ($BootstrapOperations -lt 0) { Fail "BootstrapOperations must be supplied from authoritative current-cycle SSL.com usage." }
+  if ([string]::IsNullOrWhiteSpace($BootstrapSource) -or [string]::IsNullOrWhiteSpace($BootstrapApprovedBy)) { Fail "BootstrapSource and BootstrapApprovedBy are required for an audited bootstrap." }
+  $cost = Project-Cost $BootstrapOperations $base $included $overage $fixed
+  if ($cost -gt $budget) { Fail "Bootstrap usage projects $cost cents, above the $budget-cent monthly budget." }
+  $now = [DateTimeOffset]::UtcNow.ToString("o")
+  $ledger = [ordered]@{
+    schema_version=1; account=$account; certificate=$certificate; billing_cycle=$cycle.id
+    cycle_starts_at=$cycle.starts_at; cycle_ends_at=$cycle.ends_at; billing_timezone=$cycle.timezone; billing_anchor_day=$cycle.anchor_day
+    configuration=$configuration; committed_or_reserved_operations=$BootstrapOperations; projected_cost_cents=$cost
+    bootstrap=[ordered]@{ operations=$BootstrapOperations; source=$BootstrapSource; recorded_at=$now; approved_by=$BootstrapApprovedBy }
+    updated_at=$now; version=1; entries=@()
+  }
+  $temp = Join-Path ([IO.Path]::GetTempPath()) "ssl-ledger-bootstrap-$([guid]::NewGuid()).json"
+  try {
+    ($ledger | ConvertTo-Json -Depth 12) | Set-Content -LiteralPath $temp -Encoding utf8
+    $result = Invoke-Aws @("s3api","put-object","--bucket",$bucket,"--key",$key,"--body",$temp,"--if-none-match","*","--endpoint-url",$endpoint,"--output","json") -AllowFailure
+    if ($result.code -ne 0) { Fail "The active-cycle ledger already exists or R2 rejected atomic bootstrap. Inspect it instead of overwriting it: $($result.output)" }
+  } finally { Remove-Item -LiteralPath $temp -Force -ErrorAction SilentlyContinue }
+  Write-Host "Bootstrapped SSL.com ledger $uri with $BootstrapOperations authoritative operation(s), projected cost $cost cents."
+  exit 0
+}
+
+if ($Mode -eq "Reserve" -and ($Operations -lt 1 -or [string]::IsNullOrWhiteSpace($Source) -or $Invocation -lt 1)) { Fail "Reserve requires Source, Invocation >= 1, and Operations >= 1." }
+$runId = Require-Text "GITHUB_RUN_ID"
+$runAttempt = Require-Text "GITHUB_RUN_ATTEMPT"
+$idempotencyKey = "$runId/$runAttempt/$Source/$Invocation"
+
+for ($attempt = 1; $attempt -le $MaxCasAttempts; $attempt++) {
+  $head = Invoke-Aws @("s3api","head-object","--bucket",$bucket,"--key",$key,"--endpoint-url",$endpoint,"--output","json") -AllowFailure
+  if ($head.code -ne 0) { Fail "Monthly ledger $uri is missing or unreachable. Bootstrap authoritative active-cycle usage before signing. $($head.output)" }
+  try { $etag = ([string](($head.output | ConvertFrom-Json).ETag)).Trim('"') } catch { Fail "Could not parse the R2 ETag for $uri." }
+  if ([string]::IsNullOrWhiteSpace($etag)) { Fail "R2 returned no ETag for $uri; atomicity cannot be proven." }
+  $current = Join-Path ([IO.Path]::GetTempPath()) "ssl-ledger-current-$([guid]::NewGuid()).json"
+  $next = Join-Path ([IO.Path]::GetTempPath()) "ssl-ledger-next-$([guid]::NewGuid()).json"
+  try {
+    $get = Invoke-Aws @("s3api","get-object","--bucket",$bucket,"--key",$key,"--if-match",$etag,"--endpoint-url",$endpoint,$current,"--output","json") -AllowFailure
+    if ($get.code -ne 0) { continue }
+    try { $ledger = Get-Content -Raw -LiteralPath $current | ConvertFrom-Json } catch { Fail "Monthly ledger $uri is corrupt: $($_.Exception.Message)" }
+    if ($ledger.schema_version -ne 1 -or $ledger.account -ne $account -or $ledger.certificate -ne $certificate -or $ledger.billing_cycle -ne $cycle.id) { Fail "Monthly ledger identity/schema does not match the configured account, certificate, and billing cycle." }
+    if ($ledger.cycle_starts_at -ne $cycle.starts_at -or $ledger.cycle_ends_at -ne $cycle.ends_at -or $ledger.billing_timezone -ne $timezone -or [int]$ledger.billing_anchor_day -ne $anchor) { Fail "Monthly ledger billing boundary is stale or conflicts with repository configuration." }
+    foreach ($name in $configuration.Keys) { if ([int64]$ledger.configuration.$name -ne [int64]$configuration[$name]) { Fail "Monthly ledger configuration '$name' conflicts with repository configuration." } }
+    if ($null -eq $ledger.bootstrap -or [string]::IsNullOrWhiteSpace([string]$ledger.bootstrap.source) -or [string]::IsNullOrWhiteSpace([string]$ledger.bootstrap.approved_by)) { Fail "Monthly ledger has no authoritative audited bootstrap." }
+    $existing = @($ledger.entries | Where-Object { $_.idempotency_key -eq $idempotencyKey })
+    if ($existing.Count -gt 0) {
+      if ([int]$existing[0].operations -ne $Operations) { Fail "Idempotency key $idempotencyKey was already reserved with a different operation count." }
+      Write-Host "Monthly reservation already committed (idempotent): $idempotencyKey."
+      if ($OutputFile) { Copy-Item -LiteralPath $current -Destination $OutputFile -Force }
+      exit 0
+    }
+    $projectedOperations = [int64]$ledger.committed_or_reserved_operations + $Operations
+    $cost = Project-Cost $projectedOperations $base $included $overage $fixed
+    if ($cost -gt $budget) {
+      if ($OutputFile) { Copy-Item -LiteralPath $current -Destination $OutputFile -Force }
+      Write-Host "::warning::Monthly SSL.com signing blocked before cloud call: cycle=$($cycle.id) used=$($ledger.committed_or_reserved_operations) requested=$Operations projected_cost_cents=$cost budget_cents=$budget."
+      exit 2
+    }
+    $entry = [PSCustomObject]@{ run_id=$runId; run_attempt=[int]$runAttempt; source=$Source; invocation=$Invocation; operations=$Operations; idempotency_key=$idempotencyKey; status="reserved_before_cloud_call"; reserved_at=[DateTimeOffset]::UtcNow.ToString("o") }
+    $ledger.entries = @($ledger.entries) + $entry
+    $ledger.committed_or_reserved_operations = $projectedOperations
+    $ledger.projected_cost_cents = $cost
+    $ledger.updated_at = [DateTimeOffset]::UtcNow.ToString("o")
+    $ledger.version = [int64]$ledger.version + 1
+    ($ledger | ConvertTo-Json -Depth 12) | Set-Content -LiteralPath $next -Encoding utf8
+    $put = Invoke-Aws @("s3api","put-object","--bucket",$bucket,"--key",$key,"--body",$next,"--if-match",$etag,"--endpoint-url",$endpoint,"--output","json") -AllowFailure
+    if ($put.code -eq 0) {
+      if ($OutputFile) { Copy-Item -LiteralPath $next -Destination $OutputFile -Force }
+      Write-Host "Reserved $Operations SSL.com operation(s): cycle=$($cycle.id) total=$projectedOperations projected_cost_cents=$cost ledger_version=$($ledger.version)."
+      $percent = [Math]::Floor(($cost * 100) / $budget)
+      if ($percent -ge 100) { Write-Host "::warning::SSL.com monthly signing budget is 100% consumed; later billable operations will be blocked." }
+      elseif ($percent -ge 90) { Write-Host "::warning::SSL.com monthly signing budget has reached at least 90% ($percent%)." }
+      elseif ($percent -ge 75) { Write-Host "::notice::SSL.com monthly signing budget has reached at least 75% ($percent%)." }
+      elseif ($percent -ge 50) { Write-Host "::notice::SSL.com monthly signing budget has reached at least 50% ($percent%)." }
+      exit 0
+    }
+    if ($put.output -notmatch "PreconditionFailed|412|ConditionalRequestConflict|409") { Fail "R2 conditional ledger write failed: $($put.output)" }
+  } finally {
+    Remove-Item -LiteralPath $current,$next -Force -ErrorAction SilentlyContinue
+  }
+  Start-Sleep -Milliseconds ([Math]::Min(1000, 50 * [Math]::Pow(2, $attempt - 1)))
+}
+Fail "Monthly ledger CAS conflicted $MaxCasAttempts times; signing is blocked because atomic reservation could not be proven."

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -217,6 +217,26 @@ describe("release workflow contract", () => {
     expect(budget).not.toContain("::warning::Windows signing budget exceeded");
     expect(signer).toContain("MAX_SIGNATURES");
   });
+
+  it("reserves the persistent monthly budget immediately before every signtool attempt (#2931)", () => {
+    const signer = readFileSync(signerScript, "utf8");
+    const monthly = readFileSync(path.join(repoRoot, "scripts", "windows-signing-monthly-budget.ps1"), "utf8");
+    const workflow = readFileSync(path.join(repoRoot, ".github", "workflows", "release.yml"), "utf8");
+    const loopAt = signer.indexOf("while ($true)");
+    const attemptAt = signer.indexOf("$attempt++", loopAt);
+    const reserveAt = signer.indexOf("Block-MonthlySigning", attemptAt);
+    const signtoolAt = signer.indexOf("& $signtool.FullName sign", reserveAt);
+
+    expect(attemptAt).toBeGreaterThan(loopAt);
+    expect(reserveAt).toBeGreaterThan(attemptAt);
+    expect(signtoolAt).toBeGreaterThan(reserveAt);
+    expect(monthly).toContain('"--if-match"');
+    expect(monthly).toContain('"--if-none-match"');
+    expect(monthly).toContain("reserved_before_cloud_call");
+    expect(monthly).toContain("BootstrapApprovedBy");
+    expect(workflow).toContain("blocked_monthly_budget");
+    expect(workflow).toContain("SSL_SIGNING_BILLING_TIMEZONE");
+  });
 });
 
 describe("sign-windows-payload.ps1 thumbprint resolution", () => {


### PR DESCRIPTION
Closes #2931.

## Audited defect

The #2930 barrier persisted only under `RUNNER_TEMP`, reset on every job, and reserved a signing source only once before all of its signtool retries. It therefore could not enforce one SSL.com invoice-cycle budget across releases, reruns, separate runners, or concurrent jobs.

The audit traced every cloud-signing source through `scripts/sign-windows-payload.ps1`: embedded runtime/MCP, NSIS stock plugins, and Tauri signCommand for app/helper/uninstaller/setup. No direct signtool/eSigner signing path bypasses that wrapper.

## Fix

- Add an R2-backed, versioned ledger keyed by account, certificate, and explicit billing boundary.
- Use Head/Get plus conditional PutObject `If-Match` CAS, with bounded conflict retries and fail-closed handling.
- Require an authoritative, actor-attributed active-cycle bootstrap created with `If-None-Match: *`; never initialize usage to zero during releases.
- Derive the operation ceiling from integer-cent Tier 1 configuration; fixed charges reduce capacity.
- Reserve every batch immediately before signtool, and reserve every retry again.
- Preserve idempotency for repeated bookkeeping via run ID, run attempt, source, and invocation.
- Feed `blocked_monthly_budget` through the transparent unsigned artifact, release-note, cache-state, and AWS Windows e2e paths established in #2930.
- Report cycle, operations used/remaining, projected charge, and ledger version, with 50/75/90/100% annotations.
- Add a manual operator bootstrap and real R2 live-test workflow. The live test admits fourteen sequential seven-operation releases (98 ops), blocks the fifteenth, races two near-limit reservations, and verifies persistence from a fresh process without mocks.

## Critical coverage

- Existing real PowerShell per-release barrier coverage remains unchanged.
- Workflow contract asserts the monthly reservation occurs inside the retry loop before signtool and that conditional-write/bootstrap contracts remain wired.
- The live R2 workflow is the functional storage/concurrency test; it uses no storage mock.

## Local validation

- Focused release-signing tests: 41 passed, 12 skipped because this host's x86 pwsh crashes before startup.
- `pnpm check` exits 0 with pre-existing warnings.
- `pnpm build`
- `pnpm verify:frontend-build`
- YAML parse for all three changed workflows.
- `git diff --check`

## Networked paths

No user-facing app UI or Seren publisher slug is added or changed. The release-CI path uses the existing Cloudflare R2 S3 endpoint and SSL.com signtool path. R2 uses `HeadObject`, conditional `GetObject --if-match`, and conditional `PutObject --if-match/--if-none-match`; Cloudflare's current S3 compatibility metadata documents those conditional operations. The live Seren publisher list was queried before implementation; this release-infrastructure path does not route through a Seren publisher.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
