### PR TITLE
fix(remote): coalesce Happy assistant deltas

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -10,6 +10,7 @@ import nacl from "tweetnacl";
 
 import {
   composeApprovalNotification,
+  createAssistantMessageCoalescer,
   createTurnCorrelator,
   translateNeutralEvent,
 } from "./translate.mjs";
@@ -510,6 +511,7 @@ export function createHappyLayer({
   const pendingRequests = Object.create(null);
   const liveSessions = new Set();
   const turnCorrelator = createTurnCorrelator();
+  const assistantMessageCoalescer = createAssistantMessageCoalescer();
 
   const sessionSummaries = new Map();
   let summariesFetchedAt = 0;
@@ -568,6 +570,7 @@ export function createHappyLayer({
       liveSessions.delete(sessionId);
       promptQueue.clear(sessionId);
       turnCorrelator.clear(sessionId);
+      assistantMessageCoalescer.clear(sessionId);
       delete pendingRequests[sessionId];
       sessionCreationPromises.delete(sessionId);
       await entry.client
@@ -778,9 +781,11 @@ export function createHappyLayer({
     if (!entry) return;
     const provider = summary?.agentType === "claude-code" ? "claude" : summary?.agentType ?? "codex";
     const correlatedEvent = turnCorrelator.correlate(event);
-    for (const message of translateNeutralEvent(correlatedEvent, { provider })) {
-      if (message.transport === "session") entry.client.sendSessionProtocolMessage(message.envelope);
-      if (message.transport === "agent") entry.client.sendAgentMessage(message.provider, message.body);
+    for (const publishableEvent of assistantMessageCoalescer.consume(correlatedEvent)) {
+      for (const message of translateNeutralEvent(publishableEvent, { provider })) {
+        if (message.transport === "session") entry.client.sendSessionProtocolMessage(message.envelope);
+        if (message.transport === "agent") entry.client.sendAgentMessage(message.provider, message.body);
+      }
     }
     if (terminal) {
       await completeTerminalSession({
@@ -844,6 +849,7 @@ export function createHappyLayer({
       if (!spawned?.sessionId) throw new Error("provider spawn returned no session");
       sessions.delete(pendingSessionId);
       turnCorrelator.clear(pendingSessionId);
+      assistantMessageCoalescer.clear(pendingSessionId);
       pending.sessionId = spawned.sessionId;
       pending.summary = spawned;
       sessions.set(spawned.sessionId, pending);
@@ -896,6 +902,7 @@ export function createHappyLayer({
     sessions.delete(pendingSessionId);
     liveSessions.delete(pendingSessionId);
     turnCorrelator.clear(pendingSessionId);
+    assistantMessageCoalescer.clear(pendingSessionId);
     delete pendingRequests[pendingSessionId];
     sessionCreationPromises.delete(pendingSessionId);
     await pending.client.close().catch(() => debug("failed to close abandoned Happy session"));
@@ -1046,6 +1053,7 @@ export function createHappyLayer({
       supervisorSubscription?.();
       promptQueue.close();
       turnCorrelator.close();
+      assistantMessageCoalescer.close();
       cancelPairing();
       await pairingAuthorizationPromise;
       // Awaited rather than fire-and-forget: the caller exits the process once

--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -138,6 +138,79 @@ export function createTurnCorrelator({ createTurnId = randomUUID } = {}) {
 }
 
 /**
+ * Provider `assistant-delta` events are stream fragments, while Happy text
+ * envelopes are complete chat messages. Buffer contiguous fragments so one
+ * provider response does not become one mobile bubble per token.
+ *
+ * @param {{createMessageId?: () => string}} options
+ */
+export function createAssistantMessageCoalescer({ createMessageId = randomUUID } = {}) {
+  const pending = new Map();
+
+  function flush(sessionId) {
+    const buffered = pending.get(sessionId);
+    if (!buffered) return [];
+    pending.delete(sessionId);
+    return [{
+      ...buffered.event,
+      payload: {
+        ...buffered.payload,
+        text: buffered.text,
+        messageId: buffered.messageId,
+      },
+    }];
+  }
+
+  function consume(event) {
+    if (!event || typeof event !== "object" || typeof event.sessionId !== "string") {
+      return [];
+    }
+    const payload = event.payload && typeof event.payload === "object" ? event.payload : {};
+    if (event.kind !== "assistant-delta") {
+      return [...flush(event.sessionId), event];
+    }
+
+    const text = stringValue(payload.text);
+    if (!text) return [];
+    const suppliedMessageId = stringValue(payload.messageId);
+    const turnId = stringValue(payload.turnId) || stringValue(payload.turn);
+    const isThought = payload.isThought === true;
+    const buffered = pending.get(event.sessionId);
+    const sameMessage = buffered &&
+      buffered.turnId === turnId &&
+      buffered.isThought === isThought &&
+      (!suppliedMessageId || buffered.suppliedMessageId === suppliedMessageId);
+
+    const flushed = sameMessage ? [] : flush(event.sessionId);
+    if (sameMessage) {
+      buffered.text += text;
+      buffered.payload = payload;
+    } else {
+      pending.set(event.sessionId, {
+        event,
+        payload,
+        text,
+        turnId,
+        isThought,
+        suppliedMessageId,
+        messageId: suppliedMessageId || createMessageId(),
+      });
+    }
+    return flushed;
+  }
+
+  return {
+    consume,
+    clear(sessionId) {
+      pending.delete(sessionId);
+    },
+    close() {
+      pending.clear();
+    },
+  };
+}
+
+/**
  * Convert exactly one neutral event. The returned list is deliberate: a
  * completion can carry both a turn boundary and usage metadata.
  *

--- a/tests/unit/happy-bridge-translate-happy.test.ts
+++ b/tests/unit/happy-bridge-translate-happy.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 // @ts-expect-error — the bridge seam is plain ESM and has no generated declarations.
 import {
   composeApprovalNotification,
+  createAssistantMessageCoalescer,
   createTurnCorrelator,
   translateNeutralEvent,
 } from "../../bin/happy-bridge/translate.mjs";
@@ -73,30 +74,40 @@ describe("neutral-to-Happy session translation", () => {
     const correlator = createTurnCorrelator({
       createTurnId: () => `turn-remote-${++sequence}`,
     });
+    const coalescer = createAssistantMessageCoalescer({
+      createMessageId: () => "message-remote-1",
+    });
     const remotePrompt = correlator.correlate({
       kind: "user-message",
       sessionId: "session-1",
       payload: { text: "remote prompt", origin: "remote" },
     });
-    const [turnStart] = translateNeutralEvent(correlator.correlate({
+    const [turnStartEvent] = coalescer.consume(correlator.correlate({
       kind: "status",
       sessionId: "session-1",
       payload: { status: "prompting" },
     }));
-    const [assistant] = translateNeutralEvent(correlator.correlate({
-      kind: "assistant-delta",
-      sessionId: "session-1",
-      payload: { text: "assistant response" },
-    }));
-    const [turnEnd] = translateNeutralEvent(correlator.correlate({
+    for (const text of ["TURN", "315", "7", "FIX", "ED"]) {
+      expect(coalescer.consume(correlator.correlate({
+        kind: "assistant-delta",
+        sessionId: "session-1",
+        payload: { text },
+      }))).toEqual([]);
+    }
+    const [assistantEvent, turnEndEvent] = coalescer.consume(correlator.correlate({
       kind: "turn-complete",
       sessionId: "session-1",
       payload: { stopReason: "end_turn" },
     }));
+    const [turnStart] = translateNeutralEvent(turnStartEvent);
+    const [assistant] = translateNeutralEvent(assistantEvent);
+    const [turnEnd] = translateNeutralEvent(turnEndEvent);
 
     expect(translateNeutralEvent(remotePrompt)).toEqual([]);
     expect(turnStart.envelope.turn).toBe("turn-remote-1");
     expect(assistant.envelope.turn).toBe("turn-remote-1");
+    expect(assistant.envelope.id).toBe("message-remote-1");
+    expect(assistant.envelope.ev.text).toBe("TURN3157FIXED");
     expect(turnEnd.envelope.turn).toBe("turn-remote-1");
   });
 


### PR DESCRIPTION
Closes #3159

## Summary

- buffer contiguous provider assistant deltas per Happy session
- publish one complete Happy text envelope with a stable message ID at the next event boundary
- preserve turn correlation, thought/tool boundaries, and clear buffered state on session cleanup and bridge shutdown

## Root cause

The provider runtime emits streamed assistant chunks, but Happy text envelopes represent complete chat messages. Publishing every chunk as an envelope caused the mobile client to render one bubble per token. Reusing one message ID is not sufficient because Happy deduplicates envelopes by ID rather than appending them.

## Validation

- `pnpm exec vitest run tests/unit/happy*.test.ts` — 95 passed
- `pnpm exec vitest run` — 2,499 passed, 15 skipped
- `cargo test happy_bridge --lib` — 17 passed
- `pnpm check` — passed (existing unrelated warnings only)
- `pnpm build` — passed
- `pnpm build:provider-runtime` — passed
- one unrelated full-suite timeout passed both in isolation and in the clean full rerun

## Network path

Desktop UI → local Tauri Happy supervisor → embedded provider runtime → Happy `GET /v1/updates`, `GET /v1/machines`, `GET /v1/sessions`, and `GET/POST /v3/sessions/:sessionId/messages`. No Seren publisher slug participates in this runtime path.

A live no-mock macOS Desktop ↔ Happy walkthrough will be recorded before merge.