### PR TITLE
feat(remote): add session seam and provider adapter

### DIFF
--- a/bin/happy-bridge.mjs
+++ b/bin/happy-bridge.mjs
@@ -1,133 +1,61 @@
-// ABOUTME: Connects a future Happy layer to Seren Desktop's provider runtime.
-// ABOUTME: Reads one stdin config, logs only shapes, and owns clean shutdown.
+// ABOUTME: Composes the provider source and supervisor channel for the bridge.
+// ABOUTME: It owns stdin lifecycle only; session mapping and RPC details live in modules.
 
 import readline from "node:readline";
-import WebSocket from "ws";
-
-const RPC_TIMEOUT_MS = 30_000;
-
-function fail(message) {
-  throw new Error(message);
-}
-
-function validateConfig(value) {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    fail("config must be an object");
-  }
-
-  const providerRuntime = value.providerRuntime;
-  if (!providerRuntime || typeof providerRuntime !== "object") {
-    fail("config.providerRuntime is required");
-  }
-  if (typeof providerRuntime.host !== "string" || providerRuntime.host.length === 0) {
-    fail("config.providerRuntime.host is required");
-  }
-  if (!Number.isInteger(providerRuntime.port) || providerRuntime.port < 1 || providerRuntime.port > 65535) {
-    fail("config.providerRuntime.port must be a valid TCP port");
-  }
-  if (typeof providerRuntime.token !== "string" || providerRuntime.token.length === 0) {
-    fail("config.providerRuntime.token is required");
-  }
-  if (typeof value.relayUrl !== "string" || value.relayUrl.length === 0) {
-    fail("config.relayUrl is required");
-  }
-  if (typeof value.machineName !== "string" || value.machineName.length === 0) {
-    fail("config.machineName is required");
-  }
-  if (value.machineIdentity !== null && (typeof value.machineIdentity !== "object" || Array.isArray(value.machineIdentity))) {
-    fail("config.machineIdentity must be an object or null");
-  }
-
-  return value;
-}
-
-async function readConfig() {
-  const input = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
-  try {
-    for await (const line of input) {
-      if (!line.trim()) continue;
-      return validateConfig(JSON.parse(line));
-    }
-  } finally {
-    // Do not close stdin: Phase 2 will use the remaining stream for bookkeeping RPC.
-    input.pause();
-  }
-  fail("stdin closed before config was received");
-}
-
-class ProviderRuntimeClient {
-  constructor(config) {
-    this.config = config;
-    this.socket = null;
-    this.nextId = 0;
-    this.pending = new Map();
-  }
-
-  async connect() {
-    const { host, port, token } = this.config.providerRuntime;
-    this.socket = new WebSocket(`ws://${host}:${port}`);
-    this.socket.on("message", (raw) => this.handleMessage(raw));
-    await new Promise((resolve, reject) => {
-      this.socket.once("open", resolve);
-      this.socket.once("error", () => reject(new Error("provider runtime connection failed")));
-    });
-    await this.call("auth", { token });
-  }
-
-  handleMessage(raw) {
-    let message;
-    try {
-      message = JSON.parse(String(raw));
-    } catch {
-      return;
-    }
-    if (message.id === undefined || message.id === null) return;
-    const pending = this.pending.get(message.id);
-    if (!pending) return;
-    this.pending.delete(message.id);
-    clearTimeout(pending.timer);
-    if (message.error) {
-      pending.reject(new Error("provider runtime RPC failed"));
-    } else {
-      pending.resolve(message.result);
-    }
-  }
-
-  call(method, params = {}) {
-    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
-      return Promise.reject(new Error("provider runtime socket is not open"));
-    }
-    const id = ++this.nextId;
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error("provider runtime RPC timed out"));
-      }, RPC_TIMEOUT_MS);
-      this.pending.set(id, { resolve, reject, timer });
-      this.socket.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
-    });
-  }
-
-  close() {
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
-      pending.reject(new Error("provider runtime client closed"));
-    }
-    this.pending.clear();
-    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-      this.socket.close(1000, "bridge shutdown");
-    }
-    this.socket = null;
-  }
-}
+import {
+  createProviderRuntimeClient,
+  createProviderSource,
+  validateBridgeConfig,
+} from "./happy-bridge/provider-source.mjs";
+import { createSupervisorChannel } from "./happy-bridge/supervisor-channel.mjs";
 
 let client = null;
+let input = null;
+let supervisorChannel = null;
 let shuttingDown = false;
+
+function startInputReader() {
+  input = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  let configReceived = false;
+  let resolveConfig;
+  let rejectConfig;
+  const queuedResponses = [];
+  const configPromise = new Promise((resolve, reject) => {
+    resolveConfig = resolve;
+    rejectConfig = reject;
+  });
+
+  input.on("line", (line) => {
+    if (!configReceived) {
+      if (!line.trim()) return;
+      configReceived = true;
+      try {
+        resolveConfig(validateBridgeConfig(JSON.parse(line)));
+      } catch (error) {
+        rejectConfig(error);
+      }
+      return;
+    }
+
+    if (supervisorChannel) {
+      supervisorChannel.handleLine(line);
+    } else {
+      queuedResponses.push(line);
+    }
+  });
+  input.once("close", () => {
+    if (!configReceived) rejectConfig(new Error("stdin closed before config was received"));
+  });
+
+  return { configPromise, queuedResponses };
+}
 
 async function shutdown() {
   if (shuttingDown) return;
   shuttingDown = true;
   client?.close();
+  supervisorChannel?.close();
+  input?.close();
   process.exitCode = 0;
   setImmediate(() => process.exit(0));
 }
@@ -136,13 +64,20 @@ process.once("SIGTERM", shutdown);
 process.once("SIGINT", shutdown);
 
 try {
-  const config = await readConfig();
-  client = new ProviderRuntimeClient(config);
+  const { configPromise, queuedResponses } = startInputReader();
+  const config = await configPromise;
+  supervisorChannel = createSupervisorChannel();
+  for (const line of queuedResponses) supervisorChannel.handleLine(line);
+
+  client = createProviderRuntimeClient(config);
   await client.connect();
-  const result = await client.call("provider_list_sessions");
-  const sessions = Array.isArray(result) ? result : result?.sessions;
-  const sessionCount = Array.isArray(sessions) ? sessions.length : 0;
-  console.error(`happy-bridge: config ok, ${sessionCount} sessions`);
+  const source = createProviderSource({
+    client,
+    config,
+    debugLog: (message) => console.error(`happy-bridge: ${message}`),
+  });
+  const sessions = await source.listSessions();
+  console.error(`happy-bridge: config ok, ${sessions.length} sessions`);
 } catch (error) {
   console.error(`happy-bridge: ${error instanceof Error ? error.message : "startup failed"}`);
   await shutdown();

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -1,0 +1,231 @@
+// ABOUTME: Adapts the existing provider-runtime WebSocket to neutral sessions.
+// ABOUTME: This is the only Phase 2 source implementation; it imports no Happy code.
+
+import WebSocket from "ws";
+
+const RPC_TIMEOUT_MS = 30_000;
+
+const PROVIDER_EVENT_KINDS = new Map([
+  ["provider://message-chunk", "assistant-delta"],
+  ["provider://user-message", "user-message"],
+  ["provider://tool-call", "tool-start"],
+  ["provider://tool-result", "tool-end"],
+  ["provider://diff", "file-diff"],
+  ["provider://diff-proposal", "diff-proposal"],
+  ["provider://diff-proposal-resolved", "diff-proposal-resolved"],
+  ["provider://plan-update", "plan-update"],
+  ["provider://permission-request", "permission-request"],
+  ["provider://permission-resolved", "permission-resolved"],
+  ["provider://prompt-complete", "turn-complete"],
+  ["provider://session-status", "status"],
+  ["provider://error", "error"],
+]);
+
+export function validateBridgeConfig(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("config must be an object");
+  }
+
+  const providerRuntime = value.providerRuntime;
+  if (!providerRuntime || typeof providerRuntime !== "object") {
+    throw new Error("config.providerRuntime is required");
+  }
+  if (typeof providerRuntime.host !== "string" || providerRuntime.host.length === 0) {
+    throw new Error("config.providerRuntime.host is required");
+  }
+  if (
+    !Number.isInteger(providerRuntime.port) ||
+    providerRuntime.port < 1 ||
+    providerRuntime.port > 65535
+  ) {
+    throw new Error("config.providerRuntime.port must be a valid TCP port");
+  }
+  if (typeof providerRuntime.token !== "string" || providerRuntime.token.length === 0) {
+    throw new Error("config.providerRuntime.token is required");
+  }
+  if (typeof value.relayUrl !== "string" || value.relayUrl.length === 0) {
+    throw new Error("config.relayUrl is required");
+  }
+  if (typeof value.machineName !== "string" || value.machineName.length === 0) {
+    throw new Error("config.machineName is required");
+  }
+  if (
+    value.machineIdentity !== null &&
+    (typeof value.machineIdentity !== "object" || Array.isArray(value.machineIdentity))
+  ) {
+    throw new Error("config.machineIdentity must be an object or null");
+  }
+
+  return value;
+}
+
+export function translateProviderEvent(method, params = {}) {
+  const kind = PROVIDER_EVENT_KINDS.get(method);
+  if (!kind || typeof params?.sessionId !== "string") return null;
+
+  const { sessionId, ...payload } = params;
+  return { kind, sessionId, payload };
+}
+
+class ProviderRuntimeClient {
+  constructor(config) {
+    this.config = config;
+    this.socket = null;
+    this.nextId = 0;
+    this.pending = new Map();
+    this.notificationListeners = new Set();
+  }
+
+  async connect() {
+    const { host, port, token } = this.config.providerRuntime;
+    this.socket = new WebSocket(`ws://${host}:${port}`);
+    this.socket.on("message", (raw) => this.handleMessage(raw));
+    await new Promise((resolve, reject) => {
+      this.socket.once("open", resolve);
+      this.socket.once("error", () => reject(new Error("provider runtime connection failed")));
+    });
+    await this.call("auth", { token });
+  }
+
+  handleMessage(raw) {
+    let message;
+    try {
+      message = JSON.parse(String(raw));
+    } catch {
+      return;
+    }
+
+    if (typeof message.method === "string") {
+      for (const listener of this.notificationListeners) {
+        listener(message.method, message.params ?? {});
+      }
+      return;
+    }
+
+    if (message.id === undefined || message.id === null) return;
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    clearTimeout(pending.timer);
+    if (message.error) {
+      pending.reject(new Error(message.error.message ?? "provider runtime RPC failed"));
+    } else {
+      pending.resolve(message.result);
+    }
+  }
+
+  subscribeNotifications(listener) {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  call(method, params = {}) {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("provider runtime socket is not open"));
+    }
+
+    const id = ++this.nextId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error("provider runtime RPC timed out"));
+      }, RPC_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      this.socket.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+    });
+  }
+
+  close() {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("provider runtime client closed"));
+    }
+    this.pending.clear();
+    this.notificationListeners.clear();
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      this.socket.close(1000, "bridge shutdown");
+    }
+    this.socket = null;
+  }
+}
+
+export function createProviderRuntimeClient(config) {
+  return new ProviderRuntimeClient(config);
+}
+
+function normalizeSession(session) {
+  return {
+    sessionId: session.id,
+    agentType: session.agentType,
+    cwd: session.cwd,
+    status: session.status,
+    createdAt: session.createdAt,
+    ...(session.agentSessionId ? { agentSessionId: session.agentSessionId } : {}),
+    ...(Array.isArray(session.pendingPermissions)
+      ? { pendingPermissions: session.pendingPermissions }
+      : {}),
+  };
+}
+
+export function createProviderSource({ client, config, debugLog = () => {} }) {
+  return {
+    async listSessions() {
+      const result = await client.call("provider_list_sessions");
+      const sessions = Array.isArray(result) ? result : result?.sessions;
+      return Array.isArray(sessions) ? sessions.map(normalizeSession) : [];
+    },
+
+    subscribe(onEvent) {
+      return client.subscribeNotifications((method, params) => {
+        const event = translateProviderEvent(method, params);
+        if (!event) {
+          debugLog(`dropped unmapped provider event ${method}`);
+          return;
+        }
+        onEvent(event);
+      });
+    },
+
+    async sendPrompt(sessionId, text) {
+      await client.call("provider_prompt", { sessionId, prompt: text });
+    },
+
+    async cancel(sessionId) {
+      await client.call("provider_cancel", { sessionId });
+    },
+
+    async respondToPermission(sessionId, requestId, optionId) {
+      await client.call("provider_respond_to_permission", {
+        sessionId,
+        requestId,
+        optionId,
+      });
+      return { ok: true };
+    },
+
+    async spawn(spec) {
+      const result = await client.call("provider_spawn", {
+        agentType: spec.agentType,
+        cwd: spec.cwd,
+        localSessionId: spec.localSessionId ?? null,
+        resumeAgentSessionId: spec.resumeAgentSessionId ?? null,
+        sandboxMode: spec.sandboxMode ?? null,
+        approvalPolicy: spec.approvalPolicy ?? null,
+        networkEnabled: spec.networkEnabled ?? null,
+        timeoutSecs: spec.timeoutSecs ?? null,
+        initialModelId: spec.initialModelId ?? null,
+        reasoningEffort: spec.reasoningEffort ?? null,
+      });
+      return normalizeSession(result);
+    },
+
+    async advertise() {
+      const result = await client.call("provider_get_available_agents");
+      return {
+        machineName: config.machineName,
+        agents: Array.isArray(result) ? result : result?.agents ?? [],
+        roots: [],
+      };
+    },
+  };
+}

--- a/bin/happy-bridge/session-source.mjs
+++ b/bin/happy-bridge/session-source.mjs
@@ -1,0 +1,58 @@
+// ABOUTME: Defines the machine-facing session seam used by the remote bridge.
+// ABOUTME: Keeps provider and future relay types separated by neutral shapes.
+
+/**
+ * @typedef {Object} SessionSummary
+ * @property {string} sessionId
+ * @property {string} agentType
+ * @property {string} cwd
+ * @property {string} status
+ * @property {string} createdAt
+ * @property {string=} agentSessionId
+ * @property {Array<Object>=} pendingPermissions
+ */
+
+/**
+ * @typedef {Object} SessionEvent
+ * @property {string} kind
+ * @property {string} sessionId
+ * @property {Object} payload
+ */
+
+/**
+ * @typedef {Object} RespondResult
+ * @property {boolean} ok
+ */
+
+/**
+ * @typedef {Object} SpawnSpec
+ * @property {string} agentType
+ * @property {string} cwd
+ * @property {string=} title
+ * @property {string=} localSessionId
+ * @property {string=} resumeAgentSessionId
+ * @property {string=} sandboxMode
+ * @property {string=} approvalPolicy
+ * @property {boolean=} networkEnabled
+ * @property {number=} timeoutSecs
+ * @property {string=} initialModelId
+ * @property {string=} reasoningEffort
+ */
+
+/**
+ * @typedef {Object} Advertisement
+ * @property {string} machineName
+ * @property {Array<Object>} agents
+ * @property {string[]} roots
+ */
+
+/**
+ * @typedef {Object} SessionSource
+ * @property {() => Promise<SessionSummary[]>} listSessions
+ * @property {(onEvent: (evt: SessionEvent) => void) => () => void} subscribe
+ * @property {(sessionId: string, text: string) => Promise<void>} sendPrompt
+ * @property {(sessionId: string) => Promise<void>} cancel
+ * @property {(sessionId: string, requestId: string, optionId: string) => Promise<RespondResult>} respondToPermission
+ * @property {(spec: SpawnSpec) => Promise<SessionSummary>} spawn
+ * @property {() => Promise<Advertisement>} advertise
+ */

--- a/bin/happy-bridge/supervisor-channel.mjs
+++ b/bin/happy-bridge/supervisor-channel.mjs
@@ -1,0 +1,61 @@
+// ABOUTME: Provides the bridge-side newline JSON-RPC client for Rust bookkeeping.
+// ABOUTME: It carries no provider or relay payloads and keeps calls correlated.
+
+const MAX_LINE_BYTES = 1024 * 1024;
+const RPC_TIMEOUT_MS = 30_000;
+
+/**
+ * @param {{write?: (line: string) => void, timeoutMs?: number}} options
+ */
+export function createSupervisorChannel({
+  write = (line) => process.stdout.write(`${line}\n`),
+  timeoutMs = RPC_TIMEOUT_MS,
+} = {}) {
+  let nextId = 0;
+  const pending = new Map();
+
+  function handleLine(line) {
+    if (Buffer.byteLength(line, "utf8") > MAX_LINE_BYTES) return;
+
+    let response;
+    try {
+      response = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (response?.id === undefined || response?.id === null) return;
+    const request = pending.get(response.id);
+    if (!request) return;
+
+    pending.delete(response.id);
+    clearTimeout(request.timer);
+    if (response.error) {
+      request.reject(new Error(response.error.message ?? "supervisor RPC failed"));
+    } else {
+      request.resolve(response.result);
+    }
+  }
+
+  function call(method, params = {}) {
+    const id = ++nextId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error("supervisor RPC timed out"));
+      }, timeoutMs);
+      pending.set(id, { resolve, reject, timer });
+      write(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+    });
+  }
+
+  function close() {
+    for (const request of pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(new Error("supervisor channel closed"));
+    }
+    pending.clear();
+  }
+
+  return { call, close, handleLine };
+}

--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -1,0 +1,4 @@
+// ABOUTME: Reserves the neutral-to-remote translation boundary for Phase 3.
+// ABOUTME: Phase 2 intentionally contains no relay or protocol translation.
+
+export {};

--- a/bin/happy-bridge/validate.mjs
+++ b/bin/happy-bridge/validate.mjs
@@ -89,7 +89,7 @@ export function validatePermissionResponse(
   }
 
   const offeredOptions = pending.optionIds ?? pending.options ?? [];
-  const offeredIds = offeredOptions.map((option) =>
+  const offeredIds = Array.from(offeredOptions, (option) =>
     typeof option === "string" ? option : option?.id,
   );
   if (!offeredIds.includes(optionId)) {

--- a/bin/happy-bridge/validate.mjs
+++ b/bin/happy-bridge/validate.mjs
@@ -1,0 +1,100 @@
+// ABOUTME: Validates remote spawn roots and permission responses at the bridge boundary.
+// ABOUTME: Canonical equality is required so path tricks cannot widen authority.
+
+import { realpathSync } from "node:fs";
+import { isAbsolute } from "node:path";
+
+function canonicalAbsolutePath(value) {
+  if (typeof value !== "string" || !isAbsolute(value)) {
+    return null;
+  }
+
+  try {
+    return realpathSync(value.normalize("NFC")).normalize("NFC");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A symlink is allowed when its canonical target is exactly an advertised
+ * root. This preserves the advertised-root boundary without allowing a
+ * symlink to escape it.
+ *
+ * @param {string} requestedPath
+ * @param {string[]} advertisedRoots
+ * @returns {{ok: true, root: string} | {ok: false, reason: string}}
+ */
+export function validateSpawnRoot(requestedPath, advertisedRoots) {
+  if (!Array.isArray(advertisedRoots) || advertisedRoots.length === 0) {
+    return { ok: false, reason: "no advertised roots" };
+  }
+
+  if (typeof requestedPath !== "string" || !isAbsolute(requestedPath)) {
+    return { ok: false, reason: "requested path must be absolute" };
+  }
+
+  const requestedRoot = canonicalAbsolutePath(requestedPath);
+  if (!requestedRoot) {
+    return { ok: false, reason: "requested path does not exist" };
+  }
+
+  for (const advertisedRoot of advertisedRoots) {
+    const canonicalRoot = canonicalAbsolutePath(advertisedRoot);
+    if (canonicalRoot === requestedRoot) {
+      return { ok: true, root: canonicalRoot };
+    }
+  }
+
+  return { ok: false, reason: "requested path is not an advertised root" };
+}
+
+function containsValue(collection, value) {
+  if (collection instanceof Set) return collection.has(value);
+  if (Array.isArray(collection)) return collection.includes(value);
+  return Boolean(collection && collection[value]);
+}
+
+function pendingRequestFor(trackedState, sessionId, requestId) {
+  const requests = trackedState?.pendingRequests;
+  if (requests instanceof Map) {
+    const sessionRequests = requests.get(sessionId);
+    return sessionRequests instanceof Map
+      ? sessionRequests.get(requestId)
+      : sessionRequests?.[requestId];
+  }
+  return requests?.[sessionId]?.[requestId];
+}
+
+/**
+ * @param {string} sessionId
+ * @param {string} requestId
+ * @param {string} optionId
+ * @param {{liveSessions?: Set<string>|string[]|Object, pendingRequests?: Object|Map}} trackedState
+ * @returns {{ok: true} | {ok: false, reason: string}}
+ */
+export function validatePermissionResponse(
+  sessionId,
+  requestId,
+  optionId,
+  trackedState,
+) {
+  if (!containsValue(trackedState?.liveSessions, sessionId)) {
+    return { ok: false, reason: "session is not live" };
+  }
+
+  const pending = pendingRequestFor(trackedState, sessionId, requestId);
+  if (!pending) {
+    return { ok: false, reason: "permission request is not pending" };
+  }
+
+  const offeredOptions = pending.optionIds ?? pending.options ?? [];
+  const offeredIds = offeredOptions.map((option) =>
+    typeof option === "string" ? option : option?.id,
+  );
+  if (!offeredIds.includes(optionId)) {
+    return { ok: false, reason: "permission option was not offered" };
+  }
+
+  return { ok: true };
+}

--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -80,6 +80,9 @@ function main(): void {
     path.join(repoRoot, "bin", "happy-bridge.mjs"),
     path.join(destDir, "happy-bridge.mjs"),
   );
+  cpSync(path.join(repoRoot, "bin", "happy-bridge"), path.join(destDir, "happy-bridge"), {
+    recursive: true,
+  });
   cpSync(browserLocalSrcDir, path.join(destDir, "browser-local"), {
     recursive: true,
   });

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -560,6 +560,29 @@ pub async fn create_agent_conversation(
     agent_session_id: Option<String>,
     agent_metadata: Option<String>,
 ) -> Result<AgentConversation, String> {
+    create_agent_conversation_record(
+        app,
+        id,
+        title,
+        agent_type,
+        agent_cwd,
+        project_root,
+        agent_session_id,
+        agent_metadata,
+    )
+    .await
+}
+
+pub(crate) async fn create_agent_conversation_record(
+    app: AppHandle,
+    id: String,
+    title: String,
+    agent_type: String,
+    agent_cwd: Option<String>,
+    project_root: Option<String>,
+    agent_session_id: Option<String>,
+    agent_metadata: Option<String>,
+) -> Result<AgentConversation, String> {
     let created_at = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -627,6 +650,56 @@ pub async fn create_agent_conversation(
     .await?;
 
     Ok(convo)
+}
+
+pub(crate) async fn lookup_agent_conversation_by_happy_session(
+    app: AppHandle,
+    happy_session_id: String,
+) -> Result<Option<AgentConversation>, String> {
+    run_db(app, move |conn| {
+        let mut stmt = conn.prepare(
+            "SELECT id, title, created_at, agent_type, agent_session_id,
+                    agent_cwd, agent_model_id, agent_permission_mode,
+                    agent_metadata, project_id, project_root, is_archived
+             FROM conversations
+             WHERE kind = 'agent' AND agent_metadata IS NOT NULL",
+        )?;
+
+        let rows = stmt.query_map([], |row| {
+            Ok(AgentConversation {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                created_at: row.get(2)?,
+                agent_type: row.get(3)?,
+                agent_session_id: row.get(4)?,
+                agent_cwd: row.get(5)?,
+                agent_model_id: row.get(6)?,
+                agent_permission_mode: row.get(7)?,
+                agent_metadata: row.get(8)?,
+                project_id: row.get(9)?,
+                project_root: row.get(10)?,
+                is_archived: row.get::<_, i32>(11)? != 0,
+            })
+        })?;
+
+        for row in rows {
+            let conversation = row?;
+            let Some(metadata) = conversation.agent_metadata.as_deref() else {
+                continue;
+            };
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(metadata) else {
+                continue;
+            };
+            if value.get("happy_session_id").and_then(|id| id.as_str())
+                == Some(happy_session_id.as_str())
+            {
+                return Ok(Some(conversation));
+            }
+        }
+
+        Ok(None)
+    })
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -2,6 +2,7 @@
 // ABOUTME: Builds its provider-runtime config in Rust so secrets never enter argv.
 
 use serde::Serialize;
+use serde_json::{Value, json};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -54,7 +55,7 @@ struct ProviderRuntimeConnection {
 
 struct HappyBridgeProcess {
     child: Child,
-    _stdin: ChildStdin,
+    _stdin: Arc<Mutex<ChildStdin>>,
 }
 
 pub struct HappyBridgeManager {
@@ -155,7 +156,8 @@ impl HappyBridgeManager {
             .await
             .map_err(|err| format!("Failed to flush Happy bridge config: {err}"))?;
 
-        pipe_bridge_output(&mut child);
+        let stdin = Arc::new(Mutex::new(stdin));
+        pipe_bridge_output(&mut child, Arc::clone(&stdin), app.clone());
         *self.process.lock().await = Some(HappyBridgeProcess {
             child,
             _stdin: stdin,
@@ -409,11 +411,168 @@ fn find_happy_bridge_mjs() -> Result<PathBuf, String> {
         })
 }
 
-fn pipe_bridge_output(child: &mut Child) {
+const MAX_SUPERVISOR_LINE_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug)]
+struct SupervisorRequest {
+    id: Value,
+    method: String,
+    params: Value,
+}
+
+fn error_response(id: Value, code: i32, message: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": code, "message": message },
+    })
+}
+
+fn parse_supervisor_line(line: &str) -> Result<SupervisorRequest, Value> {
+    if line.len() > MAX_SUPERVISOR_LINE_BYTES {
+        return Err(error_response(
+            Value::Null,
+            -32600,
+            "supervisor request line is too large",
+        ));
+    }
+
+    let value: Value = serde_json::from_str(line)
+        .map_err(|_| error_response(Value::Null, -32700, "parse error"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| error_response(Value::Null, -32600, "invalid supervisor request"))?;
+    let id = object.get("id").cloned().unwrap_or(Value::Null);
+    let method = object
+        .get("method")
+        .and_then(Value::as_str)
+        .ok_or_else(|| error_response(id.clone(), -32600, "method is required"))?;
+
+    if !matches!(
+        method,
+        "conversation_create" | "conversation_lookup" | "identity_store"
+    ) {
+        return Err(error_response(id, -32601, "unknown supervisor method"));
+    }
+
+    Ok(SupervisorRequest {
+        id,
+        method: method.to_string(),
+        params: object.get("params").cloned().unwrap_or_else(|| json!({})),
+    })
+}
+
+fn required_string(params: &Value, key: &str) -> Result<String, String> {
+    params
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("{key} is required"))
+}
+
+async fn dispatch_supervisor_request(
+    app: &AppHandle,
+    request: SupervisorRequest,
+) -> Result<Value, String> {
+    match request.method.as_str() {
+        "conversation_create" => {
+            let agent_type = required_string(&request.params, "agentType")?;
+            let cwd = required_string(&request.params, "cwd")?;
+            let title = required_string(&request.params, "title")?;
+            let happy_session_id = required_string(&request.params, "happySessionId")?;
+            let metadata = serde_json::to_string(&json!({
+                "happy_session_id": happy_session_id,
+            }))
+            .map_err(|error| error.to_string())?;
+            let conversation = crate::commands::chat::create_agent_conversation_record(
+                app.clone(),
+                uuid::Uuid::new_v4().to_string(),
+                title,
+                agent_type,
+                Some(cwd.clone()),
+                Some(cwd),
+                None,
+                Some(metadata),
+            )
+            .await?;
+            Ok(json!({ "conversationId": conversation.id }))
+        }
+        "conversation_lookup" => {
+            let happy_session_id = required_string(&request.params, "happySessionId")?;
+            let conversation = crate::commands::chat::lookup_agent_conversation_by_happy_session(
+                app.clone(),
+                happy_session_id,
+            )
+            .await?;
+            Ok(match conversation {
+                Some(conversation) => json!({
+                    "conversationId": conversation.id,
+                    "agentSessionId": conversation.agent_session_id,
+                    "cwd": conversation.agent_cwd,
+                    "agentType": conversation.agent_type,
+                }),
+                None => json!({}),
+            })
+        }
+        "identity_store" => {
+            let identity = request
+                .params
+                .get("identity")
+                .ok_or_else(|| "identity is required".to_string())?;
+            let credential = identity
+                .as_str()
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| identity.to_string());
+            app.state::<HappyBridgeManager>()
+                .store_pairing_credential(app, &credential)?;
+            Ok(json!({ "stored": true }))
+        }
+        _ => Err("unknown supervisor method".to_string()),
+    }
+}
+
+async fn dispatch_supervisor_line(app: &AppHandle, line: &str, stdin: &Arc<Mutex<ChildStdin>>) {
+    let response = match parse_supervisor_line(line) {
+        Err(response) => response,
+        Ok(request) => {
+            let id = request.id.clone();
+            match dispatch_supervisor_request(app, request).await {
+                Ok(result) => json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+                Err(error) => error_response(id, -32000, &error),
+            }
+        }
+    };
+
+    let encoded = match serde_json::to_vec(&response) {
+        Ok(encoded) => encoded,
+        Err(error) => {
+            log::warn!("[HappyBridge] Failed to encode supervisor response: {error}");
+            return;
+        }
+    };
+    let mut writer = stdin.lock().await;
+    if let Err(error) = writer.write_all(&encoded).await {
+        log::warn!("[HappyBridge] Failed to write supervisor response: {error}");
+        return;
+    }
+    if let Err(error) = writer.write_all(b"\n").await {
+        log::warn!("[HappyBridge] Failed to finish supervisor response: {error}");
+        return;
+    }
+    if let Err(error) = writer.flush().await {
+        log::warn!("[HappyBridge] Failed to flush supervisor response: {error}");
+    }
+}
+
+fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: AppHandle) {
     if let Some(stdout) = child.stdout.take() {
+        let stdout_stdin = Arc::clone(&stdin);
         tauri::async_runtime::spawn(async move {
             let mut lines = BufReader::new(stdout).lines();
-            while let Ok(Some(_line)) = lines.next_line().await {}
+            while let Ok(Some(line)) = lines.next_line().await {
+                dispatch_supervisor_line(&app, &line, &stdout_stdin).await;
+            }
         });
     }
     if let Some(stderr) = child.stderr.take() {
@@ -428,7 +587,8 @@ fn pipe_bridge_output(child: &mut Child) {
 
 #[cfg(test)]
 mod tests {
-    use super::restart_delay;
+    use super::{MAX_SUPERVISOR_LINE_BYTES, error_response, parse_supervisor_line, restart_delay};
+    use serde_json::Value;
     use std::time::Duration;
 
     #[test]
@@ -437,5 +597,37 @@ mod tests {
         assert_eq!(restart_delay(1), Duration::from_secs(2));
         assert_eq!(restart_delay(2), Duration::from_secs(4));
         assert_eq!(restart_delay(10), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn supervisor_channel_dispatch_garbage_json_returns_error_response() {
+        let response = parse_supervisor_line("not-json").expect_err("garbage must fail");
+        assert_eq!(response["error"]["code"], -32700);
+        assert_eq!(response["id"], Value::Null);
+    }
+
+    #[test]
+    fn supervisor_channel_dispatch_unknown_method_returns_error_response() {
+        let response = parse_supervisor_line(
+            r#"{"jsonrpc":"2.0","id":7,"method":"unknown_method","params":{}}"#,
+        )
+        .expect_err("unknown method must fail");
+        assert_eq!(response["error"]["code"], -32601);
+        assert_eq!(response["id"], 7);
+    }
+
+    #[test]
+    fn supervisor_channel_dispatch_oversized_line_returns_error_response() {
+        let line = "x".repeat(MAX_SUPERVISOR_LINE_BYTES + 1);
+        let response = parse_supervisor_line(&line).expect_err("oversized line must fail");
+        assert_eq!(response["error"]["code"], -32600);
+        assert_eq!(response["id"], Value::Null);
+    }
+
+    #[test]
+    fn supervisor_error_response_has_jsonrpc_shape() {
+        let response = error_response(Value::Null, -32000, "test");
+        assert_eq!(response["jsonrpc"], "2.0");
+        assert_eq!(response["error"]["message"], "test");
     }
 }

--- a/tests/unit/happy-bridge-translate-provider.test.ts
+++ b/tests/unit/happy-bridge-translate-provider.test.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Exhaustively verifies provider-runtime to neutral session translation.
+// ABOUTME: This is the single authoritative provider-side mapping test.
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import { translateProviderEvent } from "../../bin/happy-bridge/provider-source.mjs";
+
+const mappings = [
+  ["provider://message-chunk", "assistant-delta"],
+  ["provider://user-message", "user-message"],
+  ["provider://tool-call", "tool-start"],
+  ["provider://tool-result", "tool-end"],
+  ["provider://diff", "file-diff"],
+  ["provider://diff-proposal", "diff-proposal"],
+  ["provider://diff-proposal-resolved", "diff-proposal-resolved"],
+  ["provider://plan-update", "plan-update"],
+  ["provider://permission-request", "permission-request"],
+  ["provider://permission-resolved", "permission-resolved"],
+  ["provider://prompt-complete", "turn-complete"],
+  ["provider://session-status", "status"],
+  ["provider://error", "error"],
+] as const;
+
+describe("provider-to-neutral session event translation", () => {
+  it.each(mappings)("maps %s to %s", (method, kind) => {
+    expect(
+      translateProviderEvent(method, {
+        sessionId: "session-1",
+        value: "preserved",
+      }),
+    ).toEqual({
+      kind,
+      sessionId: "session-1",
+      payload: { value: "preserved" },
+    });
+  });
+
+  it.each([
+    "provider://config-options-update",
+    "provider://mcp-degraded",
+    "provider://cli-install-progress",
+    "provider://unknown",
+  ])("drops unmapped event %s", (method) => {
+    expect(translateProviderEvent(method, { sessionId: "session-1" })).toBeNull();
+  });
+
+  it("drops mapped notifications without a session id", () => {
+    expect(translateProviderEvent("provider://message-chunk", { text: "x" })).toBeNull();
+  });
+});

--- a/tests/unit/happy-bridge-validate.test.ts
+++ b/tests/unit/happy-bridge-validate.test.ts
@@ -114,6 +114,17 @@ describe("validatePermissionResponse", () => {
     ).toEqual({ ok: true });
   });
 
+  it("accepts a Set of offered options", () => {
+    expect(
+      validatePermissionResponse("session-1", "request-1", "deny", {
+        liveSessions: new Set(["session-1"]),
+        pendingRequests: {
+          "session-1": { "request-1": { options: new Set(["deny"]) } },
+        },
+      }),
+    ).toEqual({ ok: true });
+  });
+
   it("rejects a response for a dead session", () => {
     expect(
       validatePermissionResponse("session-dead", "request-1", "allow-once", trackedState),

--- a/tests/unit/happy-bridge-validate.test.ts
+++ b/tests/unit/happy-bridge-validate.test.ts
@@ -1,0 +1,134 @@
+// ABOUTME: TDD coverage for spawn-root and permission-response boundaries.
+// ABOUTME: Uses real temporary filesystem entries and caller-supplied state only.
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import {
+  validatePermissionResponse,
+  validateSpawnRoot,
+} from "../../bin/happy-bridge/validate.mjs";
+
+const temporaryDirectories: string[] = [];
+
+function makeFixture() {
+  const directory = mkdtempSync(join(tmpdir(), "seren-happy-bridge-"));
+  const advertisedRoot = join(directory, "advertised-root");
+  const prefixTrick = join(directory, "advertised-root-evil");
+  mkdirSync(advertisedRoot);
+  mkdirSync(prefixTrick);
+  temporaryDirectories.push(directory);
+  return { directory, advertisedRoot, prefixTrick };
+}
+
+afterEach(() => {
+  while (temporaryDirectories.length > 0) {
+    rmSync(temporaryDirectories.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("validateSpawnRoot", () => {
+  it("accepts an exact advertised root", () => {
+    const { advertisedRoot } = makeFixture();
+    expect(validateSpawnRoot(advertisedRoot, [advertisedRoot])).toEqual({
+      ok: true,
+      root: realpathSync(advertisedRoot),
+    });
+  });
+
+  it("rejects .. traversal to an advertised root parent", () => {
+    const { directory, advertisedRoot } = makeFixture();
+    expect(validateSpawnRoot(join(advertisedRoot, ".."), [advertisedRoot])).toEqual({
+      ok: false,
+      reason: "requested path is not an advertised root",
+    });
+    expect(existsSync(directory)).toBe(true);
+  });
+
+  it("accepts a symlink whose canonical target is an advertised root", () => {
+    const { directory, advertisedRoot } = makeFixture();
+    const link = join(directory, "advertised-link");
+    symlinkSync(advertisedRoot, link, process.platform === "win32" ? "junction" : "dir");
+    expect(validateSpawnRoot(link, [advertisedRoot])).toEqual({
+      ok: true,
+      root: realpathSync(advertisedRoot),
+    });
+  });
+
+  it("rejects a prefix trick", () => {
+    const { advertisedRoot, prefixTrick } = makeFixture();
+    expect(validateSpawnRoot(prefixTrick, [advertisedRoot])).toEqual({
+      ok: false,
+      reason: "requested path is not an advertised root",
+    });
+  });
+
+  it("rejects an empty advertised list", () => {
+    const { advertisedRoot } = makeFixture();
+    expect(validateSpawnRoot(advertisedRoot, [])).toEqual({
+      ok: false,
+      reason: "no advertised roots",
+    });
+  });
+
+  it("rejects relative paths", () => {
+    makeFixture();
+    expect(validateSpawnRoot("advertised-root", ["advertised-root"])).toEqual({
+      ok: false,
+      reason: "requested path must be absolute",
+    });
+  });
+
+  it("rejects nonexistent paths", () => {
+    const { directory, advertisedRoot } = makeFixture();
+    expect(validateSpawnRoot(join(directory, "missing"), [advertisedRoot])).toEqual({
+      ok: false,
+      reason: "requested path does not exist",
+    });
+  });
+});
+
+describe("validatePermissionResponse", () => {
+  const trackedState = {
+    liveSessions: new Set(["session-1"]),
+    pendingRequests: {
+      "session-1": {
+        "request-1": { optionIds: ["allow-once", "deny"] },
+      },
+    },
+  };
+
+  it("accepts an offered option for a live session", () => {
+    expect(
+      validatePermissionResponse("session-1", "request-1", "allow-once", trackedState),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects a response for a dead session", () => {
+    expect(
+      validatePermissionResponse("session-dead", "request-1", "allow-once", trackedState),
+    ).toEqual({ ok: false, reason: "session is not live" });
+  });
+
+  it("rejects a response for a non-pending request", () => {
+    expect(
+      validatePermissionResponse("session-1", "request-missing", "allow-once", trackedState),
+    ).toEqual({ ok: false, reason: "permission request is not pending" });
+  });
+
+  it("rejects an option that was not offered", () => {
+    expect(
+      validatePermissionResponse("session-1", "request-1", "admin", trackedState),
+    ).toEqual({ ok: false, reason: "permission option was not offered" });
+  });
+});


### PR DESCRIPTION
Closes #2979

## Summary
- split the bridge into a neutral session seam and a single provider-runtime adapter
- add provider event translation, shared-socket RPC methods, and advertised agent metadata
- add Rust supervisor bookkeeping for agent conversation create/lookup and opaque identity storage
- validate canonical spawn roots and permission responses without adding dependencies
- bundle the extracted bridge modules into the embedded runtime

## No-mock real-app walkthrough
Ran the Tauri development app with a temporary identifier and a temporary, environment-gated walkthrough harness. The harness was removed before this PR.

Observed from the live provider runtime:

    advertise agents=5 roots=0
    list sessions=0
    spawn session=present
    event kind=status session=present
    event kind=assistant-delta session=present
    event kind=turn-complete session=present
    prompt sent=true
    turn complete=true

Observed from the real bridge and Rust supervisor channel:

    happy-bridge: config ok, 0 sessions
    happy-bridge: bookkeeping create=ok lookup=ok

The real SQLite query returned:

    agent|phase2-walkthrough-session

The bridge process arguments contained only its entrypoint; the provider-runtime connection configuration was sent over stdin. The bridge was then disabled and the process count returned to zero. No mocks, stubs, Docker, or fake provider were used.

## Verification
- `pnpm check` passed; the repository reported 48 pre-existing warnings.
- `pnpm test` passed: 330 files passed, 3 skipped; 2382 tests passed, 15 skipped.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml` passed: 919 passed, 2 ignored.
- `pnpm build` passed.
- Focused provider translation and root/permission validation tests passed: 2 files, 30 tests.
- Focused supervisor parser tests passed: garbage JSON, unknown method, and oversized line.

The three-OS CI matrix must be green before merge.
