### PR TITLE
ci(release): use curated release notes automatically when present

### DIFF
--- a/.github/release-notes/v3.72.0.md
+++ b/.github/release-notes/v3.72.0.md
@@ -1,0 +1,36 @@
+## What's New
+
+Seren Desktop **v3.72.0** adds Grok as a native agent and delivers a broad hardening pass on Happy remote access, the agent file boundary, and the embedded runtime.
+
+### ✨ Grok as a native agent
+
+- **Grok runs natively through the shared ACP runtime.** Grok joins Claude, Codex, Gemini, and LM Studio as a first-class coding agent, with cancel, permission, and model dispatch routed through the same path as the other native agents. Install and sign-in are handled on first launch, and an org policy (`allow_grok_agent`) gates availability — an org that has already locked down every other local agent keeps Grok closed on upgrade rather than gaining it silently (#3087, #3154, #3163).
+
+### 📱 Remote access (Happy)
+
+- **Phone prompts sent mid-turn are queued, not dropped.** A prompt submitted from the mobile client while a turn is running now waits for the active turn and then runs exactly once, across every native agent including LM Studio (#3134, #3145, #3146).
+- **Assistant replies arrive intact.** Provider turns are correlated so replies reach the controlling client, and streamed fragments coalesce into a single message instead of one bubble per token (#3157, #3159).
+- **Shared-folder consent is enforced consistently.** Only folders shown as shared in Settings are reachable from a paired device; the app and the bridge now derive that set from the same place, and pairing is cancelled when the settings section closes so a scanned code cannot linger (#3144, #3151, #3164).
+- **Provider events are no longer lost on restart.** Notifications that arrive before the bridge subscribes are buffered, closing a window where a restart during a live turn could wedge a session's prompt queue; bridge write failures now surface instead of reporting success (#3150, #3153).
+- **Additional reliability.** Sessions recover when their stored history cannot be read, prompt echoes are suppressed, mobile tool and file output is bounded, and the patched Happy runtime ships with the bundle (#3116, #3119, #3125, #3130, #3132, #3141).
+
+### 🔒 Agent file boundary
+
+- **The project boundary no longer disables the agent.** On Linux the sandbox stops hard-failing when its OS dependencies are absent, so the agent starts instead of aborting; credential directories are denied without cutting off `~/.gitconfig` or `$HOME`-installed toolchains, so `git commit` and build commands keep working. Read Only mode denies writes to sensitive paths outright rather than offering an approval prompt (#3097, #3143).
+- **Windows shell scope is stated honestly.** On native Windows the OS sandbox is unavailable, so Settings now makes clear that the boundary covers the file, search, and web tools only, and points at Approval Policy for shell commands (#3149).
+
+### 📝 Agent output
+
+- **Markdown survives validation.** Output validation no longer destroys Markdown, discloses any substitutions it makes, and constrains `publisher_unavailable` to genuine capability claims (#3107, #3110, #3111).
+
+### 👥 Employees
+
+- **Clearer spend and health.** Since-launch spend refreshes and converges after a run completes, health controls and run costs read more clearly, and imported skill instructions render as Markdown (#3077, #3081, #3085, #3094, #3113).
+
+### ⚙️ Embedded runtime and updates
+
+- **The bundled runtime is used where it should be.** Node resolves from the embedded PATH before it is exported, Claude Code's PATH includes the bundled runtime, and a crash-looping provider runtime is now bounded rather than restarting forever. Background CLI updates verify before reporting success (#3096, #3147, #3148, #3156, #3165).
+
+### 🛠 Windows and release pipeline
+
+- **The Windows e2e release gate is healthy again.** The gate box provisions Node 24 and the release payload carries `pnpm-workspace.yaml` and `patches/`, so the frozen install runs and the gate certifies the build. NSIS installs progress to completion and every build platform is reported on failure (#3099, #3136, #3166, #3167).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,22 +76,32 @@ jobs:
       - name: Generate release notes
         id: release_notes
         run: |
-          # Get previous tag
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          # A curated changelog at .github/release-notes/<tag>.md is used verbatim
+          # as the "What's New" body when present; otherwise fall back to the
+          # commit list. Either way the Installation/Note footer below is always
+          # appended, so the boilerplate stays single-sourced and cannot drift.
+          # This replaces hand-editing the release body after publish.
+          CURATED=".github/release-notes/${GITHUB_REF_NAME}.md"
 
-          if [ -z "$PREV_TAG" ]; then
-            # First release - get all commits
-            COMMITS=$(git log --pretty=format:"- %s" --no-merges | head -20)
-          else
-            # Get commits since previous tag
-            COMMITS=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s" --no-merges)
-          fi
-
-          # Create release body by writing commits directly (avoid sed issues with special chars)
+          # Create release body (avoid sed issues with special chars)
           {
-            echo "## What's New"
-            echo ""
-            echo "$COMMITS"
+            if [ -f "$CURATED" ]; then
+              echo "Using curated release notes from $CURATED" >&2
+              cat "$CURATED"
+            else
+              echo "No curated notes at $CURATED; using the commit list" >&2
+              # Get previous tag
+              PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+              echo "## What's New"
+              echo ""
+              if [ -z "$PREV_TAG" ]; then
+                # First release - get all commits
+                git log --pretty=format:"- %s" --no-merges | head -20
+              else
+                # Get commits since previous tag
+                git log ${PREV_TAG}..HEAD --pretty=format:"- %s" --no-merges
+              fi
+            fi
             echo ""
             echo "## Installation"
             echo ""

--- a/tests/unit/release-notes-curated.test.ts
+++ b/tests/unit/release-notes-curated.test.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Guards the curated release-notes mechanism in the release workflow.
+// ABOUTME: Curated notes must be picked up automatically, never hand-edited post-publish.
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const releaseWorkflow = readFileSync(
+  join(root, ".github/workflows/release.yml"),
+  "utf8",
+);
+
+describe("curated release notes", () => {
+  it("reads a per-tag curated file from .github/release-notes when present", () => {
+    // The release body was hand-edited after publish for good releases and
+    // left as the raw commit dump otherwise. The workflow must pick up a
+    // curated changelog automatically so the format cannot regress by neglect.
+    expect(releaseWorkflow).toContain(
+      'CURATED=".github/release-notes/${GITHUB_REF_NAME}.md"',
+    );
+    expect(releaseWorkflow).toMatch(/if \[ -f "\$CURATED" \]; then\s+.*cat "\$CURATED"/s);
+  });
+
+  it("still falls back to the commit list when no curated file exists", () => {
+    expect(releaseWorkflow).toMatch(/git log .*--pretty=format:"- %s"/);
+  });
+
+  it("always appends the Installation and Note footer regardless of source", () => {
+    // The footer is single-sourced in the workflow, so a curated file only
+    // supplies the What's New body and cannot drift the install instructions.
+    const gen = releaseWorkflow.slice(
+      releaseWorkflow.indexOf("Generate release notes"),
+      releaseWorkflow.indexOf("> release_notes.md"),
+    );
+    const curatedAt = gen.indexOf('cat "$CURATED"');
+    const installAt = gen.indexOf('echo "## Installation"');
+    const noteAt = gen.indexOf('echo "## Note"');
+    expect(curatedAt).toBeGreaterThanOrEqual(0);
+    expect(installAt).toBeGreaterThan(curatedAt);
+    expect(noteAt).toBeGreaterThan(installAt);
+  });
+
+  it("keeps any committed curated file to the changelog only, no duplicated footer", () => {
+    // A curated file must not carry its own Installation/Note — the workflow
+    // appends those. If it did, the published body would show them twice.
+    const dir = join(root, ".github/release-notes");
+    if (!existsSync(dir)) return;
+    for (const file of readdirSync(dir).filter((f) => f.endsWith(".md"))) {
+      const body = readFileSync(join(dir, file), "utf8");
+      expect(body, `${file} must start with the What's New heading`).toMatch(
+        /^## What's New/,
+      );
+      expect(body, `${file} must not carry its own Installation footer`).not.toContain(
+        "## Installation",
+      );
+    }
+  });
+});


### PR DESCRIPTION
Makes curated release notes automatic, so the format cannot regress by neglect.

## Why

The workflow has **always** written the raw `git log` as the release body (added in `8ee9e7a2`, never changed). Readable notes only happened when the published release was hand-edited afterward — which is exactly why v3.66.0 / v3.70.0 / v3.70.1 look curated and v3.67.0–v3.69.0 / v3.71.0 are commit dumps. There was never an automated path; I was hand-editing the good ones.

## What this does

The notes step uses `.github/release-notes/<tag>.md` verbatim as the What's New body when it exists, and falls back to the commit list when it does not. The Installation/Note footer is always appended, so the boilerplate is single-sourced and a curated file only supplies the changelog. Committing the notes alongside the release that ships them removes the post-publish hand-edit for good.

`docs/` is gitignored, so the notes live under `.github/release-notes/`.

## Included

- The curated `v3.72.0.md` changelog, in the v3.66.0 house style (emoji section headers, prose bullets, PR refs).
- A test guarding the mechanism: the workflow must read the per-tag file, still fall back to commits, and append the footer; any committed notes file must be changelog-only so the footer is not duplicated. Negative control: pointing the workflow at the wrong dir fails the read assertion.

## Verified locally

Ran the exact generation logic: file present -> curated body emitted; file absent -> commit list. Both append the footer. `pnpm check` exit 0.

## Note on this release

The in-progress v3.72.0 run already passed `create-release`, so its body is locked to the commit dump. See the separate decision on whether to fold this into v3.72.0 (retag) or apply it from v3.72.1 onward.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com