### PR TITLE
feat(sandbox): Linux Landlock backend with fail-closed launcher

### DIFF
--- a/bin/browser-local/claude-runtime.mjs
+++ b/bin/browser-local/claude-runtime.mjs
@@ -151,10 +151,10 @@ function resolveSpawnShell(claudeBin) {
 }
 
 /**
- * Build the actual child invocation for the local Claude CLI. On macOS every
- * bounded session must carry the verified Rust-authored Seatbelt profile;
- * missing proof is a hard launch failure rather than an unsandboxed fallback.
- * #3192.
+ * Build the actual child invocation for the local Claude CLI. On macOS and
+ * Linux every bounded session must carry the verified Rust-authored launcher
+ * spec; missing proof is a hard launch failure rather than an unsandboxed
+ * fallback. #3192.
  */
 function buildClaudeSpawnInvocation({
   claudeBin,
@@ -166,14 +166,47 @@ function buildClaudeSpawnInvocation({
     sandboxMode === "full-access" || sandboxMode === "danger-full-access";
 
   if (process.platform === "darwin" && !fullAccess) {
-    if (typeof sandboxProfile !== "string" || sandboxProfile.trim().length === 0) {
+    if (
+      !sandboxProfile ||
+      typeof sandboxProfile !== "object" ||
+      sandboxProfile.kind !== "seatbelt" ||
+      typeof sandboxProfile.profile !== "string" ||
+      sandboxProfile.profile.trim().length === 0
+    ) {
       throw new Error(
         "Claude Code launch blocked: the verified macOS sandbox profile is missing.",
       );
     }
     return {
       command: "/usr/bin/sandbox-exec",
-      args: ["-p", sandboxProfile, claudeBin, ...claudeArgs],
+      args: ["-p", sandboxProfile.profile, claudeBin, ...claudeArgs],
+      shell: false,
+    };
+  }
+
+  if (process.platform === "linux" && !fullAccess) {
+    if (
+      !sandboxProfile ||
+      typeof sandboxProfile !== "object" ||
+      sandboxProfile.kind !== "linux-launcher" ||
+      typeof sandboxProfile.launcherPath !== "string" ||
+      sandboxProfile.launcherPath.trim().length === 0 ||
+      typeof sandboxProfile.policyBase64 !== "string" ||
+      sandboxProfile.policyBase64.trim().length === 0
+    ) {
+      throw new Error(
+        "Claude Code launch blocked: the verified Linux sandbox launcher is missing.",
+      );
+    }
+    return {
+      command: sandboxProfile.launcherPath,
+      args: [
+        "__seren-sandbox-run",
+        sandboxProfile.policyBase64,
+        "--",
+        claudeBin,
+        ...claudeArgs,
+      ],
       shell: false,
     };
   }
@@ -2696,7 +2729,12 @@ export function createClaudeRuntime({ emit, runtimeMode = "provider-runtime" }) 
               PATH: extendedPath,
               SEREN_AGENT_PROJECT_ROOT: cwd,
               SEREN_AGENT_SANDBOX_MODE: sandboxMode ?? "workspace-write",
-              SEREN_AGENT_SANDBOX_PROFILE: sandboxProfile ?? "",
+              SEREN_AGENT_SANDBOX_PROFILE:
+                sandboxProfile?.kind === "seatbelt"
+                  ? sandboxProfile.profile
+                  : sandboxProfile?.kind === "linux-launcher"
+                    ? sandboxProfile.policyBase64
+                    : "",
               SEREN_AGENT_APPROVAL_POLICY: approvalPolicy ?? "on-request",
               SEREN_AGENT_AUTO_APPROVE_READS:
                 autoApproveReads === false ? "false" : "true",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4574,6 +4574,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7912,6 +7923,7 @@ dependencies = [
  "image",
  "jiff",
  "keyring",
+ "landlock",
  "lazy_static",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -110,6 +110,9 @@ tauri-plugin-deep-link = "2"
 tauri-plugin-single-instance = "2"
 xcap = "0.9.6"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = "0.4.5"
+
 # System-audio ("Them") loopback capture for Meeting Mode.
 [target.'cfg(target_os = "windows")'.dependencies]
 cpal = "0.18.1"

--- a/src-tauri/src/commands/sandbox.rs
+++ b/src-tauri/src/commands/sandbox.rs
@@ -1,10 +1,16 @@
-// ABOUTME: Tauri command that returns the verified macOS provider sandbox profile.
-// ABOUTME: Credential-store paths are denied before the profile crosses into the child runtime.
+// ABOUTME: Tauri command that returns the verified OS provider sandbox launch spec.
+// ABOUTME: Credential-store paths are denied before the policy crosses into the child runtime.
 
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use crate::sandbox::{SandboxMode, SandboxPolicy, seatbelt_profile};
+use serde::Serialize;
+
+use crate::sandbox::{SandboxMode, SandboxPolicy};
+#[cfg(target_os = "linux")]
+use crate::sandbox::encode_policy;
+#[cfg(target_os = "macos")]
+use crate::sandbox::seatbelt_profile;
 
 const CREDENTIAL_STORE_SUFFIXES: &[&str] = &[
     ".ssh",
@@ -18,12 +24,26 @@ const CREDENTIAL_STORE_SUFFIXES: &[&str] = &[
     ".netrc",
 ];
 
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind")]
+pub enum AgentSandboxLaunchSpec {
+    #[serde(rename = "seatbelt")]
+    Seatbelt { profile: String },
+    #[serde(rename = "linux-launcher")]
+    LinuxLauncher {
+        #[serde(rename = "launcherPath")]
+        launcher_path: String,
+        #[serde(rename = "policyBase64")]
+        policy_base64: String,
+    },
+}
+
 #[tauri::command]
 pub fn agent_sandbox_profile(
     mode: String,
     project_root: String,
     network_enabled: Option<bool>,
-) -> Result<String, String> {
+) -> Result<AgentSandboxLaunchSpec, String> {
     let mode = SandboxMode::from_str(&mode).map_err(|error| error.to_string())?;
     if mode == SandboxMode::FullAccess {
         return Err("No sandbox profile is generated for full-access mode.".to_string());
@@ -50,5 +70,29 @@ pub fn agent_sandbox_profile(
     )
     .map_err(|error| error.to_string())?;
 
-    seatbelt_profile(&policy).map_err(|error| error.to_string())
+    #[cfg(target_os = "macos")]
+    {
+        return seatbelt_profile(&policy)
+            .map(|profile| AgentSandboxLaunchSpec::Seatbelt { profile })
+            .map_err(|error| error.to_string());
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let launcher_path = std::env::current_exe()
+            .map_err(|error| format!("Could not resolve the sandbox launcher: {error}"))?
+            .to_string_lossy()
+            .into_owned();
+        let policy_base64 = encode_policy(&policy).map_err(|error| error.to_string())?;
+        return Ok(AgentSandboxLaunchSpec::LinuxLauncher {
+            launcher_path,
+            policy_base64,
+        });
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = policy;
+        Err("The provider sandbox backend is unavailable on this platform.".to_string())
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,5 +5,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args
+        .get(1)
+        .is_some_and(|argument| argument == "__seren-sandbox-run")
+    {
+        seren_desktop_lib::sandbox::sandbox_run_main(args);
+    }
     seren_desktop_lib::run()
 }

--- a/src-tauri/src/sandbox/landlock.rs
+++ b/src-tauri/src/sandbox/landlock.rs
@@ -1,0 +1,252 @@
+// ABOUTME: Applies the Linux Landlock policy and provides the hidden app-binary launcher mode.
+// ABOUTME: The launcher enforces the policy before exec so every descendant inherits the boundary.
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::env;
+    use std::path::{Path, PathBuf};
+    use std::process::{self, Command};
+
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use landlock::{
+        ABI, Access, AccessFs, AccessNet, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset,
+        RulesetAttr, RulesetCreated, RulesetCreatedAttr, RulesetStatus,
+    };
+    use std::os::unix::process::CommandExt;
+
+    use super::super::policy::{SandboxError, SandboxMode, SandboxPolicy};
+
+    const SANDBOX_LAUNCHER_ARGUMENT: &str = "__seren-sandbox-run";
+    const BAD_ARGUMENTS_EXIT: i32 = 64;
+    const BAD_POLICY_EXIT: i32 = 65;
+    const ENFORCEMENT_FAILURE_EXIT: i32 = 69;
+    const EXEC_FAILURE_EXIT: i32 = 127;
+
+    pub fn apply_landlock(policy: &SandboxPolicy) -> Result<(), SandboxError> {
+        apply_landlock_for_command(policy, None, &[])
+    }
+
+    fn apply_landlock_for_command(
+        policy: &SandboxPolicy,
+        command: Option<&Path>,
+        command_args: &[String],
+    ) -> Result<(), SandboxError> {
+        if policy.mode == SandboxMode::FullAccess {
+            return Err(SandboxError::FullAccessNoProfile);
+        }
+
+        let mut allowed_paths = system_read_paths();
+        allowed_paths.extend(policy.workspace_roots.iter().cloned());
+        if let Some(command) = command {
+            allowed_paths.extend(command_related_paths(command));
+        }
+        let argument_file_paths = command_argument_file_paths(command_args);
+        allowed_paths.extend(argument_file_paths.iter().cloned());
+        validate_deny_read(policy, &allowed_paths)?;
+
+        // V7 is the complete filesystem access set known to this crate. HardRequirement is
+        // intentional: a kernel that cannot represent one of these controls must not silently
+        // receive a weaker policy.
+        let abi = ABI::V7;
+        let mut ruleset = Ruleset::default()
+            .set_compatibility(CompatLevel::HardRequirement)
+            .handle_access(AccessFs::from_all(abi))
+            .map_err(|error| SandboxError::Landlock(error.to_string()))?;
+
+        if !policy.network_enabled {
+            // No NetPort rules are added, so every handled TCP bind/connect is denied. ABI V4 is
+            // the first Landlock ABI that can enforce both TCP rights.
+            ruleset = ruleset
+                .handle_access(AccessNet::from_all(ABI::V4))
+                .map_err(|error| SandboxError::Landlock(error.to_string()))?;
+        }
+
+        let mut created = ruleset
+            .create()
+            .map_err(|error| SandboxError::Landlock(error.to_string()))?;
+        let read_access = AccessFs::from_read(abi);
+        let write_access = AccessFs::from_all(abi);
+
+        for path in system_read_paths()
+            .into_iter()
+            .chain(command.map(command_related_paths).into_iter().flatten())
+        {
+            if path.exists() {
+                created = add_path_rule(created, &path, read_access)?;
+            }
+        }
+        for path in argument_file_paths {
+            created = add_file_rule(created, &path)?;
+        }
+
+        let workspace_access = if policy.mode == SandboxMode::WorkspaceWrite {
+            write_access
+        } else {
+            read_access
+        };
+        for path in &policy.workspace_roots {
+            created = add_path_rule(created, path, workspace_access)?;
+        }
+
+        let status = created
+            .restrict_self()
+            .map_err(|error| SandboxError::Landlock(error.to_string()))?;
+        if status.ruleset != RulesetStatus::FullyEnforced {
+            return Err(SandboxError::Landlock(format!(
+                "Landlock ruleset was not fully enforced: {:?}",
+                status.ruleset
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn add_path_rule(
+        created: RulesetCreated,
+        path: &Path,
+        access: impl Into<landlock::BitFlags<AccessFs>>,
+    ) -> Result<RulesetCreated, SandboxError> {
+        let path_fd = PathFd::new(path)
+            .map_err(|error| SandboxError::Landlock(format!("cannot open {path:?}: {error}")))?;
+        created
+            .add_rule(PathBeneath::new(path_fd, access))
+            .map_err(|error| SandboxError::Landlock(error.to_string()))
+    }
+
+    fn add_file_rule(created: RulesetCreated, path: &Path) -> Result<RulesetCreated, SandboxError> {
+        let path_fd = PathFd::new(path)
+            .map_err(|error| SandboxError::Landlock(format!("cannot open {path:?}: {error}")))?;
+        created
+            .add_rule(PathBeneath::new(path_fd, AccessFs::ReadFile))
+            .map_err(|error| SandboxError::Landlock(error.to_string()))
+    }
+
+    fn system_read_paths() -> Vec<PathBuf> {
+        [
+            "/bin", "/dev", "/etc", "/lib", "/lib64", "/proc", "/sbin", "/sys", "/usr",
+        ]
+        .into_iter()
+        .map(PathBuf::from)
+        .filter(|path| path.exists())
+        .collect()
+    }
+
+    fn command_related_paths(command: &Path) -> Vec<PathBuf> {
+        if command.is_absolute() || command.components().count() > 1 {
+            return command
+                .parent()
+                .map(Path::to_path_buf)
+                .into_iter()
+                .collect();
+        }
+
+        env::var_os("PATH")
+            .into_iter()
+            .flat_map(|path| env::split_paths(&path).collect::<Vec<_>>())
+            .filter(|path| path.as_os_str().is_empty() || path.is_dir())
+            .collect()
+    }
+
+    fn command_argument_file_paths(args: &[String]) -> Vec<PathBuf> {
+        args.windows(2)
+            .filter(|window| matches!(window[0].as_str(), "--mcp-config" | "--settings"))
+            .map(|window| PathBuf::from(&window[1]))
+            .filter(|path| path.is_file())
+            .collect()
+    }
+
+    fn validate_deny_read(
+        policy: &SandboxPolicy,
+        allowed_paths: &[PathBuf],
+    ) -> Result<(), SandboxError> {
+        for denied in &policy.deny_read {
+            if allowed_paths
+                .iter()
+                .any(|allowed| denied.starts_with(allowed) || allowed.starts_with(denied))
+            {
+                return Err(SandboxError::Landlock(format!(
+                    "deny-read path {:?} overlaps an allowed hierarchy",
+                    denied
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn decode_policy(encoded: &str) -> Result<SandboxPolicy, SandboxError> {
+        let bytes = STANDARD
+            .decode(encoded)
+            .map_err(|error| SandboxError::PolicyDecode(error.to_string()))?;
+        let decoded: SandboxPolicy = serde_json::from_slice(&bytes)
+            .map_err(|error| SandboxError::PolicyDecode(error.to_string()))?;
+        SandboxPolicy::new(
+            decoded.mode,
+            decoded.workspace_roots,
+            decoded.deny_read,
+            decoded.network_enabled,
+        )
+        .map_err(|error| SandboxError::PolicyDecode(error.to_string()))
+    }
+
+    fn exit_with(code: i32, message: impl std::fmt::Display) -> ! {
+        eprintln!("Seren sandbox launcher: {message}");
+        process::exit(code);
+    }
+
+    pub fn sandbox_run_main(args: Vec<String>) -> ! {
+        let rest = args.into_iter().skip(1).collect::<Vec<_>>();
+        if rest.len() < 4
+            || rest[0] != SANDBOX_LAUNCHER_ARGUMENT
+            || rest[2] != "--"
+            || rest[3].trim().is_empty()
+        {
+            exit_with(
+                BAD_ARGUMENTS_EXIT,
+                "usage: __seren-sandbox-run <base64-policy-json> -- <command> [args...]",
+            );
+        }
+
+        let policy = match decode_policy(&rest[1]) {
+            Ok(policy) => policy,
+            Err(error) => exit_with(BAD_POLICY_EXIT, error),
+        };
+        let command = rest[3].clone();
+        let command_args = &rest[4..];
+
+        if let Some(workspace_root) = policy.workspace_roots.first()
+            && let Err(error) = env::set_current_dir(workspace_root)
+        {
+            exit_with(ENFORCEMENT_FAILURE_EXIT, error);
+        }
+
+        if let Err(error) =
+            apply_landlock_for_command(&policy, Some(Path::new(&command)), command_args)
+        {
+            exit_with(ENFORCEMENT_FAILURE_EXIT, error);
+        }
+
+        let error = Command::new(&command).args(command_args).exec();
+        exit_with(EXEC_FAILURE_EXIT, error);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod unsupported {
+    use super::super::policy::{SandboxError, SandboxPolicy};
+
+    pub fn apply_landlock(_policy: &SandboxPolicy) -> Result<(), SandboxError> {
+        Err(SandboxError::BackendUnavailable)
+    }
+
+    pub fn sandbox_run_main(_args: Vec<String>) -> ! {
+        eprintln!(
+            "Seren sandbox launcher: Linux Landlock backend is unavailable on this platform."
+        );
+        std::process::exit(78);
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub use linux::{apply_landlock, sandbox_run_main};
+#[cfg(not(target_os = "linux"))]
+pub use unsupported::{apply_landlock, sandbox_run_main};

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -1,8 +1,10 @@
 // ABOUTME: Canonical provider-process sandbox policy and platform backends.
 // ABOUTME: Keeps the security boundary in Rust before a child process is spawned.
 
+mod landlock;
 mod policy;
 mod seatbelt;
 
-pub use policy::{SandboxError, SandboxMode, SandboxPolicy};
+pub use landlock::{apply_landlock, sandbox_run_main};
+pub use policy::{SandboxError, SandboxMode, SandboxPolicy, encode_policy};
 pub use seatbelt::{seatbelt_profile, wrap_spawn};

--- a/src-tauri/src/sandbox/policy.rs
+++ b/src-tauri/src/sandbox/policy.rs
@@ -4,9 +4,12 @@
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum SandboxMode {
     ReadOnly,
     WorkspaceWrite,
@@ -39,18 +42,30 @@ pub enum SandboxError {
     EmptyWorkspaceRoots,
     #[error("a full-access session does not have a sandbox profile")]
     FullAccessNoProfile,
-    #[error("the macOS Seatbelt backend is unavailable on this platform")]
+    #[error("the sandbox backend is unavailable on this platform")]
     BackendUnavailable,
     #[error("sandbox command path cannot be empty")]
     EmptyCommand,
+    #[error("sandbox policy serialization failed: {0}")]
+    PolicySerialization(String),
+    #[error("sandbox policy decoding failed: {0}")]
+    PolicyDecode(String),
+    #[error("Landlock backend error: {0}")]
+    Landlock(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SandboxPolicy {
     pub mode: SandboxMode,
     pub workspace_roots: Vec<PathBuf>,
     pub deny_read: Vec<PathBuf>,
     pub network_enabled: bool,
+}
+
+pub fn encode_policy(policy: &SandboxPolicy) -> Result<String, SandboxError> {
+    let serialized = serde_json::to_vec(policy)
+        .map_err(|error| SandboxError::PolicySerialization(error.to_string()))?;
+    Ok(STANDARD.encode(serialized))
 }
 
 impl SandboxPolicy {

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -4,6 +4,8 @@
 use std::path::{Path, PathBuf};
 
 use super::policy::{SandboxError, SandboxMode, SandboxPolicy};
+#[cfg(target_os = "linux")]
+use super::policy::encode_policy;
 
 const SEATBELT_EXECUTABLE: &str = "/usr/bin/sandbox-exec";
 
@@ -75,7 +77,21 @@ pub fn wrap_spawn(
         Ok((SEATBELT_EXECUTABLE.to_string(), wrapped_args))
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    {
+        let launcher = std::env::current_exe()
+            .map_err(|error| SandboxError::Landlock(format!("cannot resolve launcher: {error}")))?;
+        let policy_base64 = encode_policy(policy)?;
+        let mut wrapped_args = Vec::with_capacity(args.len() + 4);
+        wrapped_args.push("__seren-sandbox-run".to_string());
+        wrapped_args.push(policy_base64);
+        wrapped_args.push("--".to_string());
+        wrapped_args.push(command.to_string());
+        wrapped_args.extend(args.iter().cloned());
+        Ok((launcher.to_string_lossy().into_owned(), wrapped_args))
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "linux")))]
     {
         let _ = (args, policy);
         Err(SandboxError::BackendUnavailable)

--- a/src-tauri/tests/sandbox_landlock.rs
+++ b/src-tauri/tests/sandbox_landlock.rs
@@ -1,0 +1,192 @@
+#![cfg(target_os = "linux")]
+
+// Real Linux Landlock canaries. The CI Ubuntu runner executes these against the kernel.
+
+use std::fs;
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use seren_desktop_lib::sandbox::{SandboxMode, SandboxPolicy};
+use tempfile::TempDir;
+
+fn policy_payload(policy: &SandboxPolicy) -> String {
+    STANDARD.encode(serde_json::to_vec(policy).expect("policy serializes"))
+}
+
+fn run_command(policy: &SandboxPolicy, cwd: &Path, command: &str, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_Seren"))
+        .args([
+            "__seren-sandbox-run",
+            &policy_payload(policy),
+            "--",
+            command,
+        ])
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("sandbox launcher starts")
+}
+
+fn workspace_policy(mode: SandboxMode, workspace: &TempDir) -> SandboxPolicy {
+    SandboxPolicy::new(mode, vec![workspace.path().to_path_buf()], Vec::new(), true)
+        .expect("test workspace policy is valid")
+}
+
+#[test]
+fn sandbox_workspace_write_canary_succeeds() {
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
+
+    let output = run_command(
+        &policy,
+        workspace.path(),
+        "/bin/sh",
+        &["-c", "touch inside"],
+    );
+
+    assert!(
+        output.status.success(),
+        "workspace write failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(workspace.path().join("inside").is_file());
+}
+
+#[test]
+fn sandbox_outside_write_canary_is_denied() {
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let outside_file = outside.path().join("escape");
+    let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
+
+    let output = run_command(
+        &policy,
+        workspace.path(),
+        "/bin/sh",
+        &["-c", &format!("touch '{}'", outside_file.display())],
+    );
+
+    assert!(!output.status.success());
+    assert!(!outside_file.exists());
+}
+
+#[test]
+fn sandbox_deny_read_canary_is_denied() {
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let denied = tempfile::tempdir().expect("denied tempdir");
+    let readable_file = workspace.path().join("readable");
+    let denied_file = denied.path().join("secret");
+    fs::write(&readable_file, "readable").expect("write readable canary");
+    fs::write(&denied_file, "secret").expect("write denied canary");
+    let policy = SandboxPolicy::new(
+        SandboxMode::ReadOnly,
+        vec![workspace.path().to_path_buf()],
+        vec![denied.path().to_path_buf()],
+        true,
+    )
+    .expect("deny-read policy is valid");
+
+    let output = run_command(
+        &policy,
+        workspace.path(),
+        "/bin/sh",
+        &[
+            "-c",
+            &format!(
+                "cat '{}' && ! cat '{}'",
+                readable_file.display(),
+                denied_file.display()
+            ),
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "read canary failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "readable");
+}
+
+#[test]
+fn sandbox_grandchild_write_cannot_escape() {
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let outside_file = outside.path().join("grandchild-escape");
+    let policy = workspace_policy(SandboxMode::WorkspaceWrite, &workspace);
+
+    let output = run_command(
+        &policy,
+        workspace.path(),
+        "/bin/sh",
+        &[
+            "-c",
+            &format!("/bin/sh -c \"touch '{}'\"", outside_file.display()),
+        ],
+    );
+
+    assert!(!output.status.success());
+    assert!(!outside_file.exists());
+}
+
+#[test]
+fn sandbox_network_disabled_denies_tcp_or_fails_closed() {
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind canary listener");
+    let port = listener.local_addr().expect("listener address").port();
+    let policy = SandboxPolicy::new(
+        SandboxMode::ReadOnly,
+        vec![workspace.path().to_path_buf()],
+        Vec::new(),
+        false,
+    )
+    .expect("network-disabled policy is valid");
+
+    let output = run_command(
+        &policy,
+        workspace.path(),
+        "/bin/bash",
+        &["-c", &format!("exec 3<>/dev/tcp/127.0.0.1/{port}")],
+    );
+
+    if output.status.code() != Some(69) {
+        assert!(
+            !output.status.success()
+                && (String::from_utf8_lossy(&output.stderr).contains("Permission denied")
+                    || String::from_utf8_lossy(&output.stderr).contains("Operation not permitted")
+                    || String::from_utf8_lossy(&output.stderr).contains("Network is unreachable")),
+            "network canary did not show a denied connect: status={:?} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn sandbox_read_only_denies_workspace_write() {
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let inside_file = workspace.path().join("read-only-escape");
+    let policy = workspace_policy(SandboxMode::ReadOnly, &workspace);
+
+    let output = run_command(
+        &policy,
+        workspace.path(),
+        "/bin/sh",
+        &["-c", "touch read-only-escape"],
+    );
+
+    assert!(!output.status.success());
+    assert!(!inside_file.exists());
+}
+
+#[test]
+fn sandbox_bad_policy_payload_exits_65() {
+    let output = Command::new(env!("CARGO_BIN_EXE_Seren"))
+        .args(["__seren-sandbox-run", "not-base64", "--", "/bin/true"])
+        .output()
+        .expect("sandbox launcher starts");
+
+    assert_eq!(output.status.code(), Some(65));
+}

--- a/src/services/providers.ts
+++ b/src/services/providers.ts
@@ -104,6 +104,14 @@ export interface AgentInfo {
   unavailableReason?: string;
 }
 
+export type SandboxLaunchSpec =
+  | { kind: "seatbelt"; profile: string }
+  | {
+      kind: "linux-launcher";
+      launcherPath: string;
+      policyBase64: string;
+    };
+
 // Remote sessions (provider runtime listSessions capability)
 export interface RemoteSessionInfo {
   sessionId: string;
@@ -519,12 +527,14 @@ export async function spawnAgent(
   const isMacOsDesktop =
     typeof navigator !== "undefined" &&
     /Macintosh|Mac OS X/i.test(navigator.userAgent);
+  const isLinuxDesktop =
+    typeof navigator !== "undefined" && /Linux/i.test(navigator.userAgent);
   const sandboxProfile =
     agentType === "claude-code" &&
     isTauriRuntime() &&
-    isMacOsDesktop &&
+    (isMacOsDesktop || isLinuxDesktop) &&
     !fullAccess
-      ? await invoke<string>("agent_sandbox_profile", {
+      ? await invoke<SandboxLaunchSpec>("agent_sandbox_profile", {
           mode: sandboxMode ?? "workspace-write",
           projectRoot: cwd,
           networkEnabled: networkEnabled !== false,

--- a/tests/unit/claude-sandbox-spawn.test.ts
+++ b/tests/unit/claude-sandbox-spawn.test.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Critical guard for #3192 — bounded macOS Claude sessions cannot spawn without Seatbelt.
+// ABOUTME: Critical guard for #3192 — bounded Claude sessions cannot spawn without an OS launcher.
 // ABOUTME: Verifies the wrapper shape and the fail-closed missing-profile path without spawning a process.
 
 import { describe, expect, it } from "vitest";
@@ -11,7 +11,7 @@ const {
   _buildClaudeSpawnInvocation: buildClaudeSpawnInvocation,
 } = await import(/* @vite-ignore */ modulePath);
 
-describe("Claude macOS Seatbelt spawn boundary (#3192)", () => {
+describe("Claude bounded spawn boundary (#3192)", () => {
   const withDarwin = (callback: () => void) => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", {
@@ -35,11 +35,54 @@ describe("Claude macOS Seatbelt spawn boundary (#3192)", () => {
           claudeBin: "/usr/local/bin/claude",
           claudeArgs: ["--version"],
           sandboxMode: "workspace-write",
-          sandboxProfile: "(version 1)",
+          sandboxProfile: { kind: "seatbelt", profile: "(version 1)" },
         }),
       ).toEqual({
         command: "/usr/bin/sandbox-exec",
         args: ["-p", "(version 1)", "/usr/local/bin/claude", "--version"],
+        shell: false,
+      });
+    });
+  });
+
+  const withLinux = (callback: () => void) => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+    try {
+      callback();
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  };
+
+  it("wraps Linux bounded sessions with the app-binary launcher", () => {
+    withLinux(() => {
+      expect(
+        buildClaudeSpawnInvocation({
+          claudeBin: "/usr/local/bin/claude",
+          claudeArgs: ["--version"],
+          sandboxMode: "workspace-write",
+          sandboxProfile: {
+            kind: "linux-launcher",
+            launcherPath: "/opt/Seren",
+            policyBase64: "encoded-policy",
+          },
+        }),
+      ).toEqual({
+        command: "/opt/Seren",
+        args: [
+          "__seren-sandbox-run",
+          "encoded-policy",
+          "--",
+          "/usr/local/bin/claude",
+          "--version",
+        ],
         shell: false,
       });
     });
@@ -55,6 +98,19 @@ describe("Claude macOS Seatbelt spawn boundary (#3192)", () => {
           sandboxProfile: null,
         }),
       ).toThrow(/verified macOS sandbox profile is missing/);
+    });
+  });
+
+  it("throws before spawning when a Linux bounded session has no launcher", () => {
+    withLinux(() => {
+      expect(() =>
+        buildClaudeSpawnInvocation({
+          claudeBin: "/usr/local/bin/claude",
+          claudeArgs: [],
+          sandboxMode: "read-only",
+          sandboxProfile: null,
+        }),
+      ).toThrow(/verified Linux sandbox launcher is missing/);
     });
   });
 


### PR DESCRIPTION
## Summary

This PR continues #3192 with the Linux backend for the canonical provider-process sandbox.

### New dependency — acknowledgment required before merge

landlock is a new Linux-only dependency. It provides Rust bindings maintained alongside the kernel LSM and is needed for unprivileged filesystem and TCP confinement. Please acknowledge this dependency before merge; the PR will remain open until that acknowledgment is recorded.

### Audit and implementation

- The policy model in src-tauri/src/sandbox/policy.rs is serialized and revalidated in the Rust launcher.
- src-tauri/src/sandbox/landlock.rs applies a hard-requirement Landlock filesystem ruleset, denies TCP bind/connect when network access is disabled, and exits fail-closed when the kernel cannot enforce the requested controls.
- The hidden __seren-sandbox-run mode is dispatched in src-tauri/src/main.rs before Tauri initialization; descendants inherit the restriction through exec.
- src-tauri/src/commands/sandbox.rs returns a platform-tagged launch specification, and src/services/providers.ts plus bin/browser-local/claude-runtime.mjs require the Linux launcher for every bounded Linux session.
- Exact inline/runtime configuration handling does not broaden access to temporary directories.
- src-tauri/tests/sandbox_landlock.rs contains real Linux canaries for workspace writes, outside writes, denied reads, grandchild confinement, read-only writes, malformed policies, and network-disabled TCP.

### Verification

- cargo check --locked --manifest-path src-tauri/Cargo.toml passed on macOS.
- cargo test --locked --manifest-path src-tauri/Cargo.toml sandbox passed on macOS; the six existing Seatbelt canaries passed and the Linux canaries are target-gated for the Ubuntu CI runner.
- pnpm vitest run tests/unit/claude-sandbox-spawn.test.ts passed all five focused tests.
- pnpm check exited 0 with no errors.
- The Ubuntu test-rust job is the real Linux enforcement gate; it runs the Landlock integration tests without mocks.

Networked path: none — this change constrains local process spawning; no publisher or API call is added or modified.

Refs #3192

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
