### PR TITLE
fix(signing): audited bootstrap controls and adjust mode for the monthly ledger

### DIFF
--- a/.github/workflows/windows-signing-ledger.yml
+++ b/.github/workflows/windows-signing-ledger.yml
@@ -12,20 +12,29 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: "live-test or bootstrap-active-cycle"
+        description: "live-test, bootstrap-active-cycle, or adjust-active-cycle"
         required: true
         type: choice
-        options: [live-test, bootstrap-active-cycle]
+        options: [live-test, bootstrap-active-cycle, adjust-active-cycle]
       authoritative_operations:
-        description: "SSL.com operations already billed in the active cycle (bootstrap only)"
+        description: "operations billed in the active cycle per the billing record (bootstrap/adjust)"
         required: false
         default: ""
       authoritative_source:
         description: "Invoice/dashboard evidence and timestamp (bootstrap only)"
         required: false
         default: ""
+      billing_reference:
+        description: "Billing-record reference and portal timestamp (bootstrap/adjust)"
+        required: false
+        default: ""
+      confirm_zero_usage:
+        description: "Confirm that an authoritative billing record proves zero usage"
+        required: false
+        default: false
+        type: boolean
       approval:
-        description: "Type BOOTSTRAP MONTHLY SSL LEDGER (bootstrap only)"
+        description: "Type the exact audited approval phrase for the selected operation"
         required: false
         default: ""
 
@@ -60,12 +69,32 @@ jobs:
         env:
           BOOTSTRAP_OPERATIONS: ${{ inputs.authoritative_operations }}
           BOOTSTRAP_SOURCE: ${{ inputs.authoritative_source }}
+          BILLING_REFERENCE: ${{ inputs.billing_reference }}
+          CONFIRM_ZERO_USAGE: ${{ inputs.confirm_zero_usage }}
           BOOTSTRAP_APPROVAL: ${{ inputs.approval }}
         run: |
           if ($env:BOOTSTRAP_APPROVAL -cne "BOOTSTRAP MONTHLY SSL LEDGER") { throw "Exact audited approval phrase is required." }
           [int]$operations = -1
           if (-not [int]::TryParse($env:BOOTSTRAP_OPERATIONS, [ref]$operations) -or $operations -lt 0) { throw "authoritative_operations must be a non-negative integer." }
-          ./scripts/windows-signing-monthly-budget.ps1 -Mode Bootstrap -BootstrapOperations $operations -BootstrapSource $env:BOOTSTRAP_SOURCE -BootstrapApprovedBy '${{ github.actor }}'
+          $bootstrapArgs = @('-Mode', 'Bootstrap', '-BootstrapOperations', $operations, '-BootstrapSource', $env:BOOTSTRAP_SOURCE, '-BootstrapApprovedBy', '${{ github.actor }}', '-BillingReference', $env:BILLING_REFERENCE)
+          if ($env:CONFIRM_ZERO_USAGE -eq 'true') { $bootstrapArgs += '-ConfirmZeroUsage' }
+          ./scripts/windows-signing-monthly-budget.ps1 @bootstrapArgs
+
+      - name: Adjust active billing cycle baseline
+        if: inputs.operation == 'adjust-active-cycle'
+        shell: pwsh
+        env:
+          ADJUSTED_BASELINE_OPERATIONS: ${{ inputs.authoritative_operations }}
+          BILLING_REFERENCE: ${{ inputs.billing_reference }}
+          CONFIRM_ZERO_USAGE: ${{ inputs.confirm_zero_usage }}
+          ADJUST_APPROVAL: ${{ inputs.approval }}
+        run: |
+          if ($env:ADJUST_APPROVAL -cne "ADJUST MONTHLY SSL LEDGER") { throw "Exact audited adjustment approval phrase is required." }
+          [int64]$operations = -1
+          if (-not [int64]::TryParse($env:ADJUSTED_BASELINE_OPERATIONS, [ref]$operations) -or $operations -lt 0) { throw "authoritative_operations must be a non-negative integer." }
+          $adjustArgs = @('-Mode', 'Adjust', '-AdjustedBaselineOperations', $operations, '-BillingReference', $env:BILLING_REFERENCE, '-AdjustApprovedBy', '${{ github.actor }}')
+          if ($env:CONFIRM_ZERO_USAGE -eq 'true') { $adjustArgs += '-ConfirmZeroUsage' }
+          ./scripts/windows-signing-monthly-budget.ps1 @adjustArgs
 
       - name: Live R2 CAS and persistence test
         if: github.event_name == 'pull_request' || inputs.operation == 'live-test'

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -224,22 +224,31 @@ and 100%; the workflow summary exposes the authoritative values.
 
 #### Bootstrap, rollover, and reconciliation
 
-The first release in an active invoice cycle must never create a zero ledger.
-Run the manual **Windows signing monthly ledger** workflow with
-`bootstrap-active-cycle`, the authoritative operation count from SSL.com's
-dashboard/invoice, its evidence timestamp/source, and the exact approval
-phrase. The object is created with `If-None-Match: *`, records the approving
-GitHub actor, and cannot overwrite an existing cycle. If authoritative usage is
-unknown, leave signing blocked and bootstrap at the next configured boundary
-with a verified zero. A new cycle also requires this explicit bootstrap; prior
-cycle objects remain under `windows-signing-ledgers/v1/` for audit.
+The first release in an active invoice cycle must not create a zero ledger
+without an explicit confirmation. Run the manual **Windows signing monthly
+ledger** workflow with `bootstrap-active-cycle`, the authoritative operation
+count from SSL.com's dashboard/invoice, its evidence timestamp/source, a
+structured billing-record reference, and the exact approval phrase. The object
+is created with `If-None-Match: *`, records the approving GitHub actor, and
+cannot overwrite an existing cycle. A zero count additionally requires the
+explicit zero-usage confirmation. If authoritative usage is unknown, leave
+signing blocked and bootstrap at the next configured boundary with a verified
+zero. A new cycle also requires this explicit bootstrap; prior cycle objects
+remain under `windows-signing-ledgers/v1/` for audit.
+
+If the active cycle was bootstrapped from an incomplete baseline, use
+`adjust-active-cycle` with the authoritative billing-record reference and the
+exact adjustment approval phrase. The adjustment uses the same R2 CAS barrier,
+preserves all existing reservations, records the previous and new baselines in
+the ledger's `adjustments` array, and keeps future reservations fail-closed when
+the corrected projection is over budget.
 
 Reconcile `committed_or_reserved_operations` and each run/source/invocation
 entry against the SSL.com invoice. Reservations may conservatively exceed the
 invoice after ambiguous failures, but the projected charge must never exceed
 the repository budget. Before changing pricing, fixed charges, account,
 certificate, anchor, or timezone, reconcile the current object and bootstrap
-the new identity/cycle rather than editing a ledger in place.
+the new identity/cycle rather than editing those configuration fields in place.
 
 For a live backend check, dispatch the same workflow with `live-test`. It uses
 real R2 conditional writes, launches two simultaneous near-limit reservations,

--- a/scripts/test-windows-signing-monthly-budget-live.ps1
+++ b/scripts/test-windows-signing-monthly-budget-live.ps1
@@ -68,5 +68,8 @@ if ($LASTEXITCODE -ne 0) { throw "The audited baseline adjustment should have su
 & $barrier -Mode Reserve -Source "adjusted-baseline-block" -Invocation 1 -Operations 7
 if ($LASTEXITCODE -ne 2) { throw "The reservation above the adjusted baseline was not blocked." }
 
+& $barrier -Mode Adjust -AdjustedBaselineOperations 95 -BillingReference "synthetic adjust reference second" -AdjustApprovedBy $env:GITHUB_ACTOR
+if ($LASTEXITCODE -ne 0) { throw "The repeated audited baseline adjustment should have succeeded." }
+
 Write-Host "Live R2 monthly signing ledger validation passed without mocks."
 exit 0

--- a/scripts/test-windows-signing-monthly-budget-live.ps1
+++ b/scripts/test-windows-signing-monthly-budget-live.ps1
@@ -14,7 +14,7 @@ $env:SSL_SIGNING_ACCOUNT = "live-cas-test"
 $env:SSL_SIGNING_CERTIFICATE = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-sequential"
 $env:SSL_SIGNING_LEDGER_R2_PREFIX = "windows-signing-ledgers/live-tests"
 
-& $barrier -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow sequential budget test" -BootstrapApprovedBy $env:GITHUB_ACTOR
+& $barrier -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow sequential budget test" -BootstrapApprovedBy $env:GITHUB_ACTOR -BillingReference "synthetic live-test sequential cycle" -ConfirmZeroUsage
 if ($LASTEXITCODE -ne 0) { throw "Could not bootstrap the isolated sequential live-test ledger." }
 foreach ($release in 1..14) {
   & $barrier -Mode Reserve -Source "seven-operation-release-$release" -Invocation 1 -Operations 7
@@ -28,7 +28,7 @@ $env:SSL_SIGNING_TIER_BASE_CENTS = "0"
 $env:SSL_SIGNING_TIER_INCLUDED_OPERATIONS = "0"
 $env:SSL_SIGNING_TIER_OVERAGE_CENTS = "2000"
 $env:SSL_SIGNING_CERTIFICATE = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-concurrent"
-& $barrier -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow concurrent CAS test" -BootstrapApprovedBy $env:GITHUB_ACTOR
+& $barrier -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow concurrent CAS test" -BootstrapApprovedBy $env:GITHUB_ACTOR -BillingReference "synthetic live-test concurrent cycle" -ConfirmZeroUsage
 if ($LASTEXITCODE -ne 0) { throw "Could not bootstrap the isolated concurrent live-test ledger." }
 
 $aOut = Join-Path $env:RUNNER_TEMP "a.out"; $aErr = Join-Path $env:RUNNER_TEMP "a.err"
@@ -42,5 +42,31 @@ if (($codes -join ',') -ne '0,2') { throw "CAS test expected one admission and o
 
 & $barrier -Mode Reserve -Source "persistence-check" -Invocation 1 -Operations 1
 if ($LASTEXITCODE -ne 2) { throw "A separate process did not observe the persisted reservation." }
+
+$env:SSL_SIGNING_MONTHLY_BUDGET_CENTS = "10000"
+$env:SSL_SIGNING_TIER_BASE_CENTS = "2000"
+$env:SSL_SIGNING_TIER_INCLUDED_OPERATIONS = "20"
+$env:SSL_SIGNING_TIER_OVERAGE_CENTS = "100"
+$env:SSL_SIGNING_OTHER_FIXED_MONTHLY_CENTS = "0"
+$env:SSL_SIGNING_CERTIFICATE = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-adjust"
+
+& $barrier -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow adjust zero-confirmation control" -BootstrapApprovedBy $env:GITHUB_ACTOR -BillingReference "synthetic adjust zero control"
+if ($LASTEXITCODE -ne 1) { throw "A zero bootstrap without -ConfirmZeroUsage was not rejected." }
+
+& $barrier -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow adjust billing-reference control" -BootstrapApprovedBy $env:GITHUB_ACTOR -ConfirmZeroUsage
+if ($LASTEXITCODE -ne 1) { throw "A zero bootstrap without -BillingReference was not rejected." }
+
+& $barrier -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow adjust baseline test" -BootstrapApprovedBy $env:GITHUB_ACTOR -BillingReference "synthetic adjust baseline cycle" -ConfirmZeroUsage
+if ($LASTEXITCODE -ne 0) { throw "Could not bootstrap the isolated adjust live-test ledger." }
+
+& $barrier -Mode Reserve -Source "adjust-baseline-seed" -Invocation 1 -Operations 7
+if ($LASTEXITCODE -ne 0) { throw "The adjust live-test seed reservation should have been admitted." }
+
+& $barrier -Mode Adjust -AdjustedBaselineOperations 90 -BillingReference "synthetic adjust reference" -AdjustApprovedBy $env:GITHUB_ACTOR
+if ($LASTEXITCODE -ne 0) { throw "The audited baseline adjustment should have succeeded." }
+
+& $barrier -Mode Reserve -Source "adjusted-baseline-block" -Invocation 1 -Operations 7
+if ($LASTEXITCODE -ne 2) { throw "The reservation above the adjusted baseline was not blocked." }
+
 Write-Host "Live R2 monthly signing ledger validation passed without mocks."
 exit 0

--- a/scripts/windows-signing-monthly-budget.ps1
+++ b/scripts/windows-signing-monthly-budget.ps1
@@ -3,13 +3,17 @@
 
 [CmdletBinding()]
 param(
-  [ValidateSet("Reserve", "Bootstrap")][string]$Mode = "Reserve",
+  [ValidateSet("Reserve", "Bootstrap", "Adjust")][string]$Mode = "Reserve",
   [string]$Source = "",
   [int]$Invocation = 0,
   [int]$Operations = 0,
   [int]$BootstrapOperations = -1,
   [string]$BootstrapSource = "",
   [string]$BootstrapApprovedBy = "",
+  [string]$BillingReference = "",
+  [switch]$ConfirmZeroUsage,
+  [int64]$AdjustedBaselineOperations = -1,
+  [string]$AdjustApprovedBy = "",
   [string]$OutputFile = "",
   [int]$MaxCasAttempts = 8
 )
@@ -106,17 +110,40 @@ $key = "$($prefix.Trim('/'))/$safeAccount/$safeCertificate/$($cycle.id).json"
 $uri = "s3://$bucket/$key"
 $configuration = [ordered]@{ budget_cents=$budget; base_cents=$base; included_operations=$included; overage_cents=$overage; other_fixed_monthly_cents=$fixed }
 
+function Read-LedgerWithETag {
+  $head = Invoke-Aws @("s3api","head-object","--bucket",$bucket,"--key",$key,"--endpoint-url",$endpoint,"--output","json") -AllowFailure
+  if ($head.code -ne 0) { Fail "Monthly ledger $uri is missing or unreachable. Bootstrap authoritative active-cycle usage before signing. $($head.output)" }
+  try { $etag = ([string](($head.output | ConvertFrom-Json).ETag)).Trim('"') } catch { Fail "Could not parse the R2 ETag for $uri." }
+  if ([string]::IsNullOrWhiteSpace($etag)) { Fail "R2 returned no ETag for $uri; atomicity cannot be proven." }
+
+  $current = Join-Path ([IO.Path]::GetTempPath()) "ssl-ledger-current-$([guid]::NewGuid()).json"
+  $get = Invoke-Aws @("s3api","get-object","--bucket",$bucket,"--key",$key,"--if-match",$etag,"--endpoint-url",$endpoint,$current,"--output","json") -AllowFailure
+  if ($get.code -ne 0) {
+    Remove-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue
+    return [ordered]@{ retry=$true }
+  }
+
+  try { $ledger = Get-Content -Raw -LiteralPath $current | ConvertFrom-Json } catch { Fail "Monthly ledger $uri is corrupt: $($_.Exception.Message)" }
+  if ($ledger.schema_version -ne 1 -or $ledger.account -ne $account -or $ledger.certificate -ne $certificate -or $ledger.billing_cycle -ne $cycle.id) { Fail "Monthly ledger identity/schema does not match the configured account, certificate, and billing cycle." }
+  if ($ledger.cycle_starts_at -ne $cycle.starts_at -or $ledger.cycle_ends_at -ne $cycle.ends_at -or $ledger.billing_timezone -ne $timezone -or [int]$ledger.billing_anchor_day -ne $anchor) { Fail "Monthly ledger billing boundary is stale or conflicts with repository configuration." }
+  foreach ($name in $configuration.Keys) { if ([int64]$ledger.configuration.$name -ne [int64]$configuration[$name]) { Fail "Monthly ledger configuration '$name' conflicts with repository configuration." } }
+  if ($null -eq $ledger.bootstrap -or [string]::IsNullOrWhiteSpace([string]$ledger.bootstrap.source) -or [string]::IsNullOrWhiteSpace([string]$ledger.bootstrap.approved_by)) { Fail "Monthly ledger has no authoritative audited bootstrap." }
+  return [ordered]@{ ledger=$ledger; etag=$etag; path=$current; retry=$false }
+}
+
 if ($Mode -eq "Bootstrap") {
   if ($BootstrapOperations -lt 0) { Fail "BootstrapOperations must be supplied from authoritative current-cycle SSL.com usage." }
+  if ([string]::IsNullOrWhiteSpace($BillingReference)) { Fail "BillingReference is required and must identify the authoritative billing record and its portal timestamp." }
+  if ($BootstrapOperations -eq 0 -and -not $ConfirmZeroUsage) { Fail "Zero mid-cycle usage is almost never true; pass -ConfirmZeroUsage only after verifying the billing record." }
   if ([string]::IsNullOrWhiteSpace($BootstrapSource) -or [string]::IsNullOrWhiteSpace($BootstrapApprovedBy)) { Fail "BootstrapSource and BootstrapApprovedBy are required for an audited bootstrap." }
   $cost = Project-Cost $BootstrapOperations $base $included $overage $fixed
-  if ($cost -gt $budget) { Fail "Bootstrap usage projects $cost cents, above the $budget-cent monthly budget." }
+  if ($cost -gt $budget) { Write-Host "::warning::Bootstrap usage projects $cost cents, above the $budget-cent monthly budget; recording the truthful baseline so future reservations remain blocked." }
   $now = [DateTimeOffset]::UtcNow.ToString("o")
   $ledger = [ordered]@{
     schema_version=1; account=$account; certificate=$certificate; billing_cycle=$cycle.id
     cycle_starts_at=$cycle.starts_at; cycle_ends_at=$cycle.ends_at; billing_timezone=$cycle.timezone; billing_anchor_day=$cycle.anchor_day
     configuration=$configuration; committed_or_reserved_operations=$BootstrapOperations; projected_cost_cents=$cost
-    bootstrap=[ordered]@{ operations=$BootstrapOperations; source=$BootstrapSource; recorded_at=$now; approved_by=$BootstrapApprovedBy }
+    bootstrap=[ordered]@{ operations=$BootstrapOperations; source=$BootstrapSource; billing_reference=$BillingReference; recorded_at=$now; approved_by=$BootstrapApprovedBy }
     updated_at=$now; version=1; entries=@()
   }
   $temp = Join-Path ([IO.Path]::GetTempPath()) "ssl-ledger-bootstrap-$([guid]::NewGuid()).json"
@@ -129,26 +156,80 @@ if ($Mode -eq "Bootstrap") {
   exit 0
 }
 
-if ($Mode -eq "Reserve" -and ($Operations -lt 1 -or [string]::IsNullOrWhiteSpace($Source) -or $Invocation -lt 1)) { Fail "Reserve requires Source, Invocation >= 1, and Operations >= 1." }
+if ($Mode -eq "Adjust") {
+  if ($AdjustedBaselineOperations -lt 0) { Fail "AdjustedBaselineOperations must be a non-negative integer." }
+  if ($AdjustedBaselineOperations -eq 0 -and -not $ConfirmZeroUsage) { Fail "Zero adjusted usage requires -ConfirmZeroUsage after verifying the billing record." }
+  if ([string]::IsNullOrWhiteSpace($BillingReference)) { Fail "BillingReference is required and must identify the authoritative billing record and its portal timestamp." }
+  if ([string]::IsNullOrWhiteSpace($AdjustApprovedBy)) { Fail "AdjustApprovedBy is required for an audited baseline adjustment." }
+
+  for ($attempt = 1; $attempt -le $MaxCasAttempts; $attempt++) {
+    $read = Read-LedgerWithETag
+    if ($read.retry) {
+      Start-Sleep -Milliseconds ([Math]::Min(1000, 50 * [Math]::Pow(2, $attempt - 1)))
+      continue
+    }
+    $ledger = $read.ledger
+    $etag = $read.etag
+    $current = $read.path
+    $next = Join-Path ([IO.Path]::GetTempPath()) "ssl-ledger-next-$([guid]::NewGuid()).json"
+    try {
+      $previousBaselineOperations = [int64]$ledger.bootstrap.operations
+      [int64]$entriesSum = 0
+      foreach ($entry in @($ledger.entries)) { $entriesSum += [int64]$entry.operations }
+      $now = [DateTimeOffset]::UtcNow.ToString("o")
+      $bootstrap = [ordered]@{}
+      foreach ($property in $ledger.bootstrap.PSObject.Properties) { $bootstrap[$property.Name] = $property.Value }
+      $bootstrap.operations = $AdjustedBaselineOperations
+      $bootstrap.billing_reference = $BillingReference
+      $ledger.bootstrap = $bootstrap
+      $adjustment = [ordered]@{
+        previous_baseline_operations=$previousBaselineOperations
+        new_baseline_operations=$AdjustedBaselineOperations
+        billing_reference=$BillingReference
+        recorded_at=$now
+        approved_by=$AdjustApprovedBy
+      }
+      $adjustments = @()
+      if ($null -ne $ledger.adjustments) { $adjustments = @($ledger.adjustments) }
+      $ledger.adjustments = $adjustments + [PSCustomObject]$adjustment
+      $committedOperations = $AdjustedBaselineOperations + $entriesSum
+      $cost = Project-Cost $committedOperations $base $included $overage $fixed
+      $ledger.committed_or_reserved_operations = $committedOperations
+      $ledger.projected_cost_cents = $cost
+      $ledger.updated_at = $now
+      $ledger.version = [int64]$ledger.version + 1
+      if ($cost -gt $budget) { Write-Host "::warning::Adjusted baseline projects $cost cents, above the $budget-cent monthly budget; future reservations remain blocked until the cycle changes." }
+      ($ledger | ConvertTo-Json -Depth 12) | Set-Content -LiteralPath $next -Encoding utf8
+      $put = Invoke-Aws @("s3api","put-object","--bucket",$bucket,"--key",$key,"--body",$next,"--if-match",$etag,"--endpoint-url",$endpoint,"--output","json") -AllowFailure
+      if ($put.code -eq 0) {
+        Write-Host "Adjusted SSL.com ledger baseline: previous=$previousBaselineOperations new=$AdjustedBaselineOperations committed=$committedOperations ledger_version=$($ledger.version)."
+        exit 0
+      }
+      if ($put.output -notmatch "PreconditionFailed|412|ConditionalRequestConflict|409") { Fail "R2 conditional ledger adjustment failed: $($put.output)" }
+    } finally {
+      Remove-Item -LiteralPath $current,$next -Force -ErrorAction SilentlyContinue
+    }
+    Start-Sleep -Milliseconds ([Math]::Min(1000, 50 * [Math]::Pow(2, $attempt - 1)))
+  }
+  Fail "Monthly ledger adjustment CAS conflicted $MaxCasAttempts times; the baseline was not changed because atomicity could not be proven."
+}
+
+if ($Operations -lt 1 -or [string]::IsNullOrWhiteSpace($Source) -or $Invocation -lt 1) { Fail "Reserve requires Source, Invocation >= 1, and Operations >= 1." }
 $runId = Require-Text "GITHUB_RUN_ID"
 $runAttempt = Require-Text "GITHUB_RUN_ATTEMPT"
 $idempotencyKey = "$runId/$runAttempt/$Source/$Invocation"
 
 for ($attempt = 1; $attempt -le $MaxCasAttempts; $attempt++) {
-  $head = Invoke-Aws @("s3api","head-object","--bucket",$bucket,"--key",$key,"--endpoint-url",$endpoint,"--output","json") -AllowFailure
-  if ($head.code -ne 0) { Fail "Monthly ledger $uri is missing or unreachable. Bootstrap authoritative active-cycle usage before signing. $($head.output)" }
-  try { $etag = ([string](($head.output | ConvertFrom-Json).ETag)).Trim('"') } catch { Fail "Could not parse the R2 ETag for $uri." }
-  if ([string]::IsNullOrWhiteSpace($etag)) { Fail "R2 returned no ETag for $uri; atomicity cannot be proven." }
-  $current = Join-Path ([IO.Path]::GetTempPath()) "ssl-ledger-current-$([guid]::NewGuid()).json"
+  $read = Read-LedgerWithETag
+  if ($read.retry) {
+    Start-Sleep -Milliseconds ([Math]::Min(1000, 50 * [Math]::Pow(2, $attempt - 1)))
+    continue
+  }
+  $ledger = $read.ledger
+  $etag = $read.etag
+  $current = $read.path
   $next = Join-Path ([IO.Path]::GetTempPath()) "ssl-ledger-next-$([guid]::NewGuid()).json"
   try {
-    $get = Invoke-Aws @("s3api","get-object","--bucket",$bucket,"--key",$key,"--if-match",$etag,"--endpoint-url",$endpoint,$current,"--output","json") -AllowFailure
-    if ($get.code -ne 0) { continue }
-    try { $ledger = Get-Content -Raw -LiteralPath $current | ConvertFrom-Json } catch { Fail "Monthly ledger $uri is corrupt: $($_.Exception.Message)" }
-    if ($ledger.schema_version -ne 1 -or $ledger.account -ne $account -or $ledger.certificate -ne $certificate -or $ledger.billing_cycle -ne $cycle.id) { Fail "Monthly ledger identity/schema does not match the configured account, certificate, and billing cycle." }
-    if ($ledger.cycle_starts_at -ne $cycle.starts_at -or $ledger.cycle_ends_at -ne $cycle.ends_at -or $ledger.billing_timezone -ne $timezone -or [int]$ledger.billing_anchor_day -ne $anchor) { Fail "Monthly ledger billing boundary is stale or conflicts with repository configuration." }
-    foreach ($name in $configuration.Keys) { if ([int64]$ledger.configuration.$name -ne [int64]$configuration[$name]) { Fail "Monthly ledger configuration '$name' conflicts with repository configuration." } }
-    if ($null -eq $ledger.bootstrap -or [string]::IsNullOrWhiteSpace([string]$ledger.bootstrap.source) -or [string]::IsNullOrWhiteSpace([string]$ledger.bootstrap.approved_by)) { Fail "Monthly ledger has no authoritative audited bootstrap." }
     $existing = @($ledger.entries | Where-Object { $_.idempotency_key -eq $idempotencyKey })
     if ($existing.Count -gt 0) {
       if ([int]$existing[0].operations -ne $Operations) { Fail "Idempotency key $idempotencyKey was already reserved with a different operation count." }

--- a/scripts/windows-signing-monthly-budget.ps1
+++ b/scripts/windows-signing-monthly-budget.ps1
@@ -191,7 +191,7 @@ if ($Mode -eq "Adjust") {
       }
       $adjustments = @()
       if ($null -ne $ledger.adjustments) { $adjustments = @($ledger.adjustments) }
-      $ledger.adjustments = $adjustments + [PSCustomObject]$adjustment
+      $ledger | Add-Member -NotePropertyName adjustments -NotePropertyValue ($adjustments + [PSCustomObject]$adjustment) -Force
       $committedOperations = $AdjustedBaselineOperations + $entriesSum
       $cost = Project-Cost $committedOperations $base $included $overage $fixed
       $ledger.committed_or_reserved_operations = $committedOperations


### PR DESCRIPTION
## Audit

Issue #3175 was traced through the manual signing-ledger workflow, the R2-backed reservation script, the live R2 test, the release signing wrapper, and the code-signing runbook. The existing bootstrap accepted ledger-tracked zero as authoritative usage and had no structured billing-record reference. The existing workflow could create the baseline but could not safely correct an already-created active-cycle baseline.

Prior ledger work in #2930/#2933 established the R2 compare-and-swap reservation barrier; this change preserves that barrier and adds the missing audited baseline controls.

## Fix

- Add `BillingReference`, explicit zero-usage confirmation, and a structured billing reference on bootstrap records.
- Allow truthful over-budget baselines to be recorded with a warning so the reservation barrier remains fail-closed.
- Add CAS-protected `Adjust` mode that preserves entries, records every baseline change in `adjustments`, recomputes committed usage, and bumps the ledger version.
- Expose bootstrap and adjustment controls through the manual workflow with exact approval phrases.
- Extend the real R2 test with both bootstrap negative controls, the adjustment path, and a post-adjustment reservation block.
- Update the signing runbook to document the operator paths.

## Verification

- `pnpm vitest run tests/unit/windows-sign-overlay.test.ts` — 15 passed, 2 PowerShell-host tests skipped because local `pwsh` aborts before startup.
- `pnpm check` — exit 0; repository reports existing warnings and schema information, with no errors.
- `yq eval '.' .github/workflows/windows-signing-ledger.yml` — passed.
- `git diff --check` — passed.
- The required live functional check runs in the PR-triggered Windows job against real R2; no storage mock is used.

Networked path: `aws s3api` HEAD/GET/PUT against Cloudflare R2 from CI only — no Seren publisher or Gateway API is involved.

Fixes #3175
Fixes #3205

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
