### PR TITLE
fix(employees): render SKILL.md as formatted prose

### DIFF
--- a/src/components/common/MarkdownProse.tsx
+++ b/src/components/common/MarkdownProse.tsx
@@ -1,0 +1,52 @@
+// ABOUTME: Compact markdown renderer for readable employee instruction panels.
+// ABOUTME: Delegates external links to the system browser instead of the app webview.
+
+/* eslint-disable solid/no-innerhtml */
+import { type Component, createMemo } from "solid-js";
+import { openExternalLink } from "@/lib/external-link";
+import { renderMarkdown } from "@/lib/render-markdown";
+
+interface MarkdownProseProps {
+  content: string;
+  class?: string;
+}
+
+export const MarkdownProse: Component<MarkdownProseProps> = (props) => {
+  const renderedHtml = createMemo(() => renderMarkdown(props.content));
+
+  const handleClick = (event: MouseEvent) => {
+    const link = (event.target as HTMLElement | null)?.closest(
+      ".external-link",
+    ) as HTMLAnchorElement | null;
+    if (!link) return;
+
+    event.preventDefault();
+    void openExternalLink(link.getAttribute("data-external-url") ?? "");
+  };
+
+  return (
+    <div
+      class={`text-[13px] leading-relaxed text-foreground
+        [&_h1]:mt-5 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-semibold [&_h1]:leading-tight [&_h1]:border-b [&_h1]:border-border-hover [&_h1]:pb-1
+        [&_h2]:mt-5 [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:leading-tight [&_h2]:border-b [&_h2]:border-border-medium [&_h2]:pb-1
+        [&_h3]:mt-4 [&_h3]:mb-1.5 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:leading-tight
+        [&_h4]:mt-4 [&_h4]:mb-1.5 [&_h4]:text-[13px] [&_h4]:font-semibold [&_h4]:leading-tight
+        [&_p]:m-0 [&_p]:mb-3
+        [&_a]:text-accent [&_a]:no-underline [&_a:hover]:underline
+        [&_ul]:m-0 [&_ul]:mb-3 [&_ul]:pl-6 [&_ol]:m-0 [&_ol]:mb-3 [&_ol]:pl-6
+        [&_li]:mb-1 [&_li>ul]:mt-1 [&_li>ul]:mb-0 [&_li>ol]:mt-1 [&_li>ol]:mb-0
+        [&_blockquote]:m-0 [&_blockquote]:mb-3 [&_blockquote]:border-l-2 [&_blockquote]:border-accent [&_blockquote]:bg-primary/10 [&_blockquote]:px-3 [&_blockquote]:py-2 [&_blockquote]:text-muted-foreground [&_blockquote_p:last-child]:mb-0
+        [&_code]:rounded [&_code]:bg-border-medium [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.9em]
+        [&_pre]:m-0 [&_pre]:mb-3 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:border [&_pre]:border-border-hover [&_pre]:bg-background/65 [&_pre]:p-3
+        [&_.code-block-wrapper]:mb-3 [&_.code-block-wrapper_pre]:mb-0 [&_.code-block-wrapper_pre]:rounded-t-none [&_.code-block-wrapper_pre]:border-t-0
+        [&_.code-block-header]:rounded-t-md [&_.code-block-header]:border [&_.code-block-header]:border-border-hover [&_.code-block-header]:bg-surface-2
+        [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[12px] [&_pre_code]:leading-normal
+        [&_table]:mb-3 [&_table]:w-full [&_table]:border-collapse [&_th]:border [&_th]:border-border-hover [&_th]:bg-border [&_th]:px-2 [&_th]:py-1.5 [&_th]:text-left [&_th]:font-semibold [&_td]:border [&_td]:border-border-hover [&_td]:px-2 [&_td]:py-1.5 [&_td]:text-left
+        [&_hr]:my-5 [&_hr]:border-0 [&_hr]:border-t [&_hr]:border-border-strong
+        [&_img]:h-auto [&_img]:max-w-full [&_img]:rounded
+        [&_input[type='checkbox']]:mr-2 ${props.class ?? ""}`}
+      onClick={handleClick}
+      innerHTML={renderedHtml()}
+    />
+  );
+};

--- a/src/components/employees/EmployeeDetail.tsx
+++ b/src/components/employees/EmployeeDetail.tsx
@@ -16,6 +16,7 @@ import {
   onMount,
   Show,
 } from "solid-js";
+import { MarkdownProse } from "@/components/common/MarkdownProse";
 import { EmployeeCheckpointsList } from "@/components/employees/EmployeeCheckpointsList";
 import { EmployeeControlBar } from "@/components/employees/EmployeeControlBar";
 import { EmployeeCostSummary } from "@/components/employees/EmployeeCostSummary";
@@ -186,6 +187,7 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
   const [detailRunId, setDetailRunId] = createSignal<string | null>(null);
   const [editingEvalGate, setEditingEvalGate] = createSignal(false);
   const [showCheckpoints, setShowCheckpoints] = createSignal(true);
+  const [skillExpanded, setSkillExpanded] = createSignal(false);
 
   const [organizationId] = createResource(async () =>
     getDefaultOrganizationId(),
@@ -962,9 +964,29 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
                   }
                 >
                   {(text) => (
-                    <pre class="whitespace-pre-wrap font-sans text-[13px] leading-relaxed text-foreground m-0">
-                      {text()}
-                    </pre>
+                    <>
+                      <div
+                        class={`relative ${
+                          !skillExpanded() && text().length > 1200
+                            ? "max-h-[22rem] overflow-hidden after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-16 after:bg-gradient-to-t after:from-background after:to-transparent"
+                            : ""
+                        }`}
+                      >
+                        <MarkdownProse content={text()} />
+                      </div>
+                      <Show when={text().length > 1200}>
+                        <button
+                          type="button"
+                          class="mt-2 text-[12px] font-medium text-accent hover:underline underline-offset-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/60 rounded"
+                          aria-expanded={skillExpanded()}
+                          onClick={() =>
+                            setSkillExpanded((expanded) => !expanded)
+                          }
+                        >
+                          {skillExpanded() ? "Show less" : "Show more"}
+                        </button>
+                      </Show>
+                    </>
                   )}
                 </Show>
               </div>

--- a/src/lib/employees/instructions.ts
+++ b/src/lib/employees/instructions.ts
@@ -55,9 +55,23 @@ function frontmatterFor(name: string, slug: string): string {
   ].join("\n");
 }
 
+function stripEmbeddedSkillFrontmatter(content: string): string {
+  const match = content.match(
+    /^[ \t]*---[ \t]*\n([\s\S]*?)\n[ \t]*---[ \t]*\n/m,
+  );
+  if (!match || match.index === undefined || match.index === 0) return content;
+
+  const frontmatter = match[1];
+  if (!/^[ \t]*(?:name|description):\s*/m.test(frontmatter)) return content;
+
+  return `${content.slice(0, match.index)}${content.slice(
+    match.index + match[0].length,
+  )}`;
+}
+
 function stripGeneratedSkillWrapper(content: string): string {
   const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n*/);
-  if (!frontmatterMatch) return content.trim();
+  if (!frontmatterMatch) return stripEmbeddedSkillFrontmatter(content).trim();
 
   const frontmatter = frontmatterMatch[1];
   const generatedByDesktop =

--- a/tests/unit/employee-instructions.test.ts
+++ b/tests/unit/employee-instructions.test.ts
@@ -91,6 +91,34 @@ describe("employee instruction-file helpers", () => {
     });
   });
 
+  it("strips embedded imported-skill frontmatter after a lead-in", () => {
+    const sections = extractInstructionSections([
+      {
+        kind: "skill",
+        path: "SKILL.md",
+        content:
+          "This skill was imported.\n\nSkill instructions:\n\n---\ndescription: Imported helper\nname: imported-helper\n---\n\n## Steps\n\n- Read the request.",
+      },
+    ]);
+
+    expect(sections.skill).toContain("This skill was imported.");
+    expect(sections.skill).toContain("## Steps");
+    expect(sections.skill).not.toContain("description:");
+    expect(sections.skill).not.toMatch(/^---/);
+  });
+
+  it("keeps a legitimate horizontal rule in a skill body", () => {
+    const sections = extractInstructionSections([
+      {
+        kind: "skill",
+        path: "SKILL.md",
+        content: "Overview\n\n---\n\nContinue here.",
+      },
+    ]);
+
+    expect(sections.skill).toContain("\n---\n");
+  });
+
   it("does not split ordinary skill text that quotes old marker syntax", () => {
     const instructions = buildEmployeeInstructionFiles({
       name: "Writer",


### PR DESCRIPTION
Closes #3093

## Summary

- Render employee SKILL.md instructions as styled markdown prose with readable headings, lists, inline code, code blocks, tables, and links.
- Keep external links delegated to the system browser.
- Strip embedded imported-skill YAML frontmatter while preserving legitimate horizontal rules.
- Add a compact disclosure control for long instructions.

## Verification

- `pnpm vitest run tests/unit/employee-instructions.test.ts`
- `pnpm check`
- `pnpm test`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm build`
- Real-app walkthrough with `pnpm tauri:validation:dev`, including collapsed and expanded instruction captures.

No new networked request path was added.