### PR TITLE
fix(signing): count every signer pass; scope ledger idempotency to ambiguous CAS retries

### DIFF
--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -243,9 +243,11 @@ preserves all existing reservations, records the previous and new baselines in
 the ledger's `adjustments` array, and keeps future reservations fail-closed when
 the corrected projection is over budget.
 
-Reconcile `committed_or_reserved_operations` and each run/source/invocation
-entry against the SSL.com invoice. Reservations may conservatively exceed the
-invoice after ambiguous failures, but the projected charge must never exceed
+Reconcile `committed_or_reserved_operations` and each run/attempt/source/invocation
+entry against the SSL.com invoice. Each entry also carries a per-reservation
+nonce in its idempotency key, so repeated signer passes over the same filename
+count as separate billable operations. Reservations may conservatively exceed
+the invoice after ambiguous failures, but the projected charge must never exceed
 the repository budget. Before changing pricing, fixed charges, account,
 certificate, anchor, or timezone, reconcile the current object and bootstrap
 the new identity/cycle rather than editing those configuration fields in place.

--- a/scripts/test-windows-signing-monthly-budget-live.ps1
+++ b/scripts/test-windows-signing-monthly-budget-live.ps1
@@ -71,5 +71,20 @@ if ($LASTEXITCODE -ne 2) { throw "The reservation above the adjusted baseline wa
 & $barrier -Mode Adjust -AdjustedBaselineOperations 95 -BillingReference "synthetic adjust reference second" -AdjustApprovedBy $env:GITHUB_ACTOR
 if ($LASTEXITCODE -ne 0) { throw "The repeated audited baseline adjustment should have succeeded." }
 
+$env:SSL_SIGNING_CERTIFICATE = "$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-dupes"
+& $barrier -Mode Bootstrap -BootstrapOperations 0 -BootstrapSource "live workflow duplicate-pass test" -BootstrapApprovedBy $env:GITHUB_ACTOR -BillingReference "synthetic duplicate-pass cycle" -ConfirmZeroUsage
+if ($LASTEXITCODE -ne 0) { throw "Could not bootstrap the isolated duplicate-pass live-test ledger." }
+
+$firstDuplicateOutput = (& $barrier -Mode Reserve -Source "nsis-double-pass" -Invocation 1 -Operations 1 *>&1 | Out-String)
+$firstDuplicateExit = $LASTEXITCODE
+if ($firstDuplicateExit -ne 0) { throw "The first duplicate-pass reservation should have succeeded." }
+
+$secondDuplicateOutput = (& $barrier -Mode Reserve -Source "nsis-double-pass" -Invocation 1 -Operations 1 *>&1 | Out-String)
+$secondDuplicateExit = $LASTEXITCODE
+if ($secondDuplicateExit -ne 0) { throw "The second duplicate-pass reservation should have succeeded." }
+if ($secondDuplicateOutput -notmatch "total=2" -or $secondDuplicateOutput -match "already committed") {
+  throw "The second duplicate-pass reservation did not count as a new operation."
+}
+
 Write-Host "Live R2 monthly signing ledger validation passed without mocks."
 exit 0

--- a/scripts/windows-signing-monthly-budget.ps1
+++ b/scripts/windows-signing-monthly-budget.ps1
@@ -217,7 +217,10 @@ if ($Mode -eq "Adjust") {
 if ($Operations -lt 1 -or [string]::IsNullOrWhiteSpace($Source) -or $Invocation -lt 1) { Fail "Reserve requires Source, Invocation >= 1, and Operations >= 1." }
 $runId = Require-Text "GITHUB_RUN_ID"
 $runAttempt = Require-Text "GITHUB_RUN_ATTEMPT"
-$idempotencyKey = "$runId/$runAttempt/$Source/$Invocation"
+$reservationNonce = [guid]::NewGuid().ToString("N")
+# The nonce scopes idempotency to ambiguous conditional-write retries within one
+# reservation process; each signer pass over the same filename is a distinct billable operation.
+$idempotencyKey = "$runId/$runAttempt/$Source/$Invocation/$reservationNonce"
 
 for ($attempt = 1; $attempt -le $MaxCasAttempts; $attempt++) {
   $read = Read-LedgerWithETag


### PR DESCRIPTION
## Audit

Issue #3174 was traced through the Windows release workflow, `scripts/sign-windows-payload.ps1`, and the R2-backed reservation barrier. The signer caller creates a fresh process for each pass, while the prior idempotency key was only `$runId/$runAttempt/$Source/$Invocation`. NSIS can sign the same filename in two independent passes with the same source and invocation, so the second billable operation was incorrectly treated as already committed.

The scoped audit command `rg -n -i "idempotency" scripts .github/workflows docs tests src-tauri src` found the signing-ledger key construction and comparison only in `scripts/windows-signing-monthly-budget.ps1`. The other repository matches are unrelated wallet, cloud protocol, or test idempotency concepts; no other consumer parses the signing-ledger key format.

## Fix

- Generate one GUID nonce per reservation process and append it to the key.
- Preserve that key across ambiguous conditional-write retries, while independent signer passes receive different keys.
- Extend the real R2 live test with two identical `nsis-double-pass` reservations and require both to exit 0; the second must report `total=2` without an idempotent skip.
- Document the run/attempt/source/invocation/nonce reconciliation rule.

Verification before CI:

- `pnpm vitest run tests/unit/windows-sign-overlay.test.ts` — 15 passed, 2 host-dependent tests skipped because local PowerShell aborts before startup.
- `pnpm check` — exit 0; existing repository warnings only.
- `git diff --check` — passed.

Networked path: `aws s3api` HEAD/GET/PUT against Cloudflare R2 from CI only — no Seren publisher or Gateway API is involved.

Refs #3174

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
