### PR TITLE
fix(remote): ship patched Happy runtime

### DIFF
--- a/patches/happy@1.2.0.patch
+++ b/patches/happy@1.2.0.patch
@@ -110,3 +110,115 @@ index 09c68a0e9c1c90e55115b3bcdfc92a0d408325b6..e222a76faae481cbfc2814568349c10e
      this.sendSync.stop();
      this.receiveSync.stop();
      if (this.reconnectInterval) {
+diff --git a/dist/types-D0KwHfY9.cjs b/dist/types-D0KwHfY9.cjs
+index 4aebb1233520dbe47c2069294ff3664300e99177..577cd7e5d4985c746db1f3867f8559c53fb7ac7d 100644
+--- a/dist/types-D0KwHfY9.cjs
++++ b/dist/types-D0KwHfY9.cjs
+@@ -2145,6 +2145,7 @@ class ApiSessionClient extends node_events.EventEmitter {
+   };
+   lastSeq = 0;
+   pendingOutbox = [];
++  outboundMessageLocalIds = /* @__PURE__ */ new Set();
+   sendSync;
+   receiveSync;
+   constructor(token, session) {
+@@ -2209,18 +2210,22 @@ class ApiSessionClient extends node_events.EventEmitter {
+           return;
+         }
+         if (data.body.t === "new-message") {
+-          const messageSeq = data.body.message?.seq;
+-          if (typeof messageSeq !== "number" || messageSeq !== this.lastSeq + 1 || data.body.message.content.t !== "encrypted") {
++          const message = data.body.message;
++          const messageSeq = message?.seq;
++          if (typeof messageSeq !== "number" || messageSeq !== this.lastSeq + 1 || message?.content?.t !== "encrypted") {
+             this.receiveSync.invalidate();
+             return;
+           }
+-          const body = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.message.content.c));
++          this.lastSeq = messageSeq;
++          if (this.outboundMessageLocalIds.delete(message.localId)) {
++            return;
++          }
++          const body = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(message.content.c));
+           logger.debug("[SOCKET] [UPDATE] Decrypted message", {
+             role: typeof body?.role === "string" ? body.role : "unknown",
+             contentType: typeof body?.content?.type === "string" ? body.content.type : "unknown"
+           });
+           this.routeIncomingMessage(body);
+-          this.lastSeq = messageSeq;
+         } else if (data.body.t === "update-session") {
+           if (data.body.metadata && data.body.metadata.version > this.metadataVersion) {
+             this.metadata = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.metadata.value));
+@@ -2457,7 +2462,17 @@ class ApiSessionClient extends node_events.EventEmitter {
+         if (message.seq > maxSeq) {
+           maxSeq = message.seq;
+         }
+-        if (skipRouting) continue;
++        // The socket handler routes live messages and advances lastSeq while
++        // this fetch is parked on its await. Without this guard the page that
++        // comes back re-routes anything the socket already delivered, and a
++        // user prompt is executed twice. lastSeq advances per message rather
++        // than after the loop so the two paths cannot overlap.
++        if (message.seq <= this.lastSeq) {
++          continue;
++        }
++        this.lastSeq = message.seq;
++        const isOutboundEcho = this.outboundMessageLocalIds.delete(message.localId);
++        if (skipRouting || isOutboundEcho) continue;
+         if (message.content?.t !== "encrypted") {
+           continue;
+         }
+@@ -2490,10 +2505,13 @@ class ApiSessionClient extends node_events.EventEmitter {
+   static MAX_OUTBOX_BATCH_SIZE = 50;
+   async flushOutbox() {
+     while (this.pendingOutbox.length > 0) {
++      // Drain from the head. Slicing the tail sent any backlog over the batch
++      // cap newest-block-first, so the relay assigned sequence numbers that did
++      // not match production order and the phone rendered the turn scrambled.
+       const batchSize = Math.min(this.pendingOutbox.length, ApiSessionClient.MAX_OUTBOX_BATCH_SIZE);
+-      const batchStart = this.pendingOutbox.length - batchSize;
+-      const batch = this.pendingOutbox.slice(batchStart);
+-      const response = await axios.post(
++      const batchStart = 0;
++      const batch = this.pendingOutbox.slice(batchStart, batchSize);
++      await axios.post(
+         `${configuration.serverUrl}/v3/sessions/${encodeURIComponent(this.sessionId)}/messages`,
+         {
+           messages: batch
+@@ -2503,17 +2521,16 @@ class ApiSessionClient extends node_events.EventEmitter {
+           timeout: 6e4
+         }
+       );
+-      const messages = Array.isArray(response.data.messages) ? response.data.messages : [];
+-      const maxSeq = messages.reduce((acc, message) => message.seq > acc ? message.seq : acc, this.lastSeq);
+-      this.lastSeq = maxSeq;
+       this.pendingOutbox.splice(batchStart, batch.length);
+     }
+   }
+   enqueueMessage(content, invalidate = true) {
+     const encrypted = encodeBase64(encrypt(this.encryptionKey, this.encryptionVariant, content));
++    const localId = node_crypto.randomUUID();
++    this.outboundMessageLocalIds.add(localId);
+     this.pendingOutbox.push({
+       content: encrypted,
+-      localId: node_crypto.randomUUID()
++      localId
+     });
+     if (invalidate) {
+       this.sendSync.invalidate();
+@@ -2780,6 +2797,15 @@ class ApiSessionClient extends node_events.EventEmitter {
+   }
+   async close() {
+     logger.debug("[API] socket.close() called");
++    // Drain anything still queued before stopping the sync. stop() latches a
++    // flag that makes the pending flush return without running, so closing
++    // first discarded the tail of every turn — the final assistant text never
++    // reached the relay.
++    try {
++      await this.flushOutbox();
++    } catch (error) {
++      logger.debug("[API] Failed to flush outbox during close", { error });
++    }
+     this.sendSync.stop();
+     this.receiveSync.stop();
+     if (this.reconnectInterval) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  happy@1.2.0: b1df4fbb8dd327f2d185b36c501d50d74ec1ef25f91cebe75ca349cd63ada943
+  happy@1.2.0: 9a27f64c864212eb200daf80274b48bfe45c528b78aa019ec4a5bba2b36a2771
 
 importers:
 
@@ -79,7 +79,7 @@ importers:
         version: 2.10.1
       happy:
         specifier: 1.2.0
-        version: 1.2.0(patch_hash=b1df4fbb8dd327f2d185b36c501d50d74ec1ef25f91cebe75ca349cd63ada943)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10)
+        version: 1.2.0(patch_hash=9a27f64c864212eb200daf80274b48bfe45c528b78aa019ec4a5bba2b36a2771)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10)
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -10140,7 +10140,7 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
-  happy@1.2.0(patch_hash=b1df4fbb8dd327f2d185b36c501d50d74ec1ef25f91cebe75ca349cd63ada943)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10):
+  happy@1.2.0(patch_hash=9a27f64c864212eb200daf80274b48bfe45c528b78aa019ec4a5bba2b36a2771)(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@fastify/swagger@9.8.1)(@types/node@26.1.1)(bufferutil@4.1.0)(openapi-types@12.1.3)(utf-8-validate@5.0.10):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk': 0.3.214(@anthropic-ai/sdk@0.112.3(zod@3.25.75))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)

--- a/scripts/build-provider-runtime.ts
+++ b/scripts/build-provider-runtime.ts
@@ -129,6 +129,28 @@ function main(): void {
   }).stdout.trim();
   console.log(`provider-runtime/node_modules before Happy SDK binary prune: ${bundleSizeBeforePrune}`);
   const happyPackage = path.join(bundleNodeModules, "happy");
+  const workspaceHappyDist = path.join(
+    repoRoot,
+    "node_modules",
+    "happy",
+    "dist",
+  );
+  const bundledHappyDist = path.join(happyPackage, "dist");
+  if (!existsSync(workspaceHappyDist)) {
+    throw new Error(
+      "Workspace Happy dependency is missing; run pnpm install before building the provider runtime",
+    );
+  }
+  // The isolated install above intentionally ignores the root workspace, so it
+  // cannot see pnpm-workspace.yaml's patchedDependencies entry. Replace its raw
+  // Happy distribution with the already-patched workspace distribution before
+  // this directory becomes the production Tauri resource bundle.
+  rmSync(bundledHappyDist, { recursive: true, force: true });
+  cpSync(workspaceHappyDist, bundledHappyDist, {
+    recursive: true,
+    force: true,
+    dereference: true,
+  });
   const sdkPackage = path.join(bundleNodeModules, "@anthropic-ai", "claude-agent-sdk");
   const happyReferenceRoot = existsSync(path.join(happyPackage, "lib"))
     ? path.join(happyPackage, "lib")

--- a/tests/unit/happy-relay-sync-patch.test.ts
+++ b/tests/unit/happy-relay-sync-patch.test.ts
@@ -7,17 +7,22 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = join(dirname(new URL(import.meta.url).pathname), "..", "..");
 
-function installedClientSource(): string {
+function installedClientSources(): Array<{ name: string; source: string }> {
   const distDir = join(repoRoot, "node_modules", "happy", "dist");
-  const clientFile = readdirSync(distDir).find(
-    (name) => name.startsWith("types-") && name.endsWith(".mjs"),
+  const clientFiles = readdirSync(distDir).filter(
+    (name) => name.startsWith("types-") && /\.(?:cjs|mjs)$/.test(name),
   );
-  if (!clientFile) throw new Error("happy dist client bundle not found");
-  return readFileSync(join(distDir, clientFile), "utf8");
+  if (clientFiles.length !== 2) {
+    throw new Error("happy ESM and CommonJS client bundles not found");
+  }
+  return clientFiles.map((name) => ({
+    name,
+    source: readFileSync(join(distDir, name), "utf8"),
+  }));
 }
 
 describe("happy relay sync patch", () => {
-  const source = installedClientSource();
+  const sources = installedClientSources();
 
   it("stays pinned to the happy version the patch was built against", () => {
     const declared = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
@@ -30,68 +35,93 @@ describe("happy relay sync patch", () => {
   it("skips relay messages the socket handler already routed", () => {
     // Without this guard an in-flight fetch re-routes messages the socket
     // delivered mid-await, and a phone prompt executes twice on the desktop.
-    expect(source).toContain("if (message.seq <= this.lastSeq)");
+    for (const { source } of sources) {
+      expect(source).toContain("if (message.seq <= this.lastSeq)");
+    }
   });
 
   it("advances lastSeq before routing so fetch and socket cannot overlap", () => {
-    const fetchIndex = source.indexOf("async fetchMessages()");
-    const sequenceIndex = source.indexOf("this.lastSeq = message.seq;", fetchIndex);
-    const routeIndex = source.indexOf("this.routeIncomingMessage(body);", fetchIndex);
-    expect(sequenceIndex).toBeGreaterThan(fetchIndex);
-    expect(routeIndex).toBeGreaterThan(sequenceIndex);
+    for (const { source } of sources) {
+      const fetchIndex = source.indexOf("async fetchMessages()");
+      const sequenceIndex = source.indexOf("this.lastSeq = message.seq;", fetchIndex);
+      const routeIndex = source.indexOf("this.routeIncomingMessage(body);", fetchIndex);
+      expect(sequenceIndex).toBeGreaterThan(fetchIndex);
+      expect(routeIndex).toBeGreaterThan(sequenceIndex);
+    }
   });
 
   it("does not advance the inbound cursor from outbound POST responses", () => {
     // POST responses may leapfrog an unfetched phone prompt in the shared relay
     // sequence. Only socket/GET observation is allowed to advance lastSeq.
-    const flushIndex = source.indexOf("async flushOutbox()");
-    const enqueueIndex = source.indexOf("enqueueMessage(content", flushIndex);
-    const flushBody = source.slice(flushIndex, enqueueIndex);
-    expect(flushBody).not.toContain("this.lastSeq");
-    expect(flushBody).not.toContain("response.data.messages");
+    for (const { source } of sources) {
+      const flushIndex = source.indexOf("async flushOutbox()");
+      const enqueueIndex = source.indexOf("enqueueMessage(content", flushIndex);
+      const flushBody = source.slice(flushIndex, enqueueIndex);
+      expect(flushBody).not.toContain("this.lastSeq");
+      expect(flushBody).not.toContain("response.data.messages");
+    }
   });
 
   it("filters this client's echoed outbound messages from socket and fetch routing", () => {
-    expect(source).toContain("this.outboundMessageLocalIds.add(localId);");
+    for (const { source } of sources) {
+      expect(source).toContain("this.outboundMessageLocalIds.add(localId);");
 
-    const socketStart = source.indexOf('if (data.body.t === "new-message")');
-    const socketEnd = source.indexOf('data.body.t === "update-session"', socketStart);
-    const socketBody = source.slice(socketStart, socketEnd);
-    const socketAdvance = socketBody.indexOf("this.lastSeq = messageSeq;");
-    const socketFilter = socketBody.indexOf(
-      "this.outboundMessageLocalIds.delete(message.localId)",
-    );
-    expect(socketAdvance).toBeGreaterThan(-1);
-    expect(socketFilter).toBeGreaterThan(socketAdvance);
+      const socketStart = source.indexOf('if (data.body.t === "new-message")');
+      const socketEnd = source.indexOf('data.body.t === "update-session"', socketStart);
+      const socketBody = source.slice(socketStart, socketEnd);
+      const socketAdvance = socketBody.indexOf("this.lastSeq = messageSeq;");
+      const socketFilter = socketBody.indexOf(
+        "this.outboundMessageLocalIds.delete(message.localId)",
+      );
+      expect(socketAdvance).toBeGreaterThan(-1);
+      expect(socketFilter).toBeGreaterThan(socketAdvance);
 
-    const fetchStart = source.indexOf("async fetchMessages()");
-    const fetchEnd = source.indexOf("async flushOutbox()", fetchStart);
-    const fetchBody = source.slice(fetchStart, fetchEnd);
-    const fetchAdvance = fetchBody.indexOf("this.lastSeq = message.seq;");
-    const fetchFilter = fetchBody.indexOf(
-      "this.outboundMessageLocalIds.delete(message.localId)",
-    );
-    expect(fetchAdvance).toBeGreaterThan(-1);
-    expect(fetchFilter).toBeGreaterThan(fetchAdvance);
+      const fetchStart = source.indexOf("async fetchMessages()");
+      const fetchEnd = source.indexOf("async flushOutbox()", fetchStart);
+      const fetchBody = source.slice(fetchStart, fetchEnd);
+      const fetchAdvance = fetchBody.indexOf("this.lastSeq = message.seq;");
+      const fetchFilter = fetchBody.indexOf(
+        "this.outboundMessageLocalIds.delete(message.localId)",
+      );
+      expect(fetchAdvance).toBeGreaterThan(-1);
+      expect(fetchFilter).toBeGreaterThan(fetchAdvance);
+    }
   });
 
   it("flushes the outbox before stopping the send sync on close", () => {
-    const closeIndex = source.indexOf("[API] socket.close() called");
-    expect(closeIndex).toBeGreaterThan(-1);
-    const closeBody = source.slice(closeIndex, closeIndex + 600);
-    const flushIndex = closeBody.indexOf("await this.flushOutbox()");
-    const stopIndex = closeBody.indexOf("this.sendSync.stop()");
-    expect(flushIndex).toBeGreaterThan(-1);
-    // stop() latches a flag that makes a pending flush a no-op, so ordering is
-    // the whole fix: flush must complete first or the turn's tail is dropped.
-    expect(flushIndex).toBeLessThan(stopIndex);
+    for (const { source } of sources) {
+      const closeIndex = source.indexOf("[API] socket.close() called");
+      expect(closeIndex).toBeGreaterThan(-1);
+      const closeBody = source.slice(closeIndex, closeIndex + 600);
+      const flushIndex = closeBody.indexOf("await this.flushOutbox()");
+      const stopIndex = closeBody.indexOf("this.sendSync.stop()");
+      expect(flushIndex).toBeGreaterThan(-1);
+      // stop() latches a flag that makes a pending flush a no-op, so ordering is
+      // the whole fix: flush must complete first or the turn's tail is dropped.
+      expect(flushIndex).toBeLessThan(stopIndex);
+    }
   });
 
   it("drains the outbox from the head so batches keep production order", () => {
-    const flushIndex = source.indexOf("MAX_OUTBOX_BATCH_SIZE);");
-    expect(flushIndex).toBeGreaterThan(-1);
-    const flushBody = source.slice(flushIndex, flushIndex + 300);
-    expect(flushBody).toContain("const batchStart = 0;");
-    expect(flushBody).not.toContain("this.pendingOutbox.length - batchSize");
+    for (const { source } of sources) {
+      const flushIndex = source.indexOf("MAX_OUTBOX_BATCH_SIZE);");
+      expect(flushIndex).toBeGreaterThan(-1);
+      const flushBody = source.slice(flushIndex, flushIndex + 300);
+      expect(flushBody).toContain("const batchStart = 0;");
+      expect(flushBody).not.toContain("this.pendingOutbox.length - batchSize");
+    }
+  });
+
+  it("copies the patched Happy dist into the isolated production bundle", () => {
+    const buildScript = readFileSync(
+      join(repoRoot, "scripts", "build-provider-runtime.ts"),
+      "utf8",
+    );
+    const isolatedInstall = buildScript.indexOf('"--ignore-workspace"');
+    const patchedDistCopy = buildScript.indexOf(
+      "cpSync(workspaceHappyDist, bundledHappyDist",
+    );
+    expect(isolatedInstall).toBeGreaterThan(-1);
+    expect(patchedDistCopy).toBeGreaterThan(isolatedInstall);
   });
 });


### PR DESCRIPTION
Closes #3130

## Summary

- copy the workspace-patched Happy distribution into the isolated provider-runtime bundle after its production-only install
- apply the relay cursor, echo filtering, FIFO batching, and close-flush fixes to Happy's CommonJS distribution as well as its ESM distribution
- guard both distributed module formats and the production bundle copy in the existing focused regression test

## Root cause

The provider-runtime build intentionally installs dependencies with `--ignore-workspace`. That install therefore could not see the root workspace's `patchedDependencies` entry and packaged the upstream Happy 1.2.0 distribution. The real Tauri app consequently retained the outbound-POST cursor bug even though the workspace tests exercised the patched package.

## Validation

- `pnpm exec vitest run tests/unit/happy-relay-sync-patch.test.ts` — 8 passed
- `pnpm test` — 343 files passed, 3 skipped; 2,489 tests passed, 15 skipped
- `pnpm check` — passed (existing warnings only)
- `pnpm build` — passed
- `pnpm build:provider-runtime` — passed
- generated provider-runtime Happy ESM and CommonJS distributions match the patched workspace distribution and contain no outbound POST cursor mutation

## Network path

No Seren Gateway publisher slug is involved in this feature. The desktop UI invokes the local Tauri/provider-runtime bridge; the embedded Happy client then uses the authenticated Happy relay WebSocket `/v1/updates` and authenticated GET/POST `/v3/sessions/:sessionId/messages`. This change does not alter those methods, paths, or authentication.