### PR TITLE
fix(deps): realign cpal windows-core to 0.62.2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1823,7 +1823,7 @@ dependencies = [
  "objc2-foundation",
  "web-sys",
  "windows 0.62.2",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #3075. **P0 — `main` currently does not build on Windows.** I introduced this in #3072; this restores it.

## What broke

`cpal` 0.18.1 declares both of its Windows dependencies across a span of two semver-incompatible generations:

```
windows       req: >=0.61, <=0.62
windows-core  req: >=0.61, <=0.62
```

Nothing forces the two to the same generation, but `cpal`'s code requires it — `windows` 0.62.2 re-exports `windows-core` 0.62.2's `Interface` trait, so a direct `windows-core` at 0.61.2 yields two distinct `Interface` traits and every COM call fails to typecheck:

```
error[E0277]: the trait bound `...: windows_core::Interface` is not satisfied
  ::: windows-core-0.62.2/src/interface.rs:14:1   <- this is the found trait
help: the following other types implement trait `windows_core::Interface`
  --> windows-core-0.61.2/src/inspectable.rs:52:1
error: could not compile `cpal` (lib) due to 18 previous errors
```

The lock drifted apart at exactly one commit:

| commit | PR | `windows` | `windows-core` | Windows build |
| --- | --- | --- | --- | --- |
| `c00f1dd9` | #3050 | 0.62.2 | 0.62.2 | pass |
| `6a0b6a12` | #3065 | 0.62.2 | 0.62.2 | pass |
| `e4007765` | **#3072** | 0.62.2 | **0.61.2** | **fail** |

The `cargo update -p serde -p uuid -p thiserror -p alloy` runs in #3072 re-unified the `windows-core` graph and dragged `cpal`'s edge down.

## The fix

Move `cpal`'s `windows-core` edge back to 0.62.2 so it matches its `windows` 0.62.2.

Nine other crates genuinely require `windows-core ^0.61`, so promoting every consumer is not an option — `cargo update -p windows-core@0.61.2 --precise 0.62.2` fails outright with `failed to select a version for the requirement windows-core = "^0.61"`. Both generations stay in the tree; only `cpal`'s edge moves.

`cargo metadata --locked` accepts the result, which confirms this is a valid resolution cargo will honor rather than silently re-resolve on the next build.

## Why CI let this through

Worth fixing separately (noted in #3075), because three gaps compounded:

1. **`main`'s push build is ubuntu-only** — `ci.yml:217` runs the three-OS matrix only for `pull_request`. A Windows-specific break leaves `main` green.
2. **Both PRs merged before their Windows leg finished** — `build` is gated on `needs: [lint, test-frontend, test-rust, test-e2e]`, so it starts late and was still queued at merge time.
3. **No `fail-fast: false` on the matrix** — when Windows fails, the other two legs are cancelled, so the run shows three red legs and the one real failure is easy to misread.

#3073 (jiff) did not cause this; it was just the first PR to complete a Windows build after #3072 landed.

## Network/API path audit

No networked path is involved. This is a Cargo lockfile resolution fix affecting compilation of the `cpal` audio backend. **No Seren publisher slug, no `api.serendb.com` path, and no first-party API method is on the changed surface.**

## Validation

Local, macOS:

| Check | Result |
| --- | --- |
| `cargo check --all-targets --locked` | exit 0 |
| `cargo test --locked` | 931 passed, 0 failed |
| `cargo metadata --locked` | accepted — no re-resolution |

**Local validation is not sufficient evidence for this fix.** The failure is Windows-only and cannot be reproduced on macOS, so this is unproven until `build (windows-latest)` passes on this PR. That result will be posted here before merge — please do not merge on the local numbers alone.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
