### PR TITLE
fix(remote): harden bridge supervisor and relocate Happy state

### DIFF
--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -17,6 +17,8 @@ pub const HAPPY_RELAY_URL: &str = "https://api.cluster-fluster.com";
 const MAX_RESTART_ATTEMPTS: u32 = 3;
 const MAX_BACKOFF_SECONDS: u64 = 30;
 const STOP_GRACE_PERIOD: Duration = Duration::from_secs(5);
+const KILL_LOCK_ATTEMPTS: u32 = 20;
+const KILL_LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
 const STATUS_EVENT: &str = "happy-bridge://status";
 const PAIRING_EVENT: &str = "happy-bridge://pairing";
 const CREDENTIAL_ACCOUNT: &str = "happy-bridge-pairing-credential";
@@ -163,6 +165,21 @@ impl HappyBridgeManager {
             command.env("PATH", embedded_path);
         }
         command.env("SEREN_EMBEDDED_NODE_BIN", &node_binary);
+        // Left unset, the vendored Happy configuration roots itself at
+        // `~/.happy` and appends to a per-start log file there unconditionally.
+        // That sits outside app data, outside log retention, and outside
+        // support-report redaction, so the whole tree is relocated under the
+        // app's own directory.
+        if let Some(happy_home) = happy_home_dir(app) {
+            match std::fs::create_dir_all(&happy_home) {
+                Ok(()) => {
+                    command.env("HAPPY_HOME_DIR", &happy_home);
+                }
+                Err(error) => {
+                    log::warn!("[HappyBridge] Failed to create Happy home dir: {error}");
+                }
+            }
+        }
         crate::embedded_runtime::sanitize_spawn_env(&mut command);
 
         #[cfg(windows)]
@@ -266,12 +283,19 @@ impl HappyBridgeManager {
     }
 
     pub async fn update_roots(&self, roots: Vec<String>) -> Result<(), String> {
-        let guard = self.process.lock().await;
-        let Some(process) = guard.as_ref() else {
-            return Err("Happy bridge is not running".to_string());
+        // The stdin handle is cloned out and the process lock released before
+        // writing. A bridge that is alive but not draining stdin blocks the
+        // write once the pipe buffer fills, and holding the lock across that
+        // would wedge `stop`, `process_exists` and the monitor loop with it.
+        let stdin = {
+            let guard = self.process.lock().await;
+            let Some(process) = guard.as_ref() else {
+                return Err("Happy bridge is not running".to_string());
+            };
+            Arc::clone(&process._stdin)
         };
         write_supervisor_notification(
-            &process._stdin,
+            &stdin,
             json!({
                 "jsonrpc": "2.0",
                 "method": "roots_update",
@@ -378,9 +402,26 @@ impl HappyBridgeManager {
                 handle.abort();
             }
         }
-        if let Ok(mut guard) = self.process.try_lock() {
+        // The monitor loop takes this same lock every 2s, so a single `try_lock`
+        // can lose the race. Tauri exits via `process::exit`, which skips
+        // `Drop`/`kill_on_drop`, and a missed kill leaves an orphaned bridge
+        // holding the relay connection after the app is gone.
+        let mut process_guard = None;
+        for _ in 0..KILL_LOCK_ATTEMPTS {
+            if let Ok(guard) = self.process.try_lock() {
+                process_guard = Some(guard);
+                break;
+            }
+            std::thread::sleep(KILL_LOCK_RETRY_DELAY);
+        }
+        let Some(mut guard) = process_guard else {
+            log::warn!("[HappyBridge] Could not acquire process lock; bridge may be orphaned");
+            return;
+        };
+        {
             if let Some(process) = guard.as_ref() {
                 if let Some(pid) = process.child.id() {
+                    log::info!("[HappyBridge] Killing bridge pid {pid}");
                     #[cfg(unix)]
                     unsafe {
                         libc::kill(pid as i32, libc::SIGKILL);
@@ -554,6 +595,16 @@ fn report_state(state: Option<&str>) -> Option<HappyBridgeState> {
 
 fn should_rearm(spawned_at: Instant, already_rearmed: bool, now: Instant) -> bool {
     !already_rearmed && now.duration_since(spawned_at) >= Duration::from_secs(60)
+}
+
+/// Keeps the vendored Happy client's state and logs inside the app's own data
+/// directory rather than `~/.happy`.
+fn happy_home_dir(app: &AppHandle) -> Option<PathBuf> {
+    use tauri::Manager;
+    app.path()
+        .app_data_dir()
+        .ok()
+        .map(|dir| dir.join("happy-bridge"))
 }
 
 fn resolve_node_binary(app: &AppHandle) -> PathBuf {
@@ -920,7 +971,25 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
                         )
                         .await;
                     }
-                    Ok(None) | Err(_) => break,
+                    // A single non-UTF-8 byte is a corrupt line, not a dead
+                    // pipe. Breaking here left the child alive with its control
+                    // channel silently dead while the UI still read Connected,
+                    // so only a real read error ends the loop.
+                    Err(error) if error.kind() == std::io::ErrorKind::InvalidData => {
+                        log::warn!("[HappyBridge] Discarded non-UTF-8 supervisor line");
+                    }
+                    Ok(None) => break,
+                    Err(error) => {
+                        log::warn!("[HappyBridge] Supervisor channel read failed: {error}");
+                        app.state::<HappyBridgeManager>()
+                            .set_status(
+                                &app,
+                                HappyBridgeState::Error,
+                                Some("supervisor channel closed".to_string()),
+                            )
+                            .await;
+                        break;
+                    }
                 }
             }
         });
@@ -1185,6 +1254,34 @@ mod tests {
             read_bounded_line(&mut reader).await.unwrap(),
             Some(BoundedLine::Complete(line)) if line == "{}"
         ));
+        writer_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn non_utf8_line_is_discarded_without_ending_the_channel() {
+        // The stdout loop treats InvalidData as a corrupt line rather than a
+        // dead pipe. That is only safe because the bad line is consumed before
+        // the UTF-8 check fails, so the very next read must still succeed —
+        // otherwise the loop would spin on the same bytes forever.
+        let (reader, mut writer) = duplex(1024);
+        let writer_task = tokio::spawn(async move {
+            writer.write_all(&[0xff, 0xfe]).await.unwrap();
+            writer.write_all(b"\n{\"jsonrpc\":\"2.0\"}\n").await.unwrap();
+        });
+        let mut reader = BufReader::new(reader);
+
+        let corrupt = read_bounded_line(&mut reader).await;
+        assert!(
+            matches!(&corrupt, Err(error) if error.kind() == std::io::ErrorKind::InvalidData),
+            "a non-UTF-8 line surfaces as InvalidData"
+        );
+        assert!(
+            matches!(
+                read_bounded_line(&mut reader).await.unwrap(),
+                Some(BoundedLine::Complete(line)) if line == "{\"jsonrpc\":\"2.0\"}"
+            ),
+            "the channel stays usable for the next supervisor line"
+        );
         writer_task.await.unwrap();
     }
 

--- a/src/components/settings/HappyRemoteSettings.tsx
+++ b/src/components/settings/HappyRemoteSettings.tsx
@@ -41,15 +41,20 @@ function uniqueRoots(
 }
 
 function statusLabel(status: HappyRemoteStatus): string {
+  // A restart is reported as `starting` with a "restart attempt N/M" detail, so
+  // the check has to come before the state switch. Nested under `error` it was
+  // unreachable, and a crash-looping bridge read as "Connecting…" until the
+  // budget ran out.
+  if (status.detail?.startsWith("restart attempt")) {
+    return `Offline — retrying (${status.detail.replace("restart attempt ", "")})`;
+  }
   switch (status.state) {
     case "starting":
       return "Connecting…";
     case "running":
       return "Connected";
     case "error":
-      return status.detail?.startsWith("restart attempt")
-        ? "Offline — retrying"
-        : `Error: ${status.detail ?? "bridge unavailable"}`;
+      return `Error: ${status.detail ?? "bridge unavailable"}`;
     default:
       return "Off";
   }


### PR DESCRIPTION
Closes #3039, closes #3041.

Four supervisor defects shared a failure mode: the bridge wedges or dies while
the UI still reports Connected.

`update_roots` held the process lock across a write to the child's stdin. A
bridge that is alive but not draining stdin blocks that write once the pipe
buffer fills, and the lock was held through it — wedging `stop` (so
`happy_bridge_disable` never returns), `process_exists`, and the monitor loop.
The stdin handle is now cloned out and the lock dropped before writing, matching
what `start_process` already does.

A single non-UTF-8 byte on stdout permanently killed the supervisor channel. The
loop treated every `Err` as a dead pipe and broke, but the child stayed alive, so
`try_wait` kept reporting running and the status stayed Connected while
`conversation_create`, `status_report` and `pairing_payload` were silently
dropped. `InvalidData` is now a discarded line; a genuine read error ends the
loop and reports `Error`. This is only sound because `read_bounded_line` consumes
the line before the UTF-8 check fails — a test asserts the next read still
succeeds, so the loop cannot spin on the same bytes.

`kill_sync` skipped the kill entirely if a single `try_lock` lost the race with
the monitor loop, which takes the same lock every 2s. Tauri exits via
`process::exit`, so `Drop` and `kill_on_drop` never run, and a missed kill left
an orphaned bridge holding the relay connection after the app quit. It now
retries briefly and logs both the pid it kills and the give-up path.

The "Offline — retrying" label was unreachable: a restart is reported as
`starting` with a "restart attempt N/M" detail, but the check sat inside the
`error` branch. A crash-looping bridge read as "Connecting…" until the budget ran
out. The check moved ahead of the switch and now shows the attempt count.

The vendored Happy configuration roots itself at `~/.happy` and appends to a
per-start log file unconditionally, outside app data, log retention and
support-report redaction (#3041). `HAPPY_HOME_DIR` is verified to drive both
`happyHomeDir` and `logsDir` in the vendored client, so the tree is relocated
under the app's own data directory.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com