### PR TITLE
fix(remote): recover unreadable Happy sessions

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -274,6 +274,39 @@ export function createStartupStatusGate(notify) {
   };
 }
 
+function isUsableHappySession(session) {
+  return (
+    session !== null &&
+    typeof session === "object" &&
+    typeof session.metadata?.path === "string" &&
+    session.metadata.path.length > 0
+  );
+}
+
+export async function getOrCreateUsableHappySession({
+  api,
+  tag,
+  metadata,
+  state,
+  debugLog = () => {},
+  replacementTag = () => `seren-recovery-${randomUUID()}`,
+}) {
+  const initial = await api.getOrCreateSession({ tag, metadata, state });
+  if (!initial || isUsableHappySession(initial)) return initial ?? null;
+
+  // Data-key sessions cannot decrypt a relay record created by an earlier
+  // bridge process because Happy 1.2.0 keeps that session key only in memory.
+  // A one-time tag forces a fresh encrypted record instead of passing null
+  // metadata into ApiSessionClient, whose constructor dereferences `.path`.
+  debugLog("replacing Happy session with unreadable metadata");
+  const replacement = await api.getOrCreateSession({
+    tag: replacementTag(),
+    metadata,
+    state,
+  });
+  return isUsableHappySession(replacement) ? replacement : null;
+}
+
 export function createHappyLayer({
   config,
   supervisorChannel,
@@ -468,12 +501,19 @@ export function createHappyLayer({
     if (existing) return existing;
     if (!api || !identity) throw new Error("Happy API is not registered");
     const machineId = identity.machineId ?? "seren-desktop";
-    const session = existingSession ?? await api.getOrCreateSession({
-      tag: `seren-${sessionId}`,
-      metadata: sessionMetadata(config, summary, machineId),
-      state: { controlledByUser: true },
-    });
-    if (!session) throw new Error("Happy relay did not return a session");
+    const metadata = sessionMetadata(config, summary, machineId);
+    const session =
+      existingSession ??
+      (await getOrCreateUsableHappySession({
+        api,
+        tag: `seren-${sessionId}`,
+        metadata,
+        state: { controlledByUser: true },
+        debugLog: debug,
+      }));
+    if (!isUsableHappySession(session)) {
+      throw new Error("Happy relay did not return a usable session");
+    }
     const client = api.sessionSyncClient(session);
     const entry = { sessionId, happySessionId: session.id, summary, session, client };
     sessions.set(sessionId, entry);

--- a/tests/unit/happy-session-recovery.test.ts
+++ b/tests/unit/happy-session-recovery.test.ts
@@ -1,0 +1,54 @@
+// ABOUTME: Guards Happy bridge recovery when a stable relay tag returns metadata
+// ABOUTME: that the restarted data-key client can no longer decrypt.
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — the bridge layer is plain ESM without declarations.
+import { getOrCreateUsableHappySession } from "../../bin/happy-bridge/happy-layer.mjs";
+
+describe("Happy relay session recovery", () => {
+  it("replaces an existing session whose metadata is unreadable", async () => {
+    const metadata = { path: "/advertised/project" };
+    const calls: Array<Record<string, unknown>> = [];
+    const logs: string[] = [];
+    const replacement = { id: "replacement", metadata };
+    const api = {
+      getOrCreateSession: async (input: Record<string, unknown>) => {
+        calls.push(input);
+        return calls.length === 1 ? { id: "stale", metadata: null } : replacement;
+      },
+    };
+
+    await expect(
+      getOrCreateUsableHappySession({
+        api,
+        tag: "seren-local-session",
+        metadata,
+        state: { controlledByUser: true },
+        debugLog: (message: string) => logs.push(message),
+        replacementTag: () => "seren-recovery-test",
+      }),
+    ).resolves.toBe(replacement);
+    expect(calls.map((call) => call.tag)).toEqual([
+      "seren-local-session",
+      "seren-recovery-test",
+    ]);
+    expect(logs).toEqual(["replacing Happy session with unreadable metadata"]);
+  });
+
+  it("fails closed when the replacement session is also unreadable", async () => {
+    const api = {
+      getOrCreateSession: async () => ({ id: "stale", metadata: null }),
+    };
+
+    await expect(
+      getOrCreateUsableHappySession({
+        api,
+        tag: "seren-local-session",
+        metadata: { path: "/advertised/project" },
+        state: { controlledByUser: true },
+        replacementTag: () => "seren-recovery-test",
+      }),
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #3132

## Summary

- validate a Happy relay session before constructing the upstream session client
- when a stable data-key session tag returns unreadable metadata after restart, retry once with a fresh recovery tag and expected metadata
- fail closed if the replacement is also unusable
- add focused coverage for the recovery and fail-closed paths

## Root cause

Happy 1.2.0 data-key session keys are generated in memory by `getOrCreateSession`. After a bridge restart, the stable `seren-<local-session-id>` tag can resolve to the previous relay record, but the new process cannot decrypt that record's metadata. Happy returns `metadata: null`, and `ApiSessionClient` immediately dereferences `metadata.path`, aborting the entire bridge startup.

A fresh recovery tag is required because the prior record's encryption key is unavailable to the restarted process.

## Validation

- focused Happy recovery/arbitration/relay suite — 21 passed
- `pnpm test` — 344 files passed, 3 skipped; 2,491 tests passed, 15 skipped
- `pnpm check` — passed (existing warnings only)
- `pnpm build` — passed
- `pnpm build:provider-runtime` — passed; bundled Happy layer matches source

## Network path

No Seren Gateway publisher slug is involved. The desktop settings action invokes the local Tauri Happy supervisor and embedded provider-runtime bridge. The Happy client uses authenticated WebSocket `/v1/updates`, machine/session creation under `/v1/machines` and `/v1/sessions`, and authenticated GET/POST `/v3/sessions/:sessionId/messages`. This repair changes only local retry/tag selection; it does not alter methods, paths, or authentication.