### PR TITLE
fix(validation): re-root validation app HOME into repo-local scratch dir

### DIFF
--- a/scripts/validate-walkthrough.ts
+++ b/scripts/validate-walkthrough.ts
@@ -3,6 +3,7 @@
 
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
@@ -10,6 +11,11 @@ import {
   acquireValidationSlot,
   type ValidationSlot,
 } from "./validation-slots";
+import {
+  ensureValidationHome,
+  resolvePnpmStoreDir,
+  validationChildEnv,
+} from "./validation-env";
 
 interface DiscoveryFile {
   port: number;
@@ -74,9 +80,24 @@ async function main(): Promise<void> {
   let app: ChildProcess | null = null;
   let discovery: DiscoveryFile | null = null;
   try {
+    const validationHome = await ensureValidationHome(process.cwd(), slot.port);
+    const pnpmStoreDir = await resolvePnpmStoreDir();
+    const childEnv = {
+      ...validationChildEnv({
+        baseEnv: process.env,
+        port: slot.port,
+        repoRoot: process.cwd(),
+        realHome: os.homedir(),
+        pnpmStoreDir,
+      }),
+      SEREN_VALIDATION_DEV_PORT: String(slot.port),
+      SEREN_VALIDATION_INSTANCE: "1",
+    };
+    console.log(`[validate:walkthrough] scratch home ${validationHome}`);
+
     await rm(artifactsDir, { recursive: true, force: true });
     await mkdir(artifactsDir, { recursive: true });
-    app = launchValidationApp(slot);
+    app = launchValidationApp(slot, childEnv);
     discovery = await waitForDiscovery(discoveryPath, discoveryTimeoutMs);
     await waitForFrontendReady(discovery, 60_000);
     const client = createClient(discovery);
@@ -144,7 +165,10 @@ async function waitForFrontendReady(
   throw new Error("Timed out waiting for validation WebView bridge readiness");
 }
 
-function launchValidationApp(slot: ValidationSlot): ChildProcess {
+function launchValidationApp(
+  slot: ValidationSlot,
+  childEnv: NodeJS.ProcessEnv,
+): ChildProcess {
   const child = spawn(
     "pnpm",
     [
@@ -162,7 +186,7 @@ function launchValidationApp(slot: ValidationSlot): ChildProcess {
       cwd: root,
       stdio: "inherit",
       env: {
-        ...process.env,
+        ...childEnv,
         SEREN_VALIDATION_DEV_PORT: String(slot.port),
         SEREN_VALIDATION_INSTANCE: "1",
         SEREN_VALIDATION_DISCOVERY_PATH: discoveryPath,

--- a/scripts/validation-dev.ts
+++ b/scripts/validation-dev.ts
@@ -2,17 +2,38 @@
 // ABOUTME: Releases the slot after the Tauri process and its dev server exit.
 
 import { spawn } from "node:child_process";
+import os from "node:os";
 import { validationDevArgs } from "./validation-dev-args";
+import {
+  ensureValidationHome,
+  resolvePnpmStoreDir,
+  validationChildEnv,
+} from "./validation-env";
 import { acquireValidationSlot } from "./validation-slots";
 
 async function main(): Promise<void> {
   const slot = await acquireValidationSlot();
   const forwardedArgs = validationDevArgs(process.argv.slice(2));
-  console.log(
-    `[validation] leased port ${slot.port} with identifier ${slot.identifier}`,
-  );
 
   try {
+    const validationHome = await ensureValidationHome(process.cwd(), slot.port);
+    const pnpmStoreDir = await resolvePnpmStoreDir();
+    const childEnv = {
+      ...validationChildEnv({
+        baseEnv: process.env,
+        port: slot.port,
+        repoRoot: process.cwd(),
+        realHome: os.homedir(),
+        pnpmStoreDir,
+      }),
+      SEREN_VALIDATION_DEV_PORT: String(slot.port),
+      SEREN_VALIDATION_INSTANCE: "1",
+    };
+
+    console.log(
+      `[validation] leased port ${slot.port} with identifier ${slot.identifier}; scratch home ${validationHome}`,
+    );
+
     const child = spawn(
       "pnpm",
       [
@@ -29,11 +50,7 @@ async function main(): Promise<void> {
       {
         cwd: process.cwd(),
         stdio: "inherit",
-        env: {
-          ...process.env,
-          SEREN_VALIDATION_DEV_PORT: String(slot.port),
-          SEREN_VALIDATION_INSTANCE: "1",
-        },
+        env: childEnv,
       },
     );
 

--- a/scripts/validation-env.ts
+++ b/scripts/validation-env.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Builds hermetic child-process environments for validation app launches.
+// ABOUTME: Keeps app state in the worktree while preserving host toolchain caches.
+
+import { execFile } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export function validationHomeForSlot(repoRoot: string, port: number): string {
+  assertValidPort(port);
+  return path.join(repoRoot, "artifacts", "validation-home", `slot${port}`);
+}
+
+export function validationChildEnv(inputs: {
+  baseEnv: NodeJS.ProcessEnv;
+  port: number;
+  repoRoot: string;
+  realHome: string;
+  pnpmStoreDir?: string | null;
+}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...inputs.baseEnv,
+    HOME: validationHomeForSlot(inputs.repoRoot, inputs.port),
+    CARGO_HOME:
+      inputs.baseEnv.CARGO_HOME ?? path.join(inputs.realHome, ".cargo"),
+    RUSTUP_HOME:
+      inputs.baseEnv.RUSTUP_HOME ?? path.join(inputs.realHome, ".rustup"),
+  };
+
+  if (inputs.pnpmStoreDir != null) {
+    env.npm_config_store_dir = inputs.pnpmStoreDir;
+  }
+
+  return env;
+}
+
+export async function resolvePnpmStoreDir(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("pnpm", ["store", "path"]);
+    const storeDir = stdout.trim();
+    return storeDir || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function ensureValidationHome(
+  repoRoot: string,
+  port: number,
+): Promise<string> {
+  const validationHome = validationHomeForSlot(repoRoot, port);
+  await mkdir(validationHome, { recursive: true, mode: 0o700 });
+  return validationHome;
+}
+
+function assertValidPort(port: number): void {
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("validation port must be an integer from 1 to 65535");
+  }
+}

--- a/tests/unit/validation-env.test.ts
+++ b/tests/unit/validation-env.test.ts
@@ -1,0 +1,87 @@
+// ABOUTME: Protects the validation launcher's hermetic child environment.
+// ABOUTME: Covers worktree state roots while keeping toolchain caches stable.
+
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  validationChildEnv,
+  validationHomeForSlot,
+} from "../../scripts/validation-env";
+
+describe("validation environment", () => {
+  it("roots HOME in the repo-local slot directory", () => {
+    const repoRoot = "/repo";
+    const env = validationChildEnv({
+      baseEnv: {},
+      port: 1422,
+      repoRoot,
+      realHome: "/real-home",
+    });
+
+    expect(env.HOME).toBe(
+      path.join(repoRoot, "artifacts", "validation-home", "slot1422"),
+    );
+    expect(validationHomeForSlot(repoRoot, 1422)).toBe(
+      path.join(repoRoot, "artifacts", "validation-home", "slot1422"),
+    );
+  });
+
+  it("preserves configured toolchain homes and defaults missing ones", () => {
+    const configured = validationChildEnv({
+      baseEnv: {
+        CARGO_HOME: "/custom/cargo",
+        RUSTUP_HOME: "/custom/rustup",
+      },
+      port: 1422,
+      repoRoot: "/repo",
+      realHome: "/real-home",
+    });
+    const defaults = validationChildEnv({
+      baseEnv: {},
+      port: 1422,
+      repoRoot: "/repo",
+      realHome: "/real-home",
+    });
+
+    expect(configured.CARGO_HOME).toBe("/custom/cargo");
+    expect(configured.RUSTUP_HOME).toBe("/custom/rustup");
+    expect(defaults.CARGO_HOME).toBe(path.join("/real-home", ".cargo"));
+    expect(defaults.RUSTUP_HOME).toBe(path.join("/real-home", ".rustup"));
+  });
+
+  it("sets the pnpm store only when one is provided", () => {
+    const withStore = validationChildEnv({
+      baseEnv: {},
+      port: 1422,
+      repoRoot: "/repo",
+      realHome: "/real-home",
+      pnpmStoreDir: "/pnpm/store",
+    });
+    const withoutStore = validationChildEnv({
+      baseEnv: {},
+      port: 1422,
+      repoRoot: "/repo",
+      realHome: "/real-home",
+    });
+
+    expect(withStore.npm_config_store_dir).toBe("/pnpm/store");
+    expect(withoutStore.npm_config_store_dir).toBeUndefined();
+  });
+
+  it("passes unrelated environment variables through unchanged", () => {
+    const env = validationChildEnv({
+      baseEnv: { SEREN_TEST_VALUE: "preserved" },
+      port: 1422,
+      repoRoot: "/repo",
+      realHome: "/real-home",
+    });
+
+    expect(env.SEREN_TEST_VALUE).toBe("preserved");
+  });
+
+  it("rejects invalid ports", () => {
+    expect(() => validationHomeForSlot("/repo", 65_536)).toThrow(
+      "validation port must be an integer from 1 to 65535",
+    );
+  });
+});


### PR DESCRIPTION
## Audit

Audited #3191, the current validation launchers, slot allocation, Tauri validation configuration, validation documentation/workflow, and prior validation work in #2782 and #3117 before editing. The confirmed gap was launcher-level HOME inheritance: macOS HOME-derived logs and application support could still resolve under the operator home even though the validation app data roots were slot-scoped.

## Fix

- Added a shared validation child-environment builder that roots HOME at the repo-local per-slot scratch directory.
- Preserved CARGO_HOME and RUSTUP_HOME, and pinned the pnpm store when it can be resolved.
- Applied the environment to both manual validation-dev and app-ready walkthrough launches.
- Added focused pure-function coverage for HOME, toolchain defaults/preservation, pnpm-store handling, passthrough variables, and invalid ports.

## Verification

- `pnpm vitest run tests/unit/validation-env.test.ts tests/unit/validation-slots.test.ts tests/unit/validation-dev-args.test.ts` — 10 tests passed.
- `pnpm check` — exit 0 with no Biome errors; only existing repository warnings were reported.
- `pnpm validate:walkthrough app-ready` — real macOS Tauri walkthrough completed with no mocks; the harness parent exited 0 after normal child teardown.
- Reopened `artifacts/validation-walkthrough/result.json`: `ok: true`.
- `artifacts/validation-home/slot1422/Library/Logs/com.serendb.desktop.validation.slot1422/` contains one log file.
- Reopened all walkthrough JSON artifacts; required fields and non-empty UI evidence are present, and the placeholder scan is clean.
- Before/after diffs of `~/Library/Logs` and `~/Library/Application Support` contain no newly added `com.serendb.desktop*` entries.
- Walkthrough classification: no new P0, P1, or P2 issues; only existing non-blocking development warnings were observed.
- No credentials, screenshots, logs, or absolute local paths are included here.

Networked paths: none — this change only alters the local launcher child-process environment; no publisher/API call is added or modified.

Fixes #3191

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
