### PR TITLE
docs(release): require a live Happy walkthrough before tagging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,10 +162,33 @@ Before cutting ANY new release tag, you MUST run a full audit:
 2. Audit embedded runtime discovery (platform subdirs, PATH construction in `embedded_runtime.rs`).
 3. Check for resource leaks, race conditions, and silent failures.
 4. **Verify embedded tool invocations actually execute** — don't just check paths exist; run `node --version`, `npm install`, and the agent binary against the embedded runtime end-to-end.
-5. File GitHub tickets in `serenorg/seren-desktop` for any bugs found.
-6. Fix critical/high bugs BEFORE tagging the release.
+5. **Run the live Happy remote walkthrough** (see below). REQUIRED whenever the tag contains any change under `bin/happy-bridge/`, `src-tauri/src/happy_bridge.rs`, `src/components/settings/HappyRemoteSettings.tsx`, or the provider event path they consume.
+6. File GitHub tickets in `serenorg/seren-desktop` for any bugs found.
+7. Fix critical/high bugs BEFORE tagging the release.
 
 NEVER tag a release without completing this audit. No exceptions.
+
+### Live Happy remote walkthrough (REQUIRED)
+
+Reading the bridge code does not surface how a turn actually renders on the phone. #3157 (assistant replies never rendered) and #3159 (one reply split into five bubbles) both reached `main` under a passing unit suite and a completed code audit; both were caught only by driving a real Happy client. Unit tests bound the translator's inputs — they cannot observe the wire.
+
+Run against the REAL app and a REAL paired Happy client. A mocked relay does not satisfy this gate.
+
+1. Launch the real desktop build for the candidate commit and pair a Happy client.
+2. Open a fresh coding-agent thread so the session history is short.
+3. From the Happy client, send a prompt demanding an exact response, e.g.
+   `Reply with exactly TAGCHECK-<version> and nothing else.`
+4. Let the turn complete, then reload the Happy session.
+
+Pass criteria — ALL must hold:
+
+- Desktop shows the prompt exactly once and the reply exactly once.
+- Happy shows the prompt exactly once and the reply exactly once, **after reload as well as live**.
+- The reply is **one** message, not one bubble per streamed delta.
+- Sending a second prompt while the first turn is still running queues it — it is neither dropped nor interleaved.
+- Only folders shown as shared in Settings are reachable from the client.
+
+Record the observed counts in the release notes or the audit ticket. "The relay sequence advanced" is NOT evidence a reply rendered — verify what the client displays.
 
 ## Version Control
 


### PR DESCRIPTION
Makes the live Happy remote walkthrough a standing pre-tag gate, per Taariq.

## Why

Two P1s reached `main` during the v3.72.0 window under a **green unit suite and a completed pre-release code audit**:

- **#3157** — a phone prompt executed in Desktop but the assistant reply never rendered in Happy.
- **#3159** — the reply arrived but was split into one bubble per provider delta.

Both were found only by driving a real Happy client. This is a structural gap, not bad luck: the bridge's unit tests bound the translator's *inputs*, and no unit test can observe what the client actually renders. My own audit of this surface swept the code, verified the patched runtime ships, and confirmed session teardown — and still saw neither bug.

## What this adds

A required audit step, scoped to tags that touch `bin/happy-bridge/`, `happy_bridge.rs`, `HappyRemoteSettings.tsx`, or the provider event path — with pass criteria specific enough to fail on:

- prompt and reply each rendered exactly once, **live and after reload**
- the reply is **one** message, not one bubble per streamed delta (catches #3159)
- a second prompt mid-turn queues rather than dropping or interleaving
- only folders shown as shared in Settings are reachable

It also records that *"the relay sequence advanced"* is not evidence a reply rendered — that inference is precisely what let #3157 through.

## Scope and honesty

This codifies a **manual** gate. The desktop half is automatable through the existing `tests/validation/scenarios` harness, but acting as the Happy client needs an authenticated relay identity, and I did not want to ship an automated walkthrough I could not verify without a paired device — a gate that looks green while proving nothing is worse than a documented manual step, and is the exact failure mode CLAUDE.md's no-mocks rule exists to prevent.

Automating the client half is worthwhile follow-up.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
