### PR TITLE
fix(release): cache gate accepts embedded-runtime source (#2948)

### DIFF
--- a/scripts/assert-windows-signature-cache.ps1
+++ b/scripts/assert-windows-signature-cache.ps1
@@ -130,7 +130,8 @@ function Read-TelemetrySummary {
     }
     if ($null -ne $record.signed) { $totalSigned += [int]$record.signed }
     $source = [string]$record.source
-    if ($source.StartsWith("list:", [System.StringComparison]::OrdinalIgnoreCase)) {
+    if ($source.StartsWith("list:", [System.StringComparison]::OrdinalIgnoreCase) -or
+        $source.StartsWith("embedded-runtime", [System.StringComparison]::OrdinalIgnoreCase)) {
       $embeddedRecords++
       if ($null -ne $record.discovered) { $embeddedDiscovered += [int]$record.discovered }
       if ($null -ne $record.skipped) { $embeddedSkipped += [int]$record.skipped }
@@ -140,7 +141,7 @@ function Read-TelemetrySummary {
   }
 
   if ($embeddedRecords -eq 0) {
-    throw "No embedded-runtime list telemetry found in $Path."
+    throw "No embedded-runtime signing telemetry found in $Path."
   }
 
   [PSCustomObject]@{

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -184,6 +184,28 @@ describe("release workflow contract", () => {
     expect(uploadStateAt).toBeGreaterThan(uploadWindowsAt);
   });
 
+  it("keeps the embedded-runtime sign source recognized by the cache-hit assert (#2948)", () => {
+    // The sign step's -SigningSource becomes the telemetry `source` field, and
+    // the cache-hit assert isolates the embedded-runtime batch by that field's
+    // prefix. When #2930 renamed the source to "embedded-runtime-and-mcp" but
+    // the assert still only matched "list:", every Windows release failed with
+    // zero embedded records (v3.69.2). This ties the producer to the consumer.
+    const signStepAt = workflow.indexOf("Sign embedded runtime (Windows)");
+    const nextStepAt = workflow.indexOf("Save Windows signature cache to R2", signStepAt);
+    const signStep = workflow.slice(signStepAt, nextStepAt);
+    const sourceMatch = signStep.match(/-SigningSource\s+"([^"]+)"/);
+    expect(sourceMatch).not.toBeNull();
+    const signingSource = sourceMatch?.[1] ?? "";
+
+    const assertScript = readFileSync(
+      path.join(repoRoot, "scripts", "assert-windows-signature-cache.ps1"),
+      "utf8",
+    );
+    const prefixes = [...assertScript.matchAll(/StartsWith\("([^"]+)"/g)].map((match) => match[1]);
+    expect(prefixes.length).toBeGreaterThan(0);
+    expect(prefixes.some((prefix) => signingSource.startsWith(prefix))).toBe(true);
+  });
+
   it("hard-blocks Windows signing before signtool and preserves the unsigned fallback (#2929)", () => {
     const signer = readFileSync(signerScript, "utf8");
     const budget = readFileSync(path.join(repoRoot, "scripts", "windows-signing-budget.ps1"), "utf8");

--- a/tests/unit/windows-signature-cache-gate.test.ts
+++ b/tests/unit/windows-signature-cache-gate.test.ts
@@ -39,7 +39,7 @@ function writeArtifacts(
     telemetry,
     `${JSON.stringify({
       status: "success",
-      source: "list:sign-targets.txt",
+      source: "embedded-runtime-and-mcp",
       discovered: 729,
       skipped,
       would_sign: signed,


### PR DESCRIPTION
## Root cause
The v3.69.2 Windows release build failed at `Assert Windows signature cache hit budget`:
```
No embedded-runtime list telemetry found in windows-signing-telemetry.jsonl
```
`assert-windows-signature-cache.ps1` isolates the embedded-runtime signing batch by telemetry records whose `source` starts with `list:`. #2930 added `-SigningSource "embedded-runtime-and-mcp"` to the sign step (for the #2933 monthly ledger), which overrode the `list:` prefix — so the assert found zero embedded records and threw, blocking `publish-release` and the whole release.

The producer (sign step) was updated but not the consumer (assert), and the consumer's unit test used a stale `source: "list:sign-targets.txt"` fixture, so it stayed green while the real pipeline broke.

Cache health was fine (`discovered=729, skipped=729, signed=0`, 100% restore). **No SSL.com signings were consumed** by the failed run.

## Fix
- `assert-windows-signature-cache.ps1`: recognize the embedded-runtime batch by `list:` **or** `embedded-runtime` source prefix (keeps the pre-#2930 fallback).
- `windows-signature-cache-gate.test.ts`: refresh the fixture to the real `embedded-runtime-and-mcp` source.
- `windows-sign-overlay.test.ts`: add a workflow-contract test tying the sign step's `-SigningSource` to the assert's recognized prefixes — fails if they ever drift again (would have caught this).

## Validation
- `windows-sign-overlay.test.ts`: 14 passed (incl. the new contract test; verified non-vacuous — workflow source `embedded-runtime-and-mcp` matches assert prefix `embedded-runtime`).
- `windows-signature-cache-gate.test.ts`: pwsh-gated tests skip locally (host pwsh unavailable); the real `assert-windows-signature-cache.ps1` runs on real pwsh in the re-tag release — that run is the functional validation.

Closes #2948.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com