### PR TITLE
feat(sandbox): canonical Rust sandbox policy with macOS Seatbelt backend

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -151,6 +151,41 @@ function resolveSpawnShell(claudeBin) {
 }
 
 /**
+ * Build the actual child invocation for the local Claude CLI. On macOS every
+ * bounded session must carry the verified Rust-authored Seatbelt profile;
+ * missing proof is a hard launch failure rather than an unsandboxed fallback.
+ * #3192.
+ */
+function buildClaudeSpawnInvocation({
+  claudeBin,
+  claudeArgs,
+  sandboxMode,
+  sandboxProfile,
+}) {
+  const fullAccess =
+    sandboxMode === "full-access" || sandboxMode === "danger-full-access";
+
+  if (process.platform === "darwin" && !fullAccess) {
+    if (typeof sandboxProfile !== "string" || sandboxProfile.trim().length === 0) {
+      throw new Error(
+        "Claude Code launch blocked: the verified macOS sandbox profile is missing.",
+      );
+    }
+    return {
+      command: "/usr/bin/sandbox-exec",
+      args: ["-p", sandboxProfile, claudeBin, ...claudeArgs],
+      shell: false,
+    };
+  }
+
+  return {
+    command: claudeBin,
+    args: claudeArgs,
+    shell: resolveSpawnShell(claudeBin),
+  };
+}
+
+/**
  * Build a PATH string that includes well-known CLI install locations.
  * GUI apps don't inherit the user's shell profile, so tools installed via
  * native installers or npm global aren't on PATH. Without this, spawned
@@ -2537,6 +2572,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
       mcpServers,
       approvalPolicy,
       sandboxMode,
+      sandboxProfile,
       networkEnabled,
       autoApproveReads,
       timeoutSecs,
@@ -2643,9 +2679,15 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
 
       let processHandle;
       try {
-        processHandle = spawn(
+        const spawnInvocation = buildClaudeSpawnInvocation({
           claudeBin,
           claudeArgs,
+          sandboxMode,
+          sandboxProfile,
+        });
+        processHandle = spawn(
+          spawnInvocation.command,
+          spawnInvocation.args,
           {
             cwd,
             env: {
@@ -2654,6 +2696,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
               PATH: extendedPath,
               SEREN_AGENT_PROJECT_ROOT: cwd,
               SEREN_AGENT_SANDBOX_MODE: sandboxMode ?? "workspace-write",
+              SEREN_AGENT_SANDBOX_PROFILE: sandboxProfile ?? "",
               SEREN_AGENT_APPROVAL_POLICY: approvalPolicy ?? "on-request",
               SEREN_AGENT_AUTO_APPROVE_READS:
                 autoApproveReads === false ? "false" : "true",
@@ -2661,7 +2704,7 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
                 networkEnabled === false ? "false" : "true",
             },
             stdio: ["pipe", "pipe", "pipe"],
-            shell: resolveSpawnShell(claudeBin),
+            shell: spawnInvocation.shell,
           },
         );
       } catch (spawnError) {
@@ -3320,6 +3363,7 @@ export {
   claudeModeFromApprovalPolicy as _claudeModeFromApprovalPolicy,
   comparePickerEntries as _comparePickerEntries,
   resolveSpawnShell as _resolveSpawnShell,
+  buildClaudeSpawnInvocation as _buildClaudeSpawnInvocation,
   buildClaudeArgs as _buildClaudeArgs,
   removeClaudeArgsTempFiles as _removeClaudeArgsTempFiles,
   buildClaudePolicySettings as _buildClaudePolicySettings,

--- a/src-tauri/src/commands/sandbox.rs
+++ b/src-tauri/src/commands/sandbox.rs
@@ -1,0 +1,54 @@
+// ABOUTME: Tauri command that returns the verified macOS provider sandbox profile.
+// ABOUTME: Credential-store paths are denied before the profile crosses into the child runtime.
+
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use crate::sandbox::{SandboxMode, SandboxPolicy, seatbelt_profile};
+
+const CREDENTIAL_STORE_SUFFIXES: &[&str] = &[
+    ".ssh",
+    ".aws",
+    ".gnupg",
+    ".seren",
+    ".config/seren",
+    ".config/gcloud",
+    ".config/autostart",
+    "Library/LaunchAgents",
+    ".netrc",
+];
+
+#[tauri::command]
+pub fn agent_sandbox_profile(
+    mode: String,
+    project_root: String,
+    network_enabled: Option<bool>,
+) -> Result<String, String> {
+    let mode = SandboxMode::from_str(&mode).map_err(|error| error.to_string())?;
+    if mode == SandboxMode::FullAccess {
+        return Err("No sandbox profile is generated for full-access mode.".to_string());
+    }
+
+    let project_root = project_root.trim();
+    if project_root.is_empty() {
+        return Err("A project root is required to generate a sandbox profile.".to_string());
+    }
+
+    let home =
+        dirs::home_dir().ok_or_else(|| "Could not resolve the home directory.".to_string())?;
+    let deny_read = CREDENTIAL_STORE_SUFFIXES
+        .iter()
+        .map(|suffix| home.join(suffix))
+        .filter(|path| path.exists())
+        .collect::<Vec<PathBuf>>();
+
+    let policy = SandboxPolicy::new(
+        mode,
+        vec![PathBuf::from(project_root)],
+        deny_read,
+        network_enabled.unwrap_or(true),
+    )
+    .map_err(|error| error.to_string())?;
+
+    seatbelt_profile(&policy).map_err(|error| error.to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub mod commands {
     pub mod orchestrator;
     pub mod provider_runtime;
     pub mod recording;
+    pub mod sandbox;
     pub mod session;
     pub mod transcript_search;
     pub mod updater;
@@ -40,6 +41,8 @@ pub mod services {
     pub mod transcript_vectors;
     pub mod vector_store;
 }
+
+pub mod sandbox;
 
 pub mod audio;
 mod auth;
@@ -1036,6 +1039,7 @@ pub fn run() {
             commands::recording::recording_reveal_local,
             commands::history_sync::history_sync_run_now,
             commands::history_sync::history_sync_wipe_remote,
+            commands::sandbox::agent_sandbox_profile,
             // Meeting Mode persistence commands
             commands::audio::create_meeting,
             commands::audio::get_meeting,

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -1,0 +1,8 @@
+// ABOUTME: Canonical provider-process sandbox policy and platform backends.
+// ABOUTME: Keeps the security boundary in Rust before a child process is spawned.
+
+mod policy;
+mod seatbelt;
+
+pub use policy::{SandboxError, SandboxMode, SandboxPolicy};
+pub use seatbelt::{seatbelt_profile, wrap_spawn};

--- a/src-tauri/src/sandbox/policy.rs
+++ b/src-tauri/src/sandbox/policy.rs
@@ -1,0 +1,88 @@
+// ABOUTME: Validated, canonical sandbox policy shared by all provider backends.
+// ABOUTME: Paths are resolved before profile generation so a profile cannot scope a spelling alias.
+
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxMode {
+    ReadOnly,
+    WorkspaceWrite,
+    FullAccess,
+}
+
+impl FromStr for SandboxMode {
+    type Err = SandboxError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "read-only" => Ok(Self::ReadOnly),
+            "workspace-write" => Ok(Self::WorkspaceWrite),
+            "full-access" | "danger-full-access" => Ok(Self::FullAccess),
+            other => Err(SandboxError::InvalidMode(other.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SandboxError {
+    #[error("invalid agent sandbox mode: {0}")]
+    InvalidMode(String),
+    #[error("sandbox path cannot be canonicalized: {path}: {source}")]
+    PathCanonicalization {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("a bounded sandbox requires at least one workspace root")]
+    EmptyWorkspaceRoots,
+    #[error("a full-access session does not have a sandbox profile")]
+    FullAccessNoProfile,
+    #[error("the macOS Seatbelt backend is unavailable on this platform")]
+    BackendUnavailable,
+    #[error("sandbox command path cannot be empty")]
+    EmptyCommand,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxPolicy {
+    pub mode: SandboxMode,
+    pub workspace_roots: Vec<PathBuf>,
+    pub deny_read: Vec<PathBuf>,
+    pub network_enabled: bool,
+}
+
+impl SandboxPolicy {
+    pub fn new(
+        mode: SandboxMode,
+        workspace_roots: Vec<PathBuf>,
+        deny_read: Vec<PathBuf>,
+        network_enabled: bool,
+    ) -> Result<Self, SandboxError> {
+        if mode != SandboxMode::FullAccess && workspace_roots.is_empty() {
+            return Err(SandboxError::EmptyWorkspaceRoots);
+        }
+
+        let workspace_roots = workspace_roots
+            .into_iter()
+            .map(canonicalize)
+            .collect::<Result<Vec<_>, _>>()?;
+        let deny_read = deny_read
+            .into_iter()
+            .map(canonicalize)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            mode,
+            workspace_roots,
+            deny_read,
+            network_enabled,
+        })
+    }
+}
+
+fn canonicalize(path: PathBuf) -> Result<PathBuf, SandboxError> {
+    std::fs::canonicalize(&path)
+        .map_err(|source| SandboxError::PathCanonicalization { path, source })
+}

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -1,0 +1,132 @@
+// ABOUTME: Generates and applies the macOS Seatbelt profile for provider children.
+// ABOUTME: The profile is deny-by-default and is passed directly to sandbox-exec.
+
+use std::path::{Path, PathBuf};
+
+use super::policy::{SandboxError, SandboxMode, SandboxPolicy};
+
+const SEATBELT_EXECUTABLE: &str = "/usr/bin/sandbox-exec";
+
+pub fn seatbelt_profile(policy: &SandboxPolicy) -> Result<String, SandboxError> {
+    if policy.mode == SandboxMode::FullAccess {
+        return Err(SandboxError::FullAccessNoProfile);
+    }
+
+    let mut profile = vec![
+        "(version 1)".to_string(),
+        "(import \"system.sb\")".to_string(),
+        "(deny default)".to_string(),
+        "(allow process-exec)".to_string(),
+        "(allow process-fork)".to_string(),
+        "(allow sysctl-read)".to_string(),
+        "(allow file-read-metadata".to_string(),
+    ];
+    profile.extend(read_subpaths(&policy.workspace_roots));
+    profile.extend(read_subpaths(&system_read_paths()));
+    profile.push(")".to_string());
+
+    profile.push("(allow file-read*".to_string());
+    profile.extend(read_subpaths(&policy.workspace_roots));
+    profile.extend(read_subpaths(&system_read_paths()));
+    let runtime_read_paths = runtime_read_paths();
+    profile.extend(read_subpaths(&runtime_read_paths));
+    profile.push(")".to_string());
+
+    profile.push("(allow file-map-executable".to_string());
+    profile.extend(read_subpaths(&runtime_read_paths));
+    profile.push(")".to_string());
+
+    if policy.mode == SandboxMode::WorkspaceWrite {
+        profile.push("(allow file-write*".to_string());
+        profile.extend(read_subpaths(&policy.workspace_roots));
+        profile.push(")".to_string());
+    }
+
+    if policy.network_enabled {
+        profile.push("(allow network*)".to_string());
+    } else {
+        profile.push("(deny network*)".to_string());
+    }
+
+    for path in &policy.deny_read {
+        profile.push(format!("(deny file-read* (subpath {}))", sbpl_path(path)));
+    }
+
+    Ok(profile.join("\n"))
+}
+
+pub fn wrap_spawn(
+    command: &str,
+    args: &[String],
+    policy: &SandboxPolicy,
+) -> Result<(String, Vec<String>), SandboxError> {
+    if command.trim().is_empty() {
+        return Err(SandboxError::EmptyCommand);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let profile = seatbelt_profile(policy)?;
+        let mut wrapped_args = Vec::with_capacity(args.len() + 3);
+        wrapped_args.push("-p".to_string());
+        wrapped_args.push(profile);
+        wrapped_args.push(command.to_string());
+        wrapped_args.extend(args.iter().cloned());
+        Ok((SEATBELT_EXECUTABLE.to_string(), wrapped_args))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (args, policy);
+        Err(SandboxError::BackendUnavailable)
+    }
+}
+
+fn read_subpaths(paths: &[impl AsRef<Path>]) -> Vec<String> {
+    paths
+        .iter()
+        .map(|path| format!("  (subpath {})", sbpl_path(path.as_ref())))
+        .collect()
+}
+
+fn system_read_paths() -> Vec<&'static Path> {
+    [
+        Path::new("/System"),
+        Path::new("/usr"),
+        Path::new("/bin"),
+        Path::new("/sbin"),
+        Path::new("/private/etc"),
+        Path::new("/dev"),
+        Path::new("/private/tmp"),
+        Path::new("/private/var/folders"),
+    ]
+    .to_vec()
+}
+
+fn runtime_read_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        for suffix in [".local/bin", ".claude/bin"] {
+            let path = home.join(suffix);
+            if path.is_dir() {
+                paths.push(path);
+            }
+        }
+    }
+
+    if let Ok(current_exe) = std::env::current_exe()
+        && let Some(parent) = current_exe.parent()
+    {
+        paths.push(parent.to_path_buf());
+    }
+
+    paths
+}
+
+fn sbpl_path(path: &Path) -> String {
+    let escaped = path
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}

--- a/src-tauri/tests/sandbox_seatbelt.rs
+++ b/src-tauri/tests/sandbox_seatbelt.rs
@@ -1,0 +1,153 @@
+// ABOUTME: Real macOS Seatbelt canaries for the provider-independent sandbox boundary.
+// ABOUTME: Every case runs a child process through the generated profile with no mocks.
+
+#![cfg(target_os = "macos")]
+
+use seren_desktop_lib::sandbox::{SandboxMode, SandboxPolicy, wrap_spawn};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::tempdir;
+
+fn shell_literal(path: &Path) -> String {
+    format!("'{}'", path.to_string_lossy().replace('\'', "'\\''"))
+}
+
+fn run_shell(policy: &SandboxPolicy, shell: &str, script: String) -> Output {
+    let args = vec!["-c".to_string(), script];
+    let (executable, wrapped_args) = wrap_spawn(shell, &args, policy).expect("wrap spawn");
+    Command::new(executable)
+        .args(wrapped_args)
+        .current_dir(
+            policy
+                .workspace_roots
+                .first()
+                .expect("workspace root for sandbox child"),
+        )
+        .output()
+        .expect("run sandboxed child")
+}
+
+fn policy(
+    mode: SandboxMode,
+    workspace: &Path,
+    deny_read: &[PathBuf],
+    network_enabled: bool,
+) -> SandboxPolicy {
+    SandboxPolicy::new(
+        mode,
+        vec![workspace.to_path_buf()],
+        deny_read.to_vec(),
+        network_enabled,
+    )
+    .expect("valid sandbox policy")
+}
+
+#[test]
+fn sandbox_workspace_write_canary_succeeds() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let inside = workspace.path().join("inside.txt");
+    let sandbox = policy(SandboxMode::WorkspaceWrite, workspace.path(), &[], true);
+
+    let output = run_shell(
+        &sandbox,
+        "/bin/sh",
+        format!("set -e; touch {}", shell_literal(&inside)),
+    );
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(inside.is_file());
+}
+
+#[test]
+fn sandbox_outside_write_canary_is_denied() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let outside = tempdir().expect("outside tempdir");
+    let canary = outside.path().join("outside.txt");
+    let sandbox = policy(SandboxMode::WorkspaceWrite, workspace.path(), &[], true);
+
+    let output = run_shell(
+        &sandbox,
+        "/bin/sh",
+        format!("set -e; touch {}", shell_literal(&canary)),
+    );
+
+    assert!(!output.status.success());
+    assert!(!canary.exists());
+}
+
+#[test]
+fn sandbox_deny_read_canary_is_denied() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let denied = tempdir().expect("denied tempdir");
+    let secret = denied.path().join("secret.txt");
+    fs::write(&secret, "do not read").expect("secret fixture");
+    let sandbox = policy(
+        SandboxMode::WorkspaceWrite,
+        workspace.path(),
+        &[denied.path().to_path_buf()],
+        true,
+    );
+
+    let output = run_shell(
+        &sandbox,
+        "/bin/sh",
+        format!("set -e; cat {}", shell_literal(&secret)),
+    );
+
+    assert!(!output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("do not read"));
+}
+
+#[test]
+fn sandbox_grandchild_write_cannot_escape() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let outside = tempdir().expect("outside tempdir");
+    let canary = outside.path().join("grandchild.txt");
+    let sandbox = policy(SandboxMode::WorkspaceWrite, workspace.path(), &[], true);
+
+    let output = run_shell(
+        &sandbox,
+        "/bin/sh",
+        format!("set -e; /bin/sh -c 'touch {}'", shell_literal(&canary)),
+    );
+
+    assert!(!output.status.success());
+    assert!(!canary.exists());
+}
+
+#[test]
+fn sandbox_network_disabled_denies_dev_tcp() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let sandbox = policy(SandboxMode::WorkspaceWrite, workspace.path(), &[], false);
+
+    let output = run_shell(
+        &sandbox,
+        "/bin/bash",
+        "set -e; exec 3<>/dev/tcp/127.0.0.1/80".to_string(),
+    );
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn sandbox_read_only_denies_workspace_write() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let inside = workspace.path().join("read-only.txt");
+    let sandbox = policy(SandboxMode::ReadOnly, workspace.path(), &[], true);
+
+    let output = run_shell(
+        &sandbox,
+        "/bin/sh",
+        format!("set -e; touch {}", shell_literal(&inside)),
+    );
+
+    assert!(!output.status.success());
+    assert!(!inside.exists());
+}

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -514,6 +514,23 @@ export async function spawnAgent(
   lmStudioApiKey?: string,
   autoApproveReads?: boolean,
 ): Promise<AgentSessionInfo> {
+  const fullAccess =
+    sandboxMode === "full-access" || sandboxMode === "danger-full-access";
+  const isMacOsDesktop =
+    typeof navigator !== "undefined" &&
+    /Macintosh|Mac OS X/i.test(navigator.userAgent);
+  const sandboxProfile =
+    agentType === "claude-code" &&
+    isTauriRuntime() &&
+    isMacOsDesktop &&
+    !fullAccess
+      ? await invoke<string>("agent_sandbox_profile", {
+          mode: sandboxMode ?? "workspace-write",
+          projectRoot: cwd,
+          networkEnabled: networkEnabled !== false,
+        })
+      : null;
+
   return invokeProvider<AgentSessionInfo>(
     "provider_spawn",
     {
@@ -522,6 +539,7 @@ export async function spawnAgent(
       localSessionId: localSessionId ?? null,
       resumeAgentSessionId: resumeAgentSessionId ?? null,
       sandboxMode: sandboxMode ?? null,
+      sandboxProfile,
       apiKey: apiKey ?? null,
       approvalPolicy: approvalPolicy ?? null,
       searchEnabled: searchEnabled ?? null,

--- a/tests/unit/claude-sandbox-spawn.test.ts
+++ b/tests/unit/claude-sandbox-spawn.test.ts
@@ -1,0 +1,77 @@
+// ABOUTME: Critical guard for #3192 — bounded macOS Claude sessions cannot spawn without Seatbelt.
+// ABOUTME: Verifies the wrapper shape and the fail-closed missing-profile path without spawning a process.
+
+import { describe, expect, it } from "vitest";
+
+const modulePath = new URL(
+  "../../bin/browser-local/claude-runtime.mjs",
+  import.meta.url,
+).href;
+const {
+  _buildClaudeSpawnInvocation: buildClaudeSpawnInvocation,
+} = await import(/* @vite-ignore */ modulePath);
+
+describe("Claude macOS Seatbelt spawn boundary (#3192)", () => {
+  const withDarwin = (callback: () => void) => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
+    try {
+      callback();
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  };
+
+  it("wraps a bounded session with sandbox-exec and the supplied profile", () => {
+    withDarwin(() => {
+      expect(
+        buildClaudeSpawnInvocation({
+          claudeBin: "/usr/local/bin/claude",
+          claudeArgs: ["--version"],
+          sandboxMode: "workspace-write",
+          sandboxProfile: "(version 1)",
+        }),
+      ).toEqual({
+        command: "/usr/bin/sandbox-exec",
+        args: ["-p", "(version 1)", "/usr/local/bin/claude", "--version"],
+        shell: false,
+      });
+    });
+  });
+
+  it("throws before spawning when a bounded session has no profile", () => {
+    withDarwin(() => {
+      expect(() =>
+        buildClaudeSpawnInvocation({
+          claudeBin: "/usr/local/bin/claude",
+          claudeArgs: [],
+          sandboxMode: "read-only",
+          sandboxProfile: null,
+        }),
+      ).toThrow(/verified macOS sandbox profile is missing/);
+    });
+  });
+
+  it("leaves full-access sessions unwrapped", () => {
+    withDarwin(() => {
+      expect(
+        buildClaudeSpawnInvocation({
+          claudeBin: "/usr/local/bin/claude",
+          claudeArgs: ["--version"],
+          sandboxMode: "full-access",
+          sandboxProfile: null,
+        }),
+      ).toEqual({
+        command: "/usr/local/bin/claude",
+        args: ["--version"],
+        shell: false,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Audit

- `SEREN_AGENT_SANDBOX_MODE` is consumed at the Claude CLI spawn site in `bin/browser-local/claude-runtime.mjs`.
- The normal session producer is `src/services/providers.ts::spawnAgent`.
- The native command is registered from `src-tauri/src/lib.rs`.
- The stage-1 policy mapping and fail-closed checks remain the caller-side containment boundary.

## Change

This PR adds the canonical Rust sandbox policy and macOS Seatbelt backend for the bounded Claude CLI path. Rust now canonicalizes the workspace and deny-read roots, rejects invalid bounded policies, emits a deny-by-default SBPL profile, and exposes `agent_sandbox_profile` through Tauri. The provider obtains the profile from the validated session settings and passes it to the runtime. On macOS, bounded Claude launches now require `/usr/bin/sandbox-exec -p` with the generated profile; a missing profile fails closed. Full-access mode remains unwrapped.

The policy is authored from persisted settings and validated inputs; model output never selects the sandbox mode. The fixed credential-store deny list is expanded by the native command, and the network allow/deny decision is enforced in the Seatbelt profile.

## Verification

- `pnpm test` — 359 files passed; 2,553 tests passed; 15 skipped.
- `pnpm vitest run tests/unit/claude-sandbox-spawn.test.ts` — 3 tests passed.
- The affected Claude-runtime unit set — 31 files, 156 tests — passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER='arch -arm64' cargo test --manifest-path src-tauri/Cargo.toml --target aarch64-apple-darwin sandbox` passed all six real Seatbelt canaries: workspace write, outside-write denial, deny-read denial, grandchild confinement, network denial through `/dev/tcp`, and read-only write denial.
- `pnpm check` passed with the repository's existing Biome schema notice and unrelated warnings.
- `pnpm build && pnpm verify:frontend-build` passed.
- `pnpm build:provider-runtime` passed.

The active Rust toolchain is x86_64 under Rosetta, so the macOS canaries were executed with the installed native arm64 target and runner.

## Real-binary smoke

Using the generated profile and the installed Claude CLI:

```text
$ claude --version (sandbox-exec -p with generated profile)
status=0 stdout=2.1.217
$ sh -c 'touch an outside temporary file' (same generated profile)
status=1 created=false
```

The first command started the actual CLI; the second used the same generated Seatbelt boundary to verify that an outside write is denied.

Networked path: none — this change constrains local process spawning; no publisher or API call is added or modified.

Refs #3192

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
