### PR TITLE
fix(agent): constrain publisher_unavailable to capability claims

### DIFF
--- a/src/lib/agent-output-validation/claims.ts
+++ b/src/lib/agent-output-validation/claims.ts
@@ -6,7 +6,41 @@ import type { ClaimKind, ExtractedClaim, SentenceSpan } from "./types";
 type ClaimMatcher = {
   kind: ClaimKind;
   pattern: RegExp;
+  /** Additional condition on the same sentence. The claim is only extracted
+   * when this also matches, so a matcher can constrain what a sentence is
+   * *about* separately from the phrasing it keys on. Offsets still come from
+   * `pattern`. */
+  requiresContext?: RegExp;
 };
+
+// An availability-negative phrase on its own says nothing about the subject:
+// a conference room, an airline seat and a publisher are all "unavailable" in
+// the same words. Matching the phrase alone made every such sentence a claim
+// about agent capability, and the rewrite replaced it with a hedge (#3108).
+//
+// Capability context is therefore required alongside the trigger, in one of
+// two forms: gateway vocabulary that only appears when discussing what this
+// agent can reach, or framing that scopes the statement to this agent.
+//
+// `tool` and `plugin` are ordinary English and are not gateway vocabulary on
+// their own — "their build tool is not available for Windows" is prose about
+// someone else's product. They count only under agent-scope framing, which is
+// how a real capability claim reads ("I don't have a tool for that").
+// `api`, `endpoint`, `host` and `server` are excluded for the same reason and
+// have no agent-scope form worth admitting.
+const PUBLISHER_ABSENCE_TRIGGER =
+  /\b(unavailable|not available|not exposed|not configured|not enabled|not connected|not supported|could not access|couldn'?t access|cannot access|can'?t access|not found|no access to|do(?: not|n'?t) have)\b|\bno\s+(?:\w+\s+){0,2}(?:publishers?|integrations?|connectors?|gateways?|mcp|tools?|skills?|plugins?)\b/i;
+
+const GATEWAY_VOCABULARY =
+  /\b(?:publishers?|integrations?|connectors?|gateways?|mcp|skills?)\b/i;
+
+const AGENT_SCOPE =
+  /\b(?:in|for|during|from) th(?:is|e current) (?:session|conversation|chat)\b|\bavailable to me\b|\bmy (?:tools?|capabilities|access)\b|\bI (?:can'?t|cannot|could not|couldn'?t|do not|don'?t|have no)\b/i;
+
+const AGENT_CAPABILITY_CONTEXT = new RegExp(
+  `${GATEWAY_VOCABULARY.source}|${AGENT_SCOPE.source}`,
+  "i",
+);
 
 const CLAIM_MATCHERS: ClaimMatcher[] = [
   {
@@ -36,8 +70,8 @@ const CLAIM_MATCHERS: ClaimMatcher[] = [
   },
   {
     kind: "publisher_unavailable",
-    pattern:
-      /\b(unavailable|not available|not configured|could not access|can't access|cannot access|no .*integration|no .*tool|publisher .*not found)\b/i,
+    pattern: PUBLISHER_ABSENCE_TRIGGER,
+    requiresContext: AGENT_CAPABILITY_CONTEXT,
   },
   {
     kind: "browser_action",
@@ -60,6 +94,12 @@ export function extractClaims(finalText: string): ExtractedClaim[] {
     for (const matcher of CLAIM_MATCHERS) {
       const match = matcher.pattern.exec(sentence.text);
       if (!match) continue;
+      if (
+        matcher.requiresContext &&
+        !matcher.requiresContext.test(sentence.text)
+      ) {
+        continue;
+      }
       sentenceClaims.push({
         id: `${sentenceIndex}:${matcher.kind}`,
         kind: matcher.kind,

--- a/tests/unit/agent-output-validation.test.ts
+++ b/tests/unit/agent-output-validation.test.ts
@@ -384,7 +384,7 @@ describe("#1987 Verified Agent Output", () => {
       "// updated the file",
       "```",
       "",
-      "Gemini CLI is not available in seren-desktop.",
+      "The Gemini publisher is not available in this session.",
       "",
       "That is the end of the audit.",
     ].join("\n");
@@ -397,7 +397,7 @@ describe("#1987 Verified Agent Output", () => {
     // Only the offending sentence is replaced; every other byte is identical.
     expect(report.safeDisplayText).toBe(
       finalText.replace(
-        "Gemini CLI is not available in seren-desktop.",
+        "The Gemini publisher is not available in this session.",
         `${SUBSTITUTION_MARKER} I could not verify that the service is unavailable.`,
       ),
     );
@@ -412,6 +412,48 @@ describe("#1987 Verified Agent Output", () => {
     expect(report.claims).toMatchObject([
       { kind: "publisher_unavailable", status: "unverified" },
     ]);
+  });
+
+  it("only treats capability claims as publisher_unavailable (#3108)", () => {
+    const fires = (finalText: string) =>
+      validateFinalOutput({
+        finalText,
+        evidence: extractEvidenceFromUnifiedMessages([]),
+      }).claims.some((claim) => claim.kind === "publisher_unavailable");
+
+    // Prose that merely contains an availability word is not a claim about
+    // this agent's capabilities and must reach the user untouched.
+    for (const sentence of [
+      "The conference room was not available on Tuesday.",
+      "Seats in economy are unavailable for that flight.",
+      "This endpoint returns 503 when the upstream is unavailable.",
+      "Their build tool is not available for Windows.",
+    ]) {
+      expect(fires(sentence), sentence).toBe(false);
+    }
+
+    // Real capability claims stay guarded. The first is the phrasing from the
+    // #2910 incident this rule was written for, which never matched before.
+    for (const sentence of [
+      "google-sheets is not exposed in the current publisher list.",
+      "GitHub is unavailable in this session.",
+      "The Slack integration is not configured.",
+      "I don't have a tool for that.",
+    ]) {
+      expect(fires(sentence), sentence).toBe(true);
+    }
+
+    // Unrelated prose is passed through byte-for-byte, with no substitution
+    // marker anywhere in the message.
+    const passage =
+      "The conference room was not available on Tuesday.\n\nWe moved the review to Thursday.";
+    const report = validateFinalOutput({
+      finalText: passage,
+      evidence: extractEvidenceFromUnifiedMessages([]),
+    });
+    expect(report.safeDisplayText).toBe(passage);
+    expect(report.safeDisplayText).not.toContain(SUBSTITUTION_MARKER);
+    expect(report.canStoreMemory).toBe(true);
   });
 
   it("marks substituted sentences without disturbing markdown (#3109)", () => {


### PR DESCRIPTION
Closes #3108.

## Problem

`publisher_unavailable` keyed on availability phrasing and never looked at the subject of the sentence. A conference room, an airline seat and a publisher are all "unavailable" in the same words, so every such sentence was treated as the agent claiming a service was down and replaced with `"I could not verify that the service is unavailable."`

The same blind spot ran the other way. #2910's report describes the executor calling a live publisher **"not exposed in the current publisher list"** — `not exposed` was never in the verb list, so the phrasing from the incident this rule was written for did not match at all.

Measured with the real matcher imported from `claims.ts` (no reimplementation), before this change:

```
false negatives: 3/10
false positives: 8/9
```

## Change

Add an optional `requiresContext` regex to `ClaimMatcher` and apply it to `publisher_unavailable`. The trigger must now co-occur with capability context in the same sentence, in one of two forms:

- **Gateway vocabulary** — `publisher`, `integration`, `connector`, `gateway`, `mcp`, `skill`. These only show up when discussing what this agent can reach.
- **Agent scope** — `in this session`, `available to me`, `my tools`, `I can't / cannot / could not / don't have / have no`.

`tool` and `plugin` are ordinary English and do **not** stand alone; they count only under agent-scope framing. `api`, `endpoint`, `host` and `server` are excluded entirely. That is what keeps *"their build tool is not available for Windows"* and *"this endpoint returns 503 when the upstream is unavailable"* out.

Because the false-positive class is gone, the trigger list could safely widen to `not exposed`, `not enabled`, `not connected`, `not supported`, `don't have` — closing the #2910 gap that has been open since #1989.

After:

```
false negatives: 0/10
false positives: 0/9
```

## Honest limits

These are judgement calls, not measurements — there is no corpus of real agent replies to quantify them against:

- **Bare unqualified claims no longer fire.** `"GitHub is unavailable."` with no context marker is now silent. Accepted in exchange for the two classes above.
- **`"I could not access the shared drive."` still fires** even though a shared drive is not a publisher. First-person access failure is within the guardrail's intent, so this is left alone.
- The `#3105` fixture sentence `"Gemini CLI is not available in seren-desktop."` is now silent and the test moves to a real capability claim. That sentence is product-comparison prose — the exact class this PR stops rewriting — so the test's subject changes while its purpose (markdown preservation) does not.

## Evidence side untouched

`list_agent_publishers` was verified live during this work. It returns `{"publishers":[...],"total":138,...}` — JSON, never prose like "not found" — confirming the #2918 evidence-side fix is still correct. This PR changes only claim extraction; `isSuccessfulPublisherAbsenceVerification` is unmodified.

## Networked paths

None. This change is pure frontend claim extraction and issues no outbound requests. Its only coupling to a networked path is that the evidence side matches on the `list_agent_publishers` tool name, verified live above.

## Tests

One focused regression test covering both directions: unrelated prose is passed through byte-for-byte with no substitution marker, and real capability claims — including the #2910 phrasing that never matched before — still fire.

Full suite: 2467 passed, 15 skipped. Biome clean on both changed files.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
