### PR TITLE
fix(remote): stop dropped events and silent bridge failures (#3150, #3151, #3153)

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -871,12 +871,14 @@ export function createHappyLayer({
     }
   }
 
-  // Registered from both the freshly-paired and already-paired startup paths.
-  // A single listener keeps `dispatchNotification`'s queueing behaviour intact —
-  // it stops queueing as soon as any listener exists, so adding a second one
-  // elsewhere would drop notifications this one is waiting for.
+  // Registered once, from `start()`, and torn down in `close()`. A single
+  // listener keeps `dispatchNotification`'s queueing behaviour intact — it stops
+  // queueing as soon as any listener exists, so adding a second one elsewhere
+  // would drop notifications this one is waiting for. It also has to stay
+  // attached across the pairing wait, which is exactly when `cancel_pairing`
+  // arrives. Returns the unsubscribe handle the caller stores.
   function subscribeToSupervisor() {
-    supervisorSubscription = supervisorChannel.onNotification((method, params) => {
+    return supervisorChannel.onNotification((method, params) => {
       if (method === "roots_update") {
         advertisedRoots = Array.isArray(params?.roots) ? params.roots : [];
         void (async () => {
@@ -961,7 +963,6 @@ export function createHappyLayer({
         identity = identityFromAuthResponse(result.token, decryptAuthResponse(result.response, keyPair.secretKey));
         await supervisorChannel.call("identity_store", { identity });
         await registerMachine();
-        supervisorSubscription = subscribeToSupervisor();
         await finishRegistration();
         return true;
       }
@@ -991,7 +992,11 @@ export function createHappyLayer({
       }
       return pairingPromise;
     }
-    pairingPromise = (async () => {
+    // Cancelling and immediately re-pairing leaves the abandoned attempt still
+    // settling. Releasing the slot is gated on this attempt still owning it, so
+    // an aborted attempt cannot clear its successor and let a third keypair be
+    // minted while the second is still polling.
+    const attempt = (async () => {
       const keyPair = nacl.box.keyPair();
       await postAuthRequest(config.relayUrl, keyPair.publicKey);
       const payload = `happy://terminal?${encodeBase64Url(keyPair.publicKey)}`;
@@ -999,12 +1004,15 @@ export function createHappyLayer({
       supervisorChannel.notify("pairing_payload", { payload });
       const abortController = new AbortController();
       pairingAbortController = abortController;
+      const releaseAttempt = () => {
+        if (pairingPromise === attempt) pairingPromise = null;
+      };
       pairingAuthorizationPromise = waitForAuthorization(keyPair, abortController.signal)
         .then((authorized) => {
-          if (!authorized) pairingPromise = null;
+          if (!authorized) releaseAttempt();
         })
         .catch((error) => {
-          pairingPromise = null;
+          releaseAttempt();
           if (error?.name !== "AbortError") {
             debug(`pairing authorization failed: ${error instanceof Error ? error.message : "unknown error"}`);
           }
@@ -1018,7 +1026,8 @@ export function createHappyLayer({
       void pairingAuthorizationPromise;
       return payload;
     })();
-    return pairingPromise;
+    pairingPromise = attempt;
+    return attempt;
   }
 
   async function finishRegistration() {
@@ -1043,8 +1052,6 @@ export function createHappyLayer({
         await finishRegistration();
         return;
       }
-      supervisorSubscription?.();
-      supervisorSubscription = null;
       return startPairing();
     },
     startPairing,

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -4,6 +4,7 @@
 import WebSocket from "ws";
 
 const RPC_TIMEOUT_MS = 30_000;
+const MAX_QUEUED_NOTIFICATIONS = 32;
 
 const PROVIDER_EVENT_KINDS = new Map([
   ["provider://message-chunk", "assistant-delta"],
@@ -74,6 +75,7 @@ class ProviderRuntimeClient {
     this.nextId = 0;
     this.pending = new Map();
     this.notificationListeners = new Set();
+    this.notificationQueue = [];
     this.onUnexpectedDisconnect = onUnexpectedDisconnect;
     this.intentionalClose = false;
     this.disconnectReported = false;
@@ -109,9 +111,7 @@ class ProviderRuntimeClient {
     }
 
     if (typeof message.method === "string") {
-      for (const listener of this.notificationListeners) {
-        listener(message.method, message.params ?? {});
-      }
+      this.dispatchNotification(message.method, message.params ?? {});
       return;
     }
 
@@ -127,8 +127,26 @@ class ProviderRuntimeClient {
     }
   }
 
+  // Registration attaches its subscriber only after several relay round trips.
+  // Discarding what arrives first lost the `prompt-complete` of a turn that was
+  // already running, leaving the queue for that session marked busy forever.
+  dispatchNotification(method, params) {
+    if (this.notificationListeners.size === 0) {
+      if (this.notificationQueue.length === MAX_QUEUED_NOTIFICATIONS) {
+        this.notificationQueue.shift();
+      }
+      this.notificationQueue.push({ method, params });
+      return;
+    }
+    for (const listener of this.notificationListeners) listener(method, params);
+  }
+
   subscribeNotifications(listener) {
     this.notificationListeners.add(listener);
+    while (this.notificationQueue.length > 0) {
+      const notification = this.notificationQueue.shift();
+      listener(notification.method, notification.params);
+    }
     return () => this.notificationListeners.delete(listener);
   }
 
@@ -156,6 +174,7 @@ class ProviderRuntimeClient {
     }
     this.pending.clear();
     this.notificationListeners.clear();
+    this.notificationQueue.length = 0;
     const socket = this.socket;
     this.socket = null;
     if (!socket || socket.readyState !== WebSocket.OPEN) return Promise.resolve();

--- a/bin/happy-bridge/translate.mjs
+++ b/bin/happy-bridge/translate.mjs
@@ -9,6 +9,7 @@ const AGENT_PROVIDER = "codex";
 const TOOL_OUTPUT_MAX_CHARS = 1_200;
 const TOOL_ERROR_MAX_CHARS = 6_000;
 const FILE_DIFF_MAX_CHARS = 2_000;
+const TOOL_INPUT_MAX_CHARS = 2_000;
 const MOBILE_TRUNCATION_MARKER = "\n… [truncated for Happy Mobile]";
 
 function stringValue(value, fallback = "") {
@@ -36,6 +37,21 @@ function boundedMobileText(value, maxChars) {
     prefix = prefix.slice(0, -1);
   }
   return `${prefix}${MOBILE_TRUNCATION_MARKER}`;
+}
+
+// Tool parameters carry whole file bodies — a `Write` call's content arrives
+// here in full. Every string is bounded in place so the argument shape the
+// phone renders survives, matching the limit already applied to the diff the
+// same write produces.
+function boundedToolInput(value) {
+  if (typeof value === "string") return boundedMobileText(value, TOOL_INPUT_MAX_CHARS);
+  if (Array.isArray(value)) return value.map(boundedToolInput);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, boundedToolInput(entry)]),
+    );
+  }
+  return value;
 }
 
 function summarizeFileContent(value) {
@@ -244,7 +260,7 @@ export function translateNeutralEvent(event, { provider = AGENT_PROVIDER } = {})
         type: "tool-call",
         callId: stringValue(payload.toolCallId, "unknown-call"),
         name: stringValue(payload.name, stringValue(payload.kind, "tool")),
-        input: payload.parameters ?? {},
+        input: boundedToolInput(payload.parameters ?? {}),
         id: stringValue(payload.toolCallId, "unknown-call"),
       }), provider }];
     case "tool-end":

--- a/src-tauri/src/commands/happy_bridge.rs
+++ b/src-tauri/src/commands/happy_bridge.rs
@@ -148,8 +148,7 @@ pub async fn happy_bridge_start_pairing(
 pub async fn happy_bridge_cancel_pairing(
     state: State<'_, HappyBridgeManager>,
 ) -> Result<(), String> {
-    state.cancel_pairing().await;
-    Ok(())
+    state.cancel_pairing().await
 }
 
 /// Stops the bridge before clearing the credential. The running process holds

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -17,7 +17,7 @@ pub const HAPPY_RELAY_URL: &str = "https://api.cluster-fluster.com";
 const MAX_RESTART_ATTEMPTS: u32 = 3;
 const MAX_BACKOFF_SECONDS: u64 = 30;
 const STOP_GRACE_PERIOD: Duration = Duration::from_secs(5);
-const SHUTDOWN_NOTIFY_TIMEOUT: Duration = Duration::from_millis(500);
+const SUPERVISOR_NOTIFY_TIMEOUT: Duration = Duration::from_millis(500);
 const KILL_LOCK_ATTEMPTS: u32 = 20;
 const KILL_LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
 const STATUS_EVENT: &str = "happy-bridge://status";
@@ -132,22 +132,15 @@ impl HappyBridgeManager {
         // Agent conversations only, matching the set HappyRemoteSettings renders
         // checkboxes for. Including chat conversations advertised roots the user
         // was never shown and could not withdraw. #3144
-        let discovered_roots = crate::commands::chat::list_conversations(
-            app.clone(),
-            Some("agent".to_string()),
-            None,
-            None,
-        )
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|conversation| conversation.project_root.or(conversation.agent_cwd))
-                .fold(Vec::<String>::new(), |mut roots, root| {
-                    if !roots.iter().any(|existing| existing == &root) {
-                        roots.push(root);
-                    }
-                    roots
-                });
+        let discovered_roots = discovered_project_roots(
+            crate::commands::chat::list_conversations(
+                app.clone(),
+                Some("agent".to_string()),
+                None,
+                None,
+            )
+            .await,
+        )?;
         let advertised_roots =
             crate::commands::happy_bridge::effective_advertised_roots(app, discovered_roots);
         let config = HappyBridgeConfig {
@@ -216,7 +209,7 @@ impl HappyBridgeManager {
             .map_err(|err| format!("Failed to flush Happy bridge config: {err}"))?;
 
         let stdin = Arc::new(Mutex::new(stdin));
-        write_supervisor_notification(
+        notify_supervisor(
             &stdin,
             json!({
                 "jsonrpc": "2.0",
@@ -224,7 +217,8 @@ impl HappyBridgeManager {
                 "params": { "roots": advertised_roots },
             }),
         )
-        .await;
+        .await
+        .map_err(|error| format!("Failed to advertise Happy project folders: {error}"))?;
         pipe_bridge_output(&mut child, Arc::clone(&stdin), app.clone());
         let mut guard = self.process.lock().await;
         // `stop()` can take the process slot while a start is still in flight.
@@ -303,7 +297,7 @@ impl HappyBridgeManager {
             };
             Arc::clone(&process._stdin)
         };
-        write_supervisor_notification(
+        notify_supervisor(
             &stdin,
             json!({
                 "jsonrpc": "2.0",
@@ -311,25 +305,26 @@ impl HappyBridgeManager {
                 "params": { "roots": roots },
             }),
         )
-        .await;
-        Ok(())
+        .await
     }
 
     /// Tells a running bridge to abandon an in-flight pairing wait, and drops any
     /// payload already minted so it cannot be handed out afterwards.
-    pub async fn cancel_pairing(&self) {
+    pub async fn cancel_pairing(&self) -> Result<(), String> {
         let stdin = {
             let guard = self.process.lock().await;
             guard.as_ref().map(|process| Arc::clone(&process._stdin))
         };
         *self.pairing_payload.lock().await = None;
-        if let Some(stdin) = stdin {
-            write_supervisor_notification(
-                &stdin,
-                json!({ "jsonrpc": "2.0", "method": "cancel_pairing" }),
-            )
-            .await;
-        }
+        // A bridge that never received the cancellation is still willing to
+        // authorize whoever scanned the code, so the caller has to hear about a
+        // failed write rather than see the dialog close on a lie.
+        let Some(stdin) = stdin else { return Ok(()) };
+        notify_supervisor(
+            &stdin,
+            json!({ "jsonrpc": "2.0", "method": "cancel_pairing" }),
+        )
+        .await
     }
 
     pub async fn wait_for_pairing_payload(&self) -> Result<String, String> {
@@ -594,14 +589,8 @@ async fn terminate_child(
     if let Some(stdin) = stdin {
         // Bounded: a wedged bridge that is not draining stdin must not stall the
         // stop path, which is exactly the deadlock the grace period exists for.
-        let _ = tokio::time::timeout(
-            SHUTDOWN_NOTIFY_TIMEOUT,
-            write_supervisor_notification(
-                stdin,
-                json!({ "jsonrpc": "2.0", "method": "shutdown" }),
-            ),
-        )
-        .await;
+        // The signal and kill fallbacks below cover a failed write.
+        let _ = notify_supervisor(stdin, json!({ "jsonrpc": "2.0", "method": "shutdown" })).await;
     }
 
     #[cfg(unix)]
@@ -731,6 +720,26 @@ fn is_advertised_root<R: tauri::Runtime>(app: &AppHandle<R>, cwd: &str) -> bool 
         .iter()
         .filter_map(|root| std::fs::canonicalize(root).ok())
         .any(|root| root == candidate)
+}
+
+/// The distinct project folders behind the user's agent conversations, in the
+/// order they were seen. A failed lookup is reported rather than absorbed: an
+/// empty set is also what a user with no projects has, so absorbing it started a
+/// bridge that reported connected and then refused every remote spawn.
+fn discovered_project_roots(
+    conversations: Result<Vec<crate::commands::chat::UnifiedConversationRow>, String>,
+) -> Result<Vec<String>, String> {
+    let conversations =
+        conversations.map_err(|error| format!("Failed to read Happy project folders: {error}"))?;
+    Ok(conversations
+        .into_iter()
+        .filter_map(|conversation| conversation.project_root.or(conversation.agent_cwd))
+        .fold(Vec::<String>::new(), |mut roots, root| {
+            if !roots.iter().any(|existing| existing == &root) {
+                roots.push(root);
+            }
+            roots
+        }))
 }
 
 fn error_response(id: Value, code: i32, message: &str) -> Value {
@@ -923,19 +932,51 @@ where
     }
 }
 
-async fn write_supervisor_notification(writer: &Arc<Mutex<ChildStdin>>, notification: Value) {
+/// Reports whether the notification actually reached the bridge. A caller that
+/// changes shared state on the strength of a delivery — advertised folders,
+/// an abandoned pairing — must not report success when the write failed.
+async fn write_supervisor_notification<W>(
+    writer: &Arc<Mutex<W>>,
+    notification: Value,
+) -> Result<(), String>
+where
+    W: AsyncWrite + Unpin,
+{
     let Ok(mut encoded) = serde_json::to_vec(&notification) else {
         log::warn!("[HappyBridge] Failed to encode supervisor notification");
-        return;
+        return Err("Failed to encode supervisor notification".to_string());
     };
     encoded.push(b'\n');
     let mut writer = writer.lock().await;
     if let Err(error) = writer.write_all(&encoded).await {
         log::warn!("[HappyBridge] Failed to write supervisor notification: {error}");
-        return;
+        return Err(format!("Failed to write supervisor notification: {error}"));
     }
     if let Err(error) = writer.flush().await {
         log::warn!("[HappyBridge] Failed to flush supervisor notification: {error}");
+        return Err(format!("Failed to flush supervisor notification: {error}"));
+    }
+    Ok(())
+}
+
+/// Bounds a notification write. A bridge that is alive but not draining stdin
+/// blocks the write once the pipe buffer fills, and the caller must fail rather
+/// than hold its lock there forever.
+async fn notify_supervisor<W>(writer: &Arc<Mutex<W>>, notification: Value) -> Result<(), String>
+where
+    W: AsyncWrite + Unpin,
+{
+    match tokio::time::timeout(
+        SUPERVISOR_NOTIFY_TIMEOUT,
+        write_supervisor_notification(writer, notification),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            log::warn!("[HappyBridge] Timed out writing supervisor notification");
+            Err("Happy bridge did not accept the message".to_string())
+        }
     }
 }
 
@@ -1059,15 +1100,16 @@ fn pipe_bridge_output(child: &mut Child, stdin: Arc<Mutex<ChildStdin>>, app: App
 #[cfg(test)]
 mod tests {
     use super::{
-        BoundedLine, HappyBridgeState, MAX_RESTART_ATTEMPTS, MAX_SUPERVISOR_LINE_BYTES, error_response,
-        is_advertised_root, next_restart_attempt, parse_supervisor_line, read_bounded_line,
-        restart_allowed, restart_delay, report_state, should_rearm,
+        BoundedLine, HappyBridgeState, MAX_RESTART_ATTEMPTS, MAX_SUPERVISOR_LINE_BYTES,
+        discovered_project_roots, error_response, is_advertised_root, next_restart_attempt,
+        notify_supervisor, parse_supervisor_line, read_bounded_line, report_state, restart_allowed,
+        restart_delay, should_rearm,
     };
     use crate::commands::happy_bridge::{ADVERTISED_ROOTS_KEY, SETTINGS_STORE};
     use serde_json::Value;
     use std::time::Duration;
     use tauri_plugin_store::StoreExt;
-    use tokio::io::{AsyncWriteExt, BufReader, duplex};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, duplex};
 
     /// The store persists to the mock runtime's data dir, which sibling tests on
     /// the same host share, so the key is always reset rather than assumed absent.
@@ -1371,5 +1413,117 @@ mod tests {
                 .success()
         );
         assert!(matches!(entry.get_password(), Err(keyring::Error::NoEntry)));
+    }
+
+    fn conversation(project_root: Option<&str>, agent_cwd: Option<&str>) -> Value {
+        serde_json::json!({
+            "id": "conversation-1",
+            "title": "Agent",
+            "created_at": 0,
+            "kind": "agent",
+            "project_root": project_root,
+            "is_archived": false,
+            "selected_provider": null,
+            "selected_model": null,
+            "employee_id": null,
+            "agent_type": "claude-code",
+            "agent_session_id": null,
+            "agent_cwd": agent_cwd,
+            "agent_model_id": null,
+            "agent_permission_mode": null,
+            "agent_metadata": null,
+            "project_id": null,
+        })
+    }
+
+    fn conversations(rows: Vec<Value>) -> Vec<crate::commands::chat::UnifiedConversationRow> {
+        rows.into_iter()
+            .map(|row| serde_json::from_value(row).expect("conversation row deserializes"))
+            .collect()
+    }
+
+    #[test]
+    fn project_root_discovery_reports_a_failed_lookup() {
+        // Regression: the lookup was absorbed with `unwrap_or_default()`. On a
+        // busy database the bridge started, advertised zero folders, reported
+        // itself connected, and then refused every remote spawn silently.
+        let failure = discovered_project_roots(Err("database is locked".to_string()));
+
+        assert!(
+            failure.is_err_and(|error| error.contains("database is locked")),
+            "a failed folder lookup must not be reported as an empty project list"
+        );
+    }
+
+    #[test]
+    fn project_root_discovery_keeps_first_seen_distinct_roots() {
+        let roots = discovered_project_roots(Ok(conversations(vec![
+            conversation(Some("/workspace/alpha"), None),
+            // A conversation with no project falls back to where the agent ran.
+            conversation(None, Some("/workspace/beta")),
+            conversation(Some("/workspace/alpha"), Some("/workspace/gamma")),
+            conversation(None, None),
+        ])));
+
+        assert_eq!(
+            roots.expect("a successful lookup yields roots"),
+            vec![
+                "/workspace/alpha".to_string(),
+                "/workspace/beta".to_string()
+            ],
+        );
+    }
+
+    #[tokio::test]
+    async fn supervisor_notification_delivers_a_line() {
+        let (writer, mut reader) = duplex(1024);
+        let writer = std::sync::Arc::new(tokio::sync::Mutex::new(writer));
+
+        notify_supervisor(&writer, serde_json::json!({ "method": "cancel_pairing" }))
+            .await
+            .expect("a drained pipe accepts the notification");
+
+        let mut line = String::new();
+        BufReader::new(&mut reader)
+            .read_line(&mut line)
+            .await
+            .expect("the notification is readable");
+        assert_eq!(line.trim_end(), r#"{"method":"cancel_pairing"}"#);
+    }
+
+    #[tokio::test]
+    async fn supervisor_notification_reports_a_closed_pipe() {
+        // Regression: `update_roots` returned `Ok(())` and `cancel_pairing`
+        // returned `()` no matter what the write did, so the checkbox kept a
+        // change the bridge never saw and a dismissed pairing dialog reported
+        // success while the code stayed authorizable.
+        let (writer, reader) = duplex(1024);
+        drop(reader);
+        let writer = std::sync::Arc::new(tokio::sync::Mutex::new(writer));
+
+        let result =
+            notify_supervisor(&writer, serde_json::json!({ "method": "roots_update" })).await;
+
+        assert!(
+            result.is_err(),
+            "a notification that never reached the bridge must not report success"
+        );
+    }
+
+    #[tokio::test]
+    async fn supervisor_notification_gives_up_on_a_pipe_nobody_drains() {
+        // A bridge that is alive but not reading stdin blocks the write once the
+        // pipe buffer fills. `_reader` stays bound so the pipe is open but idle,
+        // which is exactly that state.
+        let (writer, _reader) = duplex(8);
+        let writer = std::sync::Arc::new(tokio::sync::Mutex::new(writer));
+
+        let result =
+            notify_supervisor(&writer, serde_json::json!({ "method": "roots_update" })).await;
+
+        assert!(
+            result.is_err(),
+            "a wedged bridge must fail the caller rather than block it forever"
+        );
     }
 }

--- a/src/components/settings/HappyRemoteSettings.tsx
+++ b/src/components/settings/HappyRemoteSettings.tsx
@@ -117,6 +117,7 @@ export const HappyRemoteSettings: Component = () => {
   const [pairingQr, setPairingQr] = createSignal<string | null>(null);
   const [pairingError, setPairingError] = createSignal(false);
   let unlistenStatus: (() => void) | undefined;
+  let unmounted = false;
 
   const loadRoots = async () => {
     try {
@@ -154,11 +155,27 @@ export const HappyRemoteSettings: Component = () => {
         });
       }
     }).then((unlisten) => {
+      // The listener resolves after a round trip, so a section switch can land
+      // first. Dropping the handle there leaked one listener per mount, each
+      // still reporting every bridge error.
+      if (unmounted) {
+        unlisten();
+        return;
+      }
       unlistenStatus = unlisten;
     });
   });
 
-  onCleanup(() => unlistenStatus?.());
+  // Switching settings sections unmounts this component without going through
+  // the dismiss button, and the bridge kept the scanned code authorizable for
+  // the rest of its timeout. Unmounting has to withdraw the code too.
+  onCleanup(() => {
+    unmounted = true;
+    unlistenStatus?.();
+    if (pairingPayload() !== null) {
+      void cancelPairing().catch(() => undefined);
+    }
+  });
 
   const toggleRemoteAccess = async (enabled: boolean) => {
     setBusy(true);

--- a/tests/unit/happy-bridge-translate-happy.test.ts
+++ b/tests/unit/happy-bridge-translate-happy.test.ts
@@ -134,6 +134,31 @@ describe("neutral-to-Happy session translation", () => {
     });
   });
 
+  it("bounds tool input without flattening its shape", () => {
+    // A `Write` call carries the whole file body in its parameters. Left
+    // unbounded it went to the relay and onto the phone in full, while the
+    // diff the same write produces was capped.
+    const [message] = translateNeutralEvent({
+      kind: "tool-start",
+      sessionId: "session-1",
+      payload: {
+        toolCallId: "call-write",
+        name: "Write",
+        parameters: {
+          file_path: "/workspace/project/file.ts",
+          content: "x".repeat(2_000_000),
+          replacements: [{ old: "y".repeat(5_000), count: 3 }],
+        },
+      },
+    });
+
+    expect(message.body.input.file_path).toBe("/workspace/project/file.ts");
+    expect(message.body.input.content).toHaveLength(2_000);
+    expect(message.body.input.content).toContain("[truncated for Happy Mobile]");
+    expect(message.body.input.replacements[0].old).toHaveLength(2_000);
+    expect(message.body.input.replacements[0].count).toBe(3);
+  });
+
   it.each([
     ["file-diff", "toolCallId", "file-change-1"],
     ["diff-proposal", "proposalId", "proposal-1"],

--- a/tests/unit/happy-provider-notification-buffer.test.ts
+++ b/tests/unit/happy-provider-notification-buffer.test.ts
@@ -1,0 +1,142 @@
+// ABOUTME: Verifies provider notifications sent before a subscriber attaches are delivered.
+// ABOUTME: Runs a real WebSocket server against the real provider-runtime client.
+
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+
+// @ts-expect-error — the bridge layer is plain ESM without declarations.
+import {
+  createProviderRuntimeClient,
+  createProviderSource,
+  // @ts-expect-error — the bridge layer is plain ESM without declarations.
+} from "../../bin/happy-bridge/provider-source.mjs";
+
+type BridgeClient = {
+  connect(): Promise<void>;
+  call(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  close(): Promise<void>;
+};
+
+const servers: WebSocketServer[] = [];
+const clients: BridgeClient[] = [];
+
+afterEach(async () => {
+  await Promise.all(clients.splice(0).map((client) => client.close()));
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+/**
+ * Answers the handshake and every later RPC, and hands the live socket back so
+ * the test can push notifications the way the provider runtime does.
+ */
+async function startProviderRuntime(): Promise<{
+  port: number;
+  socket: Promise<{ send(data: string): void }>;
+}> {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+
+  const socket = new Promise<{ send(data: string): void }>((resolve) => {
+    server.once("connection", (connection) => {
+      connection.on("message", (raw) => {
+        const message = JSON.parse(String(raw));
+        if (message.id === undefined || message.id === null) return;
+        connection.send(
+          JSON.stringify({ jsonrpc: "2.0", id: message.id, result: {} }),
+        );
+      });
+      resolve(connection);
+    });
+  });
+
+  return { port: (server.address() as AddressInfo).port, socket };
+}
+
+function connectedClient(port: number): BridgeClient {
+  const client = createProviderRuntimeClient({
+    providerRuntime: { host: "127.0.0.1", port, token: "test-token" },
+  }) as BridgeClient;
+  clients.push(client);
+  return client;
+}
+
+describe("Happy provider notification buffering (#3150)", () => {
+  it("delivers a turn completion that arrived before registration subscribed", async () => {
+    // A bridge restart during a live turn seeds the session busy from the
+    // list-time snapshot, then spends several relay round trips before
+    // subscribing. Dropping what lands in that window left the queue for that
+    // session busy forever and the next phone prompt never drained.
+    const runtime = await startProviderRuntime();
+    const client = connectedClient(runtime.port);
+    await client.connect();
+    const socket = await runtime.socket;
+
+    socket.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "provider://prompt-complete",
+        params: { sessionId: "session-a", stopReason: "completed" },
+      }),
+    );
+    // The socket preserves order, so an answered RPC proves the notification
+    // above was already handled.
+    await client.call("provider_ping");
+
+    const source = createProviderSource({
+      client,
+      config: { machineName: "buffer-test" },
+    }) as { subscribe(onEvent: (event: unknown) => void): () => void };
+    const received: Array<{ kind: string; sessionId: string }> = [];
+    source.subscribe((event) =>
+      received.push(event as { kind: string; sessionId: string }),
+    );
+
+    expect(received).toEqual([
+      { kind: "turn-complete", sessionId: "session-a", payload: { stopReason: "completed" } },
+    ]);
+  });
+
+  it("keeps the newest notifications when nothing is subscribed for a long time", async () => {
+    const runtime = await startProviderRuntime();
+    const client = connectedClient(runtime.port);
+    await client.connect();
+    const socket = await runtime.socket;
+
+    for (let index = 0; index < 40; index += 1) {
+      socket.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "provider://message-chunk",
+          params: { sessionId: "session-a", text: `chunk-${index}` },
+        }),
+      );
+    }
+    await client.call("provider_ping");
+
+    const received: Array<{ payload: { text: string } }> = [];
+    (
+      client as unknown as {
+        subscribeNotifications(
+          listener: (method: string, params: { text: string }) => void,
+        ): () => void;
+      }
+    ).subscribeNotifications((_method, params) =>
+      received.push({ payload: params }),
+    );
+
+    // Bounded, and the oldest are the ones dropped: a terminal event is always
+    // the most recent thing a stalled session emitted.
+    expect(received).toHaveLength(32);
+    expect(received[0].payload.text).toBe("chunk-8");
+    expect(received[31].payload.text).toBe("chunk-39");
+  });
+});

--- a/tests/unit/happy-remote-settings-ui.test.ts
+++ b/tests/unit/happy-remote-settings-ui.test.ts
@@ -32,6 +32,34 @@ describe("Happy Remote Access app discovery (#3127)", () => {
   });
 });
 
+/**
+ * Asserted against the source rather than a mounted component: the Vitest
+ * project runs in a `node` environment with no DOM and no Solid test renderer,
+ * so this section cannot be rendered here. These lock the two statements whose
+ * absence caused the defects.
+ */
+describe("Happy Remote Access unmount teardown (#3151, #3153)", () => {
+  const cleanup = remoteSettings.slice(
+    remoteSettings.indexOf("onCleanup(() => {"),
+    remoteSettings.indexOf("const toggleRemoteAccess"),
+  );
+
+  it("withdraws an in-flight pairing code when the section unmounts", () => {
+    // Switching settings sections unmounts without going through the dismiss
+    // button, and the bridge kept polling for the full 5 minute timeout with a
+    // scanned QR still authorizable.
+    expect(cleanup).toContain("pairingPayload()");
+    expect(cleanup).toContain("cancelPairing()");
+  });
+
+  it("releases a status listener that resolved after the unmount", () => {
+    // `onStatusChange` resolves after a round trip, so a fast unmount dropped
+    // the handle and leaked a listener that kept reporting bridge errors.
+    expect(cleanup).toContain("unmounted = true");
+    expect(remoteSettings).toMatch(/if \(unmounted\) \{\s*unlisten\(\);/);
+  });
+});
+
 describe("Happy advertised-root consent (#3144)", () => {
   it("derives roots from the same conversations the user sees checkboxes for", () => {
     // The UI lists agent conversations. If the bridge discovers roots from a

--- a/tests/unit/happy-supervisor-listener.test.ts
+++ b/tests/unit/happy-supervisor-listener.test.ts
@@ -1,0 +1,195 @@
+// ABOUTME: Verifies the bridge keeps exactly one supervisor listener across pairing.
+// ABOUTME: Drives the real layer and supervisor channel against a local relay.
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+
+// @ts-expect-error — the bridge layer is plain ESM without declarations.
+import { createHappyLayer } from "../../bin/happy-bridge/happy-layer.mjs";
+// @ts-expect-error — the bridge layer is plain ESM without declarations.
+import { createSupervisorChannel } from "../../bin/happy-bridge/supervisor-channel.mjs";
+
+type HappyLayer = {
+  start(): Promise<unknown>;
+  startPairing(): Promise<string>;
+  close(): Promise<void>;
+};
+
+type SupervisorChannel = {
+  handleLine(line: string): void;
+  close(): void;
+};
+
+const servers: Array<ReturnType<typeof createServer>> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+          server.closeAllConnections();
+        }),
+    ),
+  );
+});
+
+function readBody(request: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => resolve(body));
+  });
+}
+
+/**
+ * Stands in for the Happy relay: it answers the request that mints a pairing
+ * code and then leaves every authorization poll for that key hanging, which is
+ * the state a user sits in while the QR is on screen.
+ */
+async function startRelay(): Promise<{
+  url: string;
+  publicKeys: string[];
+  pollsClosed: number;
+  pollStarted: Promise<void>;
+}> {
+  const publicKeys: string[] = [];
+  const seen = new Map<string, number>();
+  const state = { pollsClosed: 0 };
+  let resolvePollStarted: (() => void) | undefined;
+  const pollStarted = new Promise<void>((resolve) => {
+    resolvePollStarted = resolve;
+  });
+
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    void readBody(request).then((body) => {
+      const publicKey = String(JSON.parse(body).publicKey);
+      const count = (seen.get(publicKey) ?? 0) + 1;
+      seen.set(publicKey, count);
+      if (count === 1) {
+        publicKeys.push(publicKey);
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{}");
+        return;
+      }
+      resolvePollStarted?.();
+      response.on("close", () => {
+        state.pollsClosed += 1;
+      });
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    publicKeys,
+    get pollsClosed() {
+      return state.pollsClosed;
+    },
+    pollStarted,
+  };
+}
+
+function createLayer(
+  relayUrl: string,
+  channel: SupervisorChannel,
+  onShutdownRequest: () => Promise<void>,
+): HappyLayer {
+  return createHappyLayer({
+    config: {
+      machineIdentity: null,
+      machineName: "supervisor-listener-test",
+      relayUrl,
+    },
+    source: {},
+    supervisorChannel: channel,
+    onShutdownRequest,
+  }) as HappyLayer;
+}
+
+async function waitFor(condition: () => boolean, label: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+describe("Happy supervisor listener lifetime (#3153)", () => {
+  it("detaches its supervisor listener when the layer closes", async () => {
+    // `subscribeToSupervisor` returned nothing, so every call site stored
+    // `undefined` and the listener it registered could never be removed. The
+    // handle is only observable through the teardown it is supposed to perform.
+    const relay = await startRelay();
+    const channel = createSupervisorChannel({ write: () => {} }) as SupervisorChannel;
+    let shutdownRequests = 0;
+    const layer = createLayer(relay.url, channel, async () => {
+      shutdownRequests += 1;
+    });
+
+    await layer.start();
+    await relay.pollStarted;
+    await layer.close();
+
+    channel.handleLine(JSON.stringify({ jsonrpc: "2.0", method: "shutdown" }));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(shutdownRequests).toBe(0);
+  });
+
+  it("still handles cancel_pairing while the pairing wait is in flight", async () => {
+    // The listener has to stay attached across pairing: `cancel_pairing` is the
+    // one notification that only ever arrives during it. Unsubscribing before
+    // `startPairing` would queue it until pairing succeeded — never, for a user
+    // who is cancelling.
+    const relay = await startRelay();
+    const channel = createSupervisorChannel({ write: () => {} }) as SupervisorChannel;
+    const layer = createLayer(relay.url, channel, async () => {});
+
+    await layer.start();
+    await relay.pollStarted;
+    expect(relay.pollsClosed).toBe(0);
+
+    channel.handleLine(JSON.stringify({ jsonrpc: "2.0", method: "cancel_pairing" }));
+
+    await waitFor(() => relay.pollsClosed > 0, "the abandoned authorization poll to close");
+    await layer.close();
+  });
+});
+
+describe("Happy pairing attempt ownership (#3153)", () => {
+  it("keeps the live attempt when an abandoned one settles", async () => {
+    // Attempt #1's rejection nulled the shared slot unconditionally, so a third
+    // `startPairing` minted a third keypair while attempt #2 was still polling,
+    // leaving two authorization loops live at once.
+    const relay = await startRelay();
+    const channel = createSupervisorChannel({ write: () => {} }) as SupervisorChannel;
+    const layer = createLayer(relay.url, channel, async () => {});
+
+    await layer.start();
+    await relay.pollStarted;
+    expect(relay.publicKeys).toHaveLength(1);
+
+    // Dismiss and re-pair without yielding, which is what a user clicking
+    // straight through does: attempt #2 claims the slot before attempt #1's
+    // aborted request has reached its rejection handler.
+    channel.handleLine(JSON.stringify({ jsonrpc: "2.0", method: "cancel_pairing" }));
+    await layer.startPairing();
+    expect(relay.publicKeys).toHaveLength(2);
+
+    // Now let attempt #1 settle, with #2 live and still polling.
+    await waitFor(() => relay.pollsClosed > 0, "attempt #1's poll to be abandoned");
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    await layer.startPairing();
+    expect(relay.publicKeys).toHaveLength(2);
+
+    await layer.close();
+  });
+});


### PR DESCRIPTION
Fixes #3150, fixes #3151, fixes #3153.

Rebased onto #3157/#3158 and #3159/#3161. Verified the three writers in `translate.mjs` coexist: turn correlation, delta coalescing, and the new input bound are independent and all wired in `happy-layer.mjs`.

## #3150 — dropped events wedging the prompt queue

`finishRegistration` does several relay round trips before attaching its subscriber, and the client discarded notifications while no listener existed. A bridge restart during a live turn therefore lost that turn's completion, leaving the session marked busy with nothing left to clear it — the next phone prompt enqueued, never drained, never errored, and its promise never settled.

The client now buffers until the first subscriber attaches and drains on subscribe, mirroring `supervisor-channel.mjs` with the same 32-entry bound so it cannot become a new leak. `close()` clears it.

The busy-state reconciliation the issue offered as an alternative was deliberately not added — buffering closes the actual window, and a second mechanism would be redundant.

## #3151 — pairing survived unmount

Switching settings sections unmounted the component without withdrawing the code, so a photographed QR stayed authorizable for the rest of the 5-minute timeout, and a successful pairing persisted to the keychain with no UI signal. `onCleanup` now cancels an outstanding pairing.

## #3153 — the P2 group

**The dead unsubscribe handle had a trap.** The obvious fix — add `return`, keep the unsubscribe — is wrong, and there's a negative control proving it. That unsubscribe was harmless *only because* the handle was dead. Repairing the handle while leaving the call detaches the listener for the entire pairing wait, which is exactly when `cancel_pairing` arrives — silently breaking the shipped dismiss path and the #3151 fix above. The redundant re-subscribe is removed instead, giving one listener from `start()` to `close()`.

Also: pairing-slot release keyed on promise identity rather than controller identity (which an attempt settling before the next is assigned slips past); tool-call **input** bounded at 2,000 chars like results and diffs already were, preserving object shape so structured input still renders; a status handle resolving after cleanup is unlistened rather than leaked; supervisor writes and root discovery propagate failures instead of reporting success while the phone's folder list goes stale or empty.

## Verification

Every new test fails with its fix reverted:

| Test | Reverted | Failure |
|---|---|---|
| notification buffer (2) | buffering removed | `expected [] to have a length of 32` |
| supervisor listener detach | original `subscribeToSupervisor` | listener live after `close()` |
| `cancel_pairing` in flight | **naive** return-only fix | `timed out waiting for the abandoned poll to close` |
| pairing ownership | guard → unconditional null | `length 2 but got 3` (third keypair minted) |
| bounds tool input | `input: payload.parameters` | `length 2000 but got 2000000` |
| root discovery failure | `unwrap_or_default()` | fails |
| supervisor write failures (2) | `Ok(())` unconditional | both fail |

Gates re-run by me on the rebased branch:

- `pnpm test` — **2507 passed**, 15 skipped, 0 failed
- `pnpm check` — **exit 0**
- `cargo test` — **943 passed**, 0 failed

## Deliberately skipped, with reasons

**Two bridges briefly live.** The fix is a serialization mutex, but reproducing the race needs two concurrent real `start()` calls — a provider runtime, embedded Node, and a real Tauri `AppHandle`. A mocked substitute would prove nothing under the no-mocks rule, and shipping an untested concurrency fix is the failure mode CLAUDE.md exists to prevent. `kill_on_drop` already prevents an orphan, so the damage is transient duplicate session events.

**Pair button on an already-paired machine.** Bigger than it reads: the correct signal is "does a credential exist", which lives in the OS keychain and isn't exposed to the UI, and `pairPhone`'s catch discards the backend error text — so a new Rust error would still surface as the same wrong message. A real fix needs `is_paired()` plumbed to the UI plus error surfacing, and its only honest regression test would touch the real Keychain.

**One caveat on the UI tests.** The #3151 and listener-leak tests are source-shape assertions, not behavioral — the Vitest project runs `environment: "node"` with no DOM or Solid renderer, so the component cannot be mounted without a new dependency and a config change. They guard against the statements being removed; they do not prove the cleanup runs at unmount. Stated rather than implied.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
