### PR TITLE
feat(agent): add Happy approval arbitration

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -207,6 +207,49 @@ function mapDecision(optionId) {
   }
 }
 
+function normalizeOrigin(origin) {
+  return origin === "remote" ? "remote" : "desktop";
+}
+
+/**
+ * Keep resolution idempotency separate from the runtime-specific request
+ * objects. The provider runtime can receive the same response from the
+ * desktop and a remote client during a race, and both callers need a
+ * success-shaped result.
+ */
+export function createResolutionTracker() {
+  const resolved = new Set();
+  const inFlight = new Set();
+  const keyFor = (sessionId, requestId) => `${sessionId}:${requestId}`;
+
+  return {
+    claim(sessionId, requestId) {
+      const key = keyFor(sessionId, requestId);
+      if (resolved.has(key) || inFlight.has(key)) {
+        return { alreadyResolved: true };
+      }
+      inFlight.add(key);
+      return null;
+    },
+    resolve(sessionId, requestId) {
+      const key = keyFor(sessionId, requestId);
+      inFlight.delete(key);
+      resolved.add(key);
+    },
+    release(sessionId, requestId) {
+      inFlight.delete(keyFor(sessionId, requestId));
+    },
+    duplicate(sessionId, requestId) {
+      return resolved.has(keyFor(sessionId, requestId))
+        ? { alreadyResolved: true }
+        : null;
+    },
+    mark(sessionId, requestId) {
+      this.resolve(sessionId, requestId);
+    },
+  };
+}
+
 function modeFromApprovalPolicy(approvalPolicy) {
   switch (approvalPolicy) {
     case "on-request":
@@ -1404,6 +1447,8 @@ function attachProcessListeners(
 
 export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-runtime" }) {
   const sessions = new Map();
+  const permissionResolutions = createResolutionTracker();
+  const diffProposalResolutions = createResolutionTracker();
   // Paired-thread interceptor (#2368): events from inner Claude/Codex
   // sessions that belong to a paired `claude-codex` thread are remapped to
   // the paired session id (with role attribution) before reaching the
@@ -1412,6 +1457,33 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
   const emit = (channel, payload) => {
     if (pairedRuntime?.interceptEmit(channel, payload)) return;
     rawEmit(channel, payload);
+  };
+  const publishPermissionResolution = (sessionId, requestId, optionId, source) => {
+    emit("provider://permission-resolved", {
+      sessionId,
+      requestId,
+      resolution: { optionId, source },
+      origin: source,
+    });
+  };
+  const runPermissionResolution = async ({
+    sessionId,
+    requestId,
+    optionId,
+    source,
+    action,
+  }) => {
+    const duplicate = permissionResolutions.claim(sessionId, requestId);
+    if (duplicate) return duplicate;
+    try {
+      const result = await action();
+      permissionResolutions.resolve(sessionId, requestId);
+      publishPermissionResolution(sessionId, requestId, optionId, source);
+      return result ?? { ok: true };
+    } catch (error) {
+      permissionResolutions.release(sessionId, requestId);
+      throw error;
+    }
   };
   const codexLogPrefix = providerLogPrefix("codex", runtimeMode);
   const agentRegistry = createBrowserLocalAgentRegistry({ emit });
@@ -1720,19 +1792,40 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     }
   }
 
-  async function sendPrompt({ sessionId, prompt, context }) {
+  async function sendPrompt({ sessionId, prompt, context, origin = "desktop" }) {
+    const source = normalizeOrigin(origin);
     const session = sessions.get(sessionId);
     if (!session) {
       if (pairedRuntime.hasSession(sessionId)) {
-        return pairedRuntime.sendPrompt({ sessionId, prompt, context });
+        emit("provider://user-message", {
+          sessionId,
+          text: prompt,
+          origin: source,
+        });
+        return pairedRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
       }
       if (geminiRuntime.hasSession(sessionId)) {
-        return geminiRuntime.sendPrompt({ sessionId, prompt, context });
+        emit("provider://user-message", {
+          sessionId,
+          text: prompt,
+          origin: source,
+        });
+        return geminiRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
       }
       if (lmStudioRuntime.hasSession(sessionId)) {
-        return lmStudioRuntime.sendPrompt({ sessionId, prompt, context });
+        emit("provider://user-message", {
+          sessionId,
+          text: prompt,
+          origin: source,
+        });
+        return lmStudioRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
       }
-      return claudeRuntime.sendPrompt({ sessionId, prompt, context });
+      emit("provider://user-message", {
+        sessionId,
+        text: prompt,
+        origin: source,
+      });
+      return claudeRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
     }
     if (session.currentPrompt) {
       throw new Error("Another prompt is already active for this session.");
@@ -1740,6 +1833,11 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
 
     session.status = "prompting";
     session.latestTurnUsage = undefined;
+    emit("provider://user-message", {
+      sessionId,
+      text: prompt,
+      origin: source,
+    });
     emit("provider://session-status", {
       sessionId,
       status: "prompting",
@@ -1918,46 +2016,85 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     session.serenMcpProxy?.setRouting(routing);
   }
 
-  async function respondToPermission({ sessionId, requestId, optionId }) {
+  async function respondToPermission({
+    sessionId,
+    requestId,
+    optionId,
+    origin = "desktop",
+  }) {
+    const source = normalizeOrigin(origin);
     const session = sessions.get(sessionId);
     if (!session) {
       if (pairedRuntime.hasSession(sessionId)) {
-        return pairedRuntime.respondToPermission({
-          sessionId,
-          requestId,
-          optionId,
+        return runPermissionResolution({
+          sessionId, requestId, optionId, source,
+          action: () => pairedRuntime.respondToPermission({
+            sessionId,
+            requestId,
+            optionId,
+          }),
         });
       }
       if (geminiRuntime.hasSession(sessionId)) {
-        return geminiRuntime.respondToPermission({ sessionId, requestId, optionId });
-      }
-      if (lmStudioRuntime.hasSession(sessionId)) {
-        return lmStudioRuntime.respondToPermission({
-          sessionId,
-          requestId,
-          optionId,
+        return runPermissionResolution({
+          sessionId, requestId, optionId, source,
+          action: () => geminiRuntime.respondToPermission({ sessionId, requestId, optionId }),
         });
       }
-      return claudeRuntime.respondToPermission({ sessionId, requestId, optionId });
+      if (lmStudioRuntime.hasSession(sessionId)) {
+        return runPermissionResolution({
+          sessionId, requestId, optionId, source,
+          action: () => lmStudioRuntime.respondToPermission({
+            sessionId,
+            requestId,
+            optionId,
+          }),
+        });
+      }
+      return runPermissionResolution({
+        sessionId, requestId, optionId, source,
+        action: () => claudeRuntime.respondToPermission({ sessionId, requestId, optionId }),
+      });
     }
 
-    const pending = session.pendingPermissions.get(requestId);
-    if (!pending) {
-      throw new Error(`No pending permission request: ${requestId}`);
-    }
+    return runPermissionResolution({
+      sessionId, requestId, optionId, source,
+      action: () => {
+        const pending = session.pendingPermissions.get(requestId);
+        if (!pending) {
+          throw new Error(`No pending permission request: ${requestId}`);
+        }
 
-    session.pendingPermissions.delete(requestId);
-    writeMessage(session, {
-      jsonrpc: "2.0",
-      id: pending.jsonRpcId,
-      result: {
-        decision: mapDecision(optionId),
+        session.pendingPermissions.delete(requestId);
+        writeMessage(session, {
+          jsonrpc: "2.0",
+          id: pending.jsonRpcId,
+          result: {
+            decision: mapDecision(optionId),
+          },
+        });
       },
     });
   }
 
-  async function respondToDiffProposal() {
-    return null;
+  async function respondToDiffProposal({
+    sessionId,
+    proposalId,
+    accepted,
+    origin = "desktop",
+  }) {
+    const duplicate = diffProposalResolutions.claim(sessionId, proposalId);
+    if (duplicate) return duplicate;
+
+    const source = normalizeOrigin(origin);
+    diffProposalResolutions.resolve(sessionId, proposalId);
+    emit("provider://diff-proposal-resolved", {
+      sessionId,
+      proposalId,
+      resolution: { accepted: accepted === true, source },
+      origin: source,
+    });
+    return { ok: true };
   }
 
   async function getAvailableAgents() {

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -12,6 +12,24 @@ import { validatePermissionResponse, validateSpawnRoot } from "./validate.mjs";
 const AUTH_POLL_MS = 1000;
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_CODEX_APPROVAL_POLICY = "on-failure";
+const DENY_OPTION_IDS = new Set([
+  "deny",
+  "decline",
+  "reject",
+  "reject_once",
+  "reject_always",
+  "cancel",
+]);
+// These are the affirmative option ids currently emitted by the supported
+// desktop runtimes. Prefer the one-turn variant whenever it is offered.
+const NARROW_ALLOW_OPTION_IDS = new Set([
+  "accept",
+  "accept_once",
+  "allow_once",
+  "allow-once",
+  "approve",
+]);
+const NARROW_ALLOW_KINDS = new Set(["allow_once", "allow-once"]);
 
 function encodeBase64(bytes) {
   return Buffer.from(bytes).toString("base64");
@@ -130,6 +148,33 @@ function defaultApprovalPolicy(agentType) {
   return agentType === "codex" ? DEFAULT_CODEX_APPROVAL_POLICY : undefined;
 }
 
+export function selectApprovalOption(options, approved) {
+  const normalized = (Array.isArray(options) ? options : [])
+    .map((option) => (typeof option === "string" ? { optionId: option } : option))
+    .filter((option) => typeof option?.optionId === "string");
+  if (!approved) {
+    return normalized.find(
+      (option) =>
+        DENY_OPTION_IDS.has(option.optionId) ||
+        DENY_OPTION_IDS.has(option.kind) ||
+        DENY_OPTION_IDS.has(option.description),
+    )?.optionId;
+  }
+
+  const narrow = normalized.find(
+    (option) =>
+      NARROW_ALLOW_OPTION_IDS.has(option.optionId) ||
+      NARROW_ALLOW_KINDS.has(option.kind) ||
+      NARROW_ALLOW_KINDS.has(option.description),
+  );
+  return narrow?.optionId ?? normalized.find(
+    (option) =>
+      !DENY_OPTION_IDS.has(option.optionId) &&
+      !DENY_OPTION_IDS.has(option.kind) &&
+      !DENY_OPTION_IDS.has(option.description),
+  )?.optionId;
+}
+
 function sessionMetadata(config, summary, machineId) {
   const cwd = typeof summary.cwd === "string" && summary.cwd.length > 0 ? summary.cwd : os.homedir();
   return {
@@ -178,6 +223,7 @@ export function createHappyLayer({
       if (typeof event.payload?.requestId !== "string") return;
       pendingRequests[event.sessionId][event.payload.requestId] = {
         optionIds: options.map((option) => option?.optionId ?? option?.id).filter(Boolean),
+        options,
       };
     } else if (event.kind === "permission-resolved") {
       delete pendingRequests[event.sessionId]?.[event.payload?.requestId];
@@ -251,10 +297,16 @@ export function createHappyLayer({
     const requestId = response?.id ?? response?.requestId;
     const offered = pendingRequests[entry.sessionId]?.[requestId];
     let optionId = response?.optionId;
-    if (!optionId && offered?.optionIds) {
-      optionId = response?.approved
-        ? offered.optionIds.find((id) => !["deny", "decline", "reject", "cancel"].includes(id))
-        : offered.optionIds.find((id) => ["deny", "decline", "reject", "cancel"].includes(id));
+    if (!optionId && offered) {
+      optionId = selectApprovalOption(
+        offered.options ?? offered.optionIds,
+        response?.approved === true,
+      );
+      debug(
+        `selected approval option (${optionId ? "matched" : "none"}; ${
+          response?.approved === true ? "approve" : "deny"
+        })`,
+      );
     }
     if (typeof requestId !== "string" || typeof optionId !== "string") {
       debug("dropped invalid Happy permission response");

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -211,7 +211,11 @@ export function createProviderSource({ client, config, debugLog = () => {} }) {
     },
 
     async sendPrompt(sessionId, text) {
-      await client.call("provider_prompt", { sessionId, prompt: text });
+      await client.call("provider_prompt", {
+        sessionId,
+        prompt: text,
+        origin: "remote",
+      });
     },
 
     async cancel(sessionId) {
@@ -223,6 +227,17 @@ export function createProviderSource({ client, config, debugLog = () => {} }) {
         sessionId,
         requestId,
         optionId,
+        origin: "remote",
+      });
+      return { ok: true };
+    },
+
+    async respondToDiffProposal(sessionId, proposalId, accepted) {
+      await client.call("provider_respond_to_diff_proposal", {
+        sessionId,
+        proposalId,
+        accepted,
+        origin: "remote",
       });
       return { ok: true };
     },

--- a/bin/happy-bridge/session-source.mjs
+++ b/bin/happy-bridge/session-source.mjs
@@ -12,6 +12,7 @@
  * @property {(sessionId: string, text: string) => Promise<void>} sendPrompt
  * @property {(sessionId: string) => Promise<void>} cancel
  * @property {(sessionId: string, requestId: string, optionId: string) => Promise<{ok: boolean}>} respondToPermission
+ * @property {(sessionId: string, proposalId: string, accepted: boolean) => Promise<{ok: boolean}>} respondToDiffProposal
  * @property {(sessionId: string, mode: string) => Promise<void>} setPermissionMode
  * @property {(spec: SpawnSpec) => Promise<SessionSummary>} spawn
  * @property {() => Promise<Advertisement>} advertise

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -32,6 +32,8 @@ export type AgentType =
   | "lmstudio";
 export type UnlistenFn = () => void;
 
+export type ProviderOrigin = "desktop" | "remote";
+
 /** Roles inside a paired `claude-codex` thread (#2368). */
 export type PairedRole = "planner" | "executor";
 
@@ -238,6 +240,16 @@ export interface PermissionRequestEvent {
   options: PermissionOption[];
 }
 
+export interface PermissionResolvedEvent {
+  sessionId: string;
+  requestId: string;
+  resolution: {
+    optionId: string;
+    source: ProviderOrigin;
+  };
+  origin?: ProviderOrigin;
+}
+
 /** Paired workflow stage shown in the thread header (#2368). */
 export type PairedState =
   | "idle"
@@ -371,6 +383,16 @@ export interface DiffProposalEvent {
   newText: string;
 }
 
+export interface DiffProposalResolvedEvent {
+  sessionId: string;
+  proposalId: string;
+  resolution: {
+    accepted: boolean;
+    source: ProviderOrigin;
+  };
+  origin?: ProviderOrigin;
+}
+
 export interface ConfigOptionsUpdateEvent {
   sessionId: string;
   configOptions: SessionConfigOption[];
@@ -385,6 +407,7 @@ export interface UserMessageEvent {
   timestamp?: number;
   /** True when this user message was emitted from session history replay. */
   replay?: boolean;
+  origin?: ProviderOrigin;
 }
 
 export interface ErrorEvent {
@@ -427,7 +450,9 @@ export type AgentEvent =
   | { type: "planUpdate"; data: PlanUpdateEvent }
   | { type: "promptComplete"; data: PromptCompleteEvent }
   | { type: "permissionRequest"; data: PermissionRequestEvent }
+  | { type: "permissionResolved"; data: PermissionResolvedEvent }
   | { type: "diffProposal"; data: DiffProposalEvent }
+  | { type: "diffProposalResolved"; data: DiffProposalResolvedEvent }
   | { type: "configOptionsUpdate"; data: ConfigOptionsUpdateEvent }
   | { type: "sessionStatus"; data: SessionStatusEvent }
   | { type: "userMessage"; data: UserMessageEvent }
@@ -516,10 +541,11 @@ export async function sendPrompt(
   sessionId: string,
   prompt: string,
   context?: Array<Record<string, string>>,
+  origin?: ProviderOrigin,
 ): Promise<void> {
   return invokeProvider(
     "provider_prompt",
-    { sessionId, prompt, context },
+    { sessionId, prompt, context, ...(origin ? { origin } : {}) },
     { timeoutMs: null },
   );
 }
@@ -657,11 +683,13 @@ export async function respondToPermission(
   sessionId: string,
   requestId: string,
   optionId: string,
+  origin?: ProviderOrigin,
 ): Promise<void> {
   return invokeProvider("provider_respond_to_permission", {
     sessionId,
     requestId,
     optionId,
+    ...(origin ? { origin } : {}),
   });
 }
 
@@ -672,11 +700,13 @@ export async function respondToDiffProposal(
   sessionId: string,
   proposalId: string,
   accepted: boolean,
+  origin?: ProviderOrigin,
 ): Promise<void> {
   return invokeProvider("provider_respond_to_diff_proposal", {
     sessionId,
     proposalId,
     accepted,
+    ...(origin ? { origin } : {}),
   });
 }
 
@@ -820,7 +850,9 @@ const EVENT_SUFFIXES = {
   planUpdate: "plan-update",
   promptComplete: "prompt-complete",
   permissionRequest: "permission-request",
+  permissionResolved: "permission-resolved",
   diffProposal: "diff-proposal",
+  diffProposalResolved: "diff-proposal-resolved",
   sessionStatus: "session-status",
   configOptionsUpdate: "config-options-update",
   userMessage: "user-message",
@@ -948,11 +980,25 @@ export async function subscribeToSession(
         data: PermissionRequestEvent;
       }>("permissionRequest"),
     ),
+    subscribeToEvent<PermissionResolvedEvent>(
+      "permissionResolved",
+      createHandler<{
+        type: "permissionResolved";
+        data: PermissionResolvedEvent;
+      }>("permissionResolved"),
+    ),
     subscribeToEvent<DiffProposalEvent>(
       "diffProposal",
       createHandler<{ type: "diffProposal"; data: DiffProposalEvent }>(
         "diffProposal",
       ),
+    ),
+    subscribeToEvent<DiffProposalResolvedEvent>(
+      "diffProposalResolved",
+      createHandler<{
+        type: "diffProposalResolved";
+        data: DiffProposalResolvedEvent;
+      }>("diffProposalResolved"),
     ),
     subscribeToEvent<SessionStatusEvent>(
       "sessionStatus",
@@ -1018,8 +1064,15 @@ export async function subscribeToAllEvents(
     subscribeToEvent<PermissionRequestEvent>("permissionRequest", (data) =>
       callback({ type: "permissionRequest", data }),
     ),
+    subscribeToEvent<PermissionResolvedEvent>("permissionResolved", (data) =>
+      callback({ type: "permissionResolved", data }),
+    ),
     subscribeToEvent<DiffProposalEvent>("diffProposal", (data) =>
       callback({ type: "diffProposal", data }),
+    ),
+    subscribeToEvent<DiffProposalResolvedEvent>(
+      "diffProposalResolved",
+      (data) => callback({ type: "diffProposalResolved", data }),
     ),
     subscribeToEvent<SessionStatusEvent>("sessionStatus", (data) =>
       callback({ type: "sessionStatus", data }),

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -6651,12 +6651,17 @@ export const agentStore = {
         break;
 
       case "userMessage":
-        this.appendReplayUserChunk(
-          sessionId,
-          event.data.text,
-          event.data.messageId,
-          event.data.timestamp,
-        );
+        // Desktop prompts are already appended by sendPrompt's UI path.
+        // Remote prompts and history replay are the provider's source of
+        // truth and must be reflected in the thread.
+        if (event.data.replay === true || event.data.origin === "remote") {
+          this.appendReplayUserChunk(
+            sessionId,
+            event.data.text,
+            event.data.messageId,
+            event.data.timestamp,
+          );
+        }
         break;
 
       case "promptComplete": {
@@ -7363,6 +7368,24 @@ export const agentStore = {
         ]);
         break;
       }
+
+      case "permissionResolved":
+        setState(
+          "pendingPermissions",
+          state.pendingPermissions.filter(
+            (permission) => permission.requestId !== event.data.requestId,
+          ),
+        );
+        break;
+
+      case "diffProposalResolved":
+        setState(
+          "pendingDiffProposals",
+          state.pendingDiffProposals.filter(
+            (proposal) => proposal.proposalId !== event.data.proposalId,
+          ),
+        );
+        break;
     }
   },
 

--- a/tests/services/providers.test.ts
+++ b/tests/services/providers.test.ts
@@ -110,10 +110,10 @@ describe("provider runtime event subscriptions", () => {
     const unlisteners = mockRuntimeSubscriptions();
 
     const dispose = await subscribeToSession("session-1", vi.fn());
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(14);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(16);
 
     dispose();
-    expect(unlisteners).toHaveLength(14);
+    expect(unlisteners).toHaveLength(16);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -124,8 +124,8 @@ describe("provider runtime event subscriptions", () => {
 
     await expectAggregateError(subscribeToSession("session-1", vi.fn()));
 
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(14);
-    expect(unlisteners).toHaveLength(13);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(16);
+    expect(unlisteners).toHaveLength(15);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -135,10 +135,10 @@ describe("provider runtime event subscriptions", () => {
     const unlisteners = mockRuntimeSubscriptions();
 
     const dispose = await subscribeToAllEvents(vi.fn());
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(15);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(17);
 
     dispose();
-    expect(unlisteners).toHaveLength(15);
+    expect(unlisteners).toHaveLength(17);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }
@@ -149,8 +149,8 @@ describe("provider runtime event subscriptions", () => {
 
     await expectAggregateError(subscribeToAllEvents(vi.fn()));
 
-    expect(onRuntimeEventMock).toHaveBeenCalledTimes(15);
-    expect(unlisteners).toHaveLength(14);
+    expect(onRuntimeEventMock).toHaveBeenCalledTimes(17);
+    expect(unlisteners).toHaveLength(16);
     for (const unlisten of unlisteners) {
       expect(unlisten).toHaveBeenCalledTimes(1);
     }

--- a/tests/unit/happy-bridge-translate-provider.test.ts
+++ b/tests/unit/happy-bridge-translate-provider.test.ts
@@ -4,7 +4,10 @@
 import { describe, expect, it } from "vitest";
 
 // @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
-import { translateProviderEvent } from "../../bin/happy-bridge/provider-source.mjs";
+import {
+  createProviderSource,
+  translateProviderEvent,
+} from "../../bin/happy-bridge/provider-source.mjs";
 
 const mappings = [
   ["provider://message-chunk", "assistant-delta"],
@@ -47,5 +50,54 @@ describe("provider-to-neutral session event translation", () => {
 
   it("drops mapped notifications without a session id", () => {
     expect(translateProviderEvent("provider://message-chunk", { text: "x" })).toBeNull();
+  });
+
+  it("preserves remote origin attribution in provider payloads", () => {
+    expect(
+      translateProviderEvent("provider://permission-resolved", {
+        sessionId: "session-1",
+        origin: "remote",
+        requestId: "request-1",
+        resolution: { optionId: "accept", source: "remote" },
+      }),
+    ).toEqual({
+      kind: "permission-resolved",
+      sessionId: "session-1",
+      payload: {
+        origin: "remote",
+        requestId: "request-1",
+        resolution: { optionId: "accept", source: "remote" },
+      },
+    });
+  });
+
+  it("sends remote origin on bridge prompts and approval responses", async () => {
+    const calls: Array<[string, Record<string, unknown>]> = [];
+    const source = createProviderSource({
+      config: { machineName: "test-machine" },
+      client: {
+        call: async (method: string, params: Record<string, unknown>) => {
+          calls.push([method, params]);
+          return [];
+        },
+        subscribeNotifications: () => () => {},
+      },
+    });
+
+    await source.sendPrompt("session-1", "hello");
+    await source.respondToPermission("session-1", "request-1", "allow_once");
+
+    expect(calls).toEqual([
+      ["provider_prompt", { sessionId: "session-1", prompt: "hello", origin: "remote" }],
+      [
+        "provider_respond_to_permission",
+        {
+          sessionId: "session-1",
+          requestId: "request-1",
+          optionId: "allow_once",
+          origin: "remote",
+        },
+      ],
+    ]);
   });
 });

--- a/tests/unit/happy-resolution-arbitration.test.ts
+++ b/tests/unit/happy-resolution-arbitration.test.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Verifies provider resolution idempotency and safe approval choice.
+// ABOUTME: These tests exercise pure arbitration helpers without runtime mocks.
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — the provider runtime is plain ESM without declarations.
+import { createResolutionTracker } from "../../bin/browser-local/providers.mjs";
+// @ts-expect-error — the bridge layer is plain ESM without declarations.
+import { selectApprovalOption } from "../../bin/happy-bridge/happy-layer.mjs";
+
+describe("provider resolution arbitration", () => {
+  it("returns a success-shaped alreadyResolved result for duplicate responses", () => {
+    const tracker = createResolutionTracker();
+
+    expect(tracker.duplicate("session-1", "request-1")).toBeNull();
+    tracker.mark("session-1", "request-1");
+    expect(tracker.duplicate("session-1", "request-1")).toEqual({
+      alreadyResolved: true,
+    });
+  });
+
+  it("maps approval to the narrowest known allow option", () => {
+    expect(
+      selectApprovalOption(
+        [
+          { optionId: "allow_session", kind: "allow_always" },
+          { optionId: "allow_once", kind: "allow_once" },
+          { optionId: "deny", kind: "reject_once" },
+        ],
+        true,
+      ),
+    ).toBe("allow_once");
+  });
+
+  it("uses the first non-deny option only when no known allow id or kind is offered", () => {
+    expect(
+      selectApprovalOption(
+        [
+          { optionId: "custom_allow", description: "custom_allow" },
+          { optionId: "reject_once", description: "reject_once" },
+        ],
+        true,
+      ),
+    ).toBe("custom_allow");
+  });
+});


### PR DESCRIPTION
Closes #2988
Closes #2987

## Summary

This change adds provider-runtime approval arbitration for remote clients. Permission and diff-proposal resolutions are broadcast to every connected client, duplicate responses are success-shaped and idempotent, and prompt and resolution events carry desktop/remote origin attribution. The Happy bridge sends remote origin on prompt and approval RPCs and chooses a narrow one-turn approval option when the runtime advertises one.

## Verification

- `pnpm check` exits 0; the repository reports existing warnings in unrelated files.
- `pnpm test` passes: 332 files, 2,407 tests; 3 files and 15 tests skipped by repository configuration.
- `pnpm test:runtime-smoke` passes against the real local provider-runtime process.
- `cargo check --locked --manifest-path src-tauri/Cargo.toml` passes.
- `cargo test --locked --manifest-path src-tauri/Cargo.toml` passes: 921 passed, 2 ignored.
- No manifest or lockfile changes.

## Real-app walkthrough

The validation Tauri app was built and run from this branch. Two independent WebSocket clients authenticated to its live provider runtime; one real Codex session was created in a temporary directory, prompted once, and terminated after the run. The second client observed redacted event kinds: `session-status`, `user-message`, `message-chunk`, `tool-call`, `tool-result`, and `prompt-complete`.

The selected runtime executed the command without emitting a permission request, so a real approval dialog was not available for this run. Consequently, the second-client approval, desktop auto-dismiss, duplicate-response result, and origin echo on a resolved approval remain unverified and are not claimed here. No mock server or synthetic provider was used.

## Remaining live verification

Run one real permission-capable session with a second authenticated runtime client, answer it from the second client, verify the desktop dialog closes, repeat the response, and record the success-shaped duplicate result. Merge remains subject to that live walkthrough.
