### PR TITLE
fix(agent): immediate containment — fail-closed Linux sandbox, Windows shell gating, honest on-request mapping

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -639,13 +639,16 @@ const DEFAULT_PREFERRED_MODEL = "claude-opus-4-8[1m]";
 const DEFAULT_PREFERRED_MODE = "bypassPermissions";
 
 // Maps the persisted agent approval policy to the permission mode a fresh
-// Claude thread spawns in. The default and on-request policies land on the
-// out-of-box DEFAULT_PREFERRED_MODE; only an explicitly stricter policy
-// (untrusted / on-failure) downgrades to acceptEdits. Runs against the stored
-// setting at every spawn, so it governs the composer default without mutating
-// the saved value. #2810.
+// Claude thread spawns in. On-request must stay the normal prompt-producing
+// default rather than inheriting the bypassPermissions seed; only the
+// explicitly permissive never policy uses DEFAULT_PREFERRED_MODE, while an
+// explicitly stricter policy (untrusted / on-failure) downgrades to
+// acceptEdits. Runs against the stored setting at every spawn, so it governs
+// the composer default without mutating the saved value. #2810, #3192.
 function claudeModeFromApprovalPolicy(approvalPolicy) {
   switch (approvalPolicy) {
+    case "on-request":
+      return "default";
     case "untrusted":
     case "on-failure":
       return "acceptEdits";
@@ -1186,24 +1189,20 @@ function buildClaudePolicySettings({ cwd, sandboxMode, networkEnabled }) {
 
   // Claude's native sandbox constrains Bash subprocesses on macOS/Linux.
   // Built-in file tools are independently constrained by the hook above.
-  //
-  // Native Windows gets no Bash boundary at all. The sandbox is built on
-  // Seatbelt (macOS) and bubblewrap (Linux/WSL2); upstream states native
-  // Windows is unsupported, so emitting these keys there configures nothing.
-  // The only Windows-viable alternative is matching file paths out of
-  // arbitrary shell strings in the PreToolUse hook, which any indirection
-  // (`cat $(printf ...)`) defeats — a boundary that reads as real while
-  // failing open is worse than a stated gap, so Settings → Agent says
-  // plainly that shell commands are unbounded on Windows. #3149
+  // Native Windows has no supported OS-level Bash boundary, so immediate
+  // containment denies the Bash tool entirely in every bounded mode. Full
+  // Access remains an explicit user-selected escape hatch. #3192
+  if (process.platform === "win32") {
+    settings.permissions = { deny: ["Bash"] };
+  }
+
   if (process.platform !== "win32") {
     settings.sandbox = {
       enabled: true,
-      // Left at the default (false). The Linux sandbox needs bubblewrap and
-      // socat from the distro, which the .deb and AppImage cannot guarantee;
-      // failing closed there turns a missing OS package into an agent that
-      // never starts. Claude warns and runs unsandboxed instead, and the
-      // PreToolUse hook still bounds the built-in file tools. #3138
-      failIfUnavailable: false,
+      // The Linux sandbox needs bubblewrap and socat from the distro. If the
+      // required boundary cannot initialize, Claude must block rather than
+      // warn and continue unsandboxed. #3138, #3192
+      failIfUnavailable: true,
       autoAllowBashIfSandboxed: true,
       allowUnsandboxedCommands: false,
       filesystem: {

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1336,14 +1336,11 @@ export const SettingsPanel: Component<SettingsPanelProps> = (props) => {
             >
               <p class="m-0 py-3 border-b border-border text-[0.8rem] text-muted-foreground leading-normal">
                 <span class="font-medium text-foreground">
-                  On Windows this bounds the agent's file, search, and web tools
-                  only.
+                  On native Windows, shell commands are disabled unless Full
+                  Access is explicitly selected.
                 </span>{" "}
-                Shell commands are not bounded. Claude Code's operating-system
-                sandbox does not support native Windows, so a shell command the
-                agent runs can read and write anywhere your account can. Set
-                Approval Policy to Untrusted or On Failure to review each
-                command before it runs.
+                File, search, and web tools remain bounded by the selected
+                workspace.
               </p>
             </Show>
 

--- a/tests/unit/agent-file-access-policy.test.ts
+++ b/tests/unit/agent-file-access-policy.test.ts
@@ -112,9 +112,9 @@ describe("Claude promptless containment (#3091)", () => {
     });
     if (process.platform === "win32") return;
 
-    // failIfUnavailable turns a missing bubblewrap/socat into a Claude Code
-    // that will not start, and we ship neither. #3138
-    expect(settings.sandbox.failIfUnavailable).toBe(false);
+    // A missing bubblewrap/socat must block the Claude Code launch instead of
+    // warning and continuing without an OS boundary. #3138, #3192
+    expect(settings.sandbox.failIfUnavailable).toBe(true);
 
     // Denying all of ~/ also hides ~/.gitconfig and $HOME toolchains, which
     // breaks git commit and most build commands. #3139
@@ -157,7 +157,7 @@ describe("Claude promptless containment (#3091)", () => {
   });
 });
 
-describe("Windows shell boundary gap is stated, not faked (#3149)", () => {
+describe("Windows shell boundary is denied until Full Access (#3149, #3192)", () => {
   const settingsPanel = readFileSync(
     resolve("src/components/settings/SettingsPanel.tsx"),
     "utf8",
@@ -168,29 +168,53 @@ describe("Windows shell boundary gap is stated, not faked (#3149)", () => {
   );
 
   it("keeps Bash out of the hook matcher, which cannot bound a shell string", () => {
-    // Claude's sandbox is the only layer that bounds Bash, and upstream does
-    // not run it on native Windows. Matching Bash here would mean parsing
-    // file arguments out of arbitrary shell commands — `cat $(printf ...)`
-    // walks straight past that, so the hook would fail open while reading as
-    // a real boundary. The gap is surfaced in Settings instead.
+    // The hook intentionally covers built-in file tools only. Native Windows
+    // uses the policy deny rule below rather than pretending to parse paths
+    // out of arbitrary shell strings.
     const settings = buildClaudePolicySettings({
       cwd: tempProject(),
       sandboxMode: "workspace-write",
       networkEnabled: false,
     });
     expect(settings.hooks.PreToolUse[0].matcher).not.toContain("Bash");
-    if (process.platform === "win32") {
-      expect(settings.sandbox).toBeUndefined();
-    }
-    expect(claudeRuntime).toContain("#3149");
+    expect(claudeRuntime).toContain("#3192");
   });
 
-  it("tells Windows users their shell commands are unbounded", () => {
-    // Without this the feature advertises containment it does not deliver on
-    // Windows. The note must be platform-gated so macOS and Linux, where the
-    // sandbox does bound Bash, are not told otherwise.
+  it("denies Bash for bounded native-Windows modes but not Full Access", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "win32",
+      configurable: true,
+    });
+    try {
+      for (const sandboxMode of ["read-only", "workspace-write"] as const) {
+        const settings = buildClaudePolicySettings({
+          cwd: tempProject(),
+          sandboxMode,
+          networkEnabled: false,
+        });
+        expect(settings.permissions.deny).toContain("Bash");
+        expect(settings.sandbox).toBeUndefined();
+      }
+
+      expect(
+        buildClaudePolicySettings({
+          cwd: tempProject(),
+          sandboxMode: "full-access",
+          networkEnabled: false,
+        }),
+      ).toEqual({});
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  it("tells Windows users shell commands are disabled unless Full Access", () => {
     expect(settingsPanel).toContain("isWindowsPlatform");
-    const noteAt = settingsPanel.indexOf("Shell commands are not bounded");
+    const noteAt = settingsPanel.indexOf("shell commands are disabled unless Full");
     expect(noteAt).toBeGreaterThan(-1);
     const gateAt = settingsPanel.lastIndexOf("isWindowsPlatform()", noteAt);
     expect(gateAt).toBeGreaterThan(-1);

--- a/tests/unit/claude-runtime-default-permission-mode.test.ts
+++ b/tests/unit/claude-runtime-default-permission-mode.test.ts
@@ -19,11 +19,11 @@ describe("DEFAULT_PREFERRED_MODE — fresh-session out-of-box permission mode (#
 });
 
 describe("claudeModeFromApprovalPolicy — fresh-session seed (#2810)", () => {
-  it("lands the default 'on-request' policy on bypassPermissions", () => {
-    // 'on-request' is the shipped default agentApprovalPolicy; running the
-    // stored value through the mapping at spawn is what fixes existing installs
-    // without mutating the saved setting.
-    expect(claudeModeFromApprovalPolicy("on-request")).toBe("bypassPermissions");
+  it("keeps the default 'on-request' policy in the normal prompt mode (#3192)", () => {
+    // 'on-request' is the shipped default agentApprovalPolicy. It must not
+    // inherit the bypassPermissions seed, because that silently removes the
+    // approval boundary from fresh sessions.
+    expect(claudeModeFromApprovalPolicy("on-request")).toBe("default");
   });
 
   it("keeps 'never' on bypassPermissions", () => {


### PR DESCRIPTION
## Summary

- Map the persisted `on-request` approval policy to Claude Code's normal `default` permission mode instead of silently inheriting `bypassPermissions`.
- Make the Linux Claude sandbox fail closed when its required host boundary cannot initialize.
- Deny the Claude `Bash` tool in bounded native-Windows modes, retain Full Access as the explicit escape hatch, and state that behavior accurately in Settings.

## Audit trace

- `bin/browser-local/claude-runtime.mjs:641-655`: approval-policy to permission-mode mapping used at every Claude spawn.
- `bin/browser-local/claude-runtime.mjs:1161-1220`: policy serialization for hooks, native sandbox settings, and platform-specific containment.
- `src/components/settings/SettingsPanel.tsx:1331-1348`: platform-gated agent sandbox notice.
- `tests/unit/agent-file-access-policy.test.ts` and `tests/unit/claude-runtime-default-permission-mode.test.ts`: locked regression coverage for Linux fail-closed behavior, Windows Bash denial, Full Access, and on-request mapping.

## Permission-rule verification

The bare `Bash` deny rule is the documented Claude Code form for removing the tool from the session. Verified against the official permissions documentation: https://code.claude.com/docs/en/permissions

## Verification

- `pnpm vitest run tests/unit/agent-file-access-policy.test.ts tests/unit/claude-runtime-default-permission-mode.test.ts` — 15 tests passed.
- All 30 test files importing `claude-runtime.mjs` — 153 tests passed.
- `pnpm check` — passed; only the repository's existing Biome schema notice and unrelated warnings were reported.
- `git diff --check` — passed.

## Scope and residual verification

This PR covers the ticket's immediate-containment controls only. The canonical Rust sandbox launcher, descendant coverage, OS-level network enforcement, verified effective-sandbox reporting, and real provider-launched shell tests on macOS/Linux/Windows remain outstanding under #3192. Native macOS Seatbelt behavior is unchanged; the fail-closed flip applies to the Linux Claude sandbox configuration. Windows and Linux host-level behavior still require the ticket's platform walkthroughs.

Networked path: none — this change alters local agent spawn policy only; no publisher or API call is added or modified.

Refs #3192

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
