### PR TITLE
fix(release): prune Happy tool archives so macOS can notarize

### DIFF
--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -168,6 +168,29 @@ function main(): void {
       }
     }
   }
+  // Happy vendors ripgrep and difftastic as per-platform tarballs under
+  // `tools/archives`. Apple's notary service reads inside archives, so the
+  // unsigned Mach-O binaries in the darwin tarballs get the whole DMG rejected
+  // ("The binary is not signed", "does not have the hardened runtime enabled").
+  // That blocked the v3.71.0 macOS release (#3048).
+  //
+  // They are also dead weight: the binaries are resolved from `tools/unpacked`,
+  // which only its postinstall creates, and the install above runs with
+  // `--ignore-scripts`. The guard below keeps that reasoning honest — if a
+  // future change ever does unpack them, the prune backs off instead of
+  // silently deleting something that became load-bearing.
+  const happyTools = path.join(happyPackage, "tools");
+  const happyArchives = path.join(happyTools, "archives");
+  if (existsSync(happyArchives)) {
+    if (existsSync(path.join(happyTools, "unpacked"))) {
+      console.warn("Skipping Happy tool archive prune: tools/unpacked exists, archives may be in use");
+    } else {
+      // `tools/licenses` is deliberately kept for attribution.
+      rmSync(happyArchives, { recursive: true, force: true });
+      console.log("Pruned happy/tools/archives (unsigned platform binaries)");
+    }
+  }
+
   const bundleSize = spawnSync("du", ["-sh", bundleNodeModules], { encoding: "utf8" })
     .stdout.trim();
   console.log(`provider-runtime/node_modules after Happy SDK binary prune: ${bundleSize}`);


### PR DESCRIPTION
Closes #3048.

The v3.71.0 macOS x64 release build failed: Apple rejected the DMG because
`happy` vendors ripgrep and difftastic as per-platform tarballs under
`tools/archives`, and the notary service reads inside archives. The darwin
tarballs contain unsigned Mach-O binaries, which produced "The binary is not
signed", "The signature does not include a secure timestamp" and "The executable
does not have the hardened runtime enabled" for `difft`, `rg` and `ripgrep.node`,
then "Notarization was rejected by Apple - not retrying".

The stapling error later in the same job (`CloudKit query ... "Record not found"`,
Error 65) is downstream of that rejection, not an independent propagation flake.

These archives are also unusable as bundled. Happy resolves the binaries from
`tools/unpacked`, which only its postinstall creates, and the bundle install runs
with `--ignore-scripts` — so the directory can never exist and the code path can
never succeed. Nothing in this repository references them either. The prune is
guarded on `tools/unpacked` being absent, so if a future change does unpack them
it backs off rather than deleting something that became load-bearing.
`tools/licenses` is kept for attribution.

Bundle drops from 492M to 151M, and the bundle now contains no Mach-O binaries
at all.

Verified locally after the prune: all four bridge dependencies still resolve from
the bundle, the bridge entrypoint imports, and the graceful-shutdown check still
passes. Full suites green.

The layer that actually failed is Apple's notary service, which no local check
reaches — this is not proven until a real release build notarizes.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com