### PR TITLE
fix(employees): clarify health, controls, and run costs

### DIFF
--- a/src/components/employees/EmployeeControlBar.tsx
+++ b/src/components/employees/EmployeeControlBar.tsx
@@ -1,0 +1,152 @@
+// ABOUTME: Renders the employee's primary run/chat and suspend/wake controls.
+// ABOUTME: Keeps control layout and action semantics consistent across modes.
+
+import { type Component, Show } from "solid-js";
+import type { EmployeeHealth } from "@/lib/employees/health";
+import type { EmployeeSummary } from "@/lib/employees/types";
+
+type EmployeeActionPending = "suspend" | "wake" | "delete" | null;
+
+interface EmployeeControlBarProps {
+  employee: EmployeeSummary;
+  health: EmployeeHealth;
+  isRunning: boolean;
+  isWakeable: boolean;
+  actionPending: EmployeeActionPending;
+  manualRunInFlight: boolean;
+  canStartRun: boolean;
+  onPrimary: () => void;
+  onSuspendOrWake: () => void;
+}
+
+function primaryCtaLabel(mode: EmployeeSummary["mode"]): string {
+  return mode === "always_on" ? "New conversation" : "Run now";
+}
+
+export const EmployeeControlBar: Component<EmployeeControlBarProps> = (
+  props,
+) => {
+  const isAlwaysOn = () => props.employee.mode === "always_on";
+  const primaryTitle = () =>
+    isAlwaysOn()
+      ? `Open a new chat with ${props.employee.name}`
+      : `Run ${props.employee.name} once, outside its schedule`;
+  const primaryDisabled = () =>
+    props.manualRunInFlight ||
+    !props.canStartRun ||
+    props.actionPending !== null;
+  const secondaryLabel = () => (props.isRunning ? "Suspend" : "Wake");
+  const secondaryTitle = () =>
+    props.isRunning
+      ? "Pause scheduled runs. The employee stays deployed and can be woken later."
+      : "Redeploy and resume scheduled runs.";
+
+  return (
+    <div
+      class="flex flex-wrap items-center gap-2 border-b border-border px-6 py-3"
+      data-health={props.health}
+    >
+      <button
+        type="button"
+        class="inline-flex h-10 min-w-[9rem] items-center justify-center gap-2 rounded-md border border-primary bg-primary px-4 text-[13.5px] font-medium text-primary-foreground shadow-sm shadow-primary/20 transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        disabled={primaryDisabled()}
+        title={primaryTitle()}
+        onClick={props.onPrimary}
+      >
+        <Show
+          when={!props.manualRunInFlight}
+          fallback={
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 16 16"
+              fill="none"
+              aria-hidden="true"
+              class="shrink-0 animate-spin"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="6"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-dasharray="22 14"
+              />
+            </svg>
+          }
+        >
+          <Show
+            when={isAlwaysOn()}
+            fallback={
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 16 16"
+                fill="none"
+                aria-hidden="true"
+                class="shrink-0"
+              >
+                <path
+                  d="M5 4 L12 8 L5 12 Z"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linejoin="round"
+                  stroke-linecap="round"
+                />
+              </svg>
+            }
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 16 16"
+              fill="none"
+              aria-hidden="true"
+              class="shrink-0"
+            >
+              <path
+                d="M3.5 4.5h9v5.5h-5l-3 2v-2h-1z"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linejoin="round"
+                stroke-linecap="round"
+              />
+            </svg>
+          </Show>
+        </Show>
+        {props.manualRunInFlight
+          ? "Running..."
+          : primaryCtaLabel(props.employee.mode)}
+      </button>
+
+      <button
+        type="button"
+        class="rounded-md border px-3.5 py-2 text-[12.5px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/60"
+        classList={{
+          "border-border text-foreground hover:bg-surface-2":
+            props.isRunning || !props.isWakeable,
+          "border-emerald-500/40 text-emerald-300 hover:bg-emerald-500/10":
+            props.isWakeable && !props.isRunning,
+        }}
+        disabled={
+          props.actionPending !== null ||
+          (!props.isRunning && !props.isWakeable)
+        }
+        title={secondaryTitle()}
+        onClick={props.onSuspendOrWake}
+      >
+        <Show when={props.actionPending === "suspend"}>Suspending...</Show>
+        <Show when={props.actionPending === "wake"}>Waking...</Show>
+        <Show when={props.actionPending === null}>{secondaryLabel()}</Show>
+      </button>
+
+      <Show when={!props.canStartRun}>
+        <div class="basis-full text-[12px] text-muted-foreground">
+          Wake this employee before starting {isAlwaysOn() ? "a chat" : "a run"}
+          .
+        </div>
+      </Show>
+    </div>
+  );
+};

--- a/src/components/employees/EmployeeCostSummary.tsx
+++ b/src/components/employees/EmployeeCostSummary.tsx
@@ -1,0 +1,99 @@
+// ABOUTME: Presents employee spend as a compact three-cell operator summary.
+// ABOUTME: Keeps cost fetches fail-soft so detail rendering remains available.
+
+import {
+  type Component,
+  createMemo,
+  createResource,
+  type JSX,
+  Show,
+} from "solid-js";
+import {
+  formatMicrosUsd,
+  sumRunCostMicros,
+  windowStartIso,
+} from "@/lib/employees/spend";
+import type { EmployeeRun } from "@/lib/employees/types";
+import { employees as svc } from "@/services/employees";
+
+interface EmployeeCostSummaryProps {
+  employeeId: string;
+  refreshNonce: number;
+}
+
+const CostCell: Component<{ label: string; children: JSX.Element }> = (
+  props,
+) => (
+  <div class="min-w-0 px-4 py-3 first:pl-0 last:pr-0">
+    <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">
+      {props.label}
+    </div>
+    <div class="mt-1 text-[13px] text-foreground truncate">
+      {props.children}
+    </div>
+  </div>
+);
+
+export const EmployeeCostSummary: Component<EmployeeCostSummaryProps> = (
+  props,
+) => {
+  const resourceKey = () => `${props.employeeId}::${props.refreshNonce}`;
+  const [spend] = createResource(resourceKey, async (key) => {
+    const [employeeId] = key.split("::");
+    return svc.getSpend(employeeId);
+  });
+  const [recentSpend] = createResource(resourceKey, async (key) => {
+    const [employeeId] = key.split("::");
+    return svc.listRunsSince(employeeId, windowStartIso(Date.now(), 30));
+  });
+
+  const sortedRuns = createMemo(() => {
+    const rows = recentSpend()?.rows ?? [];
+    return [...rows].sort(
+      (left, right) =>
+        new Date(right.startedAt).getTime() -
+        new Date(left.startedAt).getTime(),
+    );
+  });
+  const hasError = () => Boolean(spend.error || recentSpend.error);
+  const lastRun = (): EmployeeRun | undefined => sortedRuns()[0];
+  const lastRunCost = () => {
+    const run = lastRun();
+    return run
+      ? formatMicrosUsd(run.inferenceCostAtomic + run.computeCostAtomic)
+      : "—";
+  };
+  const sinceLaunchCost = () => {
+    const total = spend();
+    return total
+      ? `${formatMicrosUsd(total.totalMicros)} · ${total.runCount} runs`
+      : "—";
+  };
+
+  return (
+    <div
+      class="border-b border-border px-6"
+      data-testid="employee-cost-summary"
+    >
+      <Show
+        when={!hasError()}
+        fallback={
+          <div class="py-3 text-[12px] text-muted-foreground">
+            Costs unavailable
+          </div>
+        }
+      >
+        <div class="grid grid-cols-3 divide-x divide-border">
+          <CostCell label="Last run">{lastRunCost()}</CostCell>
+          <CostCell label="Last 30 days">
+            {formatMicrosUsd(sumRunCostMicros(recentSpend()?.rows ?? []))}
+            {" · "}
+            {recentSpend()?.rows.length ?? 0} runs
+            <Show when={recentSpend()?.truncated}> (partial)</Show>
+          </CostCell>
+          <CostCell label="Since launch">{sinceLaunchCost()}</CostCell>
+        </div>
+      </Show>
+    </div>
+  );
+};

--- a/src/components/employees/EmployeeDetail.tsx
+++ b/src/components/employees/EmployeeDetail.tsx
@@ -17,6 +17,8 @@ import {
   Show,
 } from "solid-js";
 import { EmployeeCheckpointsList } from "@/components/employees/EmployeeCheckpointsList";
+import { EmployeeControlBar } from "@/components/employees/EmployeeControlBar";
+import { EmployeeCostSummary } from "@/components/employees/EmployeeCostSummary";
 import { EmployeeEvalDriftCard } from "@/components/employees/EmployeeEvalDriftCard";
 import { EmployeeRevisionsModal } from "@/components/employees/EmployeeRevisionsModal";
 import { EmployeeRunDetailModal } from "@/components/employees/EmployeeRunDetailModal";
@@ -24,12 +26,14 @@ import { EmployeeRunsList } from "@/components/employees/EmployeeRunsList";
 import { EvalGateEditor } from "@/components/employees/EvalGateEditor";
 import { CreateEmployeeModal } from "@/components/sidebar/CreateEmployeeModal";
 import { gradientFor, initialFor } from "@/lib/employees/avatar";
+import {
+  type EmployeeHealth,
+  employeeHealth,
+  healthDotClass,
+  healthLabel,
+} from "@/lib/employees/health";
 import { extractInstructionSections } from "@/lib/employees/instructions";
-import type {
-  EmployeeMode,
-  EmployeeStatus,
-  EmployeeSummary,
-} from "@/lib/employees/types";
+import type { EmployeeMode, EmployeeSummary } from "@/lib/employees/types";
 import { getDefaultOrganizationId } from "@/lib/tauri-bridge";
 import { employees as svc } from "@/services/employees";
 import { employeesArchiveStore } from "@/services/employees-archive";
@@ -68,21 +72,14 @@ function modeLabel(mode: EmployeeMode): string {
   return "On-demand";
 }
 
-function statusLabel(status: EmployeeStatus): string {
-  if (status === "running") return "Live";
-  if (status === "stopped") return "Suspended";
-  if (status === "failed") return "Error";
-  if (status === "pending") return "Pending";
-  if (status === "building") return "Deploying";
-  return status;
-}
-
-function statusPillClass(status: EmployeeStatus): string {
-  if (status === "running")
+function statusPillClass(health: EmployeeHealth): string {
+  if (health === "healthy")
     return "bg-emerald-500/15 text-emerald-400 border-emerald-500/30";
-  if (status === "failed")
+  if (health === "degraded")
+    return "bg-amber-500/15 text-amber-300 border-amber-500/30";
+  if (health === "faulted")
     return "bg-red-500/15 text-red-400 border-red-500/30";
-  if (status === "stopped")
+  if (health === "suspended")
     return "bg-slate-500/15 text-slate-300 border-slate-500/30";
   return "bg-sky-500/15 text-sky-300 border-sky-500/30";
 }
@@ -105,12 +102,6 @@ function capabilityGroupClass(tone: "neutral" | "success" | "warning") {
     return "border-amber-500/25 bg-amber-500/[0.08]";
   }
   return "border-border bg-surface-2";
-}
-
-function primaryCtaLabel(mode: EmployeeMode): string {
-  if (mode === "always_on") return "New conversation";
-  if (mode === "cron") return "Run now";
-  return "Run now";
 }
 
 const Avatar: Component<{ name: string; seed: string; size?: number }> = (
@@ -138,26 +129,18 @@ const Avatar: Component<{ name: string; seed: string; size?: number }> = (
  * transitory states (running/building/pending) so the operator gets an
  * ambient "this is live" signal without scanning text.
  */
-const StatusDot: Component<{ status: EmployeeStatus }> = (props) => {
-  const tone = () => {
-    if (props.status === "running") return "bg-emerald-400";
-    if (props.status === "failed") return "bg-red-400";
-    if (props.status === "stopped") return "bg-slate-400";
-    return "bg-sky-400";
-  };
+const StatusDot: Component<{ health: EmployeeHealth }> = (props) => {
   const transitory = () =>
-    props.status === "running" ||
-    props.status === "pending" ||
-    props.status === "building";
+    props.health === "healthy" || props.health === "transitioning";
   return (
     <span class="relative inline-flex w-1.5 h-1.5 shrink-0" aria-hidden="true">
       <Show when={transitory()}>
         <span
-          class={`absolute inset-0 rounded-full ${tone()} opacity-60 animate-ping`}
+          class={`absolute inset-0 rounded-full ${healthDotClass(props.health)} opacity-60 animate-ping`}
         />
       </Show>
       <span
-        class={`relative inline-block w-1.5 h-1.5 rounded-full ${tone()}`}
+        class={`relative inline-block w-1.5 h-1.5 rounded-full ${healthDotClass(props.health)}`}
       />
     </span>
   );
@@ -168,18 +151,9 @@ const StatusDot: Component<{ status: EmployeeStatus }> = (props) => {
  * Conveys deployment status at a glance even when the status pill is off
  * screen (e.g. when the operator is reading past the header).
  */
-const AvatarPresence: Component<{ status: EmployeeStatus }> = (props) => (
+const AvatarPresence: Component<{ health: EmployeeHealth }> = (props) => (
   <span
-    class="absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-[2px] border-background"
-    classList={{
-      "bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.55)]":
-        props.status === "running",
-      "bg-red-400 shadow-[0_0_6px_rgba(248,113,113,0.55)]":
-        props.status === "failed",
-      "bg-sky-400 animate-pulse":
-        props.status === "pending" || props.status === "building",
-      "bg-slate-500": props.status === "stopped",
-    }}
+    class={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-[2px] border-background ${healthDotClass(props.health)}`}
     aria-hidden="true"
   />
 );
@@ -347,6 +321,12 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
   const isRunning = () => status() === "running";
   const isWakeable = () => status() === "stopped" || status() === "failed";
   const canStartRun = () => isRunning() && actionPending() === null;
+  const health = () =>
+    employeeHealth({
+      status: status(),
+      errorMessage: summary()?.errorMessage,
+      hasAlertConditions: alertConditions().length > 0,
+    });
 
   const handleSuspendOrWake = async () => {
     const id = props.employeeId;
@@ -549,113 +529,6 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
     }
   };
 
-  const PrimaryActionButton: Component<{
-    employee: EmployeeSummary;
-    variant?: "full" | "compact";
-  }> = (buttonProps) => {
-    const isCompact = () => buttonProps.variant === "compact";
-    const isAlwaysOn = () => buttonProps.employee.mode === "always_on";
-    // Only on-demand/cron buttons drive a manual run; always-on never enters
-    // this loading state because the action opens a chat instead.
-    const isManualRunInFlight = () =>
-      !isAlwaysOn() && manualRun()?.kind === "running";
-    const isDisabled = () => isManualRunInFlight() || !canStartRun();
-    const actionNoun = () => (isAlwaysOn() ? "chat" : "run");
-    const title = () => {
-      if (!canStartRun()) {
-        return `${buttonProps.employee.name} is ${statusLabel(
-          buttonProps.employee.status,
-        ).toLowerCase()}; wake it before starting a ${actionNoun()}`;
-      }
-      return isAlwaysOn()
-        ? `Open a new chat with ${buttonProps.employee.name}`
-        : `Run ${buttonProps.employee.name} once now`;
-    };
-
-    // `min-w-[12rem]` keeps the compact button at a stable footprint so the
-    // header doesn't reflow when the label or icon changes width.
-    const compactClass =
-      "inline-flex h-10 min-w-[12rem] items-center justify-center gap-2 rounded-md border border-primary bg-primary px-4 text-[13.5px] font-medium text-primary-foreground shadow-sm shadow-primary/20 transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
-    const fullClass =
-      "inline-flex w-full items-center justify-center gap-2 py-3 px-4 rounded-lg bg-primary text-primary-foreground font-medium text-[14px] transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
-
-    return (
-      <button
-        type="button"
-        class={isCompact() ? compactClass : fullClass}
-        disabled={isDisabled()}
-        title={title()}
-        onClick={handlePrimaryAction}
-      >
-        <Show
-          when={!isManualRunInFlight()}
-          fallback={
-            <svg
-              width="13"
-              height="13"
-              viewBox="0 0 16 16"
-              fill="none"
-              aria-hidden="true"
-              class="shrink-0 animate-spin"
-            >
-              <circle
-                cx="8"
-                cy="8"
-                r="6"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-dasharray="22 14"
-              />
-            </svg>
-          }
-        >
-          <Show
-            when={isAlwaysOn()}
-            fallback={
-              <svg
-                width="13"
-                height="13"
-                viewBox="0 0 16 16"
-                fill="none"
-                aria-hidden="true"
-                class="shrink-0"
-              >
-                <path
-                  d="M5 4 L12 8 L5 12 Z"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linejoin="round"
-                  stroke-linecap="round"
-                />
-              </svg>
-            }
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="none"
-              aria-hidden="true"
-              class="shrink-0"
-            >
-              <path
-                d="M3.5 4.5h9v5.5h-5l-3 2v-2h-1z"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linejoin="round"
-                stroke-linecap="round"
-              />
-            </svg>
-          </Show>
-        </Show>
-        {isManualRunInFlight()
-          ? "Running..."
-          : primaryCtaLabel(buttonProps.employee.mode)}
-      </button>
-    );
-  };
-
   return (
     <div class="flex flex-col h-full overflow-hidden bg-background">
       <Show
@@ -689,7 +562,7 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
             <div class="flex items-start gap-4 px-6 py-5 border-b border-border">
               <div class="relative flex-none">
                 <Avatar name={emp().name} seed={emp().avatarSeed} />
-                <AvatarPresence status={emp().status} />
+                <AvatarPresence health={health()} />
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2 flex-wrap">
@@ -697,10 +570,10 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
                     {emp().name}
                   </h1>
                   <span
-                    class={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full border text-[11px] font-medium ${statusPillClass(emp().status)}`}
+                    class={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full border text-[11px] font-medium ${statusPillClass(health())}`}
                   >
-                    <StatusDot status={emp().status} />
-                    {statusLabel(emp().status)}
+                    <StatusDot health={health()} />
+                    {healthLabel(health())}
                   </span>
                 </div>
                 <div class="mt-1 text-[12px] text-muted-foreground flex items-center gap-3 flex-wrap">
@@ -788,46 +661,6 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
                 </Show>
               </div>
               <div class="flex items-center justify-end gap-2 flex-none relative flex-wrap max-w-[420px]">
-                <Show when={emp().mode === "always_on"}>
-                  <PrimaryActionButton employee={emp()} variant="compact" />
-                </Show>
-                <Show when={emp().mode === "always_on" && !canStartRun()}>
-                  <div class="basis-full text-right text-[12px] text-muted-foreground">
-                    Wake this employee before starting a chat.
-                  </div>
-                </Show>
-                <Show
-                  when={isRunning() || isWakeable() || actionPending() !== null}
-                  fallback={
-                    <span
-                      class="px-3 py-1.5 rounded-md border border-border text-[12px] font-medium text-muted-foreground"
-                      aria-label={`Status: ${statusLabel(emp().status)}`}
-                    >
-                      {statusLabel(emp().status)}
-                    </span>
-                  }
-                >
-                  <button
-                    type="button"
-                    class="px-3 py-1.5 rounded-md border text-[12px] font-medium transition-colors disabled:opacity-50"
-                    classList={{
-                      "border-emerald-500/40 text-emerald-300 hover:bg-emerald-500/10":
-                        isWakeable(),
-                      "border-amber-500/40 text-amber-300 hover:bg-amber-500/10":
-                        isRunning(),
-                    }}
-                    disabled={actionPending() !== null}
-                    onClick={handleSuspendOrWake}
-                  >
-                    <Show when={actionPending() === "suspend"}>
-                      Suspending...
-                    </Show>
-                    <Show when={actionPending() === "wake"}>Waking...</Show>
-                    <Show when={actionPending() === null}>
-                      {isRunning() ? "Suspend" : "Wake"}
-                    </Show>
-                  </button>
-                </Show>
                 <div ref={kebabContainerRef} class="relative">
                   <button
                     type="button"
@@ -921,6 +754,22 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
               </div>
             </div>
 
+            <EmployeeControlBar
+              employee={emp()}
+              health={health()}
+              isRunning={isRunning()}
+              isWakeable={isWakeable()}
+              actionPending={actionPending()}
+              manualRunInFlight={manualRun()?.kind === "running"}
+              canStartRun={canStartRun()}
+              onPrimary={handlePrimaryAction}
+              onSuspendOrWake={handleSuspendOrWake}
+            />
+            <EmployeeCostSummary
+              employeeId={props.employeeId}
+              refreshNonce={runsRefreshNonce()}
+            />
+
             {/* Body */}
             <div class="flex-1 overflow-y-auto px-6 py-6 w-full min-w-0">
               <Show when={actionError()}>
@@ -930,15 +779,6 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
                 >
                   {actionError()}
                 </div>
-              </Show>
-
-              <Show when={emp().mode !== "always_on"}>
-                <PrimaryActionButton employee={emp()} />
-                <Show when={!canStartRun()}>
-                  <div class="mt-2 mb-4 text-[12px] text-muted-foreground">
-                    Wake this employee before starting a run.
-                  </div>
-                </Show>
               </Show>
 
               {/* Inline manual-run status (cron / on-demand only) */}

--- a/src/components/employees/EmployeeRunsList.tsx
+++ b/src/components/employees/EmployeeRunsList.tsx
@@ -12,6 +12,7 @@ import {
   Show,
 } from "solid-js";
 import { EmployeeRunDetailModal } from "@/components/employees/EmployeeRunDetailModal";
+import { formatMicrosUsd } from "@/lib/employees/spend";
 import type { EmployeeRun } from "@/lib/employees/types";
 import { employees as svc } from "@/services/employees";
 
@@ -250,6 +251,11 @@ export const EmployeeRunsList: Component<EmployeeRunsListProps> = (props) => {
                         Copy
                       </button>
                       <span>{durationLabel(run.executionTimeMs)}</span>
+                      <span>
+                        {formatMicrosUsd(
+                          run.inferenceCostAtomic + run.computeCostAtomic,
+                        )}
+                      </span>
                       <Show
                         when={run.status === "awaiting_approval"}
                         fallback={

--- a/src/components/sidebar/EmployeesSection.tsx
+++ b/src/components/sidebar/EmployeesSection.tsx
@@ -13,10 +13,14 @@ import {
   untrack,
 } from "solid-js";
 import { gradientFor, initialFor } from "@/lib/employees/avatar";
+import {
+  employeeHealth,
+  healthDotClass,
+  healthLabel,
+} from "@/lib/employees/health";
 import type {
   ArchivedEmployee,
   EmployeeMode,
-  EmployeeStatus,
   EmployeeSummary,
 } from "@/lib/employees/types";
 import {
@@ -63,31 +67,6 @@ const Avatar: Component<{ name: string; seed: string; size?: number }> = (
     </div>
   );
 };
-
-function statusDotClass(status: EmployeeStatus, mode: EmployeeMode): string {
-  // A faint colored shadow on healthy/live dots reads as a hardware LED;
-  // operators scan the sidebar for "what's lit up". Stopped/idle stays flat.
-  if (status === "running") {
-    return mode === "cron"
-      ? "bg-amber-400 shadow-[0_0_4px_rgba(251,191,36,0.55)]"
-      : "bg-emerald-400 shadow-[0_0_4px_rgba(52,211,153,0.55)]";
-  }
-  if (status === "failed")
-    return "bg-red-500 shadow-[0_0_3px_rgba(248,113,113,0.5)]";
-  if (status === "stopped") return "bg-slate-500";
-  if (status === "pending" || status === "building")
-    return "bg-sky-400 animate-pulse";
-  return "bg-slate-500";
-}
-
-function statusLabel(status: EmployeeStatus, mode: EmployeeMode): string {
-  if (status === "running") return mode === "cron" ? "Scheduled" : "Live";
-  if (status === "failed") return "Error";
-  if (status === "stopped") return "Suspended";
-  if (status === "pending") return "Pending";
-  if (status === "building") return "Deploying";
-  return status;
-}
 
 function modeLabel(mode: EmployeeMode): string {
   if (mode === "always_on") return "On-call";
@@ -157,6 +136,11 @@ const EmployeeRow: Component<{
   pendingCount: number;
   onSelect: (id: string) => void;
 }> = (props) => {
+  const health = () =>
+    employeeHealth({
+      status: props.employee.status,
+      errorMessage: props.employee.errorMessage,
+    });
   const pluralRuns = () => (props.pendingCount === 1 ? "" : "s");
   const ariaSuffix = () =>
     props.pendingCount > 0
@@ -172,7 +156,7 @@ const EmployeeRow: Component<{
       aria-current={props.active ? "page" : undefined}
       onClick={() => props.onSelect(props.employee.id)}
       title={`${props.employee.name} (${modeLabel(props.employee.mode)})`}
-      aria-label={`Open ${props.employee.name}, ${modeLabel(props.employee.mode)}, ${statusLabel(props.employee.status, props.employee.mode)}${ariaSuffix()}`}
+      aria-label={`Open ${props.employee.name}, ${modeLabel(props.employee.mode)}, ${healthLabel(health())}${ariaSuffix()}`}
     >
       <Avatar name={props.employee.name} seed={props.employee.avatarSeed} />
       <div class="flex-1 min-w-0">
@@ -181,8 +165,8 @@ const EmployeeRow: Component<{
         </div>
         <div class="thread-list-meta text-muted-foreground truncate">
           {modeLabel(props.employee.mode)}
-          {" - "}
-          {statusLabel(props.employee.status, props.employee.mode)}
+          {" · "}
+          {healthLabel(health())}
         </div>
       </div>
       <Show when={props.pendingCount > 0}>
@@ -195,7 +179,7 @@ const EmployeeRow: Component<{
         </span>
       </Show>
       <span
-        class={`w-1.5 h-1.5 rounded-full flex-none ${statusDotClass(props.employee.status, props.employee.mode)}`}
+        class={`w-1.5 h-1.5 rounded-full flex-none ${healthDotClass(health())}`}
         aria-hidden="true"
       />
     </button>

--- a/src/lib/employees/health.ts
+++ b/src/lib/employees/health.ts
@@ -1,0 +1,48 @@
+// ABOUTME: Maps employee runtime state to a mode-independent health semantic.
+// ABOUTME: Keeps sidebar, detail, and presence indicators consistent.
+
+import type { EmployeeStatus } from "@/lib/employees/types";
+
+export type EmployeeHealth =
+  | "healthy"
+  | "degraded"
+  | "faulted"
+  | "suspended"
+  | "transitioning";
+
+export function employeeHealth(input: {
+  status: EmployeeStatus;
+  errorMessage?: string | null;
+  hasAlertConditions?: boolean;
+}): EmployeeHealth {
+  if (input.status === "failed") return "faulted";
+  if (input.status === "stopped") return "suspended";
+  if (input.status === "pending" || input.status === "building")
+    return "transitioning";
+  if (
+    input.status === "running" &&
+    (Boolean(input.errorMessage) || input.hasAlertConditions)
+  ) {
+    return "degraded";
+  }
+  return input.status === "running" ? "healthy" : "transitioning";
+}
+
+export function healthDotClass(health: EmployeeHealth): string {
+  if (health === "healthy")
+    return "bg-emerald-400 shadow-[0_0_4px_rgba(52,211,153,0.55)]";
+  if (health === "degraded")
+    return "bg-amber-400 shadow-[0_0_4px_rgba(251,191,36,0.55)]";
+  if (health === "faulted")
+    return "bg-red-500 shadow-[0_0_3px_rgba(248,113,113,0.5)]";
+  if (health === "suspended") return "bg-slate-500";
+  return "bg-sky-400 animate-pulse";
+}
+
+export function healthLabel(health: EmployeeHealth): string {
+  if (health === "healthy") return "Live";
+  if (health === "degraded") return "Degraded";
+  if (health === "faulted") return "Error";
+  if (health === "suspended") return "Suspended";
+  return "Starting";
+}

--- a/src/lib/employees/spend.ts
+++ b/src/lib/employees/spend.ts
@@ -1,0 +1,31 @@
+// ABOUTME: Converts employee spend values to exact integer micro-dollar totals.
+// ABOUTME: Provides rolling-window and display helpers for employee cost UI.
+
+import type { EmployeeRun } from "@/lib/employees/types";
+
+export function parseUsdToMicros(value: string): number {
+  const [wholePart, fractionPart = ""] = value.split(".");
+  const wholeMicros = Number.parseInt(wholePart, 10) * 1_000_000;
+  const fractionMicros = Number.parseInt(
+    fractionPart.slice(0, 6).padEnd(6, "0") || "0",
+    10,
+  );
+  return wholeMicros + fractionMicros;
+}
+
+export function formatMicrosUsd(micros: number): string {
+  if (micros === 0) return "$0.00";
+  const precision = micros < 10_000 ? 4 : 2;
+  return `$${(micros / 1e6).toFixed(precision)}`;
+}
+
+export function sumRunCostMicros(runs: EmployeeRun[]): number {
+  return runs.reduce(
+    (total, run) => total + run.inferenceCostAtomic + run.computeCostAtomic,
+    0,
+  );
+}
+
+export function windowStartIso(now: number, days: number): string {
+  return new Date(now - days * 24 * 60 * 60 * 1000).toISOString();
+}

--- a/src/lib/employees/types.ts
+++ b/src/lib/employees/types.ts
@@ -150,6 +150,8 @@ export type EmployeeRun = {
   statusMessage: string | null;
   stopReason: string | null;
   output: string | null;
+  inferenceCostAtomic: number;
+  computeCostAtomic: number;
 };
 
 export type EmployeeRunDetail = EmployeeRun & {

--- a/src/services/employees.ts
+++ b/src/services/employees.ts
@@ -35,9 +35,11 @@ import {
   serenCloudDeploymentRunArtifacts,
   serenCloudDeploymentRunPendingApprovals,
   serenCloudDeploymentRuns,
+  serenCloudGetDeploymentSpend,
   serenCloudRun,
 } from "@/api/seren-cloud";
 import { formatApiError } from "@/lib/api-errors";
+import { parseUsdToMicros } from "@/lib/employees/spend";
 import type {
   EmployeeDetail,
   EmployeePatch,
@@ -208,6 +210,8 @@ function runFromCloud(row: CloudDeploymentRunEvent): EmployeeRun {
     statusMessage: row.status_message ?? null,
     stopReason: row.stop_reason ?? null,
     output: row.output ?? null,
+    inferenceCostAtomic: row.inference_cost_atomic,
+    computeCostAtomic: row.compute_cost_atomic,
   };
 }
 
@@ -645,6 +649,62 @@ export const employees = {
       hasMore: data?.pagination?.has_more ?? false,
       total: data?.pagination?.total ?? rows.length,
     };
+  },
+
+  async getSpend(id: string): Promise<{
+    totalMicros: number;
+    inferenceMicros: number;
+    computeMicros: number;
+    runCount: number;
+  }> {
+    const { data, error, response } = await serenCloudGetDeploymentSpend({
+      path: { id },
+      throwOnError: false,
+    });
+    if (error || !data?.data) {
+      throw new Error(
+        `Failed to load employee spend: ${formatApiError(error, response, "")}`,
+      );
+    }
+    // Deliberately leave first_event_at/last_event_at unmapped: the live API
+    // serializes them as arrays despite the spec declaring date-time strings.
+    return {
+      totalMicros: parseUsdToMicros(data.data.total_cost_usd),
+      inferenceMicros: parseUsdToMicros(data.data.inference_cost_usd),
+      computeMicros: parseUsdToMicros(data.data.compute_cost_usd),
+      runCount: data.data.run_count,
+    };
+  },
+
+  async listRunsSince(
+    id: string,
+    sinceIso: string,
+    maxPages = 5,
+  ): Promise<{ rows: EmployeeRun[]; truncated: boolean }> {
+    const rows: EmployeeRun[] = [];
+    let offset = 0;
+    let truncated = false;
+
+    for (let page = 0; page < maxPages; page += 1) {
+      const { data, error, response } = await serenCloudDeploymentRuns({
+        path: { id },
+        query: { limit: 100, offset, started_after: sinceIso },
+        throwOnError: false,
+      });
+      if (error) {
+        throw new Error(
+          `Failed to list employee runs: ${formatApiError(error, response, "")}`,
+        );
+      }
+      const pageRows = data?.data ?? [];
+      rows.push(...pageRows.map(runFromCloud));
+      const hasMore = data?.pagination?.has_more ?? false;
+      if (!hasMore) return { rows, truncated: false };
+      offset += 100;
+      if (page === maxPages - 1) truncated = true;
+    }
+
+    return { rows, truncated };
   },
 
   async listPendingApprovals(

--- a/tests/unit/employee-health.test.ts
+++ b/tests/unit/employee-health.test.ts
@@ -1,0 +1,35 @@
+import {
+  employeeHealth,
+  healthDotClass,
+} from "@/lib/employees/health";
+import { describe, expect, it } from "vitest";
+
+describe("employee health", () => {
+  it("treats a running employee as healthy and green", () => {
+    expect(employeeHealth({ status: "running" })).toBe("healthy");
+    expect(healthDotClass("healthy")).toContain("bg-emerald-400");
+  });
+
+  it("treats a running cron employee identically to any running employee", () => {
+    expect(employeeHealth({ status: "running" })).toBe("healthy");
+    expect(healthDotClass(employeeHealth({ status: "running" }))).toContain(
+      "bg-emerald-400",
+    );
+  });
+
+  it("marks runtime warnings as degraded and amber", () => {
+    expect(
+      employeeHealth({ status: "running", errorMessage: "runtime warning" }),
+    ).toBe("degraded");
+    expect(healthDotClass("degraded")).toContain("bg-amber-400");
+  });
+
+  it.each([
+    ["failed", "faulted"],
+    ["stopped", "suspended"],
+    ["pending", "transitioning"],
+    ["building", "transitioning"],
+  ] as const)("maps %s to %s", (status, expected) => {
+    expect(employeeHealth({ status })).toBe(expected);
+  });
+});

--- a/tests/unit/employee-spend.test.ts
+++ b/tests/unit/employee-spend.test.ts
@@ -1,0 +1,43 @@
+import type { EmployeeRun } from "@/lib/employees/types";
+import {
+  formatMicrosUsd,
+  parseUsdToMicros,
+  sumRunCostMicros,
+} from "@/lib/employees/spend";
+import { describe, expect, it } from "vitest";
+
+function run(inferenceCostAtomic: number, computeCostAtomic: number): EmployeeRun {
+  return {
+    id: "run",
+    deploymentId: "deployment",
+    status: "completed",
+    source: "ui",
+    runName: null,
+    startedAt: "2026-07-20T00:00:00Z",
+    completedAt: null,
+    executionTimeMs: 1,
+    statusMessage: null,
+    stopReason: null,
+    output: null,
+    inferenceCostAtomic,
+    computeCostAtomic,
+  };
+}
+
+describe("employee spend", () => {
+  it("parses decimal USD strings as integer micro-dollars", () => {
+    expect(parseUsdToMicros("0.000311")).toBe(311);
+    expect(parseUsdToMicros("0")).toBe(0);
+    expect(parseUsdToMicros("1.5")).toBe(1_500_000);
+  });
+
+  it("sums inference and compute atomics across runs", () => {
+    expect(sumRunCostMicros([run(11, 20), run(300, 400)])).toBe(731);
+  });
+
+  it("formats micro-dollar totals for operator display", () => {
+    expect(formatMicrosUsd(311)).toBe("$0.0003");
+    expect(formatMicrosUsd(0)).toBe("$0.00");
+    expect(formatMicrosUsd(1_234_567)).toBe("$1.23");
+  });
+});


### PR DESCRIPTION
Closes #3074

## Summary

- Unifies employee health semantics across the sidebar, header, avatar presence, and status pill so a healthy running scheduled employee is green; amber is reserved for degraded health.
- Moves Run now and Suspend/Wake into one compact control bar with explicit labels and neutral suspend styling.
- Adds last-run, last-30-day, and since-launch cost summaries backed by the live Seren Cloud spend and runs endpoints, with run costs shown in the runs list.

## Audited network paths

- GET /publishers/seren-cloud/deployments/{id}/spend
- GET /publishers/seren-cloud/deployments/{id}/runs?started_after=...&limit=...&offset=...

The live spend response was independently checked during the walkthrough. The timestamp fields are intentionally not mapped because the live response serializes them as arrays despite the published date-time schema.

## Verification

- Focused health and spend Vitest suites pass.
- Biome check on touched files passes.
- Rust cargo check passes.
- Real Tauri walkthrough completed against the live scheduled employee: green sidebar dot, Scheduled · Live metadata, side-by-side Run now and neutral Suspend, spend row, and post-run count refresh.
- Full repository check and test commands exit zero; existing repository warnings and skipped suites are recorded in the handoff.