### PR TITLE
fix(employees): make imported SKILL.md readable

### DIFF
--- a/src/components/common/MarkdownProse.tsx
+++ b/src/components/common/MarkdownProse.tsx
@@ -32,16 +32,19 @@ export const MarkdownProse: Component<MarkdownProseProps> = (props) => {
       const originalText = copyBtn.innerHTML;
 
       if (copyRestoreTimer) clearTimeout(copyRestoreTimer);
-      void navigator.clipboard.writeText(decodedCode).then(() => {
-        copyBtn.classList.add("copied");
-        copyBtn.textContent = "Copied!";
-        copyRestoreTimer = setTimeout(() => {
-          copyBtn.classList.remove("copied");
-          copyBtn.innerHTML = originalText;
-        }, 2000);
-      }).catch(() => {
-        // Clipboard permissions can be denied by the host; keep the control inert.
-      });
+      void navigator.clipboard
+        .writeText(decodedCode)
+        .then(() => {
+          copyBtn.classList.add("copied");
+          copyBtn.textContent = "Copied!";
+          copyRestoreTimer = setTimeout(() => {
+            copyBtn.classList.remove("copied");
+            copyBtn.innerHTML = originalText;
+          }, 2000);
+        })
+        .catch(() => {
+          // Clipboard permissions can be denied by the host; keep the control inert.
+        });
       return;
     }
 

--- a/src/components/common/MarkdownProse.tsx
+++ b/src/components/common/MarkdownProse.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Delegates external links to the system browser instead of the app webview.
 
 /* eslint-disable solid/no-innerhtml */
-import { type Component, createMemo } from "solid-js";
+import { type Component, createMemo, onCleanup } from "solid-js";
 import { openExternalLink } from "@/lib/external-link";
 import { renderMarkdown } from "@/lib/render-markdown";
 
@@ -13,20 +13,52 @@ interface MarkdownProseProps {
 
 export const MarkdownProse: Component<MarkdownProseProps> = (props) => {
   const renderedHtml = createMemo(() => renderMarkdown(props.content));
+  let copyRestoreTimer: ReturnType<typeof setTimeout> | undefined;
 
   const handleClick = (event: MouseEvent) => {
-    const link = (event.target as HTMLElement | null)?.closest(
-      ".external-link",
-    ) as HTMLAnchorElement | null;
+    const target = event.target as HTMLElement | null;
+    const copyBtn = target?.closest(
+      ".code-copy-btn",
+    ) as HTMLButtonElement | null;
+    if (copyBtn) {
+      const code = copyBtn.dataset.code;
+      if (!code || typeof navigator === "undefined" || !navigator.clipboard) {
+        return;
+      }
+
+      const textarea = document.createElement("textarea");
+      textarea.innerHTML = code;
+      const decodedCode = textarea.value;
+      const originalText = copyBtn.innerHTML;
+
+      if (copyRestoreTimer) clearTimeout(copyRestoreTimer);
+      void navigator.clipboard.writeText(decodedCode).then(() => {
+        copyBtn.classList.add("copied");
+        copyBtn.textContent = "Copied!";
+        copyRestoreTimer = setTimeout(() => {
+          copyBtn.classList.remove("copied");
+          copyBtn.innerHTML = originalText;
+        }, 2000);
+      }).catch(() => {
+        // Clipboard permissions can be denied by the host; keep the control inert.
+      });
+      return;
+    }
+
+    const link = target?.closest(".external-link") as HTMLAnchorElement | null;
     if (!link) return;
 
     event.preventDefault();
     void openExternalLink(link.getAttribute("data-external-url") ?? "");
   };
 
+  onCleanup(() => {
+    if (copyRestoreTimer) clearTimeout(copyRestoreTimer);
+  });
+
   return (
     <div
-      class={`text-[13px] leading-relaxed text-foreground
+      class={`max-w-[72ch] text-[13px] leading-relaxed text-foreground
         [&_h1]:mt-5 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-semibold [&_h1]:leading-tight [&_h1]:border-b [&_h1]:border-border-hover [&_h1]:pb-1
         [&_h2]:mt-5 [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:leading-tight [&_h2]:border-b [&_h2]:border-border-medium [&_h2]:pb-1
         [&_h3]:mt-4 [&_h3]:mb-1.5 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:leading-tight

--- a/src/components/employees/EmployeeDetail.tsx
+++ b/src/components/employees/EmployeeDetail.tsx
@@ -33,7 +33,10 @@ import {
   healthDotClass,
   healthLabel,
 } from "@/lib/employees/health";
-import { extractInstructionSections } from "@/lib/employees/instructions";
+import {
+  extractInstructionSections,
+  splitSkillDocument,
+} from "@/lib/employees/instructions";
 import type { EmployeeMode, EmployeeSummary } from "@/lib/employees/types";
 import { getDefaultOrganizationId } from "@/lib/tauri-bridge";
 import { employees as svc } from "@/services/employees";
@@ -188,6 +191,7 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
   const [editingEvalGate, setEditingEvalGate] = createSignal(false);
   const [showCheckpoints, setShowCheckpoints] = createSignal(true);
   const [skillExpanded, setSkillExpanded] = createSignal(false);
+  const [runtimePromptExpanded, setRuntimePromptExpanded] = createSignal(false);
 
   const [organizationId] = createResource(async () =>
     getDefaultOrganizationId(),
@@ -518,11 +522,13 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
 
   const detailRecord = () => employeeStore.detail(props.employeeId);
 
-  const description = () => {
+  const skillContent = createMemo(() => {
     const instructions = detailRecord()?.instructions;
-    if (!instructions) return null;
-    return extractInstructionSections(instructions).skill.trim();
-  };
+    if (!instructions) return { runtimePrompt: "", document: "" };
+    return splitSkillDocument(extractInstructionSections(instructions).skill);
+  });
+  const skillDocument = () => skillContent().document;
+  const runtimePrompt = () => skillContent().runtimePrompt;
 
   const copyEndpoint = async () => {
     const url = summary()?.endpointUrl;
@@ -947,7 +953,7 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
                   SKILL.md
                 </div>
                 <Show
-                  when={description()}
+                  when={skillDocument()}
                   fallback={
                     <Show
                       when={!detail.loading}
@@ -985,6 +991,31 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
                         >
                           {skillExpanded() ? "Show less" : "Show more"}
                         </button>
+                      </Show>
+                    </>
+                  )}
+                </Show>
+                <Show when={runtimePrompt()}>
+                  {(prompt) => (
+                    <>
+                      <button
+                        type="button"
+                        data-testid="employee-runtime-prompt-toggle"
+                        class="mt-2 text-[12px] font-medium text-accent hover:underline underline-offset-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/60 rounded"
+                        aria-expanded={runtimePromptExpanded()}
+                        onClick={() =>
+                          setRuntimePromptExpanded((expanded) => !expanded)
+                        }
+                      >
+                        Runtime prompt
+                      </button>
+                      <Show when={runtimePromptExpanded()}>
+                        <div
+                          data-testid="employee-runtime-prompt"
+                          class="mt-3 rounded-md border border-border bg-surface-2/40 p-3"
+                        >
+                          <MarkdownProse content={prompt()} />
+                        </div>
                       </Show>
                     </>
                   )}

--- a/src/components/employees/EmployeeDetail.tsx
+++ b/src/components/employees/EmployeeDetail.tsx
@@ -1001,7 +1001,7 @@ export const EmployeeDetail: Component<EmployeeDetailProps> = (props) => {
                       <button
                         type="button"
                         data-testid="employee-runtime-prompt-toggle"
-                        class="mt-2 text-[12px] font-medium text-accent hover:underline underline-offset-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/60 rounded"
+                        class="block mt-2 text-[12px] font-medium text-accent hover:underline underline-offset-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/60 rounded"
                         aria-expanded={runtimePromptExpanded()}
                         onClick={() =>
                           setRuntimePromptExpanded((expanded) => !expanded)

--- a/src/lib/employees/instructions.ts
+++ b/src/lib/employees/instructions.ts
@@ -82,6 +82,27 @@ function stripGeneratedSkillWrapper(content: string): string {
   return withoutFrontmatter.replace(/^# .*(?:\n+|$)/, "").trim();
 }
 
+export function splitSkillDocument(content: string): {
+  runtimePrompt: string;
+  document: string;
+} {
+  const normalizedContent = stripEmbeddedSkillFrontmatter(content);
+  const marker = normalizedContent.match(/^[ \t]*skill instructions:[ \t]*$/im);
+  const documentStart =
+    marker?.index === undefined
+      ? normalizedContent.trim()
+      : normalizedContent.slice(marker.index + marker[0].length).trim();
+  const runtimePrompt =
+    marker?.index === undefined
+      ? ""
+      : normalizedContent.slice(0, marker.index).trim();
+
+  return {
+    runtimePrompt,
+    document: stripEmbeddedSkillFrontmatter(documentStart).trim(),
+  };
+}
+
 export function extractInstructionSections(
   instructions: AgentInstructionFile[] | null | undefined,
 ): InstructionSections {

--- a/tests/unit/employee-instructions.test.ts
+++ b/tests/unit/employee-instructions.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildEmployeeInstructionFiles,
   extractInstructionSections,
+  splitSkillDocument,
 } from "@/lib/employees/instructions";
 
 const EMPTY = {
@@ -117,6 +118,60 @@ describe("employee instruction-file helpers", () => {
     ]);
 
     expect(sections.skill).toContain("\n---\n");
+  });
+
+  it("splits the runtime prompt from the display document", () => {
+    const content =
+      "Use the following runtime behavior.\n\nSkill instructions:\n\n---\ndescription: Imported helper\nname: imported-helper\n---\n\n# Imported Skill\n\n## Steps\n\n- Read the request.";
+
+    const result = splitSkillDocument(content);
+
+    expect(result.runtimePrompt).toBe("Use the following runtime behavior.");
+    expect(result.document).toMatch(/^# Imported Skill/);
+    expect(result.document).toContain("## Steps");
+    expect(result.document).not.toContain("Skill instructions:");
+    expect(result.document).not.toContain("description:");
+    expect(result.document).not.toContain("name:");
+    expect(result.document).not.toMatch(/^---/);
+  });
+
+  it("returns the complete document when no marker line exists", () => {
+    const content = "# Plain Skill\n\nUse short sentences.";
+
+    expect(splitSkillDocument(content)).toEqual({
+      runtimePrompt: "",
+      document: content,
+    });
+  });
+
+  it("matches the marker case-insensitively with trailing whitespace", () => {
+    const result = splitSkillDocument(
+      "Runtime guidance.\n\nSKILL INSTRUCTIONS:   \n\n# Human documentation",
+    );
+
+    expect(result.runtimePrompt).toBe("Runtime guidance.");
+    expect(result.document).toBe("# Human documentation");
+  });
+
+  it("does not split a mid-sentence marker phrase", () => {
+    const content =
+      "Explain why the phrase Skill instructions: is not a section marker.";
+
+    expect(splitSkillDocument(content)).toEqual({
+      runtimePrompt: "",
+      document: content,
+    });
+  });
+
+  it("keeps extractInstructionSections unsplit for edit round-trips", () => {
+    const content =
+      "Runtime behavior.\n\nSkill instructions:\n\n# Human documentation\n\nKeep this body.";
+
+    expect(
+      extractInstructionSections([
+        { kind: "skill", path: "SKILL.md", content },
+      ]).skill,
+    ).toBe(content);
   });
 
   it("does not split ordinary skill text that quotes old marker syntax", () => {


### PR DESCRIPTION
Closes #3112

## What changed

- Cap MarkdownProse to a readable 72-character measure while keeping fenced code blocks horizontally scrollable.
- Split an imported SKILL.md runtime preamble from the human-facing document for display only.
- Keep the full unsplit skill content for edit and save round-trips.
- Add a collapsed Runtime prompt disclosure so the preamble remains accessible.
- Handle fenced-code Copy buttons inside MarkdownProse with decoded clipboard text and bounded feedback.
- Keep external-link delegation owned by MarkdownProse.

## Verification

- Focused instruction helper tests pass.
- Full frontend check and test suites pass with the main-branch diagnostic baseline: 48 Biome warnings, one Biome info, 3 skipped test files, and 15 skipped tests.
- Cargo check passes after MCP server preparation.
- Real `pnpm tauri:validation:dev` walkthrough passes on the validation app at port 1422: heading-first skill view, readable measure, collapsed and expanded Runtime prompt, working Copy feedback, green scheduled employee state, neutral Suspend control, and cost summary.

## PII review

Issue and PR text contain no deployment, organization, user, or run identifiers; email addresses; wallet balances; or raw run output. Validation screenshots are cropped to the employee panel and are not attached to this public PR.