### PR TITLE
fix(agent): honor selected OAuth account in native Codex

### DIFF
--- a/bin/browser-local/mcp-config.mjs
+++ b/bin/browser-local/mcp-config.mjs
@@ -68,7 +68,7 @@ function normalizeLocalServer(server) {
   };
 }
 
-function createRemoteSerenServer(apiKey) {
+function createRemoteSerenServer(apiKey, gatewayUrl = SEREN_MCP_GATEWAY_URL) {
   if (!trimToNull(apiKey)) {
     return null;
   }
@@ -76,7 +76,7 @@ function createRemoteSerenServer(apiKey) {
   return {
     name: SEREN_MCP_SERVER_NAME,
     type: "http",
-    url: SEREN_MCP_GATEWAY_URL,
+    url: gatewayUrl,
     headers: {
       Authorization: `Bearer \${${SEREN_MCP_API_KEY_ENV}}`,
     },
@@ -236,9 +236,13 @@ function buildGeminiMcpServers(servers, { mcpCapabilities = {} } = {}) {
   return out;
 }
 
-export function buildProviderMcpConfig({ apiKey, mcpServers } = {}) {
+export function buildProviderMcpConfig({
+  apiKey,
+  mcpServers,
+  serenMcpGatewayUrl,
+} = {}) {
   const normalizedServers = dedupeServers([
-    createRemoteSerenServer(apiKey),
+    createRemoteSerenServer(apiKey, serenMcpGatewayUrl),
     ...((Array.isArray(mcpServers) ? mcpServers : [])
       .map((server) => normalizeLocalServer(server))
       .filter(Boolean)),

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -8,6 +8,7 @@ import {
   createBrowserLocalAgentRegistry,
   resolveInstalledCodexBinary,
 } from "./agent-registry.mjs";
+import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
 import { providerLogPrefix } from "./logging.mjs";
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
 import { composeWindowsShellCommand } from "./windows-shell-args.mjs";
@@ -314,8 +315,15 @@ function buildInitializeParams() {
   };
 }
 
-function spawnCodexProcess(cwd, { apiKey, mcpServers } = {}) {
-  const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
+function spawnCodexProcess(
+  cwd,
+  { apiKey, mcpServers, serenMcpGatewayUrl } = {},
+) {
+  const mcpConfig = buildProviderMcpConfig({
+    apiKey,
+    mcpServers,
+    serenMcpGatewayUrl,
+  });
   const useWindowsShell = process.platform === "win32";
   const args = ["app-server"];
   if (mcpConfig.codexMcpConfigOverride) {
@@ -352,6 +360,7 @@ function createCodexSessionRecord({
   sessionId,
   cwd,
   processHandle,
+  serenMcpProxy,
   timeoutSecs,
   currentModeId,
 }) {
@@ -362,6 +371,7 @@ function createCodexSessionRecord({
     status: "initializing",
     createdAt: new Date().toISOString(),
     process: processHandle,
+    serenMcpProxy,
     output: readline.createInterface({ input: processHandle.stdout }),
     pendingRequests: new Map(),
     nextRequestId: 1,
@@ -1333,6 +1343,7 @@ function attachProcessListeners(
         : `Codex spawn error: ${err?.message ?? String(err)}`;
     console.warn(`${logPrefix} ${message}`);
     sessions.delete(session.id);
+    void session.serenMcpProxy?.close();
     if (session.currentPrompt) {
       rejectCurrentPrompt(session, new Error(message));
     }
@@ -1351,6 +1362,7 @@ function attachProcessListeners(
 
   session.process.on("exit", () => {
     const wasTracked = sessions.delete(session.id);
+    void session.serenMcpProxy?.close();
     if (!wasTracked) {
       return;
     }
@@ -1488,11 +1500,24 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     const sessionId = localSessionId ?? randomUUID();
     const resolvedMode = modeFromApprovalPolicy(approvalPolicy);
     const resolvedSandbox = sandboxFromMode(sandboxMode, networkEnabled);
-    const processHandle = spawnCodexProcess(cwd, { apiKey, mcpServers });
+    let serenMcpProxy = null;
+    let processHandle;
+    try {
+      if (apiKey) serenMcpProxy = await createSerenMcpOAuthProxy();
+      processHandle = spawnCodexProcess(cwd, {
+        apiKey,
+        mcpServers,
+        serenMcpGatewayUrl: serenMcpProxy?.url,
+      });
+    } catch (error) {
+      await serenMcpProxy?.close();
+      throw error;
+    }
     const session = createCodexSessionRecord({
       sessionId,
       cwd,
       processHandle,
+      serenMcpProxy,
       timeoutSecs,
       currentModeId: resolvedMode,
     });
@@ -1677,6 +1702,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       const message = error instanceof Error ? error.message : String(error);
       sessions.delete(sessionId);
       killChildTree(processHandle);
+      await serenMcpProxy?.close();
       emit("provider://error", {
         sessionId,
         error: isAuthError(message)
@@ -1820,6 +1846,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     rejectCurrentPrompt(session, new Error("Session terminated."));
     session.output.close();
     killChildTree(session.process);
+    await session.serenMcpProxy?.close();
     emit("provider://session-status", {
       sessionId,
       status: "terminated",
@@ -1881,8 +1908,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       }
       return claudeRuntime.setOAuthRouting({ sessionId, routing });
     }
-    // Native Codex sessions do not use Seren MCP OAuth routing yet.
-    console.info(`[provider-runtime] OAuth routing is a no-op for ${session.agentType} session ${sessionId}`);
+    session.serenMcpProxy?.setRouting(routing);
   }
 
   async function respondToPermission({ sessionId, requestId, optionId }) {

--- a/bin/browser-local/seren-mcp-oauth-proxy.mjs
+++ b/bin/browser-local/seren-mcp-oauth-proxy.mjs
@@ -1,0 +1,562 @@
+// ABOUTME: Per-Codex-session loopback proxy for deterministic Seren OAuth account routing.
+// ABOUTME: Forwards MCP traffic unchanged except selected call_publisher requests, which use the supported Core selector header.
+
+import { randomBytes } from "node:crypto";
+import http from "node:http";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+const DEFAULT_SEREN_MCP_GATEWAY_URL =
+  process.env.SEREN_MCP_GATEWAY_URL ?? "https://mcp.serendb.com/mcp";
+const DEFAULT_SEREN_API_URL =
+  process.env.SEREN_API_BASE ??
+  process.env.SEREN_API_URL ??
+  process.env.VITE_SEREN_API_URL ??
+  "https://api.serendb.com";
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "content-encoding",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "set-cookie",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const PROTECTED_PUBLISHER_HEADERS = new Set([
+  ...HOP_BY_HOP_HEADERS,
+  "authorization",
+  "cookie",
+  "mcp-protocol-version",
+  "mcp-session-id",
+  "x-seren-oauth-connection-id",
+]);
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function toolError(id, message) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    result: {
+      content: [{ type: "text", text: message }],
+      isError: true,
+    },
+  };
+}
+
+/**
+ * Decide whether a Seren MCP request can pass through unchanged, must fail
+ * closed, or should use the first-party publisher proxy with an OAuth selector.
+ */
+export function planSerenMcpRequest(routing, payload) {
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    Array.isArray(payload) ||
+    payload.method !== "tools/call" ||
+    payload.params?.name !== "call_publisher"
+  ) {
+    return { kind: "passthrough" };
+  }
+
+  const args = payload.params?.arguments;
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return { kind: "passthrough" };
+  }
+
+  const publisher = nonEmptyString(args.publisher);
+  if (!publisher) return { kind: "passthrough" };
+
+  const explicitConnectionId = nonEmptyString(args.connection_id);
+  if (!explicitConnectionId && routing == null) {
+    return {
+      kind: "error",
+      response: toolError(
+        payload.id,
+        "OAuth account routing is still initializing. Retry this publisher call after connected accounts finish loading.",
+      ),
+    };
+  }
+
+  if (!explicitConnectionId && routing?.available === false) {
+    return {
+      kind: "error",
+      response: toolError(
+        payload.id,
+        "OAuth account routing is unavailable. Retry after connected accounts finish loading; refusing to use a default account.",
+      ),
+    };
+  }
+
+  const ambiguity = explicitConnectionId
+    ? null
+    : nonEmptyString(routing?.ambiguous?.[publisher]);
+  if (ambiguity) {
+    return {
+      kind: "error",
+      response: toolError(payload.id, ambiguity),
+    };
+  }
+
+  const connectionId =
+    explicitConnectionId ?? nonEmptyString(routing?.publishers?.[publisher]);
+  if (!connectionId) return { kind: "passthrough" };
+
+  const tool = nonEmptyString(args.tool);
+  if (tool) {
+    return {
+      kind: "publisher",
+      id: payload.id,
+      connectionId,
+      publisher,
+      request: {
+        kind: "tool",
+        tool,
+        toolArgs:
+          args.tool_args &&
+          typeof args.tool_args === "object" &&
+          !Array.isArray(args.tool_args)
+            ? args.tool_args
+            : {},
+        headers: args.headers,
+        requestId: args.request_id,
+        payment: args._x402_payment,
+        confirm: args.confirm,
+      },
+    };
+  }
+
+  const method = nonEmptyString(args.method) ?? "POST";
+  const path = nonEmptyString(args.path);
+  if (path) {
+    return {
+      kind: "publisher",
+      id: payload.id,
+      connectionId,
+      publisher,
+      request: {
+        kind: "api",
+        method,
+        path,
+        body: args.body,
+        bodyBase64: args.body_base64,
+        headers: args.headers,
+        requestId: args.request_id,
+        payment: args._x402_payment,
+        confirm: args.confirm,
+      },
+    };
+  }
+
+  return {
+    kind: "error",
+    response: toolError(
+      payload.id,
+      `Selected-account routing for ${publisher} requires a publisher API path or tool name; refusing to fall back to the default account.`,
+    ),
+  };
+}
+
+function ensureTrailingSlash(value) {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function buildPublisherUrl(apiUrl, plan) {
+  const base = new URL(ensureTrailingSlash(apiUrl));
+  const publisherRoot = new URL(
+    `publishers/${encodeURIComponent(plan.publisher)}/`,
+    base,
+  );
+  const relativePath =
+    plan.request.kind === "tool"
+      ? `_mcp/tools/${encodeURIComponent(plan.request.tool)}`
+      : plan.request.path.replace(/^\/+/, "");
+  const target = new URL(relativePath, publisherRoot);
+
+  if (
+    target.origin !== publisherRoot.origin ||
+    !target.pathname.startsWith(publisherRoot.pathname)
+  ) {
+    throw new Error("Publisher path escapes the configured Seren API route");
+  }
+
+  // The selector belongs in the ownership-checked header. Ignore any
+  // model-provided query selector so two conflicting identities cannot exist.
+  target.searchParams.delete("connection_id");
+  target.hash = "";
+  return target;
+}
+
+function copyPublisherHeaders(source, destination) {
+  if (!source || typeof source !== "object" || Array.isArray(source)) return;
+  for (const [name, value] of Object.entries(source)) {
+    if (
+      typeof value === "string" &&
+      !PROTECTED_PUBLISHER_HEADERS.has(name.toLowerCase())
+    ) {
+      destination.set(name, value);
+    }
+  }
+}
+
+function buildPublisherBody(request, headers) {
+  if (request.kind === "tool") {
+    headers.set("Content-Type", "application/json");
+    return JSON.stringify(request.toolArgs);
+  }
+
+  if (request.bodyBase64 != null && request.body != null) {
+    throw new Error("body and body_base64 are mutually exclusive");
+  }
+  if (request.bodyBase64 != null) {
+    const encoded = nonEmptyString(request.bodyBase64);
+    if (!encoded) throw new Error("body_base64 must be a non-empty string");
+    return Buffer.from(encoded, "base64");
+  }
+  if (request.body === undefined || request.body === null) return undefined;
+
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  return JSON.stringify(request.body);
+}
+
+function textResponseBody(response, bytes) {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (
+    contentType.includes("json") ||
+    contentType.startsWith("text/") ||
+    contentType.length === 0
+  ) {
+    return bytes.toString("utf8");
+  }
+  return JSON.stringify({
+    data: {
+      status: response.status,
+      body_base64: bytes.toString("base64"),
+      response_bytes: bytes.length,
+    },
+  });
+}
+
+export function buildSerenPublisherRequest(plan, authorization, apiUrl) {
+  const headers = new Headers({
+    Accept: "application/json",
+    Authorization: authorization,
+    "User-Agent": "Seren-Desktop-Codex-OAuth-Router",
+    "x-seren-oauth-connection-id": plan.connectionId,
+  });
+
+  const target = buildPublisherUrl(apiUrl, plan);
+  copyPublisherHeaders(plan.request.headers, headers);
+  if (nonEmptyString(plan.request.requestId)) {
+    headers.set("Idempotency-Key", plan.request.requestId.trim());
+  }
+  if (nonEmptyString(plan.request.payment)) {
+    headers.set("X-PAYMENT", plan.request.payment.trim());
+  }
+  const body = buildPublisherBody(plan.request, headers);
+
+  const method =
+    plan.request.kind === "tool" ? "POST" : plan.request.method.toUpperCase();
+  if (!new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]).has(method)) {
+    throw new Error(
+      `Unsupported publisher HTTP method for selected-account routing: ${method}`,
+    );
+  }
+
+  return { body, headers, method, url: target.toString() };
+}
+
+async function executePublisherPlan(plan, authorization, apiUrl, signal) {
+  if (!authorization) {
+    return toolError(plan.id, "Seren API authorization is unavailable.");
+  }
+  if (plan.request.confirm === true) {
+    return toolError(
+      plan.id,
+      "Selected-account routing cannot safely confirm an x402 payment on this path.",
+    );
+  }
+
+  let publisherRequest;
+  try {
+    publisherRequest = buildSerenPublisherRequest(
+      plan,
+      authorization,
+      apiUrl,
+    );
+  } catch (error) {
+    return toolError(
+      plan.id,
+      `Selected-account publisher request is invalid: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  try {
+    const response = await fetch(publisherRequest.url, {
+      method: publisherRequest.method,
+      headers: publisherRequest.headers,
+      body:
+        publisherRequest.method === "GET"
+          ? undefined
+          : publisherRequest.body,
+      redirect: "manual",
+      signal,
+    });
+    const bytes = Buffer.from(await response.arrayBuffer());
+    const text =
+      textResponseBody(response, bytes) ||
+      JSON.stringify({ data: { status: response.status } });
+    return {
+      jsonrpc: "2.0",
+      id: plan.id,
+      result: {
+        content: [{ type: "text", text }],
+        isError: !response.ok,
+      },
+    };
+  } catch {
+    return toolError(
+      plan.id,
+      "Selected-account publisher request failed before Seren returned a response.",
+    );
+  }
+}
+
+async function readRequestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function copyForwardRequestHeaders(requestHeaders) {
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(requestHeaders)) {
+    if (HOP_BY_HOP_HEADERS.has(name.toLowerCase()) || value == null) continue;
+    headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+  }
+  // Node fetch transparently decodes compressed responses. Ask the upstream
+  // for identity encoding so relayed bytes always match relayed headers.
+  headers.set("Accept-Encoding", "identity");
+  return headers;
+}
+
+function copyForwardResponseHeaders(response, outgoing) {
+  for (const [name, value] of response.headers.entries()) {
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
+      outgoing.setHeader(name, value);
+    }
+  }
+}
+
+async function forwardMcpRequest({
+  request,
+  response,
+  body,
+  gatewayUrl,
+  localUrl,
+  controllers,
+}) {
+  const target = new URL(gatewayUrl);
+  target.search = localUrl.search;
+  const controller = new AbortController();
+  controllers.add(controller);
+  request.once("aborted", () => controller.abort());
+  response.once("close", () => controller.abort());
+
+  try {
+    const method = request.method ?? "GET";
+    const upstream = await fetch(target, {
+      method,
+      headers: copyForwardRequestHeaders(request.headers),
+      body:
+        method === "GET" || method === "HEAD" || body.length === 0
+          ? undefined
+          : body,
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    response.statusCode = upstream.status;
+    copyForwardResponseHeaders(upstream, response);
+    if (!upstream.body) {
+      response.end();
+      return;
+    }
+    await pipeline(Readable.fromWeb(upstream.body), response);
+  } catch (error) {
+    if (controller.signal.aborted || response.destroyed) return;
+    if (!response.headersSent) {
+      response.writeHead(502, { "Content-Type": "application/json" });
+    }
+    response.end(
+      JSON.stringify({
+        error: "seren_mcp_proxy_failure",
+        message: "Seren MCP gateway request failed",
+      }),
+    );
+  } finally {
+    controllers.delete(controller);
+  }
+}
+
+function sendLocalMcpResponse(response, payload) {
+  response.writeHead(200, {
+    "Cache-Control": "no-cache",
+    "Content-Type": "text/event-stream",
+  });
+  response.end(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+function sendLocalProxyFailure(request, response) {
+  if (request.aborted || response.destroyed) return;
+  try {
+    if (!response.headersSent) {
+      response.writeHead(502, { "Content-Type": "application/json" });
+    }
+    response.end(
+      JSON.stringify({
+        error: "seren_mcp_proxy_failure",
+        message: "Seren MCP proxy could not process the request",
+      }),
+    );
+  } catch {
+    response.destroy();
+  }
+}
+
+export async function createSerenMcpOAuthProxy({
+  gatewayUrl = DEFAULT_SEREN_MCP_GATEWAY_URL,
+  apiUrl = DEFAULT_SEREN_API_URL,
+} = {}) {
+  const gateway = new URL(gatewayUrl);
+  const api = new URL(apiUrl);
+  if (gateway.protocol !== "https:" || api.protocol !== "https:") {
+    throw new Error("Seren OAuth routing proxy requires HTTPS upstreams");
+  }
+
+  let routing = null;
+  let closed = false;
+  const routePath = `/${randomBytes(24).toString("hex")}/mcp`;
+  const controllers = new Set();
+  const sockets = new Set();
+
+  const handleRequest = async (request, response) => {
+    const localUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (closed || localUrl.pathname !== routePath) {
+      response.writeHead(404, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: "not_found" }));
+      return;
+    }
+
+    const body = await readRequestBody(request);
+    if ((request.method ?? "GET") === "POST" && body.length > 0) {
+      let payload = null;
+      try {
+        payload = JSON.parse(body.toString("utf8"));
+      } catch {
+        // Let the upstream MCP server return the protocol parse error.
+      }
+      const plan = planSerenMcpRequest(routing, payload);
+      if (plan.kind === "error") {
+        sendLocalMcpResponse(response, plan.response);
+        return;
+      }
+      if (plan.kind === "publisher") {
+        const controller = new AbortController();
+        controllers.add(controller);
+        request.once("aborted", () => controller.abort());
+        response.once("close", () => controller.abort());
+        try {
+          const routedResponse = await executePublisherPlan(
+            plan,
+            nonEmptyString(request.headers.authorization),
+            api.toString(),
+            controller.signal,
+          );
+          if (!response.destroyed) {
+            sendLocalMcpResponse(response, routedResponse);
+          }
+        } finally {
+          controllers.delete(controller);
+        }
+        return;
+      }
+    }
+
+    await forwardMcpRequest({
+      request,
+      response,
+      body,
+      gatewayUrl: gateway.toString(),
+      localUrl,
+      controllers,
+    });
+  };
+
+  const server = http.createServer((request, response) => {
+    void handleRequest(request, response).catch(() => {
+      sendLocalProxyFailure(request, response);
+    });
+  });
+
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+
+  await new Promise((resolve, reject) => {
+    const onError = (error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(0, "127.0.0.1");
+  });
+  server.unref();
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Seren OAuth routing proxy did not bind a TCP port");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}${routePath}`,
+    setRouting(nextRouting) {
+      routing = {
+        publishers: { ...(nextRouting?.publishers ?? {}) },
+        ambiguous: { ...(nextRouting?.ambiguous ?? {}) },
+        available: nextRouting?.available,
+      };
+    },
+    async close() {
+      if (closed) return;
+      closed = true;
+      for (const controller of controllers) controller.abort();
+      for (const socket of sockets) socket.destroy();
+      if (!server.listening) return;
+      await new Promise((resolve) => server.close(() => resolve()));
+    },
+  };
+}

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -38,6 +38,8 @@ export type PairedRole = "planner" | "executor";
 export interface AgentOAuthRouting {
   publishers: Record<string, string>;
   ambiguous: Record<string, string>;
+  /** False when account discovery failed, so runtimes can refuse default-account fallback. */
+  available?: boolean;
 }
 
 export function supportsConversationFork(agentType: AgentType): boolean {

--- a/src/services/publisher-oauth.ts
+++ b/src/services/publisher-oauth.ts
@@ -72,6 +72,10 @@ async function loadPublisherOAuthProviderLookup(): Promise<
     }),
   ]);
 
+  if (providerResult.error || publisherResult.error) {
+    throw new Error("OAuth publisher metadata is unavailable");
+  }
+
   const providers = providerResult.data?.providers ?? [];
   const publishers = publisherResult.data?.data ?? [];
   const providersById = new Map(
@@ -116,19 +120,31 @@ export async function listPublisherOAuthProviderResolutions(): Promise<
   PublisherOAuthProviderResolution[]
 > {
   providerLookupPromise ??= loadPublisherOAuthProviderLookup();
-  const lookup = await providerLookupPromise;
-  return Array.from(lookup.values());
+  try {
+    const lookup = await providerLookupPromise;
+    return Array.from(lookup.values());
+  } catch (error) {
+    providerLookupPromise = null;
+    throw error;
+  }
 }
 
 export async function computeAgentOAuthRouting(
   threadId: string | null,
 ): Promise<AgentOAuthRouting> {
   try {
+    if (!(await getToken())) {
+      throw new Error("OAuth account discovery requires authentication");
+    }
     const [resolutions, connections] = await Promise.all([
       listPublisherOAuthProviderResolutions(),
       listConnectedPublishers(),
     ]);
-    const routing: AgentOAuthRouting = { publishers: {}, ambiguous: {} };
+    const routing: AgentOAuthRouting = {
+      publishers: {},
+      ambiguous: {},
+      available: true,
+    };
     for (const resolution of resolutions) {
       const validConnections = getOAuthConnectionsForProvider(
         connections,
@@ -160,7 +176,7 @@ export async function computeAgentOAuthRouting(
       "[PublisherOAuth] Failed to compute agent OAuth routing:",
       error,
     );
-    return { publishers: {}, ambiguous: {} };
+    return { publishers: {}, ambiguous: {}, available: false };
   }
 }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -1756,16 +1756,81 @@ const [state, setState] = createStore<AgentState>({
   agentModeEnabled: false,
 });
 
-async function refreshAgentOAuthRouting(conversationId: string): Promise<void> {
+const agentOAuthRoutingRefreshes = new Map<string, Promise<boolean>>();
+const agentOAuthRoutingAvailability = new Map<string, boolean>();
+const agentOAuthRoutingDelivery = new Map<string, boolean>();
+const agentOAuthRoutingRevisions = new Map<string, string>();
+const agentOAuthRoutingSelectionThreads = new Map<string, string>();
+
+function currentAgentOAuthRoutingRevision(): string {
+  return `${oauthConnectionsRevision()}:${oauthSelectionsRevision()}`;
+}
+
+async function refreshAgentOAuthRouting(
+  providerSessionId: string,
+  selectionThreadId = providerSessionId,
+): Promise<boolean> {
+  const previous = agentOAuthRoutingRefreshes.get(providerSessionId);
+  const refresh = (previous ?? Promise.resolve(true))
+    .catch(() => false)
+    .then(async () => {
+      const revision = currentAgentOAuthRoutingRevision();
+      try {
+        const routing = await computeAgentOAuthRouting(selectionThreadId);
+        await providerService.setOAuthRouting(providerSessionId, routing);
+        agentOAuthRoutingAvailability.set(
+          providerSessionId,
+          routing.available !== false,
+        );
+        agentOAuthRoutingDelivery.set(providerSessionId, true);
+        agentOAuthRoutingRevisions.set(providerSessionId, revision);
+        agentOAuthRoutingSelectionThreads.set(
+          providerSessionId,
+          selectionThreadId,
+        );
+        return true;
+      } catch (error) {
+        agentOAuthRoutingAvailability.set(providerSessionId, false);
+        agentOAuthRoutingDelivery.set(providerSessionId, false);
+        console.warn(
+          `[AgentStore] Failed to refresh OAuth routing for ${selectionThreadId}:`,
+          error,
+        );
+        return false;
+      }
+    });
+  agentOAuthRoutingRefreshes.set(providerSessionId, refresh);
   try {
-    const routing = await computeAgentOAuthRouting(conversationId);
-    await providerService.setOAuthRouting(conversationId, routing);
-  } catch (error) {
-    console.warn(
-      `[AgentStore] Failed to refresh OAuth routing for ${conversationId}:`,
-      error,
-    );
+    return await refresh;
+  } finally {
+    if (agentOAuthRoutingRefreshes.get(providerSessionId) === refresh) {
+      agentOAuthRoutingRefreshes.delete(providerSessionId);
+    }
   }
+}
+
+async function awaitAgentOAuthRoutingForPrompt(
+  providerSessionId: string,
+  selectionThreadId: string,
+): Promise<boolean> {
+  await agentOAuthRoutingRefreshes.get(providerSessionId);
+  if (
+    agentOAuthRoutingAvailability.get(providerSessionId) === false ||
+    agentOAuthRoutingDelivery.get(providerSessionId) === false ||
+    agentOAuthRoutingRevisions.get(providerSessionId) !==
+      currentAgentOAuthRoutingRevision() ||
+    agentOAuthRoutingSelectionThreads.get(providerSessionId) !==
+      selectionThreadId
+  ) {
+    await refreshAgentOAuthRouting(providerSessionId, selectionThreadId);
+  }
+  return (
+    agentOAuthRoutingDelivery.get(providerSessionId) === true &&
+    agentOAuthRoutingRevisions.get(providerSessionId) ===
+      currentAgentOAuthRoutingRevision() &&
+    agentOAuthRoutingSelectionThreads.get(providerSessionId) ===
+      selectionThreadId
+  );
 }
 
 createRoot(() => {
@@ -1774,7 +1839,7 @@ createRoot(() => {
     oauthSelectionsRevision();
     for (const session of Object.values(state.sessions)) {
       if (session.conversationId) {
-        void refreshAgentOAuthRouting(session.conversationId);
+        void refreshAgentOAuthRouting(session.info.id, session.conversationId);
       }
     }
   });
@@ -3247,7 +3312,7 @@ export const agentStore = {
           settingsStore.settings.lmStudioApiKey,
         );
         console.log("[AgentStore] Spawn result:", info);
-        await refreshAgentOAuthRouting(localSessionId ?? info.id);
+        await refreshAgentOAuthRouting(info.id, localSessionId ?? info.id);
         expectedReadySessionId = info.id;
 
         // The new session is alive — immediately clear the terminated flag so
@@ -3839,7 +3904,7 @@ export const agentStore = {
       };
       setState("sessions", conversationId, session);
       setState("activeSessionId", conversationId);
-      await refreshAgentOAuthRouting(conversationId);
+      await refreshAgentOAuthRouting(liveInfo.id, conversationId);
 
       if (rehydratedPendingPermissions.length > 0) {
         const seenRequestIds = new Set(
@@ -5805,6 +5870,23 @@ export const agentStore = {
       } else {
         setState("error", "Session has ended. Please start a new session.");
       }
+      return;
+    }
+
+    if (
+      session.conversationId &&
+      !(await awaitAgentOAuthRoutingForPrompt(
+        session.info.id,
+        session.conversationId,
+      ))
+    ) {
+      setState(
+        "sessions",
+        sessionId,
+        "error",
+        "Connected account routing is temporarily unavailable. Retry after your accounts finish loading.",
+      );
+      if (threadId) this.setTurnInFlight(threadId, false);
       return;
     }
 

--- a/tests/unit/agent-oauth-routing.test.ts
+++ b/tests/unit/agent-oauth-routing.test.ts
@@ -40,6 +40,7 @@ describe("computeAgentOAuthRouting", () => {
     await expect(computeAgentOAuthRouting("thread-routing")).resolves.toEqual({
       publishers: { gmail: "conn-other", google: "conn-other" },
       ambiguous: {},
+      available: true,
     });
   });
 
@@ -48,6 +49,7 @@ describe("computeAgentOAuthRouting", () => {
     await expect(computeAgentOAuthRouting("thread-default")).resolves.toEqual({
       publishers: { gmail: "conn-default", google: "conn-default" },
       ambiguous: {},
+      available: true,
     });
 
     mocks.listConnections.mockResolvedValue({
@@ -56,6 +58,7 @@ describe("computeAgentOAuthRouting", () => {
     await expect(computeAgentOAuthRouting("thread-sole")).resolves.toEqual({
       publishers: { gmail: "conn-other", google: "conn-other" },
       ambiguous: {},
+      available: true,
     });
   });
 
@@ -70,6 +73,17 @@ describe("computeAgentOAuthRouting", () => {
         gmail: expect.stringContaining("Multiple Google accounts are connected"),
         google: expect.stringContaining("Multiple Google accounts are connected"),
       },
+      available: true,
+    });
+  });
+
+  it("marks routing unavailable when account discovery fails", async () => {
+    mocks.listConnections.mockResolvedValue({ error: "offline" });
+    const { computeAgentOAuthRouting } = await import("@/services/publisher-oauth");
+    await expect(computeAgentOAuthRouting("thread-error")).resolves.toEqual({
+      publishers: {},
+      ambiguous: {},
+      available: false,
     });
   });
 });

--- a/tests/unit/codex-seren-mcp-proxy.test.ts
+++ b/tests/unit/codex-seren-mcp-proxy.test.ts
@@ -1,0 +1,191 @@
+import net from "node:net";
+import { describe, expect, it } from "vitest";
+import {
+  buildSerenPublisherRequest,
+  createSerenMcpOAuthProxy,
+  planSerenMcpRequest,
+} from "../../bin/browser-local/seren-mcp-oauth-proxy.mjs";
+
+const callPublisher = (args: Record<string, unknown>) => ({
+  jsonrpc: "2.0",
+  id: 7,
+  method: "tools/call",
+  params: { name: "call_publisher", arguments: args },
+});
+
+describe("native Codex Seren MCP OAuth routing", () => {
+  it("routes API and synthesized-tool calls through the selected connection", () => {
+    const routing = {
+      publishers: { gmail: "conn-selected" },
+      ambiguous: {},
+    };
+
+    expect(
+      planSerenMcpRequest(
+        routing,
+        callPublisher({
+          publisher: "gmail",
+          method: "GET",
+          path: "/messages?maxResults=1",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "publisher",
+      connectionId: "conn-selected",
+      publisher: "gmail",
+      request: { kind: "api", method: "GET", path: "/messages?maxResults=1" },
+    });
+
+    expect(
+      planSerenMcpRequest(
+        routing,
+        callPublisher({
+          publisher: "gmail",
+          tool: "get_messages",
+          tool_args: { maxResults: 1 },
+        }),
+      ),
+    ).toMatchObject({
+      kind: "publisher",
+      connectionId: "conn-selected",
+      publisher: "gmail",
+      request: {
+        kind: "tool",
+        tool: "get_messages",
+        toolArgs: { maxResults: 1 },
+      },
+    });
+  });
+
+  it("pins the selected identity on the ownership-checked Core request", () => {
+    const plan = planSerenMcpRequest(
+      { publishers: { gmail: "conn-selected" }, ambiguous: {} },
+      callPublisher({
+        publisher: "gmail",
+        method: "GET",
+        path: "/messages?maxResults=1&connection_id=conn-wrong",
+        headers: {
+          Authorization: "Bearer wrong",
+          "x-seren-oauth-connection-id": "conn-wrong",
+        },
+      }),
+    );
+    expect(plan.kind).toBe("publisher");
+    if (plan.kind !== "publisher") throw new Error("Expected publisher plan");
+
+    const request = buildSerenPublisherRequest(
+      plan,
+      "Bearer desktop-key",
+      "https://api.serendb.com",
+    );
+
+    expect(request.url).toBe(
+      "https://api.serendb.com/publishers/gmail/messages?maxResults=1",
+    );
+    expect(request.headers.get("Authorization")).toBe("Bearer desktop-key");
+    expect(request.headers.get("x-seren-oauth-connection-id")).toBe(
+      "conn-selected",
+    );
+  });
+
+  it("preserves an explicit selector and fails closed while ambiguous or initializing", () => {
+    expect(
+      planSerenMcpRequest(
+        { publishers: {}, ambiguous: { gmail: "Choose an account" } },
+        callPublisher({
+          publisher: "gmail",
+          method: "GET",
+          path: "/messages",
+          connection_id: "conn-explicit",
+        }),
+      ),
+    ).toMatchObject({ kind: "publisher", connectionId: "conn-explicit" });
+
+    expect(
+      planSerenMcpRequest(
+        { publishers: {}, ambiguous: { gmail: "Choose an account" } },
+        callPublisher({ publisher: "gmail", method: "GET", path: "/messages" }),
+      ),
+    ).toMatchObject({
+      kind: "error",
+      response: { result: { isError: true } },
+    });
+
+    expect(
+      planSerenMcpRequest(
+        null,
+        callPublisher({ publisher: "gmail", method: "GET", path: "/messages" }),
+      ),
+    ).toMatchObject({
+      kind: "error",
+      response: { result: { isError: true } },
+    });
+
+    expect(
+      planSerenMcpRequest(
+        { publishers: {}, ambiguous: {}, available: false },
+        callPublisher({ publisher: "gmail", method: "GET", path: "/messages" }),
+      ),
+    ).toMatchObject({
+      kind: "error",
+      response: { result: { isError: true } },
+    });
+  });
+
+  it("leaves unrelated and unselected MCP calls unchanged", () => {
+    expect(
+      planSerenMcpRequest(
+        { publishers: {}, ambiguous: {} },
+        callPublisher({
+          publisher: "coingecko-serenai",
+          method: "GET",
+          path: "/ping",
+        }),
+      ),
+    ).toEqual({ kind: "passthrough" });
+
+    expect(
+      planSerenMcpRequest(
+        { publishers: { gmail: "conn-selected" }, ambiguous: {} },
+        { jsonrpc: "2.0", id: 8, method: "tools/list", params: {} },
+      ),
+    ).toEqual({ kind: "passthrough" });
+  });
+
+  it("contains an aborted request body without leaking a runtime rejection", async () => {
+    const proxy = await createSerenMcpOAuthProxy({
+      gatewayUrl: "https://mcp.invalid/mcp",
+      apiUrl: "https://api.invalid",
+    });
+    const target = new URL(proxy.url);
+    let unhandled: unknown = null;
+    const onUnhandled = (reason: unknown) => {
+      unhandled = reason;
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const socket = net.createConnection(
+          Number(target.port),
+          target.hostname,
+        );
+        socket.once("error", reject);
+        socket.once("connect", () => {
+          socket.write(
+            `POST ${target.pathname} HTTP/1.1\r\nHost: ${target.host}\r\nContent-Type: application/json\r\nContent-Length: 128\r\n\r\n{`,
+            () => {
+              socket.destroy();
+              resolve();
+            },
+          );
+        });
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(unhandled).toBeNull();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      await proxy.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #2956.

## Summary

- route each native Codex session through a loopback Streamable HTTP proxy
- pass ordinary Seren MCP traffic through unchanged
- execute selected-account publisher calls through Core's ownership-checked publisher route with `x-seren-oauth-connection-id`
- fail closed for ambiguous or unavailable account routing and protect the selected identity from model-supplied overrides
- serialize routing refreshes and confirm the current provider session accepted the thread selection before prompt dispatch

## Root cause

The multi-account UI and thread selection were correct, but native Codex explicitly discarded the computed routing. The prior spawned-agent implementation relied on adding a top-level `connection_id`; live gateway metadata and contract probes show that the normal `tool` + `tool_args` form does not enforce that selector. The Core publisher proxy header does.

## Network path audited

```text
header account switcher
  -> OAuth connection/provider/publisher discovery
  -> provider_set_oauth_routing
  -> per-Codex loopback MCP proxy
     -> unselected calls: POST/GET/DELETE https://mcp.serendb.com/mcp
     -> selected synthetic tool: POST https://api.serendb.com/publishers/{slug}/_mcp/tools/{tool}
        x-seren-oauth-connection-id: <selected connection>
```

The live publisher list and Gmail synthetic-tool metadata were verified before implementation. A two-account, read-only live probe through the new proxy matched the selected identity and did not match the default identity. Raw account data, identifiers, logs, and screenshots remain local.

## Validation

- focused OAuth/proxy suite: 5 files, 18 tests passed
- full Vitest suite: 324 files passed, 3 skipped; 2,335 tests passed, 15 skipped
- Rust: 913 passed, 2 ignored; doc tests passed
- provider runtime bundle + local runtime smoke passed
- production frontend build + build-manifest verification passed
- lint passed with existing unrelated warnings
- live no-mock selected/default identity contract proof passed

## Audit follow-up

The same live-contract audit found a separate pre-existing non-Codex gap in Claude/renderer synthetic-tool dispatch. It is isolated and tracked in #2959 so this PR remains scoped to the reported native Codex failure.