### PR TITLE
fix(runtime): resolve node from the embedded PATH before exporting it (#3147, #3148, #3152, #3156)

### DIFF
--- a/build/darwin/prepare-embedded-runtime.ts
+++ b/build/darwin/prepare-embedded-runtime.ts
@@ -69,13 +69,37 @@ async function extractTarGz(archivePath: string, destDir: string): Promise<void>
 	execSync(`tar -xzf "${archivePath}" -C "${destDir}"`, { stdio: 'inherit' });
 }
 
-async function prepareNodejs(options: DownloadOptions): Promise<string> {
+/**
+ * Replace the extracted bin/npm, bin/npx and bin/corepack symlinks with shell
+ * wrappers.
+ *
+ * Tauri resolves symlinks into regular files when bundling the .app, which
+ * breaks `require('../lib/cli.js')` because the path resolves relative to bin/
+ * rather than lib/node_modules/npm/bin/ where the symlink target lives. A shell
+ * wrapper computes its own directory at runtime and stays correct whether or
+ * not Tauri has dereferenced it.
+ */
+export function ensureRuntimeShims(nodeDir: string): void {
+	const npmWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npm-cli.js" "$@"\n`;
+	const npxWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npx-cli.js" "$@"\n`;
+	const corepackWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/corepack/dist/corepack.js" "$@"\n`;
+	replaceRuntimeShim(path.join(nodeDir, 'bin', 'npm'), npmWrapper);
+	replaceRuntimeShim(path.join(nodeDir, 'bin', 'npx'), npxWrapper);
+	replaceRuntimeShim(path.join(nodeDir, 'bin', 'corepack'), corepackWrapper);
+	console.log('Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.');
+}
+
+export async function prepareNodejs(options: DownloadOptions): Promise<string> {
 	const { arch, outputDir } = options;
 	const nodeConfig = NODE_DOWNLOADS[arch];
 	const nodeDir = path.join(outputDir, 'node');
 
 	if (fs.existsSync(nodeDir)) {
-		console.log(`Node.js directory already exists at ${nodeDir}, skipping...`);
+		console.log(`Node.js directory already exists at ${nodeDir}, skipping download...`);
+		// The download is skippable; the wrappers are not. A tree extracted
+		// before this step existed still holds the original symlinks, and Tauri
+		// dereferences those at bundle time (#3152).
+		ensureRuntimeShims(nodeDir);
 		return nodeDir;
 	}
 
@@ -103,19 +127,7 @@ async function prepareNodejs(options: DownloadOptions): Promise<string> {
 	fs.rmSync(tempDir, { recursive: true, force: true });
 	fs.unlinkSync(tarPath);
 
-	// Replace bin/npm and bin/npx symlinks with shell wrappers.
-	// Tauri resolves symlinks into regular files when bundling the .app, which
-	// breaks `require('../lib/cli.js')` because the path resolves relative to
-	// bin/ rather than lib/node_modules/npm/bin/ where the symlink target lives.
-	// A shell wrapper computes its own directory at runtime and stays correct
-	// whether or not Tauri has dereferenced it.
-	const npmWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npm-cli.js" "$@"\n`;
-	const npxWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/npm/bin/npx-cli.js" "$@"\n`;
-	const corepackWrapper = `#!/bin/sh\nexec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/corepack/dist/corepack.js" "$@"\n`;
-	replaceRuntimeShim(path.join(nodeDir, 'bin', 'npm'), npmWrapper);
-	replaceRuntimeShim(path.join(nodeDir, 'bin', 'npx'), npxWrapper);
-	replaceRuntimeShim(path.join(nodeDir, 'bin', 'corepack'), corepackWrapper);
-	console.log('Replaced bin/npm, bin/npx, and bin/corepack with Tauri-safe shell wrappers.');
+	ensureRuntimeShims(nodeDir);
 
 	console.log(`Node.js prepared at ${nodeDir}`);
 	return nodeDir;

--- a/src-tauri/src/claude_setup.rs
+++ b/src-tauri/src/claude_setup.rs
@@ -3,10 +3,40 @@
 
 use log::info;
 use std::fs;
+use std::path::Path;
+
+/// Build the PATH written into `~/.claude/settings.json`.
+///
+/// Claude Code's `env.PATH` **replaces** PATH for everything it spawns, so
+/// whatever is missing here is missing for every MCP server and hook it
+/// launches. The bundled runtime's node directory therefore has to lead the
+/// list — on a machine with no system node (the case the bundled runtime
+/// exists for) the system entries alone resolve nothing (#3148).
+fn claude_code_path(node_dir: Option<&Path>, cargo_bin: &Path) -> String {
+    let mut entries: Vec<String> = Vec::new();
+    if let Some(node_dir) = node_dir {
+        entries.push(node_dir.to_string_lossy().to_string());
+    }
+    entries.push(cargo_bin.to_string_lossy().to_string());
+    // Windows separates PATH with `;` and has no /usr/bin. Joining with `:`
+    // there also splits every entry at its drive letter, so the settings file
+    // Claude Code reads becomes unparseable and the whole PATH is lost.
+    if cfg!(target_os = "windows") {
+        entries.join(";")
+    } else {
+        entries.extend([
+            "/usr/local/bin".to_string(),
+            "/usr/bin".to_string(),
+            "/bin".to_string(),
+        ]);
+        entries.join(":")
+    }
+}
 
 /// Configure Claude Code environment if both cargo and Claude Code are installed.
-/// Adds cargo to PATH in ~/.claude/settings.json.
-pub fn configure_claude_code_environment() {
+/// Adds the embedded runtime's node directory and cargo to PATH in
+/// ~/.claude/settings.json.
+pub fn configure_claude_code_environment(node_dir: Option<&Path>) {
     // Get home directory
     let home = match dirs::home_dir() {
         Some(h) => h,
@@ -43,17 +73,17 @@ pub fn configure_claude_code_environment() {
     }
 
     // Configure Claude Code
-    let cargo_path = cargo_bin.to_string_lossy();
+    let claude_path = claude_code_path(node_dir, &cargo_bin);
 
     if !claude_settings.exists() {
         // Create new settings file
         let settings = format!(
             r#"{{
   "env": {{
-    "PATH": "{}:/usr/local/bin:/usr/bin:/bin"
+    "PATH": "{}"
   }}
 }}"#,
-            cargo_path
+            claude_path
         );
 
         if let Err(e) = fs::write(&claude_settings, settings) {
@@ -91,9 +121,9 @@ pub fn configure_claude_code_environment() {
             &format!(
                 r#"{{
   "env": {{
-    "PATH": "{}:/usr/local/bin:/usr/bin:/bin"
+    "PATH": "{}"
   }},"#,
-                cargo_path
+                claude_path
             ),
             1,
         );
@@ -104,5 +134,79 @@ pub fn configure_claude_code_environment() {
         }
 
         info!("[Claude Setup] Updated Claude Code settings with cargo in PATH");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// Regression guard for #3148.
+    ///
+    /// Claude Code replaces (not extends) PATH for its children from this
+    /// value, so a settings file that lists only the system bin directories
+    /// leaves node-based MCP servers and hooks unable to find node on a
+    /// machine that has no system node — the exact machine the bundled
+    /// runtime is shipped for.
+    #[test]
+    fn claude_code_path_leads_with_the_embedded_node_dir() {
+        let node_dir = PathBuf::from("/Apps/Seren.app/Contents/Resources/embedded-runtime/node/bin");
+        let cargo_bin = PathBuf::from("/Users/dev/.cargo/bin");
+
+        let path = claude_code_path(Some(&node_dir), &cargo_bin);
+        let entries: Vec<&str> = path.split(path_separator()).collect();
+
+        assert_eq!(
+            entries.first().copied(),
+            Some(node_dir.to_string_lossy().as_ref()),
+            "embedded node dir must lead the Claude Code PATH, got: {path}"
+        );
+        assert!(entries.contains(&cargo_bin.to_string_lossy().as_ref()));
+        if !cfg!(target_os = "windows") {
+            for system_bin in ["/usr/local/bin", "/usr/bin", "/bin"] {
+                assert!(
+                    entries.contains(&system_bin),
+                    "expected {system_bin} in Claude Code PATH, got: {path}"
+                );
+            }
+        }
+    }
+
+    fn path_separator() -> char {
+        if cfg!(target_os = "windows") { ';' } else { ':' }
+    }
+
+    /// Claude Code replaces PATH with whatever this writes, so a Windows
+    /// separator mistake costs the user every entry — `C:\...` splits at the
+    /// drive letter, and /usr/bin does not exist there to fall back on.
+    #[test]
+    fn claude_code_path_uses_the_platform_separator() {
+        let node_dir = PathBuf::from("/Apps/embedded-runtime/node/bin");
+        let cargo_bin = PathBuf::from("/Users/dev/.cargo/bin");
+        let path = claude_code_path(Some(&node_dir), &cargo_bin);
+
+        if cfg!(target_os = "windows") {
+            assert!(
+                !path.contains(':') || !path.contains("/usr/bin"),
+                "Windows must not inherit the Unix separator or /usr paths, got: {path}"
+            );
+            assert!(path.contains(';'), "expected ';' on Windows, got: {path}");
+        } else {
+            assert!(path.contains(':'), "expected ':' on Unix, got: {path}");
+            assert!(path.ends_with("/bin"), "unexpected tail: {path}");
+        }
+    }
+
+    /// Discovery can legitimately come back empty (runtime not staged in a
+    /// dev checkout). The written PATH must stay valid rather than gain an
+    /// empty entry, which resolves to the current directory.
+    #[test]
+    fn claude_code_path_omits_missing_node_dir() {
+        let cargo_bin = PathBuf::from("/Users/dev/.cargo/bin");
+
+        let path = claude_code_path(None, &cargo_bin);
+
+        assert_eq!(path, "/Users/dev/.cargo/bin:/usr/local/bin:/usr/bin:/bin");
     }
 }

--- a/src-tauri/src/embedded_runtime.rs
+++ b/src-tauri/src/embedded_runtime.rs
@@ -158,9 +158,18 @@ pub fn platform_subdir() -> String {
     format!("{}-{}", platform, arch)
 }
 
+/// The two directories the embedded runtime is spread across: the
+/// platform-specific subdirectory holding node/git, and the root that
+/// holds the platform-agnostic pieces (`provider-runtime/`, `bin/`).
+#[derive(Debug, Clone)]
+struct EmbeddedRuntimeDirs {
+    platform_dir: PathBuf,
+    root_dir: PathBuf,
+}
+
 /// Gets the path to the embedded runtime directory based on the application location.
 /// The embedded runtime is stored in the resources folder of the application.
-fn get_embedded_runtime_dir(app: &AppHandle) -> Option<PathBuf> {
+fn get_embedded_runtime_dir(app: &AppHandle) -> Option<EmbeddedRuntimeDirs> {
     let subdir = platform_subdir();
 
     // Use Tauri's resource resolver to find the embedded-runtime directory
@@ -171,10 +180,26 @@ fn get_embedded_runtime_dir(app: &AppHandle) -> Option<PathBuf> {
         // Check for platform-specific subdirectory first
         let platform_dir = runtime_dir.join(&subdir);
         if platform_dir.exists() {
-            return Some(platform_dir);
+            return Some(EmbeddedRuntimeDirs {
+                platform_dir,
+                root_dir: runtime_dir,
+            });
         }
-        // Fall back to flat layout (node/bin directly in embedded-runtime)
-        return Some(runtime_dir);
+        // Fall back to flat layout (node/bin directly in embedded-runtime).
+        // A cross-arch or half-staged build lands here and then degrades to
+        // whatever node the user happens to have, so say so loudly (#3152).
+        log::warn!(
+            "[EmbeddedRuntime] No {} subdirectory under {:?}; falling back to the flat \
+             layout. If node/git are not there either, child processes will run on the \
+             user's system node. Fix: run `pnpm prepare:runtime:{}`.",
+            subdir,
+            runtime_dir,
+            subdir
+        );
+        return Some(EmbeddedRuntimeDirs {
+            platform_dir: runtime_dir.clone(),
+            root_dir: runtime_dir,
+        });
     }
 
     // In development mode, check src-tauri/embedded-runtime
@@ -182,7 +207,10 @@ fn get_embedded_runtime_dir(app: &AppHandle) -> Option<PathBuf> {
         let dev_runtime = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("embedded-runtime");
         let platform_runtime = dev_runtime.join(&subdir);
         if platform_runtime.exists() {
-            return Some(platform_runtime);
+            return Some(EmbeddedRuntimeDirs {
+                platform_dir: platform_runtime,
+                root_dir: dev_runtime,
+            });
         }
         log::info!(
             "[EmbeddedRuntime] Dev runtime not found at {:?}. \
@@ -195,10 +223,27 @@ fn get_embedded_runtime_dir(app: &AppHandle) -> Option<PathBuf> {
     None
 }
 
+/// Locate the bundled CLI wrapper directory.
+///
+/// `scripts/build-provider-runtime.ts` writes the wrappers next to the
+/// platform-agnostic `provider-runtime/` bundle — that is, into the runtime
+/// *root* — while node and git live under the platform subdirectory. Probing
+/// only the platform subdirectory never found them, so the PATH entry was
+/// dead (#3152). Check the platform subdirectory first so a future
+/// per-platform staging wins, then fall back to the root.
+fn embedded_bin_dir(platform_dir: &std::path::Path, root_dir: &std::path::Path) -> Option<PathBuf> {
+    for candidate in [platform_dir.join("bin"), root_dir.join("bin")] {
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
 /// Discovers the paths to embedded Node.js and Git installations.
 pub fn discover_embedded_runtime(app: &AppHandle) -> EmbeddedRuntimePaths {
-    let runtime_dir = match get_embedded_runtime_dir(app) {
-        Some(dir) => dir,
+    let dirs = match get_embedded_runtime_dir(app) {
+        Some(dirs) => dirs,
         None => {
             let subdir = platform_subdir();
             if cfg!(debug_assertions) {
@@ -224,6 +269,8 @@ pub fn discover_embedded_runtime(app: &AppHandle) -> EmbeddedRuntimePaths {
             };
         }
     };
+
+    let runtime_dir = dirs.platform_dir;
 
     let mut node_dir: Option<PathBuf> = None;
     let mut git_dir: Option<PathBuf> = None;
@@ -287,12 +334,7 @@ pub fn discover_embedded_runtime(app: &AppHandle) -> EmbeddedRuntimePaths {
     }
 
     // Check for bundled helper binaries in bin/ directory (all platforms).
-    let bin_dir = runtime_dir.join("bin");
-    let bin_dir = if bin_dir.exists() {
-        Some(bin_dir)
-    } else {
-        None
-    };
+    let bin_dir = embedded_bin_dir(&runtime_dir, &dirs.root_dir);
 
     EmbeddedRuntimePaths {
         node_dir,
@@ -300,6 +342,32 @@ pub fn discover_embedded_runtime(app: &AppHandle) -> EmbeddedRuntimePaths {
         bin_dir,
         python_dir,
     }
+}
+
+fn node_executable_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "node.exe"
+    } else {
+        "node"
+    }
+}
+
+/// Absolute path to the bundled node binary, or `None` when the embedded
+/// runtime was not staged for this platform.
+///
+/// Callers that fall back to a bare `node` must log the fallback: the bare
+/// name is resolved against the *parent's* PATH at spawn time, so a later
+/// `.env("PATH", get_embedded_path())` cannot redirect it, and the app
+/// silently ends up on whatever node the user happens to have (#3152).
+pub fn embedded_node_binary(paths: &EmbeddedRuntimePaths) -> Option<PathBuf> {
+    let candidate = paths.node_dir.as_ref()?.join(node_executable_name());
+    candidate.exists().then_some(candidate)
+}
+
+/// The bare `node` name, used only when [`embedded_node_binary`] comes back
+/// empty and the caller has logged that fallback.
+pub fn system_node_fallback() -> PathBuf {
+    PathBuf::from(node_executable_name())
 }
 
 /// Configures the embedded runtime paths.
@@ -662,6 +730,78 @@ mod tests {
             .expect("write python.exe stub");
         let found = embedded_python_dir(runtime_dir).expect("python_dir discovered");
         assert_eq!(found, runtime_dir.join("python"));
+    }
+
+    /// Regression guard for #3152.
+    ///
+    /// `scripts/build-provider-runtime.ts` writes the CLI wrappers to the
+    /// runtime root, next to the platform-agnostic `provider-runtime/`
+    /// bundle, while node and git live under the platform subdirectory.
+    /// Probing only the platform subdirectory meant `bin_dir` was always
+    /// `None` and the PATH entry never existed.
+    #[test]
+    fn embedded_bin_dir_finds_the_wrappers_in_the_runtime_root() {
+        use std::fs;
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let root = tmp.path().join("embedded-runtime");
+        let platform_dir = root.join("darwin-arm64");
+        fs::create_dir_all(&platform_dir).expect("create platform dir");
+
+        // No bin/ anywhere yet.
+        assert_eq!(embedded_bin_dir(&platform_dir, &root), None);
+
+        // The wrappers land in the runtime root, as the build script writes them.
+        fs::create_dir_all(root.join("bin")).expect("create root bin");
+        assert_eq!(
+            embedded_bin_dir(&platform_dir, &root),
+            Some(root.join("bin")),
+            "wrappers staged in the runtime root must be discovered"
+        );
+
+        // A per-platform staging, should one ever exist, wins.
+        fs::create_dir_all(platform_dir.join("bin")).expect("create platform bin");
+        assert_eq!(
+            embedded_bin_dir(&platform_dir, &root),
+            Some(platform_dir.join("bin"))
+        );
+    }
+
+    /// Regression guard for #3152.
+    ///
+    /// Spawn sites fall back to a bare `node` when the bundled binary is
+    /// missing. `Command::new` resolves that against the *parent's* PATH, so
+    /// a later `.env("PATH", ...)` cannot redirect it and the app silently
+    /// runs on the user's own node. The fallback has to be detectable — and
+    /// therefore loggable — rather than a path that merely looks valid.
+    #[test]
+    fn embedded_node_binary_is_none_when_the_bundled_binary_is_missing() {
+        use std::fs;
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let node_dir = tmp.path().join("node").join("bin");
+        fs::create_dir_all(&node_dir).expect("create node bin dir");
+
+        let mut paths = EmbeddedRuntimePaths {
+            node_dir: None,
+            git_dir: None,
+            bin_dir: None,
+            python_dir: None,
+        };
+
+        // Runtime not staged at all.
+        assert_eq!(embedded_node_binary(&paths), None);
+
+        // Directory staged but the binary never landed in it.
+        paths.node_dir = Some(node_dir.clone());
+        assert_eq!(
+            embedded_node_binary(&paths),
+            None,
+            "an empty node dir must not be reported as a usable bundled node"
+        );
+
+        // Fully staged.
+        let node_path = node_dir.join(node_executable_name());
+        fs::write(&node_path, b"stub").expect("write node stub");
+        assert_eq!(embedded_node_binary(&paths), Some(node_path));
     }
 
     #[test]

--- a/src-tauri/src/happy_bridge.rs
+++ b/src-tauri/src/happy_bridge.rs
@@ -645,21 +645,19 @@ fn happy_home_dir(app: &AppHandle) -> Option<PathBuf> {
 }
 
 fn resolve_node_binary(app: &AppHandle) -> PathBuf {
-    if let Some(node_dir) = crate::embedded_runtime::discover_embedded_runtime(app).node_dir {
-        let candidate = if cfg!(target_os = "windows") {
-            node_dir.join("node.exe")
-        } else {
-            node_dir.join("node")
-        };
-        if candidate.exists() {
-            return candidate;
-        }
+    let paths = crate::embedded_runtime::discover_embedded_runtime(app);
+    if let Some(node) = crate::embedded_runtime::embedded_node_binary(&paths) {
+        return node;
     }
-    if cfg!(target_os = "windows") {
-        PathBuf::from("node.exe")
-    } else {
-        PathBuf::from("node")
-    }
+
+    log::warn!(
+        "[HappyBridge] Bundled node not found under {:?}; falling back to the user's system \
+         node. The bridge will run on an unmanaged node version, or fail to spawn at all if \
+         the machine has none. Fix: run `pnpm prepare:runtime:{}`.",
+        paths.node_dir,
+        crate::embedded_runtime::platform_subdir()
+    );
+    crate::embedded_runtime::system_node_fallback()
 }
 
 fn find_happy_bridge_mjs() -> Result<PathBuf, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -707,34 +707,11 @@ pub fn run() {
             // detect that it's running under Seren Desktop.
             // Spec: serenorg/seren-desktop#1496
             //
-            // SEREN_PLAYWRIGHT_MCP_COMMAND lets skill subprocesses
-            // (prophet-arb-bot's automated browser flows) spawn the bundled
-            // playwright-stealth MCP server without hardcoding the macOS
-            // path. Resolved once here from the resource_dir so Windows and
-            // Linux inherit a working absolute command too. #1945.
-            //
             // SAFETY: set_var is unsafe in Rust 2024. Called exactly once
             // during app setup before any threads spawn child processes.
             unsafe {
                 std::env::set_var("SEREN_HOST", "seren-desktop");
                 std::env::set_var("SEREN_DESKTOP", "1");
-
-                let resource_dir = app.path().resource_dir().ok();
-                if let Some(script) =
-                    mcp::resolve_playwright_mcp_script_path_from(resource_dir.as_deref())
-                {
-                    let node = mcp::resolve_command_in_embedded_path("node");
-                    let cmd = mcp::format_playwright_mcp_command(&node, &script);
-                    log::info!("[MCP] SEREN_PLAYWRIGHT_MCP_COMMAND={}", cmd);
-                    std::env::set_var("SEREN_PLAYWRIGHT_MCP_COMMAND", cmd);
-                } else {
-                    log::warn!(
-                        "[MCP] playwright-stealth script not found on disk; \
-                         SEREN_PLAYWRIGHT_MCP_COMMAND not exported. Skill \
-                         subprocesses that need it will fail with a clear \
-                         setup error."
-                    );
-                }
             }
 
             // Build native menu bar for all platforms
@@ -828,8 +805,46 @@ pub fn run() {
                 );
             }
 
+            // SEREN_PLAYWRIGHT_MCP_COMMAND lets skill subprocesses
+            // (prophet-arb-bot's automated browser flows) spawn the bundled
+            // playwright-stealth MCP server without hardcoding the macOS
+            // path. Resolved once here from the resource_dir so Windows and
+            // Linux inherit a working absolute command too. #1945.
+            //
+            // Must run after `configure_embedded_runtime` — the node lookup
+            // reads the PATH that call publishes, and resolving before it
+            // silently yields a bare `node` (#3147).
+            //
+            // SAFETY: set_var is unsafe in Rust 2024. Called exactly once
+            // during app setup before any threads spawn child processes.
+            unsafe {
+                let resource_dir = app.path().resource_dir().ok();
+                if let Some(script) =
+                    mcp::resolve_playwright_mcp_script_path_from(resource_dir.as_deref())
+                {
+                    let node = mcp::resolve_command_in_embedded_path("node");
+                    if std::path::Path::new(&node).is_relative() {
+                        log::warn!(
+                            "[MCP] node did not resolve to an absolute path in the embedded \
+                             PATH; SEREN_PLAYWRIGHT_MCP_COMMAND will depend on the consumer's \
+                             own PATH to find node."
+                        );
+                    }
+                    let cmd = mcp::format_playwright_mcp_command(&node, &script);
+                    log::info!("[MCP] SEREN_PLAYWRIGHT_MCP_COMMAND={}", cmd);
+                    std::env::set_var("SEREN_PLAYWRIGHT_MCP_COMMAND", cmd);
+                } else {
+                    log::warn!(
+                        "[MCP] playwright-stealth script not found on disk; \
+                         SEREN_PLAYWRIGHT_MCP_COMMAND not exported. Skill \
+                         subprocesses that need it will fail with a clear \
+                         setup error."
+                    );
+                }
+            }
+
             // Configure Claude Code environment (adds cargo to PATH if needed)
-            claude_setup::configure_claude_code_environment();
+            claude_setup::configure_claude_code_environment(paths.node_dir.as_deref());
 
             // Install panic sidecar capture for desktop support reports.
             support::init(app.handle());
@@ -1333,6 +1348,36 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::{InterviewLaunchPayload, parse_interview_launch_url};
+
+    /// Regression guard for #3147.
+    ///
+    /// `resolve_command_in_embedded_path` reads the PATH published by
+    /// `configure_embedded_runtime`. When the playwright export ran first
+    /// that PATH was still empty, so the lookup fell through to a bare
+    /// `node` and every consumer that does not inherit the embedded PATH
+    /// got a command it could not run — with no error, just a wrong value
+    /// in the info log.
+    ///
+    /// The ordering lives inside the Tauri `setup` closure, which needs a
+    /// real `AppHandle` and so cannot be driven from a unit test. Assert on
+    /// the source order instead: it is the exact invariant that broke.
+    #[test]
+    fn embedded_runtime_is_configured_before_node_is_resolved() {
+        let source = include_str!("lib.rs");
+        let configure = source
+            .find("embedded_runtime::configure_embedded_runtime(app.handle())")
+            .expect("setup must configure the embedded runtime");
+        let resolve = source
+            .find(r#"mcp::resolve_command_in_embedded_path("node")"#)
+            .expect("setup must resolve node for SEREN_PLAYWRIGHT_MCP_COMMAND");
+
+        assert!(
+            configure < resolve,
+            "configure_embedded_runtime must run before node is resolved from the \
+             embedded PATH, otherwise SEREN_PLAYWRIGHT_MCP_COMMAND exports a bare \
+             `node` (#3147)"
+        );
+    }
 
     #[test]
     fn parses_interview_launch_host_url() {

--- a/src-tauri/src/provider_runtime.rs
+++ b/src-tauri/src/provider_runtime.rs
@@ -36,15 +36,27 @@ const STARTUP_ATTEMPT_BUDGETS: &[Duration] = &[
     Duration::from_secs(45),
 ];
 
+/// A restart only re-arms the budget once the runtime has proved it can stay
+/// up this long. Shorter than that and a crash loop just keeps buying itself
+/// fresh attempts.
+const RESTART_REARM_UPTIME: Duration = Duration::from_secs(60);
+
 struct ProviderRuntimeProcess {
     child: Child,
     config: ProviderRuntimeConfig,
+    spawned_at: Instant,
+    restart_budget_rearmed: bool,
 }
 
 pub struct ProviderRuntimeState {
     process: Mutex<Option<ProviderRuntimeProcess>>,
     monitor_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     last_config: Mutex<Option<ProviderRuntimeConfig>>,
+    /// Crash-restart budget. Owned by the state, not by the monitor task:
+    /// a successful restart goes through `ensure_started`, which aborts the
+    /// monitor and spawns a fresh one, so a task-local counter reset itself
+    /// on every restart and the give-up check could never fire (#3156).
+    restart_attempts: Mutex<u32>,
 }
 
 impl ProviderRuntimeState {
@@ -53,7 +65,21 @@ impl ProviderRuntimeState {
             process: Mutex::new(None),
             monitor_handle: Mutex::new(None),
             last_config: Mutex::new(None),
+            restart_attempts: Mutex::new(0),
         }
+    }
+
+    /// Claims the next restart from the shared budget, or `None` once it is
+    /// exhausted.
+    async fn claim_restart_attempt(&self) -> Option<u32> {
+        let mut attempts = self.restart_attempts.lock().await;
+        let next = next_restart_attempt(*attempts)?;
+        *attempts = next;
+        Some(next)
+    }
+
+    async fn rearm_restart_budget(&self) {
+        *self.restart_attempts.lock().await = 0;
     }
 
     pub(crate) async fn ensure_started(
@@ -140,6 +166,8 @@ impl ProviderRuntimeState {
                     *guard = Some(ProviderRuntimeProcess {
                         child,
                         config: config.clone(),
+                        spawned_at: Instant::now(),
+                        restart_budget_rearmed: false,
                     });
                     drop(guard);
                     *self.last_config.lock().await = Some(config.clone());
@@ -344,23 +372,18 @@ fn generate_auth_token() -> String {
 
 fn resolve_node_binary(app: &AppHandle) -> PathBuf {
     let paths = crate::embedded_runtime::discover_embedded_runtime(app);
-    if let Some(node_dir) = paths.node_dir {
-        let candidate = if cfg!(target_os = "windows") {
-            node_dir.join("node.exe")
-        } else {
-            node_dir.join("node")
-        };
-
-        if candidate.exists() {
-            return candidate;
-        }
+    if let Some(node) = crate::embedded_runtime::embedded_node_binary(&paths) {
+        return node;
     }
 
-    if cfg!(target_os = "windows") {
-        PathBuf::from("node.exe")
-    } else {
-        PathBuf::from("node")
-    }
+    log::warn!(
+        "[ProviderRuntime] Bundled node not found under {:?}; falling back to the user's \
+         system node. The runtime will run on an unmanaged node version, or fail to spawn \
+         at all if the machine has none. Fix: run `pnpm prepare:runtime:{}`.",
+        paths.node_dir,
+        crate::embedded_runtime::platform_subdir()
+    );
+    crate::embedded_runtime::system_node_fallback()
 }
 
 fn find_provider_runtime_mjs() -> Result<PathBuf, String> {
@@ -557,58 +580,91 @@ async fn check_provider_runtime_health_once(config: &ProviderRuntimeConfig) -> b
     }
 }
 
+/// Whether another restart fits in the budget.
+fn restart_allowed(attempts: u32) -> bool {
+    attempts < MAX_RESTART_ATTEMPTS
+}
+
+fn next_restart_attempt(attempts: u32) -> Option<u32> {
+    restart_allowed(attempts).then_some(attempts + 1)
+}
+
+/// Whether a run that has lasted `spawned_at..now` has earned a fresh restart
+/// budget. Once per process, so a runtime that is up for hours cannot bank
+/// re-arms.
+fn should_rearm(spawned_at: Instant, already_rearmed: bool, now: Instant) -> bool {
+    !already_rearmed && now.duration_since(spawned_at) >= RESTART_REARM_UPTIME
+}
+
 /// Watches for provider runtime process death and attempts bounded auto-restart.
 fn spawn_process_monitor(app: AppHandle) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        let mut restart_attempts: u32 = 0;
         loop {
             tokio::time::sleep(Duration::from_secs(5)).await;
 
             let state = app.state::<ProviderRuntimeState>();
-            let exited = {
+            let (exited, should_rearm_budget) = {
                 let mut guard = state.process.lock().await;
                 match guard.as_mut() {
                     None => break, // Process was intentionally stopped
                     Some(proc) => match proc.child.try_wait() {
-                        Ok(None) => false, // Still running
+                        Ok(None) => {
+                            // Still running.
+                            let rearm = should_rearm(
+                                proc.spawned_at,
+                                proc.restart_budget_rearmed,
+                                Instant::now(),
+                            );
+                            if rearm {
+                                proc.restart_budget_rearmed = true;
+                            }
+                            (false, rearm)
+                        }
                         Ok(Some(status)) => {
                             log::warn!("[ProviderRuntime] Process exited unexpectedly: {}", status);
                             *guard = None;
-                            true
+                            (true, false)
                         }
                         Err(err) => {
                             log::warn!("[ProviderRuntime] Failed to check process status: {}", err);
-                            false
+                            (false, false)
                         }
                     },
                 }
             };
 
+            if should_rearm_budget {
+                log::info!(
+                    "[ProviderRuntime] Stable for {}s; re-arming the restart budget",
+                    RESTART_REARM_UPTIME.as_secs()
+                );
+                state.rearm_restart_budget().await;
+            }
+
             if exited {
-                restart_attempts += 1;
-                if restart_attempts > MAX_RESTART_ATTEMPTS {
+                let Some(attempt) = state.claim_restart_attempt().await else {
                     log::error!(
                         "[ProviderRuntime] Crashed {} times, giving up",
-                        restart_attempts - 1
+                        MAX_RESTART_ATTEMPTS
                     );
                     crate::support::report_runtime_error(
                         &app,
                         "provider_runtime.crash_loop",
                         &format!(
                             "provider runtime crashed {} times; giving up",
-                            restart_attempts - 1
+                            MAX_RESTART_ATTEMPTS
                         ),
                     );
                     let _ = app.emit(
                         "provider-runtime://failed",
-                        serde_json::json!({ "attempts": restart_attempts - 1 }),
+                        serde_json::json!({ "attempts": MAX_RESTART_ATTEMPTS }),
                     );
                     return;
-                }
+                };
 
                 log::info!(
                     "[ProviderRuntime] Restarting (attempt {}/{})",
-                    restart_attempts,
+                    attempt,
                     MAX_RESTART_ATTEMPTS
                 );
                 tokio::time::sleep(Duration::from_secs(2)).await;
@@ -618,7 +674,9 @@ fn spawn_process_monitor(app: AppHandle) -> tokio::task::JoinHandle<()> {
                     Ok(_) => {
                         log::info!("[ProviderRuntime] Restarted successfully");
                         let _ = app.emit("provider-runtime://restarted", serde_json::json!({}));
-                        return; // ensure_started spawns a new monitor
+                        // `ensure_started` aborted this task and stored a fresh
+                        // monitor; that one inherits the budget from the state.
+                        return;
                     }
                     Err(err) => {
                         // #2563: `ensure_started` has already exhausted its
@@ -635,7 +693,7 @@ fn spawn_process_monitor(app: AppHandle) -> tokio::task::JoinHandle<()> {
                         );
                         let _ = app.emit(
                             "provider-runtime://failed",
-                            serde_json::json!({ "attempts": restart_attempts, "error": err }),
+                            serde_json::json!({ "attempts": attempt, "error": err }),
                         );
                         return;
                     }
@@ -661,6 +719,10 @@ pub async fn provider_runtime_stop(state: State<'_, ProviderRuntimeState>) -> Re
     if let Some(handle) = state.monitor_handle.lock().await.take() {
         handle.abort();
     }
+
+    // An intentional stop is not a crash — the next start begins with a full
+    // budget rather than inheriting whatever the last session spent.
+    state.rearm_restart_budget().await;
 
     let mut guard = state.process.lock().await;
     let Some(mut process) = guard.take() else {
@@ -835,6 +897,78 @@ pub async fn provider_force_kill_session(
 mod tests {
     use super::*;
     use tokio::process::Command as TokioCommand;
+
+    /// Regression guard for #3156.
+    ///
+    /// Every successful restart goes through `ensure_started`, which aborts
+    /// the current monitor and spawns a fresh one. While the counter lived in
+    /// the monitor task, each new monitor started from zero, so the give-up
+    /// check could never fire and a runtime that died every few seconds
+    /// respawned node forever with nothing logged and no `failed` event.
+    ///
+    /// Drive the budget the way successive monitor generations do — one claim
+    /// per generation — and assert it runs out.
+    #[tokio::test]
+    async fn restart_budget_survives_monitor_respawn() {
+        let state = ProviderRuntimeState::new();
+
+        let mut restarts = 0_u32;
+        while state.claim_restart_attempt().await.is_some() {
+            restarts += 1;
+            assert!(
+                restarts <= MAX_RESTART_ATTEMPTS,
+                "restart budget is unbounded: granted {restarts} restarts across monitor \
+                 generations with MAX_RESTART_ATTEMPTS={MAX_RESTART_ATTEMPTS} (#3156)"
+            );
+        }
+
+        assert_eq!(restarts, MAX_RESTART_ATTEMPTS);
+        assert!(state.claim_restart_attempt().await.is_none());
+    }
+
+    /// A runtime that proves it can stay up earns its budget back, so a
+    /// crash weeks into a session is not judged against restarts from
+    /// startup. Once per process — a long-lived runtime cannot bank re-arms.
+    #[tokio::test]
+    async fn stable_uptime_rearms_the_restart_budget() {
+        let state = ProviderRuntimeState::new();
+        assert!(state.claim_restart_attempt().await.is_some());
+        assert!(state.claim_restart_attempt().await.is_some());
+
+        state.rearm_restart_budget().await;
+
+        let mut restarts = 0_u32;
+        while state.claim_restart_attempt().await.is_some() {
+            restarts += 1;
+            assert!(
+                restarts <= MAX_RESTART_ATTEMPTS,
+                "re-arming must restore the budget, not remove it: granted {restarts} \
+                 restarts with MAX_RESTART_ATTEMPTS={MAX_RESTART_ATTEMPTS}"
+            );
+        }
+        assert_eq!(restarts, MAX_RESTART_ATTEMPTS);
+    }
+
+    #[test]
+    fn rearm_needs_sustained_uptime_and_happens_once() {
+        let spawned_at = Instant::now();
+
+        assert!(!should_rearm(
+            spawned_at,
+            false,
+            spawned_at + Duration::from_secs(59)
+        ));
+        assert!(should_rearm(
+            spawned_at,
+            false,
+            spawned_at + RESTART_REARM_UPTIME
+        ));
+        assert!(!should_rearm(
+            spawned_at,
+            true,
+            spawned_at + Duration::from_secs(3600)
+        ));
+    }
 
     #[test]
     fn config_with_port_rebinds_without_rotating_token() {

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -3656,20 +3656,38 @@ fn compose_cli_command(
     Ok(parts.join(" "))
 }
 
-/// PATH for terminal child processes — the parent process PATH plus
-/// the CLI install dirs (`~/.claude/bin`, `~/.local/bin`, Homebrew,
-/// `%APPDATA%\npm`) a GUI-launched Tauri app typically misses.
+/// PATH for terminal child processes — the embedded runtime directories
+/// plus the parent process PATH plus the CLI install dirs
+/// (`~/.claude/bin`, `~/.local/bin`, Homebrew, `%APPDATA%\npm`) a
+/// GUI-launched Tauri app typically misses.
 ///
 /// Single source of truth for both the PTY spawn and the `claude
 /// --version` probe so a regression in one surface can't desync from
-/// the other.
+/// the other. Both spawn `claude` programmatically, and the agent it
+/// runs shells out to node — so the bundled node has to be on this PATH
+/// too, not just on the one provider workers get (#3152).
 fn augmented_path_for_terminal() -> String {
     #[cfg(target_os = "windows")]
     let path_separator = ";";
     #[cfg(not(target_os = "windows"))]
     let path_separator = ":";
-    let current = env::var("PATH").unwrap_or_default();
-    crate::embedded_runtime::extend_path_with_common_bins(&current, path_separator)
+    terminal_path_from(
+        crate::embedded_runtime::get_embedded_path(),
+        &env::var("PATH").unwrap_or_default(),
+        path_separator,
+    )
+}
+
+/// Prefer the PATH published by `configure_embedded_runtime` — it is
+/// already the process PATH extended with the common bins and led by the
+/// embedded runtime directories. It is empty only before startup
+/// configures it, or when no runtime was staged; extend the process PATH
+/// directly in that case.
+fn terminal_path_from(embedded_path: &str, process_path: &str, separator: &str) -> String {
+    if !embedded_path.is_empty() {
+        return embedded_path.to_string();
+    }
+    crate::embedded_runtime::extend_path_with_common_bins(process_path, separator)
 }
 
 fn default_shell() -> String {
@@ -4160,6 +4178,40 @@ mod tests {
                 "expected {expected} to be in augmented PATH, got: {path}",
             );
         }
+    }
+
+    /// Regression guard for #3152.
+    ///
+    /// `terminal.rs` spawns `claude` programmatically over this PATH, and
+    /// the agent it starts shells out to node. Building the PATH from the
+    /// process env plus the common bins alone left the bundled node off it
+    /// entirely, so a machine with no system node ran the terminal agent
+    /// against nothing.
+    #[test]
+    fn terminal_path_leads_with_the_embedded_runtime_when_configured() {
+        let embedded = "/Apps/Seren.app/Contents/Resources/embedded-runtime/node/bin:/usr/bin";
+
+        let path = terminal_path_from(embedded, "/usr/bin:/bin", ":");
+
+        assert_eq!(
+            path.split(':').next(),
+            Some("/Apps/Seren.app/Contents/Resources/embedded-runtime/node/bin"),
+            "terminal PATH must lead with the embedded runtime, got: {path}"
+        );
+    }
+
+    /// Before startup configures the runtime — and on a checkout with no
+    /// staged runtime — the embedded PATH is empty and the process PATH
+    /// still has to be extended with the CLI install dirs (#2008).
+    #[test]
+    fn terminal_path_extends_process_path_without_an_embedded_runtime() {
+        let path = terminal_path_from("", "/usr/bin:/bin", ":");
+
+        assert!(path.split(':').any(|p| p == "/usr/bin"));
+        assert!(
+            path.split(':').count() > 2,
+            "expected the common bin dirs to be appended, got: {path}"
+        );
     }
 
     fn cell_at(snap: &GridSnapshot, row: u16, col: u16) -> char {

--- a/tests/unit/darwin-embedded-runtime-warm-tree.test.ts
+++ b/tests/unit/darwin-embedded-runtime-warm-tree.test.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Regression coverage for macOS embedded-runtime preparation on a warm tree (#3152).
+// ABOUTME: Proves an incremental prepare still replaces the npm/npx/corepack symlinks.
+
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { prepareNodejs } from "../../build/darwin/prepare-embedded-runtime";
+import { expect, it } from "vitest";
+
+/**
+ * The download is skipped when `<outputDir>/node` already exists, which is the
+ * state of every incremental `pnpm prepare:runtime:darwin-*`. That early return
+ * used to skip the wrapper replacement with it, leaving the original symlinks
+ * in place — and Tauri dereferences symlinks when bundling the .app, which
+ * breaks `require('../lib/cli.js')` for npm/npx/corepack.
+ *
+ * Exercising the real function against a real warm tree also proves the early
+ * return still short-circuits the network: the download would fail or hang
+ * here, not silently pass.
+ */
+it("replaces runtime symlinks on an already-prepared node tree", async () => {
+  const outputDir = mkdtempSync(join(tmpdir(), "seren-warm-runtime-"));
+  try {
+    const nodeDir = join(outputDir, "node");
+    const binDir = join(nodeDir, "bin");
+    const targetDir = join(nodeDir, "lib", "node_modules", "npm", "bin");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(targetDir, "npm-cli.js"), "// original npm entrypoint\n");
+    symlinkSync("../lib/node_modules/npm/bin/npm-cli.js", join(binDir, "npm"));
+    symlinkSync("../lib/node_modules/npm/bin/npx-cli.js", join(binDir, "npx"));
+    symlinkSync("../lib/node_modules/corepack/dist/corepack.js", join(binDir, "corepack"));
+
+    const prepared = await prepareNodejs({ arch: "arm64", outputDir });
+
+    expect(prepared).toBe(nodeDir);
+    for (const wrapper of ["npm", "npx", "corepack"]) {
+      const wrapperPath = join(binDir, wrapper);
+      expect(
+        lstatSync(wrapperPath).isSymbolicLink(),
+        `${wrapper} must not still be a symlink after an incremental prepare`,
+      ).toBe(false);
+      expect(readFileSync(wrapperPath, "utf8")).toContain("#!/bin/sh");
+    }
+    expect(readFileSync(join(targetDir, "npm-cli.js"), "utf8")).toBe(
+      "// original npm entrypoint\n",
+    );
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #3147, fixes #3148, fixes #3152, fixes #3156.

## #3147 — bare `node` exported

The playwright export resolved node ~96 lines *before* `configure_embedded_runtime` published the PATH it reads, so `get_embedded_path()` was empty and the lookup fell through to a bare `node`. It failed silently — only the info log showed the wrong value. The export now runs after configuration, and warns when the resolved path is still relative.

## #3148 — Claude Code PATH omitted the bundled runtime

Claude Code's `env.PATH` **replaces** PATH for everything it spawns, so node-based MCP servers and hooks it launched had nothing to resolve on a machine without system node — precisely the case the bundled runtime exists for. The embedded node directory now leads that PATH.

**Additional defect found while fixing this, not in the ticket.** `configure_claude_code_environment` runs on every platform with no gate, but joined with `:` and appended `/usr/local/bin:/usr/bin:/bin`. On Windows that splits every entry at its drive letter (`C:\...`) and appends paths that do not exist — so the **global** `~/.claude/settings.json` this writes was unusable there, and #3148's fix would have injected the node dir into that same broken string. Now joined with the platform separator, with the Unix system entries omitted on Windows. Covered by `claude_code_path_uses_the_platform_separator`.

## #3152 — four discovery defects

- `bin_dir` probed the platform subdir while `build-provider-runtime.ts` writes wrappers to the runtime root, so it never resolved. Discovery now probes both.
- The warm-tree early return skipped shim replacement, so an incremental prepare left `npm` a symlink — the exact thing the shim exists to prevent. Extracted `ensureRuntimeShims()`, called on both paths.
- Falling back to system node is now a loud warning naming the missing directory and the `pnpm prepare:runtime:*` fix, instead of silently running an unmanaged node version.
- Terminal-spawned agents now prefer the embedded PATH.

## #3156 — unbounded restarts

`restart_attempts` was task-local, but a successful restart goes through `ensure_started`, which spawns a fresh monitor with the counter reset — so it never exceeded 1 and the `> MAX_RESTART_ATTEMPTS` branch could never fire. A runtime dying every ~6s respawned forever with no give-up log, no telemetry, and no `provider-runtime://failed` event. The budget now lives on the shared state and re-arms only after 60s of uptime, matching `happy_bridge`'s working implementation.

## Verification

Every new test fails with its fix reverted:

| Test | Failure when reverted |
|---|---|
| `embedded_runtime_is_configured_before_node_is_resolved` | ordering assertion (#3147) |
| `claude_code_path_leads_with_the_embedded_node_dir` | leads with cargo bin, not node dir |
| `claude_code_path_uses_the_platform_separator` | Unix separator on Windows |
| `embedded_bin_dir_finds_the_wrappers_in_the_runtime_root` | `None` |
| `embedded_node_binary_is_none_when_the_bundled_binary_is_missing` | returns a path for a dir with no binary |
| `terminal_path_leads_with_the_embedded_runtime_when_configured` | `/usr/bin` |
| `restart_budget_survives_monitor_respawn` | granted 4 restarts, MAX=3 |
| `stable_uptime_rearms_the_restart_budget` | granted 4, MAX=3 |
| `darwin-embedded-runtime-warm-tree.test.ts` | npm still a symlink after incremental prepare |

Gates re-run by me on the rebased branch:

- `cargo test` — **949 passed**, 0 failed
- `pnpm test` — **2499 passed**, 0 failed
- `pnpm check` — **exit 0**

## Stated limitations

- **The #3147 test is structural, not behavioral.** The ordering lives inside the Tauri `setup` closure, which needs a real `AppHandle`. The test compares source offsets via `include_str!`. It catches the exact regression (proven above) but does not execute the path.
- **#3152's warm-tree fix cannot be validated against a real CI tree from here.** The test drives the real `prepareNodejs` against a real temp tree with real symlinks and no mocks, but the scenario the issue worries about — macOS CI caching `embedded-runtime/` and shipping symlinks — only appears in a real release build. Unvalidated until a release runs.
- **The new fallback warnings are not asserted.** The triggering condition is tested; the log emission is not, which would need a capture harness.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
