### PR TITLE
test(skills): stop the payload-status suite timing out under load

### DIFF
--- a/tests/unit/skill-payload-status.test.ts
+++ b/tests/unit/skill-payload-status.test.ts
@@ -104,7 +104,11 @@ function installedSkill(slug: string, overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe("skill-install race fix (#1917)", () => {
+// Each case re-imports the store and parser after resetModules(), so the work
+// is a full module-graph load rather than the assertion. On a loaded machine
+// that exceeded the 5s default and failed the suite for a reason unrelated to
+// what is being tested.
+describe("skill-install race fix (#1917)", { timeout: 30_000 }, () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();


### PR DESCRIPTION
Fixes a flake that failed `pnpm test` on `main` twice tonight.

## Symptom

```
× matchSkillCommand returns null for a skill flagged payloadStatus='failed'  5094ms
× matchSkillCommand returns null for a skill flagged payloadStatus='failed'  5101ms
```

Both failures landed at ~5.1s — vitest's 5s default — while three agents and a 3-OS build matrix were saturating the machine. The same test passes 4/4 in isolation.

## Cause

Not a product race. The suite is fully mocked, with no real I/O or concurrency. `beforeEach` calls `vi.resetModules()`, so every case re-imports the skills store and the command parser and pays a full module-graph load. The first case after a reset absorbs the worst of it, which is why only that one trips.

The elapsed time is therefore import cost, not the behaviour under test — so the default budget is measuring the wrong thing.

## Change

Raises the suite budget to 30s. No assertion is touched, and nothing is skipped or weakened.

Verified on a quiet machine: 5 passed. Full suite on `main` with the fix: 2499 passed.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com