### PR TITLE
fix(release): prune ps-list vendor executables from the bundle

### DIFF
--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -191,6 +191,35 @@ function main(): void {
     }
   }
 
+  // `ps-list` arrives as a Happy dependency and vendors two prebuilt Windows
+  // executables. They are only reached by `ps-list`'s `windows()` branch, and
+  // nothing on the bridge's load path reaches `ps-list` at all: the bridge
+  // imports `happy/lib` only, and loading that entry pulls 246 modules with
+  // `ps-list` among none of them. Its importers are Happy's CLI and
+  // agent-runner entrypoints, which Seren never invokes.
+  //
+  // Signing them would apply Seren's EV certificate to vendored third-party
+  // binaries and bill two extra SSL.com operations on every release.
+  //
+  // The guard checks the entry the bridge actually loads: if a future Happy
+  // version makes `lib` depend on `ps-list`, the prune backs off.
+  const psListVendor = path.join(bundleNodeModules, "ps-list", "vendor");
+  if (existsSync(psListVendor)) {
+    const happyLibEntry = path.join(happyPackage, "dist", "lib.cjs");
+    const libUsesPsList =
+      existsSync(happyLibEntry) && readFileSync(happyLibEntry, "utf8").includes("ps-list");
+    if (libUsesPsList) {
+      console.warn("Skipping ps-list vendor prune: happy/lib references ps-list");
+    } else {
+      for (const entry of readdirSync(psListVendor, { withFileTypes: true })) {
+        if (entry.isFile() && entry.name.toLowerCase().endsWith(".exe")) {
+          rmSync(path.join(psListVendor, entry.name), { force: true });
+        }
+      }
+      console.log("Pruned ps-list/vendor executables (unreachable from the bridge)");
+    }
+  }
+
   const bundleSize = spawnSync("du", ["-sh", bundleNodeModules], { encoding: "utf8" })
     .stdout.trim();
   console.log(`provider-runtime/node_modules after Happy SDK binary prune: ${bundleSize}`);


### PR DESCRIPTION
Follow-up to #3049, which pruned Happy's tool archives after Apple rejected the
unsigned Mach-O binaries inside them. The same sweep found two vendored Windows
executables still shipping in the bundle:

  ps-list/vendor/fastlist-0.3.0-x64.exe
  ps-list/vendor/fastlist-0.3.0-x86.exe

`ps-list` arrives as a dependency of `happy`, so both are new in v3.71.0 — the
v3.70.1 bundle contained only `@lmstudio/sdk` and `ws`.

Unlike the archives these would not have failed a build. Authenticode signing
enumerates by extension over a directory walk and never opens archives, which is
why the same Happy tarballs that Apple rejected passed Windows signing untouched.
These two are loose `.exe` files, so they are signable, valid, and would simply
be signed. That is the problem: it applies Seren's EV certificate to vendored
third-party binaries and bills two extra SSL.com operations on every release.

Verified unreachable rather than assumed. `ps-list` is only entered through its
`windows()` branch, which resolves `vendor/<binary>` at index.js:26. The bridge
imports `happy/lib` and nothing else; loading that entry pulls 246 modules and
`ps-list` is among none of them. Its real importers are Happy's CLI and
agent-runner entrypoints (`index.*`, `runAgy`, `runGemini`, `config-*`), which
Seren never invokes because agents run through the provider runtime. The guard
tests the entry the bridge actually loads, so if a future Happy version makes
`lib` depend on `ps-list` the prune backs off instead of deleting something that
became load-bearing.

The bundle now contains no `.exe`, `.dll`, `.node` or `.pyd` at all, and no
archives. The only remaining archives anywhere are two `thread-stream` test zips,
each holding a single `worker.js` — no binaries, and present since before
v3.71.0.

Verified after the prune: `happy/lib` still loads the same 246 modules, all four
bridge dependencies resolve, and the graceful-shutdown check passes. Full suites
green.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com