### PR TITLE
fix(e2e): provision Node 24 on the release gate box for pnpm 11

### DIFF
--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -492,6 +492,40 @@ try {
   Import-AgentCredentialArchive
 
   Set-Location `$work
+
+  # The box's baked Node is too old for the toolchain the pipeline uses. pnpm 11
+  # requires Node >= 22.13 (it imports node:sqlite); #3136 moved the box to
+  # pnpm 11 but left it on the baked Node 20, so the frozen install crashed with
+  # ERR_UNKNOWN_BUILTIN_MODULE. Provision the pipeline's Node major here and put
+  # it first on PATH, so the harness no longer depends on whatever Node is baked
+  # into the box — the same reason it no longer depends on a baked pnpm. Keep
+  # this major aligned with node-version in .github/workflows/release.yml.
+  `$nodeVersion = "v24.18.0"
+  `$nodeDirName = "node-`$nodeVersion-win-x64"
+  `$nodeZip = Join-Path `$work "`$nodeDirName.zip"
+  `$nodeUrl = "https://nodejs.org/dist/`$nodeVersion/`$nodeDirName.zip"
+  Write-TaskLog "Provisioning Node `$nodeVersion for the harness toolchain"
+  `$previousProgress = `$ProgressPreference
+  `$ProgressPreference = "SilentlyContinue"
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  try {
+    Invoke-WebRequest -Uri `$nodeUrl -OutFile `$nodeZip -UseBasicParsing -TimeoutSec 120
+    Expand-Archive -LiteralPath `$nodeZip -DestinationPath `$work -Force
+  } finally {
+    `$ProgressPreference = `$previousProgress
+  }
+  `$nodeDir = Join-Path `$work `$nodeDirName
+  if (-not (Test-Path -LiteralPath (Join-Path `$nodeDir "node.exe"))) {
+    throw "Node `$nodeVersion did not extract to `$nodeDir"
+  }
+  `$env:PATH = "`$nodeDir;`$env:PATH"
+  `$activeNode = [string](& (Join-Path `$nodeDir "node.exe") --version).Trim()
+  Write-TaskLog "Harness Node is now `$activeNode"
+  `$expectedNodePrefix = "`$((`$nodeVersion -split '\.')[0])."
+  if (-not `$activeNode.StartsWith(`$expectedNodePrefix)) {
+    throw "Expected Node `$expectedNodePrefix* on PATH for the harness, got `$activeNode"
+  }
+
   Write-TaskLog "Using install directory `$installDir"
   Invoke-LoggedNative "Corepack enable" "corepack" @("enable") 120
   Invoke-LoggedNative "Corepack prepare pnpm" "corepack" @("prepare", "pnpm@11", "--activate") 180

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -699,4 +699,38 @@ describe("Windows production e2e release gate", () => {
     expect(patchesAreWorkspaceScoped).toBe(true);
     expect(boxMajor).toBeGreaterThanOrEqual(10);
   });
+
+  it("provisions a Node the box's pnpm can actually run on", () => {
+    // pnpm 11 imports node:sqlite and refuses to run on Node < 22.13. #3136
+    // moved the box to pnpm 11 but left it on the baked Node 20, so the frozen
+    // install crashed with ERR_UNKNOWN_BUILTIN_MODULE and the gate failed the
+    // publish. The harness must provision its own Node, first on PATH, before
+    // the corepack/pnpm steps — and it has to be recent enough for pnpm 11.
+    const provisioned = taskUserRunner.match(
+      /\$nodeVersion\s*=\s*"v(\d+)\.\d+\.\d+"/,
+    );
+    expect(provisioned).not.toBeNull();
+    const nodeMajor = Number(provisioned?.[1]);
+
+    // pnpm 11's floor is Node 22.13; require the major that ships node:sqlite.
+    expect(nodeMajor).toBeGreaterThanOrEqual(22);
+
+    // The provision must precede the corepack/pnpm activation, or the box's
+    // baked Node is still what runs the install.
+    const provisionAt = taskUserRunner.indexOf("$nodeVersion");
+    const corepackAt = taskUserRunner.indexOf('"Corepack enable"');
+    expect(provisionAt).toBeGreaterThanOrEqual(0);
+    expect(corepackAt).toBeGreaterThan(provisionAt);
+
+    // And it must actually lead PATH, not just be downloaded. The task body is
+    // a here-string, so `$` is backtick-escaped in the raw file.
+    expect(taskUserRunner).toContain('"`$nodeDir;`$env:PATH"');
+
+    // Keep the harness Node major aligned with the pipeline's.
+    const releaseNodeMajor = Number(
+      releaseWorkflow.match(/node-version:\s*(\d+)/)?.[1],
+    );
+    expect(releaseNodeMajor).toBeGreaterThan(0);
+    expect(nodeMajor).toBe(releaseNodeMajor);
+  });
 });


### PR DESCRIPTION
## The v3.72.0 release did not publish

The release run reached `windows-app-e2e`, activated pnpm 11 exactly as #3136 intended, then crashed the frozen install:

```
[windows-e2e:task] Starting Corepack prepare pnpm
Preparing pnpm@11 for immediate activation...
[windows-e2e:task] Starting pnpm install
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
Node.js v20.20.2
::error::pnpm install failed with exit code 1
```

`windows-app-e2e` is a `needs:` of `publish-release`, so the tag built and the release stayed a draft with 0 assets. **Nothing shipped.**

## Root cause

pnpm 11 imports `node:sqlite` and refuses to run below Node 22.13. #3136 correctly moved the box to pnpm 11 — pnpm 9/10 can't read the workspace-scoped `patchedDependencies` — but the box's baked Node is 20.20.2, so it swapped a pnpm incompatibility for a Node one. The box was a straggler on Node the same way it had been on pnpm.

This is the exact "layer that fails cannot be reached in a unit test" case flagged in the #3136 PR: #3136 was verified against the real lockfile locally (on Node 26), but the box's Node 20 is only observable in a real release run — which is what surfaced it.

## Fix

The harness downloads the pipeline's Node major (24.18.0) and puts it first on PATH before the corepack/pnpm steps, so the frozen install runs under Node 24 regardless of what's baked into the box — the same reason it no longer depends on a baked pnpm. The Node zip ships `corepack`/`npm`/`npx`, and `Start-Job` children inherit the process PATH, so every downstream harness command (corepack, pnpm, the npm global CLI installs, playwright) resolves the provisioned Node.

## Verification

- The pinned **Node 24.18.0 Windows x64 zip is live** (HTTP 200) and ships `corepack.cmd`, `npm.cmd`, `npx.cmd`, `node.exe` at the top level — confirmed by downloading and listing it.
- **pnpm 10 reproduces the same `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` as pnpm 9** against the real tree, confirming pnpm 11 — and therefore Node 22.13+ — is the only combination that reads the workspace `patchedDependencies`. There is no pnpm version that both reads the workspace file and runs on Node 20.
- New gate test asserts the harness provisions a Node **≥ 22** that **leads PATH before corepack**, and that its major **matches `node-version` in the release workflow**. Negative controls: Node pinned to v20 → fails `expected 20 to be >= 22`; provisioning block removed → fails the not-null check.
- `pnpm test` — **2527 passed**, 0 failed. `pnpm check` — exit 0.

## Stated limitation

The on-box PowerShell path is validated only by the next real release run — local pwsh cannot parse in this environment (a known constraint, and the reason #3136's residual surfaced here rather than earlier). This time the fix is written against the **exact failure signature** from a real run, and the structural test prevents the box's Node from silently drifting below the toolchain again.

Once merged, the fix is re-run against tag `v3.72.0` (the tag and commit are correct; only the box tooling was wrong).

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
