### PR TITLE
fix(release): give Windows sign build R2 creds for ledger (#2950)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -754,6 +754,16 @@ jobs:
           # re-preparation so the build does not overwrite the signed binaries
           # with fresh unsigned downloads (#2235).
           SEREN_TAURI_SKIP_PREP: "1"
+          # The bundler's signCommand child reserves each app/setup signature
+          # against the persistent monthly R2 ledger (#2931) before signtool, so
+          # it needs the same R2 credentials the direct sign steps carry. Without
+          # them windows-signing-monthly-budget.ps1 exits and the bundle fails at
+          # "failed to run pwsh".
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET_NAME }}
         shell: pwsh
         run: |
           pnpm tsx scripts/print-windows-sign-overlay.ts "$env:GITHUB_WORKSPACE" > sign-overlay.json

--- a/tests/unit/windows-sign-overlay.test.ts
+++ b/tests/unit/windows-sign-overlay.test.ts
@@ -206,6 +206,25 @@ describe("release workflow contract", () => {
     expect(prefixes.some((prefix) => signingSource.startsWith(prefix))).toBe(true);
   });
 
+  it("gives the Windows signing build the R2 creds its signCommand needs to reserve the monthly ledger (#2950)", () => {
+    // Tauri's signCommand child runs sign-windows-payload.ps1 on each fresh
+    // app/setup binary, which reserves against the monthly R2 ledger before
+    // signtool. That reservation reads R2_BUCKET / AWS_ENDPOINT_URL and the AWS
+    // credentials; if the build step omits them the bundle dies at "failed to
+    // run pwsh" (v3.69.2). Keep the signing build step carrying them.
+    const stepAt = workflow.indexOf("- name: Build Tauri app (budget-aware, Windows)");
+    const nextStepAt = workflow.indexOf("\n      - name:", stepAt + 1);
+    const step = workflow.slice(stepAt, nextStepAt === -1 ? undefined : nextStepAt);
+    for (const key of [
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "AWS_ENDPOINT_URL",
+      "R2_BUCKET",
+    ]) {
+      expect(step).toContain(key);
+    }
+  });
+
   it("hard-blocks Windows signing before signtool and preserves the unsigned fallback (#2929)", () => {
     const signer = readFileSync(signerScript, "utf8");
     const budget = readFileSync(path.join(repoRoot, "scripts", "windows-signing-budget.ps1"), "utf8");


### PR DESCRIPTION
## Root cause
The v3.69.2 Windows build failed in the Tauri bundle phase (`failed to run pwsh`). Tauri's signCommand runs `sign-windows-payload.ps1` on each freshly-built app/setup binary; since #2933 that reserves against the persistent monthly R2 ledger (`windows-signing-monthly-budget.ps1`) before signtool. The `Build Tauri app (budget-aware, Windows)` step only set `SEREN_TAURI_SKIP_PREP`, so the signCommand subprocess had no R2 credentials → the ledger script exits → Tauri reports `failed to run pwsh`.

First time #2933's Reserve path ran against a real signature: prior sign steps signed 0 cache-hit files (exit before the ledger call), and the direct steps that would reserve carry R2 creds — the Tauri signCommand does not. Not dependabot: `@tauri-apps/cli 2.11.4` / `tauri 2.11.5` are byte-identical to green v3.69.1.

## Fix
- Pass the R2 credential env block (AWS_ACCESS_KEY_ID/SECRET/REGION/ENDPOINT_URL, R2_BUCKET) to the signing build step, matching the direct sign steps.
- Add a workflow-contract test asserting the step carries them.

## Operational prerequisites (done out of band)
- Set the previously-empty ledger repo vars: `SSL_SIGNING_ACCOUNT`, `SSL_SIGNING_CERTIFICATE` (EV thumbprint), `SSL_SIGNING_BILLING_ANCHOR_DAY=1`, `SSL_SIGNING_BILLING_TIMEZONE=UTC`.
- Bootstrapped the 2026-07 active-cycle ledger via `windows-signing-ledger.yml` (0 authoritative ops).

## Validation
- `windows-sign-overlay.test.ts`: 15 passed (incl. the new contract test).
- Real validation is the re-tag release: the Windows build must clear the Tauri bundle + app signing on real pwsh.

Closes #2950.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com