### PR TITLE
fix(remote): suppress Happy prompt echoes

### DIFF
--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -87,6 +87,10 @@ export function translateNeutralEvent(event, { provider = AGENT_PROVIDER } = {})
         ...(payload.isThought === true ? { thinking: true } : {}),
       }, payload, "text")];
     case "user-message":
+      // Happy already persisted the remote peer's prompt before the bridge
+      // received it. Republishing the provider's attribution event would add a
+      // second user bubble to the controlling client.
+      if (payload.origin === "remote") return [];
       if (!text) return [];
       return [eventEnvelope("user", { t: "text", text }, payload, "user")];
     case "tool-start":

--- a/tests/unit/happy-bridge-translate-happy.test.ts
+++ b/tests/unit/happy-bridge-translate-happy.test.ts
@@ -57,6 +57,16 @@ describe("neutral-to-Happy session translation", () => {
     expect(translateNeutralEvent({ kind: "unknown", sessionId: "session-1", payload })).toEqual([]);
   });
 
+  it("does not republish a Happy-originated user message back to Happy", () => {
+    expect(
+      translateNeutralEvent({
+        kind: "user-message",
+        sessionId: "session-1",
+        payload: { text: "remote prompt", origin: "remote" },
+      }),
+    ).toEqual([]);
+  });
+
   it("bounds tool output for mobile while retaining more error context", () => {
     const success = translateNeutralEvent({
       kind: "tool-end",


### PR DESCRIPTION
Closes #3141

## Summary

- suppress provider-attribution events for Happy-originated user prompts
- keep Desktop-originated user messages and all assistant/status/tool events unchanged
- add one focused regression test for the duplicate-bubble behavior

## Root cause

Happy persists a phone prompt before the local provider receives it. The provider then emits a `provider://user-message` attribution event with `origin: "remote"`. Republishing that event into Happy creates a second user bubble even though the prompt executes only once in Desktop.

## Validation

- focused Happy tests: 92 passed
- full unit suite: 346 files passed, 3 skipped; 2,495 tests passed, 15 skipped
- `pnpm check`: passed with 48 existing warnings and 1 existing info
- focused Rust bridge tests: 17 passed
- `pnpm build`: passed
- `pnpm build:provider-runtime`: passed
- pre-fix real macOS app + real Happy account/relay reproduction, no mocks:
  - the phone prompt executed exactly once in Desktop
  - Happy rendered the same phone prompt twice
  - an independent second probe reproduced the same 1-versus-2 count

The post-fix real-app walkthrough will be recorded before merge. No screenshot is attached because the live UI surfaces a local project path.

## Network path

Happy submit → `POST /v3/sessions/:sessionId/messages` → `/v1/updates` WebSocket or `GET /v3/sessions/:sessionId/messages` gap recovery → local bridge → provider-runtime `provider_prompt` → provider attribution event → Happy relay publish.

No Seren publisher slug participates in this feature path. This change does not alter the Happy relay host, method, path, or authentication.