### PR TITLE
fix(memory): require real user id for sync, drain queue periodically, keep record scope locally

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7977,7 +7977,7 @@ dependencies = [
 [[package]]
 name = "seren-memory-sdk"
 version = "0.1.0"
-source = "git+https://github.com/serenorg/seren-memory-sdk.git?branch=main#f8602f5113349e044f055a5ad90552596e7c8f59"
+source = "git+https://github.com/serenorg/seren-memory-sdk.git?branch=main#0133c145953bcf133b1d4d76bdbee4d4183607f"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -7,7 +7,7 @@ use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use tauri::State;
 
 use seren_memory_sdk::bootstrap::BootstrapOrchestrator;
@@ -238,6 +238,15 @@ fn insert_optional<T: Serialize>(args: &mut Value, key: &str, value: Option<T>) 
     }
 }
 
+fn parse_sync_user_id(user_id: Option<&str>) -> Result<uuid::Uuid, String> {
+    let user_id = user_id
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "memory sync requires an authenticated user id".to_string())?;
+
+    uuid::Uuid::parse_str(user_id.trim())
+        .map_err(|_| "memory sync user id is not a valid UUID".to_string())
+}
+
 /// Output type for bootstrap (serializable to frontend).
 #[derive(Serialize)]
 pub struct BootstrapResult {
@@ -399,6 +408,12 @@ pub async fn memory_remember(
     // Write to local cache first (synced=false) so memory survives cloud failures
     // such as scale-to-zero cold starts. The sync engine will push pending entries later.
     let local_id = uuid::Uuid::new_v4();
+    let project_uuid = project_id
+        .as_deref()
+        .and_then(|value| uuid::Uuid::parse_str(value).ok());
+    let org_uuid = org_id
+        .as_deref()
+        .and_then(|value| uuid::Uuid::parse_str(value).ok());
     state.ensure_cache()?;
     let cached = CachedMemory {
         id: local_id,
@@ -411,12 +426,14 @@ pub async fn memory_remember(
         synced: false,
         cloud_id: None,
         feedback_signal: None,
-        pinned: false,
+        pinned: pin.unwrap_or(false),
     };
     {
         let guard = state.cache.lock().map_err(|e| e.to_string())?;
         if let Some(cache) = guard.as_ref() {
-            cache.insert_memory(&cached).ok();
+            cache
+                .insert_memory_scoped(&cached, project_uuid, org_uuid)
+                .ok();
         }
     }
 
@@ -711,10 +728,7 @@ pub async fn memory_sync(
     user_id: Option<String>,
     project_id: Option<String>,
 ) -> Result<SyncOutput, String> {
-    let user_uuid = user_id
-        .as_deref()
-        .and_then(|s| uuid::Uuid::parse_str(s).ok())
-        .unwrap_or_else(uuid::Uuid::new_v4);
+    let user_uuid = parse_sync_user_id(user_id.as_deref())?;
     let project_uuid = project_id
         .as_deref()
         .and_then(|s| uuid::Uuid::parse_str(s).ok());
@@ -783,6 +797,24 @@ mod tests {
         assert!(ensure_delete_confirmed(true).is_ok());
         let err = ensure_delete_confirmed(false).unwrap_err();
         assert!(err.contains("requires confirmation"));
+    }
+
+    #[test]
+    fn parse_sync_user_id_rejects_missing_id() {
+        let error = parse_sync_user_id(None).unwrap_err();
+        assert_eq!(error, "memory sync requires an authenticated user id");
+    }
+
+    #[test]
+    fn parse_sync_user_id_rejects_non_uuid() {
+        let error = parse_sync_user_id(Some("not-a-user-id")).unwrap_err();
+        assert_eq!(error, "memory sync user id is not a valid UUID");
+    }
+
+    #[test]
+    fn parse_sync_user_id_accepts_uuid() {
+        let user_id = uuid::Uuid::new_v4();
+        assert_eq!(parse_sync_user_id(Some(&user_id.to_string())), Ok(user_id));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import { shortcuts } from "@/lib/shortcuts";
 import { captureUnknownError, reportError } from "@/lib/support/hook";
 import { Phase3Playground } from "@/playground/Phase3Playground";
 import { initAutoTopUp } from "@/services/autoTopUp";
-import { consolidateMemories, syncMemories } from "@/services/memory";
+import { startMemorySyncLoop, stopMemorySyncLoop } from "@/services/memory";
 import { resetUserSessionState } from "@/services/session-state";
 import { telemetry } from "@/services/telemetry";
 import { agentStore } from "@/stores/agent.store";
@@ -219,12 +219,8 @@ function App() {
         cleanupAutoTopUp = initAutoTopUp();
         checkDailyClaim();
         startDailyClaimPolling();
-        // Push any locally-cached memories that failed to reach cloud (e.g. cold start)
-        void syncMemories()
-          .then(() => consolidateMemories({}))
-          .catch((err) =>
-            console.warn("[App] memory consolidation skipped:", err),
-          );
+        // Drain locally-cached memories immediately and on a periodic interval.
+        startMemorySyncLoop();
         void threadStore.refresh();
         // Re-initialize the agent runtime side-channel listeners after a
         // re-login: `resetUserSessionState()` disposes them on logout so
@@ -251,6 +247,7 @@ function App() {
           cleanupAutoTopUp = null;
         }
         stopAutoRefresh();
+        stopMemorySyncLoop();
         resetUserSessionState();
       });
     }

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -559,7 +559,12 @@ export async function syncMemories(): Promise<SyncResult | null> {
     return null;
   }
 
-  const userId = authStore.user?.id ?? null;
+  const userId = authStore.user?.id;
+  if (!userId) {
+    console.warn("[Memory] Skipping sync: no authenticated user id");
+    return null;
+  }
+
   const projectId = getProjectId();
 
   try {
@@ -571,6 +576,48 @@ export async function syncMemories(): Promise<SyncResult | null> {
     console.warn("[Memory] Failed to sync memories:", error);
     return null;
   }
+}
+
+const MEMORY_SYNC_INTERVAL_MS = 15 * 60 * 1000;
+let syncTimer: number | null = null;
+let syncInFlight = false;
+
+async function drainMemorySync(): Promise<void> {
+  if (syncInFlight) {
+    return;
+  }
+
+  syncInFlight = true;
+  try {
+    const result = await syncMemories();
+    if (result) {
+      await consolidateMemories({});
+    }
+  } catch (error) {
+    console.warn("[Memory] Memory consolidation skipped:", error);
+  } finally {
+    syncInFlight = false;
+  }
+}
+
+export function startMemorySyncLoop(): void {
+  if (syncTimer !== null) {
+    return;
+  }
+
+  void drainMemorySync();
+  syncTimer = window.setInterval(() => {
+    void drainMemorySync();
+  }, MEMORY_SYNC_INTERVAL_MS);
+}
+
+export function stopMemorySyncLoop(): void {
+  if (syncTimer === null) {
+    return;
+  }
+
+  window.clearInterval(syncTimer);
+  syncTimer = null;
 }
 
 export function raceWithDeadline<T>(

--- a/tests/services/memory.test.ts
+++ b/tests/services/memory.test.ts
@@ -58,6 +58,7 @@ import {
   recallMemories,
   rememberMemory,
   storeAssistantResponse,
+  syncMemories,
 } from "@/services/memory";
 
 describe("memory service integration path", () => {
@@ -65,7 +66,21 @@ describe("memory service integration path", () => {
     vi.clearAllMocks();
     memoryEnabledState.enabled = true;
     authStoreMock.isAuthenticated = true;
+    authStoreMock.user = { id: "user-1", email: "user@example.com", name: "User" };
     projectStoreMock.activeProject = { id: "project-1" };
+  });
+
+  it("skips sync when the authenticated state has no user id", async () => {
+    authStoreMock.user = { id: "", email: "user@example.com", name: "User" };
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(syncMemories()).resolves.toBeNull();
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledWith(
+      "[Memory] Skipping sync: no authenticated user id",
+    );
+
+    warning.mockRestore();
   });
 
   it("writes then reads memory with project context", async () => {

--- a/tests/unit/memory-recall-wiring.test.ts
+++ b/tests/unit/memory-recall-wiring.test.ts
@@ -27,6 +27,8 @@ describe("memory recall wiring", () => {
   });
 
   it("consolidates memories after authenticated sync", () => {
-    expect(readSource("src/App.tsx")).toContain("consolidateMemories");
+    const memorySource = readSource("src/services/memory.ts");
+    expect(memorySource).toContain("startMemorySyncLoop");
+    expect(memorySource).toContain("consolidateMemories({})");
   });
 });


### PR DESCRIPTION
Closes #3181

### Changes

- Reject missing, blank, or invalid sync user IDs without inventing an identity.
- Preserve project and organization scope plus pin state in the local cache before retryable cloud sync.
- Drain the queue immediately after authentication and every 15 minutes with an idempotent timer and in-flight guard; stop the loop on logout.
- Pin the lockfile to merged seren-memory-sdk commit 0133c14.

### Verification

- `cargo test --manifest-path src-tauri/Cargo.toml`: 961 passed, 2 ignored.
- `cargo check --manifest-path src-tauri/Cargo.toml`: passed.
- `pnpm test`: 2,542 passed, 15 skipped.
- Focused Biome check for all changed TypeScript and test files: passed.
- `pnpm prepare:mcp-servers`: passed.
- Live unauthenticated route probes were auth-gated at 401; the local service router and legacy-route test establish the MCP contract.

No private data, identifiers, credentials, or memory contents are included in this PR.