### PR TITLE
fix(tools): close the fail-open approval allowlist with session-bounded grants

### DIFF
--- a/src/lib/tools/approval-config.ts
+++ b/src/lib/tools/approval-config.ts
@@ -16,9 +16,20 @@ export interface ApprovalRequirement {
 }
 
 /**
- * List of Gateway publisher operations that require user approval.
- *
- * Operations not in this list execute immediately (e.g., read-only operations).
+ * Authorization behavior for a Gateway, built-in Seren, or local MCP operation.
+ * Unknown operations intentionally remain unclassified until trusted metadata exists.
+ */
+export type OperationClass = "trusted-read" | "high-risk" | "unclassified";
+
+interface OperationPattern {
+  publisherSlug: string;
+  toolPattern: string;
+}
+
+/**
+ * Explicit high-risk operations that always require one-shot approval.
+ * Operations absent from both this list and TRUSTED_READ_OPERATIONS are
+ * unclassified and must be escalated before their first use in a session.
  */
 export const APPROVAL_REQUIREMENTS: ApprovalRequirement[] = [
   // Gmail - Modify operations
@@ -67,21 +78,92 @@ export const APPROVAL_REQUIREMENTS: ApprovalRequirement[] = [
 ];
 
 /**
+ * Positively identified read-only operations that may execute silently.
+ * Keep this list narrow: verb-shaped names and undiscovered publishers do not
+ * become trusted merely because they look like reads.
+ */
+export const TRUSTED_READ_OPERATIONS: readonly OperationPattern[] = [
+  { publisherSlug: "gmail", toolPattern: "messages" },
+  { publisherSlug: "gmail", toolPattern: "messages/*" },
+  { publisherSlug: "gmail", toolPattern: "threads" },
+  { publisherSlug: "gmail", toolPattern: "threads/*" },
+  { publisherSlug: "gmail", toolPattern: "labels/list" },
+  { publisherSlug: "gmail", toolPattern: "get_messages" },
+  { publisherSlug: "gmail", toolPattern: "get_message" },
+  { publisherSlug: "gmail", toolPattern: "get_thread" },
+  { publisherSlug: "gmail", toolPattern: "list_messages" },
+  { publisherSlug: "gmail", toolPattern: "list_threads" },
+  { publisherSlug: "gmail", toolPattern: "list_labels" },
+  { publisherSlug: "seren", toolPattern: "list_projects" },
+  { publisherSlug: "seren", toolPattern: "get_project" },
+  { publisherSlug: "seren", toolPattern: "search_projects" },
+  { publisherSlug: "seren", toolPattern: "get_status" },
+];
+
+function matchesOperation(
+  requirement: OperationPattern,
+  publisherSlug: string,
+  toolName: string,
+): boolean {
+  if (requirement.publisherSlug !== publisherSlug) return false;
+
+  // Simple wildcard matching: "messages/*/delete" matches
+  // "messages/123/delete" without allowing a wildcard to span a path segment.
+  const pattern = requirement.toolPattern
+    .split("*")
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("[^/]+");
+  return new RegExp(`^${pattern}$`).test(toolName);
+}
+
+/**
+ * Classify an operation only when it has an explicit policy entry.
+ * Everything else is deliberately unclassified rather than implicitly safe.
+ */
+export function classifyGatewayOperation(
+  publisherSlug: string,
+  toolName: string,
+): OperationClass {
+  if (
+    APPROVAL_REQUIREMENTS.some((requirement) =>
+      matchesOperation(requirement, publisherSlug, toolName),
+    )
+  ) {
+    return "high-risk";
+  }
+
+  if (
+    TRUSTED_READ_OPERATIONS.some((operation) =>
+      matchesOperation(operation, publisherSlug, toolName),
+    )
+  ) {
+    return "trusted-read";
+  }
+
+  return "unclassified";
+}
+
+/**
+ * Escalate recognizably high-risk names even before their publisher supplies
+ * trusted metadata. This helper only adds prompts; it never grants access.
+ */
+export function isHighRiskVerb(toolName: string): boolean {
+  return /send|delete|remove|pay|transfer|trade|execute|credential|revoke/i.test(
+    toolName,
+  );
+}
+
+/**
  * Check if a Gateway tool call requires user approval.
  */
 export function requiresApproval(
   publisherSlug: string,
   toolName: string,
 ): boolean {
-  // Check if any approval requirement matches this operation
-  return APPROVAL_REQUIREMENTS.some((req) => {
-    if (req.publisherSlug !== publisherSlug) return false;
-
-    // Simple wildcard matching: "messages/*/delete" matches "messages/123/delete"
-    const pattern = req.toolPattern.replace(/\*/g, "[^/]+");
-    const regex = new RegExp(`^${pattern}$`);
-    return regex.test(toolName);
-  });
+  return (
+    classifyGatewayOperation(publisherSlug, toolName) === "high-risk" ||
+    isHighRiskVerb(toolName)
+  );
 }
 
 /**
@@ -92,10 +174,7 @@ export function getApprovalRequirement(
   toolName: string,
 ): ApprovalRequirement | null {
   const req = APPROVAL_REQUIREMENTS.find((req) => {
-    if (req.publisherSlug !== publisherSlug) return false;
-    const pattern = req.toolPattern.replace(/\*/g, "[^/]+");
-    const regex = new RegExp(`^${pattern}$`);
-    return regex.test(toolName);
+    return matchesOperation(req, publisherSlug, toolName);
   });
 
   return req || null;

--- a/src/lib/tools/approval-session.ts
+++ b/src/lib/tools/approval-session.ts
@@ -1,0 +1,69 @@
+// ABOUTME: In-memory, session-bounded grants and denials for tool authorization.
+// ABOUTME: Decisions are deliberately not persisted because incomplete metadata is never durable authority.
+
+type SessionDecision = "granted" | "denied";
+
+const sessionDecisions = new Map<string, SessionDecision>();
+
+function decisionKey(
+  conversationId: string,
+  publisherSlug: string,
+  toolName: string,
+): string {
+  return JSON.stringify([conversationId, publisherSlug, toolName]);
+}
+
+export function hasSessionGrant(
+  conversationId: string,
+  publisherSlug: string,
+  toolName: string,
+): boolean {
+  return (
+    sessionDecisions.get(
+      decisionKey(conversationId, publisherSlug, toolName),
+    ) === "granted"
+  );
+}
+
+export function recordSessionGrant(
+  conversationId: string,
+  publisherSlug: string,
+  toolName: string,
+): void {
+  sessionDecisions.set(
+    decisionKey(conversationId, publisherSlug, toolName),
+    "granted",
+  );
+}
+
+export function hasSessionDenial(
+  conversationId: string,
+  publisherSlug: string,
+  toolName: string,
+): boolean {
+  return (
+    sessionDecisions.get(
+      decisionKey(conversationId, publisherSlug, toolName),
+    ) === "denied"
+  );
+}
+
+export function recordSessionDenial(
+  conversationId: string,
+  publisherSlug: string,
+  toolName: string,
+): void {
+  sessionDecisions.set(
+    decisionKey(conversationId, publisherSlug, toolName),
+    "denied",
+  );
+}
+
+export function clearSessionDecisions(conversationId: string): void {
+  const prefix = JSON.stringify([conversationId]).slice(0, -1);
+  for (const key of sessionDecisions.keys()) {
+    if (key.startsWith(prefix)) {
+      sessionDecisions.delete(key);
+    }
+  }
+}

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -16,7 +16,18 @@ import { computeAgentOAuthRouting } from "@/services/publisher-oauth";
 import { startShellProgressListener } from "@/services/shell-progress";
 import { x402Service } from "@/services/x402";
 import { conversationStore } from "@/stores/conversation.store";
-import { getApprovalRequirement, requiresApproval } from "./approval-config";
+import type { OperationClass } from "./approval-config";
+import {
+  classifyGatewayOperation,
+  getApprovalRequirement,
+  isHighRiskVerb,
+} from "./approval-config";
+import {
+  hasSessionDenial,
+  hasSessionGrant,
+  recordSessionDenial,
+  recordSessionGrant,
+} from "./approval-session";
 import { parseGatewayToolName, parseMcpToolName } from "./definitions";
 
 const GATEWAY_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -32,6 +43,15 @@ interface GatewayApprovalResult {
 interface GatewayConnectionArgsResult {
   args: Record<string, unknown>;
   error?: string;
+}
+
+interface GatewayApprovalPrompt {
+  description?: string;
+  isDestructive?: boolean;
+}
+
+interface ToolAuthorizationOptions {
+  operationClass?: OperationClass;
 }
 
 /**
@@ -125,6 +145,7 @@ async function requestGatewayApproval(
   toolName: string,
   args: Record<string, unknown>,
   conversationId: string | null,
+  prompt?: GatewayApprovalPrompt,
 ): Promise<GatewayApprovalResult> {
   const approvalId = `gateway-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const requirement = getApprovalRequirement(publisherSlug, toolName);
@@ -141,8 +162,10 @@ async function requestGatewayApproval(
       toolName,
       args,
       threadId: conversationId ?? conversationStore.activeConversationId,
-      description: requirement?.description || "Execute operation",
-      isDestructive: requirement?.isDestructive || false,
+      description:
+        requirement?.description ?? prompt?.description ?? "Execute operation",
+      isDestructive:
+        requirement?.isDestructive ?? prompt?.isDestructive ?? false,
     });
   } catch (err) {
     console.error("[Tool Executor] Failed to emit approval request:", err);
@@ -182,6 +205,87 @@ async function requestGatewayApproval(
         resolve({ approved: false });
       });
   });
+}
+
+function sessionConversationId(conversationId: string | null): string {
+  return (
+    conversationId ??
+    conversationStore.activeConversationId ??
+    "session-without-conversation"
+  );
+}
+
+/**
+ * Apply the temporary, renderer-side containment policy at every currently
+ * reachable publisher route. The future Rust gate will become the trusted
+ * boundary; until then this keeps unknown operations from failing open.
+ */
+async function authorizeToolOperation(
+  publisherSlug: string,
+  toolName: string,
+  args: Record<string, unknown>,
+  conversationId: string | null,
+  options?: ToolAuthorizationOptions,
+): Promise<GatewayApprovalResult> {
+  const operationClass =
+    options?.operationClass ??
+    classifyGatewayOperation(publisherSlug, toolName);
+  const highRisk = operationClass === "high-risk" || isHighRiskVerb(toolName);
+
+  if (operationClass === "trusted-read" && !highRisk) {
+    return { approved: true };
+  }
+
+  const sessionId = sessionConversationId(conversationId);
+  if (!highRisk) {
+    if (hasSessionDenial(sessionId, publisherSlug, toolName)) {
+      console.log(
+        `[Tool Executor] Reusing denied session decision for ${publisherSlug}/${toolName}`,
+      );
+      return { approved: false };
+    }
+
+    if (hasSessionGrant(sessionId, publisherSlug, toolName)) {
+      console.log(
+        `[Tool Executor] Reusing granted session decision for ${publisherSlug}/${toolName}`,
+      );
+      return { approved: true };
+    }
+  }
+
+  const approval = await requestGatewayApproval(
+    publisherSlug,
+    toolName,
+    args,
+    conversationId,
+    highRisk
+      ? {
+          description: `High-risk operation on ${publisherSlug}/${toolName}`,
+        }
+      : {
+          description: `Unclassified operation on ${publisherSlug} — first use this session`,
+        },
+  );
+
+  // High-risk calls are exact one-shot approvals. Only unclassified calls may
+  // receive a temporary, in-memory session decision.
+  if (!highRisk) {
+    if (approval.approved) {
+      recordSessionGrant(sessionId, publisherSlug, toolName);
+    } else {
+      recordSessionDenial(sessionId, publisherSlug, toolName);
+    }
+  }
+
+  return approval;
+}
+
+function deniedToolResult(toolCallId: string): ToolResult {
+  return {
+    tool_call_id: toolCallId,
+    content: "Operation was not approved by user",
+    is_error: true,
+  };
 }
 
 async function resolveGatewayOAuthConnectionArgs(
@@ -297,6 +401,15 @@ export async function executeTool(
     // Check if this is a built-in Seren tool (seren__toolName)
     if (name.startsWith("seren__")) {
       const serenToolName = name.slice("seren__".length);
+      const approval = await authorizeToolOperation(
+        "seren",
+        serenToolName,
+        args,
+        conversationId,
+      );
+      if (!approval.approved) {
+        return deniedToolResult(toolCall.id);
+      }
       const response = await callSerenTool(serenToolName, args);
       const content =
         typeof response.result === "string"
@@ -329,6 +442,7 @@ export async function executeTool(
         mcpInfo.serverName,
         mcpInfo.toolName,
         args,
+        conversationId,
       );
     }
 
@@ -527,8 +641,22 @@ async function executeMcpTool(
   serverName: string,
   toolName: string,
   args: Record<string, unknown>,
+  conversationId: string | null,
 ): Promise<ToolResult> {
   try {
+    const approval = await authorizeToolOperation(
+      serverName,
+      toolName,
+      args,
+      conversationId,
+      // Local stdio server names are user-controlled and have no trusted
+      // metadata yet, even when a name happens to resemble a publisher slug.
+      { operationClass: "unclassified" },
+    );
+    if (!approval.approved) {
+      return deniedToolResult(toolCallId);
+    }
+
     const result = await mcpClient.callTool(serverName, {
       name: toolName,
       arguments: args,
@@ -611,32 +739,19 @@ async function executeGatewayTool(
   try {
     let callArgs = args;
 
-    // Check if this operation requires user approval
-    if (requiresApproval(publisherSlug, toolName)) {
-      console.log(
-        `[Tool Executor] Operation requires approval: ${publisherSlug}/${toolName}`,
-      );
-      const approval = await requestGatewayApproval(
-        publisherSlug,
-        toolName,
-        args,
-        conversationId,
-      );
+    const approval = await authorizeToolOperation(
+      publisherSlug,
+      toolName,
+      args,
+      conversationId,
+    );
+    if (!approval.approved) {
+      console.log("[Tool Executor] Operation denied by user");
+      return deniedToolResult(toolCallId);
+    }
 
-      if (!approval.approved) {
-        console.log("[Tool Executor] Operation denied by user");
-        return {
-          tool_call_id: toolCallId,
-          content: "Operation was not approved by user",
-          is_error: true,
-        };
-      }
-
-      console.log("[Tool Executor] Operation approved by user");
-
-      if (approval.connectionId) {
-        callArgs = { ...args, connection_id: approval.connectionId };
-      }
+    if (approval.connectionId) {
+      callArgs = { ...args, connection_id: approval.connectionId };
     }
 
     const resolvedArgs = await resolveGatewayOAuthConnectionArgs(
@@ -788,6 +903,9 @@ async function executeGatewayTool(
  */
 export async function executeTools(
   toolCalls: ToolCall[],
+  conversationId: string | null = null,
 ): Promise<ToolResult[]> {
-  return Promise.all(toolCalls.map(executeTool));
+  return Promise.all(
+    toolCalls.map((toolCall) => executeTool(toolCall, conversationId)),
+  );
 }

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -717,7 +717,10 @@ export async function* streamMessageWithTools(
     });
 
     // Execute tools
-    const results = await executeTools(response.tool_calls);
+    const results = await executeTools(
+      response.tool_calls,
+      memorySource?.conversationId ?? null,
+    );
     hasExecutedTools = true;
 
     // Log tool execution results
@@ -877,7 +880,10 @@ export async function* continueToolIteration(
       tool_calls: response.tool_calls,
     });
 
-    const results = await executeTools(response.tool_calls);
+    const results = await executeTools(
+      response.tool_calls,
+      memorySource?.conversationId ?? null,
+    );
     hasExecutedTools = true;
     yield { type: "tool_results", results };
 

--- a/tests/unit/approval-config.test.ts
+++ b/tests/unit/approval-config.test.ts
@@ -2,7 +2,9 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  classifyGatewayOperation,
   getApprovalRequirement,
+  isHighRiskVerb,
   requiresApproval,
 } from "@/lib/tools/approval-config";
 
@@ -39,10 +41,38 @@ describe("approval-config", () => {
       expect(requiresApproval("gmail", "labels/list")).toBe(false);
     });
 
-    it("should NOT require approval for non-Gmail publishers", () => {
+    it("requires approval for destructive-looking operations on non-Gmail publishers", () => {
       expect(requiresApproval("other-publisher", "messages/123/delete")).toBe(
-        false,
+        true,
       );
+    });
+  });
+
+  describe("classifyGatewayOperation", () => {
+    it("classifies explicitly configured Gmail mutations as high-risk", () => {
+      expect(classifyGatewayOperation("gmail", "messages/123/delete")).toBe(
+        "high-risk",
+      );
+    });
+
+    it("classifies only explicit known reads as trusted", () => {
+      expect(classifyGatewayOperation("gmail", "get_messages")).toBe(
+        "trusted-read",
+      );
+      expect(classifyGatewayOperation("seren", "list_projects")).toBe(
+        "trusted-read",
+      );
+    });
+
+    it("leaves a never-seen publisher and tool unclassified", () => {
+      expect(classifyGatewayOperation("new-publisher", "inspect_records")).toBe(
+        "unclassified",
+      );
+    });
+
+    it("escalates high-risk verbs without using them as an allowlist", () => {
+      expect(isHighRiskVerb("delete_record")).toBe(true);
+      expect(isHighRiskVerb("inspect_records")).toBe(false);
     });
   });
 

--- a/tests/unit/tool-executor-approval.test.ts
+++ b/tests/unit/tool-executor-approval.test.ts
@@ -1,0 +1,279 @@
+// ABOUTME: Verifies the temporary centralized approval containment for tool execution.
+// ABOUTME: Covers trusted reads, one-shot high risk, session grants, and durable denials.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearSessionDecisions } from "@/lib/tools/approval-session";
+
+const mocks = vi.hoisted(() => ({
+  approvalId: "",
+  approvalResponse: true,
+  callGatewayTool: vi.fn(),
+  callMcpTool: vi.fn(),
+  callSerenTool: vi.fn(),
+  computeAgentOAuthRouting: vi.fn(),
+  emit: vi.fn(),
+  listen: vi.fn(),
+  invoke: vi.fn(),
+  startShellProgressListener: vi.fn(),
+  handlePaymentRequired: vi.fn(),
+}));
+
+vi.mock("@/services/mcp-gateway", () => ({
+  callGatewayTool: mocks.callGatewayTool,
+  callSerenTool: mocks.callSerenTool,
+}));
+
+vi.mock("@/lib/mcp/client", () => ({
+  mcpClient: {
+    callTool: mocks.callMcpTool,
+  },
+}));
+
+vi.mock("@/services/publisher-oauth", () => ({
+  computeAgentOAuthRouting: mocks.computeAgentOAuthRouting,
+}));
+
+vi.mock("@/stores/conversation.store", () => ({
+  conversationStore: {
+    activeConversationId: "active-conversation",
+  },
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: mocks.emit,
+  listen: mocks.listen,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@/services/shell-progress", () => ({
+  startShellProgressListener: mocks.startShellProgressListener,
+}));
+
+vi.mock("@/services/x402", () => ({
+  x402Service: {
+    handlePaymentRequired: mocks.handlePaymentRequired,
+  },
+}));
+
+function gatewayCall(publisher: string, toolName: string) {
+  return {
+    id: `${publisher}-${toolName}`,
+    type: "function" as const,
+    function: {
+      name: `gateway__${publisher}__${toolName}`,
+      arguments: JSON.stringify({ value: "test" }),
+    },
+  };
+}
+
+function localMcpCall(serverName: string, toolName: string) {
+  return {
+    id: `${serverName}-${toolName}`,
+    type: "function" as const,
+    function: {
+      name: `mcp__${serverName}__${toolName}`,
+      arguments: JSON.stringify({ value: "test" }),
+    },
+  };
+}
+
+function serenCall(toolName: string) {
+  return {
+    id: `seren-${toolName}`,
+    type: "function" as const,
+    function: {
+      name: `seren__${toolName}`,
+      arguments: JSON.stringify({ value: "test" }),
+    },
+  };
+}
+
+function approvalRequestCount(): number {
+  return mocks.emit.mock.calls.filter(
+    ([eventName]) => eventName === "gateway-tool-approval-request",
+  ).length;
+}
+
+describe("tool executor approval containment", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.approvalId = "";
+    mocks.approvalResponse = true;
+    mocks.computeAgentOAuthRouting.mockResolvedValue({
+      publishers: {},
+      ambiguous: {},
+      available: true,
+    });
+    mocks.callGatewayTool.mockResolvedValue({ result: "ok", is_error: false });
+    mocks.callMcpTool.mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    });
+    mocks.callSerenTool.mockResolvedValue({ result: "ok", is_error: false });
+    mocks.emit.mockImplementation(async (eventName, payload) => {
+      if (eventName === "gateway-tool-approval-request") {
+        mocks.approvalId = (payload as { approvalId: string }).approvalId;
+      }
+    });
+    mocks.listen.mockImplementation(async (eventName, handler) => {
+      if (eventName === "gateway-tool-approval-response") {
+        handler({
+          payload: {
+            id: mocks.approvalId,
+            approved: mocks.approvalResponse,
+          },
+        });
+      }
+      return () => {};
+    });
+
+    for (const conversationId of [
+      "grant-conversation",
+      "denial-conversation",
+      "high-risk-conversation",
+      "trusted-read-conversation",
+      "unknown-conversation",
+      "local-mcp-conversation",
+      "builtin-conversation",
+      "batch-conversation",
+    ]) {
+      clearSessionDecisions(conversationId);
+    }
+  });
+
+  it("prompts an unclassified operation once and reuses its session grant", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+
+    const first = await executeTool(
+      gatewayCall("new-publisher", "inspect_records"),
+      "grant-conversation",
+    );
+    const second = await executeTool(
+      gatewayCall("new-publisher", "inspect_records"),
+      "grant-conversation",
+    );
+
+    expect(first.is_error).toBe(false);
+    expect(second.is_error).toBe(false);
+    expect(approvalRequestCount()).toBe(1);
+    expect(mocks.emit).toHaveBeenCalledWith(
+      "gateway-tool-approval-request",
+      expect.objectContaining({
+        description:
+          "Unclassified operation on new-publisher — first use this session",
+      }),
+    );
+    expect(mocks.callGatewayTool).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a durable denial for a rejected unclassified operation", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+    mocks.approvalResponse = false;
+
+    const first = await executeTool(
+      gatewayCall("new-publisher", "inspect_records"),
+      "denial-conversation",
+    );
+    const second = await executeTool(
+      gatewayCall("new-publisher", "inspect_records"),
+      "denial-conversation",
+    );
+
+    expect(first.is_error).toBe(true);
+    expect(second.is_error).toBe(true);
+    expect(first.content).toContain("not approved");
+    expect(second.content).toContain("not approved");
+    expect(approvalRequestCount()).toBe(1);
+    expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("requires a one-shot approval for every high-risk verb call", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+
+    await executeTool(
+      gatewayCall("new-publisher", "delete_record"),
+      "high-risk-conversation",
+    );
+    await executeTool(
+      gatewayCall("new-publisher", "delete_record"),
+      "high-risk-conversation",
+    );
+
+    expect(approvalRequestCount()).toBe(2);
+    expect(mocks.callGatewayTool).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows explicit trusted reads without a confirmation prompt", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+
+    const result = await executeTool(
+      gatewayCall("gmail", "get_messages"),
+      "trusted-read-conversation",
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(approvalRequestCount()).toBe(0);
+    expect(mocks.callGatewayTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not silently allow a never-seen publisher and tool", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+
+    const result = await executeTool(
+      gatewayCall("never-seen", "inspect_everything"),
+      "unknown-conversation",
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(approvalRequestCount()).toBe(1);
+  });
+
+  it("routes unclassified built-in Seren tools through the same gate", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+
+    const result = await executeTool(
+      serenCall("call_publisher"),
+      "builtin-conversation",
+    );
+
+    expect(result.is_error).toBe(false);
+    expect(approvalRequestCount()).toBe(1);
+    expect(mocks.callSerenTool).toHaveBeenCalledWith("call_publisher", {
+      value: "test",
+    });
+  });
+
+  it("routes local MCP dispatch through the same session-bound gate", async () => {
+    const { executeTool } = await import("@/lib/tools/executor");
+
+    const first = await executeTool(
+      // A local server can choose a publisher-like name, but it still has no
+      // trusted security metadata and must not inherit Gmail's read allowlist.
+      localMcpCall("gmail", "get_messages"),
+      "local-mcp-conversation",
+    );
+    const second = await executeTool(
+      localMcpCall("gmail", "get_messages"),
+      "local-mcp-conversation",
+    );
+
+    expect(first.is_error).toBe(false);
+    expect(second.is_error).toBe(false);
+    expect(approvalRequestCount()).toBe(1);
+    expect(mocks.callMcpTool).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps batched gateway execution bound to its supplied conversation", async () => {
+    const { executeTool, executeTools } = await import("@/lib/tools/executor");
+    const call = gatewayCall("batch-publisher", "inspect_records");
+
+    await executeTools([call], "batch-conversation");
+    await executeTool(call, "batch-conversation");
+
+    expect(approvalRequestCount()).toBe(1);
+    expect(mocks.callGatewayTool).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Close the renderer's fail-open publisher allowlist with a narrow trusted-read classification and in-memory, conversation-bounded approval decisions.

## Audit trace

- `src/lib/tools/approval-config.ts`: the former Gmail-only list is now an explicit high-risk list, an explicit trusted-read list, and an unclassified default.
- `src/lib/tools/approval-session.ts`: grants and denials are process-memory only, keyed by conversation, publisher, and tool; no decision is persisted.
- `src/lib/tools/executor.ts`: Gateway publishers, direct built-in Seren tools, and local stdio MCP servers use the same classified authorization decision before dispatch.
- `src/services/chat.ts`: batch tool execution now receives the owning conversation ID so a session decision cannot fall back across conversations.

## Behavior

| Operation class | Behavior |
| --- | --- |
| Explicit trusted read | Silent execution |
| Unclassified operation | One prompt on first use per conversation, then an in-memory session grant |
| High-risk configured operation or verb | Exact one-shot approval every call |
| Denied unclassified operation | Durable in-memory denial without a repeat prompt |

The trusted list is intentionally narrow. Local stdio MCP servers remain unclassified even when a server chooses a publisher-like name. Built-in Seren operations not explicitly listed as trusted reads also enter the unclassified path.

## Verification

- Focused approval, OAuth dispatch, local MCP dispatch, and built-in dispatch tests: 32 passing assertions.
- Full frontend suite: 2,571 passing assertions and 15 intentional skips.
- Production frontend build completed successfully.
- The changed files pass the scoped Biome check. Repository-wide `pnpm check` still reports the same 48 pre-existing warnings on `main` outside this diff.

Networked path: no new outbound calls — this change gates the existing Gateway publisher and local MCP dispatch paths client-side pending the Rust gate.

Refs #3193

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
