### PR TITLE
fix(remote): scope remote sessions to shared folders

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -7,10 +7,15 @@ import { ApiClient, configuration } from "happy/lib";
 import nacl from "tweetnacl";
 
 import { translateNeutralEvent, composeApprovalNotification } from "./translate.mjs";
-import { validatePermissionResponse, validateSpawnRoot } from "./validate.mjs";
+import {
+  isWithinAdvertisedRoots,
+  validatePermissionResponse,
+  validateSpawnRoot,
+} from "./validate.mjs";
 
 const AUTH_POLL_MS = 1000;
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
+const SUMMARY_CACHE_TTL_MS = 1000;
 const DEFAULT_CODEX_APPROVAL_POLICY = "on-failure";
 const DENY_OPTION_IDS = new Set([
   "deny",
@@ -134,11 +139,19 @@ function machineMetadata(config, capabilities = { agents: [], roots: [] }) {
   };
 }
 
+// The remote peer names the agent, and the value is persisted as a conversation
+// row before the provider runtime ever validates it. Resolve to a known agent or
+// refuse, so an arbitrary remote string cannot reach the database.
+const HAPPY_AGENT_TYPES = new Map([
+  ["claude", "claude-code"],
+  ["claude-code", "claude-code"],
+  ["gemini", "gemini"],
+  ["codex", "codex"],
+]);
+
 function happyAgentType(agent) {
-  if (agent === "claude") return "claude-code";
-  if (agent === "gemini") return "gemini";
-  if (agent === "codex") return "codex";
-  return typeof agent === "string" && agent.length > 0 ? agent : "claude-code";
+  if (agent === undefined || agent === null) return "claude-code";
+  return HAPPY_AGENT_TYPES.get(agent) ?? null;
 }
 
 function defaultApprovalPolicy(agentType) {
@@ -285,8 +298,55 @@ export function createHappyLayer({
   const pendingRequests = Object.create(null);
   const liveSessions = new Set();
 
+  const sessionSummaries = new Map();
+  let summariesFetchedAt = 0;
+
   function debug(message) {
     debugLog(message);
+  }
+
+  /// Listing every session once per streamed event issued one provider RPC per
+  /// assistant delta. Summaries are stable for the fields consumed here
+  /// (agentType, cwd), so they are cached and only re-listed for a session the
+  /// cache has never seen, at most once per interval.
+  async function refreshSessionSummaries() {
+    const listed = await source.listSessions();
+    sessionSummaries.clear();
+    for (const summary of listed) sessionSummaries.set(summary.sessionId, summary);
+    summariesFetchedAt = Date.now();
+    return listed;
+  }
+
+  async function sessionSummary(sessionId) {
+    if (
+      !sessionSummaries.has(sessionId) &&
+      Date.now() - summariesFetchedAt > SUMMARY_CACHE_TTL_MS
+    ) {
+      await refreshSessionSummaries();
+    }
+    return sessionSummaries.get(sessionId) ?? null;
+  }
+
+  /// A paired device may only observe and drive sessions in folders the user
+  /// shared. Spawning still requires the path to *be* an advertised root; an
+  /// already-running session inside one is in scope.
+  function isSessionInScope(summary) {
+    return isWithinAdvertisedRoots(summary?.cwd, advertisedRoots);
+  }
+
+  /// Called whenever the advertised roots change so sessions that fall out of
+  /// scope stop being observable rather than lingering until restart.
+  async function dropSessionsOutOfScope() {
+    for (const [sessionId, entry] of Array.from(sessions.entries())) {
+      if (isSessionInScope(entry.summary)) continue;
+      sessions.delete(sessionId);
+      liveSessions.delete(sessionId);
+      delete pendingRequests[sessionId];
+      sessionCreationPromises.delete(sessionId);
+      await entry.client
+        .close()
+        .catch(() => debug("failed to close Happy session leaving scope"));
+    }
   }
 
   function rememberPermission(event) {
@@ -320,24 +380,25 @@ export function createHappyLayer({
     client.onUserMessage((message) => {
       void handleUserMessage(entry, message).catch(() => debug("ignored Happy inbound user message"));
     });
-    client.rpcHandlerManager.registerHandler("abort", async () => {
+    // Decryption failure yields null params rather than throwing, and these two
+    // handlers ignore their argument, so without this guard a relay could cancel
+    // a live turn with ciphertext it cannot even produce. A legitimate empty
+    // payload decrypts to {}, so null is unambiguously a failed decrypt.
+    const cancelSession = (label) => async (params) => {
+      if (params === null) {
+        debug(`dropped unauthenticated Happy ${label} request`);
+        return { ok: false };
+      }
       try {
         await source.cancel(entry.sessionId);
         return { ok: true };
       } catch {
-        debug("ignored failed Happy abort request");
+        debug(`ignored failed Happy ${label} request`);
         return { ok: false };
       }
-    });
-    client.rpcHandlerManager.registerHandler("switch", async () => {
-      try {
-        await source.cancel(entry.sessionId);
-        return { ok: true };
-      } catch {
-        debug("ignored failed Happy switch request");
-        return { ok: false };
-      }
-    });
+    };
+    client.rpcHandlerManager.registerHandler("abort", cancelSession("abort"));
+    client.rpcHandlerManager.registerHandler("switch", cancelSession("switch"));
     client.rpcHandlerManager.registerHandler("permission", async (response) => {
       try {
         return await handlePermissionResponse(entry, response);
@@ -427,13 +488,15 @@ export function createHappyLayer({
     const inFlight = sessionCreationPromises.get(sessionId);
     if (inFlight) return inFlight;
     const creation = (async () => {
-      const listed = summary ?? (await source.listSessions()).find((item) => item.sessionId === sessionId);
-      return createSessionEntry(sessionId, listed ?? {
-        sessionId,
-        agentType: "claude-code",
-        cwd: os.homedir(),
-        status: "ready",
-      });
+      const listed = summary ?? (await sessionSummary(sessionId));
+      // The previous fallback invented a summary rooted at the home directory,
+      // which is not a folder the user shared. A session the provider runtime
+      // cannot describe stays out of scope rather than being exposed.
+      if (!listed || !isSessionInScope(listed)) {
+        debug("skipped Happy session outside advertised roots");
+        return null;
+      }
+      return createSessionEntry(sessionId, listed);
     })();
     sessionCreationPromises.set(sessionId, creation);
     try {
@@ -444,6 +507,15 @@ export function createHappyLayer({
   }
 
   async function publishEvent(event) {
+    // An entry only exists if it passed the scope check when it was created, so
+    // a tracked session stays tracked; an unknown one is gated here, before any
+    // bookkeeping, so out-of-scope sessions accumulate no state either.
+    const summary =
+      (await sessionSummary(event.sessionId)) ?? sessions.get(event.sessionId)?.summary ?? null;
+    if (!sessions.has(event.sessionId) && !isSessionInScope(summary)) {
+      debug("dropped event for session outside advertised roots");
+      return;
+    }
     const terminal =
       event.kind === "status" && ["error", "terminated"].includes(event.payload?.status);
     if (terminal) {
@@ -456,7 +528,6 @@ export function createHappyLayer({
     }
     rememberPermission(event);
     if (terminal && !sessions.has(event.sessionId)) return;
-    const summary = (await source.listSessions()).find((item) => item.sessionId === event.sessionId);
     const entry = await findOrCreateSession(event.sessionId, summary);
     if (!entry) return;
     const provider = summary?.agentType === "claude-code" ? "claude" : summary?.agentType ?? "codex";
@@ -495,6 +566,10 @@ export function createHappyLayer({
       return { type: "error", errorMessage: "Requested directory is not an advertised root" };
     }
     const agentType = happyAgentType(options?.agent);
+    if (!agentType) {
+      debug("refused spawn for unknown agent type");
+      return { type: "error", errorMessage: "Requested agent is not available" };
+    }
     const pendingSessionId = `spawn-${randomUUID()}`;
     const pending = await createSessionEntry(pendingSessionId, {
       sessionId: pendingSessionId,
@@ -503,28 +578,66 @@ export function createHappyLayer({
       title: `${agentType} Agent`,
       status: "initializing",
     });
-    const conversation = await supervisorChannel.call("conversation_create", {
-      agentType,
-      cwd: validation.root,
-      title: `${agentType} Agent`,
-      happySessionId: pending.happySessionId,
+    // Everything past this point can reject, and the pending entry already holds
+    // an open sync client and a relay-side session. Unwind it on failure so a
+    // repeated failing spawn cannot accumulate open sockets.
+    try {
+      const conversation = await supervisorChannel.call("conversation_create", {
+        agentType,
+        cwd: validation.root,
+        title: `${agentType} Agent`,
+        happySessionId: pending.happySessionId,
+      });
+      const spawned = await source.spawn({
+        agentType,
+        cwd: validation.root,
+        localSessionId: conversation.conversationId,
+        approvalPolicy: defaultApprovalPolicy(agentType),
+      });
+      if (!spawned?.sessionId) throw new Error("provider spawn returned no session");
+      sessions.delete(pendingSessionId);
+      pending.sessionId = spawned.sessionId;
+      pending.summary = spawned;
+      sessions.set(spawned.sessionId, pending);
+      liveSessions.delete(pendingSessionId);
+      liveSessions.add(spawned.sessionId);
+      pendingRequests[spawned.sessionId] = pendingRequests[pendingSessionId] ?? Object.create(null);
+      delete pendingRequests[pendingSessionId];
+      // Seed the cache so the first streamed event resolves this session's
+      // provider without re-listing.
+      sessionSummaries.set(spawned.sessionId, spawned);
+      return { type: "success", sessionId: pending.happySessionId };
+    } catch (error) {
+      await discardPendingSpawn(pendingSessionId, pending);
+      debug("failed to spawn Happy session");
+      return {
+        type: "error",
+        errorMessage: error instanceof Error ? error.message : "spawn failed",
+      };
+    }
+  }
+
+  /// Registered from both the freshly-paired and already-paired startup paths.
+  /// A single listener keeps `dispatchNotification`'s queueing behaviour intact —
+  /// it stops queueing as soon as any listener exists, so adding a second one
+  /// elsewhere would drop notifications this one is waiting for.
+  function subscribeToSupervisor() {
+    supervisorSubscription = supervisorChannel.onNotification((method, params) => {
+      if (method !== "roots_update") return;
+      advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
+      void (async () => {
+        await dropSessionsOutOfScope();
+        await updateCapabilities();
+      })().catch(() => debug("failed to apply Happy roots update"));
     });
-    const spawned = await source.spawn({
-      agentType,
-      cwd: validation.root,
-      localSessionId: conversation.conversationId,
-      approvalPolicy: defaultApprovalPolicy(agentType),
-    });
-    if (!spawned?.sessionId) throw new Error("provider spawn returned no session");
+  }
+
+  async function discardPendingSpawn(pendingSessionId, pending) {
     sessions.delete(pendingSessionId);
-    pending.sessionId = spawned.sessionId;
-    pending.summary = spawned;
-    sessions.set(spawned.sessionId, pending);
     liveSessions.delete(pendingSessionId);
-    liveSessions.add(spawned.sessionId);
-    pendingRequests[spawned.sessionId] = pendingRequests[pendingSessionId] ?? Object.create(null);
     delete pendingRequests[pendingSessionId];
-    return { type: "success", sessionId: pending.happySessionId };
+    sessionCreationPromises.delete(pendingSessionId);
+    await pending.client.close().catch(() => debug("failed to close abandoned Happy session"));
   }
 
   function setupMachineHandlers() {
@@ -570,12 +683,7 @@ export function createHappyLayer({
         identity = identityFromAuthResponse(result.token, decryptAuthResponse(result.response, keyPair.secretKey));
         await supervisorChannel.call("identity_store", { identity });
         await registerMachine();
-        supervisorSubscription = supervisorChannel.onNotification((method, params) => {
-          if (method === "roots_update") {
-            advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
-            void updateCapabilities().catch(() => debug("failed to update Happy capabilities"));
-          }
-        });
+        supervisorSubscription = subscribeToSupervisor();
         await finishRegistration();
         return true;
       }
@@ -614,8 +722,11 @@ export function createHappyLayer({
   async function finishRegistration() {
     return startupStatusGate.complete(async () => {
       await updateCapabilities();
-      const listed = await source.listSessions();
-      for (const summary of listed) await createSessionEntry(summary.sessionId, summary);
+      const listed = await refreshSessionSummaries();
+      for (const summary of listed) {
+        if (!isSessionInScope(summary)) continue;
+        await createSessionEntry(summary.sessionId, summary);
+      }
       sourceSubscription?.();
       sourceSubscription = source.subscribe((event) => {
         void publishEvent(event).catch(() => debug("failed to publish Happy session event"));
@@ -625,12 +736,7 @@ export function createHappyLayer({
 
   return {
     async start() {
-      supervisorSubscription = supervisorChannel.onNotification((method, params) => {
-        if (method === "roots_update") {
-          advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
-          void updateCapabilities().catch(() => debug("failed to update Happy capabilities"));
-        }
-      });
+      supervisorSubscription = subscribeToSupervisor();
       if (await registerMachine()) {
         await finishRegistration();
         return;

--- a/bin/happy-bridge/validate.mjs
+++ b/bin/happy-bridge/validate.mjs
@@ -2,7 +2,7 @@
 // ABOUTME: Canonical equality is required so path tricks cannot widen authority.
 
 import { realpathSync } from "node:fs";
-import { isAbsolute } from "node:path";
+import { isAbsolute, sep } from "node:path";
 
 function canonicalAbsolutePath(value) {
   if (typeof value !== "string" || !isAbsolute(value)) {
@@ -47,6 +47,38 @@ export function validateSpawnRoot(requestedPath, advertisedRoots) {
   }
 
   return { ok: false, reason: "requested path is not an advertised root" };
+}
+
+/**
+ * Visibility scope for an existing session. Spawning requires the requested path
+ * to *be* an advertised root; a session already running inside one is in scope
+ * too, since the user shared that folder. Both sides are canonicalized first so
+ * a symlink cannot smuggle a path in, and the boundary check requires a
+ * separator so `/srv/project-secret` is not treated as inside `/srv/project`.
+ *
+ * @param {string} sessionCwd
+ * @param {string[]} advertisedRoots
+ * @returns {boolean}
+ */
+export function isWithinAdvertisedRoots(sessionCwd, advertisedRoots) {
+  if (!Array.isArray(advertisedRoots) || advertisedRoots.length === 0) {
+    return false;
+  }
+
+  const canonicalCwd = canonicalAbsolutePath(sessionCwd);
+  if (!canonicalCwd) {
+    return false;
+  }
+
+  for (const advertisedRoot of advertisedRoots) {
+    const canonicalRoot = canonicalAbsolutePath(advertisedRoot);
+    if (!canonicalRoot) continue;
+    if (canonicalCwd === canonicalRoot) return true;
+    const boundary = canonicalRoot.endsWith(sep) ? canonicalRoot : `${canonicalRoot}${sep}`;
+    if (canonicalCwd.startsWith(boundary)) return true;
+  }
+
+  return false;
 }
 
 function containsValue(collection, value) {

--- a/tests/unit/happy-bridge-validate.test.ts
+++ b/tests/unit/happy-bridge-validate.test.ts
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 // @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
 import {
+  isWithinAdvertisedRoots,
   validatePermissionResponse,
   validateSpawnRoot,
 } from "../../bin/happy-bridge/validate.mjs";
@@ -159,5 +160,55 @@ describe("validatePermissionResponse", () => {
         pendingRequests: { "session-1": {} },
       }),
     ).toEqual({ ok: false, reason: "permission request is not pending" });
+  });
+});
+
+describe("isWithinAdvertisedRoots", () => {
+  it("accepts the advertised root itself", () => {
+    const { advertisedRoot } = makeFixture();
+    expect(isWithinAdvertisedRoots(advertisedRoot, [advertisedRoot])).toBe(true);
+  });
+
+  it("accepts a session running inside an advertised root", () => {
+    const { advertisedRoot } = makeFixture();
+    const nested = join(advertisedRoot, "packages", "api");
+    mkdirSync(nested, { recursive: true });
+    expect(isWithinAdvertisedRoots(nested, [advertisedRoot])).toBe(true);
+  });
+
+  it("rejects a sibling whose path merely starts with the advertised root", () => {
+    // `advertised-root-evil` shares a string prefix with `advertised-root`; the
+    // boundary check must require a separator.
+    const { advertisedRoot, prefixTrick } = makeFixture();
+    expect(isWithinAdvertisedRoots(prefixTrick, [advertisedRoot])).toBe(false);
+  });
+
+  it("rejects a directory outside every advertised root", () => {
+    const { directory, advertisedRoot } = makeFixture();
+    expect(isWithinAdvertisedRoots(directory, [advertisedRoot])).toBe(false);
+  });
+
+  it("rejects .. traversal out of an advertised root", () => {
+    const { advertisedRoot, prefixTrick } = makeFixture();
+    const escape = join(advertisedRoot, "..", "advertised-root-evil");
+    expect(isWithinAdvertisedRoots(escape, [advertisedRoot])).toBe(false);
+    expect(existsSync(prefixTrick)).toBe(true);
+  });
+
+  it("resolves a symlink before deciding scope", () => {
+    const { advertisedRoot, prefixTrick } = makeFixture();
+    const link = join(advertisedRoot, "escape-link");
+    symlinkSync(prefixTrick, link);
+    // The link lives inside the advertised root but points outside it.
+    expect(isWithinAdvertisedRoots(link, [advertisedRoot])).toBe(false);
+  });
+
+  it("fails closed when nothing is advertised or the path is unusable", () => {
+    const { advertisedRoot } = makeFixture();
+    expect(isWithinAdvertisedRoots(advertisedRoot, [])).toBe(false);
+    expect(isWithinAdvertisedRoots(advertisedRoot, undefined)).toBe(false);
+    expect(isWithinAdvertisedRoots(join(advertisedRoot, "missing"), [advertisedRoot])).toBe(false);
+    expect(isWithinAdvertisedRoots("relative/path", [advertisedRoot])).toBe(false);
+    expect(isWithinAdvertisedRoots(undefined, [advertisedRoot])).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #3036, closes #3037, closes #3042.

Partially addresses #3040 — items 1 (unauthenticated abort/switch) and 2
(unvalidated agent type) are fixed here. Item 3 (the uncancellable pairing
window, and reset_identity not stopping the bridge) needs a supervisor
notification and is handled in the follow-up PR, so #3040 stays open.

The advertised-roots list gated spawning but nothing else, so a paired device
observed and could drive every local session regardless of folder (#3036).
`advertisedRoots` was read in only two places: capability advertisement and
`validateSpawnRoot`. `finishRegistration` enumerated every session from
`listSessions()` and `registerInbound` wired abort/switch/permission handlers for
each, and `publishEvent` streamed assistant text, tool parameters and file diffs
carrying verbatim old and new contents.

Session visibility now uses `isWithinAdvertisedRoots`. Spawning still demands the
requested path *be* an advertised root; a session already running inside one is
in scope, since that is the folder the user shared. Both sides are canonicalized
before comparison and the containment check requires a separator, so a symlink
out of a root and a sibling like `project-secret` next to `project` are both
rejected. Sessions falling out of scope on a `roots_update` are torn down instead
of lingering until restart, and the fallback that invented a summary rooted at
the home directory is gone — a session that cannot be placed inside a shared
folder is not exposed.

A failed spawn leaked its pending entry (#3037): the relay session and sync
client were created before `conversation_create` and `source.spawn`, and neither
was unwound when those rejected, so a repeatedly failing spawn accumulated open
sockets. The tail is now wrapped and `discardPendingSpawn` closes the client and
clears the tracking maps.

`abort` and `switch` ignore their argument, and decryption returns null params
rather than throwing, so a relay could cancel a live turn with ciphertext it
cannot produce (#3040). Both now reject null params; a legitimate empty payload
decrypts to `{}`. The agent type a remote peer sends is resolved against a known
set instead of passed through, so an arbitrary string can no longer be persisted
as a conversation row before the provider runtime validates it.

`publishEvent` listed every session once per streamed event — one provider RPC
per assistant delta (#3042). Summaries are cached and refreshed at most once per
interval, seeded directly on spawn.

The two identical supervisor subscriptions are consolidated into one registration
so `dispatchNotification` keeps queueing correctly; it stops queueing as soon as
any listener exists, so a second listener would drop notifications.

Seven filesystem-backed tests cover the scope boundary. Confirmed load-bearing:
replacing the separator check with a naive prefix match fails the sibling,
traversal and symlink cases.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com