### PR TITLE
fix(memory): bound MCP request and bootstrap latency

### DIFF
--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -3,7 +3,8 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -21,6 +22,14 @@ const AUTH_STORE: &str = "auth.json";
 // cloud call to return HTTP 401, silently falling back to local-only cache.
 // Same credential used by claude_memory.rs (fixed in #1511). Resolves #1540.
 const TOKEN_KEY: &str = "seren_api_key";
+
+static MEMORY_HTTP: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+});
 
 pub const MEMORY_MCP_TOOLS: &[&str] = &[
     "session_bootstrap",
@@ -104,7 +113,7 @@ impl MemoryState {
             }
         });
 
-        let response = reqwest::Client::new()
+        let response = MEMORY_HTTP
             .post(&url)
             .bearer_auth(client.api_key())
             .header("Accept", "application/json, text/event-stream")

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -493,24 +493,70 @@ export async function syncMemories(): Promise<SyncResult | null> {
   }
 }
 
+export function raceWithDeadline<T>(
+  promise: Promise<T>,
+  deadlineMs: number,
+): Promise<T | null> {
+  return new Promise<T | null>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(
+      () => {
+        settled = true;
+        resolve(null);
+      },
+      Math.max(0, deadlineMs),
+    );
+
+    promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
 export async function bootstrapMemoryContextDetails(
   input: {
     tokenBudget?: number;
     orgId?: string;
     projectId?: string | null;
+    deadlineMs?: number;
   } = {},
 ): Promise<MemorySessionBootstrapResult | null> {
   if (!isMemoryAvailable()) {
     return null;
   }
 
+  const deadlineMs = input.deadlineMs ?? 2500;
+  const startedAt = performance.now();
   try {
-    const raw = await invoke("memory_session_bootstrap", {
-      projectId: getProjectId(input.projectId),
-      orgId: input.orgId,
-      tokenBudget: input.tokenBudget,
-    });
+    const raw = await raceWithDeadline(
+      invoke("memory_session_bootstrap", {
+        projectId: getProjectId(input.projectId),
+        orgId: input.orgId,
+        tokenBudget: input.tokenBudget,
+      }),
+      deadlineMs,
+    );
+    if (raw === null) {
+      console.warn(
+        `[Memory] bootstrap deadline ${deadlineMs}ms exceeded — proceeding without memory context`,
+      );
+      return null;
+    }
     const result = normalizeBootstrapResult(raw);
+    console.info(
+      `[Memory] bootstrap served from ${result.source} in ${Math.round(performance.now() - startedAt)}ms`,
+    );
     return result.prompt || result.totalMemories > 0 ? result : null;
   } catch (error) {
     console.warn("[Memory] Failed to bootstrap memory context:", error);

--- a/tests/unit/memory-bootstrap-deadline.test.ts
+++ b/tests/unit/memory-bootstrap-deadline.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { raceWithDeadline } from "@/services/memory";
+
+describe("memory bootstrap deadline", () => {
+  it("returns null at the deadline without waiting for a slow promise", async () => {
+    const startedAt = performance.now();
+    const result = await raceWithDeadline(
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("late"), 100);
+      }),
+      10,
+    );
+
+    expect(result).toBeNull();
+    expect(performance.now() - startedAt).toBeLessThan(80);
+  });
+
+  it("returns a fast promise value", async () => {
+    await expect(raceWithDeadline(Promise.resolve("ready"), 100)).resolves.toBe(
+      "ready",
+    );
+  });
+
+  it("uses the deadline helper for bootstrap", () => {
+    const source = readFileSync(resolve("src/services/memory.ts"), "utf-8");
+    const start = source.indexOf("export async function bootstrapMemoryContextDetails");
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(source.slice(start, start + 1800)).toContain("raceWithDeadline(");
+  });
+});


### PR DESCRIPTION
## Summary
- reuse a bounded shared HTTP client for memory MCP calls
- cap bootstrap context retrieval with a deadline and latency logging
- add real-timer regression coverage for the deadline helper

Fixes #3182

## Verification
- `pnpm vitest run tests/unit/memory-bootstrap-deadline.test.ts`
- `env CARGO_HOME=/private/tmp/seren-cargo cargo test --manifest-path src-tauri/Cargo.toml memory --locked`
- scoped Biome check for changed TypeScript files

The upstream SDK timeout implementation is already merged on main; this PR contains the desktop request reuse and bootstrap deadline. No local paths, email addresses, credentials, or tokens are included.