### PR TITLE
chore(deps): bump jiff to 0.2.34

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4281,11 +4281,12 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -4296,11 +4297,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.114",


### PR DESCRIPTION
Supersedes #3071.

Lockfile-only patch bump: `jiff` and `jiff-static` 0.2.32 → 0.2.34. `src-tauri/Cargo.toml` already requires `jiff = { version = "0.2", features = ["serde"] }`, so the manifest is untouched and the bump stays within the `0.2` series.

Rebased onto current `main`, which is why this replaces #3071 rather than merging it — and per #3069, Dependabot's own PRs cannot build on macOS or Windows regardless of merit.

## Risk review

`jiff` is a date/time crate used in exactly two places, both found by `grep -rln jiff src-tauri/src/`:

- `src-tauri/src/support.rs` — timestamps on support reports
- `src-tauri/src/secret_broker.rs` — lease/expiry handling

`secret_broker.rs` is the one worth care, since expiry arithmetic that silently changes behavior would be a security-relevant regression rather than a cosmetic one. Both modules were exercised directly against 0.2.34 rather than relying on the aggregate count:

```
cargo test support::        -> 10 passed, 0 failed
cargo test secret_broker::  ->  7 passed, 0 failed
```

## Network/API path audit

No networked path changes. `jiff` is a pure date/time library and originates no requests; the two call sites format and compare timestamps locally. **No Seren publisher slug, no `api.serendb.com` path, and no first-party API method is on the changed surface.**

## Validation (real toolchains, no mocks)

| Check | Result |
| --- | --- |
| `cargo test` | 931 passed, 0 failed |
| `cargo test support::` | 10 passed, 0 failed |
| `cargo test secret_broker::` | 7 passed, 0 failed |
| `cargo check --all-targets` | exit 0 |

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
