### PR TITLE
fix(remote): close open Happy bridge audit findings (#3027, #3028, #3029)

### DIFF
--- a/bin/happy-bridge.mjs
+++ b/bin/happy-bridge.mjs
@@ -63,8 +63,10 @@ async function shutdown(exitCode = 0) {
   setImmediate(() => process.exit(exitCode));
 }
 
-process.once("SIGTERM", shutdown);
-process.once("SIGINT", shutdown);
+// Signal handlers receive the signal name as their first argument, which is not
+// a valid exit code; pass an explicit one.
+process.once("SIGTERM", () => void shutdown(0));
+process.once("SIGINT", () => void shutdown(0));
 
 try {
   const { configPromise, queuedResponses } = startInputReader();

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -192,6 +192,34 @@ function sessionMetadata(config, summary, machineId) {
   };
 }
 
+// Modes the provider runtimes accept. A remote peer may only move a session
+// between these; anything else is rejected at the bridge boundary rather than
+// coerced, because codex maps unknown modes to its permissive "auto".
+const SUPPORTED_PERMISSION_MODES = new Set([
+  "default",
+  "acceptEdits",
+  "plan",
+  "bypassPermissions",
+  "read-only",
+  "safe-yolo",
+  "yolo",
+  "ask",
+  "auto",
+]);
+
+export function isSupportedPermissionMode(mode) {
+  return typeof mode === "string" && SUPPORTED_PERMISSION_MODES.has(mode);
+}
+
+// An already-tracked entry wins over the terminated mark, so a terminal event
+// can still flush its envelopes and close the relay client. The mark only blocks
+// *creating* a new entry for a session that has already ended.
+export function resolveTrackedSession({ sessions, terminatedSessions, sessionId }) {
+  const entry = sessions.get(sessionId);
+  if (entry) return { entry, blocked: false };
+  return { entry: null, blocked: terminatedSessions.has(sessionId) };
+}
+
 export function createTerminatedSessionTracker(maxSize = 256) {
   const terminated = new Set();
   const order = [];
@@ -330,7 +358,7 @@ export function createHappyLayer({
       return;
     }
     const mode = message.meta?.permissionMode;
-    if (message.meta && mode !== undefined && typeof mode !== "string") {
+    if (message.meta && mode !== undefined && !isSupportedPermissionMode(mode)) {
       debug("dropped invalid Happy permission mode");
       return;
     }
@@ -393,9 +421,9 @@ export function createHappyLayer({
   }
 
   async function findOrCreateSession(sessionId, summary = null) {
-    if (terminatedSessions.has(sessionId)) return null;
-    const existing = sessions.get(sessionId);
-    if (existing) return existing;
+    const tracked = resolveTrackedSession({ sessions, terminatedSessions, sessionId });
+    if (tracked.entry) return tracked.entry;
+    if (tracked.blocked) return null;
     const inFlight = sessionCreationPromises.get(sessionId);
     if (inFlight) return inFlight;
     const creation = (async () => {

--- a/bin/happy-bridge/validate.mjs
+++ b/bin/happy-bridge/validate.mjs
@@ -96,7 +96,7 @@ export function validatePermissionResponse(
 
   const offeredOptions = pending.optionIds ?? pending.options ?? [];
   const offeredIds = Array.from(offeredOptions, (option) =>
-    typeof option === "string" ? option : option?.id,
+    typeof option === "string" ? option : (option?.optionId ?? option?.id),
   );
   if (!offeredIds.includes(optionId)) {
     return { ok: false, reason: "permission option was not offered" };

--- a/src-tauri/src/commands/happy_bridge.rs
+++ b/src-tauri/src/commands/happy_bridge.rs
@@ -121,7 +121,12 @@ pub async fn happy_bridge_start_pairing(
     app: AppHandle,
     state: State<'_, HappyBridgeManager>,
 ) -> Result<String, String> {
-    if matches!(state.status().await.state, HappyBridgeState::Stopped) {
+    // Any state other than Running means there is no usable pairing code: the
+    // payload is consumed on first read, and a timed-out or failed pairing
+    // leaves a bridge that will never emit another one. Restart so the user
+    // always gets a fresh code instead of a dead one.
+    if !matches!(state.status().await.state, HappyBridgeState::Running) {
+        state.stop(&app).await?;
         state.start(&app).await?;
     }
     state.wait_for_pairing_payload().await

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -201,7 +201,16 @@ impl HappyBridgeManager {
         )
         .await;
         pipe_bridge_output(&mut child, Arc::clone(&stdin), app.clone());
-        *self.process.lock().await = Some(HappyBridgeProcess {
+        let mut guard = self.process.lock().await;
+        // `stop()` can take the process slot while a start is still in flight.
+        // Storing the child now would leave a live bridge accepting inbound
+        // requests behind a "Stopped" status, so discard it instead.
+        if self.stopping.load(Ordering::Acquire) {
+            drop(guard);
+            let _ = child.kill().await;
+            return Ok(());
+        }
+        *guard = Some(HappyBridgeProcess {
             child,
             _stdin: stdin,
             spawned_at: Instant::now(),
@@ -288,9 +297,10 @@ impl HappyBridgeManager {
         state: Option<String>,
         detail: Option<String>,
     ) {
-        if state.as_deref() == Some("connected") || detail.as_deref() == Some("Connected") {
-            *self.restart_attempts.lock().await = 0;
-        }
+        // The restart budget is refunded only by sustained uptime (see
+        // `should_rearm`). A connection report says startup succeeded once, not
+        // that the process is durable, so refunding here would let a bridge that
+        // connects and immediately dies respawn forever.
         let mut status = self.status.lock().await;
         if let Some(next_state) = report_state(state.as_deref()) {
             status.state = next_state;
@@ -602,6 +612,19 @@ struct SupervisorRequest {
     params: Value,
 }
 
+/// Mirrors `validate.mjs`: an advertised root must match after canonicalization,
+/// so symlink escapes and `..` traversal are both rejected. Fails closed when no
+/// roots are advertised or a path cannot be resolved.
+fn is_advertised_root(app: &AppHandle, cwd: &str) -> bool {
+    let Ok(candidate) = std::fs::canonicalize(cwd) else {
+        return false;
+    };
+    crate::commands::happy_bridge::effective_advertised_roots(app, Vec::new())
+        .iter()
+        .filter_map(|root| std::fs::canonicalize(root).ok())
+        .any(|root| root == candidate)
+}
+
 fn error_response(id: Value, code: i32, message: &str) -> Value {
     json!({
         "jsonrpc": "2.0",
@@ -662,6 +685,12 @@ async fn dispatch_supervisor_request(
             let agent_type = required_string(&request.params, "agentType")?;
             let cwd = required_string(&request.params, "cwd")?;
             let title = required_string(&request.params, "title")?;
+            // The bridge is the process parsing attacker-controlled relay
+            // traffic, so its advertised-root check is re-run here rather than
+            // trusted. Defense in depth for remote session spawn.
+            if !is_advertised_root(app, &cwd) {
+                return Err("cwd is not an advertised root".to_string());
+            }
             let happy_session_id = required_string(&request.params, "happySessionId")?;
             let metadata = serde_json::to_string(&json!({
                 "happy_session_id": happy_session_id,
@@ -891,7 +920,11 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
         tauri::async_runtime::spawn(async move {
             let mut reader = BufReader::new(stderr);
             while let Ok(Some(BoundedLine::Complete(line))) = read_bounded_line(&mut reader).await {
-                log::info!("[HappyBridge] {line}");
+                // The bridge holds the relay token, the NaCl secret, and the
+                // provider-runtime token. Its stderr is not a vetted channel, so
+                // it stays out of the default log; status flows through
+                // `status_report` instead.
+                log::debug!("[HappyBridge] {line}");
             }
         });
     }

--- a/tests/unit/happy-resolution-arbitration.test.ts
+++ b/tests/unit/happy-resolution-arbitration.test.ts
@@ -10,6 +10,8 @@ import {
   createStartupStatusGate,
   completeTerminalSession,
   createTerminatedSessionTracker,
+  isSupportedPermissionMode,
+  resolveTrackedSession,
   selectApprovalOption,
 } from "../../bin/happy-bridge/happy-layer.mjs";
 
@@ -114,5 +116,37 @@ describe("provider resolution arbitration", () => {
     expect(emitted).toEqual(["terminal"]);
     expect(sessions.has("session-1")).toBe(false);
     expect(closed).toBe(true);
+  });
+
+  it("still resolves a tracked session after it is marked terminated", () => {
+    const terminatedSessions = createTerminatedSessionTracker();
+    const entry = { sessionId: "session-1" };
+    const sessions = new Map([["session-1", entry]]);
+    terminatedSessions.mark("session-1");
+
+    // Without this precedence the terminal event returns early and the relay
+    // client is never closed, leaking one socket per finished session.
+    expect(resolveTrackedSession({ sessions, terminatedSessions, sessionId: "session-1" })).toEqual({
+      entry,
+      blocked: false,
+    });
+  });
+
+  it("refuses to create a new session for an id that already terminated", () => {
+    const terminatedSessions = createTerminatedSessionTracker();
+    terminatedSessions.mark("session-2");
+
+    expect(
+      resolveTrackedSession({ sessions: new Map(), terminatedSessions, sessionId: "session-2" }),
+    ).toEqual({ entry: null, blocked: true });
+  });
+
+  it("rejects permission modes the provider runtimes do not accept", () => {
+    for (const mode of ["default", "plan", "bypassPermissions", "ask", "auto"]) {
+      expect(isSupportedPermissionMode(mode)).toBe(true);
+    }
+    for (const mode of ["", "sudo", "PLAN", 1, null, undefined]) {
+      expect(isSupportedPermissionMode(mode)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
Closes #3027
Closes #3028
Closes #3029
Refs #3003

Addresses the open audit findings on the Happy remote-access bridge. Each fix is narrow and independently verified.

## P1 — terminal session cleanup was unreachable (#3027)

`publishEvent` marks a session terminated, then calls `findOrCreateSession`, which returned `null` for any marked id **before** it could return the already-tracked entry. So the terminal envelopes were never flushed and `completeTerminalSession` was never called — one relay client and socket leaked per finished session, and the phone never saw sessions end.

An existing entry now takes precedence; the mark only blocks *creating* a new entry for a session that has already ended. The precedence decision is extracted into `resolveTrackedSession` so it is directly testable — the previous test passed because it called `completeTerminalSession` directly and never exercised the call site that skipped it.

## P2 — every graceful shutdown crashed (#3028)

`shutdown` was registered directly as a signal handler, so Node passed it the signal *name* as its `exitCode` parameter. `process.exitCode = "SIGTERM"` throws `ERR_INVALID_ARG_TYPE`, and the throw inside the un-awaited async handler became an unhandled rejection.

**Verified live** against the real bridge entrypoint under the real embedded Node (v22.12.0), spawning the process and sending it a real SIGTERM:

```
BEFORE  exit code=1  CRASHED on shutdown
        stderr: node:internal/bootstrap/node:123  validateInteger(value, 'code');
AFTER   exit code=0  clean shutdown, no unhandled rejection
```

## P2 — restart budget refunded on every connection report (#3029)

A connection report says startup succeeded once, not that the process is durable. Refunding the budget there let a bridge that connects and immediately dies respawn indefinitely. Sustained uptime (`should_rearm`, 60s) is now the only thing that refunds it; the report still sets `Running`.

## Hardening from #3003 (items 2, 3, 4, 5, 8)

- **cwd re-validation (item 2)** — `conversation_create` now re-checks `cwd` against the advertised roots in Rust. The bridge is the process parsing attacker-controlled relay traffic, so its own check is no longer the only gate. Canonicalizes before comparing, mirroring `validate.mjs`, and fails closed.
- **stderr redaction (item 3)** — bridge stderr drops to `debug`. The process holds the relay token, the NaCl secret, and the provider-runtime token; its stderr is not a vetted channel. Status still flows through `status_report`.
- **permission-mode allowlist (item 4)** — modes are validated at the bridge boundary instead of forwarded as any string. Previously an unrecognized mode was silently coerced by codex to its permissive `auto`.
- **stop/start race (item 5)** — `start_process` discards the child if `stop()` ran while the start was in flight, instead of leaving a live bridge behind a `Stopped` status.
- **offered option matching (item 8)** — `validate.mjs` matches on `optionId`, which is what every option object actually uses.

**Item 6 (Windows termination) is deliberately not included.** `terminate_child` cannot close stdin — it was already moved into an `Arc` in `start_process` — and the bridge does not exit on stdin EOF after config, so the obvious fix is a no-op. The alternatives (an entrypoint-level supervisor listener, or `taskkill`) either break the `roots_update` notification queue-drain or remove graceful relay shutdown. Not worth that risk for a 5-second cosmetic stall on disable. #3003 stays open with the detail recorded.

## Networked paths

The bridge's only outbound HTTP is `POST`/`GET {relayUrl}/v1/auth/request` (Happy hosted relay, `happy-layer.mjs`), plus a local `ws://host:port` to the provider runtime. **No `api.serendb.com` publisher slug is in any changed path**, and no slug, method, or path is altered by this PR.

## Validation

- `pnpm test` — 2415 passed, 0 failed (+3 new)
- `cargo test` — 925 passed, 0 failed
- `pnpm check` — 0 errors (48 pre-existing warnings)
- `cargo check` — clean
- `pnpm test:runtime-e2e` — **4/4 passed**, live provider runtime and real CLIs, both runtimes
- Live SIGTERM probe — real process, real signal, before/after above
- Shipped-bundle simulation — fixed bridge loads under the real embedded Node in a directory with no ancestor `node_modules` (257M, exit 0)

## Tests added

Three, all on real code paths with no mocks: existing-entry precedence survives the terminated mark; a genuinely new id is still refused; permission-mode allowlist accepts supported modes and rejects unknown/non-string input.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
