### PR TITLE
fix(chat): show account switcher before first prompt

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -1688,8 +1688,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       </Show>
 
       {/* Action Buttons Header */}
-      <Show when={threadMessages().length > 0}>
-        <div class="flex items-center justify-end gap-2 px-4 py-2 border-b border-surface-3">
+      <div
+        class="flex items-center justify-end gap-2 px-4 py-2 border-b border-surface-3"
+        data-testid="agent-chat-account-header"
+      >
+        <Show when={threadMessages().length > 0}>
           <Show when={!isPairedThread()}>
             <button
               type="button"
@@ -1763,9 +1766,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           >
             Clear
           </button>
-          <OAuthAccountSwitcher threadId={props.threadId} />
-        </div>
-      </Show>
+        </Show>
+        <OAuthAccountSwitcher threadId={props.threadId} />
+      </div>
 
       {/* Messages Area */}
       <div

--- a/tests/unit/agent-chat-oauth-switcher.test.ts
+++ b/tests/unit/agent-chat-oauth-switcher.test.ts
@@ -1,0 +1,25 @@
+// ABOUTME: Guards first-turn OAuth account selection in native agent chats.
+// ABOUTME: Ensures history-only actions cannot hide the account switcher on an empty thread.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("AgentChat OAuth account switcher", () => {
+  it("renders once outside the message-dependent history actions", () => {
+    const source = readFileSync(
+      resolve("src/components/chat/AgentChat.tsx"),
+      "utf8",
+    );
+    const headerStart = source.indexOf("data-testid=\"agent-chat-account-header\"");
+    const headerEnd = source.indexOf("{/* Messages Area */}", headerStart);
+    const header = source.slice(headerStart, headerEnd);
+
+    expect(headerStart).toBeGreaterThanOrEqual(0);
+    expect(headerEnd).toBeGreaterThan(headerStart);
+    expect(header.match(/<OAuthAccountSwitcher/g)).toHaveLength(1);
+    expect(header).toMatch(
+      /<Show when=\{threadMessages\(\)\.length > 0\}>[\s\S]*<\/Show>\s*<OAuthAccountSwitcher/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- render the OAuth account switcher before an agent thread has any messages
- keep compact/copy/download/clear controls message-dependent
- protect first-turn account selection with one focused regression test

## Reproduction fixed

A newly created native-agent thread previously hid the switcher inside `threadMessages().length > 0`. Users could not select a non-default identity before a first-turn publisher call.

## Network path

No network contract changes. The UI selection feeds the existing selected-account route:

`POST https://api.serendb.com/publishers/{publisher}/_mcp/tools/{tool}`

with `x-seren-oauth-connection-id`.

No Seren Core source changes.

## Validation

- focused regression: 1 passed
- full frontend unit suite: 326 files passed, 3 skipped; 2,346 tests passed, 15 skipped
- scoped formatting/diff/PII checks: clean
- reproduced in a real packaged macOS validation app with no mocks

Closes #2965