### PR TITLE
fix(agent): default direct Codex to Fast and xhigh

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -540,12 +540,24 @@ function resolveCodexInitialReasoningEffort(
       ? explicitEffort
       : normalizeCodexDefaultIntent(intent) === "paired-executor"
         ? "low"
-        : (modelRecord?.defaultReasoningEffort ?? "medium");
+        : supported.includes("xhigh")
+          ? "xhigh"
+          : (modelRecord?.defaultReasoningEffort ?? "medium");
 
   if (supports(preferred)) return preferred;
   const modelDefault = modelRecord?.defaultReasoningEffort ?? null;
   if (modelDefault && supports(modelDefault)) return modelDefault;
   return supported[0] ?? "medium";
+}
+
+function resolveCodexInitialServiceTier(
+  modelRecord,
+  { intent = "direct" } = {},
+) {
+  if (normalizeCodexDefaultIntent(intent) !== "direct") {
+    return null;
+  }
+  return getFastServiceTier(modelRecord)?.id ?? null;
 }
 
 function getSelectedModelRecord(session) {
@@ -1545,6 +1557,10 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
           explicitEffort: reasoningEffort,
         },
       );
+      session.serviceTier = resolveCodexInitialServiceTier(
+        preferredModelRecord,
+        { intent: defaultIntent },
+      );
 
       const threadParams = {
         cwd,
@@ -1620,7 +1636,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       session.currentModelId = resumedExistingThread
         ? (servedModelId ?? requestedModelId ?? null)
         : (requestedModelId ?? servedModelId ?? null);
-      if (resumedExistingThread) {
+      if (resumedExistingThread && defaultIntent === "paired-executor") {
         session.reasoningEffort =
           threadResult?.reasoningEffort ??
           getSelectedModelRecord(session)?.defaultReasoningEffort ??
@@ -2247,6 +2263,7 @@ export {
   modeFromApprovalPolicy as _modeFromApprovalPolicy,
   normalizeModelRecords as _normalizeCodexModelRecords,
   resolveCodexInitialReasoningEffort as _resolveCodexInitialReasoningEffort,
+  resolveCodexInitialServiceTier as _resolveCodexInitialServiceTier,
   resolveCodexPreferredModelRecord as _resolveCodexPreferredModelRecord,
   sandboxFromMode as _sandboxFromMode,
 };

--- a/tests/unit/codex-fast-mode-config.test.ts
+++ b/tests/unit/codex-fast-mode-config.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Critical guards for #2888 — Codex Fast Mode maps to app-server serviceTier.
-// ABOUTME: Keeps model service-tier metadata, config options, and turn payloads wired.
+// ABOUTME: Critical guards for Codex reasoning and Fast service-tier defaults.
+// ABOUTME: Keeps #2957 direct-spawn defaults isolated from paired executor behavior.
 
 import { describe, expect, it } from "vitest";
 
@@ -14,6 +14,7 @@ const {
   _codexServiceTierFromFastModeValue: codexServiceTierFromFastModeValue,
   _normalizeCodexModelRecords: normalizeCodexModelRecords,
   _resolveCodexInitialReasoningEffort: resolveCodexInitialReasoningEffort,
+  _resolveCodexInitialServiceTier: resolveCodexInitialServiceTier,
   _resolveCodexPreferredModelRecord: resolveCodexPreferredModelRecord,
 } = await import(/* @vite-ignore */ modulePath);
 
@@ -81,7 +82,7 @@ describe("#2890 Codex GPT-5.6 defaults", () => {
     expect(preferred?.name).toBe("GPT-5.6 Sol");
     expect(
       resolveCodexInitialReasoningEffort(preferred, { intent: "direct" }),
-    ).toBe("medium");
+    ).toBe("xhigh");
   });
 
   it("prefers GPT-5.6 Luna with low effort for the paired Claude + Codex executor even when model/list is stale", () => {
@@ -123,6 +124,73 @@ describe("#2890 Codex GPT-5.6 defaults", () => {
       sandbox: "danger-full-access",
       model: "gpt-5.6-sol",
     });
+  });
+});
+
+describe("#2957 direct Codex spawn defaults", () => {
+  it("selects xhigh and Fast for direct sessions without changing paired defaults", () => {
+    const baseModel = session().availableModelRecords[0];
+    const model = {
+      ...baseModel,
+      defaultReasoningEffort: "low",
+      supportedReasoningEfforts: [
+        { value: "low", name: "low" },
+        ...baseModel.supportedReasoningEfforts,
+        { value: "xhigh", name: "xhigh" },
+      ],
+    };
+
+    expect(
+      resolveCodexInitialReasoningEffort(model, { intent: "direct" }),
+    ).toBe("xhigh");
+    expect(
+      resolveCodexInitialServiceTier(model, { intent: "direct" }),
+    ).toBe("fast");
+
+    const directSession = session({
+      availableModelRecords: [model],
+      currentModelId: model.modelId,
+      reasoningEffort: "xhigh",
+      serviceTier: "fast",
+    });
+    expect(
+      buildCodexThreadStartParams(
+        directSession,
+        "/repo",
+        "auto",
+        "danger-full-access",
+      ),
+    ).toMatchObject({ serviceTier: "fast" });
+    expect(buildCodexSessionStatus(directSession).configOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "reasoning_effort",
+          currentValue: "xhigh",
+        }),
+        expect.objectContaining({ id: "fast_mode", currentValue: "on" }),
+      ]),
+    );
+
+    expect(
+      resolveCodexInitialReasoningEffort(model, {
+        intent: "paired-executor",
+      }),
+    ).toBe("low");
+    expect(
+      resolveCodexInitialServiceTier(model, {
+        intent: "paired-executor",
+      }),
+    ).toBeNull();
+
+    const unsupportedModel = session().availableModelRecords[1];
+    expect(
+      resolveCodexInitialReasoningEffort(unsupportedModel, {
+        intent: "direct",
+      }),
+    ).toBe("medium");
+    expect(
+      resolveCodexInitialServiceTier(unsupportedModel, { intent: "direct" }),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #2957

## Summary
- Defaults a newly spawned direct Codex session to `xhigh` reasoning when the selected model advertises it.
- Defaults the same direct session to the catalog-advertised `fast` service tier before `thread/start` or `thread/resume`.
- Preserves the paired Claude + Codex executor low-effort behavior and keeps unsupported-model fallbacks metadata-safe.

## Audited path
- UI launcher -> `thread.store.createAgentThread` -> `agent.store.spawnSession` -> `providers.spawnAgent`.
- Local provider runtime -> `codex app-server` over stdio JSON-RPC: `initialize`, `model/list`, `thread/start` or `thread/resume`, then `turn/start`.
- No outbound Seren publisher or HTTP API slug, method, or path exists in the changed feature path.
- Current Codex app-server schemas expose `serviceTier` on thread and turn requests plus `effort` on turn requests. Current Codex documentation supports Fast mode and `xhigh` reasoning.

## Validation
- `pnpm vitest run tests/unit/codex-fast-mode-config.test.ts tests/unit/paired-runtime.test.ts` — 62 passed.
- `pnpm test` — 2,330 passed, 15 skipped.
- `pnpm check` — passed with 48 existing warnings.
- `pnpm build` — passed.
- `pnpm verify:frontend-build` — passed.
- `pnpm test:runtime-smoke` — passed.
- Real macOS Tauri walkthrough — pending; evidence will be added before merge.