### PR TITLE
fix(ci): skip empty GitHub credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ env:
   # multiplexing so one dropped connection cannot fail the Rust test or build job.
   CARGO_NET_RETRY: "10"
   CARGO_HTTP_MULTIPLEXING: "false"
+  # Dependabot and fork PRs cannot read Actions secrets. Do not install an
+  # empty credential that breaks otherwise-public GitHub dependency fetches.
+  HAS_GH_PAT: ${{ secrets.GH_PAT != '' }}
 
 jobs:
   check-commit-subjects:
@@ -96,7 +99,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Configure git for private dependencies
-        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
+        if: env.HAS_GH_PAT == 'true'
+        shell: bash
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -223,7 +230,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Configure git for private dependencies
-        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
+        if: env.HAS_GH_PAT == 'true'
+        shell: bash
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"
       - uses: pnpm/action-setup@v5
         with:
           version: 9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ env:
   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
   # Signing availability flags (for conditional steps)
   HAS_APPLE_SIGNING: ${{ secrets.APPLE_CERTIFICATE != '' }}
+  # Keep the git credential rewrite disabled when the token is unavailable.
+  HAS_GH_PAT: ${{ secrets.GH_PAT != '' }}
   # SSL.com eSigner cloud signing for Windows EV code signing
   HAS_WINDOWS_SIGNING: ${{ secrets.ES_USERNAME != '' }}
   # Fail-closed ceiling for billable SSL.com cloud hash-signing operations in one
@@ -192,7 +194,11 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Configure git for private dependencies
-        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
+        if: env.HAS_GH_PAT == 'true'
+        shell: bash
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"
 
       - name: Set version from tag
         shell: bash


### PR DESCRIPTION
## Summary

- detect whether `GH_PAT` is available without exposing it beyond the credential step
- skip all three GitHub URL rewrites when the token is absent
- run the credential command under Bash on every matrix OS so environment expansion is consistent

Fixes #3069

## Audit

- #1175 / #1176 introduced the CI rewrite when `seren-memory-sdk` was private
- Dependabot-triggered workflows receive Dependabot secrets, not Actions secrets; this repository currently has no Dependabot secrets
- the current pinned `seren-memory-sdk` and `seren-secrets` refs both resolve anonymously
- matrix `fail-fast: false` already landed in #3083, so it is intentionally not duplicated here

## Validation

- official `actionlint` 1.7.12: `.github/workflows/ci.yml` and `.github/workflows/release.yml` pass
- isolated guard check: absent token writes no URL rewrite; present token writes the expected rewrite
- live anonymous `git ls-remote`: both pinned GitHub dependency refs resolve with an empty global config and credential helpers disabled
- repository commit-subject validation passes
- this PR's GitHub-hosted CI run is the live functional walkthrough for the affected workflow path

## Network/API path audit

This is CI-only. No application UI action, Seren publisher slug, `api.serendb.com` route, or first-party application API method is changed. The only outbound path affected is Cargo/git fetching public dependencies from GitHub over HTTPS.