### PR TITLE
fix(remote): harden Happy bridge before Phase 3

### DIFF
--- a/bin/happy-bridge/validate.mjs
+++ b/bin/happy-bridge/validate.mjs
@@ -52,7 +52,7 @@ export function validateSpawnRoot(requestedPath, advertisedRoots) {
 function containsValue(collection, value) {
   if (collection instanceof Set) return collection.has(value);
   if (Array.isArray(collection)) return collection.includes(value);
-  return Boolean(collection && collection[value]);
+  return Boolean(collection && Object.hasOwn(collection, value) && collection[value]);
 }
 
 function pendingRequestFor(trackedState, sessionId, requestId) {
@@ -61,9 +61,15 @@ function pendingRequestFor(trackedState, sessionId, requestId) {
     const sessionRequests = requests.get(sessionId);
     return sessionRequests instanceof Map
       ? sessionRequests.get(requestId)
-      : sessionRequests?.[requestId];
+      : sessionRequests && Object.hasOwn(sessionRequests, requestId)
+        ? sessionRequests[requestId]
+        : undefined;
   }
-  return requests?.[sessionId]?.[requestId];
+  if (!requests || !Object.hasOwn(requests, sessionId)) return undefined;
+  const sessionRequests = requests[sessionId];
+  return sessionRequests && Object.hasOwn(sessionRequests, requestId)
+    ? sessionRequests[requestId]
+    : undefined;
 }
 
 /**

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2226,6 +2226,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "defmt"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4532,6 +4542,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.5.1",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5028,7 +5053,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.5.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -7456,7 +7481,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -7484,7 +7509,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.9",
- "security-framework",
+ "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -7717,6 +7742,19 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -7993,6 +8031,7 @@ dependencies = [
  "html2md",
  "image",
  "jiff",
+ "keyring",
  "lazy_static",
  "libc",
  "log",
@@ -9414,7 +9453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -87,6 +87,7 @@ tree-sitter-typescript = "0.23.2"
 sonora = "0.1.0"
 
 tokio-tungstenite = { version = "0.28" }
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 # Messaging transport adapters (opt-in via cargo features)
 teloxide = { version = "0.14", features = ["macros"], optional = true }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -662,10 +662,12 @@ pub(crate) async fn lookup_agent_conversation_by_happy_session(
                     agent_cwd, agent_model_id, agent_permission_mode,
                     agent_metadata, project_id, project_root, is_archived
              FROM conversations
-             WHERE kind = 'agent' AND agent_metadata IS NOT NULL",
+             WHERE kind = 'agent'
+               AND json_extract(agent_metadata, '$.happy_session_id') = ?1
+             LIMIT 1",
         )?;
 
-        let rows = stmt.query_map([], |row| {
+        let conversation = stmt.query_row(params![happy_session_id], |row| {
             Ok(AgentConversation {
                 id: row.get(0)?,
                 title: row.get(1)?,
@@ -680,24 +682,13 @@ pub(crate) async fn lookup_agent_conversation_by_happy_session(
                 project_root: row.get(10)?,
                 is_archived: row.get::<_, i32>(11)? != 0,
             })
-        })?;
+        });
 
-        for row in rows {
-            let conversation = row?;
-            let Some(metadata) = conversation.agent_metadata.as_deref() else {
-                continue;
-            };
-            let Ok(value) = serde_json::from_str::<serde_json::Value>(metadata) else {
-                continue;
-            };
-            if value.get("happy_session_id").and_then(|id| id.as_str())
-                == Some(happy_session_id.as_str())
-            {
-                return Ok(Some(conversation));
-            }
+        match conversation {
+            Ok(conversation) => Ok(Some(conversation)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(error) => Err(error),
         }
-
-        Ok(None)
     })
     .await
 }

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -8,8 +8,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
-use tauri_plugin_store::StoreExt;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::Mutex;
 
@@ -18,8 +17,7 @@ const MAX_RESTART_ATTEMPTS: u32 = 3;
 const MAX_BACKOFF_SECONDS: u64 = 30;
 const STOP_GRACE_PERIOD: Duration = Duration::from_secs(5);
 const STATUS_EVENT: &str = "happy-bridge://status";
-const CREDENTIAL_STORE: &str = "happy_bridge.json";
-const CREDENTIAL_KEY: &str = "credential_blob";
+const CREDENTIAL_ACCOUNT: &str = "happy-bridge-pairing-credential";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -111,6 +109,9 @@ impl HappyBridgeManager {
             .await?;
         let node_binary = resolve_node_binary(app);
         let bridge_entry = find_happy_bridge_mjs()?;
+        let machine_identity = self.load_pairing_credential(app)?.map(|credential| {
+            serde_json::from_str(&credential).unwrap_or_else(|_| Value::String(credential))
+        });
         let config = HappyBridgeConfig {
             provider_runtime: ProviderRuntimeConnection {
                 host: provider_runtime.host,
@@ -118,7 +119,7 @@ impl HappyBridgeManager {
                 token: provider_runtime.token,
             },
             relay_url: HAPPY_RELAY_URL.to_string(),
-            machine_identity: None,
+            machine_identity,
             machine_name: "seren-desktop".to_string(),
         };
 
@@ -195,9 +196,8 @@ impl HappyBridgeManager {
         self.status.lock().await.clone()
     }
 
-    /// Store the opaque credential received during future pairing. This follows
-    /// the existing encrypted Tauri store pattern used by auth.rs; no bridge
-    /// identity is generated locally in Phase 1.
+    /// Store the opaque credential received during pairing in the OS credential
+    /// store. The value is never inspected, serialized into app data, or logged.
     pub fn store_pairing_credential(
         &self,
         app: &AppHandle,
@@ -206,22 +206,35 @@ impl HappyBridgeManager {
         if credential.trim().is_empty() {
             return Err("pairing credential must not be empty".to_string());
         }
-        let store = app.store(CREDENTIAL_STORE).map_err(|err| err.to_string())?;
-        store.set(CREDENTIAL_KEY, serde_json::json!(credential));
-        store.save().map_err(|err| err.to_string())
+        let entry = credential_entry(app)?;
+        entry
+            .set_password(credential)
+            .map_err(|err| format!("failed to store pairing credential: {err}"))?;
+        remove_legacy_credential_store(app);
+        Ok(())
     }
 
     pub fn load_pairing_credential(&self, app: &AppHandle) -> Result<Option<String>, String> {
-        let store = app.store(CREDENTIAL_STORE).map_err(|err| err.to_string())?;
-        Ok(store
-            .get(CREDENTIAL_KEY)
-            .and_then(|value| value.as_str().map(String::from)))
+        let entry = credential_entry(app)?;
+        let result = match entry.get_password() {
+            Ok(credential) => Some(credential),
+            Err(keyring::Error::NoEntry) => None,
+            Err(err) => {
+                return Err(format!("failed to load pairing credential: {err}"));
+            }
+        };
+        remove_legacy_credential_store(app);
+        Ok(result)
     }
 
     pub fn delete_pairing_credential(&self, app: &AppHandle) -> Result<(), String> {
-        let store = app.store(CREDENTIAL_STORE).map_err(|err| err.to_string())?;
-        store.delete(CREDENTIAL_KEY);
-        store.save().map_err(|err| err.to_string())
+        let entry = credential_entry(app)?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Err(err) => return Err(format!("failed to delete pairing credential: {err}")),
+        }
+        remove_legacy_credential_store(app);
+        Ok(())
     }
 
     async fn set_status(&self, app: &AppHandle, state: HappyBridgeState, detail: Option<String>) {
@@ -256,6 +269,18 @@ impl HappyBridgeManager {
             *guard = None;
         }
     }
+}
+
+fn credential_entry(app: &AppHandle) -> Result<keyring::Entry, String> {
+    keyring::Entry::new(&app.config().identifier, CREDENTIAL_ACCOUNT)
+        .map_err(|err| format!("failed to open pairing credential store: {err}"))
+}
+
+fn remove_legacy_credential_store(app: &AppHandle) {
+    let Ok(app_data_dir) = app.path().app_data_dir() else {
+        return;
+    };
+    let _ = std::fs::remove_file(app_data_dir.join("happy_bridge.json"));
 }
 
 impl Default for HappyBridgeManager {
@@ -544,6 +569,13 @@ async fn dispatch_supervisor_line(app: &AppHandle, line: &str, stdin: &Arc<Mutex
         }
     };
 
+    write_supervisor_response(stdin, response).await;
+}
+
+async fn write_supervisor_response<W>(writer: &Arc<Mutex<W>>, response: Value)
+where
+    W: AsyncWrite + Unpin,
+{
     let encoded = match serde_json::to_vec(&response) {
         Ok(encoded) => encoded,
         Err(error) => {
@@ -551,7 +583,7 @@ async fn dispatch_supervisor_line(app: &AppHandle, line: &str, stdin: &Arc<Mutex
             return;
         }
     };
-    let mut writer = stdin.lock().await;
+    let mut writer = writer.lock().await;
     if let Err(error) = writer.write_all(&encoded).await {
         log::warn!("[HappyBridge] Failed to write supervisor response: {error}");
         return;
@@ -565,20 +597,95 @@ async fn dispatch_supervisor_line(app: &AppHandle, line: &str, stdin: &Arc<Mutex
     }
 }
 
+enum BoundedLine {
+    Complete(String),
+    Oversized,
+}
+
+async fn read_bounded_line<R>(reader: &mut R) -> std::io::Result<Option<BoundedLine>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut line = Vec::new();
+    let mut oversized = false;
+
+    loop {
+        let buffer = reader.fill_buf().await?;
+        if buffer.is_empty() {
+            if line.is_empty() && !oversized {
+                return Ok(None);
+            }
+            return Ok(Some(if oversized {
+                BoundedLine::Oversized
+            } else {
+                BoundedLine::Complete(String::from_utf8(line).map_err(|_| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "supervisor line is not UTF-8",
+                    )
+                })?)
+            }));
+        }
+
+        if let Some(newline_at) = buffer.iter().position(|byte| *byte == b'\n') {
+            if line.len() + newline_at > MAX_SUPERVISOR_LINE_BYTES {
+                oversized = true;
+            } else if !oversized {
+                line.extend_from_slice(&buffer[..newline_at]);
+            }
+            reader.consume(newline_at + 1);
+            return Ok(Some(if oversized {
+                BoundedLine::Oversized
+            } else {
+                BoundedLine::Complete(String::from_utf8(line).map_err(|_| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "supervisor line is not UTF-8",
+                    )
+                })?)
+            }));
+        }
+
+        if !oversized && line.len() + buffer.len() <= MAX_SUPERVISOR_LINE_BYTES {
+            line.extend_from_slice(buffer);
+        } else {
+            oversized = true;
+        }
+        let consumed = buffer.len();
+        reader.consume(consumed);
+    }
+}
+
 fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: AppHandle) {
     if let Some(stdout) = child.stdout.take() {
         let stdout_stdin = Arc::clone(&stdin);
         tauri::async_runtime::spawn(async move {
-            let mut lines = BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                dispatch_supervisor_line(&app, &line, &stdout_stdin).await;
+            let mut reader = BufReader::new(stdout);
+            loop {
+                match read_bounded_line(&mut reader).await {
+                    Ok(Some(BoundedLine::Complete(line))) => {
+                        dispatch_supervisor_line(&app, &line, &stdout_stdin).await;
+                    }
+                    Ok(Some(BoundedLine::Oversized)) => {
+                        write_supervisor_response(
+                            &stdout_stdin,
+                            error_response(
+                                Value::Null,
+                                -32600,
+                                "supervisor request line is too large",
+                            ),
+                        )
+                        .await;
+                    }
+                    Ok(None) | Err(_) => break,
+                }
             }
         });
     }
     if let Some(stderr) = child.stderr.take() {
         tauri::async_runtime::spawn(async move {
-            let mut lines = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
+            let mut reader = BufReader::new(stderr);
+            while let Ok(Some(BoundedLine::Complete(line))) = read_bounded_line(&mut reader).await {
                 log::info!("[HappyBridge] {line}");
             }
         });
@@ -587,9 +694,13 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
 
 #[cfg(test)]
 mod tests {
-    use super::{MAX_SUPERVISOR_LINE_BYTES, error_response, parse_supervisor_line, restart_delay};
+    use super::{
+        BoundedLine, MAX_SUPERVISOR_LINE_BYTES, error_response, parse_supervisor_line,
+        read_bounded_line, restart_delay,
+    };
     use serde_json::Value;
     use std::time::Duration;
+    use tokio::io::{AsyncWriteExt, BufReader, duplex};
 
     #[test]
     fn restart_backoff_is_capped() {
@@ -629,5 +740,68 @@ mod tests {
         let response = error_response(Value::Null, -32000, "test");
         assert_eq!(response["jsonrpc"], "2.0");
         assert_eq!(response["error"]["message"], "test");
+    }
+
+    #[tokio::test]
+    async fn bounded_stdout_reader_discards_over_cap_line_and_resynchronizes() {
+        let (mut writer, reader) = duplex(64 * 1024);
+        let writer_task = tokio::spawn(async move {
+            writer
+                .write_all(&vec![b'x'; MAX_SUPERVISOR_LINE_BYTES + 1])
+                .await
+                .unwrap();
+            writer.write_all(b"\n{}\n").await.unwrap();
+        });
+        let mut reader = BufReader::new(reader);
+
+        assert!(matches!(
+            read_bounded_line(&mut reader).await.unwrap(),
+            Some(BoundedLine::Oversized)
+        ));
+        assert!(matches!(
+            read_bounded_line(&mut reader).await.unwrap(),
+            Some(BoundedLine::Complete(line)) if line == "{}"
+        ));
+        writer_task.await.unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn keyring_credential_round_trip_uses_macos_keychain() {
+        let account = format!("happy-bridge-test-{}", std::process::id());
+        let entry = keyring::Entry::new("com.serendb.desktop", &account).unwrap();
+        let _ = entry.delete_credential();
+        entry.set_password("phase5-round-trip-value").unwrap();
+        assert!(
+            std::process::Command::new("security")
+                .args([
+                    "find-generic-password",
+                    "-s",
+                    "com.serendb.desktop",
+                    "-a",
+                    &account
+                ])
+                .output()
+                .unwrap()
+                .status
+                .success()
+        );
+        assert_eq!(entry.get_password().unwrap(), "phase5-round-trip-value");
+        entry.delete_credential().unwrap();
+        assert!(
+            !std::process::Command::new("security")
+                .args([
+                    "find-generic-password",
+                    "-s",
+                    "com.serendb.desktop",
+                    "-a",
+                    &account
+                ])
+                .output()
+                .unwrap()
+                .status
+                .success()
+        );
+        assert!(matches!(entry.get_password(), Err(keyring::Error::NoEntry)));
     }
 }

--- a/tests/unit/happy-bridge-validate.test.ts
+++ b/tests/unit/happy-bridge-validate.test.ts
@@ -142,4 +142,22 @@ describe("validatePermissionResponse", () => {
       validatePermissionResponse("session-1", "request-1", "admin", trackedState),
     ).toEqual({ ok: false, reason: "permission option was not offered" });
   });
+
+  it("rejects inherited live-session ids", () => {
+    expect(
+      validatePermissionResponse("constructor", "request-1", "allow-once", {
+        liveSessions: {},
+        pendingRequests: {},
+      }),
+    ).toEqual({ ok: false, reason: "session is not live" });
+  });
+
+  it("rejects inherited pending-request ids", () => {
+    expect(
+      validatePermissionResponse("session-1", "toString", "allow-once", {
+        liveSessions: { "session-1": true },
+        pendingRequests: { "session-1": {} },
+      }),
+    ).toEqual({ ok: false, reason: "permission request is not pending" });
+  });
 });


### PR DESCRIPTION
Closes #2978
Closes #2981

## Summary

- Store the Happy pairing credential with `keyring::Entry` using the production bundle identifier and a fixed account name.
- Load the stored identity into the bridge configuration without putting its value in argv, logs, JSON app data, or SQLite.
- Remove the legacy bridge store file on credential access as a best-effort cleanup.
- Replace the Happy-session conversation table scan with a SQLite JSON1 lookup.
- Bound bridge stdout reads during ingestion, discard an over-cap line, and resynchronize at the next newline.
- Harden plain-object permission state checks with own-property semantics and cover inherited `constructor` and `toString` ids.

## Keychain verification

The macOS-gated test `keyring_credential_round_trip_uses_macos_keychain` used the real Keychain through `keyring::Entry` and verified store, read, delete, and absence. Its redacted command observations were:

    security find-generic-password -s com.serendb.desktop -a <redacted-test-account>
    after store: found; command output redacted
    after delete: not found; command output redacted

No credential value appeared in the test output, command transcript, or this PR. Linux and Windows remain covered by the platform-neutral build and test paths in CI; the real Keychain assertion is macOS-gated because those runners do not provide the macOS Keychain backend.

## Verification

- `pnpm check`: passed with 48 pre-existing warnings.
- `pnpm test`: 330 files passed, 3 skipped; 2384 tests passed, 15 skipped.
- `cargo check --locked --manifest-path src-tauri/Cargo.toml`: passed.
- `cargo test --locked --manifest-path src-tauri/Cargo.toml`: 921 passed, 2 ignored.
- Focused bridge tests: keychain round-trip, bounded stdout resynchronization, and existing supervisor parser cases passed.
- Focused validation tests: inherited `constructor` and `toString` ids are rejected.

The existing authentication credential migration is explicitly deferred to a follow-up; this PR changes only the Happy pairing credential path.
