### PR TITLE
fix(oauth): keep agent threads available during account-list outages

### DIFF
--- a/src/components/chat/OAuthAccountSwitcher.tsx
+++ b/src/components/chat/OAuthAccountSwitcher.tsx
@@ -16,7 +16,6 @@ import { humanizeOAuthProviderSlug } from "@/lib/oauth-provider-resolution";
 import { listenForOAuthCallback } from "@/lib/tauri-bridge";
 import {
   connectPublisher,
-  listConnectedPublishers,
   setDefaultOAuthConnection,
 } from "@/services/publisher-oauth";
 import {
@@ -28,6 +27,7 @@ import {
   resolveThreadOAuthConnection,
   setThreadOAuthConnectionId,
 } from "@/stores/oauth-account.store";
+import { loadOAuthAccountSwitcherState } from "./oauth-account-switcher-load";
 
 interface OAuthAccountSwitcherProps {
   threadId?: string | null;
@@ -58,8 +58,9 @@ export const OAuthAccountSwitcher: Component<OAuthAccountSwitcherProps> = (
   >(null);
   let rootRef: HTMLDivElement | undefined;
   let connectTimeout: ReturnType<typeof setTimeout> | null = null;
-  const [connections] = createResource(oauthConnectionsRevision, async () =>
-    listConnectedPublishers(),
+  const [accountLoad, { refetch: refetchAccounts }] = createResource(
+    oauthConnectionsRevision,
+    loadOAuthAccountSwitcherState,
   );
 
   onMount(() => {
@@ -102,7 +103,7 @@ export const OAuthAccountSwitcher: Component<OAuthAccountSwitcherProps> = (
   });
 
   const groups = createMemo<ProviderAccountGroup[]>(() => {
-    const allConnections = connections() ?? [];
+    const allConnections = accountLoad()?.connections ?? [];
     const providerSlugs = Array.from(
       new Set(
         allConnections
@@ -178,7 +179,35 @@ export const OAuthAccountSwitcher: Component<OAuthAccountSwitcherProps> = (
   };
 
   return (
-    <Show when={primaryConnection()}>
+    <Show
+      when={primaryConnection()}
+      fallback={
+        <Show when={accountLoad()?.error}>
+          {(message) => (
+            <div
+              class="fixed right-4 top-14 z-50 w-[300px] max-w-[calc(100vw-2rem)] rounded-lg border border-destructive/40 bg-background p-3 text-left shadow-[var(--shadow-lg)]"
+              role="alert"
+              aria-live="polite"
+              data-testid="oauth-account-load-error"
+            >
+              <div class="text-[0.8rem] font-semibold text-foreground">
+                Couldn&apos;t load connected accounts
+              </div>
+              <div class="mt-1 text-[0.75rem] text-muted-foreground">
+                {message()}
+              </div>
+              <button
+                type="button"
+                class="mt-2 text-[0.75rem] font-medium text-foreground underline underline-offset-2 hover:text-muted-foreground"
+                onClick={() => void refetchAccounts()}
+              >
+                Retry
+              </button>
+            </div>
+          )}
+        </Show>
+      }
+    >
       {(connection) => (
         <div ref={rootRef} class="relative">
           <button

--- a/src/components/chat/oauth-account-switcher-load.ts
+++ b/src/components/chat/oauth-account-switcher-load.ts
@@ -1,0 +1,27 @@
+// ABOUTME: Contains optional OAuth account discovery failures inside the chat header.
+// ABOUTME: Keeps transient connection-list outages from rejecting a render resource.
+
+import { listConnectedPublishers } from "@/services/publisher-oauth";
+import type { OAuthConnection } from "@/stores/oauth-account.store";
+
+export const OAUTH_ACCOUNT_LOAD_ERROR =
+  "Connected accounts are temporarily unavailable. Chat remains available.";
+
+export interface OAuthAccountLoadState {
+  connections: OAuthConnection[];
+  error: string | null;
+}
+
+export async function loadOAuthAccountSwitcherState(): Promise<OAuthAccountLoadState> {
+  try {
+    return {
+      connections: await listConnectedPublishers(),
+      error: null,
+    };
+  } catch {
+    return {
+      connections: [],
+      error: OAUTH_ACCOUNT_LOAD_ERROR,
+    };
+  }
+}

--- a/tests/unit/oauth-account-switcher-load.test.ts
+++ b/tests/unit/oauth-account-switcher-load.test.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Guards #2973 so connected-account outages cannot blank agent threads.
+// ABOUTME: Verifies the optional fetch degrades locally with a retryable notice.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listConnectedPublishers: vi.fn(),
+}));
+
+vi.mock("@/services/publisher-oauth", () => ({
+  listConnectedPublishers: mocks.listConnectedPublishers,
+}));
+
+describe("OAuthAccountSwitcher connection loading (#2973)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("contains a rejected account fetch as an empty, non-fatal state", async () => {
+    mocks.listConnectedPublishers.mockRejectedValue(
+      new Error("private transport detail"),
+    );
+    const { loadOAuthAccountSwitcherState, OAUTH_ACCOUNT_LOAD_ERROR } =
+      await import("@/components/chat/oauth-account-switcher-load");
+
+    await expect(loadOAuthAccountSwitcherState()).resolves.toEqual({
+      connections: [],
+      error: OAUTH_ACCOUNT_LOAD_ERROR,
+    });
+  });
+
+  it("renders a retryable alert without exposing the transport error", () => {
+    const source = readFileSync(
+      resolve("src/components/chat/OAuthAccountSwitcher.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain('data-testid="oauth-account-load-error"');
+    expect(source).toContain('role="alert"');
+    expect(source).toContain("refetchAccounts()");
+    expect(source).not.toContain("private transport detail");
+  });
+});


### PR DESCRIPTION
Closes #2973

## Summary
- contain optional connected-account discovery failures inside the chat-header switcher
- keep the transcript/composer mounted and show a retryable non-fatal alert
- preserve successful account switching while preventing rejected Solid resources from reaching AppShell's main recovery boundary

## Root cause
`OAuthAccountSwitcher` directly exposed the rejecting `listConnectedPublishers()` promise as a Solid resource. Reading that resource during render re-threw a transport failure into `ShellSurfaceBoundary(surface="main")`. #2966 made the switcher mount for every new agent chat, increasing exposure to the latent failure path.

## Network/API path
No publisher slug is invoked by this feature path.

`AgentChat -> OAuthAccountSwitcher -> listConnectedPublishers -> listConnections -> GET https://api.serendb.com/oauth/connections`

The authenticated method/path is verified in generated Seren Core API metadata. This PR does not change the API contract or request; it changes only client-side failure containment and retry UI.

## Validation
- focused regression: 4 files passed, 16 tests passed
- full frontend unit suite: 328 files passed, 3 skipped; 2,351 tests passed, 15 skipped
- `pnpm build`
- `pnpm verify:frontend-build`
- `pnpm check` (passes; existing repository warnings only)
- `git diff --check`
- PII scan of changed files: clean
- GitHub CI matrix: passed frontend, lint, Rust, production-bundle E2E, and Linux/macOS/Windows builds ([run 29669087104](https://github.com/serenorg/seren-desktop/actions/runs/29669087104))
- real macOS `agent-send-recovery` walkthrough: passed for Claude and Codex, including 12 active-turn polls per provider
- real macOS `paired-agent-recovery` walkthrough: passed while the app logged a degraded OAuth-routing fetch; the thread and composer remained mounted

## Evidence handling
The raw user log and screenshot were not attached because they contain private workspace/thread information. Only sanitized error text appears in #2973.