### PR TITLE
fix(updater): disable updates in validation releases

### DIFF
--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -6,6 +6,7 @@ import { check, type DownloadEvent } from "@tauri-apps/plugin-updater";
 import { createStore } from "solid-js/store";
 import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
+import { getValidationRuntimeInfo } from "@/services/oauth-callback";
 import { telemetry } from "@/services/telemetry";
 
 export type UpdateStatus =
@@ -56,6 +57,14 @@ function isDevRuntime(): boolean {
   return import.meta.env.DEV === true;
 }
 
+async function isValidationRuntime(): Promise<boolean> {
+  const runtime = await getValidationRuntimeInfo();
+  if (!runtime.isValidation) return false;
+
+  setState({ status: "unsupported" });
+  return true;
+}
+
 async function initUpdater(): Promise<void> {
   if (initialized) return;
   initialized = true;
@@ -70,6 +79,8 @@ async function initUpdater(): Promise<void> {
     setState({ status: "unsupported" });
     return;
   }
+
+  if (await isValidationRuntime()) return;
 
   await checkForUpdates();
 
@@ -102,6 +113,8 @@ async function checkForUpdates(_manual = false): Promise<void> {
     setState({ status: "unsupported" });
     return;
   }
+
+  if (await isValidationRuntime()) return;
 
   setState({ status: "checking", error: null });
 
@@ -307,6 +320,7 @@ async function installAvailableUpdate(
     console.warn("[Updater] Install skipped: not Tauri runtime");
     return;
   }
+  if (await isValidationRuntime()) return;
   if (!pendingUpdate) {
     console.warn("[Updater] Install skipped: no pending update");
     setState({

--- a/tests/unit/updater-store.test.ts
+++ b/tests/unit/updater-store.test.ts
@@ -12,6 +12,7 @@ const {
   captureErrorMock,
   invokeMock,
   messageMock,
+  getValidationRuntimeInfoMock,
 } = vi.hoisted(() => ({
   mockStoreState: {} as Record<string, unknown>,
   isTauriRuntimeMock: vi.fn<() => boolean>(),
@@ -21,6 +22,7 @@ const {
   captureErrorMock: vi.fn(),
   invokeMock: vi.fn(),
   messageMock: vi.fn(),
+  getValidationRuntimeInfoMock: vi.fn(),
 }));
 
 vi.mock("solid-js/store", () => ({
@@ -35,6 +37,10 @@ vi.mock("solid-js/store", () => ({
 
 vi.mock("@/lib/tauri-bridge", () => ({
   isTauriRuntime: isTauriRuntimeMock,
+}));
+
+vi.mock("@/services/oauth-callback", () => ({
+  getValidationRuntimeInfo: getValidationRuntimeInfoMock,
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -76,7 +82,15 @@ describe("updaterStore install flow", () => {
     captureErrorMock.mockReset();
     invokeMock.mockReset();
     messageMock.mockReset();
+    getValidationRuntimeInfoMock.mockReset();
     messageMock.mockResolvedValue(undefined);
+    getValidationRuntimeInfoMock.mockResolvedValue({
+      isValidation: false,
+      controlEnabled: false,
+      identifier: "com.serendb.desktop",
+      oauthCallbackPort: 8787,
+      processId: 1,
+    });
     invokeMock.mockImplementation(async (command: string) => {
       if (command === "updater_install_preflight") {
         return {
@@ -158,6 +172,43 @@ describe("updaterStore install flow", () => {
 
     await updaterStore.initUpdater();
 
+    expect(downloadAndInstallMock).not.toHaveBeenCalled();
+    expect(relaunchMock).not.toHaveBeenCalled();
+  });
+
+  it("never checks or installs updates in a validation release (#2962)", async () => {
+    isTauriRuntimeMock.mockReturnValue(true);
+    const downloadAndInstallMock = vi.fn(async () => {});
+    checkMock.mockResolvedValue({
+      version: "1.3.53",
+      downloadAndInstall: downloadAndInstallMock,
+    });
+
+    const { updaterStore } = await import("@/stores/updater.store");
+
+    // Seed a pending update as a production runtime so the install assertion
+    // proves the validation guard wins even when update state already exists.
+    await updaterStore.checkForUpdates();
+    expect(checkMock).toHaveBeenCalledOnce();
+
+    checkMock.mockClear();
+    invokeMock.mockClear();
+    getValidationRuntimeInfoMock.mockResolvedValue({
+      isValidation: true,
+      controlEnabled: true,
+      identifier: "com.serendb.desktop.validation",
+      oauthCallbackPort: 0,
+      processId: 2,
+    });
+
+    await updaterStore.initUpdater();
+    await updaterStore.checkForUpdates(true);
+    await updaterStore.installAvailableUpdate();
+
+    expect(updaterStore.state.status).toBe("unsupported");
+    expect(checkMock).not.toHaveBeenCalled();
+    expect(invokeMock).not.toHaveBeenCalledWith("updater_install_preflight");
+    expect(invokeMock).not.toHaveBeenCalledWith("updater_pre_install");
     expect(downloadAndInstallMock).not.toHaveBeenCalled();
     expect(relaunchMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Closes #2962

## What changed

- Detect the isolated validation runtime inside the updater store.
- Fail closed with updater status `unsupported` from initialization, manual checks, and install paths.
- Add one critical regression test proving validation releases never call updater check, install preflight/pre-install, download/install, or relaunch—even with a pending production update.

## Audit

The validation bundle inherits production updater configuration, while release validation builds have `import.meta.env.DEV === false`. The startup auto-install path therefore drained the packaged provider runtime and replaced/exited the artifact under test. The validation runtime added in #2782 had no updater gate for the startup behavior introduced in #1721.

## Validation

- `pnpm exec vitest run tests/unit/updater-store.test.ts` — 10/10 passed
- scoped Biome check — passed
- `git diff --check` — passed

## Network and privacy

This removes updater network activity from validation bundles. It adds no publisher/API route, changes no Core contract, and includes no private logs, account data, or credentials.