### PR TITLE
fix(chat): preserve Codex context after login Dismiss (#2967)

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -884,8 +884,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     });
 
     // Cold-start path (#1631): if the thread has no live session yet,
-    // turn on the thinking indicator and spawn synchronously so the user
-    // bubble + dots appear before the first stream chunk arrives.
+    // turn on the thinking indicator and resume synchronously so the user
+    // bubble + dots appear before the first stream chunk arrives. Resuming
+    // preserves persisted history and provider context after Login → Dismiss.
     const thread = activeAgentThread();
     if (!hasSession()) {
       if (!trimmed) {
@@ -910,10 +911,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       agentStore.setTurnInFlight(thread.id, true);
       agentStore.armRestartTimer(thread.id, 60_000, "spawn_failed");
       try {
-        const sid = await agentStore.spawnSession(
-          fileTreeState.rootPath,
-          lockedAgentType(),
-          { localSessionId: thread.id },
+        const sid = await agentStore.resumeAgentConversation(
+          thread.id,
+          thread.projectRoot || fileTreeState.rootPath,
         );
         // User pressed Stop mid-spawn — abortTurn flipped turnInFlight off.
         // Honor the cancel: terminate the spawn we just created (if any) and

--- a/tests/unit/chat-empties-after-login-2097.test.ts
+++ b/tests/unit/chat-empties-after-login-2097.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: #2097 regression — Login / Restart Session must resume the active
-// ABOUTME: thread from SQLite instead of cold-spawning a fresh bare session.
+// ABOUTME: Login recovery must keep agent threads bound to durable history.
+// ABOUTME: Guards explicit restart and post-dismiss cold-start paths.
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -32,5 +32,23 @@ describe("#2097 — startSession resumes the active thread", () => {
     // Pre-fix the body unconditionally called agentStore.spawnSession(cwd, agentType),
     // which dropped the thread binding and left messages stranded in SQLite.
     expect(startSessionBody).not.toContain("agentStore.spawnSession(");
+  });
+});
+
+describe("#2967 — post-login cold-start resumes the active thread", () => {
+  const sendMessageIdx = agentChatSource.indexOf("const sendMessage = async");
+  const coldStartEnd = agentChatSource.indexOf(
+    "// Require text content even when images are attached",
+    sendMessageIdx,
+  );
+  const coldStartBody = agentChatSource.slice(sendMessageIdx, coldStartEnd);
+
+  it("resumes the persisted conversation instead of bare-spawning without history", () => {
+    expect(sendMessageIdx).toBeGreaterThan(0);
+    expect(coldStartEnd).toBeGreaterThan(sendMessageIdx);
+    expect(coldStartBody).toMatch(
+      /resumeAgentConversation\(\s*thread\.id,\s*thread\.projectRoot \|\| fileTreeState\.rootPath,?\s*\)/,
+    );
+    expect(coldStartBody).not.toContain("agentStore.spawnSession(");
   });
 });


### PR DESCRIPTION
## Summary

Closes #2967.

After Codex authentication, choosing the green **Dismiss** action leaves the selected thread without a live session. The next Send previously bare-spawned with only `localSessionId`, omitting the stored Codex thread, persisted transcript, original working directory, model, permission mode, and bootstrap context. The first new live message then superseded the SQLite display fallback, so prior chat history disappeared and the agent continued without context.

The cold-start send branch now delegates to `resumeAgentConversation(thread.id, fallbackCwd)`, the same durable restoration path already used by Login then Start Session and explicit Restart Session.

## Scope

- One production behavior change in `AgentChat.sendMessage`.
- One focused regression guard added beside the existing Login/history test.
- Existing turn timer, duplicate-spawn guard, cancel-during-spawn guard, and final prompt dispatch are unchanged.

## Code-path audit

- Login handlers terminate the expired session and set `awaitingLogin`.
- Start Session already resumes through `resumeAgentConversation` after #2097/#2098.
- Dismiss intentionally hides the banner without starting a session after #448/#449.
- The exposed composer from #2517/#2523 then reaches the no-live-session cold-start branch.
- The prior bare spawn did not restore provider or local context.
- The durable display fallback from #2499/#2501 cannot preserve the full view once a non-empty partial live session takes precedence.

## Network path audit

No Seren publisher or HTTP API slug is used or changed. Login is local IPC `provider_launch_login` to the provider runtime, which resolves the installed Codex binary and launches `codex login`. Resume reads local SQLite and invokes local runtime command `provider_spawn` with the stored Codex thread ID when present. The Codex CLI owns its upstream authentication and model traffic.

## Validation before PR

- `pnpm exec vitest run tests/unit/chat-empties-after-login-2097.test.ts tests/unit/agent-history-persistence.test.ts tests/unit/agent-predictive-compaction.test.ts tests/unit/thread-store.test.ts` — 67 passed.
- `pnpm test` — 2,347 passed, 15 skipped.
- `pnpm check` — exits clean with the existing 48 warnings outside this diff.
- `pnpm build` — passed.
- `cargo check` — passed.
- `cargo test --lib` — 913 passed, 2 environment-dependent tests ignored.
- `pnpm exec tsc --noEmit` — unchanged main baseline: identical pre-existing errors in both main and this branch; no changed file reports an error.
- Staged credential/PII scan — no matches.

## Post-PR walkthrough

A real macOS Tauri/provider-runtime walkthrough with the installed Codex CLI will exercise an established thread, real provider-session loss, and the next-send resume path without mocks. Any newly observed regression will be classified and handled under the issue/branch workflow before merge.
