### PR TITLE
feat(remote): add Happy bridge process and supervisor

### DIFF
--- a/bin/happy-bridge.mjs
+++ b/bin/happy-bridge.mjs
@@ -1,0 +1,149 @@
+// ABOUTME: Connects a future Happy layer to Seren Desktop's provider runtime.
+// ABOUTME: Reads one stdin config, logs only shapes, and owns clean shutdown.
+
+import readline from "node:readline";
+import WebSocket from "ws";
+
+const RPC_TIMEOUT_MS = 30_000;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function validateConfig(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail("config must be an object");
+  }
+
+  const providerRuntime = value.providerRuntime;
+  if (!providerRuntime || typeof providerRuntime !== "object") {
+    fail("config.providerRuntime is required");
+  }
+  if (typeof providerRuntime.host !== "string" || providerRuntime.host.length === 0) {
+    fail("config.providerRuntime.host is required");
+  }
+  if (!Number.isInteger(providerRuntime.port) || providerRuntime.port < 1 || providerRuntime.port > 65535) {
+    fail("config.providerRuntime.port must be a valid TCP port");
+  }
+  if (typeof providerRuntime.token !== "string" || providerRuntime.token.length === 0) {
+    fail("config.providerRuntime.token is required");
+  }
+  if (typeof value.relayUrl !== "string" || value.relayUrl.length === 0) {
+    fail("config.relayUrl is required");
+  }
+  if (typeof value.machineName !== "string" || value.machineName.length === 0) {
+    fail("config.machineName is required");
+  }
+  if (value.machineIdentity !== null && (typeof value.machineIdentity !== "object" || Array.isArray(value.machineIdentity))) {
+    fail("config.machineIdentity must be an object or null");
+  }
+
+  return value;
+}
+
+async function readConfig() {
+  const input = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  try {
+    for await (const line of input) {
+      if (!line.trim()) continue;
+      return validateConfig(JSON.parse(line));
+    }
+  } finally {
+    // Do not close stdin: Phase 2 will use the remaining stream for bookkeeping RPC.
+    input.pause();
+  }
+  fail("stdin closed before config was received");
+}
+
+class ProviderRuntimeClient {
+  constructor(config) {
+    this.config = config;
+    this.socket = null;
+    this.nextId = 0;
+    this.pending = new Map();
+  }
+
+  async connect() {
+    const { host, port, token } = this.config.providerRuntime;
+    this.socket = new WebSocket(`ws://${host}:${port}`);
+    this.socket.on("message", (raw) => this.handleMessage(raw));
+    await new Promise((resolve, reject) => {
+      this.socket.once("open", resolve);
+      this.socket.once("error", () => reject(new Error("provider runtime connection failed")));
+    });
+    await this.call("auth", { token });
+  }
+
+  handleMessage(raw) {
+    let message;
+    try {
+      message = JSON.parse(String(raw));
+    } catch {
+      return;
+    }
+    if (message.id === undefined || message.id === null) return;
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    clearTimeout(pending.timer);
+    if (message.error) {
+      pending.reject(new Error("provider runtime RPC failed"));
+    } else {
+      pending.resolve(message.result);
+    }
+  }
+
+  call(method, params = {}) {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("provider runtime socket is not open"));
+    }
+    const id = ++this.nextId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error("provider runtime RPC timed out"));
+      }, RPC_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      this.socket.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+    });
+  }
+
+  close() {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("provider runtime client closed"));
+    }
+    this.pending.clear();
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      this.socket.close(1000, "bridge shutdown");
+    }
+    this.socket = null;
+  }
+}
+
+let client = null;
+let shuttingDown = false;
+
+async function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  client?.close();
+  process.exitCode = 0;
+  setImmediate(() => process.exit(0));
+}
+
+process.once("SIGTERM", shutdown);
+process.once("SIGINT", shutdown);
+
+try {
+  const config = await readConfig();
+  client = new ProviderRuntimeClient(config);
+  await client.connect();
+  const result = await client.call("provider_list_sessions");
+  const sessions = Array.isArray(result) ? result : result?.sessions;
+  const sessionCount = Array.isArray(sessions) ? sessions.length : 0;
+  console.error(`happy-bridge: config ok, ${sessionCount} sessions`);
+} catch (error) {
+  console.error(`happy-bridge: ${error instanceof Error ? error.message : "startup failed"}`);
+  await shutdown();
+}

--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -76,6 +76,10 @@ function main(): void {
     path.join(repoRoot, "bin", "provider-runtime.mjs"),
     path.join(destDir, "provider-runtime.mjs"),
   );
+  cpSync(
+    path.join(repoRoot, "bin", "happy-bridge.mjs"),
+    path.join(destDir, "happy-bridge.mjs"),
+  );
   cpSync(browserLocalSrcDir, path.join(destDir, "browser-local"), {
     recursive: true,
   });

--- a/src-tauri/src/commands/happy_bridge.rs
+++ b/src-tauri/src/commands/happy_bridge.rs
@@ -1,0 +1,64 @@
+// ABOUTME: Tauri commands for enabling, disabling, and inspecting Happy Remote Access.
+// ABOUTME: Persists only the opt-in flag here; pairing credentials are handled separately.
+
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_store::StoreExt;
+
+use crate::happy_bridge::{HappyBridgeManager, HappyBridgeStatus};
+
+const SETTINGS_STORE: &str = "settings.json";
+const ENABLED_KEY: &str = "happy_bridge_enabled";
+
+fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), String> {
+    let store = app.store(SETTINGS_STORE).map_err(|err| err.to_string())?;
+    store.set(ENABLED_KEY, serde_json::json!(enabled));
+    store.save().map_err(|err| err.to_string())
+}
+
+fn is_enabled(app: &AppHandle) -> bool {
+    app.store(SETTINGS_STORE)
+        .ok()
+        .and_then(|store| store.get(ENABLED_KEY))
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+}
+
+#[tauri::command]
+pub async fn happy_bridge_enable(
+    app: AppHandle,
+    state: State<'_, HappyBridgeManager>,
+) -> Result<HappyBridgeStatus, String> {
+    set_enabled(&app, true)?;
+    if let Err(error) = state.start(&app).await {
+        let _ = set_enabled(&app, false);
+        return Err(error);
+    }
+    Ok(state.status().await)
+}
+
+#[tauri::command]
+pub async fn happy_bridge_disable(
+    app: AppHandle,
+    state: State<'_, HappyBridgeManager>,
+) -> Result<HappyBridgeStatus, String> {
+    set_enabled(&app, false)?;
+    state.stop(&app).await?;
+    Ok(state.status().await)
+}
+
+#[tauri::command]
+pub async fn happy_bridge_status(
+    state: State<'_, HappyBridgeManager>,
+) -> Result<HappyBridgeStatus, String> {
+    Ok(state.status().await)
+}
+
+pub async fn auto_start_if_enabled(app: AppHandle) {
+    if !is_enabled(&app) {
+        return;
+    }
+    let state = app.state::<HappyBridgeManager>();
+    if let Err(error) = state.start(&app).await {
+        log::error!("[HappyBridge] Auto-start failed: {error}");
+    }
+}

--- a/src-tauri/src/commands/happy_bridge.rs
+++ b/src-tauri/src/commands/happy_bridge.rs
@@ -53,6 +53,14 @@ pub async fn happy_bridge_status(
     Ok(state.status().await)
 }
 
+#[tauri::command]
+pub fn happy_bridge_reset_identity(
+    app: AppHandle,
+    state: State<'_, HappyBridgeManager>,
+) -> Result<(), String> {
+    state.delete_pairing_credential(&app)
+}
+
 pub async fn auto_start_if_enabled(app: AppHandle) {
     if !is_enabled(&app) {
         return;

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -1,0 +1,409 @@
+// ABOUTME: Supervises the local Happy bridge process and exposes lifecycle status.
+// ABOUTME: Builds its provider-runtime config in Rust so secrets never enter argv.
+
+use serde::Serialize;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::Mutex;
+
+pub const HAPPY_RELAY_URL: &str = "https://api.cluster-fluster.com";
+const MAX_RESTART_ATTEMPTS: u32 = 3;
+const MAX_BACKOFF_SECONDS: u64 = 30;
+const STOP_GRACE_PERIOD: Duration = Duration::from_secs(5);
+const STATUS_EVENT: &str = "happy-bridge://status";
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HappyBridgeState {
+    Stopped,
+    Starting,
+    Running,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HappyBridgeStatus {
+    pub state: HappyBridgeState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HappyBridgeConfig {
+    provider_runtime: ProviderRuntimeConnection,
+    relay_url: String,
+    machine_identity: Option<serde_json::Value>,
+    machine_name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ProviderRuntimeConnection {
+    host: String,
+    port: u16,
+    token: String,
+}
+
+struct HappyBridgeProcess {
+    child: Child,
+    _stdin: ChildStdin,
+}
+
+pub struct HappyBridgeManager {
+    process: Arc<Mutex<Option<HappyBridgeProcess>>>,
+    monitor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    status: Arc<Mutex<HappyBridgeStatus>>,
+}
+
+impl HappyBridgeManager {
+    pub fn new() -> Self {
+        Self {
+            process: Arc::new(Mutex::new(None)),
+            monitor_handle: Mutex::new(None),
+            status: Arc::new(Mutex::new(HappyBridgeStatus {
+                state: HappyBridgeState::Stopped,
+                detail: None,
+            })),
+        }
+    }
+
+    pub async fn start(&self, app: &AppHandle) -> Result<(), String> {
+        {
+            let mut guard = self.process.lock().await;
+            if let Some(process) = guard.as_mut() {
+                if process
+                    .child
+                    .try_wait()
+                    .map_err(|err| format!("Failed checking Happy bridge: {err}"))?
+                    .is_none()
+                {
+                    return Ok(());
+                }
+            }
+            *guard = None;
+        }
+
+        self.set_status(app, HappyBridgeState::Starting, None).await;
+        if let Err(error) = self.start_process(app).await {
+            self.set_status(app, HappyBridgeState::Error, Some(error.clone()))
+                .await;
+            return Err(error);
+        }
+
+        self.set_status(app, HappyBridgeState::Running, None).await;
+        self.ensure_monitor(app.clone()).await;
+        Ok(())
+    }
+
+    async fn start_process(&self, app: &AppHandle) -> Result<(), String> {
+        let provider_runtime = app
+            .state::<crate::provider_runtime::ProviderRuntimeState>()
+            .ensure_started(app)
+            .await?;
+        let node_binary = resolve_node_binary(app);
+        let bridge_entry = find_happy_bridge_mjs()?;
+        let config = HappyBridgeConfig {
+            provider_runtime: ProviderRuntimeConnection {
+                host: provider_runtime.host,
+                port: provider_runtime.port,
+                token: provider_runtime.token,
+            },
+            relay_url: HAPPY_RELAY_URL.to_string(),
+            machine_identity: None,
+            machine_name: "seren-desktop".to_string(),
+        };
+
+        let mut command = Command::new(node_binary);
+        command
+            .arg(&bridge_entry)
+            .kill_on_drop(true)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        crate::embedded_runtime::sanitize_spawn_env(&mut command);
+
+        #[cfg(windows)]
+        command.creation_flags(0x08000000);
+
+        let mut child = command
+            .spawn()
+            .map_err(|err| format!("Failed to spawn Happy bridge: {err}"))?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "Happy bridge stdin was not piped".to_string())?;
+        let encoded = serde_json::to_vec(&config)
+            .map_err(|err| format!("Failed to encode Happy bridge config: {err}"))?;
+        stdin
+            .write_all(&encoded)
+            .await
+            .map_err(|err| format!("Failed to write Happy bridge config: {err}"))?;
+        stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|err| format!("Failed to finish Happy bridge config: {err}"))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|err| format!("Failed to flush Happy bridge config: {err}"))?;
+
+        pipe_bridge_output(&mut child);
+        *self.process.lock().await = Some(HappyBridgeProcess {
+            child,
+            _stdin: stdin,
+        });
+        Ok(())
+    }
+
+    async fn ensure_monitor(&self, app: AppHandle) {
+        let mut guard = self.monitor_handle.lock().await;
+        if guard.as_ref().is_some_and(|handle| !handle.is_finished()) {
+            return;
+        }
+        guard.take();
+        let process = Arc::clone(&self.process);
+        let status = Arc::clone(&self.status);
+        *guard = Some(tokio::spawn(async move {
+            monitor_process(app, process, status).await;
+        }));
+    }
+
+    pub async fn stop(&self, app: &AppHandle) -> Result<(), String> {
+        if let Some(handle) = self.monitor_handle.lock().await.take() {
+            handle.abort();
+        }
+
+        let process = self.process.lock().await.take();
+        if let Some(mut process) = process {
+            terminate_child(&mut process.child).await?;
+        }
+        self.set_status(app, HappyBridgeState::Stopped, None).await;
+        Ok(())
+    }
+
+    pub async fn status(&self) -> HappyBridgeStatus {
+        self.status.lock().await.clone()
+    }
+
+    async fn set_status(&self, app: &AppHandle, state: HappyBridgeState, detail: Option<String>) {
+        let status = HappyBridgeStatus { state, detail };
+        *self.status.lock().await = status.clone();
+        let _ = app.emit(STATUS_EVENT, status);
+    }
+
+    pub fn kill_sync(&self) {
+        if let Ok(mut guard) = self.monitor_handle.try_lock() {
+            if let Some(handle) = guard.take() {
+                handle.abort();
+            }
+        }
+        if let Ok(mut guard) = self.process.try_lock() {
+            if let Some(process) = guard.as_ref() {
+                if let Some(pid) = process.child.id() {
+                    #[cfg(unix)]
+                    unsafe {
+                        libc::kill(pid as i32, libc::SIGKILL);
+                    }
+                    #[cfg(windows)]
+                    {
+                        use std::os::windows::process::CommandExt;
+                        let _ = std::process::Command::new("taskkill")
+                            .args(["/F", "/T", "/PID", &pid.to_string()])
+                            .creation_flags(0x08000000)
+                            .spawn();
+                    }
+                }
+            }
+            *guard = None;
+        }
+    }
+}
+
+impl Default for HappyBridgeManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+async fn monitor_process(
+    app: AppHandle,
+    process: Arc<Mutex<Option<HappyBridgeProcess>>>,
+    status: Arc<Mutex<HappyBridgeStatus>>,
+) {
+    loop {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let exited = {
+            let mut guard = process.lock().await;
+            match guard.as_mut() {
+                None => return,
+                Some(process) => match process.child.try_wait() {
+                    Ok(None) => false,
+                    Ok(Some(_)) => {
+                        *guard = None;
+                        true
+                    }
+                    Err(error) => {
+                        log::warn!("[HappyBridge] Failed checking process status: {error}");
+                        false
+                    }
+                },
+            }
+        };
+        if !exited {
+            continue;
+        }
+
+        for attempt in 0..MAX_RESTART_ATTEMPTS {
+            let delay = restart_delay(attempt);
+            {
+                let mut current = status.lock().await;
+                current.state = HappyBridgeState::Starting;
+                current.detail = Some(format!(
+                    "restart attempt {}/{}",
+                    attempt + 1,
+                    MAX_RESTART_ATTEMPTS
+                ));
+                let _ = app.emit(STATUS_EVENT, current.clone());
+            }
+            tokio::time::sleep(delay).await;
+
+            let manager = app.state::<HappyBridgeManager>();
+            match manager.start_process(&app).await {
+                Ok(()) => {
+                    let running = HappyBridgeStatus {
+                        state: HappyBridgeState::Running,
+                        detail: None,
+                    };
+                    *status.lock().await = running.clone();
+                    let _ = app.emit(STATUS_EVENT, running);
+                    break;
+                }
+                Err(error) if attempt + 1 == MAX_RESTART_ATTEMPTS => {
+                    let failed = HappyBridgeStatus {
+                        state: HappyBridgeState::Error,
+                        detail: Some(error),
+                    };
+                    *status.lock().await = failed.clone();
+                    let _ = app.emit(STATUS_EVENT, failed);
+                }
+                Err(error) => {
+                    log::warn!("[HappyBridge] Restart failed: {error}");
+                }
+            }
+        }
+    }
+}
+
+async fn terminate_child(child: &mut Child) -> Result<(), String> {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        unsafe {
+            libc::kill(pid as i32, libc::SIGTERM);
+        }
+    }
+
+    match tokio::time::timeout(STOP_GRACE_PERIOD, child.wait()).await {
+        Ok(Ok(_)) => Ok(()),
+        _ => child
+            .kill()
+            .await
+            .map_err(|err| format!("Failed to stop Happy bridge: {err}")),
+    }
+}
+
+fn restart_delay(attempt: u32) -> Duration {
+    let seconds = 2u64.saturating_pow(attempt).min(MAX_BACKOFF_SECONDS);
+    Duration::from_secs(seconds)
+}
+
+fn resolve_node_binary(app: &AppHandle) -> PathBuf {
+    if let Some(node_dir) = crate::embedded_runtime::discover_embedded_runtime(app).node_dir {
+        let candidate = if cfg!(target_os = "windows") {
+            node_dir.join("node.exe")
+        } else {
+            node_dir.join("node")
+        };
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    if cfg!(target_os = "windows") {
+        PathBuf::from("node.exe")
+    } else {
+        PathBuf::from("node")
+    }
+}
+
+fn find_happy_bridge_mjs() -> Result<PathBuf, String> {
+    let exe_dir = std::env::current_exe()
+        .map_err(|err| format!("Failed to get current exe path: {err}"))?
+        .parent()
+        .ok_or_else(|| "Failed to get exe directory".to_string())?
+        .to_path_buf();
+    let platform = crate::embedded_runtime::platform_subdir();
+    let candidates = [
+        exe_dir
+            .join("../Resources/embedded-runtime")
+            .join(&platform)
+            .join("provider-runtime/happy-bridge.mjs"),
+        exe_dir.join("../Resources/embedded-runtime/provider-runtime/happy-bridge.mjs"),
+        exe_dir
+            .join("embedded-runtime")
+            .join(&platform)
+            .join("provider-runtime/happy-bridge.mjs"),
+        exe_dir.join("embedded-runtime/provider-runtime/happy-bridge.mjs"),
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("embedded-runtime/provider-runtime/happy-bridge.mjs"),
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../bin/happy-bridge.mjs"),
+    ];
+    candidates
+        .iter()
+        .find(|candidate| candidate.exists())
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "happy-bridge.mjs not found in {}",
+                candidates
+                    .iter()
+                    .map(|candidate| candidate.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })
+}
+
+fn pipe_bridge_output(child: &mut Child) {
+    if let Some(stdout) = child.stdout.take() {
+        tauri::async_runtime::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(_line)) = lines.next_line().await {}
+        });
+    }
+    if let Some(stderr) = child.stderr.take() {
+        tauri::async_runtime::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                log::info!("[HappyBridge] {line}");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::restart_delay;
+    use std::time::Duration;
+
+    #[test]
+    fn restart_backoff_is_capped() {
+        assert_eq!(restart_delay(0), Duration::from_secs(1));
+        assert_eq!(restart_delay(1), Duration::from_secs(2));
+        assert_eq!(restart_delay(2), Duration::from_secs(4));
+        assert_eq!(restart_delay(10), Duration::from_secs(30));
+    }
+}

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -7,6 +7,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_store::StoreExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::Mutex;
@@ -16,6 +17,8 @@ const MAX_RESTART_ATTEMPTS: u32 = 3;
 const MAX_BACKOFF_SECONDS: u64 = 30;
 const STOP_GRACE_PERIOD: Duration = Duration::from_secs(5);
 const STATUS_EVENT: &str = "happy-bridge://status";
+const CREDENTIAL_STORE: &str = "happy_bridge.json";
+const CREDENTIAL_KEY: &str = "credential_blob";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -188,6 +191,35 @@ impl HappyBridgeManager {
 
     pub async fn status(&self) -> HappyBridgeStatus {
         self.status.lock().await.clone()
+    }
+
+    /// Store the opaque credential received during future pairing. This follows
+    /// the existing encrypted Tauri store pattern used by auth.rs; no bridge
+    /// identity is generated locally in Phase 1.
+    pub fn store_pairing_credential(
+        &self,
+        app: &AppHandle,
+        credential: &str,
+    ) -> Result<(), String> {
+        if credential.trim().is_empty() {
+            return Err("pairing credential must not be empty".to_string());
+        }
+        let store = app.store(CREDENTIAL_STORE).map_err(|err| err.to_string())?;
+        store.set(CREDENTIAL_KEY, serde_json::json!(credential));
+        store.save().map_err(|err| err.to_string())
+    }
+
+    pub fn load_pairing_credential(&self, app: &AppHandle) -> Result<Option<String>, String> {
+        let store = app.store(CREDENTIAL_STORE).map_err(|err| err.to_string())?;
+        Ok(store
+            .get(CREDENTIAL_KEY)
+            .and_then(|value| value.as_str().map(String::from)))
+    }
+
+    pub fn delete_pairing_credential(&self, app: &AppHandle) -> Result<(), String> {
+        let store = app.store(CREDENTIAL_STORE).map_err(|err| err.to_string())?;
+        store.delete(CREDENTIAL_KEY);
+        store.save().map_err(|err| err.to_string())
     }
 
     async fn set_status(&self, app: &AppHandle, state: HappyBridgeState, detail: Option<String>) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,7 @@ pub mod claude_memory;
 mod claude_setup;
 mod embedded_runtime;
 mod files;
+pub mod happy_bridge;
 mod mcp;
 pub mod messaging;
 mod oauth;
@@ -622,6 +623,7 @@ pub fn run() {
             .manage(orchestrator::eval::EvalState::new())
             .manage(orchestrator::tool_bridge::ToolResultBridge::new())
             .manage(provider_runtime::ProviderRuntimeState::new())
+            .manage(happy_bridge::HappyBridgeManager::new())
             .manage(std::sync::Arc::new(
                 commands::updater::ShutdownGuard::default(),
             ))
@@ -1289,6 +1291,9 @@ pub fn run() {
                 // Stop the provider runtime node process
                 if let Some(rt_state) = app.try_state::<provider_runtime::ProviderRuntimeState>() {
                     rt_state.kill_sync();
+                }
+                if let Some(happy_state) = app.try_state::<happy_bridge::HappyBridgeManager>() {
+                    happy_state.kill_sync();
                 }
                 // Stop an in-progress native recorder so a screen-capture child
                 // process is not orphaned and left recording the screen after

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1272,6 +1272,7 @@ pub fn run() {
             commands::happy_bridge::happy_bridge_enable,
             commands::happy_bridge::happy_bridge_disable,
             commands::happy_bridge::happy_bridge_status,
+            commands::happy_bridge::happy_bridge_reset_identity,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub mod commands {
     pub mod conversation_search;
     pub mod employees_archive;
     pub mod gateway_http;
+    pub mod happy_bridge;
     pub mod history_sync;
     pub mod indexing;
     pub mod memory;
@@ -939,6 +940,10 @@ pub fn run() {
                 ));
             }
 
+            tauri::async_runtime::spawn(commands::happy_bridge::auto_start_if_enabled(
+                app.handle().clone(),
+            ));
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -1263,6 +1268,10 @@ pub fn run() {
             commands::session::add_session_event,
             commands::session::get_session_events,
             commands::session::update_session_event_status,
+            // Happy Remote Access bridge
+            commands::happy_bridge::happy_bridge_enable,
+            commands::happy_bridge::happy_bridge_disable,
+            commands::happy_bridge::happy_bridge_status,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src/services/happyRemote.ts
+++ b/src/services/happyRemote.ts
@@ -1,0 +1,34 @@
+// ABOUTME: Frontend service for Happy Remote Access bridge lifecycle commands.
+// ABOUTME: Keeps all Tauri IPC and status-event wiring behind one typed module.
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+export type HappyRemoteState = "stopped" | "starting" | "running" | "error";
+
+export interface HappyRemoteStatus {
+  state: HappyRemoteState;
+  detail?: string;
+}
+
+const STATUS_EVENT = "happy-bridge://status";
+
+export async function enableRemoteAccess(): Promise<HappyRemoteStatus> {
+  return invoke<HappyRemoteStatus>("happy_bridge_enable");
+}
+
+export async function disableRemoteAccess(): Promise<HappyRemoteStatus> {
+  return invoke<HappyRemoteStatus>("happy_bridge_disable");
+}
+
+export async function getRemoteAccessStatus(): Promise<HappyRemoteStatus> {
+  return invoke<HappyRemoteStatus>("happy_bridge_status");
+}
+
+export function onStatusChange(
+  callback: (status: HappyRemoteStatus) => void,
+): Promise<UnlistenFn> {
+  return listen<HappyRemoteStatus>(STATUS_EVENT, (event) => {
+    callback(event.payload);
+  });
+}


### PR DESCRIPTION
Closes #2970

## Scope
Adds the Phase 1 bridge process, Rust supervisor, lifecycle commands, frontend service, embedded-runtime packaging, and opaque credential reset plumbing. The bridge is opt-in and sends its configuration over stdin; no Happy message sync is included in this phase.

## Real-app walkthrough
Run against the real macOS Tauri dev app with a temporary development identifier (no mock, local relay, or Docker server):

- `VITE_HAPPY_BRIDGE_WALKTHROUGH=1 SEREN_E2E_REMOTE_DEBUG_PORT=9230 pnpm tauri dev --config {"identifier":"com.seren.desktop.phase3"}`
- In-app service call: `[HappyWalkthrough] enabled state=running`
- Bridge stderr: `[HappyBridge] happy-bridge: config ok, 0 sessions`
- Redacted `ps` check: `node <worktree>/src-tauri/target/debug/embedded-runtime/provider-runtime/happy-bridge.mjs`; no credential appeared in argv.
- One crash test: `kill -9 <bridge-pid>`; a new bridge PID appeared and the bridge logged a second `config ok, 0 sessions` line.
- In-app service call: `[HappyWalkthrough] disabled state=stopped`; a subsequent process check found no bridge process.

The walkthrough harness was removed before this PR was opened.

## Verification
- `pnpm check` — pass; repository reports 48 pre-existing warnings.
- `pnpm build` — pass.
- `cargo check --manifest-path src-tauri/Cargo.toml` — pass.
- `cargo test --manifest-path src-tauri/Cargo.toml` — 914 passed, 2 ignored, 0 failed.

No new package or Cargo dependencies were added.