### PR TITLE
fix(auth): hydrate restored user before memory sync

### DIFF
--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Tracks user session and installs runtime-specific auth bindings lazily.
 
 import { createStore } from "solid-js/store";
+import { getCurrentUser } from "@/api";
 import { runtimeHasCapability } from "@/lib/runtime";
 import { verboseRuntimeConsole } from "@/lib/runtime-console";
 import {
@@ -180,6 +181,25 @@ function authEpochChanged(expectedEpoch: number | undefined): boolean {
   return expectedEpoch !== undefined && expectedEpoch !== authEpoch;
 }
 
+async function loadCurrentUser(): Promise<User | undefined> {
+  try {
+    const { data } = await getCurrentUser({ throwOnError: false });
+    if (!data?.data) {
+      return undefined;
+    }
+
+    return {
+      id: data.data.id,
+      email: data.data.email,
+      name: data.data.name,
+    };
+  } catch {
+    // Preserve the existing offline session behavior. Downstream services
+    // remain guarded until a later auth refresh hydrates the user.
+    return undefined;
+  }
+}
+
 async function activateAuthenticatedSession(
   user?: User,
   expectedEpoch?: number,
@@ -239,7 +259,7 @@ export async function restoreAuthenticatedSession(
     return false;
   }
 
-  return activateAuthenticatedSession(undefined, expectedEpoch);
+  return activateAuthenticatedSession(await loadCurrentUser(), expectedEpoch);
 }
 
 async function resetSkillsCatalog(): Promise<void> {
@@ -267,7 +287,7 @@ export async function checkAuth(): Promise<void> {
       return;
     }
 
-    await activateAuthenticatedSession();
+    await activateAuthenticatedSession(await loadCurrentUser());
   } finally {
     setState("isLoading", false);
   }

--- a/tests/unit/auth-store-apikey-ordering.test.ts
+++ b/tests/unit/auth-store-apikey-ordering.test.ts
@@ -16,6 +16,7 @@ const {
   resetGatewayMock,
   runtimeHasCapabilityMock,
   getPolicyMock,
+  getCurrentUserMock,
   storedKeyRef,
   listenMock,
   eventListeners,
@@ -40,6 +41,15 @@ const {
     resetGatewayMock: vi.fn(async () => {}),
     runtimeHasCapabilityMock: vi.fn(() => false),
     getPolicyMock: vi.fn(async () => null),
+    getCurrentUserMock: vi.fn(async () => ({
+      data: {
+        data: {
+          id: "u-restored",
+          email: "restored@example.com",
+          name: "Restored User",
+        },
+      },
+    })),
     eventListeners: listeners,
     listenMock: vi.fn(async (event: string, handler: (event?: unknown) => unknown) => {
       listeners.set(event, handler);
@@ -60,6 +70,10 @@ vi.mock("@/services/auth", () => ({
   hasStoredToken: hasStoredTokenMock,
   createApiKey: createApiKeyMock,
   logout: authLogoutMock,
+}));
+
+vi.mock("@/api", () => ({
+  getCurrentUser: getCurrentUserMock,
 }));
 
 vi.mock("@/services/mcp-gateway", () => ({
@@ -169,6 +183,11 @@ describe("auth.store #1613 — API key before isAuthenticated flips", () => {
     expect(authAtStoreTime).toBe(false);
     expect(storedKeyRef.value).toBeTruthy();
     expect(authStore.isAuthenticated).toBe(true);
+    expect(authStore.user).toEqual({
+      id: "u-restored",
+      email: "restored@example.com",
+      name: "Restored User",
+    });
   });
 
   it("setAuthenticated: existing stored key — no create call, still no premature flip", async () => {


### PR DESCRIPTION
Closes #3201

### Changes

- Hydrate the current user from the authenticated profile on cold boot and token-refresh restoration.
- Preserve the existing offline-session fallback when profile hydration is unavailable; the memory sync guard remains authoritative.
- Extend the existing auth-store regression test to assert that a restored user reaches the authenticated state with an ID.

### Verification

- Focused auth-store regression suite: 9 passed.
- Focused Biome check for the changed auth store and regression test: passed.
- `git diff --check`: passed.
- Live `GET /auth/me` preflight for the stored session: HTTP 200 with a user ID present.

No private data, identifiers, credentials, or memory contents are included in this PR.