### PR TITLE
fix(e2e): activate pnpm 11 on the Windows release gate box (#3136)

### DIFF
--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -494,7 +494,7 @@ try {
   Set-Location `$work
   Write-TaskLog "Using install directory `$installDir"
   Invoke-LoggedNative "Corepack enable" "corepack" @("enable") 120
-  Invoke-LoggedNative "Corepack prepare pnpm" "corepack" @("prepare", "pnpm@9", "--activate") 180
+  Invoke-LoggedNative "Corepack prepare pnpm" "corepack" @("prepare", "pnpm@11", "--activate") 180
   Invoke-LoggedNative "pnpm install" "pnpm" @("install", "--frozen-lockfile") 1200
   # #3096 intentionally removed provider-startup installation. The release
   # user is disposable and starts empty, so provision its real CLI prerequisites

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -666,4 +666,37 @@ describe("Windows production e2e release gate", () => {
     expect(stage).toContain("if ($LASTEXITCODE) { exit $LASTEXITCODE }");
     expect(stage).not.toContain("if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }");
   });
+
+  it("activates the same pnpm major on the e2e box as the release build", () => {
+    // The box runs `pnpm install --frozen-lockfile`. pnpm 10 moved
+    // patchedDependencies from package.json into pnpm-workspace.yaml, so a
+    // pnpm 9 box reads an empty config, sees the key in the lockfile, and
+    // aborts with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH — failing the gate that
+    // publish-release needs, so the tag never publishes (#3136).
+    const workspace = readFileSync(join(root, "pnpm-workspace.yaml"), "utf8");
+    const lockfile = readFileSync(join(root, "pnpm-lock.yaml"), "utf8");
+    const patchesAreWorkspaceScoped =
+      /^patchedDependencies:/m.test(workspace) &&
+      /^patchedDependencies:/m.test(lockfile);
+
+    const activated = taskUserRunner.match(
+      /"prepare",\s*"pnpm@(\d+)"/,
+    );
+    expect(activated).not.toBeNull();
+    const boxMajor = Number(activated?.[1]);
+
+    const releaseMajor = Number(
+      releaseWorkflow.match(
+        /uses: pnpm\/action-setup@v\d+\s+with:\s+version: (\d+)/,
+      )?.[1],
+    );
+    expect(releaseMajor).toBeGreaterThan(0);
+    expect(boxMajor).toBe(releaseMajor);
+
+    // The mismatch above is only silent-fatal while patches live in the
+    // workspace file; assert the precondition so this test explains itself
+    // if the patch declaration ever moves back.
+    expect(patchesAreWorkspaceScoped).toBe(true);
+    expect(boxMajor).toBeGreaterThanOrEqual(10);
+  });
 });


### PR DESCRIPTION
Fixes #3136. **P0 — blocks tagging v3.72.0.**

## Problem

`scripts/windows-e2e-task-user.ps1` activated `pnpm@9` on the e2e box, while `.github/workflows/ci.yml` and `release.yml` moved to pnpm 11 this cycle. The box then runs `pnpm install --frozen-lockfile`.

pnpm 10 relocated `patchedDependencies` from `package.json` to `pnpm-workspace.yaml`. This repo declares it there:

```yaml
patchedDependencies:
  happy@1.2.0: patches/happy@1.2.0.patch
```

pnpm 9 does not read that key from the workspace file. It sees `patchedDependencies` in `pnpm-lock.yaml` against an empty config, treats them as divergent, and refuses the frozen install.

`windows-app-e2e` is a `needs:` of `publish-release` (`release.yml:1969`), so this fails the job and the tag never publishes.

The declaration entered the tree in #3116, **after** v3.71.0 — the last green release never exercised it:

```
$ git show v3.71.0:pnpm-workspace.yaml | grep -c patchedDependencies
0
```

## Verification

Against the real repo tree and lockfile — the actual layer that fails, not a mock:

```
$ npx pnpm@11 install --frozen-lockfile --ignore-scripts
Done in 11.4s using pnpm v11.1.2                                    # succeeds

$ npx pnpm@9 install --frozen-lockfile --ignore-scripts
 ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen
 installation. The current "patchedDependencies" configuration does not
 match the value found in the lockfile                               # fails
```

The worktree's own `pnpm install --frozen-lockfile` also completed clean under pnpm 11.

Caveat, stated plainly: the on-box PowerShell path itself can only be validated by a real tag-driven release run. What is proven here is the package-manager behaviour that the box depends on.

## Regression test

`tests/unit/windows-e2e-release-gate.test.ts` asserts the box pin equals the release workflow pin, and that it is >= 10 while patches remain workspace-scoped. Negative control — reverting the pin to 9 fails it:

```
× activates the same pnpm major on the e2e box as the release build
AssertionError: expected 9 to be 11
```

With the fix: 29 passed.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
