### PR TITLE
fix(agent): enforce project-scoped file access

### DIFF
--- a/bin/browser-local/claude-file-policy-hook.mjs
+++ b/bin/browser-local/claude-file-policy-hook.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// ABOUTME: Claude PreToolUse hook that enforces Seren's project-root policy in bypass mode.
+// ABOUTME: Emits only denials so approved in-project work remains promptless.
+
+import { evaluateFileAccess } from "./file-access-policy.mjs";
+
+const input = await new Promise((resolve) => {
+  let raw = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    raw += chunk;
+  });
+  process.stdin.on("end", () => {
+    try {
+      resolve(JSON.parse(raw));
+    } catch {
+      resolve({});
+    }
+  });
+});
+
+const toolName = input?.tool_name;
+const toolInput = input?.tool_input ?? {};
+const pathFields = {
+  Read: ["file_path", "read"],
+  Edit: ["file_path", "write"],
+  Write: ["file_path", "write"],
+  Glob: ["path", "read"],
+  Grep: ["path", "read"],
+  NotebookEdit: ["notebook_path", "write"],
+};
+
+let permissionDecision = null;
+let permissionDecisionReason = null;
+if (
+  (toolName === "WebFetch" || toolName === "WebSearch") &&
+  process.env.SEREN_AGENT_NETWORK_ENABLED === "false"
+) {
+  permissionDecision = "deny";
+  permissionDecisionReason = "Network access is disabled in Settings → Agent.";
+} else if (pathFields[toolName]) {
+  const [field, kind] = pathFields[toolName];
+  const requestedPath = toolInput[field] ?? process.env.SEREN_AGENT_PROJECT_ROOT;
+  const result = evaluateFileAccess({
+    requestedPath,
+    projectRoot: process.env.SEREN_AGENT_PROJECT_ROOT,
+    kind,
+    sandboxMode: process.env.SEREN_AGENT_SANDBOX_MODE,
+    approvalPolicy: process.env.SEREN_AGENT_APPROVAL_POLICY,
+    autoApproveReads: process.env.SEREN_AGENT_AUTO_APPROVE_READS !== "false",
+  });
+  if (result.decision === "require_approval") {
+    permissionDecision = "ask";
+    permissionDecisionReason =
+      "This file is outside the active project and needs one-time approval.";
+  } else if (result.decision === "deny") {
+    permissionDecision = "deny";
+    permissionDecisionReason =
+      result.reason ??
+      "File access is outside the active project. Select Full Access in Settings → Agent to allow it.";
+  }
+}
+
+if (permissionDecision) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision,
+        permissionDecisionReason,
+      },
+    }),
+  );
+}

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -8,6 +8,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
+import { fileURLToPath } from "node:url";
 import { buildProviderMcpConfig } from "./mcp-config.mjs";
 import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
 import {
@@ -1062,6 +1063,7 @@ function buildClaudeArgs({
   resumeSessionId,
   preferredModel,
   mcpConfigJson,
+  policySettingsJson,
   effort,
 }) {
   const args = [
@@ -1095,6 +1097,17 @@ function buildClaudeArgs({
     }
   }
 
+  if (policySettingsJson) {
+    if (process.platform === "win32") {
+      const tempPath = path.join(os.tmpdir(), `seren-policy-${sessionId}.json`);
+      writeFileSync(tempPath, policySettingsJson, "utf-8");
+      args.push("--settings", tempPath);
+      args._policyTempFile = tempPath;
+    } else {
+      args.push("--settings", policySettingsJson);
+    }
+  }
+
   if (resumeSessionId) {
     args.push("--resume", resumeSessionId);
   } else {
@@ -1106,6 +1119,61 @@ function buildClaudeArgs({
   }
 
   return args;
+}
+
+function quoteHookArgument(value) {
+  const text = String(value);
+  if (process.platform === "win32") {
+    return `"${text.replaceAll('"', '""')}"`;
+  }
+  return `'${text.replaceAll("'", "'\\''")}'`;
+}
+
+function buildClaudePolicySettings({ cwd, sandboxMode, networkEnabled }) {
+  const fullAccess =
+    sandboxMode === "full-access" || sandboxMode === "danger-full-access";
+  if (fullAccess) return {};
+
+  const hookPath = fileURLToPath(
+    new URL("./claude-file-policy-hook.mjs", import.meta.url),
+  );
+  const settings = {
+    disableAllHooks: false,
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: "Read|Edit|Write|Glob|Grep|NotebookEdit|WebFetch|WebSearch",
+          hooks: [
+            {
+              type: "command",
+              command: `${quoteHookArgument(process.execPath)} ${quoteHookArgument(hookPath)}`,
+              timeout: 10,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  // Claude's native sandbox constrains Bash subprocesses on macOS/Linux.
+  // Built-in file tools are independently constrained by the hook above.
+  if (process.platform !== "win32") {
+    settings.sandbox = {
+      enabled: true,
+      failIfUnavailable: true,
+      autoAllowBashIfSandboxed: true,
+      allowUnsandboxedCommands: false,
+      filesystem: {
+        denyRead: ["~/"],
+        allowRead: [cwd],
+        allowWrite: [cwd],
+      },
+      ...(networkEnabled === false
+        ? { network: { deniedDomains: ["*"] } }
+        : {}),
+    };
+  }
+  return settings;
 }
 
 // Mirror of CLAUDE_1M_TIER_CAPABLE_MODELS in src/stores/agent.store.ts. Set
@@ -2422,6 +2490,9 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       apiKey,
       mcpServers,
       approvalPolicy,
+      sandboxMode,
+      networkEnabled,
+      autoApproveReads,
       timeoutSecs,
       reasoningEffort,
       initialModelId,
@@ -2464,6 +2535,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
     let serenMcpProxy = null;
     let mcpConfig;
     let claudeArgs;
+    let policySettingsJson;
     try {
       if (apiKey) serenMcpProxy = await createSerenMcpOAuthProxy();
       mcpConfig = buildProviderMcpConfig({
@@ -2471,11 +2543,15 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         mcpServers,
         serenMcpGatewayUrl: serenMcpProxy?.url,
       });
+      policySettingsJson = JSON.stringify(
+        buildClaudePolicySettings({ cwd, sandboxMode, networkEnabled }),
+      );
       claudeArgs = buildClaudeArgs({
         sessionId: remoteSessionId,
         resumeSessionId: resumeAgentSessionId ?? null,
         preferredModel,
         mcpConfigJson: mcpConfig.claudeMcpConfigJson,
+        policySettingsJson,
         effort: effectiveEffort,
       });
     } catch (error) {
@@ -2515,6 +2591,9 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
           "utf-8",
         );
       }
+      if (claudeArgs._policyTempFile && policySettingsJson) {
+        writeFileSync(claudeArgs._policyTempFile, policySettingsJson, "utf-8");
+      }
 
       const processHandle = spawn(
         claudeBin,
@@ -2525,6 +2604,13 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
             ...process.env,
             ...mcpConfig.childEnv,
             PATH: extendedPath,
+            SEREN_AGENT_PROJECT_ROOT: cwd,
+            SEREN_AGENT_SANDBOX_MODE: sandboxMode ?? "workspace-write",
+            SEREN_AGENT_APPROVAL_POLICY: approvalPolicy ?? "on-request",
+            SEREN_AGENT_AUTO_APPROVE_READS:
+              autoApproveReads === false ? "false" : "true",
+            SEREN_AGENT_NETWORK_ENABLED:
+              networkEnabled === false ? "false" : "true",
           },
           stdio: ["pipe", "pipe", "pipe"],
           shell: resolveSpawnShell(claudeBin),
@@ -2534,6 +2620,12 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       // Clean up MCP config temp file when the process exits
       if (claudeArgs._mcpTempFile) {
         const tempFile = claudeArgs._mcpTempFile;
+        processHandle.on("exit", () => {
+          try { unlinkSync(tempFile); } catch {}
+        });
+      }
+      if (claudeArgs._policyTempFile) {
+        const tempFile = claudeArgs._policyTempFile;
         processHandle.on("exit", () => {
           try { unlinkSync(tempFile); } catch {}
         });
@@ -3185,6 +3277,7 @@ export {
   comparePickerEntries as _comparePickerEntries,
   resolveSpawnShell as _resolveSpawnShell,
   buildClaudeArgs as _buildClaudeArgs,
+  buildClaudePolicySettings as _buildClaudePolicySettings,
   normalizeModelRecords as _normalizeModelRecords,
   buildSessionStatus as _buildSessionStatus,
   buildFastModeFlagSettings as _buildFastModeFlagSettings,

--- a/bin/browser-local/file-access-policy.mjs
+++ b/bin/browser-local/file-access-policy.mjs
@@ -1,0 +1,195 @@
+// ABOUTME: Provider-runtime filesystem policy shared by local model and CLI adapters.
+// ABOUTME: Canonicalizes paths before deciding whether access stays inside the active project.
+
+import {
+  existsSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const FILE_READ_TOOLS = new Set([
+  "read_file",
+  "read_file_base64",
+  "list_directory",
+  "path_exists",
+]);
+
+export const FILE_WRITE_TOOLS = new Set([
+  "write_file",
+  "write_pdf_from_html",
+  "create_directory",
+]);
+
+export function fileAccessKind(toolName) {
+  if (FILE_READ_TOOLS.has(toolName)) return "read";
+  if (FILE_WRITE_TOOLS.has(toolName)) return "write";
+  return null;
+}
+
+function hasParentTraversal(requested) {
+  return String(requested)
+    .replaceAll("\\", "/")
+    .split("/")
+    .includes("..");
+}
+
+function expandHome(requested) {
+  if (requested === "~") return os.homedir();
+  if (requested.startsWith("~/") || requested.startsWith("~\\")) {
+    return path.join(os.homedir(), requested.slice(2));
+  }
+  return requested;
+}
+
+function canonicalizeExistingOrParent(candidate) {
+  if (existsSync(candidate)) return realpathSync.native(candidate);
+
+  const missing = [];
+  let ancestor = candidate;
+  while (!existsSync(ancestor)) {
+    const parent = path.dirname(ancestor);
+    if (parent === ancestor) {
+      throw new Error("File access denied: path has no existing ancestor.");
+    }
+    missing.push(path.basename(ancestor));
+    ancestor = parent;
+  }
+
+  let resolved = realpathSync.native(ancestor);
+  for (const component of missing.reverse()) {
+    resolved = path.join(resolved, component);
+  }
+  return resolved;
+}
+
+export function pathIsWithin(candidate, root) {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) &&
+      relative !== ".." &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function isSensitivePath(candidate) {
+  const home = os.homedir();
+  const sensitiveDirectories = [
+    ".ssh",
+    ".aws",
+    ".gnupg",
+    ".seren",
+    path.join(".config", "seren"),
+    path.join(".config", "gcloud"),
+    path.join(".config", "autostart"),
+    path.join("Library", "LaunchAgents"),
+  ].map((entry) => path.join(home, entry));
+  if (sensitiveDirectories.some((entry) => pathIsWithin(candidate, entry))) {
+    return true;
+  }
+
+  return new Set([
+    ".bashrc",
+    ".bash_profile",
+    ".zshrc",
+    ".zprofile",
+    ".profile",
+    ".gitconfig",
+    ".npmrc",
+    ".netrc",
+  ]).has(path.basename(candidate).toLowerCase());
+}
+
+function grantDirectory(candidate, kind) {
+  if (kind === "read" && existsSync(candidate)) {
+    try {
+      if (statSync(candidate).isDirectory()) return candidate;
+    } catch {
+      // The canonical path will be revalidated when the operation executes.
+    }
+  }
+  return path.dirname(candidate);
+}
+
+export function evaluateFileAccess({
+  requestedPath,
+  projectRoot,
+  kind,
+  sandboxMode = "workspace-write",
+  approvalPolicy = "on-request",
+  autoApproveReads = true,
+}) {
+  if (
+    typeof requestedPath !== "string" ||
+    requestedPath.length === 0 ||
+    requestedPath.includes("\0") ||
+    hasParentTraversal(requestedPath)
+  ) {
+    return { decision: "deny", reason: "File access denied: invalid path." };
+  }
+
+  let canonicalRoot;
+  let resolvedPath;
+  try {
+    canonicalRoot = projectRoot
+      ? realpathSync.native(path.resolve(expandHome(projectRoot)))
+      : null;
+    const expanded = expandHome(requestedPath);
+    const candidate = path.isAbsolute(expanded)
+      ? path.resolve(expanded)
+      : canonicalRoot
+        ? path.resolve(canonicalRoot, expanded)
+        : null;
+    if (!candidate) {
+      return {
+        decision: "deny",
+        reason: "File access denied: choose a project folder first.",
+      };
+    }
+    resolvedPath = canonicalizeExistingOrParent(candidate);
+  } catch {
+    return {
+      decision: "deny",
+      reason: "File access denied: path could not be resolved.",
+    };
+  }
+
+  const access = {
+    resolvedPath,
+    grantDirectory: grantDirectory(resolvedPath, kind),
+    kind,
+    sensitive: isSensitivePath(resolvedPath),
+  };
+  const fullAccess =
+    sandboxMode === "full-access" || sandboxMode === "danger-full-access";
+  if (fullAccess) return { decision: "allow", ...access };
+
+  if (kind === "write" && sandboxMode === "read-only") {
+    return {
+      decision: "deny",
+      reason: "File write denied: Agent Sandbox Mode is Read Only.",
+      ...access,
+    };
+  }
+
+  const inProject = canonicalRoot
+    ? pathIsWithin(resolvedPath, canonicalRoot)
+    : false;
+  if (inProject && !access.sensitive) {
+    if (kind !== "read" || autoApproveReads) {
+      return { decision: "allow", ...access };
+    }
+  }
+
+  if (approvalPolicy === "on-request" || approvalPolicy === "untrusted") {
+    return { decision: "require_approval", ...access };
+  }
+  return {
+    decision: "deny",
+    reason:
+      "File access denied by the active project scope. Select Full Access to allow external files.",
+    ...access,
+  };
+}

--- a/bin/browser-local/gemini-runtime.mjs
+++ b/bin/browser-local/gemini-runtime.mjs
@@ -78,7 +78,9 @@ function isGeminiAuthError(message) {
 
 function resolveGeminiMode({ approvalPolicy, sandboxMode }) {
   if (sandboxMode === "read-only") return "plan";
-  if (sandboxMode === "danger-full-access") return "yolo";
+  if (sandboxMode === "danger-full-access" || sandboxMode === "full-access") {
+    return "yolo";
+  }
   if (approvalPolicy === "on-request" || approvalPolicy === "untrusted") {
     return "default";
   }
@@ -113,13 +115,30 @@ function buildGeminiModes(session) {
   };
 }
 
-function spawnGeminiProcess(cwd, { extraEnv = {} } = {}) {
+function geminiSandboxEnv({ sandboxMode, networkEnabled } = {}) {
+  const fullAccess =
+    sandboxMode === "full-access" || sandboxMode === "danger-full-access";
+  if (fullAccess) return { GEMINI_SANDBOX: "false" };
+
+  return {
+    GEMINI_SANDBOX: "true",
+    ...(process.platform === "darwin"
+      ? {
+          SEATBELT_PROFILE:
+            networkEnabled === false ? "strict-proxied" : "strict-open",
+        }
+      : {}),
+  };
+}
+
+function spawnGeminiProcess(cwd, { extraEnv = {}, params = {} } = {}) {
   return spawn(resolveGeminiBinary(), ["--acp"], {
     cwd,
     env: {
       ...process.env,
       NODE_NO_READLINE: "1",
       ...extraEnv,
+      ...geminiSandboxEnv(params),
     },
     stdio: ["pipe", "pipe", "pipe"],
     shell: process.platform === "win32",
@@ -160,3 +179,5 @@ const GEMINI_ADAPTER = {
 export function createGeminiRuntime(options) {
   return createAcpRuntime({ ...options, adapter: GEMINI_ADAPTER });
 }
+
+export { geminiSandboxEnv as _geminiSandboxEnv };

--- a/bin/browser-local/grok-runtime.mjs
+++ b/bin/browser-local/grok-runtime.mjs
@@ -21,7 +21,9 @@ const GROK_DEFAULT_MODEL_ID = "grok-4.5";
 
 function resolveGrokMode({ approvalPolicy, sandboxMode }) {
   if (sandboxMode === "read-only") return "plan";
-  if (sandboxMode === "danger-full-access") return "bypassPermissions";
+  if (sandboxMode === "danger-full-access" || sandboxMode === "full-access") {
+    return "bypassPermissions";
+  }
   if (approvalPolicy === "on-request" || approvalPolicy === "untrusted") {
     return "default";
   }
@@ -30,7 +32,9 @@ function resolveGrokMode({ approvalPolicy, sandboxMode }) {
 
 function resolveGrokSandbox({ sandboxMode, networkEnabled }) {
   if (sandboxMode === "read-only") return "read-only";
-  if (sandboxMode === "danger-full-access") return "off";
+  if (sandboxMode === "danger-full-access" || sandboxMode === "full-access") {
+    return "off";
+  }
   if (networkEnabled === false) return "strict";
   return "workspace";
 }

--- a/bin/browser-local/lmstudio-runtime.mjs
+++ b/bin/browser-local/lmstudio-runtime.mjs
@@ -16,6 +16,11 @@ import {
   readFileBase64,
   writeFile,
 } from "./fs.mjs";
+import {
+  evaluateFileAccess,
+  fileAccessKind,
+  pathIsWithin,
+} from "./file-access-policy.mjs";
 import { providerLogPrefix } from "./logging.mjs";
 import { createSerenMcpOAuthProxy } from "./seren-mcp-oauth-proxy.mjs";
 
@@ -1232,27 +1237,36 @@ async function runChatCompletion({ session, tools, signal, onContent }) {
   }
 }
 
-function buildPermissionOptions() {
-  return [
+function buildPermissionOptions({ canTrustDirectory = true } = {}) {
+  const options = [
     {
       optionId: "accept",
       label: "Approve once",
       description: "Run this tool call one time.",
     },
-    {
+  ];
+  if (canTrustDirectory) {
+    options.push({
       optionId: "acceptForSession",
-      label: "Approve session",
-      description: "Allow this tool for the rest of the session.",
-    },
-    {
+      label: "Trust folder this turn",
+      description: "Allow this operation in the same folder for this agent turn.",
+    });
+  }
+  options.push({
       optionId: "decline",
       label: "Deny",
       description: "Return a denial to the model.",
-    },
-  ];
+  });
+  return options;
 }
 
-function buildPermissionRequestEvent(session, requestId, toolCall, args) {
+function buildPermissionRequestEvent(
+  session,
+  requestId,
+  toolCall,
+  args,
+  fileAccess,
+) {
   return {
     sessionId: session.id,
     requestId,
@@ -1261,7 +1275,9 @@ function buildPermissionRequestEvent(session, requestId, toolCall, args) {
       title: toolCall.function.name,
       input: args,
     },
-    options: buildPermissionOptions(),
+    options: buildPermissionOptions({
+      canTrustDirectory: !fileAccess?.sensitive,
+    }),
   };
 }
 
@@ -1271,9 +1287,24 @@ function listPendingPermissions(session) {
   );
 }
 
-async function requestPermission(session, toolCall, args) {
+async function requestPermission(session, toolCall, args, fileAccess) {
+  if (fileAccess?.decision === "allow") return "accept";
   if (
-    session.currentModeId === "auto" ||
+    fileAccess?.decision === "require_approval" &&
+    !fileAccess.sensitive &&
+    session.fileAccessGrants.some(
+      (grant) =>
+        grant.kind === fileAccess.kind &&
+        pathIsWithin(fileAccess.resolvedPath, grant.directory),
+    )
+  ) {
+    return "accept";
+  }
+
+  // Auto mode still cannot cross the project boundary silently. It remains
+  // automatic for every in-project file operation and for non-file tools.
+  if (
+    (!fileAccess && session.currentModeId === "auto") ||
     session.approvedForSession.has(toolCall.function.name)
   ) {
     return "accept";
@@ -1285,6 +1316,7 @@ async function requestPermission(session, toolCall, args) {
     requestId,
     toolCall,
     args,
+    fileAccess,
   );
   const permission = new Promise((resolve) => {
     session.pendingPermissions.set(requestId, {
@@ -1303,6 +1335,18 @@ async function executeToolCall(session, toolCall, handlers) {
   const args = safeJsonParse(toolCall.function.arguments, {});
   const handler = handlers.get(toolCall.function.name);
   const title = handler?.displayName ?? toolCall.function.name;
+  const kind =
+    handler?.kind === "local" ? fileAccessKind(toolCall.function.name) : null;
+  const fileAccess = kind
+    ? evaluateFileAccess({
+        requestedPath: args.path,
+        projectRoot: session.cwd,
+        kind,
+        sandboxMode: session.sandboxMode,
+        approvalPolicy: session.approvalPolicy,
+        autoApproveReads: session.autoApproveReads,
+      })
+    : null;
 
   session.emit("provider://tool-call", {
     sessionId: session.id,
@@ -1314,7 +1358,19 @@ async function executeToolCall(session, toolCall, handlers) {
     parameters: args,
   });
 
-  const decision = await requestPermission(session, toolCall, args);
+  if (fileAccess?.decision === "deny") {
+    const denial = fileAccess.reason ?? "File access denied by project scope.";
+    session.emit("provider://tool-result", {
+      sessionId: session.id,
+      toolCallId: toolCall.id,
+      status: "denied",
+      error: denial,
+    });
+    return { role: "tool", tool_call_id: toolCall.id, content: denial };
+  }
+  if (fileAccess?.resolvedPath) args.path = fileAccess.resolvedPath;
+
+  const decision = await requestPermission(session, toolCall, args, fileAccess);
   if (decision === "decline" || decision === "cancel" || decision === "deny") {
     const denial = "Tool call denied by the user.";
     session.emit("provider://tool-result", {
@@ -1326,7 +1382,14 @@ async function executeToolCall(session, toolCall, handlers) {
     return { role: "tool", tool_call_id: toolCall.id, content: denial };
   }
   if (decision === "acceptForSession") {
-    session.approvedForSession.add(toolCall.function.name);
+    if (fileAccess && !fileAccess.sensitive) {
+      session.fileAccessGrants.push({
+        kind: fileAccess.kind,
+        directory: fileAccess.grantDirectory,
+      });
+    } else {
+      session.approvedForSession.add(toolCall.function.name);
+    }
   }
 
   session.emit("provider://tool-call", {
@@ -1562,9 +1625,13 @@ export function createLmStudioRuntime({ emit, runtimeMode = "provider-runtime" }
         availableModelRecords,
         currentModelId: initialModel.modelId,
         currentModeId: params.approvalPolicy === "never" ? "auto" : "ask",
+        sandboxMode: params.sandboxMode ?? "workspace-write",
+        approvalPolicy: params.approvalPolicy ?? "on-request",
+        autoApproveReads: params.autoApproveReads !== false,
         currentPrompt: null,
         pendingPermissions: new Map(),
         approvedForSession: new Set(),
+        fileAccessGrants: [],
         messages: [],
         toolIncompatibleModelIds: new Set(),
         loadedModelKey: null,

--- a/bin/browser-local/paired-runtime.mjs
+++ b/bin/browser-local/paired-runtime.mjs
@@ -979,6 +979,9 @@ export function createPairedRuntime({ emit, inner }) {
       apiKey: params.apiKey,
       mcpServers: params.mcpServers,
       timeoutSecs: params.timeoutSecs,
+      sandboxMode: params.sandboxMode,
+      networkEnabled: params.networkEnabled,
+      autoApproveReads: params.autoApproveReads,
     };
 
     if (role === "planner") {
@@ -1033,8 +1036,6 @@ export function createPairedRuntime({ emit, inner }) {
       // Match direct Codex sessions: paired executor work should start in
       // Permission Mode: Auto, not inherit Claude's default on-request policy.
       approvalPolicy: "on-failure",
-      sandboxMode: params.sandboxMode,
-      networkEnabled: params.networkEnabled,
       initialModelId: config.modelId ?? undefined,
       reasoningEffort: config.effort ?? undefined,
       codexDefaultIntent: "paired-executor",

--- a/bin/browser-local/providers.mjs
+++ b/bin/browser-local/providers.mjs
@@ -264,9 +264,8 @@ function modeFromApprovalPolicy(approvalPolicy) {
   }
 }
 
-function sandboxFromMode(sandboxMode, networkEnabled) {
+function sandboxFromMode(sandboxMode, _networkEnabled) {
   if (
-    networkEnabled ||
     sandboxMode === "danger-full-access" ||
     sandboxMode === "full-access"
   ) {
@@ -276,6 +275,12 @@ function sandboxFromMode(sandboxMode, networkEnabled) {
     return "read-only";
   }
   return "workspace-write";
+}
+
+function codexNetworkConfigOverride(networkEnabled) {
+  return typeof networkEnabled === "boolean"
+    ? `sandbox_workspace_write.network_access=${networkEnabled}`
+    : null;
 }
 
 function codexApprovalPolicy(modeId) {
@@ -364,7 +369,7 @@ function buildInitializeParams() {
 
 function spawnCodexProcess(
   cwd,
-  { apiKey, mcpServers, serenMcpGatewayUrl } = {},
+  { apiKey, mcpServers, serenMcpGatewayUrl, networkEnabled } = {},
 ) {
   const mcpConfig = buildProviderMcpConfig({
     apiKey,
@@ -376,6 +381,8 @@ function spawnCodexProcess(
   if (mcpConfig.codexMcpConfigOverride) {
     args.push("-c", mcpConfig.codexMcpConfigOverride);
   }
+  const networkConfig = codexNetworkConfigOverride(networkEnabled);
+  if (networkConfig) args.push("-c", networkConfig);
 
   // Use the absolute-path resolver instead of bare `"codex"` so GUI-launched
   // instances don't depend on shell PATH — addresses the same class of
@@ -1609,6 +1616,7 @@ export function createProviderHandlers({ emit: rawEmit, runtimeMode = "provider-
         apiKey,
         mcpServers,
         serenMcpGatewayUrl: serenMcpProxy?.url,
+        networkEnabled,
       });
     } catch (error) {
       await serenMcpProxy?.close();
@@ -2476,4 +2484,5 @@ export {
   resolveCodexInitialServiceTier as _resolveCodexInitialServiceTier,
   resolveCodexPreferredModelRecord as _resolveCodexPreferredModelRecord,
   sandboxFromMode as _sandboxFromMode,
+  codexNetworkConfigOverride as _codexNetworkConfigOverride,
 };

--- a/src-tauri/src/orchestrator/chat_model_worker.rs
+++ b/src-tauri/src/orchestrator/chat_model_worker.rs
@@ -7,17 +7,20 @@ use futures::StreamExt;
 use log;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
-use tauri::{Emitter, Manager};
-use tokio::sync::{Mutex, mpsc};
+use tauri::{Emitter, Listener, Manager};
+use tokio::sync::{Mutex, mpsc, oneshot};
 
+use super::file_access_policy::{
+    path_is_within, FileAccessDecision, FileAccessKind, FileAccessPolicy, ResolvedFileAccess,
+};
 use super::gateway_envelope::{
     publisher_cost, publisher_status, unwrap_data_response, unwrap_publisher_body,
 };
 use super::tool_bridge::ToolResultBridge;
 use super::tool_relevance;
-use super::types::{ImageAttachment, RoutingDecision, WorkerEvent};
+use super::types::{EffectiveAgentPolicy, ImageAttachment, RoutingDecision, WorkerEvent};
 use super::worker::Worker;
 
 const GATEWAY_BASE_URL: &str = "https://api.serendb.com";
@@ -43,6 +46,23 @@ const CONNECT_TIMEOUT_SECS: u64 = 30;
 /// Overall request timeout for Gateway API calls (10 minutes).
 /// Allows for long-running agent requests with multiple tool execution rounds.
 const REQUEST_TIMEOUT_SECS: u64 = 600;
+const FILE_APPROVAL_TIMEOUT_SECS: u64 = 300;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FileAccessApprovalRequest {
+    approval_id: String,
+    conversation_id: String,
+    operation: String,
+    path: String,
+    can_trust_directory: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct FileAccessApprovalResponse {
+    id: String,
+    decision: String,
+}
 
 /// Maximum size (in bytes) of a single tool result when appended to the LLM
 /// conversation context.  Results larger than this are truncated to prevent the
@@ -253,6 +273,8 @@ pub struct ChatModelWorker {
     publisher_slug: String,
     /// OpenAI-format tool definitions passed to the LLM for function calling.
     tool_definitions: Vec<serde_json::Value>,
+    /// Snapshot of Settings -> Agent captured with the request.
+    effective_agent_policy: EffectiveAgentPolicy,
 }
 
 impl ChatModelWorker {
@@ -267,11 +289,16 @@ impl ChatModelWorker {
             cancelled: Arc::new(Mutex::new(false)),
             publisher_slug: DEFAULT_PUBLISHER_SLUG.to_string(),
             tool_definitions: Vec::new(),
+            effective_agent_policy: EffectiveAgentPolicy::default(),
         }
     }
 
     /// Create a worker with tool definitions for function calling.
-    pub fn with_tools(tools: Vec<serde_json::Value>, publisher_slug: Option<String>) -> Self {
+    pub fn with_tools(
+        tools: Vec<serde_json::Value>,
+        publisher_slug: Option<String>,
+        effective_agent_policy: EffectiveAgentPolicy,
+    ) -> Self {
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
             .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
@@ -283,6 +310,7 @@ impl ChatModelWorker {
             publisher_slug: publisher_slug
                 .unwrap_or_else(|| DEFAULT_PUBLISHER_SLUG.to_string()),
             tool_definitions: Self::inject_local_tool_definitions(tools),
+            effective_agent_policy,
         }
     }
 
@@ -1191,6 +1219,128 @@ created if missing.",
             .and_then(|v| v.get("path").and_then(|p| p.as_str()).map(String::from))
     }
 
+    fn file_access_kind(name: &str) -> Option<FileAccessKind> {
+        match name {
+            "read_file" | "read_file_base64" | "list_directory" | "path_exists" => {
+                Some(FileAccessKind::Read)
+            }
+            "write_file" | "write_pdf_from_html" | "create_directory" => {
+                Some(FileAccessKind::Write)
+            }
+            _ => None,
+        }
+    }
+
+    async fn request_file_access_approval(
+        app: &tauri::AppHandle,
+        conversation_id: &str,
+        access: &ResolvedFileAccess,
+    ) -> Option<String> {
+        let approval_id = format!("file-{}", uuid::Uuid::new_v4());
+        let (tx, rx) = oneshot::channel::<String>();
+        let sender = Arc::new(StdMutex::new(Some(tx)));
+        let sender_for_listener = Arc::clone(&sender);
+        let expected_id = approval_id.clone();
+
+        // Register before emitting so an immediate renderer response cannot race
+        // the listener. The sender is single-use and unrelated responses are ignored.
+        let listener = app.listen("file-access-approval-response", move |event| {
+            let Ok(response) = serde_json::from_str::<FileAccessApprovalResponse>(event.payload())
+            else {
+                return;
+            };
+            if response.id != expected_id {
+                return;
+            }
+            if let Ok(mut guard) = sender_for_listener.lock() {
+                if let Some(tx) = guard.take() {
+                    let _ = tx.send(response.decision);
+                }
+            }
+        });
+
+        let request = FileAccessApprovalRequest {
+            approval_id,
+            conversation_id: conversation_id.to_string(),
+            operation: access.kind.label().to_string(),
+            path: access.path.to_string_lossy().to_string(),
+            can_trust_directory: !access.sensitive,
+        };
+        if app.emit("file-access-approval-request", request).is_err() {
+            app.unlisten(listener);
+            return None;
+        }
+
+        let decision = tokio::time::timeout(Duration::from_secs(FILE_APPROVAL_TIMEOUT_SECS), rx)
+            .await
+            .ok()
+            .and_then(Result::ok);
+        app.unlisten(listener);
+        decision
+    }
+
+    async fn execute_model_file_tool(
+        app: &tauri::AppHandle,
+        conversation_id: &str,
+        policy: &FileAccessPolicy,
+        grants: &mut HashSet<(FileAccessKind, std::path::PathBuf)>,
+        name: &str,
+        arguments: &str,
+    ) -> (String, bool) {
+        let Some(kind) = Self::file_access_kind(name) else {
+            return ("Unsupported file operation".to_string(), true);
+        };
+        let mut args: serde_json::Value = match serde_json::from_str(arguments) {
+            Ok(value) => value,
+            Err(error) => {
+                return (format!("Failed to parse tool arguments: {}", error), true);
+            }
+        };
+        let Some(requested) = args.get("path").and_then(serde_json::Value::as_str) else {
+            return ("Missing required parameter: path".to_string(), true);
+        };
+
+        let access = match policy.evaluate(requested, kind) {
+            FileAccessDecision::Allow(access) => access,
+            FileAccessDecision::Deny(message) => return (message, true),
+            FileAccessDecision::RequireApproval(access) => {
+                let already_granted = !access.sensitive
+                    && grants.iter().any(|(grant_kind, directory)| {
+                        *grant_kind == access.kind && path_is_within(&access.path, directory)
+                    });
+                if already_granted {
+                    access
+                } else {
+                    match Self::request_file_access_approval(app, conversation_id, &access)
+                        .await
+                        .as_deref()
+                    {
+                        Some("approve_once") => access,
+                        Some("trust_directory") if !access.sensitive => {
+                            grants.insert((access.kind, access.grant_directory.clone()));
+                            access
+                        }
+                        _ => {
+                            return (
+                                "File access denied or approval timed out.".to_string(),
+                                true,
+                            );
+                        }
+                    }
+                }
+            }
+        };
+
+        let Some(resolved) = access.path.to_str() else {
+            return ("File access denied: path encoding is unsupported.".to_string(), true);
+        };
+        args["path"] = serde_json::Value::String(resolved.to_string());
+        let Ok(arguments) = serde_json::to_string(&args) else {
+            return ("Failed to serialize authorized file operation.".to_string(), true);
+        };
+        Self::execute_tool_with_app(Some(app), name, &arguments).await
+    }
+
     /// Track repeated identical parse-error tool calls within a single
     /// `execute()` invocation. Returns true when the loop must abort because
     /// the model has retried the same `(tool_name, arguments)` parse failure
@@ -1626,6 +1776,13 @@ impl Worker for ChatModelWorker {
         // Track file paths already read in this execution to avoid re-inlining
         // the same content. On duplicate reads, return a short reference instead.
         let mut read_file_paths: HashSet<String> = HashSet::new();
+        let file_access_policy = FileAccessPolicy::new(
+            self.effective_agent_policy.clone(),
+            routing.project_root.as_deref(),
+        );
+        // Directory grants are scoped to this conversation turn and separated
+        // by read/write kind. They are never persisted or model-controlled.
+        let mut file_access_grants: HashSet<(FileAccessKind, std::path::PathBuf)> = HashSet::new();
 
         let mut total_cost: f64 = 0.0;
 
@@ -1874,7 +2031,23 @@ impl Worker for ChatModelWorker {
                             tc.id
                         );
 
-                        let (result_content, is_error) = if Self::is_local_tool(&tc.name) {
+                        let (result_content, is_error) = if Self::file_access_kind(&tc.name).is_some()
+                        {
+                            match &file_access_policy {
+                                Ok(policy) => {
+                                    Self::execute_model_file_tool(
+                                        app,
+                                        conversation_id,
+                                        policy,
+                                        &mut file_access_grants,
+                                        &tc.name,
+                                        &tc.arguments,
+                                    )
+                                    .await
+                                }
+                                Err(message) => (message.clone(), true),
+                            }
+                        } else if Self::is_local_tool(&tc.name) {
                             Self::execute_tool_with_app(Some(app), &tc.name, &tc.arguments).await
                         } else {
                             // Route non-local tools (gateway__, mcp__)
@@ -3007,7 +3180,11 @@ mod tests {
                 "parameters": {"type": "object", "properties": {}}
             }
         })];
-        let worker = ChatModelWorker::with_tools(tools.clone(), None);
+        let worker = ChatModelWorker::with_tools(
+            tools.clone(),
+            None,
+            EffectiveAgentPolicy::default(),
+        );
         // `with_tools` injects `write_pdf_from_html` (GH #1585) at the front
         // of the list, so the caller's tools follow. Assert both are present
         // and read_file is preserved.

--- a/src-tauri/src/orchestrator/file_access_policy.rs
+++ b/src-tauri/src/orchestrator/file_access_policy.rs
@@ -1,0 +1,338 @@
+// ABOUTME: Backend authorization boundary for model-originated local file tools.
+// ABOUTME: Resolves canonical project scope without changing editor/file-tree commands.
+
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+
+use super::types::EffectiveAgentPolicy;
+use crate::path_util::expand_tilde;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FileAccessKind {
+    Read,
+    Write,
+}
+
+impl FileAccessKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::Write => "write",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedFileAccess {
+    pub path: PathBuf,
+    pub grant_directory: PathBuf,
+    pub kind: FileAccessKind,
+    pub sensitive: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileAccessDecision {
+    Allow(ResolvedFileAccess),
+    RequireApproval(ResolvedFileAccess),
+    Deny(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct FileAccessPolicy {
+    settings: EffectiveAgentPolicy,
+    project_root: Option<PathBuf>,
+}
+
+impl FileAccessPolicy {
+    pub fn new(settings: EffectiveAgentPolicy, project_root: Option<&str>) -> Result<Self, String> {
+        let project_root = project_root
+            .filter(|root| !root.trim().is_empty())
+            .map(|root| {
+                let expanded = expand_tilde(root)?;
+                std::fs::canonicalize(&expanded)
+                    .map_err(|_| "The selected project folder is unavailable.".to_string())
+            })
+            .transpose()?;
+
+        Ok(Self {
+            settings,
+            project_root,
+        })
+    }
+
+    pub fn evaluate(&self, requested: &str, kind: FileAccessKind) -> FileAccessDecision {
+        let resolved = match self.resolve_target(requested) {
+            Ok(path) => path,
+            Err(message) => return FileAccessDecision::Deny(message),
+        };
+        let grant_directory = grant_directory(&resolved, kind);
+        let sensitive = is_sensitive_path(&resolved);
+        let access = ResolvedFileAccess {
+            path: resolved.clone(),
+            grant_directory,
+            kind,
+            sensitive,
+        };
+
+        let full_access = matches!(
+            self.settings.sandbox_mode.as_str(),
+            "full-access" | "danger-full-access"
+        );
+        if full_access {
+            return FileAccessDecision::Allow(access);
+        }
+
+        if sensitive {
+            return self.approval_or_deny(access);
+        }
+
+        if kind == FileAccessKind::Write && self.settings.sandbox_mode == "read-only" {
+            return FileAccessDecision::Deny(
+                "File write denied: Agent Sandbox Mode is Read Only.".to_string(),
+            );
+        }
+
+        let in_project = self
+            .project_root
+            .as_ref()
+            .is_some_and(|root| path_is_within(&resolved, root));
+
+        if in_project && !sensitive {
+            if kind == FileAccessKind::Read && !self.settings.auto_approve_reads {
+                return self.approval_or_deny(access);
+            }
+            return FileAccessDecision::Allow(access);
+        }
+
+        self.approval_or_deny(access)
+    }
+
+    fn approval_or_deny(&self, access: ResolvedFileAccess) -> FileAccessDecision {
+        match self.settings.approval_policy.as_str() {
+            "on-request" | "untrusted" => FileAccessDecision::RequireApproval(access),
+            _ => FileAccessDecision::Deny(
+                "File access denied by the current project scope. Select Full Access or use an approval-enabled policy for external files."
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn resolve_target(&self, requested: &str) -> Result<PathBuf, String> {
+        if requested.is_empty() || requested.contains('\0') {
+            return Err("File access denied: invalid path.".to_string());
+        }
+        let expanded = expand_tilde(requested)?;
+        if expanded
+            .components()
+            .any(|component| component == Component::ParentDir)
+        {
+            return Err("File access denied: parent traversal is not allowed.".to_string());
+        }
+
+        let candidate = if expanded.is_absolute() {
+            expanded
+        } else if let Some(root) = &self.project_root {
+            root.join(expanded)
+        } else {
+            return Err(
+                "File access denied: choose a project folder before using a relative path."
+                    .to_string(),
+            );
+        };
+
+        canonicalize_existing_or_parent(&candidate)
+    }
+}
+
+fn canonicalize_existing_or_parent(candidate: &Path) -> Result<PathBuf, String> {
+    if candidate.exists() {
+        return std::fs::canonicalize(candidate)
+            .map_err(|_| "File access denied: path could not be resolved.".to_string());
+    }
+
+    let mut ancestor = candidate;
+    let mut missing: Vec<OsString> = Vec::new();
+    while !ancestor.exists() {
+        let name = ancestor
+            .file_name()
+            .ok_or_else(|| "File access denied: path has no existing ancestor.".to_string())?;
+        missing.push(name.to_os_string());
+        ancestor = ancestor
+            .parent()
+            .ok_or_else(|| "File access denied: path has no existing ancestor.".to_string())?;
+    }
+
+    let mut resolved = std::fs::canonicalize(ancestor)
+        .map_err(|_| "File access denied: path ancestor could not be resolved.".to_string())?;
+    for component in missing.into_iter().rev() {
+        resolved.push(component);
+    }
+    Ok(resolved)
+}
+
+fn grant_directory(path: &Path, kind: FileAccessKind) -> PathBuf {
+    if kind == FileAccessKind::Read && path.is_dir() {
+        return path.to_path_buf();
+    }
+    path.parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| path.to_path_buf())
+}
+
+#[cfg(not(windows))]
+pub fn path_is_within(path: &Path, root: &Path) -> bool {
+    path.starts_with(root)
+}
+
+#[cfg(windows)]
+pub fn path_is_within(path: &Path, root: &Path) -> bool {
+    let normalize = |value: &Path| {
+        value
+            .to_string_lossy()
+            .replace('/', "\\")
+            .trim_end_matches('\\')
+            .to_lowercase()
+    };
+    let path = normalize(path);
+    let root = normalize(root);
+    path == root || path.starts_with(&format!("{}\\", root))
+}
+
+fn is_sensitive_path(path: &Path) -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    let sensitive_directories = [
+        home.join(".ssh"),
+        home.join(".aws"),
+        home.join(".gnupg"),
+        home.join(".seren"),
+        home.join(".config/seren"),
+        home.join(".config/gcloud"),
+        home.join(".config/autostart"),
+        home.join("Library/LaunchAgents"),
+    ];
+    if sensitive_directories
+        .iter()
+        .any(|directory| path_is_within(path, directory))
+    {
+        return true;
+    }
+
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    matches!(
+        file_name.to_ascii_lowercase().as_str(),
+        ".bashrc"
+            | ".bash_profile"
+            | ".zshrc"
+            | ".zprofile"
+            | ".profile"
+            | ".gitconfig"
+            | ".npmrc"
+            | ".netrc"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy(root: &Path, sandbox: &str, approval: &str) -> FileAccessPolicy {
+        FileAccessPolicy::new(
+            EffectiveAgentPolicy {
+                sandbox_mode: sandbox.to_string(),
+                approval_policy: approval.to_string(),
+                auto_approve_reads: true,
+                network_enabled: true,
+            },
+            root.to_str(),
+        )
+        .expect("policy")
+    }
+
+    #[test]
+    fn project_reads_and_nonexistent_writes_are_automatic() {
+        let root = tempfile::tempdir().expect("root");
+        let read = root.path().join("input.txt");
+        std::fs::write(&read, "ok").expect("fixture");
+        let policy = policy(root.path(), "workspace-write", "on-request");
+
+        assert!(matches!(
+            policy.evaluate(read.to_str().unwrap(), FileAccessKind::Read),
+            FileAccessDecision::Allow(_)
+        ));
+        assert!(matches!(
+            policy.evaluate("nested/output.txt", FileAccessKind::Write),
+            FileAccessDecision::Allow(_)
+        ));
+    }
+
+    #[test]
+    fn prefix_collision_and_parent_traversal_do_not_escape_project() {
+        let parent = tempfile::tempdir().expect("parent");
+        let root = parent.path().join("project");
+        let sibling = parent.path().join("project-secret");
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::create_dir_all(&sibling).expect("sibling");
+        let policy = policy(&root, "workspace-write", "never");
+
+        assert!(matches!(
+            policy.evaluate(sibling.to_str().unwrap(), FileAccessKind::Read),
+            FileAccessDecision::Deny(_)
+        ));
+        assert!(matches!(
+            policy.evaluate("../project-secret", FileAccessKind::Read),
+            FileAccessDecision::Deny(_)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escape_resolves_outside_project_before_authorization() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().expect("parent");
+        let root = parent.path().join("project");
+        let outside = parent.path().join("outside");
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::create_dir_all(&outside).expect("outside");
+        symlink(&outside, root.join("link")).expect("symlink");
+        let policy = policy(&root, "workspace-write", "never");
+
+        assert!(matches!(
+            policy.evaluate("link/secret.txt", FileAccessKind::Write),
+            FileAccessDecision::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn read_only_denies_writes_and_full_access_allows_external_paths() {
+        let root = tempfile::tempdir().expect("root");
+        let outside = tempfile::tempdir().expect("outside");
+        assert!(matches!(
+            policy(root.path(), "read-only", "on-request")
+                .evaluate("output.txt", FileAccessKind::Write),
+            FileAccessDecision::Deny(_)
+        ));
+        assert!(matches!(
+            policy(root.path(), "full-access", "never")
+                .evaluate(outside.path().to_str().unwrap(), FileAccessKind::Read),
+            FileAccessDecision::Allow(_)
+        ));
+    }
+
+    #[test]
+    fn disabling_auto_read_requires_one_scoped_approval() {
+        let root = tempfile::tempdir().expect("root");
+        let mut settings = EffectiveAgentPolicy::default();
+        settings.auto_approve_reads = false;
+        let policy = FileAccessPolicy::new(settings, root.path().to_str()).expect("policy");
+
+        assert!(matches!(
+            policy.evaluate(root.path().to_str().unwrap(), FileAccessKind::Read),
+            FileAccessDecision::RequireApproval(_)
+        ));
+    }
+}

--- a/src-tauri/src/orchestrator/mod.rs
+++ b/src-tauri/src/orchestrator/mod.rs
@@ -6,6 +6,7 @@ pub mod classifier;
 pub mod cloud_agent_worker;
 pub mod decomposer;
 pub mod eval;
+pub mod file_access_policy;
 pub mod gateway_envelope;
 pub mod mcp_publisher_worker;
 pub mod provider_worker;

--- a/src-tauri/src/orchestrator/router.rs
+++ b/src-tauri/src/orchestrator/router.rs
@@ -539,6 +539,7 @@ fn humanize_task_type(task_type: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::orchestrator::types::EffectiveAgentPolicy;
 
     fn make_capabilities(has_agent: bool, models: &[&str], tools: &[&str]) -> UserCapabilities {
         UserCapabilities {
@@ -563,6 +564,7 @@ mod tests {
             model_rankings: vec![],
             reasoning_effort: None,
             project_root: None,
+            effective_agent_policy: EffectiveAgentPolicy::default(),
         }
     }
 
@@ -593,6 +595,7 @@ mod tests {
             model_rankings: vec![],
             reasoning_effort: None,
             project_root: None,
+            effective_agent_policy: EffectiveAgentPolicy::default(),
         }
     }
 

--- a/src-tauri/src/orchestrator/service.rs
+++ b/src-tauri/src/orchestrator/service.rs
@@ -1448,6 +1448,7 @@ fn create_worker(
         WorkerType::ChatModel => Ok(Arc::new(ChatModelWorker::with_tools(
             capabilities.tool_definitions.clone(),
             routing.publisher_slug.clone(),
+            capabilities.effective_agent_policy.clone(),
         ))),
         WorkerType::CloudAgent => {
             let deployment_id = capabilities

--- a/src-tauri/src/orchestrator/types.rs
+++ b/src-tauri/src/orchestrator/types.rs
@@ -126,6 +126,45 @@ pub enum DelegationType {
     FullHandoff,
 }
 
+/// Provider-independent agent filesystem policy compiled from Settings -> Agent.
+///
+/// This is captured with each orchestration request so model-originated file
+/// tools cannot observe a partially-updated set of renderer preferences.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EffectiveAgentPolicy {
+    #[serde(default = "default_agent_sandbox_mode")]
+    pub sandbox_mode: String,
+    #[serde(default = "default_agent_approval_policy")]
+    pub approval_policy: String,
+    #[serde(default = "default_true")]
+    pub auto_approve_reads: bool,
+    #[serde(default = "default_true")]
+    pub network_enabled: bool,
+}
+
+fn default_agent_sandbox_mode() -> String {
+    "workspace-write".to_string()
+}
+
+fn default_agent_approval_policy() -> String {
+    "on-request".to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for EffectiveAgentPolicy {
+    fn default() -> Self {
+        Self {
+            sandbox_mode: default_agent_sandbox_mode(),
+            approval_policy: default_agent_approval_policy(),
+            auto_approve_reads: true,
+            network_enabled: true,
+        }
+    }
+}
+
 /// Image attachment passed from the frontend.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageAttachment {
@@ -171,6 +210,9 @@ pub struct UserCapabilities {
     /// branch, directory structure) for injection into the system prompt.
     #[serde(default)]
     pub project_root: Option<String>,
+    /// Backend-enforced policy for model-originated local file operations.
+    #[serde(default)]
+    pub effective_agent_policy: EffectiveAgentPolicy,
 }
 
 impl UserCapabilities {
@@ -477,6 +519,7 @@ mod tests {
             model_rankings: vec![],
             reasoning_effort: None,
             project_root: None,
+            effective_agent_policy: EffectiveAgentPolicy::default(),
         };
 
         assert_eq!(
@@ -501,9 +544,9 @@ mod tests {
             model_rankings: vec![],
             reasoning_effort: None,
             project_root: None,
+            effective_agent_policy: EffectiveAgentPolicy::default(),
         };
 
         assert_eq!(caps.configured_private_chat_deployment_id(), None);
     }
 }
-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
 import { AboutDialog } from "@/components/common/AboutDialog";
 import { LowBalanceModal } from "@/components/common/LowBalanceWarning";
 import { OrganizationOtpModal } from "@/components/common/OrganizationOtpModal";
+import { FileAccessApproval } from "@/components/files/FileAccessApproval";
 import { GatewayToolApproval } from "@/components/gateway/GatewayToolApproval";
 import { OPEN_INTERVIEW_LANDING_EVENT } from "@/components/interview/interviewLandingEvents";
 import { AppShell } from "@/components/layout/AppShell";
@@ -450,6 +451,7 @@ function App() {
           <ShellApproval />
         </Show>
         <Show when={runtime.mode === "desktop-native"}>
+          <FileAccessApproval />
           <AboutDialog />
         </Show>
       </Show>

--- a/src/components/files/FileAccessApproval.tsx
+++ b/src/components/files/FileAccessApproval.tsx
@@ -1,0 +1,134 @@
+// ABOUTME: Approval dialog for model-requested file access outside the active project.
+// ABOUTME: Keeps normal project work automatic and scopes optional grants to the current turn.
+
+import { emit, listen } from "@tauri-apps/api/event";
+import {
+  type Component,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+
+interface FileAccessApprovalRequest {
+  approvalId: string;
+  conversationId: string;
+  operation: "read" | "write";
+  path: string;
+  canTrustDirectory: boolean;
+}
+
+type FileAccessDecision = "deny" | "approve_once" | "trust_directory";
+
+export const FileAccessApproval: Component = () => {
+  const [request, setRequest] = createSignal<FileAccessApprovalRequest | null>(
+    null,
+  );
+  const [isProcessing, setIsProcessing] = createSignal(false);
+
+  onMount(async () => {
+    const unlisten = await listen<FileAccessApprovalRequest>(
+      "file-access-approval-request",
+      (event) => {
+        setRequest(event.payload);
+        setIsProcessing(false);
+      },
+    );
+    onCleanup(unlisten);
+  });
+
+  const respond = async (decision: FileAccessDecision) => {
+    const current = request();
+    if (!current || isProcessing()) return;
+
+    setIsProcessing(true);
+    try {
+      await emit("file-access-approval-response", {
+        id: current.approvalId,
+        decision,
+      });
+      setRequest(null);
+    } catch (error) {
+      console.error("[FileAccessApproval] Failed to send response:", error);
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <Show when={request()}>
+      {(current) => (
+        <div class="fixed inset-0 z-[10000] flex items-center justify-center bg-black/70 backdrop-blur-[4px]">
+          <div
+            aria-describedby="file-access-description"
+            aria-labelledby="file-access-title"
+            aria-modal="true"
+            class="flex max-h-[80vh] w-[90%] max-w-[600px] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-[var(--shadow-lg)]"
+            role="dialog"
+          >
+            <div class="border-b border-border px-6 py-5">
+              <h2
+                class="m-0 text-xl font-semibold text-foreground"
+                id="file-access-title"
+              >
+                Allow file {current().operation} outside this project?
+              </h2>
+            </div>
+
+            <div class="flex-1 overflow-y-auto p-6">
+              <p
+                class="mb-4 mt-0 text-sm leading-6 text-muted-foreground"
+                id="file-access-description"
+              >
+                The agent can work inside the selected project automatically.
+                This path is outside that boundary and needs your approval.
+              </p>
+              <div class="rounded-lg border border-border bg-surface-1 px-4 py-3">
+                <span class="mb-2 block text-xs font-medium uppercase tracking-[0.5px] text-muted-foreground">
+                  Requested path
+                </span>
+                <code class="block break-all font-[var(--font-mono)] text-sm text-foreground">
+                  {current().path}
+                </code>
+              </div>
+              <p class="mb-0 mt-4 text-sm text-muted-foreground">
+                Approve once affects only this operation. Trust folder applies
+                only to the same operation for this agent turn.
+              </p>
+            </div>
+
+            <div class="flex flex-wrap justify-end gap-3 border-t border-border px-6 py-4">
+              <button
+                class="rounded-md border border-border bg-transparent px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-surface-1"
+                disabled={isProcessing()}
+                onClick={() => void respond("deny")}
+                type="button"
+              >
+                Deny
+              </button>
+              <Show when={current().canTrustDirectory}>
+                <button
+                  class="rounded-md border border-border bg-surface-1 px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-surface-2"
+                  disabled={isProcessing()}
+                  onClick={() => void respond("trust_directory")}
+                  type="button"
+                >
+                  Trust folder this turn
+                </button>
+              </Show>
+              <button
+                class="rounded-md border-0 bg-accent px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+                disabled={isProcessing()}
+                onClick={() => void respond("approve_once")}
+                type="button"
+              >
+                {isProcessing() ? "Processing…" : "Approve once"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Show>
+  );
+};
+
+export default FileAccessApproval;

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -339,6 +339,12 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
     settingsStore.set(key, value as Settings[typeof key]);
   };
 
+  const confirmFullAgentAccess = () =>
+    settingsState.app.agentSandboxMode === "full-access" ||
+    window.confirm(
+      "Full Access lets agents read and write outside the selected project. Continue?",
+    );
+
   const handleDefaultModelChange = (modelId: string) => {
     // Update settings store
     settingsStore.set("chatDefaultModel", modelId);
@@ -1266,17 +1272,17 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                       {
                         value: "read-only",
                         label: "Read Only",
-                        desc: "Read files only, no writes or network",
+                        desc: "Read project files; block file writes",
                       },
                       {
                         value: "workspace-write",
                         label: "Workspace Write",
-                        desc: "Write workspace, network, secrets blocked",
+                        desc: "Read and write inside the selected project",
                       },
                       {
                         value: "full-access",
                         label: "Full Access",
-                        desc: "No restrictions at all",
+                        desc: "Allow access outside the selected project",
                       },
                     ] as const
                   }
@@ -1289,9 +1295,14 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                           ? "border-accent bg-primary/10"
                           : "border-border-hover hover:border-muted-foreground/40"
                       }`}
-                      onClick={() =>
-                        handleStringChange("agentSandboxMode", mode.value)
-                      }
+                      onClick={() => {
+                        if (
+                          mode.value !== "full-access" ||
+                          confirmFullAgentAccess()
+                        ) {
+                          handleStringChange("agentSandboxMode", mode.value);
+                        }
+                      }}
                     >
                       <span class="text-2xl">
                         {mode.value === "read-only"
@@ -1320,8 +1331,8 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                   Approval Policy
                 </span>
                 <span class="text-[0.8rem] text-muted-foreground">
-                  When the agent requires human approval before executing
-                  commands
+                  How exceptional operations outside the selected project are
+                  handled. Normal project work stays automatic.
                 </span>
               </label>
               <div class="flex gap-3">
@@ -1422,6 +1433,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                       : "border-red-500/30 bg-surface-3/60 text-red-400/70 hover:border-red-500/60"
                   }`}
                   onClick={() => {
+                    if (!confirmFullAgentAccess()) return;
                     handleStringChange("agentSandboxMode", "full-access");
                     handleStringChange("agentApprovalPolicy", "never");
                   }}
@@ -1498,7 +1510,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                     Auto-approve read operations
                   </span>
                   <span class="text-[0.8rem] text-muted-foreground">
-                    Automatically approve file read requests without prompting
+                    Automatically approve reads inside the selected project
                   </span>
                 </div>
               </label>

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -19,15 +19,6 @@ import { conversationStore } from "@/stores/conversation.store";
 import { getApprovalRequirement, requiresApproval } from "./approval-config";
 import { parseGatewayToolName, parseMcpToolName } from "./definitions";
 
-/**
- * File entry returned by list_directory.
- */
-interface FileEntry {
-  name: string;
-  path: string;
-  is_directory: boolean;
-}
-
 const GATEWAY_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const SHELL_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_RESULT_SIZE = 50_000; // 50KB cap
@@ -341,55 +332,29 @@ export async function executeTool(
       );
     }
 
-    // Otherwise, handle local file tools
+    // Model-originated file tools must execute in the Rust worker, where the
+    // canonical project-root policy is enforced before invoking Tauri file
+    // commands. Refuse any legacy/frontend-routed copy instead of bypassing it.
+    if (
+      [
+        "read_file",
+        "read_file_base64",
+        "list_directory",
+        "write_file",
+        "write_pdf_from_html",
+        "path_exists",
+        "create_directory",
+      ].includes(name)
+    ) {
+      throw new Error(
+        "Local file tools must execute through the protected backend worker",
+      );
+    }
+
+    // Otherwise, handle non-file local tools.
     let result: unknown;
 
     switch (name) {
-      case "read_file": {
-        const path = args.path as string;
-        validatePath(path);
-        result = await invoke<string>("read_file", { path });
-        break;
-      }
-
-      case "list_directory": {
-        const path = args.path as string;
-        validatePath(path);
-        const entries = await invoke<FileEntry[]>("list_directory", { path });
-        result = formatDirectoryListing(entries);
-        break;
-      }
-
-      case "write_file": {
-        const path = args.path as string;
-        const content = args.content as string;
-        validatePath(path);
-        if (content == null) {
-          throw new Error("Invalid content: content must be provided");
-        }
-        await invoke("write_file", { path, content });
-        result = `Successfully wrote ${content.length} characters to ${path}`;
-        break;
-      }
-
-      case "path_exists": {
-        const path = args.path as string;
-        validatePath(path);
-        const exists = await invoke<boolean>("path_exists", { path });
-        result = exists
-          ? `Path exists: ${path}`
-          : `Path does not exist: ${path}`;
-        break;
-      }
-
-      case "create_directory": {
-        const path = args.path as string;
-        validatePath(path);
-        await invoke("create_directory", { path });
-        result = `Successfully created directory: ${path}`;
-        break;
-      }
-
       case "seren_web_fetch": {
         const url = args.url as string;
         const timeoutMs = args.timeout_ms as number | undefined;
@@ -825,44 +790,4 @@ export async function executeTools(
   toolCalls: ToolCall[],
 ): Promise<ToolResult[]> {
   return Promise.all(toolCalls.map(executeTool));
-}
-
-/**
- * Validate a path to prevent directory traversal attacks.
- * Throws if the path is suspicious.
- */
-function validatePath(path: string): void {
-  if (!path || typeof path !== "string") {
-    throw new Error("Invalid path: path must be a non-empty string");
-  }
-
-  // Check for null bytes (common attack vector)
-  if (path.includes("\0")) {
-    throw new Error("Invalid path: contains null byte");
-  }
-
-  // Warn about suspicious patterns but don't block (user may have legitimate use)
-  // The Tauri sandbox should handle actual security
-  const normalized = path.replace(/\\/g, "/");
-  if (normalized.includes("/../") || normalized.startsWith("../")) {
-    console.warn(
-      `[Tool Executor] Path contains parent directory traversal: ${path}`,
-    );
-  }
-}
-
-/**
- * Format directory listing for readable output.
- */
-function formatDirectoryListing(entries: FileEntry[]): string {
-  if (entries.length === 0) {
-    return "Directory is empty";
-  }
-
-  const lines = entries.map((entry) => {
-    const prefix = entry.is_directory ? "[DIR]  " : "[FILE] ";
-    return `${prefix}${entry.name}`;
-  });
-
-  return lines.join("\n");
 }

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -127,6 +127,13 @@ interface UserCapabilities {
   /** Active project root, threaded through to RoutingDecision.project_root
    * so the Rust ChatModelWorker can inject live git/repo context. */
   project_root: string | null;
+  /** Snapshot of the existing Settings -> Agent controls for backend enforcement. */
+  effective_agent_policy: {
+    sandbox_mode: "read-only" | "workspace-write" | "full-access";
+    approval_policy: "untrusted" | "on-failure" | "on-request" | "never";
+    auto_approve_reads: boolean;
+    network_enabled: boolean;
+  };
 }
 
 interface SkillRef {
@@ -1339,5 +1346,11 @@ function buildCapabilities(
     })),
     reasoning_effort: chatStore.reasoningEffort ?? null,
     project_root: fileTreeState.rootPath ?? null,
+    effective_agent_policy: {
+      sandbox_mode: settingsStore.settings.agentSandboxMode,
+      approval_policy: settingsStore.settings.agentApprovalPolicy,
+      auto_approve_reads: settingsStore.settings.agentAutoApproveReads,
+      network_enabled: settingsStore.settings.agentNetworkEnabled,
+    },
   };
 }

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -491,7 +491,8 @@ async function invokeProvider<T>(
  * @param apiKey - Optional API key to enable Seren MCP tools for the agent
  * @param approvalPolicy - Optional approval policy for command execution
  * @param searchEnabled - Optional flag to enable web search
- * @param networkEnabled - Optional flag to enable direct network access (uses full-access sandbox)
+ * @param networkEnabled - Optional flag to enable direct network access
+ * @param autoApproveReads - Automatically allow reads that stay inside the active project
  * @param timeoutSecs - Optional timeout in seconds for prompts. Undefined means unlimited.
  */
 export async function spawnAgent(
@@ -511,6 +512,7 @@ export async function spawnAgent(
   paired?: PairedSpawnConfig,
   lmStudioBaseUrl?: string,
   lmStudioApiKey?: string,
+  autoApproveReads?: boolean,
 ): Promise<AgentSessionInfo> {
   return invokeProvider<AgentSessionInfo>(
     "provider_spawn",
@@ -531,6 +533,7 @@ export async function spawnAgent(
       paired: paired ?? null,
       lmStudioBaseUrl: lmStudioBaseUrl ?? null,
       lmStudioApiKey: lmStudioApiKey ?? null,
+      autoApproveReads: autoApproveReads ?? null,
     },
     { timeoutMs: 120_000 },
   );

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -3324,6 +3324,7 @@ export const agentStore = {
           opts?.paired,
           settingsStore.settings.lmStudioBaseUrl,
           settingsStore.settings.lmStudioApiKey,
+          settingsStore.settings.agentAutoApproveReads,
         );
         console.log("[AgentStore] Spawn result:", info);
         await refreshAgentOAuthRouting(info.id, localSessionId ?? info.id);

--- a/tests/unit/agent-file-access-policy.test.ts
+++ b/tests/unit/agent-file-access-policy.test.ts
@@ -1,0 +1,152 @@
+// ABOUTME: Critical regression guards for project-scoped local-agent file access (#3091).
+// ABOUTME: Preserves promptless in-project work while preventing silent boundary escapes.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, symlinkSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+// @ts-ignore - browser-local runtime is plain ESM.
+import { evaluateFileAccess } from "../../bin/browser-local/file-access-policy.mjs";
+
+const claudeModulePath = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const { _buildClaudePolicySettings: buildClaudePolicySettings } = await import(
+  /* @vite-ignore */ claudeModulePath
+);
+const geminiModulePath = new URL(
+  "../../bin/browser-local/gemini-runtime.mjs",
+  import.meta.url,
+).href;
+const { _geminiSandboxEnv: geminiSandboxEnv } = await import(
+  /* @vite-ignore */ geminiModulePath
+);
+const claudeHookPath = fileURLToPath(
+  new URL("../../bin/browser-local/claude-file-policy-hook.mjs", import.meta.url),
+);
+
+function tempProject() {
+  return mkdtempSync(path.join(os.tmpdir(), "seren-file-policy-"));
+}
+
+describe("local-agent file access policy (#3091)", () => {
+  it("keeps reads and writes inside the active project automatic", () => {
+    const root = tempProject();
+    mkdirSync(path.join(root, "src"));
+
+    for (const kind of ["read", "write"] as const) {
+      const result = evaluateFileAccess({
+        requestedPath: path.join(root, "src", "new-file.ts"),
+        projectRoot: root,
+        kind,
+        sandboxMode: "workspace-write",
+        approvalPolicy: "on-request",
+        autoApproveReads: true,
+      });
+      expect(result.decision).toBe("allow");
+    }
+  });
+
+  it("canonicalizes symlinks and does not treat sibling prefixes as project paths", () => {
+    const root = tempProject();
+    const outside = tempProject();
+    const link = path.join(root, "outside-link");
+    symlinkSync(outside, link, "dir");
+
+    for (const requestedPath of [
+      path.join(link, "secret.txt"),
+      `${root}-sibling/secret.txt`,
+    ]) {
+      const result = evaluateFileAccess({
+        requestedPath,
+        projectRoot: root,
+        kind: "read",
+        sandboxMode: "workspace-write",
+        approvalPolicy: "never",
+      });
+      expect(result.decision).toBe("deny");
+    }
+  });
+
+  it("keeps Full Access as the explicit escape hatch", () => {
+    const root = tempProject();
+    const outside = tempProject();
+    const result = evaluateFileAccess({
+      requestedPath: path.join(outside, "file.txt"),
+      projectRoot: root,
+      kind: "write",
+      sandboxMode: "full-access",
+      approvalPolicy: "never",
+    });
+    expect(result.decision).toBe("allow");
+  });
+});
+
+describe("Claude promptless containment (#3091)", () => {
+  it("adds a mandatory file hook and Bash sandbox without changing permission mode", () => {
+    const root = tempProject();
+    const settings = buildClaudePolicySettings({
+      cwd: root,
+      sandboxMode: "workspace-write",
+      networkEnabled: false,
+    });
+
+    expect(settings.hooks.PreToolUse[0].matcher).toContain("Read");
+    expect(settings.hooks.PreToolUse[0].matcher).toContain("Write");
+    if (process.platform !== "win32") {
+      expect(settings.sandbox.enabled).toBe(true);
+      expect(settings.sandbox.autoAllowBashIfSandboxed).toBe(true);
+      expect(settings.sandbox.allowUnsandboxedCommands).toBe(false);
+      expect(settings.sandbox.filesystem.allowRead).toEqual([root]);
+    }
+  });
+
+  it("stays silent in-project and asks only for exceptional external access", () => {
+    const root = tempProject();
+    const outside = tempProject();
+    const runHook = (filePath: string) =>
+      spawnSync(process.execPath, [claudeHookPath], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SEREN_AGENT_PROJECT_ROOT: root,
+          SEREN_AGENT_SANDBOX_MODE: "workspace-write",
+          SEREN_AGENT_APPROVAL_POLICY: "on-request",
+          SEREN_AGENT_AUTO_APPROVE_READS: "true",
+          SEREN_AGENT_NETWORK_ENABLED: "true",
+        },
+        input: JSON.stringify({
+          tool_name: "Read",
+          tool_input: { file_path: filePath },
+        }),
+      });
+
+    expect(runHook(path.join(root, "README.md")).stdout).toBe("");
+    const exceptional = JSON.parse(
+      runHook(path.join(outside, "outside.txt")).stdout,
+    );
+    expect(
+      exceptional.hookSpecificOutput.permissionDecision,
+    ).toBe("ask");
+  });
+});
+
+describe("Gemini ACP containment (#3091)", () => {
+  it("enables Gemini's project sandbox except for explicit Full Access", () => {
+    expect(
+      geminiSandboxEnv({
+        sandboxMode: "workspace-write",
+        networkEnabled: true,
+      }).GEMINI_SANDBOX,
+    ).toBe("true");
+    expect(
+      geminiSandboxEnv({
+        sandboxMode: "full-access",
+        networkEnabled: true,
+      }).GEMINI_SANDBOX,
+    ).toBe("false");
+  });
+});

--- a/tests/unit/codex-runtime-permission-defaults.test.ts
+++ b/tests/unit/codex-runtime-permission-defaults.test.ts
@@ -9,6 +9,7 @@ const modulePath = new URL(
 ).href;
 const {
   _codexApprovalPolicy: codexApprovalPolicy,
+  _codexNetworkConfigOverride: codexNetworkConfigOverride,
   _modeFromApprovalPolicy: modeFromApprovalPolicy,
   _sandboxFromMode: sandboxFromMode,
 } = await import(/* @vite-ignore */ modulePath);
@@ -31,10 +32,19 @@ describe("Codex sandbox mapping (#2886)", () => {
     expect(sandboxFromMode("full-access", false)).toBe("danger-full-access");
   });
 
-  it("keeps legacy runtime full-access and network-enabled sessions full access", () => {
+  it("keeps legacy runtime full-access while separating network from filesystem scope", () => {
     expect(sandboxFromMode("danger-full-access", false)).toBe(
       "danger-full-access",
     );
-    expect(sandboxFromMode("workspace-write", true)).toBe("danger-full-access");
+    expect(sandboxFromMode("workspace-write", true)).toBe("workspace-write");
+  });
+
+  it("applies network access as a workspace sandbox option", () => {
+    expect(codexNetworkConfigOverride(true)).toBe(
+      "sandbox_workspace_write.network_access=true",
+    );
+    expect(codexNetworkConfigOverride(false)).toBe(
+      "sandbox_workspace_write.network_access=false",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3091.

- compiles the existing Settings → Agent controls into a backend-owned policy for hosted chat and local runtimes
- automatically permits ordinary canonical in-project work while gating or denying external and sensitive paths
- preserves Claude `bypassPermissions` and direct/paired Codex Auto exactly as intentional long-run UX invariants
- separates Codex network access from filesystem scope, adds Claude/Gemini/Grok containment adapters, and path-scopes LM Studio grants
- removes the legacy frontend file-tool bypass and adds a concise external-file approval dialog
- keeps Full Access as the existing explicit, confirmed escape hatch

## Security and UX boundary

This is the minimum viable P0 containment improvement, not a claim of perfect cross-platform TOCTOU protection. Canonical-root and nearest-existing-parent checks block traversal, prefix collisions, and symlink escapes before model-originated file operations. Normal work inside the selected project remains promptless.

Claude's built-in file tools are constrained by a mandatory PreToolUse hook even while Claude stays in `bypassPermissions`; its Bash subprocesses also use Claude's native sandbox where supported. Codex stays in Auto and `workspace-write`, with network configured independently.

## Network path audit

No new networked product feature path is introduced. Settings flow locally from the renderer through Tauri/provider-runtime session creation. Existing outbound model and publisher API slugs, methods, and paths are unchanged. The GitHub API is used only for issue/PR workflow.

## Verification

- `pnpm test`: 2,455 passed, 15 skipped
- `cargo test --manifest-path src-tauri/Cargo.toml`: 936 passed, 2 ignored
- `pnpm build`
- `pnpm check` (existing warnings only)
- `pnpm build:provider-runtime`
- `pnpm test:runtime-smoke`
- exact source/bundled-runtime parity for all eight changed runtime files
- focused live Claude hook process check: in-project read silent; external read requests exceptional approval

No mocks were used for runtime checks. Public text intentionally excludes local paths, credentials, and screenshots.