### PR TITLE
feat(privacy): honest egress controls — disclosure and exclusions

### DIFF
--- a/src-tauri/src/commands/history_sync.rs
+++ b/src-tauri/src/commands/history_sync.rs
@@ -2,7 +2,7 @@
 // ABOUTME: Thin command layer over services::history_sync.
 
 use crate::services::history_sync::{
-    HistorySyncConfig, HistorySyncSummary, run_history_sync_once, wipe_remote_history,
+    run_history_sync_once, wipe_remote_history, HistorySyncConfig, HistorySyncSummary,
 };
 use tauri::AppHandle;
 
@@ -12,6 +12,7 @@ pub async fn history_sync_run_now(
     project_id: String,
     branch_id: String,
     database_name: String,
+    excluded_conversation_ids: Option<Vec<String>>,
 ) -> Result<HistorySyncSummary, String> {
     run_history_sync_once(
         app,
@@ -19,6 +20,7 @@ pub async fn history_sync_run_now(
             project_id,
             branch_id,
             database_name,
+            excluded_conversation_ids: excluded_conversation_ids.unwrap_or_default(),
         },
     )
     .await
@@ -38,6 +40,7 @@ pub async fn history_sync_wipe_remote(
             project_id,
             branch_id,
             database_name,
+            excluded_conversation_ids: Vec::new(),
         },
         confirmation,
     )

--- a/src-tauri/src/services/history_sync.rs
+++ b/src-tauri/src/services/history_sync.rs
@@ -2,14 +2,15 @@
 // ABOUTME: Keeps local SQLite as the fast path and mirrors durable text rows to Postgres.
 
 use postgres::{Client as PgClient, Row as PgRow};
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
+use std::collections::HashSet;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_store::StoreExt;
 
 use crate::auth;
-use crate::services::database::{DbPool, HISTORY_SYNC_TABLES, now_ms};
+use crate::services::database::{now_ms, DbPool, HISTORY_SYNC_TABLES};
 
 const GATEWAY_BASE_URL: &str = "https://api.serendb.com/publishers/seren-db";
 const HISTORY_SYNC_STORE: &str = "history_sync.json";
@@ -35,6 +36,7 @@ pub struct HistorySyncConfig {
     pub project_id: String,
     pub branch_id: String,
     pub database_name: String,
+    pub excluded_conversation_ids: Vec<String>,
 }
 
 /// Serializes a history sync run against a remote wipe so the two never
@@ -196,11 +198,14 @@ pub async fn run_history_sync_once(
     let lock = HistorySyncLock::handle(&app);
     let _guard = lock.lock().await;
     let sync_scope = history_sync_scope(&config);
+    let excluded_conversation_ids = config.excluded_conversation_ids.clone();
     with_remote_client(&app, &config, move |app, mut client| {
         ensure_remote_schema(&mut client)?;
 
-        let backfilled = with_local_db(&app, |conn| enqueue_initial_backfill(conn, &sync_scope))?;
-        let pushed = push_outbox(&app, &mut client)?;
+        let backfilled = with_local_db(&app, |conn| {
+            enqueue_initial_backfill(conn, &sync_scope, &excluded_conversation_ids)
+        })?;
+        let pushed = push_outbox(&app, &mut client, &excluded_conversation_ids)?;
         let pulled = pull_remote(&app, &mut client, &sync_scope)?;
         let (queued, conflicts) = with_local_db(&app, |conn| {
             Ok((
@@ -452,7 +457,11 @@ fn with_local_db<T>(
     pool.with_connection(task)
 }
 
-fn enqueue_initial_backfill(conn: &Connection, sync_scope: &str) -> rusqlite::Result<usize> {
+fn enqueue_initial_backfill(
+    conn: &Connection,
+    sync_scope: &str,
+    excluded_conversation_ids: &[String],
+) -> rusqlite::Result<usize> {
     let completed: i64 = conn
         .query_row(
             "SELECT MAX(first_backfill_completed)
@@ -472,10 +481,11 @@ fn enqueue_initial_backfill(conn: &Connection, sync_scope: &str) -> rusqlite::Re
     for table in HISTORY_SYNC_TABLES {
         match *table {
             "thread_drafts" => {
-                count += enqueue_rows(
+                count += enqueue_rows_excluding(
                     conn,
                     table,
                     "SELECT id FROM conversations WHERE draft IS NOT NULL AND draft <> ''",
+                    excluded_conversation_ids,
                 )?;
             }
             _ => {
@@ -509,7 +519,37 @@ fn enqueue_rows(conn: &Connection, table_name: &str, query: &str) -> rusqlite::R
     Ok(ids.len())
 }
 
-fn push_outbox(app: &AppHandle, client: &mut PgClient) -> Result<usize, String> {
+fn enqueue_rows_excluding(
+    conn: &Connection,
+    table_name: &str,
+    query: &str,
+    excluded_conversation_ids: &[String],
+) -> rusqlite::Result<usize> {
+    let mut stmt = conn.prepare(query)?;
+    let ids = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(stmt);
+    let mut count = 0;
+    for id in ids {
+        if excluded_conversation_ids
+            .iter()
+            .any(|excluded| excluded == &id)
+        {
+            continue;
+        }
+        crate::services::database::enqueue_sync_outbox(conn, table_name, &id, "upsert")?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+fn push_outbox(
+    app: &AppHandle,
+    client: &mut PgClient,
+    excluded_conversation_ids: &[String],
+) -> Result<usize, String> {
+    let excluded: HashSet<String> = excluded_conversation_ids.iter().cloned().collect();
     let mut pushed = 0usize;
     loop {
         let batch = with_local_db(app, read_outbox_batch)?;
@@ -518,7 +558,7 @@ fn push_outbox(app: &AppHandle, client: &mut PgClient) -> Result<usize, String> 
         }
         let mut left_active_set = 0usize;
         for item in batch {
-            match push_outbox_item(app, client, &item) {
+            match push_outbox_item(app, client, &item, &excluded) {
                 Ok(PushItemOutcome::Pushed) => {
                     clear_outbox_item(app, item.id)?;
                     mark_synced(app, &item.table_name, &item.row_id)?;
@@ -534,6 +574,7 @@ fn push_outbox(app: &AppHandle, client: &mut PgClient) -> Result<usize, String> 
                     clear_outbox_item(app, item.id)?;
                     left_active_set += 1;
                 }
+                Ok(PushItemOutcome::Excluded) => {}
                 Err(err) => {
                     let quarantined = record_push_failure(app, item.id, &err)?;
                     if quarantined {
@@ -553,13 +594,20 @@ enum PushItemOutcome {
     Pushed,
     Tombstoned,
     Skipped,
+    Excluded,
 }
 
 fn push_outbox_item(
     app: &AppHandle,
     client: &mut PgClient,
     item: &OutboxItem,
+    excluded_conversation_ids: &HashSet<String>,
 ) -> Result<PushItemOutcome, String> {
+    if let Some(conversation_id) = outbox_item_conversation_id(app, item)? {
+        if excluded_conversation_ids.contains(&conversation_id) {
+            return Ok(PushItemOutcome::Excluded);
+        }
+    }
     if item.op == "tombstone" {
         push_tombstone(client, item)?;
         return Ok(PushItemOutcome::Tombstoned);
@@ -633,6 +681,22 @@ fn push_outbox_item(
     } else {
         PushItemOutcome::Skipped
     })
+}
+
+fn outbox_item_conversation_id(
+    app: &AppHandle,
+    item: &OutboxItem,
+) -> Result<Option<String>, String> {
+    match item.table_name.as_str() {
+        "conversations" | "thread_drafts" => Ok(Some(item.row_id.clone())),
+        "messages" => Ok(with_local_db(app, |conn| {
+            Ok(load_message(conn, &item.row_id)?.map(|row| row.conversation_id))
+        })?),
+        "message_events" => Ok(with_local_db(app, |conn| {
+            Ok(load_message_event(conn, &item.row_id)?.map(|row| row.conversation_id))
+        })?),
+        _ => Ok(None),
+    }
 }
 
 fn record_push_failure(app: &AppHandle, item_id: i64, error: &str) -> Result<bool, String> {
@@ -1907,7 +1971,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::database::{PersistedMessage, save_message_record, setup_schema};
+    use crate::services::database::{save_message_record, setup_schema, PersistedMessage};
     use std::cell::RefCell;
 
     const SCOPE_A: &str = "scope-a";
@@ -2038,8 +2102,8 @@ mod tests {
         .unwrap();
 
         conn.execute("DELETE FROM sync_outbox", []).unwrap();
-        let first = enqueue_initial_backfill(&conn, SCOPE_A).unwrap();
-        let second = enqueue_initial_backfill(&conn, SCOPE_A).unwrap();
+        let first = enqueue_initial_backfill(&conn, SCOPE_A, &[]).unwrap();
+        let second = enqueue_initial_backfill(&conn, SCOPE_A, &[]).unwrap();
         let queued: i64 = conn
             .query_row("SELECT COUNT(*) FROM sync_outbox", [], |row| row.get(0))
             .unwrap();
@@ -2047,6 +2111,39 @@ mod tests {
         assert!(first >= 3);
         assert_eq!(second, 0);
         assert_eq!(queued, first as i64);
+    }
+
+    #[test]
+    fn excluded_conversation_drafts_are_not_enqueued() {
+        let conn = Connection::open_in_memory().unwrap();
+        setup_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind, draft)
+             VALUES ('included', 'Included', 1000, 'chat', 'keep this')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO conversations (id, title, created_at, kind, draft)
+             VALUES ('excluded', 'Excluded', 1000, 'chat', 'do not sync this')",
+            [],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM sync_outbox", []).unwrap();
+
+        enqueue_initial_backfill(&conn, SCOPE_A, &["excluded".to_string()]).unwrap();
+
+        let draft_ids: Vec<String> = conn
+            .prepare(
+                "SELECT row_id FROM sync_outbox
+                 WHERE table_name = 'thread_drafts' ORDER BY row_id",
+            )
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(draft_ids, vec!["included"]);
     }
 
     #[test]
@@ -2061,13 +2158,13 @@ mod tests {
         .unwrap();
 
         conn.execute("DELETE FROM sync_outbox", []).unwrap();
-        let first_scope_a = enqueue_initial_backfill(&conn, SCOPE_A).unwrap();
+        let first_scope_a = enqueue_initial_backfill(&conn, SCOPE_A, &[]).unwrap();
         assert!(first_scope_a > 0);
         conn.execute("DELETE FROM sync_outbox", []).unwrap();
 
-        assert_eq!(enqueue_initial_backfill(&conn, SCOPE_A).unwrap(), 0);
+        assert_eq!(enqueue_initial_backfill(&conn, SCOPE_A, &[]).unwrap(), 0);
 
-        let first_scope_b = enqueue_initial_backfill(&conn, SCOPE_B).unwrap();
+        let first_scope_b = enqueue_initial_backfill(&conn, SCOPE_B, &[]).unwrap();
         assert_eq!(
             first_scope_b, first_scope_a,
             "a new destination must receive its own initial backfill"
@@ -2080,11 +2177,13 @@ mod tests {
             project_id: "project-a".to_string(),
             branch_id: "branch-a".to_string(),
             database_name: "seren_desktop_history".to_string(),
+            excluded_conversation_ids: Vec::new(),
         };
         let config_b = HistorySyncConfig {
             project_id: "project-b".to_string(),
             branch_id: "branch-a".to_string(),
             database_name: "seren_desktop_history".to_string(),
+            excluded_conversation_ids: Vec::new(),
         };
 
         let scope_a = history_sync_scope(&config_a);
@@ -2250,7 +2349,7 @@ mod tests {
 
         // First sync: backfill everything, then simulate a successful push that
         // drains the outbox and stamps rows as synced.
-        let first = enqueue_initial_backfill(&conn, SCOPE_A).unwrap();
+        let first = enqueue_initial_backfill(&conn, SCOPE_A, &[]).unwrap();
         assert!(first >= 2);
         conn.execute("DELETE FROM sync_outbox", []).unwrap();
         conn.execute("UPDATE conversations SET synced_at = 123", [])
@@ -2259,7 +2358,7 @@ mod tests {
             .unwrap();
 
         // Without a reset, a re-sync short-circuits and uploads nothing — the bug.
-        assert_eq!(enqueue_initial_backfill(&conn, SCOPE_A).unwrap(), 0);
+        assert_eq!(enqueue_initial_backfill(&conn, SCOPE_A, &[]).unwrap(), 0);
 
         // Wiping the remote must reset local state so the next sync re-uploads.
         reset_local_sync_state(&conn, SCOPE_A).unwrap();
@@ -2291,6 +2390,9 @@ mod tests {
         assert_eq!(outbox, 0, "stale outbox rows must be cleared");
 
         // The next backfill re-enqueues the full history.
-        assert_eq!(enqueue_initial_backfill(&conn, SCOPE_A).unwrap(), first);
+        assert_eq!(
+            enqueue_initial_backfill(&conn, SCOPE_A, &[]).unwrap(),
+            first
+        );
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import { autocompleteStore } from "@/stores/autocomplete.store";
 import { chatStore } from "@/stores/chat.store";
 import { fileTreeState, initDefaultRootIfNeeded } from "@/stores/fileTree";
 import { loadKeybindings } from "@/stores/keybindings.store";
+import { loadPrivacySettings } from "@/stores/privacy.store";
 import { providerStore } from "@/stores/provider.store";
 import { loadAllSettings, settingsState } from "@/stores/settings.store";
 import { skillsStore } from "@/stores/skills.store";
@@ -58,9 +59,6 @@ import "./styles.css";
 
 const FIRST_AUTH_INTERVIEW_LANDING_KEY =
   "seren:employee_intake_first_authenticated_launch";
-
-// Initialize telemetry early to capture startup errors
-telemetry.init();
 
 function claimFirstAuthenticatedInterviewLaunch(): boolean {
   try {
@@ -89,6 +87,11 @@ function App() {
 
   const runtime = getRuntimeConfig();
 
+  createEffect(() => {
+    if (settingsState.isLoading) return;
+    telemetry.setEnabled(settingsState.app.telemetryEnabled);
+  });
+
   onMount(async () => {
     await initAuthRuntimeBindings();
     await checkAuth();
@@ -116,6 +119,7 @@ function App() {
 
     // Load all settings including app settings (chatDefaultModel, etc.) and MCP settings
     await loadAllSettings();
+    await loadPrivacySettings();
     await loadKeybindings();
 
     // Load provider settings - this restores the last used model from previous session

--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -109,6 +109,7 @@ import {
   COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES,
   COMPOSER_TOOLBAR_ROOT_CLASSES,
 } from "./composerToolbarClasses";
+import { DataDestinationsPanel } from "./DataDestinationsPanel";
 import { DiffCard } from "./DiffCard";
 import { ImageAttachmentBar } from "./ImageAttachmentBar";
 import { OAuthAccountSwitcher } from "./OAuthAccountSwitcher";
@@ -154,6 +155,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const [savedInput, setSavedInput] = createSignal("");
   const [isAttaching, setIsAttaching] = createSignal(false);
   const [isProcessingDocs, setIsProcessingDocs] = createSignal(false);
+  const [showDataDestinations, setShowDataDestinations] = createSignal(false);
   const [awaitingLogin, setAwaitingLogin] = createSignal<AgentType | null>(
     null,
   );
@@ -1773,6 +1775,23 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           >
             Clear
           </button>
+          <div class="relative">
+            <button
+              type="button"
+              class="bg-transparent border border-[#3a5650] text-[#9ce3c3] px-2 py-1 rounded text-xs cursor-pointer transition-all hover:bg-[#172b25]"
+              aria-expanded={showDataDestinations()}
+              onClick={() => setShowDataDestinations((open) => !open)}
+            >
+              Destinations
+            </button>
+            <Show when={showDataDestinations()}>
+              <div class="absolute right-0 top-full z-40 mt-2 w-[min(560px,calc(100vw-2rem))]">
+                <DataDestinationsPanel
+                  conversationId={activeAgentThread()?.id}
+                />
+              </div>
+            </Show>
+          </div>
         </Show>
         <OAuthAccountSwitcher threadId={props.threadId} />
       </div>
@@ -1853,6 +1872,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 Describe what you'd like the agent to do. It can read files,
                 make edits, run commands, and more.
               </p>
+              <div class="mt-8 w-full max-w-[560px]">
+                <DataDestinationsPanel
+                  conversationId={activeAgentThread()?.id}
+                />
+              </div>
             </div>
           }
         >

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -121,6 +121,7 @@ import {
   COMPOSER_TOOLBAR_RIGHT_GROUP_CLASSES,
   COMPOSER_TOOLBAR_ROOT_CLASSES,
 } from "./composerToolbarClasses";
+import { DataDestinationsPanel } from "./DataDestinationsPanel";
 import { ImageAttachmentBar } from "./ImageAttachmentBar";
 import { MessageImages } from "./MessageImages";
 import { ModelSelector } from "./ModelSelector";
@@ -179,6 +180,7 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
   // Message queue for sending messages while streaming
   const [messageQueue, setMessageQueue] = createSignal<string[]>([]);
   const [showSignInPrompt, setShowSignInPrompt] = createSignal(false);
+  const [showDataDestinations, setShowDataDestinations] = createSignal(false);
   const [showDepositFromError, setShowDepositFromError] = createSignal(false);
   const [memoryPanelMessageId, setMemoryPanelMessageId] = createSignal<
     string | null
@@ -1496,6 +1498,21 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
             >
               Clear
             </button>
+            <div class="relative">
+              <button
+                type="button"
+                class="bg-transparent border border-[#3a5650] text-[#9ce3c3] px-2 py-1 rounded text-xs cursor-pointer transition-all hover:bg-[#172b25]"
+                aria-expanded={showDataDestinations()}
+                onClick={() => setShowDataDestinations((open) => !open)}
+              >
+                Destinations
+              </button>
+              <Show when={showDataDestinations()}>
+                <div class="absolute right-0 top-full z-40 mt-2 w-[min(560px,calc(100vw-2rem))]">
+                  <DataDestinationsPanel conversationId={conversationId()} />
+                </div>
+              </Show>
+            </div>
           </div>
         </header>
 
@@ -1529,6 +1546,9 @@ export const ChatContent: Component<ChatContentProps> = (props) => {
                   "Create the skill to identify new business leads and introduce
                   our company using Seren's Publishers"
                 </p>
+                <div class="mt-8 w-full max-w-[560px]">
+                  <DataDestinationsPanel conversationId={conversationId()} />
+                </div>
               </div>
             }
           >

--- a/src/components/chat/DataDestinationsPanel.tsx
+++ b/src/components/chat/DataDestinationsPanel.tsx
@@ -1,0 +1,204 @@
+// ABOUTME: Compact, live disclosure of every data destination used by a conversation.
+// ABOUTME: Gives each conversation its memory and history-sync exclusion controls.
+
+import type { Component } from "solid-js";
+import { createMemo, For, Show } from "solid-js";
+import { privacyStore } from "@/stores/privacy.store";
+import { settingsState } from "@/stores/settings.store";
+import { threadStore } from "@/stores/thread.store";
+
+interface DataDestinationsPanelProps {
+  conversationId?: string | null;
+}
+
+interface Destination {
+  label: string;
+  detail: () => string;
+  control: string;
+  enabled: () => boolean;
+}
+
+export const DataDestinationsPanel: Component<DataDestinationsPanelProps> = (
+  props,
+) => {
+  const conversation = createMemo(() =>
+    props.conversationId
+      ? threadStore.findConversation(props.conversationId)
+      : undefined,
+  );
+
+  const destinationState = createMemo<Destination[]>(() => [
+    {
+      label: "Inference provider",
+      detail: () => {
+        const provider = conversation()?.provider ?? "selected provider";
+        const model = conversation()?.model ?? "selected model";
+        return `${provider} · ${model}`;
+      },
+      control: "Chosen per conversation",
+      enabled: () => true,
+    },
+    {
+      label: "Memory capture",
+      detail: () =>
+        privacyStore.isMemoryExcluded(props.conversationId)
+          ? "Excluded for this conversation"
+          : "Structured memories may be created from completed turns",
+      control: "Settings → Memory",
+      enabled: () =>
+        settingsState.app.memoryEnabled &&
+        !privacyStore.isMemoryExcluded(props.conversationId),
+    },
+    {
+      label: "History sync",
+      detail: () =>
+        privacyStore.isHistorySyncExcluded(props.conversationId)
+          ? "Excluded for this conversation"
+          : "Remote history copy, including unsent drafts, every 15 seconds",
+      control: "Settings → Sync",
+      enabled: () =>
+        settingsState.app.historySyncEnabled &&
+        !privacyStore.isHistorySyncExcluded(props.conversationId),
+    },
+    {
+      label: "Error telemetry",
+      detail: () =>
+        settingsState.app.telemetryEnabled
+          ? "Scrubbed diagnostics are sent only when an error is captured"
+          : "Disabled; queued diagnostics are discarded",
+      control: "Settings → General",
+      enabled: () => settingsState.app.telemetryEnabled,
+    },
+    {
+      label: "Organization cloud runs",
+      detail: () => "Only when an organization workflow is explicitly launched",
+      control: "Requires an explicit action",
+      enabled: () => false,
+    },
+    {
+      label: "MCP tool arguments",
+      detail: () => "Only when a tool is explicitly invoked during this turn",
+      control: "Requires an explicit action",
+      enabled: () => false,
+    },
+  ]);
+
+  const updatePrivacy = (
+    key: "excludeMemory" | "excludeHistorySync",
+    checked: boolean,
+  ) => {
+    const id = props.conversationId;
+    if (!id) return;
+    privacyStore.setConversationPrivacy(id, { [key]: checked });
+  };
+
+  return (
+    <section
+      class="w-full max-w-[560px] overflow-hidden rounded-xl border border-[#293438] bg-[#101719] text-[#e8f0ef] shadow-[0_18px_50px_rgba(0,0,0,0.24)]"
+      data-testid="data-destinations-panel"
+      aria-label="Data destinations"
+    >
+      <div class="border-b border-[#293438] bg-[linear-gradient(105deg,rgba(116,220,177,0.12),transparent_42%)] px-4 py-3">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <p class="m-0 text-[10px] font-semibold uppercase tracking-[0.18em] text-[#86d9b8]">
+              Data destinations
+            </p>
+            <h2 class="m-0 mt-1 text-sm font-semibold text-[#f2f7f6]">
+              Where this conversation can go
+            </h2>
+          </div>
+          <span class="rounded-full border border-[#345047] bg-[#15241f] px-2 py-1 text-[10px] font-medium text-[#9ce3c3]">
+            live state
+          </span>
+        </div>
+        <p class="m-0 mt-2 max-w-[450px] text-xs leading-relaxed text-[#a8b9b5]">
+          Controls below update the local capture and synchronization paths
+          immediately.
+        </p>
+      </div>
+
+      <div class="divide-y divide-[#253135]">
+        <For each={destinationState()}>
+          {(destination) => (
+            <div class="flex gap-3 px-4 py-3">
+              <span
+                class={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${
+                  destination.enabled()
+                    ? "bg-[#76ddb0] shadow-[0_0_0_3px_rgba(118,221,176,0.12)]"
+                    : "bg-[#61716f]"
+                }`}
+                aria-hidden="true"
+              />
+              <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+                  <span class="text-xs font-semibold text-[#e8f0ef]">
+                    {destination.label}
+                  </span>
+                  <span
+                    class={`text-[10px] font-semibold uppercase tracking-[0.12em] ${destination.enabled() ? "text-[#86d9b8]" : "text-[#82918f]"}`}
+                  >
+                    {destination.enabled() ? "active" : "off"}
+                  </span>
+                </div>
+                <p class="m-0 mt-1 text-xs leading-relaxed text-[#a8b9b5]">
+                  {destination.detail()}
+                </p>
+                <p class="m-0 mt-1 text-[10px] text-[#71817e]">
+                  {destination.control}
+                </p>
+              </div>
+            </div>
+          )}
+        </For>
+      </div>
+
+      <Show when={props.conversationId}>
+        <div class="border-t border-[#293438] bg-[#0d1416] px-4 py-3">
+          <p class="m-0 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#82918f]">
+            Conversation controls
+          </p>
+          <div class="mt-2 grid gap-2 sm:grid-cols-2">
+            <label class="flex cursor-pointer items-start gap-2 rounded-lg border border-[#293438] px-3 py-2 transition-colors hover:border-[#4a6a5e]">
+              <input
+                type="checkbox"
+                class="mt-0.5 accent-[#76ddb0]"
+                checked={privacyStore.isMemoryExcluded(props.conversationId)}
+                onChange={(event) =>
+                  updatePrivacy("excludeMemory", event.currentTarget.checked)
+                }
+                aria-label="Exclude this conversation from memory"
+              />
+              <span class="text-xs leading-relaxed text-[#c4d1ce]">
+                Exclude from memory capture
+              </span>
+            </label>
+            <label class="flex cursor-pointer items-start gap-2 rounded-lg border border-[#293438] px-3 py-2 transition-colors hover:border-[#4a6a5e]">
+              <input
+                type="checkbox"
+                class="mt-0.5 accent-[#76ddb0]"
+                checked={privacyStore.isHistorySyncExcluded(
+                  props.conversationId,
+                )}
+                onChange={(event) =>
+                  updatePrivacy(
+                    "excludeHistorySync",
+                    event.currentTarget.checked,
+                  )
+                }
+                aria-label="Exclude this conversation from history sync"
+              />
+              <span class="text-xs leading-relaxed text-[#c4d1ce]">
+                Exclude from history sync
+              </span>
+            </label>
+          </div>
+          <p class="m-0 mt-2 text-[10px] leading-relaxed text-[#71817e]">
+            Exclusion takes effect before the next capture or sync drain; queued
+            history remains local until you include it again.
+          </p>
+        </div>
+      </Show>
+    </section>
+  );
+};

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -27,6 +27,7 @@ import {
   wipeHistorySyncRemote,
 } from "@/services/historySync";
 import { allowsSerenPublicModels } from "@/services/organization-policy";
+import { telemetry } from "@/services/telemetry";
 import {
   appearanceState,
   appearanceStore,
@@ -466,6 +467,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
             {(section) => (
               <button
                 type="button"
+                data-testid={`settings-section-${section.id}`}
                 class={`flex items-center gap-2.5 px-3 py-2.5 border-none rounded-md cursor-pointer text-[0.9rem] text-left transition-all duration-150 ${
                   activeSection() === section.id
                     ? "bg-accent text-white"
@@ -2130,6 +2132,7 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
               <label class="flex items-start gap-3 cursor-pointer">
                 <input
                   type="checkbox"
+                  data-testid="history-sync-enabled"
                   checked={settingsState.app.historySyncEnabled}
                   disabled={historySyncBusy()}
                   onChange={(e) =>
@@ -2274,13 +2277,13 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
               <label class="flex items-start gap-3 cursor-pointer">
                 <input
                   type="checkbox"
+                  data-testid="telemetry-enabled"
                   checked={settingsState.app.telemetryEnabled}
-                  onChange={(e) =>
-                    handleBooleanChange(
-                      "telemetryEnabled",
-                      e.currentTarget.checked,
-                    )
-                  }
+                  onChange={(e) => {
+                    const enabled = e.currentTarget.checked;
+                    handleBooleanChange("telemetryEnabled", enabled);
+                    telemetry.setEnabled(enabled);
+                  }}
                   class="w-[18px] h-[18px] mt-0.5 accent-accent cursor-pointer"
                 />
                 <span class="flex flex-col gap-0.5">

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -260,6 +260,7 @@ export interface ToolIterationState {
 /** Stable source identity used to make memory capture idempotent across retries. */
 export interface ToolMemorySource {
   sourceExternalId: string;
+  conversationId?: string;
   sourceRevision?: string;
   sourceUri?: string;
   sessionId?: string;
@@ -663,6 +664,7 @@ export async function* streamMessageWithTools(
       if (finalOutputValidation.canStoreMemory && memorySource) {
         processAssistantResponseMemory(fullContent, {
           ...memorySource,
+          conversationId: memorySource.conversationId,
           model,
           userQuery: content,
         }).catch((err) => {
@@ -839,6 +841,7 @@ export async function* continueToolIteration(
       if (finalOutputValidation.canStoreMemory && memorySource) {
         processAssistantResponseMemory(fullContent, {
           ...memorySource,
+          conversationId: memorySource.conversationId,
           model,
           userQuery,
         }).catch((err) => {

--- a/src/services/historySync.ts
+++ b/src/services/historySync.ts
@@ -5,6 +5,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { isTauriRuntime } from "@/lib/tauri-bridge";
 import { waitForDatabaseReady } from "@/services/claudeMemory";
 import { type Branch, databases } from "@/services/databases";
+import { privacyStore } from "@/stores/privacy.store";
 import { settingsStore } from "@/stores/settings.store";
 
 const HISTORY_SYNC_PROJECT_NAME = "speech-text";
@@ -180,6 +181,7 @@ export async function runHistorySyncNow(): Promise<HistorySyncSummary> {
       projectId: provisioning.projectId,
       branchId: provisioning.branchId,
       databaseName: provisioning.databaseName,
+      excludedConversationIds: privacyStore.excludedHistorySyncIds(),
     });
     settingsStore.set("historySyncLastSyncedAt", Date.now());
     return summary;

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -3,6 +3,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { authStore } from "@/stores/auth.store";
+import { privacyStore } from "@/stores/privacy.store";
 import { projectStore } from "@/stores/project.store";
 import { settingsStore } from "@/stores/settings.store";
 import type {
@@ -76,6 +77,7 @@ export interface MemorySessionBootstrapResult {
 
 export interface ProcessConversationInput {
   transcript: string;
+  conversationId?: string;
   projectContext?: string;
   projectId?: string | null;
   sessionId?: string;
@@ -102,6 +104,7 @@ export interface RememberMemoryOptions {
 }
 
 export interface AssistantMemoryContext {
+  conversationId?: string;
   model?: string;
   userQuery?: string;
   sessionId?: string;
@@ -699,6 +702,12 @@ export async function bootstrapMemoryContext(): Promise<string | null> {
 export async function processConversationMemory(
   input: ProcessConversationInput,
 ): Promise<ProcessConversationResult | null> {
+  if (
+    input.conversationId &&
+    privacyStore.isMemoryExcluded(input.conversationId)
+  ) {
+    return null;
+  }
   if (!isMemoryAvailable()) {
     return null;
   }
@@ -740,6 +749,7 @@ export async function processConversationTurn(
   const sourceExternalId = context?.sourceExternalId;
   return processConversationMemory({
     transcript: `User: ${userMessage}\n\nAssistant: ${assistantMessage}${metadata}`,
+    conversationId: context?.conversationId,
     sessionId: context?.sessionId,
     projectContext: context?.projectContext,
     retainSource: sourceExternalId !== undefined,
@@ -765,6 +775,7 @@ export async function processAssistantResponseMemory(
   const sourceExternalId = context?.sourceExternalId;
   return processConversationMemory({
     transcript: `${content}${metadata}`,
+    conversationId: context?.conversationId,
     sessionId: context?.sessionId,
     projectContext: context?.projectContext,
     retainSource: sourceExternalId !== undefined,

--- a/src/services/orchestrator.ts
+++ b/src/services/orchestrator.ts
@@ -710,6 +710,7 @@ function handleComplete(
   const model = stream.modelId || providerStore.activeModel || "unknown";
   if (finalOutputValidation.canStoreMemory) {
     processAssistantResponseMemory(safeContent, {
+      conversationId,
       model,
       userQuery: stream.prompt,
       sessionId: conversationId,

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -68,7 +68,7 @@ export function buildEmployeeInterestTelemetryPayload(
   };
 }
 
-class TelemetryService {
+export class TelemetryService {
   private config: TelemetryConfig;
   private rateLimiter: RateLimiter;
   private errorQueue: ErrorReport[] = [];
@@ -182,7 +182,7 @@ class TelemetryService {
    * Send queued errors to the server.
    */
   async flush(): Promise<void> {
-    if (this.errorQueue.length === 0) return;
+    if (!this.config.enabled || this.errorQueue.length === 0) return;
 
     const batch = this.errorQueue.splice(0, this.config.maxBatchSize);
 
@@ -221,7 +221,11 @@ class TelemetryService {
     if (!enabled) {
       this.stopBatchTimer();
       this.errorQueue = [];
-    } else if (this.initialized) {
+      return;
+    }
+    if (!this.initialized) {
+      this.init();
+    } else {
       this.startBatchTimer();
     }
   }

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -8418,6 +8418,7 @@ export const agentStore = {
         finalOutputValidation.canStoreMemory
       ) {
         processAssistantResponseMemory(safeContent, {
+          conversationId: session.conversationId,
           model: `agent:${session.info.agentType}`,
           userQuery: session.lastUserPrompt,
           sessionId: session.conversationId,

--- a/src/stores/privacy.store.ts
+++ b/src/stores/privacy.store.ts
@@ -1,0 +1,142 @@
+// ABOUTME: Conversation-level privacy controls for local memory and history sync.
+// ABOUTME: Persists exclusion choices through the same Tauri/browser settings boundary as app settings.
+
+import { createStore } from "solid-js/store";
+import { isTauriRuntime } from "@/lib/tauri-bridge";
+
+const PRIVACY_STORE = "privacy.json";
+const CONVERSATIONS_KEY = "conversations";
+const BROWSER_PRIVACY_KEY = "seren_conversation_privacy";
+
+export interface ConversationPrivacy {
+  excludeMemory: boolean;
+  excludeHistorySync: boolean;
+}
+
+interface PrivacyState {
+  conversations: Record<string, ConversationPrivacy>;
+  isLoading: boolean;
+}
+
+const [privacyState, setPrivacyState] = createStore<PrivacyState>({
+  conversations: {},
+  isLoading: true,
+});
+
+async function getInvoke(): Promise<
+  typeof import("@tauri-apps/api/core").invoke | null
+> {
+  if (!isTauriRuntime()) return null;
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke;
+}
+
+function normalizeConversations(
+  value: unknown,
+): Record<string, ConversationPrivacy> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+
+  const normalized: Record<string, ConversationPrivacy> = {};
+  for (const [id, flags] of Object.entries(value)) {
+    if (!flags || typeof flags !== "object" || Array.isArray(flags)) continue;
+    const candidate = flags as Partial<ConversationPrivacy>;
+    normalized[id] = {
+      excludeMemory: candidate.excludeMemory === true,
+      excludeHistorySync: candidate.excludeHistorySync === true,
+    };
+  }
+  return normalized;
+}
+
+async function loadStoredPrivacy(): Promise<string | null> {
+  const invoke = await getInvoke();
+  if (invoke) {
+    return invoke<string | null>("get_setting", {
+      store: PRIVACY_STORE,
+      key: CONVERSATIONS_KEY,
+    });
+  }
+  if (typeof localStorage === "undefined") return null;
+  return localStorage.getItem(BROWSER_PRIVACY_KEY);
+}
+
+async function saveStoredPrivacy(): Promise<void> {
+  const value = JSON.stringify(privacyState.conversations);
+  try {
+    const invoke = await getInvoke();
+    if (invoke) {
+      await invoke("set_setting", {
+        store: PRIVACY_STORE,
+        key: CONVERSATIONS_KEY,
+        value,
+      });
+      return;
+    }
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(BROWSER_PRIVACY_KEY, value);
+    }
+  } catch (error) {
+    console.warn("[Privacy] Failed to persist conversation controls:", error);
+  }
+}
+
+export async function loadPrivacySettings(): Promise<void> {
+  setPrivacyState("isLoading", true);
+  try {
+    const stored = await loadStoredPrivacy();
+    if (stored) {
+      setPrivacyState(
+        "conversations",
+        normalizeConversations(JSON.parse(stored)),
+      );
+    }
+  } catch {
+    setPrivacyState("conversations", {});
+  } finally {
+    setPrivacyState("isLoading", false);
+  }
+}
+
+function flagsFor(id: string): ConversationPrivacy {
+  return (
+    privacyState.conversations[id] ?? {
+      excludeMemory: false,
+      excludeHistorySync: false,
+    }
+  );
+}
+
+export const privacyStore = {
+  getConversationPrivacy(id: string): ConversationPrivacy {
+    return flagsFor(id);
+  },
+
+  isMemoryExcluded(id: string | null | undefined): boolean {
+    return id ? flagsFor(id).excludeMemory : false;
+  },
+
+  isHistorySyncExcluded(id: string | null | undefined): boolean {
+    return id ? flagsFor(id).excludeHistorySync : false;
+  },
+
+  setConversationPrivacy(
+    id: string,
+    updates: Partial<ConversationPrivacy>,
+  ): void {
+    if (!id) return;
+    const next = {
+      ...flagsFor(id),
+      ...updates,
+    };
+    setPrivacyState("conversations", id, next);
+    void saveStoredPrivacy();
+  },
+
+  excludedHistorySyncIds(): string[] {
+    return Object.entries(privacyState.conversations)
+      .filter(([, flags]) => flags.excludeHistorySync)
+      .map(([id]) => id);
+  },
+};
+
+export { privacyState };

--- a/tests/unit/memory-exclusion.test.ts
+++ b/tests/unit/memory-exclusion.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Verifies excluded conversations stop memory capture at the frontend choke point.
+// ABOUTME: Protects the no-cache/no-sync invariant without invoking the backend command.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invokeMock, authStoreMock, projectStoreMock, settingsGetMock } =
+  vi.hoisted(() => ({
+    invokeMock: vi.fn(),
+    authStoreMock: {
+      isAuthenticated: true,
+      user: { id: "user-1" },
+    },
+    projectStoreMock: {
+      activeProject: { id: "project-1" },
+    },
+    settingsGetMock: vi.fn((key: string) => key === "memoryEnabled"),
+  }));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@/stores/auth.store", () => ({
+  authStore: authStoreMock,
+}));
+
+vi.mock("@/stores/project.store", () => ({
+  projectStore: projectStoreMock,
+}));
+
+vi.mock("@/stores/settings.store", () => ({
+  settingsStore: {
+    get: settingsGetMock,
+  },
+}));
+
+import { processConversationMemory } from "@/services/memory";
+import { privacyStore } from "@/stores/privacy.store";
+
+describe("conversation memory exclusions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    privacyStore.setConversationPrivacy("excluded-conversation", {
+      excludeMemory: true,
+      excludeHistorySync: false,
+    });
+  });
+
+  it("does not invoke memory_process_conversation for an excluded conversation", async () => {
+    await expect(
+      processConversationMemory({
+        conversationId: "excluded-conversation",
+        transcript: "A private conversation that must not become memory.",
+      }),
+    ).resolves.toBeNull();
+
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "memory_process_conversation",
+      expect.anything(),
+    );
+  });
+});

--- a/tests/unit/telemetry-disabled.test.ts
+++ b/tests/unit/telemetry-disabled.test.ts
@@ -1,0 +1,64 @@
+// ABOUTME: Verifies telemetry stays silent while the persisted setting is off.
+// ABOUTME: Covers queue dropping and re-enabling through the real telemetry service.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchMock, getTokenMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  getTokenMock: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/tauri-bridge", () => ({
+  getToken: getTokenMock,
+}));
+
+vi.mock("@/lib/tauri-fetch", () => ({
+  getTauriFetch: vi.fn(async () => globalThis.fetch),
+  shouldSkipRefresh: vi.fn(() => true),
+  shouldUseRustGatewayAuth: vi.fn(() => false),
+}));
+
+import { TelemetryService } from "@/services/telemetry";
+
+describe("telemetry disabled behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("navigator", { userAgent: "Seren test runner" });
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+  });
+
+  it("sends nothing while disabled, drops queued errors, and resumes when enabled", async () => {
+    const service = new TelemetryService({
+      enabled: false,
+      batchIntervalMs: 60_000,
+    });
+
+    service.captureError(new Error("disabled error"));
+    await service.flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    service.setEnabled(true);
+    service.captureError(new Error("enabled error"));
+    await service.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0]?.[0] as Request).url).toBe(
+      "https://api.serendb.com/diagnostics/errors",
+    );
+
+    service.captureError(new Error("discarded after disable"));
+    service.setEnabled(false);
+    await service.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    service.setEnabled(true);
+    await service.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    service.shutdown();
+    expect(getTokenMock).toHaveBeenCalled();
+  });
+});

--- a/tests/validation/scenarios/egress-disclosure.ts
+++ b/tests/validation/scenarios/egress-disclosure.ts
@@ -1,0 +1,83 @@
+// ABOUTME: Verifies the live data-destination disclosure and settings reactions.
+// ABOUTME: Exercises only signed-out UI paths reachable in the hermetic validation app.
+
+import type { ScenarioContext } from "../../../scripts/validate-walkthrough";
+
+interface TextDump {
+  text?: string;
+}
+
+function textOf(value: unknown): string {
+  return typeof (value as TextDump)?.text === "string"
+    ? (value as TextDump).text as string
+    : JSON.stringify(value);
+}
+
+async function capturePanel(
+  ctx: ScenarioContext,
+  stage: string,
+): Promise<string> {
+  const panel = await ctx.client.dumpText(
+    "[data-testid='data-destinations-panel']",
+  );
+  await ctx.writeArtifact(`${stage}-panel.json`, panel);
+  await ctx.writeArtifact(
+    `${stage}-panel-screenshot.json`,
+    await ctx.client.screenshot("[data-testid='data-destinations-panel']"),
+  );
+  return textOf(panel);
+}
+
+export default async function run(ctx: ScenarioContext): Promise<void> {
+  await ctx.client.waitFor("[data-testid='new-thread-button']", 30_000);
+  await ctx.client.click("[data-testid='new-thread-button']");
+  await ctx.client.waitFor("[data-testid='new-seren-chat']", 10_000);
+  await ctx.client.click("[data-testid='new-seren-chat']");
+  await ctx.client.waitFor(
+    "[data-testid='data-destinations-panel']",
+    30_000,
+  );
+  const before = await capturePanel(ctx, "before-settings-flip");
+
+  await ctx.client.click("button[title='Settings']");
+  await ctx.client.waitFor("[data-testid='settings-section-sync']", 10_000);
+  await ctx.client.click("[data-testid='settings-section-sync']");
+  await ctx.client.waitFor("[data-testid='history-sync-enabled']", 10_000);
+  await ctx.client.click("[data-testid='history-sync-enabled']");
+
+  await ctx.client.click("[data-testid='settings-section-general']");
+  await ctx.client.waitFor("[data-testid='telemetry-enabled']", 10_000);
+  await ctx.client.click("[data-testid='telemetry-enabled']");
+  await ctx.writeArtifact(
+    "settings-after-flips.json",
+    await ctx.client.dumpText("main"),
+  );
+  await ctx.writeArtifact(
+    "settings-after-flips-screenshot.json",
+    await ctx.client.screenshot("main"),
+  );
+
+  await ctx.client.click("button[title='Close panel']");
+  await ctx.client.waitFor(
+    "[data-testid='data-destinations-panel']",
+    10_000,
+  );
+  const after = await capturePanel(ctx, "after-settings-flip");
+  await ctx.writeArtifact("settings-flip-summary.json", {
+    changed: before !== after,
+    before,
+    after,
+  });
+
+  if (before === after) {
+    throw new Error("The data-destination panel did not react to settings changes");
+  }
+  if (!after.includes("Disabled; queued diagnostics are discarded")) {
+    throw new Error("The telemetry disclosure did not show its disabled state");
+  }
+
+  await ctx.writeArtifact(
+    "after-settings-flip-native-screenshot.json",
+    await ctx.client.nativeScreenshot(),
+  );
+}


### PR DESCRIPTION
## Summary

- Gate error telemetry on the persisted setting and make disabling it stop the timer and discard queued diagnostics.
- Add persisted per-conversation memory and history-sync exclusions at the capture and outbox drain boundaries.
- Add a live data-destination disclosure to empty chat and conversation header/menu surfaces, with controls for both exclusions.

## Audit trace

- Memory capture has one frontend choke point in `processConversationMemory`; the four existing capture callers now pass the enclosing conversation ID.
- History sync carries excluded IDs from the frontend invoke through the Rust command and skips excluded conversations before upload or `synced_at` updates. Draft backfill applies the same filter, and excluded outbox rows remain local for a later opt-in.
- Telemetry initialization now follows the loaded `telemetryEnabled` setting, and settings changes call `setEnabled` immediately.

## Networked paths

- Telemetry: `appFetch` POST to `https://api.serendb.com/diagnostics/errors`.
- Memory capture: `memory_process_conversation` → the `process_conversation` tool over POST `https://memory.serendb.com/mcp`.
- History sync: `history_sync_run_now` → authenticated GET `https://api.serendb.com/publishers/seren-db/projects/{project}/branches/{branch}/connection-string?pooled=true`, followed by the existing authenticated PostgreSQL sync.
- These paths were traced from the UI boundary and checked against the live Seren publisher metadata: `seren-memory` exposes `process_conversation`, and `seren-db` exposes the project/branch database surface. No new publisher or API path is added by this change.

## Verification

- `pnpm check` passed; the repository reports only its existing Biome schema-version notice and unrelated warnings.
- Focused Vitest passed: 5 files, 16 tests, including disabled telemetry and excluded-memory regression coverage.
- `cargo test --manifest-path src-tauri/Cargo.toml history_sync` passed: 17 tests.
- Scoped Rust formatting and `git diff --check` passed.
- Live no-mock `pnpm validate:walkthrough egress-disclosure` passed with `artifacts/validation-walkthrough/result.json` reporting `"ok": true`. The signed-out hermetic instance created a local chat, rendered the disclosure, flipped history sync and telemetry off in Settings, and verified the panel changed to the disabled states. Native screenshot capture succeeded. The validation log was written under the repo-local validation home.

The walkthrough coverage bound is the signed-out UI path. The signed-in end-to-end invariants—no `process_conversation` call, no pending memory cache record, and no remote history rows for an excluded conversation—remain explicitly pending a signed-in walkthrough, so this PR references rather than closes the issue.

Refs #3196

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
