### PR TITLE
fix(happy): stop outbound sends from skipping phone prompts

### DIFF
--- a/patches/happy@1.2.0.patch
+++ b/patches/happy@1.2.0.patch
@@ -1,11 +1,47 @@
 diff --git a/dist/types-CV0guBiJ.mjs b/dist/types-CV0guBiJ.mjs
-index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..665154ffa9d89d56d4fcf61d4ff830a5e7a49a58 100644
+index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..e222a76faae481cbfc2814568349c10e6bc11c91 100644
 --- a/dist/types-CV0guBiJ.mjs
 +++ b/dist/types-CV0guBiJ.mjs
-@@ -2458,8 +2458,17 @@ class ApiSessionClient extends EventEmitter {
-         if (message.content?.t !== "encrypted") {
-           continue;
+@@ -2142,6 +2142,7 @@ class ApiSessionClient extends EventEmitter {
+   };
+   lastSeq = 0;
+   pendingOutbox = [];
++  outboundMessageLocalIds = /* @__PURE__ */ new Set();
+   sendSync;
+   receiveSync;
+   constructor(token, session) {
+@@ -2206,18 +2207,22 @@ class ApiSessionClient extends EventEmitter {
+           return;
          }
+         if (data.body.t === "new-message") {
+-          const messageSeq = data.body.message?.seq;
+-          if (typeof messageSeq !== "number" || messageSeq !== this.lastSeq + 1 || data.body.message.content.t !== "encrypted") {
++          const message = data.body.message;
++          const messageSeq = message?.seq;
++          if (typeof messageSeq !== "number" || messageSeq !== this.lastSeq + 1 || message?.content?.t !== "encrypted") {
+             this.receiveSync.invalidate();
+             return;
+           }
+-          const body = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.message.content.c));
++          this.lastSeq = messageSeq;
++          if (this.outboundMessageLocalIds.delete(message.localId)) {
++            return;
++          }
++          const body = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(message.content.c));
+           logger.debug("[SOCKET] [UPDATE] Decrypted message", {
+             role: typeof body?.role === "string" ? body.role : "unknown",
+             contentType: typeof body?.content?.type === "string" ? body.content.type : "unknown"
+           });
+           this.routeIncomingMessage(body);
+-          this.lastSeq = messageSeq;
+         } else if (data.body.t === "update-session") {
+           if (data.body.metadata && data.body.metadata.version > this.metadataVersion) {
+             this.metadata = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.metadata.value));
+@@ -2454,7 +2459,17 @@ class ApiSessionClient extends EventEmitter {
+         if (message.seq > maxSeq) {
+           maxSeq = message.seq;
+         }
+-        if (skipRouting) continue;
 +        // The socket handler routes live messages and advances lastSeq while
 +        // this fetch is parked on its await. Without this guard the page that
 +        // comes back re-routes anything the socket already delivered, and a
@@ -14,13 +50,13 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..665154ffa9d89d56d4fcf61d4ff830a5
 +        if (message.seq <= this.lastSeq) {
 +          continue;
 +        }
-         try {
-           const body = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(message.content.c));
-+          this.lastSeq = message.seq;
-           this.routeIncomingMessage(body);
-         } catch (error) {
-           logger.debug("[API] Failed to decrypt fetched message", {
-@@ -2487,9 +2496,12 @@ class ApiSessionClient extends EventEmitter {
++        this.lastSeq = message.seq;
++        const isOutboundEcho = this.outboundMessageLocalIds.delete(message.localId);
++        if (skipRouting || isOutboundEcho) continue;
+         if (message.content?.t !== "encrypted") {
+           continue;
+         }
+@@ -2487,10 +2502,13 @@ class ApiSessionClient extends EventEmitter {
    static MAX_OUTBOX_BATCH_SIZE = 50;
    async flushOutbox() {
      while (this.pendingOutbox.length > 0) {
@@ -30,12 +66,35 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..665154ffa9d89d56d4fcf61d4ff830a5
        const batchSize = Math.min(this.pendingOutbox.length, ApiSessionClient.MAX_OUTBOX_BATCH_SIZE);
 -      const batchStart = this.pendingOutbox.length - batchSize;
 -      const batch = this.pendingOutbox.slice(batchStart);
+-      const response = await axios.post(
 +      const batchStart = 0;
 +      const batch = this.pendingOutbox.slice(batchStart, batchSize);
-       const response = await axios.post(
++      await axios.post(
          `${configuration.serverUrl}/v3/sessions/${encodeURIComponent(this.sessionId)}/messages`,
          {
-@@ -2777,6 +2789,15 @@ class ApiSessionClient extends EventEmitter {
+           messages: batch
+@@ -2500,17 +2518,16 @@ class ApiSessionClient extends EventEmitter {
+           timeout: 6e4
+         }
+       );
+-      const messages = Array.isArray(response.data.messages) ? response.data.messages : [];
+-      const maxSeq = messages.reduce((acc, message) => message.seq > acc ? message.seq : acc, this.lastSeq);
+-      this.lastSeq = maxSeq;
+       this.pendingOutbox.splice(batchStart, batch.length);
+     }
+   }
+   enqueueMessage(content, invalidate = true) {
+     const encrypted = encodeBase64(encrypt(this.encryptionKey, this.encryptionVariant, content));
++    const localId = randomUUID();
++    this.outboundMessageLocalIds.add(localId);
+     this.pendingOutbox.push({
+       content: encrypted,
+-      localId: randomUUID()
++      localId
+     });
+     if (invalidate) {
+       this.sendSync.invalidate();
+@@ -2777,6 +2794,15 @@ class ApiSessionClient extends EventEmitter {
    }
    async close() {
      logger.debug("[API] socket.close() called");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  happy@1.2.0: c8b4fbe169e3d55f3a97f731e40a6d8adaf5878b3998002229a81758a9e6a133
+  happy@1.2.0: b1df4fbb8dd327f2d185b36c501d50d74ec1ef25f91cebe75ca349cd63ada943
 
 importers:
 
@@ -79,7 +79,7 @@ importers:
         version: 2.10.1
       happy:
         specifier: 1.2.0
-        version: 1.2.0(patch_hash=c8b4fbe169e3d55f3a97f731e40a6d8adaf5878b3998002229a81758a9e6a133)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10)
+        version: 1.2.0(patch_hash=b1df4fbb8dd327f2d185b36c501d50d74ec1ef25f91cebe75ca349cd63ada943)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10)
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -10140,7 +10140,7 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
-  happy@1.2.0(patch_hash=c8b4fbe169e3d55f3a97f731e40a6d8adaf5878b3998002229a81758a9e6a133)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10):
+  happy@1.2.0(patch_hash=b1df4fbb8dd327f2d185b36c501d50d74ec1ef25f91cebe75ca349cd63ada943)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk': 0.3.214(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)

--- a/tests/unit/happy-relay-sync-patch.test.ts
+++ b/tests/unit/happy-relay-sync-patch.test.ts
@@ -34,10 +34,45 @@ describe("happy relay sync patch", () => {
   });
 
   it("advances lastSeq before routing so fetch and socket cannot overlap", () => {
-    const routeIndex = source.indexOf("this.lastSeq = message.seq;");
-    expect(routeIndex).toBeGreaterThan(-1);
-    const tail = source.slice(routeIndex, routeIndex + 200);
-    expect(tail).toContain("this.routeIncomingMessage(body)");
+    const fetchIndex = source.indexOf("async fetchMessages()");
+    const sequenceIndex = source.indexOf("this.lastSeq = message.seq;", fetchIndex);
+    const routeIndex = source.indexOf("this.routeIncomingMessage(body);", fetchIndex);
+    expect(sequenceIndex).toBeGreaterThan(fetchIndex);
+    expect(routeIndex).toBeGreaterThan(sequenceIndex);
+  });
+
+  it("does not advance the inbound cursor from outbound POST responses", () => {
+    // POST responses may leapfrog an unfetched phone prompt in the shared relay
+    // sequence. Only socket/GET observation is allowed to advance lastSeq.
+    const flushIndex = source.indexOf("async flushOutbox()");
+    const enqueueIndex = source.indexOf("enqueueMessage(content", flushIndex);
+    const flushBody = source.slice(flushIndex, enqueueIndex);
+    expect(flushBody).not.toContain("this.lastSeq");
+    expect(flushBody).not.toContain("response.data.messages");
+  });
+
+  it("filters this client's echoed outbound messages from socket and fetch routing", () => {
+    expect(source).toContain("this.outboundMessageLocalIds.add(localId);");
+
+    const socketStart = source.indexOf('if (data.body.t === "new-message")');
+    const socketEnd = source.indexOf('data.body.t === "update-session"', socketStart);
+    const socketBody = source.slice(socketStart, socketEnd);
+    const socketAdvance = socketBody.indexOf("this.lastSeq = messageSeq;");
+    const socketFilter = socketBody.indexOf(
+      "this.outboundMessageLocalIds.delete(message.localId)",
+    );
+    expect(socketAdvance).toBeGreaterThan(-1);
+    expect(socketFilter).toBeGreaterThan(socketAdvance);
+
+    const fetchStart = source.indexOf("async fetchMessages()");
+    const fetchEnd = source.indexOf("async flushOutbox()", fetchStart);
+    const fetchBody = source.slice(fetchStart, fetchEnd);
+    const fetchAdvance = fetchBody.indexOf("this.lastSeq = message.seq;");
+    const fetchFilter = fetchBody.indexOf(
+      "this.outboundMessageLocalIds.delete(message.localId)",
+    );
+    expect(fetchAdvance).toBeGreaterThan(-1);
+    expect(fetchFilter).toBeGreaterThan(fetchAdvance);
   });
 
   it("flushes the outbox before stopping the send sync on close", () => {


### PR DESCRIPTION
Closes #3119

## What was broken

Happy's session client used one `lastSeq` for both messages observed through WebSocket/GET and sequence numbers returned by the client's own outbound POSTs. Because the relay uses one shared sequence space, an outbound batch could move `lastSeq` past a phone prompt that had not been fetched yet. The next GET then skipped that prompt permanently.

## Fix

- Stop outbound POST responses from advancing the inbound observation cursor.
- Record each outbound message's relay `localId`.
- Consume the client's echoed outbound messages on both WebSocket and GET paths without routing them as inbound.
- Advance `lastSeq` before filtering an echo, preserving sequence continuity and the prior socket/fetch race fix.
- Keep the change in the pinned `happy@1.2.0` pnpm patch so production installs and release builds receive it.

## Critical coverage

The existing real-installed-package guard now verifies that:

- `flushOutbox` cannot mutate `lastSeq`;
- outbound `localId` values are registered;
- socket and GET paths advance the cursor and filter the client's own echoes.

Validation completed before opening:

- `pnpm install --frozen-lockfile`
- `pnpm test` — 2,487 passed, 15 skipped
- `pnpm check` — completed successfully
- `pnpm build` — completed successfully

## Networked path

No Seren Gateway publisher slug is involved.

The affected path is:

1. Remote Access settings invoke the local Happy bridge through Tauri IPC.
2. The bridge assigns the configured Happy relay URL to the vendored client.
3. The client connects to WebSocket `/v1/updates`.
4. Relay synchronization uses authenticated `GET` and `POST /v3/sessions/:sessionId/messages`.
5. The official Happy server contract preserves `localId`, returns forward messages ordered by global `seq`, and emits created messages to interested session clients.

No endpoint, method, authentication header, or publisher configuration changes in this PR.