### PR TITLE
fix(agent): state the Windows shell gap and close Grok policy holes (#3149, #3154)

### DIFF
--- a/bin/browser-local/agent-registry.mjs
+++ b/bin/browser-local/agent-registry.mjs
@@ -422,6 +422,7 @@ const CLI_INSTALL_INSTRUCTIONS = {
   "@anthropic-ai/claude-code":
     "https://code.claude.com/docs/en/installation",
   "@openai/codex": "https://developers.openai.com/codex/cli/",
+  "@xai-official/grok": "https://docs.x.ai/build/overview",
 };
 
 function emitCliActionRequired(
@@ -969,7 +970,27 @@ export function createBrowserLocalAgentRegistry({ emit }) {
           packageName: "@xai-official/grok",
           label: "Grok",
         });
-        return resolveGrokBinary();
+        const installed = resolveGrokBinary();
+        if (installed !== "grok") {
+          return installed;
+        }
+        // A user-managed grok outside the paths resolveGrokBinary knows is
+        // still spawnable, so PATH decides before we give up.
+        if (await isCommandAvailable("grok")) {
+          return "grok";
+        }
+        // Returning the bare command here spawned an ENOENT that surfaced as
+        // "Grok agent stopped before request completed", which says nothing
+        // about a missing install. Mirrors Claude/Codex. #3154
+        const url = emitCliActionRequired(emit, {
+          label: "Grok",
+          bareCommand: "grok",
+          packageName: "@xai-official/grok",
+          reason: "installation_required",
+        });
+        throw new Error(
+          `Grok CLI is not installed in a verifiable location. Install it from ${url}, then retry.`,
+        );
       },
       launchLogin() {
         const resolved = resolveGrokBinary();
@@ -1191,3 +1212,8 @@ export function createBrowserLocalAgentRegistry({ emit }) {
     },
   };
 }
+
+// Exported for regression tests. A package missing from this map makes its
+// ensureCli failure interpolate `undefined` in place of the install URL,
+// which is the unhelpful error #3154 was filed about.
+export { CLI_INSTALL_INSTRUCTIONS as _CLI_INSTALL_INSTRUCTIONS };

--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -1121,6 +1121,20 @@ function buildClaudeArgs({
   return args;
 }
 
+// Companion to buildClaudeArgs: clears the Windows temp files it materializes
+// for --mcp-config and --settings. Every launch outcome has to route here.
+// Node emits "error" for a process that never started and may never emit
+// "exit", so binding cleanup to "exit" alone stranded one file per failed
+// launch. #3154
+function removeClaudeArgsTempFiles(args) {
+  for (const tempFile of [args?._mcpTempFile, args?._policyTempFile]) {
+    if (!tempFile) continue;
+    try {
+      unlinkSync(tempFile);
+    } catch {}
+  }
+}
+
 function quoteHookArgument(value) {
   const text = String(value);
   if (process.platform === "win32") {
@@ -1172,6 +1186,15 @@ function buildClaudePolicySettings({ cwd, sandboxMode, networkEnabled }) {
 
   // Claude's native sandbox constrains Bash subprocesses on macOS/Linux.
   // Built-in file tools are independently constrained by the hook above.
+  //
+  // Native Windows gets no Bash boundary at all. The sandbox is built on
+  // Seatbelt (macOS) and bubblewrap (Linux/WSL2); upstream states native
+  // Windows is unsupported, so emitting these keys there configures nothing.
+  // The only Windows-viable alternative is matching file paths out of
+  // arbitrary shell strings in the PreToolUse hook, which any indirection
+  // (`cat $(printf ...)`) defeats — a boundary that reads as real while
+  // failing open is worse than a stated gap, so Settings → Agent says
+  // plainly that shell commands are unbounded on Windows. #3149
   if (process.platform !== "win32") {
     settings.sandbox = {
       enabled: true,
@@ -2619,41 +2642,35 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         writeFileSync(claudeArgs._policyTempFile, policySettingsJson, "utf-8");
       }
 
-      const processHandle = spawn(
-        claudeBin,
-        claudeArgs,
-        {
-          cwd,
-          env: {
-            ...process.env,
-            ...mcpConfig.childEnv,
-            PATH: extendedPath,
-            SEREN_AGENT_PROJECT_ROOT: cwd,
-            SEREN_AGENT_SANDBOX_MODE: sandboxMode ?? "workspace-write",
-            SEREN_AGENT_APPROVAL_POLICY: approvalPolicy ?? "on-request",
-            SEREN_AGENT_AUTO_APPROVE_READS:
-              autoApproveReads === false ? "false" : "true",
-            SEREN_AGENT_NETWORK_ENABLED:
-              networkEnabled === false ? "false" : "true",
+      let processHandle;
+      try {
+        processHandle = spawn(
+          claudeBin,
+          claudeArgs,
+          {
+            cwd,
+            env: {
+              ...process.env,
+              ...mcpConfig.childEnv,
+              PATH: extendedPath,
+              SEREN_AGENT_PROJECT_ROOT: cwd,
+              SEREN_AGENT_SANDBOX_MODE: sandboxMode ?? "workspace-write",
+              SEREN_AGENT_APPROVAL_POLICY: approvalPolicy ?? "on-request",
+              SEREN_AGENT_AUTO_APPROVE_READS:
+                autoApproveReads === false ? "false" : "true",
+              SEREN_AGENT_NETWORK_ENABLED:
+                networkEnabled === false ? "false" : "true",
+            },
+            stdio: ["pipe", "pipe", "pipe"],
+            shell: resolveSpawnShell(claudeBin),
           },
-          stdio: ["pipe", "pipe", "pipe"],
-          shell: resolveSpawnShell(claudeBin),
-        },
-      );
+        );
+      } catch (spawnError) {
+        removeClaudeArgsTempFiles(claudeArgs);
+        throw spawnError;
+      }
 
-      // Clean up MCP config temp file when the process exits
-      if (claudeArgs._mcpTempFile) {
-        const tempFile = claudeArgs._mcpTempFile;
-        processHandle.on("exit", () => {
-          try { unlinkSync(tempFile); } catch {}
-        });
-      }
-      if (claudeArgs._policyTempFile) {
-        const tempFile = claudeArgs._policyTempFile;
-        processHandle.on("exit", () => {
-          try { unlinkSync(tempFile); } catch {}
-        });
-      }
+      processHandle.on("exit", () => removeClaudeArgsTempFiles(claudeArgs));
 
       // Declared before the error listener so the listener can identity-check
       // against this launch's session; assigned below once the record exists.
@@ -2674,6 +2691,10 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
         console.error(`${claudeLogPrefix} Spawn error: ${spawnError.message}`);
         sessions.delete(sessionId);
         void serenMcpProxy?.close();
+        // A process that never started may never emit "exit", so this launch's
+        // temp config files are cleared here or not at all. The orphan guard
+        // above keeps a replaced handle from clearing the live launch's. #3154
+        removeClaudeArgsTempFiles(claudeArgs);
         // macOS surfaces a wrong-arch binary as `errno: -86` / "Bad CPU type in
         // executable" (EBADARCH). It hits when a prior install dropped the wrong
         // slice (e.g. x86_64 claude on an arm64 Mac without Rosetta) and our
@@ -3301,6 +3322,7 @@ export {
   comparePickerEntries as _comparePickerEntries,
   resolveSpawnShell as _resolveSpawnShell,
   buildClaudeArgs as _buildClaudeArgs,
+  removeClaudeArgsTempFiles as _removeClaudeArgsTempFiles,
   buildClaudePolicySettings as _buildClaudePolicySettings,
   normalizeModelRecords as _normalizeModelRecords,
   buildSessionStatus as _buildSessionStatus,

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -11,6 +11,7 @@ import {
   Show,
 } from "solid-js";
 import { isBuiltinServer, isLocalServer } from "@/lib/mcp/types";
+import { isWindowsPlatform } from "@/lib/platform";
 import { type BuildInfo, getBuildInfo } from "@/services/buildInfo";
 import {
   getClaudeMemoryStatus,
@@ -1324,6 +1325,25 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
                 </For>
               </div>
             </div>
+
+            <Show
+              when={
+                isWindowsPlatform() &&
+                settingsState.app.agentSandboxMode !== "full-access"
+              }
+            >
+              <p class="m-0 py-3 border-b border-border text-[0.8rem] text-muted-foreground leading-normal">
+                <span class="font-medium text-foreground">
+                  On Windows this bounds the agent's file, search, and web tools
+                  only.
+                </span>{" "}
+                Shell commands are not bounded. Claude Code's operating-system
+                sandbox does not support native Windows, so a shell command the
+                agent runs can read and write anywhere your account can. Set
+                Approval Policy to Untrusted or On Failure to review each
+                command before it runs.
+              </p>
+            </Show>
 
             <div class="flex items-start justify-between gap-4 py-3 border-b border-border">
               <label class="flex flex-col gap-0.5 flex-1">

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -17,3 +17,18 @@ export function isMacPlatform(): boolean {
   const userAgent = navigator.userAgent ?? "";
   return /mac os x|macintosh|iphone|ipad|ipod/i.test(userAgent);
 }
+
+/**
+ * True when running on native Windows.
+ *
+ * Anchored on `Win32`/`Win64` so `Darwin` cannot match, with the same blank
+ * `navigator.platform` fallback as {@link isMacPlatform}. WSL2 runs a Linux
+ * webview and correctly reports false.
+ */
+export function isWindowsPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const platform = navigator.platform ?? "";
+  if (/^win/i.test(platform)) return true;
+  const userAgent = navigator.userAgent ?? "";
+  return /windows/i.test(userAgent);
+}

--- a/src/services/organization-policy.ts
+++ b/src/services/organization-policy.ts
@@ -92,10 +92,28 @@ export function allowsGeminiAgent(
   return policy?.allow_gemini_agent ?? true;
 }
 
+// Local agents that shipped before allow_grok_agent existed. An admin who set
+// every one of these to false expressed a lockdown they had no field to extend
+// to Grok, so Grok inherits that answer instead of appearing on upgrade with
+// workspace write access.
+function disabledEveryPriorLocalAgent(
+  policy: OrganizationPrivateModelsPolicy,
+): boolean {
+  return (
+    policy.allow_claude_agent === false &&
+    policy.allow_codex_agent === false &&
+    policy.allow_gemini_agent === false &&
+    policy.allow_lmstudio_agent === false
+  );
+}
+
 export function allowsGrokAgent(
   policy: OrganizationPrivateModelsPolicy | null | undefined,
 ): boolean {
-  return policy?.allow_grok_agent ?? true;
+  if (!policy) return true;
+  if (policy.allow_grok_agent !== undefined) return policy.allow_grok_agent;
+  if (policy.disable_local_agents) return false;
+  return !disabledEveryPriorLocalAgent(policy);
 }
 
 export function allowsLmStudioAgent(

--- a/tests/unit/agent-file-access-policy.test.ts
+++ b/tests/unit/agent-file-access-policy.test.ts
@@ -2,9 +2,9 @@
 // ABOUTME: Preserves promptless in-project work while preventing silent boundary escapes.
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, symlinkSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, symlinkSync } from "node:fs";
 import os from "node:os";
-import path from "node:path";
+import path, { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 // @ts-ignore - browser-local runtime is plain ESM.
@@ -154,6 +154,47 @@ describe("Claude promptless containment (#3091)", () => {
     expect(
       exceptional.hookSpecificOutput.permissionDecision,
     ).toBe("ask");
+  });
+});
+
+describe("Windows shell boundary gap is stated, not faked (#3149)", () => {
+  const settingsPanel = readFileSync(
+    resolve("src/components/settings/SettingsPanel.tsx"),
+    "utf8",
+  );
+  const claudeRuntime = readFileSync(
+    resolve("bin/browser-local/claude-runtime.mjs"),
+    "utf8",
+  );
+
+  it("keeps Bash out of the hook matcher, which cannot bound a shell string", () => {
+    // Claude's sandbox is the only layer that bounds Bash, and upstream does
+    // not run it on native Windows. Matching Bash here would mean parsing
+    // file arguments out of arbitrary shell commands — `cat $(printf ...)`
+    // walks straight past that, so the hook would fail open while reading as
+    // a real boundary. The gap is surfaced in Settings instead.
+    const settings = buildClaudePolicySettings({
+      cwd: tempProject(),
+      sandboxMode: "workspace-write",
+      networkEnabled: false,
+    });
+    expect(settings.hooks.PreToolUse[0].matcher).not.toContain("Bash");
+    if (process.platform === "win32") {
+      expect(settings.sandbox).toBeUndefined();
+    }
+    expect(claudeRuntime).toContain("#3149");
+  });
+
+  it("tells Windows users their shell commands are unbounded", () => {
+    // Without this the feature advertises containment it does not deliver on
+    // Windows. The note must be platform-gated so macOS and Linux, where the
+    // sandbox does bound Bash, are not told otherwise.
+    expect(settingsPanel).toContain("isWindowsPlatform");
+    const noteAt = settingsPanel.indexOf("Shell commands are not bounded");
+    expect(noteAt).toBeGreaterThan(-1);
+    const gateAt = settingsPanel.lastIndexOf("isWindowsPlatform()", noteAt);
+    expect(gateAt).toBeGreaterThan(-1);
+    expect(settingsPanel.slice(gateAt, noteAt)).not.toContain("</Show>");
   });
 });
 

--- a/tests/unit/claude-policy-temp-file-cleanup.test.ts
+++ b/tests/unit/claude-policy-temp-file-cleanup.test.ts
@@ -1,0 +1,81 @@
+// ABOUTME: Guards the Windows --settings/--mcp-config temp files against per-launch leaks (#3154).
+// ABOUTME: A spawn that never starts emits "error" without "exit", so both must clear them.
+
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const claudeModulePath = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const { _removeClaudeArgsTempFiles: removeClaudeArgsTempFiles } = await import(
+  /* @vite-ignore */ claudeModulePath
+);
+const claudeRuntime = readFileSync(
+  resolve("bin/browser-local/claude-runtime.mjs"),
+  "utf8",
+);
+
+describe("Claude temp settings cleanup (#3154)", () => {
+  it("removes both temp config files from disk", () => {
+    const root = mkdtempSync(join(tmpdir(), "seren-claude-temp-"));
+    const mcpTempFile = join(root, "seren-mcp-session.json");
+    const policyTempFile = join(root, "seren-policy-session.json");
+    writeFileSync(mcpTempFile, "{}", "utf-8");
+    writeFileSync(policyTempFile, "{}", "utf-8");
+
+    removeClaudeArgsTempFiles({
+      _mcpTempFile: mcpTempFile,
+      _policyTempFile: policyTempFile,
+    });
+
+    expect(existsSync(mcpTempFile)).toBe(false);
+    expect(existsSync(policyTempFile)).toBe(false);
+  });
+
+  it("tolerates already-removed files and the non-Windows shape", () => {
+    // On macOS and Linux the config is passed inline, so neither field is
+    // ever set. A respawn also unlinks the same paths twice.
+    const root = mkdtempSync(join(tmpdir(), "seren-claude-temp-"));
+    expect(() => removeClaudeArgsTempFiles({})).not.toThrow();
+    expect(() =>
+      removeClaudeArgsTempFiles({
+        _policyTempFile: join(root, "never-written.json"),
+      }),
+    ).not.toThrow();
+  });
+
+  it("clears the files on a spawn that never starts", () => {
+    // Binding cleanup to "exit" alone stranded one %TEMP%\\seren-policy-*.json
+    // per failed launch: Node emits "error" for a process that failed to
+    // spawn and may never emit "exit". A synchronous spawn throw skips the
+    // listeners entirely, so that path unlinks directly.
+    const launchAt = claudeRuntime.indexOf("const launchClaudeProcess = ()");
+    expect(launchAt).toBeGreaterThan(-1);
+    const region = claudeRuntime.slice(launchAt, launchAt + 4000);
+
+    expect(region).toMatch(
+      /catch \(spawnError\) \{\s*removeClaudeArgsTempFiles\(claudeArgs\);\s*throw spawnError;/,
+    );
+    expect(region).toContain(
+      'processHandle.on("exit", () => removeClaudeArgsTempFiles(claudeArgs))',
+    );
+
+    // The "error" path cleans up inside the existing #2470-guarded listener,
+    // after the orphan check, so a replaced handle cannot clear the live
+    // launch's files. A second listener here would also shadow the #2470
+    // regression guard, which anchors on the first processHandle.on("error").
+    const errorAt = region.indexOf('processHandle.on("error"');
+    expect(errorAt).toBeGreaterThan(-1);
+    expect(region.indexOf('processHandle.on("error"', errorAt + 1)).toBe(-1);
+    const guardAt = region.indexOf("sessions.get(sessionId) !== launchedSession");
+    const cleanupAt = region.indexOf(
+      "removeClaudeArgsTempFiles(claudeArgs)",
+      errorAt,
+    );
+    expect(guardAt).toBeGreaterThan(errorAt);
+    expect(cleanupAt).toBeGreaterThan(guardAt);
+  });
+});

--- a/tests/unit/grok-agent.test.ts
+++ b/tests/unit/grok-agent.test.ts
@@ -10,6 +10,8 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+// @ts-ignore - browser-local runtime is plain ESM.
+import { _CLI_INSTALL_INSTRUCTIONS } from "../../bin/browser-local/agent-registry.mjs";
 import { resolveGrokBinary } from "../../bin/browser-local/grok-binary.mjs";
 import { describe, expect, it } from "vitest";
 
@@ -108,6 +110,39 @@ describe("Grok native ACP agent (#3084)", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("publishes official install instructions for the Grok package (#3154)", () => {
+    // emitCliActionRequired reads this map. A missing entry interpolates
+    // `undefined` into the thrown message and leaves the action-required
+    // event with no URL to open.
+    const url = _CLI_INSTALL_INSTRUCTIONS["@xai-official/grok"];
+    expect(url).toBe("https://docs.x.ai/build/overview");
+    expect(() => new URL(url)).not.toThrow();
+    expect(new URL(url).protocol).toBe("https:");
+  });
+
+  it("reports a missing install instead of spawning a bare command (#3154)", () => {
+    // Returning "grok" when nothing resolved produced a spawn ENOENT that
+    // reached the user as "Grok agent stopped before request completed",
+    // which says nothing about a missing install. Mirrors Claude/Codex.
+    const start = registrySource.indexOf("    grok: {");
+    const end = registrySource.indexOf("    lmstudio: {", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const ensureCli = registrySource.slice(
+      registrySource.indexOf("async ensureCli()", start),
+      end,
+    );
+
+    expect(ensureCli).toContain("emitCliActionRequired");
+    expect(ensureCli).toContain('packageName: "@xai-official/grok"');
+    expect(ensureCli).toContain('reason: "installation_required"');
+    expect(ensureCli).toMatch(/throw new Error\(/);
+    expect(ensureCli).toContain("Install it from ${url}");
+    // A user-managed grok on PATH sits outside every path the resolver
+    // knows; it must still spawn rather than hit the throw.
+    expect(ensureCli).toContain('isCommandAvailable("grok")');
   });
 
   it("routes Grok through the registry, runtime dispatcher, and public agent type", () => {

--- a/tests/unit/organization-policy-grok-default.test.ts
+++ b/tests/unit/organization-policy-grok-default.test.ts
@@ -1,0 +1,99 @@
+// ABOUTME: Guards the allow_grok_agent default against reopening a closed org (#3154).
+// ABOUTME: A field an admin never had cannot be read as consent to a new agent.
+
+import { describe, expect, it } from "vitest";
+import {
+  allowsGrokAgent,
+  type OrganizationPrivateModelsPolicy,
+} from "@/services/organization-policy";
+
+function policy(
+  overrides: Partial<OrganizationPrivateModelsPolicy>,
+): OrganizationPrivateModelsPolicy {
+  return {
+    organization_id: "org_test",
+    mode: "standard",
+    deployment_id: null,
+    disable_seren_models: false,
+    disable_local_agents: false,
+    disable_external_model_providers: false,
+    hide_model_picker: false,
+    session_database: null,
+    private_output_policy: "control_plane",
+    updated_at: "2026-07-21T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("allowsGrokAgent (#3154)", () => {
+  it("stays open for orgs that never restricted local agents", () => {
+    expect(allowsGrokAgent(null)).toBe(true);
+    expect(allowsGrokAgent(undefined)).toBe(true);
+    expect(allowsGrokAgent(policy({}))).toBe(true);
+  });
+
+  it("honors an explicit allow_grok_agent in both directions", () => {
+    expect(allowsGrokAgent(policy({ allow_grok_agent: true }))).toBe(true);
+    expect(allowsGrokAgent(policy({ allow_grok_agent: false }))).toBe(false);
+  });
+
+  it("keeps an explicit opt-in above the inferred lockdown", () => {
+    // An admin who names Grok has answered for it; the inference below only
+    // fills in for the field they never had.
+    expect(
+      allowsGrokAgent(
+        policy({
+          allow_grok_agent: true,
+          allow_claude_agent: false,
+          allow_codex_agent: false,
+          allow_gemini_agent: false,
+          allow_lmstudio_agent: false,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not appear on upgrade for an org that closed every prior local agent", () => {
+    // The upgrade path from #3154: on v3.71.0 this org saw zero local coding
+    // agents. Defaulting the new field to true handed them a Grok launcher
+    // with workspace write access, and allow_grok_agent did not exist yet so
+    // there was no way to pre-set it.
+    expect(
+      allowsGrokAgent(
+        policy({
+          allow_claude_agent: false,
+          allow_codex_agent: false,
+          allow_gemini_agent: false,
+          allow_lmstudio_agent: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("honors disable_local_agents the way LM Studio does", () => {
+    expect(allowsGrokAgent(policy({ disable_local_agents: true }))).toBe(false);
+  });
+
+  it("stays open when the org left any prior local agent enabled", () => {
+    // A partial restriction is a choice about those agents, not a lockdown.
+    expect(
+      allowsGrokAgent(
+        policy({
+          allow_claude_agent: false,
+          allow_codex_agent: false,
+          allow_gemini_agent: false,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      allowsGrokAgent(
+        policy({
+          allow_claude_agent: false,
+          allow_codex_agent: false,
+          allow_gemini_agent: false,
+          allow_lmstudio_agent: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/platform.test.ts
+++ b/tests/unit/platform.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Pins the "macOS" lowercase case that broke mac-only keybindings.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isMacPlatform } from "@/lib/platform";
+import { isMacPlatform, isWindowsPlatform } from "@/lib/platform";
 
 function stubNavigator(platform: string, userAgent = ""): void {
   vi.stubGlobal("navigator", { platform, userAgent });
@@ -36,5 +36,40 @@ describe("isMacPlatform", () => {
   it("returns false when navigator is unavailable", () => {
     vi.stubGlobal("navigator", undefined);
     expect(isMacPlatform()).toBe(false);
+  });
+});
+
+describe("isWindowsPlatform", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("matches the platforms WebView2 reports", () => {
+    for (const platform of ["Win32", "Win64", "Windows"]) {
+      stubNavigator(platform, "Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+      expect(isWindowsPlatform()).toBe(true);
+    }
+  });
+
+  it("falls back to userAgent when platform is blank", () => {
+    stubNavigator("", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+    expect(isWindowsPlatform()).toBe(true);
+  });
+
+  it("does not match Darwin on the trailing 'win'", () => {
+    stubNavigator("Darwin", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+    expect(isWindowsPlatform()).toBe(false);
+  });
+
+  it("reports false for the Mac and Linux webviews", () => {
+    stubNavigator("MacIntel", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+    expect(isWindowsPlatform()).toBe(false);
+    stubNavigator("Linux x86_64", "Mozilla/5.0 (X11; Linux x86_64)");
+    expect(isWindowsPlatform()).toBe(false);
+  });
+
+  it("returns false when navigator is unavailable", () => {
+    vi.stubGlobal("navigator", undefined);
+    expect(isWindowsPlatform()).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #3149, fixes #3154.

## #3149 — Windows shell boundary

**I did not add `Bash` to the hook matcher, deliberately.** Verified against [Claude Code's sandboxing docs](https://code.claude.com/docs/en/sandboxing): *"supports macOS, Linux, and WSL2. WSL1 and native Windows are not supported."* The `process.platform !== "win32"` guard is therefore correct — emitting sandbox keys on Windows would configure nothing.

The only Windows-viable alternative was parsing file paths out of arbitrary shell strings, which `cat $(printf ...)` walks straight past. A boundary that reads as real while failing open is worse than a stated gap.

So Settings now states the gap, gated to Windows and hidden on Full Access, and points at Approval Policy — a *real* remedy, since `claudeModeFromApprovalPolicy` maps Untrusted/On Failure to `acceptEdits` rather than `bypassPermissions`, making shell commands prompt.

**What this guarantees on Windows:** the built-in file, search and web tools are bounded by the PreToolUse hook. **What it does not:** shell commands are unbounded — a Bash command can read and write anywhere the account can, including the credential stores `SANDBOX_DENY_READ_PATHS` protects elsewhere. `networkEnabled: false` has the same shape — the hook denies WebFetch/WebSearch, but `curl` in Bash is unaffected.

#3143's `failIfUnavailable: false` and scoped `denyRead` are untouched.

## #3154 — Grok policy holes

- **Policy default.** `allowsGrokAgent` now resolves explicit `allow_grok_agent` first, then honors `disable_local_agents` as LM Studio does, then closes only when an org set claude/codex/gemini/lmstudio *all* to `false` — an admin who expressed a total lockdown they had no field to extend to Grok. Partial restrictions and unrestricted orgs are unaffected, so this closes exactly the upgrade path in the issue.
- **Install error.** `grok.ensureCli()` falls back to a PATH install, then emits the action-required event and throws with the official install URL, instead of surfacing later as "Grok agent stopped before request completed."
- **Temp file leak.** The Windows policy settings file is now removed when a spawn never starts. Folded into the existing guarded exit listener rather than a second `error` handler — a second listener silently broke `claude-initialize-timeout.test.ts`, whose #2470 guard anchors on the first.

## Verification

Negative control on every new test — each fails with its fix reverted:

| Fix | Reverted to | Failing test |
|---|---|---|
| #3149 note | block deleted | `tells Windows users their shell commands are unbounded` |
| #3149 gating | `<Show>` removed | same (gate assertion) |
| #3149 matcher | `Bash` added | `keeps Bash out of the hook matcher` |
| `isWindowsPlatform` | `/^win/i` → `/win/i` | `does not match Darwin on the trailing 'win'` |
| #3154 policy | `?? true` | upgrade-lockdown + `disable_local_agents` |
| #3154 install | bare resolve, URL dropped | 2 tests |
| #3154 temp file | exit-only / rethrow / no-op body | 3 tests |

Gates re-run by me on the rebased branch, not taken from the agent's report:

- `pnpm test` — **2517 passed**, 15 skipped, 0 failed
- `pnpm check` — **exit 0**
- `cargo test` — **938 passed**, 0 failed

## Noted, not fixed

`allowsClaudeAgent`, `allowsCodexAgent` and `allowsGeminiAgent` still ignore `disable_local_agents` — only LM Studio and now Grok honor it. Arguably a wider hole than the one filed, but fixing it would immediately lock out any org currently running those agents with the flag set. Out of scope here; worth a decision.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
