### PR TITLE
fix(agent): stop the file boundary from disabling the agent (#3138, #3139, #3140)

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1129,6 +1129,21 @@ function quoteHookArgument(value) {
   return `'${text.replaceAll("'", "'\\''")}'`;
 }
 
+// Credential stores kept out of reach of sandboxed Bash. Mirrors the
+// sensitive directories in bin/browser-local/file-access-policy.mjs, minus the
+// shell/git dotfiles that build tooling legitimately reads.
+const SANDBOX_DENY_READ_PATHS = [
+  "~/.ssh",
+  "~/.aws",
+  "~/.gnupg",
+  "~/.seren",
+  "~/.config/seren",
+  "~/.config/gcloud",
+  "~/.config/autostart",
+  "~/Library/LaunchAgents",
+  "~/.netrc",
+];
+
 function buildClaudePolicySettings({ cwd, sandboxMode, networkEnabled }) {
   const fullAccess =
     sandboxMode === "full-access" || sandboxMode === "danger-full-access";
@@ -1160,11 +1175,20 @@ function buildClaudePolicySettings({ cwd, sandboxMode, networkEnabled }) {
   if (process.platform !== "win32") {
     settings.sandbox = {
       enabled: true,
-      failIfUnavailable: true,
+      // Left at the default (false). The Linux sandbox needs bubblewrap and
+      // socat from the distro, which the .deb and AppImage cannot guarantee;
+      // failing closed there turns a missing OS package into an agent that
+      // never starts. Claude warns and runs unsandboxed instead, and the
+      // PreToolUse hook still bounds the built-in file tools. #3138
+      failIfUnavailable: false,
       autoAllowBashIfSandboxed: true,
       allowUnsandboxedCommands: false,
       filesystem: {
-        denyRead: ["~/"],
+        // Deny the credential stores rather than all of $HOME. A blanket
+        // "~/" also hides ~/.gitconfig and every $HOME-installed toolchain
+        // (nvm, pyenv, rustup), which breaks git commit and most build
+        // commands with no escape hatch. #3139
+        denyRead: SANDBOX_DENY_READ_PATHS,
         allowRead: [cwd],
         allowWrite: [cwd],
       },

--- a/src-tauri/src/orchestrator/file_access_policy.rs
+++ b/src-tauri/src/orchestrator/file_access_policy.rs
@@ -82,14 +82,18 @@ impl FileAccessPolicy {
             return FileAccessDecision::Allow(access);
         }
 
-        if sensitive {
-            return self.approval_or_deny(access);
-        }
-
+        // Read Only precedes the sensitive check, matching
+        // bin/browser-local/file-access-policy.mjs. Reversed, a write to a
+        // credential path resolved to an approval prompt while an ordinary
+        // path was denied outright. #3140
         if kind == FileAccessKind::Write && self.settings.sandbox_mode == "read-only" {
             return FileAccessDecision::Deny(
                 "File write denied: Agent Sandbox Mode is Read Only.".to_string(),
             );
+        }
+
+        if sensitive {
+            return self.approval_or_deny(access);
         }
 
         let in_project = self
@@ -320,6 +324,21 @@ mod tests {
             policy(root.path(), "full-access", "never")
                 .evaluate(outside.path().to_str().unwrap(), FileAccessKind::Read),
             FileAccessDecision::Allow(_)
+        ));
+    }
+
+    #[test]
+    fn read_only_denies_sensitive_writes_instead_of_prompting() {
+        // Read Only must not become approvable just because the target is a
+        // credential path — the JS twin denies both. #3140
+        let root = tempfile::tempdir().expect("root");
+        let home = dirs::home_dir().expect("home");
+        let credentials = home.join(".aws").join("credentials");
+
+        assert!(matches!(
+            policy(root.path(), "read-only", "on-request")
+                .evaluate(credentials.to_str().unwrap(), FileAccessKind::Write),
+            FileAccessDecision::Deny(_)
         ));
     }
 

--- a/tests/unit/agent-file-access-policy.test.ts
+++ b/tests/unit/agent-file-access-policy.test.ts
@@ -104,6 +104,29 @@ describe("Claude promptless containment (#3091)", () => {
     }
   });
 
+  it("keeps the agent startable and $HOME toolchains usable", () => {
+    const settings = buildClaudePolicySettings({
+      cwd: tempProject(),
+      sandboxMode: "workspace-write",
+      networkEnabled: false,
+    });
+    if (process.platform === "win32") return;
+
+    // failIfUnavailable turns a missing bubblewrap/socat into a Claude Code
+    // that will not start, and we ship neither. #3138
+    expect(settings.sandbox.failIfUnavailable).toBe(false);
+
+    // Denying all of ~/ also hides ~/.gitconfig and $HOME toolchains, which
+    // breaks git commit and most build commands. #3139
+    const denyRead: string[] = settings.sandbox.filesystem.denyRead;
+    expect(denyRead).not.toContain("~/");
+    expect(denyRead).toContain("~/.aws");
+    expect(denyRead).toContain("~/.ssh");
+    for (const readable of ["~/.gitconfig", "~/.nvm", "~/.cargo", "~/.pyenv"]) {
+      expect(denyRead).not.toContain(readable);
+    }
+  });
+
   it("stays silent in-project and asks only for exceptional external access", () => {
     const root = tempProject();
     const outside = tempProject();


### PR DESCRIPTION
Fixes #3138 (P0), #3139 (P1), #3140 (P1). All three come from the sandbox block added in #3097, after v3.71.0 — none of this has shipped.

## 1. Linux agent could not start (#3138, P0)

`failIfUnavailable: true` was set for every non-Windows platform. Per the [official docs](https://code.claude.com/docs/en/sandboxing.md):

> `failIfUnavailable`: a missing dependency such as bubblewrap on Linux blocks Claude Code from **starting** rather than showing a warning and falling back to unsandboxed execution.

Linux needs `bubblewrap` + `socat` from the distro. We ship neither and declare no `bundle.linux.depends`, so every Linux user would get an agent that never starts. Now left at the default (`false`).

## 2. Bash lost `$HOME` (#3139, P1)

`denyRead: ["~/"]` also hid `~/.gitconfig` and every `$HOME`-installed toolchain (nvm, pyenv, rustup), with `allowUnsandboxedCommands: false` and no `excludedCommands` leaving no escape hatch. `denyRead` now names the credential stores, mirroring the sensitive-directory list already in `file-access-policy.mjs`.

## 3. Read Only prompted instead of denying (#3140, P1)

The Rust policy evaluated `sensitive` before the read-only write deny, so a write to `~/.aws/credentials` in Read Only mode became an approval prompt while a write to `output.txt` was denied outright. Reordered to match the JS twin.

## Functional verification

Run against the **real** `claude` CLI (2.1.216) with settings generated by `_buildClaudePolicySettings` itself — not a mock, and not a shape assertion:

| command | old settings | new settings |
|---|---|---|
| `git config --get user.name` | `fatal: unable to access '/Users/…/.gitconfig': Operation not permitted` | `Taariq Lewis` |
| `ls ~/.ssh` | denied | `Operation not permitted` (still denied) |

So the break is fixed and the security intent is preserved.

**Stated limitation:** the #3138 Linux abort cannot be reproduced on macOS — Seatbelt is always available, so `failIfUnavailable` never fires here. That fix rests on the documented behaviour plus the settings assertion, and is only truly observable on a Linux box without bubblewrap.

## Tests

Both new tests fail without their fix:

```
× keeps the agent startable and $HOME toolchains usable
AssertionError: expected true to be false

read_only_denies_sensitive_writes_instead_of_prompting ... FAILED
```

With the fix: vitest 2495 passed, cargo 938 passed, biome exit 0.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
