### PR TITLE
fix(remote): close Happy v3.71.0 release blockers

### DIFF
--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -1047,6 +1047,11 @@ function buildApprovalOptions() {
       label: "Approve session",
       description: "Allow similar actions for the rest of this session.",
     },
+    {
+      optionId: "decline",
+      label: "Deny",
+      description: "Reject this action.",
+    },
   ];
 }
 

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -243,13 +243,13 @@ export function createHappyLayer({
   }
 
   function registerInbound(entry) {
-    const { sessionId, client } = entry;
+    const { client } = entry;
     client.onUserMessage((message) => {
       void handleUserMessage(entry, message).catch(() => debug("ignored Happy inbound user message"));
     });
     client.rpcHandlerManager.registerHandler("abort", async () => {
       try {
-        await source.cancel(sessionId);
+        await source.cancel(entry.sessionId);
         return { ok: true };
       } catch {
         debug("ignored failed Happy abort request");
@@ -258,7 +258,7 @@ export function createHappyLayer({
     });
     client.rpcHandlerManager.registerHandler("switch", async () => {
       try {
-        await source.cancel(sessionId);
+        await source.cancel(entry.sessionId);
         return { ok: true };
       } catch {
         debug("ignored failed Happy switch request");
@@ -295,7 +295,8 @@ export function createHappyLayer({
 
   async function handlePermissionResponse(entry, response) {
     const requestId = response?.id ?? response?.requestId;
-    const offered = pendingRequests[entry.sessionId]?.[requestId];
+    const sessionId = entry.sessionId;
+    const offered = pendingRequests[sessionId]?.[requestId];
     let optionId = response?.optionId;
     if (!optionId && offered) {
       optionId = selectApprovalOption(
@@ -312,7 +313,7 @@ export function createHappyLayer({
       debug("dropped invalid Happy permission response");
       return { ok: false };
     }
-    const validation = validatePermissionResponse(entry.sessionId, requestId, optionId, {
+    const validation = validatePermissionResponse(sessionId, requestId, optionId, {
       liveSessions,
       pendingRequests,
     });
@@ -320,8 +321,8 @@ export function createHappyLayer({
       debug("dropped invalid Happy permission response");
       return { ok: false };
     }
-    await source.respondToPermission(entry.sessionId, requestId, optionId);
-    delete pendingRequests[entry.sessionId]?.[requestId];
+    await source.respondToPermission(sessionId, requestId, optionId);
+    delete pendingRequests[sessionId]?.[requestId];
     return { ok: true };
   }
 
@@ -385,6 +386,11 @@ export function createHappyLayer({
       if (message.transport === "session") entry.client.sendSessionProtocolMessage(message.envelope);
       if (message.transport === "agent") entry.client.sendAgentMessage(message.provider, message.body);
     }
+    if (terminal) {
+      const terminalEntry = sessions.get(event.sessionId);
+      sessions.delete(event.sessionId);
+      void terminalEntry?.client.close();
+    }
     if (event.kind === "permission-request" && api) {
       const notification = composeApprovalNotification();
       api.push().sendToAllDevices(notification.title, notification.body, notification.data);
@@ -430,7 +436,9 @@ export function createHappyLayer({
     });
     if (!spawned?.sessionId) throw new Error("provider spawn returned no session");
     sessions.delete(pendingSessionId);
-    sessions.set(spawned.sessionId, { ...pending, sessionId: spawned.sessionId, summary: spawned });
+    pending.sessionId = spawned.sessionId;
+    pending.summary = spawned;
+    sessions.set(spawned.sessionId, pending);
     liveSessions.delete(pendingSessionId);
     liveSessions.add(spawned.sessionId);
     pendingRequests[spawned.sessionId] = pendingRequests[pendingSessionId] ?? Object.create(null);
@@ -478,6 +486,13 @@ export function createHappyLayer({
         identity = identityFromAuthResponse(result.token, decryptAuthResponse(result.response, keyPair.secretKey));
         await supervisorChannel.call("identity_store", { identity });
         await registerMachine();
+        supervisorSubscription = supervisorChannel.onNotification((method, params) => {
+          if (method === "roots_update") {
+            advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
+            void updateCapabilities().catch(() => debug("failed to update Happy capabilities"));
+          }
+        });
+        await finishRegistration();
         return;
       }
       await new Promise((resolve) => setTimeout(resolve, AUTH_POLL_MS));
@@ -500,6 +515,16 @@ export function createHappyLayer({
     return pairingPromise;
   }
 
+  async function finishRegistration() {
+    await updateCapabilities();
+    const listed = await source.listSessions();
+    for (const summary of listed) await createSessionEntry(summary.sessionId, summary);
+    sourceSubscription?.();
+    sourceSubscription = source.subscribe((event) => {
+      void publishEvent(event).catch(() => debug("failed to publish Happy session event"));
+    });
+  }
+
   return {
     async start() {
       supervisorSubscription = supervisorChannel.onNotification((method, params) => {
@@ -509,12 +534,7 @@ export function createHappyLayer({
         }
       });
       if (await registerMachine()) {
-        await updateCapabilities();
-        const listed = await source.listSessions();
-        for (const summary of listed) await createSessionEntry(summary.sessionId, summary);
-        sourceSubscription = source.subscribe((event) => {
-          void publishEvent(event).catch(() => debug("failed to publish Happy session event"));
-        });
+        await finishRegistration();
         return;
       }
       supervisorSubscription?.();

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -379,6 +379,7 @@ export function createHappyLayer({
       liveSessions.add(event.sessionId);
     }
     rememberPermission(event);
+    if (terminal && !sessions.has(event.sessionId)) return;
     const summary = (await source.listSessions()).find((item) => item.sessionId === event.sessionId);
     const entry = await findOrCreateSession(event.sessionId, summary);
     const provider = summary?.agentType === "claude-code" ? "claude" : summary?.agentType ?? "codex";

--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -68,6 +68,9 @@ function main(): void {
   // the package must be present in the bundle or the runtime exits before it
   // becomes ready (#2456).
   const lmstudioSdkVersion = rootPackageJson.dependencies?.["@lmstudio/sdk"] ?? "1.5.0";
+  const happyVersion = rootPackageJson.dependencies?.happy ?? "1.2.0";
+  const tweetnaclVersion = rootPackageJson.dependencies?.tweetnacl ?? "1.0.3";
+  const happyWireVersion = rootPackageJson.dependencies?.["@slopus/happy-wire"] ?? "0.1.0";
 
   rmSync(destDir, { recursive: true, force: true });
   mkdirSync(destDir, { recursive: true });
@@ -97,6 +100,9 @@ function main(): void {
         type: "module",
         dependencies: {
           "@lmstudio/sdk": lmstudioSdkVersion,
+          "@slopus/happy-wire": happyWireVersion,
+          happy: happyVersion,
+          tweetnacl: tweetnaclVersion,
           ws: wsVersion,
         },
       },
@@ -122,6 +128,9 @@ function main(): void {
         builtAt: new Date().toISOString(),
         dependencies: {
           "@lmstudio/sdk": lmstudioSdkVersion,
+          "@slopus/happy-wire": happyWireVersion,
+          happy: happyVersion,
+          tweetnacl: tweetnaclVersion,
           ws: wsVersion,
         },
       },

--- a/src-tauri/src/commands/happy_bridge.rs
+++ b/src-tauri/src/commands/happy_bridge.rs
@@ -30,11 +30,11 @@ pub fn effective_advertised_roots(app: &AppHandle, discovered: Vec<String>) -> V
         .ok()
         .and_then(|store| store.get(ADVERTISED_ROOTS_KEY))
     else {
-        return discovered;
+        return Vec::new();
     };
 
     let Some(saved) = value.as_array() else {
-        return discovered;
+        return Vec::new();
     };
     saved
         .iter()

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -61,6 +61,7 @@ pub struct HappyBridgeManager {
     process: Arc<Mutex<Option<HappyBridgeProcess>>>,
     monitor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     status: Arc<Mutex<HappyBridgeStatus>>,
+    restart_attempts: Arc<Mutex<u32>>,
     pairing_payload: Arc<Mutex<Option<String>>>,
 }
 
@@ -73,6 +74,7 @@ impl HappyBridgeManager {
                 state: HappyBridgeState::Stopped,
                 detail: None,
             })),
+            restart_attempts: Arc::new(Mutex::new(0)),
             pairing_payload: Arc::new(Mutex::new(None)),
         }
     }
@@ -94,13 +96,13 @@ impl HappyBridgeManager {
         }
 
         self.set_status(app, HappyBridgeState::Starting, None).await;
+        *self.restart_attempts.lock().await = 0;
         if let Err(error) = self.start_process(app).await {
             self.set_status(app, HappyBridgeState::Error, Some(error.clone()))
                 .await;
             return Err(error);
         }
 
-        self.set_status(app, HappyBridgeState::Running, None).await;
         self.ensure_monitor(app.clone()).await;
         Ok(())
     }
@@ -117,26 +119,20 @@ impl HappyBridgeManager {
         });
         // Reuse the existing conversation reader as the source of recent project roots.
         // There is no separate Rust recent-project registry in this repository.
-        let discovered_roots = crate::commands::chat::list_conversations(
-            app.clone(),
-            None,
-            None,
-            None,
-        )
-        .await
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|conversation| conversation.project_root.or(conversation.agent_cwd))
-        .fold(Vec::<String>::new(), |mut roots, root| {
-            if !roots.iter().any(|existing| existing == &root) {
-                roots.push(root);
-            }
-            roots
-        });
-        let advertised_roots = crate::commands::happy_bridge::effective_advertised_roots(
-            app,
-            discovered_roots,
-        );
+        let discovered_roots =
+            crate::commands::chat::list_conversations(app.clone(), None, None, None)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|conversation| conversation.project_root.or(conversation.agent_cwd))
+                .fold(Vec::<String>::new(), |mut roots, root| {
+                    if !roots.iter().any(|existing| existing == &root) {
+                        roots.push(root);
+                    }
+                    roots
+                });
+        let advertised_roots =
+            crate::commands::happy_bridge::effective_advertised_roots(app, discovered_roots);
         let config = HappyBridgeConfig {
             provider_runtime: ProviderRuntimeConnection {
                 host: provider_runtime.host,
@@ -148,7 +144,7 @@ impl HappyBridgeManager {
             machine_name: "seren-desktop".to_string(),
         };
 
-        let mut command = Command::new(node_binary);
+        let mut command = Command::new(&node_binary);
         command
             .arg(&bridge_entry)
             .kill_on_drop(true)
@@ -213,8 +209,9 @@ impl HappyBridgeManager {
         guard.take();
         let process = Arc::clone(&self.process);
         let status = Arc::clone(&self.status);
+        let restart_attempts = Arc::clone(&self.restart_attempts);
         *guard = Some(tokio::spawn(async move {
-            monitor_process(app, process, status).await;
+            monitor_process(app, process, status, restart_attempts).await;
         }));
     }
 
@@ -376,6 +373,7 @@ async fn monitor_process(
     app: AppHandle,
     process: Arc<Mutex<Option<HappyBridgeProcess>>>,
     status: Arc<Mutex<HappyBridgeStatus>>,
+    restart_attempts: Arc<Mutex<u32>>,
 ) {
     loop {
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -400,42 +398,40 @@ async fn monitor_process(
             continue;
         }
 
-        for attempt in 0..MAX_RESTART_ATTEMPTS {
-            let delay = restart_delay(attempt);
-            {
-                let mut current = status.lock().await;
-                current.state = HappyBridgeState::Starting;
-                current.detail = Some(format!(
-                    "restart attempt {}/{}",
-                    attempt + 1,
-                    MAX_RESTART_ATTEMPTS
-                ));
-                let _ = app.emit(STATUS_EVENT, current.clone());
+        let attempt = {
+            let mut attempts = restart_attempts.lock().await;
+            if !restart_allowed(*attempts) {
+                let failed = HappyBridgeStatus {
+                    state: HappyBridgeState::Error,
+                    detail: Some("restart budget exhausted".to_string()),
+                };
+                *status.lock().await = failed.clone();
+                let _ = app.emit(STATUS_EVENT, failed);
+                return;
             }
-            tokio::time::sleep(delay).await;
+            *attempts += 1;
+            *attempts
+        };
+        let delay = restart_delay(attempt - 1);
+        {
+            let mut current = status.lock().await;
+            current.state = HappyBridgeState::Starting;
+            current.detail = Some(format!("restart attempt {attempt}/{MAX_RESTART_ATTEMPTS}"));
+            let _ = app.emit(STATUS_EVENT, current.clone());
+        }
+        tokio::time::sleep(delay).await;
 
-            let manager = app.state::<HappyBridgeManager>();
-            match manager.start_process(&app).await {
-                Ok(()) => {
-                    let running = HappyBridgeStatus {
-                        state: HappyBridgeState::Running,
-                        detail: None,
-                    };
-                    *status.lock().await = running.clone();
-                    let _ = app.emit(STATUS_EVENT, running);
-                    break;
-                }
-                Err(error) if attempt + 1 == MAX_RESTART_ATTEMPTS => {
-                    let failed = HappyBridgeStatus {
-                        state: HappyBridgeState::Error,
-                        detail: Some(error),
-                    };
-                    *status.lock().await = failed.clone();
-                    let _ = app.emit(STATUS_EVENT, failed);
-                }
-                Err(error) => {
-                    log::warn!("[HappyBridge] Restart failed: {error}");
-                }
+        let manager = app.state::<HappyBridgeManager>();
+        if let Err(error) = manager.start_process(&app).await {
+            if attempt >= MAX_RESTART_ATTEMPTS {
+                let failed = HappyBridgeStatus {
+                    state: HappyBridgeState::Error,
+                    detail: Some(error),
+                };
+                *status.lock().await = failed.clone();
+                let _ = app.emit(STATUS_EVENT, failed);
+            } else {
+                log::warn!("[HappyBridge] Restart failed: {error}");
             }
         }
     }
@@ -461,6 +457,10 @@ async fn terminate_child(child: &mut Child) -> Result<(), String> {
 fn restart_delay(attempt: u32) -> Duration {
     let seconds = 2u64.saturating_pow(attempt).min(MAX_BACKOFF_SECONDS);
     Duration::from_secs(seconds)
+}
+
+fn restart_allowed(attempts: u32) -> bool {
+    attempts < MAX_RESTART_ATTEMPTS
 }
 
 fn resolve_node_binary(app: &AppHandle) -> PathBuf {
@@ -822,8 +822,8 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
 #[cfg(test)]
 mod tests {
     use super::{
-        BoundedLine, MAX_SUPERVISOR_LINE_BYTES, error_response, parse_supervisor_line,
-        read_bounded_line, restart_delay,
+        BoundedLine, MAX_RESTART_ATTEMPTS, MAX_SUPERVISOR_LINE_BYTES, error_response,
+        parse_supervisor_line, read_bounded_line, restart_allowed, restart_delay,
     };
     use serde_json::Value;
     use std::time::Duration;
@@ -835,6 +835,13 @@ mod tests {
         assert_eq!(restart_delay(1), Duration::from_secs(2));
         assert_eq!(restart_delay(2), Duration::from_secs(4));
         assert_eq!(restart_delay(10), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn restart_budget_is_global_and_exhausts() {
+        assert!(restart_allowed(0));
+        assert!(restart_allowed(MAX_RESTART_ATTEMPTS - 1));
+        assert!(!restart_allowed(MAX_RESTART_ATTEMPTS));
     }
 
     #[test]

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -155,6 +155,11 @@ impl HappyBridgeManager {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        let embedded_path = crate::embedded_runtime::get_embedded_path();
+        if !embedded_path.is_empty() {
+            command.env("PATH", embedded_path);
+        }
+        command.env("SEREN_EMBEDDED_NODE_BIN", &node_binary);
         crate::embedded_runtime::sanitize_spawn_env(&mut command);
 
         #[cfg(windows)]

--- a/src/components/settings/HappyRemoteSettings.tsx
+++ b/src/components/settings/HappyRemoteSettings.tsx
@@ -10,6 +10,7 @@ import {
   Show,
 } from "solid-js";
 import { toDataURL } from "@/lib/qrcode-shim";
+import { captureSupportError } from "@/lib/support/hook";
 import { listConversations } from "@/lib/tauri-bridge";
 import {
   disableRemoteAccess,
@@ -96,7 +97,15 @@ export const HappyRemoteSettings: Component = () => {
   onMount(() => {
     void refreshStatus();
     void loadRoots();
-    void onStatusChange((next) => setStatus(next)).then((unlisten) => {
+    void onStatusChange((next) => {
+      setStatus(next);
+      if (next.state === "error") {
+        void captureSupportError({
+          kind: "HappyBridgeError",
+          message: next.detail ?? "Happy bridge stopped unexpectedly",
+        });
+      }
+    }).then((unlisten) => {
       unlistenStatus = unlisten;
     });
   });

--- a/tests/unit/happy-resolution-arbitration.test.ts
+++ b/tests/unit/happy-resolution-arbitration.test.ts
@@ -32,6 +32,19 @@ describe("provider resolution arbitration", () => {
     ).toBe("allow_once");
   });
 
+  it("maps a Codex-style approval denial to the explicit decline option", () => {
+    expect(
+      selectApprovalOption(
+        [
+          { optionId: "accept" },
+          { optionId: "acceptForSession" },
+          { optionId: "decline" },
+        ],
+        false,
+      ),
+    ).toBe("decline");
+  });
+
   it("uses the first non-deny option only when no known allow id or kind is offered", () => {
     expect(
       selectApprovalOption(


### PR DESCRIPTION
## Summary

Fixes the v3.71.0 Happy release blockers in the shipped bridge and supervisor paths.

Closes #2995
Closes #2996
Closes #2997
Closes #2998
Closes #3000
Closes #3001
Closes #3002
Closes #3005

#3003 item 1 (unset advertised roots default to an empty advertisement) is fixed in this branch. Its remaining P2 follow-ups remain tracked in #3003.

## Changes

- Include the approved Happy runtime packages in the generated provider bundle.
- Gate bridge Running/Connected status on the bridge readiness signal and use a global restart budget.
- Route spawned-session inbound controls through the live session entry.
- Complete first-pairing registration with capabilities, sessions, subscriptions, and roots updates.
- Add an explicit remote denial option for Codex-style approvals.
- Release session clients on terminal events and ignore unknown terminal events.
- Pass the embedded runtime PATH and node marker to the bridge.
- Default unset advertised roots to none.
- Capture terminal bridge failures through the existing support-error path.

## Verification

- `pnpm check` — passed (48 existing warnings).
- `pnpm test` — 332 files passed, 2,408 tests passed, 15 skipped.
- `pnpm test:runtime-smoke` — passed.
- `cargo check --locked --manifest-path src-tauri/Cargo.toml` — passed.
- `cargo test --locked --manifest-path src-tauri/Cargo.toml` — 922 passed, 0 failed, 2 ignored.
- Focused arbitration and restart-budget tests passed.
- Redacted packaged-layout smoke: scratch directory had no parent `node_modules`; the generated bridge imported and reached `config ok, 0 sessions` against a real provider runtime. The hosted relay connection was intentionally not claimed as a completed pairing walkthrough because this run had no stored machine identity.
- No dependency manifest or lockfile changes.

## Remaining live verification

The real second-client first-pairing/prompt/abort/approval walkthrough against the hosted relay requires an authenticated disposable machine identity and a running app session. No synthetic or mocked result is substituted for that evidence.
