### PR TITLE
fix(e2e): ship pnpm-workspace.yaml and patches in the release payload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1684,9 +1684,17 @@ jobs:
           fi
           signing_blocked="$(jq -r 'if .blocked == true then "true" else "false" end' "$budget_state")"
           payload="$RUNNER_TEMP/windows-e2e-payload.zip"
+          # pnpm-workspace.yaml and patches/ are required for the box's frozen
+          # install: pnpm 11 reads patchedDependencies from the workspace file,
+          # and the lockfile references patches/happy@1.2.0.patch. Without them
+          # the install aborts with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH (config
+          # empty) or ENOENT (patch missing), failing the gate that
+          # publish-release needs. #3136
           zip -q -r "$payload" \
             package.json \
             pnpm-lock.yaml \
+            pnpm-workspace.yaml \
+            patches \
             scripts/windows-e2e-task-user.ps1 \
             scripts/windows-e2e-app.ps1 \
             scripts/windows-e2e-app.mjs

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -700,6 +700,29 @@ describe("Windows production e2e release gate", () => {
     expect(boxMajor).toBeGreaterThanOrEqual(10);
   });
 
+  it("ships every file the box's frozen install needs", () => {
+    // The box runs `pnpm install --frozen-lockfile` against the payload zip.
+    // pnpm 11 reads patchedDependencies from pnpm-workspace.yaml and the
+    // lockfile references patches/happy@1.2.0.patch. A payload with only
+    // package.json + pnpm-lock.yaml aborts with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
+    // (no workspace config) or ENOENT (no patch), failing the gate that
+    // publish-release needs. #3136
+    const stageJob = workflowJob("windows-app-e2e");
+    const zipCmd = stageJob.slice(
+      stageJob.indexOf('zip -q -r "$payload"'),
+    );
+    const line = zipCmd.slice(0, zipCmd.indexOf("prefix="));
+
+    for (const required of [
+      "package.json",
+      "pnpm-lock.yaml",
+      "pnpm-workspace.yaml",
+      "patches",
+    ]) {
+      expect(line).toContain(required);
+    }
+  });
+
   it("provisions a Node the box's pnpm can actually run on", () => {
     // pnpm 11 imports node:sqlite and refuses to run on Node < 22.13. #3136
     // moved the box to pnpm 11 but left it on the baked Node 20, so the frozen


### PR DESCRIPTION
Fixes #3136 at its real root. **This is the last thing between us and a published v3.72.0.**

## The onion, fully peeled

The Windows e2e gate has failed the release three ways, each hidden behind the last:

1. **#3136** — box ran pnpm 9, which can't read workspace-scoped `patchedDependencies`. Bumped to pnpm 11.
2. **#3166** — box ran Node 20, and pnpm 11 needs Node 22.13+ (`node:sqlite`). Provisioned Node 24. The latest run confirms this worked: `Harness Node is now v24.18.0`, pnpm 11 activated, `Lockfile passes supply-chain policies`.
3. **This** — with pnpm 11 finally running, it surfaced the actual defect: the payload zip never shipped the files a frozen install needs.

## Root cause

`release.yml` built the e2e payload from `package.json` + `pnpm-lock.yaml` only. The lockfile declares `patchedDependencies`, and pnpm 11 reads that config from `pnpm-workspace.yaml` — absent from the payload — so the box compared a populated lockfile against an empty config and aborted with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.

This was the true cause all along. #3136 correctly identified the mismatch but attributed it to the pnpm version; the deeper issue is that `pnpm-workspace.yaml` and `patches/` were never in the payload. I own that miss — at #3136 I verified pnpm 11 against a tree that *had* the workspace file rather than auditing what the payload actually shipped.

## Fix

The payload now includes `pnpm-workspace.yaml` and `patches/`.

## Verification — validated locally against the exact box condition

Reproduced with the box's own pnpm (11.15.1), no mocks:

```
package.json + pnpm-lock.yaml only        → ERR_PNPM_LOCKFILE_CONFIG_MISMATCH   (the box error)
+ pnpm-workspace.yaml (no patches)         → ENOENT: patches/happy@1.2.0.patch
+ pnpm-workspace.yaml + patches/           → Done in 11.2s, happy patch applied, node_modules/happy present
```

Both files are required; both are shipped. Unlike #3166's on-box PowerShell, this fix is fully validated locally — the repro is the exact tree the box unzips.

New gate test asserts the payload carries `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, and `patches`. Negative control: removing the two additions fails with `expected ... to contain 'pnpm-workspace.yaml'`. Full suite green.

Once merged, retag v3.72.0 at the new HEAD and re-run the release.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
