### PR TITLE
fix(remote): report Connected only after startup completes

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -217,6 +217,21 @@ export function createTerminatedSessionTracker(maxSize = 256) {
   };
 }
 
+export function createStartupStatusGate(notify) {
+  return {
+    async complete(startupWork) {
+      try {
+        const result = await startupWork();
+        notify({ state: "connected", detail: "Connected" });
+        return result;
+      } catch (error) {
+        notify({ state: "error", detail: "startup failed" });
+        throw error;
+      }
+    },
+  };
+}
+
 export function createHappyLayer({
   config,
   supervisorChannel,
@@ -233,6 +248,9 @@ export function createHappyLayer({
   let supervisorSubscription = null;
   let advertisedRoots = [];
   let advertisedAgents = [];
+  const startupStatusGate = createStartupStatusGate((status) => {
+    supervisorChannel.notify("status_report", status);
+  });
   const sessions = new Map();
   const sessionCreationPromises = new Map();
   const terminatedSessions = createTerminatedSessionTracker();
@@ -512,7 +530,6 @@ export function createHappyLayer({
     machineClient = api.machineSyncClient(machine);
     setupMachineHandlers();
     machineClient.connect();
-    supervisorChannel.notify("status_report", { state: "connected", detail: "Connected" });
     return true;
   }
 
@@ -566,12 +583,14 @@ export function createHappyLayer({
   }
 
   async function finishRegistration() {
-    await updateCapabilities();
-    const listed = await source.listSessions();
-    for (const summary of listed) await createSessionEntry(summary.sessionId, summary);
-    sourceSubscription?.();
-    sourceSubscription = source.subscribe((event) => {
-      void publishEvent(event).catch(() => debug("failed to publish Happy session event"));
+    return startupStatusGate.complete(async () => {
+      await updateCapabilities();
+      const listed = await source.listSessions();
+      for (const summary of listed) await createSessionEntry(summary.sessionId, summary);
+      sourceSubscription?.();
+      sourceSubscription = source.subscribe((event) => {
+        void publishEvent(event).catch(() => debug("failed to publish Happy session event"));
+      });
     });
   }
 

--- a/tests/unit/happy-resolution-arbitration.test.ts
+++ b/tests/unit/happy-resolution-arbitration.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { createResolutionTracker } from "../../bin/browser-local/providers.mjs";
 // @ts-expect-error — the bridge layer is plain ESM without declarations.
 import {
+  createStartupStatusGate,
   createTerminatedSessionTracker,
   selectApprovalOption,
 } from "../../bin/happy-bridge/happy-layer.mjs";
@@ -66,5 +67,32 @@ describe("provider resolution arbitration", () => {
     expect(tracker.has("session-1")).toBe(true);
     tracker.forget("session-1");
     expect(tracker.has("session-1")).toBe(false);
+  });
+
+  it("does not report connected until registration work completes", async () => {
+    const statuses = [];
+    let resolveStartup;
+    const gate = createStartupStatusGate((status) => statuses.push(status));
+    const startup = gate.complete(
+      () => new Promise((resolve) => {
+        resolveStartup = resolve;
+      }),
+    );
+
+    await Promise.resolve();
+    expect(statuses).toEqual([]);
+    resolveStartup();
+    await startup;
+    expect(statuses).toEqual([{ state: "connected", detail: "Connected" }]);
+  });
+
+  it("reports a non-connected status when registration work fails", async () => {
+    const statuses = [];
+    const gate = createStartupStatusGate((status) => statuses.push(status));
+
+    await expect(gate.complete(async () => { throw new Error("unreachable relay"); })).rejects.toThrow(
+      "unreachable relay",
+    );
+    expect(statuses).toEqual([{ state: "error", detail: "startup failed" }]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #3017
Refs #3019

- Removes the early `Connected` report from `registerMachine()`.
- Reports `Connected` only after capabilities, session enumeration, session creation, and event subscription complete.
- Reports a non-connected startup failure when that sequence throws.

## Verification

- `pnpm exec vitest run tests/unit/happy-resolution-arbitration.test.ts` — 7 passed, including both startup-order cases.
- `pnpm test` — 2,411 passed, 15 skipped; `pnpm test:runtime-smoke` — passed.
- `cargo check --locked` — passed; `cargo test --locked` — 923 passed, 2 ignored.
- Existing Rust restart-budget regression `failed_restart_retries_until_budget_then_errors_and_stop_is_distinct` remains present.
- No dependency or manifest changes.

## Walkthrough status

The real unreachable-relay Rust-side loop-death transcript was not completed in this execution. The code-level restart-budget test remains green, but no live attempt-number transcript is claimed; this gap is tracked by #3019. The physical/real-client walkthrough remains an operator QA item tracked in #3016.

No release tag was created.
