### PR TITLE
fix(remote): resolve bridge audit round 4 findings

### DIFF
--- a/bin/happy-bridge.mjs
+++ b/bin/happy-bridge.mjs
@@ -52,15 +52,15 @@ function startInputReader() {
   return { configPromise, queuedResponses };
 }
 
-async function shutdown() {
+async function shutdown(exitCode = 0) {
   if (shuttingDown) return;
   shuttingDown = true;
   client?.close();
   happyLayer?.close();
   supervisorChannel?.close();
   input?.close();
-  process.exitCode = 0;
-  setImmediate(() => process.exit(0));
+  process.exitCode = exitCode;
+  setImmediate(() => process.exit(exitCode));
 }
 
 process.once("SIGTERM", shutdown);
@@ -72,7 +72,15 @@ try {
   supervisorChannel = createSupervisorChannel();
   for (const line of queuedResponses) supervisorChannel.handleLine(line);
 
-  client = createProviderRuntimeClient(config);
+  client = createProviderRuntimeClient(config, {
+    onUnexpectedDisconnect: (reason) => {
+      supervisorChannel?.notify("status_report", {
+        state: "error",
+        detail: `provider runtime connection lost (${reason})`,
+      });
+      void shutdown(1);
+    },
+  });
   await client.connect();
   const source = createProviderSource({
     client,

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -393,9 +393,6 @@ export function createHappyLayer({
   }
 
   async function findOrCreateSession(sessionId, summary = null) {
-    if (summary && !["error", "terminated"].includes(summary.status)) {
-      terminatedSessions.forget(sessionId);
-    }
     if (terminatedSessions.has(sessionId)) return null;
     const existing = sessions.get(sessionId);
     if (existing) return existing;
@@ -427,21 +424,25 @@ export function createHappyLayer({
       terminatedSessions.mark(event.sessionId);
     } else {
       liveSessions.add(event.sessionId);
+      terminatedSessions.forget(event.sessionId);
     }
     rememberPermission(event);
     if (terminal && !sessions.has(event.sessionId)) return;
     const summary = (await source.listSessions()).find((item) => item.sessionId === event.sessionId);
     const entry = await findOrCreateSession(event.sessionId, summary);
-    if (!entry || (terminal && terminatedSessions.has(event.sessionId))) return;
+    if (!entry) return;
     const provider = summary?.agentType === "claude-code" ? "claude" : summary?.agentType ?? "codex";
     for (const message of translateNeutralEvent(event, { provider })) {
       if (message.transport === "session") entry.client.sendSessionProtocolMessage(message.envelope);
       if (message.transport === "agent") entry.client.sendAgentMessage(message.provider, message.body);
     }
     if (terminal) {
-      const terminalEntry = sessions.get(event.sessionId);
-      sessions.delete(event.sessionId);
-      void terminalEntry?.client.close().catch(() => debug("failed to close Happy session"));
+      await completeTerminalSession({
+        sessions,
+        sessionId: event.sessionId,
+        entry,
+        send: async () => {},
+      }).catch(() => debug("failed to close Happy session"));
     }
     if (event.kind === "permission-request" && api) {
       const notification = composeApprovalNotification();
@@ -624,4 +625,10 @@ export function createHappyLayer({
       api = null;
     },
   };
+}
+
+export async function completeTerminalSession({ sessions, sessionId, entry, send }) {
+  await send(entry);
+  sessions.delete(sessionId);
+  await entry.client.close();
 }

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -68,23 +68,36 @@ export function translateProviderEvent(method, params = {}) {
 }
 
 class ProviderRuntimeClient {
-  constructor(config) {
+  constructor(config, { onUnexpectedDisconnect = () => {} } = {}) {
     this.config = config;
     this.socket = null;
     this.nextId = 0;
     this.pending = new Map();
     this.notificationListeners = new Set();
+    this.onUnexpectedDisconnect = onUnexpectedDisconnect;
+    this.intentionalClose = false;
+    this.disconnectReported = false;
+    this.handshakeComplete = false;
   }
 
   async connect() {
     const { host, port, token } = this.config.providerRuntime;
     this.socket = new WebSocket(`ws://${host}:${port}`);
     this.socket.on("message", (raw) => this.handleMessage(raw));
+    this.socket.on("error", () => this.reportUnexpectedDisconnect("error"));
+    this.socket.on("close", () => this.reportUnexpectedDisconnect("close"));
     await new Promise((resolve, reject) => {
       this.socket.once("open", resolve);
       this.socket.once("error", () => reject(new Error("provider runtime connection failed")));
     });
     await this.call("auth", { token });
+    this.handshakeComplete = true;
+  }
+
+  reportUnexpectedDisconnect(reason) {
+    if (this.intentionalClose || !this.handshakeComplete || this.disconnectReported) return;
+    this.disconnectReported = true;
+    this.onUnexpectedDisconnect(reason);
   }
 
   handleMessage(raw) {
@@ -136,6 +149,7 @@ class ProviderRuntimeClient {
   }
 
   close() {
+    this.intentionalClose = true;
     for (const pending of this.pending.values()) {
       clearTimeout(pending.timer);
       pending.reject(new Error("provider runtime client closed"));
@@ -149,8 +163,8 @@ class ProviderRuntimeClient {
   }
 }
 
-export function createProviderRuntimeClient(config) {
-  return new ProviderRuntimeClient(config);
+export function createProviderRuntimeClient(config, options) {
+  return new ProviderRuntimeClient(config, options);
 }
 
 function normalizeSession(session) {

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
@@ -56,6 +56,8 @@ struct ProviderRuntimeConnection {
 struct HappyBridgeProcess {
     child: Child,
     _stdin: Arc<Mutex<ChildStdin>>,
+    spawned_at: Instant,
+    restart_budget_rearmed: bool,
 }
 
 pub struct HappyBridgeManager {
@@ -202,6 +204,8 @@ impl HappyBridgeManager {
         *self.process.lock().await = Some(HappyBridgeProcess {
             child,
             _stdin: stdin,
+            spawned_at: Instant::now(),
+            restart_budget_rearmed: false,
         });
         Ok(())
     }
@@ -278,12 +282,19 @@ impl HappyBridgeManager {
         }
     }
 
-    async fn record_status_report(&self, app: &AppHandle, detail: Option<String>) {
-        if detail.as_deref() == Some("Connected") {
+    async fn record_status_report(
+        &self,
+        app: &AppHandle,
+        state: Option<String>,
+        detail: Option<String>,
+    ) {
+        if state.as_deref() == Some("connected") || detail.as_deref() == Some("Connected") {
             *self.restart_attempts.lock().await = 0;
         }
         let mut status = self.status.lock().await;
-        if detail.as_deref() == Some("Connected") {
+        if let Some(next_state) = report_state(state.as_deref()) {
+            status.state = next_state;
+        } else if detail.as_deref() == Some("Connected") {
             status.state = HappyBridgeState::Running;
         }
         status.detail = detail;
@@ -397,28 +408,42 @@ async fn monitor_process(
 ) {
     loop {
         tokio::time::sleep(Duration::from_secs(2)).await;
-        let exited = {
+        let (exited, should_rearm) = {
             let mut guard = process.lock().await;
             match guard.as_mut() {
                 None => {
                     if stopping.load(Ordering::Acquire) {
                         return;
                     }
-                    true
+                    (true, false)
                 }
                 Some(process) => match process.child.try_wait() {
-                    Ok(None) => false,
+                    Ok(None) => {
+                        let rearm = should_rearm(
+                            process.spawned_at,
+                            process.restart_budget_rearmed,
+                            Instant::now(),
+                        );
+                        if rearm {
+                            process.restart_budget_rearmed = true;
+                        }
+                        (false, rearm)
+                    }
                     Ok(Some(_)) => {
                         *guard = None;
-                        true
+                        (true, false)
                     }
                     Err(error) => {
                         log::warn!("[HappyBridge] Failed checking process status: {error}");
-                        false
+                        (false, false)
                     }
                 },
             }
         };
+        if should_rearm {
+            *restart_attempts.lock().await = 0;
+        }
+        let exited = exited;
         if !exited {
             continue;
         }
@@ -498,6 +523,18 @@ fn restart_allowed(attempts: u32) -> bool {
 
 fn next_restart_attempt(attempts: u32) -> Option<u32> {
     restart_allowed(attempts).then_some(attempts + 1)
+}
+
+fn report_state(state: Option<&str>) -> Option<HappyBridgeState> {
+    match state {
+        Some("connected") => Some(HappyBridgeState::Running),
+        Some("error") => Some(HappyBridgeState::Error),
+        _ => None,
+    }
+}
+
+fn should_rearm(spawned_at: Instant, already_rearmed: bool, now: Instant) -> bool {
+    !already_rearmed && now.duration_since(spawned_at) >= Duration::from_secs(60)
 }
 
 fn resolve_node_binary(app: &AppHandle) -> PathBuf {
@@ -687,11 +724,15 @@ async fn dispatch_supervisor_line(app: &AppHandle, line: &str, stdin: &Arc<Mutex
             let manager = app.state::<HappyBridgeManager>();
             match method {
                 "status_report" => {
+                    let state = params
+                        .get("state")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned);
                     let detail = params
                         .get("detail")
                         .and_then(Value::as_str)
                         .map(ToOwned::to_owned);
-                    manager.record_status_report(app, detail).await;
+                    manager.record_status_report(app, state, detail).await;
                 }
                 "pairing_payload" => {
                     if let Some(payload) = params.get("payload").and_then(Value::as_str) {
@@ -859,9 +900,9 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
 #[cfg(test)]
 mod tests {
     use super::{
-        BoundedLine, MAX_RESTART_ATTEMPTS, MAX_SUPERVISOR_LINE_BYTES, error_response,
+        BoundedLine, HappyBridgeState, MAX_RESTART_ATTEMPTS, MAX_SUPERVISOR_LINE_BYTES, error_response,
         next_restart_attempt, parse_supervisor_line, read_bounded_line, restart_allowed,
-        restart_delay,
+        restart_delay, report_state, should_rearm,
     };
     use serde_json::Value;
     use std::time::Duration;
@@ -896,6 +937,25 @@ mod tests {
             restart_allowed(0),
             "an intentional stop does not consume restart budget"
         );
+    }
+
+    #[test]
+    fn bridge_error_status_is_preserved_as_error() {
+        assert!(matches!(report_state(Some("error")), Some(HappyBridgeState::Error)));
+        assert!(matches!(report_state(Some("connected")), Some(HappyBridgeState::Running)));
+        assert!(report_state(Some("starting")).is_none());
+    }
+
+    #[test]
+    fn restart_budget_rearms_once_after_sustained_uptime() {
+        let spawned = std::time::Instant::now() - Duration::from_secs(60);
+        assert!(should_rearm(spawned, false, std::time::Instant::now()));
+        assert!(!should_rearm(spawned, true, std::time::Instant::now()));
+        assert!(!should_rearm(
+            std::time::Instant::now(),
+            false,
+            std::time::Instant::now()
+        ));
     }
 
     #[test]

--- a/tests/unit/happy-resolution-arbitration.test.ts
+++ b/tests/unit/happy-resolution-arbitration.test.ts
@@ -8,6 +8,7 @@ import { createResolutionTracker } from "../../bin/browser-local/providers.mjs";
 // @ts-expect-error — the bridge layer is plain ESM without declarations.
 import {
   createStartupStatusGate,
+  completeTerminalSession,
   createTerminatedSessionTracker,
   selectApprovalOption,
 } from "../../bin/happy-bridge/happy-layer.mjs";
@@ -94,5 +95,24 @@ describe("provider resolution arbitration", () => {
       "unreachable relay",
     );
     expect(statuses).toEqual([{ state: "error", detail: "startup failed" }]);
+  });
+
+  it("emits a terminal message before removing and closing the live session", async () => {
+    const sessions = new Map();
+    let closed = false;
+    const entry = { client: { close: async () => { closed = true; } } };
+    sessions.set("session-1", entry);
+    const emitted = [];
+
+    await completeTerminalSession({
+      sessions,
+      sessionId: "session-1",
+      entry,
+      send: async () => emitted.push("terminal"),
+    });
+
+    expect(emitted).toEqual(["terminal"]);
+    expect(sessions.has("session-1")).toBe(false);
+    expect(closed).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #3021
Closes #3022
Closes #3023
Closes #3024
Refs #3025

## Changes
- provider-runtime socket loss now reports an error and exits nonzero so Rust supervision restarts it; intentional shutdown is excluded
- status_report state is mapped to Rust Running/Error states
- terminal events are delivered before Happy session cleanup
- restart budget re-arms once after 60 seconds of observed uptime

## Verification
- `pnpm check` passed with the repository's existing 48 warnings
- `pnpm test`: 332 files passed, 2,412 tests passed, 15 skipped
- `pnpm test:runtime-smoke` passed
- `cargo check --locked --manifest-path src-tauri/Cargo.toml` passed
- `cargo test --locked --manifest-path src-tauri/Cargo.toml`: 925 passed, 2 ignored
- focused bridge tests passed, including terminal cleanup, error state, and uptime re-arm cases
- real local provider-runtime loss harness: provider was terminated after bridge authentication; bridge emitted a redacted `status_report` with state `error` and exited with status 1

## Walkthrough boundary
The physical-phone/live-pairing and remote spawn walkthrough was not run in this executor pass; no fabricated pairing evidence is included. It remains an operator QA item before release.