### PR TITLE
Add Grok as a native agent through the shared ACP runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Seren is built for people who spend their day making decisions, not stitching to
 - **Analysts, operators, and finance teams** - automate reporting, reconciliation, intake, and back-office workflows
 - **Job seekers and independent professionals** - automate a full pipeline: company discovery, contact research, personalized outreach, and application tracking
 - **Finance and tax filers** - process bank statements, reconcile transactions, and prepare crypto and traditional tax filings
-- **Developers and engineers** - use Codex, Claude Code, or Gemini, open terminals, and work across project files
+- **Developers and engineers** - use Codex, Claude Code, Gemini, or Grok, open terminals, and work across project files
 
 ---
 
@@ -65,9 +65,9 @@ Browse open bounties from the sidebar, review the reward pool and tiers, and joi
 
 ### Work with native agents
 
-Use Codex, Claude Code, or Gemini directly inside Seren and switch providers mid-task without losing the conversation. Open a project, drop files into a thread, edit them in the built-in editor, and review diffs before they land.
+Use Codex, Claude Code, Gemini, or Grok directly inside Seren and switch providers mid-task without losing the conversation. Open a project, drop files into a thread, edit them in the built-in editor, and review diffs before they land.
 
-- Use Codex, Claude Code, or Gemini in the same workspace
+- Use Codex, Claude Code, Gemini, or Grok in the same workspace
 - Run terminal-based Codex or Claude Code for a CLI-feel session inside the app
 - Open a plain terminal alongside your threads for shell work and one-off commands
 - Edit files in the built-in editor while a thread is running

--- a/bin/browser-local/acp-runtime.mjs
+++ b/bin/browser-local/acp-runtime.mjs
@@ -1,0 +1,988 @@
+// ABOUTME: Shared browser-local Agent Client Protocol runtime over newline-delimited JSON-RPC.
+// ABOUTME: Owns session lifecycle, streaming, permissions, MCP wiring, cancellation, and cleanup for ACP agents.
+
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import readline from "node:readline";
+
+import { buildProviderMcpConfig } from "./mcp-config.mjs";
+import { providerLogPrefix } from "./logging.mjs";
+import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
+
+// ============================================================================
+// Process helpers
+// ============================================================================
+
+function killChildTree(child) {
+  if (process.platform === "win32" && child.pid !== undefined) {
+    try {
+      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+      return;
+    } catch {
+      // Fall through to direct kill.
+    }
+  }
+  try {
+    child.kill();
+  } catch {
+    // Ignore double-kill races during cleanup.
+  }
+}
+
+// ============================================================================
+// ACP protocol helpers
+// ============================================================================
+
+/**
+ * ACP protocol version this client implements. ACP uses uint16 versions,
+ * starting at 1. Bump only when every configured ACP agent supports it.
+ */
+const ACP_PROTOCOL_VERSION = 1;
+
+function buildInitializeParams() {
+  return {
+    protocolVersion: ACP_PROTOCOL_VERSION,
+    clientInfo: {
+      name: "seren_provider_runtime",
+      title: "Seren Provider Runtime",
+      version: "0.1.0",
+    },
+    clientCapabilities: {
+      // We don't expose terminal/fs capabilities to the agent — the desktop
+      // mediates these via the existing approval UI and provider events.
+      fs: { readTextFile: false, writeTextFile: false },
+      terminal: false,
+    },
+  };
+}
+
+// ============================================================================
+// Session record
+// ============================================================================
+
+function createAcpSessionRecord({
+  adapter,
+  sessionId,
+  cwd,
+  processHandle,
+  timeoutSecs,
+  currentModeId,
+  currentModelId,
+  logPrefix,
+  serenMcpProxy = null,
+}) {
+  return {
+    id: sessionId,
+    agentType: adapter.agentType,
+    agentName: adapter.agentName,
+    agentInfoName: adapter.agentInfoName,
+    adapter,
+    cwd,
+    status: "initializing",
+    createdAt: new Date().toISOString(),
+    process: processHandle,
+    output: readline.createInterface({ input: processHandle.stdout }),
+    pendingRequests: new Map(),
+    nextRequestId: 1,
+    pendingPermissions: new Map(),
+    logPrefix,
+    currentPrompt: null,
+    agentSessionId: undefined,
+    timeoutSecs: timeoutSecs ?? undefined,
+    agentVersion: null,
+    currentModeId: currentModeId ?? adapter.defaultModeId,
+    currentModelId: currentModelId ?? adapter.defaultModelId,
+    availableModels: adapter.availableModels,
+    configOptions: [],
+    serenMcpProxy,
+  };
+}
+
+// ============================================================================
+// JSON-RPC framing (newline-delimited JSON over stdio)
+// ============================================================================
+
+function sendRequest(session, method, params, timeoutMs = 30_000) {
+  const id = session.nextRequestId;
+  session.nextRequestId += 1;
+
+  const payload = {
+    jsonrpc: "2.0",
+    id,
+    method,
+    params,
+  };
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    const timeout = setTimeout(() => {
+      session.pendingRequests.delete(String(id));
+      rejectPromise(new Error(`Timed out waiting for ${method}.`));
+    }, timeoutMs);
+
+    session.pendingRequests.set(String(id), {
+      method,
+      timeout,
+      resolve: resolvePromise,
+      reject: rejectPromise,
+    });
+
+    session.process.stdin.write(`${JSON.stringify(payload)}\n`);
+  });
+}
+
+function writeMessage(session, message) {
+  session.process.stdin.write(`${JSON.stringify(message)}\n`);
+}
+
+function rejectPendingRequests(session, error) {
+  for (const [key, pending] of session.pendingRequests) {
+    clearTimeout(pending.timeout);
+    pending.reject(error);
+    session.pendingRequests.delete(key);
+  }
+}
+
+function rejectCurrentPrompt(session, error) {
+  if (!session.currentPrompt) return;
+  const pending = session.currentPrompt;
+  session.currentPrompt = null;
+  pending.reject(error);
+}
+
+function resolveCurrentPrompt(session) {
+  if (!session.currentPrompt) return;
+  const pending = session.currentPrompt;
+  session.currentPrompt = null;
+  pending.resolve();
+}
+
+// Resolve true once `pendingPrompt` is no longer the session's active prompt
+// (the agent settled the turn — resolve or reject clears currentPrompt), or
+// false if `timeoutMs` elapses first. Used to detect whether a cooperative
+// cancel actually stopped the turn before escalating to a hard kill.
+function waitForPromptToClear(session, pendingPrompt, timeoutMs) {
+  if (session.currentPrompt !== pendingPrompt) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const deadline = setTimeout(() => {
+      clearInterval(poll);
+      resolve(false);
+    }, timeoutMs);
+    const poll = setInterval(() => {
+      if (session.currentPrompt !== pendingPrompt) {
+        clearInterval(poll);
+        clearTimeout(deadline);
+        resolve(true);
+      }
+    }, 100);
+  });
+}
+
+function handleResponse(session, payload) {
+  const pending = session.pendingRequests.get(String(payload.id));
+  if (!pending) return;
+
+  clearTimeout(pending.timeout);
+  session.pendingRequests.delete(String(payload.id));
+
+  if (payload.error?.message) {
+    pending.reject(
+      new Error(`${pending.method} failed: ${payload.error.message}`),
+    );
+    return;
+  }
+
+  pending.resolve(payload.result);
+}
+
+// ============================================================================
+// ACP → provider:// event translation
+// ============================================================================
+
+/**
+ * Extract a text string from an ACP ContentBlock or array of blocks.
+ * The agent emits ContentBlocks in `agent_message_chunk.content` and
+ * `agent_thought_chunk.content`. We only render text blocks today.
+ */
+function contentBlockText(content) {
+  if (typeof content === "string") return content;
+  if (!content || typeof content !== "object") return "";
+  if (content.type === "text" && typeof content.text === "string") {
+    return content.text;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => contentBlockText(block))
+      .filter(Boolean)
+      .join("");
+  }
+  return "";
+}
+
+/**
+ * ACP `tool_call` and `tool_call_update` updates carry a ToolCallContent[]
+ * array. We flatten any text/diff/terminal output into a single string for
+ * the existing provider://tool-result event format.
+ */
+function flattenToolCallContent(content) {
+  if (!Array.isArray(content)) return undefined;
+  const parts = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    if (block.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    } else if (block.type === "diff") {
+      parts.push(JSON.stringify(block));
+    }
+  }
+  return parts.length > 0 ? parts.join("\n") : undefined;
+}
+
+function emitToolCallUpdate(emit, session, update) {
+  const toolCallId = String(update.toolCallId ?? randomUUID());
+  const status = update.status ?? "running";
+  // ACP ToolCallContent supports text/image/diff/resource/terminal — for
+  // active sessions we surface the title + raw input on the call event and
+  // the flattened content on the result event below.
+  emit("provider://tool-call", {
+    sessionId: session.id,
+    toolCallId,
+    title: update.title ?? update.name ?? "Tool call",
+    kind: update.name ?? "tool",
+    status,
+    parameters: update,
+  });
+
+  // Terminal/completed updates also produce a tool-result so the desktop's
+  // existing approval UI can render the output.
+  if (status === "completed" || status === "error") {
+    emit("provider://tool-result", {
+      sessionId: session.id,
+      toolCallId,
+      status,
+      result: flattenToolCallContent(update.content),
+      error:
+        status === "error"
+          ? update.result?.error ?? "Tool call failed"
+          : undefined,
+    });
+  }
+}
+
+function handleSessionUpdate(emit, session, params) {
+  const update = params?.update ?? {};
+  const type = update.type ?? update.sessionUpdate;
+
+  switch (type) {
+    case "agent_message_chunk": {
+      const text = contentBlockText(update.content);
+      if (text) {
+        emit("provider://message-chunk", { sessionId: session.id, text });
+      }
+      return;
+    }
+
+    case "agent_thought_chunk": {
+      const text = contentBlockText(update.content);
+      if (text) {
+        emit("provider://message-chunk", {
+          sessionId: session.id,
+          text,
+          isThought: true,
+        });
+      }
+      return;
+    }
+
+    case "tool_call":
+    case "tool_call_update":
+      emitToolCallUpdate(emit, session, update);
+      return;
+
+    case "plan": {
+      const entries = Array.isArray(update.entries) ? update.entries : [];
+      emit("provider://plan-update", {
+        sessionId: session.id,
+        entries: entries.map((entry) => ({
+          content: entry.content ?? entry.title ?? "Untitled step",
+          status:
+            entry.status ??
+            (entry.completed === true ? "completed" : "pending"),
+        })),
+      });
+      return;
+    }
+
+    case "current_mode_update": {
+      if (typeof update.modeId === "string") {
+        session.currentModeId = update.modeId;
+        emit("provider://session-status", buildSessionStatus(session));
+      }
+      return;
+    }
+
+    default:
+      // Unknown update types are ignored — ACP agents may add new ones over
+      // time and we don't want to crash on unfamiliar shapes.
+      return;
+  }
+}
+
+/**
+ * Handle an inbound ACP request from the agent. Today the only one we expect
+ * is `session/request_permission` for tool approvals.
+ */
+function buildPermissionRequestEvent(session, requestId, params) {
+  return {
+    sessionId: session.id,
+    requestId,
+    toolCall: {
+      name: params.toolCall?.name ?? "tool",
+      title: params.toolCall?.title ?? "Tool call",
+      input: params.toolCall ?? {},
+    },
+    options: (params.options ?? []).map((opt) => ({
+      optionId: opt.optionId,
+      label: opt.name ?? opt.optionId,
+      description: opt.kind,
+    })),
+  };
+}
+
+function listPendingPermissions(session) {
+  return Array.from(session.pendingPermissions.values()).map(
+    (pending) => pending.permissionRequest,
+  );
+}
+
+function handleAgentRequest(emit, session, payload) {
+  if (payload.method === "session/request_permission") {
+    const params = payload.params ?? {};
+    const requestId = randomUUID();
+    const permissionRequest = buildPermissionRequestEvent(
+      session,
+      requestId,
+      params,
+    );
+    session.pendingPermissions.set(requestId, {
+      requestId,
+      jsonRpcId: payload.id,
+      // Store the ACP option list verbatim so respondToPermission can map
+      // a desktop optionId back to the agent's expected outcome.
+      options: Array.isArray(params.options) ? params.options : [],
+      permissionRequest,
+    });
+
+    // Auto-approve in YOLO / auto_edit mode for non-destructive tools.
+    // This mirrors how Codex handles "auto" mode in providers.mjs.
+    if (session.adapter.autoApproveModeIds.includes(session.currentModeId)) {
+      const allowOption = (params.options ?? []).find(
+        (opt) => opt.kind === "allow_once" || opt.kind === "allow_always",
+      );
+      writeMessage(session, {
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: {
+          outcome: allowOption
+            ? { outcome: "selected", optionId: allowOption.optionId }
+            : { outcome: "cancelled" },
+        },
+      });
+      session.pendingPermissions.delete(requestId);
+      return;
+    }
+
+    emit("provider://permission-request", permissionRequest);
+    return;
+  }
+
+  // Unknown request — respond with method-not-found so the agent doesn't
+  // hang waiting for a reply.
+  writeMessage(session, {
+    jsonrpc: "2.0",
+    id: payload.id,
+    error: {
+      code: -32601,
+      message: `Method not implemented: ${payload.method}`,
+    },
+  });
+}
+
+function handleNotification(emit, session, payload) {
+  const method = payload.method;
+  const params = payload.params ?? {};
+
+  if (method === "session/update") {
+    handleSessionUpdate(emit, session, params);
+    return;
+  }
+  // Other notifications (cancel, etc.) are agent→client info we don't act on.
+}
+
+function handleLine(emit, session, line) {
+  let payload;
+  try {
+    payload = JSON.parse(line);
+  } catch {
+    // Some ACP agents write diagnostic strings to stdout. Ignore
+    // anything that isn't a valid JSON-RPC frame.
+    return;
+  }
+
+  if (payload.id != null && payload.method) {
+    handleAgentRequest(emit, session, payload);
+    return;
+  }
+  if (payload.id != null) {
+    handleResponse(session, payload);
+    return;
+  }
+  if (payload.method) {
+    handleNotification(emit, session, payload);
+  }
+}
+
+// ============================================================================
+// Session status payloads
+// ============================================================================
+
+function buildSessionStatus(session, status = session.status) {
+  return {
+    sessionId: session.id,
+    status,
+    agentSessionId: session.agentSessionId,
+    agentInfo: {
+      name: session.agentInfoName,
+      version: session.agentVersion ?? "unknown",
+    },
+    models: {
+      currentModelId: session.currentModelId ?? session.adapter.defaultModelId,
+      availableModels: session.availableModels,
+    },
+    modes: session.adapter.buildModes(session),
+    configOptions: session.configOptions,
+  };
+}
+
+function attachProcessListeners(emit, sessions, session) {
+  const logPrefix =
+    session.logPrefix ?? providerLogPrefix(session.agentType);
+  session.output.on("line", (line) => handleLine(emit, session, line));
+
+  // Buffer the latest stderr lines so the spawn-time catch block has
+  // something to inspect when a JSON-RPC handshake fails. Some agents write
+  // auth/keychain errors to stderr, not over JSON-RPC, so without
+  // this buffer the desktop only sees a generic "process exited" error.
+  session.stderrTail = "";
+  session.process.stderr.on("data", (chunk) => {
+    const message = String(chunk);
+    if (!message) return;
+    session.stderrTail = (session.stderrTail + message).slice(-4096);
+    const trimmed = message.trim();
+    if (trimmed.length > 0) {
+      console.log(`${logPrefix} ${trimmed}`);
+    }
+
+    // Proactively detect auth failures from stderr while initialize is
+    // still in flight — gives the catch block a richer error to surface.
+    if (
+      !session.authErrorDetected &&
+      session.adapter.isAuthError(trimmed)
+    ) {
+      session.authErrorDetected = true;
+    }
+  });
+
+  // ChildProcess emits `error` before `close` when spawning fails. Keep an
+  // error listener installed so the provider runtime does not crash; `close`
+  // remains the single cleanup path for both spawn failures and normal exits.
+  session.process.on("error", (error) => {
+    console.error(`${logPrefix} process error: ${error.message}`);
+  });
+
+  session.process.on("close", () => {
+    const wasTracked = sessions.delete(session.id);
+    if (!wasTracked) return;
+
+    void session.serenMcpProxy?.close();
+
+    rejectPendingRequests(
+      session,
+      new Error(session.adapter.stoppedBeforeRequestMessage),
+    );
+
+    if (session.currentPrompt) {
+      rejectCurrentPrompt(
+        session,
+        new Error(session.adapter.processExitedWhilePromptMessage),
+      );
+      emit("provider://error", {
+        sessionId: session.id,
+        error: session.adapter.processExitedWhilePromptMessage,
+      });
+    }
+
+    session.status = "terminated";
+    emit("provider://session-status", {
+      sessionId: session.id,
+      status: "terminated",
+      agentSessionId: session.agentSessionId,
+    });
+  });
+}
+
+// ============================================================================
+// Public factory
+// ============================================================================
+
+export function createAcpRuntime({
+  emit,
+  runtimeMode = "provider-runtime",
+  adapter,
+}) {
+  if (!adapter?.agentType || !adapter?.agentName) {
+    throw new Error("ACP runtime requires an agent adapter.");
+  }
+
+  const sessions = new Map();
+  const agentLogPrefix = providerLogPrefix(adapter.agentType, runtimeMode);
+
+  async function spawnSession(params) {
+    const {
+      cwd,
+      localSessionId,
+      apiKey,
+      mcpServers,
+      approvalPolicy,
+      sandboxMode,
+      networkEnabled,
+      timeoutSecs,
+      initialModelId,
+    } = params;
+
+    const sessionId = localSessionId ?? randomUUID();
+    const resolvedMode = adapter.resolveInitialMode({
+      approvalPolicy,
+      sandboxMode,
+      networkEnabled,
+    });
+    const requestedModel = adapter.availableModels.some(
+      (model) => model.modelId === initialModelId,
+    )
+      ? initialModelId
+      : adapter.defaultModelId;
+    const resolvedModel = adapter.resolveInitialModelId
+      ? adapter.resolveInitialModelId(requestedModel)
+      : requestedModel;
+    let serenMcpProxy = null;
+    let mcpConfig;
+    let processHandle;
+    let session;
+    try {
+      if (apiKey) serenMcpProxy = await createSerenMcpOAuthProxy();
+      mcpConfig = buildProviderMcpConfig({
+        apiKey,
+        mcpServers,
+        serenMcpGatewayUrl: serenMcpProxy?.url,
+      });
+      processHandle = adapter.spawnProcess(cwd, {
+        extraEnv: mcpConfig.childEnv,
+        currentModeId: resolvedMode,
+        currentModelId: resolvedModel,
+        params,
+      });
+      session = createAcpSessionRecord({
+        adapter,
+        sessionId,
+        cwd,
+        processHandle,
+        timeoutSecs,
+        currentModeId: resolvedMode,
+        currentModelId: resolvedModel,
+        logPrefix: agentLogPrefix,
+        serenMcpProxy,
+      });
+
+      sessions.set(sessionId, session);
+      attachProcessListeners(emit, sessions, session);
+    } catch (error) {
+      sessions.delete(sessionId);
+      if (processHandle) killChildTree(processHandle);
+      await serenMcpProxy?.close();
+      throw error;
+    }
+
+    try {
+      // ACP step 1: initialize handshake
+      const initResult = await sendRequest(
+        session,
+        "initialize",
+        buildInitializeParams(),
+        15_000,
+      );
+      session.agentVersion = initResult?.agentInfo?.version ?? null;
+      // Per ACP, the client (us) is responsible for honoring the agent's
+      // advertised mcpCapabilities. The encoder gates optional HTTP/SSE
+      // transports so a runtime degrades cleanly instead of failing session/new.
+      const mcpCapabilities =
+        initResult?.agentCapabilities?.mcpCapabilities ?? {};
+
+      if (adapter.authenticate) {
+        await adapter.authenticate({
+          initResult,
+          session,
+          request(method, requestParams, timeoutMs) {
+            return sendRequest(session, method, requestParams, timeoutMs);
+          },
+        });
+      }
+
+      // Verify the session is still tracked before proceeding to session/new.
+      // A terminated process during init would otherwise hang on a dead pipe.
+      if (!sessions.has(sessionId)) {
+        throw new Error(
+          `${adapter.agentName} session was terminated during initialization.`,
+        );
+      }
+
+      // ACP step 2: create a new session in the requested cwd, wired up with
+      // the user's configured MCP servers. The agent child is a separate
+      // process and cannot see the Tauri-side MCP supervisor, so the
+      // wiring must be passed explicitly on every session/new.
+      const sessionResult = await sendRequest(
+        session,
+        "session/new",
+        {
+          cwd,
+          mcpServers: mcpConfig.acpMcpServers(mcpCapabilities),
+        },
+        20_000,
+      );
+
+      session.agentSessionId = sessionResult?.sessionId ?? sessionId;
+      session.status = "ready";
+
+      emit("provider://session-status", buildSessionStatus(session, "ready"));
+
+      return {
+        id: session.id,
+        agentType: session.agentType,
+        cwd: session.cwd,
+        status: session.status,
+        createdAt: session.createdAt,
+        agentSessionId: session.agentSessionId,
+        timeoutSecs: session.timeoutSecs,
+        // OS PID of the agent child, so Rust can force-kill this one session
+        // when the cooperative cancel/terminate RPCs are unreachable. #2313
+        pid: session.process?.pid ?? null,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Auth failure can surface either via the JSON-RPC error message
+      // returned by initialize/session/new OR via stderr (see attachProcessListeners
+      // — keytar/keychain failures land on stderr, not JSON-RPC).
+      const stderrTail = session.stderrTail ?? "";
+      const authFailed =
+        session.authErrorDetected ||
+        adapter.isAuthError(message) ||
+        adapter.isAuthError(stderrTail);
+
+      sessions.delete(sessionId);
+      killChildTree(processHandle);
+      await serenMcpProxy?.close();
+
+      if (authFailed) {
+        // Emit a typed event so agent.store can auto-trigger launchLogin
+        // and surface a clear next-step toast to the user. This is the
+        emit("provider://login-required", {
+          sessionId,
+          agentType: adapter.agentType,
+          reason:
+            message ||
+            stderrTail ||
+            `${adapter.agentName} authentication required.`,
+        });
+      }
+
+      emit("provider://error", {
+        sessionId,
+        error: authFailed
+          ? adapter.loginRequiredMessage
+          : message,
+      });
+      throw error;
+    }
+  }
+
+  async function sendPrompt({ sessionId, prompt, context }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No ${adapter.agentName} session: ${sessionId}`);
+    }
+    if (session.currentPrompt) {
+      throw new Error("Another prompt is already active for this session.");
+    }
+
+    // Combine optional context blocks (selected code, files) with the user
+    // prompt — same shape Codex uses for the inline context parameter.
+    const contextText = Array.isArray(context)
+      ? context
+          .map((entry) => entry?.text)
+          .filter((value) => typeof value === "string" && value.length > 0)
+          .join("\n\n")
+      : "";
+    const combinedPrompt = [contextText, prompt].filter(Boolean).join("\n\n");
+
+    session.status = "prompting";
+    emit("provider://session-status", {
+      sessionId,
+      status: "prompting",
+      agentSessionId: session.agentSessionId,
+    });
+
+    const pendingPrompt = new Promise((resolvePromise, rejectPromise) => {
+      session.currentPrompt = {
+        resolve: resolvePromise,
+        reject: rejectPromise,
+      };
+    });
+    // Four sites can reject pendingPrompt before the success-path
+    // `await pendingPrompt` below ever runs: sendPrompt's own catch,
+    // process-exit handler, cancelPrompt, and terminateSession. Without a
+    // handler here, any of those leaves pendingPrompt as an orphaned
+    // rejected promise → Node 22 unhandledRejection → the runtime process
+    // crashes, killing every session (including Claude Code) sharing the
+    // runtime. The real error still flows through `await sendRequest(...)`
+    // → catch → `throw`; this no-op handler only marks pendingPrompt as
+    // handled so the orphaned-rejection path is silent. See #1486.
+    pendingPrompt.catch(() => {});
+
+    try {
+      // ACP `session/prompt` returns when the agent finishes the turn. The
+      // streaming output arrives via session/update notifications in
+      // parallel; the response.stopReason tells us how the turn ended.
+      const response = await sendRequest(
+        session,
+        "session/prompt",
+        {
+          sessionId: session.agentSessionId ?? sessionId,
+          prompt: [{ type: "text", text: combinedPrompt }],
+        },
+        // Coding-agent turns can run for minutes on large tasks.
+        10 * 60_000,
+      );
+
+      const stopReason = response?.stopReason ?? "completed";
+      session.status = "ready";
+
+      emit("provider://prompt-complete", {
+        sessionId: session.id,
+        stopReason,
+      });
+      emit("provider://session-status", buildSessionStatus(session, "ready"));
+      resolveCurrentPrompt(session);
+
+      await pendingPrompt;
+    } catch (error) {
+      session.status = "ready";
+      rejectCurrentPrompt(
+        session,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      emit("provider://session-status", buildSessionStatus(session, "ready"));
+      throw error;
+    }
+  }
+
+  async function cancelPrompt({ sessionId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No ${adapter.agentName} session: ${sessionId}`);
+    }
+
+    const pendingPrompt = session.currentPrompt;
+
+    // ACP `session/cancel` is a notification (no id, no response).
+    writeMessage(session, {
+      jsonrpc: "2.0",
+      method: "session/cancel",
+      params: { sessionId: session.agentSessionId ?? sessionId },
+    });
+
+    // The notification has no acknowledgement. Give the agent a short grace
+    // window to actually stop — its own turn-end clears currentPrompt. If the
+    // turn is still active after the window the agent ignored the cancel, so
+    // hard-kill the child tree to guarantee it stops, mirroring the Claude and
+    // Codex cancel paths. #2304.
+    if (pendingPrompt) {
+      const settled = await waitForPromptToClear(session, pendingPrompt, 10_000);
+      if (!settled) {
+        killChildTree(session.process);
+      }
+    }
+
+    session.status = "ready";
+    emit("provider://error", { sessionId, error: "Task cancelled" });
+    emit("provider://session-status", buildSessionStatus(session, "ready"));
+    rejectCurrentPrompt(session, new Error("Task cancelled"));
+  }
+
+  async function terminateSession({ sessionId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No ${adapter.agentName} session: ${sessionId}`);
+    }
+
+    sessions.delete(sessionId);
+    rejectPendingRequests(
+      session,
+      new Error("Session terminated before request completed."),
+    );
+    rejectCurrentPrompt(session, new Error("Session terminated."));
+    try {
+      session.output.close();
+    } catch {
+      // Ignore double-close races.
+    }
+    await session.serenMcpProxy?.close();
+    killChildTree(session.process);
+    emit("provider://session-status", {
+      sessionId,
+      status: "terminated",
+      agentSessionId: session.agentSessionId,
+    });
+  }
+
+  async function listSessions() {
+    return Array.from(sessions.values()).map((session) => ({
+      id: session.id,
+      agentType: session.agentType,
+      cwd: session.cwd,
+      status: session.status,
+      createdAt: session.createdAt,
+      agentSessionId: session.agentSessionId,
+      timeoutSecs: session.timeoutSecs,
+      currentModelId: session.currentModelId,
+      currentModeId: session.currentModeId,
+      pendingPermissions: listPendingPermissions(session),
+    }));
+  }
+
+  async function setPermissionMode({ sessionId, mode }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No ${adapter.agentName} session: ${sessionId}`);
+    }
+
+    if (!adapter.validModeIds.includes(mode)) {
+      throw new Error(`Unknown ${adapter.agentName} mode: ${mode}`);
+    }
+
+    session.currentModeId = mode;
+    // ACP `session/set_mode` lets the agent know about the change too.
+    sendRequest(
+      session,
+      "session/set_mode",
+      { sessionId: session.agentSessionId, modeId: mode },
+      5_000,
+    ).catch(() => {
+      // Best-effort — older ACP agents may not support set_mode yet.
+    });
+    emit("provider://session-status", buildSessionStatus(session));
+  }
+
+  async function setOAuthRouting({ sessionId, routing }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No ${adapter.agentName} session: ${sessionId}`);
+    }
+    session.serenMcpProxy?.setRouting(routing);
+  }
+
+  async function respondToPermission({ sessionId, requestId, optionId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No ${adapter.agentName} session: ${sessionId}`);
+    }
+
+    const pending = session.pendingPermissions.get(requestId);
+    if (!pending) {
+      throw new Error(`No pending permission request: ${requestId}`);
+    }
+
+    session.pendingPermissions.delete(requestId);
+
+    // The user-supplied optionId may be the desktop's (accept/decline) form
+    // or a verbatim ACP optionId. Map decline → cancelled, anything else →
+    // selected with the matching ACP option.
+    const isDecline =
+      optionId === "decline" ||
+      optionId === "deny" ||
+      optionId === "reject" ||
+      optionId === "cancel";
+
+    let outcome;
+    if (isDecline) {
+      const rejectOption = pending.options.find(
+        (opt) => opt.kind === "reject_once" || opt.kind === "reject_always",
+      );
+      outcome = rejectOption
+        ? { outcome: "selected", optionId: rejectOption.optionId }
+        : { outcome: "cancelled" };
+    } else {
+      // Try the verbatim id first, then fall back to the first allow option.
+      const exact = pending.options.find((opt) => opt.optionId === optionId);
+      const allowOption =
+        exact ??
+        pending.options.find(
+          (opt) => opt.kind === "allow_once" || opt.kind === "allow_always",
+        );
+      outcome = allowOption
+        ? { outcome: "selected", optionId: allowOption.optionId }
+        : { outcome: "cancelled" };
+    }
+
+    writeMessage(session, {
+      jsonrpc: "2.0",
+      id: pending.jsonRpcId,
+      result: { outcome },
+    });
+  }
+
+  async function setModel({ sessionId, modelId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No ${adapter.agentName} session: ${sessionId}`);
+    }
+    const known = adapter.availableModels.find((model) => model.modelId === modelId);
+    if (!known) {
+      throw new Error(`Unknown ${adapter.agentName} model: ${modelId}`);
+    }
+    session.currentModelId = modelId;
+    emit("provider://session-status", buildSessionStatus(session));
+    await adapter.setModel?.({
+      session,
+      modelId,
+      request(method, requestParams, timeoutMs) {
+        return sendRequest(session, method, requestParams, timeoutMs);
+      },
+      logPrefix: session.logPrefix ?? agentLogPrefix,
+    });
+  }
+
+  return {
+    hasSession(sessionId) {
+      return sessions.has(sessionId);
+    },
+    spawnSession,
+    sendPrompt,
+    cancelPrompt,
+    terminateSession,
+    listSessions,
+    setPermissionMode,
+    setOAuthRouting,
+    respondToPermission,
+    setModel,
+  };
+}

--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -19,6 +19,7 @@ import {
   isBelowBaseline,
   runInstalledVersion,
 } from "./cli-updater.mjs";
+import { resolveGrokBinary } from "./grok-binary.mjs";
 
 // LM Studio support is loaded lazily so a missing LM Studio dependency (e.g.
 // @lmstudio/sdk) never crashes the registry, which every agent relies on for
@@ -306,6 +307,13 @@ function hasGeminiCredentials() {
     ]);
 }
 
+function hasGrokCredentials() {
+  return (
+    Boolean(process.env.XAI_API_KEY) ||
+    hasAnyCredentialPath([path.join(os.homedir(), ".grok", "auth.json")])
+  );
+}
+
 function isAgentAuthenticated(agentType) {
   switch (agentType) {
     case "claude-code":
@@ -314,6 +322,8 @@ function isAgentAuthenticated(agentType) {
       return hasCodexCredentials();
     case "gemini":
       return hasGeminiCredentials();
+    case "grok":
+      return hasGrokCredentials();
     case "lmstudio":
       return false;
     case "claude-codex":
@@ -1019,6 +1029,50 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         // with the WORKING binary (with compiled keytar), not the broken one.
         const resolved = resolveInstalledGeminiBinary();
         launchLoginCommand(resolved !== "gemini" ? resolved : "gemini");
+      },
+    },
+    grok: {
+      type: "grok",
+      name: "Grok",
+      description: "xAI Grok Build via Agent Client Protocol",
+      command: "grok",
+      async getAvailability() {
+        const resolved = resolveGrokBinary();
+        const installed = resolved !== "grok";
+        return {
+          type: "grok",
+          name: "Grok",
+          description: "xAI Grok Build via Agent Client Protocol",
+          command: "grok",
+          available: true,
+          authenticated: isAgentAuthenticated("grok"),
+          ...(installed
+            ? {}
+            : {
+                unavailableReason:
+                  "Grok CLI is not installed yet. Seren can install it automatically on first launch.",
+              }),
+        };
+      },
+      async canSpawn() {
+        return true;
+      },
+      async ensureCli() {
+        const resolved = resolveGrokBinary();
+        if (resolved !== "grok") {
+          return resolved;
+        }
+        await ensureGlobalNpmPackage({
+          emit,
+          command: "grok",
+          packageName: "@xai-official/grok",
+          label: "Grok",
+        });
+        return resolveGrokBinary();
+      },
+      launchLogin() {
+        const resolved = resolveGrokBinary();
+        launchLoginCommand(resolved !== "grok" ? resolved : "grok");
       },
     },
     lmstudio: {

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -1,141 +1,13 @@
-// ABOUTME: Browser-local Gemini runtime that embeds gemini-cli via ACP over stdio.
-// ABOUTME: Mirrors the Codex inline pattern in providers.mjs but speaks Agent Client Protocol.
+// ABOUTME: Gemini-specific configuration for the shared browser-local ACP runtime.
+// ABOUTME: Preserves gemini-cli resolution, modes, model metadata, and authentication behavior.
 
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
-import readline from "node:readline";
 
-import { buildProviderMcpConfig } from "./mcp-config.mjs";
-import { providerLogPrefix } from "./logging.mjs";
-import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
+import { createAcpRuntime } from "./acp-runtime.mjs";
 
-// ============================================================================
-// Binary resolution
-// ============================================================================
-
-/**
- * Resolve the installed gemini binary path. GUI apps don't inherit shell PATH
- * updates, so we check well-known npm-global install locations before falling
- * back to the bare command name.
- *
- * IMPORTANT: prefer the embedded-runtime npm install path (`<prefix>/bin/gemini`
- * on Unix, `<nodeDir>/gemini.cmd` on Windows) over ANY system install. The
- * Homebrew gemini-cli formula skips the keytar postinstall, so a Homebrew
- * binary on PATH cannot read its own keychain when spawned from a GUI app
- * and fails with "GEMINI_API_KEY environment variable" (#1476). Falling back
- * to a Homebrew install would silently break first-run auth.
- *
- * The bare "gemini" return value is the signal to the caller that no install
- * was found and ensureCli() should run.
- */
-function resolveGeminiBinary() {
-  if (process.platform === "win32") {
-    const home = os.homedir();
-    const appData = process.env.APPDATA ?? "";
-    const nodeDir = path.dirname(process.execPath);
-    const candidates = [
-      // Embedded runtime install (preferred — keytar postinstall ran here)
-      path.join(nodeDir, "gemini.cmd"),
-      path.join(nodeDir, "gemini"),
-      // System-wide npm install
-      ...(appData ? [path.join(appData, "npm", "gemini.cmd")] : []),
-      // Generic user-local fallback
-      path.join(home, ".local", "bin", "gemini.exe"),
-    ];
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) return candidate;
-    }
-  } else {
-    const nodeDir = path.dirname(process.execPath);
-    const prefix = path.dirname(nodeDir);
-    const home = os.homedir();
-    const candidates = [
-      // Embedded runtime install (preferred — keytar postinstall ran here)
-      path.join(prefix, "bin", "gemini"),
-      // Generic user-local fallback
-      path.join(home, ".local", "bin", "gemini"),
-      // NOTE: /usr/local/bin/gemini and /opt/homebrew/bin/gemini are
-      // intentionally NOT in this list. See block comment above.
-    ];
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) return candidate;
-    }
-  }
-  return "gemini";
-}
-
-// ============================================================================
-// Process helpers
-// ============================================================================
-
-function killChildTree(child) {
-  if (process.platform === "win32" && child.pid !== undefined) {
-    try {
-      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
-        stdio: "ignore",
-      });
-      return;
-    } catch {
-      // Fall through to direct kill.
-    }
-  }
-  try {
-    child.kill();
-  } catch {
-    // Ignore double-kill races during cleanup.
-  }
-}
-
-/**
- * Detect whether an error message from gemini-cli (or our own spawn pipeline)
- * indicates the user needs to run `gemini login`. Catches the literal string
- * gemini-cli prints when it cannot find credentials, the keychain failure
- * mode shipped by Homebrew's broken keytar, and the desktop's own
- * `Gemini API key is missing` wrapping.
- */
-function isAuthError(message) {
-  const lower = String(message).toLowerCase();
-  if (lower.includes("not authenticated")) return true;
-  if (lower.includes("authentication required")) return true;
-  if (lower.includes("auth required")) return true;
-  if (lower.includes("login required")) return true;
-  if (lower.includes("not logged in")) return true;
-  if (lower.includes("please run") && lower.includes("login")) return true;
-  // Verbatim gemini-cli error when GEMINI_API_KEY env var is missing AND
-  // no keychain credentials are available. (#1476)
-  if (lower.includes("gemini_api_key")) return true;
-  if (lower.includes("api key is missing")) return true;
-  if (lower.includes("api key is not configured")) return true;
-  // Homebrew's gemini-cli ships broken keytar; the keychain init failure
-  // is a leading indicator that the next request will fail with auth.
-  if (lower.includes("keychain initialization") && lower.includes("keytar")) {
-    return true;
-  }
-  return false;
-}
-
-// ============================================================================
-// ACP protocol helpers
-// ============================================================================
-
-/**
- * ACP protocol version this client implements. ACP uses uint16 versions,
- * starting at 1. Bump when gemini-cli requires a newer version.
- */
-const ACP_PROTOCOL_VERSION = 1;
-
-/**
- * Static list of supported Gemini models. ACP `initialize` does not return
- * a model list (Codex's `model/list` RPC has no equivalent in gemini-cli's
- * ACP surface), so we hardcode the publicly-available Gemini 2.5 family
- * to give the user a visible model picker. (#1480)
- *
- * Update this list when Google ships new models. Phase 2 follow-up could
- * query gemini-cli at startup if upstream adds a list endpoint.
- */
 const GEMINI_AVAILABLE_MODELS = [
   {
     modelId: "gemini-2.5-pro",
@@ -157,13 +29,54 @@ const GEMINI_AVAILABLE_MODELS = [
 const GEMINI_DEFAULT_MODEL_ID = "gemini-2.5-pro";
 
 /**
- * Map Seren's approval policies to gemini-cli's --approval-mode values.
- *   - "never" / "auto"           → "auto_edit" (auto-approve safe edits)
- *   - "on-request" / "untrusted" → "default"   (prompt for approval)
- *   - "danger-full-access"       → "yolo"       (auto-approve everything)
- *   - "read-only"                → "plan"       (read-only / plan mode)
+ * GUI apps do not inherit shell PATH updates. Prefer the embedded npm install
+ * and deliberately exclude Homebrew builds, whose skipped keytar postinstall
+ * breaks Gemini credential access when launched by the desktop. #1476.
  */
-function geminiApprovalMode(approvalPolicy, sandboxMode) {
+function resolveGeminiBinary() {
+  if (process.platform === "win32") {
+    const home = os.homedir();
+    const appData = process.env.APPDATA ?? "";
+    const nodeDir = path.dirname(process.execPath);
+    const candidates = [
+      path.join(nodeDir, "gemini.cmd"),
+      path.join(nodeDir, "gemini"),
+      ...(appData ? [path.join(appData, "npm", "gemini.cmd")] : []),
+      path.join(home, ".local", "bin", "gemini.exe"),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return candidate;
+    }
+  } else {
+    const nodeDir = path.dirname(process.execPath);
+    const prefix = path.dirname(nodeDir);
+    const home = os.homedir();
+    const candidates = [
+      path.join(prefix, "bin", "gemini"),
+      path.join(home, ".local", "bin", "gemini"),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return "gemini";
+}
+
+function isGeminiAuthError(message) {
+  const lower = String(message).toLowerCase();
+  if (lower.includes("not authenticated")) return true;
+  if (lower.includes("authentication required")) return true;
+  if (lower.includes("auth required")) return true;
+  if (lower.includes("login required")) return true;
+  if (lower.includes("not logged in")) return true;
+  if (lower.includes("please run") && lower.includes("login")) return true;
+  if (lower.includes("gemini_api_key")) return true;
+  if (lower.includes("api key is missing")) return true;
+  if (lower.includes("api key is not configured")) return true;
+  return lower.includes("keychain initialization") && lower.includes("keytar");
+}
+
+function resolveGeminiMode({ approvalPolicy, sandboxMode }) {
   if (sandboxMode === "read-only") return "plan";
   if (sandboxMode === "danger-full-access") return "yolo";
   if (approvalPolicy === "on-request" || approvalPolicy === "untrusted") {
@@ -172,11 +85,7 @@ function geminiApprovalMode(approvalPolicy, sandboxMode) {
   return "auto_edit";
 }
 
-/**
- * Build the available approval modes that the desktop UI can switch between
- * for a Gemini session. Mirrors the Codex `availableModes` shape.
- */
-function geminiModes(session) {
+function buildGeminiModes(session) {
   return {
     currentModeId: session?.currentModeId ?? "default",
     availableModes: [
@@ -204,34 +113,11 @@ function geminiModes(session) {
   };
 }
 
-function buildInitializeParams() {
-  return {
-    protocolVersion: ACP_PROTOCOL_VERSION,
-    clientInfo: {
-      name: "seren_provider_runtime",
-      title: "Seren Provider Runtime",
-      version: "0.1.0",
-    },
-    clientCapabilities: {
-      // We don't expose terminal/fs capabilities to the agent — the desktop
-      // mediates these via the existing approval UI and provider events.
-      fs: { readTextFile: false, writeTextFile: false },
-      terminal: false,
-    },
-  };
-}
-
-// ============================================================================
-// Spawn / session record
-// ============================================================================
-
 function spawnGeminiProcess(cwd, { extraEnv = {} } = {}) {
-  const binary = resolveGeminiBinary();
-  return spawn(binary, ["--acp"], {
+  return spawn(resolveGeminiBinary(), ["--acp"], {
     cwd,
     env: {
       ...process.env,
-      // Force unbuffered stdout so the parent reads ACP messages promptly.
       NODE_NO_READLINE: "1",
       ...extraEnv,
     },
@@ -240,897 +126,37 @@ function spawnGeminiProcess(cwd, { extraEnv = {} } = {}) {
   });
 }
 
-function createGeminiSessionRecord({
-  sessionId,
-  cwd,
-  processHandle,
-  timeoutSecs,
-  currentModeId,
-  logPrefix,
-  serenMcpProxy = null,
-}) {
-  return {
-    id: sessionId,
-    agentType: "gemini",
-    cwd,
-    status: "initializing",
-    createdAt: new Date().toISOString(),
-    process: processHandle,
-    output: readline.createInterface({ input: processHandle.stdout }),
-    pendingRequests: new Map(),
-    nextRequestId: 1,
-    pendingPermissions: new Map(),
-    logPrefix,
-    currentPrompt: null,
-    agentSessionId: undefined,
-    timeoutSecs: timeoutSecs ?? undefined,
-    geminiVersion: null,
-    currentModeId: currentModeId ?? "default",
-    // Default to Gemini 2.5 Pro until the user picks something else.
-    // Switching is wired through setSessionModel; the runtime persists
-    // the choice but does NOT yet re-spawn gemini-cli with --model
-    // (phase 2 of #1480 follow-up).
-    currentModelId: GEMINI_DEFAULT_MODEL_ID,
-    serenMcpProxy,
-  };
-}
-
-// ============================================================================
-// JSON-RPC framing (newline-delimited JSON over stdio)
-// ============================================================================
-
-function sendRequest(session, method, params, timeoutMs = 30_000) {
-  const id = session.nextRequestId;
-  session.nextRequestId += 1;
-
-  const payload = {
-    jsonrpc: "2.0",
-    id,
-    method,
-    params,
-  };
-
-  return new Promise((resolvePromise, rejectPromise) => {
-    const timeout = setTimeout(() => {
-      session.pendingRequests.delete(String(id));
-      rejectPromise(new Error(`Timed out waiting for ${method}.`));
-    }, timeoutMs);
-
-    session.pendingRequests.set(String(id), {
-      method,
-      timeout,
-      resolve: resolvePromise,
-      reject: rejectPromise,
-    });
-
-    session.process.stdin.write(`${JSON.stringify(payload)}\n`);
-  });
-}
-
-function writeMessage(session, message) {
-  session.process.stdin.write(`${JSON.stringify(message)}\n`);
-}
-
-function rejectPendingRequests(session, error) {
-  for (const [key, pending] of session.pendingRequests) {
-    clearTimeout(pending.timeout);
-    pending.reject(error);
-    session.pendingRequests.delete(key);
-  }
-}
-
-function rejectCurrentPrompt(session, error) {
-  if (!session.currentPrompt) return;
-  const pending = session.currentPrompt;
-  session.currentPrompt = null;
-  pending.reject(error);
-}
-
-function resolveCurrentPrompt(session) {
-  if (!session.currentPrompt) return;
-  const pending = session.currentPrompt;
-  session.currentPrompt = null;
-  pending.resolve();
-}
-
-// Resolve true once `pendingPrompt` is no longer the session's active prompt
-// (the agent settled the turn — resolve or reject clears currentPrompt), or
-// false if `timeoutMs` elapses first. Used to detect whether a cooperative
-// cancel actually stopped the turn before escalating to a hard kill.
-function waitForPromptToClear(session, pendingPrompt, timeoutMs) {
-  if (session.currentPrompt !== pendingPrompt) return Promise.resolve(true);
-  return new Promise((resolve) => {
-    const deadline = setTimeout(() => {
-      clearInterval(poll);
-      resolve(false);
-    }, timeoutMs);
-    const poll = setInterval(() => {
-      if (session.currentPrompt !== pendingPrompt) {
-        clearInterval(poll);
-        clearTimeout(deadline);
-        resolve(true);
-      }
-    }, 100);
-  });
-}
-
-function handleResponse(session, payload) {
-  const pending = session.pendingRequests.get(String(payload.id));
-  if (!pending) return;
-
-  clearTimeout(pending.timeout);
-  session.pendingRequests.delete(String(payload.id));
-
-  if (payload.error?.message) {
-    pending.reject(
-      new Error(`${pending.method} failed: ${payload.error.message}`),
-    );
-    return;
-  }
-
-  pending.resolve(payload.result);
-}
-
-// ============================================================================
-// ACP → provider:// event translation
-// ============================================================================
-
-/**
- * Extract a text string from an ACP ContentBlock or array of blocks.
- * The agent emits ContentBlocks in `agent_message_chunk.content` and
- * `agent_thought_chunk.content`. We only render text blocks today.
- */
-function contentBlockText(content) {
-  if (typeof content === "string") return content;
-  if (!content || typeof content !== "object") return "";
-  if (content.type === "text" && typeof content.text === "string") {
-    return content.text;
-  }
-  if (Array.isArray(content)) {
-    return content
-      .map((block) => contentBlockText(block))
-      .filter(Boolean)
-      .join("");
-  }
-  return "";
-}
-
-/**
- * ACP `tool_call` and `tool_call_update` updates carry a ToolCallContent[]
- * array. We flatten any text/diff/terminal output into a single string for
- * the existing provider://tool-result event format.
- */
-function flattenToolCallContent(content) {
-  if (!Array.isArray(content)) return undefined;
-  const parts = [];
-  for (const block of content) {
-    if (!block || typeof block !== "object") continue;
-    if (block.type === "text" && typeof block.text === "string") {
-      parts.push(block.text);
-    } else if (block.type === "diff") {
-      parts.push(JSON.stringify(block));
-    }
-  }
-  return parts.length > 0 ? parts.join("\n") : undefined;
-}
-
-function emitToolCallUpdate(emit, session, update) {
-  const toolCallId = String(update.toolCallId ?? randomUUID());
-  const status = update.status ?? "running";
-  // ACP ToolCallContent supports text/image/diff/resource/terminal — for
-  // active sessions we surface the title + raw input on the call event and
-  // the flattened content on the result event below.
-  emit("provider://tool-call", {
-    sessionId: session.id,
-    toolCallId,
-    title: update.title ?? update.name ?? "Tool call",
-    kind: update.name ?? "tool",
-    status,
-    parameters: update,
-  });
-
-  // Terminal/completed updates also produce a tool-result so the desktop's
-  // existing approval UI can render the output.
-  if (status === "completed" || status === "error") {
-    emit("provider://tool-result", {
-      sessionId: session.id,
-      toolCallId,
-      status,
-      result: flattenToolCallContent(update.content),
-      error:
-        status === "error"
-          ? update.result?.error ?? "Tool call failed"
-          : undefined,
-    });
-  }
-}
-
-function handleSessionUpdate(emit, session, params) {
-  const update = params?.update ?? {};
-  const type = update.type ?? update.sessionUpdate;
-
-  switch (type) {
-    case "agent_message_chunk": {
-      const text = contentBlockText(update.content);
-      if (text) {
-        emit("provider://message-chunk", { sessionId: session.id, text });
-      }
-      return;
-    }
-
-    case "agent_thought_chunk": {
-      const text = contentBlockText(update.content);
-      if (text) {
-        emit("provider://message-chunk", {
-          sessionId: session.id,
-          text,
-          isThought: true,
-        });
-      }
-      return;
-    }
-
-    case "tool_call":
-    case "tool_call_update":
-      emitToolCallUpdate(emit, session, update);
-      return;
-
-    case "plan": {
-      const entries = Array.isArray(update.entries) ? update.entries : [];
-      emit("provider://plan-update", {
-        sessionId: session.id,
-        entries: entries.map((entry) => ({
-          content: entry.content ?? entry.title ?? "Untitled step",
-          status:
-            entry.status ??
-            (entry.completed === true ? "completed" : "pending"),
-        })),
-      });
-      return;
-    }
-
-    case "current_mode_update": {
-      if (typeof update.modeId === "string") {
-        session.currentModeId = update.modeId;
-        emit("provider://session-status", buildSessionStatus(session));
-      }
-      return;
-    }
-
-    default:
-      // Unknown update types are ignored — gemini-cli may add new ones over
-      // time and we don't want to crash on unfamiliar shapes.
-      return;
-  }
-}
-
-/**
- * Handle an inbound ACP request from the agent. Today the only one we expect
- * is `session/request_permission` for tool approvals.
- */
-function buildPermissionRequestEvent(session, requestId, params) {
-  return {
-    sessionId: session.id,
-    requestId,
-    toolCall: {
-      name: params.toolCall?.name ?? "tool",
-      title: params.toolCall?.title ?? "Tool call",
-      input: params.toolCall ?? {},
-    },
-    options: (params.options ?? []).map((opt) => ({
-      optionId: opt.optionId,
-      label: opt.name ?? opt.optionId,
-      description: opt.kind,
-    })),
-  };
-}
-
-function listPendingPermissions(session) {
-  return Array.from(session.pendingPermissions.values()).map(
-    (pending) => pending.permissionRequest,
-  );
-}
-
-function handleAgentRequest(emit, session, payload) {
-  if (payload.method === "session/request_permission") {
-    const params = payload.params ?? {};
-    const requestId = randomUUID();
-    const permissionRequest = buildPermissionRequestEvent(
-      session,
-      requestId,
-      params,
-    );
-    session.pendingPermissions.set(requestId, {
-      requestId,
-      jsonRpcId: payload.id,
-      // Store the ACP option list verbatim so respondToPermission can map
-      // a desktop optionId back to the agent's expected outcome.
-      options: Array.isArray(params.options) ? params.options : [],
-      permissionRequest,
-    });
-
-    // Auto-approve in YOLO / auto_edit mode for non-destructive tools.
-    // This mirrors how Codex handles "auto" mode in providers.mjs.
-    if (session.currentModeId === "yolo") {
-      const allowOption = (params.options ?? []).find(
-        (opt) => opt.kind === "allow_once" || opt.kind === "allow_always",
-      );
-      writeMessage(session, {
-        jsonrpc: "2.0",
-        id: payload.id,
-        result: {
-          outcome: allowOption
-            ? { outcome: "selected", optionId: allowOption.optionId }
-            : { outcome: "cancelled" },
-        },
-      });
-      session.pendingPermissions.delete(requestId);
-      return;
-    }
-
-    emit("provider://permission-request", permissionRequest);
-    return;
-  }
-
-  // Unknown request — respond with method-not-found so the agent doesn't
-  // hang waiting for a reply.
-  writeMessage(session, {
-    jsonrpc: "2.0",
-    id: payload.id,
-    error: {
-      code: -32601,
-      message: `Method not implemented: ${payload.method}`,
-    },
-  });
-}
-
-function handleNotification(emit, session, payload) {
-  const method = payload.method;
-  const params = payload.params ?? {};
-
-  if (method === "session/update") {
-    handleSessionUpdate(emit, session, params);
-    return;
-  }
-  // Other notifications (cancel, etc.) are agent→client info we don't act on.
-}
-
-function handleLine(emit, session, line) {
-  let payload;
-  try {
-    payload = JSON.parse(line);
-  } catch {
-    // gemini-cli occasionally writes diagnostic strings to stdout. Ignore
-    // anything that isn't a valid JSON-RPC frame.
-    return;
-  }
-
-  if (payload.id != null && payload.method) {
-    handleAgentRequest(emit, session, payload);
-    return;
-  }
-  if (payload.id != null) {
-    handleResponse(session, payload);
-    return;
-  }
-  if (payload.method) {
-    handleNotification(emit, session, payload);
-  }
-}
-
-// ============================================================================
-// Session status payloads
-// ============================================================================
-
-function buildSessionStatus(session, status = session.status) {
-  return {
-    sessionId: session.id,
-    status,
-    agentSessionId: session.agentSessionId,
-    agentInfo: {
-      name: "Gemini ACP",
-      version: session.geminiVersion ?? "unknown",
-    },
-    models: {
-      currentModelId: session.currentModelId ?? GEMINI_DEFAULT_MODEL_ID,
-      availableModels: GEMINI_AVAILABLE_MODELS,
-    },
-    modes: geminiModes(session),
-    configOptions: [],
-  };
-}
-
-function attachProcessListeners(emit, sessions, session) {
-  const logPrefix = session.logPrefix ?? providerLogPrefix("gemini");
-  session.output.on("line", (line) => handleLine(emit, session, line));
-
-  // Buffer the latest stderr lines so the spawn-time catch block has
-  // something to inspect when the JSON-RPC initialize call fails. gemini-cli
-  // writes its auth/keychain errors to stderr, not over JSON-RPC, so without
-  // this buffer the desktop only sees a generic "process exited" error.
-  session.stderrTail = "";
-  session.process.stderr.on("data", (chunk) => {
-    const message = String(chunk);
-    if (!message) return;
-    session.stderrTail = (session.stderrTail + message).slice(-4096);
-    const trimmed = message.trim();
-    if (trimmed.length > 0) {
-      console.log(`${logPrefix} ${trimmed}`);
-    }
-
-    // Proactively detect auth failures from stderr while initialize is
-    // still in flight — gives the catch block a richer error to surface.
-    if (!session.authErrorDetected && isAuthError(trimmed)) {
-      session.authErrorDetected = true;
-    }
-  });
-
-  // ChildProcess emits `error` before `close` when spawning fails. Keep an
-  // error listener installed so the provider runtime does not crash; `close`
-  // remains the single cleanup path for both spawn failures and normal exits.
-  session.process.on("error", (error) => {
-    console.error(`${logPrefix} process error: ${error.message}`);
-  });
-
-  session.process.on("close", () => {
-    const wasTracked = sessions.delete(session.id);
-    if (!wasTracked) return;
-
-    void session.serenMcpProxy?.close();
-
-    rejectPendingRequests(
-      session,
-      new Error("Gemini agent stopped before request completed."),
-    );
-
-    if (session.currentPrompt) {
-      rejectCurrentPrompt(
-        session,
-        new Error("Gemini process exited while prompt was active."),
-      );
-      emit("provider://error", {
-        sessionId: session.id,
-        error: "Gemini process exited while prompt was active.",
-      });
-    }
-
-    session.status = "terminated";
-    emit("provider://session-status", {
-      sessionId: session.id,
-      status: "terminated",
-      agentSessionId: session.agentSessionId,
-    });
-  });
-}
-
-// ============================================================================
-// Public factory
-// ============================================================================
-
-export function createGeminiRuntime({ emit, runtimeMode = "provider-runtime" }) {
-  const sessions = new Map();
-  const geminiLogPrefix = providerLogPrefix("gemini", runtimeMode);
-
-  async function spawnSession(params) {
-    const {
-      cwd,
-      localSessionId,
-      apiKey,
-      mcpServers,
-      approvalPolicy,
-      sandboxMode,
-      networkEnabled,
-      timeoutSecs,
-    } = params;
-
-    const sessionId = localSessionId ?? randomUUID();
-    const resolvedMode = geminiApprovalMode(approvalPolicy, sandboxMode);
-    let serenMcpProxy = null;
-    let mcpConfig;
-    let processHandle;
-    let session;
-    try {
-      if (apiKey) serenMcpProxy = await createSerenMcpOAuthProxy();
-      mcpConfig = buildProviderMcpConfig({
-        apiKey,
-        mcpServers,
-        serenMcpGatewayUrl: serenMcpProxy?.url,
-      });
-      processHandle = spawnGeminiProcess(cwd, {
-        extraEnv: mcpConfig.childEnv,
-      });
-      session = createGeminiSessionRecord({
-        sessionId,
-        cwd,
-        processHandle,
-        timeoutSecs,
-        currentModeId: resolvedMode,
-        logPrefix: geminiLogPrefix,
-        serenMcpProxy,
-      });
-
-      sessions.set(sessionId, session);
-      attachProcessListeners(emit, sessions, session);
-    } catch (error) {
-      sessions.delete(sessionId);
-      if (processHandle) killChildTree(processHandle);
-      await serenMcpProxy?.close();
-      throw error;
-    }
-
-    try {
-      // ACP step 1: initialize handshake
-      const initResult = await sendRequest(
-        session,
-        "initialize",
-        buildInitializeParams(),
-        15_000,
-      );
-      session.geminiVersion = initResult?.agentInfo?.version ?? null;
-      // Per ACP, the client (us) is responsible for honoring the agent's
-      // advertised mcpCapabilities. gemini-cli v0.41.x advertises
-      // { http: true, sse: true }; we still gate here so a future build
-      // that drops one of those degrades cleanly instead of erroring on
-      // session/new. Stdio MCP is mandatory and does not need a flag.
-      const mcpCapabilities =
-        initResult?.agentCapabilities?.mcpCapabilities ?? {};
-
-      // Verify the session is still tracked before proceeding to session/new.
-      // A terminated process during init would otherwise hang on a dead pipe.
-      if (!sessions.has(sessionId)) {
-        throw new Error("Gemini session was terminated during initialization.");
-      }
-
-      // ACP step 2: create a new session in the requested cwd, wired up with
-      // the user's configured MCP servers (#1887). The gemini-cli child is a
-      // separate process and cannot see the Tauri-side MCP supervisor, so the
-      // wiring must be passed explicitly on every session/new.
-      const sessionResult = await sendRequest(
-        session,
-        "session/new",
-        {
-          cwd,
-          mcpServers: mcpConfig.geminiMcpServers(mcpCapabilities),
-        },
-        20_000,
-      );
-
-      session.agentSessionId = sessionResult?.sessionId ?? sessionId;
-      session.status = "ready";
-
-      emit("provider://session-status", buildSessionStatus(session, "ready"));
-
-      return {
-        id: session.id,
-        agentType: session.agentType,
-        cwd: session.cwd,
-        status: session.status,
-        createdAt: session.createdAt,
-        agentSessionId: session.agentSessionId,
-        timeoutSecs: session.timeoutSecs,
-        // OS PID of the agent child, so Rust can force-kill this one session
-        // when the cooperative cancel/terminate RPCs are unreachable. #2313
-        pid: session.process?.pid ?? null,
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      // Auth failure can surface either via the JSON-RPC error message
-      // returned by initialize/session/new OR via stderr (see attachProcessListeners
-      // — keytar/keychain failures land on stderr, not JSON-RPC).
-      const stderrTail = session.stderrTail ?? "";
-      const authFailed =
-        session.authErrorDetected ||
-        isAuthError(message) ||
-        isAuthError(stderrTail);
-
-      sessions.delete(sessionId);
-      killChildTree(processHandle);
-      await serenMcpProxy?.close();
-
-      if (authFailed) {
-        // Emit a typed event so agent.store can auto-trigger launchLogin
-        // and surface a clear next-step toast to the user. This is the
-        // Gemini equivalent of Claude/Codex's first-spawn login prompt.
-        emit("provider://login-required", {
-          sessionId,
-          agentType: "gemini",
-          reason: message || stderrTail || "Gemini authentication required.",
-        });
-      }
-
-      emit("provider://error", {
-        sessionId,
-        error: authFailed
-          ? "Gemini authentication required. Opening `gemini login` in a Terminal window — finish the sign-in there, then click + New Agent → Gemini Agent again."
-          : message,
-      });
-      throw error;
-    }
-  }
-
-  async function sendPrompt({ sessionId, prompt, context }) {
-    const session = sessions.get(sessionId);
-    if (!session) {
-      throw new Error(`No Gemini session: ${sessionId}`);
-    }
-    if (session.currentPrompt) {
-      throw new Error("Another prompt is already active for this session.");
-    }
-
-    // Combine optional context blocks (selected code, files) with the user
-    // prompt — same shape Codex uses for the inline context parameter.
-    const contextText = Array.isArray(context)
-      ? context
-          .map((entry) => entry?.text)
-          .filter((value) => typeof value === "string" && value.length > 0)
-          .join("\n\n")
-      : "";
-    const combinedPrompt = [contextText, prompt].filter(Boolean).join("\n\n");
-
-    session.status = "prompting";
-    emit("provider://session-status", {
-      sessionId,
-      status: "prompting",
-      agentSessionId: session.agentSessionId,
-    });
-
-    const pendingPrompt = new Promise((resolvePromise, rejectPromise) => {
-      session.currentPrompt = {
-        resolve: resolvePromise,
-        reject: rejectPromise,
-      };
-    });
-    // Four sites can reject pendingPrompt before the success-path
-    // `await pendingPrompt` below ever runs: sendPrompt's own catch,
-    // process-exit handler, cancelPrompt, and terminateSession. Without a
-    // handler here, any of those leaves pendingPrompt as an orphaned
-    // rejected promise → Node 22 unhandledRejection → the runtime process
-    // crashes, killing every session (including Claude Code) sharing the
-    // runtime. The real error still flows through `await sendRequest(...)`
-    // → catch → `throw`; this no-op handler only marks pendingPrompt as
-    // handled so the orphaned-rejection path is silent. See #1486.
-    pendingPrompt.catch(() => {});
-
-    try {
-      // ACP `session/prompt` returns when the agent finishes the turn. The
-      // streaming output arrives via session/update notifications in
-      // parallel; the response.stopReason tells us how the turn ended.
-      const response = await sendRequest(
-        session,
-        "session/prompt",
-        {
-          sessionId: session.agentSessionId ?? sessionId,
-          prompt: [{ type: "text", text: combinedPrompt }],
-        },
-        // Long timeout — Gemini turns can run minutes for big tasks. The
-        // upstream WebSocket layer also has a 10-minute overall request cap.
-        10 * 60_000,
-      );
-
-      const stopReason = response?.stopReason ?? "completed";
-      session.status = "ready";
-
-      emit("provider://prompt-complete", {
-        sessionId: session.id,
-        stopReason,
-      });
-      emit("provider://session-status", buildSessionStatus(session, "ready"));
-      resolveCurrentPrompt(session);
-
-      await pendingPrompt;
-    } catch (error) {
-      session.status = "ready";
-      rejectCurrentPrompt(
-        session,
-        error instanceof Error ? error : new Error(String(error)),
-      );
-      emit("provider://session-status", buildSessionStatus(session, "ready"));
-      throw error;
-    }
-  }
-
-  async function cancelPrompt({ sessionId }) {
-    const session = sessions.get(sessionId);
-    if (!session) {
-      throw new Error(`No Gemini session: ${sessionId}`);
-    }
-
-    const pendingPrompt = session.currentPrompt;
-
-    // ACP `session/cancel` is a notification (no id, no response).
-    writeMessage(session, {
-      jsonrpc: "2.0",
-      method: "session/cancel",
-      params: { sessionId: session.agentSessionId ?? sessionId },
-    });
-
-    // The notification has no acknowledgement. Give the agent a short grace
-    // window to actually stop — its own turn-end clears currentPrompt. If the
-    // turn is still active after the window the agent ignored the cancel, so
-    // hard-kill the child tree to guarantee it stops, mirroring the Claude and
-    // Codex cancel paths. #2304.
-    if (pendingPrompt) {
-      const settled = await waitForPromptToClear(session, pendingPrompt, 10_000);
-      if (!settled) {
-        killChildTree(session.process);
-      }
-    }
-
-    session.status = "ready";
-    emit("provider://error", { sessionId, error: "Task cancelled" });
-    emit("provider://session-status", buildSessionStatus(session, "ready"));
-    rejectCurrentPrompt(session, new Error("Task cancelled"));
-  }
-
-  async function terminateSession({ sessionId }) {
-    const session = sessions.get(sessionId);
-    if (!session) {
-      throw new Error(`No Gemini session: ${sessionId}`);
-    }
-
-    sessions.delete(sessionId);
-    rejectPendingRequests(
-      session,
-      new Error("Session terminated before request completed."),
-    );
-    rejectCurrentPrompt(session, new Error("Session terminated."));
-    try {
-      session.output.close();
-    } catch {
-      // Ignore double-close races.
-    }
-    await session.serenMcpProxy?.close();
-    killChildTree(session.process);
-    emit("provider://session-status", {
-      sessionId,
-      status: "terminated",
-      agentSessionId: session.agentSessionId,
-    });
-  }
-
-  async function listSessions() {
-    return Array.from(sessions.values()).map((session) => ({
-      id: session.id,
-      agentType: session.agentType,
-      cwd: session.cwd,
-      status: session.status,
-      createdAt: session.createdAt,
-      agentSessionId: session.agentSessionId,
-      timeoutSecs: session.timeoutSecs,
-      currentModelId: session.currentModelId,
-      currentModeId: session.currentModeId,
-      pendingPermissions: listPendingPermissions(session),
-    }));
-  }
-
-  async function setPermissionMode({ sessionId, mode }) {
-    const session = sessions.get(sessionId);
-    if (!session) {
-      throw new Error(`No Gemini session: ${sessionId}`);
-    }
-
-    // Validate against the four modes geminiModes() advertises.
-    const valid = ["default", "auto_edit", "yolo", "plan"];
-    if (!valid.includes(mode)) {
-      throw new Error(`Unknown Gemini mode: ${mode}`);
-    }
-
-    session.currentModeId = mode;
-    // ACP `session/set_mode` lets the agent know about the change too.
-    sendRequest(
-      session,
-      "session/set_mode",
-      { sessionId: session.agentSessionId, modeId: mode },
-      5_000,
-    ).catch(() => {
-      // Best-effort — older gemini-cli builds may not support set_mode yet.
-    });
-    emit("provider://session-status", buildSessionStatus(session));
-  }
-
-  async function setOAuthRouting({ sessionId, routing }) {
-    const session = sessions.get(sessionId);
-    if (!session) {
-      throw new Error(`No Gemini session: ${sessionId}`);
-    }
-    session.serenMcpProxy?.setRouting(routing);
-  }
-
-  async function respondToPermission({ sessionId, requestId, optionId }) {
-    const session = sessions.get(sessionId);
-    if (!session) {
-      throw new Error(`No Gemini session: ${sessionId}`);
-    }
-
-    const pending = session.pendingPermissions.get(requestId);
-    if (!pending) {
-      throw new Error(`No pending permission request: ${requestId}`);
-    }
-
-    session.pendingPermissions.delete(requestId);
-
-    // The user-supplied optionId may be the desktop's (accept/decline) form
-    // or a verbatim ACP optionId. Map decline → cancelled, anything else →
-    // selected with the matching ACP option.
-    const isDecline =
-      optionId === "decline" ||
-      optionId === "deny" ||
-      optionId === "reject" ||
-      optionId === "cancel";
-
-    let outcome;
-    if (isDecline) {
-      const rejectOption = pending.options.find(
-        (opt) => opt.kind === "reject_once" || opt.kind === "reject_always",
-      );
-      outcome = rejectOption
-        ? { outcome: "selected", optionId: rejectOption.optionId }
-        : { outcome: "cancelled" };
-    } else {
-      // Try the verbatim id first, then fall back to the first allow option.
-      const exact = pending.options.find((opt) => opt.optionId === optionId);
-      const allowOption =
-        exact ??
-        pending.options.find(
-          (opt) => opt.kind === "allow_once" || opt.kind === "allow_always",
-        );
-      outcome = allowOption
-        ? { outcome: "selected", optionId: allowOption.optionId }
-        : { outcome: "cancelled" };
-    }
-
-    writeMessage(session, {
-      jsonrpc: "2.0",
-      id: pending.jsonRpcId,
-      result: { outcome },
-    });
-  }
-
-  /**
-   * Update the active model for a Gemini session. Persists the choice on the
-   * session record and emits a status update so the UI re-renders the picker.
-   *
-   * Phase 1 (this PR): the choice is persisted but is not yet sent to
-   * gemini-cli — Gemini's --model flag is set at spawn time, so changing
-   * models mid-session would require re-spawning the process. Phase 2
-   * follow-up will plumb this through.
-   */
-  async function setModel({ sessionId, modelId }) {
-    const session = sessions.get(sessionId);
-    if (!session) {
-      throw new Error(`No Gemini session: ${sessionId}`);
-    }
-    const known = GEMINI_AVAILABLE_MODELS.find((m) => m.modelId === modelId);
-    if (!known) {
-      throw new Error(`Unknown Gemini model: ${modelId}`);
-    }
-    session.currentModelId = modelId;
-    emit("provider://session-status", buildSessionStatus(session));
-    // Phase 1 limitation: Gemini's --model flag is set at spawn time. The
-    // running gemini-cli process keeps its spawn-time model regardless of
-    // this assignment; the picker change only takes effect on the next
-    // session spawn. Surface this so the user can see the disconnect in
-    // logs instead of silently sending prompts to the wrong model. #1718.
-    const logPrefix = session.logPrefix ?? geminiLogPrefix;
+const GEMINI_ADAPTER = {
+  agentType: "gemini",
+  agentName: "Gemini",
+  agentInfoName: "Gemini ACP",
+  defaultModelId: GEMINI_DEFAULT_MODEL_ID,
+  availableModels: GEMINI_AVAILABLE_MODELS,
+  // Preserve Gemini's pre-refactor behavior: the ACP process does not receive
+  // an initial model and every fresh session starts on the static default.
+  resolveInitialModelId: () => GEMINI_DEFAULT_MODEL_ID,
+  defaultModeId: "default",
+  validModeIds: ["default", "auto_edit", "yolo", "plan"],
+  autoApproveModeIds: ["yolo"],
+  buildModes: buildGeminiModes,
+  resolveInitialMode: resolveGeminiMode,
+  spawnProcess: spawnGeminiProcess,
+  isAuthError: isGeminiAuthError,
+  stoppedBeforeRequestMessage:
+    "Gemini agent stopped before request completed.",
+  processExitedWhilePromptMessage:
+    "Gemini process exited while prompt was active.",
+  loginRequiredMessage:
+    "Gemini authentication required. Opening `gemini login` in a Terminal window — finish the sign-in there, then click + New Agent → Gemini Agent again.",
+  async setModel({ modelId, logPrefix }) {
     console.warn(
       `${logPrefix} setModel: ${modelId} stored as session intent — ` +
         "no-op against the running CLI process (Gemini --model is fixed at " +
         "spawn time). The next session spawn will use this model.",
     );
-  }
+  },
+};
 
-  return {
-    hasSession(sessionId) {
-      return sessions.has(sessionId);
-    },
-    spawnSession,
-    sendPrompt,
-    cancelPrompt,
-    terminateSession,
-    listSessions,
-    setPermissionMode,
-    setOAuthRouting,
-    respondToPermission,
-    setModel,
-  };
+export function createGeminiRuntime(options) {
+  return createAcpRuntime({ ...options, adapter: GEMINI_ADAPTER });
 }

--- a/bin/browser-local/grok-binary.mjs
+++ b/bin/browser-local/grok-binary.mjs
@@ -1,0 +1,40 @@
+// ABOUTME: Resolves the Grok CLI across Seren's embedded npm prefix and official install paths.
+// ABOUTME: Keeps registry availability, login, installation, and runtime spawn on the same executable.
+
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export function resolveGrokBinary() {
+  const home = os.homedir();
+  const nodeDir = path.dirname(process.execPath);
+
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA ?? "";
+    const candidates = [
+      path.join(nodeDir, "grok.cmd"),
+      path.join(nodeDir, "grok.exe"),
+      path.join(nodeDir, "grok"),
+      path.join(home, ".grok", "bin", "grok.exe"),
+      ...(appData ? [path.join(appData, "npm", "grok.cmd")] : []),
+      path.join(home, ".local", "bin", "grok.exe"),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return candidate;
+    }
+    return "grok";
+  }
+
+  const prefix = path.dirname(nodeDir);
+  const candidates = [
+    path.join(prefix, "bin", "grok"),
+    path.join(home, ".grok", "bin", "grok"),
+    path.join(home, ".local", "bin", "grok"),
+    "/usr/local/bin/grok",
+    "/opt/homebrew/bin/grok",
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return "grok";
+}

--- a/bin/browser-local/grok-binary.mjs
+++ b/bin/browser-local/grok-binary.mjs
@@ -1,21 +1,49 @@
 // ABOUTME: Resolves the Grok CLI across Seren's embedded npm prefix and official install paths.
 // ABOUTME: Keeps registry availability, login, installation, and runtime spawn on the same executable.
 
-import { existsSync } from "node:fs";
+import { existsSync, lstatSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-export function resolveGrokBinary() {
-  const home = os.homedir();
-  const nodeDir = path.dirname(process.execPath);
+function isSymlink(candidate) {
+  try {
+    return lstatSync(candidate).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
 
-  if (process.platform === "win32") {
-    const appData = process.env.APPDATA ?? "";
+export function resolveGrokBinary({
+  execPath = process.execPath,
+  platform = process.platform,
+  arch = process.arch,
+  home = os.homedir(),
+  appData = process.env.APPDATA ?? "",
+} = {}) {
+  const nodeDir = path.dirname(execPath);
+  const executableName = platform === "win32" ? "grok.exe" : "grok";
+  const npmPrefix = platform === "win32" ? nodeDir : path.dirname(nodeDir);
+  const embeddedNative = path.join(
+    npmPrefix,
+    platform === "win32" ? "node_modules" : "lib/node_modules",
+    "@xai-official",
+    "grok",
+    "node_modules",
+    "@xai-official",
+    `grok-${platform}-${arch}`,
+    "bin",
+    executableName,
+  );
+
+  if (platform === "win32") {
     const candidates = [
+      // Prefer the package-owned native binary. Unlike npm's command shim it
+      // remains executable after Tauri relocates embedded resources. #3088.
+      embeddedNative,
+      path.join(home, ".grok", "bin", "grok.exe"),
       path.join(nodeDir, "grok.cmd"),
       path.join(nodeDir, "grok.exe"),
       path.join(nodeDir, "grok"),
-      path.join(home, ".grok", "bin", "grok.exe"),
       ...(appData ? [path.join(appData, "npm", "grok.cmd")] : []),
       path.join(home, ".local", "bin", "grok.exe"),
     ];
@@ -25,10 +53,16 @@ export function resolveGrokBinary() {
     return "grok";
   }
 
-  const prefix = path.dirname(nodeDir);
+  const embeddedShim = path.join(npmPrefix, "bin", "grok");
   const candidates = [
-    path.join(prefix, "bin", "grok"),
+    // Tauri dereferences npm bin symlinks while staging resources. Executing
+    // the relocated CommonJS trampoline from node/bin makes Node classify it
+    // as ESM under Seren's package root. Use the official native payload (or
+    // canonical postinstall binary) instead; accept the npm shim only while it
+    // is still a symlink to its package-owned location. #3088.
+    embeddedNative,
     path.join(home, ".grok", "bin", "grok"),
+    ...(isSymlink(embeddedShim) ? [embeddedShim] : []),
     path.join(home, ".local", "bin", "grok"),
     "/usr/local/bin/grok",
     "/opt/homebrew/bin/grok",

--- a/bin/browser-local/grok-runtime.mjs
+++ b/bin/browser-local/grok-runtime.mjs
@@ -1,0 +1,186 @@
+// ABOUTME: Grok-specific configuration for the shared browser-local ACP runtime.
+// ABOUTME: Resolves and launches Grok Build, authenticates ACP, and maps Seren safety modes.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { createAcpRuntime } from "./acp-runtime.mjs";
+import { resolveGrokBinary } from "./grok-binary.mjs";
+
+const GROK_AVAILABLE_MODELS = [
+  {
+    modelId: "grok-4.5",
+    name: "Grok 4.5",
+    description: "Default Grok Build coding-agent model — 1M context window",
+  },
+];
+
+const GROK_DEFAULT_MODEL_ID = "grok-4.5";
+
+function resolveGrokMode({ approvalPolicy, sandboxMode }) {
+  if (sandboxMode === "read-only") return "plan";
+  if (sandboxMode === "danger-full-access") return "bypassPermissions";
+  if (approvalPolicy === "on-request" || approvalPolicy === "untrusted") {
+    return "default";
+  }
+  return "acceptEdits";
+}
+
+function resolveGrokSandbox({ sandboxMode, networkEnabled }) {
+  if (sandboxMode === "read-only") return "read-only";
+  if (sandboxMode === "danger-full-access") return "off";
+  if (networkEnabled === false) return "strict";
+  return "workspace";
+}
+
+function buildGrokModes(session) {
+  return {
+    currentModeId: session?.currentModeId ?? "default",
+    availableModes: [
+      {
+        modeId: "default",
+        name: "Default",
+        description: "Prompt when a tool is not already allowed",
+      },
+      {
+        modeId: "acceptEdits",
+        name: "Accept Edits",
+        description: "Auto-approve file edits and prompt for shell commands",
+      },
+      {
+        modeId: "dontAsk",
+        name: "Don't Ask",
+        description: "Silently deny tools without an explicit allow rule",
+      },
+      {
+        modeId: "bypassPermissions",
+        name: "Always Approve",
+        description: "Auto-approve all tools (use with caution)",
+      },
+      {
+        modeId: "plan",
+        name: "Plan",
+        description: "Read-only — propose changes without executing",
+      },
+    ],
+  };
+}
+
+function isGrokAuthError(message) {
+  const lower = String(message).toLowerCase();
+  return (
+    lower.includes("not authenticated") ||
+    lower.includes("authentication required") ||
+    lower.includes("auth required") ||
+    lower.includes("login required") ||
+    lower.includes("not logged in") ||
+    lower.includes("run `grok login`") ||
+    lower.includes("run grok login") ||
+    lower.includes("xai_api_key") ||
+    lower.includes("xai.api_key") ||
+    lower.includes("cached_token") ||
+    lower.includes("grok authentication failed") ||
+    lower.includes("no supported grok authentication method")
+  );
+}
+
+function spawnGrokProcess(
+  cwd,
+  { extraEnv = {}, currentModeId, currentModelId, params },
+) {
+  const sandbox = resolveGrokSandbox(params);
+  const args = [
+    "--no-auto-update",
+    "--model",
+    currentModelId,
+    "--permission-mode",
+    currentModeId,
+    "--sandbox",
+    sandbox,
+    "agent",
+    "stdio",
+  ];
+  const binary = resolveGrokBinary();
+  return spawn(binary, args, {
+    cwd,
+    env: { ...process.env, ...extraEnv },
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32" && !binary.toLowerCase().endsWith(".exe"),
+  });
+}
+
+async function authenticateGrok({ initResult, request }) {
+  const authMethods = new Set(
+    (initResult?.authMethods ?? [])
+      .map((method) => method?.id)
+      .filter((id) => typeof id === "string"),
+  );
+  const hasCachedAuth = existsSync(
+    path.join(os.homedir(), ".grok", "auth.json"),
+  );
+  const methodId =
+    process.env.XAI_API_KEY && authMethods.has("xai.api_key")
+      ? "xai.api_key"
+      : hasCachedAuth && authMethods.has("grok.com")
+        ? "grok.com"
+        : hasCachedAuth && authMethods.has("cached_token")
+          ? "cached_token"
+          : null;
+
+  if (!methodId) {
+    throw new Error(
+      "No supported Grok authentication method. Run `grok login` or set XAI_API_KEY.",
+    );
+  }
+
+  try {
+    await request(
+      "authenticate",
+      { methodId, _meta: { headless: true } },
+      30_000,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Grok authentication failed: ${message}`);
+  }
+}
+
+const GROK_ADAPTER = {
+  agentType: "grok",
+  agentName: "Grok",
+  agentInfoName: "Grok ACP",
+  defaultModelId: GROK_DEFAULT_MODEL_ID,
+  availableModels: GROK_AVAILABLE_MODELS,
+  defaultModeId: "default",
+  validModeIds: [
+    "default",
+    "dontAsk",
+    "acceptEdits",
+    "bypassPermissions",
+    "plan",
+  ],
+  autoApproveModeIds: ["bypassPermissions"],
+  buildModes: buildGrokModes,
+  resolveInitialMode: resolveGrokMode,
+  spawnProcess: spawnGrokProcess,
+  authenticate: authenticateGrok,
+  isAuthError: isGrokAuthError,
+  stoppedBeforeRequestMessage: "Grok agent stopped before request completed.",
+  processExitedWhilePromptMessage:
+    "Grok process exited while prompt was active.",
+  loginRequiredMessage:
+    "Grok authentication required. Opening `grok login` in a Terminal window — finish the sign-in there, then click + New Agent → Grok again.",
+  async setModel({ modelId, logPrefix }) {
+    console.warn(
+      `${logPrefix} setModel: ${modelId} stored as session intent — ` +
+        "the running Grok process keeps its spawn-time model. The next " +
+        "session spawn will use this model.",
+    );
+  },
+};
+
+export function createGrokRuntime(options) {
+  return createAcpRuntime({ ...options, adapter: GROK_ADAPTER });
+}

--- a/bin/browser-local/mcp-config.mjs
+++ b/bin/browser-local/mcp-config.mjs
@@ -188,17 +188,15 @@ function buildCodexMcpOverride(servers) {
   return `mcp_servers=${encodeTomlValue(mcpServers)}`;
 }
 
-// serenorg/seren-desktop#1887 — Gemini consumes MCP via the ACP `session/new`
-// JSON-RPC `mcpServers` parameter, a discriminated union on `type` with
-// `headers`/`env` encoded as `[{name, value}]` arrays. Returned as a function
-// so the caller can pass the live `mcpCapabilities` block from `initialize`,
-// dropping HTTP/SSE entries if the running gemini-cli build does not
-// advertise support for them.
-function encodeGeminiPairs(record) {
+// ACP agents consume MCP via the `session/new` JSON-RPC `mcpServers`
+// parameter, a discriminated union on `type` with `headers`/`env` encoded as
+// `[{name, value}]` arrays. The live initialize capabilities gate optional
+// HTTP/SSE entries; stdio is part of the baseline protocol. #1887, #3084.
+function encodeAcpPairs(record) {
   return Object.entries(record ?? {}).map(([name, value]) => ({ name, value }));
 }
 
-function buildGeminiMcpServers(servers, { mcpCapabilities = {} } = {}) {
+function buildAcpMcpServers(servers, { mcpCapabilities = {} } = {}) {
   if (servers.length === 0) return [];
   const supportsHttp = mcpCapabilities.http === true;
   const supportsSse = mcpCapabilities.sse === true;
@@ -211,7 +209,7 @@ function buildGeminiMcpServers(servers, { mcpCapabilities = {} } = {}) {
         type: "http",
         name: server.name,
         url: server.url,
-        headers: encodeGeminiPairs(server.headers),
+        headers: encodeAcpPairs(server.headers),
       });
       continue;
     }
@@ -221,7 +219,7 @@ function buildGeminiMcpServers(servers, { mcpCapabilities = {} } = {}) {
         type: "sse",
         name: server.name,
         url: server.url,
-        headers: encodeGeminiPairs(server.headers),
+        headers: encodeAcpPairs(server.headers),
       });
       continue;
     }
@@ -230,7 +228,7 @@ function buildGeminiMcpServers(servers, { mcpCapabilities = {} } = {}) {
       name: server.name,
       command: resolveLocalServerCommand(server.command),
       args: server.args ?? [],
-      env: encodeGeminiPairs(server.env),
+      env: encodeAcpPairs(server.env),
     });
   }
   return out;
@@ -255,7 +253,10 @@ export function buildProviderMcpConfig({
         : { [SEREN_MCP_API_KEY_ENV]: trimToNull(apiKey) },
     claudeMcpConfigJson: buildClaudeMcpConfig(normalizedServers),
     codexMcpConfigOverride: buildCodexMcpOverride(normalizedServers),
+    acpMcpServers: (mcpCapabilities) =>
+      buildAcpMcpServers(normalizedServers, { mcpCapabilities }),
+    // Compatibility alias for existing callers and focused #1887 coverage.
     geminiMcpServers: (mcpCapabilities) =>
-      buildGeminiMcpServers(normalizedServers, { mcpCapabilities }),
+      buildAcpMcpServers(normalizedServers, { mcpCapabilities }),
   };
 }

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -37,6 +37,10 @@ const geminiRuntimeModule = await loadAgentRuntimeModule(
   "gemini",
   () => import("./gemini-runtime.mjs"),
 );
+const grokRuntimeModule = await loadAgentRuntimeModule(
+  "grok",
+  () => import("./grok-runtime.mjs"),
+);
 const lmStudioRuntimeModule = await loadAgentRuntimeModule(
   "lmstudio",
   () => import("./lmstudio-runtime.mjs"),
@@ -1504,6 +1508,12 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     "createGeminiRuntime",
     { emit, runtimeMode },
   );
+  const grokRuntime = instantiateAgentRuntime(
+    "grok",
+    grokRuntimeModule,
+    "createGrokRuntime",
+    { emit, runtimeMode },
+  );
   const lmStudioRuntime = instantiateAgentRuntime(
     "lmstudio",
     lmStudioRuntimeModule,
@@ -1574,6 +1584,10 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
 
     if (agentType === "gemini") {
       return geminiRuntime.spawnSession(params);
+    }
+
+    if (agentType === "grok") {
+      return grokRuntime.spawnSession(params);
     }
 
     if (agentType === "lmstudio") {
@@ -1817,6 +1831,14 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         });
         return geminiRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
       }
+      if (grokRuntime.hasSession(sessionId)) {
+        emit("provider://user-message", {
+          sessionId,
+          text: prompt,
+          origin: source,
+        });
+        return grokRuntime.sendPrompt({ sessionId, prompt, context, origin: source });
+      }
       if (lmStudioRuntime.hasSession(sessionId)) {
         emit("provider://user-message", {
           sessionId,
@@ -1889,6 +1911,9 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       if (geminiRuntime.hasSession(sessionId)) {
         return geminiRuntime.cancelPrompt({ sessionId });
       }
+      if (grokRuntime.hasSession(sessionId)) {
+        return grokRuntime.cancelPrompt({ sessionId });
+      }
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.cancelPrompt({ sessionId });
       }
@@ -1942,6 +1967,9 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       if (geminiRuntime.hasSession(sessionId)) {
         return geminiRuntime.terminateSession({ sessionId });
       }
+      if (grokRuntime.hasSession(sessionId)) {
+        return grokRuntime.terminateSession({ sessionId });
+      }
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.terminateSession({ sessionId });
       }
@@ -1980,6 +2008,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       })),
       ...(await claudeRuntime.listSessions()),
       ...(await geminiRuntime.listSessions()),
+      ...(await grokRuntime.listSessions()),
       ...(await lmStudioRuntime.listSessions()),
       ...(await pairedRuntime.listSessions()),
     ];
@@ -1993,6 +2022,9 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       }
       if (geminiRuntime.hasSession(sessionId)) {
         return geminiRuntime.setPermissionMode({ sessionId, mode });
+      }
+      if (grokRuntime.hasSession(sessionId)) {
+        return grokRuntime.setPermissionMode({ sessionId, mode });
       }
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.setPermissionMode({ sessionId, mode });
@@ -2012,6 +2044,9 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       }
       if (geminiRuntime.hasSession(sessionId)) {
         return geminiRuntime.setOAuthRouting({ sessionId, routing });
+      }
+      if (grokRuntime.hasSession(sessionId)) {
+        return grokRuntime.setOAuthRouting({ sessionId, routing });
       }
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.setOAuthRouting({ sessionId, routing });
@@ -2044,6 +2079,16 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         return runPermissionResolution({
           sessionId, requestId, optionId, source,
           action: () => geminiRuntime.respondToPermission({ sessionId, requestId, optionId }),
+        });
+      }
+      if (grokRuntime.hasSession(sessionId)) {
+        return runPermissionResolution({
+          sessionId,
+          requestId,
+          optionId,
+          source,
+          action: () =>
+            grokRuntime.respondToPermission({ sessionId, requestId, optionId }),
         });
       }
       if (lmStudioRuntime.hasSession(sessionId)) {
@@ -2133,10 +2178,9 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       return { sessions: [], nextCursor: null };
     }
 
-    if (agentType === "gemini") {
-      // gemini-cli supports `--list-sessions` and `--resume <index>` but the
-      // ACP `session/load` flow is not yet wired through the desktop. Return
-      // an empty list so the UI doesn't fail; users always get a fresh thread.
+    if (agentType === "gemini" || agentType === "grok") {
+      // ACP session/load is not yet wired through the desktop for these
+      // agents. Return an empty list so the UI starts a fresh thread.
       return { sessions: [], nextCursor: null };
     }
 
@@ -2232,6 +2276,9 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       if (geminiRuntime.hasSession(sessionId)) {
         return geminiRuntime.setModel({ sessionId, modelId });
       }
+      if (grokRuntime.hasSession(sessionId)) {
+        return grokRuntime.setModel({ sessionId, modelId });
+      }
       if (lmStudioRuntime.hasSession(sessionId)) {
         return lmStudioRuntime.setSessionModel({ sessionId, modelId });
       }
@@ -2306,6 +2353,10 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
       }
       if (geminiRuntime.hasSession(sessionId)) {
         // Gemini exposes no config options today — silently no-op.
+        return null;
+      }
+      if (grokRuntime.hasSession(sessionId)) {
+        // Grok exposes model/mode controls through the existing session RPCs.
         return null;
       }
       if (lmStudioRuntime.hasSession(sessionId)) {

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -146,6 +146,7 @@ const HAPPY_AGENT_TYPES = new Map([
   ["claude", "claude-code"],
   ["claude-code", "claude-code"],
   ["gemini", "gemini"],
+  ["grok", "grok"],
   ["codex", "codex"],
 ]);
 
@@ -156,7 +157,7 @@ function happyAgentType(agent) {
 
 function defaultApprovalPolicy(agentType) {
   // Match the desktop's fresh-session defaults. Codex is explicitly
-  // on-failure; Claude and Gemini resolve their normal defaults in their
+  // on-failure; Claude, Gemini, and Grok resolve their normal defaults in their
   // runtimes when no stricter policy is supplied.
   return agentType === "codex" ? DEFAULT_CODEX_APPROVAL_POLICY : undefined;
 }

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -203,6 +203,19 @@ export function providerPermissionMode(mode, agentType) {
       yolo: "yolo",
     }[mode] ?? mode;
   }
+  if (agentType === "grok") {
+    return {
+      default: "default",
+      auto_edit: "acceptEdits",
+      acceptEdits: "acceptEdits",
+      dontAsk: "dontAsk",
+      bypassPermissions: "bypassPermissions",
+      plan: "plan",
+      "read-only": "plan",
+      "safe-yolo": "bypassPermissions",
+      yolo: "bypassPermissions",
+    }[mode] ?? mode;
+  }
   return mode;
 }
 

--- a/build/darwin/prepare-embedded-runtime.ts
+++ b/build/darwin/prepare-embedded-runtime.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import * as https from 'https';
 import { pipeline } from 'stream/promises';
 import { execSync } from 'child_process';
+import { pathToFileURL } from 'url';
 
 // Version configuration - update these for new releases
 const NODE_VERSION = '22.12.0';
@@ -24,6 +25,12 @@ const NODE_DOWNLOADS: Record<string, { url: string }> = {
 interface DownloadOptions {
 	arch: 'x64' | 'arm64';
 	outputDir: string;
+}
+
+/** Replace an extracted symlink with a regular wrapper without touching its target. */
+export function replaceRuntimeShim(wrapperPath: string, contents: string): void {
+	fs.rmSync(wrapperPath, { force: true });
+	fs.writeFileSync(wrapperPath, contents, { mode: 0o755 });
 }
 
 async function downloadFile(url: string, dest: string): Promise<void> {
@@ -105,9 +112,9 @@ async function prepareNodejs(options: DownloadOptions): Promise<string> {
 	const npmWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npm-cli.js" "$@"\n`;
 	const npxWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npx-cli.js" "$@"\n`;
 	const corepackWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/corepack/dist/corepack.js" "$@"\n`;
-	fs.writeFileSync(path.join(nodeDir, 'bin', 'npm'), npmWrapper, { mode: 0o755 });
-	fs.writeFileSync(path.join(nodeDir, 'bin', 'npx'), npxWrapper, { mode: 0o755 });
-	fs.writeFileSync(path.join(nodeDir, 'bin', 'corepack'), corepackWrapper, { mode: 0o755 });
+	replaceRuntimeShim(path.join(nodeDir, 'bin', 'npm'), npmWrapper);
+	replaceRuntimeShim(path.join(nodeDir, 'bin', 'npx'), npxWrapper);
+	replaceRuntimeShim(path.join(nodeDir, 'bin', 'corepack'), corepackWrapper);
 	console.log('Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.');
 
 	console.log(`Node.js prepared at ${nodeDir}`);
@@ -179,13 +186,16 @@ export async function prepareEmbeddedRuntime(arch: 'x64' | 'arm64', outputDir: s
 	return { nodeDir, gitDir };
 }
 
-// CLI entry point (ESM compatible)
-const arch = (process.argv[2] as 'x64' | 'arm64') || 'arm64';
-const outputDir = process.argv[3] || path.join(process.cwd(), 'src-tauri', 'embedded-runtime', `darwin-${arch}`);
+// CLI entry point (ESM compatible). Keep imports side-effect free so the
+// symlink replacement contract can be exercised against a real temp tree.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	const arch = (process.argv[2] as 'x64' | 'arm64') || 'arm64';
+	const outputDir = process.argv[3] || path.join(process.cwd(), 'src-tauri', 'embedded-runtime', `darwin-${arch}`);
 
-prepareEmbeddedRuntime(arch, outputDir)
-	.then(() => process.exit(0))
-	.catch((err) => {
-		console.error('Failed to prepare embedded runtime:', err);
-		process.exit(1);
-	});
+	prepareEmbeddedRuntime(arch, outputDir)
+		.then(() => process.exit(0))
+		.catch((err) => {
+			console.error('Failed to prepare embedded runtime:', err);
+			process.exit(1);
+		});
+}

--- a/src-tauri/src/audio/llm.rs
+++ b/src-tauri/src/audio/llm.rs
@@ -214,7 +214,7 @@ fn choose_authenticated_agent(
         }
     }
 
-    ["claude-code", "codex", "gemini", "lmstudio"]
+    ["claude-code", "codex", "gemini", "grok", "lmstudio"]
         .into_iter()
         .find(|agent_type| is_authenticated(agent_type))
         .map(str::to_string)
@@ -231,6 +231,9 @@ fn preferred_agent_for_model(model: &str) -> Option<&'static str> {
     }
     if bare.starts_with("gemini-") {
         return Some("gemini");
+    }
+    if bare.starts_with("grok-") {
+        return Some("grok");
     }
     if normalized.starts_with("lmstudio/") || bare.starts_with("lmstudio-") {
         return Some("lmstudio");
@@ -275,6 +278,7 @@ fn agent_model_for_request(agent_type: &str, requested_model: &str) -> Option<St
                 || lower.starts_with("o4")
         }
         "gemini" => lower.starts_with("gemini-"),
+        "grok" => lower.starts_with("grok-"),
         _ => false,
     };
     compatible.then(|| trimmed.to_string())
@@ -290,7 +294,7 @@ fn seren_models_fallback_model(requested_model: &str) -> String {
 /// the provider isn't authenticated, or the provider's subscription has no
 /// remaining capacity (quota/rate-limit), or the local provider runtime
 /// transport dropped mid one-shot. A long meeting that exhausts the user's
-/// Claude/Codex/Gemini subscription mid-pass must still produce notes, and a
+/// Claude/Codex/Gemini/Grok subscription mid-pass must still produce notes, and a
 /// Windows loopback socket reset must not strand a saved transcript without
 /// notes. Safety errors (e.g. a tool-call abort) are deliberately excluded so
 /// they still fail closed. #2397 #2680.
@@ -365,6 +369,15 @@ mod tests {
             CompletionRoute::ProviderAgent {
                 agent_type: "claude-code".to_string(),
                 model: Some("claude-opus-4-8".to_string()),
+            }
+        );
+
+        let agents = vec![agent("grok", true), agent("codex", true)];
+        assert_eq!(
+            resolve_completion_route_from_agents(&agents, "grok-4.5"),
+            CompletionRoute::ProviderAgent {
+                agent_type: "grok".to_string(),
+                model: Some("grok-4.5".to_string()),
             }
         );
     }

--- a/src-tauri/src/commands/provider_runtime.rs
+++ b/src-tauri/src/commands/provider_runtime.rs
@@ -261,8 +261,14 @@ pub async fn switch_thread_provider(
 /// runtime binding. Adding a new external agent on either side without
 /// updating the other will cause threads bound to that agent to route
 /// to the wrong shell.
-pub(crate) const NATIVE_AGENT_PROVIDERS: &[&str] =
-    &["claude-code", "codex", "gemini", "claude-codex", "lmstudio"];
+pub(crate) const NATIVE_AGENT_PROVIDERS: &[&str] = &[
+    "claude-code",
+    "codex",
+    "gemini",
+    "grok",
+    "claude-codex",
+    "lmstudio",
+];
 
 /// SQL CASE expression that derives a thread's effective `kind` from
 /// `provider_session_runtime.provider`, falling back to the stored
@@ -274,7 +280,7 @@ pub(crate) const NATIVE_AGENT_PROVIDERS: &[&str] =
 /// test in this module asserts that invariant.
 pub(crate) const DERIVED_KIND_CASE_SQL: &str = "CASE \
      WHEN psr.provider IS NULL THEN c.kind \
-     WHEN psr.provider IN ('claude-code', 'codex', 'gemini', 'claude-codex', 'lmstudio') THEN 'agent' \
+     WHEN psr.provider IN ('claude-code', 'codex', 'gemini', 'grok', 'claude-codex', 'lmstudio') THEN 'agent' \
      ELSE 'chat' \
      END";
 

--- a/src-tauri/src/orchestrator/provider_worker.rs
+++ b/src-tauri/src/orchestrator/provider_worker.rs
@@ -309,7 +309,7 @@ pub async fn complete_oneshot(
             spawn_params["lmStudioApiKey"] = json!(api_key);
         }
     }
-    if agent_type == "claude-code" || agent_type == "lmstudio" {
+    if agent_type == "claude-code" || agent_type == "grok" || agent_type == "lmstudio" {
         if let Some(model) = request
             .model
             .as_deref()
@@ -358,7 +358,7 @@ pub async fn complete_oneshot(
         // rejects an unknown model id with a hard error, but a toolless
         // summarization does not need an exact model — log and proceed on the
         // agent default rather than failing the whole completion. #2398.
-        if agent_type != "gemini" {
+        if agent_type != "gemini" && agent_type != "grok" {
             if let Some(model) = request
                 .model
                 .as_deref()
@@ -631,7 +631,7 @@ fn provider_oneshot_cwd(app: &AppHandle) -> Result<String, String> {
 
 fn provider_oneshot_permission_mode(agent_type: &str) -> &'static str {
     match agent_type {
-        "claude-code" | "gemini" => "plan",
+        "claude-code" | "gemini" | "grok" => "plan",
         "codex" => "ask",
         _ => "ask",
     }
@@ -837,6 +837,7 @@ mod tests {
         // gets an auto-approving mode in a one-shot.
         assert_eq!(provider_oneshot_permission_mode("claude-code"), "plan");
         assert_eq!(provider_oneshot_permission_mode("gemini"), "plan");
+        assert_eq!(provider_oneshot_permission_mode("grok"), "plan");
         assert_eq!(provider_oneshot_permission_mode("codex"), "ask");
         assert_eq!(provider_oneshot_permission_mode("lmstudio"), "ask");
         assert_eq!(provider_oneshot_permission_mode("unknown"), "ask");

--- a/src/components/bounties/BountyDetail.tsx
+++ b/src/components/bounties/BountyDetail.tsx
@@ -746,6 +746,7 @@ export const BountyDetail: Component<BountyDetailProps> = (props) => {
       value === "claude-code" ||
       value === "codex" ||
       value === "gemini" ||
+      value === "grok" ||
       value === "claude-codex" ||
       value === "lmstudio"
     );

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -567,6 +567,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       threadType === "codex" ||
       threadType === "claude-code" ||
       threadType === "gemini" ||
+      threadType === "grok" ||
       threadType === "claude-codex" ||
       threadType === "lmstudio"
     ) {
@@ -577,6 +578,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       sessionAgent === "codex" ||
       sessionAgent === "claude-code" ||
       sessionAgent === "gemini" ||
+      sessionAgent === "grok" ||
       sessionAgent === "claude-codex" ||
       sessionAgent === "lmstudio"
     ) {
@@ -607,6 +609,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         return "Codex";
       case "gemini":
         return "Gemini";
+      case "grok":
+        return "Grok";
       case "claude-codex":
         return "Claude + Codex";
       case "lmstudio":
@@ -1977,11 +1981,13 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
               ? "Codex"
               : agentType === "gemini"
                 ? "Gemini"
-                : agentType === "claude-codex"
-                  ? "Claude + Codex"
-                  : agentType === "lmstudio"
-                    ? "LM Studio"
-                    : "Claude Code";
+                : agentType === "grok"
+                  ? "Grok"
+                  : agentType === "claude-codex"
+                    ? "Claude + Codex"
+                    : agentType === "lmstudio"
+                      ? "LM Studio"
+                      : "Claude Code";
           const reason = agentStore.agentFallbackReason;
           const title =
             reason === "prompt_too_long"

--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -336,7 +336,7 @@ export const ModelSelector: Component<ModelSelectorProps> = (props) => {
 
   /**
    * Switch the active thread INTO a native-agent provider (claude-code /
-   * codex / gemini). Passes a null model so the agent's runtime decides
+   * codex / gemini / grok). Passes a null model so the agent's runtime decides
    * which model to spawn with; the user can refine via AgentChat's
    * AgentModelSelector after the session is live. The cross-category
    * machinery in `switchChatProvider` handles the cache move, native

--- a/src/components/chat/ProviderIcon.tsx
+++ b/src/components/chat/ProviderIcon.tsx
@@ -36,6 +36,7 @@ const GLYPHS: Record<string, string> = {
   openai: "\u{26A1}", // ⚡ lightning bolt — OpenAI / Codex family
   codex: "\u{26A1}", // ⚡ lightning bolt
   gemini: "\u{2728}", // ✨ sparkles
+  grok: "𝕏",
   "claude-codex": "\u{1F91D}", // 🤝 handshake — paired Claude + Codex
   lmstudio: "\u{1F5A5}\uFE0F", // 🖥️ desktop computer
 };

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -249,7 +249,10 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
     if (!cwd) return;
     setSpawning(true);
     try {
-      await threadStore.createAgentThread(agentType, cwd);
+      const threadId = await threadStore.createAgentThread(agentType, cwd);
+      if (!threadId && agentStore.error) {
+        setShowLauncher(true);
+      }
     } finally {
       setSpawning(false);
     }
@@ -622,6 +625,23 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
 
           <Show when={showLauncher()}>
             <div class="absolute top-[calc(100%+4px)] left-3 right-3 max-h-[60vh] overflow-y-auto bg-surface-2 border border-border rounded-lg z-20 shadow-lg animate-[slideDown_150ms_ease] py-1">
+              <Show when={agentStore.error}>
+                <div
+                  data-testid="agent-launch-error"
+                  role="alert"
+                  class="mx-2 my-1 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-2.5 py-2 text-[11px] text-destructive"
+                >
+                  <span class="min-w-0 flex-1">{agentStore.error}</span>
+                  <button
+                    type="button"
+                    class="shrink-0 border-0 bg-transparent p-0 text-destructive cursor-pointer"
+                    aria-label="Dismiss agent launch error"
+                    onClick={() => agentStore.clearError()}
+                  >
+                    ×
+                  </button>
+                </div>
+              </Show>
               {/* ---------- Chat ---------- */}
               <Show when={hasChatSection()}>
                 <SectionLabel>Chat</SectionLabel>

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -32,6 +32,7 @@ import {
   allowsClaudeAgent,
   allowsCodexAgent,
   allowsGeminiAgent,
+  allowsGrokAgent,
   allowsLmStudioAgent,
   allowsSerenPrivateAgent,
   allowsSerenPublicModels,
@@ -440,6 +441,9 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
   const showGeminiAgent = createMemo(() =>
     allowsGeminiAgent(authStore.privateChatPolicy),
   );
+  const showGrokAgent = createMemo(() =>
+    allowsGrokAgent(authStore.privateChatPolicy),
+  );
   const showLmStudioAgent = createMemo(() =>
     allowsLmStudioAgent(authStore.privateChatPolicy),
   );
@@ -462,6 +466,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
       showCodexAgent() ||
       showPairedAgent() ||
       showGeminiAgent() ||
+      showGrokAgent() ||
       showLmStudioAgent(),
   );
   const hasCliSection = createMemo(() => showCliLaunchers());
@@ -748,6 +753,27 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                   </div>
                   <LauncherChip variant="subscription">
                     Subscription
+                  </LauncherChip>
+                </button>
+              </Show>
+              <Show when={showGrokAgent()}>
+                <button
+                  type="button"
+                  data-testid="new-grok-agent"
+                  class="flex items-center gap-2.5 w-full py-2 px-3 bg-transparent border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:bg-surface-3 text-left"
+                  onClick={() => void handleNewAgent("grok")}
+                >
+                  <span class="text-[14px] w-[22px] text-center shrink-0">
+                    𝕏
+                  </span>
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium">Grok</div>
+                    <div class="text-[11px] text-muted-foreground">
+                      xAI · chat-style coding agent
+                    </div>
+                  </div>
+                  <LauncherChip variant="subscription">
+                    Subscription / API key
                   </LauncherChip>
                 </button>
               </Show>
@@ -1038,11 +1064,13 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                                   ? "\u26A1"
                                   : thread.agentType === "gemini"
                                     ? "\u2728"
-                                    : thread.agentType === "claude-codex"
-                                      ? "\u{1F91D}"
-                                      : thread.agentType === "lmstudio"
-                                        ? "\u{1F5A5}\uFE0F"
-                                        : "\u{1F916}"}
+                                    : thread.agentType === "grok"
+                                      ? "𝕏"
+                                      : thread.agentType === "claude-codex"
+                                        ? "\u{1F91D}"
+                                        : thread.agentType === "lmstudio"
+                                          ? "\u{1F5A5}\uFE0F"
+                                          : "\u{1F916}"}
                               </span>
                             </Show>
                           </div>

--- a/src/components/layout/ThreadTabBar.tsx
+++ b/src/components/layout/ThreadTabBar.tsx
@@ -14,6 +14,7 @@ import {
   allowsClaudeAgent,
   allowsCodexAgent,
   allowsGeminiAgent,
+  allowsGrokAgent,
   allowsSerenPrivateAgent,
   allowsSerenPublicModels,
 } from "@/services/organization-policy";
@@ -92,7 +93,7 @@ export const ThreadTabBar: Component = () => {
   };
 
   const handleNewAgent = async (
-    agentType: "claude-code" | "codex" | "gemini" | "claude-codex",
+    agentType: "claude-code" | "codex" | "gemini" | "grok" | "claude-codex",
   ) => {
     setShowNewMenu(false);
     const cwd = fileTreeState.rootPath;
@@ -113,6 +114,7 @@ export const ThreadTabBar: Component = () => {
       return providerGlyph(thread.provider ?? "seren");
     if (thread.agentType === "codex") return "⚡";
     if (thread.agentType === "gemini") return "✨";
+    if (thread.agentType === "grok") return "𝕏";
     if (thread.agentType === "claude-codex") return "🤝";
     return "🤖";
   };
@@ -338,6 +340,24 @@ export const ThreadTabBar: Component = () => {
                 </span>
                 <div class="flex-1 min-w-0 font-medium">Gemini</div>
                 <Chip variant="subscription">Subscription</Chip>
+              </button>
+            </Show>
+            <Show when={allowsGrokAgent(authStore.privateChatPolicy)}>
+              <button
+                type="button"
+                data-testid="new-grok-agent"
+                class="flex items-center gap-2.5 w-full py-[7px] px-2.5 bg-none border-none rounded-md text-foreground text-[13px] cursor-pointer transition-colors duration-100 hover:enabled:bg-border/80 disabled:opacity-40 disabled:cursor-not-allowed text-left"
+                onClick={() => handleNewAgent("grok")}
+                disabled={!fileTreeState.rootPath}
+                title={
+                  !fileTreeState.rootPath
+                    ? "Open a folder first to use agents"
+                    : undefined
+                }
+              >
+                <span class="text-[13px] w-[18px] text-center shrink-0">𝕏</span>
+                <div class="flex-1 min-w-0 font-medium">Grok</div>
+                <Chip variant="subscription">Subscription / API key</Chip>
               </button>
             </Show>
             <Show when={!authStore.privateChatPolicy?.disable_local_agents}>

--- a/src/components/layout/ThreadTabBar.tsx
+++ b/src/components/layout/ThreadTabBar.tsx
@@ -98,7 +98,10 @@ export const ThreadTabBar: Component = () => {
     setShowNewMenu(false);
     const cwd = fileTreeState.rootPath;
     if (!cwd) return;
-    await threadStore.createAgentThread(agentType, cwd);
+    const threadId = await threadStore.createAgentThread(agentType, cwd);
+    if (!threadId && agentStore.error) {
+      setShowNewMenu(true);
+    }
   };
 
   const handleNewTerminal = async (options?: {
@@ -227,6 +230,23 @@ export const ThreadTabBar: Component = () => {
 
         <Show when={showNewMenu()}>
           <div class="absolute top-full right-0 min-w-[300px] max-h-[70vh] overflow-y-auto bg-surface-2 border border-border rounded-lg p-1 z-20 shadow-[var(--shadow-lg)] animate-[slideInDown_150ms_ease]">
+            <Show when={agentStore.error}>
+              <div
+                data-testid="agent-launch-error"
+                role="alert"
+                class="m-1 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-2.5 py-2 text-[11px] text-destructive"
+              >
+                <span class="min-w-0 flex-1">{agentStore.error}</span>
+                <button
+                  type="button"
+                  class="shrink-0 border-0 bg-transparent p-0 text-destructive cursor-pointer"
+                  aria-label="Dismiss agent launch error"
+                  onClick={() => agentStore.clearError()}
+                >
+                  ×
+                </button>
+              </div>
+            </Show>
             <Show when={allowsSerenPublicModels(authStore.privateChatPolicy)}>
               <button
                 type="button"

--- a/src/lib/provider-bootstrap.ts
+++ b/src/lib/provider-bootstrap.ts
@@ -14,6 +14,7 @@ const NATIVE_AGENT_PROVIDERS: ReadonlySet<AgentType> = new Set<AgentType>([
   "claude-code",
   "codex",
   "gemini",
+  "grok",
   "lmstudio",
 ]);
 

--- a/src/lib/provider-boundaries.ts
+++ b/src/lib/provider-boundaries.ts
@@ -25,6 +25,8 @@ export function providerDisplayName(
       return "Codex";
     case "gemini":
       return "Gemini";
+    case "grok":
+      return "Grok";
     case "claude-codex":
       return "Claude + Codex";
     case "lmstudio":

--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -148,6 +148,7 @@ const DEFAULT_SEREN_MODELS: Record<AgentType, string> = {
   "claude-code": "arcee-ai/trinity-large-thinking",
   codex: "arcee-ai/trinity-large-thinking",
   gemini: "google/gemini-2.5-pro",
+  grok: "arcee-ai/trinity-large-thinking",
   "claude-codex": "arcee-ai/trinity-large-thinking",
   lmstudio: "arcee-ai/trinity-large-thinking",
 };
@@ -241,11 +242,13 @@ export function buildRedirectMessage(
       ? "Codex"
       : agentType === "gemini"
         ? "Gemini"
-        : agentType === "claude-codex"
-          ? "Claude + Codex"
-          : agentType === "lmstudio"
-            ? "LM Studio"
-            : "Claude Code";
+        : agentType === "grok"
+          ? "Grok"
+          : agentType === "claude-codex"
+            ? "Claude + Codex"
+            : agentType === "lmstudio"
+              ? "LM Studio"
+              : "Claude Code";
   const reasonText =
     reason === "prompt_too_long"
       ? `${agentName} agent's context window is full.`
@@ -296,11 +299,13 @@ export async function performAgentFallback(
       ? "Codex"
       : agentType === "gemini"
         ? "Gemini"
-        : agentType === "claude-codex"
-          ? "Claude + Codex"
-          : agentType === "lmstudio"
-            ? "LM Studio"
-            : "Claude";
+        : agentType === "grok"
+          ? "Grok"
+          : agentType === "claude-codex"
+            ? "Claude + Codex"
+            : agentType === "lmstudio"
+              ? "LM Studio"
+              : "Claude";
   const title = sessionTitle || `${agentName} Agent (continued)`;
 
   try {

--- a/src/services/organization-policy.ts
+++ b/src/services/organization-policy.ts
@@ -29,6 +29,7 @@ export interface OrganizationPrivateModelsPolicy {
   allow_claude_agent?: boolean;
   allow_codex_agent?: boolean;
   allow_gemini_agent?: boolean;
+  allow_grok_agent?: boolean;
   allow_lmstudio_agent?: boolean;
   allow_cloud_agent_launch?: boolean;
   model_id?: string | null;
@@ -89,6 +90,12 @@ export function allowsGeminiAgent(
   policy: OrganizationPrivateModelsPolicy | null | undefined,
 ): boolean {
   return policy?.allow_gemini_agent ?? true;
+}
+
+export function allowsGrokAgent(
+  policy: OrganizationPrivateModelsPolicy | null | undefined,
+): boolean {
+  return policy?.allow_grok_agent ?? true;
 }
 
 export function allowsLmStudioAgent(

--- a/src/services/provider-bindings.ts
+++ b/src/services/provider-bindings.ts
@@ -113,7 +113,7 @@ export async function switchChatProvider(
   }
 
   // Build a deterministic bootstrap when switching into a provider that
-  // owns a fresh native session - claude-code / codex / gemini have no
+  // owns a fresh native session - claude-code / codex / gemini / grok have no
   // way to see the prior chat transcript otherwise. Chat-side switches
   // skip this: they re-read the canonical Seren transcript directly.
   const bootstrap = providerNeedsBootstrap(targetProvider)

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -28,6 +28,7 @@ export type AgentType =
   | "claude-code"
   | "codex"
   | "gemini"
+  | "grok"
   | "claude-codex"
   | "lmstudio";
 export type UnlistenFn = () => void;
@@ -52,6 +53,7 @@ export function supportsConversationFork(agentType: AgentType): boolean {
     agentType === "claude-code" ||
     agentType === "codex" ||
     agentType === "gemini" ||
+    agentType === "grok" ||
     agentType === "claude-codex" ||
     agentType === "lmstudio"
   );
@@ -416,7 +418,7 @@ export interface ErrorEvent {
 }
 
 /**
- * Emitted by an agent runtime (gemini-runtime today) when a spawn fails
+ * Emitted by an agent runtime when a spawn fails
  * because the user has not yet authenticated with the upstream CLI.
  * Triggers the desktop to call `launchLogin(agentType)` automatically so
  * the user finishes sign-in in a Terminal/browser without needing to know
@@ -746,6 +748,13 @@ export async function ensureCodexCli(): Promise<string> {
 export async function ensureGeminiCli(): Promise<string> {
   return invokeProvider<string>("provider_ensure_agent_cli", {
     agentType: "gemini",
+  });
+}
+
+/** Ensure the official Grok Build CLI is installed in the embedded runtime. */
+export async function ensureGrokCli(): Promise<string> {
+  return invokeProvider<string>("provider_ensure_agent_cli", {
+    agentType: "grok",
   });
 }
 

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -487,6 +487,7 @@ const CLAUDE_1M_TIER_CAPABLE_MODELS = new Set([
 function defaultContextWindowFor(agentType: string, modelId?: string): number {
   if (agentType === "codex") return 1_000_000;
   if (agentType === "gemini") return 1_000_000;
+  if (agentType === "grok") return 1_000_000;
   if (agentType === "lmstudio") return 128_000;
   // Paired threads gauge against the planner (Claude defaults to the 1M
   // tier); the runtime-reported contextWindow corrects this per turn.
@@ -1148,6 +1149,8 @@ export function agentDisplayName(agentType?: string): string {
       return "Claude Code";
     case "gemini":
       return "Gemini";
+    case "grok":
+      return "Grok";
     case "claude-codex":
       return "Claude + Codex";
     case "lmstudio":
@@ -1164,11 +1167,13 @@ function agentInitializationFailureMessage(agentType?: string): string {
       ? "Codex is installed and signed in"
       : agentType === "gemini"
         ? "Gemini is installed and signed in"
-        : agentType === "lmstudio"
-          ? "LM Studio is running and reachable"
-          : agentType === "claude-codex"
-            ? "Claude Code and Codex are installed and signed in"
-            : `${agentName} is installed and authenticated`;
+        : agentType === "grok"
+          ? "Grok is installed and signed in"
+          : agentType === "lmstudio"
+            ? "LM Studio is running and reachable"
+            : agentType === "claude-codex"
+              ? "Claude Code and Codex are installed and signed in"
+              : `${agentName} is installed and authenticated`;
 
   return `Agent session terminated before initialization completed. Check that ${remediation}.`;
 }
@@ -3034,11 +3039,13 @@ export const agentStore = {
         ? "Codex Agent"
         : resolvedAgentType === "gemini"
           ? "Gemini Agent"
-          : resolvedAgentType === "claude-codex"
-            ? "Claude + Codex"
-            : resolvedAgentType === "lmstudio"
-              ? "LM Studio Agent"
-              : "Claude Code Agent");
+          : resolvedAgentType === "grok"
+            ? "Grok Agent"
+            : resolvedAgentType === "claude-codex"
+              ? "Claude + Codex"
+              : resolvedAgentType === "lmstudio"
+                ? "LM Studio Agent"
+                : "Claude Code Agent");
 
     // Prevent concurrent spawns for the same conversation. Internal retries
     // (initRetryAttempt > 0) are allowed through because they are sequential
@@ -3196,9 +3203,11 @@ export const agentStore = {
               ? providerService.ensureCodexCli
               : resolvedAgentType === "gemini"
                 ? providerService.ensureGeminiCli
-                : resolvedAgentType === "claude-codex"
-                  ? providerService.ensurePairedCli
-                  : null;
+                : resolvedAgentType === "grok"
+                  ? providerService.ensureGrokCli
+                  : resolvedAgentType === "claude-codex"
+                    ? providerService.ensurePairedCli
+                    : null;
 
         if (ensureFn) {
           console.log("[AgentStore] Ensuring CLI is installed...");
@@ -4055,6 +4064,7 @@ export const agentStore = {
       convo.agent_type === "codex" ||
       convo.agent_type === "claude-code" ||
       convo.agent_type === "gemini" ||
+      convo.agent_type === "grok" ||
       convo.agent_type === "claude-codex" ||
       convo.agent_type === "lmstudio"
         ? (convo.agent_type as AgentType)

--- a/src/stores/thread.store.ts
+++ b/src/stores/thread.store.ts
@@ -226,7 +226,7 @@ function mapSessionStatusToThread(status: SessionStatus): ThreadStatus {
  * If preferChat is set, always returns chat.
  * Otherwise respects `agentStore.selectedAgentType` as the user's preference,
  * then falls back to availability order:
- * claude-code > codex > gemini > lmstudio > chat.
+ * claude-code > codex > gemini > grok > lmstudio > chat.
  */
 function getBestAgent():
   | { kind: "agent"; agentType: AgentType }
@@ -258,6 +258,11 @@ function getBestAgent():
     (a) => a.type === "gemini" && canAutoSelectAgent(a),
   );
   if (gemini) return { kind: "agent", agentType: "gemini" };
+
+  const grok = agents.find(
+    (agent) => agent.type === "grok" && canAutoSelectAgent(agent),
+  );
+  if (grok) return { kind: "agent", agentType: "grok" };
 
   const lmStudio = agents.find(
     (a) => a.type === "lmstudio" && canAutoSelectAgent(a),

--- a/tests/services/providers.test.ts
+++ b/tests/services/providers.test.ts
@@ -25,6 +25,7 @@ describe("provider fork capabilities", () => {
       "claude-code",
       "codex",
       "gemini",
+      "grok",
       "claude-codex",
       "lmstudio",
     ];

--- a/tests/unit/agent-model-observability.test.ts
+++ b/tests/unit/agent-model-observability.test.ts
@@ -79,7 +79,7 @@ describe("#1718 Gemini runtime — mid-session setModel surfaces as a warn", () 
     // Mid-session setModel does not plumb to gemini-cli (Phase 1 limitation
     // documented in the runtime). Without a log the user can change the
     // picker and never know the running process is unchanged.
-    const fnIdx = geminiRuntime.indexOf("async function setModel(");
+    const fnIdx = geminiRuntime.indexOf("async setModel(");
     expect(fnIdx).toBeGreaterThan(0);
     const region = geminiRuntime.slice(fnIdx, fnIdx + 1200);
     expect(region).toContain("console.warn(");

--- a/tests/unit/agent-session-died-mid-prompt.test.ts
+++ b/tests/unit/agent-session-died-mid-prompt.test.ts
@@ -10,6 +10,7 @@ const agentChatSource = readSource("src/components/chat/AgentChat.tsx");
 const claudeRuntimeSource = readSource("bin/browser-local/claude-runtime.mjs");
 const codexRuntimeSource = readSource("bin/browser-local/providers.mjs");
 const geminiRuntimeSource = readSource("bin/browser-local/gemini-runtime.mjs");
+const acpRuntimeSource = readSource("bin/browser-local/acp-runtime.mjs");
 
 describe("#1805 — death-string catalog matches what runtimes emit", () => {
   // The error event handler's session-death detection MUST stay in sync with
@@ -44,9 +45,10 @@ describe("#1805 — death-string catalog matches what runtimes emit", () => {
     expect(geminiRuntimeSource).toContain(
       '"Gemini agent stopped before request completed."',
     );
-    expect(geminiRuntimeSource).toContain(
+    expect(acpRuntimeSource).toContain(
       '"Session terminated before request completed."',
     );
+    expect(acpRuntimeSource).toContain("stoppedBeforeRequestMessage");
   });
 });
 

--- a/tests/unit/darwin-embedded-runtime.test.ts
+++ b/tests/unit/darwin-embedded-runtime.test.ts
@@ -1,0 +1,39 @@
+// ABOUTME: Critical regression coverage for macOS embedded-runtime wrapper preparation (#3086).
+// ABOUTME: Proves replacing an extracted npm symlink never overwrites its JavaScript target.
+
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { replaceRuntimeShim } from "../../build/darwin/prepare-embedded-runtime";
+import { expect, it } from "vitest";
+
+it("replaces an npm symlink without corrupting its target", () => {
+  const root = mkdtempSync(join(tmpdir(), "seren-runtime-shim-"));
+  try {
+    const binDir = join(root, "bin");
+    const targetDir = join(root, "lib", "node_modules", "npm", "bin");
+    const target = join(targetDir, "npm-cli.js");
+    const shim = join(binDir, "npm");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(target, "// original npm entrypoint\n");
+    symlinkSync("../lib/node_modules/npm/bin/npm-cli.js", shim);
+
+    replaceRuntimeShim(shim, "#!/bin/sh\nexit 0\n");
+
+    expect(lstatSync(shim).isSymbolicLink()).toBe(false);
+    expect(lstatSync(shim).mode & 0o111).not.toBe(0);
+    expect(readFileSync(shim, "utf8")).toBe("#!/bin/sh\nexit 0\n");
+    expect(readFileSync(target, "utf8")).toBe("// original npm entrypoint\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/gemini-1480-fixes.test.ts
+++ b/tests/unit/gemini-1480-fixes.test.ts
@@ -13,6 +13,10 @@ const geminiRuntimeMjs = readFileSync(
   resolve("bin/browser-local/gemini-runtime.mjs"),
   "utf-8",
 );
+const acpRuntimeMjs = readFileSync(
+  resolve("bin/browser-local/acp-runtime.mjs"),
+  "utf-8",
+);
 
 describe("Gemini Agent #1480 — bottom-control regression guards", () => {
   it("lockedAgentType filter accepts gemini (not just codex/claude-code)", () => {
@@ -37,11 +41,14 @@ describe("Gemini Agent #1480 — bottom-control regression guards", () => {
     // hidden-picker / wrong-label state.
     expect(geminiRuntimeMjs).toContain("GEMINI_AVAILABLE_MODELS");
     expect(geminiRuntimeMjs).toContain("gemini-2.5-pro");
-    // buildSessionStatus must reference the constant, not the empty array.
-    const buildIdx = geminiRuntimeMjs.indexOf("function buildSessionStatus");
+    expect(geminiRuntimeMjs).toContain(
+      "availableModels: GEMINI_AVAILABLE_MODELS",
+    );
+    // The shared status builder must surface the adapter's non-empty list.
+    const buildIdx = acpRuntimeMjs.indexOf("function buildSessionStatus");
     expect(buildIdx).toBeGreaterThan(-1);
-    const fn = geminiRuntimeMjs.slice(buildIdx, buildIdx + 800);
-    expect(fn).toContain("availableModels: GEMINI_AVAILABLE_MODELS");
+    const fn = acpRuntimeMjs.slice(buildIdx, buildIdx + 800);
+    expect(fn).toContain("availableModels: session.availableModels");
     // Negative: must NOT be the empty array literal anymore.
     expect(fn).not.toMatch(/availableModels:\s*\[\s*\]/);
   });

--- a/tests/unit/gemini-1486-fix.test.ts
+++ b/tests/unit/gemini-1486-fix.test.ts
@@ -5,8 +5,8 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const geminiRuntimeMjs = readFileSync(
-  resolve("bin/browser-local/gemini-runtime.mjs"),
+const acpRuntimeMjs = readFileSync(
+  resolve("bin/browser-local/acp-runtime.mjs"),
   "utf-8",
 );
 
@@ -24,13 +24,13 @@ describe("Gemini #1486 — pendingPrompt orphaned rejection crash", () => {
     // Guard: the `.catch(` handler must appear on pendingPrompt, within a
     // small window after its declaration, BEFORE the `try {` block. If a
     // future refactor deletes this line, the crash cascade returns.
-    const declIdx = geminiRuntimeMjs.indexOf("const pendingPrompt = new Promise");
+    const declIdx = acpRuntimeMjs.indexOf("const pendingPrompt = new Promise");
     expect(declIdx).toBeGreaterThan(-1);
 
     // Look at the region between the declaration and the first `try {` after it.
-    const tryIdx = geminiRuntimeMjs.indexOf("try {", declIdx);
+    const tryIdx = acpRuntimeMjs.indexOf("try {", declIdx);
     expect(tryIdx).toBeGreaterThan(declIdx);
-    const region = geminiRuntimeMjs.slice(declIdx, tryIdx);
+    const region = acpRuntimeMjs.slice(declIdx, tryIdx);
 
     // Some form of pendingPrompt.catch(...) must be present in that region.
     // Accept variations like `pendingPrompt.catch(() => {})` or

--- a/tests/unit/gemini-agent.test.ts
+++ b/tests/unit/gemini-agent.test.ts
@@ -17,6 +17,10 @@ const geminiRuntimeMjs = readFileSync(
   resolve("bin/browser-local/gemini-runtime.mjs"),
   "utf-8",
 );
+const acpRuntimeMjs = readFileSync(
+  resolve("bin/browser-local/acp-runtime.mjs"),
+  "utf-8",
+);
 const agentStoreTs = readFileSync(
   resolve("src/stores/agent.store.ts"),
   "utf-8",
@@ -79,17 +83,21 @@ describe("Gemini Agent — registry definition (#1471)", () => {
   });
 });
 
-describe("Gemini Agent — gemini-runtime.mjs ACP client (#1471)", () => {
-  it("exports createGeminiRuntime factory matching the claude-runtime contract", () => {
+describe("Gemini Agent — shared ACP client (#1471, #3084)", () => {
+  it("keeps createGeminiRuntime as a thin adapter over the shared factory", () => {
     expect(geminiRuntimeMjs).toContain("export function createGeminiRuntime");
+    expect(geminiRuntimeMjs).toContain(
+      'import { createAcpRuntime } from "./acp-runtime.mjs"',
+    );
+    expect(geminiRuntimeMjs).toContain("adapter: GEMINI_ADAPTER");
     // Must expose hasSession so providers.mjs fallback chain works.
-    expect(geminiRuntimeMjs).toContain("hasSession(sessionId)");
+    expect(acpRuntimeMjs).toContain("hasSession(sessionId)");
     // Public RPC surface.
-    expect(geminiRuntimeMjs).toContain("spawnSession");
-    expect(geminiRuntimeMjs).toContain("sendPrompt");
-    expect(geminiRuntimeMjs).toContain("cancelPrompt");
-    expect(geminiRuntimeMjs).toContain("terminateSession");
-    expect(geminiRuntimeMjs).toContain("respondToPermission");
+    expect(acpRuntimeMjs).toContain("spawnSession");
+    expect(acpRuntimeMjs).toContain("sendPrompt");
+    expect(acpRuntimeMjs).toContain("cancelPrompt");
+    expect(acpRuntimeMjs).toContain("terminateSession");
+    expect(acpRuntimeMjs).toContain("respondToPermission");
   });
 
   it("spawns gemini-cli with the --acp flag", () => {
@@ -100,28 +108,28 @@ describe("Gemini Agent — gemini-runtime.mjs ACP client (#1471)", () => {
 
   it("speaks ACP method names verbatim from the schema", () => {
     // Catches accidental rename to e.g. "session/newSession" or "newSession".
-    expect(geminiRuntimeMjs).toContain('"initialize"');
-    expect(geminiRuntimeMjs).toContain('"session/new"');
-    expect(geminiRuntimeMjs).toContain('"session/prompt"');
-    expect(geminiRuntimeMjs).toContain('"session/cancel"');
-    expect(geminiRuntimeMjs).toContain('"session/request_permission"');
+    expect(acpRuntimeMjs).toContain('"initialize"');
+    expect(acpRuntimeMjs).toContain('"session/new"');
+    expect(acpRuntimeMjs).toContain('"session/prompt"');
+    expect(acpRuntimeMjs).toContain('"session/cancel"');
+    expect(acpRuntimeMjs).toContain('"session/request_permission"');
   });
 
   it("translates ACP session/update notifications to provider:// events", () => {
     // The session/update branch must handle each ACP update type and emit
     // the existing provider:// events the desktop already knows.
-    expect(geminiRuntimeMjs).toContain('"agent_message_chunk"');
-    expect(geminiRuntimeMjs).toContain('"agent_thought_chunk"');
-    expect(geminiRuntimeMjs).toContain('"tool_call"');
-    expect(geminiRuntimeMjs).toContain('"tool_call_update"');
-    expect(geminiRuntimeMjs).toContain('"plan"');
-    expect(geminiRuntimeMjs).toContain('"provider://message-chunk"');
-    expect(geminiRuntimeMjs).toContain('"provider://tool-call"');
-    expect(geminiRuntimeMjs).toContain('"provider://prompt-complete"');
+    expect(acpRuntimeMjs).toContain('"agent_message_chunk"');
+    expect(acpRuntimeMjs).toContain('"agent_thought_chunk"');
+    expect(acpRuntimeMjs).toContain('"tool_call"');
+    expect(acpRuntimeMjs).toContain('"tool_call_update"');
+    expect(acpRuntimeMjs).toContain('"plan"');
+    expect(acpRuntimeMjs).toContain('"provider://message-chunk"');
+    expect(acpRuntimeMjs).toContain('"provider://tool-call"');
+    expect(acpRuntimeMjs).toContain('"provider://prompt-complete"');
   });
 
   it("declares an ACP protocol version constant", () => {
-    expect(geminiRuntimeMjs).toContain("ACP_PROTOCOL_VERSION");
+    expect(acpRuntimeMjs).toContain("ACP_PROTOCOL_VERSION");
   });
 });
 
@@ -198,7 +206,7 @@ describe("Gemini Agent — UI surface (#1471)", () => {
 
   it("handleNewAgent type signature accepts 'gemini'", () => {
     expect(threadTabBarTsx).toMatch(
-      /agentType:\s*"claude-code"\s*\|\s*"codex"\s*\|\s*"gemini"/,
+      /agentType:[\s\S]{0,120}"claude-code"[\s\S]{0,120}"codex"[\s\S]{0,120}"gemini"/,
     );
   });
 });

--- a/tests/unit/grok-agent.test.ts
+++ b/tests/unit/grok-agent.test.ts
@@ -1,8 +1,16 @@
 // ABOUTME: Critical regression guards for the native Grok ACP agent (#3084).
 // ABOUTME: Protects its thin-adapter boundary, auth ordering, CLI safety flags, and desktop routing.
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { resolveGrokBinary } from "../../bin/browser-local/grok-binary.mjs";
 import { describe, expect, it } from "vitest";
 
 function readSource(relativePath: string): string {
@@ -51,6 +59,55 @@ describe("Grok native ACP agent (#3084)", () => {
     expect(grokSource).toContain('"agent"');
     expect(grokSource).toContain('"stdio"');
     expect(registrySource).toContain('packageName: "@xai-official/grok"');
+  });
+
+  it("prefers the package-owned native binary over a Tauri-relocated npm shim", () => {
+    const root = mkdtempSync(join(tmpdir(), "seren-grok-binary-"));
+    try {
+      const prefix = join(root, "node");
+      const execPath = join(prefix, "bin", "node");
+      const relocatedShim = join(prefix, "bin", "grok");
+      const nativeBinary = join(
+        prefix,
+        "lib",
+        "node_modules",
+        "@xai-official",
+        "grok",
+        "node_modules",
+        "@xai-official",
+        "grok-darwin-x64",
+        "bin",
+        "grok",
+      );
+      mkdirSync(join(prefix, "bin"), { recursive: true });
+      mkdirSync(dirname(nativeBinary), { recursive: true });
+      writeFileSync(execPath, "");
+      writeFileSync(relocatedShim, "const { spawn } = require('child_process');\n");
+      writeFileSync(nativeBinary, "native executable");
+
+      expect(
+        resolveGrokBinary({
+          execPath,
+          platform: "darwin",
+          arch: "x64",
+          home: join(root, "home"),
+          appData: "",
+        }),
+      ).toBe(nativeBinary);
+
+      rmSync(nativeBinary);
+      expect(
+        resolveGrokBinary({
+          execPath,
+          platform: "darwin",
+          arch: "x64",
+          home: join(root, "home"),
+          appData: "",
+        }),
+      ).toBe("grok");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("routes Grok through the registry, runtime dispatcher, and public agent type", () => {

--- a/tests/unit/grok-agent.test.ts
+++ b/tests/unit/grok-agent.test.ts
@@ -1,0 +1,65 @@
+// ABOUTME: Critical regression guards for the native Grok ACP agent (#3084).
+// ABOUTME: Protects its thin-adapter boundary, auth ordering, CLI safety flags, and desktop routing.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(relativePath), "utf8");
+}
+
+const acpSource = readSource("bin/browser-local/acp-runtime.mjs");
+const grokSource = readSource("bin/browser-local/grok-runtime.mjs");
+const providersSource = readSource("bin/browser-local/providers.mjs");
+const registrySource = readSource("bin/browser-local/agent-registry.mjs");
+const providerServiceSource = readSource("src/services/providers.ts");
+
+describe("Grok native ACP agent (#3084)", () => {
+  it("is a thin adapter over the shared Gemini-derived ACP transport", () => {
+    expect(grokSource).toContain(
+      'import { createAcpRuntime } from "./acp-runtime.mjs"',
+    );
+    expect(grokSource).toContain("adapter: GROK_ADAPTER");
+    expect(grokSource).not.toContain("function sendRequest(");
+    expect(grokSource).not.toContain("function handleSessionUpdate(");
+  });
+
+  it("authenticates after initialize and before session/new", () => {
+    const initializeAt = acpSource.indexOf('"initialize"');
+    const authenticateAt = acpSource.indexOf("await adapter.authenticate");
+    const sessionNewAt = acpSource.indexOf('"session/new"', authenticateAt);
+
+    expect(initializeAt).toBeGreaterThan(-1);
+    expect(authenticateAt).toBeGreaterThan(initializeAt);
+    expect(sessionNewAt).toBeGreaterThan(authenticateAt);
+    expect(grokSource).toContain('"xai.api_key"');
+    expect(grokSource).toContain('"grok.com"');
+    expect(grokSource).toContain('"cached_token"');
+    expect(grokSource).toContain("_meta: { headless: true }");
+  });
+
+  it("launches official Grok ACP mode without child-process self-updates", () => {
+    expect(grokSource).toContain('modelId: "grok-4.5"');
+    expect(grokSource).toContain(
+      'const GROK_DEFAULT_MODEL_ID = "grok-4.5"',
+    );
+    expect(grokSource).not.toContain('modelId: "grok-build"');
+    expect(grokSource).toContain('"--no-auto-update"');
+    expect(grokSource).toContain('"--permission-mode"');
+    expect(grokSource).toContain('"--sandbox"');
+    expect(grokSource).toContain('"agent"');
+    expect(grokSource).toContain('"stdio"');
+    expect(registrySource).toContain('packageName: "@xai-official/grok"');
+  });
+
+  it("routes Grok through the registry, runtime dispatcher, and public agent type", () => {
+    expect(registrySource).toContain("grok: {");
+    expect(providersSource).toContain('import("./grok-runtime.mjs")');
+    expect(providersSource).toMatch(
+      /if\s*\(\s*agentType\s*===\s*"grok"\s*\)\s*\{[^}]*grokRuntime\.spawnSession/s,
+    );
+    expect(providerServiceSource).toContain('| "grok"');
+    expect(providerServiceSource).toContain("ensureGrokCli");
+  });
+});

--- a/tests/unit/launcher-redesign.test.ts
+++ b/tests/unit/launcher-redesign.test.ts
@@ -293,6 +293,20 @@ describe("Launcher policy freshness", () => {
   });
 });
 
+describe("Coding-agent launch failures (#3089)", () => {
+  it("reopens both launch menus and renders the existing agent error", () => {
+    expect(sidebarTsx).toContain("if (!threadId && agentStore.error)");
+    expect(sidebarTsx).toContain("setShowLauncher(true)");
+    expect(tabBarTsx).toContain("if (!threadId && agentStore.error)");
+    expect(tabBarTsx).toContain("setShowNewMenu(true)");
+    for (const source of [sidebarTsx, tabBarTsx]) {
+      expect(source).toContain('data-testid="agent-launch-error"');
+      expect(source).toContain('role="alert"');
+      expect(source).toContain("agentStore.clearError()");
+    }
+  });
+});
+
 describe("ThreadSidebar — LM Studio local agent row (#2444)", () => {
   it("renders LM Studio in Coding agents with local copy and dispatch", () => {
     expect(sidebarTsx).toContain('data-testid="new-lmstudio-agent"');

--- a/tests/unit/launcher-redesign.test.ts
+++ b/tests/unit/launcher-redesign.test.ts
@@ -37,6 +37,7 @@ describe("ThreadSidebar — stable testids on every row (#1832)", () => {
     "new-claude-agent",
     "new-codex-agent",
     "new-gemini-agent",
+    "new-grok-agent",
     "new-lmstudio-agent",
     "new-claude-cli",
     "new-codex-cli",
@@ -57,7 +58,7 @@ describe("ThreadSidebar — chip vocabulary (#1832)", () => {
     expect(chips.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("uses 'Subscription' for Claude / Codex / Gemini coding-agent rows", () => {
+  it("uses 'Subscription' for Claude / Codex / Gemini / Grok coding-agent rows", () => {
     const chips = sidebarTsx.match(/>\s*Subscription\s*</g) ?? [];
     expect(chips.length).toBeGreaterThanOrEqual(3);
   });
@@ -95,6 +96,7 @@ describe("ThreadSidebar — gating preserved (#1832)", () => {
     expect(sidebarTsx).toContain("allowsClaudeAgent(authStore.privateChatPolicy)");
     expect(sidebarTsx).toContain("allowsCodexAgent(authStore.privateChatPolicy)");
     expect(sidebarTsx).toContain("allowsGeminiAgent(authStore.privateChatPolicy)");
+    expect(sidebarTsx).toContain("allowsGrokAgent(authStore.privateChatPolicy)");
     expect(sidebarTsx).toContain("allowsLmStudioAgent(authStore.privateChatPolicy)");
   });
 });
@@ -122,6 +124,7 @@ describe("ThreadSidebar — dispatch preserved (#1832)", () => {
     expect(sidebarTsx).toContain('handleNewAgent("claude-code")');
     expect(sidebarTsx).toContain('handleNewAgent("codex")');
     expect(sidebarTsx).toContain('handleNewAgent("gemini")');
+    expect(sidebarTsx).toContain('handleNewAgent("grok")');
     expect(sidebarTsx).toContain('handleNewAgent("lmstudio")');
   });
 
@@ -158,6 +161,7 @@ describe("ThreadTabBar — chip vocabulary on the secondary +New menu (#1832)", 
     expect(tabBarTsx).toContain("allowsClaudeAgent(authStore.privateChatPolicy)");
     expect(tabBarTsx).toContain("allowsCodexAgent(authStore.privateChatPolicy)");
     expect(tabBarTsx).toContain("allowsGeminiAgent(authStore.privateChatPolicy)");
+    expect(tabBarTsx).toContain("allowsGrokAgent(authStore.privateChatPolicy)");
   });
 
   it("does not add LM Studio to the secondary top-tab +New menu", () => {
@@ -259,6 +263,7 @@ describe("ThreadSidebar — launcher rows are policy-gated, not probe-gated", ()
       "const showClaudeAgent",
       "const showCodexAgent",
       "const showGeminiAgent",
+      "const showGrokAgent",
       "const showLmStudioAgent",
     ]) {
       const gate = sidebarTsx.slice(

--- a/tests/unit/native-runtime-oauth-proxy.test.ts
+++ b/tests/unit/native-runtime-oauth-proxy.test.ts
@@ -11,12 +11,12 @@ function readSource(relativePath: string): string {
 
 describe("native agent selected OAuth identity routing", () => {
   const claudeSource = readSource("bin/browser-local/claude-runtime.mjs");
-  const geminiSource = readSource("bin/browser-local/gemini-runtime.mjs");
+  const acpSource = readSource("bin/browser-local/acp-runtime.mjs");
   const lmStudioSource = readSource("bin/browser-local/lmstudio-runtime.mjs");
 
   it.each([
     ["Claude", claudeSource],
-    ["Gemini", geminiSource],
+    ["ACP agents", acpSource],
     ["LM Studio", lmStudioSource],
   ])("routes %s Seren MCP calls through a session proxy", (_name, source) => {
     expect(source).toContain("createSerenMcpOAuthProxy");

--- a/tests/unit/per-session-force-kill.test.ts
+++ b/tests/unit/per-session-force-kill.test.ts
@@ -24,7 +24,7 @@ describe("#2313 — runtime spawn response carries the agent child PID", () => {
     for (const file of [
       "bin/browser-local/claude-runtime.mjs",
       "bin/browser-local/providers.mjs",
-      "bin/browser-local/gemini-runtime.mjs",
+      "bin/browser-local/acp-runtime.mjs",
     ]) {
       const src = readFileSync(resolve(file), "utf-8");
       expect(src, `${file} must report the child pid`).toContain(

--- a/tests/unit/provider-agent-auth-status.test.ts
+++ b/tests/unit/provider-agent-auth-status.test.ts
@@ -16,6 +16,7 @@ describe("provider agent authentication status", () => {
     expect(registrySource).toContain('path.join(home, ".claude", ".credentials.json")');
     expect(registrySource).toContain('path.join(home, ".codex", "auth.json")');
     expect(registrySource).toContain('path.join(home, ".gemini", "oauth_creds.json")');
+    expect(registrySource).toContain('path.join(os.homedir(), ".grok", "auth.json")');
   });
 
   it("exposes a provider_check_agent_authenticated RPC", () => {

--- a/tests/unit/provider-bootstrap.test.ts
+++ b/tests/unit/provider-bootstrap.test.ts
@@ -12,6 +12,7 @@ describe("providerNeedsBootstrap", () => {
     expect(providerNeedsBootstrap("claude-code")).toBe(true);
     expect(providerNeedsBootstrap("codex")).toBe(true);
     expect(providerNeedsBootstrap("gemini")).toBe(true);
+    expect(providerNeedsBootstrap("grok")).toBe(true);
     expect(providerNeedsBootstrap("lmstudio")).toBe(true);
   });
 

--- a/tests/unit/provider-boundaries.test.ts
+++ b/tests/unit/provider-boundaries.test.ts
@@ -62,6 +62,7 @@ describe("providerDisplayName", () => {
     expect(providerDisplayName("claude-code")).toBe("Claude Code");
     expect(providerDisplayName("codex")).toBe("Codex");
     expect(providerDisplayName("gemini")).toBe("Gemini");
+    expect(providerDisplayName("grok")).toBe("Grok");
     expect(providerDisplayName("lmstudio")).toBe("LM Studio");
   });
 

--- a/tests/unit/provider-cancel-parity.test.ts
+++ b/tests/unit/provider-cancel-parity.test.ts
@@ -9,8 +9,8 @@ const codexSource = readFileSync(
   resolve("bin/browser-local/providers.mjs"),
   "utf-8",
 );
-const geminiSource = readFileSync(
-  resolve("bin/browser-local/gemini-runtime.mjs"),
+const acpSource = readFileSync(
+  resolve("bin/browser-local/acp-runtime.mjs"),
   "utf-8",
 );
 
@@ -53,11 +53,11 @@ describe("#2304 — Codex cancelPrompt escalates to a hard kill when interrupt f
   });
 });
 
-describe("#2304 — Gemini cancelPrompt escalates to a hard kill when the agent does not stop", () => {
-  const body = sliceAsyncFn(geminiSource, "async function cancelPrompt({ sessionId })");
+describe("#2304 — ACP cancelPrompt escalates to a hard kill when the agent does not stop", () => {
+  const body = sliceAsyncFn(acpSource, "async function cancelPrompt({ sessionId })");
 
   it("body extraction succeeds and still sends the cooperative cancel", () => {
-    expect(body, "Gemini cancelPrompt body must be non-empty").not.toBe("");
+    expect(body, "ACP cancelPrompt body must be non-empty").not.toBe("");
     expect(body).toContain("session/cancel");
   });
 
@@ -67,7 +67,7 @@ describe("#2304 — Gemini cancelPrompt escalates to a hard kill when the agent 
     // turn still being active after a grace window (currentPrompt not cleared).
     expect(
       body,
-      "Gemini cancelPrompt must hard-kill the child when the cooperative cancel is not honored.",
+      "ACP cancelPrompt must hard-kill the child when the cooperative cancel is not honored.",
     ).toContain("killChildTree");
     expect(
       body,

--- a/tests/unit/provider-runtime-agent-isolation.test.ts
+++ b/tests/unit/provider-runtime-agent-isolation.test.ts
@@ -46,6 +46,7 @@ describe("#2457 — agent runtimes are not statically imported at startup", () =
     for (const mod of [
       "claude-runtime.mjs",
       "gemini-runtime.mjs",
+      "grok-runtime.mjs",
       "lmstudio-runtime.mjs",
       "paired-runtime.mjs",
     ]) {

--- a/tests/unit/provider-runtime-log-prefix.test.ts
+++ b/tests/unit/provider-runtime-log-prefix.test.ts
@@ -9,7 +9,9 @@ import { providerLogPrefix } from "../../bin/browser-local/logging.mjs";
 
 const runtimeLogFiles = [
   "bin/browser-local/claude-runtime.mjs",
+  "bin/browser-local/acp-runtime.mjs",
   "bin/browser-local/gemini-runtime.mjs",
+  "bin/browser-local/grok-runtime.mjs",
   "bin/browser-local/providers.mjs",
 ];
 

--- a/tests/unit/resume-reattach-live-session-2675.test.ts
+++ b/tests/unit/resume-reattach-live-session-2675.test.ts
@@ -16,7 +16,7 @@ const providerServiceSource = readFileSync(
 const runtimeSources = [
   "bin/browser-local/claude-runtime.mjs",
   "bin/browser-local/providers.mjs",
-  "bin/browser-local/gemini-runtime.mjs",
+  "bin/browser-local/acp-runtime.mjs",
   "bin/browser-local/lmstudio-runtime.mjs",
 ].map((path) => [path, readFileSync(resolve(path), "utf-8")] as const);
 

--- a/tests/validation/scenarios/grok-agent-unauthenticated.ts
+++ b/tests/validation/scenarios/grok-agent-unauthenticated.ts
@@ -1,0 +1,71 @@
+// ABOUTME: Walks the real Grok launcher and unauthenticated ACP spawn path in the validation app.
+// ABOUTME: Captures evidence that Grok fails closed with sign-in guidance and no workspace recovery.
+
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+
+interface DumpTextResult {
+  text?: string;
+}
+
+const RECOVERY_TEXT = "Workspace is recovering.";
+const AUTH_MESSAGES = [
+  "Grok sign-in required",
+  "Grok authentication required",
+  "No supported Grok authentication method",
+];
+
+function dumpTextValue(value: unknown): string {
+  return typeof (value as DumpTextResult)?.text === "string"
+    ? ((value as DumpTextResult).text as string)
+    : JSON.stringify(value);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  await ctx.client.command({ command: "setRootPath", path: process.cwd() });
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 30_000);
+  await ctx.client.click("[data-testid='new-thread-button']");
+  await ctx.client.waitFor("[data-testid='new-grok-agent']", 10_000);
+
+  const launcherText = await ctx.client.dumpText("body");
+  const launcherBody = dumpTextValue(launcherText);
+  if (!launcherBody.includes("Grok") || !launcherBody.includes("xAI")) {
+    throw new Error("Grok launcher row or xAI description was not visible");
+  }
+  await ctx.writeArtifact("grok-launcher-text.json", launcherText);
+  await ctx.writeArtifact(
+    "grok-launcher-screenshot.json",
+    await ctx.client.screenshot("body"),
+  );
+
+  await ctx.client.click("[data-testid='new-grok-agent']");
+
+  let finalText: unknown = null;
+  let finalBody = "";
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    await sleep(500);
+    finalText = await ctx.client.dumpText("body");
+    finalBody = dumpTextValue(finalText);
+    if (finalBody.includes(RECOVERY_TEXT)) {
+      throw new Error(`${RECOVERY_TEXT} appeared during Grok launch`);
+    }
+    if (AUTH_MESSAGES.some((message) => finalBody.includes(message))) break;
+  }
+
+  if (!AUTH_MESSAGES.some((message) => finalBody.includes(message))) {
+    throw new Error("Grok launch did not surface its authentication guidance");
+  }
+
+  await ctx.writeArtifact("grok-auth-required-text.json", finalText);
+  await ctx.writeArtifact(
+    "grok-auth-required-screenshot.json",
+    await ctx.client.screenshot("body"),
+  );
+  await ctx.writeArtifact(
+    "grok-auth-required-native-screenshot.json",
+    await ctx.client.nativeScreenshot(),
+  );
+}


### PR DESCRIPTION
## Summary

- extract Gemini's reusable ACP JSON-RPC transport into a shared runtime while preserving Gemini behavior
- add Grok as a thin adapter backed by the official `@xai-official/grok` ACP CLI
- wire Grok through agent selection, policy, lifecycle, MCP forwarding, runtime packaging, and one-shot routing
- preserve npm package targets during macOS runtime preparation and resolve Grok's staged native payload
- surface actionable launch failures when agent startup fails before a thread exists

## Audit

Reviewed the existing Gemini ACP implementation, provider bridge, agent registry/store, organization policy, Tauri runtime staging, tests, README, and prior ACP/MCP/isolation issues and PRs before editing.

Gemini is refactored, not reimplemented: its existing flags, authentication order, models, modes, session behavior, cancellation, permissions, and errors remain adapter-owned and covered by existing tests.

## Network path

The desktop does not add a Seren publisher/API request for Grok. The UI calls the local provider bridge, which launches the bundled official Grok CLI over stdio ACP. The CLI owns its outbound authentication/model traffic. Live official metadata confirmed the ACP methods, authentication methods, current model, and documented xAI domains.

## Validation

- `pnpm test`: 338 files passed, 3 skipped; 2,448 tests passed, 15 skipped
- `pnpm build`: passed
- `pnpm build:provider-runtime`: passed
- `cargo check`: passed
- focused runtime, provider, UI, packaging, and Rust checks: passed
- real macOS Tauri/WebView walkthrough with the staged embedded runtime and official Grok CLI: passed without mocks
  - Grok launcher entry rendered
  - official CLI was resolved and launched
  - unauthenticated launch returned actionable in-app guidance
  - launcher recovered without leaving an orphan thread/session
  - native screenshot capture succeeded

## Post-PR findings

- P1 #3086: npm wrapper preparation followed symlinks and could corrupt package targets — fixed
- P1 #3088: Tauri resource staging relocated the npm bin shim — fixed by selecting the staged package-owned native executable
- P2 #3089: pre-thread launch failures had no visible UI surface — fixed with launcher recovery and a focused regression test
- non-blocking: the default validation dev port was occupied by an unrelated local validation run; the walkthrough used an isolated app identifier and port

No credentials, local paths, account data, or other private artifacts are included in this PR.

Closes #3084
Closes #3086
Closes #3088
Closes #3089