### PR TITLE
fix(remote): add supervisor shutdown and pairing control

### DIFF
--- a/bin/happy-bridge.mjs
+++ b/bin/happy-bridge.mjs
@@ -96,6 +96,7 @@ try {
     supervisorChannel,
     source,
     debugLog: (message) => console.error(`happy-bridge: ${message}`),
+    onShutdownRequest: () => shutdown(0),
   });
   await happyLayer.start();
 } catch (error) {

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -278,6 +278,7 @@ export function createHappyLayer({
   supervisorChannel,
   source,
   debugLog = () => {},
+  onShutdownRequest = async () => {},
 }) {
   configuration.serverUrl = config.relayUrl;
   let identity = config.machineIdentity;
@@ -285,6 +286,7 @@ export function createHappyLayer({
   let machineClient = null;
   let pairingPromise = null;
   let latestPairingPayload = null;
+  let pairingCancelled = false;
   let sourceSubscription = null;
   let supervisorSubscription = null;
   let advertisedRoots = [];
@@ -305,10 +307,10 @@ export function createHappyLayer({
     debugLog(message);
   }
 
-  /// Listing every session once per streamed event issued one provider RPC per
-  /// assistant delta. Summaries are stable for the fields consumed here
-  /// (agentType, cwd), so they are cached and only re-listed for a session the
-  /// cache has never seen, at most once per interval.
+  // Listing every session once per streamed event issued one provider RPC per
+  // assistant delta. Summaries are stable for the fields consumed here
+  // (agentType, cwd), so they are cached and only re-listed for a session the
+  // cache has never seen, at most once per interval.
   async function refreshSessionSummaries() {
     const listed = await source.listSessions();
     sessionSummaries.clear();
@@ -327,15 +329,15 @@ export function createHappyLayer({
     return sessionSummaries.get(sessionId) ?? null;
   }
 
-  /// A paired device may only observe and drive sessions in folders the user
-  /// shared. Spawning still requires the path to *be* an advertised root; an
-  /// already-running session inside one is in scope.
+  // A paired device may only observe and drive sessions in folders the user
+  // shared. Spawning still requires the path to *be* an advertised root; an
+  // already-running session inside one is in scope.
   function isSessionInScope(summary) {
     return isWithinAdvertisedRoots(summary?.cwd, advertisedRoots);
   }
 
-  /// Called whenever the advertised roots change so sessions that fall out of
-  /// scope stop being observable rather than lingering until restart.
+  // Called whenever the advertised roots change so sessions that fall out of
+  // scope stop being observable rather than lingering until restart.
   async function dropSessionsOutOfScope() {
     for (const [sessionId, entry] of Array.from(sessions.entries())) {
       if (isSessionInScope(entry.summary)) continue;
@@ -617,18 +619,30 @@ export function createHappyLayer({
     }
   }
 
-  /// Registered from both the freshly-paired and already-paired startup paths.
-  /// A single listener keeps `dispatchNotification`'s queueing behaviour intact —
-  /// it stops queueing as soon as any listener exists, so adding a second one
-  /// elsewhere would drop notifications this one is waiting for.
+  // Registered from both the freshly-paired and already-paired startup paths.
+  // A single listener keeps `dispatchNotification`'s queueing behaviour intact —
+  // it stops queueing as soon as any listener exists, so adding a second one
+  // elsewhere would drop notifications this one is waiting for.
   function subscribeToSupervisor() {
     supervisorSubscription = supervisorChannel.onNotification((method, params) => {
-      if (method !== "roots_update") return;
-      advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
-      void (async () => {
-        await dropSessionsOutOfScope();
-        await updateCapabilities();
-      })().catch(() => debug("failed to apply Happy roots update"));
+      if (method === "roots_update") {
+        advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
+        void (async () => {
+          await dropSessionsOutOfScope();
+          await updateCapabilities();
+        })().catch(() => debug("failed to apply Happy roots update"));
+        return;
+      }
+      if (method === "cancel_pairing") {
+        cancelPairing();
+        return;
+      }
+      if (method === "shutdown") {
+        // Windows has no SIGTERM, so a graceful stop has to arrive over the
+        // channel that already exists. Handled inside this listener rather than
+        // a second one, which would defeat `dispatchNotification`'s queueing.
+        void onShutdownRequest().catch(() => debug("failed to handle shutdown request"));
+      }
     });
   }
 
@@ -678,7 +692,17 @@ export function createHappyLayer({
   async function waitForAuthorization(keyPair) {
     const deadline = Date.now() + AUTH_TIMEOUT_MS;
     while (Date.now() < deadline) {
+      if (pairingCancelled) {
+        debug("pairing abandoned before authorization");
+        return false;
+      }
       const result = await readAuthRequest(config.relayUrl, keyPair.publicKey);
+      // Checked again after the round trip: an authorization that lands while
+      // the user is dismissing the dialog must not be accepted.
+      if (pairingCancelled) {
+        debug("pairing abandoned before authorization");
+        return false;
+      }
       if (result.state === "authorized") {
         identity = identityFromAuthResponse(result.token, decryptAuthResponse(result.response, keyPair.secretKey));
         await supervisorChannel.call("identity_store", { identity });
@@ -693,7 +717,19 @@ export function createHappyLayer({
     return false;
   }
 
+  // Abandons an in-flight pairing wait. Without this, dismissing the QR dialog
+  // left `waitForAuthorization` polling for the full timeout and still
+  // accepting whoever scanned the code in the meantime.
+  function cancelPairing() {
+    if (!pairingPromise && !latestPairingPayload) return;
+    pairingCancelled = true;
+    pairingPromise = null;
+    latestPairingPayload = null;
+    debug("pairing cancelled by supervisor");
+  }
+
   async function startPairing() {
+    pairingCancelled = false;
     if (pairingPromise) {
       if (latestPairingPayload) {
         supervisorChannel.notify("pairing_payload", { payload: latestPairingPayload });

--- a/src-tauri/src/commands/happy_bridge.rs
+++ b/src-tauri/src/commands/happy_bridge.rs
@@ -145,10 +145,22 @@ pub async fn happy_bridge_start_pairing(
 }
 
 #[tauri::command]
-pub fn happy_bridge_reset_identity(
+pub async fn happy_bridge_cancel_pairing(
+    state: State<'_, HappyBridgeManager>,
+) -> Result<(), String> {
+    state.cancel_pairing().await;
+    Ok(())
+}
+
+/// Stops the bridge before clearing the credential. The running process holds
+/// the identity in memory, so deleting only the keychain entry would leave a
+/// live, still-paired bridge behind.
+#[tauri::command]
+pub async fn happy_bridge_reset_identity(
     app: AppHandle,
     state: State<'_, HappyBridgeManager>,
 ) -> Result<(), String> {
+    state.stop(&app).await?;
     state.delete_pairing_credential(&app)
 }
 

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -17,6 +17,7 @@ pub const HAPPY_RELAY_URL: &str = "https://api.cluster-fluster.com";
 const MAX_RESTART_ATTEMPTS: u32 = 3;
 const MAX_BACKOFF_SECONDS: u64 = 30;
 const STOP_GRACE_PERIOD: Duration = Duration::from_secs(5);
+const SHUTDOWN_NOTIFY_TIMEOUT: Duration = Duration::from_millis(500);
 const KILL_LOCK_ATTEMPTS: u32 = 20;
 const KILL_LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
 const STATUS_EVENT: &str = "happy-bridge://status";
@@ -259,7 +260,8 @@ impl HappyBridgeManager {
 
         let process = self.process.lock().await.take();
         if let Some(mut process) = process {
-            terminate_child(&mut process.child).await?;
+            let stdin = Arc::clone(&process._stdin);
+            terminate_child(&mut process.child, Some(&stdin)).await?;
         }
         // A pairing payload is only usable while the process that minted it is
         // alive, because the matching secret key lives in that process. Drop it
@@ -304,6 +306,23 @@ impl HappyBridgeManager {
         )
         .await;
         Ok(())
+    }
+
+    /// Tells a running bridge to abandon an in-flight pairing wait, and drops any
+    /// payload already minted so it cannot be handed out afterwards.
+    pub async fn cancel_pairing(&self) {
+        let stdin = {
+            let guard = self.process.lock().await;
+            guard.as_ref().map(|process| Arc::clone(&process._stdin))
+        };
+        *self.pairing_payload.lock().await = None;
+        if let Some(stdin) = stdin {
+            write_supervisor_notification(
+                &stdin,
+                json!({ "jsonrpc": "2.0", "method": "cancel_pairing" }),
+            )
+            .await;
+        }
     }
 
     pub async fn wait_for_pairing_payload(&self) -> Result<String, String> {
@@ -555,7 +574,29 @@ async fn monitor_process(
     }
 }
 
-async fn terminate_child(child: &mut Child) -> Result<(), String> {
+/// Asks the bridge to shut down over the supervisor channel, then falls back to
+/// signals. Windows has no SIGTERM, so before this the child was never told to
+/// exit: every stop burned the full grace period and was then hard-killed,
+/// skipping the relay disconnect so the machine was left to time out. The
+/// notification is sent on every platform, which also gives unix a clean
+/// shutdown ahead of SIGTERM rather than relying on the signal handler alone.
+async fn terminate_child(
+    child: &mut Child,
+    stdin: Option<&Arc<Mutex<ChildStdin>>>,
+) -> Result<(), String> {
+    if let Some(stdin) = stdin {
+        // Bounded: a wedged bridge that is not draining stdin must not stall the
+        // stop path, which is exactly the deadlock the grace period exists for.
+        let _ = tokio::time::timeout(
+            SHUTDOWN_NOTIFY_TIMEOUT,
+            write_supervisor_notification(
+                stdin,
+                json!({ "jsonrpc": "2.0", "method": "shutdown" }),
+            ),
+        )
+        .await;
+    }
+
     #[cfg(unix)]
     if let Some(pid) = child.id() {
         unsafe {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1276,6 +1276,7 @@ pub fn run() {
             commands::happy_bridge::happy_bridge_disable,
             commands::happy_bridge::happy_bridge_status,
             commands::happy_bridge::happy_bridge_start_pairing,
+            commands::happy_bridge::happy_bridge_cancel_pairing,
             commands::happy_bridge::happy_bridge_reset_identity,
             commands::happy_bridge::happy_bridge_get_advertised_roots,
             commands::happy_bridge::happy_bridge_update_roots,

--- a/src/components/settings/HappyRemoteSettings.tsx
+++ b/src/components/settings/HappyRemoteSettings.tsx
@@ -13,6 +13,7 @@ import { toDataURL } from "@/lib/qrcode-shim";
 import { captureSupportError } from "@/lib/support/hook";
 import { listConversations } from "@/lib/tauri-bridge";
 import {
+  cancelPairing,
   disableRemoteAccess,
   enableRemoteAccess,
   getAdvertisedRoots,
@@ -150,6 +151,22 @@ export const HappyRemoteSettings: Component = () => {
     }
   };
 
+  // Dismissing the dialog has to tell the bridge to stop waiting. Clearing the
+  // local signals alone left the pairing window open for its full timeout,
+  // still ready to accept whoever scanned the code.
+  const dismissPairing = async () => {
+    setPairingPayload(null);
+    setPairingQr(null);
+    try {
+      await cancelPairing();
+    } catch {
+      setMessage(
+        "Could not cancel pairing. Turn remote access off to be sure.",
+      );
+    }
+    await refreshStatus();
+  };
+
   const toggleRoot = async (root: string, included: boolean) => {
     const previous = advertisedRoots();
     const next = included
@@ -236,14 +253,20 @@ export const HappyRemoteSettings: Component = () => {
             Pair a phone
           </span>
           <span class="text-[0.8rem] text-muted-foreground">
-            Scan a one-time pairing code in the Happy mobile app
+            {status().state === "running"
+              ? "This device is already paired. Reset the pairing first to pair a different phone."
+              : "Scan a one-time pairing code in the Happy mobile app"}
           </span>
         </span>
         <button
           type="button"
           class="px-4 py-1.5 border border-border-strong rounded-md bg-transparent text-foreground text-[0.85rem] cursor-pointer hover:bg-border disabled:opacity-50 disabled:cursor-not-allowed"
           onClick={() => void pairPhone()}
-          disabled={busy()}
+          // A paired bridge never re-enters the pairing path, so the request
+          // would stall for the full payload timeout and then error. Re-pairing
+          // also mints a new machineId and replaces the stored identity, which
+          // would orphan the existing pairing rather than add a second device.
+          disabled={busy() || status().state === "running"}
         >
           Pair a phone
         </button>
@@ -308,10 +331,7 @@ export const HappyRemoteSettings: Component = () => {
         {(payload) => (
           <div
             class="fixed inset-0 bg-black/60 flex items-center justify-center z-[1000]"
-            onClick={() => {
-              setPairingPayload(null);
-              setPairingQr(null);
-            }}
+            onClick={() => void dismissPairing()}
           >
             <div
               class="bg-popover border border-border-strong rounded-xl p-6 max-w-[420px] w-[90%]"
@@ -346,10 +366,7 @@ export const HappyRemoteSettings: Component = () => {
               <button
                 type="button"
                 class="mt-4 w-full px-4 py-2 bg-transparent border border-border-strong rounded-md text-muted-foreground text-[0.9rem] cursor-pointer hover:bg-border"
-                onClick={() => {
-                  setPairingPayload(null);
-                  setPairingQr(null);
-                }}
+                onClick={() => void dismissPairing()}
               >
                 Close
               </button>

--- a/src/services/happyRemote.ts
+++ b/src/services/happyRemote.ts
@@ -44,6 +44,10 @@ export async function startPairing(): Promise<string> {
   return invoke<string>("happy_bridge_start_pairing");
 }
 
+export async function cancelPairing(): Promise<void> {
+  return invoke<void>("happy_bridge_cancel_pairing");
+}
+
 export function onStatusChange(
   callback: (status: HappyRemoteStatus) => void,
 ): Promise<UnlistenFn> {


### PR DESCRIPTION
Closes #3031, closes #3038, closes #3040.

All three need the same thing: a way for the supervisor to tell a *running*
bridge to do something. They are handled inside the single existing notification
listener, because `dispatchNotification` stops queueing as soon as any listener
exists — a second listener would drop notifications the first is waiting for.

Stopping the bridge on Windows burned the full five-second grace period and then
hard-killed it (#3031). The SIGTERM was `#[cfg(unix)]` only, so nothing ever told
the child to exit: `child.wait()` timed out, the bridge's handler never ran,
`machineClient.shutdown()` was skipped and the relay was left to time the machine
out. `terminate_child` now writes a `shutdown` notification before waiting, on
every platform, which also gives unix a clean exit ahead of the signal. The write
is bounded by its own timeout so a bridge that is not draining stdin cannot stall
the stop path — the exact deadlock the grace period exists for.

"Pair a phone" could never mint a code once connected (#3038). A bridge that
starts with an identity returns from `registerMachine()` before `startPairing()`,
and no message could ask it to pair, so the button froze the UI for the full
ten-second payload deadline and then errored. Re-pairing is also not "add a
second device": `identityFromAuthResponse` mints a new `machineId` and replaces
the stored identity, which would orphan the existing pairing. The button is
therefore disabled while connected and says to reset the pairing first.

Dismissing the QR dialog only cleared local signals (#3040, item 3).
`waitForAuthorization` kept polling for the full five-minute timeout and would
still accept whoever scanned the code, so a user who showed the QR and thought
better of it stayed pairable. A `cancel_pairing` notification now abandons the
wait, checked both before and after each relay round trip so an authorization
landing mid-dismissal is not accepted, and the supervisor drops any payload it
already holds. `happy_bridge_reset_identity` also stops the bridge before
clearing the credential — deleting only the keychain entry left a live,
still-paired process holding the identity in memory.

Items 1 and 2 of #3040 shipped in #3044; this completes it.

Verified the real supervisor channel dispatches `shutdown`, `cancel_pairing` and
`roots_update` to the single listener under the embedded runtime. The Windows
graceful-stop path itself cannot be exercised on macOS and is unvalidated until
it runs on Windows.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com

---

**Stacks on #3045** (`fix/happy-supervisor`), so the diff includes that PR's commits until it merges.