### PR TITLE
fix(agent): preserve explicit conversation titles

### DIFF
--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3367,6 +3367,9 @@ export const agentStore = {
           : null;
         const session: ActiveSession = {
           info,
+          // Only explicit titles belong in live state. Fresh conversations omit
+          // this option so their first user prompt can still derive the title.
+          title: opts?.conversationTitle,
           messages: opts?.restoredMessages ?? [],
           plan: [],
           pendingToolCalls: new Map(),

--- a/tests/unit/paired-agent-fork.test.ts
+++ b/tests/unit/paired-agent-fork.test.ts
@@ -15,6 +15,12 @@ const forkEnd = agentStoreSource.indexOf(
   forkStart,
 );
 const forkBody = agentStoreSource.slice(forkStart, forkEnd);
+const spawnStart = agentStoreSource.indexOf("async spawnSession(");
+const spawnEnd = agentStoreSource.indexOf(
+  "async resumeAgentConversation(",
+  spawnStart,
+);
+const spawnBody = agentStoreSource.slice(spawnStart, spawnEnd);
 
 describe("#2971 — paired agent conversation fork", () => {
   it("carries paired role pins through conversation metadata and spawn", () => {
@@ -47,5 +53,12 @@ describe("#2971 — paired agent conversation fork", () => {
     expect(setterStart).toBeGreaterThan(0);
     expect(setterBody).toContain("pairedSpawnConfigFromStatus(");
     expect(setterBody).toContain("session.paired");
+  });
+
+  it("preserves the explicit fork title in the live session", () => {
+    expect(spawnStart).toBeGreaterThan(0);
+    expect(forkBody).toContain("conversationTitle: forkTitle");
+    expect(spawnBody).toContain("title: opts?.conversationTitle,");
+    expect(spawnBody).not.toContain("title: conversationTitle,");
   });
 });


### PR DESCRIPTION
## Summary

- preserve explicitly supplied fork and resumed-conversation titles in live session state
- keep first-prompt title derivation unchanged for brand-new threads
- add one focused regression assertion for the paired-fork path

Closes #2974

## Validation

- `pnpm exec vitest run tests/unit/paired-agent-fork.test.ts tests/services/providers.test.ts` (10 passed)
- `pnpm test` (2,350 passed, 15 skipped)
- `pnpm lint` (passes with 48 pre-existing warnings outside this change)
- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml` (914 passed, 2 ignored)

## Functional finding

A real macOS Tauri walkthrough with live Claude + Codex sessions showed the fork title changing after its first prompt. No mocks were used. A repaired walkthrough will be attached as a sanitized result after this PR is raised.

## Network path

This title path has no outbound publisher or third-party API call. It is local UI state plus SQLite persistence.