### PR TITLE
fix(remote): harden post-3012 Happy paths

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -192,6 +192,31 @@ function sessionMetadata(config, summary, machineId) {
   };
 }
 
+export function createTerminatedSessionTracker(maxSize = 256) {
+  const terminated = new Set();
+  const order = [];
+  return {
+    mark(sessionId) {
+      if (terminated.has(sessionId)) return;
+      terminated.add(sessionId);
+      order.push(sessionId);
+      while (order.length > maxSize) terminated.delete(order.shift());
+    },
+    forget(sessionId) {
+      if (!terminated.delete(sessionId)) return;
+      const index = order.indexOf(sessionId);
+      if (index >= 0) order.splice(index, 1);
+    },
+    has(sessionId) {
+      return terminated.has(sessionId);
+    },
+    clear() {
+      terminated.clear();
+      order.length = 0;
+    },
+  };
+}
+
 export function createHappyLayer({
   config,
   supervisorChannel,
@@ -210,7 +235,7 @@ export function createHappyLayer({
   let advertisedAgents = [];
   const sessions = new Map();
   const sessionCreationPromises = new Map();
-  const terminatedSessions = new Set();
+  const terminatedSessions = createTerminatedSessionTracker();
   const pendingRequests = Object.create(null);
   const liveSessions = new Set();
 
@@ -350,6 +375,9 @@ export function createHappyLayer({
   }
 
   async function findOrCreateSession(sessionId, summary = null) {
+    if (summary && !["error", "terminated"].includes(summary.status)) {
+      terminatedSessions.forget(sessionId);
+    }
     if (terminatedSessions.has(sessionId)) return null;
     const existing = sessions.get(sessionId);
     if (existing) return existing;
@@ -378,7 +406,7 @@ export function createHappyLayer({
     if (terminal) {
       liveSessions.delete(event.sessionId);
       delete pendingRequests[event.sessionId];
-      terminatedSessions.add(event.sessionId);
+      terminatedSessions.mark(event.sessionId);
     } else {
       liveSessions.add(event.sessionId);
     }

--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -129,21 +129,39 @@ function main(): void {
   }).stdout.trim();
   console.log(`provider-runtime/node_modules before Happy SDK binary prune: ${bundleSizeBeforePrune}`);
   const happyPackage = path.join(bundleNodeModules, "happy");
+  const sdkPackage = path.join(bundleNodeModules, "@anthropic-ai", "claude-agent-sdk");
   const happyReferenceRoot = existsSync(path.join(happyPackage, "lib"))
     ? path.join(happyPackage, "lib")
     : path.join(happyPackage, "dist");
-  const happyReferenceCheck = spawnSync("grep", ["-rl", "claude-agent-sdk", happyReferenceRoot], {
-    encoding: "utf8",
-  });
+  const platformBinaryPattern =
+    "(from[[:space:]]+|import[[:space:]]*\\(|require[[:space:]]*\\()[[:space:]]*['\"][^'\"]*claude-agent-sdk-(linux-x64|linux-arm64|linux-x64-musl|linux-arm64-musl|darwin-x64|darwin-arm64|win32-x64|win32-arm64)[^'\"]*['\"]";
+  // Keep the SDK JS package: Happy's types chunk embeds its version string and
+  // declares the JS package as a regular dependency. Only its optional,
+  // platform-specific native binaries are prunable; Seren runs agents through
+  // its provider runtime and never invokes Happy's agent-runner modules.
+  const happyReferenceCheck = spawnSync(
+    "grep",
+    [
+      "-REl",
+      "--include=*.js",
+      "--include=*.mjs",
+      "--include=*.cjs",
+      platformBinaryPattern,
+      happyReferenceRoot,
+      sdkPackage,
+    ],
+    { encoding: "utf8" },
+  );
   const scanFailed = Boolean(happyReferenceCheck.error) || happyReferenceCheck.status === null;
-  const referencesSdk = happyReferenceCheck.status === 0;
-  if (scanFailed || referencesSdk || happyReferenceCheck.status !== 1) {
+  const referencesBinary = happyReferenceCheck.status === 0;
+  if (scanFailed || referencesBinary || happyReferenceCheck.status !== 1) {
+    const matchedFiles = referencesBinary ? happyReferenceCheck.stdout.trim() : "";
     console.warn(
-      `Skipping Happy SDK binary prune: ${scanFailed ? "reference scan failed" : referencesSdk ? "happy/lib references the SDK" : "unexpected scan result"}`,
+      `Skipping Happy SDK binary prune: ${scanFailed ? "reference scan failed" : referencesBinary ? `binary specifier found in ${matchedFiles}` : "unexpected scan result"}`,
     );
   }
   const anthropicModules = path.join(bundleNodeModules, "@anthropic-ai");
-  if (!scanFailed && !referencesSdk && happyReferenceCheck.status === 1 && existsSync(anthropicModules)) {
+  if (!scanFailed && !referencesBinary && happyReferenceCheck.status === 1 && existsSync(anthropicModules)) {
     for (const entry of readdirSync(anthropicModules, { withFileTypes: true })) {
       if (entry.isDirectory() && entry.name.startsWith("claude-agent-sdk-")) {
         rmSync(path.join(anthropicModules, entry.name), { recursive: true, force: true });

--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -5,6 +5,7 @@ import { spawnSync } from "node:child_process";
 import {
   chmodSync,
   cpSync,
+  existsSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -127,17 +128,26 @@ function main(): void {
     encoding: "utf8",
   }).stdout.trim();
   console.log(`provider-runtime/node_modules before Happy SDK binary prune: ${bundleSizeBeforePrune}`);
-  const happyLib = path.join(bundleNodeModules, "happy", "lib");
-  const happyReferenceCheck = spawnSync("grep", ["-rl", "claude-agent-sdk", happyLib], {
+  const happyPackage = path.join(bundleNodeModules, "happy");
+  const happyReferenceRoot = existsSync(path.join(happyPackage, "lib"))
+    ? path.join(happyPackage, "lib")
+    : path.join(happyPackage, "dist");
+  const happyReferenceCheck = spawnSync("grep", ["-rl", "claude-agent-sdk", happyReferenceRoot], {
     encoding: "utf8",
   });
-  if (happyReferenceCheck.status === 0) {
-    throw new Error("happy/lib references claude-agent-sdk; refusing to prune its binaries");
+  const scanFailed = Boolean(happyReferenceCheck.error) || happyReferenceCheck.status === null;
+  const referencesSdk = happyReferenceCheck.status === 0;
+  if (scanFailed || referencesSdk || happyReferenceCheck.status !== 1) {
+    console.warn(
+      `Skipping Happy SDK binary prune: ${scanFailed ? "reference scan failed" : referencesSdk ? "happy/lib references the SDK" : "unexpected scan result"}`,
+    );
   }
   const anthropicModules = path.join(bundleNodeModules, "@anthropic-ai");
-  for (const entry of readdirSync(anthropicModules, { withFileTypes: true })) {
-    if (entry.isDirectory() && entry.name.startsWith("claude-agent-sdk-")) {
-      rmSync(path.join(anthropicModules, entry.name), { recursive: true, force: true });
+  if (!scanFailed && !referencesSdk && happyReferenceCheck.status === 1 && existsSync(anthropicModules)) {
+    for (const entry of readdirSync(anthropicModules, { withFileTypes: true })) {
+      if (entry.isDirectory() && entry.name.startsWith("claude-agent-sdk-")) {
+        rmSync(path.join(anthropicModules, entry.name), { recursive: true, force: true });
+      }
     }
   }
   const bundleSize = spawnSync("du", ["-sh", bundleNodeModules], { encoding: "utf8" })

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -62,6 +62,7 @@ pub struct HappyBridgeManager {
     process: Arc<Mutex<Option<HappyBridgeProcess>>>,
     monitor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     status: Arc<Mutex<HappyBridgeStatus>>,
+    // These mutexes are always acquired independently; never hold one while awaiting the other.
     restart_attempts: Arc<Mutex<u32>>,
     stopping: Arc<AtomicBool>,
     pairing_payload: Arc<Mutex<Option<String>>>,
@@ -278,9 +279,11 @@ impl HappyBridgeManager {
     }
 
     async fn record_status_report(&self, app: &AppHandle, detail: Option<String>) {
-        let mut status = self.status.lock().await;
         if detail.as_deref() == Some("Connected") {
             *self.restart_attempts.lock().await = 0;
+        }
+        let mut status = self.status.lock().await;
+        if detail.as_deref() == Some("Connected") {
             status.state = HappyBridgeState::Running;
         }
         status.detail = detail;
@@ -420,20 +423,28 @@ async fn monitor_process(
             continue;
         }
 
-        let attempt = {
+        let (attempt, exhausted) = {
             let mut attempts = restart_attempts.lock().await;
-            let Some(next) = next_restart_attempt(*attempts) else {
-                let failed = HappyBridgeStatus {
-                    state: HappyBridgeState::Error,
-                    detail: Some("restart budget exhausted".to_string()),
-                };
-                *status.lock().await = failed.clone();
-                let _ = app.emit(STATUS_EVENT, failed);
-                return;
-            };
-            *attempts = next;
-            next
+            match next_restart_attempt(*attempts) {
+                Some(next) => {
+                    *attempts = next;
+                    (next, false)
+                }
+                None => (0, true),
+            }
         };
+        if exhausted {
+            let failed = HappyBridgeStatus {
+                state: HappyBridgeState::Error,
+                detail: Some("restart budget exhausted".to_string()),
+            };
+            {
+                let mut current = status.lock().await;
+                *current = failed.clone();
+            };
+            let _ = app.emit(STATUS_EVENT, failed);
+            return;
+        }
         let delay = restart_delay(attempt - 1);
         {
             let mut current = status.lock().await;

--- a/tests/unit/happy-resolution-arbitration.test.ts
+++ b/tests/unit/happy-resolution-arbitration.test.ts
@@ -6,7 +6,10 @@ import { describe, expect, it } from "vitest";
 // @ts-expect-error — the provider runtime is plain ESM without declarations.
 import { createResolutionTracker } from "../../bin/browser-local/providers.mjs";
 // @ts-expect-error — the bridge layer is plain ESM without declarations.
-import { selectApprovalOption } from "../../bin/happy-bridge/happy-layer.mjs";
+import {
+  createTerminatedSessionTracker,
+  selectApprovalOption,
+} from "../../bin/happy-bridge/happy-layer.mjs";
 
 describe("provider resolution arbitration", () => {
   it("returns a success-shaped alreadyResolved result for duplicate responses", () => {
@@ -55,5 +58,13 @@ describe("provider resolution arbitration", () => {
         true,
       ),
     ).toBe("custom_allow");
+  });
+
+  it("allows a terminated session id to be recreated when announced live again", () => {
+    const tracker = createTerminatedSessionTracker(2);
+    tracker.mark("session-1");
+    expect(tracker.has("session-1")).toBe(true);
+    tracker.forget("session-1");
+    expect(tracker.has("session-1")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes #3013
Closes #3014
Closes #3015
Refs #3016

- Removes the Happy bridge status/restart mutex lock inversion by acquiring the mutexes in independent scopes.
- Makes the Happy SDK prune fail closed and tolerant of package-layout drift.
- Bounds terminated-session tracking and permits a live re-announcement to recreate an entry.
- Scopes the SDK safety scan to actual platform-binary module specifiers.

## Verification

- `pnpm exec vitest run tests/unit/happy-resolution-arbitration.test.ts` — 5 passed, including terminate/re-announce coverage.
- `cargo check --locked --manifest-path src-tauri/Cargo.toml` — passed after supplying the repository's generated MCP resource link; the temporary link was removed.
- `pnpm exec tsx scripts/build-provider-runtime.ts` — completed; bundle measured 492M before and 256M after pruning.
- The definitive bare-string match is `node_modules/happy/dist/types-CV0guBiJ.mjs:102`, where `@anthropic-ai/claude-agent-sdk` is version-string data in an embedded package manifest, not an import.
- The scan now matches only eight platform-binary specifiers in JS/MJS/CJS module positions. The SDK JS package remains; all eight `claude-agent-sdk-*` platform directories are absent after the build.
- Packaged-layout smoke: embedded provider runtime started; packaged bridge emitted `happy-bridge: config ok, 0 sessions` and reached the relay-facing pairing path. Pairing material was redacted.

## Walkthrough status

The live real-app first-pairing/spawn walkthrough was not completed in this execution; no fabricated relay or phone evidence is included. The remaining real-app/hosted-relay walkthrough is tracked by #3016 and remains required before release readiness is claimed.

No dependency manifests were changed. No release tag was created.
