### PR TITLE
fix(employees): converge since-launch spend after a run

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -664,6 +664,7 @@ pub fn run() {
                         "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --autoplay-policy=no-user-gesture-required --remote-debugging-port={port} --remote-allow-origins=*"
                     )
                 });
+            let validation_window = validation::is_validation_identifier(&app.config().identifier);
             let window_configs = app.config().app.windows.clone();
             for window_config in &window_configs {
                 let mut window_builder =
@@ -676,6 +677,12 @@ pub fn run() {
                     );
                 }
                 window_builder.build()?;
+            }
+
+            if validation_window {
+                if let Some(window) = app.get_webview_window("main") {
+                    window.set_title("SerenDesktop (Validation)")?;
+                }
             }
 
             let app_identifier = app.config().identifier.clone();

--- a/src-tauri/tauri.validation.conf.json
+++ b/src-tauri/tauri.validation.conf.json
@@ -6,6 +6,24 @@
     "beforeDevCommand": "pnpm prepare:mcp-servers && pnpm build:provider-runtime && pnpm dev --host 127.0.0.1 --port 1422",
     "devUrl": "http://127.0.0.1:1422"
   },
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "create": false,
+        "title": "SerenDesktop (Validation)",
+        "width": 1200,
+        "height": 800,
+        "resizable": true,
+        "fullscreen": false,
+        "minWidth": 800,
+        "minHeight": 600,
+        "devtools": true,
+        "hiddenTitle": true,
+        "dragDropEnabled": false
+      }
+    ]
+  },
   "plugins": {
     "deep-link": {
       "desktop": {

--- a/src/components/employees/EmployeeCostSummary.tsx
+++ b/src/components/employees/EmployeeCostSummary.tsx
@@ -3,13 +3,18 @@
 
 import {
   type Component,
+  createEffect,
   createMemo,
   createResource,
+  createSignal,
   type JSX,
+  onCleanup,
+  untrack,
   Show,
 } from "solid-js";
 import {
   formatMicrosUsd,
+  nextSpendPollDelayMs,
   sumRunCostMicros,
   windowStartIso,
 } from "@/lib/employees/spend";
@@ -37,15 +42,81 @@ const CostCell: Component<{ label: string; children: JSX.Element }> = (
 export const EmployeeCostSummary: Component<EmployeeCostSummaryProps> = (
   props,
 ) => {
-  const resourceKey = () => `${props.employeeId}::${props.refreshNonce}`;
-  const [spend] = createResource(resourceKey, async (key) => {
+  const [spendAttempt, setSpendAttempt] = createSignal(0);
+  const spendResourceKey = () =>
+    `${props.employeeId}::${props.refreshNonce}::${spendAttempt()}`;
+  const recentResourceKey = () => `${props.employeeId}::${props.refreshNonce}`;
+  const [spend] = createResource(spendResourceKey, async (key) => {
     const [employeeId] = key.split("::");
     return svc.getSpend(employeeId);
   });
-  const [recentSpend] = createResource(resourceKey, async (key) => {
+  const [recentSpend] = createResource(recentResourceKey, async (key) => {
     const [employeeId] = key.split("::");
     return svc.listRunsSince(employeeId, windowStartIso(Date.now(), 30));
   });
+
+  let convergedRunCount: number | null = null;
+  const [baselineRunCount, setBaselineRunCount] = createSignal<number | null>(
+    null,
+  );
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let seenNonce: number | null = null;
+
+  const clearPollTimer = () => {
+    if (pollTimer !== null) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+  };
+
+  createEffect(() => {
+    const nonce = props.refreshNonce;
+    if (seenNonce === null) {
+      seenNonce = nonce;
+      return;
+    }
+    if (nonce === seenNonce) return;
+    seenNonce = nonce;
+    setBaselineRunCount(convergedRunCount);
+    setSpendAttempt(0);
+    clearPollTimer();
+  });
+
+  createEffect(() => {
+    props.employeeId;
+    convergedRunCount = null;
+    setBaselineRunCount(null);
+    setSpendAttempt(0);
+    clearPollTimer();
+  });
+
+  createEffect(() => {
+    const total = spend();
+    const attempt = spendAttempt();
+    if (!total || spend.loading) return;
+
+    const baseline = untrack(baselineRunCount);
+    if (baseline === null) {
+      convergedRunCount = total.runCount;
+      clearPollTimer();
+      return;
+    }
+
+    const delay = nextSpendPollDelayMs(attempt, baseline, total.runCount);
+    clearPollTimer();
+    if (delay === null) {
+      convergedRunCount = total.runCount;
+      setBaselineRunCount(null);
+      return;
+    }
+
+    pollTimer = setTimeout(() => {
+      pollTimer = null;
+      setSpendAttempt((current) => current + 1);
+    }, delay);
+  });
+
+  onCleanup(clearPollTimer);
 
   const sortedRuns = createMemo(() => {
     const rows = recentSpend()?.rows ?? [];
@@ -56,6 +127,8 @@ export const EmployeeCostSummary: Component<EmployeeCostSummaryProps> = (
     );
   });
   const hasError = () => Boolean(spend.error || recentSpend.error);
+  const spendUpdating = () =>
+    baselineRunCount() !== null && !spend.error && !recentSpend.error;
   const lastRun = (): EmployeeRun | undefined => sortedRuns()[0];
   const lastRunCost = () => {
     const run = lastRun();
@@ -91,7 +164,12 @@ export const EmployeeCostSummary: Component<EmployeeCostSummaryProps> = (
             {recentSpend()?.rows.length ?? 0} runs
             <Show when={recentSpend()?.truncated}> (partial)</Show>
           </CostCell>
-          <CostCell label="Since launch">{sinceLaunchCost()}</CostCell>
+          <CostCell label="Since launch">
+            {sinceLaunchCost()}
+            <Show when={spendUpdating()}>
+              <span class="text-muted-foreground"> · updating…</span>
+            </Show>
+          </CostCell>
         </div>
       </Show>
     </div>

--- a/src/components/employees/EmployeeCostSummary.tsx
+++ b/src/components/employees/EmployeeCostSummary.tsx
@@ -9,8 +9,8 @@ import {
   createSignal,
   type JSX,
   onCleanup,
-  untrack,
   Show,
+  untrack,
 } from "solid-js";
 import {
   formatMicrosUsd,

--- a/src/components/employees/EmployeeDetail.tsx
+++ b/src/components/employees/EmployeeDetail.tsx
@@ -183,7 +183,6 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
   const [showRevisions, setShowRevisions] = createSignal(false);
   const [manualRun, setManualRun] = createSignal<ManualRunState | null>(null);
   const [runsRefreshNonce, setRunsRefreshNonce] = createSignal(0);
-  let delayedRunRefresh: ReturnType<typeof setTimeout> | null = null;
   const [detailRunId, setDetailRunId] = createSignal<string | null>(null);
   const [editingEvalGate, setEditingEvalGate] = createSignal(false);
   const [showCheckpoints, setShowCheckpoints] = createSignal(true);
@@ -316,17 +315,10 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
   onCleanup(() => {
     document.removeEventListener("keydown", handleDocumentKeydown);
     document.removeEventListener("mousedown", handleDocumentMousedown);
-    if (delayedRunRefresh !== null) clearTimeout(delayedRunRefresh);
   });
 
   const refreshRunData = () => {
     setRunsRefreshNonce((n) => n + 1);
-    if (delayedRunRefresh !== null) clearTimeout(delayedRunRefresh);
-    // Spend aggregation can trail the completed run event by a short window.
-    delayedRunRefresh = setTimeout(() => {
-      delayedRunRefresh = null;
-      setRunsRefreshNonce((n) => n + 1);
-    }, 3_000);
   };
 
   const status = () => summary()?.status ?? "pending";

--- a/src/lib/employees/spend.ts
+++ b/src/lib/employees/spend.ts
@@ -3,6 +3,25 @@
 
 import type { EmployeeRun } from "@/lib/employees/types";
 
+export const SPEND_POLL_DELAYS_MS: readonly number[] = [
+  1_000, 2_000, 4_000, 8_000,
+];
+
+export function nextSpendPollDelayMs(
+  attempt: number,
+  baselineRunCount: number | null,
+  observedRunCount: number,
+): number | null {
+  if (
+    baselineRunCount === null ||
+    observedRunCount > baselineRunCount ||
+    attempt >= SPEND_POLL_DELAYS_MS.length
+  ) {
+    return null;
+  }
+  return SPEND_POLL_DELAYS_MS[attempt];
+}
+
 export function parseUsdToMicros(value: string): number {
   const [wholePart, fractionPart = ""] = value.split(".");
   const wholeMicros = Number.parseInt(wholePart, 10) * 1_000_000;

--- a/tests/unit/employee-spend.test.ts
+++ b/tests/unit/employee-spend.test.ts
@@ -1,7 +1,9 @@
 import type { EmployeeRun } from "@/lib/employees/types";
 import {
   formatMicrosUsd,
+  nextSpendPollDelayMs,
   parseUsdToMicros,
+  SPEND_POLL_DELAYS_MS,
   sumRunCostMicros,
 } from "@/lib/employees/spend";
 import { describe, expect, it } from "vitest";
@@ -39,5 +41,15 @@ describe("employee spend", () => {
     expect(formatMicrosUsd(311)).toBe("$0.0003");
     expect(formatMicrosUsd(0)).toBe("$0.00");
     expect(formatMicrosUsd(1_234_567)).toBe("$1.23");
+  });
+
+  it("bounds spend convergence polling and stops after the run count advances", () => {
+    expect(nextSpendPollDelayMs(0, 1, 1)).toBe(1_000);
+    expect(nextSpendPollDelayMs(1, 1, 1)).toBe(2_000);
+    expect(nextSpendPollDelayMs(0, 1, 2)).toBeNull();
+    expect(nextSpendPollDelayMs(0, null, 5)).toBeNull();
+    expect(
+      nextSpendPollDelayMs(SPEND_POLL_DELAYS_MS.length, 1, 1),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #3082

## Summary

- Re-fetch employee spend after a manual run and poll with a bounded backoff until the cloud run count advances.
- Keep the last known since-launch amount visible while showing a muted · updating… marker during convergence.
- Reset convergence state when switching employees and keep the baseline signal isolated from the settled spend effect.
- Add focused regression coverage for converged and bounded polling.
- Make validation builds identify themselves as SerenDesktop (Validation).

## Validation

- `pnpm check:fix`
- `pnpm vitest run tests/unit/employee-spend.test.ts`
- `pnpm vitest run tests/unit/employee-health.test.ts`
- `pnpm check`
- `pnpm test`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Live walkthrough with `pnpm tauri:validation:dev` on `127.0.0.1:1422`; completed runs showed the in-panel updating marker and same-panel convergence.