### PR TITLE
fix(memory): surface MCP tool errors

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7977,7 +7977,7 @@ dependencies = [
 [[package]]
 name = "seren-memory-sdk"
 version = "0.1.0"
-source = "git+https://github.com/serenorg/seren-memory-sdk.git?branch=main#ed22cff8aaf65566e7a753d1ee37c8a68722953b"
+source = "git+https://github.com/serenorg/seren-memory-sdk.git?branch=main#f8602f5113349e044f055a5ad90552596e7c8f59"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -135,7 +135,11 @@ impl MemoryState {
             body
         };
         let rpc_response: Value = serde_json::from_str(&json_body).map_err(|e| e.to_string())?;
-        parse_mcp_tool_result(rpc_response)
+        let parsed = parse_mcp_tool_result(rpc_response);
+        if let Err(error) = &parsed {
+            log::warn!("memory tool {tool_name} failed: {error}");
+        }
+        parsed
     }
 }
 
@@ -181,14 +185,23 @@ fn parse_mcp_tool_result(rpc_response: Value) -> Result<Value, String> {
     if let Some(error) = rpc_response.get("error") {
         return Err(error.to_string());
     }
-    let text = rpc_response
+    let result = rpc_response
         .get("result")
-        .and_then(|r| r.get("content"))
+        .ok_or_else(|| "unexpected MCP response format".to_string())?;
+    let text = result
+        .get("content")
         .and_then(|c| c.as_array())
         .and_then(|items| items.first())
         .and_then(|item| item.get("text"))
-        .and_then(Value::as_str)
-        .ok_or_else(|| "unexpected MCP response format".to_string())?;
+        .and_then(Value::as_str);
+
+    if result.get("isError").and_then(Value::as_bool) == Some(true) {
+        return Err(text
+            .map(ToString::to_string)
+            .unwrap_or_else(|| result.to_string()));
+    }
+
+    let text = text.ok_or_else(|| "unexpected MCP response format".to_string())?;
 
     match serde_json::from_str(text) {
         Ok(value) => Ok(value),
@@ -750,6 +763,20 @@ mod tests {
         });
         let parsed = parse_mcp_tool_result(response).unwrap();
         assert_eq!(parsed["created_count"], 2);
+    }
+
+    #[test]
+    fn tool_error_result_is_err() {
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "isError": true,
+                "content": [{ "type": "text", "text": "internal error" }]
+            }
+        });
+        let error = parse_mcp_tool_result(response).unwrap_err();
+        assert!(error.contains("internal error"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3178

## Summary

- Treat MCP `result.isError: true` responses as failed memory operations while preserving successful plain-text tool responses.
- Emit the surfaced tool error through the durable Rust log path.
- Pin the desktop SDK dependency to the merged upstream timeout and MCP-error fixes.

## Upstream

The SDK behavior is provided by merged `serenorg/seren-memory-sdk` PRs #14 and #15 (with #12/#13 included in the current main line).

## Verification

- `env CARGO_HOME=/private/tmp/seren-cargo cargo test --manifest-path src-tauri/Cargo.toml memory --locked`
- `pnpm check`
- `git diff --check`

No user paths, emails, tokens, or keys are included in this PR.
