### PR TITLE
fix(memory): clarify remembered detail provenance

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -1683,11 +1683,12 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                                 );
                               }}
                             >
-                              Used {(message.memory?.used ?? []).length}{" "}
-                              remembered detail
+                              {(message.memory?.used ?? []).length} remembered
+                              detail
                               {(message.memory?.used ?? []).length === 1
                                 ? ""
-                                : "s"}
+                                : "s"}{" "}
+                              available
                             </button>
                             <button
                               type="button"
@@ -2240,11 +2241,12 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
       >
         <div class="px-5 pb-6 pt-12">
           <h2 class="m-0 text-base font-semibold text-foreground">
-            Memory used in this answer
+            Memory available to this answer
           </h2>
           <p class="mt-2 mb-4 text-[12px] leading-relaxed text-muted-foreground">
-            These are the remembered details attached to this answer. This panel
-            only covers the current response.
+            These memories were retrieved and made available (injected into
+            context) for this answer. The model may or may not have drawn on
+            them.
           </p>
           <Show when={memoryPanelMessage()}>
             {(panelMessage) => (
@@ -2253,7 +2255,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                   when={(panelMessage().memory?.used ?? []).length > 0}
                   fallback={
                     <div class="rounded border border-border bg-card px-3 py-2 text-[12px] text-muted-foreground">
-                      No remembered details are attached to this answer.
+                      No remembered details are available for this answer.
                     </div>
                   }
                 >

--- a/tests/unit/chat-memory-affordance.test.ts
+++ b/tests/unit/chat-memory-affordance.test.ts
@@ -15,9 +15,13 @@ describe("#2083 chat memory affordance", () => {
     expect(chatContentSource).toContain(
       'import { SlidePanel } from "@/components/layout/SlidePanel"',
     );
-    expect(chatContentSource).toContain("Used ");
+    expect(chatContentSource).toContain("available");
     expect(chatContentSource).toContain(" remembered detail");
-    expect(chatContentSource).toContain("Memory used in this answer");
+    expect(chatContentSource).toContain("Memory available to this answer");
+    expect(chatContentSource).toContain("retrieved and made available");
+    expect(chatContentSource).toContain("may or may not have drawn on");
+    expect(chatContentSource).not.toContain("Memory used in this answer");
+    expect(chatContentSource).not.toContain("Used {");
     expect(chatContentSource).toContain("Something is wrong");
     expect(chatContentSource).toContain("Undo remember");
     expect(chatContentSource).toContain("Do not use here");

--- a/tests/unit/memory-recall-wiring.test.ts
+++ b/tests/unit/memory-recall-wiring.test.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Source-level guards for memory recall, error learning, and consolidation wiring.
+// ABOUTME: Verifies all authenticated prompt and startup integration points remain connected.
+
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";


### PR DESCRIPTION
Fixes #3185

Clarifies that retrieved memories are available to the answer rather than claiming the model used them. Preserves the existing memory detail actions and adds source-level assertions for the honest copy. Also adds the required ABOUTME header to the memory recall wiring test.