### PR TITLE
fix(e2e): provision Windows CLI prerequisites explicitly

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -811,9 +811,9 @@ function authError(journey, detail) {
 
 function provisioningError(journey, detail) {
   return new AgentProvisioningError(
-    `${journey} CLI could not be installed, launched, or kept alive long ` +
-      `enough to complete the Windows e2e prompt. Verify the scheduled-task ` +
-      `user can resolve the CLI binary and received agent credentials via ` +
+    `${journey} CLI could not be resolved, launched, or kept alive long enough ` +
+      `to complete the Windows e2e prompt. Verify the scheduled-task user ` +
+      `received the explicit e2e CLI prerequisites and agent credentials via ` +
       `SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_S3_URI or ` +
       `SEREN_E2E_AGENT_CREDENTIAL_ARCHIVE_B64, and check provider-runtime logs ` +
       `for a real process crash. Detail: ${detail}`,
@@ -882,7 +882,7 @@ async function ensureAgentCli(ws, agentType) {
       "provider_ensure_agent_cli",
       { agentType },
       PROVIDER_ENSURE_CLI_TIMEOUT_MS,
-      `${agentType} CLI install`,
+      `${agentType} CLI resolution`,
     );
     logStage(`${agentType} provider CLI ready: ${String(resolved || "<unknown>")}`);
   } catch (error) {

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -496,6 +496,33 @@ try {
   Invoke-LoggedNative "Corepack enable" "corepack" @("enable") 120
   Invoke-LoggedNative "Corepack prepare pnpm" "corepack" @("prepare", "pnpm@9", "--activate") 180
   Invoke-LoggedNative "pnpm install" "pnpm" @("install", "--frozen-lockfile") 1200
+  # #3096 intentionally removed provider-startup installation. The release
+  # user is disposable and starts empty, so provision its real CLI prerequisites
+  # explicitly as test setup using the vendors' documented npm packages. This
+  # must remain outside provider_ensure_agent_cli: production startup should
+  # continue to hand a missing CLI to the user for review/manual installation.
+  Invoke-LoggedNative "Install e2e agent CLIs" "npm" @(
+    "install",
+    "--global",
+    "--no-audit",
+    "--no-fund",
+    "@anthropic-ai/claude-code@latest",
+    "@openai/codex@latest"
+  ) 1200
+  `$npmGlobalPrefix = [string](& npm prefix --global | Select-Object -Last 1)
+  `$npmGlobalPrefix = `$npmGlobalPrefix.Trim()
+  if ([string]::IsNullOrWhiteSpace(`$npmGlobalPrefix)) {
+    throw "npm did not report a global prefix after installing the e2e agent CLIs"
+  }
+  `$claudeCliPath = Join-Path `$npmGlobalPrefix "claude.cmd"
+  `$codexCliPath = Join-Path `$npmGlobalPrefix "codex.cmd"
+  foreach (`$cliPath in @(`$claudeCliPath, `$codexCliPath)) {
+    if (-not (Test-Path -LiteralPath `$cliPath)) {
+      throw "Required e2e agent CLI was not installed at the npm global prefix"
+    }
+  }
+  Invoke-LoggedNative "Verify Claude Code CLI" `$claudeCliPath @("--version") 120
+  Invoke-LoggedNative "Verify Codex CLI" `$codexCliPath @("--version") 120
   Invoke-LoggedNative "Playwright Chromium install" "pnpm" @("exec", "playwright", "install", "chromium") 600
   `$harnessArgs = @(
     "-NoProfile",

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -444,10 +444,26 @@ describe("Windows production e2e release gate", () => {
     expect(releaseWorkflow).toContain("windows-app-e2e-logs");
   });
 
-  it("provisions agent CLIs before checking release-gate availability (#2481)", () => {
-    // A Bedrock-backed Claude run still needs a launchable local Claude Code
-    // binary. The release probe must use the same install contract as the
-    // desktop spawn path before it asks whether the provider can launch.
+  it("preprovisions real agent CLIs outside provider startup before checking release-gate availability (#2481, #3100)", () => {
+    // #3096 removed automatic provider-startup installers. The disposable
+    // Windows release user must install its explicit test prerequisites before
+    // app launch, while the production RPC only verifies resolution.
+    const cliSetupAt = taskUserRunner.indexOf(
+      'Invoke-LoggedNative "Install e2e agent CLIs"',
+    );
+    const appHarnessAt = taskUserRunner.indexOf(
+      'Invoke-LoggedNative "Windows app harness"',
+    );
+    expect(cliSetupAt).toBeGreaterThanOrEqual(0);
+    expect(appHarnessAt).toBeGreaterThanOrEqual(0);
+    expect(cliSetupAt).toBeLessThan(appHarnessAt);
+    expect(taskUserRunner).toContain("@anthropic-ai/claude-code@latest");
+    expect(taskUserRunner).toContain("@openai/codex@latest");
+    expect(taskUserRunner).toContain('Join-Path `$npmGlobalPrefix "claude.cmd"');
+    expect(taskUserRunner).toContain('Join-Path `$npmGlobalPrefix "codex.cmd"');
+    expect(taskUserRunner).toContain('Verify Claude Code CLI');
+    expect(taskUserRunner).toContain('Verify Codex CLI');
+
     expect(probe).toContain("provider_ensure_agent_cli");
     expect(probe).toContain("ensureAgentCli");
     expect(probe).toContain("ensuring provider CLI");


### PR DESCRIPTION
## Summary

- explicitly provision Claude Code and Codex in the disposable Windows release-test user using the vendors' documented npm packages
- verify both real Windows CLI shims before launching the production app
- keep `provider_ensure_agent_cli` as a resolution/compatibility check, never an installer
- correct the probe error wording now that provider startup is manual/review-first

Fixes #3100

## Why this is separate

PR #3099 merged the NSIS timeout repair before the follow-up SSM walkthrough completed. That walkthrough proved the installer fix (the unchanged production installer completed successfully in 650 seconds), then found #3100: the clean release user still relied on the provider auto-install behavior removed by #3096.

## Safety and network audit

Production provider startup remains unchanged and contains no downloaded shell/PowerShell installer. The CLI installation runs only in `scripts/windows-e2e-task-user.ps1` for a disposable test user.

There is no product UI action, Seren publisher slug, or product API method/path added by this PR. Test setup invokes the system npm client for:
- `@anthropic-ai/claude-code@latest`
- `@openai/codex@latest`

The npm client uses its configured registry; the app does not issue or proxy those requests. Official references:
- https://code.claude.com/docs/en/installation
- https://developers.openai.com/codex/cli/

## Checks

- Windows release-gate + CLI-updater unit tests: 73/73 passed
- release workflow YAML parse: passed
- `git diff --check`: passed
- live no-mock Windows SSM rerun: pending and will be posted before merge

No user, host, account, bucket, parameter, command, credential, or local-path identifiers are included here.