### PR TITLE
fix(e2e): install only the driver deps on the release gate box

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1694,17 +1694,15 @@ jobs:
           fi
           signing_blocked="$(jq -r 'if .blocked == true then "true" else "false" end' "$budget_state")"
           payload="$RUNNER_TEMP/windows-e2e-payload.zip"
-          # pnpm-workspace.yaml and patches/ are required for the box's frozen
-          # install: pnpm 11 reads patchedDependencies from the workspace file,
-          # and the lockfile references patches/happy@1.2.0.patch. Without them
-          # the install aborts with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH (config
-          # empty) or ENOENT (patch missing), failing the gate that
-          # publish-release needs. #3136
-          zip -q -r "$payload" \
-            package.json \
-            pnpm-lock.yaml \
-            pnpm-workspace.yaml \
-            patches \
+          # The box drives the installed app over CDP; it does not run the app
+          # from source, so it needs only the test driver's two deps
+          # (@playwright/test + ws), not the app's ~1100-package tree. Installing
+          # the full tree timed out the box's frozen install at 1200s. Ship the
+          # minimal driver manifest as the payload's package.json/pnpm-lock.yaml
+          # instead — it has no patchedDependencies, so the workspace file and
+          # patches/ are unnecessary too. #3136
+          ( cd scripts/windows-e2e-driver && zip -q "$payload" package.json pnpm-lock.yaml )
+          zip -q "$payload" \
             scripts/windows-e2e-task-user.ps1 \
             scripts/windows-e2e-app.ps1 \
             scripts/windows-e2e-app.mjs

--- a/scripts/windows-e2e-driver/package.json
+++ b/scripts/windows-e2e-driver/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "seren-windows-e2e-driver",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Minimal dependency set the Windows e2e box installs to drive the installed app over CDP. The app under test ships its own runtime; this is only the test driver.",
+  "dependencies": {
+    "@playwright/test": "1.61.1",
+    "ws": "8.18.3"
+  }
+}

--- a/scripts/windows-e2e-driver/pnpm-lock.yaml
+++ b/scripts/windows-e2e-driver/pnpm-lock.yaml
@@ -1,0 +1,69 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@playwright/test':
+        specifier: 1.61.1
+        version: 1.61.1
+      ws:
+        specifier: 8.18.3
+        version: 8.18.3
+
+packages:
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+snapshots:
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  ws@8.18.3: {}

--- a/scripts/windows-e2e-task-user.ps1
+++ b/scripts/windows-e2e-task-user.ps1
@@ -529,7 +529,10 @@ try {
   Write-TaskLog "Using install directory `$installDir"
   Invoke-LoggedNative "Corepack enable" "corepack" @("enable") 120
   Invoke-LoggedNative "Corepack prepare pnpm" "corepack" @("prepare", "pnpm@11", "--activate") 180
-  Invoke-LoggedNative "pnpm install" "pnpm" @("install", "--frozen-lockfile") 1200
+  # Installs the minimal e2e driver manifest (@playwright/test + ws), not the
+  # app's full tree, so this completes in seconds. The tight timeout turns a
+  # hung install into a fast failure instead of a 20-minute stall. #3136
+  Invoke-LoggedNative "pnpm install" "pnpm" @("install", "--frozen-lockfile") 300
   # #3096 intentionally removed provider-startup installation. The release
   # user is disposable and starts empty, so provision its real CLI prerequisites
   # explicitly as test setup using the vendors' documented npm packages. This

--- a/tests/unit/windows-e2e-release-gate.test.ts
+++ b/tests/unit/windows-e2e-release-gate.test.ts
@@ -668,17 +668,8 @@ describe("Windows production e2e release gate", () => {
   });
 
   it("activates the same pnpm major on the e2e box as the release build", () => {
-    // The box runs `pnpm install --frozen-lockfile`. pnpm 10 moved
-    // patchedDependencies from package.json into pnpm-workspace.yaml, so a
-    // pnpm 9 box reads an empty config, sees the key in the lockfile, and
-    // aborts with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH — failing the gate that
-    // publish-release needs, so the tag never publishes (#3136).
-    const workspace = readFileSync(join(root, "pnpm-workspace.yaml"), "utf8");
-    const lockfile = readFileSync(join(root, "pnpm-lock.yaml"), "utf8");
-    const patchesAreWorkspaceScoped =
-      /^patchedDependencies:/m.test(workspace) &&
-      /^patchedDependencies:/m.test(lockfile);
-
+    // The box and the release build should use the same pnpm major so the
+    // frozen install behaves identically. #3136 moved the box off pnpm 9.
     const activated = taskUserRunner.match(
       /"prepare",\s*"pnpm@(\d+)"/,
     );
@@ -692,35 +683,46 @@ describe("Windows production e2e release gate", () => {
     );
     expect(releaseMajor).toBeGreaterThan(0);
     expect(boxMajor).toBe(releaseMajor);
-
-    // The mismatch above is only silent-fatal while patches live in the
-    // workspace file; assert the precondition so this test explains itself
-    // if the patch declaration ever moves back.
-    expect(patchesAreWorkspaceScoped).toBe(true);
     expect(boxMajor).toBeGreaterThanOrEqual(10);
   });
 
-  it("ships every file the box's frozen install needs", () => {
-    // The box runs `pnpm install --frozen-lockfile` against the payload zip.
-    // pnpm 11 reads patchedDependencies from pnpm-workspace.yaml and the
-    // lockfile references patches/happy@1.2.0.patch. A payload with only
-    // package.json + pnpm-lock.yaml aborts with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
-    // (no workspace config) or ENOENT (no patch), failing the gate that
-    // publish-release needs. #3136
-    const stageJob = workflowJob("windows-app-e2e");
-    const zipCmd = stageJob.slice(
-      stageJob.indexOf('zip -q -r "$payload"'),
+  it("ships the minimal driver manifest, not the app's full tree", () => {
+    // The box drives the installed app over CDP; it needs only the driver's
+    // two deps (@playwright/test + ws). Shipping the app's ~1100-package tree
+    // timed out the box's frozen install at 1200s, failing the gate that
+    // publish-release needs. The payload must carry the driver manifest from
+    // scripts/windows-e2e-driver, and must NOT carry the app's package.json,
+    // workspace file, or patches. #3136
+    const payloadAt = releaseWorkflow.indexOf(
+      'payload="$RUNNER_TEMP/windows-e2e-payload.zip"',
     );
-    const line = zipCmd.slice(0, zipCmd.indexOf("prefix="));
+    expect(payloadAt).toBeGreaterThanOrEqual(0);
+    const zipSection = releaseWorkflow.slice(
+      payloadAt,
+      releaseWorkflow.indexOf("prefix=", payloadAt),
+    );
 
-    for (const required of [
-      "package.json",
-      "pnpm-lock.yaml",
-      "pnpm-workspace.yaml",
-      "patches",
-    ]) {
-      expect(line).toContain(required);
-    }
+    // Manifest sourced from the driver directory.
+    expect(zipSection).toMatch(
+      /cd scripts\/windows-e2e-driver && zip[^\n]*package\.json pnpm-lock\.yaml/,
+    );
+    // The app's full tree must not be shipped.
+    expect(zipSection).not.toContain("pnpm-workspace.yaml");
+    expect(zipSection).not.toMatch(/^\s*patches\b/m);
+
+    // The driver manifest exists, is minimal, and carries no patchedDependencies.
+    const manifest = JSON.parse(
+      readFileSync(join(root, "scripts/windows-e2e-driver/package.json"), "utf8"),
+    );
+    expect(Object.keys(manifest.dependencies).sort()).toEqual([
+      "@playwright/test",
+      "ws",
+    ]);
+    const driverLock = readFileSync(
+      join(root, "scripts/windows-e2e-driver/pnpm-lock.yaml"),
+      "utf8",
+    );
+    expect(driverLock).not.toContain("patchedDependencies");
   });
 
   it("provisions a Node the box's pnpm can actually run on", () => {


### PR DESCRIPTION
Fixes #3136 at the true root — the fourth and final layer of this gate failure.

## Progress so far

Each fix cleared one layer and exposed the next:

1. #3136 pnpm 9 -> 11 · 2. #3166 Node 20 -> 24 · 3. #3167 payload shipped the workspace file + patches

With those, the box's `pnpm install` finally **ran** — and timed out at **1200s**.

## Root cause

`pnpm install --frozen-lockfile` was installing the app's **~1100-package tree**. But the box drives the *installed* app over CDP — it never runs the app from source. The harness (`scripts/windows-e2e-app.mjs`) imports exactly two packages:

```js
import { chromium } from "@playwright/test";
import { WebSocket } from "ws";
```

So it was downloading 1095 packages it never uses, on a fresh store, and timing out. The earlier runs never reached this because they died at the config check *before* downloading.

## Fix

Ship a minimal driver manifest (`scripts/windows-e2e-driver/`, just `@playwright/test` + `ws`) as the payload's `package.json`/`pnpm-lock.yaml`. A two-dep manifest has no `patchedDependencies`, so `pnpm-workspace.yaml` and `patches/` are no longer needed on the box — this supersedes #3167's payload additions.

## Verified locally against the exact box condition (fresh store)

```
$ pnpm install --frozen-lockfile --store-dir <fresh>
+ @playwright/test 1.61.1
+ ws 8.18.3
Done in 873ms                          # was: timeout at 1200s

$ node -e "import('@playwright/test').then(m=>...)"  -> chromium.connectOverCDP is fn: true
$ import { WebSocket } from "ws"                       -> WebSocket is fn: true
$ pnpm exec playwright install chromium               -> Chrome Headless Shell downloaded, exit 0
```

Unlike the box-only PowerShell paths, **this fix is fully validated locally** — the minimal frozen install, both harness imports, and the browser install all run here against a fresh store.

The box install timeout drops to 300s so a hang fails fast. Gate test asserts the payload ships the driver manifest, not the app's tree/workspace/patches; negative control (pointing back at the full tree) fails it. Full suite 2532 green.

## Cost note

This is the 4th e2e-gate iteration; each build run signs ~7 SSL.com operations (~$36 of $100 monthly budget used, within budget). Had I audited what the box actually needs at #3136 — rather than the pnpm version in isolation — layers 1–4 would have been one fix. Owning that.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
