### PR TITLE
fix(ci): report every build platform on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,10 @@ jobs:
     env:
       NODE_OPTIONS: '--max-old-space-size=4096'
     strategy:
+      # Report every platform. Under fail-fast one platform's failure cancels the
+      # others, so a single real break reads as three red legs with no error of
+      # their own — that misdirected the diagnosis of #3075 for hours.
+      fail-fast: false
       matrix:
         # Only run Linux on direct pushes to main, full matrix on PRs
         os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}


### PR DESCRIPTION
Follow-up to #3075. One line: `fail-fast: false` on the `build` matrix.

## Why

The matrix ran under the default `fail-fast: true`, so the first platform to fail cancels the other two. A single genuine break therefore surfaces as **three red legs, two of which contain no error of their own**.

That is not hypothetical — it is how #3075 hid. Across the 2026-07-20 Dependabot batch every PR showed three red `build` legs, and the per-job conclusions were:

| PR | ubuntu | macos | windows |
| --- | --- | --- | --- |
| #3053 | cancelled | **failure** | cancelled |
| #3056 | cancelled | cancelled | **failure** |
| #3060 | cancelled | **failure** | cancelled |

Reading the check list alone, thirteen PRs looked identically and inexplicably broken. It took per-job API queries to find that each had exactly one real failure and two pieces of collateral — and my first root-cause call was wrong as a direct result (I attributed it to CI concurrency; corrected in #3064).

With `fail-fast: false`, every platform reports its own verdict, so "Windows is broken, the other two are fine" is legible from the check list.

## Cost

Slightly more CI minutes when a build genuinely fails — the surviving legs now run to completion instead of being cancelled. That is the point: the information they produce is what was missing.

## A second gap, deliberately NOT changed here

`ci.yml:217` runs the three-OS matrix only on `pull_request`; a push to `main` builds **ubuntu only**:

```yaml
os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
```

This is the other half of why #3075 went unobserved: the break was Windows-only, so `main` stayed green after it landed. Combined with `build` being gated on `needs: [lint, test-frontend, test-rust, test-e2e]` — which makes it the slowest check and the easiest to merge past — a platform-specific regression can reach `main` and sit there.

I have not changed it, because running the full matrix on every push to `main` roughly triples build minutes on the busiest trigger, and that is a cost call rather than a correctness one. **Taariq — worth deciding explicitly.** The options as I see them:

1. **Leave as-is.** Cheapest. Accepts that a platform-specific break can live on `main` until someone opens a PR.
2. **Full matrix on `main` pushes.** Closes the hole outright, ~3x build minutes on pushes.
3. **Don't merge lockfile PRs before `build` completes.** Free, but relies on discipline — and it already failed once today, in #3072, by me.

## Note on merging

This touches `.github/workflows/ci.yml`, so it needs a manual merge — my token has `repo` but not `workflow` scope (see #3069).

## Validation

`fail-fast: false` is a documented `strategy` key; the edit is inside the existing `strategy:` block and the surrounding `matrix:`/`os:` lines are unchanged. The workflow's own run on this PR exercises the parse — if the key or indentation were wrong, the run would fail to start.

That run also serves a second purpose: it is the first full three-platform build against `main` since #3076 landed, so a green `build (windows-latest)` here independently confirms the P0 fix holds on current `main`.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
