### PR TITLE
fix(agent): route all selected OAuth identities

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -9,6 +9,7 @@ import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
+import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
 import {
   buildEffortArgs,
   buildEffortConfigOption,
@@ -2269,6 +2270,8 @@ function attachProcessListeners(emit, sessions, session, exitPromises) {
       return;
     }
 
+    void session.serenMcpProxy?.close();
+
     const diagnosticSuffix = stderrTail
       ? ` (${exitDetail}): ${stderrTail.split("\n").pop()}`
       : ` (${exitDetail})`;
@@ -2341,6 +2344,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     spawnEnv = {},
     reasoningEffort = DEFAULT_CLAUDE_EFFORT,
     serenMcpConfigured = false,
+    serenMcpProxy = null,
   }) {
     return {
       id: sessionId,
@@ -2378,6 +2382,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       // audit has already run. See maybeAuditSerenMcpTools / #2802.
       serenMcpConfigured,
       serenMcpToolsChecked: false,
+      serenMcpProxy,
     };
   }
 
@@ -2405,7 +2410,6 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     }
 
     const remoteSessionId = resumeAgentSessionId ?? randomUUID();
-    const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
     // The Seren gateway is only in the MCP config when an API key is present
     // (see createRemoteSerenServer). Mirror that check so the post-spawn tool
     // audit only runs for sessions that actually expect gateway tools. #2802
@@ -2429,13 +2433,27 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       typeof initialModelId === "string" && initialModelId.length > 0
         ? initialModelId
         : DEFAULT_PREFERRED_MODEL;
-    const claudeArgs = buildClaudeArgs({
-      sessionId: remoteSessionId,
-      resumeSessionId: resumeAgentSessionId ?? null,
-      preferredModel,
-      mcpConfigJson: mcpConfig.claudeMcpConfigJson,
-      effort: effectiveEffort,
-    });
+    let serenMcpProxy = null;
+    let mcpConfig;
+    let claudeArgs;
+    try {
+      if (apiKey) serenMcpProxy = await createSerenMcpOAuthProxy();
+      mcpConfig = buildProviderMcpConfig({
+        apiKey,
+        mcpServers,
+        serenMcpGatewayUrl: serenMcpProxy?.url,
+      });
+      claudeArgs = buildClaudeArgs({
+        sessionId: remoteSessionId,
+        resumeSessionId: resumeAgentSessionId ?? null,
+        preferredModel,
+        mcpConfigJson: mcpConfig.claudeMcpConfigJson,
+        effort: effectiveEffort,
+      });
+    } catch (error) {
+      await serenMcpProxy?.close();
+      throw error;
+    }
     // Surface the resolved --model value at every spawn so UI/runtime model
     // mismatches (e.g. picker shows [1m] but the spawned session reports a
     // 200K window) are diagnosable without ad-hoc instrumentation. Goes to
@@ -2511,6 +2529,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         }
         console.error(`${claudeLogPrefix} Spawn error: ${spawnError.message}`);
         sessions.delete(sessionId);
+        void serenMcpProxy?.close();
         // macOS surfaces a wrong-arch binary as `errno: -86` / "Bad CPU type in
         // executable" (EBADARCH). It hits when a prior install dropped the wrong
         // slice (e.g. x86_64 claude on an arm64 Mac without Rosetta) and our
@@ -2557,6 +2576,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         spawnEnv: mcpConfig.childEnv,
         reasoningEffort: effectiveEffort,
         serenMcpConfigured,
+        serenMcpProxy,
       });
 
       sessions.set(sessionId, launchedSession);
@@ -2564,9 +2584,10 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       return { processHandle, session: launchedSession };
     };
 
-    let { processHandle, session } = launchClaudeProcess();
-
+    let processHandle;
+    let session;
     try {
+      ({ processHandle, session } = launchClaudeProcess());
       // Initialize handshake with kill+respawn. A first-run stall can wedge the
       // CLI so it never answers the request; re-asking the SAME process can't
       // recover (it's already stuck), so on timeout we kill it and hand the
@@ -2681,7 +2702,8 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       sessions.delete(sessionId);
-      killChildTree(processHandle);
+      if (processHandle) killChildTree(processHandle);
+      await serenMcpProxy?.close();
       emit("provider://error", {
         sessionId,
         error: isAuthError(message)
@@ -2795,6 +2817,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     );
     rejectCurrentPrompt(session, new Error("Session terminated."));
     session.output.close();
+    await session.serenMcpProxy?.close();
     killChildTree(session.process);
     emit("provider://session-status", {
       sessionId,
@@ -2863,8 +2886,11 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
 
   async function setOAuthRouting({ sessionId, routing }) {
     const session = sessions.get(sessionId);
-    if (session) session.oauthRouting = routing;
-    else console.warn(`[claude-runtime] OAuth routing session not found: ${sessionId}`);
+    if (!session) {
+      throw new Error(`OAuth routing session not found: ${sessionId}`);
+    }
+    session.oauthRouting = routing;
+    session.serenMcpProxy?.setRouting(routing);
   }
 
   async function respondToPermission({ sessionId, requestId, optionId }) {

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -10,6 +10,7 @@ import readline from "node:readline";
 
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
 import { providerLogPrefix } from "./logging.mjs";
+import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
 
 // ============================================================================
 // Binary resolution
@@ -246,6 +247,7 @@ function createGeminiSessionRecord({
   timeoutSecs,
   currentModeId,
   logPrefix,
+  serenMcpProxy = null,
 }) {
   return {
     id: sessionId,
@@ -269,6 +271,7 @@ function createGeminiSessionRecord({
     // the choice but does NOT yet re-spawn gemini-cli with --model
     // (phase 2 of #1480 follow-up).
     currentModelId: GEMINI_DEFAULT_MODEL_ID,
+    serenMcpProxy,
   };
 }
 
@@ -662,9 +665,18 @@ function attachProcessListeners(emit, sessions, session) {
     }
   });
 
-  session.process.on("exit", () => {
+  // ChildProcess emits `error` before `close` when spawning fails. Keep an
+  // error listener installed so the provider runtime does not crash; `close`
+  // remains the single cleanup path for both spawn failures and normal exits.
+  session.process.on("error", (error) => {
+    console.error(`${logPrefix} process error: ${error.message}`);
+  });
+
+  session.process.on("close", () => {
     const wasTracked = sessions.delete(session.id);
     if (!wasTracked) return;
+
+    void session.serenMcpProxy?.close();
 
     rejectPendingRequests(
       session,
@@ -713,21 +725,38 @@ export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) 
 
     const sessionId = localSessionId ?? randomUUID();
     const resolvedMode = geminiApprovalMode(approvalPolicy, sandboxMode);
-    const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
-    const processHandle = spawnGeminiProcess(cwd, {
-      extraEnv: mcpConfig.childEnv,
-    });
-    const session = createGeminiSessionRecord({
-      sessionId,
-      cwd,
-      processHandle,
-      timeoutSecs,
-      currentModeId: resolvedMode,
-      logPrefix: geminiLogPrefix,
-    });
+    let serenMcpProxy = null;
+    let mcpConfig;
+    let processHandle;
+    let session;
+    try {
+      if (apiKey) serenMcpProxy = await createSerenMcpOAuthProxy();
+      mcpConfig = buildProviderMcpConfig({
+        apiKey,
+        mcpServers,
+        serenMcpGatewayUrl: serenMcpProxy?.url,
+      });
+      processHandle = spawnGeminiProcess(cwd, {
+        extraEnv: mcpConfig.childEnv,
+      });
+      session = createGeminiSessionRecord({
+        sessionId,
+        cwd,
+        processHandle,
+        timeoutSecs,
+        currentModeId: resolvedMode,
+        logPrefix: geminiLogPrefix,
+        serenMcpProxy,
+      });
 
-    sessions.set(sessionId, session);
-    attachProcessListeners(emit, sessions, session);
+      sessions.set(sessionId, session);
+      attachProcessListeners(emit, sessions, session);
+    } catch (error) {
+      sessions.delete(sessionId);
+      if (processHandle) killChildTree(processHandle);
+      await serenMcpProxy?.close();
+      throw error;
+    }
 
     try {
       // ACP step 1: initialize handshake
@@ -796,6 +825,7 @@ export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) 
 
       sessions.delete(sessionId);
       killChildTree(processHandle);
+      await serenMcpProxy?.close();
 
       if (authFailed) {
         // Emit a typed event so agent.store can auto-trigger launchLogin
@@ -949,6 +979,7 @@ export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) 
     } catch {
       // Ignore double-close races.
     }
+    await session.serenMcpProxy?.close();
     killChildTree(session.process);
     emit("provider://session-status", {
       sessionId,
@@ -995,6 +1026,14 @@ export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) 
       // Best-effort — older gemini-cli builds may not support set_mode yet.
     });
     emit("provider://session-status", buildSessionStatus(session));
+  }
+
+  async function setOAuthRouting({ sessionId, routing }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No Gemini session: ${sessionId}`);
+    }
+    session.serenMcpProxy?.setRouting(routing);
   }
 
   async function respondToPermission({ sessionId, requestId, optionId }) {
@@ -1090,7 +1129,7 @@ export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) 
     terminateSession,
     listSessions,
     setPermissionMode,
-    setOAuthRouting: async () => {},
+    setOAuthRouting,
     respondToPermission,
     setModel,
   };

--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -17,6 +17,7 @@ import {
   writeFile,
 } from "./fs.mjs";
 import { providerLogPrefix } from "./logging.mjs";
+import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
 
 const DEFAULT_BASE_URL = "http://localhost:1234";
 const DEFAULT_MCP_GATEWAY_URL =
@@ -1532,39 +1533,59 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
       .then((info) => info.version)
       .catch(() => null);
 
-    const session = {
-      id: sessionId,
-      agentType: LMSTUDIO_AGENT_TYPE,
-      cwd: params.cwd,
-      status: "initializing",
-      createdAt: new Date().toISOString(),
-      agentSessionId: sessionId,
-      timeoutSecs: params.timeoutSecs ?? undefined,
-      baseUrl,
-      apiKey: lmStudioApiKey,
-      client,
-      mcpGateway: createMcpGatewayClient({ apiKey: serenApiKey }),
-      availableModelRecords,
-      currentModelId: initialModel.modelId,
-      currentModeId: params.approvalPolicy === "never" ? "auto" : "ask",
-      currentPrompt: null,
-      pendingPermissions: new Map(),
-      approvedForSession: new Set(),
-      messages: [],
-      toolIncompatibleModelIds: new Set(),
-      loadedModelKey: null,
-      loadedModelIdentifier: null,
-      loadedModelHandle: null,
-      loadedBySession: false,
-      contextLength: null,
-      lmStudioVersion,
-      logPrefix,
-      emit,
-    };
+    let serenMcpProxy = null;
+    try {
+      if (serenApiKey) serenMcpProxy = await createSerenMcpOAuthProxy();
+    } catch (error) {
+      await client[Symbol.asyncDispose]?.().catch(() => {});
+      throw error;
+    }
 
-    sessions.set(sessionId, session);
-    session.status = "ready";
-    emit("provider://session-status", buildSessionStatus(session, "ready"));
+    let session;
+    try {
+      session = {
+        id: sessionId,
+        agentType: LMSTUDIO_AGENT_TYPE,
+        cwd: params.cwd,
+        status: "initializing",
+        createdAt: new Date().toISOString(),
+        agentSessionId: sessionId,
+        timeoutSecs: params.timeoutSecs ?? undefined,
+        baseUrl,
+        apiKey: lmStudioApiKey,
+        client,
+        mcpGateway: createMcpGatewayClient({
+          apiKey: serenApiKey,
+          url: serenMcpProxy?.url,
+        }),
+        serenMcpProxy,
+        availableModelRecords,
+        currentModelId: initialModel.modelId,
+        currentModeId: params.approvalPolicy === "never" ? "auto" : "ask",
+        currentPrompt: null,
+        pendingPermissions: new Map(),
+        approvedForSession: new Set(),
+        messages: [],
+        toolIncompatibleModelIds: new Set(),
+        loadedModelKey: null,
+        loadedModelIdentifier: null,
+        loadedModelHandle: null,
+        loadedBySession: false,
+        contextLength: null,
+        lmStudioVersion,
+        logPrefix,
+        emit,
+      };
+
+      sessions.set(sessionId, session);
+      session.status = "ready";
+      emit("provider://session-status", buildSessionStatus(session, "ready"));
+    } catch (error) {
+      sessions.delete(sessionId);
+      await serenMcpProxy?.close();
+      await client[Symbol.asyncDispose]?.().catch(() => {});
+      throw error;
+    }
 
     return {
       id: session.id,
@@ -1604,6 +1625,7 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
         console.warn(`${logPrefix} failed to unload model:`, error);
       });
     }
+    await session.serenMcpProxy?.close();
     await session.client[Symbol.asyncDispose]?.().catch(() => {});
     emit("provider://session-status", {
       sessionId,
@@ -1632,6 +1654,12 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
     if (!session) throw new Error(`Unknown LM Studio session: ${sessionId}`);
     session.currentModeId = mode === "auto" ? "auto" : "ask";
     emit("provider://session-status", buildSessionStatus(session));
+  }
+
+  async function setOAuthRouting({ sessionId, routing }) {
+    const session = sessions.get(sessionId);
+    if (!session) throw new Error(`Unknown LM Studio session: ${sessionId}`);
+    session.serenMcpProxy?.setRouting(routing);
   }
 
   async function respondToPermission({ sessionId, requestId, optionId }) {
@@ -1720,7 +1748,7 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
     terminateSession,
     listSessions,
     setPermissionMode,
-    setOAuthRouting: async () => {},
+    setOAuthRouting,
     respondToPermission,
     setSessionModel,
     updateSessionConfigOption,

--- a/bin/browser-local/seren-mcp-oauth-proxy.mjs
+++ b/bin/browser-local/seren-mcp-oauth-proxy.mjs
@@ -1,4 +1,4 @@
-// ABOUTME: Per-Codex-session loopback proxy for deterministic Seren OAuth account routing.
+// ABOUTME: Per-agent-session loopback proxy for deterministic Seren OAuth account routing.
 // ABOUTME: Forwards MCP traffic unchanged except selected call_publisher requests, which use the supported Core selector header.
 
 import { randomBytes } from "node:crypto";
@@ -250,11 +250,21 @@ function textResponseBody(response, bytes) {
   });
 }
 
+function x402PaymentHeaderName(payment) {
+  try {
+    const payload = JSON.parse(Buffer.from(payment, "base64").toString("utf8"));
+    if (payload?.x402Version === 2) return "PAYMENT-SIGNATURE";
+  } catch {
+    // Legacy v1 payloads and opaque gateway-issued values use X-PAYMENT.
+  }
+  return "X-PAYMENT";
+}
+
 export function buildSerenPublisherRequest(plan, authorization, apiUrl) {
   const headers = new Headers({
     Accept: "application/json",
     Authorization: authorization,
-    "User-Agent": "Seren-Desktop-Codex-OAuth-Router",
+    "User-Agent": "Seren-Desktop-OAuth-Router",
     "x-seren-oauth-connection-id": plan.connectionId,
   });
 
@@ -264,7 +274,8 @@ export function buildSerenPublisherRequest(plan, authorization, apiUrl) {
     headers.set("Idempotency-Key", plan.request.requestId.trim());
   }
   if (nonEmptyString(plan.request.payment)) {
-    headers.set("X-PAYMENT", plan.request.payment.trim());
+    const payment = plan.request.payment.trim();
+    headers.set(x402PaymentHeaderName(payment), payment);
   }
   const body = buildPublisherBody(plan.request, headers);
 
@@ -318,9 +329,16 @@ async function executePublisherPlan(plan, authorization, apiUrl, signal) {
       signal,
     });
     const bytes = Buffer.from(await response.arrayBuffer());
+    const paymentRequiredHeader = response.headers.get("payment-required");
     const text =
-      textResponseBody(response, bytes) ||
-      JSON.stringify({ data: { status: response.status } });
+      response.status === 402 && paymentRequiredHeader
+        ? JSON.stringify({
+            error: "payment_required",
+            proxy_payment: true,
+            payment_required_header: paymentRequiredHeader,
+          })
+        : textResponseBody(response, bytes) ||
+          JSON.stringify({ data: { status: response.status } });
     return {
       jsonrpc: "2.0",
       id: plan.id,

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -12,18 +12,10 @@ import {
   callSerenTool,
   type PaymentProxyInfo,
 } from "@/services/mcp-gateway";
-import {
-  listConnectedPublishers,
-  resolveOAuthProviderForPublisher,
-} from "@/services/publisher-oauth";
+import { computeAgentOAuthRouting } from "@/services/publisher-oauth";
 import { startShellProgressListener } from "@/services/shell-progress";
 import { x402Service } from "@/services/x402";
 import { conversationStore } from "@/stores/conversation.store";
-import {
-  getOAuthConnectionsForProvider,
-  hasAmbiguousOAuthConnections,
-  resolveThreadOAuthConnection,
-} from "@/stores/oauth-account.store";
 import { getApprovalRequirement, requiresApproval } from "./approval-config";
 import { parseGatewayToolName, parseMcpToolName } from "./definitions";
 
@@ -211,45 +203,26 @@ async function resolveGatewayOAuthConnectionArgs(
     return { args };
   }
 
-  try {
-    const [provider, connections] = await Promise.all([
-      resolveOAuthProviderForPublisher(publisherSlug),
-      listConnectedPublishers(),
-    ]);
-    const providerConnections = getOAuthConnectionsForProvider(
-      connections,
-      provider.providerSlug,
-    );
-    if (providerConnections.length === 0) return { args };
-
-    const threadId = conversationId ?? conversationStore.activeConversationId;
-    const selected = resolveThreadOAuthConnection(
-      threadId,
-      provider.providerSlug,
-      connections,
-    );
-
-    if (selected) {
-      return { args: { ...args, connection_id: selected.id } };
-    }
-
-    if (
-      hasAmbiguousOAuthConnections(threadId, provider.providerSlug, connections)
-    ) {
-      return {
-        args,
-        error: `Multiple ${provider.providerName} accounts are connected. Choose an active account for this chat before running ${publisherSlug}/${toolName}.`,
-      };
-    }
-
-    return { args };
-  } catch (err) {
-    console.warn(
-      `[Tool Executor] Failed to resolve OAuth connection for ${publisherSlug}:`,
-      err,
-    );
-    return { args };
+  const threadId = conversationId ?? conversationStore.activeConversationId;
+  const routing = await computeAgentOAuthRouting(threadId);
+  if (routing.available === false) {
+    return {
+      args,
+      error: `OAuth account routing is unavailable. Retry ${publisherSlug}/${toolName} after connected accounts finish loading; refusing to use a default account.`,
+    };
   }
+
+  const ambiguity = routing.ambiguous[publisherSlug];
+  if (ambiguity) {
+    return { args, error: ambiguity };
+  }
+
+  const connectionId = routing.publishers[publisherSlug];
+  if (connectionId) {
+    return { args: { ...args, connection_id: connectionId } };
+  }
+
+  return { args };
 }
 
 /**

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -1,12 +1,17 @@
 // ABOUTME: MCP Gateway service for connecting to Seren MCP gateway via MCP protocol.
 // ABOUTME: Uses rmcp HTTP streaming transport to connect to mcp.serendb.com/mcp.
 
-import { MCP_GATEWAY_INITIALIZE_METHOD, MCP_GATEWAY_URL } from "@/lib/config";
+import {
+  API_BASE,
+  MCP_GATEWAY_INITIALIZE_METHOD,
+  MCP_GATEWAY_URL,
+} from "@/lib/config";
 import { mcpClient } from "@/lib/mcp/client";
 import type { McpTool, McpToolResult } from "@/lib/mcp/types";
 import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import { captureSupportError } from "@/lib/support/hook";
 import { getSerenApiKey } from "@/lib/tauri-bridge";
+import { getTauriFetch, shouldUseRustGatewayAuth } from "@/lib/tauri-fetch";
 
 const SEREN_MCP_SERVER_NAME = "seren-gateway";
 
@@ -625,6 +630,77 @@ function parsePaymentProxyError(content: unknown): PaymentProxyInfo | null {
   return null;
 }
 
+function x402PaymentHeaderName(
+  payment: string,
+): "X-PAYMENT" | "PAYMENT-SIGNATURE" {
+  try {
+    const payload = JSON.parse(atob(payment)) as { x402Version?: unknown };
+    if (payload.x402Version === 2) return "PAYMENT-SIGNATURE";
+  } catch {
+    // Legacy v1 payloads and opaque gateway-issued values use X-PAYMENT.
+  }
+  return "X-PAYMENT";
+}
+
+async function callSelectedPublisherTool(
+  publisherSlug: string,
+  toolName: string,
+  toolArgs: Record<string, unknown>,
+  connectionId: string,
+  payment: unknown,
+  startTime: number,
+): Promise<McpToolCallResponse> {
+  const url = `${API_BASE}/publishers/${encodeURIComponent(
+    publisherSlug,
+  )}/_mcp/tools/${encodeURIComponent(toolName)}`;
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    "x-seren-oauth-connection-id": connectionId,
+  };
+
+  if (typeof payment === "string" && payment.length > 0) {
+    headers[x402PaymentHeaderName(payment)] = payment;
+  }
+  if (!shouldUseRustGatewayAuth(url)) {
+    const apiKey = await getSerenApiKey();
+    if (!apiKey) {
+      throw new McpGatewayError(
+        "Seren API key required - please log in",
+        401,
+        url,
+      );
+    }
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  const fetchFn = await getTauriFetch();
+  const response = await fetchFn(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(toolArgs),
+  });
+  const responseText = await response.text();
+  const text =
+    responseText || JSON.stringify({ data: { status: response.status } });
+  const content = [{ type: "text", text }];
+  const paymentRequiredHeader = response.headers.get("payment-required");
+  const parsedPaymentProxy = parsePaymentProxyError(content);
+  const paymentProxy =
+    parsedPaymentProxy ??
+    (response.status === 402 && paymentRequiredHeader
+      ? { payment_required_header: paymentRequiredHeader }
+      : null);
+
+  return {
+    result: content,
+    is_error: !response.ok,
+    execution_time_ms: Date.now() - startTime,
+    response_bytes: new TextEncoder().encode(responseText).byteLength,
+    ...(paymentProxy ? { payment_proxy: paymentProxy } : {}),
+  };
+}
+
 /**
  * Call a tool via the MCP Gateway.
  *
@@ -651,6 +727,21 @@ export async function callGatewayTool(
     // Separate gateway metadata from publisher tool args.
     const { _x402_payment, connection_id, ...toolArgs } = args;
 
+    // A selected OAuth identity must use Core's ownership-checked selector
+    // header. The MCP call_publisher tool ignores unknown top-level metadata,
+    // so forwarding connection_id there silently executes as the default
+    // account instead.
+    if (typeof connection_id === "string" && connection_id.length > 0) {
+      return await callSelectedPublisherTool(
+        publisherSlug,
+        toolName,
+        toolArgs,
+        connection_id,
+        _x402_payment,
+        startTime,
+      );
+    }
+
     // Check if this is a first-class MCP tool on the gateway.
     // Native tools (from the gateway's list_tools response) are called directly
     // via MCP protocol, bypassing the call_publisher dispatch mechanism.
@@ -673,10 +764,6 @@ export async function callGatewayTool(
       if (_x402_payment !== undefined) {
         dispatchArgs._x402_payment = _x402_payment;
       }
-      if (typeof connection_id === "string" && connection_id.length > 0) {
-        dispatchArgs.connection_id = connection_id;
-      }
-
       result = await mcpClient.callToolHttp(SEREN_MCP_SERVER_NAME, {
         name: "call_publisher",
         arguments: dispatchArgs,

--- a/tests/services/mcp-gateway.test.ts
+++ b/tests/services/mcp-gateway.test.ts
@@ -3,12 +3,19 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const gatewayFetchMock = vi.hoisted(() => vi.fn());
+
 // Mock tauri-bridge to avoid localStorage dependency in Node.
 vi.mock("@/lib/tauri-bridge", () => ({
   getSerenApiKey: vi.fn().mockResolvedValue("test-api-key"),
   clearSerenApiKey: vi.fn().mockResolvedValue(undefined),
   isTauri: vi.fn().mockReturnValue(false),
   isTauriRuntime: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/tauri-fetch", () => ({
+  getTauriFetch: vi.fn(async () => gatewayFetchMock),
+  shouldUseRustGatewayAuth: vi.fn(() => false),
 }));
 
 // Mock the support pipeline so captureSupportError is a no-op. Otherwise
@@ -332,7 +339,7 @@ describe("MCP Gateway Native Tool Routing (#1329)", () => {
     expect(result.is_error).toBe(false);
   });
 
-  it("should pass connection_id as call_publisher metadata for REST publisher tools", async () => {
+  it("should route a selected REST publisher tool through Core's selector header", async () => {
     const { mcpClient } = await import("@/lib/mcp/client");
     const callToolMock = vi.mocked(mcpClient.callToolHttp);
 
@@ -381,28 +388,40 @@ describe("MCP Gateway Native Tool Routing (#1329)", () => {
 
     await initializeGateway();
     callToolMock.mockClear();
-    callToolMock.mockResolvedValue({
-      content: [{ type: "text", text: "sent" }],
-      isError: false,
-    });
+    gatewayFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: { sent: true } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
 
+    const signedV2Payment = btoa(JSON.stringify({ x402Version: 2 }));
     const result = await callGatewayTool("gmail", "post_messages_send", {
       connection_id: "conn_google_1",
-      to: "user@example.com",
+      _x402_payment: signedV2Payment,
+      to: "recipient@example.invalid",
       subject: "Hello",
     });
 
-    expect(callToolMock).toHaveBeenCalledWith("seren-gateway", {
-      name: "call_publisher",
-      arguments: {
-        publisher: "gmail",
-        tool: "post_messages_send",
-        connection_id: "conn_google_1",
-        tool_args: {
-          to: "user@example.com",
-          subject: "Hello",
-        },
-      },
+    expect(callToolMock).not.toHaveBeenCalled();
+    expect(gatewayFetchMock).toHaveBeenCalledOnce();
+    const [url, init] = gatewayFetchMock.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe(
+      "https://api.serendb.com/publishers/gmail/_mcp/tools/post_messages_send",
+    );
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer test-api-key",
+      "Content-Type": "application/json",
+      "PAYMENT-SIGNATURE": signedV2Payment,
+      "x-seren-oauth-connection-id": "conn_google_1",
+    });
+    expect(init.headers).not.toHaveProperty("X-PAYMENT");
+    expect(JSON.parse(String(init.body))).toEqual({
+      to: "recipient@example.invalid",
+      subject: "Hello",
     });
     expect(result.is_error).toBe(false);
   });

--- a/tests/unit/codex-seren-mcp-proxy.test.ts
+++ b/tests/unit/codex-seren-mcp-proxy.test.ts
@@ -1,5 +1,5 @@
 import net from "node:net";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildSerenPublisherRequest,
   createSerenMcpOAuthProxy,
@@ -86,6 +86,105 @@ describe("native Codex Seren MCP OAuth routing", () => {
     expect(request.headers.get("x-seren-oauth-connection-id")).toBe(
       "conn-selected",
     );
+  });
+
+  it("uses the versioned x402 header while keeping the selected identity pinned", () => {
+    const paymentFor = (x402Version: number) =>
+      Buffer.from(JSON.stringify({ x402Version })).toString("base64");
+    const requestFor = (x402Version: number) => {
+      const plan = planSerenMcpRequest(
+        { publishers: { gmail: "conn-selected" }, ambiguous: {} },
+        callPublisher({
+          publisher: "gmail",
+          tool: "get_messages",
+          tool_args: { maxResults: 1 },
+          _x402_payment: paymentFor(x402Version),
+        }),
+      );
+      if (plan.kind !== "publisher") {
+        throw new Error("Expected publisher plan");
+      }
+      return buildSerenPublisherRequest(
+        plan,
+        "Bearer desktop-key",
+        "https://api.serendb.com",
+      );
+    };
+
+    const v2 = requestFor(2);
+    expect(v2.headers.get("PAYMENT-SIGNATURE")).toBe(paymentFor(2));
+    expect(v2.headers.has("X-PAYMENT")).toBe(false);
+    expect(v2.headers.get("x-seren-oauth-connection-id")).toBe(
+      "conn-selected",
+    );
+
+    const v1 = requestFor(1);
+    expect(v1.headers.get("X-PAYMENT")).toBe(paymentFor(1));
+    expect(v1.headers.has("PAYMENT-SIGNATURE")).toBe(false);
+  });
+
+  it("surfaces Core's payment-required header as the standard MCP proxy error", async () => {
+    const originalFetch = globalThis.fetch;
+    const paymentRequiredHeader = Buffer.from(
+      JSON.stringify({ x402Version: 2 }),
+    ).toString("base64");
+    const upstreamFetch = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 402,
+        headers: { "payment-required": paymentRequiredHeader },
+      }),
+    );
+    globalThis.fetch = upstreamFetch as typeof fetch;
+    const proxy = await createSerenMcpOAuthProxy({
+      gatewayUrl: "https://mcp.invalid/mcp",
+      apiUrl: "https://api.invalid",
+    });
+    proxy.setRouting({
+      publishers: { gmail: "conn-selected" },
+      ambiguous: {},
+    });
+
+    try {
+      const response = await originalFetch(proxy.url, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer desktop-key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(
+          callPublisher({
+            publisher: "gmail",
+            tool: "get_messages",
+            tool_args: { maxResults: 1 },
+          }),
+        ),
+      });
+      const event = (await response.text())
+        .split("\n")
+        .find((line) => line.startsWith("data: "));
+      expect(event).toBeDefined();
+      const payload = JSON.parse(event?.slice(6) ?? "null");
+      const proxyError = JSON.parse(payload.result.content[0].text);
+
+      expect(proxyError).toEqual({
+        error: "payment_required",
+        proxy_payment: true,
+        payment_required_header: paymentRequiredHeader,
+      });
+      expect(payload.result.isError).toBe(true);
+      const [, requestInit] = upstreamFetch.mock.calls[0] as [
+        string,
+        RequestInit,
+      ];
+      expect(
+        new Headers(requestInit.headers).get(
+          "x-seren-oauth-connection-id",
+        ),
+      ).toBe("conn-selected");
+    } finally {
+      globalThis.fetch = originalFetch;
+      await proxy.close();
+    }
   });
 
   it("preserves an explicit selector and fails closed while ambiguous or initializing", () => {

--- a/tests/unit/lmstudio-runtime.test.ts
+++ b/tests/unit/lmstudio-runtime.test.ts
@@ -339,8 +339,10 @@ describe("LM Studio runtime wiring", () => {
     expect(runtimeSource).toContain("const lmStudioApiKey");
     expect(runtimeSource).toContain("const serenApiKey");
     expect(runtimeSource).toContain(
-      "mcpGateway: createMcpGatewayClient({ apiKey: serenApiKey })",
+      "mcpGateway: createMcpGatewayClient({",
     );
+    expect(runtimeSource).toContain("apiKey: serenApiKey");
+    expect(runtimeSource).toContain("url: serenMcpProxy?.url");
   });
 
   it("is wired into the provider dispatcher", () => {

--- a/tests/unit/native-runtime-oauth-proxy.test.ts
+++ b/tests/unit/native-runtime-oauth-proxy.test.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Critical wiring guards for selected OAuth identities in native agent MCP clients.
+// ABOUTME: Ensures every direct Seren gateway runtime routes through the per-session proxy.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(relativePath), "utf8");
+}
+
+describe("native agent selected OAuth identity routing", () => {
+  const claudeSource = readSource("bin/browser-local/claude-runtime.mjs");
+  const geminiSource = readSource("bin/browser-local/gemini-runtime.mjs");
+  const lmStudioSource = readSource("bin/browser-local/lmstudio-runtime.mjs");
+
+  it.each([
+    ["Claude", claudeSource],
+    ["Gemini", geminiSource],
+    ["LM Studio", lmStudioSource],
+  ])("routes %s Seren MCP calls through a session proxy", (_name, source) => {
+    expect(source).toContain("createSerenMcpOAuthProxy");
+    expect(source).toContain("serenMcpProxy?.url");
+    expect(source).toContain("serenMcpProxy?.setRouting(routing)");
+    expect(source).toContain("serenMcpProxy?.close()");
+  });
+
+  it("does not close Claude's shared proxy when an initialization process is replaced", () => {
+    const listenerStart = claudeSource.indexOf("function attachProcessListeners");
+    const listenerEnd = claudeSource.indexOf(
+      "export function createClaudeRuntime",
+      listenerStart,
+    );
+    const listenerSource = claudeSource.slice(listenerStart, listenerEnd);
+    const guardIndex = listenerSource.indexOf("if (!wasTracked)");
+    const closeIndex = listenerSource.indexOf("serenMcpProxy?.close()");
+
+    expect(guardIndex).toBeGreaterThanOrEqual(0);
+    expect(closeIndex).toBeGreaterThan(guardIndex);
+  });
+});

--- a/tests/unit/tool-executor-oauth-account.test.ts
+++ b/tests/unit/tool-executor-oauth-account.test.ts
@@ -3,8 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   callGatewayTool: vi.fn(),
   callSerenTool: vi.fn(),
-  listConnectedPublishers: vi.fn(),
-  resolveOAuthProviderForPublisher: vi.fn(),
+  computeAgentOAuthRouting: vi.fn(),
   emit: vi.fn(),
   listen: vi.fn(),
   invoke: vi.fn(),
@@ -18,8 +17,7 @@ vi.mock("@/services/mcp-gateway", () => ({
 }));
 
 vi.mock("@/services/publisher-oauth", () => ({
-  listConnectedPublishers: mocks.listConnectedPublishers,
-  resolveOAuthProviderForPublisher: mocks.resolveOAuthProviderForPublisher,
+  computeAgentOAuthRouting: mocks.computeAgentOAuthRouting,
 }));
 
 vi.mock("@/stores/conversation.store", () => ({
@@ -47,29 +45,6 @@ vi.mock("@/services/x402", () => ({
   },
 }));
 
-const googleConnections = [
-  {
-    id: "conn-google-work",
-    provider_slug: "google",
-    provider_email: "work@example.com",
-    provider_user_id: "work",
-    is_valid: true,
-    is_default: false,
-    connected_at: "2026-06-01T00:00:00Z",
-    last_used_at: null,
-  },
-  {
-    id: "conn-google-personal",
-    provider_slug: "google",
-    provider_email: "personal@example.com",
-    provider_user_id: "personal",
-    is_valid: true,
-    is_default: false,
-    connected_at: "2026-06-15T00:00:00Z",
-    last_used_at: null,
-  },
-];
-
 describe("tool executor OAuth account routing", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -78,12 +53,11 @@ describe("tool executor OAuth account routing", () => {
     );
     setThreadOAuthConnectionId("thread-1", "google", null);
     setThreadOAuthConnectionId("thread-2", "google", null);
-    mocks.resolveOAuthProviderForPublisher.mockResolvedValue({
-      publisherSlug: "gmail",
-      providerSlug: "google",
-      providerName: "Google",
+    mocks.computeAgentOAuthRouting.mockResolvedValue({
+      publishers: {},
+      ambiguous: {},
+      available: true,
     });
-    mocks.listConnectedPublishers.mockResolvedValue(googleConnections);
     mocks.callGatewayTool.mockResolvedValue({
       result: "ok",
       is_error: false,
@@ -101,6 +75,11 @@ describe("tool executor OAuth account routing", () => {
       "google",
       "conn-google-personal",
     );
+    mocks.computeAgentOAuthRouting.mockResolvedValue({
+      publishers: { gmail: "conn-google-personal" },
+      ambiguous: {},
+      available: true,
+    });
 
     const result = await executeTool({
       id: "tool-call-1",
@@ -128,6 +107,16 @@ describe("tool executor OAuth account routing", () => {
     // while a background run in thread-2 selected the personal account.
     setThreadOAuthConnectionId("thread-1", "google", "conn-google-work");
     setThreadOAuthConnectionId("thread-2", "google", "conn-google-personal");
+    mocks.computeAgentOAuthRouting.mockImplementation(async (threadId) => ({
+      publishers: {
+        gmail:
+          threadId === "thread-2"
+            ? "conn-google-personal"
+            : "conn-google-work",
+      },
+      ambiguous: {},
+      available: true,
+    }));
 
     const result = await executeTool(
       {
@@ -150,6 +139,14 @@ describe("tool executor OAuth account routing", () => {
 
   it("fails closed before dispatch when multiple accounts have no default or chat selection", async () => {
     const { executeTool } = await import("@/lib/tools/executor");
+    mocks.computeAgentOAuthRouting.mockResolvedValue({
+      publishers: {},
+      ambiguous: {
+        gmail:
+          "Multiple Google accounts are connected. Choose an active account for this chat.",
+      },
+      available: true,
+    });
 
     const result = await executeTool({
       id: "tool-call-2",
@@ -163,5 +160,87 @@ describe("tool executor OAuth account routing", () => {
     expect(result.is_error).toBe(true);
     expect(result.content).toContain("Multiple Google accounts are connected");
     expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when connected-account discovery is unavailable", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.computeAgentOAuthRouting.mockResolvedValue({
+      publishers: {},
+      ambiguous: {},
+      available: false,
+    });
+
+    const result = await executeTool({
+      id: "tool-call-unavailable",
+      type: "function",
+      function: {
+        name: "gateway__gmail__messages",
+        arguments: JSON.stringify({ q: "safe-read" }),
+      },
+    });
+
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("OAuth account routing is unavailable");
+    expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("retains the owning OAuth connection when retrying a signed x402 payment", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    const paymentRequiredHeader = btoa(
+      JSON.stringify({ x402Version: 2, accepts: [] }),
+    );
+    const signedV2Payment = btoa(JSON.stringify({ x402Version: 2 }));
+    mocks.computeAgentOAuthRouting.mockResolvedValue({
+      publishers: { gmail: "conn-google-personal" },
+      ambiguous: {},
+      available: true,
+    });
+    mocks.callGatewayTool
+      .mockResolvedValueOnce({
+        result: "payment required",
+        is_error: true,
+        payment_proxy: {
+          payment_required_header: paymentRequiredHeader,
+        },
+      })
+      .mockResolvedValueOnce({ result: "paid", is_error: false });
+    mocks.handlePaymentRequired.mockResolvedValue({
+      success: true,
+      method: "crypto",
+      paymentHeader: signedV2Payment,
+    });
+
+    const result = await executeTool(
+      {
+        id: "tool-call-paid",
+        type: "function",
+        function: {
+          name: "gateway__gmail__messages",
+          arguments: JSON.stringify({ q: "safe-read" }),
+        },
+      },
+      "thread-2",
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(mocks.callGatewayTool).toHaveBeenNthCalledWith(
+      1,
+      "gmail",
+      "messages",
+      {
+        q: "safe-read",
+        connection_id: "conn-google-personal",
+      },
+    );
+    expect(mocks.callGatewayTool).toHaveBeenNthCalledWith(
+      2,
+      "gmail",
+      "messages",
+      {
+        q: "safe-read",
+        connection_id: "conn-google-personal",
+        _x402_payment: signedV2Payment,
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary

- route selected OAuth identities through the per-session loopback proxy for native Claude, Gemini, and LM Studio agents
- route renderer publisher calls with a selected identity through Core's ownership-checked selector header
- use the owning thread's account selection and fail closed while routing metadata is ambiguous or unavailable
- preserve x402 semantics: v2 uses `PAYMENT-SIGNATURE`, v1 uses `X-PAYMENT`, and native 402 responses retain `payment-required` metadata
- close each native session proxy across initialization failures, replacement processes, exits, and explicit termination

## Audited network contract

- publisher discovery and unselected calls remain Streamable HTTP through `https://mcp.serendb.com/mcp`
- selected tool call: `POST https://api.serendb.com/publishers/{publisher}/_mcp/tools/{tool}`
- identity selector: `x-seren-oauth-connection-id`
- x402 retry header: `PAYMENT-SIGNATURE` for v2, `X-PAYMENT` for v1
- no Seren Core source changes

## Validation

- focused OAuth/proxy/gateway tests: 46 passed
- full frontend unit suite: 326 files passed, 3 skipped; 2,346 tests passed, 15 skipped
- provider runtime bundle: passed
- provider runtime smoke: passed
- frontend production build: passed
- lint: passed with existing warnings
- diff/PII checks: clean

Closes #2959

## Post-PR walkthrough finding

A real packaged macOS validation walkthrough found that the account switcher was hidden on empty native-agent threads, preventing first-turn selection. The same PR now renders it before the first prompt and adds focused regression coverage.

Closes #2965