### PR TITLE
fix(windows): let progressing NSIS installs finish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1791,7 +1791,7 @@ jobs:
             "Expand-Archive -LiteralPath (Join-Path $work 'windows-e2e-payload.zip') -DestinationPath $work -Force",
             "Set-Location $work",
             "Write-Host '[windows-e2e:ssm] Running Windows app harness as scheduled task user'",
-            `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-task-user.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe') -WorkDir $work -SecretParameterPrefix ${psString(env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX)} -ProbeTimeoutSeconds 1800 -TaskTimeoutSeconds 3600${unsignedBudgetArg}`,
+            `powershell -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\windows-e2e-task-user.ps1 -InstallerPath (Join-Path $work 'SerenDesktop-setup.exe') -WorkDir $work -SecretParameterPrefix ${psString(env.WINDOWS_E2E_SECRET_PARAMETER_PREFIX)} -ProbeTimeoutSeconds 1800 -TaskTimeoutSeconds 4800${unsignedBudgetArg}`,
             "$harnessExitCode = $LASTEXITCODE",
             "Write-Host '[windows-e2e:ssm] Bundling Windows app harness logs'",
             "$logPaths = @((Join-Path $work 'windows-e2e-task.log'), (Join-Path $work 'windows-e2e-logs')) | Where-Object { Test-Path -LiteralPath $_ }",
@@ -1810,10 +1810,10 @@ jobs:
             ];
           // executionTimeout bounds the whole on-box command. It must exceed the
           // harness's own budget: the scheduled-task wait (TaskTimeoutSeconds + 60
-          // = 3660s) plus the pre-task per-step timeouts (corepack/pnpm/playwright
-          // ~2100s worst case). The default 3600s killed valid runs before the
-          // harness finished. The harness now fails fast on a dead task (#2431),
-          // so this large value is only a backstop, never the normal bound.
+          // = 4860s) plus wrapper overhead. The task budget includes bounded
+          // corepack/pnpm/playwright setup, the 1200s installer allowance, and the
+          // app probe. The harness fails fast on a dead task (#2431), so this large
+          // value is only a backstop, never the normal bound.
           process.stdout.write(
             JSON.stringify({ commands, executionTimeout: ["6000"] }, null, 2),
           );

--- a/scripts/windows-e2e-app.ps1
+++ b/scripts/windows-e2e-app.ps1
@@ -12,7 +12,7 @@ param(
 
   [int]$StartupTimeoutSeconds = 120,
 
-  [int]$InstallerTimeoutSeconds = 180,
+  [int]$InstallerTimeoutSeconds = 1200,
 
   [int]$ProbeTimeoutSeconds = 1800
 )

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -12,11 +12,11 @@ param(
 
   [int]$StartupTimeoutSeconds = 120,
 
-  [int]$InstallerTimeoutSeconds = 600,
+  [int]$InstallerTimeoutSeconds = 1200,
 
   [int]$ProbeTimeoutSeconds = 1800,
 
-  [int]$TaskTimeoutSeconds = 3600,
+  [int]$TaskTimeoutSeconds = 4800,
 
   [switch]$AllowUnsignedPrArtifact,
 

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -73,7 +73,7 @@ describe("Windows production e2e release gate", () => {
     expect(sendAt).toBeGreaterThanOrEqual(0);
     expect(preflightAt).toBeLessThan(sendAt);
     // The SSM doc and the runner poll deadline must both exceed the on-box wait
-    // budget (TaskTimeoutSeconds + 60 = 3660s) plus pre-task overhead, so a valid
+    // budget (TaskTimeoutSeconds + 60 = 4860s) plus wrapper overhead, so a valid
     // slow run is not killed by the harness before it finishes.
     expect(job).toContain('executionTimeout: ["6000"]');
     expect(job).toContain("SECONDS + 6300");
@@ -275,7 +275,10 @@ describe("Windows production e2e release gate", () => {
     expect(taskUserRunner).toContain("SEREN_E2E_UNSIGNED_PR_RUN");
     expect(taskUserRunner).toContain("SerenDesktopE2E");
     expect(taskUserRunner).toContain("-InstallDir");
-    expect(taskUserRunner).toContain("InstallerTimeoutSeconds = 600");
+    expect(runner).toContain("InstallerTimeoutSeconds = 1200");
+    expect(taskUserRunner).toContain("InstallerTimeoutSeconds = 1200");
+    expect(taskUserRunner).toContain("TaskTimeoutSeconds = 4800");
+    expect(releaseWorkflow).toContain("-TaskTimeoutSeconds 4800");
     expect(taskUserRunner).toContain("windows-e2e-app.ps1");
     expect(taskUserRunner).toContain("Windows app scheduled-task harness failed");
     expect(taskUserRunner).toContain("Stop-E2EProcessTree");


### PR DESCRIPTION
## Summary

- raise the Windows NSIS install budget from 600s to 1200s after two live SSM reproductions showed the installer still making progress at the old boundary
- raise the scheduled-task envelope from 3600s to 4800s while keeping the existing 6000s SSM backstop and 6300s poll above it
- align the standalone app-harness default with the release path
- update only the existing release-gate regression assertion

Fixes #3098
Fixes #3100

## Audit

The clean reproduction used the exact Windows CI artifact from #3096, a fresh host stop/start cycle, release-equivalent scratch pruning, and more than 50 GB free. NSIS was still adding files when the 600s harness killed it. Prior disk-pressure fix #2905 and outer-budget fix #2436 do not cover this inner timeout.

No product network path changes. This PR changes only the Windows functional-test/release harness; there are no outbound publisher/API slugs, methods, or paths to verify.

## Checks

- `pnpm vitest run tests/unit/windows-e2e-release-gate.test.ts` — 28/28 passed
- release workflow YAML parse — passed
- `git diff --check` — passed
- live no-mock Windows SSM rerun — pending on this PR branch and will be posted before merge

The public description contains no user, host, account, bucket, parameter, command, or credential identifiers.

## Follow-up walkthrough repair

The first post-PR SSM run proved the 1200s installer budget (NSIS completed successfully in 650s), then exposed #3100: the clean release user still depended on the provider auto-install behavior removed by #3096. Commit `79d1a486` now provisions the vendors' documented npm packages as explicit test setup, verifies both CLI binaries, and leaves production provider startup manual/review-first. Focused Windows-gate + CLI-updater tests: 73/73 passed. A fresh live SSM rerun is pending.