### PR TITLE
fix(remote): keep Happy sessions active

### DIFF
--- a/bin/happy-bridge/happy-layer.mjs
+++ b/bin/happy-bridge/happy-layer.mjs
@@ -23,7 +23,9 @@ import {
 const AUTH_POLL_MS = 1000;
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const SUMMARY_CACHE_TTL_MS = 1000;
+const SESSION_KEEP_ALIVE_MS = 2000;
 const DEFAULT_CODEX_APPROVAL_POLICY = "on-failure";
+const BUSY_SESSION_STATUSES = new Set(["prompting", "busy", "running"]);
 const DENY_OPTION_IDS = new Set([
   "deny",
   "decline",
@@ -337,6 +339,29 @@ export function createTerminatedSessionTracker(maxSize = 256) {
   };
 }
 
+function createSessionLiveness(client, initialThinking = false) {
+  let thinking = initialThinking;
+  let stopped = false;
+  const pulse = () => {
+    if (!stopped) client.keepAlive(thinking, "remote");
+  };
+  pulse();
+  const interval = setInterval(pulse, SESSION_KEEP_ALIVE_MS);
+
+  return {
+    setThinking(value) {
+      if (stopped || thinking === value) return;
+      thinking = value;
+      pulse();
+    },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(interval);
+    },
+  };
+}
+
 export function createStartupStatusGate(notify) {
   return {
     async complete(startupWork) {
@@ -498,6 +523,7 @@ export function createHappyLayer({
   let pairingAbortController = null;
   let latestPairingPayload = null;
   let pairingCancelled = false;
+  let closing = false;
   let sourceSubscription = null;
   let supervisorSubscription = null;
   let advertisedRoots = [];
@@ -507,6 +533,8 @@ export function createHappyLayer({
   });
   const sessions = new Map();
   const sessionCreationPromises = new Map();
+  const sessionDisposals = new Set();
+  const remotelyArchivedSessions = new Set();
   const terminatedSessions = createTerminatedSessionTracker();
   const pendingRequests = Object.create(null);
   const liveSessions = new Set();
@@ -518,6 +546,11 @@ export function createHappyLayer({
 
   function debug(message) {
     debugLog(message);
+  }
+
+  function trackSessionDisposal(disposal) {
+    sessionDisposals.add(disposal);
+    void disposal.finally(() => sessionDisposals.delete(disposal));
   }
 
   const promptQueue = createDeferredPromptQueue({
@@ -573,6 +606,7 @@ export function createHappyLayer({
       assistantMessageCoalescer.clear(sessionId);
       delete pendingRequests[sessionId];
       sessionCreationPromises.delete(sessionId);
+      entry.liveness.stop();
       await entry.client
         .close()
         .catch(() => debug("failed to close Happy session leaving scope"));
@@ -607,6 +641,30 @@ export function createHappyLayer({
 
   function registerInbound(entry) {
     const { client } = entry;
+    client.on("archived", () => {
+      const sessionId = entry.sessionId;
+      if (sessions.get(sessionId) !== entry) return;
+
+      // Happy's native runners treat a mobile archive as termination. Mirror
+      // that contract without letting the next pulse reactivate the relay row.
+      sessions.delete(sessionId);
+      liveSessions.delete(sessionId);
+      promptQueue.clear(sessionId);
+      turnCorrelator.clear(sessionId);
+      assistantMessageCoalescer.clear(sessionId);
+      delete pendingRequests[sessionId];
+      sessionCreationPromises.delete(sessionId);
+      terminatedSessions.mark(sessionId);
+      remotelyArchivedSessions.add(sessionId);
+      entry.liveness.stop();
+      const disposal = (async () => {
+        await source
+          .terminate(sessionId)
+          .catch(() => debug("failed to terminate Happy session archived remotely"));
+        await client.close().catch(() => debug("failed to close archived Happy session"));
+      })();
+      trackSessionDisposal(disposal);
+    });
     client.onUserMessage((message) => {
       void promptQueue.enqueue(entry.sessionId, { entry, message });
     });
@@ -691,6 +749,7 @@ export function createHappyLayer({
   }
 
   async function createSessionEntry(sessionId, summary, existingSession = null) {
+    if (closing) throw new Error("Happy layer is closing");
     const existing = sessions.get(sessionId);
     if (existing) return existing;
     if (!api || !identity) throw new Error("Happy API is not registered");
@@ -705,14 +764,25 @@ export function createHappyLayer({
         state: { controlledByUser: true },
         debugLog: debug,
       }));
+    // The relay lookup can outlive bridge shutdown. Do not create a socket or
+    // heartbeat after close() has already drained the tracked entries.
+    if (closing) throw new Error("Happy layer is closing");
     if (!isUsableHappySession(session)) {
       throw new Error("Happy relay did not return a usable session");
     }
     const client = api.sessionSyncClient(session);
-    const entry = { sessionId, happySessionId: session.id, summary, session, client };
+    const thinking = BUSY_SESSION_STATUSES.has(summary?.status);
+    const entry = {
+      sessionId,
+      happySessionId: session.id,
+      summary,
+      session,
+      client,
+      liveness: createSessionLiveness(client, thinking),
+    };
     sessions.set(sessionId, entry);
     liveSessions.add(sessionId);
-    promptQueue.setBusy(sessionId, ["prompting", "busy", "running"].includes(summary?.status));
+    promptQueue.setBusy(sessionId, thinking);
     rememberPendingPermissions(sessionId, summary?.pendingPermissions);
     registerInbound(entry);
     client.sendSessionEvent({ type: "switch", mode: "remote" });
@@ -720,6 +790,8 @@ export function createHappyLayer({
   }
 
   async function findOrCreateSession(sessionId, summary = null) {
+    if (closing) return null;
+    if (remotelyArchivedSessions.has(sessionId)) return null;
     const tracked = resolveTrackedSession({ sessions, terminatedSessions, sessionId });
     if (tracked.entry) return tracked.entry;
     if (tracked.blocked) return null;
@@ -757,13 +829,14 @@ export function createHappyLayer({
     const terminal =
       event.kind === "status" && ["error", "terminated"].includes(event.payload?.status);
     const providerStatus = event.kind === "status" ? event.payload?.status : null;
-    if (["prompting", "busy", "running"].includes(providerStatus)) {
-      promptQueue.setBusy(event.sessionId, true);
-    } else if (
+    const providerThinking = BUSY_SESSION_STATUSES.has(providerStatus);
+    const providerReady =
       event.kind === "turn-complete" ||
       event.kind === "error" ||
-      ["ready", "idle", "completed"].includes(providerStatus)
-    ) {
+      ["ready", "idle", "completed"].includes(providerStatus);
+    if (providerThinking) {
+      promptQueue.setBusy(event.sessionId, true);
+    } else if (providerReady) {
       promptQueue.setBusy(event.sessionId, false);
     }
     if (terminal) {
@@ -779,6 +852,11 @@ export function createHappyLayer({
     if (terminal && !sessions.has(event.sessionId)) return;
     const entry = await findOrCreateSession(event.sessionId, summary);
     if (!entry) return;
+    if (providerThinking) {
+      entry.liveness.setThinking(true);
+    } else if (providerReady) {
+      entry.liveness.setThinking(false);
+    }
     const provider = summary?.agentType === "claude-code" ? "claude" : summary?.agentType ?? "codex";
     const correlatedEvent = turnCorrelator.correlate(event);
     for (const publishableEvent of assistantMessageCoalescer.consume(correlatedEvent)) {
@@ -840,6 +918,9 @@ export function createHappyLayer({
         title: `${agentType} Agent`,
         happySessionId: pending.happySessionId,
       });
+      if (closing || sessions.get(pendingSessionId) !== pending) {
+        return { type: "error", errorMessage: "Happy session closed before provider spawn" };
+      }
       const spawned = await source.spawn({
         agentType,
         cwd: validation.root,
@@ -847,6 +928,12 @@ export function createHappyLayer({
         approvalPolicy: defaultApprovalPolicy(agentType),
       });
       if (!spawned?.sessionId) throw new Error("provider spawn returned no session");
+      if (closing || sessions.get(pendingSessionId) !== pending) {
+        await source
+          .terminate(spawned.sessionId)
+          .catch(() => debug("failed to terminate provider spawned after Happy session closed"));
+        return { type: "error", errorMessage: "Happy session closed during provider spawn" };
+      }
       sessions.delete(pendingSessionId);
       turnCorrelator.clear(pendingSessionId);
       assistantMessageCoalescer.clear(pendingSessionId);
@@ -901,12 +988,14 @@ export function createHappyLayer({
   }
 
   async function discardPendingSpawn(pendingSessionId, pending) {
+    if (sessions.get(pendingSessionId) !== pending) return;
     sessions.delete(pendingSessionId);
     liveSessions.delete(pendingSessionId);
     turnCorrelator.clear(pendingSessionId);
     assistantMessageCoalescer.clear(pendingSessionId);
     delete pendingRequests[pendingSessionId];
     sessionCreationPromises.delete(pendingSessionId);
+    pending.liveness.stop();
     await pending.client.close().catch(() => debug("failed to close abandoned Happy session"));
   }
 
@@ -1056,6 +1145,7 @@ export function createHappyLayer({
     },
     startPairing,
     async close() {
+      closing = true;
       sourceSubscription?.();
       supervisorSubscription?.();
       promptQueue.close();
@@ -1067,11 +1157,15 @@ export function createHappyLayer({
       // this resolves, and tearing the event loop down while these closes are
       // still in flight aborts the process on Windows.
       await Promise.allSettled(
-        [...sessions.values()].map((entry) =>
-          entry.client.close().catch(() => debug("failed to close Happy session")),
-        ),
+        [...sessions.values()].map((entry) => {
+          entry.liveness.stop();
+          return entry.client.close().catch(() => debug("failed to close Happy session"));
+        }),
       );
       sessions.clear();
+      await Promise.allSettled([...sessionDisposals]);
+      sessionDisposals.clear();
+      remotelyArchivedSessions.clear();
       terminatedSessions.clear();
       machineClient?.shutdown();
       machineClient = null;
@@ -1083,5 +1177,6 @@ export function createHappyLayer({
 export async function completeTerminalSession({ sessions, sessionId, entry, send }) {
   await send(entry);
   sessions.delete(sessionId);
+  entry.liveness?.stop();
   await entry.client.close();
 }

--- a/bin/happy-bridge/provider-source.mjs
+++ b/bin/happy-bridge/provider-source.mjs
@@ -280,6 +280,10 @@ export function createProviderSource({ client, config, debugLog = () => {} }) {
       await client.call("provider_cancel", { sessionId });
     },
 
+    async terminate(sessionId) {
+      await client.call("provider_terminate", { sessionId });
+    },
+
     async respondToPermission(sessionId, requestId, optionId) {
       await client.call("provider_respond_to_permission", {
         sessionId,

--- a/tests/unit/happy-bridge-translate-provider.test.ts
+++ b/tests/unit/happy-bridge-translate-provider.test.ts
@@ -85,10 +85,12 @@ describe("provider-to-neutral session event translation", () => {
     });
 
     await source.sendPrompt("session-1", "hello");
+    await source.terminate("session-1");
     await source.respondToPermission("session-1", "request-1", "allow_once");
 
     expect(calls).toEqual([
       ["provider_prompt", { sessionId: "session-1", prompt: "hello", origin: "remote" }],
+      ["provider_terminate", { sessionId: "session-1" }],
       [
         "provider_respond_to_permission",
         {

--- a/tests/unit/happy-session-liveness.test.ts
+++ b/tests/unit/happy-session-liveness.test.ts
@@ -1,0 +1,261 @@
+// ABOUTME: Guards Happy liveness pulses for desktop sessions exposed to mobile.
+// ABOUTME: Tracks busy state and stops the pulse when a relay entry is torn down.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const happyLib = vi.hoisted(() => ({
+  createApiClient: vi.fn(),
+  configuration: {} as { serverUrl?: string },
+}));
+
+vi.mock("happy/lib", () => ({
+  ApiClient: { create: happyLib.createApiClient },
+  configuration: happyLib.configuration,
+}));
+
+const SYNTHETIC_ROOT = process.cwd();
+
+// @ts-expect-error — the bridge layer is plain ESM without declarations.
+import { createHappyLayer } from "../../bin/happy-bridge/happy-layer.mjs";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function createClient() {
+  const eventHandlers = new Map<string, () => void>();
+  return {
+    close: vi.fn(async () => {}),
+    emit(event: string) {
+      eventHandlers.get(event)?.();
+    },
+    keepAlive: vi.fn(),
+    on: vi.fn((event: string, handler: () => void) => {
+      eventHandlers.set(event, handler);
+    }),
+    onUserMessage: vi.fn(),
+    rpcHandlerManager: { registerHandler: vi.fn() },
+    sendAgentMessage: vi.fn(),
+    sendSessionEvent: vi.fn(),
+    sendSessionProtocolMessage: vi.fn(),
+  };
+}
+
+function createLayerHarness({ initialSessions = [] }: { initialSessions?: Array<Record<string, unknown>> } = {}) {
+  const client = createClient();
+  let machineHandlers:
+    | { spawnSession(options: Record<string, unknown>): Promise<Record<string, unknown>> }
+    | undefined;
+  const machineClient = {
+    connect: vi.fn(),
+    setRPCHandlers: vi.fn((handlers) => {
+      machineHandlers = handlers;
+    }),
+    shutdown: vi.fn(),
+    updateMachineMetadata: vi.fn(async () => {}),
+  };
+  const api = {
+    getOrCreateMachine: vi.fn(async () => ({ id: "relay-machine" })),
+    getOrCreateSession: vi.fn(async ({ metadata }: { metadata: Record<string, unknown> }) => ({
+      id: "relay-session",
+      metadata,
+    })),
+    machineSyncClient: vi.fn(() => machineClient),
+    sessionSyncClient: vi.fn(() => client),
+  };
+  happyLib.createApiClient.mockResolvedValue(api);
+
+  let publishProviderEvent: ((event: Record<string, unknown>) => void) | undefined;
+  const source = {
+    advertise: vi.fn(async () => ({ agents: [] })),
+    cancel: vi.fn(async () => {}),
+    listSessions: vi.fn(async () => initialSessions),
+    spawn: vi.fn(async () => ({
+      sessionId: "spawned-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    })),
+    subscribe: vi.fn((handler: (event: Record<string, unknown>) => void) => {
+      publishProviderEvent = handler;
+      return () => {};
+    }),
+    terminate: vi.fn(async () => {}),
+  };
+  const layer = createHappyLayer({
+    config: {
+      machineIdentity: {
+        token: "test",
+        machineId: "synthetic-machine",
+        encryption: { type: "legacy", secret: Buffer.alloc(32).toString("base64") },
+      },
+      machineName: "liveness-test",
+      relayUrl: "https://relay.invalid",
+    },
+    source,
+    supervisorChannel: {
+      call: vi.fn(async () => ({ conversationId: "synthetic-conversation" })),
+      notify: vi.fn(),
+      onNotification(handler: (method: string, params: Record<string, unknown>) => void) {
+        handler("roots_update", { roots: [SYNTHETIC_ROOT] });
+        return () => {};
+      },
+    },
+  });
+
+  return {
+    api,
+    client,
+    layer,
+    publish(event: Record<string, unknown>) {
+      if (!publishProviderEvent) throw new Error("provider subscription is not ready");
+      publishProviderEvent(event);
+    },
+    spawn(options: Record<string, unknown>) {
+      if (!machineHandlers) throw new Error("machine handlers are not ready");
+      return machineHandlers.spawnSession(options);
+    },
+    source,
+  };
+}
+
+describe("Happy session liveness", () => {
+  it("wires provider status into pulses and stops an entry archived from mobile", async () => {
+    vi.useFakeTimers();
+    const summary = {
+      sessionId: "local-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Synthetic session",
+      status: "ready",
+    };
+    const harness = createLayerHarness({ initialSessions: [summary] });
+
+    await harness.layer.start();
+    expect(harness.client.keepAlive).toHaveBeenCalledWith(false, "remote");
+    vi.advanceTimersByTime(2_000);
+    expect(harness.client.keepAlive).toHaveBeenCalledTimes(2);
+
+    harness.publish({
+      kind: "status",
+      sessionId: "local-session",
+      payload: { status: "busy" },
+    });
+    await vi.waitFor(() => {
+      expect(harness.client.keepAlive).toHaveBeenLastCalledWith(true, "remote");
+    });
+    const busyPulseAt = harness.client.keepAlive.mock.calls.length;
+    vi.advanceTimersByTime(2_000);
+    expect(harness.client.keepAlive).toHaveBeenCalledTimes(busyPulseAt + 1);
+    expect(harness.client.keepAlive).toHaveBeenLastCalledWith(true, "remote");
+
+    let resolveClientClose: (() => void) | undefined;
+    harness.client.close.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveClientClose = resolve;
+        }),
+    );
+    harness.client.emit("archived");
+    const stoppedAt = harness.client.keepAlive.mock.calls.length;
+    vi.advanceTimersByTime(4_000);
+    expect(harness.client.keepAlive).toHaveBeenCalledTimes(stoppedAt);
+    harness.publish({
+      kind: "status",
+      sessionId: "local-session",
+      payload: { status: "ready" },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(harness.api.sessionSyncClient).toHaveBeenCalledTimes(1);
+    expect(harness.source.terminate).toHaveBeenCalledWith("local-session");
+
+    let layerClosed = false;
+    const close = harness.layer.close().then(() => {
+      layerClosed = true;
+    });
+    await Promise.resolve();
+    expect(layerClosed).toBe(false);
+    resolveClientClose?.();
+    await close;
+    expect(harness.client.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start a pulse when a relay lookup finishes after shutdown", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const summary = {
+      sessionId: "late-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      title: "Late synthetic session",
+      status: "ready",
+    };
+    const harness = createLayerHarness();
+    await harness.layer.start();
+
+    harness.source.listSessions.mockResolvedValue([summary]);
+    let resolveLookupStarted: (() => void) | undefined;
+    const lookupStarted = new Promise<void>((resolve) => {
+      resolveLookupStarted = resolve;
+    });
+    let resolveSession: ((session: Record<string, unknown>) => void) | undefined;
+    harness.api.getOrCreateSession.mockImplementation(
+      ({ metadata }: { metadata: Record<string, unknown> }) => {
+        resolveLookupStarted?.();
+        return new Promise((resolve) => {
+          resolveSession = () => resolve({ id: "late-relay-session", metadata });
+        });
+      },
+    );
+    vi.setSystemTime(1_001);
+    harness.publish({
+      kind: "status",
+      sessionId: "late-session",
+      payload: { status: "ready" },
+    });
+    await lookupStarted;
+
+    await harness.layer.close();
+    resolveSession?.({});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.api.sessionSyncClient).not.toHaveBeenCalled();
+    expect(harness.client.keepAlive).not.toHaveBeenCalled();
+  });
+
+  it("terminates a provider whose spawn resolves after layer shutdown", async () => {
+    vi.useFakeTimers();
+    const harness = createLayerHarness();
+    await harness.layer.start();
+
+    let resolveSpawn: ((session: Record<string, unknown>) => void) | undefined;
+    const spawnStarted = new Promise<void>((resolveStarted) => {
+      harness.source.spawn.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSpawn = resolve;
+            resolveStarted();
+          }),
+      );
+    });
+    const result = harness.spawn({ directory: SYNTHETIC_ROOT, agent: "codex" });
+    await spawnStarted;
+    await harness.layer.close();
+
+    resolveSpawn?.({
+      sessionId: "late-provider-session",
+      agentType: "codex",
+      cwd: SYNTHETIC_ROOT,
+      status: "ready",
+    });
+    await expect(result).resolves.toEqual({
+      type: "error",
+      errorMessage: "Happy session closed during provider spawn",
+    });
+    expect(harness.source.terminate).toHaveBeenCalledWith("late-provider-session");
+    expect(harness.client.close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #3208

## Summary
- Send Happy `session-alive` pulses immediately and every two seconds for each bridged desktop agent, including its current thinking state.
- Stop pulses on terminal, scope-removal, archive, abandoned-spawn, and bridge-shutdown paths.
- Honor a mobile archive with durable detachment and `provider_terminate`, while preventing queued provider events from resurrecting the relay entry.
- Guard shutdown and spawn races so late relay lookups or providers cannot recreate closed sessions.

## Audited path
`HappyRemoteSettings` → Tauri `happy_bridge_enable` → Rust Happy bridge manager → embedded Happy bridge → hosted Happy relay.

This path does not use a Seren Gateway publisher. The verified direct relay operations are `POST /v1/machines`, `POST /v1/sessions`, authenticated Socket.IO `/v1/updates` with `session-alive`, and `GET`/`POST /v3/sessions/{id}/messages`. Inbound prompts then use the local loopback `provider_prompt` JSON-RPC method; remote archive uses local `provider_terminate`.

## Validation
- `pnpm test` — 2,552 passed, 15 skipped
- Happy-focused Vitest suite — 106 passed
- `pnpm check` — passed (existing warnings only)
- `pnpm build` — passed
- `pnpm build:provider-runtime` — passed; bundled sources byte-match
- `pnpm test:runtime-smoke` — passed
- `cargo test --locked --manifest-path src-tauri/Cargo.toml` — 962 passed, 2 ignored
- Independent blocker review — clean

A real macOS Tauri + hosted relay + paired mobile walkthrough will be recorded before merge. Supplied user screenshots and local logs were intentionally excluded because they contain private data.