### PR TITLE
fix(memory): wire recall and consolidation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import { shortcuts } from "@/lib/shortcuts";
 import { captureUnknownError, reportError } from "@/lib/support/hook";
 import { Phase3Playground } from "@/playground/Phase3Playground";
 import { initAutoTopUp } from "@/services/autoTopUp";
-import { syncMemories } from "@/services/memory";
+import { consolidateMemories, syncMemories } from "@/services/memory";
 import { resetUserSessionState } from "@/services/session-state";
 import { telemetry } from "@/services/telemetry";
 import { agentStore } from "@/stores/agent.store";
@@ -220,7 +220,11 @@ function App() {
         checkDailyClaim();
         startDailyClaimPolling();
         // Push any locally-cached memories that failed to reach cloud (e.g. cold start)
-        void syncMemories();
+        void syncMemories()
+          .then(() => consolidateMemories({}))
+          .catch((err) =>
+            console.warn("[App] memory consolidation skipped:", err),
+          );
         void threadStore.refresh();
         // Re-initialize the agent runtime side-channel listeners after a
         // re-login: `resetUserSessionState()` disposes them on logout so

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -33,7 +33,9 @@ import {
 } from "@/services/mcp-gateway";
 import {
   bootstrapMemoryContext,
+  learnFromErrorMemory,
   processAssistantResponseMemory,
+  recallMemoryContext,
 } from "@/services/memory";
 import { authStore } from "@/stores/auth.store";
 import { conversationStore } from "@/stores/conversation.store";
@@ -542,6 +544,10 @@ export async function* streamMessageWithTools(
       if (memoryContext) {
         systemContent += memoryContext;
       }
+      const recall = await recallMemoryContext(content);
+      if (recall) {
+        systemContent += `\n\n${recall.prompt}`;
+      }
     } catch (error) {
       console.warn("[Chat] Failed to retrieve memory context:", error);
     }
@@ -571,6 +577,7 @@ export async function* streamMessageWithTools(
   let yieldedContent = "";
   let hasExecutedTools = false;
   let hasNudged = false;
+  let firstToolError: string | null = null;
 
   for (
     let iteration = 0;
@@ -628,6 +635,17 @@ export async function* streamMessageWithTools(
 
       // Store conversation to memory if enabled
       if (finalOutputValidation.canStoreMemory) {
+        if (firstToolError) {
+          learnFromErrorMemory({
+            errorContent: firstToolError,
+            fixContent: fullContent.slice(0, 2000),
+          }).catch((err) => {
+            console.warn(
+              "[streamMessageWithTools] Failed to learn from tool error:",
+              err,
+            );
+          });
+        }
         processAssistantResponseMemory(fullContent, {
           model,
           userQuery: content,
@@ -687,6 +705,13 @@ export async function* streamMessageWithTools(
     // Log tool execution results
     for (const result of results) {
       if (result.is_error) {
+        if (!firstToolError) {
+          const toolName =
+            response.tool_calls.find(
+              (toolCall) => toolCall.id === result.tool_call_id,
+            )?.function.name ?? result.tool_call_id;
+          firstToolError = `${toolName}: ${result.content.slice(0, 2000)}`;
+        }
         console.warn(
           `[streamMessageWithTools] Tool error: ${result.tool_call_id}`,
           result.content.substring(0, 200),

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -378,6 +378,56 @@ export async function recallMemories(
   }
 }
 
+export async function recallMemoryContext(
+  query: string,
+  limit = 5,
+  deadlineMs = 2500,
+): Promise<{ prompt: string; details: MessageMemoryDetail[] } | null> {
+  if (!isMemoryAvailable() || !query.trim()) {
+    return null;
+  }
+
+  const startedAt = performance.now();
+  const results = await raceWithDeadline(
+    recallMemories(query, limit),
+    deadlineMs,
+  );
+  if (results === null) {
+    console.warn(
+      `[Memory] recall deadline ${deadlineMs}ms exceeded — proceeding without recalled context`,
+    );
+    return null;
+  }
+
+  const details = results
+    .map((record) =>
+      detailFromRecord(
+        {
+          id: record.id,
+          content: record.content,
+          memory_type: record.memory_type,
+        },
+        record.memory_type,
+      ),
+    )
+    .filter((detail): detail is MessageMemoryDetail => detail !== null);
+  if (details.length === 0) {
+    console.info(
+      `[Memory] recall injected 0 memories in ${Math.round(performance.now() - startedAt)}ms`,
+    );
+    return null;
+  }
+
+  const prompt = [
+    "## Relevant memories for this request",
+    ...details.map((detail) => `- [${detail.type}] ${detail.summary}`),
+  ].join("\n");
+  console.info(
+    `[Memory] recall injected ${details.length} memories in ${Math.round(performance.now() - startedAt)}ms`,
+  );
+  return { prompt, details };
+}
+
 export async function listMemories(
   input: {
     memoryType?: string;

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -26,6 +26,7 @@ import {
 import {
   bootstrapMemoryContextDetails,
   processAssistantResponseMemory,
+  recallMemoryContext,
 } from "@/services/memory";
 import { serializeHistory } from "@/services/orchestrator-history";
 import {
@@ -243,6 +244,21 @@ export async function orchestrate(
           ...history,
         ];
         answerMemory = memoryContext.messageMemory;
+      }
+      const recall = await recallMemoryContext(prompt);
+      if (recall) {
+        history = [{ role: "system", content: recall.prompt }, ...history];
+        const existingUsed = answerMemory?.used ?? [];
+        const seenIds = new Set(
+          existingUsed.flatMap((detail) => (detail.id ? [detail.id] : [])),
+        );
+        const newDetails = recall.details.filter(
+          (detail) => !detail.id || !seenIds.has(detail.id),
+        );
+        answerMemory = {
+          ...(answerMemory ?? {}),
+          used: [...existingUsed, ...newDetails],
+        };
       }
     } catch (error) {
       console.warn("[orchestrator] Failed to retrieve memory context:", error);

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -548,6 +548,7 @@ import {
 import {
   bootstrapMemoryContext,
   processAssistantResponseMemory,
+  recallMemoryContext,
 } from "@/services/memory";
 import {
   getCachedModelContextWindow,
@@ -4451,6 +4452,20 @@ export const agentStore = {
         { type: "text", text: session.bootstrapPromptContext },
         ...mergedContext,
       ];
+    }
+
+    if (settingsStore.settings.memoryEnabled && promptForBudget?.trim()) {
+      try {
+        const recall = await recallMemoryContext(promptForBudget);
+        if (recall) {
+          mergedContext = [
+            { type: "text", text: recall.prompt },
+            ...mergedContext,
+          ];
+        }
+      } catch (error) {
+        console.warn("[AgentStore] Memory recall failed (non-fatal):", error);
+      }
     }
 
     if (!alreadyPrimed) {

--- a/tests/unit/memory-recall-wiring.test.ts
+++ b/tests/unit/memory-recall-wiring.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const readSource = (path: string) => readFileSync(resolve(path), "utf-8");
+
+describe("memory recall wiring", () => {
+  it("injects recall into the orchestrator and chat paths", () => {
+    expect(readSource("src/services/orchestrator.ts")).toContain(
+      "recallMemoryContext(",
+    );
+    const chatSource = readSource("src/services/chat.ts");
+    expect(chatSource).toContain("recallMemoryContext(");
+    expect(chatSource).toContain("learnFromErrorMemory(");
+  });
+
+  it("injects recall into agent prompt context", () => {
+    const source = readSource("src/stores/agent.store.ts");
+    const start = source.indexOf("async buildPromptContext(");
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(source.slice(start, start + 5000)).toContain(
+      "recallMemoryContext(",
+    );
+  });
+
+  it("consolidates memories after authenticated sync", () => {
+    expect(readSource("src/App.tsx")).toContain("consolidateMemories");
+  });
+});


### PR DESCRIPTION
Fixes #3183

Wires memory recall into orchestration, chat, and agent prompt context; learns from the first tool error after a storable response; and consolidates memories after authenticated startup sync. Includes source-level coverage for all four integration points.

The SDK error propagation and HTTP timeout changes are already merged upstream and in desktop main.