### PR TITLE
fix(agent): stop output validation from destroying markdown

### DIFF
--- a/src/lib/agent-output-validation/claims.ts
+++ b/src/lib/agent-output-validation/claims.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Deterministic claim extraction for Verified Agent Output.
 // ABOUTME: Finds concrete completion claims without relying on model self-reporting.
 
-import type { ClaimKind, ExtractedClaim } from "./types";
+import type { ClaimKind, ExtractedClaim, SentenceSpan } from "./types";
 
 type ClaimMatcher = {
   kind: ClaimKind;
@@ -75,15 +75,40 @@ export function extractClaims(finalText: string): ExtractedClaim[] {
   return claims;
 }
 
-export function splitSentences(
-  text: string,
-): Array<{ index: number; text: string }> {
-  const normalized = text.replace(/\s+/g, " ").trim();
-  if (!normalized) return [];
-  const matches = normalized.match(/[^.!?]+[.!?]?/g);
-  return (matches ?? [normalized])
-    .map((part, index) => ({ index, text: part.trim() }))
-    .filter((part) => part.text.length > 0);
+// Sentence spans carry offsets into the untouched source so callers can splice
+// a rewrite in place instead of rebuilding the message. Two bounds keep a
+// rewrite from destroying markdown (#3105): a sentence never crosses a line
+// break, because ordered-list markers and dotted filenames otherwise open a
+// "sentence" that swallows blank lines and whole blocks before the next
+// terminator; and fenced code is skipped entirely, so prose rules can never
+// overwrite a line of code.
+export function splitSentences(text: string): SentenceSpan[] {
+  const spans: SentenceSpan[] = [];
+  let lineStart = 0;
+  let inFence = false;
+
+  for (const line of text.split("\n")) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+    } else if (!inFence) {
+      for (const match of line.matchAll(/[^.!?]+[.!?]?/g)) {
+        const raw = match[0];
+        const trimmed = raw.trim();
+        if (!trimmed) continue;
+        const start =
+          lineStart + match.index + (raw.length - raw.trimStart().length);
+        spans.push({
+          index: spans.length,
+          text: trimmed.replace(/\s+/g, " "),
+          start,
+          end: start + trimmed.length,
+        });
+      }
+    }
+    lineStart += line.length + 1;
+  }
+
+  return spans;
 }
 
 function dedupeSentenceClaims(claims: ExtractedClaim[]): ExtractedClaim[] {

--- a/src/lib/agent-output-validation/types.ts
+++ b/src/lib/agent-output-validation/types.ts
@@ -20,6 +20,16 @@ export interface EvidenceRequirement {
   anyOf: string[];
 }
 
+export interface SentenceSpan {
+  index: number;
+  /** Whitespace-normalized sentence text, used for claim matching. */
+  text: string;
+  /** Inclusive offset of the sentence in the original, unmodified text. */
+  start: number;
+  /** Exclusive offset of the sentence in the original, unmodified text. */
+  end: number;
+}
+
 export interface ExtractedClaim {
   id: string;
   kind: ClaimKind;

--- a/src/lib/agent-output-validation/validateFinalOutput.ts
+++ b/src/lib/agent-output-validation/validateFinalOutput.ts
@@ -125,21 +125,27 @@ function buildSafeDisplayText(
     unverifiedBySentence.set(claim.sentenceIndex, existing);
   }
 
-  const safeSentences = sentences.map((sentence) => {
+  // Splice rewrites into the original text by offset. Everything outside an
+  // unverified sentence is copied byte-for-byte, so markdown structure and all
+  // unrelated content survive verbatim (#3105).
+  let result = "";
+  let cursor = 0;
+  for (const sentence of sentences) {
     const unverifiedClaims = unverifiedBySentence.get(sentence.index);
-    if (!unverifiedClaims || unverifiedClaims.length === 0) {
-      return sentence.text;
-    }
+    if (!unverifiedClaims || unverifiedClaims.length === 0) continue;
     const rewrites = [...unverifiedClaims]
       .sort((a, b) => a.sentenceOffset - b.sentenceOffset)
       .map((claim) => {
         const rule = ruleForClaim(claim.kind);
         return rule.safeRewrite(claim, evidence);
       });
-    return dedupe(rewrites).join(" ");
-  });
+    result +=
+      displayText.slice(cursor, sentence.start) + dedupe(rewrites).join(" ");
+    cursor = sentence.end;
+  }
+  result += displayText.slice(cursor);
 
-  return safeSentences.join(" ").trim();
+  return result.trim();
 }
 
 function ruleForClaim(kind: ClaimKind): FinalizationRule {

--- a/tests/unit/agent-output-validation.test.ts
+++ b/tests/unit/agent-output-validation.test.ts
@@ -368,6 +368,51 @@ describe("#1987 Verified Agent Output", () => {
     });
   });
 
+  it("preserves markdown structure and unrelated content when rewriting (#3105)", () => {
+    const finalText = [
+      "## Parity verdicts",
+      "",
+      "| Feature | Status |",
+      "| --- | --- |",
+      "| Unified Context | Exists in `provider-bindings.ts` |",
+      "",
+      "1. Host reliability",
+      "2. Remote host",
+      "",
+      "```ts",
+      "// updated the file",
+      "```",
+      "",
+      "Gemini CLI is not available in seren-desktop.",
+      "",
+      "That is the end of the audit.",
+    ].join("\n");
+
+    const report = validateFinalOutput({
+      finalText,
+      evidence: extractEvidenceFromUnifiedMessages([]),
+    });
+
+    // Only the offending sentence is replaced; every other byte is identical.
+    expect(report.safeDisplayText).toBe(
+      finalText.replace(
+        "Gemini CLI is not available in seren-desktop.",
+        "I could not verify that the service is unavailable.",
+      ),
+    );
+    // The block structure that markdown rendering depends on survives.
+    expect(report.safeDisplayText).toContain("## Parity verdicts\n");
+    expect(report.safeDisplayText).toContain("| --- | --- |\n");
+    // Fenced code is never claim-matched, so a prose rule cannot overwrite it
+    // even though this line matches the file_edit pattern.
+    expect(report.safeDisplayText).toContain("```ts\n// updated the file\n```");
+    // Tokens are never split mid-word by the sentence walker.
+    expect(report.safeDisplayText).toContain("`provider-bindings.ts`");
+    expect(report.claims).toMatchObject([
+      { kind: "publisher_unavailable", status: "unverified" },
+    ]);
+  });
+
   it("wires validation into all required finalization paths", () => {
     const chatSource = readFileSync("src/services/chat.ts", "utf8");
     const orchestratorSource = readFileSync(


### PR DESCRIPTION
Closes #3105

## What was broken

`validateFinalOutput` rebuilt the **entire** assistant message from whitespace-normalized sentence fragments whenever any single claim came back `unverified`. `splitSentences` collapsed every newline to a space, and `buildSafeDisplayText` re-joined the fragments with `" "`. All markdown block structure — headings, tables, lists, fenced code, paragraph breaks — was destroyed, and the damaged text (not the original) is what `persistAgentMessage` wrote to the messages table.

Reproduced against real audit-shaped text before touching anything:

```
| BYOA (Claude Code, Codex, Cursor, OpenCode) | Mostly parity |
| Agent-to-Agent Communication | Missing. |

Traycer features not available in seren-desktop are listed above.
```

became

```
| BYOA (Claude Code, Codex, Cursor, OpenCode) | Mostly parity | | Agent-to-Agent Communication | Missing. | Traycer features not available in seren-desktop are listed above.
```

— the exact `| … | | … |` degradation seen in the reported screenshot. The trigger was `publisher_unavailable` firing on the descriptive phrase "not available", i.e. prose about a third-party product, not a completion claim at all.

## The fix

1. **`splitSentences` returns offsets into the original string.** Sentence `text` stays whitespace-normalized for claim matching; `start`/`end` point into the untouched source.
2. **`buildSafeDisplayText` splices by offset.** Everything outside an unverified sentence is copied byte-for-byte, so the all-or-nothing flattening is gone by construction — only the offending span is replaced.
3. **Two bounds on how far a rewrite can reach**, both found by the regression test rather than assumed:
   - A sentence never crosses a line break. Splitting only on `.!?` meant an ordered-list marker (`2.`) or a dotted filename opened a "sentence" that swallowed blank lines and an entire code fence before the next terminator — so offset-splicing alone still deleted whole blocks.
   - Fenced code is skipped entirely, so a prose rule can never overwrite a line of code. Mutation-checked: disabling the skip makes `// updated the file` inside a fence get replaced with "I could not verify that the file was changed." and the test catches it.

## Scope / what is not addressed

Item 4 of the issue's suggested fix — surfacing substitutions in the UI so a swapped sentence is visibly marked — is **not** in this PR. It needs the validation report threaded through persistence and the render path, which is a materially larger surface than the formatting fix. Tracked separately; the silent-substitution trust concern from #3105 is still open.

The false-positive matcher behaviour (descriptive prose matching `publisher_unavailable`) is also unchanged. This PR bounds the blast radius to a single sentence rather than re-tuning the matchers.

## Networked paths

None. This change is pure local text processing in the frontend — no publisher slug, endpoint, or outbound request is added, removed, or altered.

## Testing

- `vitest run` — 339 files, 2465 passed, 0 failed. All 9 pre-existing `agent-output-validation` tests pass unchanged, so rewrite semantics are preserved.
- One added regression test asserting a message with a heading, table, ordered list and fenced code survives byte-identical except for the single rewritten span.
- `biome check` clean on touched files. `tsc` reports no new errors (pre-existing errors elsewhere are untouched).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
