### PR TITLE
fix(agent): enable paired conversation forks

### DIFF
--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -43,9 +43,16 @@ export interface AgentOAuthRouting {
 }
 
 export function supportsConversationFork(agentType: AgentType): boolean {
-  // Paired threads span two inner sessions; forking one coherent copy is
-  // not supported.
-  return agentType !== "claude-codex";
+  // Provider-native forking is narrower (Claude only), but every agent can
+  // branch through the fresh-session transcript bootstrap. Paired threads use
+  // that path to start a new coordinated planner/executor pair.
+  return (
+    agentType === "claude-code" ||
+    agentType === "codex" ||
+    agentType === "gemini" ||
+    agentType === "claude-codex" ||
+    agentType === "lmstudio"
+  );
 }
 
 export function supportsNativeProviderFork(agentType: AgentType): boolean {
@@ -289,6 +296,37 @@ export interface PairedTranscriptEvent {
 export interface PairedSpawnConfig {
   planner?: { modelId?: string; effort?: string; serviceTier?: string };
   executor?: { modelId?: string; effort?: string; serviceTier?: string };
+}
+
+/** Capture only explicit paired role pins that a fresh session can restore. */
+export function pairedSpawnConfigFromStatus(
+  paired?: PairedStatus,
+): PairedSpawnConfig | undefined {
+  if (!paired) return undefined;
+
+  const roleConfig = (
+    role: PairedRoleStatus,
+  ):
+    | { modelId?: string; effort?: string; serviceTier?: string }
+    | undefined => {
+    const config = {
+      ...(role.pinnedModelId ? { modelId: role.pinnedModelId } : {}),
+      ...(role.pinnedEffort ? { effort: role.pinnedEffort } : {}),
+      ...(role.pinnedServiceTier
+        ? { serviceTier: role.pinnedServiceTier }
+        : {}),
+    };
+    return Object.keys(config).length > 0 ? config : undefined;
+  };
+
+  const planner = roleConfig(paired.planner);
+  const executor = roleConfig(paired.executor);
+  return planner || executor
+    ? {
+        ...(planner ? { planner } : {}),
+        ...(executor ? { executor } : {}),
+      }
+    : undefined;
 }
 
 export interface SessionStatusEvent {

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -4409,6 +4409,9 @@ export const agentStore = {
           pendingBootstrapMessages: bootstrapPromptContext
             ? session.messages
             : undefined,
+          pairedConfig: providerService.pairedSpawnConfigFromStatus(
+            session.paired,
+          ),
         }),
       ).catch((error) => {
         console.warn("Failed to persist agent bootstrap context", error);
@@ -6308,29 +6311,7 @@ export const agentStore = {
     const conversationId = session?.conversationId;
     if (!conversationId) return;
 
-    const roleConfig = (
-      role: PairedStatus["planner"],
-    ):
-      | { modelId?: string; effort?: string; serviceTier?: string }
-      | undefined => {
-      const config = {
-        ...(role.pinnedModelId ? { modelId: role.pinnedModelId } : {}),
-        ...(role.pinnedEffort ? { effort: role.pinnedEffort } : {}),
-        ...(role.pinnedServiceTier
-          ? { serviceTier: role.pinnedServiceTier }
-          : {}),
-      };
-      return Object.keys(config).length > 0 ? config : undefined;
-    };
-    const planner = roleConfig(paired.planner);
-    const executor = roleConfig(paired.executor);
-    const pairedConfig: PairedSpawnConfig | undefined =
-      planner || executor
-        ? {
-            ...(planner ? { planner } : {}),
-            ...(executor ? { executor } : {}),
-          }
-        : undefined;
+    const pairedConfig = providerService.pairedSpawnConfigFromStatus(paired);
 
     const serialized = JSON.stringify(pairedConfig ?? null);
     if (pairedConfigPersisted.get(conversationId) === serialized) return;
@@ -8273,6 +8254,10 @@ export const agentStore = {
 
     const agentType = session.info.agentType;
     const cwd = session.cwd;
+    const newConversationId = crypto.randomUUID();
+    const pairedConfig = providerService.pairedSpawnConfigFromStatus(
+      session.paired,
+    );
 
     // 1. Collect messages up to the fork point.
     const allMessages = session.messages;
@@ -8283,7 +8268,15 @@ export const agentStore = {
       );
       return null;
     }
-    const forkedMessages = allMessages.slice(0, forkIndex + 1);
+    const forkedMessages = allMessages.slice(0, forkIndex + 1).map((message) =>
+      agentType === "claude-codex" &&
+      message.id === `paired-declaration-${session.conversationId}`
+        ? {
+            ...message,
+            id: `paired-declaration-${newConversationId}`,
+          }
+        : message,
+    );
     const isHeadFork = forkIndex === allMessages.length - 1;
     const useNativeFork =
       providerService.supportsNativeProviderFork(agentType) && isHeadFork;
@@ -8345,7 +8338,6 @@ export const agentStore = {
     }
 
     // 2. Create a new local conversation in SQLite.
-    const newConversationId = crypto.randomUUID();
     const forkTitle = `Fork of ${session.title ?? "Agent"}`;
     try {
       await createAgentConversation(
@@ -8360,6 +8352,7 @@ export const agentStore = {
           pendingBootstrapMessages: bootstrapPromptContext
             ? forkedMessages
             : undefined,
+          pairedConfig,
         }) ?? undefined,
       );
     } catch (err) {
@@ -8376,6 +8369,7 @@ export const agentStore = {
       restoredMessages: forkedMessages,
       bootstrapPromptContext,
       initialModelId: session.currentModelId,
+      paired: pairedConfig,
     });
 
     if (!newSessionId) {

--- a/tests/services/providers.test.ts
+++ b/tests/services/providers.test.ts
@@ -1,7 +1,12 @@
 import { onRuntimeEvent } from "@/lib/browser-local-runtime";
 import {
+  pairedSpawnConfigFromStatus,
   subscribeToAllEvents,
   subscribeToSession,
+  supportsConversationFork,
+  supportsNativeProviderFork,
+  type AgentType,
+  type PairedStatus,
   type UnlistenFn,
 } from "@/services/providers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,6 +18,56 @@ vi.mock("@/lib/browser-local-runtime", () => ({
 }));
 
 const onRuntimeEventMock = vi.mocked(onRuntimeEvent);
+
+describe("provider fork capabilities", () => {
+  it("supports conversation branches for every desktop agent type", () => {
+    const agentTypes: AgentType[] = [
+      "claude-code",
+      "codex",
+      "gemini",
+      "claude-codex",
+      "lmstudio",
+    ];
+
+    expect(agentTypes.every(supportsConversationFork)).toBe(true);
+    expect(agentTypes.filter(supportsNativeProviderFork)).toEqual([
+      "claude-code",
+    ]);
+  });
+
+  it("copies explicit paired role pins into a fresh-session config", () => {
+    const paired = {
+      state: "idle",
+      activeRole: null,
+      planner: {
+        role: "planner",
+        label: "Claude",
+        agentType: "claude-code",
+        defaultModelLabel: "Claude Default",
+        pinnedModelId: "planner-model",
+        pinnedEffort: "high",
+      },
+      executor: {
+        role: "executor",
+        label: "Codex",
+        agentType: "codex",
+        defaultModelLabel: "Codex Recommended",
+        pinnedModelId: "executor-model",
+        pinnedEffort: "medium",
+        pinnedServiceTier: "fast",
+      },
+    } satisfies PairedStatus;
+
+    expect(pairedSpawnConfigFromStatus(paired)).toEqual({
+      planner: { modelId: "planner-model", effort: "high" },
+      executor: {
+        modelId: "executor-model",
+        effort: "medium",
+        serviceTier: "fast",
+      },
+    });
+  });
+});
 
 function mockRuntimeSubscriptions(failOnCall?: number) {
   const unlisteners: Array<ReturnType<typeof vi.fn>> = [];

--- a/tests/unit/paired-agent-fork.test.ts
+++ b/tests/unit/paired-agent-fork.test.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Critical regression guards for #2971 — paired threads can fork.
+// ABOUTME: The fresh pair keeps its declaration identity and explicit role pins.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentStoreSource = readFileSync(
+  resolve("src/stores/agent.store.ts"),
+  "utf-8",
+);
+const forkStart = agentStoreSource.indexOf("async forkConversation(");
+const forkEnd = agentStoreSource.indexOf(
+  "addErrorMessage(sessionId: string",
+  forkStart,
+);
+const forkBody = agentStoreSource.slice(forkStart, forkEnd);
+
+describe("#2971 — paired agent conversation fork", () => {
+  it("carries paired role pins through conversation metadata and spawn", () => {
+    expect(forkStart).toBeGreaterThan(0);
+    expect(forkBody).toContain("pairedSpawnConfigFromStatus(");
+    expect(forkBody).toContain("session.paired");
+    expect(forkBody).toMatch(/pendingBootstrapMessages:[\s\S]*pairedConfig,/);
+    expect(forkBody).toMatch(/spawnSession\([\s\S]*paired: pairedConfig,/);
+  });
+
+  it("remaps the setup declaration to the forked conversation", () => {
+    expect(forkBody).toContain(
+      "message.id === `paired-declaration-${session.conversationId}`",
+    );
+    expect(forkBody).toContain(
+      "id: `paired-declaration-${newConversationId}`",
+    );
+  });
+
+  it("does not erase paired role pins when bootstrap context is consumed", () => {
+    const setterStart = agentStoreSource.indexOf(
+      "setBootstrapPromptContext(\n",
+    );
+    const setterEnd = agentStoreSource.indexOf(
+      "clearBootstrapPromptContext(sessionId: string)",
+      setterStart,
+    );
+    const setterBody = agentStoreSource.slice(setterStart, setterEnd);
+
+    expect(setterStart).toBeGreaterThan(0);
+    expect(setterBody).toContain("pairedSpawnConfigFromStatus(");
+    expect(setterBody).toContain("session.paired");
+  });
+});


### PR DESCRIPTION
## Summary

- expose the per-message Fork action for Claude + Codex threads
- branch paired threads through the existing fresh-session transcript bootstrap while keeping native fork limited to standalone Claude
- preserve planner/executor model, effort, and service-tier pins in fork metadata and spawn configuration
- remap the paired setup declaration to the forked conversation so it updates in place instead of duplicating
- preserve paired configuration when the one-shot bootstrap context is consumed

Closes #2971

## Audited path

AgentChat Fork action -> threadStore.forkAgentThread -> agentStore.forkConversation -> local SQLite conversation -> provider_spawn -> paired runtime -> fresh Claude planner and Codex executor sessions.

The fork action has no publisher slug or third-party HTTP request. It uses the local runtime bridge; normal model traffic starts only after a later user prompt.

## Validation before PR

- pnpm test: 2,349 passed, 15 skipped
- pnpm lint: passed (pre-existing warnings only)
- pnpm build: passed
- cargo test --manifest-path src-tauri/Cargo.toml: 914 passed, 2 ignored
- focused fork regression suite: 18 passed

## Post-PR validation still required

- live, no-mock macOS app walkthrough for paired thread creation, fork visibility, branch transcript/config preservation, follow-up execution, and source-thread integrity
- required CI checks
