### PR TITLE
fix(agent): route spawned-agent gateway calls to the selected OAuth account (#2946)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -992,6 +992,22 @@ const INITIALIZE_MAX_ATTEMPTS = 2;
 // tools re-fetch, no process restart) before surfacing a degraded state. #2802
 const SEREN_MCP_SERVER_NAME = "seren-mcp";
 const SEREN_MCP_TOOL_PREFIX = `mcp__${SEREN_MCP_SERVER_NAME}__`;
+
+function applySerenMcpOAuthRouting(routing, toolName, toolInput) {
+  if (toolName !== `${SEREN_MCP_TOOL_PREFIX}call_publisher`) {
+    return { input: toolInput, denyMessage: null };
+  }
+  if (typeof toolInput?.connection_id === "string" && toolInput.connection_id.trim()) {
+    return { input: toolInput, denyMessage: null };
+  }
+  const publisher = toolInput?.publisher;
+  const denyMessage = routing?.ambiguous?.[publisher];
+  if (denyMessage) return { input: toolInput, denyMessage };
+  const connectionId = routing?.publishers?.[publisher];
+  return connectionId
+    ? { input: { ...toolInput, connection_id: connectionId }, denyMessage: null }
+    : { input: toolInput, denyMessage: null };
+}
 // The remote HTTP gateway's connect + tools/list races in the background and is
 // often still `pending` when the first `system init` fires, so a bare "0 tools
 // at init" is NOT yet a failure. Give the connection this long to register its
@@ -1665,7 +1681,7 @@ function handlePermissionRequest(emit, session, payload) {
 
   const toolName =
     payload.request.tool_name ?? payload.request.toolName ?? "Tool";
-  const toolInput =
+  let toolInput =
     payload.request.input ??
     payload.request.tool_input ??
     payload.request.toolInput ??
@@ -1676,6 +1692,21 @@ function handlePermissionRequest(emit, session, payload) {
   const toolUseId =
     payload.request.tool_use_id ?? payload.request.toolUseId ?? randomUUID();
 
+  const routed = applySerenMcpOAuthRouting(
+    session.oauthRouting,
+    toolName,
+    toolInput,
+  );
+  if (routed.denyMessage) {
+    emitToolResult(emit, session, toolUseId, routed.denyMessage, true);
+    respondToControlRequest(session, payload, {
+      behavior: "deny",
+      message: routed.denyMessage,
+      interrupt: false,
+    });
+    return;
+  }
+  toolInput = routed.input;
   emitToolCall(emit, session, toolName, toolInput, toolUseId, "pending");
 
   // AskUserQuestion (#1731): Claude Code's built-in interactive picker has
@@ -2830,6 +2861,12 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     emit("provider://session-status", buildSessionStatus(session));
   }
 
+  async function setOAuthRouting({ sessionId, routing }) {
+    const session = sessions.get(sessionId);
+    if (session) session.oauthRouting = routing;
+    else console.warn(`[claude-runtime] OAuth routing session not found: ${sessionId}`);
+  }
+
   async function respondToPermission({ sessionId, requestId, optionId }) {
     const session = sessions.get(sessionId);
     if (!session) {
@@ -3059,6 +3096,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     listSessions,
     listRemoteSessions,
     setPermissionMode,
+    setOAuthRouting,
     respondToPermission,
     setModel,
     listSessionModels,
@@ -3090,4 +3128,5 @@ export {
   handleStreamEvent as _handleStreamEvent,
   countSerenMcpTools as _countSerenMcpTools,
   SEREN_MCP_TOOL_PREFIX as _SEREN_MCP_TOOL_PREFIX,
+  applySerenMcpOAuthRouting as _applySerenMcpOAuthRouting,
 };

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -1090,6 +1090,7 @@ export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) 
     terminateSession,
     listSessions,
     setPermissionMode,
+    setOAuthRouting: async () => {},
     respondToPermission,
     setModel,
   };

--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -1720,6 +1720,7 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
     terminateSession,
     listSessions,
     setPermissionMode,
+    setOAuthRouting: async () => {},
     respondToPermission,
     setSessionModel,
     updateSessionConfigOption,

--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -1589,6 +1589,18 @@ export function createPairedRuntime({ emit, inner }) {
     emitPairedStatus(paired);
   }
 
+  async function setOAuthRouting({ sessionId, routing }) {
+    const paired = requirePaired(sessionId);
+    await Promise.all(
+      [paired.roles.planner, paired.roles.executor].map((role) =>
+        inner.setOAuthRouting({
+          sessionId: role.innerSessionId,
+          routing,
+        }),
+      ),
+    );
+  }
+
   async function respondToPermission({ sessionId, requestId, optionId }) {
     const paired = requirePaired(sessionId);
     const innerSessionId = paired.permissionRoutes.get(requestId);
@@ -1622,6 +1634,7 @@ export function createPairedRuntime({ emit, inner }) {
     setSessionModel,
     updateSessionConfigOption,
     setPermissionMode,
+    setOAuthRouting,
     respondToPermission,
   };
 }

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -119,6 +119,7 @@ export function createUnavailableRuntime(label, reason) {
     cancelPrompt: unavailable,
     terminateSession: unavailable,
     setPermissionMode: unavailable,
+    setOAuthRouting: unavailable,
     respondToPermission: unavailable,
     listRemoteSessions: unavailable,
     setModel: unavailable,
@@ -1866,6 +1867,24 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     emit("provider://session-status", buildSessionStatus(session));
   }
 
+  async function setOAuthRouting({ sessionId, routing }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      if (pairedRuntime.hasSession(sessionId)) {
+        return pairedRuntime.setOAuthRouting({ sessionId, routing });
+      }
+      if (geminiRuntime.hasSession(sessionId)) {
+        return geminiRuntime.setOAuthRouting({ sessionId, routing });
+      }
+      if (lmStudioRuntime.hasSession(sessionId)) {
+        return lmStudioRuntime.setOAuthRouting({ sessionId, routing });
+      }
+      return claudeRuntime.setOAuthRouting({ sessionId, routing });
+    }
+    // Native Codex sessions do not use Seren MCP OAuth routing yet.
+    console.info(`[provider-runtime] OAuth routing is a no-op for ${session.agentType} session ${sessionId}`);
+  }
+
   async function respondToPermission({ sessionId, requestId, optionId }) {
     const session = sessions.get(sessionId);
     if (!session) {
@@ -2186,6 +2205,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         listSessionModels,
         updateSessionConfigOption,
         setPermissionMode,
+        setOAuthRouting,
         respondToPermission,
       },
     },
@@ -2198,6 +2218,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     terminateSession,
     listSessions,
     setPermissionMode,
+    setOAuthRouting,
     respondToPermission,
     respondToDiffProposal,
     getAvailableAgents,

--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -88,6 +88,10 @@ function registerProviderHandlers() {
     providerHandlers.setPermissionMode,
   );
   registerHandler(
+    "provider_set_oauth_routing",
+    providerHandlers.setOAuthRouting,
+  );
+  registerHandler(
     "provider_respond_to_permission",
     providerHandlers.respondToPermission,
   );

--- a/bin/seren-desktop.mjs
+++ b/bin/seren-desktop.mjs
@@ -248,6 +248,10 @@ function registerBrowserLocalHandlers() {
     providerHandlers.setPermissionMode,
   );
   registerHandler(
+    "provider_set_oauth_routing",
+    providerHandlers.setOAuthRouting,
+  );
+  registerHandler(
     "provider_respond_to_permission",
     providerHandlers.respondToPermission,
   );

--- a/src/components/chat/OAuthAccountSwitcher.tsx
+++ b/src/components/chat/OAuthAccountSwitcher.tsx
@@ -17,6 +17,7 @@ import { listenForOAuthCallback } from "@/lib/tauri-bridge";
 import {
   connectPublisher,
   listConnectedPublishers,
+  setDefaultOAuthConnection,
 } from "@/services/publisher-oauth";
 import {
   formatOAuthConnectionLabel,
@@ -52,6 +53,9 @@ export const OAuthAccountSwitcher: Component<OAuthAccountSwitcherProps> = (
     string | null
   >(null);
   const [connectError, setConnectError] = createSignal<string | null>(null);
+  const [defaultingConnection, setDefaultingConnection] = createSignal<
+    string | null
+  >(null);
   let rootRef: HTMLDivElement | undefined;
   let connectTimeout: ReturnType<typeof setTimeout> | null = null;
   const [connections] = createResource(oauthConnectionsRevision, async () =>
@@ -209,17 +213,23 @@ export const OAuthAccountSwitcher: Component<OAuthAccountSwitcherProps> = (
                           (!group.selected && item.is_default);
 
                         return (
-                          <button
-                            type="button"
+                          <div
                             class={`w-full text-left px-3 py-2 flex items-center justify-between gap-3 hover:bg-surface-2 transition-colors ${
                               selected()
                                 ? "text-foreground"
                                 : "text-muted-foreground"
                             }`}
                             role="menuitem"
+                            tabIndex={0}
                             onClick={() =>
                               chooseConnection(group.providerSlug, item)
                             }
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter" || event.key === " ") {
+                                event.preventDefault();
+                                chooseConnection(group.providerSlug, item);
+                              }
+                            }}
                           >
                             <span class="min-w-0">
                               <span class="block text-[0.85rem] truncate">
@@ -231,12 +241,42 @@ export const OAuthAccountSwitcher: Component<OAuthAccountSwitcherProps> = (
                                 </span>
                               </Show>
                             </span>
-                            <Show when={selected()}>
-                              <span class="text-success text-xs font-semibold">
-                                Active
-                              </span>
-                            </Show>
-                          </button>
+                            <span class="flex items-center gap-2 shrink-0">
+                              <Show when={selected()}>
+                                <span class="text-success text-xs font-semibold">
+                                  Active
+                                </span>
+                              </Show>
+                              <Show when={!item.is_default}>
+                                <button
+                                  type="button"
+                                  class="text-[0.7rem] text-muted-foreground hover:text-foreground underline underline-offset-2 disabled:opacity-50"
+                                  disabled={defaultingConnection() !== null}
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    setDefaultingConnection(item.id);
+                                    setConnectError(null);
+                                    void setDefaultOAuthConnection(item.id)
+                                      .catch((error) => {
+                                        setConnectError(
+                                          error instanceof Error
+                                            ? error.message
+                                            : "Failed to set default account",
+                                        );
+                                      })
+                                      .finally(() =>
+                                        setDefaultingConnection(null),
+                                      );
+                                  }}
+                                  onKeyDown={(event) => event.stopPropagation()}
+                                >
+                                  {defaultingConnection() === item.id
+                                    ? "Setting…"
+                                    : "Set default"}
+                                </button>
+                              </Show>
+                            </span>
+                          </div>
                         );
                       }}
                     </For>

--- a/src/components/gateway/GatewayToolApproval.tsx
+++ b/src/components/gateway/GatewayToolApproval.tsx
@@ -171,7 +171,7 @@ export const GatewayToolApproval: Component = () => {
   );
 
   const shouldRenderAccountChoices = createMemo(
-    () => validConnections().length > 1 && !hasDefaultConnection(),
+    () => validConnections().length > 1,
   );
 
   const needsConnectionChoice = createMemo(() => {
@@ -378,7 +378,15 @@ export const GatewayToolApproval: Component = () => {
                       <span class="text-[0.8rem] text-warning/90">
                         {validConnections().length}{" "}
                         {providerResolution()?.providerName ?? "OAuth"} accounts
-                        are connected and no default is set.
+                        are connected
+                        <Show when={!hasDefaultConnection()}>
+                          {" "}
+                          and no default is set.
+                        </Show>
+                        <Show when={hasDefaultConnection()}>
+                          {" "}
+                          Confirm which account to send from.
+                        </Show>
                       </span>
                       <For each={validConnections()}>
                         {(connection) => {

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -35,6 +35,11 @@ export type UnlistenFn = () => void;
 /** Roles inside a paired `claude-codex` thread (#2368). */
 export type PairedRole = "planner" | "executor";
 
+export interface AgentOAuthRouting {
+  publishers: Record<string, string>;
+  ambiguous: Record<string, string>;
+}
+
 export function supportsConversationFork(agentType: AgentType): boolean {
   // Paired threads span two inner sessions; forking one coherent copy is
   // not supported.
@@ -596,6 +601,13 @@ export async function setPermissionMode(
   mode: string,
 ): Promise<void> {
   return invokeProvider("provider_set_permission_mode", { sessionId, mode });
+}
+
+export async function setOAuthRouting(
+  sessionId: string,
+  routing: AgentOAuthRouting,
+): Promise<void> {
+  return invokeProvider("provider_set_oauth_routing", { sessionId, routing });
 }
 
 /**

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -20,9 +20,13 @@ import {
   getDesktopOAuthCallbackUrl,
   getValidationRuntimeInfo,
 } from "@/services/oauth-callback";
+import type { AgentOAuthRouting } from "@/services/providers";
 import {
+  getOAuthConnectionsForProvider,
+  hasAmbiguousOAuthConnections,
   markOAuthConnectionsChanged,
   type OAuthConnection,
+  resolveThreadOAuthConnection,
 } from "@/stores/oauth-account.store";
 
 export interface PublisherOAuthProviderResolution {
@@ -106,6 +110,58 @@ async function loadPublisherOAuthProviderLookup(): Promise<
   }
 
   return lookup;
+}
+
+export async function listPublisherOAuthProviderResolutions(): Promise<
+  PublisherOAuthProviderResolution[]
+> {
+  providerLookupPromise ??= loadPublisherOAuthProviderLookup();
+  const lookup = await providerLookupPromise;
+  return Array.from(lookup.values());
+}
+
+export async function computeAgentOAuthRouting(
+  threadId: string | null,
+): Promise<AgentOAuthRouting> {
+  try {
+    const [resolutions, connections] = await Promise.all([
+      listPublisherOAuthProviderResolutions(),
+      listConnectedPublishers(),
+    ]);
+    const routing: AgentOAuthRouting = { publishers: {}, ambiguous: {} };
+    for (const resolution of resolutions) {
+      const validConnections = getOAuthConnectionsForProvider(
+        connections,
+        resolution.providerSlug,
+      );
+      if (validConnections.length === 0) continue;
+      if (
+        hasAmbiguousOAuthConnections(
+          threadId,
+          resolution.providerSlug,
+          connections,
+        )
+      ) {
+        routing.ambiguous[resolution.publisherSlug] =
+          `Multiple ${resolution.providerName} accounts are connected. Choose an active account for this chat in the header account switcher before running ${resolution.publisherSlug} tools.`;
+        continue;
+      }
+      const connection = resolveThreadOAuthConnection(
+        threadId,
+        resolution.providerSlug,
+        connections,
+      );
+      if (connection)
+        routing.publishers[resolution.publisherSlug] = connection.id;
+    }
+    return routing;
+  } catch (error) {
+    console.warn(
+      "[PublisherOAuth] Failed to compute agent OAuth routing:",
+      error,
+    );
+    return { publishers: {}, ambiguous: {} };
+  }
 }
 
 /**

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Stores agent sessions, message streams, tool calls, and plan state.
 
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { createEffect, createRoot } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import {
   extractEvidenceFromAgentMessages,
@@ -570,11 +571,16 @@ import type {
   ToolCallEvent,
 } from "@/services/providers";
 import * as providerService from "@/services/providers";
+import { computeAgentOAuthRouting } from "@/services/publisher-oauth";
 import {
   authStore,
   ensureApiKey,
   requestSignInModal,
 } from "@/stores/auth.store";
+import {
+  oauthConnectionsRevision,
+  oauthSelectionsRevision,
+} from "@/stores/oauth-account.store";
 
 /** Set once we've subscribed to `provider-runtime://ready` so repeated
  *  initialize() calls don't stack listeners. */
@@ -1750,6 +1756,30 @@ const [state, setState] = createStore<AgentState>({
   agentModeEnabled: false,
 });
 
+async function refreshAgentOAuthRouting(conversationId: string): Promise<void> {
+  try {
+    const routing = await computeAgentOAuthRouting(conversationId);
+    await providerService.setOAuthRouting(conversationId, routing);
+  } catch (error) {
+    console.warn(
+      `[AgentStore] Failed to refresh OAuth routing for ${conversationId}:`,
+      error,
+    );
+  }
+}
+
+createRoot(() => {
+  createEffect(() => {
+    oauthConnectionsRevision();
+    oauthSelectionsRevision();
+    for (const session of Object.values(state.sessions)) {
+      if (session.conversationId) {
+        void refreshAgentOAuthRouting(session.conversationId);
+      }
+    }
+  });
+});
+
 let globalUnsubscribe: UnlistenFn | null = null;
 const pendingSessionEvents = new Map<string, AgentEvent[]>();
 
@@ -2024,6 +2054,8 @@ function getIdleClaudeSessionIds(excludeConversationId?: string): string[] {
 // ============================================================================
 
 export const agentStore = {
+  refreshAgentOAuthRouting,
+
   // ============================================================================
   // Getters
   // ============================================================================
@@ -3215,6 +3247,7 @@ export const agentStore = {
           settingsStore.settings.lmStudioApiKey,
         );
         console.log("[AgentStore] Spawn result:", info);
+        await refreshAgentOAuthRouting(localSessionId ?? info.id);
         expectedReadySessionId = info.id;
 
         // The new session is alive — immediately clear the terminated flag so
@@ -3806,6 +3839,7 @@ export const agentStore = {
       };
       setState("sessions", conversationId, session);
       setState("activeSessionId", conversationId);
+      await refreshAgentOAuthRouting(conversationId);
 
       if (rehydratedPendingPermissions.length > 0) {
         const seenRequestIds = new Set(

--- a/src/stores/oauth-account.store.ts
+++ b/src/stores/oauth-account.store.ts
@@ -58,8 +58,10 @@ const [selections, setSelections] = createSignal<ThreadConnectionSelections>(
   readSelections(),
 );
 const [connectionsRevision, setConnectionsRevision] = createSignal(0);
+const [selectionsRevision, setSelectionsRevision] = createSignal(0);
 
 export const oauthConnectionsRevision = connectionsRevision;
+export const oauthSelectionsRevision = selectionsRevision;
 
 export function markOAuthConnectionsChanged(): void {
   setConnectionsRevision((revision) => revision + 1);
@@ -126,6 +128,7 @@ export function setThreadOAuthConnectionId(
 
   setSelections(next);
   writeSelections(next);
+  setSelectionsRevision((revision) => revision + 1);
 }
 
 export function resolveThreadOAuthConnection(

--- a/tests/unit/agent-oauth-routing.test.ts
+++ b/tests/unit/agent-oauth-routing.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getToken: vi.fn(),
+  listConnections: vi.fn(),
+  listProviders: vi.fn(),
+  listStorePublishers: vi.fn(),
+}));
+
+vi.mock("@/api", () => ({
+  listConnections: mocks.listConnections,
+  listProviders: mocks.listProviders,
+  listStorePublishers: mocks.listStorePublishers,
+  revokeConnectionById: vi.fn(),
+  setDefaultConnection: vi.fn(),
+}));
+vi.mock("@/lib/tauri-bridge", () => ({ getToken: mocks.getToken }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+const connections = [
+  { id: "conn-default", provider_slug: "google", provider_email: "default@example.com", is_valid: true, is_default: true },
+  { id: "conn-other", provider_slug: "google", provider_email: "other@example.com", is_valid: true, is_default: false },
+];
+
+describe("computeAgentOAuthRouting", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.getToken.mockResolvedValue("token");
+    mocks.listConnections.mockResolvedValue({ data: { connections } });
+    mocks.listProviders.mockResolvedValue({ data: { providers: [{ id: "google-provider", slug: "google", name: "Google" }] } });
+    mocks.listStorePublishers.mockResolvedValue({ data: { data: [{ slug: "gmail", oauth_provider_id: "google-provider" }] } });
+  });
+
+  it("prefers an explicit thread selection over the default", async () => {
+    const { setThreadOAuthConnectionId } = await import("@/stores/oauth-account.store");
+    setThreadOAuthConnectionId("thread-routing", "google", "conn-other");
+    const { computeAgentOAuthRouting } = await import("@/services/publisher-oauth");
+    await expect(computeAgentOAuthRouting("thread-routing")).resolves.toEqual({
+      publishers: { gmail: "conn-other", google: "conn-other" },
+      ambiguous: {},
+    });
+  });
+
+  it("uses the default, then the sole connection", async () => {
+    const { computeAgentOAuthRouting } = await import("@/services/publisher-oauth");
+    await expect(computeAgentOAuthRouting("thread-default")).resolves.toEqual({
+      publishers: { gmail: "conn-default", google: "conn-default" },
+      ambiguous: {},
+    });
+
+    mocks.listConnections.mockResolvedValue({
+      data: { connections: [connections[1]] },
+    });
+    await expect(computeAgentOAuthRouting("thread-sole")).resolves.toEqual({
+      publishers: { gmail: "conn-other", google: "conn-other" },
+      ambiguous: {},
+    });
+  });
+
+  it("marks multiple connections without a default or selection ambiguous", async () => {
+    mocks.listConnections.mockResolvedValue({
+      data: { connections: connections.map((connection) => ({ ...connection, is_default: false })) },
+    });
+    const { computeAgentOAuthRouting } = await import("@/services/publisher-oauth");
+    await expect(computeAgentOAuthRouting("thread-ambiguous")).resolves.toEqual({
+      publishers: {},
+      ambiguous: {
+        gmail: expect.stringContaining("Multiple Google accounts are connected"),
+        google: expect.stringContaining("Multiple Google accounts are connected"),
+      },
+    });
+  });
+});

--- a/tests/unit/claude-runtime-oauth-routing.test.ts
+++ b/tests/unit/claude-runtime-oauth-routing.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { _applySerenMcpOAuthRouting as applyRouting } from "../../bin/browser-local/claude-runtime.mjs";
+
+const tool = "mcp__seren-mcp__call_publisher";
+
+describe("spawned Claude Seren MCP OAuth routing", () => {
+  it("injects the mapped connection id", () => {
+    expect(
+      applyRouting(
+        { publishers: { gmail: "conn-alpha" }, ambiguous: {} },
+        tool,
+        { publisher: "gmail", tool: "post_send" },
+      ),
+    ).toEqual({
+      input: { publisher: "gmail", tool: "post_send", connection_id: "conn-alpha" },
+      denyMessage: null,
+    });
+  });
+
+  it("preserves an explicit connection id", () => {
+    const input = { publisher: "gmail", connection_id: "conn-explicit" };
+    expect(applyRouting({ publishers: { gmail: "conn-alpha" }, ambiguous: {} }, tool, input)).toEqual({
+      input,
+      denyMessage: null,
+    });
+  });
+
+  it("returns an actionable denial for an ambiguous publisher", () => {
+    expect(
+      applyRouting(
+        { publishers: {}, ambiguous: { gmail: "Choose an account" } },
+        tool,
+        { publisher: "gmail" },
+      ),
+    ).toEqual({ input: { publisher: "gmail" }, denyMessage: "Choose an account" });
+  });
+
+  it("ignores non-Seren tools and unmapped publishers", () => {
+    const routing = { publishers: { gmail: "conn-alpha" }, ambiguous: {} };
+    const input = { publisher: "calendar" };
+    expect(applyRouting(routing, "mcp__other__call", input)).toEqual({ input, denyMessage: null });
+    expect(applyRouting(routing, tool, input)).toEqual({ input, denyMessage: null });
+  });
+});


### PR DESCRIPTION
## Root cause

Spawned Claude sessions called the Seren MCP gateway directly without attaching `connection_id`, so the gateway fell back to the default OAuth connection.

## Fix

- Added OAuth routing computation and push plumbing for spawned, rehydrated, and live sessions.
- Injects the selected connection into Seren `call_publisher` calls, while denying ambiguous publishers clearly.
- Approval dialogs show account choice whenever multiple accounts exist.
- Header account switcher adds a per-row “Set default” action.
- Added only critical routing regression tests.

## Validation

- Focused Vitest: 4 files, 20 tests passed.
- `pnpm build`: passed.
- Scoped Biome checks for touched files: passed.
- Repository-wide `pnpm check`: fails on unrelated baseline diagnostics in untouched files.

## Networked path

The only outbound path touched is the existing Seren MCP HTTP connection to https://mcp.serendb.com/mcp. The existing JSON-RPC `call_publisher` call gains a top-level `connection_id` argument, matching the in-app path at `src/services/mcp-gateway.ts:676-678`. No new endpoints, slugs, or headers are introduced.

The Gmail/gateway silent `From:` rewrite and 200 response is a gateway/seren-core dependency outside this repository.

Closes #2946.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com