### PR TITLE
fix(happy): keep verbose tool output readable on mobile

### DIFF
--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -4,9 +4,42 @@
 import { createEnvelope } from "@slopus/happy-wire";
 
 const AGENT_PROVIDER = "codex";
+const TOOL_OUTPUT_MAX_CHARS = 1_200;
+const TOOL_ERROR_MAX_CHARS = 6_000;
+const FILE_DIFF_MAX_CHARS = 2_000;
+const MOBILE_TRUNCATION_MARKER = "\n… [truncated for Happy Mobile]";
 
 function stringValue(value, fallback = "") {
   return typeof value === "string" ? value : fallback;
+}
+
+function displayText(value) {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  try {
+    const serialized = JSON.stringify(value, null, 2);
+    return typeof serialized === "string" ? serialized : String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function boundedMobileText(value, maxChars) {
+  const text = displayText(value);
+  if (text.length <= maxChars) return text;
+  const prefixLength = Math.max(0, maxChars - MOBILE_TRUNCATION_MARKER.length);
+  let prefix = text.slice(0, prefixLength);
+  const finalCodeUnit = prefix.charCodeAt(prefix.length - 1);
+  if (finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) {
+    prefix = prefix.slice(0, -1);
+  }
+  return `${prefix}${MOBILE_TRUNCATION_MARKER}`;
+}
+
+function summarizeFileContent(value) {
+  if (typeof value !== "string") return undefined;
+  const lines = value.length === 0 ? 0 : value.split(/\r\n|\r|\n/).length;
+  return `[${lines} ${lines === 1 ? "line" : "lines"} hidden on Happy Mobile]`;
 }
 
 function eventEnvelope(role, ev, payload, suffix) {
@@ -68,7 +101,10 @@ export function translateNeutralEvent(event, { provider = AGENT_PROVIDER } = {})
       return [{ ...acp({
         type: "tool-result",
         callId: stringValue(payload.toolCallId, "unknown-call"),
-        output: payload.error ?? payload.result ?? "",
+        output: boundedMobileText(
+          payload.error ?? payload.result ?? "",
+          payload.error ? TOOL_ERROR_MAX_CHARS : TOOL_OUTPUT_MAX_CHARS,
+        ),
         id: stringValue(payload.toolCallId, "unknown-call"),
         ...(payload.error ? { isError: true } : {}),
       }), provider }];
@@ -77,9 +113,11 @@ export function translateNeutralEvent(event, { provider = AGENT_PROVIDER } = {})
         type: "file-edit",
         description: "File change",
         filePath: stringValue(payload.path, "unknown file"),
-        diff: typeof payload.newText === "string" ? payload.newText : undefined,
-        oldContent: typeof payload.oldText === "string" ? payload.oldText : undefined,
-        newContent: typeof payload.newText === "string" ? payload.newText : undefined,
+        diff: typeof payload.newText === "string"
+          ? boundedMobileText(payload.newText, FILE_DIFF_MAX_CHARS)
+          : undefined,
+        oldContent: summarizeFileContent(payload.oldText),
+        newContent: summarizeFileContent(payload.newText),
         id: stringValue(payload.toolCallId, "file-change"),
       }), provider }];
     case "diff-proposal":
@@ -87,9 +125,11 @@ export function translateNeutralEvent(event, { provider = AGENT_PROVIDER } = {})
         type: "file-edit",
         description: "File change requires approval",
         filePath: stringValue(payload.path, "unknown file"),
-        diff: typeof payload.newText === "string" ? payload.newText : undefined,
-        oldContent: typeof payload.oldText === "string" ? payload.oldText : undefined,
-        newContent: typeof payload.newText === "string" ? payload.newText : undefined,
+        diff: typeof payload.newText === "string"
+          ? boundedMobileText(payload.newText, FILE_DIFF_MAX_CHARS)
+          : undefined,
+        oldContent: summarizeFileContent(payload.oldText),
+        newContent: summarizeFileContent(payload.newText),
         id: stringValue(payload.proposalId, "file-proposal"),
       }), provider }];
     case "diff-proposal-resolved":

--- a/tests/unit/happy-bridge-translate-happy.test.ts
+++ b/tests/unit/happy-bridge-translate-happy.test.ts
@@ -57,6 +57,55 @@ describe("neutral-to-Happy session translation", () => {
     expect(translateNeutralEvent({ kind: "unknown", sessionId: "session-1", payload })).toEqual([]);
   });
 
+  it("bounds tool output for mobile while retaining more error context", () => {
+    const success = translateNeutralEvent({
+      kind: "tool-end",
+      sessionId: "session-1",
+      payload: { toolCallId: "call-success", result: "x".repeat(6_000) },
+    })[0].body;
+    const error = translateNeutralEvent({
+      kind: "tool-end",
+      sessionId: "session-1",
+      payload: { toolCallId: "call-error", error: "e".repeat(3_000) },
+    })[0].body;
+
+    expect(success).toMatchObject({ callId: "call-success", id: "call-success" });
+    expect(success.output).toHaveLength(1_200);
+    expect(success.output).toContain("[truncated for Happy Mobile]");
+    expect(error).toMatchObject({
+      callId: "call-error",
+      id: "call-error",
+      isError: true,
+      output: "e".repeat(3_000),
+    });
+  });
+
+  it.each([
+    ["file-diff", "toolCallId", "file-change-1"],
+    ["diff-proposal", "proposalId", "proposal-1"],
+  ])("summarizes %s snapshots and caps its mobile diff", (kind, idField, id) => {
+    const newText = Array.from({ length: 400 }, (_, index) => `new line ${index}`).join("\n");
+    const [message] = translateNeutralEvent({
+      kind,
+      sessionId: "session-1",
+      payload: {
+        [idField]: id,
+        path: "/workspace/project/file.ts",
+        oldText: "old line 1\nold line 2",
+        newText,
+      },
+    });
+
+    expect(message.body).toMatchObject({
+      id,
+      oldContent: "[2 lines hidden on Happy Mobile]",
+      newContent: "[400 lines hidden on Happy Mobile]",
+    });
+    expect(message.body.diff).toHaveLength(2_000);
+    expect(message.body.diff).toContain("[truncated for Happy Mobile]");
+    expect(message.body.oldContent).not.toContain("old line 1");
+  });
+
   it.each([
     ["prompting", "turn-start"],
     ["ready", "turn-end"],


### PR DESCRIPTION
Fixes #3118

## Summary

- Bound successful Happy Mobile tool results to 1,200 characters with an explicit truncation marker.
- Retain a larger 6,000-character budget for error output.
- Replace full old/new file snapshots with line-count summaries and cap the mobile diff preview at 2,000 characters.
- Preserve event types, provider selection, file paths, call/proposal IDs, and error state.

The filter stays in `bin/happy-bridge/translate.mjs`, whose only production caller is the Happy relay adapter. Desktop provider-event rendering does not pass through this translator.

## Critical regression coverage

The focused translation tests now verify:

- verbose success output is bounded;
- materially longer error context remains available;
- file and proposal snapshots no longer carry raw full contents;
- file preview output is bounded;
- call and proposal identifiers remain stable.

## Network path audit

The changed events follow this path:

`provider://tool-result|diff|diff-proposal`
→ local provider-runtime WebSocket
→ `publishEvent`
→ `translateNeutralEvent`
→ Happy `sendAgentMessage`
→ encrypted outbox
→ `POST /v3/sessions/{sessionId}/messages` on the configured Happy relay.

No Seren Gateway publisher slug is present on this path. The current live Seren publisher inventory contains no Happy publisher. This PR changes message payload size only; it does not change the relay host, method, or path.

## Validation

- `pnpm exec vitest run tests/unit/happy-bridge-translate-happy.test.ts tests/unit/happy-bridge-translate-provider.test.ts`
- `pnpm test` — 2,485 passed, 15 skipped
- `pnpm check` — passed with the 48 existing warnings
- `pnpm lint` — passed with the 48 existing warnings
- `pnpm build`
- `pnpm prepare:mcp-servers`
- `cargo test --manifest-path src-tauri/Cargo.toml` — 937 passed, 2 ignored; doc tests passed with 1 ignored

## Walkthrough status

The required real paired-phone walkthrough will be run against this PR before merge. No mocks or local relay will be used.