### PR TITLE
fix(happy): await socket teardown before exiting the bridge

### DIFF
--- a/scripts/verify-happy-bridge-shutdown.mjs
+++ b/scripts/verify-happy-bridge-shutdown.mjs
@@ -170,7 +170,10 @@ async function main() {
     return;
   }
   if (code !== 0) {
+    // Every other failure path reports the child's stderr; this one did not, so
+    // a crash on shutdown surfaced as a bare exit code with no cause attached.
     log(`FAIL: expected a clean exit code, got ${code}`);
+    log(stderr.trim() ? `bridge stderr:\n${stderr.trim()}` : "bridge stderr: (empty)");
     process.exitCode = 1;
     return;
   }


### PR DESCRIPTION
Closes #3122

## Root cause

The Windows build failed with the bridge aborting on shutdown as exit code `3221226505`. The first commit here made the shutdown verifier print the child's stderr — it was the only failure branch that did not — which named the cause immediately:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
```

That is libuv asserting inside `uv_async_send` on a handle that is already closing. `shutdown()` in `bin/happy-bridge.mjs` closed the provider socket and the Happy layer without awaiting either, then exited on the next tick via `setImmediate`, so the event loop was torn down mid-close.

The race has always been there. Node 20's libuv tolerated it; Node 24's asserts, which is why it appeared only after the CI pin moved in #3116. Diagnostic #3123 had already ruled out the `happy@1.2.0` patch by reverting it and seeing an identical failure.

## Fix

- `ProviderRuntimeClient.close()` resolves on the socket's close handshake instead of returning immediately and nulling the reference.
- The Happy layer's `close()` awaits its session closes rather than firing them with `void` and returning.
- `shutdown()` awaits both, capped at 2s so a socket that never completes its handshake still exits inside the supervisor's 5s grace period.

The loop is deliberately not left to drain on its own. A child process with piped stdout and stderr never reaches zero handles — verified with `process.getActiveResourcesInfo()`, which still showed two `PipeWrap` entries after stdin was paused and unref'd. So the explicit exit stays; it just runs after the closes complete rather than during them.

## Validation

Shutdown verifier on darwin: clean exit, code 0, **5-6ms across four consecutive runs**.

An earlier attempt at this fix passed the verifier at 2010ms — the force-exit timer firing, not a clean drain. That is recorded here because it looked green while masking the problem; the committed fix waits on a real signal instead.

Full unit suite: 2428 passed, 15 skipped, 0 failed.

The Windows result from this PR's own matrix is the actual proof, since the failure does not reproduce on darwin or Linux.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com