### PR TITLE
fix(validation): handle package-manager argument separator

### DIFF
--- a/docs/validation-isolated-launch.md
+++ b/docs/validation-isolated-launch.md
@@ -18,9 +18,11 @@ pnpm tauri:validation:dev
 
 Both development commands automatically lease the first available port from
 `1422` through `1431`. The lease also selects a distinct Tauri identifier, so
-up to ten validation apps can run concurrently without sharing a Vite server,
-app-data root, or single-instance service. Set `SEREN_VALIDATION_DEV_PORT` to a
-specific free port when a diagnostic run needs a stable override.
+up to ten validation worktrees can run concurrently without sharing a Vite
+server, app-data root, or single-instance service. Keep each concurrent run in
+its own worktree because generated runtime resources remain checkout-scoped.
+Set `SEREN_VALIDATION_DEV_PORT` to a specific free port when a diagnostic run
+needs a stable override.
 
 Build a validation bundle:
 

--- a/scripts/validation-dev-args.ts
+++ b/scripts/validation-dev-args.ts
@@ -1,0 +1,6 @@
+// ABOUTME: Normalizes package-manager arguments before the validation Tauri launch.
+// ABOUTME: Keeps pnpm's separator from being forwarded as an application argument.
+
+export function validationDevArgs(args: string[]): string[] {
+  return args[0] === "--" ? args.slice(1) : [...args];
+}

--- a/scripts/validation-dev.ts
+++ b/scripts/validation-dev.ts
@@ -2,12 +2,12 @@
 // ABOUTME: Releases the slot after the Tauri process and its dev server exit.
 
 import { spawn } from "node:child_process";
+import { validationDevArgs } from "./validation-dev-args";
 import { acquireValidationSlot } from "./validation-slots";
 
 async function main(): Promise<void> {
   const slot = await acquireValidationSlot();
-  const forwardedArgs = process.argv.slice(2);
-  if (forwardedArgs[0] === "--") forwardedArgs.shift();
+  const forwardedArgs = validationDevArgs(process.argv.slice(2));
   console.log(
     `[validation] leased port ${slot.port} with identifier ${slot.identifier}`,
   );

--- a/scripts/validation-dev.ts
+++ b/scripts/validation-dev.ts
@@ -6,6 +6,8 @@ import { acquireValidationSlot } from "./validation-slots";
 
 async function main(): Promise<void> {
   const slot = await acquireValidationSlot();
+  const forwardedArgs = process.argv.slice(2);
+  if (forwardedArgs[0] === "--") forwardedArgs.shift();
   console.log(
     `[validation] leased port ${slot.port} with identifier ${slot.identifier}`,
   );
@@ -22,7 +24,7 @@ async function main(): Promise<void> {
         "src-tauri/tauri.validation.conf.json",
         "--config",
         JSON.stringify(slot.tauriConfig),
-        ...process.argv.slice(2),
+        ...forwardedArgs,
       ],
       {
         cwd: process.cwd(),

--- a/tests/unit/validation-dev-args.test.ts
+++ b/tests/unit/validation-dev-args.test.ts
@@ -1,0 +1,12 @@
+// ABOUTME: Protects validation launcher argument forwarding.
+// ABOUTME: Covers pnpm's optional separator without changing direct Tauri flags.
+
+import { describe, expect, it } from "vitest";
+import { validationDevArgs } from "../../scripts/validation-dev-args";
+
+describe("validation dev arguments", () => {
+  it("removes only the leading package-manager separator", () => {
+    expect(validationDevArgs(["--", "--no-watch"])).toEqual(["--no-watch"]);
+    expect(validationDevArgs(["--no-watch"])).toEqual(["--no-watch"]);
+  });
+});


### PR DESCRIPTION
Closes #3120

## Summary

- consume one leading package-manager `--` before forwarding manual validation flags to Tauri
- preserve direct Tauri flag forwarding
- document that concurrent validation runs use separate worktrees because generated runtime resources are checkout-scoped
- add one focused pure-function regression test for the separator behavior

## Reproduction fixed

```bash
pnpm tauri:validation:dev -- --no-watch
```

Before this change, Cargo received `--no-watch` and rejected it. The launcher now emits a Tauri command with `--no-watch` in the correct position.

## Audit

The post-#3117 live walkthrough confirmed that slot leasing, strict Vite ports, and numeric validation identifiers worked. The failure occurred solely in `scripts/validation-dev.ts` argument forwarding. The walkthrough also confirmed that generated MCP/provider runtime resources remain checkout-scoped, matching the repository's required worktree workflow.

## Validation

- focused launcher and allocator tests: 2 files, 5 tests passed
- focused TypeScript compilation passed
- Biome stdin checks passed for the touched TypeScript files
- diff whitespace check passed
- live, no-mock macOS launch using the exact reproduction command passed
- Tauri received `--no-watch` before the Cargo application-argument boundary
- Vite and the native Tauri app started successfully while another validation app and the installed production app remained running
- clean shutdown released the leased slot; another concurrent validation checkout acquired it immediately afterward

Post-PR functional classification: no additional P0, P1, or P2 regression was found.

## Network path

No product publisher, third-party API, or outbound network path is added or changed. This is local process argument handling and documentation only.

No credentials, account data, local paths, screenshots, or raw logs are included.