### PR TITLE
fix(happy): close pairing poll before bridge exit

### DIFF
--- a/bin/happy-bridge.mjs
+++ b/bin/happy-bridge.mjs
@@ -52,15 +52,25 @@ function startInputReader() {
   return { configPromise, queuedResponses };
 }
 
+// Caps the wait for the closes below so a socket that never completes its
+// handshake still exits well inside the supervisor's STOP_GRACE_PERIOD.
+const CLOSE_TIMEOUT_MS = 2000;
+
 async function shutdown(exitCode = 0) {
   if (shuttingDown) return;
   shuttingDown = true;
-  client?.close();
-  happyLayer?.close();
+  // Awaited: exiting while these are still tearing down aborts the process on
+  // Windows with an assertion in uv_async_send. The loop cannot be left to
+  // drain on its own instead, because a child's piped stdout and stderr keep
+  // it alive indefinitely.
+  await Promise.race([
+    Promise.allSettled([client?.close(), happyLayer?.close()]),
+    new Promise((resolve) => setTimeout(resolve, CLOSE_TIMEOUT_MS)),
+  ]);
   supervisorChannel?.close();
   input?.close();
   process.exitCode = exitCode;
-  setImmediate(() => process.exit(exitCode));
+  process.exit(exitCode);
 }
 
 // Signal handlers receive the signal name as their first argument, which is not

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -2,6 +2,8 @@
 // ABOUTME: Pairing material crosses the supervisor channel only and is never logged.
 
 import { randomUUID } from "node:crypto";
+import http from "node:http";
+import https from "node:https";
 import os from "node:os";
 import { ApiClient, configuration } from "happy/lib";
 import nacl from "tweetnacl";
@@ -108,23 +110,94 @@ function identityFromAuthResponse(token, decrypted) {
   throw new Error("Happy pairing response used an unsupported credential format");
 }
 
-async function postAuthRequest(relayUrl, publicKey) {
-  const response = await fetch(`${relayUrl}/v1/auth/request`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", "X-Happy-Client": "seren-desktop/phase-3" },
-    body: JSON.stringify({ publicKey: encodeBase64(publicKey), supportsV2: true }),
+function postPairingRequest(relayUrl, publicKey, signal) {
+  const url = new URL(`${relayUrl.replace(/\/+$/, "")}/v1/auth/request`);
+  const transport = url.protocol === "https:" ? https : url.protocol === "http:" ? http : null;
+  if (!transport) return Promise.reject(new Error("Happy relay must use HTTP or HTTPS"));
+  const body = JSON.stringify({ publicKey: encodeBase64(publicKey), supportsV2: true });
+
+  return new Promise((resolve, reject) => {
+    let responseBody = "";
+    let responseEnded = false;
+    let responseStatus = 0;
+    let failure = null;
+    let aborted = false;
+    const request = transport.request(
+      url,
+      {
+        method: "POST",
+        agent: false,
+        headers: {
+          Connection: "close",
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+          "X-Happy-Client": "seren-desktop/phase-3",
+        },
+      },
+      (response) => {
+        responseStatus = response.statusCode ?? 0;
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          responseBody += chunk;
+        });
+        response.once("aborted", () => {
+          failure = new Error("Happy pairing response ended early");
+        });
+        response.once("error", (error) => {
+          failure = error;
+        });
+        response.once("end", () => {
+          responseEnded = true;
+        });
+      },
+    );
+
+    const onAbort = () => {
+      aborted = true;
+      const error = new Error("Happy pairing request aborted");
+      error.name = "AbortError";
+      request.destroy(error);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    request.once("error", (error) => {
+      if (!aborted) failure = error;
+    });
+    // Resolve only after the request's own socket closes. The bridge exits as
+    // soon as its cleanup promises settle, so response `end` is too early on
+    // Windows: libuv may still be closing the underlying async handle.
+    request.once("close", () => {
+      signal?.removeEventListener("abort", onAbort);
+      if (aborted) {
+        const error = new Error("Happy pairing request aborted");
+        error.name = "AbortError";
+        reject(error);
+      } else if (failure) {
+        reject(failure);
+      } else if (!responseEnded) {
+        reject(new Error("Happy pairing response ended early"));
+      } else {
+        resolve({ status: responseStatus, body: responseBody });
+      }
+    });
+
+    if (signal?.aborted) onAbort();
+    else request.end(body);
   });
-  if (!response.ok) throw new Error(`Happy pairing request rejected (${response.status})`);
 }
 
-async function readAuthRequest(relayUrl, publicKey) {
-  const response = await fetch(`${relayUrl}/v1/auth/request`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", "X-Happy-Client": "seren-desktop/phase-3" },
-    body: JSON.stringify({ publicKey: encodeBase64(publicKey), supportsV2: true }),
-  });
-  if (!response.ok) throw new Error(`Happy pairing status rejected (${response.status})`);
-  return response.json();
+async function postAuthRequest(relayUrl, publicKey) {
+  const response = await postPairingRequest(relayUrl, publicKey);
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`Happy pairing request rejected (${response.status})`);
+  }
+}
+
+async function readAuthRequest(relayUrl, publicKey, signal) {
+  const response = await postPairingRequest(relayUrl, publicKey, signal);
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`Happy pairing status rejected (${response.status})`);
+  }
+  return JSON.parse(response.body);
 }
 
 function machineMetadata(config, capabilities = { agents: [], roots: [] }) {
@@ -286,6 +359,8 @@ export function createHappyLayer({
   let api = null;
   let machineClient = null;
   let pairingPromise = null;
+  let pairingAuthorizationPromise = null;
+  let pairingAbortController = null;
   let latestPairingPayload = null;
   let pairingCancelled = false;
   let sourceSubscription = null;
@@ -690,14 +765,14 @@ export function createHappyLayer({
     return true;
   }
 
-  async function waitForAuthorization(keyPair) {
+  async function waitForAuthorization(keyPair, signal) {
     const deadline = Date.now() + AUTH_TIMEOUT_MS;
     while (Date.now() < deadline) {
       if (pairingCancelled) {
         debug("pairing abandoned before authorization");
         return false;
       }
-      const result = await readAuthRequest(config.relayUrl, keyPair.publicKey);
+      const result = await readAuthRequest(config.relayUrl, keyPair.publicKey, signal);
       // Checked again after the round trip: an authorization that lands while
       // the user is dismissing the dialog must not be accepted.
       if (pairingCancelled) {
@@ -724,6 +799,7 @@ export function createHappyLayer({
   function cancelPairing() {
     if (!pairingPromise && !latestPairingPayload) return;
     pairingCancelled = true;
+    pairingAbortController?.abort();
     pairingPromise = null;
     latestPairingPayload = null;
     debug("pairing cancelled by supervisor");
@@ -743,14 +819,25 @@ export function createHappyLayer({
       const payload = `happy://terminal?${encodeBase64Url(keyPair.publicKey)}`;
       latestPairingPayload = payload;
       supervisorChannel.notify("pairing_payload", { payload });
-      void waitForAuthorization(keyPair)
+      const abortController = new AbortController();
+      pairingAbortController = abortController;
+      pairingAuthorizationPromise = waitForAuthorization(keyPair, abortController.signal)
         .then((authorized) => {
           if (!authorized) pairingPromise = null;
         })
         .catch((error) => {
           pairingPromise = null;
-          debug(`pairing authorization failed: ${error instanceof Error ? error.message : "unknown error"}`);
+          if (error?.name !== "AbortError") {
+            debug(`pairing authorization failed: ${error instanceof Error ? error.message : "unknown error"}`);
+          }
+        })
+        .finally(() => {
+          if (pairingAbortController === abortController) {
+            pairingAbortController = null;
+            pairingAuthorizationPromise = null;
+          }
         });
+      void pairingAuthorizationPromise;
       return payload;
     })();
     return pairingPromise;
@@ -786,6 +873,8 @@ export function createHappyLayer({
     async close() {
       sourceSubscription?.();
       supervisorSubscription?.();
+      cancelPairing();
+      await pairingAuthorizationPromise;
       // Awaited rather than fire-and-forget: the caller exits the process once
       // this resolves, and tearing the event loop down while these closes are
       // still in flight aborts the process on Windows.

--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -783,12 +783,17 @@ export function createHappyLayer({
       return startPairing();
     },
     startPairing,
-    close() {
+    async close() {
       sourceSubscription?.();
       supervisorSubscription?.();
-      for (const entry of sessions.values()) {
-        void entry.client.close().catch(() => debug("failed to close Happy session"));
-      }
+      // Awaited rather than fire-and-forget: the caller exits the process once
+      // this resolves, and tearing the event loop down while these closes are
+      // still in flight aborts the process on Windows.
+      await Promise.allSettled(
+        [...sessions.values()].map((entry) =>
+          entry.client.close().catch(() => debug("failed to close Happy session")),
+        ),
+      );
       sessions.clear();
       terminatedSessions.clear();
       machineClient?.shutdown();

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -156,10 +156,16 @@ class ProviderRuntimeClient {
     }
     this.pending.clear();
     this.notificationListeners.clear();
-    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-      this.socket.close(1000, "bridge shutdown");
-    }
+    const socket = this.socket;
     this.socket = null;
+    if (!socket || socket.readyState !== WebSocket.OPEN) return Promise.resolve();
+    // Resolves on the close handshake rather than returning immediately: the
+    // caller exits the process next, and exiting while the socket is still
+    // tearing down aborts on Windows inside uv_async_send.
+    return new Promise((resolve) => {
+      socket.once("close", resolve);
+      socket.close(1000, "bridge shutdown");
+    });
   }
 }
 

--- a/tests/unit/happy-pairing-shutdown.test.ts
+++ b/tests/unit/happy-pairing-shutdown.test.ts
@@ -1,0 +1,79 @@
+// ABOUTME: Verifies bridge shutdown aborts and joins an in-flight Happy pairing poll.
+// ABOUTME: Protects Windows from exiting while Node's HTTP handles are still active.
+
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+
+// @ts-expect-error — the bridge layer is plain ESM without declarations.
+import { createHappyLayer } from "../../bin/happy-bridge/happy-layer.mjs";
+
+const servers: Array<ReturnType<typeof createServer>> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+          server.closeAllConnections();
+        }),
+    ),
+  );
+});
+
+describe("Happy pairing shutdown", () => {
+  it("aborts the authorization request before close resolves", async () => {
+    let requestCount = 0;
+    let authorizationRequestClosed = false;
+    let resolveAuthorizationStarted: (() => void) | undefined;
+    let resolveAuthorizationClosed: (() => void) | undefined;
+    const authorizationStarted = new Promise<void>((resolve) => {
+      resolveAuthorizationStarted = resolve;
+    });
+    const authorizationClosed = new Promise<void>((resolve) => {
+      resolveAuthorizationClosed = resolve;
+    });
+    const server = createServer((request, response) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{}");
+        return;
+      }
+      resolveAuthorizationStarted?.();
+      response.on("close", () => {
+        authorizationRequestClosed = true;
+        resolveAuthorizationClosed?.();
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("test server did not bind");
+
+    const layer = createHappyLayer({
+      config: {
+        machineIdentity: null,
+        machineName: "shutdown-test",
+        relayUrl: `http://127.0.0.1:${address.port}`,
+      },
+      source: {},
+      supervisorChannel: {
+        notify: () => {},
+        onNotification: () => () => {},
+      },
+    });
+
+    await layer.start();
+    await authorizationStarted;
+    await layer.close();
+    await Promise.race([
+      authorizationClosed,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("authorization request stayed open")), 500),
+      ),
+    ]);
+
+    expect(authorizationRequestClosed).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #3122

## Audit update

The first revision of this PR awaited the provider socket and Happy session closes, but the rerun still reproduced the same Windows abort:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
exit code 3221226505 (0xC0000409)
```

That result narrowed the remaining failure to the **unpaired** state: the verifier has no machine client and no Happy sessions, but it does have an active pairing authorization request.

## Root cause

After `startPairing()` emits the QR payload, `waitForAuthorization()` continues polling the direct Happy relay in the background. `close()` did not cancel or join that request, so `shutdown()` could call `process.exit()` while Node/libuv was still closing its HTTP handle on Windows.

The request contract is unchanged:

- direct relay URL from configuration
- `POST {relayUrl}/v1/auth/request`
- no Seren publisher or proxy is involved

## Fix

- Keep the original provider/session teardown awaits.
- Own pairing HTTP/HTTPS requests explicitly with connection reuse disabled.
- Attach an `AbortController` to the authorization poll.
- Resolve request cleanup only after the request socket emits `close`.
- Cancel and await the authorization worker from `happyLayer.close()`.

## Critical regression coverage

`tests/unit/happy-pairing-shutdown.test.ts` uses a real local HTTP server, holds the authorization response open, calls `layer.close()`, and asserts that the live request is closed before cleanup resolves. No network mocks are used.

## Validation

Rebased onto current `main`, including #3129 and #3131.

- Focused shutdown + arbitration tests: **12 passed**
- Focused shutdown regression: **3 consecutive passes**
- Full unit suite: **2486 passed, 15 skipped, 0 failed**
- `pnpm check`: passed (48 pre-existing warnings)
- `pnpm build`: passed (pre-existing chunk-size warnings)
- Real bridge shutdown verifier on macOS: **4 clean runs**, code 0, approximately **0.9–1.0s**

The Windows packaging job is the definitive platform proof for this P0. Do not merge until that matrix completes successfully.