### PR TITLE
fix(cli): fail closed on unverifiable background updates

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -17,6 +17,7 @@ import {
   backgroundUpdateCli,
   CLI_MIN_VERSION_BASELINE,
   isBelowBaseline,
+  loadState,
   runInstalledVersion,
 } from "./cli-updater.mjs";
 import { resolveGrokBinary } from "./grok-binary.mjs";
@@ -417,40 +418,49 @@ async function ensureGlobalNpmPackage({ emit, command, packageName, label }) {
   return command;
 }
 
-function runCodexSelfUpdate(resolvedPath) {
-  const command =
-    typeof resolvedPath === "string" && resolvedPath.length > 0
-      ? resolvedPath
-      : "codex";
-  const shell =
-    process.platform === "win32" && command.toLowerCase().endsWith(".cmd");
-  return new Promise((resolvePromise, rejectPromise) => {
-    execFile(
-      command,
-      ["update"],
-      { timeout: 180_000, shell },
-      (error, stdout, stderr) => {
-        if (error) {
-          rejectPromise(new Error(stderr || error.message));
-          return;
-        }
-        resolvePromise(stdout.trim());
-      },
-    );
+const CLI_INSTALL_INSTRUCTIONS = {
+  "@anthropic-ai/claude-code":
+    "https://code.claude.com/docs/en/installation",
+  "@openai/codex": "https://developers.openai.com/codex/cli/",
+};
+
+function emitCliActionRequired(
+  emit,
+  { label, bareCommand, packageName, from = null, to = null, reason },
+) {
+  const officialInstructionsUrl = CLI_INSTALL_INSTRUCTIONS[packageName];
+  emit?.("provider://cli-install-progress", {
+    stage: "action_required",
+    message: `${label} needs your attention before Seren can use it.`,
   });
+  emit?.("provider://cli-update-action-required", {
+    label,
+    bareCommand,
+    packageName,
+    from,
+    to,
+    reason,
+    actions: ["retry", "open_official_instructions"],
+    officialInstructionsUrl,
+  });
+  return officialInstructionsUrl;
 }
 
 async function ensureCodexCliViaUpdater(emit) {
-  await ensureGlobalNpmPackage({
-    emit,
-    command: "codex",
-    packageName: "@openai/codex",
-    label: "Codex",
-  });
-
   const baseline = CLI_MIN_VERSION_BASELINE["@openai/codex"];
   let resolved = resolveInstalledCodexBinary();
   const installed = await runInstalledVersion(resolved, "codex");
+  if (!installed) {
+    const url = emitCliActionRequired(emit, {
+      label: "Codex",
+      bareCommand: "codex",
+      packageName: "@openai/codex",
+      reason: "installation_required",
+    });
+    throw new Error(
+      `Codex CLI is not installed in a verifiable location. Install it from ${url}, then retry.`,
+    );
+  }
   if (!isBelowBaseline(installed, baseline)) {
     return resolved;
   }
@@ -460,23 +470,32 @@ async function ensureCodexCliViaUpdater(emit) {
     message: `Updating Codex CLI to ${baseline} or newer...`,
   });
 
-  try {
-    await runCodexSelfUpdate(resolved !== "codex" ? resolved : "codex");
-  } catch (error) {
-    throw new Error(
-      `Codex CLI ${installed ?? "unknown"} is too old for Seren's GPT-5.6 ` +
-        `defaults and auto-update failed. Run "codex update" manually and ` +
-        `restart Seren. ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
+  const outcome = await backgroundUpdateCli({
+    label: "Codex",
+    bareCommand: "codex",
+    resolvedPath: resolved,
+    packageName: "@openai/codex",
+    npmCliScript: resolveNpmCliScript(),
+    force: true,
+    onUpdated: ({ label, from, to }) =>
+      emit?.("provider://cli-updated", { label, from, to }),
+    onScanRejected: (event) =>
+      emit?.("provider://cli-scan-rejected", event),
+    onActionRequired: (event) =>
+      emit?.("provider://cli-update-action-required", event),
+  });
 
   resolved = resolveInstalledCodexBinary();
   const updated = await runInstalledVersion(resolved, "codex");
-  if (isBelowBaseline(updated, baseline)) {
+  if (
+    outcome.outcome !== "success" ||
+    !updated ||
+    isBelowBaseline(updated, baseline)
+  ) {
     throw new Error(
-      `Codex CLI is still ${updated ?? "unknown"} after update; Seren requires ` +
-        `${baseline} or newer for GPT-5.6 defaults. Run "codex update" manually ` +
-        "and restart Seren.",
+      `Codex CLI is still ${updated ?? "unknown"}; Seren requires ${baseline} ` +
+        `or newer. Update it from ${CLI_INSTALL_INSTRUCTIONS["@openai/codex"]}, ` +
+        `then retry. (${outcome.outcome})`,
     );
   }
 
@@ -488,7 +507,7 @@ async function ensureCodexCliViaUpdater(emit) {
   return resolved;
 }
 
-async function ensureClaudeCodeViaNativeInstaller(emit) {
+async function ensureClaudeCodeCli(emit) {
   // Check well-known install paths first (bare `which`/`where` can find stale wrappers)
   const existing = resolveInstalledClaudeBinary();
   if (existing !== "claude") {
@@ -512,137 +531,19 @@ async function ensureClaudeCodeViaNativeInstaller(emit) {
         return "claude";
       }
     } catch {
-      // which/where failed — fall through to install
+      // which/where failed — fall through to the manual install handoff.
     }
   }
 
-  // Strategy 1: Official native installer (PowerShell on Windows, bash on Unix)
-  emit("provider://cli-install-progress", {
-    stage: "installing",
-    message: "Installing Claude Code CLI via official installer...",
+  const url = emitCliActionRequired(emit, {
+    label: "Claude Code",
+    bareCommand: "claude",
+    packageName: "@anthropic-ai/claude-code",
+    reason: "installation_required",
   });
-
-  let nativeInstallerFailed = false;
-  try {
-    await new Promise((resolvePromise, rejectPromise) => {
-      let cmd;
-      let args;
-
-      if (process.platform === "win32") {
-        cmd = "powershell";
-        args = ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "irm https://claude.ai/install.ps1 | iex"];
-      } else {
-        cmd = "bash";
-        args = ["-c", "curl -fsSL https://claude.ai/install.sh | bash"];
-      }
-
-      execFile(cmd, args, { timeout: 120_000 }, (error, stdout, stderr) => {
-        if (error) {
-          rejectPromise(new Error(stderr || error.message));
-          return;
-        }
-        resolvePromise(stdout.trim());
-      });
-    });
-
-    // Verify the binary actually landed where we expect AND that it's the
-    // right arch for this host. `resolveInstalledClaudeBinary` skips wrong-arch
-    // candidates, so a returned sentinel here means either no install dropped
-    // or install.sh dropped a wrong-arch slice (e.g. uname -m fooled by a
-    // Rosetta'd parent context). Both cases fall through to npm install, which
-    // uses our embedded arm64/x64 node and gets the arch right by construction. #1862
-    const resolved = resolveInstalledClaudeBinary();
-    if (resolved !== "claude") {
-      emit("provider://cli-install-progress", {
-        stage: "complete",
-        message: "Claude Code CLI installed successfully",
-      });
-      return resolved;
-    }
-
-    console.warn(
-      "[agent-registry] Native installer succeeded but no arch-compatible binary " +
-        `was found at expected paths (host=${process.arch}). Falling back to npm install.`,
-    );
-    nativeInstallerFailed = true;
-  } catch (nativeError) {
-    console.warn("[agent-registry] Native installer failed:", nativeError.message);
-    nativeInstallerFailed = true;
-  }
-
-  // Strategy 2: npm install via the embedded runtime's own Node.js and npm.
-  // The Seren Desktop bundle ships node.exe and npm — use them directly so the
-  // install works regardless of system PATH, PowerShell execution policy, or
-  // whether the user has Node.js installed globally.
-  if (nativeInstallerFailed) {
-    emit("provider://cli-install-progress", {
-      stage: "installing",
-      message: "Installing Claude Code CLI via npm (bundled runtime)...",
-    });
-
-    const npmCliScript = resolveNpmCliScript();
-    try {
-      if (npmCliScript) {
-        await new Promise((resolvePromise, rejectPromise) => {
-          execFile(
-            process.execPath,
-            [npmCliScript, "install", "-g", "@anthropic-ai/claude-code"],
-            { timeout: 120_000 },
-            (error, stdout, stderr) => {
-              if (error) {
-                rejectPromise(new Error(stderr || error.message));
-                return;
-              }
-              resolvePromise(stdout.trim());
-            },
-          );
-        });
-      } else if (process.platform === "win32") {
-        // Last resort on Windows: try npm.cmd from PATH
-        await new Promise((resolvePromise, rejectPromise) => {
-          execFile(
-            "npm.cmd",
-            ["install", "-g", "@anthropic-ai/claude-code"],
-            { timeout: 120_000 },
-            (error, stdout, stderr) => {
-              if (error) {
-                rejectPromise(new Error(stderr || error.message));
-                return;
-              }
-              resolvePromise(stdout.trim());
-            },
-          );
-        });
-      } else {
-        throw new Error("npm not available in embedded runtime");
-      }
-
-      const resolved = resolveInstalledClaudeBinary();
-      if (resolved !== "claude") {
-        emit("provider://cli-install-progress", {
-          stage: "complete",
-          message: "Claude Code CLI installed successfully via npm",
-        });
-        return resolved;
-      }
-
-      // npm install returned success but binary not found
-      throw new Error(
-        "Claude Code package installed but binary not found. " +
-        "Try running: npm install -g @anthropic-ai/claude-code"
-      );
-    } catch (npmError) {
-      console.error("[agent-registry] npm install also failed:", npmError.message);
-      throw new Error(
-        `Failed to install Claude Code CLI.\n` +
-        `Native installer: ${nativeInstallerFailed ? "failed (possibly blocked by execution policy)" : "skipped"}\n` +
-        `npm install: ${npmError.message}\n` +
-        `Please install manually: npm install -g @anthropic-ai/claude-code`
-      );
-    }
-  }
-
-  return resolveInstalledClaudeBinary();
+  throw new Error(
+    `Claude Code CLI is not installed. Install it from ${url}, then retry.`,
+  );
 }
 
 /**
@@ -876,7 +777,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             ? {}
             : {
                 unavailableReason:
-                  "Codex CLI is not installed yet. Seren can install it automatically on first launch.",
+                  "Codex CLI is not installed. Seren will open the official installation instructions when you start this agent.",
               }),
         };
       },
@@ -913,7 +814,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
             ? {}
             : {
                 unavailableReason:
-                  "Claude Code CLI is not installed yet. Seren can install it automatically on first launch.",
+                  "Claude Code CLI is not installed. Seren will open the official installation instructions when you start this agent.",
               }),
         };
       },
@@ -921,7 +822,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
         return true;
       },
       async ensureCli() {
-        return ensureClaudeCodeViaNativeInstaller(emit);
+        return ensureClaudeCodeCli(emit);
       },
       launchLogin() {
         // Login MUST target the same binary that claude-runtime resolves
@@ -957,7 +858,7 @@ export function createBrowserLocalAgentRegistry({ emit }) {
           ...(missing.length === 0
             ? {}
             : {
-                unavailableReason: `${missing.join(" and ")} CLI${missing.length > 1 ? "s are" : " is"} not installed yet. Seren can install ${missing.length > 1 ? "them" : "it"} automatically on first launch.`,
+                unavailableReason: `${missing.join(" and ")} CLI${missing.length > 1 ? "s are" : " is"} not installed. Seren will provide official installation instructions when you start this agent.`,
               }),
         };
       },
@@ -1140,10 +1041,21 @@ export function createBrowserLocalAgentRegistry({ emit }) {
   }
 
   // Fire-and-forget background update checks for bundled CLIs (#1637).
-  // TTL-gated to 24h inside backgroundUpdateCli, same-channel only, silent
-  // on failure. Do not await — registry init must not block on npm.
+  // TTL-gated to 24h inside backgroundUpdateCli and same-channel only. Any
+  // verification failure emits one deduplicated recovery event. Do not await
+  // here — registry init must not block on npm.
   const npmCliScript = resolveNpmCliScript();
-  const onUpdated = async ({ label, from, to }) => {
+  const persistedUpdaterState = loadState();
+  let pendingCliUpdateAction = [
+    persistedUpdaterState["pendingAction:codex"],
+    persistedUpdaterState["pendingAction:claude"],
+  ]
+    .filter(Boolean)
+    .sort((left, right) => (right.at ?? 0) - (left.at ?? 0))[0] ?? null;
+  const onUpdated = async ({ label, bareCommand, from, to }) => {
+    if (pendingCliUpdateAction?.bareCommand === bareCommand) {
+      pendingCliUpdateAction = null;
+    }
     emit?.("provider://cli-updated", { label, from, to });
     // #1713 §4.7 schema-drift gate: after a Claude CLI auto-update, run
     // the synthetic-transcript builder against a known-good fixture and
@@ -1187,24 +1099,52 @@ export function createBrowserLocalAgentRegistry({ emit }) {
       flags,
     });
   };
-  void backgroundUpdateCli({
-    label: "Codex",
-    bareCommand: "codex",
-    resolvedPath: resolveInstalledCodexBinary(),
-    packageName: "@openai/codex",
-    npmCliScript,
-    onUpdated,
-    onScanRejected,
-  });
-  void backgroundUpdateCli({
-    label: "Claude Code",
-    bareCommand: "claude",
-    resolvedPath: resolveInstalledClaudeBinary(),
-    packageName: "@anthropic-ai/claude-code",
-    npmCliScript,
-    onUpdated,
-    onScanRejected,
-  });
+  const onActionRequired = (event) => {
+    pendingCliUpdateAction = event;
+    emit?.("provider://cli-update-action-required", event);
+  };
+  const cliUpdateConfigs = {
+    codex: {
+      label: "Codex",
+      bareCommand: "codex",
+      packageName: "@openai/codex",
+      resolvePath: resolveInstalledCodexBinary,
+    },
+    claude: {
+      label: "Claude Code",
+      bareCommand: "claude",
+      packageName: "@anthropic-ai/claude-code",
+      resolvePath: resolveInstalledClaudeBinary,
+    },
+  };
+  const runCliUpdate = async (bareCommand, { force = false } = {}) => {
+    const config = cliUpdateConfigs[bareCommand];
+    if (!config) {
+      throw new Error(`Unsupported CLI update target: ${bareCommand}`);
+    }
+    const result = await backgroundUpdateCli({
+      label: config.label,
+      bareCommand: config.bareCommand,
+      resolvedPath: config.resolvePath(),
+      packageName: config.packageName,
+      npmCliScript,
+      force,
+      onUpdated,
+      onScanRejected,
+      onActionRequired,
+    });
+    if (result.actionRequired) {
+      pendingCliUpdateAction = result.actionRequired;
+    } else if (
+      pendingCliUpdateAction?.bareCommand === bareCommand &&
+      (result.outcome === "success" || result.outcome === "skipped:up_to_date")
+    ) {
+      pendingCliUpdateAction = null;
+    }
+    return result;
+  };
+  void runCliUpdate("codex");
+  void runCliUpdate("claude");
 
   return {
     async getAvailableAgents() {
@@ -1229,6 +1169,21 @@ export function createBrowserLocalAgentRegistry({ emit }) {
 
     async ensureAgentCli(agentType) {
       return getDefinition(agentType).ensureCli();
+    },
+
+    async retryCliUpdate(bareCommand) {
+      const result = await runCliUpdate(bareCommand, { force: true });
+      if (
+        result.outcome === "success" ||
+        result.outcome === "skipped:up_to_date"
+      ) {
+        pendingCliUpdateAction = null;
+      }
+      return result;
+    },
+
+    getPendingCliUpdateAction() {
+      return pendingCliUpdateAction;
     },
 
     launchLogin(agentType) {

--- a/bin/browser-local/cli-scanner.mjs
+++ b/bin/browser-local/cli-scanner.mjs
@@ -2,7 +2,7 @@
 // ABOUTME: Diffs an npm pack against the last-known-good baseline + runs static heuristics.
 
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -40,11 +40,31 @@ const EVAL_INVOCATION_RE = /\beval\s*\(/g;
 const NEW_FUNCTION_RE = /\bnew\s+Function\s*\(/g;
 const DYNAMIC_REQUIRE_RE = /\brequire\s*\(\s*[^"'`)\s][^)]*\)/g;
 const HOSTNAME_RE = /(https?:\/\/|[a-z0-9.-]+\.[a-z]{2,})/gi;
+const NETWORK_URL_RE = /https?:\/\/[^\s"'`<>\\]+/gi;
+const EXECUTABLE_FILE_RE = /\.(exe|dll|so|dylib|bin)$/i;
 
 export function computeSha512(absPath) {
   const hash = createHash("sha512");
   hash.update(readFileSync(absPath));
   return hash.digest("hex");
+}
+
+/** Verify downloaded bytes against the registry's exact sha512 SRI value. */
+export function verifyTarballIntegrity(absPath, integrity) {
+  if (typeof integrity !== "string") return false;
+  const sha512Token = integrity
+    .trim()
+    .split(/\s+/)
+    .find((token) => token.startsWith("sha512-"));
+  if (!sha512Token) return false;
+
+  try {
+    const expected = Buffer.from(sha512Token.slice("sha512-".length), "base64");
+    const actual = createHash("sha512").update(readFileSync(absPath)).digest();
+    return expected.length === actual.length && timingSafeEqual(expected, actual);
+  } catch {
+    return false;
+  }
 }
 
 function packageRelativePath(root, absPath) {
@@ -166,19 +186,106 @@ export function buildPackageSnapshot(extractedRoot) {
     ...(pkg.optionalDependencies ?? {}),
   }).sort();
 
+  const binEntries = {};
+  if (typeof pkg.bin === "string") {
+    const command =
+      typeof pkg.name === "string" ? pkg.name.split("/").at(-1) : null;
+    if (command) binEntries[command] = pkg.bin;
+  } else if (pkg.bin && typeof pkg.bin === "object") {
+    for (const [command, target] of Object.entries(pkg.bin)) {
+      if (typeof target === "string") binEntries[command] = target;
+    }
+  }
+
   const files = walkFiles(extractedRoot);
   const fileHashes = {};
+  const executableFiles = new Set(Object.values(binEntries));
+  const networkHosts = new Set();
   for (const rel of files) {
-    fileHashes[rel] = computeSha512(path.join(extractedRoot, rel));
+    const absPath = path.join(extractedRoot, rel);
+    fileHashes[rel] = computeSha512(absPath);
+    if (EXECUTABLE_FILE_RE.test(rel)) executableFiles.add(rel);
+    if (/\.(c?js|mjs)$/.test(rel)) {
+      let content = "";
+      try {
+        content = readFileSync(absPath, "utf8");
+      } catch {
+        // The file hash still protects unreadable files; no host can be extracted.
+      }
+      NETWORK_URL_RE.lastIndex = 0;
+      for (const match of content.matchAll(NETWORK_URL_RE)) {
+        try {
+          networkHosts.add(new URL(match[0]).hostname.toLowerCase());
+        } catch {
+          // Ignore malformed URL-looking text.
+        }
+      }
+    }
   }
 
   return {
     version: typeof pkg.version === "string" ? pkg.version : null,
     installScripts,
     declaredDependencies,
+    binEntries,
+    executableFiles: [...executableFiles].sort(),
+    networkHosts: [...networkHosts].sort(),
     files,
     fileHashes,
   };
+}
+
+/**
+ * Conservative allowlist used when no prior known-good package snapshot exists.
+ * Any unexpected install hook, dependency, executable, or network host rejects
+ * the candidate instead of treating the first observed release as trusted.
+ */
+export function evaluateFirstBaselinePolicy(candidate, policy) {
+  if (!candidate || !policy) return ["first_baseline_policy_missing"];
+  const flags = [];
+  const allowedScripts = policy.installScripts ?? {};
+  for (const [hook, script] of Object.entries(candidate.installScripts ?? {})) {
+    if (allowedScripts[hook] !== script) {
+      flags.push(`first_baseline_install_script:${hook}`);
+    }
+  }
+
+  const dependencyPatterns = policy.dependencyPatterns ?? [];
+  for (const dependency of candidate.declaredDependencies ?? []) {
+    if (!dependencyPatterns.some((pattern) => pattern.test(dependency))) {
+      flags.push(`first_baseline_dependency:${dependency}`);
+    }
+  }
+
+  const allowedBins = policy.binEntries ?? {};
+  const candidateBins = candidate.binEntries ?? {};
+  for (const command of new Set([
+    ...Object.keys(allowedBins),
+    ...Object.keys(candidateBins),
+  ])) {
+    if (candidateBins[command] !== allowedBins[command]) {
+      flags.push(
+        `first_baseline_executable:${command}:${candidateBins[command] ?? "missing"}`,
+      );
+    }
+  }
+
+  const allowedExecutableFiles = new Set(policy.executableFiles ?? []);
+  for (const executable of candidate.executableFiles ?? []) {
+    if (!allowedExecutableFiles.has(executable)) {
+      flags.push(`first_baseline_executable:${executable}`);
+    }
+  }
+
+  const allowedHosts = new Set(
+    (policy.hostnameAllowlist ?? []).map((host) => host.toLowerCase()),
+  );
+  for (const host of candidate.networkHosts ?? []) {
+    if (!isHostAllowed(host.toLowerCase(), allowedHosts)) {
+      flags.push(`first_baseline_host:${host}`);
+    }
+  }
+  return flags;
 }
 
 /**

--- a/bin/browser-local/cli-updater.mjs
+++ b/bin/browser-local/cli-updater.mjs
@@ -1,5 +1,5 @@
 // ABOUTME: Background updates for bundled agent CLIs (Codex, Claude Code) per #1637.
-// ABOUTME: Fire-and-forget at startup, TTL-gated, same-channel only, silent on failure.
+// ABOUTME: Verifies candidate bytes and post-update health before reporting success.
 
 import { execFile } from "node:child_process";
 import {
@@ -15,7 +15,12 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import { npmPackToDirectory, scanTarball } from "./cli-scanner.mjs";
+import {
+  evaluateFirstBaselinePolicy,
+  npmPackToDirectory,
+  scanTarball,
+  verifyTarballIntegrity,
+} from "./cli-scanner.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -297,32 +302,31 @@ const HOSTNAME_ALLOWLIST = {
   ],
 };
 
-/**
- * Run the Claude Code native installer script. Matches the original install
- * path in agent-registry.mjs so we stay on the same channel rather than
- * silently writing a parallel npm install.
- */
-async function runClaudeNativeInstaller() {
-  if (process.platform === "win32") {
-    await execFileAsync(
-      "powershell",
-      [
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        "irm https://claude.ai/install.ps1 | iex",
-      ],
-      { timeout: NPM_INSTALL_TIMEOUT_MS },
-    );
-    return;
-  }
-  await execFileAsync(
-    "bash",
-    ["-c", "curl -fsSL https://claude.ai/install.sh | bash"],
-    { timeout: NPM_INSTALL_TIMEOUT_MS },
-  );
-}
+const FIRST_BASELINE_POLICIES = {
+  "@anthropic-ai/claude-code": {
+    installScripts: { postinstall: "node install.cjs" },
+    dependencyPatterns: [
+      /^@anthropic-ai\/claude-code-(darwin|linux|win32)-(arm64|x64)(-musl)?$/,
+    ],
+    binEntries: { claude: "bin/claude.exe" },
+    executableFiles: ["bin/claude.exe"],
+    hostnameAllowlist: HOSTNAME_ALLOWLIST["@anthropic-ai/claude-code"],
+  },
+  "@openai/codex": {
+    installScripts: {},
+    dependencyPatterns: [
+      /^@openai\/codex-(darwin|linux|win32)-(arm64|x64)$/,
+    ],
+    binEntries: { codex: "bin/codex.js" },
+    executableFiles: ["bin/codex.js"],
+    hostnameAllowlist: HOSTNAME_ALLOWLIST["@openai/codex"],
+  },
+};
+
+const OFFICIAL_INSTRUCTIONS_URLS = {
+  "@anthropic-ai/claude-code": "https://code.claude.com/docs/en/installation",
+  "@openai/codex": "https://developers.openai.com/codex/cli/",
+};
 
 /**
  * Attempt the CLI's own self-update first (native-channel binaries that
@@ -341,6 +345,67 @@ async function tryCliSelfUpdate(resolvedPath) {
   } catch {
     return false;
   }
+}
+
+/** Basic post-update spawn check that does not require authentication. */
+async function runCliHealthCheck(resolvedPath) {
+  try {
+    const onWindowsCmd =
+      process.platform === "win32" && resolvedPath.toLowerCase().endsWith(".cmd");
+    await execFileAsync(resolvedPath, ["--help"], {
+      timeout: VERSION_CMD_TIMEOUT_MS,
+      shell: onWindowsCmd,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Fetch the exact registry SRI for a version before accepting packed bytes. */
+export async function runNpmViewIntegrity(
+  packageName,
+  version,
+  { npmCliScript } = {},
+) {
+  try {
+    const args = [
+      ...(npmCliScript ? [npmCliScript] : []),
+      "view",
+      `${packageName}@${version}`,
+      "dist.integrity",
+      "--json",
+    ];
+    const command = npmCliScript
+      ? process.execPath
+      : process.platform === "win32"
+        ? "npm.cmd"
+        : "npm";
+    const { stdout } = await execFileAsync(command, args, {
+      timeout: NPM_VIEW_TIMEOUT_MS,
+    });
+    const trimmed = stdout.trim();
+    if (!trimmed) return null;
+    const parsed = JSON.parse(trimmed);
+    return typeof parsed === "string" && parsed.startsWith("sha512-")
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isVersionAtLeast(installed, expected) {
+  if (typeof installed !== "string" || typeof expected !== "string") return false;
+  const a = installed.match(SEMVER_EXACT_RE);
+  const b = expected.match(SEMVER_EXACT_RE);
+  if (!a || !b) return false;
+  for (let i = 1; i <= 3; i++) {
+    const ai = Number(a[i]);
+    const bi = Number(b[i]);
+    if (ai !== bi) return ai > bi;
+  }
+  return true;
 }
 
 /**
@@ -374,6 +439,9 @@ function emitOutcomeLog({ packageName, outcome, details, logger }) {
   const level =
     outcome === "skipped:scan_rejected" ||
     outcome === "skipped:scan_error" ||
+    outcome === "skipped:integrity_failed" ||
+    outcome === "skipped:self_update_failed" ||
+    outcome === "skipped:verification_required" ||
     outcome === "skipped:install_failed"
       ? "warn"
       : "info";
@@ -391,9 +459,9 @@ function emitOutcomeLog({ packageName, outcome, details, logger }) {
 }
 
 /**
- * Fire-and-forget update check for a single CLI. TTL-gated; same-channel
- * only; silent on failure. Called once per app launch — two launches within
- * 24h make zero additional npm calls for this CLI.
+ * Fire-and-forget update check for a single CLI. TTL-gated and same-channel
+ * only. Verification failures emit a deduplicated recovery event. Called once
+ * per app launch — two launches within 24h make zero additional npm calls.
  *
  * Returns a normalized outcome object: `{ outcome, packageName, ...details }`.
  * Every invocation emits exactly one log line + (for success or scan_rejected)
@@ -407,8 +475,10 @@ export async function backgroundUpdateCli({
   npmCliScript,
   now = Date.now(),
   state,
+  force = false,
   onUpdated,
   onScanRejected,
+  onActionRequired,
   logger,
   // Test seams — production callers leave these undefined and the real
   // scanner + version commands run against npm/disk.
@@ -419,10 +489,18 @@ export async function backgroundUpdateCli({
   const scanFn = _scannerOverrides?.scanTarball ?? scanTarball;
   const installFromTarballFn =
     _scannerOverrides?.runNpmInstallFromTarball ?? runNpmInstallFromTarball;
+  const verifyIntegrityFn =
+    _scannerOverrides?.verifyTarballIntegrity ?? verifyTarballIntegrity;
+  const firstBaselinePolicyFn =
+    _scannerOverrides?.evaluateFirstBaselinePolicy ?? evaluateFirstBaselinePolicy;
   const installedVersionFn =
     _versionOverrides?.runInstalledVersion ?? runInstalledVersion;
   const npmViewFn = _versionOverrides?.runNpmView ?? runNpmView;
+  const npmViewIntegrityFn =
+    _versionOverrides?.runNpmViewIntegrity ?? runNpmViewIntegrity;
   const selfUpdateFn = _versionOverrides?.tryCliSelfUpdate ?? tryCliSelfUpdate;
+  const healthCheckFn =
+    _versionOverrides?.runCliHealthCheck ?? runCliHealthCheck;
 
   // Compatibility: production runs may not pass `state` (callers were
   // written before the test seam). When state is omitted we manage
@@ -448,6 +526,7 @@ export async function backgroundUpdateCli({
   try {
     const persisted = state ?? loadState();
     const key = `lastUpdateCheck:${bareCommand}`;
+    const pendingActionKey = `pendingAction:${bareCommand}`;
     const lastCheck = persisted[key];
 
     const channel = classifyInstallChannel(resolvedPath, bareCommand);
@@ -465,6 +544,7 @@ export async function backgroundUpdateCli({
       typeof baseline === "string" && isBelowBaseline(installed, baseline);
 
     if (
+      !force &&
       !belowBaseline &&
       typeof lastCheck === "number" &&
       now - lastCheck < UPDATE_CHECK_TTL_MS
@@ -486,48 +566,74 @@ export async function backgroundUpdateCli({
       return report("skipped:network", { installed });
     }
 
-    if (installed && latest && isNewer(installed, latest)) {
-      if (packageName === "@openai/codex") {
-        const selfOk = await selfUpdateFn(resolvedPath);
-        if (selfOk) {
-          saveState(persisted);
-          onUpdated?.({
-            label,
-            bareCommand,
-            from: installed,
-            to: latest,
-            channel: "self",
-          });
-          return report("success", { from: installed, to: latest, channel: "self" });
-        }
+    function requireAction(reason, details = {}) {
+      const actionKey = `lastActionRequired:${bareCommand}:${latest}`;
+      const lastAction = persisted[actionKey];
+      const actionRequired = {
+        label,
+        bareCommand,
+        packageName,
+        from: installed,
+        to: latest,
+        reason,
+        actions: ["retry", "open_official_instructions"],
+        officialInstructionsUrl: OFFICIAL_INSTRUCTIONS_URLS[packageName] ?? null,
+        at: now,
+        ...details,
+      };
+      persisted[pendingActionKey] = actionRequired;
+      if (
+        typeof lastAction !== "number" ||
+        now - lastAction >= UPDATE_CHECK_TTL_MS
+      ) {
+        persisted[actionKey] = now;
+        onActionRequired?.(actionRequired);
       }
+      if (ownsPersistence) saveState(persisted);
+      return report(`skipped:${reason}`, {
+        from: installed,
+        to: latest,
+        actionRequired,
+        ...details,
+      });
+    }
 
-      // Native installs are gated by the upstream's signed installer + their
-      // own self-update mechanism; we don't have a tarball to scan. Keep
-      // existing flow. npm channel updates are scanned per #1647.
-      if (channel === "native") {
-        try {
-          const selfOk = await selfUpdateFn(resolvedPath);
-          if (!selfOk) {
-            await runClaudeNativeInstaller();
-          }
-          saveState(persisted);
-          onUpdated?.({
-            label,
-            bareCommand,
-            from: installed,
-            to: latest,
+    if (installed && latest && isNewer(installed, latest)) {
+      // Native-channel binaries and Codex's package-manager-aware updater must
+      // verify the resulting bytes before success is surfaced. Never fall back
+      // to a downloaded installer script when self-update fails.
+      if (channel === "native" || packageName === "@openai/codex") {
+        const selfOk = await selfUpdateFn(resolvedPath);
+        if (!selfOk) {
+          return requireAction("self_update_failed", { channel });
+        }
+        const verifiedVersion = await installedVersionFn(
+          resolvedPath,
+          bareCommand,
+        );
+        const healthy = await healthCheckFn(resolvedPath);
+        if (!isVersionAtLeast(verifiedVersion, latest) || !healthy) {
+          return requireAction("verification_required", {
             channel,
-          });
-          return report("success", { from: installed, to: latest, channel });
-        } catch {
-          saveState(persisted);
-          return report("skipped:install_failed", {
-            from: installed,
-            to: latest,
-            channel,
+            verifiedVersion,
           });
         }
+        persisted[pendingActionKey] = null;
+        if (ownsPersistence) saveState(persisted);
+        onUpdated?.({
+          label,
+          bareCommand,
+          from: installed,
+          to: latest,
+          channel: "self",
+          verifiedVersion,
+        });
+        return report("success", {
+          from: installed,
+          to: latest,
+          channel: "self",
+          verifiedVersion,
+        });
       }
 
       // npm channel: pack-extract-scan-install-baseline.
@@ -543,20 +649,50 @@ export async function backgroundUpdateCli({
       } catch {
         // Silent.
       }
+      const cleanupStaging = () => {
+        try {
+          rmSync(stagingDir, { recursive: true, force: true });
+        } catch {
+          // Silent.
+        }
+      };
       try {
+        const expectedIntegrity = await npmViewIntegrityFn(
+          packageName,
+          latest,
+          { npmCliScript },
+        );
+        if (!expectedIntegrity) {
+          cleanupStaging();
+          return requireAction("integrity_failed", { channel });
+        }
         const tarballPath = await packFn({
           packageName,
           version: latest,
           destinationDir: stagingDir,
           npmCliScript,
         });
+        if (!verifyIntegrityFn(tarballPath, expectedIntegrity)) {
+          cleanupStaging();
+          return requireAction("integrity_failed", { channel });
+        }
         const baseline = persisted[`baseline:${packageName}`];
-        const scan = await scanFn({
+        let scan = await scanFn({
           tarballPath,
           baseline,
           workDir: path.join(stagingDir, "extracted"),
           hostnameAllowlist: HOSTNAME_ALLOWLIST[packageName] ?? [],
         });
+
+        if (scan.verdict === "no_baseline") {
+          const policyFlags = firstBaselinePolicyFn(
+            scan.candidate,
+            FIRST_BASELINE_POLICIES[packageName],
+          );
+          if (policyFlags.length > 0) {
+            scan = { ...scan, verdict: "reject", flags: policyFlags };
+          }
+        }
 
         if (scan.verdict === "reject") {
           // Quarantine: leave the rejected tarball + flag list on disk under
@@ -584,11 +720,7 @@ export async function backgroundUpdateCli({
           };
           saveState(persisted);
           // Cleanup staging now that we've recorded the rejection.
-          try {
-            rmSync(stagingDir, { recursive: true, force: true });
-          } catch {
-            // Silent.
-          }
+          cleanupStaging();
           // UI surfacing: notify the registry / TS layer so a banner or
           // notification can fire. Default-on per #1646 — silent scan
           // rejections are worse UX than no scanner at all.
@@ -607,23 +739,30 @@ export async function backgroundUpdateCli({
           });
         }
 
-        // verdict is "pass" or "no_baseline" — install. First install of a
-        // CLI is unguarded by design (no baseline to diff against); the
-        // candidate snapshot becomes the seed baseline so subsequent
-        // updates ARE scanned.
+        // verdict is "pass" or a policy-approved "no_baseline" — install the
+        // exact integrity-verified tarball and seed the next diff baseline.
         try {
           await installFromTarballFn(tarballPath, { npmCliScript });
         } catch {
           saveState(persisted);
-          try {
-            rmSync(stagingDir, { recursive: true, force: true });
-          } catch {
-            // Silent.
-          }
+          cleanupStaging();
           return report("skipped:install_failed", {
             from: installed,
             to: latest,
             channel,
+          });
+        }
+
+        const verifiedVersion = await installedVersionFn(
+          resolvedPath,
+          bareCommand,
+        );
+        const healthy = await healthCheckFn(resolvedPath);
+        if (!isVersionAtLeast(verifiedVersion, latest) || !healthy) {
+          cleanupStaging();
+          return requireAction("verification_required", {
+            channel,
+            verifiedVersion,
           });
         }
 
@@ -632,9 +771,13 @@ export async function backgroundUpdateCli({
           tarballSha512: scan.candidate.tarballSha512,
           installScripts: scan.candidate.installScripts,
           declaredDependencies: scan.candidate.declaredDependencies,
+          binEntries: scan.candidate.binEntries,
+          executableFiles: scan.candidate.executableFiles,
+          networkHosts: scan.candidate.networkHosts,
           files: scan.candidate.files,
           fileHashes: scan.candidate.fileHashes,
         };
+        persisted[pendingActionKey] = null;
         saveState(persisted);
         onUpdated?.({
           label,
@@ -643,31 +786,26 @@ export async function backgroundUpdateCli({
           to: latest,
           channel,
           tarballSha512: scan.candidate.tarballSha512,
+          verifiedVersion,
         });
-        try {
-          rmSync(stagingDir, { recursive: true, force: true });
-        } catch {
-          // Silent.
-        }
+        cleanupStaging();
         return report("success", {
           from: installed,
           to: latest,
           channel,
           tarballSha512: scan.candidate.tarballSha512,
           firstInstall: scan.verdict === "no_baseline",
+          verifiedVersion,
         });
       } catch {
         // Pack/scan failure — fail closed. Don't update.
         saveState(persisted);
-        try {
-          rmSync(stagingDir, { recursive: true, force: true });
-        } catch {
-          // Silent.
-        }
+        cleanupStaging();
         return report("skipped:scan_error", { from: installed, to: latest });
       }
     }
 
+    persisted[pendingActionKey] = null;
     saveState(persisted);
     return report("skipped:up_to_date", { installed, latest });
   } catch {

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -2163,6 +2163,14 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     return agentRegistry.ensureAgentCli(agentType);
   }
 
+  async function retryCliUpdate({ bareCommand }) {
+    return agentRegistry.retryCliUpdate(bareCommand);
+  }
+
+  async function getPendingCliUpdateAction() {
+    return agentRegistry.getPendingCliUpdateAction();
+  }
+
   async function launchLogin({ agentType }) {
     agentRegistry.launchLogin(agentType);
   }
@@ -2451,6 +2459,8 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
     checkAgentAvailable,
     checkAgentAuthenticated,
     ensureAgentCli,
+    retryCliUpdate,
+    getPendingCliUpdateAction,
     launchLogin,
     listRemoteSessions,
     nativeForkSession,

--- a/bin/provider-runtime.mjs
+++ b/bin/provider-runtime.mjs
@@ -112,6 +112,11 @@ function registerProviderHandlers() {
     providerHandlers.checkAgentAuthenticated,
   );
   registerHandler("provider_ensure_agent_cli", providerHandlers.ensureAgentCli);
+  registerHandler("provider_retry_cli_update", providerHandlers.retryCliUpdate);
+  registerHandler(
+    "provider_get_pending_cli_update_action",
+    providerHandlers.getPendingCliUpdateAction,
+  );
   registerHandler("provider_launch_login", providerHandlers.launchLogin);
   registerHandler(
     "provider_native_fork_session",

--- a/src-tauri/src/commands/cli_installer.rs
+++ b/src-tauri/src/commands/cli_installer.rs
@@ -1,5 +1,5 @@
-// ABOUTME: CLI installer commands for auto-installing Claude Code, Codex, and Gemini CLIs
-// ABOUTME: Detects missing CLIs and downloads/installs them automatically
+// ABOUTME: CLI availability checks and guarded installation handoffs.
+// ABOUTME: Avoids executing downloaded scripts; unverified tools require official manual setup.
 
 use std::process::Command;
 use tauri::{AppHandle, Emitter};
@@ -44,143 +44,45 @@ pub async fn check_cli_installed(tool: CliTool) -> Result<bool, String> {
     }
 }
 
-/// Install a CLI tool using the official installer
+fn manual_install_url(tool: &CliTool) -> &'static str {
+    match tool {
+        CliTool::Claude => "https://code.claude.com/docs/en/installation",
+        CliTool::Codex => "https://developers.openai.com/codex/cli/",
+        CliTool::Gemini => "https://github.com/google-gemini/gemini-cli",
+    }
+}
+
+/// Fail closed from the legacy Rust installer. Agent CLI installation belongs
+/// to the embedded provider runtime; this bridge must never invoke system npm
+/// or pipe mutable remote scripts into a shell.
 #[tauri::command]
 pub async fn install_cli_tool(app: AppHandle, tool: CliTool) -> Result<bool, String> {
-    let install_script = match tool {
-        CliTool::Claude => get_claude_install_script(),
-        CliTool::Codex => get_codex_install_script(),
-        CliTool::Gemini => get_gemini_install_script(),
-    };
-
-    log::info!(
-        "[CliInstaller] Installing {:?} using: {}",
-        tool,
-        install_script
+    let url = manual_install_url(&tool);
+    let message = format!(
+        "Automatic installation is disabled on this legacy path. Install from {url}, then retry in Seren."
     );
-
-    // Emit status update
     let _ = app.emit(
         "cli-install-status",
         serde_json::json!({
             "tool": tool,
-            "status": "downloading"
+            "status": "action_required",
+            "message": message,
+            "officialInstructionsUrl": url,
         }),
     );
+    Err(message)
+}
 
-    // Run the installation command
-    let result = if cfg!(target_os = "windows") {
-        install_windows(&install_script)
-    } else {
-        install_unix(&install_script)
-    };
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    match result {
-        Ok(success) => {
-            if success {
-                let _ = app.emit(
-                    "cli-install-status",
-                    serde_json::json!({
-                        "tool": tool,
-                        "status": "installed"
-                    }),
-                );
-                log::info!("[CliInstaller] {:?} installed successfully", tool);
-            } else {
-                let _ = app.emit(
-                    "cli-install-status",
-                    serde_json::json!({
-                        "tool": tool,
-                        "status": "error",
-                        "message": "Installation failed"
-                    }),
-                );
-                log::error!("[CliInstaller] {:?} installation failed", tool);
-            }
-            Ok(success)
-        }
-        Err(e) => {
-            let _ = app.emit(
-                "cli-install-status",
-                serde_json::json!({
-                    "tool": tool,
-                    "status": "error",
-                    "message": e.clone()
-                }),
-            );
-            log::error!("[CliInstaller] {:?} installation error: {}", tool, e);
-            Err(e)
+    #[test]
+    fn unverified_tools_only_return_https_instructions() {
+        for tool in [CliTool::Claude, CliTool::Codex, CliTool::Gemini] {
+            let url = manual_install_url(&tool);
+            assert!(url.starts_with("https://"));
+            assert!(!url.contains('|'));
         }
     }
-}
-
-/// Get Claude Code installation script for current platform
-fn get_claude_install_script() -> String {
-    if cfg!(target_os = "windows") {
-        // PowerShell one-liner
-        "irm https://claude.ai/install.ps1 | iex".to_string()
-    } else {
-        // macOS/Linux bash one-liner
-        "curl -fsSL https://claude.ai/install.sh | bash".to_string()
-    }
-}
-
-/// Get Codex installation script for current platform
-fn get_codex_install_script() -> String {
-    // TODO: Update with actual Codex installation URLs when available
-    if cfg!(target_os = "windows") {
-        "irm https://codex.example.com/install.ps1 | iex".to_string()
-    } else {
-        "curl -fsSL https://codex.example.com/install.sh | bash".to_string()
-    }
-}
-
-/// Get Gemini CLI installation script for current platform.
-/// Installs `@google/gemini-cli` globally via npm. The provider runtime
-/// also has its own install path via `ensureGlobalNpmPackage` in
-/// agent-registry.mjs — this Tauri command exists for the legacy
-/// cliInstallerStore code path used by Settings panels.
-fn get_gemini_install_script() -> String {
-    if cfg!(target_os = "windows") {
-        "npm install -g @google/gemini-cli".to_string()
-    } else {
-        "npm install -g @google/gemini-cli".to_string()
-    }
-}
-
-/// Install on Windows using PowerShell
-fn install_windows(script: &str) -> Result<bool, String> {
-    let mut cmd = Command::new("powershell");
-    cmd.arg("-NoProfile").arg("-Command").arg(script);
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-    }
-    let output = cmd
-        .output()
-        .map_err(|e| format!("Failed to execute PowerShell: {}", e))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("Installation failed: {}", stderr));
-    }
-
-    Ok(true)
-}
-
-/// Install on Unix-like systems using bash
-fn install_unix(script: &str) -> Result<bool, String> {
-    let output = Command::new("bash")
-        .arg("-c")
-        .arg(script)
-        .output()
-        .map_err(|e| format!("Failed to execute bash: {}", e))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("Installation failed: {}", stderr));
-    }
-
-    Ok(true)
 }

--- a/src/components/agents/CliUpdateActionCard.tsx
+++ b/src/components/agents/CliUpdateActionCard.tsx
@@ -1,0 +1,71 @@
+// ABOUTME: Recovery card for CLI updates that could not be verified safely.
+// ABOUTME: Offers a verified retry and an allowlisted official instructions link.
+
+import { type Component, Show } from "solid-js";
+import { agentStore } from "@/stores/agent.store";
+
+function reasonLabel(reason: string): string {
+  switch (reason) {
+    case "installation_required":
+      return "Installation required";
+    case "integrity_failed":
+      return "Download verification failed";
+    case "self_update_failed":
+      return "Update failed";
+    case "verification_required":
+      return "Updated CLI could not be verified";
+    case "unresolved":
+      return "CLI not found in a verifiable location";
+    default:
+      return "Update needs attention";
+  }
+}
+
+export const CliUpdateActionCard: Component = () => (
+  <Show when={agentStore.cliUpdateActionRequired} keyed>
+    {(action) => (
+      <div
+        data-testid="cli-update-action-required"
+        role="alert"
+        class="mx-1 my-1 rounded-lg border border-amber-500/35 bg-amber-500/10 px-2.5 py-2 text-[11px] text-foreground shadow-sm"
+      >
+        <div class="flex items-start gap-2">
+          <div class="min-w-0 flex-1">
+            <div class="font-semibold text-amber-300">
+              {action.label} needs attention
+            </div>
+            <div class="mt-0.5 text-muted-foreground">
+              {reasonLabel(action.reason)}. Seren kept the previous verified
+              version.
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label="Dismiss CLI update action"
+            class="border-0 bg-transparent p-0 text-muted-foreground hover:text-foreground cursor-pointer"
+            onClick={() => agentStore.dismissCliUpdateActionRequired()}
+          >
+            ×
+          </button>
+        </div>
+        <div class="mt-2 flex flex-wrap gap-1.5">
+          <button
+            type="button"
+            class="rounded-md border border-amber-500/35 bg-amber-500/15 px-2 py-1 font-medium text-amber-200 hover:bg-amber-500/25 disabled:cursor-wait disabled:opacity-60"
+            disabled={action.retrying}
+            onClick={() => void agentStore.retryCliUpdate()}
+          >
+            {action.retrying ? "Retrying…" : "Retry"}
+          </button>
+          <button
+            type="button"
+            class="rounded-md border border-border bg-surface-2 px-2 py-1 font-medium text-foreground hover:bg-surface-3"
+            onClick={() => agentStore.openCliUpdateInstructions()}
+          >
+            Install instructions
+          </button>
+        </div>
+      </div>
+    )}
+  </Show>
+);

--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -12,6 +12,7 @@ import {
   Show,
   Switch,
 } from "solid-js";
+import { CliUpdateActionCard } from "@/components/agents/CliUpdateActionCard";
 import { providerGlyph } from "@/components/chat/ProviderIcon";
 import { BountiesSection } from "@/components/sidebar/BountiesSection";
 import { CreateEmployeeModal } from "@/components/sidebar/CreateEmployeeModal";
@@ -622,6 +623,8 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
             </Show>
             {spawning() ? (agentStore.installStatus ?? "Starting...") : "New"}
           </button>
+
+          <CliUpdateActionCard />
 
           <Show when={showLauncher()}>
             <div class="absolute top-[calc(100%+4px)] left-3 right-3 max-h-[60vh] overflow-y-auto bg-surface-2 border border-border rounded-lg z-20 shadow-lg animate-[slideDown_150ms_ease] py-1">

--- a/src/components/layout/ThreadTabBar.tsx
+++ b/src/components/layout/ThreadTabBar.tsx
@@ -9,6 +9,7 @@ import {
   onMount,
   Show,
 } from "solid-js";
+import { CliUpdateActionCard } from "@/components/agents/CliUpdateActionCard";
 import { providerGlyph } from "@/components/chat/ProviderIcon";
 import {
   allowsClaudeAgent,
@@ -230,6 +231,7 @@ export const ThreadTabBar: Component = () => {
 
         <Show when={showNewMenu()}>
           <div class="absolute top-full right-0 min-w-[300px] max-h-[70vh] overflow-y-auto bg-surface-2 border border-border rounded-lg p-1 z-20 shadow-[var(--shadow-lg)] animate-[slideInDown_150ms_ease]">
+            <CliUpdateActionCard />
             <Show when={agentStore.error}>
               <div
                 data-testid="agent-launch-error"

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -720,8 +720,8 @@ export async function getAvailableAgents(): Promise<AgentInfo[]> {
 }
 
 /**
- * Ensure Claude Code CLI is installed, auto-installing via npm if needed.
- * Returns the bin directory path containing the claude binary.
+ * Ensure Claude Code CLI is installed. Missing installs surface an explicit
+ * official-instructions recovery action instead of running a remote script.
  */
 export async function ensureClaudeCli(): Promise<string> {
   return invokeProvider<string>("provider_ensure_agent_cli", {
@@ -731,13 +731,49 @@ export async function ensureClaudeCli(): Promise<string> {
 
 /**
  * Ensure Codex CLI (`@openai/codex`) is installed and meets the minimum version.
- * Installs or upgrades via npm if needed.
- * Returns the bin directory path containing the codex binary.
+ * Missing installs require official manual setup; upgrades are verified before
+ * success is reported.
  */
 export async function ensureCodexCli(): Promise<string> {
   return invokeProvider<string>("provider_ensure_agent_cli", {
     agentType: "codex",
   });
+}
+
+export type CliUpdateOutcome = {
+  outcome: string;
+  packageName: string;
+  bareCommand: string;
+  label: string;
+  from?: string | null;
+  to?: string;
+};
+
+export type CliUpdateActionRequired = {
+  label: string;
+  bareCommand: "claude" | "codex";
+  packageName: string;
+  from?: string | null;
+  to?: string | null;
+  reason: string;
+  officialInstructionsUrl: string;
+  at?: number;
+};
+
+/** Retry one supported CLI update through the verified runtime path. */
+export async function retryCliUpdate(
+  bareCommand: "claude" | "codex",
+): Promise<CliUpdateOutcome> {
+  return invokeProvider<CliUpdateOutcome>("provider_retry_cli_update", {
+    bareCommand,
+  });
+}
+
+/** Read an updater action that may have fired before the UI subscribed. */
+export async function getPendingCliUpdateAction(): Promise<CliUpdateActionRequired | null> {
+  return invokeProvider<CliUpdateActionRequired | null>(
+    "provider_get_pending_cli_update_action",
+  );
 }
 
 /**

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -38,6 +38,7 @@ import {
   type CompactionWindowItem,
   selectCompactionWindow,
 } from "@/lib/compaction/window";
+import { openExternalLink } from "@/lib/external-link";
 import { runtimeHasCapability } from "@/lib/runtime";
 import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import { estimateTokens } from "@/lib/token-counter";
@@ -596,6 +597,9 @@ let providerRuntimeRestartedListener: Promise<UnlistenFn> | null = null;
  *  initialize() calls don't stack listeners. #1646. */
 let cliScanRejectedUnsub: (() => void) | null = null;
 
+/** Set once we've subscribed to actionable CLI update/install failures. */
+let cliUpdateActionRequiredUnsub: (() => void) | null = null;
+
 /** Set once we've subscribed to `provider://synthetic-transcript-schema-drift`
  *  so a Claude CLI auto-update that breaks the splice invariants forces
  *  `compactSyntheticTranscript=false` at runtime. The per-call try/catch
@@ -638,6 +642,9 @@ function disposeAgentStoreSideChannelListeners(): void {
   cliScanRejectedUnsub?.();
   cliScanRejectedUnsub = null;
 
+  cliUpdateActionRequiredUnsub?.();
+  cliUpdateActionRequiredUnsub = null;
+
   syntheticSchemaDriftUnsub?.();
   syntheticSchemaDriftUnsub = null;
 
@@ -675,6 +682,7 @@ function subscribeToProviderRuntimeReady(): void {
         if (agents.length > 0) {
           applyAgents(agents);
         }
+        await hydratePendingCliUpdateAction();
       } catch (error) {
         console.error(
           "Failed to load agents on provider-runtime ready event:",
@@ -874,6 +882,87 @@ function subscribeToCliScanRejections(): void {
         // Silent — best-effort surface, never fail the subscriber.
       }
     },
+  );
+}
+
+/**
+ * Surface verified-updater failures with a recoverable in-app action. Runtime
+ * persistence deduplicates these events to one CLI/version per update TTL.
+ */
+function applyCliUpdateAction(payload: unknown, notify = true): void {
+  const event = payload as Partial<providerService.CliUpdateActionRequired>;
+  if (event.bareCommand !== "claude" && event.bareCommand !== "codex") {
+    return;
+  }
+  const bareCommand = event.bareCommand;
+  const expectedPackage =
+    bareCommand === "claude" ? "@anthropic-ai/claude-code" : "@openai/codex";
+  const expectedInstructionsOrigin =
+    bareCommand === "claude"
+      ? "https://code.claude.com/"
+      : "https://developers.openai.com/";
+  const officialInstructionsUrl = event.officialInstructionsUrl;
+  if (
+    event.packageName !== expectedPackage ||
+    typeof officialInstructionsUrl !== "string" ||
+    !officialInstructionsUrl.startsWith(expectedInstructionsOrigin)
+  ) {
+    return;
+  }
+  if (
+    state.cliUpdateActionRequired?.bareCommand === event.bareCommand &&
+    state.cliUpdateActionRequired?.to === (event.to ?? null) &&
+    state.cliUpdateActionRequired?.reason === event.reason
+  ) {
+    return;
+  }
+  const action = {
+    label: event.label ?? event.packageName,
+    bareCommand,
+    packageName: event.packageName,
+    from: event.from ?? null,
+    to: event.to ?? null,
+    reason: event.reason ?? "verification_required",
+    officialInstructionsUrl,
+    retrying: false,
+    at: event.at ?? Date.now(),
+  };
+  setState("cliUpdateActionRequired", action);
+  console.warn(
+    `[cli-updater] action required for ${action.packageName}; reason=${action.reason}`,
+  );
+  try {
+    if (
+      notify &&
+      typeof Notification !== "undefined" &&
+      Notification.permission === "granted"
+    ) {
+      const notification = new Notification(`${action.label} needs attention`, {
+        body: "Seren kept the previous verified version. Retry or review the official installation instructions in Seren.",
+      });
+      notification.onclick = () => {
+        void openExternalLink(action.officialInstructionsUrl);
+      };
+    }
+  } catch {
+    // Best-effort OS notification; the in-app recovery card remains.
+  }
+}
+
+async function hydratePendingCliUpdateAction(): Promise<void> {
+  try {
+    const action = await providerService.getPendingCliUpdateAction();
+    if (action) applyCliUpdateAction(action, false);
+  } catch {
+    // Runtime startup retries will call this again after the ready event.
+  }
+}
+
+function subscribeToCliUpdateActions(): void {
+  if (cliUpdateActionRequiredUnsub) return;
+  cliUpdateActionRequiredUnsub = onRuntimeEvent(
+    "provider://cli-update-action-required",
+    applyCliUpdateAction,
   );
 }
 
@@ -1714,6 +1803,18 @@ interface AgentState {
     flags: string[];
     at: number;
   } | null;
+  /** Pending manual recovery for a failed or unverifiable CLI update. */
+  cliUpdateActionRequired: {
+    label: string;
+    bareCommand: "claude" | "codex";
+    packageName: string;
+    from: string | null;
+    to: string | null;
+    reason: string;
+    officialInstructionsUrl: string;
+    retrying: boolean;
+    at: number;
+  } | null;
   /** Pending permission requests awaiting user response */
   pendingPermissions: PermissionRequestEvent[];
   /** Pending diff proposals awaiting user accept/reject */
@@ -1761,6 +1862,7 @@ const [state, setState] = createStore<AgentState>({
   error: null,
   installStatus: null,
   cliScanRejection: null,
+  cliUpdateActionRequired: null,
   pendingPermissions: [],
   pendingDiffProposals: [],
   agentModeEnabled: false,
@@ -2188,6 +2290,10 @@ export const agentStore = {
 
   get installStatus() {
     return state.installStatus;
+  },
+
+  get cliUpdateActionRequired() {
+    return state.cliUpdateActionRequired;
   },
 
   get pendingPermissions() {
@@ -2844,6 +2950,8 @@ export const agentStore = {
     // per launch per CLI). System notification + state record so the user
     // can review what was rejected and why.
     subscribeToCliScanRejections();
+    subscribeToCliUpdateActions();
+    void hydratePendingCliUpdateAction();
     // #1829: consume the synthetic-transcript schema-drift event so a
     // breaking Claude CLI auto-update forces compactSyntheticTranscript=false
     // at runtime. Pre-#1829 the runtime emitted this event but no consumer
@@ -6576,6 +6684,53 @@ export const agentStore = {
     setState("error", null);
   },
 
+  async retryCliUpdate() {
+    const action = state.cliUpdateActionRequired;
+    if (!action || action.retrying) return;
+    setState("cliUpdateActionRequired", "retrying", true);
+    try {
+      const result = await providerService.retryCliUpdate(action.bareCommand);
+      if (
+        result.outcome === "success" ||
+        result.outcome === "skipped:up_to_date"
+      ) {
+        setState("cliUpdateActionRequired", null);
+        return;
+      }
+      setState("cliUpdateActionRequired", (current) =>
+        current
+          ? {
+              ...current,
+              reason: result.outcome.replace(/^skipped:/, ""),
+              from: result.from ?? current.from,
+              to: result.to ?? current.to,
+              retrying: false,
+            }
+          : null,
+      );
+    } catch (error) {
+      setState("cliUpdateActionRequired", "retrying", false);
+      setState(
+        "error",
+        error instanceof Error ? error.message : "CLI update retry failed.",
+      );
+    }
+  },
+
+  openCliUpdateInstructions() {
+    const url = state.cliUpdateActionRequired?.officialInstructionsUrl;
+    if (
+      url &&
+      /^https:\/\/(code\.claude\.com|developers\.openai\.com)\//.test(url)
+    ) {
+      void openExternalLink(url);
+    }
+  },
+
+  dismissCliUpdateActionRequired() {
+    setState("cliUpdateActionRequired", null);
+  },
+
   resetSessionState() {
     sessionResetGeneration += 1;
     disposeAgentStoreRuntimeBindings();
@@ -6600,6 +6755,7 @@ export const agentStore = {
       error: null,
       installStatus: null,
       cliScanRejection: null,
+      cliUpdateActionRequired: null,
       pendingPermissions: [],
       pendingDiffProposals: [],
       agentModeEnabled: false,

--- a/tests/unit/cli-scanner.test.ts
+++ b/tests/unit/cli-scanner.test.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Critical tests for #1647 — local diff + static-check scanner.
 // ABOUTME: Locks the gate behavior; no live npm pack / no network in tests.
 
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -13,7 +14,9 @@ const modulePath = new URL(
 const {
   buildPackageSnapshot,
   diffSnapshots,
+  evaluateFirstBaselinePolicy,
   runStaticChecks,
+  verifyTarballIntegrity,
 } = await import(/* @vite-ignore */ modulePath);
 
 let tempRoot: string;
@@ -38,23 +41,84 @@ function writePackage(files: Record<string, string>) {
 }
 
 describe("buildPackageSnapshot", () => {
-  it("captures install scripts, declared deps, files, and hashes", () => {
+  it("captures install scripts, declared deps, executables, hosts, files, and hashes", () => {
     const pkgDir = writePackage({
       "package.json": JSON.stringify({
         name: "@test/x",
         version: "1.0.0",
         scripts: { postinstall: "node setup.js", build: "tsc" },
         dependencies: { foo: "1.0.0", bar: "^2.0.0" },
+        bin: { x: "bin/x.js" },
       }),
-      "dist/index.js": "module.exports = {};",
+      "bin/x.js": 'fetch("https://api.example.com/v1");',
     });
     const snap = buildPackageSnapshot(pkgDir);
     expect(snap.version).toBe("1.0.0");
     expect(snap.installScripts).toEqual({ postinstall: "node setup.js" });
     expect(snap.declaredDependencies).toEqual(["bar", "foo"]);
+    expect(snap.binEntries).toEqual({ x: "bin/x.js" });
+    expect(snap.executableFiles).toEqual(["bin/x.js"]);
+    expect(snap.networkHosts).toEqual(["api.example.com"]);
     expect(snap.files).toContain("package.json");
-    expect(snap.files).toContain("dist/index.js");
+    expect(snap.files).toContain("bin/x.js");
     expect(typeof snap.fileHashes["package.json"]).toBe("string");
+  });
+});
+
+describe("registry integrity and first-baseline gate (#3092)", () => {
+  it("accepts only the exact sha512 integrity for the downloaded tarball", () => {
+    const tarballPath = path.join(tempRoot, "candidate.tgz");
+    writeFileSync(tarballPath, "verified candidate bytes", "utf8");
+    const expected = `sha512-${createHash("sha512")
+      .update("verified candidate bytes")
+      .digest("base64")}`;
+
+    expect(verifyTarballIntegrity(tarballPath, expected)).toBe(true);
+    expect(verifyTarballIntegrity(tarballPath, "sha512-AAAAAAAA")).toBe(false);
+    expect(verifyTarballIntegrity(tarballPath, "sha1-deadbeef")).toBe(false);
+  });
+
+  it("fails a first baseline closed on unapproved scripts, deps, executables, or hosts", () => {
+    const policy = {
+      installScripts: { postinstall: "node install.cjs" },
+      dependencyPatterns: [/^@vendor\/cli-(darwin|linux|win32)-/],
+      binEntries: { cli: "bin/cli.js" },
+      executableFiles: ["bin/cli.js"],
+      hostnameAllowlist: ["vendor.example"],
+    };
+    const candidate = {
+      installScripts: { postinstall: "node install.cjs" },
+      declaredDependencies: ["@vendor/cli-darwin-arm64"],
+      binEntries: { cli: "bin/cli.js" },
+      executableFiles: ["bin/cli.js"],
+      networkHosts: ["api.vendor.example"],
+    };
+
+    expect(evaluateFirstBaselinePolicy(candidate, policy)).toEqual([]);
+    expect(
+      evaluateFirstBaselinePolicy(
+        { ...candidate, installScripts: { postinstall: "node payload.js" } },
+        policy,
+      ),
+    ).toContain("first_baseline_install_script:postinstall");
+    expect(
+      evaluateFirstBaselinePolicy(
+        { ...candidate, declaredDependencies: ["plain-crypto-js"] },
+        policy,
+      ),
+    ).toContain("first_baseline_dependency:plain-crypto-js");
+    expect(
+      evaluateFirstBaselinePolicy(
+        { ...candidate, executableFiles: ["bin/cli.js", "payload.exe"] },
+        policy,
+      ),
+    ).toContain("first_baseline_executable:payload.exe");
+    expect(
+      evaluateFirstBaselinePolicy(
+        { ...candidate, networkHosts: ["collector.invalid"] },
+        policy,
+      ),
+    ).toContain("first_baseline_host:collector.invalid");
   });
 });
 

--- a/tests/unit/cli-updater.test.ts
+++ b/tests/unit/cli-updater.test.ts
@@ -1,7 +1,13 @@
 // ABOUTME: Critical tests for #1637 — background CLI updater pure logic.
 // ABOUTME: Guards TTL gate, semver compare, and same-channel classification.
 
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -240,6 +246,7 @@ describe("isBelowBaseline (#1761)", () => {
   it("uses Codex self-update before npm tarball scanning (#2904)", async () => {
     let selfUpdateCalls = 0;
     let scanCalled = false;
+    const versions = ["0.143.0", "0.144.1"];
     const result = await backgroundUpdateCli({
       label: "Codex",
       bareCommand: "codex",
@@ -248,12 +255,13 @@ describe("isBelowBaseline (#1761)", () => {
       state: {},
       now: Date.now(),
       _versionOverrides: {
-        runInstalledVersion: async () => "0.143.0",
+        runInstalledVersion: async () => versions.shift() ?? null,
         runNpmView: async () => "0.144.1",
         tryCliSelfUpdate: async () => {
           selfUpdateCalls++;
           return true;
         },
+        runCliHealthCheck: async () => true,
       },
       _scannerOverrides: {
         npmPackToDirectory: async () => {
@@ -413,10 +421,10 @@ describe("failure paths (#1645)", () => {
   // every subsequent run short-circuits on TTL).
   function freshInvocation() {
     return {
-      label: "Codex",
-      bareCommand: "codex",
-      resolvedPath: "/usr/local/bin/codex",
-      packageName: "@openai/codex",
+      label: "Claude Code",
+      bareCommand: "claude",
+      resolvedPath: "/usr/local/bin/claude",
+      packageName: "@anthropic-ai/claude-code",
       state: {} as Record<string, unknown>,
       now: Date.now(),
     };
@@ -471,9 +479,11 @@ describe("failure paths (#1645)", () => {
       _versionOverrides: {
         runInstalledVersion: async () => "1.5.0",
         runNpmView: async () => "1.5.3",
+        runNpmViewIntegrity: async () => "sha512-test",
       },
       _scannerOverrides: {
         npmPackToDirectory: async () => "/tmp/fake.tgz",
+        verifyTarballIntegrity: () => true,
         scanTarball: async () => ({
           verdict: "pass",
           flags: [],
@@ -505,9 +515,11 @@ describe("failure paths (#1645)", () => {
       _versionOverrides: {
         runInstalledVersion: async () => "1.5.3",
         runNpmView: async () => "1.5.4",
+        runNpmViewIntegrity: async () => "sha512-test",
       },
       _scannerOverrides: {
         npmPackToDirectory: async () => "/tmp/fake.tgz",
+        verifyTarballIntegrity: () => true,
         scanTarball: async () => ({ verdict: "reject", flags, candidate: null }),
         runNpmInstallFromTarball: async () => {
           throw new Error("must NOT install when scan rejects");
@@ -529,9 +541,11 @@ describe("failure paths (#1645)", () => {
       _versionOverrides: {
         runInstalledVersion: async () => "1.5.0",
         runNpmView: async () => "1.5.3",
+        runNpmViewIntegrity: async () => "sha512-test",
       },
       _scannerOverrides: {
         npmPackToDirectory: async () => "/tmp/fake.tgz",
+        verifyTarballIntegrity: () => true,
         scanTarball: async () => {
           throw new Error("scanner exploded");
         },
@@ -548,20 +562,27 @@ describe("failure paths (#1645)", () => {
     const candidate = {
       version: "1.5.3",
       tarballSha512: "abc",
-      installScripts: {},
-      declaredDependencies: ["foo"],
-      files: ["package.json"],
-      fileHashes: { "package.json": "h" },
+      installScripts: { postinstall: "node install.cjs" },
+      declaredDependencies: ["@anthropic-ai/claude-code-darwin-arm64"],
+      binEntries: { claude: "bin/claude.exe" },
+      executableFiles: ["bin/claude.exe"],
+      networkHosts: ["api.anthropic.com"],
+      files: ["package.json", "bin/claude.exe"],
+      fileHashes: { "package.json": "h", "bin/claude.exe": "b" },
     };
     let installCalled = false;
+    const versions = ["1.5.0", "1.5.3"];
     const result = await backgroundUpdateCli({
       ...freshInvocation(),
       _versionOverrides: {
-        runInstalledVersion: async () => "1.5.0",
+        runInstalledVersion: async () => versions.shift() ?? null,
         runNpmView: async () => "1.5.3",
+        runNpmViewIntegrity: async () => "sha512-test",
+        runCliHealthCheck: async () => true,
       },
       _scannerOverrides: {
         npmPackToDirectory: async () => "/tmp/fake.tgz",
+        verifyTarballIntegrity: () => true,
         scanTarball: async () => ({
           verdict: "no_baseline",
           flags: [],
@@ -593,5 +614,154 @@ describe("failure paths (#1645)", () => {
     process.env.SEREN_CLI_UPDATER_STATE_PATH = path.join(blockedFile, "child.json");
     // Should not throw.
     expect(() => saveState({ a: 1 })).not.toThrow();
+  });
+});
+
+describe("verified fail-closed updates (#3092)", () => {
+  it("emits success only after native self-update version and health verification", async () => {
+    const versions = ["2.1.200", "2.1.216"];
+    const updated: unknown[] = [];
+    const actions: unknown[] = [];
+    const result = await backgroundUpdateCli({
+      label: "Claude Code",
+      bareCommand: "claude",
+      resolvedPath: "/Users/u/.local/bin/claude",
+      packageName: "@anthropic-ai/claude-code",
+      state: {},
+      now: Date.now(),
+      onUpdated: (event: unknown) => updated.push(event),
+      onActionRequired: (event: unknown) => actions.push(event),
+      _versionOverrides: {
+        runInstalledVersion: async () => versions.shift() ?? null,
+        runNpmView: async () => "2.1.216",
+        tryCliSelfUpdate: async () => true,
+        runCliHealthCheck: async () => true,
+      },
+    });
+
+    expect(result).toMatchObject({
+      outcome: "success",
+      from: "2.1.200",
+      to: "2.1.216",
+      verifiedVersion: "2.1.216",
+    });
+    expect(updated).toHaveLength(1);
+    expect(actions).toHaveLength(0);
+  });
+
+  it("fails closed and deduplicates action-required when native verification fails", async () => {
+    const state: Record<string, unknown> = {};
+    const updated: unknown[] = [];
+    const actions: Array<Record<string, unknown>> = [];
+    const invoke = () => {
+      const versions = ["2.1.200", "2.1.200"];
+      return backgroundUpdateCli({
+        label: "Claude Code",
+        bareCommand: "claude",
+        resolvedPath: "/Users/u/.local/bin/claude",
+        packageName: "@anthropic-ai/claude-code",
+        state,
+        now: 1_000,
+        force: true,
+        onUpdated: (event: unknown) => updated.push(event),
+        onActionRequired: (event: Record<string, unknown>) => actions.push(event),
+        _versionOverrides: {
+          runInstalledVersion: async () => versions.shift() ?? null,
+          runNpmView: async () => "2.1.216",
+          tryCliSelfUpdate: async () => true,
+          runCliHealthCheck: async () => true,
+        },
+      });
+    };
+
+    const first = await invoke();
+    const second = await invoke();
+
+    expect(first.outcome).toBe("skipped:verification_required");
+    expect(second.outcome).toBe("skipped:verification_required");
+    expect(updated).toHaveLength(0);
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      reason: "verification_required",
+      actions: ["retry", "open_official_instructions"],
+    });
+    expect(state["pendingAction:claude"]).toMatchObject({
+      reason: "verification_required",
+      to: "2.1.216",
+    });
+  });
+
+  it("rejects an npm tarball whose bytes do not match registry dist.integrity", async () => {
+    let installCalled = false;
+    const actions: unknown[] = [];
+    const result = await backgroundUpdateCli({
+      label: "Claude Code",
+      bareCommand: "claude",
+      resolvedPath: "/opt/homebrew/bin/claude",
+      packageName: "@anthropic-ai/claude-code",
+      state: {},
+      now: Date.now(),
+      onActionRequired: (event: unknown) => actions.push(event),
+      _versionOverrides: {
+        runInstalledVersion: async () => "2.1.200",
+        runNpmView: async () => "2.1.216",
+        runNpmViewIntegrity: async () => "sha512-expected",
+      },
+      _scannerOverrides: {
+        npmPackToDirectory: async () => "/tmp/candidate.tgz",
+        verifyTarballIntegrity: () => false,
+        scanTarball: async () => {
+          throw new Error("must not scan unverified bytes");
+        },
+        runNpmInstallFromTarball: async () => {
+          installCalled = true;
+        },
+      },
+    });
+
+    expect(installCalled).toBe(false);
+    expect(result.outcome).toBe("skipped:integrity_failed");
+    expect(actions).toHaveLength(1);
+  });
+
+  it("contains no automatic downloaded-script execution in production CLI paths", () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../..");
+    const sources = [
+      "bin/browser-local/agent-registry.mjs",
+      "bin/browser-local/cli-updater.mjs",
+      "src-tauri/src/commands/cli_installer.rs",
+    ].map((relative) => readFileSync(path.join(repoRoot, relative), "utf8"));
+    const productionSource = sources.join("\n");
+
+    expect(productionSource).not.toContain("install.sh | bash");
+    expect(productionSource).not.toContain("install.ps1 | iex");
+    expect(productionSource).not.toContain("codex.example.com");
+  });
+
+  it("wires each action-required event to retry and official-instructions controls", () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../..");
+    const registry = readFileSync(
+      path.join(repoRoot, "bin/browser-local/agent-registry.mjs"),
+      "utf8",
+    );
+    const runtime = readFileSync(
+      path.join(repoRoot, "bin/provider-runtime.mjs"),
+      "utf8",
+    );
+    const card = readFileSync(
+      path.join(repoRoot, "src/components/agents/CliUpdateActionCard.tsx"),
+      "utf8",
+    );
+    const store = readFileSync(
+      path.join(repoRoot, "src/stores/agent.store.ts"),
+      "utf8",
+    );
+
+    expect(registry).toContain("provider://cli-update-action-required");
+    expect(runtime).toContain("provider_retry_cli_update");
+    expect(card).toContain("agentStore.retryCliUpdate()");
+    expect(card).toContain("agentStore.openCliUpdateInstructions()");
+    expect(store).toContain("https://code.claude.com/");
+    expect(store).toContain("https://developers.openai.com/");
   });
 });

--- a/tests/unit/codex-cli-upgrade-gate.test.ts
+++ b/tests/unit/codex-cli-upgrade-gate.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Focused guard for #2904 — Codex spawn must block on upgrading old CLIs.
-// ABOUTME: Prevents regressing to install-only ensureCli while GPT-5.6 defaults require a newer Codex.
+// ABOUTME: Prevents regressing to unverified ensureCli while GPT-5.6 defaults require a newer Codex.
 
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
@@ -23,18 +23,20 @@ describe("#2904 Codex CLI upgrade gate", () => {
     expect(codexDefinition).not.toContain("return ensureGlobalNpmPackage({");
   });
 
-  it("the Codex updater runs codex update and fails closed if still below baseline", () => {
+  it("the Codex updater uses the verified update path and fails closed", () => {
     const helperStart = agentRegistrySource.indexOf(
       "async function ensureCodexCliViaUpdater",
     );
     const helperEnd = agentRegistrySource.indexOf(
-      "async function ensureClaudeCodeViaNativeInstaller",
+      "async function ensureClaudeCodeCli",
     );
     const helper = agentRegistrySource.slice(helperStart, helperEnd);
 
     expect(helper).toContain("CLI_MIN_VERSION_BASELINE");
     expect(helper).toContain("isBelowBaseline");
-    expect(helper).toContain("runCodexSelfUpdate");
-    expect(helper).toContain('Run "codex update" manually');
+    expect(helper).toContain("backgroundUpdateCli");
+    expect(helper).toContain("force: true");
+    expect(helper).toContain("provider://cli-update-action-required");
+    expect(helper).toContain('outcome.outcome !== "success"');
   });
 });


### PR DESCRIPTION
## Summary

Implements the minimum viable P0 from #3092 without closing the signed-artifact follow-up.

- removes every automatic downloaded shell/PowerShell installer from provider startup and the legacy Rust bridge
- verifies npm candidate bytes against the exact registry `dist.integrity` value before scanning or installing
- applies a conservative install-script, dependency, executable, bin-entry, and network-host policy when no prior baseline exists
- installs the exact verified tarball, then requires expected `--version` and `--help` health before reporting success
- keeps failed checks fire-and-forget and adds a persisted, TTL-deduplicated Retry / official-instructions recovery action
- preserves the existing scan-rejection diagnostics and schema-drift check

Refs #3092

## Scope

This deliberately ships the issue's immediate P0 boundary. A signed upstream manifest, staged atomic swap, rollback, and verified one-click first install remain tracked in #3092 and are not represented as complete here.

## Network path audit

- startup/UI: provider registry -> local `provider_*` RPC -> `backgroundUpdateCli`
- npm channel: npm registry version/integrity metadata lookup -> versioned tarball download -> local integrity verification/scanner -> exact local tarball install
- native/self-update channel: the already installed vendor CLI runs its supported `update` command, followed by local version and health verification
- recovery UI opens only allowlisted official HTTPS documentation origins
- this runtime feature does not call a Seren publisher; the live npm publisher metadata was used during audit to verify the current package slugs and integrity fields

Package slugs audited:
- `@anthropic-ai/claude-code`
- `@openai/codex`

## Validation

- `pnpm test --reporter=dot`: 338 files passed, 3 skipped; 2,455 tests passed, 15 skipped
- `pnpm build`
- focused Rust installer guard: passed
- Biome on changed JS/TS files: passed
- changed-file TypeScript diagnostics: none
- live macOS app walkthrough, no mocks: app reached ready state; real Codex self-update completed from 0.144.1 to 0.144.6; post-update version and help health checks passed; launcher remained usable
