### PR TITLE
fix(remote): honor root consent and defer LM Studio prompts (#3144, #3145)

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -347,6 +347,18 @@ export function createStartupStatusGate(notify) {
   };
 }
 
+// Matched on shape rather than the exact sentence. Runtimes name the session
+// in their own words — LM Studio says "...for this LM Studio session." — and an
+// exact compare silently discarded the queued prompt for those sessions. #3145
+export function isPromptBusyError(error) {
+  return (
+    error instanceof Error &&
+    /^Another prompt is already active for this .*session\.$/.test(
+      error.message,
+    )
+  );
+}
+
 export function createDeferredPromptQueue({
   send,
   onError = () => {},
@@ -504,9 +516,7 @@ export function createHappyLayer({
   const promptQueue = createDeferredPromptQueue({
     send: async (_sessionId, queued) =>
       handleUserMessage(queued.entry, queued.message),
-    shouldRetry: (error) =>
-      error instanceof Error &&
-      error.message === "Another prompt is already active for this session.",
+    shouldRetry: isPromptBusyError,
     onError: (_error, outcome) =>
       debug(
         outcome.deferred

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -129,8 +129,15 @@ impl HappyBridgeManager {
         });
         // Reuse the existing conversation reader as the source of recent project roots.
         // There is no separate Rust recent-project registry in this repository.
-        let discovered_roots =
-            crate::commands::chat::list_conversations(app.clone(), None, None, None)
+        // Agent conversations only, matching the set HappyRemoteSettings renders
+        // checkboxes for. Including chat conversations advertised roots the user
+        // was never shown and could not withdraw. #3144
+        let discovered_roots = crate::commands::chat::list_conversations(
+            app.clone(),
+            Some("agent".to_string()),
+            None,
+            None,
+        )
                 .await
                 .unwrap_or_default()
                 .into_iter()

--- a/tests/unit/happy-prompt-queue.test.ts
+++ b/tests/unit/happy-prompt-queue.test.ts
@@ -1,9 +1,14 @@
 // ABOUTME: Protects Happy phone prompts submitted while a local agent turn is active.
 // ABOUTME: The queued prompt must wait for readiness and then run exactly once.
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { createDeferredPromptQueue } from "../../bin/happy-bridge/happy-layer.mjs";
+import {
+  createDeferredPromptQueue,
+  isPromptBusyError,
+} from "../../bin/happy-bridge/happy-layer.mjs";
 
 describe("Happy deferred prompt queue", () => {
   it("delivers a phone prompt once after the active provider turn becomes ready", async () => {
@@ -23,5 +28,35 @@ describe("Happy deferred prompt queue", () => {
 
     await expect(delivered).resolves.toBe(true);
     expect(sent).toEqual(["phone prompt"]);
+  });
+
+  it("defers on the busy error every runtime actually throws", () => {
+    // Read the sentences out of the runtimes rather than restating them, so a
+    // provider that words its message differently fails here instead of
+    // silently dropping the phone's prompt. #3145
+    const runtimes = [
+      "claude-runtime.mjs",
+      "acp-runtime.mjs",
+      "lmstudio-runtime.mjs",
+      "paired-runtime.mjs",
+      "providers.mjs",
+    ];
+    const thrown = runtimes.flatMap((file) => {
+      const source = readFileSync(
+        join(process.cwd(), "bin/browser-local", file),
+        "utf8",
+      );
+      return [...source.matchAll(/"(Another prompt is already active[^"]*)"/g)]
+        .map((match) => match[1]);
+    });
+
+    expect(thrown.length).toBe(runtimes.length);
+    for (const message of thrown) {
+      expect(isPromptBusyError(new Error(message))).toBe(true);
+    }
+
+    // Unrelated failures must still surface rather than being retried forever.
+    expect(isPromptBusyError(new Error("Session not found."))).toBe(false);
+    expect(isPromptBusyError("not an error")).toBe(false);
   });
 });

--- a/tests/unit/happy-remote-settings-ui.test.ts
+++ b/tests/unit/happy-remote-settings-ui.test.ts
@@ -31,3 +31,19 @@ describe("Happy Remote Access app discovery (#3127)", () => {
     expect(remoteSettings).toContain("void openExternalLink(store.url)");
   });
 });
+
+describe("Happy advertised-root consent (#3144)", () => {
+  it("derives roots from the same conversations the user sees checkboxes for", () => {
+    // The UI lists agent conversations. If the bridge discovers roots from a
+    // wider set, it advertises folders the user was never shown and cannot
+    // withdraw — a remote spawn into them still passes is_advertised_root.
+    expect(remoteSettings).toContain('listConversations({ kind: "agent" })');
+
+    const bridge = readFileSync(resolve("src-tauri/src/happy_bridge.rs"), "utf-8");
+    const call = bridge.match(
+      /list_conversations\(\s*app\.clone\(\),\s*([^,]+),/,
+    );
+    expect(call).not.toBeNull();
+    expect(call?.[1].trim()).toBe('Some("agent".to_string())');
+  });
+});


### PR DESCRIPTION
Fixes #3144, #3145. Both surfaced auditing the nine Happy bridge fixes that landed since v3.71.0.

## 1. Advertised roots ignored the consent UI (#3144)

`happy_bridge.rs:133` discovered roots with `kind: None`, so **chat** conversations contributed folders. `HappyRemoteSettings.tsx:124` lists `{ kind: "agent" }`.

A root that survives only through a chat conversation renders no checkbox, and `setAdvertisedRoots(saved.filter(...))` drops it from the display **without rewriting the store**. On restart the bridge rediscovers and advertises it, and `is_advertised_root` (`happy_bridge.rs:719`) validates against the unfiltered store — so a folder the UI presents as unshared stays spawnable from a paired phone.

Both sides now read the same conversation set.

## 2. LM Studio prompts silently dropped (#3145)

The deferred queue compared the busy error to one exact sentence:

```js
error.message === "Another prompt is already active for this session."
```

`claude-runtime`, `acp-runtime`, `paired-runtime` and `providers` throw exactly that. `lmstudio-runtime.mjs:1468` throws `"Another prompt is already active for this LM Studio session."` — so `shouldRetry` returned false and the prompt was discarded behind a `debug()` line. The phone showed it as sent and no reply ever arrived.

LM Studio sessions are in scope: the bridge attaches to any listed session in an advertised root with no agent-type filter (`HAPPY_AGENT_TYPES` gates spawn only). This is the failure #3134/#3135 set out to fix, left open for one provider.

The predicate is now extracted as `isPromptBusyError` and matched on shape.

## Tests

The prompt-queue test reads the thrown sentences **out of the five runtime sources** rather than restating them, so a provider that words its message differently fails the test instead of silently dropping prompts.

Both new tests fail without their fix:

```
× defers on the busy error every runtime actually throws
AssertionError: expected false to be true

× derives roots from the same conversations the user sees checkboxes for
```

With the fixes: vitest 2496 passed, cargo 937 passed, biome exit 0.

**Stated limitation:** neither fix was exercised against a live relay or a paired handset — I have no paired device here. The consent fix is verified at the call-site level and the LM Studio fix against the real runtime strings, but the end-to-end phone behaviour is unproven until someone runs it with a handset.

## Not fixed here

The same audit found further Happy issues that are not release-blocking and are filed separately for follow-up — provider events dropped before `source.subscribe()` attaches, pairing not cancelled on unmount, `subscribeToSupervisor()` returning no unsubscribe handle, and unbounded tool-call input on the wire.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
