### PR TITLE
fix(remote): correlate Happy provider turns

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -8,7 +8,11 @@ import os from "node:os";
 import { ApiClient, configuration } from "happy/lib";
 import nacl from "tweetnacl";
 
-import { translateNeutralEvent, composeApprovalNotification } from "./translate.mjs";
+import {
+  composeApprovalNotification,
+  createTurnCorrelator,
+  translateNeutralEvent,
+} from "./translate.mjs";
 import {
   isWithinAdvertisedRoots,
   validatePermissionResponse,
@@ -505,6 +509,7 @@ export function createHappyLayer({
   const terminatedSessions = createTerminatedSessionTracker();
   const pendingRequests = Object.create(null);
   const liveSessions = new Set();
+  const turnCorrelator = createTurnCorrelator();
 
   const sessionSummaries = new Map();
   let summariesFetchedAt = 0;
@@ -562,6 +567,7 @@ export function createHappyLayer({
       sessions.delete(sessionId);
       liveSessions.delete(sessionId);
       promptQueue.clear(sessionId);
+      turnCorrelator.clear(sessionId);
       delete pendingRequests[sessionId];
       sessionCreationPromises.delete(sessionId);
       await entry.client
@@ -771,7 +777,8 @@ export function createHappyLayer({
     const entry = await findOrCreateSession(event.sessionId, summary);
     if (!entry) return;
     const provider = summary?.agentType === "claude-code" ? "claude" : summary?.agentType ?? "codex";
-    for (const message of translateNeutralEvent(event, { provider })) {
+    const correlatedEvent = turnCorrelator.correlate(event);
+    for (const message of translateNeutralEvent(correlatedEvent, { provider })) {
       if (message.transport === "session") entry.client.sendSessionProtocolMessage(message.envelope);
       if (message.transport === "agent") entry.client.sendAgentMessage(message.provider, message.body);
     }
@@ -836,6 +843,7 @@ export function createHappyLayer({
       });
       if (!spawned?.sessionId) throw new Error("provider spawn returned no session");
       sessions.delete(pendingSessionId);
+      turnCorrelator.clear(pendingSessionId);
       pending.sessionId = spawned.sessionId;
       pending.summary = spawned;
       sessions.set(spawned.sessionId, pending);
@@ -887,6 +895,7 @@ export function createHappyLayer({
   async function discardPendingSpawn(pendingSessionId, pending) {
     sessions.delete(pendingSessionId);
     liveSessions.delete(pendingSessionId);
+    turnCorrelator.clear(pendingSessionId);
     delete pendingRequests[pendingSessionId];
     sessionCreationPromises.delete(pendingSessionId);
     await pending.client.close().catch(() => debug("failed to close abandoned Happy session"));
@@ -1036,6 +1045,7 @@ export function createHappyLayer({
       sourceSubscription?.();
       supervisorSubscription?.();
       promptQueue.close();
+      turnCorrelator.close();
       cancelPairing();
       await pairingAuthorizationPromise;
       // Awaited rather than fire-and-forget: the caller exits the process once

--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -1,6 +1,8 @@
 // ABOUTME: Translates provider-neutral session events into Happy wire messages.
 // ABOUTME: This module is pure apart from Happy's schema helper and performs no I/O.
 
+import { randomUUID } from "node:crypto";
+
 import { createEnvelope } from "@slopus/happy-wire";
 
 const AGENT_PROVIDER = "codex";
@@ -62,6 +64,77 @@ function acp(body) {
 
 function service(payload, text) {
   return eventEnvelope("agent", { t: "service", text }, payload, "service");
+}
+
+const ACTIVE_STATUSES = new Set(["prompting", "busy", "running"]);
+const TERMINAL_STATUSES = new Set([
+  "ready",
+  "idle",
+  "completed",
+  "error",
+  "terminated",
+]);
+const AGENT_SESSION_EVENTS = new Set([
+  "assistant-delta",
+  "diff-proposal-resolved",
+  "plan-update",
+  "permission-resolved",
+]);
+
+/**
+ * Happy requires every agent-originated session envelope to name its turn, but
+ * provider runtimes do not consistently include their native turn id on
+ * streamed events. Correlate one local id across the prompt attribution,
+ * response chunks, and terminal boundary without changing provider state.
+ *
+ * @param {{createTurnId?: () => string}} options
+ */
+export function createTurnCorrelator({ createTurnId = randomUUID } = {}) {
+  const activeTurns = new Map();
+
+  function correlate(event) {
+    if (!event || typeof event !== "object" || typeof event.sessionId !== "string") {
+      return event;
+    }
+    const payload = event.payload && typeof event.payload === "object" ? event.payload : {};
+    const suppliedTurn = stringValue(payload.turnId) || stringValue(payload.turn);
+    let turnId = suppliedTurn || activeTurns.get(event.sessionId);
+    const status = event.kind === "status" ? stringValue(payload.status) : "";
+    const startsTurn = event.kind === "user-message" || ACTIVE_STATUSES.has(status);
+    const needsTurn = startsTurn || AGENT_SESSION_EVENTS.has(event.kind) ||
+      event.kind === "turn-complete" || event.kind === "error";
+
+    if (event.kind === "user-message" && !suppliedTurn) {
+      turnId = createTurnId();
+    } else if (!turnId && needsTurn) {
+      turnId = createTurnId();
+    }
+    if (turnId && (startsTurn || needsTurn)) {
+      activeTurns.set(event.sessionId, turnId);
+    }
+
+    const correlated = turnId
+      ? { ...event, payload: { ...payload, turnId } }
+      : event;
+    if (
+      event.kind === "turn-complete" ||
+      event.kind === "error" ||
+      TERMINAL_STATUSES.has(status)
+    ) {
+      activeTurns.delete(event.sessionId);
+    }
+    return correlated;
+  }
+
+  return {
+    correlate,
+    clear(sessionId) {
+      activeTurns.delete(sessionId);
+    },
+    close() {
+      activeTurns.clear();
+    },
+  };
 }
 
 /**

--- a/tests/unit/happy-bridge-translate-happy.test.ts
+++ b/tests/unit/happy-bridge-translate-happy.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 // @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
 import {
   composeApprovalNotification,
+  createTurnCorrelator,
   translateNeutralEvent,
 } from "../../bin/happy-bridge/translate.mjs";
 
@@ -65,6 +66,38 @@ describe("neutral-to-Happy session translation", () => {
         payload: { text: "remote prompt", origin: "remote" },
       }),
     ).toEqual([]);
+  });
+
+  it("correlates a suppressed Happy prompt with its assistant response", () => {
+    let sequence = 0;
+    const correlator = createTurnCorrelator({
+      createTurnId: () => `turn-remote-${++sequence}`,
+    });
+    const remotePrompt = correlator.correlate({
+      kind: "user-message",
+      sessionId: "session-1",
+      payload: { text: "remote prompt", origin: "remote" },
+    });
+    const [turnStart] = translateNeutralEvent(correlator.correlate({
+      kind: "status",
+      sessionId: "session-1",
+      payload: { status: "prompting" },
+    }));
+    const [assistant] = translateNeutralEvent(correlator.correlate({
+      kind: "assistant-delta",
+      sessionId: "session-1",
+      payload: { text: "assistant response" },
+    }));
+    const [turnEnd] = translateNeutralEvent(correlator.correlate({
+      kind: "turn-complete",
+      sessionId: "session-1",
+      payload: { stopReason: "end_turn" },
+    }));
+
+    expect(translateNeutralEvent(remotePrompt)).toEqual([]);
+    expect(turnStart.envelope.turn).toBe("turn-remote-1");
+    expect(assistant.envelope.turn).toBe("turn-remote-1");
+    expect(turnEnd.envelope.turn).toBe("turn-remote-1");
   });
 
   it("bounds tool output for mobile while retaining more error context", () => {


### PR DESCRIPTION
Closes #3157

## Summary

- correlate one bridge-local turn ID across a Happy-originated prompt and its provider response
- keep the Happy-originated user attribution suppressed so the phone prompt still renders once
- clear correlation state on terminal, scope-removal, spawn cleanup, and bridge shutdown paths

## Root cause

Happy discards agent session envelopes that do not include a turn ID. The provider event stream emits assistant deltas and lifecycle events without native turn IDs, so the relay persisted those messages but the Happy client rejected them during normalization.

## Validation

- `pnpm exec vitest run tests/unit/happy*.test.ts` — 95 passed
- `pnpm exec vitest run` — 2,499 passed, 15 skipped
- `cargo test happy_bridge --lib` — 17 passed
- `pnpm check` — passed (existing unrelated warnings only)
- `pnpm build` — passed
- `pnpm build:provider-runtime` — passed

## Network path

Desktop UI → local Tauri Happy supervisor → embedded provider runtime → Happy `GET /v1/updates`, `GET /v1/machines`, `GET /v1/sessions`, and `GET/POST /v3/sessions/:sessionId/messages`. No Seren publisher slug participates in this runtime path.

A live no-mock macOS Desktop ↔ Happy walkthrough will be recorded before merge.