### PR TITLE
fix(e2e): cover all Windows provider CLIs

### DIFF
--- a/scripts/windows-e2e-app.mjs
+++ b/scripts/windows-e2e-app.mjs
@@ -28,6 +28,18 @@ const GITHUB_PAT = requiredEnv("SEREN_E2E_GITHUB_PAT");
 // The paired workflow ships as one agent type backed by two CLIs. Declared
 // locally because the e2e payload only bundles this script — never bin/.
 const PAIRED_AGENT_TYPE = "claude-codex";
+// npm-backed CLIs are installed and version-checked by the disposable Windows
+// test-user setup before the app starts. Exercise the production resolver for
+// every corresponding provider here without requiring credentials or turning
+// provider_ensure_agent_cli back into an installer. LM Studio is excluded:
+// its `lms` CLI ships with the separately installed LM Studio application.
+const CLI_COMPATIBILITY_AGENT_TYPES = [
+  "codex",
+  "claude-code",
+  PAIRED_AGENT_TYPE,
+  "gemini",
+  "grok",
+];
 // Every shipped subscription coding-agent journey is certified, not one
 // env-selected type (#2375). Override with a comma list for ad-hoc runs.
 const AGENT_JOURNEYS = (
@@ -891,6 +903,15 @@ async function ensureAgentCli(ws, agentType) {
   }
 }
 
+async function verifyAgentCliCompatibility(ws) {
+  for (const agentType of CLI_COMPATIBILITY_AGENT_TYPES) {
+    await ensureAgentCli(ws, agentType);
+  }
+  logStage(
+    `all provider CLI resolution checks passed: ${CLI_COMPATIBILITY_AGENT_TYPES.join(", ")}`,
+  );
+}
+
 // A raw spawn/prompt failure carries a generic message; the runtime also emits
 // a provider://error with the auth text. Promote either signal to a distinct
 // AgentAuthError so the job names the credential gap, not a timeout (#2375).
@@ -1217,6 +1238,7 @@ async function exerciseAgentRuntime(page) {
   const ws = await connectProviderRuntime(page, config);
   const buffer = createRuntimeBuffer(ws);
   try {
+    await verifyAgentCliCompatibility(ws);
     for (const journey of AGENT_JOURNEYS) {
       if (journey === PAIRED_AGENT_TYPE) {
         await runPairedJourney(ws, buffer);

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -501,28 +501,28 @@ try {
   # explicitly as test setup using the vendors' documented npm packages. This
   # must remain outside provider_ensure_agent_cli: production startup should
   # continue to hand a missing CLI to the user for review/manual installation.
-  Invoke-LoggedNative "Install e2e agent CLIs" "npm" @(
-    "install",
-    "--global",
-    "--no-audit",
-    "--no-fund",
-    "@anthropic-ai/claude-code@latest",
-    "@openai/codex@latest"
-  ) 1200
+  `$agentCliPackages = @(
+    @{ Label = "Claude Code"; Package = "@anthropic-ai/claude-code@latest"; Binary = "claude.cmd" },
+    @{ Label = "Codex"; Package = "@openai/codex@latest"; Binary = "codex.cmd" },
+    @{ Label = "Gemini"; Package = "@google/gemini-cli@latest"; Binary = "gemini.cmd" },
+    @{ Label = "Grok"; Package = "@xai-official/grok@latest"; Binary = "grok.cmd" }
+  )
+  `$agentCliInstallArgs = @("install", "--global", "--no-audit", "--no-fund") + @(
+    `$agentCliPackages | ForEach-Object { `$_.Package }
+  )
+  Invoke-LoggedNative "Install e2e agent CLIs" "npm" `$agentCliInstallArgs 1200
   `$npmGlobalPrefix = [string](& npm prefix --global | Select-Object -Last 1)
   `$npmGlobalPrefix = `$npmGlobalPrefix.Trim()
   if ([string]::IsNullOrWhiteSpace(`$npmGlobalPrefix)) {
     throw "npm did not report a global prefix after installing the e2e agent CLIs"
   }
-  `$claudeCliPath = Join-Path `$npmGlobalPrefix "claude.cmd"
-  `$codexCliPath = Join-Path `$npmGlobalPrefix "codex.cmd"
-  foreach (`$cliPath in @(`$claudeCliPath, `$codexCliPath)) {
+  foreach (`$agentCli in `$agentCliPackages) {
+    `$cliPath = Join-Path `$npmGlobalPrefix `$agentCli.Binary
     if (-not (Test-Path -LiteralPath `$cliPath)) {
-      throw "Required e2e agent CLI was not installed at the npm global prefix"
+      throw "Required `$(`$agentCli.Label) e2e agent CLI was not installed at the npm global prefix"
     }
+    Invoke-LoggedNative "Verify `$(`$agentCli.Label) CLI" `$cliPath @("--version") 120
   }
-  Invoke-LoggedNative "Verify Claude Code CLI" `$claudeCliPath @("--version") 120
-  Invoke-LoggedNative "Verify Codex CLI" `$codexCliPath @("--version") 120
   Invoke-LoggedNative "Playwright Chromium install" "pnpm" @("exec", "playwright", "install", "chromium") 600
   `$harnessArgs = @(
     "-NoProfile",

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -459,15 +459,51 @@ describe("Windows production e2e release gate", () => {
     expect(cliSetupAt).toBeLessThan(appHarnessAt);
     expect(taskUserRunner).toContain("@anthropic-ai/claude-code@latest");
     expect(taskUserRunner).toContain("@openai/codex@latest");
-    expect(taskUserRunner).toContain('Join-Path `$npmGlobalPrefix "claude.cmd"');
-    expect(taskUserRunner).toContain('Join-Path `$npmGlobalPrefix "codex.cmd"');
-    expect(taskUserRunner).toContain('Verify Claude Code CLI');
-    expect(taskUserRunner).toContain('Verify Codex CLI');
+    expect(taskUserRunner).toContain("@google/gemini-cli@latest");
+    expect(taskUserRunner).toContain("@xai-official/grok@latest");
+    for (const [label, binary] of [
+      ["Claude Code", "claude.cmd"],
+      ["Codex", "codex.cmd"],
+      ["Gemini", "gemini.cmd"],
+      ["Grok", "grok.cmd"],
+    ]) {
+      expect(taskUserRunner).toContain(
+        `Label = "${label}"; Package =`,
+      );
+      expect(taskUserRunner).toContain(`Binary = "${binary}"`);
+    }
+    expect(taskUserRunner).toContain(
+      'Invoke-LoggedNative "Verify `$(`$agentCli.Label) CLI"',
+    );
 
     expect(probe).toContain("provider_ensure_agent_cli");
     expect(probe).toContain("ensureAgentCli");
     expect(probe).toContain("ensuring provider CLI");
     expect(probe).toContain("provider CLI ready");
+    expect(probe).toContain("CLI_COMPATIBILITY_AGENT_TYPES");
+    expect(probe).toContain("verifyAgentCliCompatibility");
+    expect(probe).toContain("all provider CLI resolution checks passed");
+    for (const agentType of [
+      "codex",
+      "claude-code",
+      "claude-codex",
+      "gemini",
+      "grok",
+    ]) {
+      expect(probe).toContain(`"${agentType}"`);
+    }
+    const runtimeExerciseAt = probe.indexOf("async function exerciseAgentRuntime");
+    const compatibilityCheckAt = probe.indexOf(
+      "await verifyAgentCliCompatibility(ws)",
+      runtimeExerciseAt,
+    );
+    const authenticatedJourneysAt = probe.indexOf(
+      "for (const journey of AGENT_JOURNEYS)",
+      runtimeExerciseAt,
+    );
+    expect(runtimeExerciseAt).toBeGreaterThanOrEqual(0);
+    expect(compatibilityCheckAt).toBeGreaterThan(runtimeExerciseAt);
+    expect(compatibilityCheckAt).toBeLessThan(authenticatedJourneysAt);
 
     const singleJourneyStart = probe.indexOf("async function runSingleAgentJourney");
     const pairedJourneyStart = probe.indexOf("async function runPairedJourney");


### PR DESCRIPTION
## Summary

- install every npm-distributed production provider CLI in the disposable Windows release-test user
- verify the real Windows shims for Claude Code, Codex, Gemini, and Grok before app launch
- run a pre-auth production compatibility phase that resolves Codex, Claude Code, paired Claude/Codex, Gemini, and Grok through `provider_ensure_agent_cli`
- keep authenticated prompt journeys credential-driven and keep LM Studio outside this npm set because `lms` ships with the separately installed LM Studio product

Fixes #3102

## Audit result

The production `AgentType` union has six entries:

- Claude Code → `@anthropic-ai/claude-code`
- Codex → `@openai/codex`
- Gemini → `@google/gemini-cli`
- Grok → `@xai-official/grok`
- paired Claude/Codex → reuses the first two binaries
- LM Studio → `lms` ships with the separately installed LM Studio application; there is no npm CLI package to add here

The merged #3101 setup covered only the first two packages. This PR makes the four-package set explicit and ensures the app resolves every corresponding provider type before authentication.

## Safety and network audit

Production provider startup is unchanged. This PR adds no product UI action, Seren publisher slug, or product API method/path.

The only added outbound path is the disposable Windows test user's system npm client to its configured registry for:

- `@anthropic-ai/claude-code@latest`
- `@openai/codex@latest`
- `@google/gemini-cli@latest`
- `@xai-official/grok@latest`

`provider_ensure_agent_cli` remains a resolution/compatibility check after setup, not the e2e installer.

Official references:

- https://code.claude.com/docs/en/installation
- https://developers.openai.com/codex/cli/
- https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/index.md
- https://docs.x.ai/build/enterprise
- https://lmstudio.ai/docs/cli

## Checks

- focused Windows release-gate, updater, Gemini, and Grok tests: 100/100 passed
- `node --check scripts/windows-e2e-app.mjs`: passed
- `git diff --check`: passed
- real no-mock Windows SSM walkthrough: pending; sanitized results will be posted before merge

No user, host, account, credential, bucket, parameter, command, or local-path identifiers are included here.
