### PR TITLE
fix(agent): default direct Codex to Fast and xhigh

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -540,12 +540,22 @@ function resolveCodexInitialReasoningEffort(
       ? explicitEffort
       : normalizeCodexDefaultIntent(intent) === "paired-executor"
         ? "low"
-        : (modelRecord?.defaultReasoningEffort ?? "medium");
+        : "xhigh";
 
   if (supports(preferred)) return preferred;
   const modelDefault = modelRecord?.defaultReasoningEffort ?? null;
   if (modelDefault && supports(modelDefault)) return modelDefault;
   return supported[0] ?? "medium";
+}
+
+function resolveCodexInitialServiceTier(
+  modelRecord,
+  { intent = "direct" } = {},
+) {
+  if (normalizeCodexDefaultIntent(intent) === "paired-executor") {
+    return null;
+  }
+  return getFastServiceTier(modelRecord)?.id ?? null;
 }
 
 function getSelectedModelRecord(session) {
@@ -1545,6 +1555,10 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
           explicitEffort: reasoningEffort,
         },
       );
+      session.serviceTier = resolveCodexInitialServiceTier(
+        preferredModelRecord,
+        { intent: defaultIntent },
+      );
 
       const threadParams = {
         cwd,
@@ -1620,22 +1634,15 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       session.currentModelId = resumedExistingThread
         ? (servedModelId ?? requestedModelId ?? null)
         : (requestedModelId ?? servedModelId ?? null);
-      if (resumedExistingThread) {
-        session.reasoningEffort =
-          threadResult?.reasoningEffort ??
-          getSelectedModelRecord(session)?.defaultReasoningEffort ??
-          session.reasoningEffort ??
-          "medium";
-      } else {
-        session.reasoningEffort = resolveCodexInitialReasoningEffort(
-          getSelectedModelRecord(session),
-          {
-            intent: defaultIntent,
-            explicitEffort: reasoningEffort,
-          },
-        );
-      }
-      session.serviceTier = normalizeServiceTier(threadResult?.serviceTier);
+      session.reasoningEffort = resolveCodexInitialReasoningEffort(
+        getSelectedModelRecord(session),
+        {
+          intent: defaultIntent,
+          explicitEffort: reasoningEffort,
+        },
+      );
+      session.serviceTier =
+        session.serviceTier ?? normalizeServiceTier(threadResult?.serviceTier);
 
       if (resumedExistingThread && session.agentSessionId) {
         let replayThread = threadResult?.thread;
@@ -2247,6 +2254,7 @@ export {
   modeFromApprovalPolicy as _modeFromApprovalPolicy,
   normalizeModelRecords as _normalizeCodexModelRecords,
   resolveCodexInitialReasoningEffort as _resolveCodexInitialReasoningEffort,
+  resolveCodexInitialServiceTier as _resolveCodexInitialServiceTier,
   resolveCodexPreferredModelRecord as _resolveCodexPreferredModelRecord,
   sandboxFromMode as _sandboxFromMode,
 };

--- a/tests/unit/codex-fast-mode-config.test.ts
+++ b/tests/unit/codex-fast-mode-config.test.ts
@@ -14,6 +14,7 @@ const {
   _codexServiceTierFromFastModeValue: codexServiceTierFromFastModeValue,
   _normalizeCodexModelRecords: normalizeCodexModelRecords,
   _resolveCodexInitialReasoningEffort: resolveCodexInitialReasoningEffort,
+  _resolveCodexInitialServiceTier: resolveCodexInitialServiceTier,
   _resolveCodexPreferredModelRecord: resolveCodexPreferredModelRecord,
 } = await import(/* @vite-ignore */ modulePath);
 
@@ -27,8 +28,10 @@ function modelListResult() {
         hidden: false,
         defaultReasoningEffort: "medium",
         supportedReasoningEfforts: [
+          { reasoningEffort: "low", description: "Less depth" },
           { reasoningEffort: "medium", description: "Balanced" },
           { reasoningEffort: "high", description: "More depth" },
+          { reasoningEffort: "xhigh", description: "Maximum depth" },
         ],
         defaultServiceTier: null,
         serviceTiers: [
@@ -81,7 +84,7 @@ describe("#2890 Codex GPT-5.6 defaults", () => {
     expect(preferred?.name).toBe("GPT-5.6 Sol");
     expect(
       resolveCodexInitialReasoningEffort(preferred, { intent: "direct" }),
-    ).toBe("medium");
+    ).toBe("xhigh");
   });
 
   it("prefers GPT-5.6 Luna with low effort for the paired Claude + Codex executor even when model/list is stale", () => {
@@ -122,6 +125,50 @@ describe("#2890 Codex GPT-5.6 defaults", () => {
       approvalPolicy: "never",
       sandbox: "danger-full-access",
       model: "gpt-5.6-sol",
+    });
+  });
+});
+
+describe("#2957 direct Codex spawn defaults", () => {
+  it("defaults direct Codex to xhigh and Fast while leaving paired executor defaults unchanged", () => {
+    const records = normalizeCodexModelRecords(modelListResult());
+    const directModel = records[0];
+
+    expect(
+      resolveCodexInitialReasoningEffort(directModel, { intent: "direct" }),
+    ).toBe("xhigh");
+    expect(
+      resolveCodexInitialServiceTier(directModel, { intent: "direct" }),
+    ).toBe("fast");
+    expect(
+      resolveCodexInitialReasoningEffort(directModel, {
+        intent: "paired-executor",
+      }),
+    ).toBe("low");
+    expect(
+      resolveCodexInitialServiceTier(directModel, {
+        intent: "paired-executor",
+      }),
+    ).toBeNull();
+
+    expect(
+      buildCodexThreadStartParams(
+        session({ reasoningEffort: "xhigh", serviceTier: "fast" }),
+        "/repo",
+        "auto",
+        "danger-full-access",
+      ),
+    ).toMatchObject({ model: "gpt-5.5", serviceTier: "fast" });
+    expect(
+      buildCodexTurnStartParams(
+        session({ reasoningEffort: "xhigh", serviceTier: "fast" }),
+        "hello",
+        [],
+      ),
+    ).toMatchObject({
+      model: "gpt-5.5",
+      effort: "xhigh",
+      serviceTier: "fast",
     });
   });
 });


### PR DESCRIPTION
## Summary

- defaults newly spawned direct Codex sessions to `xhigh` reasoning when the live model supports it;
- selects the live model's Fast service tier before direct `thread/start` or `thread/resume`;
- preserves the requested direct tier when app-server returns a generic thread default;
- leaves paired executor defaults unchanged at low effort and Fast off;
- falls back to live supported metadata when xhigh or Fast is unavailable.

Fixes #2957

## Root cause

The Codex runtime initialized `serviceTier` to `null` and resolved direct reasoning effort from the live model's default. The current live GPT-5.6 Sol record reports low as its model default, so a ready direct session rendered Low and Fast Off despite advertising xhigh and Fast support.

## Code-path audit

Direct launcher → `thread.store#createAgentThread` → `agent.store#spawnSession` → `src/services/providers.ts#spawnAgent` → `bin/browser-local/providers.mjs#spawnSession` → local Codex app-server stdio JSON-RPC.

Prior issues/PRs reviewed: #2888/#2889, #2890/#2899, and #2904/#2906.

## Network path audit

No Seren publisher/API request exists in the changed feature path. Runtime calls are local stdio JSON-RPC: `initialize`, `model/list`, `thread/start` or `thread/resume`, and `turn/start`. GitHub workflow calls use the live `github-api` publisher.

## Validation completed before PR

- `node --check bin/browser-local/providers.mjs`
- `git diff --check`
- `pnpm vitest run tests/unit/codex-fast-mode-config.test.ts tests/unit/paired-runtime.test.ts` — 62 passed
- `pnpm test` — 2,330 passed, 15 skipped
- `pnpm check` — passed with 48 existing warnings
- `pnpm build`
- `pnpm verify:frontend-build`
- Live no-mock browser-local runtime turn: GPT-5.6 Sol, xhigh, Fast On, exact successful reply, no provider errors

No Rust files changed, so no Rust compilation surface is affected.

## Post-PR walkthrough gate

The validation-isolated Tauri walkthrough and P0/P1/P2 regression classification will be added before merge.