### PR TITLE
fix(agent): disclose validator substitutions in output

### DIFF
--- a/src/lib/agent-output-validation/index.ts
+++ b/src/lib/agent-output-validation/index.ts
@@ -18,4 +18,7 @@ export type {
   ToolEvidence,
   ValidatedClaim,
 } from "./types";
-export { validateFinalOutput } from "./validateFinalOutput";
+export {
+  SUBSTITUTION_MARKER,
+  validateFinalOutput,
+} from "./validateFinalOutput";

--- a/src/lib/agent-output-validation/validateFinalOutput.ts
+++ b/src/lib/agent-output-validation/validateFinalOutput.ts
@@ -14,6 +14,11 @@ import type {
   ValidateFinalOutputInput,
 } from "./types";
 
+/** Prefixes any sentence the validator replaced, so substituted text is never
+ * mistaken for the agent's own words. Inline-level so it survives being
+ * spliced mid-paragraph. */
+export const SUBSTITUTION_MARKER = "**[unverified]**";
+
 export function validateFinalOutput({
   finalText,
   evidence,
@@ -140,12 +145,24 @@ function buildSafeDisplayText(
         return rule.safeRewrite(claim, evidence);
       });
     result +=
-      displayText.slice(cursor, sentence.start) + dedupe(rewrites).join(" ");
+      displayText.slice(cursor, sentence.start) +
+      markSubstitution(dedupe(rewrites).join(" "));
     cursor = sentence.end;
   }
   result += displayText.slice(cursor);
 
   return result.trim();
+}
+
+// Substituted text is otherwise written in the first person and reads as the
+// agent's own words, so a reader cannot tell which sentences the agent wrote
+// (#3109). The marker is inline-level on purpose: rewrites are spliced
+// mid-paragraph, and a block construct would not render as intended and could
+// break the surrounding markdown (#3105). The unverified original is not
+// reproduced — disclosing the substitution must not restore the claim the
+// evidence failed to support.
+function markSubstitution(rewrite: string): string {
+  return `${SUBSTITUTION_MARKER} ${rewrite}`;
 }
 
 function ruleForClaim(kind: ClaimKind): FinalizationRule {

--- a/tests/unit/agent-output-validation.test.ts
+++ b/tests/unit/agent-output-validation.test.ts
@@ -8,6 +8,7 @@ import {
   extractEvidenceFromToolLoopMessages,
   extractEvidenceFromUnifiedMessages,
   INITIAL_FINALIZATION_RULES,
+  SUBSTITUTION_MARKER,
   validateFinalOutput,
 } from "@/lib/agent-output-validation";
 import type { UnifiedMessage } from "@/types/conversation";
@@ -116,7 +117,7 @@ describe("#1987 Verified Agent Output", () => {
     });
 
     expect(report.safeDisplayText).toBe(
-      "I could not verify that the file was changed. I could not verify that the email was sent.",
+      `${SUBSTITUTION_MARKER} I could not verify that the file was changed. I could not verify that the email was sent.`,
     );
     expect(report.canStoreMemory).toBe(false);
     expect(report.claims.map((claim) => claim.status)).toEqual([
@@ -150,7 +151,7 @@ describe("#1987 Verified Agent Output", () => {
       { kind: "draft_created", status: "verified" },
     ]);
     expect(report.safeDisplayText).toBe(
-      "I prepared the email draft, but I could not verify that it was sent.",
+      `${SUBSTITUTION_MARKER} I prepared the email draft, but I could not verify that it was sent.`,
     );
   });
 
@@ -184,7 +185,7 @@ describe("#1987 Verified Agent Output", () => {
       evidence: extractEvidenceFromUnifiedMessages([]),
     });
     expect(unavailableWithoutCheck.safeDisplayText).toBe(
-      "I could not verify that the service is unavailable.",
+      `${SUBSTITUTION_MARKER} I could not verify that the service is unavailable.`,
     );
 
     const unavailableWithMalformedCheck = validateFinalOutput({
@@ -308,7 +309,7 @@ describe("#1987 Verified Agent Output", () => {
       ]),
     });
     expect(failedReport.safeDisplayText).toBe(
-      "I could not verify that the browser action completed.",
+      `${SUBSTITUTION_MARKER} I could not verify that the browser action completed.`,
     );
   });
 
@@ -397,7 +398,7 @@ describe("#1987 Verified Agent Output", () => {
     expect(report.safeDisplayText).toBe(
       finalText.replace(
         "Gemini CLI is not available in seren-desktop.",
-        "I could not verify that the service is unavailable.",
+        `${SUBSTITUTION_MARKER} I could not verify that the service is unavailable.`,
       ),
     );
     // The block structure that markdown rendering depends on survives.
@@ -411,6 +412,39 @@ describe("#1987 Verified Agent Output", () => {
     expect(report.claims).toMatchObject([
       { kind: "publisher_unavailable", status: "unverified" },
     ]);
+  });
+
+  it("marks substituted sentences without disturbing markdown (#3109)", () => {
+    const finalText = [
+      "## Findings",
+      "",
+      "| Item | State |",
+      "| --- | --- |",
+      "| Sync | Exists |",
+      "",
+      "The connector is not available here.",
+      "",
+      "Everything else checked out.",
+    ].join("\n");
+
+    const report = validateFinalOutput({
+      finalText,
+      evidence: extractEvidenceFromUnifiedMessages([]),
+    });
+
+    // The substitution is disclosed rather than passed off as agent prose.
+    expect(report.safeDisplayText).toContain(SUBSTITUTION_MARKER);
+    // The marker is inline-level, so it cannot open a block and break the
+    // surrounding structure the way the #3105 rewrite did.
+    expect(SUBSTITUTION_MARKER).not.toContain("\n");
+    expect(report.safeDisplayText).toBe(
+      finalText.replace(
+        "The connector is not available here.",
+        `${SUBSTITUTION_MARKER} I could not verify that the service is unavailable.`,
+      ),
+    );
+    // The unsupported claim itself is not restored alongside the disclosure.
+    expect(report.safeDisplayText).not.toContain("The connector is not");
   });
 
   it("wires validation into all required finalization paths", () => {


### PR DESCRIPTION
Closes #3109

## What was wrong

When `validateFinalOutput` could not tie a claim to execution evidence, it replaced the sentence with canned text from `rules.ts` — written in the first person, in the agent's voice — and spliced it into the message with no indication a substitution had happened. That text was then rendered and persisted, so the stored history showed the agent stating something it never wrote.

During the #3105 investigation one such inserted sentence was initially mistaken for a copy/paste artifact; identifying it required reading `rules.ts`.

## The change

Substituted spans are prefixed with an inline marker (`**[unverified]**`), exported as `SUBSTITUTION_MARKER` so tests reference the constant rather than hardcoding it.

The marker is **inline-level on purpose**. Rewrites are spliced mid-paragraph by `buildSafeDisplayText`, so a block construct (blockquote, heading) would not render as intended and could break surrounding markdown — the exact failure #3107 just fixed. Verified through the real `renderMarkdown`, not asserted:

```html
<h2>Findings</h2>
<table>
...
<td>Sync</td>
<td>Exists</td>
...
</table>
<p><strong>[unverified]</strong> I could not verify that the service is unavailable.</p>
```

Heading and table survive intact; the disclosure renders as inline emphasis inside its own paragraph.

The unverified original is **not** reproduced in the output. Disclosing the substitution must not restore the claim the evidence failed to support.

## Scope

This discloses substitutions. It does not change *when* a substitution happens — the over-broad `publisher_unavailable` matcher that triggers many of them is tracked separately in #3108 with the #2910/#2918 history, deliberately unpatched because tightening that guardrail trades false positives for false negatives.

## Networked paths

None. Pure local text processing in the frontend — no publisher slug, endpoint, or outbound request is added, removed, or altered.

## Testing

- `vitest run` — 339 files, 2466 passed, 0 failed.
- Five existing exact-match assertions updated to reference `SUBSTITUTION_MARKER`; none deleted.
- One added test covering the acceptance criteria: marker present, marker contains no newline, surrounding markdown byte-identical, original claim not restored.
- Render behavior verified against the real `renderMarkdown` (output above).
- `biome check` clean on touched files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
