### PR TITLE
fix(remote): close v3.71.0 release blockers (#3032, #3033, #3034)

### DIFF
--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -181,10 +181,16 @@ function normalizeSession(session) {
   };
 }
 
-function providerPermissionMode(mode, agentType) {
+// codex collapses every mode onto two approval policies: "ask" prompts via
+// ActionConfirmation, everything else runs unattended. Only a mode that
+// explicitly asks to skip approvals may reach "auto" — anything else, including
+// the baseline "default" a remote peer sends by omission, must fail closed to
+// "ask" so approval prompts are never dropped silently.
+const CODEX_UNATTENDED_MODES = new Set(["auto", "bypassPermissions", "safe-yolo", "yolo"]);
+
+export function providerPermissionMode(mode, agentType) {
   if (agentType === "codex") {
-    if (mode === "ask" || mode === "auto") return mode;
-    return ["plan", "read-only"].includes(mode) ? "ask" : "auto";
+    return CODEX_UNATTENDED_MODES.has(mode) ? "auto" : "ask";
   }
   if (agentType === "gemini") {
     return {

--- a/src-tauri/src/commands/happy_bridge.rs
+++ b/src-tauri/src/commands/happy_bridge.rs
@@ -1,14 +1,14 @@
 // ABOUTME: Tauri commands for enabling, disabling, and inspecting Happy Remote Access.
 // ABOUTME: Persists only the opt-in flag here; pairing credentials are handled separately.
 
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, Manager, Runtime, State};
 use tauri_plugin_store::StoreExt;
 
 use crate::happy_bridge::{HappyBridgeManager, HappyBridgeState, HappyBridgeStatus};
 
-const SETTINGS_STORE: &str = "settings.json";
+pub(crate) const SETTINGS_STORE: &str = "settings.json";
 const ENABLED_KEY: &str = "happy_bridge_enabled";
-const ADVERTISED_ROOTS_KEY: &str = "happy_bridge_advertised_roots";
+pub(crate) const ADVERTISED_ROOTS_KEY: &str = "happy_bridge_advertised_roots";
 
 fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), String> {
     let store = app.store(SETTINGS_STORE).map_err(|err| err.to_string())?;
@@ -24,23 +24,35 @@ fn is_enabled(app: &AppHandle) -> bool {
         .unwrap_or(false)
 }
 
-pub fn effective_advertised_roots(app: &AppHandle, discovered: Vec<String>) -> Vec<String> {
-    let Some(value) = app
-        .store(SETTINGS_STORE)
+/// The roots the user has explicitly consented to, unfiltered. This is the
+/// authoritative record of consent: `happy_bridge_update_roots` advertises
+/// exactly this set, so the spawn re-check must validate against it rather than
+/// against the start-time intersection, which is narrower and drifts as soon as
+/// the user edits their selection.
+pub fn saved_advertised_roots<R: Runtime>(app: &AppHandle<R>) -> Vec<String> {
+    app.store(SETTINGS_STORE)
         .ok()
         .and_then(|store| store.get(ADVERTISED_ROOTS_KEY))
-    else {
-        return Vec::new();
-    };
+        .and_then(|value| {
+            value.as_array().map(|saved| {
+                saved
+                    .iter()
+                    .filter_map(|root| root.as_str().map(str::to_string))
+                    .collect()
+            })
+        })
+        .unwrap_or_default()
+}
 
-    let Some(saved) = value.as_array() else {
-        return Vec::new();
-    };
-    saved
-        .iter()
-        .filter_map(|value| value.as_str())
+/// The subset of consented roots that still correspond to a known project, used
+/// to decide what the bridge advertises at startup.
+pub fn effective_advertised_roots<R: Runtime>(
+    app: &AppHandle<R>,
+    discovered: Vec<String>,
+) -> Vec<String> {
+    saved_advertised_roots(app)
+        .into_iter()
         .filter(|root| discovered.iter().any(|candidate| candidate == root))
-        .map(str::to_string)
         .collect()
 }
 

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -234,7 +234,7 @@ impl HappyBridgeManager {
         }));
     }
 
-    pub async fn stop(&self, app: &AppHandle) -> Result<(), String> {
+    pub async fn stop<R: tauri::Runtime>(&self, app: &AppHandle<R>) -> Result<(), String> {
         self.stopping.store(true, Ordering::Release);
         if let Some(handle) = self.monitor_handle.lock().await.take() {
             handle.abort();
@@ -244,6 +244,10 @@ impl HappyBridgeManager {
         if let Some(mut process) = process {
             terminate_child(&mut process.child).await?;
         }
+        // A pairing payload is only usable while the process that minted it is
+        // alive, because the matching secret key lives in that process. Drop it
+        // so a restart cannot hand back a code whose secret half is gone.
+        *self.pairing_payload.lock().await = None;
         self.set_status(app, HappyBridgeState::Stopped, None).await;
         Ok(())
     }
@@ -311,7 +315,7 @@ impl HappyBridgeManager {
         let _ = app.emit(STATUS_EVENT, status.clone());
     }
 
-    async fn record_pairing_payload(&self, app: &AppHandle, payload: String) {
+    async fn record_pairing_payload<R: tauri::Runtime>(&self, app: &AppHandle<R>, payload: String) {
         *self.pairing_payload.lock().await = Some(payload.clone());
         let _ = app.emit(PAIRING_EVENT, payload);
     }
@@ -357,7 +361,12 @@ impl HappyBridgeManager {
         Ok(())
     }
 
-    async fn set_status(&self, app: &AppHandle, state: HappyBridgeState, detail: Option<String>) {
+    async fn set_status<R: tauri::Runtime>(
+        &self,
+        app: &AppHandle<R>,
+        state: HappyBridgeState,
+        detail: Option<String>,
+    ) {
         let status = HappyBridgeStatus { state, detail };
         *self.status.lock().await = status.clone();
         let _ = app.emit(STATUS_EVENT, status);
@@ -615,11 +624,11 @@ struct SupervisorRequest {
 /// Mirrors `validate.mjs`: an advertised root must match after canonicalization,
 /// so symlink escapes and `..` traversal are both rejected. Fails closed when no
 /// roots are advertised or a path cannot be resolved.
-fn is_advertised_root(app: &AppHandle, cwd: &str) -> bool {
+fn is_advertised_root<R: tauri::Runtime>(app: &AppHandle<R>, cwd: &str) -> bool {
     let Ok(candidate) = std::fs::canonicalize(cwd) else {
         return false;
     };
-    crate::commands::happy_bridge::effective_advertised_roots(app, Vec::new())
+    crate::commands::happy_bridge::saved_advertised_roots(app)
         .iter()
         .filter_map(|root| std::fs::canonicalize(root).ok())
         .any(|root| root == candidate)
@@ -934,12 +943,145 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
 mod tests {
     use super::{
         BoundedLine, HappyBridgeState, MAX_RESTART_ATTEMPTS, MAX_SUPERVISOR_LINE_BYTES, error_response,
-        next_restart_attempt, parse_supervisor_line, read_bounded_line, restart_allowed,
-        restart_delay, report_state, should_rearm,
+        is_advertised_root, next_restart_attempt, parse_supervisor_line, read_bounded_line,
+        restart_allowed, restart_delay, report_state, should_rearm,
     };
+    use crate::commands::happy_bridge::{ADVERTISED_ROOTS_KEY, SETTINGS_STORE};
     use serde_json::Value;
     use std::time::Duration;
+    use tauri_plugin_store::StoreExt;
     use tokio::io::{AsyncWriteExt, BufReader, duplex};
+
+    /// The store persists to the mock runtime's data dir, which sibling tests on
+    /// the same host share, so the key is always reset rather than assumed absent.
+    fn mock_app_with_roots(roots: Option<Vec<String>>) -> tauri::App<tauri::test::MockRuntime> {
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_store::Builder::default().build())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app builds");
+        let store = app.store(SETTINGS_STORE).expect("settings store opens");
+        store.delete(ADVERTISED_ROOTS_KEY);
+        if let Some(roots) = roots {
+            store.set(ADVERTISED_ROOTS_KEY, serde_json::json!(roots));
+        }
+        app
+    }
+
+    #[tokio::test]
+    async fn stopping_discards_the_pairing_payload_of_the_dead_process() {
+        // Regression: the payload outlived the process that minted it, so
+        // `happy_bridge_start_pairing`'s stop/start handed back a QR code whose
+        // secret key had died with the previous bridge and pairing never completed.
+        let app = mock_app_with_roots(None);
+        let manager = super::HappyBridgeManager::new();
+
+        manager
+            .record_pairing_payload(app.handle(), "payload-from-bridge-a".to_string())
+            .await;
+        assert!(
+            manager.pairing_payload.lock().await.is_some(),
+            "the live bridge's payload is available before the stop"
+        );
+
+        manager.stop(app.handle()).await.expect("stop succeeds");
+
+        // Asserted on the stored value rather than through
+        // `wait_for_pairing_payload`, which would burn its full 10s deadline.
+        assert!(
+            manager.pairing_payload.lock().await.is_none(),
+            "a payload minted by a stopped bridge must not be handed out"
+        );
+    }
+
+    #[test]
+    fn advertised_root_accepts_a_consented_root() {
+        // Regression: the re-check intersected the saved roots against an empty
+        // `discovered` set, so it returned false for every path and remote
+        // session spawn failed unconditionally.
+        let consented = tempfile::tempdir().expect("temp dir");
+        let consented_path = consented.path().to_string_lossy().to_string();
+        let app = mock_app_with_roots(Some(vec![consented_path.clone()]));
+
+        assert!(
+            is_advertised_root(app.handle(), &consented_path),
+            "a root the user consented to must pass the spawn re-check"
+        );
+    }
+
+    #[test]
+    fn advertised_root_rejects_paths_outside_the_consented_set() {
+        let consented = tempfile::tempdir().expect("temp dir");
+        let sibling = tempfile::tempdir().expect("temp dir");
+        let nested = consented.path().join("nested");
+        std::fs::create_dir(&nested).expect("nested dir");
+
+        let app = mock_app_with_roots(Some(vec![
+            consented.path().to_string_lossy().to_string(),
+        ]));
+
+        let sibling_path = sibling.path().to_string_lossy().to_string();
+        assert!(
+            !is_advertised_root(app.handle(), &sibling_path),
+            "an unrelated directory must be rejected"
+        );
+
+        // Membership is canonical equality, not prefix containment, so a
+        // subdirectory of a consented root is still not itself a root.
+        assert!(
+            !is_advertised_root(app.handle(), &nested.to_string_lossy()),
+            "a nested directory must not inherit its parent's consent"
+        );
+
+        // `..` traversal out of a consented root canonicalizes to the sibling.
+        let escape = consented.path().join("..").join(
+            sibling
+                .path()
+                .file_name()
+                .expect("sibling has a final component"),
+        );
+        assert!(
+            !is_advertised_root(app.handle(), &escape.to_string_lossy()),
+            "traversal out of a consented root must be rejected"
+        );
+    }
+
+    #[test]
+    fn advertised_root_fails_closed_when_nothing_is_consented() {
+        let candidate = tempfile::tempdir().expect("temp dir");
+        let candidate_path = candidate.path().to_string_lossy().to_string();
+
+        let unset = mock_app_with_roots(None);
+        assert!(
+            !is_advertised_root(unset.handle(), &candidate_path),
+            "no saved roots must reject every path"
+        );
+
+        let empty = mock_app_with_roots(Some(Vec::new()));
+        assert!(
+            !is_advertised_root(empty.handle(), &candidate_path),
+            "an empty consent list must reject every path"
+        );
+    }
+
+    #[test]
+    fn effective_advertised_roots_keeps_only_discovered_projects() {
+        let consented = tempfile::tempdir().expect("temp dir");
+        let consented_path = consented.path().to_string_lossy().to_string();
+        let app = mock_app_with_roots(Some(vec![consented_path.clone()]));
+
+        assert_eq!(
+            crate::commands::happy_bridge::effective_advertised_roots(
+                app.handle(),
+                vec![consented_path.clone()],
+            ),
+            vec![consented_path.clone()],
+        );
+        assert!(
+            crate::commands::happy_bridge::effective_advertised_roots(app.handle(), Vec::new())
+                .is_empty(),
+            "a root with no matching project is not advertised at startup"
+        );
+    }
 
     #[test]
     fn restart_backoff_is_capped() {

--- a/tests/unit/happy-bridge-permission-mode.test.ts
+++ b/tests/unit/happy-bridge-permission-mode.test.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Verifies remote permission modes can never silently drop approval prompts.
+// ABOUTME: Guards the ActionConfirmation boundary against a remote peer's mode change.
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import { providerPermissionMode } from "../../bin/happy-bridge/provider-source.mjs";
+// @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
+import { isSupportedPermissionMode } from "../../bin/happy-bridge/happy-layer.mjs";
+
+// Mirrors codexApprovalPolicy in bin/browser-local/providers.mjs: only "ask"
+// prompts, every other mode runs unattended.
+const promptsForApproval = (providerMode: string) => providerMode === "ask";
+
+// The modes a remote peer is allowed to send. Anything outside this set is
+// dropped at the bridge boundary before it reaches the provider runtime.
+const REMOTE_MODES = [
+  "default",
+  "acceptEdits",
+  "plan",
+  "bypassPermissions",
+  "read-only",
+  "safe-yolo",
+  "yolo",
+  "ask",
+  "auto",
+];
+
+// Modes whose entire purpose is to run without approval prompts. Only these may
+// legitimately reach codex's unattended policy.
+const EXPLICITLY_UNATTENDED = new Set(["auto", "bypassPermissions", "safe-yolo", "yolo"]);
+
+describe("codex permission mode mapping", () => {
+  it("does not let the baseline 'default' mode disable approval prompts", () => {
+    // Regression: "default" fell through to "auto" -> approval_policy "never",
+    // so an ordinary remote message silently bypassed ActionConfirmation.
+    expect(providerPermissionMode("default", "codex")).toBe("ask");
+    expect(promptsForApproval(providerPermissionMode("default", "codex"))).toBe(true);
+  });
+
+  it("fails closed for modes it does not recognize", () => {
+    for (const mode of ["", "unknown", "Default", "AUTO", "acceptEdits"]) {
+      expect(providerPermissionMode(mode, "codex")).toBe("ask");
+    }
+  });
+
+  it("keeps prompting for every remote mode that is not explicitly unattended", () => {
+    for (const mode of REMOTE_MODES) {
+      const providerMode = providerPermissionMode(mode, "codex");
+      expect(promptsForApproval(providerMode)).toBe(!EXPLICITLY_UNATTENDED.has(mode));
+    }
+  });
+
+  it("still honors modes that explicitly ask to run unattended", () => {
+    for (const mode of EXPLICITLY_UNATTENDED) {
+      expect(providerPermissionMode(mode, "codex")).toBe("auto");
+    }
+  });
+
+  it("only accepts remote modes the mapping has a defined answer for", () => {
+    for (const mode of REMOTE_MODES) {
+      expect(isSupportedPermissionMode(mode)).toBe(true);
+    }
+    expect(isSupportedPermissionMode("nope")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #3032, closes #3033, closes #3034.

Found by the v3.71.0 pre-release audit. All three break or subvert the Happy
remote-access feature this release ships, so all three block the tag.

## #3032 — remote session spawn never succeeded

`is_advertised_root` called `effective_advertised_roots(app, Vec::new())`, and
that function filters the saved roots by membership in `discovered`. With
`discovered` empty the predicate is false for every root, so it returned an
empty list unconditionally and the check failed for every path.
`conversation_create` is the only remote-spawn path, so **every** spawn was
rejected with `cwd is not an advertised root` — including spawns into correctly
ticked folders.

Introduced by #3030, which added the intersection filter without updating this
call site. Neither function had test coverage.

Fixed by splitting out `saved_advertised_roots`, the user's explicit consent
list, and re-checking against that. This is also exactly what
`happy_bridge_update_roots` advertises to the bridge, so the enforcement set and
the advertised set can no longer drift. `effective_advertised_roots` keeps its
narrower start-time role of only advertising roots that map to a known project.

## #3033 — pairing never completed

`pairing_payload` was never cleared when the process that minted it died, so
`happy_bridge_start_pairing`'s stop/start returned the *previous* bridge's
payload. The QR encoded a public key whose secret half died with that process,
so the phone's auth response could never be decrypted. The enable-then-pair
sequence hit this every time, and each retry stayed one generation behind.

Fixed by clearing the payload in `stop()`.

## #3034 — remote message could disable Codex approval prompts

`providerPermissionMode` sent any mode outside a small allowlist to codex's
permissive `"auto"`, which `codexApprovalPolicy` maps to
`approval_policy: "never"`. `"default"` — the baseline mode a remote peer sends
— was one of those, so a single ordinary message from a paired phone silently
dropped ActionConfirmation for the rest of the session, violating
"All tool calls require user approval via the ActionConfirmation flow."

The comment above `SUPPORTED_PERMISSION_MODES` already named this hazard; the
allowlist just did not cover it. The mapping now fails **closed** to `"ask"`,
and only modes that explicitly request unattended execution (`auto`,
`bypassPermissions`, `yolo`, `safe-yolo`) reach `"auto"`.

## Verification

- `is_advertised_root`, `set_status`, `stop` and `record_pairing_payload` now
  take a runtime parameter, following the existing `<R: Runtime>` pattern in
  `shell.rs` / `provider_runtime.rs`, so the authorization check and the pairing
  lifecycle are testable against a mock runtime with a real store.
- 5 new Rust tests + 5 new frontend tests. **Each was confirmed to fail against
  the pre-fix code** — the roots test panics with "a root the user consented to
  must pass the spawn re-check", the pairing test with "a payload minted by a
  stopped bridge must not be handed out", and the mode tests with
  `expected 'auto' to be 'ask'`.
- Root coverage includes canonical equality (a nested subdirectory does not
  inherit its parent's consent), `..` traversal out of a consented root, and
  fail-closed behaviour for both an unset and an empty consent list.
- Full suites green: Rust 930 passed, frontend 2420 passed, Biome exit 0.
- The mode mapping was additionally exercised under the **embedded node
  runtime**, confirming no benign mode reaches `approval_policy: never`.

Not covered: an end-to-end spawn against a real paired device and the Happy
relay. That needs hardware and the live relay, so it is unverified here and
should be walked on the release build.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
