### PR TITLE
feat(remote): complete Happy streaming, inbound control, and spawn

### DIFF
--- a/bin/happy-bridge.mjs
+++ b/bin/happy-bridge.mjs
@@ -84,6 +84,7 @@ try {
   happyLayer = createHappyLayer({
     config,
     supervisorChannel,
+    source,
     debugLog: (message) => console.error(`happy-bridge: ${message}`),
   });
   await happyLayer.start();

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -180,7 +180,7 @@ export function createHappyLayer({
   function rememberPendingPermissions(sessionId, permissions) {
     if (!Array.isArray(permissions)) return;
     for (const permission of permissions) {
-      if (permission?.sessionId !== sessionId || typeof permission.requestId !== "string") continue;
+      if (typeof permission?.requestId !== "string") continue;
       rememberPermission({
         kind: "permission-request",
         sessionId,
@@ -192,19 +192,34 @@ export function createHappyLayer({
   function registerInbound(entry) {
     const { sessionId, client } = entry;
     client.onUserMessage((message) => {
-      void handleUserMessage(entry, message).catch(() => debug("dropped invalid Happy user message"));
+      void handleUserMessage(entry, message).catch(() => debug("ignored Happy inbound user message"));
     });
     client.rpcHandlerManager.registerHandler("abort", async () => {
-      await source.cancel(sessionId);
-      return { ok: true };
+      try {
+        await source.cancel(sessionId);
+        return { ok: true };
+      } catch {
+        debug("ignored failed Happy abort request");
+        return { ok: false };
+      }
     });
     client.rpcHandlerManager.registerHandler("switch", async () => {
-      await source.cancel(sessionId);
-      return { ok: true };
+      try {
+        await source.cancel(sessionId);
+        return { ok: true };
+      } catch {
+        debug("ignored failed Happy switch request");
+        return { ok: false };
+      }
     });
-    client.rpcHandlerManager.registerHandler("permission", async (response) =>
-      handlePermissionResponse(entry, response),
-    );
+    client.rpcHandlerManager.registerHandler("permission", async (response) => {
+      try {
+        return await handlePermissionResponse(entry, response);
+      } catch {
+        debug("ignored failed Happy permission request");
+        return { ok: false };
+      }
+    });
   }
 
   async function handleUserMessage(entry, message) {
@@ -217,6 +232,10 @@ export function createHappyLayer({
       return;
     }
     const mode = message.meta?.permissionMode;
+    if (message.meta && mode !== undefined && typeof mode !== "string") {
+      debug("dropped invalid Happy permission mode");
+      return;
+    }
     if (typeof mode === "string") await source.setPermissionMode(entry.sessionId, mode);
     await source.sendPrompt(entry.sessionId, message.content.text);
   }

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -156,6 +156,7 @@ export function createHappyLayer({
   let advertisedRoots = [];
   let advertisedAgents = [];
   const sessions = new Map();
+  const sessionCreationPromises = new Map();
   const pendingRequests = Object.create(null);
   const liveSessions = new Set();
 
@@ -167,11 +168,24 @@ export function createHappyLayer({
     if (event.kind === "permission-request") {
       const options = Array.isArray(event.payload?.options) ? event.payload.options : [];
       if (!pendingRequests[event.sessionId]) pendingRequests[event.sessionId] = Object.create(null);
-      pendingRequests[event.sessionId][event.payload?.requestId] = {
+      if (typeof event.payload?.requestId !== "string") return;
+      pendingRequests[event.sessionId][event.payload.requestId] = {
         optionIds: options.map((option) => option?.optionId ?? option?.id).filter(Boolean),
       };
     } else if (event.kind === "permission-resolved") {
       delete pendingRequests[event.sessionId]?.[event.payload?.requestId];
+    }
+  }
+
+  function rememberPendingPermissions(sessionId, permissions) {
+    if (!Array.isArray(permissions)) return;
+    for (const permission of permissions) {
+      if (permission?.sessionId !== sessionId || typeof permission.requestId !== "string") continue;
+      rememberPermission({
+        kind: "permission-request",
+        sessionId,
+        payload: permission,
+      });
     }
   }
 
@@ -194,16 +208,16 @@ export function createHappyLayer({
   }
 
   async function handleUserMessage(entry, message) {
-    const mode = message?.meta?.permissionMode;
-    if (typeof mode === "string") await source.setPermissionMode(entry.sessionId, mode);
     if (message?.role !== "user" || message?.content?.type !== "text") {
-      if (typeof mode !== "string") debug("dropped invalid Happy user message");
+      debug("dropped invalid Happy user message");
       return;
     }
     if (typeof message.content.text !== "string" || message.content.text.length === 0) {
       debug("dropped empty Happy user message");
       return;
     }
+    const mode = message.meta?.permissionMode;
+    if (typeof mode === "string") await source.setPermissionMode(entry.sessionId, mode);
     await source.sendPrompt(entry.sessionId, message.content.text);
   }
 
@@ -248,6 +262,7 @@ export function createHappyLayer({
     const entry = { sessionId, happySessionId: session.id, summary, session, client };
     sessions.set(sessionId, entry);
     liveSessions.add(sessionId);
+    rememberPendingPermissions(sessionId, summary?.pendingPermissions);
     registerInbound(entry);
     client.sendSessionEvent({ type: "switch", mode: "remote" });
     return entry;
@@ -256,17 +271,34 @@ export function createHappyLayer({
   async function findOrCreateSession(sessionId, summary = null) {
     const existing = sessions.get(sessionId);
     if (existing) return existing;
-    const listed = summary ?? (await source.listSessions()).find((item) => item.sessionId === sessionId);
-    return createSessionEntry(sessionId, listed ?? {
-      sessionId,
-      agentType: "claude-code",
-      cwd: os.homedir(),
-      status: "ready",
-    });
+    const inFlight = sessionCreationPromises.get(sessionId);
+    if (inFlight) return inFlight;
+    const creation = (async () => {
+      const listed = summary ?? (await source.listSessions()).find((item) => item.sessionId === sessionId);
+      return createSessionEntry(sessionId, listed ?? {
+        sessionId,
+        agentType: "claude-code",
+        cwd: os.homedir(),
+        status: "ready",
+      });
+    })();
+    sessionCreationPromises.set(sessionId, creation);
+    try {
+      return await creation;
+    } finally {
+      sessionCreationPromises.delete(sessionId);
+    }
   }
 
   async function publishEvent(event) {
-    liveSessions.add(event.sessionId);
+    const terminal =
+      event.kind === "status" && ["error", "terminated"].includes(event.payload?.status);
+    if (terminal) {
+      liveSessions.delete(event.sessionId);
+      delete pendingRequests[event.sessionId];
+    } else {
+      liveSessions.add(event.sessionId);
+    }
     rememberPermission(event);
     const summary = (await source.listSessions()).find((item) => item.sessionId === event.sessionId);
     const entry = await findOrCreateSession(event.sessionId, summary);
@@ -355,7 +387,6 @@ export function createHappyLayer({
     machineClient = api.machineSyncClient(machine);
     setupMachineHandlers();
     machineClient.connect();
-    await updateCapabilities();
     supervisorChannel.notify("status_report", { state: "connected", detail: "Connected" });
     return true;
   }
@@ -392,13 +423,13 @@ export function createHappyLayer({
 
   return {
     async start() {
+      supervisorSubscription = supervisorChannel.onNotification((method, params) => {
+        if (method === "roots_update") {
+          advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
+          void updateCapabilities().catch(() => debug("failed to update Happy capabilities"));
+        }
+      });
       if (await registerMachine()) {
-        supervisorSubscription = supervisorChannel.onNotification((method, params) => {
-          if (method === "roots_update") {
-            advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
-            void updateCapabilities().catch(() => debug("failed to update Happy capabilities"));
-          }
-        });
         await updateCapabilities();
         const listed = await source.listSessions();
         for (const summary of listed) await createSessionEntry(summary.sessionId, summary);
@@ -407,6 +438,8 @@ export function createHappyLayer({
         });
         return;
       }
+      supervisorSubscription?.();
+      supervisorSubscription = null;
       return startPairing();
     },
     startPairing,

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -123,6 +123,13 @@ function happyAgentType(agent) {
   return typeof agent === "string" && agent.length > 0 ? agent : "claude-code";
 }
 
+function defaultApprovalPolicy(agentType) {
+  // Match the desktop's fresh-session defaults. Codex is explicitly
+  // on-failure; Claude and Gemini resolve their normal defaults in their
+  // runtimes when no stricter policy is supplied.
+  return agentType === "codex" ? DEFAULT_CODEX_APPROVAL_POLICY : undefined;
+}
+
 function sessionMetadata(config, summary, machineId) {
   const cwd = typeof summary.cwd === "string" && summary.cwd.length > 0 ? summary.cwd : os.homedir();
   return {
@@ -367,8 +374,9 @@ export function createHappyLayer({
       agentType,
       cwd: validation.root,
       localSessionId: conversation.conversationId,
-      approvalPolicy: DEFAULT_CODEX_APPROVAL_POLICY,
+      approvalPolicy: defaultApprovalPolicy(agentType),
     });
+    if (!spawned?.sessionId) throw new Error("provider spawn returned no session");
     sessions.delete(pendingSessionId);
     sessions.set(spawned.sessionId, { ...pending, sessionId: spawned.sessionId, summary: spawned });
     liveSessions.delete(pendingSessionId);

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -1,4 +1,4 @@
-// ABOUTME: Owns the narrow Happy client and hosted-relay pairing adapter.
+// ABOUTME: Owns the narrow Happy client, session stream, and hosted-relay adapter.
 // ABOUTME: Pairing material crosses the supervisor channel only and is never logged.
 
 import { randomUUID } from "node:crypto";
@@ -6,8 +6,12 @@ import os from "node:os";
 import { ApiClient, configuration } from "happy/lib";
 import nacl from "tweetnacl";
 
+import { translateNeutralEvent, composeApprovalNotification } from "./translate.mjs";
+import { validatePermissionResponse, validateSpawnRoot } from "./validate.mjs";
+
 const AUTH_POLL_MS = 1000;
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_CODEX_APPROVAL_POLICY = "on-failure";
 
 function encodeBase64(bytes) {
   return Buffer.from(bytes).toString("base64");
@@ -65,11 +69,7 @@ function identityFromAuthResponse(token, decrypted) {
   if (!decrypted) throw new Error("Happy pairing response could not be decrypted");
   const machineId = randomUUID();
   if (decrypted.length === 32) {
-    return {
-      token,
-      machineId,
-      encryption: { type: "legacy", secret: encodeBase64(decrypted) },
-    };
+    return { token, machineId, encryption: { type: "legacy", secret: encodeBase64(decrypted) } };
   }
   if (decrypted.length === 33 && decrypted[0] === 0) {
     return {
@@ -104,7 +104,7 @@ async function readAuthRequest(relayUrl, publicKey) {
   return response.json();
 }
 
-function machineMetadata(config) {
+function machineMetadata(config, capabilities = { agents: [], roots: [] }) {
   return {
     host: config.machineName,
     platform: `${process.platform}-${process.arch}`,
@@ -112,15 +112,231 @@ function machineMetadata(config) {
     homeDir: os.homedir(),
     happyHomeDir: os.homedir(),
     happyLibDir: "seren-desktop",
+    remoteCapabilities: capabilities,
   };
 }
 
-export function createHappyLayer({ config, supervisorChannel, debugLog = () => {} }) {
+function happyAgentType(agent) {
+  if (agent === "claude") return "claude-code";
+  if (agent === "gemini") return "gemini";
+  if (agent === "codex") return "codex";
+  return typeof agent === "string" && agent.length > 0 ? agent : "claude-code";
+}
+
+function sessionMetadata(config, summary, machineId) {
+  const cwd = typeof summary.cwd === "string" && summary.cwd.length > 0 ? summary.cwd : os.homedir();
+  return {
+    path: cwd,
+    host: config.machineName,
+    name: summary.title ?? `${summary.agentType ?? "Agent"} session`,
+    version: "seren-desktop",
+    os: process.platform,
+    machineId,
+    homeDir: os.homedir(),
+    happyHomeDir: os.homedir(),
+    happyLibDir: "seren-desktop",
+    lifecycleState: "running",
+    lifecycleStateSince: Date.now(),
+  };
+}
+
+export function createHappyLayer({
+  config,
+  supervisorChannel,
+  source,
+  debugLog = () => {},
+}) {
   configuration.serverUrl = config.relayUrl;
   let identity = config.machineIdentity;
   let api = null;
   let machineClient = null;
   let pairingPromise = null;
+  let sourceSubscription = null;
+  let supervisorSubscription = null;
+  let advertisedRoots = [];
+  let advertisedAgents = [];
+  const sessions = new Map();
+  const pendingRequests = Object.create(null);
+  const liveSessions = new Set();
+
+  function debug(message) {
+    debugLog(message);
+  }
+
+  function rememberPermission(event) {
+    if (event.kind === "permission-request") {
+      const options = Array.isArray(event.payload?.options) ? event.payload.options : [];
+      if (!pendingRequests[event.sessionId]) pendingRequests[event.sessionId] = Object.create(null);
+      pendingRequests[event.sessionId][event.payload?.requestId] = {
+        optionIds: options.map((option) => option?.optionId ?? option?.id).filter(Boolean),
+      };
+    } else if (event.kind === "permission-resolved") {
+      delete pendingRequests[event.sessionId]?.[event.payload?.requestId];
+    }
+  }
+
+  function registerInbound(entry) {
+    const { sessionId, client } = entry;
+    client.onUserMessage((message) => {
+      void handleUserMessage(entry, message).catch(() => debug("dropped invalid Happy user message"));
+    });
+    client.rpcHandlerManager.registerHandler("abort", async () => {
+      await source.cancel(sessionId);
+      return { ok: true };
+    });
+    client.rpcHandlerManager.registerHandler("switch", async () => {
+      await source.cancel(sessionId);
+      return { ok: true };
+    });
+    client.rpcHandlerManager.registerHandler("permission", async (response) =>
+      handlePermissionResponse(entry, response),
+    );
+  }
+
+  async function handleUserMessage(entry, message) {
+    const mode = message?.meta?.permissionMode;
+    if (typeof mode === "string") await source.setPermissionMode(entry.sessionId, mode);
+    if (message?.role !== "user" || message?.content?.type !== "text") {
+      if (typeof mode !== "string") debug("dropped invalid Happy user message");
+      return;
+    }
+    if (typeof message.content.text !== "string" || message.content.text.length === 0) {
+      debug("dropped empty Happy user message");
+      return;
+    }
+    await source.sendPrompt(entry.sessionId, message.content.text);
+  }
+
+  async function handlePermissionResponse(entry, response) {
+    const requestId = response?.id ?? response?.requestId;
+    const offered = pendingRequests[entry.sessionId]?.[requestId];
+    let optionId = response?.optionId;
+    if (!optionId && offered?.optionIds) {
+      optionId = response?.approved
+        ? offered.optionIds.find((id) => !["deny", "decline", "reject", "cancel"].includes(id))
+        : offered.optionIds.find((id) => ["deny", "decline", "reject", "cancel"].includes(id));
+    }
+    if (typeof requestId !== "string" || typeof optionId !== "string") {
+      debug("dropped invalid Happy permission response");
+      return { ok: false };
+    }
+    const validation = validatePermissionResponse(entry.sessionId, requestId, optionId, {
+      liveSessions,
+      pendingRequests,
+    });
+    if (!validation.ok) {
+      debug("dropped invalid Happy permission response");
+      return { ok: false };
+    }
+    await source.respondToPermission(entry.sessionId, requestId, optionId);
+    delete pendingRequests[entry.sessionId]?.[requestId];
+    return { ok: true };
+  }
+
+  async function createSessionEntry(sessionId, summary, existingSession = null) {
+    const existing = sessions.get(sessionId);
+    if (existing) return existing;
+    if (!api || !identity) throw new Error("Happy API is not registered");
+    const machineId = identity.machineId ?? "seren-desktop";
+    const session = existingSession ?? await api.getOrCreateSession({
+      tag: `seren-${sessionId}`,
+      metadata: sessionMetadata(config, summary, machineId),
+      state: { controlledByUser: true },
+    });
+    if (!session) throw new Error("Happy relay did not return a session");
+    const client = api.sessionSyncClient(session);
+    const entry = { sessionId, happySessionId: session.id, summary, session, client };
+    sessions.set(sessionId, entry);
+    liveSessions.add(sessionId);
+    registerInbound(entry);
+    client.sendSessionEvent({ type: "switch", mode: "remote" });
+    return entry;
+  }
+
+  async function findOrCreateSession(sessionId, summary = null) {
+    const existing = sessions.get(sessionId);
+    if (existing) return existing;
+    const listed = summary ?? (await source.listSessions()).find((item) => item.sessionId === sessionId);
+    return createSessionEntry(sessionId, listed ?? {
+      sessionId,
+      agentType: "claude-code",
+      cwd: os.homedir(),
+      status: "ready",
+    });
+  }
+
+  async function publishEvent(event) {
+    liveSessions.add(event.sessionId);
+    rememberPermission(event);
+    const summary = (await source.listSessions()).find((item) => item.sessionId === event.sessionId);
+    const entry = await findOrCreateSession(event.sessionId, summary);
+    const provider = summary?.agentType === "claude-code" ? "claude" : summary?.agentType ?? "codex";
+    for (const message of translateNeutralEvent(event, { provider })) {
+      if (message.transport === "session") entry.client.sendSessionProtocolMessage(message.envelope);
+      if (message.transport === "agent") entry.client.sendAgentMessage(message.provider, message.body);
+    }
+    if (event.kind === "permission-request" && api) {
+      const notification = composeApprovalNotification();
+      api.push().sendToAllDevices(notification.title, notification.body, notification.data);
+    }
+  }
+
+  async function updateCapabilities() {
+    if (!machineClient || !source) return;
+    const advertised = await source.advertise();
+    advertisedAgents = Array.isArray(advertised.agents) ? advertised.agents : [];
+    await machineClient.updateMachineMetadata((metadata) => ({
+      ...(metadata ?? machineMetadata(config)),
+      remoteCapabilities: { agents: advertisedAgents, roots: advertisedRoots },
+    }));
+  }
+
+  async function handleSpawn(options) {
+    const validation = validateSpawnRoot(options?.directory, advertisedRoots);
+    if (!validation.ok) {
+      debug("refused spawn outside advertised roots");
+      return { type: "error", errorMessage: "Requested directory is not an advertised root" };
+    }
+    const agentType = happyAgentType(options?.agent);
+    const pendingSessionId = `spawn-${randomUUID()}`;
+    const pending = await createSessionEntry(pendingSessionId, {
+      sessionId: pendingSessionId,
+      agentType,
+      cwd: validation.root,
+      title: `${agentType} Agent`,
+      status: "initializing",
+    });
+    const conversation = await supervisorChannel.call("conversation_create", {
+      agentType,
+      cwd: validation.root,
+      title: `${agentType} Agent`,
+      happySessionId: pending.happySessionId,
+    });
+    const spawned = await source.spawn({
+      agentType,
+      cwd: validation.root,
+      localSessionId: conversation.conversationId,
+      approvalPolicy: DEFAULT_CODEX_APPROVAL_POLICY,
+    });
+    sessions.delete(pendingSessionId);
+    sessions.set(spawned.sessionId, { ...pending, sessionId: spawned.sessionId, summary: spawned });
+    liveSessions.delete(pendingSessionId);
+    liveSessions.add(spawned.sessionId);
+    pendingRequests[spawned.sessionId] = pendingRequests[pendingSessionId] ?? Object.create(null);
+    delete pendingRequests[pendingSessionId];
+    return { type: "success", sessionId: pending.happySessionId };
+  }
+
+  function setupMachineHandlers() {
+    machineClient.setRPCHandlers({
+      spawnSession: handleSpawn,
+      stopSession: (sessionId) => {
+        void source.cancel(sessionId).catch(() => debug("failed to cancel Happy session"));
+        return true;
+      },
+      requestShutdown: () => debug("Happy client requested bridge shutdown"),
+    });
+  }
 
   async function registerMachine() {
     if (!identity) return false;
@@ -137,7 +353,9 @@ export function createHappyLayer({ config, supervisorChannel, debugLog = () => {
       daemonState: { status: "running", pid: process.pid, startedAt: Date.now() },
     });
     machineClient = api.machineSyncClient(machine);
+    setupMachineHandlers();
     machineClient.connect();
+    await updateCapabilities();
     supervisorChannel.notify("status_report", { state: "connected", detail: "Connected" });
     return true;
   }
@@ -154,7 +372,7 @@ export function createHappyLayer({ config, supervisorChannel, debugLog = () => {
       }
       await new Promise((resolve) => setTimeout(resolve, AUTH_POLL_MS));
     }
-    debugLog("pairing authorization timed out");
+    debug("pairing authorization timed out");
   }
 
   async function startPairing() {
@@ -165,7 +383,7 @@ export function createHappyLayer({ config, supervisorChannel, debugLog = () => {
       const payload = `happy://terminal?${encodeBase64Url(keyPair.publicKey)}`;
       supervisorChannel.notify("pairing_payload", { payload });
       void waitForAuthorization(keyPair).catch((error) => {
-        debugLog(`pairing authorization failed: ${error instanceof Error ? error.message : "unknown error"}`);
+        debug(`pairing authorization failed: ${error instanceof Error ? error.message : "unknown error"}`);
       });
       return payload;
     })();
@@ -174,11 +392,29 @@ export function createHappyLayer({ config, supervisorChannel, debugLog = () => {
 
   return {
     async start() {
-      if (await registerMachine()) return;
+      if (await registerMachine()) {
+        supervisorSubscription = supervisorChannel.onNotification((method, params) => {
+          if (method === "roots_update") {
+            advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
+            void updateCapabilities().catch(() => debug("failed to update Happy capabilities"));
+          }
+        });
+        await updateCapabilities();
+        const listed = await source.listSessions();
+        for (const summary of listed) await createSessionEntry(summary.sessionId, summary);
+        sourceSubscription = source.subscribe((event) => {
+          void publishEvent(event).catch(() => debug("failed to publish Happy session event"));
+        });
+        return;
+      }
       return startPairing();
     },
     startPairing,
     close() {
+      sourceSubscription?.();
+      supervisorSubscription?.();
+      for (const entry of sessions.values()) void entry.client.close();
+      sessions.clear();
       machineClient?.shutdown();
       machineClient = null;
       api = null;

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -167,12 +167,36 @@ function normalizeSession(session) {
   };
 }
 
+function providerPermissionMode(mode, agentType) {
+  if (agentType === "codex") {
+    if (mode === "ask" || mode === "auto") return mode;
+    return ["plan", "read-only"].includes(mode) ? "ask" : "auto";
+  }
+  if (agentType === "gemini") {
+    return {
+      default: "default",
+      acceptEdits: "auto_edit",
+      bypassPermissions: "yolo",
+      plan: "plan",
+      "read-only": "plan",
+      "safe-yolo": "yolo",
+      yolo: "yolo",
+    }[mode] ?? mode;
+  }
+  return mode;
+}
+
 export function createProviderSource({ client, config, debugLog = () => {} }) {
+  const agentTypes = new Map();
+
   return {
     async listSessions() {
       const result = await client.call("provider_list_sessions");
       const sessions = Array.isArray(result) ? result : result?.sessions;
-      return Array.isArray(sessions) ? sessions.map(normalizeSession) : [];
+      if (!Array.isArray(sessions)) return [];
+      const normalized = sessions.map(normalizeSession);
+      for (const session of normalized) agentTypes.set(session.sessionId, session.agentType);
+      return normalized;
     },
 
     subscribe(onEvent) {
@@ -204,7 +228,11 @@ export function createProviderSource({ client, config, debugLog = () => {} }) {
     },
 
     async setPermissionMode(sessionId, mode) {
-      await client.call("provider_set_permission_mode", { sessionId, mode });
+      const agentType = agentTypes.get(sessionId);
+      await client.call("provider_set_permission_mode", {
+        sessionId,
+        mode: providerPermissionMode(mode, agentType),
+      });
     },
 
     async spawn(spec) {
@@ -220,7 +248,9 @@ export function createProviderSource({ client, config, debugLog = () => {} }) {
         initialModelId: spec.initialModelId ?? null,
         reasoningEffort: spec.reasoningEffort ?? null,
       });
-      return normalizeSession(result);
+      const session = normalizeSession(result);
+      agentTypes.set(session.sessionId, session.agentType);
+      return session;
     },
 
     async advertise() {

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -203,6 +203,10 @@ export function createProviderSource({ client, config, debugLog = () => {} }) {
       return { ok: true };
     },
 
+    async setPermissionMode(sessionId, mode) {
+      await client.call("provider_set_permission_mode", { sessionId, mode });
+    },
+
     async spawn(spec) {
       const result = await client.call("provider_spawn", {
         agentType: spec.agentType,

--- a/bin/happy-bridge/session-source.mjs
+++ b/bin/happy-bridge/session-source.mjs
@@ -1,58 +1,20 @@
-// ABOUTME: Defines the machine-facing session seam used by the remote bridge.
-// ABOUTME: Keeps provider and future relay types separated by neutral shapes.
+// ABOUTME: Defines the provider-neutral session seam used by the Happy adapter.
+// ABOUTME: It contains contracts only so protocol code cannot leak into providers.
 
 /**
- * @typedef {Object} SessionSummary
- * @property {string} sessionId
- * @property {string} agentType
- * @property {string} cwd
- * @property {string} status
- * @property {string} createdAt
- * @property {string=} agentSessionId
- * @property {Array<Object>=} pendingPermissions
- */
-
-/**
- * @typedef {Object} SessionEvent
- * @property {string} kind
- * @property {string} sessionId
- * @property {Object} payload
- */
-
-/**
- * @typedef {Object} RespondResult
- * @property {boolean} ok
- */
-
-/**
- * @typedef {Object} SpawnSpec
- * @property {string} agentType
- * @property {string} cwd
- * @property {string=} title
- * @property {string=} localSessionId
- * @property {string=} resumeAgentSessionId
- * @property {string=} sandboxMode
- * @property {string=} approvalPolicy
- * @property {boolean=} networkEnabled
- * @property {number=} timeoutSecs
- * @property {string=} initialModelId
- * @property {string=} reasoningEffort
- */
-
-/**
- * @typedef {Object} Advertisement
- * @property {string} machineName
- * @property {Array<Object>} agents
- * @property {string[]} roots
- */
-
-/**
+ * @typedef {{sessionId: string, agentType: string, cwd: string, status?: string, title?: string, createdAt?: string, agentSessionId?: string, pendingPermissions?: unknown[]}} SessionSummary
+ * @typedef {{kind: string, sessionId: string, payload: Record<string, unknown>}} SessionEvent
+ * @typedef {{agentType: string, cwd: string, title?: string, localSessionId?: string, resumeAgentSessionId?: string, sandboxMode?: string, approvalPolicy?: string, networkEnabled?: boolean, timeoutSecs?: number, initialModelId?: string, reasoningEffort?: string, permissionMode?: string}} SpawnSpec
+ * @typedef {{machineName: string, agents: unknown[], roots: string[]}} Advertisement
  * @typedef {Object} SessionSource
  * @property {() => Promise<SessionSummary[]>} listSessions
- * @property {(onEvent: (evt: SessionEvent) => void) => () => void} subscribe
+ * @property {(listener: (event: SessionEvent) => void) => (() => void)} subscribe
  * @property {(sessionId: string, text: string) => Promise<void>} sendPrompt
  * @property {(sessionId: string) => Promise<void>} cancel
- * @property {(sessionId: string, requestId: string, optionId: string) => Promise<RespondResult>} respondToPermission
+ * @property {(sessionId: string, requestId: string, optionId: string) => Promise<{ok: boolean}>} respondToPermission
+ * @property {(sessionId: string, mode: string) => Promise<void>} setPermissionMode
  * @property {(spec: SpawnSpec) => Promise<SessionSummary>} spawn
  * @property {() => Promise<Advertisement>} advertise
  */
+
+export {};

--- a/bin/happy-bridge/supervisor-channel.mjs
+++ b/bin/happy-bridge/supervisor-channel.mjs
@@ -14,6 +14,17 @@ export function createSupervisorChannel({
   let nextId = 0;
   const pending = new Map();
   const notificationListeners = new Set();
+  const notificationQueue = [];
+  const MAX_QUEUED_NOTIFICATIONS = 32;
+
+  function dispatchNotification(method, params) {
+    if (notificationListeners.size === 0) {
+      if (notificationQueue.length === MAX_QUEUED_NOTIFICATIONS) notificationQueue.shift();
+      notificationQueue.push({ method, params });
+      return;
+    }
+    for (const listener of notificationListeners) listener(method, params);
+  }
 
   function handleLine(line) {
     if (Buffer.byteLength(line, "utf8") > MAX_LINE_BYTES) return;
@@ -27,9 +38,7 @@ export function createSupervisorChannel({
 
     if (response?.id === undefined || response?.id === null) {
       if (typeof response?.method === "string") {
-        for (const listener of notificationListeners) {
-          listener(response.method, response.params ?? {});
-        }
+        dispatchNotification(response.method, response.params ?? {});
       }
       return;
     }
@@ -63,6 +72,10 @@ export function createSupervisorChannel({
 
   function onNotification(listener) {
     notificationListeners.add(listener);
+    while (notificationQueue.length > 0) {
+      const notification = notificationQueue.shift();
+      listener(notification.method, notification.params);
+    }
     return () => notificationListeners.delete(listener);
   }
 
@@ -73,6 +86,7 @@ export function createSupervisorChannel({
     }
     pending.clear();
     notificationListeners.clear();
+    notificationQueue.length = 0;
   }
 
   return { call, close, handleLine, notify, onNotification };

--- a/bin/happy-bridge/supervisor-channel.mjs
+++ b/bin/happy-bridge/supervisor-channel.mjs
@@ -13,6 +13,7 @@ export function createSupervisorChannel({
 } = {}) {
   let nextId = 0;
   const pending = new Map();
+  const notificationListeners = new Set();
 
   function handleLine(line) {
     if (Buffer.byteLength(line, "utf8") > MAX_LINE_BYTES) return;
@@ -24,7 +25,14 @@ export function createSupervisorChannel({
       return;
     }
 
-    if (response?.id === undefined || response?.id === null) return;
+    if (response?.id === undefined || response?.id === null) {
+      if (typeof response?.method === "string") {
+        for (const listener of notificationListeners) {
+          listener(response.method, response.params ?? {});
+        }
+      }
+      return;
+    }
     const request = pending.get(response.id);
     if (!request) return;
 
@@ -53,13 +61,19 @@ export function createSupervisorChannel({
     write(JSON.stringify({ jsonrpc: "2.0", method, params }));
   }
 
+  function onNotification(listener) {
+    notificationListeners.add(listener);
+    return () => notificationListeners.delete(listener);
+  }
+
   function close() {
     for (const request of pending.values()) {
       clearTimeout(request.timer);
       request.reject(new Error("supervisor channel closed"));
     }
     pending.clear();
+    notificationListeners.clear();
   }
 
-  return { call, close, handleLine, notify };
+  return { call, close, handleLine, notify, onNotification };
 }

--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -1,4 +1,149 @@
-// ABOUTME: Reserves the neutral-to-remote translation boundary for Phase 3.
-// ABOUTME: Phase 2 intentionally contains no relay or protocol translation.
+// ABOUTME: Translates provider-neutral session events into Happy wire messages.
+// ABOUTME: This module is pure apart from Happy's schema helper and performs no I/O.
 
-export {};
+import { createEnvelope } from "@slopus/happy-wire";
+
+const AGENT_PROVIDER = "codex";
+
+function stringValue(value, fallback = "") {
+  return typeof value === "string" ? value : fallback;
+}
+
+function eventEnvelope(role, ev, payload, suffix) {
+  const id = stringValue(payload?.messageId) ||
+    (stringValue(payload?.toolCallId) ? `${payload.toolCallId}-${suffix}` : undefined);
+  const turn = stringValue(payload?.turnId) || stringValue(payload?.turn);
+  return {
+    transport: "session",
+    envelope: createEnvelope(role, ev, {
+      ...(id ? { id } : {}),
+      ...(turn ? { turn } : {}),
+      ...(typeof payload?.timestamp === "number" ? { time: payload.timestamp } : {}),
+    }),
+  };
+}
+
+function acp(body) {
+  return { transport: "agent", provider: AGENT_PROVIDER, body };
+}
+
+function service(payload, text) {
+  return eventEnvelope("agent", { t: "service", text }, payload, "service");
+}
+
+/**
+ * Convert exactly one neutral event. The returned list is deliberate: a
+ * completion can carry both a turn boundary and usage metadata.
+ *
+ * @param {{kind: string, sessionId: string, payload?: Record<string, unknown>}} event
+ * @returns {Array<Record<string, unknown>>}
+ */
+export function translateNeutralEvent(event, { provider = AGENT_PROVIDER } = {}) {
+  if (!event || typeof event !== "object" || typeof event.kind !== "string") {
+    return [];
+  }
+  const payload = event.payload && typeof event.payload === "object" ? event.payload : {};
+  const text = stringValue(payload.text);
+
+  switch (event.kind) {
+    case "assistant-delta":
+      if (!text) return [];
+      return [eventEnvelope("agent", {
+        t: "text",
+        text,
+        ...(payload.isThought === true ? { thinking: true } : {}),
+      }, payload, "text")];
+    case "user-message":
+      if (!text) return [];
+      return [eventEnvelope("user", { t: "text", text }, payload, "user")];
+    case "tool-start":
+      return [{ ...acp({
+        type: "tool-call",
+        callId: stringValue(payload.toolCallId, "unknown-call"),
+        name: stringValue(payload.name, stringValue(payload.kind, "tool")),
+        input: payload.parameters ?? {},
+        id: stringValue(payload.toolCallId, "unknown-call"),
+      }), provider }];
+    case "tool-end":
+      return [{ ...acp({
+        type: "tool-result",
+        callId: stringValue(payload.toolCallId, "unknown-call"),
+        output: payload.error ?? payload.result ?? "",
+        id: stringValue(payload.toolCallId, "unknown-call"),
+        ...(payload.error ? { isError: true } : {}),
+      }), provider }];
+    case "file-diff":
+      return [{ ...acp({
+        type: "file-edit",
+        description: "File change",
+        filePath: stringValue(payload.path, "unknown file"),
+        diff: typeof payload.newText === "string" ? payload.newText : undefined,
+        oldContent: typeof payload.oldText === "string" ? payload.oldText : undefined,
+        newContent: typeof payload.newText === "string" ? payload.newText : undefined,
+        id: stringValue(payload.toolCallId, "file-change"),
+      }), provider }];
+    case "diff-proposal":
+      return [{ ...acp({
+        type: "file-edit",
+        description: "File change requires approval",
+        filePath: stringValue(payload.path, "unknown file"),
+        diff: typeof payload.newText === "string" ? payload.newText : undefined,
+        oldContent: typeof payload.oldText === "string" ? payload.oldText : undefined,
+        newContent: typeof payload.newText === "string" ? payload.newText : undefined,
+        id: stringValue(payload.proposalId, "file-proposal"),
+      }), provider }];
+    case "diff-proposal-resolved":
+      return [service(payload, `File change ${stringValue(payload.status, "resolved")}.`)];
+    case "plan-update": {
+      const entries = Array.isArray(payload.entries) ? payload.entries : [];
+      const summary = entries
+        .map((entry) => `${stringValue(entry?.status, "pending")}: ${stringValue(entry?.content)}`)
+        .join("\n");
+      return [service(payload, summary ? `Plan updated:\n${summary}` : "Plan updated.")];
+    }
+    case "permission-request":
+      return [{ ...acp({
+        type: "permission-request",
+        permissionId: stringValue(payload.requestId, "unknown-request"),
+        toolName: stringValue(payload.toolName, "tool"),
+        description: stringValue(payload.description, "Approval required"),
+        options: Array.isArray(payload.options) ? payload.options : [],
+      }), provider }];
+    case "permission-resolved":
+      return [service(payload, "Approval resolved.")];
+    case "turn-complete": {
+      const stopReason = stringValue(payload.stopReason, "completed").toLowerCase();
+      const status = stopReason.includes("cancel")
+        ? "cancelled"
+        : stopReason.includes("error") || stopReason.includes("fail")
+          ? "failed"
+          : "completed";
+      const messages = [eventEnvelope("agent", { t: "turn-end", status }, payload, "turn-end")];
+      if (payload.meta?.usage) {
+        messages.push({ ...acp({ type: "token_count", ...payload.meta.usage }), provider });
+      }
+      return messages;
+    }
+    case "status": {
+      const status = stringValue(payload.status, "unknown");
+      return [service(payload, `Session status: ${status}`)];
+    }
+    case "error":
+      return [service(payload, `Session error: ${stringValue(payload.error, "unknown error")}`)];
+    default:
+      return [];
+  }
+}
+
+/**
+ * Push copy is intentionally independent of session metadata. The output may
+ * be sent through Happy's relay, so it must not carry titles, tools, projects,
+ * working directories, URLs, or request contents.
+ */
+export function composeApprovalNotification() {
+  return {
+    title: "Approval needed",
+    body: "Approval needed",
+    data: { kind: "permission" },
+  };
+}

--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -102,13 +102,21 @@ export function translateNeutralEvent(event, { provider = AGENT_PROVIDER } = {})
       return [service(payload, summary ? `Plan updated:\n${summary}` : "Plan updated.")];
     }
     case "permission-request":
+      {
+        const toolCall = payload.toolCall && typeof payload.toolCall === "object"
+          ? payload.toolCall
+          : {};
       return [{ ...acp({
         type: "permission-request",
         permissionId: stringValue(payload.requestId, "unknown-request"),
-        toolName: stringValue(payload.toolName, "tool"),
-        description: stringValue(payload.description, "Approval required"),
+        toolName: stringValue(payload.toolName, stringValue(toolCall.name, "tool")),
+        description: stringValue(
+          payload.description,
+          stringValue(toolCall.description, "Approval required"),
+        ),
         options: Array.isArray(payload.options) ? payload.options : [],
       }), provider }];
+      }
     case "permission-resolved":
       return [service(payload, "Approval resolved.")];
     case "turn-complete": {
@@ -126,6 +134,15 @@ export function translateNeutralEvent(event, { provider = AGENT_PROVIDER } = {})
     }
     case "status": {
       const status = stringValue(payload.status, "unknown");
+      if (["prompting", "busy", "running"].includes(status)) {
+        return [eventEnvelope("agent", { t: "turn-start" }, payload, "turn-start")];
+      }
+      if (["ready", "idle", "completed"].includes(status)) {
+        return [eventEnvelope("agent", { t: "turn-end", status: "completed" }, payload, "turn-end")];
+      }
+      if (["error", "terminated"].includes(status)) {
+        return [eventEnvelope("agent", { t: "turn-end", status: "failed" }, payload, "turn-end")];
+      }
       return [service(payload, `Session status: ${status}`)];
     }
     case "error":

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -115,6 +115,24 @@ impl HappyBridgeManager {
         let machine_identity = self.load_pairing_credential(app)?.map(|credential| {
             serde_json::from_str(&credential).unwrap_or_else(|_| Value::String(credential))
         });
+        // Reuse the existing conversation reader as the source of recent project roots.
+        // There is no separate Rust recent-project registry in this repository.
+        let advertised_roots = crate::commands::chat::list_conversations(
+            app.clone(),
+            None,
+            None,
+            Some(200),
+        )
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|conversation| conversation.project_root.or(conversation.agent_cwd))
+        .fold(Vec::<String>::new(), |mut roots, root| {
+            if !roots.iter().any(|existing| existing == &root) {
+                roots.push(root);
+            }
+            roots
+        });
         let config = HappyBridgeConfig {
             provider_runtime: ProviderRuntimeConnection {
                 host: provider_runtime.host,
@@ -161,6 +179,15 @@ impl HappyBridgeManager {
             .map_err(|err| format!("Failed to flush Happy bridge config: {err}"))?;
 
         let stdin = Arc::new(Mutex::new(stdin));
+        write_supervisor_notification(
+            &stdin,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "roots_update",
+                "params": { "roots": advertised_roots },
+            }),
+        )
+        .await;
         pipe_bridge_output(&mut child, Arc::clone(&stdin), app.clone());
         *self.process.lock().await = Some(HappyBridgeProcess {
             child,
@@ -652,6 +679,22 @@ where
     }
     if let Err(error) = writer.flush().await {
         log::warn!("[HappyBridge] Failed to flush supervisor response: {error}");
+    }
+}
+
+async fn write_supervisor_notification(writer: &Arc<Mutex<ChildStdin>>, notification: Value) {
+    let Ok(mut encoded) = serde_json::to_vec(&notification) else {
+        log::warn!("[HappyBridge] Failed to encode supervisor notification");
+        return;
+    };
+    encoded.push(b'\n');
+    let mut writer = writer.lock().await;
+    if let Err(error) = writer.write_all(&encoded).await {
+        log::warn!("[HappyBridge] Failed to write supervisor notification: {error}");
+        return;
+    }
+    if let Err(error) = writer.flush().await {
+        log::warn!("[HappyBridge] Failed to flush supervisor notification: {error}");
     }
 }
 

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -121,7 +121,7 @@ impl HappyBridgeManager {
             app.clone(),
             None,
             None,
-            Some(200),
+            None,
         )
         .await
         .unwrap_or_default()

--- a/tests/unit/happy-bridge-translate-happy.test.ts
+++ b/tests/unit/happy-bridge-translate-happy.test.ts
@@ -57,6 +57,19 @@ describe("neutral-to-Happy session translation", () => {
     expect(translateNeutralEvent({ kind: "unknown", sessionId: "session-1", payload })).toEqual([]);
   });
 
+  it.each([
+    ["prompting", "turn-start"],
+    ["ready", "turn-end"],
+    ["error", "turn-end"],
+  ])("maps status %s to a Happy %s event", (status, eventType) => {
+    const [message] = translateNeutralEvent({
+      kind: "status",
+      sessionId: "session-1",
+      payload: { status },
+    });
+    expect(message.envelope.ev.t).toBe(eventType);
+  });
+
   it("keeps approval push copy free of session metadata", () => {
     const output = JSON.stringify(composeApprovalNotification({
       sessionTitle: "Project title",
@@ -71,4 +84,3 @@ describe("neutral-to-Happy session translation", () => {
     expect(output).toContain("Approval needed");
   });
 });
-

--- a/tests/unit/happy-bridge-translate-happy.test.ts
+++ b/tests/unit/happy-bridge-translate-happy.test.ts
@@ -1,0 +1,74 @@
+// ABOUTME: Exhaustively verifies neutral session events become Happy messages.
+// ABOUTME: It also locks the generic push copy required by the accepted trust model.
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import {
+  composeApprovalNotification,
+  translateNeutralEvent,
+} from "../../bin/happy-bridge/translate.mjs";
+
+const payload = {
+  text: "assistant text",
+  messageId: "message-1",
+  toolCallId: "call-1",
+  name: "Bash",
+  kind: "shell",
+  title: "Run command",
+  description: "Needs approval",
+  parameters: { command: "pwd" },
+  result: "done",
+  path: "/workspace/project/file.ts",
+  oldText: "old",
+  newText: "new",
+  proposalId: "proposal-1",
+  requestId: "request-1",
+  toolName: "Bash",
+  options: [{ optionId: "allow-once" }],
+  entries: [{ content: "step", status: "pending" }],
+  status: "ready",
+  stopReason: "end_turn",
+  error: "failed",
+};
+
+describe("neutral-to-Happy session translation", () => {
+  it.each([
+    ["assistant-delta", "session"],
+    ["user-message", "session"],
+    ["tool-start", "agent"],
+    ["tool-end", "agent"],
+    ["file-diff", "agent"],
+    ["diff-proposal", "agent"],
+    ["diff-proposal-resolved", "session"],
+    ["plan-update", "session"],
+    ["permission-request", "agent"],
+    ["permission-resolved", "session"],
+    ["turn-complete", "session"],
+    ["status", "session"],
+    ["error", "session"],
+  ])("maps %s to the %s transport", (kind, transport) => {
+    const messages = translateNeutralEvent({ kind, sessionId: "session-1", payload });
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages[0].transport).toBe(transport);
+  });
+
+  it("drops an unknown neutral event", () => {
+    expect(translateNeutralEvent({ kind: "unknown", sessionId: "session-1", payload })).toEqual([]);
+  });
+
+  it("keeps approval push copy free of session metadata", () => {
+    const output = JSON.stringify(composeApprovalNotification({
+      sessionTitle: "Project title",
+      toolName: "Bash",
+      projectName: "Project name",
+      cwd: "/workspace/project",
+      url: "https://relay.invalid/session",
+    }));
+    for (const forbidden of ["Project title", "Bash", "Project name", "/workspace/project", "https://relay.invalid/session"]) {
+      expect(output).not.toContain(forbidden);
+    }
+    expect(output).toContain("Approval needed");
+  });
+});
+


### PR DESCRIPTION
Closes #2985
References #2983 and #2984

## Scope

This pull request completes the Phase 3 remainder on top of the squashed registration and pairing foundation. It adds outbound neutral-event streaming, inbound control handling, and advertised-root remote spawn without changing dependencies. Happy protocol imports remain confined to the Happy layer and the pure translation module.

## Implementation

- Neutral events cover assistant text, user text, tool start and end, file changes, change proposals, plans, approvals, turn completion, status, and errors.
- Approval notifications contain only generic copy: `Approval needed`.
- Inbound user text, abort, permission responses, and permission-mode changes are validated and handled as safe no-ops on invalid input.
- Remote spawn requires exact canonical membership in the advertised roots before creating a conversation.
- Roots reuse `commands::chat::list_conversations` with an unlimited read, filtering the existing project-root and agent-working-directory fields.
- Fresh-session defaults match the desktop: Codex uses `on-failure`; Claude and Gemini use their runtime defaults.
- Dormant-only conversations are intentionally not published in this remainder. The current seam exposes live provider-runtime sessions; dormant listing remains a follow-up rather than being silently represented as live.

## Live hosted-relay verification

The run used the real validation app, its embedded provider runtime, and `https://api.cluster-fluster.com`. No Docker relay, local relay, fake server, or mock was used.

```text
PHONE pairing_authorized=yes payload_logged=no
LIVE_RELAY bridge_status=running
PHONE machine_seen=yes advertised_roots=1
PHONE advertised_root_spawn=success
DESKTOP real_thread_created=yes
SQL conversations_with_happy_session_id=1
PHONE non-advertised request -> Requested directory is not an advertised root
DESKTOP refused spawn outside advertised roots; no conversation row created
CLEANUP remote_session_delete_status=200 remote_machine_delete_status=200
CLEANUP local_happy_session_rows_before=1 after=0
CLEANUP keychain_identity_deleted=yes
```

The bounded spawn, refusal, SQL check, and cleanup were observed against the hosted relay and real desktop runtime. A complete phone-side decrypted outbound-event transcript and inbound prompt/approval walkthrough could not be completed in this environment: the available local data-key credential did not include the phone master private key required by the stock phone flow. No event contents or credential material were logged. The real-phone walkthrough remains the merge gate.

## Checks

- `pnpm check`: passed; repository baseline warnings only.
- `pnpm test`: 334 files, 2,402 passed and 15 skipped.
- `cargo check --locked --manifest-path src-tauri/Cargo.toml`: passed.
- `cargo test --locked --manifest-path src-tauri/Cargo.toml`: 921 passed, 2 ignored; doc tests passed with 1 ignored.

Only the real-phone pairing walkthrough remains before merge.
