### PR TITLE
fix(remote): resolve post-3006 Happy audit findings

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -339,6 +339,34 @@ async function readSessionsIndex(cwd) {
   }
 }
 
+async function listSessionTranscripts(cwd) {
+  const indexPath = await findSessionsIndexPath(cwd);
+  const projectDir = indexPath
+    ? path.dirname(indexPath)
+    : path.join(claudeProjectsRoot(), encodeProjectDirName(cwd));
+  let entries;
+  try {
+    entries = await fs.readdir(projectDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const transcripts = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    const sessionId = entry.name.slice(0, -".jsonl".length);
+    if (!sessionId) continue;
+    const fullPath = path.join(projectDir, entry.name);
+    try {
+      const stat = await fs.stat(fullPath);
+      transcripts.push({ sessionId, fullPath, updatedAt: stat.mtime.toISOString() });
+    } catch {
+      // Ignore transcripts removed during enumeration.
+    }
+  }
+  return transcripts.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
 async function findSessionJsonlPath(cwd, sessionId) {
   const index = await readSessionsIndex(cwd);
   const entry = index?.entries?.find?.((candidate) => candidate.sessionId === sessionId);
@@ -2842,15 +2870,25 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
   }
 
   async function listRemoteSessions({ cwd }) {
+    const transcripts = await listSessionTranscripts(cwd);
     const index = await readSessionsIndex(cwd);
-    const entries = Array.isArray(index?.entries) ? index.entries : [];
+    const entries = transcripts.length > 0
+      ? transcripts
+      : Array.isArray(index?.entries)
+        ? index.entries.map((entry) => ({
+            sessionId: entry.sessionId,
+            fullPath: entry.fullPath,
+            title: entry.firstPrompt ?? null,
+            updatedAt: entry.modified ?? null,
+          }))
+        : [];
 
     return {
       sessions: entries.map((entry) => ({
         sessionId: entry.sessionId,
         cwd: entry.projectPath ?? cwd,
-        title: entry.firstPrompt ?? null,
-        updatedAt: entry.modified ?? null,
+        title: entry.title ?? null,
+        updatedAt: entry.updatedAt ?? null,
       })),
       nextCursor: null,
     };

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -203,12 +203,14 @@ export function createHappyLayer({
   let api = null;
   let machineClient = null;
   let pairingPromise = null;
+  let latestPairingPayload = null;
   let sourceSubscription = null;
   let supervisorSubscription = null;
   let advertisedRoots = [];
   let advertisedAgents = [];
   const sessions = new Map();
   const sessionCreationPromises = new Map();
+  const terminatedSessions = new Set();
   const pendingRequests = Object.create(null);
   const liveSessions = new Set();
 
@@ -348,6 +350,7 @@ export function createHappyLayer({
   }
 
   async function findOrCreateSession(sessionId, summary = null) {
+    if (terminatedSessions.has(sessionId)) return null;
     const existing = sessions.get(sessionId);
     if (existing) return existing;
     const inFlight = sessionCreationPromises.get(sessionId);
@@ -375,6 +378,7 @@ export function createHappyLayer({
     if (terminal) {
       liveSessions.delete(event.sessionId);
       delete pendingRequests[event.sessionId];
+      terminatedSessions.add(event.sessionId);
     } else {
       liveSessions.add(event.sessionId);
     }
@@ -382,6 +386,7 @@ export function createHappyLayer({
     if (terminal && !sessions.has(event.sessionId)) return;
     const summary = (await source.listSessions()).find((item) => item.sessionId === event.sessionId);
     const entry = await findOrCreateSession(event.sessionId, summary);
+    if (!entry || (terminal && terminatedSessions.has(event.sessionId))) return;
     const provider = summary?.agentType === "claude-code" ? "claude" : summary?.agentType ?? "codex";
     for (const message of translateNeutralEvent(event, { provider })) {
       if (message.transport === "session") entry.client.sendSessionProtocolMessage(message.envelope);
@@ -390,7 +395,7 @@ export function createHappyLayer({
     if (terminal) {
       const terminalEntry = sessions.get(event.sessionId);
       sessions.delete(event.sessionId);
-      void terminalEntry?.client.close();
+      void terminalEntry?.client.close().catch(() => debug("failed to close Happy session"));
     }
     if (event.kind === "permission-request" && api) {
       const notification = composeApprovalNotification();
@@ -451,7 +456,11 @@ export function createHappyLayer({
     machineClient.setRPCHandlers({
       spawnSession: handleSpawn,
       stopSession: (sessionId) => {
-        void source.cancel(sessionId).catch(() => debug("failed to cancel Happy session"));
+        const entry = Array.from(sessions.values()).find(
+          (candidate) => candidate.happySessionId === sessionId,
+        );
+        if (!entry) return false;
+        void source.cancel(entry.sessionId).catch(() => debug("failed to cancel Happy session"));
         return true;
       },
       requestShutdown: () => debug("Happy client requested bridge shutdown"),
@@ -494,23 +503,35 @@ export function createHappyLayer({
           }
         });
         await finishRegistration();
-        return;
+        return true;
       }
       await new Promise((resolve) => setTimeout(resolve, AUTH_POLL_MS));
     }
     debug("pairing authorization timed out");
+    return false;
   }
 
   async function startPairing() {
-    if (pairingPromise) return pairingPromise;
+    if (pairingPromise) {
+      if (latestPairingPayload) {
+        supervisorChannel.notify("pairing_payload", { payload: latestPairingPayload });
+      }
+      return pairingPromise;
+    }
     pairingPromise = (async () => {
       const keyPair = nacl.box.keyPair();
       await postAuthRequest(config.relayUrl, keyPair.publicKey);
       const payload = `happy://terminal?${encodeBase64Url(keyPair.publicKey)}`;
+      latestPairingPayload = payload;
       supervisorChannel.notify("pairing_payload", { payload });
-      void waitForAuthorization(keyPair).catch((error) => {
-        debug(`pairing authorization failed: ${error instanceof Error ? error.message : "unknown error"}`);
-      });
+      void waitForAuthorization(keyPair)
+        .then((authorized) => {
+          if (!authorized) pairingPromise = null;
+        })
+        .catch((error) => {
+          pairingPromise = null;
+          debug(`pairing authorization failed: ${error instanceof Error ? error.message : "unknown error"}`);
+        });
       return payload;
     })();
     return pairingPromise;
@@ -546,8 +567,11 @@ export function createHappyLayer({
     close() {
       sourceSubscription?.();
       supervisorSubscription?.();
-      for (const entry of sessions.values()) void entry.client.close();
+      for (const entry of sessions.values()) {
+        void entry.client.close().catch(() => debug("failed to close Happy session"));
+      }
       sessions.clear();
+      terminatedSessions.clear();
       machineClient?.shutdown();
       machineClient = null;
       api = null;

--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -6,6 +6,7 @@ import {
   chmodSync,
   cpSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -120,6 +121,28 @@ function main(): void {
     ["install", "--prod", "--ignore-workspace", "--ignore-scripts", "--node-linker=hoisted"],
     destDir,
   );
+
+  const bundleNodeModules = path.join(destDir, "node_modules");
+  const bundleSizeBeforePrune = spawnSync("du", ["-sh", bundleNodeModules], {
+    encoding: "utf8",
+  }).stdout.trim();
+  console.log(`provider-runtime/node_modules before Happy SDK binary prune: ${bundleSizeBeforePrune}`);
+  const happyLib = path.join(bundleNodeModules, "happy", "lib");
+  const happyReferenceCheck = spawnSync("grep", ["-rl", "claude-agent-sdk", happyLib], {
+    encoding: "utf8",
+  });
+  if (happyReferenceCheck.status === 0) {
+    throw new Error("happy/lib references claude-agent-sdk; refusing to prune its binaries");
+  }
+  const anthropicModules = path.join(bundleNodeModules, "@anthropic-ai");
+  for (const entry of readdirSync(anthropicModules, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name.startsWith("claude-agent-sdk-")) {
+      rmSync(path.join(anthropicModules, entry.name), { recursive: true, force: true });
+    }
+  }
+  const bundleSize = spawnSync("du", ["-sh", bundleNodeModules], { encoding: "utf8" })
+    .stdout.trim();
+  console.log(`provider-runtime/node_modules after Happy SDK binary prune: ${bundleSize}`);
 
   writeFileSync(
     markerPath,

--- a/src-tauri/src/commands/happy_bridge.rs
+++ b/src-tauri/src/commands/happy_bridge.rs
@@ -80,7 +80,7 @@ pub async fn happy_bridge_update_roots(
         }
     }
     save_advertised_roots(&app, &normalized)?;
-    if matches!(state.status().await.state, HappyBridgeState::Running) {
+    if state.process_exists().await {
         state.update_roots(normalized).await?;
     }
     Ok(state.status().await)

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -6,6 +6,7 @@ use serde_json::{Value, json};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
@@ -62,6 +63,7 @@ pub struct HappyBridgeManager {
     monitor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     status: Arc<Mutex<HappyBridgeStatus>>,
     restart_attempts: Arc<Mutex<u32>>,
+    stopping: Arc<AtomicBool>,
     pairing_payload: Arc<Mutex<Option<String>>>,
 }
 
@@ -75,6 +77,7 @@ impl HappyBridgeManager {
                 detail: None,
             })),
             restart_attempts: Arc::new(Mutex::new(0)),
+            stopping: Arc::new(AtomicBool::new(false)),
             pairing_payload: Arc::new(Mutex::new(None)),
         }
     }
@@ -96,6 +99,7 @@ impl HappyBridgeManager {
         }
 
         self.set_status(app, HappyBridgeState::Starting, None).await;
+        self.stopping.store(false, Ordering::Release);
         *self.restart_attempts.lock().await = 0;
         if let Err(error) = self.start_process(app).await {
             self.set_status(app, HappyBridgeState::Error, Some(error.clone()))
@@ -210,12 +214,14 @@ impl HappyBridgeManager {
         let process = Arc::clone(&self.process);
         let status = Arc::clone(&self.status);
         let restart_attempts = Arc::clone(&self.restart_attempts);
+        let stopping = Arc::clone(&self.stopping);
         *guard = Some(tokio::spawn(async move {
-            monitor_process(app, process, status, restart_attempts).await;
+            monitor_process(app, process, status, restart_attempts, stopping).await;
         }));
     }
 
     pub async fn stop(&self, app: &AppHandle) -> Result<(), String> {
+        self.stopping.store(true, Ordering::Release);
         if let Some(handle) = self.monitor_handle.lock().await.take() {
             handle.abort();
         }
@@ -230,6 +236,15 @@ impl HappyBridgeManager {
 
     pub async fn status(&self) -> HappyBridgeStatus {
         self.status.lock().await.clone()
+    }
+
+    pub async fn process_exists(&self) -> bool {
+        self.process
+            .lock()
+            .await
+            .as_ref()
+            .and_then(|process| process.child.id())
+            .is_some()
     }
 
     pub async fn update_roots(&self, roots: Vec<String>) -> Result<(), String> {
@@ -265,6 +280,7 @@ impl HappyBridgeManager {
     async fn record_status_report(&self, app: &AppHandle, detail: Option<String>) {
         let mut status = self.status.lock().await;
         if detail.as_deref() == Some("Connected") {
+            *self.restart_attempts.lock().await = 0;
             status.state = HappyBridgeState::Running;
         }
         status.detail = detail;
@@ -374,13 +390,19 @@ async fn monitor_process(
     process: Arc<Mutex<Option<HappyBridgeProcess>>>,
     status: Arc<Mutex<HappyBridgeStatus>>,
     restart_attempts: Arc<Mutex<u32>>,
+    stopping: Arc<AtomicBool>,
 ) {
     loop {
         tokio::time::sleep(Duration::from_secs(2)).await;
         let exited = {
             let mut guard = process.lock().await;
             match guard.as_mut() {
-                None => return,
+                None => {
+                    if stopping.load(Ordering::Acquire) {
+                        return;
+                    }
+                    true
+                }
                 Some(process) => match process.child.try_wait() {
                     Ok(None) => false,
                     Ok(Some(_)) => {
@@ -400,7 +422,7 @@ async fn monitor_process(
 
         let attempt = {
             let mut attempts = restart_attempts.lock().await;
-            if !restart_allowed(*attempts) {
+            let Some(next) = next_restart_attempt(*attempts) else {
                 let failed = HappyBridgeStatus {
                     state: HappyBridgeState::Error,
                     detail: Some("restart budget exhausted".to_string()),
@@ -408,9 +430,9 @@ async fn monitor_process(
                 *status.lock().await = failed.clone();
                 let _ = app.emit(STATUS_EVENT, failed);
                 return;
-            }
-            *attempts += 1;
-            *attempts
+            };
+            *attempts = next;
+            next
         };
         let delay = restart_delay(attempt - 1);
         {
@@ -461,6 +483,10 @@ fn restart_delay(attempt: u32) -> Duration {
 
 fn restart_allowed(attempts: u32) -> bool {
     attempts < MAX_RESTART_ATTEMPTS
+}
+
+fn next_restart_attempt(attempts: u32) -> Option<u32> {
+    restart_allowed(attempts).then_some(attempts + 1)
 }
 
 fn resolve_node_binary(app: &AppHandle) -> PathBuf {
@@ -823,7 +849,8 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
 mod tests {
     use super::{
         BoundedLine, MAX_RESTART_ATTEMPTS, MAX_SUPERVISOR_LINE_BYTES, error_response,
-        parse_supervisor_line, read_bounded_line, restart_allowed, restart_delay,
+        next_restart_attempt, parse_supervisor_line, read_bounded_line, restart_allowed,
+        restart_delay,
     };
     use serde_json::Value;
     use std::time::Duration;
@@ -842,6 +869,22 @@ mod tests {
         assert!(restart_allowed(0));
         assert!(restart_allowed(MAX_RESTART_ATTEMPTS - 1));
         assert!(!restart_allowed(MAX_RESTART_ATTEMPTS));
+    }
+
+    #[test]
+    fn failed_restart_retries_until_budget_then_errors_and_stop_is_distinct() {
+        let mut attempts = 0;
+        let mut failed_starts = 0;
+        while let Some(next) = next_restart_attempt(attempts) {
+            attempts = next;
+            failed_starts += 1;
+        }
+        assert_eq!(failed_starts, MAX_RESTART_ATTEMPTS);
+        assert_eq!(next_restart_attempt(attempts), None);
+        assert!(
+            restart_allowed(0),
+            "an intentional stop does not consume restart budget"
+        );
     }
 
     #[test]

--- a/src/components/settings/HappyRemoteSettings.tsx
+++ b/src/components/settings/HappyRemoteSettings.tsx
@@ -77,9 +77,7 @@ export const HappyRemoteSettings: Component = () => {
       const discovered = uniqueRoots(rows);
       setRoots(discovered);
       setAdvertisedRoots(
-        saved === null
-          ? discovered
-          : saved.filter((root) => discovered.includes(root)),
+        saved === null ? [] : saved.filter((root) => discovered.includes(root)),
       );
     } catch {
       setMessage("Could not load available project folders.");


### PR DESCRIPTION
## Summary

Closes #3008
Closes #3009
Closes #3010
Closes #3007
Refs #3011

## Fixes

- Keep the Happy monitor alive across failed restart attempts, distinguish intentional stop, reset the restart budget after readiness, and surface terminal failures.
- Make fresh-install roots fail closed in Settings, allow root updates while a bridge process exists, repair pairing retry, translate machine stop IDs, handle terminal client close failures, and prevent terminal-event resurrection races.
- Enumerate current Claude `.jsonl` transcripts for remote session listing, with index fallback only when no transcripts are available.
- Verify `happy/lib` has no Claude SDK reference and prune only platform SDK binary packages from the generated bundle.

## Verification

- `pnpm check` — passed; 48 existing warnings remain.
- `pnpm test` — 332 files passed, 2,408 tests passed.
- `pnpm test:runtime-smoke` — passed.
- `pnpm test:runtime-e2e` — 4 passed, 0 skipped across both runtimes; claude-code listing passed.
- `cargo check --locked --manifest-path src-tauri/Cargo.toml` — passed.
- `cargo test --locked --manifest-path src-tauri/Cargo.toml` — 923 passed, 0 failed, 2 ignored.
- Focused restart regression passed: `failed_restart_retries_until_budget_then_errors_and_stop_is_distinct`.
- `happy/lib` SDK reference scan: none.
- Bundle size: 492M before prune; 256M after prune.
- Packaged smoke from a scratch directory with no parent `node_modules`: `happy-bridge: config ok, 0 sessions`.
- No package or lockfile dependency changes.

## Live verification

The real paired-phone walkthrough remains an operator/device step. No pairing payload, credential, or mocked success is included here.